### PR TITLE
fix(rust): reconstruct receiver chains from macro token streams for call resolution

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -3077,6 +3077,10 @@ TS_RS_TYPE_ARGUMENTS = "type_arguments"
 TS_RS_TRY_EXPRESSION = "try_expression"
 TS_RS_FIELD_EXPRESSION = "field_expression"
 TS_RS_FIELD_PATH = "path"
+TS_RS_TOKEN_DOT = "."
+# (H) Nodes that can be a receiver token preceding `.method` in a macro token
+# (H) stream: a plain identifier or the `self` keyword.
+RS_MACRO_RECEIVER_TYPES = (TS_IDENTIFIER, KEYWORD_SELF)
 # (H) Rust `Self` return type resolves to the enclosing impl target.
 RS_SELF_TYPE = "Self"
 # (H) Transparent smart pointers that auto-deref to their inner type: a method

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1109,13 +1109,39 @@ class CallProcessor:
                     func_node_starts=func_node_starts,
                 )
 
+    def _macro_call_name(self, ident: Node) -> str | None:
+        # (H) Reconstruct a `<recv>.method` chain from a macro token stream by walking
+        # (H) the method identifier's preceding siblings over `("." <ident|self>)*`.
+        # (H) `server . run` -> "server.run"; `self . shutdown . recv` ->
+        # (H) "self.shutdown.recv". A method with no preceding `.` stays bare.
+        method = ident.text.decode(cs.ENCODING_UTF8) if ident.text else None
+        if not method:
+            return None
+        parts = [method]
+        cur = ident.prev_sibling
+        while cur is not None and cur.type == cs.TS_RS_TOKEN_DOT:
+            recv = cur.prev_sibling
+            if recv is None or recv.type not in cs.RS_MACRO_RECEIVER_TYPES:
+                break
+            if not recv.text:
+                break
+            parts.append(recv.text.decode(cs.ENCODING_UTF8))
+            cur = recv.prev_sibling
+        parts.reverse()
+        return cs.SEPARATOR_DOT.join(parts)
+
     def _get_call_target_name(
         self, call_node: Node, language: cs.SupportedLanguage | None = None
     ) -> str | None:
         # (H) A macro-internal call (Rust `name(args)` inside a token_tree) is
-        # (H) captured as the bare identifier node; its text is the callee name.
+        # (H) captured as the bare identifier node; its text is the callee name. A
+        # (H) macro tokenizes `server.run()` into loose tokens (`server . run ( )`),
+        # (H) dropping the field_expression, so reconstruct any `<recv>.method`
+        # (H) receiver chain from the preceding sibling tokens -- else the bare method
+        # (H) mis-resolves (`server.run()` in tokio::select! -> the same-module free
+        # (H) fn `run` instead of Listener.run).
         if call_node.type == cs.TS_IDENTIFIER and call_node.text is not None:
-            return call_node.text.decode(cs.ENCODING_UTF8)
+            return self._macro_call_name(call_node)
         if func_child := call_node.child_by_field_name(cs.TS_FIELD_FUNCTION):
             match func_child.type:
                 case (

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1114,14 +1114,14 @@ class CallProcessor:
         # (H) the method identifier's preceding siblings over `("." <ident|self>)*`.
         # (H) `server . run` -> "server.run"; `self . shutdown . recv` ->
         # (H) "self.shutdown.recv". A method with no preceding `.` stays bare.
-        method = ident.text.decode(cs.ENCODING_UTF8) if ident.text else None
-        if not method:
+        if not (method := ident.text.decode(cs.ENCODING_UTF8) if ident.text else None):
             return None
         parts = [method]
         cur = ident.prev_sibling
         while cur is not None and cur.type == cs.TS_RS_TOKEN_DOT:
-            recv = cur.prev_sibling
-            if recv is None or recv.type not in cs.RS_MACRO_RECEIVER_TYPES:
+            if (recv := cur.prev_sibling) is None or (
+                recv.type not in cs.RS_MACRO_RECEIVER_TYPES
+            ):
                 break
             if not recv.text:
                 break

--- a/codebase_rag/tests/test_rust_receiver_resolution.py
+++ b/codebase_rag/tests/test_rust_receiver_resolution.py
@@ -346,3 +346,57 @@ def test_fully_qualified_inline_assoc_call_dispatch(tmp_path: Path) -> None:
     calls = _calls(tmp_path)
     assert ("crate.app.go", "crate.types.Real.run") in calls
     assert ("crate.app.go", "crate.types.Fake.run") not in calls
+
+
+def test_macro_buried_receiver_call_dispatch(tmp_path: Path) -> None:
+    # (H) A `receiver.method()` call buried inside a macro token stream
+    # (H) (`sel! { res = server.run() => {} }`, like tokio::select!) loses its
+    # (H) field_expression structure -- the receiver `server` becomes a loose token.
+    # (H) The reconstructed call must be `server.run` so it dispatches to the local's
+    # (H) type (Listener.run), NOT the same-module free fn `run` (a false self-edge
+    # (H) that severed the whole server/command cluster in mini-redis).
+    _make_crate(
+        tmp_path,
+        "pub struct Listener {}\n"
+        "impl Listener {\n"
+        "    fn run(&self) -> i32 { 1 }\n"
+        "}\n"
+        "pub fn run(server: Listener) -> i32 {\n"
+        "    sel! {\n"
+        "        res = server.run() => {}\n"
+        "    }\n"
+        "    0\n"
+        "}\n",
+    )
+    calls = _calls(tmp_path)
+    assert ("crate.lib.run", "crate.lib.Listener.run") in calls
+    # (H) must not mis-resolve to the same-module free function (self-edge)
+    assert ("crate.lib.run", "crate.lib.run") not in calls
+
+
+def test_macro_buried_field_hop_call_dispatch(tmp_path: Path) -> None:
+    # (H) A field-hop receiver buried in a macro (`self.shutdown.recv()`) must
+    # (H) reconstruct the full chain so it hops self -> field type -> method.
+    _make_crate(
+        tmp_path,
+        "pub struct Aaa {}\n"
+        "impl Aaa {\n"
+        "    fn recv(&self) -> i32 { 2 }\n"
+        "}\n"
+        "pub struct Shutdown {}\n"
+        "impl Shutdown {\n"
+        "    fn recv(&self) -> i32 { 1 }\n"
+        "}\n"
+        "pub struct Handler { shutdown: Shutdown }\n"
+        "impl Handler {\n"
+        "    fn run(&self) -> i32 {\n"
+        "        sel! {\n"
+        "            x = self.shutdown.recv() => {}\n"
+        "        }\n"
+        "        0\n"
+        "    }\n"
+        "}\n",
+    )
+    calls = _calls(tmp_path)
+    assert ("crate.lib.Handler.run", "crate.lib.Shutdown.recv") in calls
+    assert ("crate.lib.Handler.run", "crate.lib.Aaa.recv") not in calls

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.231"
+version = "0.0.232"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Problem

A `receiver.method()` call buried inside a macro (e.g. `tokio::select! { res = server.run() => ... }`) is tokenized into loose tokens (`server . run ( )`) — the `field_expression` structure is gone. Only the bare method identifier `run` was captured, so it mis-resolved to the same-module free function `server::run` — a **false self-edge**. In mini-redis this severed `Listener.run`'s only incoming edge, cascading the entire server/command cluster to dead: `Handler.run`, `Listener.accept`, `DbDropGuard.db`, `Shutdown::new/.is_shutdown`, `Command.apply`, `Unknown.apply`.

## Fix

`_macro_call_name` reconstructs the `<recv>.method` chain by walking the captured identifier's preceding sibling tokens over `("." <ident|self>)*`:
- `server . run` → `server.run` → resolves via the local's type to `Listener.run`
- `self . shutdown . recv` → `self.shutdown.recv` → hops `self` → field type → `Shutdown.recv`

Resolution itself is unchanged — this just hands the receiver-qualified name to the existing type-inference machinery. A receiverless macro call (`foo()`) still returns the bare name, so non-macro and other-language behavior is untouched.

## Impact

- mini-redis dead-code false positives **36 → 28** — exactly the 8 nodes predicted by tracing the cascade, zero regressions.
- gin (Go) unchanged at 2 — no cross-language regression.

This is the first of three verified root causes behind the remaining mini-redis false positives (the others: match-arm variable shadowing, and closures — filed separately).

## Tests

Two new RED→GREEN tests in `test_rust_receiver_resolution.py` (`test_macro_buried_receiver_call_dispatch`, `test_macro_buried_field_hop_call_dispatch`), each with a sort-first decoy type to defeat the trie coincidence. Full suite passes (the 2 tool-calling integration tests that fail are the live local Ollama model not emitting tool calls, unrelated).