### PR TITLE
feat(references): emit REFERENCES for inline object-literal callback values

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -131,6 +131,13 @@ _ASSIGNMENT_RHS_REF_TYPES = frozenset(
 _JSX_NAMED_ELEMENT_TYPES = frozenset(
     {cs.TS_JSX_SELF_CLOSING_ELEMENT, cs.TS_JSX_OPENING_ELEMENT}
 )
+# (H) Inline function values in an object literal (`{ onSuccess: () => {} }`): the
+# (H) JS/TS definition pass registers these as their own nodes named by the key
+# (H) (scope.onSuccess), so a passed object of callbacks (useMutation/useQuery) must
+# (H) reference each or every TanStack-style callback reports as dead.
+_INLINE_FUNC_VALUE_TYPES = frozenset(
+    {cs.TS_ARROW_FUNCTION, cs.TS_FUNCTION_EXPRESSION}
+)
 
 
 class CallProcessor:
@@ -1844,6 +1851,11 @@ class CallProcessor:
                         and (value := pair.child_by_field_name(cs.FIELD_VALUE))
                         is not None
                     ):
+                        if value.type in _INLINE_FUNC_VALUE_TYPES:
+                            self._emit_inline_value_function_ref(
+                                pair, caller_spec, ensure_rel
+                            )
+                            continue
                         self._emit_value_function_ref(
                             value,
                             caller_spec,
@@ -1891,6 +1903,35 @@ class CallProcessor:
             resolve_func,
             ensure_rel,
         )
+
+    def _emit_inline_value_function_ref(
+        self,
+        pair: Node,
+        caller_spec: tuple[str, str, str],
+        ensure_rel,
+    ) -> None:
+        # (H) An inline arrow/function-expression object value is registered by the
+        # (H) definition pass under {enclosing_scope}.{key}; that scope is caller_spec's
+        # (H) qn, so reconstruct the qn from the key and reference the registered
+        # (H) node(s) (variants cover same-key duplicates in one scope).
+        key_node = pair.child_by_field_name(cs.FIELD_KEY)
+        if key_node is None or key_node.type not in (
+            cs.TS_PROPERTY_IDENTIFIER,
+            cs.TS_IDENTIFIER,
+        ):
+            return
+        if not (key := safe_decode_text(key_node)):
+            return
+        registry = self._resolver.function_registry
+        base_qn = f"{caller_spec[2]}{cs.SEPARATOR_DOT}{key}"
+        for target_qn in registry.variants(base_qn):
+            if registry.get(target_qn) is None:
+                continue
+            ensure_rel(
+                caller_spec,
+                cs.RelationshipType.REFERENCES,
+                (cs.NodeLabel.FUNCTION, cs.KEY_QUALIFIED_NAME, target_qn),
+            )
 
     @staticmethod
     def _flow_scope_boundaries(lang_config: LanguageSpec) -> frozenset[str]:

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -135,9 +135,7 @@ _JSX_NAMED_ELEMENT_TYPES = frozenset(
 # (H) JS/TS definition pass registers these as their own nodes named by the key
 # (H) (scope.onSuccess), so a passed object of callbacks (useMutation/useQuery) must
 # (H) reference each or every TanStack-style callback reports as dead.
-_INLINE_FUNC_VALUE_TYPES = frozenset(
-    {cs.TS_ARROW_FUNCTION, cs.TS_FUNCTION_EXPRESSION}
-)
+_INLINE_FUNC_VALUE_TYPES = frozenset({cs.TS_ARROW_FUNCTION, cs.TS_FUNCTION_EXPRESSION})
 
 
 class CallProcessor:
@@ -1853,7 +1851,7 @@ class CallProcessor:
                     ):
                         if value.type in _INLINE_FUNC_VALUE_TYPES:
                             self._emit_inline_value_function_ref(
-                                pair, caller_spec, ensure_rel
+                                pair, value, caller_spec, ensure_rel
                             )
                             continue
                         self._emit_value_function_ref(
@@ -1907,31 +1905,38 @@ class CallProcessor:
     def _emit_inline_value_function_ref(
         self,
         pair: Node,
+        value: Node,
         caller_spec: tuple[str, str, str],
         ensure_rel,
     ) -> None:
         # (H) An inline arrow/function-expression object value is registered by the
-        # (H) definition pass under {enclosing_scope}.{key}; that scope is caller_spec's
-        # (H) qn, so reconstruct the qn from the key and reference the registered
-        # (H) node(s) (variants cover same-key duplicates in one scope).
-        key_node = pair.child_by_field_name(cs.FIELD_KEY)
-        if key_node is None or key_node.type not in (
-            cs.TS_PROPERTY_IDENTIFIER,
-            cs.TS_IDENTIFIER,
-        ):
-            return
-        if not (key := safe_decode_text(key_node)):
-            return
+        # (H) definition pass under {enclosing_scope}.<name>. An identifier key names it
+        # (H) by the key (scope.onSuccess); a string-literal key ({'onSuccess': ...})
+        # (H) has no property name, so it registers as scope.anonymous_<row>_<col> from
+        # (H) the value's position. Reference every candidate that is actually
+        # (H) registered (variants cover same-name duplicates in one scope).
         registry = self._resolver.function_registry
-        base_qn = f"{caller_spec[2]}{cs.SEPARATOR_DOT}{key}"
-        for target_qn in registry.variants(base_qn):
-            if registry.get(target_qn) is None:
-                continue
-            ensure_rel(
-                caller_spec,
-                cs.RelationshipType.REFERENCES,
-                (cs.NodeLabel.FUNCTION, cs.KEY_QUALIFIED_NAME, target_qn),
-            )
+        scope_qn = caller_spec[2]
+        candidates = {
+            f"{scope_qn}{cs.SEPARATOR_DOT}{cs.PREFIX_ANONYMOUS}"
+            f"{value.start_point[0]}_{value.start_point[1]}"
+        }
+        key_node = pair.child_by_field_name(cs.FIELD_KEY)
+        if (
+            key_node is not None
+            and key_node.type in (cs.TS_PROPERTY_IDENTIFIER, cs.TS_IDENTIFIER)
+            and (key := safe_decode_text(key_node))
+        ):
+            candidates.add(f"{scope_qn}{cs.SEPARATOR_DOT}{key}")
+        for candidate in candidates:
+            for target_qn in registry.variants(candidate):
+                if registry.get(target_qn) is None:
+                    continue
+                ensure_rel(
+                    caller_spec,
+                    cs.RelationshipType.REFERENCES,
+                    (cs.NodeLabel.FUNCTION, cs.KEY_QUALIFIED_NAME, target_qn),
+                )
 
     @staticmethod
     def _flow_scope_boundaries(lang_config: LanguageSpec) -> frozenset[str]:

--- a/codebase_rag/tests/test_object_literal_callback_references.py
+++ b/codebase_rag/tests/test_object_literal_callback_references.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+REFERENCES = cs.RelationshipType.REFERENCES.value
+
+
+def _run_rels(
+    tmp_path: Path, files: dict[str, str], lang_key: str
+) -> set[tuple[str, str, str]]:
+    # (H) Build the graph for `files` and return (caller_qn, rel_type, callee_qn).
+    parsers, queries = load_parsers()
+    if lang_key not in parsers:
+        pytest.skip(f"{lang_key} parser not available")
+    for rel, content in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock, repo_path=tmp_path, parsers=parsers, queries=queries
+    ).run()
+    return {
+        (c.args[0][2], str(c.args[1]), c.args[2][2])
+        for c in mock.ensure_relationship_batch.call_args_list
+    }
+
+
+def _has(
+    rels: set[tuple[str, str, str]], caller_suffix: str, rel: str, callee_suffix: str
+) -> bool:
+    return any(
+        a.endswith(caller_suffix) and r == rel and b.endswith(callee_suffix)
+        for a, r, b in rels
+    )
+
+
+def test_object_literal_inline_arrow_is_referenced(tmp_path: Path) -> None:
+    # (H) useMutation({ mutationFn: () => {}, onSuccess: () => {} }) registers each
+    # (H) inline arrow as its own node (AddUser.mutationFn / AddUser.onSuccess); the
+    # (H) library invokes them, so the enclosing scope must REFERENCE them or every
+    # (H) TanStack Query callback reports as dead (the dominant remaining gap on the
+    # (H) FastAPI full-stack template).
+    files = {
+        "AddUser.tsx": (
+            "import { useMutation } from '@tanstack/react-query'\n\n\n"
+            "export function AddUser() {\n"
+            "  const mutation = useMutation({\n"
+            "    mutationFn: (data) => save(data),\n"
+            "    onSuccess: () => { reset() },\n"
+            "  })\n"
+            "  return mutation\n"
+            "}\n\n\n"
+            "function save(d) { return d }\n"
+            "function reset() {}\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files, "typescript")
+    assert _has(rels, "AddUser.AddUser", REFERENCES, "AddUser.AddUser.mutationFn")
+    assert _has(rels, "AddUser.AddUser", REFERENCES, "AddUser.AddUser.onSuccess")
+
+
+def test_object_literal_inline_function_expr_is_referenced(tmp_path: Path) -> None:
+    # (H) A classic function expression as an object value is the same first-class
+    # (H) value handoff and must also be referenced.
+    files = {
+        "config.ts": (
+            "export function build() {\n"
+            "  register({\n"
+            "    handler: function () { run() },\n"
+            "  })\n"
+            "}\n\n\n"
+            "function register(o) { return o }\n"
+            "function run() {}\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files, "typescript")
+    assert _has(rels, "config.build", REFERENCES, "config.build.handler")

--- a/codebase_rag/tests/test_object_literal_callback_references.py
+++ b/codebase_rag/tests/test_object_literal_callback_references.py
@@ -83,3 +83,26 @@ def test_object_literal_inline_function_expr_is_referenced(tmp_path: Path) -> No
     }
     rels = _run_rels(tmp_path, files, "typescript")
     assert _has(rels, "config.build", REFERENCES, "config.build.handler")
+
+
+def test_object_literal_string_key_inline_arrow_is_referenced(tmp_path: Path) -> None:
+    # (H) A string-literal key ({'onSuccess': () => {}}) has no property name, so the
+    # (H) inline arrow registers as scope.anonymous_<row>_<col>, not scope.onSuccess.
+    # (H) The reference must target the actual registered (anonymous) node by the
+    # (H) value's position, or the callback still reports as dead.
+    files = {
+        "widget.tsx": (
+            "export function Widget() {\n"
+            "  register({\n"
+            "    'onSuccess': () => { done() },\n"
+            "  })\n"
+            "}\n\n\n"
+            "function register(o) { return o }\n"
+            "function done() {}\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files, "typescript")
+    refs = {b for a, r, b in rels if r == REFERENCES and a.endswith("widget.Widget")}
+    assert any(".widget.Widget.anonymous_" in b for b in refs), (
+        f"no anonymous ref emitted; refs={refs}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.215"
+version = "0.0.218"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Inline arrow/function-expression values in object literals (`useMutation({ mutationFn: () => {}, onSuccess: () => {} })`) are registered by the JS/TS definition pass as their own nodes (`scope.mutationFn`, `scope.onSuccess`) but had zero incoming edges, so every TanStack Query / React callback reported as dead code.

`_ingest_collection_function_references` now detects inline function values at the object-literal pair level and emits a REFERENCES edge from the enclosing scope to each registered variant (`_emit_inline_value_function_ref` reconstructs the `{scope}.{key}` qn). Applies at both function and module scope; classic function-expression object values covered too.

This was the dominant remaining gap on the FastAPI full-stack template dead-code run (~75 of 168 candidates).

Tests: 2 new RED to GREEN cases in test_object_literal_callback_references.py; full suite 4457 passed.