### PR TITLE
fix(parser): correct module-level call attribution and close Rust/C call-recall gaps

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -1987,7 +1987,11 @@ TS_SCALA_COMPILATION_UNIT = "compilation_unit"
 TS_SCALA_FUNCTION_DEFINITION = "function_definition"
 TS_SCALA_FUNCTION_DECLARATION = "function_declaration"
 TS_SCALA_CALL_EXPRESSION = "call_expression"
-TS_SCALA_GENERIC_FUNCTION = "generic_function"
+# (H) Shared tree-sitter node type: a call with explicit type args, e.g. Rust
+# (H) turbofish `f::<T>()` and Scala `f[T]()`. Its `function` field holds the
+# (H) actual callee (identifier or scoped_identifier).
+TS_GENERIC_FUNCTION = "generic_function"
+TS_SCALA_GENERIC_FUNCTION = TS_GENERIC_FUNCTION
 TS_SCALA_FIELD_EXPRESSION = "field_expression"
 TS_SCALA_INFIX_EXPRESSION = "infix_expression"
 TS_SCALA_IMPORT_DECLARATION = "import_declaration"

--- a/codebase_rag/language_spec.py
+++ b/codebase_rag/language_spec.py
@@ -332,7 +332,7 @@ LANGUAGE_SPECS: dict[cs.SupportedLanguage, LanguageSpec] = {
         (token_tree
             (identifier) @name @call
             .
-            (token_tree))
+            (token_tree . "("))
         """,
     ),
     cs.SupportedLanguage.GO: LanguageSpec(

--- a/codebase_rag/language_spec.py
+++ b/codebase_rag/language_spec.py
@@ -325,8 +325,14 @@ LANGUAGE_SPECS: dict[cs.SupportedLanguage, LanguageSpec] = {
             function: (scoped_identifier
                 "::"
                 name: (identifier) @name)) @call
+        (call_expression
+            function: (generic_function) @name) @call
         (macro_invocation
             macro: (identifier) @name) @call
+        (token_tree
+            (identifier) @name @call
+            .
+            (token_tree))
         """,
     ),
     cs.SupportedLanguage.GO: LanguageSpec(

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -120,6 +120,23 @@ class CallProcessor:
         hi = bisect_right(call_starts, end)
         return [n for n in all_call_nodes[lo:hi] if n.end_byte <= end]
 
+    def _filter_top_level_calls(
+        self,
+        all_call_nodes: list[Node],
+        call_starts: list[int],
+        func_nodes: list[Node],
+    ) -> list[Node]:
+        # (H) Calls lexically inside a function/method belong to that function,
+        # (H) not the module; only genuine top-level calls (module-load time,
+        # (H) including `if __name__ == "__main__"` blocks) are module-attributed.
+        nested_starts: set[int] = set()
+        for func_node in func_nodes:
+            for call in self._filter_calls_in_node(
+                all_call_nodes, call_starts, func_node
+            ):
+                nested_starts.add(call.start_byte)
+        return [c for c in all_call_nodes if c.start_byte not in nested_starts]
+
     def _module_qn(self, relative_path: Path, file_name: str) -> str:
         if file_name in (cs.INIT_PY, cs.MOD_RS):
             return cs.SEPARATOR_DOT.join(
@@ -258,6 +275,12 @@ class CallProcessor:
                 sorted_func_nodes=sorted_func_nodes,
                 func_node_starts=func_node_starts,
             )
+            if sorted_func_nodes and call_starts is not None:
+                module_calls = self._filter_top_level_calls(
+                    all_call_nodes, call_starts, sorted_func_nodes
+                )
+            else:
+                module_calls = all_call_nodes
             self._ingest_function_calls(
                 root_node,
                 module_qn,
@@ -265,7 +288,7 @@ class CallProcessor:
                 module_qn,
                 language,
                 queries,
-                call_nodes=all_call_nodes,
+                call_nodes=module_calls,
                 call_name_cache=call_name_cache,
             )
 
@@ -491,6 +514,10 @@ class CallProcessor:
                 )
 
     def _get_call_target_name(self, call_node: Node) -> str | None:
+        # (H) A macro-internal call (Rust `name(args)` inside a token_tree) is
+        # (H) captured as the bare identifier node; its text is the callee name.
+        if call_node.type == cs.TS_IDENTIFIER and call_node.text is not None:
+            return call_node.text.decode(cs.ENCODING_UTF8)
         if func_child := call_node.child_by_field_name(cs.TS_FIELD_FUNCTION):
             match func_child.type:
                 case (
@@ -502,6 +529,11 @@ class CallProcessor:
                 ):
                     if func_child.text is not None:
                         return func_child.text.decode(cs.ENCODING_UTF8)
+                case cs.TS_GENERIC_FUNCTION:
+                    # (H) turbofish: unwrap to the underlying callee identifier
+                    inner = func_child.child_by_field_name(cs.TS_FIELD_FUNCTION)
+                    if inner and inner.text:
+                        return inner.text.decode(cs.ENCODING_UTF8)
                 case cs.TS_CPP_FIELD_EXPRESSION:
                     field_node = func_child.child_by_field_name(cs.FIELD_FIELD)
                     if field_node and field_node.text:

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -50,6 +50,11 @@ _TYPED_LANGUAGES = frozenset(
     }
 )
 
+# (H) C and C++ share the function_definition/declarator shape, so the callee
+# (H) name lives in a nested declarator (no `name` field). Both need the libclang
+# (H) declarator-aware extractor rather than a plain child_by_field_name("name").
+_C_FAMILY_LANGUAGES = frozenset({cs.SupportedLanguage.C, cs.SupportedLanguage.CPP})
+
 
 class CallProcessor:
     __slots__ = (
@@ -321,7 +326,7 @@ class CallProcessor:
             if has_classes and self._is_method(func_node, lang_config):
                 continue
 
-            if language == cs.SupportedLanguage.CPP:
+            if language in _C_FAMILY_LANGUAGES:
                 func_name = cpp_utils.extract_function_name(func_node)
             else:
                 func_name = self._get_node_name(func_node)
@@ -447,7 +452,7 @@ class CallProcessor:
             method_captures = sorted_captures(method_cursor, body_node)
             method_nodes = method_captures.get(cs.CAPTURE_FUNCTION, [])
         for method_node in method_nodes:
-            if language == cs.SupportedLanguage.CPP:
+            if language in _C_FAMILY_LANGUAGES:
                 method_name = cpp_utils.extract_function_name(method_node)
             else:
                 method_name = self._get_node_name(method_node)

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -135,11 +135,16 @@ class CallProcessor:
         # (H) module; only genuine top-level calls are module-attributed. The body
         # (H) (not the whole node) is the boundary so def-time calls in the
         # (H) signature -- default args like `def f(x=make_default())` and
-        # (H) decorators -- run at module load and stay module-attributed.
+        # (H) decorators -- run at module load and stay module-attributed. A node
+        # (H) with no body is not a real function scope (e.g. a file-scope
+        # (H) declaration `int x = top();` that the grammar captures as a
+        # (H) function); its calls run at load time, so it excludes nothing.
         nested_starts: set[int] = set()
         for func_node in func_nodes:
-            scope = func_node.child_by_field_name(cs.FIELD_BODY) or func_node
-            for call in self._filter_calls_in_node(all_call_nodes, call_starts, scope):
+            body = func_node.child_by_field_name(cs.FIELD_BODY)
+            if body is None:
+                continue
+            for call in self._filter_calls_in_node(all_call_nodes, call_starts, body):
                 nested_starts.add(call.start_byte)
         return [c for c in all_call_nodes if c.start_byte not in nested_starts]
 

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -131,14 +131,15 @@ class CallProcessor:
         call_starts: list[int],
         func_nodes: list[Node],
     ) -> list[Node]:
-        # (H) Calls lexically inside a function/method belong to that function,
-        # (H) not the module; only genuine top-level calls (module-load time,
-        # (H) including `if __name__ == "__main__"` blocks) are module-attributed.
+        # (H) Calls inside a function's BODY belong to that function, not the
+        # (H) module; only genuine top-level calls are module-attributed. The body
+        # (H) (not the whole node) is the boundary so def-time calls in the
+        # (H) signature -- default args like `def f(x=make_default())` and
+        # (H) decorators -- run at module load and stay module-attributed.
         nested_starts: set[int] = set()
         for func_node in func_nodes:
-            for call in self._filter_calls_in_node(
-                all_call_nodes, call_starts, func_node
-            ):
+            scope = func_node.child_by_field_name(cs.FIELD_BODY) or func_node
+            for call in self._filter_calls_in_node(all_call_nodes, call_starts, scope):
                 nested_starts.add(call.start_byte)
         return [c for c in all_call_nodes if c.start_byte not in nested_starts]
 

--- a/codebase_rag/tests/test_cpp_cross_file_singleton.py
+++ b/codebase_rag/tests/test_cpp_cross_file_singleton.py
@@ -147,15 +147,21 @@ def test_cpp_singleton_pattern_cross_file_calls(
 
         found_calls.add((caller_short, callee_short))
 
+    # (H) Calls are attributed to the enclosing method/function, not the file:
+    # the singleton calls live inside SceneController's methods and
+    # Application.start(), so those are the callers (not the module nodes).
+    sc = "controllers.SceneController.SceneController"
     expected_calls = [
-        ("controllers.SceneController", "storage.Storage.Storage.getInstance"),
-        ("controllers.SceneController", "storage.Storage.Storage.clearAll"),
-        ("controllers.SceneController", "storage.Storage.Storage.save"),
-        ("controllers.SceneController", "storage.Storage.Storage.load"),
-        ("main", "controllers.SceneController.SceneController.loadMenuScene"),
-        ("main", "controllers.SceneController.SceneController.loadGameScene"),
-        ("main", "storage.Storage.Storage.getInstance"),
-        ("main", "storage.Storage.Storage.load"),
+        (f"{sc}.loadMenuScene", "storage.Storage.Storage.getInstance"),
+        (f"{sc}.loadMenuScene", "storage.Storage.Storage.clearAll"),
+        (f"{sc}.loadMenuScene", "storage.Storage.Storage.save"),
+        (f"{sc}.loadMenuScene", "storage.Storage.Storage.load"),
+        (f"{sc}.loadGameScene", "storage.Storage.Storage.getInstance"),
+        (f"{sc}.loadGameScene", "storage.Storage.Storage.save"),
+        ("main.Application.start", f"{sc}.loadMenuScene"),
+        ("main.Application.start", f"{sc}.loadGameScene"),
+        ("main.Application.start", "storage.Storage.Storage.getInstance"),
+        ("main.Application.start", "storage.Storage.Storage.load"),
         ("main.main", "main.Application.start"),
     ]
 

--- a/codebase_rag/tests/test_lua_modern_features.py
+++ b/codebase_rag/tests/test_lua_modern_features.py
@@ -621,9 +621,23 @@ end
             assert expected_fn in fn_qns, f"Missing function: {expected_fn}"
 
         calls_rels = get_relationships(mock_ingestor, "CALLS")
+        call_edges = {(c.args[0][2], c.args[2][2]) for c in calls_rels}
 
-        assert len(calls_rels) >= 10, (
-            f"Expected at least 10 CALLS, got {len(calls_rels)}"
+        # (H) stdlib calls (math.*, string.*, table.*, io.*, os.*) are not
+        # (H) first-party, so the only CALLS edges are between StdLib methods:
+        # (H) run_all_tests fans out to the six test_* methods, and the
+        # (H) top-level `StdLib.run_all_tests()` in main.lua is attributed to
+        # (H) the main module (not duplicated onto every nested call site).
+        run_all = f"{stdlib_qn}.StdLib.run_all_tests"
+        main_qn = f"{project.name}.main"
+        for method in expected_functions:
+            if method == run_all:
+                continue
+            assert (run_all, method) in call_edges, (
+                f"Missing CALLS edge {run_all} -> {method}"
+            )
+        assert (main_qn, run_all) in call_edges, (
+            f"Missing module-level CALLS edge {main_qn} -> {run_all}"
         )
 
         print("✅ Lua 5.4 enhanced standard library test PASSED")

--- a/codebase_rag/tests/test_module_call_attribution.py
+++ b/codebase_rag/tests/test_module_call_attribution.py
@@ -121,3 +121,27 @@ class TestModuleCallAttribution:
         module_callees = _module_callees(_calls(mock_ingestor))
 
         assert "make_default" in module_callees
+
+    def test_cpp_file_scope_initializer_call_attributed_to_module(
+        self, temp_repo: Path, mock_ingestor: MagicMock
+    ) -> None:
+        # a C++ file-scope initializer runs at load time, so its call is
+        # module-attributed; a call inside a function body is not.
+        (temp_repo / "app.cpp").write_text(
+            "int nested_cpp() { return 1; }\n"
+            "int top_cpp() { return 2; }\n"
+            "int run_cpp() { return nested_cpp(); }\n"
+            "int module_value = top_cpp();\n",
+            encoding="utf-8",
+        )
+
+        run_updater(temp_repo, mock_ingestor, skip_if_missing="cpp")
+        calls = _calls(mock_ingestor)
+        module_callees = _module_callees(calls)
+
+        assert "top_cpp" in module_callees
+        assert "nested_cpp" not in module_callees
+        assert any(
+            caller.endswith(".run_cpp") and callee.endswith(".nested_cpp")
+            for _label, caller, callee in calls
+        )

--- a/codebase_rag/tests/test_module_call_attribution.py
+++ b/codebase_rag/tests/test_module_call_attribution.py
@@ -8,7 +8,7 @@ from codebase_rag.tests.conftest import run_updater
 
 
 def _calls(mock_ingestor: MagicMock) -> list[tuple[str, str, str]]:
-    """Return CALLS edges as (caller_label, caller_qn, callee_qn)."""
+    # CALLS edges as (caller_label, caller_qn, callee_qn).
     out: list[tuple[str, str, str]] = []
     for c in mock_ingestor.ensure_relationship_batch.call_args_list:
         if c.args[1] == cs.RelationshipType.CALLS:
@@ -101,3 +101,23 @@ class TestModuleCallAttribution:
         assert "setup" in module_callees
         # helper is never called at all -> no module edge to it
         assert "helper" not in module_callees
+
+    def test_default_argument_call_attributed_to_module(
+        self, temp_repo: Path, mock_ingestor: MagicMock
+    ) -> None:
+        # a default-argument expression runs at module-load (definition) time,
+        # not when the function body executes, so it is a module-level call.
+        (temp_repo / "app.py").write_text(
+            "def make_default():\n"
+            "    return 1\n"
+            "\n"
+            "\n"
+            "def with_default(x=make_default()):\n"
+            "    return x\n",
+            encoding="utf-8",
+        )
+
+        run_updater(temp_repo, mock_ingestor, skip_if_missing="python")
+        module_callees = _module_callees(_calls(mock_ingestor))
+
+        assert "make_default" in module_callees

--- a/codebase_rag/tests/test_module_call_attribution.py
+++ b/codebase_rag/tests/test_module_call_attribution.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import run_updater
+
+
+def _calls(mock_ingestor: MagicMock) -> list[tuple[str, str, str]]:
+    """Return CALLS edges as (caller_label, caller_qn, callee_qn)."""
+    out: list[tuple[str, str, str]] = []
+    for c in mock_ingestor.ensure_relationship_batch.call_args_list:
+        if c.args[1] == cs.RelationshipType.CALLS:
+            caller_label, _caller_key, caller_qn = c.args[0]
+            _callee_label, _callee_key, callee_qn = c.args[2]
+            out.append((caller_label, caller_qn, callee_qn))
+    return out
+
+
+def _module_callees(calls: list[tuple[str, str, str]]) -> set[str]:
+    return {
+        callee.rsplit(cs.SEPARATOR_DOT, 1)[-1]
+        for label, _caller, callee in calls
+        if label == cs.NodeLabel.MODULE
+    }
+
+
+class TestModuleCallAttribution:
+    def test_nested_call_not_attributed_to_module(
+        self, temp_repo: Path, mock_ingestor: MagicMock
+    ) -> None:
+        (temp_repo / "app.py").write_text(
+            "def main():\n"
+            "    used_by_main()\n"
+            "\n"
+            "\n"
+            "def used_by_main():\n"
+            "    return 1\n"
+            "\n"
+            "\n"
+            'if __name__ == "__main__":\n'
+            "    main()\n",
+            encoding="utf-8",
+        )
+
+        run_updater(temp_repo, mock_ingestor, skip_if_missing="python")
+        calls = _calls(mock_ingestor)
+        module_callees = _module_callees(calls)
+
+        # the function-body call is attributed to the function, not the module
+        assert any(
+            caller.endswith(".main") and callee.endswith(".used_by_main")
+            for _label, caller, callee in calls
+        )
+        # used_by_main is only called inside main(), never at module top level
+        assert "used_by_main" not in module_callees
+
+    def test_top_level_call_is_attributed_to_module(
+        self, temp_repo: Path, mock_ingestor: MagicMock
+    ) -> None:
+        (temp_repo / "app.py").write_text(
+            "def main():\n"
+            "    used_by_main()\n"
+            "\n"
+            "\n"
+            "def used_by_main():\n"
+            "    return 1\n"
+            "\n"
+            "\n"
+            'if __name__ == "__main__":\n'
+            "    main()\n",
+            encoding="utf-8",
+        )
+
+        run_updater(temp_repo, mock_ingestor, skip_if_missing="python")
+        module_callees = _module_callees(_calls(mock_ingestor))
+
+        # the `if __name__ == "__main__": main()` call runs at module load
+        assert "main" in module_callees
+
+    def test_bare_module_level_call_attributed_to_module(
+        self, temp_repo: Path, mock_ingestor: MagicMock
+    ) -> None:
+        (temp_repo / "app.py").write_text(
+            "def setup():\n"
+            "    return 1\n"
+            "\n"
+            "\n"
+            "def helper():\n"
+            "    return 2\n"
+            "\n"
+            "\n"
+            "VALUE = setup()\n",
+            encoding="utf-8",
+        )
+
+        run_updater(temp_repo, mock_ingestor, skip_if_missing="python")
+        module_callees = _module_callees(_calls(mock_ingestor))
+
+        assert "setup" in module_callees
+        # helper is never called at all -> no module edge to it
+        assert "helper" not in module_callees

--- a/codebase_rag/tests/test_rust_call_recall.py
+++ b/codebase_rag/tests/test_rust_call_recall.py
@@ -79,3 +79,32 @@ class TestRustMacroCalls:
             caller.endswith(".caller") and callee.endswith(".value")
             for caller, callee in calls
         ), f"bare identifier wrongly captured as call; calls={sorted(calls)}"
+
+    def test_struct_literal_in_macro_is_not_a_call(
+        self, temp_repo: Path, mock_ingestor: MagicMock
+    ) -> None:
+        # `Widget { ... }` (token_tree starting with `{`) and `arr[..]` (starting
+        # with `[`) inside a macro are not calls; only `name(...)` is.
+        (temp_repo / "mac3.rs").write_text(
+            "struct Widget { n: i32 }\n"
+            "fn helper() -> i32 { 1 }\n"
+            "\n"
+            "fn caller() {\n"
+            '    println!("{}", Widget { n: helper() }.n);\n'
+            "}\n",
+            encoding="utf-8",
+        )
+
+        run_updater(temp_repo, mock_ingestor, skip_if_missing="rust")
+        calls = _calls(mock_ingestor)
+
+        # the real call inside the macro is still captured
+        assert any(
+            caller.endswith(".caller") and callee.endswith(".helper")
+            for caller, callee in calls
+        ), f"macro call not captured; calls={sorted(calls)}"
+        # the struct literal `Widget { ... }` must not be a call
+        assert not any(
+            caller.endswith(".caller") and callee.endswith(".Widget")
+            for caller, callee in calls
+        ), f"struct literal wrongly captured as call; calls={sorted(calls)}"

--- a/codebase_rag/tests/test_rust_call_recall.py
+++ b/codebase_rag/tests/test_rust_call_recall.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import run_updater
+
+
+def _calls(mock_ingestor: MagicMock) -> set[tuple[str, str]]:
+    out: set[tuple[str, str]] = set()
+    for c in mock_ingestor.ensure_relationship_batch.call_args_list:
+        if c.args[1] == cs.RelationshipType.CALLS:
+            out.add((c.args[0][2], c.args[2][2]))
+    return out
+
+
+class TestRustTurbofishCalls:
+    def test_turbofish_call_is_captured(
+        self, temp_repo: Path, mock_ingestor: MagicMock
+    ) -> None:
+        (temp_repo / "tf.rs").write_text(
+            "fn generic_function<T: Clone>(value: T) -> T { value }\n"
+            "\n"
+            "fn caller() {\n"
+            "    let _ = generic_function::<i32>(10);\n"
+            "}\n",
+            encoding="utf-8",
+        )
+
+        run_updater(temp_repo, mock_ingestor, skip_if_missing="rust")
+        calls = _calls(mock_ingestor)
+
+        assert any(
+            caller.endswith(".caller") and callee.endswith(".generic_function")
+            for caller, callee in calls
+        ), f"turbofish call not captured; calls={sorted(calls)}"
+
+
+class TestRustMacroCalls:
+    def test_call_inside_macro_is_captured(
+        self, temp_repo: Path, mock_ingestor: MagicMock
+    ) -> None:
+        (temp_repo / "mac.rs").write_text(
+            "fn describe(x: i32) -> i32 { x }\n"
+            "\n"
+            "fn caller() {\n"
+            '    println!("{}", describe(5));\n'
+            "}\n",
+            encoding="utf-8",
+        )
+
+        run_updater(temp_repo, mock_ingestor, skip_if_missing="rust")
+        calls = _calls(mock_ingestor)
+
+        assert any(
+            caller.endswith(".caller") and callee.endswith(".describe")
+            for caller, callee in calls
+        ), f"macro-internal call not captured; calls={sorted(calls)}"
+
+    def test_bare_identifier_in_macro_is_not_a_call(
+        self, temp_repo: Path, mock_ingestor: MagicMock
+    ) -> None:
+        # a plain value interpolated into a macro must not become a CALLS edge
+        (temp_repo / "mac2.rs").write_text(
+            "fn value() -> i32 { 1 }\n"
+            "\n"
+            "fn caller() {\n"
+            "    let value = 5;\n"
+            '    println!("{}", value);\n'
+            "}\n",
+            encoding="utf-8",
+        )
+
+        run_updater(temp_repo, mock_ingestor, skip_if_missing="rust")
+        calls = _calls(mock_ingestor)
+
+        assert not any(
+            caller.endswith(".caller") and callee.endswith(".value")
+            for caller, callee in calls
+        ), f"bare identifier wrongly captured as call; calls={sorted(calls)}"


### PR DESCRIPTION
## What

Corrects how `CALLS` edges are attributed and closes call-recall gaps in three languages. Foundation for trustworthy reachability analysis (e.g. dead-code detection).

## Changes

**1. Module-level call attribution (all languages)**
Previously every call nested inside a function was *also* emitted with the enclosing module as the caller, so `(Module)->callee` edges existed for calls the module never makes. Now the module is the caller only for genuine top-level calls (module-load time, including `if __name__ == "__main__"` blocks). `call_processor._filter_top_level_calls`.

**2. Rust turbofish calls**
`generic_function::<T>()` was captured by neither the call query nor name extraction, so the call was dropped. Added a `generic_function` query pattern and unwrap it to the underlying callee identifier.

**3. Rust macro-internal calls**
Calls inside macro token-trees (`println!("{}", f(x))`) were never `call_expression` nodes, so `f` was missed. Added a query pattern matching an identifier immediately followed by a token-tree, with a precision guard so bare interpolated identifiers (`println!("{}", value)`) do not become calls.

**4. C function-body calls**
C `function_definition` nests its name in a declarator (no `name` field), so the call-attribution pass skipped every C function and emitted zero C `CALLS`. C now uses the same declarator-aware name extractor as C++ (`_C_FAMILY_LANGUAGES`).

## Tests (red → green)

- New: `test_module_call_attribution` (top-level vs nested attribution), `test_rust_call_recall` (turbofish, macro calls, and the bare-identifier precision guard).
- Corrected two tests that had encoded the old over-attribution: `test_cpp_cross_file_singleton` (calls attributed to the enclosing method, not the file) and `test_lua_modern_features` (precise edge assertions instead of a duplicate-inflated count).
- The previously-skipped `test_c_language` call suite (24 tests) now passes.
- Full non-infra suite: 4088 passed, 0 failed.
