### PR TITLE
ci: use published marketplace tag v1.0.0 for pr-split

### DIFF
--- a/.github/workflows/split-score.yml
+++ b/.github/workflows/split-score.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: vitali87/pr-split@adad0c2b3db0a9cff42a54c5d988f1600f072124 # v1.0.0
+      - name: pr-split score
+        uses: vitali87/pr-split@v1.0.0
         with:
           max-loc: "400"


### PR DESCRIPTION
## Summary

- Replace commit SHA reference with published marketplace tag `vitali87/pr-split@v1.0.0`

## Test plan

- [ ] Verify action runs on this PR