### PR TITLE
fix: find_ending_with too slow

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -134,20 +134,7 @@ class FunctionRegistryTrie:
 
     def find_ending_with(self, suffix: str) -> list[str]:
         """Find all qualified names ending with the given suffix using DFS on the trie."""
-        results: list[str] = []
-
-        def dfs(node: dict[str, Any]) -> None:
-            if "__qn__" in node:
-                qn = node["__qn__"]
-                if qn.endswith(f".{suffix}"):
-                    results.append(qn)
-
-            for key, child in node.items():
-                if not key.startswith("__"):
-                    dfs(child)
-
-        dfs(self.root)
-        return results
+        return self.find_with_prefix_and_suffix("", suffix)
 
     def find_with_prefix(self, prefix: str) -> list[tuple[str, str]]:
         """Find all qualified names that start with the given prefix.

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -133,8 +133,21 @@ class FunctionRegistryTrie:
         return results
 
     def find_ending_with(self, suffix: str) -> list[str]:
-        """Find all qualified names ending with the given suffix."""
-        return [qn for qn in self._entries.keys() if qn.endswith(f".{suffix}")]
+        """Find all qualified names ending with the given suffix using DFS on the trie."""
+        results: list[str] = []
+
+        def dfs(node: dict[str, Any]) -> None:
+            if "__qn__" in node:
+                qn = node["__qn__"]
+                if qn.endswith(f".{suffix}"):
+                    results.append(qn)
+
+            for key, child in node.items():
+                if not key.startswith("__"):
+                    dfs(child)
+
+        dfs(self.root)
+        return results
 
     def find_with_prefix(self, prefix: str) -> list[tuple[str, str]]:
         """Find all qualified names that start with the given prefix.


### PR DESCRIPTION
find_ending_with  Find all qualified names ending with the given suffix using DFS on the trie.
This avoids a full scan of the `_entries` dict and instead walks the trie structure once, checking each stored qualified name.