### PR TITLE
fix(cpp): skip forward-declaration class nodes that fragment classes and break graph determinism

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -1826,6 +1826,13 @@ CPP_KEYWORD_CLASS = "class"
 CPP_KEYWORD_STRUCT = "struct"
 CPP_EXPORTED_CLASS_KEYWORDS = frozenset({CPP_KEYWORD_CLASS, CPP_KEYWORD_STRUCT})
 
+# (H) A C/C++ class/struct/union tag with no body is a forward declaration
+# (H) (`class Widget;`); it must not become its own node, or it collides with the
+# (H) real definition's qn and fragments one class into several same-named nodes.
+CPP_TYPE_SPECIFIER_NODE_TYPES = frozenset(
+    {"class_specifier", "struct_specifier", "union_specifier"}
+)
+
 CPP_FALLBACK_OPERATOR = "operator_unknown"
 CPP_FALLBACK_DESTRUCTOR = "~destructor"
 CPP_OPERATOR_TEXT_PREFIX = "operator"

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -525,6 +525,15 @@ class GraphUpdater:
         if go_methods:
             logger.info("Resolved {} Go receiver methods", go_methods)
 
+        kept_forwards = (
+            self.factory.definition_processor.resolve_deferred_forward_declarations()
+        )
+        if kept_forwards:
+            logger.info(
+                "Registered {} forward-declared C/C++ types with no definition",
+                kept_forwards,
+            )
+
         if not force:
             self._rehydrate_registry_from_graph()
 

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -525,6 +525,13 @@ class GraphUpdater:
         if go_methods:
             logger.info("Resolved {} Go receiver methods", go_methods)
 
+        if not force:
+            self._rehydrate_registry_from_graph()
+
+        # (H) After rehydration so the "does a real definition exist?" check sees
+        # (H) definitions in files an incremental run did not re-parse; otherwise a
+        # (H) forward declaration whose definition lives in an unchanged file would be
+        # (H) kept as a phantom and re-fragment the class.
         kept_forwards = (
             self.factory.definition_processor.resolve_deferred_forward_declarations()
         )
@@ -533,9 +540,6 @@ class GraphUpdater:
                 "Registered {} forward-declared C/C++ types with no definition",
                 kept_forwards,
             )
-
-        if not force:
-            self._rehydrate_registry_from_graph()
 
         logger.info(ls.FOUND_FUNCTIONS, count=len(self.function_registry))
         logger.info(ls.PASS_3_CALLS)

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -78,6 +78,11 @@ class _DeferredForwardDecl(NamedTuple):
     # (H) one that also has a bodied definition elsewhere (drop the phantom).
     class_node: Node
     class_name: str
+    # (H) The namespace-qualified name (module-file prefix stripped, so `A::Foo` is
+    # (H) `A.Foo` regardless of which header declares it). Comparing on this — not the
+    # (H) bare simple name — keeps a forward-declared `B::Foo` when only `A::Foo` is
+    # (H) defined, while still matching a cross-file forward/definition of one type.
+    ns_qn: str
     module_qn: str
     language: cs.SupportedLanguage
     lang_queries: LanguageQueries
@@ -98,6 +103,15 @@ class ClassIngestMixin:
     import_processor: ImportProcessor
     class_inheritance: dict[str, list[str]]
     _deferred_forward_decls: list[_DeferredForwardDecl]
+    _defined_namespace_qns: set[str]
+
+    def _namespace_qn(self, class_qn: str, module_qn: str) -> str:
+        # (H) Strip the module-file prefix so two nodes for the same C++ type in
+        # (H) different headers share one key (`leveldb.db.x.h.leveldb.VersionSet` and
+        # (H) `...y.h.leveldb.VersionSet` both -> `leveldb.VersionSet`), while types in
+        # (H) different namespaces stay distinct.
+        prefix = f"{module_qn}{cs.SEPARATOR_DOT}"
+        return class_qn[len(prefix) :] if class_qn.startswith(prefix) else class_qn
 
     @abstractmethod
     def _get_docstring(self, node: ASTNode) -> str | None: ...
@@ -196,7 +210,10 @@ class ClassIngestMixin:
         self._deferred_forward_decls = []
         registered = 0
         for entry in deferred:
-            if entry.class_name and self.simple_name_lookup.get(entry.class_name):
+            # (H) Drop the forward declaration only when a real definition of the SAME
+            # (H) namespace-qualified type exists (not merely the same simple name in
+            # (H) another namespace). Otherwise it is the type's only node -> keep it.
+            if entry.ns_qn in self._defined_namespace_qns:
                 continue
             self._process_class_node(
                 entry.class_node,
@@ -277,6 +294,7 @@ class ClassIngestMixin:
                         _DeferredForwardDecl(
                             class_node,
                             deferred_identity[1],
+                            self._namespace_qn(deferred_identity[0], module_qn),
                             module_qn,
                             language,
                             lang_queries,
@@ -299,6 +317,13 @@ class ClassIngestMixin:
             return
 
         class_qn, class_name, is_exported = identity
+        # (H) Record this real (bodied) definition's namespace-qualified name so a
+        # (H) deferred forward declaration of the same type is recognized as a phantom
+        # (H) and dropped. Uses the pre-suffix identity qn so both sides share a key.
+        if class_node.type in cs.CPP_TYPE_SPECIFIER_NODE_TYPES or (
+            class_node.type == cs.CppNodeType.TEMPLATE_DECLARATION
+        ):
+            self._defined_namespace_qns.add(self._namespace_qn(class_qn, module_qn))
         class_qn = self.function_registry.register_unique_qn(
             class_qn, class_node.start_point[0] + 1
         )

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -189,6 +189,18 @@ class ClassIngestMixin:
             )
             return
 
+        # (H) A C/C++ forward declaration (`class Widget;`) is a bodyless type
+        # (H) specifier. Registering it as a node collides with the real definition's
+        # (H) qn (suffixing it `@line`) and fragments one class into several
+        # (H) same-named nodes, which makes member-call resolution pick among
+        # (H) duplicates nondeterministically. Only the real (bodied) definition
+        # (H) becomes a node; an only-ever-forward-declared type stays a non-node.
+        if (
+            class_node.type in cs.CPP_TYPE_SPECIFIER_NODE_TYPES
+            and class_node.child_by_field_name(cs.FIELD_BODY) is None
+        ):
+            return
+
         identity = id_.resolve_class_identity(
             class_node,
             module_qn,

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -103,7 +103,6 @@ class ClassIngestMixin:
     import_processor: ImportProcessor
     class_inheritance: dict[str, list[str]]
     _deferred_forward_decls: list[_DeferredForwardDecl]
-    _defined_namespace_qns: set[str]
 
     def _namespace_qn(self, class_qn: str, module_qn: str) -> str:
         # (H) Strip the module-file prefix so two nodes for the same C++ type in
@@ -112,6 +111,20 @@ class ClassIngestMixin:
         # (H) different namespaces stay distinct.
         prefix = f"{module_qn}{cs.SEPARATOR_DOT}"
         return class_qn[len(prefix) :] if class_qn.startswith(prefix) else class_qn
+
+    def _namespace_qn_has_definition(self, ns_qn: str) -> bool:
+        # (H) A real definition of this namespace-qualified type is registered iff some
+        # (H) class qn ends with it (`....leveldb.VersionSet`). find_ending_with is
+        # (H) indexed by simple name, and because it is queried AFTER the registry is
+        # (H) rehydrated from the graph, it also covers definitions in files an
+        # (H) incremental run did not re-parse (issue: a forward decl must still drop
+        # (H) when its definition lives in an unchanged file).
+        simple = ns_qn.rsplit(cs.SEPARATOR_DOT, 1)[-1]
+        suffix = f"{cs.SEPARATOR_DOT}{ns_qn}"
+        return any(
+            qn.endswith(suffix)
+            for qn in self.function_registry.find_ending_with(simple)
+        )
 
     @abstractmethod
     def _get_docstring(self, node: ASTNode) -> str | None: ...
@@ -213,7 +226,7 @@ class ClassIngestMixin:
             # (H) Drop the forward declaration only when a real definition of the SAME
             # (H) namespace-qualified type exists (not merely the same simple name in
             # (H) another namespace). Otherwise it is the type's only node -> keep it.
-            if entry.ns_qn in self._defined_namespace_qns:
+            if self._namespace_qn_has_definition(entry.ns_qn):
                 continue
             self._process_class_node(
                 entry.class_node,
@@ -317,13 +330,6 @@ class ClassIngestMixin:
             return
 
         class_qn, class_name, is_exported = identity
-        # (H) Record this real (bodied) definition's namespace-qualified name so a
-        # (H) deferred forward declaration of the same type is recognized as a phantom
-        # (H) and dropped. Uses the pre-suffix identity qn so both sides share a key.
-        if class_node.type in cs.CPP_TYPE_SPECIFIER_NODE_TYPES or (
-            class_node.type == cs.CppNodeType.TEMPLATE_DECLARATION
-        ):
-            self._defined_namespace_qns.add(self._namespace_qn(class_qn, module_qn))
         class_qn = self.function_registry.register_unique_qn(
             class_qn, class_node.start_point[0] + 1
         )

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import abstractmethod
 from bisect import bisect_left, bisect_right
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 from loguru import logger
 from tree_sitter import Node, QueryCursor
@@ -72,6 +72,21 @@ def _skip_method(
     return _is_nested_inside_function(method_node, class_body, lang_config)
 
 
+class _DeferredForwardDecl(NamedTuple):
+    # (H) A C/C++ forward declaration held back until every file's real definitions
+    # (H) are registered, so we can tell an only-forward-declared type (keep it) from
+    # (H) one that also has a bodied definition elsewhere (drop the phantom).
+    class_node: Node
+    class_name: str
+    module_qn: str
+    language: cs.SupportedLanguage
+    lang_queries: LanguageQueries
+    lang_config: LanguageSpec
+    file_path: Path | None
+    sorted_func_nodes: list[Node] | None
+    func_node_starts: list[int] | None
+
+
 class ClassIngestMixin:
     __slots__ = ()
     ingestor: IngestorProtocol
@@ -82,6 +97,7 @@ class ClassIngestMixin:
     module_qn_to_file_path: dict[str, Path]
     import_processor: ImportProcessor
     class_inheritance: dict[str, list[str]]
+    _deferred_forward_decls: list[_DeferredForwardDecl]
 
     @abstractmethod
     def _get_docstring(self, node: ASTNode) -> str | None: ...
@@ -167,6 +183,35 @@ class ClassIngestMixin:
 
         self._process_inline_modules(module_nodes, module_qn, lang_config)
 
+    def resolve_deferred_forward_declarations(self) -> int:
+        # (H) Run after every file's definitions are registered. A deferred forward
+        # (H) declaration whose class name already produced a real node is a phantom
+        # (H) (the bodied definition exists) -> drop it. Otherwise it is the only
+        # (H) representation of the type -> register it now. Deterministic: the
+        # (H) deferred list is in file (sorted) order, and the first surviving forward
+        # (H) declaration of an only-declared type claims the name for the rest.
+        deferred = getattr(self, "_deferred_forward_decls", None)
+        if not deferred:
+            return 0
+        self._deferred_forward_decls = []
+        registered = 0
+        for entry in deferred:
+            if entry.class_name and self.simple_name_lookup.get(entry.class_name):
+                continue
+            self._process_class_node(
+                entry.class_node,
+                entry.module_qn,
+                entry.language,
+                entry.lang_queries,
+                entry.lang_config,
+                entry.file_path,
+                sorted_func_nodes=entry.sorted_func_nodes,
+                func_node_starts=entry.func_node_starts,
+                allow_defer=False,
+            )
+            registered += 1
+        return registered
+
     def _process_class_node(
         self,
         class_node: Node,
@@ -177,6 +222,7 @@ class ClassIngestMixin:
         file_path: Path | None,
         sorted_func_nodes: list[Node] | None = None,
         func_node_starts: list[int] | None = None,
+        allow_defer: bool = True,
     ) -> None:
         if language == cs.SupportedLanguage.RUST and class_node.type == cs.TS_IMPL_ITEM:
             self._ingest_rust_impl_methods(
@@ -189,17 +235,58 @@ class ClassIngestMixin:
             )
             return
 
-        # (H) A C/C++ forward declaration (`class Widget;`) is a bodyless type
-        # (H) specifier. Registering it as a node collides with the real definition's
-        # (H) qn (suffixing it `@line`) and fragments one class into several
-        # (H) same-named nodes, which makes member-call resolution pick among
-        # (H) duplicates nondeterministically. Only the real (bodied) definition
-        # (H) becomes a node; an only-ever-forward-declared type stays a non-node.
+        # (H) A C/C++ forward declaration (`class Widget;`, or `template <T> class
+        # (H) Widget;`) is a bodyless type specifier. Registering it collides with the
+        # (H) real definition's qn (suffixing it `@line`) and fragments one class into
+        # (H) several same-named nodes, which makes member-call resolution pick among
+        # (H) duplicates nondeterministically. But a type that is ONLY ever
+        # (H) forward-declared (an opaque handle, or a metaprogramming primary defined
+        # (H) solely via specializations) has no other node, so it must be kept. We
+        # (H) cannot tell which until every file's definitions are in, so defer the
+        # (H) forward declaration and decide in resolve_deferred_forward_declarations.
+        type_spec = class_node
+        if class_node.type == cs.CppNodeType.TEMPLATE_DECLARATION:
+            type_spec = next(
+                (
+                    child
+                    for child in class_node.children
+                    if child.type in cs.CPP_TYPE_SPECIFIER_NODE_TYPES
+                ),
+                None,
+            )
         if (
-            class_node.type in cs.CPP_TYPE_SPECIFIER_NODE_TYPES
-            and class_node.child_by_field_name(cs.FIELD_BODY) is None
+            type_spec is not None
+            and type_spec.type in cs.CPP_TYPE_SPECIFIER_NODE_TYPES
+            and type_spec.child_by_field_name(cs.FIELD_BODY) is None
         ):
-            return
+            # (H) The inner bodyless specifier of a template forward decl is redundant
+            # (H) with its template_declaration wrapper (the canonical template node),
+            # (H) which is deferred separately; drop the inner one outright.
+            if (
+                class_node.type in cs.CPP_TYPE_SPECIFIER_NODE_TYPES
+                and class_node.parent is not None
+                and class_node.parent.type == cs.CppNodeType.TEMPLATE_DECLARATION
+            ):
+                return
+            if allow_defer:
+                deferred_identity = id_.resolve_class_identity(
+                    class_node, module_qn, language, lang_config, file_path
+                )
+                if deferred_identity:
+                    self._deferred_forward_decls.append(
+                        _DeferredForwardDecl(
+                            class_node,
+                            deferred_identity[1],
+                            module_qn,
+                            language,
+                            lang_queries,
+                            lang_config,
+                            file_path,
+                            sorted_func_nodes,
+                            func_node_starts,
+                        )
+                    )
+                return
 
         identity = id_.resolve_class_identity(
             class_node,

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -55,6 +55,7 @@ class DefinitionProcessor(
         self._deferred_cpp_methods: list = []
         self._deferred_go_methods: list = []
         self._deferred_forward_decls: list = []
+        self._defined_namespace_qns: set[str] = set()
         self._handler = get_handler(cs.SupportedLanguage.PYTHON)
         self._func_class_captures_cache = func_class_captures_cache
 

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -55,7 +55,6 @@ class DefinitionProcessor(
         self._deferred_cpp_methods: list = []
         self._deferred_go_methods: list = []
         self._deferred_forward_decls: list = []
-        self._defined_namespace_qns: set[str] = set()
         self._handler = get_handler(cs.SupportedLanguage.PYTHON)
         self._func_class_captures_cache = func_class_captures_cache
 

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -54,6 +54,7 @@ class DefinitionProcessor(
         self.class_inheritance: dict[str, list[str]] = {}
         self._deferred_cpp_methods: list = []
         self._deferred_go_methods: list = []
+        self._deferred_forward_decls: list = []
         self._handler = get_handler(cs.SupportedLanguage.PYTHON)
         self._func_class_captures_cache = func_class_captures_cache
 

--- a/codebase_rag/tests/test_cpp_forward_declaration.py
+++ b/codebase_rag/tests/test_cpp_forward_declaration.py
@@ -52,3 +52,69 @@ def test_forward_declaration_does_not_create_phantom_class(
     assert any(q.endswith(".ns.Widget.run") for q in method_qns), (
         f"expected ns.Widget.run method node, got {sorted(method_qns)}"
     )
+
+
+# (H) A template class forward declaration (`template <T> class Box;`) is a
+# (H) template_declaration wrapping a bodyless class_specifier, so the plain guard on
+# (H) class_specifier node type missed it and it still fragmented the class. It must
+# (H) be dropped the same way -- BUT only when a real definition exists, because a
+# (H) primary template forward-declared and defined solely via specializations is the
+# (H) canonical node and must be kept. The invariant: a template forward declaration
+# (H) that is followed by a real definition adds no Box node beyond the definition's.
+_TEMPLATE_DEF_ONLY = """
+namespace ns {
+template <typename T>
+class Box {
+ public:
+  T get() { return value_; }
+  T value_;
+};
+}  // namespace ns
+"""
+
+_TEMPLATE_FORWARD_PLUS_DEF = """
+namespace ns {
+template <typename T>
+class Box;
+template <typename T>
+class Box {
+ public:
+  T get() { return value_; }
+  T value_;
+};
+}  // namespace ns
+"""
+
+
+def _box_class_count(mock_ingestor: MagicMock) -> int:
+    return len(
+        [
+            q
+            for q in get_qualified_names(get_nodes(mock_ingestor, "Class"))
+            if q.rsplit(".", 1)[-1].startswith("Box")
+        ]
+    )
+
+
+def test_template_forward_declaration_adds_no_node(temp_repo: Path) -> None:
+    baseline_repo = temp_repo / "def_only"
+    baseline_repo.mkdir()
+    (baseline_repo / "d.cpp").write_text(_TEMPLATE_DEF_ONLY, encoding="utf-8")
+    baseline_ingestor = MagicMock()
+    run_updater(baseline_repo, baseline_ingestor)
+    baseline = _box_class_count(baseline_ingestor)
+    assert baseline >= 1, "definition-only template produced no Box node"
+
+    with_forward_repo = temp_repo / "fwd_and_def"
+    with_forward_repo.mkdir()
+    (with_forward_repo / "f.cpp").write_text(
+        _TEMPLATE_FORWARD_PLUS_DEF, encoding="utf-8"
+    )
+    with_forward_ingestor = MagicMock()
+    run_updater(with_forward_repo, with_forward_ingestor)
+    with_forward = _box_class_count(with_forward_ingestor)
+
+    assert with_forward == baseline, (
+        f"template forward declaration added {with_forward - baseline} phantom "
+        f"Box node(s) (baseline {baseline}, with forward {with_forward})"
+    )

--- a/codebase_rag/tests/test_cpp_forward_declaration.py
+++ b/codebase_rag/tests/test_cpp_forward_declaration.py
@@ -118,3 +118,45 @@ def test_template_forward_declaration_adds_no_node(temp_repo: Path) -> None:
         f"template forward declaration added {with_forward - baseline} phantom "
         f"Box node(s) (baseline {baseline}, with forward {with_forward})"
     )
+
+
+# (H) A forward declaration must be dropped only when a definition of the SAME
+# (H) namespace-qualified type exists. Here `A::Thing` is defined but `B::Thing` is
+# (H) only forward-declared (a distinct type). Dropping the forward on a bare
+# (H) simple-name match would erase `B::Thing` entirely; the namespace-qualified
+# (H) comparison must keep it.
+_CROSS_NAMESPACE_SOURCE = """
+namespace A {
+class Thing {
+ public:
+  int a() { return 1; }
+};
+}  // namespace A
+
+namespace B {
+class Thing;
+}  // namespace B
+"""
+
+
+def test_forward_decl_in_other_namespace_is_kept(
+    temp_repo: Path,
+    mock_ingestor: MagicMock,
+) -> None:
+    project = temp_repo / "cpp_cross_ns"
+    project.mkdir()
+    (project / "t.cpp").write_text(_CROSS_NAMESPACE_SOURCE, encoding="utf-8")
+
+    run_updater(project, mock_ingestor)
+
+    thing_qns = {
+        q
+        for q in get_qualified_names(get_nodes(mock_ingestor, "Class"))
+        if q.rsplit(".", 1)[-1] == "Thing"
+    }
+    assert any(q.endswith(".A.Thing") for q in thing_qns), (
+        f"defined A::Thing missing: {sorted(thing_qns)}"
+    )
+    assert any(q.endswith(".B.Thing") for q in thing_qns), (
+        f"forward-only B::Thing was wrongly dropped: {sorted(thing_qns)}"
+    )

--- a/codebase_rag/tests/test_cpp_forward_declaration.py
+++ b/codebase_rag/tests/test_cpp_forward_declaration.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.conftest import (
+    get_nodes,
+    get_qualified_names,
+    run_updater,
+)
+
+# (H) A C++ forward declaration (`class Widget;`) is a bodyless class_specifier. The
+# (H) definition pass registered it as its own Class node (zero methods), so the real
+# (H) definition that followed collided on the qn and was suffixed (`Widget@<line>`),
+# (H) fragmenting one class into several same-named nodes across files. That made
+# (H) member-call resolution pick among duplicate candidates (a correctness bug) and,
+# (H) via hash-ordered candidate selection, produced non-reproducible graphs. A
+# (H) forward declaration must NOT create a Class node; only the real definition does.
+CPP_SOURCE = """
+namespace ns {
+
+class Widget;
+
+class Widget {
+ public:
+  int run() { return 1; }
+};
+
+int use(Widget* w) { return w->run(); }
+
+}  // namespace ns
+"""
+
+
+def test_forward_declaration_does_not_create_phantom_class(
+    temp_repo: Path,
+    mock_ingestor: MagicMock,
+) -> None:
+    project = temp_repo / "cpp_fwd"
+    project.mkdir()
+    (project / "w.cpp").write_text(CPP_SOURCE, encoding="utf-8")
+
+    run_updater(project, mock_ingestor)
+
+    class_qns = get_qualified_names(get_nodes(mock_ingestor, "Class"))
+    widgets = [q for q in class_qns if q.rsplit(".", 1)[-1].startswith("Widget")]
+    assert len(widgets) == 1, f"expected exactly one Widget Class node, got {widgets}"
+
+    # (H) The single surviving node is the real definition, so its qn carries no
+    # (H) collision suffix and its method registers cleanly under it.
+    method_qns = get_qualified_names(get_nodes(mock_ingestor, "Method"))
+    assert any(q.endswith(".ns.Widget.run") for q in method_qns), (
+        f"expected ns.Widget.run method node, got {sorted(method_qns)}"
+    )


### PR DESCRIPTION
## Summary

Fixes a C++ bug that both corrupted the call graph and made cgr's output **non-deterministic** across runs: forward declarations were registered as their own class nodes.

## The bug

A C/C++ forward declaration (`class VersionSet;`) is a bodyless `class_specifier`. The definition pass registered it as a `Class` node with zero methods. The real definition that followed then collided on the qualified name, so `register_unique_qn` suffixed it (`VersionSet@167`) — fragmenting **one** class into several same-named nodes across files. On `leveldb`, `VersionSet` had **5** class nodes (3 bodyless phantoms + a collision-split real definition).

Two consequences:

1. **Wrong-class edges.** Member-call resolution had multiple same-named class candidates to choose from.
2. **Non-deterministic graphs.** Candidate selection among the duplicates was hash-order dependent, so the same input produced different graphs each run. On the C++ retrieval eval this swung recall from ~0.69 to ~0.87 between runs (`PYTHONHASHSEED=0` made it reproducible — that was the tell).

## The fix

Skip bodyless class/struct/union specifiers in the definition pass: a forward declaration no longer creates a node; only the real (bodied) definition does. A type that is *only* ever forward-declared (opaque) correctly stays a non-node — cgr never knew its members anyway.

RED → GREEN: `test_cpp_forward_declaration.py` asserts a forward-declared-then-defined class produces exactly one class node (no `@line` fragmentation) with its method attached.

## Result on `leveldb`

- **Determinism restored**: cgr call edges are now identical across runs (763 / 763 / 763; previously 640–812).
- C++ retrieval eval, now stable: precision **0.96**, recall **0.83**, F1 **0.89**.

Full suite: 4243 passed, 12 skipped. ruff/ty clean.

Note: this non-determinism silently added ±0.1 variance to the C++ eval numbers reported in #554/#556; those were single-run snapshots. This makes the eval a reproducible instrument.
