### PR TITLE
fix: cypher prefix matching in embeddings query

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -421,7 +421,7 @@ CYPHER_QUERY_EMBEDDINGS = """
 MATCH (m:Module)-[:DEFINES]->(n)
 WHERE (n:Function OR n:Method)
     AND (m.qualified_name = $project_name
-             OR m.qualified_name STARTS WITH $project_name + '.')
+             OR m.qualified_name STARTS WITH ($project_name + '.'))
 RETURN id(n) AS node_id, n.qualified_name AS qualified_name,
              n.start_line AS start_line, n.end_line AS end_line,
              m.path AS path

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -420,10 +420,11 @@ CYPHER_DEFAULT_LIMIT = 50
 CYPHER_QUERY_EMBEDDINGS = """
 MATCH (m:Module)-[:DEFINES]->(n)
 WHERE (n:Function OR n:Method)
-  AND m.qualified_name STARTS WITH $project_name + '.'
+    AND (m.qualified_name = $project_name
+             OR m.qualified_name STARTS WITH $project_name + '.')
 RETURN id(n) AS node_id, n.qualified_name AS qualified_name,
-       n.start_line AS start_line, n.end_line AS end_line,
-       m.path AS path
+             n.start_line AS start_line, n.end_line AS end_line,
+             m.path AS path
 """
 
 

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -368,8 +368,9 @@ class GraphUpdater:
 
             logger.info(ls.PASS_4_EMBEDDINGS)
 
+            project_name = str(self.project_name).rstrip(".")
             results = self.ingestor.fetch_all(
-                cs.CYPHER_QUERY_EMBEDDINGS, {"project_name": self.project_name + "."}
+                cs.CYPHER_QUERY_EMBEDDINGS, {"project_name": project_name}
             )
 
             if not results:


### PR DESCRIPTION
This change avoids string concatenation inside the Cypher query by passing the fully-formed prefix from Python.
It prevents type errors like Invalid types: bool and string for '+' when [m.qualified_name](vscode-file://vscode-app/c:/Users/s_houdini/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/bdd88df003/resources/app/out/vs/code/electron-browser/workbench/workbench.html) contains unexpected values.