### PR TITLE
fix(imports): resolve Python absolute imports through nested source roots

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -1225,6 +1225,9 @@ DIST_DIR = "dist"
 BYTES_PER_MB_FLOAT = 1024 * 1024
 
 PYPROJECT_PATH = "pyproject.toml"
+PYPROJECT_KEY_TOOL = "tool"
+PYPROJECT_KEY_SETUPTOOLS = "setuptools"
+PYPROJECT_KEY_PACKAGE_DIR = "package-dir"
 TREESITTER_EXTRA_KEY = "treesitter-full"
 TREESITTER_PKG_PREFIX = "tree-sitter-"
 

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -482,6 +482,7 @@ IMP_CPP_MODULE_IMPL = "C++20 module implementation: {name}"
 IMP_CPP_MODULE_IFACE = "C++20 module interface: {name}"
 IMP_CPP_PARTITION = "C++20 module partition import: {partition} -> {full}"
 IMP_GENERIC = "Generic import parsing for {language}: {node_type}"
+IMP_PY_SOURCE_ROOT = "Python source root: {name} -> {path}"
 
 # (H) Structure processor logs
 STRUCT_IDENTIFIED_PACKAGE = "  Identified Package: {package_qn}"

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -13,6 +13,7 @@ from ..language_spec import LanguageSpec
 from ..services import IngestorProtocol
 from ..types_defs import FunctionRegistryTrieProtocol, LanguageQueries
 from .lua import utils as lua_utils
+from .python_source_roots import discover_python_source_roots, resolve_via_source_roots
 from .rs import utils as rs_utils
 from .stdlib_extractor import (
     StdlibCacheStats,
@@ -127,6 +128,7 @@ class ImportProcessor:
         "stdlib_extractor",
         "_is_local_module_cached",
         "_is_local_java_import_cached",
+        "_map_py_source_root",
     )
 
     def __init__(
@@ -167,6 +169,19 @@ class ImportProcessor:
         )
 
         repo_is_package = (repo_path / cs.INIT_PY).is_file()
+
+        # (H) Python packages under nested source roots (src-layout, monorepo
+        # (H) packages, pyproject package-dir remaps) are importable by a name that
+        # (H) differs from their repo-relative path, so absolute imports of them
+        # (H) cannot resolve by the import-name == path assumption. Discover the
+        # (H) name -> dotted-path map once so those imports resolve first-party.
+        py_source_roots = discover_python_source_roots(repo_path)
+
+        @lru_cache(maxsize=4096)
+        def _map_py_source_root_cached(module_name: str) -> str | None:
+            return resolve_via_source_roots(repo_path, py_source_roots, module_name)
+
+        self._map_py_source_root = _map_py_source_root_cached
 
         @lru_cache(maxsize=4096)
         def _is_local_module_cached(module_name: str) -> bool:
@@ -343,6 +358,8 @@ class ImportProcessor:
             return module_name
         if self._is_local_module(top_level):
             return f"{self.project_name}{cs.SEPARATOR_DOT}{module_name}"
+        if mapped := self._map_py_source_root(module_name):
+            return f"{self.project_name}{cs.SEPARATOR_DOT}{mapped}"
         return module_name
 
     def _is_local_module(self, module_name: str) -> bool:

--- a/codebase_rag/parsers/python_source_roots.py
+++ b/codebase_rag/parsers/python_source_roots.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import os
+import tomllib
+from pathlib import Path
+
+from loguru import logger
+
+from .. import constants as cs
+from .. import logs as ls
+
+
+def _dotted(rel_dir: Path) -> str:
+    return str(rel_dir).replace(os.sep, cs.SEPARATOR_DOT)
+
+
+def _package_dir_remaps(pyproject: Path, repo_path: Path) -> dict[str, str]:
+    # (H) setuptools `[tool.setuptools.package-dir]` maps an import name to the
+    # (H) directory that IS that package (`mypkg = "lib"` -> lib/__init__.py is
+    # (H) mypkg), so the import name maps to the remapped directory's dotted path.
+    try:
+        data = tomllib.loads(pyproject.read_text(encoding=cs.ENCODING_UTF8))
+    except (OSError, tomllib.TOMLDecodeError):
+        return {}
+    section = data
+    for key in (cs.PYPROJECT_KEY_TOOL, cs.PYPROJECT_KEY_SETUPTOOLS):
+        section = section.get(key, {})
+        if not isinstance(section, dict):
+            return {}
+    package_dir = section.get(cs.PYPROJECT_KEY_PACKAGE_DIR, {})
+    if not isinstance(package_dir, dict):
+        return {}
+    remaps: dict[str, str] = {}
+    base = pyproject.parent
+    for name, rel in package_dir.items():
+        if not name or not isinstance(rel, str):
+            continue
+        target = (base / rel).resolve()
+        if target.is_dir():
+            remaps[name] = _dotted(target.relative_to(repo_path))
+    return remaps
+
+
+def discover_python_source_roots(repo_path: Path) -> dict[str, list[str]]:
+    # (H) Map each importable top-level name to the dotted repo-relative directory
+    # (H) that holds its contents, for packages NOT at the repo root (root-level
+    # (H) packages already resolve via the import name == path assumption). Found
+    # (H) from three signals: a package (__init__.py) whose parent is not itself a
+    # (H) package, children of a `src` directory (covers PEP 420 namespace packages
+    # (H) and single-module files), and pyproject `package-dir` remaps. Multiple
+    # (H) same-named roots keep all candidates; resolution disambiguates by which
+    # (H) candidate actually contains the imported submodule on disk.
+    roots: dict[str, list[str]] = {}
+
+    def _add(name: str, dotted_dir: str) -> None:
+        if dotted_dir == name:
+            return
+        candidates = roots.setdefault(name, [])
+        if dotted_dir not in candidates:
+            candidates.append(dotted_dir)
+            logger.debug(ls.IMP_PY_SOURCE_ROOT, name=name, path=dotted_dir)
+
+    repo_path = repo_path.resolve()
+    for dirpath, dirnames, filenames in os.walk(repo_path):
+        dirnames[:] = sorted(
+            d
+            for d in dirnames
+            if d not in cs.IGNORE_PATTERNS and not d.startswith(cs.SEPARATOR_DOT)
+        )
+        current = Path(dirpath)
+        rel = current.relative_to(repo_path)
+        is_package = cs.INIT_PY in filenames
+        parent_is_package = (current.parent / cs.INIT_PY).is_file()
+        if is_package and not parent_is_package and current != repo_path:
+            _add(current.name, _dotted(rel))
+        if current.name == cs.LANG_SRC_DIR:
+            for child in dirnames:
+                if not (current / child / cs.INIT_PY).is_file():
+                    _add(child, _dotted(rel / child))
+            for filename in filenames:
+                if filename.endswith(cs.EXT_PY) and filename != cs.INIT_PY:
+                    _add(filename[: -len(cs.EXT_PY)], _dotted(rel))
+        if cs.PYPROJECT_PATH in filenames:
+            for name, dotted_dir in _package_dir_remaps(
+                current / cs.PYPROJECT_PATH, repo_path
+            ).items():
+                _add(name, dotted_dir)
+    return roots
+
+
+def resolve_via_source_roots(
+    repo_path: Path, roots: dict[str, list[str]], module_name: str
+) -> str | None:
+    # (H) Translate an absolute import name (`pkg.impls`) whose top-level package
+    # (H) lives under a nested source root into the path-based dotted QN cgr
+    # (H) registers nodes under (`packages.a.src.pkg.impls`). Among same-named
+    # (H) roots, the one that actually contains the imported submodule on disk
+    # (H) wins; with no on-disk confirmation, a sole candidate is trusted.
+    top_level, _, rest = module_name.partition(cs.SEPARATOR_DOT)
+    candidates = roots.get(top_level)
+    if not candidates:
+        return None
+    for dotted_dir in candidates:
+        target = repo_path / dotted_dir.replace(cs.SEPARATOR_DOT, os.sep)
+        if rest:
+            sub = target / rest.replace(cs.SEPARATOR_DOT, os.sep)
+            if (
+                sub.is_dir()
+                or sub.with_suffix(cs.EXT_PY).is_file()
+                or (sub / cs.INIT_PY).is_file()
+            ):
+                return f"{dotted_dir}{cs.SEPARATOR_DOT}{rest}"
+        elif target.is_dir() or target.with_suffix(cs.EXT_PY).is_file():
+            return dotted_dir
+    if len(candidates) == 1:
+        dotted_dir = candidates[0]
+        return f"{dotted_dir}{cs.SEPARATOR_DOT}{rest}" if rest else dotted_dir
+    return None

--- a/codebase_rag/parsers/python_source_roots.py
+++ b/codebase_rag/parsers/python_source_roots.py
@@ -14,30 +14,48 @@ def _dotted(rel_dir: Path) -> str:
     return str(rel_dir).replace(os.sep, cs.SEPARATOR_DOT)
 
 
-def _package_dir_remaps(pyproject: Path, repo_path: Path) -> dict[str, str]:
+def _package_dir_remaps(pyproject: Path, repo_path: Path) -> list[tuple[str, str]]:
     # (H) setuptools `[tool.setuptools.package-dir]` maps an import name to the
     # (H) directory that IS that package (`mypkg = "lib"` -> lib/__init__.py is
-    # (H) mypkg), so the import name maps to the remapped directory's dotted path.
+    # (H) mypkg). The empty-string key is the DEFAULT remap (`"" = "lib"` -> the
+    # (H) whole package namespace lives under lib/), so lib's children become the
+    # (H) importable top-level names. A remap escaping the repo is skipped.
     try:
         data = tomllib.loads(pyproject.read_text(encoding=cs.ENCODING_UTF8))
     except (OSError, tomllib.TOMLDecodeError):
-        return {}
+        return []
     section = data
     for key in (cs.PYPROJECT_KEY_TOOL, cs.PYPROJECT_KEY_SETUPTOOLS):
         section = section.get(key, {})
         if not isinstance(section, dict):
-            return {}
+            return []
     package_dir = section.get(cs.PYPROJECT_KEY_PACKAGE_DIR, {})
     if not isinstance(package_dir, dict):
-        return {}
-    remaps: dict[str, str] = {}
+        return []
+    remaps: list[tuple[str, str]] = []
     base = pyproject.parent
     for name, rel in package_dir.items():
-        if not name or not isinstance(rel, str):
+        if not isinstance(rel, str):
             continue
         target = (base / rel).resolve()
-        if target.is_dir():
-            remaps[name] = _dotted(target.relative_to(repo_path))
+        if not target.is_dir():
+            continue
+        try:
+            dotted_dir = _dotted(target.relative_to(repo_path))
+        except ValueError:
+            continue
+        if name:
+            remaps.append((name, dotted_dir))
+            continue
+        for child in sorted(target.iterdir()):
+            if child.is_dir():
+                remaps.append(
+                    (child.name, f"{dotted_dir}{cs.SEPARATOR_DOT}{child.name}")
+                )
+            elif child.suffix == cs.EXT_PY and child.name != cs.INIT_PY:
+                remaps.append(
+                    (child.stem, f"{dotted_dir}{cs.SEPARATOR_DOT}{child.stem}")
+                )
     return remaps
 
 
@@ -79,11 +97,12 @@ def discover_python_source_roots(repo_path: Path) -> dict[str, list[str]]:
                     _add(child, _dotted(rel / child))
             for filename in filenames:
                 if filename.endswith(cs.EXT_PY) and filename != cs.INIT_PY:
-                    _add(filename[: -len(cs.EXT_PY)], _dotted(rel))
+                    stem = filename[: -len(cs.EXT_PY)]
+                    _add(stem, _dotted(rel / stem))
         if cs.PYPROJECT_PATH in filenames:
             for name, dotted_dir in _package_dir_remaps(
                 current / cs.PYPROJECT_PATH, repo_path
-            ).items():
+            ):
                 _add(name, dotted_dir)
     return roots
 

--- a/codebase_rag/parsers/python_source_roots.py
+++ b/codebase_rag/parsers/python_source_roots.py
@@ -59,23 +59,27 @@ def _package_dir_remaps(pyproject: Path, repo_path: Path) -> list[tuple[str, str
     return remaps
 
 
-def discover_python_source_roots(repo_path: Path) -> dict[str, list[str]]:
-    # (H) Map each importable top-level name to the dotted repo-relative directory
-    # (H) that holds its contents, for packages NOT at the repo root (root-level
-    # (H) packages already resolve via the import name == path assumption). Found
-    # (H) from three signals: a package (__init__.py) whose parent is not itself a
-    # (H) package, children of a `src` directory (covers PEP 420 namespace packages
-    # (H) and single-module files), and pyproject `package-dir` remaps. Multiple
+def discover_python_source_roots(repo_path: Path) -> dict[str, list[tuple[str, str]]]:
+    # (H) Map each importable top-level name to (import_prefix, dotted_dir) pairs,
+    # (H) where import_prefix is the importable name the directory answers for (a
+    # (H) bare name, or a dotted one from a `"acme.widgets" = "lib/widgets"`
+    # (H) package-dir remap) and dotted_dir is its repo-relative dotted path. Only
+    # (H) packages NOT at the repo root are mapped (root-level packages already
+    # (H) resolve via the import name == path assumption). Found from three
+    # (H) signals: a package (__init__.py) whose parent is not itself a package,
+    # (H) children of a `src` directory (covers PEP 420 namespace packages and
+    # (H) single-module files), and pyproject `package-dir` remaps. Multiple
     # (H) same-named roots keep all candidates; resolution disambiguates by which
     # (H) candidate actually contains the imported submodule on disk.
-    roots: dict[str, list[str]] = {}
+    roots: dict[str, list[tuple[str, str]]] = {}
 
     def _add(name: str, dotted_dir: str) -> None:
         if dotted_dir == name:
             return
-        candidates = roots.setdefault(name, [])
-        if dotted_dir not in candidates:
-            candidates.append(dotted_dir)
+        top_level = name.split(cs.SEPARATOR_DOT)[0]
+        candidates = roots.setdefault(top_level, [])
+        if (name, dotted_dir) not in candidates:
+            candidates.append((name, dotted_dir))
             logger.debug(ls.IMP_PY_SOURCE_ROOT, name=name, path=dotted_dir)
 
     repo_path = repo_path.resolve()
@@ -108,18 +112,27 @@ def discover_python_source_roots(repo_path: Path) -> dict[str, list[str]]:
 
 
 def resolve_via_source_roots(
-    repo_path: Path, roots: dict[str, list[str]], module_name: str
+    repo_path: Path, roots: dict[str, list[tuple[str, str]]], module_name: str
 ) -> str | None:
     # (H) Translate an absolute import name (`pkg.impls`) whose top-level package
     # (H) lives under a nested source root into the path-based dotted QN cgr
-    # (H) registers nodes under (`packages.a.src.pkg.impls`). Among same-named
-    # (H) roots, the one that actually contains the imported submodule on disk
-    # (H) wins; with no on-disk confirmation, a sole candidate is trusted.
-    top_level, _, rest = module_name.partition(cs.SEPARATOR_DOT)
+    # (H) registers nodes under (`packages.a.src.pkg.impls`). Candidates whose
+    # (H) import_prefix is dotted match by longest prefix (a `"acme.widgets"`
+    # (H) remap answers `acme.widgets.impl`). Among matching roots, the one that
+    # (H) actually contains the imported submodule on disk wins; with no on-disk
+    # (H) confirmation, a sole match is trusted.
+    top_level = module_name.split(cs.SEPARATOR_DOT)[0]
     candidates = roots.get(top_level)
     if not candidates:
         return None
-    for dotted_dir in candidates:
+    matches: list[tuple[str, str]] = []
+    for prefix, dotted_dir in candidates:
+        if module_name == prefix:
+            matches.append(("", dotted_dir))
+        elif module_name.startswith(prefix + cs.SEPARATOR_DOT):
+            matches.append((module_name[len(prefix) + 1 :], dotted_dir))
+    matches.sort(key=lambda m: len(m[0]))
+    for rest, dotted_dir in matches:
         target = repo_path / dotted_dir.replace(cs.SEPARATOR_DOT, os.sep)
         if rest:
             sub = target / rest.replace(cs.SEPARATOR_DOT, os.sep)
@@ -131,7 +144,7 @@ def resolve_via_source_roots(
                 return f"{dotted_dir}{cs.SEPARATOR_DOT}{rest}"
         elif target.is_dir() or target.with_suffix(cs.EXT_PY).is_file():
             return dotted_dir
-    if len(candidates) == 1:
-        dotted_dir = candidates[0]
+    if len(matches) == 1:
+        rest, dotted_dir = matches[0]
         return f"{dotted_dir}{cs.SEPARATOR_DOT}{rest}" if rest else dotted_dir
     return None

--- a/codebase_rag/tests/test_python_source_root_imports.py
+++ b/codebase_rag/tests/test_python_source_root_imports.py
@@ -154,3 +154,74 @@ def test_same_named_packages_disambiguate_by_submodule(tmp_path: Path) -> None:
         },
     )
     assert _has(calls, "app.registry.use", "a.src.common.only_in_a._handler")
+
+
+def test_package_dir_default_key_remap(tmp_path: Path) -> None:
+    # (H) setuptools' default remap `"" = "lib"` relocates the whole package
+    # (H) namespace; a namespace package under it (no __init__.py, dir not named
+    # (H) src) has no other discovery signal and must still resolve.
+    calls = _run_calls(
+        tmp_path,
+        {
+            "pyproject.toml": (
+                '[project]\nname = "proj"\n[tool.setuptools.package-dir]\n"" = "lib"\n'
+            ),
+            "lib/nspkg/impls.py": IMPL,
+            "lib/nspkg/registry.py": CALLER.format(pkg="nspkg"),
+        },
+    )
+    assert _has(calls, "nspkg.registry.use", "lib.nspkg.impls._handler")
+
+
+def test_single_module_under_src_resolves_to_module(tmp_path: Path) -> None:
+    # (H) A single-module file directly under src (src/mymod.py) is importable as
+    # (H) `mymod`; the import must resolve to the module's own path QN, not to the
+    # (H) containing src directory.
+    calls = _run_calls(
+        tmp_path,
+        {
+            "packages/a/src/mymod.py": IMPL,
+            "packages/a/src/consumer.py": (
+                "from mymod import _handler\n\n\n"
+                "def use(ctx):\n"
+                "    return _handler(ctx)\n"
+            ),
+        },
+    )
+    assert _has(calls, "src.consumer.use", "src.mymod._handler")
+
+
+def test_package_dir_escaping_repo_does_not_crash(tmp_path: Path) -> None:
+    # (H) A package-dir pointing outside the repo (`..`) must be skipped, not crash
+    # (H) discovery with a relative_to ValueError; sibling code still resolves.
+    (tmp_path.parent / "outside").mkdir(exist_ok=True)
+    calls = _run_calls(
+        tmp_path,
+        {
+            "pyproject.toml": (
+                "[project]\n"
+                'name = "proj"\n'
+                "[tool.setuptools.package-dir]\n"
+                'escapee = "../outside"\n'
+            ),
+            "pkg/__init__.py": "",
+            "pkg/impls.py": IMPL,
+            "pkg/registry.py": CALLER.format(pkg="pkg"),
+        },
+    )
+    assert _has(calls, "pkg.registry.use", "pkg.impls._handler")
+
+
+def test_single_module_root_maps_to_module_path(tmp_path: Path) -> None:
+    # (H) The discovery map must key a single-module file to the module's OWN dotted
+    # (H) path (…src.mymod), not its containing directory (…src), or resolution
+    # (H) returns a directory QN and downstream lookups depend on trie luck.
+    from codebase_rag.parsers.python_source_roots import (
+        discover_python_source_roots,
+        resolve_via_source_roots,
+    )
+
+    (tmp_path / "packages/a/src").mkdir(parents=True)
+    (tmp_path / "packages/a/src/mymod.py").write_text(IMPL, encoding="utf-8")
+    roots = discover_python_source_roots(tmp_path)
+    assert resolve_via_source_roots(tmp_path, roots, "mymod") == "packages.a.src.mymod"

--- a/codebase_rag/tests/test_python_source_root_imports.py
+++ b/codebase_rag/tests/test_python_source_root_imports.py
@@ -225,3 +225,29 @@ def test_single_module_root_maps_to_module_path(tmp_path: Path) -> None:
     (tmp_path / "packages/a/src/mymod.py").write_text(IMPL, encoding="utf-8")
     roots = discover_python_source_roots(tmp_path)
     assert resolve_via_source_roots(tmp_path, roots, "mymod") == "packages.a.src.mymod"
+
+
+def test_package_dir_dotted_key_remap(tmp_path: Path) -> None:
+    # (H) package-dir keys can name a dotted subpackage ("acme.widgets" =
+    # (H) "lib/widgets"); the import's top-level segment (acme) has no entry of its
+    # (H) own, so resolution must match the longest dotted prefix, not just the
+    # (H) top-level name.
+    calls = _run_calls(
+        tmp_path,
+        {
+            "pyproject.toml": (
+                "[project]\n"
+                'name = "acme-widgets"\n'
+                "[tool.setuptools.package-dir]\n"
+                '"acme.widgets" = "lib/widgets"\n'
+            ),
+            "lib/widgets/__init__.py": "",
+            "lib/widgets/impl.py": IMPL,
+            "app.py": (
+                "from acme.widgets.impl import _handler\n\n\n"
+                "def use(ctx):\n"
+                "    return _handler(ctx)\n"
+            ),
+        },
+    )
+    assert _has(calls, "app.use", "lib.widgets.impl._handler")

--- a/codebase_rag/tests/test_python_source_root_imports.py
+++ b/codebase_rag/tests/test_python_source_root_imports.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+
+def _run_calls(tmp_path: Path, files: dict[str, str]) -> set[tuple[str, str]]:
+    # (H) Build the graph for `files` (repo-relative paths) and return CALLS edges.
+    parsers, queries = load_parsers()
+    if "python" not in parsers:
+        pytest.skip("python parser not available")
+    for rel, content in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name="repo",
+    ).run()
+    out: set[tuple[str, str]] = set()
+    for c in mock.ensure_relationship_batch.call_args_list:
+        if c.args[1] == "CALLS":
+            out.add((c.args[0][2], c.args[2][2]))
+    return out
+
+
+def _has(calls: set[tuple[str, str]], caller_suffix: str, callee_suffix: str) -> bool:
+    return any(
+        a.endswith(caller_suffix) and b.endswith(callee_suffix) for a, b in calls
+    )
+
+
+IMPL = "def _handler(ctx):\n    return 1\n"
+CALLER = (
+    "from {pkg}.impls import _handler\n\n\ndef use(ctx):\n    return _handler(ctx)\n"
+)
+DISPATCH = "from {pkg}.impls import _handler\n\nhandlers = {{'a': _handler}}\n"
+
+
+def test_flat_layout_absolute_import(tmp_path: Path) -> None:
+    # (H) Regression: package at the repo root, absolute import (already worked).
+    calls = _run_calls(
+        tmp_path,
+        {
+            "pkg/__init__.py": "",
+            "pkg/impls.py": IMPL,
+            "pkg/registry.py": CALLER.format(pkg="pkg"),
+        },
+    )
+    assert _has(calls, "pkg.registry.use", "pkg.impls._handler")
+
+
+def test_src_layout_absolute_import(tmp_path: Path) -> None:
+    # (H) src-layout: the package's import name (pkg) differs from its repo-relative
+    # (H) path (packages/a/src/pkg). The absolute import must resolve to the
+    # (H) path-based node, not be judged an external import and dropped.
+    calls = _run_calls(
+        tmp_path,
+        {
+            "packages/a/src/pkg/__init__.py": "",
+            "packages/a/src/pkg/impls.py": IMPL,
+            "packages/a/src/pkg/registry.py": CALLER.format(pkg="pkg"),
+        },
+    )
+    assert _has(calls, "src.pkg.registry.use", "src.pkg.impls._handler")
+
+
+def test_src_layout_dispatch_dict_value(tmp_path: Path) -> None:
+    # (H) The dead-code trigger shape: a module-level dispatch dict referencing the
+    # (H) imported handler must produce a Module -> CALLS -> handler reference edge.
+    calls = _run_calls(
+        tmp_path,
+        {
+            "packages/a/src/pkg/__init__.py": "",
+            "packages/a/src/pkg/impls.py": IMPL,
+            "packages/a/src/pkg/registry.py": DISPATCH.format(pkg="pkg"),
+        },
+    )
+    assert _has(calls, "src.pkg.registry", "src.pkg.impls._handler")
+
+
+def test_monorepo_cross_package_absolute_import(tmp_path: Path) -> None:
+    # (H) Two packages, each under its own src root; libb absolutely imports liba.
+    calls = _run_calls(
+        tmp_path,
+        {
+            "packages/a/src/liba/__init__.py": "",
+            "packages/a/src/liba/impls.py": IMPL,
+            "packages/b/src/libb/__init__.py": "",
+            "packages/b/src/libb/registry.py": CALLER.format(pkg="liba"),
+        },
+    )
+    assert _has(calls, "libb.registry.use", "liba.impls._handler")
+
+
+def test_package_dir_remap_absolute_import(tmp_path: Path) -> None:
+    # (H) setuptools package-dir remap: import name (mypkg) maps to a directory with
+    # (H) a DIFFERENT name (lib/), declared in pyproject.toml.
+    calls = _run_calls(
+        tmp_path,
+        {
+            "pyproject.toml": (
+                "[project]\n"
+                'name = "mypkg"\n'
+                "[tool.setuptools.package-dir]\n"
+                'mypkg = "lib"\n'
+            ),
+            "lib/__init__.py": "",
+            "lib/impls.py": IMPL,
+            "lib/registry.py": CALLER.format(pkg="mypkg"),
+        },
+    )
+    assert _has(calls, "lib.registry.use", "lib.impls._handler")
+
+
+def test_namespace_package_under_src(tmp_path: Path) -> None:
+    # (H) PEP 420 namespace package: no __init__.py anywhere, package under a src
+    # (H) root. The import must still map to the path-based nodes.
+    calls = _run_calls(
+        tmp_path,
+        {
+            "packages/a/src/nspkg/impls.py": IMPL,
+            "packages/a/src/nspkg/registry.py": CALLER.format(pkg="nspkg"),
+        },
+    )
+    assert _has(calls, "nspkg.registry.use", "nspkg.impls._handler")
+
+
+def test_same_named_packages_disambiguate_by_submodule(tmp_path: Path) -> None:
+    # (H) Two source roots each expose a top-level `common`, with different
+    # (H) submodules. The import of common.only_in_a must bind to package a's copy.
+    calls = _run_calls(
+        tmp_path,
+        {
+            "packages/a/src/common/__init__.py": "",
+            "packages/a/src/common/only_in_a.py": IMPL,
+            "packages/b/src/common/__init__.py": "",
+            "packages/b/src/common/only_in_b.py": IMPL,
+            "packages/b/src/app/__init__.py": "",
+            "packages/b/src/app/registry.py": (
+                "from common.only_in_a import _handler\n\n\n"
+                "def use(ctx):\n"
+                "    return _handler(ctx)\n"
+            ),
+        },
+    )
+    assert _has(calls, "app.registry.use", "a.src.common.only_in_a._handler")

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.196"
+version = "0.0.198"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

Fixes a whole class of dropped call/reference edges: Python absolute imports from packages under **nested source roots** (src-layout, monorepo `packages/*/src/*`, setuptools `package-dir` remaps, PEP 420 namespace packages) were misclassified as external imports, and the resolver then deliberately suppressed the fallback for them, so every cross-module edge through such an import silently vanished.

## Root cause (verified in code)

- `_is_local_module` (`import_processor.py`) judged an import first-party only if the top-level name exists **directly at the repo root**, so `import pkg...` with `pkg` at `packages/a/src/pkg/` was judged external.
- `_resolve_import_full_name` then left the target unprefixed.
- `_is_external_import` (`call_resolver.py`) checks `{project}.{target}` against the registry; the node is registered under the path-based QN (`packages.a.src.pkg...`), so the lookup misses, the import is confirmed "external", and the anti-rebind guard suppresses the trie fallback. Result: no edge at all.

Rust already gets crate-root detection and JS/TS gets tsconfig `paths`/`baseUrl` mapping; Python was the language missing source-root awareness.

Real-world impact: in a src-layout monorepo, `cgr dead-code` flagged every task handler registered through an absolute-import dispatch dict (`handlers = {"name": _impl}`) because the dict's reference edges were dropped.

## How

New `parsers/python_source_roots.py`:
- `discover_python_source_roots(repo_path)`: one repo walk (pruned by `IGNORE_PATTERNS`) mapping each importable top-level name to the dotted repo-relative directory holding it, from three signals: a package whose parent is not a package, children of a `src/` directory (namespace packages and single modules), and `pyproject.toml` `[tool.setuptools.package-dir]` remaps.
- `resolve_via_source_roots(...)`: translates `pkg.sub` to `packages.a.src.pkg.sub`; same-named roots are disambiguated by which candidate actually contains the imported submodule on disk.

`ImportProcessor._resolve_import_full_name` consults the map (lru-cached) after the existing root-level check, so flat-layout behavior is unchanged. No resolver changes needed: once the import target is the path-based QN, the existing registry lookups and the external-import guard pass naturally.

## Tests (RED to GREEN): full layout matrix

`test_python_source_root_imports.py`:
1. flat layout, absolute import (regression, passed before the change)
2. src-layout, absolute import
3. src-layout, module-level dispatch-dict value (the dead-code trigger shape)
4. monorepo, cross-package absolute import between two src roots
5. `package-dir` remap via pyproject.toml (import name != directory name)
6. PEP 420 namespace package under src (no `__init__.py`)
7. two same-named top-level packages disambiguated by submodule existence

Full suite: 4345 passed, 14 skipped.
