### PR TITLE
fix: sort tree-sitter captures by start_byte for deterministic graph output

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -14,7 +14,7 @@ from .call_resolver import CallResolver
 from .cpp import utils as cpp_utils
 from .import_processor import ImportProcessor
 from .type_inference import TypeInferenceEngine
-from .utils import get_function_captures, is_method_node
+from .utils import get_function_captures, is_method_node, sorted_captures
 
 
 class CallProcessor:
@@ -143,7 +143,7 @@ class CallProcessor:
         if not method_query:
             return
         method_cursor = QueryCursor(method_query)
-        method_captures = method_cursor.captures(body_node)
+        method_captures = sorted_captures(method_cursor, body_node)
         method_nodes = method_captures.get(cs.CAPTURE_FUNCTION, [])
         for method_node in method_nodes:
             if not isinstance(method_node, Node):
@@ -176,7 +176,7 @@ class CallProcessor:
         if not query:
             return
         cursor = QueryCursor(query)
-        captures = cursor.captures(root_node)
+        captures = sorted_captures(cursor, root_node)
         class_nodes = captures.get(cs.CAPTURE_CLASS, [])
 
         for class_node in class_nodes:
@@ -275,7 +275,7 @@ class CallProcessor:
         )
 
         cursor = QueryCursor(calls_query)
-        captures = cursor.captures(caller_node)
+        captures = sorted_captures(cursor, caller_node)
         call_nodes = captures.get(cs.CAPTURE_CALL, [])
 
         logger.debug(

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -14,7 +14,7 @@ from ...types_defs import ASTNode, PropertyDict
 from ..java import utils as java_utils
 from ..py import resolve_class_name
 from ..rs import utils as rs_utils
-from ..utils import ingest_method, safe_decode_text
+from ..utils import ingest_method, safe_decode_text, sorted_captures
 from . import cpp_modules
 from . import identity as id_
 from . import method_override as mo
@@ -96,7 +96,7 @@ class ClassIngestMixin:
 
         lang_config: LanguageSpec = lang_queries[cs.QUERY_CONFIG]
         cursor = QueryCursor(query)
-        captures = cursor.captures(root_node)
+        captures = sorted_captures(cursor, root_node)
         class_nodes = captures.get(cs.CAPTURE_CLASS, [])
         module_nodes = captures.get(cs.ONEOF_MODULE, [])
 
@@ -202,7 +202,7 @@ class ClassIngestMixin:
         file_path = self.module_qn_to_file_path.get(module_qn)
         lang_config: LanguageSpec = lang_queries[cs.QUERY_CONFIG]
         method_cursor = QueryCursor(method_query)
-        method_captures = method_cursor.captures(body_node)
+        method_captures = sorted_captures(method_cursor, body_node)
         for method_node in method_captures.get(cs.CAPTURE_FUNCTION, []):
             if not isinstance(method_node, Node):
                 continue
@@ -236,7 +236,7 @@ class ClassIngestMixin:
 
         lang_config: LanguageSpec = lang_queries[cs.QUERY_CONFIG]
         method_cursor = QueryCursor(method_query)
-        method_captures = method_cursor.captures(body_node)
+        method_captures = sorted_captures(method_cursor, body_node)
         for method_node in method_captures.get(cs.CAPTURE_FUNCTION, []):
             if not isinstance(method_node, Node):
                 continue

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -20,7 +20,12 @@ from .stdlib_extractor import (
     load_persistent_cache,
     save_persistent_cache,
 )
-from .utils import get_query_cursor, safe_decode_text, safe_decode_with_fallback
+from .utils import (
+    get_query_cursor,
+    safe_decode_text,
+    safe_decode_with_fallback,
+    sorted_captures,
+)
 
 
 class ImportProcessor:
@@ -106,7 +111,7 @@ class ImportProcessor:
 
         try:
             cursor = get_query_cursor(imports_query)
-            captures = cursor.captures(root_node)
+            captures = sorted_captures(cursor, root_node)
 
             match language:
                 case cs.SupportedLanguage.PYTHON:

--- a/codebase_rag/parsers/js_ts/ingest.py
+++ b/codebase_rag/parsers/js_ts/ingest.py
@@ -16,7 +16,7 @@ from ...types_defs import (
     PropertyDict,
     SimpleNameLookup,
 )
-from ..utils import safe_decode_text, safe_decode_with_fallback
+from ..utils import safe_decode_text, safe_decode_with_fallback, sorted_captures
 from .module_system import JsTsModuleSystemMixin
 from .utils import get_js_ts_language_obj
 
@@ -96,7 +96,7 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
     ):
         query = Query(language_obj, cs.JS_PROTOTYPE_INHERITANCE_QUERY)
         cursor = QueryCursor(query)
-        captures = cursor.captures(root_node)
+        captures = sorted_captures(cursor, root_node)
 
         child_classes = captures.get(cs.CAPTURE_CHILD_CLASS, [])
         parent_classes = captures.get(cs.CAPTURE_PARENT_CLASS, [])
@@ -147,7 +147,7 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
     def _process_prototype_method_captures(self, language_obj, root_node, module_qn):
         method_query = Query(language_obj, cs.JS_PROTOTYPE_METHOD_QUERY)
         method_cursor = QueryCursor(method_query)
-        method_captures = method_cursor.captures(root_node)
+        method_captures = sorted_captures(method_cursor, root_node)
 
         constructor_names = method_captures.get(cs.CAPTURE_CONSTRUCTOR_NAME, [])
         method_names = method_captures.get(cs.CAPTURE_METHOD_NAME, [])
@@ -225,7 +225,7 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
         try:
             query = Query(language_obj, query_text)
             cursor = QueryCursor(query)
-            captures = cursor.captures(root_node)
+            captures = sorted_captures(cursor, root_node)
 
             method_names = captures.get(cs.CAPTURE_METHOD_NAME, [])
             method_functions = captures.get(cs.CAPTURE_METHOD_FUNCTION, [])
@@ -362,7 +362,7 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
         try:
             query = Query(lang_query, query_text)
             cursor = QueryCursor(query)
-            captures = cursor.captures(root_node)
+            captures = sorted_captures(cursor, root_node)
 
             method_names = captures.get(cs.CAPTURE_METHOD_NAME, [])
             member_exprs = captures.get(cs.CAPTURE_MEMBER_EXPR, [])

--- a/codebase_rag/parsers/js_ts/module_system.py
+++ b/codebase_rag/parsers/js_ts/module_system.py
@@ -15,6 +15,7 @@ from ..utils import (
     ingest_exported_function,
     safe_decode_text,
     safe_decode_with_fallback,
+    sorted_captures,
 )
 from .utils import get_js_ts_language_obj
 
@@ -62,7 +63,7 @@ class JsTsModuleSystemMixin:
             try:
                 query = Query(language_obj, cs.JS_COMMONJS_DESTRUCTURE_QUERY)
                 cursor = QueryCursor(query)
-                captures = cursor.captures(root_node)
+                captures = sorted_captures(cursor, root_node)
 
                 variable_declarators = captures.get(cs.CAPTURE_VARIABLE_DECLARATOR, [])
 
@@ -280,9 +281,8 @@ class JsTsModuleSystemMixin:
 
         for query_text in query_texts:
             try:
-                captures = QueryCursor(Query(language_obj, query_text)).captures(
-                    root_node
-                )
+                _cursor = QueryCursor(Query(language_obj, query_text))
+                captures = sorted_captures(_cursor, root_node)
 
                 self._process_exports_pattern(
                     captures.get(cs.CAPTURE_EXPORTS_OBJ, []),
@@ -320,7 +320,7 @@ class JsTsModuleSystemMixin:
                     cleaned_query = textwrap.dedent(query_text).strip()
                     query = Query(lang_query, cleaned_query)
                     cursor = QueryCursor(query)
-                    captures = cursor.captures(root_node)
+                    captures = sorted_captures(cursor, root_node)
 
                     export_names = captures.get(cs.CAPTURE_EXPORT_NAME, [])
                     export_functions = captures.get(cs.CAPTURE_EXPORT_FUNCTION, [])

--- a/codebase_rag/parsers/py/ast_analyzer.py
+++ b/codebase_rag/parsers/py/ast_analyzer.py
@@ -10,7 +10,7 @@ from ... import constants as cs
 from ... import logs as lg
 from ...types_defs import LanguageQueries
 from ..js_ts.utils import find_method_in_ast as find_js_method_in_ast
-from ..utils import safe_decode_text
+from ..utils import safe_decode_text, sorted_captures
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -211,7 +211,7 @@ class PythonAstAnalyzerMixin(_AstBase):
         if not class_query:
             return None
         cursor = QueryCursor(class_query)
-        captures = cursor.captures(root_node)
+        captures = sorted_captures(cursor, root_node)
 
         method_query = lang_queries[cs.QUERY_KEY_FUNCTIONS]
         if not method_query:
@@ -233,7 +233,7 @@ class PythonAstAnalyzerMixin(_AstBase):
                 continue
 
             method_cursor = QueryCursor(method_query)
-            method_captures = method_cursor.captures(body_node)
+            method_captures = sorted_captures(method_cursor, body_node)
 
             for method_node in method_captures.get(cs.QUERY_CAPTURE_FUNCTION, []):
                 if not isinstance(method_node, Node):

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -30,6 +30,15 @@ class FunctionCapturesResult(NamedTuple):
     captures: dict[str, list[ASTNode]]
 
 
+def sorted_captures(cursor: QueryCursor, node: ASTNode) -> dict[str, list[ASTNode]]:
+    # (H) tree-sitter v0.25 captures() returns nodes in non-deterministic order
+    # across process invocations; sort by start_byte for reproducibility
+    raw = cursor.captures(node)
+    return {
+        name: sorted(nodes, key=lambda n: n.start_byte) for name, nodes in raw.items()
+    }
+
+
 def get_function_captures(
     root_node: ASTNode,
     language: cs.SupportedLanguage,
@@ -42,7 +51,7 @@ def get_function_captures(
         return None
 
     cursor = QueryCursor(query)
-    captures = cursor.captures(root_node)
+    captures = sorted_captures(cursor, root_node)
     return FunctionCapturesResult(lang_config, captures)
 
 


### PR DESCRIPTION
## Summary

- `QueryCursor.captures()` in py-tree-sitter v0.25 returns capture node lists in non-deterministic order across process invocations (consistent within a single process, but varies between separate Python processes)
- This caused `_search_method_in_class` to pick different method overloads as the "first match" between runs, producing non-reproducible CALLS relationships for Java repos with overloaded methods
- Verified on gson: 5 runs produced 5 different digests (3054-3062 relationships), with 73 differing relationship pairs per run pair
- Root cause confirmed by isolating that `captures()` on a 5-method class returns `[alpha, gamma, delta, epsilon, beta]` in one process but `[alpha, gamma, epsilon, delta, beta]` in another, while `matches()` always returns correct byte-offset order

### Fix

- Add `sorted_captures()` wrapper in `parsers/utils.py` that sorts each capture list by `node.start_byte`
- Replace all 17 `captures()` call sites across the codebase to use the wrapper
- This affects all languages, not just Java, ensuring deterministic processing everywhere

## Test plan

- [x] All 3672 existing tests pass
- [x] gson: 5/5 runs produce identical digest (`a3fed97f3ba7f3f9...`, 1313 nodes, 3062 rels)
- [x] javapoet: 5/5 runs produce identical digest (`3640905e3bae26da...`, 677 nodes, 1409 rels)
- [x] requests (Python): 3/3 runs produce identical digest (regression check)