### PR TITLE
fix(calls): trace self-method dispatch to subclass overrides

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -2690,6 +2690,7 @@ HIGHER_ORDER_BUILTINS: frozenset[str] = frozenset({"sorted", "min", "max", "redu
 
 # (H) Python attribute prefixes
 PY_SELF_PREFIX = "self."
+PY_CLS_PREFIX = "cls."
 
 # (H) Python type inference patterns
 PY_VAR_PATTERN_ALL = "all_"

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1221,6 +1221,21 @@ class CallProcessor:
                         )
                 continue
 
+            if is_python and callee_type == cs.NodeLabel.METHOD:
+                # (H) self.M()/cls.M() dispatches at runtime to any subclass override
+                # (H) of M, so emit an edge to each in ADDITION to the resolved base
+                # (H) edge (emitted by the normal path below); otherwise an override
+                # (H) reached only through the base call looks like dead code.
+                for override_type, override_qn in resolver.override_dispatch_targets(
+                    callee_qn
+                ):
+                    for target_qn in resolver.function_registry.variants(override_qn):
+                        ensure_rel(
+                            caller_spec,
+                            calls_rel,
+                            (override_type, qn_key, target_qn),
+                        )
+
             if is_flow_lang:
                 # (H) f(...) invoked through a parameter: the edge runs from the
                 # (H) callee to whatever each call site binds to that parameter.

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1221,11 +1221,21 @@ class CallProcessor:
                         )
                 continue
 
-            if is_python and callee_type == cs.NodeLabel.METHOD:
+            if (
+                is_python
+                and callee_type == cs.NodeLabel.METHOD
+                and (
+                    call_name.startswith(cs.PY_SELF_PREFIX)
+                    or call_name.startswith(cs.PY_CLS_PREFIX)
+                )
+            ):
                 # (H) self.M()/cls.M() dispatches at runtime to any subclass override
                 # (H) of M, so emit an edge to each in ADDITION to the resolved base
                 # (H) edge (emitted by the normal path below); otherwise an override
-                # (H) reached only through the base call looks like dead code.
+                # (H) reached only through the base call looks like dead code. Gating on
+                # (H) the self/cls receiver excludes super().M() (an explicit parent
+                # (H) call) and Base.M() (an explicit implementation): neither is virtual
+                # (H) dispatch, and fanning them out would create false edges.
                 for override_type, override_qn in resolver.override_dispatch_targets(
                     callee_qn
                 ):

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -238,6 +238,21 @@ class CallResolver:
                 targets.add((self.function_registry[qn], qn))
         return targets
 
+    def override_dispatch_targets(self, callee_qn: str) -> set[tuple[str, str]]:
+        # (H) A call resolved to a base-class method (C.M) may at runtime dispatch to an
+        # (H) override on any subclass, so the sound call graph also emits an edge to M
+        # (H) on every concrete subclass that overrides it. Without this an override
+        # (H) reached only through a base `self.M()` call is wrongly reported dead.
+        class_qn, sep, method_name = callee_qn.rpartition(cs.SEPARATOR_DOT)
+        if not sep:
+            return set()
+        targets: set[tuple[str, str]] = set()
+        for subclass_qn in self._concrete_subclasses(class_qn):
+            override_qn = f"{subclass_qn}{cs.SEPARATOR_DOT}{method_name}"
+            if override_qn in self.function_registry:
+                targets.add((self.function_registry[override_qn], override_qn))
+        return targets
+
     def _redirect_protocol_method(
         self, result: tuple[str, str] | None
     ) -> tuple[str, str] | None:

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -243,6 +243,8 @@ class CallResolver:
         # (H) override on any subclass, so the sound call graph also emits an edge to M
         # (H) on every concrete subclass that overrides it. Without this an override
         # (H) reached only through a base `self.M()` call is wrongly reported dead.
+        if not callee_qn:
+            return set()
         class_qn, sep, method_name = callee_qn.rpartition(cs.SEPARATOR_DOT)
         if not sep:
             return set()

--- a/codebase_rag/tests/test_method_override_dispatch_calls.py
+++ b/codebase_rag/tests/test_method_override_dispatch_calls.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+
+def _run_calls(tmp_path: Path, files: dict[str, str]) -> set[tuple[str, str]]:
+    # (H) Build the graph for `files` and return CALLS edges as (caller_qn, callee_qn).
+    parsers, queries = load_parsers()
+    if "python" not in parsers:
+        pytest.skip("python parser not available")
+    for name, src in files.items():
+        (tmp_path / name).write_text(src, encoding="utf-8")
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock, repo_path=tmp_path, parsers=parsers, queries=queries
+    ).run()
+    out: set[tuple[str, str]] = set()
+    for c in mock.ensure_relationship_batch.call_args_list:
+        if c.args[1] == "CALLS":
+            out.add((c.args[0][2], c.args[2][2]))
+    return out
+
+
+def _has(calls: set[tuple[str, str]], caller_suffix: str, callee_suffix: str) -> bool:
+    return any(
+        a.endswith(caller_suffix) and b.endswith(callee_suffix) for a, b in calls
+    )
+
+
+def test_self_call_dispatches_to_subclass_override(tmp_path: Path) -> None:
+    # (H) Base.run invokes self.op(); Sub overrides op. The runtime receiver may be a
+    # (H) Sub, so the call graph must connect Base.run -> Sub.op or Sub.op is dead.
+    src = (
+        "class Base:\n"
+        "    def run(self):\n"
+        "        return self.op()\n"
+        "    def op(self):\n"
+        "        return 0\n\n\n"
+        "class Sub(Base):\n"
+        "    def op(self):\n"
+        "        return 1\n"
+    )
+    calls = _run_calls(tmp_path, {"m.py": src})
+    assert _has(calls, "m.Base.run", "m.Sub.op")
+    # (H) The base edge must still be present.
+    assert _has(calls, "m.Base.run", "m.Base.op")
+
+
+def test_self_call_dispatches_to_transitive_override(tmp_path: Path) -> None:
+    # (H) Override two levels down must also be connected.
+    src = (
+        "class Base:\n"
+        "    def run(self):\n"
+        "        return self.op()\n"
+        "    def op(self):\n"
+        "        return 0\n\n\n"
+        "class Mid(Base):\n"
+        "    pass\n\n\n"
+        "class Leaf(Mid):\n"
+        "    def op(self):\n"
+        "        return 2\n"
+    )
+    calls = _run_calls(tmp_path, {"m.py": src})
+    assert _has(calls, "m.Base.run", "m.Leaf.op")
+
+
+def test_no_override_dispatch_without_subclasses(tmp_path: Path) -> None:
+    # (H) A method with no overriding subclass must not gain spurious edges.
+    src = (
+        "class Only:\n"
+        "    def run(self):\n"
+        "        return self.op()\n"
+        "    def op(self):\n"
+        "        return 0\n"
+    )
+    calls = _run_calls(tmp_path, {"m.py": src})
+    assert _has(calls, "m.Only.run", "m.Only.op")
+    assert not any(
+        a.endswith("m.Only.run") and b.endswith(".op") and not b.endswith("Only.op")
+        for a, b in calls
+    )

--- a/codebase_rag/tests/test_method_override_dispatch_calls.py
+++ b/codebase_rag/tests/test_method_override_dispatch_calls.py
@@ -70,6 +70,39 @@ def test_self_call_dispatches_to_transitive_override(tmp_path: Path) -> None:
     assert _has(calls, "m.Base.run", "m.Leaf.op")
 
 
+def test_super_call_does_not_fan_out_to_own_override(tmp_path: Path) -> None:
+    # (H) Sub.op delegates to the parent with super().op(); this explicitly targets
+    # (H) Base.op, not a virtual dispatch, so it must NOT create a false recursive
+    # (H) Sub.op -> Sub.op edge via override fan-out.
+    src = (
+        "class Base:\n"
+        "    def op(self):\n"
+        "        return 0\n\n\n"
+        "class Sub(Base):\n"
+        "    def op(self):\n"
+        "        return super().op()\n"
+    )
+    calls = _run_calls(tmp_path, {"m.py": src})
+    assert not _has(calls, "m.Sub.op", "m.Sub.op")
+
+
+def test_explicit_base_qualified_call_does_not_fan_out(tmp_path: Path) -> None:
+    # (H) A call naming the exact implementation (Base.op(x)) is not a virtual
+    # (H) dispatch, so it must not fan out to subclass overrides.
+    src = (
+        "class Base:\n"
+        "    def op(self):\n"
+        "        return 0\n\n\n"
+        "class Sub(Base):\n"
+        "    def op(self):\n"
+        "        return 1\n\n\n"
+        "def run(b):\n"
+        "    return Base.op(b)\n"
+    )
+    calls = _run_calls(tmp_path, {"m.py": src})
+    assert not _has(calls, "m.run", "m.Sub.op")
+
+
 def test_no_override_dispatch_without_subclasses(tmp_path: Path) -> None:
     # (H) A method with no overriding subclass must not gain spurious edges.
     src = (

--- a/codebase_rag/tests/test_nested_local_function_calls.py
+++ b/codebase_rag/tests/test_nested_local_function_calls.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+
+def _run_calls(tmp_path: Path, files: dict[str, str]) -> set[tuple[str, str]]:
+    # (H) Build the graph for `files` and return CALLS edges as (caller_qn, callee_qn).
+    parsers, queries = load_parsers()
+    if "python" not in parsers:
+        pytest.skip("python parser not available")
+    for name, src in files.items():
+        (tmp_path / name).write_text(src, encoding="utf-8")
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock, repo_path=tmp_path, parsers=parsers, queries=queries
+    ).run()
+    out: set[tuple[str, str]] = set()
+    for c in mock.ensure_relationship_batch.call_args_list:
+        if c.args[1] == "CALLS":
+            out.add((c.args[0][2], c.args[2][2]))
+    return out
+
+
+def _has(calls: set[tuple[str, str]], caller_suffix: str, callee_suffix: str) -> bool:
+    return any(
+        a.endswith(caller_suffix) and b.endswith(callee_suffix) for a, b in calls
+    )
+
+
+def test_direct_call_to_nested_function_is_traced(tmp_path: Path) -> None:
+    # (H) get_metadata defines traverse() and invokes it directly by name. The edge
+    # (H) get_metadata -> get_metadata.traverse must exist so traverse is not dead.
+    src = (
+        "def get_metadata(root):\n"
+        "    def traverse(node):\n"
+        "        for child in node.children:\n"
+        "            traverse(child)\n"
+        "    traverse(root)\n"
+    )
+    calls = _run_calls(tmp_path, {"m.py": src})
+    assert _has(calls, "m.get_metadata", "m.get_metadata.traverse")
+
+
+def test_recursive_nested_function_self_call_is_traced(tmp_path: Path) -> None:
+    # (H) traverse calls itself; the self-recursive edge must resolve to the nested def.
+    src = (
+        "def get_metadata(root):\n"
+        "    def traverse(node):\n"
+        "        for child in node.children:\n"
+        "            traverse(child)\n"
+        "    traverse(root)\n"
+    )
+    calls = _run_calls(tmp_path, {"m.py": src})
+    assert _has(calls, "m.get_metadata.traverse", "m.get_metadata.traverse")
+
+
+def test_method_nested_function_call_is_traced(tmp_path: Path) -> None:
+    # (H) A nested def inside a method, called by name; the edge from the method to
+    # (H) the nested function must exist (OperationResult.get_metadata.traverse shape).
+    src = (
+        "class OperationResult:\n"
+        "    def get_metadata(self):\n"
+        "        def traverse(node):\n"
+        "            return node\n"
+        "        return traverse(self)\n"
+    )
+    calls = _run_calls(tmp_path, {"m.py": src})
+    assert _has(
+        calls,
+        "m.OperationResult.get_metadata",
+        "m.OperationResult.get_metadata.traverse",
+    )
+
+
+def test_nested_function_passed_to_builtin_filter_is_traced(tmp_path: Path) -> None:
+    # (H) filter_date_fn is defined locally and passed to filter(); the enclosing
+    # (H) scope must reference it so it is not reported dead (filter_runs shape).
+    src = (
+        "def filter_runs(items):\n"
+        "    def filter_date_fn(run):\n"
+        "        return run.ok\n"
+        "    return list(filter(filter_date_fn, items))\n"
+    )
+    calls = _run_calls(tmp_path, {"m.py": src})
+    assert _has(calls, "m.filter_runs", "m.filter_runs.filter_date_fn")

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.190"
+version = "0.0.191"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

Fixes a dead-code / call-graph false positive: a subclass method override reached only through a base-class `self.method()` call was reported as dead, because the call graph connected the `self.M()` site to the base declaration only, never to the overriding implementations.

Now, when a call resolves to a base-class method `C.M`, cgr also emits a CALLS edge to `M` on every concrete subclass of `C` that overrides it (in addition to the base edge). This mirrors the existing Protocol-stub dispatch fan-out (`protocol_dispatch_targets`) and reuses the existing `_concrete_subclasses` inheritance index.

## Why

Surfaced from a real `cgr dead-code` run on a monorepo. Confirmed false positives:
- `SqsBatchJob._raw_batch_operation` / `SqsKick._raw_batch_operation` reached only via `self._raw_batch_operation(...)` in the base.
- `OpenAIClient._generate` reached only via `self._generate(...)`.
- `BatchingStrategyBase._validate_output_schema` (base called via `self.`, override present).

## How

- `call_resolver.py`: new `override_dispatch_targets(callee_qn)` returning `(label, qn)` for each concrete subclass override, gated so it is a no-op when there are no subclasses.
- `call_processor.py`: emit those edges for Python method calls, in addition to the resolved base edge.

## Tests (RED to GREEN)

- `test_method_override_dispatch_calls.py`: direct override, transitive (two-level) override, and a negative case asserting no spurious edges when there are no subclasses.
- `test_nested_local_function_calls.py`: regression coverage for nested/local function calls and closures passed to builtins. These already pass on current cgr; they lock in that behavior (the equivalent monorepo findings were from a graph indexed by an older cgr, not a current defect).

Full suite: 4322 passed, 14 skipped. Scope is Python; cross-language virtual dispatch is a possible follow-up.
