### PR TITLE
Fix: Use public execute_write method and correct pyproject.toml and redundancy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dev-dependencies = [
 ]
 
 [project.optional-dependencies]
-# Tree-sitter language support (optional)
 treesitter-full = [
     "tree-sitter-python>=0.23.6",
     "tree-sitter-javascript>=0.23.1", 


### PR DESCRIPTION
This PR introduces improvements in two main areas:

Project Configuration

Updated pyproject.toml to explicitly declare the codebase_rag package, resolving build issues caused by package discovery errors.

Relocated pytest and pytest-asyncio from [tool.uv].dev-dependencies to [project.optional-dependencies.test] for more effective dependency management.

Database Interaction

Refactored realtime_updater.py to utilize the public MemgraphIngestor.execute_write method in place of the private _execute_query, promoting better coding practices, improved reliability and redundancy.