### PR TITLE
fix(cli): make --clean work independently of --update-graph and delete hash cache

### DIFF
--- a/codebase_rag/cli.py
+++ b/codebase_rag/cli.py
@@ -86,7 +86,7 @@ def _delete_hash_cache(repo_path: Path) -> None:
                 cs.Color.YELLOW,
             )
         )
-        cache_path.unlink()
+        cache_path.unlink(missing_ok=True)
 
 
 @app.command(help=ch.CMD_START)

--- a/codebase_rag/cli.py
+++ b/codebase_rag/cli.py
@@ -77,6 +77,18 @@ def _info(msg: str) -> None:
         app_context.console.print(msg)
 
 
+def _delete_hash_cache(repo_path: Path) -> None:
+    cache_path = repo_path / cs.HASH_CACHE_FILENAME
+    if cache_path.exists():
+        _info(
+            style(
+                cs.CLI_MSG_CLEANING_HASH_CACHE.format(path=cache_path),
+                cs.Color.YELLOW,
+            )
+        )
+        cache_path.unlink()
+
+
 @app.command(help=ch.CMD_START)
 def start(
     repo_path: str | None = typer.Option(
@@ -140,8 +152,6 @@ def start(
         )
         raise typer.Exit(1)
 
-    _update_and_validate_models(orchestrator, cypher)
-
     effective_batch_size = settings.resolve_batch_size(batch_size)
 
     if clean and not update_graph:
@@ -150,18 +160,11 @@ def start(
             _info(style(cs.CLI_MSG_CLEANING_DB, cs.Color.YELLOW))
             ingestor.clean_database()
 
-        cache_path = repo_to_clean / cs.HASH_CACHE_FILENAME
-        if cache_path.exists():
-            _info(
-                style(
-                    cs.CLI_MSG_CLEANING_HASH_CACHE.format(path=cache_path),
-                    cs.Color.YELLOW,
-                )
-            )
-            cache_path.unlink()
-
+        _delete_hash_cache(repo_to_clean)
         _info(style(cs.CLI_MSG_CLEAN_DONE, cs.Color.GREEN))
         return
+
+    _update_and_validate_models(orchestrator, cypher)
 
     if update_graph:
         repo_to_update = Path(target_repo_path)
@@ -183,16 +186,7 @@ def start(
             if clean:
                 _info(style(cs.CLI_MSG_CLEANING_DB, cs.Color.YELLOW))
                 ingestor.clean_database()
-
-                cache_path = repo_to_update / cs.HASH_CACHE_FILENAME
-                if cache_path.exists():
-                    _info(
-                        style(
-                            cs.CLI_MSG_CLEANING_HASH_CACHE.format(path=cache_path),
-                            cs.Color.YELLOW,
-                        )
-                    )
-                    cache_path.unlink()
+                _delete_hash_cache(repo_to_update)
 
             ingestor.ensure_constraints()
 

--- a/codebase_rag/cli.py
+++ b/codebase_rag/cli.py
@@ -144,6 +144,25 @@ def start(
 
     effective_batch_size = settings.resolve_batch_size(batch_size)
 
+    if clean and not update_graph:
+        repo_to_clean = Path(target_repo_path)
+        with connect_memgraph(effective_batch_size) as ingestor:
+            _info(style(cs.CLI_MSG_CLEANING_DB, cs.Color.YELLOW))
+            ingestor.clean_database()
+
+        cache_path = repo_to_clean / cs.HASH_CACHE_FILENAME
+        if cache_path.exists():
+            _info(
+                style(
+                    cs.CLI_MSG_CLEANING_HASH_CACHE.format(path=cache_path),
+                    cs.Color.YELLOW,
+                )
+            )
+            cache_path.unlink()
+
+        _info(style(cs.CLI_MSG_CLEAN_DONE, cs.Color.GREEN))
+        return
+
     if update_graph:
         repo_to_update = Path(target_repo_path)
         _info(
@@ -164,6 +183,17 @@ def start(
             if clean:
                 _info(style(cs.CLI_MSG_CLEANING_DB, cs.Color.YELLOW))
                 ingestor.clean_database()
+
+                cache_path = repo_to_update / cs.HASH_CACHE_FILENAME
+                if cache_path.exists():
+                    _info(
+                        style(
+                            cs.CLI_MSG_CLEANING_HASH_CACHE.format(path=cache_path),
+                            cs.Color.YELLOW,
+                        )
+                    )
+                    cache_path.unlink()
+
             ingestor.ensure_constraints()
 
             parsers, queries = load_parsers()

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -226,6 +226,8 @@ CLI_ERR_MCP_SERVER = "MCP Server Error: {error}"
 
 CLI_MSG_UPDATING_GRAPH = "Updating knowledge graph for: {path}"
 CLI_MSG_CLEANING_DB = "Cleaning database..."
+CLI_MSG_CLEANING_HASH_CACHE = "Removing hash cache: {path}"
+CLI_MSG_CLEAN_DONE = "Clean completed successfully!"
 CLI_MSG_EXPORTING_TO = "Exporting graph to: {path}"
 CLI_MSG_GRAPH_UPDATED = "Graph update completed!"
 CLI_MSG_APP_TERMINATED = "\nApplication terminated by user."

--- a/codebase_rag/tests/test_cli_clean.py
+++ b/codebase_rag/tests/test_cli_clean.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from codebase_rag import constants as cs
+from codebase_rag.cli import app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def mock_memgraph_connect() -> Generator[MagicMock, None, None]:
+    with patch("codebase_rag.cli.connect_memgraph") as mock_connect:
+        mock_ingestor = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=mock_ingestor)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+        yield mock_connect
+
+
+def _get_ingestor(mock_connect: MagicMock) -> MagicMock:
+    return mock_connect.return_value.__enter__.return_value
+
+
+class TestCleanWithoutUpdateGraph:
+    def test_clean_alone_wipes_database(
+        self,
+        mock_memgraph_connect: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        result = runner.invoke(
+            app,
+            ["start", "--clean", "--repo-path", str(tmp_path)],
+        )
+
+        assert result.exit_code == 0, result.output
+        ingestor = _get_ingestor(mock_memgraph_connect)
+        ingestor.clean_database.assert_called_once()
+
+    def test_clean_alone_deletes_hash_cache(
+        self,
+        mock_memgraph_connect: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        cache_path = tmp_path / cs.HASH_CACHE_FILENAME
+        cache_path.write_text(json.dumps({"file.py": "abc123"}))
+
+        result = runner.invoke(
+            app,
+            ["start", "--clean", "--repo-path", str(tmp_path)],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert not cache_path.exists()
+
+    def test_clean_alone_no_cache_file_still_succeeds(
+        self,
+        mock_memgraph_connect: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        cache_path = tmp_path / cs.HASH_CACHE_FILENAME
+        assert not cache_path.exists()
+
+        result = runner.invoke(
+            app,
+            ["start", "--clean", "--repo-path", str(tmp_path)],
+        )
+
+        assert result.exit_code == 0, result.output
+
+    def test_clean_alone_does_not_invoke_graph_updater(
+        self,
+        mock_memgraph_connect: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        with patch("codebase_rag.cli.GraphUpdater") as mock_updater:
+            result = runner.invoke(
+                app,
+                ["start", "--clean", "--repo-path", str(tmp_path)],
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_updater.assert_not_called()
+
+    def test_clean_alone_shows_clean_done_message(
+        self,
+        mock_memgraph_connect: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        result = runner.invoke(
+            app,
+            ["start", "--clean", "--repo-path", str(tmp_path)],
+        )
+
+        assert result.exit_code == 0
+        assert cs.CLI_MSG_CLEAN_DONE in result.output
+
+
+class TestCleanWithUpdateGraph:
+    @patch("codebase_rag.cli.GraphUpdater")
+    @patch("codebase_rag.cli.load_parsers", return_value=({}, {}))
+    @patch("codebase_rag.cli.load_cgrignore_patterns")
+    def test_clean_with_update_deletes_hash_cache(
+        self,
+        mock_cgrignore: MagicMock,
+        mock_load_parsers: MagicMock,
+        mock_graph_updater: MagicMock,
+        mock_memgraph_connect: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        from codebase_rag.config import CgrignorePatterns
+
+        mock_cgrignore.return_value = CgrignorePatterns(
+            exclude=frozenset(), unignore=frozenset()
+        )
+
+        cache_path = tmp_path / cs.HASH_CACHE_FILENAME
+        cache_path.write_text(json.dumps({"file.py": "abc123"}))
+
+        result = runner.invoke(
+            app,
+            ["start", "--clean", "--update-graph", "--repo-path", str(tmp_path)],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert not cache_path.exists()
+
+    @patch("codebase_rag.cli.GraphUpdater")
+    @patch("codebase_rag.cli.load_parsers", return_value=({}, {}))
+    @patch("codebase_rag.cli.load_cgrignore_patterns")
+    def test_clean_with_update_calls_clean_database(
+        self,
+        mock_cgrignore: MagicMock,
+        mock_load_parsers: MagicMock,
+        mock_graph_updater: MagicMock,
+        mock_memgraph_connect: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        from codebase_rag.config import CgrignorePatterns
+
+        mock_cgrignore.return_value = CgrignorePatterns(
+            exclude=frozenset(), unignore=frozenset()
+        )
+
+        result = runner.invoke(
+            app,
+            ["start", "--clean", "--update-graph", "--repo-path", str(tmp_path)],
+        )
+
+        assert result.exit_code == 0, result.output
+        ingestor = _get_ingestor(mock_memgraph_connect)
+        ingestor.clean_database.assert_called_once()
+
+    @patch("codebase_rag.cli.GraphUpdater")
+    @patch("codebase_rag.cli.load_parsers", return_value=({}, {}))
+    @patch("codebase_rag.cli.load_cgrignore_patterns")
+    def test_update_without_clean_preserves_hash_cache(
+        self,
+        mock_cgrignore: MagicMock,
+        mock_load_parsers: MagicMock,
+        mock_graph_updater: MagicMock,
+        mock_memgraph_connect: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        from codebase_rag.config import CgrignorePatterns
+
+        mock_cgrignore.return_value = CgrignorePatterns(
+            exclude=frozenset(), unignore=frozenset()
+        )
+
+        cache_path = tmp_path / cs.HASH_CACHE_FILENAME
+        cache_data = {"file.py": "abc123"}
+        cache_path.write_text(json.dumps(cache_data))
+
+        result = runner.invoke(
+            app,
+            ["start", "--update-graph", "--repo-path", str(tmp_path)],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert cache_path.exists()
+        assert json.loads(cache_path.read_text()) == cache_data

--- a/codebase_rag/tests/test_cli_clean.py
+++ b/codebase_rag/tests/test_cli_clean.py
@@ -10,6 +10,7 @@ from typer.testing import CliRunner
 
 from codebase_rag import constants as cs
 from codebase_rag.cli import app
+from codebase_rag.config import CgrignorePatterns
 
 runner = CliRunner()
 
@@ -87,6 +88,20 @@ class TestCleanWithoutUpdateGraph:
         assert result.exit_code == 0, result.output
         mock_updater.assert_not_called()
 
+    def test_clean_alone_skips_model_validation(
+        self,
+        mock_memgraph_connect: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        with patch("codebase_rag.cli._update_and_validate_models") as mock_validate:
+            result = runner.invoke(
+                app,
+                ["start", "--clean", "--repo-path", str(tmp_path)],
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_validate.assert_not_called()
+
     def test_clean_alone_shows_clean_done_message(
         self,
         mock_memgraph_connect: MagicMock,
@@ -113,8 +128,6 @@ class TestCleanWithUpdateGraph:
         mock_memgraph_connect: MagicMock,
         tmp_path: Path,
     ) -> None:
-        from codebase_rag.config import CgrignorePatterns
-
         mock_cgrignore.return_value = CgrignorePatterns(
             exclude=frozenset(), unignore=frozenset()
         )
@@ -141,8 +154,6 @@ class TestCleanWithUpdateGraph:
         mock_memgraph_connect: MagicMock,
         tmp_path: Path,
     ) -> None:
-        from codebase_rag.config import CgrignorePatterns
-
         mock_cgrignore.return_value = CgrignorePatterns(
             exclude=frozenset(), unignore=frozenset()
         )
@@ -167,8 +178,6 @@ class TestCleanWithUpdateGraph:
         mock_memgraph_connect: MagicMock,
         tmp_path: Path,
     ) -> None:
-        from codebase_rag.config import CgrignorePatterns
-
         mock_cgrignore.return_value = CgrignorePatterns(
             exclude=frozenset(), unignore=frozenset()
         )

--- a/uv.lock
+++ b/uv.lock
@@ -494,7 +494,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.118"
+version = "0.0.119"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- `--clean` now works without `--update-graph`, connecting to Memgraph and wiping the database independently (fixes #436)
- `--clean` now deletes the `.cgr-hash-cache.json` file so subsequent `--update-graph` runs re-index all files from scratch (fixes #434)
- Both behaviors work for standalone `--clean` and combined `--clean --update-graph`

## Test plan
- [x] `--clean` alone wipes the database
- [x] `--clean` alone deletes the hash cache
- [x] `--clean` alone succeeds when no cache file exists
- [x] `--clean` alone does not invoke GraphUpdater
- [x] `--clean` alone shows completion message
- [x] `--clean --update-graph` deletes the hash cache
- [x] `--clean --update-graph` calls clean_database
- [x] `--update-graph` without `--clean` preserves the hash cache

Closes #436
Closes #434