### PR TITLE
feat(mcp/client): add MCP client CLI for querying the code graph via MCP server

### DIFF
--- a/codebase_rag/mcp/client.py
+++ b/codebase_rag/mcp/client.py
@@ -1,0 +1,120 @@
+"""MCP client for querying the code graph via the MCP server.
+
+
+
+This module provides a simple CLI client that connects to the MCP server
+
+and executes the ask_agent tool with a provided question.
+
+"""
+
+import asyncio
+import json
+import os
+import sys
+from typing import Any
+
+import typer
+from mcp import ClientSession
+from mcp.client.stdio import StdioServerParameters, stdio_client
+
+app = typer.Typer()
+
+
+async def query_mcp_server(question: str) -> dict[str, Any]:
+    """Query the MCP server with a question.
+
+
+
+    Args:
+
+        question: The question to ask about the codebase
+
+
+
+    Returns:
+
+        Dictionary with the response from the server
+
+    """
+
+    # Start the MCP server as a subprocess with stderr redirected to /dev/null
+
+    # This suppresses all server logs while keeping stdout/stdin for MCP communication
+
+    with open(os.devnull, "w") as devnull:
+        server_params = StdioServerParameters(
+            command="python",
+            args=["-m", "codebase_rag.main", "mcp-server"],
+        )
+
+        async with stdio_client(server=server_params, errlog=devnull) as (read, write):
+            async with ClientSession(read, write) as session:
+                # Initialize the session
+
+                await session.initialize()
+
+                # Call the ask_agent tool
+
+                result = await session.call_tool("ask_agent", {"question": question})
+
+                # Extract the response text
+
+                if result.content:
+                    response_text = result.content[0].text
+
+                    # Parse JSON response
+
+                    try:
+                        parsed = json.loads(response_text)
+
+                        if isinstance(parsed, dict):
+                            return parsed
+
+                        return {"output": str(parsed)}
+
+                    except json.JSONDecodeError:
+                        return {"output": response_text}
+
+                return {"output": "No response from server"}
+
+
+@app.command()
+def main(
+    question: str = typer.Option(
+        ..., "--ask-agent", "-a", help="Question to ask about the codebase"
+    ),
+) -> None:
+    """Query the code graph via MCP server.
+
+
+
+    Example:
+
+        python -m codebase_rag.mcp.client --ask-agent "What functions call UserService.create_user?"
+
+    """
+
+    try:
+        # Run the async query
+
+        result = asyncio.run(query_mcp_server(question))
+
+        # Print only the output (clean for scripting)
+
+        if isinstance(result, dict) and "output" in result:
+            print(result["output"])
+
+        else:
+            print(json.dumps(result))
+
+    except Exception as e:
+        # Print error to stderr and exit with error code
+
+        print(f"Error: {str(e)}", file=sys.stderr)
+
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
New module codebase_rag/mcp/client.py that spawns the MCP server as a subprocess and calls the ask_agent tool, printing only clean output to stdout. Useful for scripting and CI pipelines.

## Dependency graph

Merge in this order:

```
pr-1: chore: update .gitignore with popular vibe-coding agent directories
pr-2: fix(llm): add retries to RAG orchestrator to handle output validation issues
├── pr-4: feat(mcp/tools): add shell_command, document_analyzer, semantic_search, and ask_agent tools to MCP registry
│   └── pr-5: feat(mcp/client): add MCP client CLI for querying the code graph via MCP server  <-- this PR
│       └── pr-7: docs: update README with non-interactive mode, new MCP tools, and agent tool list
└── pr-6: feat(main): add non-interactive --ask-agent mode to the CLI
    └── pr-7: docs: update README with non-interactive mode, new MCP tools, and agent tool list
pr-3: feat(mcp/server): improve MCP server logging and suppress output during tool execution
└── pr-4: feat(mcp/tools): add shell_command, document_analyzer, semantic_search, and ask_agent tools to MCP registry
    └── pr-5: feat(mcp/client): add MCP client CLI for querying the code graph via MCP server  <-- this PR
        └── pr-7: docs: update README with non-interactive mode, new MCP tools, and agent tool list
```