### PR TITLE
fix(config): skip API key validation for Vertex AI provider type

### DIFF
--- a/codebase_rag/config.py
+++ b/codebase_rag/config.py
@@ -102,7 +102,7 @@ class ModelConfig:
     endpoint: str | None = None
     project_id: str | None = None
     region: str | None = None
-    provider_type: str | None = None
+    provider_type: cs.GoogleProviderType | None = None
     thinking_budget: int | None = None
     service_account_file: str | None = None
 

--- a/codebase_rag/config.py
+++ b/codebase_rag/config.py
@@ -94,6 +94,9 @@ def format_missing_api_key_errors(
     return error_msg
 
 
+LOCAL_PROVIDERS = frozenset({cs.Provider.OLLAMA, cs.Provider.LOCAL, cs.Provider.VLLM})
+
+
 @dataclass
 class ModelConfig:
     provider: str
@@ -113,9 +116,9 @@ class ModelConfig:
         return ModelConfigKwargs(**result)
 
     def validate_api_key(self, role: str = cs.DEFAULT_MODEL_ROLE) -> None:
-        local_providers = {cs.Provider.OLLAMA, cs.Provider.LOCAL, cs.Provider.VLLM}
-        if self.provider.lower() in local_providers or (
-            self.provider.lower() == cs.Provider.GOOGLE
+        provider_lower = self.provider.lower()
+        if provider_lower in LOCAL_PROVIDERS or (
+            provider_lower == cs.Provider.GOOGLE
             and self.provider_type == cs.GoogleProviderType.VERTEX
         ):
             return

--- a/codebase_rag/config.py
+++ b/codebase_rag/config.py
@@ -114,9 +114,10 @@ class ModelConfig:
 
     def validate_api_key(self, role: str = cs.DEFAULT_MODEL_ROLE) -> None:
         local_providers = {cs.Provider.OLLAMA, cs.Provider.LOCAL, cs.Provider.VLLM}
-        if self.provider.lower() in local_providers:
-            return
-        if self.provider_type == cs.GoogleProviderType.VERTEX:
+        if (
+            self.provider.lower() in local_providers
+            or self.provider_type == cs.GoogleProviderType.VERTEX
+        ):
             return
         if (
             not self.api_key

--- a/codebase_rag/config.py
+++ b/codebase_rag/config.py
@@ -116,6 +116,8 @@ class ModelConfig:
         local_providers = {cs.Provider.OLLAMA, cs.Provider.LOCAL, cs.Provider.VLLM}
         if self.provider.lower() in local_providers:
             return
+        if self.provider_type == cs.GoogleProviderType.VERTEX:
+            return
         if (
             not self.api_key
             or not self.api_key.strip()

--- a/codebase_rag/config.py
+++ b/codebase_rag/config.py
@@ -114,9 +114,9 @@ class ModelConfig:
 
     def validate_api_key(self, role: str = cs.DEFAULT_MODEL_ROLE) -> None:
         local_providers = {cs.Provider.OLLAMA, cs.Provider.LOCAL, cs.Provider.VLLM}
-        if (
-            self.provider.lower() in local_providers
-            or self.provider_type == cs.GoogleProviderType.VERTEX
+        if self.provider.lower() in local_providers or (
+            self.provider.lower() == cs.Provider.GOOGLE
+            and self.provider_type == cs.GoogleProviderType.VERTEX
         ):
             return
         if (

--- a/codebase_rag/config.py
+++ b/codebase_rag/config.py
@@ -153,7 +153,7 @@ class AppConfig(BaseSettings):
     ORCHESTRATOR_ENDPOINT: str | None = None
     ORCHESTRATOR_PROJECT_ID: str | None = None
     ORCHESTRATOR_REGION: str = cs.DEFAULT_REGION
-    ORCHESTRATOR_PROVIDER_TYPE: str | None = None
+    ORCHESTRATOR_PROVIDER_TYPE: cs.GoogleProviderType | None = None
     ORCHESTRATOR_THINKING_BUDGET: int | None = None
     ORCHESTRATOR_SERVICE_ACCOUNT_FILE: str | None = None
 
@@ -163,7 +163,7 @@ class AppConfig(BaseSettings):
     CYPHER_ENDPOINT: str | None = None
     CYPHER_PROJECT_ID: str | None = None
     CYPHER_REGION: str = cs.DEFAULT_REGION
-    CYPHER_PROVIDER_TYPE: str | None = None
+    CYPHER_PROVIDER_TYPE: cs.GoogleProviderType | None = None
     CYPHER_THINKING_BUDGET: int | None = None
     CYPHER_SERVICE_ACCOUNT_FILE: str | None = None
 

--- a/codebase_rag/tests/test_github_issues_integration.py
+++ b/codebase_rag/tests/test_github_issues_integration.py
@@ -142,9 +142,6 @@ class TestGitHubIssuesIntegration:
             assert orchestrator.endpoint == "https://api.together.xyz/v1"
 
     def test_vertex_ai_enterprise_scenario(self) -> None:
-        """
-        Test enterprise Vertex AI configuration scenario.
-        """
         env_content = {
             "ORCHESTRATOR_PROVIDER": "google",
             "ORCHESTRATOR_MODEL": "gemini-2.5-pro",
@@ -164,6 +161,31 @@ class TestGitHubIssuesIntegration:
             assert orchestrator.region == "us-central1"
             assert orchestrator.provider_type == "vertex"
             assert orchestrator.service_account_file == "/path/to/service-account.json"
+
+    def test_vertex_ai_skips_api_key_validation(self) -> None:
+        env_content = {
+            "ORCHESTRATOR_PROVIDER": "google",
+            "ORCHESTRATOR_MODEL": "gemini-2.5-pro",
+            "ORCHESTRATOR_PROJECT_ID": "my-project",
+            "ORCHESTRATOR_REGION": "us-central1",
+            "ORCHESTRATOR_PROVIDER_TYPE": "vertex",
+            "ORCHESTRATOR_SERVICE_ACCOUNT_FILE": "/path/to/sa.json",
+            "CYPHER_PROVIDER": "google",
+            "CYPHER_MODEL": "gemini-2.5-flash",
+            "CYPHER_PROJECT_ID": "my-project",
+            "CYPHER_REGION": "us-central1",
+            "CYPHER_PROVIDER_TYPE": "vertex",
+            "CYPHER_SERVICE_ACCOUNT_FILE": "/path/to/sa.json",
+        }
+
+        with patch.dict(os.environ, env_content):
+            config = AppConfig()
+
+            orchestrator = config.active_orchestrator_config
+            orchestrator.validate_api_key("orchestrator")
+
+            cypher = config.active_cypher_config
+            cypher.validate_api_key("cypher")
 
     def test_reasoning_model_thinking_budget(self) -> None:
         """

--- a/codebase_rag/tests/test_github_issues_integration.py
+++ b/codebase_rag/tests/test_github_issues_integration.py
@@ -2,6 +2,7 @@ import os
 from unittest.mock import patch
 
 from codebase_rag.config import AppConfig
+from codebase_rag.constants import GoogleProviderType
 
 
 class TestGitHubIssuesIntegration:
@@ -159,7 +160,7 @@ class TestGitHubIssuesIntegration:
             assert orchestrator.model_id == "gemini-2.5-pro"
             assert orchestrator.project_id == "my-enterprise-project"
             assert orchestrator.region == "us-central1"
-            assert orchestrator.provider_type == "vertex"
+            assert orchestrator.provider_type == GoogleProviderType.VERTEX
             assert orchestrator.service_account_file == "/path/to/service-account.json"
 
     def test_vertex_ai_skips_api_key_validation(self) -> None:

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -9,7 +9,12 @@ from typing import TYPE_CHECKING, NamedTuple, Protocol, TypedDict
 
 from prompt_toolkit.styles import Style
 
-from .constants import NodeLabel, RelationshipType, SupportedLanguage
+from .constants import (
+    GoogleProviderType,
+    NodeLabel,
+    RelationshipType,
+    SupportedLanguage,
+)
 
 if TYPE_CHECKING:
     from tree_sitter import Language, Node, Parser, Query
@@ -148,7 +153,7 @@ class ModelConfigKwargs(TypedDict, total=False):
     endpoint: str | None
     project_id: str | None
     region: str | None
-    provider_type: str | None
+    provider_type: GoogleProviderType | None
     thinking_budget: int | None
     service_account_file: str | None
 

--- a/uv.lock
+++ b/uv.lock
@@ -461,7 +461,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.72"
+version = "0.0.74"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- `ModelConfig.validate_api_key()` now skips validation when `provider_type` is `vertex`, since Vertex AI authenticates via service account files, not API keys
- Adds integration test verifying both orchestrator and cypher configs pass validation with Vertex AI and no API key

Closes #307

## Test plan

- [x] New test `test_vertex_ai_skips_api_key_validation` passes
- [x] All 8 integration tests pass
- [x] Lint and format clean