### PR TITLE
feat(mcp): add MCP Registry server manifest and PyPI verification tag

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -92,12 +92,17 @@ jobs:
         run: |
           sed -i 's/^version = ".*"/version = "${{ steps.bump_version.outputs.new }}"/' pyproject.toml
 
+      - name: Update server.json
+        if: steps.check_manual.outputs.skip == 'false'
+        run: |
+          sed -i 's/"version": "[^"]*"/"version": "${{ steps.bump_version.outputs.new }}"/g' server.json
+
       - name: Commit version bump
         if: steps.check_manual.outputs.skip == 'false'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add pyproject.toml
+          git add pyproject.toml server.json
           git commit -m "chore: bump version to ${{ steps.bump_version.outputs.new }}"
           git push
 

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -156,3 +156,5 @@ Full documentation, architecture details, and contribution guide:
 ## License
 
 MIT
+
+<!-- mcp-name: io.github.vitali87/code-graph-rag -->

--- a/README.md
+++ b/README.md
@@ -887,5 +887,3 @@ We also offer custom development, integration consulting, technical support cont
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=vitali87/code-graph-rag&type=Date)](https://www.star-history.com/#vitali87/code-graph-rag&Date)
-
-<!-- mcp-name: io.github.vitali87/code-graph-rag -->

--- a/README.md
+++ b/README.md
@@ -887,3 +887,5 @@ We also offer custom development, integration consulting, technical support cont
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=vitali87/code-graph-rag&type=Date)](https://www.star-history.com/#vitali87/code-graph-rag&Date)
+
+<!-- mcp-name: io.github.vitali87/code-graph-rag -->

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vitali87/code-graph-rag",
     "source": "github"
   },
-  "version": "0.0.79",
+  "version": "0.0.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "code-graph-rag",
-      "version": "0.0.79",
+      "version": "0.0.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.vitali87/code-graph-rag",
+  "title": "Code-Graph-RAG",
+  "description": "Graph-based RAG system for multi-language codebases. Parse, index, query, and edit code using knowledge graphs and natural language.",
+  "websiteUrl": "https://code-graph-rag.com",
+  "repository": {
+    "url": "https://github.com/vitali87/code-graph-rag",
+    "source": "github"
+  },
+  "version": "0.0.79",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "code-graph-rag",
+      "version": "0.0.79",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp-server"
+        }
+      ],
+      "environmentVariables": [
+        {
+          "name": "ORCHESTRATOR_PROVIDER",
+          "description": "LLM provider for the orchestrator agent (openai, anthropic, google, azure, cohere, ollama)",
+          "default": "anthropic"
+        },
+        {
+          "name": "ORCHESTRATOR_MODEL",
+          "description": "Model name for the orchestrator agent",
+          "default": "claude-sonnet-4-20250514"
+        },
+        {
+          "name": "ORCHESTRATOR_API_KEY",
+          "description": "API key for the orchestrator LLM provider",
+          "isRequired": true,
+          "isSecret": true
+        },
+        {
+          "name": "CYPHER_PROVIDER",
+          "description": "LLM provider for Cypher query generation (openai, anthropic, google, azure, cohere, ollama)",
+          "default": "anthropic"
+        },
+        {
+          "name": "CYPHER_MODEL",
+          "description": "Model name for Cypher query generation",
+          "default": "claude-sonnet-4-20250514"
+        },
+        {
+          "name": "CYPHER_API_KEY",
+          "description": "API key for the Cypher LLM provider",
+          "isRequired": true,
+          "isSecret": true
+        },
+        {
+          "name": "MEMGRAPH_HOST",
+          "description": "Hostname of the Memgraph database",
+          "default": "localhost"
+        },
+        {
+          "name": "MEMGRAPH_PORT",
+          "description": "Port of the Memgraph database",
+          "default": "7687"
+        },
+        {
+          "name": "TARGET_REPO_PATH",
+          "description": "Path to the repository to analyze (auto-detected from working directory if not set)"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `server.json` manifest for publishing to the official MCP Registry at registry.modelcontextprotocol.io
- Add hidden `mcp-name` verification tag to README.md (required for PyPI package ownership verification)

## Test plan
- [ ] Verify `server.json` validates against the schema at `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`
- [ ] After merging and publishing to PyPI, install `mcp-publisher` and run `mcp-publisher publish`
- [ ] Confirm server appears at `https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.vitali87/code-graph-rag`