### PR TITLE
fix: add site-packages to IGNORE_PATTERNS

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -696,6 +696,7 @@ IGNORE_PATTERNS = frozenset(
         ".venv",
         "__pycache__",
         "node_modules",
+        "site-packages",
         "build",
         "dist",
         ".eggs",


### PR DESCRIPTION
## Summary

- Adds `site-packages` to `IGNORE_PATTERNS` to prevent parsing vendored dependencies

Closes #216

## Test plan

- [x] All existing tests pass (2482 passed, 23 skipped)
- [x] Linting and formatting pass
- [x] Type checking passes