### PR TITLE
feat(sdk): add cgr shim package for short Python imports

### DIFF
--- a/cgr/__init__.py
+++ b/cgr/__init__.py
@@ -1,0 +1,14 @@
+from codebase_rag.config import settings
+from codebase_rag.embedder import embed_code
+from codebase_rag.graph_loader import GraphLoader, load_graph
+from codebase_rag.services.graph_service import MemgraphIngestor
+from codebase_rag.services.llm import CypherGenerator
+
+__all__ = [
+    "CypherGenerator",
+    "GraphLoader",
+    "MemgraphIngestor",
+    "embed_code",
+    "load_graph",
+    "settings",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ cgr = "codebase_rag.cli:app"
 package = true
 
 [tool.setuptools]
-packages = ["codebase_rag", "codec"]
+packages = ["codebase_rag", "codec", "cgr"]
 
 [project.optional-dependencies]
 test = [

--- a/uv.lock
+++ b/uv.lock
@@ -461,7 +461,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.76"
+version = "0.0.78"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Add `cgr/` shim package that re-exports SDK components from `codebase_rag`
- Register `cgr` in `[tool.setuptools] packages`

Users who `pip install code-graph-rag` can now use short imports:

```python
from cgr import load_graph, GraphLoader, MemgraphIngestor, CypherGenerator, embed_code, settings
```

Instead of the longer form:

```python
from codebase_rag.graph_loader import load_graph
from codebase_rag.services.graph_service import MemgraphIngestor
from codebase_rag.services.llm import CypherGenerator
```

Both import styles continue to work. The `cgr` CLI command is unaffected.