### PR TITLE
fix(incremental): rehydrate property status so property-dispatch calls survive re-index

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -185,6 +185,7 @@ KEY_EXPORTED_AT = "exported_at"
 KEY_PARSER = "parser"
 KEY_NAME = "name"
 KEY_QUALIFIED_NAME = "qualified_name"
+KEY_IS_PROPERTY = "is_property"
 KEY_QUERY = "query"
 KEY_RESPONSE = "response"
 KEY_START_LINE = "start_line"
@@ -1101,7 +1102,8 @@ CYPHER_ALL_FOLDER_PATHS = (
 CYPHER_ALL_DEFINITION_QNS = (
     "MATCH (n) WHERE n:Function OR n:Method OR n:Class OR n:Interface "
     "OR n:Enum OR n:Type OR n:Union "
-    "RETURN n.qualified_name AS qualified_name, head(labels(n)) AS label"
+    "RETURN n.qualified_name AS qualified_name, head(labels(n)) AS label, "
+    "n.is_property AS is_property"
 )
 
 # (H) Inbound reference edges (from unchanged files) into symbols defined in one

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -576,6 +576,11 @@ class GraphUpdater:
             except ValueError:
                 continue
             self.function_registry[qn] = node_type
+            # (H) Restore the property-name set for unchanged files: property-dispatch
+            # (H) resolution (`obj.prop`) consults it, so a re-parsed file's call to a
+            # (H) @property defined elsewhere would otherwise drop vs a clean index.
+            if row.get(cs.KEY_IS_PROPERTY):
+                self.function_registry.mark_property(qn)
             added += 1
         if added:
             logger.info(ls.REGISTRY_REHYDRATED, count=added)

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -287,10 +287,18 @@ def ingest_method(
         ).as_posix()
         method_props[cs.KEY_ABSOLUTE_PATH] = cached_resolve_posix(file_path)
 
+    # (H) Persist @property status on the node so an incremental rebuild can restore
+    # (H) the registry's property-name set for unchanged files (it re-marks from this
+    # (H) flag rather than re-parsing decorators); property-dispatch call resolution
+    # (H) depends on it, so without persistence those edges drop (issue #532 parity).
+    is_property = _is_property_decorator(decorators)
+    if is_property:
+        method_props[cs.KEY_IS_PROPERTY] = True
+
     logger.info(logs.METHOD_FOUND.format(name=method_name, qn=method_qn))
     ingestor.ensure_node_batch(cs.NodeLabel.METHOD, method_props)
     function_registry[method_qn] = NodeType.METHOD
-    if _is_property_decorator(decorators):
+    if is_property:
         function_registry.mark_property(method_qn)
     if _is_abstract_decorator(decorators):
         function_registry.mark_abstract(method_qn)

--- a/codebase_rag/tests/test_incremental_eval.py
+++ b/codebase_rag/tests/test_incremental_eval.py
@@ -219,6 +219,43 @@ class TestIncrementalScenario:
         assert (_FUNCTION, "proj.other.helper") in clean.nodes
         assert (_FUNCTION, "proj.other.helper") in incr.nodes
 
+    def test_incremental_preserves_property_dispatch_editing_caller(
+        self, tmp_path: Path, parsers_queries: tuple[object, object]
+    ) -> None:
+        # (H) Issue #532 residual (full-parity): editing client.py re-parses only it,
+        # (H) so the property status of Factory.dep (a @property in the unchanged
+        # (H) factory.py) is not re-marked. cgr resolves the attribute access
+        # (H) `self.d.dep` to that property via its property-name set, which the
+        # (H) incremental run must rehydrate from the graph (not just the function
+        # (H) registry). Without it the property-dispatch edge drops vs a clean index.
+        method = cs.NodeLabel.METHOD.value
+        prop_call = (
+            _FUNCTION,
+            "proj.client.use",
+            _CALLS,
+            method,
+            "proj.factory.Factory.dep",
+        )
+        src = tmp_path / "proj"
+        src.mkdir(parents=True)
+        (src / "__init__.py").write_text("", encoding="utf-8")
+        (src / "factory.py").write_text(
+            "class Factory:\n    @property\n    def dep(self):\n        return 1\n",
+            encoding="utf-8",
+        )
+        (src / "client.py").write_text(
+            "from proj.factory import Factory\n\n\n"
+            "def use(f: Factory):\n    return f.dep\n",
+            encoding="utf-8",
+        )
+        parsers, queries = parsers_queries
+        incr, clean = run_neutral_edit_scenario(
+            src, "proj", "client.py", parsers, queries, tmp_path / "scn"
+        )
+        assert prop_call in clean.edges
+        assert prop_call in incr.edges
+        assert incr == clean
+
     def test_compare_states_flags_missing_edge(self) -> None:
         from evals.types_defs import GraphState
 

--- a/evals/cgr_graph.py
+++ b/evals/cgr_graph.py
@@ -157,6 +157,7 @@ class _StatefulIngestor:
                     row: ResultRow = {
                         cs.KEY_QUALIFIED_NAME: _text(qn),
                         cs.KEY_LABEL: label,
+                        cs.KEY_IS_PROPERTY: bool(props.get(cs.KEY_IS_PROPERTY)),
                     }
                     defs.append(row)
                 return defs


### PR DESCRIPTION
## What

Closes a slice of the issue #532 incremental-update residual: a re-parsed file's call to a `@property` defined in an unchanged file was dropped versus a clean re-index.

## The bug

On an incremental rebuild, only the function registry is rehydrated from the graph for unchanged files. The registry trie also tracks a **property-name set** (`mark_property`), populated during the definition pass from `@property` decorators. That set was never persisted or rehydrated, so property-dispatch resolution (`obj.prop`) could not recognize a property defined in an unchanged file, and the resulting `CALLS` edge dropped.

## The fix

- Persist `is_property` on the Method node when it carries a property decorator.
- Return it from the definition-QN rehydration query.
- In `_rehydrate_registry_from_graph`, `mark_property` each rehydrated definition flagged as a property, restoring the property-name set for unchanged files.
- Mirror the new query field in the eval's in-memory stateful ingestor.

## Impact

On the `codebase_rag/parsers` incremental eval, clean-equivalent probes rose **19/25 → 21/25**, and `call_resolver.py` divergence dropped from **-13 to -1** edges, with **no new extra edges** introduced.

## Scope / remaining residual

This is the clean, no-regression slice. A further attempt to rehydrate the full `class_inheritance` hierarchy (for super()/override/protocol/subclass dispatch into unchanged files) was measured and **reverted**: it traded some dropped edges for new extra edges (net-negative parity), because clean builds `class_inheritance` in a specific incremental order during parsing and rehydrating the full hierarchy changes context-sensitive resolution outcomes. Full parity there needs order-identical resolution context, not naive rehydration; documented for follow-up.

## Testing

RED->GREEN: `test_incremental_preserves_property_dispatch_editing_caller` fails before the fix (property-dispatch edge dropped) and passes after. Full non-integration suite: 4122 passed, 3 skipped.
