### PR TITLE
test(cpp): address codecov and sonar reports from #672 (macro guard coverage, complexity)

### DIFF
--- a/codebase_rag/parsers/cpp_frontend/frontend.py
+++ b/codebase_rag/parsers/cpp_frontend/frontend.py
@@ -301,13 +301,19 @@ class _Collector:
         return self.resolver.function_qn(cursor)
 
     def _process_macro_definition(self, cursor: Cursor) -> None:
-        qn = self._macro_function_qn(cursor)
-        if qn is None:
+        # (H) Guard order matters for reachability: builtins/command-line
+        # (H) macros (no file) first, system-header macros (outside the repo)
+        # (H) second, THEN the shared eligibility check (whose remaining filter
+        # (H) here is the empty-body one -- include guards, feature flags).
+        if cursor.location.file is None:
             return
         file_name = cursor.location.file.name
         rel = self.resolver.rel_path(file_name)
         module_qn = self.resolver.module_qn(file_name)
         if rel is None or module_qn is None:
+            return
+        qn = self._macro_function_qn(cursor)
+        if qn is None:
             return
         self.covered.add(rel)
         self._add_module(module_qn, rel, file_name)

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -693,20 +693,11 @@ class FunctionIngestMixin:
             start_col=func_node.start_point[1],
         )
         self.function_locations[(module_qn, func_node.start_point[0] + 1)] = location
-        if language == cs.SupportedLanguage.CPP:
-            # (H) A template wrapper's body walk in Pass 3 visits the INNER
-            # (H) definition (it starts on its own line), so record that line
-            # (H) against the wrapper's node too.
-            if func_node.type == cs.CppNodeType.TEMPLATE_DECLARATION:
-                for child in func_node.children:
-                    if child.type == cs.CppNodeType.FUNCTION_DEFINITION:
-                        # (H) The Pass-3 walk matches on the CHILD node, so the
-                        # (H) entry must carry the child's column, not the
-                        # (H) wrapper's, or the column check rejects it.
-                        self.function_locations[
-                            (module_qn, child.start_point[0] + 1)
-                        ] = location._replace(start_col=child.start_point[1])
-                        break
+        if (
+            language == cs.SupportedLanguage.CPP
+            and func_node.type == cs.CppNodeType.TEMPLATE_DECLARATION
+        ):
+            self._record_cpp_template_child_location(func_node, module_qn, location)
 
         # (H) A method-body anonymous-class override (`new Base(){ @Override m(){} }`
         # (H) inside a method) is captured as a function here; record it so the deferred
@@ -729,6 +720,21 @@ class FunctionIngestMixin:
         self._create_function_relationships(
             func_node, resolution, module_qn, language, lang_config
         )
+
+    def _record_cpp_template_child_location(
+        self, func_node: Node, module_qn: str, location: FunctionLocation
+    ) -> None:
+        # (H) A template wrapper's body walk in Pass 3 visits the INNER
+        # (H) definition (it starts on its own line), so record that line
+        # (H) against the wrapper's node too. The Pass-3 walk matches on the
+        # (H) CHILD node, so the entry must carry the child's column, not the
+        # (H) wrapper's, or the column check rejects it.
+        for child in func_node.children:
+            if child.type == cs.CppNodeType.FUNCTION_DEFINITION:
+                self.function_locations[(module_qn, child.start_point[0] + 1)] = (
+                    location._replace(start_col=child.start_point[1])
+                )
+                break
 
     def _build_function_props(
         self, func_node: Node, resolution: FunctionResolution, module_qn: str

--- a/codebase_rag/tests/test_cpp_frontend_macros.py
+++ b/codebase_rag/tests/test_cpp_frontend_macros.py
@@ -24,6 +24,7 @@ pytestmark = pytest.mark.skipif(
 _CALC_H = """\
 #ifndef CALC_H
 #define CALC_H
+#include <limits.h>
 #define SQUARE(x) ((x)*(x))
 #define MAX_SIZE 100
 int compute(int v);
@@ -32,7 +33,7 @@ int compute(int v);
 
 _SRC = """\
 #include "calc.h"
-int compute(int v) { return SQUARE(v) + MAX_SIZE; }
+int compute(int v) { return SQUARE(v) + MAX_SIZE + CMDLINE_LIMIT + INT_MAX; }
 int main() { return compute(2); }
 """
 
@@ -49,6 +50,7 @@ def _write(root: Path) -> None:
                     "arguments": [
                         "c++",
                         "-std=c++17",
+                        "-DCMDLINE_LIMIT=7",
                         f"-I{root}",
                         str(root / "calc.cpp"),
                     ],
@@ -87,8 +89,12 @@ def test_macro_definitions_register_as_functions(temp_repo: Path) -> None:
     assert "macproj.calc.h.MAX_SIZE" in functions, sorted(functions)
     # (H) the include guard is an empty flag, not a callable
     assert not any(qn.endswith(".CALC_H") for qn in functions), sorted(functions)
-    # (H) builtins/system macros live outside the repo
+    # (H) builtins/system macros live outside the repo; a command-line -D
+    # (H) macro has no file at all -- none of them are nodes, and their use
+    # (H) sites carry no edges
     assert not any("__GNUC__" in qn for qn in functions), sorted(functions)
+    assert not any("CMDLINE_LIMIT" in qn for qn in functions), sorted(functions)
+    assert not any("INT_MAX" in qn for qn in functions), sorted(functions)
 
 
 def test_macro_instantiations_emit_calls_from_enclosing_function(
@@ -101,3 +107,90 @@ def test_macro_instantiations_emit_calls_from_enclosing_function(
     calls = _calls(ingestor)
     assert ("macproj2.calc.compute", "macproj2.calc.h.SQUARE") in calls, sorted(calls)
     assert ("macproj2.calc.compute", "macproj2.calc.h.MAX_SIZE") in calls, sorted(calls)
+
+
+def test_file_scope_macro_use_attributes_to_module(temp_repo: Path) -> None:
+    # (H) A macro expanded outside any function span (a file-scope global
+    # (H) initializer) attributes its CALLS to the Module, mirroring the
+    # (H) module-caller rule for ordinary calls.
+    root = temp_repo / "macmod"
+    root.mkdir()
+    (root / "calc.h").write_text(_CALC_H, encoding="utf-8")
+    (root / "calc.cpp").write_text(
+        '#include "calc.h"\nint global_limit = MAX_SIZE;\n', encoding="utf-8"
+    )
+    (root / "compile_commands.json").write_text(
+        json.dumps(
+            [
+                {
+                    "directory": str(root),
+                    "arguments": [
+                        "c++",
+                        "-std=c++17",
+                        f"-I{root}",
+                        str(root / "calc.cpp"),
+                    ],
+                    "file": str(root / "calc.cpp"),
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    ingestor = MagicMock()
+    run_cpp_frontend(ingestor, root, root.name, root)
+    calls = _calls(ingestor)
+    assert ("macmod.calc", "macmod.calc.h.MAX_SIZE") in calls, sorted(calls)
+
+
+def test_macro_use_outside_repo_emits_no_edge(temp_repo: Path) -> None:
+    # (H) A TU outside the indexed repo (rel unresolvable) and a TU in an
+    # (H) ignored dir (rel resolves but has no module qn, e.g. build/) both use
+    # (H) a repo macro: the definition node still registers via the header, but
+    # (H) neither use site can carry a CALLS edge.
+    root = temp_repo / "macext"
+    root.mkdir()
+    (root / "calc.h").write_text(_CALC_H, encoding="utf-8")
+    outside = temp_repo / "outside_main.cpp"
+    outside.write_text(
+        '#include "calc.h"\nint compute(int v) { return SQUARE(v); }\n',
+        encoding="utf-8",
+    )
+    build_dir = root / "build"
+    build_dir.mkdir()
+    (build_dir / "gen.cpp").write_text(
+        # (H) a macro DEFINED in the ignored dir: rel resolves but there is no
+        # (H) module qn, so it must not become a node either
+        '#include "calc.h"\n#define GEN_LIMIT 42\n'
+        "int generated_limit = MAX_SIZE + GEN_LIMIT;\n",
+        encoding="utf-8",
+    )
+    (root / "compile_commands.json").write_text(
+        json.dumps(
+            [
+                {
+                    "directory": str(root),
+                    "arguments": ["c++", "-std=c++17", f"-I{root}", str(outside)],
+                    "file": str(outside),
+                },
+                {
+                    "directory": str(root),
+                    "arguments": [
+                        "c++",
+                        "-std=c++17",
+                        f"-I{root}",
+                        str(build_dir / "gen.cpp"),
+                    ],
+                    "file": str(build_dir / "gen.cpp"),
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+    ingestor = MagicMock()
+    run_cpp_frontend(ingestor, root, root.name, root)
+    # (H) no calc.cpp in this fixture, so calc.h claims the plain module qn
+    assert "macext.calc.SQUARE" in _functions(ingestor)
+    assert not any("GEN_LIMIT" in qn for qn in _functions(ingestor))
+    assert not any("SQUARE" in t or "MAX_SIZE" in t for _, t in _calls(ingestor)), (
+        sorted(_calls(ingestor))
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.268"
+version = "0.0.270"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Addresses the two bot reports left unhandled on #672: the Codecov patch-coverage report (9 uncovered lines in `cpp_frontend/frontend.py`, 86.36% patch coverage) and the SonarQube new issue (S3776 cognitive complexity).

## Codecov: 9 flagged lines -> 7 covered, 2 defended

New/extended tests in `test_cpp_frontend_macros.py`:

- **Module-caller fallback**: a file-scope macro use (`int global_limit = MAX_SIZE;`) attributes CALLS to the Module, mirroring the module-caller rule.
- **Out-of-repo and ignored-dir use sites**: a TU outside the indexed repo and a TU under `build/` both use repo macros; the definition node still registers via the header, but neither use site may carry a CALLS edge. A macro DEFINED under `build/` (rel resolves, no module qn) must not become a node.
- **Command-line and system macros**: `-DCMDLINE_LIMIT=7` and `<limits.h>` macros are used in source; neither is a node and their uses carry no edges.
- **Guard reordering**: `_process_macro_definition` previously checked rel/module AFTER `_macro_function_qn` had already required them, making that guard unreachable; guards now run in reachability order (no file -> outside repo -> empty body), each exercised by the fixtures.

The 2 remaining lines (`_queue_macro_call`'s `location.file is None` and `referenced is None` returns) are defensive guards against libclang returning None cursors; no source-level fixture can construct them, and removing them would trade a silent skip for a crash on unusual TUs.

## SonarQube: S3776 on `_register_function`

The `is_macro` branch added in #672 pushed cognitive complexity to 16 (limit 15). The nested C++ template-location block is extracted into `_record_cpp_template_child_location`, dropping the function back under the threshold with behavior unchanged.

## Verification

- Full suite: 4692 passed, 0 failed
- `frontend.py` macro paths: every codecov-flagged line except the two defended guards now covered
- ruff clean; ty diagnostic count identical to main
