### PR TITLE
fix(deadcode): recognize a root-level tests/ dir in test-path exclusion

### DIFF
--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -103,8 +103,11 @@ ORDER BY count DESC
 """
 
 
+# (H) Match against a leading-slash-normalized path so a `/tests/` pattern also
+# (H) matches a ROOT `tests/` dir (Rust integration tests, a top-level tests/
+# (H) folder), not just a nested `src/tests/`; `/contests/` still won't match.
 _DEAD_CODE_TEST_ROOT_CLAUSE = (
-    "\n    OR ANY(p IN $test_patterns WHERE n.path CONTAINS p)"
+    "\n    OR ANY(p IN $test_patterns WHERE ('/' + coalesce(n.path, '')) CONTAINS p)"
 )
 
 # (H) When tests are excluded, a test-file symbol's only callers (test functions)
@@ -115,7 +118,7 @@ _DEAD_CODE_TEST_ROOT_CLAUSE = (
 # (H) coalesce: a null path must not null out the NOT and silently drop the
 # (H) node from the report (NOT null = null in Cypher).
 _DEAD_CODE_CANDIDATE_NON_TEST = (
-    "\n  AND NOT ANY(p IN $test_patterns WHERE coalesce(n.path, '') CONTAINS p)"
+    "\n  AND NOT ANY(p IN $test_patterns WHERE ('/' + coalesce(n.path, '')) CONTAINS p)"
 )
 
 # (H) A node reached by a Module node runs at import (top-level statement,
@@ -129,7 +132,8 @@ _DEAD_CODE_CANDIDATE_NON_TEST = (
 _DEAD_CODE_MODULE_ROOT_ANY = "size([(n)<-[:{module_rels}]-(:Module) | 1]) > 0"
 _DEAD_CODE_MODULE_ROOT_NON_TEST = (
     "size([(n)<-[:{module_rels}]-(m:Module)"
-    " WHERE NOT ANY(p IN $test_patterns WHERE m.path CONTAINS p) | 1]) > 0"
+    " WHERE NOT ANY(p IN $test_patterns"
+    " WHERE ('/' + coalesce(m.path, '')) CONTAINS p) | 1]) > 0"
 )
 
 # (H) A method whose class INHERITS typing.Protocol is an interface stub; callers

--- a/codebase_rag/tests/integration/test_cypher_queries.py
+++ b/codebase_rag/tests/integration/test_cypher_queries.py
@@ -358,8 +358,9 @@ class TestBuildDeadCodeQueryUnit:
         # (H) enumerating every path (which times out on real graphs). REFERENCES
         # (H) (a function passed/stored as a value) keeps callbacks reachable.
         assert "CALLS|REFERENCES*BFS" in query
-        # (H) test functions are roots when tests are included
-        assert "n.path CONTAINS" in query
+        # (H) test functions are roots when tests are included; the path is
+        # (H) leading-slash-normalized so a root tests/ dir matches too.
+        assert "coalesce(n.path, '')) CONTAINS" in query
 
     def test_exclude_tests_omits_test_function_roots(self) -> None:
         query = build_dead_code_query(include_tests=False)
@@ -369,15 +370,15 @@ class TestBuildDeadCodeQueryUnit:
         # (H) ... but test_patterns still filters test modules out of the
         # (H) module-load root clause so test-only code is not kept alive.
         assert "$test_patterns" in query
-        assert "m.path CONTAINS" in query
+        assert "coalesce(m.path, '')) CONTAINS" in query
         assert "$project_prefix" in query
         # (H) ... and test-file symbols are excluded from the REPORT: their only
         # (H) callers are excluded as roots, so reporting them is unconditional
         # (H) noise (test helpers/mocks are infrastructure, not dead production
-        # (H) code).
+        # (H) code). Path is leading-slash-normalized so a root tests/ dir matches.
         assert (
-            "AND NOT ANY(p IN $test_patterns WHERE coalesce(n.path, '') CONTAINS p)"
-            in query
+            "AND NOT ANY(p IN $test_patterns"
+            " WHERE ('/' + coalesce(n.path, '')) CONTAINS p)" in query
         )
 
     def test_include_tests_reports_test_file_candidates(self) -> None:

--- a/codebase_rag/tests/test_dead_code_command.py
+++ b/codebase_rag/tests/test_dead_code_command.py
@@ -234,9 +234,10 @@ class TestDeadCodeCommand:
         # (H) test functions themselves are not roots.
         assert "test_patterns" in params
         assert "OR ANY(p IN $test_patterns WHERE n.path CONTAINS p)" not in query
+        # (H) Path is leading-slash-normalized so a root tests/ dir is excluded too.
         assert (
-            "AND NOT ANY(p IN $test_patterns WHERE coalesce(n.path, '') CONTAINS p)"
-            in query
+            "AND NOT ANY(p IN $test_patterns"
+            " WHERE ('/' + coalesce(n.path, '')) CONTAINS p)" in query
         )
 
     def test_classes_flag_includes_class_candidates(

--- a/codebase_rag/tests/test_dead_code_eval.py
+++ b/codebase_rag/tests/test_dead_code_eval.py
@@ -128,6 +128,32 @@ def test_rust_trait_methods_and_main_are_roots() -> None:
     assert "proj.frame.Frame.main" in dead
 
 
+def test_root_level_tests_dir_is_excluded() -> None:
+    # (H) A top-level `tests/` dir (Rust integration tests `tests/client.rs`, a JS
+    # (H) `tests/` folder) is test infrastructure. The `/tests/` pattern needs a
+    # (H) leading slash, so a root tests/ dir was missed and every test fn leaked as
+    # (H) a candidate. Path matching must normalize a leading slash so root tests/ is
+    # (H) recognized; a `contests/` dir must NOT be mistaken for a tests dir.
+    nodes = dict(
+        [
+            (
+                (_MODULE, "proj.tests.client"),
+                {
+                    cs.KEY_QUALIFIED_NAME: "proj.tests.client",
+                    cs.KEY_PATH: "tests/client.rs",
+                },
+            ),
+            _fn("proj.tests.client.smoke", path="tests/client.rs"),
+            _fn("proj.contests.entry", path="contests/entry.rs"),
+        ]
+    )
+    dead = dead_code_from_graph(nodes, [], _PREFIX, _CONFIG)
+    assert "proj.tests.client.smoke" not in dead
+    # (H) `contests/` is not a tests dir, so a genuinely-uncalled symbol there is
+    # (H) still reported (no false leading-slash match).
+    assert "proj.contests.entry" in dead
+
+
 def test_dead_code_excludes_generated_paths() -> None:
     # (H) A generated file (openapi-ts client/core, routeTree.gen.ts) has no
     # (H) in-repo caller, so every symbol in it reports as dead -- pure noise the

--- a/evals/dead_code.py
+++ b/evals/dead_code.py
@@ -97,6 +97,17 @@ def _is_rust_runtime_root(name: str, is_method: bool, path: str) -> bool:
     return is_method and name in cs.RUST_TRAIT_METHOD_NAMES
 
 
+def _matches_test_path(path: str, patterns: tuple[str, ...]) -> bool:
+    # (H) Match test-path patterns against a leading-slash-normalized path so a dir
+    # (H) pattern like `/tests/` also matches a ROOT `tests/` dir (Rust integration
+    # (H) tests, a top-level tests/ folder) -- not just a nested `src/tests/`. The
+    # (H) leading slash keeps `contests/` from matching `/tests/` (no false segment).
+    normalized = (
+        path if path.startswith(cs.SEPARATOR_SLASH) else cs.SEPARATOR_SLASH + path
+    )
+    return any(pattern in normalized for pattern in patterns)
+
+
 def _has_root_decorator(props: PropertyDict, root_decorators: frozenset[str]) -> bool:
     decorators = props.get(cs.KEY_DECORATORS)
     if not isinstance(decorators, list):
@@ -140,9 +151,8 @@ def dead_code_from_graph(
             # (H) excluded, a test-file symbol's only callers are excluded as
             # (H) roots, so reporting it is unconditional noise (test helpers
             # (H) and mocks are infrastructure, not dead production code).
-            if not config.include_tests and any(
-                pattern in str(props.get(cs.KEY_PATH) or "")
-                for pattern in config.test_patterns
+            if not config.include_tests and _matches_test_path(
+                str(props.get(cs.KEY_PATH) or ""), config.test_patterns
             ):
                 continue
             candidates.add(str(uid))
@@ -171,7 +181,7 @@ def dead_code_from_graph(
         if target_qn not in candidates:
             continue
         path = module_path.get(str(from_val), "")
-        is_test = any(pattern in path for pattern in config.test_patterns)
+        is_test = _matches_test_path(path, config.test_patterns)
         if config.include_tests or not is_test:
             roots.add(target_qn)
     protocol_stubs = {m for c, m in class_methods if c in protocol_classes}
@@ -206,9 +216,8 @@ def dead_code_from_graph(
             roots.add(qn)
         elif any(qn.endswith(entry) for entry in config.entry_points):
             roots.add(qn)
-        elif config.include_tests and any(
-            pattern in str(props.get(cs.KEY_PATH, ""))
-            for pattern in config.test_patterns
+        elif config.include_tests and _matches_test_path(
+            str(props.get(cs.KEY_PATH, "")), config.test_patterns
         ):
             roots.add(qn)
 


### PR DESCRIPTION
## What

The test-path patterns include `/tests/`, which requires a leading slash — so a **top-level** `tests/` directory (Rust integration tests `tests/client.rs`, a JS `tests/` folder) never matched, and every test function in it leaked as a dead-code candidate. A nested `src/tests/` matched fine; only the repo root was missed.

Fix: match test-path patterns against a **leading-slash-normalized** path (`"/" + path`), so `/tests/` matches a root `tests/` dir too. This deliberately keeps `contests/` from matching `/tests/` (the char before `tests` is not `/`), so there are no false positives — a segment-accurate result without switching to segment-splitting.

Applied to both dead-code surfaces: the eval reachability (new `_matches_test_path` helper replacing three inline `pattern in path` sites) and the production `cgr dead-code` Cypher clauses (`('/' + coalesce(path, '')) CONTAINS p`).

## Impact

Measured on `tokio-rs/mini-redis`: dead-code candidates **59 → 41** — all 18 `tests/*.rs` integration-test functions are now correctly excluded (`--no-include-tests`). Language-agnostic: helps any repo with a root-level `tests/` dir (also the zustand `tests/` leak noted earlier). The remaining 41 are a separate Rust method-receiver resolution gap and closures.

## Test

RED→GREEN `test_root_level_tests_dir_is_excluded`: a symbol in `tests/client.rs` is excluded, while a genuinely-uncalled symbol in `contests/entry.rs` is still reported (no false leading-slash match). Cypher/CLI query-text assertions updated to the normalized form.