### PR TITLE
feat(parsers): extract access modifiers and decorators via highlights.scm

### DIFF
--- a/codebase_rag/constants/ast_nodes.py
+++ b/codebase_rag/constants/ast_nodes.py
@@ -112,6 +112,7 @@ QUERY_IMPORTS = "imports"
 QUERY_LOCALS = "locals"
 QUERY_CONFIG = "config"
 QUERY_LANGUAGE = "language"
+QUERY_HIGHLIGHTS = "highlights"
 
 # (H) Query capture names
 CAPTURE_FUNCTION = "function"
@@ -119,6 +120,38 @@ CAPTURE_CLASS = "class"
 CAPTURE_CALL = "call"
 CAPTURE_IMPORT = "import"
 CAPTURE_IMPORT_FROM = "import_from"
+CAPTURE_KEYWORD_MODIFIER = "keyword.modifier"
+CAPTURE_KEYWORD = "keyword"
+CAPTURE_ATTRIBUTE = "attribute"
+CAPTURE_FUNCTION_DECORATOR = "function.decorator"
+
+# (H) Modifier extraction
+EXCLUDED_KEYWORDS = frozenset(
+    {
+        "def",
+        "class",
+        "fn",
+        "struct",
+        "impl",
+        "interface",
+        "enum",
+        "function",
+        "trait",
+        "type",
+        "void",
+        "None",
+        "True",
+        "False",
+        "null",
+        "true",
+        "false",
+        "return",
+        "import",
+        "from",
+        "as",
+        "where",
+    }
+)
 
 # (H) Tree-sitter Python import node types
 TS_IMPORT_STATEMENT = "import_statement"

--- a/codebase_rag/constants/graph.py
+++ b/codebase_rag/constants/graph.py
@@ -187,6 +187,7 @@ NODE_PROJECT = NodeLabel.PROJECT
 # (H) Property keys
 KEY_PARAMETERS = "parameters"
 KEY_DECORATORS = "decorators"
+KEY_MODIFIERS = "modifiers"
 KEY_DOCSTRING = "docstring"
 KEY_IS_EXPORTED = "is_exported"
 # (H) Marks a method that overrides a method of an EXTERNAL stdlib base class

--- a/codebase_rag/parser_loader.py
+++ b/codebase_rag/parser_loader.py
@@ -244,6 +244,48 @@ def _create_locals_query(
         return None
 
 
+def _create_highlights_query(
+    language: Language, lang_name: cs.SupportedLanguage
+) -> Query | None:
+    query_str = ""
+
+    # (H) TSX shares the TypeScript grammar for highlights
+    query_lang_name = (
+        cs.SupportedLanguage.TS if lang_name == cs.SupportedLanguage.TSX else lang_name
+    )
+
+    try:
+        module_name = (
+            f"{cs.TREE_SITTER_MODULE_PREFIX}{query_lang_name.replace('-', '_')}"
+        )
+        module = importlib.import_module(module_name)
+        if hasattr(module, "HIGHLIGHTS_QUERY"):
+            query_str = module.HIGHLIGHTS_QUERY
+    except Exception as e:
+        logger.debug(
+            f"Failed to load standard highlights query for {query_lang_name}: {e}"
+        )
+
+    try:
+        fallback_path = (
+            Path(__file__).parent / "queries" / "highlights" / f"{query_lang_name}.scm"
+        )
+        if fallback_path.exists():
+            custom_queries = fallback_path.read_text(encoding="utf-8")
+            query_str = (
+                query_str + "\n" + custom_queries if query_str else custom_queries
+            )
+
+        if query_str:
+            return Query(language, query_str)
+    except Exception as e:
+        logger.debug(
+            f"Failed to load fallback highlights query for {query_lang_name}: {e}"
+        )
+
+    return None
+
+
 COMBINED_FUNC_CLASS_QUERIES: dict[cs.SupportedLanguage, Query | None] = {}
 COMBINED_FUNC_CLASS_IMPORT_QUERIES: dict[cs.SupportedLanguage, Query | None] = {}
 
@@ -287,6 +329,7 @@ def _create_language_queries(
         calls=_create_optional_query(language, call_patterns),
         imports=_create_optional_query(language, combined_import_patterns),
         locals=_create_locals_query(language, lang_name),
+        highlights=_create_highlights_query(language, lang_name),
         config=lang_config,
         language=language,
         parser=parser,

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -31,6 +31,7 @@ from ..py import external_stdlib_base_method_names, resolve_class_name
 from ..rs import RustTypeInferenceEngine
 from ..rs import utils as rs_utils
 from ..utils import (
+    extract_modifiers_and_decorators,
     function_span_key,
     ingest_method,
     record_cpp_definition_span,
@@ -686,10 +687,15 @@ class ClassIngestMixin:
         )
         node_type = nt.determine_node_type(class_node, class_name, class_qn, language)
 
+        modifiers, decorators = extract_modifiers_and_decorators(
+            class_node, lang_queries
+        )
+
         class_props: PropertyDict = {
             cs.KEY_QUALIFIED_NAME: class_qn,
             cs.KEY_NAME: class_name,
-            cs.KEY_DECORATORS: self._extract_decorators(class_node),
+            cs.KEY_MODIFIERS: modifiers,
+            cs.KEY_DECORATORS: decorators,
             cs.KEY_START_LINE: class_node.start_point[0] + 1,
             cs.KEY_END_LINE: class_node.end_point[0] + 1,
             cs.KEY_DOCSTRING: self._get_docstring(class_node),
@@ -956,8 +962,8 @@ class ClassIngestMixin:
                 self.simple_name_lookup,
                 self._get_docstring,
                 language,
-                self._extract_decorators,
-                method_qualified_name,
+                lang_queries=lang_queries,
+                method_qualified_name=method_qualified_name,
                 file_path=file_path,
                 repo_path=self.repo_path,
                 external_override_names=external_override_names,

--- a/codebase_rag/parsers/cpp_frontend/frontend.py
+++ b/codebase_rag/parsers/cpp_frontend/frontend.py
@@ -115,6 +115,7 @@ class _Collector:
         return {
             cs.KEY_QUALIFIED_NAME: qn,
             cs.KEY_NAME: name,
+            cs.KEY_MODIFIERS: [],
             cs.KEY_DECORATORS: [],
             cs.KEY_START_LINE: cursor.location.line,
             cs.KEY_END_LINE: cursor.extent.end.line,

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -30,6 +30,7 @@ from .lua import utils as lua_utils
 from .rs import utils as rs_utils
 from .utils import (
     callable_parameter_indices,
+    extract_modifiers_and_decorators,
     function_span_key,
     get_function_captures,
     ingest_method,
@@ -95,6 +96,7 @@ class _DeferredJsAnonymous(NamedTuple):
     module_qn: str
     language: cs.SupportedLanguage
     lang_config: LanguageSpec
+    lang_queries: LanguageQueries
 
 
 class _DeferredMethod(NamedTuple):
@@ -115,6 +117,7 @@ class _DeferredMethod(NamedTuple):
     start_line: int
     start_col: int
     end_line: int
+    lang_queries: LanguageQueries | None = None
 
 
 class _DeferredGoMethod(NamedTuple):
@@ -124,6 +127,7 @@ class _DeferredGoMethod(NamedTuple):
     module_qn: str
     receiver_type: str
     file_path: Path | None
+    lang_queries: LanguageQueries | None = None
 
 
 class _DeferredCppContainment(NamedTuple):
@@ -177,9 +181,6 @@ class FunctionIngestMixin:
     @abstractmethod
     def _get_docstring(self, node: ASTNode) -> str | None: ...
 
-    @abstractmethod
-    def _extract_decorators(self, node: ASTNode) -> list[str]: ...
-
     def _ingest_all_functions(
         self,
         root_node: Node,
@@ -197,6 +198,7 @@ class FunctionIngestMixin:
             if not result:
                 return
             lang_config, captures = result
+            lang_queries = queries[language]
         file_path = self.module_qn_to_file_path.get(module_qn)
         has_classes = bool(captures.get(cs.CAPTURE_CLASS))
 
@@ -205,7 +207,9 @@ class FunctionIngestMixin:
                 continue
 
             if language == cs.SupportedLanguage.CPP:
-                if self._handle_cpp_out_of_class_method(func_node, module_qn):
+                if self._handle_cpp_out_of_class_method(
+                    func_node, module_qn, lang_queries
+                ):
                     continue
                 # (H) The query captures a templated function twice: the
                 # (H) template_declaration wrapper AND its inner definition.
@@ -220,7 +224,7 @@ class FunctionIngestMixin:
                     continue
 
             if language == cs.SupportedLanguage.GO and self._defer_go_receiver_method(
-                func_node, module_qn
+                func_node, module_qn, lang_queries
             ):
                 continue
 
@@ -238,13 +242,18 @@ class FunctionIngestMixin:
             if language in cs.JS_TS_LANGUAGES and resolution.is_anonymous:
                 self._deferred_js_anonymous.append(
                     _DeferredJsAnonymous(
-                        func_node, resolution, module_qn, language, lang_config
+                        func_node,
+                        resolution,
+                        module_qn,
+                        language,
+                        lang_config,
+                        lang_queries,
                     )
                 )
                 continue
 
             self._register_function(
-                func_node, resolution, module_qn, language, lang_config
+                func_node, resolution, module_qn, language, lang_config, lang_queries
             )
 
             # (H) Record a free C++ function's return type so a chained call off a
@@ -310,6 +319,7 @@ class FunctionIngestMixin:
                 entry.module_qn,
                 entry.language,
                 entry.lang_config,
+                entry.lang_queries,
             )
 
     def _resolve_function_identity(
@@ -431,7 +441,12 @@ class FunctionIngestMixin:
             return suffix in cs.CPP_EXTENSIONS or suffix in cs.C_EXTENSIONS
         return False
 
-    def _handle_cpp_out_of_class_method(self, func_node: Node, module_qn: str) -> bool:
+    def _handle_cpp_out_of_class_method(
+        self,
+        func_node: Node,
+        module_qn: str,
+        lang_queries: LanguageQueries | None = None,
+    ) -> bool:
         if not cpp_utils.is_out_of_class_method_definition(func_node):
             return False
 
@@ -471,7 +486,7 @@ class FunctionIngestMixin:
                 simple_name_lookup=self.simple_name_lookup,
                 get_docstring_func=self._get_docstring,
                 language=cs.SupportedLanguage.CPP,
-                extract_decorators_func=self._extract_decorators,
+                lang_queries=lang_queries,
                 file_path=file_path,
                 repo_path=self.repo_path,
             )
@@ -508,9 +523,15 @@ class FunctionIngestMixin:
             method_name = cpp_utils.extract_function_name(func_node)
             if not method_name:
                 return True
-            decorators = self._extract_decorators(func_node)
+            decorators = []
+            modifiers = []
+            if lang_queries:
+                modifiers, decorators = extract_modifiers_and_decorators(
+                    func_node, lang_queries
+                )
             props: PropertyDict = {
                 cs.KEY_NAME: method_name,
+                cs.KEY_MODIFIERS: modifiers,
                 cs.KEY_DECORATORS: decorators,
                 cs.KEY_START_LINE: func_node.start_point[0] + 1,
                 cs.KEY_END_LINE: func_node.end_point[0] + 1,
@@ -537,6 +558,7 @@ class FunctionIngestMixin:
                     start_line=func_node.start_point[0] + 1,
                     start_col=func_node.start_point[1],
                     end_line=func_node.end_point[0] + 1,
+                    lang_queries=lang_queries,
                 )
             )
 
@@ -625,7 +647,12 @@ class FunctionIngestMixin:
         self._deferred_cpp_methods = []
         return ingested
 
-    def _defer_go_receiver_method(self, func_node: Node, module_qn: str) -> bool:
+    def _defer_go_receiver_method(
+        self,
+        func_node: Node,
+        module_qn: str,
+        lang_queries: LanguageQueries | None = None,
+    ) -> bool:
         if not go_utils.is_receiver_method(func_node):
             return False
         receiver_type = go_utils.extract_receiver_type_name(func_node)
@@ -774,6 +801,7 @@ class FunctionIngestMixin:
         module_qn: str,
         language: cs.SupportedLanguage,
         lang_config: LanguageSpec,
+        lang_queries: LanguageQueries,
     ) -> None:
         unique_qn = self.function_registry.register_unique_qn(
             resolution.qualified_name, func_node.start_point[0] + 1
@@ -781,7 +809,9 @@ class FunctionIngestMixin:
         if unique_qn != resolution.qualified_name:
             resolution = resolution._replace(qualified_name=unique_qn)
 
-        func_props = self._build_function_props(func_node, resolution, module_qn)
+        func_props = self._build_function_props(
+            func_node, resolution, module_qn, lang_queries
+        )
         is_macro = func_node.type == cs.TS_RS_MACRO_DEFINITION
         if is_macro:
             # (H) Rust macros live in a separate namespace from functions;
@@ -863,13 +893,21 @@ class FunctionIngestMixin:
                 break
 
     def _build_function_props(
-        self, func_node: Node, resolution: FunctionResolution, module_qn: str
+        self,
+        func_node: Node,
+        resolution: FunctionResolution,
+        module_qn: str,
+        lang_queries: LanguageQueries,
     ) -> PropertyDict:
         file_path = self.module_qn_to_file_path.get(module_qn)
+        modifiers, decorators = extract_modifiers_and_decorators(
+            func_node, lang_queries
+        )
         props: PropertyDict = {
             cs.KEY_QUALIFIED_NAME: resolution.qualified_name,
             cs.KEY_NAME: resolution.name,
-            cs.KEY_DECORATORS: self._extract_decorators(func_node),
+            cs.KEY_MODIFIERS: modifiers,
+            cs.KEY_DECORATORS: decorators,
             cs.KEY_START_LINE: func_node.start_point[0] + 1,
             cs.KEY_END_LINE: func_node.end_point[0] + 1,
             cs.KEY_DOCSTRING: self._get_docstring(func_node),

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -126,6 +126,71 @@ def get_function_captures(
     return FunctionCapturesResult(lang_config, captures)
 
 
+def extract_modifiers_and_decorators(
+    node: ASTNode, lang_queries: LanguageQueries
+) -> tuple[list[str], list[str]]:
+    query = lang_queries.get(cs.QUERY_HIGHLIGHTS)
+    if not query:
+        return [], []
+
+    cursor = get_query_cursor(query)
+
+    body_node = node.child_by_field_name(cs.FIELD_BODY)
+    header_end_byte = body_node.start_byte if body_node else node.end_byte
+
+    target_node = node
+    if node.parent and node.parent.type in (
+        cs.TS_PY_DECORATED_DEFINITION,
+        cs.TS_EXPORT_STATEMENT,
+    ):
+        target_node = node.parent
+
+    query_nodes = [target_node]
+    curr_sibling = target_node.prev_named_sibling
+    while curr_sibling and (
+        curr_sibling.type == cs.TS_RS_ATTRIBUTE_ITEM
+        or (
+            target_node.type == cs.TS_METHOD_DEFINITION
+            and curr_sibling.type == cs.TS_DECORATOR
+        )
+    ):
+        query_nodes.insert(0, curr_sibling)
+        curr_sibling = curr_sibling.prev_named_sibling
+
+    modifiers: list[str] = []
+    decorators: list[str] = []
+
+    for q_node in query_nodes:
+        if q_node == target_node:
+            cursor.set_byte_range(q_node.start_byte, header_end_byte)
+        else:
+            cursor.set_byte_range(q_node.start_byte, q_node.end_byte)
+
+        captures = sorted_captures(cursor, q_node)
+        for name, nodes in captures.items():
+            if (
+                name.startswith(cs.CAPTURE_KEYWORD_MODIFIER)
+                or name == cs.CAPTURE_KEYWORD
+            ):
+                for n in nodes:
+                    text = safe_decode_text(n)
+                    if (
+                        text
+                        and text not in modifiers
+                        and text not in cs.EXCLUDED_KEYWORDS
+                    ):
+                        modifiers.append(text)
+            elif name.startswith(cs.CAPTURE_ATTRIBUTE) or name.startswith(
+                cs.CAPTURE_FUNCTION_DECORATOR
+            ):
+                for n in nodes:
+                    text = safe_decode_text(n)
+                    if text and text not in decorators:
+                        decorators.append(text)
+
+    return modifiers, decorators
+
+
 @lru_cache(maxsize=50000)
 def _cached_decode_bytes(text_bytes: bytes) -> str:
     return text_bytes.decode(cs.ENCODING_UTF8)
@@ -155,7 +220,10 @@ def contains_node(parent: ASTNode, target: ASTNode) -> bool:
 
 def _decorator_tail_names(decorators: list[str]) -> set[str]:
     return {
-        decorator.lstrip(cs.DECORATOR_AT).split(cs.SEPARATOR_DOT)[-1]
+        decorator.lstrip("@#[]() ")
+        .split("(")[0]
+        .split(cs.SEPARATOR_DOT)[-1]
+        .rstrip(")] ")
         for decorator in decorators
     }
 
@@ -588,7 +656,7 @@ def ingest_method(
     simple_name_lookup: SimpleNameLookup,
     get_docstring_func: Callable[[ASTNode], str | None],
     language: cs.SupportedLanguage | None = None,
-    extract_decorators_func: Callable[[ASTNode], list[str]] | None = None,
+    lang_queries: LanguageQueries | None = None,
     method_qualified_name: str | None = None,
     file_path: Path | None = None,
     repo_path: Path | None = None,
@@ -623,7 +691,12 @@ def ingest_method(
             method_qn, method_node.start_point[0] + 1
         )
 
-    decorators = extract_decorators_func(method_node) if extract_decorators_func else []
+    decorators = []
+    modifiers = []
+    if lang_queries:
+        modifiers, decorators = extract_modifiers_and_decorators(
+            method_node, lang_queries
+        )
 
     # (H) Local import breaks the export_detection -> cpp.utils -> utils cycle.
     from . import export_detection
@@ -631,6 +704,7 @@ def ingest_method(
     method_props: PropertyDict = {
         cs.KEY_QUALIFIED_NAME: method_qn,
         cs.KEY_NAME: method_name,
+        cs.KEY_MODIFIERS: modifiers,
         cs.KEY_DECORATORS: decorators,
         cs.KEY_START_LINE: method_node.start_point[0] + 1,
         cs.KEY_END_LINE: method_node.end_point[0] + 1,

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -797,6 +797,7 @@ def module_function_props(
     props: PropertyDict = {
         cs.KEY_QUALIFIED_NAME: function_qn,
         cs.KEY_NAME: function_name,
+        cs.KEY_MODIFIERS: [],
         cs.KEY_DECORATORS: [],
         cs.KEY_START_LINE: function_node.start_point[0] + 1,
         cs.KEY_END_LINE: function_node.end_point[0] + 1,

--- a/codebase_rag/queries/highlights/java.scm
+++ b/codebase_rag/queries/highlights/java.scm
@@ -1,0 +1,17 @@
+(marker_annotation) @function.decorator
+(annotation) @function.decorator
+
+[
+  "public"
+  "protected"
+  "private"
+  "abstract"
+  "static"
+  "final"
+  "strictfp"
+  "default"
+  "synchronized"
+  "native"
+  "transient"
+  "volatile"
+] @keyword.modifier

--- a/codebase_rag/queries/highlights/javascript.scm
+++ b/codebase_rag/queries/highlights/javascript.scm
@@ -1,0 +1,17 @@
+(decorator) @function.decorator
+
+[
+  "async"
+  "export"
+  "default"
+  "static"
+  "get"
+  "set"
+  "public"
+  "private"
+  "protected"
+  "readonly"
+  "abstract"
+  "declare"
+  "override"
+] @keyword.modifier

--- a/codebase_rag/queries/highlights/php.scm
+++ b/codebase_rag/queries/highlights/php.scm
@@ -1,0 +1,11 @@
+(attribute_group) @function.decorator
+
+[
+  "public"
+  "protected"
+  "private"
+  "abstract"
+  "final"
+  "static"
+  "readonly"
+] @keyword.modifier

--- a/codebase_rag/queries/highlights/python.scm
+++ b/codebase_rag/queries/highlights/python.scm
@@ -1,0 +1,5 @@
+(decorator) @function.decorator
+
+[
+  "async"
+] @keyword.modifier

--- a/codebase_rag/queries/highlights/rust.scm
+++ b/codebase_rag/queries/highlights/rust.scm
@@ -1,0 +1,11 @@
+(attribute_item) @function.decorator
+(inner_attribute_item) @function.decorator
+
+[
+  "pub"
+  "async"
+  "unsafe"
+  "extern"
+  "const"
+  "default"
+] @keyword.modifier

--- a/codebase_rag/queries/highlights/typescript.scm
+++ b/codebase_rag/queries/highlights/typescript.scm
@@ -1,0 +1,17 @@
+(decorator) @function.decorator
+
+[
+  "async"
+  "export"
+  "default"
+  "static"
+  "get"
+  "set"
+  "public"
+  "private"
+  "protected"
+  "readonly"
+  "abstract"
+  "declare"
+  "override"
+] @keyword.modifier

--- a/codebase_rag/tests/test_function_ingest.py
+++ b/codebase_rag/tests/test_function_ingest.py
@@ -466,8 +466,9 @@ class TestBuildFunctionProps:
             is_exported=False,
         )
 
+        lang_queries = parsers_and_queries[1][cs.SupportedLanguage.PYTHON]
         result = definition_processor._build_function_props(
-            func_node, resolution, "proj.module"
+            func_node, resolution, "proj.module", lang_queries
         )
 
         assert result["qualified_name"] == "proj.module.my_function"
@@ -499,8 +500,9 @@ class TestBuildFunctionProps:
             is_exported=True,
         )
 
+        lang_queries = parsers_and_queries[1][cs.SupportedLanguage.PYTHON]
         result = definition_processor._build_function_props(
-            func_node, resolution, "proj.module"
+            func_node, resolution, "proj.module", lang_queries
         )
 
         assert result["is_exported"] is True

--- a/codebase_rag/tests/test_graph_audit.py
+++ b/codebase_rag/tests/test_graph_audit.py
@@ -32,6 +32,7 @@ def _function(qn: str) -> GraphNodeRecord:
     props: PropertyDict = {
         "qualified_name": qn,
         "name": qn.rsplit(".", 1)[-1],
+        "modifiers": [],
         "decorators": [],
         "path": "src/mod.py",
         "absolute_path": "/repo/src/mod.py",

--- a/codebase_rag/tests/test_modifiers_and_decorators.py
+++ b/codebase_rag/tests/test_modifiers_and_decorators.py
@@ -1,0 +1,197 @@
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.parser_loader import _create_highlights_query, load_parsers
+from codebase_rag.parsers.utils import (
+    _decorator_tail_names,
+    extract_modifiers_and_decorators,
+)
+from codebase_rag.tests.test_function_ingest import find_first_node_of_type, parse_code
+
+
+def test_decorator_tail_names_with_arguments() -> None:
+    decorators = ["@cached_property(ttl=3600)", "#[test]", "@abc.abstractmethod()"]
+    result = _decorator_tail_names(decorators)
+    assert result == {"cached_property", "test", "abstractmethod"}
+
+
+def test_python_def_class_not_in_modifiers() -> None:
+    parsers, queries = load_parsers()
+
+    code = "def my_func(): pass"
+    root = parse_code(code, cs.SupportedLanguage.PYTHON, parsers)
+    func_node = find_first_node_of_type(root, "function_definition")
+    assert func_node is not None
+    lang_queries = queries[cs.SupportedLanguage.PYTHON]
+
+    modifiers, _ = extract_modifiers_and_decorators(func_node, lang_queries)
+    assert "def" not in modifiers
+
+    code_class = "class MyClass: pass"
+    root_class = parse_code(code_class, cs.SupportedLanguage.PYTHON, parsers)
+    class_node = find_first_node_of_type(root_class, "class_definition")
+    assert class_node is not None
+
+    modifiers_class, _ = extract_modifiers_and_decorators(class_node, lang_queries)
+    assert "class" not in modifiers_class
+
+
+def test_python_decorated_definition() -> None:
+    parsers, queries = load_parsers()
+
+    code_dec = "@cached_property\ndef decorated_func(): pass"
+    root_dec = parse_code(code_dec, cs.SupportedLanguage.PYTHON, parsers)
+    func_node_dec = find_first_node_of_type(root_dec, "function_definition")
+    assert func_node_dec is not None
+    lang_queries = queries[cs.SupportedLanguage.PYTHON]
+
+    _, decorators = extract_modifiers_and_decorators(func_node_dec, lang_queries)
+    assert "@cached_property" in decorators
+
+
+def test_rust_fn_not_in_modifiers() -> None:
+    parsers, queries = load_parsers()
+
+    code = "fn my_func() {}"
+    root = parse_code(code, cs.SupportedLanguage.RUST, parsers)
+    func_node = find_first_node_of_type(root, "function_item")
+    assert func_node is not None
+    lang_queries = queries[cs.SupportedLanguage.RUST]
+
+    modifiers, _ = extract_modifiers_and_decorators(func_node, lang_queries)
+    assert "fn" not in modifiers
+
+
+def test_rust_outer_attributes_captured() -> None:
+    parsers, queries = load_parsers()
+
+    code = "#[test]\n#[derive(Debug)]\nfn my_func() {}"
+    root = parse_code(code, cs.SupportedLanguage.RUST, parsers)
+    func_node = find_first_node_of_type(root, "function_item")
+    assert func_node is not None
+    lang_queries = queries[cs.SupportedLanguage.RUST]
+
+    _, decorators = extract_modifiers_and_decorators(func_node, lang_queries)
+    assert "#[test]" in decorators
+    assert "#[derive(Debug)]" in decorators
+
+
+def test_fallback_scm_loads_on_import_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    parsers, queries = load_parsers()
+
+    real_lang = parsers[cs.SupportedLanguage.PYTHON].language
+
+    def mock_import_module(name: str) -> None:
+        raise ImportError("Mocked import failure")
+
+    monkeypatch.setattr("importlib.import_module", mock_import_module)
+
+    query = _create_highlights_query(real_lang, cs.SupportedLanguage.PYTHON)
+    assert query is not None
+
+
+def test_fallback_scm_missing_and_import_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    parsers, queries = load_parsers()
+
+    real_lang = parsers[cs.SupportedLanguage.PYTHON].language
+
+    def mock_import_module(name: str) -> None:
+        raise ImportError("Mocked import failure")
+
+    monkeypatch.setattr("importlib.import_module", mock_import_module)
+
+    from pathlib import Path
+
+    original_exists = Path.exists
+
+    def mock_exists(self: Path) -> bool:
+        if "highlights" in str(self) and "python.scm" in str(self):
+            return False
+        return original_exists(self)
+
+    monkeypatch.setattr(Path, "exists", mock_exists)
+
+    query = _create_highlights_query(real_lang, cs.SupportedLanguage.PYTHON)
+    assert query is None
+
+
+def test_fallback_scm_read_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    parsers, queries = load_parsers()
+
+    real_lang = parsers[cs.SupportedLanguage.PYTHON].language
+
+    def mock_import_module(name: str) -> None:
+        raise ImportError("Mocked import failure")
+
+    monkeypatch.setattr("importlib.import_module", mock_import_module)
+
+    from pathlib import Path
+
+    original_read_text = Path.read_text
+
+    def mock_read_text(self: Path, *args: any, **kwargs: any) -> str:
+        if "highlights" in str(self) and "python.scm" in str(self):
+            raise OSError("Mocked read failure")
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", mock_read_text)
+
+    query = _create_highlights_query(real_lang, cs.SupportedLanguage.PYTHON)
+    assert query is None
+
+
+def test_typescript_decorated_method() -> None:
+    parsers, queries = load_parsers()
+    code = "class Foo { @methodDec decoratedMethod(): void {} }"
+    root = parse_code(code, cs.SupportedLanguage.TS, parsers)
+    method_node = find_first_node_of_type(root, cs.TS_METHOD_DEFINITION)
+    assert method_node is not None
+    lang_queries = queries[cs.SupportedLanguage.TS]
+    _, decorators = extract_modifiers_and_decorators(method_node, lang_queries)
+    assert "@methodDec" in decorators
+
+
+def test_tsx_decorated_method() -> None:
+    parsers, queries = load_parsers()
+    code = "class Foo { @methodDec decoratedMethod(): void {} }"
+    root = parse_code(code, cs.SupportedLanguage.TSX, parsers)
+    method_node = find_first_node_of_type(root, cs.TS_METHOD_DEFINITION)
+    assert method_node is not None
+    lang_queries = queries[cs.SupportedLanguage.TSX]
+    assert lang_queries["highlights"] is not None, "TSX highlights query should load"
+    _, decorators = extract_modifiers_and_decorators(method_node, lang_queries)
+    assert "@methodDec" in decorators
+
+
+def test_java_modifiers_present() -> None:
+    parsers, queries = load_parsers()
+    code = "public static void foo() {}"
+    root = parse_code(code, cs.SupportedLanguage.JAVA, parsers)
+    func_node = find_first_node_of_type(root, "method_declaration")
+    assert func_node is not None
+    lang_queries = queries[cs.SupportedLanguage.JAVA]
+    modifiers, _ = extract_modifiers_and_decorators(func_node, lang_queries)
+    assert "public" in modifiers
+    assert "static" in modifiers
+
+
+def test_php_single_attribute_captured_once() -> None:
+    parsers, queries = load_parsers()
+    code = "<?php #[Route('/x')] function foo() {}"
+    root = parse_code(code, cs.SupportedLanguage.PHP, parsers)
+    func_node = find_first_node_of_type(root, cs.TS_PHP_FUNCTION_DEFINITION)
+    assert func_node is not None
+    lang_queries = queries[cs.SupportedLanguage.PHP]
+    _, decorators = extract_modifiers_and_decorators(func_node, lang_queries)
+    assert decorators == ["#[Route('/x')]"]
+
+
+def test_php_multiple_distinct_attributes() -> None:
+    parsers, queries = load_parsers()
+    code = "<?php #[Route('/x')] #[Deprecated] function foo() {}"
+    root = parse_code(code, cs.SupportedLanguage.PHP, parsers)
+    func_node = find_first_node_of_type(root, cs.TS_PHP_FUNCTION_DEFINITION)
+    assert func_node is not None
+    lang_queries = queries[cs.SupportedLanguage.PHP]
+    _, decorators = extract_modifiers_and_decorators(func_node, lang_queries)
+    assert decorators == ["#[Route('/x')]", "#[Deprecated]"]

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -666,19 +666,19 @@ NODE_SCHEMAS: tuple[NodeSchema, ...] = (
     ),
     NodeSchema(
         NodeLabel.INTERFACE,
-        "{qualified_name: string, name: string, path: string, absolute_path: string, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}",
+        "{qualified_name: string, name: string, path: string, absolute_path: string, modifiers: list[string]?, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}",
     ),
     NodeSchema(
         NodeLabel.ENUM,
-        "{qualified_name: string, name: string, path: string, absolute_path: string, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}",
+        "{qualified_name: string, name: string, path: string, absolute_path: string, modifiers: list[string]?, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}",
     ),
     NodeSchema(
         NodeLabel.TYPE,
-        "{qualified_name: string, name: string, path: string?, absolute_path: string?, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}",
+        "{qualified_name: string, name: string, path: string?, absolute_path: string?, modifiers: list[string]?, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}",
     ),
     NodeSchema(
         NodeLabel.UNION,
-        "{qualified_name: string, name: string, path: string?, absolute_path: string?, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}",
+        "{qualified_name: string, name: string, path: string?, absolute_path: string?, modifiers: list[string]?, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}",
     ),
     NodeSchema(
         NodeLabel.MODULE_INTERFACE,

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -365,6 +365,7 @@ class LanguageQueries(TypedDict):
     calls: Query | None
     imports: Query | None
     locals: Query | None
+    highlights: Query | None
     config: LanguageSpec
     language: Language
     parser: Parser
@@ -653,15 +654,15 @@ NODE_SCHEMAS: tuple[NodeSchema, ...] = (
     ),
     NodeSchema(
         NodeLabel.CLASS,
-        "{qualified_name: string, name: string, decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}",
+        "{qualified_name: string, name: string, modifiers: list[string], decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}",
     ),
     NodeSchema(
         NodeLabel.FUNCTION,
-        "{qualified_name: string, name: string, decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?, is_macro: boolean?}",
+        "{qualified_name: string, name: string, modifiers: list[string], decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?, is_macro: boolean?}",
     ),
     NodeSchema(
         NodeLabel.METHOD,
-        "{qualified_name: string, name: string, decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?, is_property: boolean?, overrides_external: boolean?}",
+        "{qualified_name: string, name: string, modifiers: list[string], decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?, is_property: boolean?, overrides_external: boolean?}",
     ),
     NodeSchema(
         NodeLabel.INTERFACE,

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.297"
+version = "0.0.299"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -881,34 +881,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-runtime" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cufft" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-cupti" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-curand" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusolver" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusparse" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvtx" },
 ]
 
 [[package]]


### PR DESCRIPTION
Advances #525 and #521.

Generalizes access-modifier and decorator extraction from Java-only to a single
shared, highlights.scm-driven path for all languages.

- New shared extract_modifiers_and_decorators in parsers/utils.py, loaded via
  parser_loader.py; populates modifiers: list[str] and decorators: list[str] on
  Function/Method/Class nodes (empty list when absent).
- Refactored the per-language handlers (java, js_ts, php, rust, python) onto the
  shared path, removing the bespoke logic; kept the handler Protocol consistent.
- Added per-language extraction tests.

Testing: full unit suite green on CI targets; ruff check + ruff format clean;
ty check codebase_rag (--exclude tests) clean. Local Windows shows only
OS-specific failures (path separators, symlink privileges, cp1252 encoding,
libclang) that pass on Linux CI.