### PR TITLE
Fixes bug #235

### DIFF
--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -130,7 +130,8 @@ class DefinitionProcessor(
             self._ingest_classes_and_methods(root_node, module_qn, language, queries)
             self._ingest_object_literal_methods(root_node, module_qn, language, queries)
             self._ingest_commonjs_exports(root_node, module_qn, language, queries)
-            self._ingest_es6_exports(root_node, module_qn, language, queries)
+            if language in {cs.SupportedLanguage.JS, cs.SupportedLanguage.TS}:
+                self._ingest_es6_exports(root_node, module_qn, language, queries)
             self._ingest_assignment_arrow_functions(
                 root_node, module_qn, language, queries
             )

--- a/uv.lock
+++ b/uv.lock
@@ -1054,7 +1054,7 @@ wheels = [
 
 [[package]]
 name = "graph-code"
-version = "0.0.36"
+version = "0.0.40"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Bypasses the parsers from attempting to shove every file through the es6_exports, which will fail every time that the file is not TypeScript or JavaScript.
