### PR TITLE
fix(rust): reference closures from their enclosing scope so they are reachable

### DIFF
--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -532,6 +532,25 @@ class FunctionIngestMixin:
             (cs.NodeLabel.FUNCTION, cs.KEY_QUALIFIED_NAME, resolution.qualified_name),
         )
 
+        # (H) A Rust closure is a value constructed at its definition site (a `.map`
+        # (H) arg, spawn body, `let` binding), so it is used wherever it is written.
+        # (H) Dead-code reachability walks CALLS/REFERENCES (not DEFINES), so mirror the
+        # (H) DEFINES with a REFERENCES from the enclosing scope -- else every closure is
+        # (H) an orphan and reports dead. (JS/TS emit the analogous inline-callback ref.)
+        if (
+            language == cs.SupportedLanguage.RUST
+            and func_node.type == cs.TS_RS_CLOSURE_EXPRESSION
+        ):
+            self.ingestor.ensure_relationship_batch(
+                (parent_type, cs.KEY_QUALIFIED_NAME, parent_qn),
+                cs.RelationshipType.REFERENCES,
+                (
+                    cs.NodeLabel.FUNCTION,
+                    cs.KEY_QUALIFIED_NAME,
+                    resolution.qualified_name,
+                ),
+            )
+
         if resolution.is_exported and language == cs.SupportedLanguage.CPP:
             self.ingestor.ensure_relationship_batch(
                 (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, module_qn),

--- a/codebase_rag/tests/test_rust_closure_references.py
+++ b/codebase_rag/tests/test_rust_closure_references.py
@@ -8,8 +8,7 @@ from pathlib import Path
 from evals.cgr_graph import _capture
 
 
-def _refs(tmp_path: Path) -> set[tuple[str, str]]:
-    ingestor = _capture(tmp_path, "crate")
+def _refs(ingestor) -> set[tuple[str, str]]:
     return {
         (str(from_val), str(to_val))
         for _fl, from_val, rel, _tl, to_val in ingestor.rels
@@ -17,8 +16,7 @@ def _refs(tmp_path: Path) -> set[tuple[str, str]]:
     }
 
 
-def _closure_nodes(tmp_path: Path) -> set[str]:
-    ingestor = _capture(tmp_path, "crate")
+def _closure_nodes(ingestor) -> set[str]:
     return {str(uid) for _label, uid in ingestor.nodes if "anonymous_" in str(uid)}
 
 
@@ -36,8 +34,9 @@ def test_closure_arg_referenced_by_enclosing_fn(tmp_path: Path) -> None:
         "    xs.iter().map(|s| s.len()).sum()\n"
         "}\n",
     )
-    refs = _refs(tmp_path)
-    closures = _closure_nodes(tmp_path)
+    ingestor = _capture(tmp_path, "crate")
+    refs = _refs(ingestor)
+    closures = _closure_nodes(ingestor)
     assert closures, "expected a closure node to be registered"
     for closure in closures:
         assert any(to == closure and frm == "crate.lib.run" for frm, to in refs), (
@@ -56,8 +55,9 @@ def test_closure_in_method_referenced(tmp_path: Path) -> None:
         "    }\n"
         "}\n",
     )
-    refs = _refs(tmp_path)
-    closures = _closure_nodes(tmp_path)
+    ingestor = _capture(tmp_path, "crate")
+    refs = _refs(ingestor)
+    closures = _closure_nodes(ingestor)
     assert closures
     for closure in closures:
         assert any(to == closure and frm == "crate.lib.Db.purge" for frm, to in refs), (

--- a/codebase_rag/tests/test_rust_closure_references.py
+++ b/codebase_rag/tests/test_rust_closure_references.py
@@ -1,0 +1,65 @@
+# (H) A Rust closure is a value constructed where it is written (a `.map(|x| ..)`
+# (H) arg, a spawn body, a `let` binding). For dead-code reachability (which walks
+# (H) CALLS/REFERENCES, not DEFINES), the closure must carry an incoming REFERENCES
+# (H) edge from its enclosing function -- else every closure is an orphan and reports
+# (H) as dead. This mirrors the inline-callback REFERENCES edge JS/TS already emit.
+from pathlib import Path
+
+from evals.cgr_graph import _capture
+
+
+def _refs(tmp_path: Path) -> set[tuple[str, str]]:
+    ingestor = _capture(tmp_path, "crate")
+    return {
+        (str(from_val), str(to_val))
+        for _fl, from_val, rel, _tl, to_val in ingestor.rels
+        if rel == "REFERENCES"
+    }
+
+
+def _closure_nodes(tmp_path: Path) -> set[str]:
+    ingestor = _capture(tmp_path, "crate")
+    return {str(uid) for _label, uid in ingestor.nodes if "anonymous_" in str(uid)}
+
+
+def _make_crate(root: Path, body: str) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "lib.rs").write_text(body, encoding="utf-8")
+
+
+def test_closure_arg_referenced_by_enclosing_fn(tmp_path: Path) -> None:
+    # (H) `xs.iter().map(|s| s.len())` inside a free fn: the closure must be
+    # (H) referenced by the enclosing function so it is reachable, not orphaned.
+    _make_crate(
+        tmp_path,
+        "pub fn run(xs: Vec<String>) -> usize {\n"
+        "    xs.iter().map(|s| s.len()).sum()\n"
+        "}\n",
+    )
+    refs = _refs(tmp_path)
+    closures = _closure_nodes(tmp_path)
+    assert closures, "expected a closure node to be registered"
+    for closure in closures:
+        assert any(to == closure and frm == "crate.lib.run" for frm, to in refs), (
+            f"closure {closure} has no REFERENCES edge from its enclosing fn"
+        )
+
+
+def test_closure_in_method_referenced(tmp_path: Path) -> None:
+    # (H) A closure in an impl method body must be referenced by that method.
+    _make_crate(
+        tmp_path,
+        "pub struct Db {}\n"
+        "impl Db {\n"
+        "    pub fn purge(&self, xs: Vec<i32>) -> i32 {\n"
+        "        xs.iter().map(|x| x + 1).sum()\n"
+        "    }\n"
+        "}\n",
+    )
+    refs = _refs(tmp_path)
+    closures = _closure_nodes(tmp_path)
+    assert closures
+    for closure in closures:
+        assert any(to == closure and frm == "crate.lib.Db.purge" for frm, to in refs), (
+            f"closure {closure} has no REFERENCES edge from Db.purge"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.233"
+version = "0.0.234"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Problem

A Rust `closure_expression` (`.map(|x| ...)`, a spawn body, a `let` binding) receives a `DEFINES` edge from its enclosing function but **no** `CALLS`/`REFERENCES` edge. Dead-code reachability walks only `CALLS`/`REFERENCES`, so every closure is an orphan and reports as a false positive — 14 of mini-redis's remaining candidates were closures.

## Fix

A closure is a value constructed at its definition site, so it is used wherever it is written. In `_create_function_relationships`, for a Rust `closure_expression`, emit a `REFERENCES` edge mirroring the `DEFINES` (enclosing scope → closure). The closure is then reachable exactly when its enclosing function is — the same treatment JS/TS already give inline callbacks. Gated to Rust closures; no other language or node type is affected.

## Impact

- mini-redis dead-code false positives **15 → 2** — all 13 orphaned closures (and their reachable bodies) revived.
- gin (Go) unchanged at 2.
- The remaining 2 (`State.next_expiration` and its own closure) are a **separate** finding: `state.next_expiration()` has `state` typed as `MutexGuard<State>` from `.lock().unwrap()` — a smart-pointer/guard deref receiver, not a closure issue.

This is the last of the three verified root causes behind mini-redis's post-receiver-resolution false positives (macro-buried calls #627, match-arm shadowing #628, and now closures).

## Tests

New `test_rust_closure_references.py` (RED→GREEN): asserts a closure in a free fn and in an impl method each carries a `REFERENCES` edge from its enclosing scope. Existing closure DEFINES/containment oracle tests still pass. Full suite green (the 2 tool-calling integration failures are the live local Ollama model, unrelated).