### PR TITLE
fix: Update Memgraph index 

### DIFF
--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -99,8 +99,7 @@ def build_constraint_query(label: str, prop: str) -> str:
 
 
 def build_index_query(label: str, prop: str) -> str:
-    """Build a label-property index query for efficient MERGE operations.
-    """
+    """Build a label-property index query for efficient MERGE operations."""
     return f"CREATE INDEX ON :{label}({prop});"
 
 

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -99,7 +99,6 @@ def build_constraint_query(label: str, prop: str) -> str:
 
 
 def build_index_query(label: str, prop: str) -> str:
-    """Build a label-property index query for efficient MERGE operations."""
     return f"CREATE INDEX ON :{label}({prop});"
 
 

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -98,6 +98,12 @@ def build_constraint_query(label: str, prop: str) -> str:
     return f"CREATE CONSTRAINT ON (n:{label}) ASSERT n.{prop} IS UNIQUE;"
 
 
+def build_index_query(label: str, prop: str) -> str:
+    """Build a label-property index query for efficient MERGE operations.
+    """
+    return f"CREATE INDEX ON :{label}({prop});"
+
+
 def build_merge_node_query(label: str, id_key: str) -> str:
     return f"MERGE (n:{label} {{{id_key}: row.id}})\nSET n += row.props"
 

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -168,6 +168,8 @@ MG_DELETING_PROJECT = "--- Deleting project: {project_name} ---"
 MG_PROJECT_DELETED = "--- Project {project_name} deleted. ---"
 MG_ENSURING_CONSTRAINTS = "Ensuring constraints..."
 MG_CONSTRAINTS_DONE = "Constraints checked/created."
+MG_ENSURING_INDEXES = "Ensuring label-property indexes for MERGE performance..."
+MG_INDEXES_DONE = "Indexes checked/created."
 MG_NODE_BUFFER_FLUSH = (
     "Node buffer reached batch size ({size}). Performing incremental flush."
 )

--- a/codebase_rag/services/graph_service.py
+++ b/codebase_rag/services/graph_service.py
@@ -189,17 +189,11 @@ class MemgraphIngestor:
         self._ensure_indexes()
 
     def _ensure_indexes(self) -> None:
-        """Create label-property indexes for efficient MERGE operations.
-
-        In Memgraph, uniqueness constraints do NOT automatically create indexes.
-        Without explicit indexes, MERGE operations perform full scan operations.
-        """
         logger.info(ls.MG_ENSURING_INDEXES)
         for label, prop in NODE_UNIQUE_CONSTRAINTS.items():
             try:
                 self._execute_query(build_index_query(label, prop))
             except Exception:
-                # (H) Index may already exist
                 pass
         logger.info(ls.MG_INDEXES_DONE)
 

--- a/codebase_rag/services/graph_service.py
+++ b/codebase_rag/services/graph_service.py
@@ -192,9 +192,7 @@ class MemgraphIngestor:
         """Create label-property indexes for efficient MERGE operations.
 
         In Memgraph, uniqueness constraints do NOT automatically create indexes.
-        Without explicit indexes, MERGE operations perform full table scans,
-        causing exponential slowdown as the dataset grows (O(n) per MERGE).
-        With indexes, MERGE operations are O(log n).
+        Without explicit indexes, MERGE operations perform full scan operations.
         """
         logger.info(ls.MG_ENSURING_INDEXES)
         for label, prop in NODE_UNIQUE_CONSTRAINTS.items():

--- a/codebase_rag/services/graph_service.py
+++ b/codebase_rag/services/graph_service.py
@@ -199,7 +199,7 @@ class MemgraphIngestor:
             try:
                 self._execute_query(build_index_query(label, prop))
             except Exception:
-                # Index may already exist
+                # (H) Index may already exist
                 pass
         logger.info(ls.MG_INDEXES_DONE)
 

--- a/codebase_rag/tests/test_graph_service.py
+++ b/codebase_rag/tests/test_graph_service.py
@@ -285,8 +285,6 @@ class TestEnsureConstraints:
         with patch.object(ingestor, "_execute_query", side_effect=fail_then_succeed):
             ingestor.ensure_constraints()
 
-        # (H) ensure_constraints creates both constraints AND indexes for each label
-        # (H) (constraints for uniqueness, indexes for MERGE performance)
         expected_queries = len(NODE_UNIQUE_CONSTRAINTS) * 2
         assert call_count == expected_queries
 

--- a/codebase_rag/tests/test_graph_service.py
+++ b/codebase_rag/tests/test_graph_service.py
@@ -285,8 +285,8 @@ class TestEnsureConstraints:
         with patch.object(ingestor, "_execute_query", side_effect=fail_then_succeed):
             ingestor.ensure_constraints()
 
-        # ensure_constraints creates both constraints AND indexes for each label
-        # (constraints for uniqueness, indexes for MERGE performance)
+        # (H) ensure_constraints creates both constraints AND indexes for each label
+        # (H) (constraints for uniqueness, indexes for MERGE performance)
         expected_queries = len(NODE_UNIQUE_CONSTRAINTS) * 2
         assert call_count == expected_queries
 

--- a/codebase_rag/tests/test_graph_service.py
+++ b/codebase_rag/tests/test_graph_service.py
@@ -285,7 +285,10 @@ class TestEnsureConstraints:
         with patch.object(ingestor, "_execute_query", side_effect=fail_then_succeed):
             ingestor.ensure_constraints()
 
-        assert call_count == len(NODE_UNIQUE_CONSTRAINTS)
+        # ensure_constraints creates both constraints AND indexes for each label
+        # (constraints for uniqueness, indexes for MERGE performance)
+        expected_queries = len(NODE_UNIQUE_CONSTRAINTS) * 2
+        assert call_count == expected_queries
 
 
 class TestFlushNodesEdgeCases:

--- a/codebase_rag/tests/test_node_relationship_coverage.py
+++ b/codebase_rag/tests/test_node_relationship_coverage.py
@@ -245,6 +245,26 @@ class TestEnsureConstraintsForAllLabels:
                 f"Missing constraint for {label.value}. Expected query: {expected}"
             )
 
+    def test_ensure_constraints_creates_all_indexes(self) -> None:
+        """Verify that label-property indexes are created for MERGE performance.
+        """
+        ingestor = MemgraphIngestor(host="localhost", port=7687)
+        executed_queries: list[str] = []
+
+        def capture_query(query: str) -> None:
+            executed_queries.append(query)
+
+        with patch.object(ingestor, "_execute_query", side_effect=capture_query):
+            ingestor.ensure_constraints()
+
+        for label in NodeLabel:
+            prop = NODE_UNIQUE_CONSTRAINTS[label.value]
+            expected_index = f"CREATE INDEX ON :{label.value}({prop});"
+            assert expected_index in executed_queries, (
+                f"Missing index for {label.value}. Expected query: {expected_index}. "
+                "Indexes are required for efficient MERGE operations in Memgraph."
+            )
+
 
 class TestImportTimeValidation:
     def test_import_time_validation_catches_missing_keys(self) -> None:

--- a/codebase_rag/tests/test_node_relationship_coverage.py
+++ b/codebase_rag/tests/test_node_relationship_coverage.py
@@ -246,8 +246,7 @@ class TestEnsureConstraintsForAllLabels:
             )
 
     def test_ensure_constraints_creates_all_indexes(self) -> None:
-        """Verify that label-property indexes are created for MERGE performance.
-        """
+        """Verify that label-property indexes are created for MERGE performance."""
         ingestor = MemgraphIngestor(host="localhost", port=7687)
         executed_queries: list[str] = []
 

--- a/codebase_rag/tests/test_node_relationship_coverage.py
+++ b/codebase_rag/tests/test_node_relationship_coverage.py
@@ -246,7 +246,6 @@ class TestEnsureConstraintsForAllLabels:
             )
 
     def test_ensure_constraints_creates_all_indexes(self) -> None:
-        """Verify that label-property indexes are created for MERGE performance."""
         ingestor = MemgraphIngestor(host="localhost", port=7687)
         executed_queries: list[str] = []
 


### PR DESCRIPTION
This PR introduces the label property index since the constraints and indexes are separated in Memgraph storage.

Context on the topic: https://memgraph.com/docs/fundamentals/constraints#uniqueness-constraint  