### PR TITLE
fix(calls): resolve bare nested-function calls against the caller's enclosing scope

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1092,7 +1092,7 @@ class CallProcessor:
                 )
             else:
                 callee_info = resolve_func(
-                    call_name, module_qn, local_var_types, class_context
+                    call_name, module_qn, local_var_types, class_context, caller_qn
                 )
             if not callee_info and resolve_builtin is not None:
                 callee_info = resolve_builtin(call_name)

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1109,7 +1109,7 @@ class CallProcessor:
                         )
                     if (rhs := alias_map.get(call_name)) is not None:
                         callee_info = resolve_func(
-                            rhs, module_qn, local_var_types, class_context
+                            rhs, module_qn, local_var_types, class_context, caller_qn
                         )
                 if callee_info is None and is_flow_lang:
                     # (H) `x = factory(...); x(cb)`: x holds a closure returned by a
@@ -1125,6 +1125,7 @@ class CallProcessor:
                             self._flow_scope_boundaries(
                                 queries[language][cs.QUERY_CONFIG]
                             ),
+                            caller_qn,
                         )
                     if (factory_qn := factory_aliases.get(call_name)) is not None:
                         self._record_factory_call(
@@ -1156,6 +1157,7 @@ class CallProcessor:
                     class_context,
                     resolve_func,
                     ensure_rel,
+                    caller_qn,
                 )
 
             if not callee_info:
@@ -1174,6 +1176,7 @@ class CallProcessor:
                         class_context,
                         resolve_func,
                         ensure_rel,
+                        caller_qn,
                     )
                 continue
 
@@ -1196,6 +1199,7 @@ class CallProcessor:
                     class_context,
                     resolve_func,
                     ensure_rel,
+                    caller_qn,
                 )
 
             if is_flow_lang and not callee_is_builtin:
@@ -1260,6 +1264,7 @@ class CallProcessor:
                     class_context,
                     resolve_func,
                     ensure_rel,
+                    caller_qn,
                 )
 
             if callee_type == class_label:
@@ -1557,7 +1562,7 @@ class CallProcessor:
                         )
                     elif (
                         resolved := resolve_func(
-                            name, module_qn, local_var_types, class_context
+                            name, module_qn, local_var_types, class_context, caller_qn
                         )
                     ) is not None and resolved[0] in _CALLABLE_NODE_LABELS:
                         self._returned_callables.setdefault(caller_qn, set()).add(
@@ -1572,6 +1577,7 @@ class CallProcessor:
         local_var_types: dict[str, str] | None,
         class_context: str | None,
         boundary_types: frozenset[str],
+        caller_qn: str | None = None,
     ) -> dict[str, str]:
         # (H) Map a local `x` to the function `factory` in `x = factory(...)`, so a
         # (H) later `x(cb)` can be traced through factory's returned closure. Handles
@@ -1587,7 +1593,7 @@ class CallProcessor:
             for var, fn_name in self._factory_bindings(node):
                 if (
                     resolved := resolve_func(
-                        fn_name, module_qn, local_var_types, class_context
+                        fn_name, module_qn, local_var_types, class_context, caller_qn
                     )
                 ) is not None:
                     aliases.setdefault(var, resolved[1])
@@ -1656,13 +1662,14 @@ class CallProcessor:
         module_qn: str,
         local_var_types: dict[str, str] | None,
         class_context: str | None,
+        caller_qn: str | None = None,
     ) -> str | None:
         if node.type not in (cs.TS_PY_IDENTIFIER, cs.TS_PY_ATTRIBUTE):
             return None
         if not (text := safe_decode_text(node)):
             return None
         resolved = self._resolver.resolve_function_call(
-            text, module_qn, local_var_types, class_context
+            text, module_qn, local_var_types, class_context, caller_qn
         )
         if resolved is None or resolved[0] not in _CALLABLE_NODE_LABELS:
             return None
@@ -1679,7 +1686,9 @@ class CallProcessor:
     ) -> None:
         positional, keyword = self._parse_call_arguments(call_node)
         pos_qns = tuple(
-            self._resolve_callback_qn(n, module_qn, local_var_types, class_context)
+            self._resolve_callback_qn(
+                n, module_qn, local_var_types, class_context, scope_qn
+            )
             or ""
             for n in positional
         )
@@ -1688,7 +1697,7 @@ class CallProcessor:
             for name, value in keyword.items()
             if (
                 qn := self._resolve_callback_qn(
-                    value, module_qn, local_var_types, class_context
+                    value, module_qn, local_var_types, class_context, scope_qn
                 )
             )
         )
@@ -1728,12 +1737,13 @@ class CallProcessor:
         class_context: str | None,
         resolve_func,
         ensure_rel,
+        caller_qn: str | None = None,
     ) -> None:
         if not (arg_text := safe_decode_text(arg_node)):
             return
         if not (
             resolved := resolve_func(
-                arg_text, module_qn, local_var_types, class_context
+                arg_text, module_qn, local_var_types, class_context, caller_qn
             )
         ):
             return
@@ -1762,6 +1772,7 @@ class CallProcessor:
         class_context: str | None,
         resolve_func,
         ensure_rel,
+        caller_qn: str | None = None,
     ) -> None:
         if not (params := self._resolver.function_registry.callable_params(callee_qn)):
             return
@@ -1780,6 +1791,7 @@ class CallProcessor:
                     class_context,
                     resolve_func,
                     ensure_rel,
+                    caller_qn,
                 )
 
     def _collect_callable_flow(
@@ -1820,7 +1832,7 @@ class CallProcessor:
                 )
                 continue
             resolved = self._resolver.resolve_function_call(
-                arg_text, module_qn, local_var_types, class_context
+                arg_text, module_qn, local_var_types, class_context, caller_qn
             )
             if resolved is not None and resolved[0] in callable_labels:
                 self._flow_args.append(
@@ -1968,6 +1980,7 @@ class CallProcessor:
         class_context: str | None,
         resolve_func,
         ensure_rel,
+        caller_qn: str | None = None,
     ) -> None:
         positional, keyword = self._parse_call_arguments(call_node)
         for arg_node in (*positional, *keyword.values()):
@@ -1979,6 +1992,7 @@ class CallProcessor:
                 class_context,
                 resolve_func,
                 ensure_rel,
+                caller_qn,
             )
 
     def _ingest_argument_function_references(
@@ -1990,6 +2004,7 @@ class CallProcessor:
         class_context: str | None,
         resolve_func,
         ensure_rel,
+        caller_qn: str | None = None,
     ) -> None:
         # (H) For a call whose callee is not first-party, a function/method passed as
         # (H) an argument is handed off to be invoked by that external callee; emit a
@@ -2004,6 +2019,7 @@ class CallProcessor:
                 class_context,
                 resolve_func,
                 ensure_rel,
+                caller_qn,
             )
 
     def _build_local_alias_map(
@@ -2176,7 +2192,11 @@ class CallProcessor:
                     )
                     if not is_call_target and (
                         callee_info := resolve_func(
-                            attr_text, module_qn, local_var_types, class_context
+                            attr_text,
+                            module_qn,
+                            local_var_types,
+                            class_context,
+                            caller_qn,
                         )
                     ):
                         callee_qn = callee_info[1]

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -187,12 +187,37 @@ class CallResolver:
         module_qn: str,
         local_var_types: dict[str, str] | None = None,
         class_context: str | None = None,
+        caller_qn: str | None = None,
     ) -> tuple[str, str] | None:
         return self._redirect_protocol_method(
             self._resolve_function_call(
-                call_name, module_qn, local_var_types, class_context
+                call_name, module_qn, local_var_types, class_context, caller_qn
             )
         )
+
+    def _resolve_enclosing_scope(
+        self, call_name: str, caller_qn: str | None, module_qn: str
+    ) -> tuple[str, str] | None:
+        # (H) Python LEGB: a bare name defined in the caller's own body or an enclosing
+        # (H) FUNCTION scope (a nested def) shadows module-level and same-named nested
+        # (H) defs in sibling scopes. The module-keyed trie fallback cannot tell two
+        # (H) sibling `traverse` defs apart, so resolve against the caller's scope chain
+        # (H) first. Walk up only through function/method scopes (each ancestor must be
+        # (H) in the registry); a class or the module boundary stops the walk, because
+        # (H) class scope is NOT part of a method's name-lookup chain in Python.
+        if not caller_qn or cs.SEPARATOR_DOT in call_name:
+            return None
+        scope = caller_qn
+        while True:
+            candidate = f"{scope}{cs.SEPARATOR_DOT}{call_name}"
+            if candidate in self.function_registry:
+                return self.function_registry[candidate], candidate
+            if cs.SEPARATOR_DOT not in scope:
+                return None
+            parent = scope.rsplit(cs.SEPARATOR_DOT, 1)[0]
+            if parent == module_qn or parent not in self.function_registry:
+                return None
+            scope = parent
 
     def _protocol_impl_map(self) -> dict[str, str]:
         # (H) A Protocol stub never runs; the concrete implementer does. Map each
@@ -304,7 +329,14 @@ class CallResolver:
         module_qn: str,
         local_var_types: dict[str, str] | None = None,
         class_context: str | None = None,
+        caller_qn: str | None = None,
     ) -> tuple[str, str] | None:
+        # (H) Enclosing-scope (nested def) lookup is caller-specific, so it must run
+        # (H) before the module-keyed cache/trie, which would otherwise return a sibling
+        # (H) scope's same-named nested function.
+        if result := self._resolve_enclosing_scope(call_name, caller_qn, module_qn):
+            return result
+
         use_cache = not local_var_types
         if use_cache:
             cache_key = (call_name, module_qn)

--- a/codebase_rag/tests/test_nested_local_function_calls.py
+++ b/codebase_rag/tests/test_nested_local_function_calls.py
@@ -89,3 +89,44 @@ def test_nested_function_passed_to_builtin_filter_is_traced(tmp_path: Path) -> N
     )
     calls = _run_calls(tmp_path, {"m.py": src})
     assert _has(calls, "m.filter_runs", "m.filter_runs.filter_date_fn")
+
+
+def test_sibling_methods_resolve_own_nested_function(tmp_path: Path) -> None:
+    # (H) Two methods each define a nested traverse and call it. Each call must bind to
+    # (H) ITS OWN enclosing scope's nested function, not the first same-named sibling,
+    # (H) or the other method's traverse gets no inbound edge (OperationResult shape:
+    # (H) get_llm_results.traverse and get_metadata.traverse both exist).
+    src = (
+        "class Op:\n"
+        "    def get_a(self):\n"
+        "        def traverse(node):\n"
+        "            return node\n"
+        "        return traverse(self)\n"
+        "    def get_b(self):\n"
+        "        def traverse(node):\n"
+        "            return node\n"
+        "        return traverse(self)\n"
+    )
+    calls = _run_calls(tmp_path, {"m.py": src})
+    assert _has(calls, "m.Op.get_a", "m.Op.get_a.traverse")
+    assert _has(calls, "m.Op.get_b", "m.Op.get_b.traverse")
+
+
+def test_sibling_module_functions_resolve_own_nested_function(
+    tmp_path: Path,
+) -> None:
+    # (H) Two module-level functions each define a nested helper of the same name; each
+    # (H) call must bind to its own (run_determination/run_determinations._get_param).
+    src = (
+        "def run_one(kwargs):\n"
+        "    def _get_param(name):\n"
+        "        return kwargs[name]\n"
+        "    return _get_param('a')\n\n\n"
+        "def run_many(kwargs):\n"
+        "    def _get_param(name):\n"
+        "        return kwargs[name]\n"
+        "    return _get_param('b')\n"
+    )
+    calls = _run_calls(tmp_path, {"m.py": src})
+    assert _has(calls, "m.run_one", "m.run_one._get_param")
+    assert _has(calls, "m.run_many", "m.run_many._get_param")

--- a/codebase_rag/tests/test_nested_local_function_calls.py
+++ b/codebase_rag/tests/test_nested_local_function_calls.py
@@ -130,3 +130,25 @@ def test_sibling_module_functions_resolve_own_nested_function(
     calls = _run_calls(tmp_path, {"m.py": src})
     assert _has(calls, "m.run_one", "m.run_one._get_param")
     assert _has(calls, "m.run_many", "m.run_many._get_param")
+
+
+def test_sibling_callback_args_resolve_own_nested_function(tmp_path: Path) -> None:
+    # (H) Two sibling functions each define a nested worker and pass it as a callback to
+    # (H) a consumer that invokes it. Each callback arg must resolve to ITS OWN nested
+    # (H) worker, so both workers are reached (create_context-as-kwarg shape). Without
+    # (H) threading the caller scope into callback resolution, both bind to the first.
+    src = (
+        "def consume(cb):\n"
+        "    return cb()\n\n\n"
+        "def outer_a():\n"
+        "    def worker():\n"
+        "        return 1\n"
+        "    return consume(worker)\n\n\n"
+        "def outer_b():\n"
+        "    def worker():\n"
+        "        return 2\n"
+        "    return consume(worker)\n"
+    )
+    calls = _run_calls(tmp_path, {"m.py": src})
+    assert _has(calls, "m.consume", "m.outer_a.worker")
+    assert _has(calls, "m.consume", "m.outer_b.worker")

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.193"
+version = "0.0.194"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

Fixes a dead-code false positive from wrong resolution of bare calls to nested (local) functions. When two sibling scopes each define a nested function of the same name, both calls resolved to the first one alphabetically, orphaning the other so it was reported dead.

## Why

The bare-name resolver had no notion of the caller's enclosing scope. `_try_resolve_via_trie` matched by name suffix across the whole module and broke ties by qualified-name string, so for

```python
class Op:
    def get_a(self):
        def traverse(node): ...
        return traverse(self)
    def get_b(self):
        def traverse(node): ...
        return traverse(self)
```

both `traverse(...)` calls resolved to `Op.get_a.traverse`; `Op.get_b.traverse` got no inbound edge and was flagged dead. Real instances: `OperationResult.get_metadata.traverse` (alongside `get_llm_results.traverse`), and the `run_determination`/`run_determinations` pair each with a nested `_get_param`.

## How

- Thread the caller's qualified name into `resolve_function_call` / `_resolve_function_call`.
- Resolve a bare name against the caller's scope chain FIRST (before the module-keyed cache/trie): try `{caller_qn}.{name}`, then walk up through enclosing FUNCTION scopes only. Each ancestor must be in the function registry, so a class or the module boundary stops the walk — matching Python's LEGB rule, where class scope is not part of a method's name lookup. This also fixes recursive calls inside the correct nested function.

## Tests (RED to GREEN)

- `test_sibling_methods_resolve_own_nested_function` and `test_sibling_module_functions_resolve_own_nested_function` in `test_nested_local_function_calls.py`; the four existing nested-call tests still pass.

Full suite: 4333 passed, 14 skipped.
