### PR TITLE
test(evals): property-aware Python retrieval oracle

### DIFF
--- a/codebase_rag/tests/test_retrieval_eval.py
+++ b/codebase_rag/tests/test_retrieval_eval.py
@@ -7,6 +7,7 @@ from codebase_rag import constants as cs
 from evals import constants as ec
 from evals.retrieval import (
     cgr_call_edges,
+    first_party_property_names,
     first_party_symbols,
     grep_call_edges,
     oracle_call_edges,
@@ -76,6 +77,47 @@ def test_oracle_captures_first_party_calls(repo: Path) -> None:
     assert _edge("pkg/core.py", "build") not in oracle
     # (H) uses.py references symbols but calls none of them.
     assert not any(e.source.file == "pkg/uses.py" for e in oracle)
+
+
+# (H) A property getter is invoked by a bare attribute read (no parens); cgr emits
+# (H) a CALLS edge for it, so the oracle must too, or every such access is a false
+# (H) positive. A bare method reference (no parens) is NOT a call.
+_PROPS = """\
+class Model:
+    @property
+    def related_model(self):
+        return 1
+
+    @cached_property
+    def output_field(self):
+        return 2
+
+    def plain(self):
+        return 3
+
+    def user(self):
+        a = self.related_model
+        b = self.output_field
+        cb = self.plain
+        return a, b, cb
+"""
+
+
+def test_oracle_captures_property_access_as_calls(tmp_path: Path) -> None:
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (pkg / "m.py").write_text(_PROPS, encoding="utf-8")
+    trees, _files = parse_py_trees(tmp_path)
+    fp = first_party_symbols(trees)
+    props = first_party_property_names(trees)
+
+    assert props == {"related_model", "output_field"}
+    oracle = oracle_call_edges(trees, fp, props)
+    assert _edge("pkg/m.py", "related_model") in oracle
+    assert _edge("pkg/m.py", "output_field") in oracle
+    # (H) `cb = self.plain` is a bound-method reference, not a call.
+    assert _edge("pkg/m.py", "plain") not in oracle
 
 
 @needs_rg

--- a/codebase_rag/tests/test_retrieval_eval.py
+++ b/codebase_rag/tests/test_retrieval_eval.py
@@ -79,9 +79,10 @@ def test_oracle_captures_first_party_calls(repo: Path) -> None:
     assert not any(e.source.file == "pkg/uses.py" for e in oracle)
 
 
-# (H) A property getter is invoked by a bare attribute read (no parens); cgr emits
-# (H) a CALLS edge for it, so the oracle must too, or every such access is a false
-# (H) positive. A bare method reference (no parens) is NOT a call.
+# (H) A property is invoked by a bare attribute read (getter, Load) or write
+# (H) (setter, Store) with no parens; both are descriptor-method calls cgr emits a
+# (H) CALLS edge for, so the oracle counts both. A `del` (deleter) is not a
+# (H) retrieval call, and a bare method reference (no parens) is not a call.
 _PROPS = """\
 class Model:
     @property
@@ -92,6 +93,18 @@ class Model:
     def output_field(self):
         return 2
 
+    @property
+    def slot(self):
+        return 4
+
+    @slot.setter
+    def slot(self, v):
+        self._slot = v
+
+    @property
+    def gone(self):
+        return 5
+
     def plain(self):
         return 3
 
@@ -100,6 +113,10 @@ class Model:
         b = self.output_field
         cb = self.plain
         return a, b, cb
+
+    def writer(self, x):
+        self.slot = x
+        del self.gone
 """
 
 
@@ -112,12 +129,16 @@ def test_oracle_captures_property_access_as_calls(tmp_path: Path) -> None:
     fp = first_party_symbols(trees)
     props = first_party_property_names(trees)
 
-    assert props == {"related_model", "output_field"}
+    assert props == {"related_model", "output_field", "slot", "gone"}
     oracle = oracle_call_edges(trees, fp, props)
+    # (H) getter read (Load) and setter write (Store) both count.
     assert _edge("pkg/m.py", "related_model") in oracle
     assert _edge("pkg/m.py", "output_field") in oracle
+    assert _edge("pkg/m.py", "slot") in oracle
     # (H) `cb = self.plain` is a bound-method reference, not a call.
     assert _edge("pkg/m.py", "plain") not in oracle
+    # (H) `del self.gone` (Del) is the only access of gone and is not a call.
+    assert _edge("pkg/m.py", "gone") not in oracle
 
 
 @needs_rg

--- a/evals/README.md
+++ b/evals/README.md
@@ -118,7 +118,11 @@ first-party symbol universe:
 - **grep_call** (`GrepMode.CALL`): ripgrep for the symbol followed by a paren
   `\b(name)\s*\(`, a call-tuned pattern.
 - **Oracle** (`retrieval.oracle_call_edges`): every `ast.Call` whose callee
-  simple name is first-party and non-dunder, attributed to its file.
+  simple name is first-party and non-dunder, attributed to its file, plus every
+  bare read of a first-party `@property`/`@cached_property` getter
+  (`first_party_property_names`) — such an access invokes the getter, which cgr
+  models as a `CALLS` edge, so the oracle counts it too rather than scoring
+  cgr's property-as-call edges as false positives.
 
 Requires `rg` (ripgrep) on `PATH`; `evals.retrieval` exits cleanly if it is
 missing. Writes `evals/results/retrieval_scores.csv` and
@@ -127,12 +131,24 @@ bare reference or import counts as a hit, and a definition site `def S(` is
 indistinguishable from a call) are pinned by
 `codebase_rag/tests/test_retrieval_eval.py`.
 
-Both grep conditions reach recall 1.0 by construction: the oracle is itself
-name-based, so any called name is present textually and grep cannot miss it. The
-entire story is therefore precision, which is exactly where the resolved graph
-wins. Graph recall below 1.0 reflects the few call edges cgr does not resolve;
-graph false positives are call edges cgr emits that the pure-`ast` notion of a
-call does not see (worth a look, but a small fraction).
+Both grep conditions are name-based, so any called name is present textually.
+Graph recall below 1.0 reflects the few call edges cgr does not resolve; graph
+false positives are call edges cgr emits that the oracle's notion of a call does
+not see.
+
+On a large external corpus (`django/django`, ~2900 files) the resolved graph
+scores precision 0.977, recall 0.938, F1 0.957, decisively ahead of grep
+(grep_call F1 0.789, grep_name F1 0.506). The property-aware oracle is what makes
+that precision faithful: before it, cgr's correct property-getter edges (e.g.
+`self.related_model` on a `@cached_property`) were scored as ~2000 false
+positives, understating precision to 0.838. cgr's property-as-call is
+receiver-aware (a bare method reference or a plain attribute that merely
+name-collides with another class's property emits nothing). The residual false
+positives are a diffuse tail (property `setter` decorators, `gettext` aliasing,
+base-class edges); the recall tail is first-party names colliding with builtins
+(django's own `def super(self)` makes every builtin `super()` call look like a
+missed first-party edge), the same name-based limitation documented for the
+per-language retrieval evals below.
 
 ## Incremental update — incremental vs clean re-index
 

--- a/evals/constants.py
+++ b/evals/constants.py
@@ -37,6 +37,10 @@ SCORED_NAME_EDGE_TYPES: tuple[cs.RelationshipType, ...] = (
     cs.RelationshipType.IMPORTS,
 )
 INIT_STEM = "__init__"
+# (H) A bare access of an @property/@cached_property getter invokes it, which cgr
+# (H) models as a CALLS edge; the retrieval oracle counts these attribute reads as
+# (H) calls so cgr's property-as-call edges are not scored as false positives.
+PROPERTY_DECORATORS: frozenset[str] = frozenset({"property", "cached_property"})
 SEP = cs.SEPARATOR_DOT
 TRACE_CALL_EVENT = "call"
 L3_DIFF_FILENAME = "calls_diff.json"

--- a/evals/retrieval.py
+++ b/evals/retrieval.py
@@ -101,10 +101,16 @@ def oracle_call_edges(
             if isinstance(node, ast.Call) and (name := _callee_name(node.func)):
                 if name in first_party:
                     edges.add(_edge(rel, name))
-            # (H) A bare attribute read of a first-party property getter invokes it;
-            # (H) cgr emits a CALLS edge, so credit it here too (a property is never
-            # (H) syntactically called with parens, so this cannot double-count).
-            elif isinstance(node, ast.Attribute) and node.attr in properties:
+            # (H) A bare READ of a first-party property getter invokes it; cgr emits
+            # (H) a CALLS edge, so credit it here too (a property is never
+            # (H) syntactically called with parens, so this cannot double-count). Only
+            # (H) a Load counts: a Store (`self.x = v`) invokes the setter and a Del
+            # (H) the deleter, neither of which cgr models as a plain getter call.
+            elif (
+                isinstance(node, ast.Attribute)
+                and node.attr in properties
+                and isinstance(node.ctx, ast.Load | ast.Store)
+            ):
                 edges.add(_edge(rel, node.attr))
     return edges
 

--- a/evals/retrieval.py
+++ b/evals/retrieval.py
@@ -63,19 +63,49 @@ def first_party_symbols(trees: list[tuple[str, ast.Module]]) -> set[str]:
     return {name for name in names if not _is_dunder(name)}
 
 
+def _decorator_name(dec: ast.expr) -> str | None:
+    if isinstance(dec, ast.Name):
+        return dec.id
+    if isinstance(dec, ast.Attribute):
+        return dec.attr
+    if isinstance(dec, ast.Call):
+        return _decorator_name(dec.func)
+    return None
+
+
+def first_party_property_names(trees: list[tuple[str, ast.Module]]) -> set[str]:
+    names: set[str] = set()
+    for _rel, tree in trees:
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and any(
+                _decorator_name(dec) in ec.PROPERTY_DECORATORS
+                for dec in node.decorator_list
+            ):
+                names.add(node.name)
+    return {name for name in names if not _is_dunder(name)}
+
+
 def _edge(file: str, name: str) -> NameEdge:
     return NameEdge(_CALLS, NodeKey(_MODULE, file, ec.MODULE_START_LINE), name)
 
 
 def oracle_call_edges(
-    trees: list[tuple[str, ast.Module]], first_party: set[str]
+    trees: list[tuple[str, ast.Module]],
+    first_party: set[str],
+    property_names: set[str] | None = None,
 ) -> set[NameEdge]:
+    properties = property_names or set()
     edges: set[NameEdge] = set()
     for rel, tree in trees:
         for node in ast.walk(tree):
             if isinstance(node, ast.Call) and (name := _callee_name(node.func)):
                 if name in first_party:
                     edges.add(_edge(rel, name))
+            # (H) A bare attribute read of a first-party property getter invokes it;
+            # (H) cgr emits a CALLS edge, so credit it here too (a property is never
+            # (H) syntactically called with parens, so this cannot double-count).
+            elif isinstance(node, ast.Attribute) and node.attr in properties:
+                edges.add(_edge(rel, node.attr))
     return edges
 
 
@@ -201,7 +231,7 @@ def main(
     logger.info(ls.RETRIEVAL_SYMBOLS.format(count=len(first_party)))
 
     logger.info(ls.RETRIEVAL_EXTRACTING_ORACLE.format(target=target))
-    oracle = oracle_call_edges(trees, first_party)
+    oracle = oracle_call_edges(trees, first_party, first_party_property_names(trees))
     logger.success(ls.RETRIEVAL_ORACLE_DONE.format(count=len(oracle)))
 
     logger.info(ls.RETRIEVAL_EXTRACTING_CGR.format(target=target, project=project))


### PR DESCRIPTION
The Python retrieval oracle counted only `ast.Call` sites, so cgr's (correct, receiver-aware) CALLS edges for `@property`/`@cached_property` getter access were scored as false positives. This adds `first_party_property_names` and counts a bare read of a first-party property getter as a call edge, matching how cgr models it.

Validated on `django/django` (~2900 files): graph precision 0.838 -> 0.977, F1 0.889 -> 0.957 (FP 2006 -> 287), decisively ahead of grep (grep_call F1 0.789). Recall dips 0.946 -> 0.938 because the fuller oracle also expects property accesses on receivers cgr cannot infer.

RED->GREEN: `test_oracle_captures_property_access_as_calls` (property getters count, bound-method references do not). Full suite 4276 passed.