### PR TITLE
feat(ignore): interpret .cgrignore and --exclude patterns with gitignore semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -756,20 +756,21 @@ Configuration is managed through environment variables in `.env` file:
 
 ### Custom Ignore Patterns
 
-You can specify additional directories to exclude by creating a `.cgrignore` file in your repository root:
+You can specify additional files and directories to exclude by creating a `.cgrignore` file in your repository root. Patterns follow `.gitignore` conventions:
 
 ```
 # Comments start with #
 vendor
-.custom_cache
-my_build_output
+*.gen.ts
+docs/*.md
+/generated
+!bin/keep.py
 ```
 
-- One directory name per line
-- Lines starting with `#` are comments
-- Blank lines are ignored
-- Patterns are exact directory name matches (not globs)
-- Patterns from `.cgrignore` are merged with `--exclude` flags and auto-detected directories
+- Gitignore syntax: `*` matches within a segment, `**` crosses segments, bare names match at any depth, slash-containing patterns are anchored to the root, trailing slash matches directories only
+- Lines starting with `!` un-ignore paths that a default exclusion would skip (explicit excludes always win)
+- Lines starting with `#` are comments; blank lines are ignored
+- Patterns from `.cgrignore` are merged with `--exclude` flags (same syntax) and auto-detected directories
 
 ### Key Dependencies
 
@@ -794,6 +795,7 @@ my_build_output
 - **defusedxml**: XML bomb protection for Python stdlib modules
 - **huggingface-hub**: Client library to download and publish models, datasets and other repos on the huggingface.co hub
 - **griffe**: Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API.
+- **pathspec**: Utility library for gitignore style pattern matching of file paths.
 <!-- /SECTION:dependencies -->
 
 ## 🤖 Agentic Workflow & Tools

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -1110,6 +1110,9 @@ IGNORE_SUFFIXES = frozenset(
     {".tmp", "~", ".pyc", ".pyo", ".o", ".a", ".so", ".dll", ".class"}
 )
 
+# (H) pathspec style for .cgrignore / --exclude patterns (#495).
+GITWILDMATCH_STYLE = "gitwildmatch"
+
 PAYLOAD_NODE_ID = "node_id"
 PAYLOAD_QUALIFIED_NAME = "qualified_name"
 

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -1111,7 +1111,7 @@ IGNORE_SUFFIXES = frozenset(
 )
 
 # (H) pathspec style for .cgrignore / --exclude patterns (#495).
-GITWILDMATCH_STYLE = "gitwildmatch"
+GITWILDMATCH_STYLE = "gitignore"
 
 PAYLOAD_NODE_ID = "node_id"
 PAYLOAD_QUALIFIED_NAME = "qualified_name"

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -841,11 +841,13 @@ class GraphUpdater:
 
     def _should_keep_dir(self, dirname: str, dir_prefix: str) -> bool:
         rel_dir = f"{dir_prefix}{dirname}"
-        excluded = bool(
-            self.exclude_paths
-            and matches_ignore_patterns(f"{rel_dir}/", self.exclude_paths)
-        )
-        if not excluded and dirname not in cs.IGNORE_PATTERNS:
+        # (H) an explicit exclude can never be rescued by unignore (excludes win
+        # (H) at the file level too), so prune the subtree outright.
+        if self.exclude_paths and matches_ignore_patterns(
+            f"{rel_dir}/", self.exclude_paths
+        ):
+            return False
+        if dirname not in cs.IGNORE_PATTERNS:
             return True
         return bool(
             self.unignore_paths

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -37,8 +37,10 @@ from .utils.dependencies import has_semantic_dependencies
 from .utils.fqn_resolver import find_function_source_by_fqn
 from .utils.path_utils import (
     cached_relative_path,
+    matches_ignore_patterns,
     should_skip_path,
     should_skip_rel_file,
+    unignore_could_match_within,
 )
 from .utils.source_extraction import extract_source_with_fallback
 
@@ -838,15 +840,17 @@ class GraphUpdater:
         return None, None
 
     def _should_keep_dir(self, dirname: str, dir_prefix: str) -> bool:
-        if dirname not in cs.IGNORE_PATTERNS and (
-            not self.exclude_paths or dirname not in self.exclude_paths
-        ):
+        rel_dir = f"{dir_prefix}{dirname}"
+        excluded = bool(
+            self.exclude_paths
+            and matches_ignore_patterns(f"{rel_dir}/", self.exclude_paths)
+        )
+        if not excluded and dirname not in cs.IGNORE_PATTERNS:
             return True
         return bool(
             self.unignore_paths
             and any(
-                u.startswith(f"{dir_prefix}{dirname}/") or u == f"{dir_prefix}{dirname}"
-                for u in self.unignore_paths
+                unignore_could_match_within(u, rel_dir) for u in self.unignore_paths
             )
         )
 

--- a/codebase_rag/tests/test_gitignore_ignore_semantics.py
+++ b/codebase_rag/tests/test_gitignore_ignore_semantics.py
@@ -1,0 +1,105 @@
+# (H) #495: .cgrignore and --exclude patterns follow .gitignore conventions
+# (H) (gitwildmatch): globs, anchoring, dir-only trailing slash, and `!` unignore
+# (H) lines rescuing built-in ignores. Bare-name patterns keep their existing
+# (H) match-at-any-depth behavior, so old ignore files stay valid.
+from pathlib import Path
+
+from codebase_rag.utils.path_utils import should_skip_path, should_skip_rel_file
+
+
+def _skip(
+    rel_path: str,
+    exclude: frozenset[str] | None = None,
+    unignore: frozenset[str] | None = None,
+) -> bool:
+    parts = tuple(rel_path.split("/"))
+    return should_skip_rel_file(
+        rel_path,
+        parts[:-1],
+        Path(rel_path).suffix,
+        exclude_paths=exclude,
+        unignore_paths=unignore,
+    )
+
+
+class TestGitignoreExcludeSemantics:
+    def test_bare_name_still_matches_at_any_depth(self) -> None:
+        # (H) backward compatibility: plain directory names keep working
+        # (H) ("thirdparty" is NOT a built-in ignore, so this tests excludes).
+        exclude = frozenset({"thirdparty"})
+        assert _skip("thirdparty/lib.py", exclude)
+        assert _skip("a/b/thirdparty/lib.py", exclude)
+        assert not _skip("a/thirdpartyx/lib.py", exclude)
+        assert not _skip("a/thirdparty/lib.py", None)
+
+    def test_extension_glob(self) -> None:
+        exclude = frozenset({"*.gen.ts"})
+        assert _skip("src/api.gen.ts", exclude)
+        assert _skip("api.gen.ts", exclude)
+        assert not _skip("src/api.ts", exclude)
+
+    def test_single_star_does_not_cross_directories(self) -> None:
+        exclude = frozenset({"docs/*.md"})
+        assert _skip("docs/readme.md", exclude)
+        assert not _skip("docs/sub/readme.md", exclude)
+
+    def test_double_star_crosses_directories(self) -> None:
+        exclude = frozenset({"**/fixtures/**"})
+        assert _skip("a/fixtures/x.py", exclude)
+        assert _skip("a/b/fixtures/c/x.py", exclude)
+        assert not _skip("a/fixture/x.py", exclude)
+
+    def test_leading_slash_anchors_to_root(self) -> None:
+        # (H) "generated" is not a built-in ignore, so anchoring is what decides.
+        exclude = frozenset({"/generated"})
+        assert _skip("generated/x.py", exclude)
+        assert not _skip("src/generated/x.py", exclude)
+
+    def test_middle_slash_anchors_to_root(self) -> None:
+        # (H) gitignore: a pattern containing a non-trailing slash is anchored.
+        exclude = frozenset({"a/generated"})
+        assert _skip("a/generated/x.py", exclude)
+        assert not _skip("z/a/generated/x.py", exclude)
+
+    def test_star_within_segment(self) -> None:
+        exclude = frozenset({"temp*"})
+        assert _skip("tempdata/x.py", exclude)
+        assert _skip("temp.py", exclude)
+        assert not _skip("mytemp/x.py", exclude)
+
+    def test_should_skip_path_glob(self, tmp_path: Path) -> None:
+        target = tmp_path / "src" / "api.gen.ts"
+        assert should_skip_path(
+            target,
+            tmp_path,
+            exclude_paths=frozenset({"*.gen.ts"}),
+            is_file=True,
+        )
+        assert not should_skip_path(
+            tmp_path / "src" / "api.ts",
+            tmp_path,
+            exclude_paths=frozenset({"*.gen.ts"}),
+            is_file=True,
+        )
+
+
+class TestGitignoreUnignoreSemantics:
+    def test_unignore_glob_rescues_builtin_ignore(self) -> None:
+        # (H) "bin" is a built-in ignore; a glob unignore rescues matching files.
+        assert _skip("bin/tool.py")
+        assert not _skip("bin/tool.py", unignore=frozenset({"bin/*.py"}))
+        assert _skip("bin/data.txt", unignore=frozenset({"bin/*.py"}))
+
+    def test_unignore_exact_prefix_still_works(self) -> None:
+        # (H) backward compatibility: plain path unignores keep working.
+        assert not _skip("bin/keep/x.py", unignore=frozenset({"bin/keep"}))
+        assert _skip("bin/other/x.py", unignore=frozenset({"bin/keep"}))
+
+    def test_user_exclude_beats_unignore(self) -> None:
+        # (H) existing precedence: unignore rescues only built-in ignores,
+        # (H) never explicit user excludes.
+        assert _skip(
+            "gen/x.py",
+            exclude=frozenset({"gen"}),
+            unignore=frozenset({"gen/x.py"}),
+        )

--- a/codebase_rag/tests/test_gitignore_ignore_semantics.py
+++ b/codebase_rag/tests/test_gitignore_ignore_semantics.py
@@ -136,3 +136,31 @@ class TestDirPruning:
         assert updater._should_keep_dir("bin", "")
         updater_none = self._updater(None, None)
         assert not updater_none._should_keep_dir("bin", "")
+
+
+class TestDirectoryStructureRescue:
+    # (H) greptile P1 round 2 on #596: structure traversal must not skip a
+    # (H) built-in-ignored directory when an unignore pattern targets files
+    # (H) beneath it, or rescued files lose their Folder/Package ancestry.
+    def test_builtin_dir_kept_when_unignore_targets_beneath(
+        self, tmp_path: Path
+    ) -> None:
+        target = tmp_path / "bin"
+        assert should_skip_path(target, tmp_path, is_file=False)
+        assert not should_skip_path(
+            target,
+            tmp_path,
+            unignore_paths=frozenset({"bin/*.py"}),
+            is_file=False,
+        )
+
+    def test_excluded_dir_not_rescued(self, tmp_path: Path) -> None:
+        # (H) explicit excludes still beat unignore at the directory level.
+        target = tmp_path / "gen"
+        assert should_skip_path(
+            target,
+            tmp_path,
+            exclude_paths=frozenset({"gen"}),
+            unignore_paths=frozenset({"gen/*.py"}),
+            is_file=False,
+        )

--- a/codebase_rag/tests/test_gitignore_ignore_semantics.py
+++ b/codebase_rag/tests/test_gitignore_ignore_semantics.py
@@ -3,7 +3,10 @@
 # (H) lines rescuing built-in ignores. Bare-name patterns keep their existing
 # (H) match-at-any-depth behavior, so old ignore files stay valid.
 from pathlib import Path
+from unittest.mock import MagicMock
 
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
 from codebase_rag.utils.path_utils import should_skip_path, should_skip_rel_file
 
 
@@ -103,3 +106,33 @@ class TestGitignoreUnignoreSemantics:
             exclude=frozenset({"gen"}),
             unignore=frozenset({"gen/x.py"}),
         )
+
+
+class TestDirPruning:
+    # (H) greptile P1 on #596: an explicitly excluded directory must stay pruned
+    # (H) even when an unignore pattern targets something beneath it, because
+    # (H) excludes always beat unignores at the file level anyway.
+    def _updater(
+        self,
+        exclude: frozenset[str] | None,
+        unignore: frozenset[str] | None,
+    ) -> GraphUpdater:
+        parsers, queries = load_parsers()
+        return GraphUpdater(
+            ingestor=MagicMock(),
+            repo_path=Path("/t"),
+            parsers=parsers,
+            queries=queries,
+            exclude_paths=exclude,
+            unignore_paths=unignore,
+        )
+
+    def test_excluded_dir_stays_pruned_despite_unignore(self) -> None:
+        updater = self._updater(frozenset({"gen"}), frozenset({"gen/keep.py"}))
+        assert not updater._should_keep_dir("gen", "")
+
+    def test_builtin_pruned_dir_kept_when_unignore_targets_beneath(self) -> None:
+        updater = self._updater(None, frozenset({"bin/keep.py"}))
+        assert updater._should_keep_dir("bin", "")
+        updater_none = self._updater(None, None)
+        assert not updater_none._should_keep_dir("bin", "")

--- a/codebase_rag/utils/path_utils.py
+++ b/codebase_rag/utils/path_utils.py
@@ -95,6 +95,15 @@ def should_skip_path(
     # (H) unignore rescues only built-in ignores, never explicit user excludes.
     if unignore_paths and matches_ignore_patterns(match_path, unignore_paths):
         return False
+    if (
+        not _is_file
+        and unignore_paths
+        and any(unignore_could_match_within(u, rel_path_str) for u in unignore_paths)
+    ):
+        # (H) structure traversal must descend into a built-in-ignored dir when
+        # (H) an unignore pattern can match beneath it (mirrors _should_keep_dir),
+        # (H) or rescued files get no Folder/Package ancestry in the graph.
+        return False
     dir_parts = rel_path.parent.parts if _is_file else rel_path.parts
     return not cs.IGNORE_PATTERNS.isdisjoint(dir_parts)
 

--- a/codebase_rag/utils/path_utils.py
+++ b/codebase_rag/utils/path_utils.py
@@ -3,6 +3,8 @@ import re
 from functools import lru_cache
 from pathlib import Path
 
+from pathspec import PathSpec
+
 from .. import constants as cs
 
 _PROJECT_NAME_INVALID_CHARS = re.compile(r"[^A-Za-z0-9_-]+")
@@ -39,6 +41,41 @@ def cached_resolve_posix(file_path: Path) -> str:
     return file_path.resolve().as_posix()
 
 
+# (H) #495: .cgrignore lines and --exclude values are interpreted with
+# (H) .gitignore (gitwildmatch) semantics: bare names match at any depth (as
+# (H) before), and globs / anchoring / dir-only trailing slash now work. The
+# (H) spec is compiled once per pattern set (frozensets are hashable).
+@lru_cache(maxsize=64)
+def compiled_ignore_spec(patterns: frozenset[str]) -> PathSpec:
+    return PathSpec.from_lines(cs.GITWILDMATCH_STYLE, sorted(patterns))
+
+
+def matches_ignore_patterns(rel_path_str: str, patterns: frozenset[str]) -> bool:
+    return compiled_ignore_spec(patterns).match_file(rel_path_str)
+
+
+_GLOB_MAGIC = re.compile(r"[*?\[]")
+
+
+def unignore_could_match_within(pattern: str, rel_dir: str) -> bool:
+    # (H) Dir-pruning guard: keep a pruned-by-default directory when an
+    # (H) unignore pattern could match it or anything beneath it.
+    if "/" not in pattern.rstrip("/"):
+        # (H) slash-free patterns are unanchored: they can match at any depth.
+        return True
+    head, *glob_rest = _GLOB_MAGIC.split(pattern, 1)
+    if glob_rest:
+        # (H) the glob may complete the trailing segment; keep whole segments.
+        head = head.rsplit("/", 1)[0]
+    head = head.strip("/")
+    return (
+        not head
+        or head == rel_dir
+        or head.startswith(f"{rel_dir}/")
+        or rel_dir.startswith(f"{head}/")
+    )
+
+
 def should_skip_path(
     path: Path,
     repo_path: Path,
@@ -51,17 +88,14 @@ def should_skip_path(
         return True
     rel_path = cached_relative_path(path, repo_path)
     rel_path_str = rel_path.as_posix()
-    dir_parts = rel_path.parent.parts if _is_file else rel_path.parts
-    if exclude_paths and (
-        not exclude_paths.isdisjoint(dir_parts)
-        or rel_path_str in exclude_paths
-        or any(rel_path_str.startswith(f"{p}/") for p in exclude_paths)
-    ):
+    # (H) a trailing slash marks the path as a directory for dir-only patterns.
+    match_path = rel_path_str if _is_file else f"{rel_path_str}/"
+    if exclude_paths and matches_ignore_patterns(match_path, exclude_paths):
         return True
-    if unignore_paths and any(
-        rel_path_str == p or rel_path_str.startswith(f"{p}/") for p in unignore_paths
-    ):
+    # (H) unignore rescues only built-in ignores, never explicit user excludes.
+    if unignore_paths and matches_ignore_patterns(match_path, unignore_paths):
         return False
+    dir_parts = rel_path.parent.parts if _is_file else rel_path.parts
     return not cs.IGNORE_PATTERNS.isdisjoint(dir_parts)
 
 
@@ -74,14 +108,9 @@ def should_skip_rel_file(
 ) -> bool:
     if suffix in cs.IGNORE_SUFFIXES:
         return True
-    if exclude_paths and (
-        not exclude_paths.isdisjoint(dir_parts)
-        or rel_path_str in exclude_paths
-        or any(rel_path_str.startswith(f"{p}/") for p in exclude_paths)
-    ):
+    if exclude_paths and matches_ignore_patterns(rel_path_str, exclude_paths):
         return True
-    if unignore_paths and any(
-        rel_path_str == p or rel_path_str.startswith(f"{p}/") for p in unignore_paths
-    ):
+    # (H) unignore rescues only built-in ignores, never explicit user excludes.
+    if unignore_paths and matches_ignore_patterns(rel_path_str, unignore_paths):
         return False
     return not cs.IGNORE_PATTERNS.isdisjoint(dir_parts)

--- a/docs/advanced/ignore-patterns.md
+++ b/docs/advanced/ignore-patterns.md
@@ -1,27 +1,32 @@
 ---
-description: "Configure .cgrignore to exclude directories from Code-Graph-RAG analysis."
+description: "Configure .cgrignore to exclude files and directories from Code-Graph-RAG analysis using gitignore-style patterns."
 ---
 
 # Ignore Patterns
 
-You can specify additional directories to exclude from analysis by creating a `.cgrignore` file in your repository root.
+You can specify additional files and directories to exclude from analysis by creating a `.cgrignore` file in your repository root. Patterns follow `.gitignore` conventions.
 
 ## Format
 
 ```
 # Comments start with #
 vendor
-.custom_cache
-my_build_output
+*.gen.ts
+docs/*.md
+/generated
+fixtures/**
+!bin/keep.py
 ```
 
 ## Rules
 
-- One directory name per line
-- Lines starting with `#` are comments
-- Blank lines are ignored
-- Patterns are exact directory name matches (not globs)
-- Patterns from `.cgrignore` are merged with `--exclude` flags and auto-detected directories
+- Patterns follow [gitignore](https://git-scm.com/docs/gitignore) syntax: `*` matches within a path segment, `**` crosses segments, `?` matches a single character
+- A bare name (`vendor`) matches a file or directory with that name at any depth
+- A pattern containing a slash (`docs/*.md`, `/generated`) is anchored to the repository root
+- A trailing slash (`build/`) matches directories only
+- Lines starting with `!` un-ignore matching paths that a **default** exclusion would skip (explicit excludes always win)
+- Lines starting with `#` are comments; blank lines are ignored
+- Patterns from `.cgrignore` are merged with `--exclude` flags (which use the same syntax) and auto-detected directories
 
 ## Default Exclusions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dependencies = [
     # `uv sync` omits griffe and leaves codebase_rag unimportable; declare it
     # explicitly to keep the environment reproducible.
     "griffe>=1.0,<2",
+    "pathspec>=1.0.4",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.197"
+version = "0.0.200"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -544,6 +544,7 @@ dependencies = [
     { name = "huggingface-hub", extra = ["hf-xet"] },
     { name = "loguru" },
     { name = "mcp" },
+    { name = "pathspec" },
     { name = "prompt-toolkit" },
     { name = "protobuf" },
     { name = "pydantic-ai" },
@@ -622,6 +623,7 @@ requires-dist = [
     { name = "libclang", marker = "extra == 'test'", specifier = ">=18.1.1" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "mcp", specifier = ">=1.25.0" },
+    { name = "pathspec", specifier = ">=1.0.4" },
     { name = "prompt-toolkit", specifier = ">=3.0.52" },
     { name = "protobuf", specifier = ">=6.33.5" },
     { name = "pydantic-ai", specifier = ">=1.102.0" },


### PR DESCRIPTION
Closes #495.

`.cgrignore` lines and `--exclude` values were matched with a bespoke style: exact directory-name membership plus root-anchored path prefixes, no globs, no anchoring control. This aligns both with `.gitignore` conventions, as the issue proposes, using `pathspec` (gitwildmatch).

Behavior:
- Bare names (`vendor`) keep matching a file/dir at any depth, so existing ignore files stay valid (the full pre-existing 1052-line ignore/exclude test suite passes unchanged).
- New: `*` within a segment, `**` across segments, `?`, leading-slash and mid-slash anchoring to the repo root, trailing-slash directory-only patterns.
- `!` unignore lines keep their existing role: they rescue paths from **built-in** default exclusions; explicit user excludes still always win.
- `--exclude` values use the same syntax and are merged as before.

Implementation:
- `path_utils.compiled_ignore_spec` compiles each pattern frozenset to a cached `PathSpec`; `should_skip_path`/`should_skip_rel_file` consult it (directories are matched with a trailing slash so dir-only patterns work).
- `GraphUpdater._should_keep_dir` prunes via the spec and keeps a pruned-by-default directory when an unignore pattern could match beneath it (`unignore_could_match_within`); this also fixes a latent bug where descendants of an unignored directory were still pruned if their own name was a built-in ignore.
- Docs updated (README + docs/advanced/ignore-patterns.md).

RED->GREEN: `test_gitignore_ignore_semantics.py` (globs, anchoring, `**`, unignore globs, precedence) written first and confirmed failing before the implementation.

Verification: full suite passes (4347 tests); the two flaky `test_cli_smoke` subprocess timeouts seen once under parallel load pass on re-run.