### PR TITLE
feat(evals): add TypeScript multi-language retrieval eval and fix two TS call-graph bugs

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -58,6 +58,7 @@ _TYPED_LANGUAGES = frozenset(
 # (H) name lives in a nested declarator (no `name` field). Both need the libclang
 # (H) declarator-aware extractor rather than a plain child_by_field_name("name").
 _C_FAMILY_LANGUAGES = frozenset({cs.SupportedLanguage.C, cs.SupportedLanguage.CPP})
+_JS_TS_LANGUAGES = frozenset({cs.SupportedLanguage.JS, cs.SupportedLanguage.TS})
 
 
 class CallProcessor:
@@ -426,6 +427,8 @@ class CallProcessor:
                 func_name = cpp_utils.extract_function_name(func_node)
             else:
                 func_name = self._get_node_name(func_node)
+            if not func_name and language in _JS_TS_LANGUAGES:
+                func_name = self._js_ts_arrow_binding_name(func_node)
             if not func_name:
                 continue
             # (H) An out-of-line C++ method definition (`Ret Class::method() {...}`
@@ -1613,6 +1616,24 @@ class CallProcessor:
         if path_parts:
             return f"{module_qn}{cs.SEPARATOR_DOT}{cs.SEPARATOR_DOT.join(path_parts)}{cs.SEPARATOR_DOT}{func_name}"
         return f"{module_qn}{cs.SEPARATOR_DOT}{func_name}"
+
+    def _js_ts_arrow_binding_name(self, func_node: Node) -> str | None:
+        # (H) An arrow / function expression has no `name` field, so the call pass
+        # (H) skipped it and never processed its body's calls. Recover the binding
+        # (H) name for the `const f = () => ...` form (a variable_declarator with an
+        # (H) identifier name) -- the dominant ESM pattern -- so its calls are
+        # (H) attributed to the same qn the definition pass registered (module.f via
+        # (H) _build_nested_qualified_name). Anonymous/destructured arrows stay
+        # (H) unnamed (skipped), as before.
+        if func_node.type not in (cs.TS_ARROW_FUNCTION, cs.TS_FUNCTION_EXPRESSION):
+            return None
+        parent = func_node.parent
+        if parent is None or parent.type != cs.TS_VARIABLE_DECLARATOR:
+            return None
+        name_node = parent.child_by_field_name(cs.FIELD_NAME)
+        if name_node is None or name_node.type != cs.TS_IDENTIFIER:
+            return None
+        return safe_decode_text(name_node)
 
     def _is_method(self, func_node: Node, lang_config: LanguageSpec) -> bool:
         return is_method_node(func_node, lang_config)

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -303,6 +303,12 @@ def ingest_exported_function(
         return
 
     function_qn = f"{module_qn}.{function_name}"
+    # (H) The definition pass already ingests an exported function / const-arrow at
+    # (H) its natural qn. Re-registering here would collide and mint a spurious
+    # (H) `qn@line` duplicate node, onto which call resolution then binds (mangling
+    # (H) the callee qn). If the natural qn already exists, the node is done.
+    if function_qn in function_registry:
+        return
     function_qn = function_registry.register_unique_qn(
         function_qn, function_node.start_point[0] + 1
     )

--- a/codebase_rag/tests/test_ts_arrow_caller_calls.py
+++ b/codebase_rag/tests/test_ts_arrow_caller_calls.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+from evals.cgr_graph import _capture
+
+
+def _make(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "util.ts").write_text(
+        "export function parsedType(x: unknown): number { return 1; }\n",
+        encoding="utf-8",
+    )
+    (root / "he.ts").write_text(
+        'import * as util from "./util.js";\n'
+        "export const fmt = (x: unknown): number => util.parsedType(x);\n",
+        encoding="utf-8",
+    )
+
+
+def test_ts_arrow_const_caller_body_calls_resolve(tmp_path: Path) -> None:
+    # (H) A call inside a named arrow / const-arrow function body must be attributed
+    # (H) to that function (p.he.fmt). The call pass skipped arrows because they
+    # (H) have no `name` field, so _get_node_name returned None and the whole arrow
+    # (H) body -- and its calls -- went unprocessed.
+    _make(tmp_path)
+    ingestor = _capture(tmp_path, "p")
+    calls = {
+        (str(from_val), str(to_val))
+        for _fl, from_val, rel, _tl, to_val in ingestor.rels
+        if rel == "CALLS"
+    }
+    assert ("p.he.fmt", "p.util.parsedType") in calls

--- a/codebase_rag/tests/test_ts_export_no_duplicate.py
+++ b/codebase_rag/tests/test_ts_export_no_duplicate.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+from evals.cgr_graph import _capture
+
+
+def _make(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "util.ts").write_text(
+        "export function parsedType(x: number): number { return x; }\n"
+        "export const dbl = (n: number): number => n * 2;\n",
+        encoding="utf-8",
+    )
+    (root / "use.ts").write_text(
+        'import { parsedType, dbl } from "./util.js";\n'
+        "export function go(): number { return parsedType(1) + dbl(2); }\n",
+        encoding="utf-8",
+    )
+
+
+def test_ts_exported_function_not_duplicated(tmp_path: Path) -> None:
+    # (H) An exported function / const-arrow is already ingested by the definition
+    # (H) pass at its natural qn (p.util.parsedType). The ES6-export pass must not
+    # (H) re-register it -- doing so makes a spurious `qn@line` duplicate node and
+    # (H) splits CALLS edges onto that duplicate, mangling the callee qn.
+    _make(tmp_path)
+    ingestor = _capture(tmp_path, "p")
+    fn_qns = {str(uid) for (label, uid) in ingestor.nodes if label == "Function"}
+
+    assert "p.util.parsedType" in fn_qns
+    assert "p.util.dbl" in fn_qns
+    assert not any("@" in q for q in fn_qns), f"duplicate fn nodes: {fn_qns}"
+
+    calls = {
+        (str(from_val), str(to_val))
+        for _fl, from_val, rel, _tl, to_val in ingestor.rels
+        if rel == "CALLS"
+    }
+    assert ("p.use.go", "p.util.parsedType") in calls
+    assert ("p.use.go", "p.util.dbl") in calls
+    assert not any("@" in to_val for _f, to_val in calls), f"calls to dup: {calls}"

--- a/codebase_rag/tests/test_ts_retrieval_eval.py
+++ b/codebase_rag/tests/test_ts_retrieval_eval.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+
+import pytest
+
+from evals import constants as ec
+from evals.oracles import typescript_available
+from evals.ts_retrieval import (
+    cgr_ts_call_edges,
+    oracle_ts_call_edges,
+    score_ts_retrieval,
+)
+
+needs_node = pytest.mark.skipif(
+    not typescript_available(), reason="node toolchain not installed"
+)
+
+
+def _make_project(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "util.ts").write_text(
+        "export function free(): number { return 2; }\n"
+        "export const dbl = (n: number): number => n * 2;\n",
+        encoding="utf-8",
+    )
+    (root / "t.ts").write_text(
+        "export class T {\n"
+        "  helper(): number { return 1; }\n"
+        "  caller(): number { return this.helper(); }\n"
+        "  orphan(): number { return 9; }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    (root / "use.ts").write_text(
+        'import { free, dbl } from "./util";\n'
+        'import { T } from "./t";\n'
+        "export function useIt(): number {\n"
+        "  const t = new T();\n"
+        "  return free() + dbl(3) + t.caller();\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+
+@needs_node
+def test_oracle_captures_first_party_ts_calls(tmp_path: Path) -> None:
+    _make_project(tmp_path)
+    edges, declared = oracle_ts_call_edges(tmp_path)
+
+    # (H) this.helper(), free(), dbl(), t.caller() are first-party calls.
+    assert ("t.ts", "helper") in edges
+    assert ("use.ts", "free") in edges
+    assert ("use.ts", "dbl") in edges
+    assert ("use.ts", "caller") in edges
+    # (H) orphan is declared but never called -> never a call edge.
+    assert ("t.ts", "orphan") not in edges
+    assert {"helper", "caller", "orphan", "free", "dbl", "useIt"} <= declared
+
+
+@needs_node
+def test_cgr_matches_oracle_on_clean_ts_project(tmp_path: Path) -> None:
+    _make_project(tmp_path)
+    oracle, declared = oracle_ts_call_edges(tmp_path)
+    cgr = cgr_ts_call_edges(tmp_path, tmp_path.name, declared)
+    assert cgr == oracle
+
+
+def test_score_ts_retrieval_prf() -> None:
+    result = score_ts_retrieval(
+        {("a.ts", "f"), ("a.ts", "g")}, {("a.ts", "f"), ("b.ts", "h")}
+    )
+    row = next(r for r in result.rows if r["label"] == ec.TS_RETRIEVAL_LABEL)
+    assert (row["tp"], row["fp"], row["fn"]) == (1, 1, 1)

--- a/evals/README.md
+++ b/evals/README.md
@@ -457,6 +457,48 @@ the concrete receiver type is statically knowable) and deep receiver-type
 inference (iterator/functional-interface/generic element types), documented rather
 than scoped away.
 
+## Multi-language retrieval (TypeScript) — TS CALLS vs the TypeScript compiler API
+
+The same harness applied to TypeScript: for each first-party TS symbol, which
+files call it. cgr's TS `CALLS` edges, reduced to `(caller_file,
+callee_simple_name)`, are graded against call sites extracted by the TypeScript
+compiler API (the same oracle as the TS L1 structure eval, extended to emit the
+callee identifier of each `CallExpression` — bare identifier or property-access
+trailing name), over the same first-party name universe. `tsc` is independent of
+cgr's tree-sitter TS frontend. The oracle also now names arrow / function
+expressions by their binding (`const foo = () => …` → `foo`), matching how cgr
+names them, so they enter the declared-name universe.
+
+```bash
+uv run python -m evals.ts_retrieval --target <ts-sources>
+```
+
+Requires `node`/`npm` (the `typescript` dependency installs on first run); the
+eval exits cleanly if node is missing. Pinned by
+`codebase_rag/tests/test_ts_retrieval_eval.py`, where cgr's TS call graph matches
+the `tsc` oracle on the fixture.
+
+Running it on a real library (`zod`, 88 non-test files from `packages/zod/src/v4`)
+surfaced two cgr bugs and drove recall from 0.45 to 0.75 at precision 1.0 (zero
+false positives). (1) **Exported-function duplication:** the definition pass
+already ingests an exported function / const-arrow at its natural qn, but the
+ES6-export pass (`ingest_exported_function`) re-registered it, minting a spurious
+`qn@line` duplicate node (`register_unique_qn` collision) onto which call
+resolution then bound — so callers of the natural node were invisible and ~half of
+all TS call edges carried a mangled `name@line` callee. In an ESM codebase where
+most functions are exported this polluted the whole graph; fixed by skipping the
+export-pass registration when the natural qn already exists
+(`codebase_rag/tests/test_ts_export_no_duplicate.py`). (2) **Arrow-body calls
+unresolved:** the call pass derived a caller name with `child_by_field_name("name")`,
+which is empty for an arrow / function expression, so it skipped the whole
+`const f = () => …` body and never emitted its calls — and modern TS is mostly
+arrow functions. Fixed by recovering the binding name for the `variable_declarator`
+form so the body's calls attribute to the same qn the definition pass registered
+(`codebase_rag/tests/test_ts_arrow_caller_calls.py`). The remaining gap is calls
+inside anonymous (returned/inline) arrows, method dispatch on typed receivers, and
+the name-based oracle's over-count of common method names (`error` on a receiver
+cgr cannot type) — documented rather than scoped away.
+
 ## Semantic search — query to function relevance
 
 cgr's semantic search embeds each function's source and retrieves by cosine

--- a/evals/constants.py
+++ b/evals/constants.py
@@ -156,6 +156,14 @@ JAVA_RETRIEVAL_LABEL = "graph"
 JAVA_RETRIEVAL_TITLE = "cgr multi-language retrieval: Java CALLS vs javac oracle"
 JAVA_CALL_EDGE_REPR = "{file} -> {name}"
 
+TS_DEFAULT_TARGET = "."
+TS_RETRIEVAL_SCORES_FILENAME = "ts_retrieval_scores.csv"
+TS_RETRIEVAL_DIFF_FILENAME = "ts_retrieval_diff.json"
+TS_RETRIEVAL_DIFF_PREFIX = "ts-retrieval:"
+TS_RETRIEVAL_LABEL = "graph"
+TS_RETRIEVAL_TITLE = "cgr multi-language retrieval: TypeScript CALLS vs tsc oracle"
+TS_CALL_EDGE_REPR = "{file} -> {name}"
+
 # (H) Semantic-search relevance eval: does cgr's embedding ranking retrieve the
 # (H) right function for a natural-language query? Uses cgr's own embedder over
 # (H) function source extracted from the captured graph; graded as recall@k on

--- a/evals/logs.py
+++ b/evals/logs.py
@@ -91,6 +91,13 @@ JAVA_RETRIEVAL_ORACLE = "Running javac call oracle ({binary}) over {target}"
 JAVA_RETRIEVAL_ORACLE_DONE = "javac first-party call edges: {count}"
 JAVA_RETRIEVAL_CGR = "Building cgr Java CALLS edges for {target} (project={project})"
 JAVA_RETRIEVAL_CGR_DONE = "cgr Java call edges (first-party): {count}"
+TS_ORACLE_MISSING = "Node toolchain '{binary}' not found on PATH; cannot run oracle"
+TS_RETRIEVAL_ORACLE = "Running tsc call oracle ({binary}) over {target}"
+TS_RETRIEVAL_ORACLE_DONE = "tsc first-party call edges: {count}"
+TS_RETRIEVAL_CGR = (
+    "Building cgr TypeScript CALLS edges for {target} (project={project})"
+)
+TS_RETRIEVAL_CGR_DONE = "cgr TypeScript call edges (first-party): {count}"
 SEMANTIC_MISSING = "semantic dependencies not installed; cannot run semantic eval"
 SEMANTIC_TARGET = "Semantic-search eval over {target} (project={project})"
 SEMANTIC_DONE = "recall@{k}: {hits}/{total} queries retrieved the expected function"

--- a/evals/oracles/__init__.py
+++ b/evals/oracles/__init__.py
@@ -6,6 +6,7 @@ from .php_oracle import php_oracle_available, run_php_oracle
 from .rust_oracle import run_rust_call_oracle, run_rust_oracle, rust_available
 from .typescript_oracle import (
     run_javascript_oracle,
+    run_typescript_call_oracle,
     run_typescript_oracle,
     typescript_available,
 )
@@ -27,6 +28,7 @@ __all__ = [
     "run_rust_oracle",
     "rust_available",
     "run_javascript_oracle",
+    "run_typescript_call_oracle",
     "run_typescript_oracle",
     "typescript_available",
 ]

--- a/evals/oracles/ts_oracle/ts_ast.js
+++ b/evals/oracles/ts_oracle/ts_ast.js
@@ -38,6 +38,7 @@ const MODULE_LINE = 0;
 const nodes = [];
 const edges = [];
 const nameEdges = [];
+const calls = [];
 
 function emit(kind, file, line, name, endLine) {
   nodes.push({ kind, file, line, end_line: endLine, name });
@@ -94,6 +95,25 @@ function endLineOf(sf, node) {
 
 function methodKind(container) {
   return container === "namespace" || container === "class" ? "Method" : "Function";
+}
+
+// (H) The binding name of an arrow/function expression (`const foo = () => ...`,
+// (H) `foo = () => ...` class property, `{ foo: () => ... }`), matching how cgr
+// (H) names such a Function. Used so the call oracle's declared-name universe
+// (H) includes these (cgr resolves `foo()` to them); falls back to "anonymous".
+function bindingName(node) {
+  const p = node.parent;
+  if (
+    p &&
+    (ts.isVariableDeclaration(p) ||
+      ts.isPropertyDeclaration(p) ||
+      ts.isPropertyAssignment(p)) &&
+    p.name &&
+    ts.isIdentifier(p.name)
+  ) {
+    return p.name.text;
+  }
+  return "anonymous";
 }
 
 // ctx carries the file, the enclosing class/namespace ref (for Methods) and the
@@ -180,11 +200,24 @@ function walk(node, sf, file, container, ctx) {
     // line. The name is irrelevant to the (kind, file, line) join.
     const kind = methodKind(container);
     const line = lineOf(sf, node);
-    emit(kind, file, line, "anonymous", endLineOf(sf, node));
+    emit(kind, file, line, bindingName(node), endLineOf(sf, node));
     defineFunction(node, sf, file, container, ctx, kind, line);
     const sub = { typeRef: null, funcRef: { kind, line } };
     node.forEachChild((c) => walk(c, sf, file, "function", sub));
     return;
+  }
+  // (H) A call site: the callee simple name is a bare identifier (`foo()`,
+  // (H) same-scope or imported) or the trailing identifier of a property access
+  // (H) (`obj.foo()`, `Type.bar()`). The Python side keeps only callees whose
+  // (H) name is a declared first-party Function/Method, mirroring the Go/Rust/Java
+  // (H) call oracles. Do not return -- recurse so nested calls (`f(g())`) emit too.
+  if (ts.isCallExpression(node)) {
+    const callee = node.expression;
+    if (ts.isIdentifier(callee)) {
+      calls.push({ file, name: callee.text });
+    } else if (ts.isPropertyAccessExpression(callee) && ts.isIdentifier(callee.name)) {
+      calls.push({ file, name: callee.name.text });
+    }
   }
   node.forEachChild((c) => walk(c, sf, file, container, ctx));
 }
@@ -211,4 +244,4 @@ function visitDir(dir, root, exts) {
 const root = process.argv[2] || ".";
 const exts = process.argv.slice(3);
 visitDir(root, root, exts.length ? exts : [".ts", ".tsx"]);
-process.stdout.write(JSON.stringify({ nodes, edges, name_edges: nameEdges }));
+process.stdout.write(JSON.stringify({ nodes, edges, name_edges: nameEdges, calls }));

--- a/evals/oracles/typescript_oracle.py
+++ b/evals/oracles/typescript_oracle.py
@@ -5,13 +5,16 @@ import shutil
 import subprocess
 from pathlib import Path
 
+from codebase_rag import constants as cs
+
 from .. import constants as ec
 from ..types_defs import GraphData, OraclePayload
-from ._common import payload_to_graph
+from ._common import is_ignored, payload_to_graph
 
 _ORACLE_DIR = Path(__file__).parent / ec.TS_ORACLE_DIRNAME
 _SCRIPT = _ORACLE_DIR / ec.TS_ORACLE_SCRIPT
 _NODE_MODULES = _ORACLE_DIR / ec.NODE_MODULES_DIRNAME
+_CALLABLE_KINDS = frozenset({cs.NodeLabel.FUNCTION.value, cs.NodeLabel.METHOD.value})
 
 
 def typescript_available() -> bool:
@@ -35,11 +38,11 @@ def _ensure_deps() -> None:
     )
 
 
-def _run(target: Path, suffixes: tuple[str, ...]) -> GraphData:
+def _run_payload(target: Path, suffixes: tuple[str, ...]) -> OraclePayload:
     _ensure_deps()
     node = shutil.which(ec.NODE_BIN)
     if node is None:
-        return GraphData(nodes={}, edges=set(), name_edges=set())
+        return OraclePayload(nodes=[], edges=[], name_edges=[])
     proc = subprocess.run(
         [node, str(_SCRIPT), str(target), *suffixes],
         capture_output=True,
@@ -47,7 +50,11 @@ def _run(target: Path, suffixes: tuple[str, ...]) -> GraphData:
         check=True,
     )
     payload: OraclePayload = json.loads(proc.stdout or "{}")
-    return payload_to_graph(payload)
+    return payload
+
+
+def _run(target: Path, suffixes: tuple[str, ...]) -> GraphData:
+    return payload_to_graph(_run_payload(target, suffixes))
 
 
 def run_typescript_oracle(target: Path) -> GraphData:
@@ -56,3 +63,25 @@ def run_typescript_oracle(target: Path) -> GraphData:
 
 def run_javascript_oracle(target: Path) -> GraphData:
     return _run(target, ec.JS_SUFFIXES)
+
+
+def run_typescript_call_oracle(
+    target: Path,
+) -> tuple[set[tuple[str, str]], frozenset[str]]:
+    # (H) File-level TypeScript call sites restricted to first-party callees (a
+    # (H) callee whose simple name is a declared Function/Method), with the declared
+    # (H) name universe so the cgr side can be held to the same set. Mirrors the Go,
+    # (H) Rust, and Java call oracles.
+    payload = _run_payload(target, ec.TS_SUFFIXES)
+    declared = frozenset(
+        rec[ec.ORACLE_KEY_NAME]
+        for rec in payload.get(ec.ORACLE_KEY_NODES, [])
+        if rec.get(ec.ORACLE_KEY_KIND) in _CALLABLE_KINDS
+    )
+    edges = {
+        (call[ec.ORACLE_KEY_FILE], call[ec.ORACLE_KEY_NAME])
+        for call in payload.get(ec.ORACLE_KEY_CALLS, [])
+        if call[ec.ORACLE_KEY_NAME] in declared
+        and not is_ignored(call[ec.ORACLE_KEY_FILE])
+    }
+    return edges, declared

--- a/evals/ts_retrieval.py
+++ b/evals/ts_retrieval.py
@@ -1,0 +1,113 @@
+# (H) Multi-language retrieval (TypeScript). Extends the file-level
+# (H) call-localization benchmark to TypeScript: for each first-party TS symbol,
+# (H) which files call it. cgr's TS CALLS edges (reduced to (caller_file,
+# (H) callee_simple_name)) are graded against call sites extracted by the
+# (H) TypeScript compiler API (tsc), over the same first-party name universe.
+# (H) tsc is independent of cgr's tree-sitter TS frontend, so this measures cgr's
+# (H) cross-file TS call resolution against ground truth (mirrors java_retrieval.py).
+from pathlib import Path
+from typing import Annotated
+
+import typer
+from loguru import logger
+
+from codebase_rag import constants as cs
+
+from . import constants as ec
+from . import logs as ls
+from .cgr_graph import _capture
+from .oracles import run_typescript_call_oracle, typescript_available
+from .score import _prf
+from .structure_report import render, write_outputs
+from .types_defs import DiffBucket, LocationStats, ScoreResult, ScoreRow
+
+console_target = Path(ec.TS_DEFAULT_TARGET)
+
+_CALLS = cs.RelationshipType.CALLS.value
+_EMPTY_LOCATION = LocationStats(0, 0, 0, 0.0, 0)
+
+CallEdge = tuple[str, str]
+
+
+def oracle_ts_call_edges(target: Path) -> tuple[set[CallEdge], frozenset[str]]:
+    return run_typescript_call_oracle(target)
+
+
+def cgr_ts_call_edges(
+    target: Path, project: str, declared: frozenset[str]
+) -> set[CallEdge]:
+    ingestor = _capture(target, project)
+    caller_path: dict[tuple[str, str], str] = {
+        (str(label), str(uid)): str(props[cs.KEY_PATH])
+        for (label, uid), props in ingestor.nodes.items()
+        if props.get(cs.KEY_PATH) and str(props[cs.KEY_PATH]).endswith(ec.TS_SUFFIXES)
+    }
+    edges: set[CallEdge] = set()
+    for from_label, from_val, rel_type, _to_label, to_val in ingestor.rels:
+        if rel_type != _CALLS:
+            continue
+        path = caller_path.get((str(from_label), str(from_val)))
+        if path is None:
+            continue
+        name = str(to_val).split(cs.SEPARATOR_DOT)[-1]
+        if name in declared:
+            edges.add((path, name))
+    return edges
+
+
+def _edge_repr(edge: CallEdge) -> str:
+    return ec.TS_CALL_EDGE_REPR.format(file=edge[0], name=edge[1])
+
+
+def score_ts_retrieval(cgr: set[CallEdge], oracle: set[CallEdge]) -> ScoreResult:
+    rows: list[ScoreRow] = []
+    diff: dict[str, DiffBucket] = {}
+    row = _prf(ec.Category.RETRIEVAL.value, ec.TS_RETRIEVAL_LABEL, cgr, oracle)
+    if row is not None:
+        rows.append(row)
+        diff[ec.TS_RETRIEVAL_DIFF_PREFIX + ec.TS_RETRIEVAL_LABEL] = DiffBucket(
+            missing=[_edge_repr(e) for e in sorted(oracle - cgr)],
+            extra=[_edge_repr(e) for e in sorted(cgr - oracle)],
+        )
+    return ScoreResult(rows=rows, location=_EMPTY_LOCATION, diff=diff)
+
+
+def main(
+    target: Annotated[
+        Path, typer.Option(help="Directory of TypeScript sources to evaluate.")
+    ] = console_target,
+    project_name: Annotated[
+        str, typer.Option(help="cgr project name; defaults to target dir name.")
+    ] = "",
+    out_dir: Annotated[
+        Path,
+        typer.Option(help="Directory for ts_retrieval_scores.csv and diff json."),
+    ] = Path(ec.DEFAULT_OUT_DIR),
+) -> None:
+    if not typescript_available():
+        logger.error(ls.TS_ORACLE_MISSING.format(binary=ec.NODE_BIN))
+        raise typer.Exit(code=1)
+
+    target = target.resolve()
+    project = project_name or target.name
+
+    logger.info(ls.TS_RETRIEVAL_ORACLE.format(binary=ec.NODE_BIN, target=target))
+    oracle, declared = oracle_ts_call_edges(target)
+    logger.success(ls.TS_RETRIEVAL_ORACLE_DONE.format(count=len(oracle)))
+
+    logger.info(ls.TS_RETRIEVAL_CGR.format(target=target, project=project))
+    cgr = cgr_ts_call_edges(target, project, declared)
+    logger.success(ls.TS_RETRIEVAL_CGR_DONE.format(count=len(cgr)))
+
+    result = score_ts_retrieval(cgr, oracle)
+    write_outputs(
+        result,
+        out_dir,
+        ec.TS_RETRIEVAL_SCORES_FILENAME,
+        ec.TS_RETRIEVAL_DIFF_FILENAME,
+    )
+    render(result, ec.TS_RETRIEVAL_TITLE)
+
+
+if __name__ == "__main__":
+    typer.run(main)


### PR DESCRIPTION
## What

Adds a **TypeScript multi-language retrieval eval** (`evals/ts_retrieval.py`), mirroring the Go/Rust/Java retrieval evals: for each first-party TS symbol, which files call it. cgr's TS `CALLS` edges, reduced to `(caller_file, callee_simple_name)`, are graded against call sites extracted by the TypeScript compiler API, over the same first-party name universe. `tsc` is independent of cgr's tree-sitter TS frontend.

The tsc structure oracle (`ts_ast.js`) is extended to emit the callee of each `CallExpression` (bare identifier or property-access trailing name) and to name arrow / function expressions by their binding (`const foo = () => …` → `foo`), matching how cgr names them.

## Bugs found and fixed

Running the eval on a real library (`zod`, 88 non-test files from `packages/zod/src/v4`) drove recall from **0.45 to 0.75** at precision 1.0 (zero false positives) by fixing two real cgr bugs, each pinned by a RED→GREEN test:

1. **Exported-function duplication.** The definition pass already ingests an exported function / const-arrow at its natural qn, but the ES6-export pass (`ingest_exported_function`) re-registered it, and `register_unique_qn` minted a spurious `qn@line` duplicate node onto which call resolution then bound. ~54% of all TS call edges (1280/2370 on zod) carried a mangled `name@line` callee, and callers of the natural node were invisible. In an ESM codebase where most functions are exported, this pollutes the whole graph. Fixed by skipping the export-pass registration when the natural qn already exists. (`codebase_rag/tests/test_ts_export_no_duplicate.py`)
2. **Arrow-body calls unresolved.** The call pass derived a caller name with `child_by_field_name("name")`, which is empty for an arrow / function expression, so it skipped the entire `const f = () => …` body and never emitted its calls — and modern TS is mostly arrow functions. Fixed by recovering the binding name for the `variable_declarator` form so the body's calls attribute to the same qn the definition pass registered. (`codebase_rag/tests/test_ts_arrow_caller_calls.py`)

Bug 2 is pre-existing (verified by stashing the bug-1 fix); the bug-1 fix caused no regression.

## Remaining gap (documented, not scoped away)

Calls inside anonymous (returned/inline) arrows, method dispatch on typed receivers, and the name-based oracle's over-count of common method names (e.g. `error` on a receiver cgr cannot type). Documented in `evals/README.md`.

## Validation

- Full suite: 4223 passed, 12 skipped, 0 failed
- `ruff` and `ty` clean on changed files
- Eval pinned by `codebase_rag/tests/test_ts_retrieval_eval.py` (cgr matches the `tsc` oracle on the fixture)
