### PR TITLE
fix: Prevent add_grammer command corrupts language_config.py by calcu…

### DIFF
--- a/codebase_rag/tools/language.py
+++ b/codebase_rag/tools/language.py
@@ -427,7 +427,8 @@ def add_grammar(
     ),"""
 
         # Find the end of the LANGUAGE_CONFIGS dictionary
-        closing_brace_pos = config_content.rfind("}")
+        language_configs_pos = config_content.find("LANGUAGE_CONFIGS = {")
+        closing_brace_pos = config_content.find("\n}", language_configs_pos) + 1
         if closing_brace_pos != -1:
             # Insert the new config before the closing brace
             new_content = (


### PR DESCRIPTION
…lating file offset via looking up for LANGUAGE_CONFIGS and '\n}'

Originally the code seeks for "}" to insert custom tree-sitter configs. 
However the config file now has multiple "}" chars, making the code snippet plug into a wrong position