### PR TITLE
chore(pypi): add classifiers, keywords, and license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,15 @@ requires-python = ">=3.12"
 license = "MIT"
 classifiers = [
     "Development Status :: 4 - Beta",
+    "Environment :: Console",
     "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Code Generators",
     "Topic :: Software Development :: Libraries :: Python Modules",
+    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 keywords = [
     "rag",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,30 @@ version = "0.0.76"
 description = "The ultimate RAG for your monorepo. Query, understand, and edit multi-language codebases with the power of AI and knowledge graphs"
 readme = "README.md"
 requires-python = ">=3.12"
+license = "MIT"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Code Generators",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Programming Language :: Python :: 3.12",
+]
+keywords = [
+    "rag",
+    "retrieval-augmented-generation",
+    "knowledge-graph",
+    "code-analysis",
+    "tree-sitter",
+    "mcp",
+    "mcp-server",
+    "llm",
+    "graph-database",
+    "semantic-search",
+    "codebase",
+    "memgraph",
+    "developer-tools",
+    "monorepo",
+]
 dependencies = [
     "loguru>=0.7.3",
     "mcp>=1.21.1",

--- a/uv.lock
+++ b/uv.lock
@@ -461,7 +461,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.75"
+version = "0.0.76"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Add PyPI classifiers (dev status, audience, topics, Python version)
- Add 14 searchable keywords (rag, mcp, knowledge-graph, tree-sitter, etc.)
- Add PEP 639 `license = "MIT"` field

These fields are indexed by PyPI search and improve discoverability for terms like "rag", "mcp-server", "knowledge-graph", and "semantic-search".