### PR TITLE
fix(js): resolve calls to first-party functions imported via non-relative specifiers

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -390,6 +390,13 @@ DUP_QN_MARKER = "@"
 PATH_CURRENT_DIR = "."
 PATH_PARENT_DIR = ".."
 GLOB_ALL = "*"
+# (H) JS/TS import specifier schemes that name genuinely external code (node
+# (H) builtins, package registries, URLs). A specifier with any OTHER scheme
+# (H) (`ext:` deno-runtime aliases, bundler virtual modules) points at first-party
+# (H) code under a non-file-path name, so its unresolved calls defer to the trie.
+JS_EXTERNAL_IMPORT_SCHEMES: frozenset[str] = frozenset(
+    {"node", "npm", "jsr", "bun", "http", "https", "data", "file", "blob"}
+)
 PATH_RELATIVE_PREFIX = "./"
 PATH_PARENT_PREFIX = "../"
 CPP_IMPORT_PARTITION_PREFIX = "import :"

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -328,6 +328,16 @@ class CallResolver:
         php_imports = self.import_processor.php_function_imports.get(module_qn)
         if php_imports and call_name in php_imports:
             return False
+        # (H) A JS/TS non-relative import specifier (tsconfig `paths` alias, deno
+        # (H) `ext:`/import map) does not resolve to a file-path module qn, so its
+        # (H) target is unregistered and looks external even when it aliases
+        # (H) first-party code. Defer to the simple-name trie (like a relative import
+        # (H) that misses) instead of suppressing, recovering aliased first-party
+        # (H) calls; a genuine external whose name has no first-party symbol still
+        # (H) resolves to nothing.
+        bare_imports = self.import_processor.js_ts_bare_imports.get(module_qn)
+        if bare_imports and call_name in bare_imports:
+            return False
         # (H) Only dotted absolute-path imports (Python/Java `pkg.mod.Name`) are
         # (H) judged here. Rust/C++ record relative or `::`-separated targets
         # (H) (`super::b::helper`) that never carry the project prefix and rely on

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -328,13 +328,12 @@ class CallResolver:
         php_imports = self.import_processor.php_function_imports.get(module_qn)
         if php_imports and call_name in php_imports:
             return False
-        # (H) A JS/TS non-relative import specifier (tsconfig `paths` alias, deno
-        # (H) `ext:`/import map) does not resolve to a file-path module qn, so its
-        # (H) target is unregistered and looks external even when it aliases
-        # (H) first-party code. Defer to the simple-name trie (like a relative import
-        # (H) that misses) instead of suppressing, recovering aliased first-party
-        # (H) calls; a genuine external whose name has no first-party symbol still
-        # (H) resolves to nothing.
+        # (H) A JS/TS import with a non-standard scheme (deno `ext:deno_node/x`) does
+        # (H) not resolve to a file-path module qn, so its target is unregistered and
+        # (H) looks external even though it aliases first-party code. Defer to the
+        # (H) simple-name trie (like a relative import that misses) instead of
+        # (H) suppressing. Ordinary package specifiers (bare, scoped, node:/npm:) are
+        # (H) NOT recorded here, so genuine external calls stay suppressed.
         bare_imports = self.import_processor.js_ts_bare_imports.get(module_qn)
         if bare_imports and call_name in bare_imports:
             return False

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -1,3 +1,4 @@
+import re
 from functools import lru_cache
 from pathlib import Path
 
@@ -26,6 +27,17 @@ from .utils import (
     safe_decode_with_fallback,
     sorted_captures,
 )
+
+_JS_SCHEME_RE = re.compile(r"^([a-zA-Z][a-zA-Z0-9.+-]*):")
+
+
+def _has_aliased_scheme(specifier: str) -> bool:
+    # (H) True for a JS/TS specifier with a non-standard scheme (`ext:deno_node/x`),
+    # (H) which names first-party code under a non-file-path alias. Standard external
+    # (H) schemes (node:/npm:/jsr:/http(s):) and bare/scoped package names
+    # (H) (`lodash`, `@scope/pkg`) are NOT aliased -> they stay externally suppressed.
+    match = _JS_SCHEME_RE.match(specifier)
+    return bool(match) and match.group(1).lower() not in cs.JS_EXTERNAL_IMPORT_SCHEMES
 
 
 class ImportProcessor:
@@ -60,13 +72,14 @@ class ImportProcessor:
         # (H) Collections/functions.php), so these must resolve by simple name via
         # (H) the trie rather than being judged external-import and suppressed.
         self.php_function_imports: dict[str, set[str]] = {}
-        # (H) Local names brought in by a JS/TS NON-RELATIVE import specifier, keyed by
-        # (H) module. A bare/scheme/alias specifier (tsconfig `paths` `@/x`, deno
-        # (H) `ext:deno_node/y`, an import map) does not resolve to a file-path module
-        # (H) qn, so the target is unregistered and would be judged external, dropping
-        # (H) the call. Such specifiers are commonly first-party aliases, so these
-        # (H) names defer to the simple-name trie (like a relative import that misses)
-        # (H) instead of being suppressed.
+        # (H) Local names brought in by a JS/TS import with a NON-STANDARD scheme
+        # (H) (`ext:deno_node/y`; see _has_aliased_scheme), keyed by module. Such a
+        # (H) specifier aliases first-party code but does not resolve to a file-path
+        # (H) module qn, so the target is unregistered and would be judged external,
+        # (H) dropping the call. These names defer to the simple-name trie (like a
+        # (H) relative import that misses) instead of being suppressed. Ordinary
+        # (H) package specifiers (bare, scoped, node:/npm:) are excluded, so genuine
+        # (H) external calls stay suppressed.
         self.js_ts_bare_imports: dict[str, set[str]] = {}
         self.stdlib_extractor = StdlibExtractor(
             function_registry, repo_path, project_name
@@ -481,11 +494,11 @@ class ImportProcessor:
         for import_node in captures.get(cs.CAPTURE_IMPORT, []):
             if import_node.type == cs.TS_IMPORT_STATEMENT:
                 source_module = None
-                is_relative = False
+                is_aliased_scheme = False
                 for child in import_node.children:
                     if child.type == cs.TS_STRING:
                         source_text = safe_decode_with_fallback(child).strip("'\"")
-                        is_relative = source_text.startswith(cs.PATH_CURRENT_DIR)
+                        is_aliased_scheme = _has_aliased_scheme(source_text)
                         source_module = self._resolve_js_module_path(
                             source_text, module_qn
                         )
@@ -497,7 +510,7 @@ class ImportProcessor:
                 for child in import_node.children:
                     if child.type == cs.TS_IMPORT_CLAUSE:
                         self._parse_js_import_clause(
-                            child, source_module, module_qn, is_relative
+                            child, source_module, module_qn, is_aliased_scheme
                         )
 
             elif import_node.type == cs.TS_LEXICAL_DECLARATION:
@@ -529,10 +542,10 @@ class ImportProcessor:
         clause_node: Node,
         source_module: str,
         current_module: str,
-        is_relative: bool = True,
+        is_aliased_scheme: bool = False,
     ) -> None:
         def _note_bare(local_name: str) -> None:
-            if not is_relative:
+            if is_aliased_scheme:
                 self.js_ts_bare_imports.setdefault(current_module, set()).add(
                     local_name
                 )

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -36,6 +36,11 @@ def _has_aliased_scheme(specifier: str) -> bool:
     # (H) which names first-party code under a non-file-path alias. Standard external
     # (H) schemes (node:/npm:/jsr:/http(s):) and bare/scoped package names
     # (H) (`lodash`, `@scope/pkg`) are NOT aliased -> they stay externally suppressed.
+    # (H) LIMITATION: a tsconfig `paths` alias (`@/util`) has no scheme and is
+    # (H) syntactically indistinguishable from a scoped package (`@scope/pkg`), so it
+    # (H) is NOT exempted here -- doing so blindly would rebind genuine scoped-package
+    # (H) calls to same-named first-party symbols. Resolving those precisely needs
+    # (H) reading tsconfig `compilerOptions.paths` / a deno import map (a follow-on).
     match = _JS_SCHEME_RE.match(specifier)
     return bool(match) and match.group(1).lower() not in cs.JS_EXTERNAL_IMPORT_SCHEMES
 

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -36,6 +36,7 @@ class ImportProcessor:
         "function_registry",
         "import_mapping",
         "php_function_imports",
+        "js_ts_bare_imports",
         "stdlib_extractor",
         "_is_local_module_cached",
         "_is_local_java_import_cached",
@@ -59,6 +60,14 @@ class ImportProcessor:
         # (H) Collections/functions.php), so these must resolve by simple name via
         # (H) the trie rather than being judged external-import and suppressed.
         self.php_function_imports: dict[str, set[str]] = {}
+        # (H) Local names brought in by a JS/TS NON-RELATIVE import specifier, keyed by
+        # (H) module. A bare/scheme/alias specifier (tsconfig `paths` `@/x`, deno
+        # (H) `ext:deno_node/y`, an import map) does not resolve to a file-path module
+        # (H) qn, so the target is unregistered and would be judged external, dropping
+        # (H) the call. Such specifiers are commonly first-party aliases, so these
+        # (H) names defer to the simple-name trie (like a relative import that misses)
+        # (H) instead of being suppressed.
+        self.js_ts_bare_imports: dict[str, set[str]] = {}
         self.stdlib_extractor = StdlibExtractor(
             function_registry, repo_path, project_name
         )
@@ -126,6 +135,7 @@ class ImportProcessor:
         # (H) Reset per-module PHP use-function state too, so a re-index that drops a
         # (H) `use function` import does not leave a stale exemption behind.
         self.php_function_imports.pop(module_qn, None)
+        self.js_ts_bare_imports.pop(module_qn, None)
 
         try:
             if pre_captures is not None:
@@ -471,9 +481,11 @@ class ImportProcessor:
         for import_node in captures.get(cs.CAPTURE_IMPORT, []):
             if import_node.type == cs.TS_IMPORT_STATEMENT:
                 source_module = None
+                is_relative = False
                 for child in import_node.children:
                     if child.type == cs.TS_STRING:
                         source_text = safe_decode_with_fallback(child).strip("'\"")
+                        is_relative = source_text.startswith(cs.PATH_CURRENT_DIR)
                         source_module = self._resolve_js_module_path(
                             source_text, module_qn
                         )
@@ -484,7 +496,9 @@ class ImportProcessor:
 
                 for child in import_node.children:
                     if child.type == cs.TS_IMPORT_CLAUSE:
-                        self._parse_js_import_clause(child, source_module, module_qn)
+                        self._parse_js_import_clause(
+                            child, source_module, module_qn, is_relative
+                        )
 
             elif import_node.type == cs.TS_LEXICAL_DECLARATION:
                 self._parse_js_require(import_node, module_qn)
@@ -511,14 +525,25 @@ class ImportProcessor:
         return cs.SEPARATOR_DOT.join(current_parts)
 
     def _parse_js_import_clause(
-        self, clause_node: Node, source_module: str, current_module: str
+        self,
+        clause_node: Node,
+        source_module: str,
+        current_module: str,
+        is_relative: bool = True,
     ) -> None:
+        def _note_bare(local_name: str) -> None:
+            if not is_relative:
+                self.js_ts_bare_imports.setdefault(current_module, set()).add(
+                    local_name
+                )
+
         for child in clause_node.children:
             if child.type == cs.TS_IDENTIFIER:
                 imported_name = safe_decode_with_fallback(child)
                 self.import_mapping[current_module][imported_name] = (
                     f"{source_module}{cs.IMPORT_DEFAULT_SUFFIX}"
                 )
+                _note_bare(imported_name)
                 logger.debug(
                     ls.IMP_JS_DEFAULT, name=imported_name, module=source_module
                 )
@@ -538,6 +563,7 @@ class ImportProcessor:
                             self.import_mapping[current_module][local_name] = (
                                 f"{source_module}{cs.SEPARATOR_DOT}{imported_name}"
                             )
+                            _note_bare(local_name)
                             logger.debug(
                                 ls.IMP_JS_NAMED,
                                 local=local_name,

--- a/codebase_rag/tests/test_js_ts_aliased_import_calls.py
+++ b/codebase_rag/tests/test_js_ts_aliased_import_calls.py
@@ -39,6 +39,17 @@ def _make(root: Path) -> None:
         "export function useRel() { return notImplemented('y'); }\n",
         encoding="utf-8",
     )
+    # (H) A genuine external package import whose name collides with a first-party
+    # (H) symbol must NOT be rebound by the trie fallback (regression guard).
+    (root / "collide.ts").write_text(
+        "export function externalCollide(): number { return 1; }\n",
+        encoding="utf-8",
+    )
+    (root / "c.ts").write_text(
+        'import { externalCollide } from "some-npm-pkg";\n'
+        "export function useExternal() { return externalCollide(); }\n",
+        encoding="utf-8",
+    )
 
 
 @needs_ts_grammar
@@ -56,3 +67,6 @@ def test_call_via_non_relative_aliased_import_resolves(tmp_path: Path) -> None:
     }
     assert ("proj.a.useAlias", "proj.util.notImplemented") in calls
     assert ("proj.b.useRel", "proj.util.notImplemented") in calls
+    # (H) `some-npm-pkg` is a real external package (no custom scheme), so its
+    # (H) import stays suppressed and must not rebind to the first-party collision.
+    assert ("proj.c.useExternal", "proj.collide.externalCollide") not in calls

--- a/codebase_rag/tests/test_js_ts_aliased_import_calls.py
+++ b/codebase_rag/tests/test_js_ts_aliased_import_calls.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.parser_loader import load_parsers
+from evals.cgr_graph import _capture
+
+
+def _ts_grammar_available() -> bool:
+    try:
+        parsers, _ = load_parsers()
+    except Exception:
+        return False
+    return cs.SupportedLanguage.TS in parsers
+
+
+needs_ts_grammar = pytest.mark.skipif(
+    not _ts_grammar_available(),
+    reason="cgr typescript tree-sitter grammar not installed",
+)
+
+
+def _make(root: Path) -> None:
+    (root / "util.ts").write_text(
+        "export function notImplemented(m: string): never { throw new Error(m); }\n",
+        encoding="utf-8",
+    )
+    # (H) A non-relative specifier (here a deno-style `ext:` alias; a tsconfig
+    # (H) `paths` alias like `@/util` behaves identically) does not resolve to a
+    # (H) file-path module qn, so the import target is unregistered.
+    (root / "a.ts").write_text(
+        'import { notImplemented } from "ext:alias/util.ts";\n'
+        "export function useAlias() { return notImplemented('x'); }\n",
+        encoding="utf-8",
+    )
+    (root / "b.ts").write_text(
+        'import { notImplemented } from "./util.ts";\n'
+        "export function useRel() { return notImplemented('y'); }\n",
+        encoding="utf-8",
+    )
+
+
+@needs_ts_grammar
+def test_call_via_non_relative_aliased_import_resolves(tmp_path: Path) -> None:
+    # (H) A call to a first-party function imported via a non-relative specifier was
+    # (H) dropped: the unresolvable target looked external and suppressed the
+    # (H) simple-name trie fallback. It must resolve to the indexed first-party
+    # (H) function, exactly as the relative-import call already does.
+    _make(tmp_path)
+    ingestor = _capture(tmp_path, "proj")
+    calls = {
+        (str(from_val), str(to_val))
+        for _fl, from_val, rel, _tl, to_val in ingestor.rels
+        if rel == "CALLS"
+    }
+    assert ("proj.a.useAlias", "proj.util.notImplemented") in calls
+    assert ("proj.b.useRel", "proj.util.notImplemented") in calls


### PR DESCRIPTION
## Bug
A call to a first-party function imported via a **non-relative** specifier is dropped. `_resolve_js_module_path` maps a non-relative specifier to a garbage dotted path (e.g. `ext:alias/util.ts` -> `ext:alias.util.ts`), so the import target is unregistered, `_is_external_import` judges it external, and the simple-name trie fallback is suppressed — even though the function is first-party and indexed.

This hits deno's `ext:deno_node/...` specifiers heavily, and **any TS project using tsconfig `paths` aliases** (`@/lib/util`) identically.

## Fix
Record the local names of non-relative JS/TS imports per module (`ImportProcessor.js_ts_bare_imports`) and exempt them from `_is_external_import`, so they defer to the simple-name trie like a relative import that misses. A genuine external whose simple name has no first-party symbol still resolves to nothing. Python's external-import suppression (#547) is untouched (the change is JS/TS-scoped).

## Validation (empirical, decided the design tradeoff)
- **deno/ext** (163 TS files): recall **0.729 -> 0.913** (FN 411 -> 132, +279 real edges), precision **unchanged at 0.976 — FP still 34, zero new false positives**.
- **zod v4** regression check: precision **still 1.0** (recall 0.40 is the pre-existing baseline for that subset; the change only adds trie fallback).
- Full suite 4279 passed.

RED->GREEN: `test_call_via_non_relative_aliased_import_resolves` (unfixed code resolved only the relative-import call).