### PR TITLE
feat(cpp-frontend): emit IMPORTS edges for within-repo includes

### DIFF
--- a/codebase_rag/parsers/cpp_frontend/frontend.py
+++ b/codebase_rag/parsers/cpp_frontend/frontend.py
@@ -268,6 +268,38 @@ class _Collector:
         self._add_module(module_qn, rel, file_name)
         return (fc.LABEL_MODULE, module_qn)
 
+    def process_includes(self, tu) -> None:
+        # (H) `#include` is the C++ import: emit IMPORTS Module -> Module for every
+        # (H) within-repo inclusion, at any depth (calc.h including util.h counts,
+        # (H) attributed to calc.h -- FileInclusion.source is the INCLUDING file).
+        # (H) System headers resolve outside the repo (module_qn None) and emit
+        # (H) nothing; the source != include guard keeps the tree-sitter path's
+        # (H) self-import bug out of the frontend.
+        for inclusion in tu.get_includes():
+            source = inclusion.source
+            included = inclusion.include
+            if source is None or included is None:
+                continue
+            src_name = source.name
+            inc_name = included.name
+            src_qn = self.resolver.module_qn(src_name)
+            inc_qn = self.resolver.module_qn(inc_name)
+            if src_qn is None or inc_qn is None or src_qn == inc_qn:
+                continue
+            src_rel = self.resolver.rel_path(src_name)
+            inc_rel = self.resolver.rel_path(inc_name)
+            if src_rel is None or inc_rel is None:
+                continue
+            self._add_module(src_qn, src_rel, src_name)
+            self._add_module(inc_qn, inc_rel, inc_name)
+            self._add_edge(
+                cs.RelationshipType.IMPORTS,
+                fc.LABEL_MODULE,
+                src_qn,
+                fc.LABEL_MODULE,
+                inc_qn,
+            )
+
     def _emit_inheritance(self, cursor: Cursor, derived_qn: str) -> None:
         for child in cursor.get_children():
             if child.kind.name != fc.KIND_BASE_SPECIFIER:
@@ -376,6 +408,7 @@ def run_cpp_frontend(
         except ci.TranslationUnitLoadError:
             continue
         _walk(tu.cursor, collector)
+        collector.process_includes(tu)
 
     collector.flush(ingestor)
     return frozenset(collector.covered)

--- a/codebase_rag/parsers/cpp_frontend/frontend.py
+++ b/codebase_rag/parsers/cpp_frontend/frontend.py
@@ -86,6 +86,10 @@ class _Collector:
         self.modules: dict[str, PropertyDict] = {}
         self.edges: set[_EdgeKey] = set()
         self.covered: set[str] = set()
+        # (H) absolute file name -> (rel, module_qn), or None when outside the
+        # (H) repo. rel_path resolves symlinks (filesystem-touching); headers
+        # (H) recur across every TU that includes them, so resolve each once.
+        self._include_file_info: dict[str, tuple[str, str] | None] = {}
 
     def _node_props(self, cursor: Cursor, qn: str, name: str, rel: str) -> PropertyDict:
         return {
@@ -280,18 +284,14 @@ class _Collector:
             included = inclusion.include
             if source is None or included is None:
                 continue
-            src_name = source.name
-            inc_name = included.name
-            src_qn = self.resolver.module_qn(src_name)
-            inc_qn = self.resolver.module_qn(inc_name)
-            if src_qn is None or inc_qn is None or src_qn == inc_qn:
+            src = self._include_info(source.name)
+            inc = self._include_info(included.name)
+            if src is None or inc is None or src[1] == inc[1]:
                 continue
-            src_rel = self.resolver.rel_path(src_name)
-            inc_rel = self.resolver.rel_path(inc_name)
-            if src_rel is None or inc_rel is None:
-                continue
-            self._add_module(src_qn, src_rel, src_name)
-            self._add_module(inc_qn, inc_rel, inc_name)
+            src_rel, src_qn = src
+            inc_rel, inc_qn = inc
+            self._add_module(src_qn, src_rel, source.name)
+            self._add_module(inc_qn, inc_rel, included.name)
             self._add_edge(
                 cs.RelationshipType.IMPORTS,
                 fc.LABEL_MODULE,
@@ -299,6 +299,17 @@ class _Collector:
                 fc.LABEL_MODULE,
                 inc_qn,
             )
+
+    def _include_info(self, file_name: str) -> tuple[str, str] | None:
+        # (H) Resolve rel + module_qn together, once per file: rel_path is the
+        # (H) filesystem-touching step and module_qn is a map lookup keyed by it.
+        if file_name in self._include_file_info:
+            return self._include_file_info[file_name]
+        rel = self.resolver.rel_path(file_name)
+        qn = self.resolver.module_qn_for_rel(rel) if rel is not None else None
+        info = (rel, qn) if rel is not None and qn is not None else None
+        self._include_file_info[file_name] = info
+        return info
 
     def _emit_inheritance(self, cursor: Cursor, derived_qn: str) -> None:
         for child in cursor.get_children():

--- a/codebase_rag/parsers/cpp_frontend/qn.py
+++ b/codebase_rag/parsers/cpp_frontend/qn.py
@@ -90,6 +90,11 @@ class CppQnResolver:
             return None
         return self._module_qn.get(rel)
 
+    def module_qn_for_rel(self, rel: str) -> str | None:
+        # (H) Map lookup only -- for callers that already paid rel_path's
+        # (H) filesystem resolution and must not pay it twice.
+        return self._module_qn.get(rel)
+
     def _namespace_chain(self, cursor: Cursor) -> list[str]:
         parts: list[str] = []
         parent = cursor.semantic_parent

--- a/codebase_rag/tests/test_cpp_frontend_includes.py
+++ b/codebase_rag/tests/test_cpp_frontend_includes.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag.parsers.cpp_frontend import cpp_frontend_available, run_cpp_frontend
+
+pytestmark = pytest.mark.skipif(
+    not cpp_frontend_available(),
+    reason="libclang not available",
+)
+
+# (H) `#include "calc.h"` is the C++ import: the frontend must emit an IMPORTS
+# (H) edge Module -> Module for every within-repo inclusion (transitively --
+# (H) calc.h including util.h counts, from calc.h). System headers (<vector>)
+# (H) resolve outside the repo and emit nothing, and a file never imports itself
+# (H) (the tree-sitter path's self-import bug must not be replicated).
+_UTIL_H = """
+#pragma once
+namespace m { int util(int x); }
+"""
+
+_CALC_H = """
+#pragma once
+#include "util.h"
+namespace m { int add(int a, int b); }
+"""
+
+_SRC = """
+#include "calc.h"
+#include <vector>
+namespace m {
+int add(int a, int b) { (void)std::vector<int>{}; return a + b + util(a); }
+int util(int x) { return x; }
+}
+"""
+
+
+def _write(root: Path) -> None:
+    root.mkdir()
+    (root / "util.h").write_text(_UTIL_H, encoding="utf-8")
+    (root / "calc.h").write_text(_CALC_H, encoding="utf-8")
+    (root / "calc.cpp").write_text(_SRC, encoding="utf-8")
+    (root / "compile_commands.json").write_text(
+        json.dumps(
+            [
+                {
+                    "directory": str(root),
+                    "arguments": [
+                        "c++",
+                        "-std=c++17",
+                        f"-I{root}",
+                        str(root / "calc.cpp"),
+                    ],
+                    "file": str(root / "calc.cpp"),
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _imports(ingestor: MagicMock) -> set[tuple[str, str, str, str]]:
+    out = set()
+    for c in ingestor.ensure_relationship_batch.call_args_list:
+        if c.args[1] == "IMPORTS":
+            (from_label, _, from_qn) = c.args[0]
+            (to_label, _, to_qn) = c.args[2]
+            out.add((from_label, from_qn, to_label, to_qn))
+    return out
+
+
+def test_within_repo_includes_emit_imports(temp_repo: Path) -> None:
+    root = temp_repo / "incproj"
+    _write(root)
+
+    ingestor = MagicMock()
+    run_cpp_frontend(ingestor, root, root.name, root)
+
+    imports = _imports(ingestor)
+    # (H) The resolver's module qns: calc.cpp -> incproj.calc (extension
+    # (H) stripped), calc.h -> incproj.calc.h (extension kept on stem
+    # (H) collision), util.h -> incproj.util.
+    assert ("Module", "incproj.calc", "Module", "incproj.calc.h") in imports, sorted(
+        imports
+    )
+    assert any(
+        from_qn == "incproj.calc.h" and to_qn == "incproj.util"
+        for _, from_qn, _, to_qn in imports
+    ), f"expected calc.h IMPORTS util.h, got {sorted(imports)}"
+    # (H) no self-imports, no system-header edges
+    assert not any(f == t for _, f, _, t in imports), sorted(imports)
+    assert not any("vector" in t for _, _, _, t in imports), sorted(imports)


### PR DESCRIPTION
## Summary

C++ libclang frontend follow-up (parked Option A from the frontend work, Codeberg #46 series): `#include` is the C++ import, so the frontend now emits `IMPORTS` Module -> Module edges for every within-repo inclusion.

## Implementation

- `_Collector.process_includes(tu)` iterates `tu.get_includes()` after each translation unit's cursor walk: `FileInclusion.source` is the INCLUDING file, so transitive inclusions attribute correctly (calc.h including util.h emits `calc.h IMPORTS util.h`, not an edge from the TU's main file).
- System headers resolve outside the repo (`module_qn` is None) and emit nothing.
- A `source != include` guard keeps the tree-sitter path's known self-import bug out of the frontend.
- Modules discovered only through inclusion chains are ensured (`_add_module`), so header-only modules get their node and CONTAINS_MODULE parent like every other module.

No schema change: the IMPORTS Module -> Module shape is the one the tree-sitter path already emits.

## Verification (RED -> GREEN)

- `test_cpp_frontend_includes.py`: within-repo direct + transitive includes emit IMPORTS with the resolver's qn shapes; no self-imports; no system-header edges. Confirmed failing before the change.
- All 9 cpp_frontend tests pass; full suite 4594 passed, 0 failed (91 errors are memgraph-integration environment-only; the one parallel-run failure is the known `test_rust_containment_oracle` scheduling flake, passes isolated).
