### PR TITLE
feat(references): extend first-class assignment REFERENCES to JS/TS

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -110,6 +110,20 @@ _FLOW_ARG_REF_TYPES = frozenset(
 # (H) Qualified-name prefix marking a resolved callee as a builtin rather than a
 # (H) first-party function whose body the call chain can be followed into.
 _BUILTIN_QN_PREFIX = f"{cs.BUILTIN_PREFIX}{cs.SEPARATOR_DOT}"
+# (H) Assignment node type -> RHS field, per language family: Python `assignment`
+# (H) and JS/TS `assignment_expression` (client.post = fn) carry the RHS in
+# (H) `right`; a JS/TS `variable_declarator` (const cb = handler) carries it in
+# (H) `value`.
+_ASSIGNMENT_RHS_FIELDS = {
+    cs.TS_PY_ASSIGNMENT: cs.TS_FIELD_RIGHT,
+    cs.TS_ASSIGNMENT_EXPRESSION: cs.TS_FIELD_RIGHT,
+    cs.TS_VARIABLE_DECLARATOR: cs.FIELD_VALUE,
+}
+# (H) RHS node types that name a callable value: a bare identifier, a Python
+# (H) attribute (mod.fn), or a JS/TS member expression (handlers.run).
+_ASSIGNMENT_RHS_REF_TYPES = frozenset(
+    {cs.TS_PY_IDENTIFIER, cs.TS_PY_ATTRIBUTE, cs.TS_MEMBER_EXPRESSION}
+)
 
 
 class CallProcessor:
@@ -426,10 +440,10 @@ class CallProcessor:
                     None,
                     self._flow_scope_boundaries(queries[language][cs.QUERY_CONFIG]),
                 )
-            if language == cs.SupportedLanguage.PYTHON:
                 # (H) A module-scope first-class assignment (registry_handler =
-                # (H) handle_event) references its target even in a file with no
-                # (H) call expressions, so scan before the no-calls early return.
+                # (H) handle_event, module.exports.run = run) references its target
+                # (H) even in a file with no call expressions, so scan before the
+                # (H) no-calls early return.
                 self._ingest_assignment_function_references(
                     root_node,
                     (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, module_qn),
@@ -438,6 +452,7 @@ class CallProcessor:
                     None,
                     self._flow_scope_boundaries(queries[language][cs.QUERY_CONFIG]),
                 )
+            if language == cs.SupportedLanguage.PYTHON:
                 decorator_targets = list(sorted_func_nodes or [])
                 if combined_captures and (
                     class_nodes := combined_captures.get(cs.CAPTURE_CLASS)
@@ -1033,6 +1048,7 @@ class CallProcessor:
             self._ingest_operator_dispatch_calls(
                 caller_node, caller_spec, module_qn, local_var_types
             )
+        if language == cs.SupportedLanguage.PYTHON or language in _JS_TS_LANGUAGES:
             self._ingest_assignment_function_references(
                 caller_node,
                 caller_spec,
@@ -1504,12 +1520,9 @@ class CallProcessor:
             node = stack.pop()
             if node.type in boundary_types:
                 continue
-            if node.type == cs.TS_PY_ASSIGNMENT:
-                right = node.child_by_field_name(cs.TS_FIELD_RIGHT)
-                if right is not None and right.type in (
-                    cs.TS_PY_IDENTIFIER,
-                    cs.TS_PY_ATTRIBUTE,
-                ):
+            if rhs_field := _ASSIGNMENT_RHS_FIELDS.get(node.type):
+                right = node.child_by_field_name(rhs_field)
+                if right is not None and right.type in _ASSIGNMENT_RHS_REF_TYPES:
                     self._emit_callback_edge(
                         caller_spec,
                         right,

--- a/codebase_rag/tests/test_js_ts_assignment_reference_edges.py
+++ b/codebase_rag/tests/test_js_ts_assignment_reference_edges.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+
+def _run_rels(
+    tmp_path: Path, files: dict[str, str], lang_key: str
+) -> set[tuple[str, str, str]]:
+    # (H) Build the graph for `files` and return (caller_qn, rel_type, callee_qn).
+    parsers, queries = load_parsers()
+    if lang_key not in parsers:
+        pytest.skip(f"{lang_key} parser not available")
+    for rel, content in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock, repo_path=tmp_path, parsers=parsers, queries=queries
+    ).run()
+    return {
+        (c.args[0][2], str(c.args[1]), c.args[2][2])
+        for c in mock.ensure_relationship_batch.call_args_list
+    }
+
+
+def _has(
+    rels: set[tuple[str, str, str]], caller_suffix: str, rel: str, callee_suffix: str
+) -> bool:
+    return any(
+        a.endswith(caller_suffix) and r == rel and b.endswith(callee_suffix)
+        for a, r, b in rels
+    )
+
+
+REFERENCES = cs.RelationshipType.REFERENCES.value
+
+
+def test_js_function_assigned_to_const_is_referenced(tmp_path: Path) -> None:
+    # (H) `const cb = handler` binds a first-class function to a local for later
+    # (H) dynamic dispatch; the assignment must reference it exactly like the
+    # (H) Python `http_callback = fn` shape or dead-code wrongly flags handler.
+    files = {
+        "m.js": (
+            "function handler(evt) { return evt; }\n\n"
+            "function setup() {\n"
+            "    const cb = handler;\n"
+            "    return cb;\n"
+            "}\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files, "javascript")
+    assert _has(rels, "m.setup", REFERENCES, "m.handler")
+
+
+def test_js_function_assigned_to_object_attribute_is_referenced(
+    tmp_path: Path,
+) -> None:
+    # (H) A nested function monkeypatched onto an object attribute
+    # (H) (client.post = handlePost) is invoked later through that attribute; the
+    # (H) assignment_expression must reference it (MockHTTPRouter shape in JS).
+    files = {
+        "m.js": (
+            "function createMockClient(client) {\n"
+            "    async function handlePost(url) { return url; }\n"
+            "    client.post = handlePost;\n"
+            "    return client;\n"
+            "}\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files, "javascript")
+    assert _has(rels, "m.createMockClient", REFERENCES, "handlePost")
+
+
+def test_js_module_exports_assignment_in_callless_module_is_referenced(
+    tmp_path: Path,
+) -> None:
+    # (H) `module.exports.run = run` in a file with NO call expressions must still
+    # (H) emit the Module -> REFERENCES edge; the call-driven pass early-returns on
+    # (H) such modules, so the assignment scan has to run before it.
+    files = {
+        "m.js": ("function run() { return 1; }\n\nmodule.exports.run = run;\n"),
+    }
+    rels = _run_rels(tmp_path, files, "javascript")
+    assert _has(rels, "m", REFERENCES, "m.run")
+
+
+def test_js_imported_function_assigned_at_module_scope_is_referenced(
+    tmp_path: Path,
+) -> None:
+    # (H) A function defined in one file, imported and re-bound in another
+    # (H) (registryHandler = handleEvent) must reference the ORIGIN function.
+    files = {
+        "handlers.js": "export function handleEvent(evt) { return evt; }\n",
+        "registry.js": (
+            "import { handleEvent } from './handlers.js';\n\n"
+            "const registryHandler = handleEvent;\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files, "javascript")
+    assert _has(rels, "registry", REFERENCES, "handlers.handleEvent")
+
+
+def test_ts_annotated_const_assignment_is_referenced(tmp_path: Path) -> None:
+    # (H) A TS annotated declarator (const handler: Handler = handleEvent) carries
+    # (H) an extra type child; the walker must reference its value exactly like an
+    # (H) unannotated one.
+    files = {
+        "m.ts": (
+            "type Handler = (evt: string) => string;\n\n"
+            "function handleEvent(evt: string): string { return evt; }\n\n"
+            "const handler: Handler = handleEvent;\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files, "typescript")
+    assert _has(rels, "m", REFERENCES, "m.handleEvent")
+
+
+def test_js_plain_value_assignments_are_not_referenced(tmp_path: Path) -> None:
+    # (H) Non-callable RHS values (literals, plain locals) must not produce
+    # (H) REFERENCES noise.
+    files = {
+        "m.js": (
+            "function setup() {\n"
+            "    const limit = 3;\n"
+            "    const name = 'x';\n"
+            "    const copy = limit;\n"
+            "    return copy;\n"
+            "}\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files, "javascript")
+    assert not any(r == REFERENCES for _, r, _ in rels)

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.206"
+version = "0.0.207"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
The first-class assignment walker (`_ingest_assignment_function_references`, added in #599) only ran for Python, so JS/TS functions bound via `const cb = handler`, `client.post = handlePost`, or `module.exports.run = run` produced no REFERENCES edge and were wrongly flagged by dead-code.

- Generalize the walker's node matching via an assignment-node -> RHS-field table: Python `assignment` and JS/TS `assignment_expression` use `right`; JS/TS `variable_declarator` uses `value`. RHS ref types now include `member_expression`.
- Open both wiring gates (function-scope pass and the module-scope pass that runs before the no-calls early return) to JS/TS.

## Tests (RED -> GREEN)
6 new tests in `test_js_ts_assignment_reference_edges.py`: const alias, object-attribute monkeypatch of a nested function, `module.exports` assignment in a call-less module, cross-file imported function re-bound at module scope, TS annotated declarator, and a no-noise negative.

Full suite: 4397 passed, 14 skipped. ruff + format clean; ty at the pre-existing baseline.