### PR TITLE
feat(references): reference inline arrow/function-expression call arguments

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1938,6 +1938,30 @@ class CallProcessor:
                     (cs.NodeLabel.FUNCTION, cs.KEY_QUALIFIED_NAME, target_qn),
                 )
 
+    def _emit_inline_arg_function_ref(
+        self,
+        arg_node: Node,
+        source_spec: tuple[str, str, str],
+        ensure_rel,
+    ) -> None:
+        # (H) An inline arrow/function-expression call argument is registered by the
+        # (H) definition pass as {enclosing_scope}.anonymous_<row>_<col> from its own
+        # (H) start position. Reference that node from the scope holding the call so
+        # (H) the callback stays reachable (registry guard skips unregistered names).
+        registry = self._resolver.function_registry
+        candidate = (
+            f"{source_spec[2]}{cs.SEPARATOR_DOT}{cs.PREFIX_ANONYMOUS}"
+            f"{arg_node.start_point[0]}_{arg_node.start_point[1]}"
+        )
+        for target_qn in registry.variants(candidate):
+            if registry.get(target_qn) is None:
+                continue
+            ensure_rel(
+                source_spec,
+                cs.RelationshipType.REFERENCES,
+                (cs.NodeLabel.FUNCTION, cs.KEY_QUALIFIED_NAME, target_qn),
+            )
+
     @staticmethod
     def _flow_scope_boundaries(lang_config: LanguageSpec) -> frozenset[str]:
         # (H) A nested function/class scope; a scan of a function body must not descend
@@ -2161,6 +2185,14 @@ class CallProcessor:
         caller_qn: str | None = None,
         rel_type: cs.RelationshipType = cs.RelationshipType.CALLS,
     ) -> None:
+        # (H) An arrow/function-expression passed DIRECTLY as a call argument
+        # (H) (useCallback(() => {}), setTimeout(() => {}), arr.map(x => ...)) is
+        # (H) registered anonymously in the enclosing scope but named after no
+        # (H) identifier, so resolve_func cannot find it. The call consumes it, so
+        # (H) reference it by position the same way inline object-literal values are.
+        if arg_node.type in _INLINE_FUNC_VALUE_TYPES:
+            self._emit_inline_arg_function_ref(arg_node, source_spec, ensure_rel)
+            return
         if not (arg_text := safe_decode_text(arg_node)):
             return
         if not (

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1943,14 +1943,18 @@ class CallProcessor:
         arg_node: Node,
         source_spec: tuple[str, str, str],
         ensure_rel,
+        caller_qn: str | None = None,
+        rel_type: cs.RelationshipType = cs.RelationshipType.REFERENCES,
     ) -> None:
         # (H) An inline arrow/function-expression call argument is registered by the
         # (H) definition pass as {enclosing_scope}.anonymous_<row>_<col> from its own
-        # (H) start position. Reference that node from the scope holding the call so
-        # (H) the callback stays reachable (registry guard skips unregistered names).
+        # (H) start position. The anonymous node lives in the CALLER's scope, so build
+        # (H) the candidate from caller_qn (source_spec[2] is the callee for the
+        # (H) callable-param path). Registry guard skips unregistered names.
         registry = self._resolver.function_registry
+        scope_qn = caller_qn or source_spec[2]
         candidate = (
-            f"{source_spec[2]}{cs.SEPARATOR_DOT}{cs.PREFIX_ANONYMOUS}"
+            f"{scope_qn}{cs.SEPARATOR_DOT}{cs.PREFIX_ANONYMOUS}"
             f"{arg_node.start_point[0]}_{arg_node.start_point[1]}"
         )
         for target_qn in registry.variants(candidate):
@@ -1958,7 +1962,7 @@ class CallProcessor:
                 continue
             ensure_rel(
                 source_spec,
-                cs.RelationshipType.REFERENCES,
+                rel_type,
                 (cs.NodeLabel.FUNCTION, cs.KEY_QUALIFIED_NAME, target_qn),
             )
 
@@ -2191,7 +2195,9 @@ class CallProcessor:
         # (H) identifier, so resolve_func cannot find it. The call consumes it, so
         # (H) reference it by position the same way inline object-literal values are.
         if arg_node.type in _INLINE_FUNC_VALUE_TYPES:
-            self._emit_inline_arg_function_ref(arg_node, source_spec, ensure_rel)
+            self._emit_inline_arg_function_ref(
+                arg_node, source_spec, ensure_rel, caller_qn, rel_type
+            )
             return
         if not (arg_text := safe_decode_text(arg_node)):
             return

--- a/codebase_rag/tests/test_object_literal_callback_references.py
+++ b/codebase_rag/tests/test_object_literal_callback_references.py
@@ -181,3 +181,52 @@ def test_object_literal_string_key_inline_arrow_is_referenced(tmp_path: Path) ->
     assert any(".widget.Widget.anonymous_" in b for b in refs), (
         f"no anonymous ref emitted; refs={refs}"
     )
+
+
+def test_inline_arrow_call_argument_is_referenced(tmp_path: Path) -> None:
+    # (H) An arrow passed DIRECTLY as a call argument (useCallback(() => {}),
+    # (H) setTimeout(() => {}), arr.map(x => ...)) registers as an anonymous node in
+    # (H) the enclosing scope but has no incoming edge -- the call consumes it, so
+    # (H) the scope must REFERENCE it or every inline callback reports as dead (the
+    # (H) dominant remaining false-positive class on the FastAPI template).
+    files = {
+        "hook.tsx": (
+            "export function useCopyToClipboard() {\n"
+            "  const copy = useCallback(async (text) => {\n"
+            "    return write(text)\n"
+            "  }, [])\n"
+            "  return copy\n"
+            "}\n\n\n"
+            "function write(t) { return t }\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files, "typescript")
+    refs = {
+        b
+        for a, r, b in rels
+        if r == REFERENCES and a.endswith("hook.useCopyToClipboard")
+    }
+    assert any(".hook.useCopyToClipboard.anonymous_" in b for b in refs), (
+        f"inline call-argument arrow not referenced; refs={refs}"
+    )
+
+
+def test_inline_arrow_call_argument_function_expr_is_referenced(
+    tmp_path: Path,
+) -> None:
+    # (H) A classic function expression passed directly as a call argument is the
+    # (H) same first-class handoff and must also be referenced.
+    files = {
+        "timer.ts": (
+            "export function start() {\n"
+            "  schedule(function () { tick() })\n"
+            "}\n\n\n"
+            "function schedule(cb) { return cb }\n"
+            "function tick() {}\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files, "typescript")
+    refs = {b for a, r, b in rels if r == REFERENCES and a.endswith("timer.start")}
+    assert any(".timer.start.anonymous_" in b for b in refs), (
+        f"inline call-argument function expression not referenced; refs={refs}"
+    )

--- a/codebase_rag/tests/test_object_literal_callback_references.py
+++ b/codebase_rag/tests/test_object_literal_callback_references.py
@@ -201,13 +201,11 @@ def test_inline_arrow_call_argument_is_referenced(tmp_path: Path) -> None:
         ),
     }
     rels = _run_rels(tmp_path, files, "typescript")
-    refs = {
-        b
-        for a, r, b in rels
-        if r == REFERENCES and a.endswith("hook.useCopyToClipboard")
-    }
-    assert any(".hook.useCopyToClipboard.anonymous_" in b for b in refs), (
-        f"inline call-argument arrow not referenced; refs={refs}"
+    # (H) An external callee (useCallback) gets the historical CALLS edge, a
+    # (H) first-party one REFERENCES; either keeps the callback reachable.
+    edges = {b for a, _r, b in rels if a.endswith("hook.useCopyToClipboard")}
+    assert any(".hook.useCopyToClipboard.anonymous_" in b for b in edges), (
+        f"inline call-argument arrow not referenced; edges={edges}"
     )
 
 
@@ -226,6 +224,7 @@ def test_inline_arrow_call_argument_function_expr_is_referenced(
         ),
     }
     rels = _run_rels(tmp_path, files, "typescript")
+    # (H) schedule is first-party, so the handoff records as REFERENCES.
     refs = {b for a, r, b in rels if r == REFERENCES and a.endswith("timer.start")}
     assert any(".timer.start.anonymous_" in b for b in refs), (
         f"inline call-argument function expression not referenced; refs={refs}"


### PR DESCRIPTION
An arrow or function expression passed directly as a call argument (`useCallback(() => {})`, `setTimeout(() => {})`, `arr.map(x => ...)`) is registered by the definition pass as an anonymous node (`scope.anonymous_<row>_<col>`) but had no incoming edge, so every inline callback reported as dead code.

Fix: when `_emit_callback_edge` sees an argument that is itself an arrow/function-expression, emit a `REFERENCES` edge from the calling scope to the anonymous node at the argument's start position (registry-existence guarded), mirroring the inline object-literal value handling from #612.

## Impact
full-stack-fastapi-template dead-code candidates: **86 -> 51**, 35 anonymous inline callbacks eliminated, **zero** new candidates. Covers nested cases too (a `setTimeout(() => ...)` inside a `useCallback(() => ...)`).

## Tests
- Two RED->GREEN tests: inline arrow call argument and inline function-expression call argument are referenced.
- Full suite: 4462 passed, 14 skipped. ruff + ty clean.