### PR TITLE
feat: add --version/-v flag to CLI

### DIFF
--- a/codebase_rag/cli.py
+++ b/codebase_rag/cli.py
@@ -30,7 +30,7 @@ from .tools.language import cli as language_cli
 from .types_defs import ResultRow
 
 app = typer.Typer(
-    name="code-graph-rag",
+    name=cs.PACKAGE_NAME,
     help=ch.APP_DESCRIPTION,
     no_args_is_help=True,
     add_completion=False,
@@ -40,7 +40,7 @@ app = typer.Typer(
 def _version_callback(value: bool) -> None:
     if value:
         app_context.console.print(
-            cs.CLI_MSG_VERSION.format(version=get_version("code-graph-rag")),
+            cs.CLI_MSG_VERSION.format(package=cs.PACKAGE_NAME, version=get_version(cs.PACKAGE_NAME)),
             highlight=False,
         )
         raise typer.Exit()

--- a/codebase_rag/cli.py
+++ b/codebase_rag/cli.py
@@ -1,5 +1,6 @@
 import asyncio
 from collections.abc import Callable
+from importlib.metadata import version as get_version
 from pathlib import Path
 
 import typer
@@ -36,6 +37,15 @@ app = typer.Typer(
 )
 
 
+def _version_callback(value: bool) -> None:
+    if value:
+        app_context.console.print(
+            cs.CLI_MSG_VERSION.format(version=get_version("code-graph-rag")),
+            highlight=False,
+        )
+        raise typer.Exit()
+
+
 def validate_models_early() -> None:
     try:
         orchestrator_config = settings.active_orchestrator_config
@@ -60,6 +70,14 @@ def _update_and_validate_models(orchestrator: str | None, cypher: str | None) ->
 
 @app.callback()
 def _global_options(
+    version: bool | None = typer.Option(
+        None,
+        "--version",
+        "-v",
+        help=ch.HELP_VERSION,
+        callback=_version_callback,
+        is_eager=True,
+    ),
     quiet: bool = typer.Option(
         False,
         "--quiet",

--- a/codebase_rag/cli_help.py
+++ b/codebase_rag/cli_help.py
@@ -52,6 +52,7 @@ HELP_REPO_PATH_RETRIEVAL = "Path to the target repository for code retrieval"
 HELP_REPO_PATH_INDEX = "Path to the target repository to index."
 HELP_REPO_PATH_OPTIMIZE = "Path to the repository to optimize"
 HELP_REPO_PATH_WATCH = "Path to the repository to watch."
+HELP_VERSION = "Show the version and exit."
 
 HELP_DEBOUNCE = "Debounce delay in seconds. Set to 0 to disable debouncing."
 HELP_MAX_WAIT = (

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -245,6 +245,7 @@ CLI_MSG_CONNECTING_MEMGRAPH = "Connecting to Memgraph to export graph..."
 CLI_MSG_EXPORTING_DATA = "Exporting graph data..."
 CLI_MSG_OPTIMIZATION_TERMINATED = "\nOptimization session terminated by user."
 CLI_MSG_MCP_TERMINATED = "\nMCP server terminated by user."
+CLI_MSG_VERSION = "code-graph-rag version {version}"
 CLI_MSG_HINT_TARGET_REPO = (
     "\nHint: Make sure TARGET_REPO_PATH environment variable is set."
 )

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -245,7 +245,8 @@ CLI_MSG_CONNECTING_MEMGRAPH = "Connecting to Memgraph to export graph..."
 CLI_MSG_EXPORTING_DATA = "Exporting graph data..."
 CLI_MSG_OPTIMIZATION_TERMINATED = "\nOptimization session terminated by user."
 CLI_MSG_MCP_TERMINATED = "\nMCP server terminated by user."
-CLI_MSG_VERSION = "code-graph-rag version {version}"
+PACKAGE_NAME = "code-graph-rag"
+CLI_MSG_VERSION = "{package} version {version}"
 CLI_MSG_HINT_TARGET_REPO = (
     "\nHint: Make sure TARGET_REPO_PATH environment variable is set."
 )

--- a/codebase_rag/tests/test_cli_smoke.py
+++ b/codebase_rag/tests/test_cli_smoke.py
@@ -1,9 +1,12 @@
 import re
 import subprocess
 import sys
+from importlib.metadata import version as get_version
 from pathlib import Path
 
 import pytest
+
+from codebase_rag import constants as cs
 
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
@@ -35,3 +38,26 @@ def test_import_cli_module() -> None:
         assert hasattr(cli, "app"), "CLI module missing app attribute"
     except ImportError as e:
         pytest.fail(f"Failed to import cli module: {e}")
+
+
+def test_version_flag() -> None:
+    repo_root = Path(__file__).parent.parent.parent
+
+    for flag in ["--version", "-v"]:
+        result = subprocess.run(
+            [sys.executable, "-m", "codebase_rag.cli", flag],
+            check=False,
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        assert result.returncode == 0, (
+            f"{flag} exited with code {result.returncode}: {result.stderr}"
+        )
+        expected = cs.CLI_MSG_VERSION.format(version=get_version("code-graph-rag"))
+        assert result.stdout.strip() == expected, (
+            f"{flag} output did not match expected format: {repr(result.stdout)}"
+        )
+        assert result.stderr == "", f"Unexpected stderr for {flag}: {result.stderr}"

--- a/codebase_rag/tests/test_cli_smoke.py
+++ b/codebase_rag/tests/test_cli_smoke.py
@@ -56,7 +56,7 @@ def test_version_flag() -> None:
         assert result.returncode == 0, (
             f"{flag} exited with code {result.returncode}: {result.stderr}"
         )
-        expected = cs.CLI_MSG_VERSION.format(version=get_version("code-graph-rag"))
+        expected = cs.CLI_MSG_VERSION.format(package=cs.PACKAGE_NAME, version=get_version(cs.PACKAGE_NAME))
         assert result.stdout.strip() == expected, (
             f"{flag} output did not match expected format: {repr(result.stdout)}"
         )


### PR DESCRIPTION
Implements cgr --version and cgr -v commands that display the current package version read from importlib.metadata.

Acceptance criteria from issue #239:
- cgr --version and cgr -v both work
- Version read from package metadata (not hardcoded)
- Output format: code-graph-rag version X.Y.Z

Test: added test_version_flag() to test_cli_smoke.py (subprocess pattern)

## Summary

<!-- What does this PR do? Keep it brief: 1-3 bullet points. -->

-

## Type of Change

<!-- Check all that apply. -->

- [x] Bug fix
- [x] New feature
- [x] Performance improvement
- [x] Refactoring (no functional changes)
- [x] Documentation
- [x] CI/CD or tooling
- [x] Dependencies

## Related Issues

<!-- Link related issues: "Fixes #123", "Closes #456", or "Related to #789" -->

## Test Plan

<!-- How was this tested? Check all that apply. -->

- [x] Unit tests pass (`make test-parallel` or `uv run pytest -n auto -m "not integration"`)
- [x] New tests added
- [x] Integration tests pass (`make test-integration`, requires Docker)
- [x] Manual testing (describe below)

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [x] No new comments or docstrings (code should be self-documenting)
