### PR TITLE
feat(resolver): single-implementer interface dispatch

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -134,6 +134,7 @@ class CallProcessor:
         type_inference: TypeInferenceEngine,
         class_inheritance: dict[str, list[str]],
         type_aliases: dict[str, str] | None = None,
+        interface_implementers: dict[str, list[str]] | None = None,
     ) -> None:
         self.ingestor = ingestor
         self.repo_path = repo_path
@@ -145,6 +146,7 @@ class CallProcessor:
             type_inference=type_inference,
             class_inheritance=class_inheritance,
             type_aliases=type_aliases,
+            interface_implementers=interface_implementers,
         )
         # (H) Inter-procedural callable-parameter flow: ordered params per function and
         # (H) the per-call-site argument bindings, resolved to a fixpoint in finalize.

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -134,7 +134,7 @@ class CallProcessor:
         type_inference: TypeInferenceEngine,
         class_inheritance: dict[str, list[str]],
         type_aliases: dict[str, str] | None = None,
-        interface_implementers: dict[str, list[str]] | None = None,
+        interface_implementers: dict[str, set[str]] | None = None,
     ) -> None:
         self.ingestor = ingestor
         self.repo_path = repo_path

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -49,6 +49,8 @@ class CallResolver:
         "type_inference",
         "class_inheritance",
         "type_aliases",
+        "interface_implementers",
+        "_interface_impl_cache",
         "_simple_resolution_cache",
         "_wildcard_cache",
         "_protocol_impl_cache",
@@ -66,11 +68,19 @@ class CallResolver:
         type_inference: TypeInferenceEngine,
         class_inheritance: dict[str, list[str]],
         type_aliases: dict[str, str] | None = None,
+        interface_implementers: dict[str, list[str]] | None = None,
     ) -> None:
         self.function_registry = function_registry
         self.import_processor = import_processor
         self.type_inference = type_inference
         self.class_inheritance = class_inheritance
+        # (H) {interface_qn: [implementer_qns]} (shared ref, populated during
+        # (H) ingestion). Used to redirect an interface-typed call to the single
+        # (H) concrete implementer's method (call-graph accuracy; single-impl only).
+        self.interface_implementers = (
+            interface_implementers if interface_implementers is not None else {}
+        )
+        self._interface_impl_cache: dict[str, str] | None = None
         # (H) C++ typedef/using alias -> underlying bare type, consulted when a
         # (H) receiver type name is mapped to a class (empty for other languages).
         self.type_aliases = type_aliases if type_aliases is not None else {}
@@ -238,6 +248,21 @@ class CallResolver:
                 targets.add((self.function_registry[qn], qn))
         return targets
 
+    def _interface_impl_map(self) -> dict[str, str]:
+        # (H) Map an interface to its SOLE first-party implementer. A call typed to an
+        # (H) interface resolves to the interface's own method declaration; when the
+        # (H) interface has exactly one implementer the concrete method is the one that
+        # (H) runs, so redirect to it (call-graph accuracy). >1 implementer is
+        # (H) ambiguous -> not mapped -> the call stays on the interface method (no
+        # (H) precision risk, recall preserved).
+        if self._interface_impl_cache is None:
+            self._interface_impl_cache = {
+                interface_qn: next(iter(unique))
+                for interface_qn, implementers in self.interface_implementers.items()
+                if len(unique := set(implementers)) == 1
+            }
+        return self._interface_impl_cache
+
     def _redirect_protocol_method(
         self, result: tuple[str, str] | None
     ) -> tuple[str, str] | None:
@@ -246,7 +271,9 @@ class CallResolver:
         class_qn, sep, method_name = result[1].rpartition(cs.SEPARATOR_DOT)
         if not sep:
             return result
-        impl_qn = self._protocol_impl_map().get(class_qn)
+        impl_qn = self._protocol_impl_map().get(
+            class_qn
+        ) or self._interface_impl_map().get(class_qn)
         if impl_qn is None:
             return result
         redirected = f"{impl_qn}{cs.SEPARATOR_DOT}{method_name}"
@@ -1250,8 +1277,8 @@ class CallResolver:
     ) -> tuple[str, str] | None:
         java_engine = self.type_inference.java_type_inference
 
-        result = java_engine.resolve_java_method_call(
-            call_node, local_var_types, module_qn
+        result = self._redirect_protocol_method(
+            java_engine.resolve_java_method_call(call_node, local_var_types, module_qn)
         )
 
         if result:

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -68,7 +68,7 @@ class CallResolver:
         type_inference: TypeInferenceEngine,
         class_inheritance: dict[str, list[str]],
         type_aliases: dict[str, str] | None = None,
-        interface_implementers: dict[str, list[str]] | None = None,
+        interface_implementers: dict[str, set[str]] | None = None,
     ) -> None:
         self.function_registry = function_registry
         self.import_processor = import_processor
@@ -257,9 +257,9 @@ class CallResolver:
         # (H) precision risk, recall preserved).
         if self._interface_impl_cache is None:
             self._interface_impl_cache = {
-                interface_qn: next(iter(unique))
+                interface_qn: next(iter(implementers))
                 for interface_qn, implementers in self.interface_implementers.items()
-                if len(unique := set(implementers)) == 1
+                if len(implementers) == 1
             }
         return self._interface_impl_cache
 

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -104,7 +104,7 @@ class ClassIngestMixin:
     import_processor: ImportProcessor
     class_inheritance: dict[str, list[str]]
     class_field_types: dict[str, dict[str, str]]
-    interface_implementers: dict[str, list[str]]
+    interface_implementers: dict[str, set[str]]
     _deferred_forward_decls: list[_DeferredForwardDecl]
 
     def _namespace_qn(self, class_qn: str, module_qn: str) -> str:
@@ -426,15 +426,15 @@ class ClassIngestMixin:
                 if owner_type is not None
                 else cs.NodeLabel.CLASS
             )
+            trait_qn = self._resolve_to_qn(trait_name, owner_module_qn)
             self.ingestor.ensure_relationship_batch(
                 (owner_label, cs.KEY_QUALIFIED_NAME, class_qn),
                 cs.RelationshipType.IMPLEMENTS,
-                (
-                    cs.NodeLabel.INTERFACE,
-                    cs.KEY_QUALIFIED_NAME,
-                    self._resolve_to_qn(trait_name, owner_module_qn),
-                ),
+                (cs.NodeLabel.INTERFACE, cs.KEY_QUALIFIED_NAME, trait_qn),
             )
+            # (H) Record the implementer so a Rust trait call to the sole concrete
+            # (H) impl redirects, matching the class-declaration IMPLEMENTS path.
+            self.interface_implementers.setdefault(trait_qn, set()).add(class_qn)
 
         body_node = class_node.child_by_field_name("body")
 

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -104,6 +104,7 @@ class ClassIngestMixin:
     import_processor: ImportProcessor
     class_inheritance: dict[str, list[str]]
     class_field_types: dict[str, dict[str, str]]
+    interface_implementers: dict[str, list[str]]
     _deferred_forward_decls: list[_DeferredForwardDecl]
 
     def _namespace_qn(self, class_qn: str, module_qn: str) -> str:
@@ -373,6 +374,7 @@ class ClassIngestMixin:
             self.import_processor,
             self._resolve_to_qn,
             self.function_registry,
+            self.interface_implementers,
         )
         if language == cs.SupportedLanguage.CPP:
             # (H) Record this class's member-field types now (from the class body,

--- a/codebase_rag/parsers/class_ingest/relationships.py
+++ b/codebase_rag/parsers/class_ingest/relationships.py
@@ -29,7 +29,7 @@ def create_class_relationships(
     import_processor: ImportProcessor,
     resolve_to_qn: Callable[[str, str], str],
     function_registry: FunctionRegistryTrieProtocol,
-    interface_implementers: dict[str, list[str]] | None = None,
+    interface_implementers: dict[str, set[str]] | None = None,
 ) -> None:
     parent_classes = pe.extract_parent_classes(
         class_node, module_qn, import_processor, resolve_to_qn
@@ -69,7 +69,7 @@ def create_class_relationships(
             # (H) Record implementers so the resolver can dispatch an interface-typed
             # (H) call to the concrete method when the interface has exactly one impl.
             if interface_implementers is not None:
-                interface_implementers.setdefault(interface_qn, []).append(class_qn)
+                interface_implementers.setdefault(interface_qn, set()).add(class_qn)
 
 
 def get_node_type_for_inheritance(

--- a/codebase_rag/parsers/class_ingest/relationships.py
+++ b/codebase_rag/parsers/class_ingest/relationships.py
@@ -29,6 +29,7 @@ def create_class_relationships(
     import_processor: ImportProcessor,
     resolve_to_qn: Callable[[str, str], str],
     function_registry: FunctionRegistryTrieProtocol,
+    interface_implementers: dict[str, list[str]] | None = None,
 ) -> None:
     parent_classes = pe.extract_parent_classes(
         class_node, module_qn, import_processor, resolve_to_qn
@@ -65,6 +66,10 @@ def create_class_relationships(
             class_node, module_qn, resolve_to_qn
         ):
             create_implements_relationship(node_type, class_qn, interface_qn, ingestor)
+            # (H) Record implementers so the resolver can dispatch an interface-typed
+            # (H) call to the concrete method when the interface has exactly one impl.
+            if interface_implementers is not None:
+                interface_implementers.setdefault(interface_qn, []).append(class_qn)
 
 
 def get_node_type_for_inheritance(

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -56,7 +56,7 @@ class DefinitionProcessor(
         # (H) {interface_qn: [implementer_class_qns]} from IMPLEMENTS edges, so the
         # (H) resolver can redirect an interface-typed call `I.m` to the concrete
         # (H) `Impl.m` when I has exactly one first-party implementer (unambiguous).
-        self.interface_implementers: dict[str, list[str]] = {}
+        self.interface_implementers: dict[str, set[str]] = {}
         # (H) {class_qn: {field_name: bare_type_name}} for C++ member fields, so a
         # (H) member call `field_.method()` in a (possibly out-of-line, cross-file)
         # (H) method resolves via the field's declared type. Populated at class

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -53,6 +53,10 @@ class DefinitionProcessor(
         self.import_processor = import_processor
         self.module_qn_to_file_path = module_qn_to_file_path
         self.class_inheritance: dict[str, list[str]] = {}
+        # (H) {interface_qn: [implementer_class_qns]} from IMPLEMENTS edges, so the
+        # (H) resolver can redirect an interface-typed call `I.m` to the concrete
+        # (H) `Impl.m` when I has exactly one first-party implementer (unambiguous).
+        self.interface_implementers: dict[str, list[str]] = {}
         # (H) {class_qn: {field_name: bare_type_name}} for C++ member fields, so a
         # (H) member call `field_.method()` in a (possibly out-of-line, cross-file)
         # (H) method resolves via the field's declared type. Populated at class

--- a/codebase_rag/parsers/factory.py
+++ b/codebase_rag/parsers/factory.py
@@ -135,5 +135,6 @@ class ProcessorFactory:
                 type_inference=self.type_inference,
                 class_inheritance=self.definition_processor.class_inheritance,
                 type_aliases=self.definition_processor.type_aliases,
+                interface_implementers=self.definition_processor.interface_implementers,
             )
         return self._call_processor

--- a/codebase_rag/tests/test_interface_dispatch_single_impl.py
+++ b/codebase_rag/tests/test_interface_dispatch_single_impl.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+from evals.cgr_graph import _capture
+
+
+def _calls(tmp_path: Path, name: str, body: str) -> set[tuple[str, str]]:
+    (tmp_path / name).write_text(body, encoding="utf-8")
+    ingestor = _capture(tmp_path, "proj")
+    return {(str(f), str(t)) for _fl, f, rel, _tl, t in ingestor.rels if rel == "CALLS"}
+
+
+def test_single_implementer_interface_call_dispatches_to_concrete(
+    tmp_path: Path,
+) -> None:
+    # (H) `s.run()` on an interface-typed receiver resolves to the interface method;
+    # (H) since Svc has exactly ONE implementer, redirect to the concrete SvcImpl.run
+    # (H) (the method that actually runs).
+    calls = _calls(
+        tmp_path,
+        "Svc.java",
+        "interface Svc { int run(); }\n"
+        "class SvcImpl implements Svc { public int run() { return 1; } }\n"
+        "class Client { int use(Svc s) { return s.run(); } }\n",
+    )
+    assert ("proj.Svc.Client.use(Svc)", "proj.Svc.SvcImpl.run()") in calls
+    # (H) it must NOT stay on the interface method when a unique impl exists.
+    assert ("proj.Svc.Client.use(Svc)", "proj.Svc.Svc.run()") not in calls
+
+
+def test_multi_implementer_interface_call_stays_on_interface(tmp_path: Path) -> None:
+    # (H) Two implementers -> ambiguous -> no redirect; the call stays on the
+    # (H) interface method (no wrong-impl edge). Recall preserved.
+    calls = _calls(
+        tmp_path,
+        "Svc.java",
+        "interface Svc { int run(); }\n"
+        "class A implements Svc { public int run() { return 1; } }\n"
+        "class B implements Svc { public int run() { return 2; } }\n"
+        "class Client { int use(Svc s) { return s.run(); } }\n",
+    )
+    assert ("proj.Svc.Client.use(Svc)", "proj.Svc.Svc.run()") in calls
+    assert ("proj.Svc.Client.use(Svc)", "proj.Svc.A.run()") not in calls
+    assert ("proj.Svc.Client.use(Svc)", "proj.Svc.B.run()") not in calls

--- a/codebase_rag/tests/test_interface_dispatch_single_impl.py
+++ b/codebase_rag/tests/test_interface_dispatch_single_impl.py
@@ -41,3 +41,17 @@ def test_multi_implementer_interface_call_stays_on_interface(tmp_path: Path) -> 
     assert ("proj.Svc.Client.use(Svc)", "proj.Svc.Svc.run()") in calls
     assert ("proj.Svc.Client.use(Svc)", "proj.Svc.A.run()") not in calls
     assert ("proj.Svc.Client.use(Svc)", "proj.Svc.B.run()") not in calls
+
+
+def test_rust_single_trait_impl_dispatches_to_concrete(tmp_path: Path) -> None:
+    # (H) The Rust `impl Trait for Type` path must also feed the implementers map, so
+    # (H) a trait-typed call redirects to the sole concrete impl.
+    calls = _calls(
+        tmp_path,
+        "m.rs",
+        "trait Svc { fn run(&self) -> i32; }\n"
+        "struct SvcImpl;\n"
+        "impl Svc for SvcImpl { fn run(&self) -> i32 { 1 } }\n"
+        "fn use_it(s: &dyn Svc) -> i32 { s.run() }\n",
+    )
+    assert ("proj.m.use_it", "proj.m.SvcImpl.run") in calls


### PR DESCRIPTION
## What
When a call resolves to an interface's method (`I.m`) and that interface has **exactly one** first-party implementer `C`, redirect the edge to the concrete `C.m` — the method that actually runs. Generalizes the existing Python-Protocol redirect (`_redirect_protocol_method`) to `IMPLEMENTS` edges across languages.

- New `interface_implementers` map (interface_qn -> implementer qns), captured from IMPLEMENTS edges at ingestion and threaded DefinitionProcessor -> factory -> CallProcessor -> CallResolver.
- `_interface_impl_map` maps an interface to its SOLE implementer; >1 implementer is ambiguous -> not mapped -> the call stays on the interface method (no wrong-impl edge, recall preserved).
- Applied to both the general resolver and the Java resolution path.

## Why
The type-inference workstream's interface-dispatch item: a call typed to an interface should point at the concrete method. This is a call-graph **accuracy** improvement.

## Validation
- Precision-safe by construction (single implementer only; redirect only when the concrete method exists, else unchanged).
- spring-beans retrieval **exactly unchanged** (P 0.9916 / R 0.3643) — the metric is simple-name level so it can't distinguish `I.m` from `Impl.m`; this confirms zero regression while call-graph accuracy improves.
- Full suite 4316 passed.

RED->GREEN: test_interface_dispatch_single_impl.py (single-impl dispatches to concrete; multi-impl stays on interface).