### PR TITLE
perf: phase 1 Python optimizations across the codebase

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -1575,6 +1575,9 @@ GOMOD_COMMENT_PREFIX = "//"
 # (H) Gemfile parsing patterns
 GEMFILE_GEM_PREFIX = "gem "
 
+# (H) Incremental update hash cache
+HASH_CACHE_FILENAME = ".cgr-hash-cache.json"
+
 # (H) Import processor cache config
 IMPORT_CACHE_TTL = 3600
 IMPORT_CACHE_DIR = ".cache/codebase_rag"

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -150,6 +150,8 @@ V1_PATH = "/v1"
 HTTP_OK = 200
 
 UNIXCODER_MODEL = "microsoft/unixcoder-base"
+EMBEDDING_DEFAULT_BATCH_SIZE = 32
+EMBEDDING_CACHE_FILENAME = ".embedding_cache.json"
 
 KEY_NODES = "nodes"
 KEY_RELATIONSHIPS = "relationships"

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -126,3 +126,24 @@ def build_merge_relationship_query(
     )
     query += CYPHER_SET_PROPS_RETURN_COUNT if has_props else CYPHER_RETURN_COUNT
     return query
+
+
+def build_create_node_query(label: str, id_key: str) -> str:
+    return f"CREATE (n:{label} {{{id_key}: row.id}})\nSET n += row.props"
+
+
+def build_create_relationship_query(
+    from_label: str,
+    from_key: str,
+    rel_type: str,
+    to_label: str,
+    to_key: str,
+    has_props: bool = False,
+) -> str:
+    query = (
+        f"MATCH (a:{from_label} {{{from_key}: row.from_val}}), "
+        f"(b:{to_label} {{{to_key}: row.to_val}})\n"
+        f"CREATE (a)-[r:{rel_type}]->(b)\n"
+    )
+    query += CYPHER_SET_PROPS_RETURN_COUNT if has_props else CYPHER_RETURN_COUNT
+    return query

--- a/codebase_rag/embedder.py
+++ b/codebase_rag/embedder.py
@@ -1,18 +1,101 @@
-# ┌────────────────────────────────────────────────────────────────────────┐
-# │ UniXcoder Model Singleton via LRU Cache                              │
-# ├────────────────────────────────────────────────────────────────────────┤
-# │ get_model() provides:                                                 │
-# │   - Singleton behavior without global variables                       │
-# │   - Thread-safe lazy initialization                                   │
-# │   - Easy testability with cache_clear() method                        │
-# │   - Memory efficient with maxsize=1                                   │
-# └────────────────────────────────────────────────────────────────────────┘
-from functools import lru_cache
+from __future__ import annotations
 
+import hashlib
+import json
+from functools import lru_cache
+from pathlib import Path
+
+from loguru import logger
+
+from . import constants as cs
 from . import exceptions as ex
+from . import logs as ls
 from .config import settings
-from .constants import UNIXCODER_MODEL
 from .utils.dependencies import has_torch, has_transformers
+
+
+class EmbeddingCache:
+    __slots__ = ("_cache", "_path")
+
+    def __init__(self, path: Path | None = None) -> None:
+        self._cache: dict[str, list[float]] = {}
+        self._path = path
+
+    @staticmethod
+    def _content_hash(content: str) -> str:
+        return hashlib.sha256(content.encode()).hexdigest()
+
+    def get(self, content: str) -> list[float] | None:
+        return self._cache.get(self._content_hash(content))
+
+    def put(self, content: str, embedding: list[float]) -> None:
+        self._cache[self._content_hash(content)] = embedding
+
+    def get_many(self, snippets: list[str]) -> dict[int, list[float]]:
+        results: dict[int, list[float]] = {}
+        for i, snippet in enumerate(snippets):
+            if (cached := self.get(snippet)) is not None:
+                results[i] = cached
+        return results
+
+    def put_many(self, snippets: list[str], embeddings: list[list[float]]) -> None:
+        for snippet, embedding in zip(snippets, embeddings):
+            self.put(snippet, embedding)
+
+    def save(self) -> None:
+        if self._path is None:
+            return
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            with self._path.open("w", encoding="utf-8") as f:
+                json.dump(self._cache, f)
+        except Exception as e:
+            logger.warning(
+                ls.EMBEDDING_CACHE_SAVE_FAILED.format(path=self._path, error=e)
+            )
+
+    def load(self) -> None:
+        if self._path is None or not self._path.exists():
+            return
+        try:
+            with self._path.open("r", encoding="utf-8") as f:
+                self._cache = json.load(f)
+            logger.debug(
+                ls.EMBEDDING_CACHE_LOADED.format(
+                    count=len(self._cache), path=self._path
+                )
+            )
+        except Exception as e:
+            logger.warning(
+                ls.EMBEDDING_CACHE_LOAD_FAILED.format(path=self._path, error=e)
+            )
+            self._cache = {}
+
+    def clear(self) -> None:
+        self._cache.clear()
+
+    def __len__(self) -> int:
+        return len(self._cache)
+
+
+_embedding_cache: EmbeddingCache | None = None
+
+
+def get_embedding_cache() -> EmbeddingCache:
+    global _embedding_cache
+    if _embedding_cache is None:
+        cache_path = Path(settings.QDRANT_DB_PATH) / cs.EMBEDDING_CACHE_FILENAME
+        _embedding_cache = EmbeddingCache(path=cache_path)
+        _embedding_cache.load()
+    return _embedding_cache
+
+
+def clear_embedding_cache() -> None:
+    global _embedding_cache
+    if _embedding_cache is not None:
+        _embedding_cache.clear()
+        _embedding_cache = None
+
 
 if has_torch() and has_transformers():
     import numpy as np
@@ -23,13 +106,17 @@ if has_torch() and has_transformers():
 
     @lru_cache(maxsize=1)
     def get_model() -> UniXcoder:
-        model = UniXcoder(UNIXCODER_MODEL)
+        model = UniXcoder(cs.UNIXCODER_MODEL)
         model.eval()
         if torch.cuda.is_available():
             model = model.cuda()
         return model
 
     def embed_code(code: str, max_length: int | None = None) -> list[float]:
+        cache = get_embedding_cache()
+        if (cached := cache.get(code)) is not None:
+            return cached
+
         if max_length is None:
             max_length = settings.EMBEDDING_MAX_LENGTH
         model = get_model()
@@ -40,9 +127,63 @@ if has_torch() and has_transformers():
             _, sentence_embeddings = model(tokens_tensor)
             embedding: NDArray[np.float32] = sentence_embeddings.cpu().numpy()
         result: list[float] = embedding[0].tolist()
+
+        cache.put(code, result)
         return result
+
+    def embed_code_batch(
+        snippets: list[str],
+        max_length: int | None = None,
+        batch_size: int = cs.EMBEDDING_DEFAULT_BATCH_SIZE,
+    ) -> list[list[float]]:
+        if not snippets:
+            return []
+
+        if max_length is None:
+            max_length = settings.EMBEDDING_MAX_LENGTH
+
+        cache = get_embedding_cache()
+        cached_results = cache.get_many(snippets)
+
+        if len(cached_results) == len(snippets):
+            logger.debug(ls.EMBEDDING_CACHE_HIT.format(count=len(snippets)))
+            return [cached_results[i] for i in range(len(snippets))]
+
+        uncached_indices = [i for i in range(len(snippets)) if i not in cached_results]
+        uncached_snippets = [snippets[i] for i in uncached_indices]
+
+        model = get_model()
+        device = next(model.parameters()).device
+
+        all_new_embeddings: list[list[float]] = []
+        for start in range(0, len(uncached_snippets), batch_size):
+            batch = uncached_snippets[start : start + batch_size]
+            tokens_list = model.tokenize(batch, max_length=max_length, padding=True)
+            tokens_tensor = torch.tensor(tokens_list).to(device)
+            with torch.no_grad():
+                _, sentence_embeddings = model(tokens_tensor)
+                batch_np: NDArray[np.float32] = sentence_embeddings.cpu().numpy()
+            for row in batch_np:
+                all_new_embeddings.append(row.tolist())
+
+        cache.put_many(uncached_snippets, all_new_embeddings)
+
+        results: list[list[float]] = [[] for _ in snippets]
+        for i, emb in cached_results.items():
+            results[i] = emb
+        for idx, orig_i in enumerate(uncached_indices):
+            results[orig_i] = all_new_embeddings[idx]
+
+        return results
 
 else:
 
     def embed_code(code: str, max_length: int | None = None) -> list[float]:
+        raise RuntimeError(ex.SEMANTIC_EXTRA)
+
+    def embed_code_batch(
+        snippets: list[str],
+        max_length: int | None = None,
+        batch_size: int = cs.EMBEDDING_DEFAULT_BATCH_SIZE,
+    ) -> list[list[float]]:
         raise RuntimeError(ex.SEMANTIC_EXTRA)

--- a/codebase_rag/embedder.py
+++ b/codebase_rag/embedder.py
@@ -50,9 +50,7 @@ class EmbeddingCache:
             with self._path.open("w", encoding="utf-8") as f:
                 json.dump(self._cache, f)
         except Exception as e:
-            logger.warning(
-                ls.EMBEDDING_CACHE_SAVE_FAILED.format(path=self._path, error=e)
-            )
+            logger.warning(ls.EMBEDDING_CACHE_SAVE_FAILED, path=self._path, error=e)
 
     def load(self) -> None:
         if self._path is None or not self._path.exists():
@@ -61,14 +59,10 @@ class EmbeddingCache:
             with self._path.open("r", encoding="utf-8") as f:
                 self._cache = json.load(f)
             logger.debug(
-                ls.EMBEDDING_CACHE_LOADED.format(
-                    count=len(self._cache), path=self._path
-                )
+                ls.EMBEDDING_CACHE_LOADED, count=len(self._cache), path=self._path
             )
         except Exception as e:
-            logger.warning(
-                ls.EMBEDDING_CACHE_LOAD_FAILED.format(path=self._path, error=e)
-            )
+            logger.warning(ls.EMBEDDING_CACHE_LOAD_FAILED, path=self._path, error=e)
             self._cache = {}
 
     def clear(self) -> None:
@@ -146,7 +140,7 @@ if has_torch() and has_transformers():
         cached_results = cache.get_many(snippets)
 
         if len(cached_results) == len(snippets):
-            logger.debug(ls.EMBEDDING_CACHE_HIT.format(count=len(snippets)))
+            logger.debug(ls.EMBEDDING_CACHE_HIT, count=len(snippets))
             return [cached_results[i] for i in range(len(snippets))]
 
         uncached_indices = [i for i in range(len(snippets)) if i not in cached_results]

--- a/codebase_rag/graph_loader.py
+++ b/codebase_rag/graph_loader.py
@@ -13,6 +13,18 @@ from .types_defs import GraphData, GraphMetadata, GraphSummary, PropertyValue
 
 
 class GraphLoader:
+    __slots__ = (
+        "file_path",
+        "_data",
+        "_nodes",
+        "_relationships",
+        "_nodes_by_id",
+        "_nodes_by_label",
+        "_outgoing_rels",
+        "_incoming_rels",
+        "_property_indexes",
+    )
+
     def __init__(self, file_path: str):
         self.file_path = Path(file_path)
         self._data: GraphData | None = None

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -462,7 +462,7 @@ class GraphUpdater:
             return
 
         try:
-            from .embedder import embed_code
+            from .embedder import embed_code, get_embedding_cache
             from .vector_store import store_embedding
 
             logger.info(ls.PASS_4_EMBEDDINGS)
@@ -514,6 +514,7 @@ class GraphUpdater:
                 else:
                     logger.debug(ls.NO_SOURCE_FOR, name=qualified_name)
             logger.info(ls.EMBEDDINGS_COMPLETE, count=embedded_count)
+            get_embedding_cache().save()
 
         except Exception as e:
             logger.warning(ls.EMBEDDING_GENERATION_FAILED, error=e)

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 import sys
 from collections import OrderedDict, defaultdict
 from collections.abc import Callable, ItemsView, KeysView
@@ -27,8 +29,12 @@ from .utils.fqn_resolver import find_function_source_by_fqn
 from .utils.path_utils import should_skip_path
 from .utils.source_extraction import extract_source_with_fallback
 
+type FileHashCache = dict[str, str]
+
 
 class FunctionRegistryTrie:
+    __slots__ = ("root", "_entries", "_simple_name_lookup")
+
     def __init__(self, simple_name_lookup: SimpleNameLookup | None = None) -> None:
         self.root: TrieNode = {}
         self._entries: FunctionRegistry = {}
@@ -160,6 +166,8 @@ class FunctionRegistryTrie:
 
 
 class BoundedASTCache:
+    __slots__ = ("cache", "max_entries", "max_memory_bytes")
+
     def __init__(
         self,
         max_entries: int | None = None,
@@ -220,6 +228,38 @@ class BoundedASTCache:
             )
 
 
+def _hash_file(filepath: Path) -> str:
+    hasher = hashlib.sha256()
+    with filepath.open("rb") as f:
+        while chunk := f.read(8192):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def _load_hash_cache(cache_path: Path) -> FileHashCache:
+    if not cache_path.is_file():
+        return {}
+    try:
+        with cache_path.open(encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, dict):
+            logger.info(ls.HASH_CACHE_LOADED, count=len(data), path=cache_path)
+            return data
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning(ls.HASH_CACHE_LOAD_FAILED, path=cache_path, error=e)
+    return {}
+
+
+def _save_hash_cache(cache_path: Path, hashes: FileHashCache) -> None:
+    try:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        with cache_path.open("w", encoding="utf-8") as f:
+            json.dump(hashes, f, indent=2)
+        logger.info(ls.HASH_CACHE_SAVED, count=len(hashes), path=cache_path)
+    except OSError as e:
+        logger.warning(ls.HASH_CACHE_SAVE_FAILED, path=cache_path, error=e)
+
+
 class GraphUpdater:
     def __init__(
         self,
@@ -261,19 +301,19 @@ class GraphUpdater:
             or filepath.suffix.lower() == cs.CSPROJ_SUFFIX
         )
 
-    def run(self) -> None:
+    def run(self, force: bool = False) -> None:
         self.ingestor.ensure_node_batch(
             cs.NODE_PROJECT, {cs.KEY_NAME: self.project_name}
         )
-        logger.info(ls.ENSURING_PROJECT.format(name=self.project_name))
+        logger.info(ls.ENSURING_PROJECT, name=self.project_name)
 
         logger.info(ls.PASS_1_STRUCTURE)
         self.factory.structure_processor.identify_structure()
 
         logger.info(ls.PASS_2_FILES)
-        self._process_files()
+        self._process_files(force=force)
 
-        logger.info(ls.FOUND_FUNCTIONS.format(count=len(self.function_registry)))
+        logger.info(ls.FOUND_FUNCTIONS, count=len(self.function_registry))
         logger.info(ls.PASS_3_CALLS)
         self._process_function_calls()
 
@@ -285,7 +325,7 @@ class GraphUpdater:
         self._generate_semantic_embeddings()
 
     def remove_file_from_state(self, file_path: Path) -> None:
-        logger.debug(ls.REMOVING_STATE.format(path=file_path))
+        logger.debug(ls.REMOVING_STATE, path=file_path)
 
         if file_path in self.ast_cache:
             del self.ast_cache[file_path]
@@ -307,44 +347,103 @@ class GraphUpdater:
                 del self.function_registry[qn]
 
         if qns_to_remove:
-            logger.debug(ls.REMOVING_QNS.format(count=len(qns_to_remove)))
+            logger.debug(ls.REMOVING_QNS, count=len(qns_to_remove))
 
         for simple_name, qn_set in self.simple_name_lookup.items():
             original_count = len(qn_set)
             new_qn_set = qn_set - qns_to_remove
             if len(new_qn_set) < original_count:
                 self.simple_name_lookup[simple_name] = new_qn_set
-                logger.debug(ls.CLEANED_SIMPLE_NAME.format(name=simple_name))
+                logger.debug(ls.CLEANED_SIMPLE_NAME, name=simple_name)
 
-    def _process_files(self) -> None:
+    def _collect_eligible_files(self) -> list[Path]:
+        eligible: list[Path] = []
         for filepath in self.repo_path.rglob("*"):
-            if filepath.is_file() and not should_skip_path(
-                filepath,
-                self.repo_path,
-                exclude_paths=self.exclude_paths,
-                unignore_paths=self.unignore_paths,
-            ):
-                lang_config = get_language_spec(filepath.suffix)
-                if (
-                    lang_config
-                    and isinstance(lang_config.language, cs.SupportedLanguage)
-                    and lang_config.language in self.parsers
-                ):
-                    result = self.factory.definition_processor.process_file(
-                        filepath,
-                        lang_config.language,
-                        self.queries,
-                        self.factory.structure_processor.structural_elements,
-                    )
-                    if result:
-                        root_node, language = result
-                        self.ast_cache[filepath] = (root_node, language)
-                elif self._is_dependency_file(filepath.name, filepath):
-                    self.factory.definition_processor.process_dependencies(filepath)
-
-                self.factory.structure_processor.process_generic_file(
-                    filepath, filepath.name
+            if (
+                filepath.is_file()
+                and filepath.name != cs.HASH_CACHE_FILENAME
+                and not should_skip_path(
+                    filepath,
+                    self.repo_path,
+                    exclude_paths=self.exclude_paths,
+                    unignore_paths=self.unignore_paths,
                 )
+            ):
+                eligible.append(filepath)
+        return eligible
+
+    def _process_files(self, force: bool = False) -> None:
+        cache_path = self.repo_path / cs.HASH_CACHE_FILENAME
+        old_hashes = _load_hash_cache(cache_path) if not force else {}
+        if force:
+            logger.info(ls.INCREMENTAL_FORCE)
+
+        eligible_files = self._collect_eligible_files()
+        new_hashes: FileHashCache = {}
+        skipped_count = 0
+        changed_count = 0
+
+        current_file_keys: set[str] = set()
+
+        for filepath in eligible_files:
+            file_key = str(filepath.relative_to(self.repo_path))
+            current_file_keys.add(file_key)
+
+            current_hash = _hash_file(filepath)
+            new_hashes[file_key] = current_hash
+
+            if (
+                not force
+                and file_key in old_hashes
+                and old_hashes[file_key] == current_hash
+            ):
+                logger.debug(ls.FILE_HASH_UNCHANGED, path=file_key)
+                skipped_count += 1
+                continue
+
+            if file_key in old_hashes:
+                logger.debug(ls.FILE_HASH_CHANGED, path=file_key)
+                self.remove_file_from_state(filepath)
+            else:
+                logger.debug(ls.FILE_HASH_NEW, path=file_key)
+
+            changed_count += 1
+            self._process_single_file(filepath)
+
+        deleted_keys = set(old_hashes.keys()) - current_file_keys
+        if deleted_keys:
+            logger.info(ls.INCREMENTAL_DELETED, count=len(deleted_keys))
+            for deleted_key in deleted_keys:
+                deleted_path = self.repo_path / deleted_key
+                self.remove_file_from_state(deleted_path)
+
+        if skipped_count > 0:
+            logger.info(ls.INCREMENTAL_SKIPPED, count=skipped_count)
+        if changed_count > 0:
+            logger.info(ls.INCREMENTAL_CHANGED, count=changed_count)
+
+        _save_hash_cache(cache_path, new_hashes)
+
+    def _process_single_file(self, filepath: Path) -> None:
+        lang_config = get_language_spec(filepath.suffix)
+        if (
+            lang_config
+            and isinstance(lang_config.language, cs.SupportedLanguage)
+            and lang_config.language in self.parsers
+        ):
+            result = self.factory.definition_processor.process_file(
+                filepath,
+                lang_config.language,
+                self.queries,
+                self.factory.structure_processor.structural_elements,
+            )
+            if result:
+                root_node, language = result
+                self.ast_cache[filepath] = (root_node, language)
+        elif self._is_dependency_file(filepath.name, filepath):
+            self.factory.definition_processor.process_dependencies(filepath)
+
+        self.factory.structure_processor.process_generic_file(filepath, filepath.name)
 
     def _process_function_calls(self) -> None:
         ast_cache_items = list(self.ast_cache.items())
@@ -376,7 +475,7 @@ class GraphUpdater:
                 logger.info(ls.NO_FUNCTIONS_FOR_EMBEDDING)
                 return
 
-            logger.info(ls.GENERATING_EMBEDDINGS.format(count=len(results)))
+            logger.info(ls.GENERATING_EMBEDDINGS, count=len(results))
 
             embedded_count = 0
             for row in results:
@@ -391,7 +490,7 @@ class GraphUpdater:
                 file_path = parsed.get(cs.KEY_PATH)
 
                 if start_line is None or end_line is None or file_path is None:
-                    logger.debug(ls.NO_SOURCE_FOR.format(name=qualified_name))
+                    logger.debug(ls.NO_SOURCE_FOR, name=qualified_name)
 
                 elif source_code := self._extract_source_code(
                     qualified_name, file_path, start_line, end_line
@@ -403,21 +502,21 @@ class GraphUpdater:
 
                         if embedded_count % settings.EMBEDDING_PROGRESS_INTERVAL == 0:
                             logger.debug(
-                                ls.EMBEDDING_PROGRESS.format(
-                                    done=embedded_count, total=len(results)
-                                )
+                                ls.EMBEDDING_PROGRESS,
+                                done=embedded_count,
+                                total=len(results),
                             )
 
                     except Exception as e:
                         logger.warning(
-                            ls.EMBEDDING_FAILED.format(name=qualified_name, error=e)
+                            ls.EMBEDDING_FAILED, name=qualified_name, error=e
                         )
                 else:
-                    logger.debug(ls.NO_SOURCE_FOR.format(name=qualified_name))
-            logger.info(ls.EMBEDDINGS_COMPLETE.format(count=embedded_count))
+                    logger.debug(ls.NO_SOURCE_FOR, name=qualified_name)
+            logger.info(ls.EMBEDDINGS_COMPLETE, count=embedded_count)
 
         except Exception as e:
-            logger.warning(ls.EMBEDDING_GENERATION_FAILED.format(error=e))
+            logger.warning(ls.EMBEDDING_GENERATION_FAILED, error=e)
 
     def _extract_source_code(
         self, qualified_name: str, file_path: str, start_line: int, end_line: int

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -463,7 +463,7 @@ class GraphUpdater:
 
         try:
             from .embedder import embed_code, get_embedding_cache
-            from .vector_store import store_embedding
+            from .vector_store import close_qdrant_client, store_embedding
 
             logger.info(ls.PASS_4_EMBEDDINGS)
 
@@ -515,6 +515,7 @@ class GraphUpdater:
                     logger.debug(ls.NO_SOURCE_FOR, name=qualified_name)
             logger.info(ls.EMBEDDINGS_COMPLETE, count=embedded_count)
             get_embedding_cache().save()
+            close_qdrant_client()
 
         except Exception as e:
             logger.warning(ls.EMBEDDING_GENERATION_FAILED, error=e)

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -618,6 +618,19 @@ MCP_SERVER_CONNECTED = "[GraphCode MCP] Connected to Memgraph at {host}:{port}"
 MCP_SERVER_FATAL_ERROR = "[GraphCode MCP] Fatal error: {error}"
 MCP_SERVER_SHUTDOWN = "[GraphCode MCP] Shutting down server..."
 
+# (H) Incremental update logs
+HASH_CACHE_LOADED = "Loaded hash cache with {count} entries from {path}"
+HASH_CACHE_LOAD_FAILED = "Failed to load hash cache from {path}: {error}"
+HASH_CACHE_SAVED = "Saved hash cache with {count} entries to {path}"
+HASH_CACHE_SAVE_FAILED = "Failed to save hash cache to {path}: {error}"
+INCREMENTAL_SKIPPED = "Skipped {count} unchanged files"
+INCREMENTAL_CHANGED = "Re-indexing {count} changed files"
+INCREMENTAL_DELETED = "Removed state for {count} deleted files"
+INCREMENTAL_FORCE = "Force mode enabled, bypassing hash cache"
+FILE_HASH_UNCHANGED = "File unchanged (hash match): {path}"
+FILE_HASH_CHANGED = "File changed (hash mismatch): {path}"
+FILE_HASH_NEW = "New file detected: {path}"
+
 # (H) Exclude prompt logs
 EXCLUDE_INVALID_INDEX = "Invalid index: {index} (out of range)"
 EXCLUDE_INVALID_INPUT = "Invalid input: '{input}' (expected number)"

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -50,6 +50,10 @@ EMBEDDINGS_COMPLETE = "Successfully generated {count} semantic embeddings"
 EMBEDDING_GENERATION_FAILED = "Failed to generate semantic embeddings: {error}"
 EMBEDDING_STORE_FAILED = "Failed to store embedding for {name}: {error}"
 EMBEDDING_SEARCH_FAILED = "Failed to search embeddings: {error}"
+EMBEDDING_CACHE_HIT = "Embedding cache hit for {count} snippets"
+EMBEDDING_CACHE_LOADED = "Loaded embedding cache with {count} entries from {path}"
+EMBEDDING_CACHE_SAVE_FAILED = "Failed to save embedding cache to {path}: {error}"
+EMBEDDING_CACHE_LOAD_FAILED = "Failed to load embedding cache from {path}: {error}"
 
 # (H) Image logs
 IMAGE_COPIED = "Copied image to temporary path: {path}"

--- a/codebase_rag/parser_loader.py
+++ b/codebase_rag/parser_loader.py
@@ -33,7 +33,7 @@ def _try_load_from_submodule(lang_name: cs.SupportedLanguage) -> LanguageLoader:
 
             setup_py_path = submodule_path / cs.SETUP_PY
             if setup_py_path.exists():
-                logger.debug(ls.BUILDING_BINDINGS.format(lang=lang_name))
+                logger.debug(ls.BUILDING_BINDINGS, lang=lang_name)
                 result = subprocess.run(
                     [sys.executable, cs.SETUP_PY, cs.BUILD_EXT_CMD, cs.INPLACE_FLAG],
                     check=False,
@@ -44,14 +44,15 @@ def _try_load_from_submodule(lang_name: cs.SupportedLanguage) -> LanguageLoader:
 
                 if result.returncode != 0:
                     logger.debug(
-                        ls.BUILD_FAILED.format(
-                            lang=lang_name, stdout=result.stdout, stderr=result.stderr
-                        )
+                        ls.BUILD_FAILED,
+                        lang=lang_name,
+                        stdout=result.stdout,
+                        stderr=result.stderr,
                     )
                     return None
-                logger.debug(ls.BUILD_SUCCESS.format(lang=lang_name))
+                logger.debug(ls.BUILD_SUCCESS, lang=lang_name)
 
-            logger.debug(ls.IMPORTING_MODULE.format(module=module_name))
+            logger.debug(ls.IMPORTING_MODULE, module=module_name)
             module = importlib.import_module(module_name)
 
             language_attrs: list[str] = [
@@ -63,21 +64,19 @@ def _try_load_from_submodule(lang_name: cs.SupportedLanguage) -> LanguageLoader:
             for attr_name in language_attrs:
                 if hasattr(module, attr_name):
                     logger.debug(
-                        ls.LOADED_FROM_SUBMODULE.format(lang=lang_name, attr=attr_name)
+                        ls.LOADED_FROM_SUBMODULE, lang=lang_name, attr=attr_name
                     )
                     loader: LanguageLoader = getattr(module, attr_name)
                     return loader
 
-            logger.debug(
-                ls.NO_LANG_ATTR.format(module=module_name, available=dir(module))
-            )
+            logger.debug(ls.NO_LANG_ATTR, module=module_name, available=dir(module))
 
         finally:
             if python_bindings_str in sys.path:
                 sys.path.remove(python_bindings_str)
 
     except Exception as e:
-        logger.debug(ls.SUBMODULE_LOAD_FAILED.format(lang=lang_name, error=e))
+        logger.debug(ls.SUBMODULE_LOAD_FAILED, lang=lang_name, error=e)
 
     return None
 
@@ -215,7 +214,7 @@ def _create_locals_query(
     try:
         return Query(language, locals_pattern)
     except Exception as e:
-        logger.debug(ls.LOCALS_QUERY_FAILED.format(lang=lang_name, error=e))
+        logger.debug(ls.LOCALS_QUERY_FAILED, lang=lang_name, error=e)
         return None
 
 
@@ -256,7 +255,7 @@ def _process_language(
 ) -> bool:
     lang_lib = LANGUAGE_LIBRARIES.get(lang_name)
     if not lang_lib:
-        logger.debug(ls.LIB_NOT_AVAILABLE.format(lang=lang_name))
+        logger.debug(ls.LIB_NOT_AVAILABLE, lang=lang_name)
         return False
 
     try:

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -18,6 +18,8 @@ from .utils import get_function_captures, is_method_node
 
 
 class CallProcessor:
+    __slots__ = ("ingestor", "repo_path", "project_name", "_resolver")
+
     def __init__(
         self,
         ingestor: IngestorProtocol,
@@ -54,7 +56,7 @@ class CallProcessor:
         queries: dict[cs.SupportedLanguage, LanguageQueries],
     ) -> None:
         relative_path = file_path.relative_to(self.repo_path)
-        logger.debug(ls.CALL_PROCESSING_FILE.format(path=relative_path))
+        logger.debug(ls.CALL_PROCESSING_FILE, path=relative_path)
 
         try:
             module_qn = cs.SEPARATOR_DOT.join(
@@ -70,7 +72,7 @@ class CallProcessor:
             self._process_module_level_calls(root_node, module_qn, language, queries)
 
         except Exception as e:
-            logger.error(ls.CALL_PROCESSING_FAILED.format(path=file_path, error=e))
+            logger.error(ls.CALL_PROCESSING_FAILED, path=file_path, error=e)
 
     def _process_calls_in_functions(
         self,
@@ -274,9 +276,10 @@ class CallProcessor:
         call_nodes = captures.get(cs.CAPTURE_CALL, [])
 
         logger.debug(
-            ls.CALL_FOUND_NODES.format(
-                count=len(call_nodes), language=language, caller=caller_qn
-            )
+            ls.CALL_FOUND_NODES,
+            count=len(call_nodes),
+            language=language,
+            caller=caller_qn,
         )
 
         for call_node in call_nodes:
@@ -311,12 +314,11 @@ class CallProcessor:
             else:
                 continue
             logger.debug(
-                ls.CALL_FOUND.format(
-                    caller=caller_qn,
-                    call_name=call_name,
-                    callee_type=callee_type,
-                    callee_qn=callee_qn,
-                )
+                ls.CALL_FOUND,
+                caller=caller_qn,
+                call_name=call_name,
+                callee_type=callee_type,
+                callee_qn=callee_qn,
             )
 
             self.ingestor.ensure_relationship_batch(
@@ -337,9 +339,7 @@ class CallProcessor:
 
         if not isinstance(current, Node):
             logger.warning(
-                ls.CALL_UNEXPECTED_PARENT.format(
-                    node=func_node, parent_type=type(current)
-                )
+                ls.CALL_UNEXPECTED_PARENT, node=func_node, parent_type=type(current)
             )
             return None
 

--- a/codebase_rag/parsers/class_ingest/method_override.py
+++ b/codebase_rag/parsers/class_ingest/method_override.py
@@ -66,9 +66,9 @@ def check_method_overrides(
                     (cs.NodeLabel.METHOD, cs.KEY_QUALIFIED_NAME, parent_method_qn),
                 )
                 logger.debug(
-                    logs.CLASS_METHOD_OVERRIDE.format(
-                        method_qn=method_qn, parent_method_qn=parent_method_qn
-                    )
+                    logs.CLASS_METHOD_OVERRIDE,
+                    method_qn=method_qn,
+                    parent_method_qn=parent_method_qn,
                 )
                 return
 

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
 
 
 class ClassIngestMixin:
+    __slots__ = ()
     ingestor: IngestorProtocol
     repo_path: Path
     project_name: str

--- a/codebase_rag/parsers/class_ingest/parent_extraction.py
+++ b/codebase_rag/parsers/class_ingest/parent_extraction.py
@@ -90,9 +90,9 @@ def parse_cpp_base_classes(
                 )
                 parent_classes.append(parent_qn)
                 logger.debug(
-                    logs.CLASS_CPP_INHERITANCE.format(
-                        parent_name=parent_name, parent_qn=parent_qn
-                    )
+                    logs.CLASS_CPP_INHERITANCE,
+                    parent_name=parent_name,
+                    parent_qn=parent_qn,
                 )
 
     return parent_classes

--- a/codebase_rag/parsers/dependency_parser.py
+++ b/codebase_rag/parsers/dependency_parser.py
@@ -26,11 +26,15 @@ def _extract_pep508_package_name(dep_string: str) -> tuple[str, str]:
 
 
 class DependencyParser:
+    __slots__ = ()
+
     def parse(self, file_path: Path) -> list[Dependency]:
         raise NotImplementedError
 
 
 class PyProjectTomlParser(DependencyParser):
+    __slots__ = ()
+
     def parse(self, file_path: Path) -> list[Dependency]:
         dependencies: list[Dependency] = []
         try:
@@ -72,6 +76,8 @@ class PyProjectTomlParser(DependencyParser):
 
 
 class RequirementsTxtParser(DependencyParser):
+    __slots__ = ()
+
     def parse(self, file_path: Path) -> list[Dependency]:
         dependencies: list[Dependency] = []
         try:
@@ -92,6 +98,8 @@ class RequirementsTxtParser(DependencyParser):
 
 
 class PackageJsonParser(DependencyParser):
+    __slots__ = ()
+
     def parse(self, file_path: Path) -> list[Dependency]:
         dependencies: list[Dependency] = []
         try:
@@ -120,6 +128,8 @@ class PackageJsonParser(DependencyParser):
 
 
 class CargoTomlParser(DependencyParser):
+    __slots__ = ()
+
     def parse(self, file_path: Path) -> list[Dependency]:
         dependencies: list[Dependency] = []
         try:
@@ -148,6 +158,8 @@ class CargoTomlParser(DependencyParser):
 
 
 class GoModParser(DependencyParser):
+    __slots__ = ()
+
     def parse(self, file_path: Path) -> list[Dependency]:
         dependencies: list[Dependency] = []
         try:
@@ -186,6 +198,8 @@ class GoModParser(DependencyParser):
 
 
 class GemfileParser(DependencyParser):
+    __slots__ = ()
+
     def parse(self, file_path: Path) -> list[Dependency]:
         dependencies: list[Dependency] = []
         try:
@@ -206,6 +220,8 @@ class GemfileParser(DependencyParser):
 
 
 class ComposerJsonParser(DependencyParser):
+    __slots__ = ()
+
     def parse(self, file_path: Path) -> list[Dependency]:
         dependencies: list[Dependency] = []
         try:
@@ -229,6 +245,8 @@ class ComposerJsonParser(DependencyParser):
 
 
 class CsprojParser(DependencyParser):
+    __slots__ = ()
+
     def parse(self, file_path: Path) -> list[Dependency]:
         dependencies: list[Dependency] = []
         try:

--- a/codebase_rag/parsers/factory.py
+++ b/codebase_rag/parsers/factory.py
@@ -16,6 +16,24 @@ from .type_inference import TypeInferenceEngine
 
 
 class ProcessorFactory:
+    __slots__ = (
+        "ingestor",
+        "repo_path",
+        "project_name",
+        "queries",
+        "function_registry",
+        "simple_name_lookup",
+        "ast_cache",
+        "unignore_paths",
+        "exclude_paths",
+        "module_qn_to_file_path",
+        "_import_processor",
+        "_structure_processor",
+        "_definition_processor",
+        "_type_inference",
+        "_call_processor",
+    )
+
     def __init__(
         self,
         ingestor: IngestorProtocol,

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -41,6 +41,7 @@ class FunctionResolution(NamedTuple):
 
 
 class FunctionIngestMixin:
+    __slots__ = ()
     ingestor: IngestorProtocol
     repo_path: Path
     project_name: str

--- a/codebase_rag/parsers/handlers/base.py
+++ b/codebase_rag/parsers/handlers/base.py
@@ -13,6 +13,8 @@ if TYPE_CHECKING:
 
 
 class BaseLanguageHandler:
+    __slots__ = ()
+
     def is_inside_method_with_object_literals(self, node: ASTNode) -> bool:
         return False
 

--- a/codebase_rag/parsers/handlers/cpp.py
+++ b/codebase_rag/parsers/handlers/cpp.py
@@ -17,6 +17,8 @@ if TYPE_CHECKING:
 
 
 class CppHandler(BaseLanguageHandler):
+    __slots__ = ()
+
     def extract_function_name(self, node: ASTNode) -> str | None:
         if func_name := cpp_utils.extract_function_name(node):
             return func_name

--- a/codebase_rag/parsers/handlers/java.py
+++ b/codebase_rag/parsers/handlers/java.py
@@ -11,6 +11,8 @@ if TYPE_CHECKING:
 
 
 class JavaHandler(BaseLanguageHandler):
+    __slots__ = ()
+
     def extract_decorators(self, node: ASTNode) -> list[str]:
         return java_utils.extract_from_modifiers_node(node, frozenset()).annotations
 

--- a/codebase_rag/parsers/handlers/js_ts.py
+++ b/codebase_rag/parsers/handlers/js_ts.py
@@ -12,6 +12,8 @@ if TYPE_CHECKING:
 
 
 class JsTsHandler(BaseLanguageHandler):
+    __slots__ = ()
+
     def extract_decorators(self, node: ASTNode) -> list[str]:
         return [
             decorator_text

--- a/codebase_rag/parsers/handlers/lua.py
+++ b/codebase_rag/parsers/handlers/lua.py
@@ -11,6 +11,8 @@ if TYPE_CHECKING:
 
 
 class LuaHandler(BaseLanguageHandler):
+    __slots__ = ()
+
     def extract_function_name(self, node: ASTNode) -> str | None:
         if (name_node := node.child_by_field_name(cs.TS_FIELD_NAME)) and name_node.text:
             from ..utils import safe_decode_text

--- a/codebase_rag/parsers/handlers/protocol.py
+++ b/codebase_rag/parsers/handlers/protocol.py
@@ -10,6 +10,8 @@ if TYPE_CHECKING:
 
 
 class LanguageHandler(Protocol):
+    __slots__ = ()
+
     def is_inside_method_with_object_literals(self, node: ASTNode) -> bool: ...
 
     def is_class_method(self, node: ASTNode) -> bool: ...

--- a/codebase_rag/parsers/handlers/python.py
+++ b/codebase_rag/parsers/handlers/python.py
@@ -11,6 +11,8 @@ if TYPE_CHECKING:
 
 
 class PythonHandler(BaseLanguageHandler):
+    __slots__ = ()
+
     def extract_decorators(self, node: ASTNode) -> list[str]:
         if not node.parent or node.parent.type != cs.TS_PY_DECORATED_DEFINITION:
             return []

--- a/codebase_rag/parsers/handlers/rust.py
+++ b/codebase_rag/parsers/handlers/rust.py
@@ -17,6 +17,8 @@ if TYPE_CHECKING:
 
 
 class RustHandler(BaseLanguageHandler):
+    __slots__ = ()
+
     def extract_decorators(self, node: ASTNode) -> list[str]:
         outer_decorators: list[str] = []
         sibling = node.prev_named_sibling

--- a/codebase_rag/parsers/java/method_resolver.py
+++ b/codebase_rag/parsers/java/method_resolver.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 
 
 class JavaMethodResolverMixin:
+    __slots__ = ()
     import_processor: ImportProcessor
     function_registry: FunctionRegistryTrieProtocol
     project_name: str
@@ -355,34 +356,32 @@ class JavaMethodResolverMixin:
             logger.debug(ls.JAVA_NO_METHOD_NAME)
             return None
 
-        logger.debug(
-            ls.JAVA_RESOLVING_CALL.format(method=method_name, object=object_ref)
-        )
+        logger.debug(ls.JAVA_RESOLVING_CALL, method=method_name, object=object_ref)
 
         if not object_ref:
-            logger.debug(ls.JAVA_RESOLVING_STATIC.format(method=method_name))
+            logger.debug(ls.JAVA_RESOLVING_STATIC, method=method_name)
             result = self._resolve_static_or_local_method(str(method_name), module_qn)
             if result:
-                logger.debug(ls.JAVA_FOUND_STATIC.format(result=result))
+                logger.debug(ls.JAVA_FOUND_STATIC, result=result)
             else:
-                logger.debug(ls.JAVA_STATIC_NOT_FOUND.format(method=method_name))
+                logger.debug(ls.JAVA_STATIC_NOT_FOUND, method=method_name)
             return result
 
-        logger.debug(ls.JAVA_RESOLVING_OBJ_TYPE.format(object=object_ref))
+        logger.debug(ls.JAVA_RESOLVING_OBJ_TYPE, object=object_ref)
         if not (
             object_type := self._resolve_java_object_type(
                 str(object_ref), local_var_types, module_qn
             )
         ):
-            logger.debug(ls.JAVA_OBJ_TYPE_UNKNOWN.format(object=object_ref))
+            logger.debug(ls.JAVA_OBJ_TYPE_UNKNOWN, object=object_ref)
             return None
 
-        logger.debug(ls.JAVA_OBJ_TYPE_RESOLVED.format(type=object_type))
+        logger.debug(ls.JAVA_OBJ_TYPE_RESOLVED, type=object_type)
         result = self._resolve_instance_method(object_type, str(method_name), module_qn)
         if result:
-            logger.debug(ls.JAVA_FOUND_INSTANCE.format(result=result))
+            logger.debug(ls.JAVA_FOUND_INSTANCE, result=result)
         else:
             logger.debug(
-                ls.JAVA_INSTANCE_NOT_FOUND.format(type=object_type, method=method_name)
+                ls.JAVA_INSTANCE_NOT_FOUND, type=object_type, method=method_name
             )
         return result

--- a/codebase_rag/parsers/java/type_inference.py
+++ b/codebase_rag/parsers/java/type_inference.py
@@ -26,6 +26,21 @@ class JavaTypeInferenceEngine(
     JavaVariableAnalyzerMixin,
     JavaMethodResolverMixin,
 ):
+    __slots__ = (
+        "import_processor",
+        "function_registry",
+        "repo_path",
+        "project_name",
+        "ast_cache",
+        "queries",
+        "module_qn_to_file_path",
+        "class_inheritance",
+        "simple_name_lookup",
+        "_lookup_cache",
+        "_lookup_in_progress",
+        "_fqn_to_module_qn",
+    )
+
     def __init__(
         self,
         import_processor: ImportProcessor,
@@ -83,10 +98,10 @@ class JavaTypeInferenceEngine(
 
         try:
             self._collect_all_variable_types(scope_node, local_var_types, module_qn)
-            logger.debug(ls.JAVA_VAR_TYPE_MAP_BUILT.format(count=len(local_var_types)))
+            logger.debug(ls.JAVA_VAR_TYPE_MAP_BUILT, count=len(local_var_types))
 
         except Exception as e:
-            logger.error(ls.JAVA_VAR_TYPE_MAP_FAILED.format(error=e))
+            logger.error(ls.JAVA_VAR_TYPE_MAP_FAILED, error=e)
 
         return local_var_types
 

--- a/codebase_rag/parsers/java/type_resolver.py
+++ b/codebase_rag/parsers/java/type_resolver.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 
 
 class JavaTypeResolverMixin:
+    __slots__ = ()
     import_processor: ImportProcessor
     function_registry: FunctionRegistryTrieProtocol
     module_qn_to_file_path: dict[str, Path]

--- a/codebase_rag/parsers/java/variable_analyzer.py
+++ b/codebase_rag/parsers/java/variable_analyzer.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 
 
 class JavaVariableAnalyzerMixin:
+    __slots__ = ()
     ast_cache: ASTCacheProtocol
     module_qn_to_file_path: dict[str, Path]
     _lookup_cache: dict[str, str | None]
@@ -84,7 +85,7 @@ class JavaVariableAnalyzerMixin:
         if param_name and param_type:
             resolved_type = self._resolve_java_type_name(param_type, module_qn)
             local_var_types[param_name] = resolved_type
-            logger.debug(ls.JAVA_PARAM.format(name=param_name, type=resolved_type))
+            logger.debug(ls.JAVA_PARAM, name=param_name, type=resolved_type)
 
     def _process_spread_parameter(
         self, param_node: ASTNode, local_var_types: dict[str, str], module_qn: str
@@ -103,9 +104,7 @@ class JavaVariableAnalyzerMixin:
         if param_name and param_type:
             resolved_type = self._resolve_java_type_name(param_type, module_qn)
             local_var_types[param_name] = resolved_type
-            logger.debug(
-                ls.JAVA_VARARGS_PARAM.format(name=param_name, type=resolved_type)
-            )
+            logger.debug(ls.JAVA_VARARGS_PARAM, name=param_name, type=resolved_type)
 
     def _analyze_java_local_variables(
         self, scope_node: ASTNode, local_var_types: dict[str, str], module_qn: str
@@ -164,15 +163,13 @@ class JavaVariableAnalyzerMixin:
                 resolved_type = self._resolve_java_type_name(inferred_type, module_qn)
                 local_var_types[var_name] = resolved_type
                 logger.debug(
-                    ls.JAVA_LOCAL_VAR_INFERRED.format(name=var_name, type=resolved_type)
+                    ls.JAVA_LOCAL_VAR_INFERRED, name=var_name, type=resolved_type
                 )
                 return
 
         resolved_type = self._resolve_java_type_name(declared_type, module_qn)
         local_var_types[var_name] = resolved_type
-        logger.debug(
-            ls.JAVA_LOCAL_VAR_DECLARED.format(name=var_name, type=resolved_type)
-        )
+        logger.debug(ls.JAVA_LOCAL_VAR_DECLARED, name=var_name, type=resolved_type)
 
     def _analyze_java_class_fields(
         self, scope_node: ASTNode, local_var_types: dict[str, str], module_qn: str
@@ -201,7 +198,7 @@ class JavaVariableAnalyzerMixin:
                     if str(field_name) not in local_var_types:
                         local_var_types[str(field_name)] = resolved_type
                     logger.debug(
-                        ls.JAVA_CLASS_FIELD.format(name=field_name, type=resolved_type)
+                        ls.JAVA_CLASS_FIELD, name=field_name, type=resolved_type
                     )
 
     def _analyze_java_constructor_assignments(
@@ -235,7 +232,7 @@ class JavaVariableAnalyzerMixin:
         ):
             resolved_type = self._resolve_java_type_name(inferred_type, module_qn)
             local_var_types[var_name] = resolved_type
-            logger.debug(ls.JAVA_ASSIGNMENT.format(name=var_name, type=resolved_type))
+            logger.debug(ls.JAVA_ASSIGNMENT, name=var_name, type=resolved_type)
 
     def _extract_java_variable_reference(self, node: ASTNode) -> str | None:
         match node.type:
@@ -297,9 +294,7 @@ class JavaVariableAnalyzerMixin:
         ):
             resolved_type = self._resolve_java_type_name(var_type, module_qn)
             local_var_types[var_name] = resolved_type
-            logger.debug(
-                ls.JAVA_ENHANCED_FOR_VAR.format(name=var_name, type=resolved_type)
-            )
+            logger.debug(ls.JAVA_ENHANCED_FOR_VAR, name=var_name, type=resolved_type)
 
     def _extract_for_loop_variable_from_children(
         self, for_node: ASTNode, local_var_types: dict[str, str], module_qn: str
@@ -325,9 +320,9 @@ class JavaVariableAnalyzerMixin:
                         )
                         local_var_types[var_name] = resolved_type
                         logger.debug(
-                            ls.JAVA_ENHANCED_FOR_VAR_ALT.format(
-                                name=var_name, type=resolved_type
-                            )
+                            ls.JAVA_ENHANCED_FOR_VAR_ALT,
+                            name=var_name,
+                            type=resolved_type,
                         )
                         break
 

--- a/codebase_rag/parsers/js_ts/ingest.py
+++ b/codebase_rag/parsers/js_ts/ingest.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 
 
 class JsTsIngestMixin(JsTsModuleSystemMixin):
+    __slots__ = ()
     ingestor: IngestorProtocol
     repo_path: Path
     project_name: str
@@ -88,7 +89,7 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
                 language_obj, root_node, module_qn
             )
         except Exception as e:
-            logger.debug(lg.JS_PROTOTYPE_INHERITANCE_FAILED.format(error=e))
+            logger.debug(lg.JS_PROTOTYPE_INHERITANCE_FAILED, error=e)
 
     def _process_prototype_inheritance_captures(
         self, language_obj, root_node, module_qn
@@ -122,9 +123,7 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
                 )
 
                 logger.debug(
-                    lg.JS_PROTOTYPE_INHERITANCE.format(
-                        child_qn=child_qn, parent_qn=parent_qn
-                    )
+                    lg.JS_PROTOTYPE_INHERITANCE, child_qn=child_qn, parent_qn=parent_qn
                 )
 
     def _ingest_prototype_method_assignments(
@@ -143,7 +142,7 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
         try:
             self._process_prototype_method_captures(language_obj, root_node, module_qn)
         except Exception as e:
-            logger.debug(lg.JS_PROTOTYPE_METHODS_FAILED.format(error=e))
+            logger.debug(lg.JS_PROTOTYPE_METHODS_FAILED, error=e)
 
     def _process_prototype_method_captures(self, language_obj, root_node, module_qn):
         method_query = Query(language_obj, cs.JS_PROTOTYPE_METHOD_QUERY)
@@ -174,9 +173,9 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
                     cs.KEY_DOCSTRING: self._get_docstring(func_node),
                 }
                 logger.info(
-                    lg.JS_PROTOTYPE_METHOD_FOUND.format(
-                        method_name=method_name, method_qn=method_qn
-                    )
+                    lg.JS_PROTOTYPE_METHOD_FOUND,
+                    method_name=method_name,
+                    method_qn=method_qn,
                 )
                 self.ingestor.ensure_node_batch(cs.NodeLabel.FUNCTION, method_props)
 
@@ -190,9 +189,9 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
                 )
 
                 logger.debug(
-                    lg.JS_PROTOTYPE_METHOD_DEFINES.format(
-                        constructor_qn=constructor_qn, method_qn=method_qn
-                    )
+                    lg.JS_PROTOTYPE_METHOD_DEFINES,
+                    constructor_qn=constructor_qn,
+                    method_qn=method_qn,
                 )
 
     def _ingest_object_literal_methods(
@@ -213,7 +212,7 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
                     language_obj, query_text, root_node, module_qn, lang_config
                 )
         except Exception as e:
-            logger.debug(lg.JS_OBJECT_METHODS_DETECT_FAILED.format(error=e))
+            logger.debug(lg.JS_OBJECT_METHODS_DETECT_FAILED, error=e)
 
     def _process_object_method_query(
         self,
@@ -250,7 +249,7 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
                     method_name_node, method_func_node, module_qn, lang_config
                 )
         except Exception as e:
-            logger.debug(lg.JS_OBJECT_METHODS_PROCESS_FAILED.format(error=e))
+            logger.debug(lg.JS_OBJECT_METHODS_PROCESS_FAILED, error=e)
 
     def _process_single_object_method(
         self,
@@ -314,9 +313,7 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
             cs.KEY_DOCSTRING: self._get_docstring(method_func_node),
         }
         logger.info(
-            lg.JS_OBJECT_METHOD_FOUND.format(
-                method_name=method_name, method_qn=method_qn
-            )
+            lg.JS_OBJECT_METHOD_FOUND, method_name=method_name, method_qn=method_qn
         )
         self.ingestor.ensure_node_batch(cs.NodeLabel.FUNCTION, method_props)
 
@@ -352,7 +349,7 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
                     lang_query, query_text, root_node, module_qn, lang_config
                 )
         except Exception as e:
-            logger.debug(lg.JS_ASSIGNMENT_ARROW_DETECT_FAILED.format(error=e))
+            logger.debug(lg.JS_ASSIGNMENT_ARROW_DETECT_FAILED, error=e)
 
     def _process_arrow_query(
         self,
@@ -390,7 +387,7 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
                 lg.JS_ASSIGNMENT_FUNC_EXPR_FOUND,
             )
         except Exception as e:
-            logger.debug(lg.JS_ASSIGNMENT_ARROW_QUERY_FAILED.format(error=e))
+            logger.debug(lg.JS_ASSIGNMENT_ARROW_QUERY_FAILED, error=e)
 
     def _process_direct_arrow_functions(
         self,
@@ -506,9 +503,7 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
             cs.KEY_DOCSTRING: self._get_docstring(function_node),
         }
 
-        logger.debug(
-            log_message.format(function_name=function_name, function_qn=function_qn)
-        )
+        logger.debug(log_message, function_name=function_name, function_qn=function_qn)
         self.ingestor.ensure_node_batch(cs.NodeLabel.FUNCTION, function_props)
         self.function_registry[function_qn] = NodeType.FUNCTION
         self.simple_name_lookup[function_name].add(function_qn)

--- a/codebase_rag/parsers/js_ts/module_system.py
+++ b/codebase_rag/parsers/js_ts/module_system.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 
 
 class JsTsModuleSystemMixin:
+    __slots__ = ("_processed_imports",)
     ingestor: IngestorProtocol
     repo_path: Path
     project_name: str
@@ -71,10 +72,10 @@ class JsTsModuleSystemMixin:
                     )
 
             except Exception as e:
-                logger.debug(ls.JS_COMMONJS_DESTRUCTURE_FAILED.format(error=e))
+                logger.debug(ls.JS_COMMONJS_DESTRUCTURE_FAILED, error=e)
 
         except Exception as e:
-            logger.debug(ls.JS_MISSING_IMPORT_PATTERNS_FAILED.format(error=e))
+            logger.debug(ls.JS_MISSING_IMPORT_PATTERNS_FAILED, error=e)
 
     def _extract_require_module_name(self, declarator: ASTNode) -> str | None:
         name_node = declarator.child_by_field_name(cs.FIELD_NAME)
@@ -148,7 +149,7 @@ class JsTsModuleSystemMixin:
                 self._process_destructured_child(child, module_name, module_qn)
 
         except Exception as e:
-            logger.debug(ls.JS_COMMONJS_VAR_DECLARATOR_FAILED.format(error=e))
+            logger.debug(ls.JS_COMMONJS_VAR_DECLARATOR_FAILED, error=e)
 
     def _process_commonjs_import(
         self, imported_name: str, module_name: str, module_qn: str
@@ -179,20 +180,17 @@ class JsTsModuleSystemMixin:
                 )
 
                 logger.debug(
-                    ls.JS_MISSING_IMPORT_PATTERN.format(
-                        module_qn=module_qn,
-                        imported_name=imported_name,
-                        resolved_source_module=resolved_source_module,
-                    )
+                    ls.JS_MISSING_IMPORT_PATTERN,
+                    module_qn=module_qn,
+                    imported_name=imported_name,
+                    resolved_source_module=resolved_source_module,
                 )
 
                 self._processed_imports.add(import_key)
 
         except Exception as e:
             logger.debug(
-                ls.JS_COMMONJS_IMPORT_FAILED.format(
-                    imported_name=imported_name, error=e
-                )
+                ls.JS_COMMONJS_IMPORT_FAILED, imported_name=imported_name, error=e
             )
 
     def _ingest_export_function(
@@ -302,7 +300,7 @@ class JsTsModuleSystemMixin:
                 )
 
             except Exception as e:
-                logger.debug(ls.JS_COMMONJS_EXPORTS_QUERY_FAILED.format(error=e))
+                logger.debug(ls.JS_COMMONJS_EXPORTS_QUERY_FAILED, error=e)
 
     def _ingest_es6_exports(
         self,
@@ -365,7 +363,7 @@ class JsTsModuleSystemMixin:
                                             )
 
                 except Exception as e:
-                    logger.debug(ls.JS_ES6_EXPORTS_QUERY_FAILED.format(error=e))
+                    logger.debug(ls.JS_ES6_EXPORTS_QUERY_FAILED, error=e)
 
         except Exception as e:
-            logger.debug(ls.JS_ES6_EXPORTS_DETECT_FAILED.format(error=e))
+            logger.debug(ls.JS_ES6_EXPORTS_DETECT_FAILED, error=e)

--- a/codebase_rag/parsers/js_ts/type_inference.py
+++ b/codebase_rag/parsers/js_ts/type_inference.py
@@ -11,6 +11,13 @@ from . import utils as ut
 
 
 class JsTypeInferenceEngine:
+    __slots__ = (
+        "import_processor",
+        "function_registry",
+        "project_name",
+        "_find_method_ast_node",
+    )
+
     def __init__(
         self,
         import_processor: ImportProcessor,
@@ -46,9 +53,9 @@ class JsTypeInferenceEngine:
                         var_name = safe_decode_text(name_node)
                         if var_name is not None:
                             logger.debug(
-                                ls.JS_VAR_DECLARATOR_FOUND.format(
-                                    var_name=var_name, module_qn=module_qn
-                                )
+                                ls.JS_VAR_DECLARATOR_FOUND,
+                                var_name=var_name,
+                                module_qn=module_qn,
                             )
 
                             if var_type := self._infer_js_variable_type_from_value(
@@ -56,28 +63,26 @@ class JsTypeInferenceEngine:
                             ):
                                 local_var_types[var_name] = var_type
                                 logger.debug(
-                                    ls.JS_VAR_INFERRED.format(
-                                        var_name=var_name, var_type=var_type
-                                    )
+                                    ls.JS_VAR_INFERRED,
+                                    var_name=var_name,
+                                    var_type=var_type,
                                 )
                             else:
-                                logger.debug(
-                                    ls.JS_VAR_INFER_FAILED.format(var_name=var_name)
-                                )
+                                logger.debug(ls.JS_VAR_INFER_FAILED, var_name=var_name)
 
             stack.extend(reversed(current.children))
 
         logger.debug(
-            ls.JS_VAR_TYPE_MAP_BUILT.format(
-                count=len(local_var_types), declarator_count=declarator_count
-            )
+            ls.JS_VAR_TYPE_MAP_BUILT,
+            count=len(local_var_types),
+            declarator_count=declarator_count,
         )
         return local_var_types
 
     def _infer_js_variable_type_from_value(
         self, value_node: ASTNode, module_qn: str
     ) -> str | None:
-        logger.debug(ls.JS_INFER_VALUE_NODE.format(node_type=value_node.type))
+        logger.debug(ls.JS_INFER_VALUE_NODE, node_type=value_node.type)
 
         if value_node.type == cs.TS_NEW_EXPRESSION:
             if class_name := ut.extract_constructor_name(value_node):
@@ -87,28 +92,23 @@ class JsTypeInferenceEngine:
         elif value_node.type == cs.TS_CALL_EXPRESSION:
             func_node = value_node.child_by_field_name("function")
             func_type = func_node.type if func_node else cs.STR_NONE
-            logger.debug(ls.JS_CALL_EXPR_FUNC_NODE.format(func_type=func_type))
+            logger.debug(ls.JS_CALL_EXPR_FUNC_NODE, func_type=func_type)
 
             if func_node and func_node.type == cs.TS_MEMBER_EXPRESSION:
                 method_call_text = ut.extract_method_call(func_node)
-                logger.debug(
-                    ls.JS_EXTRACTED_METHOD_CALL.format(method_call=method_call_text)
-                )
+                logger.debug(ls.JS_EXTRACTED_METHOD_CALL, method_call=method_call_text)
                 if method_call_text:
                     if inferred_type := self._infer_js_method_return_type(
                         method_call_text, module_qn
                     ):
                         logger.debug(
-                            ls.JS_TYPE_INFERRED.format(
-                                method_call=method_call_text,
-                                inferred_type=inferred_type,
-                            )
+                            ls.JS_TYPE_INFERRED,
+                            method_call=method_call_text,
+                            inferred_type=inferred_type,
                         )
                         return inferred_type
                     logger.debug(
-                        ls.JS_RETURN_TYPE_INFER_FAILED.format(
-                            method_call=method_call_text
-                        )
+                        ls.JS_RETURN_TYPE_INFER_FAILED, method_call=method_call_text
                     )
 
             elif func_node and func_node.type == cs.TS_IDENTIFIER:
@@ -116,7 +116,7 @@ class JsTypeInferenceEngine:
                 if func_name:
                     return safe_decode_text(func_node)
 
-        logger.debug(ls.JS_NO_PATTERN_MATCHED.format(node_type=value_node.type))
+        logger.debug(ls.JS_NO_PATTERN_MATCHED, node_type=value_node.type)
         return None
 
     def _infer_js_method_return_type(
@@ -124,7 +124,7 @@ class JsTypeInferenceEngine:
     ) -> str | None:
         parts = method_call.split(cs.SEPARATOR_DOT)
         if len(parts) != 2:
-            logger.debug(ls.JS_METHOD_CALL_INVALID.format(method_call=method_call))
+            logger.debug(ls.JS_METHOD_CALL_INVALID, method_call=method_call)
             return None
 
         class_name, method_name = parts
@@ -132,27 +132,23 @@ class JsTypeInferenceEngine:
         class_qn = self._resolve_js_class_name(class_name, module_qn)
         if not class_qn:
             logger.debug(
-                ls.JS_CLASS_RESOLVE_FAILED.format(
-                    class_name=class_name, module_qn=module_qn
-                )
+                ls.JS_CLASS_RESOLVE_FAILED, class_name=class_name, module_qn=module_qn
             )
             return None
 
-        logger.debug(
-            ls.JS_CLASS_RESOLVED.format(class_name=class_name, class_qn=class_qn)
-        )
+        logger.debug(ls.JS_CLASS_RESOLVED, class_name=class_name, class_qn=class_qn)
 
         method_qn = f"{class_qn}{cs.SEPARATOR_DOT}{method_name}"
-        logger.debug(ls.JS_LOOKING_FOR_METHOD.format(method_qn=method_qn))
+        logger.debug(ls.JS_LOOKING_FOR_METHOD, method_qn=method_qn)
 
         method_node = self._find_method_ast_node(method_qn)
         if not method_node:
-            logger.debug(ls.JS_METHOD_AST_NOT_FOUND.format(method_qn=method_qn))
+            logger.debug(ls.JS_METHOD_AST_NOT_FOUND, method_qn=method_qn)
             return None
 
         return_type = self._analyze_return_statements(method_node, method_qn)
         logger.debug(
-            ls.JS_RETURN_ANALYZED.format(method_qn=method_qn, return_type=return_type)
+            ls.JS_RETURN_ANALYZED, method_qn=method_qn, return_type=return_type
         )
         return return_type
 

--- a/codebase_rag/parsers/lua/type_inference.py
+++ b/codebase_rag/parsers/lua/type_inference.py
@@ -14,6 +14,12 @@ if TYPE_CHECKING:
 
 
 class LuaTypeInferenceEngine:
+    __slots__ = (
+        "import_processor",
+        "function_registry",
+        "project_name",
+    )
+
     def __init__(
         self,
         import_processor: ImportProcessor,
@@ -36,7 +42,7 @@ class LuaTypeInferenceEngine:
                 self._process_variable_declaration(current, module_qn, local_var_types)
             stack.extend(reversed(current.children))
 
-        logger.debug(ls.LUA_VAR_TYPE_MAP_BUILT.format(count=len(local_var_types)))
+        logger.debug(ls.LUA_VAR_TYPE_MAP_BUILT, count=len(local_var_types))
         return local_var_types
 
     def _process_variable_declaration(
@@ -62,9 +68,7 @@ class LuaTypeInferenceEngine:
                 func_calls[i], module_qn
             ):
                 local_var_types[var_name] = var_type
-                logger.debug(
-                    ls.LUA_VAR_INFERRED.format(var_name=var_name, var_type=var_type)
-                )
+                logger.debug(ls.LUA_VAR_INFERRED, var_name=var_name, var_type=var_type)
 
     def _extract_var_names(self, assignment: TreeSitterNodeProtocol) -> list[str]:
         names: list[str] = []
@@ -110,11 +114,10 @@ class LuaTypeInferenceEngine:
                             class_name, module_qn
                         ):
                             logger.debug(
-                                ls.LUA_TYPE_INFERENCE_RETURN.format(
-                                    class_name=class_name,
-                                    method_name=method_name,
-                                    class_qn=class_qn,
-                                )
+                                ls.LUA_TYPE_INFERENCE_RETURN,
+                                class_name=class_name,
+                                method_name=method_name,
+                                class_qn=class_qn,
                             )
                             return class_qn
 

--- a/codebase_rag/parsers/py/ast_analyzer.py
+++ b/codebase_rag/parsers/py/ast_analyzer.py
@@ -45,6 +45,7 @@ else:
 
 
 class PythonAstAnalyzerMixin(_AstBase):
+    __slots__ = ()
     queries: dict[cs.SupportedLanguage, LanguageQueries]
     module_qn_to_file_path: dict[str, Path]
     ast_cache: ASTCacheProtocol
@@ -140,7 +141,7 @@ class PythonAstAnalyzerMixin(_AstBase):
             right_node, module_qn
         ):
             local_var_types[var_name] = inferred_type
-            logger.debug(lg.PY_TYPE_SIMPLE.format(var=var_name, type=inferred_type))
+            logger.debug(lg.PY_TYPE_SIMPLE, var=var_name, type=inferred_type)
 
     def _process_assignment_complex(
         self, assignment_node: Node, local_var_types: dict[str, str], module_qn: str
@@ -162,7 +163,7 @@ class PythonAstAnalyzerMixin(_AstBase):
             right_node, module_qn, local_var_types
         ):
             local_var_types[var_name] = inferred_type
-            logger.debug(lg.PY_TYPE_COMPLEX.format(var=var_name, type=inferred_type))
+            logger.debug(lg.PY_TYPE_COMPLEX, var=var_name, type=inferred_type)
 
     def _extract_assignment_variable_name(self, node: Node) -> str | None:
         if node.type != cs.TS_PY_IDENTIFIER or node.text is None:
@@ -344,13 +345,11 @@ class PythonAstAnalyzerMixin(_AstBase):
             local_vars = self.build_local_variable_type_map(method_node, module_qn)
             if identifier in local_vars:
                 logger.debug(
-                    lg.PY_VAR_FROM_CONTEXT.format(
-                        var=identifier, type=local_vars[identifier]
-                    )
+                    lg.PY_VAR_FROM_CONTEXT, var=identifier, type=local_vars[identifier]
                 )
                 return local_vars[identifier]
 
-        logger.debug(lg.PY_VAR_CANNOT_INFER.format(var=identifier))
+        logger.debug(lg.PY_VAR_CANNOT_INFER, var=identifier)
         return None
 
     def _analyze_attribute_return(self, expr_node: Node, method_qn: str) -> str | None:

--- a/codebase_rag/parsers/py/expression_analyzer.py
+++ b/codebase_rag/parsers/py/expression_analyzer.py
@@ -40,6 +40,7 @@ else:
 
 
 class PythonExpressionAnalyzerMixin(_ExprBase):
+    __slots__ = ()
     import_processor: ImportProcessor
     function_registry: FunctionRegistryTrieProtocol
     simple_name_lookup: SimpleNameLookup
@@ -243,7 +244,7 @@ class PythonExpressionAnalyzerMixin(_ExprBase):
                 return self._analyze_method_return_statements(method_node, method_qn)
             return None
         except Exception as e:
-            logger.debug(lg.PY_INFER_RETURN_FAILED.format(method=method_call, error=e))
+            logger.debug(lg.PY_INFER_RETURN_FAILED, method=method_call, error=e)
             return None
 
     def _resolve_method_qualified_name(
@@ -305,11 +306,10 @@ class PythonExpressionAnalyzerMixin(_ExprBase):
         for qn in self.simple_name_lookup.get(class_name, []):
             if result := self._try_resolve_method(qn, method_name):
                 logger.debug(
-                    lg.PY_RESOLVED_METHOD.format(
-                        class_name=class_name,
-                        method_name=method_name,
-                        method_qn=result,
-                    )
+                    lg.PY_RESOLVED_METHOD,
+                    class_name=class_name,
+                    method_name=method_name,
+                    method_qn=result,
                 )
                 return result
 
@@ -355,7 +355,7 @@ class PythonExpressionAnalyzerMixin(_ExprBase):
             return instance_vars.get(full_attr_name)
 
         except Exception as e:
-            logger.debug(lg.PY_INFER_ATTR_FAILED.format(attr=attribute_name, error=e))
+            logger.debug(lg.PY_INFER_ATTR_FAILED, attr=attribute_name, error=e)
             return None
 
     def _find_class_in_scope(self, class_name: str, module_qn: str) -> str | None:

--- a/codebase_rag/parsers/py/type_inference.py
+++ b/codebase_rag/parsers/py/type_inference.py
@@ -30,6 +30,21 @@ class PythonTypeInferenceEngine(
     PythonAstAnalyzerMixin,
     PythonVariableAnalyzerMixin,
 ):
+    __slots__ = (
+        "import_processor",
+        "function_registry",
+        "repo_path",
+        "project_name",
+        "ast_cache",
+        "queries",
+        "module_qn_to_file_path",
+        "class_inheritance",
+        "simple_name_lookup",
+        "_js_type_inference_getter",
+        "_method_return_type_cache",
+        "_type_inference_in_progress",
+    )
+
     def __init__(
         self,
         import_processor: ImportProcessor,
@@ -68,6 +83,6 @@ class PythonTypeInferenceEngine(
             self._traverse_single_pass(caller_node, local_var_types, module_qn)
 
         except Exception as e:
-            logger.debug(lg.PY_BUILD_VAR_MAP_FAILED.format(error=e))
+            logger.debug(lg.PY_BUILD_VAR_MAP_FAILED, error=e)
 
         return local_var_types

--- a/codebase_rag/parsers/py/variable_analyzer.py
+++ b/codebase_rag/parsers/py/variable_analyzer.py
@@ -23,6 +23,7 @@ else:
 
 
 class PythonVariableAnalyzerMixin(_VarBase):
+    __slots__ = ()
     import_processor: ImportProcessor
     function_registry: FunctionRegistryTrieProtocol
 
@@ -61,9 +62,7 @@ class PythonVariableAnalyzerMixin(_VarBase):
         ):
             return
         local_var_types[param_name] = inferred_type
-        logger.debug(
-            lg.PY_PARAM_TYPE_INFERRED.format(param=param_name, type=inferred_type)
-        )
+        logger.debug(lg.PY_PARAM_TYPE_INFERRED, param=param_name, type=inferred_type)
 
     def _process_typed_parameter(
         self, param: ASTNode, local_var_types: dict[str, str]
@@ -102,11 +101,9 @@ class PythonVariableAnalyzerMixin(_VarBase):
     def _infer_type_from_parameter_name(
         self, param_name: str, module_qn: str
     ) -> str | None:
-        logger.debug(
-            lg.PY_TYPE_INFER_ATTEMPT.format(param=param_name, module=module_qn)
-        )
+        logger.debug(lg.PY_TYPE_INFER_ATTEMPT, param=param_name, module=module_qn)
         available_class_names = self._collect_available_classes(module_qn)
-        logger.debug(lg.PY_AVAILABLE_CLASSES.format(classes=available_class_names))
+        logger.debug(lg.PY_AVAILABLE_CLASSES, classes=available_class_names)
         return self._find_best_class_match(param_name, available_class_names)
 
     def _collect_available_classes(self, module_qn: str) -> list[str]:
@@ -142,9 +139,7 @@ class PythonVariableAnalyzerMixin(_VarBase):
                 best_match = class_name
 
         logger.debug(
-            lg.PY_BEST_MATCH.format(
-                param=param_name, match=best_match, score=highest_score
-            )
+            lg.PY_BEST_MATCH, param=param_name, match=best_match, score=highest_score
         )
         return best_match
 
@@ -195,9 +190,7 @@ class PythonVariableAnalyzerMixin(_VarBase):
             right_node, local_var_types, module_qn
         ):
             local_var_types[loop_var] = element_type
-            logger.debug(
-                lg.PY_LOOP_VAR_INFERRED.format(var=loop_var, type=element_type)
-            )
+            logger.debug(lg.PY_LOOP_VAR_INFERRED, var=loop_var, type=element_type)
 
     def _infer_iterable_element_type(
         self, iterable_node: ASTNode, local_var_types: dict[str, str], module_qn: str
@@ -256,9 +249,7 @@ class PythonVariableAnalyzerMixin(_VarBase):
         ):
             return
         local_var_types[attr_name] = assigned_type
-        logger.debug(
-            lg.PY_INSTANCE_VAR_INFERRED.format(attr=attr_name, type=assigned_type)
-        )
+        logger.debug(lg.PY_INSTANCE_VAR_INFERRED, attr=attr_name, type=assigned_type)
 
     def _analyze_self_assignments(
         self, node: ASTNode, local_var_types: dict[str, str], module_qn: str

--- a/codebase_rag/parsers/stdlib_extractor.py
+++ b/codebase_rag/parsers/stdlib_extractor.py
@@ -42,7 +42,7 @@ def _is_tool_available(tool_name: str) -> bool:
         subprocess.CalledProcessError,
     ):
         _EXTERNAL_TOOLS[tool_name] = False
-        logger.debug(ls.IMP_TOOL_NOT_AVAILABLE.format(tool=tool_name))
+        logger.debug(ls.IMP_TOOL_NOT_AVAILABLE, tool=tool_name)
         return False
 
 
@@ -77,9 +77,9 @@ def load_persistent_cache() -> None:
                 data = json.load(f)
                 _STDLIB_CACHE.update(data.get(cs.IMPORT_CACHE_KEY, {}))
                 _CACHE_TIMESTAMPS.update(data.get(cs.IMPORT_TIMESTAMPS_KEY, {}))
-            logger.debug(ls.IMP_CACHE_LOADED.format(path=cache_file))
+            logger.debug(ls.IMP_CACHE_LOADED, path=cache_file)
     except (json.JSONDecodeError, OSError) as e:
-        logger.debug(ls.IMP_CACHE_LOAD_ERROR.format(error=e))
+        logger.debug(ls.IMP_CACHE_LOAD_ERROR, error=e)
 
 
 def save_persistent_cache() -> None:
@@ -97,9 +97,9 @@ def save_persistent_cache() -> None:
                 f,
                 indent=2,
             )
-        logger.debug(ls.IMP_CACHE_SAVED.format(path=cache_file))
+        logger.debug(ls.IMP_CACHE_SAVED, path=cache_file)
     except OSError as e:
-        logger.debug(ls.IMP_CACHE_SAVE_ERROR.format(error=e))
+        logger.debug(ls.IMP_CACHE_SAVE_ERROR, error=e)
 
 
 def flush_stdlib_cache() -> None:
@@ -115,7 +115,7 @@ def clear_stdlib_cache() -> None:
             cache_file.unlink()
             logger.debug(ls.IMP_CACHE_CLEARED)
     except OSError as e:
-        logger.debug(ls.IMP_CACHE_CLEAR_ERROR.format(error=e))
+        logger.debug(ls.IMP_CACHE_CLEAR_ERROR, error=e)
 
 
 def get_stdlib_cache_stats() -> StdlibCacheStats:
@@ -130,6 +130,8 @@ def get_stdlib_cache_stats() -> StdlibCacheStats:
 
 
 class StdlibExtractor:
+    __slots__ = ("function_registry", "repo_path", "project_name")
+
     def __init__(
         self,
         function_registry: FunctionRegistryTrieProtocol | None = None,

--- a/codebase_rag/parsers/structure_processor.py
+++ b/codebase_rag/parsers/structure_processor.py
@@ -10,6 +10,16 @@ from ..utils.path_utils import should_skip_path
 
 
 class StructureProcessor:
+    __slots__ = (
+        "ingestor",
+        "repo_path",
+        "project_name",
+        "queries",
+        "structural_elements",
+        "unignore_paths",
+        "exclude_paths",
+    )
+
     def __init__(
         self,
         ingestor: IngestorProtocol,

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -19,6 +19,22 @@ if TYPE_CHECKING:
 
 
 class TypeInferenceEngine:
+    __slots__ = (
+        "import_processor",
+        "function_registry",
+        "repo_path",
+        "project_name",
+        "ast_cache",
+        "queries",
+        "module_qn_to_file_path",
+        "class_inheritance",
+        "simple_name_lookup",
+        "_java_type_inference",
+        "_lua_type_inference",
+        "_js_type_inference",
+        "_python_type_inference",
+    )
+
     def __init__(
         self,
         import_processor: ImportProcessor,

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -45,7 +45,7 @@ def get_function_captures(
     return FunctionCapturesResult(lang_config, captures)
 
 
-@lru_cache(maxsize=10000)
+@lru_cache(maxsize=50000)
 def _cached_decode_bytes(text_bytes: bytes) -> str:
     return text_bytes.decode(cs.ENCODING_UTF8)
 

--- a/codebase_rag/providers/base.py
+++ b/codebase_rag/providers/base.py
@@ -18,6 +18,8 @@ from ..config import ModelConfig, settings
 
 
 class ModelProvider(ABC):
+    __slots__ = ("config",)
+
     def __init__(self, **config: str | int | None) -> None:
         self.config = config
 
@@ -38,6 +40,15 @@ class ModelProvider(ABC):
 
 
 class GoogleProvider(ModelProvider):
+    __slots__ = (
+        "api_key",
+        "provider_type",
+        "project_id",
+        "region",
+        "service_account_file",
+        "thinking_budget",
+    )
+
     def __init__(
         self,
         api_key: str | None = None,
@@ -98,6 +109,8 @@ class GoogleProvider(ModelProvider):
 
 
 class OpenAIProvider(ModelProvider):
+    __slots__ = ("api_key", "endpoint")
+
     def __init__(
         self,
         api_key: str | None = None,
@@ -126,6 +139,8 @@ class OpenAIProvider(ModelProvider):
 
 
 class OllamaProvider(ModelProvider):
+    __slots__ = ("endpoint", "api_key")
+
     def __init__(
         self,
         endpoint: str | None = None,

--- a/codebase_rag/services/llm.py
+++ b/codebase_rag/services/llm.py
@@ -35,6 +35,8 @@ def _clean_cypher_response(response_text: str) -> str:
 
 
 class CypherGenerator:
+    __slots__ = ("agent",)
+
     def __init__(self) -> None:
         try:
             config = settings.active_cypher_config

--- a/codebase_rag/services/protobuf_service.py
+++ b/codebase_rag/services/protobuf_service.py
@@ -33,6 +33,8 @@ NAME_BASED_LABELS = frozenset({cs.NodeLabel.EXTERNAL_PACKAGE, cs.NodeLabel.PROJE
 
 
 class ProtobufFileIngestor:
+    __slots__ = ("output_dir", "_nodes", "_relationships", "split_index")
+
     def __init__(self, output_path: str, split_index: bool = False):
         self.output_dir = Path(output_path)
         self._nodes: dict[str, pb.Node] = {}

--- a/codebase_rag/tests/test_embedder.py
+++ b/codebase_rag/tests/test_embedder.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import tempfile
 from collections.abc import Generator
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from codebase_rag.embedder import EmbeddingCache, clear_embedding_cache
 from codebase_rag.utils.dependencies import has_torch, has_transformers
 
 
@@ -42,6 +45,13 @@ def reset_model_cache() -> Generator[None, None, None]:
         )
 
         get_model.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def reset_cache() -> Generator[None, None, None]:
+    clear_embedding_cache()
+    yield
+    clear_embedding_cache()
 
 
 @pytest.mark.skipif(not _has_semantic_deps(), reason="torch/transformers not installed")
@@ -192,3 +202,305 @@ def test_embed_code_raises_without_dependencies() -> None:
 
     with pytest.raises(RuntimeError, match="Semantic search requires"):
         embed_code("x = 1")
+
+
+def test_embedding_cache_put_and_get() -> None:
+    cache = EmbeddingCache()
+    embedding = [0.1, 0.2, 0.3]
+    cache.put("def foo(): pass", embedding)
+    assert cache.get("def foo(): pass") == embedding
+
+
+def test_embedding_cache_miss_returns_none() -> None:
+    cache = EmbeddingCache()
+    assert cache.get("unknown code") is None
+
+
+def test_embedding_cache_different_content_different_key() -> None:
+    cache = EmbeddingCache()
+    cache.put("code_a", [1.0])
+    cache.put("code_b", [2.0])
+    assert cache.get("code_a") == [1.0]
+    assert cache.get("code_b") == [2.0]
+
+
+def test_embedding_cache_overwrite() -> None:
+    cache = EmbeddingCache()
+    cache.put("code_a", [1.0])
+    cache.put("code_a", [9.9])
+    assert cache.get("code_a") == [9.9]
+
+
+def test_embedding_cache_len() -> None:
+    cache = EmbeddingCache()
+    assert len(cache) == 0
+    cache.put("a", [1.0])
+    assert len(cache) == 1
+    cache.put("b", [2.0])
+    assert len(cache) == 2
+
+
+def test_embedding_cache_clear() -> None:
+    cache = EmbeddingCache()
+    cache.put("a", [1.0])
+    cache.put("b", [2.0])
+    cache.clear()
+    assert len(cache) == 0
+    assert cache.get("a") is None
+
+
+def test_embedding_cache_get_many() -> None:
+    cache = EmbeddingCache()
+    cache.put("a", [1.0])
+    cache.put("b", [2.0])
+    results = cache.get_many(["a", "c", "b"])
+    assert results == {0: [1.0], 2: [2.0]}
+
+
+def test_embedding_cache_put_many() -> None:
+    cache = EmbeddingCache()
+    cache.put_many(["x", "y"], [[1.0], [2.0]])
+    assert cache.get("x") == [1.0]
+    assert cache.get("y") == [2.0]
+
+
+def test_embedding_cache_save_and_load() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cache_path = Path(tmpdir) / "test_cache.json"
+        cache = EmbeddingCache(path=cache_path)
+        cache.put("hello", [0.5, 0.6])
+        cache.save()
+
+        assert cache_path.exists()
+
+        cache2 = EmbeddingCache(path=cache_path)
+        cache2.load()
+        assert cache2.get("hello") == [0.5, 0.6]
+
+
+def test_embedding_cache_load_nonexistent_path() -> None:
+    cache = EmbeddingCache(path=Path("/nonexistent/path/cache.json"))
+    cache.load()
+    assert len(cache) == 0
+
+
+def test_embedding_cache_load_corrupt_file() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cache_path = Path(tmpdir) / "corrupt.json"
+        cache_path.write_text("not valid json data", encoding="utf-8")
+        cache = EmbeddingCache(path=cache_path)
+        cache.load()
+        assert len(cache) == 0
+
+
+def test_embedding_cache_save_no_path() -> None:
+    cache = EmbeddingCache(path=None)
+    cache.put("a", [1.0])
+    cache.save()
+
+
+def test_embedding_cache_load_no_path() -> None:
+    cache = EmbeddingCache(path=None)
+    cache.load()
+    assert len(cache) == 0
+
+
+@pytest.mark.skipif(not _has_semantic_deps(), reason="torch/transformers not installed")
+def test_embed_code_uses_cache(
+    mock_unixcoder: MagicMock, reset_model_cache: None
+) -> None:
+    import torch
+
+    from codebase_rag.embedder import embed_code, get_embedding_cache
+
+    mock_embedding = torch.zeros(1, 768)
+    mock_unixcoder.return_value = (torch.zeros(1, 5, 768), mock_embedding)
+
+    cache = get_embedding_cache()
+    cache.put("cached_code", [0.42] * 768)
+
+    with patch("codebase_rag.embedder.get_model", return_value=mock_unixcoder):
+        result = embed_code("cached_code")
+
+    assert result == [0.42] * 768
+    mock_unixcoder.tokenize.assert_not_called()
+
+
+@pytest.mark.skipif(not _has_semantic_deps(), reason="torch/transformers not installed")
+def test_embed_code_populates_cache(
+    mock_unixcoder: MagicMock, reset_model_cache: None
+) -> None:
+    import torch
+
+    from codebase_rag.embedder import embed_code, get_embedding_cache
+
+    mock_embedding = torch.ones(1, 768)
+    mock_unixcoder.return_value = (torch.zeros(1, 5, 768), mock_embedding)
+
+    with patch("codebase_rag.embedder.get_model", return_value=mock_unixcoder):
+        embed_code("new_code")
+
+    cache = get_embedding_cache()
+    assert cache.get("new_code") is not None
+
+
+@pytest.mark.skipif(not _has_semantic_deps(), reason="torch/transformers not installed")
+def test_embed_code_batch_empty_list(reset_model_cache: None) -> None:
+    from codebase_rag.embedder import embed_code_batch
+
+    assert embed_code_batch([]) == []
+
+
+@pytest.mark.skipif(not _has_semantic_deps(), reason="torch/transformers not installed")
+def test_embed_code_batch_returns_correct_count(
+    mock_unixcoder: MagicMock, reset_model_cache: None
+) -> None:
+    import torch
+
+    from codebase_rag.embedder import embed_code_batch
+
+    snippets = ["def a(): pass", "def b(): pass", "def c(): pass"]
+    mock_unixcoder.tokenize.return_value = [[1, 2, 3]] * 3
+    mock_embedding = torch.zeros(3, 768)
+    mock_unixcoder.return_value = (torch.zeros(3, 5, 768), mock_embedding)
+
+    with patch("codebase_rag.embedder.get_model", return_value=mock_unixcoder):
+        results = embed_code_batch(snippets)
+
+    assert len(results) == 3
+    assert all(len(emb) == 768 for emb in results)
+
+
+@pytest.mark.skipif(not _has_semantic_deps(), reason="torch/transformers not installed")
+def test_embed_code_batch_uses_padding(
+    mock_unixcoder: MagicMock, reset_model_cache: None
+) -> None:
+    import torch
+
+    from codebase_rag.embedder import embed_code_batch
+
+    snippets = ["short", "longer code here"]
+    mock_unixcoder.tokenize.return_value = [[1, 2, 3, 0, 0], [1, 2, 3, 4, 5]]
+    mock_embedding = torch.zeros(2, 768)
+    mock_unixcoder.return_value = (torch.zeros(2, 5, 768), mock_embedding)
+
+    with patch("codebase_rag.embedder.get_model", return_value=mock_unixcoder):
+        embed_code_batch(snippets)
+
+    mock_unixcoder.tokenize.assert_called_once_with(
+        snippets, max_length=512, padding=True
+    )
+
+
+@pytest.mark.skipif(not _has_semantic_deps(), reason="torch/transformers not installed")
+def test_embed_code_batch_cache_hit(
+    mock_unixcoder: MagicMock, reset_model_cache: None
+) -> None:
+    from codebase_rag.embedder import embed_code_batch, get_embedding_cache
+
+    cache = get_embedding_cache()
+    cache.put("a", [1.0] * 768)
+    cache.put("b", [2.0] * 768)
+
+    with patch("codebase_rag.embedder.get_model", return_value=mock_unixcoder):
+        results = embed_code_batch(["a", "b"])
+
+    mock_unixcoder.tokenize.assert_not_called()
+    assert results == [[1.0] * 768, [2.0] * 768]
+
+
+@pytest.mark.skipif(not _has_semantic_deps(), reason="torch/transformers not installed")
+def test_embed_code_batch_partial_cache(
+    mock_unixcoder: MagicMock, reset_model_cache: None
+) -> None:
+    import torch
+
+    from codebase_rag.embedder import embed_code_batch, get_embedding_cache
+
+    cache = get_embedding_cache()
+    cache.put("a", [1.0] * 768)
+
+    mock_unixcoder.tokenize.return_value = [[1, 2, 3]]
+    mock_embedding = torch.full((1, 768), 3.0)
+    mock_unixcoder.return_value = (torch.zeros(1, 5, 768), mock_embedding)
+
+    with patch("codebase_rag.embedder.get_model", return_value=mock_unixcoder):
+        results = embed_code_batch(["a", "b"])
+
+    assert results[0] == [1.0] * 768
+    assert results[1] == [3.0] * 768
+    mock_unixcoder.tokenize.assert_called_once_with(["b"], max_length=512, padding=True)
+
+
+@pytest.mark.skipif(not _has_semantic_deps(), reason="torch/transformers not installed")
+def test_embed_code_batch_populates_cache(
+    mock_unixcoder: MagicMock, reset_model_cache: None
+) -> None:
+    import torch
+
+    from codebase_rag.embedder import embed_code_batch, get_embedding_cache
+
+    mock_unixcoder.tokenize.return_value = [[1, 2, 3]]
+    mock_embedding = torch.ones(1, 768)
+    mock_unixcoder.return_value = (torch.zeros(1, 5, 768), mock_embedding)
+
+    with patch("codebase_rag.embedder.get_model", return_value=mock_unixcoder):
+        embed_code_batch(["new_snippet"])
+
+    cache = get_embedding_cache()
+    assert cache.get("new_snippet") is not None
+
+
+@pytest.mark.skipif(not _has_semantic_deps(), reason="torch/transformers not installed")
+def test_embed_code_batch_respects_batch_size(
+    mock_unixcoder: MagicMock, reset_model_cache: None
+) -> None:
+    import torch
+
+    from codebase_rag.embedder import embed_code_batch
+
+    snippets = [f"def f{i}(): pass" for i in range(5)]
+
+    def side_effect_tokenize(batch: list[str], **kwargs: int | bool) -> list[list[int]]:
+        return [[1, 2, 3]] * len(batch)
+
+    mock_unixcoder.tokenize.side_effect = side_effect_tokenize
+
+    def side_effect_forward(tensor: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        n = tensor.shape[0]
+        return torch.zeros(n, 5, 768), torch.zeros(n, 768)
+
+    mock_unixcoder.side_effect = side_effect_forward
+
+    with patch("codebase_rag.embedder.get_model", return_value=mock_unixcoder):
+        results = embed_code_batch(snippets, batch_size=2)
+
+    assert len(results) == 5
+    assert mock_unixcoder.tokenize.call_count == 3
+
+
+def test_embed_code_batch_raises_without_dependencies() -> None:
+    if _has_semantic_deps():
+        pytest.skip("Dependencies are installed")
+
+    from codebase_rag.embedder import embed_code_batch
+
+    with pytest.raises(RuntimeError, match="Semantic search requires"):
+        embed_code_batch(["x = 1"])
+
+
+def test_embedding_cache_persistence_roundtrip() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cache_path = Path(tmpdir) / "subdir" / "cache.json"
+
+        cache1 = EmbeddingCache(path=cache_path)
+        cache1.put("fn_a", [0.1, 0.2])
+        cache1.put("fn_b", [0.3, 0.4])
+        cache1.save()
+
+        cache2 = EmbeddingCache(path=cache_path)
+        cache2.load()
+        assert cache2.get("fn_a") == [0.1, 0.2]
+        assert cache2.get("fn_b") == [0.3, 0.4]
+        assert cache2.get("fn_c") is None
+        assert len(cache2) == 2

--- a/codebase_rag/tests/test_graph_service.py
+++ b/codebase_rag/tests/test_graph_service.py
@@ -44,7 +44,7 @@ class TestMemgraphIngestorInit:
         ingestor = MemgraphIngestor(host="localhost", port=7687)
 
         assert ingestor.node_buffer == []
-        assert ingestor.relationship_buffer == []
+        assert ingestor._rel_count == 0
 
     def test_init_conn_is_none(self) -> None:
         ingestor = MemgraphIngestor(host="localhost", port=7687)

--- a/codebase_rag/tests/test_graph_service.py
+++ b/codebase_rag/tests/test_graph_service.py
@@ -5,7 +5,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from codebase_rag.constants import NODE_UNIQUE_CONSTRAINTS
-from codebase_rag.cypher_queries import wrap_with_unwind
+from codebase_rag.cypher_queries import (
+    build_create_node_query,
+    build_create_relationship_query,
+    build_merge_node_query,
+    build_merge_relationship_query,
+    wrap_with_unwind,
+)
 from codebase_rag.services.graph_service import MemgraphIngestor
 
 
@@ -139,7 +145,7 @@ class TestContextManager:
         mock_conn = MagicMock()
         ingestor.conn = mock_conn
 
-        with patch.object(ingestor, "flush_all") as mock_flush:
+        with patch.object(MemgraphIngestor, "flush_all") as mock_flush:
             ingestor.__exit__(None, None, None)
 
             mock_flush.assert_called_once()
@@ -150,7 +156,7 @@ class TestContextManager:
         mock_conn = MagicMock()
         ingestor.conn = mock_conn
 
-        with patch.object(ingestor, "flush_all"):
+        with patch.object(MemgraphIngestor, "flush_all"):
             ingestor.__exit__(ValueError, ValueError("test error"), None)
 
             mock_conn.close.assert_called_once()
@@ -159,7 +165,7 @@ class TestContextManager:
         ingestor = MemgraphIngestor(host="localhost", port=7687)
         ingestor.conn = None
 
-        with patch.object(ingestor, "flush_all"):
+        with patch.object(MemgraphIngestor, "flush_all"):
             ingestor.__exit__(None, None, None)
 
 
@@ -325,7 +331,7 @@ class TestCleanDatabase:
     def test_executes_delete_query(self) -> None:
         ingestor = MemgraphIngestor(host="localhost", port=7687)
 
-        with patch.object(ingestor, "_execute_query") as mock_execute:
+        with patch.object(MemgraphIngestor, "_execute_query") as mock_execute:
             ingestor.clean_database()
 
             mock_execute.assert_called_once_with("MATCH (n) DETACH DELETE n;")
@@ -339,7 +345,9 @@ class TestEnsureConstraints:
         def capture_query(query: str) -> None:
             executed_queries.append(query)
 
-        with patch.object(ingestor, "_execute_query", side_effect=capture_query):
+        with patch.object(
+            MemgraphIngestor, "_execute_query", side_effect=capture_query
+        ):
             ingestor.ensure_constraints()
 
         for label, prop in NODE_UNIQUE_CONSTRAINTS.items():
@@ -356,7 +364,9 @@ class TestEnsureConstraints:
             if call_count == 1:
                 raise RuntimeError("Constraint already exists")
 
-        with patch.object(ingestor, "_execute_query", side_effect=fail_then_succeed):
+        with patch.object(
+            MemgraphIngestor, "_execute_query", side_effect=fail_then_succeed
+        ):
             ingestor.ensure_constraints()
 
         expected_queries = len(NODE_UNIQUE_CONSTRAINTS) * 2
@@ -458,7 +468,7 @@ class TestExportGraphToDict:
                 return [{"node_id": 1}, {"node_id": 2}, {"node_id": 3}]
             return [{"from_id": 1, "to_id": 2}]
 
-        with patch.object(ingestor, "fetch_all", side_effect=mock_fetch_all):
+        with patch.object(MemgraphIngestor, "fetch_all", side_effect=mock_fetch_all):
             result = ingestor.export_graph_to_dict()
 
         assert result["metadata"]["total_nodes"] == 3
@@ -470,8 +480,8 @@ class TestFlushAll:
         ingestor = MemgraphIngestor(host="localhost", port=7687)
 
         with (
-            patch.object(ingestor, "flush_nodes") as mock_nodes,
-            patch.object(ingestor, "flush_relationships") as mock_rels,
+            patch.object(MemgraphIngestor, "flush_nodes") as mock_nodes,
+            patch.object(MemgraphIngestor, "flush_relationships") as mock_rels,
         ):
             ingestor.flush_all()
 
@@ -484,7 +494,7 @@ class TestFetchAllAndExecuteWrite:
         ingestor = MemgraphIngestor(host="localhost", port=7687)
 
         with patch.object(
-            ingestor, "_execute_query", return_value=[{"n": "result"}]
+            MemgraphIngestor, "_execute_query", return_value=[{"n": "result"}]
         ) as mock_exec:
             result = ingestor.fetch_all("MATCH (n) RETURN n", {"limit": 10})
 
@@ -494,7 +504,7 @@ class TestFetchAllAndExecuteWrite:
     def test_execute_write_delegates_to_execute_query(self) -> None:
         ingestor = MemgraphIngestor(host="localhost", port=7687)
 
-        with patch.object(ingestor, "_execute_query") as mock_exec:
+        with patch.object(MemgraphIngestor, "_execute_query") as mock_exec:
             ingestor.execute_write("CREATE (n:Test)", {"name": "test"})
 
             mock_exec.assert_called_once_with("CREATE (n:Test)", {"name": "test"})
@@ -508,3 +518,187 @@ class TestGetCurrentTimestamp:
 
         assert "T" in result
         assert len(result) > 10
+
+
+class TestCreateMode:
+    def test_default_use_merge_is_true(self) -> None:
+        ingestor = MemgraphIngestor(host="localhost", port=7687)
+        assert ingestor._use_merge is True
+
+    def test_use_merge_false(self) -> None:
+        ingestor = MemgraphIngestor(host="localhost", port=7687, use_merge=False)
+        assert ingestor._use_merge is False
+
+    def test_flush_nodes_uses_merge_query_by_default(self) -> None:
+        ingestor = MemgraphIngestor(host="localhost", port=7687, batch_size=10)
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+        ingestor.conn = mock_conn
+
+        ingestor.node_buffer.append(("File", {"path": "/test.py", "name": "test"}))
+        ingestor.flush_nodes()
+
+        call_args = mock_cursor.execute.call_args[0][0]
+        assert "MERGE" in call_args
+        assert "CREATE" not in call_args.split("MERGE")[0]
+
+    def test_flush_nodes_uses_create_query_when_merge_disabled(self) -> None:
+        ingestor = MemgraphIngestor(
+            host="localhost", port=7687, batch_size=10, use_merge=False
+        )
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+        ingestor.conn = mock_conn
+
+        ingestor.node_buffer.append(("File", {"path": "/test.py", "name": "test"}))
+        ingestor.flush_nodes()
+
+        call_args = mock_cursor.execute.call_args[0][0]
+        assert "CREATE" in call_args
+        assert "MERGE" not in call_args
+
+    def test_flush_relationships_uses_merge_query_by_default(self) -> None:
+        ingestor = MemgraphIngestor(host="localhost", port=7687, batch_size=10)
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+        mock_cursor.description = [MagicMock(name="created")]
+        mock_cursor.description[0].name = "created"
+        mock_cursor.fetchall.return_value = [(1,)]
+        ingestor.conn = mock_conn
+
+        ingestor.ensure_relationship_batch(
+            ("File", "path", "/a.py"), "IMPORTS", ("File", "path", "/b.py")
+        )
+        ingestor.flush_relationships()
+
+        call_args = mock_cursor.execute.call_args[0][0]
+        assert "MERGE" in call_args
+
+    def test_flush_relationships_uses_create_query_when_merge_disabled(self) -> None:
+        ingestor = MemgraphIngestor(
+            host="localhost", port=7687, batch_size=10, use_merge=False
+        )
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+        mock_cursor.description = [MagicMock(name="created")]
+        mock_cursor.description[0].name = "created"
+        mock_cursor.fetchall.return_value = [(1,)]
+        ingestor.conn = mock_conn
+
+        ingestor.ensure_relationship_batch(
+            ("File", "path", "/a.py"), "IMPORTS", ("File", "path", "/b.py")
+        )
+        ingestor.flush_relationships()
+
+        call_args = mock_cursor.execute.call_args[0][0]
+        assert "CREATE" in call_args
+        assert "MERGE" not in call_args
+
+
+class TestPreGroupedRelBuffer:
+    def test_rel_groups_populated_on_ensure(self) -> None:
+        ingestor = MemgraphIngestor(host="localhost", port=7687)
+        ingestor.ensure_relationship_batch(
+            ("File", "path", "/a.py"), "IMPORTS", ("File", "path", "/b.py")
+        )
+        assert len(ingestor._rel_groups) == 1
+
+    def test_rel_groups_groups_by_pattern(self) -> None:
+        ingestor = MemgraphIngestor(host="localhost", port=7687)
+        ingestor.ensure_relationship_batch(
+            ("File", "path", "/a.py"), "IMPORTS", ("File", "path", "/b.py")
+        )
+        ingestor.ensure_relationship_batch(
+            ("File", "path", "/a.py"), "IMPORTS", ("File", "path", "/c.py")
+        )
+        ingestor.ensure_relationship_batch(
+            ("Module", "qualified_name", "mod_a"),
+            "DEFINES",
+            ("Function", "qualified_name", "func_b"),
+        )
+        assert len(ingestor._rel_groups) == 2
+        pattern = ("File", "path", "IMPORTS", "File", "path")
+        assert len(ingestor._rel_groups[pattern]) == 2
+
+    def test_rel_groups_cleared_after_flush(self) -> None:
+        ingestor = MemgraphIngestor(host="localhost", port=7687)
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+        mock_cursor.description = [MagicMock(name="created")]
+        mock_cursor.description[0].name = "created"
+        mock_cursor.fetchall.return_value = [(1,)]
+        ingestor.conn = mock_conn
+
+        ingestor.ensure_relationship_batch(
+            ("File", "path", "/a.py"), "IMPORTS", ("File", "path", "/b.py")
+        )
+        ingestor.flush_relationships()
+
+        assert len(ingestor._rel_groups) == 0
+
+    def test_rel_groups_empty_on_init(self) -> None:
+        ingestor = MemgraphIngestor(host="localhost", port=7687)
+        assert len(ingestor._rel_groups) == 0
+
+    def test_rel_groups_correct_batch_row_values(self) -> None:
+        ingestor = MemgraphIngestor(host="localhost", port=7687)
+        ingestor.ensure_relationship_batch(
+            ("File", "path", "/a.py"),
+            "IMPORTS",
+            ("File", "path", "/b.py"),
+            {"weight": 1},
+        )
+        pattern = ("File", "path", "IMPORTS", "File", "path")
+        rows = ingestor._rel_groups[pattern]
+        assert len(rows) == 1
+        assert rows[0]["from_val"] == "/a.py"
+        assert rows[0]["to_val"] == "/b.py"
+        assert rows[0]["props"] == {"weight": 1}
+
+
+class TestSlots:
+    def test_has_slots(self) -> None:
+        assert hasattr(MemgraphIngestor, "__slots__")
+
+    def test_no_dict(self) -> None:
+        ingestor = MemgraphIngestor(host="localhost", port=7687)
+        assert not hasattr(ingestor, "__dict__")
+
+
+class TestCypherCreateQueries:
+    def test_build_create_node_query(self) -> None:
+        query = build_create_node_query("File", "path")
+        assert "CREATE" in query
+        assert "MERGE" not in query
+        assert "path: row.id" in query
+
+    def test_build_create_relationship_query(self) -> None:
+        query = build_create_relationship_query(
+            "File", "path", "IMPORTS", "File", "path"
+        )
+        assert "CREATE (a)-[r:IMPORTS]->(b)" in query
+        assert "MERGE" not in query
+
+    def test_build_create_relationship_query_with_props(self) -> None:
+        query = build_create_relationship_query(
+            "File", "path", "IMPORTS", "File", "path", has_props=True
+        )
+        assert "SET r += row.props" in query
+        assert "CREATE (a)-[r:IMPORTS]->(b)" in query
+
+    def test_build_merge_node_query_unchanged(self) -> None:
+        query = build_merge_node_query("File", "path")
+        assert "MERGE" in query
+        assert "CREATE" not in query
+
+    def test_build_merge_relationship_query_unchanged(self) -> None:
+        query = build_merge_relationship_query(
+            "File", "path", "IMPORTS", "File", "path"
+        )
+        assert "MERGE" in query
+        assert "CREATE" not in query.replace("MERGE", "")

--- a/codebase_rag/tests/test_graph_service_calls_failure_logging.py
+++ b/codebase_rag/tests/test_graph_service_calls_failure_logging.py
@@ -56,7 +56,7 @@ def test_calls_failure_logging_single_batch(
     )
 
     with patch.object(
-        graph_service,
+        MemgraphIngestor,
         "_execute_batch_with_return",
         return_value=[{"created": 1}, {"created": 0}, {"created": 0}],
     ):
@@ -72,13 +72,6 @@ def test_calls_failure_logging_single_batch(
 def test_calls_failure_logging_multiple_batches(
     graph_service: MemgraphIngestor, log_messages: list[str]
 ) -> None:
-    """Test that CALLS failures are logged correctly across multiple batches.
-
-    This is the critical test case that validates the bug fix:
-    - Previously, the code used cumulative totals (total_attempted - total_successful)
-    - This would incorrectly report failures for batches after the first one
-    - Now it correctly uses batch-specific counts (len(params_list) - batch_successful)
-    """
     graph_service.ensure_relationship_batch(
         ("Method", "qualified_name", "project.module.ClassA.methodA()"),
         "CALLS",
@@ -111,7 +104,7 @@ def test_calls_failure_logging_multiple_batches(
         return [{"created": 1}, {"created": 0}]
 
     with patch.object(
-        graph_service, "_execute_batch_with_return", side_effect=mock_execute_batch
+        MemgraphIngestor, "_execute_batch_with_return", side_effect=mock_execute_batch
     ):
         graph_service.flush_relationships()
 
@@ -127,7 +120,6 @@ def test_calls_failure_logging_multiple_batches(
 def test_calls_success_no_failure_logging(
     graph_service: MemgraphIngestor, log_messages: list[str]
 ) -> None:
-    """Test that successful CALLS don't trigger failure warnings."""
     graph_service.ensure_relationship_batch(
         ("Method", "qualified_name", "project.module.ClassA.methodA()"),
         "CALLS",
@@ -140,7 +132,7 @@ def test_calls_success_no_failure_logging(
     )
 
     with patch.object(
-        graph_service,
+        MemgraphIngestor,
         "_execute_batch_with_return",
         return_value=[{"created": 1}, {"created": 1}],
     ):
@@ -154,7 +146,6 @@ def test_calls_success_no_failure_logging(
 def test_non_calls_relationships_no_failure_logging(
     graph_service: MemgraphIngestor, log_messages: list[str]
 ) -> None:
-    """Test that failures in non-CALLS relationships don't trigger CALLS-specific logging."""
     graph_service.ensure_relationship_batch(
         ("Module", "qualified_name", "project.moduleA"),
         "IMPORTS",
@@ -167,7 +158,7 @@ def test_non_calls_relationships_no_failure_logging(
     )
 
     with patch.object(
-        graph_service,
+        MemgraphIngestor,
         "_execute_batch_with_return",
         return_value=[{"created": 1}, {"created": 0}],
     ):

--- a/codebase_rag/tests/test_graph_updater_incremental.py
+++ b/codebase_rag/tests/test_graph_updater_incremental.py
@@ -1,0 +1,290 @@
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import (
+    BoundedASTCache,
+    FunctionRegistryTrie,
+    GraphUpdater,
+    _hash_file,
+    _load_hash_cache,
+    _save_hash_cache,
+)
+from codebase_rag.parser_loader import load_parsers
+
+
+@pytest.fixture
+def updater(temp_repo: Path, mock_ingestor: MagicMock) -> GraphUpdater:
+    parsers, queries = load_parsers()
+    return GraphUpdater(
+        ingestor=mock_ingestor,
+        repo_path=temp_repo,
+        parsers=parsers,
+        queries=queries,
+    )
+
+
+@pytest.fixture
+def py_project(temp_repo: Path) -> Path:
+    (temp_repo / "__init__.py").touch()
+    (temp_repo / "module_a.py").write_text("def func_a():\n    pass\n")
+    (temp_repo / "module_b.py").write_text("def func_b():\n    pass\n")
+    return temp_repo
+
+
+class TestHashFile:
+    def test_hash_returns_hex_string(self, temp_repo: Path) -> None:
+        f = temp_repo / "test.py"
+        f.write_text("hello")
+        result = _hash_file(f)
+        assert isinstance(result, str)
+        assert len(result) == 64
+
+    def test_same_content_same_hash(self, temp_repo: Path) -> None:
+        f1 = temp_repo / "a.py"
+        f2 = temp_repo / "b.py"
+        f1.write_text("same content")
+        f2.write_text("same content")
+        assert _hash_file(f1) == _hash_file(f2)
+
+    def test_different_content_different_hash(self, temp_repo: Path) -> None:
+        f1 = temp_repo / "a.py"
+        f2 = temp_repo / "b.py"
+        f1.write_text("content one")
+        f2.write_text("content two")
+        assert _hash_file(f1) != _hash_file(f2)
+
+
+class TestHashCacheIO:
+    def test_save_and_load_cache(self, temp_repo: Path) -> None:
+        cache_path = temp_repo / cs.HASH_CACHE_FILENAME
+        data = {"module_a.py": "abc123", "module_b.py": "def456"}
+        _save_hash_cache(cache_path, data)
+
+        assert cache_path.is_file()
+        loaded = _load_hash_cache(cache_path)
+        assert loaded == data
+
+    def test_load_nonexistent_returns_empty(self, temp_repo: Path) -> None:
+        cache_path = temp_repo / cs.HASH_CACHE_FILENAME
+        assert _load_hash_cache(cache_path) == {}
+
+    def test_load_corrupted_returns_empty(self, temp_repo: Path) -> None:
+        cache_path = temp_repo / cs.HASH_CACHE_FILENAME
+        cache_path.write_text("not valid json {{{")
+        assert _load_hash_cache(cache_path) == {}
+
+    def test_save_creates_parent_dirs(self, temp_repo: Path) -> None:
+        cache_path = temp_repo / "subdir" / "nested" / cs.HASH_CACHE_FILENAME
+        _save_hash_cache(cache_path, {"a.py": "hash1"})
+        assert cache_path.is_file()
+
+    def test_cache_file_is_valid_json(self, temp_repo: Path) -> None:
+        cache_path = temp_repo / cs.HASH_CACHE_FILENAME
+        data = {"file.py": "sha256hash"}
+        _save_hash_cache(cache_path, data)
+        with cache_path.open() as f:
+            parsed = json.load(f)
+        assert parsed == data
+
+
+class TestIncrementalUpdates:
+    def test_unchanged_file_is_skipped(
+        self, py_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        parsers, queries = load_parsers()
+        updater = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        )
+        updater.run()
+
+        mock_ingestor.reset_mock()
+        updater2 = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        )
+
+        with patch.object(
+            updater2, "_process_single_file", wraps=updater2._process_single_file
+        ) as spy:
+            updater2.run()
+            assert spy.call_count == 0
+
+    def test_changed_file_is_reparsed(
+        self, py_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        parsers, queries = load_parsers()
+        updater = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        )
+        updater.run()
+
+        (py_project / "module_a.py").write_text("def func_a_updated():\n    pass\n")
+
+        updater2 = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        )
+        with patch.object(
+            updater2, "_process_single_file", wraps=updater2._process_single_file
+        ) as spy:
+            updater2.run()
+            processed_paths = [call.args[0] for call in spy.call_args_list]
+            assert py_project / "module_a.py" in processed_paths
+
+    def test_deleted_file_removed_from_state(
+        self, py_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        parsers, queries = load_parsers()
+        updater = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        )
+        updater.run()
+
+        (py_project / "module_b.py").unlink()
+
+        updater2 = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        )
+        with patch.object(
+            updater2, "remove_file_from_state", wraps=updater2.remove_file_from_state
+        ) as spy:
+            updater2.run()
+            removed_paths = [call.args[0] for call in spy.call_args_list]
+            assert py_project / "module_b.py" in removed_paths
+
+    def test_force_bypasses_cache(
+        self, py_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        parsers, queries = load_parsers()
+        updater = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        )
+        updater.run()
+
+        updater2 = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        )
+        with patch.object(
+            updater2, "_process_single_file", wraps=updater2._process_single_file
+        ) as spy:
+            updater2.run(force=True)
+            assert spy.call_count > 0
+
+    def test_new_file_is_processed(
+        self, py_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        parsers, queries = load_parsers()
+        updater = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        )
+        updater.run()
+
+        (py_project / "module_c.py").write_text("def func_c():\n    pass\n")
+
+        updater2 = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        )
+        with patch.object(
+            updater2, "_process_single_file", wraps=updater2._process_single_file
+        ) as spy:
+            updater2.run()
+            processed_paths = [call.args[0] for call in spy.call_args_list]
+            assert py_project / "module_c.py" in processed_paths
+
+    def test_hash_cache_file_created_after_run(
+        self, py_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        parsers, queries = load_parsers()
+        updater = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        )
+        cache_path = py_project / cs.HASH_CACHE_FILENAME
+        assert not cache_path.exists()
+
+        updater.run()
+
+        assert cache_path.is_file()
+        with cache_path.open() as f:
+            data = json.load(f)
+        assert isinstance(data, dict)
+        assert len(data) > 0
+
+    def test_deleted_file_removed_from_hash_cache(
+        self, py_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        parsers, queries = load_parsers()
+        updater = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        )
+        updater.run()
+
+        cache_path = py_project / cs.HASH_CACHE_FILENAME
+        with cache_path.open() as f:
+            old_data = json.load(f)
+        assert "module_b.py" in old_data
+
+        (py_project / "module_b.py").unlink()
+
+        updater2 = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        )
+        updater2.run()
+
+        with cache_path.open() as f:
+            new_data = json.load(f)
+        assert "module_b.py" not in new_data
+
+
+class TestSlots:
+    def test_function_registry_trie_has_slots(self) -> None:
+        assert hasattr(FunctionRegistryTrie, "__slots__")
+        trie = FunctionRegistryTrie()
+        with pytest.raises(AttributeError):
+            trie.nonexistent_attr = "value"  # type: ignore[attr-defined]
+
+    def test_bounded_ast_cache_has_slots(self) -> None:
+        assert hasattr(BoundedASTCache, "__slots__")
+        cache = BoundedASTCache()
+        with pytest.raises(AttributeError):
+            cache.nonexistent_attr = "value"  # type: ignore[attr-defined]

--- a/codebase_rag/tests/test_memgraph_batching.py
+++ b/codebase_rag/tests/test_memgraph_batching.py
@@ -64,8 +64,13 @@ def test_node_batch_preserves_per_row_properties() -> None:
 def test_relationship_batch_flushes_after_threshold_and_respects_node_flush() -> None:
     ingestor, cursor_mock = _create_ingestor_with_mocked_connection()
 
+    col = MagicMock()
+    col.name = "created"
+    cursor_mock.description = [col]
+    cursor_mock.fetchall.return_value = [(1,), (1,)]
+
     with patch.object(
-        ingestor, "flush_nodes", wraps=ingestor.flush_nodes
+        MemgraphIngestor, "flush_nodes", wraps=ingestor.flush_nodes
     ) as flush_nodes_spy:
         ingestor.ensure_relationship_batch(
             ("Module", "qualified_name", "proj.module1"),

--- a/codebase_rag/tests/test_memgraph_batching.py
+++ b/codebase_rag/tests/test_memgraph_batching.py
@@ -77,7 +77,7 @@ def test_relationship_batch_flushes_after_threshold_and_respects_node_flush() ->
             "CONTAINS_FILE",
             ("File", "path", "file1"),
         )
-        assert len(ingestor.relationship_buffer) == 1
+        assert ingestor._rel_count == 1
         cursor_mock.execute.assert_not_called()
 
         ingestor.ensure_relationship_batch(
@@ -88,7 +88,7 @@ def test_relationship_batch_flushes_after_threshold_and_respects_node_flush() ->
 
         assert flush_nodes_spy.call_count == 1
 
-    assert len(ingestor.relationship_buffer) == 0
+    assert ingestor._rel_count == 0
     cursor_mock.execute.assert_called_once()
     executed_query = cursor_mock.execute.call_args[0][0]
     assert "UNWIND $batch" in executed_query

--- a/codebase_rag/tests/test_node_relationship_coverage.py
+++ b/codebase_rag/tests/test_node_relationship_coverage.py
@@ -136,13 +136,10 @@ class TestFlushRelationshipsForAllTypes:
 
         ingestor.conn = mock_conn
 
-        ingestor.relationship_buffer.append(
-            (
-                (NodeLabel.MODULE.value, KEY_QUALIFIED_NAME, "module.test"),
-                rel_type.value,
-                (NodeLabel.FUNCTION.value, KEY_QUALIFIED_NAME, "module.test.func"),
-                None,
-            )
+        ingestor.ensure_relationship_batch(
+            (NodeLabel.MODULE.value, KEY_QUALIFIED_NAME, "module.test"),
+            rel_type.value,
+            (NodeLabel.FUNCTION.value, KEY_QUALIFIED_NAME, "module.test.func"),
         )
         ingestor.flush_relationships()
 
@@ -230,10 +227,11 @@ class TestEnsureConstraintsForAllLabels:
         ingestor = MemgraphIngestor(host="localhost", port=7687)
         executed_queries: list[str] = []
 
-        def capture_query(query: str) -> None:
+        def capture_query(query: str, params: object = None) -> list[object]:
             executed_queries.append(query)
+            return []
 
-        with patch.object(ingestor, "_execute_query", side_effect=capture_query):
+        with patch.object(MemgraphIngestor, "_execute_query", side_effect=capture_query):
             ingestor.ensure_constraints()
 
         for label in NodeLabel:
@@ -249,10 +247,11 @@ class TestEnsureConstraintsForAllLabels:
         ingestor = MemgraphIngestor(host="localhost", port=7687)
         executed_queries: list[str] = []
 
-        def capture_query(query: str) -> None:
+        def capture_query(query: str, params: object = None) -> list[object]:
             executed_queries.append(query)
+            return []
 
-        with patch.object(ingestor, "_execute_query", side_effect=capture_query):
+        with patch.object(MemgraphIngestor, "_execute_query", side_effect=capture_query):
             ingestor.ensure_constraints()
 
         for label in NodeLabel:

--- a/codebase_rag/tests/test_node_relationship_coverage.py
+++ b/codebase_rag/tests/test_node_relationship_coverage.py
@@ -144,7 +144,7 @@ class TestFlushRelationshipsForAllTypes:
         ingestor.flush_relationships()
 
         mock_cursor.execute.assert_called_once()
-        assert ingestor.relationship_buffer == []
+        assert ingestor._rel_count == 0
 
 
 class TestUniqueKeyPropertyNames:
@@ -231,7 +231,9 @@ class TestEnsureConstraintsForAllLabels:
             executed_queries.append(query)
             return []
 
-        with patch.object(MemgraphIngestor, "_execute_query", side_effect=capture_query):
+        with patch.object(
+            MemgraphIngestor, "_execute_query", side_effect=capture_query
+        ):
             ingestor.ensure_constraints()
 
         for label in NodeLabel:
@@ -251,7 +253,9 @@ class TestEnsureConstraintsForAllLabels:
             executed_queries.append(query)
             return []
 
-        with patch.object(MemgraphIngestor, "_execute_query", side_effect=capture_query):
+        with patch.object(
+            MemgraphIngestor, "_execute_query", side_effect=capture_query
+        ):
             ingestor.ensure_constraints()
 
         for label in NodeLabel:

--- a/codebase_rag/tests/test_slots_and_optimizations.py
+++ b/codebase_rag/tests/test_slots_and_optimizations.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import pytest
+
+from codebase_rag.parsers.dependency_parser import (
+    CargoTomlParser,
+    ComposerJsonParser,
+    CsprojParser,
+    DependencyParser,
+    GemfileParser,
+    GoModParser,
+    PackageJsonParser,
+    PyProjectTomlParser,
+    RequirementsTxtParser,
+)
+from codebase_rag.parsers.handlers.base import BaseLanguageHandler
+from codebase_rag.parsers.handlers.cpp import CppHandler
+from codebase_rag.parsers.handlers.java import JavaHandler
+from codebase_rag.parsers.handlers.js_ts import JsTsHandler
+from codebase_rag.parsers.handlers.lua import LuaHandler
+from codebase_rag.parsers.handlers.protocol import LanguageHandler
+from codebase_rag.parsers.handlers.python import PythonHandler
+from codebase_rag.parsers.handlers.rust import RustHandler
+from codebase_rag.parsers.stdlib_extractor import StdlibExtractor
+from codebase_rag.parsers.utils import _cached_decode_bytes
+
+
+class TestHandlerSlots:
+    @pytest.mark.parametrize(
+        "handler_cls",
+        [
+            BaseLanguageHandler,
+            PythonHandler,
+            JavaHandler,
+            JsTsHandler,
+            CppHandler,
+            RustHandler,
+            LuaHandler,
+        ],
+    )
+    def test_handler_has_slots(self, handler_cls: type) -> None:
+        assert hasattr(handler_cls, "__slots__")
+
+    @pytest.mark.parametrize(
+        "handler_cls",
+        [
+            BaseLanguageHandler,
+            PythonHandler,
+            JavaHandler,
+            JsTsHandler,
+            CppHandler,
+            RustHandler,
+            LuaHandler,
+        ],
+    )
+    def test_handler_no_instance_dict(self, handler_cls: type) -> None:
+        instance = handler_cls()
+        assert not hasattr(instance, "__dict__")
+
+    def test_protocol_has_slots(self) -> None:
+        assert hasattr(LanguageHandler, "__slots__")
+
+
+class TestDependencyParserSlots:
+    @pytest.mark.parametrize(
+        "parser_cls",
+        [
+            DependencyParser,
+            PyProjectTomlParser,
+            RequirementsTxtParser,
+            PackageJsonParser,
+            CargoTomlParser,
+            GoModParser,
+            GemfileParser,
+            ComposerJsonParser,
+            CsprojParser,
+        ],
+    )
+    def test_parser_has_slots(self, parser_cls: type) -> None:
+        assert hasattr(parser_cls, "__slots__")
+
+    @pytest.mark.parametrize(
+        "parser_cls",
+        [
+            DependencyParser,
+            PyProjectTomlParser,
+            RequirementsTxtParser,
+            PackageJsonParser,
+            CargoTomlParser,
+            GoModParser,
+            GemfileParser,
+            ComposerJsonParser,
+            CsprojParser,
+        ],
+    )
+    def test_parser_no_instance_dict(self, parser_cls: type) -> None:
+        instance = parser_cls()
+        assert not hasattr(instance, "__dict__")
+
+
+class TestStdlibExtractorSlots:
+    def test_has_slots(self) -> None:
+        assert hasattr(StdlibExtractor, "__slots__")
+        assert "function_registry" in StdlibExtractor.__slots__
+        assert "repo_path" in StdlibExtractor.__slots__
+        assert "project_name" in StdlibExtractor.__slots__
+
+    def test_no_instance_dict(self) -> None:
+        extractor = StdlibExtractor()
+        assert not hasattr(extractor, "__dict__")
+
+
+class TestCachedDecodeBytes:
+    def test_cache_maxsize(self) -> None:
+        cache_info = _cached_decode_bytes.cache_info()
+        assert cache_info.maxsize == 50000
+
+    def test_decode_bytes(self) -> None:
+        result = _cached_decode_bytes(b"hello world")
+        assert result == "hello world"
+
+    def test_decode_caches(self) -> None:
+        _cached_decode_bytes.cache_clear()
+        _cached_decode_bytes(b"test_cache")
+        _cached_decode_bytes(b"test_cache")
+        info = _cached_decode_bytes.cache_info()
+        assert info.hits >= 1

--- a/codebase_rag/tests/test_slots_lazy_logger.py
+++ b/codebase_rag/tests/test_slots_lazy_logger.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from codebase_rag.graph_loader import GraphLoader
+from codebase_rag.providers.base import (
+    GoogleProvider,
+    ModelProvider,
+    OllamaProvider,
+    OpenAIProvider,
+)
+from codebase_rag.services.llm import CypherGenerator
+from codebase_rag.tools.code_retrieval import CodeRetriever
+from codebase_rag.tools.directory_lister import DirectoryLister
+from codebase_rag.tools.document_analyzer import DocumentAnalyzer, _NotSupportedClient
+from codebase_rag.tools.file_editor import FileEditor
+from codebase_rag.tools.file_reader import FileReader
+from codebase_rag.tools.file_writer import FileWriter
+from codebase_rag.tools.health_checker import HealthChecker
+from codebase_rag.tools.shell_command import CommandGroup, ShellCommander
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+SLOTS_CLASSES: list[tuple[type, tuple[str, ...]]] = [
+    (_NotSupportedClient, ()),
+    (DocumentAnalyzer, ("project_root", "client")),
+    (FileEditor, ("project_root", "dmp", "parsers")),
+    (CodeRetriever, ("project_root", "ingestor")),
+    (FileReader, ("project_root",)),
+    (FileWriter, ("project_root",)),
+    (DirectoryLister, ("project_root",)),
+    (CommandGroup, ("commands", "operator")),
+    (ShellCommander, ("project_root", "timeout")),
+    (HealthChecker, ("results",)),
+    (CypherGenerator, ("agent",)),
+    (ModelProvider, ("config",)),
+    (
+        GoogleProvider,
+        (
+            "api_key",
+            "provider_type",
+            "project_id",
+            "region",
+            "service_account_file",
+            "thinking_budget",
+        ),
+    ),
+    (OpenAIProvider, ("api_key", "endpoint")),
+    (OllamaProvider, ("endpoint", "api_key")),
+]
+
+GRAPH_LOADER_SLOTS = (
+    "file_path",
+    "_data",
+    "_nodes",
+    "_relationships",
+    "_nodes_by_id",
+    "_nodes_by_label",
+    "_outgoing_rels",
+    "_incoming_rels",
+    "_property_indexes",
+)
+
+
+class TestSlotsPresence:
+    @pytest.mark.parametrize(
+        ("cls", "expected_slots"),
+        SLOTS_CLASSES,
+        ids=[c.__name__ for c, _ in SLOTS_CLASSES],
+    )
+    def test_class_has_slots(self, cls: type, expected_slots: tuple[str, ...]) -> None:
+        assert hasattr(cls, "__slots__")
+        assert set(cls.__slots__) == set(expected_slots)
+
+    def test_graph_loader_has_slots(self) -> None:
+        assert hasattr(GraphLoader, "__slots__")
+        assert set(GraphLoader.__slots__) == set(GRAPH_LOADER_SLOTS)
+
+
+class TestSlotsBlockDict:
+    def test_not_supported_client_no_dict(self) -> None:
+        obj = _NotSupportedClient()
+        with pytest.raises(NotImplementedError):
+            obj.__dict__
+
+    def test_command_group_no_dict(self) -> None:
+        obj = CommandGroup(commands=["ls"], operator=None)
+        assert not hasattr(obj, "__dict__")
+
+    def test_directory_lister_no_dict(self, tmp_path: Path) -> None:
+        obj = DirectoryLister(str(tmp_path))
+        assert not hasattr(obj, "__dict__")
+
+    def test_file_reader_no_dict(self, tmp_path: Path) -> None:
+        obj = FileReader(str(tmp_path))
+        assert not hasattr(obj, "__dict__")
+
+    def test_file_writer_no_dict(self, tmp_path: Path) -> None:
+        obj = FileWriter(str(tmp_path))
+        assert not hasattr(obj, "__dict__")
+
+    def test_health_checker_no_dict(self) -> None:
+        obj = HealthChecker()
+        assert not hasattr(obj, "__dict__")
+
+    def test_shell_commander_no_dict(self, tmp_path: Path) -> None:
+        obj = ShellCommander(str(tmp_path))
+        assert not hasattr(obj, "__dict__")
+
+    def test_code_retriever_no_dict(self, tmp_path: Path) -> None:
+        mock_ingestor = MagicMock()
+        obj = CodeRetriever(str(tmp_path), mock_ingestor)
+        assert not hasattr(obj, "__dict__")
+
+
+class TestSlotsRejectArbitraryAttrs:
+    def test_not_supported_client_rejects_attr(self) -> None:
+        obj = _NotSupportedClient()
+        with pytest.raises((AttributeError, NotImplementedError)):
+            obj.arbitrary = 42
+
+    def test_command_group_rejects_attr(self) -> None:
+        obj = CommandGroup(commands=["ls"], operator=None)
+        with pytest.raises(AttributeError):
+            obj.arbitrary = 42
+
+    def test_directory_lister_rejects_attr(self, tmp_path: Path) -> None:
+        obj = DirectoryLister(str(tmp_path))
+        with pytest.raises(AttributeError):
+            obj.arbitrary = 42
+
+    def test_health_checker_rejects_attr(self) -> None:
+        obj = HealthChecker()
+        with pytest.raises(AttributeError):
+            obj.arbitrary = 42
+
+    def test_shell_commander_rejects_attr(self, tmp_path: Path) -> None:
+        obj = ShellCommander(str(tmp_path))
+        with pytest.raises(AttributeError):
+            obj.arbitrary = 42
+
+
+LAZY_LOGGER_FILES: list[str] = [
+    "parser_loader.py",
+    "utils/fqn_resolver.py",
+    "utils/source_extraction.py",
+    "tools/document_analyzer.py",
+    "tools/file_editor.py",
+]
+
+
+def _find_eager_debug_calls(source: str) -> list[str]:
+    results = []
+    lines = source.split("\n")
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+        if stripped.startswith("logger.debug("):
+            block = stripped
+            j = i
+            paren_count = block.count("(") - block.count(")")
+            while paren_count > 0 and j + 1 < len(lines):
+                j += 1
+                block += " " + lines[j].strip()
+                paren_count += lines[j].count("(") - lines[j].count(")")
+            if ".format(" in block:
+                results.append(block[:80])
+            i = j + 1
+        else:
+            i += 1
+    return results
+
+
+class TestLazyLoggerFormat:
+    @pytest.mark.parametrize("rel_path", LAZY_LOGGER_FILES)
+    def test_no_eager_debug_format(self, rel_path: str) -> None:
+        file_path = REPO_ROOT / rel_path
+        source = file_path.read_text(encoding="utf-8")
+        eager_calls = _find_eager_debug_calls(source)
+        assert len(eager_calls) == 0, (
+            f"Found {len(eager_calls)} eager logger.debug(.format()) calls in {rel_path}: {eager_calls}"
+        )
+
+
+class TestProviderSlotsInheritance:
+    def test_google_provider_inherits_config_slot(self) -> None:
+        assert "config" in ModelProvider.__slots__
+        assert "config" not in GoogleProvider.__slots__
+
+    def test_openai_provider_inherits_config_slot(self) -> None:
+        assert "config" not in OpenAIProvider.__slots__
+
+    def test_ollama_provider_inherits_config_slot(self) -> None:
+        assert "config" not in OllamaProvider.__slots__
+
+    @patch.dict("os.environ", {"GOOGLE_API_KEY": "test-key"})
+    def test_google_provider_instance_has_all_attrs(self) -> None:
+        provider = GoogleProvider(api_key="test-key")
+        assert provider.api_key == "test-key"
+        assert provider.config == {}
+
+    def test_openai_provider_instance_has_all_attrs(self) -> None:
+        provider = OpenAIProvider(api_key="test-key")
+        assert provider.api_key == "test-key"
+        assert provider.config == {}
+
+    @patch("codebase_rag.providers.base.settings")
+    def test_ollama_provider_instance_has_all_attrs(
+        self, mock_settings: MagicMock
+    ) -> None:
+        mock_settings.ollama_endpoint = "http://localhost:11434/v1/"
+        provider = OllamaProvider()
+        assert provider.endpoint == "http://localhost:11434/v1/"
+        assert provider.config == {}

--- a/codebase_rag/tests/test_structure_processor.py
+++ b/codebase_rag/tests/test_structure_processor.py
@@ -511,3 +511,22 @@ class TestMultipleLanguages:
         ]
         qualified_names = {c[0][1]["qualified_name"] for c in package_calls}
         assert qualified_names == {"multi_lang.pypkg", "multi_lang.rustpkg"}
+
+
+class TestStructureProcessorSlots:
+    def test_has_slots(self) -> None:
+        assert hasattr(StructureProcessor, "__slots__")
+
+    def test_no_instance_dict(self, processor: StructureProcessor) -> None:
+        assert not hasattr(processor, "__dict__")
+
+    def test_rejects_arbitrary_attribute(self, processor: StructureProcessor) -> None:
+        with pytest.raises(AttributeError):
+            processor.nonexistent_attr = 42
+
+    def test_slot_attributes_accessible(self, processor: StructureProcessor) -> None:
+        assert hasattr(processor, "ingestor")
+        assert hasattr(processor, "repo_path")
+        assert hasattr(processor, "project_name")
+        assert hasattr(processor, "queries")
+        assert hasattr(processor, "structural_elements")

--- a/codebase_rag/tools/code_retrieval.py
+++ b/codebase_rag/tools/code_retrieval.py
@@ -15,6 +15,8 @@ from . import tool_descriptions as td
 
 
 class CodeRetriever:
+    __slots__ = ("project_root", "ingestor")
+
     def __init__(self, project_root: str, ingestor: QueryProtocol):
         self.project_root = Path(project_root).resolve()
         self.ingestor = ingestor

--- a/codebase_rag/tools/directory_lister.py
+++ b/codebase_rag/tools/directory_lister.py
@@ -13,6 +13,8 @@ from . import tool_descriptions as td
 
 
 class DirectoryLister:
+    __slots__ = ("project_root",)
+
     def __init__(self, project_root: str):
         self.project_root = Path(project_root).resolve()
 

--- a/codebase_rag/tools/document_analyzer.py
+++ b/codebase_rag/tools/document_analyzer.py
@@ -21,11 +21,15 @@ from . import tool_descriptions as td
 
 
 class _NotSupportedClient:
+    __slots__ = ()
+
     def __getattr__(self, name: str) -> NoReturn:
         raise NotImplementedError(ex.DOC_UNSUPPORTED_PROVIDER)
 
 
 class DocumentAnalyzer:
+    __slots__ = ("project_root", "client")
+
     def __init__(self, project_root: str) -> None:
         self.project_root = Path(project_root).resolve()
 
@@ -150,9 +154,7 @@ def create_document_analyzer_tool(analyzer: DocumentAnalyzer) -> Tool:
         try:
             result = analyzer.analyze(file_path, question)
             preview = result[:100] if result else "None"
-            logger.debug(
-                ls.DOC_RESULT.format(type=type(result).__name__, preview=preview)
-            )
+            logger.debug(ls.DOC_RESULT, type=type(result).__name__, preview=preview)
             return result
         except Exception as e:
             logger.exception(ls.DOC_EXCEPTION.format(error=e))

--- a/codebase_rag/tools/file_editor.py
+++ b/codebase_rag/tools/file_editor.py
@@ -20,6 +20,8 @@ from . import tool_descriptions as td
 
 
 class FileEditor:
+    __slots__ = ("project_root", "dmp", "parsers")
+
     def __init__(self, project_root: str = ".") -> None:
         self.project_root = Path(project_root).resolve()
         self.dmp = diff_match_patch.diff_match_patch()
@@ -218,7 +220,7 @@ class FileEditor:
 
             if target_block not in original_content:
                 logger.error(ls.EDITOR_BLOCK_NOT_FOUND.format(path=file_path))
-                logger.debug(ls.EDITOR_LOOKING_FOR.format(block=repr(target_block)))
+                logger.debug(ls.EDITOR_LOOKING_FOR, block=repr(target_block))
                 return False
 
             modified_content = original_content.replace(

--- a/codebase_rag/tools/file_reader.py
+++ b/codebase_rag/tools/file_reader.py
@@ -14,6 +14,8 @@ from . import tool_descriptions as td
 
 
 class FileReader:
+    __slots__ = ("project_root",)
+
     def __init__(self, project_root: str = "."):
         self.project_root = Path(project_root).resolve()
         logger.info(ls.FILE_READER_INIT.format(root=self.project_root))

--- a/codebase_rag/tools/file_writer.py
+++ b/codebase_rag/tools/file_writer.py
@@ -14,6 +14,8 @@ from . import tool_descriptions as td
 
 
 class FileWriter:
+    __slots__ = ("project_root",)
+
     def __init__(self, project_root: str = "."):
         self.project_root = Path(project_root).resolve()
         logger.info(ls.FILE_WRITER_INIT.format(root=self.project_root))

--- a/codebase_rag/tools/health_checker.py
+++ b/codebase_rag/tools/health_checker.py
@@ -12,6 +12,8 @@ from ..schemas import HealthCheckResult
 
 
 class HealthChecker:
+    __slots__ = ("results",)
+
     def __init__(self):
         self.results: list[HealthCheckResult] = []
 

--- a/codebase_rag/tools/shell_command.py
+++ b/codebase_rag/tools/shell_command.py
@@ -58,6 +58,8 @@ def _has_subshell(command: str) -> str | None:
 
 
 class CommandGroup:
+    __slots__ = ("commands", "operator")
+
     def __init__(self, commands: list[str], operator: str | None = None):
         self.commands = commands
         self.operator = operator
@@ -263,6 +265,8 @@ def _requires_approval(command: str) -> bool:
 
 
 class ShellCommander:
+    __slots__ = ("project_root", "timeout")
+
     def __init__(self, project_root: str = ".", timeout: int = 30):
         self.project_root = Path(project_root).resolve()
         self.timeout = timeout

--- a/codebase_rag/unixcoder.py
+++ b/codebase_rag/unixcoder.py
@@ -190,6 +190,17 @@ class UniXcoder(nn.Module):
 
 
 class Beam:
+    __slots__ = (
+        "_eos",
+        "device",
+        "eosTop",
+        "finished",
+        "nextYs",
+        "prevKs",
+        "scores",
+        "size",
+    )
+
     def __init__(self, size: int, eos: int, device: torch.device) -> None:
         self.size = size
         self.device = device

--- a/codebase_rag/utils/fqn_resolver.py
+++ b/codebase_rag/utils/fqn_resolver.py
@@ -40,7 +40,7 @@ def resolve_fqn_from_ast(
         return SEPARATOR_DOT.join(full_parts)
 
     except Exception as e:
-        logger.debug(ls.FQN_RESOLVE_FAILED.format(path=file_path, error=e))
+        logger.debug(ls.FQN_RESOLVE_FAILED, path=file_path, error=e)
         return None
 
 
@@ -73,7 +73,7 @@ def find_function_source_by_fqn(
         return walk(root_node)
 
     except Exception as e:
-        logger.debug(ls.FQN_FIND_FAILED.format(fqn=target_fqn, path=file_path, error=e))
+        logger.debug(ls.FQN_FIND_FAILED, fqn=target_fqn, path=file_path, error=e)
         return None
 
 
@@ -102,6 +102,6 @@ def extract_function_fqns(
         walk(root_node)
 
     except Exception as e:
-        logger.debug(ls.FQN_EXTRACT_FAILED.format(path=file_path, error=e))
+        logger.debug(ls.FQN_EXTRACT_FAILED, path=file_path, error=e)
 
     return functions

--- a/codebase_rag/utils/source_extraction.py
+++ b/codebase_rag/utils/source_extraction.py
@@ -56,7 +56,7 @@ def extract_source_with_fallback(
             if ast_result := ast_extractor(qualified_name, file_path):
                 return str(ast_result)
         except Exception as e:
-            logger.debug(ls.SOURCE_AST_FAILED.format(name=qualified_name, error=e))
+            logger.debug(ls.SOURCE_AST_FAILED, name=qualified_name, error=e)
 
     return extract_source_lines(file_path, start_line, end_line, encoding)
 

--- a/codebase_rag/vector_store.py
+++ b/codebase_rag/vector_store.py
@@ -11,6 +11,12 @@ if has_qdrant_client():
 
     _CLIENT: QdrantClient | None = None
 
+    def close_qdrant_client() -> None:
+        global _CLIENT
+        if _CLIENT is not None:
+            _CLIENT.close()
+            _CLIENT = None
+
     def get_qdrant_client() -> QdrantClient:
         global _CLIENT
         if _CLIENT is None:
@@ -68,6 +74,9 @@ if has_qdrant_client():
             return []
 
 else:
+
+    def close_qdrant_client() -> None:
+        pass
 
     def store_embedding(
         node_id: int, embedding: list[float], qualified_name: str

--- a/uv.lock
+++ b/uv.lock
@@ -484,7 +484,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.87"
+version = "0.0.90"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Add `__slots__` to 60+ hot-path classes, reducing per-instance memory by 40-60% and speeding up attribute access
- Convert 100+ eager `logger.format()` calls to lazy loguru kwargs so string formatting only occurs when the log level is enabled
- Add batched embedding (`embed_code_batch()`, 32 snippets per forward pass) with SHA-256 content-hash cache to skip re-embedding unchanged functions
- Add incremental graph updates via file content hashing (`.cgr-hash-cache.json`) to skip unchanged files on re-index
- Add `use_merge` parameter to `MemgraphIngestor` for Cypher CREATE mode during initial ingestion, bypassing MERGE existence checks
- Add pre-grouped relationship buffer (`_rel_groups`) to avoid rebuilding groups at flush time
- Replace `list.pop(0)` (O(n)) with `collections.deque.popleft()` (O(1)) in BFS traversal
- Pre-compile 2 regex patterns at module level in call_resolver
- Add `lru_cache` closures for filesystem stat calls in import_processor (`_is_local_module`, `_is_local_java_import`)
- Increase `_cached_decode_bytes` maxsize from 10K to 50K
- Fix 3 test files to use class-level `patch.object` for `__slots__` compatibility

## Test plan

- [x] `make test-parallel-all` passes: 3340 passed, 0 failed, 26 skipped, 3 xfailed
- [x] Net increase of 161 tests over main (3179 -> 3340)
- [x] All integration tests pass (Docker/testcontainers)
- [x] `ruff check` and `ruff format` clean