### PR TITLE
fix(cpp): suppress trie fallback for member calls on external-typed receivers

### DIFF
--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -278,6 +278,17 @@ class CallResolver:
                 self._simple_resolution_cache[cache_key] = None
             return None
 
+        # (H) A member call `obj.method` whose receiver has a KNOWN inferred type that is
+        # (H) not a first-party class is a call on an external object (e.g. a
+        # (H) `std::string`). Precise local-type resolution above already failed, so the
+        # (H) method lives on the external type; do NOT let the simple-name trie fallback
+        # (H) rebind it to an unrelated first-party method of the same name. Untyped
+        # (H) receivers keep the fallback (their type is unknown, not known-external).
+        if self._receiver_type_is_external(call_name, module_qn, local_var_types):
+            if use_cache:
+                self._simple_resolution_cache[cache_key] = None
+            return None
+
         result = self._try_resolve_via_trie(call_name, module_qn)
         if use_cache:
             self._simple_resolution_cache[cache_key] = result
@@ -308,6 +319,47 @@ class CallResolver:
         if target.split(cs.SEPARATOR_DOT, 1)[0] == project_root:
             return False
         return f"{project_root}{cs.SEPARATOR_DOT}{target}" not in self.function_registry
+
+    def _receiver_type_is_external(
+        self,
+        call_name: str,
+        module_qn: str,
+        local_var_types: dict[str, str] | None,
+    ) -> bool:
+        # (H) True only for a two-part dotted member call `obj.method` whose `obj` has an
+        # (H) inferred local type that is known to be external. The receiver type is
+        # (H) external when it resolves to nothing, or to a qn that is neither registered
+        # (H) nor rooted at the project (a `std::string` -> `std.string`). In that case
+        # (H) the method lives on the external type, so the simple-name trie fallback must
+        # (H) not rebind it to a same-named first-party method. An untyped receiver (obj
+        # (H) absent from the map) or a project-rooted type is left alone: its method may
+        # (H) still be resolved by the fallback (e.g. a cross-file imported-class call the
+        # (H) precise path missed), so only a provably external type is suppressed.
+        if not local_var_types or cs.SEPARATOR_DOT not in call_name:
+            return False
+        parts = call_name.split(cs.SEPARATOR_DOT)
+        if len(parts) != 2:
+            return False
+        var_type = local_var_types.get(parts[0])
+        if var_type is None:
+            return False
+        import_map = self.import_processor.import_mapping.get(module_qn, {})
+        class_qn = self._resolve_class_qn_from_type(var_type, import_map, module_qn)
+        if not class_qn:
+            return True
+        # (H) First-party class qns may be written without the project prefix (a bare
+        # (H) `from models.user import User` resolves to `models.user.User` while the
+        # (H) registry stores `proj.models.user.User`), so check both the qn as-is and
+        # (H) the project-prefixed form before judging a type external -- mirrors
+        # (H) _is_external_import. A project-rooted qn is always treated as first-party.
+        project_root = module_qn.split(cs.SEPARATOR_DOT, 1)[0]
+        if class_qn.split(cs.SEPARATOR_DOT, 1)[0] == project_root:
+            return False
+        return (
+            class_qn not in self.function_registry
+            and f"{project_root}{cs.SEPARATOR_DOT}{class_qn}"
+            not in self.function_registry
+        )
 
     def _try_resolve_iife(
         self, call_name: str, module_qn: str

--- a/codebase_rag/tests/test_cpp_receiver_type_dispatch.py
+++ b/codebase_rag/tests/test_cpp_receiver_type_dispatch.py
@@ -227,3 +227,49 @@ def test_cpp_lambda_local_does_not_leak_into_enclosing_scope() -> None:
     assert var_types.get("z") == "Zeta", (
         f"outer z should stay Zeta despite a lambda-local Alpha z, got {var_types}"
     )
+
+
+# (H) When a receiver's inferred type is NOT a first-party class (a `std::string`, any
+# (H) external/STL type), a member call on it must not fall through to the bare-method
+# (H) trie fallback and rebind to a same-named first-party method. Here `s` is a
+# (H) `std::string`, so `s.size()` is an external call; it must NOT resolve to the
+# (H) first-party `ns.Widget.size`. Before the guard, the trie fallback bound the bare
+# (H) `size` to `Widget.size` (the only first-party `size`), a precision bug the C++
+# (H) retrieval eval flagged on leveldb.
+_EXTERNAL_RECEIVER_SOURCE = """
+#include <string>
+
+namespace ns {
+
+class Widget {
+ public:
+  int size() { return 1; }
+};
+
+int use(std::string s) { return s.size(); }
+
+}  // namespace ns
+"""
+
+
+def test_cpp_external_receiver_call_is_not_rebound_to_first_party(
+    temp_repo: Path,
+    mock_ingestor: MagicMock,
+) -> None:
+    project = temp_repo / "cpp_ext"
+    project.mkdir()
+    (project / "s.cpp").write_text(_EXTERNAL_RECEIVER_SOURCE, encoding="utf-8")
+
+    run_updater(project, mock_ingestor)
+
+    # (H) `use` calls std::string::size, which is external; no CALLS edge from it to
+    # (H) the first-party Widget.size may be emitted.
+    bad = [
+        (str(c.args[0][2]), str(c.args[2][2]))
+        for c in get_relationships(mock_ingestor, "CALLS")
+        if str(c.args[0][2]).endswith(".use")
+        and str(c.args[2][2]).endswith(".Widget.size")
+    ]
+    assert not bad, (
+        f"std::string.size() must not resolve to first-party Widget.size, got {bad}"
+    )


### PR DESCRIPTION
## What

A C++ member call whose receiver has a known external type (e.g. `std::string s; s.size();`) was mis-resolved to a same-named first-party method by the bare-name trie fallback. When receiver type inference resolves `s` to `std::string` (`std.string`), precise local-type resolution correctly fails (the type is not a first-party class), but the call then fell through to the simple-name trie which rebinds `size` to whichever first-party `size` method exists. This is the residual precision gap the C++ retrieval eval flagged on leveldb.

This adds a guard mirroring the existing external-import suppression (`_is_external_import`): for a two-part member call `obj.method`, if `obj` has an inferred local type that resolves to no first-party class (an unresolvable type, or a qn neither registered nor registered under the project prefix, rooted outside the project), the trie fallback is skipped and no edge is emitted.

Deliberately conservative to preserve recall:
- An untyped receiver (not in the local type map) keeps the fallback: its type is unknown, not known-external.
- A receiver whose type resolves to a first-party class is left alone, including bare-prefixed imports (`from models.user import User` -> `models.user.User`, stored project-prefixed) and cross-file imported-class calls the precise path missed.

## Test

`test_cpp_external_receiver_call_is_not_rebound_to_first_party`: a `std::string` receiver calling `.size()` must not produce a CALLS edge to a first-party `Widget.size`. RED before the guard, GREEN after.

Full suite: 4253 passed. Verified no regression across the Python imported-class/return-type inference suites (the guard's first cut over-suppressed those; the project-prefixed registry check restores them).