### PR TITLE
feat(dead-code): add --exclude glob to suppress generated paths

### DIFF
--- a/codebase_rag/cli.py
+++ b/codebase_rag/cli.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import time
 from collections.abc import Callable
+from fnmatch import fnmatch
 from functools import partial
 from importlib.metadata import version as get_version
 from pathlib import Path
@@ -941,6 +942,22 @@ def _dead_code_params(
     }
 
 
+def _filter_excluded_rows(rows: list[ResultRow], exclude: list[str]) -> list[ResultRow]:
+    # (H) Drop candidates whose file path matches an exclude glob (generated dirs
+    # (H) like client/core or *.gen.* have no in-repo caller, so every symbol
+    # (H) reports as dead). fnmatch treats '*' as spanning '/', so '*client/core*'
+    # (H) matches at any depth.
+    if not exclude:
+        return rows
+    return [
+        row
+        for row in rows
+        if not any(
+            fnmatch(str(row.get(cs.KEY_PATH) or ""), pattern) for pattern in exclude
+        )
+    ]
+
+
 def _to_dead_code_row(row: ResultRow) -> DeadCodeRow:
     start = row.get(cs.KEY_START_LINE, 0)
     end = row.get(cs.KEY_END_LINE, 0)
@@ -1028,6 +1045,7 @@ def dead_code(
     decorator_root: list[str] = typer.Option(
         [], "--decorator-root", help=ch.HELP_DEADCODE_DECORATOR_ROOT
     ),
+    exclude: list[str] = typer.Option([], "--exclude", help=ch.HELP_DEADCODE_EXCLUDE),
     include_tests: bool = typer.Option(
         True,
         "--include-tests/--no-include-tests",
@@ -1083,7 +1101,9 @@ def dead_code(
         app_context.console.print(style(message, cs.Color.RED))
         raise typer.Exit(1)
 
-    candidates = [_to_dead_code_row(row) for row in rows]
+    candidates = [
+        _to_dead_code_row(row) for row in _filter_excluded_rows(rows, exclude)
+    ]
     _emit_dead_code(candidates, output_format, output, resolved)
 
     if fail_on_found and candidates:

--- a/codebase_rag/cli_help.py
+++ b/codebase_rag/cli_help.py
@@ -191,6 +191,11 @@ HELP_DEADCODE_DECORATOR_ROOT = (
     "Treat functions/methods carrying this decorator as reachable roots. "
     "Extends the built-in set (route, task, fixture, command, ...). Repeatable."
 )
+HELP_DEADCODE_EXCLUDE = (
+    "Glob matched against a symbol's file path to exclude from the report "
+    "(e.g. '*client/core*', '*.gen.*' for generated code). '*' spans '/'. "
+    "Repeatable."
+)
 HELP_DEADCODE_INCLUDE_TESTS = (
     "Treat test code as reachable roots so production code it exercises is "
     "not reported. On by default."

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -188,7 +188,7 @@ MATCH (n:{labels})
 WHERE n.qualified_name STARTS WITH $project_prefix
   AND NOT n IN live_set{candidate_clause}
 RETURN labels(n)[0] AS label, n.name AS name,
-       n.qualified_name AS qualified_name,
+       n.qualified_name AS qualified_name, n.path AS path,
        n.start_line AS start_line, n.end_line AS end_line
 ORDER BY qualified_name"""
 

--- a/codebase_rag/tests/test_dead_code_command.py
+++ b/codebase_rag/tests/test_dead_code_command.py
@@ -74,6 +74,37 @@ class TestDeadCodeCommand:
             "myproj.mod.Thing.orphan_two",
         }
 
+    def test_exclude_glob_drops_matching_paths(self, runner: CliRunner) -> None:
+        # (H) --exclude drops candidates whose file path matches the glob (generated
+        # (H) code) while keeping real orphans elsewhere.
+        rows: list[ResultRow] = [
+            {
+                "label": "Function",
+                "name": "gen_helper",
+                "qualified_name": "myproj.client.core.gen_helper",
+                "path": "client/core/request.ts",
+                "start_line": 1,
+                "end_line": 3,
+            },
+            {
+                "label": "Function",
+                "name": "orphan_one",
+                "qualified_name": "myproj.mod.orphan_one",
+                "path": "mod.ts",
+                "start_line": 5,
+                "end_line": 9,
+            },
+        ]
+        mock_ingestor = _make_mock_ingestor(projects=["myproj"], fetch_result=rows)
+        with patch("codebase_rag.cli.connect_memgraph", return_value=mock_ingestor):
+            result = runner.invoke(
+                app, ["dead-code", "--format", "json", "--exclude", "*client/core*"]
+            )
+
+        assert result.exit_code == 0
+        names = {row["qualified_name"] for row in json.loads(result.output)}
+        assert names == {"myproj.mod.orphan_one"}
+
     def test_fail_on_found_exits_one_when_dead_code(
         self, runner: CliRunner, dead_rows: list[ResultRow]
     ) -> None:

--- a/codebase_rag/tests/test_dead_code_eval.py
+++ b/codebase_rag/tests/test_dead_code_eval.py
@@ -59,6 +59,38 @@ def test_dead_code_flags_uncalled_function() -> None:
     assert dead == {"proj.m.orphan"}
 
 
+def test_dead_code_excludes_generated_paths() -> None:
+    # (H) A generated file (openapi-ts client/core, routeTree.gen.ts) has no
+    # (H) in-repo caller, so every symbol in it reports as dead -- pure noise the
+    # (H) user cannot act on. An exclude glob suppresses those from the report while
+    # (H) a real orphan elsewhere is still flagged. Crucially, the excluded file
+    # (H) stays a live participant: `used_by_gen` is called only from the generated
+    # (H) module and must NOT be flagged dead (excluding before reachability would
+    # (H) drop that edge and wrongly report it).
+    nodes = dict(
+        [
+            (
+                (_MODULE, "proj.gen"),
+                {cs.KEY_QUALIFIED_NAME: "proj.gen", cs.KEY_PATH: "client/core/req.ts"},
+            ),
+            _fn("proj.gen.helper", path="client/core/req.ts"),
+            (
+                (_MODULE, "proj.m"),
+                {cs.KEY_QUALIFIED_NAME: "proj.m", cs.KEY_PATH: "m.ts"},
+            ),
+            _fn("proj.m.orphan", path="m.ts"),
+            _fn("proj.m.used_by_gen", path="m.ts"),
+        ]
+    )
+    rels = [
+        (_MODULE, "proj.gen", _CALLS, _FUNCTION, "proj.gen.helper"),
+        (_FUNCTION, "proj.gen.helper", _CALLS, _FUNCTION, "proj.m.used_by_gen"),
+    ]
+    cfg = _CONFIG._replace(exclude_patterns=("*client/core*",))
+    dead = dead_code_from_graph(nodes, rels, _PREFIX, cfg)
+    assert dead == {"proj.m.orphan"}
+
+
 def test_dead_code_flags_orphan_chain() -> None:
     # (H) orphan() calls buried(), but orphan() itself is never reached, so both
     # (H) are dead (a callee kept alive only by dead code is dead too).

--- a/evals/dead_code.py
+++ b/evals/dead_code.py
@@ -8,6 +8,7 @@
 # (H) missing edge flagging a live function as dead), not the scorer.
 import json
 from collections import defaultdict
+from fnmatch import fnmatch
 from pathlib import Path
 from typing import Annotated, NamedTuple
 
@@ -47,10 +48,13 @@ class DeadCodeConfig(NamedTuple):
     root_decorators: frozenset[str]
     entry_points: tuple[str, ...]
     test_patterns: tuple[str, ...]
+    exclude_patterns: tuple[str, ...] = ()
 
 
 def default_dead_code_config(
-    include_tests: bool, include_classes: bool
+    include_tests: bool,
+    include_classes: bool,
+    exclude_patterns: tuple[str, ...] = (),
 ) -> DeadCodeConfig:
     return DeadCodeConfig(
         include_tests=include_tests,
@@ -58,6 +62,7 @@ def default_dead_code_config(
         root_decorators=frozenset(d.lower() for d in cs.DEFAULT_ROOT_DECORATORS),
         entry_points=(),
         test_patterns=tuple(cs.TEST_PATH_PATTERNS),
+        exclude_patterns=exclude_patterns,
     )
 
 
@@ -206,7 +211,21 @@ def dead_code_from_graph(
     live |= closure_roots
     _walk(closure_roots, adjacency, live)
 
-    return candidates - live
+    dead = candidates - live
+    # (H) Suppress generated files (openapi-ts client/core, routeTree.gen.ts) from
+    # (H) the REPORT only, after reachability: they stay full participants as roots
+    # (H) and callers, so a real function invoked only from generated glue is not
+    # (H) newly flagged -- excluding earlier would drop those live edges.
+    if config.exclude_patterns:
+        dead = {
+            qn
+            for qn in dead
+            if not any(
+                fnmatch(str(props_by_qn[qn].get(cs.KEY_PATH) or ""), pattern)
+                for pattern in config.exclude_patterns
+            )
+        }
+    return dead
 
 
 def cgr_dead_code(target: Path, project: str, config: DeadCodeConfig) -> set[str]:
@@ -241,6 +260,10 @@ def main(
     include_classes: Annotated[
         bool, typer.Option(help="Also report unreachable classes.")
     ] = False,
+    exclude: Annotated[
+        list[str] | None,
+        typer.Option(help="Glob(s) matched against a symbol's file path to exclude."),
+    ] = None,
     out_dir: Annotated[
         Path, typer.Option(help="Directory for the dead-code report json.")
     ] = Path(ec.DEFAULT_OUT_DIR),
@@ -252,7 +275,9 @@ def main(
     project = project_name or target.name
     logger.info(ls.DEAD_CODE_TARGET.format(target=target, project=project))
 
-    config = default_dead_code_config(include_tests, include_classes)
+    config = default_dead_code_config(
+        include_tests, include_classes, tuple(exclude or ())
+    )
     dead = cgr_dead_code(target, project, config)
     logger.success(ls.DEAD_CODE_DONE.format(count=len(dead)))
 


### PR DESCRIPTION
## What

Generated files (openapi-ts `client/core`, `routeTree.gen.ts`) have no in-repo caller, so every symbol in them reports as dead: pure noise the user cannot act on. Adds a repeatable `--exclude GLOB` option to `cgr dead-code` (and `evals.dead_code`) that suppresses candidates whose file path matches the glob.

```
cgr dead-code --exclude '*client/core*' --exclude '*.gen.*'
```

Uses `fnmatch` where `*` spans `/`, so a glob matches at any depth. A user-named glob is used rather than auto-detection because the `client/core` files carry no `.gen.` name and no `@generated` header, so no content signal would catch them.

Exclusion is applied to the **final report only**, after reachability: excluded files remain full participants as roots and callers, so a real function invoked only from generated glue is not newly flagged.

## Impact

Measured on full-stack-fastapi-template (with the JSX-attribute fix applied): **33 → 21** with `--exclude '*client/core*' --exclude '*.gen.*'`.

## Test

- `test_dead_code_excludes_generated_paths` (eval): asserts a real function called only from an excluded generated module stays live (guards the reachability-vs-report ordering).
- `test_exclude_glob_drops_matching_paths` (CLI): end-to-end `--exclude` filtering.