### PR TITLE
fix(js): eliminate remaining JS/TS dead-code false positives

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -3129,6 +3129,25 @@ FQN_TS_FUNCTION_TYPES = (
     TS_FUNCTION_SIGNATURE,
 )
 
+# (H) When climbing a nameless arrow's ancestors to find its binding declarator,
+# (H) crossing one of these means the arrow lives INSIDE another function's body
+# (H) (a JSX event handler, a `.map()` callback), not directly bound to the outer
+# (H) const -- so it must not inherit that const's name. Without this stop the inner
+# (H) arrow becomes `Component.Component`/`utils.getInitials.getInitials`, a
+# (H) double-segment phantom with no incoming edge (dead-code false positive) that
+# (H) also steals the enclosing scope from the real inline handler nodes.
+JS_ARROW_NAME_CLIMB_BOUNDARY = frozenset(
+    {
+        TS_STATEMENT_BLOCK,
+        TS_ARROW_FUNCTION,
+        TS_FUNCTION_DECLARATION,
+        TS_FUNCTION_EXPRESSION,
+        TS_METHOD_DEFINITION,
+        TS_GENERATOR_FUNCTION_DECLARATION,
+        TS_CLASS_BODY,
+    }
+)
+
 # (H) FQN node type tuples for Rust
 FQN_RS_SCOPE_TYPES = (
     TS_RS_STRUCT_ITEM,

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -415,6 +415,12 @@ TSCONFIG_FILENAMES: tuple[str, ...] = (
     "tsconfig.base.json",
     "jsconfig.json",
 )
+# (H) When searching subdirectories for tsconfig files (monorepo `frontend/`,
+# (H) `packages/*`), skip dependency/build/VCS trees: their tsconfigs carry
+# (H) unrelated aliases and there can be thousands of them under node_modules.
+TS_ALIAS_SKIP_DIRS: frozenset[str] = frozenset(
+    {"node_modules", "dist", "build", "out", ".git"}
+)
 JS_INDEX_STEM = "index"
 TS_COMPILER_OPTIONS_KEY = "compilerOptions"
 TS_PATHS_KEY = "paths"
@@ -1667,6 +1673,13 @@ JS_FUNCTION_PROTOTYPE_SUFFIXES: dict[str, str] = {
     JS_SUFFIX_CALL: JS_METHOD_CALL,
     JS_SUFFIX_APPLY: JS_METHOD_APPLY,
 }
+# (H) `fn.bind(ctx)` / `fn.call(...)` / `fn.apply(...)` all use `fn`; when such a
+# (H) call sits in a value position (`onError: handleError.bind(toast)`) the `.bind`
+# (H) resolves to the Function.prototype builtin, so `fn` itself must be referenced
+# (H) separately or it reports as dead.
+JS_FUNCTION_PROTOTYPE_METHODS = frozenset(
+    {JS_METHOD_BIND, JS_METHOD_CALL, JS_METHOD_APPLY}
+)
 
 # (H) C++ operator mappings
 CPP_OPERATORS: dict[str, str] = {

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1800,7 +1800,12 @@ class CallProcessor:
         stack: list[Node] = list(caller_node.children)
         while stack:
             node = stack.pop()
-            if node.type in boundary_types:
+            # (H) Stop at a nested scope that gets its OWN caller pass (a named
+            # (H) function/arrow, a class), but continue THROUGH an anonymous arrow
+            # (H) (a `.map()`/`cell`/forwardRef callback): those are skipped as
+            # (H) callers, so their JSX -- rendered on behalf of this scope -- would
+            # (H) otherwise be scanned by nobody and report as dead.
+            if node.type in boundary_types and not self._is_unowned_js_scope(node):
                 continue
             if node.type in _JSX_NAMED_ELEMENT_TYPES:
                 name_node = node.child_by_field_name(cs.FIELD_NAME)
@@ -2800,6 +2805,15 @@ class CallProcessor:
             for n in func_nodes
             if self._get_node_name(n) or self._js_ts_arrow_binding_name(n)
         ]
+
+    def _is_unowned_js_scope(self, node: Node) -> bool:
+        # (H) An anonymous arrow/function-expression that gets no caller node of its
+        # (H) own (no name, no binding name) -- a `.map()`/`cell`/forwardRef callback.
+        # (H) Its calls bubble up to the enclosing named scope (_js_ts_attributable_nodes),
+        # (H) and so must its JSX references: the enclosing JSX walk continues through it.
+        if node.type not in (cs.TS_ARROW_FUNCTION, cs.TS_FUNCTION_EXPRESSION):
+            return False
+        return not (self._get_node_name(node) or self._js_ts_arrow_binding_name(node))
 
     def _is_method(self, func_node: Node, lang_config: LanguageSpec) -> bool:
         return is_method_node(func_node, lang_config)

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1294,6 +1294,15 @@ class CallProcessor:
                 self._flow_scope_boundaries(queries[language][cs.QUERY_CONFIG]),
                 caller_qn,
             )
+            self._ingest_returned_function_references(
+                caller_node,
+                caller_spec,
+                module_qn,
+                local_var_types,
+                class_context,
+                self._flow_scope_boundaries(queries[language][cs.QUERY_CONFIG]),
+                caller_qn,
+            )
         # (H) Dispatch-table handler references, for every flow language. Module-scope
         # (H) literals are scanned explicitly in process_calls_in_file (before the
         # (H) no-calls early return), so only nested scopes here.
@@ -1758,7 +1767,15 @@ class CallProcessor:
                 continue
             if rhs_field := _ASSIGNMENT_RHS_FIELDS.get(node.type):
                 right = node.child_by_field_name(rhs_field)
-                if right is not None and right.type in _ASSIGNMENT_RHS_REF_TYPES:
+                # (H) A bare-name RHS names a callable; an inline arrow/function-expr
+                # (H) RHS (`OpenAPI.TOKEN = async () => {}`) stores an anonymous
+                # (H) function on the target for later invocation -- _emit_callback_edge
+                # (H) references it by position. A named arrow-const RHS is registered
+                # (H) by its name, so the by-position lookup simply finds nothing.
+                if right is not None and (
+                    right.type in _ASSIGNMENT_RHS_REF_TYPES
+                    or right.type in _INLINE_FUNC_VALUE_TYPES
+                ):
                     self._emit_callback_edge(
                         caller_spec,
                         right,
@@ -1828,6 +1845,44 @@ class CallProcessor:
                 # (H) or inline arrow (onClick={() => x()}) is a function the
                 # (H) framework invokes on the event, so reference it; other
                 # (H) expressions resolve to nothing and are skipped by the helper.
+                for value in node.named_children:
+                    self._emit_callback_edge(
+                        caller_spec,
+                        value,
+                        module_qn,
+                        local_var_types,
+                        class_context,
+                        resolve_func,
+                        ensure_rel,
+                        caller_qn=caller_qn,
+                        rel_type=cs.RelationshipType.REFERENCES,
+                    )
+            stack.extend(node.children)
+
+    def _ingest_returned_function_references(
+        self,
+        caller_node: Node,
+        caller_spec: tuple[str, str, str],
+        module_qn: str,
+        local_var_types: dict[str, str] | None,
+        class_context: str | None,
+        boundary_types: frozenset[str],
+        caller_qn: str | None = None,
+    ) -> None:
+        # (H) A function handed back via `return` (a useEffect cleanup
+        # (H) `return () => unsubscribe()`, a factory `return handler`) is invoked by
+        # (H) whoever receives it, never by a call the graph can see. Reference it from
+        # (H) the returning scope. Walk continues through anonymous arrows (the effect
+        # (H) callback is anonymous, so its `return` bubbles here) but stops at named
+        # (H) nested functions, which own their returns.
+        resolve_func = self._resolver.resolve_function_call
+        ensure_rel = self.ingestor.ensure_relationship_batch
+        stack: list[Node] = list(caller_node.children)
+        while stack:
+            node = stack.pop()
+            if node.type in boundary_types and not self._is_unowned_js_scope(node):
+                continue
+            if node.type == cs.TS_RETURN_STATEMENT:
                 for value in node.named_children:
                     self._emit_callback_edge(
                         caller_spec,

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1904,6 +1904,12 @@ class CallProcessor:
         resolve_func,
         ensure_rel,
     ) -> None:
+        # (H) `fn.bind(ctx)` / `fn.call(...)` / `fn.apply(...)` in value position
+        # (H) (onError: handleError.bind(toast)) hands off `fn`; the call resolves to
+        # (H) the Function.prototype builtin, so unwrap to the bound function and
+        # (H) reference it instead, or it reports as dead.
+        if (bound := self._unwrap_bound_function(node)) is not None:
+            node = bound
         # (H) Only a bare name / attribute / member-expression in value position names
         # (H) a function; a call, comprehension or literal is not a reference to a
         # (H) callable itself. Reuses the flow-arg ref types (identifier, Python
@@ -1919,6 +1925,24 @@ class CallProcessor:
             resolve_func,
             ensure_rel,
         )
+
+    def _unwrap_bound_function(self, node: Node) -> Node | None:
+        # (H) For `fn.bind(ctx)` (a call_expression whose function is `fn.bind`),
+        # (H) return the bound function `fn` (the member object) so the value is
+        # (H) referenced as `fn`, not the Function.prototype builtin. call/apply use
+        # (H) the function the same way. Returns None when the node is not such a call.
+        if node.type != cs.TS_CALL_EXPRESSION:
+            return None
+        fn = node.child_by_field_name(cs.TS_FIELD_FUNCTION)
+        if fn is None or fn.type != cs.TS_MEMBER_EXPRESSION:
+            return None
+        prop = fn.child_by_field_name(cs.FIELD_PROPERTY)
+        if (
+            prop is None
+            or safe_decode_text(prop) not in cs.JS_FUNCTION_PROTOTYPE_METHODS
+        ):
+            return None
+        return fn.child_by_field_name(cs.FIELD_OBJECT)
 
     def _emit_inline_value_function_ref(
         self,

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -565,6 +565,13 @@ class FunctionIngestMixin:
                     for child in current.children:
                         if child.type == cs.TS_IDENTIFIER and child.text:
                             return safe_decode_text(child)
+                    return None
+                # (H) Crossing another function's body means this arrow is nested
+                # (H) inside it (a JSX handler, a `.map()` callback), not bound to the
+                # (H) outer const -- stop so it stays anonymous instead of inheriting
+                # (H) the component's name as a `Component.Component` phantom.
+                if current.type in cs.JS_ARROW_NAME_CLIMB_BOUNDARY:
+                    return None
                 current = current.parent
 
         return None

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -61,45 +61,95 @@ def _load_jsonc(path: Path) -> dict | None:
     return None
 
 
+def _child_dirs(path: Path) -> list[Path]:
+    # (H) Immediate subdirectories worth searching, pruning dependency/build/VCS
+    # (H) trees at traversal time so we never stat into node_modules (thousands of
+    # (H) package tsconfigs) or hidden dirs.
+    try:
+        return sorted(
+            child
+            for child in path.iterdir()
+            if child.is_dir()
+            and child.name not in cs.TS_ALIAS_SKIP_DIRS
+            and not child.name.startswith(cs.PATH_CURRENT_DIR)
+        )
+    except OSError:
+        return []
+
+
+def _find_tsconfig_files(repo_path: Path) -> list[Path]:
+    # (H) tsconfig can live at the repo root OR in a subdirectory (a monorepo's
+    # (H) `frontend/`, `packages/*`), so search the root and up to two levels down.
+    # (H) Root first so its aliases win prefix-length ties.
+    level_one = _child_dirs(repo_path)
+    search_dirs = [repo_path, *level_one]
+    for child in level_one:
+        search_dirs.extend(_child_dirs(child))
+    found: list[Path] = []
+    for directory in search_dirs:
+        for name in cs.TSCONFIG_FILENAMES:
+            candidate = directory / name
+            if candidate.is_file():
+                found.append(candidate)
+    return found
+
+
+def _parse_tsconfig_aliases(data: dict, dir_prefix: str) -> list[tuple[str, str, bool]]:
+    # (H) Parse one tsconfig's `compilerOptions.paths` into (match_prefix,
+    # (H) target_prefix, is_wildcard) tuples, folding baseUrl and the tsconfig's own
+    # (H) directory into the target so targets are repo-root-relative. A `@/*`->`src/*`
+    # (H) entry in `frontend/tsconfig.json` yields ("@/", "frontend/src/", True); an
+    # (H) exact `~lib`->`src/lib/index.ts` yields ("~lib", ".../src/lib/index.ts",
+    # (H) False). `extends` chains are not followed.
+    options = data.get(cs.TS_COMPILER_OPTIONS_KEY)
+    if not isinstance(options, dict):
+        return []
+    paths = options.get(cs.TS_PATHS_KEY)
+    if not isinstance(paths, dict):
+        return []
+    base = options.get(cs.TS_BASE_URL_KEY) or cs.PATH_CURRENT_DIR
+    base = str(base).strip(cs.SEPARATOR_SLASH)
+    base_prefix = "" if base in ("", cs.PATH_CURRENT_DIR) else base + cs.SEPARATOR_SLASH
+    aliases: list[tuple[str, str, bool]] = []
+    for pattern, targets in paths.items():
+        if not isinstance(targets, list) or not targets:
+            continue
+        target = targets[0]
+        if not isinstance(pattern, str) or not isinstance(target, str):
+            continue
+        if pattern.endswith(cs.GLOB_ALL) and cs.GLOB_ALL in target:
+            aliases.append(
+                (
+                    pattern[: -len(cs.GLOB_ALL)],
+                    dir_prefix + base_prefix + target[: target.index(cs.GLOB_ALL)],
+                    True,
+                )
+            )
+        elif cs.GLOB_ALL not in pattern:
+            aliases.append((pattern, dir_prefix + base_prefix + target, False))
+    return aliases
+
+
 def _load_ts_path_aliases(repo_path: Path) -> list[tuple[str, str, bool]]:
-    # (H) Parse tsconfig `compilerOptions.paths` into (match_prefix, target_prefix,
-    # (H) is_wildcard) tuples, folding baseUrl into the target. A `@/*`->`src/*` entry
-    # (H) yields ("@/", "src/", True); an exact `~lib`->`src/lib/index.ts` yields
-    # (H) ("~lib", "src/lib/index.ts", False). `extends` chains are not followed.
-    for name in cs.TSCONFIG_FILENAMES:
-        data = _load_jsonc(repo_path / name)
+    # (H) Aggregate `paths` aliases from every tsconfig at or below the repo root,
+    # (H) each target prefixed by the tsconfig's own directory so `@/util` resolves
+    # (H) against the config that defines it (a subdir `frontend/tsconfig.json` maps
+    # (H) `@/` to `frontend/src/`). _ts_alias_module_qn keeps only aliases whose
+    # (H) target exists on disk, so same-prefix aliases from sibling packages do not
+    # (H) collide.
+    aliases: list[tuple[str, str, bool]] = []
+    for cfg in _find_tsconfig_files(repo_path):
+        data = _load_jsonc(cfg)
         if not data:
             continue
-        options = data.get(cs.TS_COMPILER_OPTIONS_KEY)
-        if not isinstance(options, dict):
-            continue
-        paths = options.get(cs.TS_PATHS_KEY)
-        if not isinstance(paths, dict):
-            continue
-        base = options.get(cs.TS_BASE_URL_KEY) or cs.PATH_CURRENT_DIR
-        base = str(base).strip(cs.SEPARATOR_SLASH)
-        base_prefix = (
-            "" if base in ("", cs.PATH_CURRENT_DIR) else base + cs.SEPARATOR_SLASH
+        parent = cfg.parent
+        dir_prefix = (
+            ""
+            if parent == repo_path
+            else parent.relative_to(repo_path).as_posix() + cs.SEPARATOR_SLASH
         )
-        aliases: list[tuple[str, str, bool]] = []
-        for pattern, targets in paths.items():
-            if not isinstance(targets, list) or not targets:
-                continue
-            target = targets[0]
-            if not isinstance(pattern, str) or not isinstance(target, str):
-                continue
-            if pattern.endswith(cs.GLOB_ALL) and cs.GLOB_ALL in target:
-                aliases.append(
-                    (
-                        pattern[: -len(cs.GLOB_ALL)],
-                        base_prefix + target[: target.index(cs.GLOB_ALL)],
-                        True,
-                    )
-                )
-            elif cs.GLOB_ALL not in pattern:
-                aliases.append((pattern, base_prefix + target, False))
-        return aliases
-    return []
+        aliases.extend(_parse_tsconfig_aliases(data, dir_prefix))
+    return aliases
 
 
 def _has_aliased_scheme(specifier: str) -> bool:
@@ -653,49 +703,51 @@ class ImportProcessor:
         # (H) first-party module qn, so the call binds to the real file instead of
         # (H) being dropped as external. Precise (maps to the actual path), so no
         # (H) trie-fallback collision risk. Longest matching prefix wins.
-        best: tuple[int, str] | None = None
+        # (H) Collect every matching alias (a monorepo may define `@/` in several
+        # (H) tsconfigs pointing at different package dirs), then accept the first,
+        # (H) longest-prefix one whose target is a real first-party file on disk. The
+        # (H) disk check both disambiguates siblings and blocks a catch-all alias
+        # (H) (`"*": ["src/*"]`) from capturing bare package imports (`lodash` ->
+        # (H) `proj.src.lodash`) and rebinding them to same-named locals (#580).
+        candidates: list[tuple[int, str]] = []
         for prefix, target_prefix, is_wildcard in self.js_path_aliases:
             if is_wildcard:
-                if import_path.startswith(prefix) and len(prefix) > (
-                    best[0] if best else -1
-                ):
-                    best = (len(prefix), target_prefix + import_path[len(prefix) :])
-            elif import_path == prefix and len(prefix) > (best[0] if best else -1):
-                best = (len(prefix), target_prefix)
-        if best is None:
-            return None
-        path = best[1]
-        for ext in cs.JS_TS_MODULE_EXTENSIONS:
-            if path.endswith(ext):
-                path = path[: -len(ext)]
-                break
-        # (H) normpath collapses `.`/`..` so the qn is clean and an escaping alias
-        # (H) (`../x`) is rejected below.
-        normalized = posixpath.normpath(path)
-        if normalized in (cs.PATH_CURRENT_DIR, "") or normalized.startswith(
-            cs.PATH_PARENT_DIR
-        ):
-            return None
-        # (H) Only accept the alias when it maps to a real first-party file on disk.
-        # (H) A broad/catch-all alias (`"*": ["src/*"]`) would otherwise capture bare
-        # (H) package imports (`lodash` -> `proj.src.lodash`) and let their calls
-        # (H) rebind to same-named first-party symbols (the #580 collision). A missing
-        # (H) target falls through to the normal external handling.
-        module_rel: str | None = None
-        if any(
-            (self.repo_path / f"{normalized}{ext}").is_file()
-            for ext in cs.JS_TS_MODULE_EXTENSIONS
-        ):
-            module_rel = normalized
-        elif (self.repo_path / normalized).is_dir() and any(
-            (self.repo_path / normalized / f"{cs.JS_INDEX_STEM}{ext}").is_file()
-            for ext in cs.JS_TS_MODULE_EXTENSIONS
-        ):
-            module_rel = f"{normalized}{cs.SEPARATOR_SLASH}{cs.JS_INDEX_STEM}"
-        if module_rel is None:
-            return None
-        dotted = module_rel.replace(cs.SEPARATOR_SLASH, cs.SEPARATOR_DOT)
-        return f"{self.project_name}{cs.SEPARATOR_DOT}{dotted}"
+                if import_path.startswith(prefix):
+                    candidates.append(
+                        (len(prefix), target_prefix + import_path[len(prefix) :])
+                    )
+            elif import_path == prefix:
+                candidates.append((len(prefix), target_prefix))
+        candidates.sort(key=lambda c: c[0], reverse=True)
+        for _prefix_len, raw_path in candidates:
+            path = raw_path
+            for ext in cs.JS_TS_MODULE_EXTENSIONS:
+                if path.endswith(ext):
+                    path = path[: -len(ext)]
+                    break
+            # (H) normpath collapses `.`/`..` so the qn is clean and an escaping alias
+            # (H) (`../x`) is rejected below.
+            normalized = posixpath.normpath(path)
+            if normalized in (cs.PATH_CURRENT_DIR, "") or normalized.startswith(
+                cs.PATH_PARENT_DIR
+            ):
+                continue
+            module_rel: str | None = None
+            if any(
+                (self.repo_path / f"{normalized}{ext}").is_file()
+                for ext in cs.JS_TS_MODULE_EXTENSIONS
+            ):
+                module_rel = normalized
+            elif (self.repo_path / normalized).is_dir() and any(
+                (self.repo_path / normalized / f"{cs.JS_INDEX_STEM}{ext}").is_file()
+                for ext in cs.JS_TS_MODULE_EXTENSIONS
+            ):
+                module_rel = f"{normalized}{cs.SEPARATOR_SLASH}{cs.JS_INDEX_STEM}"
+            if module_rel is None:
+                continue
+            dotted = module_rel.replace(cs.SEPARATOR_SLASH, cs.SEPARATOR_DOT)
+            return f"{self.project_name}{cs.SEPARATOR_DOT}{dotted}"
+        return None
 
     def _resolve_js_module_path(self, import_path: str, current_module: str) -> str:
         if not import_path.startswith(cs.PATH_CURRENT_DIR):

--- a/codebase_rag/tests/test_javascript_object_patterns.py
+++ b/codebase_rag/tests/test_javascript_object_patterns.py
@@ -345,20 +345,18 @@ console.log(secureObject[Symbol.for('public')]); // shared
             f"Missing object literal function: {expected}"
         )
 
-    all_nodes = mock_ingestor.ensure_node_batch.call_args_list
-
-    object_like_nodes = [
-        call
-        for call in all_nodes
+    # (H) Object-literal methods are captured as functions in the module (mathUtils'
+    # (H) square/cube/power). This previously counted phantom nodes an inner arrow
+    # (H) left by climbing to its object const's name; those are gone now, so assert
+    # (H) the real method functions are present.
+    object_method_names = {
+        call[0][1].get("qualified_name", "").rsplit(".", 1)[-1].split("@")[0]
+        for call in mock_ingestor.ensure_node_batch.call_args_list
         if "object_literals" in call[0][1].get("qualified_name", "")
-        and any(
-            pattern in call[0][1].get("qualified_name", "")
-            for pattern in ["calculator", "user", "playlist", "mathUtils"]
-        )
-    ]
+    }
 
-    assert len(object_like_nodes) >= 2, (
-        f"Expected at least 2 object-like nodes, found {len(object_like_nodes)}"
+    assert {"square", "cube", "power"} <= object_method_names, (
+        f"Missing object-literal methods; found {sorted(object_method_names)}"
     )
 
 
@@ -778,17 +776,18 @@ console.log(users.map(u => u.getProfile()));
         f"Expected at least 6 factory functions, found {len(found_factories)}"
     )
 
-    all_nodes = mock_ingestor.ensure_node_batch.call_args_list
-
-    factory_object_nodes = [
-        call
-        for call in all_nodes
+    # (H) userFactory's methods are captured as module functions (createAdmin,
+    # (H) createFromData, createBatch). This previously matched a phantom node an
+    # (H) inner `.map()` arrow left by inheriting the userFactory const name; assert
+    # (H) the real methods instead.
+    factory_method_names = {
+        call[0][1].get("qualified_name", "").rsplit(".", 1)[-1].split("@")[0]
+        for call in mock_ingestor.ensure_node_batch.call_args_list
         if "factory_functions" in call[0][1].get("qualified_name", "")
-        and "userFactory" in call[0][1].get("qualified_name", "")
-    ]
+    }
 
-    assert len(factory_object_nodes) >= 1, (
-        f"Expected userFactory object methods, found {len(factory_object_nodes)}"
+    assert {"createAdmin", "createFromData", "createBatch"} <= factory_method_names, (
+        f"Missing userFactory methods; found {sorted(factory_method_names)}"
     )
 
 
@@ -1581,20 +1580,17 @@ console.log('Cloned:', cloned.toJSON());
         f"Expected at least 5 composition functions, found {len(found_composition_functions)}"
     )
 
-    all_nodes = mock_ingestor.ensure_node_batch.call_args_list
-
-    mixin_nodes = [
-        call
-        for call in all_nodes
+    # (H) Mixin object methods are captured as module functions (canWalk's walk,
+    # (H) canRun's run, etc.). This previously counted phantom nodes an inner arrow
+    # (H) left by inheriting a mixin const's name; assert the real methods instead.
+    composition_method_names = {
+        call[0][1].get("qualified_name", "").rsplit(".", 1)[-1].split("@")[0]
+        for call in mock_ingestor.ensure_node_batch.call_args_list
         if "object_composition" in call[0][1].get("qualified_name", "")
-        and any(
-            pattern in call[0][1].get("qualified_name", "")
-            for pattern in ["Mixin", "canWalk", "canRun", "canSwim", "canFly"]
-        )
-    ]
+    }
 
-    assert len(mixin_nodes) >= 2, (
-        f"Expected at least 2 mixin-related nodes, found {len(mixin_nodes)}"
+    assert {"walk", "run", "swim", "fly"} <= composition_method_names, (
+        f"Missing mixin methods; found {sorted(composition_method_names)}"
     )
 
 

--- a/codebase_rag/tests/test_jsx_component_references.py
+++ b/codebase_rag/tests/test_jsx_component_references.py
@@ -185,6 +185,49 @@ def test_jsx_attribute_inline_arrow_is_referenced(tmp_path: Path) -> None:
     )
 
 
+def test_jsx_handler_in_nested_callback_is_referenced(tmp_path: Path) -> None:
+    # (H) A JSX handler inside a nested anonymous callback (`items.map(item => <a
+    # (H) onClick={handleMenuClick}/>)`) must still be referenced by the enclosing
+    # (H) component. The map arrow is anonymous, so it never gets its own caller pass;
+    # (H) the component's JSX walk must therefore continue THROUGH it instead of
+    # (H) stopping at the arrow boundary, or the handler reports as dead.
+    files = {
+        "main.tsx": (
+            "export function Main() {\n"
+            "  const handleMenuClick = () => { go() }\n"
+            "  return (\n"
+            "    <ul>{items.map((item) => <a onClick={handleMenuClick}>{item}</a>)}</ul>\n"
+            "  )\n"
+            "}\n\n\n"
+            "function go() {}\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files, "tsx")
+    assert _has(rels, "main.Main", REFERENCES, "main.Main.handleMenuClick")
+
+
+def test_jsx_component_in_config_callback_is_referenced(tmp_path: Path) -> None:
+    # (H) TanStack Table columns render via `cell: ({ row }) => <CopyId />`; the cell
+    # (H) arrow is an anonymous value in a module-level array, so the module JSX walk
+    # (H) must descend through it to reference the rendered component (else CopyId,
+    # (H) used only in config callbacks, reports as dead).
+    files = {
+        "cols.tsx": (
+            "import { CopyId } from './copy'\n\n"
+            "export const columns = [\n"
+            "  { cell: ({ row }) => <CopyId id={row.id} /> },\n"
+            "]\n"
+        ),
+        "copy.tsx": (
+            "export function CopyId({ id }: { id: string }) {\n"
+            "  return <span>{id}</span>\n"
+            "}\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files, "tsx")
+    assert _has(rels, "cols", REFERENCES, "copy.CopyId")
+
+
 def test_member_expression_component_is_referenced(tmp_path: Path) -> None:
     # (H) A namespaced component (<Menu.Item />) names its member through a
     # (H) member expression; resolve it like any dotted callable reference.

--- a/codebase_rag/tests/test_object_literal_callback_references.py
+++ b/codebase_rag/tests/test_object_literal_callback_references.py
@@ -90,6 +90,61 @@ def test_use_mutation_variable_not_registered_as_function(tmp_path: Path) -> Non
     )
 
 
+def test_inline_arrow_in_component_not_named_after_component(tmp_path: Path) -> None:
+    # (H) An inline arrow inside an arrow-const component's JSX (an onClick handler)
+    # (H) has no declarator of its own, so climbing ancestors for a name must STOP at
+    # (H) the component's function-body boundary -- otherwise it reaches the
+    # (H) `const Appearance = () =>` declarator and registers as
+    # (H) `module.Appearance.Appearance` (a double-segment phantom with no incoming
+    # (H) edge = dead code, and it orphans the real inline handlers from #616).
+    files = {
+        "widget.tsx": (
+            "export const Panel = () => {\n"
+            "  return (\n"
+            "    <Menu>\n"
+            "      <Item onClick={() => setTheme('light')}>L</Item>\n"
+            "      <Item onClick={() => setTheme('dark')}>D</Item>\n"
+            "    </Menu>\n"
+            "  )\n"
+            "}\n\n\n"
+            "function setTheme(x) {}\n"
+        ),
+    }
+    fns = _function_qns(tmp_path, files, "tsx")
+    assert not any(qn.endswith(".Panel.Panel") for qn in fns), (
+        f"component arrow double-registered under itself; fns={fns}"
+    )
+
+
+def test_arrow_const_with_inner_arrow_is_callable(tmp_path: Path) -> None:
+    # (H) An exported arrow-const whose body contains an inner arrow (`.map(w => ...)`)
+    # (H) must register as `utils.getInitials` (single segment) so a cross-module
+    # (H) call resolves. The inner arrow must not climb to the getInitials declarator
+    # (H) and push the real function to `utils.getInitials.getInitials`, which no call
+    # (H) site matches (the util then reports as dead despite being called).
+    files = {
+        "utils.ts": (
+            "export const getInitials = (name) => {\n"
+            "  return name.split(' ').map((w) => w[0]).join('')\n"
+            "}\n"
+        ),
+        "user.tsx": (
+            "import { getInitials } from './utils'\n\n"
+            "export function User() {\n"
+            "  return <div>{getInitials('x')}</div>\n"
+            "}\n"
+        ),
+    }
+    fns = _function_qns(tmp_path, files, "tsx")
+    assert not any(qn.endswith(".getInitials.getInitials") for qn in fns), (
+        f"inner arrow mis-named after the getInitials const; fns={fns}"
+    )
+    # (H) The real function keeps the single-segment name a call site resolves to.
+    assert any(qn.endswith(".utils.getInitials") for qn in fns), (
+        f"getInitials not registered at the expected single-segment qn; fns={fns}"
+    )
+
+
 def test_object_literal_inline_arrow_is_referenced(tmp_path: Path) -> None:
     # (H) useMutation({ mutationFn: () => {}, onSuccess: () => {} }) registers each
     # (H) inline arrow as its own node (AddUser.mutationFn / AddUser.onSuccess); the

--- a/codebase_rag/tests/test_object_literal_callback_references.py
+++ b/codebase_rag/tests/test_object_literal_callback_references.py
@@ -145,6 +145,35 @@ def test_arrow_const_with_inner_arrow_is_callable(tmp_path: Path) -> None:
     )
 
 
+def test_object_value_bound_function_is_referenced(tmp_path: Path) -> None:
+    # (H) `onError: handleError.bind(showToast)` hands the bound function
+    # (H) `handleError` to the mutation config; the `.bind(...)` call resolves to the
+    # (H) Function.prototype builtin, so without unwrapping it the real `handleError`
+    # (H) gets no incoming edge and reports as dead (and drags down the private
+    # (H) helper it calls). The enclosing scope must reference the bound function.
+    files = {
+        "utils.ts": (
+            "function extractErrorMessage(e) { return e.message }\n"
+            "export const handleError = function (e) {\n"
+            "  return extractErrorMessage(e)\n"
+            "}\n"
+        ),
+        "comp.tsx": (
+            "import { handleError } from './utils'\n\n"
+            "export function AddItem() {\n"
+            "  return doMutation({ onError: handleError.bind(showToast) })\n"
+            "}\n\n\n"
+            "function doMutation(o) { return o }\n"
+            "function showToast(m) {}\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files, "tsx")
+    edges = {(r, b) for a, r, b in rels if a.endswith("comp.AddItem")}
+    assert any(b.endswith("utils.handleError") for _r, b in edges), (
+        f"bound function handleError not referenced; edges={edges}"
+    )
+
+
 def test_object_literal_inline_arrow_is_referenced(tmp_path: Path) -> None:
     # (H) useMutation({ mutationFn: () => {}, onSuccess: () => {} }) registers each
     # (H) inline arrow as its own node (AddUser.mutationFn / AddUser.onSuccess); the

--- a/codebase_rag/tests/test_object_literal_callback_references.py
+++ b/codebase_rag/tests/test_object_literal_callback_references.py
@@ -145,6 +145,58 @@ def test_arrow_const_with_inner_arrow_is_callable(tmp_path: Path) -> None:
     )
 
 
+def test_function_expression_assigned_to_property_is_referenced(
+    tmp_path: Path,
+) -> None:
+    # (H) `OpenAPI.TOKEN = async () => {...}` stores a function on an object property
+    # (H) for a library to invoke later (the openapi-ts token provider); the arrow is
+    # (H) anonymous with no incoming edge. The assigning scope must reference it or it
+    # (H) reports as dead (the last frontend false positive on the template).
+    files = {
+        "main.tsx": (
+            "import { OpenAPI } from './client'\n\n"
+            "OpenAPI.TOKEN = async () => {\n"
+            "  return getToken()\n"
+            "}\n\n\n"
+            "function getToken() {\n"
+            "  return ''\n"
+            "}\n"
+        ),
+        "client.ts": "export const OpenAPI = { TOKEN: '' }\n",
+    }
+    rels = _run_rels(tmp_path, files, "tsx")
+    refs = {b for a, r, b in rels if r == REFERENCES and a.endswith(".main")}
+    assert any(".main.anonymous_" in b for b in refs), (
+        f"function-expression assigned to a property not referenced; refs={refs}"
+    )
+
+
+def test_returned_cleanup_closure_is_referenced(tmp_path: Path) -> None:
+    # (H) A useEffect cleanup (`return () => unsubscribe()`) is a function the hook
+    # (H) hands back for React to invoke; it registers as an anonymous node under the
+    # (H) enclosing hook (the effect arrow is anonymous, so it nests one level up) but
+    # (H) has no incoming edge. The scope that returns it must reference it or every
+    # (H) effect cleanup reports as dead.
+    files = {
+        "hook.tsx": (
+            "export function useThing() {\n"
+            "  useEffect(() => {\n"
+            "    subscribe(handler)\n"
+            "    return () => unsubscribe(handler)\n"
+            "  }, [])\n"
+            "}\n\n\n"
+            "function subscribe(f) {}\n"
+            "function unsubscribe(f) {}\n"
+            "function handler() {}\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files, "tsx")
+    refs = {b for a, r, b in rels if r == REFERENCES and a.endswith("hook.useThing")}
+    assert any(".hook.useThing.anonymous_" in b for b in refs), (
+        f"returned cleanup closure not referenced; refs={refs}"
+    )
+
+
 def test_object_value_bound_function_is_referenced(tmp_path: Path) -> None:
     # (H) `onError: handleError.bind(showToast)` hands the bound function
     # (H) `handleError` to the mutation config; the `.bind(...)` call resolves to the

--- a/codebase_rag/tests/test_ts_tsconfig_paths.py
+++ b/codebase_rag/tests/test_ts_tsconfig_paths.py
@@ -59,6 +59,39 @@ def _make(root: Path) -> None:
 
 
 @needs_ts_grammar
+def test_tsconfig_paths_alias_in_subdirectory_resolves(tmp_path: Path) -> None:
+    # (H) The tsconfig lives in a subdirectory (a monorepo `frontend/`), not the
+    # (H) indexed repo root. Its `@/* -> ./src/*` alias is relative to that
+    # (H) subdirectory, so an `@/util` import must resolve to `frontend/src/util`
+    # (H) (the full-stack-fastapi-template layout). Reading only the root tsconfig
+    # (H) leaves every `@/` import unresolved and its callees reported as dead.
+    fe = tmp_path / "frontend"
+    (fe / "src").mkdir(parents=True)
+    (fe / "tsconfig.json").write_text(
+        '{"compilerOptions":{"baseUrl":".","paths":{"@/*":["./src/*"]}}}',
+        encoding="utf-8",
+    )
+    (fe / "src" / "util.ts").write_text(
+        "export function aliasedHelper(): number { return 1; }\n", encoding="utf-8"
+    )
+    (fe / "src" / "app.ts").write_text(
+        'import { aliasedHelper } from "@/util";\n'
+        "export function useIt(): number { return aliasedHelper(); }\n",
+        encoding="utf-8",
+    )
+    ingestor = _capture(tmp_path, "proj")
+    calls = {
+        (str(from_val), str(to_val))
+        for _fl, from_val, rel, _tl, to_val in ingestor.rels
+        if rel == "CALLS"
+    }
+    assert (
+        "proj.frontend.src.app.useIt",
+        "proj.frontend.src.util.aliasedHelper",
+    ) in calls
+
+
+@needs_ts_grammar
 def test_tsconfig_paths_alias_calls_resolve_to_first_party_files(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## What

Eliminates the last classes of JS/TS dead-code false positives. Measured on full-stack-fastapi-template: frontend candidates **21 → 0** (`--exclude '*client/core*' '*.gen.*'`); raw **105 → 7**, and those 7 are all generated `client/core`.

Four independent root causes, one commit each:

### 1. Arrow-const inner-arrow double-registration (`de6c9f8`)
A nameless inline arrow (a JSX `onClick={() => x()}`, a `.map(w => ...)` callback) had no declarator of its own, so `_extract_function_name` climbed all the way up to the enclosing component's `const Foo = () =>` declarator and named the arrow `Foo` — producing a `module.Foo.Foo` phantom with no incoming edge, and orphaning the real inline handlers. Fix: stop the name-climb at a function-body boundary (`JS_ARROW_NAME_CLIMB_BOUNDARY`); crossing one means the arrow is nested, not the declarator's value.

This also fixed `getInitials` (its inner `.map(w => ...)` had double-registered it as `utils.getInitials.getInitials`).

Note: three `test_javascript_object_patterns` assertions were counting these phantom nodes (object methods are registered flat, e.g. `object_literals.square`, never `mathUtils.square`), so they were rewritten to assert the real method names.

### 2. `.bind`/`.call`/`.apply` references + subdir tsconfig aliases (`8fcc533`)
`onError: handleError.bind(showErrorToast)` resolved to the `Function.prototype.bind` builtin, so `handleError` got no edge. `_unwrap_bound_function` unwraps `X.bind|call|apply(...)` to reference `X`. It was also blocked by path aliases: the template's tsconfig is at `frontend/tsconfig.json`, but the alias loader only read the repo-root tsconfig — so `@/utils` never resolved. The loader now searches subdirectory tsconfigs (targets prefixed by the config's dir, `node_modules`/`dist`/`build`/`.git` pruned), and resolution tries all matching aliases by disk existence so sibling-package aliases don't collide. `extractErrorMessage` (called only by `handleError`) recovers by cascade.

### 3. JSX in anonymous nested callbacks (`bd556db`)
A JSX handler/component inside an anonymous nested callback (`items.map(i => <a onClick={h}/>)`, TanStack `cell: ({row}) => <CopyId/>`, `forwardRef`) was scanned by nobody: the anonymous arrow is skipped as a caller, and the enclosing scope's JSX walk stopped at its boundary. The JSX walk now continues *through* unowned (anonymous) arrows, stopping only at named nested functions that get their own pass.

### 4. Returned closures + function-exprs assigned to properties (`45ba067`)
A useEffect cleanup (`return () => unsubscribe()`) and a function stored on a property (`OpenAPI.TOKEN = async () => {}`) are invoked by whoever receives them, never by a visible call. A new returned-function reference pass handles `return`, and the assignment-reference walker now accepts inline-arrow RHS (referenced by position).

## Test

Every fix is RED→GREEN. New tests in `test_object_literal_callback_references.py`, `test_jsx_component_references.py`, `test_ts_tsconfig_paths.py`. Full unit suite (4328) and integration suite (146) pass locally.