### PR TITLE
feat(references): emit REFERENCES for JSX component usage

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -2290,6 +2290,11 @@ CPP_NESTED_SCOPE_NODE_TYPES = frozenset(
     )
 )
 JS_TS_PARENT_REF_TYPES = (TS_IDENTIFIER, TS_MEMBER_EXPRESSION)
+# (H) JSX element nodes that carry a component name (javascript and tsx
+# (H) grammars share these); the closing element repeats the name and must not
+# (H) double-emit.
+TS_JSX_SELF_CLOSING_ELEMENT = "jsx_self_closing_element"
+TS_JSX_OPENING_ELEMENT = "jsx_opening_element"
 
 # (H) Import processor function names
 IMPORT_REQUIRE = "require"

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1581,8 +1581,14 @@ class CallProcessor:
         # (H) The walk stops at nested scope boundaries (each nested function's
         # (H) own pass covers its JSX), but continues THROUGH jsx elements so
         # (H) nested markup is covered by the scope that renders it.
+        # (H) Resolve and emit directly rather than via _emit_callback_edge: a
+        # (H) class component resolves to a CLASS node whose reference must point
+        # (H) at the class itself, but that helper redirects CLASS -> __init__
+        # (H) (Python construction semantics) and drops the edge when __init__ is
+        # (H) absent, as it always is for a JS/TS class.
         resolve_func = self._resolver.resolve_function_call
         ensure_rel = self.ingestor.ensure_relationship_batch
+        registry = self._resolver.function_registry
         stack: list[Node] = list(caller_node.children)
         while stack:
             node = stack.pop()
@@ -1592,17 +1598,17 @@ class CallProcessor:
                 name_node = node.child_by_field_name(cs.FIELD_NAME)
                 name_text = safe_decode_text(name_node) if name_node else None
                 if name_text and name_text[0].isupper():
-                    self._emit_callback_edge(
-                        caller_spec,
-                        name_node,
-                        module_qn,
-                        local_var_types,
-                        class_context,
-                        resolve_func,
-                        ensure_rel,
-                        caller_qn,
-                        cs.RelationshipType.REFERENCES,
+                    resolved = resolve_func(
+                        name_text, module_qn, local_var_types, class_context, caller_qn
                     )
+                    if resolved:
+                        res_type, res_qn = resolved
+                        for target_qn in registry.variants(res_qn):
+                            ensure_rel(
+                                caller_spec,
+                                cs.RelationshipType.REFERENCES,
+                                (res_type, cs.KEY_QUALIFIED_NAME, target_qn),
+                            )
             stack.extend(node.children)
 
     def _ingest_collection_function_references(

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -125,6 +125,11 @@ _ASSIGNMENT_RHS_FIELDS = {
 _ASSIGNMENT_RHS_REF_TYPES = frozenset(
     {cs.TS_PY_IDENTIFIER, cs.TS_PY_ATTRIBUTE, cs.TS_MEMBER_EXPRESSION}
 )
+# (H) JSX nodes that carry a component name (self-closing and opening; a
+# (H) closing element repeats the name, so a paired element emits once).
+_JSX_NAMED_ELEMENT_TYPES = frozenset(
+    {cs.TS_JSX_SELF_CLOSING_ELEMENT, cs.TS_JSX_OPENING_ELEMENT}
+)
 
 
 class CallProcessor:
@@ -446,6 +451,18 @@ class CallProcessor:
                 # (H) even in a file with no call expressions, so scan before the
                 # (H) no-calls early return.
                 self._ingest_assignment_function_references(
+                    root_node,
+                    (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, module_qn),
+                    module_qn,
+                    None,
+                    None,
+                    self._flow_scope_boundaries(queries[language][cs.QUERY_CONFIG]),
+                )
+            if language in _JS_TS_LANGUAGES:
+                # (H) A module-scope JSX element (export default <App />) can sit
+                # (H) in a file with no call expressions; scan before the early
+                # (H) return like the assignment pass.
+                self._ingest_jsx_component_references(
                     root_node,
                     (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, module_qn),
                     module_qn,
@@ -1059,6 +1076,16 @@ class CallProcessor:
                 self._flow_scope_boundaries(queries[language][cs.QUERY_CONFIG]),
                 caller_qn,
             )
+        if language in _JS_TS_LANGUAGES:
+            self._ingest_jsx_component_references(
+                caller_node,
+                caller_spec,
+                module_qn,
+                local_var_types,
+                class_context,
+                self._flow_scope_boundaries(queries[language][cs.QUERY_CONFIG]),
+                caller_qn,
+            )
         # (H) Dispatch-table handler references, for every flow language. Module-scope
         # (H) literals are scanned explicitly in process_calls_in_file (before the
         # (H) no-calls early return), so only nested scopes here.
@@ -1527,6 +1554,47 @@ class CallProcessor:
                     self._emit_callback_edge(
                         caller_spec,
                         right,
+                        module_qn,
+                        local_var_types,
+                        class_context,
+                        resolve_func,
+                        ensure_rel,
+                        caller_qn,
+                        cs.RelationshipType.REFERENCES,
+                    )
+            stack.extend(node.children)
+
+    def _ingest_jsx_component_references(
+        self,
+        caller_node: Node,
+        caller_spec: tuple[str, str, str],
+        module_qn: str,
+        local_var_types: dict[str, str] | None,
+        class_context: str | None,
+        boundary_types: frozenset[str],
+        caller_qn: str | None = None,
+    ) -> None:
+        # (H) `<Card />` renders the Card component: the framework invokes it
+        # (H) through the element, never by a call the graph can see, so the JSX
+        # (H) usage references the component. Uppercase names only -- lowercase
+        # (H) tags are HTML elements and must not misbind to same-named locals.
+        # (H) The walk stops at nested scope boundaries (each nested function's
+        # (H) own pass covers its JSX), but continues THROUGH jsx elements so
+        # (H) nested markup is covered by the scope that renders it.
+        resolve_func = self._resolver.resolve_function_call
+        ensure_rel = self.ingestor.ensure_relationship_batch
+        stack: list[Node] = list(caller_node.children)
+        while stack:
+            node = stack.pop()
+            if node.type in boundary_types:
+                continue
+            if node.type in _JSX_NAMED_ELEMENT_TYPES:
+                name_node = node.child_by_field_name(cs.FIELD_NAME)
+                name_text = safe_decode_text(name_node) if name_node else None
+                if name_text and name_text[0].isupper():
+                    self._emit_callback_edge(
+                        caller_spec,
+                        name_node,
                         module_qn,
                         local_var_types,
                         class_context,

--- a/codebase_rag/tests/test_jsx_component_references.py
+++ b/codebase_rag/tests/test_jsx_component_references.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+REFERENCES = cs.RelationshipType.REFERENCES.value
+
+
+def _run_rels(
+    tmp_path: Path, files: dict[str, str], lang_key: str
+) -> set[tuple[str, str, str]]:
+    # (H) Build the graph for `files` and return (caller_qn, rel_type, callee_qn).
+    parsers, queries = load_parsers()
+    if lang_key not in parsers:
+        pytest.skip(f"{lang_key} parser not available")
+    for rel, content in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock, repo_path=tmp_path, parsers=parsers, queries=queries
+    ).run()
+    return {
+        (c.args[0][2], str(c.args[1]), c.args[2][2])
+        for c in mock.ensure_relationship_batch.call_args_list
+    }
+
+
+def _has(
+    rels: set[tuple[str, str, str]], caller_suffix: str, rel: str, callee_suffix: str
+) -> bool:
+    return any(
+        a.endswith(caller_suffix) and r == rel and b.endswith(callee_suffix)
+        for a, r, b in rels
+    )
+
+
+def test_tsx_component_usage_is_referenced(tmp_path: Path) -> None:
+    # (H) `<Card />` renders the Card component: React invokes it through the
+    # (H) element, so the JSX usage must reference it or every component used
+    # (H) only in markup reports as dead (the shadcn/ui cluster on the FastAPI
+    # (H) template).
+    files = {
+        "card.tsx": (
+            "export function Card({ title }: { title: string }) {\n"
+            "  return <div>{title}</div>\n"
+            "}\n"
+        ),
+        "app.tsx": (
+            "import { Card } from './card'\n\n"
+            "export function App() {\n"
+            "  return (\n"
+            "    <div>\n"
+            "      <Card title='a' />\n"
+            "    </div>\n"
+            "  )\n"
+            "}\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files, "tsx")
+    assert _has(rels, "app.App", REFERENCES, "card.Card")
+
+
+def test_tsx_paired_element_component_is_referenced(tmp_path: Path) -> None:
+    # (H) A paired element (<Layout>...</Layout>) carries the component name on
+    # (H) its opening element; only the opening side must emit (no duplicate
+    # (H) from the closing tag).
+    files = {
+        "layout.tsx": (
+            "export function Layout({ children }: { children: unknown }) {\n"
+            "  return <main>{children}</main>\n"
+            "}\n"
+        ),
+        "app.tsx": (
+            "import { Layout } from './layout'\n\n"
+            "export function App() {\n"
+            "  return <Layout><span>x</span></Layout>\n"
+            "}\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files, "tsx")
+    assert _has(rels, "app.App", REFERENCES, "layout.Layout")
+
+
+def test_jsx_component_usage_in_js_is_referenced(tmp_path: Path) -> None:
+    # (H) The javascript grammar parses JSX natively; .jsx files get the same
+    # (H) component-reference edges.
+    files = {
+        "widget.jsx": "export function Widget() {\n  return <b>w</b>\n}\n",
+        "page.jsx": (
+            "import { Widget } from './widget'\n\n"
+            "export function Page() {\n"
+            "  return <Widget />\n"
+            "}\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files, "javascript")
+    assert _has(rels, "page.Page", REFERENCES, "widget.Widget")
+
+
+def test_html_tags_are_not_referenced(tmp_path: Path) -> None:
+    # (H) Lowercase tags are HTML elements, not components; a same-named local
+    # (H) function (div) must not be misbound.
+    files = {
+        "app.tsx": (
+            "function div() { return 1 }\n\n"
+            "export function App() {\n"
+            "  return <div>x</div>\n"
+            "}\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files, "tsx")
+    assert not any(r == REFERENCES for _, r, _ in rels)
+
+
+def test_member_expression_component_is_referenced(tmp_path: Path) -> None:
+    # (H) A namespaced component (<Menu.Item />) names its member through a
+    # (H) member expression; resolve it like any dotted callable reference.
+    files = {
+        "menu.tsx": (
+            "export const Menu = {\n  Item: function Item() { return <li>i</li> },\n}\n"
+        ),
+        "app.tsx": (
+            "import { Menu } from './menu'\n\n"
+            "export function App() {\n"
+            "  return <Menu.Item />\n"
+            "}\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files, "tsx")
+    assert _has(rels, "app.App", REFERENCES, "Item")

--- a/codebase_rag/tests/test_jsx_component_references.py
+++ b/codebase_rag/tests/test_jsx_component_references.py
@@ -105,6 +105,29 @@ def test_jsx_component_usage_in_js_is_referenced(tmp_path: Path) -> None:
     assert _has(rels, "page.Page", REFERENCES, "widget.Widget")
 
 
+def test_tsx_class_component_usage_is_referenced(tmp_path: Path) -> None:
+    # (H) A React class component resolves to a CLASS node, not a function; the
+    # (H) JSX usage must still reference the class. JS/TS classes have no
+    # (H) __init__, so routing through the Python callback helper (which
+    # (H) redirects CLASS -> Class.__init__) would silently drop the edge.
+    files = {
+        "card.tsx": (
+            "import * as React from 'react'\n"
+            "export class Card extends React.Component {\n"
+            "  render() { return <div>x</div> }\n"
+            "}\n"
+        ),
+        "app.tsx": (
+            "import { Card } from './card'\n\n"
+            "export function App() {\n"
+            "  return <Card />\n"
+            "}\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files, "tsx")
+    assert _has(rels, "app.App", REFERENCES, "card.Card")
+
+
 def test_html_tags_are_not_referenced(tmp_path: Path) -> None:
     # (H) Lowercase tags are HTML elements, not components; a same-named local
     # (H) function (div) must not be misbound.

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -615,7 +615,7 @@ RELATIONSHIP_SCHEMAS: tuple[RelationshipSchema, ...] = (
     RelationshipSchema(
         (NodeLabel.MODULE, NodeLabel.FUNCTION, NodeLabel.METHOD),
         RelationshipType.REFERENCES,
-        (NodeLabel.FUNCTION, NodeLabel.METHOD),
+        (NodeLabel.FUNCTION, NodeLabel.METHOD, NodeLabel.CLASS),
     ),
     RelationshipSchema(
         (NodeLabel.MODULE, NodeLabel.FUNCTION, NodeLabel.METHOD),

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.209"
+version = "0.0.215"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
Follow-up to #608: with .tsx finally parsing, `<Card />` usage still produced no edge -- React invokes components through the element, never by a call the graph can see -- so components used only in markup still reported as dead.

- `_ingest_jsx_component_references`: walks each scope (plus module scope before the no-calls early return, like the assignment pass) for `jsx_self_closing_element` / `jsx_opening_element`, resolves the name through the standard callback-edge path, and emits REFERENCES from the rendering scope.
- Uppercase names only: lowercase tags are HTML elements and must not misbind to same-named locals. Closing elements are excluded so paired elements emit once. Member-expression names (`<Menu.Item />`) resolve like any dotted callable reference.
- Applies to both .tsx (tsx grammar) and .jsx (the javascript grammar parses JSX natively).

## Tests (RED -> GREEN)
5 tests in `test_jsx_component_references.py`: self-closing usage, paired element, .jsx parity, lowercase-tag negative, namespaced member component. 4 were RED.

Validation: FastAPI full-stack template dead-code 177 -> 168 with the ui/* component cluster cleared (proper .tsx parsing also registers more nested functions, so remaining candidates shifted to the useMutation-callback and generated-client classes).

Full suite: 4439 passed, 14 skipped. ruff + format clean; ty at the pre-existing baseline.