### PR TITLE
docs(evals): document tree-sitter-cpp parse corruption as the C++ retrieval residual root cause

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -701,15 +701,39 @@ The remaining tail is documented, not scoped away:
   the misses): `libclang` records `a = b` and `a[i]` as calls to the overloaded
   operator methods, while cgr models them as `builtin.cpp.*` operator calls — a
   metric difference, not a misresolution.
-- **STL calls on non-simple receivers** (the residual `begin`/`end`/`empty`/`clear`
-  false positives): receiver type inference covers parameters, locals, and member
-  fields named by a bare identifier, but not chained receivers (`map_.begin()` via a
-  nested `this->` expression) or STL locals whose element type cgr does not model, so
-  a few external calls still reach the name-only fallback.
-- **Namespace-scoped and singleton calls** (`Schedule`, `SetReadOnlyFDLimit`,
-  `DebugString`): a call on a singleton (`Env::Default()->Schedule()`) or a
-  free/namespace function the oracle attributes to a different site. Each is a
-  distinct smaller sub-case the eval continues to surface; none are hidden.
+- **tree-sitter-cpp parse corruption in complex files (the dominant residual FP).**
+  Traced to a `tree-sitter-cpp` grammar limitation, not a cgr resolution bug. A
+  preprocessor conditional inside a construct — the reduced minimal trigger is a
+  constructor member-initializer list interrupted by `#if`/`#endif`:
+
+  ```cpp
+  class A { public: A(int n) :
+  #if !defined(NDEBUG)
+      x_(n),
+  #endif
+      y_(n) {} int x_; int y_; };
+  ```
+
+  emits `ERROR` nodes (4 vs 0 without the `#if`). In real files this cascades:
+  `util/env_posix.cc` (24 `ERROR` nodes) mis-nests every sibling class under the
+  first (`Limiter.PosixEnv`), turns `struct ::flock` references into phantom classes,
+  and degrades out-of-line methods like `DBImpl::BuildBatchGroup` into free functions
+  that lose member-field inference — which is what produces the residual `begin`/`end`
+  and `Schedule`/`SetReadOnly*` false positives. Same family as the tree-sitter-c
+  issue tracked in #555. It is an **emergent cascade** — every isolated small
+  reproduction (clean out-of-line methods, same-basename `.h`/`.cc`, an unrelated
+  `#if` error in the same file) resolves correctly, so there is no minimally
+  reproducible cgr-side fix; the fix is upstream (grammar) or the libclang frontend.
+- **The libclang frontend trades this precision gain for recall.** Running the same
+  `leveldb` benchmark with `CPP_FRONTEND=libclang` (a `compile_commands.json` from
+  CMake) parses the corrupt files correctly — env_posix classes nest properly and the
+  FP drop to 1 (precision **0.9975**) — but recall falls to **0.46** (F1 0.63): the
+  frontend emits far fewer `CALLS` edges than the tree-sitter resolver, a diffuse gap
+  (implicit operators, compile-DB parse-context differences from the oracle's
+  per-file parse, and header-inline caller-file attribution). So the default
+  tree-sitter path remains the higher-F1 choice; the libclang frontend is the correct
+  frontend for parse fidelity but needs its own call-edge recall work before it is a
+  drop-in improvement.
 
 ## Semantic search — query to function relevance
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -701,7 +701,7 @@ The remaining tail is documented, not scoped away:
   the misses): `libclang` records `a = b` and `a[i]` as calls to the overloaded
   operator methods, while cgr models them as `builtin.cpp.*` operator calls — a
   metric difference, not a misresolution.
-- **tree-sitter-cpp parse corruption in complex files (the dominant residual FP).**
+- **tree-sitter-cpp parse corruption in complex files (the dominant residual FPs).**
   Traced to a `tree-sitter-cpp` grammar limitation, not a cgr resolution bug. A
   preprocessor conditional inside a construct — the reduced minimal trigger is a
   constructor member-initializer list interrupted by `#if`/`#endif`:
@@ -726,8 +726,8 @@ The remaining tail is documented, not scoped away:
   reproducible cgr-side fix; the fix is upstream (grammar) or the libclang frontend.
 - **The libclang frontend trades this precision gain for recall.** Running the same
   `leveldb` benchmark with `CPP_FRONTEND=libclang` (a `compile_commands.json` from
-  CMake) parses the corrupt files correctly — env_posix classes nest properly and the
-  FP drop to 1 (precision **0.9975**) — but recall falls to **0.46** (F1 0.63): the
+  CMake) parses the corrupt files correctly — `env_posix` classes nest properly and the
+  FP count drops to 1 (precision **0.9975**) — but recall falls to **0.46** (F1 0.63): the
   frontend emits far fewer `CALLS` edges than the tree-sitter resolver, a diffuse gap
   (implicit operators, compile-DB parse-context differences from the oracle's
   per-file parse, and header-inline caller-file attribution). So the default


### PR DESCRIPTION
## What

Completes the C++ retrieval investigation by documenting the root cause of the remaining leveldb false positives in `evals/README.md`.

After the four C++ retrieval fixes (#558, #559, #561, #562) the tree-sitter path reaches P 0.99 / R 0.83 / F1 0.90. Classifying the residual against the leveldb source shows the dominant remaining false positives (`begin`/`end`, `Schedule`/`SetReadOnly*`) are **not** a cgr resolution bug — they trace to a `tree-sitter-cpp` grammar limitation.

## Findings documented

- **Reduced minimal trigger:** a preprocessor conditional inside a constructor member-initializer list (`A(int n) : #if ... x_(n), #endif y_(n) {}`) emits ERROR nodes (4 vs 0 without the `#if`). Same family as the tree-sitter-c issue #555.
- **Cascade:** in `util/env_posix.cc` (24 ERROR nodes) this mis-nests sibling classes under the first (`Limiter.PosixEnv`), makes `struct ::flock` refs phantom classes, and degrades out-of-line methods (`DBImpl::BuildBatchGroup`) into free functions that lose member-field inference — the source of the residual FP.
- **Emergent, not minimally reproducible:** every isolated small reproduction (clean out-of-line methods, same-basename .h/.cc, an unrelated #if error in-file) resolves correctly; only the full-file complexity degrades. So there is no minimally reproducible cgr-side fix — the fix is upstream (grammar) or the libclang frontend.
- **libclang frontend tradeoff (measured):** `CPP_FRONTEND=libclang` on leveldb parses the corrupt files correctly (FP 10 → 1, precision 0.9975) but recall falls to 0.46 (F1 0.63) — it emits far fewer CALLS edges (diffuse: implicit operators, compile-DB parse-context differences, header-inline attribution). So the default tree-sitter path stays the higher-F1 choice; the libclang frontend needs its own call-edge recall work before it is a drop-in improvement.

Docs-only; no code change.