### PR TITLE
feat: add multi-project support to MCP tools

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -268,7 +268,7 @@ class GraphUpdater:
         self.repo_path = repo_path
         self.parsers = parsers
         self.queries = self._prepare_queries_with_parsers(queries, parsers)
-        self.project_name = repo_path.name
+        self.project_name = repo_path.resolve().name
         self.function_registry = FunctionRegistryTrie()
         self.simple_name_lookup: dict[str, set[str]] = defaultdict(set)
         self.ast_cache = BoundedASTCache(max_entries=1000, max_memory_mb=500)

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -288,7 +288,7 @@ class MCPToolsRegistry:
             project_name: Name of the project to delete
 
         Returns:
-            Dictionary with deletion status and count of deleted nodes
+            Dictionary with deletion status
         """
         logger.info(f"[MCP] Deleting project: {project_name}")
         try:
@@ -298,19 +298,17 @@ class MCPToolsRegistry:
                 return {
                     "success": False,
                     "error": f"Project '{project_name}' not found. Available projects: {projects}",
-                    "deleted_nodes": 0,
                 }
 
-            deleted_count = self.ingestor.delete_project(project_name)
+            self.ingestor.delete_project(project_name)
             return {
                 "success": True,
                 "project": project_name,
-                "deleted_nodes": deleted_count,
-                "message": f"Successfully deleted project '{project_name}' ({deleted_count} nodes removed).",
+                "message": f"Successfully deleted project '{project_name}'.",
             }
         except Exception as e:
             logger.error(f"[MCP] Error deleting project: {e}")
-            return {"success": False, "error": str(e), "deleted_nodes": 0}
+            return {"success": False, "error": str(e)}
 
     async def wipe_database(self, confirm: bool) -> str:
         """Completely wipe the entire database.
@@ -350,9 +348,7 @@ class MCPToolsRegistry:
         try:
             # Delete only the current project's data (preserves other projects)
             logger.info(f"[MCP] Clearing existing data for project '{project_name}'...")
-            deleted_count = self.ingestor.delete_project(project_name)
-            if deleted_count > 0:
-                logger.info(f"[MCP] Removed {deleted_count} existing nodes for '{project_name}'.")
+            self.ingestor.delete_project(project_name)
 
             updater = GraphUpdater(
                 ingestor=self.ingestor,

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -343,7 +343,7 @@ class MCPToolsRegistry:
             Success message with indexing statistics
         """
         logger.info(f"[MCP] Indexing repository at: {self.project_root}")
-        project_name = Path(self.project_root).name
+        project_name = Path(self.project_root).resolve().name
 
         try:
             # Delete only the current project's data (preserves other projects)

--- a/codebase_rag/services/graph_service.py
+++ b/codebase_rag/services/graph_service.py
@@ -124,9 +124,59 @@ class MemgraphIngestor:
                 cursor.close()
 
     def clean_database(self) -> None:
+        """Wipe the entire database. Use with caution."""
         logger.info("--- Cleaning database... ---")
         self._execute_query("MATCH (n) DETACH DELETE n;")
         logger.info("--- Database cleaned. ---")
+
+    def list_projects(self) -> list[str]:
+        """List all indexed projects in the database.
+
+        Returns:
+            List of project names
+        """
+        result = self.fetch_all("MATCH (p:Project) RETURN p.name AS name ORDER BY p.name")
+        return [r["name"] for r in result]
+
+    def delete_project(self, project_name: str) -> int:
+        """Delete all nodes associated with a specific project.
+
+        This removes the Project node and all nodes whose qualified_name
+        starts with the project name prefix, preserving other projects.
+
+        Args:
+            project_name: Name of the project to delete
+
+        Returns:
+            Number of nodes deleted
+        """
+        logger.info(f"--- Deleting project: {project_name} ---")
+
+        # First, count nodes to be deleted
+        count_result = self.fetch_all(
+            """
+            MATCH (n)
+            WHERE n.qualified_name STARTS WITH $prefix
+               OR (n:Project AND n.name = $project_name)
+            RETURN count(n) AS count
+            """,
+            {"prefix": f"{project_name}.", "project_name": project_name},
+        )
+        node_count = count_result[0]["count"] if count_result else 0
+
+        # Delete all nodes with qualified_name starting with project name
+        self._execute_query(
+            """
+            MATCH (n)
+            WHERE n.qualified_name STARTS WITH $prefix
+               OR (n:Project AND n.name = $project_name)
+            DETACH DELETE n
+            """,
+            {"prefix": f"{project_name}.", "project_name": project_name},
+        )
+
+        logger.info(f"--- Project {project_name} deleted. {node_count} nodes removed. ---")
+        return node_count
 
     def ensure_constraints(self) -> None:
         logger.info("Ensuring constraints...")


### PR DESCRIPTION
## Summary

- Add `list_projects()` and `delete_project()` methods to `MemgraphIngestor` class for project-scoped database operations
- Add 3 new MCP tools: `list_projects`, `delete_project`, `wipe_database`
- Modify `index_repository` to use project-scoped deletion instead of wiping entire database

This enables indexing multiple repositories without losing data from other projects when re-indexing a single repository.

## Changes

### graph_service.py
- `list_projects()`: Returns list of all indexed project names
- `delete_project(project_name)`: Deletes all nodes with `qualified_name` starting with the project name prefix, preserving other projects

### mcp/tools.py  
- `list_projects`: MCP tool to list all indexed projects
- `delete_project`: MCP tool to delete a specific project
- `wipe_database`: MCP tool to clear entire database (requires confirmation flag)
- `index_repository`: Updated to use `delete_project()` instead of `clean_database()`, preserving other projects

## Test plan

- [x] Verify imports work correctly
- [x] Run MCP tools integration tests (5/5 passed)
- [x] Run type inference tests (2/2 passed)
- [x] Manual testing with Memgraph to verify project isolation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)