### PR TITLE
feat(cpp): infer member-field receiver types so field method calls resolve cross-file

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -873,7 +873,7 @@ class CallProcessor:
         if language in _TYPED_LANGUAGES:
             local_var_types = (
                 self._resolver.type_inference.build_local_variable_type_map(
-                    caller_node, module_qn, language
+                    caller_node, module_qn, language, class_context
                 )
             )
         else:

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -14,6 +14,7 @@ from ...config import settings
 from ...language_spec import LanguageSpec
 from ...types_defs import ASTNode, PropertyDict
 from ...utils.path_utils import cached_relative_path, cached_resolve_posix
+from ..cpp import CppTypeInferenceEngine
 from ..java import utils as java_utils
 from ..py import resolve_class_name
 from ..rs import utils as rs_utils
@@ -102,6 +103,7 @@ class ClassIngestMixin:
     module_qn_to_file_path: dict[str, Path]
     import_processor: ImportProcessor
     class_inheritance: dict[str, list[str]]
+    class_field_types: dict[str, dict[str, str]]
     _deferred_forward_decls: list[_DeferredForwardDecl]
 
     def _namespace_qn(self, class_qn: str, module_qn: str) -> str:
@@ -372,6 +374,12 @@ class ClassIngestMixin:
             self._resolve_to_qn,
             self.function_registry,
         )
+        if language == cs.SupportedLanguage.CPP:
+            # (H) Record this class's member-field types now (from the class body,
+            # (H) usually a header) so out-of-line method bodies in other files can
+            # (H) resolve `field_.method()` via the field's type at call resolution.
+            if field_types := CppTypeInferenceEngine().build_field_type_map(class_node):
+                self.class_field_types[class_qn] = field_types
         self._ingest_class_methods(
             class_node,
             class_qn,

--- a/codebase_rag/parsers/cpp/type_inference.py
+++ b/codebase_rag/parsers/cpp/type_inference.py
@@ -51,24 +51,35 @@ class CppTypeInferenceEngine:
         # (H) out-of-line method bodies, so this is captured once at class ingestion and
         # (H) looked up by the enclosing class qn at call resolution.
         field_types: dict[str, str] = {}
-        body = class_node.child_by_field_name(cs.FIELD_BODY)
-        if body is None:
-            return field_types
-        for child in body.children:
-            if child.type != cs.CppNodeType.FIELD_DECLARATION:
-                continue
-            type_node = child.child_by_field_name(cs.FIELD_TYPE)
-            if type_node is None or not (type_name := self._bare_type_name(type_node)):
-                continue
-            for declarator in child.children_by_field_name(cs.FIELD_DECLARATOR):
-                # (H) A member function declaration (`void Lock();`) is also a
-                # (H) field_declaration, but its declarator is a function_declarator;
-                # (H) only data members are fields.
-                if declarator.type == cs.CppNodeType.FUNCTION_DECLARATOR:
-                    continue
-                if (name := self._declarator_name(declarator)) is not None:
-                    field_types.setdefault(name, type_name)
+        if body := class_node.child_by_field_name(cs.FIELD_BODY):
+            self._collect_fields(body, field_types)
         return field_types
+
+    def _collect_fields(self, node: Node, field_types: dict[str, str]) -> None:
+        for child in node.children:
+            # (H) A nested type / function / lambda opens its own member scope; its
+            # (H) declarations are not this class's fields. Preprocessor blocks
+            # (H) (`#ifdef ... #endif`) are transparent, so recurse through them to
+            # (H) reach fields declared conditionally.
+            if child.type in cs.CPP_NESTED_SCOPE_NODE_TYPES:
+                continue
+            if child.type == cs.CppNodeType.FIELD_DECLARATION:
+                self._record_field(child, field_types)
+                continue
+            self._collect_fields(child, field_types)
+
+    def _record_field(self, node: Node, field_types: dict[str, str]) -> None:
+        type_node = node.child_by_field_name(cs.FIELD_TYPE)
+        if type_node is None or not (type_name := self._bare_type_name(type_node)):
+            return
+        for declarator in node.children_by_field_name(cs.FIELD_DECLARATOR):
+            # (H) A member function declaration (`void Lock();`) is also a
+            # (H) field_declaration, but its declarator is a function_declarator;
+            # (H) only data members are fields.
+            if declarator.type == cs.CppNodeType.FUNCTION_DECLARATOR:
+                continue
+            if (name := self._declarator_name(declarator)) is not None:
+                field_types.setdefault(name, type_name)
 
     def _function_declarator(self, caller_node: Node) -> Node | None:
         # (H) The parameter_list hangs off the (possibly pointer/reference-wrapped)

--- a/codebase_rag/parsers/cpp/type_inference.py
+++ b/codebase_rag/parsers/cpp/type_inference.py
@@ -44,6 +44,32 @@ class CppTypeInferenceEngine:
             var_types[name] = type_name
         return var_types
 
+    def build_field_type_map(self, class_node: Node) -> dict[str, str]:
+        # (H) Map each data member of a C++ class to its bare type name, so a member
+        # (H) call `field_.method()` inside the class's methods can resolve via the
+        # (H) field's type. Fields live in the class body (often a header) separate from
+        # (H) out-of-line method bodies, so this is captured once at class ingestion and
+        # (H) looked up by the enclosing class qn at call resolution.
+        field_types: dict[str, str] = {}
+        body = class_node.child_by_field_name(cs.FIELD_BODY)
+        if body is None:
+            return field_types
+        for child in body.children:
+            if child.type != cs.CppNodeType.FIELD_DECLARATION:
+                continue
+            type_node = child.child_by_field_name(cs.FIELD_TYPE)
+            if type_node is None or not (type_name := self._bare_type_name(type_node)):
+                continue
+            for declarator in child.children_by_field_name(cs.FIELD_DECLARATOR):
+                # (H) A member function declaration (`void Lock();`) is also a
+                # (H) field_declaration, but its declarator is a function_declarator;
+                # (H) only data members are fields.
+                if declarator.type == cs.CppNodeType.FUNCTION_DECLARATOR:
+                    continue
+                if (name := self._declarator_name(declarator)) is not None:
+                    field_types.setdefault(name, type_name)
+        return field_types
+
     def _function_declarator(self, caller_node: Node) -> Node | None:
         # (H) The parameter_list hangs off the (possibly pointer/reference-wrapped)
         # (H) function_declarator in the definition's declarator chain.
@@ -124,7 +150,10 @@ class CppTypeInferenceEngine:
         # (H) Unwrap pointer/reference/init declarators down to the bound identifier.
         current = declarator
         while current is not None:
-            if current.type == cs.CppNodeType.IDENTIFIER:
+            if current.type in (
+                cs.CppNodeType.IDENTIFIER,
+                cs.CppNodeType.FIELD_IDENTIFIER,
+            ):
                 return safe_decode_text(current)
             if inner := current.child_by_field_name(cs.FIELD_DECLARATOR):
                 current = inner
@@ -140,6 +169,7 @@ class CppTypeInferenceEngine:
         for child in node.children:
             if child.type in (
                 cs.CppNodeType.IDENTIFIER,
+                cs.CppNodeType.FIELD_IDENTIFIER,
                 cs.CppNodeType.REFERENCE_DECLARATOR,
                 cs.CppNodeType.POINTER_DECLARATOR,
                 cs.CppNodeType.INIT_DECLARATOR,

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -52,6 +52,11 @@ class DefinitionProcessor(
         self.import_processor = import_processor
         self.module_qn_to_file_path = module_qn_to_file_path
         self.class_inheritance: dict[str, list[str]] = {}
+        # (H) {class_qn: {field_name: bare_type_name}} for C++ member fields, so a
+        # (H) member call `field_.method()` in a (possibly out-of-line, cross-file)
+        # (H) method resolves via the field's declared type. Populated at class
+        # (H) ingestion, read by the type-inference engine at call resolution.
+        self.class_field_types: dict[str, dict[str, str]] = {}
         self._deferred_cpp_methods: list = []
         self._deferred_go_methods: list = []
         self._deferred_forward_decls: list = []

--- a/codebase_rag/parsers/factory.py
+++ b/codebase_rag/parsers/factory.py
@@ -118,6 +118,7 @@ class ProcessorFactory:
                 module_qn_to_file_path=self.module_qn_to_file_path,
                 class_inheritance=self.definition_processor.class_inheritance,
                 simple_name_lookup=self.simple_name_lookup,
+                class_field_types=self.definition_processor.class_field_types,
             )
         return self._type_inference
 

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -155,9 +155,29 @@ class TypeInferenceEngine:
         # (H) When the caller is a method, overlay its class's member-field types as a
         # (H) base so a bare `field_.method()` receiver resolves; parameters and locals
         # (H) with the same name shadow a field, so the local map wins on conflict.
-        if class_context and (fields := self.class_field_types.get(class_context)):
+        if class_context and (fields := self._collect_field_types(class_context)):
             return {**fields, **local}
         return local
+
+    def _collect_field_types(self, class_qn: str) -> dict[str, str]:
+        # (H) Collect member-field types along the inheritance chain so a derived class
+        # (H) method can resolve a field inherited from a base. Bases are visited first
+        # (H) and the class's own fields applied last, so a derived field shadows a
+        # (H) base field of the same name. Guards against inheritance cycles.
+        fields: dict[str, str] = {}
+        seen: set[str] = set()
+
+        def collect(qn: str) -> None:
+            if qn in seen:
+                return
+            seen.add(qn)
+            for base in self.class_inheritance.get(qn, []):
+                collect(base)
+            if own := self.class_field_types.get(qn):
+                fields.update(own)
+
+        collect(class_qn)
+        return fields
 
     def _build_local_variable_type_map(
         self, caller_node: ASTNode, module_qn: str, language: cs.SupportedLanguage

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -31,6 +31,7 @@ class TypeInferenceEngine:
         "module_qn_to_file_path",
         "class_inheritance",
         "simple_name_lookup",
+        "class_field_types",
         "_java_type_inference",
         "_lua_type_inference",
         "_js_type_inference",
@@ -50,6 +51,7 @@ class TypeInferenceEngine:
         module_qn_to_file_path: dict[str, Path],
         class_inheritance: dict[str, list[str]],
         simple_name_lookup: SimpleNameLookup,
+        class_field_types: dict[str, dict[str, str]] | None = None,
     ):
         self.import_processor = import_processor
         self.function_registry = function_registry
@@ -60,6 +62,13 @@ class TypeInferenceEngine:
         self.module_qn_to_file_path = module_qn_to_file_path
         self.class_inheritance = class_inheritance
         self.simple_name_lookup = simple_name_lookup
+        # (H) Must preserve the shared dict reference: the factory passes the
+        # (H) DefinitionProcessor's map, which is empty at construction and populated
+        # (H) later during ingestion. `or {}` would swap an empty dict for a new one and
+        # (H) silently lose every field type written afterward.
+        self.class_field_types = (
+            class_field_types if class_field_types is not None else {}
+        )
 
         self._java_type_inference: JavaTypeInferenceEngine | None = None
         self._lua_type_inference: LuaTypeInferenceEngine | None = None
@@ -136,6 +145,21 @@ class TypeInferenceEngine:
         return self._python_type_inference
 
     def build_local_variable_type_map(
+        self,
+        caller_node: ASTNode,
+        module_qn: str,
+        language: cs.SupportedLanguage,
+        class_context: str | None = None,
+    ) -> dict[str, str]:
+        local = self._build_local_variable_type_map(caller_node, module_qn, language)
+        # (H) When the caller is a method, overlay its class's member-field types as a
+        # (H) base so a bare `field_.method()` receiver resolves; parameters and locals
+        # (H) with the same name shadow a field, so the local map wins on conflict.
+        if class_context and (fields := self.class_field_types.get(class_context)):
+            return {**fields, **local}
+        return local
+
+    def _build_local_variable_type_map(
         self, caller_node: ASTNode, module_qn: str, language: cs.SupportedLanguage
     ) -> dict[str, str]:
         match language:

--- a/codebase_rag/tests/test_cpp_member_field_receiver.py
+++ b/codebase_rag/tests/test_cpp_member_field_receiver.py
@@ -181,3 +181,70 @@ def test_cpp_out_of_line_member_field_call_resolves_cross_file(
         f"buffer_.clear() on a std::string field must not resolve first-party, "
         f"got {callees}"
     )
+
+
+# (H) Member fields are frequently declared inside preprocessor conditionals
+# (H) (`#ifdef`), which wrap the field_declaration in a preproc_ifdef node. Iterating
+# (H) only the class body's direct children misses them; the collector must recurse
+# (H) through preprocessor blocks while still skipping nested type/function scopes.
+def test_cpp_build_field_type_map_captures_fields_in_preproc_blocks() -> None:
+    src = """
+class C {
+ private:
+  Mutex mutex_;
+#ifdef LEVELDB_FOO
+  Slice cond_;
+#endif
+};
+"""
+    fields = CppTypeInferenceEngine().build_field_type_map(_first_class_node(src))
+    assert fields == {"mutex_": "Mutex", "cond_": "Slice"}, fields
+
+
+# (H) A derived class accesses fields inherited from its base. The receiver map must
+# (H) collect fields along the inheritance chain (derived shadows base). `Alpha.Lock`
+# (H) is a same-named competitor that sorts first, so name-only resolution picks it;
+# (H) only the inherited field type resolves `mutex_.Lock()` to Mutex.Lock.
+_INHERITED_SOURCE = """
+namespace ns {
+
+class Alpha {
+ public:
+  void Lock() {}
+};
+
+class Mutex {
+ public:
+  void Lock() {}
+};
+
+class Base {
+ protected:
+  Mutex mutex_;
+};
+
+class Derived : public Base {
+ public:
+  void Run() { mutex_.Lock(); }
+};
+
+}  // namespace ns
+"""
+
+
+def test_cpp_inherited_member_field_resolves(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    project = temp_repo / "cpp_field_inherit"
+    project.mkdir()
+    (project / "s.cpp").write_text(_INHERITED_SOURCE, encoding="utf-8")
+
+    run_updater(project, mock_ingestor)
+
+    callees = _calls_from(mock_ingestor, ".Derived.Run")
+    assert any(c.endswith(".Mutex.Lock") for c in callees), (
+        f"inherited field mutex_.Lock() should resolve to Mutex.Lock, got {callees}"
+    )
+    assert not any(c.endswith(".Alpha.Lock") for c in callees), (
+        f"inherited mutex_.Lock() must not resolve to Alpha.Lock, got {callees}"
+    )

--- a/codebase_rag/tests/test_cpp_member_field_receiver.py
+++ b/codebase_rag/tests/test_cpp_member_field_receiver.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.parsers.cpp import CppTypeInferenceEngine
+from codebase_rag.tests.conftest import get_relationships, run_updater
+
+
+def _first_class_node(source: str):
+    parsers, _ = load_parsers()
+    tree = parsers["cpp"].parse(source.encode("utf-8"))
+
+    def walk(node):
+        if node.type in ("class_specifier", "struct_specifier"):
+            return node
+        for child in node.children:
+            if (found := walk(child)) is not None:
+                return found
+        return None
+
+    node = walk(tree.root_node)
+    assert node is not None
+    return node
+
+
+def _calls_from(mock_ingestor: MagicMock, caller_suffix: str) -> set[str]:
+    return {
+        str(c.args[2][2])
+        for c in get_relationships(mock_ingestor, "CALLS")
+        if str(c.args[0][2]).endswith(caller_suffix)
+    }
+
+
+# (H) Member data declarations use `field_identifier`, not `identifier`, and a member
+# (H) FUNCTION declaration (`void Lock();`) is also a field_declaration but with a
+# (H) function_declarator -- only data members are fields. Pointer/qualified/template
+# (H) types reduce to a bare type name the resolver can map to a class.
+def test_cpp_build_field_type_map_captures_data_members_only() -> None:
+    src = """
+class DBImpl {
+ public:
+  void Lock();
+  int Count(int x);
+ private:
+  port::Mutex mutex_;
+  std::string buffer_;
+  Foo* ptr_;
+  int counter_, extra_;
+};
+"""
+    fields = CppTypeInferenceEngine().build_field_type_map(_first_class_node(src))
+    # (H) Only class-typed fields are recorded: primitive-typed members (`int
+    # (H) counter_, extra_;`) can never be a method-call receiver, so they are omitted.
+    assert fields == {
+        "mutex_": "Mutex",
+        "buffer_": "string",
+        "ptr_": "Foo",
+    }, fields
+    assert "Lock" not in fields and "Count" not in fields
+
+
+# (H) A first-party member field receiver: `mutex_.Lock()` must resolve to the field's
+# (H) class method, not fall to a name-only guess. `Alpha` also defines `Lock` and sorts
+# (H) before `Mutex`, so the name-only trie fallback deterministically picks the WRONG
+# (H) `Alpha.Lock` -- only the field's type disambiguates. The method is defined INLINE
+# (H) here, so field decls and the call are in the same AST.
+_INLINE_SOURCE = """
+namespace ns {
+
+class Alpha {
+ public:
+  void Lock() {}
+};
+
+class Mutex {
+ public:
+  void Lock() {}
+};
+
+class DB {
+ public:
+  void Run() { mutex_.Lock(); }
+ private:
+  Mutex mutex_;
+};
+
+}  // namespace ns
+"""
+
+
+def test_cpp_inline_member_field_call_resolves_to_field_type(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    project = temp_repo / "cpp_field_inline"
+    project.mkdir()
+    (project / "s.cpp").write_text(_INLINE_SOURCE, encoding="utf-8")
+
+    run_updater(project, mock_ingestor)
+
+    callees = _calls_from(mock_ingestor, ".DB.Run")
+    assert any(c.endswith(".Mutex.Lock") for c in callees), (
+        f"mutex_.Lock() should resolve to Mutex.Lock via the field type, got {callees}"
+    )
+    assert not any(c.endswith(".Alpha.Lock") for c in callees), (
+        f"mutex_.Lock() must not resolve to the same-named Alpha.Lock, got {callees}"
+    )
+
+
+# (H) The real leveldb shape: the class (with its fields) is declared in a header and
+# (H) the method is defined OUT-OF-LINE in a .cc, so the field declarations live in a
+# (H) different translation unit than the method body. Field types must therefore be
+# (H) captured at class ingestion and looked up by the enclosing class qn.
+# (H) `Alpha.Lock` (sorts before `Mutex.Lock`) and `Buf.clear` are same-named
+# (H) first-party competitors: without field-type inference the name-only trie binds
+# (H) mutex_.Lock() to Alpha.Lock and buffer_.clear() to Buf.clear.
+_HEADER = """
+namespace ns {
+
+class Alpha {
+ public:
+  void Lock();
+};
+
+class Mutex {
+ public:
+  void Lock();
+};
+
+class Buf {
+ public:
+  void clear();
+};
+
+class DB {
+ public:
+  void Run();
+ private:
+  Mutex mutex_;
+  std::string buffer_;
+};
+
+}  // namespace ns
+"""
+
+_IMPL = """
+#include "db.h"
+
+namespace ns {
+
+void Mutex::Lock() {}
+
+void DB::Run() {
+  mutex_.Lock();
+  buffer_.clear();
+}
+
+}  // namespace ns
+"""
+
+
+def test_cpp_out_of_line_member_field_call_resolves_cross_file(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    project = temp_repo / "cpp_field_xfile"
+    project.mkdir()
+    (project / "db.h").write_text(_HEADER, encoding="utf-8")
+    (project / "db.cc").write_text(_IMPL, encoding="utf-8")
+
+    run_updater(project, mock_ingestor)
+
+    callees = _calls_from(mock_ingestor, ".DB.Run")
+    # (H) FN fix: first-party Mutex field method resolves cross-file.
+    assert any(c.endswith(".Mutex.Lock") for c in callees), (
+        f"mutex_.Lock() should resolve to Mutex.Lock across files, got {callees}"
+    )
+    # (H) FP fix: buffer_ is a std::string (external), so buffer_.clear() must NOT be
+    # (H) rebound to any first-party clear method.
+    assert not any(c.endswith(".clear") for c in callees), (
+        f"buffer_.clear() on a std::string field must not resolve first-party, "
+        f"got {callees}"
+    )

--- a/evals/README.md
+++ b/evals/README.md
@@ -665,8 +665,9 @@ counted as a first-party `size` edge. Pinned by
 the `libclang` oracle on a header-free namespaced fixture.
 
 Running it on a real project (`leveldb`, 40 of 42 core sources parsed cleanly; the
-other two are Windows-only or need gmock) gives precision **0.96**, recall
-**0.82**, F1 0.88 — recall up from **0.54** before the fix below.
+other two are Windows-only or need gmock) gives precision **0.99**, recall
+**0.83**, F1 **0.90** — recall up from **0.54** before the namespace fix below, and
+precision lifted from 0.96 by the receiver type inference chain (next section).
 
 **The dominant gap was a real cgr bug: the call pass dropped the namespace from
 the caller qn.** The definition pass binds a C++ free function or class inside a
@@ -680,25 +681,35 @@ routes both the free-function and class qns through the same
 always agree (RED test `test_cpp_namespace_call_caller_qn.py`). Dangling sources
 fell to 251 and recall rose 0.54 → 0.82.
 
+**Three follow-on cgr fixes then landed on top of the namespace fix, building out
+C++ receiver type inference:** (a) C++ joined the typed-language set with an engine
+(`parsers/cpp/type_inference.py`) mapping parameters and local variables — including
+reference declarators, multi-variable declarations, and drop-on-conflict lexical
+scope handling — to their class types, so `obj->method()` resolves to the method on
+the receiver's class instead of by bare name; (b) a member call whose receiver has a
+known external type (a `std::string`) skips the name-only trie fallback instead of
+mis-binding to a same-named first-party method (`call_resolver._receiver_type_is_external`);
+(c) member **fields** are captured per class at ingestion (`build_field_type_map`,
+stored in `class_field_types` keyed by class qn) and merged into the receiver map by
+the caller's enclosing class, so `mutex_.Lock()` in an out-of-line method resolves to
+the field's type even though the field is declared in a different file (the header).
+Together these lifted precision **0.96 → 0.99** (false positives 30 → 10) on `leveldb`.
+
 The remaining tail is documented, not scoped away:
 
-- **Operator overloads** (`operator=` ×25, `operator[]`, `operator==`/`!=`):
-  `libclang` records `a = b` and `a[i]` as calls to the overloaded operator
-  methods, while cgr models them as `builtin.cpp.*` operator calls — a metric
-  difference, not a misresolution.
-- **Trie-fallback misresolution of external calls** (the ~30 false positives:
-  `size`, `data`, `empty`, `clear`, `begin`, `end`): when a call's simple name
-  collides with a first-party method, cgr's name-only trie fallback binds the
-  external `std::` call to the same-named first-party method. The oracle correctly
-  treats it as external, so it surfaces as a cgr false positive.
-- **Receiver-type method dispatch and out-of-line static methods** (`DB::Open`):
-  resolving `obj->method()` to the right class needs C++ receiver type inference
-  (C++ is not yet in the typed-language set that builds a local-variable type
-  map), the same deeper gap as the Go/Java/Rust tails.
-
-The last two share one root cause: cgr has no C++ receiver type inference, so it
-resolves member calls by name alone. The eval keeps surfacing it; it is a
-follow-on, not hidden.
+- **Operator overloads** (`operator=` ×25, `operator[]`, `operator==`/`!=`, 23% of
+  the misses): `libclang` records `a = b` and `a[i]` as calls to the overloaded
+  operator methods, while cgr models them as `builtin.cpp.*` operator calls — a
+  metric difference, not a misresolution.
+- **STL calls on non-simple receivers** (the residual `begin`/`end`/`empty`/`clear`
+  false positives): receiver type inference covers parameters, locals, and member
+  fields named by a bare identifier, but not chained receivers (`map_.begin()` via a
+  nested `this->` expression) or STL locals whose element type cgr does not model, so
+  a few external calls still reach the name-only fallback.
+- **Namespace-scoped and singleton calls** (`Schedule`, `SetReadOnlyFDLimit`,
+  `DebugString`): a call on a singleton (`Env::Default()->Schedule()`) or a
+  free/namespace function the oracle attributes to a different site. Each is a
+  distinct smaller sub-case the eval continues to surface; none are hidden.
 
 ## Semantic search — query to function relevance
 


### PR DESCRIPTION
## What

Extends C++ receiver type inference to **member fields**. A member call `field_.method()` inside a method resolved by the method's bare name alone, so it either missed the real edge or mis-bound to a same-named first-party method. cgr never recorded field types.

This captures each C++ class's data-member types at ingestion (`CppTypeInferenceEngine.build_field_type_map`), stores them in a `class_field_types` map keyed by class qn (threaded DefinitionProcessor -> factory -> TypeInferenceEngine, mirroring `class_inheritance`), and merges them into the receiver map by the caller's enclosing class — params/locals shadow a field on name conflict. The existing local-type resolution and external-receiver suppression then do the rest:

- `mutex_.Lock()` where `mutex_` is a first-party `port::Mutex` -> resolves to `Mutex::Lock` (missed edge fixed).
- `buffer_.clear()` where `buffer_` is a `std::string` -> external type, trie fallback suppressed, no false edge.

**Cross-file is the point:** fields are declared in the class body (usually a header) while methods are often defined out-of-line in a .cc. Because field types are captured at class ingestion and looked up by the enclosing class qn, an out-of-line `DB::Run()` in `db.cc` resolves `mutex_` against the `DB` fields declared in `db.h`. Only class-typed fields are recorded (a primitive `int counter_` can never be a receiver); member function declarations (`void Lock();`, also a `field_declaration`) are skipped.

## Impact

leveldb C++ retrieval: precision **0.976 -> 0.9865** (false positives 18 -> 10), F1 0.899 -> 0.904, recall unchanged (the remaining misses are implicit `operator=` and free-function calls, not member fields). The 8 eliminated false positives were exactly the STL member-field calls (`buffer_.clear`, `restarts_.empty`, `arena size`, ...).

## Tests

`test_cpp_member_field_receiver.py`: engine unit test (data members only, primitives and method decls excluded), inline resolution against a same-named competitor (`Alpha.Lock` sorts first, so name-only picks wrong), and cross-file out-of-line resolution proving both the first-party FN fix and the external-field FP fix. RED before, GREEN after.

Full suite: 4257 passed, no regressions (the change touches shared type-inference plumbing; a subtle `or {}` bug that swapped the shared field-types dict for an empty one is fixed with an `is not None` check).