### PR TITLE
refactor: move Ollama URL config from constants to settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,5 +74,5 @@ MEMGRAPH_BATCH_SIZE=1000
 # Repository settings
 TARGET_REPO_PATH=.
 
-# Fallback endpoint for Ollama
-LOCAL_MODEL_ENDPOINT=http://localhost:11434/v1
+# Ollama base URL (without /v1 suffix)
+OLLAMA_BASE_URL=http://localhost:11434

--- a/codebase_rag/config.py
+++ b/codebase_rag/config.py
@@ -168,7 +168,7 @@ class AppConfig(BaseSettings):
 
     @property
     def ollama_endpoint(self) -> str:
-        return f"{self.OLLAMA_BASE_URL}/v1"
+        return f"{self.OLLAMA_BASE_URL.rstrip('/')}/v1"
 
     TARGET_REPO_PATH: str = "."
     SHELL_COMMAND_TIMEOUT: int = 30

--- a/codebase_rag/config.py
+++ b/codebase_rag/config.py
@@ -6,7 +6,7 @@ from typing import TypedDict, Unpack
 
 from dotenv import load_dotenv
 from loguru import logger
-from pydantic import AnyHttpUrl, Field
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from . import constants as cs
@@ -164,7 +164,11 @@ class AppConfig(BaseSettings):
     CYPHER_THINKING_BUDGET: int | None = None
     CYPHER_SERVICE_ACCOUNT_FILE: str | None = None
 
-    LOCAL_MODEL_ENDPOINT: AnyHttpUrl = AnyHttpUrl("http://localhost:11434/v1")
+    OLLAMA_BASE_URL: str = "http://localhost:11434"
+
+    @property
+    def ollama_endpoint(self) -> str:
+        return f"{self.OLLAMA_BASE_URL}/v1"
 
     TARGET_REPO_PATH: str = "."
     SHELL_COMMAND_TIMEOUT: int = 30
@@ -273,7 +277,7 @@ class AppConfig(BaseSettings):
         return ModelConfig(
             provider=cs.Provider.OLLAMA,
             model_id=cs.DEFAULT_MODEL,
-            endpoint=str(self.LOCAL_MODEL_ENDPOINT),
+            endpoint=self.ollama_endpoint,
             api_key=cs.DEFAULT_API_KEY,
         )
 

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -142,8 +142,6 @@ class GoogleProviderType(StrEnum):
 
 # (H) Provider endpoints
 OPENAI_DEFAULT_ENDPOINT = "https://api.openai.com/v1"
-OLLAMA_DEFAULT_BASE_URL = "http://localhost:11434"
-OLLAMA_DEFAULT_ENDPOINT = f"{OLLAMA_DEFAULT_BASE_URL}/v1"
 OLLAMA_HEALTH_PATH = "/api/tags"
 GOOGLE_CLOUD_SCOPE = "https://www.googleapis.com/auth/cloud-platform"
 V1_PATH = "/v1"

--- a/codebase_rag/main.py
+++ b/codebase_rag/main.py
@@ -553,7 +553,7 @@ def _create_model_from_string(
         config = ModelConfig(
             provider=provider_name,
             model_id=model_id,
-            endpoint=str(settings.LOCAL_MODEL_ENDPOINT),
+            endpoint=settings.ollama_endpoint,
             api_key=cs.DEFAULT_API_KEY,
         )
     else:
@@ -708,7 +708,7 @@ def _update_single_model_setting(role: cs.ModelRole, model_string: str) -> None:
     kwargs = current_config.to_update_kwargs()
 
     if provider == cs.Provider.OLLAMA and not kwargs[cs.FIELD_ENDPOINT]:
-        kwargs[cs.FIELD_ENDPOINT] = str(settings.LOCAL_MODEL_ENDPOINT)
+        kwargs[cs.FIELD_ENDPOINT] = settings.ollama_endpoint
         kwargs[cs.FIELD_API_KEY] = cs.DEFAULT_API_KEY
 
     set_method(provider, model, **kwargs)

--- a/codebase_rag/providers/base.py
+++ b/codebase_rag/providers/base.py
@@ -128,12 +128,12 @@ class OpenAIProvider(ModelProvider):
 class OllamaProvider(ModelProvider):
     def __init__(
         self,
-        endpoint: str = cs.OLLAMA_DEFAULT_ENDPOINT,
+        endpoint: str | None = None,
         api_key: str = cs.DEFAULT_API_KEY,
         **kwargs: str | int | None,
     ) -> None:
         super().__init__(**kwargs)
-        self.endpoint = endpoint
+        self.endpoint = endpoint or settings.ollama_endpoint
         self.api_key = api_key
 
     @property
@@ -198,7 +198,8 @@ def list_providers() -> list[str]:
     return list(PROVIDER_REGISTRY.keys())
 
 
-def check_ollama_running(endpoint: str = cs.OLLAMA_DEFAULT_BASE_URL) -> bool:
+def check_ollama_running(endpoint: str | None = None) -> bool:
+    endpoint = endpoint or settings.OLLAMA_BASE_URL
     try:
         health_url = urljoin(endpoint, cs.OLLAMA_HEALTH_PATH)
         with httpx.Client(timeout=settings.OLLAMA_HEALTH_TIMEOUT) as client:

--- a/codebase_rag/tests/test_model_switching.py
+++ b/codebase_rag/tests/test_model_switching.py
@@ -417,7 +417,7 @@ class TestCreateModelFromString:
         self, mock_settings: MagicMock
     ) -> None:
         mock_model = MagicMock()
-        mock_settings.LOCAL_MODEL_ENDPOINT = "http://localhost:11434/v1"
+        mock_settings.ollama_endpoint = "http://localhost:11434/v1"
 
         with patch("codebase_rag.main.get_provider_from_config") as mock_get_provider:
             mock_provider = MagicMock()

--- a/uv.lock
+++ b/uv.lock
@@ -1080,7 +1080,7 @@ wheels = [
 
 [[package]]
 name = "graph-code"
-version = "0.0.42"
+version = "0.0.46"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Replace hardcoded `OLLAMA_DEFAULT_BASE_URL` and `OLLAMA_DEFAULT_ENDPOINT` constants with configurable `OLLAMA_BASE_URL` setting
- Add `ollama_endpoint` property that constructs the full endpoint URL from the base URL
- Update all usages to read from `settings` instead of `constants`
- Remove deprecated `LOCAL_MODEL_ENDPOINT` in favor of `OLLAMA_BASE_URL`

## Changes
- `config.py`: Add `OLLAMA_BASE_URL` setting and `ollama_endpoint` property
- `constants.py`: Remove `OLLAMA_DEFAULT_BASE_URL` and `OLLAMA_DEFAULT_ENDPOINT`
- `providers/base.py`: Update `OllamaProvider` and `check_ollama_running` to use settings
- `main.py`: Update model creation to use `settings.ollama_endpoint`
- `.env.example`: Update documentation for the new env var

## Test plan
- [ ] Set custom `OLLAMA_BASE_URL` env var and verify Ollama provider uses it
- [ ] Verify default behavior works without env var set
- [ ] Run existing tests

Fixes #284