### PR TITLE
docs: update fork history chart to sketch style

### DIFF
--- a/README.md
+++ b/README.md
@@ -917,4 +917,4 @@ We also offer custom development, integration consulting, technical support cont
 
 ## Fork History
 
-[![Fork History Chart](https://fork-history.site/svg?repos=vitali87/code-graph-rag)](https://fork-history.site/#vitali87/code-graph-rag)
+[![Fork History Chart](https://fork-history.site/svg?repos=vitali87/code-graph-rag&v=2)](https://fork-history.site/#vitali87/code-graph-rag)


### PR DESCRIPTION
## Summary
- Add cache-busting param to fork history SVG URL so GitHub's camo proxy picks up the new sketch style

## Test plan
- [ ] Verify the fork history chart renders in the sketch (hand-drawn) style on the README