### PR TITLE
fix(windows): make the unit test suite pass on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ evals/oracles/java_oracle/*.class
 evals/oracles/lua_oracle/node_modules/
 # PHP oracle deps (the source + package-lock.json are committed)
 evals/oracles/php_oracle/node_modules/
+# Node oracle install bookkeeping (completion marker + concurrent-install lock)
+evals/oracles/*/.node-deps-installed
+evals/oracles/*/.node-deps-lock/
 # Scala oracle build artifacts (the source is committed; scala-cli fetches deps)
 evals/oracles/scala_oracle/.scala-build/
 evals/oracles/scala_oracle/.bsp/

--- a/codebase_rag/main.py
+++ b/codebase_rag/main.py
@@ -694,7 +694,7 @@ def _git_state() -> tuple[str, bool] | None:
             check=True,
             cwd=repo,
         )
-    except (subprocess.SubprocessError, FileNotFoundError):
+    except (subprocess.SubprocessError, OSError):
         return None
     lines = result.stdout.splitlines()
     if not lines or not lines[0].startswith("## "):
@@ -785,9 +785,13 @@ def _abbreviated_repo(p: Path | None) -> str:
         return ""
     try:
         home = Path.home()
-        return f"~/{p.relative_to(home)}" if p.is_relative_to(home) else str(p)
+        return (
+            f"~/{p.relative_to(home).as_posix()}"
+            if p.is_relative_to(home)
+            else p.as_posix()
+        )
     except (ValueError, OSError):
-        return str(p)
+        return p.as_posix()
 
 
 def _config_segments() -> list[tuple[str, str]]:

--- a/codebase_rag/main.py
+++ b/codebase_rag/main.py
@@ -790,7 +790,7 @@ def _abbreviated_repo(p: Path | None) -> str:
             if p.is_relative_to(home)
             else p.as_posix()
         )
-    except (ValueError, OSError):
+    except (ValueError, OSError, RuntimeError):
         return p.as_posix()
 
 

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -104,7 +104,7 @@ class DefinitionProcessor(
         if isinstance(file_path, str):
             file_path = Path(file_path)
         relative_path = cached_relative_path(file_path, self.repo_path)
-        relative_path_str = str(relative_path)
+        relative_path_str = relative_path.as_posix()
         logger.info(
             ls.DEF_PARSING_AST.format(language=language, path=relative_path_str)
         )
@@ -159,7 +159,7 @@ class DefinitionProcessor(
                 (cs.NodeLabel.PACKAGE, cs.KEY_QUALIFIED_NAME, parent_container_qn)
                 if parent_container_qn
                 else (
-                    (cs.NodeLabel.FOLDER, cs.KEY_PATH, str(parent_rel_path))
+                    (cs.NodeLabel.FOLDER, cs.KEY_PATH, parent_rel_path.as_posix())
                     if parent_rel_path != Path(".")
                     else (cs.NodeLabel.PROJECT, cs.KEY_NAME, self.project_name)
                 )

--- a/codebase_rag/tests/test_dead_code_command.py
+++ b/codebase_rag/tests/test_dead_code_command.py
@@ -153,7 +153,7 @@ class TestDeadCodeCommand:
             )
 
         assert result.exit_code == 0
-        payload = json.loads(out.read_text())
+        payload = json.loads(out.read_text(encoding="utf-8"))
         assert len(payload) == 2
 
     def test_writes_table_to_output_file(
@@ -165,7 +165,7 @@ class TestDeadCodeCommand:
             result = runner.invoke(app, ["dead-code", "--output", str(out)])
 
         assert result.exit_code == 0
-        written = out.read_text()
+        written = out.read_text(encoding="utf-8")
         assert "orphan_one" in written
 
     def test_handles_connection_error(self, runner: CliRunner) -> None:

--- a/codebase_rag/tests/test_node_oracle_deps.py
+++ b/codebase_rag/tests/test_node_oracle_deps.py
@@ -37,6 +37,21 @@ def test_half_installed_node_modules_triggers_install(tmp_path: Path) -> None:
     assert (tmp_path / ec.NODE_DEPS_MARKER).exists()
 
 
+def test_stale_marker_without_node_modules_reinstalls(tmp_path: Path) -> None:
+    # (H) Cache cleanup can remove node_modules but leave the gitignored marker;
+    # (H) the bootstrap must drop the stale marker and reinstall, not run the
+    # (H) oracle with missing packages.
+    (tmp_path / ec.NODE_DEPS_MARKER).touch()
+    with (
+        patch("evals.oracles._common.shutil.which", return_value="npm"),
+        patch(
+            "evals.oracles._common.subprocess.run", return_value=_npm_ok()
+        ) as run_mock,
+    ):
+        ensure_node_deps(tmp_path)
+    run_mock.assert_called_once()
+
+
 def test_completed_marker_skips_install(tmp_path: Path) -> None:
     (tmp_path / ec.NODE_MODULES_DIRNAME).mkdir()
     (tmp_path / ec.NODE_DEPS_MARKER).touch()
@@ -54,6 +69,7 @@ def test_concurrent_installer_lock_is_waited_out(tmp_path: Path) -> None:
     (tmp_path / ec.NODE_DEPS_LOCK).mkdir()
 
     def _finish_install(_seconds: float) -> None:
+        (tmp_path / ec.NODE_MODULES_DIRNAME).mkdir(exist_ok=True)
         (tmp_path / ec.NODE_DEPS_MARKER).touch()
 
     with (

--- a/codebase_rag/tests/test_node_oracle_deps.py
+++ b/codebase_rag/tests/test_node_oracle_deps.py
@@ -1,0 +1,82 @@
+# (H) Covers the shared node-oracle dependency bootstrap: `node_modules` existing
+# (H) is NOT proof of a completed npm install (npm creates the directory before
+# (H) populating it), so under pytest-xdist a sibling worker could run an oracle
+# (H) against a half-installed tree. The bootstrap must key on a completion marker
+# (H) written only after npm succeeds, and must surface node's stderr on failure.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from evals import constants as ec
+from evals.oracles._common import ensure_node_deps, run_node_oracle_payload
+
+
+def _npm_ok() -> MagicMock:
+    proc = MagicMock()
+    proc.returncode = 0
+    proc.stdout = "{}"
+    proc.stderr = ""
+    return proc
+
+
+def test_half_installed_node_modules_triggers_install(tmp_path: Path) -> None:
+    # (H) node_modules exists (npm died mid-install) but the marker is absent: the
+    # (H) bootstrap must run npm install anyway, then write the marker.
+    (tmp_path / ec.NODE_MODULES_DIRNAME).mkdir()
+    with (
+        patch("evals.oracles._common.shutil.which", return_value="npm"),
+        patch(
+            "evals.oracles._common.subprocess.run", return_value=_npm_ok()
+        ) as run_mock,
+    ):
+        ensure_node_deps(tmp_path)
+    run_mock.assert_called_once()
+    assert (tmp_path / ec.NODE_DEPS_MARKER).exists()
+
+
+def test_completed_marker_skips_install(tmp_path: Path) -> None:
+    (tmp_path / ec.NODE_MODULES_DIRNAME).mkdir()
+    (tmp_path / ec.NODE_DEPS_MARKER).touch()
+    with (
+        patch("evals.oracles._common.shutil.which", return_value="npm"),
+        patch("evals.oracles._common.subprocess.run") as run_mock,
+    ):
+        ensure_node_deps(tmp_path)
+    run_mock.assert_not_called()
+
+
+def test_concurrent_installer_lock_is_waited_out(tmp_path: Path) -> None:
+    # (H) Another worker holds the lock and finishes (writes the marker) while we
+    # (H) poll: no second npm install must run.
+    (tmp_path / ec.NODE_DEPS_LOCK).mkdir()
+
+    def _finish_install(_seconds: float) -> None:
+        (tmp_path / ec.NODE_DEPS_MARKER).touch()
+
+    with (
+        patch("evals.oracles._common.shutil.which", return_value="npm"),
+        patch("evals.oracles._common.subprocess.run") as run_mock,
+        patch("evals.oracles._common.time.sleep", side_effect=_finish_install),
+    ):
+        ensure_node_deps(tmp_path)
+    run_mock.assert_not_called()
+
+
+def test_failed_oracle_surfaces_stderr(tmp_path: Path) -> None:
+    # (H) exit 1 from the node script must raise with the script's stderr in the
+    # (H) message, not a blind CalledProcessError (CI debugging depends on it).
+    (tmp_path / ec.NODE_DEPS_MARKER).touch()
+    proc = MagicMock()
+    proc.returncode = 1
+    proc.stdout = ""
+    proc.stderr = "Cannot find module 'typescript'"
+    script = tmp_path / "ts_ast.js"
+    with (
+        patch("evals.oracles._common.shutil.which", return_value="node"),
+        patch("evals.oracles._common.subprocess.run", return_value=proc),
+        pytest.raises(RuntimeError, match="Cannot find module"),
+    ):
+        run_node_oracle_payload(tmp_path, script, ())

--- a/codebase_rag/tests/test_provider_configuration.py
+++ b/codebase_rag/tests/test_provider_configuration.py
@@ -133,7 +133,15 @@ class TestProviderConfiguration:
 
     def test_default_fallback_behavior(self) -> None:
         """Test that defaults work when no explicit provider is configured."""
-        with patch.dict(os.environ, {}, clear=True):
+        # (H) Clear provider vars but keep the home-dir vars: AppConfig's CGR_HOME
+        # (H) default calls Path.home(), which hard-fails on Windows without
+        # (H) USERPROFILE (POSIX falls back to pwd, so only CI on Windows caught it).
+        home_env = {
+            k: v
+            for k, v in os.environ.items()
+            if k in ("HOME", "USERPROFILE", "HOMEDRIVE", "HOMEPATH")
+        }
+        with patch.dict(os.environ, home_env, clear=True):
             config = AppConfig(_env_file=None)  # ty: ignore[unknown-argument]
 
             orch_config = config.active_orchestrator_config

--- a/codebase_rag/tests/test_status_bar_config.py
+++ b/codebase_rag/tests/test_status_bar_config.py
@@ -75,6 +75,14 @@ def test_abbreviated_repo_keeps_absolute_for_outside_paths() -> None:
     assert main_mod._abbreviated_repo(Path("/etc/hosts")) == "/etc/hosts"
 
 
+def test_abbreviated_repo_survives_unresolvable_home() -> None:
+    # (H) Path.home() raises RuntimeError when no home env vars are set (Windows
+    # (H) without USERPROFILE, bare containers); the status bar must fall back to
+    # (H) the absolute path instead of crashing.
+    with patch.object(main_mod.Path, "home", side_effect=RuntimeError):
+        assert main_mod._abbreviated_repo(Path("/etc/hosts")) == "/etc/hosts"
+
+
 def test_abbreviated_repo_handles_none() -> None:
     assert main_mod._abbreviated_repo(None) == ""
 

--- a/evals/constants.py
+++ b/evals/constants.py
@@ -343,6 +343,14 @@ NPM_BIN = "npm"
 NPM_INSTALL = "install"
 NPM_FLAGS: tuple[str, ...] = ("--no-audit", "--no-fund")
 NODE_MODULES_DIRNAME = "node_modules"
+# (H) npm creates node_modules before populating it, so its existence is not
+# (H) proof of a completed install; the marker is written only after npm exits 0,
+# (H) and the lock directory serializes concurrent pytest-xdist installers.
+NODE_DEPS_MARKER = ".node-deps-installed"
+NODE_DEPS_LOCK = ".node-deps-lock"
+NODE_DEPS_LOCK_TRIES = 600
+NODE_DEPS_LOCK_POLL_SECONDS = 0.5
+NODE_ORACLE_FAILED = "{script} exited {code}: {stderr}"
 TS_DTS_SUFFIX = ".d.ts"
 TS_SCORES_FILENAME = "ts_scores.csv"
 TS_DIFF_FILENAME = "ts_diff.json"

--- a/evals/oracles/_common.py
+++ b/evals/oracles/_common.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-from pathlib import PurePosixPath
+import json
+import shutil
+import subprocess
+import time
+from pathlib import Path, PurePosixPath
 
 from codebase_rag import constants as cs
 
@@ -17,6 +21,68 @@ from ..types_defs import (
     OraclePayload,
     OracleRecord,
 )
+
+
+def ensure_node_deps(oracle_dir: Path) -> None:
+    # (H) The marker (written only after npm exits 0) is the completion signal;
+    # (H) node_modules existing is not, because npm creates it before populating
+    # (H) it and a concurrent pytest-xdist worker would run the oracle against a
+    # (H) half-installed tree. The mkdir lock is atomic on every platform.
+    # (H) ponytail: a stale lock (installer killed mid-run) is waited out for
+    # (H) TRIES*POLL seconds and then skipped, letting the node run surface the
+    # (H) real error; clean the lock dir manually if that ever happens.
+    marker = oracle_dir / ec.NODE_DEPS_MARKER
+    if marker.exists():
+        return
+    npm = shutil.which(ec.NPM_BIN)
+    if npm is None:
+        return
+    lock = oracle_dir / ec.NODE_DEPS_LOCK
+    for _ in range(ec.NODE_DEPS_LOCK_TRIES):
+        try:
+            lock.mkdir()
+            break
+        except FileExistsError:
+            time.sleep(ec.NODE_DEPS_LOCK_POLL_SECONDS)
+            if marker.exists():
+                return
+    else:
+        return
+    try:
+        if not marker.exists():
+            subprocess.run(
+                [npm, ec.NPM_INSTALL, *ec.NPM_FLAGS],
+                cwd=str(oracle_dir),
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            marker.touch()
+    finally:
+        lock.rmdir()
+
+
+def run_node_oracle_payload(
+    oracle_dir: Path, script: Path, args: tuple[str, ...]
+) -> OraclePayload:
+    ensure_node_deps(oracle_dir)
+    node = shutil.which(ec.NODE_BIN)
+    if node is None:
+        return OraclePayload(nodes=[], edges=[], name_edges=[])
+    proc = subprocess.run(
+        [node, str(script), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            ec.NODE_ORACLE_FAILED.format(
+                script=script.name, code=proc.returncode, stderr=proc.stderr
+            )
+        )
+    payload: OraclePayload = json.loads(proc.stdout or "{}")
+    return payload
 
 
 def is_ignored(rel_file: str) -> bool:

--- a/evals/oracles/_common.py
+++ b/evals/oracles/_common.py
@@ -23,6 +23,14 @@ from ..types_defs import (
 )
 
 
+def _node_deps_ready(oracle_dir: Path) -> bool:
+    # (H) Both must hold: the marker proves npm completed, node_modules proves a
+    # (H) later cache cleanup did not delete the installed tree under the marker.
+    return (oracle_dir / ec.NODE_DEPS_MARKER).exists() and (
+        oracle_dir / ec.NODE_MODULES_DIRNAME
+    ).is_dir()
+
+
 def ensure_node_deps(oracle_dir: Path) -> None:
     # (H) The marker (written only after npm exits 0) is the completion signal;
     # (H) node_modules existing is not, because npm creates it before populating
@@ -32,7 +40,7 @@ def ensure_node_deps(oracle_dir: Path) -> None:
     # (H) TRIES*POLL seconds and then skipped, letting the node run surface the
     # (H) real error; clean the lock dir manually if that ever happens.
     marker = oracle_dir / ec.NODE_DEPS_MARKER
-    if marker.exists():
+    if _node_deps_ready(oracle_dir):
         return
     npm = shutil.which(ec.NPM_BIN)
     if npm is None:
@@ -44,12 +52,13 @@ def ensure_node_deps(oracle_dir: Path) -> None:
             break
         except FileExistsError:
             time.sleep(ec.NODE_DEPS_LOCK_POLL_SECONDS)
-            if marker.exists():
+            if _node_deps_ready(oracle_dir):
                 return
     else:
         return
     try:
-        if not marker.exists():
+        if not _node_deps_ready(oracle_dir):
+            marker.unlink(missing_ok=True)
             subprocess.run(
                 [npm, ec.NPM_INSTALL, *ec.NPM_FLAGS],
                 cwd=str(oracle_dir),

--- a/evals/oracles/lua_oracle.py
+++ b/evals/oracles/lua_oracle.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
-import json
 import shutil
-import subprocess
 from pathlib import Path
 
 from codebase_rag import constants as cs
 
 from .. import constants as ec
 from ..types_defs import GraphData, OraclePayload
-from ._common import is_ignored, payload_to_graph
+from ._common import is_ignored, payload_to_graph, run_node_oracle_payload
 
 _ORACLE_DIR = Path(__file__).parent / ec.LUA_ORACLE_DIRNAME
 _SCRIPT = _ORACLE_DIR / ec.LUA_ORACLE_SCRIPT
@@ -23,34 +21,8 @@ def lua_oracle_available() -> bool:
     )
 
 
-def _ensure_deps() -> None:
-    if _NODE_MODULES.is_dir():
-        return
-    npm = shutil.which(ec.NPM_BIN)
-    if npm is None:
-        return
-    subprocess.run(
-        [npm, ec.NPM_INSTALL, *ec.NPM_FLAGS],
-        cwd=str(_ORACLE_DIR),
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-
-
 def _run_lua_oracle_payload(target: Path) -> OraclePayload:
-    _ensure_deps()
-    node = shutil.which(ec.NODE_BIN)
-    if node is None:
-        return OraclePayload(nodes=[], edges=[], name_edges=[])
-    proc = subprocess.run(
-        [node, str(_SCRIPT), str(target)],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    payload: OraclePayload = json.loads(proc.stdout or "{}")
-    return payload
+    return run_node_oracle_payload(_ORACLE_DIR, _SCRIPT, (str(target),))
 
 
 def run_lua_oracle(target: Path) -> GraphData:

--- a/evals/oracles/php_oracle.py
+++ b/evals/oracles/php_oracle.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
-import json
 import shutil
-import subprocess
 from pathlib import Path
 
 from codebase_rag import constants as cs
 
 from .. import constants as ec
 from ..types_defs import GraphData, OraclePayload
-from ._common import is_ignored, payload_to_graph
+from ._common import is_ignored, payload_to_graph, run_node_oracle_payload
 
 _ORACLE_DIR = Path(__file__).parent / ec.PHP_ORACLE_DIRNAME
 _SCRIPT = _ORACLE_DIR / ec.PHP_ORACLE_SCRIPT
@@ -23,34 +21,8 @@ def php_oracle_available() -> bool:
     )
 
 
-def _ensure_deps() -> None:
-    if _NODE_MODULES.is_dir():
-        return
-    npm = shutil.which(ec.NPM_BIN)
-    if npm is None:
-        return
-    subprocess.run(
-        [npm, ec.NPM_INSTALL, *ec.NPM_FLAGS],
-        cwd=str(_ORACLE_DIR),
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-
-
 def _run_php_oracle_payload(target: Path) -> OraclePayload:
-    _ensure_deps()
-    node = shutil.which(ec.NODE_BIN)
-    if node is None:
-        return OraclePayload(nodes=[], edges=[], name_edges=[])
-    proc = subprocess.run(
-        [node, str(_SCRIPT), str(target)],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    payload: OraclePayload = json.loads(proc.stdout or "{}")
-    return payload
+    return run_node_oracle_payload(_ORACLE_DIR, _SCRIPT, (str(target),))
 
 
 def run_php_oracle(target: Path) -> GraphData:

--- a/evals/oracles/typescript_oracle.py
+++ b/evals/oracles/typescript_oracle.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
-import json
 import shutil
-import subprocess
 from pathlib import Path
 
 from codebase_rag import constants as cs
 
 from .. import constants as ec
 from ..types_defs import GraphData, OraclePayload
-from ._common import is_ignored, payload_to_graph
+from ._common import is_ignored, payload_to_graph, run_node_oracle_payload
 
 _ORACLE_DIR = Path(__file__).parent / ec.TS_ORACLE_DIRNAME
 _SCRIPT = _ORACLE_DIR / ec.TS_ORACLE_SCRIPT
@@ -23,34 +21,8 @@ def typescript_available() -> bool:
     )
 
 
-def _ensure_deps() -> None:
-    if _NODE_MODULES.is_dir():
-        return
-    npm = shutil.which(ec.NPM_BIN)
-    if npm is None:
-        return
-    subprocess.run(
-        [npm, ec.NPM_INSTALL, *ec.NPM_FLAGS],
-        cwd=str(_ORACLE_DIR),
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-
-
 def _run_payload(target: Path, suffixes: tuple[str, ...]) -> OraclePayload:
-    _ensure_deps()
-    node = shutil.which(ec.NODE_BIN)
-    if node is None:
-        return OraclePayload(nodes=[], edges=[], name_edges=[])
-    proc = subprocess.run(
-        [node, str(_SCRIPT), str(target), *suffixes],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    payload: OraclePayload = json.loads(proc.stdout or "{}")
-    return payload
+    return run_node_oracle_payload(_ORACLE_DIR, _SCRIPT, (str(target), *suffixes))
 
 
 def _run(target: Path, suffixes: tuple[str, ...]) -> GraphData:


### PR DESCRIPTION
## Problem

PR #602 made the Windows Unit Tests jobs actually run pytest, which surfaced 14 pre-existing failures (both py3.12 and py3.13). Six root causes:

1. **Backslash paths stored in the graph**: `definition_processor.py` used `str(relative_path)` for the Module `path` property and `str(parent_rel_path)` for Folder refs, while every other producer (File nodes, Function/Method props, cpp frontend) already used `as_posix()`. On Windows this broke module path lookups (`test_module_qn_language_collision`, 2 tests), CONTAINS_MODULE Folder refs, and produced mixed-separator edge ids in the C++/Rust oracle evals (3 tests).
2. **`_git_state` crash**: `subprocess.run` with an invalid `cwd` raises `NotADirectoryError` from `CreateProcess` on Windows, where POSIX returns a nonzero exit. The handler caught only `FileNotFoundError`; broadened to `OSError` (2 tests).
3. **Status bar rendered `str(Path)`**: backslashes leaked into the repo chip; `_abbreviated_repo` now renders POSIX consistently (5 tests).
4. **Provider test cleared the whole environment**: without `USERPROFILE`, `Path.home()` hard-fails on Windows (POSIX falls back to `pwd`). The test now keeps home vars while clearing provider vars (1 test).
5. **Dead-code output read with platform default encoding**: the CLI writes UTF-8 explicitly; the test read cp1252 on Windows and hit `UnicodeDecodeError` on box-drawing characters. Reads are now explicit UTF-8 (1 test).

## Verification

RED is the failing Windows matrix on main (e.g. run 28684978889: 14 failed). GREEN is this PR's Windows jobs. The full suite on macOS stays green (4398 passed), confirming the POSIX normalization is behavior-preserving off Windows.