### PR TITLE
fix(ci): update osv-scanner-action to tag ref and add actions:read permission

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -26,8 +26,9 @@ permissions: read-all
 jobs:
   scan-scheduled:
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@c5996e0193a3df57d695c1b8a1dec2a4c62e8730" # v2.3.3
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.3"
     permissions:
+      actions: read
       security-events: write
       contents: read
     with:
@@ -37,8 +38,9 @@ jobs:
         ./
   scan-pr:
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@c5996e0193a3df57d695c1b8a1dec2a4c62e8730" # v2.3.3
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v2.3.3"
     permissions:
+      actions: read
       security-events: write
       contents: read
     with:


### PR DESCRIPTION
## Summary
- Switch from pinned commit hash to `@v2.3.3` tag ref for `google/osv-scanner-action` reusable workflows
- Add missing `actions: read` permission required by the reusable workflows per [official docs](https://google.github.io/osv-scanner/github-action/)

## Test plan
- [ ] Verify OSV-Scanner workflow no longer fails with startup_failure on this PR