### PR TITLE
feat(cli): add --output-format json to wrap single-query agent output

### DIFF
--- a/codebase_rag/cli.py
+++ b/codebase_rag/cli.py
@@ -390,6 +390,12 @@ def start(
     app_context.session.confirm_edits = not no_confirm
     app_context.session.load_cgr_instructions = not no_instructions
 
+    if output_format == cs.QueryFormat.JSON and not ask_agent:
+        app_context.console.print(
+            style(cs.CLI_ERR_JSON_REQUIRES_ASK_AGENT, cs.Color.RED)
+        )
+        raise typer.Exit(1)
+
     resolved_repo = _resolve_and_validate_repo(repo_path)
     target_repo_path = str(resolved_repo)
     resolved_project_name = project_name or derive_project_name(resolved_repo)

--- a/codebase_rag/cli.py
+++ b/codebase_rag/cli.py
@@ -361,6 +361,11 @@ def start(
         "--ask-agent",
         help=ch.HELP_ASK_AGENT,
     ),
+    output_format: cs.QueryFormat = typer.Option(
+        cs.QueryFormat.TABLE,
+        "--output-format",
+        help=ch.HELP_QUERY_OUTPUT_FORMAT,
+    ),
     no_start_stack: bool = typer.Option(
         False,
         "--no-start-stack",
@@ -471,6 +476,7 @@ def start(
                 effective_batch_size,
                 ask_agent,
                 active_projects=active_projects,
+                output_format=output_format,
             )
         else:
             asyncio.run(

--- a/codebase_rag/cli_help.py
+++ b/codebase_rag/cli_help.py
@@ -166,6 +166,11 @@ HELP_ASK_AGENT = (
     "Output is sent to stdout, useful for scripting."
 )
 
+HELP_QUERY_OUTPUT_FORMAT = (
+    "Output format for --ask-agent: 'table' (default) prints the plain answer; "
+    '\'json\' wraps it as {"query": ..., "response": ...} for scripting.'
+)
+
 HELP_MCP_TRANSPORT = "Transport mode: 'stdio' (default) or 'http'"
 HELP_MCP_HTTP_HOST = (
     "Host to bind the HTTP server — only used when --transport http (default: 0.0.0.0)"

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -185,6 +185,8 @@ KEY_EXPORTED_AT = "exported_at"
 KEY_PARSER = "parser"
 KEY_NAME = "name"
 KEY_QUALIFIED_NAME = "qualified_name"
+KEY_QUERY = "query"
+KEY_RESPONSE = "response"
 KEY_START_LINE = "start_line"
 KEY_END_LINE = "end_line"
 KEY_PATH = "path"
@@ -401,6 +403,11 @@ class UniqueKeyType(StrEnum):
 
 
 class DeadCodeFormat(StrEnum):
+    TABLE = "table"
+    JSON = "json"
+
+
+class QueryFormat(StrEnum):
     TABLE = "table"
     JSON = "json"
 

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -239,6 +239,10 @@ CLI_ERR_OUTPUT_REQUIRES_UPDATE = (
     "Error: --output/-o option requires --update-graph to be specified."
 )
 CLI_ERR_ONLY_JSON = "Error: Currently only JSON format is supported."
+CLI_ERR_JSON_REQUIRES_ASK_AGENT = (
+    "Error: --output-format json requires --ask-agent/-a; "
+    "it only applies to single-query output."
+)
 CLI_ERR_PATH_NOT_EXISTS = "Error: --repo-path does not exist: {path}"
 CLI_ERR_PATH_NOT_DIR = "Error: --repo-path is not a directory: {path}"
 CLI_WARN_NOT_GIT_REPO = "Warning: --repo-path is not a Git repository: {path}"

--- a/codebase_rag/main.py
+++ b/codebase_rag/main.py
@@ -74,6 +74,7 @@ from .types_defs import (
     ConfirmationToolNames,
     CreateFileArgs,
     GraphData,
+    QueryJsonOutput,
     RawToolArgs,
     ReplaceCodeArgs,
     ShellCommandArgs,
@@ -1576,6 +1577,7 @@ def main_single_query(
     batch_size: int,
     question: str,
     active_projects: list[str] | None = None,
+    output_format: cs.QueryFormat = cs.QueryFormat.TABLE,
 ) -> None:
     _setup_common_initialization(repo_path)
     # (H) Override logger to stderr so stdout is clean for scripted output
@@ -1587,7 +1589,11 @@ def main_single_query(
             repo_path, ingestor, active_projects=active_projects
         )
         response = asyncio.run(rag_agent.run(question, message_history=[]))
-        print(response.output)  # noqa: T201
+        if output_format == cs.QueryFormat.JSON:
+            payload = QueryJsonOutput(query=question, response=str(response.output))
+            print(json.dumps(payload))  # noqa: T201
+        else:
+            print(response.output)  # noqa: T201
 
 
 async def main_async(

--- a/codebase_rag/main.py
+++ b/codebase_rag/main.py
@@ -1591,7 +1591,7 @@ def main_single_query(
         response = asyncio.run(rag_agent.run(question, message_history=[]))
         if output_format == cs.QueryFormat.JSON:
             payload = QueryJsonOutput(query=question, response=str(response.output))
-            print(json.dumps(payload))  # noqa: T201
+            print(json.dumps(payload, ensure_ascii=False))  # noqa: T201
         else:
             print(response.output)  # noqa: T201
 

--- a/codebase_rag/tests/test_single_query_output_format.py
+++ b/codebase_rag/tests/test_single_query_output_format.py
@@ -1,16 +1,28 @@
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from typer.testing import CliRunner
 
 from codebase_rag import constants as cs
+from codebase_rag.cli import app
 from codebase_rag.main import main_single_query
 
 _QUESTION = "What does the parser do?"
 _ANSWER = "The parser builds a knowledge graph."
+
+runner = CliRunner()
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _plain(output: str) -> str:
+    # (H) ANSI-stripped output with Rich soft-wrap newlines rejoined
+    return _ANSI.sub("", output).replace("\n", "")
 
 
 @pytest.fixture
@@ -46,3 +58,34 @@ def test_json_format_wraps_query_and_response(
 
     payload = json.loads(capsys.readouterr().out)
     assert payload == {cs.KEY_QUERY: _QUESTION, cs.KEY_RESPONSE: _ANSWER}
+
+
+def test_json_format_preserves_non_ascii(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    answer = "Le générateur résout les nœuds — déjà"
+    agent = MagicMock()
+    agent.run = AsyncMock(return_value=MagicMock(output=answer))
+    with (
+        patch("codebase_rag.main._setup_common_initialization"),
+        patch("codebase_rag.main.connect_memgraph") as mock_connect,
+        patch(
+            "codebase_rag.main._initialize_services_and_agent",
+            return_value=(agent, [], ""),
+        ),
+    ):
+        mock_connect.return_value.__enter__ = MagicMock(return_value=MagicMock())
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+        main_single_query("/repo", 100, _QUESTION, output_format=cs.QueryFormat.JSON)
+
+    raw = capsys.readouterr().out
+    assert answer in raw
+    assert "\\u" not in raw
+    assert json.loads(raw)[cs.KEY_RESPONSE] == answer
+
+
+def test_json_format_without_ask_agent_exits_with_error() -> None:
+    result = runner.invoke(app, ["start", "--output-format", "json"])
+
+    assert result.exit_code == 1, result.output
+    assert "ask-agent" in _plain(result.output)

--- a/codebase_rag/tests/test_single_query_output_format.py
+++ b/codebase_rag/tests/test_single_query_output_format.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.main import main_single_query
+
+_QUESTION = "What does the parser do?"
+_ANSWER = "The parser builds a knowledge graph."
+
+
+@pytest.fixture
+def mock_agent_stack() -> Generator[MagicMock, None, None]:
+    agent = MagicMock()
+    agent.run = AsyncMock(return_value=MagicMock(output=_ANSWER))
+    with (
+        patch("codebase_rag.main._setup_common_initialization"),
+        patch("codebase_rag.main.connect_memgraph") as mock_connect,
+        patch(
+            "codebase_rag.main._initialize_services_and_agent",
+            return_value=(agent, [], ""),
+        ),
+    ):
+        mock_connect.return_value.__enter__ = MagicMock(return_value=MagicMock())
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+        yield agent
+
+
+def test_default_format_prints_plain_text(
+    mock_agent_stack: MagicMock, capsys: pytest.CaptureFixture[str]
+) -> None:
+    main_single_query("/repo", 100, _QUESTION)
+
+    out = capsys.readouterr().out.strip()
+    assert out == _ANSWER
+
+
+def test_json_format_wraps_query_and_response(
+    mock_agent_stack: MagicMock, capsys: pytest.CaptureFixture[str]
+) -> None:
+    main_single_query("/repo", 100, _QUESTION, output_format=cs.QueryFormat.JSON)
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {cs.KEY_QUERY: _QUESTION, cs.KEY_RESPONSE: _ANSWER}

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -210,6 +210,11 @@ class GraphSummary(TypedDict):
     metadata: GraphMetadata
 
 
+class QueryJsonOutput(TypedDict):
+    query: str
+    response: str
+
+
 class EmbeddingQueryResult(TypedDict):
     node_id: int
     qualified_name: str


### PR DESCRIPTION
Closes #250 (reframed scope).

## What

Adds a `--output-format table|json` option to the `start` command's single-query path (`-a/--ask-agent`). Default `table` keeps the current plain-text behavior; `json` wraps the agent answer so it can be piped into `jq`:

```
cgr start -a "What does the parser do?" --output-format json
{"query": "What does the parser do?", "response": "...agent answer..."}
```

Logs already go to stderr, so stdout stays clean for scripting.

## Why this scope

The original issue asked for row-structured `{query, results[], count}` JSON. cgr's query path is agentic (an LLM RAG agent returns free-form text), not a row query engine, so row-shaped results don't map onto the architecture. Export to JSON already exists (`cgr export`). The achievable, useful piece is wrapping the single-query answer as JSON, mirroring the existing `dead-code --format table|json` precedent.

## Changes

- `constants.py`: `QueryFormat` StrEnum + `KEY_QUERY`/`KEY_RESPONSE`
- `types_defs.py`: `QueryJsonOutput` TypedDict
- `cli_help.py`: help text for the new option
- `main.py`: `main_single_query` emits JSON when requested
- `cli.py`: `--output-format` option on `start`
- Tests: TDD coverage for default-text and JSON wrapping