### PR TITLE
feat: add progress bar for indexing

### DIFF
--- a/codebase_rag/cli.py
+++ b/codebase_rag/cli.py
@@ -40,7 +40,9 @@ app = typer.Typer(
 def _version_callback(value: bool) -> None:
     if value:
         app_context.console.print(
-            cs.CLI_MSG_VERSION.format(package=cs.PACKAGE_NAME, version=get_version(cs.PACKAGE_NAME)),
+            cs.CLI_MSG_VERSION.format(
+                package=cs.PACKAGE_NAME, version=get_version(cs.PACKAGE_NAME)
+            ),
             highlight=False,
         )
         raise typer.Exit()

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -410,11 +410,11 @@ class GraphUpdater:
 
         with Progress(
             SpinnerColumn(),
-            TextColumn("[bold blue]Indexing files..."),
+            TextColumn(ls.PROGRESS_INDEXING_LABEL),
             TextColumn("[progress.description]{task.description}"),
             transient=True,
         ) as progress:
-            task = progress.add_task("", total=None)
+            task = progress.add_task("", total=len(eligible_files))
 
             for filepath in eligible_files:
                 file_key = str(filepath.relative_to(self.repo_path))
@@ -430,6 +430,7 @@ class GraphUpdater:
                 ):
                     logger.debug(ls.FILE_HASH_UNCHANGED, path=file_key)
                     skipped_count += 1
+                    progress.advance(task)
                     continue
 
                 if file_key in old_hashes:
@@ -447,7 +448,11 @@ class GraphUpdater:
                     self.ingestor.flush_all()
                     processed_since_flush = 0
 
-                progress.update(task, description=f"{changed_count} processed")
+                progress.update(
+                    task,
+                    advance=1,
+                    description=ls.PROGRESS_FILES_PROCESSED.format(count=changed_count),
+                )
 
         deleted_keys = set(old_hashes.keys()) - current_file_keys
         if deleted_keys:

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -6,6 +6,7 @@ from collections.abc import Callable, ItemsView, KeysView
 from pathlib import Path
 
 from loguru import logger
+from rich.progress import Progress, SpinnerColumn, TextColumn
 from tree_sitter import Node, Parser
 
 from . import constants as cs
@@ -407,36 +408,46 @@ class GraphUpdater:
 
         processed_since_flush = 0
 
-        for filepath in eligible_files:
-            file_key = str(filepath.relative_to(self.repo_path))
-            current_file_keys.add(file_key)
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[bold blue]Indexing files..."),
+            TextColumn("[progress.description]{task.description}"),
+            transient=True,
+        ) as progress:
+            task = progress.add_task("", total=None)
 
-            current_hash = _hash_file(filepath)
-            new_hashes[file_key] = current_hash
+            for filepath in eligible_files:
+                file_key = str(filepath.relative_to(self.repo_path))
+                current_file_keys.add(file_key)
 
-            if (
-                not force
-                and file_key in old_hashes
-                and old_hashes[file_key] == current_hash
-            ):
-                logger.debug(ls.FILE_HASH_UNCHANGED, path=file_key)
-                skipped_count += 1
-                continue
+                current_hash = _hash_file(filepath)
+                new_hashes[file_key] = current_hash
 
-            if file_key in old_hashes:
-                logger.debug(ls.FILE_HASH_CHANGED, path=file_key)
-                self.remove_file_from_state(filepath)
-            else:
-                logger.debug(ls.FILE_HASH_NEW, path=file_key)
+                if (
+                    not force
+                    and file_key in old_hashes
+                    and old_hashes[file_key] == current_hash
+                ):
+                    logger.debug(ls.FILE_HASH_UNCHANGED, path=file_key)
+                    skipped_count += 1
+                    continue
 
-            changed_count += 1
-            self._process_single_file(filepath)
+                if file_key in old_hashes:
+                    logger.debug(ls.FILE_HASH_CHANGED, path=file_key)
+                    self.remove_file_from_state(filepath)
+                else:
+                    logger.debug(ls.FILE_HASH_NEW, path=file_key)
 
-            processed_since_flush += 1
-            if processed_since_flush >= settings.FILE_FLUSH_INTERVAL:
-                logger.info(ls.PERIODIC_FLUSH.format(count=processed_since_flush))
-                self.ingestor.flush_all()
-                processed_since_flush = 0
+                changed_count += 1
+                self._process_single_file(filepath)
+
+                processed_since_flush += 1
+                if processed_since_flush >= settings.FILE_FLUSH_INTERVAL:
+                    logger.info(ls.PERIODIC_FLUSH.format(count=processed_since_flush))
+                    self.ingestor.flush_all()
+                    processed_since_flush = 0
+
+                progress.update(task, description=f"{changed_count} processed")
 
         deleted_keys = set(old_hashes.keys()) - current_file_keys
         if deleted_keys:

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -698,3 +698,7 @@ EXCLUDE_INVALID_INPUT = "Invalid input: '{input}' (expected number)"
 MODEL_SWITCHED = "Model switched to: {model}"
 MODEL_SWITCH_FAILED = "Failed to switch model: {error}"
 MODEL_CURRENT = "Current model: {model}"
+
+# (H) Progress bar logs
+PROGRESS_INDEXING_LABEL = "[bold blue]Indexing files..."
+PROGRESS_FILES_PROCESSED = "{count} processed"

--- a/codebase_rag/tests/test_cli_smoke.py
+++ b/codebase_rag/tests/test_cli_smoke.py
@@ -56,7 +56,9 @@ def test_version_flag() -> None:
         assert result.returncode == 0, (
             f"{flag} exited with code {result.returncode}: {result.stderr}"
         )
-        expected = cs.CLI_MSG_VERSION.format(package=cs.PACKAGE_NAME, version=get_version(cs.PACKAGE_NAME))
+        expected = cs.CLI_MSG_VERSION.format(
+            package=cs.PACKAGE_NAME, version=get_version(cs.PACKAGE_NAME)
+        )
         assert result.stdout.strip() == expected, (
             f"{flag} output did not match expected format: {repr(result.stdout)}"
         )


### PR DESCRIPTION
## Summary
- Add a rich progress spinner with file counter during `_process_files` indexing
- Uses `rich.Progress` with transient display (disappears after completion)
- Shows count of processed (changed) files during indexing

Based on the idea from @tibisabau in PR #297. Reimplemented on the current codebase which now uses hash-based incremental processing. Closes #241.