### PR TITLE
ci: fix format drift and missing libclang extra breaking main checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --extra treesitter-full --extra semantic --group dev
+          uv sync --extra treesitter-full --extra semantic --extra test --group dev
 
       - name: Run type checking
         run: |

--- a/codebase_rag/tests/test_call_processor.py
+++ b/codebase_rag/tests/test_call_processor.py
@@ -1582,7 +1582,10 @@ class TestIngestFunctionCallsWithoutCallNodes:
         root_node = tree.root_node
 
         empty_queries: dict = {
-            cs.SupportedLanguage.PYTHON: {cs.QUERY_CALLS: None, cs.QUERY_CONFIG: queries[cs.SupportedLanguage.PYTHON][cs.QUERY_CONFIG]}
+            cs.SupportedLanguage.PYTHON: {
+                cs.QUERY_CALLS: None,
+                cs.QUERY_CONFIG: queries[cs.SupportedLanguage.PYTHON][cs.QUERY_CONFIG],
+            }
         }
         cp._ingest_function_calls(
             root_node,
@@ -1627,19 +1630,25 @@ class TestCombinedQueryCompilationExceptionPaths:
             return RealQuery(language, pattern)
 
         original_fc = COMBINED_FUNC_CLASS_QUERIES.get(cs.SupportedLanguage.PYTHON)
-        original_fci = COMBINED_FUNC_CLASS_IMPORT_QUERIES.get(cs.SupportedLanguage.PYTHON)
+        original_fci = COMBINED_FUNC_CLASS_IMPORT_QUERIES.get(
+            cs.SupportedLanguage.PYTHON
+        )
         try:
             with patch("codebase_rag.parser_loader.Query", side_effect=patched_query):
                 _create_language_queries(
                     language_obj, parser, lang_config, cs.SupportedLanguage.PYTHON
                 )
             assert COMBINED_FUNC_CLASS_QUERIES[cs.SupportedLanguage.PYTHON] is None
-            assert COMBINED_FUNC_CLASS_IMPORT_QUERIES[cs.SupportedLanguage.PYTHON] is None
+            assert (
+                COMBINED_FUNC_CLASS_IMPORT_QUERIES[cs.SupportedLanguage.PYTHON] is None
+            )
         finally:
             if original_fc is not None:
                 COMBINED_FUNC_CLASS_QUERIES[cs.SupportedLanguage.PYTHON] = original_fc
             if original_fci is not None:
-                COMBINED_FUNC_CLASS_IMPORT_QUERIES[cs.SupportedLanguage.PYTHON] = original_fci
+                COMBINED_FUNC_CLASS_IMPORT_QUERIES[cs.SupportedLanguage.PYTHON] = (
+                    original_fci
+                )
 
 
 class TestGetRustImplClassName:

--- a/codebase_rag/tests/test_semantic_search.py
+++ b/codebase_rag/tests/test_semantic_search.py
@@ -58,7 +58,9 @@ def test_semantic_code_search_returns_empty_without_dependencies() -> None:
     assert results == []
 
 
-@patch("codebase_rag.tools.semantic_search.has_semantic_dependencies", return_value=True)
+@patch(
+    "codebase_rag.tools.semantic_search.has_semantic_dependencies", return_value=True
+)
 @patch("codebase_rag.vector_store.search_embeddings")
 @patch("codebase_rag.embedder.embed_code")
 def test_semantic_code_search_reuses_injected_ingestor(
@@ -93,7 +95,9 @@ def test_semantic_code_search_reuses_injected_ingestor(
     assert results[0]["score"] == 0.99
 
 
-@patch("codebase_rag.tools.semantic_search.has_semantic_dependencies", return_value=True)
+@patch(
+    "codebase_rag.tools.semantic_search.has_semantic_dependencies", return_value=True
+)
 @patch("codebase_rag.vector_store.search_embeddings")
 @patch("codebase_rag.embedder.embed_code")
 def test_semantic_code_search_tolerates_missing_result_fields(

--- a/codebase_rag/tools/semantic_search.py
+++ b/codebase_rag/tools/semantic_search.py
@@ -72,9 +72,7 @@ def semantic_code_search(
                     )
                 )
 
-        logger.info(
-            ls.SEMANTIC_FOUND.format(count=len(formatted_results), query=query)
-        )
+        logger.info(ls.SEMANTIC_FOUND.format(count=len(formatted_results), query=query))
         return formatted_results
 
     except Exception as e:
@@ -120,9 +118,7 @@ def create_semantic_search_tool(ingestor: QueryProtocol) -> Tool:
     async def semantic_search_functions(query: str, top_k: int = 5) -> str:
         logger.info(ls.SEMANTIC_TOOL_SEARCH.format(query=query))
 
-        results = await asyncio.to_thread(
-            semantic_code_search, ingestor, query, top_k
-        )
+        results = await asyncio.to_thread(semantic_code_search, ingestor, query, top_k)
 
         if not results:
             return cs.MSG_SEMANTIC_NO_RESULTS.format(query=query)

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.196"
+version = "0.0.197"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Main's CI is red, which fails the Lint & Format and Type Check jobs on every open PR (#591, #592). Two independent breakages, both introduced by recent merges:

1. **Format drift**: `test_call_processor.py`, `test_semantic_search.py`, and `tools/semantic_search.py` landed unformatted; `ruff format --check` fails. Reformatted (no behavior change; the 109 affected tests pass).
2. **Type Check job**: `parsers/cpp_frontend/` imports `clang.cindex`, but the job's `uv sync` omits the `test` extra where `libclang` is declared, so `ty` reports unresolved-import errors. Added `--extra test` to the job's sync, matching the unit-test jobs.

Verification: `ruff format --check` and `uv run ty check codebase_rag --exclude codebase_rag/tests/` both pass locally with this branch.