### PR TITLE
fix: provider-specific env var takes priority over generic config key

### DIFF
--- a/codebase_rag/providers/base.py
+++ b/codebase_rag/providers/base.py
@@ -45,8 +45,12 @@ class ModelProvider(ABC):
 
 
 def _resolve_api_key(api_key: str | None, env_var: str) -> str | None:
-    effective = api_key if api_key and api_key != cs.DEFAULT_API_KEY else None
-    return effective or os.environ.get(env_var)
+    env_key = os.environ.get(env_var)
+    if env_key:
+        return env_key
+    if api_key and api_key != cs.DEFAULT_API_KEY:
+        return api_key
+    return None
 
 
 class GoogleProvider(ModelProvider):


### PR DESCRIPTION
## Summary
Fixes 401 error when using `--orchestrator anthropic:claude-opus-4-6` with `ANTHROPIC_API_KEY` set, when `.env` also has a different provider's key in `ORCHESTRATOR_API_KEY`.

## Root cause
`_resolve_api_key` checked the passed `api_key` first, falling back to the env var. When `.env` has `ORCHESTRATOR_API_KEY=AIzaSy...` (a Google key), that key was passed to the Anthropic provider — which then got rejected by Anthropic's API with 401.

## Fix
Provider-specific env var (`ANTHROPIC_API_KEY`, `AZURE_API_KEY`, etc.) now takes priority over the generic config key. Order:
1. Provider-specific env var — always wins if set
2. Passed api_key — only if not the default "ollama"
3. None — triggers validation error

## Test plan
- [x] 30 provider tests pass
- [x] Manually verified: ANTHROPIC_API_KEY correctly reaches provider even when config has a different key