### PR TITLE
fix(call-graph): process calls for every parsed file, not just AST-cache survivors

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -437,6 +437,10 @@ class GraphUpdater:
             simple_name_lookup=self.simple_name_lookup
         )
         self.ast_cache = BoundedASTCache()
+        # (H) Every file parsed this run, in parse order. The AST cache is bounded
+        # (H) and evicts on large repos, so Pass 3 must iterate this full list (not
+        # (H) the cache) and re-parse evicted files, or their calls are dropped.
+        self._parsed_files: list[tuple[Path, cs.SupportedLanguage]] = []
         self.unignore_paths = unignore_paths
         self.exclude_paths = exclude_paths
         self.skipped_because_in_sync = False
@@ -1051,15 +1055,42 @@ class GraphUpdater:
             if result:
                 root_node, language = result
                 self.ast_cache[filepath] = (root_node, language)
+                self._parsed_files.append((filepath, language))
         elif self._is_dependency_file(filepath.name, filepath):
             self.factory.definition_processor.process_dependencies(filepath)
 
         self.factory.structure_processor.process_generic_file(filepath, filepath.name)
 
+    def _ast_for(self, file_path: Path, language: cs.SupportedLanguage) -> Node | None:
+        # (H) Return the file's AST from the bounded cache, or re-parse from disk
+        # (H) when it was evicted. Evicted files carry stale captures (nodes from
+        # (H) the discarded tree), so drop them: downstream recomputes captures
+        # (H) from this fresh tree. Re-caching keeps the cache bounded across the
+        # (H) two Pass-3 loops.
+        if file_path in self.ast_cache:
+            return self.ast_cache[file_path][0]
+        parser = self.queries[language].get(cs.KEY_PARSER)
+        if parser is None:
+            return None
+        try:
+            file_bytes = file_path.read_bytes()
+        except OSError as e:
+            logger.error(ls.CALL_PROCESSING_FAILED, path=file_path, error=e)
+            return None
+        root_node = parser.parse(file_bytes).root_node
+        self.ast_cache[file_path] = (root_node, language)
+        self.factory._func_class_captures_cache.pop(file_path, None)
+        return root_node
+
     def _process_function_calls(self) -> None:
         captures_cache = self.factory._func_class_captures_cache
-        ast_cache_items = list(self.ast_cache.items())
-        for file_path, (root_node, language) in ast_cache_items:
+        # (H) Iterate every file parsed this run, not the bounded AST cache: on a
+        # (H) large repo the cache evicts most files, and iterating it drops their
+        # (H) calls (a whole module ends up with zero CALLS edges).
+        for file_path, language in self._parsed_files:
+            root_node = self._ast_for(file_path, language)
+            if root_node is None:
+                continue
             self.factory.call_processor.collect_callable_field_bindings(
                 file_path,
                 root_node,
@@ -1067,7 +1098,10 @@ class GraphUpdater:
                 self.queries,
                 func_class_captures_cache=captures_cache,
             )
-        for file_path, (root_node, language) in ast_cache_items:
+        for file_path, language in self._parsed_files:
+            root_node = self._ast_for(file_path, language)
+            if root_node is None:
+                continue
             if captures_cache is not None and file_path in captures_cache:
                 cached = captures_cache[file_path]
                 if not cached.get(cs.CAPTURE_CALL) and not cached.get(

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -502,6 +502,9 @@ class GraphUpdater:
             py_engine._return_stmt_cache.clear()
             py_engine._method_return_type_cache.clear()
             py_engine._self_assignment_cache.clear()
+        # (H) Reset per-run parse tracking so a reused updater does not reprocess
+        # (H) a previous run's files in Pass 3.
+        self._parsed_files.clear()
         self.ingestor.ensure_node_batch(
             cs.NODE_PROJECT, {cs.KEY_NAME: self.project_name}
         )

--- a/codebase_rag/tests/test_ast_cache_eviction_calls.py
+++ b/codebase_rag/tests/test_ast_cache_eviction_calls.py
@@ -48,3 +48,8 @@ def test_calls_survive_ast_cache_eviction(tmp_path: Path) -> None:
         ), (
             f"missing top->helper CALLS edge for evicted module {name}; calls={sorted(calls)}"
         )
+
+    # (H) A reused updater must reset per-run parse tracking, not accumulate.
+    parsed_after_first = len(updater._parsed_files)
+    updater.run(force=True)
+    assert len(updater._parsed_files) == parsed_after_first

--- a/codebase_rag/tests/test_ast_cache_eviction_calls.py
+++ b/codebase_rag/tests/test_ast_cache_eviction_calls.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+
+def _calls(mock_ingestor: MagicMock) -> set[tuple[str, str]]:
+    # (H) CALLS edges as (caller_qn, callee_qn).
+    out: set[tuple[str, str]] = set()
+    for c in mock_ingestor.ensure_relationship_batch.call_args_list:
+        if c.args[1] == "CALLS":
+            out.add((c.args[0][2], c.args[2][2]))
+    return out
+
+
+def test_calls_survive_ast_cache_eviction(tmp_path: Path) -> None:
+    # (H) The AST cache is bounded and evicts on large repos. Pass 3 must still
+    # (H) emit calls for every parsed file, not just cache survivors. With the
+    # (H) cache pinned to one entry, all but the last-parsed file are evicted
+    # (H) during Pass 2; every module's intra-file call must still be recorded.
+    parsers, queries = load_parsers()
+    if "python" not in parsers:
+        pytest.skip("python parser not available")
+
+    for name in ("a", "b", "c", "d", "e"):
+        (tmp_path / f"{name}.py").write_text(
+            "def helper():\n    return 1\n\n\ndef top():\n    return helper()\n",
+            encoding="utf-8",
+        )
+
+    mock = MagicMock()
+    updater = GraphUpdater(
+        ingestor=mock, repo_path=tmp_path, parsers=parsers, queries=queries
+    )
+    updater.ast_cache.max_entries = 1  # force eviction of all but the last file
+    updater.run()
+
+    calls = _calls(mock)
+    for name in ("a", "b", "c", "d", "e"):
+        assert any(
+            caller.endswith(f"{name}.top") and callee.endswith(f"{name}.helper")
+            for caller, callee in calls
+        ), (
+            f"missing top->helper CALLS edge for evicted module {name}; calls={sorted(calls)}"
+        )


### PR DESCRIPTION
## The bug

On any repository larger than the AST cache, cgr silently drops most of the call graph.

Pass 2 parses each file and stores its AST in `BoundedASTCache` (default `CACHE_MAX_ENTRIES=1000`, `CACHE_MAX_MEMORY_MB=500`), which evicts LRU entries as it fills. Pass 3 (`_process_function_calls`) then iterated **only the survivors** in that cache (`self.ast_cache.items()`), so every file evicted during Pass 2 never had its calls resolved. A whole module ends up with zero CALLS edges even though its functions call each other.

This corrupts reachability analysis (`cgr dead-code` reports live code as dead) and any query that relies on CALLS.

### Evidence (real 6,400-file repo)

| Build | AST cache | Modules with CALLS | Total CALLS |
|---|---|---|---|
| default | 1000 / 500 MB | 500 / 4229 | 6,344 |
| large | effectively unbounded | 1,797 / 4229 | 31,577 |

The default cache dropped ~80% of the call graph (~25k edges). One module (`csv_builder.py`) had 12 functions with obvious intra-file calls and **zero** CALLS edges under the default cache, **46** under a large cache.

## The fix

`GraphUpdater` records every file parsed this run in `self._parsed_files`. Pass 3 iterates that list instead of the bounded cache, fetching each AST from the cache or re-parsing it from disk on a miss (`_ast_for`). Re-parsed trees re-enter the bounded cache (memory stays bounded) and their stale captures are dropped so captures recompute against the fresh tree.

Correctness is now independent of cache size; the only cost on huge repos is re-parsing evicted files in Pass 3.

## Test

`test_ast_cache_eviction_calls.py`: pins the cache to one entry so all but the last file are evicted during Pass 2, then asserts every module's intra-file `top -> helper` CALLS edge is still recorded. RED before the fix, GREEN after.

Full suite: 4264 passed, 14 skipped.