### PR TITLE
fix(java): root serialization hooks so reflectively-invoked methods are reachable

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -565,6 +565,21 @@ RUST_TRAIT_METHOD_NAMES: frozenset[str] = frozenset(
     }
 )
 
+# (H) Java serialization hooks the java.io runtime invokes reflectively during
+# (H) (de)serialization -- never through a call the graph can see -- so they are
+# (H) reachability roots (like Python dunders / Rust trait methods), gated by the .java
+# (H) extension. These names are reserved by the Serializable contract, so rooting them
+# (H) by name under-reports a same-named genuinely-dead method rather than mis-reporting.
+JAVA_SERIALIZATION_METHOD_NAMES: frozenset[str] = frozenset(
+    {
+        "readObject",
+        "writeObject",
+        "readObjectNoData",
+        "readResolve",
+        "writeReplace",
+    }
+)
+
 # (H) Base classes that mark a class as a structural interface: its method stubs
 # (H) are never call targets themselves (callers resolve to the implementations),
 # (H) so dead-code analysis roots every method the class defines.

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -3,6 +3,7 @@ from .constants import (
     CPP_OPERATOR_PREFIX,
     CYPHER_DEFAULT_LIMIT,
     GO_ROOT_FUNCTION_NAMES,
+    JAVA_SERIALIZATION_METHOD_NAMES,
     PROTOCOL_BASE_QNS,
     RUST_ROOT_FUNCTION_NAMES,
     RUST_TRAIT_METHOD_NAMES,
@@ -210,6 +211,8 @@ WHERE n.qualified_name STARTS WITH $project_prefix
         AND n.name IN {rust_root_names} AND n.path ENDS WITH '.rs')
     OR ('Method' IN labels(n)
         AND n.name IN {rust_trait_methods} AND n.path ENDS WITH '.rs')
+    OR ('Method' IN labels(n)
+        AND n.name IN {java_serialization_methods} AND n.path ENDS WITH '.java')
     OR {cpp_operator_clause}
     OR ANY(e IN $entry_points WHERE n.qualified_name ENDS WITH e)
     OR {module_clause}{test_clause}
@@ -259,6 +262,7 @@ def build_dead_code_query(include_tests: bool, include_classes: bool = False) ->
     go_root_names = _cypher_str_list(GO_ROOT_FUNCTION_NAMES)
     rust_root_names = _cypher_str_list(RUST_ROOT_FUNCTION_NAMES)
     rust_trait_methods = _cypher_str_list(RUST_TRAIT_METHOD_NAMES)
+    java_serialization_methods = _cypher_str_list(JAVA_SERIALIZATION_METHOD_NAMES)
     return _DEAD_CODE_QUERY_TEMPLATE.format(
         labels=labels,
         traversal=traversal,
@@ -268,6 +272,7 @@ def build_dead_code_query(include_tests: bool, include_classes: bool = False) ->
         go_root_names=go_root_names,
         rust_root_names=rust_root_names,
         rust_trait_methods=rust_trait_methods,
+        java_serialization_methods=java_serialization_methods,
         cpp_operator_clause=_cpp_operator_root_clause(),
         protocol_stub_clause=_DEAD_CODE_PROTOCOL_STUB_CLAUSE.format(
             protocol_bases=protocol_bases

--- a/codebase_rag/tests/test_dead_code_eval.py
+++ b/codebase_rag/tests/test_dead_code_eval.py
@@ -161,6 +161,38 @@ def test_cpp_operator_overloads_are_roots() -> None:
     assert "proj.mod.operator_equal" in dead
 
 
+def test_java_serialization_hooks_are_roots() -> None:
+    # (H) Java serialization hooks (readObject/writeObject/writeReplace/readResolve/
+    # (H) readObjectNoData) are invoked reflectively by the java.io runtime, never by a
+    # (H) call the graph can see, so they are reachability roots (like Python dunders),
+    # (H) gated by the .java extension. The real Java QN carries a signature
+    # (H) (`readObject(ObjectInputStream)`), which must be stripped to the bare name. A
+    # (H) regular uncalled method stays dead, and a same-named symbol on a non-Java file
+    # (H) is NOT rooted.
+    nodes = dict(
+        [
+            (
+                (_MODULE, "proj.S"),
+                {cs.KEY_QUALIFIED_NAME: "proj.S", cs.KEY_PATH: "S.java"},
+            ),
+            _method("proj.S.S.readObject(ObjectInputStream)", "S.java"),
+            _method("proj.S.S.writeReplace()", "S.java"),
+            _method("proj.S.S.readResolve()", "S.java"),
+            _method("proj.S.S.helper()", "S.java"),
+            _method("proj.mod.C.readObject(ObjectInputStream)", "mod.py"),
+        ]
+    )
+    dead = dead_code_from_graph(nodes, [], _PREFIX, _CONFIG)
+    assert "proj.S.S.readObject(ObjectInputStream)" not in dead
+    assert "proj.S.S.writeReplace()" not in dead
+    assert "proj.S.S.readResolve()" not in dead
+    # (H) A regular uncalled method is still dead -- rooting is name-scoped to the
+    # (H) reserved serialization hooks, not a blanket Java exemption.
+    assert "proj.S.S.helper()" in dead
+    # (H) The hook names only root on a .java file; a .py symbol stays dead.
+    assert "proj.mod.C.readObject(ObjectInputStream)" in dead
+
+
 def test_root_level_tests_dir_is_excluded() -> None:
     # (H) A top-level `tests/` dir (Rust integration tests `tests/client.rs`, a JS
     # (H) `tests/` folder) is test infrastructure. The `/tests/` pattern needs a

--- a/evals/dead_code.py
+++ b/evals/dead_code.py
@@ -106,6 +106,19 @@ def _is_cpp_operator_root(name: str, path: str) -> bool:
     return name.startswith(cs.CPP_OPERATOR_PREFIX) and path.endswith(cs.CPP_EXTENSIONS)
 
 
+def _is_java_serialization_root(name: str, is_method: bool, path: str) -> bool:
+    # (H) A Java serialization hook (`readObject`/`writeObject`/`writeReplace`/
+    # (H) `readResolve`/`readObjectNoData`) is invoked reflectively by the java.io
+    # (H) serialization runtime, never by a named call the graph can see, so it is a
+    # (H) reachability root (like Python dunders / Rust trait methods). Gated to methods
+    # (H) on a .java file; `name` is the bare method name (signature stripped by caller).
+    return (
+        is_method
+        and path.endswith(cs.EXT_JAVA)
+        and name in cs.JAVA_SERIALIZATION_METHOD_NAMES
+    )
+
+
 def _matches_test_path(path: str, patterns: tuple[str, ...]) -> bool:
     # (H) Match test-path patterns against a leading-slash-normalized path so a dir
     # (H) pattern like `/tests/` also matches a ROOT `tests/` dir (Rust integration
@@ -225,6 +238,12 @@ def dead_code_from_graph(
             roots.add(qn)
         elif _is_cpp_operator_root(
             qn.rsplit(cs.SEPARATOR_DOT, 1)[-1], str(props.get(cs.KEY_PATH, ""))
+        ):
+            roots.add(qn)
+        elif _is_java_serialization_root(
+            qn.rsplit(cs.SEPARATOR_DOT, 1)[-1].split(cs.CHAR_PAREN_OPEN, 1)[0],
+            qn in method_qns,
+            str(props.get(cs.KEY_PATH, "")),
         ):
             roots.add(qn)
         elif any(qn.endswith(entry) for entry in config.entry_points):


### PR DESCRIPTION
Second Java dead-code class found by dogfooding google/gson. After the constructor fix (#658), drives gson core from 79 to 75 by rooting Java serialization hooks.

## The class: reflectively-invoked serialization hooks reported as dead

Java's `java.io` serialization runtime invokes `readObject`, `writeObject`, `writeReplace`, `readResolve`, and `readObjectNoData` reflectively during (de)serialization. They have no call site the graph can see, so they were reported as dead (gson's `LazilyParsedNumber` and `LinkedTreeMap` hooks). This is the exact pattern already handled for Python dunders, Go `init`/`main`, Rust trait methods, and C++ operators.

## Fix

Root these methods by name, gated to the `.java` extension, in both dead-code surfaces:
- `evals/dead_code.py`: new `_is_java_serialization_root` helper (the real Java QN carries a signature, e.g. `readObject(ObjectInputStream)`, so the bare name is extracted before matching).
- `codebase_rag/cypher_queries.py`: a matching `n.name IN [...] AND n.path ENDS WITH '.java'` clause in the dead-code query template.
- `codebase_rag/constants.py`: `JAVA_SERIALIZATION_METHOD_NAMES`.

Name-scoped like the dunder exemption: a genuinely-dead method that happens to share one of these reserved names is under-reported rather than mis-reported. A same-named method on a non-Java file is not rooted.

## Tests

`test_dead_code_eval.py::test_java_serialization_hooks_are_roots`: the five hooks (with real signatures) are roots on `.java`; a regular uncalled `.java` method stays dead; a same-named `.py` symbol stays dead.

Verified: gson 79 -> 75 (the 4 serialization callbacks revived, none remain), full suite green (4430 passed). Change is `.java`-gated, no cross-language effect.
