### PR TITLE
docs: update README with non-interactive mode, new MCP tools, and agent tool list

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,10 +309,21 @@ The system automatically detects and processes files for all supported languages
 
 ### Step 2: Query the Codebase
 
+**Interactive mode:**
+
 Start the interactive RAG CLI:
 
 ```bash
 cgr start --repo-path /path/to/your/repo
+```
+
+**Non-interactive mode (single query):**
+
+Run a single query and exit, with output sent to stdout (useful for scripting):
+
+```bash
+python -m codebase_rag.main start --repo-path /path/to/your/repo \
+  --ask-agent "What functions call UserService.create_user?"
 ```
 
 ### Step 2.5: Real-Time Graph Updates (Optional)
@@ -566,6 +577,7 @@ claude mcp add --transport stdio code-graph-rag \
 | `write_file` | Write content to a file, creating it if it doesn't exist. |
 | `list_directory` | List contents of a directory in the project. |
 | `semantic_search` | Performs a semantic search for functions based on a natural language query describing their purpose, returning a list of potential matches with similarity scores. Requires the 'semantic' extra to be installed. |
+| `ask_agent` | Ask the RAG agent a question about the codebase. Wraps the full RAG pipeline (graph query, LLM response) as an MCP tool. |
 <!-- /SECTION:mcp_tools -->
 
 ### Example Usage


### PR DESCRIPTION
Document the new --ask-agent non-interactive CLI flag, add the four newly exposed MCP tools (shell_command, document_analyzer, semantic_search, get_function_source) to the tools list, and expand the agent tools section with analyze_document, semantic_search_functions, and get_function_source_by_id.

## Dependency graph

Merge in this order:

```
pr-1: chore: update .gitignore with popular vibe-coding agent directories
pr-2: fix(llm): add retries to RAG orchestrator to handle output validation issues
├── pr-4: feat(mcp/tools): add shell_command, document_analyzer, semantic_search, and ask_agent tools to MCP registry
│   └── pr-5: feat(mcp/client): add MCP client CLI for querying the code graph via MCP server
│       └── pr-7: docs: update README with non-interactive mode, new MCP tools, and agent tool list  <-- this PR
└── pr-6: feat(main): add non-interactive --ask-agent mode to the CLI
    └── pr-7: docs: update README with non-interactive mode, new MCP tools, and agent tool list  <-- this PR
pr-3: feat(mcp/server): improve MCP server logging and suppress output during tool execution
└── pr-4: feat(mcp/tools): add shell_command, document_analyzer, semantic_search, and ask_agent tools to MCP registry
    └── pr-5: feat(mcp/client): add MCP client CLI for querying the code graph via MCP server
        └── pr-7: docs: update README with non-interactive mode, new MCP tools, and agent tool list  <-- this PR
```