### PR TITLE
fix(ci): build darwin-amd64 binary on macos-15-intel runner

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -27,7 +27,7 @@ jobs:
           - os: windows-latest
             platform: windows
             arch: amd64
-          - os: macos-latest
+          - os: macos-15-intel
             platform: darwin
             arch: amd64
           - os: macos-14
@@ -64,9 +64,9 @@ jobs:
         shell: bash
         run: |
           if [ "${{ matrix.platform }}" = "windows" ]; then
-            ./dist/code-graph-rag-*.exe --version
+            ./dist/code-graph-rag-${{ matrix.platform }}-${{ matrix.arch }}.exe --version
           else
-            ./dist/code-graph-rag-* --version
+            ./dist/code-graph-rag-${{ matrix.platform }}-${{ matrix.arch }} --version
           fi
 
       - name: Upload binary artifact

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.245"
+version = "0.0.246"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Problem

The v0.0.246 release shipped only three binaries despite a four-platform matrix. The `darwin-amd64` matrix entry runs on `macos-latest`, which GitHub now maps to macos-15-arm64. The binary name is derived from `platform.machine()` at runtime, so that job silently built a second `code-graph-rag-darwin-arm64` that overwrote the real one on release upload, and Intel Mac users got no binary at all.

## Fix

- Pin the `darwin-amd64` matrix entry to `macos-15-intel`, GitHub's free x64 macOS runner.
- Smoke-test the exact expected filename (`code-graph-rag-<platform>-<arch>`) instead of a glob, so any future runner-arch/matrix mismatch fails the job loudly instead of silently mislabeling a release asset.