### PR TITLE
fix(mcp): route default query tool console output to stderr

### DIFF
--- a/codebase_rag/tests/test_codebase_query.py
+++ b/codebase_rag/tests/test_codebase_query.py
@@ -69,6 +69,21 @@ class TestCreateQueryTool:
         tool = create_query_tool(mock_ingestor, mock_cypher_gen, console=mock_console)
         assert tool is not None
 
+    async def test_default_console_writes_to_stderr(
+        self,
+        mock_ingestor: MagicMock,
+        mock_cypher_gen: MagicMock,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        mock_cypher_gen.generate = AsyncMock(return_value="MATCH (n) RETURN n")
+        mock_ingestor.fetch_all.return_value = [{"name": "example"}]
+
+        tool = create_query_tool(mock_ingestor, mock_cypher_gen, console=None)
+        await tool.function(natural_language_query="Find all functions")
+
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
 
 class TestQueryCodebaseKnowledgeGraph:
     async def test_successful_query_returns_results(

--- a/codebase_rag/tests/test_codebase_query.py
+++ b/codebase_rag/tests/test_codebase_query.py
@@ -83,6 +83,7 @@ class TestCreateQueryTool:
 
         captured = capsys.readouterr()
         assert captured.out == ""
+        assert captured.err != ""
 
 
 class TestQueryCodebaseKnowledgeGraph:

--- a/codebase_rag/tools/codebase_query.py
+++ b/codebase_rag/tools/codebase_query.py
@@ -27,7 +27,8 @@ def create_query_tool(
     console: Console | None = None,
 ) -> Tool:
     if console is None:
-        console = Console(width=None, force_terminal=True)
+        # Keep protocol stdout clean for MCP stdio transport.
+        console = Console(width=None, stderr=True, force_terminal=False)
 
     async def query_codebase_knowledge_graph(
         natural_language_query: str,

--- a/codebase_rag/tools/codebase_query.py
+++ b/codebase_rag/tools/codebase_query.py
@@ -27,8 +27,7 @@ def create_query_tool(
     console: Console | None = None,
 ) -> Tool:
     if console is None:
-        # Keep protocol stdout clean for MCP stdio transport.
-        console = Console(width=None, stderr=True, force_terminal=False)
+        console = Console(width=None, stderr=True, force_terminal=True)
 
     async def query_codebase_knowledge_graph(
         natural_language_query: str,


### PR DESCRIPTION
## Summary

- Route default Rich console output to `stderr` instead of `stdout` to prevent MCP stdio protocol corruption
- Keep `force_terminal=True` (only `stderr=True` is needed for the fix)
- Add unit test verifying stdout remains clean and stderr receives output

Based on #358 by @melan335993 with review fixes applied:
- Removed comment (codebase convention: no comments)
- Reverted `force_terminal` back to `True` (changing it to `False` was not needed for the fix)
- Strengthened test with `assert captured.err != ""` to verify output actually goes to stderr

## Test plan

- [x] `uv run pytest codebase_rag/tests/test_codebase_query.py` (16 passed)
- [x] `ruff check` and `ruff format` pass