### PR TITLE
feat: add update_repository and semantic_search MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ claude mcp add --transport stdio code-graph-rag \
 | `list_projects` | List all indexed projects in the knowledge graph database. Returns a list of project names that have been indexed. |
 | `delete_project` | Delete a specific project from the knowledge graph database. This removes all nodes associated with the project while preserving other projects. Use list_projects first to see available projects. |
 | `wipe_database` | WARNING: Completely wipe the entire database, removing ALL indexed projects. This cannot be undone. Use delete_project for removing individual projects. |
-| `index_repository` | WARNING: Clears the entire database including embeddings. Parse and ingest the repository into the Memgraph knowledge graph. Use update_repository for incremental updates. Only use when explicitly requested. |
+| `index_repository` | WARNING: Clears all data for the current project including its embeddings. Parse and ingest the repository into the Memgraph knowledge graph. Use update_repository for incremental updates. Only use when explicitly requested. |
 | `update_repository` | Update the repository in the Memgraph knowledge graph without clearing existing data. Use this for incremental updates. |
 | `query_code_graph` | Query the codebase knowledge graph using natural language. Use semantic_search unless you know the exact names of classes/functions you are searching for. Ask questions like 'What functions call UserService.create_user?' or 'Show me all classes that implement the Repository interface'. |
 | `get_code_snippet` | Retrieve source code for a function, class, or method by its qualified name. Returns the source code, file path, line numbers, and docstring. |

--- a/README.md
+++ b/README.md
@@ -557,13 +557,15 @@ claude mcp add --transport stdio code-graph-rag \
 | `list_projects` | List all indexed projects in the knowledge graph database. Returns a list of project names that have been indexed. |
 | `delete_project` | Delete a specific project from the knowledge graph database. This removes all nodes associated with the project while preserving other projects. Use list_projects first to see available projects. |
 | `wipe_database` | WARNING: Completely wipe the entire database, removing ALL indexed projects. This cannot be undone. Use delete_project for removing individual projects. |
-| `index_repository` | Parse and ingest the repository into the Memgraph knowledge graph. This builds a comprehensive graph of functions, classes, dependencies, and relationships. Note: This preserves other projects - only the current project is re-indexed. |
-| `query_code_graph` | Query the codebase knowledge graph using natural language. Ask questions like 'What functions call UserService.create_user?' or 'Show me all classes that implement the Repository interface'. |
+| `index_repository` | WARNING: Clears the entire database including embeddings. Parse and ingest the repository into the Memgraph knowledge graph. Use update_repository for incremental updates. Only use when explicitly requested. |
+| `update_repository` | Update the repository in the Memgraph knowledge graph without clearing existing data. Use this for incremental updates. |
+| `query_code_graph` | Query the codebase knowledge graph using natural language. Use semantic_search unless you know the exact names of classes/functions you are searching for. Ask questions like 'What functions call UserService.create_user?' or 'Show me all classes that implement the Repository interface'. |
 | `get_code_snippet` | Retrieve source code for a function, class, or method by its qualified name. Returns the source code, file path, line numbers, and docstring. |
 | `surgical_replace_code` | Surgically replace an exact code block in a file using diff-match-patch. Only modifies the exact target block, leaving the rest unchanged. |
 | `read_file` | Read the contents of a file from the project. Supports pagination for large files. |
 | `write_file` | Write content to a file, creating it if it doesn't exist. |
 | `list_directory` | List contents of a directory in the project. |
+| `semantic_search` | Performs a semantic search for functions based on a natural language query describing their purpose, returning a list of potential matches with similarity scores. Requires the 'semantic' extra to be installed. |
 <!-- /SECTION:mcp_tools -->
 
 ### Example Usage

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -2458,12 +2458,14 @@ class MCPToolName(StrEnum):
     DELETE_PROJECT = "delete_project"
     WIPE_DATABASE = "wipe_database"
     INDEX_REPOSITORY = "index_repository"
+    UPDATE_REPOSITORY = "update_repository"
     QUERY_CODE_GRAPH = "query_code_graph"
     GET_CODE_SNIPPET = "get_code_snippet"
     SURGICAL_REPLACE_CODE = "surgical_replace_code"
     READ_FILE = "read_file"
     WRITE_FILE = "write_file"
     LIST_DIRECTORY = "list_directory"
+    SEMANTIC_SEARCH = "semantic_search"
 
 
 # (H) MCP transport selection
@@ -2509,6 +2511,7 @@ class MCPParamName(StrEnum):
     LIMIT = "limit"
     CONTENT = "content"
     DIRECTORY_PATH = "directory_path"
+    TOP_K = "top_k"
 
 
 # (H) MCP server constants
@@ -2527,6 +2530,11 @@ MCP_INDEX_ERROR = "Error indexing repository: {error}"
 MCP_WRITE_SUCCESS = "Successfully wrote file: {path}"
 MCP_UNKNOWN_TOOL_ERROR = "Unknown tool: {name}"
 MCP_TOOL_EXEC_ERROR = "Error executing tool '{name}': {error}"
+MCP_UPDATE_SUCCESS = "Successfully updated repository at {path} (no database wipe)."
+MCP_UPDATE_ERROR = "Error updating repository: {error}"
+MCP_SEMANTIC_NOT_AVAILABLE_RESPONSE = (
+    "Semantic search is not available. Install with: uv sync --extra semantic"
+)
 MCP_PROJECT_DELETED = "Successfully deleted project '{project_name}'."
 MCP_WIPE_CANCELLED = "Database wipe cancelled. Set confirm=true to proceed."
 MCP_WIPE_SUCCESS = "Database completely wiped. All projects have been removed."

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -645,6 +645,12 @@ MCP_WRITE_FILE = "[MCP] write_file: {path}"
 MCP_ERROR_WRITE = "[MCP] Error writing file: {error}"
 MCP_LIST_DIR = "[MCP] list_directory: {path}"
 MCP_ERROR_LIST_DIR = "[MCP] Error listing directory: {error}"
+MCP_SEMANTIC_NOT_AVAILABLE = (
+    "[MCP] Semantic search not available. Install with: uv sync --extra semantic"
+)
+MCP_UPDATING_REPO = "[MCP] Updating repository at: {path}"
+MCP_ERROR_UPDATING = "[MCP] Error updating repository: {error}"
+MCP_SEMANTIC_SEARCH = "[MCP] semantic_search: {query}"
 
 # (H) MCP server logs
 MCP_SERVER_INFERRED_ROOT = "[GraphCode MCP] Using inferred project root: {path}"

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -13,7 +13,10 @@ from codebase_rag.parser_loader import load_parsers
 from codebase_rag.services.graph_service import MemgraphIngestor
 from codebase_rag.services.llm import CypherGenerator
 from codebase_rag.tools import tool_descriptions as td
-from codebase_rag.tools.code_retrieval import CodeRetriever, create_code_retrieval_tool
+from codebase_rag.tools.code_retrieval import (
+    CodeRetriever,
+    create_code_retrieval_tool,
+)
 from codebase_rag.tools.codebase_query import create_query_tool
 from codebase_rag.tools.directory_lister import (
     DirectoryLister,
@@ -36,6 +39,7 @@ from codebase_rag.types_defs import (
     MCPToolSchema,
     QueryResultDict,
 )
+from codebase_rag.utils.dependencies import has_semantic_dependencies
 from codebase_rag.vector_store import delete_project_embeddings
 
 
@@ -69,6 +73,19 @@ class MCPToolsRegistry:
         self._directory_lister_tool = create_directory_lister_tool(
             directory_lister=self.directory_lister
         )
+
+        self._semantic_search_tool = None
+        self._semantic_search_available = False
+
+        if has_semantic_dependencies():
+            from codebase_rag.tools.semantic_search import (
+                create_semantic_search_tool,
+            )
+
+            self._semantic_search_tool = create_semantic_search_tool()
+            self._semantic_search_available = True
+        else:
+            logger.info(lg.MCP_SEMANTIC_NOT_AVAILABLE)
 
         self._tools: dict[str, ToolMetadata] = {
             cs.MCPToolName.LIST_PROJECTS: ToolMetadata(
@@ -123,6 +140,17 @@ class MCPToolsRegistry:
                     required=[],
                 ),
                 handler=self.index_repository,
+                returns_json=False,
+            ),
+            cs.MCPToolName.UPDATE_REPOSITORY: ToolMetadata(
+                name=cs.MCPToolName.UPDATE_REPOSITORY,
+                description=td.MCP_TOOLS[cs.MCPToolName.UPDATE_REPOSITORY],
+                input_schema=MCPInputSchema(
+                    type=cs.MCPSchemaType.OBJECT,
+                    properties={},
+                    required=[],
+                ),
+                handler=self.update_repository,
                 returns_json=False,
             ),
             cs.MCPToolName.QUERY_CODE_GRAPH: ToolMetadata(
@@ -250,6 +278,28 @@ class MCPToolsRegistry:
                 returns_json=False,
             ),
         }
+        if self._semantic_search_available:
+            self._tools[cs.MCPToolName.SEMANTIC_SEARCH] = ToolMetadata(
+                name=cs.MCPToolName.SEMANTIC_SEARCH,
+                description=td.MCP_TOOLS[cs.MCPToolName.SEMANTIC_SEARCH],
+                input_schema=MCPInputSchema(
+                    type=cs.MCPSchemaType.OBJECT,
+                    properties={
+                        cs.MCPParamName.NATURAL_LANGUAGE_QUERY: MCPInputSchemaProperty(
+                            type=cs.MCPSchemaType.STRING,
+                            description=td.MCP_PARAM_NATURAL_LANGUAGE_QUERY,
+                        ),
+                        cs.MCPParamName.TOP_K: MCPInputSchemaProperty(
+                            type=cs.MCPSchemaType.INTEGER,
+                            description=td.MCP_PARAM_TOP_K,
+                            default="5",
+                        ),
+                    },
+                    required=[cs.MCPParamName.NATURAL_LANGUAGE_QUERY],
+                ),
+                handler=self.semantic_search,
+                returns_json=False,
+            )
 
     async def list_projects(self) -> ListProjectsResult:
         logger.info(lg.MCP_LISTING_PROJECTS)
@@ -340,6 +390,34 @@ class MCPToolsRegistry:
         except Exception as e:
             logger.error(lg.MCP_ERROR_INDEXING.format(error=e))
             return cs.MCP_INDEX_ERROR.format(error=e)
+
+    def _update_repository_sync(self) -> str:
+        updater = GraphUpdater(
+            ingestor=self.ingestor,
+            repo_path=Path(self.project_root),
+            parsers=self.parsers,
+            queries=self.queries,
+        )
+        updater.run()
+        return cs.MCP_UPDATE_SUCCESS.format(path=self.project_root)
+
+    async def update_repository(self) -> str:
+        logger.info(lg.MCP_UPDATING_REPO.format(path=self.project_root))
+        try:
+            async with self._ingestor_lock:
+                return await asyncio.to_thread(self._update_repository_sync)
+        except Exception as e:
+            logger.error(lg.MCP_ERROR_UPDATING.format(error=e))
+            return cs.MCP_UPDATE_ERROR.format(error=e)
+
+    async def semantic_search(self, natural_language_query: str, top_k: int = 5) -> str:
+        if self._semantic_search_tool is None:
+            return cs.MCP_SEMANTIC_NOT_AVAILABLE_RESPONSE
+        logger.info(lg.MCP_SEMANTIC_SEARCH.format(query=natural_language_query))
+        result = await self._semantic_search_tool.function(
+            query=natural_language_query, top_k=top_k
+        )
+        return str(result)
 
     async def query_code_graph(self, natural_language_query: str) -> QueryResultDict:
         logger.info(lg.MCP_QUERY_CODE_GRAPH.format(query=natural_language_query))

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -292,7 +292,7 @@ class MCPToolsRegistry:
                         cs.MCPParamName.TOP_K: MCPInputSchemaProperty(
                             type=cs.MCPSchemaType.INTEGER,
                             description=td.MCP_PARAM_TOP_K,
-                            default="5",
+                            default=5,
                         ),
                     },
                     required=[cs.MCPParamName.NATURAL_LANGUAGE_QUERY],
@@ -411,8 +411,7 @@ class MCPToolsRegistry:
             return cs.MCP_UPDATE_ERROR.format(error=e)
 
     async def semantic_search(self, natural_language_query: str, top_k: int = 5) -> str:
-        if self._semantic_search_tool is None:
-            return cs.MCP_SEMANTIC_NOT_AVAILABLE_RESPONSE
+        assert self._semantic_search_tool is not None
         logger.info(lg.MCP_SEMANTIC_SEARCH.format(query=natural_language_query))
         result = await self._semantic_search_tool.function(
             query=natural_language_query, top_k=top_k

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -1,0 +1,166 @@
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.mcp.tools import MCPToolsRegistry
+
+pytestmark = [pytest.mark.anyio]
+
+
+@pytest.fixture(params=["asyncio"])
+def anyio_backend(request: pytest.FixtureRequest) -> str:
+    return str(request.param)
+
+
+@pytest.fixture
+def temp_project_root(tmp_path: Path) -> Path:
+    sample_file = tmp_path / "app.py"
+    sample_file.write_text("def main(): pass\n", encoding="utf-8")
+    return tmp_path
+
+
+@pytest.fixture
+def mcp_registry(temp_project_root: Path) -> MCPToolsRegistry:
+    mock_ingestor = MagicMock()
+    mock_cypher_gen = MagicMock()
+
+    registry = MCPToolsRegistry(
+        project_root=str(temp_project_root),
+        ingestor=mock_ingestor,
+        cypher_gen=mock_cypher_gen,
+    )
+    return registry
+
+
+class TestUpdateRepository:
+    async def test_update_repository_success(
+        self, mcp_registry: MCPToolsRegistry
+    ) -> None:
+        with patch(
+            "codebase_rag.mcp.tools.GraphUpdater"
+        ) as mock_updater_cls:
+            mock_updater = MagicMock()
+            mock_updater_cls.return_value = mock_updater
+
+            result = await mcp_registry.update_repository()
+
+            mock_updater_cls.assert_called_once()
+            mock_updater.run.assert_called_once()
+            assert mcp_registry.project_root in result
+
+    async def test_update_repository_error(
+        self, mcp_registry: MCPToolsRegistry
+    ) -> None:
+        with patch(
+            "codebase_rag.mcp.tools.GraphUpdater"
+        ) as mock_updater_cls:
+            mock_updater_cls.side_effect = RuntimeError("parse error")
+
+            result = await mcp_registry.update_repository()
+
+            assert "Error" in result
+
+    async def test_update_repository_registered(
+        self, mcp_registry: MCPToolsRegistry
+    ) -> None:
+        assert cs.MCPToolName.UPDATE_REPOSITORY in mcp_registry._tools
+
+    async def test_update_repository_no_wipe(
+        self, mcp_registry: MCPToolsRegistry
+    ) -> None:
+        with patch(
+            "codebase_rag.mcp.tools.GraphUpdater"
+        ) as mock_updater_cls:
+            mock_updater = MagicMock()
+            mock_updater_cls.return_value = mock_updater
+
+            await mcp_registry.update_repository()
+
+            mcp_registry.ingestor.delete_project.assert_not_called()
+            mcp_registry.ingestor.clean_database.assert_not_called()
+
+
+class TestSemanticSearchRegistration:
+    def test_semantic_search_not_registered_without_deps(
+        self, mcp_registry: MCPToolsRegistry
+    ) -> None:
+        assert cs.MCPToolName.SEMANTIC_SEARCH not in mcp_registry._tools
+
+    def test_semantic_search_registered_with_deps(
+        self, temp_project_root: Path
+    ) -> None:
+        mock_ingestor = MagicMock()
+        mock_cypher_gen = MagicMock()
+
+        with (
+            patch(
+                "codebase_rag.mcp.tools.has_semantic_dependencies",
+                return_value=True,
+            ),
+            patch(
+                "codebase_rag.tools.semantic_search.create_semantic_search_tool"
+            ) as mock_create,
+        ):
+            mock_tool = MagicMock()
+            mock_create.return_value = mock_tool
+
+            registry = MCPToolsRegistry(
+                project_root=str(temp_project_root),
+                ingestor=mock_ingestor,
+                cypher_gen=mock_cypher_gen,
+            )
+
+            assert cs.MCPToolName.SEMANTIC_SEARCH in registry._tools
+            assert registry._semantic_search_available is True
+
+    async def test_semantic_search_calls_tool(
+        self, temp_project_root: Path
+    ) -> None:
+        mock_ingestor = MagicMock()
+        mock_cypher_gen = MagicMock()
+
+        with (
+            patch(
+                "codebase_rag.mcp.tools.has_semantic_dependencies",
+                return_value=True,
+            ),
+            patch(
+                "codebase_rag.tools.semantic_search.create_semantic_search_tool"
+            ) as mock_create,
+        ):
+            mock_tool = MagicMock()
+            mock_tool.function = AsyncMock(return_value="result1, result2")
+            mock_create.return_value = mock_tool
+
+            registry = MCPToolsRegistry(
+                project_root=str(temp_project_root),
+                ingestor=mock_ingestor,
+                cypher_gen=mock_cypher_gen,
+            )
+
+            result = await registry.semantic_search("find auth functions", top_k=3)
+
+            mock_tool.function.assert_called_once_with(
+                query="find auth functions", top_k=3
+            )
+            assert "result1" in result
+
+
+class TestToolDescriptions:
+    def test_update_repository_in_tool_map(self) -> None:
+        from codebase_rag.tools.tool_descriptions import MCP_TOOLS
+
+        assert cs.MCPToolName.UPDATE_REPOSITORY in MCP_TOOLS
+
+    def test_semantic_search_in_tool_map(self) -> None:
+        from codebase_rag.tools.tool_descriptions import MCP_TOOLS
+
+        assert cs.MCPToolName.SEMANTIC_SEARCH in MCP_TOOLS
+
+    def test_index_repository_warns_about_project_clear(self) -> None:
+        from codebase_rag.tools.tool_descriptions import MCP_INDEX_REPOSITORY
+
+        assert "current project" in MCP_INDEX_REPOSITORY
+        assert "entire database" not in MCP_INDEX_REPOSITORY

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -78,9 +78,23 @@ class TestUpdateRepository:
 
 class TestSemanticSearchRegistration:
     def test_semantic_search_not_registered_without_deps(
-        self, mcp_registry: MCPToolsRegistry
+        self, temp_project_root: Path
     ) -> None:
-        assert cs.MCPToolName.SEMANTIC_SEARCH not in mcp_registry._tools
+        mock_ingestor = MagicMock()
+        mock_cypher_gen = MagicMock()
+
+        with patch(
+            "codebase_rag.mcp.tools.has_semantic_dependencies",
+            return_value=False,
+        ):
+            registry = MCPToolsRegistry(
+                project_root=str(temp_project_root),
+                ingestor=mock_ingestor,
+                cypher_gen=mock_cypher_gen,
+            )
+
+        assert cs.MCPToolName.SEMANTIC_SEARCH not in registry._tools
+        assert registry._semantic_search_available is False
 
     def test_semantic_search_registered_with_deps(
         self, temp_project_root: Path

--- a/codebase_rag/tests/test_mcp_update_and_search.py
+++ b/codebase_rag/tests/test_mcp_update_and_search.py
@@ -38,9 +38,7 @@ class TestUpdateRepository:
     async def test_update_repository_success(
         self, mcp_registry: MCPToolsRegistry
     ) -> None:
-        with patch(
-            "codebase_rag.mcp.tools.GraphUpdater"
-        ) as mock_updater_cls:
+        with patch("codebase_rag.mcp.tools.GraphUpdater") as mock_updater_cls:
             mock_updater = MagicMock()
             mock_updater_cls.return_value = mock_updater
 
@@ -53,9 +51,7 @@ class TestUpdateRepository:
     async def test_update_repository_error(
         self, mcp_registry: MCPToolsRegistry
     ) -> None:
-        with patch(
-            "codebase_rag.mcp.tools.GraphUpdater"
-        ) as mock_updater_cls:
+        with patch("codebase_rag.mcp.tools.GraphUpdater") as mock_updater_cls:
             mock_updater_cls.side_effect = RuntimeError("parse error")
 
             result = await mcp_registry.update_repository()
@@ -70,9 +66,7 @@ class TestUpdateRepository:
     async def test_update_repository_no_wipe(
         self, mcp_registry: MCPToolsRegistry
     ) -> None:
-        with patch(
-            "codebase_rag.mcp.tools.GraphUpdater"
-        ) as mock_updater_cls:
+        with patch("codebase_rag.mcp.tools.GraphUpdater") as mock_updater_cls:
             mock_updater = MagicMock()
             mock_updater_cls.return_value = mock_updater
 
@@ -115,9 +109,7 @@ class TestSemanticSearchRegistration:
             assert cs.MCPToolName.SEMANTIC_SEARCH in registry._tools
             assert registry._semantic_search_available is True
 
-    async def test_semantic_search_calls_tool(
-        self, temp_project_root: Path
-    ) -> None:
+    async def test_semantic_search_calls_tool(self, temp_project_root: Path) -> None:
         mock_ingestor = MagicMock()
         mock_cypher_gen = MagicMock()
 

--- a/codebase_rag/tools/tool_descriptions.py
+++ b/codebase_rag/tools/tool_descriptions.py
@@ -88,13 +88,19 @@ MCP_WIPE_DATABASE = (
 )
 
 MCP_INDEX_REPOSITORY = (
+    "WARNING: Clears the entire database including embeddings. "
     "Parse and ingest the repository into the Memgraph knowledge graph. "
-    "This builds a comprehensive graph of functions, classes, dependencies, and relationships. "
-    "Note: This preserves other projects - only the current project is re-indexed."
+    "Use update_repository for incremental updates. Only use when explicitly requested."
+)
+
+MCP_UPDATE_REPOSITORY = (
+    "Update the repository in the Memgraph knowledge graph without clearing existing data. "
+    "Use this for incremental updates."
 )
 
 MCP_QUERY_CODE_GRAPH = (
     "Query the codebase knowledge graph using natural language. "
+    "Use semantic_search unless you know the exact names of classes/functions you are searching for. "
     "Ask questions like 'What functions call UserService.create_user?' or "
     "'Show me all classes that implement the Repository interface'."
 )
@@ -117,6 +123,12 @@ MCP_WRITE_FILE = "Write content to a file, creating it if it doesn't exist."
 
 MCP_LIST_DIRECTORY = "List contents of a directory in the project."
 
+MCP_SEMANTIC_SEARCH = (
+    "Performs a semantic search for functions based on a natural language query "
+    "describing their purpose, returning a list of potential matches with similarity scores. "
+    "Requires the 'semantic' extra to be installed."
+)
+
 MCP_PARAM_PROJECT_NAME = "Name of the project to delete (e.g., 'my-project')"
 MCP_PARAM_CONFIRM = "Must be true to confirm the wipe operation"
 MCP_PARAM_NATURAL_LANGUAGE_QUERY = "Your question in plain English about the codebase"
@@ -130,6 +142,7 @@ MCP_PARAM_OFFSET = "Line number to start reading from (0-based, optional)"
 MCP_PARAM_LIMIT = "Maximum number of lines to read (optional)"
 MCP_PARAM_CONTENT = "Content to write to the file"
 MCP_PARAM_DIRECTORY_PATH = "Relative path to directory from project root (default: '.')"
+MCP_PARAM_TOP_K = "Max number of results to return (optional, default: 5)"
 
 
 MCP_TOOLS: dict[MCPToolName, str] = {
@@ -137,12 +150,14 @@ MCP_TOOLS: dict[MCPToolName, str] = {
     MCPToolName.DELETE_PROJECT: MCP_DELETE_PROJECT,
     MCPToolName.WIPE_DATABASE: MCP_WIPE_DATABASE,
     MCPToolName.INDEX_REPOSITORY: MCP_INDEX_REPOSITORY,
+    MCPToolName.UPDATE_REPOSITORY: MCP_UPDATE_REPOSITORY,
     MCPToolName.QUERY_CODE_GRAPH: MCP_QUERY_CODE_GRAPH,
     MCPToolName.GET_CODE_SNIPPET: MCP_GET_CODE_SNIPPET,
     MCPToolName.SURGICAL_REPLACE_CODE: MCP_SURGICAL_REPLACE_CODE,
     MCPToolName.READ_FILE: MCP_READ_FILE,
     MCPToolName.WRITE_FILE: MCP_WRITE_FILE,
     MCPToolName.LIST_DIRECTORY: MCP_LIST_DIRECTORY,
+    MCPToolName.SEMANTIC_SEARCH: MCP_SEMANTIC_SEARCH,
 }
 
 AGENTIC_TOOLS: dict[AgenticToolName, str] = {

--- a/codebase_rag/tools/tool_descriptions.py
+++ b/codebase_rag/tools/tool_descriptions.py
@@ -88,7 +88,7 @@ MCP_WIPE_DATABASE = (
 )
 
 MCP_INDEX_REPOSITORY = (
-    "WARNING: Clears the entire database including embeddings. "
+    "WARNING: Clears all data for the current project including its embeddings. "
     "Parse and ingest the repository into the Memgraph knowledge graph. "
     "Use update_repository for incremental updates. Only use when explicitly requested."
 )

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -350,7 +350,7 @@ MCPToolArguments = dict[str, str | int | None]
 class MCPInputSchemaProperty(TypedDict, total=False):
     type: str
     description: str
-    default: str
+    default: str | int
 
 
 MCPInputSchemaProperties = dict[str, MCPInputSchemaProperty]


### PR DESCRIPTION
## Summary
- Add `update_repository` MCP tool for incremental graph updates without database wipe
- Add `semantic_search` MCP tool for vector-based function search (conditionally loaded when `semantic` extra is installed)
- Update `index_repository` description to warn about database clearing
- Update `query_code_graph` description to suggest semantic_search for natural language lookups
- Update README MCP tools table

Based on the idea from @luxannaxul in PR #212. Reimplemented on the current codebase.