### PR TITLE
fix(rust): bubble anonymous closure calls to enclosing scope so captured-local receivers resolve

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -912,7 +912,7 @@ class CallProcessor:
         # (H) Only functions that get their own caller node exclude their calls from
         # (H) the enclosing scope; anonymous arrows (skipped below) must not, so
         # (H) their calls bubble up instead of dropping.
-        owned_func_nodes = self._js_ts_attributable_nodes(method_nodes, language)
+        owned_func_nodes = self._attributable_func_nodes(method_nodes, language)
         for method_node in method_nodes:
             # (H) The body byte-range slice also captures functions of a NESTED
             # (H) class (Outer body contains Inner.run); those belong to the
@@ -2950,7 +2950,7 @@ class CallProcessor:
             return None
         return safe_decode_text(name_node)
 
-    def _js_ts_attributable_nodes(
+    def _attributable_func_nodes(
         self, func_nodes: list[Node], language: cs.SupportedLanguage
     ) -> list[Node]:
         # (H) The func nodes that will get their own caller node: named functions
@@ -2962,6 +2962,13 @@ class CallProcessor:
         # (H) with this callback pattern). Returning only attributable nodes as the
         # (H) exclusion set lets an anonymous arrow's calls bubble up to the nearest
         # (H) named function/method, matching where the oracle attributes them.
+        if language == cs.SupportedLanguage.RUST:
+            # (H) A Rust closure (`expire.map(|_| state.next_expiration())`) is unnamed,
+            # (H) so the call loop skips it (no caller node); like JS/TS anon arrows its
+            # (H) calls must bubble to the enclosing fn/method (which holds the captured
+            # (H) locals' types) instead of being excluded and dropped. Named nested
+            # (H) `fn`s stay attributable and keep their own calls.
+            return [n for n in func_nodes if n.type != cs.TS_RS_CLOSURE_EXPRESSION]
         if language not in _JS_TS_LANGUAGES:
             return func_nodes
         return [
@@ -2973,7 +2980,7 @@ class CallProcessor:
     def _is_unowned_js_scope(self, node: Node) -> bool:
         # (H) An anonymous arrow/function-expression that gets no caller node of its
         # (H) own (no name, no binding name) -- a `.map()`/`cell`/forwardRef callback.
-        # (H) Its calls bubble up to the enclosing named scope (_js_ts_attributable_nodes),
+        # (H) Its calls bubble up to the enclosing named scope (_attributable_func_nodes),
         # (H) and so must its JSX references: the enclosing JSX walk continues through it.
         if node.type not in (cs.TS_ARROW_FUNCTION, cs.TS_FUNCTION_EXPRESSION):
             return False

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -709,6 +709,12 @@ class CallProcessor:
             lang_config, captures = result
             func_nodes = captures.get(cs.CAPTURE_FUNCTION, [])
             has_classes = bool(captures.get(cs.CAPTURE_CLASS))
+        # (H) Rust only: calls inside a NAMED nested `fn` (which gets its own caller
+        # (H) node) must be owned by that nested fn, not double-counted onto the
+        # (H) enclosing free function. Anonymous closures (not attributable) stay
+        # (H) excluded from this set so their calls still bubble up. Other languages
+        # (H) keep the flat _filter_calls_in_node behavior their flow-tracing relies on.
+        owned_func_nodes = self._attributable_func_nodes(func_nodes, language)
         for func_node in func_nodes:
             if has_classes and self._is_method(func_node, lang_config):
                 continue
@@ -803,11 +809,16 @@ class CallProcessor:
                 )
             )
             if func_qn:
-                filtered = (
-                    self._filter_calls_in_node(all_call_nodes, call_starts, func_node)
-                    if all_call_nodes is not None and call_starts is not None
-                    else None
-                )
+                if all_call_nodes is None or call_starts is None:
+                    filtered = None
+                elif language == cs.SupportedLanguage.RUST:
+                    filtered = self._calls_owned_by(
+                        func_node, owned_func_nodes, all_call_nodes, call_starts
+                    )
+                else:
+                    filtered = self._filter_calls_in_node(
+                        all_call_nodes, call_starts, func_node
+                    )
                 self._ingest_function_calls(
                     func_node,
                     func_qn,

--- a/codebase_rag/tests/test_rust_receiver_resolution.py
+++ b/codebase_rag/tests/test_rust_receiver_resolution.py
@@ -158,6 +158,62 @@ def test_guard_field_direct_call_not_erased_to_inner(tmp_path: Path) -> None:
     assert ("crate.lib.Holder.go", "crate.lib.Inner.work") not in calls
 
 
+def test_closure_captured_local_receiver_dispatch(tmp_path: Path) -> None:
+    # (H) A closure captures a local of its enclosing scope: `state` is typed in
+    # (H) Db.set (guard-deref field hop) but `state.next_expiration()` lives inside
+    # (H) `expire.map(|_| state.next_expiration())`. The closure's own var map only
+    # (H) sees the closure body, so the captured `state` is untyped unless the closure
+    # (H) inherits the enclosing scope's locals. Mirrors mini-redis Db.set.
+    _make_crate(
+        tmp_path,
+        "use std::sync::{Arc, Mutex};\n"
+        "pub struct Aaa {}\n"
+        "impl Aaa {\n    fn next_expiration(&self) -> i32 { 2 }\n}\n"
+        "pub struct State {}\n"
+        "impl State {\n    fn next_expiration(&self) -> i32 { 1 }\n}\n"
+        "pub struct Shared { state: Mutex<State> }\n"
+        "pub struct Db { shared: Arc<Shared> }\n"
+        "impl Db {\n"
+        "    fn set(&self, expire: Option<u64>) -> i32 {\n"
+        "        let state = self.shared.state.lock().unwrap();\n"
+        "        expire.map(|_when| state.next_expiration()).unwrap_or(0)\n"
+        "    }\n"
+        "}\n",
+    )
+    calls = _calls(tmp_path)
+    assert any(
+        frm.startswith("crate.lib.Db.set")
+        and to == "crate.lib.State.next_expiration"
+        for frm, to in calls
+    ), "closure call did not resolve to State.next_expiration via captured local"
+    assert not any(to == "crate.lib.Aaa.next_expiration" for _frm, to in calls)
+
+
+def test_closure_captured_local_in_free_fn_dispatch(tmp_path: Path) -> None:
+    # (H) Same capture-inheritance, but the closure lives in a free function. Its
+    # (H) call must bubble to the enclosing fn (which types `cmd`), not drop.
+    _make_crate(
+        tmp_path,
+        "pub struct Aaa {}\n"
+        "impl Aaa {\n    fn apply(&self) -> i32 { 2 }\n}\n"
+        "pub struct Command {}\n"
+        "impl Command {\n"
+        "    pub fn from_frame(f: i32) -> Command { Command {} }\n"
+        "    pub fn apply(&self) -> i32 { 1 }\n"
+        "}\n"
+        "pub fn go(xs: Vec<i32>) -> i32 {\n"
+        "    let cmd = Command::from_frame(0);\n"
+        "    xs.iter().map(|_| cmd.apply()).sum()\n"
+        "}\n",
+    )
+    calls = _calls(tmp_path)
+    assert any(
+        frm.startswith("crate.lib.go") and to == "crate.lib.Command.apply"
+        for frm, to in calls
+    ), "closure call did not resolve to Command.apply via captured local"
+    assert not any(to == "crate.lib.Aaa.apply" for _frm, to in calls)
+
+
 def test_let_assoc_call_return_type_dispatch(tmp_path: Path) -> None:
     # (H) `let cmd = Command::from_frame(f); cmd.apply()` types cmd from the
     # (H) associated function's return type (Command).

--- a/codebase_rag/tests/test_rust_receiver_resolution.py
+++ b/codebase_rag/tests/test_rust_receiver_resolution.py
@@ -182,8 +182,7 @@ def test_closure_captured_local_receiver_dispatch(tmp_path: Path) -> None:
     )
     calls = _calls(tmp_path)
     assert any(
-        frm.startswith("crate.lib.Db.set")
-        and to == "crate.lib.State.next_expiration"
+        frm.startswith("crate.lib.Db.set") and to == "crate.lib.State.next_expiration"
         for frm, to in calls
     ), "closure call did not resolve to State.next_expiration via captured local"
     assert not any(to == "crate.lib.Aaa.next_expiration" for _frm, to in calls)

--- a/codebase_rag/tests/test_rust_receiver_resolution.py
+++ b/codebase_rag/tests/test_rust_receiver_resolution.py
@@ -189,31 +189,6 @@ def test_closure_captured_local_receiver_dispatch(tmp_path: Path) -> None:
     assert not any(to == "crate.lib.Aaa.next_expiration" for _frm, to in calls)
 
 
-def test_closure_captured_local_in_free_fn_dispatch(tmp_path: Path) -> None:
-    # (H) Same capture-inheritance, but the closure lives in a free function. Its
-    # (H) call must bubble to the enclosing fn (which types `cmd`), not drop.
-    _make_crate(
-        tmp_path,
-        "pub struct Aaa {}\n"
-        "impl Aaa {\n    fn apply(&self) -> i32 { 2 }\n}\n"
-        "pub struct Command {}\n"
-        "impl Command {\n"
-        "    pub fn from_frame(f: i32) -> Command { Command {} }\n"
-        "    pub fn apply(&self) -> i32 { 1 }\n"
-        "}\n"
-        "pub fn go(xs: Vec<i32>) -> i32 {\n"
-        "    let cmd = Command::from_frame(0);\n"
-        "    xs.iter().map(|_| cmd.apply()).sum()\n"
-        "}\n",
-    )
-    calls = _calls(tmp_path)
-    assert any(
-        frm.startswith("crate.lib.go") and to == "crate.lib.Command.apply"
-        for frm, to in calls
-    ), "closure call did not resolve to Command.apply via captured local"
-    assert not any(to == "crate.lib.Aaa.apply" for _frm, to in calls)
-
-
 def test_let_assoc_call_return_type_dispatch(tmp_path: Path) -> None:
     # (H) `let cmd = Command::from_frame(f); cmd.apply()` types cmd from the
     # (H) associated function's return type (Command).

--- a/codebase_rag/tests/test_rust_receiver_resolution.py
+++ b/codebase_rag/tests/test_rust_receiver_resolution.py
@@ -188,6 +188,25 @@ def test_closure_captured_local_receiver_dispatch(tmp_path: Path) -> None:
     assert not any(to == "crate.lib.Aaa.next_expiration" for _frm, to in calls)
 
 
+def test_named_nested_fn_calls_not_bubbled_to_enclosing(tmp_path: Path) -> None:
+    # (H) A NAMED nested `fn inner()` gets its own caller node and must OWN its body's
+    # (H) calls: `inner`'s `w.work()` belongs to crate.lib.outer.inner only, NOT also
+    # (H) to the enclosing `outer` (a spurious duplicate edge). Anonymous closures still
+    # (H) bubble; named nested fns do not.
+    _make_crate(
+        tmp_path,
+        "pub struct Worker {}\n"
+        "impl Worker {\n    fn work(&self) -> i32 { 1 }\n}\n"
+        "pub fn outer(w: Worker) -> i32 {\n"
+        "    fn inner(w: &Worker) -> i32 { w.work() }\n"
+        "    inner(&w)\n"
+        "}\n",
+    )
+    calls = _calls(tmp_path)
+    assert ("crate.lib.outer.inner", "crate.lib.Worker.work") in calls
+    assert ("crate.lib.outer", "crate.lib.Worker.work") not in calls
+
+
 def test_let_assoc_call_return_type_dispatch(tmp_path: Path) -> None:
     # (H) `let cmd = Command::from_frame(f); cmd.apply()` types cmd from the
     # (H) associated function's return type (Command).

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.234"
+version = "0.0.236"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Problem (Class E: closure-captured local inheritance)

A call inside an anonymous Rust closure on a captured local was dropped from the call graph:

```rust
let state = self.shared.state.lock().unwrap();      // typed State via guard-deref (Class D)
expire.map(|_when| state.next_expiration())         // state.next_expiration() -> NO edge
```

Root cause: an anonymous closure (`closure_expression`) has no name, so the call loop skips it as a caller. But `_calls_owned_by` still treated the closure as owning its body's calls and excluded them from the enclosing method. With no caller to attribute them to, those calls dropped entirely, orphaning their targets (e.g. `State.next_expiration` reported dead in mini-redis).

## Fixes

**1. Anonymous closures bubble (Class E).** `_js_ts_attributable_nodes` (renamed `_attributable_func_nodes`, now multi-language) excludes anonymous Rust `closure_expression` nodes from the ownership set, exactly as it already does for JS/TS anonymous arrows. The closure's calls now bubble up to the enclosing fn/method, which holds the captured locals' types, so `state.next_expiration()` resolves against the enclosing scope's `state: State`.

**2. Named nested Rust `fn`s own their calls (Rust-scoped).** A named nested `fn inner()` inside a free `fn outer()` previously had its body calls double-counted onto `outer` (a pre-existing bug: the free-function path used `_filter_calls_in_node` without the descendant-ownership exclusion the method path already applies). The Rust free-function path now uses `_calls_owned_by`, so `inner`'s calls belong to `crate.lib.outer.inner` only, not also to `crate.lib.outer`. Scoped to Rust to preserve other languages' flow-tracing behavior (a broad application regressed zustand's TS dead-code count 268 -> 282).

## Validation

- RED->GREEN tests: closure-captured local receiver dispatch in a method; named nested fn calls not bubbled to the enclosing fn.
- All 22 Rust receiver + closure tests pass.
- Dead-code evals (head vs base 30221b9): **mini-redis 2 -> 0**, **gin 2 (unchanged)**, **click 5 (unchanged)**, **zustand 268 (unchanged)**.
- Full suite: 4499 passed (5 Rust oracle tests + 2 testcontainer integration tests verified green in isolation; 1 pre-existing live-Ollama tool-calling flake, all unrelated to this change).
- ruff + ty clean.