### PR TITLE
fix: filter embedding generation by project name

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -415,7 +415,8 @@ CYPHER_DEFAULT_LIMIT = 50
 
 CYPHER_QUERY_EMBEDDINGS = """
 MATCH (m:Module)-[:DEFINES]->(n)
-WHERE n:Function OR n:Method
+WHERE (n:Function OR n:Method)
+  AND m.qualified_name STARTS WITH $project_name
 RETURN id(n) AS node_id, n.qualified_name AS qualified_name,
        n.start_line AS start_line, n.end_line AS end_line,
        m.path AS path

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -416,7 +416,7 @@ CYPHER_DEFAULT_LIMIT = 50
 CYPHER_QUERY_EMBEDDINGS = """
 MATCH (m:Module)-[:DEFINES]->(n)
 WHERE (n:Function OR n:Method)
-  AND m.qualified_name STARTS WITH $project_name
+  AND m.qualified_name STARTS WITH $project_name + '.'
 RETURN id(n) AS node_id, n.qualified_name AS qualified_name,
        n.start_line AS start_line, n.end_line AS end_line,
        m.path AS path

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -420,7 +420,6 @@ WHERE (n:Function OR n:Method)
 RETURN id(n) AS node_id, n.qualified_name AS qualified_name,
        n.start_line AS start_line, n.end_line AS end_line,
        m.path AS path
-ORDER BY n.qualified_name
 """
 
 

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -369,7 +369,7 @@ class GraphUpdater:
             logger.info(ls.PASS_4_EMBEDDINGS)
 
             results = self.ingestor.fetch_all(
-                cs.CYPHER_QUERY_EMBEDDINGS, {"project_name": self.project_name}
+                cs.CYPHER_QUERY_EMBEDDINGS, {"project_name": self.project_name + "."}
             )
 
             if not results:

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -368,7 +368,9 @@ class GraphUpdater:
 
             logger.info(ls.PASS_4_EMBEDDINGS)
 
-            results = self.ingestor.fetch_all(cs.CYPHER_QUERY_EMBEDDINGS)
+            results = self.ingestor.fetch_all(
+                cs.CYPHER_QUERY_EMBEDDINGS, {"project_name": self.project_name}
+            )
 
             if not results:
                 logger.info(ls.NO_FUNCTIONS_FOR_EMBEDDING)

--- a/uv.lock
+++ b/uv.lock
@@ -1054,7 +1054,7 @@ wheels = [
 
 [[package]]
 name = "graph-code"
-version = "0.0.36"
+version = "0.0.40"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Fixes cross-repository embedding generation by filtering functions from the current project only. Previously, indexing a repository would attempt to generate embeddings for all functions in the database, including those from other projects, leading to file not found errors.