### PR TITLE
fix: use service account file for vertexai client initialization

### DIFF
--- a/codebase_rag/tools/document_analyzer.py
+++ b/codebase_rag/tools/document_analyzer.py
@@ -35,6 +35,8 @@ class DocumentAnalyzer:
         if orchestrator_provider == cs.Provider.GOOGLE:
             if orchestrator_config.provider_type == cs.GoogleProviderType.VERTEX:
                 self.client = genai.Client(
+                    vertexai=True,
+                    credentials=orchestrator_config.service_account_file,
                     project=orchestrator_config.project_id,
                     location=orchestrator_config.region,
                 )

--- a/uv.lock
+++ b/uv.lock
@@ -461,7 +461,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.75"
+version = "0.0.76"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Fixes issue https://github.com/vitali87/code-graph-rag/issues/307.

There are 2 parts of this PR.

-  First, if VertexIAI is used, don't check for GOOGLE_API_KEY because the service account file is used instead.
-  Second, add vertexai variable and service account to the client initialization

Without these I was unable to run cgr on VertexAI