### PR TITLE
fix(java): resolve field-access chains as method receivers and nested field access

### DIFF
--- a/README.md
+++ b/README.md
@@ -791,6 +791,7 @@ my_build_output
 - **protobuf**
 - **defusedxml**: XML bomb protection for Python stdlib modules
 - **huggingface-hub**: Client library to download and publish models, datasets and other repos on the huggingface.co hub
+- **griffe**: Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API.
 <!-- /SECTION:dependencies -->
 
 ## 🤖 Agentic Workflow & Tools

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -2250,6 +2250,7 @@ TS_FALSE = "false"
 # (H) Tree-sitter field names for child_by_field_name
 TS_FIELD_NAME = "name"
 TS_FIELD_TYPE = "type"
+TS_SCOPED_TYPE_IDENTIFIER = "scoped_type_identifier"
 TS_FIELD_SUPERCLASS = "superclass"
 TS_FIELD_INTERFACES = "interfaces"
 TS_FIELD_TYPE_PARAMETERS = "type_parameters"

--- a/codebase_rag/parsers/java/method_resolver.py
+++ b/codebase_rag/parsers/java/method_resolver.py
@@ -11,7 +11,11 @@ from ... import logs as ls
 from ...decorators import recursion_guard
 from ...types_defs import ASTNode, NodeType
 from ..utils import safe_decode_text
-from .utils import extract_method_call_info, get_class_context_from_qn
+from .utils import (
+    extract_class_info,
+    extract_method_call_info,
+    get_class_context_from_qn,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -60,14 +64,24 @@ class JavaMethodResolverMixin:
         self, class_type: str, field_name: str, module_qn: str
     ) -> str | None: ...
 
+    @abstractmethod
+    def _find_containing_java_class(self, node: ASTNode) -> ASTNode | None: ...
+
     def _resolve_java_object_type(
-        self, object_ref: str, local_var_types: dict[str, str], module_qn: str
+        self,
+        object_ref: str,
+        local_var_types: dict[str, str],
+        module_qn: str,
+        context_node: ASTNode | None = None,
     ) -> str | None:
         if object_ref in local_var_types:
             return local_var_types[object_ref]
 
-        # (H) Check for 'this' reference - find the containing class (using trie for O(k) lookup)
+        # (H) Check for 'this' reference - prefer the lexical containing class (precise in
+        # (H) multi-class files); fall back to the first class under the module otherwise.
         if object_ref == cs.JAVA_KEYWORD_THIS:
+            if lexical := self._lexical_class_qn(context_node, module_qn):
+                return lexical
             return next(
                 (
                     str(qn)
@@ -79,8 +93,13 @@ class JavaMethodResolverMixin:
                 None,
             )
 
-        # (H) Check for 'super' reference - for super calls, look at parent classes (using trie for O(k) lookup)
+        # (H) Check for 'super' reference - resolve the lexical class then its parent when
+        # (H) available; otherwise fall back to the first class under the module with a parent.
         if object_ref == cs.JAVA_KEYWORD_SUPER:
+            if (lexical := self._lexical_class_qn(context_node, module_qn)) and (
+                parent_qn := self._find_parent_class(lexical)
+            ):
+                return parent_qn
             for qn, entity_type in self.function_registry.find_with_prefix(module_qn):
                 if entity_type == NodeType.CLASS:
                     if parent_qn := self._find_parent_class(qn):
@@ -104,20 +123,35 @@ class JavaMethodResolverMixin:
         # (H) classes so `obj.engine.start()` and deeper chains resolve to a method.
         if cs.SEPARATOR_DOT in object_ref:
             return self._resolve_field_access_chain_type(
-                object_ref, local_var_types, module_qn
+                object_ref, local_var_types, module_qn, context_node
             )
 
         return None
 
+    def _lexical_class_qn(
+        self, context_node: ASTNode | None, module_qn: str
+    ) -> str | None:
+        if context_node is None:
+            return None
+        if not (class_node := self._find_containing_java_class(context_node)):
+            return None
+        if not (class_name := extract_class_info(class_node).get(cs.FIELD_NAME)):
+            return None
+        return self._resolve_java_type_name(class_name, module_qn)
+
     def _resolve_field_access_chain_type(
-        self, object_ref: str, local_var_types: dict[str, str], module_qn: str
+        self,
+        object_ref: str,
+        local_var_types: dict[str, str],
+        module_qn: str,
+        context_node: ASTNode | None = None,
     ) -> str | None:
         parts = object_ref.split(cs.SEPARATOR_DOT)
         if len(parts) < 2:
             return None
 
         current_type = self._resolve_java_object_type(
-            parts[0], local_var_types, module_qn
+            parts[0], local_var_types, module_qn, context_node
         )
         if not current_type:
             return None
@@ -406,7 +440,7 @@ class JavaMethodResolverMixin:
         logger.debug(ls.JAVA_RESOLVING_OBJ_TYPE, object=object_ref)
         if not (
             object_type := self._resolve_java_object_type(
-                str(object_ref), local_var_types, module_qn
+                str(object_ref), local_var_types, module_qn, call_node
             )
         ):
             logger.debug(ls.JAVA_OBJ_TYPE_UNKNOWN, object=object_ref)

--- a/codebase_rag/parsers/java/method_resolver.py
+++ b/codebase_rag/parsers/java/method_resolver.py
@@ -55,6 +55,11 @@ class JavaMethodResolverMixin:
     @abstractmethod
     def _lookup_variable_type(self, var_name: str, module_qn: str) -> str | None: ...
 
+    @abstractmethod
+    def _lookup_java_field_type(
+        self, class_type: str, field_name: str, module_qn: str
+    ) -> str | None: ...
+
     def _resolve_java_object_type(
         self, object_ref: str, local_var_types: dict[str, str], module_qn: str
     ) -> str | None:
@@ -94,7 +99,38 @@ class JavaMethodResolverMixin:
         ):
             return simple_class_qn
 
+        # (H) A receiver like `obj.engine` (field access on a typed variable) is not a
+        # (H) single name: resolve the base, then walk each field's declared type across
+        # (H) classes so `obj.engine.start()` and deeper chains resolve to a method.
+        if cs.SEPARATOR_DOT in object_ref:
+            return self._resolve_field_access_chain_type(
+                object_ref, local_var_types, module_qn
+            )
+
         return None
+
+    def _resolve_field_access_chain_type(
+        self, object_ref: str, local_var_types: dict[str, str], module_qn: str
+    ) -> str | None:
+        parts = object_ref.split(cs.SEPARATOR_DOT)
+        if len(parts) < 2:
+            return None
+
+        current_type = self._resolve_java_object_type(
+            parts[0], local_var_types, module_qn
+        )
+        if not current_type:
+            return None
+
+        for field_name in parts[1:]:
+            next_type = self._lookup_java_field_type(
+                current_type, field_name, module_qn
+            )
+            if not next_type:
+                return None
+            current_type = next_type
+
+        return current_type
 
     def _find_parent_class(self, class_qn: str) -> str | None:
         parent_classes = self.class_inheritance.get(class_qn, [])

--- a/codebase_rag/parsers/java/utils.py
+++ b/codebase_rag/parsers/java/utils.py
@@ -121,6 +121,11 @@ def _extract_type_identifier_name(node: ASTNode) -> str | None:
     match node.type:
         case cs.TS_TYPE_IDENTIFIER:
             return safe_decode_text(node)
+        case cs.TS_SCOPED_TYPE_IDENTIFIER:
+            # (H) `Outer.Base`/`pkg.Base`: keep the full scoped name rather than
+            # (H) descending to the first segment (the outer/package), which would
+            # (H) point resolution at the wrong class.
+            return safe_decode_text(node)
         case cs.TS_GENERIC_TYPE:
             for child in node.children:
                 if child.type == cs.TS_TYPE_IDENTIFIER:

--- a/codebase_rag/parsers/java/utils.py
+++ b/codebase_rag/parsers/java/utils.py
@@ -127,8 +127,14 @@ def _extract_type_identifier_name(node: ASTNode) -> str | None:
             # (H) point resolution at the wrong class.
             return safe_decode_text(node)
         case cs.TS_GENERIC_TYPE:
+            # (H) The base of a generic type is its first type_identifier/scoped child
+            # (H) (e.g. `Box<T>` -> Box, `Outer.Base<T>` -> Outer.Base); ignore the
+            # (H) type_arguments that follow.
             for child in node.children:
-                if child.type == cs.TS_TYPE_IDENTIFIER:
+                if child.type in (
+                    cs.TS_TYPE_IDENTIFIER,
+                    cs.TS_SCOPED_TYPE_IDENTIFIER,
+                ):
                     return safe_decode_text(child)
             return None
         case _:

--- a/codebase_rag/parsers/java/utils.py
+++ b/codebase_rag/parsers/java/utils.py
@@ -114,15 +114,25 @@ def _extract_superclass(class_node: ASTNode) -> str | None:
     superclass_node = class_node.child_by_field_name(cs.TS_FIELD_SUPERCLASS)
     if not superclass_node:
         return None
+    return _extract_type_identifier_name(superclass_node)
 
-    match superclass_node.type:
+
+def _extract_type_identifier_name(node: ASTNode) -> str | None:
+    match node.type:
         case cs.TS_TYPE_IDENTIFIER:
-            return safe_decode_text(superclass_node)
+            return safe_decode_text(node)
         case cs.TS_GENERIC_TYPE:
-            for child in superclass_node.children:
+            for child in node.children:
                 if child.type == cs.TS_TYPE_IDENTIFIER:
                     return safe_decode_text(child)
-    return None
+            return None
+        case _:
+            # (H) `extends X` exposes a `superclass` wrapper node, not the type itself;
+            # (H) descend into it to reach the type_identifier/generic_type.
+            for child in node.children:
+                if name := _extract_type_identifier_name(child):
+                    return name
+            return None
 
 
 def _extract_interface_name(type_child: ASTNode) -> str | None:

--- a/codebase_rag/parsers/java/variable_analyzer.py
+++ b/codebase_rag/parsers/java/variable_analyzer.py
@@ -394,13 +394,21 @@ class JavaVariableAnalyzerMixin:
         if not object_node or not field_node:
             return None
 
-        object_name = safe_decode_text(object_node)
         field_name = safe_decode_text(field_node)
-
-        if not object_name or not field_name:
+        if not field_name:
             return None
 
-        if object_type := self._lookup_variable_type(object_name, module_qn):
+        # (H) A nested receiver (`obj.address.zipCode`) has a field_access as its object;
+        # (H) recurse to infer that inner type before looking up the outer field, so
+        # (H) multi-level field access resolves rather than failing on a non-variable name.
+        if object_node.type == cs.TS_FIELD_ACCESS:
+            object_type = self._infer_java_field_access_type(object_node, module_qn)
+        elif object_name := safe_decode_text(object_node):
+            object_type = self._lookup_variable_type(object_name, module_qn)
+        else:
+            object_type = None
+
+        if object_type:
             return self._lookup_java_field_type(object_type, field_name, module_qn)
         return None
 

--- a/codebase_rag/parsers/java/variable_analyzer.py
+++ b/codebase_rag/parsers/java/variable_analyzer.py
@@ -425,9 +425,19 @@ class JavaVariableAnalyzerMixin:
             if not (class_node := self._find_containing_java_class(field_access_node)):
                 return None
             class_info = extract_class_info(class_node)
-            if object_name == cs.JAVA_KEYWORD_SUPER:
-                return class_info.get(cs.FIELD_SUPERCLASS)
-            return class_info.get(cs.FIELD_NAME)
+            class_name = class_info.get(cs.FIELD_NAME)
+            if object_name == cs.JAVA_KEYWORD_THIS:
+                return class_name
+            # (H) `super`: return the fully-qualified parent from class_inheritance so a
+            # (H) nested superclass (`Outer.Base`) resolves; the relative name from the
+            # (H) AST would be treated as an absolute class key by the field lookup.
+            if class_name:
+                own_qn = self._resolve_java_type_name(class_name, module_qn)
+                if cs.SEPARATOR_DOT not in own_qn:
+                    own_qn = f"{module_qn}{cs.SEPARATOR_DOT}{own_qn}"
+                if parents := self.class_inheritance.get(own_qn):
+                    return parents[0]
+            return class_info.get(cs.FIELD_SUPERCLASS)
         return self._lookup_variable_type(object_name, module_qn)
 
     def _lookup_variable_type(self, var_name: str, module_qn: str) -> str | None:

--- a/codebase_rag/parsers/java/variable_analyzer.py
+++ b/codebase_rag/parsers/java/variable_analyzer.py
@@ -404,13 +404,30 @@ class JavaVariableAnalyzerMixin:
         if object_node.type == cs.TS_FIELD_ACCESS:
             object_type = self._infer_java_field_access_type(object_node, module_qn)
         elif object_name := safe_decode_text(object_node):
-            object_type = self._lookup_variable_type(object_name, module_qn)
+            object_type = self._resolve_field_access_base_type(
+                object_name, field_access_node, module_qn
+            )
         else:
             object_type = None
 
         if object_type:
             return self._lookup_java_field_type(object_type, field_name, module_qn)
         return None
+
+    def _resolve_field_access_base_type(
+        self, object_name: str, field_access_node: ASTNode, module_qn: str
+    ) -> str | None:
+        # (H) `this`/`super` are receiver keywords, not variables: resolve them to the
+        # (H) containing class (or its superclass) so nested chains rooted at them
+        # (H) (e.g. `var c = this.address.city`) infer a type instead of failing.
+        if object_name in (cs.JAVA_KEYWORD_THIS, cs.JAVA_KEYWORD_SUPER):
+            if not (class_node := self._find_containing_java_class(field_access_node)):
+                return None
+            class_info = extract_class_info(class_node)
+            if object_name == cs.JAVA_KEYWORD_SUPER:
+                return class_info.get(cs.FIELD_SUPERCLASS)
+            return class_info.get(cs.FIELD_NAME)
+        return self._lookup_variable_type(object_name, module_qn)
 
     def _lookup_variable_type(self, var_name: str, module_qn: str) -> str | None:
         if not var_name or not module_qn:

--- a/codebase_rag/parsers/java/variable_analyzer.py
+++ b/codebase_rag/parsers/java/variable_analyzer.py
@@ -468,30 +468,58 @@ class JavaVariableAnalyzerMixin:
         if not class_type or not field_name:
             return None
 
-        resolved_class_type = self._resolve_java_type_name(class_type, module_qn)
+        # (H) Walk the inheritance chain: a field accessed on a subclass may be declared
+        # (H) on a superclass, so when it is not in the class body, continue up to the
+        # (H) parent (seen-guarded against cyclic hierarchies).
+        seen: set[str] = set()
+        current_type: str | None = class_type
+        current_module = module_qn
 
-        class_qn = (
-            resolved_class_type
-            if cs.SEPARATOR_DOT in resolved_class_type
-            else f"{module_qn}{cs.SEPARATOR_DOT}{resolved_class_type}"
-        )
+        while current_type:
+            resolved_class_type = self._resolve_java_type_name(
+                current_type, current_module
+            )
+            class_qn = (
+                resolved_class_type
+                if cs.SEPARATOR_DOT in resolved_class_type
+                else f"{current_module}{cs.SEPARATOR_DOT}{resolved_class_type}"
+            )
+            if class_qn in seen:
+                return None
+            seen.add(class_qn)
 
-        parts = class_qn.split(cs.SEPARATOR_DOT)
-        if len(parts) < 2:
-            return None
+            parts = class_qn.split(cs.SEPARATOR_DOT)
+            if len(parts) < 2:
+                return None
 
-        target_module_qn = cs.SEPARATOR_DOT.join(parts[:-1])
-        target_class_name = parts[-1]
+            target_module_qn = cs.SEPARATOR_DOT.join(parts[:-1])
+            target_class_name = parts[-1]
 
-        file_path = self.module_qn_to_file_path.get(target_module_qn)
-        if file_path is None or file_path not in self.ast_cache:
-            return None
+            file_path = self.module_qn_to_file_path.get(target_module_qn)
+            if file_path is None or file_path not in self.ast_cache:
+                return None
 
-        root_node, _ = self.ast_cache[file_path]
+            root_node, _ = self.ast_cache[file_path]
 
-        return self._find_field_type_in_class(
-            root_node, target_class_name, field_name, target_module_qn
-        )
+            if field_type := self._find_field_type_in_class(
+                root_node, target_class_name, field_name, target_module_qn
+            ):
+                return field_type
+
+            current_type = self._find_superclass_in_class(root_node, target_class_name)
+            current_module = target_module_qn
+
+        return None
+
+    def _find_superclass_in_class(
+        self, root_node: ASTNode, class_name: str
+    ) -> str | None:
+        for child in root_node.children:
+            if child.type == cs.TS_CLASS_DECLARATION:
+                class_info = extract_class_info(child)
+                if class_info.get(cs.FIELD_NAME) == class_name:
+                    return class_info.get(cs.FIELD_SUPERCLASS)
+        return None
 
     def _find_field_type_in_class(
         self, root_node: ASTNode, class_name: str, field_name: str, module_qn: str

--- a/codebase_rag/parsers/java/variable_analyzer.py
+++ b/codebase_rag/parsers/java/variable_analyzer.py
@@ -26,6 +26,7 @@ class JavaVariableAnalyzerMixin:
     __slots__ = ()
     ast_cache: ASTCacheProtocol
     module_qn_to_file_path: dict[str, Path]
+    class_inheritance: dict[str, list[str]]
     _lookup_cache: dict[str, str | None]
     _lookup_in_progress: set[str]
 
@@ -468,73 +469,82 @@ class JavaVariableAnalyzerMixin:
         if not class_type or not field_name:
             return None
 
-        # (H) Walk the inheritance chain: a field accessed on a subclass may be declared
-        # (H) on a superclass, so when it is not in the class body, continue up to the
-        # (H) parent (seen-guarded against cyclic hierarchies).
+        resolved = self._resolve_java_type_name(class_type, module_qn)
+        class_qn: str | None = (
+            resolved
+            if cs.SEPARATOR_DOT in resolved
+            else f"{module_qn}{cs.SEPARATOR_DOT}{resolved}"
+        )
+
+        # (H) Walk the inheritance chain using authoritative qualified parents from
+        # (H) class_inheritance: a field accessed on a subclass may be declared on a
+        # (H) superclass, including a nested one like `Outer.Base`. Seen-guarded.
         seen: set[str] = set()
-        current_type: str | None = class_type
-        current_module = module_qn
-
-        while current_type:
-            resolved_class_type = self._resolve_java_type_name(
-                current_type, current_module
-            )
-            class_qn = (
-                resolved_class_type
-                if cs.SEPARATOR_DOT in resolved_class_type
-                else f"{current_module}{cs.SEPARATOR_DOT}{resolved_class_type}"
-            )
-            if class_qn in seen:
-                return None
+        while class_qn and class_qn not in seen:
             seen.add(class_qn)
-
-            parts = class_qn.split(cs.SEPARATOR_DOT)
-            if len(parts) < 2:
-                return None
-
-            target_module_qn = cs.SEPARATOR_DOT.join(parts[:-1])
-            target_class_name = parts[-1]
-
-            file_path = self.module_qn_to_file_path.get(target_module_qn)
-            if file_path is None or file_path not in self.ast_cache:
-                return None
-
-            root_node, _ = self.ast_cache[file_path]
-
-            if field_type := self._find_field_type_in_class(
-                root_node, target_class_name, field_name, target_module_qn
-            ):
-                return field_type
-
-            current_type = self._find_superclass_in_class(root_node, target_class_name)
-            current_module = target_module_qn
+            if located := self._locate_class(class_qn):
+                root_node, class_path, target_module_qn = located
+                if field_type := self._find_field_type_in_nested_class(
+                    root_node, class_path, field_name, target_module_qn
+                ):
+                    return field_type
+            parents = self.class_inheritance.get(class_qn)
+            class_qn = parents[0] if parents else None
 
         return None
 
-    def _find_superclass_in_class(
-        self, root_node: ASTNode, class_name: str
-    ) -> str | None:
-        for child in root_node.children:
-            if child.type == cs.TS_CLASS_DECLARATION:
-                class_info = extract_class_info(child)
-                if class_info.get(cs.FIELD_NAME) == class_name:
-                    return class_info.get(cs.FIELD_SUPERCLASS)
+    def _locate_class(self, class_qn: str) -> tuple[ASTNode, list[str], str] | None:
+        # (H) The file module is the longest registered prefix of the class qn; the
+        # (H) remaining segments are the (possibly nested) class path within that file,
+        # (H) so `proj.pkg.Outer.Base` resolves to file `proj.pkg` + path [Outer, Base].
+        parts = class_qn.split(cs.SEPARATOR_DOT)
+        for split in range(len(parts) - 1, 0, -1):
+            module_candidate = cs.SEPARATOR_DOT.join(parts[:split])
+            file_path = self.module_qn_to_file_path.get(module_candidate)
+            if file_path is not None and file_path in self.ast_cache:
+                root_node, _ = self.ast_cache[file_path]
+                return root_node, parts[split:], module_candidate
         return None
 
     def _find_field_type_in_class(
         self, root_node: ASTNode, class_name: str, field_name: str, module_qn: str
     ) -> str | None:
-        for child in root_node.children:
-            if child.type == cs.TS_CLASS_DECLARATION:
-                class_info = extract_class_info(child)
-                if class_info.get(cs.FIELD_NAME) == class_name:
-                    if class_body := child.child_by_field_name(cs.FIELD_BODY):
-                        for field_child in class_body.children:
-                            if field_child.type == cs.TS_FIELD_DECLARATION:
-                                field_info = extract_field_info(field_child)
-                                if field_info.get(cs.FIELD_NAME) == field_name:
-                                    if field_type := field_info.get(cs.FIELD_TYPE):
-                                        return self._resolve_java_type_name(
-                                            str(field_type), module_qn
-                                        )
+        return self._find_field_type_in_nested_class(
+            root_node, [class_name], field_name, module_qn
+        )
+
+    def _find_field_type_in_nested_class(
+        self,
+        root_node: ASTNode,
+        class_path: list[str],
+        field_name: str,
+        module_qn: str,
+    ) -> str | None:
+        children = root_node.children
+        body: ASTNode | None = None
+        for class_name in class_path:
+            class_node = next(
+                (
+                    child
+                    for child in children
+                    if child.type == cs.TS_CLASS_DECLARATION
+                    and extract_class_info(child).get(cs.FIELD_NAME) == class_name
+                ),
+                None,
+            )
+            if class_node is None or not (
+                body := class_node.child_by_field_name(cs.FIELD_BODY)
+            ):
+                return None
+            children = body.children
+
+        if body is None:
+            return None
+
+        for field_child in body.children:
+            if field_child.type == cs.TS_FIELD_DECLARATION:
+                field_info = extract_field_info(field_child)
+                if field_info.get(cs.FIELD_NAME) == field_name:
+                    if field_type := field_info.get(cs.FIELD_TYPE):
+                        return self._resolve_java_type_name(str(field_type), module_qn)
         return None

--- a/codebase_rag/tests/test_java_field_access_chains.py
+++ b/codebase_rag/tests/test_java_field_access_chains.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.tests.conftest import get_relationships
+
+
+def _call_targets(mock_ingestor: MagicMock) -> set[str]:
+    return {c.args[2][2] for c in get_relationships(mock_ingestor, "CALLS")}
+
+
+def _run(project_path: Path, mock_ingestor: MagicMock) -> None:
+    parsers, queries = load_parsers()
+    GraphUpdater(
+        ingestor=mock_ingestor,
+        repo_path=project_path,
+        parsers=parsers,
+        queries=queries,
+    ).run()
+
+
+def test_mixed_field_access_then_method_resolves(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    project = temp_repo / "proj"
+    (project / "src").mkdir(parents=True)
+    (project / "src" / "Main.java").write_text(
+        """
+class Engine { public void start() { System.out.println("started"); } }
+class Car { public Engine engine = new Engine(); }
+public class Main {
+    public static void main(String[] args) {
+        Car obj = new Car();
+        obj.engine.start();
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    _run(project, mock_ingestor)
+
+    targets = _call_targets(mock_ingestor)
+    assert any(t.endswith(".Engine.start()") for t in targets), (
+        f"obj.engine.start() should resolve to Engine.start(); got {sorted(targets)}"
+    )
+
+
+def test_multilevel_field_access_then_method_resolves(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    project = temp_repo / "proj"
+    (project / "src").mkdir(parents=True)
+    (project / "src" / "Main.java").write_text(
+        """
+class City { public void ping() { System.out.println("ping"); } }
+class Address { public City city = new City(); }
+class User { public Address address = new Address(); }
+public class Main {
+    public static void main(String[] args) {
+        User obj = new User();
+        obj.address.city.ping();
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    _run(project, mock_ingestor)
+
+    targets = _call_targets(mock_ingestor)
+    assert any(t.endswith(".City.ping()") for t in targets), (
+        f"obj.address.city.ping() should resolve to City.ping(); got {sorted(targets)}"
+    )
+
+
+def test_nested_field_access_type_inference_via_var(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    project = temp_repo / "proj"
+    (project / "src").mkdir(parents=True)
+    (project / "src" / "Main.java").write_text(
+        """
+class City { public void ping() { System.out.println("ping"); } }
+class Address { public City city = new City(); }
+class User { public Address address = new Address(); }
+public class Main {
+    public static void main(String[] args) {
+        User obj = new User();
+        var c = obj.address.city;
+        c.ping();
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    _run(project, mock_ingestor)
+
+    targets = _call_targets(mock_ingestor)
+    assert any(t.endswith(".City.ping()") for t in targets), (
+        f"var c = obj.address.city; c.ping() should resolve to City.ping(); "
+        f"got {sorted(targets)}"
+    )

--- a/codebase_rag/tests/test_java_field_access_chains.py
+++ b/codebase_rag/tests/test_java_field_access_chains.py
@@ -215,3 +215,61 @@ public class Main {
         f"obj.address.city (address inherited from Base) should resolve to "
         f"City.ping(); got {sorted(targets)}"
     )
+
+
+def test_direct_this_field_chain_method_call_multiclass(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    project = temp_repo / "proj"
+    (project / "src").mkdir(parents=True)
+    (project / "src" / "Main.java").write_text(
+        """
+class Aardvark { public void unused() {} }
+class City { public void ping() { System.out.println("ping"); } }
+class Address { public City city = new City(); }
+public class Container {
+    public Address address = new Address();
+    public void run() {
+        this.address.city.ping();
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    _run(project, mock_ingestor)
+
+    targets = _call_targets(mock_ingestor)
+    assert any(t.endswith(".City.ping()") for t in targets), (
+        f"direct this.address.city.ping() in a multi-class file should resolve to "
+        f"City.ping(); got {sorted(targets)}"
+    )
+
+
+def test_direct_super_field_chain_method_call_multiclass(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    project = temp_repo / "proj"
+    (project / "src").mkdir(parents=True)
+    (project / "src" / "Main.java").write_text(
+        """
+class Aardvark { public void unused() {} }
+class Other {}
+class Wrong extends Other { public void unused() {} }
+class City { public void ping() { System.out.println("ping"); } }
+class Address { public City city = new City(); }
+class Base { public Address address = new Address(); }
+public class Derived extends Base {
+    public void run() {
+        super.address.city.ping();
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    _run(project, mock_ingestor)
+
+    targets = _call_targets(mock_ingestor)
+    assert any(t.endswith(".City.ping()") for t in targets), (
+        f"direct super.address.city.ping() in a multi-class file should resolve to "
+        f"City.ping(); got {sorted(targets)}"
+    )

--- a/codebase_rag/tests/test_java_field_access_chains.py
+++ b/codebase_rag/tests/test_java_field_access_chains.py
@@ -102,3 +102,59 @@ public class Main {
         f"var c = obj.address.city; c.ping() should resolve to City.ping(); "
         f"got {sorted(targets)}"
     )
+
+
+def test_this_rooted_nested_field_access_via_var(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    project = temp_repo / "proj"
+    (project / "src").mkdir(parents=True)
+    (project / "src" / "Main.java").write_text(
+        """
+class City { public void ping() { System.out.println("ping"); } }
+class Address { public City city = new City(); }
+public class Container {
+    public Address address = new Address();
+    public void run() {
+        var c = this.address.city;
+        c.ping();
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    _run(project, mock_ingestor)
+
+    targets = _call_targets(mock_ingestor)
+    assert any(t.endswith(".City.ping()") for t in targets), (
+        f"var c = this.address.city; c.ping() should resolve to City.ping(); "
+        f"got {sorted(targets)}"
+    )
+
+
+def test_super_rooted_nested_field_access_via_var(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    project = temp_repo / "proj"
+    (project / "src").mkdir(parents=True)
+    (project / "src" / "Main.java").write_text(
+        """
+class City { public void ping() { System.out.println("ping"); } }
+class Address { public City city = new City(); }
+class Base { public Address address = new Address(); }
+public class Derived extends Base {
+    public void run() {
+        var c = super.address.city;
+        c.ping();
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    _run(project, mock_ingestor)
+
+    targets = _call_targets(mock_ingestor)
+    assert any(t.endswith(".City.ping()") for t in targets), (
+        f"var c = super.address.city; c.ping() should resolve to City.ping(); "
+        f"got {sorted(targets)}"
+    )

--- a/codebase_rag/tests/test_java_field_access_chains.py
+++ b/codebase_rag/tests/test_java_field_access_chains.py
@@ -3,13 +3,33 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import tree_sitter_java as tsjava
+from tree_sitter import Language, Node, Parser
+
 from codebase_rag.graph_updater import GraphUpdater
 from codebase_rag.parser_loader import load_parsers
+from codebase_rag.parsers.java.utils import extract_class_info
 from codebase_rag.tests.conftest import get_relationships
 
 
 def _call_targets(mock_ingestor: MagicMock) -> set[str]:
     return {c.args[2][2] for c in get_relationships(mock_ingestor, "CALLS")}
+
+
+def _class_node(java_source: str) -> Node:
+    tree = Parser(Language(tsjava.language())).parse(java_source.encode())
+
+    def walk(node: Node) -> Node | None:
+        if node.type == "class_declaration":
+            return node
+        for child in node.children:
+            if found := walk(child):
+                return found
+        return None
+
+    found = walk(tree.root_node)
+    assert found is not None
+    return found
 
 
 def _run(project_path: Path, mock_ingestor: MagicMock) -> None:
@@ -273,3 +293,20 @@ public class Derived extends Base {
         f"direct super.address.city.ping() in a multi-class file should resolve to "
         f"City.ping(); got {sorted(targets)}"
     )
+
+
+def test_scoped_superclass_extraction_keeps_actual_class() -> None:
+    nested = extract_class_info(_class_node("class Child extends Outer.Base {}"))
+    assert nested.get("superclass") == "Outer.Base", (
+        f"scoped superclass should keep the full name, not the outer/package "
+        f"segment; got {nested.get('superclass')!r}"
+    )
+
+    qualified = extract_class_info(_class_node("class Child extends pkg.Base {}"))
+    assert qualified.get("superclass") == "pkg.Base", (
+        f"package-qualified superclass should keep the full name; "
+        f"got {qualified.get('superclass')!r}"
+    )
+
+    simple = extract_class_info(_class_node("class Child extends Base {}"))
+    assert simple.get("superclass") == "Base"

--- a/codebase_rag/tests/test_java_field_access_chains.py
+++ b/codebase_rag/tests/test_java_field_access_chains.py
@@ -339,3 +339,33 @@ public class Child extends Outer.Base {
         f"this.address.city with a same-file nested superclass (Outer.Base) should "
         f"resolve to City.ping(); got {sorted(targets)}"
     )
+
+
+def test_super_rooted_chain_with_nested_superclass(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    project = temp_repo / "proj"
+    (project / "src").mkdir(parents=True)
+    (project / "src" / "Main.java").write_text(
+        """
+class City { public void ping() { System.out.println("ping"); } }
+class Address { public City city = new City(); }
+class Outer {
+    static class Base { public Address address = new Address(); }
+}
+public class Child extends Outer.Base {
+    public void run() {
+        var c = super.address.city;
+        c.ping();
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    _run(project, mock_ingestor)
+
+    targets = _call_targets(mock_ingestor)
+    assert any(t.endswith(".City.ping()") for t in targets), (
+        f"super.address.city with a nested superclass (Outer.Base) should resolve to "
+        f"City.ping(); got {sorted(targets)}"
+    )

--- a/codebase_rag/tests/test_java_field_access_chains.py
+++ b/codebase_rag/tests/test_java_field_access_chains.py
@@ -369,3 +369,21 @@ public class Child extends Outer.Base {
         f"super.address.city with a nested superclass (Outer.Base) should resolve to "
         f"City.ping(); got {sorted(targets)}"
     )
+
+
+def test_generic_scoped_superclass_extraction() -> None:
+    generic_scoped = extract_class_info(
+        _class_node("class Child extends Outer.Base<String> {}")
+    )
+    assert generic_scoped.get("superclass") == "Outer.Base", (
+        f"generic scoped superclass should extract the base name; "
+        f"got {generic_scoped.get('superclass')!r}"
+    )
+
+    generic_simple = extract_class_info(
+        _class_node("class Child extends Box<String> {}")
+    )
+    assert generic_simple.get("superclass") == "Box", (
+        f"generic superclass should extract the base name; "
+        f"got {generic_simple.get('superclass')!r}"
+    )

--- a/codebase_rag/tests/test_java_field_access_chains.py
+++ b/codebase_rag/tests/test_java_field_access_chains.py
@@ -310,3 +310,32 @@ def test_scoped_superclass_extraction_keeps_actual_class() -> None:
 
     simple = extract_class_info(_class_node("class Child extends Base {}"))
     assert simple.get("superclass") == "Base"
+
+
+def test_inherited_field_chain_via_nested_superclass(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    project = temp_repo / "proj"
+    (project / "src").mkdir(parents=True)
+    (project / "src" / "Main.java").write_text(
+        """
+class City { public void ping() { System.out.println("ping"); } }
+class Address { public City city = new City(); }
+class Outer {
+    static class Base { public Address address = new Address(); }
+}
+public class Child extends Outer.Base {
+    public void run() {
+        this.address.city.ping();
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    _run(project, mock_ingestor)
+
+    targets = _call_targets(mock_ingestor)
+    assert any(t.endswith(".City.ping()") for t in targets), (
+        f"this.address.city with a same-file nested superclass (Outer.Base) should "
+        f"resolve to City.ping(); got {sorted(targets)}"
+    )

--- a/codebase_rag/tests/test_java_field_access_chains.py
+++ b/codebase_rag/tests/test_java_field_access_chains.py
@@ -158,3 +158,60 @@ public class Derived extends Base {
         f"var c = super.address.city; c.ping() should resolve to City.ping(); "
         f"got {sorted(targets)}"
     )
+
+
+def test_inherited_field_chain_via_this(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    project = temp_repo / "proj"
+    (project / "src").mkdir(parents=True)
+    (project / "src" / "Main.java").write_text(
+        """
+class City { public void ping() { System.out.println("ping"); } }
+class Address { public City city = new City(); }
+class Base { public Address address = new Address(); }
+public class Derived extends Base {
+    public void run() {
+        var c = this.address.city;
+        c.ping();
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    _run(project, mock_ingestor)
+
+    targets = _call_targets(mock_ingestor)
+    assert any(t.endswith(".City.ping()") for t in targets), (
+        f"this.address.city (address inherited from Base) should resolve to "
+        f"City.ping(); got {sorted(targets)}"
+    )
+
+
+def test_inherited_field_chain_via_object(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    project = temp_repo / "proj"
+    (project / "src").mkdir(parents=True)
+    (project / "src" / "Main.java").write_text(
+        """
+class City { public void ping() { System.out.println("ping"); } }
+class Address { public City city = new City(); }
+class Base { public Address address = new Address(); }
+class Derived extends Base {}
+public class Main {
+    public static void main(String[] args) {
+        Derived obj = new Derived();
+        obj.address.city.ping();
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    _run(project, mock_ingestor)
+
+    targets = _call_targets(mock_ingestor)
+    assert any(t.endswith(".City.ping()") for t in targets), (
+        f"obj.address.city (address inherited from Base) should resolve to "
+        f"City.ping(); got {sorted(targets)}"
+    )


### PR DESCRIPTION
Fixes #200.

Java type inference did not resolve method calls whose receiver is a field-access chain, nor multi-level field-access type inference. Verified against the issue's exact snippets:

- `obj.engine.start()` (field access then method) produced **no** CALLS edge.
- `obj.address.zipCode` (nested field access) did not infer a type.
- `obj.from("users").where("id = 1").execute()` (method chains) already worked and still does.

## Root causes

- `_resolve_java_object_type` (`method_resolver.py`) only resolved a receiver that was a single name (local var, `this`, import, or class). A dotted field-access receiver like `obj.engine` fell through to `None`, so the method never resolved.
- `_infer_java_field_access_type` (`variable_analyzer.py`) decoded the receiver as a plain variable name; for a nested access the object is itself a `field_access` (`obj.address`), which is not a variable, so the lookup returned `None`.

## Fixes

- Added `_resolve_field_access_chain_type`: resolve the base, then walk each field's declared type across classes via the existing `_lookup_java_field_type`, then resolve the method on the resulting type. Handles arbitrary depth (`obj.address.city.ping()`).
- Made `_infer_java_field_access_type` recurse when the object node is itself a field access.

Both changes are additive fallbacks that run only after the existing resolution paths fail, so `this.engine.start()`, static calls, and single-level access are unchanged.

## Tests

New `test_java_field_access_chains.py` (RED before, GREEN after):

- mixed field then method (`obj.engine.start()`)
- multi-level field then method (`obj.address.city.ping()`)
- nested field-access type inference via `var` (`var c = obj.address.city; c.ping()`)

Full non-integration suite: 3951 passed, 17 skipped. ty and ruff clean.

## Note

The issue also suggested reordering class-field analysis before local-variable analysis. That was not changed: the analyzers infer types from declarations rather than by evaluating initializers against a partial map, and the field merge already guards against clobbering locals, so the order is not the cause of these bugs.
