### PR TITLE
chore: update .gitignore with popular vibe-coding agent directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ wheels/
 .pytest_cache/
 .claude/
 .qdrant_code_embeddings/
+
+# Popular VibeCoding Agents
+.roo/
+.augment
+.vscode


### PR DESCRIPTION
Add .roo/, .augment, and .vscode to .gitignore for popular vibe-coding agents.

## Dependency graph

Merge in this order:

```
pr-1: chore: update .gitignore with popular vibe-coding agent directories  <-- this PR
pr-2: fix(llm): add retries to RAG orchestrator to handle output validation issues
├── pr-4: feat(mcp/tools): add shell_command, document_analyzer, semantic_search, and ask_agent tools to MCP registry
│   └── pr-5: feat(mcp/client): add MCP client CLI for querying the code graph via MCP server
│       └── pr-7: docs: update README with non-interactive mode, new MCP tools, and agent tool list
└── pr-6: feat(main): add non-interactive --ask-agent mode to the CLI
    └── pr-7: docs: update README with non-interactive mode, new MCP tools, and agent tool list
pr-3: feat(mcp/server): improve MCP server logging and suppress output during tool execution
└── pr-4: feat(mcp/tools): add shell_command, document_analyzer, semantic_search, and ask_agent tools to MCP registry
    └── pr-5: feat(mcp/client): add MCP client CLI for querying the code graph via MCP server
        └── pr-7: docs: update README with non-interactive mode, new MCP tools, and agent tool list
```