### PR TITLE
fix(dead-code): exclude test-file symbols from candidates when tests are excluded

### DIFF
--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -101,6 +101,15 @@ _DEAD_CODE_TEST_ROOT_CLAUSE = (
     "\n    OR ANY(p IN $test_patterns WHERE n.path CONTAINS p)"
 )
 
+# (H) When tests are excluded, a test-file symbol's only callers (test functions)
+# (H) are excluded as roots, so reporting it is unconditional noise: test helpers
+# (H) and mocks are test infrastructure, not dead production code. Filter them
+# (H) from the reported candidates; production code reached only from tests is
+# (H) still reported.
+_DEAD_CODE_CANDIDATE_NON_TEST = (
+    "\n  AND NOT ANY(p IN $test_patterns WHERE n.path CONTAINS p)"
+)
+
 # (H) A node reached by a Module node runs at import (top-level statement,
 # (H) `if __name__ == "__main__"`, a bare decorator, or a module-scope
 # (H) construction), so it is a root. `size([...])` avoids the non-standard
@@ -175,7 +184,7 @@ WITH live_set, closure_roots, collect(DISTINCT cr_reached) AS cr_reached_set
 WITH live_set + closure_roots + cr_reached_set AS live_set
 MATCH (n:{labels})
 WHERE n.qualified_name STARTS WITH $project_prefix
-  AND NOT n IN live_set
+  AND NOT n IN live_set{candidate_clause}
 RETURN labels(n)[0] AS label, n.name AS name,
        n.qualified_name AS qualified_name,
        n.start_line AS start_line, n.end_line AS end_line
@@ -194,15 +203,18 @@ def build_dead_code_query(include_tests: bool, include_classes: bool = False) ->
     if include_tests:
         module_clause = _DEAD_CODE_MODULE_ROOT_ANY.format(module_rels=module_rels)
         test_clause = _DEAD_CODE_TEST_ROOT_CLAUSE
+        candidate_clause = ""
     else:
         module_clause = _DEAD_CODE_MODULE_ROOT_NON_TEST.format(module_rels=module_rels)
         test_clause = ""
+        candidate_clause = _DEAD_CODE_CANDIDATE_NON_TEST
     protocol_bases = ", ".join(f"'{qn}'" for qn in PROTOCOL_BASE_QNS)
     return _DEAD_CODE_QUERY_TEMPLATE.format(
         labels=labels,
         traversal=traversal,
         module_clause=module_clause,
         test_clause=test_clause,
+        candidate_clause=candidate_clause,
         protocol_stub_clause=_DEAD_CODE_PROTOCOL_STUB_CLAUSE.format(
             protocol_bases=protocol_bases
         ),

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -106,8 +106,10 @@ _DEAD_CODE_TEST_ROOT_CLAUSE = (
 # (H) and mocks are test infrastructure, not dead production code. Filter them
 # (H) from the reported candidates; production code reached only from tests is
 # (H) still reported.
+# (H) coalesce: a null path must not null out the NOT and silently drop the
+# (H) node from the report (NOT null = null in Cypher).
 _DEAD_CODE_CANDIDATE_NON_TEST = (
-    "\n  AND NOT ANY(p IN $test_patterns WHERE n.path CONTAINS p)"
+    "\n  AND NOT ANY(p IN $test_patterns WHERE coalesce(n.path, '') CONTAINS p)"
 )
 
 # (H) A node reached by a Module node runs at import (top-level statement,

--- a/codebase_rag/tests/integration/test_cypher_queries.py
+++ b/codebase_rag/tests/integration/test_cypher_queries.py
@@ -365,12 +365,24 @@ class TestBuildDeadCodeQueryUnit:
         query = build_dead_code_query(include_tests=False)
 
         # (H) test functions are NOT roots when excluding tests ...
-        assert "n.path CONTAINS" not in query
+        assert "OR ANY(p IN $test_patterns WHERE n.path CONTAINS p)" not in query
         # (H) ... but test_patterns still filters test modules out of the
         # (H) module-load root clause so test-only code is not kept alive.
         assert "$test_patterns" in query
         assert "m.path CONTAINS" in query
         assert "$project_prefix" in query
+        # (H) ... and test-file symbols are excluded from the REPORT: their only
+        # (H) callers are excluded as roots, so reporting them is unconditional
+        # (H) noise (test helpers/mocks are infrastructure, not dead production
+        # (H) code).
+        assert "AND NOT ANY(p IN $test_patterns WHERE n.path CONTAINS p)" in query
+
+    def test_include_tests_reports_test_file_candidates(self) -> None:
+        query = build_dead_code_query(include_tests=True)
+
+        # (H) with tests included, test-file symbols are roots AND stay
+        # (H) reportable candidates; no candidate-side path filter exists.
+        assert "AND NOT ANY(p IN $test_patterns WHERE n.path CONTAINS p)" not in query
 
     def test_module_load_callees_are_roots(self) -> None:
         query = build_dead_code_query(include_tests=False)
@@ -475,10 +487,11 @@ class TestBuildDeadCodeQueryIntegration:
         )
 
         names = {r["qualified_name"] for r in results}
-        # (H) without test roots, the test fn and its helper are no longer reachable
+        # (H) without test roots, production code reached only from tests (helper)
+        # (H) is reported; the test fn itself is test infrastructure, filtered
+        # (H) from candidates by path.
         assert names == {
             "proj.mod.orphan",
-            "proj.tests.test_runs",
             "proj.mod.helper",
         }
 

--- a/codebase_rag/tests/integration/test_cypher_queries.py
+++ b/codebase_rag/tests/integration/test_cypher_queries.py
@@ -375,14 +375,20 @@ class TestBuildDeadCodeQueryUnit:
         # (H) callers are excluded as roots, so reporting them is unconditional
         # (H) noise (test helpers/mocks are infrastructure, not dead production
         # (H) code).
-        assert "AND NOT ANY(p IN $test_patterns WHERE n.path CONTAINS p)" in query
+        assert (
+            "AND NOT ANY(p IN $test_patterns WHERE coalesce(n.path, '') CONTAINS p)"
+            in query
+        )
 
     def test_include_tests_reports_test_file_candidates(self) -> None:
         query = build_dead_code_query(include_tests=True)
 
         # (H) with tests included, test-file symbols are roots AND stay
         # (H) reportable candidates; no candidate-side path filter exists.
-        assert "AND NOT ANY(p IN $test_patterns WHERE n.path CONTAINS p)" not in query
+        assert (
+            "AND NOT ANY(p IN $test_patterns WHERE coalesce(n.path, '') CONTAINS p)"
+            not in query
+        )
 
     def test_module_load_callees_are_roots(self) -> None:
         query = build_dead_code_query(include_tests=False)

--- a/codebase_rag/tests/test_dead_code_command.py
+++ b/codebase_rag/tests/test_dead_code_command.py
@@ -203,7 +203,10 @@ class TestDeadCodeCommand:
         # (H) test functions themselves are not roots.
         assert "test_patterns" in params
         assert "OR ANY(p IN $test_patterns WHERE n.path CONTAINS p)" not in query
-        assert "AND NOT ANY(p IN $test_patterns WHERE n.path CONTAINS p)" in query
+        assert (
+            "AND NOT ANY(p IN $test_patterns WHERE coalesce(n.path, '') CONTAINS p)"
+            in query
+        )
 
     def test_classes_flag_includes_class_candidates(
         self, runner: CliRunner, dead_rows: list[ResultRow]

--- a/codebase_rag/tests/test_dead_code_command.py
+++ b/codebase_rag/tests/test_dead_code_command.py
@@ -199,9 +199,11 @@ class TestDeadCodeCommand:
         assert result.exit_code == 0
         query, params = mock_ingestor.fetch_all.call_args.args
         # (H) test_patterns is still passed (it filters test modules out of the
-        # (H) module-load roots), but test functions themselves are not roots.
+        # (H) module-load roots and test-file symbols out of the report), but
+        # (H) test functions themselves are not roots.
         assert "test_patterns" in params
-        assert "n.path CONTAINS" not in query
+        assert "OR ANY(p IN $test_patterns WHERE n.path CONTAINS p)" not in query
+        assert "AND NOT ANY(p IN $test_patterns WHERE n.path CONTAINS p)" in query
 
     def test_classes_flag_includes_class_candidates(
         self, runner: CliRunner, dead_rows: list[ResultRow]

--- a/codebase_rag/tests/test_dead_code_eval.py
+++ b/codebase_rag/tests/test_dead_code_eval.py
@@ -120,6 +120,32 @@ def test_pydantic_validator_is_a_root() -> None:
     assert dead == set()
 
 
+def test_test_file_symbols_are_not_candidates_when_tests_excluded() -> None:
+    # (H) A helper defined INSIDE a test file is test infrastructure, not
+    # (H) production dead code. With tests excluded its only callers (test
+    # (H) functions) can never root it, so reporting it is unconditional noise
+    # (H) (the MockHTTPRouter/mock-helper cluster); production code reached only
+    # (H) from tests must still be reported.
+    nodes = dict(
+        [
+            (
+                (_MODULE, "proj.tests.test_m"),
+                {
+                    cs.KEY_QUALIFIED_NAME: "proj.tests.test_m",
+                    cs.KEY_PATH: "tests/test_m.py",
+                },
+            ),
+            _fn("proj.tests.test_m._helper", path="tests/test_m.py"),
+            _fn("proj.m.only_tested"),
+        ]
+    )
+    rels = [
+        (_MODULE, "proj.tests.test_m", _CALLS, _FUNCTION, "proj.m.only_tested"),
+    ]
+    dead = dead_code_from_graph(nodes, rels, _PREFIX, _CONFIG)
+    assert dead == {"proj.m.only_tested"}
+
+
 def test_non_test_module_does_not_keep_code_alive_when_tests_excluded() -> None:
     # (H) With tests excluded, a call from a test module must not root project code.
     nodes = dict(

--- a/evals/dead_code.py
+++ b/evals/dead_code.py
@@ -118,6 +118,15 @@ def dead_code_from_graph(
         if label == _MODULE:
             module_path[str(uid)] = str(props.get(cs.KEY_PATH, ""))
         elif label in labels and str(uid).startswith(project_prefix):
+            # (H) Mirror the query's candidate-side test filter: with tests
+            # (H) excluded, a test-file symbol's only callers are excluded as
+            # (H) roots, so reporting it is unconditional noise (test helpers
+            # (H) and mocks are infrastructure, not dead production code).
+            if not config.include_tests and any(
+                pattern in str(props.get(cs.KEY_PATH, ""))
+                for pattern in config.test_patterns
+            ):
+                continue
             candidates.add(str(uid))
             props_by_qn[str(uid)] = props
             if label == _METHOD:

--- a/evals/dead_code.py
+++ b/evals/dead_code.py
@@ -123,7 +123,7 @@ def dead_code_from_graph(
             # (H) roots, so reporting it is unconditional noise (test helpers
             # (H) and mocks are infrastructure, not dead production code).
             if not config.include_tests and any(
-                pattern in str(props.get(cs.KEY_PATH, ""))
+                pattern in str(props.get(cs.KEY_PATH) or "")
                 for pattern in config.test_patterns
             ):
                 continue


### PR DESCRIPTION
## Summary
Dogfooding `dead-code` on cgr's own repo surfaced an asymmetry: with tests excluded (the default), test modules are filtered out of the ROOT set, but test-file symbols still appear as CANDIDATES. A helper or mock defined inside a test file can then never be rooted by its only callers, so it is reported unconditionally. This is exactly the MockHTTPRouter/mock-helper noise class from the platform-anterior report.

- `build_dead_code_query`: the final candidate MATCH gains `AND NOT ANY(p IN $test_patterns WHERE n.path CONTAINS p)` when tests are excluded. Production code reached only from tests (e.g. a helper only tests call) is still reported; the test infrastructure itself is not.
- `evals/dead_code.py`: mirror filter in the candidate loop.
- Integration expectation updated: excluding tests now reports `{orphan, helper}` (production), not the test function itself.

## Tests (RED -> GREEN)
- `test_test_file_symbols_are_not_candidates_when_tests_excluded` (eval mirror; also asserts production-only-tested code is still reported)
- query-shape assertions for both include_tests variants; `--no-include-tests` CLI test updated to pin the root clause absent and the candidate filter present.

Full suite: 4406 passed, 14 skipped. ruff + format clean; ty at the pre-existing baseline.