### PR TITLE
fix(calls): attribute nested-class method calls to the full enclosing-class qn

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -16,6 +16,7 @@ from ..services import IngestorProtocol
 from ..types_defs import FunctionRegistryTrieProtocol, LanguageQueries
 from ..utils.path_utils import cached_relative_path
 from .call_resolver import CallResolver
+from .class_ingest.identity import build_nested_qualified_name_for_class
 from .cpp import utils as cpp_utils
 from .go import utils as go_utils
 from .import_processor import ImportProcessor
@@ -907,6 +908,13 @@ class CallProcessor:
         # (H) their calls bubble up instead of dropping.
         owned_func_nodes = self._js_ts_attributable_nodes(method_nodes, language)
         for method_node in method_nodes:
+            # (H) The body byte-range slice also captures functions of a NESTED
+            # (H) class (Outer body contains Inner.run); those belong to the
+            # (H) nested class and are processed when it is iterated, so skip any
+            # (H) whose nearest enclosing class is not this one (else run would
+            # (H) also emit as the phantom Outer.run).
+            if not self._method_in_class_body(method_node, body_node, lang_config):
+                continue
             if language in _C_FAMILY_LANGUAGES:
                 method_name = cpp_utils.extract_function_name(method_node)
             else:
@@ -983,6 +991,26 @@ class CallProcessor:
         param_sig = f"({','.join(parameters)})" if parameters else cs.EMPTY_PARENS
         return f"{name}{param_sig}"
 
+    @staticmethod
+    def _method_in_class_body(
+        method_node: Node, class_body: Node, lang_config: LanguageSpec
+    ) -> bool:
+        # (H) True when method_node's nearest enclosing class is the one whose
+        # (H) body is class_body: walk up, and the first class ancestor's body
+        # (H) must be this body (compared by byte span). A method with no
+        # (H) enclosing class (out-of-class C++ definition captured elsewhere)
+        # (H) returns True so existing handling is unaffected.
+        current = method_node.parent
+        while current is not None:
+            if current.type in lang_config.class_node_types:
+                body = current.child_by_field_name(cs.FIELD_BODY)
+                return body is not None and (
+                    body.start_byte == class_body.start_byte
+                    and body.end_byte == class_body.end_byte
+                )
+            current = current.parent
+        return True
+
     def _calls_owned_by(
         self,
         func_node: Node,
@@ -1040,15 +1068,27 @@ class CallProcessor:
             class_name = self._get_class_name_for_node(class_node, language)
             if not class_name:
                 continue
-            # (H) A C++ class inside a namespace is bound by the definition pass via
-            # (H) build_qualified_name (qn `module.ns.Class`); the bare join would drop
-            # (H) the namespace, dangling every inline method's CALLS source. Use the
-            # (H) same builder so the class qn (and thus method caller qns) agree.
-            class_qn = (
-                cpp_utils.build_qualified_name(class_node, module_qn, class_name)
-                if language == cs.SupportedLanguage.CPP
-                else f"{module_qn}{cs.SEPARATOR_DOT}{class_name}"
-            )
+            # (H) A C++ class inside a namespace, or a NESTED class (Outer.Inner),
+            # (H) is bound by the definition pass through its enclosing scope
+            # (H) (qn `module.ns.Class` / `module.Outer.Inner`); the bare
+            # (H) `module.class_name` join drops those ancestors, dangling every
+            # (H) inline method's CALLS source off a phantom node. Use the SAME
+            # (H) builders the definition pass uses so the class qn (and thus
+            # (H) method caller qns) agree.
+            if language == cs.SupportedLanguage.CPP:
+                class_qn = cpp_utils.build_qualified_name(
+                    class_node, module_qn, class_name
+                )
+            else:
+                class_qn = (
+                    build_nested_qualified_name_for_class(
+                        class_node,
+                        module_qn,
+                        class_name,
+                        queries[language][cs.QUERY_CONFIG],
+                    )
+                    or f"{module_qn}{cs.SEPARATOR_DOT}{class_name}"
+                )
             if body_node := class_node.child_by_field_name(cs.FIELD_BODY):
                 self._process_methods_in_class(
                     body_node,

--- a/codebase_rag/tests/test_nested_class_method_qn.py
+++ b/codebase_rag/tests/test_nested_class_method_qn.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+
+def _run(tmp_path: Path, files: dict[str, str]) -> set[tuple[str, str, str]]:
+    parsers, queries = load_parsers()
+    if "python" not in parsers:
+        pytest.skip("python parser not available")
+    for rel, content in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock, repo_path=tmp_path, parsers=parsers, queries=queries
+    ).run()
+    return {
+        (c.args[0][2], str(c.args[1]), c.args[2][2])
+        for c in mock.ensure_relationship_batch.call_args_list
+    }
+
+
+def test_nested_class_method_call_edge_uses_full_qn(tmp_path: Path) -> None:
+    # (H) A method of a nested class (Outer.Inner.run) must emit its CALLS edge
+    # (H) from the FULL qn that the definition pass registered
+    # (H) (module.Outer.Inner.run), not the enclosing-class-dropping
+    # (H) module.Inner.run, or the edge dangles off a phantom node.
+    files = {
+        "m.py": (
+            "def helper():\n"
+            "    return 1\n\n\n"
+            "class Outer:\n"
+            "    class Inner:\n"
+            "        def run(self):\n"
+            "            return helper()\n"
+        ),
+    }
+    rels = _run(tmp_path, files)
+    calls = {(a, b) for a, r, b in rels if r == "CALLS"}
+    assert any(
+        a.endswith("m.Outer.Inner.run") and b.endswith("m.helper") for a, b in calls
+    )
+    assert not any(
+        a.endswith("m.Inner.run") and not a.endswith("Outer.Inner.run")
+        for a, _ in calls
+    )
+
+
+def test_nested_class_method_qn_matches_registered_node(tmp_path: Path) -> None:
+    # (H) The caller qn of a nested-class method CALLS edge must be a real
+    # (H) registered node, so an INSTANTIATES/CALLS traversal reaches it.
+    files = {
+        "m.py": (
+            "def helper():\n"
+            "    return 1\n\n\n"
+            "class Outer:\n"
+            "    class Inner:\n"
+            "        def run(self):\n"
+            "            return helper()\n"
+        ),
+    }
+    parsers, queries = load_parsers()
+    if "python" not in parsers:
+        pytest.skip("python parser not available")
+    (tmp_path / "m.py").write_text(files["m.py"], encoding="utf-8")
+    mock = MagicMock()
+    updater = GraphUpdater(
+        ingestor=mock, repo_path=tmp_path, parsers=parsers, queries=queries
+    )
+    updater.run()
+    registry = updater.factory.call_processor._resolver.function_registry
+    callers = {
+        c.args[0][2]
+        for c in mock.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) == "CALLS" and c.args[2][2].endswith("m.helper")
+    }
+    run_callers = {q for q in callers if q.endswith("run")}
+    assert run_callers
+    assert all(q in registry for q in run_callers)


### PR DESCRIPTION
## Summary
A method of a nested class (`Outer.Inner.run`) emitted its CALLS edge from a phantom caller qn that dropped the enclosing class (`module.Inner.run`), so the edge dangled off a node that doesn't exist in the graph — every call out of a nested-class method was effectively lost. Surfaced while landing #610 (constructor field binding). Two root causes:

1. **Wrong class qn in the call pass.** `_process_calls_in_classes` built `class_qn` as `f"{module_qn}.{class_name}"`, dropping enclosing classes/namespaces. The definition pass registers the class via `build_nested_qualified_name_for_class`. Fix: the call pass now uses the same builder (matching the existing C++ namespace carve-out), so class — and thus method caller — qns agree.
2. **Nested-class methods mis-attributed to the outer class.** The outer class body's byte-range slice also captures a nested class's methods, so `Inner.run` additionally emitted as the phantom `Outer.run`. Fix: `_method_in_class_body` skips a method whose nearest enclosing class isn't the one being processed; it's covered when that nested class is iterated.

## Tests (RED -> GREEN)
2 tests in `test_nested_class_method_qn.py`: the CALLS edge uses the full `Outer.Inner.run` qn (and no phantom `Outer.run` / `Inner.run`), and every nested-class-method caller qn is a real registered node.

Full suite: 4455 passed, 14 skipped. ruff + format clean; ty at the pre-existing baseline.