### PR TITLE
fix: add docstrings to semantic search tools to prevent null description

### DIFF
--- a/codebase_rag/tools/semantic_search.py
+++ b/codebase_rag/tools/semantic_search.py
@@ -120,6 +120,7 @@ def get_function_source_code(node_id: int) -> str | None:
 
 def create_semantic_search_tool() -> Tool:
     async def semantic_search_functions(query: str, top_k: int = 5) -> str:
+        """Search for functions and classes in the codebase using semantic similarity."""
         logger.info(ls.SEMANTIC_TOOL_SEARCH.format(query=query))
 
         results = semantic_code_search(query, top_k)
@@ -144,6 +145,7 @@ def create_semantic_search_tool() -> Tool:
 
 def create_get_function_source_tool() -> Tool:
     async def get_function_source_by_id(node_id: int) -> str:
+        """Retrieves the source code of a function or class by its graph node ID."""
         logger.info(ls.SEMANTIC_TOOL_SOURCE.format(id=node_id))
 
         source_code = get_function_source_code(node_id)

--- a/codebase_rag/tools/semantic_search.py
+++ b/codebase_rag/tools/semantic_search.py
@@ -120,7 +120,6 @@ def get_function_source_code(node_id: int) -> str | None:
 
 def create_semantic_search_tool() -> Tool:
     async def semantic_search_functions(query: str, top_k: int = 5) -> str:
-        """Search for functions and classes in the codebase using semantic similarity."""
         logger.info(ls.SEMANTIC_TOOL_SEARCH.format(query=query))
 
         results = semantic_code_search(query, top_k)
@@ -140,12 +139,11 @@ def create_semantic_search_tool() -> Tool:
 
         return response
 
-    return Tool(semantic_search_functions, name=td.AgenticToolName.SEMANTIC_SEARCH)
+    return Tool(semantic_search_functions, name=td.AgenticToolName.SEMANTIC_SEARCH, description=td.SEMANTIC_SEARCH)
 
 
 def create_get_function_source_tool() -> Tool:
     async def get_function_source_by_id(node_id: int) -> str:
-        """Retrieves the source code of a function or class by its graph node ID."""
         logger.info(ls.SEMANTIC_TOOL_SOURCE.format(id=node_id))
 
         source_code = get_function_source_code(node_id)
@@ -155,4 +153,4 @@ def create_get_function_source_tool() -> Tool:
 
         return cs.MSG_SEMANTIC_SOURCE_FORMAT.format(id=node_id, code=source_code)
 
-    return Tool(get_function_source_by_id, name=td.AgenticToolName.GET_FUNCTION_SOURCE)
+    return Tool(get_function_source_by_id, name=td.AgenticToolName.GET_FUNCTION_SOURCE, description=td.GET_FUNCTION_SOURCE)


### PR DESCRIPTION
## Problem

When using `cgr` with LM Studio as the backend, the agent fails immediately with:

```
pydantic_ai.exceptions.ModelHTTPError: status_code: 400, model_name: ...,
body: {'message': 'Invalid', 'type': 'invalid_request_error', 'param': 'tools.8.type', 'code': 'invalid_string'}
```

The root cause is that `semantic_search_functions` and `get_function_source_by_id` had no docstrings. pydantic-ai derives the tool `description` field from the function docstring, so without one it sends `"description": null` in the tool schema. LM Studio's OpenAI-compatible API layer rejects null descriptions, while the real OpenAI API silently accepts them.

## Fix

Add docstrings to both inner tool functions in `codebase_rag/tools/semantic_search.py`:

- `semantic_search_functions`: describes semantic similarity search over the codebase
- `get_function_source_by_id`: describes retrieval of source code by graph node ID

This ensures both tools send a valid non-null description string, resolving the 400 error.

## Testing

Run `cgr start` with an LM Studio backend (or any OpenAI-compatible server that strictly validates tool schemas). The agent should initialize and respond without error.