### PR TITLE
fix: keep logfire_api in PyInstaller bundle for pydantic_graph

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -883,7 +883,7 @@ PYINSTALLER_ARG_HIDDEN_IMPORT = "--hidden-import"
 PYINSTALLER_ARG_EXCLUDE_MODULE = "--exclude-module"
 PYINSTALLER_ENTRY_POINT = "main.py"
 
-PYINSTALLER_EXCLUDED_MODULES = ["logfire", "logfire_api"]
+PYINSTALLER_EXCLUDED_MODULES = ["logfire"]
 
 # (H) TOML parsing constants
 TOML_KEY_PROJECT = "project"

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -908,6 +908,7 @@ PYINSTALLER_PACKAGES: list["PyInstallerPackage"] = [
     PyInstallerPackage(name="loguru", collect_all=True),
     PyInstallerPackage(name="toml", collect_all=True),
     PyInstallerPackage(name="protobuf", collect_all=True),
+    PyInstallerPackage(name="genai_prices", collect_all=True),
 ]
 
 ALLOWED_COMMENT_MARKERS = frozenset(


### PR DESCRIPTION
## Summary
- Remove `logfire_api` from `PYINSTALLER_EXCLUDED_MODULES`, keeping only `logfire`
- `pydantic_graph._utils` imports `logfire_api` at runtime, so it must remain in the bundle
- `logfire` (the full package that calls `inspect.getsource()`) is the actual problem module

## Test plan
- [ ] Verify binary builds succeed on all platforms in CI
- [ ] Verify `--version` smoke test passes in build-binaries workflow