### PR TITLE
fix: handle escaped spaces in screenshot file paths

### DIFF
--- a/codebase_rag/main.py
+++ b/codebase_rag/main.py
@@ -57,13 +57,12 @@ def _handle_chat_images(question: str, project_root: Path) -> str:
         tokens = question.split()
     
     # Find image files in tokens
-    image_extensions = ['.png', '.jpg', '.jpeg', '.gif']
-    image_files = []
-    for token in tokens:
-        if any(token.lower().endswith(ext) for ext in image_extensions):
-            # Only process absolute paths to avoid false positives
-            if token.startswith('/'):
-                image_files.append(token)
+    image_extensions = (".png", ".jpg", ".jpeg", ".gif")
+    image_files = [
+        token
+        for token in tokens
+        if token.startswith("/") and token.lower().endswith(image_extensions)
+    ]
     
     if not image_files:
         return question


### PR DESCRIPTION
- Replace regex-based path detection with shlex.split() for proper shell-style parsing
- Handle both escaped and unescaped path versions in replacement logic
- Fixes issue where macOS screencapture paths with spaces weren't being copied to .tmp directory
- Adds fallback to simple split if shlex parsing fails