### PR TITLE
perf(query): reuse Memgraph connection in semantic search tools (#505)

### DIFF
--- a/codebase_rag/main.py
+++ b/codebase_rag/main.py
@@ -1544,8 +1544,8 @@ def _initialize_services_and_agent(
     file_editor_tool = create_file_editor_tool(file_editor)
     shell_command_tool = create_shell_command_tool(shell_commander)
     directory_lister_tool = create_directory_lister_tool(directory_lister)
-    semantic_search_tool = create_semantic_search_tool()
-    function_source_tool = create_get_function_source_tool()
+    semantic_search_tool = create_semantic_search_tool(ingestor)
+    function_source_tool = create_get_function_source_tool(ingestor)
 
     confirmation_tool_names = ConfirmationToolNames(
         replace_code=file_editor_tool.name,

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -93,7 +93,7 @@ class MCPToolsRegistry:
                 create_semantic_search_tool,
             )
 
-            self._semantic_search_tool = create_semantic_search_tool()
+            self._semantic_search_tool = create_semantic_search_tool(self.ingestor)
             self._semantic_search_available = True
         else:
             logger.info(lg.MCP_SEMANTIC_NOT_AVAILABLE)
@@ -344,7 +344,7 @@ class MCPToolsRegistry:
                 self._file_editor_tool,
                 self._shell_command_tool,
                 self._directory_lister_tool,
-                create_get_function_source_tool(),
+                create_get_function_source_tool(self.ingestor),
             ]
             if self._semantic_search_tool is not None:
                 tools.append(self._semantic_search_tool)

--- a/codebase_rag/tests/test_semantic_search.py
+++ b/codebase_rag/tests/test_semantic_search.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from codebase_rag import constants as cs
 from codebase_rag.utils.dependencies import has_semantic_dependencies
 
 
@@ -90,6 +91,28 @@ def test_semantic_code_search_reuses_injected_ingestor(
     ingestor._execute_query.assert_not_called()
     assert [r["qualified_name"] for r in results] == ["pkg.mod.foo", "pkg.mod.Bar"]
     assert results[0]["score"] == 0.99
+
+
+@patch("codebase_rag.tools.semantic_search.has_semantic_dependencies", return_value=True)
+@patch("codebase_rag.vector_store.search_embeddings")
+@patch("codebase_rag.embedder.embed_code")
+def test_semantic_code_search_tolerates_missing_result_fields(
+    mock_embed: MagicMock, mock_search: MagicMock, _deps: MagicMock
+) -> None:
+    from codebase_rag.tools.semantic_search import semantic_code_search
+
+    mock_embed.return_value = [0.0]
+    mock_search.return_value = [(1, 0.99)]
+
+    ingestor = MagicMock()
+    ingestor.fetch_all.return_value = [{"node_id": 1}]
+
+    results = semantic_code_search(ingestor, "find foo", top_k=1)
+
+    assert len(results) == 1
+    assert results[0]["qualified_name"] == ""
+    assert results[0]["name"] == ""
+    assert results[0]["type"] == cs.SEMANTIC_TYPE_UNKNOWN
 
 
 @pytest.mark.skipif(

--- a/codebase_rag/tests/test_semantic_search.py
+++ b/codebase_rag/tests/test_semantic_search.py
@@ -24,9 +24,7 @@ def mock_search_embeddings() -> MagicMock:
 @pytest.fixture
 def mock_ingestor() -> MagicMock:
     mock = MagicMock()
-    mock.__enter__ = MagicMock(return_value=mock)
-    mock.__exit__ = MagicMock(return_value=False)
-    mock._execute_query.return_value = [
+    mock.fetch_all.return_value = [
         {
             "node_id": 1,
             "qualified_name": "project.module.func1",
@@ -55,8 +53,43 @@ def test_semantic_code_search_returns_empty_without_dependencies() -> None:
 
     from codebase_rag.tools.semantic_search import semantic_code_search
 
-    results = semantic_code_search("find error handlers")
+    results = semantic_code_search(MagicMock(), "find error handlers")
     assert results == []
+
+
+@patch("codebase_rag.tools.semantic_search.has_semantic_dependencies", return_value=True)
+@patch("codebase_rag.vector_store.search_embeddings")
+@patch("codebase_rag.embedder.embed_code")
+def test_semantic_code_search_reuses_injected_ingestor(
+    mock_embed: MagicMock, mock_search: MagicMock, _deps: MagicMock
+) -> None:
+    from codebase_rag.tools.semantic_search import semantic_code_search
+
+    mock_embed.return_value = [0.0]
+    mock_search.return_value = [(1, 0.99), (2, 0.42)]
+
+    ingestor = MagicMock()
+    ingestor.fetch_all.return_value = [
+        {
+            "node_id": 1,
+            "qualified_name": "pkg.mod.foo",
+            "name": "foo",
+            "type": ["Function"],
+        },
+        {
+            "node_id": 2,
+            "qualified_name": "pkg.mod.Bar",
+            "name": "Bar",
+            "type": ["Class"],
+        },
+    ]
+
+    results = semantic_code_search(ingestor, "find the foo function", top_k=2)
+
+    ingestor.fetch_all.assert_called_once()
+    ingestor._execute_query.assert_not_called()
+    assert [r["qualified_name"] for r in results] == ["pkg.mod.foo", "pkg.mod.Bar"]
+    assert results[0]["score"] == 0.99
 
 
 @pytest.mark.skipif(
@@ -72,12 +105,10 @@ def test_semantic_code_search_returns_formatted_results(
     with (
         patch("codebase_rag.embedder.embed_code", mock_embed_code),
         patch("codebase_rag.vector_store.search_embeddings", mock_search_embeddings),
-        patch(
-            "codebase_rag.services.graph_service.MemgraphIngestor",
-            return_value=mock_ingestor,
-        ),
     ):
-        results = semantic_code_search("find authentication code", top_k=3)
+        results = semantic_code_search(
+            mock_ingestor, "find authentication code", top_k=3
+        )
 
     assert len(results) == 3
     assert results[0]["node_id"] == 1
@@ -99,12 +130,8 @@ def test_semantic_code_search_calls_embed_code_with_query(
     with (
         patch("codebase_rag.embedder.embed_code", mock_embed_code),
         patch("codebase_rag.vector_store.search_embeddings", mock_search_embeddings),
-        patch(
-            "codebase_rag.services.graph_service.MemgraphIngestor",
-            return_value=mock_ingestor,
-        ),
     ):
-        semantic_code_search("database operations")
+        semantic_code_search(mock_ingestor, "database operations")
 
     mock_embed_code.assert_called_once_with("database operations")
 
@@ -122,12 +149,8 @@ def test_semantic_code_search_passes_top_k_to_search(
     with (
         patch("codebase_rag.embedder.embed_code", mock_embed_code),
         patch("codebase_rag.vector_store.search_embeddings", mock_search_embeddings),
-        patch(
-            "codebase_rag.services.graph_service.MemgraphIngestor",
-            return_value=mock_ingestor,
-        ),
     ):
-        semantic_code_search("file handling", top_k=10)
+        semantic_code_search(mock_ingestor, "file handling", top_k=10)
 
     mock_search_embeddings.assert_called_once_with([0.1] * 768, top_k=10)
 
@@ -146,7 +169,7 @@ def test_semantic_code_search_returns_empty_when_no_matches(
         patch("codebase_rag.embedder.embed_code", mock_embed_code),
         patch("codebase_rag.vector_store.search_embeddings", mock_search_empty),
     ):
-        results = semantic_code_search("nonexistent functionality")
+        results = semantic_code_search(MagicMock(), "nonexistent functionality")
 
     assert results == []
 
@@ -160,7 +183,7 @@ def test_semantic_code_search_handles_exception(mock_embed_code: MagicMock) -> N
     mock_embed_code.side_effect = Exception("Embedding failed")
 
     with patch("codebase_rag.embedder.embed_code", mock_embed_code):
-        results = semantic_code_search("some query")
+        results = semantic_code_search(MagicMock(), "some query")
 
     assert results == []
 
@@ -179,12 +202,8 @@ def test_semantic_code_search_preserves_score_order(
     with (
         patch("codebase_rag.embedder.embed_code", mock_embed_code),
         patch("codebase_rag.vector_store.search_embeddings", mock_search),
-        patch(
-            "codebase_rag.services.graph_service.MemgraphIngestor",
-            return_value=mock_ingestor,
-        ),
     ):
-        results = semantic_code_search("test query")
+        results = semantic_code_search(mock_ingestor, "test query")
 
     assert results[0]["node_id"] == 3
     assert results[0]["score"] == 0.99
@@ -198,7 +217,7 @@ def test_semantic_code_search_preserves_score_order(
 def test_get_function_source_code_returns_source(mock_ingestor: MagicMock) -> None:
     from codebase_rag.tools.semantic_search import get_function_source_code
 
-    mock_ingestor._execute_query.return_value = [
+    mock_ingestor.fetch_all.return_value = [
         {
             "qualified_name": "project.module.func",
             "start_line": 10,
@@ -212,10 +231,6 @@ def test_get_function_source_code_returns_source(mock_ingestor: MagicMock) -> No
 
     with (
         patch(
-            "codebase_rag.services.graph_service.MemgraphIngestor",
-            return_value=mock_ingestor,
-        ),
-        patch(
             "codebase_rag.utils.source_extraction.validate_source_location",
             mock_validate,
         ),
@@ -223,7 +238,7 @@ def test_get_function_source_code_returns_source(mock_ingestor: MagicMock) -> No
             "codebase_rag.utils.source_extraction.extract_source_lines", mock_extract
         ),
     ):
-        result = get_function_source_code(123)
+        result = get_function_source_code(mock_ingestor, 123)
 
     assert result == "def func():\n    return 42"
 
@@ -236,13 +251,9 @@ def test_get_function_source_code_returns_none_when_not_found(
 ) -> None:
     from codebase_rag.tools.semantic_search import get_function_source_code
 
-    mock_ingestor._execute_query.return_value = []
+    mock_ingestor.fetch_all.return_value = []
 
-    with patch(
-        "codebase_rag.services.graph_service.MemgraphIngestor",
-        return_value=mock_ingestor,
-    ):
-        result = get_function_source_code(999)
+    result = get_function_source_code(mock_ingestor, 999)
 
     assert result is None
 
@@ -255,7 +266,7 @@ def test_get_function_source_code_returns_none_on_invalid_location(
 ) -> None:
     from codebase_rag.tools.semantic_search import get_function_source_code
 
-    mock_ingestor._execute_query.return_value = [
+    mock_ingestor.fetch_all.return_value = [
         {
             "qualified_name": "project.module.func",
             "start_line": None,
@@ -266,17 +277,11 @@ def test_get_function_source_code_returns_none_on_invalid_location(
 
     mock_validate = MagicMock(return_value=(False, None))
 
-    with (
-        patch(
-            "codebase_rag.services.graph_service.MemgraphIngestor",
-            return_value=mock_ingestor,
-        ),
-        patch(
-            "codebase_rag.utils.source_extraction.validate_source_location",
-            mock_validate,
-        ),
+    with patch(
+        "codebase_rag.utils.source_extraction.validate_source_location",
+        mock_validate,
     ):
-        result = get_function_source_code(123)
+        result = get_function_source_code(mock_ingestor, 123)
 
     assert result is None
 
@@ -287,13 +292,9 @@ def test_get_function_source_code_returns_none_on_invalid_location(
 def test_get_function_source_code_handles_exception(mock_ingestor: MagicMock) -> None:
     from codebase_rag.tools.semantic_search import get_function_source_code
 
-    mock_ingestor._execute_query.side_effect = Exception("Database error")
+    mock_ingestor.fetch_all.side_effect = Exception("Database error")
 
-    with patch(
-        "codebase_rag.services.graph_service.MemgraphIngestor",
-        return_value=mock_ingestor,
-    ):
-        result = get_function_source_code(123)
+    result = get_function_source_code(mock_ingestor, 123)
 
     assert result is None
 
@@ -301,13 +302,13 @@ def test_get_function_source_code_handles_exception(mock_ingestor: MagicMock) ->
 @pytest.mark.skipif(
     not has_semantic_dependencies(), reason="semantic dependencies not installed"
 )
-def test_create_semantic_search_tool_returns_tool() -> None:
+def test_create_semantic_search_tool_returns_tool(mock_ingestor: MagicMock) -> None:
     from pydantic_ai import Tool
 
     from codebase_rag.tools.semantic_search import create_semantic_search_tool
     from codebase_rag.tools.tool_descriptions import AgenticToolName
 
-    tool = create_semantic_search_tool()
+    tool = create_semantic_search_tool(mock_ingestor)
 
     assert isinstance(tool, Tool)
     assert tool.name == AgenticToolName.SEMANTIC_SEARCH
@@ -316,13 +317,13 @@ def test_create_semantic_search_tool_returns_tool() -> None:
 @pytest.mark.skipif(
     not has_semantic_dependencies(), reason="semantic dependencies not installed"
 )
-def test_create_get_function_source_tool_returns_tool() -> None:
+def test_create_get_function_source_tool_returns_tool(mock_ingestor: MagicMock) -> None:
     from pydantic_ai import Tool
 
     from codebase_rag.tools.semantic_search import create_get_function_source_tool
     from codebase_rag.tools.tool_descriptions import AgenticToolName
 
-    tool = create_get_function_source_tool()
+    tool = create_get_function_source_tool(mock_ingestor)
 
     assert isinstance(tool, Tool)
     assert tool.name == AgenticToolName.GET_FUNCTION_SOURCE
@@ -339,15 +340,11 @@ async def test_semantic_search_tool_formats_results(
 ) -> None:
     from codebase_rag.tools.semantic_search import create_semantic_search_tool
 
-    tool = create_semantic_search_tool()
+    tool = create_semantic_search_tool(mock_ingestor)
 
     with (
         patch("codebase_rag.embedder.embed_code", mock_embed_code),
         patch("codebase_rag.vector_store.search_embeddings", mock_search_embeddings),
-        patch(
-            "codebase_rag.services.graph_service.MemgraphIngestor",
-            return_value=mock_ingestor,
-        ),
     ):
         result = await tool.function("find handlers")
 
@@ -367,7 +364,7 @@ async def test_semantic_search_tool_handles_no_results(
     from codebase_rag.tools.semantic_search import create_semantic_search_tool
 
     mock_search_empty = MagicMock(return_value=[])
-    tool = create_semantic_search_tool()
+    tool = create_semantic_search_tool(MagicMock())
 
     with (
         patch("codebase_rag.embedder.embed_code", mock_embed_code),
@@ -387,7 +384,7 @@ async def test_get_function_source_tool_returns_source(
 ) -> None:
     from codebase_rag.tools.semantic_search import create_get_function_source_tool
 
-    mock_ingestor._execute_query.return_value = [
+    mock_ingestor.fetch_all.return_value = [
         {
             "qualified_name": "project.func",
             "start_line": 1,
@@ -399,13 +396,9 @@ async def test_get_function_source_tool_returns_source(
     mock_validate = MagicMock(return_value=(True, MagicMock()))
     mock_extract = MagicMock(return_value="def func(): pass")
 
-    tool = create_get_function_source_tool()
+    tool = create_get_function_source_tool(mock_ingestor)
 
     with (
-        patch(
-            "codebase_rag.services.graph_service.MemgraphIngestor",
-            return_value=mock_ingestor,
-        ),
         patch(
             "codebase_rag.utils.source_extraction.validate_source_location",
             mock_validate,
@@ -429,14 +422,10 @@ async def test_get_function_source_tool_handles_not_found(
 ) -> None:
     from codebase_rag.tools.semantic_search import create_get_function_source_tool
 
-    mock_ingestor._execute_query.return_value = []
+    mock_ingestor.fetch_all.return_value = []
 
-    tool = create_get_function_source_tool()
+    tool = create_get_function_source_tool(mock_ingestor)
 
-    with patch(
-        "codebase_rag.services.graph_service.MemgraphIngestor",
-        return_value=mock_ingestor,
-    ):
-        result = await tool.function(999)
+    result = await tool.function(999)
 
     assert "Could not retrieve source code" in result

--- a/codebase_rag/tools/semantic_search.py
+++ b/codebase_rag/tools/semantic_search.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 
 from loguru import logger
@@ -17,11 +18,11 @@ from ..utils.dependencies import has_semantic_dependencies
 from . import tool_descriptions as td
 
 if TYPE_CHECKING:
-    from ..services.graph_service import MemgraphIngestor
+    from ..services import QueryProtocol
 
 
 def semantic_code_search(
-    ingestor: MemgraphIngestor, query: str, top_k: int = 5
+    ingestor: QueryProtocol, query: str, top_k: int = 5
 ) -> list[SemanticSearchResult]:
     if not has_semantic_dependencies():
         logger.warning(ex.SEMANTIC_EXTRA)
@@ -45,13 +46,17 @@ def semantic_code_search(
         params = {str(i): node_id for i, node_id in enumerate(node_ids)}
         results = ingestor.fetch_all(cypher_query, params)
 
-        results_map = {res["node_id"]: res for res in results}
+        results_map = {
+            node_id: res
+            for res in results
+            if isinstance((node_id := res.get("node_id")), int)
+        }
 
         formatted_results: list[SemanticSearchResult] = []
         for node_id, score in search_results:
             if node_id in results_map:
                 result = results_map[node_id]
-                result_type = result["type"]
+                result_type = result.get("type")
                 type_str = (
                     result_type[0]
                     if isinstance(result_type, list) and result_type
@@ -60,8 +65,8 @@ def semantic_code_search(
                 formatted_results.append(
                     SemanticSearchResult(
                         node_id=node_id,
-                        qualified_name=str(result["qualified_name"]),
-                        name=str(result["name"]),
+                        qualified_name=str(result.get("qualified_name", "")),
+                        name=str(result.get("name", "")),
                         type=type_str,
                         score=round(score, 3),
                     )
@@ -77,7 +82,7 @@ def semantic_code_search(
         return []
 
 
-def get_function_source_code(ingestor: MemgraphIngestor, node_id: int) -> str | None:
+def get_function_source_code(ingestor: QueryProtocol, node_id: int) -> str | None:
     try:
         from ..utils.source_extraction import (
             extract_source_lines,
@@ -111,11 +116,13 @@ def get_function_source_code(ingestor: MemgraphIngestor, node_id: int) -> str | 
         return None
 
 
-def create_semantic_search_tool(ingestor: MemgraphIngestor) -> Tool:
+def create_semantic_search_tool(ingestor: QueryProtocol) -> Tool:
     async def semantic_search_functions(query: str, top_k: int = 5) -> str:
         logger.info(ls.SEMANTIC_TOOL_SEARCH.format(query=query))
 
-        results = semantic_code_search(ingestor, query, top_k)
+        results = await asyncio.to_thread(
+            semantic_code_search, ingestor, query, top_k
+        )
 
         if not results:
             return cs.MSG_SEMANTIC_NO_RESULTS.format(query=query)
@@ -139,11 +146,13 @@ def create_semantic_search_tool(ingestor: MemgraphIngestor) -> Tool:
     )
 
 
-def create_get_function_source_tool(ingestor: MemgraphIngestor) -> Tool:
+def create_get_function_source_tool(ingestor: QueryProtocol) -> Tool:
     async def get_function_source_by_id(node_id: int) -> str:
         logger.info(ls.SEMANTIC_TOOL_SOURCE.format(id=node_id))
 
-        source_code = get_function_source_code(ingestor, node_id)
+        source_code = await asyncio.to_thread(
+            get_function_source_code, ingestor, node_id
+        )
 
         if source_code is None:
             return cs.MSG_SEMANTIC_SOURCE_UNAVAILABLE.format(id=node_id)

--- a/codebase_rag/tools/semantic_search.py
+++ b/codebase_rag/tools/semantic_search.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from loguru import logger
 from pydantic_ai import Tool
 
@@ -14,16 +16,19 @@ from ..types_defs import SemanticSearchResult
 from ..utils.dependencies import has_semantic_dependencies
 from . import tool_descriptions as td
 
+if TYPE_CHECKING:
+    from ..services.graph_service import MemgraphIngestor
 
-def semantic_code_search(query: str, top_k: int = 5) -> list[SemanticSearchResult]:
+
+def semantic_code_search(
+    ingestor: MemgraphIngestor, query: str, top_k: int = 5
+) -> list[SemanticSearchResult]:
     if not has_semantic_dependencies():
         logger.warning(ex.SEMANTIC_EXTRA)
         return []
 
     try:
-        from ..config import settings
         from ..embedder import embed_code
-        from ..services.graph_service import MemgraphIngestor
         from ..vector_store import search_embeddings
 
         query_embedding = embed_code(query)
@@ -36,93 +41,81 @@ def semantic_code_search(query: str, top_k: int = 5) -> list[SemanticSearchResul
 
         node_ids = [node_id for node_id, _ in search_results]
 
-        with MemgraphIngestor(
-            host=settings.MEMGRAPH_HOST,
-            port=settings.MEMGRAPH_PORT,
-            batch_size=cs.SEMANTIC_BATCH_SIZE,
-        ) as ingestor:
-            cypher_query = build_nodes_by_ids_query(node_ids)
-            params = {str(i): node_id for i, node_id in enumerate(node_ids)}
-            results = ingestor._execute_query(cypher_query, params)
+        cypher_query = build_nodes_by_ids_query(node_ids)
+        params = {str(i): node_id for i, node_id in enumerate(node_ids)}
+        results = ingestor.fetch_all(cypher_query, params)
 
-            results_map = {res["node_id"]: res for res in results}
+        results_map = {res["node_id"]: res for res in results}
 
-            formatted_results: list[SemanticSearchResult] = []
-            for node_id, score in search_results:
-                if node_id in results_map:
-                    result = results_map[node_id]
-                    result_type = result["type"]
-                    type_str = (
-                        result_type[0]
-                        if isinstance(result_type, list) and result_type
-                        else cs.SEMANTIC_TYPE_UNKNOWN
+        formatted_results: list[SemanticSearchResult] = []
+        for node_id, score in search_results:
+            if node_id in results_map:
+                result = results_map[node_id]
+                result_type = result["type"]
+                type_str = (
+                    result_type[0]
+                    if isinstance(result_type, list) and result_type
+                    else cs.SEMANTIC_TYPE_UNKNOWN
+                )
+                formatted_results.append(
+                    SemanticSearchResult(
+                        node_id=node_id,
+                        qualified_name=str(result["qualified_name"]),
+                        name=str(result["name"]),
+                        type=type_str,
+                        score=round(score, 3),
                     )
-                    formatted_results.append(
-                        SemanticSearchResult(
-                            node_id=node_id,
-                            qualified_name=str(result["qualified_name"]),
-                            name=str(result["name"]),
-                            type=type_str,
-                            score=round(score, 3),
-                        )
-                    )
+                )
 
-            logger.info(
-                ls.SEMANTIC_FOUND.format(count=len(formatted_results), query=query)
-            )
-            return formatted_results
+        logger.info(
+            ls.SEMANTIC_FOUND.format(count=len(formatted_results), query=query)
+        )
+        return formatted_results
 
     except Exception as e:
         logger.error(ls.SEMANTIC_FAILED.format(query=query, error=e))
         return []
 
 
-def get_function_source_code(node_id: int) -> str | None:
+def get_function_source_code(ingestor: MemgraphIngestor, node_id: int) -> str | None:
     try:
-        from ..config import settings
-        from ..services.graph_service import MemgraphIngestor
         from ..utils.source_extraction import (
             extract_source_lines,
             validate_source_location,
         )
 
-        with MemgraphIngestor(
-            host=settings.MEMGRAPH_HOST,
-            port=settings.MEMGRAPH_PORT,
-            batch_size=cs.SEMANTIC_BATCH_SIZE,
-        ) as ingestor:
-            results = ingestor._execute_query(
-                CYPHER_GET_FUNCTION_SOURCE_LOCATION, {"node_id": node_id}
-            )
+        results = ingestor.fetch_all(
+            CYPHER_GET_FUNCTION_SOURCE_LOCATION, {"node_id": node_id}
+        )
 
-            if not results:
-                logger.warning(ls.SEMANTIC_NODE_NOT_FOUND.format(id=node_id))
-                return None
+        if not results:
+            logger.warning(ls.SEMANTIC_NODE_NOT_FOUND.format(id=node_id))
+            return None
 
-            result = results[0]
-            file_path = result.get("path")
-            start_line = result.get("start_line")
-            end_line = result.get("end_line")
+        result = results[0]
+        file_path = result.get("path")
+        start_line = result.get("start_line")
+        end_line = result.get("end_line")
 
-            is_valid, file_path_obj = validate_source_location(
-                file_path, start_line, end_line
-            )
-            if not is_valid or file_path_obj is None:
-                logger.warning(ls.SEMANTIC_INVALID_LOCATION.format(id=node_id))
-                return None
+        is_valid, file_path_obj = validate_source_location(
+            file_path, start_line, end_line
+        )
+        if not is_valid or file_path_obj is None:
+            logger.warning(ls.SEMANTIC_INVALID_LOCATION.format(id=node_id))
+            return None
 
-            return extract_source_lines(file_path_obj, start_line, end_line)
+        return extract_source_lines(file_path_obj, start_line, end_line)
 
     except Exception as e:
         logger.error(ls.SEMANTIC_SOURCE_FAILED.format(id=node_id, error=e))
         return None
 
 
-def create_semantic_search_tool() -> Tool:
+def create_semantic_search_tool(ingestor: MemgraphIngestor) -> Tool:
     async def semantic_search_functions(query: str, top_k: int = 5) -> str:
         logger.info(ls.SEMANTIC_TOOL_SEARCH.format(query=query))
 
-        results = semantic_code_search(query, top_k)
+        results = semantic_code_search(ingestor, query, top_k)
 
         if not results:
             return cs.MSG_SEMANTIC_NO_RESULTS.format(query=query)
@@ -146,11 +139,11 @@ def create_semantic_search_tool() -> Tool:
     )
 
 
-def create_get_function_source_tool() -> Tool:
+def create_get_function_source_tool(ingestor: MemgraphIngestor) -> Tool:
     async def get_function_source_by_id(node_id: int) -> str:
         logger.info(ls.SEMANTIC_TOOL_SOURCE.format(id=node_id))
 
-        source_code = get_function_source_code(node_id)
+        source_code = get_function_source_code(ingestor, node_id)
 
         if source_code is None:
             return cs.MSG_SEMANTIC_SOURCE_UNAVAILABLE.format(id=node_id)


### PR DESCRIPTION
## Summary

- Reuse the orchestrator's existing `MemgraphIngestor` in `semantic_code_search` and `get_function_source_code` instead of opening a new Memgraph connection on every call.
- Switch the private `ingestor._execute_query()` calls to the public `fetch_all()` API.
- Thread the ingestor through the `create_semantic_search_tool` / `create_get_function_source_tool` factories and their call sites in `main.py` and `mcp/tools.py`. Behavior is unchanged — `fetch_all(query, params)` is the public wrapper around `_execute_query(query, params)`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD or tooling
- [ ] Dependencies

## Related Issues

Closes #505

## Test Plan

- Added `test_semantic_code_search_reuses_injected_ingestor`, which asserts the injected ingestor's `fetch_all()` is called and `_execute_query()` is never called — a regression guard against re-introducing a per-call connection.
- Migrated the existing `test_semantic_search.py` suite to pass a mock ingestor directly rather than patching `MemgraphIngestor`.
- Ran `uv run pytest -m "not integration"` locally: all 4019 non-integration tests pass. The only failures are the Java-oracle tests (`test_java_*_oracle.py`), which shell out to `javac` and fail solely because a JDK isn't installed in my local environment — unrelated to this change.