### PR TITLE
fix(graph): restore linear-scan fallback in find_ending_with

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -257,11 +257,8 @@ class FunctionRegistryTrie:
         cached = self._ending_with_cache.get(suffix)
         if cached is not None:
             return cached
-        if self._simple_name_lookup is not None:
-            if suffix in self._simple_name_lookup:
-                result = sorted(self._simple_name_lookup[suffix])
-            else:
-                result = []
+        if self._simple_name_lookup is not None and suffix in self._simple_name_lookup:
+            result = sorted(self._simple_name_lookup[suffix])
         else:
             result = sorted(
                 qn for qn in self._entries.keys() if qn.endswith(f".{suffix}")

--- a/codebase_rag/tests/test_trie_optimization.py
+++ b/codebase_rag/tests/test_trie_optimization.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -159,3 +160,19 @@ class TestTrieOptimization:
         registry["new.function.test"] = NodeType.FUNCTION
         assert "new.function.test" in registry
         assert registry["new.function.test"] == NodeType.FUNCTION
+
+    def test_find_ending_with_falls_back_when_suffix_missing_from_lookup(self) -> None:
+        trie_no_lookup = FunctionRegistryTrie(simple_name_lookup=None)
+        trie_no_lookup.insert("com.example.Logger.info", NodeType.FUNCTION)
+        assert trie_no_lookup.find_ending_with("info") == ["com.example.Logger.info"]
+
+        trie_with_lookup = FunctionRegistryTrie(simple_name_lookup=defaultdict(set))
+        trie_with_lookup.insert("com.example.Logger.debug", NodeType.FUNCTION)
+        assert trie_with_lookup.find_ending_with("debug") == [
+            "com.example.Logger.debug"
+        ]
+
+        trie_bug_state = FunctionRegistryTrie(simple_name_lookup=defaultdict(set))
+        trie_bug_state.insert("com.example.Logger.warn", NodeType.FUNCTION)
+        trie_bug_state._simple_name_lookup.pop("warn")
+        assert trie_bug_state.find_ending_with("warn") == ["com.example.Logger.warn"]


### PR DESCRIPTION
## Summary

Fixes a bug where `FunctionRegistryTrie.find_ending_with()` silently dropped call-resolution results when `_simple_name_lookup` was populated but did not contain the searched suffix.

The method returned an empty result in that case instead of falling through to the linear scan over `_entries`, so any qualified name ending in `.<suffix>` was lost. This affects repos where a function is registered in the trie but its simple name is not indexed in `_simple_name_lookup` (generated names, IIFE patterns, some JS/TS module edge cases).

## Root cause

`find_ending_with` has two paths: a fast path over `_simple_name_lookup` and a
linear scan over `_entries`. `_simple_name_lookup` is optional — it is passed in
at construction and defaults to `None` (graph_updater.py:64-65), and when
present it is kept in sync by `insert` itself (graph_updater.py:117-118). So the
two failure-free cases are: lookup is `None` (scan runs) and lookup is present
and complete (fast path hits).

The pre-fix bug surfaced only in a third state — a lookup that is present but
does not contain the queried suffix. In that case the old code returned `[]`
instead of falling back to the `_entries` scan. The fix restores the fallback so
a present-but-incomplete lookup degrades to the scan rather than dropping the
result.

Note: because `insert` maintains a present lookup, this incomplete-lookup state
is not produced by `insert` alone; it requires the lookup to be populated by a
separate path. I verified the fallback behavior directly via the added unit
test, but I have not identified that construction path in the current tree, so
I'm treating the axios impact figure as reported in #513 rather than one I
traced.

## Impact

14 CALLS relationships were silently dropped on the axios repo (JavaScript). Any repo whose functions are registered in the trie without their simple names being indexed in `_simple_name_lookup` was affected.

## How it was found

Surfaced by expanding the benchmark suite from 2 repos (requests, tree-sitter) to 10 repos across the supported languages — the original two never exercised the failing path, but axios did.

## Test plan

Added a regression test (`test_find_ending_with_falls_back_when_suffix_missing_from_lookup`) covering all three branches: `_simple_name_lookup is None`, lookup present and containing the suffix, and lookup present but missing the suffix (the bug state). Verified it fails on the pre-fix code and passes with the fix. Full `test_trie_optimization.py` suite passes.

Fixes #513