### PR TITLE
ci: pass --no-sync to uv run pytest so the synced venv with test extras is used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,15 +106,19 @@ jobs:
         run: |
           uv sync --python ${{ matrix.python-version }} --extra treesitter-full --extra test --extra semantic --group dev
 
+      # (H) --no-sync is required: a bare `uv run` re-syncs to .python-version
+      # (H) (3.12) with default deps only, so on a 3.13 matrix (and on Windows,
+      # (H) where interpreter discovery mismatches the venv) it silently rebuilds
+      # (H) the venv without the test extra and pytest loses the xdist -n flag.
       - name: Run unit tests (parallel, with coverage)
         if: matrix.os == 'macos-latest' && matrix.python-version == '3.12'
         run: |
-          uv run pytest -n auto -m "not integration" --tb=short --cov=codebase_rag --cov-report=xml --cov-report=term
+          uv run --no-sync pytest -n auto -m "not integration" --tb=short --cov=codebase_rag --cov-report=xml --cov-report=term
 
       - name: Run unit tests (parallel, no coverage)
         if: matrix.os != 'macos-latest' || matrix.python-version != '3.12'
         run: |
-          uv run pytest -n auto -m "not integration" --tb=short
+          uv run --no-sync pytest -n auto -m "not integration" --tb=short
 
       - name: Upload coverage to Codecov
         if: always() && matrix.os == 'macos-latest' && matrix.python-version == '3.12'

--- a/README.md
+++ b/README.md
@@ -715,6 +715,7 @@ The knowledge graph uses the following node types and relationships:
 | ModuleImplementation | IMPLEMENTS | ModuleInterface |
 | Project | DEPENDS_ON_EXTERNAL | ExternalPackage |
 | Function, Method | CALLS | Function, Method |
+| Module, Function, Method | REFERENCES | Function, Method |
 | Module, Function, Method | INSTANTIATES | Class |
 <!-- /SECTION:relationship_schemas -->
 
@@ -778,7 +779,7 @@ docs/*.md
 <!-- SECTION:dependencies -->
 - **loguru**: Python logging made (stupidly) simple
 - **mcp**: Model Context Protocol SDK
-- **pydantic-ai**: Agent Framework / shim to use Pydantic with LLMs
+- **pydantic-ai**: AI Agent Framework, the Pydantic way
 - **pydantic-settings**: Settings management using Pydantic
 - **pymgclient**: Memgraph database adapter for Python language
 - **python-dotenv**: Read key-value pairs from a .env file and set them as environment variables

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.206"
+version = "0.0.207"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Problem

Unit Tests fail on main and every PR for the py3.13 matrix (all OSes) and for Windows py3.12 with:

```
pytest: error: unrecognized arguments: -n
```

## Root cause

`.python-version` pins 3.12. The install step builds the venv with `uv sync --python ${{ matrix.python-version }} --extra test ...` (pytest-xdist included, visible in the job log), but the test step runs bare `uv run pytest`. Without `--python`, `uv run` targets the pinned 3.12 and, on interpreter mismatch (any 3.13 job, and Windows where discovery mismatches the venv), silently recreates the venv with default dependencies only. The `test` extra is dropped, pytest-xdist disappears, and `-n` becomes an unknown flag. The matching-interpreter jobs (ubuntu/macos py3.12) survive because `uv run`'s inexact sync leaves the extras in place.

## Fix

`uv run --no-sync pytest ...` in both unit-test steps, so the environment prepared by the install step is used as-is.

Note: the SonarCloud Analysis failure on main is unrelated (`SONAR_TOKEN` rejected with HTTP 403, a repo-secret issue) and is not addressed here.