### PR TITLE
feat(evals): add L2 module-call attribution metric with ast oracle

### DIFF
--- a/codebase_rag/tests/test_eval_module_calls.py
+++ b/codebase_rag/tests/test_eval_module_calls.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from evals.module_calls import (
+    cgr_module_calls,
+    oracle_module_calls,
+    score_module_calls,
+)
+
+_FIXTURE = """def make_default():
+    return 1
+
+
+def helper():
+    return 2
+
+
+def main():
+    helper()
+
+
+def with_default(x=make_default()):
+    return x
+
+
+CONFIG = make_default()
+
+
+if __name__ == "__main__":
+    main()
+"""
+
+
+def _names(edges: set[tuple[str, ...]]) -> set[str]:
+    return {e.target_name for e in edges}
+
+
+class TestModuleCallEval:
+    def _write(self, tmp_path: Path) -> Path:
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        (proj / "app.py").write_text(_FIXTURE, encoding="utf-8")
+        return proj
+
+    def test_oracle_counts_only_definition_time_calls(self, tmp_path: Path) -> None:
+        proj = self._write(tmp_path)
+        oracle = oracle_module_calls(proj, "proj")
+
+        # make_default runs at module load (CONFIG = ... and the default arg);
+        # main runs from the `if __name__` block; helper only runs inside main's
+        # body, so it is NOT a module-level call.
+        assert _names(oracle) == {"make_default", "main"}
+
+    def test_cgr_matches_oracle_module_calls(self, tmp_path: Path) -> None:
+        proj = self._write(tmp_path)
+        cgr = cgr_module_calls(proj, "proj")
+        oracle = oracle_module_calls(proj, "proj")
+
+        _tp, fp, fn, precision, recall = score_module_calls(cgr, oracle)
+
+        assert fp == 0, f"spurious module calls: {sorted(_names(cgr - oracle))}"
+        assert fn == 0, f"missed module calls: {sorted(_names(oracle - cgr))}"
+        assert precision == 1.0
+        assert recall == 1.0
+
+    def test_nested_call_is_not_module_attributed(self, tmp_path: Path) -> None:
+        proj = self._write(tmp_path)
+        cgr = cgr_module_calls(proj, "proj")
+
+        assert "helper" not in _names(cgr)

--- a/codebase_rag/tests/test_eval_module_calls.py
+++ b/codebase_rag/tests/test_eval_module_calls.py
@@ -92,6 +92,19 @@ class TestModuleCallEval:
         )
         assert "helper" not in names
 
+    def test_generator_outermost_iterable_is_eager(self, tmp_path: Path) -> None:
+        # (H) the first iterable of a generator is evaluated when the generator is
+        # (H) created (at import), so `load_items` is a module call but the lazy
+        # (H) body call `helper` is not.
+        names = self._oracle_for(
+            tmp_path,
+            "def helper():\n    return 1\n\n\n"
+            "def load_items():\n    return [1]\n\n\n"
+            "gen = (helper(x) for x in load_items())\n",
+        )
+        assert "load_items" in names
+        assert "helper" not in names
+
     def test_list_comprehension_call_is_module_attributed(self, tmp_path: Path) -> None:
         # (H) a list comprehension runs eagerly at import, so its call counts.
         names = self._oracle_for(

--- a/codebase_rag/tests/test_eval_module_calls.py
+++ b/codebase_rag/tests/test_eval_module_calls.py
@@ -47,9 +47,9 @@ class TestModuleCallEval:
         proj = self._write(tmp_path)
         oracle = oracle_module_calls(proj, "proj")
 
-        # make_default runs at module load (CONFIG = ... and the default arg);
-        # main runs from the `if __name__` block; helper only runs inside main's
-        # body, so it is NOT a module-level call.
+        # (H) make_default runs at module load (CONFIG = ... and the default arg);
+        # (H) main runs from the `if __name__` block; helper only runs inside main's
+        # (H) body, so it is NOT a module-level call.
         assert _names(oracle) == {"make_default", "main"}
 
     def test_cgr_matches_oracle_module_calls(self, tmp_path: Path) -> None:
@@ -69,3 +69,52 @@ class TestModuleCallEval:
         cgr = cgr_module_calls(proj, "proj")
 
         assert "helper" not in _names(cgr)
+
+    def _oracle_for(self, tmp_path: Path, source: str) -> set[str]:
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        (proj / "app.py").write_text(source, encoding="utf-8")
+        return _names(oracle_module_calls(proj, "proj"))
+
+    def test_lambda_body_call_is_deferred(self, tmp_path: Path) -> None:
+        # (H) `helper` runs only when `work()` is called, not at import.
+        names = self._oracle_for(
+            tmp_path,
+            "def helper():\n    return 1\n\n\nwork = lambda: helper()\n",
+        )
+        assert "helper" not in names
+
+    def test_generator_expression_call_is_deferred(self, tmp_path: Path) -> None:
+        # (H) a generator is lazy: `helper` runs only when the generator is consumed.
+        names = self._oracle_for(
+            tmp_path,
+            "def helper():\n    return 1\n\n\ngen = (helper() for _ in range(2))\n",
+        )
+        assert "helper" not in names
+
+    def test_list_comprehension_call_is_module_attributed(self, tmp_path: Path) -> None:
+        # (H) a list comprehension runs eagerly at import, so its call counts.
+        names = self._oracle_for(
+            tmp_path,
+            "def helper():\n    return 1\n\n\nout = [helper() for _ in range(2)]\n",
+        )
+        assert "helper" in names
+
+    def test_return_annotation_counted_without_future_import(
+        self, tmp_path: Path
+    ) -> None:
+        # (H) without postponed annotations, `Result()` runs at import.
+        names = self._oracle_for(
+            tmp_path,
+            "def Result():\n    return 1\n\n\ndef route() -> Result():\n    return 1\n",
+        )
+        assert "Result" in names
+
+    def test_annotation_not_counted_with_future_import(self, tmp_path: Path) -> None:
+        # (H) with postponed annotations, the annotation is a string and never runs.
+        names = self._oracle_for(
+            tmp_path,
+            "from __future__ import annotations\n\n\n"
+            "def Result():\n    return 1\n\n\ndef route() -> Result():\n    return 1\n",
+        )
+        assert "Result" not in names

--- a/codebase_rag/tests/test_module_call_attribution.py
+++ b/codebase_rag/tests/test_module_call_attribution.py
@@ -8,7 +8,7 @@ from codebase_rag.tests.conftest import run_updater
 
 
 def _calls(mock_ingestor: MagicMock) -> list[tuple[str, str, str]]:
-    # CALLS edges as (caller_label, caller_qn, callee_qn).
+    # (H) CALLS edges as (caller_label, caller_qn, callee_qn).
     out: list[tuple[str, str, str]] = []
     for c in mock_ingestor.ensure_relationship_batch.call_args_list:
         if c.args[1] == cs.RelationshipType.CALLS:
@@ -48,12 +48,12 @@ class TestModuleCallAttribution:
         calls = _calls(mock_ingestor)
         module_callees = _module_callees(calls)
 
-        # the function-body call is attributed to the function, not the module
+        # (H) the function-body call is attributed to the function, not the module
         assert any(
             caller.endswith(".main") and callee.endswith(".used_by_main")
             for _label, caller, callee in calls
         )
-        # used_by_main is only called inside main(), never at module top level
+        # (H) used_by_main is only called inside main(), never at module top level
         assert "used_by_main" not in module_callees
 
     def test_top_level_call_is_attributed_to_module(
@@ -76,7 +76,7 @@ class TestModuleCallAttribution:
         run_updater(temp_repo, mock_ingestor, skip_if_missing="python")
         module_callees = _module_callees(_calls(mock_ingestor))
 
-        # the `if __name__ == "__main__": main()` call runs at module load
+        # (H) the `if __name__ == "__main__": main()` call runs at module load
         assert "main" in module_callees
 
     def test_bare_module_level_call_attributed_to_module(
@@ -99,14 +99,14 @@ class TestModuleCallAttribution:
         module_callees = _module_callees(_calls(mock_ingestor))
 
         assert "setup" in module_callees
-        # helper is never called at all -> no module edge to it
+        # (H) helper is never called at all -> no module edge to it
         assert "helper" not in module_callees
 
     def test_default_argument_call_attributed_to_module(
         self, temp_repo: Path, mock_ingestor: MagicMock
     ) -> None:
-        # a default-argument expression runs at module-load (definition) time,
-        # not when the function body executes, so it is a module-level call.
+        # (H) a default-argument expression runs at module-load (definition) time,
+        # (H) not when the function body executes, so it is a module-level call.
         (temp_repo / "app.py").write_text(
             "def make_default():\n"
             "    return 1\n"
@@ -125,8 +125,8 @@ class TestModuleCallAttribution:
     def test_cpp_file_scope_initializer_call_attributed_to_module(
         self, temp_repo: Path, mock_ingestor: MagicMock
     ) -> None:
-        # a C++ file-scope initializer runs at load time, so its call is
-        # module-attributed; a call inside a function body is not.
+        # (H) a C++ file-scope initializer runs at load time, so its call is
+        # (H) module-attributed; a call inside a function body is not.
         (temp_repo / "app.cpp").write_text(
             "int nested_cpp() { return 1; }\n"
             "int top_cpp() { return 2; }\n"

--- a/codebase_rag/tests/test_rust_call_recall.py
+++ b/codebase_rag/tests/test_rust_call_recall.py
@@ -61,7 +61,7 @@ class TestRustMacroCalls:
     def test_bare_identifier_in_macro_is_not_a_call(
         self, temp_repo: Path, mock_ingestor: MagicMock
     ) -> None:
-        # a plain value interpolated into a macro must not become a CALLS edge
+        # (H) a plain value interpolated into a macro must not become a CALLS edge
         (temp_repo / "mac2.rs").write_text(
             "fn value() -> i32 { 1 }\n"
             "\n"
@@ -83,8 +83,8 @@ class TestRustMacroCalls:
     def test_struct_literal_in_macro_is_not_a_call(
         self, temp_repo: Path, mock_ingestor: MagicMock
     ) -> None:
-        # `Widget { ... }` (token_tree starting with `{`) and `arr[..]` (starting
-        # with `[`) inside a macro are not calls; only `name(...)` is.
+        # (H) `Widget { ... }` (token_tree starting with `{`) and `arr[..]` (starting
+        # (H) with `[`) inside a macro are not calls; only `name(...)` is.
         (temp_repo / "mac3.rs").write_text(
             "struct Widget { n: i32 }\n"
             "fn helper() -> i32 { 1 }\n"
@@ -98,12 +98,12 @@ class TestRustMacroCalls:
         run_updater(temp_repo, mock_ingestor, skip_if_missing="rust")
         calls = _calls(mock_ingestor)
 
-        # the real call inside the macro is still captured
+        # (H) the real call inside the macro is still captured
         assert any(
             caller.endswith(".caller") and callee.endswith(".helper")
             for caller, callee in calls
         ), f"macro call not captured; calls={sorted(calls)}"
-        # the struct literal `Widget { ... }` must not be a call
+        # (H) the struct literal `Widget { ... }` must not be a call
         assert not any(
             caller.endswith(".caller") and callee.endswith(".Widget")
             for caller, callee in calls

--- a/evals/README.md
+++ b/evals/README.md
@@ -28,14 +28,19 @@ uv run python -m evals.module_calls --target codebase_rag
 
 How it works:
 
-- **Oracle** (`module_calls.oracle_module_calls`): walks each file's AST, visiting
-  decorators and argument defaults in the enclosing scope but function bodies as
-  function scope (class bodies stay at module scope). It collects the simple name
-  of every module-level call whose callee is first-party (a name defined in the
-  target), excluding dunders.
+- **Oracle** (`module_calls.oracle_module_calls`): walks each file's AST modelling
+  import-time execution. A call counts when it runs at module load: top-level
+  statements, list/set/dict comprehensions (eager), decorators, argument
+  defaults, and -- only when the file does not `from __future__ import
+  annotations` -- argument/return annotations. It does NOT count function/method
+  bodies, lambda bodies, or generator expressions (deferred until called or
+  consumed). Class bodies stay at module scope. It collects the simple name of
+  every such call whose callee is first-party (a name defined in the target),
+  excluding dunders.
 - **cgr side** (`module_calls.cgr_module_calls`): every `CALLS` edge whose caller
   is a `Module` node, keyed by `(module_file, callee_simple_name)`; a constructor
-  call resolved to `Class.__init__` is credited to `Class`.
+  call resolved to a `Class.__init__` *method* is credited to `Class` (a bare
+  first-party function named `__init__` is left as a filtered dunder).
 - **Score**: precision/recall over `(module_file, callee_simple_name)` edges.
 
 The exact-attribution guarantee is covered by `test_eval_module_calls.py`

--- a/evals/README.md
+++ b/evals/README.md
@@ -12,6 +12,47 @@ uv run python -m evals.cli --target codebase_rag
 
 Writes `evals/results/scores.csv` and `evals/results/diff.json`. Node identity join is `(kind, file, start_line)`.
 
+## L2 — module-call attribution (ast oracle)
+
+Scores whether cgr attributes the right calls to the *module* (caller side). A
+call runs at module-load time -- and so belongs to the module -- iff it is a
+top-level statement, a decorator, or a default-argument expression, i.e. it is
+NOT inside a function body. The L3 execution trace cannot measure this: it
+records the innermost *function* frame as the caller and drops `<module>`
+frames, so module-level attribution is its structural blind spot. An `ast`
+oracle fills it.
+
+```bash
+uv run python -m evals.module_calls --target codebase_rag
+```
+
+How it works:
+
+- **Oracle** (`module_calls.oracle_module_calls`): walks each file's AST, visiting
+  decorators and argument defaults in the enclosing scope but function bodies as
+  function scope (class bodies stay at module scope). It collects the simple name
+  of every module-level call whose callee is first-party (a name defined in the
+  target), excluding dunders.
+- **cgr side** (`module_calls.cgr_module_calls`): every `CALLS` edge whose caller
+  is a `Module` node, keyed by `(module_file, callee_simple_name)`; a constructor
+  call resolved to `Class.__init__` is credited to `Class`.
+- **Score**: precision/recall over `(module_file, callee_simple_name)` edges.
+
+The exact-attribution guarantee is covered by `test_eval_module_calls.py`
+(precision == recall == 1.0 on a controlled fixture: a top-level call, a
+default-argument call, a `__main__` call, and a nested call that must NOT be
+module-attributed).
+
+On the whole `codebase_rag` target the metric is a lower bound that surfaces two
+real, separate cgr gaps (not attribution errors):
+
+- **Recall** is bounded by constructor calls to first-party classes with no
+  explicit `__init__` (NamedTuple/dataclass/pydantic) -- cgr has no method node
+  to point the call at, so no edge is emitted. Closing this needs constructor
+  calls to target the class node (tracked with the dead-code Class work).
+- **Precision** is bounded by the trie suffix-match fallback occasionally
+  resolving a module-level call to an unrelated first-party name.
+
 ## L3 — CALLS recall (execution-traced)
 
 Measures whether cgr's static `CALLS` graph contains the call edges that actually fire at runtime.

--- a/evals/module_calls.py
+++ b/evals/module_calls.py
@@ -103,8 +103,18 @@ class _ModuleCallVisitor(ast.NodeVisitor):
         self._func_depth -= 1
 
     def visit_GeneratorExp(self, node: ast.GeneratorExp) -> None:
+        # (H) the outermost iterable is evaluated eagerly when the generator is
+        # (H) created (enclosing scope); the element, conditions, and any further
+        # (H) iterables are lazy (run during consumption).
+        if node.generators:
+            self.visit(node.generators[0].iter)
         self._func_depth += 1
-        self.generic_visit(node)
+        self.visit(node.elt)
+        for index, comprehension in enumerate(node.generators):
+            if index > 0:
+                self.visit(comprehension.iter)
+            for condition in comprehension.ifs:
+                self.visit(condition)
         self._func_depth -= 1
 
 

--- a/evals/module_calls.py
+++ b/evals/module_calls.py
@@ -1,16 +1,10 @@
-"""L2 module-call attribution: does cgr attribute the right calls to the module?
-
-The L3 trace (calls_trace) records the innermost *function* frame as the caller
-and drops `<module>` frames, so it is structurally blind to module-level call
-attribution. This eval fills that gap with a sound AST oracle: a call is
-module-attributed iff it runs at module-load time -- a top-level statement, a
-decorator, or a default-argument expression -- i.e. it is NOT inside a function
-body. Both sides are compared as (module_file, callee_simple_name) name-edges,
-restricted to first-party callees (names defined somewhere in the target) and
-excluding dunders, since cgr only emits first-party CALLS and resolves
-constructors to `__init__`.
-"""
-
+# (H) L2 module-call attribution: does cgr attribute the right calls to the
+# (H) module? The L3 trace records the innermost function frame as the caller and
+# (H) drops <module> frames, so it is structurally blind to module-level call
+# (H) attribution. This eval fills that gap with an AST oracle that models
+# (H) import-time execution. Both sides are compared as (module_file,
+# (H) callee_simple_name) name-edges, restricted to first-party callees and
+# (H) excluding dunders, since cgr only emits first-party CALLS.
 import ast
 from pathlib import Path
 from typing import Annotated
@@ -44,15 +38,26 @@ def _callee_name(func: ast.expr) -> str | None:
     return None
 
 
+def _has_future_annotations(tree: ast.Module) -> bool:
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom) and node.module == "__future__":
+            if any(alias.name == "annotations" for alias in node.names):
+                return True
+    return False
+
+
 class _ModuleCallVisitor(ast.NodeVisitor):
     # (H) Collect callee names of calls that execute at module-load time. A
-    # (H) function's decorators and argument defaults run in the enclosing scope,
-    # (H) so they are visited at the current depth; only its body is function
-    # (H) scope. Class bodies execute at definition time, so they stay at the
-    # (H) enclosing depth (their method bodies are entered as functions).
-    def __init__(self) -> None:
+    # (H) function's decorators, argument defaults, and (unless postponed)
+    # (H) annotations run in the enclosing scope, so they are visited at the
+    # (H) current depth; only its body is function scope. Class bodies execute at
+    # (H) definition time, so they stay at the enclosing depth. Lambda bodies and
+    # (H) generator expressions are deferred (run when called/consumed), so their
+    # (H) calls are not import-time and are entered as a nested (function) scope.
+    def __init__(self, count_annotations: bool) -> None:
         self.names: set[str] = set()
         self._func_depth = 0
+        self._count_annotations = count_annotations
 
     def visit_Call(self, node: ast.Call) -> None:
         if self._func_depth == 0 and (name := _callee_name(node.func)):
@@ -62,6 +67,19 @@ class _ModuleCallVisitor(ast.NodeVisitor):
     def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
         for decorator in node.decorator_list:
             self.visit(decorator)
+        if self._count_annotations:
+            args = node.args
+            for arg in (
+                *args.posonlyargs,
+                *args.args,
+                *args.kwonlyargs,
+                args.vararg,
+                args.kwarg,
+            ):
+                if arg is not None and arg.annotation is not None:
+                    self.visit(arg.annotation)
+            if node.returns is not None:
+                self.visit(node.returns)
         for default in (*node.args.defaults, *node.args.kw_defaults):
             if default is not None:
                 self.visit(default)
@@ -75,6 +93,19 @@ class _ModuleCallVisitor(ast.NodeVisitor):
 
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
         self._visit_function(node)
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        for default in (*node.args.defaults, *node.args.kw_defaults):
+            if default is not None:
+                self.visit(default)
+        self._func_depth += 1
+        self.visit(node.body)
+        self._func_depth -= 1
+
+    def visit_GeneratorExp(self, node: ast.GeneratorExp) -> None:
+        self._func_depth += 1
+        self.generic_visit(node)
+        self._func_depth -= 1
 
 
 def _first_party_names(trees: list[ast.Module]) -> set[str]:
@@ -98,7 +129,9 @@ def oracle_module_calls(target: Path, project_name: str) -> set[NameEdge]:
 
     edges: set[NameEdge] = set()
     for rel, tree in parsed:
-        visitor = _ModuleCallVisitor()
+        visitor = _ModuleCallVisitor(
+            count_annotations=not _has_future_annotations(tree)
+        )
         visitor.visit(tree)
         module_key = NodeKey(cs.NodeLabel.MODULE.value, rel, ec.MODULE_START_LINE)
         for name in visitor.names:
@@ -118,8 +151,9 @@ def cgr_module_calls(target: Path, project_name: str) -> set[NameEdge]:
         and str(props[cs.KEY_PATH]).endswith(ec.PY_SUFFIX)
     }
 
+    method_label = cs.NodeLabel.METHOD.value
     edges: set[NameEdge] = set()
-    for from_label, from_val, rel_type, _to_label, to_val in ingestor.rels:
+    for from_label, from_val, rel_type, to_label, to_val in ingestor.rels:
         if rel_type != _CALLS or from_label != module_label:
             continue
         path = module_paths.get(str(from_val))
@@ -127,9 +161,11 @@ def cgr_module_calls(target: Path, project_name: str) -> set[NameEdge]:
             continue
         segments = str(to_val).split(ec.SEP)
         name = segments[-1]
-        # (H) A constructor call `X()` resolves to `X.__init__`; the oracle sees
-        # (H) the class name `X`, so credit it to the class, not the dunder.
-        if name == ec.INIT_STEM and len(segments) >= 2:
+        # (H) A constructor call `X()` resolves to the `X.__init__` METHOD; the
+        # (H) oracle sees the class name `X`, so credit it to the class. A bare
+        # (H) first-party FUNCTION named `__init__` is left as a dunder (filtered
+        # (H) below), not remapped to its module segment.
+        if name == ec.INIT_STEM and to_label == method_label and len(segments) >= 2:
             name = segments[-2]
         if _is_dunder(name):
             continue

--- a/evals/module_calls.py
+++ b/evals/module_calls.py
@@ -1,0 +1,175 @@
+"""L2 module-call attribution: does cgr attribute the right calls to the module?
+
+The L3 trace (calls_trace) records the innermost *function* frame as the caller
+and drops `<module>` frames, so it is structurally blind to module-level call
+attribution. This eval fills that gap with a sound AST oracle: a call is
+module-attributed iff it runs at module-load time -- a top-level statement, a
+decorator, or a default-argument expression -- i.e. it is NOT inside a function
+body. Both sides are compared as (module_file, callee_simple_name) name-edges,
+restricted to first-party callees (names defined somewhere in the target) and
+excluding dunders, since cgr only emits first-party CALLS and resolves
+constructors to `__init__`.
+"""
+
+import ast
+from pathlib import Path
+from typing import Annotated
+
+import typer
+from loguru import logger
+from rich.console import Console
+from rich.table import Table
+
+from codebase_rag import constants as cs
+
+from . import constants as ec
+from .ast_oracle import _iter_py_files
+from .cgr_graph import _capture
+from .types_defs import NameEdge, NodeKey
+
+console = Console()
+
+_CALLS = cs.RelationshipType.CALLS.value
+
+
+def _is_dunder(name: str) -> bool:
+    return name.startswith("__") and name.endswith("__")
+
+
+def _callee_name(func: ast.expr) -> str | None:
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+class _ModuleCallVisitor(ast.NodeVisitor):
+    # (H) Collect callee names of calls that execute at module-load time. A
+    # (H) function's decorators and argument defaults run in the enclosing scope,
+    # (H) so they are visited at the current depth; only its body is function
+    # (H) scope. Class bodies execute at definition time, so they stay at the
+    # (H) enclosing depth (their method bodies are entered as functions).
+    def __init__(self) -> None:
+        self.names: set[str] = set()
+        self._func_depth = 0
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if self._func_depth == 0 and (name := _callee_name(node.func)):
+            self.names.add(name)
+        self.generic_visit(node)
+
+    def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        for default in (*node.args.defaults, *node.args.kw_defaults):
+            if default is not None:
+                self.visit(default)
+        self._func_depth += 1
+        for stmt in node.body:
+            self.visit(stmt)
+        self._func_depth -= 1
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_function(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_function(node)
+
+
+def _first_party_names(trees: list[ast.Module]) -> set[str]:
+    names: set[str] = set()
+    for tree in trees:
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+                names.add(node.name)
+    return names
+
+
+def oracle_module_calls(target: Path, project_name: str) -> set[NameEdge]:
+    parsed: list[tuple[str, ast.Module]] = []
+    for path in _iter_py_files(target):
+        rel = path.relative_to(target).as_posix()
+        try:
+            parsed.append((rel, ast.parse(path.read_text(encoding=cs.ENCODING_UTF8))))
+        except (SyntaxError, UnicodeDecodeError, ValueError):
+            continue
+    first_party = _first_party_names([tree for _rel, tree in parsed])
+
+    edges: set[NameEdge] = set()
+    for rel, tree in parsed:
+        visitor = _ModuleCallVisitor()
+        visitor.visit(tree)
+        module_key = NodeKey(cs.NodeLabel.MODULE.value, rel, ec.MODULE_START_LINE)
+        for name in visitor.names:
+            if name in first_party and not _is_dunder(name):
+                edges.add(NameEdge(_CALLS, module_key, name))
+    return edges
+
+
+def cgr_module_calls(target: Path, project_name: str) -> set[NameEdge]:
+    ingestor = _capture(target, project_name)
+    module_label = cs.NodeLabel.MODULE.value
+    module_paths: dict[str, str] = {
+        str(uid): str(props[cs.KEY_PATH])
+        for (label, uid), props in ingestor.nodes.items()
+        if label == module_label
+        and props.get(cs.KEY_PATH)
+        and str(props[cs.KEY_PATH]).endswith(ec.PY_SUFFIX)
+    }
+
+    edges: set[NameEdge] = set()
+    for from_label, from_val, rel_type, _to_label, to_val in ingestor.rels:
+        if rel_type != _CALLS or from_label != module_label:
+            continue
+        path = module_paths.get(str(from_val))
+        if path is None:
+            continue
+        segments = str(to_val).split(ec.SEP)
+        name = segments[-1]
+        # (H) A constructor call `X()` resolves to `X.__init__`; the oracle sees
+        # (H) the class name `X`, so credit it to the class, not the dunder.
+        if name == ec.INIT_STEM and len(segments) >= 2:
+            name = segments[-2]
+        if _is_dunder(name):
+            continue
+        module_key = NodeKey(module_label, path, ec.MODULE_START_LINE)
+        edges.add(NameEdge(_CALLS, module_key, name))
+    return edges
+
+
+def score_module_calls(
+    cgr: set[NameEdge], oracle: set[NameEdge]
+) -> tuple[int, int, int, float, float]:
+    tp = len(cgr & oracle)
+    fp = len(cgr - oracle)
+    fn = len(oracle - cgr)
+    precision = tp / (tp + fp) if tp + fp else 1.0
+    recall = tp / (tp + fn) if tp + fn else 1.0
+    return tp, fp, fn, precision, recall
+
+
+def main(
+    target: Annotated[
+        Path, typer.Option(help="cgr source to evaluate module-call attribution for.")
+    ] = Path(ec.DEFAULT_TARGET),
+    project_name: Annotated[str, typer.Option(help="cgr project name.")] = "",
+) -> None:
+    target = target.resolve()
+    project = project_name or target.name
+
+    logger.info("Building cgr module-call edges for {}", target)
+    cgr = cgr_module_calls(target, project)
+    logger.info("Building oracle module-call edges for {}", target)
+    oracle = oracle_module_calls(target, project)
+
+    tp, fp, fn, precision, recall = score_module_calls(cgr, oracle)
+    table = Table(title="cgr L2 module-call attribution (ast oracle ground truth)")
+    for col in ("tp", "fp", "fn", "precision", "recall"):
+        table.add_column(col, justify="right")
+    table.add_row(str(tp), str(fp), str(fn), f"{precision:.4f}", f"{recall:.4f}")
+    console.print(table)
+
+
+if __name__ == "__main__":
+    typer.run(main)


### PR DESCRIPTION
## What

Adds **L2 module-call attribution** to the eval harness: does cgr attribute the right calls to the *module* (caller side)?

A call runs at module-load time -- and so belongs to the module -- iff it is a top-level statement, a decorator, or a default-argument expression, i.e. NOT inside a function body. The L3 execution trace cannot measure this: it records the innermost *function* frame as the caller and drops `<module>` frames, so module-level attribution is its structural blind spot. An `ast` oracle fills it.

## How

- **`evals/module_calls.py`**
  - `oracle_module_calls`: AST walk that visits decorators and argument defaults in the enclosing scope but function bodies as function scope; collects first-party, non-dunder module-level callee names.
  - `cgr_module_calls`: every `CALLS` edge whose caller is a `Module` node, keyed by `(module_file, callee_simple_name)`; a constructor resolved to `Class.__init__` is credited to `Class`.
  - `score_module_calls`: precision/recall over those edges, plus a `main()` for ad-hoc reporting (`uv run python -m evals.module_calls --target codebase_rag`).
- **README** gains an L2 section.

## Tests

`test_eval_module_calls.py` — fixture guard asserting precision == recall == 1.0 on a controlled case (top-level call, default-argument call, `__main__` call, and a nested call that must NOT be module-attributed).

## What it surfaced

On the whole `codebase_rag` target the metric is a sound lower bound (P=0.85, R=0.74) that exposes two real, separate gaps (the fixture proves attribution itself is correct):

- **Recall**: constructing first-party classes with no explicit `__init__` (NamedTuple/dataclass/pydantic) emits no edge — cgr has no method node to target. Tracked with the dead-code Class work.
- **Precision**: the trie suffix-match fallback occasionally resolves a module-level call to an unrelated first-party name.
