### PR TITLE
fix(java): cast-expression receivers and anonymous-class own-method calls

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -2417,6 +2417,7 @@ TS_ERROR = "ERROR"
 TS_EXPRESSION_STATEMENT = "expression_statement"
 TS_STATEMENT_BLOCK = "statement_block"
 TS_PARENTHESIZED_EXPRESSION = "parenthesized_expression"
+TS_JAVA_CAST_EXPRESSION = "cast_expression"
 TS_ATTRIBUTE = "attribute"
 
 FIELD_OPERATOR = "operator"

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -2659,7 +2659,13 @@ JAVA_ORDER_PATTERN = "order"
 ENTITY_CONSTRUCTOR = "Constructor"
 
 # (H) Java callable entity types for method resolution
-JAVA_CALLABLE_ENTITY_TYPES = frozenset({ENTITY_METHOD, ENTITY_CONSTRUCTOR})
+# (H) FUNCTION is included so an unqualified call inside a method-body anonymous class
+# (H) can reach the anon's OWN methods (registered as Function nodes under the enclosing
+# (H) scope, e.g. gson's `delegate()` called by the same anon's `read()`); the module
+# (H) scan is a last-resort fallback after precise class/anon-base/enclosing lookups.
+JAVA_CALLABLE_ENTITY_TYPES = frozenset(
+    {ENTITY_METHOD, ENTITY_CONSTRUCTOR, ENTITY_FUNCTION}
+)
 
 # (H) Java primitive type names
 JAVA_TYPE_STRING = "String"

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1662,7 +1662,7 @@ class CallProcessor:
 
             if is_java and call_node.type == method_invocation_type:
                 callee_info = resolver.resolve_java_method_call(
-                    call_node, module_qn, local_var_types
+                    call_node, module_qn, local_var_types, caller_qn
                 )
             else:
                 callee_info = resolve_func(

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -1827,11 +1827,14 @@ class CallResolver:
         call_node: Node,
         module_qn: str,
         local_var_types: dict[str, str] | None,
+        caller_qn: str | None = None,
     ) -> tuple[str, str] | None:
         java_engine = self.type_inference.java_type_inference
 
         result = self._redirect_protocol_method(
-            java_engine.resolve_java_method_call(call_node, local_var_types, module_qn)
+            java_engine.resolve_java_method_call(
+                call_node, local_var_types, module_qn, caller_qn
+            )
         )
 
         if result:

--- a/codebase_rag/parsers/java/method_resolver.py
+++ b/codebase_rag/parsers/java/method_resolver.py
@@ -93,6 +93,23 @@ def _overload_matches_arg_types(qn: str, arg_types: tuple[str | None, ...]) -> b
     )
 
 
+def _callable_visible_to_caller(
+    entity_type: str, qn: str, caller_qn: str | None
+) -> bool:
+    # (H) A Java FUNCTION entry is a method declared inside another method's body -- i.e.
+    # (H) an anonymous/local class method, only visible lexically. The unqualified
+    # (H) module-wide fallback must not let a call OUTSIDE that anon bind to it (M.use()
+    # (H) -> an anon-local helper() elsewhere). Accept a FUNCTION only when the caller is
+    # (H) lexically within its owning scope (owner qn prefixes the caller). METHOD and
+    # (H) CONSTRUCTOR entries are top-level and stay module-visible.
+    if entity_type != cs.ENTITY_FUNCTION:
+        return True
+    if not caller_qn:
+        return False
+    owner = qn.split(cs.CHAR_PAREN_OPEN)[0].rsplit(cs.SEPARATOR_DOT, 1)[0]
+    return caller_qn == owner or caller_qn.startswith(f"{owner}{cs.SEPARATOR_DOT}")
+
+
 def _pick_overload(
     matches: list[tuple[str, str]],
     arg_count: int | None,
@@ -351,6 +368,7 @@ class JavaMethodResolverMixin:
         module_qn: str,
         arg_count: int | None = None,
         arg_types: tuple[str | None, ...] = (),
+        caller_qn: str | None = None,
     ) -> tuple[str, str] | None:
         matches = [
             (entity_type, qn)
@@ -359,6 +377,7 @@ class JavaMethodResolverMixin:
             and qn.split(cs.CHAR_PAREN_OPEN)[0].endswith(
                 f"{cs.SEPARATOR_DOT}{method_name}"
             )
+            and _callable_visible_to_caller(entity_type, qn, caller_qn)
         ]
         return _pick_overload(matches, arg_count, arg_types)
 
@@ -647,7 +666,11 @@ class JavaMethodResolverMixin:
         return tuple(arg_types)
 
     def _do_resolve_java_method_call(
-        self, call_node: ASTNode, local_var_types: dict[str, str], module_qn: str
+        self,
+        call_node: ASTNode,
+        local_var_types: dict[str, str],
+        module_qn: str,
+        caller_qn: str | None = None,
     ) -> tuple[str, str] | None:
         if call_node.type != cs.TS_METHOD_INVOCATION:
             return None
@@ -692,7 +715,7 @@ class JavaMethodResolverMixin:
                 logger.debug(ls.JAVA_FOUND_STATIC, result=result)
                 return result
             result = self._resolve_static_or_local_method(
-                str(method_name), module_qn, arg_count, arg_types
+                str(method_name), module_qn, arg_count, arg_types, caller_qn
             )
             if result:
                 logger.debug(ls.JAVA_FOUND_STATIC, result=result)

--- a/codebase_rag/parsers/java/method_resolver.py
+++ b/codebase_rag/parsers/java/method_resolver.py
@@ -47,6 +47,74 @@ def _java_signature_arity(qn_or_member: str) -> int | None:
     return count
 
 
+def _java_param_type_names(qn: str) -> list[str]:
+    # (H) Simple parameter type names from a signatured method qn
+    # (H) (`isX(Class<?>,String)` -> ['Class', 'String']): generics and package/scope
+    # (H) stripped so they compare with inferred argument type simple names.
+    open_idx = qn.find(cs.CHAR_PAREN_OPEN)
+    close_idx = qn.rfind(cs.CHAR_PAREN_CLOSE)
+    if open_idx < 0 or close_idx <= open_idx:
+        return []
+    inner = qn[open_idx + 1 : close_idx]
+    if not inner.strip():
+        return []
+    parts: list[str] = []
+    depth = 0
+    cur = ""
+    for ch in inner:
+        if ch in "<([":
+            depth += 1
+            cur += ch
+        elif ch in ">)]":
+            depth -= 1
+            cur += ch
+        elif ch == "," and depth == 0:
+            parts.append(cur)
+            cur = ""
+        else:
+            cur += ch
+    parts.append(cur)
+    return [
+        p.split(cs.CHAR_ANGLE_OPEN, 1)[0].rsplit(cs.SEPARATOR_DOT, 1)[-1].strip()
+        for p in parts
+    ]
+
+
+def _overload_matches_arg_types(qn: str, arg_types: tuple[str | None, ...]) -> bool:
+    # (H) True when every KNOWN argument type equals the candidate's parameter type at
+    # (H) that position (simple names). Unknown args (None) are wildcards. Used to pick
+    # (H) the right same-arity overload (isX(String) vs isX(Class) for a String arg).
+    params = _java_param_type_names(qn)
+    if len(params) != len(arg_types):
+        return False
+    return all(
+        at is None or at.split(cs.SEPARATOR_DOT)[-1] == pt
+        for at, pt in zip(arg_types, params, strict=False)
+    )
+
+
+def _pick_overload(
+    matches: list[tuple[str, str]],
+    arg_count: int | None,
+    arg_types: tuple[str | None, ...],
+) -> tuple[str, str] | None:
+    # (H) Choose among same-name candidates: prefer an argument-TYPE match (resolves
+    # (H) same-arity overloads like isX(String) vs isX(Class)), then an argument-COUNT
+    # (H) match, then the first. A type match implies an arity match (equal param/arg
+    # (H) counts), so it is the most specific.
+    if not matches:
+        return None
+    if len(matches) > 1 and any(at is not None for at in arg_types):
+        for match in matches:
+            if _overload_matches_arg_types(match[1], arg_types):
+                return match
+    if len(matches) > 1 and arg_count is not None:
+        for match in matches:
+            if _java_signature_arity(match[1]) == arg_count:
+                return match
+    return matches[0]
+
+
 class JavaMethodResolverMixin:
     __slots__ = ()
     import_processor: ImportProcessor
@@ -278,7 +346,11 @@ class JavaMethodResolverMixin:
         return None
 
     def _resolve_static_or_local_method(
-        self, method_name: str, module_qn: str, arg_count: int | None = None
+        self,
+        method_name: str,
+        module_qn: str,
+        arg_count: int | None = None,
+        arg_types: tuple[str | None, ...] = (),
     ) -> tuple[str, str] | None:
         matches = [
             (entity_type, qn)
@@ -288,16 +360,7 @@ class JavaMethodResolverMixin:
                 f"{cs.SEPARATOR_DOT}{method_name}"
             )
         ]
-        if not matches:
-            return None
-        # (H) Prefer the overload whose parameter count matches the call's argument
-        # (H) count, so a same-named overload of a different arity is not left unmatched
-        # (H) (dead). Fall back to the first match when arity is unknown or none match.
-        if arg_count is not None and len(matches) > 1:
-            for entity_type, qn in matches:
-                if _java_signature_arity(qn) == arg_count:
-                    return entity_type, qn
-        return matches[0]
+        return _pick_overload(matches, arg_count, arg_types)
 
     def _resolve_instance_method(
         self,
@@ -305,21 +368,22 @@ class JavaMethodResolverMixin:
         method_name: str,
         module_qn: str,
         arg_count: int | None = None,
+        arg_types: tuple[str | None, ...] = (),
     ) -> tuple[str, str] | None:
         resolved_type = self._resolve_java_type_name(object_type, module_qn)
 
         if method_result := self._find_method_with_any_signature(
-            resolved_type, method_name, module_qn, arg_count
+            resolved_type, method_name, module_qn, arg_count, arg_types
         ):
             return method_result
 
         if inherited_result := self._find_inherited_method(
-            resolved_type, method_name, module_qn, arg_count
+            resolved_type, method_name, module_qn, arg_count, arg_types
         ):
             return inherited_result
 
         return self._find_interface_method(
-            resolved_type, method_name, module_qn, arg_count
+            resolved_type, method_name, module_qn, arg_count, arg_types
         )
 
     def _find_method_with_any_signature(
@@ -328,20 +392,27 @@ class JavaMethodResolverMixin:
         method_name: str,
         current_module_qn: str | None = None,
         arg_count: int | None = None,
+        arg_types: tuple[str | None, ...] = (),
     ) -> tuple[str, str] | None:
         if class_qn:
-            if result := self._search_method_in_class(class_qn, method_name, arg_count):
+            if result := self._search_method_in_class(
+                class_qn, method_name, arg_count, arg_types
+            ):
                 return result
 
         if class_qn and not class_qn.startswith(self.project_name):
             return self._search_method_in_alternate_modules(
-                class_qn, method_name, current_module_qn, arg_count
+                class_qn, method_name, current_module_qn, arg_count, arg_types
             )
 
         return None
 
     def _search_method_in_class(
-        self, class_qn: str, method_name: str, arg_count: int | None = None
+        self,
+        class_qn: str,
+        method_name: str,
+        arg_count: int | None = None,
+        arg_types: tuple[str | None, ...] = (),
     ) -> tuple[str, str] | None:
         matches: list[tuple[str, str]] = []
         for qn, method_type in self._find_registry_entries_under(class_qn):
@@ -353,17 +424,7 @@ class JavaMethodResolverMixin:
             member = suffix[1:]
             if self._is_matching_method(member, method_name):
                 matches.append((method_type, qn))
-        if not matches:
-            return None
-        # (H) Prefer the arity-matching overload so a same-named overload of a
-        # (H) different parameter count is not left unmatched (dead) -- gson's recursive
-        # (H) `resolve(3-arg)`/`resolve(4-arg)`. Fall back to the first match otherwise.
-        if arg_count is not None and len(matches) > 1:
-            for method_type, qn in matches:
-                if _java_signature_arity(qn) == arg_count:
-                    return method_type, qn
-        return matches[0]
-        return None
+        return _pick_overload(matches, arg_count, arg_types)
 
     def _search_method_in_alternate_modules(
         self,
@@ -371,6 +432,7 @@ class JavaMethodResolverMixin:
         method_name: str,
         current_module_qn: str | None,
         arg_count: int | None = None,
+        arg_types: tuple[str | None, ...] = (),
     ) -> tuple[str, str] | None:
         suffixes = class_qn.split(cs.SEPARATOR_DOT)
         lookup_keys = [
@@ -387,7 +449,7 @@ class JavaMethodResolverMixin:
         for module_qn in ranked_candidates:
             registry_class_qn = f"{module_qn}{cs.SEPARATOR_DOT}{simple_class_name}"
             if result := self._search_method_in_class(
-                registry_class_qn, method_name, arg_count
+                registry_class_qn, method_name, arg_count, arg_types
             ):
                 return result
 
@@ -423,17 +485,18 @@ class JavaMethodResolverMixin:
         method_name: str,
         module_qn: str,
         arg_count: int | None = None,
+        arg_types: tuple[str | None, ...] = (),
     ) -> tuple[str, str] | None:
         if not (superclass_qn := self._get_superclass_name(class_qn)):
             return None
 
         if method_result := self._find_method_with_any_signature(
-            superclass_qn, method_name, module_qn, arg_count
+            superclass_qn, method_name, module_qn, arg_count, arg_types
         ):
             return method_result
 
         return self._find_inherited_method(
-            superclass_qn, method_name, module_qn, arg_count
+            superclass_qn, method_name, module_qn, arg_count, arg_types
         )
 
     def _find_interface_method(
@@ -442,10 +505,11 @@ class JavaMethodResolverMixin:
         method_name: str,
         module_qn: str,
         arg_count: int | None = None,
+        arg_types: tuple[str | None, ...] = (),
     ) -> tuple[str, str] | None:
         for interface_qn in self._get_implemented_interfaces(class_qn):
             if method_result := self._find_method_with_any_signature(
-                interface_qn, method_name, module_qn, arg_count
+                interface_qn, method_name, module_qn, arg_count, arg_types
             ):
                 return method_result
 
@@ -558,6 +622,30 @@ class JavaMethodResolverMixin:
 
         return None
 
+    def _infer_arg_types(
+        self, call_node: ASTNode, local_var_types: dict[str, str], module_qn: str
+    ) -> tuple[str | None, ...]:
+        # (H) Infer the simple type of each argument so same-arity overloads can be told
+        # (H) apart (isX(String) vs isX(Class)). Only identifier arguments whose type is
+        # (H) known (local var or field) are resolved; everything else is None (unknown),
+        # (H) which _overload_matches_arg_types treats as a wildcard.
+        args_node = call_node.child_by_field_name(cs.TS_FIELD_ARGUMENTS)
+        if not args_node:
+            return ()
+        arg_types: list[str | None] = []
+        for child in args_node.children:
+            if child.type in cs.DELIMITER_TOKENS:
+                continue
+            if child.type != cs.TS_IDENTIFIER:
+                arg_types.append(None)
+                continue
+            name = safe_decode_text(child)
+            var_type = local_var_types.get(name) if name else None
+            if not var_type and name:
+                var_type = self._lookup_variable_type(name, module_qn)
+            arg_types.append(var_type or None)
+        return tuple(arg_types)
+
     def _do_resolve_java_method_call(
         self, call_node: ASTNode, local_var_types: dict[str, str], module_qn: str
     ) -> tuple[str, str] | None:
@@ -571,6 +659,7 @@ class JavaMethodResolverMixin:
         method_name = call_info[cs.FIELD_NAME]
         object_ref = call_info[cs.FIELD_OBJECT]
         arg_count = call_info[cs.FIELD_ARGUMENTS]
+        arg_types = self._infer_arg_types(call_node, local_var_types, module_qn)
 
         if not method_name:
             logger.debug(ls.JAVA_NO_METHOD_NAME)
@@ -590,20 +679,20 @@ class JavaMethodResolverMixin:
                 anon_base_qn := self._enclosing_anon_base_qn(call_node, module_qn)
             ) and (
                 result := self._resolve_instance_method(
-                    anon_base_qn, str(method_name), module_qn, arg_count
+                    anon_base_qn, str(method_name), module_qn, arg_count, arg_types
                 )
             ):
                 logger.debug(ls.JAVA_FOUND_STATIC, result=result)
                 return result
             if (enclosing_qn := self._lexical_class_qn(call_node, module_qn)) and (
                 result := self._resolve_instance_method(
-                    enclosing_qn, str(method_name), module_qn, arg_count
+                    enclosing_qn, str(method_name), module_qn, arg_count, arg_types
                 )
             ):
                 logger.debug(ls.JAVA_FOUND_STATIC, result=result)
                 return result
             result = self._resolve_static_or_local_method(
-                str(method_name), module_qn, arg_count
+                str(method_name), module_qn, arg_count, arg_types
             )
             if result:
                 logger.debug(ls.JAVA_FOUND_STATIC, result=result)
@@ -622,7 +711,7 @@ class JavaMethodResolverMixin:
 
         logger.debug(ls.JAVA_OBJ_TYPE_RESOLVED, type=object_type)
         result = self._resolve_instance_method(
-            object_type, str(method_name), module_qn, arg_count
+            object_type, str(method_name), module_qn, arg_count, arg_types
         )
         if result:
             logger.debug(ls.JAVA_FOUND_INSTANCE, result=result)

--- a/codebase_rag/parsers/java/type_inference.py
+++ b/codebase_rag/parsers/java/type_inference.py
@@ -110,10 +110,14 @@ class JavaTypeInferenceEngine(
         return local_var_types
 
     def resolve_java_method_call(
-        self, call_node: ASTNode, local_var_types: dict[str, str] | None, module_qn: str
+        self,
+        call_node: ASTNode,
+        local_var_types: dict[str, str] | None,
+        module_qn: str,
+        caller_qn: str | None = None,
     ) -> tuple[str, str] | None:
         return self._do_resolve_java_method_call(
-            call_node, local_var_types or {}, module_qn
+            call_node, local_var_types or {}, module_qn, caller_qn
         )
 
     def _find_containing_java_class(self, node: ASTNode) -> ASTNode | None:

--- a/codebase_rag/parsers/java/utils.py
+++ b/codebase_rag/parsers/java/utils.py
@@ -343,16 +343,21 @@ def _java_cast_target_type(object_node: ASTNode) -> str | None:
     # (H) names); stripping it would collapse it onto a same-package/imported same-leaf
     # (H) type. None when there is no cast type.
     cast = object_node
-    if cast.type == cs.TS_PARENTHESIZED_EXPRESSION:
+    while cast.type == cs.TS_PARENTHESIZED_EXPRESSION:
         cast = next(
-            (c for c in cast.children if c.type == cs.TS_JAVA_CAST_EXPRESSION), None
+            (c for c in cast.children if c.type not in cs.DELIMITER_TOKENS), None
         )
-    if cast is None or cast.type != cs.TS_JAVA_CAST_EXPRESSION:
+        if cast is None:
+            return None
+    if cast.type != cs.TS_JAVA_CAST_EXPRESSION:
         return None
     type_node = cast.child_by_field_name(cs.FIELD_TYPE)
-    if type_node is None or type_node.text is None:
+    if type_node is None:
         return None
-    base = type_node.text.decode(cs.ENCODING_UTF8).split(cs.CHAR_ANGLE_OPEN, 1)[0]
+    type_text = safe_decode_text(type_node)
+    if not type_text:
+        return None
+    base = type_text.split(cs.CHAR_ANGLE_OPEN, 1)[0]
     return base.strip() or None
 
 

--- a/codebase_rag/parsers/java/utils.py
+++ b/codebase_rag/parsers/java/utils.py
@@ -336,9 +336,12 @@ def extract_field_info(field_node: ASTNode) -> JavaFieldInfo:
 
 
 def _java_cast_target_type(object_node: ASTNode) -> str | None:
-    # (H) The simple target type of a cast receiver: unwrap a parenthesized wrapper to
-    # (H) the cast_expression, read its `type` field, strip generic args and any scope
-    # (H) so `((a.b.Reader<T>) x)` -> `Reader`. None when there is no cast type.
+    # (H) The target type of a cast receiver: unwrap a parenthesized wrapper to the
+    # (H) cast_expression, read its `type` field, strip generic args so
+    # (H) `((a.b.Reader<T>) x)` -> `a.b.Reader`. The package is KEPT so a qualified cast
+    # (H) resolves to the right class (the resolver handles dotted/alternate-module
+    # (H) names); stripping it would collapse it onto a same-package/imported same-leaf
+    # (H) type. None when there is no cast type.
     cast = object_node
     if cast.type == cs.TS_PARENTHESIZED_EXPRESSION:
         cast = next(
@@ -350,7 +353,7 @@ def _java_cast_target_type(object_node: ASTNode) -> str | None:
     if type_node is None or type_node.text is None:
         return None
     base = type_node.text.decode(cs.ENCODING_UTF8).split(cs.CHAR_ANGLE_OPEN, 1)[0]
-    return base.rsplit(cs.SEPARATOR_DOT, 1)[-1].strip() or None
+    return base.strip() or None
 
 
 def extract_method_call_info(call_node: ASTNode) -> JavaMethodCallInfo | None:

--- a/codebase_rag/parsers/java/utils.py
+++ b/codebase_rag/parsers/java/utils.py
@@ -361,6 +361,24 @@ def _java_cast_target_type(object_node: ASTNode) -> str | None:
     return base.strip() or None
 
 
+def _java_paren_receiver(object_node: ASTNode) -> str | None:
+    # (H) A parenthesized NON-cast receiver `(reader).m()` (or nested `((reader))`):
+    # (H) unwrap the parentheses and return the inner identifier/field-access text so the
+    # (H) call resolves through that variable's type, instead of falling to the
+    # (H) unqualified resolver and binding a same-named decoy. None when the inner
+    # (H) expression is neither an identifier nor a field access.
+    node = object_node
+    while node.type == cs.TS_PARENTHESIZED_EXPRESSION:
+        node = next(
+            (c for c in node.children if c.type not in cs.DELIMITER_TOKENS), None
+        )
+        if node is None:
+            return None
+    if node.type in (cs.TS_IDENTIFIER, cs.TS_FIELD_ACCESS):
+        return safe_decode_text(node)
+    return None
+
+
 def extract_method_call_info(call_node: ASTNode) -> JavaMethodCallInfo | None:
     if call_node.type != cs.TS_METHOD_INVOCATION:
         return None
@@ -380,9 +398,13 @@ def extract_method_call_info(call_node: ASTNode) -> JavaMethodCallInfo | None:
                 obj = safe_decode_text(object_node)
             case cs.TS_PARENTHESIZED_EXPRESSION | cs.TS_JAVA_CAST_EXPRESSION:
                 # (H) A cast receiver `((T) x).m()`: the cast's target type is the
-                # (H) receiver type, so m resolves on T. Without this the call falls to
-                # (H) the unqualified path and never finds a cross-file/sibling T.
-                obj = _java_cast_target_type(object_node)
+                # (H) receiver type, so m resolves on T. A parenthesized non-cast receiver
+                # (H) `(reader).m()` keeps its inner identifier/field-access receiver.
+                # (H) Without this the call falls to the unqualified path and never finds
+                # (H) a cross-file/sibling T or the variable's type.
+                obj = _java_cast_target_type(object_node) or _java_paren_receiver(
+                    object_node
+                )
 
     arguments = 0
     if args_node := call_node.child_by_field_name(cs.TS_FIELD_ARGUMENTS):

--- a/codebase_rag/parsers/java/utils.py
+++ b/codebase_rag/parsers/java/utils.py
@@ -335,6 +335,24 @@ def extract_field_info(field_node: ASTNode) -> JavaFieldInfo:
     )
 
 
+def _java_cast_target_type(object_node: ASTNode) -> str | None:
+    # (H) The simple target type of a cast receiver: unwrap a parenthesized wrapper to
+    # (H) the cast_expression, read its `type` field, strip generic args and any scope
+    # (H) so `((a.b.Reader<T>) x)` -> `Reader`. None when there is no cast type.
+    cast = object_node
+    if cast.type == cs.TS_PARENTHESIZED_EXPRESSION:
+        cast = next(
+            (c for c in cast.children if c.type == cs.TS_JAVA_CAST_EXPRESSION), None
+        )
+    if cast is None or cast.type != cs.TS_JAVA_CAST_EXPRESSION:
+        return None
+    type_node = cast.child_by_field_name(cs.FIELD_TYPE)
+    if type_node is None or type_node.text is None:
+        return None
+    base = type_node.text.decode(cs.ENCODING_UTF8).split(cs.CHAR_ANGLE_OPEN, 1)[0]
+    return base.rsplit(cs.SEPARATOR_DOT, 1)[-1].strip() or None
+
+
 def extract_method_call_info(call_node: ASTNode) -> JavaMethodCallInfo | None:
     if call_node.type != cs.TS_METHOD_INVOCATION:
         return None
@@ -352,6 +370,11 @@ def extract_method_call_info(call_node: ASTNode) -> JavaMethodCallInfo | None:
                 obj = cs.TS_SUPER
             case cs.TS_IDENTIFIER | cs.TS_FIELD_ACCESS:
                 obj = safe_decode_text(object_node)
+            case cs.TS_PARENTHESIZED_EXPRESSION | cs.TS_JAVA_CAST_EXPRESSION:
+                # (H) A cast receiver `((T) x).m()`: the cast's target type is the
+                # (H) receiver type, so m resolves on T. Without this the call falls to
+                # (H) the unqualified path and never finds a cross-file/sibling T.
+                obj = _java_cast_target_type(object_node)
 
     arguments = 0
     if args_node := call_node.child_by_field_name(cs.TS_FIELD_ARGUMENTS):

--- a/codebase_rag/tests/test_java_anon_method_caller_qn.py
+++ b/codebase_rag/tests/test_java_anon_method_caller_qn.py
@@ -150,6 +150,37 @@ def test_anon_own_method_unqualified_call_resolves(
     calls = {
         (c.args[0][2], c.args[2][2]) for c in get_relationships(mock_ingestor, "CALLS")
     }
-    assert any(
-        f.endswith(".read") and t.endswith(".helper") for f, t in calls
-    ), sorted(t for f, t in calls if "helper" in t)
+    assert any(f.endswith(".read") and t.endswith(".helper") for f, t in calls), sorted(
+        t for f, t in calls if "helper" in t
+    )
+
+
+def test_outside_call_does_not_bind_to_anon_local_method(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) An anon class's OWN method registers as a module-scoped Function; the
+    # (H) unqualified module-wide fallback must NOT let a call OUTSIDE that anon bind to
+    # (H) it. `M.use()` calling `helper()` is not lexically inside the anon that declares
+    # (H) `helper()`, so no CALLS edge to the anon-local helper may be emitted.
+    root = temp_repo / "janonscope"
+    pkg = root / "com" / "example"
+    pkg.mkdir(parents=True)
+    (pkg / "M.java").write_text(
+        "package com.example;\n"
+        "public class M {\n"
+        "  Object make() {\n"
+        "    return new Object() {\n"
+        "      int helper() { return 1; }\n"
+        "    };\n"
+        "  }\n"
+        "  int use() { return helper(); }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="java")
+    calls = {
+        (c.args[0][2], c.args[2][2]) for c in get_relationships(mock_ingestor, "CALLS")
+    }
+    assert not any(
+        f.endswith(".M.use()") and t.endswith(".make.helper") for f, t in calls
+    ), "outside call wrongly bound to an anon-class-local method (scope violation)"

--- a/codebase_rag/tests/test_java_anon_method_caller_qn.py
+++ b/codebase_rag/tests/test_java_anon_method_caller_qn.py
@@ -122,3 +122,34 @@ def test_anon_override_explicit_this_call_binds_to_base(
     assert not any(
         f.endswith(".read") and t.endswith(".M.helper()") for f, t in calls
     ), "explicit this.helper() in anon wrongly bound to enclosing class"
+
+
+def test_anon_own_method_unqualified_call_resolves(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) An unqualified call to the anonymous class's OWN (non-inherited) method
+    # (H) (gson's `delegate().read()` where `delegate()` is defined in the same anon)
+    # (H) must resolve; the anon's own methods register as Function nodes, which the
+    # (H) module-wide fallback previously skipped.
+    root = temp_repo / "janonown"
+    pkg = root / "com" / "example"
+    pkg.mkdir(parents=True)
+    (pkg / "M.java").write_text(
+        "package com.example;\n"
+        "public class M {\n"
+        "  Object make() {\n"
+        "    return new Object() {\n"
+        "      int helper() { return 1; }\n"
+        "      int read() { return helper(); }\n"
+        "    };\n"
+        "  }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="java")
+    calls = {
+        (c.args[0][2], c.args[2][2]) for c in get_relationships(mock_ingestor, "CALLS")
+    }
+    assert any(
+        f.endswith(".read") and t.endswith(".helper") for f, t in calls
+    ), sorted(t for f, t in calls if "helper" in t)

--- a/codebase_rag/tests/test_java_cast_receiver.py
+++ b/codebase_rag/tests/test_java_cast_receiver.py
@@ -45,3 +45,41 @@ def test_cast_receiver_resolves_cross_file(
     assert not any(
         f.endswith(".M.use(Object)") and t.endswith(".Other.nextX()") for f, t in calls
     ), "cast receiver wrongly bound to the decoy"
+
+
+def test_qualified_cast_receiver_does_not_bind_to_same_package_decoy(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) A fully-qualified cast target `((com.other.Reader) in).m()` must NOT resolve to
+    # (H) a same-package `Reader` decoy. Stripping the package off the cast type collapses
+    # (H) `com.other.Reader` to `Reader` and binds it to the wrong same-package class;
+    # (H) keeping the qualified name prevents that wrong edge.
+    root = temp_repo / "jqcast"
+    (root / "com" / "other").mkdir(parents=True)
+    (root / "com" / "example").mkdir(parents=True)
+    (root / "com" / "other" / "Reader.java").write_text(
+        "package com.other;\n"
+        "public class Reader { public int nextX() { return 1; } }\n",
+        encoding="utf-8",
+    )
+    # (H) same-package decoy Reader: without the qualified type the call mis-binds here.
+    (root / "com" / "example" / "Reader.java").write_text(
+        "package com.example;\n"
+        "public class Reader { public int nextX() { return 2; } }\n",
+        encoding="utf-8",
+    )
+    (root / "com" / "example" / "M.java").write_text(
+        "package com.example;\n"
+        "public class M {\n"
+        "  int use(Object in) { return ((com.other.Reader) in).nextX(); }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="java")
+    calls = {
+        (c.args[0][2], c.args[2][2]) for c in get_relationships(mock_ingestor, "CALLS")
+    }
+    assert not any(
+        f.endswith(".M.use(Object)") and t.endswith(".example.Reader.nextX()")
+        for f, t in calls
+    ), "qualified cast receiver wrongly bound to the same-package decoy"

--- a/codebase_rag/tests/test_java_cast_receiver.py
+++ b/codebase_rag/tests/test_java_cast_receiver.py
@@ -47,6 +47,36 @@ def test_cast_receiver_resolves_cross_file(
     ), "cast receiver wrongly bound to the decoy"
 
 
+def test_nested_parenthesized_cast_receiver_resolves(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) A cast wrapped in multiple parentheses `(((Reader) in)).m()` must still yield
+    # (H) the cast target type: parenthesized wrappers are unwrapped to the innermost
+    # (H) cast, not just one layer.
+    root = temp_repo / "jncast"
+    pkg = root / "com" / "example"
+    pkg.mkdir(parents=True)
+    (pkg / "Reader.java").write_text(
+        "package com.example;\n"
+        "public class Reader { public int nextX() { return 1; } }\n",
+        encoding="utf-8",
+    )
+    (pkg / "M.java").write_text(
+        "package com.example;\n"
+        "public class M {\n"
+        "  int use(Object in) { return (((Reader) in)).nextX(); }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="java")
+    calls = {
+        (c.args[0][2], c.args[2][2]) for c in get_relationships(mock_ingestor, "CALLS")
+    }
+    assert any(
+        f.endswith(".M.use(Object)") and t.endswith(".Reader.nextX()") for f, t in calls
+    ), sorted(t for f, t in calls if "nextX" in t)
+
+
 def test_qualified_cast_receiver_does_not_bind_to_same_package_decoy(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:

--- a/codebase_rag/tests/test_java_cast_receiver.py
+++ b/codebase_rag/tests/test_java_cast_receiver.py
@@ -1,0 +1,47 @@
+# (H) A method call on a cast receiver `((T) x).m()` (gson's
+# (H) `((JsonTreeReader) in).nextJsonElement()`) dropped: the object extractor ignored
+# (H) cast/parenthesized receivers, so the call fell to the unqualified path and never
+# (H) resolved m on T (cross-file/sibling T). The cast's target type is the receiver.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.conftest import create_and_run_updater, get_relationships
+
+
+def test_cast_receiver_resolves_cross_file(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    root = temp_repo / "jcast"
+    pkg = root / "com" / "example"
+    pkg.mkdir(parents=True)
+    # (H) Target Reader.nextX is in a sibling file; a decoy Other.nextX ensures the
+    # (H) unqualified fallback can't coincidentally pick the right one.
+    (pkg / "Reader.java").write_text(
+        "package com.example;\n"
+        "public class Reader { public int nextX() { return 1; } }\n",
+        encoding="utf-8",
+    )
+    (pkg / "Other.java").write_text(
+        "package com.example;\n"
+        "public class Other { public int nextX() { return 2; } }\n",
+        encoding="utf-8",
+    )
+    (pkg / "M.java").write_text(
+        "package com.example;\n"
+        "public class M {\n"
+        "  int use(Object in) { return ((Reader) in).nextX(); }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="java")
+    calls = {
+        (c.args[0][2], c.args[2][2]) for c in get_relationships(mock_ingestor, "CALLS")
+    }
+    assert any(
+        f.endswith(".M.use(Object)") and t.endswith(".Reader.nextX()") for f, t in calls
+    ), sorted(t for f, t in calls if "nextX" in t)
+    assert not any(
+        f.endswith(".M.use(Object)") and t.endswith(".Other.nextX()") for f, t in calls
+    ), "cast receiver wrongly bound to the decoy"

--- a/codebase_rag/tests/test_java_cast_receiver.py
+++ b/codebase_rag/tests/test_java_cast_receiver.py
@@ -77,6 +77,41 @@ def test_nested_parenthesized_cast_receiver_resolves(
     ), sorted(t for f, t in calls if "nextX" in t)
 
 
+def test_parenthesized_identifier_receiver_resolves(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) A parenthesized non-cast receiver `(reader).nextX()` must resolve through the
+    # (H) `reader` variable's type (Reader), not fall to the unqualified resolver and bind
+    # (H) a same-named decoy method on the enclosing class.
+    root = temp_repo / "jpid"
+    pkg = root / "com" / "example"
+    pkg.mkdir(parents=True)
+    (pkg / "Reader.java").write_text(
+        "package com.example;\n"
+        "public class Reader { public int nextX() { return 1; } }\n",
+        encoding="utf-8",
+    )
+    # (H) M declares a decoy nextX(): without a receiver the call mis-binds to it.
+    (pkg / "M.java").write_text(
+        "package com.example;\n"
+        "public class M {\n"
+        "  int nextX() { return 9; }\n"
+        "  int use(Reader reader) { return (reader).nextX(); }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="java")
+    calls = {
+        (c.args[0][2], c.args[2][2]) for c in get_relationships(mock_ingestor, "CALLS")
+    }
+    assert any(
+        f.endswith(".M.use(Reader)") and t.endswith(".Reader.nextX()") for f, t in calls
+    ), sorted(t for f, t in calls if "nextX" in t)
+    assert not any(
+        f.endswith(".M.use(Reader)") and t.endswith(".M.nextX()") for f, t in calls
+    ), "parenthesized identifier receiver wrongly bound to the enclosing-class decoy"
+
+
 def test_qualified_cast_receiver_does_not_bind_to_same_package_decoy(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:

--- a/codebase_rag/tests/test_java_overload_resolution.py
+++ b/codebase_rag/tests/test_java_overload_resolution.py
@@ -80,3 +80,31 @@ def test_inherited_overload_binds_to_arity_match(
     assert not any(
         f.endswith(".M.use(Sub)") and t.endswith(".Base.resolve(int)") for f, t in calls
     ), "2-arg call wrongly bound to the 1-arg inherited overload"
+
+
+def test_same_arity_overload_binds_by_argument_type(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) Two overloads of the SAME arity (isX(Class) vs isX(String)) can't be told
+    # (H) apart by arg count; a call with a String-typed argument must bind to the
+    # (H) isX(String) overload (gson's isJavaType/isAndroidType String overloads).
+    root = temp_repo / "jovl3"
+    pkg = root / "com" / "example"
+    pkg.mkdir(parents=True)
+    (pkg / "M.java").write_text(
+        "package com.example;\n"
+        "public class M {\n"
+        "  static boolean isX(Class<?> c) { return false; }\n"
+        "  static boolean isX(String s) { return true; }\n"
+        "  static boolean use(String name) { return isX(name); }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="java")
+    calls = _calls(mock_ingestor)
+    assert any(
+        f.endswith(".M.use(String)") and t.endswith(".M.isX(String)") for f, t in calls
+    ), sorted(t for f, t in calls if "isX" in t)
+    assert not any(
+        f.endswith(".M.use(String)") and t.endswith(".M.isX(Class<?>)") for f, t in calls
+    ), "String-arg call wrongly bound to the Class overload"

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.257"
+version = "0.0.261"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Follow-up to the Java dead-code series (#658/#659/#660/#662). Fixes two more real resolution bugs found by tracing gson's residual dead-code; gson core 21 -> 19.

## Cast-expression receivers
A method call on a cast receiver `((T) x).m()` (gson's `((JsonTreeReader) in).nextJsonElement()`) was dropped: the Java call-info extractor ignored `parenthesized_expression`/`cast_expression` receivers, so `object` was null and the call fell to the unqualified path — which never finds a cross-file/sibling `T`. Fix: extract the cast's target type as the receiver so `m` resolves on `T`.

## Anonymous-class own-method calls
An unqualified call to an anonymous class's OWN (non-inherited) method — gson's `delegate().read()` where `delegate()` is defined in the same anon — didn't resolve, because those methods register as `Function` nodes and the module-wide fallback (`_resolve_static_or_local_method`) only considered `Method`/`Constructor`. Fix: include `Function` in that fallback's callable set (it is a last-resort scan after precise class/anon-base/enclosing lookups).

## Tests
`test_java_cast_receiver.py` (cross-file cast with a decoy) and `test_java_anon_method_caller_qn.py::test_anon_own_method_unqualified_call_resolves`.

Verified: gson 21 -> 19, full suite green (4462), no over-match regression from the Function inclusion.
