### PR TITLE
fix(js): nest class-method closures and reference callbacks inside unowned arrows

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -2132,13 +2132,17 @@ class CallProcessor:
         # (H) call site is not statically resolvable. Treat each such reference as a call
         # (H) from the enclosing scope so the handler is reachable. The walk stops at
         # (H) nested function/class boundaries, so a table built inside a nested scope
-        # (H) is attributed to that scope's own pass, not this one.
+        # (H) is attributed to that scope's own pass, not this one -- EXCEPT an unowned
+        # (H) JS/TS arrow (a Promise executor, a `.forEach` callback), which gets no
+        # (H) caller pass of its own; its calls bubble to this scope, so its object
+        # (H) tables (a `defineProperty` getter descriptor) must be scanned here too or
+        # (H) the callbacks inside it are orphaned and report as dead.
         resolve_func = self._resolver.resolve_function_call
         ensure_rel = self.ingestor.ensure_relationship_batch
         stack: list[Node] = list(caller_node.children)
         while stack:
             node = stack.pop()
-            if node.type in boundary_types:
+            if node.type in boundary_types and not self._is_unowned_js_scope(node):
                 continue
             if node.type in _DICT_LIKE_COLLECTION_TYPES:
                 for pair in node.named_children:

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -709,7 +709,9 @@ class FunctionIngestMixin:
             return self._get_name_from_function_ancestor(current)
 
         if current.type in lang_config.class_node_types:
-            return self._handle_class_ancestor(func_node, current, skip_classes)
+            return self._handle_class_ancestor(
+                func_node, current, skip_classes, lang_config
+            )
 
         if current.type == cs.TS_METHOD_DEFINITION:
             return self._extract_node_name(current)
@@ -722,12 +724,40 @@ class FunctionIngestMixin:
         return self._extract_function_name(node)
 
     def _handle_class_ancestor(
-        self, func_node: Node, class_node: Node, skip_classes: bool
+        self,
+        func_node: Node,
+        class_node: Node,
+        skip_classes: bool,
+        lang_config: LanguageSpec,
     ) -> str | None | Literal[False]:
         if skip_classes:
             return None
-        if self._handler.is_inside_method_with_object_literals(func_node):
+        # (H) A function that is a DIRECT class member is a method, handled by the
+        # (H) class-ingest path -- return False so the whole qn collapses to the flat
+        # (H) module.name form that path expects. But a function NESTED inside a
+        # (H) method body (a Promise executor `new Promise(cb)`, a defineProperty
+        # (H) getter, any closure) must keep the full class.method.<name> path so the
+        # (H) call pass, which always builds that path, references the same node;
+        # (H) otherwise the closure is orphaned and reports as dead.
+        if self._is_nested_within_class_member(func_node, class_node, lang_config):
             return self._extract_node_name(class_node)
+        return False
+
+    def _is_nested_within_class_member(
+        self, func_node: Node, class_node: Node, lang_config: LanguageSpec
+    ) -> bool:
+        # (H) True when a function/method boundary sits between func_node and its
+        # (H) enclosing class -- i.e. func_node lives inside a member's body rather
+        # (H) than being the member itself. A direct method has no such intervening
+        # (H) boundary (its parent chain reaches the class body directly).
+        current = func_node.parent
+        while current is not None and current != class_node:
+            if (
+                current.type == cs.TS_METHOD_DEFINITION
+                or current.type in lang_config.function_node_types
+            ):
+                return True
+            current = current.parent
         return False
 
     def _extract_node_name(self, node: Node) -> str | None:

--- a/codebase_rag/tests/test_object_literal_callback_references.py
+++ b/codebase_rag/tests/test_object_literal_callback_references.py
@@ -423,6 +423,69 @@ def test_inline_callback_in_nested_arrow_const_is_referenced(tmp_path: Path) -> 
     )
 
 
+def test_promise_executor_in_constructor_is_referenced(tmp_path: Path) -> None:
+    # (H) The openapi-ts CancelablePromise shape: a class constructor builds
+    # (H) `this.promise = new Promise((resolve, reject) => {...})`. The executor arrow
+    # (H) is anonymous and nested inside the constructor, so its qn must keep the full
+    # (H) class.constructor path (not flatten to module.anonymous) for the constructor's
+    # (H) CALLS edge to connect; otherwise the executor is orphaned and reports dead.
+    files = {
+        "CancelablePromise.ts": (
+            "export class CancelablePromise {\n"
+            "  constructor(executor) {\n"
+            "    this.promise = new Promise((resolve, reject) => {\n"
+            "      run(resolve)\n"
+            "    })\n"
+            "  }\n"
+            "}\n\n\n"
+            "function run(f) {}\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files, "typescript")
+    defines = cs.RelationshipType.DEFINES.value
+    edges = {
+        b
+        for a, r, b in rels
+        if a.endswith("CancelablePromise.constructor") and r != defines
+    }
+    assert any(".CancelablePromise.constructor.anonymous_" in b for b in edges), (
+        f"promise executor in constructor not referenced; edges={edges}"
+    )
+
+
+def test_defineproperty_getter_in_executor_is_referenced(tmp_path: Path) -> None:
+    # (H) A getter descriptor (`Object.defineProperty(x, 'y', {get: () => ...})`) sits
+    # (H) inside an anonymous Promise-executor arrow that gets no caller pass of its own;
+    # (H) its calls bubble to the enclosing constructor. The constructor's collection
+    # (H) walk must therefore descend into the unowned executor and reference the getter,
+    # (H) or every defineProperty getter/setter reports as dead.
+    files = {
+        "CancelablePromise.ts": (
+            "export class CancelablePromise {\n"
+            "  constructor(executor) {\n"
+            "    this.promise = new Promise((resolve, reject) => {\n"
+            "      const onCancel = (h) => { track(h) }\n"
+            "      Object.defineProperty(onCancel, 'isResolved', {\n"
+            "        get: () => this._isResolved,\n"
+            "      })\n"
+            "    })\n"
+            "  }\n"
+            "}\n\n\n"
+            "function track(h) {}\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files, "typescript")
+    refs = {
+        b
+        for a, r, b in rels
+        if r == REFERENCES and a.endswith("CancelablePromise.constructor")
+    }
+    assert any(
+        ".CancelablePromise.constructor." in b and b.rsplit(".", 1)[-1] == "get"
+        for b in refs
+    ), f"defineProperty getter in executor not referenced; refs={refs}"
+
+
 def test_inline_arrow_call_argument_function_expr_is_referenced(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## What

Clears the last dead-code false positives on the full-stack-fastapi-template. Combined with #651 this takes the template from 333 to 0 unreachable functions. The remaining four were all in the auto-generated openapi-ts `CancelablePromise.ts`, and stemmed from two coupled issues.

### 1. Anonymous closures inside a class method were flattened to module scope

The definition pass only kept the `class.method` path for a closure when it sat inside an object literal (`is_inside_method_with_object_literals`); any other closure inside a method body, such as a Promise executor `this.promise = new Promise((resolve, reject) => {...})`, was named `module.anonymous_r_c` instead of `module.Class.constructor.anonymous_r_c`. The call pass always builds the full path, so the two disagreed and the executor got no incoming edge.

Now a closure that is nested inside a class member keeps the full `class.method.<name>` path. A function that is a direct class member (a real method) still returns the flat form the class-ingest path expects, so method registration is unchanged (`test_method_in_class_returns_none` still passes).

### 2. Callbacks inside an unowned arrow were never scanned

A getter descriptor (`Object.defineProperty(x, 'y', {get: () => ...})`) lives inside the anonymous executor arrow, which gets no caller pass of its own; its calls bubble to the enclosing constructor. The collection-reference walk stopped at that arrow boundary, so the getter was orphaned. The walk now descends into unowned JS/TS arrows (the same scopes whose calls already bubble up), referencing their object-literal callbacks from the enclosing named scope.

## Tests

Two new tests, each verified RED before the fix and GREEN after:

- Promise executor in a class constructor is referenced
- `defineProperty` getter inside the executor arrow is referenced

Full suite: 4561 passed, 0 failed. ruff and ty clean. Measured dead-code on the template: 0 unreachable functions.
