### PR TITLE
fix(cpp): register a bodied templated class once under its natural qn

### DIFF
--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -281,6 +281,21 @@ class ClassIngestMixin:
         # (H) solely via specializations) has no other node, so it must be kept. We
         # (H) cannot tell which until every file's definitions are in, so defer the
         # (H) forward declaration and decide in resolve_deferred_forward_declarations.
+        # (H) The class query captures a templated class twice: the inner
+        # (H) class_specifier AND its template_declaration wrapper. The wrapper is the
+        # (H) canonical node (it carries the template params and always registers with
+        # (H) its natural qn); the inner specifier is redundant. Drop the inner one
+        # (H) outright -- for bodied definitions too, not just bodyless forward decls --
+        # (H) so the class registers exactly once. Registering both suffixes the second
+        # (H) `@line`, splitting members (which attach to the bodied specifier) away
+        # (H) from the natural qn that callers reference, orphaning the whole class.
+        if (
+            class_node.type in cs.CPP_TYPE_SPECIFIER_NODE_TYPES
+            and class_node.parent is not None
+            and class_node.parent.type == cs.CppNodeType.TEMPLATE_DECLARATION
+        ):
+            return
+
         type_spec = class_node
         if class_node.type == cs.CppNodeType.TEMPLATE_DECLARATION:
             type_spec = next(
@@ -296,15 +311,6 @@ class ClassIngestMixin:
             and type_spec.type in cs.CPP_TYPE_SPECIFIER_NODE_TYPES
             and type_spec.child_by_field_name(cs.FIELD_BODY) is None
         ):
-            # (H) The inner bodyless specifier of a template forward decl is redundant
-            # (H) with its template_declaration wrapper (the canonical template node),
-            # (H) which is deferred separately; drop the inner one outright.
-            if (
-                class_node.type in cs.CPP_TYPE_SPECIFIER_NODE_TYPES
-                and class_node.parent is not None
-                and class_node.parent.type == cs.CppNodeType.TEMPLATE_DECLARATION
-            ):
-                return
             if allow_defer:
                 deferred_identity = id_.resolve_class_identity(
                     class_node, module_qn, language, lang_config, file_path
@@ -364,8 +370,15 @@ class ClassIngestMixin:
         parent_label, parent_qn = self._determine_function_parent(
             class_node, class_qn, module_qn, lang_config, language
         )
+        # (H) For a templated class the canonical node is the template_declaration
+        # (H) wrapper, which has no `body` field. Its members -- base clause, fields,
+        # (H) methods -- live on the inner class_specifier (type_spec). Extract them
+        # (H) from there so they bind to the class's natural qn. For a plain class
+        # (H) type_spec is class_node, so this is a no-op for non-templates and for
+        # (H) Go/Rust (which never take the template_declaration branch).
+        member_node = type_spec if type_spec is not None else class_node
         rel.create_class_relationships(
-            class_node,
+            member_node,
             class_qn,
             module_qn,
             parent_label,
@@ -384,7 +397,9 @@ class ClassIngestMixin:
             # (H) Record this class's member-field types now (from the class body,
             # (H) usually a header) so out-of-line method bodies in other files can
             # (H) resolve `field_.method()` via the field's type at call resolution.
-            if field_types := CppTypeInferenceEngine().build_field_type_map(class_node):
+            if field_types := CppTypeInferenceEngine().build_field_type_map(
+                member_node
+            ):
                 self.class_field_types[class_qn] = field_types
         elif language == cs.SupportedLanguage.GO:
             # (H) Record Go struct field types so a field-hop receiver
@@ -403,7 +418,7 @@ class ClassIngestMixin:
             if guard_inner := rust_engine.build_field_guard_inner_map(class_node):
                 self.class_field_guard_inner[class_qn] = guard_inner
         self._ingest_class_methods(
-            class_node,
+            member_node,
             class_qn,
             language,
             lang_queries,

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -290,7 +290,8 @@ class ClassIngestMixin:
         # (H) `@line`, splitting members (which attach to the bodied specifier) away
         # (H) from the natural qn that callers reference, orphaning the whole class.
         if (
-            class_node.type in cs.CPP_TYPE_SPECIFIER_NODE_TYPES
+            language == cs.SupportedLanguage.CPP
+            and class_node.type in cs.CPP_TYPE_SPECIFIER_NODE_TYPES
             and class_node.parent is not None
             and class_node.parent.type == cs.CppNodeType.TEMPLATE_DECLARATION
         ):

--- a/codebase_rag/tests/test_cpp_template_class_registration.py
+++ b/codebase_rag/tests/test_cpp_template_class_registration.py
@@ -1,0 +1,68 @@
+# (H) A bodied templated C++ class (`template<typename T> class Box { void open(); };`)
+# (H) is captured twice by the class query: once as the template_declaration wrapper
+# (H) (no `body` field -> no methods attach) and once as the inner class_specifier
+# (H) (has the body -> methods attach). Registering both suffixes the second with
+# (H) `@line`, so every method lives under `Box@N.*` while callers reference the
+# (H) natural `Box.*` -> the whole class is unreachable. The class must register
+# (H) exactly ONCE, under its natural qn, with methods and member calls on it.
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.conftest import get_node_names, get_relationships, run_updater
+
+
+def _write(project: Path, body: str) -> None:
+    (project / "box.cpp").write_text(body, encoding="utf-8")
+
+
+def test_templated_class_registers_once_under_natural_qn(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    _write(
+        temp_repo,
+        "template<typename T>\n"
+        "class Box {\n"
+        "  public:\n"
+        "    void open() { close(); }\n"
+        "    void close() {}\n"
+        "};\n",
+    )
+    run_updater(temp_repo, mock_ingestor, skip_if_missing="cpp")
+
+    classes = {
+        c
+        for c in get_node_names(mock_ingestor, "Class")
+        if c.endswith("Box") or ".Box@" in c or ".Box" in c
+    }
+    # (H) exactly one Box class node, no @line duplicate
+    box_nodes = {c for c in classes if c.rsplit(".", 1)[-1].split("@")[0] == "Box"}
+    assert box_nodes == {f"{temp_repo.name}.box.Box"}, box_nodes
+
+    methods = get_node_names(mock_ingestor, "Method")
+    assert f"{temp_repo.name}.box.Box.open" in methods, sorted(
+        m for m in methods if "Box" in m
+    )
+    assert f"{temp_repo.name}.box.Box.close" in methods
+
+
+def test_templated_class_member_call_resolves_to_natural_qn(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    _write(
+        temp_repo,
+        "template<typename T>\n"
+        "class Box {\n"
+        "  public:\n"
+        "    void open() { close(); }\n"
+        "    void close() {}\n"
+        "};\n",
+    )
+    run_updater(temp_repo, mock_ingestor, skip_if_missing="cpp")
+    calls = {
+        (c.args[0][2], c.args[2][2]) for c in get_relationships(mock_ingestor, "CALLS")
+    }
+    p = temp_repo.name
+    # (H) the in-class `open() { close(); }` edge must land on the same natural qn
+    assert (f"{p}.box.Box.open", f"{p}.box.Box.close") in calls, sorted(
+        e for e in calls if "Box" in e[0]
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.238"
+version = "0.0.241"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Problem

A bodied templated C++ class was captured twice by the class query: once as the `template_declaration` wrapper and once as the inner `class_specifier`. Both reached `_process_class_node`, so the class registered **two** nodes. The wrapper (no `body` field) claimed the natural qn but attached no members; the inner specifier registered with a `@line` suffix and received all the methods, fields, and base clause.

Result: every method lived under `Foo@N.*` while callers reference the natural `Foo.*`, so the whole class was orphaned from the call graph. In `nlohmann/json`, 156 of 335 class nodes had an empty natural twin, keeping the entire `parser`/`json_sax_*` cluster unreachable in dead-code analysis.

## Fix

The `template_declaration` is the canonical node (it carries the template parameters and always registers under its natural qn). Drop the inner `class_specifier` outright for bodied templates too, not just bodyless forward decls, and route member extraction (base clause, field-type map, methods) through the inner specifier so members bind to the class's natural qn.

This adds **no new edges** — it only makes the method/field nodes exist under the qn that callers already reference, so previously-dangling edges land.

## Impact

- Dead-code eval: `nlohmann/json` 436 -> 427, `fmt` 1287 -> 877 (heavily templated; all revived nodes come from pre-existing edges).
- 280 C++ tests pass; full non-integration suite green.
- No cross-language effect: the drop is gated on C++ node types, and for non-C++ (and non-template C++) the member node equals the class node, so behavior is unchanged.

## Test

`test_cpp_template_class_registration.py` (RED before, GREEN after): a templated class registers exactly one Class node under its natural qn, its methods attach to that qn, and an in-class member call resolves to it.