### PR TITLE
fix(jsx): reference function handlers passed in JSX attributes

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -2297,6 +2297,10 @@ JS_TS_PARENT_REF_TYPES = (TS_IDENTIFIER, TS_MEMBER_EXPRESSION)
 # (H) double-emit.
 TS_JSX_SELF_CLOSING_ELEMENT = "jsx_self_closing_element"
 TS_JSX_OPENING_ELEMENT = "jsx_opening_element"
+# (H) The `{...}` wrapper around an expression in a JSX attribute value or child
+# (H) (`onClick={handleLogout}`, `onClick={() => x()}`); its inner expression can
+# (H) hand a function to the element as a prop.
+TS_JSX_EXPRESSION = "jsx_expression"
 
 # (H) Import processor function names
 IMPORT_REQUIRE = "require"

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1817,6 +1817,24 @@ class CallProcessor:
                                 cs.RelationshipType.REFERENCES,
                                 (res_type, cs.KEY_QUALIFIED_NAME, target_qn),
                             )
+            elif node.type == cs.TS_JSX_EXPRESSION:
+                # (H) A `{...}` attribute value hands its inner expression to the
+                # (H) element as a prop. A bare identifier (onClick={handleLogout})
+                # (H) or inline arrow (onClick={() => x()}) is a function the
+                # (H) framework invokes on the event, so reference it; other
+                # (H) expressions resolve to nothing and are skipped by the helper.
+                for value in node.named_children:
+                    self._emit_callback_edge(
+                        caller_spec,
+                        value,
+                        module_qn,
+                        local_var_types,
+                        class_context,
+                        resolve_func,
+                        ensure_rel,
+                        caller_qn=caller_qn,
+                        rel_type=cs.RelationshipType.REFERENCES,
+                    )
             stack.extend(node.children)
 
     def _ingest_collection_function_references(

--- a/codebase_rag/tests/test_jsx_component_references.py
+++ b/codebase_rag/tests/test_jsx_component_references.py
@@ -143,6 +143,48 @@ def test_html_tags_are_not_referenced(tmp_path: Path) -> None:
     assert not any(r == REFERENCES for _, r, _ in rels)
 
 
+def test_jsx_attribute_bare_handler_is_referenced(tmp_path: Path) -> None:
+    # (H) `<button onClick={handleLogout}>` hands a local function to the element
+    # (H) as a prop; the framework invokes it on the event, never by a call the
+    # (H) graph can see, so the rendering scope must reference it or every event
+    # (H) handler passed by name reports as dead (Sidebar/User handlers on the
+    # (H) FastAPI template).
+    files = {
+        "panel.tsx": (
+            "export function Panel() {\n"
+            "  const handleLogout = () => { logout() }\n"
+            "  return <button onClick={handleLogout}>x</button>\n"
+            "}\n\n\n"
+            "function logout() {}\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files, "tsx")
+    assert _has(rels, "panel.Panel", REFERENCES, "panel.Panel.handleLogout")
+
+
+def test_jsx_attribute_inline_arrow_is_referenced(tmp_path: Path) -> None:
+    # (H) An inline arrow in a JSX attribute (`onClick={() => toggle()}`) registers
+    # (H) as an anonymous node in the rendering scope with no incoming edge; the
+    # (H) element consumes it, so the scope must reference it by position or every
+    # (H) inline JSX handler reports as dead (the routes/* form callbacks on the
+    # (H) template).
+    files = {
+        "input.tsx": (
+            "export function PasswordInput() {\n"
+            "  return <button onClick={() => toggle()}>x</button>\n"
+            "}\n\n\n"
+            "function toggle() {}\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files, "tsx")
+    refs = {
+        b for a, r, b in rels if r == REFERENCES and a.endswith("input.PasswordInput")
+    }
+    assert any(".input.PasswordInput.anonymous_" in b for b in refs), (
+        f"inline JSX-attribute arrow not referenced; refs={refs}"
+    )
+
+
 def test_member_expression_component_is_referenced(tmp_path: Path) -> None:
     # (H) A namespaced component (<Menu.Item />) names its member through a
     # (H) member expression; resolve it like any dotted callable reference.

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.219"
+version = "0.0.222"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

A function passed to a JSX element as an attribute (`onClick={handleLogout}`, `render={({field}) => ...}`) is invoked by the framework through the element, never by a call the graph can see. The JSX walk only referenced the element's component name, so these handlers had no incoming edge and reported as dead code.

Extends `_ingest_jsx_component_references` to process `jsx_expression` attribute values: a bare identifier or an inline arrow/function-expression is a function handoff, so the rendering scope now REFERENCES it. Reuses the existing `_emit_callback_edge`, which resolves a bare name, references an inline arrow by position, and skips non-callable expressions (ternaries, spreads, arithmetic).

## Impact

Measured on full-stack-fastapi-template: dead-code candidates **51 → 33** (18 eliminated, zero new). Remaining handler-ish cases are inside nested anonymous scopes (`.map()` callbacks, `forwardRef`, useEffect cleanup returns), a separate resolution class.

## Test

RED→GREEN: `test_jsx_attribute_bare_handler_is_referenced` and `test_jsx_attribute_inline_arrow_is_referenced`.