### PR TITLE
fix(doctor): catch mgclient.Error and correct README stack-start command

### DIFF
--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -34,7 +34,7 @@ The package installs a `cgr` command.
 **Start Memgraph, parse a repo, and query it:**
 
 ```bash
-docker compose up -d                       # start Memgraph
+cgr daemon up                              # start Memgraph + Qdrant
 cgr start --repo-path ./my-project \
           --update-graph --clean           # parse & launch interactive chat
 ```

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ ollama pull llama3.2
 
 4. **Start Memgraph database**:
 ```bash
-docker compose up -d
+cgr daemon up
 ```
 
 5. **Verify installation**:

--- a/codebase_rag/tests/test_health_checker.py
+++ b/codebase_rag/tests/test_health_checker.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import mgclient  # ty: ignore[unresolved-import]
+import pytest
+
+from codebase_rag.tools.health_checker import HealthChecker
+
+
+def test_check_memgraph_connection_returns_failure_when_down(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def raise_operational_error(**_: object) -> object:
+        raise mgclient.OperationalError("connection refused")
+
+    monkeypatch.setattr(mgclient, "connect", raise_operational_error)
+
+    result = HealthChecker().check_memgraph_connection()
+
+    assert result.passed is False

--- a/codebase_rag/tools/health_checker.py
+++ b/codebase_rag/tools/health_checker.py
@@ -84,7 +84,7 @@ class HealthChecker:
                 ),
             )
 
-        except mgclient.MemgraphError as e:
+        except mgclient.Error as e:
             return HealthCheckResult(
                 name=cs.HEALTH_CHECK_MEMGRAPH_FAILED,
                 passed=False,


### PR DESCRIPTION
## What

Two runtime issues found while verifying that the PyPI project page (0.0.187) is accurate against the shipped package.

### 1. `cgr doctor` crashes when Memgraph is down
`check_memgraph_connection()` caught `mgclient.MemgraphError`, which does not exist on `mgclient` (it exposes `Error`, `DatabaseError`, `OperationalError`, ...). Evaluating that `except` clause on a connection failure raised `AttributeError` instead of reporting the check as failed, so `doctor` blew up in exactly the situation it exists to diagnose.

Fixed by catching `mgclient.Error` (the DB-API base). Connection failures raise `mgclient.OperationalError`, a subclass.

RED → GREEN: `codebase_rag/tests/test_health_checker.py` was written first, confirmed failing with the `AttributeError`, then the one-line fix makes it pass. Verified with a real `cgr doctor` run (stack down): now prints "Memgraph connection failed" and exits 0.

### 2. README stack-start command is not runnable
Both READMEs told users to run `docker compose up -d` to start Memgraph, but there is no compose file in a user's working directory (it is bundled inside the package and copied to `~/.cgr/`). Replaced with `cgr daemon up`, the actual runnable command.

## Checks
- `ruff check` / `ruff format`: clean
- `ty check`: clean
- `pytest -n auto` on health/stack tests: 21 passed