### PR TITLE
fix(cpp): attribute module-scope initializer calls to the Module in the libclang frontend

### DIFF
--- a/codebase_rag/parsers/cpp_frontend/frontend.py
+++ b/codebase_rag/parsers/cpp_frontend/frontend.py
@@ -230,8 +230,6 @@ class _Collector:
         # (H) Resolve the callee semantically via cursor.referenced (libclang did
         # (H) the overload/name resolution already), preferring its definition so
         # (H) the edge targets the node the frontend emitted for the body.
-        if enclosing is None:
-            return
         referenced = cursor.referenced
         if referenced is None:
             return
@@ -246,10 +244,29 @@ class _Collector:
         )
         if callee_qn is None:
             return  # (H) callee outside the indexed repo (stdlib, etc.)
-        caller_label, caller_qn = enclosing
+        caller = enclosing or self._module_caller(cursor)
+        if caller is None:
+            return
+        caller_label, caller_qn = caller
         self._add_edge(
             cs.RelationshipType.CALLS, caller_label, caller_qn, callee_label, callee_qn
         )
+
+    def _module_caller(self, cursor: Cursor) -> _Scope:
+        # (H) A call with no enclosing function/method runs at module load time
+        # (H) (a default member initializer or a file/namespace-scope global
+        # (H) initializer); the tree-sitter path attributes these to the Module,
+        # (H) so mirror that instead of dropping the edge. The call site must be
+        # (H) inside the indexed repo (module_qn is None for system headers).
+        if cursor.location.file is None:
+            return None
+        file_name = cursor.location.file.name
+        module_qn = self.resolver.module_qn(file_name)
+        rel = self.resolver.rel_path(file_name)
+        if module_qn is None or rel is None:
+            return None
+        self._add_module(module_qn, rel, file_name)
+        return (fc.LABEL_MODULE, module_qn)
 
     def _emit_inheritance(self, cursor: Cursor, derived_qn: str) -> None:
         for child in cursor.get_children():

--- a/codebase_rag/tests/test_cpp_frontend_calls.py
+++ b/codebase_rag/tests/test_cpp_frontend_calls.py
@@ -83,3 +83,61 @@ def test_method_calls_free_function(temp_repo: Path) -> None:
         and to_qn.endswith(".m.helper")
         for from_label, from_qn, to_label, to_qn in calls
     ), f"expected Calc.add CALLS helper, got {calls}"
+
+
+# (H) A default member initializer and a namespace-scope global initializer both
+# (H) call compute() with no enclosing function or method. The tree-sitter path
+# (H) attributes such module-load-time calls to the Module node; the libclang
+# (H) frontend previously dropped them (its walk had no enclosing scope to attach
+# (H) the call to), so they must instead fall back to the enclosing Module.
+_INIT_SRC = """
+namespace m {
+
+int compute();
+
+struct S {
+  int x_ = compute();
+  int y_;
+};
+
+int g_val = compute();
+
+int compute() { return 7; }
+
+}  // namespace m
+"""
+
+
+def _write_single(root: Path, source: str) -> None:
+    root.mkdir()
+    (root / "s.cpp").write_text(source, encoding="utf-8")
+    (root / "compile_commands.json").write_text(
+        json.dumps(
+            [
+                {
+                    "directory": str(root),
+                    "arguments": ["c++", "-std=c++17", str(root / "s.cpp")],
+                    "file": str(root / "s.cpp"),
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_module_scope_initializer_calls_attributed_to_module(temp_repo: Path) -> None:
+    root = temp_repo / "initproj"
+    _write_single(root, _INIT_SRC)
+
+    ingestor = MagicMock()
+    run_cpp_frontend(ingestor, root, root.name, root)
+
+    calls = _calls(ingestor)
+    # (H) The two initializer calls collapse to a single Module -> compute edge (the
+    # (H) edge set dedups), matching the caller the tree-sitter path uses.
+    assert any(
+        from_label == "Module"
+        and to_label == "Function"
+        and to_qn.endswith(".m.compute")
+        for from_label, from_qn, to_label, to_qn in calls
+    ), f"expected Module CALLS compute for initializer calls, got {calls}"


### PR DESCRIPTION
## Bug

The libclang C++ frontend's `_process_call` opened with `if enclosing is None: return`, silently dropping every call that has no enclosing function or method scope:

- a default member initializer — `struct S { int x_ = compute(); };`
- a file/namespace-scope global initializer — `int g_val = compute();`

These are first-party calls that libclang resolves, so dropping them under-counts the call graph. The default tree-sitter path already attributes such module-load-time calls to the **Module** node (verified: `Module proj.s -> compute`); the libclang frontend was inconsistent.

## Fix

When there is no enclosing function/method scope, fall back to the enclosing **Module** (`_module_caller`), derived from the call site's own file — matching the tree-sitter path. The call site must be inside the indexed repo (`module_qn`/`rel_path` are `None` for system headers), so no external calls are introduced, and the Module node is ensured before the edge is emitted.

## Test

RED→GREEN: `test_module_scope_initializer_calls_attributed_to_module` in `test_cpp_frontend_calls.py` (a default member initializer and a namespace-scope global initializer must both surface as a `Module -> compute` edge). Failed before the fix (`got []`), passes after.

## Scope / honest measurement

This is a zero-regression correctness fix. On the `leveldb` frontend-mode benchmark it is **neutral** (recall 0.4562, FP 1, tp 401 — unchanged): leveldb barely uses initializer-context calls. leveldb's frontend recall gap is dominated by unrelated diffuse causes (documented `operator*` metric differences, and the frontend's compile-DB parse emitting fewer edges than the oracle's per-file parse), which are a separate larger workstream, not addressed here.