### PR TITLE
fix(java): externalize implicit java.lang bases onto ExternalModule nodes

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -2634,6 +2634,66 @@ JAVA_WRAPPER_TYPES = frozenset(
     }
 )
 
+# (H) java.lang types Java code names WITHOUT an import (the implicit java.lang
+# (H) import). A bare `extends`/`implements` base matching one of these that
+# (H) resolves to no first-party type is positively external
+# (H) (java.lang.<Name>), not an unresolvable guess; mirrors the JS global
+# (H) class rule (JS_GLOBAL_CLASS_NAMES -> builtin.<Name>).
+JAVA_LANG_CLASS_NAMES = JAVA_WRAPPER_TYPES | frozenset(
+    {
+        "Byte",
+        "Short",
+        "Float",
+        "Character",
+        "Number",
+        "Void",
+        "Enum",
+        "Record",
+        "Thread",
+        "ThreadLocal",
+        "ClassLoader",
+        "SecurityManager",
+        "StringBuilder",
+        "StringBuffer",
+        "Throwable",
+        "Exception",
+        "RuntimeException",
+        "Error",
+        "IllegalArgumentException",
+        "IllegalStateException",
+        "UnsupportedOperationException",
+        "NullPointerException",
+        "IndexOutOfBoundsException",
+        "ArrayIndexOutOfBoundsException",
+        "StringIndexOutOfBoundsException",
+        "ClassCastException",
+        "ArithmeticException",
+        "NumberFormatException",
+        "InterruptedException",
+        "CloneNotSupportedException",
+        "ReflectiveOperationException",
+        "ClassNotFoundException",
+        "NoSuchMethodException",
+        "NoSuchFieldException",
+        "InstantiationException",
+        "IllegalAccessException",
+        "SecurityException",
+        "AssertionError",
+        "StackOverflowError",
+        "OutOfMemoryError",
+        "LinkageError",
+        "NoClassDefFoundError",
+        "Runnable",
+        "Comparable",
+        "Iterable",
+        "Cloneable",
+        "AutoCloseable",
+        "CharSequence",
+        "Appendable",
+        "Readable",
+    }
+)
+
 # (H) Java tree-sitter node types
 TS_FORMAL_PARAMETER = "formal_parameter"
 TS_SPREAD_PARAMETER = "spread_parameter"

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -451,7 +451,8 @@ class ClassIngestMixin:
         First-party wins; a qn outside the project prefix is positive external
         knowledge (import-mapped or ::-qualified) and keeps its edge onto an
         ExternalModule node; a module-anchored GUESS that re-resolves nowhere
-        emits nothing, except a JS/TS global (Error) which is externalized.
+        emits nothing, except a JS/TS global (Error) or an implicitly imported
+        java.lang type (Exception, Runnable), which are externalized.
         """
         if (
             # (H) Parse-time resolution of a nested external base (`Entry
@@ -487,6 +488,13 @@ class ClassIngestMixin:
             and raw_name in cs.JS_GLOBAL_CLASS_NAMES
         ):
             return f"{cs.BUILTIN_PREFIX}{cs.SEPARATOR_DOT}{raw_name}", True
+        # (H) java.lang is implicitly imported: a bare base in its table is
+        # (H) positive external knowledge, not a guess.
+        if (
+            entry.language == cs.SupportedLanguage.JAVA
+            and raw_name in cs.JAVA_LANG_CLASS_NAMES
+        ):
+            return f"{cs.JAVA_LANG_PREFIX}{raw_name}", True
         return None
 
     def _process_class_node(

--- a/codebase_rag/tests/test_java_lang_base_externalization.py
+++ b/codebase_rag/tests/test_java_lang_base_externalization.py
@@ -1,0 +1,112 @@
+# (H) Java implicitly imports java.lang, so `extends Exception` or
+# (H) `implements Runnable` names a POSITIVELY external base with no import
+# (H) statement to map it. The deferred-inherits resolver used to treat these
+# (H) as unresolvable module-anchored guesses and emit nothing, losing real
+# (H) inheritance knowledge the graph should keep. Mirroring the JS global
+# (H) rule (Error -> builtin.Error), a bare base in the java.lang table now
+# (H) emits onto an ExternalModule node (java.lang.Exception), reusing the
+# (H) JAVA_LANG_PREFIX machinery the receiver type resolver already has.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import get_relationships, run_updater
+
+EXCEPTIONS_JAVA = """
+package errors;
+
+public class CustomException extends Exception {
+    public CustomException(String message) {
+        super(message);
+    }
+}
+"""
+
+TASK_JAVA = """
+package work;
+
+public class Task implements Runnable, Comparable<Task> {
+    public void run() {}
+
+    public int compareTo(Task other) {
+        return 0;
+    }
+}
+"""
+
+UNKNOWN_BASE_JAVA = """
+package widgets;
+
+public class FancyWidget extends Widget {
+    public int size() { return 1; }
+}
+"""
+
+
+def _pairs(mock_ingestor: MagicMock, rel_type: cs.RelationshipType) -> set[tuple]:
+    return {
+        (call.args[0][2], str(call.args[2][0]), call.args[2][2])
+        for call in get_relationships(mock_ingestor, rel_type.value)
+    }
+
+
+def _node_keys(mock_ingestor: MagicMock) -> set[tuple[str, str]]:
+    return {
+        (str(c.args[0]), c.args[1].get("qualified_name"))
+        for c in mock_ingestor.ensure_node_batch.call_args_list
+    }
+
+
+def test_java_lang_exception_base_emits_external_edge_and_node(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "CustomException.java").write_text(EXCEPTIONS_JAVA)
+    run_updater(temp_repo, mock_ingestor, skip_if_missing="java")
+
+    project = temp_repo.name
+    inherits = _pairs(mock_ingestor, cs.RelationshipType.INHERITS)
+    expected = (
+        f"{project}.CustomException.CustomException",
+        cs.NodeLabel.EXTERNAL_MODULE.value,
+        f"{cs.JAVA_LANG_PREFIX}Exception",
+    )
+    assert expected in inherits, inherits
+    assert (
+        cs.NodeLabel.EXTERNAL_MODULE.value,
+        f"{cs.JAVA_LANG_PREFIX}Exception",
+    ) in _node_keys(mock_ingestor)
+
+
+def test_java_lang_interfaces_emit_external_implements(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "Task.java").write_text(TASK_JAVA)
+    run_updater(temp_repo, mock_ingestor, skip_if_missing="java")
+
+    project = temp_repo.name
+    implements = _pairs(mock_ingestor, cs.RelationshipType.IMPLEMENTS)
+    child = f"{project}.Task.Task"
+    for iface in ("Runnable", "Comparable"):
+        expected = (
+            child,
+            cs.NodeLabel.EXTERNAL_MODULE.value,
+            f"{cs.JAVA_LANG_PREFIX}{iface}",
+        )
+        assert expected in implements, implements
+
+
+def test_unknown_bare_base_still_emits_nothing(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) A bare base NOT in the java.lang table stays an unresolvable guess;
+    # (H) knowledge and guesses are not the same.
+    (temp_repo / "FancyWidget.java").write_text(UNKNOWN_BASE_JAVA)
+    run_updater(temp_repo, mock_ingestor, skip_if_missing="java")
+
+    project = temp_repo.name
+    inherits = _pairs(mock_ingestor, cs.RelationshipType.INHERITS)
+    assert not any(
+        frm == f"{project}.FancyWidget.FancyWidget" for frm, _, _ in inherits
+    ), inherits

--- a/codebase_rag/tests/test_java_overload_resolution.py
+++ b/codebase_rag/tests/test_java_overload_resolution.py
@@ -106,5 +106,6 @@ def test_same_arity_overload_binds_by_argument_type(
         f.endswith(".M.use(String)") and t.endswith(".M.isX(String)") for f, t in calls
     ), sorted(t for f, t in calls if "isX" in t)
     assert not any(
-        f.endswith(".M.use(String)") and t.endswith(".M.isX(Class<?>)") for f, t in calls
+        f.endswith(".M.use(String)") and t.endswith(".M.isX(Class<?>)")
+        for f, t in calls
     ), "String-arg call wrongly bound to the Class overload"

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.261"
+version = "0.0.263"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Follow-up to #665. Java implicitly imports `java.lang`, so a bare `extends Exception` or `implements Runnable` names a positively external base with no import statement to map it. The deferred-inherits resolver treated these as unresolvable module-anchored guesses and emitted nothing, losing real inheritance knowledge (`class X extends Exception` is one of the most common shapes in Java code).

A new `JAVA_LANG_CLASS_NAMES` table (a superset of the existing `JAVA_WRAPPER_TYPES`, so wrapper types stay single-sourced) is consulted by `_resolve_deferred_parent_qn` exactly like `JS_GLOBAL_CLASS_NAMES` is for JS globals: a bare base in the table resolves to `java.lang.<Name>` and emits onto an ExternalModule node, the same node an explicit import of it would mint. A bare base NOT in the table still emits nothing; knowledge and guesses are not the same.

## Verification

- Red -> green in history: `test_java_lang_base_externalization.py` (exception base, interface bases, and the unknown-base negative)
- `uv run pytest codebase_rag/tests -n auto`: 4640 passed, 0 failed, with the #665 dangling gate verifying every new edge endpoint exists
- `uv run ty check`: at the 352-diagnostic baseline
