### PR TITLE
chore: remove unused import in protobuf test

### DIFF
--- a/codebase_rag/tests/test_protobuf_service.py
+++ b/codebase_rag/tests/test_protobuf_service.py
@@ -189,8 +189,6 @@ def test_ensure_node_batch_no_message_class_logs_warning(tmp_path: Path) -> None
 
 
 def test_ensure_node_batch_no_oneof_mapping_logs_warning(tmp_path: Path) -> None:
-    from codebase_rag.services.protobuf_service import LABEL_TO_ONEOF_FIELD
-
     output_dir = tmp_path / "out"
     output_dir.mkdir()
     ingestor = ProtobufFileIngestor(str(output_dir))
@@ -280,8 +278,7 @@ def test_ensure_relationship_batch_unknown_rel_type(tmp_path: Path) -> None:
     key = next(iter(ingestor._relationships))
     rel_obj = ingestor._relationships[key]
     assert (
-        rel_obj.type
-        == pb.Relationship.RelationshipType.RELATIONSHIP_TYPE_UNSPECIFIED
+        rel_obj.type == pb.Relationship.RelationshipType.RELATIONSHIP_TYPE_UNSPECIFIED
     )
 
 


### PR DESCRIPTION
Removes the unused `LABEL_TO_ONEOF_FIELD` import in `test_ensure_node_batch_no_oneof_mapping_logs_warning`, which was tripping `ruff check .` with F401.