### PR TITLE
docs: document dead-code detection (README, PyPI, guide)

### DIFF
--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -57,6 +57,17 @@ cgr export -o graph.json
 cgr optimize python --repo-path ./my-project
 ```
 
+**Find dead code (functions unreachable from any entry point):**
+
+```bash
+cgr dead-code                                   # scan the indexed project
+cgr dead-code -e main --exclude '*.gen.*'       # add roots, skip generated code
+cgr dead-code --format json --fail-on-found     # CI-friendly report
+```
+
+Results are candidates for review, not a guaranteed delete list. See the
+[Dead Code Detection guide](https://docs.code-graph-rag.com/guide/dead-code/).
+
 **Run as an MCP server (for Claude Code):**
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ An accurate Retrieval-Augmented Generation (RAG) system that analyzes multi-lang
 - **⚡️ Shell Command Execution**: Can execute terminal commands for tasks like running tests or using CLI tools.
 - **🚀 Interactive Code Optimization**: AI-powered codebase optimization with language-specific best practices and interactive approval workflow
 - **📚 Reference-Guided Optimization**: Use your own coding standards and architectural documents to guide optimization suggestions
+- **🧹 Dead Code Detection**: Report functions and methods unreachable from any entry point by walking `CALLS`/`REFERENCES` edges from roots (with a CI-friendly `--fail-on-found`)
 - **🔗 Dependency Analysis**: Parses `pyproject.toml` to understand external dependencies
 - **🎯 Nested Function Support**: Handles complex nested functions and class hierarchies
 - **🔄 Language-Agnostic Design**: Unified graph schema across all supported languages
@@ -606,6 +607,54 @@ The agent will incorporate the guidance from your reference documents when sugge
 - `--repo-path`: Path to repository (defaults to current directory)
 - `--batch-size`: Override Memgraph flush batch size (defaults to `MEMGRAPH_BATCH_SIZE` in settings)
 - `--reference-document`: Path to reference documentation (optimization only)
+
+### Step 5: Dead Code Detection
+
+Once a repository is indexed, report functions and methods that are unreachable
+from any entry point. The walk starts from roots (exported/public symbols,
+tests, decorated handlers like routes/tasks/commands, dunder/lifecycle methods)
+and follows `CALLS` and `REFERENCES` edges; anything it never reaches is listed.
+
+```bash
+# Scan the indexed project (auto-selected when only one exists)
+cgr dead-code
+
+# Pick a project when several are indexed
+cgr dead-code --project-name my-project
+```
+
+**Declare framework/external entry points** so the code they reach is not flagged:
+
+```bash
+cgr dead-code -e main -e cli.run --decorator-root celery_app.task
+```
+
+**Exclude generated or vendored code** (noisy with library-invoked callbacks):
+
+```bash
+cgr dead-code --exclude '*client/core*' --exclude '*.gen.*'
+```
+
+**Fail CI when new unreachable code appears**, writing a JSON report:
+
+```bash
+cgr dead-code --format json --output dead-code.json --fail-on-found
+```
+
+> Results are candidates for review, not a guaranteed delete list: code reached
+> only via dynamic dispatch, reflection, or an external framework may still be
+> reported. See the [Dead Code Detection guide](https://docs.code-graph-rag.com/guide/dead-code/) for details.
+
+**Dead Code CLI Arguments:**
+- `--project-name`, `-n`: Project to scan (defaults to the sole indexed project)
+- `--entry-point`, `-e`: Treat symbols ending with this qualified name as reachable roots (repeatable)
+- `--decorator-root`: Treat symbols carrying this decorator as roots (repeatable)
+- `--exclude`: Glob matched against a symbol's file path to exclude (repeatable)
+- `--include-tests` / `--no-include-tests`: Treat test code as roots (on by default)
+- `--classes` / `--no-classes`: Also report unreachable classes (off by default)
+- `--format`: `table` (default) or `json`
+- `--output`, `-o`: Write the report to a file instead of stdout
+- `--fail-on-found`: Exit with code 1 when any candidate is found
 
 ## 🔌 MCP Server (Claude Code Integration)
 

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -51,6 +51,27 @@ cgr optimize <language> --repo-path /path/to/repo [OPTIONS]
 
 Supported languages: `python`, `javascript`, `typescript`, `rust`, `go`, `java`, `scala`, `cpp`
 
+### `cgr dead-code`
+
+Report functions and methods unreachable from any entry point (candidates for
+review, not a guaranteed delete list). See [Dead Code Detection](dead-code.md).
+
+```bash
+cgr dead-code [OPTIONS]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--project-name`, `-n` | Project to scan. Defaults to the sole indexed project. |
+| `--entry-point`, `-e` | Treat symbols whose qualified name ends with this value as reachable roots. Repeatable. |
+| `--decorator-root` | Treat symbols carrying this decorator as roots. Repeatable. |
+| `--exclude` | Glob matched against a symbol's file path to exclude. Repeatable. |
+| `--include-tests` / `--no-include-tests` | Treat test code as reachable roots. On by default. |
+| `--classes` / `--no-classes` | Also report unreachable classes. Off by default. |
+| `--format` | Output format: `table` (default) or `json`. |
+| `--output`, `-o` | Write the report to a file instead of stdout. |
+| `--fail-on-found` | Exit with code 1 when any candidate is found (useful in CI). |
+
 ### `cgr mcp-server`
 
 Start the MCP server for Claude Code integration.

--- a/docs/guide/dead-code.md
+++ b/docs/guide/dead-code.md
@@ -1,0 +1,101 @@
+---
+description: "Find functions and methods that are unreachable from any entry point using the code knowledge graph."
+---
+
+# Dead Code Detection
+
+`cgr dead-code` reports functions and methods that are **unreachable** from any
+entry point in the knowledge graph. It walks the `CALLS` and `REFERENCES` edges
+outward from a set of roots (exported and public symbols, tests, decorated
+handlers such as routes/tasks/CLI commands, and dunder/lifecycle methods) and
+lists everything the walk never reaches.
+
+The results are **candidates for review, not a guaranteed delete list**. Code
+reached only through dynamic dispatch, reflection, string-keyed lookups, or an
+external framework that the static graph cannot see may still be reported. Read
+each candidate before removing it.
+
+## Prerequisites
+
+Index the repository first, so the graph exists in Memgraph:
+
+```bash
+cgr daemon up
+cgr start --repo-path /path/to/your/repo --update-graph --clean
+```
+
+## Basic Usage
+
+```bash
+cgr dead-code
+```
+
+If a single project is indexed it is used automatically. When several are
+indexed, name one:
+
+```bash
+cgr dead-code --project-name my-project
+```
+
+## Declaring Entry Points
+
+A function invoked only by a framework or an external caller has no visible
+call site, so it looks unreachable. Mark such roots so the code they reach is
+not reported:
+
+```bash
+# Treat any symbol whose qualified name ends with these as reachable roots
+cgr dead-code -e main -e cli.run -e handlers.webhook
+
+# Treat symbols carrying a decorator as roots (extends the built-in set:
+# route, task, fixture, command, ...)
+cgr dead-code --decorator-root celery_app.task --decorator-root my_registry.register
+```
+
+## Excluding Generated Code
+
+Generated or vendored code (API clients, protobuf stubs) is full of callbacks a
+library invokes and reports noisily. Exclude it by file-path glob:
+
+```bash
+cgr dead-code --exclude '*client/core*' --exclude '*.gen.*'
+```
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--project-name`, `-n` | Project to scan. Defaults to the sole indexed project. |
+| `--entry-point`, `-e` | Treat symbols whose qualified name ends with this value as reachable roots. Repeatable. |
+| `--decorator-root` | Treat symbols carrying this decorator as roots. Extends the built-in set. Repeatable. |
+| `--exclude` | Glob matched against a symbol's file path to exclude from the report. Repeatable. |
+| `--include-tests` / `--no-include-tests` | Treat test code as reachable roots so the production code it exercises is not reported. On by default. |
+| `--classes` / `--no-classes` | Also report unreachable classes. Off by default. |
+| `--format` | Output format: `table` (default) or `json`. |
+| `--output`, `-o` | Write the report to this file instead of stdout. |
+| `--fail-on-found` | Exit with code 1 when any candidate is found (useful in CI). |
+
+## Use in CI
+
+Fail a build when new unreachable code appears, writing a JSON report for the
+job artifacts:
+
+```bash
+cgr dead-code --format json --output dead-code.json --fail-on-found \
+  --exclude '*_generated*'
+```
+
+## How It Works
+
+1. **Roots**: exported/public symbols, tests (unless `--no-include-tests`),
+   decorated handlers, dunder/lifecycle methods, plus any `--entry-point` and
+   `--decorator-root` you add.
+2. **Reachability**: a breadth-first walk over `CALLS` and `REFERENCES` edges
+   from every root.
+3. **Report**: functions and methods (and, with `--classes`, classes) the walk
+   never reaches, minus anything matching an `--exclude` glob.
+
+First-class functions matter for accuracy: a callback stored in an object, an
+inline arrow handed to `useMutation`/`.forEach`/`new Promise`, or a function
+passed as an argument is recorded as a `REFERENCES` edge so it stays reachable
+rather than being reported as dead.

--- a/docs/guide/dead-code.md
+++ b/docs/guide/dead-code.md
@@ -91,7 +91,9 @@ cgr dead-code --format json --output dead-code.json --fail-on-found \
    decorated handlers, dunder/lifecycle methods, plus any `--entry-point` and
    `--decorator-root` you add.
 2. **Reachability**: a breadth-first walk over `CALLS` and `REFERENCES` edges
-   from every root.
+   from every root. With `--classes` the walk also follows `INSTANTIATES` and
+   `INHERITS`, so a class counts as reachable when a reachable class
+   instantiates or subclasses it.
 3. **Report**: functions and methods (and, with `--classes`, classes) the walk
    never reaches, minus anything matching an `--exclude` glob.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,7 @@ Code-Graph-RAG is an accurate Retrieval-Augmented Generation (RAG) system that a
 - **Shell Command Execution** for running tests and CLI tools
 - **Interactive Code Optimization** with language-specific best practices
 - **Reference-Guided Optimization** using your own coding standards
+- **Dead Code Detection** to find functions unreachable from any entry point
 - **Dependency Analysis** from `pyproject.toml`
 - **Semantic Code Search** using UniXcoder embeddings to find functions by intent
 - **MCP Server Integration** for seamless use with Claude Code

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,7 @@ nav:
     - CLI Reference: guide/cli-reference.md
     - Interactive Querying: guide/interactive-querying.md
     - Code Optimization: guide/code-optimization.md
+    - Dead Code Detection: guide/dead-code.md
     - Graph Export: guide/graph-export.md
     - Real-Time Updates: guide/realtime-updates.md
     - MCP Server: guide/mcp-server.md


### PR DESCRIPTION
## What

Documents the `cgr dead-code` command, which had no user-facing documentation.

- **README**: new feature bullet and a "Step 5: Dead Code Detection" usage section with examples (entry points, excludes, CI `--fail-on-found`).
- **PyPI page (`PYPI_README.md`)**: a Dead Code entry in the CLI Quick Start so it appears on the package page.
- **Docs site**: a new `guide/dead-code.md` page (added to the nav), a `cgr dead-code` entry in the CLI Reference, and a Key Features bullet on the index.

All examples mirror the command's actual options and help text. No code changes.
