### PR TITLE
fix(audit): enforce zero dangling relationships across all language fixtures

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -103,6 +103,7 @@ PY_EXTENSIONS = (EXT_PY,)
 JS_EXTENSIONS = (EXT_JS, EXT_JSX)
 TS_EXTENSIONS = (EXT_TS,)
 TSX_EXTENSIONS = (EXT_TSX,)
+JS_TS_ALL_EXTENSIONS = (EXT_JS, EXT_JSX, EXT_TS, EXT_TSX)
 RS_EXTENSIONS = (EXT_RS,)
 GO_EXTENSIONS = (EXT_GO,)
 SCALA_EXTENSIONS = (EXT_SCALA, EXT_SC)
@@ -914,6 +915,13 @@ CPP_IMPORT_NODES = ("preproc_include", "template_function", "declaration")
 INDEX_INIT = "__init__"
 INDEX_INDEX = "index"
 INDEX_MOD = "mod"
+INDEX_LUA_INIT = "init"
+
+# (H) File stems whose module is importable through the CONTAINING directory's
+# (H) name: pkg/__init__.py, shared/index.js, utils/mod.rs, storage/init.lua.
+MODULE_INDEX_FILE_STEMS = frozenset(
+    {INDEX_INIT, INDEX_INDEX, INDEX_MOD, INDEX_LUA_INIT}
+)
 
 # (H) AST field names for name extraction
 NAME_FIELDS = ("identifier", "name", "id")
@@ -1321,6 +1329,14 @@ CYPHER_ALL_DEFINITION_QNS = (
     "OR n:Enum OR n:Type OR n:Union "
     "RETURN n.qualified_name AS qualified_name, head(labels(n)) AS label, "
     "n.is_property AS is_property, n.path AS path"
+)
+
+# (H) Module-level qns (plus C++20 module interfaces) for incremental runs:
+# (H) deferred import verification must count modules in UNCHANGED files as
+# (H) real targets, or editing one file would drop cross-file IMPORTS edges.
+CYPHER_ALL_MODULE_QNS = (
+    "MATCH (n) WHERE n:Module OR n:ModuleInterface "
+    "RETURN n.qualified_name AS qualified_name, head(labels(n)) AS label"
 )
 
 # (H) Inbound reference edges (from unchanged files) into symbols defined in one

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -1772,6 +1772,38 @@ JS_BUILTIN_TYPES: frozenset[str] = frozenset(
 )
 
 # (H) JavaScript built-in function patterns
+# (H) JS/TS runtime global classes usable as `extends` bases with no import.
+# (H) A base matching one of these that resolves to no first-party class is
+# (H) positively external (builtin.<Name>), not an unresolvable guess.
+JS_GLOBAL_CLASS_NAMES: frozenset[str] = frozenset(
+    {
+        "Error",
+        "TypeError",
+        "RangeError",
+        "SyntaxError",
+        "ReferenceError",
+        "EvalError",
+        "URIError",
+        "AggregateError",
+        "Object",
+        "Array",
+        "Function",
+        "Promise",
+        "Map",
+        "Set",
+        "WeakMap",
+        "WeakSet",
+        "Date",
+        "RegExp",
+        "ArrayBuffer",
+        "SharedArrayBuffer",
+        "DataView",
+        "EventTarget",
+        "Event",
+        "HTMLElement",
+    }
+)
+
 JS_BUILTIN_PATTERNS: frozenset[str] = frozenset(
     {
         "Object.create",

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -581,6 +581,16 @@ class GraphUpdater:
         if inherits:
             logger.info("Resolved {} deferred C++ inheritance bases", inherits)
 
+        # (H) Same reasoning for every other language: parents resolve against
+        # (H) the full registry (including rehydrated definitions), and an
+        # (H) unresolvable parent emits no edge instead of a phantom.
+        generic_inherits = self.factory.definition_processor.resolve_deferred_inherits()
+        if generic_inherits:
+            logger.info(
+                "Resolved {} deferred inheritance/implements parents",
+                generic_inherits,
+            )
+
         # (H) Last containment step: every node-registering pass above (deferred
         # (H) C++ methods, Go receivers, kept forward declarations) must finish
         # (H) before parent qns are verified against the registry.

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -469,6 +469,9 @@ class GraphUpdater:
         self.skipped_because_in_sync = False
         self._collected_dir_mtimes: DirMtimesCache = {}
         self._cpp_frontend_covered: frozenset[str] = frozenset()
+        # (H) Module qns read back from the graph on incremental runs; deferred
+        # (H) import verification counts them as real internal targets.
+        self._rehydrated_module_qns: set[str] = set()
 
         self.factory = ProcessorFactory(
             ingestor=self.ingestor,
@@ -591,6 +594,26 @@ class GraphUpdater:
                 generic_inherits,
             )
 
+        module_impls = (
+            self.factory.definition_processor.resolve_deferred_cpp_module_impls()
+        )
+        if module_impls:
+            logger.info("Resolved {} C++20 module implementation links", module_impls)
+
+        # (H) IMPORTS edges verify against every module qn this run produced
+        # (H) (files, inline modules, rehydrated unchanged files); an internal
+        # (H) target that resolves nowhere emits no edge.
+        known_module_qns = (
+            {str(qn) for qn in self.factory.definition_processor.module_qn_to_file_path}
+            | self.factory.definition_processor.declared_module_qns
+            | self._rehydrated_module_qns
+        )
+        imports_emitted = self.factory.import_processor.flush_deferred_import_edges(
+            known_module_qns
+        )
+        if imports_emitted:
+            logger.info("Emitted {} verified IMPORTS edges", imports_emitted)
+
         # (H) Last containment step: every node-registering pass above (deferred
         # (H) C++ methods, Go receivers, kept forward declarations) must finish
         # (H) before parent qns are verified against the registry.
@@ -646,6 +669,18 @@ class GraphUpdater:
             added += 1
         if added:
             logger.info(ls.REGISTRY_REHYDRATED, count=added)
+        # (H) Module qns from unchanged files: deferred import verification and
+        # (H) C++20 module-impl resolution must count them as real targets, or
+        # (H) an incremental run would drop edges a clean index emits.
+        for row in self.ingestor.fetch_all(cs.CYPHER_ALL_MODULE_QNS):
+            qn = row.get(cs.KEY_QUALIFIED_NAME)
+            label = row.get(cs.KEY_LABEL)
+            if not isinstance(qn, str) or not isinstance(label, str):
+                continue
+            if label == cs.NodeLabel.MODULE_INTERFACE.value:
+                self.factory.definition_processor.cpp_module_interfaces.add(qn)
+            else:
+                self._rehydrated_module_qns.add(qn)
         self._rehydrate_class_inheritance_from_graph()
 
     def _rehydrate_class_inheritance_from_graph(self) -> None:

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -462,6 +462,10 @@ IMP_CREATED_RELATIONSHIP = (
     "  Created IMPORTS relationship: {from_module} -> {to_module} (from {full_name})"
 )
 IMP_PARSE_FAILED = "Failed to parse imports in {module}: {error}"
+IMP_DROPPED_PHANTOM_TARGET = (
+    "  Dropped IMPORTS edge to unverifiable internal target: "
+    "{from_module} -> {to_module}"
+)
 IMP_IMPORT = "  Import: {local} -> {full}"
 IMP_ALIASED_IMPORT = "  Aliased import: {alias} -> {full}"
 IMP_WILDCARD_IMPORT = "  Wildcard import: * -> {module}"

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -14,9 +14,10 @@ from ..language_spec import LanguageSpec
 from ..parser_loader import COMBINED_FUNC_CLASS_QUERIES
 from ..services import IngestorProtocol
 from ..types_defs import (
-    CppFunctionLocation,
+    FunctionLocation,
     FunctionRegistryTrieProtocol,
     LanguageQueries,
+    NodeType,
 )
 from ..utils.path_utils import cached_relative_path
 from .call_resolver import CallResolver
@@ -162,7 +163,7 @@ class CallProcessor:
         "module_qn_to_file_path",
         "_path_to_module_qn",
         "cpp_out_of_class_methods",
-        "cpp_function_locations",
+        "function_locations",
         "_resolver",
         "_flow_param_names",
         "_flow_args",
@@ -183,8 +184,7 @@ class CallProcessor:
         interface_implementers: dict[str, set[str]] | None = None,
         module_qn_to_file_path: dict[str, Path] | None = None,
         cpp_out_of_class_methods: dict[tuple[str, int], tuple[str, str]] | None = None,
-        cpp_function_locations: dict[tuple[str, int], CppFunctionLocation]
-        | None = None,
+        function_locations: dict[tuple[str, int], FunctionLocation] | None = None,
     ) -> None:
         self.ingestor = ingestor
         self.repo_path = repo_path
@@ -192,7 +192,7 @@ class CallProcessor:
         self.module_qn_to_file_path = module_qn_to_file_path or {}
         self._path_to_module_qn: dict[Path, str] | None = None
         self.cpp_out_of_class_methods = cpp_out_of_class_methods or {}
-        self.cpp_function_locations = cpp_function_locations or {}
+        self.function_locations = function_locations or {}
 
         self._resolver = CallResolver(
             function_registry=function_registry,
@@ -802,18 +802,26 @@ class CallProcessor:
                 )
             if not func_name:
                 continue
-            # (H) The definition pass records where every C++ function/method node
-            # (H) landed; reuse that qn/label instead of re-deriving them from the
-            # (H) AST -- the two walks diverge on preprocessor-distorted class
-            # (H) bodies and every divergence is a phantom caller (issue #652).
-            if language == cs.SupportedLanguage.CPP and (
-                loc := self._cpp_recorded_caller(func_node, module_qn)
-            ):
-                filtered = (
-                    self._filter_calls_in_node(all_call_nodes, call_starts, func_node)
-                    if all_call_nodes is not None and call_starts is not None
-                    else None
-                )
+            # (H) The definition pass records where every function/method node
+            # (H) landed; reuse that qn/label instead of re-deriving them from
+            # (H) the AST -- the walks diverge on preprocessor-distorted C++
+            # (H) class bodies, TS declaration merging, and duplicate-suffixed
+            # (H) qns, and every divergence is a phantom caller (issue #652).
+            if loc := self._recorded_caller(func_node, module_qn):
+                # (H) Same ownership rule as the unrecorded path: a Rust named
+                # (H) nested fn owns its body's calls, so the enclosing
+                # (H) function's slice must exclude it rather than take the
+                # (H) whole byte range.
+                if all_call_nodes is None or call_starts is None:
+                    filtered = None
+                elif language == cs.SupportedLanguage.RUST:
+                    filtered = self._calls_owned_by(
+                        func_node, owned_func_nodes, all_call_nodes, call_starts
+                    )
+                else:
+                    filtered = self._filter_calls_in_node(
+                        all_call_nodes, call_starts, func_node
+                    )
                 self._ingest_function_calls(
                     func_node,
                     loc.qualified_name,
@@ -937,12 +945,12 @@ class CallProcessor:
             return caller_qn, container_qn
         return None
 
-    def _cpp_recorded_caller(
+    def _recorded_caller(
         self, func_node: Node, module_qn: str
-    ) -> CppFunctionLocation | None:
+    ) -> FunctionLocation | None:
         # (H) The registry membership check guards incremental runs, where an
         # (H) unchanged file's locations were not re-recorded this run.
-        loc = self.cpp_function_locations.get((module_qn, func_node.start_point[0] + 1))
+        loc = self.function_locations.get((module_qn, func_node.start_point[0] + 1))
         if loc is not None and loc.qualified_name in self._resolver.function_registry:
             return loc
         return None
@@ -1051,12 +1059,11 @@ class CallProcessor:
             # (H) the method-dropping Class.nested) and label a nested function
             # (H) FUNCTION, so the CALLS edge joins the real node.
             class_context = class_qn
-            if language == cs.SupportedLanguage.CPP and (
-                loc := self._cpp_recorded_caller(method_node, module_qn)
-            ):
+            if loc := self._recorded_caller(method_node, module_qn):
                 # (H) Reuse the definition pass's recorded qn/label; the class
                 # (H) walk's structural derivation diverges from it on
-                # (H) preprocessor-distorted class bodies (issue #652).
+                # (H) preprocessor-distorted C++ class bodies and on TS
+                # (H) declaration merging (issue #652).
                 caller_qn, caller_label = loc.qualified_name, loc.label
                 class_context = loc.container_qn or class_qn
             else:
@@ -1891,6 +1898,17 @@ class CallProcessor:
                 # (H) it does not (dataclass/NamedTuple/pydantic), INSTANTIATES is
                 # (H) the only edge.
                 for class_variant in resolver.function_registry.variants(callee_qn):
+                    # (H) A duplicate-suffixed variant may be a DIFFERENT kind
+                    # (H) of node (a merged TS namespace registers as a class,
+                    # (H) a colliding function as a Function); only class-typed
+                    # (H) variants are instantiable, and a mismatched label is
+                    # (H) a phantom the database drops (issue #652).
+                    if (
+                        class_variant != callee_qn
+                        and resolver.function_registry.get(class_variant)
+                        != NodeType.CLASS
+                    ):
+                        continue
                     ensure_rel(
                         caller_spec,
                         cs.RelationshipType.INSTANTIATES,
@@ -1917,6 +1935,15 @@ class CallProcessor:
                 callee_qn = init_qn
 
             for target_qn in resolver.function_registry.variants(callee_qn):
+                # (H) A duplicate-suffixed variant may be a DIFFERENT kind of
+                # (H) node (a TS namespace merged onto a function registers as
+                # (H) a class); only callable variants take a CALLS edge, and
+                # (H) emitting the primary's label onto a differently-typed
+                # (H) node is a phantom the database drops (issue #652).
+                if target_qn != callee_qn and resolver.function_registry.get(
+                    target_qn
+                ) not in (NodeType.FUNCTION, NodeType.METHOD):
+                    continue
                 ensure_rel(
                     caller_spec,
                     calls_rel,

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1903,11 +1903,8 @@ class CallProcessor:
                     # (H) a colliding function as a Function); only class-typed
                     # (H) variants are instantiable, and a mismatched label is
                     # (H) a phantom the database drops (issue #652).
-                    if (
-                        class_variant != callee_qn
-                        and resolver.function_registry.get(class_variant)
-                        != NodeType.CLASS
-                    ):
+                    variant_type = resolver.function_registry.get(class_variant)
+                    if variant_type is not None and variant_type != NodeType.CLASS:
                         continue
                     ensure_rel(
                         caller_spec,
@@ -1939,10 +1936,14 @@ class CallProcessor:
                 # (H) node (a TS namespace merged onto a function registers as
                 # (H) a class); only callable variants take a CALLS edge, and
                 # (H) emitting the primary's label onto a differently-typed
-                # (H) node is a phantom the database drops (issue #652).
-                if target_qn != callee_qn and resolver.function_registry.get(
-                    target_qn
-                ) not in (NodeType.FUNCTION, NodeType.METHOD):
+                # (H) node is a phantom the database drops (issue #652). An
+                # (H) unregistered target keeps its edge (resolver-derived
+                # (H) callees like an unwrapped fn.call base may not register).
+                target_type = resolver.function_registry.get(target_qn)
+                if target_type is not None and target_type not in (
+                    NodeType.FUNCTION,
+                    NodeType.METHOD,
+                ):
                     continue
                 ensure_rel(
                     caller_spec,

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1764,24 +1764,27 @@ class CallProcessor:
             # (H) A callee that resolved to a builtin (e.g. JS setTimeout(target))
             # (H) has no first-party body to follow into, so pass-through flow is
             # (H) pointless; but a first-party callback handed to it is still invoked,
-            # (H) so record a reference edge from this scope to keep it reachable. The
-            # (H) builtin call edge itself is still emitted by the normal path below.
-            callee_is_builtin = is_flow_lang and callee_qn.startswith(
-                _BUILTIN_QN_PREFIX
-            )
+            # (H) so record a reference edge from this scope to keep it reachable.
+            # (H) The synthetic builtin.* qn never has a node, so emitting a CALLS
+            # (H) edge to it would only mint a phantom the database drops (issue
+            # (H) #652: 485 across the fixture suite) -- mirror the C++ builtin
+            # (H) operator rule and emit no edge at all.
+            callee_is_builtin = callee_qn.startswith(_BUILTIN_QN_PREFIX)
             if callee_is_builtin:
-                self._ingest_argument_function_references(
-                    call_node,
-                    caller_spec,
-                    module_qn,
-                    local_var_types,
-                    class_context,
-                    resolve_func,
-                    ensure_rel,
-                    caller_qn,
-                )
+                if is_flow_lang:
+                    self._ingest_argument_function_references(
+                        call_node,
+                        caller_spec,
+                        module_qn,
+                        local_var_types,
+                        class_context,
+                        resolve_func,
+                        ensure_rel,
+                        caller_qn,
+                    )
+                continue
 
-            if is_flow_lang and not callee_is_builtin:
+            if is_flow_lang:
                 self._collect_callable_flow(
                     call_node,
                     callee_qn,

--- a/codebase_rag/parsers/class_ingest/cpp_modules.py
+++ b/codebase_rag/parsers/class_ingest/cpp_modules.py
@@ -23,19 +23,33 @@ def ingest_cpp_module_declarations(
     repo_path: Path,
     project_name: str,
     ingestor: IngestorProtocol,
+    module_interfaces: set[str],
+    deferred_impls: list[tuple[str, str]],
 ) -> None:
     module_declarations = _find_module_declarations(root_node)
 
     for _, decl_text in module_declarations:
         if decl_text.startswith(cs.CPP_EXPORT_MODULE_PREFIX):
             _process_export_module(
-                decl_text, module_qn, file_path, repo_path, project_name, ingestor
+                decl_text,
+                module_qn,
+                file_path,
+                repo_path,
+                project_name,
+                ingestor,
+                module_interfaces,
             )
         elif decl_text.startswith(cs.CPP_MODULE_PREFIX) and not decl_text.startswith(
             cs.CPP_MODULE_PRIVATE_PREFIX
         ):
             _process_module_implementation(
-                decl_text, module_qn, file_path, repo_path, project_name, ingestor
+                decl_text,
+                module_qn,
+                file_path,
+                repo_path,
+                project_name,
+                ingestor,
+                deferred_impls,
             )
 
 
@@ -67,6 +81,7 @@ def _process_export_module(
     repo_path: Path,
     project_name: str,
     ingestor: IngestorProtocol,
+    module_interfaces: set[str],
 ) -> None:
     parts = decl_text.split()
     if len(parts) < 3:
@@ -74,6 +89,7 @@ def _process_export_module(
 
     module_name = parts[2].rstrip(cs.CHAR_SEMICOLON)
     interface_qn = f"{project_name}.{module_name}"
+    module_interfaces.add(interface_qn)
 
     ingestor.ensure_node_batch(
         cs.NodeLabel.MODULE_INTERFACE,
@@ -102,6 +118,7 @@ def _process_module_implementation(
     repo_path: Path,
     project_name: str,
     ingestor: IngestorProtocol,
+    deferred_impls: list[tuple[str, str]],
 ) -> None:
     parts = decl_text.split()
     if len(parts) < 2:
@@ -128,12 +145,11 @@ def _process_module_implementation(
         (cs.NodeLabel.MODULE_IMPLEMENTATION, cs.KEY_QUALIFIED_NAME, impl_qn),
     )
 
+    # (H) The exporting file may not be parsed yet (or may not exist at all);
+    # (H) hold the IMPLEMENTS edge back until every ModuleInterface is known,
+    # (H) so an implementation unit of an absent interface emits no phantom.
     interface_qn = f"{project_name}.{module_name}"
-    ingestor.ensure_relationship_batch(
-        (cs.NodeLabel.MODULE_IMPLEMENTATION, cs.KEY_QUALIFIED_NAME, impl_qn),
-        cs.RelationshipType.IMPLEMENTS,
-        (cs.NodeLabel.MODULE_INTERFACE, cs.KEY_QUALIFIED_NAME, interface_qn),
-    )
+    deferred_impls.append((impl_qn, interface_qn))
 
     logger.info(logs.CLASS_CPP_MODULE_IMPL.format(qn=impl_qn))
 

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -144,6 +144,9 @@ class ClassIngestMixin:
     _deferred_parent_links: list[DeferredParentLink]
     _deferred_cpp_inherits: list[DeferredCppInherit]
     _deferred_inherits: list[DeferredInherit]
+    cpp_module_interfaces: set[str]
+    _deferred_cpp_module_impls: list[tuple[str, str]]
+    declared_module_qns: set[str]
 
     def _namespace_qn(self, class_qn: str, module_qn: str) -> str:
         # (H) Strip the module-file prefix so two nodes for the same C++ type in
@@ -214,7 +217,32 @@ class ClassIngestMixin:
             self.repo_path,
             self.project_name,
             self.ingestor,
+            self.cpp_module_interfaces,
+            self._deferred_cpp_module_impls,
         )
+
+    def resolve_deferred_cpp_module_impls(self) -> int:
+        """Emit ModuleImplementation IMPLEMENTS edges for interfaces that exist.
+
+        An implementation unit (`module X;`) whose interface (`export module
+        X;`) lives in no parsed file has nothing real to point at; emitting
+        the edge anyway would mint a phantom the database drops.
+        """
+        deferred = self._deferred_cpp_module_impls
+        if not deferred:
+            return 0
+        self._deferred_cpp_module_impls = []
+        emitted = 0
+        for impl_qn, interface_qn in deferred:
+            if interface_qn not in self.cpp_module_interfaces:
+                continue
+            self.ingestor.ensure_relationship_batch(
+                (cs.NodeLabel.MODULE_IMPLEMENTATION, cs.KEY_QUALIFIED_NAME, impl_qn),
+                cs.RelationshipType.IMPLEMENTS,
+                (cs.NodeLabel.MODULE_INTERFACE, cs.KEY_QUALIFIED_NAME, interface_qn),
+            )
+            emitted += 1
+        return emitted
 
     def _find_cpp_exported_classes(self, root_node: Node) -> list[Node]:
         return cpp_modules.find_cpp_exported_classes(root_node)
@@ -869,6 +897,9 @@ class ClassIngestMixin:
                 )
             )
             self.ingestor.ensure_node_batch(cs.NodeLabel.MODULE, module_props)
+            # (H) Record the inline module qn so deferred import verification
+            # (H) counts it as a real internal target.
+            self.declared_module_qns.add(inline_module_qn)
 
             # (H) Link the inline module into the containment tree: its enclosing
             # (H) module (file module, or an outer mod) DEFINES it. Without this the

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -16,6 +16,7 @@ from ...types_defs import (
     ASTNode,
     CppFunctionLocation,
     DeferredCppInherit,
+    DeferredInherit,
     NodeType,
     PropertyDict,
 )
@@ -142,6 +143,7 @@ class ClassIngestMixin:
     _deferred_forward_decls: list[_DeferredForwardDecl]
     _deferred_parent_links: list[DeferredParentLink]
     _deferred_cpp_inherits: list[DeferredCppInherit]
+    _deferred_inherits: list[DeferredInherit]
 
     def _namespace_qn(self, class_qn: str, module_qn: str) -> str:
         # (H) Strip the module-file prefix so two nodes for the same C++ type in
@@ -357,6 +359,71 @@ class ClassIngestMixin:
             return entry.guess_qn
         return None
 
+    def resolve_deferred_inherits(self) -> int:
+        """Emit non-C++ INHERITS/IMPLEMENTS edges now that every class is registered.
+
+        A parent in a file parsed later resolves against the full registry; a
+        parent that resolves nowhere (java.lang.Exception, Rust Send/Sync)
+        emits no edge, because the module-anchored guess is a phantom endpoint
+        the database silently drops anyway. Resolved base qns replace the
+        guesses in class_inheritance in place so Pass-3 method resolution and
+        override detection walk the real hierarchy.
+        """
+        deferred = self._deferred_inherits
+        if not deferred:
+            return 0
+        self._deferred_inherits = []
+        emitted = 0
+        for entry in deferred:
+            child_type = self.function_registry.get(entry.child_qn)
+            if child_type is None:
+                continue
+            parent_qn = self._resolve_deferred_parent_qn(entry)
+            if parent_qn is None:
+                continue
+            if entry.rel_type == cs.RelationshipType.IMPLEMENTS:
+                rel.create_implements_relationship(
+                    str(child_type), entry.child_qn, parent_qn, self.ingestor
+                )
+                self.interface_implementers.setdefault(parent_qn, set()).add(
+                    entry.child_qn
+                )
+            else:
+                bases = self.class_inheritance.get(entry.child_qn)
+                if bases is not None and entry.base_index < len(bases):
+                    bases[entry.base_index] = parent_qn
+                rel.create_inheritance_relationship(
+                    str(child_type),
+                    entry.child_qn,
+                    parent_qn,
+                    self.function_registry,
+                    self.ingestor,
+                    entry.base_index,
+                )
+            emitted += 1
+        return emitted
+
+    def _resolve_deferred_parent_qn(self, entry: DeferredInherit) -> str | None:
+        if self.function_registry.get(entry.parent_qn) is not None:
+            return entry.parent_qn
+        # (H) Only the module-anchored fallback shape is re-resolvable: its raw
+        # (H) written name is the remainder after the module qn. Anything else
+        # (H) (an import-mapped external qn) has no first-party node to target.
+        prefix = f"{entry.module_qn}{cs.SEPARATOR_DOT}"
+        if not entry.parent_qn.startswith(prefix):
+            return None
+        raw_name = entry.parent_qn[len(prefix) :]
+        resolved = self._resolve_class_name(raw_name, entry.module_qn)
+        if (
+            resolved is None
+            # (H) A simple-name sweep can land on the child itself; a
+            # (H) self-INHERITS is never real.
+            or resolved == entry.child_qn
+            or self.function_registry.get(resolved) is None
+        ):
+            return None
+        return resolved
+
     def _process_class_node(
         self,
         class_node: Node,
@@ -511,6 +578,7 @@ class ClassIngestMixin:
             self.function_registry,
             self.interface_implementers,
             defer_cpp_inherits=self._deferred_cpp_inherits,
+            defer_inherits=self._deferred_inherits,
         )
         if language == cs.SupportedLanguage.CPP:
             # (H) Record this class's member-field types now (from the class body,
@@ -575,17 +643,19 @@ class ClassIngestMixin:
         # (H) node label may be Class/Enum/Type, so match the relationship source
         # (H) to its registered label (else the IMPLEMENTS edge never resolves).
         if trait_name := rs_utils.extract_impl_trait(class_node):
-            owner_type = self.function_registry.get(class_qn)
-            owner_label = (
-                cs.NodeLabel(owner_type.value)
-                if owner_type is not None
-                else cs.NodeLabel.CLASS
-            )
             trait_qn = self._resolve_to_qn(trait_name, owner_module_qn)
-            self.ingestor.ensure_relationship_batch(
-                (owner_label, cs.KEY_QUALIFIED_NAME, class_qn),
-                cs.RelationshipType.IMPLEMENTS,
-                (cs.NodeLabel.INTERFACE, cs.KEY_QUALIFIED_NAME, trait_qn),
+            # (H) The trait (or the impl target) may live in a file not yet
+            # (H) parsed; hold the IMPLEMENTS edge back for
+            # (H) resolve_deferred_inherits so an unresolvable trait
+            # (H) (std::fmt::Display) emits no phantom edge.
+            self._deferred_inherits.append(
+                DeferredInherit(
+                    rel_type=cs.RelationshipType.IMPLEMENTS,
+                    child_qn=class_qn,
+                    parent_qn=trait_qn,
+                    module_qn=owner_module_qn,
+                    base_index=0,
+                )
             )
             # (H) Record the implementer so a Rust trait call to the sole concrete
             # (H) impl redirects, matching the class-declaration IMPLEMENTS path.

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -14,9 +14,9 @@ from ...config import settings
 from ...language_spec import LanguageSpec
 from ...types_defs import (
     ASTNode,
-    CppFunctionLocation,
     DeferredCppInherit,
     DeferredInherit,
+    FunctionLocation,
     NodeType,
     PropertyDict,
 )
@@ -139,7 +139,7 @@ class ClassIngestMixin:
     class_field_guard_inner: dict[str, dict[str, str]]
     method_return_types: dict[str, str]
     interface_implementers: dict[str, set[str]]
-    cpp_function_locations: dict[tuple[str, int], CppFunctionLocation]
+    function_locations: dict[tuple[str, int], FunctionLocation]
     _deferred_forward_decls: list[_DeferredForwardDecl]
     _deferred_parent_links: list[DeferredParentLink]
     _deferred_cpp_inherits: list[DeferredCppInherit]
@@ -858,18 +858,20 @@ class ClassIngestMixin:
                 self.java_anon_overrides.append(
                     (ingested_qn, method_name, base, module_qn)
                 )
-            if language == cs.SupportedLanguage.CPP:
-                # (H) Record where this method landed so Pass-3 call attribution
-                # (H) reuses the registered qn/label instead of re-deriving them
-                # (H) (the walks diverge on preprocessor-distorted class bodies).
-                if ingested_qn is not None and module_qn is not None:
-                    self.cpp_function_locations[
-                        (module_qn, method_node.start_point[0] + 1)
-                    ] = CppFunctionLocation(
+            # (H) Record where this method landed so Pass-3 call attribution
+            # (H) reuses the registered qn/label instead of re-deriving them.
+            # (H) The walks diverge on preprocessor-distorted C++ class bodies
+            # (H) and on TS declaration merging, where the member registers
+            # (H) under the namespace's duplicate-suffixed qn (issue #652).
+            if ingested_qn is not None and module_qn is not None:
+                self.function_locations[(module_qn, method_node.start_point[0] + 1)] = (
+                    FunctionLocation(
                         label=cs.NodeLabel.METHOD.value,
                         qualified_name=ingested_qn,
                         container_qn=class_qn,
                     )
+                )
+            if language == cs.SupportedLanguage.CPP:
                 # (H) Record a C++ method's return type so a chained call off a
                 # (H) static factory method (`parser(...).parse(...)`, nlohmann's
                 # (H) basic_json) can type the receiver and resolve the next hop.

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -406,12 +406,23 @@ class ClassIngestMixin:
             child_type = self.function_registry.get(entry.child_qn)
             if child_type is None:
                 continue
-            parent_qn = self._resolve_deferred_parent_qn(entry)
-            if parent_qn is None:
+            resolved = self._resolve_deferred_parent_qn(entry)
+            if resolved is None:
                 continue
+            parent_qn, is_external = resolved
+            external_label: str | None = None
+            if is_external:
+                # (H) The import pass mints the same node for IMPORTS edges, so
+                # (H) this MERGEs idempotently when the base was imported.
+                self.import_processor.ensure_external_module_node(parent_qn)
+                external_label = cs.NodeLabel.EXTERNAL_MODULE.value
             if entry.rel_type == cs.RelationshipType.IMPLEMENTS:
                 rel.create_implements_relationship(
-                    str(child_type), entry.child_qn, parent_qn, self.ingestor
+                    str(child_type),
+                    entry.child_qn,
+                    parent_qn,
+                    self.ingestor,
+                    interface_label=external_label,
                 )
                 self.interface_implementers.setdefault(parent_qn, set()).add(
                     entry.child_qn
@@ -427,30 +438,50 @@ class ClassIngestMixin:
                     self.function_registry,
                     self.ingestor,
                     entry.base_index,
+                    parent_label=external_label,
                 )
             emitted += 1
         return emitted
 
-    def _resolve_deferred_parent_qn(self, entry: DeferredInherit) -> str | None:
+    def _resolve_deferred_parent_qn(
+        self, entry: DeferredInherit
+    ) -> tuple[str, bool] | None:
+        """Resolve a deferred parent to (qn, is_external), or None for no edge.
+
+        First-party wins; a qn outside the project prefix is positive external
+        knowledge (import-mapped or ::-qualified) and keeps its edge onto an
+        ExternalModule node; a module-anchored GUESS that re-resolves nowhere
+        emits nothing, except a JS/TS global (Error) which is externalized.
+        """
         if self.function_registry.get(entry.parent_qn) is not None:
-            return entry.parent_qn
-        # (H) Only the module-anchored fallback shape is re-resolvable: its raw
-        # (H) written name is the remainder after the module qn. Anything else
-        # (H) (an import-mapped external qn) has no first-party node to target.
+            return entry.parent_qn, False
+        project_prefix = f"{self.project_name}{cs.SEPARATOR_DOT}"
+        if not entry.parent_qn.startswith(project_prefix):
+            external = entry.parent_qn.replace(
+                cs.SEPARATOR_DOUBLE_COLON, cs.SEPARATOR_DOT
+            )
+            return external, True
+        # (H) The module-anchored fallback shape is re-resolvable: its raw
+        # (H) written name is the remainder after the module qn.
         prefix = f"{entry.module_qn}{cs.SEPARATOR_DOT}"
         if not entry.parent_qn.startswith(prefix):
             return None
         raw_name = entry.parent_qn[len(prefix) :]
         resolved = self._resolve_class_name(raw_name, entry.module_qn)
         if (
-            resolved is None
+            resolved is not None
             # (H) A simple-name sweep can land on the child itself; a
             # (H) self-INHERITS is never real.
-            or resolved == entry.child_qn
-            or self.function_registry.get(resolved) is None
+            and resolved != entry.child_qn
+            and self.function_registry.get(resolved) is not None
         ):
-            return None
-        return resolved
+            return resolved, False
+        if (
+            entry.language in cs.JS_TS_LANGUAGES
+            and raw_name in cs.JS_GLOBAL_CLASS_NAMES
+        ):
+            return f"{cs.BUILTIN_PREFIX}{cs.SEPARATOR_DOT}{raw_name}", True
+        return None
 
     def _process_class_node(
         self,
@@ -683,6 +714,7 @@ class ClassIngestMixin:
                     parent_qn=trait_qn,
                     module_qn=owner_module_qn,
                     base_index=0,
+                    language=cs.SupportedLanguage.RUST,
                 )
             )
             # (H) Record the implementer so a Rust trait call to the sole concrete

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -453,7 +453,13 @@ class ClassIngestMixin:
         ExternalModule node; a module-anchored GUESS that re-resolves nowhere
         emits nothing, except a JS/TS global (Error) which is externalized.
         """
-        if self.function_registry.get(entry.parent_qn) is not None:
+        if (
+            # (H) Parse-time resolution of a nested external base (`Entry
+            # (H) implements Map.Entry`) can land on the child ITSELF (the only
+            # (H) registered qn ending in Entry); a self-edge is never real.
+            entry.parent_qn != entry.child_qn
+            and self.function_registry.get(entry.parent_qn) is not None
+        ):
             return entry.parent_qn, False
         project_prefix = f"{self.project_name}{cs.SEPARATOR_DOT}"
         if not entry.parent_qn.startswith(project_prefix):

--- a/codebase_rag/parsers/class_ingest/relationships.py
+++ b/codebase_rag/parsers/class_ingest/relationships.py
@@ -85,6 +85,7 @@ def create_class_relationships(
                     parent_qn=parent_class_qn,
                     module_qn=module_qn,
                     base_index=base_index,
+                    language=language,
                 )
             )
     else:
@@ -112,6 +113,7 @@ def create_class_relationships(
                         parent_qn=interface_qn,
                         module_qn=module_qn,
                         base_index=0,
+                        language=language,
                     )
                 )
             else:
@@ -139,8 +141,11 @@ def create_inheritance_relationship(
     function_registry: FunctionRegistryTrieProtocol,
     ingestor: IngestorProtocol,
     base_index: int = 0,
+    parent_label: str | None = None,
 ) -> None:
-    parent_type = get_node_type_for_inheritance(parent_qn, function_registry)
+    parent_type = parent_label or get_node_type_for_inheritance(
+        parent_qn, function_registry
+    )
     # (H) Persist the base's position in the child's base list. An incremental run
     # (H) rehydrates class_inheritance from these edges; ordering by base_index
     # (H) restores the original source order, which method resolution (Pass 3) and
@@ -158,9 +163,14 @@ def create_implements_relationship(
     class_qn: str,
     interface_qn: str,
     ingestor: IngestorProtocol,
+    interface_label: str | None = None,
 ) -> None:
     ingestor.ensure_relationship_batch(
         (class_type, cs.KEY_QUALIFIED_NAME, class_qn),
         cs.RelationshipType.IMPLEMENTS,
-        (cs.NodeLabel.INTERFACE, cs.KEY_QUALIFIED_NAME, interface_qn),
+        (
+            interface_label or cs.NodeLabel.INTERFACE,
+            cs.KEY_QUALIFIED_NAME,
+            interface_qn,
+        ),
     )

--- a/codebase_rag/parsers/class_ingest/relationships.py
+++ b/codebase_rag/parsers/class_ingest/relationships.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 from tree_sitter import Node
 
 from ... import constants as cs
-from ...types_defs import DeferredCppInherit, NodeType
+from ...types_defs import DeferredCppInherit, DeferredInherit, NodeType
 from ..cpp import utils as cpp_utils
 from . import parent_extraction as pe
 
@@ -30,6 +30,7 @@ def create_class_relationships(
     function_registry: FunctionRegistryTrieProtocol,
     interface_implementers: dict[str, set[str]] | None = None,
     defer_cpp_inherits: list[DeferredCppInherit] | None = None,
+    defer_inherits: list[DeferredInherit] | None = None,
 ) -> None:
     cpp_bases: list[tuple[str, str]] | None = None
     if class_node.type in cs.CPP_CLASS_TYPES:
@@ -71,6 +72,21 @@ def create_class_relationships(
                     base_index=base_index,
                 )
             )
+    elif defer_inherits is not None:
+        # (H) A non-C++ parent may live in a file not yet parsed, in which case
+        # (H) the qn above is only the module-anchored fallback guess; hold the
+        # (H) edge back for resolve_deferred_inherits so it is re-resolved
+        # (H) against the full registry (an unresolvable parent emits no edge).
+        for base_index, parent_class_qn in enumerate(parent_classes):
+            defer_inherits.append(
+                DeferredInherit(
+                    rel_type=cs.RelationshipType.INHERITS,
+                    child_qn=class_qn,
+                    parent_qn=parent_class_qn,
+                    module_qn=module_qn,
+                    base_index=base_index,
+                )
+            )
     else:
         for base_index, parent_class_qn in enumerate(parent_classes):
             create_inheritance_relationship(
@@ -88,7 +104,20 @@ def create_class_relationships(
         for interface_qn in pe.extract_implemented_interfaces(
             class_node, module_qn, resolve_to_qn
         ):
-            create_implements_relationship(node_type, class_qn, interface_qn, ingestor)
+            if defer_inherits is not None:
+                defer_inherits.append(
+                    DeferredInherit(
+                        rel_type=cs.RelationshipType.IMPLEMENTS,
+                        child_qn=class_qn,
+                        parent_qn=interface_qn,
+                        module_qn=module_qn,
+                        base_index=0,
+                    )
+                )
+            else:
+                create_implements_relationship(
+                    node_type, class_qn, interface_qn, ingestor
+                )
             # (H) Record implementers so the resolver can dispatch an interface-typed
             # (H) call to the concrete method when the interface has exactly one impl.
             if interface_implementers is not None:

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -110,6 +110,14 @@ class DefinitionProcessor(
         # (H) Non-C++ INHERITS/IMPLEMENTS held back until every class is
         # (H) registered; resolve_deferred_inherits re-resolves the guesses.
         self._deferred_inherits: list[DeferredInherit] = []
+        # (H) C++20 module interfaces declared this run (export module X), and
+        # (H) implementation units whose IMPLEMENTS edge waits for its
+        # (H) interface to be known.
+        self.cpp_module_interfaces: set[str] = set()
+        self._deferred_cpp_module_impls: list[tuple[str, str]] = []
+        # (H) Inline (non-file) module qns, e.g. Rust `mod x {}`; deferred
+        # (H) import verification counts them as real internal targets.
+        self.declared_module_qns: set[str] = set()
         # (H) {qn: file path} for definitions rehydrated from the graph on an
         # (H) incremental run, whose modules are absent from module_qn_to_file_path
         # (H) (only re-parsed files populate it). _is_cpp_defined falls back to

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -13,6 +13,7 @@ from ..types_defs import (
     ASTNode,
     CppFunctionLocation,
     DeferredCppInherit,
+    DeferredInherit,
     FunctionRegistryTrieProtocol,
     SimpleNameLookup,
 )
@@ -106,6 +107,9 @@ class DefinitionProcessor(
         # (H) (the walks diverge on preprocessor-distorted class bodies).
         self.cpp_function_locations: dict[tuple[str, int], CppFunctionLocation] = {}
         self._deferred_cpp_inherits: list[DeferredCppInherit] = []
+        # (H) Non-C++ INHERITS/IMPLEMENTS held back until every class is
+        # (H) registered; resolve_deferred_inherits re-resolves the guesses.
+        self._deferred_inherits: list[DeferredInherit] = []
         # (H) {qn: file path} for definitions rehydrated from the graph on an
         # (H) incremental run, whose modules are absent from module_qn_to_file_path
         # (H) (only re-parsed files populate it). _is_cpp_defined falls back to

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -11,9 +11,9 @@ from .. import logs as ls
 from ..parser_loader import COMBINED_FUNC_CLASS_IMPORT_QUERIES
 from ..types_defs import (
     ASTNode,
-    CppFunctionLocation,
     DeferredCppInherit,
     DeferredInherit,
+    FunctionLocation,
     FunctionRegistryTrieProtocol,
     SimpleNameLookup,
 )
@@ -105,7 +105,7 @@ class DefinitionProcessor(
         # (H) method node Pass 2 registered, so Pass-3 caller attribution reuses
         # (H) the registered label/qn instead of re-deriving them structurally
         # (H) (the walks diverge on preprocessor-distorted class bodies).
-        self.cpp_function_locations: dict[tuple[str, int], CppFunctionLocation] = {}
+        self.function_locations: dict[tuple[str, int], FunctionLocation] = {}
         self._deferred_cpp_inherits: list[DeferredCppInherit] = []
         # (H) Non-C++ INHERITS/IMPLEMENTS held back until every class is
         # (H) registered; resolve_deferred_inherits re-resolves the guesses.

--- a/codebase_rag/parsers/factory.py
+++ b/codebase_rag/parsers/factory.py
@@ -139,6 +139,6 @@ class ProcessorFactory:
                 interface_implementers=self.definition_processor.interface_implementers,
                 module_qn_to_file_path=self.module_qn_to_file_path,
                 cpp_out_of_class_methods=self.definition_processor.cpp_out_of_class_methods,
-                cpp_function_locations=self.definition_processor.cpp_function_locations,
+                function_locations=self.definition_processor.function_locations,
             )
         return self._call_processor

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -12,9 +12,9 @@ from .. import logs as ls
 from ..language_spec import LANGUAGE_FQN_SPECS, LanguageSpec
 from ..types_defs import (
     ASTNode,
-    CppFunctionLocation,
     DeferredCppInherit,
     DeferredParentLink,
+    FunctionLocation,
     FunctionRegistryTrieProtocol,
     NodeType,
     PropertyDict,
@@ -139,7 +139,7 @@ class FunctionIngestMixin:
     _deferred_parent_links: list[DeferredParentLink]
     method_return_types: dict[str, str]
     cpp_out_of_class_methods: dict[tuple[str, int], tuple[str, str]]
-    cpp_function_locations: dict[tuple[str, int], CppFunctionLocation]
+    function_locations: dict[tuple[str, int], FunctionLocation]
     class_inheritance: dict[str, list[str]]
     _deferred_cpp_inherits: list[DeferredCppInherit]
     rehydrated_definition_paths: dict[str, str]
@@ -382,7 +382,7 @@ class FunctionIngestMixin:
                 bound_qn = f"{class_qn}{cs.SEPARATOR_DOT}{bound_name}"
                 location = (module_qn, func_node.start_point[0] + 1)
                 self.cpp_out_of_class_methods[location] = (bound_qn, class_qn)
-                self.cpp_function_locations[location] = CppFunctionLocation(
+                self.function_locations[location] = FunctionLocation(
                     label=cs.NodeLabel.METHOD.value,
                     qualified_name=bound_qn,
                     container_qn=class_qn,
@@ -464,8 +464,8 @@ class FunctionIngestMixin:
                 method_qn,
                 class_qn,
             )
-            self.cpp_function_locations[(entry.module_qn, entry.start_line)] = (
-                CppFunctionLocation(
+            self.function_locations[(entry.module_qn, entry.start_line)] = (
+                FunctionLocation(
                     label=cs.NodeLabel.METHOD.value,
                     qualified_name=method_qn,
                     container_qn=class_qn,
@@ -671,24 +671,24 @@ class FunctionIngestMixin:
         )
         if resolution.name:
             self.simple_name_lookup[resolution.name].add(resolution.qualified_name)
+        # (H) Record where this function landed so Pass-3 call attribution
+        # (H) reuses the registered qn/label instead of re-deriving them (for
+        # (H) every language: C++ preprocessor distortion, TS declaration
+        # (H) merging, and duplicate-suffixed qns all make the walks diverge).
+        location = FunctionLocation(
+            label=cs.NodeLabel.FUNCTION.value,
+            qualified_name=resolution.qualified_name,
+            container_qn=None,
+        )
+        self.function_locations[(module_qn, func_node.start_point[0] + 1)] = location
         if language == cs.SupportedLanguage.CPP:
-            # (H) Record where this function landed so Pass-3 call attribution
-            # (H) reuses the registered qn/label instead of re-deriving them.
-            location = CppFunctionLocation(
-                label=cs.NodeLabel.FUNCTION.value,
-                qualified_name=resolution.qualified_name,
-                container_qn=None,
-            )
-            self.cpp_function_locations[(module_qn, func_node.start_point[0] + 1)] = (
-                location
-            )
             # (H) A template wrapper's body walk in Pass 3 visits the INNER
             # (H) definition (it starts on its own line), so record that line
             # (H) against the wrapper's node too.
             if func_node.type == cs.CppNodeType.TEMPLATE_DECLARATION:
                 for child in func_node.children:
                     if child.type == cs.CppNodeType.FUNCTION_DEFINITION:
-                        self.cpp_function_locations[
+                        self.function_locations[
                             (module_qn, child.start_point[0] + 1)
                         ] = location
                         break

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -388,6 +388,18 @@ class ImportProcessor:
         except Exception as e:
             logger.warning(ls.IMP_PARSE_FAILED, module=module_qn, error=e)
 
+    def defer_import_edge(
+        self, module_qn: str, full_name: str, language: cs.SupportedLanguage
+    ) -> None:
+        # (H) Entry point for import shapes discovered outside parse_imports
+        # (H) (the CommonJS destructuring fallback); every IMPORTS edge must go
+        # (H) through the same deferred verification.
+        self._deferred_import_edges.append(
+            DeferredImportEdge(
+                module_qn=module_qn, full_name=full_name, language=language
+            )
+        )
+
     def flush_deferred_import_edges(self, known_module_qns: set[str]) -> int:
         """Emit IMPORTS edges now that every file is parsed.
 

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -896,20 +896,22 @@ class ImportProcessor:
 
     @staticmethod
     def _strip_js_extension(import_path: str) -> str:
-        # (H) ESM specifiers may carry an explicit extension (`./b.js`); the
-        # (H) module qn never does, so keeping it poisons the import map AND
-        # (H) the IMPORTS edge with a phantom `.js` segment (issue #652).
+        # (H) An ESM RELATIVE specifier may carry an explicit extension
+        # (H) (`./b.js`); the module qn never does, so keeping it poisons the
+        # (H) import map AND the IMPORTS edge with a phantom `.js` segment
+        # (H) (issue #652). Bare package specifiers are exempt: a package can
+        # (H) legitimately be NAMED with the extension (p5.js, highlight.js).
         for ext in cs.JS_TS_ALL_EXTENSIONS:
             if import_path.endswith(ext) and len(import_path) > len(ext):
                 return import_path[: -len(ext)]
         return import_path
 
     def _resolve_js_module_path(self, import_path: str, current_module: str) -> str:
-        import_path = self._strip_js_extension(import_path)
         if not import_path.startswith(cs.PATH_CURRENT_DIR):
             if aliased := self._ts_alias_module_qn(import_path):
                 return aliased
             return import_path.replace(cs.SEPARATOR_SLASH, cs.SEPARATOR_DOT)
+        import_path = self._strip_js_extension(import_path)
 
         current_parts = current_module.split(cs.SEPARATOR_DOT)[:-1]
         import_parts = import_path.split(cs.SEPARATOR_SLASH)

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -604,6 +604,12 @@ class ImportProcessor:
             return cs.NodeLabel.MODULE
         return cs.NodeLabel.EXTERNAL_MODULE
 
+    def ensure_external_module_node(self, module_path: str) -> None:
+        # (H) Public entry for non-import callers (deferred inheritance): an
+        # (H) external base keeps its edge by targeting the same ExternalModule
+        # (H) node an import of it would mint.
+        self._ensure_external_module_node(module_path, module_path)
+
     def _ensure_external_module_node(self, module_path: str, full_name: str) -> None:
         if not self.ingestor or not module_path:
             return

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -12,7 +12,11 @@ from .. import constants as cs
 from .. import logs as ls
 from ..language_spec import LanguageSpec
 from ..services import IngestorProtocol
-from ..types_defs import FunctionRegistryTrieProtocol, LanguageQueries
+from ..types_defs import (
+    DeferredImportEdge,
+    FunctionRegistryTrieProtocol,
+    LanguageQueries,
+)
 from .cpp_frontend.qn import build_module_qn_map
 from .go import discover_go_module_paths, resolve_go_import_path
 from .lua import utils as lua_utils
@@ -185,6 +189,8 @@ class ImportProcessor:
         "_map_go_import_path",
         "_cpp_module_qn_map",
         "_cpp_qn_to_rel",
+        "_deferred_import_edges",
+        "_cpp_declaration_mappings",
     )
 
     def __init__(
@@ -203,6 +209,14 @@ class ImportProcessor:
         # (H) C++ include so non-C++ projects never pay for it.
         self._cpp_module_qn_map: dict[str, str] | None = None
         self._cpp_qn_to_rel: dict[str, str] = {}
+        # (H) IMPORTS edges held back until every file is parsed, so internal
+        # (H) targets verify against the full module registry (issue #652).
+        self._deferred_import_edges: list[DeferredImportEdge] = []
+        # (H) Import-map entries registered by C++20 module DECLARATIONS
+        # (H) (`module X;`, `export module X;`, `import :partition;`). They
+        # (H) exist for name resolution only; a declaration is not an import,
+        # (H) so no IMPORTS edge may be emitted for them.
+        self._cpp_declaration_mappings: set[tuple[str, str]] = set()
         # (H) Local names brought in by a PHP `use function A\B\c` import, keyed by
         # (H) module. A PHP namespace path never matches cgr's file-path qualified
         # (H) name (a global helper declares `namespace Illuminate\Support` from
@@ -357,39 +371,138 @@ class ImportProcessor:
             )
 
             if self.ingestor:
+                # (H) Hold the edges back: an internal target is only real if
+                # (H) some file yields that module qn, which is known only after
+                # (H) every file is parsed (flush_deferred_import_edges).
                 for full_name in self.import_mapping[module_qn].values():
-                    module_path = self._resolve_module_path(
-                        full_name, module_qn, language
-                    )
-
-                    target_label = self._module_label(module_path)
-                    # (H) An external import target has no file pass to create its
-                    # (H) node; without one here the IMPORTS edge MERGEs against
-                    # (H) nothing and is silently dropped (issue #652).
-                    if target_label == cs.NodeLabel.EXTERNAL_MODULE:
-                        self._ensure_external_module_node(module_path, full_name)
-                    self.ingestor.ensure_relationship_batch(
-                        (
-                            cs.NodeLabel.MODULE,
-                            cs.KEY_QUALIFIED_NAME,
-                            module_qn,
-                        ),
-                        cs.RelationshipType.IMPORTS,
-                        (
-                            target_label,
-                            cs.KEY_QUALIFIED_NAME,
-                            module_path,
-                        ),
-                    )
-                    logger.debug(
-                        ls.IMP_CREATED_RELATIONSHIP,
-                        from_module=module_qn,
-                        to_module=module_path,
-                        full_name=full_name,
+                    if (module_qn, full_name) in self._cpp_declaration_mappings:
+                        continue
+                    self._deferred_import_edges.append(
+                        DeferredImportEdge(
+                            module_qn=module_qn,
+                            full_name=full_name,
+                            language=language,
+                        )
                     )
 
         except Exception as e:
             logger.warning(ls.IMP_PARSE_FAILED, module=module_qn, error=e)
+
+    def flush_deferred_import_edges(self, known_module_qns: set[str]) -> int:
+        """Emit IMPORTS edges now that every file is parsed.
+
+        An external target gets its ExternalModule node as before. An internal
+        target must verify against the real module qns; a guess that resolves
+        nowhere (a broken import, a directory with no index module, a crate
+        path resolved from the wrong root) emits no edge, because the phantom
+        endpoint is silently dropped by the database anyway.
+        """
+        deferred = self._deferred_import_edges
+        if not deferred or self.ingestor is None:
+            return 0
+        self._deferred_import_edges = []
+        module_aliases = self._module_alias_map(known_module_qns)
+        emitted = 0
+        for entry in deferred:
+            module_path = self._resolve_module_path(
+                entry.full_name, entry.module_qn, entry.language
+            )
+            target_label = self._module_label(module_path)
+            if target_label == cs.NodeLabel.EXTERNAL_MODULE:
+                # (H) An external import target has no file pass to create its
+                # (H) node; without one here the IMPORTS edge MERGEs against
+                # (H) nothing and is silently dropped (issue #652).
+                self._ensure_external_module_node(module_path, entry.full_name)
+            else:
+                verified = self._verify_internal_import_target(
+                    module_path, known_module_qns, module_aliases
+                )
+                if verified is None and entry.language == cs.SupportedLanguage.PYTHON:
+                    # (H) A package-anchored guess that names no sibling module
+                    # (H) is an ABSOLUTE import in Python semantics (`import
+                    # (H) sys` inside a package); re-resolve it as one.
+                    if absolute := self._python_absolute_fallback(
+                        module_path, entry.module_qn
+                    ):
+                        self._ensure_external_module_node(absolute, entry.full_name)
+                        target_label = cs.NodeLabel.EXTERNAL_MODULE
+                        verified = absolute
+                if verified is None:
+                    logger.debug(
+                        ls.IMP_DROPPED_PHANTOM_TARGET,
+                        from_module=entry.module_qn,
+                        to_module=module_path,
+                    )
+                    continue
+                module_path = verified
+            self.ingestor.ensure_relationship_batch(
+                (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, entry.module_qn),
+                cs.RelationshipType.IMPORTS,
+                (target_label, cs.KEY_QUALIFIED_NAME, module_path),
+            )
+            emitted += 1
+            logger.debug(
+                ls.IMP_CREATED_RELATIONSHIP,
+                from_module=entry.module_qn,
+                to_module=module_path,
+                full_name=entry.full_name,
+            )
+        return emitted
+
+    def _module_alias_map(self, known_module_qns: set[str]) -> dict[str, str]:
+        # (H) A module reached through its container's name: pkg/__init__.py,
+        # (H) shared/index.js, utils/mod.rs. Importers write the container qn;
+        # (H) the real Module node lives at the index-file leaf.
+        aliases: dict[str, str] = {}
+        for qn in known_module_qns:
+            base, _, leaf = qn.rpartition(cs.SEPARATOR_DOT)
+            if base and leaf in cs.MODULE_INDEX_FILE_STEMS:
+                aliases[base] = qn
+        return aliases
+
+    def _python_absolute_fallback(self, module_path: str, module_qn: str) -> str | None:
+        package_qn = module_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
+        prefix = f"{package_qn}{cs.SEPARATOR_DOT}"
+        if not module_path.startswith(prefix):
+            return None
+        written = module_path[len(prefix) :]
+        if not written:
+            return None
+        absolute = self.stdlib_extractor.extract_module_path(
+            written, cs.SupportedLanguage.PYTHON
+        )
+        project_prefix = f"{self.project_name}{cs.SEPARATOR_DOT}"
+        if not absolute or absolute.startswith(project_prefix):
+            return None
+        return absolute
+
+    def _verify_internal_import_target(
+        self,
+        module_path: str,
+        known_module_qns: set[str],
+        module_aliases: dict[str, str],
+    ) -> str | None:
+        if module_path in known_module_qns:
+            return module_path
+        if alias := module_aliases.get(module_path):
+            return alias
+        # (H) A path resolved from the wrong root (`use crate::utils` written
+        # (H) outside src/) still names a unique real module; a whole-segment
+        # (H) suffix match recovers it. Ambiguity means no edge, not a guess.
+        prefix = f"{self.project_name}{cs.SEPARATOR_DOT}"
+        if not module_path.startswith(prefix):
+            return None
+        tail = module_path[len(prefix) :]
+        if not tail:
+            return None
+        suffix = f"{cs.SEPARATOR_DOT}{tail}"
+        matches = {qn for qn in known_module_qns if qn.endswith(suffix)}
+        matches.update(
+            real for base, real in module_aliases.items() if base.endswith(suffix)
+        )
+        if len(matches) == 1:
+            return matches.pop()
+        return None
 
     def _parse_python_imports(self, captures: dict, module_qn: str) -> None:
         all_imports = captures.get(cs.CAPTURE_IMPORT, []) + captures.get(
@@ -763,7 +876,18 @@ class ImportProcessor:
             return f"{self.project_name}{cs.SEPARATOR_DOT}{dotted}"
         return None
 
+    @staticmethod
+    def _strip_js_extension(import_path: str) -> str:
+        # (H) ESM specifiers may carry an explicit extension (`./b.js`); the
+        # (H) module qn never does, so keeping it poisons the import map AND
+        # (H) the IMPORTS edge with a phantom `.js` segment (issue #652).
+        for ext in cs.JS_TS_ALL_EXTENSIONS:
+            if import_path.endswith(ext) and len(import_path) > len(ext):
+                return import_path[: -len(ext)]
+        return import_path
+
     def _resolve_js_module_path(self, import_path: str, current_module: str) -> str:
+        import_path = self._strip_js_extension(import_path)
         if not import_path.startswith(cs.PATH_CURRENT_DIR):
             if aliased := self._ts_alias_module_qn(import_path):
                 return aliased
@@ -1176,6 +1300,9 @@ class ImportProcessor:
                     partition_name = f"{cs.CPP_PARTITION_PREFIX}{partition_part}"
                     full_name = f"{self.project_name}{cs.SEPARATOR_DOT}{partition_part}"
                     self.import_mapping[module_qn][partition_name] = full_name
+                    # (H) A partition lives inside the same named module; no
+                    # (H) graph node models it, so never emit an IMPORTS edge.
+                    self._cpp_declaration_mappings.add((module_qn, full_name))
                     logger.debug(
                         ls.IMP_CPP_PARTITION,
                         partition=partition_name,
@@ -1186,9 +1313,11 @@ class ImportProcessor:
         self, parts: list[str], name_index: int, module_qn: str, log_template: str
     ) -> None:
         module_name = parts[name_index].rstrip(";")
-        self.import_mapping[module_qn][module_name] = (
-            f"{self.project_name}{cs.SEPARATOR_DOT}{module_name}"
-        )
+        full_name = f"{self.project_name}{cs.SEPARATOR_DOT}{module_name}"
+        self.import_mapping[module_qn][module_name] = full_name
+        # (H) `module X;` / `export module X;` DECLARE this file's module; the
+        # (H) mapping exists for name resolution only, never as an IMPORTS edge.
+        self._cpp_declaration_mappings.add((module_qn, full_name))
         logger.debug(log_template, name=module_name)
 
     _PHP_INCLUDE_REQUIRE_TYPES = frozenset(

--- a/codebase_rag/parsers/js_ts/module_system.py
+++ b/codebase_rag/parsers/js_ts/module_system.py
@@ -71,7 +71,7 @@ class JsTsModuleSystemMixin:
 
                 for declarator in variable_declarators:
                     self._process_variable_declarator_for_commonjs(
-                        declarator, module_qn
+                        declarator, module_qn, language
                     )
 
             except Exception as e:
@@ -113,11 +113,15 @@ class JsTsModuleSystemMixin:
         return safe_decode_with_fallback(module_string_node).strip("'\"")
 
     def _process_destructured_child(
-        self, child: ASTNode, module_name: str, module_qn: str
+        self,
+        child: ASTNode,
+        module_name: str,
+        module_qn: str,
+        language: cs.SupportedLanguage,
     ) -> None:
         if child.type == cs.TS_SHORTHAND_PROPERTY_IDENTIFIER_PATTERN:
             if child.text is not None and (name := safe_decode_text(child)):
-                self._process_commonjs_import(name, module_name, module_qn)
+                self._process_commonjs_import(name, module_name, module_qn, language)
             return
 
         if child.type != cs.TS_PAIR_PATTERN:
@@ -134,10 +138,10 @@ class JsTsModuleSystemMixin:
             return
 
         if alias_name := safe_decode_text(value_node):
-            self._process_commonjs_import(alias_name, module_name, module_qn)
+            self._process_commonjs_import(alias_name, module_name, module_qn, language)
 
     def _process_variable_declarator_for_commonjs(
-        self, declarator: ASTNode, module_qn: str
+        self, declarator: ASTNode, module_qn: str, language: cs.SupportedLanguage
     ) -> None:
         try:
             module_name = self._extract_require_module_name(declarator)
@@ -149,13 +153,19 @@ class JsTsModuleSystemMixin:
                 return
 
             for child in name_node.children:
-                self._process_destructured_child(child, module_name, module_qn)
+                self._process_destructured_child(
+                    child, module_name, module_qn, language
+                )
 
         except Exception as e:
             logger.debug(ls.JS_COMMONJS_VAR_DECLARATOR_FAILED, error=e)
 
     def _process_commonjs_import(
-        self, imported_name: str, module_name: str, module_qn: str
+        self,
+        imported_name: str,
+        module_name: str,
+        module_qn: str,
+        language: cs.SupportedLanguage,
     ) -> None:
         try:
             resolved_source_module = self.import_processor._resolve_js_module_path(
@@ -164,26 +174,13 @@ class JsTsModuleSystemMixin:
 
             import_key = f"{module_qn}->{resolved_source_module}"
             if import_key not in self._processed_imports:
-                # (H) #498: a require() target outside the project (Node builtin,
-                # (H) npm package) is an ExternalModule, not a prop-less Module.
-                # (H) Local targets get no node here: the module's own file pass
-                # (H) creates it, and a rel to a never-indexed module is a no-op.
-                target_label = self.import_processor._module_label(
-                    resolved_source_module
-                )
-                if target_label == cs.NodeLabel.EXTERNAL_MODULE:
-                    self.import_processor._ensure_external_module_node(
-                        resolved_source_module, module_name
-                    )
-
-                self.ingestor.ensure_relationship_batch(
-                    (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, module_qn),
-                    cs.RelationshipType.IMPORTS,
-                    (
-                        target_label,
-                        cs.KEY_QUALIFIED_NAME,
-                        resolved_source_module,
-                    ),
+                # (H) Route through the same deferred verification as every
+                # (H) other IMPORTS edge: an internal target must be a real
+                # (H) module, an external one gets its ExternalModule node at
+                # (H) flush (issue #652: this path emitted directly and was the
+                # (H) last source of phantom import targets).
+                self.import_processor.defer_import_edge(
+                    module_qn, resolved_source_module, language
                 )
 
                 logger.debug(

--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -13,7 +13,6 @@ from unittest.mock import MagicMock, call
 import pytest
 from loguru import logger
 
-from codebase_rag import constants as cs
 from codebase_rag import graph_audit
 from codebase_rag.graph_updater import GraphUpdater
 from codebase_rag.parser_loader import load_parsers
@@ -185,8 +184,10 @@ def _audit_recorded_graph(mock_ingestor: MagicMock) -> None:
     """Structural integrity audit of the recorded batches (issue #646).
 
     Every test that indexes a fixture also asserts the resulting graph is
-    schema-conformant and orphan-free. CGR_AUDIT_SWEEP=<file> switches to
-    collect mode, appending violations as JSON lines instead of failing.
+    schema-conformant, orphan-free, and free of dangling relationships (issue
+    #652: an edge with a phantom endpoint is silently dropped by the
+    database). CGR_AUDIT_SWEEP=<file> switches to collect mode, appending
+    violations as JSON lines instead of failing.
     """
     nodes = [
         GraphNodeRecord(str(c.args[0]), c.args[1])
@@ -196,25 +197,15 @@ def _audit_recorded_graph(mock_ingestor: MagicMock) -> None:
         GraphRelRecord(c.args[0], str(c.args[1]), c.args[2])
         for c in mock_ingestor.ensure_relationship_batch.call_args_list
     ]
-    all_violations = graph_audit.collect_violations(nodes, rels)
+    violations = graph_audit.collect_violations(nodes, rels)
     if sweep_path := os.environ.get("CGR_AUDIT_SWEEP"):
         import json
 
         test_id = os.environ.get("PYTEST_CURRENT_TEST", "")
         with open(sweep_path, "a") as f:
-            for v in all_violations:
+            for v in violations:
                 f.write(json.dumps([str(v.check), v.detail, test_id]) + "\n")
         return
-    violations = [
-        v
-        # (H) Dangling relationships are a pervasive pre-existing debt class
-        # (H) (302 fixture tests emit them across every language; issue #652).
-        # (H) Gate on them once that campaign lands; orphan detection already
-        # (H) uses live-faithful connectivity. Sweep mode above records them
-        # (H) unfiltered so the campaign can see what remains.
-        for v in all_violations
-        if v.check != cs.AuditCheck.DANGLING_RELATIONSHIP
-    ]
     assert not violations, "\n".join(v.detail for v in violations)
 
 

--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -196,22 +196,25 @@ def _audit_recorded_graph(mock_ingestor: MagicMock) -> None:
         GraphRelRecord(c.args[0], str(c.args[1]), c.args[2])
         for c in mock_ingestor.ensure_relationship_batch.call_args_list
     ]
+    all_violations = graph_audit.collect_violations(nodes, rels)
+    if sweep_path := os.environ.get("CGR_AUDIT_SWEEP"):
+        import json
+
+        test_id = os.environ.get("PYTEST_CURRENT_TEST", "")
+        with open(sweep_path, "a") as f:
+            for v in all_violations:
+                f.write(json.dumps([str(v.check), v.detail, test_id]) + "\n")
+        return
     violations = [
         v
         # (H) Dangling relationships are a pervasive pre-existing debt class
         # (H) (302 fixture tests emit them across every language; issue #652).
         # (H) Gate on them once that campaign lands; orphan detection already
-        # (H) uses live-faithful connectivity.
-        for v in graph_audit.collect_violations(nodes, rels)
+        # (H) uses live-faithful connectivity. Sweep mode above records them
+        # (H) unfiltered so the campaign can see what remains.
+        for v in all_violations
         if v.check != cs.AuditCheck.DANGLING_RELATIONSHIP
     ]
-    if sweep_path := os.environ.get("CGR_AUDIT_SWEEP"):
-        import json
-
-        with open(sweep_path, "a") as f:
-            for v in violations:
-                f.write(json.dumps([str(v.check), v.detail]) + "\n")
-        return
     assert not violations, "\n".join(v.detail for v in violations)
 
 

--- a/codebase_rag/tests/test_call_processor_integration.py
+++ b/codebase_rag/tests/test_call_processor_integration.py
@@ -317,9 +317,12 @@ function process(data) {
             if c.args[1] == cs.RelationshipType.CALLS
         ]
 
+        # (H) A synthetic builtin.* qn never has a node, so its CALLS edge was
+        # (H) always dropped by the database (issue #652); builtin resolution
+        # (H) must therefore emit NO edge, mirroring the C++ operator rule.
         call_targets = [c.args[2][2] for c in calls]
         builtin_calls = [t for t in call_targets if cs.BUILTIN_PREFIX in t]
-        assert len(builtin_calls) >= 1
+        assert not builtin_calls, builtin_calls
 
 
 class TestProcessCallsInFileJava:

--- a/codebase_rag/tests/test_cross_file_inherits_implements.py
+++ b/codebase_rag/tests/test_cross_file_inherits_implements.py
@@ -1,0 +1,147 @@
+# (H) A non-C++ base or interface that does not resolve at parse time used to
+# (H) be anchored to the child's own module qn (`_resolve_to_qn` fallback), so
+# (H) every cross-file or external base emitted an INHERITS/IMPLEMENTS edge to
+# (H) a phantom the database drops (issue #652: 136 INHERITS + 81 IMPLEMENTS
+# (H) across the fixture suite). Emission is now deferred until every class is
+# (H) registered, re-resolved against the full registry, and skipped entirely
+# (H) when the target resolves nowhere (java.lang.Exception, Rust Send/Sync).
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import get_relationships, run_updater
+
+FLYABLE_JAVA = """
+package animals;
+
+public interface Flyable {
+    void fly();
+}
+"""
+
+DUCK_JAVA = """
+package animals;
+
+public class Duck extends Bird implements Flyable {
+    public void fly() {}
+}
+"""
+
+BIRD_JAVA = """
+package animals;
+
+public class Bird {
+    protected String name;
+}
+"""
+
+CUSTOM_EXCEPTION_JAVA = """
+package errors;
+
+public class CustomException extends Exception {
+    public CustomException(String message) {
+        super(message);
+    }
+}
+"""
+
+RUST_TRAITS = """
+pub trait Processable: Send + Sync {
+    fn process(&self) -> u32;
+}
+
+pub struct CustomError {
+    code: u32,
+}
+
+impl std::fmt::Display for CustomError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.code)
+    }
+}
+
+pub trait Countable {
+    fn count(&self) -> u32;
+}
+
+impl Countable for CustomError {
+    fn count(&self) -> u32 {
+        self.code
+    }
+}
+"""
+
+
+def _node_keys(mock_ingestor: MagicMock) -> set[tuple[str, str]]:
+    return {
+        (str(c.args[0]), c.args[1].get("qualified_name"))
+        for c in mock_ingestor.ensure_node_batch.call_args_list
+    }
+
+
+def test_java_cross_file_base_and_interface_resolve(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "Flyable.java").write_text(FLYABLE_JAVA)
+    (temp_repo / "Duck.java").write_text(DUCK_JAVA)
+    (temp_repo / "Bird.java").write_text(BIRD_JAVA)
+    run_updater(temp_repo, mock_ingestor, skip_if_missing="java")
+
+    project = temp_repo.name
+    inherits = {
+        (call.args[0][2], call.args[2][2])
+        for call in get_relationships(mock_ingestor, cs.RelationshipType.INHERITS.value)
+    }
+    assert (f"{project}.Duck.Duck", f"{project}.Bird.Bird") in inherits, inherits
+
+    implements = {
+        (call.args[0][2], call.args[2][2])
+        for call in get_relationships(
+            mock_ingestor, cs.RelationshipType.IMPLEMENTS.value
+        )
+    }
+    assert (
+        f"{project}.Duck.Duck",
+        f"{project}.Flyable.Flyable",
+    ) in implements, implements
+
+
+def test_java_external_base_emits_no_phantom_edge(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "CustomException.java").write_text(CUSTOM_EXCEPTION_JAVA)
+    run_updater(temp_repo, mock_ingestor, skip_if_missing="java")
+
+    node_keys = _node_keys(mock_ingestor)
+    inherits = get_relationships(mock_ingestor, cs.RelationshipType.INHERITS.value)
+    for call in inherits:
+        to_label, _, to_qn = call.args[2]
+        assert (str(to_label), to_qn) in node_keys, call.args
+
+
+def test_rust_external_traits_emit_no_phantom_edges(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "lib.rs").write_text(RUST_TRAITS)
+    run_updater(temp_repo, mock_ingestor)
+
+    project = temp_repo.name
+    node_keys = _node_keys(mock_ingestor)
+    for rel_type in (cs.RelationshipType.INHERITS, cs.RelationshipType.IMPLEMENTS):
+        for call in get_relationships(mock_ingestor, rel_type.value):
+            to_label, _, to_qn = call.args[2]
+            assert (str(to_label), to_qn) in node_keys, call.args
+
+    # (H) The first-party trait impl must survive the deferral.
+    implements = {
+        (call.args[0][2], call.args[2][2])
+        for call in get_relationships(
+            mock_ingestor, cs.RelationshipType.IMPLEMENTS.value
+        )
+    }
+    assert (
+        f"{project}.lib.CustomError",
+        f"{project}.lib.Countable",
+    ) in implements, implements

--- a/codebase_rag/tests/test_external_base_nodes.py
+++ b/codebase_rag/tests/test_external_base_nodes.py
@@ -1,0 +1,119 @@
+# (H) A base class that is POSITIVELY external (import-mapped like
+# (H) typing.Protocol, ::-qualified like std::fmt::Display, or a JS global
+# (H) like Error) carries real information the dead-code and protocol-dispatch
+# (H) layers consume, but its INHERITS/IMPLEMENTS edge always pointed at a
+# (H) first-party label that has no node, so the database silently dropped it
+# (H) (issue #652). Mirroring the ExternalModule convention for imports, the
+# (H) edge now targets an ExternalModule node that is minted if the import
+# (H) pass did not already create it. A module-anchored GUESS that resolves
+# (H) nowhere still emits no edge; knowledge and guesses are not the same.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import get_relationships, run_updater
+
+PY_PROTOCOL = """
+from typing import Protocol
+
+
+class Loadable(Protocol):
+    def _ensure_loaded(self) -> None: ...
+"""
+
+PY_ATTRIBUTE_BASE = """
+from collections import abc
+
+
+class Registry(abc.Mapping):
+    def __getitem__(self, key):
+        return None
+"""
+
+JS_ERRORS = """
+class ValidationError extends Error {
+    constructor(message) {
+        super(message);
+    }
+}
+
+class TimeoutError extends ValidationError {
+    constructor() {
+        super("timeout");
+    }
+}
+"""
+
+
+def _inherits_pairs(mock_ingestor: MagicMock) -> set[tuple[str, str, str]]:
+    return {
+        (call.args[0][2], str(call.args[2][0]), call.args[2][2])
+        for call in get_relationships(mock_ingestor, cs.RelationshipType.INHERITS.value)
+    }
+
+
+def _node_keys(mock_ingestor: MagicMock) -> set[tuple[str, str]]:
+    return {
+        (str(c.args[0]), c.args[1].get("qualified_name"))
+        for c in mock_ingestor.ensure_node_batch.call_args_list
+    }
+
+
+def test_python_protocol_base_emits_external_edge_and_node(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "m.py").write_text(PY_PROTOCOL)
+    run_updater(temp_repo, mock_ingestor)
+
+    project = temp_repo.name
+    pairs = _inherits_pairs(mock_ingestor)
+    expected = (
+        f"{project}.m.Loadable",
+        cs.NodeLabel.EXTERNAL_MODULE.value,
+        "typing.Protocol",
+    )
+    assert expected in pairs, pairs
+    assert (
+        cs.NodeLabel.EXTERNAL_MODULE.value,
+        "typing.Protocol",
+    ) in _node_keys(mock_ingestor)
+
+
+def test_python_attribute_base_emits_external_edge(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "reg.py").write_text(PY_ATTRIBUTE_BASE)
+    run_updater(temp_repo, mock_ingestor)
+
+    project = temp_repo.name
+    pairs = _inherits_pairs(mock_ingestor)
+    expected = (
+        f"{project}.reg.Registry",
+        cs.NodeLabel.EXTERNAL_MODULE.value,
+        "collections.abc.Mapping",
+    )
+    assert expected in pairs, pairs
+
+
+def test_js_global_base_emits_external_edge(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "errors.js").write_text(JS_ERRORS)
+    run_updater(temp_repo, mock_ingestor)
+
+    project = temp_repo.name
+    pairs = _inherits_pairs(mock_ingestor)
+    external_error_qn = f"{cs.BUILTIN_PREFIX}{cs.SEPARATOR_DOT}Error"
+    assert (
+        f"{project}.errors.ValidationError",
+        cs.NodeLabel.EXTERNAL_MODULE.value,
+        external_error_qn,
+    ) in pairs, pairs
+    # (H) The first-party chain must keep its first-party label.
+    assert (
+        f"{project}.errors.TimeoutError",
+        cs.NodeLabel.CLASS.value,
+        f"{project}.errors.ValidationError",
+    ) in pairs, pairs

--- a/codebase_rag/tests/test_go_module_path_imports.py
+++ b/codebase_rag/tests/test_go_module_path_imports.py
@@ -225,7 +225,9 @@ def test_external_import_does_not_misbind_to_local_same_name(tmp_path: Path) -> 
 
 def test_local_import_edge_targets_project_qn(tmp_path: Path) -> None:
     # (H) The IMPORTS edge for a first-party Go import must target a
-    # (H) project-prefixed qn, not the dangling raw module path.
+    # (H) project-prefixed qn of a REAL module node, not the dangling raw
+    # (H) module path and not the package directory (which has no Module
+    # (H) node); deferred verification resolves the dir qn to its file.
     files = {
         "go.mod": GO_MOD,
         "main.go": (
@@ -239,5 +241,5 @@ def test_local_import_edge_targets_project_qn(tmp_path: Path) -> None:
     }
     rels = _run_rels(tmp_path, files)
     import_targets = {b for a, r, b in rels if r == "IMPORTS" and a.endswith("main")}
-    assert "mytool.util" in import_targets
+    assert "mytool.util.util" in import_targets
     assert not any(t.startswith("github.com/") for t in import_targets)

--- a/codebase_rag/tests/test_import_edge_verification.py
+++ b/codebase_rag/tests/test_import_edge_verification.py
@@ -176,6 +176,56 @@ int internal_helper() { return 7; }
     ) in implements, implements
 
 
+def test_js_destructured_require_of_missing_module_emits_no_phantom(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) The CommonJS destructuring fallback emitted its IMPORTS edges
+    # (H) directly, bypassing deferred verification entirely.
+    utils = temp_repo / "src" / "utils"
+    utils.mkdir(parents=True)
+    (utils / "helpers.js").write_text("module.exports = { helper: () => {} };\n")
+    (temp_repo / "main.js").write_text(
+        "const { helper, validator } = require('./src/utils/helpers');\n"
+        "const { api: apiClient, db: database } = require('./src/services');\n"
+        "helper();\n"
+    )
+    run_updater(temp_repo, mock_ingestor)
+
+    project = temp_repo.name
+    targets = _import_targets(mock_ingestor, f"{project}.main")
+    assert f"{project}.src.utils.helpers" in targets, targets
+    _assert_no_dangling_imports(mock_ingestor)
+
+
+def test_java_inner_class_never_self_implements(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) `static class Entry implements Map.Entry<K, V>`: the parse-time
+    # (H) resolution can land on the inner class ITSELF (the only registered
+    # (H) qn ending in Entry); a self-IMPLEMENTS is never real.
+    (temp_repo / "SimpleHashMap.java").write_text(
+        """
+import java.util.Map;
+
+public class SimpleHashMap<K, V> {
+    static class Entry<K, V> implements Map.Entry<K, V> {
+        K key;
+        V value;
+
+        public K getKey() { return key; }
+        public V getValue() { return value; }
+        public V setValue(V value) { this.value = value; return value; }
+    }
+}
+"""
+    )
+    run_updater(temp_repo, mock_ingestor, skip_if_missing="java")
+
+    for rel_type in (cs.RelationshipType.IMPLEMENTS, cs.RelationshipType.INHERITS):
+        for call in get_relationships(mock_ingestor, rel_type.value):
+            assert call.args[0][2] != call.args[2][2], call.args
+
+
 def test_lua_require_of_missing_module_emits_no_phantom(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:

--- a/codebase_rag/tests/test_import_edge_verification.py
+++ b/codebase_rag/tests/test_import_edge_verification.py
@@ -78,6 +78,23 @@ def test_js_explicit_extension_resolves_to_module(
     assert (f"{project}.a.runA", f"{project}.b.createB") in calls, calls
 
 
+def test_js_bare_package_named_like_extension_keeps_its_name(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) A bare npm package can legitimately END in .js (p5.js, highlight.js);
+    # (H) extension stripping applies to relative file paths only, or the
+    # (H) external package qn silently loses its real name.
+    (temp_repo / "sketch.js").write_text(
+        "import p5 from 'p5.js';\nexport const sketch = new p5();\n"
+    )
+    run_updater(temp_repo, mock_ingestor)
+
+    project = temp_repo.name
+    targets = _import_targets(mock_ingestor, f"{project}.sketch")
+    assert "p5.js" in targets, targets
+    assert "p5" not in targets, targets
+
+
 def test_js_directory_import_resolves_to_index_module(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:

--- a/codebase_rag/tests/test_import_edge_verification.py
+++ b/codebase_rag/tests/test_import_edge_verification.py
@@ -1,0 +1,191 @@
+# (H) IMPORTS edges were emitted straight from the import map's parse-time
+# (H) guesses, so an internal-looking target that maps to no real module (a
+# (H) broken import, a directory, a crate path resolved from the wrong root, a
+# (H) specifier with an explicit .js extension, a C++20 module declaration
+# (H) registering itself) produced an edge the database silently drops (issue
+# (H) #652: 51 across the fixture suite). Emission is now deferred until every
+# (H) file is parsed and verified against the real module qns; an internal
+# (H) target that resolves nowhere emits no edge.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import get_relationships, run_updater
+
+
+def _import_targets(mock_ingestor: MagicMock, from_qn: str) -> set[str]:
+    return {
+        call.args[2][2]
+        for call in get_relationships(mock_ingestor, cs.RelationshipType.IMPORTS.value)
+        if call.args[0][2] == from_qn
+    }
+
+
+def _node_keys(mock_ingestor: MagicMock) -> set[tuple[str, str]]:
+    return {
+        (str(c.args[0]), c.args[1].get("qualified_name"))
+        for c in mock_ingestor.ensure_node_batch.call_args_list
+    }
+
+
+def _assert_no_dangling_imports(mock_ingestor: MagicMock) -> None:
+    node_keys = _node_keys(mock_ingestor)
+    for call in get_relationships(mock_ingestor, cs.RelationshipType.IMPORTS.value):
+        to_label, _, to_qn = call.args[2]
+        assert (str(to_label), to_qn) in node_keys, call.args
+
+
+def test_python_broken_import_emits_no_phantom_edge(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    pkg = temp_repo / "app"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / "real.py").write_text("VALUE = 1\n")
+    (pkg / "main.py").write_text(
+        "from app.real import VALUE\nfrom app.missing_module import Thing\n"
+    )
+    run_updater(temp_repo, mock_ingestor)
+
+    project = temp_repo.name
+    targets = _import_targets(mock_ingestor, f"{project}.app.main")
+    assert f"{project}.app.real" in targets, targets
+    _assert_no_dangling_imports(mock_ingestor)
+
+
+def test_js_explicit_extension_resolves_to_module(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "b.js").write_text("export function createB() { return 2; }\n")
+    (temp_repo / "a.js").write_text(
+        "import { createB } from './b.js';\nexport function runA() { return createB(); }\n"
+    )
+    run_updater(temp_repo, mock_ingestor)
+
+    project = temp_repo.name
+    targets = _import_targets(mock_ingestor, f"{project}.a")
+    assert f"{project}.b" in targets, targets
+    _assert_no_dangling_imports(mock_ingestor)
+
+    # (H) The item mapping must also drop the extension or calls to createB
+    # (H) resolve against a phantom qn.
+    calls = {
+        (call.args[0][2], call.args[2][2])
+        for call in get_relationships(mock_ingestor, cs.RelationshipType.CALLS.value)
+    }
+    assert (f"{project}.a.runA", f"{project}.b.createB") in calls, calls
+
+
+def test_js_directory_import_resolves_to_index_module(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    shared = temp_repo / "shared"
+    shared.mkdir()
+    (shared / "index.js").write_text("export const config = {};\n")
+    (temp_repo / "app.js").write_text("import { config } from './shared';\n")
+    run_updater(temp_repo, mock_ingestor)
+
+    project = temp_repo.name
+    targets = _import_targets(mock_ingestor, f"{project}.app")
+    assert f"{project}.shared.index" in targets, targets
+    _assert_no_dangling_imports(mock_ingestor)
+
+
+def test_rust_crate_import_resolves_to_real_module_file(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    src = temp_repo / "src"
+    (src / "utils").mkdir(parents=True)
+    (src / "lib.rs").write_text("pub mod utils;\n")
+    (src / "utils" / "mod.rs").write_text("pub fn helper() -> i32 { 42 }\n")
+    (temp_repo / "tool.rs").write_text(
+        "use crate::utils::helper;\nfn main() { let _ = helper(); }\n"
+    )
+    run_updater(temp_repo, mock_ingestor)
+
+    _assert_no_dangling_imports(mock_ingestor)
+
+
+def test_cpp_module_declarations_emit_no_self_import(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "my_export.cppm").write_text(
+        """
+export module my_export_module;
+
+export int answer() { return 42; }
+"""
+    )
+    run_updater(temp_repo, mock_ingestor)
+
+    _assert_no_dangling_imports(mock_ingestor)
+    project = temp_repo.name
+    targets = _import_targets(mock_ingestor, f"{project}.my_export")
+    assert f"{project}.my_export_module" not in targets, targets
+
+
+def test_cpp_module_impl_without_interface_emits_no_phantom(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "orphan_impl.cpp").write_text(
+        """
+module lonely_module;
+
+int helper() { return 1; }
+"""
+    )
+    run_updater(temp_repo, mock_ingestor)
+
+    node_keys = _node_keys(mock_ingestor)
+    for call in get_relationships(mock_ingestor, cs.RelationshipType.IMPLEMENTS.value):
+        to_label, _, to_qn = call.args[2]
+        assert (str(to_label), to_qn) in node_keys, call.args
+
+
+def test_cpp_module_impl_with_interface_still_links(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "math.cppm").write_text(
+        """
+export module math_module;
+
+export int add(int a, int b) { return a + b; }
+"""
+    )
+    (temp_repo / "math_impl.cpp").write_text(
+        """
+module math_module;
+
+int internal_helper() { return 7; }
+"""
+    )
+    run_updater(temp_repo, mock_ingestor)
+
+    project = temp_repo.name
+    implements = {
+        (call.args[0][2], call.args[2][2])
+        for call in get_relationships(
+            mock_ingestor, cs.RelationshipType.IMPLEMENTS.value
+        )
+    }
+    assert (
+        f"{project}.math_module{cs.CPP_IMPL_SUFFIX}",
+        f"{project}.math_module",
+    ) in implements, implements
+
+
+def test_lua_require_of_missing_module_emits_no_phantom(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "real.lua").write_text("local M = {}\nreturn M\n")
+    (temp_repo / "main.lua").write_text(
+        'local real = require("real")\nlocal gone = require("storage")\n'
+    )
+    run_updater(temp_repo, mock_ingestor)
+
+    project = temp_repo.name
+    targets = _import_targets(mock_ingestor, f"{project}.main")
+    assert f"{project}.real" in targets, targets
+    _assert_no_dangling_imports(mock_ingestor)

--- a/codebase_rag/tests/test_java_inheritance_edges.py
+++ b/codebase_rag/tests/test_java_inheritance_edges.py
@@ -22,6 +22,9 @@ enum Color implements A { RED }
 
 class Circle extends Base implements A, B {}
 
+class Box<T> {}
+interface Comparable<T> {}
+
 class Holder extends Box<String> implements Comparable<Holder> {}
 """
 

--- a/codebase_rag/tests/test_javascript_imports.py
+++ b/codebase_rag/tests/test_javascript_imports.py
@@ -851,6 +851,20 @@ def test_commonjs_multiple_destructured_variables_regression(
     const { a, b, c } = require('module'); // 3 destructured, 1 module, 1 require
     Old code: iterate i=0,1,2 over [a,b,c] but access module_names[1] (IndexError)
     """
+    # (H) Every required path must reference a real fixture module: an IMPORTS
+    # (H) edge to a module no file yields is a phantom the database drops.
+    services_dir = javascript_imports_project / "src" / "services"
+    services_dir.mkdir()
+    (services_dir / "index.js").write_text(
+        encoding="utf-8",
+        data="module.exports = { api: {}, db: {}, cache: {} };",
+    )
+    core_dir = javascript_imports_project / "src" / "core"
+    core_dir.mkdir()
+    (core_dir / "index.js").write_text(
+        encoding="utf-8",
+        data="module.exports = { logger: {}, config: {}, utils: {}, DEBUG: true };",
+    )
     test_file = javascript_imports_project / "regression_multiple_destructured.js"
     test_file.write_text(
         encoding="utf-8",

--- a/codebase_rag/tests/test_javascript_imports.py
+++ b/codebase_rag/tests/test_javascript_imports.py
@@ -344,8 +344,22 @@ def test_relative_path_resolution(
     mock_ingestor: MagicMock,
 ) -> None:
     """Test relative import path resolution (./ and ../)."""
+    # (H) Every imported path must reference a real fixture file: an IMPORTS
+    # (H) edge to a module no file yields is a phantom the database drops, so
+    # (H) the old miscounted `../` paths only ever produced dropped edges.
     nested_dir = javascript_imports_project / "src" / "components" / "forms"
     nested_dir.mkdir()
+    (nested_dir / "Button.js").write_text(
+        encoding="utf-8", data="export default class Button {}"
+    )
+    (nested_dir / "Modal.js").write_text(
+        encoding="utf-8", data="export default class Modal {}"
+    )
+    deep_dir = javascript_imports_project / "lib" / "deep"
+    deep_dir.mkdir()
+    (deep_dir / "util.js").write_text(
+        encoding="utf-8", data="export const deepUtil = () => {};"
+    )
     test_file = nested_dir / "Input.js"
     test_file.write_text(
         encoding="utf-8",
@@ -359,8 +373,8 @@ import utils from '../../utils/helpers';
 import constants from '../../utils/constants';
 
 // Multiple levels up
-import config from '../../lib/config';
-import shared from '../../shared';
+import config from '../../../lib/config';
+import shared from '../../../shared';
 
 // Complex relative paths
 import deepUtil from '../../../lib/deep/util';
@@ -392,8 +406,9 @@ const url = constants.API_URL;
         f"{project_name}.src.components.forms.Button",
         f"{project_name}.src.utils.helpers",
         f"{project_name}.src.utils.constants",
-        f"{project_name}.src.lib.config",
-        f"{project_name}.src.shared",
+        f"{project_name}.lib.config",
+        f"{project_name}.shared",
+        f"{project_name}.lib.deep.util",
     ]
 
     for pattern in expected_patterns:

--- a/codebase_rag/tests/test_javascript_prototypes.py
+++ b/codebase_rag/tests/test_javascript_prototypes.py
@@ -438,13 +438,14 @@ myTask.outputTaskDetails();
 
     call_relationships = get_relationships(mock_ingestor, "CALLS")
 
+    # (H) Object.create resolves to a synthetic builtin.* qn with no node, so
+    # (H) its CALLS edge was always dropped by the database (issue #652); no
+    # (H) edge may be emitted for it at all.
     object_create_calls = [
         call for call in call_relationships if "Object.create" in str(call.args[2][2])
     ]
 
-    assert len(object_create_calls) >= 3, (
-        f"Expected at least 3 Object.create calls, found {len(object_create_calls)}"
-    )
+    assert not object_create_calls, object_create_calls
 
 
 def test_prototype_chain_and_method_resolution(
@@ -645,11 +646,19 @@ square.scale(2);
 
     call_relationships = get_relationships(mock_ingestor, "CALLS")
 
+    # (H) A prototype method call resolves to the method's first-party qn
+    # (H) (Constructor.method); the old `.prototype.` matches were synthetic
+    # (H) builtin Function.prototype.call/apply qns whose edges the database
+    # (H) always dropped (issue #652) and which are no longer emitted.
     prototype_calls = [
         call
         for call in call_relationships
         if "prototype_chain" in call.args[0][2]
-        and ".prototype." in str(call.args[2][2])
+        and any(
+            str(call.args[2][2]).endswith(f".{ctor}.{method}")
+            for ctor in ("Shape", "Rectangle", "Square", "ColoredSquare")
+            for method in ("getPosition", "getArea", "setSize", "setColor", "move")
+        )
     ]
 
     assert len(prototype_calls) >= 2, (

--- a/codebase_rag/tests/test_javascript_this_binding.py
+++ b/codebase_rag/tests/test_javascript_this_binding.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from codebase_rag import constants as cs
 from codebase_rag.tests.conftest import (
     get_node_names,
     get_nodes,
@@ -418,23 +419,24 @@ console.log(result2); // [15, 20]
 
     run_updater(javascript_this_project, mock_ingestor)
 
-    call_relationships = get_relationships(mock_ingestor, "CALLS")
-
-    bind_call_apply_calls = [
-        call
-        for call in call_relationships
+    # (H) bind/call/apply resolve to synthetic builtin Function.prototype qns
+    # (H) whose CALLS edges the database always dropped (issue #652); the
+    # (H) durable contract is that every first-party function handed to them
+    # (H) stays reachable through CALLS or REFERENCES edges.
+    reachable_targets = {
+        str(call.args[2][2])
+        for rel in ("CALLS", "REFERENCES")
+        for call in get_relationships(mock_ingestor, rel)
         if "bind_call_apply" in call.args[0][2]
-        and any(
-            method in str(call.args[2][2]) for method in [".bind", ".call", ".apply"]
+    }
+    project_name = javascript_this_project.name
+    for bound_fn in ("greet", "sum", "multiply"):
+        assert f"{project_name}.bind_call_apply.{bound_fn}" in reachable_targets, (
+            bound_fn,
+            reachable_targets,
         )
-    ]
-
-    assert len(bind_call_apply_calls) >= 5, (
-        f"Expected at least 5 bind/call/apply calls, found {len(bind_call_apply_calls)}"
-    )
 
     created_functions = get_node_names(mock_ingestor, "Function")
-    project_name = javascript_this_project.name
 
     expected_functions = [
         f"{project_name}.bind_call_apply.greet",
@@ -1147,14 +1149,12 @@ outer.call({ context: 'custom' });
         f"Expected at least 5 comprehensive this-related calls, found {len(comprehensive_calls)}"
     )
 
-    binding_calls = [
+    # (H) bind/call/apply resolve to synthetic builtin qns whose edges the
+    # (H) database always dropped (issue #652); no CALLS edge may carry a
+    # (H) builtin.* target anymore.
+    builtin_targets = [
         call
         for call in comprehensive_calls
-        if any(
-            method in str(call.args[2][2]) for method in [".bind", ".call", ".apply"]
-        )
+        if str(call.args[2][2]).startswith(f"{cs.BUILTIN_PREFIX}{cs.SEPARATOR_DOT}")
     ]
-
-    assert len(binding_calls) >= 2, (
-        f"Expected at least 2 bind/call/apply calls, found {len(binding_calls)}"
-    )
+    assert not builtin_targets, builtin_targets

--- a/codebase_rag/tests/test_js_builtin_call_no_phantom.py
+++ b/codebase_rag/tests/test_js_builtin_call_no_phantom.py
@@ -1,0 +1,63 @@
+# (H) JS/TS calls resolving to synthetic `builtin.*` qns (console.log,
+# (H) Date.now, JSON.stringify) emitted CALLS edges to Function nodes that are
+# (H) never created, so the database dropped every one (issue #652: 485 across
+# (H) the fixture suite). A builtin is not a first-party callee; mirroring the
+# (H) C++ builtin-operator rule, no edge is emitted at all. A first-party
+# (H) callback handed to a builtin must still be kept reachable via the
+# (H) argument-reference path.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import get_relationships, run_updater
+
+APP_JS = """
+function formatUser(user) {
+    return JSON.stringify(user);
+}
+
+function logStartup() {
+    console.log("starting", Date.now());
+}
+
+function onTick() {
+    return 42;
+}
+
+function scheduleTick() {
+    setTimeout(onTick, 100);
+}
+"""
+
+BUILTIN_QN_PREFIX = f"{cs.BUILTIN_PREFIX}{cs.SEPARATOR_DOT}"
+
+
+def test_builtin_calls_emit_no_phantom_edges(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "app.js").write_text(APP_JS)
+    run_updater(temp_repo, mock_ingestor)
+
+    calls = get_relationships(mock_ingestor, cs.RelationshipType.CALLS.value)
+    builtin_targets = [
+        call.args for call in calls if str(call.args[2][2]).startswith(BUILTIN_QN_PREFIX)
+    ]
+    assert not builtin_targets, builtin_targets
+
+
+def test_callback_passed_to_builtin_stays_reachable(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) Dropping the builtin edge must not drop the argument-flow edge that
+    # (H) keeps a first-party callback handed to the builtin reachable.
+    (temp_repo / "app.js").write_text(APP_JS)
+    run_updater(temp_repo, mock_ingestor)
+
+    project = temp_repo.name
+    called = {
+        (call.args[0][2], call.args[2][2])
+        for call in get_relationships(mock_ingestor, cs.RelationshipType.CALLS.value)
+    }
+    assert (f"{project}.app.scheduleTick", f"{project}.app.onTick") in called, called

--- a/codebase_rag/tests/test_js_builtin_call_no_phantom.py
+++ b/codebase_rag/tests/test_js_builtin_call_no_phantom.py
@@ -42,7 +42,9 @@ def test_builtin_calls_emit_no_phantom_edges(
 
     calls = get_relationships(mock_ingestor, cs.RelationshipType.CALLS.value)
     builtin_targets = [
-        call.args for call in calls if str(call.args[2][2]).startswith(BUILTIN_QN_PREFIX)
+        call.args
+        for call in calls
+        if str(call.args[2][2]).startswith(BUILTIN_QN_PREFIX)
     ]
     assert not builtin_targets, builtin_targets
 

--- a/codebase_rag/tests/test_js_ts_module_system_unit.py
+++ b/codebase_rag/tests/test_js_ts_module_system_unit.py
@@ -75,30 +75,29 @@ def mock_language_queries() -> dict[cs.SupportedLanguage, MagicMock]:
 
 
 class TestProcessCommonjsImport:
-    def test_creates_external_module_node_and_relationship(
+    # (H) The CommonJS fallback no longer emits IMPORTS edges directly; every
+    # (H) edge is deferred to the import processor so internal targets verify
+    # (H) against the real module qns before emission (issue #652).
+
+    def test_defers_external_import_edge(
         self,
         mixin: ConcreteModuleSystemMixin,
         mock_ingestor: MagicMock,
         mock_import_processor: MagicMock,
     ) -> None:
         mock_import_processor._resolve_js_module_path.return_value = "fs"
-        mock_import_processor._module_label.return_value = cs.NodeLabel.EXTERNAL_MODULE
 
-        mixin._process_commonjs_import("readFile", "fs", "my_module")
+        mixin._process_commonjs_import(
+            "readFile", "fs", "my_module", cs.SupportedLanguage.JS
+        )
 
-        # (H) #498: external require() targets get the dedicated ExternalModule
-        # (H) node via the import processor, never a prop-less bare Module.
-        mock_import_processor._ensure_external_module_node.assert_called_once_with(
-            "fs", "fs"
+        mock_import_processor.defer_import_edge.assert_called_once_with(
+            "my_module", "fs", cs.SupportedLanguage.JS
         )
         mock_ingestor.ensure_node_batch.assert_not_called()
+        mock_ingestor.ensure_relationship_batch.assert_not_called()
 
-        mock_ingestor.ensure_relationship_batch.assert_called_once()
-        rel_args = mock_ingestor.ensure_relationship_batch.call_args
-        assert rel_args[0][1] == cs.RelationshipType.IMPORTS
-        assert rel_args[0][2][0] == cs.NodeLabel.EXTERNAL_MODULE
-
-    def test_local_import_emits_relationship_without_node(
+    def test_defers_local_import_edge(
         self,
         mixin: ConcreteModuleSystemMixin,
         mock_ingestor: MagicMock,
@@ -107,17 +106,16 @@ class TestProcessCommonjsImport:
         mock_import_processor._resolve_js_module_path.return_value = (
             "test_project.src.utils"
         )
-        mock_import_processor._module_label.return_value = cs.NodeLabel.MODULE
 
-        mixin._process_commonjs_import("helper", "./src/utils", "my_module")
+        mixin._process_commonjs_import(
+            "helper", "./src/utils", "my_module", cs.SupportedLanguage.JS
+        )
 
-        # (H) The local module's own file pass creates its node; a rel to a
-        # (H) never-indexed module is a no-op instead of a phantom node.
-        mock_import_processor._ensure_external_module_node.assert_not_called()
+        mock_import_processor.defer_import_edge.assert_called_once_with(
+            "my_module", "test_project.src.utils", cs.SupportedLanguage.JS
+        )
         mock_ingestor.ensure_node_batch.assert_not_called()
-        mock_ingestor.ensure_relationship_batch.assert_called_once()
-        rel_args = mock_ingestor.ensure_relationship_batch.call_args
-        assert rel_args[0][2][0] == cs.NodeLabel.MODULE
+        mock_ingestor.ensure_relationship_batch.assert_not_called()
 
     def test_skips_duplicate_imports(
         self,
@@ -126,12 +124,15 @@ class TestProcessCommonjsImport:
         mock_import_processor: MagicMock,
     ) -> None:
         mock_import_processor._resolve_js_module_path.return_value = "fs"
-        mock_import_processor._module_label.return_value = cs.NodeLabel.EXTERNAL_MODULE
 
-        mixin._process_commonjs_import("readFile", "fs", "my_module")
-        mixin._process_commonjs_import("writeFile", "fs", "my_module")
+        mixin._process_commonjs_import(
+            "readFile", "fs", "my_module", cs.SupportedLanguage.JS
+        )
+        mixin._process_commonjs_import(
+            "writeFile", "fs", "my_module", cs.SupportedLanguage.JS
+        )
 
-        assert mock_import_processor._ensure_external_module_node.call_count == 1
+        assert mock_import_processor.defer_import_edge.call_count == 1
 
     def test_handles_resolution_error_gracefully(
         self,
@@ -143,9 +144,12 @@ class TestProcessCommonjsImport:
             "Resolution failed"
         )
 
-        mixin._process_commonjs_import("readFile", "fs", "my_module")
+        mixin._process_commonjs_import(
+            "readFile", "fs", "my_module", cs.SupportedLanguage.JS
+        )
 
         mock_ingestor.ensure_node_batch.assert_not_called()
+        mock_import_processor.defer_import_edge.assert_not_called()
 
 
 class TestProcessVariableDeclaratorForCommonjs:
@@ -180,7 +184,9 @@ class TestProcessVariableDeclaratorForCommonjs:
             },
         )
 
-        mixin._process_variable_declarator_for_commonjs(declarator, "test_module")
+        mixin._process_variable_declarator_for_commonjs(
+            declarator, "test_module", cs.SupportedLanguage.JS
+        )
 
         mock_import_processor._resolve_js_module_path.assert_called_once()
 
@@ -221,7 +227,9 @@ class TestProcessVariableDeclaratorForCommonjs:
             },
         )
 
-        mixin._process_variable_declarator_for_commonjs(declarator, "test_module")
+        mixin._process_variable_declarator_for_commonjs(
+            declarator, "test_module", cs.SupportedLanguage.JS
+        )
 
         mock_import_processor._resolve_js_module_path.assert_called_once()
 
@@ -240,7 +248,9 @@ class TestProcessVariableDeclaratorForCommonjs:
             },
         )
 
-        mixin._process_variable_declarator_for_commonjs(declarator, "test_module")
+        mixin._process_variable_declarator_for_commonjs(
+            declarator, "test_module", cs.SupportedLanguage.JS
+        )
 
         mock_import_processor._resolve_js_module_path.assert_not_called()
 
@@ -263,7 +273,9 @@ class TestProcessVariableDeclaratorForCommonjs:
             },
         )
 
-        mixin._process_variable_declarator_for_commonjs(declarator, "test_module")
+        mixin._process_variable_declarator_for_commonjs(
+            declarator, "test_module", cs.SupportedLanguage.JS
+        )
 
         mock_import_processor._resolve_js_module_path.assert_not_called()
 
@@ -293,7 +305,9 @@ class TestProcessVariableDeclaratorForCommonjs:
             },
         )
 
-        mixin._process_variable_declarator_for_commonjs(declarator, "test_module")
+        mixin._process_variable_declarator_for_commonjs(
+            declarator, "test_module", cs.SupportedLanguage.JS
+        )
 
         mock_import_processor._resolve_js_module_path.assert_not_called()
 
@@ -384,7 +398,9 @@ class TestEdgeCases:
             fields={cs.FIELD_VALUE: call_expr},
         )
 
-        mixin._process_variable_declarator_for_commonjs(declarator, "test_module")
+        mixin._process_variable_declarator_for_commonjs(
+            declarator, "test_module", cs.SupportedLanguage.JS
+        )
 
         mock_import_processor._resolve_js_module_path.assert_not_called()
 
@@ -399,7 +415,9 @@ class TestEdgeCases:
             fields={cs.FIELD_NAME: object_pattern},
         )
 
-        mixin._process_variable_declarator_for_commonjs(declarator, "test_module")
+        mixin._process_variable_declarator_for_commonjs(
+            declarator, "test_module", cs.SupportedLanguage.JS
+        )
 
         mock_import_processor._resolve_js_module_path.assert_not_called()
 
@@ -418,7 +436,9 @@ class TestEdgeCases:
             },
         )
 
-        mixin._process_variable_declarator_for_commonjs(declarator, "test_module")
+        mixin._process_variable_declarator_for_commonjs(
+            declarator, "test_module", cs.SupportedLanguage.JS
+        )
 
         mock_import_processor._resolve_js_module_path.assert_not_called()
 
@@ -441,7 +461,9 @@ class TestEdgeCases:
             },
         )
 
-        mixin._process_variable_declarator_for_commonjs(declarator, "test_module")
+        mixin._process_variable_declarator_for_commonjs(
+            declarator, "test_module", cs.SupportedLanguage.JS
+        )
 
         mock_import_processor._resolve_js_module_path.assert_not_called()
 
@@ -474,7 +496,9 @@ class TestEdgeCases:
             },
         )
 
-        mixin._process_variable_declarator_for_commonjs(declarator, "test_module")
+        mixin._process_variable_declarator_for_commonjs(
+            declarator, "test_module", cs.SupportedLanguage.JS
+        )
 
         mock_import_processor._resolve_js_module_path.assert_not_called()
 
@@ -515,6 +539,8 @@ class TestEdgeCases:
             },
         )
 
-        mixin._process_variable_declarator_for_commonjs(declarator, "test_module")
+        mixin._process_variable_declarator_for_commonjs(
+            declarator, "test_module", cs.SupportedLanguage.JS
+        )
 
         mock_import_processor._resolve_js_module_path.assert_not_called()

--- a/codebase_rag/tests/test_rust_receiver_resolution.py
+++ b/codebase_rag/tests/test_rust_receiver_resolution.py
@@ -190,9 +190,11 @@ def test_closure_captured_local_receiver_dispatch(tmp_path: Path) -> None:
 
 def test_named_nested_fn_calls_not_bubbled_to_enclosing(tmp_path: Path) -> None:
     # (H) A NAMED nested `fn inner()` gets its own caller node and must OWN its body's
-    # (H) calls: `inner`'s `w.work()` belongs to crate.lib.outer.inner only, NOT also
-    # (H) to the enclosing `outer` (a spurious duplicate edge). Anonymous closures still
-    # (H) bubble; named nested fns do not.
+    # (H) calls: `inner`'s `w.work()` belongs to inner only, NOT also to the enclosing
+    # (H) `outer` (a spurious duplicate edge). Anonymous closures still bubble; named
+    # (H) nested fns do not. The caller qn is the one the definition pass REGISTERED
+    # (H) (crate.lib.inner is the actual Function node); the old crate.lib.outer.inner
+    # (H) attribution was a phantom FROM endpoint the database dropped (issue #652).
     _make_crate(
         tmp_path,
         "pub struct Worker {}\n"
@@ -203,7 +205,7 @@ def test_named_nested_fn_calls_not_bubbled_to_enclosing(tmp_path: Path) -> None:
         "}\n",
     )
     calls = _calls(tmp_path)
-    assert ("crate.lib.outer.inner", "crate.lib.Worker.work") in calls
+    assert ("crate.lib.inner", "crate.lib.Worker.work") in calls
     assert ("crate.lib.outer", "crate.lib.Worker.work") not in calls
 
 

--- a/codebase_rag/tests/test_ts_namespace_merging_containment.py
+++ b/codebase_rag/tests/test_ts_namespace_merging_containment.py
@@ -71,14 +71,13 @@ def test_merged_namespace_member_calls_attribute_to_registered_qn(
     }
     # (H) info() calls the sibling namespace function log(); both live under
     # (H) the namespace's registered (duplicate-suffixed) qn.
-    log_edges = [
-        (f, t) for f, t in calls if f.endswith(".info") and t.endswith(".log")
-    ]
+    log_edges = [(f, t) for f, t in calls if f.endswith(".info") and t.endswith(".log")]
     assert log_edges, calls
     for from_qn, to_qn in log_edges:
-        assert from_qn.rsplit(cs.SEPARATOR_DOT, 1)[0] == to_qn.rsplit(
-            cs.SEPARATOR_DOT, 1
-        )[0], (from_qn, to_qn)
+        assert (
+            from_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
+            == to_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
+        ), (from_qn, to_qn)
     # (H) The module-level Logger("hi") call still reaches the merged function.
     assert (f"{project}.namespace_merging", f"{project}.namespace_merging.Logger") in (
         calls

--- a/codebase_rag/tests/test_ts_namespace_merging_containment.py
+++ b/codebase_rag/tests/test_ts_namespace_merging_containment.py
@@ -1,0 +1,85 @@
+# (H) TS declaration merging (`class Calculator` + `namespace Calculator`)
+# (H) registers the namespace under a `qn@line` duplicate, and its members
+# (H) under `Calculator@line.create`. Pass-3 caller attribution re-derived the
+# (H) natural `Calculator.create` from the AST, so every edge FROM a merged
+# (H) namespace member had a phantom endpoint; and variant fan-out emitted the
+# (H) namespace duplicate with the CALLEE's label (Function Logger@13 for a
+# (H) Class node), a label mismatch the database drops (issue #652). Pass 3
+# (H) must reuse the registered qn (the C++ record-and-reuse rule, extended to
+# (H) every language) and fan out only to variants whose registered type
+# (H) matches the edge.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import get_relationships, run_updater
+
+MERGING_TS = """
+class Calculator {
+    add(value: number): this { return this; }
+}
+namespace Calculator {
+    export function create(): Calculator {
+        return new Calculator();
+    }
+}
+function Logger(message: string): void {
+    console.log(message);
+}
+namespace Logger {
+    export function log(message: string): void { Logger(message); }
+    export function info(message: string): void { Logger.log("INFO " + message); }
+}
+Logger("hi");
+"""
+
+
+def _node_keys(mock_ingestor: MagicMock) -> set[tuple[str, str]]:
+    return {
+        (str(c.args[0]), c.args[1].get("qualified_name"))
+        for c in mock_ingestor.ensure_node_batch.call_args_list
+    }
+
+
+def test_merged_namespace_members_emit_no_dangling_edges(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "namespace_merging.ts").write_text(MERGING_TS)
+    run_updater(temp_repo, mock_ingestor)
+
+    node_keys = _node_keys(mock_ingestor)
+    for rel_type in (cs.RelationshipType.CALLS, cs.RelationshipType.INSTANTIATES):
+        for call in get_relationships(mock_ingestor, rel_type.value):
+            from_label, _, from_qn = call.args[0]
+            to_label, _, to_qn = call.args[2]
+            assert (str(from_label), from_qn) in node_keys, call.args
+            assert (str(to_label), to_qn) in node_keys, call.args
+
+
+def test_merged_namespace_member_calls_attribute_to_registered_qn(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "namespace_merging.ts").write_text(MERGING_TS)
+    run_updater(temp_repo, mock_ingestor)
+
+    project = temp_repo.name
+    calls = {
+        (call.args[0][2], call.args[2][2])
+        for call in get_relationships(mock_ingestor, cs.RelationshipType.CALLS.value)
+    }
+    # (H) info() calls the sibling namespace function log(); both live under
+    # (H) the namespace's registered (duplicate-suffixed) qn.
+    log_edges = [
+        (f, t) for f, t in calls if f.endswith(".info") and t.endswith(".log")
+    ]
+    assert log_edges, calls
+    for from_qn, to_qn in log_edges:
+        assert from_qn.rsplit(cs.SEPARATOR_DOT, 1)[0] == to_qn.rsplit(
+            cs.SEPARATOR_DOT, 1
+        )[0], (from_qn, to_qn)
+    # (H) The module-level Logger("hi") call still reaches the merged function.
+    assert (f"{project}.namespace_merging", f"{project}.namespace_merging.Logger") in (
+        calls
+    ), calls

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -554,6 +554,7 @@ class DeferredInherit(NamedTuple):
     parent_qn: str
     module_qn: str
     base_index: int
+    language: SupportedLanguage
 
 
 class DeferredImportEdge(NamedTuple):
@@ -703,12 +704,20 @@ RELATIONSHIP_SCHEMAS: tuple[RelationshipSchema, ...] = (
     RelationshipSchema(
         (NodeLabel.CLASS, NodeLabel.INTERFACE, NodeLabel.FUNCTION),
         RelationshipType.INHERITS,
-        (NodeLabel.CLASS, NodeLabel.INTERFACE, NodeLabel.FUNCTION),
+        # (H) ExternalModule: a positively-external base (typing.Protocol,
+        # (H) js builtin.Error) keeps its edge by targeting the same external
+        # (H) node the import pass mints, mirroring Module IMPORTS.
+        (
+            NodeLabel.CLASS,
+            NodeLabel.INTERFACE,
+            NodeLabel.FUNCTION,
+            NodeLabel.EXTERNAL_MODULE,
+        ),
     ),
     RelationshipSchema(
         (NodeLabel.CLASS, NodeLabel.ENUM),
         RelationshipType.IMPLEMENTS,
-        (NodeLabel.INTERFACE,),
+        (NodeLabel.INTERFACE, NodeLabel.EXTERNAL_MODULE),
     ),
     RelationshipSchema(
         # (H) A method-body anonymous-class override is registered as a Function node,

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -540,6 +540,22 @@ class DeferredCppInherit(NamedTuple):
     base_index: int
 
 
+class DeferredInherit(NamedTuple):
+    """Non-C++ INHERITS/IMPLEMENTS edge held back until every class is registered.
+
+    A parent that does not resolve at parse time is anchored to the child's
+    own module qn as a guess; the edge is emitted after Pass 2 with the guess
+    re-resolved against the full registry. An unresolvable parent emits no
+    edge rather than a phantom the database would drop.
+    """
+
+    rel_type: RelationshipType
+    child_qn: str
+    parent_qn: str
+    module_qn: str
+    base_index: int
+
+
 class RelationshipSchema(NamedTuple):
     sources: tuple[NodeLabel, ...]
     rel_type: RelationshipType

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -556,6 +556,19 @@ class DeferredInherit(NamedTuple):
     base_index: int
 
 
+class DeferredImportEdge(NamedTuple):
+    """IMPORTS edge held back until every file is parsed.
+
+    An internal-looking target is only real if some file (or inline module)
+    actually yields that module qn; verification happens against the full
+    module registry, and a target that resolves nowhere emits no edge.
+    """
+
+    module_qn: str
+    full_name: str
+    language: SupportedLanguage
+
+
 class RelationshipSchema(NamedTuple):
     sources: tuple[NodeLabel, ...]
     rel_type: RelationshipType

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -509,7 +509,7 @@ class DeferredParentLink(NamedTuple):
     rel_type: str = RelationshipType.DEFINES.value
 
 
-class CppFunctionLocation(NamedTuple):
+class FunctionLocation(NamedTuple):
     """Where the definition pass put a C++ function/method node.
 
     Keyed by (module_qn, start_line) so Pass-3 call attribution reuses the

--- a/evals/cgr_graph.py
+++ b/evals/cgr_graph.py
@@ -56,6 +56,12 @@ _DEFINES_RELS = frozenset(
         cs.RelationshipType.DEFINES_METHOD.value,
     }
 )
+_MODULE_QN_LABELS = frozenset(
+    {
+        _MODULE_LABEL,
+        cs.NodeLabel.MODULE_INTERFACE.value,
+    }
+)
 _DEFINITION_LABELS = frozenset(
     {
         cs.NodeLabel.FUNCTION.value,
@@ -187,6 +193,17 @@ class _StatefulIngestor:
                     )
                 inherits.sort(key=lambda item: (item[0], item[1]))
                 return [row for _child, _index, row in inherits]
+            case cs.CYPHER_ALL_MODULE_QNS:
+                module_rows: list[ResultRow] = []
+                for (label, _uid), props in self.nodes.items():
+                    if label not in _MODULE_QN_LABELS:
+                        continue
+                    module_row: ResultRow = {
+                        cs.KEY_QUALIFIED_NAME: _text(props.get(cs.KEY_QUALIFIED_NAME)),
+                        cs.KEY_LABEL: label,
+                    }
+                    module_rows.append(module_row)
+                return module_rows
             case cs.CYPHER_ALL_MODULE_PATHS_INTERNAL:
                 rows: list[ResultRow] = []
                 for (label, _uid), props in self.nodes.items():


### PR DESCRIPTION
## Summary

Iteration 3 of the dangling-edge campaign (#652): eliminates every remaining dangling relationship across ALL language fixtures and flips the conftest audit gate so every fixture test now enforces zero dangling edges permanently.

An edge with a phantom endpoint is silently dropped by Memgraph's MERGE, so everything fixed here was information the live database never actually contained.

## Numbers

- Fixture sweep: **868 -> 0** dangling violations across Python, Java, JS/TS, Rust, Lua, Go, and C++20 modules
- souffle dogfood corpus re-measure: **0 dangling of 70,652 edges** (iteration 2 result preserved)
- Full suite: **4,618 passed / 0 failed** with the dangling gate enforced on every fixture test
- Campaign total: 18,175 -> 0 (#655/#657/#663/this)

## Root fixes (each red -> green in history)

1. **JS/TS builtin calls**: a callee resolving to a synthetic `builtin.*` qn (console.log, JSON.stringify, Function.prototype.bind) has no node, so no CALLS edge is emitted at all, mirroring the C++ builtin-operator rule. First-party callbacks handed to builtins stay reachable through the argument-flow path.
2. **Deferred non-C++ INHERITS/IMPLEMENTS**: parents now resolve after every class is registered (the iteration-2 C++ design, generalized via `DeferredInherit`), so cross-file bases no longer depend on parse order and self-edges are guarded on both resolution branches.
3. **External bases target ExternalModule nodes**: a positively-external base (import-mapped `typing.Protocol`, `::`-qualified `std::fmt::Display`, or a JS global like `Error`) keeps its edge by targeting the same ExternalModule node the import pass mints; the INHERITS/IMPLEMENTS schema targets are extended with `ExternalModule` (the #498 precedent). This also restores Protocol detection for dead-code analysis and incremental protocol dispatch, both of which the live database had silently lost. A module-anchored guess that resolves nowhere still emits nothing: knowledge and guesses are not the same.
4. **Verified IMPORTS emission**: all IMPORTS edges (including the CommonJS destructuring fallback, previously a direct-emission bypass) defer to a post-parse flush that verifies internal targets against the real module registry: file modules, inline modules, rehydrated modules on incremental runs (`CYPHER_ALL_MODULE_QNS`), index-file aliases (`__init__`/`index`/`mod`/`init`), and a unique whole-segment suffix match. Broken imports drop; package-anchored stdlib guesses re-resolve as absolute Python imports; explicit `.js`/`.ts` extensions strip during JS path resolution; C++20 module declarations never emit self-imports and implementation units link only to interfaces that exist.
5. **Record-and-reuse generalized to every language**: `cpp_function_locations` became `function_locations`; Pass 3 reuses the qn/label Pass 2 registered instead of re-deriving, fixing TS declaration merging (members registered under `Logger@13` while callers were attributed to `Logger`) and a Rust nested-fn phantom FROM endpoint. Rust keeps its ownership-aware call filter on the recorded path.
6. **Type-filtered variant fan-out**: duplicate-qn variants only receive CALLS if registered callable and INSTANTIATES if registered as a class, so a merged TS namespace (a Class duplicate of a Function) no longer takes a label-mismatched edge.

Test-expectation corrections are limited to assertions that encoded phantom edges (undefined Java generic bases, a Go package-dir import target, builtin-call counts, JS fixtures whose imported files never existed); each carries an explanatory comment.

## Verification

- `uv run pytest codebase_rag/tests -n auto`: 4618 passed, 14 skipped
- souffle mock-ingestor measurement: 0 dangling, 0 orphans
- `uv run ty check`: at the 352-diagnostic baseline (no new)

Closes the fixture-level goal of #652.
