### PR TITLE
fix(rust): type guard/smart-pointer deref receivers via field-hop chain inference

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -3081,13 +3081,20 @@ TS_RS_FIELD_PATH = "path"
 TS_RS_TOKEN_DOT = "."
 # (H) Nodes that can be a receiver token preceding `.method` in a macro token
 # (H) stream: a plain identifier or the `self` keyword.
-RS_MACRO_RECEIVER_TYPES = (TS_IDENTIFIER, KEYWORD_SELF)
+# (H) A receiver/chain base that is a plain identifier or the `self` keyword (used
+# (H) both for macro-token receiver reconstruction and value-chain base flattening).
+RS_IDENT_OR_SELF = (TS_IDENTIFIER, KEYWORD_SELF)
+RS_MACRO_RECEIVER_TYPES = RS_IDENT_OR_SELF
 # (H) Rust `Self` return type resolves to the enclosing impl target.
 RS_SELF_TYPE = "Self"
-# (H) Transparent smart pointers that auto-deref to their inner type: a method
-# (H) call on the pointer dispatches to the inner type's method, so strip them
-# (H) from any type name (receiver OR return) to reach the real type.
-RS_DEREF_WRAPPERS = frozenset({"Arc", "Rc", "Box", "Pin"})
+# (H) Transparent smart pointers/guards that auto-deref to their inner type: a
+# (H) method call on the wrapper (or on its lock/borrow guard) dispatches to the
+# (H) inner type's method, so strip them from any type name (receiver OR return) to
+# (H) reach the real type. Mutex/RwLock/RefCell/Cell hold their inner type behind a
+# (H) guard obtained via a guard-accessor identity method (see RS_IDENTITY_METHODS).
+RS_DEREF_WRAPPERS = frozenset(
+    {"Arc", "Rc", "Box", "Pin", "Mutex", "RwLock", "RefCell", "Cell"}
+)
 # (H) Result<T>/Option<T>: stripped to their inner T only for a RETURN type (the
 # (H) value a `?`/`.unwrap()` yields). NOT stripped for a receiver type, where a
 # (H) method call `opt.map(..)` dispatches to Option itself.
@@ -3118,6 +3125,12 @@ RS_IDENTITY_METHODS = frozenset(
         "to_owned",
         "borrow",
         "borrow_mut",
+        # (H) Guard accessors: Mutex/RwLock yield a guard that derefs to the inner
+        # (H) type, which the deref-wrapper strip already reduced the receiver to.
+        "lock",
+        "read",
+        "write",
+        "try_lock",
     }
 )
 

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -3135,13 +3135,15 @@ RS_IDENTITY_METHODS = frozenset(
         "as_mut",
         "as_deref",
         "as_deref_mut",
-        # (H) Guard accessors: Mutex/RwLock yield a guard that derefs to the inner
-        # (H) type, which the field-extraction guard strip already reduced to.
-        "lock",
-        "read",
-        "write",
-        "try_lock",
     }
+)
+# (H) Guard accessors: called on a guard container (Mutex/RwLock/RefCell) to obtain a
+# (H) guard that derefs to the inner type. In a receiver chain, one of these
+# (H) immediately after a guard-wrapped field unwraps the wrapper to its inner type
+# (H) (recorded in class_field_guard_inner) -- the only sound unwrap point, since
+# (H) guard containers do not deref-coerce.
+RS_GUARD_ACCESSORS = frozenset(
+    {"lock", "read", "write", "try_lock", "borrow", "borrow_mut"}
 )
 
 # (H) Rust identifier tuples

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -3073,6 +3073,9 @@ TS_RS_FIELD_DECLARATION = "field_declaration"
 TS_RS_FIELD_IDENTIFIER = "field_identifier"
 TS_RS_MATCH_EXPRESSION = "match_expression"
 TS_RS_MATCH_ARM = "match_arm"
+# (H) A Rust call node whose callee is descended for chain flattening: a plain call
+# (H) or a turbofish generic_function (`f::<T>()`).
+RS_CALL_OR_GENERIC_FN = (TS_RS_CALL_EXPRESSION, TS_GENERIC_FUNCTION)
 TS_RS_TUPLE_STRUCT_PATTERN = "tuple_struct_pattern"
 TS_RS_TYPE_ARGUMENTS = "type_arguments"
 TS_RS_TRY_EXPRESSION = "try_expression"
@@ -3087,14 +3090,17 @@ RS_IDENT_OR_SELF = (TS_IDENTIFIER, KEYWORD_SELF)
 RS_MACRO_RECEIVER_TYPES = RS_IDENT_OR_SELF
 # (H) Rust `Self` return type resolves to the enclosing impl target.
 RS_SELF_TYPE = "Self"
-# (H) Transparent smart pointers/guards that auto-deref to their inner type: a
-# (H) method call on the wrapper (or on its lock/borrow guard) dispatches to the
-# (H) inner type's method, so strip them from any type name (receiver OR return) to
-# (H) reach the real type. Mutex/RwLock/RefCell/Cell hold their inner type behind a
-# (H) guard obtained via a guard-accessor identity method (see RS_IDENTITY_METHODS).
-RS_DEREF_WRAPPERS = frozenset(
-    {"Arc", "Rc", "Box", "Pin", "Mutex", "RwLock", "RefCell", "Cell"}
-)
+# (H) Transparent smart pointers that auto-deref (Rust deref coercion) to their
+# (H) inner type: a method call on the pointer dispatches to the inner type's method,
+# (H) so strip them from any type name (receiver OR return) to reach the real type.
+RS_DEREF_WRAPPERS = frozenset({"Arc", "Rc", "Box", "Pin"})
+# (H) Guard containers that do NOT deref-coerce: the inner value is only reachable
+# (H) through a lock/borrow guard accessor. Stripped to the inner type ONLY in field
+# (H) extraction (where the field is virtually always accessed via a lock chain, e.g.
+# (H) `self.shared.state.lock().unwrap()`); a bare local/param/return of a guard type
+# (H) is preserved so a direct wrapper-method call (`m.is_poisoned()`) is not
+# (H) mis-resolved to an inner-type method.
+RS_GUARD_WRAPPERS = frozenset({"Mutex", "RwLock", "RefCell", "Cell"})
 # (H) Result<T>/Option<T>: stripped to their inner T only for a RETURN type (the
 # (H) value a `?`/`.unwrap()` yields). NOT stripped for a receiver type, where a
 # (H) method call `opt.map(..)` dispatches to Option itself.
@@ -3125,8 +3131,12 @@ RS_IDENTITY_METHODS = frozenset(
         "to_owned",
         "borrow",
         "borrow_mut",
+        "as_ref",
+        "as_mut",
+        "as_deref",
+        "as_deref_mut",
         # (H) Guard accessors: Mutex/RwLock yield a guard that derefs to the inner
-        # (H) type, which the deref-wrapper strip already reduced the receiver to.
+        # (H) type, which the field-extraction guard strip already reduced to.
         "lock",
         "read",
         "write",

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -106,6 +106,7 @@ class ClassIngestMixin:
     import_processor: ImportProcessor
     class_inheritance: dict[str, list[str]]
     class_field_types: dict[str, dict[str, str]]
+    class_field_guard_inner: dict[str, dict[str, str]]
     method_return_types: dict[str, str]
     interface_implementers: dict[str, set[str]]
     _deferred_forward_decls: list[_DeferredForwardDecl]
@@ -393,11 +394,14 @@ class ClassIngestMixin:
                 self.class_field_types[class_qn] = field_types
         elif language == cs.SupportedLanguage.RUST:
             # (H) Record Rust struct field types so a field-hop receiver
-            # (H) (`self.shutdown.is_shutdown()`) resolves through the field's type.
-            if field_types := RustTypeInferenceEngine().build_field_type_map(
-                class_node
-            ):
+            # (H) (`self.shutdown.is_shutdown()`) resolves through the field's type,
+            # (H) plus guard-container inner types (`state: Mutex<State>` -> State),
+            # (H) applied only at a lock/read/borrow hop.
+            rust_engine = RustTypeInferenceEngine()
+            if field_types := rust_engine.build_field_type_map(class_node):
                 self.class_field_types[class_qn] = field_types
+            if guard_inner := rust_engine.build_field_guard_inner_map(class_node):
+                self.class_field_guard_inner[class_qn] = guard_inner
         self._ingest_class_methods(
             class_node,
             class_qn,

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -62,6 +62,11 @@ class DefinitionProcessor(
         # (H) method resolves via the field's declared type. Populated at class
         # (H) ingestion, read by the type-inference engine at call resolution.
         self.class_field_types: dict[str, dict[str, str]] = {}
+        # (H) {class_qn: {field_name: inner_type}} for Rust guard-container fields
+        # (H) (`state: Mutex<State>` -> {"state": "State"}). The field map above keeps
+        # (H) the WRAPPER; this inner is applied only when a receiver chain reaches a
+        # (H) lock/read/borrow guard accessor (guards do not deref-coerce).
+        self.class_field_guard_inner: dict[str, dict[str, str]] = {}
         # (H) {alias_name: underlying_bare_type} for C++ typedef/using aliases, so a
         # (H) receiver declared with an alias resolves to the aliased class. Collected
         # (H) across all files (an alias in a header is used in a .cc), read by the

--- a/codebase_rag/parsers/factory.py
+++ b/codebase_rag/parsers/factory.py
@@ -119,6 +119,7 @@ class ProcessorFactory:
                 class_inheritance=self.definition_processor.class_inheritance,
                 simple_name_lookup=self.simple_name_lookup,
                 class_field_types=self.definition_processor.class_field_types,
+                class_field_guard_inner=self.definition_processor.class_field_guard_inner,
                 method_return_types=self.definition_processor.method_return_types,
             )
         return self._type_inference

--- a/codebase_rag/parsers/rs/type_inference.py
+++ b/codebase_rag/parsers/rs/type_inference.py
@@ -40,10 +40,36 @@ class RustTypeInferenceEngine:
             if name_node is None or type_node is None:
                 continue
             if (name := safe_decode_text(name_node)) and (
-                type_name := self._bare_type_name(type_node)
+                type_name := self._field_type_name(type_node)
             ):
                 fields[name] = type_name
         return fields
+
+    def _field_type_name(self, type_node: Node) -> str | None:
+        # (H) Like _bare_type_name, but also unwraps a guard container (`Mutex<State>`
+        # (H) -> State): a struct field holding a Mutex/RwLock/RefCell is virtually
+        # (H) always reached via a lock/borrow chain, so the field's useful receiver
+        # (H) type is the inner one. (Locals/params/returns preserve the wrapper, since
+        # (H) those are commonly used to call wrapper methods directly.)
+        if type_node.type == cs.TS_GENERIC_TYPE:
+            outer = type_node.child_by_field_name(cs.FIELD_TYPE)
+            if outer is not None and safe_decode_text(outer) in cs.RS_GUARD_WRAPPERS:
+                args = type_node.child_by_field_name(cs.TS_RS_TYPE_ARGUMENTS)
+                inner = (
+                    next(
+                        (
+                            c
+                            for c in args.children
+                            if c.type in cs.RS_RETURN_TYPE_NODE_TYPES
+                        ),
+                        None,
+                    )
+                    if args is not None
+                    else None
+                )
+                if inner is not None:
+                    return self._field_type_name(inner)
+        return self._bare_type_name(type_node)
 
     def collect_call_var_bindings(
         self, caller_node: Node
@@ -177,7 +203,8 @@ class RustTypeInferenceEngine:
         # (H) field/method/identity). Base must be an identifier, `self`, or a scoped
         # (H) `Type::assoc` path; anything else (index, literal) yields None.
         node = self._unwrap_try(node)
-        if node.type == cs.TS_RS_CALL_EXPRESSION:
+        if node.type in cs.RS_CALL_OR_GENERIC_FN:
+            # (H) generic_function is turbofish (`f::<T>()`); descend to its callee.
             func = node.child_by_field_name(cs.FIELD_FUNCTION)
             return self._callee_chain_segments(func) if func is not None else None
         if node.type == cs.TS_RS_FIELD_EXPRESSION:

--- a/codebase_rag/parsers/rs/type_inference.py
+++ b/codebase_rag/parsers/rs/type_inference.py
@@ -170,33 +170,35 @@ class RustTypeInferenceEngine:
             bindings.append((name, segments))
 
     def _callee_chain_segments(self, node: Node) -> list[str] | None:
-        # (H) A `Type::assoc(..).m1().m2()` call, flattened to type-then-methods:
-        # (H) `['Type', 'assoc', 'm1', 'm2']`. Returns None unless the chain roots in a
-        # (H) `Type::assoc` associated-function call (the only shape we can type).
-        if node.type != cs.TS_RS_CALL_EXPRESSION:
-            return None
-        func = node.child_by_field_name(cs.FIELD_FUNCTION)
-        if func is None:
-            return None
-        if func.type == cs.TS_SCOPED_IDENTIFIER:
-            path = func.child_by_field_name(cs.TS_RS_FIELD_PATH)
-            method = func.child_by_field_name(cs.FIELD_NAME)
-            # (H) Keep the FULL base path (`crate::cmd::Command`), not just the leaf, so
-            # (H) a fully-qualified inline call (`crate::cmd::Command::from_frame()`)
-            # (H) with no `use` import disambiguates by path in the return-type lookup.
-            base = safe_decode_text(path) if path else None
-            method_name = safe_decode_text(method) if method else None
-            if base and method_name:
-                return [base, method_name]
-            return None
-        if func.type == cs.TS_RS_FIELD_EXPRESSION:
-            receiver = func.child_by_field_name(cs.FIELD_VALUE)
-            method = func.child_by_field_name(cs.FIELD_FIELD)
-            method_name = safe_decode_text(method) if method else None
-            if receiver is None or not method_name:
+        # (H) Flatten a Rust value expression into ordered chain segments, base first:
+        # (H) `Type::assoc().m()` -> ['Type','assoc','m']; `self.shared.state.lock()
+        # (H) .unwrap()` -> ['self','shared','state','lock','unwrap']. Method calls and
+        # (H) field accesses are both segments (the resolver disambiguates each hop as
+        # (H) field/method/identity). Base must be an identifier, `self`, or a scoped
+        # (H) `Type::assoc` path; anything else (index, literal) yields None.
+        node = self._unwrap_try(node)
+        if node.type == cs.TS_RS_CALL_EXPRESSION:
+            func = node.child_by_field_name(cs.FIELD_FUNCTION)
+            return self._callee_chain_segments(func) if func is not None else None
+        if node.type == cs.TS_RS_FIELD_EXPRESSION:
+            receiver = node.child_by_field_name(cs.FIELD_VALUE)
+            field = node.child_by_field_name(cs.FIELD_FIELD)
+            field_name = safe_decode_text(field) if field else None
+            if receiver is None or not field_name:
                 return None
-            if base_segments := self._callee_chain_segments(self._unwrap_try(receiver)):
-                return [*base_segments, method_name]
+            if base := self._callee_chain_segments(receiver):
+                return [*base, field_name]
+            return None
+        if node.type == cs.TS_SCOPED_IDENTIFIER:
+            path = node.child_by_field_name(cs.TS_RS_FIELD_PATH)
+            name = node.child_by_field_name(cs.FIELD_NAME)
+            # (H) Keep the FULL base path (`crate::cmd::Command`) so a fully-qualified
+            # (H) inline call disambiguates by path in the return-type lookup.
+            base = safe_decode_text(path) if path else None
+            leaf = safe_decode_text(name) if name else None
+            return [base, leaf] if base and leaf else None
+        if node.type in cs.RS_IDENT_OR_SELF:
+            return [text] if (text := safe_decode_text(node)) else None
         return None
 
     def _unwrap_try(self, node: Node) -> Node:

--- a/codebase_rag/parsers/rs/type_inference.py
+++ b/codebase_rag/parsers/rs/type_inference.py
@@ -40,36 +40,58 @@ class RustTypeInferenceEngine:
             if name_node is None or type_node is None:
                 continue
             if (name := safe_decode_text(name_node)) and (
-                type_name := self._field_type_name(type_node)
+                type_name := self._bare_type_name(type_node)
             ):
                 fields[name] = type_name
         return fields
 
-    def _field_type_name(self, type_node: Node) -> str | None:
-        # (H) Like _bare_type_name, but also unwraps a guard container (`Mutex<State>`
-        # (H) -> State): a struct field holding a Mutex/RwLock/RefCell is virtually
-        # (H) always reached via a lock/borrow chain, so the field's useful receiver
-        # (H) type is the inner one. (Locals/params/returns preserve the wrapper, since
-        # (H) those are commonly used to call wrapper methods directly.)
-        if type_node.type == cs.TS_GENERIC_TYPE:
-            outer = type_node.child_by_field_name(cs.FIELD_TYPE)
-            if outer is not None and safe_decode_text(outer) in cs.RS_GUARD_WRAPPERS:
-                args = type_node.child_by_field_name(cs.TS_RS_TYPE_ARGUMENTS)
-                inner = (
-                    next(
-                        (
-                            c
-                            for c in args.children
-                            if c.type in cs.RS_RETURN_TYPE_NODE_TYPES
-                        ),
-                        None,
-                    )
-                    if args is not None
-                    else None
-                )
-                if inner is not None:
-                    return self._field_type_name(inner)
-        return self._bare_type_name(type_node)
+    def build_field_guard_inner_map(self, class_node: Node) -> dict[str, str]:
+        # (H) For struct fields whose type is a guard container (`state: Mutex<State>`),
+        # (H) record field -> inner type (`state` -> State). The field map itself keeps
+        # (H) the WRAPPER (`Mutex`), so a direct `self.state.is_poisoned()` resolves
+        # (H) against the wrapper (correct); the inner is applied ONLY when a chain
+        # (H) reaches a lock/read/borrow guard accessor. Guard containers do not
+        # (H) deref-coerce, so this is the only sound place to unwrap.
+        inners: dict[str, str] = {}
+        field_list = class_node.child_by_field_name(cs.FIELD_BODY)
+        if field_list is None or field_list.type != cs.TS_RS_FIELD_DECLARATION_LIST:
+            return inners
+        for decl in field_list.children:
+            if decl.type != cs.TS_RS_FIELD_DECLARATION:
+                continue
+            name_node = decl.child_by_field_name(cs.FIELD_NAME)
+            type_node = decl.child_by_field_name(cs.FIELD_TYPE)
+            if name_node is None or type_node is None:
+                continue
+            name = safe_decode_text(name_node)
+            if name and (inner := self._guard_inner_type(type_node)):
+                inners[name] = inner
+        return inners
+
+    def _guard_inner_type(self, type_node: Node) -> str | None:
+        # (H) `Mutex<State>` / `Arc<Mutex<State>>` -> State; None for a non-guard type.
+        # (H) A guard wrapped in a deref pointer (`Arc<Mutex<T>>`) still unwraps to the
+        # (H) guard's inner, so peel deref pointers first.
+        if type_node.type != cs.TS_GENERIC_TYPE:
+            return None
+        outer = type_node.child_by_field_name(cs.FIELD_TYPE)
+        outer_name = safe_decode_text(outer) if outer else None
+        args = type_node.child_by_field_name(cs.TS_RS_TYPE_ARGUMENTS)
+        inner = (
+            next(
+                (c for c in args.children if c.type in cs.RS_RETURN_TYPE_NODE_TYPES),
+                None,
+            )
+            if args is not None
+            else None
+        )
+        if inner is None:
+            return None
+        if outer_name in cs.RS_GUARD_WRAPPERS:
+            return self._bare_type_name(inner)
+        if outer_name in cs.RS_DEREF_WRAPPERS:
+            return self._guard_inner_type(inner)
+        return None
 
     def collect_call_var_bindings(
         self, caller_node: Node

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -266,6 +266,14 @@ class TypeInferenceEngine:
         for hop in segments[1:]:
             if current_type is None:
                 return None
+            # (H) A bare guard-wrapper type (`Mutex`/`RwLock`/...) can't continue the
+            # (H) chain: its inner type is only reachable at runtime via lock/borrow and
+            # (H) is unrecoverable from the bare name. Bail so the caller stays untyped
+            # (H) and the name-only trie fallback resolves the downstream call (a
+            # (H) guard-typed field is already stripped to its inner in field extraction,
+            # (H) so only a local/param/return guard reaches here).
+            if current_type in cs.RS_GUARD_WRAPPERS:
+                return None
             class_qn = self._resolve_rust_type_qn(current_type, module_qn)
             if field_type := self.class_field_types.get(class_qn, {}).get(hop):
                 current_type = field_type

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -34,6 +34,7 @@ class TypeInferenceEngine:
         "class_inheritance",
         "simple_name_lookup",
         "class_field_types",
+        "class_field_guard_inner",
         "method_return_types",
         "_java_type_inference",
         "_lua_type_inference",
@@ -56,6 +57,7 @@ class TypeInferenceEngine:
         class_inheritance: dict[str, list[str]],
         simple_name_lookup: SimpleNameLookup,
         class_field_types: dict[str, dict[str, str]] | None = None,
+        class_field_guard_inner: dict[str, dict[str, str]] | None = None,
         method_return_types: dict[str, str] | None = None,
     ):
         self.import_processor = import_processor
@@ -73,6 +75,12 @@ class TypeInferenceEngine:
         # (H) silently lose every field type written afterward.
         self.class_field_types = (
             class_field_types if class_field_types is not None else {}
+        )
+        # (H) Shared reference (as with class_field_types): Rust guard-field inner types
+        # (H) (`Shared.state` -> State for a `Mutex<State>` field), applied only at a
+        # (H) guard-accessor hop so a direct wrapper call isn't mis-resolved to the inner.
+        self.class_field_guard_inner = (
+            class_field_guard_inner if class_field_guard_inner is not None else {}
         )
         # (H) Shared reference (as with class_field_types): DefinitionProcessor's
         # (H) func_qn -> return-type map, populated during ingestion and read by the
@@ -255,28 +263,34 @@ class TypeInferenceEngine:
         # (H) Walk a flattened chain to the type it yields:
         # (H)   ['Command','from_frame']  -> base type Command, method from_frame
         # (H)   ['self','shared','state','lock','unwrap'] -> base local self (Db),
-        # (H)     field shared (Arc<Shared>->Shared), field state (Mutex<State>->State),
-        # (H)     lock/unwrap guard-identities -> State.
+        # (H)     field shared (Arc<Shared>->Shared), field state (Mutex<State>, guard
+        # (H)     inner State), lock unwraps the guard -> State, unwrap identity -> State.
         # (H) The base is a typed local (self/var) when present in var_types, else a
-        # (H) type name. Each hop tries field-type, then method-return, then a
-        # (H) passthrough identity method; an unknown hop drops the binding.
+        # (H) type name. Each hop tries: guard-unwrap (a guard accessor right after a
+        # (H) guard-wrapped field) -> field-type -> method-return -> identity.
         if len(segments) < 2:
             return None
         current_type: str | None = var_types.get(segments[0]) or segments[0]
+        # (H) Inner type of the guard-wrapped field just hopped through, pending a guard
+        # (H) accessor to unwrap it (None otherwise).
+        guard_inner: str | None = None
         for hop in segments[1:]:
             if current_type is None:
                 return None
-            # (H) A bare guard-wrapper type (`Mutex`/`RwLock`/...) can't continue the
-            # (H) chain: its inner type is only reachable at runtime via lock/borrow and
-            # (H) is unrecoverable from the bare name. Bail so the caller stays untyped
-            # (H) and the name-only trie fallback resolves the downstream call (a
-            # (H) guard-typed field is already stripped to its inner in field extraction,
-            # (H) so only a local/param/return guard reaches here).
+            if guard_inner is not None and hop in cs.RS_GUARD_ACCESSORS:
+                current_type, guard_inner = guard_inner, None
+                continue
+            guard_inner = None
+            # (H) A bare guard-wrapper type not immediately guard-accessed can't
+            # (H) continue: its inner is only reachable at runtime and is unrecoverable
+            # (H) from the bare name. Bail so the trie fallback resolves the downstream
+            # (H) call (matching a direct wrapper-method call's behavior).
             if current_type in cs.RS_GUARD_WRAPPERS:
                 return None
             class_qn = self._resolve_rust_type_qn(current_type, module_qn)
             if field_type := self.class_field_types.get(class_qn, {}).get(hop):
                 current_type = field_type
+                guard_inner = self.class_field_guard_inner.get(class_qn, {}).get(hop)
             elif next_type := self.method_return_types.get(
                 f"{class_qn}{cs.SEPARATOR_DOT}{hop}"
             ):

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -244,26 +244,36 @@ class TypeInferenceEngine:
         ):
             if name in var_types:
                 continue
-            if return_type := self._infer_rust_call_return_type(segments, module_qn):
+            if return_type := self._infer_rust_call_return_type(
+                segments, module_qn, var_types
+            ):
                 var_types[name] = return_type
 
     def _infer_rust_call_return_type(
-        self, segments: list[str], module_qn: str
+        self, segments: list[str], module_qn: str, var_types: dict[str, str]
     ) -> str | None:
-        # (H) `['Command', 'from_frame']`: base type `Command` -> its `from_frame`'s
-        # (H) recorded return type. Wrapper-passthrough hops (`.unwrap()`) keep the
-        # (H) current type. Any unknown hop drops the whole binding (never guessed).
+        # (H) Walk a flattened chain to the type it yields:
+        # (H)   ['Command','from_frame']  -> base type Command, method from_frame
+        # (H)   ['self','shared','state','lock','unwrap'] -> base local self (Db),
+        # (H)     field shared (Arc<Shared>->Shared), field state (Mutex<State>->State),
+        # (H)     lock/unwrap guard-identities -> State.
+        # (H) The base is a typed local (self/var) when present in var_types, else a
+        # (H) type name. Each hop tries field-type, then method-return, then a
+        # (H) passthrough identity method; an unknown hop drops the binding.
         if len(segments) < 2:
             return None
-        current_type: str | None = segments[0]
-        for method in segments[1:]:
+        current_type: str | None = var_types.get(segments[0]) or segments[0]
+        for hop in segments[1:]:
             if current_type is None:
                 return None
             class_qn = self._resolve_rust_type_qn(current_type, module_qn)
-            method_qn = f"{class_qn}{cs.SEPARATOR_DOT}{method}"
-            if next_type := self.method_return_types.get(method_qn):
+            if field_type := self.class_field_types.get(class_qn, {}).get(hop):
+                current_type = field_type
+            elif next_type := self.method_return_types.get(
+                f"{class_qn}{cs.SEPARATOR_DOT}{hop}"
+            ):
                 current_type = next_type
-            elif method not in cs.RS_IDENTITY_METHODS:
+            elif hop not in cs.RS_IDENTITY_METHODS:
                 return None
         return current_type
 

--- a/codebase_rag/tests/test_rust_receiver_resolution.py
+++ b/codebase_rag/tests/test_rust_receiver_resolution.py
@@ -114,6 +114,28 @@ def test_guard_deref_field_hop_binding_dispatch(tmp_path: Path) -> None:
     assert ("crate.lib.Db.set", "crate.lib.Aaa.next_expiration") not in calls
 
 
+def test_guard_wrapper_local_not_erased_to_inner(tmp_path: Path) -> None:
+    # (H) A Mutex/RwLock does NOT deref-coerce: a bare `let m: Mutex<Inner>` receiver
+    # (H) can only reach Inner via a lock/borrow hop, so `m` must stay typed as the
+    # (H) wrapper -- NOT erased to Inner (which would mis-resolve a direct `m.work()`
+    # (H) to Inner.work). `work` is defined on two types so the trie can't mask a
+    # (H) precise mis-resolution.
+    _make_crate(
+        tmp_path,
+        "use std::sync::Mutex;\n"
+        "pub struct Aaa {}\n"
+        "impl Aaa {\n    fn work(&self) -> i32 { 2 }\n}\n"
+        "pub struct Inner {}\n"
+        "impl Inner {\n    fn work(&self) -> i32 { 1 }\n}\n"
+        "pub fn go(m: Mutex<Inner>) -> i32 {\n"
+        "    m.work()\n"
+        "}\n",
+    )
+    calls = _calls(tmp_path)
+    # (H) m is a Mutex receiver; a direct m.work() must NOT bind to Inner.work
+    assert ("crate.lib.go", "crate.lib.Inner.work") not in calls
+
+
 def test_let_assoc_call_return_type_dispatch(tmp_path: Path) -> None:
     # (H) `let cmd = Command::from_frame(f); cmd.apply()` types cmd from the
     # (H) associated function's return type (Command).

--- a/codebase_rag/tests/test_rust_receiver_resolution.py
+++ b/codebase_rag/tests/test_rust_receiver_resolution.py
@@ -87,6 +87,33 @@ def test_field_type_receiver_dispatch(tmp_path: Path) -> None:
     assert ("crate.lib.Handler.run", "crate.lib.Aaa.is_shutdown") not in calls
 
 
+def test_guard_deref_field_hop_binding_dispatch(tmp_path: Path) -> None:
+    # (H) `let state = self.shared.state.lock().unwrap()` inside impl Db: type `state`
+    # (H) by hopping self -> Db, field shared: Arc<Shared> -> Shared, field
+    # (H) state: Mutex<State> -> State (deref through Arc/Mutex), then lock()/unwrap()
+    # (H) as guard-accessor identities -> State. `state.next_expiration()` must then
+    # (H) dispatch to State.next_expiration (mini-redis Db.set).
+    _make_crate(
+        tmp_path,
+        "use std::sync::{Arc, Mutex};\n"
+        "pub struct Aaa {}\n"
+        "impl Aaa {\n    fn next_expiration(&self) -> i32 { 2 }\n}\n"
+        "pub struct State {}\n"
+        "impl State {\n    fn next_expiration(&self) -> i32 { 1 }\n}\n"
+        "pub struct Shared { state: Mutex<State> }\n"
+        "pub struct Db { shared: Arc<Shared> }\n"
+        "impl Db {\n"
+        "    fn set(&self) -> i32 {\n"
+        "        let state = self.shared.state.lock().unwrap();\n"
+        "        state.next_expiration()\n"
+        "    }\n"
+        "}\n",
+    )
+    calls = _calls(tmp_path)
+    assert ("crate.lib.Db.set", "crate.lib.State.next_expiration") in calls
+    assert ("crate.lib.Db.set", "crate.lib.Aaa.next_expiration") not in calls
+
+
 def test_let_assoc_call_return_type_dispatch(tmp_path: Path) -> None:
     # (H) `let cmd = Command::from_frame(f); cmd.apply()` types cmd from the
     # (H) associated function's return type (Command).

--- a/codebase_rag/tests/test_rust_receiver_resolution.py
+++ b/codebase_rag/tests/test_rust_receiver_resolution.py
@@ -136,6 +136,28 @@ def test_guard_wrapper_local_not_erased_to_inner(tmp_path: Path) -> None:
     assert ("crate.lib.go", "crate.lib.Inner.work") not in calls
 
 
+def test_guard_field_direct_call_not_erased_to_inner(tmp_path: Path) -> None:
+    # (H) A guard-wrapped FIELD keeps its wrapper type in the field map: a DIRECT
+    # (H) `self.state.work()` (no lock) must NOT resolve to Inner.work. The inner is
+    # (H) applied only when a lock/borrow accessor intervenes (see the field-hop test).
+    _make_crate(
+        tmp_path,
+        "use std::sync::Mutex;\n"
+        "pub struct Aaa {}\n"
+        "impl Aaa {\n    fn work(&self) -> i32 { 2 }\n}\n"
+        "pub struct Inner {}\n"
+        "impl Inner {\n    fn work(&self) -> i32 { 1 }\n}\n"
+        "pub struct Holder { state: Mutex<Inner> }\n"
+        "impl Holder {\n"
+        "    fn go(&self) -> i32 {\n"
+        "        self.state.work()\n"
+        "    }\n"
+        "}\n",
+    )
+    calls = _calls(tmp_path)
+    assert ("crate.lib.Holder.go", "crate.lib.Inner.work") not in calls
+
+
 def test_let_assoc_call_return_type_dispatch(tmp_path: Path) -> None:
     # (H) `let cmd = Command::from_frame(f); cmd.apply()` types cmd from the
     # (H) associated function's return type (Command).


### PR DESCRIPTION
## Problem

A local bound through a lock guard / smart pointer could not be typed, so a later method call on it fell back to the ambiguous name-only trie:

```rust
let state = self.shared.state.lock().unwrap();  // Db.shared: Arc<Shared>, Shared.state: Mutex<State>
state.next_expiration();                         // should resolve to State.next_expiration
```

The chain roots in a **field access** (`self.shared.state`), which the Rust chain collector didn't handle (it only handled `Type::assoc()` and bare-identifier bases), and `Mutex<T>`/`RwLock<T>` weren't treated as deref-to-inner.

## Fix

- `Mutex`, `RwLock`, `RefCell`, `Cell` join the deref-wrapper set, so a field/param/return `Mutex<State>` reduces to `State` (as it behaves for method dispatch — you always lock to access the inner value).
- `lock`, `read`, `write`, `try_lock` join the identity-method set (guard accessors that yield a guard dereferencing to the inner type).
- `_callee_chain_segments` now flattens **any** value chain to ordered segments, including field-access bases: `self.shared.state.lock().unwrap()` → `['self','shared','state','lock','unwrap']`.
- `_infer_rust_call_return_type` resolves the base via the local var-type map (`self` → impl target, or a typed local) or as a type name, then walks each hop trying field-type → method-return → passthrough identity. An unknown hop drops the binding (never guessed).

## Impact

- Adds guard/smart-pointer deref receiver typing, proven by an isolated RED→GREEN test.
- gin (Go) unchanged at 2; full Rust/resolution suite green.
- Note: mini-redis's two remaining candidates are **not** cleared by this alone — there the `state.next_expiration()` call sits inside a closure that *captures* `state` from the parent scope, and closure bodies don't yet inherit captured locals (a separate follow-up). This PR is the guard-deref capability; the capture-inheritance piece lands next.

## Tests

`test_guard_deref_field_hop_binding_dispatch` (RED→GREEN): `self.shared.state.lock().unwrap()` in an impl method, asserting `state.next_expiration()` dispatches to `State.next_expiration` and not a decoy. Full suite passes (the 2 tool-calling integration failures are the live local Ollama model, unrelated).