### PR TITLE
ci: add pr-split score check on pull requests

### DIFF
--- a/.github/workflows/split-score.yml
+++ b/.github/workflows/split-score.yml
@@ -1,0 +1,20 @@
+name: PR Split Score
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  score:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: vitali87/pr-split@main
+        with:
+          max-loc: "400"

--- a/.github/workflows/split-score.yml
+++ b/.github/workflows/split-score.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
 
 permissions:
+  contents: read
   pull-requests: write
 
 jobs:
@@ -15,6 +16,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: vitali87/pr-split@main
+      - uses: vitali87/pr-split@adad0c2b3db0a9cff42a54c5d988f1600f072124 # v1.0.0
         with:
           max-loc: "400"


### PR DESCRIPTION
## Summary

- Add pr-split GitHub Action that scores every PR and posts a split plan comment when it's too large
- Uses the graph backend (no API key needed), triggers on PRs to main
- Threshold: 400 LOC per sub-PR

## Test plan

- [ ] Verify the action runs on this PR
- [ ] Future PRs will be automatically scored