### PR TITLE
fix(dead-code): root decorated closures, typer callbacks, and Protocol method stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -778,7 +778,7 @@ docs/*.md
 <!-- SECTION:dependencies -->
 - **loguru**: Python logging made (stupidly) simple
 - **mcp**: Model Context Protocol SDK
-- **pydantic-ai**: Agent Framework / shim to use Pydantic with LLMs
+- **pydantic-ai**: AI Agent Framework, the Pydantic way
 - **pydantic-settings**: Settings management using Pydantic
 - **pymgclient**: Memgraph database adapter for Python language
 - **python-dotenv**: Read key-value pairs from a .env file and set them as environment variables

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -453,6 +453,7 @@ DEFAULT_ROOT_DECORATORS: frozenset[str] = frozenset(
         "route",
         "get",
         "post",
+        "callback",
         "put",
         "delete",
         "patch",
@@ -474,6 +475,12 @@ DEFAULT_ROOT_DECORATORS: frozenset[str] = frozenset(
         "abstractmethod",
     }
 )
+
+# (H) Base classes that mark a class as a structural interface: its method stubs
+# (H) are never call targets themselves (callers resolve to the implementations),
+# (H) so dead-code analysis roots every method the class defines.
+# (H) ponytail: direct bases only; transitive Protocol subclassing is not chased.
+PROTOCOL_BASE_QNS: tuple[str, ...] = ("typing.Protocol", "typing_extensions.Protocol")
 
 # (H) Substrings in a node's file path that mark it as test code. Covers Python
 # (H) (test_, _test, conftest, /tests/), the JS/TS filename convention

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -115,16 +115,9 @@ _DEAD_CODE_MODULE_ROOT_NON_TEST = (
     " WHERE NOT ANY(p IN $test_patterns WHERE m.path CONTAINS p) | 1]) > 0"
 )
 
-# (H) A decorated function DEFINED by a function/method (prompt_toolkit
-# (H) @bindings.add, MCP @server.list_tools, nested typer/click commands) is handed
-# (H) to a framework when the enclosing function runs, so it is a root: the
-# (H) decorator-name whitelist cannot enumerate every registration API. A method
-# (H) whose class INHERITS typing.Protocol is an interface stub; callers resolve to
-# (H) the implementations, never to the stub, so every Protocol method is a root.
-_DEAD_CODE_NESTED_REGISTRATION_CLAUSE = (
-    "(size(coalesce(n.decorators, [])) > 0"
-    " AND size([(n)<-[:DEFINES]-(:Function|Method) | 1]) > 0)"
-)
+# (H) A method whose class INHERITS typing.Protocol is an interface stub; callers
+# (H) resolve to the implementations, never to the stub, so every Protocol method
+# (H) is a root.
 _DEAD_CODE_PROTOCOL_STUB_CLAUSE = (
     "size([(n)<-[:DEFINES_METHOD]-(:Class)-[:INHERITS]->(p:Class)"
     " WHERE p.qualified_name IN [{protocol_bases}] | 1]) > 0"
@@ -142,6 +135,15 @@ _DEAD_CODE_PROTOCOL_STUB_CLAUSE = (
 # (H) excludes the source node, so the roots are unioned into the live set. The
 # (H) CASE keeps one row when there are no roots (UNWIND of [] yields zero rows,
 # (H) which would drop the final MATCH and wrongly report nothing as dead).
+# (H) After the base round, a second expansion roots decorated functions DEFINED
+# (H) by a LIVE function/method (prompt_toolkit @bindings.add, MCP
+# (H) @server.list_tools, nested typer/click commands): the enclosing function
+# (H) executes the registration, so the closure and its callees are live. The
+# (H) exemption is tied to owner liveness on purpose — a decorated closure of a
+# (H) DEAD owner never registers and is reported with its whole cluster.
+# (H) ponytail: one expansion round, so a registration chain nested two closures
+# (H) deep is missed; add a third round (or iterate to fixed point) if real code
+# (H) ever registers closures from inside registered closures.
 _DEAD_CODE_QUERY_TEMPLATE = """MATCH (n:{labels})
 WHERE n.qualified_name STARTS WITH $project_prefix
   AND (
@@ -149,7 +151,6 @@ WHERE n.qualified_name STARTS WITH $project_prefix
         WHERE toLower(last(split(split(replace(d, '@', ''), '(')[0], '.')))
               IN $root_decorators)
     OR n.is_exported = true
-    OR {nested_registration_clause}
     OR {protocol_stub_clause}
     OR ('Method' IN labels(n)
         AND n.name STARTS WITH '__' AND n.name ENDS WITH '__' AND size(n.name) > 4
@@ -162,6 +163,16 @@ UNWIND (CASE WHEN size(roots) = 0 THEN [null] ELSE roots END) AS r
 OPTIONAL MATCH (r)-[:{traversal}*BFS]->(reached)
 WITH roots, collect(DISTINCT reached) AS reached_set
 WITH roots + reached_set AS live_set
+OPTIONAL MATCH (o:Function|Method)-[:DEFINES]->(c:Function|Method)
+WHERE o IN live_set AND size(coalesce(c.decorators, [])) > 0
+  AND NOT c IN live_set
+WITH live_set, collect(DISTINCT c) AS closure_roots
+UNWIND (
+  CASE WHEN size(closure_roots) = 0 THEN [null] ELSE closure_roots END
+) AS cr
+OPTIONAL MATCH (cr)-[:{traversal}*BFS]->(cr_reached)
+WITH live_set, closure_roots, collect(DISTINCT cr_reached) AS cr_reached_set
+WITH live_set + closure_roots + cr_reached_set AS live_set
 MATCH (n:{labels})
 WHERE n.qualified_name STARTS WITH $project_prefix
   AND NOT n IN live_set
@@ -192,7 +203,6 @@ def build_dead_code_query(include_tests: bool, include_classes: bool = False) ->
         traversal=traversal,
         module_clause=module_clause,
         test_clause=test_clause,
-        nested_registration_clause=_DEAD_CODE_NESTED_REGISTRATION_CLAUSE,
         protocol_stub_clause=_DEAD_CODE_PROTOCOL_STUB_CLAUSE.format(
             protocol_bases=protocol_bases
         ),

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -1,4 +1,4 @@
-from .constants import CYPHER_DEFAULT_LIMIT
+from .constants import CYPHER_DEFAULT_LIMIT, PROTOCOL_BASE_QNS
 
 CYPHER_DELETE_ALL = "MATCH (n) DETACH DELETE n;"
 
@@ -115,6 +115,21 @@ _DEAD_CODE_MODULE_ROOT_NON_TEST = (
     " WHERE NOT ANY(p IN $test_patterns WHERE m.path CONTAINS p) | 1]) > 0"
 )
 
+# (H) A decorated function DEFINED by a function/method (prompt_toolkit
+# (H) @bindings.add, MCP @server.list_tools, nested typer/click commands) is handed
+# (H) to a framework when the enclosing function runs, so it is a root: the
+# (H) decorator-name whitelist cannot enumerate every registration API. A method
+# (H) whose class INHERITS typing.Protocol is an interface stub; callers resolve to
+# (H) the implementations, never to the stub, so every Protocol method is a root.
+_DEAD_CODE_NESTED_REGISTRATION_CLAUSE = (
+    "(size(coalesce(n.decorators, [])) > 0"
+    " AND size([(n)<-[:DEFINES]-(:Function|Method) | 1]) > 0)"
+)
+_DEAD_CODE_PROTOCOL_STUB_CLAUSE = (
+    "size([(n)<-[:DEFINES_METHOD]-(:Class)-[:INHERITS]->(p:Class)"
+    " WHERE p.qualified_name IN [{protocol_bases}] | 1]) > 0"
+)
+
 # (H) Reachability walks CALLS only by default. With classes included it also
 # (H) walks INSTANTIATES (construction keeps a class live) and INHERITS forward
 # (H) from subclass to base, so a base is kept live only by a REACHABLE subclass.
@@ -134,6 +149,8 @@ WHERE n.qualified_name STARTS WITH $project_prefix
         WHERE toLower(last(split(split(replace(d, '@', ''), '(')[0], '.')))
               IN $root_decorators)
     OR n.is_exported = true
+    OR {nested_registration_clause}
+    OR {protocol_stub_clause}
     OR ('Method' IN labels(n)
         AND n.name STARTS WITH '__' AND n.name ENDS WITH '__' AND size(n.name) > 4
         AND n.path ENDS WITH '.py')
@@ -169,11 +186,16 @@ def build_dead_code_query(include_tests: bool, include_classes: bool = False) ->
     else:
         module_clause = _DEAD_CODE_MODULE_ROOT_NON_TEST.format(module_rels=module_rels)
         test_clause = ""
+    protocol_bases = ", ".join(f"'{qn}'" for qn in PROTOCOL_BASE_QNS)
     return _DEAD_CODE_QUERY_TEMPLATE.format(
         labels=labels,
         traversal=traversal,
         module_clause=module_clause,
         test_clause=test_clause,
+        nested_registration_clause=_DEAD_CODE_NESTED_REGISTRATION_CLAUSE,
+        protocol_stub_clause=_DEAD_CODE_PROTOCOL_STUB_CLAUSE.format(
+            protocol_bases=protocol_bases
+        ),
     )
 
 

--- a/codebase_rag/parsers/py/ast_analyzer.py
+++ b/codebase_rag/parsers/py/ast_analyzer.py
@@ -135,20 +135,6 @@ class PythonAstAnalyzerMixin(_AstBase):
             assignments, local_var_types, module_qn
         )
 
-    def _traverse_for_assignments(
-        self,
-        node: Node,
-        local_var_types: dict[str, str],
-        module_qn: str,
-        processor: Callable[[Node, dict[str, str], str], None],
-    ) -> None:
-        stack: list[Node] = [node]
-        while stack:
-            current = stack.pop()
-            if current.type == cs.TS_PY_ASSIGNMENT:
-                processor(current, local_var_types, module_qn)
-            stack.extend(reversed(current.children))
-
     def _process_assignment_simple(
         self, assignment_node: Node, local_var_types: dict[str, str], module_qn: str
     ) -> None:

--- a/codebase_rag/tests/integration/test_cypher_queries.py
+++ b/codebase_rag/tests/integration/test_cypher_queries.py
@@ -391,15 +391,18 @@ class TestBuildDeadCodeQueryUnit:
             assert any(p in path for p in TEST_PATH_PATTERNS), path
 
     def test_include_classes_adds_class_candidates(self) -> None:
+        # (H) the INHERITS check targets the *BFS traversal set: the protocol-stub
+        # (H) root clause mentions INHERITS in every query variant, so a bare
+        # (H) substring check would no longer prove class traversal is off.
         with_classes = build_dead_code_query(include_tests=False, include_classes=True)
         assert "Function|Method|Class" in with_classes
-        assert "INHERITS" in with_classes
+        assert "CALLS|INSTANTIATES|INHERITS*BFS" in with_classes
 
         without_classes = build_dead_code_query(
             include_tests=False, include_classes=False
         )
         assert "Function|Method|Class" not in without_classes
-        assert "INHERITS" not in without_classes
+        assert "CALLS|INSTANTIATES|INHERITS*BFS" not in without_classes
 
 
 @pytest.mark.integration
@@ -643,6 +646,58 @@ class TestBuildDeadCodeQueryIntegration:
         assert {r["qualified_name"] for r in results} == {
             "proj.mod.a",
             "proj.mod.b",
+        }
+
+    def test_registration_closure_and_protocol_stub_are_roots(
+        self, memgraph_ingestor: MemgraphIngestor
+    ) -> None:
+        # (H) a decorated closure DEFINED by a function (prompt_toolkit
+        # (H) @bindings.add, MCP @server.list_tools) is registered when the enclosing
+        # (H) function runs, and a method of a typing.Protocol subclass is an
+        # (H) interface stub whose callers resolve to the implementations; neither is
+        # (H) dead, while an undecorated closure and a plain private method are.
+        memgraph_ingestor._execute_query(
+            "CREATE "
+            "(m:Module {qualified_name: 'proj.mod', path: 'proj/mod.py'}), "
+            "(outer:Function {qualified_name: 'proj.mod.outer', name: 'outer', "
+            "  start_line: 1, end_line: 8, decorators: [], path: 'proj/mod.py'}), "
+            "(submit:Function {qualified_name: 'proj.mod.outer._submit', "
+            "  name: '_submit', start_line: 2, end_line: 3, "
+            "  decorators: ['@bindings.add(\"c-j\")'], path: 'proj/mod.py'}), "
+            "(unused:Function {qualified_name: 'proj.mod.outer._unused', "
+            "  name: '_unused', start_line: 5, end_line: 6, decorators: [], "
+            "  path: 'proj/mod.py'}), "
+            "(proto:Class {qualified_name: 'typing.Protocol', name: 'Protocol'}), "
+            "(loadable:Class {qualified_name: 'proj.mod.Loadable', "
+            "  name: 'Loadable', path: 'proj/mod.py'}), "
+            "(stub:Method {qualified_name: 'proj.mod.Loadable._ensure_loaded', "
+            "  name: '_ensure_loaded', start_line: 10, end_line: 10, "
+            "  decorators: [], path: 'proj/mod.py'}), "
+            "(plain:Class {qualified_name: 'proj.mod.Plain', name: 'Plain', "
+            "  path: 'proj/mod.py'}), "
+            "(helper:Method {qualified_name: 'proj.mod.Plain._helper', "
+            "  name: '_helper', start_line: 12, end_line: 13, decorators: [], "
+            "  path: 'proj/mod.py'}), "
+            "(m)-[:CALLS]->(outer), "
+            "(outer)-[:DEFINES]->(submit), "
+            "(outer)-[:DEFINES]->(unused), "
+            "(loadable)-[:INHERITS]->(proto), "
+            "(loadable)-[:DEFINES_METHOD]->(stub), "
+            "(plain)-[:DEFINES_METHOD]->(helper)"
+        )
+        params: dict[str, PropertyValue] = {
+            "project_prefix": "proj.",
+            "root_decorators": [],
+            "entry_points": [],
+            "test_patterns": ["test_", "_test", "conftest", "/tests/"],
+        }
+
+        results = memgraph_ingestor._execute_query(
+            build_dead_code_query(include_tests=False), params
+        )
+        assert {r["qualified_name"] for r in results} == {
+            "proj.mod.outer._unused",
+            "proj.mod.Plain._helper",
         }
 
     def test_module_load_callee_is_a_root(

--- a/codebase_rag/tests/integration/test_cypher_queries.py
+++ b/codebase_rag/tests/integration/test_cypher_queries.py
@@ -651,11 +651,13 @@ class TestBuildDeadCodeQueryIntegration:
     def test_registration_closure_and_protocol_stub_are_roots(
         self, memgraph_ingestor: MemgraphIngestor
     ) -> None:
-        # (H) a decorated closure DEFINED by a function (prompt_toolkit
+        # (H) a decorated closure DEFINED by a LIVE function (prompt_toolkit
         # (H) @bindings.add, MCP @server.list_tools) is registered when the enclosing
-        # (H) function runs, and a method of a typing.Protocol subclass is an
-        # (H) interface stub whose callers resolve to the implementations; neither is
-        # (H) dead, while an undecorated closure and a plain private method are.
+        # (H) function runs, and it keeps its own callees live; a method of a
+        # (H) typing.Protocol subclass is an interface stub whose callers resolve to
+        # (H) the implementations. Neither is dead, while an undecorated closure, a
+        # (H) plain private method, and the whole cluster under a DEAD enclosing
+        # (H) function (owner, decorated closure, closure-only callee) are.
         memgraph_ingestor._execute_query(
             "CREATE "
             "(m:Module {qualified_name: 'proj.mod', path: 'proj/mod.py'}), "
@@ -678,9 +680,23 @@ class TestBuildDeadCodeQueryIntegration:
             "(helper:Method {qualified_name: 'proj.mod.Plain._helper', "
             "  name: '_helper', start_line: 12, end_line: 13, decorators: [], "
             "  path: 'proj/mod.py'}), "
+            "(live_callee:Function {qualified_name: 'proj.mod._only_from_closure', "
+            "  name: '_only_from_closure', start_line: 15, end_line: 16, "
+            "  decorators: [], path: 'proj/mod.py'}), "
+            "(dead_outer:Function {qualified_name: 'proj.mod.dead_outer', "
+            "  name: 'dead_outer', start_line: 18, end_line: 24, decorators: [], "
+            "  path: 'proj/mod.py'}), "
+            "(ghost:Function {qualified_name: 'proj.mod.dead_outer._ghost', "
+            "  name: '_ghost', start_line: 19, end_line: 20, "
+            "  decorators: ['@bindings.add(\"c-x\")'], path: 'proj/mod.py'}), "
+            "(victim:Function {qualified_name: 'proj.mod.victim', name: 'victim', "
+            "  start_line: 26, end_line: 27, decorators: [], path: 'proj/mod.py'}), "
             "(m)-[:CALLS]->(outer), "
             "(outer)-[:DEFINES]->(submit), "
             "(outer)-[:DEFINES]->(unused), "
+            "(submit)-[:CALLS]->(live_callee), "
+            "(dead_outer)-[:DEFINES]->(ghost), "
+            "(ghost)-[:CALLS]->(victim), "
             "(loadable)-[:INHERITS]->(proto), "
             "(loadable)-[:DEFINES_METHOD]->(stub), "
             "(plain)-[:DEFINES_METHOD]->(helper)"
@@ -698,6 +714,9 @@ class TestBuildDeadCodeQueryIntegration:
         assert {r["qualified_name"] for r in results} == {
             "proj.mod.outer._unused",
             "proj.mod.Plain._helper",
+            "proj.mod.dead_outer",
+            "proj.mod.dead_outer._ghost",
+            "proj.mod.victim",
         }
 
     def test_module_load_callee_is_a_root(

--- a/codebase_rag/tests/integration/test_cypher_queries.py
+++ b/codebase_rag/tests/integration/test_cypher_queries.py
@@ -397,13 +397,13 @@ class TestBuildDeadCodeQueryUnit:
         # (H) substring check would no longer prove class traversal is off.
         with_classes = build_dead_code_query(include_tests=False, include_classes=True)
         assert "Function|Method|Class" in with_classes
-        assert "CALLS|INSTANTIATES|INHERITS*BFS" in with_classes
+        assert "CALLS|REFERENCES|INSTANTIATES|INHERITS*BFS" in with_classes
 
         without_classes = build_dead_code_query(
             include_tests=False, include_classes=False
         )
         assert "Function|Method|Class" not in without_classes
-        assert "CALLS|INSTANTIATES|INHERITS*BFS" not in without_classes
+        assert "CALLS|REFERENCES|INSTANTIATES|INHERITS*BFS" not in without_classes
 
 
 @pytest.mark.integration

--- a/codebase_rag/tests/test_dead_code_eval.py
+++ b/codebase_rag/tests/test_dead_code_eval.py
@@ -11,7 +11,11 @@ from evals.dead_code import (
 
 _MODULE = cs.NodeLabel.MODULE.value
 _FUNCTION = cs.NodeLabel.FUNCTION.value
+_CLASS = cs.NodeLabel.CLASS.value
 _CALLS = cs.RelationshipType.CALLS.value
+_DEFINES = cs.RelationshipType.DEFINES.value
+_DEFINES_METHOD = cs.RelationshipType.DEFINES_METHOD.value
+_INHERITS = cs.RelationshipType.INHERITS.value
 _PREFIX = "proj."
 _CONFIG = DeadCodeConfig(
     include_tests=False,
@@ -297,6 +301,121 @@ def test_abstract_method_is_a_root() -> None:
     )
     dead = dead_code_from_graph(nodes, [], _PREFIX, config)
     assert dead == set()
+
+
+def test_registration_decorated_nested_function_is_a_root() -> None:
+    # (H) A decorated function nested inside another function (prompt_toolkit
+    # (H) @bindings.add, MCP @server.list_tools) is handed to a framework when the
+    # (H) enclosing function runs, so it is live regardless of the decorator-name
+    # (H) whitelist; an undecorated uncalled sibling closure stays dead.
+    nodes = dict(
+        [
+            (
+                (_MODULE, "proj.m"),
+                {cs.KEY_QUALIFIED_NAME: "proj.m", cs.KEY_PATH: "m.py"},
+            ),
+            _fn("proj.m.outer"),
+            _fn("proj.m.outer._submit", decorators=["@bindings.add('c-j')"]),
+            _fn("proj.m.outer._unused"),
+        ]
+    )
+    rels = [
+        (_MODULE, "proj.m", _CALLS, _FUNCTION, "proj.m.outer"),
+        (_FUNCTION, "proj.m.outer", _DEFINES, _FUNCTION, "proj.m.outer._submit"),
+        (_FUNCTION, "proj.m.outer", _DEFINES, _FUNCTION, "proj.m.outer._unused"),
+    ]
+    dead = dead_code_from_graph(nodes, rels, _PREFIX, _CONFIG)
+    assert dead == {"proj.m.outer._unused"}
+
+
+def test_typer_callback_decorator_is_a_root() -> None:
+    # (H) typer invokes @app.callback() functions by registration, so the default
+    # (H) decorator whitelist must seed them as roots (codebase_rag.cli shape).
+    config = default_dead_code_config(include_tests=False, include_classes=False)
+    nodes = dict(
+        [
+            (
+                (_MODULE, "proj.m"),
+                {cs.KEY_QUALIFIED_NAME: "proj.m", cs.KEY_PATH: "m.py"},
+            ),
+            _fn("proj.m._global_options", decorators=["@app.callback()"]),
+        ]
+    )
+    dead = dead_code_from_graph(nodes, [], _PREFIX, config)
+    assert dead == set()
+
+
+def _class(uid: str, path: str = "m.py") -> tuple:
+    return (
+        (_CLASS, uid),
+        {cs.KEY_QUALIFIED_NAME: uid, cs.KEY_PATH: path},
+    )
+
+
+def test_protocol_stub_method_is_a_root() -> None:
+    # (H) A method of a typing.Protocol subclass is an interface stub; callers are
+    # (H) traced to the implementations, never to the stub itself, so the stub must
+    # (H) not be reported dead while a plain class's uncalled private method is.
+    nodes = dict(
+        [
+            (
+                (_MODULE, "proj.m"),
+                {cs.KEY_QUALIFIED_NAME: "proj.m", cs.KEY_PATH: "m.py"},
+            ),
+            _class("proj.m.Loadable"),
+            _class("proj.m.Plain"),
+            _method("proj.m.Loadable._ensure_loaded"),
+            _method("proj.m.Plain._helper"),
+        ]
+    )
+    rels = [
+        (_CLASS, "proj.m.Loadable", _INHERITS, _CLASS, "typing.Protocol"),
+        (
+            _CLASS,
+            "proj.m.Loadable",
+            _DEFINES_METHOD,
+            cs.NodeLabel.METHOD.value,
+            "proj.m.Loadable._ensure_loaded",
+        ),
+        (
+            _CLASS,
+            "proj.m.Plain",
+            _DEFINES_METHOD,
+            cs.NodeLabel.METHOD.value,
+            "proj.m.Plain._helper",
+        ),
+    ]
+    dead = dead_code_from_graph(nodes, rels, _PREFIX, _CONFIG)
+    assert dead == {"proj.m.Plain._helper"}
+
+
+def _make_registration_repo(root: Path) -> None:
+    root.mkdir(parents=True)
+    (root / "__init__.py").write_text("", encoding="utf-8")
+    (root / "m.py").write_text(
+        "from typing import Protocol\n\n\n"
+        "class Loadable(Protocol):\n"
+        "    def _ensure_loaded(self) -> None: ...\n\n\n"
+        "def get_input(bindings):\n"
+        "    @bindings.add('c-j')\n"
+        "    def _submit(event):\n"
+        "        return event\n"
+        "    return bindings\n\n\n"
+        "get_input(None)\n",
+        encoding="utf-8",
+    )
+
+
+def test_cgr_dead_code_keeps_registration_closures_and_protocol_stubs(
+    tmp_path: Path,
+) -> None:
+    # (H) Full parse -> graph -> reachability: the @bindings.add closure and the
+    # (H) Protocol stub must not be flagged (the 2026-07-03 false-positive shapes).
+    src = tmp_path / "proj"
+    _make_registration_repo(src)
+    dead = cgr_dead_code(src, "proj", default_dead_code_config(False, False))
+    assert "proj.m.get_input._submit" not in dead
+    assert "proj.m.Loadable._ensure_loaded" not in dead
 
 
 def test_score_dead_code_prf() -> None:

--- a/codebase_rag/tests/test_dead_code_eval.py
+++ b/codebase_rag/tests/test_dead_code_eval.py
@@ -328,6 +328,70 @@ def test_registration_decorated_nested_function_is_a_root() -> None:
     assert dead == {"proj.m.outer._unused"}
 
 
+def test_closure_of_dead_function_is_not_a_root() -> None:
+    # (H) The registration exemption is tied to a LIVE owner: when the enclosing
+    # (H) function is itself unreachable its decorated closure never registers, so
+    # (H) the closure and the helper only it calls are dead too, not hidden.
+    nodes = dict(
+        [
+            (
+                (_MODULE, "proj.m"),
+                {cs.KEY_QUALIFIED_NAME: "proj.m", cs.KEY_PATH: "m.py"},
+            ),
+            _fn("proj.m.main"),
+            _fn("proj.m.dead_outer"),
+            _fn("proj.m.dead_outer._ghost", decorators=["@bindings.add('c-x')"]),
+            _fn("proj.m.victim"),
+        ]
+    )
+    rels = [
+        (_MODULE, "proj.m", _CALLS, _FUNCTION, "proj.m.main"),
+        (
+            _FUNCTION,
+            "proj.m.dead_outer",
+            _DEFINES,
+            _FUNCTION,
+            "proj.m.dead_outer._ghost",
+        ),
+        (_FUNCTION, "proj.m.dead_outer._ghost", _CALLS, _FUNCTION, "proj.m.victim"),
+    ]
+    dead = dead_code_from_graph(nodes, rels, _PREFIX, _CONFIG)
+    assert dead == {
+        "proj.m.dead_outer",
+        "proj.m.dead_outer._ghost",
+        "proj.m.victim",
+    }
+
+
+def test_closure_callee_of_live_function_stays_live() -> None:
+    # (H) The registered closure of a LIVE owner runs, so a helper reachable only
+    # (H) through the closure's calls is live as well.
+    nodes = dict(
+        [
+            (
+                (_MODULE, "proj.m"),
+                {cs.KEY_QUALIFIED_NAME: "proj.m", cs.KEY_PATH: "m.py"},
+            ),
+            _fn("proj.m.outer"),
+            _fn("proj.m.outer._submit", decorators=["@bindings.add('c-j')"]),
+            _fn("proj.m._only_from_closure"),
+        ]
+    )
+    rels = [
+        (_MODULE, "proj.m", _CALLS, _FUNCTION, "proj.m.outer"),
+        (_FUNCTION, "proj.m.outer", _DEFINES, _FUNCTION, "proj.m.outer._submit"),
+        (
+            _FUNCTION,
+            "proj.m.outer._submit",
+            _CALLS,
+            _FUNCTION,
+            "proj.m._only_from_closure",
+        ),
+    ]
+    dead = dead_code_from_graph(nodes, rels, _PREFIX, _CONFIG)
+    assert dead == set()
+
+
 def test_typer_callback_decorator_is_a_root() -> None:
     # (H) typer invokes @app.callback() functions by registration, so the default
     # (H) decorator whitelist must seed them as roots (codebase_rag.cli shape).

--- a/evals/dead_code.py
+++ b/evals/dead_code.py
@@ -85,6 +85,16 @@ def _has_root_decorator(props: PropertyDict, root_decorators: frozenset[str]) ->
     return any(_norm_decorator(str(d)) in root_decorators for d in decorators)
 
 
+def _walk(frontier: set[str], adjacency: dict[str, set[str]], live: set[str]) -> None:
+    stack = list(frontier)
+    while stack:
+        current = stack.pop()
+        for nxt in adjacency.get(current, ()):
+            if nxt not in live:
+                live.add(nxt)
+                stack.append(nxt)
+
+
 def dead_code_from_graph(
     nodes: dict[_NodeId, PropertyDict],
     rels: list[_RelTuple],
@@ -113,16 +123,16 @@ def dead_code_from_graph(
                 method_qns.add(str(uid))
 
     roots: set[str] = set()
-    # (H) Mirror the query's registration/protocol root clauses: a decorated
-    # (H) function DEFINED by a function/method is handed to a framework when the
-    # (H) enclosing function runs, and a method of a typing.Protocol subclass is an
-    # (H) interface stub whose callers resolve to the implementations.
-    callable_defined: set[str] = set()
+    # (H) Mirror the query's protocol root clause and closure expansion inputs: a
+    # (H) method of a typing.Protocol subclass is an interface stub whose callers
+    # (H) resolve to the implementations, and DEFINES edges from functions/methods
+    # (H) feed the live-owner registration round below.
+    defines_pairs: list[tuple[str, str]] = []
     protocol_classes: set[str] = set()
     class_methods: list[tuple[str, str]] = []
     for from_label, from_val, rel_type, _to_label, to_val in rels:
         if rel_type == _DEFINES and from_label in (_FUNCTION, _METHOD):
-            callable_defined.add(str(to_val))
+            defines_pairs.append((str(from_val), str(to_val)))
         elif rel_type == _INHERITS and str(to_val) in cs.PROTOCOL_BASE_QNS:
             protocol_classes.add(str(from_val))
         elif rel_type == _DEFINES_METHOD:
@@ -146,8 +156,6 @@ def dead_code_from_graph(
             roots.add(qn)
         elif props.get(cs.KEY_IS_EXPORTED) is True:
             roots.add(qn)
-        elif qn in callable_defined and props.get(cs.KEY_DECORATORS):
-            roots.add(qn)
         elif qn in protocol_stubs:
             roots.add(qn)
         elif (
@@ -170,13 +178,23 @@ def dead_code_from_graph(
             adjacency[str(from_val)].add(str(to_val))
 
     live = set(roots)
-    stack = list(roots)
-    while stack:
-        current = stack.pop()
-        for nxt in adjacency.get(current, ()):
-            if nxt not in live:
-                live.add(nxt)
-                stack.append(nxt)
+    _walk(roots, adjacency, live)
+
+    # (H) Second expansion, mirroring the query: a decorated function DEFINED by a
+    # (H) LIVE owner is framework-registered when the owner runs, so it and its
+    # (H) callees are live; the closure of a DEAD owner never registers and stays
+    # (H) in the reported cluster. ponytail: one round, same depth-2 ceiling as the
+    # (H) Cypher template (see _DEAD_CODE_QUERY_TEMPLATE).
+    closure_roots = {
+        c
+        for o, c in defines_pairs
+        if o in live
+        and c not in live
+        and c in props_by_qn
+        and props_by_qn[c].get(cs.KEY_DECORATORS)
+    }
+    live |= closure_roots
+    _walk(closure_roots, adjacency, live)
 
     return candidates - live
 

--- a/evals/dead_code.py
+++ b/evals/dead_code.py
@@ -32,6 +32,8 @@ _CLASS = cs.NodeLabel.CLASS.value
 _CALLS = cs.RelationshipType.CALLS.value
 _INSTANTIATES = cs.RelationshipType.INSTANTIATES.value
 _INHERITS = cs.RelationshipType.INHERITS.value
+_DEFINES = cs.RelationshipType.DEFINES.value
+_DEFINES_METHOD = cs.RelationshipType.DEFINES_METHOD.value
 _EMPTY_LOCATION = LocationStats(0, 0, 0, 0.0, 0)
 
 _NodeId = tuple[str, PropertyValue]
@@ -111,7 +113,20 @@ def dead_code_from_graph(
                 method_qns.add(str(uid))
 
     roots: set[str] = set()
+    # (H) Mirror the query's registration/protocol root clauses: a decorated
+    # (H) function DEFINED by a function/method is handed to a framework when the
+    # (H) enclosing function runs, and a method of a typing.Protocol subclass is an
+    # (H) interface stub whose callers resolve to the implementations.
+    callable_defined: set[str] = set()
+    protocol_classes: set[str] = set()
+    class_methods: list[tuple[str, str]] = []
     for from_label, from_val, rel_type, _to_label, to_val in rels:
+        if rel_type == _DEFINES and from_label in (_FUNCTION, _METHOD):
+            callable_defined.add(str(to_val))
+        elif rel_type == _INHERITS and str(to_val) in cs.PROTOCOL_BASE_QNS:
+            protocol_classes.add(str(from_val))
+        elif rel_type == _DEFINES_METHOD:
+            class_methods.append((str(from_val), str(to_val)))
         if from_label != _MODULE or rel_type not in module_rels:
             continue
         target_qn = str(to_val)
@@ -121,6 +136,7 @@ def dead_code_from_graph(
         is_test = any(pattern in path for pattern in config.test_patterns)
         if config.include_tests or not is_test:
             roots.add(target_qn)
+    protocol_stubs = {m for c, m in class_methods if c in protocol_classes}
 
     for qn in candidates:
         if qn in roots:
@@ -129,6 +145,10 @@ def dead_code_from_graph(
         if _has_root_decorator(props, config.root_decorators):
             roots.add(qn)
         elif props.get(cs.KEY_IS_EXPORTED) is True:
+            roots.add(qn)
+        elif qn in callable_defined and props.get(cs.KEY_DECORATORS):
+            roots.add(qn)
+        elif qn in protocol_stubs:
             roots.add(qn)
         elif (
             qn in method_qns

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.200"
+version = "0.0.203"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Problem

A dead-code sweep over this repo reported 18 candidates; 17 were false positives in three shapes:

1. **Decorator-registered closures**: functions nested inside another function and handed to a framework via a decorator (prompt_toolkit `@bindings.add(...)` keybindings in `main.py`, MCP `@server.list_tools()` / `@server.call_tool()` handlers in `mcp/server.py`). The decorator-name whitelist cannot enumerate every registration API.
2. **Typer callback**: `@app.callback()` on `cli._global_options` (`callback` was missing from `DEFAULT_ROOT_DECORATORS`).
3. **Protocol stubs**: `...`-body methods of `typing.Protocol` subclasses (`LoadableProtocol._ensure_loaded`, the `_*Deps` protocols in `parsers/py/`). Callers resolve to implementations, never to the stub.

The 18th candidate, `PythonAstAnalyzerMixin._traverse_for_assignments`, was genuinely dead (superseded by the `_PY_TRAVERSE_QUERY` tree-sitter path) and is removed.

## Fix

Two new reachability roots in `build_dead_code_query` and the eval mirror (`evals/dead_code.py`):

- a function with a non-empty decorator list that is `DEFINES`-owned by a Function/Method is framework-registered when the enclosing function runs;
- a method whose class `INHERITS` `typing.Protocol` / `typing_extensions.Protocol` is an interface stub.

Plus `callback` added to `DEFAULT_ROOT_DECORATORS`.

Roots only grow, so the dead set strictly shrinks: no new candidates are possible.

## Tests (red/green)

- 4 new unit tests on the in-memory mirror (`test_dead_code_eval.py`), including a full parse-to-reachability fixture reproducing the false-positive shapes.
- 1 new Memgraph integration test (`test_cypher_queries.py`) seeding both shapes plus dead controls.
- All confirmed failing before the fix; full suite green after (4376 passed, 14 pre-existing environmental skips).

Re-running the sweep over this repo confirms all 18 original candidates are gone.