### PR TITLE
docs(pypi): point documentation link to docs.code-graph-rag.com

### DIFF
--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -151,7 +151,7 @@ Configure via `.env` or environment variables:
 ## Documentation
 
 Full documentation, architecture details, and contribution guide:
-[GitHub Repository](https://github.com/vitali87/code-graph-rag)
+[docs.code-graph-rag.com](https://docs.code-graph-rag.com)
 
 ## License
 

--- a/uv.lock
+++ b/uv.lock
@@ -484,7 +484,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.82"
+version = "0.0.83"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Update PYPI_README.md documentation link from GitHub repository to the new docs site at `docs.code-graph-rag.com`

## Test plan

- [ ] Verify link renders correctly on PyPI after next release