### PR TITLE
fix: remove license badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,6 @@
   <a href="https://github.com/vitali87/code-graph-rag/network/members">
     <img src="https://img.shields.io/github/forks/vitali87/code-graph-rag?style=social" alt="GitHub forks" />
   </a>
-  <a href="https://github.com/vitali87/code-graph-rag/blob/main/LICENSE">
-    <img src="https://img.shields.io/github/license/vitali87/code-graph-rag" alt="License" />
-  </a>
   <a href="https://codecov.io/gh/vitali87/code-graph-rag">
     <img src="https://codecov.io/gh/vitali87/code-graph-rag/graph/badge.svg" alt="Codecov" />
   </a>

--- a/uv.lock
+++ b/uv.lock
@@ -494,7 +494,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.113"
+version = "0.0.114"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Remove the license badge from README badges since the license is already visible in the GitHub sidebar
- Resolves the persistent "license invalid" badge caching issue from shields.io

## Test plan
- [ ] Verify README badges render correctly without the license badge