### PR TITLE
feat(graph): structural integrity audit validating graphs against documented schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,18 +664,18 @@ The knowledge graph uses the following node types and relationships:
 | Project | `{name: string}` |
 | Package | `{qualified_name: string, name: string, path: string, absolute_path: string}` |
 | Folder | `{path: string, name: string, absolute_path: string}` |
-| File | `{path: string, name: string, extension: string, absolute_path: string}` |
-| Module | `{qualified_name: string, name: string, path: string, absolute_path: string}` |
-| Class | `{qualified_name: string, name: string, decorators: list[string], path: string, absolute_path: string}` |
-| Function | `{qualified_name: string, name: string, decorators: list[string], path: string, absolute_path: string}` |
-| Method | `{qualified_name: string, name: string, decorators: list[string], path: string, absolute_path: string}` |
-| Interface | `{qualified_name: string, name: string, path: string, absolute_path: string}` |
-| Enum | `{qualified_name: string, name: string, path: string, absolute_path: string}` |
-| Type | `{qualified_name: string, name: string}` |
-| Union | `{qualified_name: string, name: string}` |
-| ModuleInterface | `{qualified_name: string, name: string, path: string, absolute_path: string}` |
-| ModuleImplementation | `{qualified_name: string, name: string, path: string, absolute_path: string, implements_module: string}` |
-| ExternalPackage | `{name: string, version_spec: string}` |
+| File | `{path: string, name: string, extension: string?, absolute_path: string}` |
+| Module | `{qualified_name: string, name: string, path: string, absolute_path: string, start_line: int?, end_line: int?}` |
+| Class | `{qualified_name: string, name: string, decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
+| Function | `{qualified_name: string, name: string, decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
+| Method | `{qualified_name: string, name: string, decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?, is_property: boolean?}` |
+| Interface | `{qualified_name: string, name: string, path: string, absolute_path: string, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
+| Enum | `{qualified_name: string, name: string, path: string, absolute_path: string, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
+| Type | `{qualified_name: string, name: string, path: string?, absolute_path: string?, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
+| Union | `{qualified_name: string, name: string, path: string?, absolute_path: string?, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
+| ModuleInterface | `{qualified_name: string, name: string, path: string, absolute_path: string, module_type: string}` |
+| ModuleImplementation | `{qualified_name: string, name: string, path: string, absolute_path: string, implements_module: string, module_type: string}` |
+| ExternalPackage | `{name: string}` |
 | ExternalModule | `{qualified_name: string, name: string, path: string}` |
 <!-- /SECTION:node_schemas -->
 
@@ -705,18 +705,18 @@ The knowledge graph uses the following node types and relationships:
 | Project, Package, Folder | CONTAINS_FOLDER | Folder |
 | Project, Package, Folder | CONTAINS_FILE | File |
 | Project, Package, Folder | CONTAINS_MODULE | Module |
-| Module | DEFINES | Class, Function |
-| Class | DEFINES_METHOD | Method |
+| Module, Function, Method | DEFINES | Class, Function, Enum, Interface, Type, Union, Module |
+| Class, Interface, Enum, Type, Union | DEFINES_METHOD | Method |
 | Module | IMPORTS | Module, ExternalModule |
 | Module | EXPORTS | Class, Function |
 | Module | EXPORTS_MODULE | ModuleInterface |
 | Module | IMPLEMENTS_MODULE | ModuleImplementation |
-| Class | INHERITS | Class |
-| Class | IMPLEMENTS | Interface |
+| Class, Interface, Function | INHERITS | Class, Interface, Function |
+| Class, Enum | IMPLEMENTS | Interface |
 | Method | OVERRIDES | Method |
 | ModuleImplementation | IMPLEMENTS | ModuleInterface |
 | Project | DEPENDS_ON_EXTERNAL | ExternalPackage |
-| Function, Method | CALLS | Function, Method |
+| Module, Function, Method | CALLS | Function, Method, Enum, Type |
 | Module, Function, Method | REFERENCES | Function, Method, Class |
 | Module, Function, Method | INSTANTIATES | Class |
 <!-- /SECTION:relationship_schemas -->

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -654,6 +654,40 @@ class RelationshipType(StrEnum):
     DEPENDS_ON_EXTERNAL = "DEPENDS_ON_EXTERNAL"
 
 
+class AuditCheck(StrEnum):
+    ORPHAN_NODE = "orphan_node"
+    UNDOCUMENTED_LABEL = "undocumented_label"
+    UNDOCUMENTED_PROPERTY = "undocumented_property"
+    MISSING_REQUIRED_PROPERTY = "missing_required_property"
+    UNDOCUMENTED_RELATIONSHIP = "undocumented_relationship"
+
+
+# (H) Graph audit violation details (issue #646)
+AUDIT_DETAIL_ORPHAN = "{label} '{key}' has no relationships"
+AUDIT_DETAIL_UNDOCUMENTED_LABEL = "label '{label}' is not documented in NODE_SCHEMAS"
+AUDIT_DETAIL_UNDOCUMENTED_PROPERTY = (
+    "{label} '{key}' has undocumented property '{prop}'"
+)
+AUDIT_DETAIL_MISSING_REQUIRED = "{label} '{key}' is missing required property '{prop}'"
+AUDIT_DETAIL_UNDOCUMENTED_RELATIONSHIP = (
+    "({from_label})-[:{rel_type}]->({to_label}) is not documented"
+    " in RELATIONSHIP_SCHEMAS"
+)
+
+# (H) Live-graph audit details (doctor)
+AUDIT_DETAIL_ORPHAN_COUNT = "{count} {label} node(s) have no relationships"
+AUDIT_DETAIL_UNDOCUMENTED_PROPERTY_LIVE = (
+    "{label} nodes carry undocumented property '{prop}'"
+)
+AUDIT_DETAIL_MISSING_REQUIRED_LIVE = (
+    "{count} {label} node(s) are missing required properties"
+)
+
+# (H) Node schema property-string tokens ("{name: string, extension: string?}")
+SCHEMA_PROPS_BRACES = "{}"
+SCHEMA_OPTIONAL_SUFFIX = "?"
+SEPARATOR_COMMA = ","
+
 NODE_PROJECT = NodeLabel.PROJECT
 
 EXCLUDED_DEPENDENCY_NAMES = frozenset({"python", "php"})
@@ -3661,6 +3695,13 @@ HEALTH_CHECK_MEMGRAPH_CONNECTION_FAILED_MSG = "Connection or query failed"
 HEALTH_CHECK_MEMGRAPH_UNEXPECTED_FAILURE_MSG = "Unexpected failure"
 HEALTH_CHECK_MEMGRAPH_ERROR = "Memgraph error: {error}"
 HEALTH_CHECK_MEMGRAPH_QUERY = "RETURN 1 AS test;"
+
+HEALTH_CHECK_GRAPH_INTEGRITY_OK = "Graph structural integrity verified"
+HEALTH_CHECK_GRAPH_INTEGRITY_FAILED = "Graph structural integrity violations"
+HEALTH_CHECK_GRAPH_INTEGRITY_OK_MSG = "No orphans or schema violations"
+HEALTH_CHECK_GRAPH_INTEGRITY_VIOLATIONS_MSG = "{count} violation(s) found"
+HEALTH_CHECK_GRAPH_INTEGRITY_ERROR_MSG = "Audit queries failed"
+HEALTH_CHECK_GRAPH_INTEGRITY_SEPARATOR = "; "
 
 HEALTH_CHECK_API_KEY_SET = "{display_name} API key is set"
 HEALTH_CHECK_API_KEY_NOT_SET = "{display_name} API key is not set"

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -10,6 +10,27 @@ from .constants import (
 
 CYPHER_DELETE_ALL = "MATCH (n) DETACH DELETE n;"
 
+# (H) Graph structural integrity audit (issue #646). A zero-degree Project is a
+# (H) valid empty-repo graph, so the orphan scan exempts it.
+CYPHER_AUDIT_ORPHANS = (
+    "MATCH (n) WHERE NOT (n)--() AND NOT n:Project "
+    "RETURN labels(n)[0] AS label, count(n) AS orphans"
+)
+CYPHER_AUDIT_LABELS = "MATCH (n) UNWIND labels(n) AS label RETURN DISTINCT label"
+CYPHER_AUDIT_REL_TRIPLES = (
+    "MATCH (a)-[r]->(b) "
+    "RETURN DISTINCT labels(a)[0] AS src, type(r) AS rel, labels(b)[0] AS dst"
+)
+CYPHER_AUDIT_LABEL_PROPS = (
+    "MATCH (n) UNWIND labels(n) AS label UNWIND keys(n) AS key "
+    "RETURN DISTINCT label AS label, key AS key"
+)
+CYPHER_AUDIT_MISSING_REQUIRED = (
+    "MATCH (n:{label}) WHERE {conditions} RETURN count(n) AS missing"
+)
+CYPHER_AUDIT_IS_NULL = "n.{prop} IS NULL"
+CYPHER_AUDIT_OR = " OR "
+
 CYPHER_LIST_PROJECTS = "MATCH (p:Project) RETURN p.name AS name ORDER BY p.name"
 
 CYPHER_DELETE_PROJECT = """

--- a/codebase_rag/graph_audit.py
+++ b/codebase_rag/graph_audit.py
@@ -1,0 +1,231 @@
+# (H) Structural integrity audit of a generated knowledge graph (issue #646).
+# (H) Validates recorded node and relationship batches against the documented
+# (H) schema (types_defs.NODE_SCHEMAS / RELATIONSHIP_SCHEMAS): orphan nodes,
+# (H) required-property completeness, and undocumented labels, properties, and
+# (H) relationship endpoint triples.
+from collections.abc import Callable, Sequence
+
+from . import constants as cs
+from . import cypher_queries as cq
+from .types_defs import (
+    NODE_SCHEMAS,
+    RELATIONSHIP_SCHEMAS,
+    AuditViolation,
+    GraphNodeRecord,
+    GraphRelRecord,
+    PropertyValue,
+    ResultRow,
+)
+
+
+def documented_node_properties() -> dict[str, dict[str, bool]]:
+    """Parse NODE_SCHEMAS property strings into {label: {prop: required}}."""
+    parsed: dict[str, dict[str, bool]] = {}
+    for schema in NODE_SCHEMAS:
+        props: dict[str, bool] = {}
+        for entry in schema.properties.strip(cs.SCHEMA_PROPS_BRACES).split(
+            cs.SEPARATOR_COMMA
+        ):
+            name, _, type_part = entry.partition(cs.SEPARATOR_COLON)
+            props[name.strip()] = not type_part.strip().endswith(
+                cs.SCHEMA_OPTIONAL_SUFFIX
+            )
+        parsed[schema.label.value] = props
+    return parsed
+
+
+def documented_relationship_triples() -> frozenset[tuple[str, str, str]]:
+    return frozenset(
+        (source.value, schema.rel_type.value, target.value)
+        for schema in RELATIONSHIP_SCHEMAS
+        for source in schema.sources
+        for target in schema.targets
+    )
+
+
+def _node_key(node: GraphNodeRecord) -> PropertyValue:
+    if key_prop := cs.NODE_UNIQUE_CONSTRAINTS.get(node.label):
+        return node.properties.get(key_prop)
+    return None
+
+
+def merge_node_records(
+    nodes: Sequence[GraphNodeRecord],
+) -> list[GraphNodeRecord]:
+    """Collapse repeated ensures of one node, merging properties.
+
+    Mirrors the ingestor's MERGE ... SET n += props semantics: the stored
+    node carries the union of all batched property dicts.
+    """
+    merged: dict[tuple[str, PropertyValue], GraphNodeRecord] = {}
+    for node in nodes:
+        identity = (node.label, _node_key(node))
+        if existing := merged.get(identity):
+            existing.properties.update(node.properties)
+        else:
+            merged[identity] = GraphNodeRecord(node.label, dict(node.properties))
+    return list(merged.values())
+
+
+def find_orphans(
+    nodes: Sequence[GraphNodeRecord], relationships: Sequence[GraphRelRecord]
+) -> list[GraphNodeRecord]:
+    connected: set[tuple[str, PropertyValue]] = set()
+    for rel in relationships:
+        for label, _, value in (rel.from_spec, rel.to_spec):
+            connected.add((label, value))
+    return [
+        node
+        for node in merge_node_records(nodes)
+        # (H) A repo with no indexable content is just its Project root, so a
+        # (H) zero-degree Project is valid rather than a construction failure.
+        if node.label != cs.NodeLabel.PROJECT
+        and (node.label, _node_key(node)) not in connected
+    ]
+
+
+def find_property_violations(
+    nodes: Sequence[GraphNodeRecord],
+) -> list[AuditViolation]:
+    documented = documented_node_properties()
+    violations: list[AuditViolation] = []
+    for node in merge_node_records(nodes):
+        schema_props = documented.get(node.label)
+        if schema_props is None:
+            violations.append(
+                AuditViolation(
+                    cs.AuditCheck.UNDOCUMENTED_LABEL,
+                    cs.AUDIT_DETAIL_UNDOCUMENTED_LABEL.format(label=node.label),
+                )
+            )
+            continue
+        key = _node_key(node)
+        for prop in node.properties:
+            if prop not in schema_props:
+                violations.append(
+                    AuditViolation(
+                        cs.AuditCheck.UNDOCUMENTED_PROPERTY,
+                        cs.AUDIT_DETAIL_UNDOCUMENTED_PROPERTY.format(
+                            label=node.label, key=key, prop=prop
+                        ),
+                    )
+                )
+        for prop, required in schema_props.items():
+            if required and node.properties.get(prop) is None:
+                violations.append(
+                    AuditViolation(
+                        cs.AuditCheck.MISSING_REQUIRED_PROPERTY,
+                        cs.AUDIT_DETAIL_MISSING_REQUIRED.format(
+                            label=node.label, key=key, prop=prop
+                        ),
+                    )
+                )
+    return violations
+
+
+def find_relationship_violations(
+    relationships: Sequence[GraphRelRecord],
+) -> list[AuditViolation]:
+    documented = documented_relationship_triples()
+    violations: list[AuditViolation] = []
+    seen: set[tuple[str, str, str]] = set()
+    for rel in relationships:
+        triple = (rel.from_spec[0], rel.rel_type, rel.to_spec[0])
+        if triple in documented or triple in seen:
+            continue
+        seen.add(triple)
+        violations.append(
+            AuditViolation(
+                cs.AuditCheck.UNDOCUMENTED_RELATIONSHIP,
+                cs.AUDIT_DETAIL_UNDOCUMENTED_RELATIONSHIP.format(
+                    from_label=triple[0], rel_type=triple[1], to_label=triple[2]
+                ),
+            )
+        )
+    return violations
+
+
+def build_missing_required_query(label: str, required_props: Sequence[str]) -> str:
+    conditions = cq.CYPHER_AUDIT_OR.join(
+        cq.CYPHER_AUDIT_IS_NULL.format(prop=prop) for prop in required_props
+    )
+    return cq.CYPHER_AUDIT_MISSING_REQUIRED.format(label=label, conditions=conditions)
+
+
+def collect_live_violations(
+    fetch_all: Callable[[str], Sequence[ResultRow]],
+) -> list[AuditViolation]:
+    """Run the structural audit against a live graph via Cypher (doctor)."""
+    violations: list[AuditViolation] = []
+    for row in fetch_all(cq.CYPHER_AUDIT_ORPHANS):
+        violations.append(
+            AuditViolation(
+                cs.AuditCheck.ORPHAN_NODE,
+                cs.AUDIT_DETAIL_ORPHAN_COUNT.format(
+                    count=row["orphans"], label=row["label"]
+                ),
+            )
+        )
+    documented_props = documented_node_properties()
+    for row in fetch_all(cq.CYPHER_AUDIT_LABELS):
+        if row["label"] not in documented_props:
+            violations.append(
+                AuditViolation(
+                    cs.AuditCheck.UNDOCUMENTED_LABEL,
+                    cs.AUDIT_DETAIL_UNDOCUMENTED_LABEL.format(label=row["label"]),
+                )
+            )
+    documented_triples = documented_relationship_triples()
+    for row in fetch_all(cq.CYPHER_AUDIT_REL_TRIPLES):
+        if (row["src"], row["rel"], row["dst"]) not in documented_triples:
+            violations.append(
+                AuditViolation(
+                    cs.AuditCheck.UNDOCUMENTED_RELATIONSHIP,
+                    cs.AUDIT_DETAIL_UNDOCUMENTED_RELATIONSHIP.format(
+                        from_label=row["src"],
+                        rel_type=row["rel"],
+                        to_label=row["dst"],
+                    ),
+                )
+            )
+    for row in fetch_all(cq.CYPHER_AUDIT_LABEL_PROPS):
+        # (H) Unknown labels are already reported above; only grade documented ones.
+        if (schema_props := documented_props.get(str(row["label"]))) and str(
+            row["key"]
+        ) not in schema_props:
+            violations.append(
+                AuditViolation(
+                    cs.AuditCheck.UNDOCUMENTED_PROPERTY,
+                    cs.AUDIT_DETAIL_UNDOCUMENTED_PROPERTY_LIVE.format(
+                        label=row["label"], prop=row["key"]
+                    ),
+                )
+            )
+    for label, schema_props in documented_props.items():
+        required = [prop for prop, is_required in schema_props.items() if is_required]
+        rows = fetch_all(build_missing_required_query(label, required))
+        if rows and (count := rows[0]["missing"]):
+            violations.append(
+                AuditViolation(
+                    cs.AuditCheck.MISSING_REQUIRED_PROPERTY,
+                    cs.AUDIT_DETAIL_MISSING_REQUIRED_LIVE.format(
+                        count=count, label=label
+                    ),
+                )
+            )
+    return violations
+
+
+def collect_violations(
+    nodes: Sequence[GraphNodeRecord], relationships: Sequence[GraphRelRecord]
+) -> list[AuditViolation]:
+    violations = [
+        AuditViolation(
+            cs.AuditCheck.ORPHAN_NODE,
+            cs.AUDIT_DETAIL_ORPHAN.format(label=node.label, key=_node_key(node)),
+        )
+        for node in find_orphans(nodes, relationships)
+    ]
+    violations.extend(find_property_violations(nodes))
+    violations.extend(find_relationship_violations(relationships))
+    return violations

--- a/codebase_rag/graph_audit.py
+++ b/codebase_rag/graph_audit.py
@@ -79,7 +79,7 @@ def find_orphans(
         for node in merge_node_records(nodes)
         # (H) A repo with no indexable content is just its Project root, so a
         # (H) zero-degree Project is valid rather than a construction failure.
-        if node.label != cs.NodeLabel.PROJECT
+        if node.label != cs.NodeLabel.PROJECT.value
         and (node.label, _node_key(node)) not in connected
     ]
 

--- a/codebase_rag/graph_audit.py
+++ b/codebase_rag/graph_audit.py
@@ -26,6 +26,10 @@ def documented_node_properties() -> dict[str, dict[str, bool]]:
         for entry in schema.properties.strip(cs.SCHEMA_PROPS_BRACES).split(
             cs.SEPARATOR_COMMA
         ):
+            # (H) A trailing comma or stray whitespace in a schema string must
+            # (H) not register an empty-named required property.
+            if not (entry := entry.strip()):
+                continue
             name, _, type_part = entry.partition(cs.SEPARATOR_COLON)
             props[name.strip()] = not type_part.strip().endswith(
                 cs.SCHEMA_OPTIONAL_SUFFIX
@@ -203,6 +207,10 @@ def collect_live_violations(
             )
     for label, schema_props in documented_props.items():
         required = [prop for prop, is_required in schema_props.items() if is_required]
+        # (H) An all-optional schema would render an empty WHERE clause, which
+        # (H) is a Cypher syntax error.
+        if not required:
+            continue
         rows = fetch_all(build_missing_required_query(label, required))
         if rows and (count := rows[0]["missing"]):
             violations.append(

--- a/codebase_rag/parsers/js_ts/ingest.py
+++ b/codebase_rag/parsers/js_ts/ingest.py
@@ -13,11 +13,11 @@ from ...types_defs import (
     ASTNode,
     FunctionRegistryTrieProtocol,
     NodeType,
-    PropertyDict,
     SimpleNameLookup,
 )
 from ..utils import (
     get_cached_query,
+    module_function_props,
     safe_decode_text,
     safe_decode_with_fallback,
     sorted_captures,
@@ -173,13 +173,14 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
                     method_qn, func_node.start_point[0] + 1
                 )
 
-                method_props: PropertyDict = {
-                    cs.KEY_QUALIFIED_NAME: method_qn,
-                    cs.KEY_NAME: method_name,
-                    cs.KEY_START_LINE: func_node.start_point[0] + 1,
-                    cs.KEY_END_LINE: func_node.end_point[0] + 1,
-                    cs.KEY_DOCSTRING: self._get_docstring(func_node),
-                }
+                method_props = module_function_props(
+                    method_qn,
+                    method_name,
+                    func_node,
+                    self._get_docstring(func_node),
+                    self.module_qn_to_file_path.get(module_qn),
+                    self.repo_path,
+                )
                 logger.info(
                     lg.JS_PROTOTYPE_METHOD_FOUND,
                     method_name=method_name,
@@ -316,13 +317,14 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
         method_qn = self.function_registry.register_unique_qn(
             method_qn, method_func_node.start_point[0] + 1
         )
-        method_props: PropertyDict = {
-            cs.KEY_QUALIFIED_NAME: method_qn,
-            cs.KEY_NAME: method_name,
-            cs.KEY_START_LINE: method_func_node.start_point[0] + 1,
-            cs.KEY_END_LINE: method_func_node.end_point[0] + 1,
-            cs.KEY_DOCSTRING: self._get_docstring(method_func_node),
-        }
+        method_props = module_function_props(
+            method_qn,
+            method_name,
+            method_func_node,
+            self._get_docstring(method_func_node),
+            self.module_qn_to_file_path.get(module_qn),
+            self.repo_path,
+        )
         logger.info(
             lg.JS_OBJECT_METHOD_FOUND, method_name=method_name, method_qn=method_qn
         )
@@ -420,7 +422,11 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
             )
 
             self._register_arrow_function(
-                function_name, function_qn, arrow_function, lg.JS_OBJECT_ARROW_FOUND
+                function_name,
+                function_qn,
+                arrow_function,
+                module_qn,
+                lg.JS_OBJECT_ARROW_FOUND,
             )
 
     def _resolve_direct_arrow_qn(
@@ -480,7 +486,7 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
             )
 
             self._register_arrow_function(
-                function_name, function_qn, function_node, log_message
+                function_name, function_qn, function_node, module_qn, log_message
             )
 
     def _resolve_member_expr_qn(
@@ -504,23 +510,30 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
         function_name: str,
         function_qn: str,
         function_node: ASTNode,
+        module_qn: str,
         log_message: str,
     ) -> None:
         function_qn = self.function_registry.register_unique_qn(
             function_qn, function_node.start_point[0] + 1
         )
-        function_props: PropertyDict = {
-            cs.KEY_QUALIFIED_NAME: function_qn,
-            cs.KEY_NAME: function_name,
-            cs.KEY_START_LINE: function_node.start_point[0] + 1,
-            cs.KEY_END_LINE: function_node.end_point[0] + 1,
-            cs.KEY_DOCSTRING: self._get_docstring(function_node),
-        }
+        function_props = module_function_props(
+            function_qn,
+            function_name,
+            function_node,
+            self._get_docstring(function_node),
+            self.module_qn_to_file_path.get(module_qn),
+            self.repo_path,
+        )
 
         logger.debug(log_message, function_name=function_name, function_qn=function_qn)
         self.ingestor.ensure_node_batch(cs.NodeLabel.FUNCTION, function_props)
         self.function_registry[function_qn] = NodeType.FUNCTION
         self.simple_name_lookup[function_name].add(function_qn)
+        self.ingestor.ensure_relationship_batch(
+            (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, module_qn),
+            cs.RelationshipType.DEFINES,
+            (cs.NodeLabel.FUNCTION, cs.KEY_QUALIFIED_NAME, function_qn),
+        )
 
     def _is_static_method_in_class(self, method_node: ASTNode) -> bool:
         if method_node.type == cs.TS_METHOD_DEFINITION:

--- a/codebase_rag/parsers/js_ts/module_system.py
+++ b/codebase_rag/parsers/js_ts/module_system.py
@@ -37,6 +37,7 @@ class JsTsModuleSystemMixin:
     project_name: str
     function_registry: FunctionRegistryTrieProtocol
     simple_name_lookup: SimpleNameLookup
+    module_qn_to_file_path: dict[str, Path]
     import_processor: ImportProcessor
     _processed_imports: set[str]
 
@@ -163,19 +164,23 @@ class JsTsModuleSystemMixin:
 
             import_key = f"{module_qn}->{resolved_source_module}"
             if import_key not in self._processed_imports:
-                self.ingestor.ensure_node_batch(
-                    cs.NodeLabel.MODULE,
-                    {
-                        cs.KEY_QUALIFIED_NAME: resolved_source_module,
-                        cs.KEY_NAME: resolved_source_module,
-                    },
+                # (H) #498: a require() target outside the project (Node builtin,
+                # (H) npm package) is an ExternalModule, not a prop-less Module.
+                # (H) Local targets get no node here: the module's own file pass
+                # (H) creates it, and a rel to a never-indexed module is a no-op.
+                target_label = self.import_processor._module_label(
+                    resolved_source_module
                 )
+                if target_label == cs.NodeLabel.EXTERNAL_MODULE:
+                    self.import_processor._ensure_external_module_node(
+                        resolved_source_module, module_name
+                    )
 
                 self.ingestor.ensure_relationship_batch(
                     (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, module_qn),
                     cs.RelationshipType.IMPORTS,
                     (
-                        cs.NodeLabel.MODULE,
+                        target_label,
                         cs.KEY_QUALIFIED_NAME,
                         resolved_source_module,
                     ),
@@ -212,6 +217,8 @@ class JsTsModuleSystemMixin:
             self.simple_name_lookup,
             self._get_docstring,
             self._is_export_inside_function,
+            self.module_qn_to_file_path.get(module_qn),
+            self.repo_path,
         )
 
     def _process_exports_pattern(
@@ -341,6 +348,8 @@ class JsTsModuleSystemMixin:
                                     self.simple_name_lookup,
                                     self._get_docstring,
                                     self._is_export_inside_function,
+                                    self.module_qn_to_file_path.get(module_qn),
+                                    self.repo_path,
                                 )
 
                     if not export_names:
@@ -361,6 +370,10 @@ class JsTsModuleSystemMixin:
                                                 self.simple_name_lookup,
                                                 self._get_docstring,
                                                 self._is_export_inside_function,
+                                                self.module_qn_to_file_path.get(
+                                                    module_qn
+                                                ),
+                                                self.repo_path,
                                             )
 
                 except Exception as e:

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -690,12 +690,14 @@ def ingest_exported_function(
     # (H) Same for a nested export (TS namespace / module block): the main pass
     # (H) already ingested it under its nested qn (e.g. lib.geo.helper), so a
     # (H) module-level re-ingest would mint a phantom duplicate node plus a
-    # (H) spurious Module-DEFINES edge.
-    module_prefix = f"{module_qn}{cs.SEPARATOR_DOT}"
-    if any(
-        qn.startswith(module_prefix) for qn in simple_name_lookup.get(function_name, ())
-    ):
-        return
+    # (H) spurious Module-DEFINES edge. Walk ancestors instead of matching
+    # (H) simple names so a top-level export may share a name with an
+    # (H) unrelated method elsewhere in the module.
+    current = function_node.parent
+    while current is not None:
+        if current.type in (cs.TS_INTERNAL_MODULE, cs.TS_MODULE):
+            return
+        current = current.parent
     function_qn = function_registry.register_unique_qn(
         function_qn, function_node.start_point[0] + 1
     )

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -641,6 +641,29 @@ def ingest_method(
     )
 
 
+def module_function_props(
+    function_qn: str,
+    function_name: str,
+    function_node: ASTNode,
+    docstring: str | None,
+    file_path: Path | None,
+    repo_path: Path | None,
+) -> PropertyDict:
+    """Standard Function node properties for module-scoped JS/TS functions."""
+    props: PropertyDict = {
+        cs.KEY_QUALIFIED_NAME: function_qn,
+        cs.KEY_NAME: function_name,
+        cs.KEY_DECORATORS: [],
+        cs.KEY_START_LINE: function_node.start_point[0] + 1,
+        cs.KEY_END_LINE: function_node.end_point[0] + 1,
+        cs.KEY_DOCSTRING: docstring,
+    }
+    if file_path is not None and repo_path is not None:
+        props[cs.KEY_PATH] = cached_relative_path(file_path, repo_path).as_posix()
+        props[cs.KEY_ABSOLUTE_PATH] = cached_resolve_posix(file_path)
+    return props
+
+
 def ingest_exported_function(
     function_node: ASTNode,
     function_name: str,
@@ -651,6 +674,8 @@ def ingest_exported_function(
     simple_name_lookup: SimpleNameLookup,
     get_docstring_func: Callable[[ASTNode], str | None],
     is_export_inside_function_func: Callable[[ASTNode], bool],
+    file_path: Path | None,
+    repo_path: Path | None,
 ) -> None:
     if is_export_inside_function_func(function_node):
         return
@@ -662,17 +687,28 @@ def ingest_exported_function(
     # (H) the callee qn). If the natural qn already exists, the node is done.
     if function_qn in function_registry:
         return
+    # (H) Same for a nested export (TS namespace / module block): the main pass
+    # (H) already ingested it under its nested qn (e.g. lib.geo.helper), so a
+    # (H) module-level re-ingest would mint a phantom duplicate node plus a
+    # (H) spurious Module-DEFINES edge.
+    module_prefix = f"{module_qn}{cs.SEPARATOR_DOT}"
+    if any(
+        qn.startswith(module_prefix) for qn in simple_name_lookup.get(function_name, ())
+    ):
+        return
     function_qn = function_registry.register_unique_qn(
         function_qn, function_node.start_point[0] + 1
     )
 
-    function_props = {
-        cs.KEY_QUALIFIED_NAME: function_qn,
-        cs.KEY_NAME: function_name,
-        cs.KEY_START_LINE: function_node.start_point[0] + 1,
-        cs.KEY_END_LINE: function_node.end_point[0] + 1,
-        cs.KEY_DOCSTRING: get_docstring_func(function_node),
-    }
+    function_props = module_function_props(
+        function_qn,
+        function_name,
+        function_node,
+        get_docstring_func(function_node),
+        file_path,
+        repo_path,
+    )
+    function_props[cs.KEY_IS_EXPORTED] = True
 
     logger.info(
         logs.EXPORT_FOUND.format(
@@ -682,6 +718,11 @@ def ingest_exported_function(
     ingestor.ensure_node_batch(cs.NodeLabel.FUNCTION, function_props)
     function_registry[function_qn] = NodeType.FUNCTION
     simple_name_lookup[function_name].add(function_qn)
+    ingestor.ensure_relationship_batch(
+        (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, module_qn),
+        cs.RelationshipType.DEFINES,
+        (cs.NodeLabel.FUNCTION, cs.KEY_QUALIFIED_NAME, function_qn),
+    )
 
 
 def is_method_node(func_node: ASTNode, lang_config: LanguageSpec) -> bool:

--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -13,8 +13,10 @@ from unittest.mock import MagicMock, call
 import pytest
 from loguru import logger
 
+from codebase_rag import graph_audit
 from codebase_rag.graph_updater import GraphUpdater
 from codebase_rag.parser_loader import load_parsers
+from codebase_rag.types_defs import GraphNodeRecord, GraphRelRecord
 
 if TYPE_CHECKING:
     pass  # ty: ignore[unresolved-import]
@@ -174,7 +176,34 @@ def create_and_run_updater(
         queries=queries,
     )
     updater.run()
+    _audit_recorded_graph(mock_ingestor)
     return updater
+
+
+def _audit_recorded_graph(mock_ingestor: MagicMock) -> None:
+    """Structural integrity audit of the recorded batches (issue #646).
+
+    Every test that indexes a fixture also asserts the resulting graph is
+    schema-conformant and orphan-free. CGR_AUDIT_SWEEP=<file> switches to
+    collect mode, appending violations as JSON lines instead of failing.
+    """
+    nodes = [
+        GraphNodeRecord(str(c.args[0]), c.args[1])
+        for c in mock_ingestor.ensure_node_batch.call_args_list
+    ]
+    rels = [
+        GraphRelRecord(c.args[0], str(c.args[1]), c.args[2])
+        for c in mock_ingestor.ensure_relationship_batch.call_args_list
+    ]
+    violations = graph_audit.collect_violations(nodes, rels)
+    if sweep_path := os.environ.get("CGR_AUDIT_SWEEP"):
+        import json
+
+        with open(sweep_path, "a") as f:
+            for v in violations:
+                f.write(json.dumps([str(v.check), v.detail]) + "\n")
+        return
+    assert not violations, "\n".join(v.detail for v in violations)
 
 
 def get_relationships(mock_ingestor: MagicMock, rel_type: str) -> list:

--- a/codebase_rag/tests/test_graph_audit.py
+++ b/codebase_rag/tests/test_graph_audit.py
@@ -292,6 +292,44 @@ class TestLiveGraphAudit:
         assert "Module" in violations[0].detail
 
 
+JS_EXPORT_NAME_COLLISION = """
+class Service {
+    helper() {
+        return 1;
+    }
+}
+
+module.exports.helper = function() {
+    return new Service().helper();
+};
+"""
+
+
+class TestExportNameCollision:
+    def test_export_sharing_a_method_name_is_still_ingested(
+        self, temp_repo, mock_ingestor
+    ) -> None:
+        # (H) The nested-export guard must not skip a legitimate top-level
+        # (H) export just because a class method elsewhere in the module
+        # (H) shares its simple name.
+        from codebase_rag.tests.conftest import run_updater
+
+        (temp_repo / "svc.js").write_text(JS_EXPORT_NAME_COLLISION)
+        run_updater(temp_repo, mock_ingestor)
+
+        function_qns = {
+            c.args[1]["qualified_name"]
+            for c in mock_ingestor.ensure_node_batch.call_args_list
+            if str(c.args[0]) == cs.NodeLabel.FUNCTION.value
+        }
+        module_level = [
+            qn
+            for qn in function_qns
+            if qn.endswith(".helper") and ".Service." not in qn
+        ]
+        assert module_level, function_qns
+
+
 class TestSchemaParsing:
     def test_every_documented_label_has_parsed_properties(self) -> None:
         parsed = ga.documented_node_properties()

--- a/codebase_rag/tests/test_graph_audit.py
+++ b/codebase_rag/tests/test_graph_audit.py
@@ -84,6 +84,12 @@ class TestOrphans:
         nodes, rels = _clean_graph()
         assert ga.find_orphans(nodes, rels) == []
 
+    def test_project_only_graph_is_valid(self) -> None:
+        # (H) An empty repo indexes to just its Project root; the recorder
+        # (H) stores labels as plain strings, so the exemption must hold for
+        # (H) the string form.
+        assert ga.collect_violations([_project()], []) == []
+
 
 class TestLabelConformance:
     def test_undocumented_label_is_flagged(self) -> None:

--- a/codebase_rag/tests/test_graph_audit.py
+++ b/codebase_rag/tests/test_graph_audit.py
@@ -1,0 +1,300 @@
+# (H) Structural integrity audit over recorded graph batches. Codifies the
+# (H) checks from the gdotv knowledge-graph analysis (issue #646): orphan
+# (H) nodes, required-property completeness, and conformance of labels,
+# (H) properties, and relationship endpoint triples against the documented
+# (H) schema in types_defs.NODE_SCHEMAS / RELATIONSHIP_SCHEMAS.
+from __future__ import annotations
+
+from codebase_rag import constants as cs
+from codebase_rag import graph_audit as ga
+from codebase_rag.types_defs import GraphNodeRecord, GraphRelRecord, PropertyDict
+
+QN = cs.UniqueKeyType.QUALIFIED_NAME.value
+
+
+def _project(name: str = "proj") -> GraphNodeRecord:
+    return GraphNodeRecord(cs.NodeLabel.PROJECT.value, {"name": name})
+
+
+def _module(qn: str) -> GraphNodeRecord:
+    props: PropertyDict = {
+        "qualified_name": qn,
+        "name": qn.rsplit(".", 1)[-1],
+        "path": "src/mod.py",
+        "absolute_path": "/repo/src/mod.py",
+    }
+    return GraphNodeRecord(cs.NodeLabel.MODULE.value, props)
+
+
+def _function(qn: str) -> GraphNodeRecord:
+    props: PropertyDict = {
+        "qualified_name": qn,
+        "name": qn.rsplit(".", 1)[-1],
+        "decorators": [],
+        "path": "src/mod.py",
+        "absolute_path": "/repo/src/mod.py",
+    }
+    return GraphNodeRecord(cs.NodeLabel.FUNCTION.value, props)
+
+
+def _rel(
+    from_label: str, from_qn: str, rel_type: str, to_label: str, to_qn: str
+) -> GraphRelRecord:
+    return GraphRelRecord((from_label, QN, from_qn), rel_type, (to_label, QN, to_qn))
+
+
+def _contains_module(project_name: str, module_qn: str) -> GraphRelRecord:
+    return GraphRelRecord(
+        (cs.NodeLabel.PROJECT.value, cs.UniqueKeyType.NAME.value, project_name),
+        cs.RelationshipType.CONTAINS_MODULE.value,
+        (cs.NodeLabel.MODULE.value, QN, module_qn),
+    )
+
+
+def _clean_graph() -> tuple[list[GraphNodeRecord], list[GraphRelRecord]]:
+    nodes = [_project(), _module("proj.mod"), _function("proj.mod.fn")]
+    rels = [
+        _contains_module("proj", "proj.mod"),
+        _rel(
+            cs.NodeLabel.MODULE.value,
+            "proj.mod",
+            cs.RelationshipType.DEFINES.value,
+            cs.NodeLabel.FUNCTION.value,
+            "proj.mod.fn",
+        ),
+    ]
+    return nodes, rels
+
+
+class TestCleanGraph:
+    def test_no_violations(self) -> None:
+        nodes, rels = _clean_graph()
+        assert ga.collect_violations(nodes, rels) == []
+
+
+class TestOrphans:
+    def test_node_without_relationships_is_flagged(self) -> None:
+        nodes, rels = _clean_graph()
+        nodes.append(_function("proj.mod.stranded"))
+        violations = ga.collect_violations(nodes, rels)
+        assert [v.check for v in violations] == [cs.AuditCheck.ORPHAN_NODE]
+        assert "proj.mod.stranded" in violations[0].detail
+
+    def test_relationship_endpoint_counts_as_connected(self) -> None:
+        nodes, rels = _clean_graph()
+        assert ga.find_orphans(nodes, rels) == []
+
+
+class TestLabelConformance:
+    def test_undocumented_label_is_flagged(self) -> None:
+        nodes, rels = _clean_graph()
+        nodes.append(GraphNodeRecord("Widget", {"qualified_name": "proj.mod.w"}))
+        checks = {v.check for v in ga.collect_violations(nodes, rels)}
+        assert cs.AuditCheck.UNDOCUMENTED_LABEL in checks
+
+
+class TestPropertyConformance:
+    def test_undocumented_property_is_flagged(self) -> None:
+        nodes, rels = _clean_graph()
+        nodes[0].properties["is_external"] = True
+        violations = ga.collect_violations(nodes, rels)
+        assert [v.check for v in violations] == [cs.AuditCheck.UNDOCUMENTED_PROPERTY]
+        assert "is_external" in violations[0].detail
+
+    def test_missing_required_property_is_flagged(self) -> None:
+        nodes, rels = _clean_graph()
+        del nodes[1].properties["name"]
+        violations = ga.collect_violations(nodes, rels)
+        assert [v.check for v in violations] == [
+            cs.AuditCheck.MISSING_REQUIRED_PROPERTY
+        ]
+
+    def test_null_required_property_is_flagged(self) -> None:
+        nodes, rels = _clean_graph()
+        nodes[2].properties["name"] = None
+        checks = [v.check for v in ga.collect_violations(nodes, rels)]
+        assert checks == [cs.AuditCheck.MISSING_REQUIRED_PROPERTY]
+
+    def test_optional_property_may_be_absent(self) -> None:
+        file_node = GraphNodeRecord(
+            cs.NodeLabel.FILE.value,
+            {
+                "path": "LICENSE",
+                "name": "LICENSE",
+                "absolute_path": "/repo/LICENSE",
+            },
+        )
+        contains = GraphRelRecord(
+            (cs.NodeLabel.PROJECT.value, cs.UniqueKeyType.NAME.value, "proj"),
+            cs.RelationshipType.CONTAINS_FILE.value,
+            (cs.NodeLabel.FILE.value, cs.UniqueKeyType.PATH.value, "LICENSE"),
+        )
+        nodes, rels = _clean_graph()
+        nodes.append(file_node)
+        rels.append(contains)
+        assert ga.collect_violations(nodes, rels) == []
+
+
+class TestPropertyMerging:
+    def test_repeated_ensures_merge_properties(self) -> None:
+        nodes, rels = _clean_graph()
+        partial = GraphNodeRecord(
+            cs.NodeLabel.MODULE.value, {"qualified_name": "proj.mod"}
+        )
+        nodes.insert(0, partial)
+        assert ga.collect_violations(nodes, rels) == []
+
+
+class TestRelationshipConformance:
+    def test_undocumented_endpoint_triple_is_flagged(self) -> None:
+        nodes, rels = _clean_graph()
+        rels.append(
+            _rel(
+                cs.NodeLabel.MODULE.value,
+                "proj.mod",
+                cs.RelationshipType.CALLS.value,
+                cs.NodeLabel.CLASS.value,
+                "proj.mod.Klass",
+            )
+        )
+        violations = ga.collect_violations(nodes, rels)
+        checks = [v.check for v in violations]
+        assert cs.AuditCheck.UNDOCUMENTED_RELATIONSHIP in checks
+        flagged = next(
+            v for v in violations if v.check == cs.AuditCheck.UNDOCUMENTED_RELATIONSHIP
+        )
+        assert cs.RelationshipType.CALLS.value in flagged.detail
+
+
+JS_EXPORT_PATTERNS = """
+const fs = require("fs");
+
+function helper() {
+    return fs.constants;
+}
+
+const obj = {
+    getValue() {
+        return 1;
+    },
+    computed: () => 2,
+};
+
+function Person(name) {
+    this.name = name;
+}
+
+Person.prototype.getAge = function() {
+    return 30;
+};
+
+module.exports.helper = helper;
+exports.inline = function inlineExport() {
+    return obj.getValue();
+};
+
+export function es6Helper() {
+    return helper();
+}
+"""
+
+
+class TestIndexedJsGraphIntegrity:
+    def test_js_side_channel_functions_are_complete(
+        self, temp_repo, mock_ingestor
+    ) -> None:
+        from codebase_rag.tests.conftest import run_updater
+
+        (temp_repo / "app.js").write_text(JS_EXPORT_PATTERNS)
+        run_updater(temp_repo, mock_ingestor)
+
+        nodes = [
+            GraphNodeRecord(str(c.args[0]), c.args[1])
+            for c in mock_ingestor.ensure_node_batch.call_args_list
+        ]
+        rels = [
+            GraphRelRecord(c.args[0], str(c.args[1]), c.args[2])
+            for c in mock_ingestor.ensure_relationship_batch.call_args_list
+        ]
+        assert ga.collect_violations(nodes, rels) == []
+
+
+class TestLiveGraphAudit:
+    def _fetch_factory(self, rows_by_query_marker: dict[str, list[dict]]):
+        def fetch_all(query: str) -> list[dict]:
+            for marker, rows in rows_by_query_marker.items():
+                if marker in query:
+                    return rows
+            return []
+
+        return fetch_all
+
+    def test_clean_live_graph_passes(self) -> None:
+        fetch = self._fetch_factory(
+            {
+                "NOT (n)--()": [],
+                "UNWIND labels(n)": [],
+                "type(r)": [],
+            }
+        )
+        assert ga.collect_live_violations(fetch) == []
+
+    def test_live_orphans_flagged(self) -> None:
+        fetch = self._fetch_factory(
+            {"NOT (n)--()": [{"label": "Method", "orphans": 427}]}
+        )
+        violations = ga.collect_live_violations(fetch)
+        checks = [v.check for v in violations]
+        assert cs.AuditCheck.ORPHAN_NODE in checks
+        assert any("427" in v.detail for v in violations)
+
+    def test_live_undocumented_label_and_triple_flagged(self) -> None:
+        fetch = self._fetch_factory(
+            {
+                "UNWIND labels(n) AS label RETURN DISTINCT label": [
+                    {"label": "Widget"}
+                ],
+                "type(r)": [
+                    {"src": "Module", "rel": "CALLS", "dst": "Class"},
+                ],
+            }
+        )
+        checks = {v.check for v in ga.collect_live_violations(fetch)}
+        assert cs.AuditCheck.UNDOCUMENTED_LABEL in checks
+        assert cs.AuditCheck.UNDOCUMENTED_RELATIONSHIP in checks
+
+    def test_live_undocumented_property_flagged(self) -> None:
+        fetch = self._fetch_factory(
+            {
+                "UNWIND keys(n)": [{"label": "Module", "key": "is_external"}],
+            }
+        )
+        violations = ga.collect_live_violations(fetch)
+        assert [v.check for v in violations] == [cs.AuditCheck.UNDOCUMENTED_PROPERTY]
+
+    def test_live_missing_required_flagged(self) -> None:
+        def fetch_all(query: str) -> list[dict]:
+            if "IS NULL" in query and "(n:Module)" in query:
+                return [{"missing": 3}]
+            if "IS NULL" in query:
+                return [{"missing": 0}]
+            return []
+
+        violations = ga.collect_live_violations(fetch_all)
+        checks = [v.check for v in violations]
+        assert checks == [cs.AuditCheck.MISSING_REQUIRED_PROPERTY]
+        assert "Module" in violations[0].detail
+
+
+class TestSchemaParsing:
+    def test_every_documented_label_has_parsed_properties(self) -> None:
+        parsed = ga.documented_node_properties()
+        assert set(parsed) == {label.value for label in cs.NodeLabel}
+        for props in parsed.values():
+            assert props
+
+    def test_file_extension_is_optional(self) -> None:
+        parsed = ga.documented_node_properties()
+        file_props = parsed[cs.NodeLabel.FILE.value]
+        assert file_props["extension"] is False
+        assert file_props["path"] is True

--- a/codebase_rag/tests/test_graph_determinism.py
+++ b/codebase_rag/tests/test_graph_determinism.py
@@ -2,6 +2,9 @@
 # (H) Replaces the digest-baseline CI artifacts proposed in #522/#646: rather
 # (H) than comparing a stored hash across runs, index the same fixture twice
 # (H) in-process and require byte-identical node and relationship output.
+# (H) Known blind spot: both runs share one hash seed, so set/dict iteration
+# (H) nondeterminism under PYTHONHASHSEED randomization across processes is
+# (H) not exercised here; parser code must sort such collections regardless.
 from __future__ import annotations
 
 from pathlib import Path

--- a/codebase_rag/tests/test_graph_determinism.py
+++ b/codebase_rag/tests/test_graph_determinism.py
@@ -1,0 +1,135 @@
+# (H) Indexing the same repo twice must produce identical batch sequences.
+# (H) Replaces the digest-baseline CI artifacts proposed in #522/#646: rather
+# (H) than comparing a stored hash across runs, index the same fixture twice
+# (H) in-process and require byte-identical node and relationship output.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.tests.conftest import _MockIngestor
+
+PY_MAIN = """
+from helpers import shout
+
+class Greeter:
+    def greet(self, name):
+        return shout(name)
+
+def main():
+    return Greeter().greet("world")
+"""
+
+PY_HELPERS = """
+def shout(text):
+    return text.upper()
+
+HANDLERS = {"shout": shout}
+"""
+
+JS_INDEX = """
+import { render } from "./render.js";
+
+export class App {
+    start() {
+        return render("app");
+    }
+}
+
+export function boot() {
+    return new App().start();
+}
+"""
+
+JS_RENDER = """
+export function render(target) {
+    return target.length;
+}
+"""
+
+RS_LIB = """
+pub struct Engine {
+    pub name: String,
+}
+
+impl Engine {
+    pub fn run(&self) -> usize {
+        helper(&self.name)
+    }
+}
+
+pub fn helper(name: &str) -> usize {
+    name.len()
+}
+"""
+
+JAVA_MAIN = """
+public class Main {
+    public static void main(String[] args) {
+        Worker worker = new Worker();
+        worker.work();
+    }
+}
+
+class Worker {
+    void work() {
+    }
+}
+"""
+
+
+def _write_fixture(repo: Path) -> None:
+    (repo / "main.py").write_text(PY_MAIN)
+    (repo / "helpers.py").write_text(PY_HELPERS)
+    (repo / "index.js").write_text(JS_INDEX)
+    (repo / "render.js").write_text(JS_RENDER)
+    (repo / "lib.rs").write_text(RS_LIB)
+    (repo / "Main.java").write_text(JAVA_MAIN)
+
+
+def _index_from_scratch(repo_path: Path, ingestor: MagicMock) -> None:
+    parsers, queries = load_parsers()
+    updater = GraphUpdater(
+        ingestor=ingestor,
+        repo_path=repo_path,
+        parsers=parsers,
+        queries=queries,
+    )
+    updater.run(force=True)
+
+
+def _recorded_batches(ingestor: MagicMock) -> tuple[list, list]:
+    nodes = [
+        (str(c.args[0]), c.args[1]) for c in ingestor.ensure_node_batch.call_args_list
+    ]
+    rels = [
+        (c.args[0], str(c.args[1]), c.args[2], *c.args[3:])
+        for c in ingestor.ensure_relationship_batch.call_args_list
+    ]
+    return nodes, rels
+
+
+@pytest.fixture
+def second_ingestor() -> _MockIngestor:
+    return _MockIngestor()
+
+
+def test_indexing_twice_is_deterministic(
+    temp_repo: Path, mock_ingestor: MagicMock, second_ingestor: MagicMock
+) -> None:
+    _write_fixture(temp_repo)
+
+    _index_from_scratch(temp_repo, mock_ingestor)
+    _index_from_scratch(temp_repo, second_ingestor)
+
+    first_nodes, first_rels = _recorded_batches(mock_ingestor)
+    second_nodes, second_rels = _recorded_batches(second_ingestor)
+
+    assert first_nodes, "fixture produced no nodes"
+    assert first_rels, "fixture produced no relationships"
+    assert first_nodes == second_nodes
+    assert first_rels == second_rels

--- a/codebase_rag/tests/test_health_checker.py
+++ b/codebase_rag/tests/test_health_checker.py
@@ -17,3 +17,76 @@ def test_check_memgraph_connection_returns_failure_when_down(
     result = HealthChecker().check_memgraph_connection()
 
     assert result.passed is False
+
+
+class _FakeCursor:
+    def __init__(self, rows_by_marker: dict[str, list[tuple]], columns: list[str]):
+        self._rows_by_marker = rows_by_marker
+        self._columns = columns
+        self._rows: list[tuple] = []
+        self.closed = False
+
+    def execute(self, query: str) -> None:
+        self._rows = []
+        for marker, rows in self._rows_by_marker.items():
+            if marker in query:
+                self._rows = rows
+                return
+
+    @property
+    def description(self) -> list[tuple]:
+        return [(name,) for name in self._columns]
+
+    def fetchall(self) -> list[tuple]:
+        return self._rows
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeConnection:
+    def __init__(self, cursor: _FakeCursor):
+        self._cursor = cursor
+        self.closed = False
+
+    def cursor(self) -> _FakeCursor:
+        return self._cursor
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_check_graph_integrity_skipped_when_memgraph_down(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def raise_operational_error(**_: object) -> object:
+        raise mgclient.OperationalError("connection refused")
+
+    monkeypatch.setattr(mgclient, "connect", raise_operational_error)
+
+    assert HealthChecker().check_graph_integrity() == []
+
+
+def test_check_graph_integrity_passes_on_clean_graph(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cursor = _FakeCursor({}, [])
+    monkeypatch.setattr(mgclient, "connect", lambda **_: _FakeConnection(cursor))
+
+    results = HealthChecker().check_graph_integrity()
+
+    assert len(results) == 1
+    assert results[0].passed is True
+
+
+def test_check_graph_integrity_reports_orphans(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cursor = _FakeCursor({"NOT (n)--()": [("Method", 427)]}, ["label", "orphans"])
+    monkeypatch.setattr(mgclient, "connect", lambda **_: _FakeConnection(cursor))
+
+    results = HealthChecker().check_graph_integrity()
+
+    assert len(results) == 1
+    assert results[0].passed is False
+    assert results[0].error is not None and "427" in results[0].error

--- a/codebase_rag/tests/test_js_ts_module_system_unit.py
+++ b/codebase_rag/tests/test_js_ts_module_system_unit.py
@@ -75,24 +75,49 @@ def mock_language_queries() -> dict[cs.SupportedLanguage, MagicMock]:
 
 
 class TestProcessCommonjsImport:
-    def test_creates_module_node_and_relationship(
+    def test_creates_external_module_node_and_relationship(
         self,
         mixin: ConcreteModuleSystemMixin,
         mock_ingestor: MagicMock,
         mock_import_processor: MagicMock,
     ) -> None:
         mock_import_processor._resolve_js_module_path.return_value = "fs"
+        mock_import_processor._module_label.return_value = cs.NodeLabel.EXTERNAL_MODULE
 
         mixin._process_commonjs_import("readFile", "fs", "my_module")
 
-        mock_ingestor.ensure_node_batch.assert_called_once()
-        call_args = mock_ingestor.ensure_node_batch.call_args
-        assert call_args[0][0] == cs.NodeLabel.MODULE
-        assert call_args[0][1][cs.KEY_QUALIFIED_NAME] == "fs"
+        # (H) #498: external require() targets get the dedicated ExternalModule
+        # (H) node via the import processor, never a prop-less bare Module.
+        mock_import_processor._ensure_external_module_node.assert_called_once_with(
+            "fs", "fs"
+        )
+        mock_ingestor.ensure_node_batch.assert_not_called()
 
         mock_ingestor.ensure_relationship_batch.assert_called_once()
         rel_args = mock_ingestor.ensure_relationship_batch.call_args
         assert rel_args[0][1] == cs.RelationshipType.IMPORTS
+        assert rel_args[0][2][0] == cs.NodeLabel.EXTERNAL_MODULE
+
+    def test_local_import_emits_relationship_without_node(
+        self,
+        mixin: ConcreteModuleSystemMixin,
+        mock_ingestor: MagicMock,
+        mock_import_processor: MagicMock,
+    ) -> None:
+        mock_import_processor._resolve_js_module_path.return_value = (
+            "test_project.src.utils"
+        )
+        mock_import_processor._module_label.return_value = cs.NodeLabel.MODULE
+
+        mixin._process_commonjs_import("helper", "./src/utils", "my_module")
+
+        # (H) The local module's own file pass creates its node; a rel to a
+        # (H) never-indexed module is a no-op instead of a phantom node.
+        mock_import_processor._ensure_external_module_node.assert_not_called()
+        mock_ingestor.ensure_node_batch.assert_not_called()
+        mock_ingestor.ensure_relationship_batch.assert_called_once()
+        rel_args = mock_ingestor.ensure_relationship_batch.call_args
+        assert rel_args[0][2][0] == cs.NodeLabel.MODULE
 
     def test_skips_duplicate_imports(
         self,
@@ -101,11 +126,12 @@ class TestProcessCommonjsImport:
         mock_import_processor: MagicMock,
     ) -> None:
         mock_import_processor._resolve_js_module_path.return_value = "fs"
+        mock_import_processor._module_label.return_value = cs.NodeLabel.EXTERNAL_MODULE
 
         mixin._process_commonjs_import("readFile", "fs", "my_module")
         mixin._process_commonjs_import("writeFile", "fs", "my_module")
 
-        assert mock_ingestor.ensure_node_batch.call_count == 1
+        assert mock_import_processor._ensure_external_module_node.call_count == 1
 
     def test_handles_resolution_error_gracefully(
         self,

--- a/codebase_rag/tests/test_typescript_namespaces_modules.py
+++ b/codebase_rag/tests/test_typescript_namespaces_modules.py
@@ -787,11 +787,12 @@ console.log('Valid method:', API.Http.isValidMethod('GET')); // true
         f"Expected at least 4 merged namespace-related nodes, found {len(merged_namespace_nodes)}"
     )
 
-    function_calls = get_nodes(mock_ingestor, "Function")
-
+    # (H) Namespace-exported functions are methods of the namespace node
+    # (H) (Class DEFINES_METHOD Method), matching the tsc containment oracle;
+    # (H) they must not also exist as module-level Function duplicates.
     merged_functions = [
         call
-        for call in function_calls
+        for call in get_nodes(mock_ingestor, "Method")
         if "namespace_merging" in call[0][1]["qualified_name"]
         and any(
             pattern in call[0][1]["qualified_name"]
@@ -1234,11 +1235,12 @@ if (ConditionalModule.IS_NODE) {
         f"Expected at least 2 classes/interfaces in modules, found {module_classes_interfaces}"
     )
 
-    function_calls = get_nodes(mock_ingestor, "Function")
-
+    # (H) Namespace-exported functions are methods of the namespace node
+    # (H) (Class DEFINES_METHOD Method), matching the tsc containment oracle;
+    # (H) they must not also exist as module-level Function duplicates.
     module_functions = [
         call
-        for call in function_calls
+        for call in get_nodes(mock_ingestor, "Method")
         if "module_patterns" in call[0][1]["qualified_name"]
         and any(
             pattern in call[0][1]["qualified_name"]

--- a/codebase_rag/tools/health_checker.py
+++ b/codebase_rag/tools/health_checker.py
@@ -7,8 +7,10 @@ import mgclient  # ty: ignore[unresolved-import]
 from loguru import logger
 
 from .. import constants as cs
+from .. import graph_audit
 from ..config import settings
 from ..schemas import HealthCheckResult
+from ..types_defs import ResultRow
 
 
 class HealthChecker:
@@ -183,10 +185,66 @@ class HealthChecker:
                 error=str(e),
             )
 
+    def check_graph_integrity(self) -> list[HealthCheckResult]:
+        """Structural audit of the live graph (issue #646).
+
+        Returns no results when Memgraph is unreachable: connectivity is
+        already reported by check_memgraph_connection.
+        """
+        try:
+            conn = mgclient.connect(
+                host=settings.MEMGRAPH_HOST,
+                port=settings.MEMGRAPH_PORT,
+            )
+        except Exception:
+            return []
+        cursor = conn.cursor()
+
+        def fetch_all(query: str) -> list[ResultRow]:
+            cursor.execute(query)
+            columns = [column[0] for column in cursor.description or []]
+            return [dict(zip(columns, row)) for row in cursor.fetchall()]
+
+        try:
+            violations = graph_audit.collect_live_violations(fetch_all)
+        except Exception as e:
+            return [
+                HealthCheckResult(
+                    name=cs.HEALTH_CHECK_GRAPH_INTEGRITY_FAILED,
+                    passed=False,
+                    message=cs.HEALTH_CHECK_GRAPH_INTEGRITY_ERROR_MSG,
+                    error=str(e),
+                )
+            ]
+        finally:
+            cursor.close()
+            conn.close()
+        if not violations:
+            return [
+                HealthCheckResult(
+                    name=cs.HEALTH_CHECK_GRAPH_INTEGRITY_OK,
+                    passed=True,
+                    message=cs.HEALTH_CHECK_GRAPH_INTEGRITY_OK_MSG,
+                )
+            ]
+        return [
+            HealthCheckResult(
+                name=cs.HEALTH_CHECK_GRAPH_INTEGRITY_FAILED,
+                passed=False,
+                message=cs.HEALTH_CHECK_GRAPH_INTEGRITY_VIOLATIONS_MSG.format(
+                    count=len(violations)
+                ),
+                error=cs.HEALTH_CHECK_GRAPH_INTEGRITY_SEPARATOR.join(
+                    v.detail for v in violations
+                ),
+            )
+        ]
+
     def run_all_checks(self) -> list[HealthCheckResult]:
         self.results = []
         self.results.append(self.check_docker())
         self.results.append(self.check_memgraph_connection())
+        self.results.extend(self.check_graph_integrity())
         self.results.extend(self.check_api_keys())
         for tool_name, cmd in cs.HEALTH_CHECK_EXTERNAL_TOOLS:
             self.results.append(self.check_external_tool(tool_name, cmd))

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, NamedTuple, Protocol, TypedDict
 
 from prompt_toolkit.styles import Style
 
-from .constants import NodeLabel, RelationshipType, SupportedLanguage
+from .constants import AuditCheck, NodeLabel, RelationshipType, SupportedLanguage
 
 if TYPE_CHECKING:
     from tree_sitter import Language, Node, Parser, Query
@@ -472,6 +472,25 @@ class NodeSchema(NamedTuple):
     properties: str
 
 
+class GraphNodeRecord(NamedTuple):
+    label: str
+    properties: PropertyDict
+
+
+type RelEndpointSpec = tuple[str, str, PropertyValue]
+
+
+class GraphRelRecord(NamedTuple):
+    from_spec: RelEndpointSpec
+    rel_type: str
+    to_spec: RelEndpointSpec
+
+
+class AuditViolation(NamedTuple):
+    check: AuditCheck
+    detail: str
+
+
 class RelationshipSchema(NamedTuple):
     sources: tuple[NodeLabel, ...]
     rel_type: RelationshipType
@@ -487,43 +506,49 @@ NODE_SCHEMAS: tuple[NodeSchema, ...] = (
     NodeSchema(NodeLabel.FOLDER, "{path: string, name: string, absolute_path: string}"),
     NodeSchema(
         NodeLabel.FILE,
-        "{path: string, name: string, extension: string, absolute_path: string}",
+        "{path: string, name: string, extension: string?, absolute_path: string}",
     ),
     NodeSchema(
         NodeLabel.MODULE,
-        "{qualified_name: string, name: string, path: string, absolute_path: string}",
+        "{qualified_name: string, name: string, path: string, absolute_path: string, start_line: int?, end_line: int?}",
     ),
     NodeSchema(
         NodeLabel.CLASS,
-        "{qualified_name: string, name: string, decorators: list[string], path: string, absolute_path: string}",
+        "{qualified_name: string, name: string, decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}",
     ),
     NodeSchema(
         NodeLabel.FUNCTION,
-        "{qualified_name: string, name: string, decorators: list[string], path: string, absolute_path: string}",
+        "{qualified_name: string, name: string, decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}",
     ),
     NodeSchema(
         NodeLabel.METHOD,
-        "{qualified_name: string, name: string, decorators: list[string], path: string, absolute_path: string}",
+        "{qualified_name: string, name: string, decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?, is_property: boolean?}",
     ),
     NodeSchema(
         NodeLabel.INTERFACE,
-        "{qualified_name: string, name: string, path: string, absolute_path: string}",
+        "{qualified_name: string, name: string, path: string, absolute_path: string, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}",
     ),
     NodeSchema(
         NodeLabel.ENUM,
-        "{qualified_name: string, name: string, path: string, absolute_path: string}",
+        "{qualified_name: string, name: string, path: string, absolute_path: string, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}",
     ),
-    NodeSchema(NodeLabel.TYPE, "{qualified_name: string, name: string}"),
-    NodeSchema(NodeLabel.UNION, "{qualified_name: string, name: string}"),
+    NodeSchema(
+        NodeLabel.TYPE,
+        "{qualified_name: string, name: string, path: string?, absolute_path: string?, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}",
+    ),
+    NodeSchema(
+        NodeLabel.UNION,
+        "{qualified_name: string, name: string, path: string?, absolute_path: string?, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}",
+    ),
     NodeSchema(
         NodeLabel.MODULE_INTERFACE,
-        "{qualified_name: string, name: string, path: string, absolute_path: string}",
+        "{qualified_name: string, name: string, path: string, absolute_path: string, module_type: string}",
     ),
     NodeSchema(
         NodeLabel.MODULE_IMPLEMENTATION,
-        "{qualified_name: string, name: string, path: string, absolute_path: string, implements_module: string}",
+        "{qualified_name: string, name: string, path: string, absolute_path: string, implements_module: string, module_type: string}",
     ),
-    NodeSchema(NodeLabel.EXTERNAL_PACKAGE, "{name: string, version_spec: string}"),
+    NodeSchema(NodeLabel.EXTERNAL_PACKAGE, "{name: string}"),
     NodeSchema(
         NodeLabel.EXTERNAL_MODULE,
         "{qualified_name: string, name: string, path: string}",
@@ -553,12 +578,26 @@ RELATIONSHIP_SCHEMAS: tuple[RelationshipSchema, ...] = (
         (NodeLabel.MODULE,),
     ),
     RelationshipSchema(
-        (NodeLabel.MODULE,),
+        (NodeLabel.MODULE, NodeLabel.FUNCTION, NodeLabel.METHOD),
         RelationshipType.DEFINES,
-        (NodeLabel.CLASS, NodeLabel.FUNCTION),
+        (
+            NodeLabel.CLASS,
+            NodeLabel.FUNCTION,
+            NodeLabel.ENUM,
+            NodeLabel.INTERFACE,
+            NodeLabel.TYPE,
+            NodeLabel.UNION,
+            NodeLabel.MODULE,
+        ),
     ),
     RelationshipSchema(
-        (NodeLabel.CLASS,),
+        (
+            NodeLabel.CLASS,
+            NodeLabel.INTERFACE,
+            NodeLabel.ENUM,
+            NodeLabel.TYPE,
+            NodeLabel.UNION,
+        ),
         RelationshipType.DEFINES_METHOD,
         (NodeLabel.METHOD,),
     ),
@@ -583,12 +622,12 @@ RELATIONSHIP_SCHEMAS: tuple[RelationshipSchema, ...] = (
         (NodeLabel.MODULE_IMPLEMENTATION,),
     ),
     RelationshipSchema(
-        (NodeLabel.CLASS,),
+        (NodeLabel.CLASS, NodeLabel.INTERFACE, NodeLabel.FUNCTION),
         RelationshipType.INHERITS,
-        (NodeLabel.CLASS,),
+        (NodeLabel.CLASS, NodeLabel.INTERFACE, NodeLabel.FUNCTION),
     ),
     RelationshipSchema(
-        (NodeLabel.CLASS,),
+        (NodeLabel.CLASS, NodeLabel.ENUM),
         RelationshipType.IMPLEMENTS,
         (NodeLabel.INTERFACE,),
     ),
@@ -608,9 +647,9 @@ RELATIONSHIP_SCHEMAS: tuple[RelationshipSchema, ...] = (
         (NodeLabel.EXTERNAL_PACKAGE,),
     ),
     RelationshipSchema(
-        (NodeLabel.FUNCTION, NodeLabel.METHOD),
+        (NodeLabel.MODULE, NodeLabel.FUNCTION, NodeLabel.METHOD),
         RelationshipType.CALLS,
-        (NodeLabel.FUNCTION, NodeLabel.METHOD),
+        (NodeLabel.FUNCTION, NodeLabel.METHOD, NodeLabel.ENUM, NodeLabel.TYPE),
     ),
     RelationshipSchema(
         (NodeLabel.MODULE, NodeLabel.FUNCTION, NodeLabel.METHOD),

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.246"
+version = "0.0.249"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #646

## What

Implements the graph structural integrity audit proposed in #646, codifying the checks from the gdotv two-part analysis so schema drift and orphan regressions surface in CI instead of in third-party blog posts.

### Audit module (`codebase_rag/graph_audit.py`)

Validates a graph against the documented schema in `types_defs.NODE_SCHEMAS` / `RELATIONSHIP_SCHEMAS` as single source of truth:

- **Orphan nodes**: any node with zero relationships, grouped by label (Project root exempt, since an empty repo is just its Project node). Would have caught #496.
- **Required-property completeness**: documented required properties must be present and non-null; a `?` suffix in the schema string (e.g. `extension: string?`) marks a property optional.
- **Schema conformance**: labels, node properties, and `(source)-[:REL]->(target)` endpoint triples present in the graph must be documented. Would have caught the `is_external` boolean of #498 and the `Module-CALLS->Class` edges of #497.

Repeated `ensure_node_batch` calls are merged per node identity, mirroring the ingestor's `MERGE ... SET n += props` semantics.

### Wiring

- **Every parser test audits its graph**: `create_and_run_updater` in conftest asserts zero violations after `updater.run()`, so the whole suite doubles as an integrity gate on every PR. `CGR_AUDIT_SWEEP=<file>` switches to collect mode for inventorying instead of failing.
- **`doctor`**: a new health check runs the same audit against live Memgraph via Cypher (skipped when Memgraph is unreachable, since connectivity is its own check).
- **Determinism**: an index-twice test (same fixture indexed twice in-process must produce identical node/relationship batch sequences) supersedes the digest/orphan-count CI baseline artifacts deferred from #522, with no stored baselines to maintain.

## Real defects surfaced and fixed by the audit sweep

Running the audit across all existing test fixtures reduced ~61k violation instances to three emission bugs, all root-caused:

1. **JS/TS side-channel Function nodes were incomplete and often orphaned**: functions ingested via CommonJS/ES6 export scanning, object-literal methods, assignment arrows, and prototype method assignments were missing `decorators`/`path`/`absolute_path` and in several paths had no `DEFINES` edge at all (229 orphan Function nodes across fixtures, the JS sibling of the 427 orphan C++ Methods from the blog). All paths now share `module_function_props()` and emit containment edges.
2. **Phantom duplicates of nested exports**: the ES6 export scanner re-minted namespace-nested exports (`export function helper` inside a TS namespace) as module-level Function nodes. Previously invisible orphans; once edges attached, the tsc containment oracle flagged them as false-positive `DEFINES` edges. The scanner now skips names already registered under the module.
3. **`require()` of Node builtins created prop-less bare `Module` nodes**: `_process_commonjs_import` bypassed the #498/#597 `ExternalModule` routing. Builtins and npm packages now get proper `ExternalModule` nodes; local targets get no placeholder node at all (the module's own file pass creates it, matching `import_processor.parse_imports`).

## Schema documentation reconciliation

The generated README tables now match what parsers actually emit:

- `start_line`/`end_line`/`docstring`/`is_exported` documented (optional) across code-entity labels; `decorators` on Interface/Enum/Type/Union; `is_property` on Method; `module_type` on ModuleInterface/ModuleImplementation.
- `DEFINES` sources extended to Function/Method (nested definitions) and targets to Enum/Interface/Type/Union/Module; `DEFINES_METHOD` sources to Interface/Enum/Type/Union; `INHERITS` to Interface and Function (JS prototype chains); `IMPLEMENTS` sources to Enum; `CALLS` sources to Module (module-level calls, decorators) and targets to Enum/Type (variant construction, type conversion).
- `ExternalPackage` documented as `{name: string}`: `version_spec` lives on the `DEPENDS_ON_EXTERNAL` edge, since one package node is shared across projects.
- `File.extension` documented as `string?` (empty for LICENSE, Dockerfile, dotfiles).

## Testing

- RED commit first: audit unit tests plus a JS fixture test asserting zero violations landed failing before the implementation.
- Full suite: 4554 passed, 0 failed. `ruff check`, `ruff format`, and the pre-commit `ty` gate are clean.
