### PR TITLE
Fix: Use public execute_write method and correct pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,13 +15,15 @@ dependencies = [
     "watchdog>=6.0.0",
 ]
 
-[tool.uv]
-dev-dependencies = [
+[tool.setuptools]
+packages = ["codebase_rag"]
+
+[project.optional-dependencies]
+test = [
     "pytest>=8.4.1",
     "pytest-asyncio>=1.0.0",
 ]
-
-[project.optional-dependencies]
+# Tree-sitter language support (optional)
 # Tree-sitter language support (optional)
 treesitter-full = [
     "tree-sitter-python>=0.23.6",

--- a/realtime_updater.py
+++ b/realtime_updater.py
@@ -34,7 +34,7 @@ class CodeChangeEventHandler(FileSystemEventHandler):
         )
         # This DETACH DELETE query is crucial
         query = "MATCH (m:Module {path: $path})-[*0..]->(c) DETACH DELETE m, c"
-        self.updater.ingestor._execute_query(
+        self.updater.ingestor.execute_write(
             query, {"path": str(path.relative_to(self.updater.repo_path))}
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -221,6 +221,10 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+test = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
 treesitter-full = [
     { name = "tree-sitter-go" },
     { name = "tree-sitter-java" },
@@ -231,17 +235,13 @@ treesitter-full = [
     { name = "tree-sitter-typescript" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-]
-
 [package.metadata]
 requires-dist = [
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "pydantic-ai-slim", extras = ["google", "openai"], specifier = ">=0.2.18" },
     { name = "pymgclient", specifier = ">=1.4.0" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.4.1" },
+    { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=1.0.0" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "toml", specifier = ">=0.10.2" },
     { name = "tree-sitter", specifier = ">=0.24.0" },
@@ -255,13 +255,7 @@ requires-dist = [
     { name = "tree-sitter-typescript", marker = "extra == 'treesitter-full'", specifier = ">=0.23.2" },
     { name = "watchdog", specifier = ">=6.0.0" },
 ]
-provides-extras = ["treesitter-full"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest", specifier = ">=8.4.1" },
-    { name = "pytest-asyncio", specifier = ">=1.0.0" },
-]
+provides-extras = ["test", "treesitter-full"]
 
 [[package]]
 name = "griffe"


### PR DESCRIPTION
This PR introduces improvements in two main areas:

Project Configuration

Updated pyproject.toml to explicitly declare the codebase_rag package, resolving build issues caused by package discovery errors.

Relocated pytest and pytest-asyncio from [tool.uv].dev-dependencies to [project.optional-dependencies.test] for more effective dependency management.

Database Interaction

Refactored realtime_updater.py to utilize the public MemgraphIngestor.execute_write method in place of the private _execute_query, promoting better coding practices and improved reliability.