### PR TITLE
fix(ts): parse .tsx files with the tsx grammar variant

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -101,7 +101,8 @@ EXT_LUA = ".lua"
 # (H) File extension tuples by language
 PY_EXTENSIONS = (EXT_PY,)
 JS_EXTENSIONS = (EXT_JS, EXT_JSX)
-TS_EXTENSIONS = (EXT_TS, EXT_TSX)
+TS_EXTENSIONS = (EXT_TS,)
+TSX_EXTENSIONS = (EXT_TSX,)
 RS_EXTENSIONS = (EXT_RS,)
 GO_EXTENSIONS = (EXT_GO,)
 SCALA_EXTENSIONS = (EXT_SCALA, EXT_SC)
@@ -623,6 +624,7 @@ class SupportedLanguage(StrEnum):
     PYTHON = "python"
     JS = "javascript"
     TS = "typescript"
+    TSX = "tsx"
     RUST = "rust"
     GO = "go"
     SCALA = "scala"
@@ -659,6 +661,11 @@ LANGUAGE_METADATA: dict[SupportedLanguage, LanguageMetadata] = {
         LanguageStatus.FULL,
         "Interfaces, type aliases, enums, namespaces, ES6/CommonJS modules",
         "TypeScript",
+    ),
+    SupportedLanguage.TSX: LanguageMetadata(
+        LanguageStatus.FULL,
+        "All TypeScript features plus JSX elements and components",
+        "TypeScript (TSX)",
     ),
     SupportedLanguage.C: LanguageMetadata(
         LanguageStatus.FULL,
@@ -754,7 +761,9 @@ JS_TS_FUNCTION_NODES = (
 )
 JS_TS_CLASS_NODES = ("class_declaration", "class")
 JS_TS_IMPORT_NODES = ("import_statement", "lexical_declaration", "export_statement")
-JS_TS_LANGUAGES = frozenset({SupportedLanguage.JS, SupportedLanguage.TS})
+JS_TS_LANGUAGES = frozenset(
+    {SupportedLanguage.JS, SupportedLanguage.TS, SupportedLanguage.TSX}
+)
 
 # (H) C++ import node types
 CPP_IMPORT_NODES = ("preproc_include", "template_function", "declaration")
@@ -1008,6 +1017,7 @@ BUILD_EXT_CMD = "build_ext"
 INPLACE_FLAG = "--inplace"
 LANG_ATTR_PREFIX = "language_"
 LANG_ATTR_TYPESCRIPT = "language_typescript"
+LANG_ATTR_TSX = "language_tsx"
 LANG_ATTR_PHP = "language_php"
 
 

--- a/codebase_rag/language_spec.py
+++ b/codebase_rag/language_spec.py
@@ -233,6 +233,7 @@ LANGUAGE_FQN_SPECS: dict[cs.SupportedLanguage, FQNSpec] = {
     cs.SupportedLanguage.PYTHON: PYTHON_FQN_SPEC,
     cs.SupportedLanguage.JS: JS_FQN_SPEC,
     cs.SupportedLanguage.TS: TS_FQN_SPEC,
+    cs.SupportedLanguage.TSX: TS_FQN_SPEC,
     cs.SupportedLanguage.RUST: RUST_FQN_SPEC,
     cs.SupportedLanguage.JAVA: JAVA_FQN_SPEC,
     cs.SupportedLanguage.C: C_FQN_SPEC,
@@ -243,6 +244,16 @@ LANGUAGE_FQN_SPECS: dict[cs.SupportedLanguage, FQNSpec] = {
     cs.SupportedLanguage.PHP: PHP_FQN_SPEC,
 }
 
+
+# (H) Node-type sets shared by the typescript and tsx grammar variants.
+_TS_FUNCTION_NODE_TYPES = cs.JS_TS_FUNCTION_NODES + (cs.TS_FUNCTION_SIGNATURE,)
+_TS_CLASS_NODE_TYPES = cs.JS_TS_CLASS_NODES + (
+    cs.TS_ABSTRACT_CLASS_DECLARATION,
+    cs.TS_ENUM_DECLARATION,
+    cs.TS_INTERFACE_DECLARATION,
+    cs.TS_TYPE_ALIAS_DECLARATION,
+    cs.TS_INTERNAL_MODULE,
+)
 
 LANGUAGE_SPECS: dict[cs.SupportedLanguage, LanguageSpec] = {
     cs.SupportedLanguage.PYTHON: LanguageSpec(
@@ -269,15 +280,22 @@ LANGUAGE_SPECS: dict[cs.SupportedLanguage, LanguageSpec] = {
     cs.SupportedLanguage.TS: LanguageSpec(
         language=cs.SupportedLanguage.TS,
         file_extensions=cs.TS_EXTENSIONS,
-        function_node_types=cs.JS_TS_FUNCTION_NODES + (cs.TS_FUNCTION_SIGNATURE,),
-        class_node_types=cs.JS_TS_CLASS_NODES
-        + (
-            cs.TS_ABSTRACT_CLASS_DECLARATION,
-            cs.TS_ENUM_DECLARATION,
-            cs.TS_INTERFACE_DECLARATION,
-            cs.TS_TYPE_ALIAS_DECLARATION,
-            cs.TS_INTERNAL_MODULE,
-        ),
+        function_node_types=_TS_FUNCTION_NODE_TYPES,
+        class_node_types=_TS_CLASS_NODE_TYPES,
+        module_node_types=cs.SPEC_JS_MODULE_TYPES,
+        call_node_types=cs.SPEC_JS_CALL_TYPES,
+        import_node_types=cs.JS_TS_IMPORT_NODES,
+        import_from_node_types=cs.JS_TS_IMPORT_NODES,
+    ),
+    # (H) .tsx needs the SEPARATE tsx grammar: the plain typescript grammar turns
+    # (H) JSX into an ERROR forest (dropping every call inside a component), and
+    # (H) the tsx grammar misparses bare generic arrows (`<T>(x) => x`) that are
+    # (H) legal .ts -- so each extension keeps its own grammar with a shared spec.
+    cs.SupportedLanguage.TSX: LanguageSpec(
+        language=cs.SupportedLanguage.TSX,
+        file_extensions=cs.TSX_EXTENSIONS,
+        function_node_types=_TS_FUNCTION_NODE_TYPES,
+        class_node_types=_TS_CLASS_NODE_TYPES,
         module_node_types=cs.SPEC_JS_MODULE_TYPES,
         call_node_types=cs.SPEC_JS_CALL_TYPES,
         import_node_types=cs.JS_TS_IMPORT_NODES,

--- a/codebase_rag/parser_loader.py
+++ b/codebase_rag/parser_loader.py
@@ -84,11 +84,14 @@ def _try_load_from_submodule(lang_name: cs.SupportedLanguage) -> LanguageLoader:
 def _try_import_language(
     module_path: str, attr_name: str, lang_name: cs.SupportedLanguage
 ) -> LanguageLoader:
+    # (H) AttributeError covers a pip package too old to export the requested
+    # (H) grammar variant (tree_sitter_typescript without language_tsx); fall
+    # (H) back rather than crash parser init for every language.
     try:
         module = importlib.import_module(module_path)
         loader: LanguageLoader = getattr(module, attr_name)
         return loader
-    except ImportError:
+    except (ImportError, AttributeError):
         return _try_load_from_submodule(lang_name)
 
 
@@ -111,6 +114,17 @@ def _import_language_loaders() -> dict[cs.SupportedLanguage, LanguageLoader]:
             cs.TreeSitterModule.TS,
             cs.LANG_ATTR_TYPESCRIPT,
             cs.SupportedLanguage.TS,
+        ),
+        # (H) Same pip package ships both grammar variants; .tsx needs the tsx
+        # (H) one or JSX parses as an ERROR forest. The submodule fallback name
+        # (H) is TSX on purpose: no grammars/tree-sitter-tsx exists, so a
+        # (H) too-old pip package leaves TSX unavailable instead of silently
+        # (H) binding the wrong (typescript) grammar.
+        LanguageImport(
+            cs.SupportedLanguage.TSX,
+            cs.TreeSitterModule.TS,
+            cs.LANG_ATTR_TSX,
+            cs.SupportedLanguage.TSX,
         ),
         LanguageImport(
             cs.SupportedLanguage.RUST,
@@ -191,7 +205,7 @@ def _get_locals_pattern(lang_name: cs.SupportedLanguage) -> str | None:
     match lang_name:
         case cs.SupportedLanguage.JS:
             return cs.JS_LOCALS_PATTERN
-        case cs.SupportedLanguage.TS:
+        case cs.SupportedLanguage.TS | cs.SupportedLanguage.TSX:
             return cs.TS_LOCALS_PATTERN
         case _:
             return None

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -63,6 +63,7 @@ _TYPED_LANGUAGES = frozenset(
         cs.SupportedLanguage.PYTHON,
         cs.SupportedLanguage.JS,
         cs.SupportedLanguage.TS,
+        cs.SupportedLanguage.TSX,
         cs.SupportedLanguage.JAVA,
         cs.SupportedLanguage.LUA,
         cs.SupportedLanguage.GO,
@@ -74,7 +75,7 @@ _TYPED_LANGUAGES = frozenset(
 # (H) name lives in a nested declarator (no `name` field). Both need the libclang
 # (H) declarator-aware extractor rather than a plain child_by_field_name("name").
 _C_FAMILY_LANGUAGES = frozenset({cs.SupportedLanguage.C, cs.SupportedLanguage.CPP})
-_JS_TS_LANGUAGES = frozenset({cs.SupportedLanguage.JS, cs.SupportedLanguage.TS})
+_JS_TS_LANGUAGES = cs.JS_TS_LANGUAGES
 
 # (H) Python nested-scope boundaries and sequence-literal node types used when
 # (H) scanning a scope for dispatch tables of function references.
@@ -1085,7 +1086,7 @@ class CallProcessor:
             return
 
         is_java = language == cs.SupportedLanguage.JAVA
-        is_js_ts = language in (cs.SupportedLanguage.JS, cs.SupportedLanguage.TS)
+        is_js_ts = language in _JS_TS_LANGUAGES
         is_cpp = language == cs.SupportedLanguage.CPP
         method_invocation_type = cs.TS_METHOD_INVOCATION
         resolver = self._resolver

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -193,7 +193,7 @@ class DefinitionProcessor(
                 queries,
                 pre_captures=combined_captures,
             )
-            if language in (cs.SupportedLanguage.JS, cs.SupportedLanguage.TS):
+            if language in cs.JS_TS_LANGUAGES:
                 self._ingest_missing_import_patterns(
                     root_node, module_qn, language, queries
                 )
@@ -216,7 +216,7 @@ class DefinitionProcessor(
                 queries,
                 combined_captures=combined_captures,
             )
-            if language in (cs.SupportedLanguage.JS, cs.SupportedLanguage.TS):
+            if language in cs.JS_TS_LANGUAGES:
                 self._ingest_object_literal_methods(
                     root_node, module_qn, language, queries
                 )

--- a/codebase_rag/parsers/handlers/registry.py
+++ b/codebase_rag/parsers/handlers/registry.py
@@ -17,6 +17,7 @@ _HANDLERS: dict[SupportedLanguage, type[BaseLanguageHandler]] = {
     SupportedLanguage.PYTHON: PythonHandler,
     SupportedLanguage.JS: JsTsHandler,
     SupportedLanguage.TS: JsTsHandler,
+    SupportedLanguage.TSX: JsTsHandler,
     SupportedLanguage.CPP: CppHandler,
     SupportedLanguage.RUST: RustHandler,
     SupportedLanguage.JAVA: JavaHandler,

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -271,7 +271,11 @@ class ImportProcessor:
             match language:
                 case cs.SupportedLanguage.PYTHON:
                     self._parse_python_imports(captures, module_qn)
-                case cs.SupportedLanguage.JS | cs.SupportedLanguage.TS:
+                case (
+                    cs.SupportedLanguage.JS
+                    | cs.SupportedLanguage.TS
+                    | cs.SupportedLanguage.TSX
+                ):
                     self._parse_js_ts_imports(captures, module_qn)
                 case cs.SupportedLanguage.JAVA:
                     self._parse_java_imports(captures, module_qn)
@@ -477,7 +481,11 @@ class ImportProcessor:
             case cs.SupportedLanguage.JAVA:
                 if full_name.startswith(project_prefix):
                     return full_name
-            case cs.SupportedLanguage.JS | cs.SupportedLanguage.TS:
+            case (
+                cs.SupportedLanguage.JS
+                | cs.SupportedLanguage.TS
+                | cs.SupportedLanguage.TSX
+            ):
                 if self._is_local_js_import(full_name):
                     return self._resolve_js_internal_module(full_name)
             case cs.SupportedLanguage.RUST:

--- a/codebase_rag/parsers/js_ts/type_inference.py
+++ b/codebase_rag/parsers/js_ts/type_inference.py
@@ -47,7 +47,9 @@ class JsTypeInferenceEngine:
     ) -> list[Node] | None:
         if self._queries is None:
             return None
-        langs = [language] if language is not None else list(cs.JS_TS_LANGUAGES)
+        # (H) sorted: frozenset order varies across runs (str-hash randomization)
+        # (H) and the first language with queries wins, so keep it deterministic.
+        langs = [language] if language is not None else sorted(cs.JS_TS_LANGUAGES)
         for lang in langs:
             lang_queries = self._queries.get(lang)
             if lang_queries and "language" in lang_queries:
@@ -236,7 +238,7 @@ class JsTypeInferenceEngine:
     def _get_language_obj(self) -> object | None:
         if self._queries is None:
             return None
-        for lang in cs.JS_TS_LANGUAGES:
+        for lang in sorted(cs.JS_TS_LANGUAGES):
             lang_queries = self._queries.get(lang)
             if lang_queries and "language" in lang_queries:
                 return lang_queries["language"]

--- a/codebase_rag/parsers/js_ts/type_inference.py
+++ b/codebase_rag/parsers/js_ts/type_inference.py
@@ -47,11 +47,7 @@ class JsTypeInferenceEngine:
     ) -> list[Node] | None:
         if self._queries is None:
             return None
-        langs = (
-            [language]
-            if language is not None
-            else [cs.SupportedLanguage.JS, cs.SupportedLanguage.TS]
-        )
+        langs = [language] if language is not None else list(cs.JS_TS_LANGUAGES)
         for lang in langs:
             lang_queries = self._queries.get(lang)
             if lang_queries and "language" in lang_queries:
@@ -240,7 +236,7 @@ class JsTypeInferenceEngine:
     def _get_language_obj(self) -> object | None:
         if self._queries is None:
             return None
-        for lang in (cs.SupportedLanguage.JS, cs.SupportedLanguage.TS):
+        for lang in cs.JS_TS_LANGUAGES:
             lang_queries = self._queries.get(lang)
             if lang_queries and "language" in lang_queries:
                 return lang_queries["language"]

--- a/codebase_rag/parsers/py/ast_analyzer.py
+++ b/codebase_rag/parsers/py/ast_analyzer.py
@@ -209,7 +209,11 @@ class PythonAstAnalyzerMixin(_AstBase):
                 return self._find_python_method_in_ast(
                     root_node, class_name, method_name
                 )
-            case cs.SupportedLanguage.JS | cs.SupportedLanguage.TS:
+            case (
+                cs.SupportedLanguage.JS
+                | cs.SupportedLanguage.TS
+                | cs.SupportedLanguage.TSX
+            ):
                 return find_js_method_in_ast(root_node, class_name, method_name)
             case _:
                 return None

--- a/codebase_rag/parsers/stdlib_extractor.py
+++ b/codebase_rag/parsers/stdlib_extractor.py
@@ -157,7 +157,11 @@ class StdlibExtractor:
         match language:
             case cs.SupportedLanguage.PYTHON:
                 return self._extract_python_stdlib_path(full_qualified_name)
-            case cs.SupportedLanguage.JS | cs.SupportedLanguage.TS:
+            case (
+                cs.SupportedLanguage.JS
+                | cs.SupportedLanguage.TS
+                | cs.SupportedLanguage.TSX
+            ):
                 return self._extract_js_stdlib_path(full_qualified_name)
             case cs.SupportedLanguage.GO:
                 return self._extract_go_stdlib_path(full_qualified_name)

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -195,7 +195,11 @@ class TypeInferenceEngine:
                 return self.python_type_inference.build_local_variable_type_map(
                     caller_node, module_qn
                 )
-            case cs.SupportedLanguage.JS | cs.SupportedLanguage.TS:
+            case (
+                cs.SupportedLanguage.JS
+                | cs.SupportedLanguage.TS
+                | cs.SupportedLanguage.TSX
+            ):
                 return self.js_type_inference.build_local_variable_type_map(
                     caller_node, module_qn, language
                 )

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -483,7 +483,7 @@ def callable_parameter_indices(
     elif language == cs.SupportedLanguage.GO:
         names = go_parameter_names(func_node)
         invoke = _go_invoked_parameter_names
-    elif language in (cs.SupportedLanguage.JS, cs.SupportedLanguage.TS):
+    elif language in cs.JS_TS_LANGUAGES:
         names = js_ts_parameter_names(func_node)
         invoke = _js_ts_invoked_parameter_names
     elif language == cs.SupportedLanguage.CPP:
@@ -522,7 +522,7 @@ def _js_ts_field_member_name(
     # (H) The binding name of a JS/TS class-field arrow / fn-expr whose enclosing
     # (H) field definition holds it as its `value` (`helper = () => ...`), so the
     # (H) member is modelled as class_qn.helper. None for other languages/shapes.
-    if language not in (cs.SupportedLanguage.JS, cs.SupportedLanguage.TS):
+    if language not in cs.JS_TS_LANGUAGES:
         return None
     if node.type not in (cs.TS_ARROW_FUNCTION, cs.TS_FUNCTION_EXPRESSION):
         return None

--- a/codebase_rag/tests/test_language_node_coverage.py
+++ b/codebase_rag/tests/test_language_node_coverage.py
@@ -82,7 +82,7 @@ EXTENSION_MAPPING_PARAMS = [
     (".js", SupportedLanguage.JS),
     (".jsx", SupportedLanguage.JS),
     (".ts", SupportedLanguage.TS),
-    (".tsx", SupportedLanguage.TS),
+    (".tsx", SupportedLanguage.TSX),
     (".rs", SupportedLanguage.RUST),
     (".go", SupportedLanguage.GO),
     (".scala", SupportedLanguage.SCALA),

--- a/codebase_rag/tests/test_tsx_jsx_calls.py
+++ b/codebase_rag/tests/test_tsx_jsx_calls.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+
+def _run_rels(tmp_path: Path, files: dict[str, str]) -> set[tuple[str, str, str]]:
+    # (H) Build the graph for `files` and return (caller_qn, rel_type, callee_qn).
+    parsers, queries = load_parsers()
+    if "typescript" not in parsers:
+        pytest.skip("typescript parser not available")
+    for rel, content in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock, repo_path=tmp_path, parsers=parsers, queries=queries
+    ).run()
+    return {
+        (c.args[0][2], str(c.args[1]), c.args[2][2])
+        for c in mock.ensure_relationship_batch.call_args_list
+    }
+
+
+def _has_call(
+    rels: set[tuple[str, str, str]], caller_suffix: str, callee_suffix: str
+) -> bool:
+    return any(
+        a.endswith(caller_suffix) and r == "CALLS" and b.endswith(callee_suffix)
+        for a, r, b in rels
+    )
+
+
+def test_tsx_call_inside_jsx_attribute_is_traced(tmp_path: Path) -> None:
+    # (H) .tsx must parse with the tsx grammar; the plain typescript grammar turns
+    # (H) JSX into an ERROR forest and every call inside any React component is
+    # (H) silently dropped (cn() in className={cn(...)} -- the shadcn/ui shape
+    # (H) that made whole component libraries report as dead code).
+    files = {
+        "utils.ts": "export function cn(...args: string[]) { return args.join(' ') }\n",
+        "card.tsx": (
+            "import { cn } from './utils'\n\n"
+            "export function Card({ className }: { className?: string }) {\n"
+            "  return <div className={cn('card', className)}>x</div>\n"
+            "}\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files)
+    assert _has_call(rels, "card.Card", "utils.cn")
+
+
+def test_tsx_call_in_jsx_event_handler_is_traced(tmp_path: Path) -> None:
+    # (H) An arrow handler inside a JSX attribute (onClick={() => save(id)}) lives
+    # (H) inside the JSX expression tree; its call must reach the graph.
+    files = {
+        "api.ts": "export function save(id: string) { return id }\n",
+        "button.tsx": (
+            "import { save } from './api'\n\n"
+            "export function SaveButton({ id }: { id: string }) {\n"
+            "  return <button onClick={() => save(id)}>save</button>\n"
+            "}\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files)
+    assert any(r == "CALLS" and b.endswith("api.save") for _, r, b in rels)
+
+
+def test_tsx_plain_typescript_constructs_still_work(tmp_path: Path) -> None:
+    # (H) The tsx grammar must not regress ordinary TS constructs inside .tsx.
+    files = {
+        "svc.tsx": (
+            "class Service {\n"
+            "  fetch(): number { return 1 }\n"
+            "}\n\n"
+            "export function useService() {\n"
+            "  const svc = new Service()\n"
+            "  return svc.fetch()\n"
+            "}\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files)
+    assert _has_call(rels, "svc.useService", "Service.fetch")
+
+
+def test_ts_generic_arrow_function_still_parses(tmp_path: Path) -> None:
+    # (H) Plain .ts keeps the typescript grammar: a bare generic arrow
+    # (H) (`<T>(x: T) => x`) is legal .ts but parses as JSX under the tsx
+    # (H) grammar, so .ts and .tsx need SEPARATE grammars, not a shared one.
+    files = {
+        "gen.ts": (
+            "export function target() { return 1 }\n\n"
+            "export const wrap = <T>(x: T): T => {\n"
+            "  target()\n"
+            "  return x\n"
+            "}\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files)
+    assert any(r == "CALLS" and b.endswith("gen.target") for _, r, b in rels)

--- a/codebase_rag/tests/test_tsx_jsx_calls.py
+++ b/codebase_rag/tests/test_tsx_jsx_calls.py
@@ -11,9 +11,12 @@ from codebase_rag.parser_loader import load_parsers
 
 def _run_rels(tmp_path: Path, files: dict[str, str]) -> set[tuple[str, str, str]]:
     # (H) Build the graph for `files` and return (caller_qn, rel_type, callee_qn).
+    # (H) Skip on the parser each fixture actually needs: an environment can have
+    # (H) typescript without tsx (pip package predating language_tsx).
     parsers, queries = load_parsers()
-    if "typescript" not in parsers:
-        pytest.skip("typescript parser not available")
+    required = {"tsx" if rel.endswith(".tsx") else "typescript" for rel in files}
+    if missing := sorted(required - parsers.keys()):
+        pytest.skip(f"parsers not available: {', '.join(missing)}")
     for rel, content in files.items():
         p = tmp_path / rel
         p.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
Dogfooding `dead-code` on the FastAPI full-stack template reported 333 candidates; the dominant cause was that **.tsx files were parsed with the plain `typescript` grammar, which cannot parse JSX**. Every component body degraded to an ERROR forest, so every call inside any React component (`cn()` in `className={...}`, handlers, hooks) was silently dropped -- whole component libraries reported as dead.

tree-sitter-typescript ships a separate `tsx` grammar. The two cannot be unified: the tsx grammar misparses bare generic arrows (`<T>(x) => x`) that are legal .ts, so each extension keeps its own grammar sharing one spec.

- `SupportedLanguage.TSX` variant: same node types, FQN spec, handler, locals pattern, and processor behavior as TS (all JS/TS gates now use the shared `cs.JS_TS_LANGUAGES`, which gains TSX); only the grammar and `.tsx` extension differ.
- Loader: `language_tsx` from the same pip package; the submodule fallback name is TSX on purpose so a too-old package leaves TSX unavailable instead of silently binding the wrong grammar; `_try_import_language` now also catches `AttributeError` for that case.

## Validation
- 4 tests in `test_tsx_jsx_calls.py` (2 RED before): call inside a JSX attribute, call in a JSX event-handler arrow, plain-TS constructs in .tsx, and the bare-generic-arrow .ts regression that forbids grammar unification.
- FastAPI template dead-code: 333 -> 177 candidates (with #604/#606 also in); the remainder is the separate JSX-component-usage reference gap.

Full suite: 4434 passed, 14 skipped. ruff + format clean; ty at the pre-existing 341 baseline.