### PR TITLE
feat(resolver): chained-call receiver type inference via method return types

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -763,6 +763,7 @@ FIELD_DECLARATOR = "declarator"
 FIELD_PARAMETERS = "parameters"
 FIELD_RECEIVER = "receiver"
 FIELD_TYPE = "type"
+FIELD_RESULT = "result"
 # (H) Rust impl `trait`/`type` fields and a trait's supertrait `bounds`.
 FIELD_TRAIT = "trait"
 FIELD_BOUNDS = "bounds"

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -2114,6 +2114,12 @@ TS_GO_EXPRESSION_LIST = "expression_list"
 TS_GO_COMPOSITE_LITERAL = "composite_literal"
 TS_GO_UNARY_EXPRESSION = "unary_expression"
 TS_GO_POINTER_TYPE = "pointer_type"
+# (H) Go composite types a method may return; a chained call lands on the CONTAINER,
+# (H) not its element, so return-type inference must not unwrap these to an element
+# (H) name (a `[]Command` return must not resolve `.Run()` to `Command.Run`).
+TS_GO_CONTAINER_TYPES: frozenset[str] = frozenset(
+    {"slice_type", "array_type", "map_type", "channel_type", "function_type"}
+)
 FIELD_OPERAND = "operand"
 
 # (H) Tree-sitter Scala node types

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -17,6 +17,29 @@ _SEPARATOR_PATTERN = re.compile(r"[.:]|::")
 _SEARCH_NAME_CACHE: dict[str, str] = {}
 _CHAINED_METHOD_PATTERN = re.compile(r"\.([^.()]+)$")
 _QN_SPLIT_CACHE: dict[str, tuple[list[str], int]] = {}
+_CHAIN_OPEN_BRACKETS = "([{"
+_CHAIN_CLOSE_BRACKETS = ")]}"
+
+
+def _split_receiver_chain(expr: str) -> list[str]:
+    # (H) Split a receiver chain (`c.Find(1.5).Root`) on the `.` separators between
+    # (H) hops only -- never on a `.` inside call arguments, an index, or a generic
+    # (H) (`1.5`, `x.y` args, `List<A.B>`), which a naive str.split would mangle.
+    parts: list[str] = []
+    depth = 0
+    current: list[str] = []
+    for char in expr:
+        if char in _CHAIN_OPEN_BRACKETS:
+            depth += 1
+        elif char in _CHAIN_CLOSE_BRACKETS:
+            depth = max(0, depth - 1)
+        if char == cs.SEPARATOR_DOT and depth == 0:
+            parts.append("".join(current))
+            current = []
+        else:
+            current.append(char)
+    parts.append("".join(current))
+    return parts
 
 
 class CallResolver:
@@ -937,7 +960,7 @@ class CallResolver:
         # (H) unresolved, never mis-resolved).
         if not local_var_types or not self.type_inference.method_return_types:
             return None
-        parts = object_expr.split(cs.SEPARATOR_DOT)
+        parts = _split_receiver_chain(object_expr)
         base = parts[0]
         if not base or cs.CHAR_PAREN_OPEN in base:
             return None

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -923,6 +923,35 @@ class CallResolver:
 
         return None
 
+    def _infer_chained_object_type(
+        self,
+        object_expr: str,
+        module_qn: str,
+        local_var_types: dict[str, str] | None,
+    ) -> str | None:
+        # (H) Type of a chained receiver expression like `c.Root()` using the shared
+        # (H) method_return_types map: the base is a typed local (`c` -> Command), and
+        # (H) each `.method()` hop advances the type by that method's return type
+        # (H) (Root() -> Command). Language-agnostic; returns the bare type name of the
+        # (H) final hop, or None if any hop is untyped/unknown (then the chain stays
+        # (H) unresolved, never mis-resolved).
+        if not local_var_types or not self.type_inference.method_return_types:
+            return None
+        parts = object_expr.split(cs.SEPARATOR_DOT)
+        base = parts[0]
+        if not base or cs.CHAR_PAREN_OPEN in base:
+            return None
+        current_type = local_var_types.get(base)
+        for part in parts[1:]:
+            if not current_type or cs.CHAR_PAREN_OPEN not in part:
+                return None
+            method = part.split(cs.CHAR_PAREN_OPEN, 1)[0]
+            class_qn = self._resolve_class_name(current_type, module_qn) or current_type
+            current_type = self.type_inference.method_return_types.get(
+                f"{class_qn}{cs.SEPARATOR_DOT}{method}"
+            )
+        return current_type
+
     def _is_method_chain(self, call_name: str) -> bool:
         if cs.CHAR_PAREN_OPEN not in call_name or cs.CHAR_PAREN_CLOSE not in call_name:
             return False
@@ -946,12 +975,13 @@ class CallResolver:
 
         object_expr = call_name[: match.start()]
 
-        if (
-            object_type
-            := self.type_inference.python_type_inference._infer_expression_return_type(
+        object_type = (
+            self.type_inference.python_type_inference._infer_expression_return_type(
                 object_expr, module_qn, local_var_types
             )
-        ):
+            or self._infer_chained_object_type(object_expr, module_qn, local_var_types)
+        )
+        if object_type:
             full_object_type = object_type
             if cs.SEPARATOR_DOT not in object_type:
                 if resolved_class := self._resolve_class_name(object_type, module_qn):

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -63,6 +63,10 @@ class DefinitionProcessor(
         # (H) across all files (an alias in a header is used in a .cc), read by the
         # (H) resolver when mapping a receiver type name to a class.
         self.type_aliases: dict[str, str] = {}
+        # (H) {func_or_method_qn: bare_return_type_name} captured at definition
+        # (H) ingestion, so a chained call `x.foo().bar()` can resolve `bar` on the
+        # (H) type `foo()` returns. Read by the resolver's chained-call path.
+        self.method_return_types: dict[str, str] = {}
         # (H) Alias names seen with conflicting underlying types across scopes/files;
         # (H) dropped from type_aliases so their receivers fall back to name-only.
         self._type_alias_conflicts: set[str] = set()

--- a/codebase_rag/parsers/factory.py
+++ b/codebase_rag/parsers/factory.py
@@ -119,6 +119,7 @@ class ProcessorFactory:
                 class_inheritance=self.definition_processor.class_inheritance,
                 simple_name_lookup=self.simple_name_lookup,
                 class_field_types=self.definition_processor.class_field_types,
+                method_return_types=self.definition_processor.method_return_types,
             )
         return self._type_inference
 

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -77,6 +77,7 @@ class FunctionIngestMixin:
     _handler: LanguageHandler
     _deferred_cpp_methods: list[_DeferredMethod]
     _deferred_go_methods: list[_DeferredGoMethod]
+    method_return_types: dict[str, str]
 
     @abstractmethod
     def _get_docstring(self, node: ASTNode) -> str | None: ...
@@ -395,6 +396,15 @@ class FunctionIngestMixin:
                 file_path=entry.file_path,
                 repo_path=self.repo_path,
             )
+            # (H) Record the method's return type so a chained call `c.Root().Run()`
+            # (H) can resolve `Run` on the type `Root()` returns.
+            method_name = self._extract_function_name(entry.method_node)
+            if method_name and (
+                return_type := go_utils.extract_return_type_name(entry.method_node)
+            ):
+                self.method_return_types[
+                    f"{container_qn}{cs.SEPARATOR_DOT}{method_name}"
+                ] = return_type
         ingested = len(deferred)
         self._deferred_go_methods = []
         return ingested

--- a/codebase_rag/parsers/go/__init__.py
+++ b/codebase_rag/parsers/go/__init__.py
@@ -1,8 +1,13 @@
 from .type_inference import GoTypeInferenceEngine
-from .utils import extract_receiver_type_name, is_receiver_method
+from .utils import (
+    extract_receiver_type_name,
+    extract_return_type_name,
+    is_receiver_method,
+)
 
 __all__ = [
     "GoTypeInferenceEngine",
     "extract_receiver_type_name",
+    "extract_return_type_name",
     "is_receiver_method",
 ]

--- a/codebase_rag/parsers/go/utils.py
+++ b/codebase_rag/parsers/go/utils.py
@@ -33,7 +33,24 @@ def extract_return_type_name(node: Node) -> str | None:
     result = node.child_by_field_name(cs.FIELD_RESULT)
     if result is None or result.type == cs.TS_GO_PARAMETER_LIST:
         return None
-    return type_identifier_text(result)
+    return _return_type_identifier(result)
+
+
+def _return_type_identifier(type_node: Node) -> str | None:
+    # (H) Like type_identifier_text but does NOT unwrap composite types: a
+    # (H) `[]Command`/`map[k]Command`/`chan Command` return is a container, and a
+    # (H) chained call lands on the container, not the element, so it must not be
+    # (H) unwrapped to "Command" (which would emit a false edge). Only a plain
+    # (H) type_identifier, a pointer to one (`*Command`), or a generic base resolves.
+    if type_node.type in cs.TS_GO_CONTAINER_TYPES:
+        return None
+    if type_node.type == cs.TS_TYPE_IDENTIFIER and type_node.text:
+        return safe_decode_text(type_node)
+    if type_node.type in (cs.TS_GO_POINTER_TYPE, cs.TS_GENERIC_TYPE):
+        for child in type_node.children:
+            if name := _return_type_identifier(child):
+                return name
+    return None
 
 
 def type_identifier_text(type_node: Node) -> str | None:

--- a/codebase_rag/parsers/go/utils.py
+++ b/codebase_rag/parsers/go/utils.py
@@ -26,6 +26,16 @@ def extract_receiver_type_name(node: Node) -> str | None:
     return None
 
 
+def extract_return_type_name(node: Node) -> str | None:
+    # (H) Bare name of a Go function/method's single return type (`Root() *Command`
+    # (H) -> "Command"), for chained-call resolution. A parameter_list result
+    # (H) (multiple/named returns) is ambiguous for chaining, so it is skipped.
+    result = node.child_by_field_name(cs.FIELD_RESULT)
+    if result is None or result.type == cs.TS_GO_PARAMETER_LIST:
+        return None
+    return type_identifier_text(result)
+
+
 def type_identifier_text(type_node: Node) -> str | None:
     if type_node.type == cs.TS_TYPE_IDENTIFIER and type_node.text:
         return safe_decode_text(type_node)

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -32,6 +32,7 @@ class TypeInferenceEngine:
         "class_inheritance",
         "simple_name_lookup",
         "class_field_types",
+        "method_return_types",
         "_java_type_inference",
         "_lua_type_inference",
         "_js_type_inference",
@@ -52,6 +53,7 @@ class TypeInferenceEngine:
         class_inheritance: dict[str, list[str]],
         simple_name_lookup: SimpleNameLookup,
         class_field_types: dict[str, dict[str, str]] | None = None,
+        method_return_types: dict[str, str] | None = None,
     ):
         self.import_processor = import_processor
         self.function_registry = function_registry
@@ -68,6 +70,12 @@ class TypeInferenceEngine:
         # (H) silently lose every field type written afterward.
         self.class_field_types = (
             class_field_types if class_field_types is not None else {}
+        )
+        # (H) Shared reference (as with class_field_types): DefinitionProcessor's
+        # (H) func_qn -> return-type map, populated during ingestion and read by the
+        # (H) resolver's chained-call path.
+        self.method_return_types = (
+            method_return_types if method_return_types is not None else {}
         )
 
         self._java_type_inference: JavaTypeInferenceEngine | None = None

--- a/codebase_rag/tests/test_go_chained_return_type.py
+++ b/codebase_rag/tests/test_go_chained_return_type.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+from evals.cgr_graph import _capture
+
+
+def _make(root: Path) -> None:
+    # (H) `c.Root().Run()`: Root() returns *Command, so Run() must resolve on
+    # (H) Command. cgr infers the receiver `c` type (Command) already; the missing
+    # (H) piece is the RETURN type of Root() feeding the next hop. This is the cobra
+    # (H) `cmd.Root().GenZshCompletion()` gap.
+    (root / "m.go").write_text(
+        "package p\n"
+        "type Command struct{}\n"
+        "func (c *Command) Root() *Command { return c }\n"
+        "func (c *Command) Run() int { return 1 }\n"
+        "func (c *Command) Use() int { return c.Root().Run() }\n",
+        encoding="utf-8",
+    )
+
+
+def test_go_chained_return_type_resolves_second_hop(tmp_path: Path) -> None:
+    _make(tmp_path)
+    ingestor = _capture(tmp_path, "proj")
+    calls = {
+        (str(from_val), str(to_val))
+        for _fl, from_val, rel, _tl, to_val in ingestor.rels
+        if rel == "CALLS"
+    }
+    # (H) first hop already resolves via receiver-type inference.
+    assert ("proj.m.Command.Use", "proj.m.Command.Root") in calls
+    # (H) second hop needs Root()'s return type (*Command) to resolve Run().
+    assert ("proj.m.Command.Use", "proj.m.Command.Run") in calls

--- a/codebase_rag/tests/test_go_chained_return_type.py
+++ b/codebase_rag/tests/test_go_chained_return_type.py
@@ -1,6 +1,15 @@
 from pathlib import Path
 
+from codebase_rag.parsers.call_resolver import _split_receiver_chain
 from evals.cgr_graph import _capture
+
+
+def test_split_receiver_chain_ignores_dots_inside_arguments() -> None:
+    # (H) `.` inside call args / index / generic must not split the receiver chain.
+    assert _split_receiver_chain("c.Find(1.5)") == ["c", "Find(1.5)"]
+    assert _split_receiver_chain("a.b(x.y).c") == ["a", "b(x.y)", "c"]
+    assert _split_receiver_chain("m[k.v].get") == ["m[k.v]", "get"]
+    assert _split_receiver_chain("c.Root") == ["c", "Root"]
 
 
 def _make(root: Path) -> None:

--- a/codebase_rag/tests/test_go_chained_return_type.py
+++ b/codebase_rag/tests/test_go_chained_return_type.py
@@ -30,3 +30,38 @@ def test_go_chained_return_type_resolves_second_hop(tmp_path: Path) -> None:
     assert ("proj.m.Command.Use", "proj.m.Command.Root") in calls
     # (H) second hop needs Root()'s return type (*Command) to resolve Run().
     assert ("proj.m.Command.Use", "proj.m.Command.Run") in calls
+
+
+def _calls(tmp_path: Path, body: str) -> set[tuple[str, str]]:
+    (tmp_path / "m.go").write_text(body, encoding="utf-8")
+    ingestor = _capture(tmp_path, "proj")
+    return {(str(f), str(t)) for _fl, f, rel, _tl, t in ingestor.rels if rel == "CALLS"}
+
+
+def test_chained_call_on_container_return_does_not_misresolve(tmp_path: Path) -> None:
+    # (H) Kids() returns []Command (a slice); a chained `.Run()` is called on the
+    # (H) slice, NOT on a Command, so it must NOT resolve to Command.Run. Unwrapping
+    # (H) the container to its element type would emit a false edge.
+    calls = _calls(
+        tmp_path,
+        "package p\n"
+        "type Command struct{}\n"
+        "func (c *Command) Kids() []Command { return nil }\n"
+        "func (c *Command) Run() int { return 1 }\n"
+        "func (c *Command) Use() int { return c.Kids().Run() }\n",
+    )
+    assert ("proj.m.Command.Use", "proj.m.Command.Run") not in calls
+
+
+def test_chained_call_with_dotted_argument_resolves(tmp_path: Path) -> None:
+    # (H) A dotted call argument (`1.5`) must not break the chain split: Find(1.5)
+    # (H) returns *Command, so Run() still resolves.
+    calls = _calls(
+        tmp_path,
+        "package p\n"
+        "type Command struct{}\n"
+        "func (c *Command) Find(x float64) *Command { return c }\n"
+        "func (c *Command) Run() int { return 1 }\n"
+        "func (c *Command) Use() int { return c.Find(1.5).Run() }\n",
+    )
+    assert ("proj.m.Command.Use", "proj.m.Command.Run") in calls

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.187"
+version = "0.0.188"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What
Adds a shared `method_return_types` map (func/method qn -> bare return-type name), populated at definition ingestion and threaded DefinitionProcessor -> factory -> TypeInferenceEngine -> CallResolver (mirrors `class_field_types`). The resolver's chained-call path now walks a receiver expression like `c.Root()` — base is a typed local (`c` -> Command), each `.method()` hop advances the type by that method's return type — so the final hop (`.Run()` / cobra's `.GenZshCompletion()`) resolves.

This is the first increment of the shared type-inference workstream: return-type capture is wired for **Go** here; TS/Java/C++ plug into the same map next.

## Why
The dominant cross-language recall gap is deeper receiver/return-type inference. Chained calls (`x.foo().bar()`) previously resolved only for Python; every other language dropped the second hop.

## Validation
- cobra (Go) retrieval: recall 0.9752 -> 0.9788, precision unchanged 1.0 (**zero new FP**).
- Language-agnostic and conservative: any untyped/unknown hop leaves the chain unresolved (never mis-resolved).
- Full suite 4280 passed; Python chained path unchanged (tried first, this is a fallback).

RED->GREEN: `test_go_chained_return_type_resolves_second_hop`.