### PR TITLE
fix(cpp): eliminate remaining dangling edges via pass-2 location reuse and deferred INHERITS resolution

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -1305,7 +1305,7 @@ CYPHER_ALL_DEFINITION_QNS = (
     "MATCH (n) WHERE n:Function OR n:Method OR n:Class OR n:Interface "
     "OR n:Enum OR n:Type OR n:Union "
     "RETURN n.qualified_name AS qualified_name, head(labels(n)) AS label, "
-    "n.is_property AS is_property"
+    "n.is_property AS is_property, n.path AS path"
 )
 
 # (H) Inbound reference edges (from unchanged files) into symbols defined in one

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -628,6 +628,11 @@ class GraphUpdater:
             # (H) @property defined elsewhere would otherwise drop vs a clean index.
             if row.get(cs.KEY_IS_PROPERTY):
                 self.function_registry.mark_property(qn)
+            # (H) Record the defining file so _is_cpp_defined can language-check
+            # (H) rehydrated candidates (deferred C++ INHERITS resolution runs
+            # (H) after this and must reach bases in UNCHANGED headers).
+            if isinstance(path := row.get(cs.KEY_PATH), str):
+                self.factory.definition_processor.rehydrated_definition_paths[qn] = path
             added += 1
         if added:
             logger.info(ls.REGISTRY_REHYDRATED, count=added)

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -575,6 +575,12 @@ class GraphUpdater:
                 kept_forwards,
             )
 
+        # (H) After forward declarations so a base whose only representation is
+        # (H) a kept forward declaration still resolves to a real node.
+        inherits = self.factory.definition_processor.resolve_deferred_cpp_inherits()
+        if inherits:
+            logger.info("Resolved {} deferred C++ inheritance bases", inherits)
+
         # (H) Last containment step: every node-registering pass above (deferred
         # (H) C++ methods, Go receivers, kept forward declarations) must finish
         # (H) before parent qns are verified against the registry.

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -942,9 +942,7 @@ class CallProcessor:
     ) -> CppFunctionLocation | None:
         # (H) The registry membership check guards incremental runs, where an
         # (H) unchanged file's locations were not re-recorded this run.
-        loc = self.cpp_function_locations.get(
-            (module_qn, func_node.start_point[0] + 1)
-        )
+        loc = self.cpp_function_locations.get((module_qn, func_node.start_point[0] + 1))
         if loc is not None and loc.qualified_name in self._resolver.function_registry:
             return loc
         return None

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -13,7 +13,11 @@ from .. import logs as ls
 from ..language_spec import LanguageSpec
 from ..parser_loader import COMBINED_FUNC_CLASS_QUERIES
 from ..services import IngestorProtocol
-from ..types_defs import FunctionRegistryTrieProtocol, LanguageQueries
+from ..types_defs import (
+    CppFunctionLocation,
+    FunctionRegistryTrieProtocol,
+    LanguageQueries,
+)
 from ..utils.path_utils import cached_relative_path
 from .call_resolver import CallResolver
 from .class_ingest.identity import build_nested_qualified_name_for_class
@@ -158,6 +162,7 @@ class CallProcessor:
         "module_qn_to_file_path",
         "_path_to_module_qn",
         "cpp_out_of_class_methods",
+        "cpp_function_locations",
         "_resolver",
         "_flow_param_names",
         "_flow_args",
@@ -178,6 +183,8 @@ class CallProcessor:
         interface_implementers: dict[str, set[str]] | None = None,
         module_qn_to_file_path: dict[str, Path] | None = None,
         cpp_out_of_class_methods: dict[tuple[str, int], tuple[str, str]] | None = None,
+        cpp_function_locations: dict[tuple[str, int], CppFunctionLocation]
+        | None = None,
     ) -> None:
         self.ingestor = ingestor
         self.repo_path = repo_path
@@ -185,6 +192,7 @@ class CallProcessor:
         self.module_qn_to_file_path = module_qn_to_file_path or {}
         self._path_to_module_qn: dict[Path, str] | None = None
         self.cpp_out_of_class_methods = cpp_out_of_class_methods or {}
+        self.cpp_function_locations = cpp_function_locations or {}
 
         self._resolver = CallResolver(
             function_registry=function_registry,
@@ -794,6 +802,30 @@ class CallProcessor:
                 )
             if not func_name:
                 continue
+            # (H) The definition pass records where every C++ function/method node
+            # (H) landed; reuse that qn/label instead of re-deriving them from the
+            # (H) AST -- the two walks diverge on preprocessor-distorted class
+            # (H) bodies and every divergence is a phantom caller (issue #652).
+            if language == cs.SupportedLanguage.CPP and (
+                loc := self._cpp_recorded_caller(func_node, module_qn)
+            ):
+                filtered = (
+                    self._filter_calls_in_node(all_call_nodes, call_starts, func_node)
+                    if all_call_nodes is not None and call_starts is not None
+                    else None
+                )
+                self._ingest_function_calls(
+                    func_node,
+                    loc.qualified_name,
+                    loc.label,
+                    module_qn,
+                    language,
+                    queries,
+                    loc.container_qn,
+                    call_nodes=filtered,
+                    call_name_cache=call_name_cache,
+                )
+                continue
             # (H) An out-of-line C++ method definition (`Ret Class::method() {...}`
             # (H) at namespace/file scope) is bound by the definition pass to its
             # (H) class node (qn `class_qn.method`). Attribute its body's calls to
@@ -905,6 +937,18 @@ class CallProcessor:
             return caller_qn, container_qn
         return None
 
+    def _cpp_recorded_caller(
+        self, func_node: Node, module_qn: str
+    ) -> CppFunctionLocation | None:
+        # (H) The registry membership check guards incremental runs, where an
+        # (H) unchanged file's locations were not re-recorded this run.
+        loc = self.cpp_function_locations.get(
+            (module_qn, func_node.start_point[0] + 1)
+        )
+        if loc is not None and loc.qualified_name in self._resolver.function_registry:
+            return loc
+        return None
+
     def _cpp_out_of_class_method_caller(
         self, func_node: Node, method_name: str, module_qn: str
     ) -> tuple[str, str] | None:
@@ -1008,9 +1052,19 @@ class CallProcessor:
             # (H) qn through the enclosing-function chain (Class.method.nested, not
             # (H) the method-dropping Class.nested) and label a nested function
             # (H) FUNCTION, so the CALLS edge joins the real node.
-            caller_qn, caller_label = self._class_member_qn_and_label(
-                method_node, class_qn, method_name, lang_config, language
-            )
+            class_context = class_qn
+            if language == cs.SupportedLanguage.CPP and (
+                loc := self._cpp_recorded_caller(method_node, module_qn)
+            ):
+                # (H) Reuse the definition pass's recorded qn/label; the class
+                # (H) walk's structural derivation diverges from it on
+                # (H) preprocessor-distorted class bodies (issue #652).
+                caller_qn, caller_label = loc.qualified_name, loc.label
+                class_context = loc.container_qn or class_qn
+            else:
+                caller_qn, caller_label = self._class_member_qn_and_label(
+                    method_node, class_qn, method_name, lang_config, language
+                )
             filtered = (
                 self._calls_owned_by(
                     method_node, owned_func_nodes, all_call_nodes, call_starts
@@ -1025,7 +1079,7 @@ class CallProcessor:
                 module_qn,
                 language,
                 queries,
-                class_qn,
+                class_context,
                 call_nodes=filtered,
                 call_name_cache=call_name_cache,
             )

--- a/codebase_rag/parsers/class_ingest/method_override.py
+++ b/codebase_rag/parsers/class_ingest/method_override.py
@@ -59,7 +59,11 @@ def check_method_overrides(
         if current_class != class_qn:
             parent_method_qn = f"{current_class}.{method_name}"
 
-            if parent_method_qn in function_registry:
+            # (H) The parent member must BE a method: a ctor of a nested class
+            # (H) that inherits its encloser (node::inner_node : node) shares
+            # (H) its name with the nested CLASS registered at parent.name, and
+            # (H) an OVERRIDES onto that class qn is a label-mismatched phantom.
+            if function_registry.get(parent_method_qn) == NodeType.METHOD:
                 ingestor.ensure_relationship_batch(
                     (cs.NodeLabel.METHOD, cs.KEY_QUALIFIED_NAME, method_qn),
                     cs.RelationshipType.OVERRIDES,

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -325,7 +325,13 @@ class ClassIngestMixin:
             )
             if resolved:
                 return parent_qn
-        if self.function_registry.get(entry.guess_qn) is not None:
+        # (H) The guess strips a qualified base (`other::Type`) to its leaf, so
+        # (H) it can collide with the CHILD's own qn when the base is
+        # (H) unresolvable; a self-INHERITS is never real.
+        if (
+            entry.guess_qn != entry.child_qn
+            and self.function_registry.get(entry.guess_qn) is not None
+        ):
             return entry.guess_qn
         return None
 

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -12,7 +12,12 @@ from ... import constants as cs
 from ... import logs
 from ...config import settings
 from ...language_spec import LanguageSpec
-from ...types_defs import ASTNode, PropertyDict
+from ...types_defs import (
+    ASTNode,
+    CppFunctionLocation,
+    DeferredCppInherit,
+    PropertyDict,
+)
 from ...utils.path_utils import cached_relative_path, cached_resolve_posix
 from ..cpp import CppTypeInferenceEngine
 from ..cpp import utils as cpp_utils
@@ -111,8 +116,10 @@ class ClassIngestMixin:
     class_field_guard_inner: dict[str, dict[str, str]]
     method_return_types: dict[str, str]
     interface_implementers: dict[str, set[str]]
+    cpp_function_locations: dict[tuple[str, int], CppFunctionLocation]
     _deferred_forward_decls: list[_DeferredForwardDecl]
     _deferred_parent_links: list[DeferredParentLink]
+    _deferred_cpp_inherits: list[DeferredCppInherit]
 
     def _namespace_qn(self, class_qn: str, module_qn: str) -> str:
         # (H) Strip the module-file prefix so two nodes for the same C++ type in
@@ -161,6 +168,11 @@ class ClassIngestMixin:
         lang_config: LanguageSpec,
         language: cs.SupportedLanguage | None = None,
     ) -> tuple[str, str]: ...
+
+    @abstractmethod
+    def _resolve_cpp_class_qn(
+        self, class_name: str, module_qn: str, exclude_qn: str | None = None
+    ) -> tuple[str, bool]: ...
 
     def _resolve_to_qn(self, name: str, module_qn: str) -> str:
         return self._resolve_class_name(name, module_qn) or f"{module_qn}.{name}"
@@ -261,6 +273,61 @@ class ClassIngestMixin:
             )
             registered += 1
         return registered
+
+    def resolve_deferred_cpp_inherits(self) -> int:
+        """Emit C++ INHERITS edges now that every class is registered.
+
+        A base written in another header resolves scope-first across all
+        parsed files (the same lookup out-of-class methods use); a base that
+        resolves nowhere emits no edge, because the module-anchored guess is a
+        phantom endpoint the database silently drops anyway. Resolved qns
+        replace the guesses in class_inheritance in place so Pass-3 method
+        resolution and override detection walk the real hierarchy.
+        """
+        deferred = self._deferred_cpp_inherits
+        if not deferred:
+            return 0
+        self._deferred_cpp_inherits = []
+        emitted = 0
+        for entry in deferred:
+            parent_qn = self._resolve_cpp_base_qn(entry)
+            if parent_qn is None:
+                continue
+            bases = self.class_inheritance.get(entry.child_qn)
+            if bases is not None and entry.base_index < len(bases):
+                bases[entry.base_index] = parent_qn
+            rel.create_inheritance_relationship(
+                entry.child_label,
+                entry.child_qn,
+                parent_qn,
+                self.function_registry,
+                self.ingestor,
+                entry.base_index,
+            )
+            emitted += 1
+        return emitted
+
+    def _resolve_cpp_base_qn(self, entry: DeferredCppInherit) -> str | None:
+        normalized = entry.base_name.replace(
+            cs.SEPARATOR_DOUBLE_COLON, cs.SEPARATOR_DOT
+        )
+        # (H) Scope-first (see resolve_deferred_cpp_methods): the enclosing
+        # (H) namespaces distinguish same-leaf classes. The child itself is
+        # (H) excluded so `class Type : public other::Type` never self-inherits.
+        candidates = [normalized]
+        if entry.namespace_path:
+            candidates.insert(
+                0, f"{entry.namespace_path}{cs.SEPARATOR_DOT}{normalized}"
+            )
+        for candidate in candidates:
+            parent_qn, resolved = self._resolve_cpp_class_qn(
+                candidate, "", exclude_qn=entry.child_qn
+            )
+            if resolved:
+                return parent_qn
+        if self.function_registry.get(entry.guess_qn) is not None:
+            return entry.guess_qn
+        return None
 
     def _process_class_node(
         self,
@@ -415,6 +482,7 @@ class ClassIngestMixin:
             self._resolve_to_qn,
             self.function_registry,
             self.interface_implementers,
+            defer_cpp_inherits=self._deferred_cpp_inherits,
         )
         if language == cs.SupportedLanguage.CPP:
             # (H) Record this class's member-field types now (from the class body,
@@ -448,6 +516,7 @@ class ClassIngestMixin:
             file_path,
             sorted_func_nodes=sorted_func_nodes,
             func_node_starts=func_node_starts,
+            module_qn=module_qn,
         )
 
     def _ingest_rust_impl_methods(
@@ -562,6 +631,7 @@ class ClassIngestMixin:
         file_path: Path | None = None,
         sorted_func_nodes: list[Node] | None = None,
         func_node_starts: list[int] | None = None,
+        module_qn: str | None = None,
     ) -> None:
         body_node = class_node.child_by_field_name("body")
         if not body_node:
@@ -599,7 +669,7 @@ class ClassIngestMixin:
                     )
                     method_qualified_name = f"{class_qn}.{method_name}{param_sig}"
 
-            ingest_method(
+            ingested_qn = ingest_method(
                 method_node,
                 class_qn,
                 cs.NodeLabel.CLASS,
@@ -613,10 +683,21 @@ class ClassIngestMixin:
                 file_path=file_path,
                 repo_path=self.repo_path,
             )
-            # (H) Record a C++ method's return type so a chained call off a static
-            # (H) factory method (`parser(...).parse(...)`, nlohmann's basic_json)
-            # (H) can type the receiver and resolve the next hop.
             if language == cs.SupportedLanguage.CPP:
+                # (H) Record where this method landed so Pass-3 call attribution
+                # (H) reuses the registered qn/label instead of re-deriving them
+                # (H) (the walks diverge on preprocessor-distorted class bodies).
+                if ingested_qn is not None and module_qn is not None:
+                    self.cpp_function_locations[
+                        (module_qn, method_node.start_point[0] + 1)
+                    ] = CppFunctionLocation(
+                        label=cs.NodeLabel.METHOD.value,
+                        qualified_name=ingested_qn,
+                        container_qn=class_qn,
+                    )
+                # (H) Record a C++ method's return type so a chained call off a
+                # (H) static factory method (`parser(...).parse(...)`, nlohmann's
+                # (H) basic_json) can type the receiver and resolve the next hop.
                 method_name = cpp_utils.extract_function_name(method_node)
                 if method_name and (
                     return_type := cpp_utils.extract_return_type_name(method_node)

--- a/codebase_rag/parsers/class_ingest/parent_extraction.py
+++ b/codebase_rag/parsers/class_ingest/parent_extraction.py
@@ -125,7 +125,9 @@ def parse_cpp_base_classes(
 
         if base_child.type in base_type_nodes and base_child.text:
             if parent_name := safe_decode_text(base_child):
-                written_name = parent_name.split(cs.CHAR_ANGLE_OPEN)[0]
+                # (H) strip(): `public Base <T>` would otherwise keep a
+                # (H) trailing space that can never match the registry.
+                written_name = parent_name.split(cs.CHAR_ANGLE_OPEN)[0].strip()
                 base_name = extract_cpp_base_class_name(parent_name)
                 parent_qn = cpp_utils.build_qualified_name(
                     class_node, module_qn, base_name
@@ -147,7 +149,8 @@ def extract_cpp_base_class_name(parent_text: str) -> str:
     if cs.SEPARATOR_DOUBLE_COLON in parent_text:
         parent_text = parent_text.split(cs.SEPARATOR_DOUBLE_COLON)[-1]
 
-    return parent_text
+    # (H) `public Base <T>` leaves a trailing space after the angle split.
+    return parent_text.strip()
 
 
 def java_base_type_identifier(type_node: Node) -> Node | None:

--- a/codebase_rag/parsers/class_ingest/parent_extraction.py
+++ b/codebase_rag/parsers/class_ingest/parent_extraction.py
@@ -90,9 +90,7 @@ def extract_cpp_parent_classes(class_node: Node, module_qn: str) -> list[str]:
     return [guess for _, guess in extract_cpp_parent_bases(class_node, module_qn)]
 
 
-def extract_cpp_parent_bases(
-    class_node: Node, module_qn: str
-) -> list[tuple[str, str]]:
+def extract_cpp_parent_bases(class_node: Node, module_qn: str) -> list[tuple[str, str]]:
     """Return (written base name, parse-time guess qn) per base, in source order.
 
     The written name keeps its ``::`` qualifiers (template arguments stripped)

--- a/codebase_rag/parsers/class_ingest/parent_extraction.py
+++ b/codebase_rag/parsers/class_ingest/parent_extraction.py
@@ -87,17 +87,29 @@ def extract_parent_classes(
 
 
 def extract_cpp_parent_classes(class_node: Node, module_qn: str) -> list[str]:
-    parent_classes: list[str] = []
+    return [guess for _, guess in extract_cpp_parent_bases(class_node, module_qn)]
+
+
+def extract_cpp_parent_bases(
+    class_node: Node, module_qn: str
+) -> list[tuple[str, str]]:
+    """Return (written base name, parse-time guess qn) per base, in source order.
+
+    The written name keeps its ``::`` qualifiers (template arguments stripped)
+    so deferred resolution can scope-match it across files; the guess anchors
+    the base to the class's own module and only holds for same-file bases.
+    """
+    bases: list[tuple[str, str]] = []
     for child in class_node.children:
         if child.type == cs.TS_BASE_CLASS_CLAUSE:
-            parent_classes.extend(parse_cpp_base_classes(child, class_node, module_qn))
-    return parent_classes
+            bases.extend(parse_cpp_base_classes(child, class_node, module_qn))
+    return bases
 
 
 def parse_cpp_base_classes(
     base_clause_node: Node, class_node: Node, module_qn: str
-) -> list[str]:
-    parent_classes: list[str] = []
+) -> list[tuple[str, str]]:
+    bases: list[tuple[str, str]] = []
     base_type_nodes = (
         cs.TS_TYPE_IDENTIFIER,
         cs.CppNodeType.QUALIFIED_IDENTIFIER,
@@ -115,18 +127,19 @@ def parse_cpp_base_classes(
 
         if base_child.type in base_type_nodes and base_child.text:
             if parent_name := safe_decode_text(base_child):
+                written_name = parent_name.split(cs.CHAR_ANGLE_OPEN)[0]
                 base_name = extract_cpp_base_class_name(parent_name)
                 parent_qn = cpp_utils.build_qualified_name(
                     class_node, module_qn, base_name
                 )
-                parent_classes.append(parent_qn)
+                bases.append((written_name, parent_qn))
                 logger.debug(
                     logs.CLASS_CPP_INHERITANCE,
                     parent_name=parent_name,
                     parent_qn=parent_qn,
                 )
 
-    return parent_classes
+    return bases
 
 
 def extract_cpp_base_class_name(parent_text: str) -> str:

--- a/codebase_rag/parsers/class_ingest/relationships.py
+++ b/codebase_rag/parsers/class_ingest/relationships.py
@@ -6,7 +6,8 @@ from typing import TYPE_CHECKING
 from tree_sitter import Node
 
 from ... import constants as cs
-from ...types_defs import NodeType
+from ...types_defs import DeferredCppInherit, NodeType
+from ..cpp import utils as cpp_utils
 from . import parent_extraction as pe
 
 if TYPE_CHECKING:
@@ -28,10 +29,16 @@ def create_class_relationships(
     resolve_to_qn: Callable[[str, str], str],
     function_registry: FunctionRegistryTrieProtocol,
     interface_implementers: dict[str, set[str]] | None = None,
+    defer_cpp_inherits: list[DeferredCppInherit] | None = None,
 ) -> None:
-    parent_classes = pe.extract_parent_classes(
-        class_node, module_qn, import_processor, resolve_to_qn
-    )
+    cpp_bases: list[tuple[str, str]] | None = None
+    if class_node.type in cs.CPP_CLASS_TYPES:
+        cpp_bases = pe.extract_cpp_parent_bases(class_node, module_qn)
+        parent_classes = [guess for _, guess in cpp_bases]
+    else:
+        parent_classes = pe.extract_parent_classes(
+            class_node, module_qn, import_processor, resolve_to_qn
+        )
     class_inheritance[class_qn] = parent_classes
 
     # (H) The DEFINES containment edge is emitted by the caller via
@@ -45,15 +52,35 @@ def create_class_relationships(
             (node_type, cs.KEY_QUALIFIED_NAME, class_qn),
         )
 
-    for base_index, parent_class_qn in enumerate(parent_classes):
-        create_inheritance_relationship(
-            node_type,
-            class_qn,
-            parent_class_qn,
-            function_registry,
-            ingestor,
-            base_index,
+    if cpp_bases is not None and defer_cpp_inherits is not None:
+        # (H) A C++ base often lives in another header, so its qn cannot resolve
+        # (H) until every class is registered; hold the INHERITS edge back for
+        # (H) resolve_deferred_cpp_inherits instead of emitting the module-anchored
+        # (H) guess (a phantom the database drops for every cross-file base).
+        namespace_path = cs.SEPARATOR_DOT.join(
+            cpp_utils.extract_namespace_path(class_node)
         )
+        for base_index, (written_name, guess_qn) in enumerate(cpp_bases):
+            defer_cpp_inherits.append(
+                DeferredCppInherit(
+                    child_label=str(node_type),
+                    child_qn=class_qn,
+                    base_name=written_name,
+                    guess_qn=guess_qn,
+                    namespace_path=namespace_path,
+                    base_index=base_index,
+                )
+            )
+    else:
+        for base_index, parent_class_qn in enumerate(parent_classes):
+            create_inheritance_relationship(
+                node_type,
+                class_qn,
+                parent_class_qn,
+                function_registry,
+                ingestor,
+                base_index,
+            )
 
     # (H) A class OR an enum can `implements` interfaces; both expose them via the
     # (H) `interfaces` field (a super_interfaces clause), so handle both.

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -100,6 +100,11 @@ class DefinitionProcessor(
         # (H) (the walks diverge on preprocessor-distorted class bodies).
         self.cpp_function_locations: dict[tuple[str, int], CppFunctionLocation] = {}
         self._deferred_cpp_inherits: list[DeferredCppInherit] = []
+        # (H) {qn: file path} for definitions rehydrated from the graph on an
+        # (H) incremental run, whose modules are absent from module_qn_to_file_path
+        # (H) (only re-parsed files populate it). _is_cpp_defined falls back to
+        # (H) this so cross-file resolution into UNCHANGED headers still works.
+        self.rehydrated_definition_paths: dict[str, str] = {}
         self._handler = get_handler(cs.SupportedLanguage.PYTHON)
         self._func_class_captures_cache = func_class_captures_cache
 

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -9,7 +9,13 @@ from tree_sitter import QueryCursor
 from .. import constants as cs
 from .. import logs as ls
 from ..parser_loader import COMBINED_FUNC_CLASS_IMPORT_QUERIES
-from ..types_defs import ASTNode, FunctionRegistryTrieProtocol, SimpleNameLookup
+from ..types_defs import (
+    ASTNode,
+    CppFunctionLocation,
+    DeferredCppInherit,
+    FunctionRegistryTrieProtocol,
+    SimpleNameLookup,
+)
 from ..utils.path_utils import cached_relative_path, cached_resolve_posix
 from .class_ingest import ClassIngestMixin
 from .cpp import CppTypeInferenceEngine
@@ -88,6 +94,12 @@ class DefinitionProcessor(
         # (H) out-of-class C++ method the definition pass bound; Pass-3 call
         # (H) attribution reuses these decisions instead of re-resolving.
         self.cpp_out_of_class_methods: dict[tuple[str, int], tuple[str, str]] = {}
+        # (H) (module_qn, def start_line) -> location of EVERY C++ function or
+        # (H) method node Pass 2 registered, so Pass-3 caller attribution reuses
+        # (H) the registered label/qn instead of re-deriving them structurally
+        # (H) (the walks diverge on preprocessor-distorted class bodies).
+        self.cpp_function_locations: dict[tuple[str, int], CppFunctionLocation] = {}
+        self._deferred_cpp_inherits: list[DeferredCppInherit] = []
         self._handler = get_handler(cs.SupportedLanguage.PYTHON)
         self._func_class_captures_cache = func_class_captures_cache
 

--- a/codebase_rag/parsers/factory.py
+++ b/codebase_rag/parsers/factory.py
@@ -139,5 +139,6 @@ class ProcessorFactory:
                 interface_implementers=self.definition_processor.interface_implementers,
                 module_qn_to_file_path=self.module_qn_to_file_path,
                 cpp_out_of_class_methods=self.definition_processor.cpp_out_of_class_methods,
+                cpp_function_locations=self.definition_processor.cpp_function_locations,
             )
         return self._call_processor

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -12,6 +12,8 @@ from .. import logs as ls
 from ..language_spec import LANGUAGE_FQN_SPECS, LanguageSpec
 from ..types_defs import (
     ASTNode,
+    CppFunctionLocation,
+    DeferredCppInherit,
     DeferredParentLink,
     FunctionRegistryTrieProtocol,
     NodeType,
@@ -110,6 +112,9 @@ class FunctionIngestMixin:
     _deferred_parent_links: list[DeferredParentLink]
     method_return_types: dict[str, str]
     cpp_out_of_class_methods: dict[tuple[str, int], tuple[str, str]]
+    cpp_function_locations: dict[tuple[str, int], CppFunctionLocation]
+    class_inheritance: dict[str, list[str]]
+    _deferred_cpp_inherits: list[DeferredCppInherit]
 
     @abstractmethod
     def _get_docstring(self, node: ASTNode) -> str | None: ...
@@ -143,6 +148,17 @@ class FunctionIngestMixin:
 
             if language == cs.SupportedLanguage.CPP:
                 if self._handle_cpp_out_of_class_method(func_node, module_qn):
+                    continue
+                # (H) The query captures a templated function twice: the
+                # (H) template_declaration wrapper AND its inner definition.
+                # (H) The wrapper is the canonical node (mirroring the class
+                # (H) rule); registering the inner too mints a `qn@line`
+                # (H) duplicate that call attribution can bind to (issue #652).
+                if (
+                    func_node.type == cs.CppNodeType.FUNCTION_DEFINITION
+                    and func_node.parent is not None
+                    and func_node.parent.type == cs.CppNodeType.TEMPLATE_DECLARATION
+                ):
                     continue
 
             if language == cs.SupportedLanguage.GO and self._defer_go_receiver_method(
@@ -234,7 +250,7 @@ class FunctionIngestMixin:
         )
 
     def _resolve_cpp_class_qn(
-        self, class_name: str, module_qn: str
+        self, class_name: str, module_qn: str, exclude_qn: str | None = None
     ) -> tuple[str, bool]:
         """Look up an existing Class node for *class_name* across all parsed files.
 
@@ -251,6 +267,8 @@ class FunctionIngestMixin:
             # (H) Sorted: the lookup is a set, and same-leaf classes in
             # (H) different namespaces would otherwise bind nondeterministically.
             for candidate_qn in sorted(self.simple_name_lookup[leaf_name]):
+                if candidate_qn == exclude_qn:
+                    continue
                 node_type = self.function_registry.get(candidate_qn)
                 if node_type in {NodeType.CLASS, NodeType.TYPE}:
                     # (H) An out-of-class nested definition keeps `Outer::Inner`
@@ -327,9 +345,14 @@ class FunctionIngestMixin:
             if bound_name := cpp_utils.extract_function_name(func_node):
                 # (H) Record the binding so Pass-3 call attribution reuses this
                 # (H) exact decision instead of re-resolving (and diverging).
-                self.cpp_out_of_class_methods[
-                    (module_qn, func_node.start_point[0] + 1)
-                ] = (f"{class_qn}{cs.SEPARATOR_DOT}{bound_name}", class_qn)
+                bound_qn = f"{class_qn}{cs.SEPARATOR_DOT}{bound_name}"
+                location = (module_qn, func_node.start_point[0] + 1)
+                self.cpp_out_of_class_methods[location] = (bound_qn, class_qn)
+                self.cpp_function_locations[location] = CppFunctionLocation(
+                    label=cs.NodeLabel.METHOD.value,
+                    qualified_name=bound_qn,
+                    container_qn=class_qn,
+                )
             if return_type and (
                 method_name := cpp_utils.extract_function_name(func_node)
             ):
@@ -406,6 +429,13 @@ class FunctionIngestMixin:
             self.cpp_out_of_class_methods[(entry.module_qn, entry.start_line)] = (
                 method_qn,
                 class_qn,
+            )
+            self.cpp_function_locations[(entry.module_qn, entry.start_line)] = (
+                CppFunctionLocation(
+                    label=cs.NodeLabel.METHOD.value,
+                    qualified_name=method_qn,
+                    container_qn=class_qn,
+                )
             )
 
             props = dict(entry.method_props)
@@ -607,6 +637,27 @@ class FunctionIngestMixin:
         )
         if resolution.name:
             self.simple_name_lookup[resolution.name].add(resolution.qualified_name)
+        if language == cs.SupportedLanguage.CPP:
+            # (H) Record where this function landed so Pass-3 call attribution
+            # (H) reuses the registered qn/label instead of re-deriving them.
+            location = CppFunctionLocation(
+                label=cs.NodeLabel.FUNCTION.value,
+                qualified_name=resolution.qualified_name,
+                container_qn=None,
+            )
+            self.cpp_function_locations[
+                (module_qn, func_node.start_point[0] + 1)
+            ] = location
+            # (H) A template wrapper's body walk in Pass 3 visits the INNER
+            # (H) definition (it starts on its own line), so record that line
+            # (H) against the wrapper's node too.
+            if func_node.type == cs.CppNodeType.TEMPLATE_DECLARATION:
+                for child in func_node.children:
+                    if child.type == cs.CppNodeType.FUNCTION_DEFINITION:
+                        self.cpp_function_locations[
+                            (module_qn, child.start_point[0] + 1)
+                        ] = location
+                        break
 
         self._create_function_relationships(
             func_node, resolution, module_qn, language, lang_config

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -645,9 +645,9 @@ class FunctionIngestMixin:
                 qualified_name=resolution.qualified_name,
                 container_qn=None,
             )
-            self.cpp_function_locations[
-                (module_qn, func_node.start_point[0] + 1)
-            ] = location
+            self.cpp_function_locations[(module_qn, func_node.start_point[0] + 1)] = (
+                location
+            )
             # (H) A template wrapper's body walk in Pass 3 visits the INNER
             # (H) definition (it starts on its own line), so record that line
             # (H) against the wrapper's node too.

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -115,6 +115,7 @@ class FunctionIngestMixin:
     cpp_function_locations: dict[tuple[str, int], CppFunctionLocation]
     class_inheritance: dict[str, list[str]]
     _deferred_cpp_inherits: list[DeferredCppInherit]
+    rehydrated_definition_paths: dict[str, str]
 
     @abstractmethod
     def _get_docstring(self, node: ASTNode) -> str | None: ...
@@ -296,6 +297,12 @@ class FunctionIngestMixin:
                     path.suffix in cs.CPP_EXTENSIONS or path.suffix in cs.C_EXTENSIONS
                 )
             parts = parts[:-1]
+        # (H) An incremental run only populates module_qn_to_file_path for
+        # (H) re-parsed files; a definition rehydrated from the graph resolves
+        # (H) through its node's recorded file path instead.
+        if rehydrated := self.rehydrated_definition_paths.get(qn):
+            suffix = Path(rehydrated).suffix
+            return suffix in cs.CPP_EXTENSIONS or suffix in cs.C_EXTENSIONS
         return False
 
     def _handle_cpp_out_of_class_method(self, func_node: Node, module_qn: str) -> bool:

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -559,21 +559,21 @@ def ingest_method(
     repo_path: Path | None = None,
     defer_containment: list[DeferredParentLink] | None = None,
     module_qn: str | None = None,
-) -> None:
+) -> str | None:
     if language == cs.SupportedLanguage.CPP:
         from .cpp import utils as cpp_utils
 
         method_name = cpp_utils.extract_function_name(method_node)
         if not method_name:
-            return
+            return None
     elif (method_name_node := method_node.child_by_field_name(cs.FIELD_NAME)) is None:
         # (H) A JS/TS class-field arrow / fn-expr (`helper = () => ...`) has no name
         # (H) field on the function node; take the binding name from the enclosing
         # (H) field definition so it is modelled as a member instead of dropped.
         if not (method_name := _js_ts_field_member_name(method_node, language)):
-            return
+            return None
     elif (text := method_name_node.text) is None:
-        return
+        return None
     else:
         method_name = text.decode(cs.ENCODING_UTF8)
 
@@ -641,7 +641,7 @@ def ingest_method(
                 rel_type=cs.RelationshipType.DEFINES_METHOD.value,
             )
         )
-        return
+        return method_qn
 
     # (H) The DEFINES_METHOD parent is matched in the graph by LABEL +
     # (H) qualified_name, so it must carry the container's real node label. Callers
@@ -658,6 +658,7 @@ def ingest_method(
         cs.RelationshipType.DEFINES_METHOD,
         (cs.NodeLabel.METHOD, cs.KEY_QUALIFIED_NAME, method_qn),
     )
+    return method_qn
 
 
 def module_function_props(

--- a/codebase_rag/tests/test_cpp_concepts.py
+++ b/codebase_rag/tests/test_cpp_concepts.py
@@ -387,6 +387,10 @@ void demonstrateConceptComposition() {
         if "concept_composition" in call.args[0][2]
     ]
 
-    assert len(composition_definitions) >= 5, (
-        f"Expected at least 5 concept composition definitions, found {len(composition_definitions)}"
+    # (H) 4 real definitions: Calculator, square_root_estimate,
+    # (H) process_elements, demonstrateConceptComposition. The old floor of 5
+    # (H) counted a DEFINES onto a `qn@line` duplicate node that template
+    # (H) functions no longer mint (wrapper is the canonical node, issue #652).
+    assert len(composition_definitions) >= 4, (
+        f"Expected at least 4 concept composition definitions, found {len(composition_definitions)}"
     )

--- a/codebase_rag/tests/test_cpp_cross_file_inherits.py
+++ b/codebase_rag/tests/test_cpp_cross_file_inherits.py
@@ -113,6 +113,30 @@ public:
     assert (f"{project}.spaced.Widget", f"{project}.spaced.Base") in pairs, pairs
 
 
+def test_unresolvable_qualified_base_never_self_inherits(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) `class Type : public other::Type` with other::Type unindexed: the
+    # (H) module-scoped guess strips the qualifier to the leaf, which equals
+    # (H) the child's own qn -- the fallback must not emit a self-edge.
+    (temp_repo / "shadow.h").write_text(
+        """
+#pragma once
+namespace ns {
+class Type : public other::Type {
+public:
+    int kind() const { return 1; }
+};
+}
+"""
+    )
+    run_updater(temp_repo, mock_ingestor)
+
+    inherits = get_relationships(mock_ingestor, cs.RelationshipType.INHERITS.value)
+    for call in inherits:
+        assert call.args[0][2] != call.args[2][2], call.args
+
+
 def test_same_file_base_still_emits_inherits(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:

--- a/codebase_rag/tests/test_cpp_cross_file_inherits.py
+++ b/codebase_rag/tests/test_cpp_cross_file_inherits.py
@@ -86,6 +86,33 @@ def test_unresolvable_external_base_emits_no_phantom_edge(
         assert (str(to_label), to_qn) in node_keys, call.args
 
 
+def test_spaced_template_base_resolves(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) `public Base <int>` (space before the angle bracket) must strip to
+    # (H) `Base`, not `Base ` -- a trailing space can never match the registry.
+    (temp_repo / "spaced.h").write_text(
+        """
+#pragma once
+template <typename T>
+class Base {
+public:
+    T get() const { return T{}; }
+};
+class Widget : public Base <int> {
+public:
+    int id() const { return 7; }
+};
+"""
+    )
+    run_updater(temp_repo, mock_ingestor)
+
+    project = temp_repo.name
+    inherits = get_relationships(mock_ingestor, cs.RelationshipType.INHERITS.value)
+    pairs = {(call.args[0][2], call.args[2][2]) for call in inherits}
+    assert (f"{project}.spaced.Widget", f"{project}.spaced.Base") in pairs, pairs
+
+
 def test_same_file_base_still_emits_inherits(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:

--- a/codebase_rag/tests/test_cpp_cross_file_inherits.py
+++ b/codebase_rag/tests/test_cpp_cross_file_inherits.py
@@ -1,0 +1,110 @@
+# (H) A C++ base class written in another header (`class Aggregator : public
+# (H) Argument` with Argument defined in Argument.h) used to be anchored to the
+# (H) CHILD's own module qn at parse time with no resolution at all, so every
+# (H) cross-file INHERITS edge pointed at a phantom the database drops (issue
+# (H) #652: 398 on souffle). Base emission is now deferred until every class is
+# (H) registered and resolved namespace-scoped across files; a base that
+# (H) resolves nowhere (std::exception) emits no edge rather than a lie.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import get_relationships, run_updater
+
+ARGUMENT_HDR = """
+#pragma once
+namespace ast {
+class Argument {
+public:
+    virtual ~Argument() = default;
+};
+}
+"""
+
+AGGREGATOR_HDR = """
+#pragma once
+#include "Argument.h"
+namespace ast {
+class Aggregator : public Argument {
+public:
+    int arity() const { return 1; }
+};
+}
+"""
+
+EXTERNAL_BASE_HDR = """
+#pragma once
+#include <exception>
+namespace ast {
+class ParseError : public std::exception {
+public:
+    int code() const { return 2; }
+};
+}
+"""
+
+
+def _write_fixture(repo: Path) -> None:
+    src = repo / "src"
+    src.mkdir()
+    (src / "Argument.h").write_text(ARGUMENT_HDR)
+    (src / "Aggregator.h").write_text(AGGREGATOR_HDR)
+    (src / "ParseError.h").write_text(EXTERNAL_BASE_HDR)
+
+
+def test_cross_header_base_resolves_to_defining_module(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    _write_fixture(temp_repo)
+    run_updater(temp_repo, mock_ingestor)
+
+    project = temp_repo.name
+    inherits = get_relationships(mock_ingestor, cs.RelationshipType.INHERITS.value)
+    aggregator_edges = [
+        call for call in inherits if str(call.args[0][2]).endswith(".ast.Aggregator")
+    ]
+    assert aggregator_edges
+    for call in aggregator_edges:
+        assert call.args[2][2] == f"{project}.src.Argument.ast.Argument", call.args
+
+
+def test_unresolvable_external_base_emits_no_phantom_edge(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    _write_fixture(temp_repo)
+    run_updater(temp_repo, mock_ingestor)
+
+    node_keys = {
+        (str(c.args[0]), c.args[1].get("qualified_name"))
+        for c in mock_ingestor.ensure_node_batch.call_args_list
+    }
+    inherits = get_relationships(mock_ingestor, cs.RelationshipType.INHERITS.value)
+    for call in inherits:
+        to_label, _, to_qn = call.args[2]
+        assert (str(to_label), to_qn) in node_keys, call.args
+
+
+def test_same_file_base_still_emits_inherits(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "bank.h").write_text(
+        """
+#pragma once
+class Account {
+public:
+    virtual ~Account() = default;
+};
+class Savings : public Account {
+public:
+    int rate() const { return 3; }
+};
+"""
+    )
+    run_updater(temp_repo, mock_ingestor)
+
+    project = temp_repo.name
+    inherits = get_relationships(mock_ingestor, cs.RelationshipType.INHERITS.value)
+    pairs = {(call.args[0][2], call.args[2][2]) for call in inherits}
+    assert (f"{project}.bank.Savings", f"{project}.bank.Account") in pairs, pairs

--- a/codebase_rag/tests/test_cpp_ctor_class_override_false_positive.py
+++ b/codebase_rag/tests/test_cpp_ctor_class_override_false_positive.py
@@ -1,0 +1,47 @@
+# (H) A nested class that inherits its enclosing class (souffle's BTree
+# (H) `node::inner_node : node`) has a constructor whose name equals the nested
+# (H) class's own name. The override pass matched any registry entry named
+# (H) `parent_qn.method_name` without checking it is a METHOD, so the ctor
+# (H) emitted OVERRIDES with a Method label onto the nested CLASS node -- a
+# (H) label-mismatched phantom the database drops (issue #652).
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import get_relationships, run_updater
+
+TREE_HDR = """
+#pragma once
+struct node {
+    int size() const { return 1; }
+
+    struct inner_node : node {
+        inner_node(int n) {}
+        int size() const { return n_; }
+        int n_;
+    };
+};
+"""
+
+
+def test_ctor_does_not_override_same_named_nested_class(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "tree.h").write_text(TREE_HDR)
+    run_updater(temp_repo, mock_ingestor)
+
+    method_qns = {
+        c.args[1].get("qualified_name")
+        for c in mock_ingestor.ensure_node_batch.call_args_list
+        if str(c.args[0]) == cs.NodeLabel.METHOD.value
+    }
+    overrides = get_relationships(mock_ingestor, cs.RelationshipType.OVERRIDES.value)
+    size_overrides = []
+    for call in overrides:
+        assert call.args[2][2] in method_qns, call.args
+        if str(call.args[0][2]).endswith(".inner_node.size"):
+            size_overrides.append(call)
+    # (H) The real override (size on the base) must survive the type check.
+    assert size_overrides

--- a/codebase_rag/tests/test_cpp_incremental_inherits.py
+++ b/codebase_rag/tests/test_cpp_incremental_inherits.py
@@ -1,0 +1,71 @@
+# (H) Incremental runs rehydrate the function registry from the graph but used
+# (H) to leave simple_name_lookup (and the qn->file map behind _is_cpp_defined)
+# (H) empty for unchanged files. Deferred C++ INHERITS resolution runs after
+# (H) rehydration, so a re-parsed file inheriting from a class in an UNCHANGED
+# (H) header could not find the base and the edge silently disappeared from the
+# (H) graph on every incremental update (PR #663 review finding).
+from __future__ import annotations
+
+from pathlib import Path
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from evals.cgr_graph import _StatefulIngestor
+
+BASE_HDR = """
+#pragma once
+namespace ast {
+class Base {
+public:
+    virtual ~Base() = default;
+};
+}
+"""
+
+DERIVED_HDR = """
+#pragma once
+#include "Base.h"
+namespace ast {
+class Derived : public Base {
+public:
+    int arity() const { return 1; }
+};
+}
+"""
+
+
+def _index(store: _StatefulIngestor, repo: Path, force: bool) -> None:
+    parsers, queries = load_parsers()
+    GraphUpdater(
+        ingestor=store, repo_path=repo, parsers=parsers, queries=queries
+    ).run(force=force)
+
+
+def _inherits_edges(store: _StatefulIngestor) -> set[tuple[str, str]]:
+    return {
+        (str(from_val), str(to_val))
+        for from_label, from_val, rel_type, to_label, to_val in store.edges
+        if rel_type == cs.RelationshipType.INHERITS.value
+    }
+
+
+def test_incremental_reparse_keeps_cross_header_inherits(temp_repo: Path) -> None:
+    (temp_repo / "Base.h").write_text(BASE_HDR)
+    (temp_repo / "Derived.h").write_text(DERIVED_HDR)
+    project = temp_repo.name
+    expected = (
+        f"{project}.Derived.ast.Derived",
+        f"{project}.Base.ast.Base",
+    )
+
+    store = _StatefulIngestor()
+    _index(store, temp_repo, force=True)
+    assert expected in _inherits_edges(store)
+
+    # (H) A trailing comment changes the hash but not the AST, so only
+    # (H) Derived.h re-parses; Base.h stays rehydration-only.
+    derived = temp_repo / "Derived.h"
+    derived.write_text(DERIVED_HDR + "// touched\n")
+    _index(store, temp_repo, force=False)
+    assert expected in _inherits_edges(store)

--- a/codebase_rag/tests/test_cpp_incremental_inherits.py
+++ b/codebase_rag/tests/test_cpp_incremental_inherits.py
@@ -37,9 +37,9 @@ public:
 
 def _index(store: _StatefulIngestor, repo: Path, force: bool) -> None:
     parsers, queries = load_parsers()
-    GraphUpdater(
-        ingestor=store, repo_path=repo, parsers=parsers, queries=queries
-    ).run(force=force)
+    GraphUpdater(ingestor=store, repo_path=repo, parsers=parsers, queries=queries).run(
+        force=force
+    )
 
 
 def _inherits_edges(store: _StatefulIngestor) -> set[tuple[str, str]]:

--- a/codebase_rag/tests/test_cpp_preproc_caller_attribution.py
+++ b/codebase_rag/tests/test_cpp_preproc_caller_attribution.py
@@ -1,0 +1,88 @@
+# (H) Methods declared inside preprocessor conditionals (#ifdef/#else within a
+# (H) class body, souffle's BTreeDelete.h pattern) distort the AST enough that
+# (H) Pass 3's structural caller-qn walk diverged from the qn Pass 2 registered
+# (H) (dropping the enclosing template class from the chain), so every call
+# (H) inside them was attributed to a phantom caller the database drops (issue
+# (H) #652). The definition pass now records each ingested function's location
+# (H) and call attribution reuses that record instead of re-deriving.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import get_relationships, run_updater
+
+ENGINE_HDR = """
+#pragma once
+#include <vector>
+
+namespace ns {
+namespace detail {
+
+template <typename T>
+class engine {
+public:
+    class iterator;
+
+    struct node {
+        int size() const { return 1; }
+
+#ifdef IS_PARALLEL
+        void split(node** root, int idx, std::vector<node*>& locked) {
+            grow(root);
+            int s = size();
+        }
+#else
+        void split(node** root, int idx) {
+            grow(root);
+            int s = size();
+        }
+#endif
+
+        void grow(node** root) {
+            split(root, 0);
+        }
+    };
+};
+
+}  // namespace detail
+}  // namespace ns
+"""
+
+
+def _node_keys(mock_ingestor: MagicMock) -> set[tuple[str, str | None]]:
+    return {
+        (str(c.args[0]), c.args[1].get("qualified_name"))
+        for c in mock_ingestor.ensure_node_batch.call_args_list
+    }
+
+
+def test_calls_inside_preproc_methods_attach_to_real_nodes(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "engine.h").write_text(ENGINE_HDR)
+    run_updater(temp_repo, mock_ingestor)
+
+    node_keys = _node_keys(mock_ingestor)
+    calls = get_relationships(mock_ingestor, cs.RelationshipType.CALLS.value)
+    assert calls
+    for call in calls:
+        from_label, _, from_qn = call.args[0]
+        assert (str(from_label), from_qn) in node_keys, call.args
+
+
+def test_preproc_method_callers_keep_full_class_chain(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "engine.h").write_text(ENGINE_HDR)
+    run_updater(temp_repo, mock_ingestor)
+
+    grow_calls = [
+        call
+        for call in get_relationships(mock_ingestor, cs.RelationshipType.CALLS.value)
+        if str(call.args[2][2]).endswith(".grow")
+    ]
+    assert grow_calls
+    for call in grow_calls:
+        assert ".engine.node.split" in str(call.args[0][2]), call.args

--- a/codebase_rag/tests/test_cpp_template_function_single_node.py
+++ b/codebase_rag/tests/test_cpp_template_function_single_node.py
@@ -1,0 +1,47 @@
+# (H) The C++ function query captures a templated free function twice: the
+# (H) template_declaration wrapper AND its inner function_definition. Both used
+# (H) to register, so every template function minted a `qn@line` duplicate node
+# (H) and Pass-3 caller attribution could bind the body's calls to the
+# (H) duplicate instead of the natural qn (issue #652). The wrapper is the
+# (H) canonical node (mirroring the class rule); the inner definition is
+# (H) redundant and must not register.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import get_relationships, run_updater
+
+SAX_HDR = """
+struct Aaa {
+    bool start_object(int n) { return true; }
+};
+template<typename SAX>
+bool run_parse(SAX* sax) {
+    return sax->start_object(1);
+}
+"""
+
+
+def test_template_function_registers_one_node_and_owns_its_calls(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "sax.h").write_text(SAX_HDR)
+    run_updater(temp_repo, mock_ingestor)
+
+    function_qns = [
+        c.args[1]["qualified_name"]
+        for c in mock_ingestor.ensure_node_batch.call_args_list
+        if str(c.args[0]) == cs.NodeLabel.FUNCTION.value
+        and "run_parse" in c.args[1]["qualified_name"]
+    ]
+    project = temp_repo.name
+    assert function_qns == [f"{project}.sax.run_parse"], function_qns
+
+    start_object_calls = {
+        call.args[0][2]
+        for call in get_relationships(mock_ingestor, cs.RelationshipType.CALLS.value)
+        if str(call.args[2][2]).endswith(".start_object")
+    }
+    assert start_object_calls == {f"{project}.sax.run_parse"}, start_object_calls

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -509,6 +509,37 @@ class DeferredParentLink(NamedTuple):
     rel_type: str = RelationshipType.DEFINES.value
 
 
+class CppFunctionLocation(NamedTuple):
+    """Where the definition pass put a C++ function/method node.
+
+    Keyed by (module_qn, start_line) so Pass-3 call attribution reuses the
+    exact label and qn Pass 2 registered instead of re-deriving them from the
+    AST; the two walks diverge on preprocessor-distorted class bodies and
+    every divergence is a phantom caller the database drops (issue #652).
+    """
+
+    label: str
+    qualified_name: str
+    container_qn: str | None
+
+
+class DeferredCppInherit(NamedTuple):
+    """C++ INHERITS edge held back until every class is registered.
+
+    A base written in another header cannot resolve at parse time, so the
+    edge is emitted after Pass 2 with the base resolved namespace-scoped
+    across files; an unresolvable base emits no edge rather than a phantom
+    the database would drop.
+    """
+
+    child_label: str
+    child_qn: str
+    base_name: str
+    guess_qn: str
+    namespace_path: str
+    base_index: int
+
+
 class RelationshipSchema(NamedTuple):
     sources: tuple[NodeLabel, ...]
     rel_type: RelationshipType

--- a/evals/cgr_graph.py
+++ b/evals/cgr_graph.py
@@ -162,6 +162,7 @@ class _StatefulIngestor:
                         cs.KEY_QUALIFIED_NAME: _text(qn),
                         cs.KEY_LABEL: label,
                         cs.KEY_IS_PROPERTY: bool(props.get(cs.KEY_IS_PROPERTY)),
+                        cs.KEY_PATH: _text(props.get(cs.KEY_PATH)),
                     }
                     defs.append(row)
                 return defs

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.256"
+version = "0.0.257"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Iteration 2 of #652. Eliminates every remaining dangling edge on the souffle corpus: 4,261 after #657, now **0** (campaign total 18,175 -> 0). Zero orphans preserved, suite 4593 passed / 0 failed, ty and ruff clean.

## Root causes fixed (each red -> green in commit history)

### 1. Residual phantom callers (3,683 CALLS FROM + 157 REFERENCES FROM + 21 INSTANTIATES FROM)
Pass 3 re-derived caller qns structurally and diverged from Pass 2 on preprocessor-distorted class bodies. souffle's `BTreeDelete.h` declares methods inside `#ifdef IS_PARALLEL` / `#else` blocks inside a template class; tree-sitter's recovery drops parts of the ancestry, so Pass 2 registered `...engine.node.split` while Pass 3 attributed the same body's calls to `...node.split` or `...split`.

Fix: Pass 2 now records every C++ Function/Method node it registers in `cpp_function_locations` keyed by `(module_qn, start_line)` (value: label, qn, container qn). Pass 3 consults the record in both walk paths (`_process_calls_in_functions`, `_process_methods_in_class`) before deriving anything. This is the record-and-reuse pattern from #657's out-of-class method fix, generalized to all C++ callers. `ingest_method` now returns the final method qn so call sites can record it.

### 2. Cross-file INHERITS bases (398 TO-missing)
`parse_cpp_base_classes` anchored every base to the child's own module qn at parse time with no resolution, so `class Aggregator : public Argument` (Argument defined in Argument.h) pointed at a phantom under Aggregator.h's module.

Fix: C++ INHERITS emission is deferred (`DeferredCppInherit`) until every class is registered, then resolved scope-first across files via `_resolve_cpp_class_qn` (new `exclude_qn` parameter prevents `class Type : public other::Type` from self-inheriting). Resolved qns replace the parse-time guesses in `class_inheritance` in place, so Pass-3 method resolution and override detection walk the real hierarchy - the run now finds cross-file overrides it previously missed. A base that resolves nowhere (`std::exception`) emits no edge rather than one the database silently drops.

### 3. Template function duplicate nodes
The C++ functions query captures a templated free function twice: the `template_declaration` wrapper and its inner `function_definition`. Both registered, minting a `qn@line` duplicate node per template function; with fix 1 in place, call attribution faithfully bound bodies to the duplicate. The inner definition no longer registers (mirroring the existing class-specifier rule); the wrapper's location is also recorded at the inner definition's start line so Pass 3's walk still hits it.

### 4. OVERRIDES onto a same-named nested class (final 4)
`check_method_overrides` matched any registry entry named `parent_qn.method_name` without checking its node type. A nested class that inherits its encloser (souffle's `node::inner_node : node`) has a constructor whose name equals the nested class registered at exactly that qn, so the ctor emitted OVERRIDES with a Method label onto a Class node. The parent member must now be `NodeType.METHOD`.

## Test changes
- New: `test_cpp_preproc_caller_attribution.py`, `test_cpp_cross_file_inherits.py`, `test_cpp_template_function_single_node.py`, `test_cpp_ctor_class_override_false_positive.py`
- Adjusted: `test_cpp_concepts` definitions floor 5 -> 4 (the old floor counted a DEFINES edge onto a now-removed template duplicate node)

## Verification
- souffle-lang/souffle full index: 0 dangling relationship endpoints (was 4,261), 0 orphans
- Full suite: 4593 passed, 14 skipped, 0 failed (`-n auto`)
- `ty check`: same 352 pre-existing diagnostics as main, none new; `ruff check` and `ruff format` clean
