### PR TITLE
fix: add CALLS relationship to graph schema

### DIFF
--- a/codebase_rag/prompts.py
+++ b/codebase_rag/prompts.py
@@ -23,6 +23,7 @@ Relationships (source)-[REL_TYPE]->(target):
 - Module -[:DEFINES]-> (Class|Function)
 - Class -[:DEFINES_METHOD]-> Method
 - Project -[:DEPENDS_ON_EXTERNAL]-> ExternalPackage
+- (Function|Method) -[:CALLS]-> (Function|Method)
 
 **2. Critical Cypher Query Rules**
 


### PR DESCRIPTION
The GraphUpdater creates CALLS relationships between functions and methods, but the schema in prompts.py was missing this relationship. This prevented the Cypher generator from creating queries involving call chains.