### PR TITLE
refactor: consolidate no-docs checks into single script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ PROJECT.md
 .coverage
 .envrc
 .DS_Store
+.pypi_cache.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,15 +25,9 @@ repos:
         pass_filenames: false
 -   repo: local
     hooks:
-    -   id: no-module-docstrings
-        name: no module-level docstrings
-        entry: bash -c 'for f in "$@"; do head -1 "$f" | grep -q "^\"\"\"" && echo "$f starts with module docstring" && exit 1; done; exit 0' --
-        language: system
-        types: [python]
-        exclude: ^codec/schema_pb2\.py$
-    -   id: no-inline-comments
-        name: no inline comments without (H)
-        entry: uv run python scripts/check_comments.py
+    -   id: check-no-docs
+        name: no module docstrings or inline comments
+        entry: uv run python scripts/check_no_docs.py
         language: system
         types: [python]
         exclude: ^codec/schema_pb2\.py$

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -110,9 +110,11 @@ BINARY_SIZE = "Size: {size:.1f} MB"
 BUILD_STDOUT = "STDOUT: {stdout}"
 BUILD_STDERR = "STDERR: {stderr}"
 
-# (H) Comment check logs
-COMMENTS_FOUND = "Comments without (H) marker found:"
-COMMENT_ERROR = "  {error}"
+# (H) No-docs check logs
+NO_DOCS_VIOLATIONS_FOUND = (
+    "No-docs violations found (module docstrings or inline comments):"
+)
+NO_DOCS_ERROR = "  {error}"
 
 # (H) Graph summary logs
 GRAPH_SUMMARY = "Graph Summary:"

--- a/codebase_rag/tests/test_check_no_docs.py
+++ b/codebase_rag/tests/test_check_no_docs.py
@@ -100,14 +100,16 @@ class TestCheckFile:
         assert len(errors) == 1
         assert "bad comment" in errors[0]
 
-    def test_shebang_and_module_docstring_ignored(self) -> None:
+    def test_shebang_and_module_docstring_detected(self) -> None:
         content = '#!/usr/bin/env python3\n"""Module docstring."""\nx = 1  # bad\n'
         with NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
             f.write(content)
             f.flush()
             errors = check_file(f.name)
         Path(f.name).unlink()
-        assert len(errors) == 1
+        assert len(errors) == 2
+        assert any("module-level docstring found" in e for e in errors)
+        assert any("bad" in e for e in errors)
 
     def test_multiline_string_not_treated_as_comment(self) -> None:
         content = 'x = """\nhas # inside\n"""\ny = 1  # bad\n'
@@ -176,6 +178,13 @@ class TestCheckModuleDocstring:
 
     def test_shebang_then_docstring(self) -> None:
         lines = ["#!/usr/bin/env python3\n", '"""Docstring."""\n']
+        result = check_module_docstring("test.py", lines)
+        assert result is not None
+        assert "test.py:2" in result
+        assert "module-level docstring found" in result
+
+    def test_shebang_then_code(self) -> None:
+        lines = ["#!/usr/bin/env python3\n", "import os\n"]
         assert check_module_docstring("test.py", lines) is None
 
     def test_file_with_module_docstring_detected(self) -> None:

--- a/codebase_rag/tests/test_check_no_docs.py
+++ b/codebase_rag/tests/test_check_no_docs.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
-from scripts.check_comments import (
+from scripts.check_no_docs import (
     _has_allowed_marker,
     check_file,
+    check_module_docstring,
     find_comment_start,
 )
 
@@ -144,3 +145,45 @@ class TestCheckFile:
             errors = check_file(f.name)
         Path(f.name).unlink()
         assert len(errors) == 2
+
+
+class TestCheckModuleDocstring:
+    def test_no_docstring(self) -> None:
+        lines = ["import os\n", "x = 1\n"]
+        assert check_module_docstring("test.py", lines) is None
+
+    def test_double_quote_docstring(self) -> None:
+        lines = ['"""Module docstring."""\n', "x = 1\n"]
+        result = check_module_docstring("test.py", lines)
+        assert result is not None
+        assert "module-level docstring found" in result
+
+    def test_single_quote_docstring(self) -> None:
+        lines = ["'''Module docstring.'''\n", "x = 1\n"]
+        result = check_module_docstring("test.py", lines)
+        assert result is not None
+        assert "module-level docstring found" in result
+
+    def test_empty_lines_before_code(self) -> None:
+        lines = ["\n", "\n", "import os\n"]
+        assert check_module_docstring("test.py", lines) is None
+
+    def test_empty_lines_before_docstring(self) -> None:
+        lines = ["\n", "\n", '"""Docstring."""\n']
+        result = check_module_docstring("test.py", lines)
+        assert result is not None
+        assert "module-level docstring found" in result
+
+    def test_shebang_then_docstring(self) -> None:
+        lines = ["#!/usr/bin/env python3\n", '"""Docstring."""\n']
+        assert check_module_docstring("test.py", lines) is None
+
+    def test_file_with_module_docstring_detected(self) -> None:
+        content = '"""Module docstring."""\nx = 1\n'
+        with NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+            f.write(content)
+            f.flush()
+            errors = check_file(f.name)
+        Path(f.name).unlink()
+        assert len(errors) == 1
+        assert "module-level docstring found" in errors[0]

--- a/scripts/check_no_docs.py
+++ b/scripts/check_no_docs.py
@@ -45,12 +45,12 @@ def _has_allowed_marker(comment: str) -> bool:
 
 
 def check_module_docstring(filepath: str, lines: list[str]) -> str | None:
-    for line in lines:
+    for i, line in enumerate(lines, 1):
         stripped = line.strip()
-        if not stripped:
+        if not stripped or stripped.startswith(COMMENT_CHAR):
             continue
         if any(stripped.startswith(q) for q in TRIPLE_QUOTES):
-            return f"{filepath}:1: module-level docstring found"
+            return f"{filepath}:{i}: module-level docstring found"
         return None
     return None
 

--- a/scripts/check_no_docs.py
+++ b/scripts/check_no_docs.py
@@ -44,12 +44,19 @@ def _has_allowed_marker(comment: str) -> bool:
     return any(marker in comment for marker in ALLOWED_COMMENT_MARKERS)
 
 
-def check_file(filepath: str) -> list[str]:
+def check_module_docstring(filepath: str, lines: list[str]) -> str | None:
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if any(stripped.startswith(q) for q in TRIPLE_QUOTES):
+            return f"{filepath}:1: module-level docstring found"
+        return None
+    return None
+
+
+def check_inline_comments(filepath: str, lines: list[str]) -> list[str]:
     errors = []
-
-    with open(filepath) as f:
-        lines = f.readlines()
-
     in_multiline_string = False
     found_first_code = False
 
@@ -83,6 +90,20 @@ def check_file(filepath: str) -> list[str]:
     return errors
 
 
+def check_file(filepath: str) -> list[str]:
+    errors = []
+
+    with open(filepath) as f:
+        lines = f.readlines()
+
+    if docstring_error := check_module_docstring(filepath, lines):
+        errors.append(docstring_error)
+
+    errors.extend(check_inline_comments(filepath, lines))
+
+    return errors
+
+
 def main() -> int:
     all_errors = []
 
@@ -91,9 +112,9 @@ def main() -> int:
         all_errors.extend(errors)
 
     if all_errors:
-        logger.error(logs.COMMENTS_FOUND)
+        logger.error(logs.NO_DOCS_VIOLATIONS_FOUND)
         for error in all_errors:
-            logger.error(logs.COMMENT_ERROR.format(error=error))
+            logger.error(logs.NO_DOCS_ERROR.format(error=error))
         return 1
 
     return 0


### PR DESCRIPTION
## Summary

- Renamed `scripts/check_comments.py` to `scripts/check_no_docs.py`
- Added module-level docstring detection to the script
- Removed the separate bash one-liner hook for module docstrings
- Consolidated into a single `check-no-docs` pre-commit hook

This addresses the inconsistency where module docstring checking was a bash one-liner while inline comment checking was in Python.

Closes #209