### PR TITLE
fix: add .qdrant_code_embeddings to IGNORE_PATTERNS

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -781,7 +781,6 @@ IGNORE_PATTERNS = frozenset(
     {
         ".cache",
         ".claude",
-        ".qdrant_code_embeddings",
         ".eclipse",
         ".eggs",
         ".env",
@@ -796,6 +795,7 @@ IGNORE_PATTERNS = frozenset(
         ".nyc_output",
         ".pnpm-store",
         ".pytest_cache",
+        ".qdrant_code_embeddings",
         ".ruff_cache",
         ".svn",
         ".tmp",

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -781,6 +781,7 @@ IGNORE_PATTERNS = frozenset(
     {
         ".cache",
         ".claude",
+        ".qdrant_code_embeddings",
         ".eclipse",
         ".eggs",
         ".env",

--- a/codebase_rag/tools/health_checker.py
+++ b/codebase_rag/tools/health_checker.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import subprocess
 
-import mgclient
+import mgclient  # ty: ignore[unresolved-import]
 from loguru import logger
 
 from .. import constants as cs

--- a/uv.lock
+++ b/uv.lock
@@ -1054,7 +1054,7 @@ wheels = [
 
 [[package]]
 name = "graph-code"
-version = "0.0.41"
+version = "0.0.43"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Add `.qdrant_code_embeddings` to `IGNORE_PATTERNS` in `constants.py` to prevent the realtime watcher from detecting Qdrant storage changes
- Add missing `ty: ignore[unresolved-import]` comment to `health_checker.py` for consistency with other mgclient imports

## Test plan
- [ ] Verify realtime watcher no longer triggers on `.qdrant_code_embeddings/storage.sqlite` changes
- [ ] Confirm semantic search embeddings are still stored and retrieved correctly

Fixes #286