### PR TITLE
feat: re-introduce batch flushing

### DIFF
--- a/codebase_rag/config.py
+++ b/codebase_rag/config.py
@@ -118,6 +118,13 @@ class AppConfig(BaseSettings):
         """Set the active cypher model."""
         self._active_cypher_model = model
 
+    def resolve_batch_size(self, batch_size: int | None) -> int:
+        """Return a validated batch size, falling back to config when needed."""
+        resolved = self.MEMGRAPH_BATCH_SIZE if batch_size is None else batch_size
+        if resolved < 0:
+            raise ValueError("batch_size must be non-negative")
+        return resolved
+
 
 settings = AppConfig()
 

--- a/codebase_rag/config.py
+++ b/codebase_rag/config.py
@@ -36,6 +36,7 @@ class AppConfig(BaseSettings):
     MEMGRAPH_PORT: int = 7687
     MEMGRAPH_HTTP_PORT: int = 7444
     LAB_PORT: int = 3000
+    MEMGRAPH_BATCH_SIZE: int = 1000
 
     GEMINI_PROVIDER: Literal["gla", "vertex"] = "gla"
 

--- a/codebase_rag/config.py
+++ b/codebase_rag/config.py
@@ -121,8 +121,8 @@ class AppConfig(BaseSettings):
     def resolve_batch_size(self, batch_size: int | None) -> int:
         """Return a validated batch size, falling back to config when needed."""
         resolved = self.MEMGRAPH_BATCH_SIZE if batch_size is None else batch_size
-        if resolved < 0:
-            raise ValueError("batch_size must be non-negative")
+        if resolved < 1:
+            raise ValueError("batch_size must be a positive integer")
         return resolved
 
 

--- a/codebase_rag/main.py
+++ b/codebase_rag/main.py
@@ -784,9 +784,7 @@ def start(
 
     _update_model_settings(orchestrator_model, cypher_model)
 
-    effective_batch_size = (
-        batch_size if batch_size is not None else settings.MEMGRAPH_BATCH_SIZE
-    )
+    effective_batch_size = settings.resolve_batch_size(batch_size)
 
     if update_graph:
         repo_to_update = Path(target_repo_path)
@@ -884,9 +882,7 @@ async def main_optimize_async(
     )
     console.print(table)
 
-    effective_batch_size = (
-        batch_size if batch_size is not None else settings.MEMGRAPH_BATCH_SIZE
-    )
+    effective_batch_size = settings.resolve_batch_size(batch_size)
 
     with MemgraphIngestor(
         host=settings.MEMGRAPH_HOST,

--- a/codebase_rag/main.py
+++ b/codebase_rag/main.py
@@ -704,21 +704,17 @@ def _initialize_services_and_agent(repo_path: str, ingestor: MemgraphIngestor) -
     return rag_agent
 
 
-async def main_async(repo_path: str, batch_size: int | None = None) -> None:
+async def main_async(repo_path: str, batch_size: int) -> None:
     """Initializes services and runs the main application loop."""
     project_root = _setup_common_initialization(repo_path)
 
     table = _create_configuration_table(repo_path)
     console.print(table)
 
-    effective_batch_size = (
-        batch_size if batch_size is not None else settings.MEMGRAPH_BATCH_SIZE
-    )
-
     with MemgraphIngestor(
         host=settings.MEMGRAPH_HOST,
         port=settings.MEMGRAPH_PORT,
-        batch_size=effective_batch_size,
+        batch_size=batch_size,
     ) as ingestor:
         console.print("[bold green]Successfully connected to Memgraph.[/bold green]")
         console.print(

--- a/codebase_rag/main.py
+++ b/codebase_rag/main.py
@@ -711,10 +711,14 @@ async def main_async(repo_path: str, batch_size: int | None = None) -> None:
     table = _create_configuration_table(repo_path)
     console.print(table)
 
+    effective_batch_size = (
+        batch_size if batch_size is not None else settings.MEMGRAPH_BATCH_SIZE
+    )
+
     with MemgraphIngestor(
         host=settings.MEMGRAPH_HOST,
         port=settings.MEMGRAPH_PORT,
-        batch_size=batch_size or settings.MEMGRAPH_BATCH_SIZE,
+        batch_size=effective_batch_size,
     ) as ingestor:
         console.print("[bold green]Successfully connected to Memgraph.[/bold green]")
         console.print(
@@ -784,7 +788,9 @@ def start(
 
     _update_model_settings(orchestrator_model, cypher_model)
 
-    effective_batch_size = batch_size or settings.MEMGRAPH_BATCH_SIZE
+    effective_batch_size = (
+        batch_size if batch_size is not None else settings.MEMGRAPH_BATCH_SIZE
+    )
 
     if update_graph:
         repo_to_update = Path(target_repo_path)
@@ -882,10 +888,14 @@ async def main_optimize_async(
     )
     console.print(table)
 
+    effective_batch_size = (
+        batch_size if batch_size is not None else settings.MEMGRAPH_BATCH_SIZE
+    )
+
     with MemgraphIngestor(
         host=settings.MEMGRAPH_HOST,
         port=settings.MEMGRAPH_PORT,
-        batch_size=batch_size or settings.MEMGRAPH_BATCH_SIZE,
+        batch_size=effective_batch_size,
     ) as ingestor:
         console.print("[bold green]Successfully connected to Memgraph.[/bold green]")
 

--- a/codebase_rag/main.py
+++ b/codebase_rag/main.py
@@ -833,6 +833,12 @@ def export(
     format_json: bool = typer.Option(
         True, "--json/--no-json", help="Export in JSON format"
     ),
+    batch_size: int | None = typer.Option(
+        None,
+        "--batch-size",
+        min=1,
+        help="Number of buffered nodes/relationships before flushing to Memgraph",
+    ),
 ) -> None:
     """Export the current knowledge graph to a file."""
     if not format_json:
@@ -843,11 +849,13 @@ def export(
 
     console.print("[bold cyan]Connecting to Memgraph to export graph...[/bold cyan]")
 
+    effective_batch_size = settings.resolve_batch_size(batch_size)
+
     try:
         with MemgraphIngestor(
             host=settings.MEMGRAPH_HOST,
             port=settings.MEMGRAPH_PORT,
-            batch_size=settings.MEMGRAPH_BATCH_SIZE,
+            batch_size=effective_batch_size,
         ) as ingestor:
             console.print("[bold cyan]Exporting graph data...[/bold cyan]")
             if not _export_graph_to_file(ingestor, output):

--- a/codebase_rag/services/graph_service.py
+++ b/codebase_rag/services/graph_service.py
@@ -87,7 +87,14 @@ class MemgraphIngestor:
             if "already exists" not in str(e).lower():
                 logger.error(f"!!! Batch Cypher Error: {e}")
                 logger.error(f"    Query: {query}")
-                logger.error(f"    Params: {params_list}")
+                if len(params_list) > 10:
+                    logger.error(
+                        "    Params (first 10 of {}): {}...",
+                        len(params_list),
+                        params_list[:10],
+                    )
+                else:
+                    logger.error(f"    Params: {params_list}")
             raise
         finally:
             if cursor:

--- a/codebase_rag/services/graph_service.py
+++ b/codebase_rag/services/graph_service.py
@@ -86,6 +86,9 @@ class MemgraphIngestor:
         except Exception as e:
             if "already exists" not in str(e).lower():
                 logger.error(f"!!! Batch Cypher Error: {e}")
+                logger.error(f"    Query: {query}")
+                logger.error(f"    Params: {params_list}")
+            raise
         finally:
             if cursor:
                 cursor.close()

--- a/codebase_rag/services/graph_service.py
+++ b/codebase_rag/services/graph_service.py
@@ -12,8 +12,8 @@ class MemgraphIngestor:
     def __init__(self, host: str, port: int, batch_size: int = 1000):
         self._host = host
         self._port = port
-        if batch_size < 0:
-            raise ValueError("batch_size must be non-negative")
+        if batch_size < 1:
+            raise ValueError("batch_size must be a positive integer")
         self.batch_size = batch_size
         self.conn: mgclient.Connection | None = None
         self.node_buffer: list[tuple[str, dict[str, Any]]] = []

--- a/codebase_rag/services/graph_service.py
+++ b/codebase_rag/services/graph_service.py
@@ -109,7 +109,7 @@ class MemgraphIngestor:
     def ensure_node_batch(self, label: str, properties: dict[str, Any]) -> None:
         """Adds a node to the buffer."""
         self.node_buffer.append((label, properties))
-        if self.batch_size and len(self.node_buffer) >= self.batch_size:
+        if len(self.node_buffer) >= self.batch_size:
             logger.debug(
                 "Node buffer reached batch size ({}). Performing incremental flush.",
                 self.batch_size,
@@ -134,7 +134,7 @@ class MemgraphIngestor:
                 properties,
             )
         )
-        if self.batch_size and len(self.relationship_buffer) >= self.batch_size:
+        if len(self.relationship_buffer) >= self.batch_size:
             logger.debug(
                 "Relationship buffer reached batch size ({}). Performing incremental flush.",
                 self.batch_size,

--- a/codebase_rag/tests/test_memgraph_batching.py
+++ b/codebase_rag/tests/test_memgraph_batching.py
@@ -27,7 +27,7 @@ def test_node_batch_flushes_when_threshold_reached() -> None:
     ingestor.ensure_node_batch("File", {"path": "b", "name": "b.txt"})
 
     assert len(ingestor.node_buffer) == 0
-    cursor_mock.execute.assert_called()
+    cursor_mock.execute.assert_called_once()
     executed_query = cursor_mock.execute.call_args[0][0]
     assert "UNWIND $batch" in executed_query
     cursor_mock.close.assert_called()
@@ -81,10 +81,10 @@ def test_relationship_batch_flushes_after_threshold_and_respects_node_flush() ->
             ("File", "path", "file2"),
         )
 
-        assert flush_nodes_spy.call_count >= 1
+        assert flush_nodes_spy.call_count == 1
 
     assert len(ingestor.relationship_buffer) == 0
-    cursor_mock.execute.assert_called()
+    cursor_mock.execute.assert_called_once()
     executed_query = cursor_mock.execute.call_args[0][0]
     assert "UNWIND $batch" in executed_query
     cursor_mock.close.assert_called()

--- a/codebase_rag/tests/test_memgraph_batching.py
+++ b/codebase_rag/tests/test_memgraph_batching.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from codebase_rag.services.graph_service import MemgraphIngestor
+
+
+def _create_ingestor_with_mocked_connection(
+    batch_size: int = 2,
+) -> tuple[MemgraphIngestor, MagicMock]:
+    """Create a MemgraphIngestor with a mocked mgclient connection."""
+    ingestor = MemgraphIngestor(host="localhost", port=7687, batch_size=batch_size)
+    conn_mock = MagicMock()
+    cursor_mock = MagicMock()
+    conn_mock.cursor.return_value = cursor_mock
+    ingestor.conn = conn_mock
+    return ingestor, cursor_mock
+
+
+def test_node_batch_flushes_when_threshold_reached() -> None:
+    ingestor, cursor_mock = _create_ingestor_with_mocked_connection()
+
+    ingestor.ensure_node_batch("File", {"path": "a", "name": "a.txt"})
+    assert len(ingestor.node_buffer) == 1
+    cursor_mock.execute.assert_not_called()
+
+    ingestor.ensure_node_batch("File", {"path": "b", "name": "b.txt"})
+
+    assert len(ingestor.node_buffer) == 0
+    cursor_mock.execute.assert_called()
+    executed_query = cursor_mock.execute.call_args[0][0]
+    assert "UNWIND $batch" in executed_query
+    cursor_mock.close.assert_called()
+
+
+def test_relationship_batch_flushes_after_threshold_and_respects_node_flush() -> None:
+    ingestor, cursor_mock = _create_ingestor_with_mocked_connection()
+
+    with patch.object(
+        ingestor, "flush_nodes", wraps=ingestor.flush_nodes
+    ) as flush_nodes_spy:
+        ingestor.ensure_relationship_batch(
+            ("Module", "qualified_name", "proj.module1"),
+            "CONTAINS_FILE",
+            ("File", "path", "file1"),
+        )
+        assert len(ingestor.relationship_buffer) == 1
+        cursor_mock.execute.assert_not_called()
+
+        ingestor.ensure_relationship_batch(
+            ("Module", "qualified_name", "proj.module2"),
+            "CONTAINS_FILE",
+            ("File", "path", "file2"),
+        )
+
+        assert flush_nodes_spy.call_count >= 1
+
+    assert len(ingestor.relationship_buffer) == 0
+    cursor_mock.execute.assert_called()
+    executed_query = cursor_mock.execute.call_args[0][0]
+    assert "UNWIND $batch" in executed_query
+    cursor_mock.close.assert_called()

--- a/realtime_updater.py
+++ b/realtime_updater.py
@@ -91,7 +91,9 @@ def start_watcher(
     with MemgraphIngestor(
         host=host,
         port=port,
-        batch_size=batch_size or settings.MEMGRAPH_BATCH_SIZE,
+        batch_size=batch_size
+        if batch_size is not None
+        else settings.MEMGRAPH_BATCH_SIZE,
     ) as ingestor:
         updater = GraphUpdater(ingestor, repo_path_obj, parsers, queries)
 

--- a/realtime_updater.py
+++ b/realtime_updater.py
@@ -132,15 +132,27 @@ if __name__ == "__main__":
     parser.add_argument("repo_path", help="Path to the repository to watch.")
     parser.add_argument("--host", default="localhost", help="Memgraph host")
     parser.add_argument("--port", type=int, default=7687, help="Memgraph port")
+
+    def positive_int(value: str) -> int:
+        """Argparse type that enforces positive integers."""
+        try:
+            ivalue = int(value)
+        except ValueError as exc:
+            raise argparse.ArgumentTypeError(
+                f"{value!r} is not a valid integer"
+            ) from exc
+        if ivalue < 1:
+            raise argparse.ArgumentTypeError(
+                f"{value!r} is not a valid positive integer"
+            )
+        return ivalue
+
     parser.add_argument(
         "--batch-size",
-        type=int,
+        type=positive_int,
         default=None,
         help="Number of buffered nodes/relationships before flushing to Memgraph",
     )
     args = parser.parse_args()
-
-    if args.batch_size is not None and args.batch_size < 1:
-        parser.error("--batch-size must be a positive integer")
 
     start_watcher(args.repo_path, args.host, args.port, args.batch_size)

--- a/realtime_updater.py
+++ b/realtime_updater.py
@@ -88,12 +88,12 @@ def start_watcher(
     repo_path_obj = Path(repo_path).resolve()
     parsers, queries = load_parsers()
 
+    effective_batch_size = settings.resolve_batch_size(batch_size)
+
     with MemgraphIngestor(
         host=host,
         port=port,
-        batch_size=batch_size
-        if batch_size is not None
-        else settings.MEMGRAPH_BATCH_SIZE,
+        batch_size=effective_batch_size,
     ) as ingestor:
         updater = GraphUpdater(ingestor, repo_path_obj, parsers, queries)
 


### PR DESCRIPTION
## Summary by Sourcery

Reintroduce batch flushing in the MemgraphIngestor with a configurable batch size across the CLI and watcher, performing incremental flushes when node or relationship buffers reach the threshold.

New Features:
- Add MEMGRAPH_BATCH_SIZE configuration option
- Expose --batch-size flag in CLI commands (start, export, optimize) and watcher to specify buffered flush size

Enhancements:
- Pass batch_size to all MemgraphIngestor initializations and compute effective_batch_size
- Implement automatic flushing in ensure_node_batch and ensure_relationship_batch when buffers exceed the batch size
- Validate that --batch-size is a positive integer in the file watcher

Tests:
- Add unit tests to verify node and relationship buffers flush correctly once the threshold is reached