### PR TITLE
fix(dead-code): treat *.test.* and *.spec.* files as test code

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -438,8 +438,17 @@ DEFAULT_ROOT_DECORATORS: frozenset[str] = frozenset(
     }
 )
 
-# (H) Substrings in a node's file path that mark it as test code.
-TEST_PATH_PATTERNS: tuple[str, ...] = ("test_", "_test", "conftest", "/tests/")
+# (H) Substrings in a node's file path that mark it as test code. Covers Python
+# (H) (test_, _test, conftest, /tests/) and the JS/TS convention (foo.test.ts,
+# (H) foo.spec.tsx) so *.test.* files are not reported as dead.
+TEST_PATH_PATTERNS: tuple[str, ...] = (
+    "test_",
+    "_test",
+    "conftest",
+    "/tests/",
+    ".test.",
+    ".spec.",
+)
 
 
 class NodeLabel(StrEnum):

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -439,8 +439,11 @@ DEFAULT_ROOT_DECORATORS: frozenset[str] = frozenset(
 )
 
 # (H) Substrings in a node's file path that mark it as test code. Covers Python
-# (H) (test_, _test, conftest, /tests/) and the JS/TS convention (foo.test.ts,
-# (H) foo.spec.tsx) so *.test.* files are not reported as dead.
+# (H) (test_, _test, conftest, /tests/), the JS/TS filename convention
+# (H) (foo.test.ts, foo.spec.tsx), and the Jest __tests__/ directory so those
+# (H) files are not reported as dead. Singular /test/ and /spec/ directories are
+# (H) intentionally excluded: they collide with product code (a domain "spec"
+# (H) module), which would misclassify live code as test.
 TEST_PATH_PATTERNS: tuple[str, ...] = (
     "test_",
     "_test",
@@ -448,6 +451,7 @@ TEST_PATH_PATTERNS: tuple[str, ...] = (
     "/tests/",
     ".test.",
     ".spec.",
+    "__tests__",
 )
 
 

--- a/codebase_rag/tests/integration/test_cypher_queries.py
+++ b/codebase_rag/tests/integration/test_cypher_queries.py
@@ -381,9 +381,13 @@ class TestBuildDeadCodeQueryUnit:
     def test_test_patterns_cover_js_ts_convention(self) -> None:
         from codebase_rag.constants import TEST_PATH_PATTERNS
 
-        # (H) *.test.ts / *.spec.tsx are test files; without these substrings
-        # (H) every symbol in them is wrongly reported as dead.
-        for path in ("src/solution.test.ts", "app/foo.spec.tsx"):
+        # (H) *.test.ts / *.spec.tsx / __tests__/ are test files; without these
+        # (H) substrings every symbol in them is wrongly reported as dead.
+        for path in (
+            "src/solution.test.ts",
+            "app/foo.spec.tsx",
+            "src/__tests__/helper.ts",
+        ):
             assert any(p in path for p in TEST_PATH_PATTERNS), path
 
     def test_include_classes_adds_class_candidates(self) -> None:

--- a/codebase_rag/tests/integration/test_cypher_queries.py
+++ b/codebase_rag/tests/integration/test_cypher_queries.py
@@ -378,6 +378,14 @@ class TestBuildDeadCodeQueryUnit:
         assert "Module" in query
         assert "[:CALLS]-(" in query
 
+    def test_test_patterns_cover_js_ts_convention(self) -> None:
+        from codebase_rag.constants import TEST_PATH_PATTERNS
+
+        # (H) *.test.ts / *.spec.tsx are test files; without these substrings
+        # (H) every symbol in them is wrongly reported as dead.
+        for path in ("src/solution.test.ts", "app/foo.spec.tsx"):
+            assert any(p in path for p in TEST_PATH_PATTERNS), path
+
     def test_include_classes_adds_class_candidates(self) -> None:
         with_classes = build_dead_code_query(include_tests=False, include_classes=True)
         assert "Function|Method|Class" in with_classes


### PR DESCRIPTION
## What

`TEST_PATH_PATTERNS` only matched Python test conventions (`test_`, `_test`, `conftest`, `/tests/`). JS/TS test files use `foo.test.ts` / `foo.spec.tsx`, which match none of those, so every symbol in a `*.test.*` file was reported as dead code.

Running `cgr dead-code` on a real polyglot repo produced hundreds of spurious `...test.anonymous_*` candidates from `.test.ts` files.

## Change

Add `.test.` and `.spec.` to `TEST_PATH_PATTERNS`.

## Test

RED→GREEN: `test_test_patterns_cover_js_ts_convention` asserts `src/solution.test.ts` and `app/foo.spec.tsx` match the patterns; fails before the fix, passes after.