### PR TITLE
refactor: added an additional validation step to check if the `LLM_PROVIDER` environment variable is present in the environment

### DIFF
--- a/codebase_rag/config.py
+++ b/codebase_rag/config.py
@@ -5,6 +5,7 @@ from typing import Literal
 from dotenv import load_dotenv
 from pydantic import AnyHttpUrl, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+import os
 
 load_dotenv()
 
@@ -49,7 +50,14 @@ class AppConfig(BaseSettings):
 
     @model_validator(mode="after")
     def check_required_fields(self) -> AppConfig:
-        """Validate that required API keys and project IDs are set based on the provider."""
+        """Validate that the LLM provider, required API keys and project IDs are set based on the provider."""
+        
+        # Checking if `LLM_PROVIDER` is set in the environment
+        if "LLM_PROVIDER" not in os.environ:
+            raise ValueError(
+                "Configuration Error: LLM_PROVIDER environment variable is required."
+            )
+
         if self.LLM_PROVIDER == "gemini":
             if self.GEMINI_PROVIDER == "gla" and not self.GEMINI_API_KEY:
                 raise ValueError(


### PR DESCRIPTION
# Description
This change introduces an additional step of validation in ```codebase_rag/config.py``` to check if the ```LLM_PROVIDER``` variable is set in the environment. This change ensures that the ```LLM_PROVIDER``` environment variable is read properly and not set to the default value "gemini" before starting the main application, which previously led to misleading logs originating from ```codebase_rag/main.py```.

# What does this PR do ?
Adds an additional validation step to check if the ```LLM_PROVIDER``` environment variable is set before starting the main application to prevent erroneous logging (specifically with respect to the Orchestrator and Cypher models used) originating from ```codebase_rag/main.py```.