### PR TITLE
fix(dead-code): treat @abstractmethod stubs as reachable roots

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -471,6 +471,7 @@ DEFAULT_ROOT_DECORATORS: frozenset[str] = frozenset(
         "root_validator",
         "field_serializer",
         "model_serializer",
+        "abstractmethod",
     }
 )
 

--- a/codebase_rag/tests/test_dead_code_eval.py
+++ b/codebase_rag/tests/test_dead_code_eval.py
@@ -280,6 +280,25 @@ def test_dunder_root_is_scoped_to_python() -> None:
     assert "proj.m.__unused__" in dead
 
 
+def test_abstract_method_is_a_root() -> None:
+    # (H) An @abstractmethod is a contract invoked polymorphically through concrete
+    # (H) overrides, never by a direct call the graph can trace, so the abstract stub
+    # (H) must not be reported dead (SqsBatchJob._raw_batch_operation shape).
+    config = default_dead_code_config(include_tests=False, include_classes=False)
+    nodes = dict(
+        [
+            (
+                (_MODULE, "proj.m"),
+                {cs.KEY_QUALIFIED_NAME: "proj.m", cs.KEY_PATH: "m.py"},
+            ),
+            _fn("proj.m.Base._raw", decorators=["@abstractmethod"]),
+            _fn("proj.m.Base._also", decorators=["@abc.abstractmethod"]),
+        ]
+    )
+    dead = dead_code_from_graph(nodes, [], _PREFIX, config)
+    assert dead == set()
+
+
 def test_score_dead_code_prf() -> None:
     result = score_dead_code({"a", "b"}, {"a", "c"})
     row = result.rows[0]

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.194"
+version = "0.0.196"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

Fixes a dead-code false positive: an `@abstractmethod` stub was reported as dead code. An abstract method is a contract invoked polymorphically through its concrete overrides, never by a direct call the reachability walk can see, so it must not be flagged.

`abstractmethod` is added to the default reachability-root decorator set.

## Why

`@abstractmethod` methods carry `abstractmethod` in their stored `decorators`, which the dead-code query already normalizes and matches against the root-decorator set, so this is a pure query/config change (no schema change, no re-index needed). Real instance from `cgr dead-code`: `SqsBatchJob._raw_batch_operation` and `BatchingStrategyBase._validate_output_schema`, both `@abstractmethod`, called via `self.M()` and implemented by concrete subclasses.

This complements the self/cls dispatch fan-out (which reaches the concrete overrides): the fan-out deliberately skips the abstract stub as a call target, and this seeds the stub as a root so the stub itself is not reported dead.

## Tests (RED to GREEN)

- `test_dead_code_eval.py::test_abstract_method_is_a_root`: `@abstractmethod` and `@abc.abstractmethod` stubs with no caller are not flagged.

Full suite: 4337 passed, 14 skipped.
