### PR TITLE
docs: add pepy.tech downloads badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@
   <a href="https://code-graph-rag.com">
     <img src="https://img.shields.io/badge/Enterprise-Support%20%26%20Services-6366f1" alt="Enterprise Support" />
   </a>
+  <a href="https://pepy.tech/projects/code-graph-rag">
+    <img src="https://static.pepy.tech/personalized-badge/code-graph-rag?period=total&units=INTERNATIONAL_SYSTEM&left_color=BLACK&right_color=GREEN&left_text=downloads" alt="PyPI Downloads" />
+  </a>
 </p>
 </div>
 

--- a/uv.lock
+++ b/uv.lock
@@ -484,7 +484,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.101"
+version = "0.0.102"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Replace the broken shields.io/pypistats downloads badge with pepy.tech, which was showing "rate limited by upstream service"
- Uses pepy.tech personalized badge with total download count

## Test plan
- [ ] Verify badge renders correctly on the README page