### PR TITLE
feat(cli): add stats command to display graph statistics

### DIFF
--- a/codebase_rag/cli.py
+++ b/codebase_rag/cli.py
@@ -383,22 +383,13 @@ def language_command(ctx: typer.Context) -> None:
 
 
 @app.command(name=ch.CLICommandName.STATS, help=ch.CMD_STATS)
-def stats(
-    batch_size: int | None = typer.Option(
-        None,
-        "--batch-size",
-        min=1,
-        help=ch.HELP_BATCH_SIZE,
-    ),
-) -> None:
+def stats() -> None:
     from rich.table import Table
 
     app_context.console.print(style(cs.CLI_MSG_CONNECTING_MEMGRAPH, cs.Color.CYAN))
 
-    effective_batch_size = settings.resolve_batch_size(batch_size)
-
     try:
-        with connect_memgraph(effective_batch_size) as ingestor:
+        with connect_memgraph(batch_size=1) as ingestor:
             node_results = ingestor.fetch_all(CYPHER_STATS_NODE_COUNTS)
             rel_results = ingestor.fetch_all(CYPHER_STATS_RELATIONSHIP_COUNTS)
 
@@ -428,7 +419,6 @@ def stats(
             app_context.console.print(node_table)
             app_context.console.print()
 
-            # Relationship statistics table
             rel_table = Table(
                 title=style(cs.CLI_STATS_REL_TITLE, cs.Color.GREEN),
                 show_header=True,

--- a/codebase_rag/cli.py
+++ b/codebase_rag/cli.py
@@ -1,6 +1,7 @@
 import asyncio
 from pathlib import Path
 
+import mgclient  # ty: ignore[unresolved-import]
 import typer
 from loguru import logger
 
@@ -407,8 +408,8 @@ def stats() -> None:
             for row in node_results:
                 labels = row.get("labels", [])
                 label = ":".join(labels) if labels else "Unknown"
-                count = str(row.get("count", 0))
-                node_table.add_row(label, f"{int(count):,}")
+                count = row.get("count", 0)
+                node_table.add_row(label, f"{count:,}")
 
             node_table.add_section()
             node_table.add_row(
@@ -428,9 +429,9 @@ def stats() -> None:
             rel_table.add_column(cs.CLI_STATS_COL_COUNT, style=cs.Color.YELLOW, justify="right")
 
             for row in rel_results:
-                rel_type = str(row.get("type", "Unknown"))
-                count = str(row.get("count", 0))
-                rel_table.add_row(rel_type, f"{int(count):,}")
+                rel_type = row.get("type", "Unknown")
+                count = row.get("count", 0)
+                rel_table.add_row(str(rel_type), f"{count:,}")
 
             rel_table.add_section()
             rel_table.add_row(
@@ -440,7 +441,7 @@ def stats() -> None:
 
             app_context.console.print(rel_table)
 
-    except Exception as e:
+    except mgclient.DatabaseError as e:
         app_context.console.print(
             style(cs.CLI_ERR_STATS_FAILED.format(error=e), cs.Color.RED)
         )

--- a/codebase_rag/cli_help.py
+++ b/codebase_rag/cli_help.py
@@ -9,6 +9,7 @@ class CLICommandName(StrEnum):
     MCP_SERVER = "mcp-server"
     GRAPH_LOADER = "graph-loader"
     LANGUAGE = "language"
+    STATS = "stats"
 
 
 APP_DESCRIPTION = (
@@ -24,6 +25,7 @@ CMD_OPTIMIZE = "AI-guided codebase optimization session"
 CMD_MCP_SERVER = "Start the MCP server for Claude Code integration"
 CMD_GRAPH_LOADER = "Load and display summary of exported graph JSON"
 CMD_LANGUAGE = "Manage language grammars (add, remove, list)"
+CMD_STATS = "Display statistics about the indexed codebase graph"
 
 CMD_LANGUAGE_GROUP = "CLI for managing language grammars"
 CMD_LANGUAGE_ADD = "Add a new language grammar to the project."
@@ -87,4 +89,5 @@ CLI_COMMANDS: dict[CLICommandName, str] = {
     CLICommandName.MCP_SERVER: CMD_MCP_SERVER,
     CLICommandName.GRAPH_LOADER: CMD_GRAPH_LOADER,
     CLICommandName.LANGUAGE: CMD_LANGUAGE,
+    CLICommandName.STATS: CMD_STATS,
 }

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -227,6 +227,16 @@ CLI_MSG_HINT_TARGET_REPO = (
     "\nHint: Make sure TARGET_REPO_PATH environment variable is set."
 )
 CLI_MSG_GRAPH_SUMMARY = "Graph Summary:"
+
+# Stats command constants
+CLI_STATS_NODE_TITLE = "Node Statistics"
+CLI_STATS_REL_TITLE = "Relationship Statistics"
+CLI_STATS_COL_NODE_TYPE = "Node Type"
+CLI_STATS_COL_REL_TYPE = "Relationship Type"
+CLI_STATS_COL_COUNT = "Count"
+CLI_STATS_TOTAL_NODES = "Total Nodes"
+CLI_STATS_TOTAL_RELS = "Total Relationships"
+CLI_ERR_STATS_FAILED = "Failed to get graph statistics: {error}"
 CLI_MSG_AUTO_EXCLUDE = (
     "Auto-excluding common directories (venv, node_modules, .git, etc.). "
     "Use --interactive-setup to customize."

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -78,6 +78,18 @@ RETURN n.name AS name, n.start_line AS start, n.end_line AS end, m.path AS path,
 LIMIT 1
 """
 
+CYPHER_STATS_NODE_COUNTS = """
+MATCH (n)
+RETURN labels(n) as labels, count(*) as count
+ORDER BY count DESC
+"""
+
+CYPHER_STATS_RELATIONSHIP_COUNTS = """
+MATCH ()-[r]->()
+RETURN type(r) as type, count(*) as count
+ORDER BY count DESC
+"""
+
 
 def wrap_with_unwind(query: str) -> str:
     return f"UNWIND $batch AS row\n{query}"

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -310,6 +310,7 @@ FILE_WRITER_SUCCESS = "[FileWriter] Successfully wrote {chars} characters to {pa
 # (H) Error logs (used with logger.error/warning)
 UNEXPECTED = "An unexpected error occurred: {error}"
 EXPORT_ERROR = "Export error: {error}"
+STATS_ERROR = "Stats error: {error}"
 INDEXING_FAILED = "Indexing failed"
 PATH_NOT_IN_QUESTION = (
     "Could not find original path in question for replacement: {path}"


### PR DESCRIPTION
## Summary
Adds a new `graph-code stats` command that displays statistics about the indexed codebase knowledge graph.

## Changes
- Added `stats` command to `cli.py`
- Added `STATS` to `CLICommandName` enum in `cli_help.py`
- Added `CMD_STATS` help text
- Added constants for table column headers and error messages

## Example Output
```
╭─ Node Statistics ────────────────────╮
│ Node Type      │ Count              │
├────────────────┼────────────────────┤
│ Function       │ 1,234              │
│ Class          │ 156                │
│ Module         │ 89                 │
├────────────────┼────────────────────┤
│ Total Nodes    │ 1,479              │
╰──────────────────────────────────────╯

╭─ Relationship Statistics ────────────╮
│ Relationship Type │ Count           │
├───────────────────┼─────────────────┤
│ CALLS             │ 3,456           │
│ CONTAINS          │ 1,245           │
│ IMPORTS           │ 567             │
├───────────────────┼─────────────────┤
│ Total Relationships │ 5,268         │
╰──────────────────────────────────────╯
```

## Test plan
- [x] Python syntax valid
- [ ] Run `graph-code stats` with Memgraph connected
- [ ] Verify node counts match expected values
- [ ] Verify relationship counts display correctly

Fixes #248