### PR TITLE
feat: register C/C++ and Rust macro definitions as Function nodes with resolvable invocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ An accurate Retrieval-Augmented Generation (RAG) system that analyzes multi-lang
 | Language | Status | Extensions | Functions | Classes/Structs | Modules | Package Detection | Additional Features |
 |--------|------|----------|---------|---------------|-------|-----------------|-------------------|
 | C | Fully Supported | .c | ✓ | ✓ | ✓ | ✓ | Functions, structs, unions, enums, preprocessor includes |
-| C++ | Fully Supported | .cpp, .h, .hpp, .cc, .cxx, .hxx, .hh, .ixx, .cppm, .ccm | ✓ | ✓ | ✓ | ✓ | Constructors, destructors, operator overloading, templates, lambdas, C++20 modules, namespaces |
+| C++ | Fully Supported | .cpp, .h, .hpp, .cc, .cxx, .hxx, .hh, .ixx, .cppm, .ccm | ✓ | ✓ | ✓ | ✓ | Constructors, destructors, operator overloading, templates, lambdas, C++20 modules, namespaces, preprocessor macros |
 | Java | Fully Supported | .java | ✓ | ✓ | ✓ | - | Generics, annotations, modern features (records/sealed classes), concurrency, reflection |
 | JavaScript | Fully Supported | .js, .jsx | ✓ | ✓ | ✓ | - | ES6 modules, CommonJS, prototype methods, object methods, arrow functions |
 | Lua | Fully Supported | .lua | ✓ | - | ✓ | - | Local/global functions, metatables, closures, coroutines |
 | PHP | Fully Supported | .php | ✓ | ✓ | ✓ | - | Classes, interfaces, traits, enums, namespaces, PHP 8 attributes |
 | Python | Fully Supported | .py | ✓ | ✓ | ✓ | ✓ | Type inference, decorators, nested functions |
-| Rust | Fully Supported | .rs | ✓ | ✓ | ✓ | ✓ | impl blocks, associated functions |
+| Rust | Fully Supported | .rs | ✓ | ✓ | ✓ | ✓ | impl blocks, associated functions, macro_rules! macros |
 | TypeScript (TSX) | Fully Supported | .tsx | ✓ | ✓ | ✓ | - | All TypeScript features plus JSX elements and components |
 | TypeScript | Fully Supported | .ts | ✓ | ✓ | ✓ | - | Interfaces, type aliases, enums, namespaces, ES6/CommonJS modules |
 | Go | In Development | .go | ✓ | ✓ | ✓ | - | Methods, type declarations |
@@ -717,7 +717,7 @@ The knowledge graph uses the following node types and relationships:
 | Module | `{qualified_name: string, name: string, path: string, absolute_path: string, start_line: int?, end_line: int?}` |
 | Class | `{qualified_name: string, name: string, decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
 | Function | `{qualified_name: string, name: string, decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
-| Method | `{qualified_name: string, name: string, decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?, is_property: boolean?}` |
+| Method | `{qualified_name: string, name: string, decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?, is_property: boolean?, overrides_external: boolean?}` |
 | Interface | `{qualified_name: string, name: string, path: string, absolute_path: string, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
 | Enum | `{qualified_name: string, name: string, path: string, absolute_path: string, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
 | Type | `{qualified_name: string, name: string, path: string?, absolute_path: string?, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
@@ -738,7 +738,7 @@ The knowledge graph uses the following node types and relationships:
 - **Lua**: `function_declaration`, `function_definition`
 - **PHP**: `anonymous_function`, `arrow_function`, `class_declaration`, `enum_declaration`, `function_definition`, `interface_declaration`, `method_declaration`, `trait_declaration`
 - **Python**: `class_definition`, `function_definition`
-- **Rust**: `closure_expression`, `enum_item`, `function_item`, `function_signature_item`, `impl_item`, `struct_item`, `trait_item`, `type_item`, `union_item`
+- **Rust**: `closure_expression`, `enum_item`, `function_item`, `function_signature_item`, `impl_item`, `macro_definition`, `struct_item`, `trait_item`, `type_item`, `union_item`
 - **TypeScript (TSX)**: `abstract_class_declaration`, `arrow_function`, `class`, `class_declaration`, `enum_declaration`, `function_declaration`, `function_expression`, `function_signature`, `generator_function_declaration`, `interface_declaration`, `internal_module`, `method_definition`, `type_alias_declaration`
 - **TypeScript**: `abstract_class_declaration`, `arrow_function`, `class`, `class_declaration`, `enum_declaration`, `function_declaration`, `function_expression`, `function_signature`, `generator_function_declaration`, `interface_declaration`, `internal_module`, `method_definition`, `type_alias_declaration`
 - **Go**: `function_declaration`, `method_declaration`, `type_alias`, `type_spec`
@@ -760,9 +760,9 @@ The knowledge graph uses the following node types and relationships:
 | Module | EXPORTS | Class, Function |
 | Module | EXPORTS_MODULE | ModuleInterface |
 | Module | IMPLEMENTS_MODULE | ModuleImplementation |
-| Class, Interface, Function | INHERITS | Class, Interface, Function |
-| Class, Enum | IMPLEMENTS | Interface |
-| Method | OVERRIDES | Method |
+| Class, Interface, Function | INHERITS | Class, Interface, Function, ExternalModule |
+| Class, Enum | IMPLEMENTS | Interface, ExternalModule |
+| Method, Function | OVERRIDES | Method |
 | ModuleImplementation | IMPLEMENTS | ModuleInterface |
 | Project | DEPENDS_ON_EXTERNAL | ExternalPackage |
 | Module, Function, Method | CALLS | Function, Method, Enum, Type |

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -195,6 +195,7 @@ KEY_PARSER = "parser"
 KEY_NAME = "name"
 KEY_QUALIFIED_NAME = "qualified_name"
 KEY_IS_PROPERTY = "is_property"
+KEY_IS_MACRO = "is_macro"
 KEY_QUERY = "query"
 KEY_RESPONSE = "response"
 KEY_START_LINE = "start_line"
@@ -1346,7 +1347,7 @@ CYPHER_ALL_DEFINITION_QNS = (
     "MATCH (n) WHERE n:Function OR n:Method OR n:Class OR n:Interface "
     "OR n:Enum OR n:Type OR n:Union "
     "RETURN n.qualified_name AS qualified_name, head(labels(n)) AS label, "
-    "n.is_property AS is_property, n.path AS path"
+    "n.is_property AS is_property, n.is_macro AS is_macro, n.path AS path"
 )
 
 # (H) Module-level qns (plus C++20 module interfaces) for incremental runs:
@@ -3255,6 +3256,9 @@ TS_RS_CALL_EXPRESSION = "call_expression"
 TS_RS_MACRO_INVOCATION = "macro_invocation"
 TS_RS_MACRO_DEFINITION = "macro_definition"
 RS_MACRO_EXPORT_ATTR = "macro_export"
+TS_RS_LINE_COMMENT = "line_comment"
+TS_RS_BLOCK_COMMENT = "block_comment"
+RS_COMMENT_TYPES = (TS_RS_LINE_COMMENT, TS_RS_BLOCK_COMMENT)
 TS_RS_ATTRIBUTE_ITEM = "attribute_item"
 TS_RS_INNER_ATTRIBUTE_ITEM = "inner_attribute_item"
 

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -2494,6 +2494,7 @@ TS_JAVA_CAST_EXPRESSION = "cast_expression"
 TS_ATTRIBUTE = "attribute"
 
 FIELD_OPERATOR = "operator"
+FIELD_MACRO = "macro"
 
 # (H) Derived node type tuples for class ingestion
 CPP_CLASS_TYPES = (CppNodeType.CLASS_SPECIFIER, TS_STRUCT_SPECIFIER)
@@ -3252,6 +3253,8 @@ TS_RS_USE_DECLARATION = "use_declaration"
 TS_RS_EXTERN_CRATE_DECLARATION = "extern_crate_declaration"
 TS_RS_CALL_EXPRESSION = "call_expression"
 TS_RS_MACRO_INVOCATION = "macro_invocation"
+TS_RS_MACRO_DEFINITION = "macro_definition"
+RS_MACRO_EXPORT_ATTR = "macro_export"
 TS_RS_ATTRIBUTE_ITEM = "attribute_item"
 TS_RS_INNER_ATTRIBUTE_ITEM = "inner_attribute_item"
 
@@ -3674,6 +3677,11 @@ SPEC_RS_FUNCTION_TYPES = (
     TS_RS_FUNCTION_ITEM,
     TS_RS_FUNCTION_SIGNATURE_ITEM,
     TS_RS_CLOSURE_EXPRESSION,
+    # (H) macro_rules! definitions register as Function nodes (the
+    # (H) cross-language decision: C/C++/Rust macros all map onto Function), so
+    # (H) macro_invocation call sites (already in SPEC_RS_CALL_TYPES) have a
+    # (H) first-party definition to resolve to.
+    TS_RS_MACRO_DEFINITION,
 )
 SPEC_RS_CLASS_TYPES = (
     TS_RS_STRUCT_ITEM,

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -824,7 +824,7 @@ LANGUAGE_METADATA: dict[SupportedLanguage, LanguageMetadata] = {
     ),
     SupportedLanguage.CPP: LanguageMetadata(
         LanguageStatus.FULL,
-        "Constructors, destructors, operator overloading, templates, lambdas, C++20 modules, namespaces",
+        "Constructors, destructors, operator overloading, templates, lambdas, C++20 modules, namespaces, preprocessor macros",
         "C++",
     ),
     SupportedLanguage.LUA: LanguageMetadata(
@@ -834,7 +834,7 @@ LANGUAGE_METADATA: dict[SupportedLanguage, LanguageMetadata] = {
     ),
     SupportedLanguage.RUST: LanguageMetadata(
         LanguageStatus.FULL,
-        "impl blocks, associated functions",
+        "impl blocks, associated functions, macro_rules! macros",
         "Rust",
     ),
     SupportedLanguage.JAVA: LanguageMetadata(

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -666,6 +666,11 @@ class GraphUpdater:
             # (H) @property defined elsewhere would otherwise drop vs a clean index.
             if row.get(cs.KEY_IS_PROPERTY):
                 self.function_registry.mark_property(qn)
+            # (H) Restore the macro-namespace set for unchanged files: the Rust
+            # (H) macro/fn gate consults it, so a re-parsed file's invocation of
+            # (H) a macro defined elsewhere would otherwise drop vs a clean index.
+            if row.get(cs.KEY_IS_MACRO):
+                self.factory.definition_processor.macro_qns.add(qn)
             # (H) Record the defining file so _is_cpp_defined can language-check
             # (H) rehydrated candidates (deferred C++ INHERITS resolution runs
             # (H) after this and must reach bases in UNCHANGED headers).

--- a/codebase_rag/language_spec.py
+++ b/codebase_rag/language_spec.py
@@ -325,6 +325,8 @@ LANGUAGE_SPECS: dict[cs.SupportedLanguage, LanguageSpec] = {
         (function_signature_item
             name: (identifier) @name) @function
         (closure_expression) @function
+        (macro_definition
+            name: (identifier) @name) @function
         """,
         class_query="""
         (struct_item

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -181,6 +181,7 @@ class CallProcessor:
         "_path_to_module_qn",
         "cpp_out_of_class_methods",
         "function_locations",
+        "macro_qns",
         "_resolver",
         "_flow_param_names",
         "_flow_args",
@@ -202,6 +203,7 @@ class CallProcessor:
         module_qn_to_file_path: dict[str, Path] | None = None,
         cpp_out_of_class_methods: dict[tuple[str, int], tuple[str, str]] | None = None,
         function_locations: dict[tuple[str, int], FunctionLocation] | None = None,
+        macro_qns: set[str] | None = None,
     ) -> None:
         self.ingestor = ingestor
         self.repo_path = repo_path
@@ -210,6 +212,7 @@ class CallProcessor:
         self._path_to_module_qn: dict[Path, str] | None = None
         self.cpp_out_of_class_methods = cpp_out_of_class_methods or {}
         self.function_locations = function_locations or {}
+        self.macro_qns = macro_qns if macro_qns is not None else set()
 
         self._resolver = CallResolver(
             function_registry=function_registry,
@@ -1458,6 +1461,14 @@ class CallProcessor:
                 operator_node = call_node.child_by_field_name(cs.FIELD_OPERATOR)
                 if operator_node and operator_node.text:
                     return operator_node.text.decode(cs.ENCODING_UTF8)
+            # (H) Rust `square!(3)`: the callee lives in the `macro` field (no
+            # (H) `function`/`name` field), so the invocation was captured as a
+            # (H) call but dropped nameless here -- unresolvable even now that
+            # (H) macro_rules! definitions register as Function nodes.
+            case cs.TS_RS_MACRO_INVOCATION if language == cs.SupportedLanguage.RUST:
+                macro_node = call_node.child_by_field_name(cs.FIELD_MACRO)
+                if macro_node is not None and macro_node.text is not None:
+                    return macro_node.text.decode(cs.ENCODING_UTF8)
 
         if name_node := call_node.child_by_field_name(cs.FIELD_NAME):
             if name_node.text is not None:
@@ -1738,6 +1749,15 @@ class CallProcessor:
                     caller_qn,
                     language,
                 )
+            if callee_info and language == cs.SupportedLanguage.RUST:
+                # (H) Rust macros and functions live in SEPARATE namespaces:
+                # (H) a macro invocation (write!) must not bind a same-named fn
+                # (H) (std-prelude macro names collide with common fn names and
+                # (H) the false edge revives dead code), and a fn call must not
+                # (H) bind a same-named macro.
+                is_macro_target = callee_info[1] in self.macro_qns
+                if is_macro_target != (call_node.type == cs.TS_RS_MACRO_INVOCATION):
+                    callee_info = None
             if not callee_info and resolve_builtin is not None:
                 callee_info = resolve_builtin(call_name)
             if not callee_info and resolve_cpp_op is not None:

--- a/codebase_rag/parsers/cpp_frontend/constants.py
+++ b/codebase_rag/parsers/cpp_frontend/constants.py
@@ -13,6 +13,8 @@ KIND_DESTRUCTOR = "DESTRUCTOR"
 KIND_BASE_SPECIFIER = "CXX_BASE_SPECIFIER"
 KIND_TRANSLATION_UNIT = "TRANSLATION_UNIT"
 KIND_CALL_EXPR = "CALL_EXPR"
+KIND_MACRO_DEFINITION = "MACRO_DEFINITION"
+KIND_MACRO_INSTANTIATION = "MACRO_INSTANTIATION"
 
 # (H) class/struct/union and their templated forms -> a Class node (cgr collapses
 # (H) struct/class to Class, matching parsers/cpp + the oracle).

--- a/codebase_rag/parsers/cpp_frontend/frontend.py
+++ b/codebase_rag/parsers/cpp_frontend/frontend.py
@@ -311,12 +311,9 @@ class _Collector:
             return
         self.covered.add(rel)
         self._add_module(module_qn, rel, file_name)
-        self._add_node(
-            fc.LABEL_FUNCTION,
-            qn,
-            self._node_props(cursor, qn, cursor.spelling, rel),
-            True,
-        )
+        props = self._node_props(cursor, qn, cursor.spelling, rel)
+        props[cs.KEY_IS_MACRO] = True
+        self._add_node(fc.LABEL_FUNCTION, qn, props, True)
         self._add_edge(
             cs.RelationshipType.DEFINES,
             fc.LABEL_MODULE,
@@ -352,10 +349,10 @@ class _Collector:
         for label, props, _ in self.nodes.values():
             if label not in (fc.LABEL_FUNCTION, fc.LABEL_METHOD):
                 continue
-            path = props[cs.KEY_PATH]
-            qn = props[cs.KEY_QUALIFIED_NAME]
-            start = props[cs.KEY_START_LINE]
-            end = props[cs.KEY_END_LINE]
+            path = props.get(cs.KEY_PATH)
+            qn = props.get(cs.KEY_QUALIFIED_NAME)
+            start = props.get(cs.KEY_START_LINE)
+            end = props.get(cs.KEY_END_LINE)
             if (
                 isinstance(path, str)
                 and isinstance(qn, str)

--- a/codebase_rag/parsers/cpp_frontend/frontend.py
+++ b/codebase_rag/parsers/cpp_frontend/frontend.py
@@ -90,6 +90,11 @@ class _Collector:
         # (H) repo. rel_path resolves symlinks (filesystem-touching); headers
         # (H) recur across every TU that includes them, so resolve each once.
         self._include_file_info: dict[str, tuple[str, str] | None] = {}
+        # (H) (use-site rel, use-site line, macro Function qn, use-site absolute
+        # (H) file): macro cursors are TU-level preprocessing entities, so the
+        # (H) enclosing caller is only recoverable by span once ALL definitions
+        # (H) are collected -- resolved at flush.
+        self._pending_macro_calls: set[tuple[str, int, str, str]] = set()
 
     def _node_props(self, cursor: Cursor, qn: str, name: str, rel: str) -> PropertyDict:
         return {
@@ -134,6 +139,12 @@ class _Collector:
         # (H) enclosing scope.
         if cursor.kind.name == fc.KIND_CALL_EXPR:
             self._process_call(cursor, enclosing)
+            return None
+        if cursor.kind.name == fc.KIND_MACRO_DEFINITION:
+            self._process_macro_definition(cursor)
+            return None
+        if cursor.kind.name == fc.KIND_MACRO_INSTANTIATION:
+            self._queue_macro_call(cursor)
             return None
         label = _classify(cursor)
         if label is None or cursor.location.file is None:
@@ -272,6 +283,110 @@ class _Collector:
         self._add_module(module_qn, rel, file_name)
         return (fc.LABEL_MODULE, module_qn)
 
+    def _macro_function_qn(self, cursor: Cursor) -> str | None:
+        # (H) Macros register as Function nodes (the cross-language decision:
+        # (H) C/C++/Rust macros all map onto Function). Builtins and
+        # (H) command-line macros have no file; system-header macros resolve
+        # (H) outside the repo; an empty-bodied object-like macro (include
+        # (H) guard, feature flag -- extent covers only the name) is a flag,
+        # (H) not a callable.
+        if cursor.location.file is None:
+            return None
+        extent = cursor.extent
+        if (
+            extent.start.line == extent.end.line
+            and extent.end.column - extent.start.column == len(cursor.spelling)
+        ):
+            return None
+        return self.resolver.function_qn(cursor)
+
+    def _process_macro_definition(self, cursor: Cursor) -> None:
+        qn = self._macro_function_qn(cursor)
+        if qn is None:
+            return
+        file_name = cursor.location.file.name
+        rel = self.resolver.rel_path(file_name)
+        module_qn = self.resolver.module_qn(file_name)
+        if rel is None or module_qn is None:
+            return
+        self.covered.add(rel)
+        self._add_module(module_qn, rel, file_name)
+        self._add_node(
+            fc.LABEL_FUNCTION,
+            qn,
+            self._node_props(cursor, qn, cursor.spelling, rel),
+            True,
+        )
+        self._add_edge(
+            cs.RelationshipType.DEFINES,
+            fc.LABEL_MODULE,
+            module_qn,
+            fc.LABEL_FUNCTION,
+            qn,
+        )
+
+    def _queue_macro_call(self, cursor: Cursor) -> None:
+        # (H) MACRO_INSTANTIATION.referenced is the exact MACRO_DEFINITION
+        # (H) (libclang resolved it); the caller needs span containment over the
+        # (H) full node set, so defer to flush.
+        if cursor.location.file is None:
+            return
+        referenced = cursor.referenced
+        if referenced is None:
+            return
+        callee_qn = self._macro_function_qn(referenced)
+        if callee_qn is None:
+            return
+        file_name = cursor.location.file.name
+        rel = self.resolver.rel_path(file_name)
+        if rel is None:
+            return
+        self._pending_macro_calls.add((rel, cursor.location.line, callee_qn, file_name))
+
+    def _resolve_macro_calls(self) -> None:
+        # (H) Attribute each macro use to the tightest enclosing
+        # (H) function/method span in its file (macro cursors are TU children,
+        # (H) never AST-nested); a use outside any span is a module-load-time
+        # (H) expansion -> the Module, mirroring _module_caller.
+        spans: dict[str, list[tuple[int, int, str, str]]] = {}
+        for label, props, _ in self.nodes.values():
+            if label not in (fc.LABEL_FUNCTION, fc.LABEL_METHOD):
+                continue
+            path = props[cs.KEY_PATH]
+            qn = props[cs.KEY_QUALIFIED_NAME]
+            start = props[cs.KEY_START_LINE]
+            end = props[cs.KEY_END_LINE]
+            if (
+                isinstance(path, str)
+                and isinstance(qn, str)
+                and isinstance(start, int)
+                and isinstance(end, int)
+            ):
+                spans.setdefault(path, []).append((start, end, label, qn))
+        for rel, line, callee_qn, file_name in sorted(self._pending_macro_calls):
+            containing = [
+                s
+                for s in spans.get(rel, ())
+                if s[0] <= line <= s[1] and s[3] != callee_qn
+            ]
+            if containing:
+                _, _, caller_label, caller_qn = min(
+                    containing, key=lambda s: s[1] - s[0]
+                )
+            else:
+                module_qn = self.resolver.module_qn_for_rel(rel)
+                if module_qn is None:
+                    continue
+                self._add_module(module_qn, rel, file_name)
+                caller_label, caller_qn = fc.LABEL_MODULE, module_qn
+            self._add_edge(
+                cs.RelationshipType.CALLS,
+                caller_label,
+                caller_qn,
+                fc.LABEL_FUNCTION,
+                callee_qn,
+            )
+
     def process_includes(self, tu) -> None:
         # (H) `#include` is the C++ import: emit IMPORTS Module -> Module for every
         # (H) within-repo inclusion, at any depth (calc.h including util.h counts,
@@ -354,6 +469,7 @@ class _Collector:
             self.simple_name_lookup[name].add(qn)
 
     def flush(self, ingestor: IngestorProtocol) -> None:
+        self._resolve_macro_calls()
         for module_qn, props in self.modules.items():
             ingestor.ensure_node_batch(fc.LABEL_MODULE, props)
             path = props[cs.KEY_PATH]
@@ -415,7 +531,14 @@ def run_cpp_frontend(
     for command in db.getAllCompileCommands():
         args = list(command.arguments)[1:]
         try:
-            tu = index.parse(None, args=args)
+            # (H) the detailed record exposes MACRO_DEFINITION /
+            # (H) MACRO_INSTANTIATION cursors (preprocessing entities are
+            # (H) otherwise absent from the cursor tree)
+            tu = index.parse(
+                None,
+                args=args,
+                options=ci.TranslationUnit.PARSE_DETAILED_PROCESSING_RECORD,
+            )
         except ci.TranslationUnitLoadError:
             continue
         _walk(tu.cursor, collector)

--- a/codebase_rag/parsers/cpp_frontend/frontend.py
+++ b/codebase_rag/parsers/cpp_frontend/frontend.py
@@ -510,9 +510,11 @@ def run_cpp_frontend(
     Parses every translation unit in the compilation database, walks the cursor
     tree, and emits Module/Class/Function/Method nodes plus DEFINES /
     DEFINES_METHOD / INHERITS edges and exact spans straight to the ingestor,
-    synthesizing the same qualified names the tree-sitter path would. Returns the
-    set of repo-relative files it covered (so callers can skip them in the
-    tree-sitter pass).
+    synthesizing the same qualified names the tree-sitter path would. Repo macro
+    definitions register as Function nodes and macro uses emit CALLS from their
+    enclosing function (see the graph-schema docs). Returns the set of
+    repo-relative files it covered (so callers can skip them in the tree-sitter
+    pass).
 
     When ``function_registry`` / ``simple_name_lookup`` are supplied, emitted
     definitions are registered for cross-file resolution; when

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -118,6 +118,11 @@ class DefinitionProcessor(
         # (H) Inline (non-file) module qns, e.g. Rust `mod x {}`; deferred
         # (H) import verification counts them as real internal targets.
         self.declared_module_qns: set[str] = set()
+        # (H) Registered qns that are macro definitions (Rust macro_rules!):
+        # (H) macros register as Function nodes but live in a separate namespace,
+        # (H) so Pass-3 gates macro-invocation call sites to these targets and
+        # (H) fn-namespace call sites away from them.
+        self.macro_qns: set[str] = set()
         # (H) {qn: file path} for definitions rehydrated from the graph on an
         # (H) incremental run, whose modules are absent from module_qn_to_file_path
         # (H) (only re-parsed files populate it). _is_cpp_defined falls back to

--- a/codebase_rag/parsers/export_detection.py
+++ b/codebase_rag/parsers/export_detection.py
@@ -154,7 +154,22 @@ def _rust_exported(node: Node) -> bool:
     # (H) (`pub(crate)`, `pub(super)`, `pub(in path)`) is visible only within the
     # (H) crate/module, so an uncalled one is genuinely dead and must not be seeded
     # (H) as a root. Bare `pub` is a lone keyword child; a restriction adds `(...)`.
+    if node.type == cs.TS_RS_MACRO_DEFINITION:
+        return _rust_macro_exported(node)
     modifier = next(
         (c for c in node.children if c.type == cs.TS_PHP_VISIBILITY_MODIFIER), None
     )
     return modifier is not None and modifier.child_count == 1
+
+
+def _rust_macro_exported(node: Node) -> bool:
+    # (H) macro_rules! takes no `pub`; a preceding #[macro_export] attribute is
+    # (H) what publishes it (to the crate root) as library API.
+    prev = node.prev_named_sibling
+    while prev is not None and prev.type == cs.TS_RS_ATTRIBUTE_ITEM:
+        if prev.text is not None and cs.RS_MACRO_EXPORT_ATTR in prev.text.decode(
+            cs.ENCODING_UTF8
+        ):
+            return True
+        prev = prev.prev_named_sibling
+    return False

--- a/codebase_rag/parsers/export_detection.py
+++ b/codebase_rag/parsers/export_detection.py
@@ -164,11 +164,18 @@ def _rust_exported(node: Node) -> bool:
 
 def _rust_macro_exported(node: Node) -> bool:
     # (H) macro_rules! takes no `pub`; a preceding #[macro_export] attribute is
-    # (H) what publishes it (to the crate root) as library API.
+    # (H) what publishes it (to the crate root) as library API. Comments (incl.
+    # (H) /// doc comments) are named siblings that interleave the attribute and
+    # (H) the definition, so skip them.
     prev = node.prev_named_sibling
-    while prev is not None and prev.type == cs.TS_RS_ATTRIBUTE_ITEM:
-        if prev.text is not None and cs.RS_MACRO_EXPORT_ATTR in prev.text.decode(
-            cs.ENCODING_UTF8
+    while prev is not None and prev.type in (
+        cs.TS_RS_ATTRIBUTE_ITEM,
+        *cs.RS_COMMENT_TYPES,
+    ):
+        if (
+            prev.type == cs.TS_RS_ATTRIBUTE_ITEM
+            and prev.text is not None
+            and cs.RS_MACRO_EXPORT_ATTR in prev.text.decode(cs.ENCODING_UTF8)
         ):
             return True
         prev = prev.prev_named_sibling

--- a/codebase_rag/parsers/factory.py
+++ b/codebase_rag/parsers/factory.py
@@ -140,5 +140,6 @@ class ProcessorFactory:
                 module_qn_to_file_path=self.module_qn_to_file_path,
                 cpp_out_of_class_methods=self.definition_processor.cpp_out_of_class_methods,
                 function_locations=self.definition_processor.function_locations,
+                macro_qns=self.definition_processor.macro_qns,
             )
         return self._call_processor

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -661,16 +661,20 @@ class FunctionIngestMixin:
             resolution = resolution._replace(qualified_name=unique_qn)
 
         func_props = self._build_function_props(func_node, resolution, module_qn)
+        is_macro = func_node.type == cs.TS_RS_MACRO_DEFINITION
+        if is_macro:
+            # (H) Rust macros live in a separate namespace from functions;
+            # (H) Pass-3 gates macro-invocation vs fn-call binding on macro_qns,
+            # (H) and the persisted property lets incremental runs rehydrate the
+            # (H) set for UNCHANGED files (the is_property pattern).
+            func_props[cs.KEY_IS_MACRO] = True
         logger.info(
             ls.FUNC_FOUND.format(name=resolution.name, qn=resolution.qualified_name)
         )
         self.ingestor.ensure_node_batch(cs.NodeLabel.FUNCTION, func_props)
 
         self.function_registry[resolution.qualified_name] = NodeType.FUNCTION
-        if func_node.type == cs.TS_RS_MACRO_DEFINITION:
-            # (H) Rust macros live in a separate namespace from functions;
-            # (H) Pass-3 needs to know which Function qns are macros to gate
-            # (H) macro-invocation vs fn-call binding.
+        if is_macro:
             self.macro_qns.add(resolution.qualified_name)
         self.function_registry.mark_callable_params(
             resolution.qualified_name,

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -140,6 +140,7 @@ class FunctionIngestMixin:
     method_return_types: dict[str, str]
     cpp_out_of_class_methods: dict[tuple[str, int], tuple[str, str]]
     function_locations: dict[tuple[str, int], FunctionLocation]
+    macro_qns: set[str]
     class_inheritance: dict[str, list[str]]
     _deferred_cpp_inherits: list[DeferredCppInherit]
     rehydrated_definition_paths: dict[str, str]
@@ -666,6 +667,11 @@ class FunctionIngestMixin:
         self.ingestor.ensure_node_batch(cs.NodeLabel.FUNCTION, func_props)
 
         self.function_registry[resolution.qualified_name] = NodeType.FUNCTION
+        if func_node.type == cs.TS_RS_MACRO_DEFINITION:
+            # (H) Rust macros live in a separate namespace from functions;
+            # (H) Pass-3 needs to know which Function qns are macros to gate
+            # (H) macro-invocation vs fn-call binding.
+            self.macro_qns.add(resolution.qualified_name)
         self.function_registry.mark_callable_params(
             resolution.qualified_name,
             callable_parameter_indices(func_node, language),

--- a/codebase_rag/tests/test_cpp_frontend_macros.py
+++ b/codebase_rag/tests/test_cpp_frontend_macros.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag.parsers.cpp_frontend import cpp_frontend_available, run_cpp_frontend
+
+pytestmark = pytest.mark.skipif(
+    not cpp_frontend_available(),
+    reason="libclang not available",
+)
+
+# (H) Preprocessor macros were invisible to the frontend (no
+# (H) PARSE_DETAILED_PROCESSING_RECORD): SQUARE(v) had no node and no CALLS
+# (H) edge. Macros register as Function nodes (the cross-language decision);
+# (H) MACRO_INSTANTIATION.referenced gives the exact definition, and the caller
+# (H) is the tightest enclosing function/method span (macro cursors are TU-level
+# (H) preprocessing entities, so lexical enclosure must be recovered by span).
+# (H) Empty-bodied object-like macros (include guards, feature flags) are NOT
+# (H) nodes; neither are compiler builtins or system-header macros.
+_CALC_H = """\
+#ifndef CALC_H
+#define CALC_H
+#define SQUARE(x) ((x)*(x))
+#define MAX_SIZE 100
+int compute(int v);
+#endif
+"""
+
+_SRC = """\
+#include "calc.h"
+int compute(int v) { return SQUARE(v) + MAX_SIZE; }
+int main() { return compute(2); }
+"""
+
+
+def _write(root: Path) -> None:
+    root.mkdir()
+    (root / "calc.h").write_text(_CALC_H, encoding="utf-8")
+    (root / "calc.cpp").write_text(_SRC, encoding="utf-8")
+    (root / "compile_commands.json").write_text(
+        json.dumps(
+            [
+                {
+                    "directory": str(root),
+                    "arguments": [
+                        "c++",
+                        "-std=c++17",
+                        f"-I{root}",
+                        str(root / "calc.cpp"),
+                    ],
+                    "file": str(root / "calc.cpp"),
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _functions(ingestor: MagicMock) -> set[str]:
+    return {
+        c.args[1]["qualified_name"]
+        for c in ingestor.ensure_node_batch.call_args_list
+        if c.args[0] == "Function"
+    }
+
+
+def _calls(ingestor: MagicMock) -> set[tuple[str, str]]:
+    return {
+        (c.args[0][2], c.args[2][2])
+        for c in ingestor.ensure_relationship_batch.call_args_list
+        if c.args[1] == "CALLS"
+    }
+
+
+def test_macro_definitions_register_as_functions(temp_repo: Path) -> None:
+    root = temp_repo / "macproj"
+    _write(root)
+    ingestor = MagicMock()
+    run_cpp_frontend(ingestor, root, root.name, root)
+    functions = _functions(ingestor)
+    # (H) calc.cpp claims macproj.calc (walk order), so calc.h keeps its ext
+    assert "macproj.calc.h.SQUARE" in functions, sorted(functions)
+    assert "macproj.calc.h.MAX_SIZE" in functions, sorted(functions)
+    # (H) the include guard is an empty flag, not a callable
+    assert not any(qn.endswith(".CALC_H") for qn in functions), sorted(functions)
+    # (H) builtins/system macros live outside the repo
+    assert not any("__GNUC__" in qn for qn in functions), sorted(functions)
+
+
+def test_macro_instantiations_emit_calls_from_enclosing_function(
+    temp_repo: Path,
+) -> None:
+    root = temp_repo / "macproj2"
+    _write(root)
+    ingestor = MagicMock()
+    run_cpp_frontend(ingestor, root, root.name, root)
+    calls = _calls(ingestor)
+    assert ("macproj2.calc.compute", "macproj2.calc.h.SQUARE") in calls, sorted(calls)
+    assert ("macproj2.calc.compute", "macproj2.calc.h.MAX_SIZE") in calls, sorted(calls)

--- a/codebase_rag/tests/test_rs_macro_definition_nodes.py
+++ b/codebase_rag/tests/test_rs_macro_definition_nodes.py
@@ -96,6 +96,66 @@ def test_macro_and_fn_namespaces_do_not_cross_bind(
     )
 
 
+def test_incremental_reparse_keeps_cross_file_macro_call(temp_repo: Path) -> None:
+    # (H) Incremental runs rehydrate function_registry from the graph, but the
+    # (H) macro-namespace gate consults macro_qns, which only definition
+    # (H) ingest populated. A re-parsed file invoking a macro from an UNCHANGED
+    # (H) file would resolve the macro qn, see it missing from macro_qns, and
+    # (H) drop the CALLS edge -- the macro then reports dead only on
+    # (H) incremental runs. Macro nodes persist is_macro and rehydration
+    # (H) restores it (the is_property pattern).
+    from codebase_rag.graph_updater import GraphUpdater
+    from codebase_rag.parser_loader import load_parsers
+    from evals.cgr_graph import _StatefulIngestor
+
+    src = temp_repo / "src"
+    src.mkdir(parents=True)
+    (temp_repo / "Cargo.toml").write_text(
+        f'[package]\nname = "{temp_repo.name}"\nversion = "0.1.0"\n', encoding="utf-8"
+    )
+    (src / "util.rs").write_text(
+        "#[macro_export]\nmacro_rules! square {\n    ($x:expr) => { $x * $x };\n}\n",
+        encoding="utf-8",
+    )
+    lib_src = (
+        "#[macro_use]\nmod util;\n"
+        "use crate::util::square;\n"
+        "pub fn use_it() -> i32 {\n"
+        "    square!(3)\n"
+        "}\n"
+    )
+    (src / "lib.rs").write_text(lib_src, encoding="utf-8")
+
+    def _calls(store: _StatefulIngestor) -> set[tuple[str, str]]:
+        return {
+            (str(f), str(t))
+            for _, f, rel, _, t in store.edges
+            if rel == cs.RelationshipType.CALLS.value
+        }
+
+    def _index(store: _StatefulIngestor, force: bool) -> None:
+        parsers, queries = load_parsers()
+        GraphUpdater(
+            ingestor=store, repo_path=temp_repo, parsers=parsers, queries=queries
+        ).run(force=force)
+
+    store = _StatefulIngestor()
+    _index(store, force=True)
+    expected = [
+        (f, t)
+        for f, t in _calls(store)
+        if f.endswith(".use_it") and t.endswith(".square")
+    ]
+    assert expected, sorted(_calls(store))
+
+    # (H) touch only the CALLING file; util.rs stays rehydration-only
+    (src / "lib.rs").write_text(lib_src + "// touched\n", encoding="utf-8")
+    _index(store, force=False)
+    assert any(
+        f.endswith(".use_it") and t.endswith(".square") for f, t in _calls(store)
+    ), "incremental run dropped the cross-file macro CALLS edge"
+
+
 def test_macro_export_attribute_marks_exported(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:
@@ -115,6 +175,12 @@ def test_macro_export_attribute_marks_exported(
         "}\n"
         "macro_rules! private_square {\n"
         "    ($x:expr) => { $x * $x };\n"
+        "}\n"
+        "#[macro_export]\n"
+        "/// commented macro (doc comments are named siblings between the\n"
+        "/// attribute and the definition)\n"
+        "macro_rules! commented_square {\n"
+        "    ($x:expr) => { $x * $x };\n"
         "}\n",
         encoding="utf-8",
     )
@@ -126,5 +192,7 @@ def test_macro_export_attribute_marks_exported(
     }
     exported = next(v for k, v in props.items() if k.endswith(".pub_square"))
     private = next(v for k, v in props.items() if k.endswith(".private_square"))
+    commented = next(v for k, v in props.items() if k.endswith(".commented_square"))
     assert exported[cs.KEY_IS_EXPORTED] is True, exported
     assert private[cs.KEY_IS_EXPORTED] is False, private
+    assert commented[cs.KEY_IS_EXPORTED] is True, commented

--- a/codebase_rag/tests/test_rs_macro_definition_nodes.py
+++ b/codebase_rag/tests/test_rs_macro_definition_nodes.py
@@ -1,0 +1,130 @@
+# (H) `macro_rules!` definitions were invisible: invocation SITES were captured
+# (H) (macro_invocation is in SPEC_RS_CALL_TYPES) but there was no definition
+# (H) node to bind to, so `square!(3)` could never resolve to first-party code.
+# (H) Macros register as Function nodes (the cross-language decision: C/C++/Rust
+# (H) macros all map onto Function); invocations then resolve like any call and
+# (H) dead-code treats macros like any function.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import create_and_run_updater, get_relationships
+
+
+def test_macro_rules_registers_function_and_invocation_resolves(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    root = temp_repo / "rsmacro"
+    src = root / "src"
+    src.mkdir(parents=True)
+    (root / "Cargo.toml").write_text(
+        '[package]\nname = "rsmacro"\nversion = "0.1.0"\n', encoding="utf-8"
+    )
+    (src / "lib.rs").write_text(
+        "macro_rules! square {\n"
+        "    ($x:expr) => { $x * $x };\n"
+        "}\n"
+        "pub fn use_it() -> i32 {\n"
+        "    square!(3)\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="rust")
+    functions = {
+        c.args[1][cs.KEY_QUALIFIED_NAME]
+        for c in mock_ingestor.ensure_node_batch.call_args_list
+        if c.args[0] == cs.NodeLabel.FUNCTION
+    }
+    assert any(qn.endswith(".square") for qn in functions), sorted(functions)
+    calls = {
+        (c.args[0][2], c.args[2][2]) for c in get_relationships(mock_ingestor, "CALLS")
+    }
+    assert any(f.endswith(".use_it") and t.endswith(".square") for f, t in calls), (
+        sorted(t for _, t in calls)
+    )
+
+
+def test_macro_and_fn_namespaces_do_not_cross_bind(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) Rust macros and functions live in SEPARATE namespaces: `write!(f, ..)`
+    # (H) (std prelude, no use statement) must not bind a same-module `fn write`
+    # (H) (a false edge that revives dead code), and `write(buf)` must not bind
+    # (H) a same-module `macro_rules! write`-alike either.
+    root = temp_repo / "rsns"
+    src = root / "src"
+    src.mkdir(parents=True)
+    (root / "Cargo.toml").write_text(
+        '[package]\nname = "rsns"\nversion = "0.1.0"\n', encoding="utf-8"
+    )
+    (src / "lib.rs").write_text(
+        "use std::fmt;\n"
+        "pub fn write(buf: &[u8]) -> usize {\n"
+        "    buf.len()\n"
+        "}\n"
+        "macro_rules! trace {\n"
+        "    ($x:expr) => { $x };\n"
+        "}\n"
+        "pub struct W;\n"
+        "impl fmt::Display for W {\n"
+        "    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {\n"
+        '        write!(f, "w")\n'
+        "    }\n"
+        "}\n"
+        "pub fn use_fn(x: i32) -> i32 {\n"
+        "    trace(x)\n"
+        "}\n"
+        "pub fn use_macro(x: i32) -> i32 {\n"
+        "    trace!(x)\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="rust")
+    calls = {
+        (c.args[0][2], c.args[2][2]) for c in get_relationships(mock_ingestor, "CALLS")
+    }
+    assert not any(f.endswith(".fmt") and t.endswith(".write") for f, t in calls), (
+        "std write! macro bound the first-party fn write"
+    )
+    assert not any(f.endswith(".use_fn") and t.endswith(".trace") for f, t in calls), (
+        "fn-namespace call bound the first-party macro"
+    )
+    assert any(f.endswith(".use_macro") and t.endswith(".trace") for f, t in calls), (
+        sorted(calls)
+    )
+
+
+def test_macro_export_attribute_marks_exported(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) macro_rules! takes no `pub`; #[macro_export] is what publishes it (to
+    # (H) the crate root) as library API -- without is_exported an exported but
+    # (H) internally-uninvoked macro would report dead.
+    root = temp_repo / "rsexport"
+    src = root / "src"
+    src.mkdir(parents=True)
+    (root / "Cargo.toml").write_text(
+        '[package]\nname = "rsexport"\nversion = "0.1.0"\n', encoding="utf-8"
+    )
+    (src / "lib.rs").write_text(
+        "#[macro_export]\n"
+        "macro_rules! pub_square {\n"
+        "    ($x:expr) => { $x * $x };\n"
+        "}\n"
+        "macro_rules! private_square {\n"
+        "    ($x:expr) => { $x * $x };\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="rust")
+    props = {
+        c.args[1][cs.KEY_QUALIFIED_NAME]: c.args[1]
+        for c in mock_ingestor.ensure_node_batch.call_args_list
+        if c.args[0] == cs.NodeLabel.FUNCTION
+    }
+    exported = next(v for k, v in props.items() if k.endswith(".pub_square"))
+    private = next(v for k, v in props.items() if k.endswith(".private_square"))
+    assert exported[cs.KEY_IS_EXPORTED] is True, exported
+    assert private[cs.KEY_IS_EXPORTED] is False, private

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -607,7 +607,7 @@ NODE_SCHEMAS: tuple[NodeSchema, ...] = (
     ),
     NodeSchema(
         NodeLabel.FUNCTION,
-        "{qualified_name: string, name: string, decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}",
+        "{qualified_name: string, name: string, decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?, is_macro: boolean?}",
     ),
     NodeSchema(
         NodeLabel.METHOD,

--- a/docs/architecture/graph-schema.md
+++ b/docs/architecture/graph-schema.md
@@ -61,6 +61,15 @@ The first definition keeps the plain dotted qualified name; each later definitio
 
 A `CALLS` edge to a name that has more than one definition links to every variant, since each is a runtime-possible target.
 
+## Macros
+
+Macro definitions map onto the existing `Function` label rather than a dedicated node type, since macros are a cross-language concept (C and C++ `#define`, Rust `macro_rules!`). Macro invocations resolve to their definitions and emit `CALLS` edges, and dead-code analysis treats macros like any function.
+
+Language notes:
+
+- **Rust**: macros and functions live in separate namespaces, so a macro invocation (`write!`) never binds a same-named `fn` and a function call never binds a same-named macro. `#[macro_export]` sets `is_exported` (macros take no `pub`).
+- **C/C++** (libclang frontend): compiler builtins, system-header macros, and empty-bodied object-like macros (include guards, feature flags) are not nodes. A macro use inside a function body emits `CALLS` from that function; a use outside any function attributes to the `Module`.
+
 ## Language-Specific AST Mappings
 
 ### C++
@@ -112,6 +121,7 @@ A `CALLS` edge to a name that has more than one definition links to every varian
 - `function_item`
 - `function_signature_item`
 - `impl_item`
+- `macro_definition`
 - `struct_item`
 - `trait_item`
 - `type_item`

--- a/docs/architecture/graph-schema.md
+++ b/docs/architecture/graph-schema.md
@@ -63,7 +63,7 @@ A `CALLS` edge to a name that has more than one definition links to every varian
 
 ## Macros
 
-Macro definitions map onto the existing `Function` label rather than a dedicated node type, since macros are a cross-language concept (C and C++ `#define`, Rust `macro_rules!`). Macro invocations resolve to their definitions and emit `CALLS` edges, and dead-code analysis treats macros like any function.
+Macro definitions map onto the existing `Function` label rather than a dedicated node type, since macros are a cross-language concept (C and C++ `#define`, Rust `macro_rules!`). Macro Function nodes carry `is_macro: true`, macro invocations resolve to their definitions and emit `CALLS` edges, and dead-code analysis treats macros like any function.
 
 Language notes:
 

--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -10,12 +10,12 @@ Code-Graph-RAG uses Tree-sitter for language-agnostic AST parsing with a unified
 
 | Language | Status | Extensions | Functions | Classes/Structs | Modules | Package Detection | Additional Features |
 |----------|--------|------------|-----------|-----------------|---------|-------------------|---------------------|
-| C++ | Fully Supported | .cpp, .h, .hpp, .cc, .cxx, .hxx, .hh, .ixx, .cppm, .ccm | Yes | Yes | Yes | Yes | Constructors, destructors, operator overloading, templates, lambdas, C++20 modules, namespaces |
+| C++ | Fully Supported | .cpp, .h, .hpp, .cc, .cxx, .hxx, .hh, .ixx, .cppm, .ccm | Yes | Yes | Yes | Yes | Constructors, destructors, operator overloading, templates, lambdas, C++20 modules, namespaces, preprocessor macros |
 | Java | Fully Supported | .java | Yes | Yes | Yes | No | Generics, annotations, modern features (records/sealed classes), concurrency, reflection |
 | JavaScript | Fully Supported | .js, .jsx | Yes | Yes | Yes | No | ES6 modules, CommonJS, prototype methods, object methods, arrow functions |
 | Lua | Fully Supported | .lua | Yes | No | Yes | No | Local/global functions, metatables, closures, coroutines |
 | Python | Fully Supported | .py | Yes | Yes | Yes | Yes | Type inference, decorators, nested functions |
-| Rust | Fully Supported | .rs | Yes | Yes | Yes | Yes | impl blocks, associated functions |
+| Rust | Fully Supported | .rs | Yes | Yes | Yes | Yes | impl blocks, associated functions, macro_rules! macros |
 | TypeScript | Fully Supported | .ts, .tsx | Yes | Yes | Yes | No | Interfaces, type aliases, enums, namespaces, ES6/CommonJS modules |
 | C# | In Development | .cs | Yes | Yes | Yes | No | Classes, interfaces, generics (planned) |
 | Go | In Development | .go | Yes | Yes | Yes | No | Methods, type declarations |

--- a/evals/cgr_graph.py
+++ b/evals/cgr_graph.py
@@ -168,6 +168,7 @@ class _StatefulIngestor:
                         cs.KEY_QUALIFIED_NAME: _text(qn),
                         cs.KEY_LABEL: label,
                         cs.KEY_IS_PROPERTY: bool(props.get(cs.KEY_IS_PROPERTY)),
+                        cs.KEY_IS_MACRO: bool(props.get(cs.KEY_IS_MACRO)),
                         cs.KEY_PATH: _text(props.get(cs.KEY_PATH)),
                     }
                     defs.append(row)

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.266"
+version = "0.0.268"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Macros are modeled cross-language as **Function nodes** (the schema decision: no language-specific label). Previously macro definitions were invisible in every language: Rust `macro_invocation` sites were captured but had no definition node to bind to, and the C++ libclang frontend never saw preprocessor entities at all. Now C/C++ `#define` and Rust `macro_rules!` register as Functions, invocations resolve to them, and dead-code treats macros like any function.

## Rust

1. **Definitions** (`test_rs_macro_definition_nodes.py`): `macro_definition` joins `SPEC_RS_FUNCTION_TYPES` and the function query, so `macro_rules! square` registers `crate.module.square` as a Function.
2. **Invocations**: `square!(3)` was captured as a call but dropped nameless -- `macro_invocation` carries its callee in the `macro` field, which `_get_call_target_name` never read. A dedicated case extracts it, so the invocation resolves through the normal chain.
3. **Namespace separation** (`test_macro_and_fn_namespaces_do_not_cross_bind`): Rust macros and functions live in separate namespaces. Without a gate, std-prelude `write!(f, ..)` would bind a same-module `fn write` (a false edge that revives dead code), and `trace(x)` would bind a same-module `macro_rules! trace`. Definition ingest records macro qns (`DefinitionProcessor.macro_qns`); Pass 3 requires macro-invocation call sites to bind macro targets and fn-namespace call sites to avoid them.
4. **`#[macro_export]`** (`test_macro_export_attribute_marks_exported`): `macro_rules!` takes no `pub`; the attribute is what publishes a macro (to the crate root) as library API, so it now sets `is_exported` -- an exported but internally-uninvoked macro must not report dead.

## C/C++ (libclang frontend)

5. **Definitions** (`test_cpp_frontend_macros.py`): TUs parse with `PARSE_DETAILED_PROCESSING_RECORD`; repo `MACRO_DEFINITION` cursors become Function nodes with Module DEFINES edges. Compiler builtins (no file), system-header macros (outside the repo), and empty-bodied object-like macros (include guards, feature flags -- extent covers only the name) are skipped.
6. **Invocations**: `MACRO_INSTANTIATION.referenced` gives the exact definition (libclang resolved it). Macro cursors are TU-level preprocessing entities, never AST-nested, so the caller is recovered at flush by tightest enclosing function/method span in the use-site file; a use outside any span attributes to the Module, mirroring the existing module-caller rule.

## Verification (RED -> GREEN)

- 5 new tests across 2 files, each confirmed failing before its fix.
- Full suite: 4689 passed, 0 failed.
- Dead-code evals: mini-redis 0 -> 0; anyhow (defines `anyhow!`/`bail!`/`ensure!`/cfg-duplicated `backtrace!` and invokes them internally) reports a byte-identical dead set vs main -- all newly-registered macros are live via roots or resolved invocations, zero regressions.
- ruff clean; ty diagnostic count identical to main.
