### PR TITLE
fix(evals): restore all eight language oracles to 1.0 on thrift after the dangling-edge campaign

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -603,13 +603,18 @@ class GraphUpdater:
         # (H) IMPORTS edges verify against every module qn this run produced
         # (H) (files, inline modules, rehydrated unchanged files); an internal
         # (H) target that resolves nowhere emits no edge.
-        known_module_qns = (
-            {str(qn) for qn in self.factory.definition_processor.module_qn_to_file_path}
-            | self.factory.definition_processor.declared_module_qns
-            | self._rehydrated_module_qns
-        )
+        known_module_paths: dict[str, str] = {
+            str(qn): path.as_posix()
+            for qn, path in (
+                self.factory.definition_processor.module_qn_to_file_path.items()
+            )
+        }
+        for qn in self.factory.definition_processor.declared_module_qns:
+            known_module_paths.setdefault(qn, "")
+        for qn in self._rehydrated_module_qns:
+            known_module_paths.setdefault(qn, "")
         imports_emitted = self.factory.import_processor.flush_deferred_import_edges(
-            known_module_qns
+            known_module_paths
         )
         if imports_emitted:
             logger.info("Emitted {} verified IMPORTS edges", imports_emitted)

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -460,11 +460,19 @@ class ClassIngestMixin:
         fact the source declares.
         """
         if entry.parent_qn == entry.child_qn:
-            # (H) Parse-time resolution of a nested external base (`Entry
-            # (H) implements Map.Entry`) can land on the child ITSELF (the only
-            # (H) registered qn ending in Entry); a self-edge is never real,
-            # (H) and the raw-name derivation below would be a lie here (the
-            # (H) remainder is the child's own name, not the written base).
+            # (H) Parse-time resolution can land on the child ITSELF. A
+            # (H) self-edge is never real, so the written base must refer to a
+            # (H) SHADOWED outer name (thrift's `pub enum Error` implementing
+            # (H) the std `Error` trait): when the module-anchored remainder is
+            # (H) a bare single segment it IS the written name and
+            # (H) externalizes. A dotted remainder (a nested child like
+            # (H) SimpleHashMap.Entry) was never written as such; derivation
+            # (H) would be a lie, so no edge.
+            self_prefix = f"{entry.module_qn}{cs.SEPARATOR_DOT}"
+            if entry.parent_qn.startswith(self_prefix):
+                raw = entry.parent_qn[len(self_prefix) :]
+                if raw and cs.SEPARATOR_DOT not in raw:
+                    return self._externalize_written_base(raw, entry.language)
             return None
         if self.function_registry.get(entry.parent_qn) is not None:
             return entry.parent_qn, False
@@ -505,15 +513,17 @@ class ClassIngestMixin:
             and self.function_registry.get(resolved) is not None
         ):
             return resolved, False
-        if (
-            entry.language in cs.JS_TS_LANGUAGES
-            and raw_name in cs.JS_GLOBAL_CLASS_NAMES
-        ):
+        return self._externalize_written_base(raw_name, entry.language)
+
+    def _externalize_written_base(
+        self, raw_name: str, language: cs.SupportedLanguage
+    ) -> tuple[str, bool]:
+        if language in cs.JS_TS_LANGUAGES and raw_name in cs.JS_GLOBAL_CLASS_NAMES:
             return f"{cs.BUILTIN_PREFIX}{cs.SEPARATOR_DOT}{raw_name}", True
         # (H) java.lang is implicitly imported: a bare base in its table gets
         # (H) its canonical java.lang qn.
         if (
-            entry.language == cs.SupportedLanguage.JAVA
+            language == cs.SupportedLanguage.JAVA
             and raw_name in cs.JAVA_LANG_CLASS_NAMES
         ):
             return f"{cs.JAVA_LANG_PREFIX}{raw_name}", True

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -450,17 +450,23 @@ class ClassIngestMixin:
 
         First-party wins; a qn outside the project prefix is positive external
         knowledge (import-mapped or ::-qualified) and keeps its edge onto an
-        ExternalModule node; a module-anchored GUESS that re-resolves nowhere
-        emits nothing, except a JS/TS global (Error) or an implicitly imported
-        java.lang type (Exception, Runnable), which are externalized.
+        ExternalModule node. A project-prefixed qn that is not a real class
+        may still name one through a src-root layout (setup.py maps src/ to
+        the distribution name), recovered by a unique whole-segment suffix
+        match. A module-anchored guess that re-resolves nowhere externalizes
+        its WRITTEN name (canonicalized for JS globals and java.lang): a base
+        name resolving to no indexed class is by construction defined outside
+        the indexed tree, and dropping it would lose a syntactic inheritance
+        fact the source declares.
         """
-        if (
+        if entry.parent_qn == entry.child_qn:
             # (H) Parse-time resolution of a nested external base (`Entry
             # (H) implements Map.Entry`) can land on the child ITSELF (the only
-            # (H) registered qn ending in Entry); a self-edge is never real.
-            entry.parent_qn != entry.child_qn
-            and self.function_registry.get(entry.parent_qn) is not None
-        ):
+            # (H) registered qn ending in Entry); a self-edge is never real,
+            # (H) and the raw-name derivation below would be a lie here (the
+            # (H) remainder is the child's own name, not the written base).
+            return None
+        if self.function_registry.get(entry.parent_qn) is not None:
             return entry.parent_qn, False
         project_prefix = f"{self.project_name}{cs.SEPARATOR_DOT}"
         if not entry.parent_qn.startswith(project_prefix):
@@ -468,11 +474,27 @@ class ClassIngestMixin:
                 cs.SEPARATOR_DOUBLE_COLON, cs.SEPARATOR_DOT
             )
             return external, True
-        # (H) The module-anchored fallback shape is re-resolvable: its raw
-        # (H) written name is the remainder after the module qn.
         prefix = f"{entry.module_qn}{cs.SEPARATOR_DOT}"
         if not entry.parent_qn.startswith(prefix):
+            # (H) Project-prefixed but not module-anchored: an import-mapped
+            # (H) qn whose written path skips real directories (thrift's
+            # (H) setup.py maps lib/py/src -> package `thrift`, so the import
+            # (H) says thrift.Thrift while the class qn says
+            # (H) thrift.src.Thrift). A UNIQUE whole-segment suffix match
+            # (H) recovers the real node; ambiguity means no edge.
+            tail = entry.parent_qn[len(project_prefix) :]
+            simple = tail.rsplit(cs.SEPARATOR_DOT, 1)[-1]
+            suffix = f"{cs.SEPARATOR_DOT}{tail}"
+            matches = {
+                qn
+                for qn in self.function_registry.find_ending_with(simple)
+                if qn.endswith(suffix) and qn != entry.child_qn
+            }
+            if len(matches) == 1:
+                return matches.pop(), False
             return None
+        # (H) The module-anchored fallback shape carries the raw written name
+        # (H) as the remainder after the module qn.
         raw_name = entry.parent_qn[len(prefix) :]
         resolved = self._resolve_class_name(raw_name, entry.module_qn)
         if (
@@ -488,14 +510,18 @@ class ClassIngestMixin:
             and raw_name in cs.JS_GLOBAL_CLASS_NAMES
         ):
             return f"{cs.BUILTIN_PREFIX}{cs.SEPARATOR_DOT}{raw_name}", True
-        # (H) java.lang is implicitly imported: a bare base in its table is
-        # (H) positive external knowledge, not a guess.
+        # (H) java.lang is implicitly imported: a bare base in its table gets
+        # (H) its canonical java.lang qn.
         if (
             entry.language == cs.SupportedLanguage.JAVA
             and raw_name in cs.JAVA_LANG_CLASS_NAMES
         ):
             return f"{cs.JAVA_LANG_PREFIX}{raw_name}", True
-        return None
+        # (H) Language-agnostic fallback: the written base name resolves to no
+        # (H) indexed class, so the base is external to the index by
+        # (H) construction (Python `object`, Rust `Default`, a generated Java
+        # (H) `Iface`); keep the fact under the written name.
+        return raw_name.replace(cs.SEPARATOR_DOUBLE_COLON, cs.SEPARATOR_DOT), True
 
     def _process_class_node(
         self,

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -1042,11 +1042,15 @@ class FunctionIngestMixin:
         child_label: str,
         child_qn: str,
         module_qn: str,
+        fallback_label: str | None = None,
+        fallback_qn: str | None = None,
     ) -> None:
         # (H) Module nodes always exist, so module-parented edges emit directly.
         # (H) Any other parent may be registered by a later pass (methods land
         # (H) after functions) or may be a phantom recomputed qn the database
-        # (H) would drop; both resolve in resolve_deferred_parent_links.
+        # (H) would drop; both resolve in resolve_deferred_parent_links, where
+        # (H) the optional fallback (a nested child's lexical enclosing
+        # (H) function) beats the module anchor.
         if parent_label == cs.NodeLabel.MODULE:
             self.ingestor.ensure_relationship_batch(
                 (parent_label, cs.KEY_QUALIFIED_NAME, parent_qn),
@@ -1061,6 +1065,8 @@ class FunctionIngestMixin:
                 child_label=child_label,
                 child_qn=child_qn,
                 module_qn=module_qn,
+                fallback_label=fallback_label,
+                fallback_qn=fallback_qn,
             )
         )
 
@@ -1083,6 +1089,21 @@ class FunctionIngestMixin:
                     entry.parent_qn,
                 )
                 rel_type = entry.rel_type
+            elif (
+                entry.fallback_qn is not None
+                and entry.fallback_label is not None
+                and self.function_registry.get(entry.fallback_qn) is not None
+            ):
+                # (H) The parent guess never registered but the child's lexical
+                # (H) enclosing function did (a prototype assignment on a
+                # (H) parameter inside a function body); the lexical parent is
+                # (H) the true containment, not the module.
+                parent_spec = (
+                    cs.NodeLabel(entry.fallback_label),
+                    cs.KEY_QUALIFIED_NAME,
+                    entry.fallback_qn,
+                )
+                rel_type = cs.RelationshipType.DEFINES.value
             else:
                 # (H) A method whose container never registered (impl on a
                 # (H) primitive, macro-corrupted class) anchors to its module
@@ -1172,6 +1193,26 @@ class FunctionIngestMixin:
                 # (H) loses that callback: anonymous scopes contribute no segment to
                 # (H) the child qn, so trimming the child qn would skip the callback
                 # (H) and hoist the child to the nearest named ancestor.
+                # (H) A Go receiver method's node lives under its receiver type
+                # (H) (module.Type.Method); identity resolution alone gives the
+                # (H) receiver-dropping module.Method, a phantom, so a local
+                # (H) type declared in the method body would fall back to the
+                # (H) module instead of its true lexical parent.
+                if (
+                    language == cs.SupportedLanguage.GO
+                    and go_utils.is_receiver_method(current)
+                    and (name_node := current.child_by_field_name(cs.FIELD_NAME))
+                    is not None
+                    and (method_name := safe_decode_text(name_node))
+                    and (receiver_type := go_utils.extract_receiver_type_name(current))
+                ):
+                    container_qn = self._resolve_go_container_qn(
+                        module_qn, receiver_type
+                    )
+                    return (
+                        cs.NodeLabel.METHOD,
+                        f"{container_qn}{cs.SEPARATOR_DOT}{method_name}",
+                    )
                 resolution = (
                     self._resolve_function_identity(
                         current, module_qn, language, lang_config, file_path

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -416,6 +416,23 @@ class ImportProcessor:
         module_aliases = self._module_alias_map(known_module_qns)
         emitted = 0
         for entry in deferred:
+            # (H) `from pkg.transport import TTransport` is ambiguous in
+            # (H) Python: TTransport may be an item OR a submodule. The stdlib
+            # (H) extractor strips it as an item, anchoring the edge at the
+            # (H) package; when the FULL dotted name verifies as a real module,
+            # (H) the submodule is the true target.
+            if entry.language == cs.SupportedLanguage.PYTHON and (
+                full_target := self._verify_internal_import_target(
+                    entry.full_name, known_module_qns, module_aliases
+                )
+            ):
+                self.ingestor.ensure_relationship_batch(
+                    (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, entry.module_qn),
+                    cs.RelationshipType.IMPORTS,
+                    (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, full_target),
+                )
+                emitted += 1
+                continue
             module_path = self._resolve_module_path(
                 entry.full_name, entry.module_qn, entry.language
             )

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -10,7 +10,7 @@ from tree_sitter import Node
 
 from .. import constants as cs
 from .. import logs as ls
-from ..language_spec import LanguageSpec
+from ..language_spec import LANGUAGE_SPECS, LanguageSpec
 from ..services import IngestorProtocol
 from ..types_defs import (
     DeferredImportEdge,
@@ -400,19 +400,21 @@ class ImportProcessor:
             )
         )
 
-    def flush_deferred_import_edges(self, known_module_qns: set[str]) -> int:
+    def flush_deferred_import_edges(self, known_module_paths: dict[str, str]) -> int:
         """Emit IMPORTS edges now that every file is parsed.
 
         An external target gets its ExternalModule node as before. An internal
-        target must verify against the real module qns; a guess that resolves
-        nowhere (a broken import, a directory with no index module, a crate
-        path resolved from the wrong root) emits no edge, because the phantom
-        endpoint is silently dropped by the database anyway.
+        target must verify against the real module qns (with their file paths
+        for language tie-breaking); a guess that resolves nowhere (a broken
+        import, a directory with no index module, a crate path resolved from
+        the wrong root) emits no edge, because the phantom endpoint is
+        silently dropped by the database anyway.
         """
         deferred = self._deferred_import_edges
         if not deferred or self.ingestor is None:
             return 0
         self._deferred_import_edges = []
+        known_module_qns = set(known_module_paths)
         module_aliases = self._module_alias_map(known_module_qns)
         emitted = 0
         for entry in deferred:
@@ -423,7 +425,7 @@ class ImportProcessor:
             # (H) the submodule is the true target.
             if entry.language == cs.SupportedLanguage.PYTHON and (
                 full_target := self._verify_internal_import_target(
-                    entry.full_name, known_module_qns, module_aliases
+                    entry.full_name, known_module_paths, module_aliases, entry.language
                 )
             ):
                 self.ingestor.ensure_relationship_batch(
@@ -444,7 +446,7 @@ class ImportProcessor:
                 self._ensure_external_module_node(module_path, entry.full_name)
             else:
                 verified = self._verify_internal_import_target(
-                    module_path, known_module_qns, module_aliases
+                    module_path, known_module_paths, module_aliases, entry.language
                 )
                 if verified is None and entry.language == cs.SupportedLanguage.PYTHON:
                     # (H) A package-anchored guess that names no sibling module
@@ -508,10 +510,11 @@ class ImportProcessor:
     def _verify_internal_import_target(
         self,
         module_path: str,
-        known_module_qns: set[str],
+        known_module_paths: dict[str, str],
         module_aliases: dict[str, str],
+        language: cs.SupportedLanguage,
     ) -> str | None:
-        if module_path in known_module_qns:
+        if module_path in known_module_paths:
             return module_path
         if alias := module_aliases.get(module_path):
             return alias
@@ -525,13 +528,33 @@ class ImportProcessor:
         if not tail:
             return None
         suffix = f"{cs.SEPARATOR_DOT}{tail}"
-        matches = {qn for qn in known_module_qns if qn.endswith(suffix)}
+        matches = {qn for qn in known_module_paths if qn.endswith(suffix)}
         matches.update(
             real for base, real in module_aliases.items() if base.endswith(suffix)
         )
+        if len(matches) > 1:
+            # (H) A polyglot repo can hold same-named modules in several
+            # (H) languages (thrift: src/protocol/__init__.py vs
+            # (H) src/ext/protocol.h); the importing language can only target
+            # (H) its own modules, so tie-break by file extension. Inline
+            # (H) modules (no file) stay eligible.
+            matches = {
+                qn
+                for qn in matches
+                if self._path_matches_language(known_module_paths.get(qn, ""), language)
+            }
         if len(matches) == 1:
             return matches.pop()
         return None
+
+    @staticmethod
+    def _path_matches_language(path: str, language: cs.SupportedLanguage) -> bool:
+        if not path:
+            return True
+        spec = LANGUAGE_SPECS.get(language)
+        if spec is None:
+            return True
+        return path.endswith(tuple(spec.file_extensions))
 
     def _parse_python_imports(self, captures: dict, module_qn: str) -> None:
         all_imports = captures.get(cs.CAPTURE_IMPORT, []) + captures.get(

--- a/codebase_rag/parsers/js_ts/ingest.py
+++ b/codebase_rag/parsers/js_ts/ingest.py
@@ -56,6 +56,8 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
         child_label: str,
         child_qn: str,
         module_qn: str,
+        fallback_label: str | None = None,
+        fallback_qn: str | None = None,
     ) -> None: ...
 
     @abstractmethod
@@ -67,6 +69,16 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
         lang_config: LanguageSpec,
         skip_classes: bool = False,
     ) -> str | None: ...
+
+    @abstractmethod
+    def _determine_function_parent(
+        self,
+        func_node: ASTNode,
+        func_qn: str,
+        module_qn: str,
+        lang_config: LanguageSpec,
+        language: cs.SupportedLanguage | None = None,
+    ) -> tuple[str, str]: ...
 
     def _ingest_prototype_inheritance(
         self,
@@ -155,11 +167,45 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
             return
 
         try:
-            self._process_prototype_method_captures(language_obj, root_node, module_qn)
+            self._process_prototype_method_captures(
+                language_obj,
+                root_node,
+                module_qn,
+                lang_queries.get(cs.QUERY_CONFIG),
+                language,
+            )
         except Exception as e:
             logger.debug(lg.JS_PROTOTYPE_METHODS_FAILED, error=e)
 
-    def _process_prototype_method_captures(self, language_obj, root_node, module_qn):
+    def _lexical_defines_fallback(
+        self,
+        func_node: ASTNode,
+        child_qn: str,
+        module_qn: str,
+        lang_config: LanguageSpec | None,
+        language: cs.SupportedLanguage,
+    ) -> tuple[str | None, str | None]:
+        # (H) The lexical enclosing function of a specially-ingested function
+        # (H) (prototype assignment, object-literal property): the true parent
+        # (H) when the node is nested, None at top level (module parenting is
+        # (H) already correct there).
+        if lang_config is None:
+            return None, None
+        parent_label, parent_qn = self._determine_function_parent(
+            func_node, child_qn, module_qn, lang_config, language
+        )
+        if str(parent_label) == cs.NodeLabel.MODULE.value:
+            return None, None
+        return str(parent_label), parent_qn
+
+    def _process_prototype_method_captures(
+        self,
+        language_obj,
+        root_node,
+        module_qn,
+        lang_config: LanguageSpec | None = None,
+        language: cs.SupportedLanguage = cs.SupportedLanguage.JS,
+    ):
         method_query = get_cached_query(language_obj, cs.JS_PROTOTYPE_METHOD_QUERY)
         method_cursor = QueryCursor(method_query)
         method_captures = sorted_captures(method_cursor, root_node)
@@ -204,13 +250,21 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
                 # (H) The assignment target is not always a registered constructor
                 # (H) function: `target.prototype.render = ...` inside a decorator
                 # (H) names a parameter, so the parent qn would be a phantom the
-                # (H) database drops. Defer so it verifies against the registry.
+                # (H) database drops. Defer so it verifies against the registry,
+                # (H) and prefer the lexical enclosing function over the module
+                # (H) when the guess never registers (a prototype assignment
+                # (H) inside a function body belongs to that function).
+                fallback_label, fallback_qn = self._lexical_defines_fallback(
+                    func_node, method_qn, module_qn, lang_config, language
+                )
                 self._emit_or_defer_defines(
                     cs.NodeLabel.FUNCTION,
                     constructor_qn,
                     cs.NodeLabel.FUNCTION,
                     method_qn,
                     module_qn,
+                    fallback_label=fallback_label,
+                    fallback_qn=fallback_qn,
                 )
 
                 logger.debug(
@@ -234,7 +288,12 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
         try:
             for query_text in [cs.JS_OBJECT_METHOD_QUERY, cs.JS_METHOD_DEF_QUERY]:
                 self._process_object_method_query(
-                    language_obj, query_text, root_node, module_qn, lang_config
+                    language_obj,
+                    query_text,
+                    root_node,
+                    module_qn,
+                    lang_config,
+                    language,
                 )
         except Exception as e:
             logger.debug(lg.JS_OBJECT_METHODS_DETECT_FAILED, error=e)
@@ -246,6 +305,7 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
         root_node: ASTNode,
         module_qn: str,
         lang_config,
+        language: cs.SupportedLanguage,
     ) -> None:
         try:
             query = get_cached_query(language_obj, query_text)
@@ -271,7 +331,7 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
                 if not method_func_node:
                     continue
                 self._process_single_object_method(
-                    method_name_node, method_func_node, module_qn, lang_config
+                    method_name_node, method_func_node, module_qn, lang_config, language
                 )
         except Exception as e:
             logger.debug(lg.JS_OBJECT_METHODS_PROCESS_FAILED, error=e)
@@ -282,6 +342,7 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
         method_func_node: ASTNode,
         module_qn: str,
         lang_config,
+        language: cs.SupportedLanguage,
     ) -> None:
         if not method_name_node.text or not method_func_node:
             return
@@ -300,7 +361,7 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
         )
 
         self._register_object_method(
-            method_name, method_qn, method_func_node, module_qn
+            method_name, method_qn, method_func_node, module_qn, lang_config, language
         )
 
     def _resolve_object_method_qn(
@@ -329,6 +390,8 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
         method_qn: str,
         method_func_node: ASTNode,
         module_qn: str,
+        lang_config: LanguageSpec | None,
+        language: cs.SupportedLanguage,
     ) -> None:
         method_qn = self.function_registry.register_unique_qn(
             method_qn, method_func_node.start_point[0] + 1
@@ -349,11 +412,26 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
         self.function_registry[method_qn] = NodeType.FUNCTION
         self.simple_name_lookup[method_name].add(method_qn)
 
-        self.ingestor.ensure_relationship_batch(
-            (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, module_qn),
-            cs.RelationshipType.DEFINES,
-            (cs.NodeLabel.FUNCTION, cs.KEY_QUALIFIED_NAME, method_qn),
+        # (H) An object-literal function nested inside another function takes
+        # (H) its lexical parent, not the module (issue: module-parented
+        # (H) duplicates of correctly-parented nodes on thrift lib/js).
+        fallback_label, fallback_qn = self._lexical_defines_fallback(
+            method_func_node, method_qn, module_qn, lang_config, language
         )
+        if fallback_label is not None and fallback_qn is not None:
+            self._emit_or_defer_defines(
+                fallback_label,
+                fallback_qn,
+                cs.NodeLabel.FUNCTION,
+                method_qn,
+                module_qn,
+            )
+        else:
+            self.ingestor.ensure_relationship_batch(
+                (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, module_qn),
+                cs.RelationshipType.DEFINES,
+                (cs.NodeLabel.FUNCTION, cs.KEY_QUALIFIED_NAME, method_qn),
+            )
 
     def _ingest_assignment_arrow_functions(
         self,
@@ -375,7 +453,7 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
                 cs.JS_ASSIGNMENT_FUNCTION_QUERY,
             ]:
                 self._process_arrow_query(
-                    lang_query, query_text, root_node, module_qn, lang_config
+                    lang_query, query_text, root_node, module_qn, lang_config, language
                 )
         except Exception as e:
             logger.debug(lg.JS_ASSIGNMENT_ARROW_DETECT_FAILED, error=e)
@@ -387,6 +465,7 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
         root_node: ASTNode,
         module_qn: str,
         lang_config,
+        language: cs.SupportedLanguage,
     ) -> None:
         try:
             query = get_cached_query(lang_query, query_text)
@@ -399,7 +478,7 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
             function_exprs = captures.get(cs.CAPTURE_FUNCTION_EXPR, [])
 
             self._process_direct_arrow_functions(
-                method_names, arrow_functions, module_qn, lang_config
+                method_names, arrow_functions, module_qn, lang_config, language
             )
             self._process_member_expr_functions(
                 member_exprs,
@@ -407,6 +486,7 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
                 module_qn,
                 lang_config,
                 lg.JS_ASSIGNMENT_ARROW_FOUND,
+                language,
             )
             self._process_member_expr_functions(
                 member_exprs,
@@ -414,6 +494,7 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
                 module_qn,
                 lang_config,
                 lg.JS_ASSIGNMENT_FUNC_EXPR_FOUND,
+                language,
             )
         except Exception as e:
             logger.debug(lg.JS_ASSIGNMENT_ARROW_QUERY_FAILED, error=e)
@@ -424,6 +505,7 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
         arrow_functions: list[ASTNode],
         module_qn: str,
         lang_config,
+        language: cs.SupportedLanguage,
     ) -> None:
         for method_name, arrow_function in zip(method_names, arrow_functions):
             if not method_name.text or not arrow_function:
@@ -443,6 +525,8 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
                 arrow_function,
                 module_qn,
                 lg.JS_OBJECT_ARROW_FOUND,
+                lang_config,
+                language,
             )
 
     def _resolve_direct_arrow_qn(
@@ -487,6 +571,7 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
         module_qn: str,
         lang_config,
         log_message: str,
+        language: cs.SupportedLanguage,
     ) -> None:
         for member_expr, function_node in zip(member_exprs, function_nodes):
             if not member_expr.text or not function_node:
@@ -496,13 +581,26 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
             if cs.SEPARATOR_DOT not in member_text:
                 continue
 
+            # (H) `X.prototype.y = function` is handled by the dedicated
+            # (H) prototype-method path (constructor-parented qn `X.y`);
+            # (H) registering it here too minted a SECOND node under a
+            # (H) module-anchored qn for the same source function.
+            if cs.SEPARATOR_PROTOTYPE in member_text:
+                continue
+
             function_name = member_text.split(cs.SEPARATOR_DOT)[-1]
             function_qn = self._resolve_member_expr_qn(
                 member_expr, function_node, module_qn, function_name, lang_config
             )
 
             self._register_arrow_function(
-                function_name, function_qn, function_node, module_qn, log_message
+                function_name,
+                function_qn,
+                function_node,
+                module_qn,
+                log_message,
+                lang_config,
+                language,
             )
 
     def _resolve_member_expr_qn(
@@ -528,6 +626,8 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
         function_node: ASTNode,
         module_qn: str,
         log_message: str,
+        lang_config: LanguageSpec | None,
+        language: cs.SupportedLanguage,
     ) -> None:
         function_qn = self.function_registry.register_unique_qn(
             function_qn, function_node.start_point[0] + 1
@@ -545,11 +645,26 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
         self.ingestor.ensure_node_batch(cs.NodeLabel.FUNCTION, function_props)
         self.function_registry[function_qn] = NodeType.FUNCTION
         self.simple_name_lookup[function_name].add(function_qn)
-        self.ingestor.ensure_relationship_batch(
-            (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, module_qn),
-            cs.RelationshipType.DEFINES,
-            (cs.NodeLabel.FUNCTION, cs.KEY_QUALIFIED_NAME, function_qn),
+        # (H) An assignment function nested inside another function takes its
+        # (H) lexical parent, not the module (issue: module-parented
+        # (H) duplicates of correctly-parented nodes on thrift lib/js).
+        fallback_label, fallback_qn = self._lexical_defines_fallback(
+            function_node, function_qn, module_qn, lang_config, language
         )
+        if fallback_label is not None and fallback_qn is not None:
+            self._emit_or_defer_defines(
+                fallback_label,
+                fallback_qn,
+                cs.NodeLabel.FUNCTION,
+                function_qn,
+                module_qn,
+            )
+        else:
+            self.ingestor.ensure_relationship_batch(
+                (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, module_qn),
+                cs.RelationshipType.DEFINES,
+                (cs.NodeLabel.FUNCTION, cs.KEY_QUALIFIED_NAME, function_qn),
+            )
 
     def _is_static_method_in_class(self, method_node: ASTNode) -> bool:
         if method_node.type == cs.TS_METHOD_DEFINITION:

--- a/codebase_rag/tests/test_go_local_type_containment_oracle.py
+++ b/codebase_rag/tests/test_go_local_type_containment_oracle.py
@@ -15,7 +15,7 @@ from evals.cgr_graph import extract_cgr_go_graph
 from evals.oracles import go_available, run_go_oracle
 from evals.score import score_edge_types
 
-GO_SRC = '''package thrift
+GO_SRC = """package thrift
 
 import (
 	"encoding/json"
@@ -41,7 +41,7 @@ func TestHeaderContext(t *testing.T) {
 		},
 	)
 }
-'''
+"""
 
 
 @pytest.mark.skipif(not go_available(), reason="go toolchain not available")

--- a/codebase_rag/tests/test_go_local_type_containment_oracle.py
+++ b/codebase_rag/tests/test_go_local_type_containment_oracle.py
@@ -1,0 +1,61 @@
+# (H) A function-local Go type (`type alias T` inside a method body, `type
+# (H) otherType string` inside a closure) is a node on both sides, but the
+# (H) oracle emitted no containment for it while cgr parents it to the nearest
+# (H) NODE-BEARING enclosing function (Go func literals have no nodes, and a
+# (H) receiver method's node is receiver-qualified). Both sides must agree
+# (H) (thrift lib/go surfaced 2 such edges as false positives).
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codebase_rag import constants as cs
+from evals.cgr_graph import extract_cgr_go_graph
+from evals.oracles import go_available, run_go_oracle
+from evals.score import score_edge_types
+
+GO_SRC = '''package thrift
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+type SlogTStructWrapper struct {
+	Value int
+}
+
+func (w SlogTStructWrapper) MarshalJSON() ([]byte, error) {
+	type alias SlogTStructWrapper
+	return json.Marshal(alias(w))
+}
+
+func TestHeaderContext(t *testing.T) {
+	t.Run(
+		"NoConflicts",
+		func(t *testing.T) {
+			type otherType string
+			const otherValue = "bar2"
+			_ = otherType(otherValue)
+		},
+	)
+}
+'''
+
+
+@pytest.mark.skipif(not go_available(), reason="go toolchain not available")
+def test_function_local_types_parent_to_enclosing_function(tmp_path: Path) -> None:
+    (tmp_path / "wrapper_test.go").write_text(GO_SRC)
+
+    cgr = extract_cgr_go_graph(tmp_path, tmp_path.name)
+    oracle = run_go_oracle(tmp_path)
+
+    result = score_edge_types(
+        cgr,
+        oracle,
+        (cs.RelationshipType.DEFINES, cs.RelationshipType.DEFINES_METHOD),
+    )
+    for row in result.rows:
+        assert row["fp"] == 0, result.rows
+        assert row["fn"] == 0, result.rows

--- a/codebase_rag/tests/test_import_edge_verification.py
+++ b/codebase_rag/tests/test_import_edge_verification.py
@@ -261,20 +261,23 @@ def test_lua_require_of_missing_module_emits_no_phantom(
 def test_python_from_package_import_submodule_targets_the_submodule(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:
-    # (H) `from pkg.transport import TTransport` imports the SUBMODULE
-    # (H) TTransport.py; the stdlib extractor treats the trailing name as an
-    # (H) item and strips it, anchoring the edge at the package __init__
-    # (H) instead of the real module file (thrift lib/py: 17 such edges).
-    # (H) The flush must verify the FULL dotted name as a module first.
-    pkg = temp_repo / "pkg"
-    transport = pkg / "transport"
+    # (H) `from thrift.transport import TTransport` under a src-root layout
+    # (H) imports the SUBMODULE TTransport.py; the stdlib extractor treats
+    # (H) the trailing name as an item and strips it, so suffix verification
+    # (H) anchored the edge at the package __init__ instead of the real
+    # (H) module file (thrift lib/py: 17 such edges). The flush must verify
+    # (H) the FULL dotted name as a module first.
+    src = temp_repo / "src"
+    transport = src / "transport"
     transport.mkdir(parents=True)
-    (pkg / "__init__.py").write_text("")
     (transport / "__init__.py").write_text("")
     (transport / "TTransport.py").write_text("class TTransportBase(object):\n    pass\n")
-    (pkg / "user.py").write_text("from pkg.transport import TTransport\n")
+    (src / "user.py").write_text(
+        "from " + temp_repo.name + ".transport import TTransport\n"
+    )
     run_updater(temp_repo, mock_ingestor)
 
     project = temp_repo.name
-    targets = _import_targets(mock_ingestor, f"{project}.pkg.user")
-    assert f"{project}.pkg.transport.TTransport" in targets, targets
+    targets = _import_targets(mock_ingestor, f"{project}.src.user")
+    assert f"{project}.src.transport.TTransport" in targets, targets
+    assert f"{project}.src.transport.__init__" not in targets, targets

--- a/codebase_rag/tests/test_import_edge_verification.py
+++ b/codebase_rag/tests/test_import_edge_verification.py
@@ -256,3 +256,25 @@ def test_lua_require_of_missing_module_emits_no_phantom(
     targets = _import_targets(mock_ingestor, f"{project}.main")
     assert f"{project}.real" in targets, targets
     _assert_no_dangling_imports(mock_ingestor)
+
+
+def test_python_from_package_import_submodule_targets_the_submodule(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) `from pkg.transport import TTransport` imports the SUBMODULE
+    # (H) TTransport.py; the stdlib extractor treats the trailing name as an
+    # (H) item and strips it, anchoring the edge at the package __init__
+    # (H) instead of the real module file (thrift lib/py: 17 such edges).
+    # (H) The flush must verify the FULL dotted name as a module first.
+    pkg = temp_repo / "pkg"
+    transport = pkg / "transport"
+    transport.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("")
+    (transport / "__init__.py").write_text("")
+    (transport / "TTransport.py").write_text("class TTransportBase(object):\n    pass\n")
+    (pkg / "user.py").write_text("from pkg.transport import TTransport\n")
+    run_updater(temp_repo, mock_ingestor)
+
+    project = temp_repo.name
+    targets = _import_targets(mock_ingestor, f"{project}.pkg.user")
+    assert f"{project}.pkg.transport.TTransport" in targets, targets

--- a/codebase_rag/tests/test_import_edge_verification.py
+++ b/codebase_rag/tests/test_import_edge_verification.py
@@ -281,3 +281,33 @@ def test_python_from_package_import_submodule_targets_the_submodule(
     targets = _import_targets(mock_ingestor, f"{project}.src.user")
     assert f"{project}.src.transport.TTransport" in targets, targets
     assert f"{project}.src.transport.__init__" not in targets, targets
+
+
+def test_python_import_suffix_match_ignores_other_language_modules(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) thrift lib/py: src/protocol/__init__.py AND src/ext/protocol.h both
+    # (H) yield module qns ending `.protocol`, so the language-blind suffix
+    # (H) match went ambiguous and dropped the edge for a Python import that
+    # (H) can only target the Python module. Candidates are tie-broken by the
+    # (H) importing language's file extensions.
+    src = temp_repo / "src"
+    proto = src / "protocol"
+    ext = src / "ext"
+    proto.mkdir(parents=True)
+    ext.mkdir()
+    (proto / "__init__.py").write_text("")
+    (ext / "protocol.h").write_text("struct TProtocol { int dummy; };\n")
+    (src / "TBinaryProtocol.py").write_text(
+        "class Accelerated(object):\n"
+        "    def __init__(self):\n"
+        "        try:\n"
+        "            from " + temp_repo.name + ".protocol import fastbinary\n"
+        "        except ImportError:\n"
+        "            pass\n"
+    )
+    run_updater(temp_repo, mock_ingestor)
+
+    project = temp_repo.name
+    targets = _import_targets(mock_ingestor, f"{project}.src.TBinaryProtocol")
+    assert f"{project}.src.protocol" in targets, targets

--- a/codebase_rag/tests/test_import_edge_verification.py
+++ b/codebase_rag/tests/test_import_edge_verification.py
@@ -271,7 +271,9 @@ def test_python_from_package_import_submodule_targets_the_submodule(
     transport = src / "transport"
     transport.mkdir(parents=True)
     (transport / "__init__.py").write_text("")
-    (transport / "TTransport.py").write_text("class TTransportBase(object):\n    pass\n")
+    (transport / "TTransport.py").write_text(
+        "class TTransportBase(object):\n    pass\n"
+    )
     (src / "user.py").write_text(
         "from " + temp_repo.name + ".transport import TTransport\n"
     )

--- a/codebase_rag/tests/test_java_anon_member_containment_oracle.py
+++ b/codebase_rag/tests/test_java_anon_member_containment_oracle.py
@@ -1,0 +1,48 @@
+# (H) A method declared in an anonymous class body (`new Runnable(){ run(){} }`)
+# (H) is modelled as a standalone Function by both cgr and the oracle, but cgr
+# (H) anchors it to the module with DEFINES (the orphan-prevention fallback)
+# (H) while the oracle emitted no containment at all, so every such member
+# (H) graded as a false-positive edge on thrift (103 in crossTest). The
+# (H) oracle must model the fallback.
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codebase_rag import constants as cs
+from evals.cgr_graph import extract_cgr_java_graph
+from evals.oracles import java_available, run_java_oracle
+from evals.score import score_edge_types
+
+JAVA_SRC = """\
+package demo;
+
+public class Client {
+    public void start() {
+        Runnable task = new Runnable() {
+            public void run() {
+                System.out.println("hi");
+            }
+        };
+        task.run();
+    }
+}
+"""
+
+
+@pytest.mark.skipif(not java_available(), reason="javac toolchain not available")
+def test_anonymous_class_members_anchor_to_module(tmp_path: Path) -> None:
+    (tmp_path / "Client.java").write_text(JAVA_SRC)
+
+    cgr = extract_cgr_java_graph(tmp_path, tmp_path.name)
+    oracle = run_java_oracle(tmp_path)
+
+    result = score_edge_types(
+        cgr,
+        oracle,
+        (cs.RelationshipType.DEFINES, cs.RelationshipType.DEFINES_METHOD),
+    )
+    for row in result.rows:
+        assert row["fp"] == 0, result.rows
+        assert row["fn"] == 0, result.rows

--- a/codebase_rag/tests/test_java_lang_base_externalization.py
+++ b/codebase_rag/tests/test_java_lang_base_externalization.py
@@ -97,16 +97,23 @@ def test_java_lang_interfaces_emit_external_implements(
         assert expected in implements, implements
 
 
-def test_unknown_bare_base_still_emits_nothing(
+def test_unknown_bare_base_externalizes_under_written_name(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:
-    # (H) A bare base NOT in the java.lang table stays an unresolvable guess;
-    # (H) knowledge and guesses are not the same.
+    # (H) A bare base NOT in the java.lang table is still a syntactic
+    # (H) inheritance fact, and a name resolving to no indexed class is by
+    # (H) construction defined outside the indexed tree (a generated Iface, a
+    # (H) dependency class). The thrift oracle re-measure showed dropping
+    # (H) these loses real recall, so the WRITTEN name externalizes; the
+    # (H) java.lang table now only refines the qn for known java.lang types.
     (temp_repo / "FancyWidget.java").write_text(UNKNOWN_BASE_JAVA)
     run_updater(temp_repo, mock_ingestor, skip_if_missing="java")
 
     project = temp_repo.name
     inherits = _pairs(mock_ingestor, cs.RelationshipType.INHERITS)
-    assert not any(
-        frm == f"{project}.FancyWidget.FancyWidget" for frm, _, _ in inherits
-    ), inherits
+    expected = (
+        f"{project}.FancyWidget.FancyWidget",
+        cs.NodeLabel.EXTERNAL_MODULE.value,
+        "Widget",
+    )
+    assert expected in inherits, inherits

--- a/codebase_rag/tests/test_js_nested_special_function_containment.py
+++ b/codebase_rag/tests/test_js_nested_special_function_containment.py
@@ -1,0 +1,68 @@
+# (H) The special JS ingestion paths (object-literal property functions,
+# (H) prototype-method assignments, assignment functions) hardcoded their
+# (H) DEFINES parent to the module, or deferred onto a constructor guess whose
+# (H) failure fell back to the module. For a function NESTED inside another
+# (H) function that parent is wrong: the lexical parent rule (the same one
+# (H) plain nested functions follow) applies. On thrift's lib/js this
+# (H) surfaced as module-parented duplicates of correctly-parented nodes once
+# (H) the dangling-edge campaign made the fallback edges real.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import get_relationships, run_updater
+
+NESTED_JS = """
+function createClient(SCl) {
+    var self = this;
+    SCl.prototype.new_seqid = function() {
+        return self.seqid;
+    };
+    var jqRequest = {
+        beforeSend: function (xreq) {
+            return xreq;
+        }
+    };
+    return jqRequest;
+}
+
+function Widget() {
+    this.size = 1;
+}
+
+Widget.prototype.grow = function() {
+    this.size += 1;
+};
+"""
+
+
+def test_nested_special_functions_take_their_lexical_parent(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "app.js").write_text(NESTED_JS)
+    run_updater(temp_repo, mock_ingestor)
+
+    project = temp_repo.name
+    defines = {
+        (call.args[0][2], call.args[2][2])
+        for call in get_relationships(mock_ingestor, cs.RelationshipType.DEFINES.value)
+    }
+    module_qn = f"{project}.app"
+    creator = f"{module_qn}.createClient"
+
+    nested_children = {
+        to
+        for frm, to in defines
+        if to.endswith(".new_seqid") or to.endswith(".beforeSend")
+    }
+    assert nested_children, defines
+    for frm, to in defines:
+        if to in nested_children:
+            assert frm == creator, (frm, to)
+
+    # (H) The top-level prototype method keeps its registered constructor
+    # (H) parent (Widget is a real Function node).
+    grow_parents = {frm for frm, to in defines if to.endswith(".grow")}
+    assert grow_parents == {f"{module_qn}.Widget"}, defines

--- a/codebase_rag/tests/test_oracle_src_root_imports.py
+++ b/codebase_rag/tests/test_oracle_src_root_imports.py
@@ -26,6 +26,7 @@ def _write_src_layout(root: Path) -> None:
     (src / "TMultiplexedProcessor.py").write_text(
         "from thrift.Thrift import TProcessor\n"
         "from thrift.protocol.TProtocol import TProtocolBase\n"
+        "import thrift.protocol.fastbinary\n"
         "import struct\n\n\n"
         "class TMultiplexedProcessor(TProcessor):\n    pass\n"
     )
@@ -42,5 +43,8 @@ def test_distribution_name_imports_resolve_via_unique_suffix(tmp_path: Path) -> 
     }
     assert "src/Thrift.py" in import_targets, import_targets
     assert "src/protocol/TProtocol.py" in import_targets, import_targets
+    # (H) `import a.b.c` of a C extension still imports the deepest importable
+    # (H) parent package.
+    assert "src/protocol/__init__.py" in import_targets, import_targets
     # (H) `import struct` has a foreign top level; it must stay external.
-    assert len(import_targets) == 2, import_targets
+    assert len(import_targets) == 3, import_targets

--- a/codebase_rag/tests/test_oracle_src_root_imports.py
+++ b/codebase_rag/tests/test_oracle_src_root_imports.py
@@ -1,0 +1,46 @@
+# (H) A src-root distribution (setup.py maps src/ to the package named after
+# (H) the project) writes absolute imports against the DISTRIBUTION name
+# (H) (`from thrift.Thrift import TProcessor`) while the oracle indexes
+# (H) modules by PATH (`thrift.src.Thrift`), so every such import was called
+# (H) external and cgr's correctly resolved edges graded as false positives
+# (H) (thrift: IMPORTS precision 0.15). When an absolute import claims the
+# (H) project's own top-level name but misses the index, it must be internal;
+# (H) a UNIQUE whole-segment suffix match recovers the file.
+from __future__ import annotations
+
+from pathlib import Path
+
+from evals.ast_oracle import extract_oracle_graph
+
+PROJECT = "thrift"
+
+
+def _write_src_layout(root: Path) -> None:
+    src = root / "src"
+    (src / "protocol").mkdir(parents=True)
+    (src / "Thrift.py").write_text("class TProcessor(object):\n    pass\n")
+    (src / "protocol" / "__init__.py").write_text("")
+    (src / "protocol" / "TProtocol.py").write_text(
+        "class TProtocolBase(object):\n    pass\n"
+    )
+    (src / "TMultiplexedProcessor.py").write_text(
+        "from thrift.Thrift import TProcessor\n"
+        "from thrift.protocol.TProtocol import TProtocolBase\n"
+        "import struct\n\n\n"
+        "class TMultiplexedProcessor(TProcessor):\n    pass\n"
+    )
+
+
+def test_distribution_name_imports_resolve_via_unique_suffix(tmp_path: Path) -> None:
+    _write_src_layout(tmp_path)
+    graph = extract_oracle_graph(tmp_path, PROJECT)
+
+    import_targets = {
+        edge.target_name
+        for edge in graph.name_edges
+        if edge.rel_type == "IMPORTS" and "TMultiplexedProcessor" in edge.source.file
+    }
+    assert "src/Thrift.py" in import_targets, import_targets
+    assert "src/protocol/TProtocol.py" in import_targets, import_targets
+    # (H) `import struct` has a foreign top level; it must stay external.
+    assert len(import_targets) == 2, import_targets

--- a/codebase_rag/tests/test_oracle_trailing_comment_spans.py
+++ b/codebase_rag/tests/test_oracle_trailing_comment_spans.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 from evals.ast_oracle import extract_oracle_graph
 
-SRC = '''class Server:
+SRC = """class Server:
     def serve(self):
         self.count = 1
 
@@ -22,7 +22,7 @@ SRC = '''class Server:
     # sibling comment about the next method
     def restart(self):
         self.shutdown()
-'''
+"""
 
 
 def test_trailing_body_comment_extends_span(tmp_path: Path) -> None:

--- a/codebase_rag/tests/test_oracle_trailing_comment_spans.py
+++ b/codebase_rag/tests/test_oracle_trailing_comment_spans.py
@@ -1,0 +1,39 @@
+# (H) Python's ast ends a def at its last STATEMENT; a trailing comment
+# (H) inside the body (thrift's THttpServer.shutdown ends with a commented-out
+# (H) call) is invisible to it, while tree-sitter's block extends over the
+# (H) comment. The comment lexically belongs to the suite, so the oracle
+# (H) extends a def's end over trailing comment lines indented deeper than
+# (H) the def itself; a comment at the def's own indentation is a sibling
+# (H) and must not extend the span.
+from __future__ import annotations
+
+from pathlib import Path
+
+from evals.ast_oracle import extract_oracle_graph
+
+SRC = '''class Server:
+    def serve(self):
+        self.count = 1
+
+    def shutdown(self):
+        self.close()
+        # hangs forever otherwise!
+
+    # sibling comment about the next method
+    def restart(self):
+        self.shutdown()
+'''
+
+
+def test_trailing_body_comment_extends_span(tmp_path: Path) -> None:
+    (tmp_path / "server.py").write_text(SRC)
+    graph = extract_oracle_graph(tmp_path, "proj")
+
+    ends = {
+        (node.key.kind, node.key.start_line): node.end_line
+        for node in graph.nodes.values()
+    }
+    assert ends[("Method", 5)] == 7, ends
+    assert ends[("Method", 10)] == 11, ends
+    # (H) The class block includes its last member's trailing extent.
+    assert ends[("Class", 1)] == 11, ends

--- a/codebase_rag/tests/test_rust_external_impl_containment_oracle.py
+++ b/codebase_rag/tests/test_rust_external_impl_containment_oracle.py
@@ -1,0 +1,48 @@
+# (H) Methods of an impl whose target is NOT a locally declared type
+# (H) (`impl<P> TInput for Box<P>`) have no owner node cgr can attach to, so
+# (H) cgr anchors them to the module with DEFINES (the documented
+# (H) orphan-prevention fallback). The syn oracle emitted NO containment for
+# (H) them, so every such method graded as a false-positive edge on thrift
+# (H) (53 in src/protocol/mod.rs). The oracle must model the fallback.
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codebase_rag import constants as cs
+from evals.cgr_graph import extract_cgr_rust_graph
+from evals.oracles import run_rust_oracle, rust_available
+from evals.score import score_edge_types
+
+RS_SRC = """\
+pub trait TInput {
+    fn read_begin(&mut self) -> u32;
+}
+
+impl<P> TInput for Box<P>
+where
+    P: TInput + ?Sized,
+{
+    fn read_begin(&mut self) -> u32 {
+        (**self).read_begin()
+    }
+}
+"""
+
+
+@pytest.mark.skipif(not rust_available(), reason="cargo toolchain not available")
+def test_impl_on_external_type_methods_anchor_to_module(tmp_path: Path) -> None:
+    (tmp_path / "lib.rs").write_text(RS_SRC)
+
+    cgr = extract_cgr_rust_graph(tmp_path, tmp_path.name)
+    oracle = run_rust_oracle(tmp_path)
+
+    result = score_edge_types(
+        cgr,
+        oracle,
+        (cs.RelationshipType.DEFINES, cs.RelationshipType.DEFINES_METHOD),
+    )
+    for row in result.rows:
+        assert row["fp"] == 0, result.rows
+        assert row["fn"] == 0, result.rows

--- a/codebase_rag/tests/test_unresolvable_base_externalization.py
+++ b/codebase_rag/tests/test_unresolvable_base_externalization.py
@@ -1,0 +1,127 @@
+# (H) Two inheritance-recall losses the thrift oracle re-measure surfaced
+# (H) after the dangling-edge campaign:
+# (H) 1. A src-root layout (setup.py maps lib/py/src -> package `thrift`)
+# (H)    makes an import-mapped base like `thrift.Thrift.TProcessor` look
+# (H)    project-internal while the real class qn is path-based
+# (H)    (`thrift.src.Thrift.TProcessor`); the deferred resolver dropped what
+# (H)    a unique whole-segment suffix match resolves to the real node.
+# (H) 2. A written base that resolves nowhere in the index (`object`,
+# (H)    Rust `Default`, generated `Iface`) is BY CONSTRUCTION defined outside
+# (H)    the indexed tree; dropping it loses a syntactic inheritance fact the
+# (H)    source declares. The written name (not the module-anchored guess)
+# (H)    now emits onto an ExternalModule node, generalizing the JS-global
+# (H)    and java.lang tables into a language-agnostic fallback.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import get_relationships, run_updater
+
+
+def _inherits(mock_ingestor: MagicMock) -> set[tuple[str, str, str]]:
+    return {
+        (call.args[0][2], str(call.args[2][0]), call.args[2][2])
+        for call in get_relationships(mock_ingestor, cs.RelationshipType.INHERITS.value)
+    }
+
+
+def test_src_root_base_suffix_resolves_to_real_class(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) Mirrors thrift's layout: the package root is src/ but imports are
+    # (H) written against the distribution name, which equals the project.
+    src = temp_repo / "src"
+    src.mkdir()
+    (src / "Thrift.py").write_text("class TProcessor(object):\n    pass\n")
+    (src / "TMultiplexedProcessor.py").write_text(
+        "from "
+        + temp_repo.name
+        + ".Thrift import TProcessor\n\n\n"
+        + "class TMultiplexedProcessor(TProcessor):\n    pass\n"
+    )
+    run_updater(temp_repo, mock_ingestor)
+
+    project = temp_repo.name
+    inherits = _inherits(mock_ingestor)
+    expected = (
+        f"{project}.src.TMultiplexedProcessor.TMultiplexedProcessor",
+        cs.NodeLabel.CLASS.value,
+        f"{project}.src.Thrift.TProcessor",
+    )
+    assert expected in inherits, inherits
+
+
+def test_python_object_base_externalizes(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "legacy.py").write_text("class Legacy(object):\n    pass\n")
+    run_updater(temp_repo, mock_ingestor)
+
+    project = temp_repo.name
+    inherits = _inherits(mock_ingestor)
+    expected = (
+        f"{project}.legacy.Legacy",
+        cs.NodeLabel.EXTERNAL_MODULE.value,
+        "object",
+    )
+    assert expected in inherits, inherits
+
+
+def test_rust_bare_std_trait_impl_externalizes(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "lib.rs").write_text(
+        """
+pub struct Config {
+    level: u32,
+}
+
+impl Default for Config {
+    fn default() -> Config {
+        Config { level: 0 }
+    }
+}
+"""
+    )
+    run_updater(temp_repo, mock_ingestor)
+
+    project = temp_repo.name
+    implements = {
+        (call.args[0][2], str(call.args[2][0]), call.args[2][2])
+        for call in get_relationships(
+            mock_ingestor, cs.RelationshipType.IMPLEMENTS.value
+        )
+    }
+    expected = (
+        f"{project}.lib.Config",
+        cs.NodeLabel.EXTERNAL_MODULE.value,
+        "Default",
+    )
+    assert expected in implements, implements
+
+
+def test_php_builtin_exception_base_externalizes(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "AppError.php").write_text(
+        """<?php
+class AppError extends Exception
+{
+    public function report(): void
+    {
+    }
+}
+"""
+    )
+    run_updater(temp_repo, mock_ingestor, skip_if_missing="php")
+
+    project = temp_repo.name
+    inherits = _inherits(mock_ingestor)
+    expected = (
+        f"{project}.AppError.AppError",
+        cs.NodeLabel.EXTERNAL_MODULE.value,
+        "Exception",
+    )
+    assert expected in inherits, inherits

--- a/codebase_rag/tests/test_unresolvable_base_externalization.py
+++ b/codebase_rag/tests/test_unresolvable_base_externalization.py
@@ -125,3 +125,51 @@ class AppError extends Exception
         "Exception",
     )
     assert expected in inherits, inherits
+
+
+def test_rust_shadowed_std_trait_externalizes(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) thrift's errors.rs: `pub enum Error` implements the std trait ALSO
+    # (H) written `Error`; parse-time resolution lands on the enum itself and
+    # (H) a self-edge is never real, but the WRITTEN bare name is still a
+    # (H) syntactic fact and must externalize (the reference is to the
+    # (H) shadowed outer name, not the child).
+    (temp_repo / "errors.rs").write_text(
+        """
+use std::fmt;
+
+pub enum Error {
+    Transport(u32),
+}
+
+impl Error for Error {
+    fn description(&self) -> &str {
+        "err"
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "err")
+    }
+}
+"""
+    )
+    run_updater(temp_repo, mock_ingestor)
+
+    project = temp_repo.name
+    implements = {
+        (call.args[0][2], str(call.args[2][0]), call.args[2][2])
+        for call in get_relationships(
+            mock_ingestor, cs.RelationshipType.IMPLEMENTS.value
+        )
+    }
+    expected = (
+        f"{project}.errors.Error",
+        cs.NodeLabel.EXTERNAL_MODULE.value,
+        "Error",
+    )
+    assert expected in implements, implements
+    for frm, _, to in implements:
+        assert frm != to, implements

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -498,7 +498,8 @@ class DeferredParentLink(NamedTuple):
     the class pass after the function pass; forward declarations register
     last), so verification waits until every pass finishes. A parent qn that
     never registers is a phantom the database would drop, so the child
-    anchors to its module instead.
+    anchors to its registered lexical fallback when one is known (a nested
+    prototype assignment belongs to its enclosing function), else its module.
     """
 
     parent_label_guess: str
@@ -507,6 +508,8 @@ class DeferredParentLink(NamedTuple):
     child_qn: str
     module_qn: str
     rel_type: str = RelationshipType.DEFINES.value
+    fallback_label: str | None = None
+    fallback_qn: str | None = None
 
 
 class FunctionLocation(NamedTuple):

--- a/evals/ast_oracle.py
+++ b/evals/ast_oracle.py
@@ -165,8 +165,17 @@ def _import_targets(
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:
-                if target := _lookup_module(alias.name, module_index, project_name):
-                    targets.add(target)
+                # (H) `import a.b.c` imports a AND a.b AND a.b.c; when the full
+                # (H) dotted name maps to no module (a C extension like
+                # (H) thrift.protocol.fastbinary), the deepest importable
+                # (H) parent package is still imported.
+                parts = alias.name.split(cs.SEPARATOR_DOT)
+                while parts:
+                    dotted = cs.SEPARATOR_DOT.join(parts)
+                    if target := _lookup_module(dotted, module_index, project_name):
+                        targets.add(target)
+                        break
+                    parts = parts[:-1]
         elif isinstance(node, ast.ImportFrom):
             base_parts = _from_base_parts(node, pkg_parts)
             if base_parts is None:

--- a/evals/ast_oracle.py
+++ b/evals/ast_oracle.py
@@ -1,4 +1,6 @@
 import ast
+import io
+import tokenize
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -25,26 +27,91 @@ def extract_oracle_graph(target: Path, project_name: str) -> GraphData:
     edges: set[EdgeKey] = set()
     name_edges: set[NameEdge] = set()
 
-    parsed: list[tuple[str, ast.Module]] = []
+    parsed: list[tuple[str, ast.Module, str]] = []
     module_index: dict[str, str] = {}
     for path in _iter_py_files(target):
         rel = path.relative_to(target).as_posix()
         try:
-            tree = ast.parse(path.read_text(encoding="utf-8"))
+            text = path.read_text(encoding="utf-8")
+            tree = ast.parse(text)
         except (SyntaxError, UnicodeDecodeError, ValueError) as error:
             logger.warning(ls.ORACLE_PARSE_FAILED.format(path=rel, error=error))
             continue
-        parsed.append((rel, tree))
+        parsed.append((rel, tree, text))
         module_index[_module_dotted(rel, project_name)] = rel
 
-    for rel, tree in parsed:
+    for rel, tree, text in parsed:
         module_key = NodeKey(_MODULE, rel, ec.MODULE_START_LINE)
         nodes[module_key] = DefNode(module_key, Path(rel).stem, 0)
         _walk_scope(tree.body, _MODULE, module_key, rel, nodes, edges, name_edges)
+        _extend_spans_over_trailing_comments(tree, text, rel, nodes)
         for target_file in _import_targets(tree, rel, module_index, project_name):
             name_edges.add(NameEdge(_IMPORTS, module_key, target_file))
 
     return GraphData(nodes=nodes, edges=edges, name_edges=name_edges)
+
+
+def _comment_and_code_lines(text: str) -> tuple[dict[int, int], set[int]]:
+    # (H) line -> column for comment-only lines, plus every line carrying code;
+    # (H) drives the trailing-comment span extension below.
+    comment_cols: dict[int, int] = {}
+    code_lines: set[int] = set()
+    skip = (
+        tokenize.NL,
+        tokenize.NEWLINE,
+        tokenize.INDENT,
+        tokenize.DEDENT,
+        tokenize.ENCODING,
+        tokenize.ENDMARKER,
+    )
+    try:
+        for tok in tokenize.generate_tokens(io.StringIO(text).readline):
+            if tok.type == tokenize.COMMENT:
+                comment_cols.setdefault(tok.start[0], tok.start[1])
+            elif tok.type not in skip:
+                code_lines.update(range(tok.start[0], tok.end[0] + 1))
+    except tokenize.TokenError:
+        return {}, set()
+    # (H) A comment sharing a line with code is not a comment-only line.
+    for line in code_lines:
+        comment_cols.pop(line, None)
+    return comment_cols, code_lines
+
+
+def _extend_spans_over_trailing_comments(
+    tree: ast.Module, text: str, rel: str, nodes: dict[NodeKey, DefNode]
+) -> None:
+    # (H) ast ends a def/class at its last STATEMENT; tree-sitter's block also
+    # (H) spans trailing comment lines indented deeper than the def keyword
+    # (H) (they lexically belong to the suite). Extend to match; a comment at
+    # (H) the def's own indentation is a sibling and stops the scan.
+    comment_cols, code_lines = _comment_and_code_lines(text)
+    if not comment_cols:
+        return
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        end = node.end_lineno
+        if end is None:
+            continue
+        extended = end
+        line = end + 1
+        while line not in code_lines:
+            col = comment_cols.get(line)
+            if col is not None:
+                if col <= node.col_offset:
+                    break
+                extended = line
+            elif line > max(comment_cols, default=0):
+                break
+            line += 1
+        if extended == end:
+            continue
+        for kind in (_CLASS, _FUNCTION, _METHOD):
+            key = NodeKey(kind, rel, node.lineno)
+            existing = nodes.get(key)
+            if existing is not None and existing.end_line == end:
+                nodes[key] = DefNode(key, existing.name, extended)
 
 
 def _module_dotted(rel: str, project_name: str) -> str:
@@ -115,9 +182,7 @@ def _import_targets(
                 sub = cs.SEPARATOR_DOT.join([*base_parts, alias.name])
                 if target := _lookup_module(sub, module_index, project_name):
                     targets.add(target)
-                elif target := _lookup_module(
-                    base_dotted, module_index, project_name
-                ):
+                elif target := _lookup_module(base_dotted, module_index, project_name):
                     targets.add(target)
     return targets
 

--- a/evals/ast_oracle.py
+++ b/evals/ast_oracle.py
@@ -66,6 +66,30 @@ def _from_base_parts(node: ast.ImportFrom, pkg_parts: list[str]) -> list[str] | 
     return parts
 
 
+def _lookup_module(
+    dotted: str, module_index: dict[str, str], project_name: str
+) -> str | None:
+    if dotted in module_index:
+        return module_index[dotted]
+    # (H) A src-root distribution (setup.py maps src/ to the package named
+    # (H) after the project) writes imports against the DISTRIBUTION name
+    # (H) (`thrift.Thrift`) while the index keys are path-based
+    # (H) (`thrift.src.Thrift`). An import claiming the project's own
+    # (H) top-level name must be internal; a UNIQUE whole-segment suffix
+    # (H) match recovers the file, ambiguity resolves nothing.
+    prefix = f"{project_name}{cs.SEPARATOR_DOT}"
+    if not dotted.startswith(prefix):
+        return None
+    tail = dotted[len(prefix) :]
+    if not tail:
+        return None
+    suffix = f"{cs.SEPARATOR_DOT}{tail}"
+    matches = {rel for key, rel in module_index.items() if key.endswith(suffix)}
+    if len(matches) == 1:
+        return matches.pop()
+    return None
+
+
 def _import_targets(
     tree: ast.Module, rel: str, module_index: dict[str, str], project_name: str
 ) -> set[str]:
@@ -74,8 +98,8 @@ def _import_targets(
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:
-                if alias.name in module_index:
-                    targets.add(module_index[alias.name])
+                if target := _lookup_module(alias.name, module_index, project_name):
+                    targets.add(target)
         elif isinstance(node, ast.ImportFrom):
             base_parts = _from_base_parts(node, pkg_parts)
             if base_parts is None:
@@ -83,14 +107,18 @@ def _import_targets(
             base_dotted = cs.SEPARATOR_DOT.join(base_parts)
             for alias in node.names:
                 if alias.name == "*":
-                    if base_dotted in module_index:
-                        targets.add(module_index[base_dotted])
+                    if target := _lookup_module(
+                        base_dotted, module_index, project_name
+                    ):
+                        targets.add(target)
                     continue
                 sub = cs.SEPARATOR_DOT.join([*base_parts, alias.name])
-                if sub in module_index:
-                    targets.add(module_index[sub])
-                elif base_dotted in module_index:
-                    targets.add(module_index[base_dotted])
+                if target := _lookup_module(sub, module_index, project_name):
+                    targets.add(target)
+                elif target := _lookup_module(
+                    base_dotted, module_index, project_name
+                ):
+                    targets.add(target)
     return targets
 
 

--- a/evals/oracles/go_ast.go
+++ b/evals/oracles/go_ast.go
@@ -193,6 +193,22 @@ func collectEdges(pf parsedFile, types map[string]Def, edges *[]Edge) {
 		switch d := decl.(type) {
 		case *ast.FuncDecl:
 			line := pf.fset.Position(d.Name.Pos()).Line
+			// A function-local type parents to the enclosing FuncDecl: Go has
+			// no nested named funcs and cgr creates no nodes for func
+			// literals, so the FuncDecl is the nearest node-bearing scope.
+			parentKind := kindFunction
+			if d.Recv != nil {
+				parentKind = kindMethod
+			}
+			funcRef := NodeRef{parentKind, pf.rel, line}
+			ast.Inspect(d.Body, func(n ast.Node) bool {
+				if ts, ok := n.(*ast.TypeSpec); ok {
+					tline := pf.fset.Position(ts.Name.Pos()).Line
+					child := NodeRef{typeSpecKind(ts), pf.rel, tline}
+					*edges = append(*edges, Edge{relDefines, funcRef, child})
+				}
+				return true
+			})
 			if d.Recv == nil {
 				child := NodeRef{kindFunction, pf.rel, line}
 				*edges = append(*edges, Edge{relDefines, module, child})

--- a/evals/oracles/java_oracle/Oracle.java
+++ b/evals/oracles/java_oracle/Oracle.java
@@ -214,13 +214,19 @@ public class Oracle {
                         long endLine = lm.getLineNumber(sp.getEndPosition(unit, node));
                         emit(kind, rel, line, endLine, node.getName().toString());
                         // (H) A Method binds to its enclosing named type; an
-                        // (H) anonymous-class member (Function) has no such edge.
+                        // (H) anonymous-class member (Function) has no owner node,
+                        // (H) so cgr anchors it to the module with DEFINES (the
+                        // (H) orphan-prevention fallback) and the oracle models
+                        // (H) the same containment.
                         if (owner != null) {
                             long opos = sp.getStartPosition(unit, owner);
                             if (opos >= 0) {
                                 emitEdge("DEFINES_METHOD", rel, classKind(owner),
                                     lm.getLineNumber(opos), "Method", line);
                             }
+                        } else {
+                            emitEdge("DEFINES", rel, "Module", MODULE_LINE,
+                                "Function", line);
                         }
                     }
                     return super.visitMethod(node, p);

--- a/evals/oracles/rs_oracle/src/main.rs
+++ b/evals/oracles/rs_oracle/src/main.rs
@@ -428,6 +428,16 @@ fn process_edges(
                                     REL_DEFINES_METHOD, file, kind, *tline, KIND_METHOD,
                                     m.sig.ident.span().start().line,
                                 ));
+                            } else {
+                                // (H) An impl on a type declared elsewhere (Box<P>,
+                                // (H) primitives, external types) has no owner node;
+                                // (H) cgr anchors such methods to the module with
+                                // (H) DEFINES (orphan-prevention fallback), so the
+                                // (H) oracle models the same containment.
+                                edges.push(edge_json(
+                                    REL_DEFINES, file, KIND_MODULE, module_line, KIND_METHOD,
+                                    m.sig.ident.span().start().line,
+                                ));
                             }
                         }
                         syn::ImplItem::Type(t) => edges.push(edge_json(

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.263"
+version = "0.0.264"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Re-measured all eight per-language structure oracles on a fresh apache/thrift checkout against the post-campaign graph (after #665/#666) and root-caused every score below 1.0. The campaign had surfaced disagreements that mutual blindness used to hide (phantom endpoints were invisible to the eval's line-keyed joins), plus a few genuine cgr and oracle gaps.

**Result: every language is back to 1.0 precision and recall on every node, edge, and span category on thrift** (Python, Go, Rust, TypeScript, JavaScript, Java, PHP, Lua; ~9,400 nodes, ~7,300 edges, spans exact on all 901 graded Python defs).

## cgr fixes (each red -> green)

1. **Src-root base resolution**: an import-mapped base like `thrift.Thrift.TProcessor` is project-prefixed but not path-based (setup.py maps `lib/py/src` to the distribution name); a unique whole-segment suffix match now recovers the real class node instead of dropping the edge.
2. **Written-base externalization generalized**: a base name that resolves to no indexed class is by construction defined outside the indexed tree (Python `object`, Rust `Default`, generated `Iface`, PHP `Exception`), so the WRITTEN name now emits onto an ExternalModule node for every language; the JS-global and java.lang tables remain as canonical-qn refinements. A shadowed self-name (`pub enum Error` implementing the std `Error` trait) externalizes when the written remainder is a bare segment; dotted derived remainders still emit nothing.
3. **Nested JS special functions take their lexical parent**: object-literal property functions, prototype-method assignments, and assignment functions hardcoded module parents (or deferred onto parameter-named constructor guesses whose fallback was the module); nested ones now defer with a lexical fallback carried through `DeferredParentLink`. The member-expr path also no longer double-registers `X.prototype.y` functions the dedicated prototype path owns.
4. **Go function-local types parent correctly**: the enclosing-function derivation now receiver-qualifies Go methods (`module.Type.Method`), so a `type alias` inside a method body anchors to the method node instead of the module.
5. **Python import verification**: the full dotted name verifies as a module before item-stripping (`from pkg.transport import TTransport` targets the submodule, not the package `__init__`), and ambiguous suffix matches tie-break by the importing language's file extensions (thrift's `src/ext/protocol.h` no longer blocks the Python `src/protocol` package).

## Oracle fixes (each red -> green)

- **ast oracle**: distribution-name imports resolve through a unique suffix; plain `import a.b.c` walks parent packages (C extensions); def/class spans extend over trailing body comments indented deeper than the def (tree-sitter block parity; Python spans now exact at 901/901).
- **syn oracle**: methods of impls on non-local types (`impl<P> TInput for Box<P>`) model cgr's documented module-anchor fallback.
- **java oracle**: anonymous-class members model the same module-anchor fallback.
- **go oracle**: function-local type declarations get containment from the nearest node-bearing enclosing function.

## Verification

- thrift (fresh HEAD): all eight language L1 evals at 1.0 across nodes, DEFINES, DEFINES_METHOD, INHERITS, IMPLEMENTS, IMPORTS, and spans
- `uv run pytest codebase_rag/tests` (node, javac, go, cargo on PATH so all oracle harness tests run): 4507 passed, 0 failed, 5 skipped
- `uv run ty check`: at the 352-diagnostic baseline
- Note: the memgraph docker integration tests are currently unrunnable on this machine (Docker daemon down, identical on unmodified main)
