### PR TITLE
fix(cpp): use definition line numbers for out-of-class methods

### DIFF
--- a/codebase_rag/language_spec.py
+++ b/codebase_rag/language_spec.py
@@ -352,11 +352,11 @@ LANGUAGE_SPECS: dict[cs.SupportedLanguage, LanguageSpec] = {
         import_from_node_types=cs.CPP_IMPORT_NODES,
         package_indicators=cs.SPEC_CPP_PACKAGE_INDICATORS,
         function_query="""
+    (field_declaration) @function
+    (declaration) @function
     (function_definition) @function
     (template_declaration (function_definition)) @function
     (lambda_expression) @function
-    (field_declaration) @function
-    (declaration) @function
     """,
         class_query="""
     (class_specifier) @class

--- a/codebase_rag/parsers/cpp/utils.py
+++ b/codebase_rag/parsers/cpp/utils.py
@@ -350,6 +350,4 @@ def extract_class_name_from_out_of_class_method_qualified(
     names = _collect_all_names_from_qualified_id(qualified_id)
     if len(names) >= 2:
         return cs.SEPARATOR_DOUBLE_COLON.join(names[:-1])
-    if names:
-        return names[0]
     return None

--- a/codebase_rag/parsers/cpp/utils.py
+++ b/codebase_rag/parsers/cpp/utils.py
@@ -337,7 +337,7 @@ def _collect_all_names_from_qualified_id(node: Node) -> list[str]:
             cs.CppNodeType.IDENTIFIER,
             cs.TS_TYPE_IDENTIFIER,
         ):
-            if child.text and (name := safe_decode_text(child)):
+            if name := safe_decode_text(child):
                 names.append(name)
         elif child.type == cs.CppNodeType.QUALIFIED_IDENTIFIER:
             names.extend(_collect_all_names_from_qualified_id(child))

--- a/codebase_rag/tests/test_cpp_line_numbers.py
+++ b/codebase_rag/tests/test_cpp_line_numbers.py
@@ -1,0 +1,665 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag.constants import SEPARATOR_DOT
+from codebase_rag.tests.conftest import get_nodes, run_updater
+
+
+def _get_method_props(
+    mock_ingestor: MagicMock, class_name: str, method_name: str
+) -> dict | None:
+    method_calls = get_nodes(mock_ingestor, "Method")
+    result = None
+    for call in method_calls:
+        props = call[0][1]
+        qn = props.get("qualified_name", "")
+        parts = qn.split(SEPARATOR_DOT)
+        if class_name in parts and parts[-1] == method_name:
+            if result is None:
+                result = props
+            else:
+                existing_span = result.get("end_line", 0) - result.get("start_line", 0)
+                new_span = props.get("end_line", 0) - props.get("start_line", 0)
+                if new_span > existing_span:
+                    result = props
+    return result
+
+
+def _get_all_methods(mock_ingestor: MagicMock) -> list[dict]:
+    method_calls = get_nodes(mock_ingestor, "Method")
+    methods_by_qn: dict[str, dict] = {}
+    for call in method_calls:
+        props = call[0][1]
+        qn = props.get("qualified_name", "")
+        if qn not in methods_by_qn:
+            methods_by_qn[qn] = props
+        else:
+            existing = methods_by_qn[qn]
+            existing_span = existing.get("end_line", 0) - existing.get("start_line", 0)
+            new_span = props.get("end_line", 0) - props.get("start_line", 0)
+            if new_span > existing_span:
+                methods_by_qn[qn] = props
+    return list(methods_by_qn.values())
+
+
+@pytest.fixture
+def cpp_line_numbers_project(temp_repo: Path) -> Path:
+    project_path = temp_repo / "cpp_line_numbers_test"
+    project_path.mkdir()
+    return project_path
+
+
+class TestIssue194OutOfClassLineNumbers:
+    def test_simple_out_of_class_method_has_definition_line_numbers(
+        self,
+        cpp_line_numbers_project: Path,
+        mock_ingestor: MagicMock,
+    ) -> None:
+        test_file = cpp_line_numbers_project / "simple.cpp"
+        test_file.write_text(
+            """\
+class QCMakeCacheView {
+public:
+    bool setSearchFilter(QString const& s);
+};
+
+bool QCMakeCacheView::setSearchFilter(QString const& s)
+{
+    return true;
+}
+"""
+        )
+
+        run_updater(cpp_line_numbers_project, mock_ingestor)
+
+        props = _get_method_props(mock_ingestor, "QCMakeCacheView", "setSearchFilter")
+
+        assert props is not None, "Method should exist"
+        assert props["start_line"] == 6, (
+            f"Expected start_line=6 (definition), got {props['start_line']}"
+        )
+        assert props["end_line"] == 9, (
+            f"Expected end_line=9 (definition), got {props['end_line']}"
+        )
+
+    def test_multiple_out_of_class_methods_have_correct_lines(
+        self,
+        cpp_line_numbers_project: Path,
+        mock_ingestor: MagicMock,
+    ) -> None:
+        test_file = cpp_line_numbers_project / "multiple.cpp"
+        test_file.write_text(
+            """\
+class Calculator {
+public:
+    int add(int a, int b);
+    int subtract(int a, int b);
+    int multiply(int a, int b);
+};
+
+int Calculator::add(int a, int b) {
+    return a + b;
+}
+
+int Calculator::subtract(int a, int b) {
+    return a - b;
+}
+
+int Calculator::multiply(int a, int b) {
+    return a * b;
+}
+"""
+        )
+
+        run_updater(cpp_line_numbers_project, mock_ingestor)
+
+        add_props = _get_method_props(mock_ingestor, "Calculator", "add")
+        subtract_props = _get_method_props(mock_ingestor, "Calculator", "subtract")
+        multiply_props = _get_method_props(mock_ingestor, "Calculator", "multiply")
+
+        assert add_props is not None
+        assert add_props["start_line"] == 8
+        assert add_props["end_line"] == 10
+
+        assert subtract_props is not None
+        assert subtract_props["start_line"] == 12
+        assert subtract_props["end_line"] == 14
+
+        assert multiply_props is not None
+        assert multiply_props["start_line"] == 16
+        assert multiply_props["end_line"] == 18
+
+    def test_constructor_out_of_class_has_definition_line_numbers(
+        self,
+        cpp_line_numbers_project: Path,
+        mock_ingestor: MagicMock,
+    ) -> None:
+        test_file = cpp_line_numbers_project / "constructor.cpp"
+        test_file.write_text(
+            """\
+class MyClass {
+public:
+    MyClass(int value);
+private:
+    int value_;
+};
+
+MyClass::MyClass(int value) : value_(value) {
+    // constructor body
+}
+"""
+        )
+
+        run_updater(cpp_line_numbers_project, mock_ingestor)
+
+        props = _get_method_props(mock_ingestor, "MyClass", "MyClass")
+
+        assert props is not None, "Constructor should exist"
+        assert props["start_line"] == 8, (
+            f"Expected start_line=8 (definition), got {props['start_line']}"
+        )
+        assert props["end_line"] == 10, (
+            f"Expected end_line=10 (definition), got {props['end_line']}"
+        )
+
+    def test_destructor_out_of_class_has_definition_line_numbers(
+        self,
+        cpp_line_numbers_project: Path,
+        mock_ingestor: MagicMock,
+    ) -> None:
+        test_file = cpp_line_numbers_project / "destructor.cpp"
+        test_file.write_text(
+            """\
+class Resource {
+public:
+    ~Resource();
+private:
+    int* data_;
+};
+
+Resource::~Resource() {
+    delete data_;
+}
+"""
+        )
+
+        run_updater(cpp_line_numbers_project, mock_ingestor)
+
+        props = _get_method_props(mock_ingestor, "Resource", "~Resource")
+
+        assert props is not None, "Destructor should exist"
+        assert props["start_line"] == 8, (
+            f"Expected start_line=8 (definition), got {props['start_line']}"
+        )
+        assert props["end_line"] == 10, (
+            f"Expected end_line=10 (definition), got {props['end_line']}"
+        )
+
+
+class TestTemplateOutOfClassLineNumbers:
+    def test_template_method_has_definition_line_numbers(
+        self,
+        cpp_line_numbers_project: Path,
+        mock_ingestor: MagicMock,
+    ) -> None:
+        test_file = cpp_line_numbers_project / "template.cpp"
+        test_file.write_text(
+            """\
+template<typename T>
+class Container {
+public:
+    void add(const T& item);
+    T get(int index) const;
+};
+
+template<typename T>
+void Container<T>::add(const T& item) {
+    // add implementation
+}
+
+template<typename T>
+T Container<T>::get(int index) const {
+    return T();
+}
+"""
+        )
+
+        run_updater(cpp_line_numbers_project, mock_ingestor)
+
+        add_props = _get_method_props(mock_ingestor, "Container", "add")
+        get_props = _get_method_props(mock_ingestor, "Container", "get")
+
+        assert add_props is not None, "add method should exist"
+        assert add_props["start_line"] == 8, (
+            f"Expected start_line=8, got {add_props['start_line']}"
+        )
+        assert add_props["end_line"] == 11, (
+            f"Expected end_line=11, got {add_props['end_line']}"
+        )
+
+        assert get_props is not None, "get method should exist"
+        assert get_props["start_line"] == 13, (
+            f"Expected start_line=13, got {get_props['start_line']}"
+        )
+        assert get_props["end_line"] == 16, (
+            f"Expected end_line=16, got {get_props['end_line']}"
+        )
+
+
+class TestInlineMethodLineNumbers:
+    def test_inline_method_has_correct_line_numbers(
+        self,
+        cpp_line_numbers_project: Path,
+        mock_ingestor: MagicMock,
+    ) -> None:
+        test_file = cpp_line_numbers_project / "inline.cpp"
+        test_file.write_text(
+            """\
+class Simple {
+public:
+    int getValue() const { return value_; }
+    void setValue(int v) { value_ = v; }
+private:
+    int value_;
+};
+"""
+        )
+
+        run_updater(cpp_line_numbers_project, mock_ingestor)
+
+        get_props = _get_method_props(mock_ingestor, "Simple", "getValue")
+        set_props = _get_method_props(mock_ingestor, "Simple", "setValue")
+
+        assert get_props is not None
+        assert get_props["start_line"] == 3
+        assert get_props["end_line"] == 3
+
+        assert set_props is not None
+        assert set_props["start_line"] == 4
+        assert set_props["end_line"] == 4
+
+    def test_multiline_inline_method_has_correct_lines(
+        self,
+        cpp_line_numbers_project: Path,
+        mock_ingestor: MagicMock,
+    ) -> None:
+        test_file = cpp_line_numbers_project / "multiline_inline.cpp"
+        test_file.write_text(
+            """\
+class Complex {
+public:
+    int compute(int x) {
+        int result = x * 2;
+        result += 10;
+        return result;
+    }
+};
+"""
+        )
+
+        run_updater(cpp_line_numbers_project, mock_ingestor)
+
+        props = _get_method_props(mock_ingestor, "Complex", "compute")
+
+        assert props is not None
+        assert props["start_line"] == 3
+        assert props["end_line"] == 7
+
+
+class TestMixedInlineAndOutOfClassLineNumbers:
+    def test_mixed_methods_have_correct_line_numbers(
+        self,
+        cpp_line_numbers_project: Path,
+        mock_ingestor: MagicMock,
+    ) -> None:
+        test_file = cpp_line_numbers_project / "mixed.cpp"
+        test_file.write_text(
+            """\
+class MixedClass {
+public:
+    int inlineMethod() { return 42; }
+    void outOfClassMethod();
+    double anotherInline() const { return 3.14; }
+};
+
+void MixedClass::outOfClassMethod() {
+    // implementation
+    return;
+}
+"""
+        )
+
+        run_updater(cpp_line_numbers_project, mock_ingestor)
+
+        inline1_props = _get_method_props(mock_ingestor, "MixedClass", "inlineMethod")
+        out_of_class_props = _get_method_props(
+            mock_ingestor, "MixedClass", "outOfClassMethod"
+        )
+        inline2_props = _get_method_props(mock_ingestor, "MixedClass", "anotherInline")
+
+        assert inline1_props is not None
+        assert inline1_props["start_line"] == 3
+        assert inline1_props["end_line"] == 3
+
+        assert out_of_class_props is not None
+        assert out_of_class_props["start_line"] == 8
+        assert out_of_class_props["end_line"] == 11
+
+        assert inline2_props is not None
+        assert inline2_props["start_line"] == 5
+        assert inline2_props["end_line"] == 5
+
+
+class TestNestedClassOutOfClassLineNumbers:
+    def test_nested_class_method_has_definition_line_numbers(
+        self,
+        cpp_line_numbers_project: Path,
+        mock_ingestor: MagicMock,
+    ) -> None:
+        test_file = cpp_line_numbers_project / "nested.cpp"
+        test_file.write_text(
+            """\
+class Outer {
+public:
+    class Inner {
+    public:
+        void innerMethod();
+    };
+    void outerMethod();
+};
+
+void Outer::outerMethod() {
+    // outer implementation
+}
+
+void Outer::Inner::innerMethod() {
+    // inner implementation
+}
+"""
+        )
+
+        run_updater(cpp_line_numbers_project, mock_ingestor)
+
+        outer_props = _get_method_props(mock_ingestor, "Outer", "outerMethod")
+        inner_props = _get_method_props(mock_ingestor, "Inner", "innerMethod")
+
+        assert outer_props is not None
+        assert outer_props["start_line"] == 10
+        assert outer_props["end_line"] == 12
+
+        assert inner_props is not None
+        assert inner_props["start_line"] == 14
+        assert inner_props["end_line"] == 16
+
+
+class TestNamespacedClassOutOfClassLineNumbers:
+    def test_namespaced_class_method_has_definition_line_numbers(
+        self,
+        cpp_line_numbers_project: Path,
+        mock_ingestor: MagicMock,
+    ) -> None:
+        test_file = cpp_line_numbers_project / "namespaced.cpp"
+        test_file.write_text(
+            """\
+namespace MyNamespace {
+
+class MyClass {
+public:
+    void method();
+};
+
+void MyClass::method() {
+    // implementation
+}
+
+}
+"""
+        )
+
+        run_updater(cpp_line_numbers_project, mock_ingestor)
+
+        props = _get_method_props(mock_ingestor, "MyClass", "method")
+
+        assert props is not None
+        assert props["start_line"] == 8
+        assert props["end_line"] == 10
+
+    def test_deeply_nested_namespace_has_correct_lines(
+        self,
+        cpp_line_numbers_project: Path,
+        mock_ingestor: MagicMock,
+    ) -> None:
+        test_file = cpp_line_numbers_project / "deep_namespace.cpp"
+        test_file.write_text(
+            """\
+namespace Level1 {
+namespace Level2 {
+namespace Level3 {
+
+class DeepClass {
+public:
+    void deepMethod();
+};
+
+void DeepClass::deepMethod() {
+    // deep implementation
+}
+
+}
+}
+}
+"""
+        )
+
+        run_updater(cpp_line_numbers_project, mock_ingestor)
+
+        props = _get_method_props(mock_ingestor, "DeepClass", "deepMethod")
+
+        assert props is not None
+        assert props["start_line"] == 10
+        assert props["end_line"] == 12
+
+
+class TestOperatorOverloadingLineNumbers:
+    def test_operator_methods_have_definition_line_numbers(
+        self,
+        cpp_line_numbers_project: Path,
+        mock_ingestor: MagicMock,
+    ) -> None:
+        test_file = cpp_line_numbers_project / "operators.cpp"
+        test_file.write_text(
+            """\
+class Vector {
+public:
+    Vector operator+(const Vector& other) const;
+    Vector operator-(const Vector& other) const;
+    bool operator==(const Vector& other) const;
+};
+
+Vector Vector::operator+(const Vector& other) const {
+    return Vector();
+}
+
+Vector Vector::operator-(const Vector& other) const {
+    return Vector();
+}
+
+bool Vector::operator==(const Vector& other) const {
+    return true;
+}
+"""
+        )
+
+        run_updater(cpp_line_numbers_project, mock_ingestor)
+
+        methods = _get_all_methods(mock_ingestor)
+        operator_methods = [
+            m for m in methods if "operator" in m.get("name", "").lower()
+        ]
+
+        assert len(operator_methods) >= 3, (
+            f"Expected at least 3 operator methods, got {len(operator_methods)}"
+        )
+
+        for method in operator_methods:
+            assert method["start_line"] >= 8, (
+                f"Operator method should have definition line >= 8, "
+                f"got {method['start_line']}"
+            )
+
+
+class TestDeclarationOnlyMethods:
+    def test_declaration_only_methods_have_declaration_line_numbers(
+        self,
+        cpp_line_numbers_project: Path,
+        mock_ingestor: MagicMock,
+    ) -> None:
+        test_file = cpp_line_numbers_project / "declaration_only.cpp"
+        test_file.write_text(
+            """\
+class HeaderOnlyClass {
+public:
+    void method1();
+    int method2(int x);
+    void method3(const std::string& s);
+};
+"""
+        )
+
+        run_updater(cpp_line_numbers_project, mock_ingestor)
+
+        method1_props = _get_method_props(mock_ingestor, "HeaderOnlyClass", "method1")
+        method2_props = _get_method_props(mock_ingestor, "HeaderOnlyClass", "method2")
+        method3_props = _get_method_props(mock_ingestor, "HeaderOnlyClass", "method3")
+
+        assert method1_props is not None
+        assert method1_props["start_line"] == 3
+        assert method1_props["end_line"] == 3
+
+        assert method2_props is not None
+        assert method2_props["start_line"] == 4
+        assert method2_props["end_line"] == 4
+
+        assert method3_props is not None
+        assert method3_props["start_line"] == 5
+        assert method3_props["end_line"] == 5
+
+
+class TestStructMethodLineNumbers:
+    def test_struct_out_of_class_method_has_definition_lines(
+        self,
+        cpp_line_numbers_project: Path,
+        mock_ingestor: MagicMock,
+    ) -> None:
+        test_file = cpp_line_numbers_project / "struct_methods.cpp"
+        test_file.write_text(
+            """\
+struct Point {
+    double x, y;
+    double distance(const Point& other) const;
+    Point operator+(const Point& other) const;
+};
+
+double Point::distance(const Point& other) const {
+    double dx = x - other.x;
+    double dy = y - other.y;
+    return dx * dx + dy * dy;
+}
+
+Point Point::operator+(const Point& other) const {
+    return Point{x + other.x, y + other.y};
+}
+"""
+        )
+
+        run_updater(cpp_line_numbers_project, mock_ingestor)
+
+        distance_props = _get_method_props(mock_ingestor, "Point", "distance")
+
+        assert distance_props is not None
+        assert distance_props["start_line"] == 7
+        assert distance_props["end_line"] == 11
+
+
+class TestConstAndStaticMethodLineNumbers:
+    def test_const_method_has_correct_lines(
+        self,
+        cpp_line_numbers_project: Path,
+        mock_ingestor: MagicMock,
+    ) -> None:
+        test_file = cpp_line_numbers_project / "const_method.cpp"
+        test_file.write_text(
+            """\
+class ConstExample {
+public:
+    int getValue() const;
+    void setValue(int v);
+private:
+    int value_;
+};
+
+int ConstExample::getValue() const {
+    return value_;
+}
+
+void ConstExample::setValue(int v) {
+    value_ = v;
+}
+"""
+        )
+
+        run_updater(cpp_line_numbers_project, mock_ingestor)
+
+        get_props = _get_method_props(mock_ingestor, "ConstExample", "getValue")
+        set_props = _get_method_props(mock_ingestor, "ConstExample", "setValue")
+
+        assert get_props is not None
+        assert get_props["start_line"] == 9
+        assert get_props["end_line"] == 11
+
+        assert set_props is not None
+        assert set_props["start_line"] == 13
+        assert set_props["end_line"] == 15
+
+    def test_static_method_has_correct_lines(
+        self,
+        cpp_line_numbers_project: Path,
+        mock_ingestor: MagicMock,
+    ) -> None:
+        test_file = cpp_line_numbers_project / "static_method.cpp"
+        test_file.write_text(
+            """\
+class StaticExample {
+public:
+    static int getCount();
+    static void resetCount();
+private:
+    static int count_;
+};
+
+int StaticExample::getCount() {
+    return count_;
+}
+
+void StaticExample::resetCount() {
+    count_ = 0;
+}
+"""
+        )
+
+        run_updater(cpp_line_numbers_project, mock_ingestor)
+
+        get_props = _get_method_props(mock_ingestor, "StaticExample", "getCount")
+        reset_props = _get_method_props(mock_ingestor, "StaticExample", "resetCount")
+
+        assert get_props is not None
+        assert get_props["start_line"] == 9
+        assert get_props["end_line"] == 11
+
+        assert reset_props is not None
+        assert reset_props["start_line"] == 13
+        assert reset_props["end_line"] == 15

--- a/codebase_rag/tests/test_cpp_out_of_class_utils.py
+++ b/codebase_rag/tests/test_cpp_out_of_class_utils.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.parsers.cpp import utils as cpp_utils
+
+
+@pytest.fixture(scope="module")
+def cpp_parser():
+    parsers, _ = load_parsers()
+    return parsers.get(cs.SupportedLanguage.CPP)
+
+
+def parse_cpp(cpp_parser, code: str):
+    return cpp_parser.parse(code.encode())
+
+
+def find_nodes_by_type(node, target_type: str) -> list:
+    results = []
+    if node.type == target_type:
+        results.append(node)
+    for child in node.children:
+        results.extend(find_nodes_by_type(child, target_type))
+    return results
+
+
+class TestIsOutOfClassMethodDefinition:
+    def test_simple_out_of_class_method(self, cpp_parser) -> None:
+        code = """\
+class Foo {
+    void bar();
+};
+
+void Foo::bar() {
+    return;
+}
+"""
+        tree = parse_cpp(cpp_parser, code)
+        func_defs = find_nodes_by_type(tree.root_node, "function_definition")
+
+        assert len(func_defs) == 1
+        assert cpp_utils.is_out_of_class_method_definition(func_defs[0]) is True
+
+    def test_inline_method_not_out_of_class(self, cpp_parser) -> None:
+        code = """\
+class Foo {
+    void bar() { return; }
+};
+"""
+        tree = parse_cpp(cpp_parser, code)
+        func_defs = find_nodes_by_type(tree.root_node, "function_definition")
+
+        assert len(func_defs) == 1
+        assert cpp_utils.is_out_of_class_method_definition(func_defs[0]) is False
+
+    def test_standalone_function_not_out_of_class(self, cpp_parser) -> None:
+        code = """\
+void standalone() {
+    return;
+}
+"""
+        tree = parse_cpp(cpp_parser, code)
+        func_defs = find_nodes_by_type(tree.root_node, "function_definition")
+
+        assert len(func_defs) == 1
+        assert cpp_utils.is_out_of_class_method_definition(func_defs[0]) is False
+
+    def test_namespaced_function_not_out_of_class(self, cpp_parser) -> None:
+        code = """\
+namespace MyNs {
+void func() {
+    return;
+}
+}
+"""
+        tree = parse_cpp(cpp_parser, code)
+        func_defs = find_nodes_by_type(tree.root_node, "function_definition")
+
+        assert len(func_defs) == 1
+        assert cpp_utils.is_out_of_class_method_definition(func_defs[0]) is False
+
+    def test_template_out_of_class_method(self, cpp_parser) -> None:
+        code = """\
+template<typename T>
+class Container {
+    void add(const T& item);
+};
+
+template<typename T>
+void Container<T>::add(const T& item) {
+    // impl
+}
+"""
+        tree = parse_cpp(cpp_parser, code)
+        template_decls = find_nodes_by_type(tree.root_node, "template_declaration")
+
+        method_template = None
+        for td in template_decls:
+            func_defs = find_nodes_by_type(td, "function_definition")
+            if func_defs:
+                method_template = td
+                break
+
+        assert method_template is not None
+        assert cpp_utils.is_out_of_class_method_definition(method_template) is True
+
+    def test_nested_class_out_of_class_method(self, cpp_parser) -> None:
+        code = """\
+class Outer {
+    class Inner {
+        void method();
+    };
+};
+
+void Outer::Inner::method() {
+    return;
+}
+"""
+        tree = parse_cpp(cpp_parser, code)
+        func_defs = find_nodes_by_type(tree.root_node, "function_definition")
+
+        outer_func_defs = [f for f in func_defs if f.parent.type == "translation_unit"]
+        assert len(outer_func_defs) == 1
+        assert cpp_utils.is_out_of_class_method_definition(outer_func_defs[0]) is True
+
+    def test_lambda_not_out_of_class(self, cpp_parser) -> None:
+        code = """\
+auto fn = []() { return 42; };
+"""
+        tree = parse_cpp(cpp_parser, code)
+        lambdas = find_nodes_by_type(tree.root_node, "lambda_expression")
+
+        assert len(lambdas) == 1
+        assert cpp_utils.is_out_of_class_method_definition(lambdas[0]) is False
+
+
+class TestExtractClassNameFromOutOfClassMethod:
+    def test_simple_class_name(self, cpp_parser) -> None:
+        code = """\
+class Calculator {
+    int add(int a, int b);
+};
+
+int Calculator::add(int a, int b) {
+    return a + b;
+}
+"""
+        tree = parse_cpp(cpp_parser, code)
+        func_defs = find_nodes_by_type(tree.root_node, "function_definition")
+
+        assert len(func_defs) == 1
+        class_name = cpp_utils.extract_class_name_from_out_of_class_method(func_defs[0])
+        assert class_name == "Calculator"
+
+    def test_nested_class_name(self, cpp_parser) -> None:
+        code = """\
+class Outer {
+    class Inner {
+        void method();
+    };
+};
+
+void Outer::Inner::method() {
+    return;
+}
+"""
+        tree = parse_cpp(cpp_parser, code)
+        func_defs = find_nodes_by_type(tree.root_node, "function_definition")
+
+        outer_func_defs = [f for f in func_defs if f.parent.type == "translation_unit"]
+        assert len(outer_func_defs) == 1
+        class_name = cpp_utils.extract_class_name_from_out_of_class_method(
+            outer_func_defs[0]
+        )
+        assert class_name == "Outer::Inner"
+
+    def test_template_class_name(self, cpp_parser) -> None:
+        code = """\
+template<typename T>
+class Container {
+    void add(const T& item);
+};
+
+template<typename T>
+void Container<T>::add(const T& item) {
+    // impl
+}
+"""
+        tree = parse_cpp(cpp_parser, code)
+        template_decls = find_nodes_by_type(tree.root_node, "template_declaration")
+
+        method_template = None
+        for td in template_decls:
+            func_defs = find_nodes_by_type(td, "function_definition")
+            if func_defs:
+                method_template = td
+                break
+
+        assert method_template is not None
+        class_name = cpp_utils.extract_class_name_from_out_of_class_method(
+            method_template
+        )
+        assert class_name == "Container"
+
+    def test_struct_class_name(self, cpp_parser) -> None:
+        code = """\
+struct Point {
+    double distance(const Point& other) const;
+};
+
+double Point::distance(const Point& other) const {
+    return 0.0;
+}
+"""
+        tree = parse_cpp(cpp_parser, code)
+        func_defs = find_nodes_by_type(tree.root_node, "function_definition")
+
+        assert len(func_defs) == 1
+        class_name = cpp_utils.extract_class_name_from_out_of_class_method(func_defs[0])
+        assert class_name == "Point"
+
+    def test_returns_none_for_standalone_function(self, cpp_parser) -> None:
+        code = """\
+void standalone() {
+    return;
+}
+"""
+        tree = parse_cpp(cpp_parser, code)
+        func_defs = find_nodes_by_type(tree.root_node, "function_definition")
+
+        assert len(func_defs) == 1
+        class_name = cpp_utils.extract_class_name_from_out_of_class_method(func_defs[0])
+        assert class_name is None
+
+    def test_returns_none_for_inline_method(self, cpp_parser) -> None:
+        code = """\
+class Foo {
+    void bar() { return; }
+};
+"""
+        tree = parse_cpp(cpp_parser, code)
+        func_defs = find_nodes_by_type(tree.root_node, "function_definition")
+
+        assert len(func_defs) == 1
+        class_name = cpp_utils.extract_class_name_from_out_of_class_method(func_defs[0])
+        assert class_name is None
+
+
+class TestExtractFunctionNameForOutOfClass:
+    def test_simple_method_name(self, cpp_parser) -> None:
+        code = """\
+class Foo {
+    void bar();
+};
+
+void Foo::bar() {
+    return;
+}
+"""
+        tree = parse_cpp(cpp_parser, code)
+        func_defs = find_nodes_by_type(tree.root_node, "function_definition")
+
+        assert len(func_defs) == 1
+        method_name = cpp_utils.extract_function_name(func_defs[0])
+        assert method_name == "bar"
+
+    def test_constructor_name(self, cpp_parser) -> None:
+        code = """\
+class MyClass {
+    MyClass();
+};
+
+MyClass::MyClass() {
+    // impl
+}
+"""
+        tree = parse_cpp(cpp_parser, code)
+        func_defs = find_nodes_by_type(tree.root_node, "function_definition")
+
+        assert len(func_defs) == 1
+        method_name = cpp_utils.extract_function_name(func_defs[0])
+        assert method_name == "MyClass"
+
+    def test_destructor_name(self, cpp_parser) -> None:
+        code = """\
+class MyClass {
+    ~MyClass();
+};
+
+MyClass::~MyClass() {
+    // impl
+}
+"""
+        tree = parse_cpp(cpp_parser, code)
+        func_defs = find_nodes_by_type(tree.root_node, "function_definition")
+
+        assert len(func_defs) == 1
+        method_name = cpp_utils.extract_function_name(func_defs[0])
+        assert method_name == "~MyClass"
+
+    def test_operator_plus_name(self, cpp_parser) -> None:
+        code = """\
+class Vector {
+    Vector operator+(const Vector& other) const;
+};
+
+Vector Vector::operator+(const Vector& other) const {
+    return Vector();
+}
+"""
+        tree = parse_cpp(cpp_parser, code)
+        func_defs = find_nodes_by_type(tree.root_node, "function_definition")
+
+        assert len(func_defs) == 1
+        method_name = cpp_utils.extract_function_name(func_defs[0])
+        assert "operator" in method_name
+
+    def test_template_method_name(self, cpp_parser) -> None:
+        code = """\
+template<typename T>
+class Container {
+    void push(const T& item);
+};
+
+template<typename T>
+void Container<T>::push(const T& item) {
+    // impl
+}
+"""
+        tree = parse_cpp(cpp_parser, code)
+        template_decls = find_nodes_by_type(tree.root_node, "template_declaration")
+
+        method_template = None
+        for td in template_decls:
+            func_defs = find_nodes_by_type(td, "function_definition")
+            if func_defs:
+                method_template = td
+                break
+
+        assert method_template is not None
+        method_name = cpp_utils.extract_function_name(method_template)
+        assert method_name == "push"
+
+
+class TestGetInnerFunctionNode:
+    def test_returns_same_node_for_function_definition(self, cpp_parser) -> None:
+        code = """\
+void Foo::bar() {
+    return;
+}
+"""
+        tree = parse_cpp(cpp_parser, code)
+        func_defs = find_nodes_by_type(tree.root_node, "function_definition")
+
+        assert len(func_defs) == 1
+        inner = cpp_utils._get_inner_function_node(func_defs[0])
+        assert inner == func_defs[0]
+
+    def test_returns_inner_function_for_template(self, cpp_parser) -> None:
+        code = """\
+template<typename T>
+void Container<T>::add(const T& item) {
+    // impl
+}
+"""
+        tree = parse_cpp(cpp_parser, code)
+        template_decls = find_nodes_by_type(tree.root_node, "template_declaration")
+
+        assert len(template_decls) == 1
+        inner = cpp_utils._get_inner_function_node(template_decls[0])
+        assert inner.type == "function_definition"
+        assert inner != template_decls[0]

--- a/uv.lock
+++ b/uv.lock
@@ -1026,7 +1026,7 @@ wheels = [
 
 [[package]]
 name = "graph-code"
-version = "0.0.29"
+version = "0.0.30"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Add helper functions to detect and handle out-of-class C++ method definitions
- Extract correct line numbers from method definitions instead of declarations
- Fix nested class name extraction (e.g., `Outer::Inner` was returning just `Outer`)
- Normalize `::` to `.` in qualified names for proper MERGE matching

Fixes #194

## Test plan
- [x] Added 20 unit tests for helper functions (`test_cpp_out_of_class_utils.py`)
- [x] Added 16 integration tests for line number correctness (`test_cpp_line_numbers.py`)
- [x] All 36 new tests pass
- [x] Full test suite passes