### PR TITLE
fix(go): treat init and main functions as dead-code roots

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -484,6 +484,12 @@ DEFAULT_ROOT_DECORATORS: frozenset[str] = frozenset(
     }
 )
 
+# (H) Go functions the runtime invokes with no explicit call site: `func init()`
+# (H) runs at package load (any number per package), `func main()` is the program
+# (H) entry. Both are reachability roots (like Python dunders), gated by the .go
+# (H) extension so same-named symbols in other languages are unaffected.
+GO_ROOT_FUNCTION_NAMES: frozenset[str] = frozenset({"init", "main"})
+
 # (H) Base classes that mark a class as a structural interface: its method stubs
 # (H) are never call targets themselves (callers resolve to the implementations),
 # (H) so dead-code analysis roots every method the class defines.

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -1,4 +1,8 @@
-from .constants import CYPHER_DEFAULT_LIMIT, PROTOCOL_BASE_QNS
+from .constants import (
+    CYPHER_DEFAULT_LIMIT,
+    GO_ROOT_FUNCTION_NAMES,
+    PROTOCOL_BASE_QNS,
+)
 
 CYPHER_DELETE_ALL = "MATCH (n) DETACH DELETE n;"
 
@@ -166,6 +170,7 @@ WHERE n.qualified_name STARTS WITH $project_prefix
     OR ('Method' IN labels(n)
         AND n.name STARTS WITH '__' AND n.name ENDS WITH '__' AND size(n.name) > 4
         AND n.path ENDS WITH '.py')
+    OR (n.name IN {go_root_names} AND n.path ENDS WITH '.go')
     OR ANY(e IN $entry_points WHERE n.qualified_name ENDS WITH e)
     OR {module_clause}{test_clause}
   )
@@ -211,12 +216,16 @@ def build_dead_code_query(include_tests: bool, include_classes: bool = False) ->
         test_clause = ""
         candidate_clause = _DEAD_CODE_CANDIDATE_NON_TEST
     protocol_bases = ", ".join(f"'{qn}'" for qn in PROTOCOL_BASE_QNS)
+    go_root_names = (
+        "[" + ", ".join(f"'{n}'" for n in sorted(GO_ROOT_FUNCTION_NAMES)) + "]"
+    )
     return _DEAD_CODE_QUERY_TEMPLATE.format(
         labels=labels,
         traversal=traversal,
         module_clause=module_clause,
         test_clause=test_clause,
         candidate_clause=candidate_clause,
+        go_root_names=go_root_names,
         protocol_stub_clause=_DEAD_CODE_PROTOCOL_STUB_CLAUSE.format(
             protocol_bases=protocol_bases
         ),

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -170,7 +170,8 @@ WHERE n.qualified_name STARTS WITH $project_prefix
     OR ('Method' IN labels(n)
         AND n.name STARTS WITH '__' AND n.name ENDS WITH '__' AND size(n.name) > 4
         AND n.path ENDS WITH '.py')
-    OR (n.name IN {go_root_names} AND n.path ENDS WITH '.go')
+    OR ('Function' IN labels(n)
+        AND n.name IN {go_root_names} AND n.path ENDS WITH '.go')
     OR ANY(e IN $entry_points WHERE n.qualified_name ENDS WITH e)
     OR {module_clause}{test_clause}
   )

--- a/codebase_rag/tests/test_dead_code_eval.py
+++ b/codebase_rag/tests/test_dead_code_eval.py
@@ -59,6 +59,28 @@ def test_dead_code_flags_uncalled_function() -> None:
     assert dead == {"proj.m.orphan"}
 
 
+def test_go_init_and_main_are_roots() -> None:
+    # (H) Go `func init()` is auto-run by the runtime at package load and `func
+    # (H) main()` is the program entry; neither is ever called explicitly, so both
+    # (H) are reachability roots (like Python dunders). A same-file helper with no
+    # (H) caller is still dead -- the exemption is name-scoped to init/main.
+    nodes = dict(
+        [
+            (
+                (_MODULE, "proj.mode"),
+                {cs.KEY_QUALIFIED_NAME: "proj.mode", cs.KEY_PATH: "mode.go"},
+            ),
+            _fn("proj.mode.init", path="mode.go"),
+            _fn("proj.main.main", path="main.go"),
+            _fn("proj.util.helper", path="util.go"),
+        ]
+    )
+    dead = dead_code_from_graph(nodes, [], _PREFIX, _CONFIG)
+    assert "proj.mode.init" not in dead
+    assert "proj.main.main" not in dead
+    assert "proj.util.helper" in dead
+
+
 def test_dead_code_excludes_generated_paths() -> None:
     # (H) A generated file (openapi-ts client/core, routeTree.gen.ts) has no
     # (H) in-repo caller, so every symbol in it reports as dead -- pure noise the

--- a/codebase_rag/tests/test_dead_code_eval.py
+++ b/codebase_rag/tests/test_dead_code_eval.py
@@ -38,6 +38,18 @@ def _fn(uid: str, path: str = "m.py", decorators: list[str] | None = None) -> tu
     )
 
 
+def _method(uid: str, path: str) -> tuple:
+    return (
+        (cs.NodeLabel.METHOD.value, uid),
+        {
+            cs.KEY_QUALIFIED_NAME: uid,
+            cs.KEY_PATH: path,
+            cs.KEY_DECORATORS: [],
+            cs.KEY_IS_EXPORTED: False,
+        },
+    )
+
+
 def test_dead_code_flags_uncalled_function() -> None:
     # (H) Module calls main(); main() calls helper(); orphan() is never called.
     nodes = dict(
@@ -73,12 +85,16 @@ def test_go_init_and_main_are_roots() -> None:
             _fn("proj.mode.init", path="mode.go"),
             _fn("proj.main.main", path="main.go"),
             _fn("proj.util.helper", path="util.go"),
+            _method("proj.mode.Type.init", path="mode.go"),
         ]
     )
     dead = dead_code_from_graph(nodes, [], _PREFIX, _CONFIG)
     assert "proj.mode.init" not in dead
     assert "proj.main.main" not in dead
     assert "proj.util.helper" in dead
+    # (H) A receiver method named init/main is NOT the package init/entry, so the
+    # (H) exemption is Function-scoped and this stays dead.
+    assert "proj.mode.Type.init" in dead
 
 
 def test_dead_code_excludes_generated_paths() -> None:

--- a/evals/dead_code.py
+++ b/evals/dead_code.py
@@ -179,9 +179,11 @@ def dead_code_from_graph(
             and str(props.get(cs.KEY_PATH, "")).endswith(cs.EXT_PY)
         ):
             roots.add(qn)
-        elif qn.rsplit(cs.SEPARATOR_DOT, 1)[-1] in cs.GO_ROOT_FUNCTION_NAMES and str(
-            props.get(cs.KEY_PATH, "")
-        ).endswith(cs.EXT_GO):
+        elif (
+            qn not in method_qns
+            and qn.rsplit(cs.SEPARATOR_DOT, 1)[-1] in cs.GO_ROOT_FUNCTION_NAMES
+            and str(props.get(cs.KEY_PATH, "")).endswith(cs.EXT_GO)
+        ):
             roots.add(qn)
         elif any(qn.endswith(entry) for entry in config.entry_points):
             roots.add(qn)

--- a/evals/dead_code.py
+++ b/evals/dead_code.py
@@ -179,6 +179,10 @@ def dead_code_from_graph(
             and str(props.get(cs.KEY_PATH, "")).endswith(cs.EXT_PY)
         ):
             roots.add(qn)
+        elif qn.rsplit(cs.SEPARATOR_DOT, 1)[-1] in cs.GO_ROOT_FUNCTION_NAMES and str(
+            props.get(cs.KEY_PATH, "")
+        ).endswith(cs.EXT_GO):
+            roots.add(qn)
         elif any(qn.endswith(entry) for entry in config.entry_points):
             roots.add(qn)
         elif config.include_tests and any(


### PR DESCRIPTION
## What

Go's `func init()` is auto-run by the runtime at package load (any number per package) and `func main()` is the program entry point — neither is ever called explicitly, so both were reported as dead code. They are now reachability roots, exactly analogous to the existing Python-dunder root exemption, gated by the `.go` extension so same-named symbols in other languages are unaffected.

Applied to both dead-code surfaces: the eval reachability (`evals/dead_code.py`) and the production `cgr dead-code` Cypher query (`_DEAD_CODE_QUERY_TEMPLATE`).

## Impact

Measured on `gin-gonic/gin`: dead-code candidates **16 → 8**. The eliminated 8 were all `func init()` (config/codec registration, appengine, generated protobuf inits). The remaining 8 are a separate, harder Go method-receiver resolution gap (`node.addChild` etc. *are* called but don't resolve) — out of scope here.

## Test

RED→GREEN `test_go_init_and_main_are_roots`: `init`/`main` in `.go` files are not flagged, while a same-file uncalled helper still is (the exemption is name-scoped).