### PR TITLE
fix(dead-code): use BFS expansion so reachability does not time out on real graphs

### DIFF
--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -122,6 +122,9 @@ _DEAD_CODE_MODULE_ROOT_NON_TEST = (
 # (H) part of the dead cluster (the subclass is reported too). Classes referenced
 # (H) solely via type annotations / isinstance / dynamic lookups are not modelled
 # (H) as edges, so class candidates are review hints, not a delete list.
+# (H) *BFS visits each reachable node once; plain *0.. enumerates every path and
+# (H) times out on real graphs (cycles/diamonds make it combinatorial). *BFS
+# (H) excludes the source node, so the roots are unioned into the live set.
 _DEAD_CODE_QUERY_TEMPLATE = """MATCH (n:{labels})
 WHERE n.qualified_name STARTS WITH $project_prefix
   AND (
@@ -134,8 +137,9 @@ WHERE n.qualified_name STARTS WITH $project_prefix
   )
 WITH collect(n) AS roots
 UNWIND roots AS r
-MATCH (r)-[:{traversal}*0..]->(live)
-WITH collect(DISTINCT live) AS live_set
+OPTIONAL MATCH (r)-[:{traversal}*BFS]->(reached)
+WITH collect(DISTINCT r) AS root_set, collect(DISTINCT reached) AS reached_set
+WITH root_set + reached_set AS live_set
 MATCH (n:{labels})
 WHERE n.qualified_name STARTS WITH $project_prefix
   AND NOT n IN live_set

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -124,7 +124,9 @@ _DEAD_CODE_MODULE_ROOT_NON_TEST = (
 # (H) as edges, so class candidates are review hints, not a delete list.
 # (H) *BFS visits each reachable node once; plain *0.. enumerates every path and
 # (H) times out on real graphs (cycles/diamonds make it combinatorial). *BFS
-# (H) excludes the source node, so the roots are unioned into the live set.
+# (H) excludes the source node, so the roots are unioned into the live set. The
+# (H) CASE keeps one row when there are no roots (UNWIND of [] yields zero rows,
+# (H) which would drop the final MATCH and wrongly report nothing as dead).
 _DEAD_CODE_QUERY_TEMPLATE = """MATCH (n:{labels})
 WHERE n.qualified_name STARTS WITH $project_prefix
   AND (
@@ -136,10 +138,10 @@ WHERE n.qualified_name STARTS WITH $project_prefix
     OR {module_clause}{test_clause}
   )
 WITH collect(n) AS roots
-UNWIND roots AS r
+UNWIND (CASE WHEN size(roots) = 0 THEN [null] ELSE roots END) AS r
 OPTIONAL MATCH (r)-[:{traversal}*BFS]->(reached)
-WITH collect(DISTINCT r) AS root_set, collect(DISTINCT reached) AS reached_set
-WITH root_set + reached_set AS live_set
+WITH roots, collect(DISTINCT reached) AS reached_set
+WITH roots + reached_set AS live_set
 MATCH (n:{labels})
 WHERE n.qualified_name STARTS WITH $project_prefix
   AND NOT n IN live_set

--- a/codebase_rag/tests/integration/test_cypher_queries.py
+++ b/codebase_rag/tests/integration/test_cypher_queries.py
@@ -354,7 +354,9 @@ class TestBuildDeadCodeQueryUnit:
         assert "$root_decorators" in query
         assert "$entry_points" in query
         assert "is_exported" in query
-        assert "CALLS*0.." in query
+        # (H) BFS expansion: visits each reachable node once instead of
+        # (H) enumerating every path (which times out on real graphs).
+        assert "CALLS*BFS" in query
         # (H) test functions are roots when tests are included
         assert "n.path CONTAINS" in query
 

--- a/codebase_rag/tests/integration/test_cypher_queries.py
+++ b/codebase_rag/tests/integration/test_cypher_queries.py
@@ -600,6 +600,36 @@ class TestBuildDeadCodeQueryIntegration:
             "proj.mod.Derived",
         }
 
+    def test_no_roots_reports_everything(
+        self, memgraph_ingestor: MemgraphIngestor
+    ) -> None:
+        # (H) with no roots at all (nothing exported / entry-point / decorated /
+        # (H) called at module load), every function is unreachable and must be
+        # (H) reported. The empty-roots guard keeps the query from silently
+        # (H) returning nothing (UNWIND of [] would drop the final MATCH).
+        memgraph_ingestor._execute_query(
+            "CREATE "
+            "(a:Function {qualified_name: 'proj.mod.a', name: 'a', start_line: 1, "
+            "  end_line: 2, decorators: [], is_exported: false, path: 'proj/mod.py'}), "
+            "(b:Function {qualified_name: 'proj.mod.b', name: 'b', start_line: 4, "
+            "  end_line: 5, decorators: [], is_exported: false, path: 'proj/mod.py'}), "
+            "(a)-[:CALLS]->(b)"
+        )
+        params: dict[str, PropertyValue] = {
+            "project_prefix": "proj.",
+            "root_decorators": [],
+            "entry_points": [],
+            "test_patterns": ["test_", "_test", "conftest", "/tests/"],
+        }
+
+        results = memgraph_ingestor._execute_query(
+            build_dead_code_query(include_tests=False), params
+        )
+        assert {r["qualified_name"] for r in results} == {
+            "proj.mod.a",
+            "proj.mod.b",
+        }
+
     def test_module_load_callee_is_a_root(
         self, memgraph_ingestor: MemgraphIngestor
     ) -> None:


### PR DESCRIPTION
## Problem

`cgr dead-code` was unusable on any real-sized repo. The reachability query used `MATCH (r)-[:CALLS*0..]->(live)`, which enumerates *every path* from every root. With cycles and diamonds in a real call graph this is combinatorial, so the query hit Memgraph's transaction timeout and the command returned nothing:

```
mgclient.DatabaseError: Transaction was asked to abort because of transaction timeout.
```

All existing tests passed because their seed graphs are tiny (no path explosion).

## Fix

Switch to Memgraph BFS expansion (`*BFS`), which visits each reachable node once instead of enumerating paths. `*BFS` excludes the source node, so the roots are unioned into the live set explicitly.

Measured on a full ingest of this repo:

| | before | after |
|---|---|---|
| reachability query | timeout | 0.04s |
| `cgr dead-code` end-to-end | empty (error) | 354 candidates, ~4s |

## Verification

- Dogfooded end-to-end against a real Memgraph on the whole repo graph (functions/methods and `--classes`).
- 50 dead-code / cypher / constructor tests pass; ruff, ty (no new diagnostics), and `check_no_docs.py` clean.
