### PR TITLE
fix(graph): fall back to linear scan for dotted suffixes in find_ending_with

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -116,8 +116,7 @@ class FunctionRegistryTrie:
         simple_name = qualified_name.rsplit(cs.SEPARATOR_DOT, 1)[-1]
         if self._simple_name_lookup is not None:
             self._simple_name_lookup[simple_name].add(qualified_name)
-        if self._ending_with_cache:
-            self._ending_with_cache.pop(simple_name, None)
+        self._invalidate_ending_with_cache(qualified_name, simple_name)
 
         parts = qualified_name.split(cs.SEPARATOR_DOT)
         current: TrieNode = self.root
@@ -169,8 +168,7 @@ class FunctionRegistryTrie:
         self._abstracts.discard(qualified_name)
         self._callable_params.pop(qualified_name, None)
 
-        if self._ending_with_cache:
-            self._ending_with_cache.pop(simple_name, None)
+        self._invalidate_ending_with_cache(qualified_name, simple_name)
 
         if self._simple_name_lookup is not None:
             if simple_name in self._simple_name_lookup:
@@ -253,6 +251,20 @@ class FunctionRegistryTrie:
         )
         return [qn for qn, _ in matches]
 
+    def _invalidate_ending_with_cache(
+        self, qualified_name: QualifiedName, simple_name: str
+    ) -> None:
+        if not self._ending_with_cache:
+            return
+        self._ending_with_cache.pop(simple_name, None)
+        # (H) dotted suffixes are cached too (#513); drop any the qn ends with.
+        for key in [
+            k
+            for k in self._ending_with_cache
+            if cs.SEPARATOR_DOT in k and qualified_name.endswith(f".{k}")
+        ]:
+            del self._ending_with_cache[key]
+
     def find_ending_with(self, suffix: str) -> list[QualifiedName]:
         cached = self._ending_with_cache.get(suffix)
         if cached is not None:
@@ -260,7 +272,16 @@ class FunctionRegistryTrie:
         if self._simple_name_lookup is not None:
             if suffix in self._simple_name_lookup:
                 result = sorted(self._simple_name_lookup[suffix])
+            elif cs.SEPARATOR_DOT in suffix:
+                # (H) #513: the index only holds last segments, so a dotted
+                # (H) suffix ("Class.method") always misses it; fall back to
+                # (H) the linear scan instead of dropping the match.
+                result = sorted(
+                    qn for qn in self._entries.keys() if qn.endswith(f".{suffix}")
+                )
             else:
+                # (H) dot-free miss is authoritative: insert() indexes every
+                # (H) entry's last segment, so nothing can end with ".suffix".
                 result = []
         else:
             result = sorted(

--- a/codebase_rag/tests/test_trie_optimization.py
+++ b/codebase_rag/tests/test_trie_optimization.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -5,7 +6,7 @@ import pytest
 
 from codebase_rag.graph_updater import FunctionRegistryTrie, GraphUpdater
 from codebase_rag.parser_loader import load_parsers
-from codebase_rag.types_defs import NodeType
+from codebase_rag.types_defs import NodeType, SimpleNameLookup
 
 
 class TestTrieOptimization:
@@ -63,6 +64,30 @@ class TestTrieOptimization:
 
         results = trie.find_ending_with("info")
         assert results == ["project.utils.logger.Logger.info"]
+
+    def test_find_ending_with_dotted_suffix_falls_back_to_scan(self) -> None:
+        # (H) #513: a dotted suffix ("Class.method") can never be a key in the
+        # (H) simple-name index (it only holds last segments), so a lookup miss
+        # (H) must fall back to the linear scan instead of returning [].
+        lookup: SimpleNameLookup = defaultdict(set)
+        trie = FunctionRegistryTrie(simple_name_lookup=lookup)
+        trie.insert("proj.mod.Class.method", NodeType.FUNCTION)
+        trie.insert("proj.other.Class.unrelated", NodeType.FUNCTION)
+
+        assert trie.find_ending_with("Class.method") == ["proj.mod.Class.method"]
+        # (H) dot-free misses stay on the O(1) path: the index holds every
+        # (H) entry's last segment, so a miss genuinely means no match.
+        assert trie.find_ending_with("missing") == []
+
+        # (H) cached dotted results must be invalidated by inserts/deletes
+        # (H) (incremental updates), not just simple-name cache entries.
+        trie.insert("pkg.sub.Class.method", NodeType.FUNCTION)
+        assert trie.find_ending_with("Class.method") == [
+            "pkg.sub.Class.method",
+            "proj.mod.Class.method",
+        ]
+        del trie["proj.mod.Class.method"]
+        assert trie.find_ending_with("Class.method") == ["pkg.sub.Class.method"]
 
     def test_trie_performance_optimization(self) -> None:
         """Test that Trie provides performance benefits over naive search."""


### PR DESCRIPTION
Fixes #513. Supersedes #590 (closed by an accidental branch deletion after a merge conflict with a moved main; identical change rebased onto current main).

`FunctionRegistryTrie.find_ending_with()` returned `[]` whenever `simple_name_lookup` was present but did not contain the suffix, instead of falling back to the linear scan over `_entries`.

The simple-name index only holds each entry's **last** segment, so a dotted suffix like `Class.method` can never be a key in it. Any caller passing a dotted suffix silently lost all matches, dropping CALLS edges.

Changes:
- Dotted suffixes now fall back to the linear scan when the index misses. Dot-free misses stay on the O(1) path, which is provably safe: `insert()` unconditionally indexes every entry's last segment, and for a dot-free suffix `qn.endswith("." + suffix)` holds iff the last segment equals the suffix, so a dot-free index miss genuinely means no match.
- `_ending_with_cache` invalidation now also drops cached dotted-suffix entries the inserted/deleted qualified name ends with, so incremental updates cannot serve stale dotted results.

RED->GREEN: `test_find_ending_with_dotted_suffix_falls_back_to_scan` (dotted fallback, dot-free O(1) miss, cache invalidation across insert/delete).

Verification: full suite 4319 passed; JS retrieval eval on axios/lib identical before/after (tp 325 / fp 40 / fn 18, P 0.8904 / R 0.9475), confirming zero precision regression. Greptile reviewed the identical pre-rebase diff at 5/5 on #590.