### PR TITLE
feat(evals): add PHP multi-language retrieval eval and fix plain PHP function-call resolution

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -759,6 +759,7 @@ class CallProcessor:
                     | cs.CppNodeType.QUALIFIED_IDENTIFIER
                     | cs.TS_SCOPED_IDENTIFIER
                     | cs.TS_SELECTOR_EXPRESSION
+                    | cs.TS_PHP_NAME
                 ):
                     if func_child.text is not None:
                         return func_child.text.decode(cs.ENCODING_UTF8)

--- a/codebase_rag/tests/test_php_function_call.py
+++ b/codebase_rag/tests/test_php_function_call.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+from evals.cgr_graph import _capture
+
+
+def _make(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "util.php").write_text(
+        "<?php\nfunction helper(): int { return 2; }\n", encoding="utf-8"
+    )
+    (root / "use.php").write_text(
+        "<?php\nfunction useIt(): int { return helper(); }\n", encoding="utf-8"
+    )
+
+
+def test_php_plain_function_call_resolves(tmp_path: Path) -> None:
+    # (H) A bare PHP function call (`helper()`) is a function_call_expression whose
+    # (H) callee is a `name` node under the `function` field. _get_call_target_name
+    # (H) did not handle the `name` type, so no callee name was extracted and the
+    # (H) CALLS edge was dropped -- only method/static calls (which expose a `name`
+    # (H) field directly) resolved.
+    _make(tmp_path)
+    ingestor = _capture(tmp_path, "p")
+    calls = {
+        (str(from_val), str(to_val))
+        for _fl, from_val, rel, _tl, to_val in ingestor.rels
+        if rel == "CALLS"
+    }
+    assert ("p.use.useIt", "p.util.helper") in calls

--- a/codebase_rag/tests/test_php_retrieval_eval.py
+++ b/codebase_rag/tests/test_php_retrieval_eval.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+
+import pytest
+
+from evals import constants as ec
+from evals.oracles import php_oracle_available
+from evals.php_retrieval import (
+    cgr_php_call_edges,
+    oracle_php_call_edges,
+    score_php_retrieval,
+)
+
+needs_node = pytest.mark.skipif(
+    not php_oracle_available(), reason="node toolchain not installed"
+)
+
+
+def _make_project(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "util.php").write_text(
+        "<?php\nfunction free(): int { return 2; }\n",
+        encoding="utf-8",
+    )
+    (root / "T.php").write_text(
+        "<?php\nclass T {\n"
+        "    public function helper(): int { return 1; }\n"
+        "    public function caller(): int { return $this->helper(); }\n"
+        "    public static function make(): int { return 3; }\n"
+        "    public function orphan(): int { return 9; }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    (root / "use.php").write_text(
+        "<?php\nfunction useIt(): int {\n"
+        "    $t = new T();\n"
+        "    return free() + T::make() + $t->caller();\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+
+@needs_node
+def test_oracle_captures_first_party_php_calls(tmp_path: Path) -> None:
+    _make_project(tmp_path)
+    edges, declared = oracle_php_call_edges(tmp_path)
+
+    # (H) $this->helper(), free(), T::make(), $t->caller() are first-party calls.
+    assert ("T.php", "helper") in edges
+    assert ("use.php", "free") in edges
+    assert ("use.php", "make") in edges
+    assert ("use.php", "caller") in edges
+    # (H) orphan is declared but never called -> never a call edge.
+    assert ("T.php", "orphan") not in edges
+    assert {"helper", "caller", "make", "free", "orphan", "useIt"} <= declared
+
+
+@needs_node
+def test_cgr_matches_oracle_on_clean_php_project(tmp_path: Path) -> None:
+    _make_project(tmp_path)
+    oracle, declared = oracle_php_call_edges(tmp_path)
+    cgr = cgr_php_call_edges(tmp_path, tmp_path.name, declared)
+    assert cgr == oracle
+
+
+def test_score_php_retrieval_prf() -> None:
+    result = score_php_retrieval(
+        {("a.php", "f"), ("a.php", "g")}, {("a.php", "f"), ("b.php", "h")}
+    )
+    row = next(r for r in result.rows if r["label"] == ec.PHP_RETRIEVAL_LABEL)
+    assert (row["tp"], row["fp"], row["fn"]) == (1, 1, 1)

--- a/codebase_rag/tests/test_php_retrieval_eval.py
+++ b/codebase_rag/tests/test_php_retrieval_eval.py
@@ -62,6 +62,25 @@ def test_cgr_matches_oracle_on_clean_php_project(tmp_path: Path) -> None:
     assert cgr == oracle
 
 
+@needs_node
+def test_php_dynamic_member_call_not_emitted(tmp_path: Path) -> None:
+    # (H) A dynamic member call (`$this->$method()`) has a `variable` offset whose
+    # (H) name is the variable identifier ("method"), not a static method name. The
+    # (H) oracle must not emit it as a call edge even when it collides with a
+    # (H) declared first-party method name, or it becomes a false ground-truth edge.
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "c.php").write_text(
+        "<?php\nclass C {\n"
+        "    public function method(): int { return 1; }\n"
+        "    public function go(): int { $method = 'x'; return $this->$method(); }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    edges, declared = oracle_php_call_edges(tmp_path)
+    assert "method" in declared
+    assert ("c.php", "method") not in edges
+
+
 def test_score_php_retrieval_prf() -> None:
     result = score_php_retrieval(
         {("a.php", "f"), ("a.php", "g")}, {("a.php", "f"), ("b.php", "h")}

--- a/evals/README.md
+++ b/evals/README.md
@@ -505,6 +505,40 @@ inside anonymous (returned/inline) arrows, method dispatch on typed receivers, a
 the name-based oracle's over-count of common method names (`error` on a receiver
 cgr cannot type) — documented rather than scoped away.
 
+## Multi-language retrieval (PHP) — PHP CALLS vs `php-parser`
+
+The same harness applied to PHP: for each first-party PHP symbol, which files
+call it. cgr's PHP `CALLS` edges, reduced to `(caller_file, callee_simple_name)`,
+are graded against call sites extracted by `php-parser` (the same oracle as the
+PHP L1 structure eval, extended to emit the callee of each `call` — a bare
+function name, or the trailing member of a `$obj->m()` / `Class::m()` lookup —
+and to carry real declaration names), over the same first-party name universe.
+`php-parser` is a pure-JS PHP parser, independent of cgr's tree-sitter PHP frontend.
+
+```bash
+uv run python -m evals.php_retrieval --target <php-sources>
+```
+
+Requires `node`/`npm` (the `php-parser` dependency installs on first run; no PHP
+runtime needed). Pinned by `codebase_rag/tests/test_php_retrieval_eval.py`, where
+cgr's PHP call graph matches the `php-parser` oracle on the fixture.
+
+Running it on a real library (`monolog`, 121 files from `src/Monolog`) surfaced
+one cgr bug and drove recall from 0.97 to 0.99 at precision 1.0 (zero false
+positives). **Plain function calls were never resolved:** a PHP
+`function_call_expression` carries its callee as a `name` node under the
+`function` field, a type `_get_call_target_name` did not handle, so no callee name
+was extracted and the edge was dropped — only method (`$obj->m()`) and static
+(`Class::m()`) calls, which expose a `name` field directly, resolved. cgr's strong
+OOP-PHP score had masked the gap (monolog is almost entirely methods). Fixed by
+adding the PHP `name` type to the callee match arm
+(`codebase_rag/tests/test_php_function_call.py`). The remaining gap is the
+name-based oracle's over-count: monolog declares first-party methods named
+`substr`/`reset`/`fwrite` (e.g. a UTF-8-aware `Utils::substr`), so a bare call to
+the PHP builtin of the same name is counted as first-party — cgr's simple-name
+trie fallback links it to the same-named first-party symbol, which the file+name
+metric credits. Documented rather than scoped away.
+
 ## Semantic search — query to function relevance
 
 cgr's semantic search embeds each function's source and retrieves by cosine

--- a/evals/constants.py
+++ b/evals/constants.py
@@ -164,6 +164,14 @@ TS_RETRIEVAL_LABEL = "graph"
 TS_RETRIEVAL_TITLE = "cgr multi-language retrieval: TypeScript CALLS vs tsc oracle"
 TS_CALL_EDGE_REPR = "{file} -> {name}"
 
+PHP_DEFAULT_TARGET = "."
+PHP_RETRIEVAL_SCORES_FILENAME = "php_retrieval_scores.csv"
+PHP_RETRIEVAL_DIFF_FILENAME = "php_retrieval_diff.json"
+PHP_RETRIEVAL_DIFF_PREFIX = "php-retrieval:"
+PHP_RETRIEVAL_LABEL = "graph"
+PHP_RETRIEVAL_TITLE = "cgr multi-language retrieval: PHP CALLS vs php-parser oracle"
+PHP_CALL_EDGE_REPR = "{file} -> {name}"
+
 # (H) Semantic-search relevance eval: does cgr's embedding ranking retrieve the
 # (H) right function for a natural-language query? Uses cgr's own embedder over
 # (H) function source extracted from the captured graph; graded as recall@k on

--- a/evals/logs.py
+++ b/evals/logs.py
@@ -98,6 +98,11 @@ TS_RETRIEVAL_CGR = (
     "Building cgr TypeScript CALLS edges for {target} (project={project})"
 )
 TS_RETRIEVAL_CGR_DONE = "cgr TypeScript call edges (first-party): {count}"
+PHP_ORACLE_MISSING = "Node toolchain '{binary}' not found on PATH; cannot run oracle"
+PHP_RETRIEVAL_ORACLE = "Running php-parser call oracle ({binary}) over {target}"
+PHP_RETRIEVAL_ORACLE_DONE = "php-parser first-party call edges: {count}"
+PHP_RETRIEVAL_CGR = "Building cgr PHP CALLS edges for {target} (project={project})"
+PHP_RETRIEVAL_CGR_DONE = "cgr PHP call edges (first-party): {count}"
 SEMANTIC_MISSING = "semantic dependencies not installed; cannot run semantic eval"
 SEMANTIC_TARGET = "Semantic-search eval over {target} (project={project})"
 SEMANTIC_DONE = "recall@{k}: {hits}/{total} queries retrieved the expected function"

--- a/evals/oracles/__init__.py
+++ b/evals/oracles/__init__.py
@@ -2,7 +2,7 @@ from .cpp_oracle import cpp_available, run_cpp_oracle
 from .go_oracle import go_available, run_go_call_oracle, run_go_oracle
 from .java_oracle import java_available, run_java_call_oracle, run_java_oracle
 from .lua_oracle import lua_oracle_available, run_lua_oracle
-from .php_oracle import php_oracle_available, run_php_oracle
+from .php_oracle import php_oracle_available, run_php_call_oracle, run_php_oracle
 from .rust_oracle import run_rust_call_oracle, run_rust_oracle, rust_available
 from .typescript_oracle import (
     run_javascript_oracle,
@@ -23,6 +23,7 @@ __all__ = [
     "lua_oracle_available",
     "run_lua_oracle",
     "php_oracle_available",
+    "run_php_call_oracle",
     "run_php_oracle",
     "run_rust_call_oracle",
     "run_rust_oracle",

--- a/evals/oracles/php_oracle.py
+++ b/evals/oracles/php_oracle.py
@@ -5,13 +5,16 @@ import shutil
 import subprocess
 from pathlib import Path
 
+from codebase_rag import constants as cs
+
 from .. import constants as ec
 from ..types_defs import GraphData, OraclePayload
-from ._common import payload_to_graph
+from ._common import is_ignored, payload_to_graph
 
 _ORACLE_DIR = Path(__file__).parent / ec.PHP_ORACLE_DIRNAME
 _SCRIPT = _ORACLE_DIR / ec.PHP_ORACLE_SCRIPT
 _NODE_MODULES = _ORACLE_DIR / ec.NODE_MODULES_DIRNAME
+_CALLABLE_KINDS = frozenset({cs.NodeLabel.FUNCTION.value, cs.NodeLabel.METHOD.value})
 
 
 def php_oracle_available() -> bool:
@@ -35,11 +38,11 @@ def _ensure_deps() -> None:
     )
 
 
-def run_php_oracle(target: Path) -> GraphData:
+def _run_php_oracle_payload(target: Path) -> OraclePayload:
     _ensure_deps()
     node = shutil.which(ec.NODE_BIN)
     if node is None:
-        return GraphData(nodes={}, edges=set(), name_edges=set())
+        return OraclePayload(nodes=[], edges=[], name_edges=[])
     proc = subprocess.run(
         [node, str(_SCRIPT), str(target)],
         capture_output=True,
@@ -47,4 +50,28 @@ def run_php_oracle(target: Path) -> GraphData:
         check=True,
     )
     payload: OraclePayload = json.loads(proc.stdout or "{}")
-    return payload_to_graph(payload)
+    return payload
+
+
+def run_php_oracle(target: Path) -> GraphData:
+    return payload_to_graph(_run_php_oracle_payload(target))
+
+
+def run_php_call_oracle(target: Path) -> tuple[set[tuple[str, str]], frozenset[str]]:
+    # (H) File-level PHP call sites restricted to first-party callees (a callee
+    # (H) whose simple name is a declared Function/Method), with the declared name
+    # (H) universe so the cgr side can be held to the same set. Mirrors the Go,
+    # (H) Rust, Java, and TypeScript call oracles.
+    payload = _run_php_oracle_payload(target)
+    declared = frozenset(
+        rec[ec.ORACLE_KEY_NAME]
+        for rec in payload.get(ec.ORACLE_KEY_NODES, [])
+        if rec.get(ec.ORACLE_KEY_KIND) in _CALLABLE_KINDS
+    )
+    edges = {
+        (call[ec.ORACLE_KEY_FILE], call[ec.ORACLE_KEY_NAME])
+        for call in payload.get(ec.ORACLE_KEY_CALLS, [])
+        if call[ec.ORACLE_KEY_NAME] in declared
+        and not is_ignored(call[ec.ORACLE_KEY_FILE])
+    }
+    return edges, declared

--- a/evals/oracles/php_oracle/php_ast.js
+++ b/evals/oracles/php_oracle/php_ast.js
@@ -41,9 +41,35 @@ const MODULE_LINE = 0;
 const nodes = [];
 const edges = [];
 const nameEdges = [];
+const calls = [];
 
-function emit(kind, file, line, endLine) {
-  nodes.push({ kind, file, line, end_line: endLine, name: "decl" });
+// (H) A php-parser declaration name is an identifier object ({name:"foo"}) or a
+// (H) bare string depending on node/version; normalise to the string.
+function nameOf(n) {
+  if (!n) return "anonymous";
+  if (typeof n === "string") return n;
+  return typeof n.name === "string" ? n.name : "anonymous";
+}
+
+function emit(kind, file, line, endLine, name) {
+  nodes.push({ kind, file, line, end_line: endLine, name: name || "decl" });
+}
+
+// (H) The callee simple name of a php-parser `call`: a bare function name
+// (H) (`foo()`), or the trailing member of a method (`$this->h()`) or static
+// (H) (`Bar::s()`) lookup. Dynamic callees (`$f()`, `$obj->$m()`) yield null.
+function callName(what) {
+  if (!what) return null;
+  if (what.kind === "name") return what.name ? what.name.split("\\").pop() : null;
+  if (
+    what.kind === "propertylookup" ||
+    what.kind === "nullsafepropertylookup" ||
+    what.kind === "staticlookup"
+  ) {
+    const off = what.offset;
+    if (off && typeof off.name === "string") return off.name;
+  }
+  return null;
 }
 
 function emitEdge(rel, file, pkind, pline, ckind, cline) {
@@ -136,7 +162,7 @@ function walk(node, file, ctx) {
         walkChildren(node, file, { container: "anon", typeRef: null, funcRef: ctx.funcRef });
       } else {
         const line = declLine(node);
-        emit("Class", file, line, node.loc.end.line);
+        emit("Class", file, line, node.loc.end.line, nameOf(node.name));
         emitEdge("DEFINES", file, "Module", MODULE_LINE, "Class", line);
         emitInheritance(node, file, "Class", line);
         walkChildren(node, file, { container: "class", typeRef: { kind: "Class", line }, funcRef: null });
@@ -145,7 +171,7 @@ function walk(node, file, ctx) {
     }
     case "interface": {
       const line = declLine(node);
-      emit("Interface", file, line, node.loc.end.line);
+      emit("Interface", file, line, node.loc.end.line, nameOf(node.name));
       emitEdge("DEFINES", file, "Module", MODULE_LINE, "Interface", line);
       emitInheritance(node, file, "Interface", line);
       walkChildren(node, file, { container: "class", typeRef: { kind: "Interface", line }, funcRef: null });
@@ -153,14 +179,14 @@ function walk(node, file, ctx) {
     }
     case "trait": {
       const line = declLine(node);
-      emit("Class", file, line, node.loc.end.line);
+      emit("Class", file, line, node.loc.end.line, nameOf(node.name));
       emitEdge("DEFINES", file, "Module", MODULE_LINE, "Class", line);
       walkChildren(node, file, { container: "class", typeRef: { kind: "Class", line }, funcRef: null });
       return;
     }
     case "enum": {
       const line = declLine(node);
-      emit("Enum", file, line, node.loc.end.line);
+      emit("Enum", file, line, node.loc.end.line, nameOf(node.name));
       emitEdge("DEFINES", file, "Module", MODULE_LINE, "Enum", line);
       emitInheritance(node, file, "Enum", line);
       walkChildren(node, file, { container: "class", typeRef: { kind: "Enum", line }, funcRef: null });
@@ -169,14 +195,14 @@ function walk(node, file, ctx) {
     case "method": {
       const kind = ctx.container === "anon" ? "Function" : "Method";
       const line = declLine(node);
-      emit(kind, file, line, node.loc.end.line);
+      emit(kind, file, line, node.loc.end.line, nameOf(node.name));
       defineFunctionEdge(file, ctx, kind, line);
       walkChildren(node, file, { container: "function", typeRef: null, funcRef: { kind, line } });
       return;
     }
     case "function": {
       const line = declLine(node);
-      emit("Function", file, line, node.loc.end.line);
+      emit("Function", file, line, node.loc.end.line, nameOf(node.name));
       defineFunctionEdge(file, ctx, "Function", line);
       walkChildren(node, file, { container: "function", typeRef: null, funcRef: { kind: "Function", line } });
       return;
@@ -184,9 +210,18 @@ function walk(node, file, ctx) {
     case "closure":
     case "arrowfunc": {
       const line = node.loc.start.line;
-      emit("Function", file, line, node.loc.end.line);
+      emit("Function", file, line, node.loc.end.line, "anonymous");
       defineFunctionEdge(file, ctx, "Function", line);
       walkChildren(node, file, { container: "function", typeRef: null, funcRef: { kind: "Function", line } });
+      return;
+    }
+    case "call": {
+      // (H) Emit the callee simple name; the Python side keeps only callees whose
+      // (H) name is a declared first-party Function/Method. Recurse for nested
+      // (H) calls in the arguments / receiver.
+      const name = callName(node.what);
+      if (name) calls.push({ file, name });
+      walkChildren(node, file, ctx);
       return;
     }
     default:
@@ -217,4 +252,4 @@ const parser = new phpParser.Engine({
   ast: { withPositions: true },
 });
 visitDir(root, root, parser);
-process.stdout.write(JSON.stringify({ nodes, edges, name_edges: nameEdges }));
+process.stdout.write(JSON.stringify({ nodes, edges, name_edges: nameEdges, calls }));

--- a/evals/oracles/php_oracle/php_ast.js
+++ b/evals/oracles/php_oracle/php_ast.js
@@ -66,8 +66,13 @@ function callName(what) {
     what.kind === "nullsafepropertylookup" ||
     what.kind === "staticlookup"
   ) {
+    // (H) Only a static identifier offset is a real callee name; a dynamic
+    // (H) offset (`$obj->$m()`) is kind "variable" whose `name` is the variable
+    // (H) identifier, which must not be emitted as a call edge.
     const off = what.offset;
-    if (off && typeof off.name === "string") return off.name;
+    if (off && off.kind === "identifier" && typeof off.name === "string") {
+      return off.name;
+    }
   }
   return null;
 }

--- a/evals/php_retrieval.py
+++ b/evals/php_retrieval.py
@@ -1,0 +1,113 @@
+# (H) Multi-language retrieval (PHP). Extends the file-level call-localization
+# (H) benchmark to PHP: for each first-party PHP symbol, which files call it.
+# (H) cgr's PHP CALLS edges (reduced to (caller_file, callee_simple_name)) are
+# (H) graded against call sites extracted by php-parser, over the same first-party
+# (H) name universe. php-parser is independent of cgr's tree-sitter PHP frontend,
+# (H) so this measures cgr's cross-file PHP call resolution against ground truth
+# (H) (mirrors evals/java_retrieval.py / ts_retrieval.py).
+from pathlib import Path
+from typing import Annotated
+
+import typer
+from loguru import logger
+
+from codebase_rag import constants as cs
+
+from . import constants as ec
+from . import logs as ls
+from .cgr_graph import _capture
+from .oracles import php_oracle_available, run_php_call_oracle
+from .score import _prf
+from .structure_report import render, write_outputs
+from .types_defs import DiffBucket, LocationStats, ScoreResult, ScoreRow
+
+console_target = Path(ec.PHP_DEFAULT_TARGET)
+
+_CALLS = cs.RelationshipType.CALLS.value
+_EMPTY_LOCATION = LocationStats(0, 0, 0, 0.0, 0)
+
+CallEdge = tuple[str, str]
+
+
+def oracle_php_call_edges(target: Path) -> tuple[set[CallEdge], frozenset[str]]:
+    return run_php_call_oracle(target)
+
+
+def cgr_php_call_edges(
+    target: Path, project: str, declared: frozenset[str]
+) -> set[CallEdge]:
+    ingestor = _capture(target, project)
+    caller_path: dict[tuple[str, str], str] = {
+        (str(label), str(uid)): str(props[cs.KEY_PATH])
+        for (label, uid), props in ingestor.nodes.items()
+        if props.get(cs.KEY_PATH) and str(props[cs.KEY_PATH]).endswith(ec.PHP_SUFFIX)
+    }
+    edges: set[CallEdge] = set()
+    for from_label, from_val, rel_type, _to_label, to_val in ingestor.rels:
+        if rel_type != _CALLS:
+            continue
+        path = caller_path.get((str(from_label), str(from_val)))
+        if path is None:
+            continue
+        name = str(to_val).split(cs.SEPARATOR_DOT)[-1]
+        if name in declared:
+            edges.add((path, name))
+    return edges
+
+
+def _edge_repr(edge: CallEdge) -> str:
+    return ec.PHP_CALL_EDGE_REPR.format(file=edge[0], name=edge[1])
+
+
+def score_php_retrieval(cgr: set[CallEdge], oracle: set[CallEdge]) -> ScoreResult:
+    rows: list[ScoreRow] = []
+    diff: dict[str, DiffBucket] = {}
+    row = _prf(ec.Category.RETRIEVAL.value, ec.PHP_RETRIEVAL_LABEL, cgr, oracle)
+    if row is not None:
+        rows.append(row)
+        diff[ec.PHP_RETRIEVAL_DIFF_PREFIX + ec.PHP_RETRIEVAL_LABEL] = DiffBucket(
+            missing=[_edge_repr(e) for e in sorted(oracle - cgr)],
+            extra=[_edge_repr(e) for e in sorted(cgr - oracle)],
+        )
+    return ScoreResult(rows=rows, location=_EMPTY_LOCATION, diff=diff)
+
+
+def main(
+    target: Annotated[
+        Path, typer.Option(help="Directory of PHP sources to evaluate call retrieval.")
+    ] = console_target,
+    project_name: Annotated[
+        str, typer.Option(help="cgr project name; defaults to target dir name.")
+    ] = "",
+    out_dir: Annotated[
+        Path,
+        typer.Option(help="Directory for php_retrieval_scores.csv and diff json."),
+    ] = Path(ec.DEFAULT_OUT_DIR),
+) -> None:
+    if not php_oracle_available():
+        logger.error(ls.PHP_ORACLE_MISSING.format(binary=ec.NODE_BIN))
+        raise typer.Exit(code=1)
+
+    target = target.resolve()
+    project = project_name or target.name
+
+    logger.info(ls.PHP_RETRIEVAL_ORACLE.format(binary=ec.NODE_BIN, target=target))
+    oracle, declared = oracle_php_call_edges(target)
+    logger.success(ls.PHP_RETRIEVAL_ORACLE_DONE.format(count=len(oracle)))
+
+    logger.info(ls.PHP_RETRIEVAL_CGR.format(target=target, project=project))
+    cgr = cgr_php_call_edges(target, project, declared)
+    logger.success(ls.PHP_RETRIEVAL_CGR_DONE.format(count=len(cgr)))
+
+    result = score_php_retrieval(cgr, oracle)
+    write_outputs(
+        result,
+        out_dir,
+        ec.PHP_RETRIEVAL_SCORES_FILENAME,
+        ec.PHP_RETRIEVAL_DIFF_FILENAME,
+    )
+    render(result, ec.PHP_RETRIEVAL_TITLE)
+
+
+if __name__ == "__main__":
+    typer.run(main)


### PR DESCRIPTION
## What

Adds a **PHP multi-language retrieval eval** (`evals/php_retrieval.py`), mirroring the Go/Rust/Java/TS retrieval evals: for each first-party PHP symbol, which files call it. cgr's PHP `CALLS` edges, reduced to `(caller_file, callee_simple_name)`, are graded against call sites extracted by `php-parser`, over the same first-party name universe. `php-parser` is a pure-JS PHP parser, independent of cgr's tree-sitter PHP frontend (no PHP runtime needed).

The `php-parser` structure oracle (`php_ast.js`) is extended to emit the callee of each `call` (bare function `name`, or the trailing member of a `$obj->m()` / `Class::m()` lookup) and to carry real declaration names (it previously hardcoded `"decl"`, fine for the structure join but not for a name-based call universe).

## Bug found and fixed

Running the eval on a real library (`monolog`, 121 files from `src/Monolog`) drove recall from **0.97 to 0.99** at precision 1.0 (zero false positives) by fixing one real cgr bug:

**Plain PHP function calls were never resolved.** A PHP `function_call_expression` carries its callee as a `name`-type node under the `function` field — a type `_get_call_target_name`'s callee match arm did not handle — so no callee name was extracted and the `CALLS` edge was dropped. Only method (`$obj->m()`) and static (`Class::m()`) calls, which expose a `name` field directly (caught by the final fallback), resolved. Even a same-file `foo()` call produced no edge. monolog's almost-entirely-OOP code had masked the gap. Fixed by adding the PHP `name` type to the match arm. (`codebase_rag/tests/test_php_function_call.py`)

## Remaining gap (documented, not scoped away)

The remaining 3 monolog misses are the name-based oracle's over-count: monolog declares first-party methods named `substr`/`reset`/`fwrite` (e.g. a UTF-8-aware `Utils::substr`), so a bare call to the PHP builtin of the same name is counted as first-party; cgr's simple-name trie fallback links it to the same-named first-party symbol, which the file+name metric credits. Documented in `evals/README.md`.

## Validation

- Full suite: 4228 passed, 12 skipped, 0 failed
- `ruff` and `ty` clean on changed files
- Eval pinned by `codebase_rag/tests/test_php_retrieval_eval.py` (cgr matches the `php-parser` oracle on the fixture)
