### PR TITLE
feat(go): promote Go to fully supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ An accurate Retrieval-Augmented Generation (RAG) system that analyzes multi-lang
 |--------|------|----------|---------|---------------|-------|-----------------|-------------------|
 | C | Fully Supported | .c | ✓ | ✓ | ✓ | ✓ | Functions, structs, unions, enums, preprocessor includes |
 | C++ | Fully Supported | .cpp, .h, .hpp, .cc, .cxx, .hxx, .hh, .ixx, .cppm, .ccm | ✓ | ✓ | ✓ | ✓ | Constructors, destructors, operator overloading, templates, lambdas, C++20 modules, namespaces, preprocessor macros |
+| Go | Fully Supported | .go | ✓ | ✓ | ✓ | - | Receiver methods with cross-file binding, structs, interfaces, type declarations, function-local types |
 | Java | Fully Supported | .java | ✓ | ✓ | ✓ | - | Generics, annotations, modern features (records/sealed classes), concurrency, reflection |
 | JavaScript | Fully Supported | .js, .jsx | ✓ | ✓ | ✓ | - | ES6 modules, CommonJS, prototype methods, object methods, arrow functions |
 | Lua | Fully Supported | .lua | ✓ | - | ✓ | - | Local/global functions, metatables, closures, coroutines |
@@ -84,7 +85,6 @@ An accurate Retrieval-Augmented Generation (RAG) system that analyzes multi-lang
 | Rust | Fully Supported | .rs | ✓ | ✓ | ✓ | ✓ | impl blocks, associated functions, macro_rules! macros |
 | TypeScript (TSX) | Fully Supported | .tsx | ✓ | ✓ | ✓ | - | All TypeScript features plus JSX elements and components |
 | TypeScript | Fully Supported | .ts | ✓ | ✓ | ✓ | - | Interfaces, type aliases, enums, namespaces, ES6/CommonJS modules |
-| Go | In Development | .go | ✓ | ✓ | ✓ | - | Methods, type declarations |
 | Scala | In Development | .scala, .sc | ✓ | ✓ | ✓ | - | Case classes, objects |
 <!-- /SECTION:supported_languages -->
 - **🌳 Tree-sitter Parsing**: Uses Tree-sitter for robust, language-agnostic AST parsing
@@ -716,7 +716,7 @@ The knowledge graph uses the following node types and relationships:
 | File | `{path: string, name: string, extension: string?, absolute_path: string}` |
 | Module | `{qualified_name: string, name: string, path: string, absolute_path: string, start_line: int?, end_line: int?}` |
 | Class | `{qualified_name: string, name: string, decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
-| Function | `{qualified_name: string, name: string, decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
+| Function | `{qualified_name: string, name: string, decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?, is_macro: boolean?}` |
 | Method | `{qualified_name: string, name: string, decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?, is_property: boolean?, overrides_external: boolean?}` |
 | Interface | `{qualified_name: string, name: string, path: string, absolute_path: string, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
 | Enum | `{qualified_name: string, name: string, path: string, absolute_path: string, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
@@ -733,6 +733,7 @@ The knowledge graph uses the following node types and relationships:
 <!-- SECTION:language_mappings -->
 - **C**: `enum_specifier`, `function_definition`, `struct_specifier`, `union_specifier`
 - **C++**: `class_specifier`, `declaration`, `enum_specifier`, `field_declaration`, `function_definition`, `lambda_expression`, `struct_specifier`, `template_declaration`, `union_specifier`
+- **Go**: `function_declaration`, `method_declaration`, `type_alias`, `type_spec`
 - **Java**: `annotation_type_declaration`, `class_declaration`, `constructor_declaration`, `enum_declaration`, `interface_declaration`, `method_declaration`, `record_declaration`
 - **JavaScript**: `arrow_function`, `class`, `class_declaration`, `function_declaration`, `function_expression`, `generator_function_declaration`, `method_definition`
 - **Lua**: `function_declaration`, `function_definition`
@@ -741,7 +742,6 @@ The knowledge graph uses the following node types and relationships:
 - **Rust**: `closure_expression`, `enum_item`, `function_item`, `function_signature_item`, `impl_item`, `macro_definition`, `struct_item`, `trait_item`, `type_item`, `union_item`
 - **TypeScript (TSX)**: `abstract_class_declaration`, `arrow_function`, `class`, `class_declaration`, `enum_declaration`, `function_declaration`, `function_expression`, `function_signature`, `generator_function_declaration`, `interface_declaration`, `internal_module`, `method_definition`, `type_alias_declaration`
 - **TypeScript**: `abstract_class_declaration`, `arrow_function`, `class`, `class_declaration`, `enum_declaration`, `function_declaration`, `function_expression`, `function_signature`, `generator_function_declaration`, `interface_declaration`, `internal_module`, `method_definition`, `type_alias_declaration`
-- **Go**: `function_declaration`, `method_declaration`, `type_alias`, `type_spec`
 - **Scala**: `class_definition`, `function_declaration`, `function_definition`, `object_definition`, `trait_definition`
 <!-- /SECTION:language_mappings -->
 

--- a/codebase_rag/constants.py
+++ b/codebase_rag/constants.py
@@ -844,8 +844,8 @@ LANGUAGE_METADATA: dict[SupportedLanguage, LanguageMetadata] = {
         "Java",
     ),
     SupportedLanguage.GO: LanguageMetadata(
-        LanguageStatus.DEV,
-        "Methods, type declarations",
+        LanguageStatus.FULL,
+        "Receiver methods with cross-file binding, structs, interfaces, type declarations, function-local types",
         "Go",
     ),
     SupportedLanguage.SCALA: LanguageMetadata(

--- a/codebase_rag/tests/integration/test_node_label_e2e.py
+++ b/codebase_rag/tests/integration/test_node_label_e2e.py
@@ -14,7 +14,6 @@ if TYPE_CHECKING:
 
 pytestmark = [pytest.mark.integration]
 
-SKIP_GO = "Go is in development status"
 SKIP_SCALA = "Scala is in development status"
 
 
@@ -609,7 +608,6 @@ class TestRustNodeLabels:
         assert "MyTrait" in interface_names
 
 
-@pytest.mark.skip(reason=SKIP_GO)
 class TestGoNodeLabels:
     def test_go_creates_class_nodes_for_structs(
         self, memgraph_ingestor: MemgraphIngestor, go_project: Path
@@ -861,7 +859,7 @@ DEFINES_TEST_PARAMS = [
     ("typescript_project", None),
     ("javascript_project", None),
     ("rust_project", None),
-    ("go_project", SKIP_GO),
+    ("go_project", None),
     ("scala_project", SKIP_SCALA),
     ("java_project", None),
     ("cpp_project", None),

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.268"
+version = "0.0.270"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Why

The "In Development" status for Go is stale. Evidence it meets the bar every other fully-supported language meets:

- **Oracle-verified at scale**: 1.0 precision/recall on all 1,533 declarations of thrift lib/go, graded against Go's own go/ast parser: every node category (Function 521, Method 855, Class 101, Interface 30, Type 26), every containment edge (DEFINES, DEFINES_METHOD), and every span.
- **The skipped integration tests just pass**: all 4 previously-skipped Go tests (structs -> Class, interfaces -> Interface, functions including constructors, DEFINES edges) are green against live memgraph. The skips predate the receiver-qualified method parents, cross-file receiver binding, and function-local type containment work.

## Changes

- `LANGUAGE_METADATA[GO]`: `LanguageStatus.DEV` -> `FULL`, feature list updated to what Go ingestion actually does now.
- Removed the `SKIP_GO` markers in `test_node_label_e2e.py`, so the 4 Go node-label/DEFINES integration tests run everywhere.
- README support table regenerated (Go moves into the Fully Supported block).

Closes #106.