### PR TITLE
feat(dead-code): treat module-load callees as reachability roots

### DIFF
--- a/codebase_rag/cli.py
+++ b/codebase_rag/cli.py
@@ -894,20 +894,20 @@ def _dead_code_params(
     project_name: str,
     entry_points: list[str],
     decorator_roots: list[str],
-    include_tests: bool,
 ) -> dict[str, PropertyValue]:
     root_decorators = sorted(
         {d.lower() for d in cs.DEFAULT_ROOT_DECORATORS}
         | {d.lower() for d in decorator_roots}
     )
-    params: dict[str, PropertyValue] = {
+    # (H) test_patterns is always passed: with tests included it makes test
+    # (H) functions roots; with tests excluded it filters test modules out of the
+    # (H) module-load root clause so test-only code is not kept alive.
+    return {
         "project_prefix": f"{project_name}{cs.SEPARATOR_DOT}",
         "root_decorators": root_decorators,
         "entry_points": list(entry_points),
+        "test_patterns": list(cs.TEST_PATH_PATTERNS),
     }
-    if include_tests:
-        params["test_patterns"] = list(cs.TEST_PATH_PATTERNS)
-    return params
 
 
 def _to_dead_code_row(row: ResultRow) -> DeadCodeRow:
@@ -1029,9 +1029,7 @@ def dead_code(
                 logger.info(ls.DEADCODE_SCANNING.format(project_name=resolved))
                 rows = ingestor.fetch_all(
                     build_dead_code_query(include_tests),
-                    _dead_code_params(
-                        resolved, entry_point, decorator_root, include_tests
-                    ),
+                    _dead_code_params(resolved, entry_point, decorator_root),
                 )
     except Exception as e:
         app_context.console.print(

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -101,6 +101,17 @@ _DEAD_CODE_TEST_ROOT_CLAUSE = (
     "\n    OR ANY(p IN $test_patterns WHERE n.path CONTAINS p)"
 )
 
+# (H) A function called by a Module node runs at import (top-level statement,
+# (H) `if __name__ == "__main__"`, or a bare decorator), so it is a root.
+# (H) `size([...])` avoids the non-standard `exists(pattern)`. When tests are
+# (H) excluded, a CALLS edge from a test module must NOT keep project code alive,
+# (H) so the test-module variant filters the calling module by path.
+_DEAD_CODE_MODULE_ROOT_ANY = "size([(n)<-[:CALLS]-(:Module) | 1]) > 0"
+_DEAD_CODE_MODULE_ROOT_NON_TEST = (
+    "size([(n)<-[:CALLS]-(m:Module)"
+    " WHERE NOT ANY(p IN $test_patterns WHERE m.path CONTAINS p) | 1]) > 0"
+)
+
 _DEAD_CODE_QUERY_TEMPLATE = """MATCH (n:Function|Method)
 WHERE n.qualified_name STARTS WITH $project_prefix
   AND (
@@ -109,7 +120,7 @@ WHERE n.qualified_name STARTS WITH $project_prefix
               IN $root_decorators)
     OR n.is_exported = true
     OR ANY(e IN $entry_points WHERE n.qualified_name ENDS WITH e)
-    OR exists((n)<-[:CALLS]-(:Module)){test_clause}
+    OR {module_clause}{test_clause}
   )
 WITH collect(n) AS roots
 UNWIND roots AS r
@@ -125,8 +136,15 @@ ORDER BY qualified_name"""
 
 
 def build_dead_code_query(include_tests: bool) -> str:
-    test_clause = _DEAD_CODE_TEST_ROOT_CLAUSE if include_tests else ""
-    return _DEAD_CODE_QUERY_TEMPLATE.format(test_clause=test_clause)
+    if include_tests:
+        module_clause = _DEAD_CODE_MODULE_ROOT_ANY
+        test_clause = _DEAD_CODE_TEST_ROOT_CLAUSE
+    else:
+        module_clause = _DEAD_CODE_MODULE_ROOT_NON_TEST
+        test_clause = ""
+    return _DEAD_CODE_QUERY_TEMPLATE.format(
+        module_clause=module_clause, test_clause=test_clause
+    )
 
 
 def wrap_with_unwind(query: str) -> str:

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -108,7 +108,8 @@ WHERE n.qualified_name STARTS WITH $project_prefix
         WHERE toLower(last(split(split(replace(d, '@', ''), '(')[0], '.')))
               IN $root_decorators)
     OR n.is_exported = true
-    OR ANY(e IN $entry_points WHERE n.qualified_name ENDS WITH e){test_clause}
+    OR ANY(e IN $entry_points WHERE n.qualified_name ENDS WITH e)
+    OR exists((n)<-[:CALLS]-(:Module)){test_clause}
   )
 WITH collect(n) AS roots
 UNWIND roots AS r

--- a/codebase_rag/tests/integration/test_cypher_queries.py
+++ b/codebase_rag/tests/integration/test_cypher_queries.py
@@ -355,11 +355,18 @@ class TestBuildDeadCodeQueryUnit:
         assert "$entry_points" in query
         assert "is_exported" in query
         assert "CALLS*0.." in query
+        # (H) test functions are roots when tests are included
+        assert "n.path CONTAINS" in query
 
-    def test_exclude_tests_omits_test_patterns(self) -> None:
+    def test_exclude_tests_omits_test_function_roots(self) -> None:
         query = build_dead_code_query(include_tests=False)
 
-        assert "$test_patterns" not in query
+        # (H) test functions are NOT roots when excluding tests ...
+        assert "n.path CONTAINS" not in query
+        # (H) ... but test_patterns still filters test modules out of the
+        # (H) module-load root clause so test-only code is not kept alive.
+        assert "$test_patterns" in query
+        assert "m.path CONTAINS" in query
         assert "$project_prefix" in query
 
     def test_module_load_callees_are_roots(self) -> None:
@@ -367,7 +374,7 @@ class TestBuildDeadCodeQueryUnit:
 
         # (H) a function called by a Module node runs at import, so it is a root
         assert "Module" in query
-        assert "CALLS]-(" in query or "]-(:Module" in query
+        assert "[:CALLS]-(" in query
 
 
 @pytest.mark.integration
@@ -404,15 +411,15 @@ class TestBuildDeadCodeQueryIntegration:
             "(testfn)-[:CALLS]->(helper)"
         )
 
-    def _params(self, include_tests: bool) -> dict[str, PropertyValue]:
-        params: dict[str, PropertyValue] = {
+    def _params(self, include_tests: bool) -> dict[str, PropertyValue]:  # noqa: ARG002
+        # (H) test_patterns is always supplied; the query (built per include_tests)
+        # (H) decides whether it gates test-function roots or test-module filtering.
+        return {
             "project_prefix": "proj.",
             "root_decorators": ["task", "route"],
             "entry_points": ["proj.mod.main"],
+            "test_patterns": ["test_", "_test", "conftest", "/tests/"],
         }
-        if include_tests:
-            params["test_patterns"] = ["test_", "_test", "conftest", "/tests/"]
-        return params
 
     def test_reports_only_the_orphan_with_tests_included(
         self, memgraph_ingestor: MemgraphIngestor
@@ -457,6 +464,38 @@ class TestBuildDeadCodeQueryIntegration:
         assert row["start_line"] == 9
         assert row["end_line"] == 11
 
+    def test_test_module_call_is_not_a_root_when_excluding_tests(
+        self, memgraph_ingestor: MemgraphIngestor
+    ) -> None:
+        # (H) a function reached only from a TEST module's top-level call must NOT
+        # (H) be kept alive when --no-include-tests, else test-only code hides as
+        # (H) live. The same call DOES keep it live when tests are included.
+        memgraph_ingestor._execute_query(
+            "CREATE "
+            "(tm:Module {qualified_name: 'proj.tests.test_x', "
+            "  path: 'proj/tests/test_x.py'}), "
+            "(tool:Function {qualified_name: 'proj.mod.tool_only', "
+            "  name: 'tool_only', start_line: 1, end_line: 2, decorators: [], "
+            "  path: 'proj/mod.py'}), "
+            "(tm)-[:CALLS]->(tool)"
+        )
+        params: dict[str, PropertyValue] = {
+            "project_prefix": "proj.",
+            "root_decorators": [],
+            "entry_points": [],
+            "test_patterns": ["test_", "_test", "conftest", "/tests/"],
+        }
+
+        excluded = memgraph_ingestor._execute_query(
+            build_dead_code_query(include_tests=False), params
+        )
+        assert {r["qualified_name"] for r in excluded} == {"proj.mod.tool_only"}
+
+        included = memgraph_ingestor._execute_query(
+            build_dead_code_query(include_tests=True), params
+        )
+        assert {r["qualified_name"] for r in included} == set()
+
     def test_module_load_callee_is_a_root(
         self, memgraph_ingestor: MemgraphIngestor
     ) -> None:
@@ -479,6 +518,7 @@ class TestBuildDeadCodeQueryIntegration:
             "project_prefix": "proj.",
             "root_decorators": [],
             "entry_points": [],
+            "test_patterns": ["test_", "_test", "conftest", "/tests/"],
         }
 
         results = memgraph_ingestor._execute_query(

--- a/codebase_rag/tests/integration/test_cypher_queries.py
+++ b/codebase_rag/tests/integration/test_cypher_queries.py
@@ -362,14 +362,21 @@ class TestBuildDeadCodeQueryUnit:
         assert "$test_patterns" not in query
         assert "$project_prefix" in query
 
+    def test_module_load_callees_are_roots(self) -> None:
+        query = build_dead_code_query(include_tests=False)
+
+        # (H) a function called by a Module node runs at import, so it is a root
+        assert "Module" in query
+        assert "CALLS]-(" in query or "]-(:Module" in query
+
 
 @pytest.mark.integration
 class TestBuildDeadCodeQueryIntegration:
     def _seed(self, ingestor: MemgraphIngestor) -> None:
-        # called -> live; orphan -> dead; handler is a @task root;
-        # routed is a @app.route root calling routed_callee (decorators are
-        # stored @-prefixed and dotted, exactly as the parser emits them);
-        # test_runs is a test root that calls helper (so helper is live)
+        # (H) called -> live; orphan -> dead; handler is a @task root;
+        # (H) routed is a @app.route root calling routed_callee (decorators are
+        # (H) stored @-prefixed and dotted, exactly as the parser emits them);
+        # (H) test_runs is a test root that calls helper (so helper is live)
         ingestor._execute_query(
             "CREATE "
             "(m:Module {qualified_name: 'proj.mod', path: 'proj/mod.py'}), "
@@ -429,7 +436,7 @@ class TestBuildDeadCodeQueryIntegration:
         )
 
         names = {r["qualified_name"] for r in results}
-        # without test roots, the test fn and its helper are no longer reachable
+        # (H) without test roots, the test fn and its helper are no longer reachable
         assert names == {
             "proj.mod.orphan",
             "proj.tests.test_runs",
@@ -449,6 +456,37 @@ class TestBuildDeadCodeQueryIntegration:
         assert row["name"] == "orphan"
         assert row["start_line"] == 9
         assert row["end_line"] == 11
+
+    def test_module_load_callee_is_a_root(
+        self, memgraph_ingestor: MemgraphIngestor
+    ) -> None:
+        # (H) a function called by a Module (e.g. `if __name__ == "__main__": main()`
+        # (H) or a bare decorator) runs at import, so it and its callees are live even
+        # (H) with no entry-point/decorator/export root.
+        memgraph_ingestor._execute_query(
+            "CREATE "
+            "(m:Module {qualified_name: 'proj.mod', path: 'proj/mod.py'}), "
+            "(main:Function {qualified_name: 'proj.mod.main', name: 'main', "
+            "  start_line: 1, end_line: 2, decorators: [], path: 'proj/mod.py'}), "
+            "(used:Function {qualified_name: 'proj.mod.used', name: 'used', "
+            "  start_line: 4, end_line: 5, decorators: [], path: 'proj/mod.py'}), "
+            "(orphan:Function {qualified_name: 'proj.mod.orphan', name: 'orphan', "
+            "  start_line: 7, end_line: 8, decorators: [], path: 'proj/mod.py'}), "
+            "(m)-[:CALLS]->(main), "
+            "(main)-[:CALLS]->(used)"
+        )
+        params: dict[str, PropertyValue] = {
+            "project_prefix": "proj.",
+            "root_decorators": [],
+            "entry_points": [],
+        }
+
+        results = memgraph_ingestor._execute_query(
+            build_dead_code_query(include_tests=False), params
+        )
+        names = {r["qualified_name"] for r in results}
+
+        assert names == {"proj.mod.orphan"}
 
 
 @pytest.mark.integration

--- a/codebase_rag/tests/test_dead_code_command.py
+++ b/codebase_rag/tests/test_dead_code_command.py
@@ -198,5 +198,7 @@ class TestDeadCodeCommand:
 
         assert result.exit_code == 0
         query, params = mock_ingestor.fetch_all.call_args.args
-        assert "test_patterns" not in params
-        assert "$test_patterns" not in query
+        # (H) test_patterns is still passed (it filters test modules out of the
+        # (H) module-load roots), but test functions themselves are not roots.
+        assert "test_patterns" in params
+        assert "n.path CONTAINS" not in query


### PR DESCRIPTION
## What

Makes `cgr dead-code` treat **module-load callees** as reachability roots. A function/method called by a `Module` node runs when the module is imported — `if __name__ == "__main__": main()`, top-level calls, and bare-decorator applications — so it (and everything it transitively calls) is live.

One clause added to `build_dead_code_query`:

```cypher
OR exists((n)<-[:CALLS]-(:Module))
```

## Why

This is the payoff of the call-graph work in #535 (module-level call attribution) and #540 (decorator edges). Together they fix the two false positives the command shipped with:

- **`__main__` entry points**: `main()` invoked under `if __name__ == "__main__"` is a module-load call, so `main` and its callees are no longer reported dead.
- **Decorator definitions**: a function used only as `@deco` is called at module load, so the decorator function is no longer reported dead.

## End-to-end

Indexed a fixture with both patterns and ran `cgr dead-code`:

```
Dead Code Candidates
  Function  app.handler   (defined + decorated but never called)
  Function  app.orphan    (never referenced)
```

Only genuinely-unused functions are flagged; `main` (via `__main__`) and the decorator function are correctly live.

## Tests

- Unit: the query contains the module-load root clause.
- Integration (real Memgraph): a function reachable only via a `(:Module)-[:CALLS]->` edge — with no entry-point/decorator/export root — is not reported dead; its callees are live; a true orphan still is.
- 42 dead-code + cypher tests pass; ruff + ty + `check_no_docs` clean.
