### PR TITLE
fix(graph_updater): handle single file as repo_path to produce graph data

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -271,6 +271,10 @@ class GraphUpdater:
         exclude_paths: frozenset[str] | None = None,
     ):
         self.ingestor = ingestor
+        self._single_file: Path | None = None
+        if repo_path.is_file():
+            self._single_file = repo_path.resolve()
+            repo_path = repo_path.resolve().parent
         self.repo_path = repo_path
         self.parsers = parsers
         self.queries = queries
@@ -357,6 +361,9 @@ class GraphUpdater:
                 logger.debug(ls.CLEANED_SIMPLE_NAME, name=simple_name)
 
     def _collect_eligible_files(self) -> list[Path]:
+        if self._single_file is not None:
+            return [self._single_file]
+
         eligible: list[Path] = []
         for filepath in self.repo_path.rglob("*"):
             if (

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -273,8 +273,9 @@ class GraphUpdater:
         self.ingestor = ingestor
         self._single_file: Path | None = None
         if repo_path.is_file():
-            self._single_file = repo_path.resolve()
-            repo_path = repo_path.resolve().parent
+            resolved = repo_path.resolve()
+            self._single_file = resolved
+            repo_path = resolved.parent
         self.repo_path = repo_path
         self.parsers = parsers
         self.queries = queries
@@ -362,7 +363,14 @@ class GraphUpdater:
 
     def _collect_eligible_files(self) -> list[Path]:
         if self._single_file is not None:
-            return [self._single_file]
+            if not should_skip_path(
+                self._single_file,
+                self.repo_path,
+                exclude_paths=self.exclude_paths,
+                unignore_paths=self.unignore_paths,
+            ):
+                return [self._single_file]
+            return []
 
         eligible: list[Path] = []
         for filepath in self.repo_path.rglob("*"):

--- a/codebase_rag/tests/test_cgr_shim.py
+++ b/codebase_rag/tests/test_cgr_shim.py
@@ -1,0 +1,41 @@
+import cgr
+
+
+class TestCgrShimExports:
+    def test_all_symbols_importable(self) -> None:
+        for name in cgr.__all__:
+            assert hasattr(cgr, name), f"{name!r} listed in __all__ but not importable"
+
+    def test_all_matches_module_exports(self) -> None:
+        public_attrs = {k for k in vars(cgr) if not k.startswith("_")}
+        assert set(cgr.__all__) == public_attrs
+
+    def test_settings_is_canonical_instance(self) -> None:
+        from codebase_rag.config import settings
+
+        assert cgr.settings is settings
+
+    def test_embed_code_is_canonical_function(self) -> None:
+        from codebase_rag.embedder import embed_code
+
+        assert cgr.embed_code is embed_code
+
+    def test_graph_loader_is_canonical_class(self) -> None:
+        from codebase_rag.graph_loader import GraphLoader
+
+        assert cgr.GraphLoader is GraphLoader
+
+    def test_load_graph_is_canonical_function(self) -> None:
+        from codebase_rag.graph_loader import load_graph
+
+        assert cgr.load_graph is load_graph
+
+    def test_memgraph_ingestor_is_canonical_class(self) -> None:
+        from codebase_rag.services.graph_service import MemgraphIngestor
+
+        assert cgr.MemgraphIngestor is MemgraphIngestor
+
+    def test_cypher_generator_is_canonical_class(self) -> None:
+        from codebase_rag.services.llm import CypherGenerator
+
+        assert cgr.CypherGenerator is CypherGenerator

--- a/codebase_rag/tests/test_config_validation.py
+++ b/codebase_rag/tests/test_config_validation.py
@@ -1,0 +1,95 @@
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.config import ModelConfig, format_missing_api_key_errors
+
+
+class TestValidateApiKey:
+    @pytest.mark.parametrize(
+        ("provider", "model_id"),
+        [
+            (cs.Provider.OLLAMA, "llama3"),
+            (cs.Provider.LOCAL, "local-model"),
+            (cs.Provider.VLLM, "vllm-model"),
+        ],
+    )
+    def test_local_providers_skip_validation(
+        self, provider: cs.Provider, model_id: str
+    ) -> None:
+        cfg = ModelConfig(provider=provider, model_id=model_id)
+        cfg.validate_api_key()
+
+    def test_google_vertex_skips_validation(self) -> None:
+        cfg = ModelConfig(
+            provider=cs.Provider.GOOGLE,
+            model_id="gemini-pro",
+            provider_type=cs.GoogleProviderType.VERTEX,
+        )
+        cfg.validate_api_key()
+
+    def test_google_gla_requires_api_key(self) -> None:
+        cfg = ModelConfig(
+            provider=cs.Provider.GOOGLE,
+            model_id="gemini-pro",
+            provider_type=cs.GoogleProviderType.GLA,
+        )
+        with pytest.raises(ValueError, match="API Key Missing"):
+            cfg.validate_api_key()
+
+    @pytest.mark.parametrize(
+        "api_key_kwargs",
+        [
+            {},
+            {"api_key": ""},
+            {"api_key": "   "},
+            {"api_key": cs.DEFAULT_API_KEY},
+        ],
+    )
+    def test_invalid_api_key_raises(self, api_key_kwargs: dict[str, str]) -> None:
+        cfg = ModelConfig(
+            provider=cs.Provider.OPENAI, model_id="gpt-4", **api_key_kwargs
+        )
+        with pytest.raises(ValueError, match="API Key Missing"):
+            cfg.validate_api_key()
+
+    def test_valid_api_key_passes(self) -> None:
+        cfg = ModelConfig(
+            provider=cs.Provider.OPENAI, model_id="gpt-4", api_key="sk-real-key-123"
+        )
+        cfg.validate_api_key()
+
+    def test_role_forwarded_to_error_message(self) -> None:
+        cfg = ModelConfig(provider=cs.Provider.OPENAI, model_id="gpt-4")
+        with pytest.raises(ValueError, match="cypher"):
+            cfg.validate_api_key(role="cypher")
+
+
+class TestFormatMissingApiKeyErrors:
+    def test_known_provider_openai(self) -> None:
+        msg = format_missing_api_key_errors(cs.Provider.OPENAI)
+        assert "OPENAI_API_KEY" in msg
+        assert "https://platform.openai.com/api-keys" in msg
+        assert "OpenAI" in msg
+
+    def test_known_provider_anthropic(self) -> None:
+        msg = format_missing_api_key_errors(cs.Provider.ANTHROPIC)
+        assert "ANTHROPIC_API_KEY" in msg
+        assert "Anthropic" in msg
+
+    def test_unknown_provider_generic_message(self) -> None:
+        msg = format_missing_api_key_errors("deepseek")
+        assert "DEEPSEEK_API_KEY" in msg
+        assert "Deepseek" in msg
+
+    def test_role_appears_in_message(self) -> None:
+        msg = format_missing_api_key_errors(cs.Provider.OPENAI, role="cypher")
+        assert "for cypher" in msg
+
+    def test_default_role_omits_role_from_message(self) -> None:
+        msg = format_missing_api_key_errors(cs.Provider.OPENAI)
+        assert "for model" not in msg
+
+    def test_case_insensitive_lookup(self) -> None:
+        msg = format_missing_api_key_errors("OpenAI")
+        assert "OPENAI_API_KEY" in msg
+        assert "OpenAI" in msg

--- a/codebase_rag/tests/test_graph_updater_embeddings.py
+++ b/codebase_rag/tests/test_graph_updater_embeddings.py
@@ -1,0 +1,257 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.services.graph_service import MemgraphIngestor
+from codebase_rag.types_defs import ResultRow
+
+MOCK_EMBEDDING = [0.1] * 768
+
+_PATCH_DEPS = patch(
+    "codebase_rag.graph_updater.has_semantic_dependencies", return_value=True
+)
+_PATCH_EMBED = patch("codebase_rag.embedder.embed_code", return_value=MOCK_EMBEDDING)
+_PATCH_STORE = patch("codebase_rag.vector_store.store_embedding")
+
+
+@pytest.fixture
+def query_ingestor() -> MagicMock:
+    mock = MagicMock(spec=MemgraphIngestor)
+    mock.fetch_all = MagicMock(return_value=[])
+    mock.execute_write = MagicMock()
+    return mock
+
+
+@pytest.fixture
+def updater_with_query(temp_repo: Path, query_ingestor: MagicMock) -> GraphUpdater:
+    parsers, queries = load_parsers()
+    return GraphUpdater(
+        ingestor=query_ingestor,
+        repo_path=temp_repo,
+        parsers=parsers,
+        queries=queries,
+    )
+
+
+class TestCypherQueryEmbeddingsStructure:
+    def test_contains_starts_with_project_name(self) -> None:
+        assert "STARTS WITH" in cs.CYPHER_QUERY_EMBEDDINGS
+        assert "$project_name" in cs.CYPHER_QUERY_EMBEDDINGS
+
+    def test_returns_required_columns(self) -> None:
+        query = cs.CYPHER_QUERY_EMBEDDINGS.upper()
+        for col in ["NODE_ID", "QUALIFIED_NAME", "START_LINE", "END_LINE", "PATH"]:
+            assert col in query
+
+    def test_dot_concatenation_is_parenthesized(self) -> None:
+        assert "($project_name + '.')" in cs.CYPHER_QUERY_EMBEDDINGS
+
+    def test_no_bare_starts_with_plus(self) -> None:
+        for line in cs.CYPHER_QUERY_EMBEDDINGS.splitlines():
+            stripped = line.strip()
+            if "STARTS WITH" in stripped and "$project_name" in stripped:
+                assert "($project_name" in stripped, (
+                    f"$project_name + '.' must be parenthesized in: {stripped!r}"
+                )
+
+
+class TestGenerateSemanticEmbeddings:
+    @_PATCH_DEPS
+    @_PATCH_EMBED
+    @_PATCH_STORE
+    def test_passes_project_name_without_trailing_dot(
+        self,
+        _mock_store: MagicMock,
+        _mock_embed: MagicMock,
+        _mock_deps: MagicMock,
+        updater_with_query: GraphUpdater,
+        query_ingestor: MagicMock,
+    ) -> None:
+        query_ingestor.fetch_all.return_value = []
+        updater_with_query._generate_semantic_embeddings()
+
+        params = query_ingestor.fetch_all.call_args[0][1]
+        project_name_param = params["project_name"]
+        assert not project_name_param.endswith("."), (
+            f"project_name should not have trailing dot, got: {project_name_param!r}"
+        )
+
+    @_PATCH_DEPS
+    @_PATCH_EMBED
+    @_PATCH_STORE
+    def test_uses_cypher_query_embeddings_constant(
+        self,
+        _mock_store: MagicMock,
+        _mock_embed: MagicMock,
+        _mock_deps: MagicMock,
+        updater_with_query: GraphUpdater,
+        query_ingestor: MagicMock,
+    ) -> None:
+        query_ingestor.fetch_all.return_value = []
+        updater_with_query._generate_semantic_embeddings()
+
+        query_arg = query_ingestor.fetch_all.call_args[0][0]
+        assert query_arg == cs.CYPHER_QUERY_EMBEDDINGS
+
+    @patch("codebase_rag.graph_updater.has_semantic_dependencies", return_value=False)
+    def test_skips_when_no_semantic_dependencies(
+        self,
+        _mock_deps: MagicMock,
+        updater_with_query: GraphUpdater,
+        query_ingestor: MagicMock,
+    ) -> None:
+        updater_with_query._generate_semantic_embeddings()
+        query_ingestor.fetch_all.assert_not_called()
+
+    @_PATCH_DEPS
+    @_PATCH_EMBED
+    @_PATCH_STORE
+    def test_returns_early_on_empty_results(
+        self,
+        mock_store: MagicMock,
+        _mock_embed: MagicMock,
+        _mock_deps: MagicMock,
+        updater_with_query: GraphUpdater,
+        query_ingestor: MagicMock,
+    ) -> None:
+        query_ingestor.fetch_all.return_value = []
+        updater_with_query._generate_semantic_embeddings()
+        mock_store.assert_not_called()
+
+    @_PATCH_DEPS
+    @_PATCH_EMBED
+    @_PATCH_STORE
+    def test_embeds_valid_function_with_source(
+        self,
+        mock_store: MagicMock,
+        mock_embed: MagicMock,
+        _mock_deps: MagicMock,
+        updater_with_query: GraphUpdater,
+        query_ingestor: MagicMock,
+        temp_repo: Path,
+    ) -> None:
+        (temp_repo / "module.py").write_text("def hello():\n    return 42\n")
+        row: ResultRow = {
+            cs.KEY_NODE_ID: 1,
+            cs.KEY_QUALIFIED_NAME: "myproject.module.hello",
+            cs.KEY_START_LINE: 1,
+            cs.KEY_END_LINE: 2,
+            cs.KEY_PATH: "module.py",
+        }
+        query_ingestor.fetch_all.return_value = [row]
+
+        updater_with_query._generate_semantic_embeddings()
+
+        mock_embed.assert_called_once()
+        mock_store.assert_called_once_with(1, MOCK_EMBEDDING, "myproject.module.hello")
+
+    @_PATCH_DEPS
+    @_PATCH_EMBED
+    @_PATCH_STORE
+    def test_skips_row_with_missing_source_info(
+        self,
+        mock_store: MagicMock,
+        mock_embed: MagicMock,
+        _mock_deps: MagicMock,
+        updater_with_query: GraphUpdater,
+        query_ingestor: MagicMock,
+    ) -> None:
+        row: ResultRow = {
+            cs.KEY_NODE_ID: 1,
+            cs.KEY_QUALIFIED_NAME: "myproject.module.hello",
+        }
+        query_ingestor.fetch_all.return_value = [row]
+
+        updater_with_query._generate_semantic_embeddings()
+
+        mock_embed.assert_not_called()
+        mock_store.assert_not_called()
+
+    @patch("codebase_rag.graph_updater.has_semantic_dependencies", return_value=True)
+    @patch("codebase_rag.embedder.embed_code", side_effect=RuntimeError("model error"))
+    @_PATCH_STORE
+    def test_handles_embed_failure_gracefully(
+        self,
+        mock_store: MagicMock,
+        _mock_embed: MagicMock,
+        _mock_deps: MagicMock,
+        updater_with_query: GraphUpdater,
+        query_ingestor: MagicMock,
+        temp_repo: Path,
+    ) -> None:
+        (temp_repo / "module.py").write_text("def hello():\n    return 42\n")
+        row: ResultRow = {
+            cs.KEY_NODE_ID: 1,
+            cs.KEY_QUALIFIED_NAME: "myproject.module.hello",
+            cs.KEY_START_LINE: 1,
+            cs.KEY_END_LINE: 2,
+            cs.KEY_PATH: "module.py",
+        }
+        query_ingestor.fetch_all.return_value = [row]
+
+        updater_with_query._generate_semantic_embeddings()
+
+        mock_store.assert_not_called()
+
+    @_PATCH_DEPS
+    @_PATCH_EMBED
+    @_PATCH_STORE
+    def test_skips_unparseable_rows(
+        self,
+        mock_store: MagicMock,
+        mock_embed: MagicMock,
+        _mock_deps: MagicMock,
+        updater_with_query: GraphUpdater,
+        query_ingestor: MagicMock,
+    ) -> None:
+        bad_row: ResultRow = {
+            cs.KEY_NODE_ID: "not_an_int",
+            cs.KEY_QUALIFIED_NAME: "pkg.func",
+        }
+        query_ingestor.fetch_all.return_value = [bad_row]
+
+        updater_with_query._generate_semantic_embeddings()
+
+        mock_embed.assert_not_called()
+        mock_store.assert_not_called()
+
+    @_PATCH_DEPS
+    @_PATCH_EMBED
+    @_PATCH_STORE
+    def test_counts_embedded_functions(
+        self,
+        mock_store: MagicMock,
+        mock_embed: MagicMock,
+        _mock_deps: MagicMock,
+        updater_with_query: GraphUpdater,
+        query_ingestor: MagicMock,
+        temp_repo: Path,
+    ) -> None:
+        (temp_repo / "a.py").write_text("def f1():\n    pass\n")
+        (temp_repo / "b.py").write_text("def f2():\n    pass\n")
+        rows: list[ResultRow] = [
+            {
+                cs.KEY_NODE_ID: 1,
+                cs.KEY_QUALIFIED_NAME: "proj.a.f1",
+                cs.KEY_START_LINE: 1,
+                cs.KEY_END_LINE: 2,
+                cs.KEY_PATH: "a.py",
+            },
+            {
+                cs.KEY_NODE_ID: 2,
+                cs.KEY_QUALIFIED_NAME: "proj.b.f2",
+                cs.KEY_START_LINE: 1,
+                cs.KEY_END_LINE: 2,
+                cs.KEY_PATH: "b.py",
+            },
+        ]
+        query_ingestor.fetch_all.return_value = rows
+
+        updater_with_query._generate_semantic_embeddings()
+
+        assert mock_embed.call_count == 2
+        assert mock_store.call_count == 2

--- a/codebase_rag/tests/test_single_file_repo_path.py
+++ b/codebase_rag/tests/test_single_file_repo_path.py
@@ -1,0 +1,159 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag.tests.conftest import (
+    get_node_names,
+    get_relationships,
+    run_updater,
+)
+
+
+@pytest.fixture
+def cpp_single_file(temp_repo: Path) -> Path:
+    test_file = temp_repo / "cmGlobalFastbuildGenerator.cxx"
+    test_file.write_text(
+        encoding="utf-8",
+        data="""
+#include <map>
+#include <set>
+#include <string>
+
+static std::map<std::string, std::string> const compilerIdToFastbuildFamily = {
+    {"GNU", "gcc"},
+    {"Clang", "clang"},
+};
+
+static std::set<std::string> const supportedLanguages = {
+    "C",
+    "CXX",
+};
+
+template <class T>
+T generateAlias(std::string const& name) { return T(); }
+
+static void helperFunc() {}
+
+class FastbuildTarget {
+public:
+    void GenerateAliases();
+};
+
+void FastbuildTarget::GenerateAliases() {
+    auto alias = generateAlias("test");
+}
+
+void freeFunction() {
+    helperFunc();
+}
+""",
+    )
+    return test_file
+
+
+def test_single_file_repo_path_produces_graph(
+    cpp_single_file: Path,
+    mock_ingestor: MagicMock,
+) -> None:
+    from codebase_rag.graph_updater import GraphUpdater
+    from codebase_rag.parser_loader import load_parsers
+
+    parsers, queries = load_parsers()
+    updater = GraphUpdater(
+        ingestor=mock_ingestor,
+        repo_path=cpp_single_file,
+        parsers=parsers,
+        queries=queries,
+    )
+    updater.run()
+
+    functions = get_node_names(mock_ingestor, "Function")
+    methods = get_node_names(mock_ingestor, "Method")
+    classes = get_node_names(mock_ingestor, "Class")
+
+    assert any("generateAlias" in qn for qn in functions)
+    assert any("helperFunc" in qn for qn in functions)
+    assert any("freeFunction" in qn for qn in functions)
+
+    assert any("GenerateAliases" in qn for qn in methods)
+    assert any("FastbuildTarget" in qn for qn in classes)
+
+    defines_rels = get_relationships(mock_ingestor, "DEFINES")
+    assert len(defines_rels) >= 3
+
+    calls_rels = get_relationships(mock_ingestor, "CALLS")
+    assert len(calls_rels) >= 1
+
+
+def test_single_file_repo_path_static_functions(
+    cpp_single_file: Path,
+    mock_ingestor: MagicMock,
+) -> None:
+    from codebase_rag.graph_updater import GraphUpdater
+    from codebase_rag.parser_loader import load_parsers
+
+    parsers, queries = load_parsers()
+    updater = GraphUpdater(
+        ingestor=mock_ingestor,
+        repo_path=cpp_single_file,
+        parsers=parsers,
+        queries=queries,
+    )
+    updater.run()
+
+    functions = get_node_names(mock_ingestor, "Function")
+
+    assert any("helperFunc" in qn for qn in functions), (
+        f"Static function helperFunc not found. Functions: {functions}"
+    )
+
+    assert any("generateAlias" in qn for qn in functions), (
+        f"Template function generateAlias not found. Functions: {functions}"
+    )
+
+
+def test_single_file_repo_path_out_of_class_methods(
+    cpp_single_file: Path,
+    mock_ingestor: MagicMock,
+) -> None:
+    from codebase_rag.graph_updater import GraphUpdater
+    from codebase_rag.parser_loader import load_parsers
+
+    parsers, queries = load_parsers()
+    updater = GraphUpdater(
+        ingestor=mock_ingestor,
+        repo_path=cpp_single_file,
+        parsers=parsers,
+        queries=queries,
+    )
+    updater.run()
+
+    methods = get_node_names(mock_ingestor, "Method")
+    defines_method_rels = get_relationships(mock_ingestor, "DEFINES_METHOD")
+
+    assert any("GenerateAliases" in qn for qn in methods), (
+        f"Out-of-class method GenerateAliases not found. Methods: {methods}"
+    )
+    assert len(defines_method_rels) >= 1
+
+
+def test_directory_repo_path_still_works(
+    temp_repo: Path,
+    mock_ingestor: MagicMock,
+) -> None:
+    project = temp_repo / "normal_project"
+    project.mkdir()
+    (project / "main.cpp").write_text(
+        encoding="utf-8",
+        data="""
+void doStuff() {}
+int main() { doStuff(); return 0; }
+""",
+    )
+
+    run_updater(project, mock_ingestor)
+
+    functions = get_node_names(mock_ingestor, "Function")
+    assert any("doStuff" in qn for qn in functions)
+    assert any("main" in qn for qn in functions)

--- a/codebase_rag/tests/test_single_file_repo_path.py
+++ b/codebase_rag/tests/test_single_file_repo_path.py
@@ -52,10 +52,8 @@ void freeFunction() {
     return test_file
 
 
-def test_single_file_repo_path_produces_graph(
-    cpp_single_file: Path,
-    mock_ingestor: MagicMock,
-) -> None:
+@pytest.fixture
+def ran_single_file_updater(cpp_single_file: Path, mock_ingestor: MagicMock) -> None:
     from codebase_rag.graph_updater import GraphUpdater
     from codebase_rag.parser_loader import load_parsers
 
@@ -68,6 +66,11 @@ def test_single_file_repo_path_produces_graph(
     )
     updater.run()
 
+
+def test_single_file_repo_path_produces_graph(
+    ran_single_file_updater: None,
+    mock_ingestor: MagicMock,
+) -> None:
     functions = get_node_names(mock_ingestor, "Function")
     methods = get_node_names(mock_ingestor, "Method")
     classes = get_node_names(mock_ingestor, "Class")
@@ -87,21 +90,9 @@ def test_single_file_repo_path_produces_graph(
 
 
 def test_single_file_repo_path_static_functions(
-    cpp_single_file: Path,
+    ran_single_file_updater: None,
     mock_ingestor: MagicMock,
 ) -> None:
-    from codebase_rag.graph_updater import GraphUpdater
-    from codebase_rag.parser_loader import load_parsers
-
-    parsers, queries = load_parsers()
-    updater = GraphUpdater(
-        ingestor=mock_ingestor,
-        repo_path=cpp_single_file,
-        parsers=parsers,
-        queries=queries,
-    )
-    updater.run()
-
     functions = get_node_names(mock_ingestor, "Function")
 
     assert any("helperFunc" in qn for qn in functions), (
@@ -114,21 +105,9 @@ def test_single_file_repo_path_static_functions(
 
 
 def test_single_file_repo_path_out_of_class_methods(
-    cpp_single_file: Path,
+    ran_single_file_updater: None,
     mock_ingestor: MagicMock,
 ) -> None:
-    from codebase_rag.graph_updater import GraphUpdater
-    from codebase_rag.parser_loader import load_parsers
-
-    parsers, queries = load_parsers()
-    updater = GraphUpdater(
-        ingestor=mock_ingestor,
-        repo_path=cpp_single_file,
-        parsers=parsers,
-        queries=queries,
-    )
-    updater.run()
-
     methods = get_node_names(mock_ingestor, "Method")
     defines_method_rels = get_relationships(mock_ingestor, "DEFINES_METHOD")
 


### PR DESCRIPTION
## Summary
- When users pass a single file path via `--repo-path`, `GraphUpdater` used `repo_path.rglob("*")` which produces no results for a file (only works for directories)
- Added detection in `GraphUpdater.__init__` for when `repo_path` is a file, normalizing it to the parent directory and storing it for targeted processing
- Modified `_collect_eligible_files` to short-circuit and return just the single file when in single-file mode

## Test plan
- [x] Single file mode produces correct graph data for static functions, template functions, free functions, and out-of-class methods
- [x] Directory mode still works correctly
- [x] All existing tests pass

Closes #201