### PR TITLE
docs: add fork history chart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -914,3 +914,7 @@ We also offer custom development, integration consulting, technical support cont
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=vitali87/code-graph-rag&type=Date)](https://www.star-history.com/#vitali87/code-graph-rag&Date)
+
+## Fork History
+
+[![Fork History Chart](https://fork-history.site/svg?repos=vitali87/code-graph-rag)](https://fork-history.site/#vitali87/code-graph-rag)


### PR DESCRIPTION
## Summary
- Adds a Fork History section below Star History in the README
- Embeds an SVG chart from `fork-history.site/svg?repos=vitali87/code-graph-rag` that shows cumulative forks over time
- Clicking the chart links to the interactive fork history page

## Test plan
- [ ] Verify the SVG renders correctly in the GitHub README preview
- [ ] Confirm the link navigates to the interactive chart