### PR TITLE
feat(graph): REFERENCES edges keep first-class function values reachable

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -553,6 +553,7 @@ class RelationshipType(StrEnum):
     IMPLEMENTS = "IMPLEMENTS"
     OVERRIDES = "OVERRIDES"
     CALLS = "CALLS"
+    REFERENCES = "REFERENCES"
     INSTANTIATES = "INSTANTIATES"
     DEPENDS_ON_EXTERNAL = "DEPENDS_ON_EXTERNAL"
 
@@ -1167,7 +1168,7 @@ CYPHER_ALL_DEFINITION_QNS = (
 # (H) cgr's call resolution is context-sensitive (protocol vs concrete receiver,
 # (H) import granularity); the original edges already match a clean re-index.
 CYPHER_INBOUND_EDGES = (
-    "MATCH (caller)-[r:CALLS|INSTANTIATES|IMPORTS|INHERITS|OVERRIDES]->(target) "
+    "MATCH (caller)-[r:CALLS|REFERENCES|INSTANTIATES|IMPORTS|INHERITS|OVERRIDES]->(target) "
     "WHERE target.path IN $paths AND caller.qualified_name IS NOT NULL "
     "AND (caller.path IS NULL OR NOT caller.path IN $paths) "
     "RETURN head(labels(caller)) AS caller_label, "

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -157,12 +157,12 @@ ORDER BY qualified_name"""
 def build_dead_code_query(include_tests: bool, include_classes: bool = False) -> str:
     if include_classes:
         labels = "Function|Method|Class"
-        traversal = "CALLS|INSTANTIATES|INHERITS"
-        module_rels = "CALLS|INSTANTIATES"
+        traversal = "CALLS|REFERENCES|INSTANTIATES|INHERITS"
+        module_rels = "CALLS|REFERENCES|INSTANTIATES"
     else:
         labels = "Function|Method"
-        traversal = "CALLS"
-        module_rels = "CALLS"
+        traversal = "CALLS|REFERENCES"
+        module_rels = "CALLS|REFERENCES"
     if include_tests:
         module_clause = _DEAD_CODE_MODULE_ROOT_ANY.format(module_rels=module_rels)
         test_clause = _DEAD_CODE_TEST_ROOT_CLAUSE

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1022,6 +1022,15 @@ class CallProcessor:
             self._ingest_operator_dispatch_calls(
                 caller_node, caller_spec, module_qn, local_var_types
             )
+            self._ingest_assignment_function_references(
+                caller_node,
+                caller_spec,
+                module_qn,
+                local_var_types,
+                class_context,
+                self._flow_scope_boundaries(queries[language][cs.QUERY_CONFIG]),
+                caller_qn,
+            )
         # (H) Dispatch-table handler references, for every flow language. Module-scope
         # (H) literals are scanned explicitly in process_calls_in_file (before the
         # (H) no-calls early return), so only nested scopes here.
@@ -1211,6 +1220,23 @@ class CallProcessor:
                     module_qn,
                     local_var_types,
                     class_context,
+                )
+                # (H) Functions are first-class values: a first-party callee may STORE
+                # (H) a passed callback for later dynamic dispatch (config objects,
+                # (H) codecs, registries), which callable-param flow cannot trace, or
+                # (H) the callee may even be a same-named misbind of an external
+                # (H) method. Record the pass itself as a REFERENCES edge from the
+                # (H) passing scope so the callback is never reported dead.
+                self._ingest_argument_function_references(
+                    call_node,
+                    caller_spec,
+                    module_qn,
+                    local_var_types,
+                    class_context,
+                    resolve_func,
+                    ensure_rel,
+                    caller_qn,
+                    cs.RelationshipType.REFERENCES,
                 )
 
             if is_python and (
@@ -1443,6 +1469,48 @@ class CallProcessor:
                     (callee_type, cs.KEY_QUALIFIED_NAME, target_qn),
                 )
         return True
+
+    def _ingest_assignment_function_references(
+        self,
+        caller_node: Node,
+        caller_spec: tuple[str, str, str],
+        module_qn: str,
+        local_var_types: dict[str, str] | None,
+        class_context: str | None,
+        boundary_types: frozenset[str],
+        caller_qn: str | None = None,
+    ) -> None:
+        # (H) `x = some_function` binds a first-class function value to a name; the
+        # (H) alias is then stored, passed onward, or returned for dynamic dispatch
+        # (H) (http_callback = llm_http_task_closure_with_context), so the assignment
+        # (H) itself references the function and must keep it reachable. Only a plain
+        # (H) name/attribute RHS counts (calls resolve as calls); the walk stops at
+        # (H) nested scope boundaries, which own their own pass.
+        resolve_func = self._resolver.resolve_function_call
+        ensure_rel = self.ingestor.ensure_relationship_batch
+        stack: list[Node] = list(caller_node.children)
+        while stack:
+            node = stack.pop()
+            if node.type in boundary_types:
+                continue
+            if node.type == cs.TS_PY_ASSIGNMENT:
+                right = node.child_by_field_name(cs.TS_FIELD_RIGHT)
+                if right is not None and right.type in (
+                    cs.TS_PY_IDENTIFIER,
+                    cs.TS_PY_ATTRIBUTE,
+                ):
+                    self._emit_callback_edge(
+                        caller_spec,
+                        right,
+                        module_qn,
+                        local_var_types,
+                        class_context,
+                        resolve_func,
+                        ensure_rel,
+                        caller_qn,
+                        cs.RelationshipType.REFERENCES,
+                    )
+            stack.extend(node.children)
 
     def _ingest_collection_function_references(
         self,
@@ -1743,6 +1811,7 @@ class CallProcessor:
         resolve_func,
         ensure_rel,
         caller_qn: str | None = None,
+        rel_type: cs.RelationshipType = cs.RelationshipType.CALLS,
     ) -> None:
         if not (arg_text := safe_decode_text(arg_node)):
             return
@@ -1763,7 +1832,7 @@ class CallProcessor:
         for target_qn in registry.variants(res_qn):
             ensure_rel(
                 source_spec,
-                cs.RelationshipType.CALLS,
+                rel_type,
                 (res_type, cs.KEY_QUALIFIED_NAME, target_qn),
             )
 
@@ -2010,10 +2079,15 @@ class CallProcessor:
         resolve_func,
         ensure_rel,
         caller_qn: str | None = None,
+        rel_type: cs.RelationshipType = cs.RelationshipType.CALLS,
     ) -> None:
-        # (H) For a call whose callee is not first-party, a function/method passed as
-        # (H) an argument is handed off to be invoked by that external callee; emit a
-        # (H) reference edge from the enclosing scope so it stays reachable.
+        # (H) A function/method passed as an argument is a first-class value the
+        # (H) callee may invoke (external framework) or store for later dynamic
+        # (H) dispatch (first-party plumbing); either way the passing scope holds a
+        # (H) live reference, so emit an edge to keep the callback reachable.
+        # (H) External/builtin callees keep the historical CALLS edge; first-party
+        # (H) callees record the pass as REFERENCES (the precise invocation edge, if
+        # (H) any, comes from callable-param flow).
         positional, keyword = self._parse_call_arguments(call_node)
         for arg_node in (*positional, *keyword.values()):
             self._emit_callback_edge(
@@ -2025,6 +2099,7 @@ class CallProcessor:
                 resolve_func,
                 ensure_rel,
                 caller_qn,
+                rel_type,
             )
 
     def _build_local_alias_map(

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -427,6 +427,17 @@ class CallProcessor:
                     self._flow_scope_boundaries(queries[language][cs.QUERY_CONFIG]),
                 )
             if language == cs.SupportedLanguage.PYTHON:
+                # (H) A module-scope first-class assignment (registry_handler =
+                # (H) handle_event) references its target even in a file with no
+                # (H) call expressions, so scan before the no-calls early return.
+                self._ingest_assignment_function_references(
+                    root_node,
+                    (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, module_qn),
+                    module_qn,
+                    None,
+                    None,
+                    self._flow_scope_boundaries(queries[language][cs.QUERY_CONFIG]),
+                )
                 decorator_targets = list(sorted_func_nodes or [])
                 if combined_captures and (
                     class_nodes := combined_captures.get(cs.CAPTURE_CLASS)

--- a/codebase_rag/tests/integration/test_cypher_queries.py
+++ b/codebase_rag/tests/integration/test_cypher_queries.py
@@ -355,8 +355,9 @@ class TestBuildDeadCodeQueryUnit:
         assert "$entry_points" in query
         assert "is_exported" in query
         # (H) BFS expansion: visits each reachable node once instead of
-        # (H) enumerating every path (which times out on real graphs).
-        assert "CALLS*BFS" in query
+        # (H) enumerating every path (which times out on real graphs). REFERENCES
+        # (H) (a function passed/stored as a value) keeps callbacks reachable.
+        assert "CALLS|REFERENCES*BFS" in query
         # (H) test functions are roots when tests are included
         assert "n.path CONTAINS" in query
 
@@ -376,7 +377,7 @@ class TestBuildDeadCodeQueryUnit:
 
         # (H) a function called by a Module node runs at import, so it is a root
         assert "Module" in query
-        assert "[:CALLS]-(" in query
+        assert "[:CALLS|REFERENCES]-(" in query
 
     def test_test_patterns_cover_js_ts_convention(self) -> None:
         from codebase_rag.constants import TEST_PATH_PATTERNS

--- a/codebase_rag/tests/test_callback_reference_edges.py
+++ b/codebase_rag/tests/test_callback_reference_edges.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+
+def _run_rels(tmp_path: Path, files: dict[str, str]) -> set[tuple[str, str, str]]:
+    # (H) Build the graph for `files` and return (caller_qn, rel_type, callee_qn).
+    parsers, queries = load_parsers()
+    if "python" not in parsers:
+        pytest.skip("python parser not available")
+    for rel, content in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock, repo_path=tmp_path, parsers=parsers, queries=queries
+    ).run()
+    return {
+        (c.args[0][2], str(c.args[1]), c.args[2][2])
+        for c in mock.ensure_relationship_batch.call_args_list
+    }
+
+
+def _has(
+    rels: set[tuple[str, str, str]], caller_suffix: str, rel: str, callee_suffix: str
+) -> bool:
+    return any(
+        a.endswith(caller_suffix) and r == rel and b.endswith(callee_suffix)
+        for a, r, b in rels
+    )
+
+
+REFERENCES = cs.RelationshipType.REFERENCES.value
+
+
+def test_callback_kwarg_to_first_party_function_is_referenced(tmp_path: Path) -> None:
+    # (H) A nested function passed by keyword to a FIRST-PARTY callee that stores it
+    # (H) (never invokes it) must get a REFERENCES edge from the passing scope, or
+    # (H) dead-code wrongly flags it (with_brrr_from_cfg/create_context shape).
+    files = {
+        "brrrlib.py": (
+            "def with_brrr_from_cfg(cfg, handlers, create_context=None):\n"
+            "    cfg.ctx_factory = create_context\n"
+            "    return cfg\n"
+        ),
+        "worker.py": (
+            "from brrrlib import with_brrr_from_cfg\n\n"
+            "def _main(cfg, handlers, extra):\n"
+            "    def create_context(active_worker, meta):\n"
+            "        return (active_worker, extra)\n"
+            "    return with_brrr_from_cfg(cfg, handlers, create_context=create_context)\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files)
+    assert _has(rels, "worker._main", REFERENCES, "worker._main.create_context")
+
+
+def test_callback_kwarg_to_constructor_is_referenced(tmp_path: Path) -> None:
+    # (H) A nested function passed into a first-party CONSTRUCTOR that stores it as a
+    # (H) field must get a REFERENCES edge (AnteriorCodec/create_context shape).
+    files = {
+        "codec.py": (
+            "class Codec:\n"
+            "    def __init__(self, create_context=None):\n"
+            "        self.create_context = create_context\n"
+        ),
+        "worker.py": (
+            "from codec import Codec\n\n"
+            "def get_local(topic, handlers, extra):\n"
+            "    def create_context(active_worker, meta):\n"
+            "        return (active_worker, extra)\n"
+            "    return Codec(create_context=create_context)\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files)
+    assert _has(rels, "worker.get_local", REFERENCES, "worker.get_local.create_context")
+
+
+def test_callback_to_misbound_external_method_is_referenced(tmp_path: Path) -> None:
+    # (H) df.apply is external (pandas), but a same-named first-party method makes the
+    # (H) trie bind the call to it; the passed callback must STILL be referenced from
+    # (H) the passing scope (build_suggestion shape).
+    files = {
+        "strategies.py": (
+            "class BatchingStrategyBase:\n"
+            "    def apply(self, batch):\n"
+            "        return batch\n"
+        ),
+        "report.py": (
+            "import pandas as pd\n\n"
+            "def write_report(results):\n"
+            "    df = pd.DataFrame(results)\n"
+            "    def build_suggestion(row):\n"
+            "        return row\n"
+            "    df['suggestions'] = df.apply(build_suggestion, axis=1)\n"
+            "    return df\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files)
+    assert _has(
+        rels, "report.write_report", REFERENCES, "report.write_report.build_suggestion"
+    )
+
+
+def test_plain_argument_is_not_referenced(tmp_path: Path) -> None:
+    # (H) Non-callable arguments (locals, literals) must not produce REFERENCES noise.
+    files = {
+        "lib.py": "def consume(x, y):\n    return x\n",
+        "m.py": (
+            "from lib import consume\n\n"
+            "def use(data):\n"
+            "    limit = 3\n"
+            "    return consume(data, limit)\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files)
+    assert not any(r == REFERENCES for _, r, _ in rels)
+
+
+def test_function_assigned_to_local_variable_is_referenced(tmp_path: Path) -> None:
+    # (H) A nested function assigned to a local (http_callback =
+    # (H) llm_http_task_closure_with_context) is referenced even if never called by
+    # (H) name in this scope; the alias may be stored or passed onward for dynamic
+    # (H) dispatch, so the assignment itself must keep the function reachable.
+    files = {
+        "svc.py": (
+            "import os\n\n"
+            "def get_llm_service(config, http_callback=None):\n"
+            "    def llm_http_task_closure_with_context(llm, method, url):\n"
+            "        return (config, llm, method, url)\n"
+            "    if http_callback:\n"
+            "        pass\n"
+            "    else:\n"
+            "        http_callback = llm_http_task_closure_with_context\n"
+            "    return http_callback\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files)
+    assert _has(
+        rels,
+        "svc.get_llm_service",
+        REFERENCES,
+        "svc.get_llm_service.llm_http_task_closure_with_context",
+    )
+
+
+def test_function_assigned_to_object_attribute_is_referenced(tmp_path: Path) -> None:
+    # (H) A nested function monkeypatched onto an object attribute (mock_client.post
+    # (H) = handle_post) is invoked later through that attribute; the assignment must
+    # (H) reference it (MockHTTPRouter shape). Its body's self-call then keeps the
+    # (H) called method reachable transitively.
+    files = {
+        "mocking.py": (
+            "class MockHTTPRouter:\n"
+            "    def _handle_post(self, url, **kwargs):\n"
+            "        return url\n"
+            "    def create_mock_client(self, mock_client):\n"
+            "        async def handle_post(url, **kwargs):\n"
+            "            return self._handle_post(url, **kwargs)\n"
+            "        mock_client.post = handle_post\n"
+            "        return mock_client\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files)
+    assert _has(
+        rels,
+        "mocking.MockHTTPRouter.create_mock_client",
+        REFERENCES,
+        "create_mock_client.handle_post",
+    )
+    assert _has(
+        rels,
+        "create_mock_client.handle_post",
+        cs.RelationshipType.CALLS.value,
+        "MockHTTPRouter._handle_post",
+    )

--- a/codebase_rag/tests/test_callback_reference_edges.py
+++ b/codebase_rag/tests/test_callback_reference_edges.py
@@ -220,3 +220,19 @@ def test_module_level_assignment_in_callless_module_is_referenced(
     }
     rels = _run_rels(tmp_path, files)
     assert _has(rels, "registry", REFERENCES, "handlers.handle_event")
+
+
+def test_annotated_assignment_is_referenced(tmp_path: Path) -> None:
+    # (H) An annotated assignment (handler: Callable = handle_event) parses as the
+    # (H) same tree-sitter `assignment` node with an extra type child; the walker
+    # (H) must reference its RHS exactly like an unannotated one.
+    files = {
+        "handlers.py": "def handle_event(evt):\n    return evt\n",
+        "registry.py": (
+            "from typing import Callable\n"
+            "from handlers import handle_event\n\n"
+            "handler: Callable = handle_event\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files)
+    assert _has(rels, "registry", REFERENCES, "handlers.handle_event")

--- a/codebase_rag/tests/test_callback_reference_edges.py
+++ b/codebase_rag/tests/test_callback_reference_edges.py
@@ -203,3 +203,20 @@ def test_monkeypatch_assignment_is_referenced(tmp_path: Path) -> None:
     assert _has(
         rels, "helpers.install_patch", REFERENCES, "helpers._vertex_ai_client_init"
     )
+
+
+def test_module_level_assignment_in_callless_module_is_referenced(
+    tmp_path: Path,
+) -> None:
+    # (H) A module whose ONLY statement is a first-class function assignment (no call
+    # (H) expressions at all) must still emit the Module -> REFERENCES edge; the
+    # (H) call-driven pass early-returns on such modules, so the assignment scan has
+    # (H) to run before it.
+    files = {
+        "handlers.py": "def handle_event(evt):\n    return evt\n",
+        "registry.py": (
+            "from handlers import handle_event\n\nregistry_handler = handle_event\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files)
+    assert _has(rels, "registry", REFERENCES, "handlers.handle_event")

--- a/codebase_rag/tests/test_callback_reference_edges.py
+++ b/codebase_rag/tests/test_callback_reference_edges.py
@@ -182,3 +182,24 @@ def test_function_assigned_to_object_attribute_is_referenced(tmp_path: Path) -> 
         cs.RelationshipType.CALLS.value,
         "MockHTTPRouter._handle_post",
     )
+
+
+def test_monkeypatch_assignment_is_referenced(tmp_path: Path) -> None:
+    # (H) A function assigned over a third-party attribute chain
+    # (H) (genai.Client.__init__ = _vertex_ai_client_init) is invoked by the
+    # (H) patched class later; the assignment must reference it
+    # (H) (_vertex_ai_client_init shape).
+    files = {
+        "helpers.py": (
+            "import google.genai as genai_client\n\n"
+            "def _vertex_ai_client_init(self, **kwargs):\n"
+            "    kwargs.pop('api_key', None)\n"
+            "    return None\n\n"
+            "def install_patch():\n"
+            "    genai_client.Client.__init__ = _vertex_ai_client_init\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files)
+    assert _has(
+        rels, "helpers.install_patch", REFERENCES, "helpers._vertex_ai_client_init"
+    )

--- a/codebase_rag/tests/test_dead_code_eval.py
+++ b/codebase_rag/tests/test_dead_code_eval.py
@@ -303,3 +303,61 @@ def test_score_dead_code_prf() -> None:
     result = score_dead_code({"a", "b"}, {"a", "c"})
     row = result.rows[0]
     assert (row["tp"], row["fp"], row["fn"]) == (1, 1, 1)
+
+
+def test_referenced_function_is_reachable() -> None:
+    # (H) A function reachable only through a REFERENCES edge (passed as a callback
+    # (H) into first-party plumbing that stores it) is live; a sibling with no
+    # (H) inbound edge stays dead.
+    nodes = dict(
+        [
+            (
+                (_MODULE, "proj.m"),
+                {cs.KEY_QUALIFIED_NAME: "proj.m", cs.KEY_PATH: "m.py"},
+            ),
+            _fn("proj.m._main"),
+            _fn("proj.m._main.create_context"),
+            _fn("proj.m._orphan"),
+        ]
+    )
+    rels = [
+        (_MODULE, "proj.m", _CALLS, _FUNCTION, "proj.m._main"),
+        (
+            _FUNCTION,
+            "proj.m._main",
+            cs.RelationshipType.REFERENCES.value,
+            _FUNCTION,
+            "proj.m._main.create_context",
+        ),
+    ]
+    dead = dead_code_from_graph(nodes, rels, _PREFIX, _CONFIG)
+    assert "proj.m._main.create_context" not in dead
+    assert "proj.m._orphan" in dead
+
+
+def _make_callback_repo(root: Path) -> None:
+    root.mkdir(parents=True)
+    (root / "__init__.py").write_text("", encoding="utf-8")
+    (root / "brrrlib.py").write_text(
+        "def with_brrr_from_cfg(cfg, handlers, create_context=None):\n"
+        "    cfg.ctx_factory = create_context\n"
+        "    return cfg\n",
+        encoding="utf-8",
+    )
+    (root / "worker.py").write_text(
+        "from proj.brrrlib import with_brrr_from_cfg\n\n\n"
+        "def main(cfg, handlers, extra):\n"
+        "    def create_context(active_worker, meta):\n"
+        "        return (active_worker, extra)\n"
+        "    return with_brrr_from_cfg(cfg, handlers, create_context=create_context)\n",
+        encoding="utf-8",
+    )
+
+
+def test_cgr_dead_code_keeps_stored_callback_alive(tmp_path: Path) -> None:
+    # (H) Full pipeline: a nested callback passed by keyword into first-party
+    # (H) plumbing that stores it must not be reported dead (create_context shape).
+    src = tmp_path / "proj"
+    _make_callback_repo(src)
+    dead = cgr_dead_code(src, "proj", default_dead_code_config(False, False))
+    assert not any(qn.endswith("create_context") for qn in dead)

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -614,6 +614,11 @@ RELATIONSHIP_SCHEMAS: tuple[RelationshipSchema, ...] = (
     ),
     RelationshipSchema(
         (NodeLabel.MODULE, NodeLabel.FUNCTION, NodeLabel.METHOD),
+        RelationshipType.REFERENCES,
+        (NodeLabel.FUNCTION, NodeLabel.METHOD),
+    ),
+    RelationshipSchema(
+        (NodeLabel.MODULE, NodeLabel.FUNCTION, NodeLabel.METHOD),
         RelationshipType.INSTANTIATES,
         (NodeLabel.CLASS,),
     ),

--- a/evals/dead_code.py
+++ b/evals/dead_code.py
@@ -30,6 +30,7 @@ _FUNCTION = cs.NodeLabel.FUNCTION.value
 _METHOD = cs.NodeLabel.METHOD.value
 _CLASS = cs.NodeLabel.CLASS.value
 _CALLS = cs.RelationshipType.CALLS.value
+_REFERENCES = cs.RelationshipType.REFERENCES.value
 _INSTANTIATES = cs.RelationshipType.INSTANTIATES.value
 _INHERITS = cs.RelationshipType.INHERITS.value
 _EMPTY_LOCATION = LocationStats(0, 0, 0, 0.0, 0)
@@ -90,8 +91,8 @@ def dead_code_from_graph(
     config: DeadCodeConfig,
 ) -> set[str]:
     labels = {_FUNCTION, _METHOD}
-    traversal = {_CALLS}
-    module_rels = {_CALLS}
+    traversal = {_CALLS, _REFERENCES}
+    module_rels = {_CALLS, _REFERENCES}
     if config.include_classes:
         labels.add(_CLASS)
         traversal |= {_INSTANTIATES, _INHERITS}

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.201"
+version = "0.0.204"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

Functions are first-class values: they get passed as arguments, assigned to variables and object attributes, and stored by framework plumbing for later dynamic dispatch. cgr's call graph only recorded a keep-alive edge when a callback was passed to an EXTERNAL callee, so every other first-class use produced a dead-code false positive.

This adds a `REFERENCES` relationship: an edge from the referencing scope to a function used as a value, walked by dead-code reachability (`CALLS|REFERENCES`).

## The three mechanisms it fixes (all reproduced from a real monorepo)

1. **Stored-not-invoked callbacks to first-party callees.** `with_brrr_from_cfg(cfg, handlers, create_context=create_context)` stores the callback in config; callable-param flow only emits an edge when the callee visibly invokes the parameter, so the callback had no inbound edge. Also covers first-party CONSTRUCTORS (`AnteriorCodec(create_context=create_context)`).
2. **Misbound external methods.** `df.apply(build_suggestion, axis=1)` is pandas, but a same-named first-party method (`BatchingStrategyBase.apply`) makes the trie bind the call to it, so the external-callee reference path never ran and the callback was dropped.
3. **Function-value assignments.** `http_callback = llm_http_task_closure_with_context` and monkeypatch-style `mock_client.post = handle_post` reference a function without any call expression at all.

## How

- `RelationshipType.REFERENCES` (+ schema entry, inbound-edges query template).
- Call arguments: the existing argument scan now also runs for first-party callees, emitting `REFERENCES` (external/builtin callees keep their historical `CALLS` reference edges; precise invocation edges still come from callable-param flow).
- Assignments: a new per-scope walker emits `REFERENCES` for a plain name/attribute RHS that resolves to a registered callable, stopping at nested-scope boundaries.
- Dead-code reachability (Cypher query + the in-memory eval mirror) traverses `CALLS|REFERENCES`, including module-root seeding.

## Tests (RED to GREEN)

- `test_callback_reference_edges.py` (6): first-party kwarg callback, constructor kwarg callback, misbound external method, local-variable assignment, object-attribute assignment (with the transitive `CALLS` chain), and a negative (plain arguments produce no REFERENCES noise).
- `test_dead_code_eval.py`: REFERENCES-only reachability keeps the callback live while an orphan stays dead; full-pipeline test for the stored-callback shape.
- Dead-code integration tests run the updated query against real Memgraph.

Full suite: 4386 passed, 14 skipped.
