### PR TITLE
fix: remove unimplemented COHERE, LOCAL, VLLM provider enum values

### DIFF
--- a/codebase_rag/config.py
+++ b/codebase_rag/config.py
@@ -45,11 +45,6 @@ API_KEY_INFO: dict[str, ApiKeyInfoEntry] = {
         "url": "https://portal.azure.com/",
         "name": "Azure OpenAI",
     },
-    cs.Provider.COHERE: {
-        "env_var": "COHERE_API_KEY",
-        "url": "https://dashboard.cohere.com/api-keys",
-        "name": "Cohere",
-    },
 }
 
 
@@ -95,7 +90,7 @@ def format_missing_api_key_errors(
     return error_msg
 
 
-LOCAL_PROVIDERS = frozenset({cs.Provider.OLLAMA, cs.Provider.LOCAL, cs.Provider.VLLM})
+LOCAL_PROVIDERS = frozenset({cs.Provider.OLLAMA})
 
 
 @dataclass

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -20,9 +20,6 @@ class Provider(StrEnum):
     OPENAI = "openai"
     GOOGLE = "google"
     AZURE = "azure"
-    COHERE = "cohere"
-    LOCAL = "local"
-    VLLM = "vllm"
 
 
 class Color(StrEnum):

--- a/codebase_rag/tests/test_config_validation.py
+++ b/codebase_rag/tests/test_config_validation.py
@@ -5,18 +5,8 @@ from codebase_rag.config import ModelConfig, format_missing_api_key_errors
 
 
 class TestValidateApiKey:
-    @pytest.mark.parametrize(
-        ("provider", "model_id"),
-        [
-            (cs.Provider.OLLAMA, "llama3"),
-            (cs.Provider.LOCAL, "local-model"),
-            (cs.Provider.VLLM, "vllm-model"),
-        ],
-    )
-    def test_local_providers_skip_validation(
-        self, provider: cs.Provider, model_id: str
-    ) -> None:
-        cfg = ModelConfig(provider=provider, model_id=model_id)
+    def test_local_providers_skip_validation(self) -> None:
+        cfg = ModelConfig(provider=cs.Provider.OLLAMA, model_id="llama3")
         cfg.validate_api_key()
 
     def test_google_vertex_skips_validation(self) -> None:


### PR DESCRIPTION
## Summary
- Remove 3 Provider enum values (COHERE, LOCAL, VLLM) that have no implementations in PROVIDER_REGISTRY
- Clean up associated references in config, constants, and tests
- These values caused "Unknown provider" errors at runtime when users tried to use them

Closes #503