### PR TITLE
fix(js): express dead-code residuals via named fn-expr references, member-call precision, twin fan-out, var-require imports, and test dir exclusion

### DIFF
--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -589,15 +589,18 @@ PROTOCOL_BASE_QNS: tuple[str, ...] = ("typing.Protocol", "typing_extensions.Prot
 
 # (H) Substrings in a node's file path that mark it as test code. Covers Python
 # (H) (test_, _test, conftest, /tests/), the JS/TS filename convention
-# (H) (foo.test.ts, foo.spec.tsx), and the Jest __tests__/ directory so those
-# (H) files are not reported as dead. Singular /test/ and /spec/ directories are
-# (H) intentionally excluded: they collide with product code (a domain "spec"
-# (H) module), which would misclassify live code as test.
+# (H) (foo.test.ts, foo.spec.tsx), the Jest __tests__/ directory, and the
+# (H) Node.js/mocha singular /test/ dir (express: 34 of 49 dead-code reports
+# (H) were test/ helpers). Matching is segment-anchored via the leading-slash
+# (H) normalization, so contest/ and latest/ do not match. Singular /spec/
+# (H) stays excluded: it collides with product code (a domain "spec" module),
+# (H) which would misclassify live code as test.
 TEST_PATH_PATTERNS: tuple[str, ...] = (
     "test_",
     "_test",
     "conftest",
     "/tests/",
+    "/test/",
     ".test.",
     ".spec.",
     "__tests__",
@@ -895,7 +898,13 @@ CALL_NODES_SPECIAL = ("new_expression", "delete_expression", "macro_invocation")
 
 IMPORT_NODES_STANDARD = ("import_declaration", "import_statement")
 IMPORT_NODES_FROM = ("import_from_statement",)
-IMPORT_NODES_MODULE = ("lexical_declaration", "export_statement")
+# (H) variable_declaration: CommonJS `var X = require(...)` (express) binds
+# (H) imports exactly like const/let lexical_declarations.
+IMPORT_NODES_MODULE = (
+    "lexical_declaration",
+    "variable_declaration",
+    "export_statement",
+)
 IMPORT_NODES_INCLUDE = ("preproc_include",)
 
 # (H) JS/TS specific node types
@@ -907,7 +916,12 @@ JS_TS_FUNCTION_NODES = (
     "method_definition",
 )
 JS_TS_CLASS_NODES = ("class_declaration", "class")
-JS_TS_IMPORT_NODES = ("import_statement", "lexical_declaration", "export_statement")
+JS_TS_IMPORT_NODES = (
+    "import_statement",
+    "lexical_declaration",
+    "variable_declaration",
+    "export_statement",
+)
 JS_TS_LANGUAGES = frozenset(
     {SupportedLanguage.JS, SupportedLanguage.TS, SupportedLanguage.TSX}
 )
@@ -2228,6 +2242,7 @@ TS_WILDCARD_IMPORT = "wildcard_import"
 TS_STRING = "string"
 TS_IMPORT_CLAUSE = "import_clause"
 TS_LEXICAL_DECLARATION = "lexical_declaration"
+TS_VARIABLE_DECLARATION = "variable_declaration"
 TS_EXPORT_STATEMENT = "export_statement"
 TS_NAMED_IMPORTS = "named_imports"
 TS_IMPORT_SPECIFIER = "import_specifier"
@@ -2469,6 +2484,12 @@ TS_ERROR = "ERROR"
 TS_EXPRESSION_STATEMENT = "expression_statement"
 TS_STATEMENT_BLOCK = "statement_block"
 TS_PARENTHESIZED_EXPRESSION = "parenthesized_expression"
+TS_BINARY_EXPRESSION = "binary_expression"
+# (H) Receivers that address the MODULE itself in CommonJS code
+# (H) (`exports.render()`, `module.exports.x()`, prototype-pattern `this`):
+# (H) only these may bind a dotted call to a same-module free function; an
+# (H) ordinary identifier receiver (`view.render()`) is an instance call.
+JS_MODULE_RECEIVERS = frozenset({"exports", "module", "this"})
 TS_JAVA_CAST_EXPRESSION = "cast_expression"
 TS_ATTRIBUTE = "attribute"
 
@@ -3501,6 +3522,11 @@ JS_ARROW_NAME_CLIMB_BOUNDARY = frozenset(
         TS_METHOD_DEFINITION,
         TS_GENERATOR_FUNCTION_DECLARATION,
         TS_CLASS_BODY,
+        # (H) An OBJECT VALUE (`var pets = { list: function(req, res) {...} }`)
+        # (H) is owned by the pair-key naming path; climbing past it would steal
+        # (H) the enclosing declarator's name and register a phantom function.
+        TS_PY_PAIR,
+        TS_OBJECT,
     }
 )
 

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1694,7 +1694,7 @@ class CallProcessor:
             # (H) Registry-guarded and idempotent with the callable-params path.
             if is_js_ts and call_node.type == cs.TS_CALL_EXPRESSION:
                 self._ingest_inline_call_arg_references(
-                    call_node, caller_spec, ensure_rel, caller_qn
+                    call_node, caller_spec, ensure_rel, caller_qn, module_qn
                 )
             if not call_name:
                 continue
@@ -2028,6 +2028,21 @@ class CallProcessor:
                         )
 
             if (
+                is_js_ts
+                and cs.SEPARATOR_DOT in call_name
+                and callee_type in (cs.NodeLabel.FUNCTION, cs.NodeLabel.METHOD)
+            ):
+                # (H) A JS member call that bound one twin of a double-registered
+                # (H) prototype method (`this.lookup()` -> module-flat `view.lookup`,
+                # (H) leaving `View.lookup` dead) edges the same-module same-name
+                # (H) member twin too (duplicate-QN keep-both design; revive-only).
+                for twin_type, twin_qn in sorted(
+                    resolver.js_member_twin_targets(callee_qn)
+                ):
+                    for variant in resolver.function_registry.variants(twin_qn):
+                        ensure_rel(caller_spec, calls_rel, (twin_type, qn_key, variant))
+
+            if (
                 is_python
                 and callee_type == cs.NodeLabel.FUNCTION
                 and cs.SEPARATOR_DOT not in call_name
@@ -2255,6 +2270,25 @@ class CallProcessor:
                     # (H) _emit_callback_edge references it by position. A named
                     # (H) arrow-const RHS is registered by its name, so the by-position
                     # (H) lookup simply finds nothing.
+                    # (H) A LOGICAL DEFAULT RHS (`done = done || function (err,
+                    # (H) str) {...}`, express's render) hides the stored function
+                    # (H) one level down; scan the binary operands too.
+                    if value.type == cs.TS_BINARY_EXPRESSION:
+                        for operand in value.named_children:
+                            operand = self._unwrap_ts_value(operand)
+                            if operand.type in _INLINE_FUNC_VALUE_TYPES:
+                                self._emit_callback_edge(
+                                    caller_spec,
+                                    operand,
+                                    module_qn,
+                                    local_var_types,
+                                    class_context,
+                                    resolve_func,
+                                    ensure_rel,
+                                    caller_qn,
+                                    cs.RelationshipType.REFERENCES,
+                                )
+                        continue
                     if (
                         value.type in _ASSIGNMENT_RHS_REF_TYPES
                         or value.type in _INLINE_FUNC_VALUE_TYPES
@@ -2505,7 +2539,7 @@ class CallProcessor:
                     ):
                         if value.type in _INLINE_FUNC_VALUE_TYPES:
                             self._emit_inline_value_function_ref(
-                                pair, value, caller_spec, ensure_rel
+                                pair, value, caller_spec, module_qn, ensure_rel
                             )
                             continue
                         self._emit_value_function_ref(
@@ -2657,6 +2691,7 @@ class CallProcessor:
         pair: Node,
         value: Node,
         caller_spec: tuple[str, str, str],
+        module_qn: str,
         ensure_rel,
     ) -> None:
         # (H) An inline arrow/function-expression object value is registered by the
@@ -2686,6 +2721,14 @@ class CallProcessor:
                 candidates.add(
                     f"{scope_qn}{cs.SEPARATOR_DOT}{pair_path}{cs.SEPARATOR_DOT}{key}"
                 )
+        # (H) A NAMED function expression value (`get: function getrouter() {...}`,
+        # (H) express) registers by its OWN name -- neither the key nor the
+        # (H) position form matches it; try the name under the scope and
+        # (H) module-flat (where the def pass puts it).
+        name_node = value.child_by_field_name(cs.FIELD_NAME)
+        if name_node is not None and (own := safe_decode_text(name_node)):
+            candidates.add(f"{scope_qn}{cs.SEPARATOR_DOT}{own}")
+            candidates.add(f"{module_qn}{cs.SEPARATOR_DOT}{own}")
         for candidate in candidates:
             for target_qn in registry.variants(candidate):
                 if registry.get(target_qn) is None:
@@ -2795,6 +2838,7 @@ class CallProcessor:
         caller_spec: tuple[str, str, str],
         ensure_rel,
         caller_qn: str | None,
+        module_qn: str | None = None,
     ) -> None:
         args = call_node.child_by_field_name(cs.FIELD_ARGUMENTS)
         if args is None:
@@ -2808,6 +2852,7 @@ class CallProcessor:
                     ensure_rel,
                     caller_qn,
                     cs.RelationshipType.REFERENCES,
+                    module_qn=module_qn,
                 )
 
     def _emit_inline_arg_function_ref(
@@ -2817,6 +2862,7 @@ class CallProcessor:
         ensure_rel,
         caller_qn: str | None = None,
         rel_type: cs.RelationshipType = cs.RelationshipType.REFERENCES,
+        module_qn: str | None = None,
     ) -> None:
         # (H) An inline arrow/function-expression call argument is registered by the
         # (H) definition pass as {enclosing_scope}.anonymous_<row>_<col> from its own
@@ -2825,23 +2871,35 @@ class CallProcessor:
         # (H) callable-param path). Registry guard skips unregistered names.
         registry = self._resolver.function_registry
         scope_qn = caller_qn or source_spec[2]
-        suffix = (
+        suffixes = [
             f"{cs.SEPARATOR_DOT}{cs.PREFIX_ANONYMOUS}"
             f"{arg_node.start_point[0]}_{arg_node.start_point[1]}"
-        )
+        ]
+        # (H) A NAMED function expression argument (`this.on('mount', function
+        # (H) onmount(parent) {...})`, express) registers by its own NAME -- the
+        # (H) position form never matches it, so try the name too, both under the
+        # (H) caller scope and module-flat (where the def pass puts it).
+        name_node = arg_node.child_by_field_name(cs.FIELD_NAME)
+        named = safe_decode_text(name_node) if name_node is not None else None
+        if named:
+            suffixes.append(f"{cs.SEPARATOR_DOT}{named}")
         # (H) A duplicate-variant caller (a TS overload implementation registers as
         # (H) `useStore@27`) owns anons the def pass registers under the NATURAL qn
         # (H) (`useStore.anonymous_R_C`); try the variant-stripped scope too.
-        for scope in _scope_qn_candidates(scope_qn):
-            candidate = f"{scope}{suffix}"
-            for target_qn in registry.variants(candidate):
-                if registry.get(target_qn) is None:
-                    continue
-                ensure_rel(
-                    source_spec,
-                    rel_type,
-                    (cs.NodeLabel.FUNCTION, cs.KEY_QUALIFIED_NAME, target_qn),
-                )
+        scopes = _scope_qn_candidates(scope_qn)
+        if named and module_qn is not None and module_qn not in scopes:
+            scopes = [*scopes, module_qn]
+        for scope in scopes:
+            for suffix in suffixes:
+                candidate = f"{scope}{suffix}"
+                for target_qn in registry.variants(candidate):
+                    if registry.get(target_qn) is None:
+                        continue
+                    ensure_rel(
+                        source_spec,
+                        rel_type,
+                        (cs.NodeLabel.FUNCTION, cs.KEY_QUALIFIED_NAME, target_qn),
+                    )
 
     @staticmethod
     def _flow_scope_boundaries(lang_config: LanguageSpec) -> frozenset[str]:

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -697,32 +697,30 @@ class CallResolver:
             # (H) function's parent is a module, which is never in the registry.
             if parent_qn in self.function_registry:
                 candidates.append(qn)
-        if len(candidates) > 1:
-            # (H) Prefer candidates VISIBLE to the calling module: parent imported
-            # (H) here or defined here (express's tryRender imports ./view, so
-            # (H) View.render wins over an unrelated example's GithubView.render).
-            import_map = self.import_processor.import_mapping.get(module_qn) or {}
-            imported = set(import_map.values())
-            # (H) A JS require maps the MODULE (`require('./view')` ->
-            # (H) express.lib.view), so a visible candidate's parent may equal an
-            # (H) import or sit anywhere under one; same-module candidates are
-            # (H) visible too.
-            visible = [
-                qn
-                for qn in candidates
-                if qn.startswith(f"{module_qn}{cs.SEPARATOR_DOT}")
-                or any(
-                    qn.rpartition(cs.SEPARATOR_DOT)[0] == imp
-                    or qn.rpartition(cs.SEPARATOR_DOT)[0].startswith(
-                        f"{imp}{cs.SEPARATOR_DOT}"
-                    )
-                    for imp in imported
+        # (H) Only candidates VISIBLE to the calling module count -- parent module
+        # (H) imported here or defined here (express's tryRender imports ./view, so
+        # (H) View.render qualifies; an unrelated example's GithubView.render does
+        # (H) not). Required even for a SINGLETON: an untyped `client.render()` in
+        # (H) a file with no relation to the sole View.render must drop, not grow a
+        # (H) false cross-module edge that hides real dead code. A JS require maps
+        # (H) the MODULE (`require('./view')` -> express.lib.view), so a visible
+        # (H) candidate's parent may equal an import or sit anywhere under one.
+        import_map = self.import_processor.import_mapping.get(module_qn) or {}
+        imported = set(import_map.values())
+        visible = [
+            qn
+            for qn in candidates
+            if qn.startswith(f"{module_qn}{cs.SEPARATOR_DOT}")
+            or any(
+                qn.rpartition(cs.SEPARATOR_DOT)[0] == imp
+                or qn.rpartition(cs.SEPARATOR_DOT)[0].startswith(
+                    f"{imp}{cs.SEPARATOR_DOT}"
                 )
-            ]
-            if visible:
-                candidates = visible
-        if len(candidates) == 1:
-            return self.function_registry[candidates[0]], candidates[0]
+                for imp in imported
+            )
+        ]
+        if len(visible) == 1:
+            return self.function_registry[visible[0]], visible[0]
         return None
 
     def _is_external_path_import(self, call_name: str, module_qn: str) -> bool:

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -410,6 +410,34 @@ class CallResolver:
                 targets.add((self.function_registry[override_qn], override_qn))
         return targets
 
+    def js_member_twin_targets(self, callee_qn: str) -> set[tuple[str, str]]:
+        # (H) `View.prototype.lookup = function lookup(...)` registers TWO nodes for
+        # (H) one method: the prototype path's `View.lookup` and the fn-expr's
+        # (H) own-name module-flat `view.lookup`. A call binds one twin and the
+        # (H) other reports dead. Return the same-name twin(s) whose parent chain
+        # (H) extends (or is extended by) the callee's parent -- i.e. the same
+        # (H) module's flat/member pair -- so the caller can edge both (the
+        # (H) duplicate-QN keep-both design). Never crosses modules.
+        parent_qn, sep, leaf = callee_qn.rpartition(cs.SEPARATOR_DOT)
+        if not sep:
+            return set()
+        twins: set[tuple[str, str]] = set()
+        for qn in self.function_registry.find_ending_with(leaf):
+            if qn == callee_qn:
+                continue
+            other_parent, d, other_leaf = qn.rpartition(cs.SEPARATOR_DOT)
+            if not d or other_leaf != leaf:
+                continue
+            if not (
+                other_parent.startswith(f"{parent_qn}{cs.SEPARATOR_DOT}")
+                or parent_qn.startswith(f"{other_parent}{cs.SEPARATOR_DOT}")
+            ):
+                continue
+            label = self.function_registry.get(qn)
+            if label in (cs.NodeLabel.FUNCTION, cs.NodeLabel.METHOD):
+                twins.add((label, qn))
+        return twins
+
     def go_package_sibling_targets(self, callee_qn: str) -> set[tuple[str, str]]:
         # (H) Go package-level functions are package-scoped, but cgr keys each file as
         # (H) its own module (`pkgdir.file.name`). Two same-package functions with the
@@ -587,7 +615,7 @@ class CallResolver:
             )
 
         if result := self._try_resolve_via_imports(
-            call_name, module_qn, local_var_types
+            call_name, module_qn, local_var_types, language
         ):
             if use_cache:
                 self._simple_resolution_cache[cache_key] = result
@@ -638,10 +666,64 @@ class CallResolver:
                 self._simple_resolution_cache[cache_key] = None
             return None
 
+        # (H) A JS/TS member call on an UNTYPED receiver (`view.render(...)` where
+        # (H) `view` is a param constructed in the caller) targets a MEMBER: the
+        # (H) bare-name trie would rebind it to a free function of the same name
+        # (H) (express's application.render), a false edge that also kills the real
+        # (H) prototype method. Bind the UNIQUE member-like candidate (parent qn
+        # (H) itself registered) or drop.
+        if language in cs.JS_TS_LANGUAGES and cs.SEPARATOR_DOT in call_name:
+            result = self._resolve_js_member_call_unique(call_name, module_qn)
+            if use_cache:
+                self._simple_resolution_cache[cache_key] = result
+            return result
+
         result = self._try_resolve_via_trie(call_name, module_qn)
         if use_cache:
             self._simple_resolution_cache[cache_key] = result
         return result
+
+    def _resolve_js_member_call_unique(
+        self, call_name: str, module_qn: str
+    ) -> tuple[str, str] | None:
+        method_name = call_name.rsplit(cs.SEPARATOR_DOT, 1)[-1]
+        candidates: list[str] = []
+        for qn in self.function_registry.find_ending_with(method_name):
+            parent_qn, sep, leaf = qn.rpartition(cs.SEPARATOR_DOT)
+            if not sep or leaf != method_name:
+                continue
+            # (H) Member-like: the parent is itself a registered node (a class, a
+            # (H) prototype constructor Function, an object scope) -- a free
+            # (H) function's parent is a module, which is never in the registry.
+            if parent_qn in self.function_registry:
+                candidates.append(qn)
+        if len(candidates) > 1:
+            # (H) Prefer candidates VISIBLE to the calling module: parent imported
+            # (H) here or defined here (express's tryRender imports ./view, so
+            # (H) View.render wins over an unrelated example's GithubView.render).
+            import_map = self.import_processor.import_mapping.get(module_qn) or {}
+            imported = set(import_map.values())
+            # (H) A JS require maps the MODULE (`require('./view')` ->
+            # (H) express.lib.view), so a visible candidate's parent may equal an
+            # (H) import or sit anywhere under one; same-module candidates are
+            # (H) visible too.
+            visible = [
+                qn
+                for qn in candidates
+                if qn.startswith(f"{module_qn}{cs.SEPARATOR_DOT}")
+                or any(
+                    qn.rpartition(cs.SEPARATOR_DOT)[0] == imp
+                    or qn.rpartition(cs.SEPARATOR_DOT)[0].startswith(
+                        f"{imp}{cs.SEPARATOR_DOT}"
+                    )
+                    for imp in imported
+                )
+            ]
+            if visible:
+                candidates = visible
+        if len(candidates) == 1:
+            return self.function_registry[candidates[0]], candidates[0]
+        return None
 
     def _is_external_path_import(self, call_name: str, module_qn: str) -> bool:
         # (H) True when the dotted call's object segment is imported from a target
@@ -779,6 +861,7 @@ class CallResolver:
         call_name: str,
         module_qn: str,
         local_var_types: dict[str, str] | None,
+        language: cs.SupportedLanguage | None = None,
     ) -> tuple[str, str] | None:
         import_map = self.import_processor.import_mapping.get(module_qn)
         if import_map is None:
@@ -796,7 +879,7 @@ class CallResolver:
             return result
 
         if result := self._try_resolve_qualified_call(
-            call_name, import_map, module_qn, local_var_types
+            call_name, import_map, module_qn, local_var_types, language
         ):
             return result
 
@@ -819,6 +902,7 @@ class CallResolver:
         import_map: dict[str, str],
         module_qn: str,
         local_var_types: dict[str, str] | None,
+        language: cs.SupportedLanguage | None = None,
     ) -> tuple[str, str] | None:
         if cs.SEPARATOR_DOUBLE_COLON in call_name:
             separator = cs.SEPARATOR_DOUBLE_COLON
@@ -833,7 +917,13 @@ class CallResolver:
 
         if len(parts) == 2:
             if result := self._resolve_two_part_call(
-                parts, call_name, separator, import_map, module_qn, local_var_types
+                parts,
+                call_name,
+                separator,
+                import_map,
+                module_qn,
+                local_var_types,
+                language,
             ):
                 return result
 
@@ -949,6 +1039,7 @@ class CallResolver:
         import_map: dict[str, str],
         module_qn: str,
         local_var_types: dict[str, str] | None,
+        language: cs.SupportedLanguage | None = None,
     ) -> tuple[str, str] | None:
         object_name, method_name = parts
 
@@ -979,6 +1070,18 @@ class CallResolver:
         ):
             return result
 
+        # (H) A JS/TS dotted call binds to a same-module free function ONLY through
+        # (H) a module-ish receiver (`exports.render()`, `this.render()` in the
+        # (H) CommonJS/prototype pattern). An ordinary identifier receiver
+        # (H) (`view.render()`) is an instance call: binding it to the free
+        # (H) function is a false edge that also kills the real prototype method
+        # (H) (express's View.render); let it fall to the unique-member gate.
+        if (
+            language in cs.JS_TS_LANGUAGES
+            and separator == cs.SEPARATOR_DOT
+            and object_name not in cs.JS_MODULE_RECEIVERS
+        ):
+            return None
         return self._try_resolve_module_method(method_name, call_name, module_qn)
 
     def _try_resolve_static_type_method(

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -903,7 +903,10 @@ class ImportProcessor:
                             child, source_module, module_qn, is_aliased_scheme
                         )
 
-            elif import_node.type == cs.TS_LEXICAL_DECLARATION:
+            elif import_node.type in (
+                cs.TS_LEXICAL_DECLARATION,
+                cs.TS_VARIABLE_DECLARATION,
+            ):
                 self._parse_js_require(import_node, module_qn)
 
             elif import_node.type == cs.TS_EXPORT_STATEMENT:

--- a/codebase_rag/tests/test_dead_code_eval.py
+++ b/codebase_rag/tests/test_dead_code_eval.py
@@ -844,3 +844,24 @@ def test_external_override_property_is_root() -> None:
     dead = dead_code_from_graph(nodes, [], _PREFIX, _CONFIG)
     assert "proj.tw.TextWrapper._wrap_chunks" not in dead
     assert "proj.tw.TextWrapper.unused" in dead
+
+
+def test_singular_test_dir_is_excluded() -> None:
+    # (H) The Node.js/mocha convention keeps tests under a singular `test/` dir
+    # (H) (express: 34 of 49 dead-code reports were test helpers). With tests
+    # (H) excluded, such symbols are unconditional noise. `contest/` and
+    # (H) `latest/` must NOT match (the pattern is segment-anchored by the
+    # (H) leading-slash normalization).
+    nodes = dict(
+        [
+            (
+                (_MODULE, "proj.m"),
+                {cs.KEY_QUALIFIED_NAME: "proj.m", cs.KEY_PATH: "m.py"},
+            ),
+            _fn("proj.test.helper", path="test/helper.js"),
+            _fn("proj.contest.helper", path="contest/helper.js"),
+        ]
+    )
+    dead = dead_code_from_graph(nodes, [], _PREFIX, _CONFIG)
+    assert "proj.test.helper" not in dead
+    assert "proj.contest.helper" in dead

--- a/codebase_rag/tests/test_js_named_function_expression_args.py
+++ b/codebase_rag/tests/test_js_named_function_expression_args.py
@@ -1,0 +1,62 @@
+# (H) A NAMED function expression passed as a call argument (express's
+# (H) `this.on('mount', function onmount(parent) {...})`, `defineGetter(req,
+# (H) 'path', function path() {...})`) registers by its own NAME, but the inline
+# (H) argument reference is built from the arg's POSITION only -- so the named
+# (H) node never matches and reports dead. Name candidates must be tried too.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.conftest import create_and_run_updater, get_relationships
+
+
+def _refs(mock_ingestor: MagicMock) -> set[tuple[str, str]]:
+    return {
+        (c.args[0][2], c.args[2][2])
+        for c in get_relationships(mock_ingestor, "REFERENCES")
+    }
+
+
+def test_named_function_expression_arg_is_referenced(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    root = temp_repo / "exarg"
+    root.mkdir(parents=True)
+    (root / "app.js").write_text(
+        "exports.init = function () {\n"
+        "  this.on('mount', function onmount(parent) {\n"
+        "    return parent\n"
+        "  })\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="typescript")
+    refs = _refs(mock_ingestor)
+    assert any(t.endswith(".onmount") for _, t in refs), sorted(
+        t for _, t in refs if "onmount" in t or "anonymous" in t
+    )
+
+
+def test_named_function_expression_getter_value_is_referenced(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) express's request.js shape: the named fn-expr is the third argument of
+    # (H) a module-scope helper call.
+    root = temp_repo / "exget"
+    root.mkdir(parents=True)
+    (root / "request.js").write_text(
+        "function defineGetter(obj, name, getter) {\n"
+        "  Object.defineProperty(obj, name, { get: getter })\n"
+        "}\n"
+        "const req = {}\n"
+        "defineGetter(req, 'secure', function secure() {\n"
+        "  return true\n"
+        "})\n",
+        encoding="utf-8",
+    )
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="typescript")
+    refs = _refs(mock_ingestor)
+    assert any(t.endswith(".secure") for _, t in refs), sorted(
+        t for _, t in refs if "secure" in t or "anonymous" in t
+    )

--- a/codebase_rag/tests/test_js_named_pair_value_and_logical_default.py
+++ b/codebase_rag/tests/test_js_named_pair_value_and_logical_default.py
@@ -1,0 +1,63 @@
+# (H) Two express residuals:
+# (H) 1. a NAMED function expression as an object-pair value (`get: function
+# (H)    getrouter() {...}`) registers by its OWN name, which neither the pair-key
+# (H)    nor the position candidate matches;
+# (H) 2. a function expression behind a LOGICAL DEFAULT (`done = done ||
+# (H)    function (err, str) {...}`) sits in a binary RHS the assignment walker
+# (H)    never descended into.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.conftest import create_and_run_updater, get_relationships
+
+
+def _refs(mock_ingestor: MagicMock) -> set[tuple[str, str]]:
+    return {
+        (c.args[0][2], c.args[2][2])
+        for c in get_relationships(mock_ingestor, "REFERENCES")
+    }
+
+
+def test_named_pair_value_function_expression_is_referenced(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    root = temp_repo / "exnpv"
+    root.mkdir(parents=True)
+    (root / "app.js").write_text(
+        "exports.init = function () {\n"
+        "  Object.defineProperty(this, 'router', {\n"
+        "    get: function getrouter() {\n"
+        "      return 1\n"
+        "    }\n"
+        "  })\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="typescript")
+    refs = _refs(mock_ingestor)
+    assert any(t.endswith(".getrouter") for _, t in refs), sorted(
+        t for _, t in refs if "getrouter" in t or "anonymous" in t
+    )
+
+
+def test_logical_default_function_expression_is_referenced(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    root = temp_repo / "exlod"
+    root.mkdir(parents=True)
+    (root / "res.js").write_text(
+        "exports.render = function (view, done) {\n"
+        "  done = done || function (err, str) {\n"
+        "    return str\n"
+        "  }\n"
+        "  return done(null, view)\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="typescript")
+    refs = _refs(mock_ingestor)
+    assert any(".anonymous_1_" in t for _, t in refs), sorted(
+        t for _, t in refs if "anonymous" in t
+    )

--- a/codebase_rag/tests/test_js_object_value_function_expression_naming.py
+++ b/codebase_rag/tests/test_js_object_value_function_expression_naming.py
@@ -1,0 +1,39 @@
+# (H) An anonymous function expression used as an OBJECT VALUE (`var pets = {
+# (H) list: function(req, res) {...}, delete: function(req, res) {...} }`,
+# (H) express's route-map example) must NOT climb past the pair to the enclosing
+# (H) declarator and steal its name -- that registers phantom `pets`/`pets@50`
+# (H) Function nodes that nothing references (false dead). The pair-key naming
+# (H) path owns object values.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.conftest import create_and_run_updater
+
+
+def test_object_value_fn_expr_does_not_take_declarator_name(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    root = temp_repo / "exobj"
+    root.mkdir(parents=True)
+    (root / "index.js").write_text(
+        "var pets = {\n"
+        "  list: function(req, res){\n"
+        "    return res\n"
+        "  },\n"
+        "  delete: function(req, res){\n"
+        "    return req\n"
+        "  }\n"
+        "};\n"
+        "exports.map = { get: pets.list, del: pets.delete }\n",
+        encoding="utf-8",
+    )
+    updater = create_and_run_updater(root, mock_ingestor, skip_if_missing="typescript")
+    registry = updater.factory.function_registry
+    phantom = [
+        qn
+        for qn, label in registry.items()
+        if qn.split(".")[-1].split("@")[0] == "pets" and str(label) == "Function"
+    ]
+    assert not phantom, phantom

--- a/codebase_rag/tests/test_js_prototype_assignment_single_registration.py
+++ b/codebase_rag/tests/test_js_prototype_assignment_single_registration.py
@@ -1,0 +1,36 @@
+# (H) `View.prototype.lookup = function lookup(...) {...}` registers TWO nodes for
+# (H) one method (the prototype path's `View.lookup` and the fn-expr's own-name
+# (H) module-flat `view.lookup`). A call binds one twin and the other reports dead.
+# (H) Per the duplicate-QN design (keep both nodes, CALLS-to-both), a dotted call
+# (H) that binds either twin must also edge the same-module same-name member twin.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.conftest import create_and_run_updater, get_relationships
+
+
+def test_member_call_edges_both_prototype_twins(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    root = temp_repo / "exproto"
+    root.mkdir(parents=True)
+    (root / "view.js").write_text(
+        "function View(name) {\n"
+        "  this.name = name\n"
+        "  this.lookup(name)\n"
+        "}\n"
+        "View.prototype.lookup = function lookup(name) {\n"
+        "  return name\n"
+        "}\n"
+        "module.exports = View\n",
+        encoding="utf-8",
+    )
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="typescript")
+    calls = {
+        (c.args[0][2], c.args[2][2]) for c in get_relationships(mock_ingestor, "CALLS")
+    }
+    assert any(f.endswith(".View") and t.endswith(".View.lookup") for f, t in calls), (
+        sorted(t for f, t in calls if "lookup" in t)
+    )

--- a/codebase_rag/tests/test_js_untyped_receiver_member_call.py
+++ b/codebase_rag/tests/test_js_untyped_receiver_member_call.py
@@ -102,3 +102,36 @@ def test_var_require_visibility_disambiguates_member_call(
     assert not any(
         f.endswith(".tryRender") and t.endswith(".GithubView.render") for f, t in calls
     ), "member call bound the invisible module's twin"
+
+
+def test_invisible_singleton_member_is_not_bound(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) An untyped member call in a file that neither defines nor imports the
+    # (H) candidate's module (`client.render()` in an unrelated file) must NOT
+    # (H) bind the repo's sole same-named member: visibility is required even
+    # (H) for a singleton, else external-object calls grow false edges that hide
+    # (H) real dead code.
+    root = temp_repo / "exinv"
+    root.mkdir(parents=True)
+    (root / "view.js").write_text(
+        "function View(name) {\n"
+        "  this.name = name\n"
+        "}\n"
+        "View.prototype.render = function render(options) {\n"
+        "  return options\n"
+        "}\n"
+        "module.exports = View\n",
+        encoding="utf-8",
+    )
+    (root / "unrelated.js").write_text(
+        "exports.ping = function (client) {\n  return client.render({})\n}\n",
+        encoding="utf-8",
+    )
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="typescript")
+    calls = {
+        (c.args[0][2], c.args[2][2]) for c in get_relationships(mock_ingestor, "CALLS")
+    }
+    assert not any(
+        f.startswith("exinv.unrelated") and "render" in t for f, t in calls
+    ), "invisible singleton member wrongly bound"

--- a/codebase_rag/tests/test_js_untyped_receiver_member_call.py
+++ b/codebase_rag/tests/test_js_untyped_receiver_member_call.py
@@ -1,0 +1,104 @@
+# (H) A JS member call on an UNTYPED receiver (`view.render(opts, cb)` inside
+# (H) `tryRender(view, cb)` -- the instance was constructed in the CALLER, so the
+# (H) param has no inferred type) fell to the bare-name trie and mis-bound to the
+# (H) same-module free function `render` (express's application.render): a false
+# (H) edge AND the real prototype method View.render reported dead. A member call
+# (H) targets a MEMBER: resolve to the unique member-like candidate (its parent qn
+# (H) is itself registered) or drop; never rebind to a free function.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.conftest import create_and_run_updater, get_relationships
+
+
+def test_untyped_receiver_member_call_binds_unique_prototype_method(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    root = temp_repo / "exview"
+    root.mkdir(parents=True)
+    (root / "view.js").write_text(
+        "function View(name) {\n"
+        "  this.name = name\n"
+        "}\n"
+        "View.prototype.render = function render(options, callback) {\n"
+        "  return callback(null, options)\n"
+        "}\n"
+        "module.exports = View\n",
+        encoding="utf-8",
+    )
+    (root / "application.js").write_text(
+        "var View = require('./view')\n"
+        "exports.render = function (name, done) {\n"
+        "  var view = new View(name)\n"
+        "  tryRender(view, done)\n"
+        "}\n"
+        "function tryRender(view, callback) {\n"
+        "  view.render({}, callback)\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="typescript")
+    calls = {
+        (c.args[0][2], c.args[2][2]) for c in get_relationships(mock_ingestor, "CALLS")
+    }
+    assert any(
+        f.endswith(".tryRender") and t.endswith(".View.render") for f, t in calls
+    ), sorted(t for f, t in calls if "render" in t)
+    assert not any(
+        f.endswith(".tryRender") and t.endswith(".application.render") for f, t in calls
+    ), "member call mis-bound to the same-module free function"
+
+
+def test_var_require_visibility_disambiguates_member_call(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) With a same-named prototype method in an UNRELATED module (express's
+    # (H) examples GithubView.render), uniqueness needs the import-visibility
+    # (H) filter -- and express binds View with `var View = require('./view')`,
+    # (H) a variable_declaration the require-mapping walk did not visit (it only
+    # (H) handled const/let lexical_declarations).
+    root = temp_repo / "exvis"
+    root.mkdir(parents=True)
+    (root / "view.js").write_text(
+        "function View(name) {\n"
+        "  this.name = name\n"
+        "}\n"
+        "View.prototype.render = function render(options, callback) {\n"
+        "  return callback(null, options)\n"
+        "}\n"
+        "module.exports = View\n",
+        encoding="utf-8",
+    )
+    (root / "github-view.js").write_text(
+        "function GithubView(name) {\n"
+        "  this.name = name\n"
+        "}\n"
+        "GithubView.prototype.render = function render(options, callback) {\n"
+        "  return callback(null, options)\n"
+        "}\n"
+        "module.exports = GithubView\n",
+        encoding="utf-8",
+    )
+    (root / "application.js").write_text(
+        "var View = require('./view')\n"
+        "exports.render = function (name, done) {\n"
+        "  var view = new View(name)\n"
+        "  tryRender(view, done)\n"
+        "}\n"
+        "function tryRender(view, callback) {\n"
+        "  view.render({}, callback)\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="typescript")
+    calls = {
+        (c.args[0][2], c.args[2][2]) for c in get_relationships(mock_ingestor, "CALLS")
+    }
+    assert any(
+        f.endswith(".tryRender") and t.endswith(".view.View.render") for f, t in calls
+    ), sorted(t for f, t in calls if "render" in t)
+    assert not any(
+        f.endswith(".tryRender") and t.endswith(".GithubView.render") for f, t in calls
+    ), "member call bound the invisible module's twin"

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.264"
+version = "0.0.266"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Fresh-repo dead-code dogfood on expressjs/express (first CommonJS/prototype-idiom target): 49 -> 1. The remaining 1 (`GithubView.render`) is genuinely dynamic (`app.set('view', GithubView)` -- a string-keyed settings registry express invokes reflectively), correct to report. Every fix RED -> GREEN; zustand 0, click 0, gson unchanged (22, after `/test/` correctly excludes its `src/test/java` tree).

## Fix classes

1. **Singular `test/` dir** (`test_dead_code_eval.py::test_singular_test_dir_is_excluded`): the Node.js/mocha convention (34 of express's 49 reports were test helpers). Previously excluded on purpose; the pattern is segment-anchored by the leading-slash normalization so `contest/`/`latest/` cannot match, and `/spec/` stays out (documented collision with domain "spec" modules).
2. **Named function expressions as call args** (`test_js_named_function_expression_args.py`): `this.on('mount', function onmount(parent) {...})`, `defineGetter(req, 'path', function path() {...})` register by their OWN name; positional candidates never matched. Name candidates (scope + module-flat) added.
3. **Named fn-exprs as pair values + logical defaults** (`test_js_named_pair_value_and_logical_default.py`): `get: function getrouter() {...}` (own-name candidates in the dispatch-table scan) and `done = done || function (err, str) {...}` (binary-RHS operands scanned).
4. **Object-value fn-exprs stealing the declarator name** (`test_js_object_value_function_expression_naming.py`): `var pets = { list: function(req, res) {...} }` climbed past the pair and registered phantom `pets`/`pets@50` Function nodes (a regression risk from #668's fn-expr climb). The climb now stops at pair/object boundaries.
5. **Untyped-receiver member calls** (`test_js_untyped_receiver_member_call.py`): `view.render(opts, cb)` inside `tryRender(view, cb)` mis-bound to the same-module free function `application.render` (false edge + dead View.render). A JS/TS dotted call now binds a same-module free function only through module-ish receivers (`exports`/`module`/`this`); otherwise it resolves to the unique member-like candidate, disambiguated by import-visibility, or drops.
6. **Prototype twin fan-out** (`test_js_prototype_assignment_single_registration.py`): `View.prototype.lookup = function lookup()` registers two nodes for one method (member `View.lookup` + module-flat own-name twin); a call that binds either now edges the same-module same-name twin too (the established duplicate-QN keep-both design; revive-only).
7. **CommonJS `var` requires** (`test_js_untyped_receiver_member_call.py::test_var_require_visibility_disambiguates_member_call`): `var View = require('./view')` is a `variable_declaration`, which the require-mapping walk never visited (only const/let `lexical_declaration`) -- import visibility was empty for classic CJS files.

## Verification

- Full suite: 4593 passed, 0 failed (91 errors all memgraph-integration, environment-only)
- express 49 -> 1 (the 1 is genuinely dynamic); zustand 0; click 0; gson 22 (55 -> 22 is its `src/test/java` tree now correctly excluded by `/test/`; main-src unchanged)
- ruff clean; ty clean on changed paths
