### PR TITLE
fix(rust): resolve receiver-dispatch calls via local, field, and call-return type inference

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -3063,6 +3063,53 @@ TS_RS_MACRO_INVOCATION = "macro_invocation"
 TS_RS_ATTRIBUTE_ITEM = "attribute_item"
 TS_RS_INNER_ATTRIBUTE_ITEM = "inner_attribute_item"
 
+# (H) Rust node types for local-variable type inference (receiver-dispatch)
+TS_RS_LET_DECLARATION = "let_declaration"
+TS_RS_PARAMETER = "parameter"
+TS_RS_SELF_PARAMETER = "self_parameter"
+TS_RS_STRUCT_EXPRESSION = "struct_expression"
+TS_RS_FIELD_DECLARATION_LIST = "field_declaration_list"
+TS_RS_FIELD_DECLARATION = "field_declaration"
+TS_RS_FIELD_IDENTIFIER = "field_identifier"
+TS_RS_MATCH_EXPRESSION = "match_expression"
+TS_RS_TUPLE_STRUCT_PATTERN = "tuple_struct_pattern"
+TS_RS_TYPE_ARGUMENTS = "type_arguments"
+TS_RS_TRY_EXPRESSION = "try_expression"
+TS_RS_FIELD_EXPRESSION = "field_expression"
+TS_RS_FIELD_PATH = "path"
+# (H) Rust `Self` return type resolves to the enclosing impl target.
+RS_SELF_TYPE = "Self"
+# (H) Transparent smart pointers that auto-deref to their inner type: a method
+# (H) call on the pointer dispatches to the inner type's method, so strip them
+# (H) from any type name (receiver OR return) to reach the real type.
+RS_DEREF_WRAPPERS = frozenset({"Arc", "Rc", "Box", "Pin"})
+# (H) Result<T>/Option<T>: stripped to their inner T only for a RETURN type (the
+# (H) value a `?`/`.unwrap()` yields). NOT stripped for a receiver type, where a
+# (H) method call `opt.map(..)` dispatches to Option itself.
+RS_RESULT_WRAPPERS = frozenset({"Result", "Option"})
+# (H) Full strip set for return types (deref pointers + Result/Option unwrap).
+RS_RETURN_STRIP_WRAPPERS = RS_DEREF_WRAPPERS | RS_RESULT_WRAPPERS
+# (H) Node types that can stand for a Rust return/field type.
+RS_RETURN_TYPE_NODE_TYPES = (
+    TS_TYPE_IDENTIFIER,
+    TS_RS_PRIMITIVE_TYPE,
+    TS_GENERIC_TYPE,
+    TS_RS_SCOPED_TYPE_IDENTIFIER,
+)
+# (H) Wrapper-passthrough methods: they return the receiver's own (inner) type, so
+# (H) a call-bound local keeps its type across them (`Type::mk().unwrap().m()`).
+RS_IDENTITY_METHODS = frozenset(
+    {
+        "unwrap",
+        "expect",
+        "clone",
+        "unwrap_or_default",
+        "to_owned",
+        "borrow",
+        "borrow_mut",
+    }
+)
+
 # (H) Rust identifier tuples
 RS_IDENTIFIER_TYPES = (TS_IDENTIFIER, TS_TYPE_IDENTIFIER)
 RS_SCOPED_TYPES = (TS_SCOPED_IDENTIFIER, TS_RS_SCOPED_TYPE_IDENTIFIER)

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -3089,12 +3089,18 @@ RS_DEREF_WRAPPERS = frozenset({"Arc", "Rc", "Box", "Pin"})
 RS_RESULT_WRAPPERS = frozenset({"Result", "Option"})
 # (H) Full strip set for return types (deref pointers + Result/Option unwrap).
 RS_RETURN_STRIP_WRAPPERS = RS_DEREF_WRAPPERS | RS_RESULT_WRAPPERS
-# (H) Node types that can stand for a Rust return/field type.
+TS_RS_REFERENCE_TYPE = "reference_type"
+TS_RS_POINTER_TYPE = "pointer_type"
+# (H) Node types that can stand for a Rust return/field type. Reference/pointer
+# (H) wrappers (`&Frame`, `*const T`) are included so a generic inner argument
+# (H) (`Result<&Frame>`) and a bare `-> &Frame` return descend to the referent.
 RS_RETURN_TYPE_NODE_TYPES = (
     TS_TYPE_IDENTIFIER,
     TS_RS_PRIMITIVE_TYPE,
     TS_GENERIC_TYPE,
     TS_RS_SCOPED_TYPE_IDENTIFIER,
+    TS_RS_REFERENCE_TYPE,
+    TS_RS_POINTER_TYPE,
 )
 # (H) Wrapper-passthrough methods: they return the receiver's own (inner) type, so
 # (H) a call-bound local keeps its type across them (`Type::mk().unwrap().m()`).

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -69,6 +69,7 @@ _TYPED_LANGUAGES = frozenset(
         cs.SupportedLanguage.LUA,
         cs.SupportedLanguage.GO,
         cs.SupportedLanguage.CPP,
+        cs.SupportedLanguage.RUST,
     }
 )
 
@@ -1133,6 +1134,15 @@ class CallProcessor:
                     inner = func_child.child_by_field_name(cs.TS_FIELD_FUNCTION)
                     if inner and inner.text:
                         return inner.text.decode(cs.ENCODING_UTF8)
+                case cs.TS_RS_FIELD_EXPRESSION if language == cs.SupportedLanguage.RUST:
+                    # (H) Rust member call `a.b.method()`: use the full dotted receiver
+                    # (H) chain as the call name so the resolver can map the receiver to
+                    # (H) its inferred type (`self.shutdown.is_shutdown`,
+                    # (H) `cmd.apply`). A chain containing a call (`x.f().g`) is left to
+                    # (H) the chained-call path; a paren-free chain still ends at the
+                    # (H) bare-method trie fallback when the receiver type is unknown.
+                    if (text := func_child.text) is not None:
+                        return text.decode(cs.ENCODING_UTF8)
                 case cs.TS_CPP_FIELD_EXPRESSION:
                     field_node = func_child.child_by_field_name(cs.FIELD_FIELD)
                     if field_node and field_node.text:

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -19,6 +19,9 @@ _CHAINED_METHOD_PATTERN = re.compile(r"\.([^.()]+)$")
 _QN_SPLIT_CACHE: dict[str, tuple[list[str], int]] = {}
 _CHAIN_OPEN_BRACKETS = "([{"
 _CHAIN_CLOSE_BRACKETS = ")]}"
+# (H) Node labels a Rust receiver type name may resolve to: a struct (Class), an
+# (H) enum, or a type alias -- all can carry impl methods.
+_RS_TYPE_NODE_TYPES = frozenset({NodeType.CLASS, NodeType.ENUM, NodeType.TYPE})
 
 
 def _split_receiver_chain(expr: str) -> list[str]:
@@ -445,14 +448,11 @@ class CallResolver:
             return self._resolve_super_call(call_name, class_context)
 
         if cs.SEPARATOR_DOT in call_name and self._is_method_chain(call_name):
-            if chained := self._resolve_chained_call(
-                call_name, module_qn, local_var_types
-            ):
-                return chained
-            # (H) A chain whose base type is unknown falls through to the shared
-            # (H) resolution below, ending at the final-method trie fallback -- the
-            # (H) same last resort every other call shape uses -- so a unique method
-            # (H) name still resolves instead of the edge being dropped.
+            # (H) A chained call resolves via return-type inference only; it does NOT
+            # (H) fall through to the trie fallback, because a hop returning a container
+            # (H) (`Kids() []Command`) or an unknown type must drop the edge rather than
+            # (H) rebind the final method by bare name (a false `Command.Run`).
+            return self._resolve_chained_call(call_name, module_qn, local_var_types)
 
         if result := self._try_resolve_via_imports(
             call_name, module_qn, local_var_types
@@ -1003,12 +1003,16 @@ class CallResolver:
         rust_parts = class_qn.split(cs.SEPARATOR_DOUBLE_COLON)
         class_name = rust_parts[-1]
 
+        # (H) A Rust receiver type may be a struct (Class), an enum (`Frame`), or a
+        # (H) type alias, all of which carry impl methods -- match any of them, else an
+        # (H) enum-typed receiver fails to resolve and its type reads as external,
+        # (H) wrongly suppressing the trie fallback.
         matching_qns = self.function_registry.find_ending_with(class_name)
         return next(
             (
                 qn
                 for qn in matching_qns
-                if self.function_registry.get(qn) == NodeType.CLASS
+                if self.function_registry.get(qn) in _RS_TYPE_NODE_TYPES
             ),
             class_qn,
         )

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -1279,7 +1279,10 @@ class CallResolver:
         segments = callee.split(cs.SEPARATOR_DOUBLE_COLON)
         if len(segments) < 2:
             return None
-        type_name, method = segments[-2], segments[-1]
+        # (H) Keep the full path prefix (`crate::parse::Parse`) so a qualified
+        # (H) associated call resolves; only the trailing segment is the method.
+        type_name = cs.SEPARATOR_DOUBLE_COLON.join(segments[:-1])
+        method = segments[-1]
         class_qn = self._chain_class_qn(type_name, module_qn)
         return self.type_inference.method_return_types.get(
             f"{class_qn}{cs.SEPARATOR_DOT}{method}"

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -204,10 +204,19 @@ class CallResolver:
         self, var_type: str, import_map: dict[str, str], module_qn: str
     ) -> str:
         var_type = self._strip_optional(var_type)
+        if cs.SEPARATOR_DOUBLE_COLON in var_type:
+            return self._resolve_rust_class_qn(var_type)
         if cs.SEPARATOR_DOT in var_type:
             return self._follow_reexports(var_type)
         if var_type in import_map:
-            return self._follow_reexports(import_map[var_type])
+            # (H) A Rust import target is a raw `::`-path (`crate::parse::Parse`) that
+            # (H) is not a registry qn; resolve it to the real type node so both
+            # (H) local-type dispatch and the external-receiver guard see it as
+            # (H) first-party (else its trie fallback is wrongly suppressed).
+            target = import_map[var_type]
+            if cs.SEPARATOR_DOUBLE_COLON in target:
+                return self._resolve_rust_class_qn(target)
+            return self._follow_reexports(target)
         return self._resolve_class_name(var_type, module_qn) or ""
 
     def _strip_optional(self, var_type: str) -> str:
@@ -436,7 +445,14 @@ class CallResolver:
             return self._resolve_super_call(call_name, class_context)
 
         if cs.SEPARATOR_DOT in call_name and self._is_method_chain(call_name):
-            return self._resolve_chained_call(call_name, module_qn, local_var_types)
+            if chained := self._resolve_chained_call(
+                call_name, module_qn, local_var_types
+            ):
+                return chained
+            # (H) A chain whose base type is unknown falls through to the shared
+            # (H) resolution below, ending at the final-method trie fallback -- the
+            # (H) same last resort every other call shape uses -- so a unique method
+            # (H) name still resolves instead of the edge being dropped.
 
         if result := self._try_resolve_via_imports(
             call_name, module_qn, local_var_types
@@ -632,10 +648,17 @@ class CallResolver:
         module_qn: str,
         local_var_types: dict[str, str] | None,
     ) -> tuple[str, str] | None:
-        if module_qn not in self.import_processor.import_mapping:
-            return None
-
-        import_map = self.import_processor.import_mapping[module_qn]
+        import_map = self.import_processor.import_mapping.get(module_qn)
+        if import_map is None:
+            # (H) A module with no `use`/import statements can still resolve a member
+            # (H) call `obj.method()` through an inferred local/self type (a
+            # (H) self-contained Rust lib.rs is the common case). Only the
+            # (H) import-dependent lookups below (direct, qualified-by-import,
+            # (H) wildcard) are no-ops here, so proceed with an empty map when there
+            # (H) is type info to drive resolution; otherwise nothing would match.
+            if not local_var_types:
+                return None
+            import_map = {}
 
         if result := self._try_resolve_direct_import(call_name, import_map):
             return result
@@ -813,7 +836,35 @@ class CallResolver:
         ):
             return result
 
+        # (H) A same-module associated-function call `Type::assoc()` (`Ping::new()`):
+        # (H) the object is a type defined in this module, not an import. Resolve it to
+        # (H) its class node and look up the method there. Gated to `::` so a `.`-dotted
+        # (H) receiver of unknown type still falls through to the trie fallback.
+        if separator == cs.SEPARATOR_DOUBLE_COLON and (
+            result := self._try_resolve_static_type_method(
+                object_name, method_name, call_name, module_qn
+            )
+        ):
+            return result
+
         return self._try_resolve_module_method(method_name, call_name, module_qn)
+
+    def _try_resolve_static_type_method(
+        self, object_name: str, method_name: str, call_name: str, module_qn: str
+    ) -> tuple[str, str] | None:
+        if not (class_qn := self._resolve_class_name(object_name, module_qn)):
+            return None
+        method_qn = f"{class_qn}{cs.SEPARATOR_DOT}{method_name}"
+        if method_qn in self.function_registry:
+            logger.debug(
+                ls.CALL_TYPE_INFERRED,
+                call_name=call_name,
+                method_qn=method_qn,
+                obj=object_name,
+                var_type=object_name,
+            )
+            return self.function_registry[method_qn], method_qn
+        return self._resolve_inherited_method(class_qn, method_name)
 
     def _try_resolve_via_local_type(
         self,
@@ -1179,22 +1230,56 @@ class CallResolver:
         # (H) (Root() -> Command). Language-agnostic; returns the bare type name of the
         # (H) final hop, or None if any hop is untyped/unknown (then the chain stays
         # (H) unresolved, never mis-resolved).
-        if not local_var_types or not self.type_inference.method_return_types:
+        if not self.type_inference.method_return_types:
             return None
         parts = _split_receiver_chain(object_expr)
         base = parts[0]
-        if not base or cs.CHAR_PAREN_OPEN in base:
+        if not base:
             return None
-        current_type = local_var_types.get(base)
+        if cs.CHAR_PAREN_OPEN in base:
+            # (H) A Rust chain rooted in an associated-function call
+            # (H) (`Ping::new(msg).into_frame()`): type the base from the assoc fn's
+            # (H) recorded return type. Other paren bases stay unresolved.
+            current_type = self._infer_rust_assoc_base_type(base, module_qn)
+        elif local_var_types:
+            current_type = local_var_types.get(base)
+        else:
+            return None
         for part in parts[1:]:
             if not current_type or cs.CHAR_PAREN_OPEN not in part:
                 return None
             method = part.split(cs.CHAR_PAREN_OPEN, 1)[0]
-            class_qn = self._resolve_class_name(current_type, module_qn) or current_type
+            class_qn = self._chain_class_qn(current_type, module_qn)
             current_type = self.type_inference.method_return_types.get(
                 f"{class_qn}{cs.SEPARATOR_DOT}{method}"
             )
         return current_type
+
+    def _chain_class_qn(self, type_name: str, module_qn: str) -> str:
+        # (H) Resolve a bare type name from a chained-call hop to its class qn, honoring
+        # (H) imports (a Rust `use` target is a raw `::`-path, not a registry qn), so a
+        # (H) method-return-type lookup keyed by the class qn hits.
+        import_map = self.import_processor.import_mapping.get(module_qn, {})
+        return (
+            self._resolve_class_qn_from_type(type_name, import_map, module_qn)
+            or type_name
+        )
+
+    def _infer_rust_assoc_base_type(self, base: str, module_qn: str) -> str | None:
+        # (H) `Ping::new(msg)` -> the return type recorded for `Ping::new` (Ping).
+        # (H) The callee is the text before the first paren; only a `::`-rooted
+        # (H) associated call (`Type::assoc`) is handled.
+        callee = base.split(cs.CHAR_PAREN_OPEN, 1)[0]
+        if cs.SEPARATOR_DOUBLE_COLON not in callee:
+            return None
+        segments = callee.split(cs.SEPARATOR_DOUBLE_COLON)
+        if len(segments) < 2:
+            return None
+        type_name, method = segments[-2], segments[-1]
+        class_qn = self._chain_class_qn(type_name, module_qn)
+        return self.type_inference.method_return_types.get(
+            f"{class_qn}{cs.SEPARATOR_DOT}{method}"
+        )
 
     def _is_method_chain(self, call_name: str) -> bool:
         if cs.CHAR_PAREN_OPEN not in call_name or cs.CHAR_PAREN_CLOSE not in call_name:
@@ -1228,7 +1313,9 @@ class CallResolver:
         if object_type:
             full_object_type = object_type
             if cs.SEPARATOR_DOT not in object_type:
-                if resolved_class := self._resolve_class_name(object_type, module_qn):
+                # (H) Honor imports (Rust `use` targets are raw `::`-paths) so an
+                # (H) imported chained type (`Get::new(k).into_frame()`) resolves.
+                if resolved_class := self._chain_class_qn(object_type, module_qn):
                     full_object_type = resolved_class
 
             method_qn = f"{full_object_type}.{final_method}"

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -18,6 +18,7 @@ from ..cpp import CppTypeInferenceEngine
 from ..go import GoTypeInferenceEngine
 from ..java import utils as java_utils
 from ..py import resolve_class_name
+from ..rs import RustTypeInferenceEngine
 from ..rs import utils as rs_utils
 from ..utils import ingest_method, safe_decode_text, sorted_captures
 from . import cpp_modules
@@ -105,6 +106,7 @@ class ClassIngestMixin:
     import_processor: ImportProcessor
     class_inheritance: dict[str, list[str]]
     class_field_types: dict[str, dict[str, str]]
+    method_return_types: dict[str, str]
     interface_implementers: dict[str, set[str]]
     _deferred_forward_decls: list[_DeferredForwardDecl]
 
@@ -389,6 +391,13 @@ class ClassIngestMixin:
             # (H) (`root := engine.trees.get(m)`) picks up the return type.
             if field_types := GoTypeInferenceEngine().build_field_type_map(class_node):
                 self.class_field_types[class_qn] = field_types
+        elif language == cs.SupportedLanguage.RUST:
+            # (H) Record Rust struct field types so a field-hop receiver
+            # (H) (`self.shutdown.is_shutdown()`) resolves through the field's type.
+            if field_types := RustTypeInferenceEngine().build_field_type_map(
+                class_node
+            ):
+                self.class_field_types[class_qn] = field_types
         self._ingest_class_methods(
             class_node,
             class_qn,
@@ -482,6 +491,19 @@ class ClassIngestMixin:
                 file_path=file_path,
                 repo_path=self.repo_path,
             )
+            # (H) Record the method's return type (Self -> impl target) so a chained
+            # (H) call (`Ping::new(msg).into_frame()`) and a call-bound local
+            # (H) (`let cmd = Command::from_frame(f)`) can resolve the next hop.
+            name_node = method_node.child_by_field_name(cs.FIELD_NAME)
+            method_name = safe_decode_text(name_node) if name_node else None
+            if method_name and (
+                return_type := rs_utils.extract_return_type_name(
+                    method_node, impl_target
+                )
+            ):
+                self.method_return_types[
+                    f"{class_qn}{cs.SEPARATOR_DOT}{method_name}"
+                ] = return_type
 
     def _ingest_class_methods(
         self,

--- a/codebase_rag/parsers/go/type_inference.py
+++ b/codebase_rag/parsers/go/type_inference.py
@@ -39,11 +39,7 @@ class GoTypeInferenceEngine:
         if struct is None:
             return fields
         field_list = next(
-            (
-                c
-                for c in struct.children
-                if c.type == cs.TS_GO_FIELD_DECLARATION_LIST
-            ),
+            (c for c in struct.children if c.type == cs.TS_GO_FIELD_DECLARATION_LIST),
             None,
         )
         if field_list is None:

--- a/codebase_rag/parsers/rs/__init__.py
+++ b/codebase_rag/parsers/rs/__init__.py
@@ -1,0 +1,3 @@
+from .type_inference import RustTypeInferenceEngine
+
+__all__ = ["RustTypeInferenceEngine"]

--- a/codebase_rag/parsers/rs/type_inference.py
+++ b/codebase_rag/parsers/rs/type_inference.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+from tree_sitter import Node
+
+from ... import constants as cs
+from ..utils import safe_decode_text
+
+
+class RustTypeInferenceEngine:
+    # (H) Maps local names (parameters, `let` bindings, enum-match variant bindings)
+    # (H) to their bare Rust type name within a function/method body, so the resolver
+    # (H) can bind a receiver-dispatch call (`cmd.apply()`) to the method on the type
+    # (H) instead of guessing via the ambiguous name-only trie fallback. Directly
+    # (H) knowable types only; call-return bindings (`let x = T::new()`) are collected
+    # (H) separately and typed by the unified engine (which has the return-type map).
+    __slots__ = ()
+
+    def build_local_variable_type_map(
+        self, caller_node: Node, module_qn: str
+    ) -> dict[str, str]:
+        var_types: dict[str, str] = {}
+        self._collect_parameters(caller_node, var_types)
+        if body := caller_node.child_by_field_name(cs.FIELD_BODY):
+            self._collect_bindings(body, var_types)
+        return var_types
+
+    def build_field_type_map(self, class_node: Node) -> dict[str, str]:
+        # (H) Map a Rust struct's field names to their bare type names
+        # (H) (`struct Handler { shutdown: Shutdown }` -> {"shutdown": "Shutdown"}),
+        # (H) so a field-hop receiver (`self.shutdown.is_shutdown()`) resolves.
+        fields: dict[str, str] = {}
+        field_list = class_node.child_by_field_name(cs.FIELD_BODY)
+        if field_list is None or field_list.type != cs.TS_RS_FIELD_DECLARATION_LIST:
+            return fields
+        for decl in field_list.children:
+            if decl.type != cs.TS_RS_FIELD_DECLARATION:
+                continue
+            name_node = decl.child_by_field_name(cs.FIELD_NAME)
+            type_node = decl.child_by_field_name(cs.FIELD_TYPE)
+            if name_node is None or type_node is None:
+                continue
+            if (name := safe_decode_text(name_node)) and (
+                type_name := self._bare_type_name(type_node)
+            ):
+                fields[name] = type_name
+        return fields
+
+    def collect_call_var_bindings(
+        self, caller_node: Node
+    ) -> list[tuple[str, list[str]]]:
+        # (H) `let x = Type::assoc(...)` / `let x = Type::assoc(...).unwrap()`: pair the
+        # (H) bound name with the callee chain segments (base type first, then method
+        # (H) hops: `['Command', 'from_frame']`). The unified engine walks the segments
+        # (H) through the return-type map to type `x`. Only type-rooted associated-call
+        # (H) chains are collected; anything else stays unresolved.
+        bindings: list[tuple[str, list[str]]] = []
+        if body := caller_node.child_by_field_name(cs.FIELD_BODY):
+            self._collect_call_bindings(body, bindings)
+        return bindings
+
+    def _collect_parameters(self, caller_node: Node, var_types: dict[str, str]) -> None:
+        params = caller_node.child_by_field_name(cs.FIELD_PARAMETERS)
+        if params is None:
+            return
+        for param in params.children:
+            if param.type != cs.TS_RS_PARAMETER:
+                continue
+            pattern = param.child_by_field_name(cs.TS_FIELD_PATTERN)
+            type_node = param.child_by_field_name(cs.FIELD_TYPE)
+            if pattern is None or pattern.type != cs.TS_IDENTIFIER or type_node is None:
+                continue
+            if (name := safe_decode_text(pattern)) and (
+                type_name := self._bare_type_name(type_node)
+            ):
+                var_types[name] = type_name
+
+    def _collect_bindings(self, node: Node, var_types: dict[str, str]) -> None:
+        match node.type:
+            case cs.TS_RS_LET_DECLARATION:
+                self._collect_let_binding(node, var_types)
+            case cs.TS_RS_MATCH_EXPRESSION:
+                self._collect_match_bindings(node, var_types)
+            case _:
+                pass
+        for child in node.children:
+            self._collect_bindings(child, var_types)
+
+    def _collect_let_binding(self, node: Node, var_types: dict[str, str]) -> None:
+        # (H) `let x: T = ...` (explicit annotation) and `let x = T { .. }` (struct
+        # (H) literal) yield a directly-known type. `let x = T::assoc(..)` is left for
+        # (H) collect_call_var_bindings (needs the return-type map).
+        pattern = node.child_by_field_name(cs.TS_FIELD_PATTERN)
+        if pattern is None or pattern.type != cs.TS_IDENTIFIER:
+            return
+        name = safe_decode_text(pattern)
+        if not name:
+            return
+        if annotation := node.child_by_field_name(cs.FIELD_TYPE):
+            if type_name := self._bare_type_name(annotation):
+                var_types[name] = type_name
+            return
+        value = node.child_by_field_name(cs.FIELD_VALUE)
+        if value is not None and value.type == cs.TS_RS_STRUCT_EXPRESSION:
+            struct_name = value.child_by_field_name(cs.FIELD_NAME)
+            if struct_name and (type_name := self._bare_type_name(struct_name)):
+                var_types[name] = type_name
+
+    def _collect_match_bindings(self, node: Node, var_types: dict[str, str]) -> None:
+        # (H) `Variant(x) => ...`: bind x to the variant's payload type. Rust's newtype
+        # (H) idiom (`Command::Get(Get)`) names the variant after the wrapped type, so
+        # (H) the variant name IS the payload type. Only single-field patterns bind (a
+        # (H) multi-field variant has no single payload type).
+        for pattern in self._descendants_of_type(node, cs.TS_RS_TUPLE_STRUCT_PATTERN):
+            variant = pattern.child_by_field_name(cs.FIELD_TYPE)
+            if variant is None:
+                continue
+            variant_name = self._path_leaf_name(variant)
+            bound = [
+                c
+                for c in pattern.children
+                if c.type == cs.TS_IDENTIFIER and c != variant
+            ]
+            if variant_name and len(bound) == 1:
+                if name := safe_decode_text(bound[0]):
+                    var_types[name] = variant_name
+
+    def _collect_call_bindings(
+        self, node: Node, bindings: list[tuple[str, list[str]]]
+    ) -> None:
+        if node.type == cs.TS_RS_LET_DECLARATION:
+            self._collect_call_binding(node, bindings)
+        for child in node.children:
+            self._collect_call_bindings(child, bindings)
+
+    def _collect_call_binding(
+        self, node: Node, bindings: list[tuple[str, list[str]]]
+    ) -> None:
+        pattern = node.child_by_field_name(cs.TS_FIELD_PATTERN)
+        value = node.child_by_field_name(cs.FIELD_VALUE)
+        if pattern is None or pattern.type != cs.TS_IDENTIFIER or value is None:
+            return
+        name = safe_decode_text(pattern)
+        if not name:
+            return
+        if segments := self._callee_chain_segments(self._unwrap_try(value)):
+            bindings.append((name, segments))
+
+    def _callee_chain_segments(self, node: Node) -> list[str] | None:
+        # (H) A `Type::assoc(..).m1().m2()` call, flattened to type-then-methods:
+        # (H) `['Type', 'assoc', 'm1', 'm2']`. Returns None unless the chain roots in a
+        # (H) `Type::assoc` associated-function call (the only shape we can type).
+        if node.type != cs.TS_RS_CALL_EXPRESSION:
+            return None
+        func = node.child_by_field_name(cs.FIELD_FUNCTION)
+        if func is None:
+            return None
+        if func.type == cs.TS_SCOPED_IDENTIFIER:
+            path = func.child_by_field_name(cs.TS_RS_FIELD_PATH)
+            method = func.child_by_field_name(cs.FIELD_NAME)
+            base = self._path_leaf_name(path) if path else None
+            method_name = safe_decode_text(method) if method else None
+            if base and method_name:
+                return [base, method_name]
+            return None
+        if func.type == cs.TS_RS_FIELD_EXPRESSION:
+            receiver = func.child_by_field_name(cs.FIELD_VALUE)
+            method = func.child_by_field_name(cs.FIELD_FIELD)
+            method_name = safe_decode_text(method) if method else None
+            if receiver is None or not method_name:
+                return None
+            if base_segments := self._callee_chain_segments(self._unwrap_try(receiver)):
+                return [*base_segments, method_name]
+        return None
+
+    def _unwrap_try(self, node: Node) -> Node:
+        # (H) `expr?` is a try_expression wrapping the real value.
+        while node.type == cs.TS_RS_TRY_EXPRESSION and node.child_count:
+            node = node.children[0]
+        return node
+
+    def _bare_type_name(self, type_node: Node) -> str | None:
+        return _rust_bare_type_name(type_node)
+
+    def _path_leaf_name(self, node: Node) -> str | None:
+        # (H) Last identifier of a path: `Command` from a bare identifier,
+        # (H) `Unknown` from `Command::Unknown`.
+        if node.type in cs.RS_IDENTIFIER_TYPES:
+            return safe_decode_text(node)
+        if node.type in cs.RS_SCOPED_TYPES:
+            name = node.child_by_field_name(cs.FIELD_NAME)
+            return safe_decode_text(name) if name else None
+        return None
+
+    def _descendants_of_type(self, node: Node, node_type: str) -> list[Node]:
+        found: list[Node] = []
+
+        def walk(n: Node) -> None:
+            if n.type == node_type:
+                found.append(n)
+            for child in n.children:
+                walk(child)
+
+        walk(node)
+        return found
+
+
+def _rust_bare_type_name(type_node: Node) -> str | None:
+    # (H) Bare type name, stripping references/generics/wrappers down to the leaf
+    # (H) identifier: `&'a mut Shutdown` -> Shutdown, `Result<Command>` -> Command.
+    match type_node.type:
+        case cs.TS_TYPE_IDENTIFIER | cs.TS_RS_PRIMITIVE_TYPE:
+            return safe_decode_text(type_node)
+        case cs.TS_GENERIC_TYPE:
+            outer = type_node.child_by_field_name(cs.FIELD_TYPE)
+            outer_name = _rust_bare_type_name(outer) if outer else None
+            # (H) A receiver type strips only transparent deref pointers (Arc<Shared>
+            # (H) -> Shared); Option/Result/Vec are kept (a call dispatches to them).
+            if outer_name not in cs.RS_DEREF_WRAPPERS:
+                return outer_name
+            args = type_node.child_by_field_name(cs.TS_RS_TYPE_ARGUMENTS)
+            if args is None:
+                return outer_name
+            inner = next(
+                (c for c in args.children if c.type in cs.RS_RETURN_TYPE_NODE_TYPES),
+                None,
+            )
+            return _rust_bare_type_name(inner) if inner else outer_name
+        case cs.TS_RS_SCOPED_TYPE_IDENTIFIER:
+            name = type_node.child_by_field_name(cs.FIELD_NAME)
+            return safe_decode_text(name) if name else None
+        case _:
+            # (H) reference_type / other wrappers: descend to the first typed child.
+            for child in type_node.children:
+                if child.type in cs.RS_RETURN_TYPE_NODE_TYPES:
+                    return _rust_bare_type_name(child)
+            return None

--- a/codebase_rag/parsers/rs/type_inference.py
+++ b/codebase_rag/parsers/rs/type_inference.py
@@ -157,7 +157,10 @@ class RustTypeInferenceEngine:
         if func.type == cs.TS_SCOPED_IDENTIFIER:
             path = func.child_by_field_name(cs.TS_RS_FIELD_PATH)
             method = func.child_by_field_name(cs.FIELD_NAME)
-            base = self._path_leaf_name(path) if path else None
+            # (H) Keep the FULL base path (`crate::cmd::Command`), not just the leaf, so
+            # (H) a fully-qualified inline call (`crate::cmd::Command::from_frame()`)
+            # (H) with no `use` import disambiguates by path in the return-type lookup.
+            base = safe_decode_text(path) if path else None
             method_name = safe_decode_text(method) if method else None
             if base and method_name:
                 return [base, method_name]

--- a/codebase_rag/parsers/rs/utils.py
+++ b/codebase_rag/parsers/rs/utils.py
@@ -159,6 +159,46 @@ def _impl_field_type_name(impl_node: Node, field: str) -> str | None:
     return None
 
 
+def extract_return_type_name(func_node: Node, impl_target: str | None) -> str | None:
+    # (H) Bare name of a Rust fn's return type, for chained-call and `let x =
+    # (H) Type::assoc()` resolution: `Self` -> the impl target, `Result<T>`/
+    # (H) `Option<T>` -> their inner `T` (the value a `?`/`.unwrap()` yields), a
+    # (H) scoped type -> its last segment. Returns None when no return type.
+    return_type = func_node.child_by_field_name(cs.FIELD_RETURN_TYPE)
+    if return_type is None:
+        return None
+    return _rust_return_type_name(return_type, impl_target)
+
+
+def _rust_return_type_name(node: Node, impl_target: str | None) -> str | None:
+    match node.type:
+        case cs.TS_TYPE_IDENTIFIER | cs.TS_RS_PRIMITIVE_TYPE:
+            name = safe_decode_text(node)
+            return impl_target if name == cs.RS_SELF_TYPE else name
+        case cs.TS_GENERIC_TYPE:
+            return _rust_generic_type_name(node, impl_target)
+        case cs.TS_RS_SCOPED_TYPE_IDENTIFIER:
+            name_node = node.child_by_field_name(cs.FIELD_NAME)
+            return safe_decode_text(name_node) if name_node else None
+        case _:
+            return None
+
+
+def _rust_generic_type_name(node: Node, impl_target: str | None) -> str | None:
+    outer = node.child_by_field_name(cs.FIELD_TYPE)
+    outer_name = _rust_return_type_name(outer, impl_target) if outer else None
+    if outer_name not in cs.RS_RETURN_STRIP_WRAPPERS:
+        return outer_name
+    # (H) Result<T>/Option<T>/Arc<T>: the useful type is the inner argument.
+    args = node.child_by_field_name(cs.TS_RS_TYPE_ARGUMENTS)
+    if args is None:
+        return outer_name
+    inner = next(
+        (c for c in args.children if c.type in cs.RS_RETURN_TYPE_NODE_TYPES), None
+    )
+    return _rust_return_type_name(inner, impl_target) if inner else outer_name
+
+
 def extract_impl_target(impl_node: Node) -> str | None:
     if impl_node.type != cs.TS_IMPL_ITEM:
         return None

--- a/codebase_rag/parsers/rs/utils.py
+++ b/codebase_rag/parsers/rs/utils.py
@@ -181,6 +181,11 @@ def _rust_return_type_name(node: Node, impl_target: str | None) -> str | None:
             name_node = node.child_by_field_name(cs.FIELD_NAME)
             return safe_decode_text(name_node) if name_node else None
         case _:
+            # (H) reference_type (`&Frame`) / pointer_type: descend to the referent
+            # (H) type so a reference-returning method still yields its element type.
+            for child in node.children:
+                if child.type in cs.RS_RETURN_TYPE_NODE_TYPES:
+                    return _rust_return_type_name(child, impl_target)
             return None
 
 

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -272,6 +272,9 @@ class TypeInferenceEngine:
         # (H) target is a raw `::`-path (`crate::cmd::Command`), not a registry qn, so
         # (H) find the registered class node whose simple name matches. Falls back to
         # (H) same-module resolution for a locally-defined type.
+        # (H) A fully-qualified inline base (`crate::cmd::Command`) carries its own path.
+        if cs.SEPARATOR_DOUBLE_COLON in type_name:
+            return self._resolve_rust_import_path(type_name)
         import_map = self.import_processor.import_mapping.get(module_qn, {})
         if (target := import_map.get(type_name)) and (
             cs.SEPARATOR_DOUBLE_COLON in target

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -6,6 +6,7 @@ from ..types_defs import (
     ASTNode,
     FunctionRegistryTrieProtocol,
     LanguageQueries,
+    NodeType,
     SimpleNameLookup,
 )
 from .cpp import CppTypeInferenceEngine
@@ -258,13 +259,32 @@ class TypeInferenceEngine:
         for method in segments[1:]:
             if current_type is None:
                 return None
-            class_qn = self._resolve_class_name(current_type, module_qn) or current_type
+            class_qn = self._resolve_rust_type_qn(current_type, module_qn)
             method_qn = f"{class_qn}{cs.SEPARATOR_DOT}{method}"
             if next_type := self.method_return_types.get(method_qn):
                 current_type = next_type
             elif method not in cs.RS_IDENTITY_METHODS:
                 return None
         return current_type
+
+    def _resolve_rust_type_qn(self, type_name: str, module_qn: str) -> str:
+        # (H) Resolve a Rust type name to its class-node qn, honoring imports: a `use`
+        # (H) target is a raw `::`-path (`crate::cmd::Command`), not a registry qn, so
+        # (H) find the registered class node whose simple name matches. Falls back to
+        # (H) same-module resolution for a locally-defined type.
+        import_map = self.import_processor.import_mapping.get(module_qn, {})
+        if (target := import_map.get(type_name)) and (
+            cs.SEPARATOR_DOUBLE_COLON in target
+        ):
+            simple = target.rsplit(cs.SEPARATOR_DOUBLE_COLON, 1)[-1]
+            for qn in self.function_registry.find_ending_with(simple):
+                if self.function_registry.get(qn) in (
+                    NodeType.CLASS,
+                    NodeType.ENUM,
+                    NodeType.TYPE,
+                ):
+                    return qn
+        return self._resolve_class_name(type_name, module_qn) or type_name
 
     def _collect_field_types(self, class_qn: str) -> dict[str, str]:
         # (H) Collect member-field types along the inheritance chain so a derived class

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -276,15 +276,34 @@ class TypeInferenceEngine:
         if (target := import_map.get(type_name)) and (
             cs.SEPARATOR_DOUBLE_COLON in target
         ):
-            simple = target.rsplit(cs.SEPARATOR_DOUBLE_COLON, 1)[-1]
-            for qn in self.function_registry.find_ending_with(simple):
-                if self.function_registry.get(qn) in (
-                    NodeType.CLASS,
-                    NodeType.ENUM,
-                    NodeType.TYPE,
-                ):
-                    return qn
+            return self._resolve_rust_import_path(target)
         return self._resolve_class_name(type_name, module_qn) or type_name
+
+    def _resolve_rust_import_path(self, target: str) -> str:
+        # (H) Map a `use` target (`crate::cmd::Command`) to its registry qn. Prefer the
+        # (H) candidate whose qn ends with the import's module path (`.cmd.Command`),
+        # (H) so two same-named types in different modules disambiguate by path; fall
+        # (H) back to the deterministic-min simple-name match when the path (e.g. a
+        # (H) crate-root re-export `crate::Command`) can't pinpoint one.
+        parts = [
+            p
+            for p in target.split(cs.SEPARATOR_DOUBLE_COLON)
+            if p not in cs.RS_PATH_KEYWORDS
+        ]
+        if not parts:
+            return target
+        simple = parts[-1]
+        candidates = [
+            qn
+            for qn in self.function_registry.find_ending_with(simple)
+            if self.function_registry.get(qn)
+            in (NodeType.CLASS, NodeType.ENUM, NodeType.TYPE)
+        ]
+        if not candidates:
+            return target
+        path_suffix = cs.SEPARATOR_DOT + cs.SEPARATOR_DOT.join(parts)
+        matching = [qn for qn in candidates if qn.endswith(path_suffix)]
+        return min(matching) if matching else min(candidates)
 
     def _collect_field_types(self, class_qn: str) -> dict[str, str]:
         # (H) Collect member-field types along the inheritance chain so a derived class

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -15,6 +15,7 @@ from .java import JavaTypeInferenceEngine
 from .js_ts import JsTypeInferenceEngine
 from .lua import LuaTypeInferenceEngine
 from .py import PythonTypeInferenceEngine, resolve_class_name
+from .rs import RustTypeInferenceEngine
 
 if TYPE_CHECKING:
     from .factory import ASTCacheProtocol
@@ -38,6 +39,7 @@ class TypeInferenceEngine:
         "_js_type_inference",
         "_python_type_inference",
         "_go_type_inference",
+        "_rust_type_inference",
         "_cpp_type_inference",
     )
 
@@ -83,6 +85,7 @@ class TypeInferenceEngine:
         self._js_type_inference: JsTypeInferenceEngine | None = None
         self._python_type_inference: PythonTypeInferenceEngine | None = None
         self._go_type_inference: GoTypeInferenceEngine | None = None
+        self._rust_type_inference: RustTypeInferenceEngine | None = None
         self._cpp_type_inference: CppTypeInferenceEngine | None = None
 
     @property
@@ -90,6 +93,12 @@ class TypeInferenceEngine:
         if self._go_type_inference is None:
             self._go_type_inference = GoTypeInferenceEngine()
         return self._go_type_inference
+
+    @property
+    def rust_type_inference(self) -> RustTypeInferenceEngine:
+        if self._rust_type_inference is None:
+            self._rust_type_inference = RustTypeInferenceEngine()
+        return self._rust_type_inference
 
     @property
     def cpp_type_inference(self) -> CppTypeInferenceEngine:
@@ -163,10 +172,23 @@ class TypeInferenceEngine:
         # (H) When the caller is a method, overlay its class's member-field types as a
         # (H) base so a bare `field_.method()` receiver resolves; parameters and locals
         # (H) with the same name shadow a field, so the local map wins on conflict.
-        if class_context and (fields := self._collect_field_types(class_context)):
+        fields = self._collect_field_types(class_context) if class_context else {}
+        if fields:
             local = {**fields, **local}
         if language == cs.SupportedLanguage.GO:
             self._enrich_go_call_locals(caller_node, module_qn, local)
+        elif language == cs.SupportedLanguage.RUST:
+            if class_context:
+                # (H) Rust member calls carry the explicit `self` receiver: type `self`
+                # (H) to the impl target (so `self.accept()` dispatches) and each
+                # (H) `self.<field>` to the field's type (so `self.shutdown.is_shutdown()`
+                # (H) hops through the field). setdefault: a same-named local wins.
+                local.setdefault(cs.KEYWORD_SELF, class_context)
+                for field, ftype in fields.items():
+                    local.setdefault(
+                        f"{cs.KEYWORD_SELF}{cs.SEPARATOR_DOT}{field}", ftype
+                    )
+            self._enrich_rust_call_locals(caller_node, module_qn, local)
         return local
 
     def _enrich_go_call_locals(
@@ -208,6 +230,41 @@ class TypeInferenceEngine:
             class_qn = self._resolve_class_name(field_type, module_qn) or field_type
         method_qn = f"{class_qn}{cs.SEPARATOR_DOT}{segments[-1]}"
         return self.method_return_types.get(method_qn)
+
+    def _enrich_rust_call_locals(
+        self, caller_node: ASTNode, module_qn: str, var_types: dict[str, str]
+    ) -> None:
+        # (H) Type a Rust local bound from an associated-function call
+        # (H) (`let cmd = Command::from_frame(f)?`) with the call's return type, so a
+        # (H) later `cmd.apply()` resolves to the real type instead of the ambiguous
+        # (H) name-only trie fallback. Only fills names not already typed.
+        for name, segments in self.rust_type_inference.collect_call_var_bindings(
+            caller_node
+        ):
+            if name in var_types:
+                continue
+            if return_type := self._infer_rust_call_return_type(segments, module_qn):
+                var_types[name] = return_type
+
+    def _infer_rust_call_return_type(
+        self, segments: list[str], module_qn: str
+    ) -> str | None:
+        # (H) `['Command', 'from_frame']`: base type `Command` -> its `from_frame`'s
+        # (H) recorded return type. Wrapper-passthrough hops (`.unwrap()`) keep the
+        # (H) current type. Any unknown hop drops the whole binding (never guessed).
+        if len(segments) < 2:
+            return None
+        current_type: str | None = segments[0]
+        for method in segments[1:]:
+            if current_type is None:
+                return None
+            class_qn = self._resolve_class_name(current_type, module_qn) or current_type
+            method_qn = f"{class_qn}{cs.SEPARATOR_DOT}{method}"
+            if next_type := self.method_return_types.get(method_qn):
+                current_type = next_type
+            elif method not in cs.RS_IDENTITY_METHODS:
+                return None
+        return current_type
 
     def _collect_field_types(self, class_qn: str) -> dict[str, str]:
         # (H) Collect member-field types along the inheritance chain so a derived class
@@ -255,6 +312,10 @@ class TypeInferenceEngine:
                 )
             case cs.SupportedLanguage.GO:
                 return self.go_type_inference.build_local_variable_type_map(
+                    caller_node, module_qn
+                )
+            case cs.SupportedLanguage.RUST:
+                return self.rust_type_inference.build_local_variable_type_map(
                     caller_node, module_qn
                 )
             case cs.SupportedLanguage.CPP:

--- a/codebase_rag/tests/test_rust_receiver_resolution.py
+++ b/codebase_rag/tests/test_rust_receiver_resolution.py
@@ -221,3 +221,28 @@ def test_imported_assoc_call_return_type_dispatch(tmp_path: Path) -> None:
     calls = _calls(tmp_path)
     assert ("crate.app.go", "crate.cmd.Command.apply") in calls
     assert ("crate.app.go", "crate.cmd.Aaa.apply") not in calls
+
+
+def test_reference_return_type_chained_dispatch(tmp_path: Path) -> None:
+    # (H) A method returning a reference (`fn frame(&self) -> &Frame`) must still
+    # (H) yield the referent type so a chained call (`self.frame().push_int()`)
+    # (H) resolves to Frame.push_int, not the ambiguous trie pick.
+    _make_crate(
+        tmp_path,
+        "pub struct Aaa {}\n"
+        "impl Aaa {\n"
+        "    fn push_int(&self) -> i32 { 2 }\n"
+        "}\n"
+        "pub struct Frame {}\n"
+        "impl Frame {\n"
+        "    fn push_int(&self) -> i32 { 1 }\n"
+        "}\n"
+        "pub struct Holder {}\n"
+        "impl Holder {\n"
+        "    fn frame(&self) -> &Frame { &Frame {} }\n"
+        "    fn go(&self) -> i32 { self.frame().push_int() }\n"
+        "}\n",
+    )
+    calls = _calls(tmp_path)
+    assert ("crate.lib.Holder.go", "crate.lib.Frame.push_int") in calls
+    assert ("crate.lib.Holder.go", "crate.lib.Aaa.push_int") not in calls

--- a/codebase_rag/tests/test_rust_receiver_resolution.py
+++ b/codebase_rag/tests/test_rust_receiver_resolution.py
@@ -297,3 +297,52 @@ def test_imported_type_disambiguated_by_path(tmp_path: Path) -> None:
     calls = _calls(tmp_path)
     assert ("crate.app.go", "crate.types.Real.run") in calls
     assert ("crate.app.go", "crate.types.Fake.run") not in calls
+
+
+def test_fully_qualified_inline_assoc_call_dispatch(tmp_path: Path) -> None:
+    # (H) A fully-qualified inline associated call with NO `use` import
+    # (H) (`let x = crate::cmd::Command::mk()`) must keep the qualified path so the
+    # (H) return-type base resolves to crate.cmd.Command (mk -> Real), not the
+    # (H) alphabetically-first crate.aaa.Command (mk -> Fake).
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "lib.rs").write_text(
+        "pub mod aaa;\npub mod cmd;\npub mod types;\npub mod app;\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "types.rs").write_text(
+        "pub struct Real {}\n"
+        "impl Real {\n"
+        "    pub fn run(&self) -> i32 { 1 }\n"
+        "}\n"
+        "pub struct Fake {}\n"
+        "impl Fake {\n"
+        "    pub fn run(&self) -> i32 { 2 }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "aaa.rs").write_text(
+        "use crate::types::Fake;\n"
+        "pub struct Command {}\n"
+        "impl Command {\n"
+        "    pub fn mk() -> Fake { Fake {} }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "cmd.rs").write_text(
+        "use crate::types::Real;\n"
+        "pub struct Command {}\n"
+        "impl Command {\n"
+        "    pub fn mk() -> Real { Real {} }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "app.rs").write_text(
+        "pub fn go() -> i32 {\n"
+        "    let x = crate::cmd::Command::mk();\n"
+        "    x.run()\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    calls = _calls(tmp_path)
+    assert ("crate.app.go", "crate.types.Real.run") in calls
+    assert ("crate.app.go", "crate.types.Fake.run") not in calls

--- a/codebase_rag/tests/test_rust_receiver_resolution.py
+++ b/codebase_rag/tests/test_rust_receiver_resolution.py
@@ -246,3 +246,54 @@ def test_reference_return_type_chained_dispatch(tmp_path: Path) -> None:
     calls = _calls(tmp_path)
     assert ("crate.lib.Holder.go", "crate.lib.Frame.push_int") in calls
     assert ("crate.lib.Holder.go", "crate.lib.Aaa.push_int") not in calls
+
+
+def test_imported_type_disambiguated_by_path(tmp_path: Path) -> None:
+    # (H) Two `Command` types in different modules whose `mk()` returns DIFFERENT
+    # (H) types (cmd.Command -> Real, other.Command -> Fake). `use crate::cmd::Command`
+    # (H) must resolve the call-return base to crate.cmd.Command so `x.run()` lands on
+    # (H) Real.run. A simple-name-only match would pick the alphabetically-first
+    # (H) crate.aaa.Command, type x as Fake, and mis-resolve to Fake.run.
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "lib.rs").write_text(
+        "pub mod aaa;\npub mod cmd;\npub mod types;\npub mod app;\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "types.rs").write_text(
+        "pub struct Real {}\n"
+        "impl Real {\n"
+        "    pub fn run(&self) -> i32 { 1 }\n"
+        "}\n"
+        "pub struct Fake {}\n"
+        "impl Fake {\n"
+        "    pub fn run(&self) -> i32 { 2 }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "aaa.rs").write_text(
+        "use crate::types::Fake;\n"
+        "pub struct Command {}\n"
+        "impl Command {\n"
+        "    pub fn mk() -> Fake { Fake {} }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "cmd.rs").write_text(
+        "use crate::types::Real;\n"
+        "pub struct Command {}\n"
+        "impl Command {\n"
+        "    pub fn mk() -> Real { Real {} }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "app.rs").write_text(
+        "use crate::cmd::Command;\n"
+        "pub fn go() -> i32 {\n"
+        "    let x = Command::mk();\n"
+        "    x.run()\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    calls = _calls(tmp_path)
+    assert ("crate.app.go", "crate.types.Real.run") in calls
+    assert ("crate.app.go", "crate.types.Fake.run") not in calls

--- a/codebase_rag/tests/test_rust_receiver_resolution.py
+++ b/codebase_rag/tests/test_rust_receiver_resolution.py
@@ -188,3 +188,36 @@ def test_assoc_fn_chain_dispatch(tmp_path: Path) -> None:
     assert ("crate.lib.go", "crate.lib.Ping.new") in calls
     assert ("crate.lib.go", "crate.lib.Ping.into_frame") in calls
     assert ("crate.lib.go", "crate.lib.Aaa.into_frame") not in calls
+
+
+def test_imported_assoc_call_return_type_dispatch(tmp_path: Path) -> None:
+    # (H) `use crate::cmd::Command; let cmd = Command::from_frame(f); cmd.apply()`:
+    # (H) the type is IMPORTED, so its import target is a raw `::`-path, not a registry
+    # (H) qn. The call-return binding must resolve it to the real class node
+    # (H) (crate.cmd.Command) to look up from_frame's recorded return type -- else it
+    # (H) falls back to the ambiguous trie path.
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "lib.rs").write_text("pub mod cmd;\npub mod app;\n", encoding="utf-8")
+    (tmp_path / "cmd.rs").write_text(
+        "pub struct Aaa {}\n"
+        "impl Aaa {\n"
+        "    pub fn apply(&self) -> i32 { 2 }\n"
+        "}\n"
+        "pub struct Command {}\n"
+        "impl Command {\n"
+        "    pub fn from_frame(f: i32) -> Command { Command {} }\n"
+        "    pub fn apply(&self) -> i32 { 1 }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "app.rs").write_text(
+        "use crate::cmd::Command;\n"
+        "pub fn go() -> i32 {\n"
+        "    let cmd = Command::from_frame(0);\n"
+        "    cmd.apply()\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    calls = _calls(tmp_path)
+    assert ("crate.app.go", "crate.cmd.Command.apply") in calls
+    assert ("crate.app.go", "crate.cmd.Aaa.apply") not in calls

--- a/codebase_rag/tests/test_rust_receiver_resolution.py
+++ b/codebase_rag/tests/test_rust_receiver_resolution.py
@@ -1,0 +1,190 @@
+from pathlib import Path
+
+from evals.cgr_graph import _capture
+
+
+def _calls(tmp_path: Path) -> set[tuple[str, str]]:
+    ingestor = _capture(tmp_path, "crate")
+    return {
+        (str(from_val), str(to_val))
+        for _fl, from_val, rel, _tl, to_val in ingestor.rels
+        if rel == "CALLS"
+    }
+
+
+def _make_crate(root: Path, body: str) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "lib.rs").write_text(body, encoding="utf-8")
+
+
+# (H) Every fixture defines the called method name on more than one type (an `Aaa`
+# (H) decoy sorting before the real type) so the name-only trie fallback is ambiguous
+# (H) and would pick the wrong `Aaa` alphabetically: only real receiver-type inference
+# (H) produces the correct edge. Mirrors mini-redis, where `apply`/`run`/`new`/
+# (H) `into_frame` live on many command types.
+
+
+def test_self_receiver_dispatch(tmp_path: Path) -> None:
+    # (H) `self.accept()` inside a method must resolve to the impl target's method.
+    _make_crate(
+        tmp_path,
+        "pub struct Aaa {}\n"
+        "impl Aaa {\n"
+        "    fn accept(&self) -> i32 { 2 }\n"
+        "}\n"
+        "pub struct Listener {}\n"
+        "impl Listener {\n"
+        "    fn accept(&self) -> i32 { 1 }\n"
+        "    fn run(&self) -> i32 { self.accept() }\n"
+        "}\n",
+    )
+    calls = _calls(tmp_path)
+    assert ("crate.lib.Listener.run", "crate.lib.Listener.accept") in calls
+    assert ("crate.lib.Listener.run", "crate.lib.Aaa.accept") not in calls
+
+
+def test_struct_literal_binding_dispatch(tmp_path: Path) -> None:
+    # (H) `let s = Listener {}; s.run()` binds s to Listener via the struct literal.
+    _make_crate(
+        tmp_path,
+        "pub struct Aaa {}\n"
+        "impl Aaa {\n"
+        "    fn run(&self) -> i32 { 2 }\n"
+        "}\n"
+        "pub struct Listener {}\n"
+        "impl Listener {\n"
+        "    fn run(&self) -> i32 { 1 }\n"
+        "}\n"
+        "pub fn go() -> i32 {\n"
+        "    let mut server = Listener {};\n"
+        "    server.run()\n"
+        "}\n",
+    )
+    calls = _calls(tmp_path)
+    assert ("crate.lib.go", "crate.lib.Listener.run") in calls
+    assert ("crate.lib.go", "crate.lib.Aaa.run") not in calls
+
+
+def test_field_type_receiver_dispatch(tmp_path: Path) -> None:
+    # (H) `self.shutdown.is_shutdown()` resolves through the struct field's type.
+    _make_crate(
+        tmp_path,
+        "pub struct Aaa {}\n"
+        "impl Aaa {\n"
+        "    fn is_shutdown(&self) -> bool { false }\n"
+        "}\n"
+        "pub struct Shutdown {}\n"
+        "impl Shutdown {\n"
+        "    fn is_shutdown(&self) -> bool { true }\n"
+        "}\n"
+        "pub struct Handler { shutdown: Shutdown }\n"
+        "impl Handler {\n"
+        "    fn run(&self) -> bool { self.shutdown.is_shutdown() }\n"
+        "}\n",
+    )
+    calls = _calls(tmp_path)
+    assert ("crate.lib.Handler.run", "crate.lib.Shutdown.is_shutdown") in calls
+    assert ("crate.lib.Handler.run", "crate.lib.Aaa.is_shutdown") not in calls
+
+
+def test_let_assoc_call_return_type_dispatch(tmp_path: Path) -> None:
+    # (H) `let cmd = Command::from_frame(f); cmd.apply()` types cmd from the
+    # (H) associated function's return type (Command).
+    _make_crate(
+        tmp_path,
+        "pub struct Aaa {}\n"
+        "impl Aaa {\n"
+        "    fn apply(&self) -> i32 { 2 }\n"
+        "}\n"
+        "pub struct Command {}\n"
+        "impl Command {\n"
+        "    pub fn from_frame(f: i32) -> Command { Command {} }\n"
+        "    pub fn apply(&self) -> i32 { 1 }\n"
+        "}\n"
+        "pub fn go() -> i32 {\n"
+        "    let cmd = Command::from_frame(0);\n"
+        "    cmd.apply()\n"
+        "}\n",
+    )
+    calls = _calls(tmp_path)
+    assert ("crate.lib.go", "crate.lib.Command.apply") in calls
+    assert ("crate.lib.go", "crate.lib.Aaa.apply") not in calls
+
+
+def test_let_assoc_call_result_wrapper_return_type(tmp_path: Path) -> None:
+    # (H) A Result<Command> return type is stripped to Command so the unwrapped
+    # (H) local still dispatches.
+    _make_crate(
+        tmp_path,
+        "pub struct Aaa {}\n"
+        "impl Aaa {\n"
+        "    fn apply(&self) -> i32 { 2 }\n"
+        "}\n"
+        "pub struct Command {}\n"
+        "impl Command {\n"
+        "    pub fn from_frame(f: i32) -> crate::Result<Command> { Ok(Command {}) }\n"
+        "    pub fn apply(&self) -> i32 { 1 }\n"
+        "}\n"
+        "pub fn go() -> i32 {\n"
+        "    let cmd = Command::from_frame(0).unwrap();\n"
+        "    cmd.apply()\n"
+        "}\n",
+    )
+    calls = _calls(tmp_path)
+    assert ("crate.lib.go", "crate.lib.Command.apply") in calls
+    assert ("crate.lib.go", "crate.lib.Aaa.apply") not in calls
+
+
+def test_enum_match_binding_dispatch(tmp_path: Path) -> None:
+    # (H) `Get(cmd) => cmd.apply()` binds cmd to the variant's payload type (Get).
+    _make_crate(
+        tmp_path,
+        "pub struct Aaa {}\n"
+        "impl Aaa {\n"
+        "    fn apply(&self) -> i32 { 2 }\n"
+        "}\n"
+        "pub struct Get {}\n"
+        "impl Get {\n"
+        "    fn apply(&self) -> i32 { 1 }\n"
+        "}\n"
+        "pub enum Command { Get(Get) }\n"
+        "impl Command {\n"
+        "    fn apply(&self) -> i32 {\n"
+        "        use Command::*;\n"
+        "        match self {\n"
+        "            Get(cmd) => cmd.apply(),\n"
+        "        }\n"
+        "    }\n"
+        "}\n",
+    )
+    calls = _calls(tmp_path)
+    assert ("crate.lib.Command.apply", "crate.lib.Get.apply") in calls
+    # (H) must not mis-resolve to the enclosing type's same-named method
+    assert ("crate.lib.Command.apply", "crate.lib.Command.apply") not in calls
+
+
+def test_assoc_fn_chain_dispatch(tmp_path: Path) -> None:
+    # (H) `Ping::new(msg).into_frame()` resolves into_frame on the type Ping::new
+    # (H) returns (Ping).
+    _make_crate(
+        tmp_path,
+        "pub struct Frame {}\n"
+        "pub struct Aaa {}\n"
+        "impl Aaa {\n"
+        "    pub fn new(msg: i32) -> Aaa { Aaa {} }\n"
+        "    pub fn into_frame(self) -> Frame { Frame {} }\n"
+        "}\n"
+        "pub struct Ping {}\n"
+        "impl Ping {\n"
+        "    pub fn new(msg: i32) -> Ping { Ping {} }\n"
+        "    pub fn into_frame(self) -> Frame { Frame {} }\n"
+        "}\n"
+        "pub fn go() -> i32 {\n"
+        "    let frame = Ping::new(0).into_frame();\n"
+        "    1\n"
+        "}\n",
+    )
+    calls = _calls(tmp_path)
+    assert ("crate.lib.go", "crate.lib.Ping.new") in calls
+    assert ("crate.lib.go", "crate.lib.Ping.into_frame") in calls
+    assert ("crate.lib.go", "crate.lib.Aaa.into_frame") not in calls

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.222"
+version = "0.0.231"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Problem

Rust had no type-inference engine, so `_build_local_variable_type_map` returned `{}` for every Rust caller. Receiver-dispatch calls (`cmd.apply()`, `self.shutdown.is_shutdown()`, `Ping::new(k).into_frame()`) could only resolve via the name-only trie fallback, which is ambiguous whenever a method name is defined on more than one type (pervasive in mini-redis: `apply`/`run`/`new`/`into_frame` live on many command types). This dropped or mis-directed CALLS edges and inflated dead-code false positives.

## Fix

New `RustTypeInferenceEngine` (`codebase_rag/parsers/rs/type_inference.py`) plus wiring into the shared resolution pipeline:

- **Local types**: parameters (`p: &mut Parse`), `let x: T` annotations, `let x = T {}` struct literals, and enum-match variant bindings (`Get(cmd) =>` binds `cmd` to the variant's payload type via Rust's newtype idiom).
- **Field types**: struct field map so a field-hop receiver (`self.shutdown.is_shutdown()`) resolves through the field's type.
- **Call-return bindings**: `let cmd = Command::from_frame(f)?` types `cmd` from the associated fn's recorded return type; wrapper-passthrough (`.unwrap()`) preserved.
- **Return-type recording**: Rust `method_return_types` captured at impl ingestion (`Self` → impl target; `Result`/`Option`/`Arc` unwrapped).
- **Resolver**: RUST added to `_TYPED_LANGUAGES` (the root reason `local_var_types` was always `None`); Rust `field_expression` now yields the full dotted receiver chain; `_resolve_class_qn_from_type` is Rust-import-aware (`::`-paths); same-module `Type::assoc()` and `Type::new(..).method()` chains resolve via the return-type map; an untyped chain base falls through to the trie fallback so no edge is lost.

## Impact

- mini-redis dead-code false positives **41 → 36** (the `into_frame` cluster and correct `apply`/enum/self/struct/field dispatch). The remaining 36 are separate findings (tokio-macro-buried calls, Rust closures).
- gin (Go) unchanged at 2 (no cross-language regression).

## Tests

New `test_rust_receiver_resolution.py` (7 tests, RED→GREEN), each using a sort-first decoy type to defeat the alphabetical trie coincidence. Full suite passes (the 2 tool-calling integration failures are the live local Ollama model not emitting tool calls, unrelated to this change).