### PR TITLE
fix(cpp): eliminate all 289 souffle orphan nodes via deferred registry-verified containment

### DIFF
--- a/README.md
+++ b/README.md
@@ -705,7 +705,7 @@ The knowledge graph uses the following node types and relationships:
 | Project, Package, Folder | CONTAINS_FOLDER | Folder |
 | Project, Package, Folder | CONTAINS_FILE | File |
 | Project, Package, Folder | CONTAINS_MODULE | Module |
-| Module, Function, Method | DEFINES | Class, Function, Enum, Interface, Type, Union, Module |
+| Module, Function, Method, Class | DEFINES | Class, Function, Method, Enum, Interface, Type, Union, Module |
 | Class, Interface, Enum, Type, Union | DEFINES_METHOD | Method |
 | Module | IMPORTS | Module, ExternalModule |
 | Module | EXPORTS | Class, Function |

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -660,6 +660,7 @@ class AuditCheck(StrEnum):
     UNDOCUMENTED_PROPERTY = "undocumented_property"
     MISSING_REQUIRED_PROPERTY = "missing_required_property"
     UNDOCUMENTED_RELATIONSHIP = "undocumented_relationship"
+    DANGLING_RELATIONSHIP = "dangling_relationship"
 
 
 # (H) Graph audit violation details (issue #646)
@@ -672,6 +673,10 @@ AUDIT_DETAIL_MISSING_REQUIRED = "{label} '{key}' is missing required property '{
 AUDIT_DETAIL_UNDOCUMENTED_RELATIONSHIP = (
     "({from_label})-[:{rel_type}]->({to_label}) is not documented"
     " in RELATIONSHIP_SCHEMAS"
+)
+AUDIT_DETAIL_DANGLING = (
+    "({from_label} '{from_key}')-[:{rel_type}]->({to_label} '{to_key}')"
+    " references a nonexistent node and would be dropped by the database"
 )
 
 # (H) Live-graph audit details (doctor)

--- a/codebase_rag/graph_audit.py
+++ b/codebase_rag/graph_audit.py
@@ -71,13 +71,24 @@ def merge_node_records(
     return list(merged.values())
 
 
+def _node_identities(
+    nodes: Sequence[GraphNodeRecord],
+) -> set[tuple[str, PropertyValue]]:
+    return {(node.label, _node_key(node)) for node in merge_node_records(nodes)}
+
+
 def find_orphans(
     nodes: Sequence[GraphNodeRecord], relationships: Sequence[GraphRelRecord]
 ) -> list[GraphNodeRecord]:
+    identities = _node_identities(nodes)
     connected: set[tuple[str, PropertyValue]] = set()
     for rel in relationships:
-        for label, _, value in (rel.from_spec, rel.to_spec):
-            connected.add((label, value))
+        # (H) The database MERGEs a relationship by MATCHing both endpoints, so
+        # (H) an edge with a nonexistent endpoint is silently dropped and must
+        # (H) not count as connectivity for the endpoint that does exist.
+        endpoints = [(label, value) for label, _, value in (rel.from_spec, rel.to_spec)]
+        if all(endpoint in identities for endpoint in endpoints):
+            connected.update(endpoints)
     return [
         node
         for node in merge_node_records(nodes)
@@ -86,6 +97,36 @@ def find_orphans(
         if node.label != cs.NodeLabel.PROJECT.value
         and (node.label, _node_key(node)) not in connected
     ]
+
+
+def find_dangling_relationships(
+    nodes: Sequence[GraphNodeRecord], relationships: Sequence[GraphRelRecord]
+) -> list[AuditViolation]:
+    identities = _node_identities(nodes)
+    violations: list[AuditViolation] = []
+    seen: set[tuple[str, PropertyValue, str, str, PropertyValue]] = set()
+    for rel in relationships:
+        from_label, _, from_key = rel.from_spec
+        to_label, _, to_key = rel.to_spec
+        if (from_label, from_key) in identities and (to_label, to_key) in identities:
+            continue
+        signature = (from_label, from_key, rel.rel_type, to_label, to_key)
+        if signature in seen:
+            continue
+        seen.add(signature)
+        violations.append(
+            AuditViolation(
+                cs.AuditCheck.DANGLING_RELATIONSHIP,
+                cs.AUDIT_DETAIL_DANGLING.format(
+                    from_label=from_label,
+                    from_key=from_key,
+                    rel_type=rel.rel_type,
+                    to_label=to_label,
+                    to_key=to_key,
+                ),
+            )
+        )
+    return violations
 
 
 def find_property_violations(
@@ -236,4 +277,5 @@ def collect_violations(
     ]
     violations.extend(find_property_violations(nodes))
     violations.extend(find_relationship_violations(relationships))
+    violations.extend(find_dangling_relationships(nodes, relationships))
     return violations

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -551,6 +551,10 @@ class GraphUpdater:
         if corrected:
             logger.info("Resolved {} deferred C++ out-of-class methods", corrected)
 
+        contained = self.factory.definition_processor.resolve_deferred_cpp_containment()
+        if contained:
+            logger.info("Resolved {} deferred C++ nested containments", contained)
+
         go_methods = self.factory.definition_processor.resolve_deferred_go_methods()
         if go_methods:
             logger.info("Resolved {} Go receiver methods", go_methods)
@@ -570,6 +574,13 @@ class GraphUpdater:
                 "Registered {} forward-declared C/C++ types with no definition",
                 kept_forwards,
             )
+
+        # (H) Last containment step: every node-registering pass above (deferred
+        # (H) C++ methods, Go receivers, kept forward declarations) must finish
+        # (H) before parent qns are verified against the registry.
+        linked = self.factory.definition_processor.resolve_deferred_parent_links()
+        if linked:
+            logger.info("Resolved {} deferred containment parents", linked)
 
         logger.info(ls.FOUND_FUNCTIONS, count=len(self.function_registry))
         logger.info(ls.PASS_3_CALLS)

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -31,6 +31,7 @@ from . import relationships as rel
 if TYPE_CHECKING:
     from ...services import IngestorProtocol
     from ...types_defs import (
+        DeferredParentLink,
         FunctionRegistryTrieProtocol,
         LanguageQueries,
         SimpleNameLookup,
@@ -111,6 +112,7 @@ class ClassIngestMixin:
     method_return_types: dict[str, str]
     interface_implementers: dict[str, set[str]]
     _deferred_forward_decls: list[_DeferredForwardDecl]
+    _deferred_parent_links: list[DeferredParentLink]
 
     def _namespace_qn(self, class_qn: str, module_qn: str) -> str:
         # (H) Strip the module-file prefix so two nodes for the same C++ type in
@@ -139,6 +141,16 @@ class ClassIngestMixin:
 
     @abstractmethod
     def _extract_decorators(self, node: ASTNode) -> list[str]: ...
+
+    @abstractmethod
+    def _emit_or_defer_defines(
+        self,
+        parent_label: str,
+        parent_qn: str,
+        child_label: str,
+        child_qn: str,
+        module_qn: str,
+    ) -> None: ...
 
     @abstractmethod
     def _determine_function_parent(
@@ -368,9 +380,20 @@ class ClassIngestMixin:
         self.function_registry[class_qn] = node_type
         if class_name:
             self.simple_name_lookup[class_name].add(class_qn)
+            # (H) An out-of-class nested definition (`class Outer::Inner {}`)
+            # (H) carries the qualifier in its extracted name. Index the leaf
+            # (H) too, or an out-of-line method (`bool Inner::m()`, often via a
+            # (H) `using Inner = Outer::Inner;` alias) can never resolve the
+            # (H) class and binds to a phantom fallback qn.
+            if cs.SEPARATOR_DOUBLE_COLON in class_name:
+                leaf = class_name.rsplit(cs.SEPARATOR_DOUBLE_COLON, 1)[-1]
+                self.simple_name_lookup[leaf].add(class_qn)
 
         parent_label, parent_qn = self._determine_function_parent(
             class_node, class_qn, module_qn, lang_config, language
+        )
+        self._emit_or_defer_defines(
+            parent_label, parent_qn, node_type, class_qn, module_qn
         )
         # (H) For a templated class the canonical node is the template_declaration
         # (H) wrapper, which has no `body` field. Its members -- base clause, fields,
@@ -383,8 +406,6 @@ class ClassIngestMixin:
             member_node,
             class_qn,
             module_qn,
-            parent_label,
-            parent_qn,
             node_type,
             is_exported,
             language,
@@ -511,6 +532,12 @@ class ClassIngestMixin:
                 language,
                 file_path=file_path,
                 repo_path=self.repo_path,
+                # (H) The impl target may be a primitive (`impl From<Foo> for u8`)
+                # (H) or a type registered later in the pass; defer the containment
+                # (H) edge so it verifies against the registry (module fallback for
+                # (H) primitives) instead of dangling on a phantom Class qn.
+                defer_containment=self._deferred_parent_links,
+                module_qn=owner_module_qn,
             )
             # (H) Record the method's return type (Self -> impl target) so a chained
             # (H) call (`Ping::new(msg).into_frame()`) and a call-bound local

--- a/codebase_rag/parsers/class_ingest/relationships.py
+++ b/codebase_rag/parsers/class_ingest/relationships.py
@@ -19,8 +19,6 @@ def create_class_relationships(
     class_node: Node,
     class_qn: str,
     module_qn: str,
-    parent_label: str,
-    parent_qn: str,
     node_type: NodeType,
     is_exported: bool,
     language: cs.SupportedLanguage,
@@ -36,11 +34,9 @@ def create_class_relationships(
     )
     class_inheritance[class_qn] = parent_classes
 
-    ingestor.ensure_relationship_batch(
-        (parent_label, cs.KEY_QUALIFIED_NAME, parent_qn),
-        cs.RelationshipType.DEFINES,
-        (node_type, cs.KEY_QUALIFIED_NAME, class_qn),
-    )
+    # (H) The DEFINES containment edge is emitted by the caller via
+    # (H) _emit_or_defer_defines, so a non-module parent is verified against
+    # (H) the registry after all passes instead of risking a phantom endpoint.
 
     if is_exported and language == cs.SupportedLanguage.CPP:
         ingestor.ensure_relationship_batch(

--- a/codebase_rag/parsers/cpp/utils.py
+++ b/codebase_rag/parsers/cpp/utils.py
@@ -25,6 +25,15 @@ def build_qualified_name(node: Node, module_qn: str, name: str) -> str:
 
         return cs.SEPARATOR_DOT.join([project_name, filename, name])
 
+    path_parts = extract_namespace_path(node)
+
+    if path_parts:
+        return cs.SEPARATOR_DOT.join([module_qn, *path_parts, name])
+    return cs.SEPARATOR_DOT.join([module_qn, name])
+
+
+def extract_namespace_path(node: Node) -> list[str]:
+    """Names of the namespace blocks enclosing *node*, outermost first."""
     path_parts: list[str] = []
     current = node.parent
 
@@ -51,10 +60,7 @@ def build_qualified_name(node: Node, module_qn: str, name: str) -> str:
         current = current.parent
 
     path_parts.reverse()
-
-    if path_parts:
-        return cs.SEPARATOR_DOT.join([module_qn, *path_parts, name])
-    return cs.SEPARATOR_DOT.join([module_qn, name])
+    return path_parts
 
 
 _EXPORT_CANDIDATE_TYPES = frozenset(

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -81,6 +81,8 @@ class DefinitionProcessor(
         self._type_alias_conflicts: set[str] = set()
         self._deferred_cpp_methods: list = []
         self._deferred_go_methods: list = []
+        self._deferred_cpp_containment: list = []
+        self._deferred_parent_links: list = []
         self._deferred_forward_decls: list = []
         self._handler = get_handler(cs.SupportedLanguage.PYTHON)
         self._func_class_captures_cache = func_class_captures_cache

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -69,13 +69,17 @@ class _DeferredCppContainment(NamedTuple):
 
     The parent method's final qn is only known after the deferred method
     resolution binds it to its class (declared in a possibly later-parsed
-    header), so the containment edge must wait for that pass.
+    header), so the containment edge must wait for that pass. namespace_path
+    carries the definition site's enclosing namespaces: the written qualifier
+    inside `namespace beta { void Widget::print() ... }` is just `Widget`, and
+    without the namespace two same-leaf classes are indistinguishable.
     """
 
     child_qn: str
     class_name: str
     method_name: str
     module_qn: str
+    namespace_path: str
 
 
 # (H) Go node labels a receiver type can resolve to (struct -> Class, defined
@@ -830,15 +834,18 @@ class FunctionIngestMixin:
         method_name = cpp_utils.extract_function_name(enclosing)
         if not class_name or not method_name:
             return False
-        leaf = class_name.replace(cs.SEPARATOR_DOUBLE_COLON, cs.SEPARATOR_DOT).rsplit(
-            cs.SEPARATOR_DOT, 1
-        )[-1]
+        # (H) Keep the FULL written qualifier (ns::Widget): _resolve_cpp_class_qn
+        # (H) splits the leaf itself and its endswith guard needs the qualifier to
+        # (H) tell same-leaf classes in different namespaces apart.
         self._deferred_cpp_containment.append(
             _DeferredCppContainment(
                 child_qn=child_qn,
-                class_name=leaf,
+                class_name=class_name,
                 method_name=method_name,
                 module_qn=module_qn,
+                namespace_path=cs.SEPARATOR_DOT.join(
+                    cpp_utils.extract_namespace_path(enclosing)
+                ),
             )
         )
         return True
@@ -923,16 +930,29 @@ class FunctionIngestMixin:
             return 0
         emitted = 0
         for entry in deferred:
-            class_qn, resolved = self._resolve_cpp_class_qn(entry.class_name, "")
-            parent_qn = f"{class_qn}{cs.SEPARATOR_DOT}{entry.method_name}"
-            if resolved and parent_qn in self.function_registry:
-                parent_spec = (cs.NodeLabel.METHOD, cs.KEY_QUALIFIED_NAME, parent_qn)
-            else:
-                parent_spec = (
-                    cs.NodeLabel.MODULE,
-                    cs.KEY_QUALIFIED_NAME,
-                    entry.module_qn,
+            # (H) Try the namespace-scoped name first (alpha.Widget beats a
+            # (H) same-leaf beta.Widget via the endswith guard), then the raw
+            # (H) written qualifier for classes matched through other scopes.
+            candidates = [entry.class_name]
+            if entry.namespace_path:
+                candidates.insert(
+                    0, f"{entry.namespace_path}{cs.SEPARATOR_DOT}{entry.class_name}"
                 )
+            parent_spec = (
+                cs.NodeLabel.MODULE,
+                cs.KEY_QUALIFIED_NAME,
+                entry.module_qn,
+            )
+            for candidate in candidates:
+                class_qn, resolved = self._resolve_cpp_class_qn(candidate, "")
+                parent_qn = f"{class_qn}{cs.SEPARATOR_DOT}{entry.method_name}"
+                if resolved and parent_qn in self.function_registry:
+                    parent_spec = (
+                        cs.NodeLabel.METHOD,
+                        cs.KEY_QUALIFIED_NAME,
+                        parent_qn,
+                    )
+                    break
             self.ingestor.ensure_relationship_batch(
                 parent_spec,
                 cs.RelationshipType.DEFINES,

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -12,6 +12,7 @@ from .. import logs as ls
 from ..language_spec import LANGUAGE_FQN_SPECS, LanguageSpec
 from ..types_defs import (
     ASTNode,
+    DeferredParentLink,
     FunctionRegistryTrieProtocol,
     NodeType,
     PropertyDict,
@@ -51,6 +52,7 @@ class _DeferredMethod(NamedTuple):
     fallback_class_qn: str
     method_props: PropertyDict
     return_type: str | None
+    module_qn: str
 
 
 class _DeferredGoMethod(NamedTuple):
@@ -60,6 +62,20 @@ class _DeferredGoMethod(NamedTuple):
     module_qn: str
     receiver_type: str
     file_path: Path | None
+
+
+class _DeferredCppContainment(NamedTuple):
+    """DEFINES from an out-of-class C++ method to a function nested in its body.
+
+    The parent method's final qn is only known after the deferred method
+    resolution binds it to its class (declared in a possibly later-parsed
+    header), so the containment edge must wait for that pass.
+    """
+
+    child_qn: str
+    class_name: str
+    method_name: str
+    module_qn: str
 
 
 # (H) Go node labels a receiver type can resolve to (struct -> Class, defined
@@ -79,6 +95,8 @@ class FunctionIngestMixin:
     _handler: LanguageHandler
     _deferred_cpp_methods: list[_DeferredMethod]
     _deferred_go_methods: list[_DeferredGoMethod]
+    _deferred_cpp_containment: list[_DeferredCppContainment]
+    _deferred_parent_links: list[DeferredParentLink]
     method_return_types: dict[str, str]
 
     @abstractmethod
@@ -221,7 +239,13 @@ class FunctionIngestMixin:
             for candidate_qn in self.simple_name_lookup[leaf_name]:
                 node_type = self.function_registry.get(candidate_qn)
                 if node_type in {NodeType.CLASS, NodeType.TYPE}:
-                    if candidate_qn.endswith(
+                    # (H) An out-of-class nested definition keeps `Outer::Inner`
+                    # (H) as one qn segment; normalize before the suffix check or
+                    # (H) `::Inner` never matches `.Inner`.
+                    normalized_candidate = candidate_qn.replace(
+                        cs.SEPARATOR_DOUBLE_COLON, cs.SEPARATOR_DOT
+                    )
+                    if normalized_candidate.endswith(
                         f".{class_name_normalized}"
                     ) and self._is_cpp_defined(candidate_qn):
                         return candidate_qn, True
@@ -305,6 +329,7 @@ class FunctionIngestMixin:
                     fallback_class_qn=class_qn,
                     method_props=props,
                     return_type=return_type,
+                    module_qn=module_qn,
                 )
             )
 
@@ -337,11 +362,22 @@ class FunctionIngestMixin:
             if entry.return_type:
                 self.method_return_types[method_qn] = entry.return_type
 
-            self.ingestor.ensure_relationship_batch(
-                (cs.NodeLabel.CLASS, cs.KEY_QUALIFIED_NAME, class_qn),
-                cs.RelationshipType.DEFINES_METHOD,
-                (cs.NodeLabel.METHOD, cs.KEY_QUALIFIED_NAME, method_qn),
-            )
+            if resolved or class_qn in self.function_registry:
+                self.ingestor.ensure_relationship_batch(
+                    (cs.NodeLabel.CLASS, cs.KEY_QUALIFIED_NAME, class_qn),
+                    cs.RelationshipType.DEFINES_METHOD,
+                    (cs.NodeLabel.METHOD, cs.KEY_QUALIFIED_NAME, method_qn),
+                )
+            else:
+                # (H) The class never resolved (not parsed, or its declaration is
+                # (H) macro-corrupted); a DEFINES_METHOD to the phantom fallback qn
+                # (H) would be dropped by the database and orphan the method, so
+                # (H) anchor it to its module instead.
+                self.ingestor.ensure_relationship_batch(
+                    (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, entry.module_qn),
+                    cs.RelationshipType.DEFINES,
+                    (cs.NodeLabel.METHOD, cs.KEY_QUALIFIED_NAME, method_qn),
+                )
             ingested += 1
 
         self._deferred_cpp_methods = []
@@ -548,13 +584,25 @@ class FunctionIngestMixin:
         language: cs.SupportedLanguage,
         lang_config: LanguageSpec,
     ) -> None:
+        # (H) A function nested in an out-of-class C++ method body (a lambda
+        # (H) passed as a call argument) cannot bind its parent yet: the method's
+        # (H) final qn is class-anchored and the class may live in a header not
+        # (H) parsed until later, so the walk would emit a phantom free-fn parent
+        # (H) that the database drops, orphaning the lambda (issue #650).
+        if language == cs.SupportedLanguage.CPP and self._defer_cpp_containment(
+            func_node, resolution.qualified_name, module_qn, lang_config
+        ):
+            return
+
         parent_type, parent_qn = self._determine_function_parent(
             func_node, resolution.qualified_name, module_qn, lang_config, language
         )
-        self.ingestor.ensure_relationship_batch(
-            (parent_type, cs.KEY_QUALIFIED_NAME, parent_qn),
-            cs.RelationshipType.DEFINES,
-            (cs.NodeLabel.FUNCTION, cs.KEY_QUALIFIED_NAME, resolution.qualified_name),
+        self._emit_or_defer_defines(
+            parent_type,
+            parent_qn,
+            cs.NodeLabel.FUNCTION,
+            resolution.qualified_name,
+            module_qn,
         )
 
         # (H) A Rust closure is a value constructed at its definition site (a `.map`
@@ -753,6 +801,146 @@ class FunctionIngestMixin:
 
     def _is_method(self, func_node: Node, lang_config: LanguageSpec) -> bool:
         return is_method_node(func_node, lang_config)
+
+    def _find_enclosing_function_node(
+        self, func_node: Node, lang_config: LanguageSpec
+    ) -> Node | None:
+        # (H) Mirrors _determine_function_parent's walk: first ancestor that is a
+        # (H) function-like node, stopping at the module boundary.
+        current = func_node.parent
+        while current is not None and current.type not in lang_config.module_node_types:
+            if current.type in lang_config.function_node_types:
+                return current
+            current = current.parent
+        return None
+
+    def _defer_cpp_containment(
+        self,
+        func_node: Node,
+        child_qn: str,
+        module_qn: str,
+        lang_config: LanguageSpec,
+    ) -> bool:
+        enclosing = self._find_enclosing_function_node(func_node, lang_config)
+        if enclosing is None or not cpp_utils.is_out_of_class_method_definition(
+            enclosing
+        ):
+            return False
+        class_name = cpp_utils.extract_class_name_from_out_of_class_method(enclosing)
+        method_name = cpp_utils.extract_function_name(enclosing)
+        if not class_name or not method_name:
+            return False
+        leaf = class_name.replace(cs.SEPARATOR_DOUBLE_COLON, cs.SEPARATOR_DOT).rsplit(
+            cs.SEPARATOR_DOT, 1
+        )[-1]
+        self._deferred_cpp_containment.append(
+            _DeferredCppContainment(
+                child_qn=child_qn,
+                class_name=leaf,
+                method_name=method_name,
+                module_qn=module_qn,
+            )
+        )
+        return True
+
+    def _emit_or_defer_defines(
+        self,
+        parent_label: str,
+        parent_qn: str,
+        child_label: str,
+        child_qn: str,
+        module_qn: str,
+    ) -> None:
+        # (H) Module nodes always exist, so module-parented edges emit directly.
+        # (H) Any other parent may be registered by a later pass (methods land
+        # (H) after functions) or may be a phantom recomputed qn the database
+        # (H) would drop; both resolve in resolve_deferred_parent_links.
+        if parent_label == cs.NodeLabel.MODULE:
+            self.ingestor.ensure_relationship_batch(
+                (parent_label, cs.KEY_QUALIFIED_NAME, parent_qn),
+                cs.RelationshipType.DEFINES,
+                (child_label, cs.KEY_QUALIFIED_NAME, child_qn),
+            )
+            return
+        self._deferred_parent_links.append(
+            DeferredParentLink(
+                parent_label_guess=parent_label,
+                parent_qn=parent_qn,
+                child_label=child_label,
+                child_qn=child_qn,
+                module_qn=module_qn,
+            )
+        )
+
+    def resolve_deferred_parent_links(self) -> int:
+        """Emit deferred non-module DEFINES once every pass has registered.
+
+        A registered parent gets the edge under its real label; an
+        unregistered parent qn is a phantom, so the child anchors to its
+        module rather than losing the edge at the database MERGE.
+        """
+        deferred = getattr(self, "_deferred_parent_links", None)
+        if not deferred:
+            return 0
+        emitted = 0
+        for entry in deferred:
+            if registered := self.function_registry.get(entry.parent_qn):
+                parent_spec = (
+                    cs.NodeLabel(registered.value),
+                    cs.KEY_QUALIFIED_NAME,
+                    entry.parent_qn,
+                )
+                rel_type = entry.rel_type
+            else:
+                # (H) A method whose container never registered (impl on a
+                # (H) primitive, macro-corrupted class) anchors to its module
+                # (H) with DEFINES; DEFINES_METHOD from a Module is not a
+                # (H) documented shape.
+                parent_spec = (
+                    cs.NodeLabel.MODULE,
+                    cs.KEY_QUALIFIED_NAME,
+                    entry.module_qn,
+                )
+                rel_type = cs.RelationshipType.DEFINES.value
+            self.ingestor.ensure_relationship_batch(
+                parent_spec,
+                rel_type,
+                (entry.child_label, cs.KEY_QUALIFIED_NAME, entry.child_qn),
+            )
+            emitted += 1
+        self._deferred_parent_links = []
+        return emitted
+
+    def resolve_deferred_cpp_containment(self) -> int:
+        """Emit DEFINES for functions nested in out-of-class C++ method bodies.
+
+        Runs after resolve_deferred_cpp_methods so the parent method nodes
+        exist under their final class-anchored qns. Falls back to the file
+        module rather than ever emitting a phantom parent.
+        """
+        deferred = getattr(self, "_deferred_cpp_containment", None)
+        if not deferred:
+            return 0
+        emitted = 0
+        for entry in deferred:
+            class_qn, resolved = self._resolve_cpp_class_qn(entry.class_name, "")
+            parent_qn = f"{class_qn}{cs.SEPARATOR_DOT}{entry.method_name}"
+            if resolved and parent_qn in self.function_registry:
+                parent_spec = (cs.NodeLabel.METHOD, cs.KEY_QUALIFIED_NAME, parent_qn)
+            else:
+                parent_spec = (
+                    cs.NodeLabel.MODULE,
+                    cs.KEY_QUALIFIED_NAME,
+                    entry.module_qn,
+                )
+            self.ingestor.ensure_relationship_batch(
+                parent_spec,
+                cs.RelationshipType.DEFINES,
+                (cs.NodeLabel.FUNCTION, cs.KEY_QUALIFIED_NAME, entry.child_qn),
+            )
+            emitted += 1
+        self._deferred_cpp_containment = []
+        return emitted
 
     def _determine_function_parent(
         self,

--- a/codebase_rag/parsers/js_ts/ingest.py
+++ b/codebase_rag/parsers/js_ts/ingest.py
@@ -49,6 +49,16 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
     def _get_docstring(self, node: ASTNode) -> str | None: ...
 
     @abstractmethod
+    def _emit_or_defer_defines(
+        self,
+        parent_label: str,
+        parent_qn: str,
+        child_label: str,
+        child_qn: str,
+        module_qn: str,
+    ) -> None: ...
+
+    @abstractmethod
     def _build_nested_qualified_name(
         self,
         func_node: ASTNode,
@@ -191,10 +201,16 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
                 self.function_registry[method_qn] = NodeType.FUNCTION
                 self.simple_name_lookup[method_name].add(method_qn)
 
-                self.ingestor.ensure_relationship_batch(
-                    (cs.NodeLabel.FUNCTION, cs.KEY_QUALIFIED_NAME, constructor_qn),
-                    cs.RelationshipType.DEFINES,
-                    (cs.NodeLabel.FUNCTION, cs.KEY_QUALIFIED_NAME, method_qn),
+                # (H) The assignment target is not always a registered constructor
+                # (H) function: `target.prototype.render = ...` inside a decorator
+                # (H) names a parameter, so the parent qn would be a phantom the
+                # (H) database drops. Defer so it verifies against the registry.
+                self._emit_or_defer_defines(
+                    cs.NodeLabel.FUNCTION,
+                    constructor_qn,
+                    cs.NodeLabel.FUNCTION,
+                    method_qn,
+                    module_qn,
                 )
 
                 logger.debug(

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -12,6 +12,7 @@ from .. import constants as cs
 from .. import logs
 from ..types_defs import (
     ASTNode,
+    DeferredParentLink,
     LanguageQueries,
     NodeType,
     PropertyDict,
@@ -556,6 +557,8 @@ def ingest_method(
     method_qualified_name: str | None = None,
     file_path: Path | None = None,
     repo_path: Path | None = None,
+    defer_containment: list[DeferredParentLink] | None = None,
+    module_qn: str | None = None,
 ) -> None:
     if language == cs.SupportedLanguage.CPP:
         from .cpp import utils as cpp_utils
@@ -623,6 +626,22 @@ def ingest_method(
         method_qn, callable_parameter_indices(method_node, language)
     )
     simple_name_lookup[method_name].add(method_qn)
+
+    # (H) A container that may never register (a Rust impl on a primitive type)
+    # (H) defers so the edge is verified once every pass has run, falling back
+    # (H) to the module rather than a phantom the database would drop.
+    if defer_containment is not None and module_qn is not None:
+        defer_containment.append(
+            DeferredParentLink(
+                parent_label_guess=container_type,
+                parent_qn=container_qn,
+                child_label=cs.NodeLabel.METHOD,
+                child_qn=method_qn,
+                module_qn=module_qn,
+                rel_type=cs.RelationshipType.DEFINES_METHOD.value,
+            )
+        )
+        return
 
     # (H) The DEFINES_METHOD parent is matched in the graph by LABEL +
     # (H) qualified_name, so it must carry the container's real node label. Callers

--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, call
 import pytest
 from loguru import logger
 
+from codebase_rag import constants as cs
 from codebase_rag import graph_audit
 from codebase_rag.graph_updater import GraphUpdater
 from codebase_rag.parser_loader import load_parsers
@@ -195,7 +196,15 @@ def _audit_recorded_graph(mock_ingestor: MagicMock) -> None:
         GraphRelRecord(c.args[0], str(c.args[1]), c.args[2])
         for c in mock_ingestor.ensure_relationship_batch.call_args_list
     ]
-    violations = graph_audit.collect_violations(nodes, rels)
+    violations = [
+        v
+        # (H) Dangling relationships are a pervasive pre-existing debt class
+        # (H) (302 fixture tests emit them across every language; issue #652).
+        # (H) Gate on them once that campaign lands; orphan detection already
+        # (H) uses live-faithful connectivity.
+        for v in graph_audit.collect_violations(nodes, rels)
+        if v.check != cs.AuditCheck.DANGLING_RELATIONSHIP
+    ]
     if sweep_path := os.environ.get("CGR_AUDIT_SWEEP"):
         import json
 

--- a/codebase_rag/tests/test_cpp_lambda_containment.py
+++ b/codebase_rag/tests/test_cpp_lambda_containment.py
@@ -1,0 +1,88 @@
+# (H) A lambda in an out-of-line C++ method body (`void Directive::print()
+# (H) { join(xs, [](){...}); }` in a .cpp, class declared in a header) must get
+# (H) its DEFINES parent from the real class-anchored Method node. The parent
+# (H) walk used to recompute a free-function qn that drops the `Class::` scope
+# (H) (module.ns.print), which matches no node, so the database dropped the
+# (H) edge and every such lambda was an orphan (issue #650: 234 on souffle).
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag import graph_audit as ga
+from codebase_rag.tests.conftest import get_relationships, run_updater
+from codebase_rag.types_defs import GraphNodeRecord, GraphRelRecord
+
+HDR = """
+#pragma once
+namespace souffle {
+class Directive {
+public:
+    void print() const;
+};
+}
+"""
+
+CPP = """
+#include "Directive.h"
+namespace souffle {
+
+void Directive::print() const {
+    invoke(1, [](int x) { return x + 1; });
+}
+
+int freeRun() {
+    return invoke(2, [](int y) { return y * 2; });
+}
+
+}
+"""
+
+
+def _write_fixture(repo: Path) -> None:
+    (repo / "Directive.h").write_text(HDR)
+    (repo / "Directive.cpp").write_text(CPP)
+
+
+def _lambda_defines(mock_ingestor: MagicMock) -> dict[str, tuple[str, str]]:
+    parents: dict[str, tuple[str, str]] = {}
+    for call in get_relationships(mock_ingestor, cs.RelationshipType.DEFINES.value):
+        to_qn = str(call.args[2][2])
+        if cs.PREFIX_LAMBDA in to_qn:
+            parents[to_qn] = (str(call.args[0][0]), str(call.args[0][2]))
+    return parents
+
+
+def test_out_of_line_method_lambda_binds_to_method_node(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    _write_fixture(temp_repo)
+    run_updater(temp_repo, mock_ingestor)
+
+    parents = _lambda_defines(mock_ingestor)
+    method_lambda = next(parents[qn] for qn in parents if "lambda_5_" in qn)
+    assert method_lambda[0] == cs.NodeLabel.METHOD.value
+    assert method_lambda[1].endswith("Directive.print")
+
+    free_lambda = next(parents[qn] for qn in parents if "lambda_9_" in qn)
+    assert free_lambda[1].endswith("freeRun")
+
+
+def test_cpp_lambda_fixture_has_no_orphans_or_dangling_defines(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    _write_fixture(temp_repo)
+    run_updater(temp_repo, mock_ingestor)
+
+    nodes = [
+        GraphNodeRecord(str(c.args[0]), c.args[1])
+        for c in mock_ingestor.ensure_node_batch.call_args_list
+    ]
+    rels = [
+        GraphRelRecord(c.args[0], str(c.args[1]), c.args[2])
+        for c in mock_ingestor.ensure_relationship_batch.call_args_list
+    ]
+    # (H) Orphan detection counts only edges the database would keep, so this
+    # (H) fails if the lambda's DEFINES parent is a phantom qn.
+    assert ga.find_orphans(nodes, rels) == []

--- a/codebase_rag/tests/test_cpp_lambda_containment.py
+++ b/codebase_rag/tests/test_cpp_lambda_containment.py
@@ -54,6 +54,54 @@ def _lambda_defines(mock_ingestor: MagicMock) -> dict[str, tuple[str, str]]:
     return parents
 
 
+TWO_NAMESPACES_HDR = """
+#pragma once
+namespace alpha {
+class Widget {
+public:
+    void print() const;
+};
+}
+namespace beta {
+class Widget {
+public:
+    void print() const;
+};
+}
+"""
+
+TWO_NAMESPACES_CPP = """
+#include "Widget.h"
+namespace alpha {
+void Widget::print() const {
+    invoke(1, [](int x) { return x + 1; });
+}
+}
+namespace beta {
+void Widget::print() const {
+    invoke(2, [](int y) { return y * 2; });
+}
+}
+"""
+
+
+def test_same_leaf_classes_bind_lambdas_to_their_own_namespace(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) alpha::Widget and beta::Widget share a leaf name; each out-of-line
+    # (H) method's lambda must bind to its own namespace's Method node, not
+    # (H) whichever Widget resolves first from the simple-name index.
+    (temp_repo / "Widget.h").write_text(TWO_NAMESPACES_HDR)
+    (temp_repo / "Widget.cpp").write_text(TWO_NAMESPACES_CPP)
+    run_updater(temp_repo, mock_ingestor)
+
+    parents = _lambda_defines(mock_ingestor)
+    alpha_lambda = next(parents[qn] for qn in parents if "lambda_4_" in qn)
+    beta_lambda = next(parents[qn] for qn in parents if "lambda_9_" in qn)
+    assert ".alpha." in alpha_lambda[1], alpha_lambda
+    assert ".beta." in beta_lambda[1], beta_lambda
+
+
 def test_out_of_line_method_lambda_binds_to_method_node(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:

--- a/codebase_rag/tests/test_cpp_nested_type_containment.py
+++ b/codebase_rag/tests/test_cpp_nested_type_containment.py
@@ -1,0 +1,71 @@
+# (H) Types nested inside a C++ class body (class/enum/union members) must get
+# (H) a DEFINES edge from the enclosing Class node. The parent walk used to
+# (H) fall back to a qn-trim labeled Method (a phantom: right qn, wrong label),
+# (H) which the database drops, orphaning every class-nested type (issue #650:
+# (H) 17 Class + 16 Enum + 1 Union orphans on souffle).
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag import graph_audit as ga
+from codebase_rag.tests.conftest import get_relationships, run_updater
+from codebase_rag.types_defs import GraphNodeRecord, GraphRelRecord
+
+HDR = """
+#pragma once
+namespace souffle {
+class Program {
+public:
+    class RelationInfo {
+    public:
+        int arity;
+    };
+    enum class State { Ok, Bad };
+    union Cell { int i; float f; };
+    void run();
+};
+}
+"""
+
+
+def _write_fixture(repo: Path) -> None:
+    (repo / "Program.h").write_text(HDR)
+
+
+def test_class_nested_types_bind_to_enclosing_class(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    _write_fixture(temp_repo)
+    run_updater(temp_repo, mock_ingestor)
+
+    parents: dict[str, tuple[str, str]] = {}
+    for call in get_relationships(mock_ingestor, cs.RelationshipType.DEFINES.value):
+        to_qn = str(call.args[2][2])
+        parents[to_qn.rsplit(".", 1)[-1]] = (
+            str(call.args[0][0]),
+            str(call.args[0][2]),
+        )
+
+    for nested in ("RelationInfo", "State", "Cell"):
+        label, qn = parents[nested]
+        assert label == cs.NodeLabel.CLASS.value, (nested, label)
+        assert qn.endswith(".Program"), (nested, qn)
+
+
+def test_cpp_nested_type_fixture_has_no_orphans(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    _write_fixture(temp_repo)
+    run_updater(temp_repo, mock_ingestor)
+
+    nodes = [
+        GraphNodeRecord(str(c.args[0]), c.args[1])
+        for c in mock_ingestor.ensure_node_batch.call_args_list
+    ]
+    rels = [
+        GraphRelRecord(c.args[0], str(c.args[1]), c.args[2])
+        for c in mock_ingestor.ensure_relationship_batch.call_args_list
+    ]
+    assert ga.find_orphans(nodes, rels) == []

--- a/codebase_rag/tests/test_cpp_out_of_class_nested_method.py
+++ b/codebase_rag/tests/test_cpp_out_of_class_nested_method.py
@@ -1,0 +1,99 @@
+# (H) A nested class defined out-of-class (`class Outer::Inner : ... {}` in a
+# (H) header) registers its name as the literal `Outer::Inner`, so an
+# (H) out-of-line method in a .cpp (`bool Inner::transform()`, typically via a
+# (H) `using Inner = Outer::Inner;` alias) failed the leaf lookup and the
+# (H) endswith guard, fell back to a phantom class qn, and both the method and
+# (H) its DEFINES_METHOD edge dangled (issue #650: the ~21-method tail of
+# (H) #496/#512 on souffle's MagicSet.cpp).
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag import graph_audit as ga
+from codebase_rag.tests.conftest import get_relationships, run_updater
+from codebase_rag.types_defs import GraphNodeRecord, GraphRelRecord
+
+HDR = """
+#pragma once
+namespace souffle {
+
+class MagicSetTransformer {
+public:
+    class NormaliseDatabaseTransformer;
+};
+
+class MagicSetTransformer::NormaliseDatabaseTransformer {
+public:
+    bool transform();
+};
+
+}
+"""
+
+CPP = """
+#include "MagicSet.h"
+namespace souffle {
+
+using NormaliseDatabaseTransformer = MagicSetTransformer::NormaliseDatabaseTransformer;
+
+bool NormaliseDatabaseTransformer::transform() {
+    return true;
+}
+
+}
+"""
+
+
+def _write_fixture(repo: Path) -> None:
+    (repo / "MagicSet.h").write_text(HDR)
+    (repo / "MagicSet.cpp").write_text(CPP)
+
+
+def test_out_of_line_method_of_nested_class_binds_to_real_class(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    _write_fixture(temp_repo)
+    run_updater(temp_repo, mock_ingestor)
+
+    class_qns = {
+        c.args[1]["qualified_name"]
+        for c in mock_ingestor.ensure_node_batch.call_args_list
+        if str(c.args[0]) == cs.NodeLabel.CLASS.value
+    }
+    # (H) The forward-declared member also mints a dot-form Class node
+    # (H) (Outer.Inner); the defined class keeps the literal Outer::Inner
+    # (H) segment, and that is the node out-of-line methods must bind to.
+    nested_class_qn = next(
+        qn for qn in class_qns if qn.endswith("::NormaliseDatabaseTransformer")
+    )
+
+    method_parents = {
+        str(call.args[2][2]): str(call.args[0][2])
+        for call in get_relationships(
+            mock_ingestor, cs.RelationshipType.DEFINES_METHOD.value
+        )
+    }
+    transform_edges = {
+        qn: parent for qn, parent in method_parents.items() if qn.endswith(".transform")
+    }
+    assert transform_edges, method_parents
+    for qn, parent in transform_edges.items():
+        assert parent == nested_class_qn, (qn, parent)
+        assert qn.startswith(nested_class_qn), qn
+
+
+def test_fixture_has_no_orphans(temp_repo: Path, mock_ingestor: MagicMock) -> None:
+    _write_fixture(temp_repo)
+    run_updater(temp_repo, mock_ingestor)
+
+    nodes = [
+        GraphNodeRecord(str(c.args[0]), c.args[1])
+        for c in mock_ingestor.ensure_node_batch.call_args_list
+    ]
+    rels = [
+        GraphRelRecord(c.args[0], str(c.args[1]), c.args[2])
+        for c in mock_ingestor.ensure_relationship_batch.call_args_list
+    ]
+    assert ga.find_orphans(nodes, rels) == []

--- a/codebase_rag/tests/test_cpp_unresolved_method_class_fallback.py
+++ b/codebase_rag/tests/test_cpp_unresolved_method_class_fallback.py
@@ -1,0 +1,51 @@
+# (H) An out-of-line C++ method whose class cannot be resolved (macro-corrupted
+# (H) declarations, or no such class parsed at all) used to get a
+# (H) DEFINES_METHOD edge to a phantom fallback class qn, which the database
+# (H) drops, orphaning the Method node (issue #650, the span.h make_span case).
+# (H) The node must instead anchor to its module so it stays reachable.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag import graph_audit as ga
+from codebase_rag.tests.conftest import get_relationships, run_updater
+from codebase_rag.types_defs import GraphNodeRecord, GraphRelRecord
+
+CPP = """
+int Mystery::bar() {
+    return 1;
+}
+"""
+
+
+def test_unresolvable_out_of_line_method_anchors_to_module(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "mystery.cpp").write_text(CPP)
+    run_updater(temp_repo, mock_ingestor)
+
+    method_qns = {
+        c.args[1]["qualified_name"]
+        for c in mock_ingestor.ensure_node_batch.call_args_list
+        if str(c.args[0]) == cs.NodeLabel.METHOD.value
+    }
+    bar_qn = next(qn for qn in method_qns if qn.endswith(".bar"))
+
+    module_defines = {
+        str(call.args[2][2])
+        for call in get_relationships(mock_ingestor, cs.RelationshipType.DEFINES.value)
+        if str(call.args[0][0]) == cs.NodeLabel.MODULE.value
+    }
+    assert bar_qn in module_defines
+
+    nodes = [
+        GraphNodeRecord(str(c.args[0]), c.args[1])
+        for c in mock_ingestor.ensure_node_batch.call_args_list
+    ]
+    rels = [
+        GraphRelRecord(c.args[0], str(c.args[1]), c.args[2])
+        for c in mock_ingestor.ensure_relationship_batch.call_args_list
+    ]
+    assert ga.find_orphans(nodes, rels) == []

--- a/codebase_rag/tests/test_graph_audit.py
+++ b/codebase_rag/tests/test_graph_audit.py
@@ -5,6 +5,8 @@
 # (H) schema in types_defs.NODE_SCHEMAS / RELATIONSHIP_SCHEMAS.
 from __future__ import annotations
 
+import collections
+
 from codebase_rag import constants as cs
 from codebase_rag import graph_audit as ga
 from codebase_rag.types_defs import GraphNodeRecord, GraphRelRecord, PropertyDict
@@ -149,6 +151,32 @@ class TestPropertyMerging:
         )
         nodes.insert(0, partial)
         assert ga.collect_violations(nodes, rels) == []
+
+
+class TestDanglingRelationships:
+    def test_edge_to_missing_node_is_flagged_and_not_connectivity(self) -> None:
+        # (H) Live Memgraph silently drops an edge whose endpoint has no node,
+        # (H) so the mock audit must flag the dangling edge AND still report
+        # (H) the emitted node as an orphan.
+        nodes, rels = _clean_graph()
+        nodes.append(_function("proj.mod.lam"))
+        rels.append(
+            _rel(
+                cs.NodeLabel.FUNCTION.value,
+                "proj.mod.GHOST",
+                cs.RelationshipType.DEFINES.value,
+                cs.NodeLabel.FUNCTION.value,
+                "proj.mod.lam",
+            )
+        )
+        violations = ga.collect_violations(nodes, rels)
+        checks = collections.Counter(v.check for v in violations)
+        assert checks[cs.AuditCheck.DANGLING_RELATIONSHIP] == 1
+        assert checks[cs.AuditCheck.ORPHAN_NODE] == 1
+        dangling = next(
+            v for v in violations if v.check == cs.AuditCheck.DANGLING_RELATIONSHIP
+        )
+        assert "proj.mod.GHOST" in dangling.detail
 
 
 class TestRelationshipConformance:

--- a/codebase_rag/tests/test_health_checker.py
+++ b/codebase_rag/tests/test_health_checker.py
@@ -19,6 +19,14 @@ def test_check_memgraph_connection_returns_failure_when_down(
     assert result.passed is False
 
 
+class _FakeColumn:
+    # (H) Mirrors mgclient.Column: exposes .name and is NOT subscriptable.
+    __slots__ = ("name",)
+
+    def __init__(self, name: str):
+        self.name = name
+
+
 class _FakeCursor:
     def __init__(self, rows_by_marker: dict[str, list[tuple]], columns: list[str]):
         self._rows_by_marker = rows_by_marker
@@ -34,8 +42,8 @@ class _FakeCursor:
                 return
 
     @property
-    def description(self) -> list[tuple]:
-        return [(name,) for name in self._columns]
+    def description(self) -> list[_FakeColumn]:
+        return [_FakeColumn(name) for name in self._columns]
 
     def fetchall(self) -> list[tuple]:
         return self._rows

--- a/codebase_rag/tools/health_checker.py
+++ b/codebase_rag/tools/health_checker.py
@@ -202,7 +202,8 @@ class HealthChecker:
 
         def fetch_all(query: str) -> list[ResultRow]:
             cursor.execute(query)
-            columns = [column[0] for column in cursor.description or []]
+            # (H) mgclient.Column is not subscriptable; the name is an attribute.
+            columns = [column.name for column in cursor.description or []]
             return [dict(zip(columns, row)) for row in cursor.fetchall()]
 
         try:

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -491,6 +491,24 @@ class AuditViolation(NamedTuple):
     detail: str
 
 
+class DeferredParentLink(NamedTuple):
+    """Containment edge whose non-module parent must exist before emission.
+
+    Parents can be registered by a later pass than the child (methods land in
+    the class pass after the function pass; forward declarations register
+    last), so verification waits until every pass finishes. A parent qn that
+    never registers is a phantom the database would drop, so the child
+    anchors to its module instead.
+    """
+
+    parent_label_guess: str
+    parent_qn: str
+    child_label: str
+    child_qn: str
+    module_qn: str
+    rel_type: str = RelationshipType.DEFINES.value
+
+
 class RelationshipSchema(NamedTuple):
     sources: tuple[NodeLabel, ...]
     rel_type: RelationshipType
@@ -578,11 +596,12 @@ RELATIONSHIP_SCHEMAS: tuple[RelationshipSchema, ...] = (
         (NodeLabel.MODULE,),
     ),
     RelationshipSchema(
-        (NodeLabel.MODULE, NodeLabel.FUNCTION, NodeLabel.METHOD),
+        (NodeLabel.MODULE, NodeLabel.FUNCTION, NodeLabel.METHOD, NodeLabel.CLASS),
         RelationshipType.DEFINES,
         (
             NodeLabel.CLASS,
             NodeLabel.FUNCTION,
+            NodeLabel.METHOD,
             NodeLabel.ENUM,
             NodeLabel.INTERFACE,
             NodeLabel.TYPE,

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.250"
+version = "0.0.251"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #650

## What

Eliminates every orphan node the #646 structural audit found on a live index of souffle-lang/souffle: 289 orphans (234 Function, 21 Method, 17 Class, 16 Enum, 1 Union) down to **zero**, with the schema staying fully conformant.

## Root causes and fixes

All orphans shared one mechanism: a containment edge emitted with a phantom parent endpoint (wrong qn or wrong label) that Memgraph's MERGE silently drops.

1. **Lambdas in out-of-line C++ method bodies** (largest bucket): the DEFINES parent walk recomputed the enclosing `void Directive::print()` as a free-function qn, dropping the `Class::` scope and the header anchoring. Fixed with a dedicated deferral (`_DeferredCppContainment`): the edge waits for the deferred out-of-class method resolution, then binds to the real class-anchored Method node.
2. **Types nested in class bodies** (`Program::RelationInfo`, `MainConfig::State`): the parent fallback trimmed to the right qn but guessed the label as Method, so the edge never MERGEd. The registry now supplies the real label, and `Class` is a documented `DEFINES` source (schema + README regenerated; the conftest audit gate enforces both sides).
3. **Out-of-line methods of out-of-class-defined nested classes** (`bool NormaliseDatabaseTransformer::transform()` via a using-alias, souffle's MagicSet pattern): the class registers its literal `Outer::Inner` name, so the leaf lookup and the `endswith` guard both missed it. The leaf is now indexed too and the candidate qn is normalized before the suffix check.
4. **Generalized guard, `resolve_deferred_parent_links`**: every non-module DEFINES parent (and Rust impl-target DEFINES_METHOD, e.g. `impl From<Foo> for u8` whose container is a primitive with no node) is now emitted only after all passes have registered, verified against the function registry. A parent that never registers anchors the child to its module instead of losing the edge. This runs last in `GraphUpdater.run()`, after deferred C++ methods, Go receivers, and kept forward declarations.
5. **Unresolvable out-of-class method classes** (macro-corrupted declarations like span.h's `TCB_SPAN_ARRAY_CONSTEXPR` split-return parse): the deferred method resolver anchors the method to its module instead of emitting DEFINES_METHOD to a phantom fallback class qn. `Method` is now a documented `DEFINES` target for this fallback.

## Audit improvements shipped alongside

- **Dangling-relationship check** (`find_dangling_relationships`): the in-memory audit previously counted an edge as connectivity even when its other endpoint had no node, which live Memgraph drops. Orphan detection now counts only edges the database would keep, matching production semantics. The new check itself is reported by `collect_violations` but excluded from the conftest gate for now: it exposes a pervasive pre-existing debt class (~19k dropped edges on souffle, 302 fixture tests across all languages), tracked as the campaign in #652.
- **Doctor fix**: `check_graph_integrity` crashed against real Memgraph because `mgclient.Column` is not subscriptable; the unit-test fake was faithful-ized (RED) and the column read fixed (GREEN).

## Verification

- RED commit first: four failing containment test files landed before the fixes.
- Full suite: 4564 passed, 0 failed; ruff and the pre-commit ty gate clean.
- Acceptance: souffle re-indexed into live Memgraph after the fixes; `graph_audit.collect_live_violations` reports **zero violations** (no orphans, no schema drift). The blog's original corpus now audits completely clean.
