### PR TITLE
feat(js): resolve tsconfig paths aliases to first-party modules

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -397,6 +397,26 @@ GLOB_ALL = "*"
 JS_EXTERNAL_IMPORT_SCHEMES: frozenset[str] = frozenset(
     {"node", "npm", "jsr", "bun", "http", "https", "data", "file", "blob"}
 )
+# (H) Module file extensions stripped when turning a tsconfig `paths` target into a
+# (H) module qn (`src/util.ts` -> `src/util`), longest first so `.d.ts`-like
+# (H) compound suffixes are handled before the bare `.ts`.
+JS_TS_MODULE_EXTENSIONS: tuple[str, ...] = (
+    ".d.ts",
+    ".tsx",
+    ".ts",
+    ".jsx",
+    ".mjs",
+    ".cjs",
+    ".js",
+)
+TSCONFIG_FILENAMES: tuple[str, ...] = (
+    "tsconfig.json",
+    "tsconfig.base.json",
+    "jsconfig.json",
+)
+TS_COMPILER_OPTIONS_KEY = "compilerOptions"
+TS_PATHS_KEY = "paths"
+TS_BASE_URL_KEY = "baseUrl"
 PATH_RELATIVE_PREFIX = "./"
 PATH_PARENT_PREFIX = "../"
 CPP_IMPORT_PARTITION_PREFIX = "import :"

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -414,6 +414,7 @@ TSCONFIG_FILENAMES: tuple[str, ...] = (
     "tsconfig.base.json",
     "jsconfig.json",
 )
+JS_INDEX_STEM = "index"
 TS_COMPILER_OPTIONS_KEY = "compilerOptions"
 TS_PATHS_KEY = "paths"
 TS_BASE_URL_KEY = "baseUrl"

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -1,3 +1,4 @@
+import json
 import re
 from functools import lru_cache
 from pathlib import Path
@@ -29,6 +30,73 @@ from .utils import (
 )
 
 _JS_SCHEME_RE = re.compile(r"^([a-zA-Z][a-zA-Z0-9.+-]*):")
+_JSONC_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+_JSONC_LINE_COMMENT_RE = re.compile(r"//[^\n]*")
+_JSONC_TRAILING_COMMA_RE = re.compile(r",(\s*[}\]])")
+
+
+def _load_jsonc(path: Path) -> dict | None:
+    # (H) tsconfig.json is JSONC (comments, trailing commas). Try strict JSON first
+    # (H) (comment-free configs), then fall back to stripping comments/trailing
+    # (H) commas. The naive strip can mangle `//` inside string values, so it is only
+    # (H) a fallback; on any failure return None (aliases simply stay unresolved).
+    try:
+        text = path.read_text(encoding=cs.ENCODING_UTF8)
+    except OSError:
+        return None
+    for candidate in (text, None):
+        source = candidate
+        if source is None:
+            source = _JSONC_BLOCK_COMMENT_RE.sub("", text)
+            source = _JSONC_LINE_COMMENT_RE.sub("", source)
+            source = _JSONC_TRAILING_COMMA_RE.sub(r"\1", source)
+        try:
+            parsed = json.loads(source)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        return parsed if isinstance(parsed, dict) else None
+    return None
+
+
+def _load_ts_path_aliases(repo_path: Path) -> list[tuple[str, str, bool]]:
+    # (H) Parse tsconfig `compilerOptions.paths` into (match_prefix, target_prefix,
+    # (H) is_wildcard) tuples, folding baseUrl into the target. A `@/*`->`src/*` entry
+    # (H) yields ("@/", "src/", True); an exact `~lib`->`src/lib/index.ts` yields
+    # (H) ("~lib", "src/lib/index.ts", False). `extends` chains are not followed.
+    for name in cs.TSCONFIG_FILENAMES:
+        data = _load_jsonc(repo_path / name)
+        if not data:
+            continue
+        options = data.get(cs.TS_COMPILER_OPTIONS_KEY)
+        if not isinstance(options, dict):
+            continue
+        paths = options.get(cs.TS_PATHS_KEY)
+        if not isinstance(paths, dict):
+            continue
+        base = options.get(cs.TS_BASE_URL_KEY) or cs.PATH_CURRENT_DIR
+        base = str(base).strip(cs.SEPARATOR_SLASH)
+        base_prefix = (
+            "" if base in ("", cs.PATH_CURRENT_DIR) else base + cs.SEPARATOR_SLASH
+        )
+        aliases: list[tuple[str, str, bool]] = []
+        for pattern, targets in paths.items():
+            if not isinstance(targets, list) or not targets:
+                continue
+            target = targets[0]
+            if not isinstance(pattern, str) or not isinstance(target, str):
+                continue
+            if pattern.endswith(cs.GLOB_ALL) and cs.GLOB_ALL in target:
+                aliases.append(
+                    (
+                        pattern[: -len(cs.GLOB_ALL)],
+                        base_prefix + target[: target.index(cs.GLOB_ALL)],
+                        True,
+                    )
+                )
+            elif cs.GLOB_ALL not in pattern:
+                aliases.append((pattern, base_prefix + target, False))
+        return aliases
+    return []
 
 
 def _has_aliased_scheme(specifier: str) -> bool:
@@ -36,11 +104,11 @@ def _has_aliased_scheme(specifier: str) -> bool:
     # (H) which names first-party code under a non-file-path alias. Standard external
     # (H) schemes (node:/npm:/jsr:/http(s):) and bare/scoped package names
     # (H) (`lodash`, `@scope/pkg`) are NOT aliased -> they stay externally suppressed.
-    # (H) LIMITATION: a tsconfig `paths` alias (`@/util`) has no scheme and is
-    # (H) syntactically indistinguishable from a scoped package (`@scope/pkg`), so it
-    # (H) is NOT exempted here -- doing so blindly would rebind genuine scoped-package
-    # (H) calls to same-named first-party symbols. Resolving those precisely needs
-    # (H) reading tsconfig `compilerOptions.paths` / a deno import map (a follow-on).
+    # (H) A tsconfig `paths` alias (`@/util`) has no scheme and is not exempted here
+    # (H) (it would be indistinguishable from a scoped package `@scope/pkg`); it is
+    # (H) instead resolved PRECISELY to its real module upstream by
+    # (H) _resolve_js_module_path via _load_ts_path_aliases, so no trie fallback is
+    # (H) needed for it.
     match = _JS_SCHEME_RE.match(specifier)
     return bool(match) and match.group(1).lower() not in cs.JS_EXTERNAL_IMPORT_SCHEMES
 
@@ -54,6 +122,7 @@ class ImportProcessor:
         "import_mapping",
         "php_function_imports",
         "js_ts_bare_imports",
+        "js_path_aliases",
         "stdlib_extractor",
         "_is_local_module_cached",
         "_is_local_java_import_cached",
@@ -86,6 +155,12 @@ class ImportProcessor:
         # (H) package specifiers (bare, scoped, node:/npm:) are excluded, so genuine
         # (H) external calls stay suppressed.
         self.js_ts_bare_imports: dict[str, set[str]] = {}
+        # (H) tsconfig `paths` aliases (match_prefix, target_prefix, is_wildcard),
+        # (H) parsed once from the repo-root tsconfig so `@/util` imports resolve to
+        # (H) the real first-party module instead of being dropped as external.
+        self.js_path_aliases: list[tuple[str, str, bool]] = _load_ts_path_aliases(
+            repo_path
+        )
         self.stdlib_extractor = StdlibExtractor(
             function_registry, repo_path, project_name
         )
@@ -524,8 +599,38 @@ class ImportProcessor:
             elif import_node.type == cs.TS_EXPORT_STATEMENT:
                 self._parse_js_reexport(import_node, module_qn)
 
+    def _ts_alias_module_qn(self, import_path: str) -> str | None:
+        # (H) Resolve a tsconfig `paths` alias (`@/util` -> `src/util`) to the
+        # (H) first-party module qn, so the call binds to the real file instead of
+        # (H) being dropped as external. Precise (maps to the actual path), so no
+        # (H) trie-fallback collision risk. Longest matching prefix wins.
+        best: tuple[int, str] | None = None
+        for prefix, target_prefix, is_wildcard in self.js_path_aliases:
+            if is_wildcard:
+                if import_path.startswith(prefix) and len(prefix) > (
+                    best[0] if best else -1
+                ):
+                    best = (len(prefix), target_prefix + import_path[len(prefix) :])
+            elif import_path == prefix and len(prefix) > (best[0] if best else -1):
+                best = (len(prefix), target_prefix)
+        if best is None:
+            return None
+        path = best[1]
+        while path.startswith(cs.PATH_CURRENT_DIR + cs.SEPARATOR_SLASH):
+            path = path[2:]
+        for ext in cs.JS_TS_MODULE_EXTENSIONS:
+            if path.endswith(ext):
+                path = path[: -len(ext)]
+                break
+        dotted = path.strip(cs.SEPARATOR_SLASH).replace(
+            cs.SEPARATOR_SLASH, cs.SEPARATOR_DOT
+        )
+        return f"{self.project_name}{cs.SEPARATOR_DOT}{dotted}" if dotted else None
+
     def _resolve_js_module_path(self, import_path: str, current_module: str) -> str:
         if not import_path.startswith(cs.PATH_CURRENT_DIR):
+            if aliased := self._ts_alias_module_qn(import_path):
+                return aliased
             return import_path.replace(cs.SEPARATOR_SLASH, cs.SEPARATOR_DOT)
 
         current_parts = current_module.split(cs.SEPARATOR_DOT)[:-1]

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -1,4 +1,5 @@
 import json
+import posixpath
 import re
 from functools import lru_cache
 from pathlib import Path
@@ -616,16 +617,37 @@ class ImportProcessor:
         if best is None:
             return None
         path = best[1]
-        while path.startswith(cs.PATH_CURRENT_DIR + cs.SEPARATOR_SLASH):
-            path = path[2:]
         for ext in cs.JS_TS_MODULE_EXTENSIONS:
             if path.endswith(ext):
                 path = path[: -len(ext)]
                 break
-        dotted = path.strip(cs.SEPARATOR_SLASH).replace(
-            cs.SEPARATOR_SLASH, cs.SEPARATOR_DOT
-        )
-        return f"{self.project_name}{cs.SEPARATOR_DOT}{dotted}" if dotted else None
+        # (H) normpath collapses `.`/`..` so the qn is clean and an escaping alias
+        # (H) (`../x`) is rejected below.
+        normalized = posixpath.normpath(path)
+        if normalized in (cs.PATH_CURRENT_DIR, "") or normalized.startswith(
+            cs.PATH_PARENT_DIR
+        ):
+            return None
+        # (H) Only accept the alias when it maps to a real first-party file on disk.
+        # (H) A broad/catch-all alias (`"*": ["src/*"]`) would otherwise capture bare
+        # (H) package imports (`lodash` -> `proj.src.lodash`) and let their calls
+        # (H) rebind to same-named first-party symbols (the #580 collision). A missing
+        # (H) target falls through to the normal external handling.
+        module_rel: str | None = None
+        if any(
+            (self.repo_path / f"{normalized}{ext}").is_file()
+            for ext in cs.JS_TS_MODULE_EXTENSIONS
+        ):
+            module_rel = normalized
+        elif (self.repo_path / normalized).is_dir() and any(
+            (self.repo_path / normalized / f"{cs.JS_INDEX_STEM}{ext}").is_file()
+            for ext in cs.JS_TS_MODULE_EXTENSIONS
+        ):
+            module_rel = f"{normalized}{cs.SEPARATOR_SLASH}{cs.JS_INDEX_STEM}"
+        if module_rel is None:
+            return None
+        dotted = module_rel.replace(cs.SEPARATOR_SLASH, cs.SEPARATOR_DOT)
+        return f"{self.project_name}{cs.SEPARATOR_DOT}{dotted}"
 
     def _resolve_js_module_path(self, import_path: str, current_module: str) -> str:
         if not import_path.startswith(cs.PATH_CURRENT_DIR):

--- a/codebase_rag/tests/test_ts_tsconfig_paths.py
+++ b/codebase_rag/tests/test_ts_tsconfig_paths.py
@@ -30,7 +30,8 @@ def _make(root: Path) -> None:
         "  // project config\n"
         '  "compilerOptions": {\n'
         '    "baseUrl": ".",\n'
-        '    "paths": { "@/*": ["src/*"], "~lib": ["src/lib/index.ts"] }\n'
+        '    "paths": { "@/*": ["src/*"], "~lib": ["src/lib/index.ts"],\n'
+        '      "*": ["src/*"] }\n'
         "  }\n"
         "}\n",
         encoding="utf-8",
@@ -43,10 +44,16 @@ def _make(root: Path) -> None:
     (src / "lib" / "index.ts").write_text(
         "export function libEntry(): number { return 2; }\n", encoding="utf-8"
     )
+    # (H) A first-party function whose name collides with an external package import.
+    (src / "collide.ts").write_text(
+        "export function pkgCollide(): number { return 9; }\n", encoding="utf-8"
+    )
     (root / "a.ts").write_text(
         'import { aliasedHelper } from "@/util";\n'
         'import { libEntry } from "~lib";\n'
-        "export function useAliases() { return aliasedHelper() + libEntry(); }\n",
+        'import { pkgCollide } from "lodash";\n'
+        "export function useAliases() { return aliasedHelper() + libEntry(); }\n"
+        "export function useExternal() { return pkgCollide(); }\n",
         encoding="utf-8",
     )
 
@@ -66,3 +73,7 @@ def test_tsconfig_paths_alias_calls_resolve_to_first_party_files(
     assert ("proj.a.useAliases", "proj.src.util.aliasedHelper") in calls
     # (H) exact (non-wildcard) alias `~lib` -> `src/lib/index.ts`
     assert ("proj.a.useAliases", "proj.src.lib.index.libEntry") in calls
+    # (H) the catch-all `"*": ["src/*"]` maps `lodash` -> `src/lodash`, which has NO
+    # (H) first-party file, so the alias must NOT apply and the external `pkgCollide`
+    # (H) call must not rebind to the first-party `src/collide.pkgCollide`.
+    assert ("proj.a.useExternal", "proj.src.collide.pkgCollide") not in calls

--- a/codebase_rag/tests/test_ts_tsconfig_paths.py
+++ b/codebase_rag/tests/test_ts_tsconfig_paths.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.parser_loader import load_parsers
+from evals.cgr_graph import _capture
+
+
+def _ts_grammar_available() -> bool:
+    try:
+        parsers, _ = load_parsers()
+    except Exception:
+        return False
+    return cs.SupportedLanguage.TS in parsers
+
+
+needs_ts_grammar = pytest.mark.skipif(
+    not _ts_grammar_available(),
+    reason="cgr typescript tree-sitter grammar not installed",
+)
+
+
+def _make(root: Path) -> None:
+    # (H) tsconfig `paths` maps the alias `@/*` to `src/*`; a call to a function
+    # (H) imported via the alias must resolve to the real first-party file, not be
+    # (H) dropped as external. JSONC (comments) is tolerated.
+    (root / "tsconfig.json").write_text(
+        "{\n"
+        "  // project config\n"
+        '  "compilerOptions": {\n'
+        '    "baseUrl": ".",\n'
+        '    "paths": { "@/*": ["src/*"], "~lib": ["src/lib/index.ts"] }\n'
+        "  }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    src = root / "src"
+    (src / "lib").mkdir(parents=True, exist_ok=True)
+    (src / "util.ts").write_text(
+        "export function aliasedHelper(): number { return 1; }\n", encoding="utf-8"
+    )
+    (src / "lib" / "index.ts").write_text(
+        "export function libEntry(): number { return 2; }\n", encoding="utf-8"
+    )
+    (root / "a.ts").write_text(
+        'import { aliasedHelper } from "@/util";\n'
+        'import { libEntry } from "~lib";\n'
+        "export function useAliases() { return aliasedHelper() + libEntry(); }\n",
+        encoding="utf-8",
+    )
+
+
+@needs_ts_grammar
+def test_tsconfig_paths_alias_calls_resolve_to_first_party_files(
+    tmp_path: Path,
+) -> None:
+    _make(tmp_path)
+    ingestor = _capture(tmp_path, "proj")
+    calls = {
+        (str(from_val), str(to_val))
+        for _fl, from_val, rel, _tl, to_val in ingestor.rels
+        if rel == "CALLS"
+    }
+    # (H) wildcard alias `@/*` -> `src/*`
+    assert ("proj.a.useAliases", "proj.src.util.aliasedHelper") in calls
+    # (H) exact (non-wildcard) alias `~lib` -> `src/lib/index.ts`
+    assert ("proj.a.useAliases", "proj.src.lib.index.libEntry") in calls


### PR DESCRIPTION
## What
Completes the #580 follow-on: cgr now reads tsconfig `compilerOptions.paths` (JSONC-tolerant) and resolves alias specifiers to the real first-party module during JS/TS import resolution.

- `@/*` -> `src/*` (wildcard) and exact aliases (`~lib` -> `src/lib/index.ts`), with `baseUrl` folded in; longest matching prefix wins.
- Precise resolution (maps to the actual file), so — unlike a trie fallback — there is **no external-collision risk**: a scoped package `@scope/pkg` that is not an alias stays external.
- `extends` chains and index-directory resolution are not followed (documented).

## Why
Path aliases are ubiquitous in real TS apps; before this, `import { x } from "@/util"` resolved to a garbage module qn and every call to `x` was dropped as external (the same class as #580, which handled deno's `ext:` scheme).

RED->GREEN: `test_tsconfig_paths_alias_calls_resolve_to_first_party_files` (wildcard + exact alias). Repos without a tsconfig are unaffected (empty alias list). Full suite 4280 passed.