### PR TITLE
test(cgrignore): verify .cgrignore is loaded without --interactive-setup

### DIFF
--- a/codebase_rag/cli.py
+++ b/codebase_rag/cli.py
@@ -169,12 +169,12 @@ def start(
             parsers, queries = load_parsers()
 
             updater = GraphUpdater(
-                ingestor,
-                repo_to_update,
-                parsers,
-                queries,
-                unignore_paths,
-                exclude_paths,
+                ingestor=ingestor,
+                repo_path=repo_to_update,
+                parsers=parsers,
+                queries=queries,
+                unignore_paths=unignore_paths,
+                exclude_paths=exclude_paths,
             )
             updater.run()
 
@@ -245,7 +245,12 @@ def index(
         )
         parsers, queries = load_parsers()
         updater = GraphUpdater(
-            ingestor, repo_to_index, parsers, queries, unignore_paths, exclude_paths
+            ingestor=ingestor,
+            repo_path=repo_to_index,
+            parsers=parsers,
+            queries=queries,
+            unignore_paths=unignore_paths,
+            exclude_paths=exclude_paths,
         )
 
         updater.run()


### PR DESCRIPTION
## Summary

- Adds CLI-level integration tests proving `.cgrignore` is **always** loaded by default, not only when `--interactive-setup` is passed
- Verifies both `start` and `index` commands pass `.cgrignore` exclude/unignore patterns to `GraphUpdater` without `--interactive-setup`
- Confirms CLI `--exclude` patterns are merged with `.cgrignore` patterns
- Confirms `prompt_for_unignored_directories` is never called without `--interactive-setup`

Closes #277 as the reported behavior is not a bug. The `.cgrignore` file is unconditionally loaded in both commands before the `interactive_setup` flag is checked.

## Test plan

- [x] All 4 new tests in `TestCgrignoreLoadedWithoutInteractiveSetup` pass
- [x] All 25 tests in `test_cgrignore.py` pass (no regressions)