### PR TITLE
Add gitcgr code graph badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@
   <a href="https://scorecard.dev/viewer/?uri=github.com/vitali87/code-graph-rag">
     <img src="https://api.scorecard.dev/projects/github.com/vitali87/code-graph-rag/badge" alt="OpenSSF Scorecard" />
   </a>
+  <a href="https://gitcgr.com/vitali87/code-graph-rag">
+    <img src="https://gitcgr.com/badge/vitali87/code-graph-rag.svg" alt="gitcgr" />
+  </a>
 </p>
 </div>
 


### PR DESCRIPTION
Adds a [gitcgr](https://gitcgr.com) badge to the README showing code graph statistics for this repository.

**Badge preview:**

[![gitcgr](https://gitcgr.com/badge/vitali87/code-graph-rag.svg)](https://gitcgr.com/vitali87/code-graph-rag)

---

[gitcgr.com](https://gitcgr.com) visualizes any GitHub repo as an interactive code graph — just change `hub` to `cgr` in the URL.

Generated automatically by [gitcgr](https://gitcgr.com).