### PR TITLE
Add ask-agent CLI and MCP integration tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ wheels/
 .pytest_cache/
 .claude/
 .qdrant_code_embeddings/
+
+# Popular VibeCoding Agents
+.roo/
+.augment
+.vscode

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Run a single query and exit, with output sent to stdout (useful for scripting):
 
 ```bash
 python -m codebase_rag.main start --repo-path /path/to/your/repo \
-  --question "What functions call UserService.create_user?"
+  --ask-agent "What functions call UserService.create_user?"
 ```
 
 ### Step 2.5: Real-Time Graph Updates (Optional)

--- a/README.md
+++ b/README.md
@@ -514,6 +514,10 @@ claude mcp add --transport stdio graph-code \
 - **surgical_replace_code** - Precise code edits
 - **read_file / write_file** - File operations
 - **list_directory** - Browse project structure
+- **shell_command** - Execute terminal commands
+- **document_analyzer** - Analyze PDFs and documents
+- **semantic_search** - Find functions by intent
+- **get_function_source** - Retrieve function source by ID
 
 ### Example Usage
 
@@ -618,6 +622,9 @@ The agent has access to a suite of tools to understand and interact with the cod
 - **`create_new_file`**: Creates a new file with specified content.
 - **`replace_code_surgically`**: Surgically replaces specific code blocks in files. Requires exact target code and replacement. Only modifies the specified block, leaving rest of file unchanged. True surgical patching.
 - **`execute_shell_command`**: Executes a shell command in the project's environment.
+- **`analyze_document`**: Analyzes PDFs and documents to answer questions about their content.
+- **`semantic_search_functions`**: Finds functions by natural language intent using embeddings.
+- **`get_function_source_by_id`**: Retrieves source code for a function by its node ID.
 
 ### Intelligent and Safe File Editing
 

--- a/README.md
+++ b/README.md
@@ -255,10 +255,21 @@ The system automatically detects and processes files for all supported languages
 
 ### Step 2: Query the Codebase
 
+**Interactive mode:**
+
 Start the interactive RAG CLI:
 
 ```bash
 python -m codebase_rag.main start --repo-path /path/to/your/repo
+```
+
+**Non-interactive mode (single query):**
+
+Run a single query and exit, with output sent to stdout (useful for scripting):
+
+```bash
+python -m codebase_rag.main start --repo-path /path/to/your/repo \
+  --question "What functions call UserService.create_user?"
 ```
 
 ### Step 2.5: Real-Time Graph Updates (Optional)

--- a/codebase_rag/main.py
+++ b/codebase_rag/main.py
@@ -873,10 +873,10 @@ def start(
         min=1,
         help="Number of buffered nodes/relationships before flushing to Memgraph",
     ),
-    question: str | None = typer.Option(
+    ask_agent: str | None = typer.Option(
         None,
-        "-q",
-        "--question",
+        "-a",
+        "--ask-agent",
         help="Run a single query and exit (non-interactive mode). Output is sent to stdout.",
     ),
 ) -> None:
@@ -931,11 +931,11 @@ def start(
         return
 
     try:
-        if question:
+        if ask_agent:
             # Non-interactive mode: run single query and exit
             asyncio.run(
                 main_async_single_query(
-                    target_repo_path, effective_batch_size, question
+                    target_repo_path, effective_batch_size, ask_agent
                 )
             )
         else:

--- a/codebase_rag/main.py
+++ b/codebase_rag/main.py
@@ -159,11 +159,21 @@ def is_edit_operation_response(response_text: str) -> bool:
     return tool_usage or content_indicators or pattern_match
 
 
-def _setup_common_initialization(repo_path: str) -> Path:
-    """Common setup logic for both main and optimize functions."""
+def _setup_common_initialization(repo_path: str, question_mode: bool = False) -> Path:
+    """Common setup logic for both main and optimize functions.
+
+    Args:
+        repo_path: Path to the repository
+        question_mode: If True, suppress INFO/DEBUG/WARNING logs (only show errors and direct output)
+    """
     # Logger initialization
     logger.remove()
-    logger.add(sys.stdout, format="{time:YYYY-MM-DD HH:mm:ss.SSS} | {message}")
+    if question_mode:
+        # In question mode, only show ERROR level logs
+        logger.add(sys.stderr, level="ERROR", format="{message}")
+    else:
+        # In interactive mode, show all logs
+        logger.add(sys.stdout, format="{time:YYYY-MM-DD HH:mm:ss.SSS} | {message}")
 
     # Temporary directory cleanup
     project_root = Path(repo_path).resolve()
@@ -778,7 +788,7 @@ async def main_async_single_query(
     repo_path: str, batch_size: int, question: str
 ) -> None:
     """Initializes services and runs a single query in non-interactive mode."""
-    project_root = _setup_common_initialization(repo_path)
+    project_root = _setup_common_initialization(repo_path, question_mode=True)
 
     with MemgraphIngestor(
         host=settings.MEMGRAPH_HOST,

--- a/codebase_rag/mcp/client.py
+++ b/codebase_rag/mcp/client.py
@@ -1,0 +1,78 @@
+"""MCP client for querying the code graph via the MCP server.
+
+This module provides a simple CLI client that connects to the MCP server
+and executes the ask_code_graph tool with a provided question.
+"""
+
+import asyncio
+import json
+import sys
+from typing import Any
+
+import typer
+from mcp import ClientSession
+from mcp.client.stdio import stdio_client
+
+app = typer.Typer()
+
+
+async def query_mcp_server(question: str) -> dict[str, Any]:
+    """Query the MCP server with a question.
+
+    Args:
+        question: The question to ask about the codebase
+
+    Returns:
+        Dictionary with the response from the server
+    """
+    async with stdio_client() as (read, write):
+        async with ClientSession(read, write) as session:
+            # Initialize the session
+            await session.initialize()
+
+            # Call the ask_code_graph tool
+            result = await session.call_tool("ask_code_graph", {"question": question})
+
+            # Extract the response text
+            if result.content:
+                response_text = result.content[0].text
+                # Parse JSON response
+                try:
+                    parsed = json.loads(response_text)
+                    if isinstance(parsed, dict):
+                        return parsed
+                    return {"output": str(parsed)}
+                except json.JSONDecodeError:
+                    return {"output": response_text}
+            return {"output": "No response from server"}
+
+
+@app.command()
+def main(
+    question: str = typer.Option(
+        ..., "--question", "-q", help="Question to ask about the codebase"
+    ),
+) -> None:
+    """Query the code graph via MCP server.
+
+    Example:
+        python -m codebase_rag.mcp.client --question "What functions call UserService.create_user?"
+    """
+    try:
+        # Run the async query
+        result = asyncio.run(query_mcp_server(question))
+
+        # Print only the output (clean for scripting)
+        if isinstance(result, dict) and "output" in result:
+            print(result["output"])
+        else:
+            print(json.dumps(result))
+
+    except Exception as e:
+        # Print error to stderr and exit with error code
+        print(f"Error: {str(e)}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    app()

--- a/codebase_rag/mcp/server.py
+++ b/codebase_rag/mcp/server.py
@@ -21,12 +21,17 @@ from codebase_rag.services.llm import CypherGenerator
 
 
 def setup_logging() -> None:
-    """Configure logging to stderr for MCP stdio transport."""
+    """Configure logging to stderr for MCP stdio transport.
+
+    Uses plain text format without ANSI colors or box drawing characters
+    to avoid interfering with JSONRPC protocol on stdout.
+    """
     logger.remove()  # Remove default handler
     logger.add(
         sys.stderr,
         level="INFO",
-        format="<green>{time:YYYY-MM-DD HH:mm:ss}</green> | <level>{level: <8}</level> | <level>{message}</level>",
+        format="{time:YYYY-MM-DD HH:mm:ss} | {level: <8} | {message}",
+        colorize=False,  # Disable ANSI color codes
     )
 
 

--- a/codebase_rag/mcp/server.py
+++ b/codebase_rag/mcp/server.py
@@ -6,7 +6,6 @@ capabilities via the Model Context Protocol.
 
 import json
 import os
-import sys
 from pathlib import Path
 
 from loguru import logger
@@ -20,19 +19,54 @@ from codebase_rag.services.graph_service import MemgraphIngestor
 from codebase_rag.services.llm import CypherGenerator
 
 
-def setup_logging() -> None:
-    """Configure logging to stderr for MCP stdio transport.
+def setup_logging(enable_logging: bool = False) -> None:
+    """Configure logging for MCP stdio transport.
 
-    Uses plain text format without ANSI colors or box drawing characters
-    to avoid interfering with JSONRPC protocol on stdout.
+    By default, logging is disabled to prevent token waste in LLM context.
+    Can be enabled via environment variable MCP_ENABLE_LOGGING=1 for debugging.
+
+    When enabled, logs are written to a file to avoid polluting STDIO transport.
+    The log file path can be configured via MCP_LOG_FILE environment variable.
+
+    Args:
+        enable_logging: Whether to enable logging output. Defaults to False.
+                       Can also be controlled via MCP_ENABLE_LOGGING environment variable.
     """
     logger.remove()  # Remove default handler
-    logger.add(
-        sys.stderr,
-        level="INFO",
-        format="{time:YYYY-MM-DD HH:mm:ss} | {level: <8} | {message}",
-        colorize=False,  # Disable ANSI color codes
+
+    # Check environment variable to override enable_logging parameter
+    env_enable = os.environ.get("MCP_ENABLE_LOGGING", "").lower() in (
+        "1",
+        "true",
+        "yes",
     )
+    should_enable = enable_logging or env_enable
+
+    if should_enable:
+        # Get log file path from environment or use default
+        log_file = os.environ.get("MCP_LOG_FILE")
+        if not log_file:
+            # Use ~/.cache/code-graph-rag/mcp.log as default
+            cache_dir = Path.home() / ".cache" / "code-graph-rag"
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            log_file = str(cache_dir / "mcp.log")
+
+        # Ensure log file directory exists
+        log_path = Path(log_file)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Add file handler - logs go to file, not STDERR/STDOUT
+        logger.add(
+            log_file,
+            level="INFO",
+            format="{time:YYYY-MM-DD HH:mm:ss} | {level: <8} | {message}",
+            colorize=False,  # Disable ANSI color codes
+            rotation="10 MB",  # Rotate when file reaches 10MB
+            retention="7 days",  # Keep logs for 7 days
+        )
+    else:
+        # Disable all logging by default for MCP mode
+        logger.disable("codebase_rag")
 
 
 def get_project_root() -> Path:
@@ -148,34 +182,45 @@ def create_server() -> tuple[Server, MemgraphIngestor]:
 
         Tool handlers are dynamically resolved from the MCPToolsRegistry,
         ensuring consistency with tool definitions.
+
+        Logging is suppressed during tool execution to prevent token waste in LLM context.
         """
-        logger.info(f"[GraphCode MCP] Calling tool: {name}")
+        import io
+        from contextlib import redirect_stderr, redirect_stdout
 
         try:
             # Resolve handler from registry
             handler_info = tools.get_tool_handler(name)
             if not handler_info:
-                error_msg = f"Unknown tool: {name}"
-                logger.error(f"[GraphCode MCP] {error_msg}")
+                error_msg = "Unknown tool"
                 return [TextContent(type="text", text=f"Error: {error_msg}")]
 
             handler, returns_json = handler_info
 
-            # Call handler with unpacked arguments
-            result = await handler(**arguments)
+            # Suppress all logging output during tool execution
+            with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+                logger.disable("codebase_rag")
+                try:
+                    # Call handler with unpacked arguments
+                    result = await handler(**arguments)
 
-            # Format result based on output type
-            if returns_json:
-                result_text = json.dumps(result, indent=2)
-            else:
-                result_text = str(result)
+                    # Format result based on output type
+                    if returns_json:
+                        result_text = json.dumps(result, indent=2)
+                    else:
+                        result_text = str(result)
 
-            return [TextContent(type="text", text=result_text)]
+                    return [TextContent(type="text", text=result_text)]
+                finally:
+                    logger.enable("codebase_rag")
 
-        except Exception as e:
-            error_msg = f"Error executing tool '{name}': {str(e)}"
-            logger.error(f"[GraphCode MCP] {error_msg}", exc_info=True)
-            return [TextContent(type="text", text=f"Error: {error_msg}")]
+        except Exception:
+            # Fail silently without logging or printing error details
+            return [
+                TextContent(
+                    type="text", text="Error: There was an error executing the tool"
+                )
+            ]
 
     return server, ingestor
 

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -240,18 +240,15 @@ class MCPToolsRegistry:
             "ask_agent": ToolMetadata(
                 name="ask_agent",
                 description="Ask the Code Graph RAG agent a question about the codebase. "
-                "This tool uses a retrieval-augmented generation (RAG) agent to answer questions about the code. "
-                "The agent can analyze code structure, relationships, and content to provide comprehensive answers. "
                 "Use this tool for general questions about the codebase, architecture, functionality, and code relationships. "
-                "Examples: 'What functions call UserService.create_user?', 'How is the authentication implemented?', "
+                "Examples: 'How is the authentication implemented?', "
                 "'What are the main components of the system?', 'Where is the database connection configured?'",
                 input_schema={
                     "type": "object",
                     "properties": {
                         "question": {
                             "type": "string",
-                            "description": "A natural language question about the codebase. "
-                            "Be specific and clear about what you want to know. "
+                            "description": "A question about the codebase, architecture, functionality, and code relationships. "
                             "Examples: 'What functions call UserService.create_user?', "
                             "'How is error handling implemented?', 'What are the main entry points?'",
                         }

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -237,21 +237,28 @@ class MCPToolsRegistry:
                 handler=self.list_directory,
                 returns_json=False,
             ),
-            "ask_code_graph": ToolMetadata(
-                name="ask_code_graph",
-                description="Ask Code Graph a single question about the codebase and get an answer. "
-                "This tool executes the question using the RAG agent and returns the response.",
+            "ask_agent": ToolMetadata(
+                name="ask_agent",
+                description="Ask the Code Graph RAG agent a question about the codebase. "
+                "This tool uses a retrieval-augmented generation (RAG) agent to answer questions about the code. "
+                "The agent can analyze code structure, relationships, and content to provide comprehensive answers. "
+                "Use this tool for general questions about the codebase, architecture, functionality, and code relationships. "
+                "Examples: 'What functions call UserService.create_user?', 'How is the authentication implemented?', "
+                "'What are the main components of the system?', 'Where is the database connection configured?'",
                 input_schema={
                     "type": "object",
                     "properties": {
                         "question": {
                             "type": "string",
-                            "description": "The question to ask about the codebase",
+                            "description": "A natural language question about the codebase. "
+                            "Be specific and clear about what you want to know. "
+                            "Examples: 'What functions call UserService.create_user?', "
+                            "'How is error handling implemented?', 'What are the main entry points?'",
                         }
                     },
                     "required": ["question"],
                 },
-                handler=self.ask_code_graph,
+                handler=self.ask_agent,
                 returns_json=True,
             ),
         }
@@ -507,7 +514,7 @@ class MCPToolsRegistry:
             logger.error(f"[MCP] Error listing directory: {e}")
             return f"Error: {str(e)}"
 
-    async def ask_code_graph(self, question: str) -> dict[str, Any]:
+    async def ask_agent(self, question: str) -> dict[str, Any]:
         """Ask a single question about the codebase and get an answer.
 
         This tool executes the question using the RAG agent and returns the response
@@ -519,7 +526,7 @@ class MCPToolsRegistry:
         Returns:
             Dictionary with 'output' key containing the answer
         """
-        logger.info(f"[MCP] ask_code_graph: {question}")
+        logger.info(f"[MCP] ask_agent: {question}")
         try:
             # Handle images in the question (copy to temp directory)
             question_with_context = self._handle_question_images(question)

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -4,12 +4,14 @@ This module adapts pydantic-ai Tool instances to MCP-compatible functions.
 """
 
 import itertools
+import sys
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
 from loguru import logger
+from rich.console import Console
 
 from codebase_rag.graph_updater import GraphUpdater
 from codebase_rag.parser_loader import load_parsers
@@ -79,8 +81,10 @@ class MCPToolsRegistry:
         self.document_analyzer = DocumentAnalyzer(project_root=project_root)
 
         # Create pydantic-ai tools - we'll call the underlying functions directly
+        # Use a Console that outputs to stderr to avoid corrupting JSONRPC on stdout
+        stderr_console = Console(file=sys.stderr, width=None, force_terminal=True)
         self._query_tool = create_query_tool(
-            ingestor=ingestor, cypher_gen=cypher_gen, console=None
+            ingestor=ingestor, cypher_gen=cypher_gen, console=stderr_console
         )
         self._code_tool = create_code_retrieval_tool(code_retriever=self.code_retriever)
         self._file_editor_tool = create_file_editor_tool(file_editor=self.file_editor)

--- a/codebase_rag/services/llm.py
+++ b/codebase_rag/services/llm.py
@@ -111,6 +111,7 @@ def create_rag_orchestrator(tools: list[Tool]) -> Agent:
             model=llm,
             system_prompt=RAG_ORCHESTRATOR_SYSTEM_PROMPT,
             tools=tools,
+            retries=3,  # Increase retries to handle output validation issues
         )
     except Exception as e:
         raise LLMGenerationError(f"Failed to initialize RAG Orchestrator: {e}") from e


### PR DESCRIPTION
- Implements the `--ask-agent` CLI flag for non-interactive queries
- Introduces the `ask_agent` tool within MCP
- Adds a test MCP client leveraging ask_agent tool

**ask_agent** - utilizes the RAG pipeline similar to the interactive mode and provides it as a tool. Often gives a better responce when used from the MCP Client.
Sometimes you want to be able to access the code-graph from CLI non-interactively by asking a single question.
