### PR TITLE
fix: add missing node labels to NODE_UNIQUE_CONSTRAINTS preventing silent node drops

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -162,6 +162,7 @@ KEY_NODE_LABELS = "node_labels"
 KEY_RELATIONSHIP_TYPES = "relationship_types"
 KEY_EXPORTED_AT = "exported_at"
 KEY_PARSER = "parser"
+KEY_NAME = "name"
 KEY_QUALIFIED_NAME = "qualified_name"
 KEY_START_LINE = "start_line"
 KEY_END_LINE = "end_line"
@@ -307,9 +308,9 @@ TRIE_INTERNAL_PREFIX = "__"
 
 
 class UniqueKeyType(StrEnum):
-    NAME = "name"
-    PATH = "path"
-    QUALIFIED_NAME = "qualified_name"
+    NAME = KEY_NAME
+    PATH = KEY_PATH
+    QUALIFIED_NAME = KEY_QUALIFIED_NAME
 
 
 class NodeLabel(StrEnum):
@@ -382,7 +383,6 @@ EXCLUDED_DEPENDENCY_NAMES = frozenset({"python", "php"})
 BYTES_PER_MB = 1024 * 1024
 
 # (H) Property keys
-KEY_NAME = "name"
 KEY_PARAMETERS = "parameters"
 KEY_DECORATORS = "decorators"
 KEY_DOCSTRING = "docstring"

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -306,6 +306,12 @@ TRIE_QN_KEY = "__qn__"
 TRIE_INTERNAL_PREFIX = "__"
 
 
+class UniqueKeyType(StrEnum):
+    NAME = "name"
+    PATH = "path"
+    QUALIFIED_NAME = "qualified_name"
+
+
 class NodeLabel(StrEnum):
     PROJECT = "Project"
     PACKAGE = "Package"
@@ -322,6 +328,32 @@ class NodeLabel(StrEnum):
     MODULE_INTERFACE = "ModuleInterface"
     MODULE_IMPLEMENTATION = "ModuleImplementation"
     EXTERNAL_PACKAGE = "ExternalPackage"
+
+
+_NODE_LABEL_UNIQUE_KEYS: dict[NodeLabel, UniqueKeyType] = {
+    NodeLabel.PROJECT: UniqueKeyType.NAME,
+    NodeLabel.PACKAGE: UniqueKeyType.QUALIFIED_NAME,
+    NodeLabel.FOLDER: UniqueKeyType.PATH,
+    NodeLabel.FILE: UniqueKeyType.PATH,
+    NodeLabel.MODULE: UniqueKeyType.QUALIFIED_NAME,
+    NodeLabel.CLASS: UniqueKeyType.QUALIFIED_NAME,
+    NodeLabel.FUNCTION: UniqueKeyType.QUALIFIED_NAME,
+    NodeLabel.METHOD: UniqueKeyType.QUALIFIED_NAME,
+    NodeLabel.INTERFACE: UniqueKeyType.QUALIFIED_NAME,
+    NodeLabel.ENUM: UniqueKeyType.QUALIFIED_NAME,
+    NodeLabel.TYPE: UniqueKeyType.QUALIFIED_NAME,
+    NodeLabel.UNION: UniqueKeyType.QUALIFIED_NAME,
+    NodeLabel.MODULE_INTERFACE: UniqueKeyType.QUALIFIED_NAME,
+    NodeLabel.MODULE_IMPLEMENTATION: UniqueKeyType.QUALIFIED_NAME,
+    NodeLabel.EXTERNAL_PACKAGE: UniqueKeyType.NAME,
+}
+
+_missing_keys = set(NodeLabel) - set(_NODE_LABEL_UNIQUE_KEYS.keys())
+if _missing_keys:
+    raise RuntimeError(
+        f"NodeLabel(s) missing from _NODE_LABEL_UNIQUE_KEYS: {_missing_keys}. "
+        "Every NodeLabel MUST have a unique key defined."
+    )
 
 
 class RelationshipType(StrEnum):
@@ -915,15 +947,7 @@ UNIXCODER_MAX_CONTEXT = 1024
 REL_TYPE_CALLS = "CALLS"
 
 NODE_UNIQUE_CONSTRAINTS: dict[str, str] = {
-    "Project": "name",
-    "Package": "qualified_name",
-    "Folder": "path",
-    "Module": "qualified_name",
-    "Class": "qualified_name",
-    "Function": "qualified_name",
-    "Method": "qualified_name",
-    "File": "path",
-    "ExternalPackage": "name",
+    label.value: key.value for label, key in _NODE_LABEL_UNIQUE_KEYS.items()
 }
 
 # (H) Cypher response cleaning

--- a/codebase_rag/tests/integration/test_node_label_e2e.py
+++ b/codebase_rag/tests/integration/test_node_label_e2e.py
@@ -288,15 +288,6 @@ def index_project(ingestor: MemgraphIngestor, project_path: Path) -> None:
     updater.run()
 
 
-def skip_if_parser_unavailable(language: str) -> None:
-    from codebase_rag.constants import SupportedLanguage
-
-    parsers, _ = load_parsers()
-    lang_enum = SupportedLanguage(language)
-    if lang_enum not in parsers:
-        pytest.skip(f"{language} parser not available")
-
-
 def get_node_labels(ingestor: MemgraphIngestor) -> set[str]:
     result = ingestor.fetch_all("MATCH (n) RETURN DISTINCT labels(n) AS labels")
     labels: set[str] = set()
@@ -643,7 +634,7 @@ class TestScalaNodeLabels:
 
         interfaces = get_nodes_by_label(memgraph_ingestor, NodeLabel.INTERFACE.value)
         interface_names = {n["name"] for n in interfaces}
-        assert "MyTrait" in interface_names or "Status" in interface_names
+        assert {"MyTrait", "Status"}.issubset(interface_names)
 
 
 class TestJavaNodeLabels:
@@ -811,7 +802,7 @@ class TestLuaNodeLabels:
 
         functions = get_nodes_by_label(memgraph_ingestor, NodeLabel.FUNCTION.value)
         func_names = {n["name"] for n in functions}
-        assert "new" in func_names or "getValue" in func_names
+        assert {"new", "MyClass:getValue"}.issubset(func_names)
 
 
 DEFINES_TEST_PARAMS = [

--- a/codebase_rag/tests/integration/test_node_label_e2e.py
+++ b/codebase_rag/tests/integration/test_node_label_e2e.py
@@ -14,6 +14,11 @@ if TYPE_CHECKING:
 
 pytestmark = [pytest.mark.integration]
 
+SKIP_GO = "Go is in development status"
+SKIP_SCALA = "Scala is in development status"
+SKIP_CSHARP = "C# is in development status"
+SKIP_PHP = "PHP is in development status"
+
 
 PYTHON_CODE = """\
 class MyClass:
@@ -569,8 +574,32 @@ class TestRustNodeLabels:
         func_names = {n["name"] for n in functions}
         assert "standalone_fn" in func_names
 
+    def test_rust_creates_class_nodes_for_enums(
+        self, memgraph_ingestor: MemgraphIngestor, rust_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, rust_project)
 
-@pytest.mark.skip(reason="Go is in development status")
+        labels = get_node_labels(memgraph_ingestor)
+        assert NodeLabel.CLASS.value in labels
+
+        classes = get_nodes_by_label(memgraph_ingestor, NodeLabel.CLASS.value)
+        class_names = {n["name"] for n in classes}
+        assert "Status" in class_names
+
+    def test_rust_creates_class_nodes_for_traits(
+        self, memgraph_ingestor: MemgraphIngestor, rust_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, rust_project)
+
+        labels = get_node_labels(memgraph_ingestor)
+        assert NodeLabel.CLASS.value in labels
+
+        classes = get_nodes_by_label(memgraph_ingestor, NodeLabel.CLASS.value)
+        class_names = {n["name"] for n in classes}
+        assert "MyTrait" in class_names
+
+
+@pytest.mark.skip(reason=SKIP_GO)
 class TestGoNodeLabels:
     def test_go_creates_class_nodes_for_structs(
         self, memgraph_ingestor: MemgraphIngestor, go_project: Path
@@ -610,7 +639,7 @@ class TestGoNodeLabels:
         assert "main" in func_names
 
 
-@pytest.mark.skip(reason="Scala is in development status")
+@pytest.mark.skip(reason=SKIP_SCALA)
 class TestScalaNodeLabels:
     def test_scala_creates_class_nodes(
         self, memgraph_ingestor: MemgraphIngestor, scala_project: Path
@@ -713,7 +742,7 @@ class TestCppNodeLabels:
         assert "standaloneFunction" in func_names
 
 
-@pytest.mark.skip(reason="C# is in development status and parser not available")
+@pytest.mark.skip(reason=SKIP_CSHARP)
 class TestCSharpNodeLabels:
     def test_csharp_creates_class_nodes(
         self, memgraph_ingestor: MemgraphIngestor, csharp_project: Path
@@ -752,7 +781,7 @@ class TestCSharpNodeLabels:
         assert "Status" in enum_names
 
 
-@pytest.mark.skip(reason="PHP is in development status and parser not available")
+@pytest.mark.skip(reason=SKIP_PHP)
 class TestPhpNodeLabels:
     def test_php_creates_class_nodes(
         self, memgraph_ingestor: MemgraphIngestor, php_project: Path
@@ -810,12 +839,12 @@ DEFINES_TEST_PARAMS = [
     ("typescript_project", None),
     ("javascript_project", None),
     ("rust_project", None),
-    ("go_project", "Go is in development status"),
-    ("scala_project", "Scala is in development status"),
+    ("go_project", SKIP_GO),
+    ("scala_project", SKIP_SCALA),
     ("java_project", None),
     ("cpp_project", None),
-    ("csharp_project", "C# is in development status"),
-    ("php_project", "PHP is in development status"),
+    ("csharp_project", SKIP_CSHARP),
+    ("php_project", SKIP_PHP),
     ("lua_project", None),
 ]
 

--- a/codebase_rag/tests/integration/test_node_label_e2e.py
+++ b/codebase_rag/tests/integration/test_node_label_e2e.py
@@ -902,6 +902,18 @@ class TestPhpNodeLabels:
         func_names = {n["name"] for n in functions}
         assert "standaloneFunction" in func_names
 
+    def test_php_creates_enum_nodes(
+        self, memgraph_ingestor: MemgraphIngestor, php_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, php_project)
+
+        labels = get_node_labels(memgraph_ingestor)
+        assert NodeLabel.ENUM.value in labels
+
+        enums = get_nodes_by_label(memgraph_ingestor, NodeLabel.ENUM.value)
+        enum_names = {n["name"] for n in enums}
+        assert "Status" in enum_names
+
 
 class TestLuaNodeLabels:
     def test_lua_creates_function_nodes(

--- a/codebase_rag/tests/integration/test_node_label_e2e.py
+++ b/codebase_rag/tests/integration/test_node_label_e2e.py
@@ -1,0 +1,897 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from codebase_rag.constants import NodeLabel
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+if TYPE_CHECKING:
+    from codebase_rag.services.graph_service import MemgraphIngestor
+
+pytestmark = [pytest.mark.integration]
+
+
+PYTHON_CODE = """\
+class MyClass:
+    def method1(self):
+        pass
+
+    def method2(self):
+        self.method1()
+
+class AnotherClass(MyClass):
+    def override_method(self):
+        pass
+
+def standalone_function():
+    obj = MyClass()
+    obj.method1()
+"""
+
+TYPESCRIPT_CODE = """\
+interface MyInterface {
+    value: number;
+    getValue(): number;
+}
+
+enum Status {
+    Active = "active",
+    Inactive = "inactive",
+}
+
+type MyType = string | number;
+
+class MyTsClass implements MyInterface {
+    value: number = 0;
+
+    getValue(): number {
+        return this.value;
+    }
+}
+
+function createInstance(): MyTsClass {
+    return new MyTsClass();
+}
+"""
+
+JAVASCRIPT_CODE = """\
+class MyJsClass {
+    constructor() {
+        this.value = 0;
+    }
+
+    getValue() {
+        return this.value;
+    }
+}
+
+function createInstance() {
+    return new MyJsClass();
+}
+
+module.exports = { MyJsClass, createInstance };
+"""
+
+RUST_CODE = """\
+pub struct MyStruct {
+    value: i32,
+}
+
+impl MyStruct {
+    pub fn new() -> Self {
+        MyStruct { value: 0 }
+    }
+
+    pub fn get_value(&self) -> i32 {
+        self.value
+    }
+}
+
+pub enum Status {
+    Active,
+    Inactive,
+}
+
+pub trait MyTrait {
+    fn do_something(&self);
+}
+
+impl MyTrait for MyStruct {
+    fn do_something(&self) {
+        println!("{}", self.value);
+    }
+}
+
+pub fn standalone_fn() -> MyStruct {
+    MyStruct::new()
+}
+"""
+
+GO_CODE = """\
+package main
+
+type MyStruct struct {
+    Value int
+}
+
+func (m *MyStruct) GetValue() int {
+    return m.Value
+}
+
+type MyInterface interface {
+    DoSomething()
+}
+
+func NewMyStruct() *MyStruct {
+    return &MyStruct{Value: 0}
+}
+
+func main() {
+    s := NewMyStruct()
+    _ = s.GetValue()
+}
+"""
+
+SCALA_CODE = """\
+class MyScalaClass {
+  def getValue: Int = 42
+}
+
+trait MyTrait {
+  def doSomething(): Unit
+}
+
+object MyObject {
+  def create(): MyScalaClass = new MyScalaClass()
+}
+
+sealed trait Status
+case object Active extends Status
+case object Inactive extends Status
+"""
+
+JAVA_CODE = """\
+public class Example {
+    private int value;
+
+    public Example() {
+        this.value = 0;
+    }
+
+    public int getValue() {
+        return this.value;
+    }
+}
+
+interface MyInterface {
+    void doSomething();
+}
+
+enum Status {
+    ACTIVE,
+    INACTIVE
+}
+"""
+
+CPP_CODE = """\
+class MyCppClass {
+public:
+    MyCppClass() : value(0) {}
+
+    int getValue() {
+        return value;
+    }
+
+private:
+    int value;
+};
+
+enum Status {
+    Active,
+    Inactive
+};
+
+void standaloneFunction() {
+    MyCppClass obj;
+    obj.getValue();
+}
+"""
+
+CSHARP_CODE = """\
+public class MyCSharpClass {
+    private int value;
+
+    public MyCSharpClass() {
+        this.value = 0;
+    }
+
+    public int GetValue() {
+        return this.value;
+    }
+}
+
+public interface IMyInterface {
+    void DoSomething();
+}
+
+public enum Status {
+    Active,
+    Inactive
+}
+"""
+
+PHP_CODE = """\
+<?php
+
+class MyPhpClass {
+    private $value;
+
+    public function __construct() {
+        $this->value = 0;
+    }
+
+    public function getValue() {
+        return $this->value;
+    }
+}
+
+interface MyInterface {
+    public function doSomething();
+}
+
+enum Status {
+    case Active;
+    case Inactive;
+}
+
+function standaloneFunction() {
+    $obj = new MyPhpClass();
+    return $obj->getValue();
+}
+"""
+
+LUA_CODE = """\
+local MyClass = {}
+MyClass.__index = MyClass
+
+function MyClass.new()
+    local self = setmetatable({}, MyClass)
+    self.value = 0
+    return self
+end
+
+function MyClass:getValue()
+    return self.value
+end
+
+local function standaloneFunction()
+    local obj = MyClass.new()
+    return obj:getValue()
+end
+
+return MyClass
+"""
+
+
+def index_project(ingestor: MemgraphIngestor, project_path: Path) -> None:
+    parsers, queries = load_parsers()
+    updater = GraphUpdater(
+        ingestor=ingestor,
+        repo_path=project_path,
+        parsers=parsers,
+        queries=queries,
+    )
+    updater.run()
+
+
+def skip_if_parser_unavailable(language: str) -> None:
+    from codebase_rag.constants import SupportedLanguage
+
+    parsers, _ = load_parsers()
+    lang_enum = SupportedLanguage(language)
+    if lang_enum not in parsers:
+        pytest.skip(f"{language} parser not available")
+
+
+def get_node_labels(ingestor: MemgraphIngestor) -> set[str]:
+    result = ingestor.fetch_all("MATCH (n) RETURN DISTINCT labels(n) AS labels")
+    labels: set[str] = set()
+    for row in result:
+        for label in row["labels"]:
+            labels.add(label)
+    return labels
+
+
+def get_nodes_by_label(ingestor: MemgraphIngestor, label: str) -> list[dict]:
+    return ingestor.fetch_all(f"MATCH (n:{label}) RETURN n.name AS name")
+
+
+def get_relationship_types(ingestor: MemgraphIngestor) -> set[str]:
+    result = ingestor.fetch_all("MATCH ()-[r]->() RETURN DISTINCT type(r) AS type")
+    return {row["type"] for row in result}
+
+
+@pytest.fixture
+def python_project(tmp_path: Path) -> Path:
+    project = tmp_path / "python_project"
+    project.mkdir()
+    (project / "example.py").write_text(PYTHON_CODE, encoding="utf-8")
+    return project
+
+
+@pytest.fixture
+def typescript_project(tmp_path: Path) -> Path:
+    project = tmp_path / "typescript_project"
+    project.mkdir()
+    (project / "example.ts").write_text(TYPESCRIPT_CODE, encoding="utf-8")
+    return project
+
+
+@pytest.fixture
+def javascript_project(tmp_path: Path) -> Path:
+    project = tmp_path / "javascript_project"
+    project.mkdir()
+    (project / "example.js").write_text(JAVASCRIPT_CODE, encoding="utf-8")
+    return project
+
+
+@pytest.fixture
+def rust_project(tmp_path: Path) -> Path:
+    project = tmp_path / "rust_project"
+    project.mkdir()
+    (project / "example.rs").write_text(RUST_CODE, encoding="utf-8")
+    return project
+
+
+@pytest.fixture
+def go_project(tmp_path: Path) -> Path:
+    project = tmp_path / "go_project"
+    project.mkdir()
+    (project / "example.go").write_text(GO_CODE, encoding="utf-8")
+    return project
+
+
+@pytest.fixture
+def scala_project(tmp_path: Path) -> Path:
+    project = tmp_path / "scala_project"
+    project.mkdir()
+    (project / "Example.scala").write_text(SCALA_CODE, encoding="utf-8")
+    return project
+
+
+@pytest.fixture
+def java_project(tmp_path: Path) -> Path:
+    project = tmp_path / "java_project"
+    project.mkdir()
+    (project / "Example.java").write_text(JAVA_CODE, encoding="utf-8")
+    return project
+
+
+@pytest.fixture
+def cpp_project(tmp_path: Path) -> Path:
+    project = tmp_path / "cpp_project"
+    project.mkdir()
+    (project / "example.cpp").write_text(CPP_CODE, encoding="utf-8")
+    return project
+
+
+@pytest.fixture
+def csharp_project(tmp_path: Path) -> Path:
+    project = tmp_path / "csharp_project"
+    project.mkdir()
+    (project / "Example.cs").write_text(CSHARP_CODE, encoding="utf-8")
+    return project
+
+
+@pytest.fixture
+def php_project(tmp_path: Path) -> Path:
+    project = tmp_path / "php_project"
+    project.mkdir()
+    (project / "example.php").write_text(PHP_CODE, encoding="utf-8")
+    return project
+
+
+@pytest.fixture
+def lua_project(tmp_path: Path) -> Path:
+    project = tmp_path / "lua_project"
+    project.mkdir()
+    (project / "example.lua").write_text(LUA_CODE, encoding="utf-8")
+    return project
+
+
+class TestPythonNodeLabels:
+    def test_python_creates_class_nodes(
+        self, memgraph_ingestor: MemgraphIngestor, python_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, python_project)
+
+        labels = get_node_labels(memgraph_ingestor)
+        assert NodeLabel.CLASS.value in labels
+
+        classes = get_nodes_by_label(memgraph_ingestor, NodeLabel.CLASS.value)
+        class_names = {n["name"] for n in classes}
+        assert "MyClass" in class_names
+        assert "AnotherClass" in class_names
+
+    def test_python_creates_function_nodes(
+        self, memgraph_ingestor: MemgraphIngestor, python_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, python_project)
+
+        labels = get_node_labels(memgraph_ingestor)
+        assert NodeLabel.FUNCTION.value in labels
+
+        functions = get_nodes_by_label(memgraph_ingestor, NodeLabel.FUNCTION.value)
+        func_names = {n["name"] for n in functions}
+        assert "standalone_function" in func_names
+
+    def test_python_creates_method_nodes(
+        self, memgraph_ingestor: MemgraphIngestor, python_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, python_project)
+
+        labels = get_node_labels(memgraph_ingestor)
+        assert NodeLabel.METHOD.value in labels
+
+        methods = get_nodes_by_label(memgraph_ingestor, NodeLabel.METHOD.value)
+        method_names = {n["name"] for n in methods}
+        assert "method1" in method_names
+        assert "method2" in method_names
+
+    def test_python_creates_defines_relationships(
+        self, memgraph_ingestor: MemgraphIngestor, python_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, python_project)
+
+        rel_types = get_relationship_types(memgraph_ingestor)
+        assert "DEFINES" in rel_types
+
+    def test_python_creates_inherits_relationships(
+        self, memgraph_ingestor: MemgraphIngestor, python_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, python_project)
+
+        rel_types = get_relationship_types(memgraph_ingestor)
+        assert "INHERITS" in rel_types
+
+
+class TestTypeScriptNodeLabels:
+    def test_typescript_creates_interface_nodes(
+        self, memgraph_ingestor: MemgraphIngestor, typescript_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, typescript_project)
+
+        labels = get_node_labels(memgraph_ingestor)
+        assert NodeLabel.INTERFACE.value in labels, (
+            f"Interface label missing. Got labels: {labels}"
+        )
+
+        interfaces = get_nodes_by_label(memgraph_ingestor, NodeLabel.INTERFACE.value)
+        interface_names = {n["name"] for n in interfaces}
+        assert "MyInterface" in interface_names
+
+    def test_typescript_creates_enum_nodes(
+        self, memgraph_ingestor: MemgraphIngestor, typescript_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, typescript_project)
+
+        labels = get_node_labels(memgraph_ingestor)
+        assert NodeLabel.ENUM.value in labels, (
+            f"Enum label missing. Got labels: {labels}"
+        )
+
+        enums = get_nodes_by_label(memgraph_ingestor, NodeLabel.ENUM.value)
+        enum_names = {n["name"] for n in enums}
+        assert "Status" in enum_names
+
+    def test_typescript_creates_type_nodes(
+        self, memgraph_ingestor: MemgraphIngestor, typescript_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, typescript_project)
+
+        labels = get_node_labels(memgraph_ingestor)
+        assert NodeLabel.TYPE.value in labels, (
+            f"Type label missing. Got labels: {labels}"
+        )
+
+        types = get_nodes_by_label(memgraph_ingestor, NodeLabel.TYPE.value)
+        type_names = {n["name"] for n in types}
+        assert "MyType" in type_names
+
+    def test_typescript_creates_class_nodes(
+        self, memgraph_ingestor: MemgraphIngestor, typescript_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, typescript_project)
+
+        labels = get_node_labels(memgraph_ingestor)
+        assert NodeLabel.CLASS.value in labels
+
+        classes = get_nodes_by_label(memgraph_ingestor, NodeLabel.CLASS.value)
+        class_names = {n["name"] for n in classes}
+        assert "MyTsClass" in class_names
+
+    def test_typescript_creates_function_nodes(
+        self, memgraph_ingestor: MemgraphIngestor, typescript_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, typescript_project)
+
+        labels = get_node_labels(memgraph_ingestor)
+        assert NodeLabel.FUNCTION.value in labels
+
+        functions = get_nodes_by_label(memgraph_ingestor, NodeLabel.FUNCTION.value)
+        func_names = {n["name"] for n in functions}
+        assert "createInstance" in func_names
+
+
+class TestJavaScriptNodeLabels:
+    def test_javascript_creates_class_nodes(
+        self, memgraph_ingestor: MemgraphIngestor, javascript_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, javascript_project)
+
+        labels = get_node_labels(memgraph_ingestor)
+        assert NodeLabel.CLASS.value in labels
+
+        classes = get_nodes_by_label(memgraph_ingestor, NodeLabel.CLASS.value)
+        class_names = {n["name"] for n in classes}
+        assert "MyJsClass" in class_names
+
+    def test_javascript_creates_function_nodes(
+        self, memgraph_ingestor: MemgraphIngestor, javascript_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, javascript_project)
+
+        labels = get_node_labels(memgraph_ingestor)
+        assert NodeLabel.FUNCTION.value in labels
+
+        functions = get_nodes_by_label(memgraph_ingestor, NodeLabel.FUNCTION.value)
+        func_names = {n["name"] for n in functions}
+        assert "createInstance" in func_names
+
+
+class TestRustNodeLabels:
+    def test_rust_creates_class_nodes_for_structs(
+        self, memgraph_ingestor: MemgraphIngestor, rust_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, rust_project)
+
+        labels = get_node_labels(memgraph_ingestor)
+        assert NodeLabel.CLASS.value in labels
+
+        classes = get_nodes_by_label(memgraph_ingestor, NodeLabel.CLASS.value)
+        class_names = {n["name"] for n in classes}
+        assert "MyStruct" in class_names
+
+    def test_rust_creates_function_nodes(
+        self, memgraph_ingestor: MemgraphIngestor, rust_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, rust_project)
+
+        labels = get_node_labels(memgraph_ingestor)
+        assert NodeLabel.FUNCTION.value in labels
+
+        functions = get_nodes_by_label(memgraph_ingestor, NodeLabel.FUNCTION.value)
+        func_names = {n["name"] for n in functions}
+        assert "standalone_fn" in func_names
+
+
+@pytest.mark.skip(reason="Go is in development status")
+class TestGoNodeLabels:
+    def test_go_creates_class_nodes_for_structs(
+        self, memgraph_ingestor: MemgraphIngestor, go_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, go_project)
+
+        labels = get_node_labels(memgraph_ingestor)
+        assert NodeLabel.CLASS.value in labels
+
+        classes = get_nodes_by_label(memgraph_ingestor, NodeLabel.CLASS.value)
+        class_names = {n["name"] for n in classes}
+        assert "MyStruct" in class_names
+
+    def test_go_creates_interface_nodes(
+        self, memgraph_ingestor: MemgraphIngestor, go_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, go_project)
+
+        labels = get_node_labels(memgraph_ingestor)
+        assert NodeLabel.INTERFACE.value in labels
+
+        interfaces = get_nodes_by_label(memgraph_ingestor, NodeLabel.INTERFACE.value)
+        interface_names = {n["name"] for n in interfaces}
+        assert "MyInterface" in interface_names
+
+    def test_go_creates_function_nodes(
+        self, memgraph_ingestor: MemgraphIngestor, go_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, go_project)
+
+        labels = get_node_labels(memgraph_ingestor)
+        assert NodeLabel.FUNCTION.value in labels
+
+        functions = get_nodes_by_label(memgraph_ingestor, NodeLabel.FUNCTION.value)
+        func_names = {n["name"] for n in functions}
+        assert "NewMyStruct" in func_names
+        assert "main" in func_names
+
+
+@pytest.mark.skip(reason="Scala is in development status")
+class TestScalaNodeLabels:
+    def test_scala_creates_class_nodes(
+        self, memgraph_ingestor: MemgraphIngestor, scala_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, scala_project)
+
+        labels = get_node_labels(memgraph_ingestor)
+        assert NodeLabel.CLASS.value in labels
+
+        classes = get_nodes_by_label(memgraph_ingestor, NodeLabel.CLASS.value)
+        class_names = {n["name"] for n in classes}
+        assert "MyScalaClass" in class_names
+
+    def test_scala_creates_interface_nodes_for_traits(
+        self, memgraph_ingestor: MemgraphIngestor, scala_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, scala_project)
+
+        labels = get_node_labels(memgraph_ingestor)
+        assert NodeLabel.INTERFACE.value in labels
+
+        interfaces = get_nodes_by_label(memgraph_ingestor, NodeLabel.INTERFACE.value)
+        interface_names = {n["name"] for n in interfaces}
+        assert "MyTrait" in interface_names or "Status" in interface_names
+
+
+class TestJavaNodeLabels:
+    def test_java_creates_class_nodes(
+        self, memgraph_ingestor: MemgraphIngestor, java_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, java_project)
+
+        labels = get_node_labels(memgraph_ingestor)
+        assert NodeLabel.CLASS.value in labels
+
+        classes = get_nodes_by_label(memgraph_ingestor, NodeLabel.CLASS.value)
+        class_names = {n["name"] for n in classes}
+        assert "Example" in class_names
+
+    def test_java_creates_interface_nodes(
+        self, memgraph_ingestor: MemgraphIngestor, java_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, java_project)
+
+        labels = get_node_labels(memgraph_ingestor)
+        assert NodeLabel.INTERFACE.value in labels
+
+        interfaces = get_nodes_by_label(memgraph_ingestor, NodeLabel.INTERFACE.value)
+        interface_names = {n["name"] for n in interfaces}
+        assert "MyInterface" in interface_names
+
+    def test_java_creates_enum_nodes(
+        self, memgraph_ingestor: MemgraphIngestor, java_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, java_project)
+
+        labels = get_node_labels(memgraph_ingestor)
+        assert NodeLabel.ENUM.value in labels
+
+        enums = get_nodes_by_label(memgraph_ingestor, NodeLabel.ENUM.value)
+        enum_names = {n["name"] for n in enums}
+        assert "Status" in enum_names
+
+
+class TestCppNodeLabels:
+    def test_cpp_creates_class_nodes(
+        self, memgraph_ingestor: MemgraphIngestor, cpp_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, cpp_project)
+
+        labels = get_node_labels(memgraph_ingestor)
+        assert NodeLabel.CLASS.value in labels
+
+        classes = get_nodes_by_label(memgraph_ingestor, NodeLabel.CLASS.value)
+        class_names = {n["name"] for n in classes}
+        assert "MyCppClass" in class_names
+
+    def test_cpp_creates_enum_nodes(
+        self, memgraph_ingestor: MemgraphIngestor, cpp_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, cpp_project)
+
+        labels = get_node_labels(memgraph_ingestor)
+        assert NodeLabel.ENUM.value in labels
+
+        enums = get_nodes_by_label(memgraph_ingestor, NodeLabel.ENUM.value)
+        enum_names = {n["name"] for n in enums}
+        assert "Status" in enum_names
+
+    def test_cpp_creates_function_nodes(
+        self, memgraph_ingestor: MemgraphIngestor, cpp_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, cpp_project)
+
+        labels = get_node_labels(memgraph_ingestor)
+        assert NodeLabel.FUNCTION.value in labels
+
+        functions = get_nodes_by_label(memgraph_ingestor, NodeLabel.FUNCTION.value)
+        func_names = {n["name"] for n in functions}
+        assert "standaloneFunction" in func_names
+
+
+@pytest.mark.skip(reason="C# is in development status and parser not available")
+class TestCSharpNodeLabels:
+    def test_csharp_creates_class_nodes(
+        self, memgraph_ingestor: MemgraphIngestor, csharp_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, csharp_project)
+
+        labels = get_node_labels(memgraph_ingestor)
+        assert NodeLabel.CLASS.value in labels
+
+        classes = get_nodes_by_label(memgraph_ingestor, NodeLabel.CLASS.value)
+        class_names = {n["name"] for n in classes}
+        assert "MyCSharpClass" in class_names
+
+    def test_csharp_creates_interface_nodes(
+        self, memgraph_ingestor: MemgraphIngestor, csharp_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, csharp_project)
+
+        labels = get_node_labels(memgraph_ingestor)
+        assert NodeLabel.INTERFACE.value in labels
+
+        interfaces = get_nodes_by_label(memgraph_ingestor, NodeLabel.INTERFACE.value)
+        interface_names = {n["name"] for n in interfaces}
+        assert "IMyInterface" in interface_names
+
+    def test_csharp_creates_enum_nodes(
+        self, memgraph_ingestor: MemgraphIngestor, csharp_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, csharp_project)
+
+        labels = get_node_labels(memgraph_ingestor)
+        assert NodeLabel.ENUM.value in labels
+
+        enums = get_nodes_by_label(memgraph_ingestor, NodeLabel.ENUM.value)
+        enum_names = {n["name"] for n in enums}
+        assert "Status" in enum_names
+
+
+@pytest.mark.skip(reason="PHP is in development status and parser not available")
+class TestPhpNodeLabels:
+    def test_php_creates_class_nodes(
+        self, memgraph_ingestor: MemgraphIngestor, php_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, php_project)
+
+        labels = get_node_labels(memgraph_ingestor)
+        assert NodeLabel.CLASS.value in labels
+
+        classes = get_nodes_by_label(memgraph_ingestor, NodeLabel.CLASS.value)
+        class_names = {n["name"] for n in classes}
+        assert "MyPhpClass" in class_names
+
+    def test_php_creates_interface_nodes(
+        self, memgraph_ingestor: MemgraphIngestor, php_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, php_project)
+
+        labels = get_node_labels(memgraph_ingestor)
+        assert NodeLabel.INTERFACE.value in labels
+
+        interfaces = get_nodes_by_label(memgraph_ingestor, NodeLabel.INTERFACE.value)
+        interface_names = {n["name"] for n in interfaces}
+        assert "MyInterface" in interface_names
+
+    def test_php_creates_function_nodes(
+        self, memgraph_ingestor: MemgraphIngestor, php_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, php_project)
+
+        labels = get_node_labels(memgraph_ingestor)
+        assert NodeLabel.FUNCTION.value in labels
+
+        functions = get_nodes_by_label(memgraph_ingestor, NodeLabel.FUNCTION.value)
+        func_names = {n["name"] for n in functions}
+        assert "standaloneFunction" in func_names
+
+
+class TestLuaNodeLabels:
+    def test_lua_creates_function_nodes(
+        self, memgraph_ingestor: MemgraphIngestor, lua_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, lua_project)
+
+        labels = get_node_labels(memgraph_ingestor)
+        assert NodeLabel.FUNCTION.value in labels
+
+        functions = get_nodes_by_label(memgraph_ingestor, NodeLabel.FUNCTION.value)
+        func_names = {n["name"] for n in functions}
+        assert "new" in func_names or "getValue" in func_names
+
+
+class TestAllLanguagesDefinesRelationship:
+    def test_python_has_defines(
+        self, memgraph_ingestor: MemgraphIngestor, python_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, python_project)
+        rel_types = get_relationship_types(memgraph_ingestor)
+        assert "DEFINES" in rel_types
+
+    def test_typescript_has_defines(
+        self, memgraph_ingestor: MemgraphIngestor, typescript_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, typescript_project)
+        rel_types = get_relationship_types(memgraph_ingestor)
+        assert "DEFINES" in rel_types
+
+    def test_javascript_has_defines(
+        self, memgraph_ingestor: MemgraphIngestor, javascript_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, javascript_project)
+        rel_types = get_relationship_types(memgraph_ingestor)
+        assert "DEFINES" in rel_types
+
+    def test_rust_has_defines(
+        self, memgraph_ingestor: MemgraphIngestor, rust_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, rust_project)
+        rel_types = get_relationship_types(memgraph_ingestor)
+        assert "DEFINES" in rel_types
+
+    @pytest.mark.skip(reason="Go is in development status")
+    def test_go_has_defines(
+        self, memgraph_ingestor: MemgraphIngestor, go_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, go_project)
+        rel_types = get_relationship_types(memgraph_ingestor)
+        assert "DEFINES" in rel_types
+
+    @pytest.mark.skip(reason="Scala is in development status")
+    def test_scala_has_defines(
+        self, memgraph_ingestor: MemgraphIngestor, scala_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, scala_project)
+        rel_types = get_relationship_types(memgraph_ingestor)
+        assert "DEFINES" in rel_types
+
+    def test_java_has_defines(
+        self, memgraph_ingestor: MemgraphIngestor, java_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, java_project)
+        rel_types = get_relationship_types(memgraph_ingestor)
+        assert "DEFINES" in rel_types
+
+    def test_cpp_has_defines(
+        self, memgraph_ingestor: MemgraphIngestor, cpp_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, cpp_project)
+        rel_types = get_relationship_types(memgraph_ingestor)
+        assert "DEFINES" in rel_types
+
+    @pytest.mark.skip(reason="C# is in development status")
+    def test_csharp_has_defines(
+        self, memgraph_ingestor: MemgraphIngestor, csharp_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, csharp_project)
+        rel_types = get_relationship_types(memgraph_ingestor)
+        assert "DEFINES" in rel_types
+
+    @pytest.mark.skip(reason="PHP is in development status")
+    def test_php_has_defines(
+        self, memgraph_ingestor: MemgraphIngestor, php_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, php_project)
+        rel_types = get_relationship_types(memgraph_ingestor)
+        assert "DEFINES" in rel_types
+
+    def test_lua_has_defines(
+        self, memgraph_ingestor: MemgraphIngestor, lua_project: Path
+    ) -> None:
+        index_project(memgraph_ingestor, lua_project)
+        rel_types = get_relationship_types(memgraph_ingestor)
+        assert "DEFINES" in rel_types

--- a/codebase_rag/tests/integration/test_node_label_e2e.py
+++ b/codebase_rag/tests/integration/test_node_label_e2e.py
@@ -814,84 +814,32 @@ class TestLuaNodeLabels:
         assert "new" in func_names or "getValue" in func_names
 
 
-class TestAllLanguagesDefinesRelationship:
-    def test_python_has_defines(
-        self, memgraph_ingestor: MemgraphIngestor, python_project: Path
-    ) -> None:
-        index_project(memgraph_ingestor, python_project)
-        rel_types = get_relationship_types(memgraph_ingestor)
-        assert "DEFINES" in rel_types
+DEFINES_TEST_PARAMS = [
+    ("python_project", None),
+    ("typescript_project", None),
+    ("javascript_project", None),
+    ("rust_project", None),
+    ("go_project", "Go is in development status"),
+    ("scala_project", "Scala is in development status"),
+    ("java_project", None),
+    ("cpp_project", None),
+    ("csharp_project", "C# is in development status"),
+    ("php_project", "PHP is in development status"),
+    ("lua_project", None),
+]
 
-    def test_typescript_has_defines(
-        self, memgraph_ingestor: MemgraphIngestor, typescript_project: Path
-    ) -> None:
-        index_project(memgraph_ingestor, typescript_project)
-        rel_types = get_relationship_types(memgraph_ingestor)
-        assert "DEFINES" in rel_types
 
-    def test_javascript_has_defines(
-        self, memgraph_ingestor: MemgraphIngestor, javascript_project: Path
-    ) -> None:
-        index_project(memgraph_ingestor, javascript_project)
-        rel_types = get_relationship_types(memgraph_ingestor)
-        assert "DEFINES" in rel_types
+@pytest.mark.parametrize("project_fixture,skip_reason", DEFINES_TEST_PARAMS)
+def test_language_has_defines(
+    project_fixture: str,
+    skip_reason: str | None,
+    request: pytest.FixtureRequest,
+    memgraph_ingestor: MemgraphIngestor,
+) -> None:
+    if skip_reason:
+        pytest.skip(skip_reason)
 
-    def test_rust_has_defines(
-        self, memgraph_ingestor: MemgraphIngestor, rust_project: Path
-    ) -> None:
-        index_project(memgraph_ingestor, rust_project)
-        rel_types = get_relationship_types(memgraph_ingestor)
-        assert "DEFINES" in rel_types
-
-    @pytest.mark.skip(reason="Go is in development status")
-    def test_go_has_defines(
-        self, memgraph_ingestor: MemgraphIngestor, go_project: Path
-    ) -> None:
-        index_project(memgraph_ingestor, go_project)
-        rel_types = get_relationship_types(memgraph_ingestor)
-        assert "DEFINES" in rel_types
-
-    @pytest.mark.skip(reason="Scala is in development status")
-    def test_scala_has_defines(
-        self, memgraph_ingestor: MemgraphIngestor, scala_project: Path
-    ) -> None:
-        index_project(memgraph_ingestor, scala_project)
-        rel_types = get_relationship_types(memgraph_ingestor)
-        assert "DEFINES" in rel_types
-
-    def test_java_has_defines(
-        self, memgraph_ingestor: MemgraphIngestor, java_project: Path
-    ) -> None:
-        index_project(memgraph_ingestor, java_project)
-        rel_types = get_relationship_types(memgraph_ingestor)
-        assert "DEFINES" in rel_types
-
-    def test_cpp_has_defines(
-        self, memgraph_ingestor: MemgraphIngestor, cpp_project: Path
-    ) -> None:
-        index_project(memgraph_ingestor, cpp_project)
-        rel_types = get_relationship_types(memgraph_ingestor)
-        assert "DEFINES" in rel_types
-
-    @pytest.mark.skip(reason="C# is in development status")
-    def test_csharp_has_defines(
-        self, memgraph_ingestor: MemgraphIngestor, csharp_project: Path
-    ) -> None:
-        index_project(memgraph_ingestor, csharp_project)
-        rel_types = get_relationship_types(memgraph_ingestor)
-        assert "DEFINES" in rel_types
-
-    @pytest.mark.skip(reason="PHP is in development status")
-    def test_php_has_defines(
-        self, memgraph_ingestor: MemgraphIngestor, php_project: Path
-    ) -> None:
-        index_project(memgraph_ingestor, php_project)
-        rel_types = get_relationship_types(memgraph_ingestor)
-        assert "DEFINES" in rel_types
-
-    def test_lua_has_defines(
-        self, memgraph_ingestor: MemgraphIngestor, lua_project: Path
-    ) -> None:
-        index_project(memgraph_ingestor, lua_project)
-        rel_types = get_relationship_types(memgraph_ingestor)
-        assert "DEFINES" in rel_types
+    project_path = request.getfixturevalue(project_fixture)
+    index_project(memgraph_ingestor, project_path)
+    rel_types = get_relationship_types(memgraph_ingestor)
+    assert "DEFINES" in rel_types

--- a/codebase_rag/tests/test_language_node_coverage.py
+++ b/codebase_rag/tests/test_language_node_coverage.py
@@ -17,7 +17,6 @@ from codebase_rag.constants import (
     SCALA_EXTENSIONS,
     TS_EXTENSIONS,
     NodeLabel,
-    RelationshipType,
     SupportedLanguage,
 )
 from codebase_rag.language_spec import (
@@ -106,49 +105,12 @@ class TestExtensionToLanguageMapping:
 
 
 class TestAllExtensionsHaveLanguage:
-    @pytest.mark.parametrize("ext", list(PY_EXTENSIONS))
-    def test_python_extensions_all_mapped(self, ext: str) -> None:
-        assert get_language_for_extension(ext) == SupportedLanguage.PYTHON
-
-    @pytest.mark.parametrize("ext", list(JS_EXTENSIONS))
-    def test_javascript_extensions_all_mapped(self, ext: str) -> None:
-        assert get_language_for_extension(ext) == SupportedLanguage.JS
-
-    @pytest.mark.parametrize("ext", list(TS_EXTENSIONS))
-    def test_typescript_extensions_all_mapped(self, ext: str) -> None:
-        assert get_language_for_extension(ext) == SupportedLanguage.TS
-
-    @pytest.mark.parametrize("ext", list(RS_EXTENSIONS))
-    def test_rust_extensions_all_mapped(self, ext: str) -> None:
-        assert get_language_for_extension(ext) == SupportedLanguage.RUST
-
-    @pytest.mark.parametrize("ext", list(GO_EXTENSIONS))
-    def test_go_extensions_all_mapped(self, ext: str) -> None:
-        assert get_language_for_extension(ext) == SupportedLanguage.GO
-
-    @pytest.mark.parametrize("ext", list(SCALA_EXTENSIONS))
-    def test_scala_extensions_all_mapped(self, ext: str) -> None:
-        assert get_language_for_extension(ext) == SupportedLanguage.SCALA
-
-    @pytest.mark.parametrize("ext", list(JAVA_EXTENSIONS))
-    def test_java_extensions_all_mapped(self, ext: str) -> None:
-        assert get_language_for_extension(ext) == SupportedLanguage.JAVA
-
-    @pytest.mark.parametrize("ext", list(CPP_EXTENSIONS))
-    def test_cpp_extensions_all_mapped(self, ext: str) -> None:
-        assert get_language_for_extension(ext) == SupportedLanguage.CPP
-
-    @pytest.mark.parametrize("ext", list(CS_EXTENSIONS))
-    def test_csharp_extensions_all_mapped(self, ext: str) -> None:
-        assert get_language_for_extension(ext) == SupportedLanguage.CSHARP
-
-    @pytest.mark.parametrize("ext", list(PHP_EXTENSIONS))
-    def test_php_extensions_all_mapped(self, ext: str) -> None:
-        assert get_language_for_extension(ext) == SupportedLanguage.PHP
-
-    @pytest.mark.parametrize("ext", list(LUA_EXTENSIONS))
-    def test_lua_extensions_all_mapped(self, ext: str) -> None:
-        assert get_language_for_extension(ext) == SupportedLanguage.LUA
+    @pytest.mark.parametrize("lang,extensions", LANGUAGE_SPEC_PARAMS)
+    def test_all_extensions_map_to_correct_language(
+        self, lang: SupportedLanguage, extensions: tuple[str, ...]
+    ) -> None:
+        for ext in extensions:
+            assert get_language_for_extension(ext) == lang
 
 
 class TestNodeTypesForLanguages:
@@ -158,151 +120,6 @@ class TestNodeTypesForLanguages:
             f"NodeType.{node_type.name} ({node_type.value}) missing from constraints. "
             "Nodes of this type will be silently dropped."
         )
-
-    def test_interface_node_type_supported(self) -> None:
-        assert NodeType.INTERFACE.value in NODE_UNIQUE_CONSTRAINTS
-
-    def test_enum_node_type_supported(self) -> None:
-        assert NodeType.ENUM.value in NODE_UNIQUE_CONSTRAINTS
-
-    def test_type_alias_node_type_supported(self) -> None:
-        assert NodeType.TYPE.value in NODE_UNIQUE_CONSTRAINTS
-
-    def test_union_node_type_supported(self) -> None:
-        assert NodeType.UNION.value in NODE_UNIQUE_CONSTRAINTS
-
-    def test_class_node_type_supported(self) -> None:
-        assert NodeType.CLASS.value in NODE_UNIQUE_CONSTRAINTS
-
-    def test_function_node_type_supported(self) -> None:
-        assert NodeType.FUNCTION.value in NODE_UNIQUE_CONSTRAINTS
-
-    def test_method_node_type_supported(self) -> None:
-        assert NodeType.METHOD.value in NODE_UNIQUE_CONSTRAINTS
-
-    def test_module_node_type_supported(self) -> None:
-        assert NodeType.MODULE.value in NODE_UNIQUE_CONSTRAINTS
-
-    def test_package_node_type_supported(self) -> None:
-        assert NodeType.PACKAGE.value in NODE_UNIQUE_CONSTRAINTS
-
-
-class TestLanguageSpecificNodeTypes:
-    def test_typescript_interface_has_constraint(self) -> None:
-        assert "Interface" in NODE_UNIQUE_CONSTRAINTS
-
-    def test_typescript_enum_has_constraint(self) -> None:
-        assert "Enum" in NODE_UNIQUE_CONSTRAINTS
-
-    def test_typescript_type_alias_has_constraint(self) -> None:
-        assert "Type" in NODE_UNIQUE_CONSTRAINTS
-
-    def test_java_interface_has_constraint(self) -> None:
-        assert "Interface" in NODE_UNIQUE_CONSTRAINTS
-
-    def test_java_enum_has_constraint(self) -> None:
-        assert "Enum" in NODE_UNIQUE_CONSTRAINTS
-
-    def test_rust_enum_has_constraint(self) -> None:
-        assert "Enum" in NODE_UNIQUE_CONSTRAINTS
-
-    def test_rust_union_has_constraint(self) -> None:
-        assert "Union" in NODE_UNIQUE_CONSTRAINTS
-
-    def test_cpp_class_has_constraint(self) -> None:
-        assert "Class" in NODE_UNIQUE_CONSTRAINTS
-
-    def test_cpp_enum_has_constraint(self) -> None:
-        assert "Enum" in NODE_UNIQUE_CONSTRAINTS
-
-    def test_cpp_union_has_constraint(self) -> None:
-        assert "Union" in NODE_UNIQUE_CONSTRAINTS
-
-    def test_cpp_module_interface_has_constraint(self) -> None:
-        assert "ModuleInterface" in NODE_UNIQUE_CONSTRAINTS
-
-    def test_cpp_module_implementation_has_constraint(self) -> None:
-        assert "ModuleImplementation" in NODE_UNIQUE_CONSTRAINTS
-
-    def test_go_interface_has_constraint(self) -> None:
-        assert "Interface" in NODE_UNIQUE_CONSTRAINTS
-
-    def test_scala_class_has_constraint(self) -> None:
-        assert "Class" in NODE_UNIQUE_CONSTRAINTS
-
-    def test_csharp_interface_has_constraint(self) -> None:
-        assert "Interface" in NODE_UNIQUE_CONSTRAINTS
-
-    def test_csharp_enum_has_constraint(self) -> None:
-        assert "Enum" in NODE_UNIQUE_CONSTRAINTS
-
-    def test_php_class_has_constraint(self) -> None:
-        assert "Class" in NODE_UNIQUE_CONSTRAINTS
-
-    def test_php_interface_has_constraint(self) -> None:
-        assert "Interface" in NODE_UNIQUE_CONSTRAINTS
-
-    def test_python_class_has_constraint(self) -> None:
-        assert "Class" in NODE_UNIQUE_CONSTRAINTS
-
-    def test_lua_function_has_constraint(self) -> None:
-        assert "Function" in NODE_UNIQUE_CONSTRAINTS
-
-
-class TestRelationshipTypesComplete:
-    @pytest.mark.parametrize("rel_type", list(RelationshipType))
-    def test_each_relationship_type_is_valid_string(
-        self, rel_type: RelationshipType
-    ) -> None:
-        assert rel_type.value, f"RelationshipType.{rel_type.name} has empty value"
-        assert rel_type.value == rel_type.value.upper(), (
-            f"RelationshipType.{rel_type.name} value '{rel_type.value}' is not uppercase"
-        )
-
-    def test_defines_relationship_exists(self) -> None:
-        assert RelationshipType.DEFINES.value == "DEFINES"
-
-    def test_defines_method_relationship_exists(self) -> None:
-        assert RelationshipType.DEFINES_METHOD.value == "DEFINES_METHOD"
-
-    def test_calls_relationship_exists(self) -> None:
-        assert RelationshipType.CALLS.value == "CALLS"
-
-    def test_imports_relationship_exists(self) -> None:
-        assert RelationshipType.IMPORTS.value == "IMPORTS"
-
-    def test_inherits_relationship_exists(self) -> None:
-        assert RelationshipType.INHERITS.value == "INHERITS"
-
-    def test_implements_relationship_exists(self) -> None:
-        assert RelationshipType.IMPLEMENTS.value == "IMPLEMENTS"
-
-    def test_overrides_relationship_exists(self) -> None:
-        assert RelationshipType.OVERRIDES.value == "OVERRIDES"
-
-    def test_exports_relationship_exists(self) -> None:
-        assert RelationshipType.EXPORTS.value == "EXPORTS"
-
-    def test_contains_package_relationship_exists(self) -> None:
-        assert RelationshipType.CONTAINS_PACKAGE.value == "CONTAINS_PACKAGE"
-
-    def test_contains_folder_relationship_exists(self) -> None:
-        assert RelationshipType.CONTAINS_FOLDER.value == "CONTAINS_FOLDER"
-
-    def test_contains_file_relationship_exists(self) -> None:
-        assert RelationshipType.CONTAINS_FILE.value == "CONTAINS_FILE"
-
-    def test_contains_module_relationship_exists(self) -> None:
-        assert RelationshipType.CONTAINS_MODULE.value == "CONTAINS_MODULE"
-
-    def test_depends_on_external_relationship_exists(self) -> None:
-        assert RelationshipType.DEPENDS_ON_EXTERNAL.value == "DEPENDS_ON_EXTERNAL"
-
-    def test_exports_module_relationship_exists(self) -> None:
-        assert RelationshipType.EXPORTS_MODULE.value == "EXPORTS_MODULE"
-
-    def test_implements_module_relationship_exists(self) -> None:
-        assert RelationshipType.IMPLEMENTS_MODULE.value == "IMPLEMENTS_MODULE"
 
 
 class TestNodeLabelStringValues:

--- a/codebase_rag/tests/test_language_node_coverage.py
+++ b/codebase_rag/tests/test_language_node_coverage.py
@@ -1,0 +1,461 @@
+from __future__ import annotations
+
+import pytest
+
+from codebase_rag.constants import (
+    CPP_EXTENSIONS,
+    CS_EXTENSIONS,
+    GO_EXTENSIONS,
+    JAVA_EXTENSIONS,
+    JS_EXTENSIONS,
+    LANGUAGE_METADATA,
+    LUA_EXTENSIONS,
+    NODE_UNIQUE_CONSTRAINTS,
+    PHP_EXTENSIONS,
+    PY_EXTENSIONS,
+    RS_EXTENSIONS,
+    SCALA_EXTENSIONS,
+    TS_EXTENSIONS,
+    NodeLabel,
+    RelationshipType,
+    SupportedLanguage,
+)
+from codebase_rag.language_spec import (
+    LANGUAGE_SPECS,
+    get_language_for_extension,
+)
+from codebase_rag.types_defs import NodeType
+
+
+class TestSupportedLanguageCoverage:
+    @pytest.mark.parametrize("lang", list(SupportedLanguage))
+    def test_each_language_has_metadata(self, lang: SupportedLanguage) -> None:
+        assert lang in LANGUAGE_METADATA, (
+            f"SupportedLanguage.{lang.name} ({lang.value}) missing from LANGUAGE_METADATA. "
+            "Every supported language must have metadata defined."
+        )
+
+    @pytest.mark.parametrize("lang", list(SupportedLanguage))
+    def test_each_language_has_language_spec(self, lang: SupportedLanguage) -> None:
+        assert lang in LANGUAGE_SPECS, (
+            f"SupportedLanguage.{lang.name} ({lang.value}) missing from LANGUAGE_SPECS. "
+            "Every supported language must have a language specification."
+        )
+
+    @pytest.mark.parametrize("lang", list(SupportedLanguage))
+    def test_each_language_has_file_extensions(self, lang: SupportedLanguage) -> None:
+        spec = LANGUAGE_SPECS.get(lang)
+        assert spec is not None, f"No spec for {lang}"
+        assert spec.file_extensions, (
+            f"SupportedLanguage.{lang.name} has no file extensions defined. "
+            "Every language must have at least one file extension."
+        )
+
+
+class TestLanguageSpecsComplete:
+    def test_python_spec_exists(self) -> None:
+        assert SupportedLanguage.PYTHON in LANGUAGE_SPECS
+        spec = LANGUAGE_SPECS[SupportedLanguage.PYTHON]
+        assert spec.file_extensions == PY_EXTENSIONS
+
+    def test_javascript_spec_exists(self) -> None:
+        assert SupportedLanguage.JS in LANGUAGE_SPECS
+        spec = LANGUAGE_SPECS[SupportedLanguage.JS]
+        assert spec.file_extensions == JS_EXTENSIONS
+
+    def test_typescript_spec_exists(self) -> None:
+        assert SupportedLanguage.TS in LANGUAGE_SPECS
+        spec = LANGUAGE_SPECS[SupportedLanguage.TS]
+        assert spec.file_extensions == TS_EXTENSIONS
+
+    def test_rust_spec_exists(self) -> None:
+        assert SupportedLanguage.RUST in LANGUAGE_SPECS
+        spec = LANGUAGE_SPECS[SupportedLanguage.RUST]
+        assert spec.file_extensions == RS_EXTENSIONS
+
+    def test_go_spec_exists(self) -> None:
+        assert SupportedLanguage.GO in LANGUAGE_SPECS
+        spec = LANGUAGE_SPECS[SupportedLanguage.GO]
+        assert spec.file_extensions == GO_EXTENSIONS
+
+    def test_scala_spec_exists(self) -> None:
+        assert SupportedLanguage.SCALA in LANGUAGE_SPECS
+        spec = LANGUAGE_SPECS[SupportedLanguage.SCALA]
+        assert spec.file_extensions == SCALA_EXTENSIONS
+
+    def test_java_spec_exists(self) -> None:
+        assert SupportedLanguage.JAVA in LANGUAGE_SPECS
+        spec = LANGUAGE_SPECS[SupportedLanguage.JAVA]
+        assert spec.file_extensions == JAVA_EXTENSIONS
+
+    def test_cpp_spec_exists(self) -> None:
+        assert SupportedLanguage.CPP in LANGUAGE_SPECS
+        spec = LANGUAGE_SPECS[SupportedLanguage.CPP]
+        assert spec.file_extensions == CPP_EXTENSIONS
+
+    def test_csharp_spec_exists(self) -> None:
+        assert SupportedLanguage.CSHARP in LANGUAGE_SPECS
+        spec = LANGUAGE_SPECS[SupportedLanguage.CSHARP]
+        assert spec.file_extensions == CS_EXTENSIONS
+
+    def test_php_spec_exists(self) -> None:
+        assert SupportedLanguage.PHP in LANGUAGE_SPECS
+        spec = LANGUAGE_SPECS[SupportedLanguage.PHP]
+        assert spec.file_extensions == PHP_EXTENSIONS
+
+    def test_lua_spec_exists(self) -> None:
+        assert SupportedLanguage.LUA in LANGUAGE_SPECS
+        spec = LANGUAGE_SPECS[SupportedLanguage.LUA]
+        assert spec.file_extensions == LUA_EXTENSIONS
+
+
+class TestExtensionToLanguageMapping:
+    def test_py_extension_maps_to_python(self) -> None:
+        assert get_language_for_extension(".py") == SupportedLanguage.PYTHON
+
+    def test_js_extension_maps_to_javascript(self) -> None:
+        assert get_language_for_extension(".js") == SupportedLanguage.JS
+
+    def test_jsx_extension_maps_to_javascript(self) -> None:
+        assert get_language_for_extension(".jsx") == SupportedLanguage.JS
+
+    def test_ts_extension_maps_to_typescript(self) -> None:
+        assert get_language_for_extension(".ts") == SupportedLanguage.TS
+
+    def test_tsx_extension_maps_to_typescript(self) -> None:
+        assert get_language_for_extension(".tsx") == SupportedLanguage.TS
+
+    def test_rs_extension_maps_to_rust(self) -> None:
+        assert get_language_for_extension(".rs") == SupportedLanguage.RUST
+
+    def test_go_extension_maps_to_go(self) -> None:
+        assert get_language_for_extension(".go") == SupportedLanguage.GO
+
+    def test_scala_extension_maps_to_scala(self) -> None:
+        assert get_language_for_extension(".scala") == SupportedLanguage.SCALA
+
+    def test_java_extension_maps_to_java(self) -> None:
+        assert get_language_for_extension(".java") == SupportedLanguage.JAVA
+
+    def test_cpp_extension_maps_to_cpp(self) -> None:
+        assert get_language_for_extension(".cpp") == SupportedLanguage.CPP
+
+    def test_h_extension_maps_to_cpp(self) -> None:
+        assert get_language_for_extension(".h") == SupportedLanguage.CPP
+
+    def test_hpp_extension_maps_to_cpp(self) -> None:
+        assert get_language_for_extension(".hpp") == SupportedLanguage.CPP
+
+    def test_cc_extension_maps_to_cpp(self) -> None:
+        assert get_language_for_extension(".cc") == SupportedLanguage.CPP
+
+    def test_cs_extension_maps_to_csharp(self) -> None:
+        assert get_language_for_extension(".cs") == SupportedLanguage.CSHARP
+
+    def test_php_extension_maps_to_php(self) -> None:
+        assert get_language_for_extension(".php") == SupportedLanguage.PHP
+
+    def test_lua_extension_maps_to_lua(self) -> None:
+        assert get_language_for_extension(".lua") == SupportedLanguage.LUA
+
+
+class TestAllExtensionsHaveLanguage:
+    @pytest.mark.parametrize("ext", list(PY_EXTENSIONS))
+    def test_python_extensions_all_mapped(self, ext: str) -> None:
+        assert get_language_for_extension(ext) == SupportedLanguage.PYTHON
+
+    @pytest.mark.parametrize("ext", list(JS_EXTENSIONS))
+    def test_javascript_extensions_all_mapped(self, ext: str) -> None:
+        assert get_language_for_extension(ext) == SupportedLanguage.JS
+
+    @pytest.mark.parametrize("ext", list(TS_EXTENSIONS))
+    def test_typescript_extensions_all_mapped(self, ext: str) -> None:
+        assert get_language_for_extension(ext) == SupportedLanguage.TS
+
+    @pytest.mark.parametrize("ext", list(RS_EXTENSIONS))
+    def test_rust_extensions_all_mapped(self, ext: str) -> None:
+        assert get_language_for_extension(ext) == SupportedLanguage.RUST
+
+    @pytest.mark.parametrize("ext", list(GO_EXTENSIONS))
+    def test_go_extensions_all_mapped(self, ext: str) -> None:
+        assert get_language_for_extension(ext) == SupportedLanguage.GO
+
+    @pytest.mark.parametrize("ext", list(SCALA_EXTENSIONS))
+    def test_scala_extensions_all_mapped(self, ext: str) -> None:
+        assert get_language_for_extension(ext) == SupportedLanguage.SCALA
+
+    @pytest.mark.parametrize("ext", list(JAVA_EXTENSIONS))
+    def test_java_extensions_all_mapped(self, ext: str) -> None:
+        assert get_language_for_extension(ext) == SupportedLanguage.JAVA
+
+    @pytest.mark.parametrize("ext", list(CPP_EXTENSIONS))
+    def test_cpp_extensions_all_mapped(self, ext: str) -> None:
+        assert get_language_for_extension(ext) == SupportedLanguage.CPP
+
+    @pytest.mark.parametrize("ext", list(CS_EXTENSIONS))
+    def test_csharp_extensions_all_mapped(self, ext: str) -> None:
+        assert get_language_for_extension(ext) == SupportedLanguage.CSHARP
+
+    @pytest.mark.parametrize("ext", list(PHP_EXTENSIONS))
+    def test_php_extensions_all_mapped(self, ext: str) -> None:
+        assert get_language_for_extension(ext) == SupportedLanguage.PHP
+
+    @pytest.mark.parametrize("ext", list(LUA_EXTENSIONS))
+    def test_lua_extensions_all_mapped(self, ext: str) -> None:
+        assert get_language_for_extension(ext) == SupportedLanguage.LUA
+
+
+class TestNodeTypesForLanguages:
+    @pytest.mark.parametrize("node_type", list(NodeType))
+    def test_all_node_types_have_constraints(self, node_type: NodeType) -> None:
+        assert node_type.value in NODE_UNIQUE_CONSTRAINTS, (
+            f"NodeType.{node_type.name} ({node_type.value}) missing from constraints. "
+            "Nodes of this type will be silently dropped."
+        )
+
+    def test_interface_node_type_supported(self) -> None:
+        assert NodeType.INTERFACE.value in NODE_UNIQUE_CONSTRAINTS
+
+    def test_enum_node_type_supported(self) -> None:
+        assert NodeType.ENUM.value in NODE_UNIQUE_CONSTRAINTS
+
+    def test_type_alias_node_type_supported(self) -> None:
+        assert NodeType.TYPE.value in NODE_UNIQUE_CONSTRAINTS
+
+    def test_union_node_type_supported(self) -> None:
+        assert NodeType.UNION.value in NODE_UNIQUE_CONSTRAINTS
+
+    def test_class_node_type_supported(self) -> None:
+        assert NodeType.CLASS.value in NODE_UNIQUE_CONSTRAINTS
+
+    def test_function_node_type_supported(self) -> None:
+        assert NodeType.FUNCTION.value in NODE_UNIQUE_CONSTRAINTS
+
+    def test_method_node_type_supported(self) -> None:
+        assert NodeType.METHOD.value in NODE_UNIQUE_CONSTRAINTS
+
+    def test_module_node_type_supported(self) -> None:
+        assert NodeType.MODULE.value in NODE_UNIQUE_CONSTRAINTS
+
+    def test_package_node_type_supported(self) -> None:
+        assert NodeType.PACKAGE.value in NODE_UNIQUE_CONSTRAINTS
+
+
+class TestLanguageSpecificNodeTypes:
+    def test_typescript_interface_has_constraint(self) -> None:
+        assert "Interface" in NODE_UNIQUE_CONSTRAINTS
+
+    def test_typescript_enum_has_constraint(self) -> None:
+        assert "Enum" in NODE_UNIQUE_CONSTRAINTS
+
+    def test_typescript_type_alias_has_constraint(self) -> None:
+        assert "Type" in NODE_UNIQUE_CONSTRAINTS
+
+    def test_java_interface_has_constraint(self) -> None:
+        assert "Interface" in NODE_UNIQUE_CONSTRAINTS
+
+    def test_java_enum_has_constraint(self) -> None:
+        assert "Enum" in NODE_UNIQUE_CONSTRAINTS
+
+    def test_rust_enum_has_constraint(self) -> None:
+        assert "Enum" in NODE_UNIQUE_CONSTRAINTS
+
+    def test_rust_union_has_constraint(self) -> None:
+        assert "Union" in NODE_UNIQUE_CONSTRAINTS
+
+    def test_cpp_class_has_constraint(self) -> None:
+        assert "Class" in NODE_UNIQUE_CONSTRAINTS
+
+    def test_cpp_enum_has_constraint(self) -> None:
+        assert "Enum" in NODE_UNIQUE_CONSTRAINTS
+
+    def test_cpp_union_has_constraint(self) -> None:
+        assert "Union" in NODE_UNIQUE_CONSTRAINTS
+
+    def test_cpp_module_interface_has_constraint(self) -> None:
+        assert "ModuleInterface" in NODE_UNIQUE_CONSTRAINTS
+
+    def test_cpp_module_implementation_has_constraint(self) -> None:
+        assert "ModuleImplementation" in NODE_UNIQUE_CONSTRAINTS
+
+    def test_go_interface_has_constraint(self) -> None:
+        assert "Interface" in NODE_UNIQUE_CONSTRAINTS
+
+    def test_scala_class_has_constraint(self) -> None:
+        assert "Class" in NODE_UNIQUE_CONSTRAINTS
+
+    def test_csharp_interface_has_constraint(self) -> None:
+        assert "Interface" in NODE_UNIQUE_CONSTRAINTS
+
+    def test_csharp_enum_has_constraint(self) -> None:
+        assert "Enum" in NODE_UNIQUE_CONSTRAINTS
+
+    def test_php_class_has_constraint(self) -> None:
+        assert "Class" in NODE_UNIQUE_CONSTRAINTS
+
+    def test_php_interface_has_constraint(self) -> None:
+        assert "Interface" in NODE_UNIQUE_CONSTRAINTS
+
+    def test_python_class_has_constraint(self) -> None:
+        assert "Class" in NODE_UNIQUE_CONSTRAINTS
+
+    def test_lua_function_has_constraint(self) -> None:
+        assert "Function" in NODE_UNIQUE_CONSTRAINTS
+
+
+class TestRelationshipTypesComplete:
+    @pytest.mark.parametrize("rel_type", list(RelationshipType))
+    def test_each_relationship_type_is_valid_string(
+        self, rel_type: RelationshipType
+    ) -> None:
+        assert rel_type.value, f"RelationshipType.{rel_type.name} has empty value"
+        assert rel_type.value == rel_type.value.upper(), (
+            f"RelationshipType.{rel_type.name} value '{rel_type.value}' is not uppercase"
+        )
+
+    def test_defines_relationship_exists(self) -> None:
+        assert RelationshipType.DEFINES.value == "DEFINES"
+
+    def test_defines_method_relationship_exists(self) -> None:
+        assert RelationshipType.DEFINES_METHOD.value == "DEFINES_METHOD"
+
+    def test_calls_relationship_exists(self) -> None:
+        assert RelationshipType.CALLS.value == "CALLS"
+
+    def test_imports_relationship_exists(self) -> None:
+        assert RelationshipType.IMPORTS.value == "IMPORTS"
+
+    def test_inherits_relationship_exists(self) -> None:
+        assert RelationshipType.INHERITS.value == "INHERITS"
+
+    def test_implements_relationship_exists(self) -> None:
+        assert RelationshipType.IMPLEMENTS.value == "IMPLEMENTS"
+
+    def test_overrides_relationship_exists(self) -> None:
+        assert RelationshipType.OVERRIDES.value == "OVERRIDES"
+
+    def test_exports_relationship_exists(self) -> None:
+        assert RelationshipType.EXPORTS.value == "EXPORTS"
+
+    def test_contains_package_relationship_exists(self) -> None:
+        assert RelationshipType.CONTAINS_PACKAGE.value == "CONTAINS_PACKAGE"
+
+    def test_contains_folder_relationship_exists(self) -> None:
+        assert RelationshipType.CONTAINS_FOLDER.value == "CONTAINS_FOLDER"
+
+    def test_contains_file_relationship_exists(self) -> None:
+        assert RelationshipType.CONTAINS_FILE.value == "CONTAINS_FILE"
+
+    def test_contains_module_relationship_exists(self) -> None:
+        assert RelationshipType.CONTAINS_MODULE.value == "CONTAINS_MODULE"
+
+    def test_depends_on_external_relationship_exists(self) -> None:
+        assert RelationshipType.DEPENDS_ON_EXTERNAL.value == "DEPENDS_ON_EXTERNAL"
+
+    def test_exports_module_relationship_exists(self) -> None:
+        assert RelationshipType.EXPORTS_MODULE.value == "EXPORTS_MODULE"
+
+    def test_implements_module_relationship_exists(self) -> None:
+        assert RelationshipType.IMPLEMENTS_MODULE.value == "IMPLEMENTS_MODULE"
+
+
+class TestNodeLabelStringValues:
+    @pytest.mark.parametrize("label", list(NodeLabel))
+    def test_node_label_value_is_pascal_case(self, label: NodeLabel) -> None:
+        value = label.value
+        assert value[0].isupper(), (
+            f"NodeLabel.{label.name} value '{value}' should start with uppercase"
+        )
+        assert "_" not in value, (
+            f"NodeLabel.{label.name} value '{value}' should be PascalCase, not snake_case"
+        )
+
+
+class TestNodeTypeStringValues:
+    @pytest.mark.parametrize("node_type", list(NodeType))
+    def test_node_type_value_is_pascal_case(self, node_type: NodeType) -> None:
+        value = node_type.value
+        assert value[0].isupper(), (
+            f"NodeType.{node_type.name} value '{value}' should start with uppercase"
+        )
+        assert "_" not in value, (
+            f"NodeType.{node_type.name} value '{value}' should be PascalCase"
+        )
+
+
+class TestConstraintsKeyFormat:
+    def test_all_constraint_keys_are_strings(self) -> None:
+        for key in NODE_UNIQUE_CONSTRAINTS:
+            assert isinstance(key, str), f"Constraint key {key} is not a string"
+
+    def test_all_constraint_values_are_strings(self) -> None:
+        for key, value in NODE_UNIQUE_CONSTRAINTS.items():
+            assert isinstance(value, str), (
+                f"Constraint value for {key} is not a string: {value}"
+            )
+
+    def test_all_constraint_keys_are_pascal_case(self) -> None:
+        for key in NODE_UNIQUE_CONSTRAINTS:
+            assert key[0].isupper(), f"Constraint key '{key}' should be PascalCase"
+
+    def test_all_constraint_values_are_valid_property_names(self) -> None:
+        valid_properties = {"name", "path", "qualified_name"}
+        for key, value in NODE_UNIQUE_CONSTRAINTS.items():
+            assert value in valid_properties, (
+                f"Constraint for '{key}' has invalid property '{value}'. "
+                f"Must be one of {valid_properties}."
+            )
+
+
+class TestLanguageSpecHasRequiredFields:
+    @pytest.mark.parametrize("lang", list(SupportedLanguage))
+    def test_each_language_spec_has_function_node_types(
+        self, lang: SupportedLanguage
+    ) -> None:
+        if lang not in LANGUAGE_SPECS:
+            pytest.skip(f"Language {lang} not in LANGUAGE_SPECS")
+        spec = LANGUAGE_SPECS[lang]
+        assert spec.function_node_types is not None, (
+            f"Language {lang} has no function_node_types defined"
+        )
+
+    @pytest.mark.parametrize("lang", list(SupportedLanguage))
+    def test_each_language_spec_has_class_node_types(
+        self, lang: SupportedLanguage
+    ) -> None:
+        if lang not in LANGUAGE_SPECS:
+            pytest.skip(f"Language {lang} not in LANGUAGE_SPECS")
+        spec = LANGUAGE_SPECS[lang]
+        assert spec.class_node_types is not None, (
+            f"Language {lang} has no class_node_types defined"
+        )
+
+    @pytest.mark.parametrize("lang", list(SupportedLanguage))
+    def test_each_language_spec_has_module_node_types(
+        self, lang: SupportedLanguage
+    ) -> None:
+        if lang not in LANGUAGE_SPECS:
+            pytest.skip(f"Language {lang} not in LANGUAGE_SPECS")
+        spec = LANGUAGE_SPECS[lang]
+        assert spec.module_node_types is not None, (
+            f"Language {lang} has no module_node_types defined"
+        )
+
+    @pytest.mark.parametrize("lang", list(SupportedLanguage))
+    def test_each_language_spec_has_call_node_types(
+        self, lang: SupportedLanguage
+    ) -> None:
+        if lang not in LANGUAGE_SPECS:
+            pytest.skip(f"Language {lang} not in LANGUAGE_SPECS")
+        spec = LANGUAGE_SPECS[lang]
+        assert spec.call_node_types is not None, (
+            f"Language {lang} has no call_node_types defined"
+        )
+
+
+class TestLanguageMetadataComplete:
+    @pytest.mark.parametrize("lang", list(SupportedLanguage))
+    def test_each_language_has_status(self, lang: SupportedLanguage) -> None:
+        assert lang in LANGUAGE_METADATA, f"Language {lang} not in LANGUAGE_METADATA"
+        metadata = LANGUAGE_METADATA[lang]
+        assert metadata.status is not None, f"Language {lang} has no status"

--- a/codebase_rag/tests/test_language_node_coverage.py
+++ b/codebase_rag/tests/test_language_node_coverage.py
@@ -52,111 +52,57 @@ class TestSupportedLanguageCoverage:
         )
 
 
+LANGUAGE_SPEC_PARAMS = [
+    (SupportedLanguage.PYTHON, PY_EXTENSIONS),
+    (SupportedLanguage.JS, JS_EXTENSIONS),
+    (SupportedLanguage.TS, TS_EXTENSIONS),
+    (SupportedLanguage.RUST, RS_EXTENSIONS),
+    (SupportedLanguage.GO, GO_EXTENSIONS),
+    (SupportedLanguage.SCALA, SCALA_EXTENSIONS),
+    (SupportedLanguage.JAVA, JAVA_EXTENSIONS),
+    (SupportedLanguage.CPP, CPP_EXTENSIONS),
+    (SupportedLanguage.CSHARP, CS_EXTENSIONS),
+    (SupportedLanguage.PHP, PHP_EXTENSIONS),
+    (SupportedLanguage.LUA, LUA_EXTENSIONS),
+]
+
+
 class TestLanguageSpecsComplete:
-    def test_python_spec_exists(self) -> None:
-        assert SupportedLanguage.PYTHON in LANGUAGE_SPECS
-        spec = LANGUAGE_SPECS[SupportedLanguage.PYTHON]
-        assert spec.file_extensions == PY_EXTENSIONS
+    @pytest.mark.parametrize("lang,extensions", LANGUAGE_SPEC_PARAMS)
+    def test_language_spec_has_correct_extensions(
+        self, lang: SupportedLanguage, extensions: tuple[str, ...]
+    ) -> None:
+        assert lang in LANGUAGE_SPECS
+        spec = LANGUAGE_SPECS[lang]
+        assert spec.file_extensions == extensions
 
-    def test_javascript_spec_exists(self) -> None:
-        assert SupportedLanguage.JS in LANGUAGE_SPECS
-        spec = LANGUAGE_SPECS[SupportedLanguage.JS]
-        assert spec.file_extensions == JS_EXTENSIONS
 
-    def test_typescript_spec_exists(self) -> None:
-        assert SupportedLanguage.TS in LANGUAGE_SPECS
-        spec = LANGUAGE_SPECS[SupportedLanguage.TS]
-        assert spec.file_extensions == TS_EXTENSIONS
-
-    def test_rust_spec_exists(self) -> None:
-        assert SupportedLanguage.RUST in LANGUAGE_SPECS
-        spec = LANGUAGE_SPECS[SupportedLanguage.RUST]
-        assert spec.file_extensions == RS_EXTENSIONS
-
-    def test_go_spec_exists(self) -> None:
-        assert SupportedLanguage.GO in LANGUAGE_SPECS
-        spec = LANGUAGE_SPECS[SupportedLanguage.GO]
-        assert spec.file_extensions == GO_EXTENSIONS
-
-    def test_scala_spec_exists(self) -> None:
-        assert SupportedLanguage.SCALA in LANGUAGE_SPECS
-        spec = LANGUAGE_SPECS[SupportedLanguage.SCALA]
-        assert spec.file_extensions == SCALA_EXTENSIONS
-
-    def test_java_spec_exists(self) -> None:
-        assert SupportedLanguage.JAVA in LANGUAGE_SPECS
-        spec = LANGUAGE_SPECS[SupportedLanguage.JAVA]
-        assert spec.file_extensions == JAVA_EXTENSIONS
-
-    def test_cpp_spec_exists(self) -> None:
-        assert SupportedLanguage.CPP in LANGUAGE_SPECS
-        spec = LANGUAGE_SPECS[SupportedLanguage.CPP]
-        assert spec.file_extensions == CPP_EXTENSIONS
-
-    def test_csharp_spec_exists(self) -> None:
-        assert SupportedLanguage.CSHARP in LANGUAGE_SPECS
-        spec = LANGUAGE_SPECS[SupportedLanguage.CSHARP]
-        assert spec.file_extensions == CS_EXTENSIONS
-
-    def test_php_spec_exists(self) -> None:
-        assert SupportedLanguage.PHP in LANGUAGE_SPECS
-        spec = LANGUAGE_SPECS[SupportedLanguage.PHP]
-        assert spec.file_extensions == PHP_EXTENSIONS
-
-    def test_lua_spec_exists(self) -> None:
-        assert SupportedLanguage.LUA in LANGUAGE_SPECS
-        spec = LANGUAGE_SPECS[SupportedLanguage.LUA]
-        assert spec.file_extensions == LUA_EXTENSIONS
+EXTENSION_MAPPING_PARAMS = [
+    (".py", SupportedLanguage.PYTHON),
+    (".js", SupportedLanguage.JS),
+    (".jsx", SupportedLanguage.JS),
+    (".ts", SupportedLanguage.TS),
+    (".tsx", SupportedLanguage.TS),
+    (".rs", SupportedLanguage.RUST),
+    (".go", SupportedLanguage.GO),
+    (".scala", SupportedLanguage.SCALA),
+    (".java", SupportedLanguage.JAVA),
+    (".cpp", SupportedLanguage.CPP),
+    (".h", SupportedLanguage.CPP),
+    (".hpp", SupportedLanguage.CPP),
+    (".cc", SupportedLanguage.CPP),
+    (".cs", SupportedLanguage.CSHARP),
+    (".php", SupportedLanguage.PHP),
+    (".lua", SupportedLanguage.LUA),
+]
 
 
 class TestExtensionToLanguageMapping:
-    def test_py_extension_maps_to_python(self) -> None:
-        assert get_language_for_extension(".py") == SupportedLanguage.PYTHON
-
-    def test_js_extension_maps_to_javascript(self) -> None:
-        assert get_language_for_extension(".js") == SupportedLanguage.JS
-
-    def test_jsx_extension_maps_to_javascript(self) -> None:
-        assert get_language_for_extension(".jsx") == SupportedLanguage.JS
-
-    def test_ts_extension_maps_to_typescript(self) -> None:
-        assert get_language_for_extension(".ts") == SupportedLanguage.TS
-
-    def test_tsx_extension_maps_to_typescript(self) -> None:
-        assert get_language_for_extension(".tsx") == SupportedLanguage.TS
-
-    def test_rs_extension_maps_to_rust(self) -> None:
-        assert get_language_for_extension(".rs") == SupportedLanguage.RUST
-
-    def test_go_extension_maps_to_go(self) -> None:
-        assert get_language_for_extension(".go") == SupportedLanguage.GO
-
-    def test_scala_extension_maps_to_scala(self) -> None:
-        assert get_language_for_extension(".scala") == SupportedLanguage.SCALA
-
-    def test_java_extension_maps_to_java(self) -> None:
-        assert get_language_for_extension(".java") == SupportedLanguage.JAVA
-
-    def test_cpp_extension_maps_to_cpp(self) -> None:
-        assert get_language_for_extension(".cpp") == SupportedLanguage.CPP
-
-    def test_h_extension_maps_to_cpp(self) -> None:
-        assert get_language_for_extension(".h") == SupportedLanguage.CPP
-
-    def test_hpp_extension_maps_to_cpp(self) -> None:
-        assert get_language_for_extension(".hpp") == SupportedLanguage.CPP
-
-    def test_cc_extension_maps_to_cpp(self) -> None:
-        assert get_language_for_extension(".cc") == SupportedLanguage.CPP
-
-    def test_cs_extension_maps_to_csharp(self) -> None:
-        assert get_language_for_extension(".cs") == SupportedLanguage.CSHARP
-
-    def test_php_extension_maps_to_php(self) -> None:
-        assert get_language_for_extension(".php") == SupportedLanguage.PHP
-
-    def test_lua_extension_maps_to_lua(self) -> None:
-        assert get_language_for_extension(".lua") == SupportedLanguage.LUA
+    @pytest.mark.parametrize("ext,expected_lang", EXTENSION_MAPPING_PARAMS)
+    def test_extension_maps_to_language(
+        self, ext: str, expected_lang: SupportedLanguage
+    ) -> None:
+        assert get_language_for_extension(ext) == expected_lang
 
 
 class TestAllExtensionsHaveLanguage:

--- a/codebase_rag/tests/test_language_node_coverage.py
+++ b/codebase_rag/tests/test_language_node_coverage.py
@@ -18,6 +18,7 @@ from codebase_rag.constants import (
     TS_EXTENSIONS,
     NodeLabel,
     SupportedLanguage,
+    UniqueKeyType,
 )
 from codebase_rag.language_spec import (
     LANGUAGE_SPECS,
@@ -162,7 +163,7 @@ class TestConstraintsKeyFormat:
             assert key[0].isupper(), f"Constraint key '{key}' should be PascalCase"
 
     def test_all_constraint_values_are_valid_property_names(self) -> None:
-        valid_properties = {"name", "path", "qualified_name"}
+        valid_properties = {v.value for v in UniqueKeyType}
         for key, value in NODE_UNIQUE_CONSTRAINTS.items():
             assert value in valid_properties, (
                 f"Constraint for '{key}' has invalid property '{value}'. "

--- a/codebase_rag/tests/test_node_relationship_coverage.py
+++ b/codebase_rag/tests/test_node_relationship_coverage.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from codebase_rag.constants import (
+    _NODE_LABEL_UNIQUE_KEYS,
+    KEY_NAME,
+    KEY_PATH,
+    KEY_QUALIFIED_NAME,
+    NODE_UNIQUE_CONSTRAINTS,
+    NodeLabel,
+    RelationshipType,
+    UniqueKeyType,
+)
+from codebase_rag.services.graph_service import MemgraphIngestor
+from codebase_rag.types_defs import NodeType
+
+
+class TestNodeLabelCoverage:
+    def test_all_node_labels_have_unique_key_mapping(self) -> None:
+        missing = set(NodeLabel) - set(_NODE_LABEL_UNIQUE_KEYS.keys())
+
+        assert not missing, (
+            f"NodeLabel(s) missing from _NODE_LABEL_UNIQUE_KEYS: {missing}. "
+            "Every NodeLabel MUST have a unique key defined."
+        )
+
+    def test_all_node_labels_in_constraints(self) -> None:
+        missing = {label.value for label in NodeLabel} - set(
+            NODE_UNIQUE_CONSTRAINTS.keys()
+        )
+
+        assert not missing, (
+            f"NodeLabel value(s) missing from NODE_UNIQUE_CONSTRAINTS: {missing}. "
+            "This would cause nodes to be silently dropped during flush."
+        )
+
+    def test_all_node_types_in_constraints(self) -> None:
+        missing = {node_type.value for node_type in NodeType} - set(
+            NODE_UNIQUE_CONSTRAINTS.keys()
+        )
+
+        assert not missing, (
+            f"NodeType value(s) missing from NODE_UNIQUE_CONSTRAINTS: {missing}. "
+            "This would cause nodes to be silently dropped during flush."
+        )
+
+    def test_node_unique_constraints_derived_from_single_source(self) -> None:
+        expected = {
+            label.value: key.value for label, key in _NODE_LABEL_UNIQUE_KEYS.items()
+        }
+
+        assert NODE_UNIQUE_CONSTRAINTS == expected, (
+            "NODE_UNIQUE_CONSTRAINTS must be derived from _NODE_LABEL_UNIQUE_KEYS. "
+            "Do not maintain NODE_UNIQUE_CONSTRAINTS manually."
+        )
+
+    def test_unique_key_types_are_valid(self) -> None:
+        valid_keys = {
+            UniqueKeyType.NAME,
+            UniqueKeyType.PATH,
+            UniqueKeyType.QUALIFIED_NAME,
+        }
+
+        for label, key in _NODE_LABEL_UNIQUE_KEYS.items():
+            assert key in valid_keys, (
+                f"Invalid unique key type {key} for {label}. "
+                f"Must be one of {valid_keys}."
+            )
+
+
+class TestNodeLabelConstraintConsistency:
+    @pytest.mark.parametrize("label", list(NodeLabel))
+    def test_each_node_label_has_constraint(self, label: NodeLabel) -> None:
+        assert label.value in NODE_UNIQUE_CONSTRAINTS, (
+            f"NodeLabel.{label.name} ({label.value}) missing from NODE_UNIQUE_CONSTRAINTS. "
+            "This would cause nodes of this type to be silently dropped."
+        )
+
+    @pytest.mark.parametrize("node_type", list(NodeType))
+    def test_each_node_type_has_constraint(self, node_type: NodeType) -> None:
+        assert node_type.value in NODE_UNIQUE_CONSTRAINTS, (
+            f"NodeType.{node_type.name} ({node_type.value}) missing from NODE_UNIQUE_CONSTRAINTS. "
+            "This would cause nodes of this type to be silently dropped."
+        )
+
+
+class TestFlushNodesForAllNodeLabels:
+    @pytest.mark.parametrize("label", list(NodeLabel))
+    def test_each_node_label_can_be_flushed(self, label: NodeLabel) -> None:
+        ingestor = MemgraphIngestor(host="localhost", port=7687, batch_size=10)
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+        ingestor.conn = mock_conn
+
+        unique_key = NODE_UNIQUE_CONSTRAINTS[label.value]
+        node_props = {unique_key: f"test_{label.value}_id", KEY_NAME: "test"}
+
+        ingestor.node_buffer.append((label.value, node_props))
+        ingestor.flush_nodes()
+
+        mock_cursor.execute.assert_called_once()
+        assert ingestor.node_buffer == []
+
+    @pytest.mark.parametrize("node_type", list(NodeType))
+    def test_each_node_type_can_be_flushed(self, node_type: NodeType) -> None:
+        ingestor = MemgraphIngestor(host="localhost", port=7687, batch_size=10)
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+        ingestor.conn = mock_conn
+
+        unique_key = NODE_UNIQUE_CONSTRAINTS[node_type.value]
+        node_props = {unique_key: f"test_{node_type.value}_id", KEY_NAME: "test"}
+
+        ingestor.node_buffer.append((node_type.value, node_props))
+        ingestor.flush_nodes()
+
+        mock_cursor.execute.assert_called_once()
+        assert ingestor.node_buffer == []
+
+
+class TestFlushRelationshipsForAllTypes:
+    @pytest.mark.parametrize("rel_type", list(RelationshipType))
+    def test_each_relationship_type_can_be_flushed(
+        self, rel_type: RelationshipType
+    ) -> None:
+        ingestor = MemgraphIngestor(host="localhost", port=7687, batch_size=10)
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+        mock_cursor.fetchall.return_value = [(1,)]
+
+        col = MagicMock()
+        col.name = "created"
+        mock_cursor.description = [col]
+
+        ingestor.conn = mock_conn
+
+        ingestor.relationship_buffer.append(
+            (
+                (NodeLabel.MODULE.value, KEY_QUALIFIED_NAME, "module.test"),
+                rel_type.value,
+                (NodeLabel.FUNCTION.value, KEY_QUALIFIED_NAME, "module.test.func"),
+                None,
+            )
+        )
+        ingestor.flush_relationships()
+
+        mock_cursor.execute.assert_called_once()
+        assert ingestor.relationship_buffer == []
+
+
+class TestUniqueKeyPropertyNames:
+    def test_name_unique_key_uses_correct_property(self) -> None:
+        for label in NodeLabel:
+            key = _NODE_LABEL_UNIQUE_KEYS[label]
+            if key == UniqueKeyType.NAME:
+                assert NODE_UNIQUE_CONSTRAINTS[label.value] == KEY_NAME
+
+    def test_path_unique_key_uses_correct_property(self) -> None:
+        for label in NodeLabel:
+            key = _NODE_LABEL_UNIQUE_KEYS[label]
+            if key == UniqueKeyType.PATH:
+                assert NODE_UNIQUE_CONSTRAINTS[label.value] == KEY_PATH
+
+    def test_qualified_name_unique_key_uses_correct_property(self) -> None:
+        for label in NodeLabel:
+            key = _NODE_LABEL_UNIQUE_KEYS[label]
+            if key == UniqueKeyType.QUALIFIED_NAME:
+                assert NODE_UNIQUE_CONSTRAINTS[label.value] == KEY_QUALIFIED_NAME
+
+
+class TestNodeLabelEnumCompleteness:
+    def test_node_label_count_matches_constraints_count(self) -> None:
+        assert len(NodeLabel) == len(NODE_UNIQUE_CONSTRAINTS), (
+            f"NodeLabel has {len(NodeLabel)} values but "
+            f"NODE_UNIQUE_CONSTRAINTS has {len(NODE_UNIQUE_CONSTRAINTS)} entries. "
+            "These must match."
+        )
+
+    def test_node_type_is_subset_of_node_label(self) -> None:
+        node_type_values = {t.value for t in NodeType}
+        node_label_values = {label.value for label in NodeLabel}
+
+        extra_in_node_type = node_type_values - node_label_values
+
+        assert not extra_in_node_type, (
+            f"NodeType has values not in NodeLabel: {extra_in_node_type}. "
+            "NodeType must be a subset of NodeLabel."
+        )
+
+
+class TestRelationshipTypeCompleteness:
+    def test_relationship_types_are_uppercase(self) -> None:
+        for rel_type in RelationshipType:
+            assert rel_type.value == rel_type.value.upper(), (
+                f"RelationshipType.{rel_type.name} has value '{rel_type.value}' "
+                "which is not uppercase. Relationship types must be uppercase."
+            )
+
+    def test_relationship_type_values_match_names(self) -> None:
+        for rel_type in RelationshipType:
+            assert rel_type.name == rel_type.value, (
+                f"RelationshipType.{rel_type.name} has mismatched value '{rel_type.value}'. "
+                "Name and value should match for relationship types."
+            )
+
+
+class TestNodeBufferFlushWithMissingKey:
+    @pytest.mark.parametrize("label", list(NodeLabel))
+    def test_node_without_unique_key_is_skipped_not_crashed(
+        self, label: NodeLabel
+    ) -> None:
+        ingestor = MemgraphIngestor(host="localhost", port=7687, batch_size=10)
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+        ingestor.conn = mock_conn
+
+        node_props = {KEY_NAME: "test_without_unique_key"}
+
+        ingestor.node_buffer.append((label.value, node_props))
+        ingestor.flush_nodes()
+
+        assert ingestor.node_buffer == []
+
+
+class TestEnsureConstraintsForAllLabels:
+    def test_ensure_constraints_creates_all_constraints(self) -> None:
+        ingestor = MemgraphIngestor(host="localhost", port=7687)
+        executed_queries: list[str] = []
+
+        def capture_query(query: str) -> None:
+            executed_queries.append(query)
+
+        with patch.object(ingestor, "_execute_query", side_effect=capture_query):
+            ingestor.ensure_constraints()
+
+        for label in NodeLabel:
+            prop = NODE_UNIQUE_CONSTRAINTS[label.value]
+            expected = (
+                f"CREATE CONSTRAINT ON (n:{label.value}) ASSERT n.{prop} IS UNIQUE;"
+            )
+            assert expected in executed_queries, (
+                f"Missing constraint for {label.value}. Expected query: {expected}"
+            )
+
+
+class TestImportTimeValidation:
+    def test_import_time_validation_catches_missing_keys(self) -> None:
+        code = """
+from enum import StrEnum
+
+class UniqueKeyType(StrEnum):
+    NAME = "name"
+    QUALIFIED_NAME = "qualified_name"
+
+class NodeLabel(StrEnum):
+    PROJECT = "Project"
+    NEW_MISSING_LABEL = "NewMissingLabel"
+
+_NODE_LABEL_UNIQUE_KEYS = {
+    NodeLabel.PROJECT: UniqueKeyType.NAME,
+}
+
+_missing_keys = set(NodeLabel) - set(_NODE_LABEL_UNIQUE_KEYS.keys())
+if _missing_keys:
+    raise RuntimeError(
+        f"NodeLabel(s) missing from _NODE_LABEL_UNIQUE_KEYS: {_missing_keys}"
+    )
+"""
+        with pytest.raises(RuntimeError, match="missing from _NODE_LABEL_UNIQUE_KEYS"):
+            exec(code)

--- a/codebase_rag/tests/test_node_relationship_coverage.py
+++ b/codebase_rag/tests/test_node_relationship_coverage.py
@@ -58,11 +58,7 @@ class TestNodeLabelCoverage:
         )
 
     def test_unique_key_types_are_valid(self) -> None:
-        valid_keys = {
-            UniqueKeyType.NAME,
-            UniqueKeyType.PATH,
-            UniqueKeyType.QUALIFIED_NAME,
-        }
+        valid_keys = set(UniqueKeyType)
 
         for label, key in _NODE_LABEL_UNIQUE_KEYS.items():
             assert key in valid_keys, (


### PR DESCRIPTION
## Summary

- Fix silent node drops for Interface, Enum, Type, Union, ModuleInterface, ModuleImplementation by adding missing entries to `NODE_UNIQUE_CONSTRAINTS`
- Add single source of truth architecture with `_NODE_LABEL_UNIQUE_KEYS` mapping and import-time validation
- Add comprehensive E2E integration tests for node label creation across all 11 supported languages

Closes #153

## Test plan

- [x] Run `make test-parallel-all` - 3163 passed, 24 skipped, 3 xfailed
- [x] Verify E2E tests cover Python, JavaScript, TypeScript, Java, Rust, C++, Lua (fully supported)
- [x] Verify in-development languages (Go, Scala, C#, PHP) are skipped with appropriate markers
- [x] Verify import-time validation catches missing node label entries