### PR TITLE
fix(parser): map Rust enums/traits/types/unions to proper node labels

### DIFF
--- a/codebase_rag/parsers/class_ingest/node_type.py
+++ b/codebase_rag/parsers/class_ingest/node_type.py
@@ -16,19 +16,24 @@ def determine_node_type(
     language: cs.SupportedLanguage,
 ) -> NodeType:
     match class_node.type:
-        case cs.TS_INTERFACE_DECLARATION:
+        case cs.TS_INTERFACE_DECLARATION | cs.TS_RS_TRAIT_ITEM:
             logger.info(logs.CLASS_FOUND_INTERFACE.format(name=class_name, qn=class_qn))
             return NodeType.INTERFACE
-        case cs.TS_ENUM_DECLARATION | cs.TS_ENUM_SPECIFIER | cs.TS_ENUM_CLASS_SPECIFIER:
+        case (
+            cs.TS_ENUM_DECLARATION
+            | cs.TS_ENUM_SPECIFIER
+            | cs.TS_ENUM_CLASS_SPECIFIER
+            | cs.TS_RS_ENUM_ITEM
+        ):
             logger.info(logs.CLASS_FOUND_ENUM.format(name=class_name, qn=class_qn))
             return NodeType.ENUM
-        case cs.TS_TYPE_ALIAS_DECLARATION:
+        case cs.TS_TYPE_ALIAS_DECLARATION | cs.TS_RS_TYPE_ITEM:
             logger.info(logs.CLASS_FOUND_TYPE.format(name=class_name, qn=class_qn))
             return NodeType.TYPE
-        case cs.TS_STRUCT_SPECIFIER:
+        case cs.TS_STRUCT_SPECIFIER | cs.TS_RS_STRUCT_ITEM:
             logger.info(logs.CLASS_FOUND_STRUCT.format(name=class_name, qn=class_qn))
             return NodeType.CLASS
-        case cs.TS_UNION_SPECIFIER:
+        case cs.TS_UNION_SPECIFIER | cs.TS_RS_UNION_ITEM:
             logger.info(logs.CLASS_FOUND_UNION.format(name=class_name, qn=class_qn))
             return NodeType.UNION
         case cs.CppNodeType.TEMPLATE_DECLARATION:

--- a/codebase_rag/tests/integration/test_node_label_e2e.py
+++ b/codebase_rag/tests/integration/test_node_label_e2e.py
@@ -617,29 +617,29 @@ class TestRustNodeLabels:
         func_names = {n["name"] for n in functions}
         assert "standalone_fn" in func_names
 
-    def test_rust_creates_class_nodes_for_enums(
+    def test_rust_creates_enum_nodes_for_enums(
         self, memgraph_ingestor: MemgraphIngestor, rust_project: Path
     ) -> None:
         index_project(memgraph_ingestor, rust_project)
 
         labels = get_node_labels(memgraph_ingestor)
-        assert NodeLabel.CLASS.value in labels
+        assert NodeLabel.ENUM.value in labels
 
-        classes = get_nodes_by_label(memgraph_ingestor, NodeLabel.CLASS.value)
-        class_names = {n["name"] for n in classes}
-        assert "Status" in class_names
+        enums = get_nodes_by_label(memgraph_ingestor, NodeLabel.ENUM.value)
+        enum_names = {n["name"] for n in enums}
+        assert "Status" in enum_names
 
-    def test_rust_creates_class_nodes_for_traits(
+    def test_rust_creates_interface_nodes_for_traits(
         self, memgraph_ingestor: MemgraphIngestor, rust_project: Path
     ) -> None:
         index_project(memgraph_ingestor, rust_project)
 
         labels = get_node_labels(memgraph_ingestor)
-        assert NodeLabel.CLASS.value in labels
+        assert NodeLabel.INTERFACE.value in labels
 
-        classes = get_nodes_by_label(memgraph_ingestor, NodeLabel.CLASS.value)
-        class_names = {n["name"] for n in classes}
-        assert "MyTrait" in class_names
+        interfaces = get_nodes_by_label(memgraph_ingestor, NodeLabel.INTERFACE.value)
+        interface_names = {n["name"] for n in interfaces}
+        assert "MyTrait" in interface_names
 
 
 @pytest.mark.skip(reason=SKIP_GO)

--- a/codebase_rag/tests/test_cgr_shim.py
+++ b/codebase_rag/tests/test_cgr_shim.py
@@ -1,0 +1,41 @@
+import cgr
+
+
+class TestCgrShimExports:
+    def test_all_symbols_importable(self) -> None:
+        for name in cgr.__all__:
+            assert hasattr(cgr, name), f"{name!r} listed in __all__ but not importable"
+
+    def test_all_matches_module_exports(self) -> None:
+        public_attrs = {k for k in vars(cgr) if not k.startswith("_")}
+        assert set(cgr.__all__) == public_attrs
+
+    def test_settings_is_canonical_instance(self) -> None:
+        from codebase_rag.config import settings
+
+        assert cgr.settings is settings
+
+    def test_embed_code_is_canonical_function(self) -> None:
+        from codebase_rag.embedder import embed_code
+
+        assert cgr.embed_code is embed_code
+
+    def test_graph_loader_is_canonical_class(self) -> None:
+        from codebase_rag.graph_loader import GraphLoader
+
+        assert cgr.GraphLoader is GraphLoader
+
+    def test_load_graph_is_canonical_function(self) -> None:
+        from codebase_rag.graph_loader import load_graph
+
+        assert cgr.load_graph is load_graph
+
+    def test_memgraph_ingestor_is_canonical_class(self) -> None:
+        from codebase_rag.services.graph_service import MemgraphIngestor
+
+        assert cgr.MemgraphIngestor is MemgraphIngestor
+
+    def test_cypher_generator_is_canonical_class(self) -> None:
+        from codebase_rag.services.llm import CypherGenerator
+
+        assert cgr.CypherGenerator is CypherGenerator

--- a/codebase_rag/tests/test_config_validation.py
+++ b/codebase_rag/tests/test_config_validation.py
@@ -1,0 +1,95 @@
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.config import ModelConfig, format_missing_api_key_errors
+
+
+class TestValidateApiKey:
+    @pytest.mark.parametrize(
+        ("provider", "model_id"),
+        [
+            (cs.Provider.OLLAMA, "llama3"),
+            (cs.Provider.LOCAL, "local-model"),
+            (cs.Provider.VLLM, "vllm-model"),
+        ],
+    )
+    def test_local_providers_skip_validation(
+        self, provider: cs.Provider, model_id: str
+    ) -> None:
+        cfg = ModelConfig(provider=provider, model_id=model_id)
+        cfg.validate_api_key()
+
+    def test_google_vertex_skips_validation(self) -> None:
+        cfg = ModelConfig(
+            provider=cs.Provider.GOOGLE,
+            model_id="gemini-pro",
+            provider_type=cs.GoogleProviderType.VERTEX,
+        )
+        cfg.validate_api_key()
+
+    def test_google_gla_requires_api_key(self) -> None:
+        cfg = ModelConfig(
+            provider=cs.Provider.GOOGLE,
+            model_id="gemini-pro",
+            provider_type=cs.GoogleProviderType.GLA,
+        )
+        with pytest.raises(ValueError, match="API Key Missing"):
+            cfg.validate_api_key()
+
+    @pytest.mark.parametrize(
+        "api_key_kwargs",
+        [
+            {},
+            {"api_key": ""},
+            {"api_key": "   "},
+            {"api_key": cs.DEFAULT_API_KEY},
+        ],
+    )
+    def test_invalid_api_key_raises(self, api_key_kwargs: dict[str, str]) -> None:
+        cfg = ModelConfig(
+            provider=cs.Provider.OPENAI, model_id="gpt-4", **api_key_kwargs
+        )
+        with pytest.raises(ValueError, match="API Key Missing"):
+            cfg.validate_api_key()
+
+    def test_valid_api_key_passes(self) -> None:
+        cfg = ModelConfig(
+            provider=cs.Provider.OPENAI, model_id="gpt-4", api_key="sk-real-key-123"
+        )
+        cfg.validate_api_key()
+
+    def test_role_forwarded_to_error_message(self) -> None:
+        cfg = ModelConfig(provider=cs.Provider.OPENAI, model_id="gpt-4")
+        with pytest.raises(ValueError, match="cypher"):
+            cfg.validate_api_key(role="cypher")
+
+
+class TestFormatMissingApiKeyErrors:
+    def test_known_provider_openai(self) -> None:
+        msg = format_missing_api_key_errors(cs.Provider.OPENAI)
+        assert "OPENAI_API_KEY" in msg
+        assert "https://platform.openai.com/api-keys" in msg
+        assert "OpenAI" in msg
+
+    def test_known_provider_anthropic(self) -> None:
+        msg = format_missing_api_key_errors(cs.Provider.ANTHROPIC)
+        assert "ANTHROPIC_API_KEY" in msg
+        assert "Anthropic" in msg
+
+    def test_unknown_provider_generic_message(self) -> None:
+        msg = format_missing_api_key_errors("deepseek")
+        assert "DEEPSEEK_API_KEY" in msg
+        assert "Deepseek" in msg
+
+    def test_role_appears_in_message(self) -> None:
+        msg = format_missing_api_key_errors(cs.Provider.OPENAI, role="cypher")
+        assert "for cypher" in msg
+
+    def test_default_role_omits_role_from_message(self) -> None:
+        msg = format_missing_api_key_errors(cs.Provider.OPENAI)
+        assert "for model" not in msg
+
+    def test_case_insensitive_lookup(self) -> None:
+        msg = format_missing_api_key_errors("OpenAI")
+        assert "OPENAI_API_KEY" in msg
+        assert "OpenAI" in msg

--- a/codebase_rag/tests/test_graph_updater_embeddings.py
+++ b/codebase_rag/tests/test_graph_updater_embeddings.py
@@ -1,0 +1,257 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.services.graph_service import MemgraphIngestor
+from codebase_rag.types_defs import ResultRow
+
+MOCK_EMBEDDING = [0.1] * 768
+
+_PATCH_DEPS = patch(
+    "codebase_rag.graph_updater.has_semantic_dependencies", return_value=True
+)
+_PATCH_EMBED = patch("codebase_rag.embedder.embed_code", return_value=MOCK_EMBEDDING)
+_PATCH_STORE = patch("codebase_rag.vector_store.store_embedding")
+
+
+@pytest.fixture
+def query_ingestor() -> MagicMock:
+    mock = MagicMock(spec=MemgraphIngestor)
+    mock.fetch_all = MagicMock(return_value=[])
+    mock.execute_write = MagicMock()
+    return mock
+
+
+@pytest.fixture
+def updater_with_query(temp_repo: Path, query_ingestor: MagicMock) -> GraphUpdater:
+    parsers, queries = load_parsers()
+    return GraphUpdater(
+        ingestor=query_ingestor,
+        repo_path=temp_repo,
+        parsers=parsers,
+        queries=queries,
+    )
+
+
+class TestCypherQueryEmbeddingsStructure:
+    def test_contains_starts_with_project_name(self) -> None:
+        assert "STARTS WITH" in cs.CYPHER_QUERY_EMBEDDINGS
+        assert "$project_name" in cs.CYPHER_QUERY_EMBEDDINGS
+
+    def test_returns_required_columns(self) -> None:
+        query = cs.CYPHER_QUERY_EMBEDDINGS.upper()
+        for col in ["NODE_ID", "QUALIFIED_NAME", "START_LINE", "END_LINE", "PATH"]:
+            assert col in query
+
+    def test_dot_concatenation_is_parenthesized(self) -> None:
+        assert "($project_name + '.')" in cs.CYPHER_QUERY_EMBEDDINGS
+
+    def test_no_bare_starts_with_plus(self) -> None:
+        for line in cs.CYPHER_QUERY_EMBEDDINGS.splitlines():
+            stripped = line.strip()
+            if "STARTS WITH" in stripped and "$project_name" in stripped:
+                assert "($project_name" in stripped, (
+                    f"$project_name + '.' must be parenthesized in: {stripped!r}"
+                )
+
+
+class TestGenerateSemanticEmbeddings:
+    @_PATCH_DEPS
+    @_PATCH_EMBED
+    @_PATCH_STORE
+    def test_passes_project_name_without_trailing_dot(
+        self,
+        _mock_store: MagicMock,
+        _mock_embed: MagicMock,
+        _mock_deps: MagicMock,
+        updater_with_query: GraphUpdater,
+        query_ingestor: MagicMock,
+    ) -> None:
+        query_ingestor.fetch_all.return_value = []
+        updater_with_query._generate_semantic_embeddings()
+
+        params = query_ingestor.fetch_all.call_args[0][1]
+        project_name_param = params["project_name"]
+        assert not project_name_param.endswith("."), (
+            f"project_name should not have trailing dot, got: {project_name_param!r}"
+        )
+
+    @_PATCH_DEPS
+    @_PATCH_EMBED
+    @_PATCH_STORE
+    def test_uses_cypher_query_embeddings_constant(
+        self,
+        _mock_store: MagicMock,
+        _mock_embed: MagicMock,
+        _mock_deps: MagicMock,
+        updater_with_query: GraphUpdater,
+        query_ingestor: MagicMock,
+    ) -> None:
+        query_ingestor.fetch_all.return_value = []
+        updater_with_query._generate_semantic_embeddings()
+
+        query_arg = query_ingestor.fetch_all.call_args[0][0]
+        assert query_arg == cs.CYPHER_QUERY_EMBEDDINGS
+
+    @patch("codebase_rag.graph_updater.has_semantic_dependencies", return_value=False)
+    def test_skips_when_no_semantic_dependencies(
+        self,
+        _mock_deps: MagicMock,
+        updater_with_query: GraphUpdater,
+        query_ingestor: MagicMock,
+    ) -> None:
+        updater_with_query._generate_semantic_embeddings()
+        query_ingestor.fetch_all.assert_not_called()
+
+    @_PATCH_DEPS
+    @_PATCH_EMBED
+    @_PATCH_STORE
+    def test_returns_early_on_empty_results(
+        self,
+        mock_store: MagicMock,
+        _mock_embed: MagicMock,
+        _mock_deps: MagicMock,
+        updater_with_query: GraphUpdater,
+        query_ingestor: MagicMock,
+    ) -> None:
+        query_ingestor.fetch_all.return_value = []
+        updater_with_query._generate_semantic_embeddings()
+        mock_store.assert_not_called()
+
+    @_PATCH_DEPS
+    @_PATCH_EMBED
+    @_PATCH_STORE
+    def test_embeds_valid_function_with_source(
+        self,
+        mock_store: MagicMock,
+        mock_embed: MagicMock,
+        _mock_deps: MagicMock,
+        updater_with_query: GraphUpdater,
+        query_ingestor: MagicMock,
+        temp_repo: Path,
+    ) -> None:
+        (temp_repo / "module.py").write_text("def hello():\n    return 42\n")
+        row: ResultRow = {
+            cs.KEY_NODE_ID: 1,
+            cs.KEY_QUALIFIED_NAME: "myproject.module.hello",
+            cs.KEY_START_LINE: 1,
+            cs.KEY_END_LINE: 2,
+            cs.KEY_PATH: "module.py",
+        }
+        query_ingestor.fetch_all.return_value = [row]
+
+        updater_with_query._generate_semantic_embeddings()
+
+        mock_embed.assert_called_once()
+        mock_store.assert_called_once_with(1, MOCK_EMBEDDING, "myproject.module.hello")
+
+    @_PATCH_DEPS
+    @_PATCH_EMBED
+    @_PATCH_STORE
+    def test_skips_row_with_missing_source_info(
+        self,
+        mock_store: MagicMock,
+        mock_embed: MagicMock,
+        _mock_deps: MagicMock,
+        updater_with_query: GraphUpdater,
+        query_ingestor: MagicMock,
+    ) -> None:
+        row: ResultRow = {
+            cs.KEY_NODE_ID: 1,
+            cs.KEY_QUALIFIED_NAME: "myproject.module.hello",
+        }
+        query_ingestor.fetch_all.return_value = [row]
+
+        updater_with_query._generate_semantic_embeddings()
+
+        mock_embed.assert_not_called()
+        mock_store.assert_not_called()
+
+    @patch("codebase_rag.graph_updater.has_semantic_dependencies", return_value=True)
+    @patch("codebase_rag.embedder.embed_code", side_effect=RuntimeError("model error"))
+    @_PATCH_STORE
+    def test_handles_embed_failure_gracefully(
+        self,
+        mock_store: MagicMock,
+        _mock_embed: MagicMock,
+        _mock_deps: MagicMock,
+        updater_with_query: GraphUpdater,
+        query_ingestor: MagicMock,
+        temp_repo: Path,
+    ) -> None:
+        (temp_repo / "module.py").write_text("def hello():\n    return 42\n")
+        row: ResultRow = {
+            cs.KEY_NODE_ID: 1,
+            cs.KEY_QUALIFIED_NAME: "myproject.module.hello",
+            cs.KEY_START_LINE: 1,
+            cs.KEY_END_LINE: 2,
+            cs.KEY_PATH: "module.py",
+        }
+        query_ingestor.fetch_all.return_value = [row]
+
+        updater_with_query._generate_semantic_embeddings()
+
+        mock_store.assert_not_called()
+
+    @_PATCH_DEPS
+    @_PATCH_EMBED
+    @_PATCH_STORE
+    def test_skips_unparseable_rows(
+        self,
+        mock_store: MagicMock,
+        mock_embed: MagicMock,
+        _mock_deps: MagicMock,
+        updater_with_query: GraphUpdater,
+        query_ingestor: MagicMock,
+    ) -> None:
+        bad_row: ResultRow = {
+            cs.KEY_NODE_ID: "not_an_int",
+            cs.KEY_QUALIFIED_NAME: "pkg.func",
+        }
+        query_ingestor.fetch_all.return_value = [bad_row]
+
+        updater_with_query._generate_semantic_embeddings()
+
+        mock_embed.assert_not_called()
+        mock_store.assert_not_called()
+
+    @_PATCH_DEPS
+    @_PATCH_EMBED
+    @_PATCH_STORE
+    def test_counts_embedded_functions(
+        self,
+        mock_store: MagicMock,
+        mock_embed: MagicMock,
+        _mock_deps: MagicMock,
+        updater_with_query: GraphUpdater,
+        query_ingestor: MagicMock,
+        temp_repo: Path,
+    ) -> None:
+        (temp_repo / "a.py").write_text("def f1():\n    pass\n")
+        (temp_repo / "b.py").write_text("def f2():\n    pass\n")
+        rows: list[ResultRow] = [
+            {
+                cs.KEY_NODE_ID: 1,
+                cs.KEY_QUALIFIED_NAME: "proj.a.f1",
+                cs.KEY_START_LINE: 1,
+                cs.KEY_END_LINE: 2,
+                cs.KEY_PATH: "a.py",
+            },
+            {
+                cs.KEY_NODE_ID: 2,
+                cs.KEY_QUALIFIED_NAME: "proj.b.f2",
+                cs.KEY_START_LINE: 1,
+                cs.KEY_END_LINE: 2,
+                cs.KEY_PATH: "b.py",
+            },
+        ]
+        query_ingestor.fetch_all.return_value = rows
+
+        updater_with_query._generate_semantic_embeddings()
+
+        assert mock_embed.call_count == 2
+        assert mock_store.call_count == 2

--- a/codebase_rag/tests/test_rust_node_type.py
+++ b/codebase_rag/tests/test_rust_node_type.py
@@ -59,7 +59,8 @@ def test_rust_enum_label(
 ) -> None:
     run_updater(rust_node_type_project, mock_ingestor, skip_if_missing="rust")
     enum_names = get_node_names(mock_ingestor, NodeType.ENUM)
-    assert any("Color" in n for n in enum_names)
+    assert len(enum_names) == 1
+    assert enum_names.pop().endswith(".Color")
 
 
 def test_rust_trait_label(
@@ -67,7 +68,8 @@ def test_rust_trait_label(
 ) -> None:
     run_updater(rust_node_type_project, mock_ingestor, skip_if_missing="rust")
     interface_names = get_node_names(mock_ingestor, NodeType.INTERFACE)
-    assert any("Drawable" in n for n in interface_names)
+    assert len(interface_names) == 1
+    assert interface_names.pop().endswith(".Drawable")
 
 
 def test_rust_type_alias_label(
@@ -75,7 +77,8 @@ def test_rust_type_alias_label(
 ) -> None:
     run_updater(rust_node_type_project, mock_ingestor, skip_if_missing="rust")
     type_names = get_node_names(mock_ingestor, NodeType.TYPE)
-    assert any("Pair" in n for n in type_names)
+    assert len(type_names) == 1
+    assert type_names.pop().endswith(".Pair")
 
 
 def test_rust_union_label(
@@ -83,7 +86,8 @@ def test_rust_union_label(
 ) -> None:
     run_updater(rust_node_type_project, mock_ingestor, skip_if_missing="rust")
     union_names = get_node_names(mock_ingestor, NodeType.UNION)
-    assert any("IntOrFloat" in n for n in union_names)
+    assert len(union_names) == 1
+    assert union_names.pop().endswith(".IntOrFloat")
 
 
 def test_rust_struct_label(
@@ -91,4 +95,5 @@ def test_rust_struct_label(
 ) -> None:
     run_updater(rust_node_type_project, mock_ingestor, skip_if_missing="rust")
     class_names = get_node_names(mock_ingestor, NodeType.CLASS)
-    assert any("Point" in n for n in class_names)
+    assert len(class_names) == 1
+    assert class_names.pop().endswith(".Point")

--- a/codebase_rag/tests/test_rust_node_type.py
+++ b/codebase_rag/tests/test_rust_node_type.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.parsers.class_ingest.node_type import determine_node_type
+from codebase_rag.tests.conftest import (
+    create_mock_node,
+    get_node_names,
+    run_updater,
+)
+from codebase_rag.types_defs import NodeType
+
+
+@pytest.mark.parametrize(
+    ("ts_node_type", "expected"),
+    [
+        (cs.TS_RS_ENUM_ITEM, NodeType.ENUM),
+        (cs.TS_RS_TRAIT_ITEM, NodeType.INTERFACE),
+        (cs.TS_RS_TYPE_ITEM, NodeType.TYPE),
+        (cs.TS_RS_UNION_ITEM, NodeType.UNION),
+        (cs.TS_RS_STRUCT_ITEM, NodeType.CLASS),
+    ],
+)
+def test_determine_node_type_rust(ts_node_type: str, expected: NodeType) -> None:
+    node = create_mock_node(ts_node_type)
+    result = determine_node_type(node, "Foo", "crate::Foo", cs.SupportedLanguage.RUST)
+    assert result == expected
+
+
+@pytest.fixture
+def rust_node_type_project(temp_repo: Path) -> Path:
+    project_path = temp_repo / "rust_node_type_test"
+    project_path.mkdir()
+    (project_path / "Cargo.toml").write_text(
+        encoding="utf-8",
+        data='[package]\nname = "rust_node_type_test"\nversion = "0.1.0"\n',
+    )
+    (project_path / "src").mkdir()
+    (project_path / "src" / "lib.rs").write_text(encoding="utf-8", data="")
+    (project_path / "types.rs").write_text(
+        encoding="utf-8",
+        data=(
+            "pub enum Color { Red, Green, Blue }\n"
+            "pub trait Drawable { fn draw(&self); }\n"
+            "pub type Pair = (i32, i32);\n"
+            "pub union IntOrFloat { i: i32, f: f32 }\n"
+            "pub struct Point { pub x: f64, pub y: f64 }\n"
+        ),
+    )
+    return project_path
+
+
+def test_rust_enum_label(
+    rust_node_type_project: Path, mock_ingestor: MagicMock
+) -> None:
+    run_updater(rust_node_type_project, mock_ingestor, skip_if_missing="rust")
+    enum_names = get_node_names(mock_ingestor, NodeType.ENUM)
+    assert any("Color" in n for n in enum_names)
+
+
+def test_rust_trait_label(
+    rust_node_type_project: Path, mock_ingestor: MagicMock
+) -> None:
+    run_updater(rust_node_type_project, mock_ingestor, skip_if_missing="rust")
+    interface_names = get_node_names(mock_ingestor, NodeType.INTERFACE)
+    assert any("Drawable" in n for n in interface_names)
+
+
+def test_rust_type_alias_label(
+    rust_node_type_project: Path, mock_ingestor: MagicMock
+) -> None:
+    run_updater(rust_node_type_project, mock_ingestor, skip_if_missing="rust")
+    type_names = get_node_names(mock_ingestor, NodeType.TYPE)
+    assert any("Pair" in n for n in type_names)
+
+
+def test_rust_union_label(
+    rust_node_type_project: Path, mock_ingestor: MagicMock
+) -> None:
+    run_updater(rust_node_type_project, mock_ingestor, skip_if_missing="rust")
+    union_names = get_node_names(mock_ingestor, NodeType.UNION)
+    assert any("IntOrFloat" in n for n in union_names)
+
+
+def test_rust_struct_label(
+    rust_node_type_project: Path, mock_ingestor: MagicMock
+) -> None:
+    run_updater(rust_node_type_project, mock_ingestor, skip_if_missing="rust")
+    class_names = get_node_names(mock_ingestor, NodeType.CLASS)
+    assert any("Point" in n for n in class_names)


### PR DESCRIPTION
## Summary
- Added Rust tree-sitter node type cases to `determine_node_type()`: `enum_item`->ENUM, `trait_item`->INTERFACE, `type_item`->TYPE, `union_item`->UNION, `struct_item`->CLASS
- Fixed 2 existing integration tests that asserted the old buggy behavior (enums/traits stored as CLASS)

## Test plan
- [x] 5 parametrized unit tests calling `determine_node_type` directly with mock nodes
- [x] 5 integration tests running the full updater on Rust source
- [x] Fixed `test_node_label_e2e.py` to assert correct labels (ENUM, INTERFACE)
- [x] All existing tests pass

Closes #260