### PR TITLE
fix(ci): use mgconsole for Memgraph readiness check instead of echo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
           docker run -d --name memgraph -p 7687:7687 memgraph/memgraph-platform:latest
           echo "Waiting for Memgraph to start..."
           for i in {1..30}; do
-            if docker exec memgraph echo "SELECT 1;" 2>/dev/null; then
+            if docker exec memgraph mgconsole --no-history -c "RETURN 1;" 2>/dev/null; then
               echo "Memgraph is ready!"
               break
             fi

--- a/uv.lock
+++ b/uv.lock
@@ -461,7 +461,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.71"
+version = "0.0.72"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Replace `docker exec memgraph echo "SELECT 1;"` with `docker exec memgraph mgconsole --no-history -c "RETURN 1;"` in the CI Memgraph readiness check
- The previous check only verified the container shell was available (echo always succeeds), not that the Bolt server was accepting connections

Closes #344