### PR TITLE
fix(ts): unwrap as/satisfies/non-null casts when resolving function references

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -2462,6 +2462,16 @@ TS_SPREAD_PARAMETER = "spread_parameter"
 TS_LOCAL_VARIABLE_DECLARATION = "local_variable_declaration"
 TS_FIELD_DECLARATION = "field_declaration"
 TS_ASSIGNMENT_EXPRESSION = "assignment_expression"
+# (H) TS "cast" wrappers that are transparent for reference resolution: `x as T`,
+# (H) `x satisfies T`, and the non-null assertion `x!`. Their first named child is
+# (H) the wrapped value, so unwrapping reaches the real referenced expression
+# (H) (`export const persist = persistImpl as unknown as Persist`).
+TS_AS_EXPRESSION = "as_expression"
+TS_SATISFIES_EXPRESSION = "satisfies_expression"
+TS_NON_NULL_EXPRESSION = "non_null_expression"
+TS_CAST_WRAPPER_TYPES = frozenset(
+    {TS_AS_EXPRESSION, TS_SATISFIES_EXPRESSION, TS_NON_NULL_EXPRESSION}
+)
 TS_OBJECT_CREATION_EXPRESSION = "object_creation_expression"
 TS_METHOD_INVOCATION = "method_invocation"
 TS_FIELD_ACCESS = "field_access"

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1767,6 +1767,11 @@ class CallProcessor:
                 continue
             if rhs_field := _ASSIGNMENT_RHS_FIELDS.get(node.type):
                 right = node.child_by_field_name(rhs_field)
+                # (H) `export const persist = persistImpl as unknown as Persist`
+                # (H) wraps the aliased impl in TS casts; unwrap them so the bare
+                # (H) name/arrow underneath is what we reference.
+                if right is not None:
+                    right = self._unwrap_ts_cast(right)
                 # (H) A bare-name RHS names a callable; an inline arrow/function-expr
                 # (H) RHS (`OpenAPI.TOKEN = async () => {}`) stores an anonymous
                 # (H) function on the target for later invocation -- _emit_callback_edge
@@ -1985,6 +1990,18 @@ class CallProcessor:
             resolve_func,
             ensure_rel,
         )
+
+    def _unwrap_ts_cast(self, node: Node) -> Node:
+        # (H) Peel TS cast wrappers (`x as T`, `x satisfies T`, `x!`) to the wrapped
+        # (H) value; they are transparent for reference resolution. The wrapped value
+        # (H) is the first named child; casts nest (`x as unknown as T`), so loop.
+        current = node
+        while current.type in cs.TS_CAST_WRAPPER_TYPES:
+            inner = current.named_child(0)
+            if inner is None:
+                break
+            current = inner
+        return current
 
     def _unwrap_bound_function(self, node: Node) -> Node | None:
         # (H) For `fn.bind(ctx)` (a call_expression whose function is `fn.bind`),
@@ -2291,6 +2308,9 @@ class CallProcessor:
         caller_qn: str | None = None,
         rel_type: cs.RelationshipType = cs.RelationshipType.CALLS,
     ) -> None:
+        # (H) A TS cast (`handler as any`, `fn satisfies T`, `cb!`) is transparent for
+        # (H) reference resolution; unwrap it so the callable underneath resolves.
+        arg_node = self._unwrap_ts_cast(arg_node)
         # (H) An arrow/function-expression passed DIRECTLY as a call argument
         # (H) (useCallback(() => {}), setTimeout(() => {}), arr.map(x => ...)) is
         # (H) registered anonymously in the enclosing scope but named after no

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1969,6 +1969,9 @@ class CallProcessor:
         resolve_func,
         ensure_rel,
     ) -> None:
+        # (H) A value cast for typing (`persistImpl as unknown as Persist`) is
+        # (H) transparent for reference resolution; unwrap it first.
+        node = self._unwrap_ts_cast(node)
         # (H) `fn.bind(ctx)` / `fn.call(...)` / `fn.apply(...)` in value position
         # (H) (onError: handleError.bind(toast)) hands off `fn`; the call resolves to
         # (H) the Function.prototype builtin, so unwrap to the bound function and
@@ -2118,7 +2121,8 @@ class CallProcessor:
             if node.type in boundary_types:
                 continue
             if node.type == cs.TS_PY_RETURN_STATEMENT:
-                for child in node.named_children:
+                for returned in node.named_children:
+                    child = self._unwrap_ts_cast(returned)
                     if child.type not in (cs.TS_PY_IDENTIFIER, cs.TS_PY_ATTRIBUTE):
                         continue
                     if not (name := safe_decode_text(child)):
@@ -2193,6 +2197,10 @@ class CallProcessor:
     ) -> list[tuple[str, str]]:
         left = node.child_by_field_name(name_field)
         right = node.child_by_field_name(value_field)
+        # (H) `const x = factory(...) as T` wraps the call in a cast; unwrap so the
+        # (H) factory binding is still recognised.
+        if right is not None:
+            right = self._unwrap_ts_cast(right)
         if (
             left is not None
             and left.type == cs.TS_PY_IDENTIFIER
@@ -2400,7 +2408,10 @@ class CallProcessor:
             cs.NodeLabel.METHOD,
             cs.NodeLabel.CLASS,
         )
-        for position, keyword_name, arg_node in items:
+        for position, keyword_name, raw_arg in items:
+            # (H) `f(callback as any)` casts the argument; unwrap so a cast callable
+            # (H) argument still flows.
+            arg_node = self._unwrap_ts_cast(raw_arg)
             if arg_node.type not in _FLOW_ARG_REF_TYPES:
                 continue
             arg_text = safe_decode_text(arg_node)
@@ -2653,6 +2664,8 @@ class CallProcessor:
         # (H) (resolve_builtin_call if is_js_ts else None), or getattr(recv, name)
         # (H) dynamic dispatch. Take the name/attribute branch (consequence or
         # (H) alternative, never the condition) or build recv.<name> for getattr.
+        # (H) A TS cast (`y as T`) is transparent; unwrap so `x = y as T` still aliases.
+        right = self._unwrap_ts_cast(right)
         if right.type in (identifier, attribute):
             return right.text.decode(cs.ENCODING_UTF8) if right.text else None
         if right.type == cs.TS_PY_CONDITIONAL_EXPRESSION and right.named_children:

--- a/codebase_rag/tests/test_js_ts_assignment_reference_edges.py
+++ b/codebase_rag/tests/test_js_ts_assignment_reference_edges.py
@@ -168,3 +168,21 @@ def test_ts_non_null_cast_assignment_references_target(tmp_path: Path) -> None:
     }
     rels = _run_rels(tmp_path, files, "typescript")
     assert _has(rels, "m", REFERENCES, "m.handleEvent")
+
+
+def test_ts_cast_object_value_is_referenced(tmp_path: Path) -> None:
+    # (H) A cast function in a collection value (`{ onEvent: handler as any }`) must
+    # (H) still be referenced -- the cast wrapper is unwrapped in the value-ref path.
+    files = {
+        "m.ts": (
+            "function handler() { return 1 }\n"
+            "export function reg() { register({ onEvent: handler as any }) }\n"
+            "function register(o: unknown) { return o }\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files, "typescript")
+    # (H) Collection-value handoffs record as CALLS; the point is the cast is unwrapped
+    # (H) so `handler` is reached at all.
+    assert any(a.endswith("m.reg") and b.endswith("m.handler") for a, _r, b in rels), (
+        "cast object value not referenced"
+    )

--- a/codebase_rag/tests/test_js_ts_assignment_reference_edges.py
+++ b/codebase_rag/tests/test_js_ts_assignment_reference_edges.py
@@ -138,3 +138,33 @@ def test_js_plain_value_assignments_are_not_referenced(tmp_path: Path) -> None:
     }
     rels = _run_rels(tmp_path, files, "javascript")
     assert not any(r == REFERENCES for _, r, _ in rels)
+
+
+def test_ts_as_cast_assignment_references_target(tmp_path: Path) -> None:
+    # (H) `export const persist = persistImpl as unknown as Persist` aliases the real
+    # (H) implementation through TS `as` casts. The cast expression is transparent for
+    # (H) reference resolution, so the module must reference persistImpl or it (and
+    # (H) everything only it reaches) reports as dead -- the zustand middleware
+    # (H) pattern where the public export is a cast of the internal impl.
+    files = {
+        "mw.ts": (
+            "const persistImpl = (config) => build(config)\n"
+            "export const persist = persistImpl as unknown as Persist\n"
+            "function build(c) { return c }\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files, "typescript")
+    assert _has(rels, "mw", REFERENCES, "mw.persistImpl")
+
+
+def test_ts_non_null_cast_assignment_references_target(tmp_path: Path) -> None:
+    # (H) A non-null assertion (`handler!`) is also a transparent wrapper.
+    files = {
+        "m.ts": (
+            "function handleEvent() { return 1 }\n"
+            "const cb = handleEvent!\n"
+            "export function use() { return cb }\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files, "typescript")
+    assert _has(rels, "m", REFERENCES, "m.handleEvent")


### PR DESCRIPTION
## What

A function aliased through a TypeScript cast — `export const persist = persistImpl as unknown as Persist` (the zustand middleware pattern), or `handler!`, or `fn satisfies T` — was never referenced: the assignment-reference walker saw an `as_expression` RHS (not a bare identifier) and skipped it, so the real implementation (and everything only it reaches) reported as dead.

A new `_unwrap_ts_cast` helper peels the transparent cast wrappers (`as_expression`, `satisfies_expression`, `non_null_expression`, nesting like `x as unknown as T`) to the wrapped value. It is applied in the assignment-reference walker's RHS and at the top of `_emit_callback_edge`, so casts resolve wherever a function reference is expected (assignments, call arguments, object values, JSX handlers, returns).

## Impact

Measured on `pmndrs/zustand`: dead-code candidates **319 → 269**, and specifically the middleware public API (`persistImpl`, `devtoolsImpl`, `immerImpl`, `reduxImpl` — each exported via `impl as unknown as Public`) is now live (`src/` 88 → 55). The remaining candidates are separate classes out of scope here: a language-agnostic top-level `tests/` path-exclusion gap, demo example apps, and deeper inline-callback patterns.

## Test

RED→GREEN `test_ts_as_cast_assignment_references_target` (`persist = persistImpl as unknown as Persist`) and `test_ts_non_null_cast_assignment_references_target` (`cb = handleEvent!`).