### PR TITLE
feat(cli): validate --repo-path exists, is a directory, and warn if not a git repo

### DIFF
--- a/codebase_rag/cli.py
+++ b/codebase_rag/cli.py
@@ -261,6 +261,25 @@ def _delete_hash_cache(repo_path: Path) -> None:
     dir_mtimes_path.unlink(missing_ok=True)
 
 
+def _resolve_and_validate_repo(repo_path: str | None) -> Path:
+    resolved = resolve_repo_path(repo_path, settings.TARGET_REPO_PATH)
+    if not resolved.exists():
+        app_context.console.print(
+            style(cs.CLI_ERR_PATH_NOT_EXISTS.format(path=resolved), cs.Color.RED)
+        )
+        raise typer.Exit(1)
+    if not resolved.is_dir():
+        app_context.console.print(
+            style(cs.CLI_ERR_PATH_NOT_DIR.format(path=resolved), cs.Color.RED)
+        )
+        raise typer.Exit(1)
+    if not (resolved / cs.GIT_DIR_NAME).is_dir():
+        app_context.console.print(
+            style(cs.CLI_WARN_NOT_GIT_REPO.format(path=resolved), cs.Color.YELLOW)
+        )
+    return resolved
+
+
 def _cleanup_project_embeddings(ingestor: MemgraphIngestor, project_name: str) -> None:
     rows = ingestor.fetch_all(
         cs.CYPHER_QUERY_PROJECT_NODE_IDS,
@@ -366,7 +385,7 @@ def start(
     app_context.session.confirm_edits = not no_confirm
     app_context.session.load_cgr_instructions = not no_instructions
 
-    resolved_repo = resolve_repo_path(repo_path, settings.TARGET_REPO_PATH)
+    resolved_repo = _resolve_and_validate_repo(repo_path)
     target_repo_path = str(resolved_repo)
     resolved_project_name = project_name or derive_project_name(resolved_repo)
 
@@ -499,7 +518,7 @@ def index(
         help=ch.HELP_INTERACTIVE_SETUP,
     ),
 ) -> None:
-    repo_to_index = resolve_repo_path(repo_path, settings.TARGET_REPO_PATH)
+    repo_to_index = _resolve_and_validate_repo(repo_path)
     _info(style(cs.CLI_MSG_INDEXING_AT.format(path=repo_to_index), cs.Color.GREEN))
 
     _info(style(cs.CLI_MSG_OUTPUT_TO.format(path=output_proto_dir), cs.Color.CYAN))
@@ -619,7 +638,7 @@ def optimize(
     app_context.session.confirm_edits = not no_confirm
     app_context.session.load_cgr_instructions = not no_instructions
 
-    target_repo_path = str(resolve_repo_path(repo_path, settings.TARGET_REPO_PATH))
+    target_repo_path = str(_resolve_and_validate_repo(repo_path))
 
     _update_and_validate_models(orchestrator, cypher)
 

--- a/codebase_rag/cli.py
+++ b/codebase_rag/cli.py
@@ -273,7 +273,7 @@ def _resolve_and_validate_repo(repo_path: str | None) -> Path:
             style(cs.CLI_ERR_PATH_NOT_DIR.format(path=resolved), cs.Color.RED)
         )
         raise typer.Exit(1)
-    if not (resolved / cs.GIT_DIR_NAME).is_dir():
+    if not (resolved / cs.GIT_DIR_NAME).exists():
         app_context.console.print(
             style(cs.CLI_WARN_NOT_GIT_REPO.format(path=resolved), cs.Color.YELLOW)
         )

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -237,6 +237,9 @@ CLI_ERR_OUTPUT_REQUIRES_UPDATE = (
     "Error: --output/-o option requires --update-graph to be specified."
 )
 CLI_ERR_ONLY_JSON = "Error: Currently only JSON format is supported."
+CLI_ERR_PATH_NOT_EXISTS = "Error: --repo-path does not exist: {path}"
+CLI_ERR_PATH_NOT_DIR = "Error: --repo-path is not a directory: {path}"
+CLI_WARN_NOT_GIT_REPO = "Warning: --repo-path is not a Git repository: {path}"
 CLI_ERR_STARTUP = "Startup Error: {error}"
 CLI_ERR_CONFIG = "Configuration Error: {error}"
 CLI_ERR_INDEXING = "An error occurred during indexing: {error}"
@@ -1868,6 +1871,7 @@ GEMFILE_GEM_PREFIX = "gem "
 # (H) Incremental update hash cache
 HASH_CACHE_FILENAME = ".cgr-hash-cache.json"
 DIR_MTIMES_FILENAME = ".cgr-dir-mtimes.json"
+GIT_DIR_NAME = ".git"
 ROOT_DIR_KEY = "."
 JSON_EMPTY_OBJECT = "{}"
 

--- a/codebase_rag/tests/test_cli_repo_path_validation.py
+++ b/codebase_rag/tests/test_cli_repo_path_validation.py
@@ -76,6 +76,16 @@ class TestStartRepoPathValidation:
         assert result.exit_code == 0, result.output
         assert "not a Git repository" not in result.output
 
+    def test_git_file_worktree_does_not_warn(
+        self, mock_memgraph_connect: MagicMock, tmp_path: Path
+    ) -> None:
+        # (H) worktrees and submodules use a .git file, not a directory
+        (tmp_path / cs.GIT_DIR_NAME).write_text("gitdir: /repo/.git/worktrees/wt\n")
+        result = runner.invoke(app, ["start", "--clean", "--repo-path", str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        assert "not a Git repository" not in result.output
+
 
 class TestIndexRepoPathValidation:
     def test_index_nonexistent_path_exits_with_error(self, tmp_path: Path) -> None:

--- a/codebase_rag/tests/test_cli_repo_path_validation.py
+++ b/codebase_rag/tests/test_cli_repo_path_validation.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from codebase_rag import constants as cs
+from codebase_rag.cli import app
+
+runner = CliRunner()
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _plain(output: str) -> str:
+    # (H) ANSI-stripped output with Rich soft-wrap newlines rejoined
+    return _ANSI.sub("", output).replace("\n", "")
+
+
+@pytest.fixture
+def mock_memgraph_connect() -> Generator[MagicMock, None, None]:
+    with (
+        patch("codebase_rag.cli.connect_memgraph") as mock_connect,
+        patch("codebase_rag.cli._maybe_start_stack"),
+    ):
+        mock_ingestor = MagicMock()
+        mock_connect.return_value.__enter__ = MagicMock(return_value=mock_ingestor)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+        yield mock_connect
+
+
+class TestStartRepoPathValidation:
+    def test_nonexistent_path_exits_with_error(
+        self, mock_memgraph_connect: MagicMock, tmp_path: Path
+    ) -> None:
+        missing = tmp_path / "does_not_exist"
+        result = runner.invoke(app, ["start", "--clean", "--repo-path", str(missing)])
+
+        assert result.exit_code == 1, result.output
+        plain = _plain(result.output)
+        assert str(missing) in plain
+        assert "does not exist" in plain
+
+    def test_file_path_exits_with_error(
+        self, mock_memgraph_connect: MagicMock, tmp_path: Path
+    ) -> None:
+        file_path = tmp_path / "a_file.txt"
+        file_path.write_text("not a directory")
+        result = runner.invoke(app, ["start", "--clean", "--repo-path", str(file_path)])
+
+        assert result.exit_code == 1, result.output
+        plain = _plain(result.output)
+        assert str(file_path) in plain
+        assert "not a directory" in plain
+
+    def test_valid_non_git_dir_warns_but_proceeds(
+        self, mock_memgraph_connect: MagicMock, tmp_path: Path
+    ) -> None:
+        result = runner.invoke(app, ["start", "--clean", "--repo-path", str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        plain = _plain(result.output)
+        assert "not a Git repository" in plain
+        assert str(tmp_path) in plain
+
+    def test_git_dir_does_not_warn(
+        self, mock_memgraph_connect: MagicMock, tmp_path: Path
+    ) -> None:
+        (tmp_path / cs.GIT_DIR_NAME).mkdir()
+        result = runner.invoke(app, ["start", "--clean", "--repo-path", str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        assert "not a Git repository" not in result.output
+
+
+class TestIndexRepoPathValidation:
+    def test_index_nonexistent_path_exits_with_error(self, tmp_path: Path) -> None:
+        missing = tmp_path / "nope"
+        result = runner.invoke(
+            app,
+            [
+                "index",
+                "--repo-path",
+                str(missing),
+                "-o",
+                str(tmp_path / "out"),
+            ],
+        )
+
+        assert result.exit_code == 1, result.output
+        assert "does not exist" in _plain(result.output)


### PR DESCRIPTION
Closes #240.

## Problem

The CLI `--repo-path` option was resolved by `resolve_repo_path()` with no validation: a nonexistent path, or a path pointing at a file, was accepted silently. For `start --clean` this meant proceeding to wipe the database against an invalid target. The MCP server already validated (`mcp/server.py`), but the CLI did not.

## Change

Added `_resolve_and_validate_repo()` in `codebase_rag/cli.py`, wired into all three `--repo-path` call sites (`start`, `index`, `optimize`):

- exits `1` with a clear error if the path does not exist
- exits `1` if the path is not a directory (e.g. a file)
- prints a warning if the path is not a Git repository (no `.git`), but proceeds

New message constants in `constants.py` (`CLI_ERR_PATH_NOT_EXISTS`, `CLI_ERR_PATH_NOT_DIR`, `CLI_WARN_NOT_GIT_REPO`, `GIT_DIR_NAME`).

## Tests

`codebase_rag/tests/test_cli_repo_path_validation.py` (TDD, RED first): nonexistent path exits 1, file path exits 1, non-git dir warns but proceeds, git dir is silent, and the `index` command shares the same validation.

Full suite: 4120 passed, 26 skipped.
