### PR TITLE
fix: skip CALLS relationship when callee is a Class node

### DIFF
--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -376,6 +376,7 @@ FILE_OUTSIDE_ROOT = "Security risk: Attempted to {action} file outside of projec
 CALL_PROCESSING_FILE = "Processing calls in cached AST for: {path}"
 CALL_PROCESSING_FAILED = "Failed to process calls in {path}: {error}"
 CALL_FOUND_NODES = "Found {count} call nodes in {language} for {caller}"
+CALL_SKIP_CLASS = "Skipping CALLS edge from {caller} to {call_name} (callee is Class node: {callee_qn})"
 CALL_FOUND = (
     "Found call from {caller} to {call_name} (resolved as {callee_type}:{callee_qn})"
 )

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -316,6 +316,15 @@ class CallProcessor:
                 callee_type, callee_qn = operator_info
             else:
                 continue
+            if callee_type == cs.NodeLabel.CLASS:
+                logger.debug(
+                    ls.CALL_SKIP_CLASS,
+                    caller=caller_qn,
+                    call_name=call_name,
+                    callee_qn=callee_qn,
+                )
+                continue
+
             logger.debug(
                 ls.CALL_FOUND,
                 caller=caller_qn,

--- a/codebase_rag/tests/test_call_processor_integration.py
+++ b/codebase_rag/tests/test_call_processor_integration.py
@@ -818,7 +818,7 @@ def main():
         ]
         assert len(calls) >= 1
 
-        # Builder() is a class instantiation, not a function call
+        # (H) Builder() is a class instantiation, not a function call
         class_targets = [c for c in calls if c.args[2][0] == cs.NodeLabel.CLASS]
         assert len(class_targets) == 0
 
@@ -864,8 +864,6 @@ package_func()
 
 
 class TestModuleCallsClassFiltered:
-    """Module CALLS Class edges are semantically incorrect and should be filtered out."""
-
     def test_module_does_not_call_class_python(
         self,
         temp_repo: Path,
@@ -906,10 +904,7 @@ helper()
         ]
 
         class_targets = [c for c in calls if c.args[2][0] == cs.NodeLabel.CLASS]
-        assert len(class_targets) == 0, (
-            f"Expected no CALLS edges to Class nodes, but found {len(class_targets)}: "
-            f"{[(c.args[0][2], c.args[2][2]) for c in class_targets]}"
-        )
+        assert class_targets == []
 
         helper_calls = [c for c in calls if "helper" in c.args[2][2]]
         assert len(helper_calls) >= 1
@@ -952,7 +947,4 @@ def factory():
         ]
 
         class_targets = [c for c in calls if c.args[2][0] == cs.NodeLabel.CLASS]
-        assert len(class_targets) == 0, (
-            f"Expected no CALLS edges to Class nodes, but found {len(class_targets)}: "
-            f"{[(c.args[0][2], c.args[2][2]) for c in class_targets]}"
-        )
+        assert class_targets == []

--- a/codebase_rag/tests/test_call_processor_integration.py
+++ b/codebase_rag/tests/test_call_processor_integration.py
@@ -793,7 +793,11 @@ class Builder:
     def build(self):
         return {}
 
+def helper():
+    pass
+
 def main():
+    helper()
     result = Builder().with_name("test").with_value(42).build()
     return result
 """,
@@ -813,6 +817,10 @@ def main():
             if c.args[1] == cs.RelationshipType.CALLS
         ]
         assert len(calls) >= 1
+
+        # Builder() is a class instantiation, not a function call
+        class_targets = [c for c in calls if c.args[2][0] == cs.NodeLabel.CLASS]
+        assert len(class_targets) == 0
 
     def test_handles_init_py_module_qn(
         self,
@@ -853,3 +861,98 @@ package_func()
         caller_qns = [c.args[0][2] for c in calls]
         package_callers = [qn for qn in caller_qns if "mypackage" in qn]
         assert len(package_callers) >= 1
+
+
+class TestModuleCallsClassFiltered:
+    """Module CALLS Class edges are semantically incorrect and should be filtered out."""
+
+    def test_module_does_not_call_class_python(
+        self,
+        temp_repo: Path,
+        mock_ingestor: MagicMock,
+        parsers_and_queries: tuple,
+    ) -> None:
+        parsers, queries = parsers_and_queries
+        if cs.SupportedLanguage.PYTHON not in parsers:
+            pytest.skip("Python parser not available")
+
+        test_file = temp_repo / "test_module.py"
+        test_file.write_text(
+            encoding="utf-8",
+            data="""
+class MyClass:
+    def method(self):
+        pass
+
+def helper():
+    pass
+
+helper()
+""",
+        )
+
+        updater = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=temp_repo,
+            parsers=parsers,
+            queries=queries,
+        )
+        updater.run()
+
+        calls = [
+            c
+            for c in mock_ingestor.ensure_relationship_batch.call_args_list
+            if c.args[1] == cs.RelationshipType.CALLS
+        ]
+
+        class_targets = [c for c in calls if c.args[2][0] == cs.NodeLabel.CLASS]
+        assert len(class_targets) == 0, (
+            f"Expected no CALLS edges to Class nodes, but found {len(class_targets)}: "
+            f"{[(c.args[0][2], c.args[2][2]) for c in class_targets]}"
+        )
+
+        helper_calls = [c for c in calls if "helper" in c.args[2][2]]
+        assert len(helper_calls) >= 1
+
+    def test_function_does_not_call_class_python(
+        self,
+        temp_repo: Path,
+        mock_ingestor: MagicMock,
+        parsers_and_queries: tuple,
+    ) -> None:
+        parsers, queries = parsers_and_queries
+        if cs.SupportedLanguage.PYTHON not in parsers:
+            pytest.skip("Python parser not available")
+
+        test_file = temp_repo / "test_module.py"
+        test_file.write_text(
+            encoding="utf-8",
+            data="""
+class MyClass:
+    pass
+
+def factory():
+    obj = MyClass()
+    return obj
+""",
+        )
+
+        updater = GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=temp_repo,
+            parsers=parsers,
+            queries=queries,
+        )
+        updater.run()
+
+        calls = [
+            c
+            for c in mock_ingestor.ensure_relationship_batch.call_args_list
+            if c.args[1] == cs.RelationshipType.CALLS
+        ]
+
+        class_targets = [c for c in calls if c.args[2][0] == cs.NodeLabel.CLASS]
+        assert len(class_targets) == 0, (
+            f"Expected no CALLS edges to Class nodes, but found {len(class_targets)}: "
+            f"{[(c.args[0][2], c.args[2][2]) for c in class_targets]}"
+        )

--- a/codebase_rag/tests/test_python_real_world.py
+++ b/codebase_rag/tests/test_python_real_world.py
@@ -874,24 +874,20 @@ export const HomePage = () => {
     return project_path
 
 
-def test_flask_model_calls(
+def test_flask_no_calls_to_class_nodes(
     todo_app_project: Path,
     mock_ingestor: MagicMock,
 ) -> None:
-    """Test detection of model usage in controllers."""
+    """Test that Class nodes are not targets of CALLS relationships."""
     run_updater(todo_app_project, mock_ingestor)
 
     function_calls = get_relationships(mock_ingestor, "CALLS")
 
-    model_usage_calls = [
-        call
-        for call in function_calls
-        if "task_controller" in call.args[0][2] and "TaskModel" in call.args[2][2]
-    ]
+    class_calls = [call for call in function_calls if call.args[2][0] == "Class"]
 
-    assert model_usage_calls, (
-        f"Expected TaskController to use TaskModel, found: "
-        f"{[(c.args[0][2], c.args[2][2]) for c in model_usage_calls]}"
+    assert not class_calls, (
+        f"Expected no CALLS edges to Class nodes, found: "
+        f"{[(c.args[0][2], c.args[2][2]) for c in class_calls]}"
     )
 
 


### PR DESCRIPTION
## Summary
- Filter out Class nodes from CALLS relationship creation in call_processor
- Module CALLS Class edges are semantically incorrect — modules don't call classes, they may instantiate or reference them
- Identified by gdotv blog analysis of knowledge graph structural integrity

Closes #497