### PR TITLE
chore: update .gitignore with popular vibe-coding agent directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ wheels/
 .pytest_cache/
 .claude/
 .qdrant_code_embeddings/
+
+# Popular VibeCoding Agents
+.roo/
+.augment
+.vscode


### PR DESCRIPTION
Adds entries for popular AI coding agent directories (.roo/, .augment, .vscode) to .gitignore.