### PR TITLE
fix(java): resolve nested-class type names referenced by simple name within a file

### DIFF
--- a/codebase_rag/parsers/java/type_resolver.py
+++ b/codebase_rag/parsers/java/type_resolver.py
@@ -162,15 +162,17 @@ class JavaTypeResolverMixin:
         # (H) A nested class referenced by its simple name from within the same file
         # (H) (`RECORD_HELPER` typed by the nested `RecordHelper`): the qn is
         # (H) `module.Outer.Nested`, not `module.Nested`, so the direct check above
-        # (H) misses it. Search this module for a CLASS/INTERFACE whose last segment is
-        # (H) the simple name, and use it only when unambiguous so a same-named nested
-        # (H) type elsewhere cannot mis-resolve.
-        prefix = f"{module_qn}{cs.SEPARATOR_DOT}"
+        # (H) misses it. Search only this module's trie subtree (bounded, not a
+        # (H) whole-registry scan) for a CLASS/INTERFACE whose last segment is the simple
+        # (H) name, and use it only when unambiguous so a same-named nested type elsewhere
+        # (H) cannot mis-resolve. The trie indexes by dot segment, so find_with_prefix
+        # (H) already excludes character-level prefix collisions.
+        suffix = f"{cs.SEPARATOR_DOT}{type_name}"
         nested = [
             qn
-            for qn in self.function_registry.find_ending_with(type_name)
-            if qn.startswith(prefix)
-            and self.function_registry[qn] in [NodeType.CLASS, NodeType.INTERFACE]
+            for qn, entity_type in self.function_registry.find_with_prefix(module_qn)
+            if qn.endswith(suffix)
+            and entity_type in (NodeType.CLASS, NodeType.INTERFACE)
         ]
         if len(nested) == 1:
             return nested[0]

--- a/codebase_rag/parsers/java/type_resolver.py
+++ b/codebase_rag/parsers/java/type_resolver.py
@@ -159,6 +159,22 @@ class JavaTypeResolverMixin:
         ] in [NodeType.CLASS, NodeType.INTERFACE]:
             return same_package_qn
 
+        # (H) A nested class referenced by its simple name from within the same file
+        # (H) (`RECORD_HELPER` typed by the nested `RecordHelper`): the qn is
+        # (H) `module.Outer.Nested`, not `module.Nested`, so the direct check above
+        # (H) misses it. Search this module for a CLASS/INTERFACE whose last segment is
+        # (H) the simple name, and use it only when unambiguous so a same-named nested
+        # (H) type elsewhere cannot mis-resolve.
+        prefix = f"{module_qn}{cs.SEPARATOR_DOT}"
+        nested = [
+            qn
+            for qn in self.function_registry.find_ending_with(type_name)
+            if qn.startswith(prefix)
+            and self.function_registry[qn] in [NodeType.CLASS, NodeType.INTERFACE]
+        ]
+        if len(nested) == 1:
+            return nested[0]
+
         return type_name
 
     def _get_superclass_name(self, class_qn: str) -> str | None:

--- a/codebase_rag/tests/test_java_nested_type_receiver.py
+++ b/codebase_rag/tests/test_java_nested_type_receiver.py
@@ -1,0 +1,52 @@
+# (H) A receiver typed as a NESTED class referenced by its simple name (gson's
+# (H) `RECORD_HELPER` field, typed by the nested `RecordHelper`) failed to resolve:
+# (H) `_resolve_java_type_name("RecordHelper", module)` only tried `module.RecordHelper`
+# (H) (module.Type), never `module.Outer.RecordHelper` (module.Enclosing.Nested), so the
+# (H) method call dropped and the whole nested hierarchy looked dead.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.conftest import create_and_run_updater, get_relationships
+
+
+def _project(temp_repo: Path, body: str) -> Path:
+    p = temp_repo / "jnest"
+    (p / "com" / "example").mkdir(parents=True)
+    (p / "com" / "example" / "M.java").write_text(
+        f"package com.example;\n{body}\n", encoding="utf-8"
+    )
+    return p
+
+
+def _calls(mock_ingestor: MagicMock) -> set[tuple[str, str]]:
+    return {
+        (c.args[0][2], c.args[2][2]) for c in get_relationships(mock_ingestor, "CALLS")
+    }
+
+
+def test_nested_class_typed_field_receiver_resolves(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    _project(
+        temp_repo,
+        "public class M {\n"
+        "  private static final Helper HELPER = new SubHelper();\n"
+        "  public static boolean ok(int x) { return HELPER.check(x); }\n"
+        "  private abstract static class Helper {\n"
+        "    abstract boolean check(int x);\n"
+        "  }\n"
+        "  private static class SubHelper extends Helper {\n"
+        "    @Override boolean check(int x) { return x > 0; }\n"
+        "  }\n"
+        "}\n",
+    )
+    create_and_run_updater(temp_repo, mock_ingestor, skip_if_missing="java")
+    calls = _calls(mock_ingestor)
+    # (H) HELPER is typed by the nested Helper, so HELPER.check must resolve to the
+    # (H) nested Helper.check -- not drop.
+    assert any(
+        f.endswith(".M.ok(int)") and t.endswith(".M.Helper.check(int)")
+        for f, t in calls
+    ), calls


### PR DESCRIPTION
Third Java dead-code class from dogfooding google/gson. Fixes nested-class type-name resolution so a receiver typed by a nested class resolves its method calls.

## The class: nested-class-typed receiver never resolves

`_resolve_java_type_name(type_name, module)` resolved a simple type name only against `module.Type` (same-package top-level). A nested class is registered as `module.Outer.Nested`, so a field/variable typed by a nested class (gson's `private static final RecordHelper RECORD_HELPER`, where `RecordHelper` is nested in `ReflectionHelper`) never resolved. Every `RECORD_HELPER.isRecord(...)` / `getRecordComponentNames(...)` call dropped, so the whole nested `RecordHelper` hierarchy (base plus its strategy subclasses) was reported dead by cascade.

## Fix

When the direct `module.Type` lookup misses, search this module for a CLASS/INTERFACE whose last qualified-name segment is the simple type name, and use it only when unambiguous (so a same-named nested type elsewhere cannot mis-resolve). This resolves `RecordHelper` to `...ReflectionHelper.ReflectionHelper.RecordHelper`.

## Tests

`test_java_nested_type_receiver.py`: a static field typed by a nested abstract class resolves its method call to the nested class's method (the gson shape).

Verified: gson core 79 -> 72 (the RecordHelper base cluster revived), full suite green (4438 passed), Java suite 525 passed, no regressions.
