### PR TITLE
fix(dead-code): suppress spurious C++ edge from nested lambda parameter shadowing

### DIFF
--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -156,9 +156,7 @@ def _python_parameter_name(param_node: Node) -> str | None:
     return None
 
 
-_PY_CLOSURE_SCOPES = frozenset(
-    {cs.TS_PY_FUNCTION_DEFINITION, cs.TS_PY_LAMBDA}
-)
+_PY_CLOSURE_SCOPES = frozenset({cs.TS_PY_FUNCTION_DEFINITION, cs.TS_PY_LAMBDA})
 _GO_CLOSURE_SCOPES = frozenset({cs.TS_GO_FUNC_LITERAL})
 
 
@@ -249,11 +247,13 @@ def _cpp_invoked_parameter_names(body_node: Node, candidates: set[str]) -> set[s
 
 
 def _cpp_scope_bound_names(scope_node: Node) -> set[str]:
-    # (H) A C++ lambda's own parameters are hard to enumerate uniformly (abstract
-    # (H) function declarators); shadowing a captured callable parameter with a
-    # (H) same-named lambda parameter and invoking it is vanishingly rare, so no
-    # (H) subtraction is applied. This only risks an extra (conservative) edge.
-    return set()
+    # (H) A C++ lambda's own parameters shadow a same-named captured parameter of the
+    # (H) enclosing function, so they must be subtracted before scanning the lambda
+    # (H) body -- otherwise the lambda invoking its own `cb` looks like an invocation
+    # (H) of the outer `cb`. The lambda's parameters hang off its `declarator` (an
+    # (H) abstract_function_declarator whose `parameters` list mirrors a function's).
+    declarator = scope_node.child_by_field_name(cs.FIELD_DECLARATOR)
+    return set(_cpp_declarator_param_names(declarator))
 
 
 def _cpp_declarator_name(declarator: Node | None) -> str | None:
@@ -285,9 +285,15 @@ def cpp_parameter_names(func_node: Node) -> list[str]:
     # (H) unwrapping each parameter's declarator to its bound identifier.
     declarator = func_node.child_by_field_name(cs.FIELD_DECLARATOR)
     func_declarator = _find_descendant(declarator, cs.CppNodeType.FUNCTION_DECLARATOR)
-    if func_declarator is None:
+    return _cpp_declarator_param_names(func_declarator)
+
+
+def _cpp_declarator_param_names(declarator: Node | None) -> list[str]:
+    # (H) Bound parameter names from a (function|abstract_function) declarator's
+    # (H) `parameters` list, unwrapping each parameter's declarator to its identifier.
+    if declarator is None:
         return []
-    params = func_declarator.child_by_field_name(cs.KEY_PARAMETERS)
+    params = declarator.child_by_field_name(cs.KEY_PARAMETERS)
     if params is None:
         return []
     names: list[str] = []

--- a/codebase_rag/tests/test_callable_flow_tracing_cpp.py
+++ b/codebase_rag/tests/test_callable_flow_tracing_cpp.py
@@ -64,3 +64,20 @@ def test_cpp_factory_alias_callback_stays_reachable(tmp_path: Path) -> None:
     )
     calls = _run_calls(tmp_path, {"m.cpp": src})
     assert _has(calls, "main", "target")
+
+
+def test_cpp_nested_lambda_shadowing_suppresses_forbidden_edge(tmp_path: Path) -> None:
+    # (H) shadow's own cb parameter is never invoked; the nested lambda has its own
+    # (H) cb parameter that shadows it, and only that inner cb is called. The flow
+    # (H) tracer must subtract the lambda's bound names before descending, so it must
+    # (H) NOT conclude shadow invokes its cb and emit shadow -> target.
+    src = (
+        "int target() { return 1; }\n"
+        "int shadow(int (*cb)()) {\n"
+        "    auto inner = [](int (*cb)()) { return cb(); };\n"
+        "    return 0;\n"
+        "}\n"
+        "int main() { return shadow(target); }\n"
+    )
+    calls = _run_calls(tmp_path, {"m.cpp": src})
+    assert not _has(calls, "shadow", "target")

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.187"
+version = "0.0.189"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

Fixes a C++ callable-parameter tracing precision bug surfaced during the #579 review: a nested lambda whose parameter shadows an enclosing function's callable parameter caused a spurious `CALLS` edge.

For

```cpp
int target() { return 1; }
int shadow(int (*cb)()) {
    auto inner = [](int (*cb)()) { return cb(); };  // lambda's own cb
    return 0;                                        // shadow's cb never invoked
}
int main() { return shadow(target); }
```

the graph emitted `shadow -> target`, even though `shadow`'s own `cb` is never invoked (only the lambda's shadowing `cb` is). All other flow languages already suppress this via their `*_scope_bound_names`, but `_cpp_scope_bound_names` returned an empty set.

## Fix

`_cpp_scope_bound_names` now enumerates a C++ lambda's own parameter names (off its `abstract_function_declarator`'s `parameters` list) so `_scan_invoked_parameters` subtracts them before descending into the lambda body. Extracted `_cpp_declarator_param_names`, shared with `cpp_parameter_names`, so both read the same declarator shape.

This is a precision/soundness fix (removes an over-connection); it never affected the false-dead-code class — an extra edge only makes a callback look more reachable.

## Tests

- `test_cpp_nested_lambda_shadowing_suppresses_forbidden_edge` (RED -> GREEN): asserts no `shadow -> target` edge.
- Existing `test_cpp_function_pointer_callback_is_traced` still passes (direct `cb()` invocation is unaffected — subtraction only applies when descending into a nested closure).

Full suite: 4311 passed, 0 failed. ruff, ty, and the no-inline-comments hook all clean.
