### PR TITLE
chore: enable blank issues alongside templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: 💬 Discussions
     url: https://github.com/vitali87/code-graph-rag/discussions

--- a/README.md
+++ b/README.md
@@ -707,7 +707,7 @@ my_build_output
 - **pydantic-settings**: Settings management using Pydantic
 - **pymgclient**: Memgraph database adapter for Python language
 - **python-dotenv**: Read key-value pairs from a .env file and set them as environment variables
-- **tiktoken**: tiktoken is a fast BPE tokeniser for use with OpenAI's models
+- **tiktoken**: Fast BPE tokeniser used for token counting and context window management
 - **toml**: Python Library for Tom's Obvious, Minimal Language
 - **tree-sitter-python**: Python grammar for tree-sitter
 - **tree-sitter**: Python bindings to the Tree-sitter parsing library

--- a/README.md
+++ b/README.md
@@ -571,19 +571,19 @@ The knowledge graph uses the following node types and relationships:
 | Label | Properties |
 |-----|----------|
 | Project | `{name: string}` |
-| Package | `{qualified_name: string, name: string, path: string}` |
-| Folder | `{path: string, name: string}` |
-| File | `{path: string, name: string, extension: string}` |
-| Module | `{qualified_name: string, name: string, path: string}` |
-| Class | `{qualified_name: string, name: string, decorators: list[string]}` |
-| Function | `{qualified_name: string, name: string, decorators: list[string]}` |
-| Method | `{qualified_name: string, name: string, decorators: list[string]}` |
-| Interface | `{qualified_name: string, name: string}` |
-| Enum | `{qualified_name: string, name: string}` |
+| Package | `{qualified_name: string, name: string, path: string, absolute_path: string}` |
+| Folder | `{path: string, name: string, absolute_path: string}` |
+| File | `{path: string, name: string, extension: string, absolute_path: string}` |
+| Module | `{qualified_name: string, name: string, path: string, absolute_path: string}` |
+| Class | `{qualified_name: string, name: string, decorators: list[string], path: string, absolute_path: string}` |
+| Function | `{qualified_name: string, name: string, decorators: list[string], path: string, absolute_path: string}` |
+| Method | `{qualified_name: string, name: string, decorators: list[string], path: string, absolute_path: string}` |
+| Interface | `{qualified_name: string, name: string, path: string, absolute_path: string}` |
+| Enum | `{qualified_name: string, name: string, path: string, absolute_path: string}` |
 | Type | `{qualified_name: string, name: string}` |
 | Union | `{qualified_name: string, name: string}` |
-| ModuleInterface | `{qualified_name: string, name: string, path: string}` |
-| ModuleImplementation | `{qualified_name: string, name: string, path: string, implements_module: string}` |
+| ModuleInterface | `{qualified_name: string, name: string, path: string, absolute_path: string}` |
+| ModuleImplementation | `{qualified_name: string, name: string, path: string, absolute_path: string, implements_module: string}` |
 | ExternalPackage | `{name: string, version_spec: string}` |
 <!-- /SECTION:node_schemas -->
 
@@ -689,6 +689,7 @@ my_build_output
 - **pydantic-settings**: Settings management using Pydantic
 - **pymgclient**: Memgraph database adapter for Python language
 - **python-dotenv**: Read key-value pairs from a .env file and set them as environment variables
+- **tiktoken**: tiktoken is a fast BPE tokeniser for use with OpenAI's models
 - **toml**: Python Library for Tom's Obvious, Minimal Language
 - **tree-sitter-python**: Python grammar for tree-sitter
 - **tree-sitter**: Python bindings to the Tree-sitter parsing library

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -159,9 +159,7 @@ class FunctionRegistryTrie:
             # (H) O(1) lookup using the simple_name_lookup index
             return sorted(self._simple_name_lookup[suffix])
         # (H) Fallback to linear scan if no index available
-        return sorted(
-            qn for qn in self._entries.keys() if qn.endswith(f".{suffix}")
-        )
+        return sorted(qn for qn in self._entries.keys() if qn.endswith(f".{suffix}"))
 
     def find_with_prefix(self, prefix: str) -> list[tuple[QualifiedName, NodeType]]:
         node = self._navigate_to_prefix(prefix)

--- a/uv.lock
+++ b/uv.lock
@@ -494,7 +494,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.130"
+version = "0.0.143"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -1268,6 +1268,7 @@ wheels = [
 name = "griffelib"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/06/eccbd311c9e2b3ca45dbc063b93134c57a1ccc7607c5e545264ad092c4a9/griffelib-2.0.0.tar.gz", hash = "sha256:e504d637a089f5cab9b5daf18f7645970509bf4f53eda8d79ed71cce8bd97934", size = 166312, upload-time = "2026-03-23T21:06:55.954Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
 ]


### PR DESCRIPTION
## Summary
- Set `blank_issues_enabled: true` in `.github/ISSUE_TEMPLATE/config.yml`
- Allows freeform issue creation via "Open a blank issue" link at the bottom of the issue chooser, while keeping existing templates available

## Test plan
- [ ] Verify "New Issue" page shows all templates plus "Open a blank issue" link at the bottom