### PR TITLE
chore(deps): declare griffe runtime dependency for pydantic-ai

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,12 @@ dependencies = [
     "protobuf>=6.33.5",
     "defusedxml>=0.7.1",
     "huggingface-hub[hf-xet]>=1.7.2",
+    # TODO: remove once pydantic-ai is upgraded to a release whose code and
+    # metadata agree on the griffe package. pydantic-ai-slim 1.102.0 imports
+    # `griffe` at runtime but only declares the renamed `griffelib`, so a clean
+    # `uv sync` omits griffe and leaves codebase_rag unimportable; declare it
+    # explicitly to keep the environment reproducible.
+    "griffe>=1.0,<2",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -525,6 +525,7 @@ dependencies = [
     { name = "click" },
     { name = "defusedxml" },
     { name = "diff-match-patch" },
+    { name = "griffe" },
     { name = "huggingface-hub", extra = ["hf-xet"] },
     { name = "loguru" },
     { name = "mcp" },
@@ -601,6 +602,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.3.1" },
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "diff-match-patch", specifier = ">=20241021" },
+    { name = "griffe", specifier = ">=1.0,<2" },
     { name = "huggingface-hub", extras = ["hf-xet"], specifier = ">=1.7.2" },
     { name = "libclang", marker = "extra == 'test'", specifier = ">=18.1.1" },
     { name = "loguru", specifier = ">=0.7.3" },
@@ -1299,6 +1301,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e5/7b/adfd75544c415c487b33061fe7ae526165241c1ea133f9a9125a56b39fd8/googleapis_common_protos-1.72.0.tar.gz", hash = "sha256:e55a601c1b32b52d7a3e65f43563e2aa61bcd737998ee672ac9b951cd49319f5", size = 147433, upload-time = "2025-11-06T18:29:24.087Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c4/ab/09169d5a4612a5f92490806649ac8d41e3ec9129c636754575b3553f4ea4/googleapis_common_protos-1.72.0-py3-none-any.whl", hash = "sha256:4299c5a82d5ae1a9702ada957347726b167f9f8d1fc352477702a1e851ff4038", size = 297515, upload-time = "2025-11-06T18:29:13.14Z" },
+]
+
+[[package]]
+name = "griffe"
+version = "1.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/0c/3a471b6e31951dce2360477420d0a8d1e00dea6cf33b70f3e8c3ab6e28e1/griffe-1.15.0.tar.gz", hash = "sha256:7726e3afd6f298fbc3696e67958803e7ac843c1cfe59734b6251a40cdbfb5eea", size = 424112, upload-time = "2025-11-10T15:03:15.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/83/3b1d03d36f224edded98e9affd0467630fc09d766c0e56fb1498cbb04a9b/griffe-1.15.0-py3-none-any.whl", hash = "sha256:6f6762661949411031f5fcda9593f586e6ce8340f0ba88921a0f2ef7a81eb9a3", size = 150705, upload-time = "2025-11-10T15:03:13.549Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Declares `griffe>=1.0,<2` as an explicit runtime dependency.

## Why

`pydantic-ai-slim` 1.102.0 (pinned via `pydantic-ai`) imports `griffe` at runtime (`pydantic_ai/_griffe.py`), but its package metadata only requires the renamed `griffelib` — a botched rename in that release. As a result, a clean `uv sync` to the lockfile installs `griffelib` but not `griffe`, leaving `codebase_rag` unimportable:

```
ModuleNotFoundError: No module named 'griffe'
```

The working environment only functioned because it had drifted from the lockfile (an older `griffe` left installed out of band). Declaring `griffe` explicitly makes a clean `uv sync` reproducible.

## Impact

With a clean environment now installable, ~98 previously-uncollectable/skipped tests run again (embedding, unixcoder, semantic-search, and the C/PHP grammar suites that depend on a working install). The lockfile change is surgical: only `griffe 1.15.0` is added; no other versions churn.
