### PR TITLE
feat(parser): emit module-load CALLS edges for bare decorators

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -148,6 +148,59 @@ class CallProcessor:
                 nested_starts.add(call.start_byte)
         return [c for c in all_call_nodes if c.start_byte not in nested_starts]
 
+    def _bare_decorator_name(self, decorator_node: Node) -> str | None:
+        # (H) A bare decorator `@task` / `@pkg.deco` (no call parens) is not a
+        # (H) `call` node, so the normal call pass misses it even though applying
+        # (H) it runs `task(func)` at module load. A call decorator `@deco(...)`
+        # (H) IS a call node and is already captured, so skip it here.
+        named = decorator_node.named_children
+        if not named:
+            return None
+        expr = named[0]
+        if expr.type in (cs.TS_IDENTIFIER, cs.TS_ATTRIBUTE) and expr.text is not None:
+            return expr.text.decode(cs.ENCODING_UTF8)
+        return None
+
+    def _runs_at_module_load(self, node: Node) -> bool:
+        # (H) A definition runs at module load only when it is at module or
+        # (H) class-body scope; nested inside a function body it runs at that
+        # (H) function's call time, so its decorator is not a module-load call.
+        ancestor = node.parent
+        while ancestor is not None:
+            if ancestor.type == cs.TS_PY_FUNCTION_DEFINITION:
+                return False
+            ancestor = ancestor.parent
+        return True
+
+    def _ingest_decorator_calls(self, func_nodes: list[Node], module_qn: str) -> None:
+        # (H) Emit `(Module)->decorator` CALLS for bare decorators: the decoration
+        # (H) executes at module-load time, so the module is the caller. Only
+        # (H) first-party callables produce an edge.
+        resolver = self._resolver
+        ensure_rel = self.ingestor.ensure_relationship_batch
+        qn_key = cs.KEY_QUALIFIED_NAME
+        module_spec = (cs.NodeLabel.MODULE, qn_key, module_qn)
+        callable_labels = (cs.NodeLabel.FUNCTION, cs.NodeLabel.METHOD)
+        for func_node in func_nodes:
+            parent = func_node.parent
+            if parent is None or parent.type != cs.TS_PY_DECORATED_DEFINITION:
+                continue
+            if not self._runs_at_module_load(parent):
+                continue
+            for child in parent.children:
+                if child.type != cs.TS_PY_DECORATOR:
+                    continue
+                name = self._bare_decorator_name(child)
+                if not name:
+                    continue
+                callee = resolver.resolve_function_call(name, module_qn)
+                if callee and callee[0] in callable_labels:
+                    ensure_rel(
+                        module_spec,
+                        cs.RelationshipType.CALLS,
+                        (callee[0], qn_key, callee[1]),
+                    )
+
     def _module_qn(self, relative_path: Path, file_name: str) -> str:
         if file_name in (cs.INIT_PY, cs.MOD_RS):
             return cs.SEPARATOR_DOT.join(
@@ -272,6 +325,11 @@ class CallProcessor:
                 call_name_cache=call_name_cache,
                 combined_captures=combined_captures or None,
             )
+            # (H) Bare decorators (`@task`) are not call nodes; emit their
+            # (H) module-load CALLS before the empty-`all_call_nodes` early return,
+            # (H) since a file may have decorators but no other calls.
+            if language == cs.SupportedLanguage.PYTHON and sorted_func_nodes:
+                self._ingest_decorator_calls(sorted_func_nodes, module_qn)
             if not all_call_nodes:
                 return
             self._process_calls_in_classes(

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -172,17 +172,24 @@ class CallProcessor:
             ancestor = ancestor.parent
         return True
 
-    def _ingest_decorator_calls(self, func_nodes: list[Node], module_qn: str) -> None:
-        # (H) Emit `(Module)->decorator` CALLS for bare decorators: the decoration
-        # (H) executes at module-load time, so the module is the caller. Only
-        # (H) first-party callables produce an edge.
+    def _ingest_decorator_calls(
+        self,
+        nodes: list[Node],
+        module_qn: str,
+        root_node: Node,
+        lang_config: LanguageSpec,
+    ) -> None:
+        # (H) Emit `(Module)->decorator` CALLS for bare decorators on functions,
+        # (H) methods, AND classes: the decoration executes at module-load time,
+        # (H) so the module is the caller. Only first-party callables get an edge.
         resolver = self._resolver
         ensure_rel = self.ingestor.ensure_relationship_batch
         qn_key = cs.KEY_QUALIFIED_NAME
         module_spec = (cs.NodeLabel.MODULE, qn_key, module_qn)
         callable_labels = (cs.NodeLabel.FUNCTION, cs.NodeLabel.METHOD)
-        for func_node in func_nodes:
-            parent = func_node.parent
+        alias_map: dict[str, str] | None = None
+        for node in nodes:
+            parent = node.parent
             if parent is None or parent.type != cs.TS_PY_DECORATED_DEFINITION:
                 continue
             if not self._runs_at_module_load(parent):
@@ -194,6 +201,15 @@ class CallProcessor:
                 if not name:
                     continue
                 callee = resolver.resolve_function_call(name, module_qn)
+                if not callee and cs.SEPARATOR_DOT not in name:
+                    # (H) `@alias` where `alias = task` still calls task at load;
+                    # (H) reuse the local-alias fallback the call pass uses.
+                    if alias_map is None:
+                        alias_map = self._build_local_alias_map(
+                            root_node, lang_config, module_qn
+                        )
+                    if (rhs := alias_map.get(name)) is not None:
+                        callee = resolver.resolve_function_call(rhs, module_qn)
                 if callee and callee[0] in callable_labels:
                     ensure_rel(
                         module_spec,
@@ -327,9 +343,21 @@ class CallProcessor:
             )
             # (H) Bare decorators (`@task`) are not call nodes; emit their
             # (H) module-load CALLS before the empty-`all_call_nodes` early return,
-            # (H) since a file may have decorators but no other calls.
-            if language == cs.SupportedLanguage.PYTHON and sorted_func_nodes:
-                self._ingest_decorator_calls(sorted_func_nodes, module_qn)
+            # (H) since a file may have decorators but no other calls. Classes can
+            # (H) be decorated too, so include captured class nodes.
+            if language == cs.SupportedLanguage.PYTHON:
+                decorator_targets = list(sorted_func_nodes or [])
+                if combined_captures and (
+                    class_nodes := combined_captures.get(cs.CAPTURE_CLASS)
+                ):
+                    decorator_targets.extend(class_nodes)
+                if decorator_targets:
+                    self._ingest_decorator_calls(
+                        decorator_targets,
+                        module_qn,
+                        root_node,
+                        queries[language][cs.QUERY_CONFIG],
+                    )
             if not all_call_nodes:
                 return
             self._process_calls_in_classes(

--- a/codebase_rag/tests/test_decorator_call_edges.py
+++ b/codebase_rag/tests/test_decorator_call_edges.py
@@ -63,6 +63,53 @@ class TestDecoratorCallEdges:
             for label, caller, callee in calls
         ), f"no module->register decorator edge; calls={sorted(calls)}"
 
+    def test_class_decorator_emits_module_call(
+        self, temp_repo: Path, mock_ingestor: MagicMock
+    ) -> None:
+        # (H) a bare decorator on a class also runs at module load.
+        (temp_repo / "app.py").write_text(
+            "def deco(cls):\n    return cls\n\n\n@deco\nclass MyClass:\n    pass\n",
+            encoding="utf-8",
+        )
+
+        run_updater(temp_repo, mock_ingestor, skip_if_missing="python")
+        calls = _calls(mock_ingestor)
+
+        assert any(
+            label == cs.NodeLabel.MODULE
+            and caller.endswith(".app")
+            and callee.endswith(".deco")
+            for label, caller, callee in calls
+        ), f"no module->deco class decorator edge; calls={sorted(calls)}"
+
+    def test_alias_decorator_resolves_to_first_party(
+        self, temp_repo: Path, mock_ingestor: MagicMock
+    ) -> None:
+        # (H) `@alias` where `alias = task` still calls task at module load.
+        (temp_repo / "app.py").write_text(
+            "def task(fn):\n"
+            "    return fn\n"
+            "\n"
+            "\n"
+            "alias = task\n"
+            "\n"
+            "\n"
+            "@alias\n"
+            "def handler():\n"
+            "    return 1\n",
+            encoding="utf-8",
+        )
+
+        run_updater(temp_repo, mock_ingestor, skip_if_missing="python")
+        calls = _calls(mock_ingestor)
+
+        assert any(
+            label == cs.NodeLabel.MODULE
+            and caller.endswith(".app")
+            and callee.endswith(".task")
+            for label, caller, callee in calls
+        ), f"alias decorator not resolved; calls={sorted(calls)}"
+
     def test_decorator_on_nested_function_not_module_attributed(
         self, temp_repo: Path, mock_ingestor: MagicMock
     ) -> None:

--- a/codebase_rag/tests/test_decorator_call_edges.py
+++ b/codebase_rag/tests/test_decorator_call_edges.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import run_updater
+
+
+def _calls(mock_ingestor: MagicMock) -> list[tuple[str, str, str]]:
+    # (H) CALLS edges as (caller_label, caller_qn, callee_qn).
+    out: list[tuple[str, str, str]] = []
+    for c in mock_ingestor.ensure_relationship_batch.call_args_list:
+        if c.args[1] == cs.RelationshipType.CALLS:
+            out.append((c.args[0][0], c.args[0][2], c.args[2][2]))
+    return out
+
+
+class TestDecoratorCallEdges:
+    def test_bare_decorator_emits_module_call(
+        self, temp_repo: Path, mock_ingestor: MagicMock
+    ) -> None:
+        # (H) `@task` applies task(handler) at module load -> a module-level call.
+        (temp_repo / "app.py").write_text(
+            "def task(fn):\n    return fn\n\n\n@task\ndef handler():\n    return 1\n",
+            encoding="utf-8",
+        )
+
+        run_updater(temp_repo, mock_ingestor, skip_if_missing="python")
+        calls = _calls(mock_ingestor)
+
+        assert any(
+            label == cs.NodeLabel.MODULE
+            and caller.endswith(".app")
+            and callee.endswith(".task")
+            for label, caller, callee in calls
+        ), f"no module->task decorator edge; calls={sorted(calls)}"
+
+    def test_call_decorator_emits_module_call(
+        self, temp_repo: Path, mock_ingestor: MagicMock
+    ) -> None:
+        # (H) `@register(...)` also runs at module load.
+        (temp_repo / "app.py").write_text(
+            "def register(name):\n"
+            "    def wrap(fn):\n"
+            "        return fn\n"
+            "    return wrap\n"
+            "\n"
+            "\n"
+            '@register("x")\n'
+            "def handler():\n"
+            "    return 1\n",
+            encoding="utf-8",
+        )
+
+        run_updater(temp_repo, mock_ingestor, skip_if_missing="python")
+        calls = _calls(mock_ingestor)
+
+        assert any(
+            label == cs.NodeLabel.MODULE
+            and caller.endswith(".app")
+            and callee.endswith(".register")
+            for label, caller, callee in calls
+        ), f"no module->register decorator edge; calls={sorted(calls)}"
+
+    def test_decorator_on_nested_function_not_module_attributed(
+        self, temp_repo: Path, mock_ingestor: MagicMock
+    ) -> None:
+        # (H) a decorator on a function nested in another function runs when the
+        # (H) outer function is called, not at module load -> no module edge.
+        (temp_repo / "app.py").write_text(
+            "def deco(fn):\n"
+            "    return fn\n"
+            "\n"
+            "\n"
+            "def outer():\n"
+            "    @deco\n"
+            "    def inner():\n"
+            "        return 1\n"
+            "\n"
+            "    return inner\n",
+            encoding="utf-8",
+        )
+
+        run_updater(temp_repo, mock_ingestor, skip_if_missing="python")
+        module_callees = {
+            callee.rsplit(cs.SEPARATOR_DOT, 1)[-1]
+            for label, _caller, callee in _calls(mock_ingestor)
+            if label == cs.NodeLabel.MODULE
+        }
+
+        assert "deco" not in module_callees
+
+    def test_undecorated_function_has_no_decorator_edge(
+        self, temp_repo: Path, mock_ingestor: MagicMock
+    ) -> None:
+        (temp_repo / "app.py").write_text(
+            "def plain():\n    return 1\n\n\ndef other():\n    return 2\n",
+            encoding="utf-8",
+        )
+
+        run_updater(temp_repo, mock_ingestor, skip_if_missing="python")
+        module_callees = {
+            callee.rsplit(cs.SEPARATOR_DOT, 1)[-1]
+            for label, _caller, callee in _calls(mock_ingestor)
+            if label == cs.NodeLabel.MODULE
+        }
+
+        assert "plain" not in module_callees
+        assert "other" not in module_callees

--- a/codebase_rag/tests/test_eval_module_calls.py
+++ b/codebase_rag/tests/test_eval_module_calls.py
@@ -113,6 +113,14 @@ class TestModuleCallEval:
         )
         assert "helper" in names
 
+    def test_class_decorator_is_module_attributed(self, tmp_path: Path) -> None:
+        # (H) a bare class decorator runs at module load -> a module call.
+        names = self._oracle_for(
+            tmp_path,
+            "def deco(cls):\n    return cls\n\n\n@deco\nclass Widget:\n    pass\n",
+        )
+        assert "deco" in names
+
     def test_return_annotation_counted_without_future_import(
         self, tmp_path: Path
     ) -> None:

--- a/evals/module_calls.py
+++ b/evals/module_calls.py
@@ -66,6 +66,14 @@ class _ModuleCallVisitor(ast.NodeVisitor):
 
     def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
         for decorator in node.decorator_list:
+            if self._func_depth == 0:
+                # (H) a bare decorator `@task` is a Name (not a Call), so record
+                # (H) its callee name explicitly; applying it runs at module load.
+                target = (
+                    decorator.func if isinstance(decorator, ast.Call) else decorator
+                )
+                if name := _callee_name(target):
+                    self.names.add(name)
             self.visit(decorator)
         if self._count_annotations:
             args = node.args

--- a/evals/module_calls.py
+++ b/evals/module_calls.py
@@ -102,6 +102,18 @@ class _ModuleCallVisitor(ast.NodeVisitor):
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
         self._visit_function(node)
 
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        # (H) a class decorator runs at definition (module-load) time too; the
+        # (H) class body stays at the current depth (eager at import).
+        if self._func_depth == 0:
+            for decorator in node.decorator_list:
+                target = (
+                    decorator.func if isinstance(decorator, ast.Call) else decorator
+                )
+                if name := _callee_name(target):
+                    self.names.add(name)
+        self.generic_visit(node)
+
     def visit_Lambda(self, node: ast.Lambda) -> None:
         for default in (*node.args.defaults, *node.args.kw_defaults):
             if default is not None:


### PR DESCRIPTION
## What

Emits `(Module)→decorator` `CALLS` edges for **bare** decorators (`@task`). Applying a decorator runs `task(func)` at module-load time, so it is a genuine module-level call — but a bare decorator is an identifier, not a call node, so the normal call pass never saw it. (Call decorators like `@register(...)` are call nodes and were already captured.)

This makes a function used only as a decorator reachable in the graph, removing a dead-code false positive (it becomes a real root once `cgr dead-code` consumes module-call roots).

## How

- `call_processor._ingest_decorator_calls`: for each decorated function/method, resolve each bare decorator's callee to a first-party function/method and emit a module-load `CALLS` edge.
- Scoped to module/class-body definitions via `_runs_at_module_load`: a decorator on a function nested inside another function runs at *that* function's call time, not at import, so it is not module-attributed.
- Python only (the L2-evaluated language); other languages' annotations are metadata, not calls.
- The L2 oracle (`evals/module_calls.py`) now also counts bare decorators, keeping the metric aligned.

## Tests

`test_decorator_call_edges.py`: bare decorator → module edge; call decorator → module edge; nested-function decorator → no module edge; undecorated → no edge. (The nested-function case was caught as an L2 eval false positive and fixed.)

## Verification

- Broad call/decorator/module/import sweep: 1022 passed, 0 failed.
- L2 module-call metric on `codebase_rag`: recall 0.74 → 0.76, precision 0.85 → 0.86 (correct decorator edges, no new spurious ones).
- ruff + ty + `check_no_docs` clean.
