### PR TITLE
feat: add token-based truncation for Cypher query results

### DIFF
--- a/codebase_rag/config.py
+++ b/codebase_rag/config.py
@@ -270,6 +270,9 @@ class AppConfig(BaseSettings):
     CACHE_EVICTION_DIVISOR: int = 10
     CACHE_MEMORY_THRESHOLD_RATIO: float = 0.8
 
+    QUERY_RESULT_MAX_TOKENS: int = Field(default=16000, gt=0)
+    QUERY_RESULT_ROW_CAP: int = Field(default=500, gt=0)
+
     OLLAMA_HEALTH_TIMEOUT: float = 5.0
 
     _active_orchestrator: ModelConfig | None = None

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -1151,7 +1151,12 @@ SHELL_DANGEROUS_PATTERNS_SEGMENT = (
 # (H) Query tool messages
 QUERY_NOT_AVAILABLE = "N/A"
 DICT_KEY_RESULTS = "results"
+TIKTOKEN_ENCODING = "cl100k_base"
 QUERY_SUMMARY_SUCCESS = "Successfully retrieved {count} item(s) from the graph."
+QUERY_SUMMARY_TRUNCATED = (
+    "Results truncated: showing {kept} of {total} items (~{tokens} tokens, limit {max_tokens}). "
+    "Refine your query for more specific results."
+)
 QUERY_SUMMARY_TRANSLATION_FAILED = (
     "I couldn't translate your request into a database query. Error: {error}"
 )

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -245,6 +245,10 @@ TOOL_FILE_EDIT_SURGICAL_SUCCESS = (
 )
 TOOL_QUERY_RECEIVED = "[Tool:QueryGraph] Received NL query: '{query}'"
 TOOL_QUERY_ERROR = "[Tool:QueryGraph] Error during query execution: {error}"
+QUERY_RESULTS_TRUNCATED = (
+    "[Tool:QueryGraph] Results truncated: showing {kept} of {total} rows "
+    "({tokens} tokens, limit {max_tokens})"
+)
 TOOL_SHELL_EXEC = "Executing shell command: {cmd}"
 TOOL_SHELL_RETURN = "Return code: {code}"
 TOOL_SHELL_STDOUT = "Stdout: {stdout}"

--- a/codebase_rag/tests/test_query_truncation.py
+++ b/codebase_rag/tests/test_query_truncation.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from codebase_rag.tools.codebase_query import create_query_tool
+from codebase_rag.types_defs import ResultRow
+
+
+@pytest.fixture
+def mock_ingestor() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_cypher_gen() -> MagicMock:
+    gen = MagicMock()
+    gen.generate = AsyncMock(return_value="MATCH (n) RETURN n")
+    return gen
+
+
+class TestQueryTruncation:
+    @pytest.mark.asyncio
+    async def test_row_cap_truncation(
+        self, mock_ingestor: MagicMock, mock_cypher_gen: MagicMock
+    ) -> None:
+        rows: list[ResultRow] = [{"name": f"node_{i}"} for i in range(600)]
+        mock_ingestor.fetch_all.return_value = rows
+
+        tool = create_query_tool(mock_ingestor, mock_cypher_gen)
+        with patch("codebase_rag.tools.codebase_query.settings") as mock_settings:
+            mock_settings.QUERY_RESULT_ROW_CAP = 500
+            mock_settings.QUERY_RESULT_MAX_TOKENS = 100000
+            result = await tool.function(natural_language_query="list all nodes")
+
+        assert len(result.results) <= 500
+        assert "truncated" in result.summary.lower() or "600" in result.summary
+
+    @pytest.mark.asyncio
+    async def test_token_truncation(
+        self, mock_ingestor: MagicMock, mock_cypher_gen: MagicMock
+    ) -> None:
+        rows: list[ResultRow] = [
+            {"name": f"function_{i}", "body": f"def func_{i}(): pass  # {'x' * 200}"}
+            for i in range(100)
+        ]
+        mock_ingestor.fetch_all.return_value = rows
+
+        tool = create_query_tool(mock_ingestor, mock_cypher_gen)
+        with patch("codebase_rag.tools.codebase_query.settings") as mock_settings:
+            mock_settings.QUERY_RESULT_ROW_CAP = 500
+            mock_settings.QUERY_RESULT_MAX_TOKENS = 500
+            result = await tool.function(natural_language_query="list functions")
+
+        assert len(result.results) < 100
+        assert "truncated" in result.summary.lower()
+
+    @pytest.mark.asyncio
+    async def test_no_truncation_when_within_limits(
+        self, mock_ingestor: MagicMock, mock_cypher_gen: MagicMock
+    ) -> None:
+        rows: list[ResultRow] = [{"name": f"node_{i}"} for i in range(5)]
+        mock_ingestor.fetch_all.return_value = rows
+
+        tool = create_query_tool(mock_ingestor, mock_cypher_gen)
+        with patch("codebase_rag.tools.codebase_query.settings") as mock_settings:
+            mock_settings.QUERY_RESULT_ROW_CAP = 500
+            mock_settings.QUERY_RESULT_MAX_TOKENS = 16000
+            result = await tool.function(natural_language_query="small query")
+
+        assert len(result.results) == 5
+        assert "Successfully" in result.summary

--- a/codebase_rag/tests/test_token_utils.py
+++ b/codebase_rag/tests/test_token_utils.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from codebase_rag.types_defs import ResultRow
+from codebase_rag.utils.token_utils import count_tokens, truncate_results_by_tokens
+
+
+class TestCountTokens:
+    def test_empty_string(self) -> None:
+        assert count_tokens("") == 0
+
+    def test_simple_string(self) -> None:
+        tokens = count_tokens("hello world")
+        assert tokens > 0
+
+    def test_longer_string_has_more_tokens(self) -> None:
+        short = count_tokens("hello")
+        long = count_tokens("hello world this is a longer string with more tokens")
+        assert long > short
+
+
+class TestTruncateResultsByTokens:
+    def test_empty_results(self) -> None:
+        results, tokens, truncated = truncate_results_by_tokens([], max_tokens=1000)
+        assert results == []
+        assert tokens == 0
+        assert truncated is False
+
+    def test_results_within_limit(self) -> None:
+        rows: list[ResultRow] = [
+            {"name": "foo", "count": 1},
+            {"name": "bar", "count": 2},
+        ]
+        results, tokens, truncated = truncate_results_by_tokens(rows, max_tokens=10000)
+        assert len(results) == 2
+        assert tokens > 0
+        assert truncated is False
+
+    def test_results_exceed_limit(self) -> None:
+        rows: list[ResultRow] = [
+            {"name": f"function_{i}", "path": f"src/module_{i}/file_{i}.py"}
+            for i in range(100)
+        ]
+        results, tokens, truncated = truncate_results_by_tokens(rows, max_tokens=200)
+        assert len(results) < 100
+        assert len(results) > 0
+        assert tokens <= 200
+        assert truncated is True
+
+    def test_single_large_row_still_included(self) -> None:
+        rows: list[ResultRow] = [
+            {"content": "x" * 5000},
+        ]
+        results, tokens, truncated = truncate_results_by_tokens(rows, max_tokens=10)
+        assert len(results) == 1
+        assert truncated is False
+
+    def test_preserves_row_order(self) -> None:
+        rows: list[ResultRow] = [
+            {"name": "first"},
+            {"name": "second"},
+            {"name": "third"},
+        ]
+        results, _, _ = truncate_results_by_tokens(rows, max_tokens=10000)
+        assert [r["name"] for r in results] == ["first", "second", "third"]
+
+    def test_token_count_accuracy(self) -> None:
+        rows: list[ResultRow] = [
+            {"name": "hello world"},
+        ]
+        results, tokens, _ = truncate_results_by_tokens(rows, max_tokens=10000)
+        assert tokens == count_tokens('{"name": "hello world"}')

--- a/codebase_rag/tools/codebase_query.py
+++ b/codebase_rag/tools/codebase_query.py
@@ -10,16 +10,19 @@ from rich.table import Table
 
 from .. import exceptions as ex
 from .. import logs as ls
+from ..config import settings
 from ..constants import (
     QUERY_NOT_AVAILABLE,
     QUERY_RESULTS_PANEL_TITLE,
     QUERY_SUMMARY_DB_ERROR,
     QUERY_SUMMARY_SUCCESS,
     QUERY_SUMMARY_TRANSLATION_FAILED,
+    QUERY_SUMMARY_TRUNCATED,
 )
 from ..schemas import QueryGraphData
 from ..services import QueryProtocol
 from ..services.llm import CypherGenerator
+from ..utils.token_utils import truncate_results_by_tokens
 from . import tool_descriptions as td
 
 
@@ -40,6 +43,16 @@ def create_query_tool(
             cypher_query = await cypher_gen.generate(natural_language_query)
 
             results = await asyncio.to_thread(ingestor.fetch_all, cypher_query)
+
+            total_count = len(results)
+            if total_count > settings.QUERY_RESULT_ROW_CAP:
+                results = results[: settings.QUERY_RESULT_ROW_CAP]
+
+            results, tokens_used, was_truncated = truncate_results_by_tokens(
+                results,
+                max_tokens=settings.QUERY_RESULT_MAX_TOKENS,
+                original_total=total_count,
+            )
 
             if results:
                 table = Table(
@@ -71,7 +84,15 @@ def create_query_tool(
                     )
                 )
 
-            summary = QUERY_SUMMARY_SUCCESS.format(count=len(results))
+            if was_truncated or total_count > len(results):
+                summary = QUERY_SUMMARY_TRUNCATED.format(
+                    kept=len(results),
+                    total=total_count,
+                    tokens=tokens_used,
+                    max_tokens=settings.QUERY_RESULT_MAX_TOKENS,
+                )
+            else:
+                summary = QUERY_SUMMARY_SUCCESS.format(count=len(results))
             return QueryGraphData(
                 query_used=cypher_query, results=results, summary=summary
             )

--- a/codebase_rag/utils/token_utils.py
+++ b/codebase_rag/utils/token_utils.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+from functools import cache
+
+import tiktoken
+from loguru import logger
+
+from .. import constants as cs
+from .. import logs as ls
+from ..types_defs import ResultRow
+
+
+@cache
+def _get_encoding() -> tiktoken.Encoding:
+    return tiktoken.get_encoding(cs.TIKTOKEN_ENCODING)
+
+
+def count_tokens(text: str) -> int:
+    return len(_get_encoding().encode(text))
+
+
+def truncate_results_by_tokens(
+    results: list[ResultRow],
+    max_tokens: int,
+    original_total: int | None = None,
+) -> tuple[list[ResultRow], int, bool]:
+    if not results:
+        return results, 0, False
+
+    kept: list[ResultRow] = []
+    total_tokens = 0
+    total_for_log = original_total if original_total is not None else len(results)
+
+    for row in results:
+        row_text = json.dumps(row, default=str)
+        row_tokens = count_tokens(row_text)
+
+        if total_tokens + row_tokens > max_tokens and kept:
+            logger.warning(
+                ls.QUERY_RESULTS_TRUNCATED.format(
+                    kept=len(kept),
+                    total=total_for_log,
+                    tokens=total_tokens,
+                    max_tokens=max_tokens,
+                )
+            )
+            return kept, total_tokens, True
+
+        kept.append(row)
+        total_tokens += row_tokens
+
+    return kept, total_tokens, False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "pydantic-settings>=2.0.0",
     "pymgclient>=1.4.0",
     "python-dotenv>=1.1.0",
+    "tiktoken>=0.12.0",
     "toml>=0.10.2",
     "tree-sitter-python>=0.23.6",
     "tree-sitter==0.25.2",

--- a/uv.lock
+++ b/uv.lock
@@ -494,7 +494,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.127"
+version = "0.0.129"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -510,6 +510,7 @@ dependencies = [
     { name = "pymgclient" },
     { name = "python-dotenv" },
     { name = "rich" },
+    { name = "tiktoken" },
     { name = "toml" },
     { name = "tree-sitter" },
     { name = "tree-sitter-python" },
@@ -587,6 +588,7 @@ requires-dist = [
     { name = "qdrant-client", marker = "extra == 'semantic'", specifier = ">=1.9.0" },
     { name = "rich", specifier = ">=13.7.1" },
     { name = "testcontainers", marker = "extra == 'test'", specifier = ">=4.9.0" },
+    { name = "tiktoken", specifier = ">=0.12.0" },
     { name = "toml", specifier = ">=0.10.2" },
     { name = "torch", marker = "extra == 'semantic'", specifier = ">=2.6.0" },
     { name = "transformers", marker = "extra == 'semantic'", specifier = ">=4.0.0" },


### PR DESCRIPTION
## Summary
- Adds token-based truncation for Cypher query results using tiktoken (cl100k_base encoding)
- Prevents LLM context window overflow from large query results
- Configurable via `QUERY_RESULT_MAX_TOKENS` (default: 16000) and `QUERY_RESULT_ROW_CAP` (default: 500)
- Closes #165

## How it works
1. Query executes with a row safety cap (500 rows max)
2. Results are serialized and tokens counted via tiktoken
3. If over the token limit, results are truncated row-by-row
4. Summary message indicates truncation: "Results truncated: showing 47 of 312 items (~16000 tokens)"

## Changes
- `utils/token_utils.py` — new module with `count_tokens()` and `truncate_results_by_tokens()`
- `tools/codebase_query.py` — integrated truncation after fetch_all
- `config.py` — added `QUERY_RESULT_MAX_TOKENS` and `QUERY_RESULT_ROW_CAP` settings
- `constants.py` — added `QUERY_SUMMARY_TRUNCATED` message
- `logs.py` — added `QUERY_RESULTS_TRUNCATED` log message
- `tests/test_token_utils.py` — 9 tests

## Test plan
- [x] 9 new tests pass (empty, within limit, exceeds limit, single large row, order preservation, accuracy)
- [x] Lint and format clean