### PR TITLE
fix: catch PermissionError in directory lister for out-of-sandbox paths

### DIFF
--- a/codebase_rag/tests/test_directory_lister.py
+++ b/codebase_rag/tests/test_directory_lister.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 from pydantic_ai import Tool
 
+from codebase_rag import tool_errors as te
 from codebase_rag.tools.directory_lister import (
     DirectoryLister,
     create_directory_lister_tool,
@@ -112,6 +113,24 @@ class TestListDirectoryContents:
         result = directory_lister.list_directory_contents("hidden")
         assert ".hidden_file" in result
         assert "visible_file" in result
+
+    def test_list_directory_returns_error_for_path_outside_root(
+        self, directory_lister: DirectoryLister
+    ) -> None:
+        result = directory_lister.list_directory_contents("../../../etc")
+        expected = te.DIRECTORY_PATH_OUTSIDE_ROOT.format(
+            path="../../../etc", root=directory_lister.project_root
+        )
+        assert result == expected
+
+    def test_list_directory_returns_error_for_absolute_path_outside_root(
+        self, directory_lister: DirectoryLister
+    ) -> None:
+        result = directory_lister.list_directory_contents("/etc/passwd")
+        expected = te.DIRECTORY_PATH_OUTSIDE_ROOT.format(
+            path="/etc/passwd", root=directory_lister.project_root
+        )
+        assert result == expected
 
 
 class TestGetSafePath:

--- a/codebase_rag/tool_errors.py
+++ b/codebase_rag/tool_errors.py
@@ -34,6 +34,10 @@ DOC_DURING_ANALYSIS = "Error: Document analysis failed: {error}"
 DIRECTORY_INVALID = "Error: '{path}' is not a valid directory."
 DIRECTORY_EMPTY = "Error: The directory '{path}' is empty."
 DIRECTORY_LIST_FAILED = "Error: Could not list contents of '{path}'."
+DIRECTORY_PATH_OUTSIDE_ROOT = (
+    "Error: '{path}' is outside the project root ({root}). "
+    "Use a relative path from the project root, or the full absolute path within it."
+)
 
 # (H) Shell command errors
 COMMAND_NOT_ALLOWED = "Command '{cmd}' is not in the allowlist.{suggestion} Available commands: {available}"

--- a/codebase_rag/tools/directory_lister.py
+++ b/codebase_rag/tools/directory_lister.py
@@ -19,7 +19,13 @@ class DirectoryLister:
         self.project_root = Path(project_root).resolve()
 
     def list_directory_contents(self, directory_path: str) -> str:
-        target_path = self._get_safe_path(directory_path)
+        try:
+            target_path = self._get_safe_path(directory_path)
+        except PermissionError:
+            return te.DIRECTORY_PATH_OUTSIDE_ROOT.format(
+                path=directory_path, root=self.project_root
+            )
+
         logger.info(ls.DIR_LISTING.format(path=target_path))
 
         try:


### PR DESCRIPTION
## Summary
- Catches `PermissionError` from `_get_safe_path` in `list_directory_contents` and returns a helpful error message instead of an unhandled exception
- Adds `DIRECTORY_PATH_OUTSIDE_ROOT` error constant that tells the LLM the path is outside the project root and suggests using a relative path
- Closes #274

## Changes
- `tools/directory_lister.py` — wrap `_get_safe_path` call in try/except PermissionError
- `tool_errors.py` — add `DIRECTORY_PATH_OUTSIDE_ROOT` message
- `tests/test_directory_lister.py` — 2 new tests for relative and absolute out-of-bounds paths

## Test plan
- [x] 20 tests pass (including 2 new)
- [x] Lint and format clean