### PR TITLE
fix: center demo gif in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@
 An accurate Retrieval-Augmented Generation (RAG) system that analyzes multi-language codebases using Tree-sitter, builds comprehensive knowledge graphs, and enables natural language querying of codebase structure and relationships as well as editing capabilities.
 
 
-![demo](./assets/demo.gif)
+<p align="center">
+  <img src="./assets/demo.gif" alt="demo">
+</p>
 
 ## Latest News 🔥
 

--- a/uv.lock
+++ b/uv.lock
@@ -461,7 +461,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.56"
+version = "0.0.58"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Center-align the demo gif in the README using HTML `<p align="center">`