### PR TITLE
fix(types): infer attribute-constructor receiver types to stop bare-name misbinds

### DIFF
--- a/codebase_rag/parsers/py/expression_analyzer.py
+++ b/codebase_rag/parsers/py/expression_analyzer.py
@@ -67,14 +67,28 @@ class PythonExpressionAnalyzerMixin(_ExprBase):
                 and func_node.type == cs.TS_PY_ATTRIBUTE
                 and (method_call_text := self._extract_full_method_call(func_node))
             ):
-                return self._infer_method_call_return_type(
+                if inferred := self._infer_method_call_return_type(
                     method_call_text, module_qn, None
-                )
+                ):
+                    return inferred
+                return self._attribute_constructor_type(method_call_text)
 
         elif node.type == cs.TS_PY_LIST_COMPREHENSION:
             if body_node := node.child_by_field_name(cs.TS_FIELD_BODY):
                 return self._infer_type_from_expression(body_node, module_qn)
 
+        return None
+
+    def _attribute_constructor_type(self, method_call_text: str) -> str | None:
+        # (H) alias.ClassName(...) is an attribute CONSTRUCTOR (pd.DataFrame,
+        # (H) genai.Client, models.Helper), not a method call: the variable's type is
+        # (H) the dotted class itself. Without this the receiver stays untyped, the
+        # (H) known-external suppression cannot fire, and a later member call on it
+        # (H) (df.apply) rebinds by bare name to an unrelated first-party method.
+        # (H) Mirrors the bare `ClassName(...)` uppercase heuristic.
+        simple_name = method_call_text.rsplit(cs.SEPARATOR_DOT, 1)[-1]
+        if simple_name and simple_name[0].isupper():
+            return method_call_text
         return None
 
     def _infer_type_from_expression_simple(
@@ -107,9 +121,11 @@ class PythonExpressionAnalyzerMixin(_ExprBase):
                 and func_node.type == cs.TS_PY_ATTRIBUTE
                 and (method_call_text := self._extract_full_method_call(func_node))
             ):
-                return self._infer_method_call_return_type(
+                if inferred := self._infer_method_call_return_type(
                     method_call_text, module_qn, local_var_types
-                )
+                ):
+                    return inferred
+                return self._attribute_constructor_type(method_call_text)
 
         return None
 

--- a/codebase_rag/tests/test_callback_reference_edges.py
+++ b/codebase_rag/tests/test_callback_reference_edges.py
@@ -85,9 +85,11 @@ def test_callback_kwarg_to_constructor_is_referenced(tmp_path: Path) -> None:
 
 
 def test_callback_to_misbound_external_method_is_referenced(tmp_path: Path) -> None:
-    # (H) df.apply is external (pandas), but a same-named first-party method makes the
-    # (H) trie bind the call to it; the passed callback must STILL be referenced from
-    # (H) the passing scope (build_suggestion shape).
+    # (H) df arrives as an UNTYPED parameter, so the trie binds df.apply by bare name
+    # (H) to a same-named first-party method; the passed callback must STILL be
+    # (H) referenced from the passing scope (build_suggestion shape). A locally
+    # (H) constructed receiver (df = pd.DataFrame(...)) is instead typed external and
+    # (H) suppressed outright -- covered in test_external_receiver_misbind.py.
     files = {
         "strategies.py": (
             "class BatchingStrategyBase:\n"
@@ -95,9 +97,7 @@ def test_callback_to_misbound_external_method_is_referenced(tmp_path: Path) -> N
             "        return batch\n"
         ),
         "report.py": (
-            "import pandas as pd\n\n"
-            "def write_report(results):\n"
-            "    df = pd.DataFrame(results)\n"
+            "def write_report(df):\n"
             "    def build_suggestion(row):\n"
             "        return row\n"
             "    df['suggestions'] = df.apply(build_suggestion, axis=1)\n"

--- a/codebase_rag/tests/test_external_receiver_misbind.py
+++ b/codebase_rag/tests/test_external_receiver_misbind.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+STRATEGIES = (
+    "class BatchingStrategyBase:\n    def apply(self, batch):\n        return batch\n"
+)
+
+
+def _run_rels(tmp_path: Path, files: dict[str, str]) -> set[tuple[str, str, str]]:
+    # (H) Build the graph for `files` and return (caller_qn, rel_type, callee_qn).
+    parsers, queries = load_parsers()
+    if "python" not in parsers:
+        pytest.skip("python parser not available")
+    for rel, content in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock, repo_path=tmp_path, parsers=parsers, queries=queries
+    ).run()
+    return {
+        (c.args[0][2], str(c.args[1]), c.args[2][2])
+        for c in mock.ensure_relationship_batch.call_args_list
+    }
+
+
+def test_external_attribute_constructor_receiver_is_not_misbound(
+    tmp_path: Path,
+) -> None:
+    # (H) df is constructed by an external attribute constructor (pd.DataFrame); its
+    # (H) .apply must NOT rebind by bare name to an unrelated first-party apply. The
+    # (H) callback reference must still be emitted.
+    files = {
+        "strategies.py": STRATEGIES,
+        "report.py": (
+            "import pandas as pd\n\n"
+            "def write_report(results):\n"
+            "    df = pd.DataFrame(results)\n"
+            "    def build_suggestion(row):\n"
+            "        return row\n"
+            "    df['suggestions'] = df.apply(build_suggestion, axis=1)\n"
+            "    return df\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files)
+    assert not any(
+        r == "CALLS" and b.endswith("BatchingStrategyBase.apply") for _, r, b in rels
+    )
+    # (H) With the receiver judged external the callee resolves to nothing, so the
+    # (H) callback keep-alive edge comes from the external-callee path (CALLS) rather
+    # (H) than the first-party REFERENCES path; either keeps it reachable.
+    assert any(
+        r in ("CALLS", "REFERENCES")
+        and a.endswith("write_report")
+        and b.endswith("write_report.build_suggestion")
+        for a, r, b in rels
+    )
+
+
+def test_first_party_attribute_constructor_receiver_resolves(tmp_path: Path) -> None:
+    # (H) The same attribute-constructor shape with a FIRST-PARTY class must resolve
+    # (H) the member call precisely (models.Helper() -> helper.process()).
+    files = {
+        "models.py": ("class Helper:\n    def process(self):\n        return 1\n"),
+        "app.py": (
+            "import models\n\n"
+            "def run():\n"
+            "    helper = models.Helper()\n"
+            "    return helper.process()\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files)
+    assert any(
+        a.endswith("app.run") and r == "CALLS" and b.endswith("models.Helper.process")
+        for a, r, b in rels
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.204"
+version = "0.0.206"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

Fixes a false CALLS edge: a member call on a variable constructed by an ATTRIBUTE constructor (`df = pd.DataFrame(results); df.apply(...)`) was rebound by bare name to an unrelated first-party method of the same name (`BatchingStrategyBase.apply`), polluting the call graph with a wrong cross-package edge.

## Root cause

Python type inference only recognized BARE constructors (`DataFrame(...)`, via the uppercase-initial heuristic). An attribute callee like `pd.DataFrame(...)` was routed to method-return-type inference, which knows nothing about external modules, so the variable stayed UNTYPED. The resolver's known-external suppression (`_receiver_type_is_external`) only fires for typed receivers, so the untyped `df.apply` fell to the last-resort trie fallback, which matches by trailing method name and picked the first-party `apply` alphabetically.

## How

`py/expression_analyzer.py`: when an attribute call's method-return inference yields nothing and the final segment is uppercase-initial, treat `alias.ClassName(...)` as a constructor and record the dotted class (`pd.DataFrame`) as the variable's type — the same heuristic the bare-name branch already uses, extracted into `_attribute_constructor_type` and applied in both the simple-pass and complex-pass inference variants.

Effects:
- External receivers (`pd.DataFrame`) are now typed, so the existing suppression kills the bare-name rebind: no more false CALLS edge, and the passed callback is kept reachable via the external-callee reference path.
- First-party attribute constructors (`models.Helper()`) gain a usable receiver type, so `helper.process()` resolves precisely (regression-tested).

One pre-existing test updated: its fixture relied on the now-suppressed misbind to exercise the first-party REFERENCES arg path; it uses an untyped parameter receiver instead (still misbinds, still covered), with the typed-receiver behavior asserted in the new test file.

## Tests (RED to GREEN)

`test_external_receiver_misbind.py`:
1. external attribute constructor: no CALLS edge to the same-named first-party method; the callback keeps a keep-alive edge.
2. first-party attribute constructor: the member call resolves precisely.

Full suite: 4391 passed, 14 skipped.
