### PR TITLE
fix(java): resolve imported class qn for flat-layout cross-package calls

### DIFF
--- a/codebase_rag/parsers/java/method_resolver.py
+++ b/codebase_rag/parsers/java/method_resolver.py
@@ -38,6 +38,9 @@ class JavaMethodResolverMixin:
     def _resolve_java_type_name(self, type_name: str, module_qn: str) -> str: ...
 
     @abstractmethod
+    def _imported_class_qn(self, target: str, type_name: str) -> str: ...
+
+    @abstractmethod
     def _rank_module_candidates(
         self, candidates: list[str], class_qn: str, current_module_qn: str | None
     ) -> list[str]: ...
@@ -109,7 +112,7 @@ class JavaMethodResolverMixin:
         if module_qn in self.import_processor.import_mapping:
             import_map = self.import_processor.import_mapping[module_qn]
             if object_ref in import_map:
-                return import_map[object_ref]
+                return self._imported_class_qn(import_map[object_ref], object_ref)
 
         simple_class_qn = f"{module_qn}{cs.SEPARATOR_DOT}{object_ref}"
         if (

--- a/codebase_rag/parsers/java/type_resolver.py
+++ b/codebase_rag/parsers/java/type_resolver.py
@@ -101,6 +101,27 @@ class JavaTypeResolverMixin:
 
         return []
 
+    def _imported_class_qn(self, target: str, type_name: str) -> str:
+        # (H) A LOCAL Java import is recorded as the imported file's MODULE qn
+        # (H) (repo.com.foo.util.Helper), but the registered class qn duplicates the
+        # (H) class segment (repo.com.foo.util.Helper.Helper); the raw target then
+        # (H) dead-ends because the project prefix also disables the fqn-map
+        # (H) fallback. Append the imported simple name when THAT is the registered
+        # (H) class. Registry-guarded, so targets that are already class qns and
+        # (H) external fqns pass through unchanged.
+        if target in self.function_registry and self.function_registry[target] in (
+            NodeType.CLASS,
+            NodeType.INTERFACE,
+        ):
+            return target
+        class_qn = f"{target}{cs.SEPARATOR_DOT}{type_name}"
+        if class_qn in self.function_registry and self.function_registry[class_qn] in (
+            NodeType.CLASS,
+            NodeType.INTERFACE,
+        ):
+            return class_qn
+        return target
+
     def _resolve_java_type_name(self, type_name: str, module_qn: str) -> str:
         if not type_name:
             return cs.JAVA_TYPE_OBJECT
@@ -126,7 +147,7 @@ class JavaTypeResolverMixin:
         if module_qn in self.import_processor.import_mapping:
             import_map = self.import_processor.import_mapping[module_qn]
             if type_name in import_map:
-                return import_map[type_name]
+                return self._imported_class_qn(import_map[type_name], type_name)
 
         same_package_qn = f"{module_qn}{cs.SEPARATOR_DOT}{type_name}"
         if same_package_qn in self.function_registry and self.function_registry[

--- a/codebase_rag/parsers/java/type_resolver.py
+++ b/codebase_rag/parsers/java/type_resolver.py
@@ -18,6 +18,10 @@ if TYPE_CHECKING:
     from ...types_defs import ASTCacheProtocol, FunctionRegistryTrieProtocol
     from ..import_processor import ImportProcessor
 
+# (H) Node types an imported Java name can declare (records and annotation types
+# (H) register as CLASS).
+_JAVA_TYPE_DECL_NODE_TYPES = (NodeType.CLASS, NodeType.INTERFACE, NodeType.ENUM)
+
 
 class JavaTypeResolverMixin:
     __slots__ = ()
@@ -109,15 +113,15 @@ class JavaTypeResolverMixin:
         # (H) fallback. Append the imported simple name when THAT is the registered
         # (H) class. Registry-guarded, so targets that are already class qns and
         # (H) external fqns pass through unchanged.
-        if target in self.function_registry and self.function_registry[target] in (
-            NodeType.CLASS,
-            NodeType.INTERFACE,
+        if (
+            target in self.function_registry
+            and self.function_registry[target] in _JAVA_TYPE_DECL_NODE_TYPES
         ):
             return target
         class_qn = f"{target}{cs.SEPARATOR_DOT}{type_name}"
-        if class_qn in self.function_registry and self.function_registry[class_qn] in (
-            NodeType.CLASS,
-            NodeType.INTERFACE,
+        if (
+            class_qn in self.function_registry
+            and self.function_registry[class_qn] in _JAVA_TYPE_DECL_NODE_TYPES
         ):
             return class_qn
         return target

--- a/codebase_rag/tests/test_java_source_layout_calls.py
+++ b/codebase_rag/tests/test_java_source_layout_calls.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+HELPER = (
+    "package com.foo.util;\n\n"
+    "public class Helper {\n"
+    "    public static int help() { return 1; }\n"
+    "    public int inst() { return 2; }\n"
+    "}\n"
+)
+MAIN = (
+    "package com.foo.app;\n\n"
+    "import com.foo.util.Helper;\n\n"
+    "public class Main {\n"
+    "    public int run() { return Helper.help(); }\n"
+    "    public int runInst() { Helper h = new Helper(); return h.inst(); }\n"
+    "}\n"
+)
+
+
+def _run_calls(tmp_path: Path, files: dict[str, str]) -> set[tuple[str, str]]:
+    # (H) Build the graph for `files` (repo-relative paths) and return CALLS edges.
+    parsers, queries = load_parsers()
+    if "java" not in parsers:
+        pytest.skip("java parser not available")
+    for rel, content in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name="repo",
+    ).run()
+    out: set[tuple[str, str]] = set()
+    for c in mock.ensure_relationship_batch.call_args_list:
+        if c.args[1] == "CALLS":
+            out.add((c.args[0][2], c.args[2][2]))
+    return out
+
+
+def _has(calls: set[tuple[str, str]], caller_suffix: str, callee_suffix: str) -> bool:
+    return any(
+        a.endswith(caller_suffix) and b.endswith(callee_suffix) for a, b in calls
+    )
+
+
+def test_flat_layout_static_call(tmp_path: Path) -> None:
+    # (H) Package dirs at the repo root: the import is judged local and resolves to
+    # (H) the MODULE qn (…util.Helper) instead of the class qn (…util.Helper.Helper),
+    # (H) so the method search misses and the cross-package call is dropped.
+    calls = _run_calls(
+        tmp_path,
+        {
+            "com/foo/util/Helper.java": HELPER,
+            "com/foo/app/Main.java": MAIN,
+        },
+    )
+    assert _has(calls, "app.Main.Main.run()", "util.Helper.Helper.help()")
+
+
+def test_flat_layout_instance_call(tmp_path: Path) -> None:
+    # (H) Same flat-layout failure through the declared-variable type path.
+    calls = _run_calls(
+        tmp_path,
+        {
+            "com/foo/util/Helper.java": HELPER,
+            "com/foo/app/Main.java": MAIN,
+        },
+    )
+    assert _has(calls, "app.Main.Main.runInst()", "util.Helper.Helper.inst()")
+
+
+def test_maven_layout_calls(tmp_path: Path) -> None:
+    # (H) Regression: the standard src/main/java layout already resolves.
+    calls = _run_calls(
+        tmp_path,
+        {
+            "src/main/java/com/foo/util/Helper.java": HELPER,
+            "src/main/java/com/foo/app/Main.java": MAIN,
+        },
+    )
+    assert _has(calls, "app.Main.Main.run()", "util.Helper.Helper.help()")
+    assert _has(calls, "app.Main.Main.runInst()", "util.Helper.Helper.inst()")
+
+
+def test_nested_unmarked_root_calls(tmp_path: Path) -> None:
+    # (H) Regression: a package root nested under an unmarked directory (lib/).
+    calls = _run_calls(
+        tmp_path,
+        {
+            "lib/com/foo/util/Helper.java": HELPER,
+            "lib/com/foo/app/Main.java": MAIN,
+        },
+    )
+    assert _has(calls, "app.Main.Main.run()", "util.Helper.Helper.help()")
+
+
+def test_gradle_multimodule_calls(tmp_path: Path) -> None:
+    # (H) Regression: cross-module call between two Gradle-style modules.
+    calls = _run_calls(
+        tmp_path,
+        {
+            "svc-a/src/main/java/com/foo/util/Helper.java": HELPER,
+            "svc-b/src/main/java/com/foo/app/Main.java": MAIN,
+        },
+    )
+    assert _has(calls, "app.Main.Main.run()", "util.Helper.Helper.help()")
+    assert _has(calls, "app.Main.Main.runInst()", "util.Helper.Helper.inst()")

--- a/codebase_rag/tests/test_java_source_layout_calls.py
+++ b/codebase_rag/tests/test_java_source_layout_calls.py
@@ -117,3 +117,33 @@ def test_gradle_multimodule_calls(tmp_path: Path) -> None:
     )
     assert _has(calls, "app.Main.Main.run()", "util.Helper.Helper.help()")
     assert _has(calls, "app.Main.Main.runInst()", "util.Helper.Helper.inst()")
+
+
+ENUM_SRC = (
+    "package com.foo.util;\n\n"
+    "public enum Mode {\n"
+    "    FAST, SLOW;\n"
+    "    public static Mode parse() { return FAST; }\n"
+    "}\n"
+)
+ENUM_MAIN = (
+    "package com.foo.app;\n\n"
+    "import com.foo.util.Mode;\n\n"
+    "public class EnumMain {\n"
+    "    public Mode pick() { return Mode.parse(); }\n"
+    "}\n"
+)
+
+
+def test_flat_layout_enum_static_call(tmp_path: Path) -> None:
+    # (H) An imported enum's static method: enums register as NodeType.ENUM, so the
+    # (H) imported-class normalization must accept them, or the flat-layout call is
+    # (H) still dropped.
+    calls = _run_calls(
+        tmp_path,
+        {
+            "com/foo/util/Mode.java": ENUM_SRC,
+            "com/foo/app/EnumMain.java": ENUM_MAIN,
+        },
+    )
+    assert _has(calls, "app.EnumMain.EnumMain.pick()", "util.Mode.Mode.parse()")

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.200"
+version = "0.0.201"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

Fixes dropped Java cross-package call edges in FLAT layouts (package directories at the repo root, e.g. `com/foo/...`). Both static (`Helper.help()`) and instance (`h.inst()`) calls through an `import com.foo.util.Helper;` produced no CALLS edge.

## Root cause

A local Java import is recorded in the import map as the imported FILE's module qn (`repo.com.foo.util.Helper`), but the registered class qn duplicates the class segment (`repo.com.foo.util.Helper.Helper`). The raw target then dead-ends: `_search_method_in_class` finds no member under the module qn, and because the target carries the project prefix, `_find_method_with_any_signature` skips the layout-independent fqn-map fallback (it is gated to non-project-prefixed types).

The irony: Maven/Gradle layouts work only by accident. There the import is misclassified as external (the locality check `_is_local_java_import` only looks at the repo root), which leaves the target unprefixed and routes it to the fqn-map fallback that resolves by package-suffix. Flat layout is the one case classified correctly, and it was the one that broke.

## How

New registry-guarded `_imported_class_qn(target, type_name)` in the Java type resolver: when the import-map target is not itself a registered Class/Interface but `target.{type_name}` is, return the class qn. Applied at both import-map consumption sites (`_resolve_java_type_name` for declared-variable types and `_resolve_java_object_type` for static receivers). Targets that are already class qns, nested-class imports, and external fqns pass through unchanged.

## Tests (RED to GREEN): Java layout matrix

`test_java_source_layout_calls.py`:
1. flat layout, static call (RED before)
2. flat layout, instance call via declared variable (RED before)
3. Maven `src/main/java` (regression)
4. package root nested under an unmarked directory (`lib/com/...`) (regression)
5. Gradle multi-module cross-module call (regression)

Full suite: 4355 passed, 14 skipped.
