### PR TITLE
feat(query): scope Cypher generation to active project in multi-project databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ An accurate Retrieval-Augmented Generation (RAG) system that analyzes multi-lang
 | PHP | Fully Supported | .php | ✓ | ✓ | ✓ | - | Classes, interfaces, traits, enums, namespaces, PHP 8 attributes |
 | Python | Fully Supported | .py | ✓ | ✓ | ✓ | ✓ | Type inference, decorators, nested functions |
 | Rust | Fully Supported | .rs | ✓ | ✓ | ✓ | ✓ | impl blocks, associated functions |
-| TypeScript | Fully Supported | .ts, .tsx | ✓ | ✓ | ✓ | - | Interfaces, type aliases, enums, namespaces, ES6/CommonJS modules |
+| TypeScript (TSX) | Fully Supported | .tsx | ✓ | ✓ | ✓ | - | All TypeScript features plus JSX elements and components |
+| TypeScript | Fully Supported | .ts | ✓ | ✓ | ✓ | - | Interfaces, type aliases, enums, namespaces, ES6/CommonJS modules |
 | Go | In Development | .go | ✓ | ✓ | ✓ | - | Methods, type declarations |
 | Scala | In Development | .scala, .sc | ✓ | ✓ | ✓ | - | Case classes, objects |
 <!-- /SECTION:supported_languages -->
@@ -689,6 +690,7 @@ The knowledge graph uses the following node types and relationships:
 - **PHP**: `anonymous_function`, `arrow_function`, `class_declaration`, `enum_declaration`, `function_definition`, `interface_declaration`, `method_declaration`, `trait_declaration`
 - **Python**: `class_definition`, `function_definition`
 - **Rust**: `closure_expression`, `enum_item`, `function_item`, `function_signature_item`, `impl_item`, `struct_item`, `trait_item`, `type_item`, `union_item`
+- **TypeScript (TSX)**: `abstract_class_declaration`, `arrow_function`, `class`, `class_declaration`, `enum_declaration`, `function_declaration`, `function_expression`, `function_signature`, `generator_function_declaration`, `interface_declaration`, `internal_module`, `method_definition`, `type_alias_declaration`
 - **TypeScript**: `abstract_class_declaration`, `arrow_function`, `class`, `class_declaration`, `enum_declaration`, `function_declaration`, `function_expression`, `function_signature`, `generator_function_declaration`, `interface_declaration`, `internal_module`, `method_definition`, `type_alias_declaration`
 - **Go**: `function_declaration`, `method_declaration`, `type_alias`, `type_spec`
 - **Scala**: `class_definition`, `function_declaration`, `function_definition`, `object_definition`, `trait_definition`
@@ -715,7 +717,7 @@ The knowledge graph uses the following node types and relationships:
 | ModuleImplementation | IMPLEMENTS | ModuleInterface |
 | Project | DEPENDS_ON_EXTERNAL | ExternalPackage |
 | Function, Method | CALLS | Function, Method |
-| Module, Function, Method | REFERENCES | Function, Method |
+| Module, Function, Method | REFERENCES | Function, Method, Class |
 | Module, Function, Method | INSTANTIATES | Class |
 <!-- /SECTION:relationship_schemas -->
 

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -59,6 +59,11 @@ LIMIT {CYPHER_DEFAULT_LIMIT}"""
 
 CYPHER_EXAMPLE_LIMIT_ONE = """MATCH (f:File) RETURN f.path as path, f.name as name, labels(f) as type LIMIT 1"""
 
+CYPHER_EXAMPLE_PROJECT_SCOPED = f"""MATCH (c:Class)
+WHERE c.qualified_name STARTS WITH 'myproject.'
+RETURN c.name AS name, c.qualified_name AS qualified_name, labels(c) AS type
+LIMIT {CYPHER_DEFAULT_LIMIT}"""
+
 CYPHER_EXAMPLE_CLASS_METHODS = f"""MATCH (c:Class)-[:DEFINES_METHOD]->(m:Method)
 WHERE c.name = 'UserService'
 RETURN c.name AS className, m.name AS methodName, m.qualified_name AS qualified_name, labels(m) AS type

--- a/codebase_rag/main.py
+++ b/codebase_rag/main.py
@@ -1529,7 +1529,7 @@ def _initialize_services_and_agent(
     )
     _validate_provider_config(cs.ModelRole.CYPHER, settings.active_cypher_config)
 
-    cypher_generator = CypherGenerator()
+    cypher_generator = CypherGenerator(active_projects=active_projects)
     code_retriever = CodeRetriever(project_root=repo_path, ingestor=ingestor)
     file_reader = FileReader(project_root=repo_path)
     file_writer = FileWriter(project_root=repo_path)

--- a/codebase_rag/prompts.py
+++ b/codebase_rag/prompts.py
@@ -204,6 +204,11 @@ def build_rag_orchestrator_prompt(
     )
 
 
+def _cypher_literal(name: str) -> str:
+    # (H) Escape for a single-quoted Cypher literal so apostrophe names stay valid.
+    return name.replace("\\", "\\\\").replace("'", "\\'")
+
+
 def _format_cypher_project_scope(active_projects: list[str] | None) -> str:
     if not active_projects:
         return (
@@ -213,21 +218,23 @@ def _format_cypher_project_scope(active_projects: list[str] | None) -> str:
         )
     if len(active_projects) == 1:
         name = active_projects[0]
+        literal = _cypher_literal(name)
         return (
             f"\n**Project Scoping (REQUIRED)**: All queries are scoped to the "
             f"project `{name}`. Unless the user explicitly asks about other "
             f"projects, ALWAYS constrain matched code nodes with "
-            f"`WHERE <var>.qualified_name STARTS WITH '{name}.'`. For `Project` "
-            f"nodes match `(p:Project {{name: '{name}'}})`.\n"
+            f"`WHERE <var>.qualified_name STARTS WITH '{literal}.'`. For `Project` "
+            f"nodes match `(p:Project {{name: '{literal}'}})`.\n"
         )
     scoped = " OR ".join(
-        f"<var>.qualified_name STARTS WITH '{p}.'" for p in active_projects
+        f"<var>.qualified_name STARTS WITH '{_cypher_literal(p)}.'"
+        for p in active_projects
     )
     return (
         f"\n**Project Scoping**: The active projects are "
         f"{', '.join(f'`{p}`' for p in active_projects)}. To restrict to one "
         f"project, filter `<var>.qualified_name STARTS WITH '<projectName>.'`. "
-        f"To restrict to the active set, filter `{scoped}`.\n"
+        f"To restrict to the active set, filter `({scoped})`.\n"
     )
 
 

--- a/codebase_rag/prompts.py
+++ b/codebase_rag/prompts.py
@@ -8,6 +8,7 @@ from .cypher_queries import (
     CYPHER_EXAMPLE_FIND_FILE,
     CYPHER_EXAMPLE_KEYWORD_SEARCH,
     CYPHER_EXAMPLE_LIMIT_ONE,
+    CYPHER_EXAMPLE_PROJECT_SCOPED,
     CYPHER_EXAMPLE_PYTHON_FILES,
     CYPHER_EXAMPLE_README,
     CYPHER_EXAMPLE_TASKS,
@@ -203,11 +204,39 @@ def build_rag_orchestrator_prompt(
     )
 
 
-CYPHER_SYSTEM_PROMPT = f"""
+def _format_cypher_project_scope(active_projects: list[str] | None) -> str:
+    if not active_projects:
+        return (
+            "\n**Project Scoping**: The database may contain multiple indexed "
+            "projects. When the user names a project, scope the query by filtering "
+            "`WHERE <var>.qualified_name STARTS WITH '<projectName>.'`.\n"
+        )
+    if len(active_projects) == 1:
+        name = active_projects[0]
+        return (
+            f"\n**Project Scoping (REQUIRED)**: All queries are scoped to the "
+            f"project `{name}`. Unless the user explicitly asks about other "
+            f"projects, ALWAYS constrain matched code nodes with "
+            f"`WHERE <var>.qualified_name STARTS WITH '{name}.'`. For `Project` "
+            f"nodes match `(p:Project {{name: '{name}'}})`.\n"
+        )
+    scoped = " OR ".join(
+        f"<var>.qualified_name STARTS WITH '{p}.'" for p in active_projects
+    )
+    return (
+        f"\n**Project Scoping**: The active projects are "
+        f"{', '.join(f'`{p}`' for p in active_projects)}. To restrict to one "
+        f"project, filter `<var>.qualified_name STARTS WITH '<projectName>.'`. "
+        f"To restrict to the active set, filter `{scoped}`.\n"
+    )
+
+
+def build_cypher_system_prompt(active_projects: list[str] | None = None) -> str:
+    return f"""
 You are an expert translator that converts natural language questions about code structure into precise Neo4j Cypher queries.
 
 {GRAPH_SCHEMA_AND_RULES}
-
+{_format_cypher_project_scope(active_projects)}
 **3. Query Optimization Rules**
 
 - **LIMIT Results**: ALWAYS add `LIMIT 50` to queries that list items. This prevents overwhelming responses.
@@ -246,16 +275,27 @@ cypher// "What methods does UserService have?" or "Show me methods in UserServic
 // Use `ENDS WITH` to match the class by short name since qualified_name contains full path.
 {CYPHER_EXAMPLE_CLASS_METHODS}
 
+**Pattern: Scoping Results to a Single Project**
+cypher// "show all classes in myproject" (multi-project database)
+// Filter on the qualified_name prefix to keep results within one project.
+{CYPHER_EXAMPLE_PROJECT_SCOPED}
+
 **4. Output Format**
 Provide only the Cypher query.
 """
 
+
+# (H) Backwards-compatible default (no project scope injected)
+CYPHER_SYSTEM_PROMPT = build_cypher_system_prompt()
+
+
 # (H) Stricter prompt for less capable open-source/local models (e.g., Ollama)
-LOCAL_CYPHER_SYSTEM_PROMPT = f"""
+def build_local_cypher_system_prompt(active_projects: list[str] | None = None) -> str:
+    return f"""
 You are a Neo4j Cypher query generator. You ONLY respond with a valid Cypher query. Do not add explanations or markdown.
 
 {GRAPH_SCHEMA_AND_RULES}
-
+{_format_cypher_project_scope(active_projects)}
 **CRITICAL RULES FOR QUERY GENERATION:**
 1.  **NO `UNION`**: Never use the `UNION` clause. Generate a single, simple `MATCH` query.
 2.  **BIND and ALIAS**: You must bind every node you use to a variable (e.g., `MATCH (f:File)`). You must use that variable to access properties and alias every returned property (e.g., `RETURN f.path AS path`).
@@ -320,7 +360,18 @@ You are a Neo4j Cypher query generator. You ONLY respond with a valid Cypher que
     ```cypher
     {CYPHER_EXAMPLE_CLASS_METHODS}
     ```
+
+*   **Natural Language:** "show all classes in myproject"
+*   **Cypher Query (scope by qualified_name prefix in a multi-project database):**
+    ```cypher
+    {CYPHER_EXAMPLE_PROJECT_SCOPED}
+    ```
 """
+
+
+# (H) Backwards-compatible default (no project scope injected)
+LOCAL_CYPHER_SYSTEM_PROMPT = build_local_cypher_system_prompt()
+
 
 OPTIMIZATION_PROMPT = """
 I want you to analyze my {language} codebase and propose specific optimizations based on best practices.

--- a/codebase_rag/services/llm.py
+++ b/codebase_rag/services/llm.py
@@ -13,8 +13,8 @@ from .. import exceptions as ex
 from .. import logs as ls
 from ..config import ModelConfig, load_cgr_instructions, settings
 from ..prompts import (
-    CYPHER_SYSTEM_PROMPT,
-    LOCAL_CYPHER_SYSTEM_PROMPT,
+    build_cypher_system_prompt,
+    build_local_cypher_system_prompt,
     build_rag_orchestrator_prompt,
 )
 from ..providers.base import get_provider_from_config
@@ -111,15 +111,15 @@ def _validate_call_procedures(query: str) -> None:
 class CypherGenerator:
     __slots__ = ("agent",)
 
-    def __init__(self) -> None:
+    def __init__(self, active_projects: list[str] | None = None) -> None:
         try:
             config = settings.active_cypher_config
             llm = _create_provider_model(config)
 
             system_prompt = (
-                LOCAL_CYPHER_SYSTEM_PROMPT
+                build_local_cypher_system_prompt(active_projects)
                 if config.provider == cs.Provider.OLLAMA
-                else CYPHER_SYSTEM_PROMPT
+                else build_cypher_system_prompt(active_projects)
             )
 
             self.agent = Agent(

--- a/codebase_rag/tests/test_cypher_project_scope.py
+++ b/codebase_rag/tests/test_cypher_project_scope.py
@@ -32,6 +32,18 @@ class TestCypherSystemPromptProjectScope:
         prompt = build_cypher_system_prompt(active_projects=None)
         assert "qualified_name STARTS WITH 'myproject.'" in prompt
 
+    def test_apostrophe_in_project_name_is_escaped(self) -> None:
+        prompt = build_cypher_system_prompt(active_projects=["team's-app"])
+        assert "team\\'s-app" in prompt
+        assert "'team's-app" not in prompt
+
+    def test_multiple_projects_wrap_or_chain_in_parentheses(self) -> None:
+        prompt = build_cypher_system_prompt(active_projects=["a", "b"])
+        assert (
+            "(<var>.qualified_name STARTS WITH 'a.' OR "
+            "<var>.qualified_name STARTS WITH 'b.')" in prompt
+        )
+
 
 class TestCypherGeneratorProjectScope:
     @patch("codebase_rag.services.llm.settings")

--- a/codebase_rag/tests/test_cypher_project_scope.py
+++ b/codebase_rag/tests/test_cypher_project_scope.py
@@ -1,0 +1,58 @@
+from unittest.mock import MagicMock, patch
+
+from codebase_rag import constants as cs
+from codebase_rag.prompts import (
+    build_cypher_system_prompt,
+    build_local_cypher_system_prompt,
+)
+from codebase_rag.services.llm import CypherGenerator
+
+
+class TestCypherSystemPromptProjectScope:
+    def test_single_project_instructs_starts_with_scoping(self) -> None:
+        prompt = build_cypher_system_prompt(active_projects=["myproj"])
+        assert "myproj" in prompt
+        assert "STARTS WITH 'myproj.'" in prompt
+
+    def test_no_projects_notes_multiple_projects_possible(self) -> None:
+        prompt = build_cypher_system_prompt(active_projects=None)
+        assert "STARTS WITH" in prompt
+
+    def test_multiple_projects_lists_each(self) -> None:
+        prompt = build_cypher_system_prompt(active_projects=["a", "b"])
+        assert "STARTS WITH 'a.'" in prompt
+        assert "STARTS WITH 'b.'" in prompt
+
+    def test_local_prompt_single_project_scopes(self) -> None:
+        prompt = build_local_cypher_system_prompt(active_projects=["only_one"])
+        assert "only_one" in prompt
+        assert "STARTS WITH 'only_one.'" in prompt
+
+    def test_project_scoped_example_present(self) -> None:
+        prompt = build_cypher_system_prompt(active_projects=None)
+        assert "qualified_name STARTS WITH 'myproject.'" in prompt
+
+
+class TestCypherGeneratorProjectScope:
+    @patch("codebase_rag.services.llm.settings")
+    @patch("codebase_rag.services.llm.get_provider_from_config")
+    @patch("codebase_rag.services.llm.Agent")
+    def test_generator_threads_project_into_system_prompt(
+        self,
+        mock_agent: MagicMock,
+        mock_get_provider: MagicMock,
+        mock_settings: MagicMock,
+    ) -> None:
+        mock_config = MagicMock()
+        mock_config.provider = cs.Provider.GOOGLE
+        mock_settings.active_cypher_config = mock_config
+        mock_settings.AGENT_RETRIES = 3
+
+        mock_provider = MagicMock()
+        mock_provider.create_model.return_value = MagicMock()
+        mock_get_provider.return_value = mock_provider
+
+        CypherGenerator(active_projects=["scoped_proj"])
+
+        system_prompt = mock_agent.call_args.kwargs["system_prompt"]
+        assert "STARTS WITH 'scoped_proj.'" in system_prompt

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.236"
+version = "0.0.238"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #500.

## Problem

When multiple projects are indexed in one Memgraph database, the Cypher *translator* prompt had no project awareness, so LLM-generated queries returned results from every project with no way to scope to the one in focus. The orchestrator prompt already carried project-scope guidance, but the component that actually writes Cypher did not.

## Change

- `prompts.py`: `build_cypher_system_prompt(active_projects)` and `build_local_cypher_system_prompt(active_projects)` inject a project-scope block. A single active project produces a REQUIRED instruction to constrain matches with `WHERE <var>.qualified_name STARTS WITH '<project>.'`; multiple projects list each; none falls back to generic scoping guidance. Module-level `CYPHER_SYSTEM_PROMPT` / `LOCAL_CYPHER_SYSTEM_PROMPT` remain as the no-scope defaults.
- `cypher_queries.py`: new `CYPHER_EXAMPLE_PROJECT_SCOPED` demonstrating prefix scoping; wired into both prompts' example sections.
- `services/llm.py`: `CypherGenerator(active_projects=None)` builds the scoped prompt.
- `main.py`: threads the session's active projects into `CypherGenerator`.

Scope injection happens at the generation layer (via the prompt), not by string-rewriting generated Cypher, since rewriting would break `count()`, `CALL` procedures, and multi-variable matches. The MCP server queries across all indexed projects, so it keeps the multi-project default.

## Tests

`test_cypher_project_scope.py` (RED first): single/multi/no-project prompt scoping, local prompt scoping, scoped example presence, and that `CypherGenerator` threads the project name into the system prompt. Full unit suite (4423) and integration suite (146) green.