### PR TITLE
feat: add Python 3.14 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/astral-sh/uv:0.10@sha256:72ab0aeb448090480ccabb99fb5f52b0dc3c71923bffb5e2e26517a1c27b7fec AS uv
 
-FROM python:3.12-slim@sha256:f3fa41d74a768c2fce8016b98c191ae8c1bacd8f1152870a3f9f87d350920b7c AS builder
+FROM python:3.14-slim@sha256:fb83750094b46fd6b8adaa80f66e2302ecbe45d513f6cece637a841e1025b4ca AS builder
 
 COPY --from=uv /uv /uvx /bin/
 
@@ -17,7 +17,7 @@ RUN uv sync --frozen --no-dev --extra treesitter-full --no-install-project --no-
 COPY . .
 RUN uv sync --frozen --no-dev --extra treesitter-full --no-binary-package pymgclient
 
-FROM python:3.12-slim@sha256:f3fa41d74a768c2fce8016b98c191ae8c1bacd8f1152870a3f9f87d350920b7c
+FROM python:3.14-slim@sha256:fb83750094b46fd6b8adaa80f66e2302ecbe45d513f6cece637a841e1025b4ca
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ripgrep libssl3 zlib1g libzstd1 && \

--- a/codebase_rag/tests/test_mcp_write_file.py
+++ b/codebase_rag/tests/test_mcp_write_file.py
@@ -199,6 +199,7 @@ class TestWriteFileErrorHandling:
     @pytest.mark.skipif(
         os.name == "nt", reason="chmod 0o444 does not prevent file creation on Windows"
     )
+    @pytest.mark.skipif(os.getuid() == 0, reason="root bypasses filesystem permissions")
     async def test_write_to_readonly_directory(
         self, mcp_registry: MCPToolsRegistry, temp_project_root: Path
     ) -> None:

--- a/codebase_rag/tests/test_mcp_write_file.py
+++ b/codebase_rag/tests/test_mcp_write_file.py
@@ -199,7 +199,10 @@ class TestWriteFileErrorHandling:
     @pytest.mark.skipif(
         os.name == "nt", reason="chmod 0o444 does not prevent file creation on Windows"
     )
-    @pytest.mark.skipif(os.getuid() == 0, reason="root bypasses filesystem permissions")
+    @pytest.mark.skipif(
+        hasattr(os, "getuid") and os.getuid() == 0,
+        reason="root bypasses filesystem permissions",
+    )
     async def test_write_to_readonly_directory(
         self, mcp_registry: MCPToolsRegistry, temp_project_root: Path
     ) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 keywords = [
     "rag",


### PR DESCRIPTION
## Summary
- Bump Docker image from python:3.12-slim to python:3.14-slim
- Add Python 3.14 classifier to pyproject.toml
- Fix `test_write_to_readonly_directory` to skip when running as root (root bypasses chmod permissions)

Tested locally: 3523 passed, 0 failed, 67 skipped on Python 3.14.3 with all extras.

Supersedes #419