### PR TITLE
refactor(java): use recursion_guard decorator for _find_inherited_method cycle detection

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -2134,8 +2134,9 @@ PY_SCORE_CONTAINS_BASE = 80
 TYPE_INFERENCE_LIST = "list"
 TYPE_INFERENCE_BASE_MODEL = "BaseModel"
 
-# (H) Type inference guard attribute
+# (H) Recursion guard attributes
 ATTR_TYPE_INFERENCE_IN_PROGRESS = "_type_inference_in_progress"
+GUARD_INHERITED_METHOD = "_inherited_method_guard"
 
 # (H) JS/TS ingest node types
 TS_PAIR = "pair"

--- a/codebase_rag/parsers/java/method_resolver.py
+++ b/codebase_rag/parsers/java/method_resolver.py
@@ -8,6 +8,7 @@ from loguru import logger
 
 from ... import constants as cs
 from ... import logs as ls
+from ...decorators import recursion_guard
 from ...types_defs import ASTNode, NodeType
 from ..utils import safe_decode_text
 from .utils import extract_method_call_info, get_class_context_from_qn
@@ -202,6 +203,10 @@ class JavaMethodResolverMixin:
             or member == f"{method_name}{cs.EMPTY_PARENS}"
         )
 
+    @recursion_guard(
+        key_func=lambda self, class_qn, *_, **__: class_qn,
+        guard_name=cs.GUARD_INHERITED_METHOD,
+    )
     def _find_inherited_method(
         self, class_qn: str, method_name: str, module_qn: str
     ) -> tuple[str, str] | None:

--- a/uv.lock
+++ b/uv.lock
@@ -461,7 +461,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.66"
+version = "0.0.69"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Replace manual `_visited` parameter in `_find_inherited_method` with the existing `@recursion_guard` decorator for consistency with the Python parser
- Add `GUARD_INHERITED_METHOD` constant for the guard name

## Context
Audited all recursive methods across all language parsers. The only method using a manual visited set instead of the decorator was `_find_inherited_method`. All other recursive hierarchy walkers are either already guarded, use iterative BFS with visited sets, or traverse acyclic AST trees.

## Test plan
- [ ] Verify Java method resolution still resolves inherited methods correctly
- [ ] Verify cyclic class hierarchies return `None` instead of causing `RecursionError`

Closes #340