### PR TITLE
fix(dead-code): treat overrides of reachable methods as reachable

### DIFF
--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -229,7 +229,7 @@ UNWIND (
 OPTIONAL MATCH (cr)-[:{traversal}*BFS]->(cr_reached)
 WITH live_set, closure_roots, collect(DISTINCT cr_reached) AS cr_reached_set
 WITH live_set + closure_roots + cr_reached_set AS live_set
-OPTIONAL MATCH (ov:Function|Method)-[:OVERRIDES]->(base)
+OPTIONAL MATCH (ov:Function|Method)-[:OVERRIDES*]->(base)
 WHERE base IN live_set AND NOT ov IN live_set
 WITH live_set, collect(DISTINCT ov) AS override_roots
 UNWIND (

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -229,6 +229,15 @@ UNWIND (
 OPTIONAL MATCH (cr)-[:{traversal}*BFS]->(cr_reached)
 WITH live_set, closure_roots, collect(DISTINCT cr_reached) AS cr_reached_set
 WITH live_set + closure_roots + cr_reached_set AS live_set
+OPTIONAL MATCH (ov:Function|Method)-[:OVERRIDES]->(base)
+WHERE base IN live_set AND NOT ov IN live_set
+WITH live_set, collect(DISTINCT ov) AS override_roots
+UNWIND (
+  CASE WHEN size(override_roots) = 0 THEN [null] ELSE override_roots END
+) AS orr
+OPTIONAL MATCH (orr)-[:{traversal}*BFS]->(or_reached)
+WITH live_set, override_roots, collect(DISTINCT or_reached) AS or_reached_set
+WITH live_set + override_roots + or_reached_set AS live_set
 MATCH (n:{labels})
 WHERE n.qualified_name STARTS WITH $project_prefix
   AND NOT n IN live_set{candidate_clause}

--- a/codebase_rag/parsers/java/type_resolver.py
+++ b/codebase_rag/parsers/java/type_resolver.py
@@ -162,15 +162,17 @@ class JavaTypeResolverMixin:
         # (H) A nested class referenced by its simple name from within the same file
         # (H) (`RECORD_HELPER` typed by the nested `RecordHelper`): the qn is
         # (H) `module.Outer.Nested`, not `module.Nested`, so the direct check above
-        # (H) misses it. Search this module for a CLASS/INTERFACE whose last segment is
-        # (H) the simple name, and use it only when unambiguous so a same-named nested
-        # (H) type elsewhere cannot mis-resolve.
-        prefix = f"{module_qn}{cs.SEPARATOR_DOT}"
+        # (H) misses it. Search only this module's trie subtree (bounded, not a
+        # (H) whole-registry scan) for a CLASS/INTERFACE whose last segment is the simple
+        # (H) name, and use it only when unambiguous so a same-named nested type elsewhere
+        # (H) cannot mis-resolve. The trie indexes by dot segment, so find_with_prefix
+        # (H) already excludes character-level prefix collisions.
+        suffix = f"{cs.SEPARATOR_DOT}{type_name}"
         nested = [
             qn
-            for qn in self.function_registry.find_ending_with(type_name)
-            if qn.startswith(prefix)
-            and self.function_registry[qn] in [NodeType.CLASS, NodeType.INTERFACE]
+            for qn, entity_type in self.function_registry.find_with_prefix(module_qn)
+            if qn.endswith(suffix)
+            and entity_type in (NodeType.CLASS, NodeType.INTERFACE)
         ]
         if len(nested) == 1:
             return nested[0]

--- a/codebase_rag/parsers/java/type_resolver.py
+++ b/codebase_rag/parsers/java/type_resolver.py
@@ -154,25 +154,25 @@ class JavaTypeResolverMixin:
                 return self._imported_class_qn(import_map[type_name], type_name)
 
         same_package_qn = f"{module_qn}{cs.SEPARATOR_DOT}{type_name}"
-        if same_package_qn in self.function_registry and self.function_registry[
-            same_package_qn
-        ] in [NodeType.CLASS, NodeType.INTERFACE]:
+        if (
+            same_package_qn in self.function_registry
+            and self.function_registry[same_package_qn] in _JAVA_TYPE_DECL_NODE_TYPES
+        ):
             return same_package_qn
 
-        # (H) A nested class referenced by its simple name from within the same file
+        # (H) A nested type referenced by its simple name from within the same file
         # (H) (`RECORD_HELPER` typed by the nested `RecordHelper`): the qn is
         # (H) `module.Outer.Nested`, not `module.Nested`, so the direct check above
         # (H) misses it. Search only this module's trie subtree (bounded, not a
-        # (H) whole-registry scan) for a CLASS/INTERFACE whose last segment is the simple
-        # (H) name, and use it only when unambiguous so a same-named nested type elsewhere
-        # (H) cannot mis-resolve. The trie indexes by dot segment, so find_with_prefix
-        # (H) already excludes character-level prefix collisions.
+        # (H) whole-registry scan) for a type declaration (class/interface/enum) whose
+        # (H) last segment is the simple name, and use it only when unambiguous so a
+        # (H) same-named nested type elsewhere cannot mis-resolve. The trie indexes by
+        # (H) dot segment, so find_with_prefix already excludes prefix collisions.
         suffix = f"{cs.SEPARATOR_DOT}{type_name}"
         nested = [
             qn
             for qn, entity_type in self.function_registry.find_with_prefix(module_qn)
-            if qn.endswith(suffix)
-            and entity_type in (NodeType.CLASS, NodeType.INTERFACE)
+            if qn.endswith(suffix) and entity_type in _JAVA_TYPE_DECL_NODE_TYPES
         ]
         if len(nested) == 1:
             return nested[0]

--- a/codebase_rag/parsers/java/type_resolver.py
+++ b/codebase_rag/parsers/java/type_resolver.py
@@ -159,6 +159,22 @@ class JavaTypeResolverMixin:
         ] in [NodeType.CLASS, NodeType.INTERFACE]:
             return same_package_qn
 
+        # (H) A nested class referenced by its simple name from within the same file
+        # (H) (`RECORD_HELPER` typed by the nested `RecordHelper`): the qn is
+        # (H) `module.Outer.Nested`, not `module.Nested`, so the direct check above
+        # (H) misses it. Search this module for a CLASS/INTERFACE whose last segment is
+        # (H) the simple name, and use it only when unambiguous so a same-named nested
+        # (H) type elsewhere cannot mis-resolve.
+        prefix = f"{module_qn}{cs.SEPARATOR_DOT}"
+        nested = [
+            qn
+            for qn in self.function_registry.find_ending_with(type_name)
+            if qn.startswith(prefix)
+            and self.function_registry[qn] in [NodeType.CLASS, NodeType.INTERFACE]
+        ]
+        if len(nested) == 1:
+            return nested[0]
+
         return type_name
 
     def _get_superclass_name(self, class_qn: str) -> str | None:

--- a/codebase_rag/tests/test_dead_code_eval.py
+++ b/codebase_rag/tests/test_dead_code_eval.py
@@ -161,6 +161,61 @@ def test_cpp_operator_overloads_are_roots() -> None:
     assert "proj.mod.operator_equal" in dead
 
 
+def test_override_of_reachable_method_is_reachable() -> None:
+    # (H) A call to a base/interface method dispatches at runtime to any override, so
+    # (H) an override of a REACHABLE method is itself reachable (sound virtual dispatch).
+    # (H) The graph records OVERRIDES (overrider -> overridden) but the reachability walk
+    # (H) follows CALLS/REFERENCES only, so overrides reached solely by dispatch looked
+    # (H) dead (gson's RecordHelper strategy subclasses). A call reaches the base; the
+    # (H) override must be revived; an override of a DEAD base stays dead.
+    _OVERRIDES = cs.RelationshipType.OVERRIDES.value
+    nodes = dict(
+        [
+            (
+                (_MODULE, "proj.m"),
+                {cs.KEY_QUALIFIED_NAME: "proj.m", cs.KEY_PATH: "m.java"},
+            ),
+            _fn("proj.m.entry", path="m.java"),
+            _method("proj.m.Base.run(int)", "m.java"),
+            _method("proj.m.Sub.run(int)", "m.java"),
+            _method("proj.m.DeadBase.gone()", "m.java"),
+            _method("proj.m.DeadSub.gone()", "m.java"),
+        ]
+    )
+    nodes[(_FUNCTION, "proj.m.entry")][cs.KEY_IS_EXPORTED] = True
+    rels = [
+        (
+            _FUNCTION,
+            "proj.m.entry",
+            _CALLS,
+            cs.NodeLabel.METHOD.value,
+            "proj.m.Base.run(int)",
+        ),
+        (
+            cs.NodeLabel.METHOD.value,
+            "proj.m.Sub.run(int)",
+            _OVERRIDES,
+            cs.NodeLabel.METHOD.value,
+            "proj.m.Base.run(int)",
+        ),
+        (
+            cs.NodeLabel.METHOD.value,
+            "proj.m.DeadSub.gone()",
+            _OVERRIDES,
+            cs.NodeLabel.METHOD.value,
+            "proj.m.DeadBase.gone()",
+        ),
+    ]
+    dead = dead_code_from_graph(nodes, rels, _PREFIX, _CONFIG)
+    # (H) Base is called (via exported entry) -> live; its override is a dispatch
+    # (H) target -> revived.
+    assert "proj.m.Base.run(int)" not in dead
+    assert "proj.m.Sub.run(int)" not in dead
+    # (H) DeadBase is never called, so neither it nor its override is reachable.
+    assert "proj.m.DeadBase.gone()" in dead
+    assert "proj.m.DeadSub.gone()" in dead
+
+
 def test_root_level_tests_dir_is_excluded() -> None:
     # (H) A top-level `tests/` dir (Rust integration tests `tests/client.rs`, a JS
     # (H) `tests/` folder) is test infrastructure. The `/tests/` pattern needs a

--- a/codebase_rag/tests/test_dead_code_eval.py
+++ b/codebase_rag/tests/test_dead_code_eval.py
@@ -178,39 +178,26 @@ def test_override_of_reachable_method_is_reachable() -> None:
             _fn("proj.m.entry", path="m.java"),
             _method("proj.m.Base.run(int)", "m.java"),
             _method("proj.m.Sub.run(int)", "m.java"),
+            _method("proj.m.SubSub.run(int)", "m.java"),
             _method("proj.m.DeadBase.gone()", "m.java"),
             _method("proj.m.DeadSub.gone()", "m.java"),
         ]
     )
+    _MTD = cs.NodeLabel.METHOD.value
     nodes[(_FUNCTION, "proj.m.entry")][cs.KEY_IS_EXPORTED] = True
     rels = [
-        (
-            _FUNCTION,
-            "proj.m.entry",
-            _CALLS,
-            cs.NodeLabel.METHOD.value,
-            "proj.m.Base.run(int)",
-        ),
-        (
-            cs.NodeLabel.METHOD.value,
-            "proj.m.Sub.run(int)",
-            _OVERRIDES,
-            cs.NodeLabel.METHOD.value,
-            "proj.m.Base.run(int)",
-        ),
-        (
-            cs.NodeLabel.METHOD.value,
-            "proj.m.DeadSub.gone()",
-            _OVERRIDES,
-            cs.NodeLabel.METHOD.value,
-            "proj.m.DeadBase.gone()",
-        ),
+        (_FUNCTION, "proj.m.entry", _CALLS, _MTD, "proj.m.Base.run(int)"),
+        (_MTD, "proj.m.Sub.run(int)", _OVERRIDES, _MTD, "proj.m.Base.run(int)"),
+        # (H) multi-level: SubSub overrides Sub overrides Base -- all must revive.
+        (_MTD, "proj.m.SubSub.run(int)", _OVERRIDES, _MTD, "proj.m.Sub.run(int)"),
+        (_MTD, "proj.m.DeadSub.gone()", _OVERRIDES, _MTD, "proj.m.DeadBase.gone()"),
     ]
     dead = dead_code_from_graph(nodes, rels, _PREFIX, _CONFIG)
-    # (H) Base is called (via exported entry) -> live; its override is a dispatch
-    # (H) target -> revived.
+    # (H) Base is called (via exported entry) -> live; its overrides (direct and
+    # (H) transitive) are dispatch targets -> revived.
     assert "proj.m.Base.run(int)" not in dead
     assert "proj.m.Sub.run(int)" not in dead
+    assert "proj.m.SubSub.run(int)" not in dead
     # (H) DeadBase is never called, so neither it nor its override is reachable.
     assert "proj.m.DeadBase.gone()" in dead
     assert "proj.m.DeadSub.gone()" in dead

--- a/codebase_rag/tests/test_java_nested_type_receiver.py
+++ b/codebase_rag/tests/test_java_nested_type_receiver.py
@@ -50,3 +50,26 @@ def test_nested_class_typed_field_receiver_resolves(
         f.endswith(".M.ok(int)") and t.endswith(".M.Helper.check(int)")
         for f, t in calls
     ), calls
+
+
+def test_nested_enum_typed_field_receiver_resolves(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) A nested ENUM is also a type declaration; a field typed by it must resolve
+    # (H) its method calls too (the nested-type search must not be class/interface-only).
+    _project(
+        temp_repo,
+        "public class M {\n"
+        "  private static final Mode MODE = Mode.FAST;\n"
+        "  public static int ok() { return MODE.weight(); }\n"
+        "  private enum Mode {\n"
+        "    FAST, SLOW;\n"
+        "    int weight() { return 1; }\n"
+        "  }\n"
+        "}\n",
+    )
+    create_and_run_updater(temp_repo, mock_ingestor, skip_if_missing="java")
+    calls = _calls(mock_ingestor)
+    assert any(
+        f.endswith(".M.ok()") and t.endswith(".M.Mode.weight()") for f, t in calls
+    ), calls

--- a/codebase_rag/tests/test_java_nested_type_receiver.py
+++ b/codebase_rag/tests/test_java_nested_type_receiver.py
@@ -1,0 +1,52 @@
+# (H) A receiver typed as a NESTED class referenced by its simple name (gson's
+# (H) `RECORD_HELPER` field, typed by the nested `RecordHelper`) failed to resolve:
+# (H) `_resolve_java_type_name("RecordHelper", module)` only tried `module.RecordHelper`
+# (H) (module.Type), never `module.Outer.RecordHelper` (module.Enclosing.Nested), so the
+# (H) method call dropped and the whole nested hierarchy looked dead.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.conftest import create_and_run_updater, get_relationships
+
+
+def _project(temp_repo: Path, body: str) -> Path:
+    p = temp_repo / "jnest"
+    (p / "com" / "example").mkdir(parents=True)
+    (p / "com" / "example" / "M.java").write_text(
+        f"package com.example;\n{body}\n", encoding="utf-8"
+    )
+    return p
+
+
+def _calls(mock_ingestor: MagicMock) -> set[tuple[str, str]]:
+    return {
+        (c.args[0][2], c.args[2][2]) for c in get_relationships(mock_ingestor, "CALLS")
+    }
+
+
+def test_nested_class_typed_field_receiver_resolves(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    _project(
+        temp_repo,
+        "public class M {\n"
+        "  private static final Helper HELPER = new SubHelper();\n"
+        "  public static boolean ok(int x) { return HELPER.check(x); }\n"
+        "  private abstract static class Helper {\n"
+        "    abstract boolean check(int x);\n"
+        "  }\n"
+        "  private static class SubHelper extends Helper {\n"
+        "    @Override boolean check(int x) { return x > 0; }\n"
+        "  }\n"
+        "}\n",
+    )
+    create_and_run_updater(temp_repo, mock_ingestor, skip_if_missing="java")
+    calls = _calls(mock_ingestor)
+    # (H) HELPER is typed by the nested Helper, so HELPER.check must resolve to the
+    # (H) nested Helper.check -- not drop.
+    assert any(
+        f.endswith(".M.ok(int)") and t.endswith(".M.Helper.check(int)")
+        for f, t in calls
+    ), calls

--- a/evals/dead_code.py
+++ b/evals/dead_code.py
@@ -36,6 +36,7 @@ _INSTANTIATES = cs.RelationshipType.INSTANTIATES.value
 _INHERITS = cs.RelationshipType.INHERITS.value
 _DEFINES = cs.RelationshipType.DEFINES.value
 _DEFINES_METHOD = cs.RelationshipType.DEFINES_METHOD.value
+_OVERRIDES = cs.RelationshipType.OVERRIDES.value
 _EMPTY_LOCATION = LocationStats(0, 0, 0, 0.0, 0)
 
 _NodeId = tuple[str, PropertyValue]
@@ -238,6 +239,14 @@ def dead_code_from_graph(
     for from_label, from_val, rel_type, _to_label, to_val in rels:
         if rel_type in traversal:
             adjacency[str(from_val)].add(str(to_val))
+        elif rel_type == _OVERRIDES:
+            # (H) OVERRIDES is recorded overrider -> overridden. A call to the base
+            # (H) method dispatches at runtime to any override, so an override of a
+            # (H) REACHABLE method is itself reachable. Add the REVERSE edge
+            # (H) (overridden -> overrider) so the walk reaches every override -- and
+            # (H) transitively its callees -- of any live base; an override of a dead
+            # (H) base stays dead. Sound virtual dispatch, mirroring self-dispatch.
+            adjacency[str(to_val)].add(str(from_val))
 
     live = set(roots)
     _walk(roots, adjacency, live)

--- a/evals/dead_code.py
+++ b/evals/dead_code.py
@@ -236,17 +236,14 @@ def dead_code_from_graph(
             roots.add(qn)
 
     adjacency: dict[str, set[str]] = defaultdict(set)
+    # (H) OVERRIDES is recorded overrider -> overridden; keep the REVERSE mapping
+    # (H) (overridden -> overriders) to expand virtual-dispatch targets below.
+    override_rev: dict[str, set[str]] = defaultdict(set)
     for from_label, from_val, rel_type, _to_label, to_val in rels:
         if rel_type in traversal:
             adjacency[str(from_val)].add(str(to_val))
         elif rel_type == _OVERRIDES:
-            # (H) OVERRIDES is recorded overrider -> overridden. A call to the base
-            # (H) method dispatches at runtime to any override, so an override of a
-            # (H) REACHABLE method is itself reachable. Add the REVERSE edge
-            # (H) (overridden -> overrider) so the walk reaches every override -- and
-            # (H) transitively its callees -- of any live base; an override of a dead
-            # (H) base stays dead. Sound virtual dispatch, mirroring self-dispatch.
-            adjacency[str(to_val)].add(str(from_val))
+            override_rev[str(to_val)].add(str(from_val))
 
     live = set(roots)
     _walk(roots, adjacency, live)
@@ -266,6 +263,22 @@ def dead_code_from_graph(
     }
     live |= closure_roots
     _walk(closure_roots, adjacency, live)
+
+    # (H) Third expansion, mirroring the query's OVERRIDES* stage: a call to a base or
+    # (H) interface method dispatches at runtime to any override, so every (transitive)
+    # (H) override of a LIVE method is a reachable dispatch target, as is its callee
+    # (H) closure. `override_rev` is walked to a fixpoint so multi-level hierarchies
+    # (H) (Base <- Sub <- SubSub) are all revived; an override of a DEAD base stays
+    # (H) dead. Bounded like the closure round: one callee-walk after the expansion.
+    override_roots: set[str] = set()
+    stack = list(live)
+    while stack:
+        for overrider in override_rev.get(stack.pop(), ()):
+            if overrider not in live and overrider not in override_roots:
+                override_roots.add(overrider)
+                stack.append(overrider)
+    live |= override_roots
+    _walk(override_roots, adjacency, live)
 
     dead = candidates - live
     # (H) Suppress generated files (openapi-ts client/core, routeTree.gen.ts) from


### PR DESCRIPTION
Stacked on #660. Fourth dead-code fix from dogfooding google/gson: an override of a reachable method is itself reachable.

## The class: overrides reached only by virtual dispatch look dead

A call to a base or interface method dispatches at runtime to any override, but the reachability walk follows `CALLS`/`REFERENCES` only. The graph records `OVERRIDES` (overrider -> overridden), so an override reached solely through dispatch on the base type had no incoming walked edge and was reported dead (gson's `RecordHelper` strategy subclasses `RecordSupportedHelper` / `RecordNotSupportedHelper`).

## Fix

An override of a REACHABLE method is a potential runtime dispatch target, so it is reachable (sound, conservative virtual dispatch, mirroring the existing Python self-dispatch handling).

- `evals/dead_code.py`: add a reverse edge `overridden -> overrider` for each `OVERRIDES` edge, so the walk reaches every override (and transitively its callees) of any live base method.
- `codebase_rag/cypher_queries.py`: an `OVERRIDES` expansion stage mirroring the existing decorated-closure expansion, adding overriders of any live method (plus their forward closure) to the live set.

Revive-only: an override of a DEAD base stays dead (verified in the test), so this only removes false positives, never masks a genuinely dead method whose base is unreachable.

## Tests

`test_dead_code_eval.py::test_override_of_reachable_method_is_reachable`: a called base method's override is revived; an override of an uncalled base stays dead.

Verified: combined with #660, gson core drops 72 -> 67 (the RecordHelper override cluster revived); full suite green (4439 passed), no cross-language regression (revive-only, gated on real OVERRIDES edges).
