### PR TITLE
ci: skip SonarCloud analysis on forked PRs

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   sonarcloud:
     name: SonarCloud Analysis
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 


### PR DESCRIPTION
## Summary
- Skip SonarCloud job when the PR comes from a fork, since forked PRs cannot access the `SONAR_TOKEN` secret
- Uses `github.event.pull_request.head.repo.full_name == github.repository` condition
- SonarCloud still runs on pushes to main and PRs from branches within the repo

## Test plan
- [x] Verify SonarCloud runs on internal PRs (same repo)
- [x] Verify SonarCloud is skipped on forked PRs
- [x] Verify "All Checks Pass" job is unaffected (it doesn't depend on SonarCloud)