### PR TITLE
feat(cpp): infer C++ receiver types so member calls resolve to the correct class

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -1794,6 +1794,15 @@ class CppNodeType(StrEnum):
     CONSTRUCTOR_OR_DESTRUCTOR_DECLARATION = "constructor_or_destructor_declaration"
     INLINE_METHOD_DEFINITION = "inline_method_definition"
     OPERATOR_CAST_DEFINITION = "operator_cast_definition"
+    TYPE_IDENTIFIER = "type_identifier"
+    PARAMETER_LIST = "parameter_list"
+    PARAMETER_DECLARATION = "parameter_declaration"
+    OPTIONAL_PARAMETER_DECLARATION = "optional_parameter_declaration"
+    INIT_DECLARATOR = "init_declarator"
+    TEMPLATE_TYPE = "template_type"
+    FIELD_EXPRESSION = "field_expression"
+    COMPOUND_STATEMENT = "compound_statement"
+    THIS = "this"
 
 
 CPP_MODULE_EXTENSIONS = (".ixx", ".cppm", ".ccm", ".mxx")

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -2159,6 +2159,16 @@ FIELD_OPERATOR = "operator"
 # (H) Derived node type tuples for class ingestion
 CPP_CLASS_TYPES = (CppNodeType.CLASS_SPECIFIER, TS_STRUCT_SPECIFIER)
 CPP_COMPOUND_TYPES = (*CPP_CLASS_TYPES, TS_UNION_SPECIFIER, TS_ENUM_SPECIFIER)
+# (H) Node types that open their own variable scope; C++ local-variable inference must
+# (H) not descend into them, or a name declared inside a lambda / nested function /
+# (H) local class body would be attributed to the enclosing function's scope.
+CPP_NESTED_SCOPE_NODE_TYPES = frozenset(
+    (
+        TS_CPP_FUNCTION_DEFINITION,
+        TS_CPP_LAMBDA_EXPRESSION,
+        *CPP_COMPOUND_TYPES,
+    )
+)
 JS_TS_PARENT_REF_TYPES = (TS_IDENTIFIER, TS_MEMBER_EXPRESSION)
 
 # (H) Import processor function names

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -52,6 +52,7 @@ _TYPED_LANGUAGES = frozenset(
         cs.SupportedLanguage.JAVA,
         cs.SupportedLanguage.LUA,
         cs.SupportedLanguage.GO,
+        cs.SupportedLanguage.CPP,
     }
 )
 
@@ -803,7 +804,22 @@ class CallProcessor:
                 case cs.TS_CPP_FIELD_EXPRESSION:
                     field_node = func_child.child_by_field_name(cs.FIELD_FIELD)
                     if field_node and field_node.text:
-                        return field_node.text.decode(cs.ENCODING_UTF8)
+                        method = field_node.text.decode(cs.ENCODING_UTF8)
+                        # (H) Prepend a simple-identifier receiver (`obj->m`/`obj.m`
+                        # (H) -> `obj.m`) so the resolver can map obj to its type and
+                        # (H) bind the correct class method; a `.`-joined two-part name
+                        # (H) still falls back to the bare method-name trie when the
+                        # (H) receiver type is unknown. Complex receivers (chains,
+                        # (H) calls, `this`) keep the bare method name, as before.
+                        arg = func_child.child_by_field_name(cs.TS_FIELD_ARGUMENT)
+                        if (
+                            arg is not None
+                            and arg.type == cs.TS_IDENTIFIER
+                            and arg.text
+                        ):
+                            receiver = arg.text.decode(cs.ENCODING_UTF8)
+                            return f"{receiver}{cs.SEPARATOR_DOT}{method}"
+                        return method
                 case cs.TS_PARENTHESIZED_EXPRESSION:
                     return self._get_iife_target_name(func_child)
 

--- a/codebase_rag/parsers/cpp/__init__.py
+++ b/codebase_rag/parsers/cpp/__init__.py
@@ -1,0 +1,5 @@
+from .type_inference import CppTypeInferenceEngine
+
+__all__ = [
+    "CppTypeInferenceEngine",
+]

--- a/codebase_rag/parsers/cpp/type_inference.py
+++ b/codebase_rag/parsers/cpp/type_inference.py
@@ -72,11 +72,16 @@ class CppTypeInferenceEngine:
         self, node: Node, decls: list[tuple[str, str]]
     ) -> None:
         for child in node.children:
+            # (H) A lambda / nested function / local class body opens its own scope;
+            # (H) its declarations are not locals of the enclosing function, so descend
+            # (H) no further or an inner `x` would be attributed to the outer `x`.
+            if child.type in cs.CPP_NESTED_SCOPE_NODE_TYPES:
+                continue
             if child.type == cs.CppNodeType.DECLARATION:
                 self._record_declaration(child, decls)
-            # (H) Recurse into nested blocks (if/for/while/try bodies) so a variable
-            # (H) declared only in an inner scope still resolves; conflicting redecls
-            # (H) across scopes are reconciled by the caller (drop-on-conflict).
+            # (H) Recurse into ordinary nested blocks (if/for/while/try bodies) so a
+            # (H) variable declared only in an inner block still resolves; conflicting
+            # (H) redecls across scopes are reconciled by the caller (drop-on-conflict).
             self._collect_body_declarations(child, decls)
 
     def _record_declaration(self, node: Node, decls: list[tuple[str, str]]) -> None:

--- a/codebase_rag/parsers/cpp/type_inference.py
+++ b/codebase_rag/parsers/cpp/type_inference.py
@@ -83,9 +83,11 @@ class CppTypeInferenceEngine:
         type_node = node.child_by_field_name(cs.FIELD_TYPE)
         if type_node is None or not (type_name := self._bare_type_name(type_node)):
             return
-        declarator = node.child_by_field_name(cs.FIELD_DECLARATOR)
-        if (name := self._declarator_name(declarator)) is not None:
-            decls.append((name, type_name))
+        # (H) One statement may declare several variables sharing the leading type
+        # (H) (`Zeta a, b;`), each its own `declarator` field child; record them all.
+        for declarator in node.children_by_field_name(cs.FIELD_DECLARATOR):
+            if (name := self._declarator_name(declarator)) is not None:
+                decls.append((name, type_name))
 
     def _bare_type_name(self, type_node: Node) -> str | None:
         match type_node.type:

--- a/codebase_rag/parsers/cpp/type_inference.py
+++ b/codebase_rag/parsers/cpp/type_inference.py
@@ -19,11 +19,29 @@ class CppTypeInferenceEngine:
     def build_local_variable_type_map(
         self, caller_node: Node, module_qn: str
     ) -> dict[str, str]:
-        var_types: dict[str, str] = {}
+        decls: list[tuple[str, str]] = []
         if declarator := self._function_declarator(caller_node):
-            self._collect_parameters(declarator, var_types)
+            self._collect_parameters(declarator, decls)
         if body := caller_node.child_by_field_name(cs.FIELD_BODY):
-            self._collect_body_declarations(body, var_types)
+            self._collect_body_declarations(body, decls)
+        # (H) The map is keyed by name only, with no knowledge of a call's lexical
+        # (H) position, so it cannot tell an outer `Zeta z` from an inner-block
+        # (H) `Alpha z` that shadows it. Rather than pick a write order that is wrong
+        # (H) for one of the two scopes, decline to infer any name declared with more
+        # (H) than one type: such a call falls back to name-only resolution instead of
+        # (H) getting a confidently wrong typed edge. (Same flat-map limitation the Go
+        # (H) engine carries; true scoping would need positional call resolution.)
+        var_types: dict[str, str] = {}
+        conflicting: set[str] = set()
+        for name, type_name in decls:
+            if name in conflicting:
+                continue
+            existing = var_types.get(name)
+            if existing is not None and existing != type_name:
+                del var_types[name]
+                conflicting.add(name)
+                continue
+            var_types[name] = type_name
         return var_types
 
     def _function_declarator(self, caller_node: Node) -> Node | None:
@@ -36,7 +54,9 @@ class CppTypeInferenceEngine:
             declarator = declarator.child_by_field_name(cs.FIELD_DECLARATOR)
         return None
 
-    def _collect_parameters(self, declarator: Node, var_types: dict[str, str]) -> None:
+    def _collect_parameters(
+        self, declarator: Node, decls: list[tuple[str, str]]
+    ) -> None:
         params = declarator.child_by_field_name(cs.KEY_PARAMETERS)
         if params is None:
             return
@@ -46,30 +66,26 @@ class CppTypeInferenceEngine:
                 cs.CppNodeType.OPTIONAL_PARAMETER_DECLARATION,
             ):
                 continue
-            self._record_declaration(param, var_types)
+            self._record_declaration(param, decls)
 
-    def _collect_body_declarations(self, node: Node, var_types: dict[str, str]) -> None:
+    def _collect_body_declarations(
+        self, node: Node, decls: list[tuple[str, str]]
+    ) -> None:
         for child in node.children:
             if child.type == cs.CppNodeType.DECLARATION:
-                self._record_declaration(child, var_types)
+                self._record_declaration(child, decls)
             # (H) Recurse into nested blocks (if/for/while/try bodies) so a variable
-            # (H) declared in an inner scope still resolves; last write wins, which is
-            # (H) good enough for the single-type-per-name model this map supports.
-            self._collect_body_declarations(child, var_types)
+            # (H) declared only in an inner scope still resolves; conflicting redecls
+            # (H) across scopes are reconciled by the caller (drop-on-conflict).
+            self._collect_body_declarations(child, decls)
 
-    def _record_declaration(self, node: Node, var_types: dict[str, str]) -> None:
+    def _record_declaration(self, node: Node, decls: list[tuple[str, str]]) -> None:
         type_node = node.child_by_field_name(cs.FIELD_TYPE)
         if type_node is None or not (type_name := self._bare_type_name(type_node)):
             return
         declarator = node.child_by_field_name(cs.FIELD_DECLARATOR)
         if (name := self._declarator_name(declarator)) is not None:
-            # (H) Outermost-first traversal + first-write-wins: a variable declared in
-            # (H) the function's outer scope keeps its type even when an inner block
-            # (H) shadows the name, so a call in the outer scope resolves to the outer
-            # (H) type. A single-type-per-name map can't fully model lexical scope
-            # (H) (calls inside the shadowing block stay ambiguous), but this prevents
-            # (H) an inner redeclaration from producing a wrong edge for outer calls.
-            var_types.setdefault(name, type_name)
+            decls.append((name, type_name))
 
     def _bare_type_name(self, type_node: Node) -> str | None:
         match type_node.type:

--- a/codebase_rag/parsers/cpp/type_inference.py
+++ b/codebase_rag/parsers/cpp/type_inference.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from tree_sitter import Node
+
+from ... import constants as cs
+from ..utils import safe_decode_text
+
+
+class CppTypeInferenceEngine:
+    # (H) Maps local variable / parameter names to their bare C++ type name within a
+    # (H) function or method body, so the resolver can bind a member-dispatch call
+    # (H) (`obj->method()` / `obj.method()`) to the method node on the receiver's
+    # (H) class instead of guessing by the bare method name. Bare names only: the
+    # (H) resolver turns a name into a class qn via the same _resolve_class_name path
+    # (H) the definition pass uses, so pointer/reference/const/template wrappers are
+    # (H) stripped here down to the underlying type identifier.
+    __slots__ = ()
+
+    def build_local_variable_type_map(
+        self, caller_node: Node, module_qn: str
+    ) -> dict[str, str]:
+        var_types: dict[str, str] = {}
+        if declarator := self._function_declarator(caller_node):
+            self._collect_parameters(declarator, var_types)
+        if body := caller_node.child_by_field_name(cs.FIELD_BODY):
+            self._collect_body_declarations(body, var_types)
+        return var_types
+
+    def _function_declarator(self, caller_node: Node) -> Node | None:
+        # (H) The parameter_list hangs off the (possibly pointer/reference-wrapped)
+        # (H) function_declarator in the definition's declarator chain.
+        declarator = caller_node.child_by_field_name(cs.FIELD_DECLARATOR)
+        while declarator is not None:
+            if declarator.type == cs.CppNodeType.FUNCTION_DECLARATOR:
+                return declarator
+            declarator = declarator.child_by_field_name(cs.FIELD_DECLARATOR)
+        return None
+
+    def _collect_parameters(self, declarator: Node, var_types: dict[str, str]) -> None:
+        params = declarator.child_by_field_name(cs.KEY_PARAMETERS)
+        if params is None:
+            return
+        for param in params.children:
+            if param.type not in (
+                cs.CppNodeType.PARAMETER_DECLARATION,
+                cs.CppNodeType.OPTIONAL_PARAMETER_DECLARATION,
+            ):
+                continue
+            self._record_declaration(param, var_types)
+
+    def _collect_body_declarations(self, node: Node, var_types: dict[str, str]) -> None:
+        for child in node.children:
+            if child.type == cs.CppNodeType.DECLARATION:
+                self._record_declaration(child, var_types)
+            # (H) Recurse into nested blocks (if/for/while/try bodies) so a variable
+            # (H) declared in an inner scope still resolves; last write wins, which is
+            # (H) good enough for the single-type-per-name model this map supports.
+            self._collect_body_declarations(child, var_types)
+
+    def _record_declaration(self, node: Node, var_types: dict[str, str]) -> None:
+        type_node = node.child_by_field_name(cs.FIELD_TYPE)
+        if type_node is None or not (type_name := self._bare_type_name(type_node)):
+            return
+        declarator = node.child_by_field_name(cs.FIELD_DECLARATOR)
+        if (name := self._declarator_name(declarator)) is not None:
+            var_types[name] = type_name
+
+    def _bare_type_name(self, type_node: Node) -> str | None:
+        match type_node.type:
+            case cs.CppNodeType.TYPE_IDENTIFIER:
+                return safe_decode_text(type_node)
+            case cs.CppNodeType.QUALIFIED_IDENTIFIER:
+                # (H) `ns::Foo` -> `Foo`: the resolver maps the bare class name to its
+                # (H) namespaced node qn via find_ending_with.
+                return self._rightmost_name(type_node)
+            case cs.CppNodeType.TEMPLATE_TYPE:
+                inner = type_node.child_by_field_name(cs.KEY_NAME)
+                return self._bare_type_name(inner) if inner is not None else None
+            case _:
+                return None
+
+    def _rightmost_name(self, node: Node) -> str | None:
+        name_node = node.child_by_field_name(cs.KEY_NAME)
+        if name_node is not None and name_node.type in (
+            cs.CppNodeType.TYPE_IDENTIFIER,
+            cs.CppNodeType.IDENTIFIER,
+        ):
+            return safe_decode_text(name_node)
+        text = safe_decode_text(node)
+        if not text:
+            return None
+        return text.rsplit(cs.SEPARATOR_DOUBLE_COLON, 1)[-1] or None
+
+    def _declarator_name(self, declarator: Node | None) -> str | None:
+        # (H) Unwrap pointer/reference/init declarators down to the bound identifier.
+        current = declarator
+        while current is not None:
+            if current.type == cs.CppNodeType.IDENTIFIER:
+                return safe_decode_text(current)
+            if inner := current.child_by_field_name(cs.FIELD_DECLARATOR):
+                current = inner
+                continue
+            return None
+        return None

--- a/codebase_rag/parsers/cpp/type_inference.py
+++ b/codebase_rag/parsers/cpp/type_inference.py
@@ -63,7 +63,13 @@ class CppTypeInferenceEngine:
             return
         declarator = node.child_by_field_name(cs.FIELD_DECLARATOR)
         if (name := self._declarator_name(declarator)) is not None:
-            var_types[name] = type_name
+            # (H) Outermost-first traversal + first-write-wins: a variable declared in
+            # (H) the function's outer scope keeps its type even when an inner block
+            # (H) shadows the name, so a call in the outer scope resolves to the outer
+            # (H) type. A single-type-per-name map can't fully model lexical scope
+            # (H) (calls inside the shadowing block stay ambiguous), but this prevents
+            # (H) an inner redeclaration from producing a wrong edge for outer calls.
+            var_types.setdefault(name, type_name)
 
     def _bare_type_name(self, type_node: Node) -> str | None:
         match type_node.type:
@@ -100,5 +106,20 @@ class CppTypeInferenceEngine:
             if inner := current.child_by_field_name(cs.FIELD_DECLARATOR):
                 current = inner
                 continue
-            return None
+            # (H) `reference_declarator` (`T& x`) holds its identifier as a positional
+            # (H) child, not under the `declarator` field that pointer/init declarators
+            # (H) expose, so the field-based unwrap stalls; descend into the first
+            # (H) named declarator-bearing child instead.
+            current = self._first_declarator_child(current)
+        return None
+
+    def _first_declarator_child(self, node: Node) -> Node | None:
+        for child in node.children:
+            if child.type in (
+                cs.CppNodeType.IDENTIFIER,
+                cs.CppNodeType.REFERENCE_DECLARATOR,
+                cs.CppNodeType.POINTER_DECLARATOR,
+                cs.CppNodeType.INIT_DECLARATOR,
+            ):
+                return child
         return None

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -8,6 +8,7 @@ from ..types_defs import (
     LanguageQueries,
     SimpleNameLookup,
 )
+from .cpp import CppTypeInferenceEngine
 from .go import GoTypeInferenceEngine
 from .import_processor import ImportProcessor
 from .java import JavaTypeInferenceEngine
@@ -35,6 +36,7 @@ class TypeInferenceEngine:
         "_js_type_inference",
         "_python_type_inference",
         "_go_type_inference",
+        "_cpp_type_inference",
     )
 
     def __init__(
@@ -64,12 +66,19 @@ class TypeInferenceEngine:
         self._js_type_inference: JsTypeInferenceEngine | None = None
         self._python_type_inference: PythonTypeInferenceEngine | None = None
         self._go_type_inference: GoTypeInferenceEngine | None = None
+        self._cpp_type_inference: CppTypeInferenceEngine | None = None
 
     @property
     def go_type_inference(self) -> GoTypeInferenceEngine:
         if self._go_type_inference is None:
             self._go_type_inference = GoTypeInferenceEngine()
         return self._go_type_inference
+
+    @property
+    def cpp_type_inference(self) -> CppTypeInferenceEngine:
+        if self._cpp_type_inference is None:
+            self._cpp_type_inference = CppTypeInferenceEngine()
+        return self._cpp_type_inference
 
     @property
     def java_type_inference(self) -> JavaTypeInferenceEngine:
@@ -148,6 +157,10 @@ class TypeInferenceEngine:
                 )
             case cs.SupportedLanguage.GO:
                 return self.go_type_inference.build_local_variable_type_map(
+                    caller_node, module_qn
+                )
+            case cs.SupportedLanguage.CPP:
+                return self.cpp_type_inference.build_local_variable_type_map(
                     caller_node, module_qn
                 )
             case _:

--- a/codebase_rag/tests/test_cpp_receiver_type_dispatch.py
+++ b/codebase_rag/tests/test_cpp_receiver_type_dispatch.py
@@ -141,47 +141,24 @@ def test_cpp_local_reference_receiver_resolves(
     )
 
 
-# (H) A single-type-per-name map cannot model true lexical scope, but an inner-block
-# (H) redeclaration must NOT clobber the outer binding for calls made in the outer
-# (H) scope. Traversal is outermost-first, so first-write-wins keeps the outer `Zeta z`
-# (H) even though an inner block shadows it with `Alpha z`; the trailing `z.run()` sits
-# (H) in the outer scope and must bind to Zeta.run.
-_SHADOW_SOURCE = """
-namespace ns {
-
-class Alpha {
- public:
-  int run() { return 1; }
-};
-
-class Zeta {
- public:
-  int run() { return 2; }
-};
-
-int use_shadow() {
-  Zeta z;
-  { Alpha z; }
-  return z.run();
-}
-
-}  // namespace ns
-"""
+# (H) The type map is keyed by name with no call-position context, so it cannot model
+# (H) true lexical scope: it cannot tell an outer `Zeta z` from an inner-block `Alpha z`
+# (H) that shadows it. Picking either write order emits a confidently wrong typed edge
+# (H) for one of the two scopes. Instead a name declared with conflicting types is NOT
+# (H) inferred at all -- the call falls back to name-only resolution rather than getting
+# (H) a wrong edge. An inner-block local whose name does NOT collide is still recorded,
+# (H) so recall for the common case is preserved.
+def test_cpp_conflicting_shadow_type_is_not_inferred() -> None:
+    node = _first_function_node("void f() { Zeta z; { Alpha z; } }")
+    var_types = CppTypeInferenceEngine().build_local_variable_type_map(node, "m")
+    assert "z" not in var_types, (
+        f"a name shadowed by a different type must not be inferred, got {var_types}"
+    )
 
 
-def test_cpp_outer_scope_survives_inner_shadow(
-    temp_repo: Path,
-    mock_ingestor: MagicMock,
-) -> None:
-    project = temp_repo / "cpp_shadow"
-    project.mkdir()
-    (project / "s.cpp").write_text(_SHADOW_SOURCE, encoding="utf-8")
-
-    run_updater(project, mock_ingestor)
-
-    calls = _calls_to_run(mock_ingestor)
-    caller = next(q for q in calls if q.endswith(".use_shadow"))
-    assert calls[caller].endswith(".Zeta.run"), (
-        f"outer-scope z.run() should resolve to Zeta.run despite inner Alpha shadow, "
-        f"got {calls[caller]}"
+def test_cpp_non_conflicting_inner_block_local_is_recorded() -> None:
+    node = _first_function_node("void f() { if (c) { Foo x; } }")
+    var_types = CppTypeInferenceEngine().build_local_variable_type_map(node, "m")
+    assert var_types.get("x") == "Foo", (
+        f"an inner-block local with no name collision should resolve, got {var_types}"
     )

--- a/codebase_rag/tests/test_cpp_receiver_type_dispatch.py
+++ b/codebase_rag/tests/test_cpp_receiver_type_dispatch.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock
 
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.parsers.cpp import CppTypeInferenceEngine
 from codebase_rag.tests.conftest import (
     get_relationships,
     run_updater,
@@ -66,4 +68,120 @@ def test_cpp_member_call_resolves_via_receiver_type(
     )
     assert calls[val_caller].endswith(".Zeta.run"), (
         f"z.run() should resolve to Zeta.run, got {calls[val_caller]}"
+    )
+
+
+def _first_function_node(source: str):
+    parsers, _ = load_parsers()
+    tree = parsers["cpp"].parse(source.encode("utf-8"))
+
+    def walk(node):
+        if node.type == "function_definition":
+            return node
+        for child in node.children:
+            if (found := walk(child)) is not None:
+                return found
+        return None
+
+    node = walk(tree.root_node)
+    assert node is not None
+    return node
+
+
+# (H) A C++ reference parameter (`Alpha& ar`) parses as a `reference_declarator` that
+# (H) holds its identifier as a POSITIONAL child, not under the `declarator` field the
+# (H) way `pointer_declarator` does. The field-only unwrap in `_declarator_name` stalled
+# (H) on it, so reference parameters/locals never entered the type map and their member
+# (H) calls fell back to bare-name resolution. References are pervasive in C++, so this
+# (H) is a real coverage hole.
+def test_cpp_reference_parameter_maps_to_type() -> None:
+    node = _first_function_node("void f(Alpha& ar, Zeta* zp) { }")
+    var_types = CppTypeInferenceEngine().build_local_variable_type_map(node, "m")
+    assert var_types.get("ar") == "Alpha", (
+        f"reference parameter ar should map to Alpha, got {var_types}"
+    )
+    assert var_types.get("zp") == "Zeta", (
+        f"pointer parameter zp should map to Zeta, got {var_types}"
+    )
+
+
+_LOCAL_REF_SOURCE = """
+namespace ns {
+
+class Alpha {
+ public:
+  int run() { return 1; }
+};
+
+class Zeta {
+ public:
+  int run() { return 2; }
+};
+
+int use_local_ref(Zeta& zr) { Zeta& z = zr; return z.run(); }
+
+}  // namespace ns
+"""
+
+
+def test_cpp_local_reference_receiver_resolves(
+    temp_repo: Path,
+    mock_ingestor: MagicMock,
+) -> None:
+    project = temp_repo / "cpp_local_ref"
+    project.mkdir()
+    (project / "s.cpp").write_text(_LOCAL_REF_SOURCE, encoding="utf-8")
+
+    run_updater(project, mock_ingestor)
+
+    calls = _calls_to_run(mock_ingestor)
+    caller = next(q for q in calls if q.endswith(".use_local_ref"))
+    assert calls[caller].endswith(".Zeta.run"), (
+        f"z.run() on a `Zeta& z` should resolve to Zeta.run, got {calls[caller]}"
+    )
+
+
+# (H) A single-type-per-name map cannot model true lexical scope, but an inner-block
+# (H) redeclaration must NOT clobber the outer binding for calls made in the outer
+# (H) scope. Traversal is outermost-first, so first-write-wins keeps the outer `Zeta z`
+# (H) even though an inner block shadows it with `Alpha z`; the trailing `z.run()` sits
+# (H) in the outer scope and must bind to Zeta.run.
+_SHADOW_SOURCE = """
+namespace ns {
+
+class Alpha {
+ public:
+  int run() { return 1; }
+};
+
+class Zeta {
+ public:
+  int run() { return 2; }
+};
+
+int use_shadow() {
+  Zeta z;
+  { Alpha z; }
+  return z.run();
+}
+
+}  // namespace ns
+"""
+
+
+def test_cpp_outer_scope_survives_inner_shadow(
+    temp_repo: Path,
+    mock_ingestor: MagicMock,
+) -> None:
+    project = temp_repo / "cpp_shadow"
+    project.mkdir()
+    (project / "s.cpp").write_text(_SHADOW_SOURCE, encoding="utf-8")
+
+    run_updater(project, mock_ingestor)
+
+    calls = _calls_to_run(mock_ingestor)
+    caller = next(q for q in calls if q.endswith(".use_shadow"))
+    assert calls[caller].endswith(".Zeta.run"), (
+        f"outer-scope z.run() should resolve to Zeta.run despite inner Alpha shadow, "
+        f"got {calls[caller]}"
     )

--- a/codebase_rag/tests/test_cpp_receiver_type_dispatch.py
+++ b/codebase_rag/tests/test_cpp_receiver_type_dispatch.py
@@ -162,3 +162,56 @@ def test_cpp_non_conflicting_inner_block_local_is_recorded() -> None:
     assert var_types.get("x") == "Foo", (
         f"an inner-block local with no name collision should resolve, got {var_types}"
     )
+
+
+# (H) One C++ declaration statement can declare several variables (`Zeta a, b;`), each
+# (H) exposed as its own `declarator` field child. Recording only the first left `b`
+# (H) unmapped, so `b.run()` fell back to bare-name resolution. Every declarator in the
+# (H) statement shares the leading type and must be recorded, including mixed
+# (H) pointer/plain forms (`Foo* p, q;`).
+def test_cpp_multi_declarator_declaration_maps_all_names() -> None:
+    node = _first_function_node("void f() { Zeta a, b; Foo* p, q; }")
+    var_types = CppTypeInferenceEngine().build_local_variable_type_map(node, "m")
+    assert var_types.get("a") == "Zeta" and var_types.get("b") == "Zeta", (
+        f"both a and b should map to Zeta, got {var_types}"
+    )
+    assert var_types.get("p") == "Foo" and var_types.get("q") == "Foo", (
+        f"both p and q should map to Foo, got {var_types}"
+    )
+
+
+_MULTI_DECL_SOURCE = """
+namespace ns {
+
+class Alpha {
+ public:
+  int run() { return 1; }
+};
+
+class Zeta {
+ public:
+  int run() { return 2; }
+};
+
+int use_second(Zeta& zr) { Zeta a = zr, b = zr; return b.run(); }
+
+}  // namespace ns
+"""
+
+
+def test_cpp_second_declarator_receiver_resolves(
+    temp_repo: Path,
+    mock_ingestor: MagicMock,
+) -> None:
+    project = temp_repo / "cpp_multi_decl"
+    project.mkdir()
+    (project / "s.cpp").write_text(_MULTI_DECL_SOURCE, encoding="utf-8")
+
+    run_updater(project, mock_ingestor)
+
+    calls = _calls_to_run(mock_ingestor)
+    caller = next(q for q in calls if q.endswith(".use_second"))
+    assert calls[caller].endswith(".Zeta.run"), (
+        f"b.run() on the second declarator `Zeta b` should resolve to Zeta.run, "
+        f"got {calls[caller]}"
+    )

--- a/codebase_rag/tests/test_cpp_receiver_type_dispatch.py
+++ b/codebase_rag/tests/test_cpp_receiver_type_dispatch.py
@@ -215,3 +215,15 @@ def test_cpp_second_declarator_receiver_resolves(
         f"b.run() on the second declarator `Zeta b` should resolve to Zeta.run, "
         f"got {calls[caller]}"
     )
+
+
+# (H) A lambda body opens its own scope. A same-named variable declared inside it must
+# (H) not leak into the enclosing function's map: without the scope guard the inner
+# (H) `Alpha z` conflicts with the outer `Zeta z`, so drop-on-conflict would discard
+# (H) `z` entirely and the outer `z.run()` would fall back to name-only (Alpha.run).
+def test_cpp_lambda_local_does_not_leak_into_enclosing_scope() -> None:
+    node = _first_function_node("void f() { Zeta z; auto g = [](){ Alpha z; }; }")
+    var_types = CppTypeInferenceEngine().build_local_variable_type_map(node, "m")
+    assert var_types.get("z") == "Zeta", (
+        f"outer z should stay Zeta despite a lambda-local Alpha z, got {var_types}"
+    )

--- a/codebase_rag/tests/test_cpp_receiver_type_dispatch.py
+++ b/codebase_rag/tests/test_cpp_receiver_type_dispatch.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.conftest import (
+    get_relationships,
+    run_updater,
+)
+
+# (H) Two classes define a method of the same name; only the receiver's type tells
+# (H) which one a call `z->run()` / `z.run()` targets. cgr resolved C++ member calls
+# (H) by the bare method name (the field_expression yielded only `run`), so the
+# (H) name-only trie fallback bound every `run()` call to whichever `run` sorted
+# (H) first (`Alpha.run`), regardless of the receiver. With receiver type inference
+# (H) (parameter/local var -> bare class name), `z` is a `Zeta`, so the call must
+# (H) resolve to `Zeta.run`. `Alpha` sorts before `Zeta`, so the wrong (old) answer
+# (H) is deterministic and this test is a real RED.
+CPP_SOURCE = """
+namespace ns {
+
+class Alpha {
+ public:
+  int run() { return 1; }
+};
+
+class Zeta {
+ public:
+  int run() { return 2; }
+};
+
+int use_ptr(Zeta* z) { return z->run(); }
+
+int use_val(Zeta z) { return z.run(); }
+
+}  // namespace ns
+"""
+
+
+def _calls_to_run(mock_ingestor: MagicMock) -> dict[str, str]:
+    # (H) map caller-qn -> callee-qn for every CALLS edge whose callee is a `run`.
+    out: dict[str, str] = {}
+    for c in get_relationships(mock_ingestor, "CALLS"):
+        callee = str(c.args[2][2])
+        if callee.rsplit(".", 1)[-1] == "run":
+            out[str(c.args[0][2])] = callee
+    return out
+
+
+def test_cpp_member_call_resolves_via_receiver_type(
+    temp_repo: Path,
+    mock_ingestor: MagicMock,
+) -> None:
+    project = temp_repo / "cpp_recv"
+    project.mkdir()
+    (project / "s.cpp").write_text(CPP_SOURCE, encoding="utf-8")
+
+    run_updater(project, mock_ingestor)
+
+    calls = _calls_to_run(mock_ingestor)
+    ptr_caller = next(q for q in calls if q.endswith(".use_ptr"))
+    val_caller = next(q for q in calls if q.endswith(".use_val"))
+
+    assert calls[ptr_caller].endswith(".Zeta.run"), (
+        f"z->run() should resolve to Zeta.run, got {calls[ptr_caller]}"
+    )
+    assert calls[val_caller].endswith(".Zeta.run"), (
+        f"z.run() should resolve to Zeta.run, got {calls[val_caller]}"
+    )

--- a/codebase_rag/tests/test_type_inference_iterative.py
+++ b/codebase_rag/tests/test_type_inference_iterative.py
@@ -259,7 +259,6 @@ class TestBuildLocalVariableTypeMapDispatch:
             cs.SupportedLanguage.RUST,
             cs.SupportedLanguage.GO,
             cs.SupportedLanguage.SCALA,
-            cs.SupportedLanguage.CPP,
             cs.SupportedLanguage.PHP,
         ],
     )


### PR DESCRIPTION
## What

C++ member calls through an object (`obj->method()`, `obj.method()`) resolved by method simple-name alone. When two unrelated classes both defined a method of the same name, cgr picked among the candidates arbitrarily, so `z->run()` on a `Zeta* z` could be attributed to `Alpha.run`.

This adds receiver type inference for C++:

- `CppTypeInferenceEngine.build_local_variable_type_map` maps each in-scope variable (function parameters and local declarations) to its declared class type, unwrapping pointer/reference/init declarators and template types.
- `call_processor` uses that map: for a `field_expression` receiver that is a simple identifier, it emits `<receiver>.<method>` so the resolver walks the object -> type -> class.method path instead of guessing by simple name.
- Wires the CPP engine into the shared `type_inference` dispatch and removes CPP from the iterative "unsupported language" list.

## Test

`test_cpp_member_call_resolves_via_receiver_type`: two classes (`Zeta`, `Alpha`) each expose `run()`; a `Zeta* z` calling `z->run()` must resolve to `Zeta.run`, not `Alpha.run`. RED before the change, GREEN after.

Full suite: 4245 passed.