### PR TITLE
feat(cli): add stats command to display graph statistics

### DIFF
--- a/codebase_rag/cli.py
+++ b/codebase_rag/cli.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections.abc import Callable
 from pathlib import Path
 
 import typer
@@ -25,6 +26,7 @@ from .parser_loader import load_parsers
 from .services.protobuf_service import ProtobufFileIngestor
 from .tools.health_checker import HealthChecker
 from .tools.language import cli as language_cli
+from .types_defs import ResultRow
 
 app = typer.Typer(
     name="code-graph-rag",
@@ -498,6 +500,75 @@ def doctor() -> None:
 
     if passed < total:
         raise typer.Exit(1)
+
+
+def _build_stats_table(
+    title: str,
+    col_label: str,
+    rows: list[ResultRow],
+    get_label: Callable[[ResultRow], str],
+    total_label: str,
+) -> Table:
+    table = Table(
+        title=style(title, cs.Color.GREEN),
+        show_header=True,
+        header_style=f"{cs.StyleModifier.BOLD} {cs.Color.MAGENTA}",
+    )
+    table.add_column(col_label, style=cs.Color.CYAN)
+    table.add_column(cs.CLI_STATS_COL_COUNT, style=cs.Color.YELLOW, justify="right")
+    total = 0
+    for row in rows:
+        count = int(row.get("count", 0))
+        total += count
+        table.add_row(get_label(row), f"{count:,}")
+    table.add_section()
+    table.add_row(
+        style(total_label, cs.Color.GREEN),
+        style(f"{total:,}", cs.Color.GREEN),
+    )
+    return table
+
+
+@app.command(name=ch.CLICommandName.STATS, help=ch.CMD_STATS)
+def stats() -> None:
+    from .cypher_queries import (
+        CYPHER_STATS_NODE_COUNTS,
+        CYPHER_STATS_RELATIONSHIP_COUNTS,
+    )
+
+    app_context.console.print(style(cs.CLI_MSG_CONNECTING_STATS, cs.Color.CYAN))
+
+    try:
+        with connect_memgraph(batch_size=1) as ingestor:
+            node_results = ingestor.fetch_all(CYPHER_STATS_NODE_COUNTS)
+            rel_results = ingestor.fetch_all(CYPHER_STATS_RELATIONSHIP_COUNTS)
+
+            app_context.console.print(
+                _build_stats_table(
+                    cs.CLI_STATS_NODE_TITLE,
+                    cs.CLI_STATS_COL_NODE_TYPE,
+                    node_results,
+                    lambda r: ":".join(r.get("labels", [])) or cs.CLI_STATS_UNKNOWN,
+                    cs.CLI_STATS_TOTAL_NODES,
+                )
+            )
+            app_context.console.print()
+            app_context.console.print(
+                _build_stats_table(
+                    cs.CLI_STATS_REL_TITLE,
+                    cs.CLI_STATS_COL_REL_TYPE,
+                    rel_results,
+                    lambda r: str(r.get("type", cs.CLI_STATS_UNKNOWN)),
+                    cs.CLI_STATS_TOTAL_RELS,
+                )
+            )
+
+    except Exception as e:
+        app_context.console.print(
+            style(cs.CLI_ERR_STATS_FAILED.format(error=e), cs.Color.RED)
+        )
+        logger.exception(ls.STATS_ERROR.format(error=e))
+        raise typer.Exit(1) from e
 
 
 if __name__ == "__main__":

--- a/codebase_rag/cli_help.py
+++ b/codebase_rag/cli_help.py
@@ -10,6 +10,7 @@ class CLICommandName(StrEnum):
     GRAPH_LOADER = "graph-loader"
     LANGUAGE = "language"
     DOCTOR = "doctor"
+    STATS = "stats"
 
 
 APP_DESCRIPTION = (
@@ -26,6 +27,7 @@ CMD_MCP_SERVER = "Start the MCP server for Claude Code integration"
 CMD_GRAPH_LOADER = "Load and display summary of exported graph JSON"
 CMD_LANGUAGE = "Manage language grammars (add, remove, list)"
 CMD_DOCTOR = "Verify that all dependencies and configurations are properly set up"
+CMD_STATS = "Display node and relationship statistics for the indexed graph"
 
 CMD_LANGUAGE_GROUP = "CLI for managing language grammars"
 CMD_LANGUAGE_ADD = "Add a new language grammar to the project."
@@ -94,4 +96,5 @@ CLI_COMMANDS: dict[CLICommandName, str] = {
     CLICommandName.GRAPH_LOADER: CMD_GRAPH_LOADER,
     CLICommandName.LANGUAGE: CMD_LANGUAGE,
     CLICommandName.DOCTOR: CMD_DOCTOR,
+    CLICommandName.STATS: CMD_STATS,
 }

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -243,6 +243,16 @@ CLI_MSG_HINT_TARGET_REPO = (
     "\nHint: Make sure TARGET_REPO_PATH environment variable is set."
 )
 CLI_MSG_GRAPH_SUMMARY = "Graph Summary:"
+CLI_MSG_CONNECTING_STATS = "Fetching graph statistics..."
+CLI_STATS_NODE_TITLE = "Node Statistics"
+CLI_STATS_REL_TITLE = "Relationship Statistics"
+CLI_STATS_COL_NODE_TYPE = "Node Type"
+CLI_STATS_COL_REL_TYPE = "Relationship Type"
+CLI_STATS_COL_COUNT = "Count"
+CLI_STATS_TOTAL_NODES = "Total Nodes"
+CLI_STATS_TOTAL_RELS = "Total Relationships"
+CLI_STATS_UNKNOWN = "Unknown"
+CLI_ERR_STATS_FAILED = "Failed to get graph statistics: {error}"
 CLI_MSG_AUTO_EXCLUDE = (
     "Auto-excluding common directories (venv, node_modules, .git, etc.). "
     "Use --interactive-setup to customize."

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -84,6 +84,19 @@ LIMIT 1
 """
 
 
+CYPHER_STATS_NODE_COUNTS = """
+MATCH (n)
+RETURN labels(n) AS labels, count(*) AS count
+ORDER BY count DESC
+"""
+
+CYPHER_STATS_RELATIONSHIP_COUNTS = """
+MATCH ()-[r]->()
+RETURN type(r) AS type, count(*) AS count
+ORDER BY count DESC
+"""
+
+
 def wrap_with_unwind(query: str) -> str:
     return f"UNWIND $batch AS row\n{query}"
 

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -342,6 +342,7 @@ FILE_WRITER_SUCCESS = "[FileWriter] Successfully wrote {chars} characters to {pa
 # (H) Error logs (used with logger.error/warning)
 UNEXPECTED = "An unexpected error occurred: {error}"
 EXPORT_ERROR = "Export error: {error}"
+STATS_ERROR = "Stats error: {error}"
 INDEXING_FAILED = "Indexing failed"
 PATH_NOT_IN_QUESTION = (
     "Could not find original path in question for replacement: {path}"


### PR DESCRIPTION
## Summary
- Adds `cgr stats` command that displays node and relationship counts from Memgraph in Rich tables
- Uses public `fetch_all()` API (not private `_execute_query`)
- Closes #248

## Attribution
Based on work from PR #255 by @AndyBodnar. Reimplemented to address review feedback (import handling, API usage, code style).

## Changes
- `cli.py` — new `stats` command
- `cli_help.py` — added `STATS` command name and help text
- `constants.py` — added stats-related constants
- `cypher_queries.py` — added `CYPHER_STATS_NODE_COUNTS` and `CYPHER_STATS_RELATIONSHIP_COUNTS`
- `logs.py` — added `STATS_ERROR` log message

## Test plan
- [x] Lint and format clean
- [x] Command requires Memgraph connection (integration test)