### PR TITLE
test(java): add label name collision regression tests

### DIFF
--- a/codebase_rag/tests/test_cgr_shim.py
+++ b/codebase_rag/tests/test_cgr_shim.py
@@ -1,0 +1,41 @@
+import cgr
+
+
+class TestCgrShimExports:
+    def test_all_symbols_importable(self) -> None:
+        for name in cgr.__all__:
+            assert hasattr(cgr, name), f"{name!r} listed in __all__ but not importable"
+
+    def test_all_matches_module_exports(self) -> None:
+        public_attrs = {k for k in vars(cgr) if not k.startswith("_")}
+        assert set(cgr.__all__) == public_attrs
+
+    def test_settings_is_canonical_instance(self) -> None:
+        from codebase_rag.config import settings
+
+        assert cgr.settings is settings
+
+    def test_embed_code_is_canonical_function(self) -> None:
+        from codebase_rag.embedder import embed_code
+
+        assert cgr.embed_code is embed_code
+
+    def test_graph_loader_is_canonical_class(self) -> None:
+        from codebase_rag.graph_loader import GraphLoader
+
+        assert cgr.GraphLoader is GraphLoader
+
+    def test_load_graph_is_canonical_function(self) -> None:
+        from codebase_rag.graph_loader import load_graph
+
+        assert cgr.load_graph is load_graph
+
+    def test_memgraph_ingestor_is_canonical_class(self) -> None:
+        from codebase_rag.services.graph_service import MemgraphIngestor
+
+        assert cgr.MemgraphIngestor is MemgraphIngestor
+
+    def test_cypher_generator_is_canonical_class(self) -> None:
+        from codebase_rag.services.llm import CypherGenerator
+
+        assert cgr.CypherGenerator is CypherGenerator

--- a/codebase_rag/tests/test_config_validation.py
+++ b/codebase_rag/tests/test_config_validation.py
@@ -1,0 +1,95 @@
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.config import ModelConfig, format_missing_api_key_errors
+
+
+class TestValidateApiKey:
+    @pytest.mark.parametrize(
+        ("provider", "model_id"),
+        [
+            (cs.Provider.OLLAMA, "llama3"),
+            (cs.Provider.LOCAL, "local-model"),
+            (cs.Provider.VLLM, "vllm-model"),
+        ],
+    )
+    def test_local_providers_skip_validation(
+        self, provider: cs.Provider, model_id: str
+    ) -> None:
+        cfg = ModelConfig(provider=provider, model_id=model_id)
+        cfg.validate_api_key()
+
+    def test_google_vertex_skips_validation(self) -> None:
+        cfg = ModelConfig(
+            provider=cs.Provider.GOOGLE,
+            model_id="gemini-pro",
+            provider_type=cs.GoogleProviderType.VERTEX,
+        )
+        cfg.validate_api_key()
+
+    def test_google_gla_requires_api_key(self) -> None:
+        cfg = ModelConfig(
+            provider=cs.Provider.GOOGLE,
+            model_id="gemini-pro",
+            provider_type=cs.GoogleProviderType.GLA,
+        )
+        with pytest.raises(ValueError, match="API Key Missing"):
+            cfg.validate_api_key()
+
+    @pytest.mark.parametrize(
+        "api_key_kwargs",
+        [
+            {},
+            {"api_key": ""},
+            {"api_key": "   "},
+            {"api_key": cs.DEFAULT_API_KEY},
+        ],
+    )
+    def test_invalid_api_key_raises(self, api_key_kwargs: dict[str, str]) -> None:
+        cfg = ModelConfig(
+            provider=cs.Provider.OPENAI, model_id="gpt-4", **api_key_kwargs
+        )
+        with pytest.raises(ValueError, match="API Key Missing"):
+            cfg.validate_api_key()
+
+    def test_valid_api_key_passes(self) -> None:
+        cfg = ModelConfig(
+            provider=cs.Provider.OPENAI, model_id="gpt-4", api_key="sk-real-key-123"
+        )
+        cfg.validate_api_key()
+
+    def test_role_forwarded_to_error_message(self) -> None:
+        cfg = ModelConfig(provider=cs.Provider.OPENAI, model_id="gpt-4")
+        with pytest.raises(ValueError, match="cypher"):
+            cfg.validate_api_key(role="cypher")
+
+
+class TestFormatMissingApiKeyErrors:
+    def test_known_provider_openai(self) -> None:
+        msg = format_missing_api_key_errors(cs.Provider.OPENAI)
+        assert "OPENAI_API_KEY" in msg
+        assert "https://platform.openai.com/api-keys" in msg
+        assert "OpenAI" in msg
+
+    def test_known_provider_anthropic(self) -> None:
+        msg = format_missing_api_key_errors(cs.Provider.ANTHROPIC)
+        assert "ANTHROPIC_API_KEY" in msg
+        assert "Anthropic" in msg
+
+    def test_unknown_provider_generic_message(self) -> None:
+        msg = format_missing_api_key_errors("deepseek")
+        assert "DEEPSEEK_API_KEY" in msg
+        assert "Deepseek" in msg
+
+    def test_role_appears_in_message(self) -> None:
+        msg = format_missing_api_key_errors(cs.Provider.OPENAI, role="cypher")
+        assert "for cypher" in msg
+
+    def test_default_role_omits_role_from_message(self) -> None:
+        msg = format_missing_api_key_errors(cs.Provider.OPENAI)
+        assert "for model" not in msg
+
+    def test_case_insensitive_lookup(self) -> None:
+        msg = format_missing_api_key_errors("OpenAI")
+        assert "OPENAI_API_KEY" in msg
+        assert "OpenAI" in msg

--- a/codebase_rag/tests/test_graph_updater_embeddings.py
+++ b/codebase_rag/tests/test_graph_updater_embeddings.py
@@ -1,0 +1,257 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.services.graph_service import MemgraphIngestor
+from codebase_rag.types_defs import ResultRow
+
+MOCK_EMBEDDING = [0.1] * 768
+
+_PATCH_DEPS = patch(
+    "codebase_rag.graph_updater.has_semantic_dependencies", return_value=True
+)
+_PATCH_EMBED = patch("codebase_rag.embedder.embed_code", return_value=MOCK_EMBEDDING)
+_PATCH_STORE = patch("codebase_rag.vector_store.store_embedding")
+
+
+@pytest.fixture
+def query_ingestor() -> MagicMock:
+    mock = MagicMock(spec=MemgraphIngestor)
+    mock.fetch_all = MagicMock(return_value=[])
+    mock.execute_write = MagicMock()
+    return mock
+
+
+@pytest.fixture
+def updater_with_query(temp_repo: Path, query_ingestor: MagicMock) -> GraphUpdater:
+    parsers, queries = load_parsers()
+    return GraphUpdater(
+        ingestor=query_ingestor,
+        repo_path=temp_repo,
+        parsers=parsers,
+        queries=queries,
+    )
+
+
+class TestCypherQueryEmbeddingsStructure:
+    def test_contains_starts_with_project_name(self) -> None:
+        assert "STARTS WITH" in cs.CYPHER_QUERY_EMBEDDINGS
+        assert "$project_name" in cs.CYPHER_QUERY_EMBEDDINGS
+
+    def test_returns_required_columns(self) -> None:
+        query = cs.CYPHER_QUERY_EMBEDDINGS.upper()
+        for col in ["NODE_ID", "QUALIFIED_NAME", "START_LINE", "END_LINE", "PATH"]:
+            assert col in query
+
+    def test_dot_concatenation_is_parenthesized(self) -> None:
+        assert "($project_name + '.')" in cs.CYPHER_QUERY_EMBEDDINGS
+
+    def test_no_bare_starts_with_plus(self) -> None:
+        for line in cs.CYPHER_QUERY_EMBEDDINGS.splitlines():
+            stripped = line.strip()
+            if "STARTS WITH" in stripped and "$project_name" in stripped:
+                assert "($project_name" in stripped, (
+                    f"$project_name + '.' must be parenthesized in: {stripped!r}"
+                )
+
+
+class TestGenerateSemanticEmbeddings:
+    @_PATCH_DEPS
+    @_PATCH_EMBED
+    @_PATCH_STORE
+    def test_passes_project_name_without_trailing_dot(
+        self,
+        _mock_store: MagicMock,
+        _mock_embed: MagicMock,
+        _mock_deps: MagicMock,
+        updater_with_query: GraphUpdater,
+        query_ingestor: MagicMock,
+    ) -> None:
+        query_ingestor.fetch_all.return_value = []
+        updater_with_query._generate_semantic_embeddings()
+
+        params = query_ingestor.fetch_all.call_args[0][1]
+        project_name_param = params["project_name"]
+        assert not project_name_param.endswith("."), (
+            f"project_name should not have trailing dot, got: {project_name_param!r}"
+        )
+
+    @_PATCH_DEPS
+    @_PATCH_EMBED
+    @_PATCH_STORE
+    def test_uses_cypher_query_embeddings_constant(
+        self,
+        _mock_store: MagicMock,
+        _mock_embed: MagicMock,
+        _mock_deps: MagicMock,
+        updater_with_query: GraphUpdater,
+        query_ingestor: MagicMock,
+    ) -> None:
+        query_ingestor.fetch_all.return_value = []
+        updater_with_query._generate_semantic_embeddings()
+
+        query_arg = query_ingestor.fetch_all.call_args[0][0]
+        assert query_arg == cs.CYPHER_QUERY_EMBEDDINGS
+
+    @patch("codebase_rag.graph_updater.has_semantic_dependencies", return_value=False)
+    def test_skips_when_no_semantic_dependencies(
+        self,
+        _mock_deps: MagicMock,
+        updater_with_query: GraphUpdater,
+        query_ingestor: MagicMock,
+    ) -> None:
+        updater_with_query._generate_semantic_embeddings()
+        query_ingestor.fetch_all.assert_not_called()
+
+    @_PATCH_DEPS
+    @_PATCH_EMBED
+    @_PATCH_STORE
+    def test_returns_early_on_empty_results(
+        self,
+        mock_store: MagicMock,
+        _mock_embed: MagicMock,
+        _mock_deps: MagicMock,
+        updater_with_query: GraphUpdater,
+        query_ingestor: MagicMock,
+    ) -> None:
+        query_ingestor.fetch_all.return_value = []
+        updater_with_query._generate_semantic_embeddings()
+        mock_store.assert_not_called()
+
+    @_PATCH_DEPS
+    @_PATCH_EMBED
+    @_PATCH_STORE
+    def test_embeds_valid_function_with_source(
+        self,
+        mock_store: MagicMock,
+        mock_embed: MagicMock,
+        _mock_deps: MagicMock,
+        updater_with_query: GraphUpdater,
+        query_ingestor: MagicMock,
+        temp_repo: Path,
+    ) -> None:
+        (temp_repo / "module.py").write_text("def hello():\n    return 42\n")
+        row: ResultRow = {
+            cs.KEY_NODE_ID: 1,
+            cs.KEY_QUALIFIED_NAME: "myproject.module.hello",
+            cs.KEY_START_LINE: 1,
+            cs.KEY_END_LINE: 2,
+            cs.KEY_PATH: "module.py",
+        }
+        query_ingestor.fetch_all.return_value = [row]
+
+        updater_with_query._generate_semantic_embeddings()
+
+        mock_embed.assert_called_once()
+        mock_store.assert_called_once_with(1, MOCK_EMBEDDING, "myproject.module.hello")
+
+    @_PATCH_DEPS
+    @_PATCH_EMBED
+    @_PATCH_STORE
+    def test_skips_row_with_missing_source_info(
+        self,
+        mock_store: MagicMock,
+        mock_embed: MagicMock,
+        _mock_deps: MagicMock,
+        updater_with_query: GraphUpdater,
+        query_ingestor: MagicMock,
+    ) -> None:
+        row: ResultRow = {
+            cs.KEY_NODE_ID: 1,
+            cs.KEY_QUALIFIED_NAME: "myproject.module.hello",
+        }
+        query_ingestor.fetch_all.return_value = [row]
+
+        updater_with_query._generate_semantic_embeddings()
+
+        mock_embed.assert_not_called()
+        mock_store.assert_not_called()
+
+    @patch("codebase_rag.graph_updater.has_semantic_dependencies", return_value=True)
+    @patch("codebase_rag.embedder.embed_code", side_effect=RuntimeError("model error"))
+    @_PATCH_STORE
+    def test_handles_embed_failure_gracefully(
+        self,
+        mock_store: MagicMock,
+        _mock_embed: MagicMock,
+        _mock_deps: MagicMock,
+        updater_with_query: GraphUpdater,
+        query_ingestor: MagicMock,
+        temp_repo: Path,
+    ) -> None:
+        (temp_repo / "module.py").write_text("def hello():\n    return 42\n")
+        row: ResultRow = {
+            cs.KEY_NODE_ID: 1,
+            cs.KEY_QUALIFIED_NAME: "myproject.module.hello",
+            cs.KEY_START_LINE: 1,
+            cs.KEY_END_LINE: 2,
+            cs.KEY_PATH: "module.py",
+        }
+        query_ingestor.fetch_all.return_value = [row]
+
+        updater_with_query._generate_semantic_embeddings()
+
+        mock_store.assert_not_called()
+
+    @_PATCH_DEPS
+    @_PATCH_EMBED
+    @_PATCH_STORE
+    def test_skips_unparseable_rows(
+        self,
+        mock_store: MagicMock,
+        mock_embed: MagicMock,
+        _mock_deps: MagicMock,
+        updater_with_query: GraphUpdater,
+        query_ingestor: MagicMock,
+    ) -> None:
+        bad_row: ResultRow = {
+            cs.KEY_NODE_ID: "not_an_int",
+            cs.KEY_QUALIFIED_NAME: "pkg.func",
+        }
+        query_ingestor.fetch_all.return_value = [bad_row]
+
+        updater_with_query._generate_semantic_embeddings()
+
+        mock_embed.assert_not_called()
+        mock_store.assert_not_called()
+
+    @_PATCH_DEPS
+    @_PATCH_EMBED
+    @_PATCH_STORE
+    def test_counts_embedded_functions(
+        self,
+        mock_store: MagicMock,
+        mock_embed: MagicMock,
+        _mock_deps: MagicMock,
+        updater_with_query: GraphUpdater,
+        query_ingestor: MagicMock,
+        temp_repo: Path,
+    ) -> None:
+        (temp_repo / "a.py").write_text("def f1():\n    pass\n")
+        (temp_repo / "b.py").write_text("def f2():\n    pass\n")
+        rows: list[ResultRow] = [
+            {
+                cs.KEY_NODE_ID: 1,
+                cs.KEY_QUALIFIED_NAME: "proj.a.f1",
+                cs.KEY_START_LINE: 1,
+                cs.KEY_END_LINE: 2,
+                cs.KEY_PATH: "a.py",
+            },
+            {
+                cs.KEY_NODE_ID: 2,
+                cs.KEY_QUALIFIED_NAME: "proj.b.f2",
+                cs.KEY_START_LINE: 1,
+                cs.KEY_END_LINE: 2,
+                cs.KEY_PATH: "b.py",
+            },
+        ]
+        query_ingestor.fetch_all.return_value = rows
+
+        updater_with_query._generate_semantic_embeddings()
+
+        assert mock_embed.call_count == 2
+        assert mock_store.call_count == 2

--- a/codebase_rag/tests/test_java_label_name_collision.py
+++ b/codebase_rag/tests/test_java_label_name_collision.py
@@ -1,0 +1,314 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag.constants import NODE_UNIQUE_CONSTRAINTS, NodeLabel
+from codebase_rag.tests.conftest import (
+    get_node_names,
+    get_nodes,
+    get_qualified_names,
+    get_relationships,
+    run_updater,
+)
+from codebase_rag.types_defs import NodeType
+
+
+@pytest.fixture
+def java_label_collision_project(temp_repo: Path) -> Path:
+    project_path = temp_repo / "java_label_collision"
+    project_path.mkdir()
+    src = project_path / "src" / "main" / "java" / "com" / "example"
+    src.mkdir(parents=True)
+    return project_path
+
+
+def _src_dir(project: Path) -> Path:
+    return project / "src" / "main" / "java" / "com" / "example"
+
+
+def _has_qn_ending(qns: set[str], suffix: str) -> bool:
+    return any(qn.endswith(suffix) for qn in qns)
+
+
+def test_interface_named_interface_ingested_as_interface_node(
+    java_label_collision_project: Path,
+    mock_ingestor: MagicMock,
+) -> None:
+    src = _src_dir(java_label_collision_project)
+    (src / "Interface.java").write_text(
+        encoding="utf-8",
+        data="""\
+package com.example;
+
+public interface Interface {
+    void doSomething();
+}
+""",
+    )
+    run_updater(java_label_collision_project, mock_ingestor, skip_if_missing="java")
+
+    interface_nodes = get_nodes(mock_ingestor, NodeType.INTERFACE)
+    interface_qns = get_qualified_names(interface_nodes)
+
+    assert _has_qn_ending(interface_qns, ".Interface"), (
+        f"Interface named 'Interface' not found in Interface nodes. Got: {interface_qns}"
+    )
+
+    class_qns = get_node_names(mock_ingestor, NodeType.CLASS)
+    interface_in_class = [qn for qn in class_qns if qn.endswith(".Interface")]
+    assert not interface_in_class, (
+        f"Interface named 'Interface' should not appear as a Class node. Got: {interface_in_class}"
+    )
+
+
+def test_enum_named_enum_ingested_as_enum_node(
+    java_label_collision_project: Path,
+    mock_ingestor: MagicMock,
+) -> None:
+    src = _src_dir(java_label_collision_project)
+    (src / "Enum.java").write_text(
+        encoding="utf-8",
+        data="""\
+package com.example;
+
+public enum Enum {
+    VALUE_A,
+    VALUE_B,
+    VALUE_C
+}
+""",
+    )
+    run_updater(java_label_collision_project, mock_ingestor, skip_if_missing="java")
+
+    enum_nodes = get_nodes(mock_ingestor, NodeType.ENUM)
+    enum_qns = get_qualified_names(enum_nodes)
+
+    assert _has_qn_ending(enum_qns, ".Enum"), (
+        f"Enum named 'Enum' not found in Enum nodes. Got: {enum_qns}"
+    )
+
+    class_qns = get_node_names(mock_ingestor, NodeType.CLASS)
+    enum_in_class = [qn for qn in class_qns if qn.endswith(".Enum")]
+    assert not enum_in_class, (
+        f"Enum named 'Enum' should not appear as a Class node. Got: {enum_in_class}"
+    )
+
+
+def test_class_named_class_ingested_as_class_node(
+    java_label_collision_project: Path,
+    mock_ingestor: MagicMock,
+) -> None:
+    src = _src_dir(java_label_collision_project)
+    (src / "Class.java").write_text(
+        encoding="utf-8",
+        data="""\
+package com.example;
+
+public class Class {
+    public void run() {}
+}
+""",
+    )
+    run_updater(java_label_collision_project, mock_ingestor, skip_if_missing="java")
+
+    class_nodes = get_nodes(mock_ingestor, NodeType.CLASS)
+    class_qns = get_qualified_names(class_nodes)
+
+    assert _has_qn_ending(class_qns, ".Class"), (
+        f"Class named 'Class' not found in Class nodes. Got: {class_qns}"
+    )
+
+
+def test_interface_and_enum_labels_have_constraints() -> None:
+    assert NodeLabel.INTERFACE in NODE_UNIQUE_CONSTRAINTS, (
+        "Interface label missing from NODE_UNIQUE_CONSTRAINTS"
+    )
+    assert NodeLabel.ENUM in NODE_UNIQUE_CONSTRAINTS, (
+        "Enum label missing from NODE_UNIQUE_CONSTRAINTS"
+    )
+    assert NODE_UNIQUE_CONSTRAINTS[NodeLabel.INTERFACE] == "qualified_name"
+    assert NODE_UNIQUE_CONSTRAINTS[NodeLabel.ENUM] == "qualified_name"
+
+
+def test_all_node_labels_have_constraints() -> None:
+    for label in NodeLabel:
+        assert label.value in NODE_UNIQUE_CONSTRAINTS, (
+            f"NodeLabel.{label.name} ('{label.value}') missing from NODE_UNIQUE_CONSTRAINTS"
+        )
+
+
+def test_interface_named_interface_has_defines_relationship(
+    java_label_collision_project: Path,
+    mock_ingestor: MagicMock,
+) -> None:
+    src = _src_dir(java_label_collision_project)
+    (src / "Interface.java").write_text(
+        encoding="utf-8",
+        data="""\
+package com.example;
+
+public interface Interface {
+    void doSomething();
+}
+""",
+    )
+    run_updater(java_label_collision_project, mock_ingestor, skip_if_missing="java")
+
+    defines_rels = get_relationships(mock_ingestor, "DEFINES")
+    found_defines = False
+    for rel in defines_rels:
+        if len(rel.args) >= 3:
+            to_spec = rel.args[2]
+            if isinstance(to_spec, tuple) and len(to_spec) >= 3:
+                to_label = to_spec[0]
+                to_qn = str(to_spec[2])
+                if to_qn.endswith(".Interface"):
+                    assert to_label == NodeType.INTERFACE, (
+                        f"DEFINES target label should be 'Interface', got '{to_label}'"
+                    )
+                    found_defines = True
+
+    assert found_defines, (
+        "No DEFINES relationship found for Interface named 'Interface'"
+    )
+
+
+def test_enum_named_enum_has_defines_relationship(
+    java_label_collision_project: Path,
+    mock_ingestor: MagicMock,
+) -> None:
+    src = _src_dir(java_label_collision_project)
+    (src / "Enum.java").write_text(
+        encoding="utf-8",
+        data="""\
+package com.example;
+
+public enum Enum {
+    VALUE_A,
+    VALUE_B
+}
+""",
+    )
+    run_updater(java_label_collision_project, mock_ingestor, skip_if_missing="java")
+
+    defines_rels = get_relationships(mock_ingestor, "DEFINES")
+    found_defines = False
+    for rel in defines_rels:
+        if len(rel.args) >= 3:
+            to_spec = rel.args[2]
+            if isinstance(to_spec, tuple) and len(to_spec) >= 3:
+                to_label = to_spec[0]
+                to_qn = str(to_spec[2])
+                if to_qn.endswith(".Enum"):
+                    assert to_label == NodeType.ENUM, (
+                        f"DEFINES target label should be 'Enum', got '{to_label}'"
+                    )
+                    found_defines = True
+
+    assert found_defines, "No DEFINES relationship found for Enum named 'Enum'"
+
+
+def test_class_implementing_interface_named_interface(
+    java_label_collision_project: Path,
+    mock_ingestor: MagicMock,
+) -> None:
+    src = _src_dir(java_label_collision_project)
+    (src / "Interface.java").write_text(
+        encoding="utf-8",
+        data="""\
+package com.example;
+
+public interface Interface {
+    void doSomething();
+}
+""",
+    )
+    (src / "Implementor.java").write_text(
+        encoding="utf-8",
+        data="""\
+package com.example;
+
+public class Implementor implements Interface {
+    public void doSomething() {
+        System.out.println("done");
+    }
+}
+""",
+    )
+    run_updater(java_label_collision_project, mock_ingestor, skip_if_missing="java")
+
+    interface_qns = get_node_names(mock_ingestor, NodeType.INTERFACE)
+    assert _has_qn_ending(interface_qns, ".Interface")
+
+    class_qns = get_node_names(mock_ingestor, NodeType.CLASS)
+    assert _has_qn_ending(class_qns, ".Implementor")
+
+    implements_rels = get_relationships(mock_ingestor, "IMPLEMENTS")
+    found_implements = False
+    for rel in implements_rels:
+        if len(rel.args) >= 3:
+            from_spec = rel.args[0]
+            if isinstance(from_spec, tuple) and len(from_spec) >= 3:
+                from_qn = str(from_spec[2])
+                if from_qn.endswith(".Implementor"):
+                    found_implements = True
+
+    assert found_implements, (
+        "No IMPLEMENTS relationship found for Implementor -> Interface"
+    )
+
+
+def test_multiple_label_colliding_names(
+    java_label_collision_project: Path,
+    mock_ingestor: MagicMock,
+) -> None:
+    src = _src_dir(java_label_collision_project)
+    (src / "Function.java").write_text(
+        encoding="utf-8",
+        data="""\
+package com.example;
+
+public class Function {
+    public void execute() {}
+}
+""",
+    )
+    (src / "Method.java").write_text(
+        encoding="utf-8",
+        data="""\
+package com.example;
+
+public class Method {
+    public void invoke() {}
+}
+""",
+    )
+    (src / "Module.java").write_text(
+        encoding="utf-8",
+        data="""\
+package com.example;
+
+public class Module {
+    public void load() {}
+}
+""",
+    )
+    run_updater(java_label_collision_project, mock_ingestor, skip_if_missing="java")
+
+    class_qns = get_node_names(mock_ingestor, NodeType.CLASS)
+    assert _has_qn_ending(class_qns, ".Function")
+    assert _has_qn_ending(class_qns, ".Method")
+    assert _has_qn_ending(class_qns, ".Module")
+
+    function_qns = get_node_names(mock_ingestor, NodeType.FUNCTION)
+    method_qns = get_node_names(mock_ingestor, NodeType.METHOD)
+    non_class_qns = function_qns | method_qns
+    collisions = [
+        qn
+        for qn in non_class_qns
+        if qn.endswith(".Function") or qn.endswith(".Method") or qn.endswith(".Module")
+    ]
+    assert not collisions, (
+        f"Class names colliding with node labels should not appear as wrong node types: {collisions}"
+    )


### PR DESCRIPTION
## Summary
- The original bug (Java `Interface`/`Enum` not recognized) was already fixed in commit `c9060c9` which added missing `NODE_UNIQUE_CONSTRAINTS` entries
- This PR adds 9 regression tests to prevent future regressions, covering Java classes named after graph labels (`Interface`, `Enum`, `Class`, `Function`, `Method`, `Module`)

## Test plan
- [x] Java `interface Interface {}` properly ingested as Interface node
- [x] Java `enum Enum {}` properly ingested as Enum node
- [x] All NodeLabel values have corresponding constraint entries
- [x] DEFINES/IMPLEMENTS relationships use correct node type labels
- [x] All existing tests pass

Closes #275
Closes #271