### PR TITLE
fix: remove ReDoS-vulnerable regex from _clean_cypher_response

### DIFF
--- a/codebase_rag/services/llm.py
+++ b/codebase_rag/services/llm.py
@@ -46,7 +46,15 @@ def _clean_cypher_response(response_text: str) -> str:
             query = block.strip()
     else:
         # Remove markdown bold/headers (e.g., **Cypher Query:**)
-        query = re.sub(r"\*\*[^*]+\*\*:?\s*", "", query)
+        while "**" in query:
+            start = query.index("**")
+            end = query.find("**", start + 2)
+            if end == -1:
+                break
+            after = end + 2
+            if after < len(query) and query[after] == ":":
+                after += 1
+            query = query[:start] + query[after:].lstrip()
         # Remove single backticks
         query = query.replace(cs.CYPHER_BACKTICK, "")
         # Remove "cypher" prefix if present


### PR DESCRIPTION
## Summary
Replaces all regex in `_clean_cypher_response` with string operations to resolve the SonarCloud ReDoS security hotspot (python:S5852).

## Changes
- Code block extraction: `re.search(r"```(?:cypher)?\s*(.*?)```")` → simple `str.split("```")`
- Bold text removal: `re.sub(r"\*\*[^*]+\*\*:?\s*", "")` → `str.index("**")` + `str.find("**")` loop

No regex used in `_clean_cypher_response` anymore. The `re` import remains for `_build_keyword_pattern` which is unaffected.

## Test plan
- [x] Verified all 6 input patterns produce correct output
- [x] Lint and format clean