### PR TITLE
fix(js-ts): model class-field arrow members and resolve their body calls

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1632,11 +1632,11 @@ class CallProcessor:
         parent = func_node.parent
         if parent is None:
             return None
-        # (H) `==` not `is`: py-tree-sitter returns a fresh Node wrapper per access,
-        # (H) so identity comparison always fails; Node equality compares the id.
-        if parent.type != cs.TS_VARIABLE_DECLARATOR and (
-            parent.child_by_field_name(cs.FIELD_VALUE) != func_node
-        ):
+        # (H) func_node must be the parent's value/initializer for both forms
+        # (H) (variable_declarator and public_field_definition), so one value check
+        # (H) covers both. `==` not `is`: py-tree-sitter returns a fresh Node wrapper
+        # (H) per access, so identity comparison always fails (Node `==` compares id).
+        if parent.child_by_field_name(cs.FIELD_VALUE) != func_node:
             return None
         name_node = parent.child_by_field_name(cs.FIELD_NAME)
         if name_node is None or name_node.type not in (

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -601,6 +601,8 @@ class CallProcessor:
                 method_name = cpp_utils.extract_function_name(method_node)
             else:
                 method_name = self._get_node_name(method_node)
+            if not method_name and language in _JS_TS_LANGUAGES:
+                method_name = self._js_ts_arrow_binding_name(method_node)
             if not method_name:
                 continue
             # (H) method_nodes includes functions nested inside methods. Build the
@@ -1620,18 +1622,27 @@ class CallProcessor:
     def _js_ts_arrow_binding_name(self, func_node: Node) -> str | None:
         # (H) An arrow / function expression has no `name` field, so the call pass
         # (H) skipped it and never processed its body's calls. Recover the binding
-        # (H) name for the `const f = () => ...` form (a variable_declarator with an
-        # (H) identifier name) -- the dominant ESM pattern -- so its calls are
-        # (H) attributed to the same qn the definition pass registered (module.f via
-        # (H) _build_nested_qualified_name). Anonymous/destructured arrows stay
-        # (H) unnamed (skipped), as before.
+        # (H) name for the two named forms whose value IS the arrow: a module/local
+        # (H) `const f = () => ...` (variable_declarator) and a class field
+        # (H) `helper = () => ...` (public_field_definition). The body's calls then
+        # (H) attribute to the same qn the definition pass registered. Anonymous /
+        # (H) destructured arrows stay unnamed (skipped), as before.
         if func_node.type not in (cs.TS_ARROW_FUNCTION, cs.TS_FUNCTION_EXPRESSION):
             return None
         parent = func_node.parent
-        if parent is None or parent.type != cs.TS_VARIABLE_DECLARATOR:
+        if parent is None:
+            return None
+        # (H) `==` not `is`: py-tree-sitter returns a fresh Node wrapper per access,
+        # (H) so identity comparison always fails; Node equality compares the id.
+        if parent.type != cs.TS_VARIABLE_DECLARATOR and (
+            parent.child_by_field_name(cs.FIELD_VALUE) != func_node
+        ):
             return None
         name_node = parent.child_by_field_name(cs.FIELD_NAME)
-        if name_node is None or name_node.type != cs.TS_IDENTIFIER:
+        if name_node is None or name_node.type not in (
+            cs.TS_IDENTIFIER,
+            cs.TS_PROPERTY_IDENTIFIER,
+        ):
             return None
         return safe_decode_text(name_node)
 

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -210,6 +210,31 @@ def callable_parameter_indices(
     return {name: index for index, name in enumerate(names) if name in invoked}
 
 
+def _js_ts_field_member_name(
+    node: ASTNode, language: cs.SupportedLanguage | None
+) -> str | None:
+    # (H) The binding name of a JS/TS class-field arrow / fn-expr whose enclosing
+    # (H) field definition holds it as its `value` (`helper = () => ...`), so the
+    # (H) member is modelled as class_qn.helper. None for other languages/shapes.
+    if language not in (cs.SupportedLanguage.JS, cs.SupportedLanguage.TS):
+        return None
+    if node.type not in (cs.TS_ARROW_FUNCTION, cs.TS_FUNCTION_EXPRESSION):
+        return None
+    parent = node.parent
+    # (H) `==` not `is`: py-tree-sitter returns a fresh Node wrapper on each access,
+    # (H) so identity comparison always fails; Node equality compares the node id.
+    if parent is None or parent.child_by_field_name(cs.FIELD_VALUE) != node:
+        return None
+    name_node = parent.child_by_field_name(cs.FIELD_NAME)
+    if name_node is None or name_node.type not in (
+        cs.TS_IDENTIFIER,
+        cs.TS_PROPERTY_IDENTIFIER,
+    ):
+        return None
+    text = name_node.text
+    return text.decode(cs.ENCODING_UTF8) if text is not None else None
+
+
 def ingest_method(
     method_node: ASTNode,
     container_qn: str,
@@ -230,8 +255,12 @@ def ingest_method(
         method_name = cpp_utils.extract_function_name(method_node)
         if not method_name:
             return
-    elif not (method_name_node := method_node.child_by_field_name(cs.FIELD_NAME)):
-        return
+    elif (method_name_node := method_node.child_by_field_name(cs.FIELD_NAME)) is None:
+        # (H) A JS/TS class-field arrow / fn-expr (`helper = () => ...`) has no name
+        # (H) field on the function node; take the binding name from the enclosing
+        # (H) field definition so it is modelled as a member instead of dropped.
+        if not (method_name := _js_ts_field_member_name(method_node, language)):
+            return
     elif (text := method_name_node.text) is None:
         return
     else:

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -231,8 +231,7 @@ def _js_ts_field_member_name(
         cs.TS_PROPERTY_IDENTIFIER,
     ):
         return None
-    text = name_node.text
-    return text.decode(cs.ENCODING_UTF8) if text is not None else None
+    return safe_decode_text(name_node)
 
 
 def ingest_method(

--- a/codebase_rag/tests/test_ts_class_field_arrow.py
+++ b/codebase_rag/tests/test_ts_class_field_arrow.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+from evals.cgr_graph import _capture
+
+
+def _make(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "util.ts").write_text(
+        "export function parsedType(x: unknown): number { return 1; }\n",
+        encoding="utf-8",
+    )
+    (root / "t.ts").write_text(
+        'import * as util from "./util.js";\n'
+        "export class T {\n"
+        "  helper = (x: unknown): number => util.parsedType(x);\n"
+        "  regular(x: unknown): number { return util.parsedType(x); }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+
+def test_ts_class_field_arrow_is_modeled_and_calls_resolve(tmp_path: Path) -> None:
+    # (H) A class-property arrow (`helper = (x) => ...`) must be modeled as a
+    # (H) member node (p.t.T.helper) just like a normal method, and the calls in
+    # (H) its body must be attributed to it. Previously the definition pass created
+    # (H) no node for it (no name field) and the call pass skipped its body.
+    _make(tmp_path)
+    ingestor = _capture(tmp_path, "p")
+    member_qns = {
+        str(uid) for (label, uid) in ingestor.nodes if label in ("Method", "Function")
+    }
+    calls = {
+        (str(from_val), str(to_val))
+        for _fl, from_val, rel, _tl, to_val in ingestor.rels
+        if rel == "CALLS"
+    }
+
+    assert "p.t.T.helper" in member_qns
+    assert ("p.t.T.helper", "p.util.parsedType") in calls
+    # (H) regression guard: the normal method still works.
+    assert ("p.t.T.regular", "p.util.parsedType") in calls

--- a/evals/README.md
+++ b/evals/README.md
@@ -494,7 +494,13 @@ which is empty for an arrow / function expression, so it skipped the whole
 `const f = () => …` body and never emitted its calls — and modern TS is mostly
 arrow functions. Fixed by recovering the binding name for the `variable_declarator`
 form so the body's calls attribute to the same qn the definition pass registered
-(`codebase_rag/tests/test_ts_arrow_caller_calls.py`). The remaining gap is calls
+(`codebase_rag/tests/test_ts_arrow_caller_calls.py`). A follow-up fix also models
+**class-field arrow members** (`class T { helper = () => … }`): the definition
+pass dropped them (the arrow has no `name` field, so `ingest_method` returned
+early) so no `T.helper` node existed and its body's calls were lost. The binding
+name is now taken from the enclosing field definition in both the definition and
+call passes, modelling it as `T.helper` like a normal method
+(`codebase_rag/tests/test_ts_class_field_arrow.py`). The remaining gap is calls
 inside anonymous (returned/inline) arrows, method dispatch on typed receivers, and
 the name-based oracle's over-count of common method names (`error` on a receiver
 cgr cannot type) — documented rather than scoped away.


### PR DESCRIPTION
## What

Models **class-field arrow functions** (`class T { helper = () => … }`) in JS/TS, a gap surfaced by review feedback on #550 and confirmed with a repro: cgr created no node for such members (the arrow has no `name` field, so `ingest_method` returned early) and consequently dropped their declaration *and* their body's calls — unlike a normal `regular() {}` method.

## Fix

Two parts, mirroring how the definition and call passes already handle `const f = () => …`:

1. **Definition pass** (`parsers/utils.ingest_method`): when a JS/TS arrow / function expression has no `name` field, derive the binding name from the enclosing field definition (new `_js_ts_field_member_name`) and model it as `class_qn.helper` instead of dropping it.
2. **Call pass** (`call_processor`): `_js_ts_arrow_binding_name` is extended to the class-field case and used as a fallback in the class-method loop, so the arrow body's calls attribute to `class_qn.helper`.

Note: the helper compares the field's `value` node with `==` rather than `is`, because py-tree-sitter returns a fresh `Node` wrapper on each access (identity comparison always fails; `Node.__eq__` compares the node id).

## Validation

- New test `codebase_rag/tests/test_ts_class_field_arrow.py` asserts both the `T.helper` node exists and its body call resolves (with a regression guard that a normal method still works).
- Full suite: 4224 passed, 12 skipped, 0 failed.
- `ruff` and `ty` clean on changed files.
