### PR TITLE
Add gitcgr code graph badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -899,3 +899,5 @@ We also offer custom development, integration consulting, technical support cont
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=vitali87/code-graph-rag&type=Date)](https://www.star-history.com/#vitali87/code-graph-rag&Date)
+
+[![gitcgr](https://gitcgr.com/badge/vitali87/code-graph-rag.svg)](https://gitcgr.com/vitali87/code-graph-rag)


### PR DESCRIPTION
Adds a [gitcgr](https://gitcgr.com) badge to the README showing code graph statistics for this repository.

**Badge preview:**

[![gitcgr](https://gitcgr.com/badge/vitali87/code-graph-rag.svg)](https://gitcgr.com/vitali87/code-graph-rag)

---

[gitcgr.com](https://gitcgr.com) visualizes any GitHub repo as an interactive code graph — just change `hub` to `cgr` in the URL.

Generated automatically by [gitcgr](https://gitcgr.com).