### PR TITLE
fix(cpp): resolve includes against real files and unify name resolution across passes

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -1804,40 +1804,6 @@ JS_FUNCTION_PROTOTYPE_METHODS = frozenset(
     {JS_METHOD_BIND, JS_METHOD_CALL, JS_METHOD_APPLY}
 )
 
-# (H) C++ operator mappings
-CPP_OPERATORS: dict[str, str] = {
-    "operator_plus": "builtin.cpp.operator_plus",
-    "operator_minus": "builtin.cpp.operator_minus",
-    "operator_multiply": "builtin.cpp.operator_multiply",
-    "operator_divide": "builtin.cpp.operator_divide",
-    "operator_modulo": "builtin.cpp.operator_modulo",
-    "operator_equal": "builtin.cpp.operator_equal",
-    "operator_not_equal": "builtin.cpp.operator_not_equal",
-    "operator_less": "builtin.cpp.operator_less",
-    "operator_greater": "builtin.cpp.operator_greater",
-    "operator_less_equal": "builtin.cpp.operator_less_equal",
-    "operator_greater_equal": "builtin.cpp.operator_greater_equal",
-    "operator_assign": "builtin.cpp.operator_assign",
-    "operator_plus_assign": "builtin.cpp.operator_plus_assign",
-    "operator_minus_assign": "builtin.cpp.operator_minus_assign",
-    "operator_multiply_assign": "builtin.cpp.operator_multiply_assign",
-    "operator_divide_assign": "builtin.cpp.operator_divide_assign",
-    "operator_modulo_assign": "builtin.cpp.operator_modulo_assign",
-    "operator_increment": "builtin.cpp.operator_increment",
-    "operator_decrement": "builtin.cpp.operator_decrement",
-    "operator_left_shift": "builtin.cpp.operator_left_shift",
-    "operator_right_shift": "builtin.cpp.operator_right_shift",
-    "operator_bitwise_and": "builtin.cpp.operator_bitwise_and",
-    "operator_bitwise_or": "builtin.cpp.operator_bitwise_or",
-    "operator_bitwise_xor": "builtin.cpp.operator_bitwise_xor",
-    "operator_bitwise_not": "builtin.cpp.operator_bitwise_not",
-    "operator_logical_and": "builtin.cpp.operator_logical_and",
-    "operator_logical_or": "builtin.cpp.operator_logical_or",
-    "operator_logical_not": "builtin.cpp.operator_logical_not",
-    "operator_subscript": "builtin.cpp.operator_subscript",
-    "operator_call": "builtin.cpp.operator_call",
-}
-
 # (H) Language CLI paths and patterns
 LANG_GRAMMARS_DIR = "grammars"
 LANG_CONFIG_FILE = "codebase_rag/language_spec.py"

--- a/codebase_rag/language_spec.py
+++ b/codebase_rag/language_spec.py
@@ -138,6 +138,14 @@ def _c_get_name(node: Node) -> str | None:
 
 
 def _cpp_get_name(node: Node) -> str | None:
+    # (H) C++17 `namespace a::b {` is ONE node named `a::b`; render it as
+    # (H) dotted segments so both nesting spellings, the namespace walk in
+    # (H) cpp/utils, and the libclang frontend agree on qns.
+    if node.type == cs.CppNodeType.NAMESPACE_DEFINITION:
+        name = _generic_get_name(node)
+        if name:
+            return name.replace(cs.SEPARATOR_DOUBLE_COLON, cs.SEPARATOR_DOT)
+        return name
     if node.type in cs.CPP_NAME_NODE_TYPES:
         name_node = node.child_by_field_name(cs.FIELD_NAME)
         if name_node and name_node.text:

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -155,6 +155,9 @@ class CallProcessor:
         "ingestor",
         "repo_path",
         "project_name",
+        "module_qn_to_file_path",
+        "_path_to_module_qn",
+        "cpp_out_of_class_methods",
         "_resolver",
         "_flow_param_names",
         "_flow_args",
@@ -173,10 +176,15 @@ class CallProcessor:
         class_inheritance: dict[str, list[str]],
         type_aliases: dict[str, str] | None = None,
         interface_implementers: dict[str, set[str]] | None = None,
+        module_qn_to_file_path: dict[str, Path] | None = None,
+        cpp_out_of_class_methods: dict[tuple[str, int], tuple[str, str]] | None = None,
     ) -> None:
         self.ingestor = ingestor
         self.repo_path = repo_path
         self.project_name = project_name
+        self.module_qn_to_file_path = module_qn_to_file_path or {}
+        self._path_to_module_qn: dict[Path, str] | None = None
+        self.cpp_out_of_class_methods = cpp_out_of_class_methods or {}
 
         self._resolver = CallResolver(
             function_registry=function_registry,
@@ -323,7 +331,19 @@ class CallProcessor:
                         (callee[0], qn_key, callee[1]),
                     )
 
-    def _module_qn(self, relative_path: Path, file_name: str) -> str:
+    def _module_qn(self, file_path: Path, relative_path: Path) -> str:
+        # (H) The definition pass is the single source of truth for module qns:
+        # (H) same-stem siblings (Aggregator.cpp / Aggregator.h) get a
+        # (H) collision-disambiguated qn there, and recomputing from the path
+        # (H) here attributed every caller inside such a header to a module qn
+        # (H) with no node, silently dropping its CALLS (issue #652).
+        if self._path_to_module_qn is None:
+            self._path_to_module_qn = {
+                path: qn for qn, path in self.module_qn_to_file_path.items()
+            }
+        if registered := self._path_to_module_qn.get(file_path):
+            return registered
+        file_name = file_path.name
         if file_name in (cs.INIT_PY, cs.MOD_RS):
             return cs.SEPARATOR_DOT.join(
                 [self.project_name] + list(relative_path.parent.parts)
@@ -351,7 +371,7 @@ class CallProcessor:
             return
         try:
             module_qn = self._module_qn(
-                cached_relative_path(file_path, self.repo_path), file_path.name
+                file_path, cached_relative_path(file_path, self.repo_path)
             )
             resolver = self._resolver
             self._collect_ctor_field_metadata(root_node, module_qn)
@@ -561,7 +581,7 @@ class CallProcessor:
         logger.debug(ls.CALL_PROCESSING_FILE, path=relative_path)
 
         try:
-            module_qn = self._module_qn(relative_path, file_path.name)
+            module_qn = self._module_qn(file_path, relative_path)
 
             call_name_cache: dict[int, str | None] = {}
 
@@ -896,6 +916,16 @@ class CallProcessor:
         # (H) actually exists before overriding the default attribution.
         if not cpp_utils.is_out_of_class_method_definition(func_node):
             return None
+        # (H) The definition pass already bound this exact definition (keyed by
+        # (H) module + start line); reuse its decision so the caller qn matches
+        # (H) the registered Method node by construction.
+        recorded = self.cpp_out_of_class_methods.get(
+            (module_qn, func_node.start_point[0] + 1)
+        )
+        if recorded is not None:
+            method_qn, class_qn = recorded
+            if method_qn in self._resolver.function_registry:
+                return method_qn, class_qn
         class_name = cpp_utils.extract_class_name_from_out_of_class_method(func_node)
         if not class_name:
             return None

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -1353,9 +1353,11 @@ class CallResolver:
         if not call_name.startswith(cs.OPERATOR_PREFIX):
             return None
 
-        if call_name in cs.CPP_OPERATORS:
-            return (cs.NodeLabel.FUNCTION, cs.CPP_OPERATORS[call_name])
-
+        # (H) A user-defined overload always beats the builtin: the old table
+        # (H) of synthetic `builtin.cpp.operator_*` qns shadowed real overloads
+        # (H) and produced edges to nodes that never exist (dropped by the
+        # (H) database). A primitive builtin operator is not a first-party
+        # (H) callee, so with no registered overload there is no edge at all.
         if possible_matches := self.function_registry.find_ending_with(call_name):
             same_module_ops = [
                 qn
@@ -1791,11 +1793,16 @@ class CallResolver:
         return type_name
 
     def _resolve_class_name(self, class_name: str, module_qn: str) -> str | None:
+        # (H) Call resolution runs in Pass 3, after every definition pass, so a
+        # (H) class qn missing from the registry can never be a real node;
+        # (H) require registration so an import-map module entry (a C++ header
+        # (H) stem shadowing its class name) cannot mask the real class.
         return resolve_class_name(
             self._dealias_type(class_name),
             module_qn,
             self.import_processor,
             self.function_registry,
+            require_registered=True,
         )
 
     def resolve_java_method_call(

--- a/codebase_rag/parsers/cpp/utils.py
+++ b/codebase_rag/parsers/cpp/utils.py
@@ -33,7 +33,13 @@ def build_qualified_name(node: Node, module_qn: str, name: str) -> str:
 
 
 def extract_namespace_path(node: Node) -> list[str]:
-    """Names of the namespace blocks enclosing *node*, outermost first."""
+    """Names of the namespace blocks enclosing *node*, outermost first.
+
+    C++17 nested syntax (`namespace a::b {`) parses as ONE namespace node
+    named `a::b`; split it so both spellings of the same namespaces yield
+    identical qn segments (`a.b`), matching classic nesting and the libclang
+    frontend's nested cursors.
+    """
     path_parts: list[str] = []
     current = node.parent
 
@@ -56,7 +62,9 @@ def extract_namespace_path(node: Node) -> list[str]:
                         namespace_name = safe_decode_text(child)
                         break
             if namespace_name:
-                path_parts.append(namespace_name)
+                path_parts.extend(
+                    reversed(namespace_name.split(cs.SEPARATOR_DOUBLE_COLON))
+                )
         current = current.parent
 
     path_parts.reverse()

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -84,6 +84,10 @@ class DefinitionProcessor(
         self._deferred_cpp_containment: list = []
         self._deferred_parent_links: list = []
         self._deferred_forward_decls: list = []
+        # (H) (module_qn, def start_line) -> (method_qn, class_qn) for every
+        # (H) out-of-class C++ method the definition pass bound; Pass-3 call
+        # (H) attribution reuses these decisions instead of re-resolving.
+        self.cpp_out_of_class_methods: dict[tuple[str, int], tuple[str, str]] = {}
         self._handler = get_handler(cs.SupportedLanguage.PYTHON)
         self._func_class_captures_cache = func_class_captures_cache
 

--- a/codebase_rag/parsers/factory.py
+++ b/codebase_rag/parsers/factory.py
@@ -137,5 +137,7 @@ class ProcessorFactory:
                 class_inheritance=self.definition_processor.class_inheritance,
                 type_aliases=self.definition_processor.type_aliases,
                 interface_implementers=self.definition_processor.interface_implementers,
+                module_qn_to_file_path=self.module_qn_to_file_path,
+                cpp_out_of_class_methods=self.definition_processor.cpp_out_of_class_methods,
             )
         return self._call_processor

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -45,7 +45,12 @@ class FunctionResolution(NamedTuple):
 
 
 class _DeferredMethod(NamedTuple):
-    """Out-of-class C++ method whose class hasn't been parsed yet."""
+    """Out-of-class C++ method whose class hasn't been parsed yet.
+
+    namespace_path carries the definition site's enclosing namespaces so the
+    class resolves scope-first: two same-leaf classes (ast::Type and
+    ast::analysis::Type) are otherwise indistinguishable by leaf lookup.
+    """
 
     method_name: str
     class_name: str
@@ -53,6 +58,8 @@ class _DeferredMethod(NamedTuple):
     method_props: PropertyDict
     return_type: str | None
     module_qn: str
+    namespace_path: str
+    start_line: int
 
 
 class _DeferredGoMethod(NamedTuple):
@@ -102,6 +109,7 @@ class FunctionIngestMixin:
     _deferred_cpp_containment: list[_DeferredCppContainment]
     _deferred_parent_links: list[DeferredParentLink]
     method_return_types: dict[str, str]
+    cpp_out_of_class_methods: dict[tuple[str, int], tuple[str, str]]
 
     @abstractmethod
     def _get_docstring(self, node: ASTNode) -> str | None: ...
@@ -240,7 +248,9 @@ class FunctionIngestMixin:
         leaf_name = class_name_normalized.rsplit(cs.SEPARATOR_DOT, 1)[-1]
 
         if leaf_name in self.simple_name_lookup:
-            for candidate_qn in self.simple_name_lookup[leaf_name]:
+            # (H) Sorted: the lookup is a set, and same-leaf classes in
+            # (H) different namespaces would otherwise bind nondeterministically.
+            for candidate_qn in sorted(self.simple_name_lookup[leaf_name]):
                 node_type = self.function_registry.get(candidate_qn)
                 if node_type in {NodeType.CLASS, NodeType.TYPE}:
                     # (H) An out-of-class nested definition keeps `Outer::Inner`
@@ -278,7 +288,20 @@ class FunctionIngestMixin:
         if not class_name:
             return False
 
-        class_qn, resolved = self._resolve_cpp_class_qn(class_name, module_qn)
+        # (H) Scope-first (see resolve_deferred_cpp_methods): the enclosing
+        # (H) namespaces distinguish same-leaf classes.
+        namespace_path = cs.SEPARATOR_DOT.join(
+            cpp_utils.extract_namespace_path(func_node)
+        )
+        candidates = [class_name]
+        if namespace_path:
+            candidates.insert(0, f"{namespace_path}{cs.SEPARATOR_DOT}{class_name}")
+        resolved = False
+        class_qn = ""
+        for candidate in candidates:
+            class_qn, resolved = self._resolve_cpp_class_qn(candidate, module_qn)
+            if resolved:
+                break
         file_path = self.module_qn_to_file_path.get(module_qn)
         # (H) The out-of-class DEFINITION carries the return type; record it here (keyed
         # (H) by the method qn) so a factory chain `parser(1).parse()` can type the
@@ -301,6 +324,12 @@ class FunctionIngestMixin:
                 file_path=file_path,
                 repo_path=self.repo_path,
             )
+            if bound_name := cpp_utils.extract_function_name(func_node):
+                # (H) Record the binding so Pass-3 call attribution reuses this
+                # (H) exact decision instead of re-resolving (and diverging).
+                self.cpp_out_of_class_methods[
+                    (module_qn, func_node.start_point[0] + 1)
+                ] = (f"{class_qn}{cs.SEPARATOR_DOT}{bound_name}", class_qn)
             if return_type and (
                 method_name := cpp_utils.extract_function_name(func_node)
             ):
@@ -334,6 +363,10 @@ class FunctionIngestMixin:
                     method_props=props,
                     return_type=return_type,
                     module_qn=module_qn,
+                    namespace_path=cs.SEPARATOR_DOT.join(
+                        cpp_utils.extract_namespace_path(func_node)
+                    ),
+                    start_line=func_node.start_point[0] + 1,
                 )
             )
 
@@ -352,9 +385,28 @@ class FunctionIngestMixin:
 
         ingested = 0
         for entry in deferred:
-            real_class_qn, resolved = self._resolve_cpp_class_qn(entry.class_name, "")
+            # (H) Scope-first: the namespace-qualified name distinguishes
+            # (H) same-leaf classes (ast::Type vs ast::analysis::Type); the raw
+            # (H) written qualifier is the fallback for other scopes.
+            candidates = [entry.class_name]
+            if entry.namespace_path:
+                candidates.insert(
+                    0, f"{entry.namespace_path}{cs.SEPARATOR_DOT}{entry.class_name}"
+                )
+            resolved = False
+            real_class_qn = entry.fallback_class_qn
+            for candidate in candidates:
+                real_class_qn, resolved = self._resolve_cpp_class_qn(candidate, "")
+                if resolved:
+                    break
             class_qn = real_class_qn if resolved else entry.fallback_class_qn
             method_qn = f"{class_qn}.{entry.method_name}"
+            # (H) Record the binding so Pass-3 call attribution reuses this
+            # (H) exact decision instead of re-resolving (and diverging).
+            self.cpp_out_of_class_methods[(entry.module_qn, entry.start_line)] = (
+                method_qn,
+                class_qn,
+            )
 
             props = dict(entry.method_props)
             props[cs.KEY_QUALIFIED_NAME] = method_qn

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -1059,10 +1059,12 @@ class ImportProcessor:
             return None
         if len(matches) > 1 and includer_rel is not None:
             # (H) Prefer the header sharing the longest path prefix with the
-            # (H) includer (the same source tree), deterministically.
+            # (H) includer (the same source tree), deterministically. commonpath
+            # (H) (not commonprefix) so sibling dirs with a shared name prefix
+            # (H) (src/ast vs src/ast_new) rank by whole components.
             matches.sort(
                 key=lambda rel: (
-                    -len(os.path.commonprefix([rel, includer_rel])),
+                    -len(os.path.commonpath([rel, includer_rel])),
                     rel,
                 )
             )

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -1,4 +1,5 @@
 import json
+import os
 import posixpath
 import re
 from functools import lru_cache
@@ -12,6 +13,7 @@ from .. import logs as ls
 from ..language_spec import LanguageSpec
 from ..services import IngestorProtocol
 from ..types_defs import FunctionRegistryTrieProtocol, LanguageQueries
+from .cpp_frontend.qn import build_module_qn_map
 from .go import discover_go_module_paths, resolve_go_import_path
 from .lua import utils as lua_utils
 from .python_source_roots import discover_python_source_roots, resolve_via_source_roots
@@ -181,6 +183,8 @@ class ImportProcessor:
         "_is_local_java_import_cached",
         "_map_py_source_root",
         "_map_go_import_path",
+        "_cpp_module_qn_map",
+        "_cpp_qn_to_rel",
     )
 
     def __init__(
@@ -195,6 +199,10 @@ class ImportProcessor:
         self.ingestor = ingestor
         self.function_registry = function_registry
         self.import_mapping: dict[str, dict[str, str]] = {}
+        # (H) Lazy: replayed walk of every eligible repo file, built on the first
+        # (H) C++ include so non-C++ projects never pay for it.
+        self._cpp_module_qn_map: dict[str, str] | None = None
+        self._cpp_qn_to_rel: dict[str, str] = {}
         # (H) Local names brought in by a PHP `use function A\B\c` import, keyed by
         # (H) module. A PHP namespace path never matches cgr's file-path qualified
         # (H) name (a global helper declares `namespace Illuminate\Support` from
@@ -354,6 +362,12 @@ class ImportProcessor:
                         full_name, module_qn, language
                     )
 
+                    target_label = self._module_label(module_path)
+                    # (H) An external import target has no file pass to create its
+                    # (H) node; without one here the IMPORTS edge MERGEs against
+                    # (H) nothing and is silently dropped (issue #652).
+                    if target_label == cs.NodeLabel.EXTERNAL_MODULE:
+                        self._ensure_external_module_node(module_path, full_name)
                     self.ingestor.ensure_relationship_batch(
                         (
                             cs.NodeLabel.MODULE,
@@ -362,7 +376,7 @@ class ImportProcessor:
                         ),
                         cs.RelationshipType.IMPORTS,
                         (
-                            self._module_label(module_path),
+                            target_label,
                             cs.KEY_QUALIFIED_NAME,
                             module_path,
                         ),
@@ -1010,6 +1024,50 @@ class ImportProcessor:
             elif import_node.type == cs.TS_DECLARATION:
                 self._parse_cpp_module_declaration(import_node, module_qn)
 
+    def _resolve_cpp_include_target(
+        self, include_path: str, module_qn: str
+    ) -> str | None:
+        """Resolve a quoted #include to the module qn of a real repo file.
+
+        Tries the includer's directory, then the repo root, then a unique
+        path-suffix match (covers -I style includes written relative to a
+        source root). Returns None for headers outside the repo.
+        """
+        if self._cpp_module_qn_map is None:
+            self._cpp_module_qn_map = build_module_qn_map(
+                self.repo_path, self.project_name
+            )
+            self._cpp_qn_to_rel = {
+                qn: rel for rel, qn in self._cpp_module_qn_map.items()
+            }
+        normalized = os.path.normpath(include_path).replace(os.sep, cs.SEPARATOR_SLASH)
+
+        includer_rel = self._cpp_qn_to_rel.get(module_qn)
+        if includer_rel is not None:
+            candidate = os.path.normpath(
+                str(Path(includer_rel).parent / normalized)
+            ).replace(os.sep, cs.SEPARATOR_SLASH)
+            if qn := self._cpp_module_qn_map.get(candidate):
+                return qn
+
+        if qn := self._cpp_module_qn_map.get(normalized):
+            return qn
+
+        suffix = f"{cs.SEPARATOR_SLASH}{normalized}"
+        matches = sorted(rel for rel in self._cpp_module_qn_map if rel.endswith(suffix))
+        if not matches:
+            return None
+        if len(matches) > 1 and includer_rel is not None:
+            # (H) Prefer the header sharing the longest path prefix with the
+            # (H) includer (the same source tree), deterministically.
+            matches.sort(
+                key=lambda rel: (
+                    -len(os.path.commonprefix([rel, includer_rel])),
+                    rel,
+                )
+            )
+        return self._cpp_module_qn_map[matches[0]]
+
     def _parse_cpp_include(self, include_node: Node, module_qn: str) -> None:
         include_path = None
         is_system_include = False
@@ -1035,13 +1093,19 @@ class ImportProcessor:
                     if include_path.startswith(cs.CPP_STD_PREFIX)
                     else f"{cs.IMPORT_STD_PREFIX}{include_path}"
                 )
+            elif resolved := self._resolve_cpp_include_target(include_path, module_qn):
+                # (H) The include resolves to a real repo file; use that file's
+                # (H) actual (collision-disambiguated) module qn. The old
+                # (H) project-rooted, extension-stripped guess produced phantom
+                # (H) module qns (self-imports for same-stem header/source pairs,
+                # (H) wrong roots for -I style includes), which poisoned both the
+                # (H) IMPORTS edges and class resolution via the import map
+                # (H) (issue #652).
+                full_name = resolved
             else:
-                path_parts = (
-                    include_path.replace(cs.SEPARATOR_SLASH, cs.SEPARATOR_DOT)
-                    .replace(cs.EXT_H, "")
-                    .replace(cs.EXT_HPP, "")
-                )
-                full_name = f"{self.project_name}{cs.SEPARATOR_DOT}{path_parts}"
+                # (H) A quoted include that matches no repo file is a third-party
+                # (H) header; a project-rooted qn would be a phantom.
+                full_name = f"{cs.IMPORT_STD_PREFIX}{include_path}"
 
             self.import_mapping[module_qn][local_name] = full_name
             logger.debug(

--- a/codebase_rag/parsers/py/utils.py
+++ b/codebase_rag/parsers/py/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from ...constants import SEPARATOR_DOT
@@ -10,13 +12,22 @@ if TYPE_CHECKING:
 def resolve_class_name(
     class_name: str,
     module_qn: str,
-    import_processor: "ImportProcessor",
+    import_processor: ImportProcessor,
     function_registry: FunctionRegistryTrieProtocol,
+    require_registered: bool = False,
 ) -> str | None:
     if module_qn in import_processor.import_mapping:
         import_map = import_processor.import_mapping[module_qn]
         if class_name in import_map:
-            return import_map[class_name]
+            mapped = import_map[class_name]
+            # (H) C++ include entries map header STEMS to MODULE qns; when the
+            # (H) stem coincides with a class name (Directive.h defining class
+            # (H) Directive, the dominant C++ layout) the map answer is a module,
+            # (H) not a class. Callers that need a real registered node (call
+            # (H) attribution in Pass 3) must fall through to the registry-backed
+            # (H) steps below (issue #652: 11k phantom callers on souffle).
+            if not require_registered or function_registry.get(mapped) is not None:
+                return mapped
 
     same_module_qn = f"{module_qn}.{class_name}"
     if same_module_qn in function_registry:

--- a/codebase_rag/tests/integration/test_imports_e2e.py
+++ b/codebase_rag/tests/integration/test_imports_e2e.py
@@ -597,7 +597,10 @@ class TestCppImportsRelationships:
 
         project_name = cpp_imports_project.name
         main_module = f"{project_name}.main"
-        utils_header = f"{project_name}.utils"
+        # (H) utils.cpp claims the base qn in walk order, so the header's real
+        # (H) module qn carries the disambiguating extension; the include edge
+        # (H) must target the header, not the same-stem source module.
+        utils_header = f"{project_name}.utils.h"
 
         assert main_module in modules, f"Main module not found. Modules: {modules}"
         assert utils_header in modules, f"Utils header not found. Modules: {modules}"

--- a/codebase_rag/tests/test_call_processor.py
+++ b/codebase_rag/tests/test_call_processor.py
@@ -472,21 +472,24 @@ class TestResolveSuperCall:
 
 
 class TestResolveCppOperatorCall:
-    def test_builtin_operator_plus(self, call_processor: CallProcessor) -> None:
+    def test_builtin_operator_plus_has_no_callee(
+        self, call_processor: CallProcessor
+    ) -> None:
+        # (H) A primitive builtin operator is not a first-party callee; the old
+        # (H) synthetic builtin.cpp.* qns had no nodes, so their edges were
+        # (H) silently dropped by the database (issue #652).
         result = call_processor._resolver.resolve_cpp_operator_call(
             "operator_plus", "proj.module"
         )
-        assert result is not None
-        assert result[0] == cs.NodeLabel.FUNCTION
-        assert result[1] == cs.CPP_OPERATORS["operator_plus"]
+        assert result is None
 
-    def test_builtin_operator_equal(self, call_processor: CallProcessor) -> None:
+    def test_builtin_operator_equal_has_no_callee(
+        self, call_processor: CallProcessor
+    ) -> None:
         result = call_processor._resolver.resolve_cpp_operator_call(
             "operator_equal", "proj.module"
         )
-        assert result is not None
-        assert result[0] == cs.NodeLabel.FUNCTION
-        assert result[1] == cs.CPP_OPERATORS["operator_equal"]
+        assert result is None
 
     def test_non_operator_returns_none(self, call_processor: CallProcessor) -> None:
         result = call_processor._resolver.resolve_cpp_operator_call(

--- a/codebase_rag/tests/test_cpp_concepts.py
+++ b/codebase_rag/tests/test_cpp_concepts.py
@@ -275,7 +275,8 @@ void demonstrateAdvancedConcepts() {
         call for call in call_relationships if "advanced_concepts" in call.args[0][2]
     ]
 
-    assert len(advanced_calls) >= 5, (
+    # (H) builtin operator edges no longer emitted (#652)
+    assert len(advanced_calls) >= 4, (
         f"Expected at least 5 advanced concept calls, found {len(advanced_calls)}"
     )
 

--- a/codebase_rag/tests/test_cpp_designated_init_consteval.py
+++ b/codebase_rag/tests/test_cpp_designated_init_consteval.py
@@ -991,7 +991,8 @@ void demonstrateLambdaInitCaptures() {
 
     total_calls = len(call_relationships)
 
-    assert total_calls >= 15, (
+    # (H) builtin operator edges no longer emitted (#652)
+    assert total_calls >= 12, (
         f"Expected at least 15 total calls across all tests, found {total_calls}"
     )
 

--- a/codebase_rag/tests/test_cpp_include_resolution.py
+++ b/codebase_rag/tests/test_cpp_include_resolution.py
@@ -1,0 +1,118 @@
+# (H) C++ #include resolution and its downstream effects (issue #652).
+# (H) The naive resolver rooted every include at the project and stripped the
+# (H) extension, so `#include "Directive.h"` from Directive.cpp mapped the stem
+# (H) to the .cpp's OWN module qn (the header's real qn is the disambiguated
+# (H) Directive.h). That poisoned the import map: IMPORTS edges pointed at
+# (H) phantom modules (3.9k on souffle), and resolve_class_name's import-map
+# (H) step returned a MODULE qn when asked for the class `Directive`, so every
+# (H) out-of-line method's calls were attributed to a phantom free-function
+# (H) caller (11k dangling CALLS on souffle).
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import get_relationships, run_updater
+
+HDR = """
+#pragma once
+namespace souffle {
+class Directive {
+public:
+    void print() const;
+};
+int helper(int x);
+}
+"""
+
+CPP = """
+#include "Directive.h"
+namespace souffle {
+
+int helper(int x) { return x + 1; }
+
+void Directive::print() const {
+    helper(1);
+}
+
+}
+"""
+
+
+def _write_same_stem_fixture(repo: Path) -> None:
+    (repo / "Directive.h").write_text(HDR)
+    (repo / "Directive.cpp").write_text(CPP)
+
+
+def _node_keys(mock_ingestor: MagicMock) -> set[tuple[str, str]]:
+    keys = set()
+    for c in mock_ingestor.ensure_node_batch.call_args_list:
+        props = c.args[1]
+        key = props.get("qualified_name") or props.get("path") or props.get("name")
+        keys.add((str(c.args[0]), key))
+    return keys
+
+
+def test_out_of_line_method_calls_attribute_to_method_node(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    _write_same_stem_fixture(temp_repo)
+    run_updater(temp_repo, mock_ingestor)
+
+    keys = _node_keys(mock_ingestor)
+    helper_calls = [
+        call
+        for call in get_relationships(mock_ingestor, cs.RelationshipType.CALLS.value)
+        if str(call.args[2][2]).endswith(".helper") and ".print" in str(call.args[0][2])
+    ]
+    assert helper_calls
+    for call in helper_calls:
+        from_label, _, from_qn = call.args[0]
+        assert str(from_label) == cs.NodeLabel.METHOD.value, call.args
+        assert ".Directive.print" in str(from_qn), call.args
+        assert (str(from_label), from_qn) in keys, call.args
+
+
+def test_include_imports_edge_targets_real_header_module(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    _write_same_stem_fixture(temp_repo)
+    run_updater(temp_repo, mock_ingestor)
+
+    keys = _node_keys(mock_ingestor)
+    cpp_module = f"{temp_repo.name}.Directive"
+    header_module = f"{temp_repo.name}.Directive.h"
+    import_targets = {
+        str(call.args[2][2])
+        for call in get_relationships(mock_ingestor, cs.RelationshipType.IMPORTS.value)
+        if str(call.args[0][2]) == cpp_module
+    }
+    assert header_module in import_targets, import_targets
+    # (H) The self-import phantom (stem resolved to the includer's own qn) must
+    # (H) be gone.
+    assert cpp_module not in import_targets, import_targets
+    assert (cs.NodeLabel.MODULE.value, header_module) in keys
+
+
+def test_subdir_include_resolves_via_path_suffix(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) souffle-style layout: includes are written relative to an -I root
+    # (H) ("ast/Directive.h"), not the includer or the repo root.
+    (temp_repo / "src" / "ast").mkdir(parents=True)
+    (temp_repo / "src" / "ast" / "Directive.h").write_text(HDR)
+    (temp_repo / "src" / "ast" / "Directive.cpp").write_text(
+        CPP.replace('#include "Directive.h"', '#include "ast/Directive.h"')
+    )
+    run_updater(temp_repo, mock_ingestor)
+
+    project = temp_repo.name
+    cpp_module = f"{project}.src.ast.Directive"
+    header_module = f"{project}.src.ast.Directive.h"
+    import_targets = {
+        str(call.args[2][2])
+        for call in get_relationships(mock_ingestor, cs.RelationshipType.IMPORTS.value)
+        if str(call.args[0][2]) == cpp_module
+    }
+    assert header_module in import_targets, import_targets

--- a/codebase_rag/tests/test_cpp_lambdas_functional.py
+++ b/codebase_rag/tests/test_cpp_lambdas_functional.py
@@ -854,7 +854,8 @@ void demonstrateComprehensiveLambdas() {
         if "comprehensive_lambdas" in call.args[0][2]
     ]
 
-    assert len(comprehensive_calls) >= 2, (
+    # (H) builtin operator edges no longer emitted (#652)
+    assert len(comprehensive_calls) >= 1, (
         f"Expected at least 2 comprehensive lambda calls, found {len(comprehensive_calls)}"
     )
 

--- a/codebase_rag/tests/test_cpp_modules.py
+++ b/codebase_rag/tests/test_cpp_modules.py
@@ -806,6 +806,7 @@ void showcaseModuleFeatures() {
         call for call in call_relationships if "module_usage" in call.args[0][2]
     ]
 
-    assert len(module_function_calls) >= 5, (
+    # (H) builtin operator edges no longer emitted (#652)
+    assert len(module_function_calls) >= 4, (
         f"Expected at least 5 module function calls, found {len(module_function_calls)}"
     )

--- a/codebase_rag/tests/test_cpp_nested_namespace_qn.py
+++ b/codebase_rag/tests/test_cpp_nested_namespace_qn.py
@@ -1,0 +1,102 @@
+# (H) C++17 nested namespace syntax (`namespace a::b {`) must produce the same
+# (H) qualified names as classic nesting (`namespace a { namespace b {`).
+# (H) The namespace walk used to keep the literal `a::b` as one qn segment
+# (H) while the FQN scope path split it into `a.b`, so one class got TWO nodes
+# (H) and out-of-line method callers resolved to the segment variant that the
+# (H) methods were not registered under, dropping their CALLS as phantom
+# (H) free-function callers (issue #652: the dominant remaining family on
+# (H) souffle, which uses `namespace souffle::ast` throughout).
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import get_relationships, run_updater
+
+HDR_MODERN = """
+#pragma once
+namespace souffle::ast {
+class Program {
+public:
+    int getTypes() const;
+};
+int toPtr(int x);
+}
+"""
+
+CPP_MODERN = """
+#include "Program.h"
+namespace souffle::ast {
+int toPtr(int x) { return x; }
+int Program::getTypes() const { return toPtr(1); }
+}
+"""
+
+
+def _classic(src: str) -> str:
+    return src.replace(
+        "namespace souffle::ast {", "namespace souffle { namespace ast {"
+    ).replace("}\n", "}\n}\n", 1)
+
+
+def _index(repo: Path, hdr: str, cpp: str, mock_ingestor: MagicMock) -> None:
+    (repo / "Program.h").write_text(hdr)
+    (repo / "Program.cpp").write_text(cpp)
+    run_updater(repo, mock_ingestor)
+
+
+def _entity_qns(mock_ingestor: MagicMock, project: str) -> set[tuple[str, str]]:
+    qns = set()
+    for c in mock_ingestor.ensure_node_batch.call_args_list:
+        label = str(c.args[0])
+        if label in ("Class", "Method", "Function"):
+            qn = str(c.args[1]["qualified_name"]).replace(project, "PROJ", 1)
+            qns.add((label, qn))
+    return qns
+
+
+def test_modern_and_classic_namespace_nesting_agree(
+    tmp_path: Path,
+) -> None:
+    from codebase_rag.tests.conftest import _MockIngestor, create_and_run_updater
+
+    modern_repo = tmp_path / "modern"
+    classic_repo = tmp_path / "classic"
+    modern_repo.mkdir()
+    classic_repo.mkdir()
+    (modern_repo / "Program.h").write_text(HDR_MODERN)
+    (modern_repo / "Program.cpp").write_text(CPP_MODERN)
+    (classic_repo / "Program.h").write_text(_classic(HDR_MODERN))
+    (classic_repo / "Program.cpp").write_text(_classic(CPP_MODERN))
+
+    modern_ing = _MockIngestor()
+    create_and_run_updater(modern_repo, modern_ing)
+    classic_ing = _MockIngestor()
+    create_and_run_updater(classic_repo, classic_ing)
+
+    modern = _entity_qns(modern_ing, "modern")
+    classic = _entity_qns(classic_ing, "classic")
+    assert modern == classic, modern.symmetric_difference(classic)
+
+
+def test_out_of_line_caller_binds_under_modern_namespace(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    _index(temp_repo, HDR_MODERN, CPP_MODERN, mock_ingestor)
+
+    node_keys = {
+        (str(c.args[0]), c.args[1].get("qualified_name"))
+        for c in mock_ingestor.ensure_node_batch.call_args_list
+    }
+    calls = [
+        call
+        for call in get_relationships(mock_ingestor, cs.RelationshipType.CALLS.value)
+        if str(call.args[2][2]).endswith(".toPtr")
+        and "getTypes" in str(call.args[0][2])
+    ]
+    assert calls
+    for call in calls:
+        from_label, _, from_qn = call.args[0]
+        assert str(from_label) == cs.NodeLabel.METHOD.value, call.args
+        assert (str(from_label), from_qn) in node_keys, call.args

--- a/codebase_rag/tests/test_cpp_operator_call_resolution.py
+++ b/codebase_rag/tests/test_cpp_operator_call_resolution.py
@@ -1,0 +1,54 @@
+# (H) C++ operator calls: a user-defined overload must win, and a primitive
+# (H) builtin operator must produce NO call edge. The old table mapped common
+# (H) operators to synthetic `builtin.cpp.operator_*` qns unconditionally,
+# (H) which both shadowed real overloads and emitted edges to nodes that never
+# (H) exist, silently dropped by the database (issue #652: 1,681 on souffle).
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import get_relationships, run_updater
+
+CPP = """
+namespace math {
+
+class Vec {
+public:
+    int x;
+    Vec operator+(const Vec& other) const;
+};
+
+Vec Vec::operator+(const Vec& other) const {
+    Vec r;
+    r.x = x + other.x;
+    return r;
+}
+
+int combine(Vec a, Vec b) {
+    Vec c = a + b;
+    return c.x && a.x;
+}
+
+}
+"""
+
+
+def test_user_defined_operator_overload_wins_and_builtins_emit_no_edge(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "vec.cpp").write_text(CPP)
+    run_updater(temp_repo, mock_ingestor)
+
+    node_keys = {
+        (str(c.args[0]), c.args[1].get("qualified_name"))
+        for c in mock_ingestor.ensure_node_batch.call_args_list
+    }
+    calls = get_relationships(mock_ingestor, cs.RelationshipType.CALLS.value)
+    operator_targets = [call for call in calls if "operator" in str(call.args[2][2])]
+    assert operator_targets, calls
+    for call in operator_targets:
+        to_label, _, to_qn = call.args[2]
+        assert not str(to_qn).startswith("builtin."), call.args
+        assert (str(to_label), to_qn) in node_keys, call.args

--- a/codebase_rag/tests/test_cpp_ranges_views.py
+++ b/codebase_rag/tests/test_cpp_ranges_views.py
@@ -991,7 +991,8 @@ void demonstrateRangeGraphProcessing() {
         if "range_graph_processing" in call.args[0][2]
     ]
 
-    assert len(range_processing_calls) >= 5, (
+    # (H) builtin operator edges no longer emitted (#652)
+    assert len(range_processing_calls) >= 4, (
         f"Expected at least 5 range processing calls, found {len(range_processing_calls)}"
     )
 

--- a/codebase_rag/tests/test_cpp_same_leaf_class_method_binding.py
+++ b/codebase_rag/tests/test_cpp_same_leaf_class_method_binding.py
@@ -1,0 +1,106 @@
+# (H) Two classes sharing a leaf name (souffle::ast::Type and
+# (H) souffle::ast::analysis::Type) each define out-of-line methods in their
+# (H) own .cpp. The class lookup used to iterate an unordered candidate set
+# (H) and accept ANY same-leaf class, so a method could bind to the wrong
+# (H) class nondeterministically; Pass 3 then re-resolved independently and
+# (H) any disagreement became a phantom caller whose CALLS the database drops
+# (H) (issue #652). The definition pass now resolves once, namespace-scoped
+# (H) and deterministic, records the decision, and call attribution reuses it.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import get_relationships, run_updater
+
+AST_HDR = """
+#pragma once
+namespace souffle::ast {
+class Type {
+public:
+    Type(int kind);
+    int getKind() const;
+};
+int check(int x);
+}
+"""
+
+AST_CPP = """
+#include "ast/Type.h"
+namespace souffle::ast {
+int check(int x) { return x; }
+Type::Type(int kind) : kind_(check(kind)) {}
+int Type::getKind() const { return check(0); }
+}
+"""
+
+ANALYSIS_HDR = """
+#pragma once
+namespace souffle::ast::analysis {
+class Type {
+public:
+    Type(int id);
+    int getId() const;
+};
+}
+"""
+
+ANALYSIS_CPP = """
+#include "ast/analysis/Type.h"
+namespace souffle::ast::analysis {
+Type::Type(int id) : id_(id) {}
+int Type::getId() const { return 1; }
+}
+"""
+
+
+def _write_fixture(repo: Path) -> None:
+    (repo / "src" / "ast" / "analysis").mkdir(parents=True)
+    (repo / "src" / "ast" / "Type.h").write_text(AST_HDR)
+    (repo / "src" / "ast" / "Type.cpp").write_text(AST_CPP)
+    (repo / "src" / "ast" / "analysis" / "Type.h").write_text(ANALYSIS_HDR)
+    (repo / "src" / "ast" / "analysis" / "Type.cpp").write_text(ANALYSIS_CPP)
+
+
+def test_same_leaf_methods_bind_to_their_own_class(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    _write_fixture(temp_repo)
+    run_updater(temp_repo, mock_ingestor)
+
+    method_qns = {
+        c.args[1]["qualified_name"]
+        for c in mock_ingestor.ensure_node_batch.call_args_list
+        if str(c.args[0]) == cs.NodeLabel.METHOD.value
+    }
+    assert any(".ast.Type.h.souffle.ast.Type.getKind" in qn for qn in method_qns), (
+        method_qns
+    )
+    assert any(
+        "analysis.Type.h.souffle.ast.analysis.Type.getId" in qn for qn in method_qns
+    ), method_qns
+
+
+def test_same_leaf_out_of_line_callers_are_real_nodes(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    _write_fixture(temp_repo)
+    run_updater(temp_repo, mock_ingestor)
+
+    node_keys = {
+        (str(c.args[0]), c.args[1].get("qualified_name"))
+        for c in mock_ingestor.ensure_node_batch.call_args_list
+    }
+    check_calls = [
+        call
+        for call in get_relationships(mock_ingestor, cs.RelationshipType.CALLS.value)
+        if str(call.args[2][2]).endswith(".check")
+    ]
+    assert check_calls
+    for call in check_calls:
+        from_label, _, from_qn = call.args[0]
+        if str(from_label) == cs.NodeLabel.MODULE.value:
+            continue
+        assert (str(from_label), from_qn) in node_keys, call.args
+        assert ".ast.Type.h.souffle.ast.Type." in str(from_qn), call.args

--- a/codebase_rag/tests/test_cpp_template_metaprogramming.py
+++ b/codebase_rag/tests/test_cpp_template_metaprogramming.py
@@ -793,7 +793,8 @@ void demonstrateComprehensiveMetaprogramming() {
         if "comprehensive_metaprogramming" in call.args[0][2]
     ]
 
-    assert len(comprehensive_calls) >= 2, (
+    # (H) builtin operator edges no longer emitted (#652)
+    assert len(comprehensive_calls) >= 1, (
         f"Expected at least 2 comprehensive metaprogramming calls, found {len(comprehensive_calls)}"
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.253"
+version = "0.0.256"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Part of #652 (first iteration of the dangling-edge campaign).

## Result

souffle-lang/souffle emitted-edge audit: **18,175 dangling edges down to 4,261 (77% reduction)**. The IMPORTS family (3,908) and the builtin-operator CALLS family (~1,700) are eliminated entirely; the phantom-caller CALLS family drops from 11,353 to 3,683. The #650 invariant holds: zero orphan nodes, zero schema violations on the re-indexed graph.

## Root causes fixed

All five are the same disease in different organs: independent components deriving names their own way, with every disagreement becoming an edge the database silently drops.

1. **C++ include resolution invented module qns.** `#include "Directive.h"` was resolved as project-root + path with the extension stripped (also mangling `.hpp` stems via `.replace(".h", "")`), so same-stem header/source pairs produced self-imports and `-I`-style includes (`ast/Directive.h`) got phantom roots. Includes now resolve against the actual file tree (includer-relative, root-relative, then unique path-suffix match with longest-common-prefix tie-break) using the collision-disambiguation replay already proven in the libclang frontend (`build_module_qn_map`). Unresolvable quoted includes are external headers, not phantom project modules.
2. **External import targets had no nodes.** The generic IMPORTS emission now creates `ExternalModule` nodes for external targets (mirroring #597), instead of emitting relationships against nothing.
3. **The import map could answer a class lookup with a module.** C++ include entries map header stems, and a stem naming the class it declares (the dominant C++ file convention) shadowed the real class in `resolve_class_name`. Pass-3 resolution now requires the answer to be a registered entity (`require_registered`), falling through to the registry-backed steps; Pass-2 semantics unchanged.
4. **Pass 3 recomputed module qns without collision disambiguation.** `CallProcessor._module_qn` used `with_suffix("")`, so every caller inside a same-stem header was attributed under the source file's qn. It now consults the definition pass's `module_qn_to_file_path` as single source of truth.
5. **C++17 `namespace a::b {` rendered two ways.** The namespace walk kept the literal `a::b` segment while other paths split it, so one class got two nodes (the forward-declaration dedup missed across spellings) and resolution picked the variant without the methods. Canonicalized to dotted segments in `extract_namespace_path` and `_cpp_get_name`; modern and classic nesting now yield byte-identical qns (also aligning tree-sitter with the libclang frontend's nested cursors).
6. **Out-of-line method binding was nondeterministic and re-done per pass.** The class lookup iterated an unordered set accepting any same-leaf class (souffle has `ast::Type` and `ast::analysis::Type`), and Pass 3 re-resolved independently, diverging. The definition pass now resolves once (namespace-scoped candidates first, deterministic sorted iteration), records each binding keyed by (module qn, definition line), and call attribution replays the recorded decision.
7. **Builtin operator table shadowed user overloads and emitted edges to nowhere.** A user-defined `operator+` never resolved because the synthetic `builtin.cpp.operator_*` table answered first, and those synthetic targets never had nodes. User overloads now win; primitive builtin operators emit no call edge (six fixture-count tests updated: they were counting edges the database always dropped).

## Verification

- RED commit first: four failing test files covering include targets, caller attribution, namespace spelling equivalence, and operator resolution; the same-leaf binding tests guard the nondeterministic case surfaced only at souffle scale.
- Full suite: 4578 passed, 0 failed; ruff and the pre-commit ty gate clean.
- souffle re-index: zero orphans, zero schema violations; dangling re-measured per family (breakdown updated on #652).

## Remaining (next iterations, tracked in #652)

3,683 CALLS + 157 REFERENCES phantom callers, 398 INHERITS cross-file base resolution, 21 INSTANTIATES, 2 OVERRIDES.
