### PR TITLE
fix(java): anonymous-class override dispatch (OVERRIDES edges + lexical-scope calls)

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -3405,6 +3405,14 @@ FQN_JAVA_SCOPE_TYPES = (
     TS_INTERFACE_DECLARATION,
     TS_ENUM_DECLARATION,
     TS_PROGRAM,
+    # (H) An enclosing method/constructor is a qn scope for a function nested in its
+    # (H) body (a method-body anonymous class's method): the call pass builds
+    # (H) `Class.method.nested`, so the definition pass must include the method too --
+    # (H) else the two disagree and every edge from the nested function dangles onto a
+    # (H) phantom `Class.method.nested` node, orphaning its callees. A direct method is
+    # (H) the func itself, not an ancestor, so its own qn is unaffected.
+    TS_METHOD_DECLARATION,
+    TS_CONSTRUCTOR_DECLARATION,
 )
 FQN_JAVA_FUNCTION_TYPES = (
     TS_METHOD_DECLARATION,

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -232,6 +232,15 @@ UNWIND (
 OPTIONAL MATCH (cr)-[:{traversal}*BFS]->(cr_reached)
 WITH live_set, closure_roots, collect(DISTINCT cr_reached) AS cr_reached_set
 WITH live_set + closure_roots + cr_reached_set AS live_set
+OPTIONAL MATCH (ov:Function|Method)-[:OVERRIDES]->(base)
+WHERE base IN live_set AND NOT ov IN live_set
+WITH live_set, collect(DISTINCT ov) AS override_roots
+UNWIND (
+  CASE WHEN size(override_roots) = 0 THEN [null] ELSE override_roots END
+) AS orr
+OPTIONAL MATCH (orr)-[:{traversal}*BFS]->(or_reached)
+WITH live_set, override_roots, collect(DISTINCT or_reached) AS or_reached_set
+WITH live_set + override_roots + or_reached_set AS live_set
 MATCH (n:{labels})
 WHERE n.qualified_name STARTS WITH $project_prefix
   AND NOT n IN live_set{candidate_clause}

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -232,15 +232,7 @@ UNWIND (
 OPTIONAL MATCH (cr)-[:{traversal}*BFS]->(cr_reached)
 WITH live_set, closure_roots, collect(DISTINCT cr_reached) AS cr_reached_set
 WITH live_set + closure_roots + cr_reached_set AS live_set
-OPTIONAL MATCH (ov:Function|Method)-[:OVERRIDES*]->(base)
-WHERE base IN live_set AND NOT ov IN live_set
-WITH live_set, collect(DISTINCT ov) AS override_roots
-UNWIND (
-  CASE WHEN size(override_roots) = 0 THEN [null] ELSE override_roots END
-) AS orr
-OPTIONAL MATCH (orr)-[:{traversal}*BFS]->(or_reached)
-WITH live_set, override_roots, collect(DISTINCT or_reached) AS or_reached_set
-WITH live_set + override_roots + or_reached_set AS live_set
+{override_stages}
 MATCH (n:{labels})
 WHERE n.qualified_name STARTS WITH $project_prefix
   AND NOT n IN live_set{candidate_clause}
@@ -248,6 +240,26 @@ RETURN labels(n)[0] AS label, n.name AS name,
        n.qualified_name AS qualified_name, n.path AS path,
        n.start_line AS start_line, n.end_line AS end_line
 ORDER BY qualified_name"""
+
+
+# (H) One override-reachability stage: revive every (transitive) override of a method
+# (H) already in live_set, plus its callee closure. Emitted several times (see
+# (H) _OVERRIDE_EXPANSION_ROUNDS) because a base can go live via a revived override's
+# (H) callee (depth-2+ interleaving), whose own overrides then need reviving; a single
+# (H) stage misses those. Repeating the block matches the offline eval's round loop.
+_DEAD_CODE_OVERRIDE_STAGE = """OPTIONAL MATCH (ov:Function|Method)-[:OVERRIDES*]->(base)
+WHERE base IN live_set AND NOT ov IN live_set
+WITH live_set, collect(DISTINCT ov) AS override_roots
+UNWIND (
+  CASE WHEN size(override_roots) = 0 THEN [null] ELSE override_roots END
+) AS orr
+OPTIONAL MATCH (orr)-[:{traversal}*BFS]->(or_reached)
+WITH live_set, override_roots, collect(DISTINCT or_reached) AS or_reached_set
+WITH live_set + override_roots + or_reached_set AS live_set"""
+
+# (H) Must equal evals.dead_code._OVERRIDE_EXPANSION_ROUNDS so the offline eval and this
+# (H) query compute the same live set for deep override/callee interleaving.
+_OVERRIDE_EXPANSION_ROUNDS = 3
 
 
 def build_dead_code_query(include_tests: bool, include_classes: bool = False) -> str:
@@ -272,6 +284,10 @@ def build_dead_code_query(include_tests: bool, include_classes: bool = False) ->
     rust_root_names = _cypher_str_list(RUST_ROOT_FUNCTION_NAMES)
     rust_trait_methods = _cypher_str_list(RUST_TRAIT_METHOD_NAMES)
     java_serialization_methods = _cypher_str_list(JAVA_SERIALIZATION_METHOD_NAMES)
+    override_stages = "\n".join(
+        _DEAD_CODE_OVERRIDE_STAGE.format(traversal=traversal)
+        for _ in range(_OVERRIDE_EXPANSION_ROUNDS)
+    )
     return _DEAD_CODE_QUERY_TEMPLATE.format(
         labels=labels,
         traversal=traversal,
@@ -282,6 +298,7 @@ def build_dead_code_query(include_tests: bool, include_classes: bool = False) ->
         rust_root_names=rust_root_names,
         rust_trait_methods=rust_trait_methods,
         java_serialization_methods=java_serialization_methods,
+        override_stages=override_stages,
         cpp_operator_clause=_cpp_operator_root_clause(),
         protocol_stub_clause=_DEAD_CODE_PROTOCOL_STUB_CLAUSE.format(
             protocol_bases=protocol_bases

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -232,7 +232,7 @@ UNWIND (
 OPTIONAL MATCH (cr)-[:{traversal}*BFS]->(cr_reached)
 WITH live_set, closure_roots, collect(DISTINCT cr_reached) AS cr_reached_set
 WITH live_set + closure_roots + cr_reached_set AS live_set
-OPTIONAL MATCH (ov:Function|Method)-[:OVERRIDES]->(base)
+OPTIONAL MATCH (ov:Function|Method)-[:OVERRIDES*]->(base)
 WHERE base IN live_set AND NOT ov IN live_set
 WITH live_set, collect(DISTINCT ov) AS override_roots
 UNWIND (

--- a/codebase_rag/parsers/class_ingest/method_override.py
+++ b/codebase_rag/parsers/class_ingest/method_override.py
@@ -39,6 +39,58 @@ def process_all_method_overrides(
                 )
 
 
+def _signature_arity(method_name: str) -> int | None:
+    # (H) Number of top-level parameters in a signatured method name
+    # (H) (`readField(A,JsonReader,BoundField)` -> 3, `create()` -> 0); None when the
+    # (H) name carries no signature (Python/JS methods). Commas inside generics
+    # (H) (`Map<K, V>`) are nested, so only depth-0 commas separate parameters.
+    open_idx = method_name.find(cs.CHAR_PAREN_OPEN)
+    if open_idx < 0:
+        return None
+    inner = method_name[open_idx + 1 : method_name.rfind(cs.CHAR_PAREN_CLOSE)]
+    if not inner.strip():
+        return 0
+    depth = 0
+    count = 1
+    for ch in inner:
+        if ch in "<([":
+            depth += 1
+        elif ch in ">)]":
+            depth -= 1
+        elif ch == "," and depth == 0:
+            count += 1
+    return count
+
+
+def _find_override_by_arity(
+    parent_class: str,
+    method_name: str,
+    function_registry: FunctionRegistryTrieProtocol,
+) -> str | None:
+    # (H) Override matching by exact signature fails when a subclass renames a generic
+    # (H) type parameter (base `readField(A,...)` vs override `readField(T,...)`), which
+    # (H) is a distinct qn. Java overriding is by name + erased parameter types, so fall
+    # (H) back to a UNIQUE parent method with the same simple name and arity; ambiguous
+    # (H) overloads (>1 candidate) are left unmatched rather than guessed.
+    arity = _signature_arity(method_name)
+    if arity is None:
+        return None
+    base_name = method_name.split(cs.CHAR_PAREN_OPEN, 1)[0]
+    prefix = f"{parent_class}{cs.SEPARATOR_DOT}"
+    matches: list[str] = []
+    for qn, node_type in function_registry.find_with_prefix(parent_class):
+        if node_type != NodeType.METHOD or not qn.startswith(prefix):
+            continue
+        leaf = qn[len(prefix) :]
+        if cs.SEPARATOR_DOT in leaf.split(cs.CHAR_PAREN_OPEN, 1)[0]:
+            continue  # (H) a method of a nested class, not directly on parent_class
+        if leaf.split(cs.CHAR_PAREN_OPEN, 1)[0] == base_name and (
+            _signature_arity(leaf) == arity
+        ):
+            matches.append(qn)
+    return matches[0] if len(matches) == 1 else None
+
+
 def check_method_overrides(
     method_qn: str,
     method_name: str,
@@ -58,6 +110,15 @@ def check_method_overrides(
 
         if current_class != class_qn:
             parent_method_qn = f"{current_class}.{method_name}"
+            if parent_method_qn not in function_registry:
+                # (H) Fall back to name+arity so a generic type-var rename in the
+                # (H) override signature still matches the base method.
+                parent_method_qn = (
+                    _find_override_by_arity(
+                        current_class, method_name, function_registry
+                    )
+                    or parent_method_qn
+                )
 
             if parent_method_qn in function_registry:
                 ingestor.ensure_relationship_batch(

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -830,6 +830,16 @@ class ClassIngestMixin:
         # (H) live when the base is reachable.
         type_decls = (NodeType.CLASS, NodeType.INTERFACE, NodeType.ENUM)
         for anon_qn, method_name, base_type, _module_qn in self.java_anon_overrides:
+            # (H) A method-body anonymous override is registered as a FUNCTION (via the
+            # (H) function-ingest path), a field-initializer one as a METHOD. The graph
+            # (H) matches an edge endpoint by LABEL + qn, so emit the source with the qn's
+            # (H) ACTUAL registered label -- a hard-coded Method label drops the edge for
+            # (H) the Function-labelled overrides (the eval matches by qn and would hide
+            # (H) this, but the production Cypher would not).
+            anon_type = self.function_registry.get(anon_qn)
+            if anon_type is None:
+                continue
+            anon_label = cs.NodeLabel(anon_type.value)
             base_candidates = [
                 qn
                 for qn in self.function_registry.find_ending_with(base_type)
@@ -849,7 +859,7 @@ class ClassIngestMixin:
                     == method_name
                 ):
                     self.ingestor.ensure_relationship_batch(
-                        (cs.NodeLabel.METHOD, cs.KEY_QUALIFIED_NAME, anon_qn),
+                        (anon_label, cs.KEY_QUALIFIED_NAME, anon_qn),
                         cs.RelationshipType.OVERRIDES,
                         (cs.NodeLabel.METHOD, cs.KEY_QUALIFIED_NAME, qn),
                     )

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -12,7 +12,7 @@ from ... import constants as cs
 from ... import logs
 from ...config import settings
 from ...language_spec import LanguageSpec
-from ...types_defs import ASTNode, PropertyDict
+from ...types_defs import ASTNode, NodeType, PropertyDict
 from ...utils.path_utils import cached_relative_path, cached_resolve_posix
 from ..cpp import CppTypeInferenceEngine
 from ..cpp import utils as cpp_utils
@@ -37,6 +37,26 @@ if TYPE_CHECKING:
         SimpleNameLookup,
     )
     from ..import_processor import ImportProcessor
+
+
+def _java_anonymous_base_type(method_node: Node, class_node: Node) -> str | None:
+    # (H) If `method_node` sits inside an anonymous class body between it and
+    # (H) `class_node` (`new Base(){ ... m() ... }`), return the anon class's base type
+    # (H) name (the object_creation's `type` field, generic args stripped). None when the
+    # (H) method belongs directly to the enclosing class, not an anonymous subclass.
+    current = method_node.parent
+    while current is not None and current is not class_node:
+        if current.type == cs.TS_CLASS_BODY:
+            parent = current.parent
+            if parent is not None and parent.type == cs.TS_OBJECT_CREATION_EXPRESSION:
+                type_node = parent.child_by_field_name(cs.FIELD_TYPE)
+                if type_node is not None and type_node.text is not None:
+                    return type_node.text.decode(cs.ENCODING_UTF8).split(
+                        cs.CHAR_ANGLE_OPEN, 1
+                    )[0]
+                return None
+        current = current.parent
+    return None
 
 
 def _is_nested_inside_function(
@@ -108,6 +128,7 @@ class ClassIngestMixin:
     import_processor: ImportProcessor
     class_inheritance: dict[str, list[str]]
     class_field_types: dict[str, dict[str, str]]
+    java_anon_overrides: list[tuple[str, str, str, str]]
     class_field_guard_inner: dict[str, dict[str, str]]
     method_return_types: dict[str, str]
     interface_implementers: dict[str, set[str]]
@@ -448,6 +469,7 @@ class ClassIngestMixin:
             file_path,
             sorted_func_nodes=sorted_func_nodes,
             func_node_starts=func_node_starts,
+            module_qn=module_qn,
         )
 
     def _ingest_rust_impl_methods(
@@ -562,6 +584,7 @@ class ClassIngestMixin:
         file_path: Path | None = None,
         sorted_func_nodes: list[Node] | None = None,
         func_node_starts: list[int] | None = None,
+        module_qn: str | None = None,
     ) -> None:
         body_node = class_node.child_by_field_name("body")
         if not body_node:
@@ -599,7 +622,7 @@ class ClassIngestMixin:
                     )
                     method_qualified_name = f"{class_qn}.{method_name}{param_sig}"
 
-            ingest_method(
+            registered_qn = ingest_method(
                 method_node,
                 class_qn,
                 cs.NodeLabel.CLASS,
@@ -613,6 +636,23 @@ class ClassIngestMixin:
                 file_path=file_path,
                 repo_path=self.repo_path,
             )
+            # (H) A Java method declared inside an anonymous class body
+            # (H) (`new Base(){ @Override m(){} }`) is ingested here under the enclosing
+            # (H) class but really overrides the anon class's base type. Record it so a
+            # (H) deferred pass emits the OVERRIDES edge once the base is registered;
+            # (H) with override-reachability that keeps the dispatch-only override live.
+            if (
+                language == cs.SupportedLanguage.JAVA
+                and registered_qn is not None
+                and module_qn is not None
+                and (base := _java_anonymous_base_type(method_node, class_node))
+            ):
+                method_name = registered_qn.rsplit(cs.SEPARATOR_DOT, 1)[-1].split(
+                    cs.CHAR_PAREN_OPEN, 1
+                )[0]
+                self.java_anon_overrides.append(
+                    (registered_qn, method_name, base, module_qn)
+                )
             # (H) Record a C++ method's return type so a chained call off a static
             # (H) factory method (`parser(...).parse(...)`, nlohmann's basic_json)
             # (H) can type the receiver and resolve the next hop.
@@ -691,6 +731,42 @@ class ClassIngestMixin:
             self.class_inheritance,
             self.ingestor,
         )
+        self._resolve_java_anon_overrides()
+
+    def _resolve_java_anon_overrides(self) -> None:
+        # (H) Emit OVERRIDES edges for Java anonymous-class methods recorded at ingestion
+        # (H) (`new Base(){ @Override m(){} }`). The base type is resolved by UNIQUE
+        # (H) global simple-name match among type declarations (the base is usually in
+        # (H) another file; a full import resolve is unnecessary and this stays
+        # (H) revive-only -- an ambiguous or unfound base is skipped). Each base method
+        # (H) directly on the base whose simple name matches gets an OVERRIDES edge from
+        # (H) the anon override, so override-reachability keeps the dispatch-only method
+        # (H) live when the base is reachable.
+        type_decls = (NodeType.CLASS, NodeType.INTERFACE, NodeType.ENUM)
+        for anon_qn, method_name, base_type, _module_qn in self.java_anon_overrides:
+            base_candidates = [
+                qn
+                for qn in self.function_registry.find_ending_with(base_type)
+                if self.function_registry.get(qn) in type_decls
+            ]
+            if len(base_candidates) != 1:
+                continue
+            base_qn = base_candidates[0]
+            base_prefix = f"{base_qn}{cs.SEPARATOR_DOT}"
+            for qn, node_type in self.function_registry.find_with_prefix(base_qn):
+                if (
+                    node_type == NodeType.METHOD
+                    and qn.startswith(base_prefix)
+                    and cs.SEPARATOR_DOT
+                    not in qn[len(base_prefix) :].split(cs.CHAR_PAREN_OPEN, 1)[0]
+                    and qn[len(base_prefix) :].split(cs.CHAR_PAREN_OPEN, 1)[0]
+                    == method_name
+                ):
+                    self.ingestor.ensure_relationship_batch(
+                        (cs.NodeLabel.METHOD, cs.KEY_QUALIFIED_NAME, anon_qn),
+                        cs.RelationshipType.OVERRIDES,
+                        (cs.NodeLabel.METHOD, cs.KEY_QUALIFIED_NAME, qn),
+                    )
 
     def _resolve_class_name(self, class_name: str, module_qn: str) -> str | None:
         return resolve_class_name(

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -62,6 +62,12 @@ class DefinitionProcessor(
         # (H) method resolves via the field's declared type. Populated at class
         # (H) ingestion, read by the type-inference engine at call resolution.
         self.class_field_types: dict[str, dict[str, str]] = {}
+        # (H) Java anonymous-class override methods: (anon_method_qn, method_name,
+        # (H) base_type_name, module_qn). An anon class `new Base(){ @Override m(){} }`
+        # (H) is not modelled as a subclass, so its overrides register under the
+        # (H) enclosing class with no OVERRIDES edge and look dead. Recorded at method
+        # (H) ingestion, resolved to OVERRIDES edges once every base type is registered.
+        self.java_anon_overrides: list[tuple[str, str, str, str]] = []
         # (H) {class_qn: {field_name: inner_type}} for Rust guard-container fields
         # (H) (`state: Mutex<State>` -> {"state": "State"}). The field map above keeps
         # (H) the WRAPPER; this inner is applied only when a receiver chain reaches a

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -38,6 +38,32 @@ if TYPE_CHECKING:
     from .handlers import LanguageHandler
 
 
+def _java_anon_base_for_function(
+    func_node: Node, class_node_types: frozenset[str]
+) -> str | None:
+    # (H) A Java method declared inside a method-body anonymous class
+    # (H) (`createBoundField(){ return new BoundField(){ @Override write(){} } }`) is
+    # (H) captured here as a FUNCTION (the class-method pass skips method-nested defs),
+    # (H) so it needs its base-type override link too. Walk to the nearest enclosing
+    # (H) type: an anon `class_body` (parent is object_creation) before any NAMED class
+    # (H) means it overrides that base; return the base type name (generics stripped).
+    current = func_node.parent
+    while current is not None:
+        if current.type in class_node_types:
+            return None
+        if current.type == cs.TS_CLASS_BODY:
+            parent = current.parent
+            if parent is not None and parent.type == cs.TS_OBJECT_CREATION_EXPRESSION:
+                type_node = parent.child_by_field_name(cs.FIELD_TYPE)
+                if type_node is not None and type_node.text is not None:
+                    return type_node.text.decode(cs.ENCODING_UTF8).split(
+                        cs.CHAR_ANGLE_OPEN, 1
+                    )[0]
+            return None
+        current = current.parent
+    return None
+
+
 class FunctionResolution(NamedTuple):
     qualified_name: str
     name: str
@@ -103,6 +129,7 @@ class FunctionIngestMixin:
     function_registry: FunctionRegistryTrieProtocol
     simple_name_lookup: SimpleNameLookup
     module_qn_to_file_path: dict[str, Path]
+    java_anon_overrides: list[tuple[str, str, str, str]]
     _handler: LanguageHandler
     _deferred_cpp_methods: list[_DeferredMethod]
     _deferred_go_methods: list[_DeferredGoMethod]
@@ -607,6 +634,24 @@ class FunctionIngestMixin:
         )
         if resolution.name:
             self.simple_name_lookup[resolution.name].add(resolution.qualified_name)
+
+        # (H) A method-body anonymous-class override (`new Base(){ @Override m(){} }`
+        # (H) inside a method) is captured as a function here; record it so the deferred
+        # (H) pass emits an OVERRIDES edge to Base.m, keeping the dispatch-only override
+        # (H) live (field-initializer anon overrides are recorded in the class-method
+        # (H) pass instead).
+        if (
+            language == cs.SupportedLanguage.JAVA
+            and resolution.name
+            and (
+                base := _java_anon_base_for_function(
+                    func_node, frozenset(lang_config.class_node_types)
+                )
+            )
+        ):
+            self.java_anon_overrides.append(
+                (resolution.qualified_name, resolution.name, base, module_qn)
+            )
 
         self._create_function_relationships(
             func_node, resolution, module_qn, language, lang_config

--- a/codebase_rag/parsers/java/method_resolver.py
+++ b/codebase_rag/parsers/java/method_resolver.py
@@ -462,6 +462,19 @@ class JavaMethodResolverMixin:
 
         if not object_ref:
             logger.debug(ls.JAVA_RESOLVING_STATIC, method=method_name)
+            # (H) An unqualified call `m(...)` is `this.m(...)`: it binds to the
+            # (H) ENCLOSING class's own (or inherited/interface) method first. The bare
+            # (H) module-wide scan below ignores lexical scope and would return an
+            # (H) unrelated same-named method in a sibling/outer class (a nested class's
+            # (H) `create()` mis-binding to the outer class's `create`), so try the
+            # (H) enclosing class hierarchy before falling back.
+            if (enclosing_qn := self._lexical_class_qn(call_node, module_qn)) and (
+                result := self._resolve_instance_method(
+                    enclosing_qn, str(method_name), module_qn
+                )
+            ):
+                logger.debug(ls.JAVA_FOUND_STATIC, result=result)
+                return result
             result = self._resolve_static_or_local_method(str(method_name), module_qn)
             if result:
                 logger.debug(ls.JAVA_FOUND_STATIC, result=result)

--- a/codebase_rag/parsers/java/method_resolver.py
+++ b/codebase_rag/parsers/java/method_resolver.py
@@ -103,9 +103,13 @@ class JavaMethodResolverMixin:
         if object_ref in local_var_types:
             return local_var_types[object_ref]
 
-        # (H) Check for 'this' reference - prefer the lexical containing class (precise in
-        # (H) multi-class files); fall back to the first class under the module otherwise.
+        # (H) Check for 'this' reference - inside a method-body anonymous class `this`
+        # (H) is the anon (its base type), which the lexical named-class walk misses;
+        # (H) prefer that, then the lexical containing class (precise in multi-class
+        # (H) files); fall back to the first class under the module otherwise.
         if object_ref == cs.JAVA_KEYWORD_THIS:
+            if anon_base := self._enclosing_anon_base_qn(context_node, module_qn):
+                return anon_base
             if lexical := self._lexical_class_qn(context_node, module_qn):
                 return lexical
             return next(

--- a/codebase_rag/parsers/java/method_resolver.py
+++ b/codebase_rag/parsers/java/method_resolver.py
@@ -144,6 +144,18 @@ class JavaMethodResolverMixin:
         ):
             return simple_class_qn
 
+        # (H) A nested class referenced by its simple name as a static receiver base
+        # (H) (`Checker.INSTANCE...`, gson's `AccessChecker.INSTANCE`) has qn
+        # (H) `module.Outer.Nested`, which the direct check above misses; use the
+        # (H) nested-aware type resolver so the static-field access chain resolves.
+        nested_qn = self._resolve_java_type_name(object_ref, module_qn)
+        if nested_qn != object_ref and self.function_registry.get(nested_qn) in (
+            NodeType.CLASS,
+            NodeType.INTERFACE,
+            NodeType.ENUM,
+        ):
+            return nested_qn
+
         # (H) An unqualified class-name receiver for a static call (`T.make()`)
         # (H) defined in a sibling file: imports and the current module were checked
         # (H) above, so the remaining unqualified case is a same-package class.

--- a/codebase_rag/parsers/java/method_resolver.py
+++ b/codebase_rag/parsers/java/method_resolver.py
@@ -274,11 +274,13 @@ class JavaMethodResolverMixin:
             return method_result
 
         if inherited_result := self._find_inherited_method(
-            resolved_type, method_name, module_qn
+            resolved_type, method_name, module_qn, arg_count
         ):
             return inherited_result
 
-        return self._find_interface_method(resolved_type, method_name, module_qn)
+        return self._find_interface_method(
+            resolved_type, method_name, module_qn, arg_count
+        )
 
     def _find_method_with_any_signature(
         self,
@@ -293,7 +295,7 @@ class JavaMethodResolverMixin:
 
         if class_qn and not class_qn.startswith(self.project_name):
             return self._search_method_in_alternate_modules(
-                class_qn, method_name, current_module_qn
+                class_qn, method_name, current_module_qn, arg_count
             )
 
         return None
@@ -324,7 +326,11 @@ class JavaMethodResolverMixin:
         return None
 
     def _search_method_in_alternate_modules(
-        self, class_qn: str, method_name: str, current_module_qn: str | None
+        self,
+        class_qn: str,
+        method_name: str,
+        current_module_qn: str | None,
+        arg_count: int | None = None,
     ) -> tuple[str, str] | None:
         suffixes = class_qn.split(cs.SEPARATOR_DOT)
         lookup_keys = [
@@ -340,7 +346,9 @@ class JavaMethodResolverMixin:
 
         for module_qn in ranked_candidates:
             registry_class_qn = f"{module_qn}{cs.SEPARATOR_DOT}{simple_class_name}"
-            if result := self._search_method_in_class(registry_class_qn, method_name):
+            if result := self._search_method_in_class(
+                registry_class_qn, method_name, arg_count
+            ):
                 return result
 
         return None
@@ -370,24 +378,34 @@ class JavaMethodResolverMixin:
         guard_name=cs.GUARD_INHERITED_METHOD,
     )
     def _find_inherited_method(
-        self, class_qn: str, method_name: str, module_qn: str
+        self,
+        class_qn: str,
+        method_name: str,
+        module_qn: str,
+        arg_count: int | None = None,
     ) -> tuple[str, str] | None:
         if not (superclass_qn := self._get_superclass_name(class_qn)):
             return None
 
         if method_result := self._find_method_with_any_signature(
-            superclass_qn, method_name, module_qn
+            superclass_qn, method_name, module_qn, arg_count
         ):
             return method_result
 
-        return self._find_inherited_method(superclass_qn, method_name, module_qn)
+        return self._find_inherited_method(
+            superclass_qn, method_name, module_qn, arg_count
+        )
 
     def _find_interface_method(
-        self, class_qn: str, method_name: str, module_qn: str
+        self,
+        class_qn: str,
+        method_name: str,
+        module_qn: str,
+        arg_count: int | None = None,
     ) -> tuple[str, str] | None:
         for interface_qn in self._get_implemented_interfaces(class_qn):
             if method_result := self._find_method_with_any_signature(
-                interface_qn, method_name, module_qn
+                interface_qn, method_name, module_qn, arg_count
             ):
                 return method_result
 

--- a/codebase_rag/parsers/java/method_resolver.py
+++ b/codebase_rag/parsers/java/method_resolver.py
@@ -24,6 +24,29 @@ if TYPE_CHECKING:
     from ..import_processor import ImportProcessor
 
 
+def _java_signature_arity(qn_or_member: str) -> int | None:
+    # (H) Top-level parameter count of a signatured Java method name
+    # (H) (`resolve(A,B,Map<K, V>)` -> 3, `create()` -> 0); None if unsignatured.
+    # (H) Generic commas (`Map<K, V>`) are nested, so only depth-0 commas separate
+    # (H) parameters. Used to pick the arity-matching overload for a call.
+    open_idx = qn_or_member.find(cs.CHAR_PAREN_OPEN)
+    if open_idx < 0:
+        return None
+    inner = qn_or_member[open_idx + 1 : qn_or_member.rfind(cs.CHAR_PAREN_CLOSE)]
+    if not inner.strip():
+        return 0
+    depth = 0
+    count = 1
+    for ch in inner:
+        if ch in "<([":
+            depth += 1
+        elif ch in ">)]":
+            depth -= 1
+        elif ch == "," and depth == 0:
+            count += 1
+    return count
+
+
 class JavaMethodResolverMixin:
     __slots__ = ()
     import_processor: ImportProcessor
@@ -203,29 +226,38 @@ class JavaMethodResolverMixin:
         return None
 
     def _resolve_static_or_local_method(
-        self, method_name: str, module_qn: str
+        self, method_name: str, module_qn: str, arg_count: int | None = None
     ) -> tuple[str, str] | None:
-        return next(
-            (
-                (entity_type, qn)
-                for qn, entity_type in self.function_registry.find_with_prefix(
-                    module_qn
-                )
-                if entity_type in cs.JAVA_CALLABLE_ENTITY_TYPES
-                and qn.split(cs.CHAR_PAREN_OPEN)[0].endswith(
-                    f"{cs.SEPARATOR_DOT}{method_name}"
-                )
-            ),
-            None,
-        )
+        matches = [
+            (entity_type, qn)
+            for qn, entity_type in self.function_registry.find_with_prefix(module_qn)
+            if entity_type in cs.JAVA_CALLABLE_ENTITY_TYPES
+            and qn.split(cs.CHAR_PAREN_OPEN)[0].endswith(
+                f"{cs.SEPARATOR_DOT}{method_name}"
+            )
+        ]
+        if not matches:
+            return None
+        # (H) Prefer the overload whose parameter count matches the call's argument
+        # (H) count, so a same-named overload of a different arity is not left unmatched
+        # (H) (dead). Fall back to the first match when arity is unknown or none match.
+        if arg_count is not None and len(matches) > 1:
+            for entity_type, qn in matches:
+                if _java_signature_arity(qn) == arg_count:
+                    return entity_type, qn
+        return matches[0]
 
     def _resolve_instance_method(
-        self, object_type: str, method_name: str, module_qn: str
+        self,
+        object_type: str,
+        method_name: str,
+        module_qn: str,
+        arg_count: int | None = None,
     ) -> tuple[str, str] | None:
         resolved_type = self._resolve_java_type_name(object_type, module_qn)
 
         if method_result := self._find_method_with_any_signature(
-            resolved_type, method_name, module_qn
+            resolved_type, method_name, module_qn, arg_count
         ):
             return method_result
 
@@ -237,10 +269,14 @@ class JavaMethodResolverMixin:
         return self._find_interface_method(resolved_type, method_name, module_qn)
 
     def _find_method_with_any_signature(
-        self, class_qn: str, method_name: str, current_module_qn: str | None = None
+        self,
+        class_qn: str,
+        method_name: str,
+        current_module_qn: str | None = None,
+        arg_count: int | None = None,
     ) -> tuple[str, str] | None:
         if class_qn:
-            if result := self._search_method_in_class(class_qn, method_name):
+            if result := self._search_method_in_class(class_qn, method_name, arg_count):
                 return result
 
         if class_qn and not class_qn.startswith(self.project_name):
@@ -251,8 +287,9 @@ class JavaMethodResolverMixin:
         return None
 
     def _search_method_in_class(
-        self, class_qn: str, method_name: str
+        self, class_qn: str, method_name: str, arg_count: int | None = None
     ) -> tuple[str, str] | None:
+        matches: list[tuple[str, str]] = []
         for qn, method_type in self._find_registry_entries_under(class_qn):
             if qn == class_qn:
                 continue
@@ -261,7 +298,17 @@ class JavaMethodResolverMixin:
                 continue
             member = suffix[1:]
             if self._is_matching_method(member, method_name):
-                return method_type, qn
+                matches.append((method_type, qn))
+        if not matches:
+            return None
+        # (H) Prefer the arity-matching overload so a same-named overload of a
+        # (H) different parameter count is not left unmatched (dead) -- gson's recursive
+        # (H) `resolve(3-arg)`/`resolve(4-arg)`. Fall back to the first match otherwise.
+        if arg_count is not None and len(matches) > 1:
+            for method_type, qn in matches:
+                if _java_signature_arity(qn) == arg_count:
+                    return method_type, qn
+        return matches[0]
         return None
 
     def _search_method_in_alternate_modules(
@@ -453,6 +500,7 @@ class JavaMethodResolverMixin:
 
         method_name = call_info[cs.FIELD_NAME]
         object_ref = call_info[cs.FIELD_OBJECT]
+        arg_count = call_info[cs.FIELD_ARGUMENTS]
 
         if not method_name:
             logger.debug(ls.JAVA_NO_METHOD_NAME)
@@ -470,12 +518,14 @@ class JavaMethodResolverMixin:
             # (H) enclosing class hierarchy before falling back.
             if (enclosing_qn := self._lexical_class_qn(call_node, module_qn)) and (
                 result := self._resolve_instance_method(
-                    enclosing_qn, str(method_name), module_qn
+                    enclosing_qn, str(method_name), module_qn, arg_count
                 )
             ):
                 logger.debug(ls.JAVA_FOUND_STATIC, result=result)
                 return result
-            result = self._resolve_static_or_local_method(str(method_name), module_qn)
+            result = self._resolve_static_or_local_method(
+                str(method_name), module_qn, arg_count
+            )
             if result:
                 logger.debug(ls.JAVA_FOUND_STATIC, result=result)
             else:
@@ -492,7 +542,9 @@ class JavaMethodResolverMixin:
             return None
 
         logger.debug(ls.JAVA_OBJ_TYPE_RESOLVED, type=object_type)
-        result = self._resolve_instance_method(object_type, str(method_name), module_qn)
+        result = self._resolve_instance_method(
+            object_type, str(method_name), module_qn, arg_count
+        )
         if result:
             logger.debug(ls.JAVA_FOUND_INSTANCE, result=result)
         else:

--- a/codebase_rag/parsers/java/method_resolver.py
+++ b/codebase_rag/parsers/java/method_resolver.py
@@ -183,6 +183,42 @@ class JavaMethodResolverMixin:
             return None
         return self._resolve_java_type_name(class_name, module_qn)
 
+    def _enclosing_anon_base_qn(
+        self, context_node: ASTNode | None, module_qn: str
+    ) -> str | None:
+        # (H) If `context_node` sits inside a method-body anonymous class
+        # (H) (`new Base(){ ... }`) before any named class, return the anon's base type
+        # (H) qn -- an unqualified call inside the anon is `this.m()`, dispatched on the
+        # (H) anon (i.e. its base), not the enclosing named class. None otherwise.
+        if context_node is None:
+            return None
+        named = (
+            cs.TS_CLASS_DECLARATION,
+            cs.TS_INTERFACE_DECLARATION,
+            cs.TS_ENUM_DECLARATION,
+            cs.TS_RECORD_DECLARATION,
+        )
+        current = context_node.parent
+        while current is not None:
+            if current.type in named:
+                return None
+            if current.type == cs.TS_CLASS_BODY:
+                parent = current.parent
+                if (
+                    parent is not None
+                    and parent.type == cs.TS_OBJECT_CREATION_EXPRESSION
+                    and (type_node := parent.child_by_field_name(cs.FIELD_TYPE))
+                    is not None
+                    and type_node.text is not None
+                ):
+                    base = type_node.text.decode(cs.ENCODING_UTF8).split(
+                        cs.CHAR_ANGLE_OPEN, 1
+                    )[0]
+                    return self._resolve_java_type_name(base, module_qn)
+                return None
+            current = current.parent
+        return None
+
     def _resolve_field_access_chain_type(
         self,
         object_ref: str,
@@ -540,12 +576,21 @@ class JavaMethodResolverMixin:
 
         if not object_ref:
             logger.debug(ls.JAVA_RESOLVING_STATIC, method=method_name)
-            # (H) An unqualified call `m(...)` is `this.m(...)`: it binds to the
-            # (H) ENCLOSING class's own (or inherited/interface) method first. The bare
-            # (H) module-wide scan below ignores lexical scope and would return an
-            # (H) unrelated same-named method in a sibling/outer class (a nested class's
-            # (H) `create()` mis-binding to the outer class's `create`), so try the
-            # (H) enclosing class hierarchy before falling back.
+            # (H) An unqualified call `m(...)` is `this.m(...)`. Inside a method-body
+            # (H) anonymous class (`new Base(){ read(){ m(); } }`), `this` is the anon,
+            # (H) so bind against the anon's base type FIRST -- `_lexical_class_qn` only
+            # (H) sees the enclosing NAMED class and would mis-bind an inherited call to
+            # (H) a same-named method there. Then the enclosing class hierarchy; the bare
+            # (H) module-wide scan is the last resort (it ignores lexical scope).
+            if (
+                anon_base_qn := self._enclosing_anon_base_qn(call_node, module_qn)
+            ) and (
+                result := self._resolve_instance_method(
+                    anon_base_qn, str(method_name), module_qn, arg_count
+                )
+            ):
+                logger.debug(ls.JAVA_FOUND_STATIC, result=result)
+                return result
             if (enclosing_qn := self._lexical_class_qn(call_node, module_qn)) and (
                 result := self._resolve_instance_method(
                     enclosing_qn, str(method_name), module_qn, arg_count

--- a/codebase_rag/parsers/py/utils.py
+++ b/codebase_rag/parsers/py/utils.py
@@ -41,6 +41,20 @@ def resolve_class_name(
             return potential_qn
 
     matches = function_registry.find_ending_with(class_name)
+    # (H) Among same-named candidates in different files (gson's per-factory nested
+    # (H) `Adapter`), prefer one nested in the CURRENT module: a sibling/enclosing
+    # (H) nested class shadows a same-named class elsewhere, so `class Sub extends
+    # (H) Adapter` binds to its own file's Adapter, not another file's that merely
+    # (H) sorts first. Fall back to the first full-segment match otherwise.
+    module_prefix = f"{module_qn}{SEPARATOR_DOT}"
+    same_module = [
+        match
+        for match in matches
+        if match.startswith(module_prefix) and class_name in match.split(SEPARATOR_DOT)
+    ]
+    if same_module:
+        return str(min(same_module, key=len))
+
     for match in matches:
         match_parts = match.split(SEPARATOR_DOT)
         if class_name in match_parts:

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -559,7 +559,11 @@ def ingest_method(
     repo_path: Path | None = None,
     defer_containment: list[DeferredParentLink] | None = None,
     module_qn: str | None = None,
-) -> None:
+) -> str | None:
+    # (H) Returns the registered method qn (post register_unique_qn, so with any
+    # (H) @line dedup suffix) so a caller can wire further edges to the exact node --
+    # (H) e.g. an anonymous-class override method's OVERRIDES edge to its base. Returns
+    # (H) None only when the method has no resolvable name and nothing was registered.
     if language == cs.SupportedLanguage.CPP:
         from .cpp import utils as cpp_utils
 
@@ -641,7 +645,7 @@ def ingest_method(
                 rel_type=cs.RelationshipType.DEFINES_METHOD.value,
             )
         )
-        return
+        return method_qn
 
     # (H) The DEFINES_METHOD parent is matched in the graph by LABEL +
     # (H) qualified_name, so it must carry the container's real node label. Callers
@@ -658,6 +662,7 @@ def ingest_method(
         cs.RelationshipType.DEFINES_METHOD,
         (cs.NodeLabel.METHOD, cs.KEY_QUALIFIED_NAME, method_qn),
     )
+    return method_qn
 
 
 def module_function_props(

--- a/codebase_rag/tests/test_dead_code_eval.py
+++ b/codebase_rag/tests/test_dead_code_eval.py
@@ -210,39 +210,26 @@ def test_override_of_reachable_method_is_reachable() -> None:
             _fn("proj.m.entry", path="m.java"),
             _method("proj.m.Base.run(int)", "m.java"),
             _method("proj.m.Sub.run(int)", "m.java"),
+            _method("proj.m.SubSub.run(int)", "m.java"),
             _method("proj.m.DeadBase.gone()", "m.java"),
             _method("proj.m.DeadSub.gone()", "m.java"),
         ]
     )
+    _MTD = cs.NodeLabel.METHOD.value
     nodes[(_FUNCTION, "proj.m.entry")][cs.KEY_IS_EXPORTED] = True
     rels = [
-        (
-            _FUNCTION,
-            "proj.m.entry",
-            _CALLS,
-            cs.NodeLabel.METHOD.value,
-            "proj.m.Base.run(int)",
-        ),
-        (
-            cs.NodeLabel.METHOD.value,
-            "proj.m.Sub.run(int)",
-            _OVERRIDES,
-            cs.NodeLabel.METHOD.value,
-            "proj.m.Base.run(int)",
-        ),
-        (
-            cs.NodeLabel.METHOD.value,
-            "proj.m.DeadSub.gone()",
-            _OVERRIDES,
-            cs.NodeLabel.METHOD.value,
-            "proj.m.DeadBase.gone()",
-        ),
+        (_FUNCTION, "proj.m.entry", _CALLS, _MTD, "proj.m.Base.run(int)"),
+        (_MTD, "proj.m.Sub.run(int)", _OVERRIDES, _MTD, "proj.m.Base.run(int)"),
+        # (H) multi-level: SubSub overrides Sub overrides Base -- all must revive.
+        (_MTD, "proj.m.SubSub.run(int)", _OVERRIDES, _MTD, "proj.m.Sub.run(int)"),
+        (_MTD, "proj.m.DeadSub.gone()", _OVERRIDES, _MTD, "proj.m.DeadBase.gone()"),
     ]
     dead = dead_code_from_graph(nodes, rels, _PREFIX, _CONFIG)
-    # (H) Base is called (via exported entry) -> live; its override is a dispatch
-    # (H) target -> revived.
+    # (H) Base is called (via exported entry) -> live; its overrides (direct and
+    # (H) transitive) are dispatch targets -> revived.
     assert "proj.m.Base.run(int)" not in dead
     assert "proj.m.Sub.run(int)" not in dead
+    assert "proj.m.SubSub.run(int)" not in dead
     # (H) DeadBase is never called, so neither it nor its override is reachable.
     assert "proj.m.DeadBase.gone()" in dead
     assert "proj.m.DeadSub.gone()" in dead

--- a/codebase_rag/tests/test_dead_code_eval.py
+++ b/codebase_rag/tests/test_dead_code_eval.py
@@ -193,6 +193,61 @@ def test_java_serialization_hooks_are_roots() -> None:
     assert "proj.mod.C.readObject(ObjectInputStream)" in dead
 
 
+def test_override_of_reachable_method_is_reachable() -> None:
+    # (H) A call to a base/interface method dispatches at runtime to any override, so
+    # (H) an override of a REACHABLE method is itself reachable (sound virtual dispatch).
+    # (H) The graph records OVERRIDES (overrider -> overridden) but the reachability walk
+    # (H) follows CALLS/REFERENCES only, so overrides reached solely by dispatch looked
+    # (H) dead (gson's RecordHelper strategy subclasses). A call reaches the base; the
+    # (H) override must be revived; an override of a DEAD base stays dead.
+    _OVERRIDES = cs.RelationshipType.OVERRIDES.value
+    nodes = dict(
+        [
+            (
+                (_MODULE, "proj.m"),
+                {cs.KEY_QUALIFIED_NAME: "proj.m", cs.KEY_PATH: "m.java"},
+            ),
+            _fn("proj.m.entry", path="m.java"),
+            _method("proj.m.Base.run(int)", "m.java"),
+            _method("proj.m.Sub.run(int)", "m.java"),
+            _method("proj.m.DeadBase.gone()", "m.java"),
+            _method("proj.m.DeadSub.gone()", "m.java"),
+        ]
+    )
+    nodes[(_FUNCTION, "proj.m.entry")][cs.KEY_IS_EXPORTED] = True
+    rels = [
+        (
+            _FUNCTION,
+            "proj.m.entry",
+            _CALLS,
+            cs.NodeLabel.METHOD.value,
+            "proj.m.Base.run(int)",
+        ),
+        (
+            cs.NodeLabel.METHOD.value,
+            "proj.m.Sub.run(int)",
+            _OVERRIDES,
+            cs.NodeLabel.METHOD.value,
+            "proj.m.Base.run(int)",
+        ),
+        (
+            cs.NodeLabel.METHOD.value,
+            "proj.m.DeadSub.gone()",
+            _OVERRIDES,
+            cs.NodeLabel.METHOD.value,
+            "proj.m.DeadBase.gone()",
+        ),
+    ]
+    dead = dead_code_from_graph(nodes, rels, _PREFIX, _CONFIG)
+    # (H) Base is called (via exported entry) -> live; its override is a dispatch
+    # (H) target -> revived.
+    assert "proj.m.Base.run(int)" not in dead
+    assert "proj.m.Sub.run(int)" not in dead
+    # (H) DeadBase is never called, so neither it nor its override is reachable.
+    assert "proj.m.DeadBase.gone()" in dead
+    assert "proj.m.DeadSub.gone()" in dead
+
+
 def test_root_level_tests_dir_is_excluded() -> None:
     # (H) A top-level `tests/` dir (Rust integration tests `tests/client.rs`, a JS
     # (H) `tests/` folder) is test infrastructure. The `/tests/` pattern needs a

--- a/codebase_rag/tests/test_java_anon_method_caller_qn.py
+++ b/codebase_rag/tests/test_java_anon_method_caller_qn.py
@@ -85,3 +85,40 @@ def test_anon_override_unqualified_call_binds_to_base(
     assert not any(
         f.endswith(".read") and t.endswith(".M.helper()") for f, t in calls
     ), "anon override call wrongly bound to the enclosing class's decoy helper"
+
+
+def test_anon_override_explicit_this_call_binds_to_base(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) `this.helper()` inside a method-body anonymous override dispatches on the anon
+    # (H) (its base), not the enclosing named class -- same as the bare-call case but via
+    # (H) the explicit-`this` receiver path.
+    root = temp_repo / "janonthis"
+    pkg = root / "com" / "example"
+    pkg.mkdir(parents=True)
+    (pkg / "M.java").write_text(
+        "package com.example;\n"
+        "class Base {\n"
+        "  int helper() { return 1; }\n"
+        "  int read() { return 0; }\n"
+        "}\n"
+        "public class M {\n"
+        "  int helper() { return 99; }\n"
+        "  Base make() {\n"
+        "    return new Base() {\n"
+        "      @Override int read() { return this.helper(); }\n"
+        "    };\n"
+        "  }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="java")
+    calls = {
+        (c.args[0][2], c.args[2][2]) for c in get_relationships(mock_ingestor, "CALLS")
+    }
+    assert any(
+        f.endswith(".read") and t.endswith(".Base.helper()") for f, t in calls
+    ), sorted(t for f, t in calls if "helper" in t)
+    assert not any(
+        f.endswith(".read") and t.endswith(".M.helper()") for f, t in calls
+    ), "explicit this.helper() in anon wrongly bound to enclosing class"

--- a/codebase_rag/tests/test_java_anon_method_caller_qn.py
+++ b/codebase_rag/tests/test_java_anon_method_caller_qn.py
@@ -1,0 +1,47 @@
+# (H) A method-body anonymous-class method (`make(){ return new Reader(){ read(){
+# (H) helper(); } }; }`) was registered by the definition pass as `Class.read` (the
+# (H) unified-FQN scope walk dropped the enclosing method `make`), but the call pass
+# (H) attributes its outgoing calls to `Class.make.read` -- a phantom qn with no node.
+# (H) So every edge FROM such a method dangled and its callees looked dead. The two
+# (H) passes must agree on the qn (both `Class.make.read`).
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.conftest import create_and_run_updater, get_relationships
+
+
+def test_anon_method_call_edge_joins_a_real_node(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    root = temp_repo / "jfqn"
+    pkg = root / "com" / "example"
+    pkg.mkdir(parents=True)
+    (pkg / "M.java").write_text(
+        "package com.example;\n"
+        "public class M {\n"
+        "  interface Reader { int read(); }\n"
+        "  static int helper(int x) { return x; }\n"
+        "  static Reader make() {\n"
+        "    return new Reader() {\n"
+        "      @Override public int read() { return helper(1); }\n"
+        "    };\n"
+        "  }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    updater = create_and_run_updater(root, mock_ingestor, skip_if_missing="java")
+    registry = updater.factory.function_registry
+    calls = get_relationships(mock_ingestor, "CALLS")
+    # (H) the CALLS edge into helper must originate from a qn that is a registered
+    # (H) node -- not a phantom `Class.make.read` that no node carries.
+    helper_callers = [
+        c.args[0][2] for c in calls if c.args[2][2].endswith(".helper(int)")
+    ]
+    assert helper_callers, "no caller recorded for helper"
+    for caller_qn in helper_callers:
+        assert caller_qn in registry, (
+            f"caller {caller_qn} is a phantom (no node); "
+            f"def-pass and call-pass disagree on the anon method qn"
+        )

--- a/codebase_rag/tests/test_java_anon_method_caller_qn.py
+++ b/codebase_rag/tests/test_java_anon_method_caller_qn.py
@@ -45,3 +45,43 @@ def test_anon_method_call_edge_joins_a_real_node(
             f"caller {caller_qn} is a phantom (no node); "
             f"def-pass and call-pass disagree on the anon method qn"
         )
+
+
+def test_anon_override_unqualified_call_binds_to_base(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) An unqualified call inside a method-body anonymous override targets the anon's
+    # (H) own/inherited method, not the enclosing named class. `helper()` inside
+    # (H) `new Base(){ read(){ return helper(); } }` must resolve to Base.helper (the
+    # (H) anon's inherited method), not drop or bind to an outer class.
+    root = temp_repo / "janonbase"
+    pkg = root / "com" / "example"
+    pkg.mkdir(parents=True)
+    # (H) M also declares helper() as a decoy: without anon-base scoping the call would
+    # (H) mis-bind to the enclosing M.helper via lexical-class resolution.
+    (pkg / "M.java").write_text(
+        "package com.example;\n"
+        "class Base {\n"
+        "  int helper() { return 1; }\n"
+        "  int read() { return 0; }\n"
+        "}\n"
+        "public class M {\n"
+        "  int helper() { return 99; }\n"
+        "  Base make() {\n"
+        "    return new Base() {\n"
+        "      @Override int read() { return helper(); }\n"
+        "    };\n"
+        "  }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="java")
+    calls = {
+        (c.args[0][2], c.args[2][2]) for c in get_relationships(mock_ingestor, "CALLS")
+    }
+    assert any(
+        f.endswith(".read") and t.endswith(".Base.helper()") for f, t in calls
+    ), sorted(t for f, t in calls if "helper" in t)
+    assert not any(
+        f.endswith(".read") and t.endswith(".M.helper()") for f, t in calls
+    ), "anon override call wrongly bound to the enclosing class's decoy helper"

--- a/codebase_rag/tests/test_java_anonymous_override_reachable.py
+++ b/codebase_rag/tests/test_java_anonymous_override_reachable.py
@@ -1,0 +1,46 @@
+# (H) A Java anonymous class (`new Base(){ @Override m(){} }`) is not modelled as a
+# (H) subclass, so its override methods register under the enclosing class with no
+# (H) OVERRIDES edge and look dead even though the base method is called and dispatch
+# (H) can land on them (gson's JavaTimeTypeAdapters `create`/`integerValues`). Recording
+# (H) the anon override and emitting OVERRIDES to the base, plus override-reachability,
+# (H) keeps them live when the base is reachable.
+from __future__ import annotations
+
+from pathlib import Path
+
+from evals.dead_code import cgr_dead_code, default_dead_code_config
+
+
+def _project(tmp_path: Path, files: dict[str, str]) -> Path:
+    root = tmp_path / "janon"
+    pkg = root / "com" / "example"
+    pkg.mkdir(parents=True)
+    for name, body in files.items():
+        (pkg / name).write_text(f"package com.example;\n{body}\n", encoding="utf-8")
+    return root
+
+
+def test_anonymous_override_of_called_base_is_not_dead(tmp_path: Path) -> None:
+    root = _project(
+        tmp_path,
+        {
+            "Base.java": (
+                "public abstract class Base {\n"
+                "  public abstract int make(int[] v);\n"
+                "  public int run(int[] v) { return make(v); }\n"
+                "}\n"
+            ),
+            "Holder.java": (
+                "public class Holder {\n"
+                "  public static final Base B = new Base() {\n"
+                "    @Override public int make(int[] v) { return v[0]; }\n"
+                "  };\n"
+                "}\n"
+            ),
+        },
+    )
+    dead = cgr_dead_code(root, "proj", default_dead_code_config(False, False))
+    # (H) run() is public (root) and calls make() -> Base.make live; the anonymous
+    # (H) override in Holder overrides Base.make, so it is a live dispatch target.
+    anon_override = [d for d in dead if d.endswith(".make(int[])") and ".Holder" in d]
+    assert not anon_override, f"anon override reported dead: {sorted(dead)}"

--- a/codebase_rag/tests/test_java_anonymous_override_reachable.py
+++ b/codebase_rag/tests/test_java_anonymous_override_reachable.py
@@ -44,3 +44,50 @@ def test_anonymous_override_of_called_base_is_not_dead(tmp_path: Path) -> None:
     # (H) override in Holder overrides Base.make, so it is a live dispatch target.
     anon_override = [d for d in dead if d.endswith(".make(int[])") and ".Holder" in d]
     assert not anon_override, f"anon override reported dead: {sorted(dead)}"
+
+
+def test_anon_override_edge_source_label_matches_node(tmp_path: Path) -> None:
+    # (H) A method-body anonymous override is registered as a Function node; the OVERRIDES
+    # (H) edge from it must carry the Function label (not a hard-coded Method), else the
+    # (H) graph endpoint match fails and the edge is dropped in the production DB.
+    from unittest.mock import MagicMock
+
+    from codebase_rag.graph_updater import GraphUpdater
+    from codebase_rag.parser_loader import load_parsers
+
+    root = _project(
+        tmp_path,
+        {
+            "M.java": (
+                "public class M {\n"
+                "  interface Reader { int read(); }\n"
+                "  static Reader make() {\n"
+                "    return new Reader() {\n"
+                "      @Override public int read() { return 1; }\n"
+                "    };\n"
+                "  }\n"
+                "}\n"
+            )
+        },
+    )
+    parsers, queries = load_parsers()
+    if "java" not in parsers:
+        import pytest
+
+        pytest.skip("java parser not available")
+    ing = MagicMock()
+    GraphUpdater(ingestor=ing, repo_path=root, parsers=parsers, queries=queries).run()
+    # (H) node label per qn
+    label_of = {
+        c.args[1].get("qualified_name"): c.args[0]
+        for c in ing.ensure_node_batch.call_args_list
+    }
+    for c in ing.ensure_relationship_batch.call_args_list:
+        if c.args[1] != "OVERRIDES":
+            continue
+        src_label, _, src_qn = c.args[0]
+        if src_qn in label_of:
+            assert src_label == label_of[src_qn], (
+                f"OVERRIDES source label {src_label} != node label "
+                f"{label_of[src_qn]} for {src_qn}"
+            )

--- a/codebase_rag/tests/test_java_generic_override_match.py
+++ b/codebase_rag/tests/test_java_generic_override_match.py
@@ -1,0 +1,43 @@
+# (H) Java override detection matched the full method signature including generic
+# (H) type-variable NAMES, so a subclass that renames a type parameter
+# (H) (`Adapter<T,A>` base declares `readField(A,...)`, `FieldReflectionAdapter<T> extends
+# (H) Adapter<T,T>` declares `readField(T,...)`) produced no OVERRIDES edge and its
+# (H) override looked dead. Overriding is by name + arity regardless of type-var names.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.conftest import create_and_run_updater, get_relationships
+
+
+def _edges(mock_ingestor: MagicMock, rel: str) -> set[tuple[str, str]]:
+    return {(c.args[0][2], c.args[2][2]) for c in get_relationships(mock_ingestor, rel)}
+
+
+def test_generic_type_var_rename_still_overrides(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    root = temp_repo / "jgen"
+    pkg = root / "com" / "example"
+    pkg.mkdir(parents=True)
+    (pkg / "M.java").write_text(
+        "package com.example;\n"
+        "public class M {\n"
+        "  abstract static class Base<T, A> {\n"
+        "    abstract A readField(A acc, int in);\n"
+        "  }\n"
+        "  static final class Impl<T> extends Base<T, T> {\n"
+        "    @Override T readField(T acc, int in) { return acc; }\n"
+        "  }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="java")
+    overrides = _edges(mock_ingestor, "OVERRIDES")
+    # (H) Impl.readField(T,int) overrides Base.readField(A,int) despite the type-var
+    # (H) rename (A -> T); matched by name + arity.
+    assert any(
+        f.endswith(".Impl.readField(T,int)") and t.endswith(".Base.readField(A,int)")
+        for f, t in overrides
+    ), overrides

--- a/codebase_rag/tests/test_java_nested_superclass_resolution.py
+++ b/codebase_rag/tests/test_java_nested_superclass_resolution.py
@@ -1,0 +1,53 @@
+# (H) When several files each declare a same-named nested class (gson has
+# (H) CollectionTypeAdapterFactory.Adapter, MapTypeAdapterFactory.Adapter,
+# (H) ReflectiveTypeAdapterFactory.Adapter), a subclass `class Sub extends Adapter`
+# (H) must inherit from the Adapter nested in ITS OWN file, not a same-named one in
+# (H) another file that merely sorts first. A wrong INHERITS sends the method-override
+# (H) edges to the wrong base, so the subclass overrides look dead.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.conftest import create_and_run_updater, get_relationships
+
+
+def _edges(mock_ingestor: MagicMock, rel: str) -> set[tuple[str, str]]:
+    return {(c.args[0][2], c.args[2][2]) for c in get_relationships(mock_ingestor, rel)}
+
+
+def test_nested_superclass_prefers_same_file(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    root = temp_repo / "jsup"
+    pkg = root / "com" / "example"
+    pkg.mkdir(parents=True)
+    # (H) Two files each declare a nested `Adapter`. The subclass in Reflective.java
+    # (H) must inherit from Reflective's Adapter, not Collection's (which sorts first).
+    (pkg / "Collection.java").write_text(
+        "package com.example;\n"
+        "public class Collection {\n"
+        "  abstract static class Adapter { abstract int make(); }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    (pkg / "Reflective.java").write_text(
+        "package com.example;\n"
+        "public class Reflective {\n"
+        "  abstract static class Adapter { abstract int make(); }\n"
+        "  static final class Sub extends Adapter {\n"
+        "    @Override int make() { return 1; }\n"
+        "  }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="java")
+    inherits = _edges(mock_ingestor, "INHERITS")
+    assert any(
+        f.endswith(".Reflective.Sub") and t.endswith(".Reflective.Adapter")
+        for f, t in inherits
+    ), inherits
+    assert not any(
+        f.endswith(".Reflective.Sub") and t.endswith(".Collection.Adapter")
+        for f, t in inherits
+    ), "Sub wrongly inherited the other file's Adapter"

--- a/codebase_rag/tests/test_java_overload_resolution.py
+++ b/codebase_rag/tests/test_java_overload_resolution.py
@@ -47,3 +47,36 @@ def test_call_binds_to_arity_matching_overload(
         and t.endswith(".M.resolve(int,int,int,HashMap<Integer, Integer>)")
         for f, t in calls
     ), sorted(t for f, t in calls if "resolve" in t)
+
+
+def test_inherited_overload_binds_to_arity_match(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) Overloads declared on a BASE class, called through a subclass receiver: the
+    # (H) inherited-method lookup must also pick the arity-matching overload, not the
+    # (H) first same-named one (a 2-arg call must reach resolve(int,int), not
+    # (H) resolve(int)).
+    root = temp_repo / "jovl2"
+    pkg = root / "com" / "example"
+    pkg.mkdir(parents=True)
+    (pkg / "M.java").write_text(
+        "package com.example;\n"
+        "class Base {\n"
+        "  int resolve(int a) { return a; }\n"
+        "  int resolve(int a, int b) { return a + b; }\n"
+        "}\n"
+        "class Sub extends Base {}\n"
+        "public class M {\n"
+        "  int use(Sub s) { return s.resolve(1, 2); }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="java")
+    calls = _calls(mock_ingestor)
+    assert any(
+        f.endswith(".M.use(Sub)") and t.endswith(".Base.resolve(int,int)")
+        for f, t in calls
+    ), sorted(t for f, t in calls if "resolve" in t)
+    assert not any(
+        f.endswith(".M.use(Sub)") and t.endswith(".Base.resolve(int)") for f, t in calls
+    ), "2-arg call wrongly bound to the 1-arg inherited overload"

--- a/codebase_rag/tests/test_java_overload_resolution.py
+++ b/codebase_rag/tests/test_java_overload_resolution.py
@@ -1,0 +1,49 @@
+# (H) The Java resolver matched a call to a method by NAME only ("any signature"),
+# (H) returning the first overload, so a same-named overload with a different arity got
+# (H) no CALLS edge and looked dead (gson's recursive `GsonTypes.resolve` 3-arg public
+# (H) vs 4-arg private, `TypeToken.isAssignableFrom` overloads). A call must bind to the
+# (H) overload whose parameter count matches the call's argument count.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.conftest import create_and_run_updater, get_relationships
+
+
+def _calls(mock_ingestor: MagicMock) -> set[tuple[str, str]]:
+    return {
+        (c.args[0][2], c.args[2][2]) for c in get_relationships(mock_ingestor, "CALLS")
+    }
+
+
+def test_call_binds_to_arity_matching_overload(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    root = temp_repo / "jovl"
+    pkg = root / "com" / "example"
+    pkg.mkdir(parents=True)
+    # (H) resolve(a,b,c) is public API; it calls the 4-arg overload resolve(a,b,c,m).
+    # (H) Both must be reachable -- the 4-arg call must bind to the 4-arg overload, not
+    # (H) the 3-arg one that merely shares the name.
+    (pkg / "M.java").write_text(
+        "package com.example;\n"
+        "import java.util.HashMap;\n"
+        "public class M {\n"
+        "  public static int resolve(int a, int b, int c) {\n"
+        "    return resolve(a, b, c, new HashMap<Integer, Integer>());\n"
+        "  }\n"
+        "  private static int resolve(int a, int b, int c, HashMap<Integer, Integer> m) {\n"
+        "    return a + b + c;\n"
+        "  }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="java")
+    calls = _calls(mock_ingestor)
+    # (H) the 3-arg resolve calls the 4-arg overload (arity 4 matches the 4-arg call).
+    assert any(
+        f.endswith(".M.resolve(int,int,int)")
+        and t.endswith(".M.resolve(int,int,int,HashMap<Integer, Integer>)")
+        for f, t in calls
+    ), sorted(t for f, t in calls if "resolve" in t)

--- a/codebase_rag/tests/test_java_static_nested_receiver.py
+++ b/codebase_rag/tests/test_java_static_nested_receiver.py
@@ -1,0 +1,45 @@
+# (H) A static-field access on a nested class used as a call receiver
+# (H) (`AccessChecker.INSTANCE.canAccess(...)`, gson's ReflectionAccessFilterHelper) did
+# (H) not resolve: the field-access chain's base (`AccessChecker`, a nested class
+# (H) referenced by simple name) was only tried as `module.AccessChecker`, never the
+# (H) nested `module.Outer.AccessChecker`, so the whole call dropped and the method
+# (H) looked dead.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.conftest import create_and_run_updater, get_relationships
+
+
+def _calls(mock_ingestor: MagicMock) -> set[tuple[str, str]]:
+    return {
+        (c.args[0][2], c.args[2][2]) for c in get_relationships(mock_ingestor, "CALLS")
+    }
+
+
+def test_static_nested_field_receiver_resolves(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    root = temp_repo / "jstat"
+    pkg = root / "com" / "example"
+    pkg.mkdir(parents=True)
+    (pkg / "M.java").write_text(
+        "package com.example;\n"
+        "public class M {\n"
+        "  public static boolean check(Object o) {\n"
+        "    return Checker.INSTANCE.canAccess(o);\n"
+        "  }\n"
+        "  static class Checker {\n"
+        "    static final Checker INSTANCE = new Checker();\n"
+        "    boolean canAccess(Object o) { return true; }\n"
+        "  }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="java")
+    calls = _calls(mock_ingestor)
+    assert any(
+        f.endswith(".M.check(Object)") and t.endswith(".Checker.canAccess(Object)")
+        for f, t in calls
+    ), sorted(t for f, t in calls if "canAccess" in t)

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -682,7 +682,9 @@ RELATIONSHIP_SCHEMAS: tuple[RelationshipSchema, ...] = (
         (NodeLabel.INTERFACE,),
     ),
     RelationshipSchema(
-        (NodeLabel.METHOD,),
+        # (H) A method-body anonymous-class override is registered as a Function node,
+        # (H) so it can be the source of an OVERRIDES edge onto the base Method.
+        (NodeLabel.METHOD, NodeLabel.FUNCTION),
         RelationshipType.OVERRIDES,
         (NodeLabel.METHOD,),
     ),

--- a/evals/dead_code.py
+++ b/evals/dead_code.py
@@ -36,6 +36,7 @@ _INSTANTIATES = cs.RelationshipType.INSTANTIATES.value
 _INHERITS = cs.RelationshipType.INHERITS.value
 _DEFINES = cs.RelationshipType.DEFINES.value
 _DEFINES_METHOD = cs.RelationshipType.DEFINES_METHOD.value
+_OVERRIDES = cs.RelationshipType.OVERRIDES.value
 _EMPTY_LOCATION = LocationStats(0, 0, 0, 0.0, 0)
 
 _NodeId = tuple[str, PropertyValue]
@@ -257,6 +258,14 @@ def dead_code_from_graph(
     for from_label, from_val, rel_type, _to_label, to_val in rels:
         if rel_type in traversal:
             adjacency[str(from_val)].add(str(to_val))
+        elif rel_type == _OVERRIDES:
+            # (H) OVERRIDES is recorded overrider -> overridden. A call to the base
+            # (H) method dispatches at runtime to any override, so an override of a
+            # (H) REACHABLE method is itself reachable. Add the REVERSE edge
+            # (H) (overridden -> overrider) so the walk reaches every override -- and
+            # (H) transitively its callees -- of any live base; an override of a dead
+            # (H) base stays dead. Sound virtual dispatch, mirroring self-dispatch.
+            adjacency[str(to_val)].add(str(from_val))
 
     live = set(roots)
     _walk(roots, adjacency, live)

--- a/evals/dead_code.py
+++ b/evals/dead_code.py
@@ -255,17 +255,14 @@ def dead_code_from_graph(
             roots.add(qn)
 
     adjacency: dict[str, set[str]] = defaultdict(set)
+    # (H) OVERRIDES is recorded overrider -> overridden; keep the REVERSE mapping
+    # (H) (overridden -> overriders) to expand virtual-dispatch targets below.
+    override_rev: dict[str, set[str]] = defaultdict(set)
     for from_label, from_val, rel_type, _to_label, to_val in rels:
         if rel_type in traversal:
             adjacency[str(from_val)].add(str(to_val))
         elif rel_type == _OVERRIDES:
-            # (H) OVERRIDES is recorded overrider -> overridden. A call to the base
-            # (H) method dispatches at runtime to any override, so an override of a
-            # (H) REACHABLE method is itself reachable. Add the REVERSE edge
-            # (H) (overridden -> overrider) so the walk reaches every override -- and
-            # (H) transitively its callees -- of any live base; an override of a dead
-            # (H) base stays dead. Sound virtual dispatch, mirroring self-dispatch.
-            adjacency[str(to_val)].add(str(from_val))
+            override_rev[str(to_val)].add(str(from_val))
 
     live = set(roots)
     _walk(roots, adjacency, live)
@@ -285,6 +282,22 @@ def dead_code_from_graph(
     }
     live |= closure_roots
     _walk(closure_roots, adjacency, live)
+
+    # (H) Third expansion, mirroring the query's OVERRIDES* stage: a call to a base or
+    # (H) interface method dispatches at runtime to any override, so every (transitive)
+    # (H) override of a LIVE method is a reachable dispatch target, as is its callee
+    # (H) closure. `override_rev` is walked to a fixpoint so multi-level hierarchies
+    # (H) (Base <- Sub <- SubSub) are all revived; an override of a DEAD base stays
+    # (H) dead. Bounded like the closure round: one callee-walk after the expansion.
+    override_roots: set[str] = set()
+    stack = list(live)
+    while stack:
+        for overrider in override_rev.get(stack.pop(), ()):
+            if overrider not in live and overrider not in override_roots:
+                override_roots.add(overrider)
+                stack.append(overrider)
+    live |= override_roots
+    _walk(override_roots, adjacency, live)
 
     dead = candidates - live
     # (H) Suppress generated files (openapi-ts client/core, routeTree.gen.ts) from

--- a/evals/dead_code.py
+++ b/evals/dead_code.py
@@ -37,6 +37,11 @@ _INHERITS = cs.RelationshipType.INHERITS.value
 _DEFINES = cs.RelationshipType.DEFINES.value
 _DEFINES_METHOD = cs.RelationshipType.DEFINES_METHOD.value
 _OVERRIDES = cs.RelationshipType.OVERRIDES.value
+# (H) Rounds of override-reachability expansion; must equal the number of OVERRIDES
+# (H) stages the Cypher dead-code query emits so eval and query agree. Covers depth-N
+# (H) override/callee interleaving (a base revived via an override's callee, whose own
+# (H) overrides then need reviving).
+_OVERRIDE_EXPANSION_ROUNDS = 3
 _EMPTY_LOCATION = LocationStats(0, 0, 0, 0.0, 0)
 
 _NodeId = tuple[str, PropertyValue]
@@ -283,21 +288,28 @@ def dead_code_from_graph(
     live |= closure_roots
     _walk(closure_roots, adjacency, live)
 
-    # (H) Third expansion, mirroring the query's OVERRIDES* stage: a call to a base or
-    # (H) interface method dispatches at runtime to any override, so every (transitive)
-    # (H) override of a LIVE method is a reachable dispatch target, as is its callee
-    # (H) closure. `override_rev` is walked to a fixpoint so multi-level hierarchies
-    # (H) (Base <- Sub <- SubSub) are all revived; an override of a DEAD base stays
-    # (H) dead. Bounded like the closure round: one callee-walk after the expansion.
-    override_roots: set[str] = set()
-    stack = list(live)
-    while stack:
-        for overrider in override_rev.get(stack.pop(), ()):
-            if overrider not in live and overrider not in override_roots:
-                override_roots.add(overrider)
-                stack.append(overrider)
-    live |= override_roots
-    _walk(override_roots, adjacency, live)
+    # (H) Override expansion, mirroring the query's OVERRIDES* stage: a call to a base
+    # (H) or interface method dispatches at runtime to any override, so every
+    # (H) (transitive) override of a LIVE method is a reachable dispatch target, as is
+    # (H) its callee closure. `override_rev` walks all multi-level overriders
+    # (H) (Base<-Sub<-SubSub); an override of a DEAD base stays dead. Run several rounds
+    # (H) because a base can go live only via a revived override's CALLEE (depth-2+
+    # (H) interleaving: FieldReflectionAdapter.readField -> BoundField.readIntoField ->
+    # (H) its anon overrides); one pass would miss those. `_OVERRIDE_EXPANSION_ROUNDS`
+    # (H) matches the number of OVERRIDES stages the Cypher query emits, so the offline
+    # (H) eval and the production query agree; a round that adds nothing is a no-op.
+    for _ in range(_OVERRIDE_EXPANSION_ROUNDS):
+        override_roots: set[str] = set()
+        stack = list(live)
+        while stack:
+            for overrider in override_rev.get(stack.pop(), ()):
+                if overrider not in live and overrider not in override_roots:
+                    override_roots.add(overrider)
+                    stack.append(overrider)
+        if not override_roots:
+            break
+        live |= override_roots
+        _walk(override_roots, adjacency, live)
 
     dead = candidates - live
     # (H) Suppress generated files (openapi-ts client/core, routeTree.gen.ts) from

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.256"
+version = "0.0.258"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Stacked on #661. Bug 1 from dogfooding google/gson: Java anonymous-class override dispatch. Clears the JavaTimeTypeAdapters cluster (gson 67 -> 49).

## Two composing bugs behind the cluster

`new IntegerFieldsTypeAdapter<T>(...){ @Override create(); integerValues(); }` — 8 anonymous adapters whose overrides looked dead.

**1. Anonymous-class methods had no OVERRIDES edge.** An anonymous class is not modelled as a subclass, so its override methods register under the enclosing class with no link to the base. Fix: `ingest_method` now returns the registered qn; `_ingest_class_methods` detects a method inside an anonymous `class_body` and records `(anon_method_qn, name, base_type, module_qn)`; a deferred pass (after all types are registered) resolves the base type by unique global simple-name match and emits an `OVERRIDES` edge to each matching base method. With #661's override-reachability, the override is live when the base is.

**2. Unqualified calls ignored lexical scope.** `create(values)` inside `IntegerFieldsTypeAdapter.read` (i.e. `this.create()`) resolved to the *outer* class's same-named `create` via a module-wide name scan, so the base's own abstract `create` never got the edge and stayed dead. Fix: an unqualified call resolves against the ENCLOSING class hierarchy (own + inherited + interface, via `_lexical_class_qn`) before the module-wide fallback.

Both are revive-only / precision-improving (an ambiguous base or a genuinely dead base leaves the override dead).

## Tests

`test_java_anonymous_override_reachable.py`: an anonymous override of a called base method is not reported dead.

Verified: gson core 67 -> 49 (JavaTime/IntegerFields cluster 19 -> 1), full suite green (4441 passed), Java suite 527 passed, no cross-language regression.
