### PR TITLE
fix: resolve path mismatch in semantic embedding generation

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -522,7 +522,7 @@ class GraphUpdater:
         if not file_path or not start_line or not end_line:
             return None
 
-        file_path_obj = Path(file_path)
+        file_path_obj = self.repo_path / file_path
 
         # Create AST extractor function if AST is available
         ast_extractor = None


### PR DESCRIPTION
Fixes #179

The database stores relative paths (e.g., `src/main.py`) but the AST cache uses absolute paths. During embedding generation, `_extract_source_code` was creating a Path from the relative path directly, causing both AST cache lookups and file existence checks to fail.

This one-line fix prepends `self.repo_path` to reconstruct the absolute path.

Tested by indexing an external repository and verifying embeddings are now generated successfully.