### PR TITLE
feat: add .cgrignore file support for custom exclude patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,6 +640,23 @@ Configuration is managed through environment variables in `.env` file:
 - `TARGET_REPO_PATH`: Default repository path (default: `.`)
 - `LOCAL_MODEL_ENDPOINT`: Fallback endpoint for Ollama (default: `http://localhost:11434/v1`)
 
+### Custom Ignore Patterns
+
+You can specify additional directories to exclude by creating a `.cgrignore` file in your repository root:
+
+```
+# Comments start with #
+vendor
+.custom_cache
+my_build_output
+```
+
+- One directory name per line
+- Lines starting with `#` are comments
+- Blank lines are ignored
+- Patterns are exact directory name matches (not globs)
+- Patterns from `.cgrignore` are merged with `--exclude` flags and auto-detected directories
+
 ### Key Dependencies
 
 <!-- SECTION:dependencies -->

--- a/codebase_rag/config.py
+++ b/codebase_rag/config.py
@@ -5,11 +5,13 @@ from pathlib import Path
 from typing import Unpack
 
 from dotenv import load_dotenv
+from loguru import logger
 from pydantic import AnyHttpUrl
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from . import constants as cs
 from . import exceptions as ex
+from . import logs
 from .types_defs import ModelConfigKwargs
 
 load_dotenv()
@@ -233,8 +235,6 @@ CGRIGNORE_FILENAME = ".cgrignore"
 
 
 def load_cgrignore_patterns(repo_path: Path) -> frozenset[str]:
-    from loguru import logger
-
     ignore_file = repo_path / CGRIGNORE_FILENAME
     if not ignore_file.exists():
         return frozenset()
@@ -248,8 +248,10 @@ def load_cgrignore_patterns(repo_path: Path) -> frozenset[str]:
                     continue
                 patterns.add(line)
         if patterns:
-            logger.info(f"Loaded {len(patterns)} patterns from {ignore_file}")
+            logger.info(
+                logs.CGRIGNORE_LOADED.format(count=len(patterns), path=ignore_file)
+            )
         return frozenset(patterns)
     except OSError as e:
-        logger.warning(f"Failed to read {ignore_file}: {e}")
+        logger.warning(logs.CGRIGNORE_READ_FAILED.format(path=ignore_file, error=e))
         return frozenset()

--- a/codebase_rag/config.py
+++ b/codebase_rag/config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
+from pathlib import Path
 from typing import Unpack
 
 from dotenv import load_dotenv
@@ -227,3 +228,28 @@ class AppConfig(BaseSettings):
 
 
 settings = AppConfig()
+
+CGRIGNORE_FILENAME = ".cgrignore"
+
+
+def load_cgrignore_patterns(repo_path: Path) -> frozenset[str]:
+    from loguru import logger
+
+    ignore_file = repo_path / CGRIGNORE_FILENAME
+    if not ignore_file.exists():
+        return frozenset()
+
+    patterns: set[str] = set()
+    try:
+        with ignore_file.open(encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                patterns.add(line)
+        if patterns:
+            logger.info(f"Loaded {len(patterns)} patterns from {ignore_file}")
+        return frozenset(patterns)
+    except OSError as e:
+        logger.warning(f"Failed to read {ignore_file}: {e}")
+        return frozenset()

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -625,6 +625,7 @@ EXCLUDE_COL_DIRECTORY = "Directory"
 EXCLUDE_COL_STATUS = "Source"
 EXCLUDE_STATUS_DETECTED = "auto-detected"
 EXCLUDE_STATUS_CLI = "--exclude"
+EXCLUDE_STATUS_CGRIGNORE = ".cgrignore"
 EXCLUDE_PROMPT_INSTRUCTIONS = (
     "Options: 'all' (exclude all), 'none' (exclude nothing), "
     "or numbers like '1,3,5' (exclude specific)"

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -89,6 +89,10 @@ GRAMMAR_LOADED = "Successfully loaded {lang} grammar."
 GRAMMAR_LOAD_FAILED = "Failed to load {lang} grammar: {error}"
 INITIALIZED_PARSERS = "Initialized parsers for: {languages}"
 
+# (H) Ignore pattern logs
+CGRIGNORE_LOADED = "Loaded {count} patterns from {path}"
+CGRIGNORE_READ_FAILED = "Failed to read {path}: {error}"
+
 # (H) File watcher logs
 WATCHER_ACTIVE = "File watcher is now active."
 WATCHER_SKIP_NO_QUERY = "Ingestor does not support querying, skipping real-time update."

--- a/codebase_rag/tests/test_cgrignore.py
+++ b/codebase_rag/tests/test_cgrignore.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codebase_rag.config import CGRIGNORE_FILENAME, load_cgrignore_patterns
+
+
+def test_returns_empty_when_no_file(temp_repo: Path) -> None:
+    result = load_cgrignore_patterns(temp_repo)
+    assert result == frozenset()
+
+
+def test_loads_patterns_from_file(temp_repo: Path) -> None:
+    cgrignore = temp_repo / CGRIGNORE_FILENAME
+    cgrignore.write_text("vendor\nmy_build\n")
+
+    result = load_cgrignore_patterns(temp_repo)
+
+    assert "vendor" in result
+    assert "my_build" in result
+    assert len(result) == 2
+
+
+def test_ignores_comments_and_blank_lines(temp_repo: Path) -> None:
+    cgrignore = temp_repo / CGRIGNORE_FILENAME
+    cgrignore.write_text("# Comment\n\nvendor\n  # Indented comment\n")
+
+    result = load_cgrignore_patterns(temp_repo)
+
+    assert result == frozenset({"vendor"})
+
+
+def test_strips_whitespace(temp_repo: Path) -> None:
+    cgrignore = temp_repo / CGRIGNORE_FILENAME
+    cgrignore.write_text("  vendor  \n\ttemp\t\n")
+
+    result = load_cgrignore_patterns(temp_repo)
+
+    assert "vendor" in result
+    assert "temp" in result
+
+
+def test_returns_empty_on_read_error(
+    temp_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cgrignore = temp_repo / CGRIGNORE_FILENAME
+    cgrignore.write_text("vendor")
+
+    original_open = Path.open
+
+    def mock_open(self: Path, *args, **kwargs):  # noqa: ANN002, ANN003
+        if self.name == CGRIGNORE_FILENAME:
+            raise PermissionError("Cannot read")
+        return original_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", mock_open)
+
+    result = load_cgrignore_patterns(temp_repo)
+    assert result == frozenset()
+
+
+def test_handles_duplicates(temp_repo: Path) -> None:
+    cgrignore = temp_repo / CGRIGNORE_FILENAME
+    cgrignore.write_text("vendor\nvendor\ntemp\n")
+
+    result = load_cgrignore_patterns(temp_repo)
+
+    assert len(result) == 2


### PR DESCRIPTION
## Summary

Add support for a `.cgrignore` file that allows users to specify additional directories to exclude from parsing, similar to `.gitignore` but simpler.

- Patterns from `.cgrignore` are merged with `--exclude` CLI flags and auto-detected directories
- File format: one directory name per line, `#` comments, blank lines ignored
- Integrates with the existing exclude patterns interactive prompt

## Changes

- `codebase_rag/config.py`: Add `load_cgrignore_patterns()` function and `CGRIGNORE_FILENAME` constant
- `codebase_rag/main.py`: Integrate `.cgrignore` loading into `prompt_exclude_directories()`
- `codebase_rag/constants.py`: Add `EXCLUDE_STATUS_CGRIGNORE` for UI display
- `codebase_rag/tests/test_cgrignore.py`: Add 6 unit tests
- `README.md`: Document the feature

## Example `.cgrignore`

```
# Comments start with #
vendor
.custom_cache
my_build_output
```

## Test plan

- [x] Unit tests pass (`pytest codebase_rag/tests/test_cgrignore.py`)
- [ ] Manual test with a `.cgrignore` file in a repository