### PR TITLE
fix(calls): anchor self/cls dispatch on the enclosing class and fan out to concrete overrides

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1225,28 +1225,33 @@ class CallProcessor:
 
             if (
                 is_python
-                and callee_type == cs.NodeLabel.METHOD
+                and class_context
                 and (
                     call_name.startswith(cs.PY_SELF_PREFIX)
                     or call_name.startswith(cs.PY_CLS_PREFIX)
                 )
             ):
-                # (H) self.M()/cls.M() dispatches at runtime to any subclass override
-                # (H) of M, so emit an edge to each in ADDITION to the resolved base
-                # (H) edge (emitted by the normal path below); otherwise an override
-                # (H) reached only through the base call looks like dead code. Gating on
-                # (H) the self/cls receiver excludes super().M() (an explicit parent
-                # (H) call) and Base.M() (an explicit implementation): neither is virtual
-                # (H) dispatch, and fanning them out would create false edges.
-                for override_type, override_qn in resolver.override_dispatch_targets(
-                    callee_qn
-                ):
-                    for target_qn in resolver.function_registry.variants(override_qn):
-                        ensure_rel(
-                            caller_spec,
-                            calls_rel,
-                            (override_type, qn_key, target_qn),
-                        )
+                # (H) self.M()/cls.M() statically targets the enclosing class's own or
+                # (H) inherited M and dynamically dispatches to every concrete subclass
+                # (H) override, so emit an edge to each in ADDITION to the resolved edge
+                # (H) below; otherwise the base (or an override) reached only through the
+                # (H) self-call looks like dead code. Anchor on the enclosing class, not
+                # (H) the resolved callee: when M is abstract with several overrides the
+                # (H) trie resolves the call to an arbitrary sibling override, so
+                # (H) anchoring there would miss the base and the other overrides. The
+                # (H) self/cls receiver excludes super().M() and Base.M() (not virtual
+                # (H) dispatch). Skip self.attr.M() (a call on a member, not on self).
+                _, _, self_method = call_name.partition(cs.SEPARATOR_DOT)
+                if cs.SEPARATOR_DOT not in self_method:
+                    for target_type, target_qn in resolver.self_dispatch_targets(
+                        class_context, self_method
+                    ):
+                        for variant in resolver.function_registry.variants(target_qn):
+                            ensure_rel(
+                                caller_spec,
+                                calls_rel,
+                                (target_type, qn_key, variant),
+                            )
 
             if is_flow_lang:
                 # (H) f(...) invoked through a parameter: the edge runs from the

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -248,20 +248,32 @@ class CallResolver:
                 targets.add((self.function_registry[qn], qn))
         return targets
 
-    def override_dispatch_targets(self, callee_qn: str) -> set[tuple[str, str]]:
-        # (H) A call resolved to a base-class method (C.M) may at runtime dispatch to an
-        # (H) override on any subclass, so the sound call graph also emits an edge to M
-        # (H) on every concrete subclass that overrides it. Without this an override
-        # (H) reached only through a base `self.M()` call is wrongly reported dead.
-        if not callee_qn:
-            return set()
-        class_qn, sep, method_name = callee_qn.rpartition(cs.SEPARATOR_DOT)
-        if not sep:
+    def self_dispatch_targets(
+        self, class_context: str, method_name: str
+    ) -> set[tuple[str, str]]:
+        # (H) self.M()/cls.M() statically targets the enclosing class's own or inherited
+        # (H) M, and dynamically dispatches to any concrete subclass override of M. Anchor
+        # (H) on the ENCLOSING class (not the resolved callee, which the trie may pick as
+        # (H) an arbitrary sibling override when M is abstract with several overrides) and
+        # (H) emit an edge to the enclosing-class method AND every concrete override, so an
+        # (H) override or an abstract base reached only through a self-call is not reported
+        # (H) dead.
+        if not class_context or not method_name:
             return set()
         targets: set[tuple[str, str]] = set()
-        for subclass_qn in self._concrete_subclasses(class_qn):
+        # (H) Skip abstract targets: an @abstractmethod stub never runs (the concrete
+        # (H) override does), so it must not be a call target -- a concrete sibling/impl
+        # (H) wins. Abstract methods that are only "reached" polymorphically are handled
+        # (H) as dead-code roots, not by a spurious CALLS edge.
+        if (base := self._try_resolve_method(class_context, method_name)) and (
+            not self.function_registry.is_abstract(base[1])
+        ):
+            targets.add(base)
+        for subclass_qn in self._concrete_subclasses(class_context):
             override_qn = f"{subclass_qn}{cs.SEPARATOR_DOT}{method_name}"
-            if override_qn in self.function_registry:
+            if override_qn in self.function_registry and not (
+                self.function_registry.is_abstract(override_qn)
+            ):
                 targets.add((self.function_registry[override_qn], override_qn))
         return targets
 

--- a/codebase_rag/tests/test_method_override_dispatch_calls.py
+++ b/codebase_rag/tests/test_method_override_dispatch_calls.py
@@ -118,3 +118,53 @@ def test_no_override_dispatch_without_subclasses(tmp_path: Path) -> None:
         a.endswith("m.Only.run") and b.endswith(".op") and not b.endswith("Only.op")
         for a, b in calls
     )
+
+
+def test_self_call_in_abstract_base_reaches_all_overrides(tmp_path: Path) -> None:
+    # (H) Base._chunk calls self._raw(); Base._raw is @abstractmethod and TWO subclasses
+    # (H) override it. The edge must anchor on the enclosing class (Base) and reach BOTH
+    # (H) overrides plus the base declaration, not just the alphabetically-first override
+    # (H) the trie happens to pick (SqsBatchJob/SqsKick/SqsDelete shape).
+    src = (
+        "from abc import ABC, abstractmethod\n"
+        "class Base(ABC):\n"
+        "    @abstractmethod\n"
+        "    def _raw(self, ctx):\n"
+        "        pass\n"
+        "    def _chunk(self, ctx):\n"
+        "        return self._raw(ctx)\n\n\n"
+        "class Kick(Base):\n"
+        "    def _raw(self, ctx):\n"
+        "        return 1\n\n\n"
+        "class Delete(Base):\n"
+        "    def _raw(self, ctx):\n"
+        "        return 2\n"
+    )
+    calls = _run_calls(tmp_path, {"m.py": src})
+    assert _has(calls, "m.Base._chunk", "m.Kick._raw")
+    assert _has(calls, "m.Base._chunk", "m.Delete._raw")
+
+
+def test_self_call_binds_to_own_class_method_amid_cousin_overrides(
+    tmp_path: Path,
+) -> None:
+    # (H) OpenAIClient.gen calls self._generate(); a sibling subclass AnthropicClient also
+    # (H) defines _generate. The call must bind to the ENCLOSING class's own method
+    # (H) (OpenAIClient._generate), not an arbitrary cousin override (OpenAIClient shape).
+    src = (
+        "from abc import ABC, abstractmethod\n"
+        "class BaseLLM(ABC):\n"
+        "    @abstractmethod\n"
+        "    def _generate(self, m):\n"
+        "        pass\n\n\n"
+        "class OpenAIClient(BaseLLM):\n"
+        "    def _generate(self, m):\n"
+        "        return 1\n"
+        "    def gen(self, m):\n"
+        "        return self._generate(m)\n\n\n"
+        "class AnthropicClient(BaseLLM):\n"
+        "    def _generate(self, m):\n"
+        "        return 2\n"
+    )
+    calls = _run_calls(tmp_path, {"m.py": src})
+    assert _has(calls, "m.OpenAIClient.gen", "m.OpenAIClient._generate")

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.193"
+version = "0.0.194"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

Fixes dead-code false positives for method overrides reached only through a `self.M()` / `cls.M()` call. A previous pass fanned out from the *resolved* callee, which is wrong: when `M` is abstract with several overrides, the resolver's trie picks an arbitrary sibling override, so the fan-out started from a leaf and missed the base and the other overrides.

Now the fan-out anchors on the ENCLOSING class (`class_context`) and emits an edge to the enclosing class's own/inherited method plus every concrete subclass override.

## Why

Real instances from `cgr dead-code`:
- `SqsBatchJob._raw_batch_operation` abstract, `SqsKick`/`SqsDelete` override it, base `_batch_chunk` calls `self._raw_batch_operation(...)`. `self._raw_batch_operation` resolved to `SqsDelete` alphabetically, so `SqsKick`'s override had no inbound edge.
- `OpenAIClient._generate` reached via `self._generate()`, but `BaseLLMClient` has several subclasses each defining `_generate`, so the call resolved to a cousin (`AnthropicClient`) instead of the enclosing class's own method.

## How

- New `CallResolver.self_dispatch_targets(class_context, method_name)`: the enclosing class's own/inherited method plus every concrete subclass override.
- It SKIPS abstract targets: an `@abstractmethod` stub never runs, so it must not become a call target (a concrete override wins). This preserves the mixin-abstract-stub contract in `test_abstract_method_override_resolution.py`.
- `call_processor` fan-out re-anchored on `class_context` (available at the call site) instead of the resolved callee; gated to `self.`/`cls.` receivers with a single method segment (excludes `super().M()`, `Base.M()`, and `self.attr.M()`).

## Tests (RED to GREEN)

- `test_self_call_in_abstract_base_reaches_all_overrides` (two overrides, both reached), `test_self_call_binds_to_own_class_method_amid_cousin_overrides` (own-class method wins over a cousin override); the five existing override-dispatch tests and both abstract-stub-resolution tests still pass.

Full suite: 4333 passed, 14 skipped. Abstract *base* methods reached only polymorphically (e.g. the `SqsBatchJob` stub itself) are a separate dead-code root-seeding concern, handled in a follow-up.
