### PR TITLE
fix(parsers): key query cache by Language object to prevent id reuse collisions

### DIFF
--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple
 
 from loguru import logger
-from tree_sitter import Node, Query, QueryCursor
+from tree_sitter import Language, Node, Query, QueryCursor
 
 from .. import constants as cs
 from .. import logs
@@ -25,13 +25,16 @@ if TYPE_CHECKING:
     from ..services import IngestorProtocol
     from ..types_defs import FunctionRegistryTrieProtocol
 
-_QUERY_CACHE: dict[tuple[int, str], Query] = {}
-_QUERY_LAST: tuple[tuple[int, str], Query] | None = None
+_QUERY_CACHE: dict[tuple[Language, str], Query] = {}
+_QUERY_LAST: tuple[tuple[Language, str], Query] | None = None
 
 
-def get_cached_query(language_obj, query_text: str) -> Query:
+def get_cached_query(language_obj: Language, query_text: str) -> Query:
+    # (H) Key by the Language itself, never id(): Language hashes by grammar
+    # (H) pointer, so wrappers dedupe, and the dict pins the key so a GC'd
+    # (H) wrapper's address can't be reused to serve a wrong-grammar Query.
     global _QUERY_LAST
-    key = (id(language_obj), query_text)
+    key = (language_obj, query_text)
     if _QUERY_LAST is not None and _QUERY_LAST[0] == key:
         return _QUERY_LAST[1]
     if key not in _QUERY_CACHE:

--- a/codebase_rag/tests/test_query_cache.py
+++ b/codebase_rag/tests/test_query_cache.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import pytest
+from tree_sitter import Language
+
+from codebase_rag.parsers.utils import get_cached_query
+
+try:
+    import tree_sitter_javascript as tsjs
+
+    JS_AVAILABLE = True
+except ImportError:
+    JS_AVAILABLE = False
+
+PATTERN = "(function_declaration) @f"
+
+
+@pytest.mark.skipif(not JS_AVAILABLE, reason="tree-sitter-javascript not available")
+def test_cache_keyed_by_grammar_not_wrapper_address() -> None:
+    # Regression: the cache was keyed by id(language_obj) without retaining
+    # the wrapper, so a GC'd wrapper's address could be reused by a Language
+    # for a different grammar and serve its Query, silently dropping captures.
+    # Keying by the Language itself (grammar identity) makes distinct wrappers
+    # of the same grammar share one entry and pins the key alive.
+    wrapper_a = Language(tsjs.language())
+    wrapper_b = Language(tsjs.language())
+    assert id(wrapper_a) != id(wrapper_b)
+    assert get_cached_query(wrapper_a, PATTERN) is get_cached_query(wrapper_b, PATTERN)

--- a/codebase_rag/tests/test_query_cache.py
+++ b/codebase_rag/tests/test_query_cache.py
@@ -17,11 +17,11 @@ PATTERN = "(function_declaration) @f"
 
 @pytest.mark.skipif(not JS_AVAILABLE, reason="tree-sitter-javascript not available")
 def test_cache_keyed_by_grammar_not_wrapper_address() -> None:
-    # Regression: the cache was keyed by id(language_obj) without retaining
-    # the wrapper, so a GC'd wrapper's address could be reused by a Language
-    # for a different grammar and serve its Query, silently dropping captures.
-    # Keying by the Language itself (grammar identity) makes distinct wrappers
-    # of the same grammar share one entry and pins the key alive.
+    # (H) Regression: the cache was keyed by id(language_obj) without retaining
+    # (H) the wrapper, so a GC'd wrapper's address could be reused by a Language
+    # (H) for a different grammar and serve its Query, silently dropping captures.
+    # (H) Keying by the Language itself (grammar identity) makes distinct wrappers
+    # (H) of the same grammar share one entry and pins the key alive.
     wrapper_a = Language(tsjs.language())
     wrapper_b = Language(tsjs.language())
     assert id(wrapper_a) != id(wrapper_b)

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.245"
+version = "0.0.246"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Problem

The JS/TS assignment-function ingestion tests (`test_assignment_arrow_functions_are_ingested`, `test_object_literal_methods_are_ingested`, `test_export_const_function_expression`, ...) flake in CI, almost exclusively on py3.13 jobs, across all three OSes. This is what failed `Unit Tests (ubuntu-latest, py3.13)` on #643 and several other recent PR runs.

## Root cause

`get_cached_query` keyed its module-level cache on `(id(language_obj), query_text)` without retaining the `Language` wrapper. `Query` does not hold a Python reference to its `Language` either (refcount stays at baseline after construction). So once a test's wrapper is garbage collected, a later `Language` allocation (possibly for a different grammar) can land at the same address, and the cache serves a `Query` compiled for the wrong grammar. Captures silently come back empty (the code path swallows the error into a debug log), and the assignment-arrow tests assert False.

Whether an address gets reused depends on allocator and GC timing, which is why the failures are nondeterministic and skew toward py3.13.

## Fix

Key the cache on the `Language` object itself. `Language.__hash__`/`__eq__` follow the underlying grammar pointer, so distinct wrappers of the same grammar share one cache entry, the dict pins the key alive, and an address can never be reused into a stale hit.

RED: `test_query_cache.py::test_cache_keyed_by_grammar_not_wrapper_address` fails on main (two wrappers of the same grammar get separate cache entries). GREEN with the one-line key change.

Full non-integration suite: 4399 passed, 5 skipped.