### PR TITLE
fix(cpp): resolve typedef and using-aliased receiver types to the underlying class

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -1803,6 +1803,9 @@ class CppNodeType(StrEnum):
     FIELD_EXPRESSION = "field_expression"
     COMPOUND_STATEMENT = "compound_statement"
     THIS = "this"
+    TYPE_DEFINITION = "type_definition"
+    ALIAS_DECLARATION = "alias_declaration"
+    TYPE_DESCRIPTOR = "type_descriptor"
 
 
 CPP_MODULE_EXTENSIONS = (".ixx", ".cppm", ".ccm", ".mxx")

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -82,6 +82,7 @@ class CallProcessor:
         import_processor: ImportProcessor,
         type_inference: TypeInferenceEngine,
         class_inheritance: dict[str, list[str]],
+        type_aliases: dict[str, str] | None = None,
     ) -> None:
         self.ingestor = ingestor
         self.repo_path = repo_path
@@ -92,6 +93,7 @@ class CallProcessor:
             import_processor=import_processor,
             type_inference=type_inference,
             class_inheritance=class_inheritance,
+            type_aliases=type_aliases,
         )
         # (H) Inter-procedural callable-parameter flow: ordered params per function and
         # (H) the per-call-site argument bindings, resolved to a fixpoint in finalize.

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -25,6 +25,7 @@ class CallResolver:
         "import_processor",
         "type_inference",
         "class_inheritance",
+        "type_aliases",
         "_simple_resolution_cache",
         "_wildcard_cache",
         "_protocol_impl_cache",
@@ -41,11 +42,15 @@ class CallResolver:
         import_processor: ImportProcessor,
         type_inference: TypeInferenceEngine,
         class_inheritance: dict[str, list[str]],
+        type_aliases: dict[str, str] | None = None,
     ) -> None:
         self.function_registry = function_registry
         self.import_processor = import_processor
         self.type_inference = type_inference
         self.class_inheritance = class_inheritance
+        # (H) C++ typedef/using alias -> underlying bare type, consulted when a
+        # (H) receiver type name is mapped to a class (empty for other languages).
+        self.type_aliases = type_aliases if type_aliases is not None else {}
         self._simple_resolution_cache: dict[
             tuple[str, str], tuple[str, str] | None
         ] = {}
@@ -1142,9 +1147,23 @@ class CallResolver:
             base_distance -= 1
         return base_distance
 
+    def _dealias_type(self, type_name: str) -> str:
+        # (H) Follow C++ typedef/using aliases (`typedef Mutex MutexAlias;`) to the
+        # (H) underlying class name so an alias'd receiver resolves like the class it
+        # (H) names. Bounded against an alias cycle; a no-op when the name is not an
+        # (H) alias (and always, for languages with no aliases collected).
+        seen: set[str] = set()
+        while type_name in self.type_aliases and type_name not in seen:
+            seen.add(type_name)
+            type_name = self.type_aliases[type_name]
+        return type_name
+
     def _resolve_class_name(self, class_name: str, module_qn: str) -> str | None:
         return resolve_class_name(
-            class_name, module_qn, self.import_processor, self.function_registry
+            self._dealias_type(class_name),
+            module_qn,
+            self.import_processor,
+            self.function_registry,
         )
 
     def resolve_java_method_call(

--- a/codebase_rag/parsers/cpp/type_inference.py
+++ b/codebase_rag/parsers/cpp/type_inference.py
@@ -44,6 +44,48 @@ class CppTypeInferenceEngine:
             var_types[name] = type_name
         return var_types
 
+    def collect_type_aliases(self, root_node: Node, aliases: dict[str, str]) -> None:
+        # (H) Map each C++ `typedef X Y;` / `using Y = X;` alias name to its underlying
+        # (H) bare type name, so a field/local declared with the alias resolves to the
+        # (H) aliased class. Collected across all files into one map (an alias in a
+        # (H) header is used in a .cc), keyed by bare name like the flat type maps.
+        # (H) Aliases to a primitive/template-arg-only type reduce to no bare name and
+        # (H) are skipped (never a first-party method-call receiver).
+        for child in root_node.children:
+            match child.type:
+                case cs.CppNodeType.TYPE_DEFINITION:
+                    self._record_typedef(child, aliases)
+                case cs.CppNodeType.ALIAS_DECLARATION:
+                    self._record_using_alias(child, aliases)
+                case _:
+                    # (H) typedef/using appear at file scope and inside namespaces
+                    # (H) (and extern "C" blocks), so recurse to reach nested ones.
+                    self.collect_type_aliases(child, aliases)
+
+    def _record_typedef(self, node: Node, aliases: dict[str, str]) -> None:
+        type_node = node.child_by_field_name(cs.FIELD_TYPE)
+        declarator = node.child_by_field_name(cs.FIELD_DECLARATOR)
+        if type_node is None or declarator is None:
+            return
+        underlying = self._bare_type_name(type_node)
+        alias = self._declarator_name(declarator)
+        if underlying and alias and alias != underlying:
+            aliases.setdefault(alias, underlying)
+
+    def _record_using_alias(self, node: Node, aliases: dict[str, str]) -> None:
+        name_node = node.child_by_field_name(cs.FIELD_NAME)
+        type_node = node.child_by_field_name(cs.FIELD_TYPE)
+        if name_node is None or type_node is None:
+            return
+        # (H) `using Y = X;` wraps X in a type_descriptor whose `type` child is the type.
+        if type_node.type == cs.CppNodeType.TYPE_DESCRIPTOR:
+            inner = type_node.child_by_field_name(cs.FIELD_TYPE)
+            type_node = inner if inner is not None else type_node
+        underlying = self._bare_type_name(type_node)
+        alias = safe_decode_text(name_node)
+        if underlying and alias and alias != underlying:
+            aliases.setdefault(alias, underlying)
+
     def build_field_type_map(self, class_node: Node) -> dict[str, str]:
         # (H) Map each data member of a C++ class to its bare type name, so a member
         # (H) call `field_.method()` inside the class's methods can resolve via the

--- a/codebase_rag/parsers/cpp/type_inference.py
+++ b/codebase_rag/parsers/cpp/type_inference.py
@@ -44,7 +44,9 @@ class CppTypeInferenceEngine:
             var_types[name] = type_name
         return var_types
 
-    def collect_type_aliases(self, root_node: Node, aliases: dict[str, str]) -> None:
+    def collect_type_aliases(
+        self, root_node: Node, aliases: dict[str, str], conflicts: set[str]
+    ) -> None:
         # (H) Map each C++ `typedef X Y;` / `using Y = X;` alias name to its underlying
         # (H) bare type name, so a field/local declared with the alias resolves to the
         # (H) aliased class. Collected across all files into one map (an alias in a
@@ -52,31 +54,69 @@ class CppTypeInferenceEngine:
         # (H) Aliases to a primitive/template-arg-only type reduce to no bare name and
         # (H) are skipped (never a first-party method-call receiver).
         for child in root_node.children:
+            # (H) An alias inside a function/method/lambda body is local to that body
+            # (H) and can never type a cross-file field/local, so skip the body (this
+            # (H) also avoids traversing the bulk of the AST -- statements/exprs).
+            if child.type in cs.CPP_NESTED_SCOPE_NODE_TYPES:
+                continue
             match child.type:
                 case cs.CppNodeType.TYPE_DEFINITION:
-                    self._record_typedef(child, aliases)
+                    self._record_alias(self._typedef_pair(child), aliases, conflicts)
                 case cs.CppNodeType.ALIAS_DECLARATION:
-                    self._record_using_alias(child, aliases)
+                    self._record_alias(self._using_pair(child), aliases, conflicts)
                 case _:
                     # (H) typedef/using appear at file scope and inside namespaces
                     # (H) (and extern "C" blocks), so recurse to reach nested ones.
-                    self.collect_type_aliases(child, aliases)
+                    self.collect_type_aliases(child, aliases, conflicts)
 
-    def _record_typedef(self, node: Node, aliases: dict[str, str]) -> None:
+    def _record_alias(
+        self,
+        pair: tuple[str, str] | None,
+        aliases: dict[str, str],
+        conflicts: set[str],
+    ) -> None:
+        # (H) Bare alias names can collide across scopes/files (two namespaces each
+        # (H) `using It = ...;` for a different type). Rather than keep whichever was
+        # (H) seen first (a confidently-wrong typed edge for the other), drop a name
+        # (H) seen with conflicting underlying types so its receivers fall back to
+        # (H) name-only resolution. Mirrors build_local_variable_type_map's
+        # (H) drop-on-conflict.
+        if pair is None:
+            return
+        alias, underlying = pair
+        if alias in conflicts:
+            return
+        existing = aliases.get(alias)
+        if existing is not None and existing != underlying:
+            del aliases[alias]
+            conflicts.add(alias)
+            return
+        aliases[alias] = underlying
+
+    def _typedef_pair(self, node: Node) -> tuple[str, str] | None:
         type_node = node.child_by_field_name(cs.FIELD_TYPE)
         declarator = node.child_by_field_name(cs.FIELD_DECLARATOR)
         if type_node is None or declarator is None:
-            return
+            return None
         underlying = self._bare_type_name(type_node)
-        alias = self._declarator_name(declarator)
+        # (H) A plain `typedef X Y;` declarator is a bare type_identifier (the new
+        # (H) type name); pointer/array/function typedefs wrap it, so fall back to the
+        # (H) declarator-unwrap used for variables. Only the bare-name form types a
+        # (H) class receiver, so the unwrap returning None for the rest is fine.
+        alias = (
+            safe_decode_text(declarator)
+            if declarator.type == cs.CppNodeType.TYPE_IDENTIFIER
+            else self._declarator_name(declarator)
+        )
         if underlying and alias and alias != underlying:
-            aliases.setdefault(alias, underlying)
+            return (alias, underlying)
+        return None
 
-    def _record_using_alias(self, node: Node, aliases: dict[str, str]) -> None:
+    def _using_pair(self, node: Node) -> tuple[str, str] | None:
         name_node = node.child_by_field_name(cs.FIELD_NAME)
         type_node = node.child_by_field_name(cs.FIELD_TYPE)
         if name_node is None or type_node is None:
-            return
+            return None
         # (H) `using Y = X;` wraps X in a type_descriptor whose `type` child is the type.
         if type_node.type == cs.CppNodeType.TYPE_DESCRIPTOR:
             inner = type_node.child_by_field_name(cs.FIELD_TYPE)
@@ -84,7 +124,8 @@ class CppTypeInferenceEngine:
         underlying = self._bare_type_name(type_node)
         alias = safe_decode_text(name_node)
         if underlying and alias and alias != underlying:
-            aliases.setdefault(alias, underlying)
+            return (alias, underlying)
+        return None
 
     def build_field_type_map(self, class_node: Node) -> dict[str, str]:
         # (H) Map each data member of a C++ class to its bare type name, so a member

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -63,6 +63,9 @@ class DefinitionProcessor(
         # (H) across all files (an alias in a header is used in a .cc), read by the
         # (H) resolver when mapping a receiver type name to a class.
         self.type_aliases: dict[str, str] = {}
+        # (H) Alias names seen with conflicting underlying types across scopes/files;
+        # (H) dropped from type_aliases so their receivers fall back to name-only.
+        self._type_alias_conflicts: set[str] = set()
         self._deferred_cpp_methods: list = []
         self._deferred_go_methods: list = []
         self._deferred_forward_decls: list = []
@@ -189,7 +192,7 @@ class DefinitionProcessor(
             if language == cs.SupportedLanguage.CPP:
                 self._ingest_cpp_module_declarations(root_node, module_qn, file_path)
                 CppTypeInferenceEngine().collect_type_aliases(
-                    root_node, self.type_aliases
+                    root_node, self.type_aliases, self._type_alias_conflicts
                 )
             self._ingest_all_functions(
                 root_node,

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -12,6 +12,7 @@ from ..parser_loader import COMBINED_FUNC_CLASS_IMPORT_QUERIES
 from ..types_defs import ASTNode, FunctionRegistryTrieProtocol, SimpleNameLookup
 from ..utils.path_utils import cached_relative_path, cached_resolve_posix
 from .class_ingest import ClassIngestMixin
+from .cpp import CppTypeInferenceEngine
 from .dependency_parser import parse_dependencies
 from .function_ingest import FunctionIngestMixin
 from .handlers import get_handler
@@ -57,6 +58,11 @@ class DefinitionProcessor(
         # (H) method resolves via the field's declared type. Populated at class
         # (H) ingestion, read by the type-inference engine at call resolution.
         self.class_field_types: dict[str, dict[str, str]] = {}
+        # (H) {alias_name: underlying_bare_type} for C++ typedef/using aliases, so a
+        # (H) receiver declared with an alias resolves to the aliased class. Collected
+        # (H) across all files (an alias in a header is used in a .cc), read by the
+        # (H) resolver when mapping a receiver type name to a class.
+        self.type_aliases: dict[str, str] = {}
         self._deferred_cpp_methods: list = []
         self._deferred_go_methods: list = []
         self._deferred_forward_decls: list = []
@@ -182,6 +188,9 @@ class DefinitionProcessor(
                 )
             if language == cs.SupportedLanguage.CPP:
                 self._ingest_cpp_module_declarations(root_node, module_qn, file_path)
+                CppTypeInferenceEngine().collect_type_aliases(
+                    root_node, self.type_aliases
+                )
             self._ingest_all_functions(
                 root_node,
                 module_qn,

--- a/codebase_rag/parsers/factory.py
+++ b/codebase_rag/parsers/factory.py
@@ -133,5 +133,6 @@ class ProcessorFactory:
                 import_processor=self.import_processor,
                 type_inference=self.type_inference,
                 class_inheritance=self.definition_processor.class_inheritance,
+                type_aliases=self.definition_processor.type_aliases,
             )
         return self._call_processor

--- a/codebase_rag/tests/test_cpp_typedef_alias_receiver.py
+++ b/codebase_rag/tests/test_cpp_typedef_alias_receiver.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.conftest import get_relationships, run_updater
+
+
+def _calls_from(mock_ingestor: MagicMock, caller_suffix: str) -> set[str]:
+    return {
+        str(c.args[2][2])
+        for c in get_relationships(mock_ingestor, "CALLS")
+        if str(c.args[0][2]).endswith(caller_suffix)
+    }
+
+
+# (H) A field's declared type can be a `typedef`/`using` alias of a first-party class
+# (H) rather than the class name itself. Resolving `m1_.Lock()` requires mapping the
+# (H) alias (`MutexAlias`/`MutexUsing`) to its underlying class (`Mutex`); without it
+# (H) the receiver has a type the resolver cannot turn into a class, so the call is
+# (H) dropped (the name-only trie fallback is skipped once a receiver type is known).
+# (H) `Alpha.Lock` sorts before `Mutex.Lock`, so a name-only guess would pick the
+# (H) wrong one -- only alias-resolved field typing binds the correct `Mutex.Lock`.
+_SOURCE = """
+namespace ns {
+
+class Alpha {
+ public:
+  void Lock() {}
+};
+
+class Mutex {
+ public:
+  void Lock() {}
+};
+
+typedef Mutex MutexAlias;
+using MutexUsing = Mutex;
+
+class DB {
+ public:
+  void Run() {
+    m1_.Lock();
+    m2_.Lock();
+  }
+ private:
+  MutexAlias m1_;
+  MutexUsing m2_;
+};
+
+}  // namespace ns
+"""
+
+
+def test_cpp_typedef_and_using_alias_field_calls_resolve_to_underlying_class(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    project = temp_repo / "cpp_alias_field"
+    project.mkdir()
+    (project / "s.cpp").write_text(_SOURCE, encoding="utf-8")
+
+    run_updater(project, mock_ingestor)
+
+    callees = _calls_from(mock_ingestor, ".DB.Run")
+    # (H) Both the typedef- and using-aliased field calls must bind Mutex.Lock.
+    mutex_hits = [c for c in callees if c.endswith(".Mutex.Lock")]
+    assert len(mutex_hits) >= 1, (
+        f"m1_.Lock()/m2_.Lock() should resolve to Mutex.Lock via the alias, "
+        f"got {callees}"
+    )
+    assert not any(c.endswith(".Alpha.Lock") for c in callees), (
+        f"alias field calls must not resolve to the same-named Alpha.Lock, "
+        f"got {callees}"
+    )

--- a/codebase_rag/tests/test_cpp_typedef_alias_receiver.py
+++ b/codebase_rag/tests/test_cpp_typedef_alias_receiver.py
@@ -3,7 +3,14 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock
 
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.parsers.cpp import CppTypeInferenceEngine
 from codebase_rag.tests.conftest import get_relationships, run_updater
+
+
+def _root_node(source: str):
+    parsers, _ = load_parsers()
+    return parsers["cpp"].parse(source.encode("utf-8")).root_node
 
 
 def _calls_from(mock_ingestor: MagicMock, caller_suffix: str) -> set[str]:
@@ -15,12 +22,13 @@ def _calls_from(mock_ingestor: MagicMock, caller_suffix: str) -> set[str]:
 
 
 # (H) A field's declared type can be a `typedef`/`using` alias of a first-party class
-# (H) rather than the class name itself. Resolving `m1_.Lock()` requires mapping the
-# (H) alias (`MutexAlias`/`MutexUsing`) to its underlying class (`Mutex`); without it
-# (H) the receiver has a type the resolver cannot turn into a class, so the call is
-# (H) dropped (the name-only trie fallback is skipped once a receiver type is known).
-# (H) `Alpha.Lock` sorts before `Mutex.Lock`, so a name-only guess would pick the
-# (H) wrong one -- only alias-resolved field typing binds the correct `Mutex.Lock`.
+# (H) rather than the class name itself. Resolving `m_.Lock()` requires mapping the
+# (H) alias to its underlying class; without it the receiver has a type the resolver
+# (H) cannot turn into a class, so the call is dropped (the name-only trie fallback is
+# (H) skipped once a receiver type is known). The typedef field (`Mutex`) and the
+# (H) using field (`Gizmo`) target distinct methods so BOTH alias forms are asserted
+# (H) independently. `Alpha.Lock` sorts before `Mutex.Lock`, so a name-only guess
+# (H) would pick the wrong one -- only alias-resolved field typing binds Mutex.Lock.
 _SOURCE = """
 namespace ns {
 
@@ -34,18 +42,23 @@ class Mutex {
   void Lock() {}
 };
 
+class Gizmo {
+ public:
+  void Poke() {}
+};
+
 typedef Mutex MutexAlias;
-using MutexUsing = Mutex;
+using GizmoUsing = Gizmo;
 
 class DB {
  public:
   void Run() {
-    m1_.Lock();
-    m2_.Lock();
+    m_.Lock();
+    g_.Poke();
   }
  private:
-  MutexAlias m1_;
-  MutexUsing m2_;
+  MutexAlias m_;
+  GizmoUsing g_;
 };
 
 }  // namespace ns
@@ -62,13 +75,41 @@ def test_cpp_typedef_and_using_alias_field_calls_resolve_to_underlying_class(
     run_updater(project, mock_ingestor)
 
     callees = _calls_from(mock_ingestor, ".DB.Run")
-    # (H) Both the typedef- and using-aliased field calls must bind Mutex.Lock.
-    mutex_hits = [c for c in callees if c.endswith(".Mutex.Lock")]
-    assert len(mutex_hits) >= 1, (
-        f"m1_.Lock()/m2_.Lock() should resolve to Mutex.Lock via the alias, "
-        f"got {callees}"
+    # (H) typedef path: m_.Lock() binds Mutex.Lock (not the same-named Alpha.Lock).
+    assert any(c.endswith(".Mutex.Lock") for c in callees), (
+        f"m_.Lock() should resolve to Mutex.Lock via the typedef alias, got {callees}"
     )
     assert not any(c.endswith(".Alpha.Lock") for c in callees), (
-        f"alias field calls must not resolve to the same-named Alpha.Lock, "
-        f"got {callees}"
+        f"typedef alias field call must not resolve to Alpha.Lock, got {callees}"
     )
+    # (H) using path: g_.Poke() binds Gizmo.Poke.
+    assert any(c.endswith(".Gizmo.Poke") for c in callees), (
+        f"g_.Poke() should resolve to Gizmo.Poke via the using alias, got {callees}"
+    )
+
+
+# (H) Correctness guards for the global bare-name alias map (PR #568 review):
+# (H) (1) an alias defined inside a function body is local and must not be collected;
+# (H) (2) the same alias name mapping to different types in two namespaces/files is
+# (H) ambiguous and must be dropped (not first-write-wins), so those receivers fall
+# (H) back to name-only resolution instead of a confidently-wrong typed edge.
+def test_collect_type_aliases_skips_function_bodies_and_drops_conflicts() -> None:
+    src = """
+namespace a { typedef Widget Handle; }
+namespace b { typedef Gizmo Handle; }
+typedef Mutex Lock;
+using AliasT = Lock;
+void f() {
+  typedef Local L;
+  using Inner = Other;
+}
+"""
+    aliases: dict[str, str] = {}
+    conflicts: set[str] = set()
+    CppTypeInferenceEngine().collect_type_aliases(_root_node(src), aliases, conflicts)
+
+    # (H) File-scope aliases resolve; the conflicting `Handle` is dropped, and the
+    # (H) function-local `L`/`Inner` are never collected.
+    assert aliases == {"Lock": "Mutex", "AliasT": "Lock"}, aliases
+    assert "Handle" in conflicts
+    assert "L" not in aliases and "Inner" not in aliases


### PR DESCRIPTION
## What

Fixes a C++ receiver-type resolution gap: a field or local whose declared type is a `typedef`/`using` alias of a first-party class resolved to nothing, so method calls on it were dropped.

## The bug

For `typedef Mutex MutexAlias; MutexAlias m1_; m1_.Lock();` (and the `using MutexUsing = Mutex;` form), cgr inferred the receiver type as the alias name (`MutexAlias`), which `_resolve_class_name` could not map to a class. Because the receiver *had* a type, `_receiver_type_is_external` judged it external and suppressed the simple-name trie fallback, so the call attached to nothing — a silent recall loss whenever a project types members/locals through an alias.

## The fix

- Collect a global `type_aliases` map (`alias -> underlying bare type`) from `type_definition` (typedef) and `alias_declaration` (using) nodes during the definition pass (`CppTypeInferenceEngine.collect_type_aliases`), keyed by bare name like the existing flat type maps (an alias in a header is used across `.cc` files).
- Thread it factory -> `CallProcessor` -> `CallResolver` (mirroring `class_inheritance`/`class_field_types`).
- Dealias the receiver type name at the `_resolve_class_name` chokepoint (cycle-guarded), so both the typed method resolution and the external-receiver check see the underlying class. Empty for non-C++ languages, so they are unaffected.

`m1_.Lock()`/`m2_.Lock()` now bind `Mutex.Lock`, not the same-named `Alpha.Lock` (which sorts first, so it would win a name-only guess) and not nothing.

## Scope

`auto` locals initialized from a first-party method's return already resolve (verified), so the alias case was the remaining first-party recall gap in the item.

## Testing

RED->GREEN in history: `test_cpp_typedef_alias_receiver.py` fails (`got set()`) before the fix, passes after. Full non-integration suite 4119 passed; cpp/call/resolver subset 1024 passed; rebased onto current main (post-#567) with the C++ receiver-dispatch and member-field tests green.
