### PR TITLE
docs: update README and constants for C language full support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ An accurate Retrieval-Augmented Generation (RAG) system that analyzes multi-lang
 
 ## Latest News 🔥
 
-- **[NEW]** **Visualise any GitHub repo instantly!** Just change `github.com` to `gitcgr.com` in any repo URL — that's it, only 3 letters! Get an interactive graph of the entire codebase structure. Try it now: [gitcgr.com](https://gitcgr.com)
+- **C Language Support**: Full C language support added — functions, structs, unions, enums, preprocessor includes, and call graph analysis. Contributed by [@dj0nes](https://github.com/dj0nes).
+- **Visualise any GitHub repo instantly!** Just change `github.com` to `gitcgr.com` in any repo URL — that's it, only 3 letters! Get an interactive graph of the entire codebase structure. Try it now: [gitcgr.com](https://gitcgr.com)
 - **MCP Server Integration**: Code-Graph-RAG now works as an MCP server with Claude Code! Query and edit your codebase using natural language directly from Claude Code. [Setup Guide](docs/claude-code-setup.md)
-- **Semantic Code Search**: Added intent-based code search using UniXcoder embeddings. Find functions by describing what they do (e.g., "error handling functions", "authentication code") rather than by exact names.
 
 ## 🚀 Features
 
@@ -55,6 +55,7 @@ An accurate Retrieval-Augmented Generation (RAG) system that analyzes multi-lang
 <!-- SECTION:supported_languages -->
 | Language | Status | Extensions | Functions | Classes/Structs | Modules | Package Detection | Additional Features |
 |--------|------|----------|---------|---------------|-------|-----------------|-------------------|
+| C | Fully Supported | .c | ✓ | ✓ | ✓ | ✓ | Functions, structs, unions, enums, preprocessor includes |
 | C++ | Fully Supported | .cpp, .h, .hpp, .cc, .cxx, .hxx, .hh, .ixx, .cppm, .ccm | ✓ | ✓ | ✓ | ✓ | Constructors, destructors, operator overloading, templates, lambdas, C++20 modules, namespaces |
 | Java | Fully Supported | .java | ✓ | ✓ | ✓ | - | Generics, annotations, modern features (records/sealed classes), concurrency, reflection |
 | JavaScript | Fully Supported | .js, .jsx | ✓ | ✓ | ✓ | - | ES6 modules, CommonJS, prototype methods, object methods, arrow functions |
@@ -464,7 +465,7 @@ cgr optimize javascript --repo-path /path/to/frontend \
 ```
 
 **Supported Languages for Optimization:**
-All supported languages: `python`, `javascript`, `typescript`, `rust`, `go`, `java`, `scala`, `cpp`
+All supported languages: `python`, `javascript`, `typescript`, `rust`, `go`, `java`, `scala`, `c`, `cpp`
 
 **How It Works:**
 1. **Analysis Phase**: The agent analyzes your codebase structure using the knowledge graph
@@ -590,6 +591,7 @@ The knowledge graph uses the following node types and relationships:
 ### Language-Specific Mappings
 
 <!-- SECTION:language_mappings -->
+- **C**: `function_definition`, `struct_specifier`, `union_specifier`, `enum_specifier`, `call_expression`, `preproc_include`
 - **C++**: `class_specifier`, `declaration`, `enum_specifier`, `field_declaration`, `function_definition`, `lambda_expression`, `struct_specifier`, `template_declaration`, `union_specifier`
 - **Java**: `annotation_type_declaration`, `class_declaration`, `constructor_declaration`, `enum_declaration`, `interface_declaration`, `method_declaration`, `record_declaration`
 - **JavaScript**: `arrow_function`, `class`, `class_declaration`, `function_declaration`, `function_expression`, `generator_function_declaration`, `method_definition`

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -498,7 +498,7 @@ LANGUAGE_METADATA: dict[SupportedLanguage, LanguageMetadata] = {
         "TypeScript",
     ),
     SupportedLanguage.C: LanguageMetadata(
-        LanguageStatus.DEV,
+        LanguageStatus.FULL,
         "Functions, structs, unions, enums, preprocessor includes",
         "C",
     ),


### PR DESCRIPTION
## Summary
- Updates C language status from DEV to FULL in constants.py
- Updates README:
  - Adds C language to latest news (crediting @dj0nes)
  - Removes [NEW] from gitcgr.com announcement
  - Drops semantic search from latest news
  - Adds C to supported languages table
  - Adds C to optimization languages list
  - Adds C to language-specific mappings section