### PR TITLE
Feat/mcp Add optional semantic_search tool + non-destructive update_repository for MCP server

### DIFF
--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -533,7 +533,7 @@ class MCPToolsRegistry:
         `get_code_snippet` or `get_function_source_by_id` to inspect implementations.
 
         Args:
-            query: Natural language description of the desired functionality.
+            natural_language_query: Natural language description of the desired functionality.
             top_k: Maximum number of results to return (default: 5).
 
         Returns:

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -22,6 +22,7 @@ from codebase_rag.tools.directory_lister import (
 from codebase_rag.tools.file_editor import FileEditor, create_file_editor_tool
 from codebase_rag.tools.file_reader import FileReader, create_file_reader_tool
 from codebase_rag.tools.file_writer import FileWriter, create_file_writer_tool
+from codebase_rag.utils.dependencies import has_semantic_dependencies
 
 
 @dataclass
@@ -74,20 +75,19 @@ class MCPToolsRegistry:
             directory_lister=self.directory_lister
         )
 
-        self._semantic_search_tool = None  # (H) It is optionally initialised below
+        self._semantic_search_tool = None
+        self._semantic_search_available = False
 
-        try:
+        if has_semantic_dependencies():
             from codebase_rag.tools.semantic_search import (
                 create_semantic_search_tool,
             )
 
             self._semantic_search_tool = create_semantic_search_tool()
             self._semantic_search_available = True
-        except ImportError:
-            self._semantic_search_available = False
+        else:
             logger.info(
-                "[MCP] Semantic search dependencies not installed. "
-                "Install with: uv sync --extra semantic"
+                "[MCP] Semantic search not available. Install with: uv sync --extra semantic"
             )
 
         self._tools: dict[str, ToolMetadata] = {

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -117,7 +117,7 @@ class MCPToolsRegistry:
             ),
             "query_code_graph": ToolMetadata(
                 name="query_code_graph",
-                description="Pefere to use semantic_search, except you know exact names of classes/functions in the code you are searching for. "
+                description="Prefer to use semantic_search, except you know exact names of classes/functions in the code you are searching for. "
                 "Query the codebase knowledge graph using natural language, based on structural and syntactic relationships in the code. "
                 "Ask questions like 'What functions call UserService.create_user?' or "
                 "'Show me all classes that implement the Repository interface'.",


### PR DESCRIPTION
Hi maintainers,

This PR improves the MCP server tool set in codebase_rag/mcp/tools.py in two areas:

Optional semantic_search tool registration
Adds a semantic search MCP tool that is only registered when semantic dependencies are installed (checked via has_semantic_dependencies()). This avoids exposing semantic_search in environments where it would otherwise return empty results. When unavailable, the server logs a clear message pointing to uv sync --extra semantic.

Non-destructive repository updates
Introduces a new MCP tool, update_repository, which runs GraphUpdater without clearing the database first. This complements the existing index_repository tool (which still performs a full wipe + reindex) and makes incremental updates available via MCP as well.

Thanks for reviewing!