### PR TITLE
refactor(config): revert provider_type to str for provider-agnostic ModelConfig

### DIFF
--- a/codebase_rag/config.py
+++ b/codebase_rag/config.py
@@ -105,7 +105,7 @@ class ModelConfig:
     endpoint: str | None = None
     project_id: str | None = None
     region: str | None = None
-    provider_type: cs.GoogleProviderType | None = None
+    provider_type: str | None = None
     thinking_budget: int | None = None
     service_account_file: str | None = None
 

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -9,12 +9,7 @@ from typing import TYPE_CHECKING, NamedTuple, Protocol, TypedDict
 
 from prompt_toolkit.styles import Style
 
-from .constants import (
-    GoogleProviderType,
-    NodeLabel,
-    RelationshipType,
-    SupportedLanguage,
-)
+from .constants import NodeLabel, RelationshipType, SupportedLanguage
 
 if TYPE_CHECKING:
     from tree_sitter import Language, Node, Parser, Query
@@ -153,7 +148,7 @@ class ModelConfigKwargs(TypedDict, total=False):
     endpoint: str | None
     project_id: str | None
     region: str | None
-    provider_type: GoogleProviderType | None
+    provider_type: str | None
     thinking_budget: int | None
     service_account_file: str | None
 

--- a/uv.lock
+++ b/uv.lock
@@ -461,7 +461,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.74"
+version = "0.0.75"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Reverts `ModelConfig.provider_type` and `ModelConfigKwargs.provider_type` from `GoogleProviderType | None` back to `str | None`
- `ModelConfig` is a generic container used across all providers, so tying it to a Google specific enum limits extensibility for future providers (e.g., AWS Bedrock)
- The `AppConfig` Pydantic fields (`ORCHESTRATOR_PROVIDER_TYPE`, `CYPHER_PROVIDER_TYPE`) remain typed as `GoogleProviderType | None` since those are explicitly Google specific and Pydantic handles the string to enum conversion
- Removes unused `GoogleProviderType` import from `types_defs.py`

## Test plan

- [x] All 42 related tests pass
- [x] Lint and format clean