### PR TITLE
feat(calls): bind positional and renamed constructor callable args to stored fields

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -790,6 +790,8 @@ FIELD_DECLARATOR = "declarator"
 FIELD_PARAMETERS = "parameters"
 FIELD_RECEIVER = "receiver"
 FIELD_TYPE = "type"
+# (H) The wrapped function/class inside a Python decorated_definition node.
+FIELD_DEFINITION = "definition"
 FIELD_RESULT = "result"
 # (H) Rust impl `trait`/`type` fields and a trait's supertrait `bounds`.
 FIELD_TRAIT = "trait"

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1186,6 +1186,10 @@ class GraphUpdater:
                 self.queries,
                 func_class_captures_cache=captures_cache,
             )
+        # (H) Bindings are pending until every file's ctor metadata (param order,
+        # (H) param->attribute renames) is in: a construction site may be scanned
+        # (H) before the file defining its class.
+        self.factory.call_processor.finalize_callable_field_bindings()
         for file_path, language in self._parsed_files:
             root_node = self._ast_for(file_path, language)
             if root_node is None:

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -320,14 +320,18 @@ class CallProcessor:
         # (H) Pre-pass: record which functions are bound to a class's callable
         # (H) fields (FQNSpec(get_name=_python_get_name, ...)). Runs before call
         # (H) resolution so a field invocation can resolve regardless of which
-        # (H) file the construction site lives in. Keyword bindings only;
-        # (H) positional callable args would need declared field order.
+        # (H) file the construction site lives in. Bindings are recorded PENDING
+        # (H) (keyword name or positional index) and resolved by
+        # (H) finalize_field_bindings after every file's ctor metadata (param
+        # (H) order + param->attribute renames) has been collected.
         if language != cs.SupportedLanguage.PYTHON:
             return
         try:
             module_qn = self._module_qn(
                 cached_relative_path(file_path, self.repo_path), file_path.name
             )
+            resolver = self._resolver
+            self._collect_ctor_field_metadata(root_node, module_qn)
             if (
                 func_class_captures_cache is not None
                 and file_path in func_class_captures_cache
@@ -339,12 +343,11 @@ class CallProcessor:
                 call_nodes, _ = self._collect_all_call_nodes(
                     root_node, language, queries
                 )
-            resolver = self._resolver
             registry = resolver.function_registry
             callable_labels = (cs.NodeLabel.FUNCTION, cs.NodeLabel.METHOD)
             for call_node in call_nodes:
-                _positional, keyword = self._parse_call_arguments(call_node)
-                if not keyword:
+                positional, keyword = self._parse_call_arguments(call_node)
+                if not positional and not keyword:
                     continue
                 name = self._get_call_target_name(call_node)
                 if not name:
@@ -352,16 +355,150 @@ class CallProcessor:
                 callee = resolver.resolve_function_call(name, module_qn)
                 if not callee or callee[0] != cs.NodeLabel.CLASS:
                     continue
-                for field, value_node in keyword.items():
+                arg_entries: list[tuple[int | str, Node]] = list(enumerate(positional))
+                arg_entries.extend(keyword.items())
+                for key, value_node in arg_entries:
                     if not (value_text := safe_decode_text(value_node)):
                         continue
                     bound = resolver.resolve_function_call(value_text, module_qn)
                     if bound and bound[0] in callable_labels and bound[1] in registry:
-                        resolver.record_callable_field_binding(
-                            callee[1], field, bound[1]
-                        )
+                        resolver.record_pending_field_binding(callee[1], key, bound[1])
         except Exception as e:
             logger.error(ls.CALL_PROCESSING_FAILED, path=file_path, error=e)
+
+    def finalize_callable_field_bindings(self) -> None:
+        self._resolver.finalize_field_bindings()
+
+    def _collect_ctor_field_metadata(self, root_node: Node, module_qn: str) -> None:
+        # (H) For every class defined in this file, record the ordered ctor param
+        # (H) names (__init__ params, or annotated class-body fields for
+        # (H) NamedTuple/dataclass classes without __init__) and the
+        # (H) param -> attribute renames from `self.attr = param` statements.
+        # (H) ponytail: top-level and class-nested walks share the plain stack;
+        # (H) a class inside a FUNCTION is skipped (its qn is caller-scoped).
+        resolver = self._resolver
+        stack: list[Node] = list(root_node.children)
+        while stack:
+            node = stack.pop()
+            if node.type == cs.TS_PY_DECORATED_DEFINITION:
+                stack.extend(node.children)
+                continue
+            if node.type == cs.TS_PY_FUNCTION_DEFINITION:
+                continue
+            if node.type != cs.TS_PY_CLASS_DEFINITION:
+                stack.extend(node.children)
+                continue
+            name_node = node.child_by_field_name(cs.FIELD_NAME)
+            class_name = safe_decode_text(name_node) if name_node else None
+            body = node.child_by_field_name(cs.FIELD_BODY)
+            if not class_name or body is None:
+                continue
+            stack.extend(body.children)
+            resolved = resolver.resolve_function_call(class_name, module_qn)
+            if not resolved or resolved[0] != cs.NodeLabel.CLASS:
+                continue
+            class_qn = resolved[1]
+            if init_node := self._find_init_method(body):
+                params = self._ordered_param_names(init_node)
+                resolver.record_ctor_params(class_qn, params)
+                self._record_param_attr_renames(init_node, class_qn, set(params))
+            else:
+                resolver.record_ctor_params(class_qn, self._annotated_field_names(body))
+
+    @staticmethod
+    def _find_init_method(class_body: Node) -> Node | None:
+        for child in class_body.children:
+            candidate = child
+            if candidate.type == cs.TS_PY_DECORATED_DEFINITION:
+                candidate = (
+                    candidate.child_by_field_name(cs.FIELD_DEFINITION) or candidate
+                )
+            if candidate.type != cs.TS_PY_FUNCTION_DEFINITION:
+                continue
+            name_node = candidate.child_by_field_name(cs.FIELD_NAME)
+            if name_node is not None and safe_decode_text(name_node) == (
+                cs.PY_METHOD_INIT
+            ):
+                return candidate
+        return None
+
+    @staticmethod
+    def _ordered_param_names(init_node: Node) -> tuple[str, ...]:
+        params_node = init_node.child_by_field_name(cs.FIELD_PARAMETERS)
+        if params_node is None:
+            return ()
+        names: list[str] = []
+        for child in params_node.named_children:
+            match child.type:
+                case cs.TS_PY_IDENTIFIER:
+                    name = safe_decode_text(child)
+                case cs.TS_PY_DEFAULT_PARAMETER | cs.TS_PY_TYPED_DEFAULT_PARAMETER:
+                    name_node = child.child_by_field_name(cs.FIELD_NAME)
+                    name = safe_decode_text(name_node) if name_node else None
+                case cs.TS_PY_TYPED_PARAMETER:
+                    inner = child.named_children[0] if child.named_children else None
+                    name = (
+                        safe_decode_text(inner)
+                        if inner is not None and inner.type == cs.TS_PY_IDENTIFIER
+                        else None
+                    )
+                case _:
+                    # (H) *args/**kwargs/keyword_separator never bind fields.
+                    name = None
+            if name and name != cs.PY_KEYWORD_SELF:
+                names.append(name)
+        return tuple(names)
+
+    def _record_param_attr_renames(
+        self, init_node: Node, class_qn: str, params: set[str]
+    ) -> None:
+        # (H) `self.ctx_factory = create_context` stores the param under a
+        # (H) DIFFERENT name; the field invocation goes through the attribute.
+        body = init_node.child_by_field_name(cs.FIELD_BODY)
+        if body is None:
+            return
+        self_prefix = f"{cs.PY_KEYWORD_SELF}{cs.SEPARATOR_DOT}"
+        stack: list[Node] = list(body.children)
+        while stack:
+            node = stack.pop()
+            if node.type == cs.TS_PY_ASSIGNMENT:
+                left = node.child_by_field_name(cs.TS_FIELD_LEFT)
+                right = node.child_by_field_name(cs.TS_FIELD_RIGHT)
+                if (
+                    left is not None
+                    and right is not None
+                    and left.type == cs.TS_PY_ATTRIBUTE
+                    and right.type == cs.TS_PY_IDENTIFIER
+                    and (left_text := safe_decode_text(left))
+                    and left_text.startswith(self_prefix)
+                    and (param := safe_decode_text(right)) in params
+                ):
+                    attr = left_text[len(self_prefix) :]
+                    if attr != param:
+                        self._resolver.record_ctor_param_attr(class_qn, param, attr)
+            stack.extend(node.children)
+
+    @staticmethod
+    def _annotated_field_names(class_body: Node) -> tuple[str, ...]:
+        # (H) NamedTuple/dataclass field order = annotated class-body assignments
+        # (H) (`fetch_name: Callable`, `other: int = 3`) in declaration order.
+        names: list[str] = []
+        for child in class_body.children:
+            if child.type != cs.TS_PY_EXPRESSION_STATEMENT or not child.named_children:
+                continue
+            stmt = child.named_children[0]
+            if stmt.type != cs.TS_PY_ASSIGNMENT:
+                continue
+            left = stmt.child_by_field_name(cs.TS_FIELD_LEFT)
+            has_type = stmt.child_by_field_name(cs.FIELD_TYPE) is not None
+            if (
+                left is not None
+                and left.type == cs.TS_PY_IDENTIFIER
+                and has_type
+                and (name := safe_decode_text(left))
+            ):
+                names.append(name)
+        return tuple(names)
 
     def process_calls_in_file(
         self,

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -461,6 +461,12 @@ class CallProcessor:
         stack: list[Node] = list(body.children)
         while stack:
             node = stack.pop()
+            # (H) A `self.x = param` inside a nested helper (def later():
+            # (H) self.cb = handler) is that helper's store, not a constructor
+            # (H) rename; descending into it would let it override the real
+            # (H) __init__ store (one attr per param), so stop at nested scopes.
+            if node.type in _PY_SCOPE_BOUNDARY_TYPES:
+                continue
             if node.type == cs.TS_PY_ASSIGNMENT:
                 left = node.child_by_field_name(cs.TS_FIELD_LEFT)
                 right = node.child_by_field_name(cs.TS_FIELD_RIGHT)

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -374,30 +374,50 @@ class CallProcessor:
         # (H) names (__init__ params, or annotated class-body fields for
         # (H) NamedTuple/dataclass classes without __init__) and the
         # (H) param -> attribute renames from `self.attr = param` statements.
-        # (H) ponytail: top-level and class-nested walks share the plain stack;
-        # (H) a class inside a FUNCTION is skipped (its qn is caller-scoped).
+        # (H) The stack carries each node's ENCLOSING class qn so a nested class
+        # (H) (Inner inside Outer) resolves to module.Outer.Inner: a bare
+        # (H) resolve_function_call("Inner", module_qn) would look for
+        # (H) module.Inner and miss it. A class inside a FUNCTION is skipped (its
+        # (H) qn is caller-scoped), so nested-in-method classes never reach here.
         resolver = self._resolver
-        stack: list[Node] = list(root_node.children)
+        registry = resolver.function_registry
+        stack: list[tuple[Node, str | None]] = [
+            (child, None) for child in root_node.children
+        ]
         while stack:
-            node = stack.pop()
+            node, enclosing_qn = stack.pop()
             if node.type == cs.TS_PY_DECORATED_DEFINITION:
-                stack.extend(node.children)
+                stack.extend((c, enclosing_qn) for c in node.children)
                 continue
             if node.type == cs.TS_PY_FUNCTION_DEFINITION:
                 continue
             if node.type != cs.TS_PY_CLASS_DEFINITION:
-                stack.extend(node.children)
+                stack.extend((c, enclosing_qn) for c in node.children)
                 continue
             name_node = node.child_by_field_name(cs.FIELD_NAME)
             class_name = safe_decode_text(name_node) if name_node else None
             body = node.child_by_field_name(cs.FIELD_BODY)
             if not class_name or body is None:
                 continue
-            stack.extend(body.children)
-            resolved = resolver.resolve_function_call(class_name, module_qn)
-            if not resolved or resolved[0] != cs.NodeLabel.CLASS:
+            if enclosing_qn is not None:
+                candidate_qn = f"{enclosing_qn}{cs.SEPARATOR_DOT}{class_name}"
+                class_qn = (
+                    candidate_qn
+                    if registry.get(candidate_qn) == cs.NodeLabel.CLASS
+                    else None
+                )
+            else:
+                resolved = resolver.resolve_function_call(class_name, module_qn)
+                class_qn = (
+                    resolved[1]
+                    if resolved and resolved[0] == cs.NodeLabel.CLASS
+                    else None
+                )
+            # (H) Descend into the body with THIS class as the enclosing scope so
+            # (H) its nested classes resolve; skip metadata when unresolved.
+            stack.extend((c, class_qn) for c in body.children)
+            if class_qn is None:
                 continue
-            class_qn = resolved[1]
             if init_node := self._find_init_method(body):
                 params = self._ordered_param_names(init_node)
                 resolver.record_ctor_params(class_qn, params)

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -120,21 +120,54 @@ class CallResolver:
         self._pending_field_bindings.append((class_qn, key, func_qn))
 
     def finalize_field_bindings(self) -> None:
-        # (H) Resolve pendings now that every class's ctor metadata is known: a
-        # (H) positional index maps through the param order (dropped when the
-        # (H) class has none recorded), and a param maps to its stored attribute
-        # (H) name when __init__ renames it (self.ctx_factory = create_context).
+        # (H) Resolve pendings now that every class's ctor metadata is known. A
+        # (H) subclass without its own __init__ inherits the base's params and
+        # (H) field, so both a positional index and a keyword name resolve
+        # (H) against the nearest self-or-ancestor that owns the ctor param, and
+        # (H) the binding is recorded under THAT owner (where the field lives) so
+        # (H) an inherited self.handler() -- typed to the base -- still matches.
         for class_qn, key, func_qn in self._pending_field_bindings:
             if isinstance(key, int):
-                params = self._ctor_params.get(class_qn)
-                if not params or key >= len(params):
+                owner_qn, params = self._ctor_params_owner(class_qn)
+                if key >= len(params):
                     continue
                 param = params[key]
             else:
                 param = key
-            field = self._ctor_param_attrs.get((class_qn, param), param)
-            self.record_callable_field_binding(class_qn, field, func_qn)
+                owner_qn = self._ctor_param_owner(class_qn, param)
+            field = self._ctor_param_attrs.get((owner_qn, param), param)
+            self.record_callable_field_binding(owner_qn, field, func_qn)
         self._pending_field_bindings.clear()
+
+    def _ctor_params_owner(self, class_qn: str) -> tuple[str, tuple[str, ...]]:
+        # (H) Nearest self-or-ancestor with a non-empty recorded ctor param list
+        # (H) (a subclass with no __init__ has an empty list, so keep walking).
+        for ancestor in self._mro(class_qn):
+            if params := self._ctor_params.get(ancestor):
+                return ancestor, params
+        return class_qn, self._ctor_params.get(class_qn, ())
+
+    def _ctor_param_owner(self, class_qn: str, param: str) -> str:
+        # (H) Nearest self-or-ancestor whose ctor declares `param`, so an
+        # (H) inherited keyword binding attaches to the class that owns the field.
+        for ancestor in self._mro(class_qn):
+            if param in self._ctor_params.get(ancestor, ()):
+                return ancestor
+        return class_qn
+
+    def _mro(self, class_qn: str) -> list[str]:
+        # (H) BFS over the inheritance graph, self first; guards cycles.
+        seen: set[str] = set()
+        order: list[str] = []
+        queue: deque[str] = deque([class_qn])
+        while queue:
+            cur = queue.popleft()
+            if cur in seen:
+                continue
+            seen.add(cur)
+            order.append(cur)
+            queue.extend(self.class_inheritance.get(cur, []))
+        return order
 
     def record_callable_field_binding(
         self, class_qn: str, field: str, func_qn: str

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -59,6 +59,9 @@ class CallResolver:
         "_subclass_map_cache",
         "_protocol_classes_cache",
         "_struct_impl_cache",
+        "_ctor_params",
+        "_ctor_param_attrs",
+        "_pending_field_bindings",
     )
 
     def __init__(
@@ -94,6 +97,44 @@ class CallResolver:
         self._subclass_map_cache: dict[str, set[str]] | None = None
         self._protocol_classes_cache: set[str] | None = None
         self._struct_impl_cache: dict[str, set[str]] = {}
+        # (H) Ordered constructor parameter names per class (explicit __init__
+        # (H) params, or annotated class-body fields for NamedTuple/dataclass),
+        # (H) plus the param -> stored-attribute renames found in __init__
+        # (H) bodies (self.ctx_factory = create_context). Construction-site
+        # (H) bindings are held PENDING until every file's ctor metadata is
+        # (H) collected, since a site may be scanned before its class's file.
+        self._ctor_params: dict[str, tuple[str, ...]] = {}
+        self._ctor_param_attrs: dict[tuple[str, str], str] = {}
+        self._pending_field_bindings: list[tuple[str, int | str, str]] = []
+
+    def record_ctor_params(self, class_qn: str, params: tuple[str, ...]) -> None:
+        self._ctor_params[class_qn] = params
+
+    def record_ctor_param_attr(self, class_qn: str, param: str, attr: str) -> None:
+        self._ctor_param_attrs[(class_qn, param)] = attr
+
+    def record_pending_field_binding(
+        self, class_qn: str, key: int | str, func_qn: str
+    ) -> None:
+        # (H) key: keyword name, or positional index awaiting the ctor param order.
+        self._pending_field_bindings.append((class_qn, key, func_qn))
+
+    def finalize_field_bindings(self) -> None:
+        # (H) Resolve pendings now that every class's ctor metadata is known: a
+        # (H) positional index maps through the param order (dropped when the
+        # (H) class has none recorded), and a param maps to its stored attribute
+        # (H) name when __init__ renames it (self.ctx_factory = create_context).
+        for class_qn, key, func_qn in self._pending_field_bindings:
+            if isinstance(key, int):
+                params = self._ctor_params.get(class_qn)
+                if not params or key >= len(params):
+                    continue
+                param = params[key]
+            else:
+                param = key
+            field = self._ctor_param_attrs.get((class_qn, param), param)
+            self.record_callable_field_binding(class_qn, field, func_qn)
+        self._pending_field_bindings.clear()
 
     def record_callable_field_binding(
         self, class_qn: str, field: str, func_qn: str

--- a/codebase_rag/tests/test_ctor_field_binding_precision.py
+++ b/codebase_rag/tests/test_ctor_field_binding_precision.py
@@ -1,0 +1,105 @@
+# (H) Store-then-invoke gaps beyond keyword-arg bindings: a callable stored via a
+# (H) POSITIONAL constructor argument, or stored under a DIFFERENT attribute name
+# (H) than its parameter (self.ctx_factory = create_context), must still resolve
+# (H) when the field is invoked (cfg.handler(), codec.ctx_factory()).
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+
+def _run_calls(tmp_path: Path, files: dict[str, str]) -> set[tuple[str, str]]:
+    parsers, queries = load_parsers()
+    if "python" not in parsers:
+        pytest.skip("python parser not available")
+    for rel, content in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock, repo_path=tmp_path, parsers=parsers, queries=queries
+    ).run()
+    return {
+        (c.args[0][2], c.args[2][2])
+        for c in mock.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) == "CALLS"
+    }
+
+
+def _has(calls: set[tuple[str, str]], caller_suffix: str, callee_suffix: str) -> bool:
+    return any(
+        a.endswith(caller_suffix) and b.endswith(callee_suffix) for a, b in calls
+    )
+
+
+def test_positional_init_arg_binds_to_stored_field(tmp_path: Path) -> None:
+    # (H) Config(fn) passes the callback positionally; __init__ stores it under
+    # (H) the same name, and run() invokes it through the field.
+    files = {
+        "config.py": (
+            "class Config:\n"
+            "    def __init__(self, handler):\n"
+            "        self.handler = handler\n\n"
+            "    def run(self):\n"
+            "        return self.handler()\n"
+        ),
+        "app.py": (
+            "from config import Config\n\n\n"
+            "def on_event():\n"
+            "    return 1\n\n\n"
+            "def main():\n"
+            "    cfg = Config(on_event)\n"
+            "    return cfg.run()\n"
+        ),
+    }
+    calls = _run_calls(tmp_path, files)
+    assert _has(calls, "Config.run", "app.on_event")
+
+
+def test_keyword_arg_stored_under_renamed_attribute(tmp_path: Path) -> None:
+    # (H) The keyword name (create_context) differs from the stored attribute
+    # (H) (ctx_factory); the invocation goes through the ATTRIBUTE name, so the
+    # (H) binding must map param -> attr (the brrr/with_brrr_from_cfg shape).
+    files = {
+        "codec.py": (
+            "class Codec:\n"
+            "    def __init__(self, create_context=None):\n"
+            "        self.ctx_factory = create_context\n\n"
+            "    def decode(self):\n"
+            "        return self.ctx_factory()\n"
+        ),
+        "worker.py": (
+            "from codec import Codec\n\n\n"
+            "def build_context():\n"
+            "    return {}\n\n\n"
+            "def get_codec():\n"
+            "    return Codec(create_context=build_context)\n"
+        ),
+    }
+    calls = _run_calls(tmp_path, files)
+    assert _has(calls, "Codec.decode", "worker.build_context")
+
+
+def test_positional_namedtuple_field_binds(tmp_path: Path) -> None:
+    # (H) A NamedTuple/dataclass without __init__ takes its field order from the
+    # (H) annotated class body; Spec(py_name) binds fetch_name positionally.
+    files = {
+        "spec.py": (
+            "from typing import Callable, NamedTuple\n\n\n"
+            "def py_name():\n"
+            '    return "py"\n\n\n'
+            "class Spec(NamedTuple):\n"
+            "    fetch_name: Callable\n\n\n"
+            "PY_SPEC = Spec(py_name)\n\n\n"
+            "def use():\n"
+            "    return PY_SPEC.fetch_name()\n"
+        ),
+    }
+    calls = _run_calls(tmp_path, files)
+    assert _has(calls, "spec.use", "spec.py_name")

--- a/codebase_rag/tests/test_ctor_field_binding_precision.py
+++ b/codebase_rag/tests/test_ctor_field_binding_precision.py
@@ -105,6 +105,72 @@ def test_positional_namedtuple_field_binds(tmp_path: Path) -> None:
     assert _has(calls, "spec.use", "spec.py_name")
 
 
+def test_typed_default_param_binds_positionally(tmp_path: Path) -> None:
+    # (H) A typed default parameter (handler: Callable = None) exposes its name as
+    # (H) an `identifier` under the `name` field, so param-order extraction gets
+    # (H) 'handler', not the whole 'handler: Callable' annotation.
+    files = {
+        "config.py": (
+            "from typing import Callable\n\n\n"
+            "class Config:\n"
+            "    def __init__(self, handler: Callable = None):\n"
+            "        self.handler = handler\n\n"
+            "    def run(self):\n"
+            "        return self.handler()\n"
+        ),
+        "app.py": (
+            "from config import Config\n\n\n"
+            "def on_event():\n"
+            "    return 1\n\n\n"
+            "def main():\n"
+            "    return Config(on_event).run()\n"
+        ),
+    }
+    calls = _run_calls(tmp_path, files)
+    assert _has(calls, "Config.run", "app.on_event")
+
+
+def test_nested_class_ctor_field_binding_is_recorded(tmp_path: Path) -> None:
+    # (H) A nested class (Inner inside Outer) must resolve to Outer.Inner via the
+    # (H) enclosing-class qn, not a bare module.Inner lookup that misses, so its
+    # (H) positional ctor field binding IS recorded (finding: nested-class params
+    # (H) and renames were silently dropped). Asserted at the binding level: the
+    # (H) CALLS EDGE additionally depends on nested-class method-qn attribution,
+    # (H) a separate pre-existing concern outside constructor-field binding.
+    parsers, queries = load_parsers()
+    if "python" not in parsers:
+        pytest.skip("python parser not available")
+    files = {
+        "outer.py": (
+            "class Outer:\n"
+            "    class Inner:\n"
+            "        def __init__(self, handler):\n"
+            "            self.handler = handler\n\n"
+            "        def run(self):\n"
+            "            return self.handler()\n"
+        ),
+        "app.py": (
+            "from outer import Outer\n\n\n"
+            "def on_event():\n"
+            "    return 1\n\n\n"
+            "def main():\n"
+            "    return Outer.Inner(on_event).run()\n"
+        ),
+    }
+    for rel, content in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    updater = GraphUpdater(
+        ingestor=MagicMock(), repo_path=tmp_path, parsers=parsers, queries=queries
+    )
+    updater.run()
+    resolver = updater.factory.call_processor._resolver
+    assert resolver.callable_field_targets("handler") == {
+        f"{tmp_path.name}.app.on_event"
+    }
+
+
 def test_nested_helper_store_does_not_clobber_ctor_rename(tmp_path: Path) -> None:
     # (H) A `self.cb = handler` inside a nested helper in __init__ must NOT be
     # (H) recorded as the constructor-store rename: the real store is

--- a/codebase_rag/tests/test_ctor_field_binding_precision.py
+++ b/codebase_rag/tests/test_ctor_field_binding_precision.py
@@ -171,6 +171,32 @@ def test_nested_class_ctor_field_binding_is_recorded(tmp_path: Path) -> None:
     }
 
 
+def test_inherited_ctor_positional_arg_binds(tmp_path: Path) -> None:
+    # (H) Sub has no __init__: Sub(on_event) uses the inherited Base.__init__,
+    # (H) which stores self.handler. The positional binding must resolve through
+    # (H) the base's ctor params and record under Base (where the field lives),
+    # (H) or inherited self.handler() never resolves.
+    files = {
+        "base.py": (
+            "class Base:\n"
+            "    def __init__(self, handler):\n"
+            "        self.handler = handler\n\n"
+            "    def run(self):\n"
+            "        return self.handler()\n"
+        ),
+        "sub.py": ("from base import Base\n\n\nclass Sub(Base):\n    pass\n"),
+        "app.py": (
+            "from sub import Sub\n\n\n"
+            "def on_event():\n"
+            "    return 1\n\n\n"
+            "def main():\n"
+            "    return Sub(on_event).run()\n"
+        ),
+    }
+    calls = _run_calls(tmp_path, files)
+    assert _has(calls, "Base.run", "app.on_event")
+
+
 def test_nested_helper_store_does_not_clobber_ctor_rename(tmp_path: Path) -> None:
     # (H) A `self.cb = handler` inside a nested helper in __init__ must NOT be
     # (H) recorded as the constructor-store rename: the real store is

--- a/codebase_rag/tests/test_ctor_field_binding_precision.py
+++ b/codebase_rag/tests/test_ctor_field_binding_precision.py
@@ -103,3 +103,33 @@ def test_positional_namedtuple_field_binds(tmp_path: Path) -> None:
     }
     calls = _run_calls(tmp_path, files)
     assert _has(calls, "spec.use", "spec.py_name")
+
+
+def test_nested_helper_store_does_not_clobber_ctor_rename(tmp_path: Path) -> None:
+    # (H) A `self.cb = handler` inside a nested helper in __init__ must NOT be
+    # (H) recorded as the constructor-store rename: the real store is
+    # (H) `self.handler = handler` in the __init__ body, and the field
+    # (H) invocation goes through self.handler(). The rename walk must skip
+    # (H) nested function/class scopes or the nested attr overrides the real one.
+    files = {
+        "config.py": (
+            "class Config:\n"
+            "    def __init__(self, handler):\n"
+            "        self.handler = handler\n\n"
+            "        def later():\n"
+            "            self.cb = handler\n\n"
+            "        self._later = later\n\n"
+            "    def run(self):\n"
+            "        return self.handler()\n"
+        ),
+        "app.py": (
+            "from config import Config\n\n\n"
+            "def on_event():\n"
+            "    return 1\n\n\n"
+            "def main():\n"
+            "    cfg = Config(on_event)\n"
+            "    return cfg.run()\n"
+        ),
+    }
+    calls = _run_calls(tmp_path, files)
+    assert _has(calls, "Config.run", "app.on_event")


### PR DESCRIPTION
## Summary
Store-then-invoke tracking (#601's `record_callable_field_binding`) only handled KEYWORD constructor arguments bound under the keyword's own name. Two real shapes stayed invisible, so their field invocations resolved to nothing:

- **Positional args**: `Config(on_event)` recorded no binding at all, so `self.handler()` in `Config.run` had no target.
- **Renamed stores**: `Codec(create_context=fn)` whose `__init__` does `self.ctx_factory = create_context` recorded the binding under `create_context`, but the invocation goes through `ctx_factory` (the brrr/with_brrr_from_cfg shape from platform-anterior).

## Design
The pre-pass now also collects per-class constructor metadata: ordered `__init__` param names (or annotated class-body fields for NamedTuple/dataclass classes without `__init__`) and `self.attr = param` renames. Construction-site bindings are recorded PENDING (keyword name or positional index) and resolved by `finalize_field_bindings` between the pre-pass and the call pass -- a construction site may be scanned before the file defining its class. Keyword bindings with no metadata finalize exactly as before (param name = field name), so existing behavior is preserved.

## Tests (RED -> GREEN)
3 tests in `test_ctor_field_binding_precision.py`: positional `__init__` arg, keyword arg stored under a renamed attribute, positional NamedTuple field. Existing `test_callable_field_calls.py` regressions pass unchanged.

Full suite: 4443 passed, 14 skipped. ruff + format clean; ty at the pre-existing 341 baseline.