### PR TITLE
fix(dead-code): root pydantic @computed_field methods as reachable

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -473,6 +473,7 @@ DEFAULT_ROOT_DECORATORS: frozenset[str] = frozenset(
         "root_validator",
         "field_serializer",
         "model_serializer",
+        "computed_field",
         "abstractmethod",
     }
 )

--- a/codebase_rag/tests/test_dead_code_eval.py
+++ b/codebase_rag/tests/test_dead_code_eval.py
@@ -178,6 +178,24 @@ def test_test_file_symbols_are_not_candidates_when_tests_excluded() -> None:
     assert dead == {"proj.m.only_tested"}
 
 
+def test_pydantic_computed_field_is_a_root() -> None:
+    # (H) Pydantic calls @computed_field methods during serialization through
+    # (H) library code outside the first-party graph, so no CALLS edge reaches
+    # (H) them; the default decorator set must seed them as roots too.
+    config = default_dead_code_config(include_tests=False, include_classes=False)
+    nodes = dict(
+        [
+            (
+                (_MODULE, "proj.m"),
+                {cs.KEY_QUALIFIED_NAME: "proj.m", cs.KEY_PATH: "m.py"},
+            ),
+            _fn("proj.m.C.full_name", decorators=["@computed_field", "@property"]),
+        ]
+    )
+    dead = dead_code_from_graph(nodes, [], _PREFIX, config)
+    assert dead == set()
+
+
 def test_non_test_module_does_not_keep_code_alive_when_tests_excluded() -> None:
     # (H) With tests excluded, a call from a test module must not root project code.
     nodes = dict(


### PR DESCRIPTION
## Problem

`cgr dead-code` flags pydantic `@computed_field` methods as dead code. Pydantic invokes them during serialization through library code outside the first-party graph, so no CALLS edge reaches them. This is the same misclassification family as #578 (pydantic validators): `field_validator`/`model_validator`/serializers were already seeded as reachability roots, but `computed_field` was missed.

## Fix

Add `computed_field` to `DEFAULT_ROOT_DECORATORS` alongside the existing pydantic validator/serializer roots.

## Test

RED→GREEN: added `test_pydantic_computed_field_is_a_root` (fails before the fix, passes after). Full `test_dead_code_eval.py` (21) and `test_dead_code_command.py` (16) pass.

Closes #578