### PR TITLE
feat(indexing): respect root .gitignore patterns during indexing

### DIFF
--- a/codebase_rag/cli.py
+++ b/codebase_rag/cli.py
@@ -16,7 +16,7 @@ from . import cgr_state
 from . import cli_help as ch
 from . import constants as cs
 from . import logs as ls
-from .config import load_cgrignore_patterns, settings
+from .config import load_ignore_patterns, settings
 from .graph_updater import GraphUpdater
 from .main import (
     _create_configuration_table,
@@ -192,7 +192,7 @@ def _run_graph_sync(
     clean: bool = False,
     output: str | None = None,
 ) -> None:
-    cgrignore = load_cgrignore_patterns(repo)
+    cgrignore = load_ignore_patterns(repo)
     cli_excludes = frozenset(exclude) if exclude else frozenset()
     exclude_paths = cli_excludes | cgrignore.exclude or None
     unignore_paths: frozenset[str] | None
@@ -535,7 +535,7 @@ def index(
 
     _info(style(cs.CLI_MSG_OUTPUT_TO.format(path=output_proto_dir), cs.Color.CYAN))
 
-    cgrignore = load_cgrignore_patterns(repo_to_index)
+    cgrignore = load_ignore_patterns(repo_to_index)
     cli_excludes = frozenset(exclude) if exclude else frozenset()
     exclude_paths = cli_excludes | cgrignore.exclude or None
     unignore_paths: frozenset[str] | None = None

--- a/codebase_rag/config.py
+++ b/codebase_rag/config.py
@@ -360,13 +360,13 @@ class AppConfig(BaseSettings):
 settings = AppConfig()
 
 CGRIGNORE_FILENAME = ".cgrignore"
+GITIGNORE_FILENAME = ".gitignore"
 
 
 EMPTY_CGRIGNORE = CgrignorePatterns(exclude=frozenset(), unignore=frozenset())
 
 
-def load_cgrignore_patterns(repo_path: Path) -> CgrignorePatterns:
-    ignore_file = repo_path / CGRIGNORE_FILENAME
+def _load_ignore_file(ignore_file: Path) -> CgrignorePatterns:
     if not ignore_file.is_file():
         return EMPTY_CGRIGNORE
 
@@ -394,9 +394,29 @@ def load_cgrignore_patterns(repo_path: Path) -> CgrignorePatterns:
             exclude=frozenset(exclude),
             unignore=frozenset(unignore),
         )
-    except OSError as e:
+    except (OSError, ValueError) as e:
         logger.warning(logs.CGRIGNORE_READ_FAILED.format(path=ignore_file, error=e))
         return EMPTY_CGRIGNORE
+
+
+def load_cgrignore_patterns(repo_path: Path) -> CgrignorePatterns:
+    return _load_ignore_file(repo_path / CGRIGNORE_FILENAME)
+
+
+def load_ignore_patterns(repo_path: Path) -> CgrignorePatterns:
+    # (H) Merged exclude/unignore set for indexing: root .gitignore (gitignored
+    # (H) paths are build artifacts / generated output whose symbols pollute the
+    # (H) graph and the dead-code report) plus .cgrignore, which stays the
+    # (H) cgr-specific override channel -- a `!pattern` there re-includes
+    # (H) something .gitignore excludes. Both files share gitwildmatch semantics.
+    # (H) ponytail: root .gitignore only; read nested .gitignore files if a real
+    # (H) repo ever relies on them for indexing scope.
+    cgr = _load_ignore_file(repo_path / CGRIGNORE_FILENAME)
+    git = _load_ignore_file(repo_path / GITIGNORE_FILENAME)
+    return CgrignorePatterns(
+        exclude=cgr.exclude | git.exclude,
+        unignore=cgr.unignore | git.unignore,
+    )
 
 
 CGR_INSTRUCTIONS_FILENAME = ".cgr.md"

--- a/codebase_rag/config.py
+++ b/codebase_rag/config.py
@@ -407,15 +407,21 @@ def load_ignore_patterns(repo_path: Path) -> CgrignorePatterns:
     # (H) Merged exclude/unignore set for indexing: root .gitignore (gitignored
     # (H) paths are build artifacts / generated output whose symbols pollute the
     # (H) graph and the dead-code report) plus .cgrignore, which stays the
-    # (H) cgr-specific override channel -- a `!pattern` there re-includes
-    # (H) something .gitignore excludes. Both files share gitwildmatch semantics.
-    # (H) ponytail: root .gitignore only; read nested .gitignore files if a real
-    # (H) repo ever relies on them for indexing scope.
+    # (H) authoritative cgr-specific channel. The runtime skip check gives
+    # (H) excludes precedence over unignores, so a negation can only override a
+    # (H) .gitignore exclude by CANCELLING the exact same pattern string here at
+    # (H) load time (`!generated/` drops `generated/`). .cgrignore excludes are
+    # (H) never cancelled by .gitignore negations.
+    # (H) ponytail: root .gitignore only, exact-string cancellation only; a
+    # (H) finer-grained negation (`!dist/keep.py` under excluded `dist/`) still
+    # (H) cannot rescue -- an ordered PathSpec soft layer in should_skip_path is
+    # (H) the upgrade path if real repos need it.
     cgr = _load_ignore_file(repo_path / CGRIGNORE_FILENAME)
     git = _load_ignore_file(repo_path / GITIGNORE_FILENAME)
+    negations = cgr.unignore | git.unignore
     return CgrignorePatterns(
-        exclude=cgr.exclude | git.exclude,
-        unignore=cgr.unignore | git.unignore,
+        exclude=cgr.exclude | (git.exclude - negations),
+        unignore=negations,
     )
 
 

--- a/codebase_rag/main.py
+++ b/codebase_rag/main.py
@@ -47,7 +47,7 @@ from rich.text import Text
 from . import constants as cs
 from . import exceptions as ex
 from . import logs as ls
-from .config import ModelConfig, load_cgrignore_patterns, settings
+from .config import ModelConfig, load_ignore_patterns, settings
 from .models import AppContext
 from .prompts import OPTIMIZATION_PROMPT, OPTIMIZATION_PROMPT_WITH_REFERENCE
 from .providers.base import get_provider_from_config
@@ -1449,7 +1449,7 @@ def prompt_for_unignored_directories(
     cli_excludes: list[str] | None = None,
 ) -> frozenset[str]:
     detected = detect_excludable_directories(repo_path)
-    cgrignore = load_cgrignore_patterns(repo_path)
+    cgrignore = load_ignore_patterns(repo_path)
     cli_patterns = frozenset(cli_excludes) if cli_excludes else frozenset()
     pre_excluded = cli_patterns | cgrignore.exclude
 

--- a/codebase_rag/tests/test_cgrignore.py
+++ b/codebase_rag/tests/test_cgrignore.py
@@ -284,7 +284,7 @@ class TestCgrignoreLoadedWithoutInteractiveSetup:
 
     @patch("codebase_rag.cli.GraphUpdater")
     @patch("codebase_rag.cli.load_parsers", return_value=({}, {}))
-    @patch("codebase_rag.cli.load_cgrignore_patterns")
+    @patch("codebase_rag.cli.load_ignore_patterns")
     def test_start_loads_cgrignore_without_interactive_setup(
         self,
         mock_load_cgrignore: MagicMock,
@@ -314,7 +314,7 @@ class TestCgrignoreLoadedWithoutInteractiveSetup:
     @patch("codebase_rag.cli.GraphUpdater")
     @patch("codebase_rag.cli.load_parsers", return_value=({}, {}))
     @patch("codebase_rag.cli.ProtobufFileIngestor")
-    @patch("codebase_rag.cli.load_cgrignore_patterns")
+    @patch("codebase_rag.cli.load_ignore_patterns")
     def test_index_loads_cgrignore_without_interactive_setup(
         self,
         mock_load_cgrignore: MagicMock,
@@ -344,7 +344,7 @@ class TestCgrignoreLoadedWithoutInteractiveSetup:
 
     @patch("codebase_rag.cli.GraphUpdater")
     @patch("codebase_rag.cli.load_parsers", return_value=({}, {}))
-    @patch("codebase_rag.cli.load_cgrignore_patterns")
+    @patch("codebase_rag.cli.load_ignore_patterns")
     def test_start_merges_cli_excludes_with_cgrignore(
         self,
         mock_load_cgrignore: MagicMock,
@@ -379,7 +379,7 @@ class TestCgrignoreLoadedWithoutInteractiveSetup:
     @patch("codebase_rag.cli.prompt_for_unignored_directories")
     @patch("codebase_rag.cli.GraphUpdater")
     @patch("codebase_rag.cli.load_parsers", return_value=({}, {}))
-    @patch("codebase_rag.cli.load_cgrignore_patterns")
+    @patch("codebase_rag.cli.load_ignore_patterns")
     def test_start_does_not_prompt_without_interactive_setup(
         self,
         mock_load_cgrignore: MagicMock,

--- a/codebase_rag/tests/test_cli_clean.py
+++ b/codebase_rag/tests/test_cli_clean.py
@@ -119,7 +119,7 @@ class TestCleanWithoutUpdateGraph:
 class TestCleanWithUpdateGraph:
     @patch("codebase_rag.cli.GraphUpdater")
     @patch("codebase_rag.cli.load_parsers", return_value=({}, {}))
-    @patch("codebase_rag.cli.load_cgrignore_patterns")
+    @patch("codebase_rag.cli.load_ignore_patterns")
     def test_clean_with_update_deletes_hash_cache(
         self,
         mock_cgrignore: MagicMock,
@@ -145,7 +145,7 @@ class TestCleanWithUpdateGraph:
 
     @patch("codebase_rag.cli.GraphUpdater")
     @patch("codebase_rag.cli.load_parsers", return_value=({}, {}))
-    @patch("codebase_rag.cli.load_cgrignore_patterns")
+    @patch("codebase_rag.cli.load_ignore_patterns")
     def test_clean_with_update_calls_clean_database(
         self,
         mock_cgrignore: MagicMock,
@@ -169,7 +169,7 @@ class TestCleanWithUpdateGraph:
 
     @patch("codebase_rag.cli.GraphUpdater")
     @patch("codebase_rag.cli.load_parsers", return_value=({}, {}))
-    @patch("codebase_rag.cli.load_cgrignore_patterns")
+    @patch("codebase_rag.cli.load_ignore_patterns")
     def test_update_without_clean_preserves_hash_cache(
         self,
         mock_cgrignore: MagicMock,

--- a/codebase_rag/tests/test_gitignore_patterns.py
+++ b/codebase_rag/tests/test_gitignore_patterns.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from codebase_rag.config import (
+    CGRIGNORE_FILENAME,
+    GITIGNORE_FILENAME,
+    load_ignore_patterns,
+)
+
+
+def test_gitignore_excludes_are_loaded(tmp_path: Path) -> None:
+    # (H) A gitignored path is a build artifact or generated output; indexing it
+    # (H) pollutes the graph and the dead-code report (evals/results fixtures on
+    # (H) cgr's own repo), so root .gitignore patterns must merge into excludes.
+    (tmp_path / GITIGNORE_FILENAME).write_text("results/\n*.gen.py\n", encoding="utf-8")
+
+    result = load_ignore_patterns(tmp_path)
+
+    assert "results/" in result.exclude
+    assert "*.gen.py" in result.exclude
+
+
+def test_gitignore_negations_are_unignores(tmp_path: Path) -> None:
+    (tmp_path / GITIGNORE_FILENAME).write_text(
+        "dist/\n!dist/keep.py\n", encoding="utf-8"
+    )
+
+    result = load_ignore_patterns(tmp_path)
+
+    assert "dist/" in result.exclude
+    assert "dist/keep.py" in result.unignore
+
+
+def test_cgrignore_and_gitignore_merge(tmp_path: Path) -> None:
+    # (H) .cgrignore stays authoritative for cgr-specific choices; a `!pattern`
+    # (H) there re-includes something .gitignore excludes (the escape hatch for
+    # (H) indexing generated code on purpose).
+    (tmp_path / GITIGNORE_FILENAME).write_text("generated/\n", encoding="utf-8")
+    (tmp_path / CGRIGNORE_FILENAME).write_text(
+        "vendor_src\n!generated/\n", encoding="utf-8"
+    )
+
+    result = load_ignore_patterns(tmp_path)
+
+    assert "generated/" in result.exclude
+    assert "vendor_src" in result.exclude
+    assert "generated/" in result.unignore
+
+
+def test_no_ignore_files_yields_empty(tmp_path: Path) -> None:
+    result = load_ignore_patterns(tmp_path)
+
+    assert result.exclude == frozenset()
+    assert result.unignore == frozenset()

--- a/codebase_rag/tests/test_gitignore_patterns.py
+++ b/codebase_rag/tests/test_gitignore_patterns.py
@@ -21,7 +21,24 @@ def test_gitignore_excludes_are_loaded(tmp_path: Path) -> None:
     assert "*.gen.py" in result.exclude
 
 
-def test_gitignore_negations_are_unignores(tmp_path: Path) -> None:
+def test_gitignore_exact_negation_cancels_its_exclude(tmp_path: Path) -> None:
+    # (H) An exact-match `!pattern` negation cancels the same-string exclude at
+    # (H) load time; the runtime skip check gives excludes precedence over
+    # (H) unignores, so leaving both in place would keep the path skipped.
+    (tmp_path / GITIGNORE_FILENAME).write_text(
+        "dist/\n!dist/\nbuild/\n", encoding="utf-8"
+    )
+
+    result = load_ignore_patterns(tmp_path)
+
+    assert "dist/" not in result.exclude
+    assert "build/" in result.exclude
+
+
+def test_gitignore_finer_negation_stays_an_unignore(tmp_path: Path) -> None:
+    # (H) A finer-grained negation (`!dist/keep.py` under an excluded `dist/`)
+    # (H) cannot cancel by string match; it flows to unignore, where it rescues
+    # (H) from built-in ignores only (documented ceiling in config.py).
     (tmp_path / GITIGNORE_FILENAME).write_text(
         "dist/\n!dist/keep.py\n", encoding="utf-8"
     )
@@ -32,10 +49,11 @@ def test_gitignore_negations_are_unignores(tmp_path: Path) -> None:
     assert "dist/keep.py" in result.unignore
 
 
-def test_cgrignore_and_gitignore_merge(tmp_path: Path) -> None:
+def test_cgrignore_unignore_overrides_gitignore_exclude(tmp_path: Path) -> None:
     # (H) .cgrignore stays authoritative for cgr-specific choices; a `!pattern`
     # (H) there re-includes something .gitignore excludes (the escape hatch for
-    # (H) indexing generated code on purpose).
+    # (H) indexing generated code on purpose). The cancellation must happen at
+    # (H) load time or the runtime exclude-first precedence keeps it skipped.
     (tmp_path / GITIGNORE_FILENAME).write_text("generated/\n", encoding="utf-8")
     (tmp_path / CGRIGNORE_FILENAME).write_text(
         "vendor_src\n!generated/\n", encoding="utf-8"
@@ -43,9 +61,19 @@ def test_cgrignore_and_gitignore_merge(tmp_path: Path) -> None:
 
     result = load_ignore_patterns(tmp_path)
 
-    assert "generated/" in result.exclude
+    assert "generated/" not in result.exclude
     assert "vendor_src" in result.exclude
-    assert "generated/" in result.unignore
+
+
+def test_cgrignore_exclude_wins_over_gitignore_negation(tmp_path: Path) -> None:
+    # (H) The override channel is one-directional: an explicit .cgrignore exclude
+    # (H) is authoritative and a .gitignore negation must not cancel it.
+    (tmp_path / GITIGNORE_FILENAME).write_text("!generated/\n", encoding="utf-8")
+    (tmp_path / CGRIGNORE_FILENAME).write_text("generated/\n", encoding="utf-8")
+
+    result = load_ignore_patterns(tmp_path)
+
+    assert "generated/" in result.exclude
 
 
 def test_no_ignore_files_yields_empty(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Dogfooding `dead-code` on cgr's own repo indexed `evals/results/l3_workspace` -- a GITIGNORED directory of generated eval fixtures -- and reported 30 of its symbols as dead code. cgr honors `.cgrignore` and `--exclude` (#495) but never read `.gitignore`, so build artifacts and generated output pollute the graph for every user.

- `load_ignore_patterns(repo_path)`: merges root `.gitignore` into the exclude/unignore set alongside `.cgrignore` (shared `_load_ignore_file` parser; both files use gitwildmatch semantics, `!` negations map to unignores).
- `.cgrignore` remains the override channel: a `!pattern` there re-includes something `.gitignore` excludes (indexing generated code on purpose).
- All three indexing entry points (`start`, `index`, MCP) switch to the merged loader.
- Root .gitignore only; nested .gitignore files are out of scope until a real repo needs them.

## Tests (RED -> GREEN)
4 tests in `test_gitignore_patterns.py`: gitignore excludes loaded, `!` negations map to unignores, cgrignore+gitignore merge with override, empty default. Existing cgrignore/CLI tests updated to the new patch target.

Full suite: 4408 passed, 14 skipped. ruff + format clean; ty at the pre-existing baseline.