### PR TITLE
feat: Add 'doctor' command for health checks

### DIFF
--- a/codebase_rag/cli.py
+++ b/codebase_rag/cli.py
@@ -381,7 +381,6 @@ def language_command(ctx: typer.Context) -> None:
 
 @app.command(name=ch.CLICommandName.DOCTOR, help=ch.CMD_DOCTOR)
 def doctor() -> None:
-    """Run health checks to verify all dependencies and configurations."""
     from rich.table import Table
 
     checker = HealthChecker()

--- a/codebase_rag/cli.py
+++ b/codebase_rag/cli.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import typer
 from loguru import logger
+from rich.panel import Panel
 
 from . import cli_help as ch
 from . import constants as cs
@@ -21,6 +22,7 @@ from .main import (
 )
 from .parser_loader import load_parsers
 from .services.protobuf_service import ProtobufFileIngestor
+from .tools.health_checker import HealthChecker
 from .tools.language import cli as language_cli
 
 app = typer.Typer(
@@ -375,6 +377,57 @@ def graph_loader_command(
 )
 def language_command(ctx: typer.Context) -> None:
     language_cli(ctx.args, standalone_mode=False)
+
+
+@app.command(name=ch.CLICommandName.DOCTOR, help=ch.CMD_DOCTOR)
+def doctor() -> None:
+    """Run health checks to verify all dependencies and configurations."""
+    from rich.table import Table
+
+    checker = HealthChecker()
+    results = checker.run_all_checks()
+
+    passed, total = checker.get_summary()
+
+    table = Table(show_header=False, box=None, padding=(0, 2))
+    table.add_column(style="cyan", no_wrap=False)
+
+    for result in results:
+        status = "✓" if result.passed else "✗"
+        status_color = cs.Color.GREEN if result.passed else cs.Color.RED
+        status_text = style(status, status_color, cs.StyleModifier.NONE)
+
+        check_name = f"{status_text} {result.name}"
+        table.add_row(check_name)
+
+    panel = Panel(
+        table,
+        title="Health Check",
+        border_style="dim",
+        padding=(1, 2),
+    )
+
+    app_context.console.print(panel)
+
+    app_context.console.print()
+    summary_text = f"{passed}/{total} checks passed"
+    if passed == total:
+        app_context.console.print(style(summary_text, cs.Color.GREEN))
+    else:
+        app_context.console.print(style(summary_text, cs.Color.YELLOW))
+
+    failed_checks = [r for r in results if not r.passed and r.error]
+    if failed_checks:
+        app_context.console.print()
+        app_context.console.print(style("Failed checks details:", cs.Color.YELLOW))
+        for result in failed_checks:
+            error_msg = f"  {result.name}: {result.error}"
+            app_context.console.print(
+                style(error_msg, cs.Color.YELLOW, cs.StyleModifier.NONE)
+            )
+
+    if passed < total:
+        raise typer.Exit(1)
 
 
 if __name__ == "__main__":

--- a/codebase_rag/cli.py
+++ b/codebase_rag/cli.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import typer
 from loguru import logger
 from rich.panel import Panel
+from rich.table import Table
 
 from . import cli_help as ch
 from . import constants as cs
@@ -381,8 +382,6 @@ def language_command(ctx: typer.Context) -> None:
 
 @app.command(name=ch.CLICommandName.DOCTOR, help=ch.CMD_DOCTOR)
 def doctor() -> None:
-    from rich.table import Table
-
     checker = HealthChecker()
     results = checker.run_all_checks()
 

--- a/codebase_rag/cli_help.py
+++ b/codebase_rag/cli_help.py
@@ -9,6 +9,7 @@ class CLICommandName(StrEnum):
     MCP_SERVER = "mcp-server"
     GRAPH_LOADER = "graph-loader"
     LANGUAGE = "language"
+    DOCTOR = "doctor"
 
 
 APP_DESCRIPTION = (
@@ -24,6 +25,7 @@ CMD_OPTIMIZE = "AI-guided codebase optimization session"
 CMD_MCP_SERVER = "Start the MCP server for Claude Code integration"
 CMD_GRAPH_LOADER = "Load and display summary of exported graph JSON"
 CMD_LANGUAGE = "Manage language grammars (add, remove, list)"
+CMD_DOCTOR = "Verify that all dependencies and configurations are properly set up"
 
 CMD_LANGUAGE_GROUP = "CLI for managing language grammars"
 CMD_LANGUAGE_ADD = "Add a new language grammar to the project."
@@ -87,4 +89,5 @@ CLI_COMMANDS: dict[CLICommandName, str] = {
     CLICommandName.MCP_SERVER: CMD_MCP_SERVER,
     CLICommandName.GRAPH_LOADER: CMD_GRAPH_LOADER,
     CLICommandName.LANGUAGE: CMD_LANGUAGE,
+    CLICommandName.DOCTOR: CMD_DOCTOR,
 }

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -2736,7 +2736,9 @@ HEALTH_CHECK_DOCKER_NOT_RESPONDING_MSG = "Not responding"
 HEALTH_CHECK_DOCKER_NOT_INSTALLED_MSG = "Not installed"
 HEALTH_CHECK_DOCKER_NOT_IN_PATH = "docker command not found in PATH"
 HEALTH_CHECK_DOCKER_TIMEOUT_MSG = "Check timed out"
-HEALTH_CHECK_DOCKER_TIMEOUT_ERROR = "The 'docker info' command took more than 5 seconds to respond."
+HEALTH_CHECK_DOCKER_TIMEOUT_ERROR = (
+    "The 'docker info' command took more than 5 seconds to respond."
+)
 HEALTH_CHECK_DOCKER_FAILED_MSG = "Check failed"
 HEALTH_CHECK_DOCKER_EXIT_CODE = "Non-zero exit code"
 
@@ -2752,14 +2754,18 @@ HEALTH_CHECK_API_KEY_SET = "{display_name} API key is set"
 HEALTH_CHECK_API_KEY_NOT_SET = "{display_name} API key is not set"
 HEALTH_CHECK_API_KEY_CONFIGURED = "Configured"
 HEALTH_CHECK_API_KEY_NOT_CONFIGURED = "Not set"
-HEALTH_CHECK_API_KEY_MISSING_MSG = "Set the {env_name} environment variable or configure it in your settings."
+HEALTH_CHECK_API_KEY_MISSING_MSG = (
+    "Set the {env_name} environment variable or configure it in your settings."
+)
 
 HEALTH_CHECK_TOOL_INSTALLED = "{tool_name} is installed"
 HEALTH_CHECK_TOOL_NOT_INSTALLED = "{tool_name} is not installed"
 HEALTH_CHECK_TOOL_INSTALLED_MSG = "Installed ({path})"
 HEALTH_CHECK_TOOL_NOT_IN_PATH_MSG = "'{cmd}' not found in PATH"
 HEALTH_CHECK_TOOL_TIMEOUT_MSG = "Check timed out"
-HEALTH_CHECK_TOOL_TIMEOUT_ERROR = "The command to find '{cmd}' took more than 4 seconds to respond."
+HEALTH_CHECK_TOOL_TIMEOUT_ERROR = (
+    "The command to find '{cmd}' took more than 4 seconds to respond."
+)
 HEALTH_CHECK_TOOL_FAILED_MSG = "Check failed"
 
 HEALTH_CHECK_TOOLS = [

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -2728,3 +2728,51 @@ SPEC_LUA_CLASS_TYPES: tuple[str, ...] = ()
 SPEC_LUA_MODULE_TYPES = (TS_LUA_CHUNK,)
 SPEC_LUA_CALL_TYPES = (TS_LUA_FUNCTION_CALL,)
 SPEC_LUA_IMPORT_TYPES = (TS_LUA_FUNCTION_CALL,)
+
+HEALTH_CHECK_DOCKER_RUNNING = "Docker daemon is running"
+HEALTH_CHECK_DOCKER_NOT_RUNNING = "Docker daemon is not running"
+HEALTH_CHECK_DOCKER_RUNNING_MSG = "Running (version {version})"
+HEALTH_CHECK_DOCKER_NOT_RESPONDING_MSG = "Not responding"
+HEALTH_CHECK_DOCKER_NOT_INSTALLED_MSG = "Not installed"
+HEALTH_CHECK_DOCKER_NOT_IN_PATH = "docker command not found in PATH"
+HEALTH_CHECK_DOCKER_TIMEOUT_MSG = "Check timed out"
+HEALTH_CHECK_DOCKER_TIMEOUT_ERROR = "The 'docker info' command took more than 5 seconds to respond."
+HEALTH_CHECK_DOCKER_FAILED_MSG = "Check failed"
+HEALTH_CHECK_DOCKER_EXIT_CODE = "Non-zero exit code"
+
+HEALTH_CHECK_MEMGRAPH_SUCCESSFUL = "Memgraph connection successful"
+HEALTH_CHECK_MEMGRAPH_FAILED = "Memgraph connection failed"
+HEALTH_CHECK_MEMGRAPH_CONNECTED_MSG = "Connected and responsive at {host}:{port}"
+HEALTH_CHECK_MEMGRAPH_CONNECTION_FAILED_MSG = "Connection or query failed"
+HEALTH_CHECK_MEMGRAPH_UNEXPECTED_FAILURE_MSG = "Unexpected failure"
+HEALTH_CHECK_MEMGRAPH_ERROR = "Memgraph error: {error}"
+HEALTH_CHECK_MEMGRAPH_QUERY = "RETURN 1 AS test;"
+
+HEALTH_CHECK_API_KEY_SET = "{display_name} API key is set"
+HEALTH_CHECK_API_KEY_NOT_SET = "{display_name} API key is not set"
+HEALTH_CHECK_API_KEY_CONFIGURED = "Configured"
+HEALTH_CHECK_API_KEY_NOT_CONFIGURED = "Not set"
+HEALTH_CHECK_API_KEY_MISSING_MSG = "Set the {env_name} environment variable or configure it in your settings."
+
+HEALTH_CHECK_TOOL_INSTALLED = "{tool_name} is installed"
+HEALTH_CHECK_TOOL_NOT_INSTALLED = "{tool_name} is not installed"
+HEALTH_CHECK_TOOL_INSTALLED_MSG = "Installed ({path})"
+HEALTH_CHECK_TOOL_NOT_IN_PATH_MSG = "'{cmd}' not found in PATH"
+HEALTH_CHECK_TOOL_TIMEOUT_MSG = "Check timed out"
+HEALTH_CHECK_TOOL_TIMEOUT_ERROR = "The command to find '{cmd}' took more than 4 seconds to respond."
+HEALTH_CHECK_TOOL_FAILED_MSG = "Check failed"
+
+HEALTH_CHECK_TOOLS = [
+    ("GEMINI_API_KEY", "Gemini"),
+    ("OPENAI_API_KEY", "OpenAI"),
+    ("ORCHESTRATOR_API_KEY", "Orchestrator"),
+    ("CYPHER_API_KEY", "Cypher"),
+]
+
+HEALTH_CHECK_EXTERNAL_TOOLS = [
+    ("ripgrep", "rg"),
+    ("cmake", "cmake"),
+]
+
+SHELL_CMD_WHERE = "where"
+SHELL_CMD_WHICH = "which"

--- a/codebase_rag/schemas.py
+++ b/codebase_rag/schemas.py
@@ -79,3 +79,10 @@ class FileCreationResult(BaseModel):
         if self.error_message is not None:
             self.success = False
         return self
+
+
+class HealthCheckResult(BaseModel):
+    name: str
+    passed: bool
+    message: str
+    error: str | None = None

--- a/codebase_rag/tools/health_checker.py
+++ b/codebase_rag/tools/health_checker.py
@@ -1,0 +1,177 @@
+import os
+import subprocess
+from dataclasses import dataclass
+
+import mgclient  # type: ignore
+
+from ..config import settings
+
+
+@dataclass
+class HealthCheckResult:
+    """Result of a single health check."""
+
+    name: str
+    passed: bool
+    message: str
+    error: str | None = None
+
+
+class HealthChecker:
+    """Verifies all critical dependencies and configurations."""
+
+    def __init__(self):
+        self.results: list[HealthCheckResult] = []
+
+    def check_docker(self) -> HealthCheckResult:
+        try:
+            result = subprocess.run(
+                ["docker", "info", "--format", "{{.ServerVersion}}"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+            if result.returncode == 0:
+                version = result.stdout.strip()
+                return HealthCheckResult(
+                    name="Docker daemon is running",
+                    passed=True,
+                    message=f"Running (version {version})",
+                )
+            else:
+                return HealthCheckResult(
+                    name="Docker daemon is not running",
+                    passed=False,
+                    message="Not responding",
+                    error=result.stderr.strip() or "Non-zero exit code",
+                )
+        except FileNotFoundError:
+            return HealthCheckResult(
+                name="Docker daemon is not running",
+                passed=False,
+                message="Not installed",
+                error="docker command not found in PATH",
+            )
+        except Exception as e:
+            return HealthCheckResult(
+                name="Docker daemon is not running",
+                passed=False,
+                message="Check failed",
+                error=str(e),
+            )
+
+    def check_memgraph_connection(self) -> HealthCheckResult:
+        """Check if Memgraph is accessible and can execute a simple query."""
+        conn = None
+        cursor = None
+        try:
+            conn = mgclient.connect(
+                host=settings.MEMGRAPH_HOST,
+                port=settings.MEMGRAPH_PORT,
+            )
+
+            cursor = conn.cursor()
+            cursor.execute("RETURN 1 AS test;")
+            list(cursor.fetchall())
+
+            return HealthCheckResult(
+                name="Memgraph connection successful",
+                passed=True,
+                message=f"Connected and responsive at {settings.MEMGRAPH_HOST}:{settings.MEMGRAPH_PORT}",
+            )
+
+        except mgclient.MemgraphError as e:
+            return HealthCheckResult(
+                name="Memgraph connection failed",
+                passed=False,
+                message="Connection or query failed",
+                error=f"Memgraph error: {str(e)}",
+            )
+        except Exception as e:
+            return HealthCheckResult(
+                name="Memgraph connection failed",
+                passed=False,
+                message="Unexpected failure",
+                error=str(e),
+            )
+        finally:
+            if cursor is not None:
+                try:
+                    cursor.close()
+                except Exception:
+                    pass
+            if conn is not None:
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+
+    def check_api_key(self, env_name: str, display_name: str) -> HealthCheckResult:
+        value = os.getenv(env_name) or getattr(
+            settings, env_name.replace("_API_KEY", "_API_KEY"), None
+        )
+        passed = bool(value)
+        return HealthCheckResult(
+            name=f"{display_name} API key is set"
+            if passed
+            else f"{display_name} API key is not set",
+            passed=passed,
+            message="Configured" if passed else "Not set",
+        )
+
+    def check_api_keys(self) -> list[HealthCheckResult]:
+        return [
+            self.check_api_key("GEMINI_API_KEY", "Gemini"),
+            self.check_api_key("OPENAI_API_KEY", "OpenAI"),
+            self.check_api_key("ORCHESTRATOR_API_KEY", "Orchestrator"),
+            self.check_api_key("CYPHER_API_KEY", "Cypher"),
+        ]
+
+    def check_external_tool(
+        self, tool_name: str, command: str | None = None
+    ) -> HealthCheckResult:
+        cmd = command or tool_name
+        check_cmd = ["where" if os.name == "nt" else "which", cmd]
+
+        try:
+            result = subprocess.run(
+                check_cmd,
+                capture_output=True,
+                timeout=4,
+                check=False,
+            )
+            if result.returncode == 0:
+                path = result.stdout.decode().strip().splitlines()[0]
+                return HealthCheckResult(
+                    name=f"{tool_name} is installed",
+                    passed=True,
+                    message=f"Installed ({path})",
+                )
+            else:
+                return HealthCheckResult(
+                    name=f"{tool_name} is not installed",
+                    passed=False,
+                    message="Not installed",
+                    error=f"'{cmd}' not found in PATH",
+                )
+        except Exception as e:
+            return HealthCheckResult(
+                name=f"{tool_name} is not installed",
+                passed=False,
+                message="Check failed",
+                error=str(e),
+            )
+
+    def run_all_checks(self) -> list[HealthCheckResult]:
+        self.results = []
+        self.results.append(self.check_docker())
+        self.results.append(self.check_memgraph_connection())
+        self.results.extend(self.check_api_keys())
+        self.results.append(self.check_external_tool("ripgrep", "rg"))
+        self.results.append(self.check_external_tool("cmake"))
+        return self.results
+
+    def get_summary(self) -> tuple[int, int]:
+        passed = sum(1 for r in self.results if r.passed)
+        return passed, len(self.results)

--- a/uv.lock
+++ b/uv.lock
@@ -1026,7 +1026,7 @@ wheels = [
 
 [[package]]
 name = "graph-code"
-version = "0.0.25"
+version = "0.0.27"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Implement a new 'graph-code doctor' CLI command that verifies all critical dependencies and configurations are properly set up. The command checks:

- Docker daemon is running
- Memgraph database connection and responsiveness
- Required API keys (GEMINI, OPENAI, ORCHESTRATOR, CYPHER)
- External tools (ripgrep for code search)

Output displays clear pass/fail status with green checkmarks for passing checks and red x's for failures. The command exits with code 1 if any checks fail, enabling integration with CI/CD pipelines.

Changes:
- codebase_rag/tools/health_checker.py: New HealthChecker class
- codebase_rag/cli.py: New doctor command with Rich formatting
- codebase_rag/cli_help.py: Added doctor command documentation