### PR TITLE
fix: include all subpackages in PyPI wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,8 +62,9 @@ cgr = "codebase_rag.cli:app"
 [tool.uv]
 package = true
 
-[tool.setuptools]
-packages = ["codebase_rag", "codec", "cgr"]
+[tool.setuptools.packages.find]
+include = ["codebase_rag*", "codec*", "cgr*"]
+exclude = ["*.tests", "*.tests.*"]
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
## Summary
Fixes broken PyPI installation where `cgr` command fails with `ModuleNotFoundError: No module named 'codebase_rag.parsers'`.

## Root cause
`[tool.setuptools]` had a flat package list: `packages = ["codebase_rag", "codec", "cgr"]`. This only included top-level directories — all subpackages (parsers, mcp, tools, services, providers, utils, and their nested packages) were excluded from the published wheel.

## Fix
Changed to auto-discovery:
```toml
[tool.setuptools.packages.find]
include = ["codebase_rag*", "codec*", "cgr*"]
```

This includes all subpackages recursively (56 parser files, 9 parser subdirectories, plus mcp, tools, services, providers, utils).

## Verification
- Built wheel locally and confirmed all subpackages are included
- Fresh `uv add code_graph_rag-0.0.147-py3-none-any.whl` → `uv run cgr --help` works

Closes #475