### PR TITLE
fix: increase pydantic-ai agent retries to 3

### DIFF
--- a/codebase_rag/config.py
+++ b/codebase_rag/config.py
@@ -43,6 +43,7 @@ class AppConfig(BaseSettings):
     MEMGRAPH_HTTP_PORT: int = 7444
     LAB_PORT: int = 3000
     MEMGRAPH_BATCH_SIZE: int = 1000
+    AGENT_RETRIES: int = 3
 
     ORCHESTRATOR_PROVIDER: str = ""
     ORCHESTRATOR_MODEL: str = ""

--- a/codebase_rag/services/llm.py
+++ b/codebase_rag/services/llm.py
@@ -9,6 +9,8 @@ from ..prompts import (
 )
 from ..providers.base import get_provider
 
+AGENT_RETRIES = 3
+
 
 class LLMGenerationError(Exception):
     """Custom exception for LLM generation failures."""
@@ -55,7 +57,7 @@ class CypherGenerator:
                 model=llm,
                 system_prompt=system_prompt,
                 output_type=str,
-                retries=3,
+                retries=AGENT_RETRIES,
             )
         except Exception as e:
             raise LLMGenerationError(
@@ -105,7 +107,7 @@ def create_rag_orchestrator(tools: list[Tool]) -> Agent:
             model=llm,
             system_prompt=RAG_ORCHESTRATOR_SYSTEM_PROMPT,
             tools=tools,
-            retries=3,
+            retries=AGENT_RETRIES,
         )
     except Exception as e:
         raise LLMGenerationError(f"Failed to initialize RAG Orchestrator: {e}") from e

--- a/codebase_rag/services/llm.py
+++ b/codebase_rag/services/llm.py
@@ -9,8 +9,6 @@ from ..prompts import (
 )
 from ..providers.base import get_provider
 
-AGENT_RETRIES = settings.AGENT_RETRIES
-
 
 class LLMGenerationError(Exception):
     """Custom exception for LLM generation failures."""
@@ -57,7 +55,7 @@ class CypherGenerator:
                 model=llm,
                 system_prompt=system_prompt,
                 output_type=str,
-                retries=AGENT_RETRIES,
+                retries=settings.AGENT_RETRIES,
             )
         except Exception as e:
             raise LLMGenerationError(
@@ -107,7 +105,7 @@ def create_rag_orchestrator(tools: list[Tool]) -> Agent:
             model=llm,
             system_prompt=RAG_ORCHESTRATOR_SYSTEM_PROMPT,
             tools=tools,
-            retries=AGENT_RETRIES,
+            retries=settings.AGENT_RETRIES,
         )
     except Exception as e:
         raise LLMGenerationError(f"Failed to initialize RAG Orchestrator: {e}") from e

--- a/codebase_rag/services/llm.py
+++ b/codebase_rag/services/llm.py
@@ -55,6 +55,7 @@ class CypherGenerator:
                 model=llm,
                 system_prompt=system_prompt,
                 output_type=str,
+                retries=3,
             )
         except Exception as e:
             raise LLMGenerationError(
@@ -104,6 +105,7 @@ def create_rag_orchestrator(tools: list[Tool]) -> Agent:
             model=llm,
             system_prompt=RAG_ORCHESTRATOR_SYSTEM_PROMPT,
             tools=tools,
+            retries=3,
         )
     except Exception as e:
         raise LLMGenerationError(f"Failed to initialize RAG Orchestrator: {e}") from e

--- a/codebase_rag/services/llm.py
+++ b/codebase_rag/services/llm.py
@@ -9,7 +9,7 @@ from ..prompts import (
 )
 from ..providers.base import get_provider
 
-AGENT_RETRIES = getattr(settings, "AGENT_RETRIES", 3)
+AGENT_RETRIES = settings.AGENT_RETRIES
 
 
 class LLMGenerationError(Exception):

--- a/codebase_rag/services/llm.py
+++ b/codebase_rag/services/llm.py
@@ -9,7 +9,7 @@ from ..prompts import (
 )
 from ..providers.base import get_provider
 
-AGENT_RETRIES = 3
+AGENT_RETRIES = getattr(settings, "AGENT_RETRIES", 3)
 
 
 class LLMGenerationError(Exception):


### PR DESCRIPTION
## Summary
- Increase retry count from default 1 to 3 for both CypherGenerator and RAG orchestrator agents
- Prevents "Exceeded maximum retries for output validation" errors when LLM responses are temporarily malformed

## Test plan
- [ ] Run `cgr start --repo-path .` and verify no validation errors on complex queries