### PR TITLE
fix(js): nest object-arrow callbacks under arrow-const function ancestors

### DIFF
--- a/codebase_rag/parsers/js_ts/ingest.py
+++ b/codebase_rag/parsers/js_ts/ingest.py
@@ -632,7 +632,34 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
             return None
 
         name_node = node.child_by_field_name(cs.FIELD_NAME)
-        return safe_decode_text(name_node) if name_node and name_node.text else None
+        if name_node and name_node.text:
+            return safe_decode_text(name_node)
+        return self._js_nameless_binding_name(node)
+
+    def _js_nameless_binding_name(self, node: ASTNode) -> str | None:
+        # (H) An arrow/function-expression has no `name` field; its effective name is
+        # (H) the binding it is assigned to (const Cmp = () => {}), the object key it is
+        # (H) a value of, or the lhs of an assignment. Recovering it keeps a callback
+        # (H) nested in an arrow-const component nested under that component
+        # (H) (module.Cmp.onSuccess), consistent with the component's own qn and the
+        # (H) call pass, instead of collapsing to module.onSuccess and dangling.
+        parent = node.parent
+        if parent is None:
+            return None
+        if parent.type == cs.TS_VARIABLE_DECLARATOR:
+            binding = parent.child_by_field_name(cs.FIELD_NAME)
+        elif parent.type == cs.TS_PAIR:
+            binding = parent.child_by_field_name(cs.FIELD_KEY)
+        elif parent.type == cs.TS_ASSIGNMENT_EXPRESSION:
+            binding = parent.child_by_field_name(cs.FIELD_LEFT)
+        else:
+            return None
+        if binding is None or binding.type not in (
+            cs.TS_IDENTIFIER,
+            cs.TS_PROPERTY_IDENTIFIER,
+        ):
+            return None
+        return safe_decode_text(binding) if binding.text else None
 
     def _js_format_qualified_name(
         self, module_qn: str, path_parts: list[str], final_name: str

--- a/codebase_rag/tests/test_object_literal_callback_references.py
+++ b/codebase_rag/tests/test_object_literal_callback_references.py
@@ -85,6 +85,33 @@ def test_object_literal_inline_function_expr_is_referenced(tmp_path: Path) -> No
     assert _has(rels, "config.build", REFERENCES, "config.build.handler")
 
 
+def test_arrow_const_component_object_callbacks_referenced(tmp_path: Path) -> None:
+    # (H) The real FastAPI-template shape: the component is an arrow bound to a const
+    # (H) (const AddUser = () => {...}), and useMutation callbacks live inside it. The
+    # (H) definition pass must nest those object-arrows under the component
+    # (H) (module.AddUser.mutationFn), matching the component's own qn and the call
+    # (H) pass, so the REFERENCES edge connects; otherwise every TanStack callback in
+    # (H) an arrow-const component (the whole template) stays dead.
+    files = {
+        "AddUser.tsx": (
+            "import { useMutation } from '@tanstack/react-query'\n\n\n"
+            "const AddUser = () => {\n"
+            "  const mutation = useMutation({\n"
+            "    mutationFn: (d) => save(d),\n"
+            "    onSuccess: () => { reset() },\n"
+            "  })\n"
+            "  return mutation\n"
+            "}\n\n\n"
+            "function save(d) { return d }\n"
+            "function reset() {}\n"
+            "export default AddUser\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files, "typescript")
+    assert _has(rels, "AddUser.AddUser", REFERENCES, "AddUser.AddUser.mutationFn")
+    assert _has(rels, "AddUser.AddUser", REFERENCES, "AddUser.AddUser.onSuccess")
+
+
 def test_object_literal_string_key_inline_arrow_is_referenced(tmp_path: Path) -> None:
     # (H) A string-literal key ({'onSuccess': () => {}}) has no property name, so the
     # (H) inline arrow registers as scope.anonymous_<row>_<col>, not scope.onSuccess.

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.218"
+version = "0.0.219"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Problem

On the full-stack-fastapi-template, TanStack Query callbacks (`useMutation({ mutationFn, onSuccess, onSettled })`) still reported as dead code even after #612, because the template writes components as arrow-consts:

```tsx
const AddUser = () => {
  const mutation = useMutation({
    mutationFn: (d) => save(d),   // registered as AddUser.mutationFn (module scope)
    onSuccess: () => { reset() },
  })
}
```

The component itself registers as `module.AddUser.AddUser`, but its nested object-arrow callbacks registered as `module.AddUser.mutationFn` — the arrow-const ancestor was **dropped**. `_js_extract_ancestor_name` names ancestors via `child_by_field_name("name")`, which an `arrow_function` node lacks (the name lives on the parent `variable_declarator`). The qn mismatch meant the #612 REFERENCES edge (computed from the call-pass caller qn, which *does* include the const name) could never connect.

## Fix

`_js_extract_ancestor_name` now recovers the binding name for nameless function ancestors (`_js_nameless_binding_name`): from a `variable_declarator` name, a `pair` key, or an `assignment_expression` lhs. Object-arrow callbacks nested in an arrow-const component now nest under it (`module.AddUser.mutationFn`), consistent with the component's own qn and the call pass, so the reference edge connects.

## Impact

Dead-code candidates on full-stack-fastapi-template: **129 → 105** (all remaining are frontend; Python backend stays 100% clean). Trajectory this session: 333 → 129 → 105.

## Tests

New RED to GREEN case `test_arrow_const_component_object_callbacks_referenced` (the real template shape); full suite 4457 passed (2 unrelated CLI-smoke subprocess timeouts under parallel load, pass in isolation).