### PR TITLE
chore: add PyPI downloads and OpenSSF Scorecard badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@
   <a href="https://code-graph-rag.com">
     <img src="https://img.shields.io/badge/Enterprise-Support%20%26%20Services-6366f1" alt="Enterprise Support" />
   </a>
+  <a href="https://pypi.org/project/code-graph-rag/">
+    <img src="https://img.shields.io/pypi/dm/code-graph-rag" alt="PyPI Downloads" />
+  </a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/vitali87/code-graph-rag">
+    <img src="https://api.scorecard.dev/projects/github.com/vitali87/code-graph-rag/badge" alt="OpenSSF Scorecard" />
+  </a>
 </p>
 </div>
 

--- a/uv.lock
+++ b/uv.lock
@@ -484,7 +484,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.101"
+version = "0.0.102"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Add PyPI monthly downloads badge
- Add OpenSSF Scorecard badge

## Test plan

- [ ] Verify badges render correctly on the README
- [ ] Confirm badge links point to correct external pages