### PR TITLE
fix(js): don't register call-result variables as functions

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -2754,6 +2754,13 @@ GUARD_INHERITED_METHOD = "_inherited_method_guard"
 TS_PAIR = "pair"
 TS_OBJECT = "object"
 TS_ARRAY = "array"
+
+# (H) When a variable_declarator's value is one of these, the variable binds the
+# (H) call/construction RESULT, not a function -- so an arrow found inside its
+# (H) arguments (`const m = useMutation({fn: () => {}})`) must not inherit the
+# (H) variable's name. Object-literal / arrow values are not here, so arrows nested
+# (H) directly under an object bound to a const still take the object's name.
+JS_CALL_RESULT_VALUE_TYPES = frozenset({TS_CALL_EXPRESSION, TS_NEW_EXPRESSION})
 TS_FUNCTION_EXPRESSION = "function_expression"
 TS_ARROW_FUNCTION = "arrow_function"
 TS_REQUIRED_PARAMETER = "required_parameter"

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -552,6 +552,16 @@ class FunctionIngestMixin:
             current = func_node.parent
             while current:
                 if current.type == cs.TS_VARIABLE_DECLARATOR:
+                    # (H) `const m = useMutation({fn: () => {}})` binds the CALL
+                    # (H) result to `m`, not the inner arrow; naming the arrow `m`
+                    # (H) invents a phantom function (dead-code false positive). Only
+                    # (H) claim the declarator name when its value is not a call.
+                    value = current.child_by_field_name(cs.FIELD_VALUE)
+                    if (
+                        value is not None
+                        and value.type in cs.JS_CALL_RESULT_VALUE_TYPES
+                    ):
+                        return None
                     for child in current.children:
                         if child.type == cs.TS_IDENTIFIER and child.text:
                             return safe_decode_text(child)

--- a/codebase_rag/tests/test_object_literal_callback_references.py
+++ b/codebase_rag/tests/test_object_literal_callback_references.py
@@ -42,6 +42,54 @@ def _has(
     )
 
 
+def _function_qns(tmp_path: Path, files: dict[str, str], lang_key: str) -> set[str]:
+    # (H) Build the graph and return the qualified names of all FUNCTION nodes.
+    parsers, queries = load_parsers()
+    if lang_key not in parsers:
+        pytest.skip(f"{lang_key} parser not available")
+    for rel, content in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock, repo_path=tmp_path, parsers=parsers, queries=queries
+    ).run()
+    return {
+        c.args[1][cs.KEY_QUALIFIED_NAME]
+        for c in mock.ensure_node_batch.call_args_list
+        if c.args[0] == cs.NodeLabel.FUNCTION
+    }
+
+
+def test_use_mutation_variable_not_registered_as_function(tmp_path: Path) -> None:
+    # (H) `const mutation = useMutation({...})` binds a call_expression, not a
+    # (H) function. The inner object-literal arrows (mutationFn/onSuccess) must NOT
+    # (H) climb past the pair/call up to the `mutation` declarator and register a
+    # (H) bogus FUNCTION node named after the variable -- that phantom node has no
+    # (H) incoming edge and reports as dead code (~27 of the template's remaining
+    # (H) false positives).
+    files = {
+        "AddUser.tsx": (
+            "import { useMutation } from '@tanstack/react-query'\n\n\n"
+            "const AddUser = () => {\n"
+            "  const mutation = useMutation({\n"
+            "    mutationFn: (d) => save(d),\n"
+            "    onSuccess: () => { reset() },\n"
+            "  })\n"
+            "  return mutation\n"
+            "}\n\n\n"
+            "function save(d) { return d }\n"
+            "function reset() {}\n"
+            "export default AddUser\n"
+        ),
+    }
+    fns = _function_qns(tmp_path, files, "typescript")
+    assert not any(qn.split(".")[-1].split("@")[0] == "mutation" for qn in fns), (
+        f"variable `mutation` wrongly registered as a function; fns={fns}"
+    )
+
+
 def test_object_literal_inline_arrow_is_referenced(tmp_path: Path) -> None:
     # (H) useMutation({ mutationFn: () => {}, onSuccess: () => {} }) registers each
     # (H) inline arrow as its own node (AddUser.mutationFn / AddUser.onSuccess); the


### PR DESCRIPTION
A nameless arrow buried inside a call argument (`const m = useMutation({ fn: () => {} })`) climbed its ancestors to the enclosing `variable_declarator` and took the variable name, inventing a phantom `Function` node named after the variable that actually binds the *call result*. Those phantoms have no incoming edge and report as dead code.

Fix: only inherit the declarator name when its value is not a `call_expression`/`new_expression`. Object literals / arrows bound directly to a const still nest under the variable, so `const mathUtils = { cube: () => ... }` is unaffected.

## Impact
full-stack-fastapi-template dead-code candidates: **105 -> 86**. All `mutation`/`signUpMutation`/`loginMutation` named phantoms eliminated. Some eliminated arrows resurface as honest `anonymous_*` nodes (inline `useCallback`/`setTimeout`/`.refine` callbacks) — a distinct pre-existing gap (inline call-argument callbacks are not referenced yet), not a regression.

## Tests
- RED->GREEN test in `test_object_literal_callback_references.py` asserting the `mutation` variable is not registered as a function.
- Full suite: 4460 passed, 14 skipped. ruff + ty clean.
- `test_javascript_object_patterns` object-literal cases still pass (arrows bound directly under a const keep the object name).