### PR TITLE
feat!: implement Pydantic AI dependency injection with RunContext and deps_type

### DIFF
--- a/codebase_rag/deps.py
+++ b/codebase_rag/deps.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from rich.console import Console
+
+from .services import QueryProtocol
+
+
+@dataclass
+class RAGDeps:
+    project_root: Path
+    ingestor: QueryProtocol
+    cypher_generator: Any
+    code_retriever: Any
+    file_reader: Any
+    file_writer: Any
+    file_editor: Any
+    shell_commander: Any
+    directory_lister: Any
+    document_analyzer: Any
+    console: Console

--- a/codebase_rag/exceptions.py
+++ b/codebase_rag/exceptions.py
@@ -1,0 +1,2 @@
+class LLMGenerationError(Exception):
+    pass

--- a/codebase_rag/tests/integration/test_mcp_tools_integration.py
+++ b/codebase_rag/tests/integration/test_mcp_tools_integration.py
@@ -109,28 +109,29 @@ class TestMCPToolsIntegration:
 class TestToolConsistency:
     """Tests that verify all tools follow consistent patterns."""
 
-    async def test_all_tools_have_consistent_takes_ctx(
+    async def test_all_service_classes_are_initialized(
         self, mcp_registry: MCPToolsRegistry
     ) -> None:
-        """Verify all tools have consistent takes_ctx settings."""
-        tools = {
-            "query": mcp_registry._query_tool,
-            "code": mcp_registry._code_tool,
-            "editor": mcp_registry._file_editor_tool,
-            "reader": mcp_registry._file_reader_tool,
-            "writer": mcp_registry._file_writer_tool,
-            "lister": mcp_registry._directory_lister_tool,
+        """Verify all service classes are properly initialized."""
+        assert mcp_registry.code_retriever is not None
+        assert mcp_registry.file_editor is not None
+        assert mcp_registry.file_reader is not None
+        assert mcp_registry.file_writer is not None
+        assert mcp_registry.directory_lister is not None
+
+    async def test_all_tools_are_registered(
+        self, mcp_registry: MCPToolsRegistry
+    ) -> None:
+        """Verify all expected tools are registered."""
+        expected_tools = {
+            "index_repository",
+            "query_code_graph",
+            "get_code_snippet",
+            "surgical_replace_code",
+            "read_file",
+            "write_file",
+            "list_directory",
         }
 
-        takes_ctx_values = {name: tool.takes_ctx for name, tool in tools.items()}
-
-        assert takes_ctx_values == {
-            "query": False,
-            "code": False,
-            "editor": False,
-            "reader": False,
-            "writer": False,
-            "lister": False,
-        }
-
-        assert all(not takes_ctx for takes_ctx in takes_ctx_values.values())
+        registered_tools = set(mcp_registry.list_tool_names())
+        assert registered_tools == expected_tools

--- a/codebase_rag/tests/test_mcp_read_file.py
+++ b/codebase_rag/tests/test_mcp_read_file.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -10,19 +10,16 @@ pytestmark = [pytest.mark.anyio]
 
 @pytest.fixture(params=["asyncio"])
 def anyio_backend(request: pytest.FixtureRequest) -> str:
-    """Configure anyio to only use asyncio backend."""
     return str(request.param)
 
 
 @pytest.fixture
 def temp_project_root(tmp_path: Path) -> Path:
-    """Create a temporary project root directory."""
     return tmp_path
 
 
 @pytest.fixture
 def sample_file(temp_project_root: Path) -> Path:
-    """Create a sample file with known content."""
     file_path = temp_project_root / "test_file.txt"
     content = "\n".join([f"Line {i}" for i in range(1, 101)])
     file_path.write_text(content, encoding="utf-8")
@@ -31,7 +28,6 @@ def sample_file(temp_project_root: Path) -> Path:
 
 @pytest.fixture
 def large_file(temp_project_root: Path) -> Path:
-    """Create a large file to test memory efficiency."""
     file_path = temp_project_root / "large_file.txt"
     with open(file_path, "w", encoding="utf-8") as f:
         for i in range(1, 10001):
@@ -41,7 +37,6 @@ def large_file(temp_project_root: Path) -> Path:
 
 @pytest.fixture
 def mcp_registry(temp_project_root: Path) -> MCPToolsRegistry:
-    """Create an MCP tools registry with mocked dependencies."""
     mock_ingestor = MagicMock()
     mock_cypher_gen = MagicMock()
 
@@ -51,37 +46,24 @@ def mcp_registry(temp_project_root: Path) -> MCPToolsRegistry:
         cypher_gen=mock_cypher_gen,
     )
 
-    registry._file_reader_tool = MagicMock()
-    registry._file_reader_tool.function = AsyncMock()
-
     return registry
 
 
 class TestReadFileWithoutPagination:
-    """Test reading files without pagination parameters."""
-
     async def test_read_full_file(
         self, mcp_registry: MCPToolsRegistry, sample_file: Path
     ) -> None:
-        """Test reading entire file without pagination."""
         expected_content = sample_file.read_text(encoding="utf-8")
-        mcp_registry._file_reader_tool.function.return_value = expected_content  # ty: ignore[invalid-assignment]
 
         result = await mcp_registry.read_file("test_file.txt")
 
         assert result == expected_content
-        mcp_registry._file_reader_tool.function.assert_called_once_with(
-            file_path="test_file.txt"
-        )
 
 
 class TestReadFileWithPagination:
-    """Test reading files with pagination parameters."""
-
     async def test_read_with_offset_only(
         self, mcp_registry: MCPToolsRegistry, sample_file: Path
     ) -> None:
-        """Test reading from a specific offset to end of file."""
         result = await mcp_registry.read_file("test_file.txt", offset=10)
 
         lines = result.split("\n")
@@ -92,7 +74,6 @@ class TestReadFileWithPagination:
     async def test_read_with_limit_only(
         self, mcp_registry: MCPToolsRegistry, sample_file: Path
     ) -> None:
-        """Test reading only first N lines."""
         result = await mcp_registry.read_file("test_file.txt", limit=10)
 
         lines = result.split("\n")
@@ -104,7 +85,6 @@ class TestReadFileWithPagination:
     async def test_read_with_offset_and_limit(
         self, mcp_registry: MCPToolsRegistry, sample_file: Path
     ) -> None:
-        """Test reading a specific range of lines."""
         result = await mcp_registry.read_file("test_file.txt", offset=20, limit=10)
 
         lines = result.split("\n")
@@ -117,7 +97,6 @@ class TestReadFileWithPagination:
     async def test_read_offset_beyond_file_length(
         self, mcp_registry: MCPToolsRegistry, sample_file: Path
     ) -> None:
-        """Test reading with offset beyond file length."""
         result = await mcp_registry.read_file("test_file.txt", offset=150)
 
         lines = result.split("\n")
@@ -127,7 +106,6 @@ class TestReadFileWithPagination:
     async def test_read_zero_offset(
         self, mcp_registry: MCPToolsRegistry, sample_file: Path
     ) -> None:
-        """Test reading with offset=0 (should read from beginning)."""
         result = await mcp_registry.read_file("test_file.txt", offset=0, limit=5)
 
         lines = result.split("\n")
@@ -137,12 +115,9 @@ class TestReadFileWithPagination:
 
 
 class TestReadFileLargeFiles:
-    """Test memory efficiency with large files."""
-
     async def test_read_middle_of_large_file(
         self, mcp_registry: MCPToolsRegistry, large_file: Path
     ) -> None:
-        """Test reading from middle of large file doesn't load entire file."""
         result = await mcp_registry.read_file("large_file.txt", offset=5000, limit=10)
 
         lines = result.split("\n")
@@ -155,7 +130,6 @@ class TestReadFileLargeFiles:
     async def test_read_last_lines_of_large_file(
         self, mcp_registry: MCPToolsRegistry, large_file: Path
     ) -> None:
-        """Test reading last few lines of large file."""
         result = await mcp_registry.read_file("large_file.txt", offset=9995, limit=10)
 
         lines = result.split("\n")
@@ -165,12 +139,9 @@ class TestReadFileLargeFiles:
 
 
 class TestReadFileEdgeCases:
-    """Test edge cases and error handling."""
-
     async def test_read_empty_file(
         self, mcp_registry: MCPToolsRegistry, temp_project_root: Path
     ) -> None:
-        """Test reading an empty file."""
         empty_file = temp_project_root / "empty.txt"
         empty_file.write_text("", encoding="utf-8")
 
@@ -180,7 +151,6 @@ class TestReadFileEdgeCases:
         assert lines[0] == "# Lines 1-0 of 0"
 
     async def test_read_nonexistent_file(self, mcp_registry: MCPToolsRegistry) -> None:
-        """Test reading a file that doesn't exist."""
         result = await mcp_registry.read_file("nonexistent.txt", offset=0, limit=10)
 
         assert "Error:" in result
@@ -188,7 +158,6 @@ class TestReadFileEdgeCases:
     async def test_read_single_line_file(
         self, mcp_registry: MCPToolsRegistry, temp_project_root: Path
     ) -> None:
-        """Test reading a file with only one line."""
         single_line_file = temp_project_root / "single.txt"
         single_line_file.write_text("Only one line", encoding="utf-8")
 
@@ -201,7 +170,6 @@ class TestReadFileEdgeCases:
     async def test_read_file_with_unicode(
         self, mcp_registry: MCPToolsRegistry, temp_project_root: Path
     ) -> None:
-        """Test reading a file with unicode characters."""
         unicode_file = temp_project_root / "unicode.txt"
         content = "\n".join(
             ["Hello 世界", "Привет мир", "مرحبا بالعالم", "🎉 Emoji line"]

--- a/codebase_rag/tools/codebase_query.py
+++ b/codebase_rag/tools/codebase_query.py
@@ -1,103 +1,81 @@
 from loguru import logger
-from pydantic_ai import Tool
-from rich.console import Console
+from pydantic_ai import RunContext
 from rich.panel import Panel
 from rich.table import Table
 
+from ..deps import RAGDeps
+from ..exceptions import LLMGenerationError
 from ..schemas import GraphData
-from ..services import QueryProtocol
-from ..services.llm import CypherGenerator, LLMGenerationError
 
 
-class GraphQueryError(Exception):
-    """Custom exception for graph query failures."""
-
-    pass
-
-
-def create_query_tool(
-    ingestor: QueryProtocol,
-    cypher_gen: CypherGenerator,
-    console: Console | None = None,
-) -> Tool:
+async def query_codebase_knowledge_graph(
+    ctx: RunContext[RAGDeps], natural_language_query: str
+) -> GraphData:
     """
-    Factory function that creates the knowledge graph query tool,
-    injecting its dependencies.
+    Queries the codebase knowledge graph using natural language.
+
+    Provide your question in plain English about the codebase structure,
+    functions, classes, dependencies, or relationships. The tool will
+    automatically translate your natural language question into the
+    appropriate database query and return the results.
+
+    Examples:
+    - "Find all functions that call each other"
+    - "What classes are in the user authentication module"
+    - "Show me functions with the longest call chains"
+    - "Which files contain functions related to database operations"
     """
-    if console is None:
-        console = Console(width=None, force_terminal=True)
+    logger.info(f"[Tool:QueryGraph] Received NL query: '{natural_language_query}'")
+    cypher_query = "N/A"
+    try:
+        cypher_query = await ctx.deps.cypher_generator.generate(natural_language_query)
 
-    async def query_codebase_knowledge_graph(natural_language_query: str) -> GraphData:
-        """
-        Queries the codebase knowledge graph using natural language.
+        results = ctx.deps.ingestor.fetch_all(cypher_query)
 
-        Provide your question in plain English about the codebase structure,
-        functions, classes, dependencies, or relationships. The tool will
-        automatically translate your natural language question into the
-        appropriate database query and return the results.
+        if results:
+            table = Table(
+                show_header=True,
+                header_style="bold magenta",
+            )
+            headers = results[0].keys()
+            for header in headers:
+                table.add_column(header)
 
-        Examples:
-        - "Find all functions that call each other"
-        - "What classes are in the user authentication module"
-        - "Show me functions with the longest call chains"
-        - "Which files contain functions related to database operations"
-        """
-        logger.info(f"[Tool:QueryGraph] Received NL query: '{natural_language_query}'")
-        cypher_query = "N/A"
-        try:
-            cypher_query = await cypher_gen.generate(natural_language_query)
+            for row in results:
+                renderable_values = []
+                for value in row.values():
+                    if value is None:
+                        renderable_values.append("")
+                    elif isinstance(value, bool):
+                        renderable_values.append("✓" if value else "✗")
+                    elif isinstance(value, int | float):
+                        renderable_values.append(str(value))
+                    else:
+                        renderable_values.append(str(value))
+                table.add_row(*renderable_values)
 
-            results = ingestor.fetch_all(cypher_query)
-
-            if results:
-                table = Table(
-                    show_header=True,
-                    header_style="bold magenta",
+            ctx.deps.console.print(
+                Panel(
+                    table,
+                    title="[bold blue]Cypher Query Results[/bold blue]",
+                    expand=False,
                 )
-                headers = results[0].keys()
-                for header in headers:
-                    table.add_column(header)
-
-                for row in results:
-                    renderable_values = []
-                    for value in row.values():
-                        if value is None:
-                            renderable_values.append("")
-                        elif isinstance(value, bool):
-                            renderable_values.append("✓" if value else "✗")
-                        elif isinstance(value, int | float):
-                            renderable_values.append(str(value))
-                        else:
-                            renderable_values.append(str(value))
-                    table.add_row(*renderable_values)
-
-                console.print(
-                    Panel(
-                        table,
-                        title="[bold blue]Cypher Query Results[/bold blue]",
-                        expand=False,
-                    )
-                )
-
-            summary = f"Successfully retrieved {len(results)} item(s) from the graph."
-            return GraphData(query_used=cypher_query, results=results, summary=summary)
-        except LLMGenerationError as e:
-            return GraphData(
-                query_used="N/A",
-                results=[],
-                summary=f"I couldn't translate your request into a database query. Error: {e}",
-            )
-        except Exception as e:
-            logger.error(
-                f"[Tool:QueryGraph] Error during query execution: {e}", exc_info=True
-            )
-            return GraphData(
-                query_used=cypher_query,
-                results=[],
-                summary=f"There was an error querying the database: {e}",
             )
 
-    return Tool(
-        function=query_codebase_knowledge_graph,
-        description="Query the codebase knowledge graph using natural language questions. Ask in plain English about classes, functions, methods, dependencies, or code structure. Examples: 'Find all functions that call each other', 'What classes are in the user module', 'Show me functions with the longest call chains'.",
-    )
+        summary = f"Successfully retrieved {len(results)} item(s) from the graph."
+        return GraphData(query_used=cypher_query, results=results, summary=summary)
+    except LLMGenerationError as e:
+        return GraphData(
+            query_used="N/A",
+            results=[],
+            summary=f"I couldn't translate your request into a database query. Error: {e}",
+        )
+    except Exception as e:
+        logger.error(
+            f"[Tool:QueryGraph] Error during query execution: {e}", exc_info=True
+        )
+        return GraphData(
+            query_used=cypher_query,
+            results=[],
+            summary=f"There was an error querying the database: {e}",
+        )

--- a/codebase_rag/tools/directory_lister.py
+++ b/codebase_rag/tools/directory_lister.py
@@ -2,7 +2,9 @@ import os
 from pathlib import Path
 
 from loguru import logger
-from pydantic_ai import Tool
+from pydantic_ai import RunContext
+
+from ..deps import RAGDeps
 
 
 class DirectoryLister:
@@ -10,9 +12,6 @@ class DirectoryLister:
         self.project_root = Path(project_root).resolve()
 
     def list_directory_contents(self, directory_path: str) -> str:
-        """
-        Lists the contents of a specified directory.
-        """
         target_path = self._get_safe_path(directory_path)
         logger.info(f"Listing contents of directory: {target_path}")
 
@@ -30,10 +29,6 @@ class DirectoryLister:
             return f"Error: Could not list contents of '{directory_path}'."
 
     def _get_safe_path(self, file_path: str) -> Path:
-        """
-        Resolves the file path relative to the root and ensures it's within
-        the project directory.
-        """
         if Path(file_path).is_absolute():
             safe_path = Path(file_path).resolve()
         else:
@@ -54,8 +49,8 @@ class DirectoryLister:
         return safe_path
 
 
-def create_directory_lister_tool(directory_lister: DirectoryLister) -> Tool:
-    return Tool(
-        function=directory_lister.list_directory_contents,
-        description="Lists the contents of a directory to explore the codebase.",
-    )
+def list_directory(ctx: RunContext[RAGDeps], directory_path: str) -> str:
+    """
+    Lists the contents of a directory to explore the codebase.
+    """
+    return ctx.deps.directory_lister.list_directory_contents(directory_path)

--- a/codebase_rag/tools/document_analyzer.py
+++ b/codebase_rag/tools/document_analyzer.py
@@ -7,14 +7,13 @@ from google import genai
 from google.genai import types
 from google.genai.errors import ClientError
 from loguru import logger
-from pydantic_ai import Tool
+from pydantic_ai import RunContext
 
 from ..config import settings
+from ..deps import RAGDeps
 
 
 class _NotSupportedClient:
-    """Placeholder client that raises NotImplementedError for unsupported providers."""
-
     def __getattr__(self, name: str) -> None:
         raise NotImplementedError(
             "DocumentAnalyzer does not support the 'local' LLM provider."
@@ -22,11 +21,6 @@ class _NotSupportedClient:
 
 
 class DocumentAnalyzer:
-    """
-    A tool to perform multimodal analysis on documents like PDFs
-    by making a direct call to the Gemini API.
-    """
-
     def __init__(self, project_root: str) -> None:
         self.project_root = Path(project_root).resolve()
 
@@ -47,10 +41,6 @@ class DocumentAnalyzer:
         logger.info(f"DocumentAnalyzer initialized with root: {self.project_root}")
 
     def analyze(self, file_path: str, question: str) -> str:
-        """
-        Reads a document (e.g., PDF), sends it to the Gemini multimodal endpoint
-        with a specific question, and returns the model's analysis.
-        """
         logger.info(
             f"[DocumentAnalyzer] Analyzing '{file_path}' with question: '{question}'"
         )
@@ -134,34 +124,25 @@ class DocumentAnalyzer:
             return f"An error occurred during analysis: {e}"
 
 
-def create_document_analyzer_tool(analyzer: DocumentAnalyzer) -> Tool:
-    """Factory function to create the document analyzer tool."""
+def analyze_document(ctx: RunContext[RAGDeps], file_path: str, question: str) -> str:
+    """
+    Analyzes a document (like a PDF) to answer a specific question about its content.
+    Use this tool when a user asks a question that requires understanding the content of a non-source-code file.
 
-    def analyze_document(file_path: str, question: str) -> str:
-        """
-        Analyzes a document (like a PDF) to answer a specific question about its content.
-        Use this tool when a user asks a question that requires understanding the content of a non-source-code file.
-
-        Args:
-            file_path: The path to the document file (e.g., 'path/to/book.pdf').
-            question: The specific question to ask about the document's content.
-        """
-        try:
-            result = analyzer.analyze(file_path, question)
-            logger.debug(
-                f"[analyze_document] Result type: {type(result)}, content: {result[:100] if result else 'None'}..."
-            )
-            return result
-        except Exception as e:
-            logger.error(
-                f"[analyze_document] Exception during analysis: {e}", exc_info=True
-            )
-            if str(e).startswith("Error:") or str(e).startswith("API error:"):
-                return str(e)
-            return f"Error during document analysis: {e}"
-
-    return Tool(
-        function=analyze_document,
-        name="analyze_document",
-        description="Analyzes documents (PDFs, images) to answer questions about their content.",
-    )
+    Args:
+        file_path: The path to the document file (e.g., 'path/to/book.pdf').
+        question: The specific question to ask about the document's content.
+    """
+    try:
+        result = ctx.deps.document_analyzer.analyze(file_path, question)
+        logger.debug(
+            f"[analyze_document] Result type: {type(result)}, content: {result[:100] if result else 'None'}..."
+        )
+        return result
+    except Exception as e:
+        logger.error(
+            f"[analyze_document] Exception during analysis: {e}", exc_info=True
+        )
+        if str(e).startswith("Error:") or str(e).startswith("API error:"):
+            return str(e)
+        return f"Error during document analysis: {e}"

--- a/codebase_rag/tools/file_reader.py
+++ b/codebase_rag/tools/file_reader.py
@@ -2,20 +2,18 @@ from pathlib import Path
 
 from loguru import logger
 from pydantic import BaseModel
-from pydantic_ai import Tool
+from pydantic_ai import RunContext
+
+from ..deps import RAGDeps
 
 
 class FileReadResult(BaseModel):
-    """Data model for file read results."""
-
     file_path: str
     content: str | None = None
     error_message: str | None = None
 
 
 class FileReader:
-    """Service to read file content from the filesystem."""
-
     def __init__(self, project_root: str = "."):
         self.project_root = Path(project_root).resolve()
         self.binary_extensions = {
@@ -32,7 +30,6 @@ class FileReader:
         logger.info(f"FileReader initialized with root: {self.project_root}")
 
     async def read_file(self, file_path: str) -> FileReadResult:
-        """Reads and returns the content of a text-based file."""
         logger.info(f"[FileReader] Attempting to read file: {file_path}")
         try:
             full_path = (self.project_root / file_path).resolve()
@@ -81,20 +78,12 @@ class FileReader:
             )
 
 
-def create_file_reader_tool(file_reader: FileReader) -> Tool:
-    """Factory function to create the file reader tool."""
-
-    async def read_file_content(file_path: str) -> str:
-        """
-        Reads the content of a specified text-based file (e.g., source code, README.md, config files).
-        This tool should NOT be used for binary files like PDFs or images. For those, use the 'analyze_document' tool.
-        """
-        result = await file_reader.read_file(file_path)
-        if result.error_message:
-            return f"Error: {result.error_message}"
-        return result.content or ""
-
-    return Tool(
-        function=read_file_content,
-        description="Reads the content of text-based files. For documents like PDFs or images, use the 'analyze_document' tool instead.",
-    )
+async def read_file_content(ctx: RunContext[RAGDeps], file_path: str) -> str:
+    """
+    Reads the content of a specified text-based file (e.g., source code, README.md, config files).
+    This tool should NOT be used for binary files like PDFs or images. For those, use the 'analyze_document' tool.
+    """
+    result = await ctx.deps.file_reader.read_file(file_path)
+    if result.error_message:
+        return f"Error: {result.error_message}"
+    return result.content or ""

--- a/codebase_rag/tools/file_writer.py
+++ b/codebase_rag/tools/file_writer.py
@@ -2,26 +2,23 @@ from pathlib import Path
 
 from loguru import logger
 from pydantic import BaseModel
-from pydantic_ai import Tool
+from pydantic_ai import RunContext
+
+from ..deps import RAGDeps
 
 
 class FileCreationResult(BaseModel):
-    """Data model for file creation results."""
-
     file_path: str
     success: bool = True
     error_message: str | None = None
 
 
 class FileWriter:
-    """Service to write file content to the filesystem."""
-
     def __init__(self, project_root: str = "."):
         self.project_root = Path(project_root).resolve()
         logger.info(f"FileWriter initialized with root: {self.project_root}")
 
     async def create_file(self, file_path: str, content: str) -> FileCreationResult:
-        """Creates or overwrites a file with the given content."""
         logger.info(f"[FileWriter] Creating file: {file_path}")
         try:
             full_path = (self.project_root / file_path).resolve()
@@ -48,25 +45,18 @@ class FileWriter:
             )
 
 
-def create_file_writer_tool(file_writer: FileWriter) -> Tool:
-    """Factory function to create the file writer tool."""
+async def create_new_file(
+    ctx: RunContext[RAGDeps], file_path: str, content: str
+) -> FileCreationResult:
+    """
+    Creates a new file with the specified content.
 
-    async def create_new_file(file_path: str, content: str) -> FileCreationResult:
-        """
-        Creates a new file with the specified content.
+    IMPORTANT: Before using this tool, you MUST check if the file already exists using
+    the file reader or directory listing tools. If the file exists, use edit_existing_file
+    instead to preserve existing content and show diffs.
 
-        IMPORTANT: Before using this tool, you MUST check if the file already exists using
-        the file reader or directory listing tools. If the file exists, use edit_existing_file
-        instead to preserve existing content and show diffs.
-
-        If the file already exists, it will be completely overwritten WITHOUT showing any diff.
-        Use this ONLY for creating entirely new files, not for modifying existing ones.
-        For modifying existing files with diff preview, use edit_existing_file instead.
-        """
-        return await file_writer.create_file(file_path, content)
-
-    return Tool(
-        function=create_new_file,
-        description="Creates a new file with content. IMPORTANT: Check file existence first! Overwrites completely WITHOUT showing diff. Use only for new files, not existing file modifications.",
-        requires_approval=True,
-    )
+    If the file already exists, it will be completely overwritten WITHOUT showing any diff.
+    Use this ONLY for creating entirely new files, not for modifying existing ones.
+    For modifying existing files with diff preview, use edit_existing_file instead.
+    """
+    return await ctx.deps.file_writer.create_file(file_path, content)

--- a/codebase_rag/tools/semantic_search.py
+++ b/codebase_rag/tools/semantic_search.py
@@ -1,30 +1,11 @@
 from typing import Any
 
 from loguru import logger
-from pydantic_ai import Tool
 
 from ..utils.dependencies import has_semantic_dependencies
 
 
 def semantic_code_search(query: str, top_k: int = 5) -> list[dict[str, Any]]:
-    """
-    Search for functions/methods by natural language intent using semantic embeddings.
-
-    Args:
-        query: Natural language description of desired functionality
-        top_k: Number of results to return
-
-    Returns:
-        List of dictionaries with node information:
-        [
-            {
-                "node_id": int,
-                "qualified_name": str,
-                "type": str,
-                "score": float
-            }
-        ]
-    """
     if not has_semantic_dependencies():
         logger.warning(
             "Semantic search requires 'semantic' extra: uv sync --extra semantic"
@@ -87,15 +68,6 @@ def semantic_code_search(query: str, top_k: int = 5) -> list[dict[str, Any]]:
 
 
 def get_function_source_code(node_id: int) -> str | None:
-    """
-    Retrieve source code for a function/method by node ID.
-
-    Args:
-        node_id: Memgraph node ID
-
-    Returns:
-        Source code string or None if not found
-    """
     try:
         from ..config import settings
         from ..services.graph_service import MemgraphIngestor
@@ -141,78 +113,62 @@ def get_function_source_code(node_id: int) -> str | None:
         return None
 
 
-def create_semantic_search_tool() -> Tool:
+async def semantic_search_functions(query: str, top_k: int = 5) -> str:
     """
-    Factory function to create the semantic code search tool.
+    Search for functions/methods using natural language descriptions of their purpose.
+
+    Use this tool when you need to find code that performs specific functionality
+    based on intent rather than exact names. Perfect for questions like:
+    - "Find error handling functions"
+    - "Show me authentication-related code"
+    - "Where is data validation implemented?"
+    - "Find functions that handle file I/O"
+
+    Args:
+        query: Natural language description of the desired functionality
+        top_k: Maximum number of results to return (default: 5)
+
+    Returns:
+        String describing the found functions with their qualified names and similarity scores
     """
+    logger.info(f"[Tool:SemanticSearch] Searching for: '{query}'")
 
-    async def semantic_search_functions(query: str, top_k: int = 5) -> str:
-        """
-        Search for functions/methods using natural language descriptions of their purpose.
+    results = semantic_code_search(query, top_k)
 
-        Use this tool when you need to find code that performs specific functionality
-        based on intent rather than exact names. Perfect for questions like:
-        - "Find error handling functions"
-        - "Show me authentication-related code"
-        - "Where is data validation implemented?"
-        - "Find functions that handle file I/O"
+    if not results:
+        return f"No semantic matches found for query: '{query}'. This could mean:\n1. No functions match this description\n2. Semantic search dependencies are not installed\n3. No embeddings have been generated yet"
 
-        Args:
-            query: Natural language description of the desired functionality
-            top_k: Maximum number of results to return (default: 5)
-
-        Returns:
-            String describing the found functions with their qualified names and similarity scores
-        """
-        logger.info(f"[Tool:SemanticSearch] Searching for: '{query}'")
-
-        results = semantic_code_search(query, top_k)
-
-        if not results:
-            return f"No semantic matches found for query: '{query}'. This could mean:\n1. No functions match this description\n2. Semantic search dependencies are not installed\n3. No embeddings have been generated yet"
-
-        formatted_results = []
-        for i, result in enumerate(results, 1):
-            formatted_results.append(
-                f"{i}. {result['qualified_name']} (type: {result['type']}, score: {result['score']})"
-            )
-
-        response = f"Found {len(results)} semantic matches for '{query}':\n\n"
-        response += "\n".join(formatted_results)
-        response += "\n\nUse the qualified names above with other tools to get more details or source code."
-
-        return response
-
-    return Tool(semantic_search_functions, name="semantic_search_functions")
-
-
-def create_get_function_source_tool() -> Tool:
-    """
-    Factory function to create the function source code retrieval tool.
-    """
-
-    async def get_function_source_by_id(node_id: int) -> str:
-        """
-        Retrieve the complete source code for a function or method by its node ID.
-
-        Use this tool after semantic search to get the actual implementation
-        of functions you're interested in.
-
-        Args:
-            node_id: The Memgraph node ID of the function/method
-
-        Returns:
-            The complete source code of the function/method
-        """
-        logger.info(
-            f"[Tool:GetFunctionSource] Retrieving source for node ID: {node_id}"
+    formatted_results = []
+    for i, result in enumerate(results, 1):
+        formatted_results.append(
+            f"{i}. {result['qualified_name']} (type: {result['type']}, score: {result['score']})"
         )
 
-        source_code = get_function_source_code(node_id)
+    response = f"Found {len(results)} semantic matches for '{query}':\n\n"
+    response += "\n".join(formatted_results)
+    response += "\n\nUse the qualified names above with other tools to get more details or source code."
 
-        if source_code is None:
-            return f"Could not retrieve source code for node ID {node_id}. The node may not exist or source file may be unavailable."
+    return response
 
-        return f"Source code for node ID {node_id}:\n\n```\n{source_code}\n```"
 
-    return Tool(get_function_source_by_id, name="get_function_source_by_id")
+async def get_function_source_by_id(node_id: int) -> str:
+    """
+    Retrieve the complete source code for a function or method by its node ID.
+
+    Use this tool after semantic search to get the actual implementation
+    of functions you're interested in.
+
+    Args:
+        node_id: The Memgraph node ID of the function/method
+
+    Returns:
+        The complete source code of the function/method
+    """
+    logger.info(f"[Tool:GetFunctionSource] Retrieving source for node ID: {node_id}")
+
+    source_code = get_function_source_code(node_id)
+
+    if source_code is None:
+        return f"Could not retrieve source code for node ID {node_id}. The node may not exist or source file may be unavailable."
+
+    return f"Source code for node ID {node_id}:\n\n```\n{source_code}\n```"


### PR DESCRIPTION
## Summary
- Add `RAGDeps` dataclass to centralize all tool dependencies
- Refactor tools to use `RunContext[RAGDeps]` instead of closure-based factories
- Update `create_rag_orchestrator` to use `deps_type` parameter
- Simplify MCP tools to use service classes directly

## Changes
- Created `codebase_rag/deps.py` with `RAGDeps` dataclass
- Created `codebase_rag/exceptions.py` to break circular imports
- Refactored all tools to accept `RunContext[RAGDeps]` as first parameter
- Updated `main.py` to create deps at runtime and pass to agent
- Simplified MCP registry by removing intermediate tool wrappers
- Updated all related tests

## Benefits
- Explicit, type-safe dependency injection
- Reduced coupling between components
- Simplified tool registration (no factory functions needed)
- Improved testability through proper dependency injection pattern

## Test plan
- [x] All existing tests pass
- [x] MCP tools work correctly with service classes
- [x] Pre-commit hooks pass