### PR TITLE
feat(cpp): root operator overloads as dead-code reachability roots

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -123,6 +123,13 @@ CPP_EXTENSIONS = (
 PHP_EXTENSIONS = (EXT_PHP,)
 LUA_EXTENSIONS = (EXT_LUA,)
 
+# (H) A C++ operator overload / user-defined literal is defined with the reserved
+# (H) `operator` keyword heading the name (`operator==`, `operator[]`, `operator""_json`).
+# (H) It is invoked by operator/literal syntax, not a named call, so it is a dead-code
+# (H) reachability root; the keyword can only head such definitions, so this prefix on a
+# (H) C++ file uniquely identifies them (member or free function).
+CPP_OPERATOR_PREFIX = "operator"
+
 # (H) Package indicator files
 PKG_INIT_PY = "__init__.py"
 PKG_CARGO_TOML = "Cargo.toml"

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -1,4 +1,6 @@
 from .constants import (
+    CPP_EXTENSIONS,
+    CPP_OPERATOR_PREFIX,
     CYPHER_DEFAULT_LIMIT,
     GO_ROOT_FUNCTION_NAMES,
     PROTOCOL_BASE_QNS,
@@ -182,6 +184,7 @@ WHERE n.qualified_name STARTS WITH $project_prefix
         AND n.name IN {rust_root_names} AND n.path ENDS WITH '.rs')
     OR ('Method' IN labels(n)
         AND n.name IN {rust_trait_methods} AND n.path ENDS WITH '.rs')
+    OR {cpp_operator_clause}
     OR ANY(e IN $entry_points WHERE n.qualified_name ENDS WITH e)
     OR {module_clause}{test_clause}
   )
@@ -239,10 +242,19 @@ def build_dead_code_query(include_tests: bool, include_classes: bool = False) ->
         go_root_names=go_root_names,
         rust_root_names=rust_root_names,
         rust_trait_methods=rust_trait_methods,
+        cpp_operator_clause=_cpp_operator_root_clause(),
         protocol_stub_clause=_DEAD_CODE_PROTOCOL_STUB_CLAUSE.format(
             protocol_bases=protocol_bases
         ),
     )
+
+
+def _cpp_operator_root_clause() -> str:
+    # (H) A C++ operator overload / user-defined literal (name headed by the reserved
+    # (H) `operator` keyword) is invoked by operator/literal syntax the call graph does
+    # (H) not model, so it is a reachability root on any C++ file (member or free).
+    exts = " OR ".join(f"n.path ENDS WITH '{ext}'" for ext in CPP_EXTENSIONS)
+    return f"(n.name STARTS WITH '{CPP_OPERATOR_PREFIX}' AND ({exts}))"
 
 
 def _cypher_str_list(values: frozenset[str]) -> str:

--- a/codebase_rag/tests/test_dead_code_eval.py
+++ b/codebase_rag/tests/test_dead_code_eval.py
@@ -128,6 +128,39 @@ def test_rust_trait_methods_and_main_are_roots() -> None:
     assert "proj.frame.Frame.main" in dead
 
 
+def test_cpp_operator_overloads_are_roots() -> None:
+    # (H) A C++ operator overload / user-defined literal (member `operator==`, free
+    # (H) `operator<<`, UDL `operator""_json`) is invoked by operator/literal SYNTAX
+    # (H) (`a == b`, `os << x`, `1_json`), never by a named call the graph can see, so
+    # (H) it is a reachability root (like Python dunders / Rust trait methods), gated
+    # (H) by a C++ file extension. A regular uncalled method stays dead, and a non-C++
+    # (H) symbol whose name merely starts with `operator` is NOT rooted.
+    nodes = dict(
+        [
+            (
+                (_MODULE, "proj.json"),
+                {cs.KEY_QUALIFIED_NAME: "proj.json", cs.KEY_PATH: "json.hpp"},
+            ),
+            _method("proj.json.Json.operator_equal", "json.hpp"),
+            _method("proj.json.Json.operator_subscript", "json.hpp"),
+            _fn("proj.json.operator_left_shift", path="json.hpp"),
+            _fn('proj.json.operator_""_json', path="json.hpp"),
+            _method("proj.json.Json.push_back", "json.hpp"),
+            _fn("proj.mod.operator_equal", path="mod.py"),
+        ]
+    )
+    dead = dead_code_from_graph(nodes, [], _PREFIX, _CONFIG)
+    assert "proj.json.Json.operator_equal" not in dead
+    assert "proj.json.Json.operator_subscript" not in dead
+    assert "proj.json.operator_left_shift" not in dead
+    assert 'proj.json.operator_""_json' not in dead
+    # (H) A regular method with no caller is still dead -- rooting is prefix-scoped
+    # (H) to `operator`, not a blanket C++ exemption.
+    assert "proj.json.Json.push_back" in dead
+    # (H) The `operator` prefix only roots on a C++ file; a .py symbol stays dead.
+    assert "proj.mod.operator_equal" in dead
+
+
 def test_root_level_tests_dir_is_excluded() -> None:
     # (H) A top-level `tests/` dir (Rust integration tests `tests/client.rs`, a JS
     # (H) `tests/` folder) is test infrastructure. The `/tests/` pattern needs a

--- a/evals/dead_code.py
+++ b/evals/dead_code.py
@@ -97,6 +97,15 @@ def _is_rust_runtime_root(name: str, is_method: bool, path: str) -> bool:
     return is_method and name in cs.RUST_TRAIT_METHOD_NAMES
 
 
+def _is_cpp_operator_root(name: str, path: str) -> bool:
+    # (H) A C++ operator overload / user-defined literal (`operator==`, `operator[]`,
+    # (H) `operator""_json`) is invoked by operator/literal SYNTAX, not a named call the
+    # (H) graph can see, so it is a reachability root (like Python dunders / Rust trait
+    # (H) methods). `operator` heads every such definition (member or free), so the name
+    # (H) prefix on a C++ file identifies them uniquely.
+    return name.startswith(cs.CPP_OPERATOR_PREFIX) and path.endswith(cs.CPP_EXTENSIONS)
+
+
 def _matches_test_path(path: str, patterns: tuple[str, ...]) -> bool:
     # (H) Match test-path patterns against a leading-slash-normalized path so a dir
     # (H) pattern like `/tests/` also matches a ROOT `tests/` dir (Rust integration
@@ -212,6 +221,10 @@ def dead_code_from_graph(
             qn.rsplit(cs.SEPARATOR_DOT, 1)[-1],
             qn in method_qns,
             str(props.get(cs.KEY_PATH, "")),
+        ):
+            roots.add(qn)
+        elif _is_cpp_operator_root(
+            qn.rsplit(cs.SEPARATOR_DOT, 1)[-1], str(props.get(cs.KEY_PATH, ""))
         ):
             roots.add(qn)
         elif any(qn.endswith(entry) for entry in config.entry_points):


### PR DESCRIPTION
## Problem

Dogfooding dead-code detection against nlohmann/json (C++) surfaced 693 unreachable functions, of which **87 are operator overloads / user-defined literals** (`operator==`, `operator[]`, `operator()`, `operator++`, `operator<=>`, `operator""_json`, ...). These are invoked by operator/literal *syntax* (`a == b`, `it[k]`, `++it`, `1_json`) that the call graph does not model, so they report as dead even when internally used (verified: `iter_impl.hpp:511` calls `!operator==(other)`, and the library's own loops drive these iterators).

This is the direct C++ analog of the already-shipped Python `__dunder__` roots and Rust trait-method roots (`fmt`/`eq`/`next`): methods the language invokes with no visible call site are reachability roots, not dead code.

## Fix

Root any symbol whose name is headed by the reserved `operator` keyword on a C++ file (member or free function, plus UDLs). Applied to both dead-code surfaces that must stay in sync:
- `evals/dead_code.py` — `_is_cpp_operator_root(name, path)` in the candidate root loop.
- `codebase_rag/cypher_queries.py` — `_cpp_operator_root_clause()` added to `_DEAD_CODE_QUERY_TEMPLATE`.
- `codebase_rag/constants.py` — `CPP_OPERATOR_PREFIX`.

`operator` is a reserved keyword that can only head an operator/UDL definition, so a name-prefix check on a C++ extension identifies them uniquely with no false roots. Scoped to C++ extensions, so no other language is affected.

## Validation

- RED->GREEN test `test_cpp_operator_overloads_are_roots`: member/free operators and a UDL are rooted; a regular uncalled method stays dead; a non-C++ (`.py`) symbol named `operator_equal` is NOT rooted (extension gate).
- nlohmann/json dead-code: **693 -> 447** (all 87 operator entries rooted, plus ~159 transitive callees pulled into reachability).
- 49 dead-code + cpp-operator tests pass; ruff + ty clean.

Follow-up (same dogfood session): the next-largest class is `to_json`/`from_json` ADL customization points (~153), which needs real ADL modeling.