### PR TITLE
chore(deps): bump code-graph-rag version to 0.0.100 in uv.lock

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -484,7 +484,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.97"
+version = "0.0.100"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Updates the locked version of the code-graph-rag package from 0.0.97 to 0.0.100 in uv.lock.