### PR TITLE
fix(js): unify duplicate function nodes via span claims and deferred anonymous registration

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -16,6 +16,7 @@ from ..services import IngestorProtocol
 from ..types_defs import (
     FunctionLocation,
     FunctionRegistryTrieProtocol,
+    FunctionSpanKey,
     LanguageQueries,
     NodeType,
 )
@@ -31,6 +32,7 @@ from .rs import utils as rs_utils
 from .type_inference import TypeInferenceEngine
 from .utils import (
     cpp_parameter_names,
+    function_span_key,
     get_function_captures,
     go_parameter_names,
     is_method_node,
@@ -202,7 +204,7 @@ class CallProcessor:
         interface_implementers: dict[str, set[str]] | None = None,
         module_qn_to_file_path: dict[str, Path] | None = None,
         cpp_out_of_class_methods: dict[tuple[str, int], tuple[str, str]] | None = None,
-        function_locations: dict[tuple[str, int], FunctionLocation] | None = None,
+        function_locations: dict[FunctionSpanKey, FunctionLocation] | None = None,
         macro_qns: set[str] | None = None,
     ) -> None:
         self.ingestor = ingestor
@@ -995,14 +997,8 @@ class CallProcessor:
     ) -> FunctionLocation | None:
         # (H) The registry membership check guards incremental runs, where an
         # (H) unchanged file's locations were not re-recorded this run.
-        loc = self.function_locations.get((module_qn, func_node.start_point[0] + 1))
+        loc = self.function_locations.get(function_span_key(module_qn, func_node))
         if loc is None or loc.qualified_name not in self._resolver.function_registry:
-            return None
-        # (H) Two functions can start on one line (a one-line curried arrow); the
-        # (H) line-keyed entry then belongs to only one of them. A column mismatch
-        # (H) means THIS node is the other one -- fall back to name-based
-        # (H) attribution rather than adopt the wrong function's qn.
-        if loc.start_col is not None and loc.start_col != func_node.start_point[1]:
             return None
         return loc
 

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -833,7 +833,20 @@ class CallProcessor:
                     accepted_var_types=(cs.TS_DOT_INDEX_EXPRESSION, cs.TS_IDENTIFIER),
                 )
             if not func_name:
-                continue
+                # (H) A nameless JS/TS function expression that a NAMED pass
+                # (H) registered (`exports.f = function`, `x: function`) has a
+                # (H) real node; its body's calls belong to that node, not the
+                # (H) module, so adopt the record's simple name and fall
+                # (H) through (the recorded-caller branch below reuses the
+                # (H) registered qn). A GENERATED record (anonymous callback,
+                # (H) IIFE) keeps the historical bubble-to-module attribution.
+                if (
+                    language not in _JS_TS_LANGUAGES
+                    or (recorded := self._recorded_caller(func_node, module_qn)) is None
+                    or not recorded.is_named
+                ):
+                    continue
+                func_name = recorded.qualified_name.rsplit(cs.SEPARATOR_DOT, 1)[-1]
             # (H) The definition pass records where every function/method node
             # (H) landed; reuse that qn/label instead of re-deriving them from
             # (H) the AST -- the walks diverge on preprocessor-distorted C++

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -17,6 +17,7 @@ from ...types_defs import (
     DeferredCppInherit,
     DeferredInherit,
     FunctionLocation,
+    FunctionSpanKey,
     NodeType,
     PropertyDict,
 )
@@ -28,7 +29,12 @@ from ..java import utils as java_utils
 from ..py import external_stdlib_base_method_names, resolve_class_name
 from ..rs import RustTypeInferenceEngine
 from ..rs import utils as rs_utils
-from ..utils import ingest_method, safe_decode_text, sorted_captures
+from ..utils import (
+    function_span_key,
+    ingest_method,
+    safe_decode_text,
+    sorted_captures,
+)
 from . import cpp_modules
 from . import identity as id_
 from . import method_override as mo
@@ -139,7 +145,7 @@ class ClassIngestMixin:
     class_field_guard_inner: dict[str, dict[str, str]]
     method_return_types: dict[str, str]
     interface_implementers: dict[str, set[str]]
-    function_locations: dict[tuple[str, int], FunctionLocation]
+    function_locations: dict[FunctionSpanKey, FunctionLocation]
     _deferred_forward_decls: list[_DeferredForwardDecl]
     _deferred_parent_links: list[DeferredParentLink]
     _deferred_cpp_inherits: list[DeferredCppInherit]
@@ -932,12 +938,11 @@ class ClassIngestMixin:
             # (H) and on TS declaration merging, where the member registers
             # (H) under the namespace's duplicate-suffixed qn (issue #652).
             if ingested_qn is not None and module_qn is not None:
-                self.function_locations[(module_qn, method_node.start_point[0] + 1)] = (
+                self.function_locations[function_span_key(module_qn, method_node)] = (
                     FunctionLocation(
                         label=cs.NodeLabel.METHOD.value,
                         qualified_name=ingested_qn,
                         container_qn=class_qn,
-                        start_col=method_node.start_point[1],
                     )
                 )
             if language == cs.SupportedLanguage.CPP:

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -15,6 +15,7 @@ from ..types_defs import (
     DeferredInherit,
     FunctionLocation,
     FunctionRegistryTrieProtocol,
+    FunctionSpanKey,
     SimpleNameLookup,
 )
 from ..utils.path_utils import cached_relative_path, cached_resolve_posix
@@ -108,7 +109,7 @@ class DefinitionProcessor(
         # (H) method node Pass 2 registered, so Pass-3 caller attribution reuses
         # (H) the registered label/qn instead of re-deriving them structurally
         # (H) (the walks diverge on preprocessor-distorted class bodies).
-        self.function_locations: dict[tuple[str, int], FunctionLocation] = {}
+        self.function_locations: dict[FunctionSpanKey, FunctionLocation] = {}
         self._deferred_cpp_inherits: list[DeferredCppInherit] = []
         # (H) Non-C++ INHERITS/IMPLEMENTS held back until every class is
         # (H) registered; resolve_deferred_inherits re-resolves the guesses.

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -97,6 +97,9 @@ class DefinitionProcessor(
         self._deferred_cpp_containment: list = []
         self._deferred_parent_links: list = []
         self._deferred_forward_decls: list = []
+        # (H) Unnamed JS/TS function expressions held back until the named
+        # (H) JS passes have claimed their spans (one node per source function).
+        self._deferred_js_anonymous: list = []
         # (H) (module_qn, def start_line) -> (method_qn, class_qn) for every
         # (H) out-of-class C++ method the definition pass bound; Pass-3 call
         # (H) attribution reuses these decisions instead of re-resolving.
@@ -279,6 +282,10 @@ class DefinitionProcessor(
                 self._ingest_prototype_inheritance(
                     root_node, module_qn, language, queries
                 )
+                # (H) Named passes above have claimed their function nodes;
+                # (H) only genuinely anonymous spans (callbacks, IIFEs) still
+                # (H) need their held-back registration.
+                self._flush_deferred_js_anonymous()
 
             return (root_node, language)
 

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -1185,6 +1185,26 @@ class FunctionIngestMixin:
             )
         )
 
+    def _claimed_qn_for_anonymous_guess(
+        self, module_qn: str, parent_qn: str
+    ) -> tuple[str, str] | None:
+        # (H) An `anonymous_row_col` guess names the SPAN it stood for; if a
+        # (H) named pass claimed that span, the claim is the real parent.
+        tail = parent_qn.rsplit(cs.SEPARATOR_DOT, 1)[-1]
+        if not tail.startswith(cs.PREFIX_ANONYMOUS):
+            return None
+        row_col = tail[len(cs.PREFIX_ANONYMOUS) :].split(cs.CHAR_UNDERSCORE)
+        if len(row_col) != 2 or not all(part.isdigit() for part in row_col):
+            return None
+        loc = self.function_locations.get((module_qn, int(row_col[0]) + 1))
+        if (
+            loc is None
+            or loc.start_col != int(row_col[1])
+            or loc.qualified_name not in self.function_registry
+        ):
+            return None
+        return loc.label, loc.qualified_name
+
     def resolve_deferred_parent_links(self) -> int:
         """Emit deferred non-module DEFINES once every pass has registered.
 
@@ -1217,6 +1237,21 @@ class FunctionIngestMixin:
                     cs.NodeLabel(entry.fallback_label),
                     cs.KEY_QUALIFIED_NAME,
                     entry.fallback_qn,
+                )
+                rel_type = cs.RelationshipType.DEFINES.value
+            elif claimed := self._claimed_qn_for_anonymous_guess(
+                entry.module_qn, entry.parent_qn
+            ):
+                # (H) The parent guess was an anonymous placeholder for a span
+                # (H) a NAMED pass claimed after the child registered
+                # (H) (`exports.receiver = function () { function helper() }`):
+                # (H) the placeholder embeds its (row, col), so the claim
+                # (H) record recovers the registered enclosing node.
+                claimed_label, claimed_qn = claimed
+                parent_spec = (
+                    cs.NodeLabel(claimed_label),
+                    cs.KEY_QUALIFIED_NAME,
+                    claimed_qn,
                 )
                 rel_type = cs.RelationshipType.DEFINES.value
             else:
@@ -1328,6 +1363,23 @@ class FunctionIngestMixin:
                         cs.NodeLabel.METHOD,
                         f"{container_qn}{cs.SEPARATOR_DOT}{method_name}",
                     )
+                # (H) Reuse the enclosing function's REGISTERED identity when
+                # (H) its span is claimed: structural re-derivation produces
+                # (H) the pre-claim qn (an anonymous name whose node no longer
+                # (H) exists for `exports.f = function`, or the FIRST `t` for
+                # (H) the second same-name fn expr registered as `t@line`),
+                # (H) hoisting the child to the module or the wrong function.
+                if language in cs.JS_TS_LANGUAGES:
+                    recorded = self.function_locations.get(
+                        (module_qn, current.start_point[0] + 1)
+                    )
+                    if (
+                        recorded is not None
+                        and recorded.start_col == current.start_point[1]
+                        and recorded.qualified_name != func_qn
+                        and recorded.qualified_name in self.function_registry
+                    ):
+                        return cs.NodeLabel(recorded.label), recorded.qualified_name
                 resolution = (
                     self._resolve_function_identity(
                         current, module_qn, language, lang_config, file_path

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -70,6 +70,27 @@ class FunctionResolution(NamedTuple):
     qualified_name: str
     name: str
     is_exported: bool
+    # (H) True when the name was GENERATED (anonymous_row_col): a JS/TS named
+    # (H) pass (object literal, export, assignment, prototype) may own this
+    # (H) same source function, so its registration defers until those ran.
+    is_anonymous: bool = False
+
+
+class _DeferredJsAnonymous(NamedTuple):
+    """Unnamed JS/TS function expression held back until named passes claim.
+
+    The generic function pass runs before the JS-specific passes, so
+    registering `anonymous_row_col` eagerly minted a second node for every
+    function a named pass registers later (521 locations on thrift's JS
+    corpora). Registration happens at the per-file flush, only for spans no
+    named pass claimed.
+    """
+
+    func_node: Node
+    resolution: FunctionResolution
+    module_qn: str
+    language: cs.SupportedLanguage
+    lang_config: LanguageSpec
 
 
 class _DeferredMethod(NamedTuple):
@@ -141,6 +162,7 @@ class FunctionIngestMixin:
     cpp_out_of_class_methods: dict[tuple[str, int], tuple[str, str]]
     function_locations: dict[tuple[str, int], FunctionLocation]
     macro_qns: set[str]
+    _deferred_js_anonymous: list[_DeferredJsAnonymous]
     class_inheritance: dict[str, list[str]]
     _deferred_cpp_inherits: list[DeferredCppInherit]
     rehydrated_definition_paths: dict[str, str]
@@ -201,6 +223,19 @@ class FunctionIngestMixin:
             if not resolution:
                 continue
 
+            # (H) A nameless JS/TS function expression may be one a NAMED pass
+            # (H) (object literal, export, assignment, prototype) registers
+            # (H) under its real name; those passes run after this one, so hold
+            # (H) the anonymous registration back and flush only unclaimed
+            # (H) spans (each eager registration was a duplicate node).
+            if language in cs.JS_TS_LANGUAGES and resolution.is_anonymous:
+                self._deferred_js_anonymous.append(
+                    _DeferredJsAnonymous(
+                        func_node, resolution, module_qn, language, lang_config
+                    )
+                )
+                continue
+
             self._register_function(
                 func_node, resolution, module_qn, language, lang_config
             )
@@ -213,6 +248,56 @@ class FunctionIngestMixin:
                 return_type := cpp_utils.extract_return_type_name(func_node)
             ):
                 self.method_return_types[resolution.qualified_name] = return_type
+
+    def _function_span_claimed(self, module_qn: str, func_node: Node) -> bool:
+        # (H) A span is claimed when a pass recorded THIS function node's
+        # (H) location (same line and column, mirroring Pass-3's ownership
+        # (H) check); a same-line different-column entry is another function.
+        loc = self.function_locations.get((module_qn, func_node.start_point[0] + 1))
+        return loc is not None and loc.start_col == func_node.start_point[1]
+
+    def _span_claimed_for_qn(
+        self, module_qn: str, func_node: Node, candidate_qn: str
+    ) -> bool:
+        # (H) A named pass re-deriving the SAME qn another pass already
+        # (H) registered for this span is a pure duplicate (it would collide
+        # (H) into a spurious `qn@line` twin). A DIFFERENT qn is the deliberate
+        # (H) twin model: `X.prototype.m = function m()` keeps both the
+        # (H) fn-expr's own-name node and the member-name node (duplicate-QN
+        # (H) design: keep both, CALLS-to-both), so it must still register.
+        loc = self.function_locations.get((module_qn, func_node.start_point[0] + 1))
+        if loc is None or loc.start_col != func_node.start_point[1]:
+            return False
+        claimed_base = loc.qualified_name.split(cs.DUP_QN_MARKER, 1)[0]
+        return claimed_base == candidate_qn
+
+    def _claim_function_span(
+        self, module_qn: str, func_node: Node, label: str, qualified_name: str
+    ) -> None:
+        # (H) First claim wins; a later pass deriving a different qn for the
+        # (H) same source function must skip registration, not mint a twin.
+        key = (module_qn, func_node.start_point[0] + 1)
+        if key not in self.function_locations:
+            self.function_locations[key] = FunctionLocation(
+                label=label,
+                qualified_name=qualified_name,
+                container_qn=None,
+                start_col=func_node.start_point[1],
+            )
+
+    def _flush_deferred_js_anonymous(self) -> None:
+        deferred = self._deferred_js_anonymous
+        self._deferred_js_anonymous = []
+        for entry in deferred:
+            if self._function_span_claimed(entry.module_qn, entry.func_node):
+                continue
+            self._register_function(
+                entry.func_node,
+                entry.resolution,
+                entry.module_qn,
+                entry.language,
+                entry.lang_config,
+            )
 
     def _resolve_function_identity(
         self,
@@ -619,6 +704,7 @@ class FunctionIngestMixin:
         ):
             func_name = self._extract_lua_assignment_function_name(func_node)
 
+        is_anonymous = not func_name
         if not func_name:
             func_name = self._generate_anonymous_function_name(func_node, module_qn)
 
@@ -626,7 +712,7 @@ class FunctionIngestMixin:
             func_node, module_qn, func_name, language, lang_config
         )
         is_exported = export_detection.is_exported(func_node, func_name, language)
-        return FunctionResolution(func_qn, func_name, is_exported)
+        return FunctionResolution(func_qn, func_name, is_exported, is_anonymous)
 
     def _build_function_qn(
         self,
@@ -691,8 +777,18 @@ class FunctionIngestMixin:
             qualified_name=resolution.qualified_name,
             container_qn=None,
             start_col=func_node.start_point[1],
+            is_named=not resolution.is_anonymous,
         )
-        self.function_locations[(module_qn, func_node.start_point[0] + 1)] = location
+        # (H) Never steal another function's line slot: a deferred anonymous
+        # (H) flushing next to a same-line named function (one-line curried
+        # (H) arrow) must not repoint the named function's Pass-3 record.
+        location_key = (module_qn, func_node.start_point[0] + 1)
+        existing_location = self.function_locations.get(location_key)
+        if (
+            existing_location is None
+            or existing_location.start_col == location.start_col
+        ):
+            self.function_locations[location_key] = location
         if language == cs.SupportedLanguage.CPP:
             # (H) A template wrapper's body walk in Pass 3 visits the INNER
             # (H) definition (it starts on its own line), so record that line

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -16,6 +16,7 @@ from ..types_defs import (
     DeferredParentLink,
     FunctionLocation,
     FunctionRegistryTrieProtocol,
+    FunctionSpanKey,
     NodeType,
     PropertyDict,
     SimpleNameLookup,
@@ -28,6 +29,7 @@ from .lua import utils as lua_utils
 from .rs import utils as rs_utils
 from .utils import (
     callable_parameter_indices,
+    function_span_key,
     get_function_captures,
     ingest_method,
     is_method_node,
@@ -109,6 +111,7 @@ class _DeferredMethod(NamedTuple):
     module_qn: str
     namespace_path: str
     start_line: int
+    start_col: int
 
 
 class _DeferredGoMethod(NamedTuple):
@@ -160,7 +163,7 @@ class FunctionIngestMixin:
     _deferred_parent_links: list[DeferredParentLink]
     method_return_types: dict[str, str]
     cpp_out_of_class_methods: dict[tuple[str, int], tuple[str, str]]
-    function_locations: dict[tuple[str, int], FunctionLocation]
+    function_locations: dict[FunctionSpanKey, FunctionLocation]
     macro_qns: set[str]
     _deferred_js_anonymous: list[_DeferredJsAnonymous]
     class_inheritance: dict[str, list[str]]
@@ -251,10 +254,9 @@ class FunctionIngestMixin:
 
     def _function_span_claimed(self, module_qn: str, func_node: Node) -> bool:
         # (H) A span is claimed when a pass recorded THIS function node's
-        # (H) location (same line and column, mirroring Pass-3's ownership
-        # (H) check); a same-line different-column entry is another function.
-        loc = self.function_locations.get((module_qn, func_node.start_point[0] + 1))
-        return loc is not None and loc.start_col == func_node.start_point[1]
+        # (H) location; the column in the key keeps a same-line neighbour's
+        # (H) claim from masking this node's own.
+        return function_span_key(module_qn, func_node) in self.function_locations
 
     def _span_claimed_for_qn(
         self, module_qn: str, func_node: Node, candidate_qn: str
@@ -265,8 +267,8 @@ class FunctionIngestMixin:
         # (H) twin model: `X.prototype.m = function m()` keeps both the
         # (H) fn-expr's own-name node and the member-name node (duplicate-QN
         # (H) design: keep both, CALLS-to-both), so it must still register.
-        loc = self.function_locations.get((module_qn, func_node.start_point[0] + 1))
-        if loc is None or loc.start_col != func_node.start_point[1]:
+        loc = self.function_locations.get(function_span_key(module_qn, func_node))
+        if loc is None:
             return False
         claimed_base = loc.qualified_name.split(cs.DUP_QN_MARKER, 1)[0]
         return claimed_base == candidate_qn
@@ -276,13 +278,12 @@ class FunctionIngestMixin:
     ) -> None:
         # (H) First claim wins; a later pass deriving a different qn for the
         # (H) same source function must skip registration, not mint a twin.
-        key = (module_qn, func_node.start_point[0] + 1)
+        key = function_span_key(module_qn, func_node)
         if key not in self.function_locations:
             self.function_locations[key] = FunctionLocation(
                 label=label,
                 qualified_name=qualified_name,
                 container_qn=None,
-                start_col=func_node.start_point[1],
             )
 
     def _flush_deferred_js_anonymous(self) -> None:
@@ -466,13 +467,15 @@ class FunctionIngestMixin:
                 # (H) Record the binding so Pass-3 call attribution reuses this
                 # (H) exact decision instead of re-resolving (and diverging).
                 bound_qn = f"{class_qn}{cs.SEPARATOR_DOT}{bound_name}"
-                location = (module_qn, func_node.start_point[0] + 1)
-                self.cpp_out_of_class_methods[location] = (bound_qn, class_qn)
-                self.function_locations[location] = FunctionLocation(
-                    label=cs.NodeLabel.METHOD.value,
-                    qualified_name=bound_qn,
-                    container_qn=class_qn,
-                    start_col=func_node.start_point[1],
+                self.cpp_out_of_class_methods[
+                    (module_qn, func_node.start_point[0] + 1)
+                ] = (bound_qn, class_qn)
+                self.function_locations[function_span_key(module_qn, func_node)] = (
+                    FunctionLocation(
+                        label=cs.NodeLabel.METHOD.value,
+                        qualified_name=bound_qn,
+                        container_qn=class_qn,
+                    )
                 )
             if return_type and (
                 method_name := cpp_utils.extract_function_name(func_node)
@@ -511,6 +514,7 @@ class FunctionIngestMixin:
                         cpp_utils.extract_namespace_path(func_node)
                     ),
                     start_line=func_node.start_point[0] + 1,
+                    start_col=func_node.start_point[1],
                 )
             )
 
@@ -551,12 +555,12 @@ class FunctionIngestMixin:
                 method_qn,
                 class_qn,
             )
-            self.function_locations[(entry.module_qn, entry.start_line)] = (
-                FunctionLocation(
-                    label=cs.NodeLabel.METHOD.value,
-                    qualified_name=method_qn,
-                    container_qn=class_qn,
-                )
+            self.function_locations[
+                (entry.module_qn, entry.start_line, entry.start_col)
+            ] = FunctionLocation(
+                label=cs.NodeLabel.METHOD.value,
+                qualified_name=method_qn,
+                container_qn=class_qn,
             )
 
             props = dict(entry.method_props)
@@ -776,32 +780,19 @@ class FunctionIngestMixin:
             label=cs.NodeLabel.FUNCTION.value,
             qualified_name=resolution.qualified_name,
             container_qn=None,
-            start_col=func_node.start_point[1],
             is_named=not resolution.is_anonymous,
         )
-        # (H) Never steal another function's line slot: a deferred anonymous
-        # (H) flushing next to a same-line named function (one-line curried
-        # (H) arrow) must not repoint the named function's Pass-3 record.
-        location_key = (module_qn, func_node.start_point[0] + 1)
-        existing_location = self.function_locations.get(location_key)
-        if (
-            existing_location is None
-            or existing_location.start_col == location.start_col
-        ):
-            self.function_locations[location_key] = location
+        self.function_locations[function_span_key(module_qn, func_node)] = location
         if language == cs.SupportedLanguage.CPP:
             # (H) A template wrapper's body walk in Pass 3 visits the INNER
-            # (H) definition (it starts on its own line), so record that line
-            # (H) against the wrapper's node too.
+            # (H) definition (it starts on its own line), so record the entry
+            # (H) under the child's span too (the walk matches on that node).
             if func_node.type == cs.CppNodeType.TEMPLATE_DECLARATION:
                 for child in func_node.children:
                     if child.type == cs.CppNodeType.FUNCTION_DEFINITION:
-                        # (H) The Pass-3 walk matches on the CHILD node, so the
-                        # (H) entry must carry the child's column, not the
-                        # (H) wrapper's, or the column check rejects it.
-                        self.function_locations[
-                            (module_qn, child.start_point[0] + 1)
-                        ] = location._replace(start_col=child.start_point[1])
+                        self.function_locations[function_span_key(module_qn, child)] = (
+                            location
+                        )
                         break
 
         # (H) A method-body anonymous-class override (`new Base(){ @Override m(){} }`
@@ -1196,12 +1187,10 @@ class FunctionIngestMixin:
         row_col = tail[len(cs.PREFIX_ANONYMOUS) :].split(cs.CHAR_UNDERSCORE)
         if len(row_col) != 2 or not all(part.isdigit() for part in row_col):
             return None
-        loc = self.function_locations.get((module_qn, int(row_col[0]) + 1))
-        if (
-            loc is None
-            or loc.start_col != int(row_col[1])
-            or loc.qualified_name not in self.function_registry
-        ):
+        loc = self.function_locations.get(
+            (module_qn, int(row_col[0]) + 1, int(row_col[1]))
+        )
+        if loc is None or loc.qualified_name not in self.function_registry:
             return None
         return loc.label, loc.qualified_name
 
@@ -1371,11 +1360,10 @@ class FunctionIngestMixin:
                 # (H) hoisting the child to the module or the wrong function.
                 if language in cs.JS_TS_LANGUAGES:
                     recorded = self.function_locations.get(
-                        (module_qn, current.start_point[0] + 1)
+                        function_span_key(module_qn, current)
                     )
                     if (
                         recorded is not None
-                        and recorded.start_col == current.start_point[1]
                         and recorded.qualified_name != func_qn
                         and recorded.qualified_name in self.function_registry
                     ):

--- a/codebase_rag/parsers/js_ts/ingest.py
+++ b/codebase_rag/parsers/js_ts/ingest.py
@@ -225,6 +225,8 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
             if constructor_name and method_name:
                 constructor_qn = f"{module_qn}{cs.SEPARATOR_DOT}{constructor_name}"
                 method_qn = f"{constructor_qn}{cs.SEPARATOR_DOT}{method_name}"
+                if self._span_claimed_for_qn(module_qn, func_node, method_qn):
+                    continue
                 method_qn = self.function_registry.register_unique_qn(
                     method_qn, func_node.start_point[0] + 1
                 )
@@ -246,6 +248,9 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
 
                 self.function_registry[method_qn] = NodeType.FUNCTION
                 self.simple_name_lookup[method_name].add(method_qn)
+                self._claim_function_span(
+                    module_qn, func_node, cs.NodeLabel.FUNCTION.value, method_qn
+                )
 
                 # (H) The assignment target is not always a registered constructor
                 # (H) function: `target.prototype.render = ...` inside a decorator
@@ -393,6 +398,8 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
         lang_config: LanguageSpec | None,
         language: cs.SupportedLanguage,
     ) -> None:
+        if self._span_claimed_for_qn(module_qn, method_func_node, method_qn):
+            return
         method_qn = self.function_registry.register_unique_qn(
             method_qn, method_func_node.start_point[0] + 1
         )
@@ -411,6 +418,9 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
 
         self.function_registry[method_qn] = NodeType.FUNCTION
         self.simple_name_lookup[method_name].add(method_qn)
+        self._claim_function_span(
+            module_qn, method_func_node, cs.NodeLabel.FUNCTION.value, method_qn
+        )
 
         # (H) An object-literal function nested inside another function takes
         # (H) its lexical parent, not the module (issue: module-parented
@@ -629,6 +639,8 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
         lang_config: LanguageSpec | None,
         language: cs.SupportedLanguage,
     ) -> None:
+        if self._span_claimed_for_qn(module_qn, function_node, function_qn):
+            return
         function_qn = self.function_registry.register_unique_qn(
             function_qn, function_node.start_point[0] + 1
         )
@@ -645,6 +657,9 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
         self.ingestor.ensure_node_batch(cs.NodeLabel.FUNCTION, function_props)
         self.function_registry[function_qn] = NodeType.FUNCTION
         self.simple_name_lookup[function_name].add(function_qn)
+        self._claim_function_span(
+            module_qn, function_node, cs.NodeLabel.FUNCTION.value, function_qn
+        )
         # (H) An assignment function nested inside another function takes its
         # (H) lexical parent, not the module (issue: module-parented
         # (H) duplicates of correctly-parented nodes on thrift lib/js).

--- a/codebase_rag/parsers/js_ts/module_system.py
+++ b/codebase_rag/parsers/js_ts/module_system.py
@@ -47,6 +47,20 @@ class JsTsModuleSystemMixin:
     @abstractmethod
     def _is_export_inside_function(self, node: ASTNode) -> bool: ...
 
+    # (H) Span-claim protocol (implemented by FunctionIngestMixin): one source
+    # (H) function must mint exactly one node PER NAME, so every JS/TS
+    # (H) registration path checks the claim before registering and claims
+    # (H) after (deliberate different-name twins still register).
+    @abstractmethod
+    def _span_claimed_for_qn(
+        self, module_qn: str, func_node: ASTNode, candidate_qn: str
+    ) -> bool: ...
+
+    @abstractmethod
+    def _claim_function_span(
+        self, module_qn: str, func_node: ASTNode, label: str, qualified_name: str
+    ) -> None: ...
+
     def __init__(self) -> None:
         self._processed_imports = set()
 
@@ -204,7 +218,13 @@ class JsTsModuleSystemMixin:
         module_qn: str,
         export_type: str,
     ) -> None:
-        ingest_exported_function(
+        if self._span_claimed_for_qn(
+            module_qn,
+            export_function,
+            f"{module_qn}{cs.SEPARATOR_DOT}{function_name}",
+        ):
+            return
+        function_qn = ingest_exported_function(
             export_function,
             function_name,
             module_qn,
@@ -217,6 +237,13 @@ class JsTsModuleSystemMixin:
             self.module_qn_to_file_path.get(module_qn),
             self.repo_path,
         )
+        if function_qn is not None:
+            self._claim_function_span(
+                module_qn,
+                export_function,
+                cs.NodeLabel.FUNCTION.value,
+                function_qn,
+            )
 
     def _process_exports_pattern(
         self,
@@ -335,18 +362,11 @@ class JsTsModuleSystemMixin:
                     ):
                         if export_name.text and export_function:
                             if function_name := safe_decode_text(export_name):
-                                ingest_exported_function(
+                                self._ingest_export_function(
                                     export_function,
                                     function_name,
                                     module_qn,
                                     cs.JS_EXPORT_TYPE_ES6_FUNCTION,
-                                    self.ingestor,
-                                    self.function_registry,
-                                    self.simple_name_lookup,
-                                    self._get_docstring,
-                                    self._is_export_inside_function,
-                                    self.module_qn_to_file_path.get(module_qn),
-                                    self.repo_path,
                                 )
 
                     if not export_names:
@@ -357,20 +377,11 @@ class JsTsModuleSystemMixin:
                                 ):
                                     if name_node.text:
                                         if function_name := safe_decode_text(name_node):
-                                            ingest_exported_function(
+                                            self._ingest_export_function(
                                                 export_function,
                                                 function_name,
                                                 module_qn,
                                                 cs.JS_EXPORT_TYPE_ES6_FUNCTION_DECL,
-                                                self.ingestor,
-                                                self.function_registry,
-                                                self.simple_name_lookup,
-                                                self._get_docstring,
-                                                self._is_export_inside_function,
-                                                self.module_qn_to_file_path.get(
-                                                    module_qn
-                                                ),
-                                                self.repo_path,
                                             )
 
                 except Exception as e:

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -707,9 +707,11 @@ def ingest_exported_function(
     is_export_inside_function_func: Callable[[ASTNode], bool],
     file_path: Path | None,
     repo_path: Path | None,
-) -> None:
+) -> str | None:
+    # (H) Returns the registered qn (None when skipped) so the caller can claim
+    # (H) the function node's span against later registration passes.
     if is_export_inside_function_func(function_node):
-        return
+        return None
 
     function_qn = f"{module_qn}.{function_name}"
     # (H) The definition pass already ingests an exported function / const-arrow at
@@ -717,7 +719,7 @@ def ingest_exported_function(
     # (H) `qn@line` duplicate node, onto which call resolution then binds (mangling
     # (H) the callee qn). If the natural qn already exists, the node is done.
     if function_qn in function_registry:
-        return
+        return None
     # (H) Same for a nested export (TS namespace / module block): the main pass
     # (H) already ingested it under its nested qn (e.g. lib.geo.helper), so a
     # (H) module-level re-ingest would mint a phantom duplicate node plus a
@@ -727,7 +729,7 @@ def ingest_exported_function(
     current = function_node.parent
     while current is not None:
         if current.type in (cs.TS_INTERNAL_MODULE, cs.TS_MODULE):
-            return
+            return None
         current = current.parent
     function_qn = function_registry.register_unique_qn(
         function_qn, function_node.start_point[0] + 1
@@ -756,6 +758,7 @@ def ingest_exported_function(
         cs.RelationshipType.DEFINES,
         (cs.NodeLabel.FUNCTION, cs.KEY_QUALIFIED_NAME, function_qn),
     )
+    return function_qn
 
 
 def is_method_node(func_node: ASTNode, lang_config: LanguageSpec) -> bool:

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -13,6 +13,7 @@ from .. import logs
 from ..types_defs import (
     ASTNode,
     DeferredParentLink,
+    FunctionSpanKey,
     LanguageQueries,
     NodeType,
     PropertyDict,
@@ -25,6 +26,12 @@ if TYPE_CHECKING:
     from ..language_spec import LanguageSpec
     from ..services import IngestorProtocol
     from ..types_defs import FunctionRegistryTrieProtocol
+
+
+def function_span_key(module_qn: str, node: Node) -> FunctionSpanKey:
+    # (H) tree-sitter points are 0-based; recorded lines are 1-based.
+    return (module_qn, node.start_point[0] + 1, node.start_point[1])
+
 
 _QUERY_CACHE: dict[tuple[Language, str], Query] = {}
 _QUERY_LAST: tuple[tuple[Language, str], Query] | None = None

--- a/codebase_rag/tests/test_javascript_containment_oracle.py
+++ b/codebase_rag/tests/test_javascript_containment_oracle.py
@@ -24,6 +24,36 @@ export class Point {
 export function free() { return 1; }
 """
 
+# (H) `View.prototype.lookup = function () {...}` is DEFINEd by the CONSTRUCTOR
+# (H) node in cgr's model (the prototype pass registers `module.View.lookup`
+# (H) under the constructor). The oracle used to expect a module parent, which
+# (H) only matched cgr's since-cured anonymous-twin duplicate; it must model
+# (H) the constructor containment, including a constructor declared as a
+# (H) var-assigned function expression and an assignment nested in a function.
+JS_PROTOTYPE_SRC = """\
+function View(name) {
+    this.name = name;
+}
+
+View.prototype.lookup = function (key) {
+    return this.name + key;
+};
+
+var Store = function (items) {
+    this.items = items;
+};
+
+Store.prototype.get = function (i) {
+    return this.items[i];
+};
+
+function install() {
+    View.prototype.reset = function () {
+        this.name = "";
+    };
+}
+"""
+
 
 def _require_js() -> None:
     if not typescript_available():
@@ -54,3 +84,21 @@ def test_cgr_matches_tsc_oracle_on_js_containment_edges(tmp_path: Path) -> None:
             row,
             result.diff,
         )
+
+
+def test_cgr_matches_tsc_oracle_on_prototype_method_containment(
+    tmp_path: Path,
+) -> None:
+    _require_js()
+    project = tmp_path / "js_proto"
+    project.mkdir()
+    (project / "view.js").write_text(JS_PROTOTYPE_SRC, encoding="utf-8")
+
+    cgr = extract_cgr_js_graph(project, project.name)
+    oracle = run_javascript_oracle(project)
+
+    result = score_edge_types(cgr, oracle, ec.SCORED_EDGE_TYPES)
+    by_label = {row["label"]: row for row in result.rows}
+    row = by_label.get(cs.RelationshipType.DEFINES.value)
+    assert row is not None, (by_label, result.diff)
+    assert row["precision"] == 1.0 and row["recall"] == 1.0, (row, result.diff)

--- a/codebase_rag/tests/test_javascript_containment_oracle.py
+++ b/codebase_rag/tests/test_javascript_containment_oracle.py
@@ -52,6 +52,26 @@ function install() {
         this.name = "";
     };
 }
+
+var Conn = (exports.Conn = function (stream) {
+    this.stream = stream;
+});
+
+Conn.prototype.close = function () {
+    this.stream = null;
+};
+
+function wrap(base) {
+    function Inner(x) {
+        base.call(this, x);
+    }
+
+    Inner.prototype.run = function () {
+        return this.x;
+    };
+
+    return Inner;
+}
 """
 
 

--- a/codebase_rag/tests/test_js_duplicate_node_unification.py
+++ b/codebase_rag/tests/test_js_duplicate_node_unification.py
@@ -1,0 +1,184 @@
+# (H) The thrift sweep found 521 JS/TS source locations minting MULTIPLE nodes:
+# (H) the generic function pass registers every unnamed function expression as
+# (H) `anonymous_row_col` BEFORE the named JS passes (object literals, exports,
+# (H) assignment arrows, prototype methods) register the same source function
+# (H) under its real name, and two named passes registering the same function
+# (H) collide in register_unique_qn, minting a spurious `name@line` twin. One
+# (H) source function must yield exactly one node: named passes claim their
+# (H) function node's span in function_locations (first claim wins), and the
+# (H) generic pass defers anonymous JS registration until after the named
+# (H) passes, registering only unclaimed spans.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import get_relationships, run_updater
+
+EXPORTS_JS = """
+exports.readByte = function (b) {
+  return b > 127 ? b - 256 : b;
+};
+"""
+
+OBJECT_LITERAL_JS = """
+var helloHandler = {
+  hello_func: function (result) {
+    return "Hello " + result;
+  },
+};
+"""
+
+PAREN_EXPORT_JS = """
+var Connection = (exports.Connection = function (stream) {
+  this.stream = stream;
+});
+"""
+
+CALLBACK_JS = """
+setTimeout(function () {
+  return 42;
+}, 100);
+"""
+
+PROTOTYPE_JS = """
+function Reader(buf) {
+  this.buf = buf;
+}
+
+Reader.prototype.readAll = function () {
+  return this.buf;
+};
+"""
+
+CALLER_JS = """
+function shift(b) {
+  return b << 1;
+}
+
+exports.readWord = function (b) {
+  return shift(b);
+};
+"""
+
+
+def _function_nodes_by_location(
+    mock_ingestor: MagicMock,
+) -> dict[tuple[str, int], set[str]]:
+    by_loc: dict[tuple[str, int], set[str]] = {}
+    for call in mock_ingestor.ensure_node_batch.call_args_list:
+        label = str(call.args[0])
+        if label not in (
+            cs.NodeLabel.FUNCTION.value,
+            cs.NodeLabel.METHOD.value,
+        ):
+            continue
+        props = call.args[1]
+        path = props.get(cs.KEY_PATH)
+        start = props.get(cs.KEY_START_LINE)
+        if path is None or start is None:
+            continue
+        by_loc.setdefault((str(path), int(start)), set()).add(
+            props[cs.KEY_QUALIFIED_NAME]
+        )
+    return by_loc
+
+
+def _assert_single_node_per_location(mock_ingestor: MagicMock) -> None:
+    duplicated = {
+        loc: qns
+        for loc, qns in _function_nodes_by_location(mock_ingestor).items()
+        if len(qns) > 1
+    }
+    assert not duplicated, duplicated
+
+
+def _all_function_qns(mock_ingestor: MagicMock) -> set[str]:
+    return {
+        qns
+        for qn_set in _function_nodes_by_location(mock_ingestor).values()
+        for qns in qn_set
+    }
+
+
+def test_commonjs_export_function_yields_single_named_node(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "binary.js").write_text(EXPORTS_JS)
+    run_updater(temp_repo, mock_ingestor, skip_if_missing="javascript")
+
+    project = temp_repo.name
+    qns = _all_function_qns(mock_ingestor)
+    assert f"{project}.binary.readByte" in qns, qns
+    _assert_single_node_per_location(mock_ingestor)
+
+
+def test_object_literal_method_yields_single_named_node(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "hello.js").write_text(OBJECT_LITERAL_JS)
+    run_updater(temp_repo, mock_ingestor, skip_if_missing="javascript")
+
+    qns = _all_function_qns(mock_ingestor)
+    assert any(qn.endswith("hello_func") for qn in qns), qns
+    _assert_single_node_per_location(mock_ingestor)
+
+
+def test_parenthesized_export_assignment_yields_single_node(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "connection.js").write_text(PAREN_EXPORT_JS)
+    run_updater(temp_repo, mock_ingestor, skip_if_missing="javascript")
+
+    project = temp_repo.name
+    qns = _all_function_qns(mock_ingestor)
+    assert f"{project}.connection.Connection" in qns, qns
+    assert not any(cs.DUP_QN_MARKER in qn for qn in qns), qns
+    _assert_single_node_per_location(mock_ingestor)
+
+
+def test_prototype_method_yields_single_constructor_scoped_node(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "reader.js").write_text(PROTOTYPE_JS)
+    run_updater(temp_repo, mock_ingestor, skip_if_missing="javascript")
+
+    project = temp_repo.name
+    qns = _all_function_qns(mock_ingestor)
+    assert f"{project}.reader.Reader.readAll" in qns, qns
+    _assert_single_node_per_location(mock_ingestor)
+
+
+def test_true_anonymous_callback_still_gets_its_node(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) A callback argument is claimed by NO named pass; deferring anonymous
+    # (H) registration must not lose it.
+    (temp_repo / "timer.js").write_text(CALLBACK_JS)
+    run_updater(temp_repo, mock_ingestor, skip_if_missing="javascript")
+
+    qns = _all_function_qns(mock_ingestor)
+    assert any(
+        qn.rsplit(cs.SEPARATOR_DOT, 1)[-1].startswith(cs.PREFIX_ANONYMOUS)
+        for qn in qns
+    ), qns
+    _assert_single_node_per_location(mock_ingestor)
+
+
+def test_calls_from_exported_function_attribute_to_named_node(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) With the anonymous twin gone, Pass-3 caller attribution must bind the
+    # (H) body's calls to the surviving NAMED node, not re-derive a phantom
+    # (H) anonymous caller (the conftest gate would flag that as dangling).
+    (temp_repo / "word.js").write_text(CALLER_JS)
+    run_updater(temp_repo, mock_ingestor, skip_if_missing="javascript")
+
+    project = temp_repo.name
+    callers = {
+        str(call.args[0][2])
+        for call in get_relationships(mock_ingestor, cs.RelationshipType.CALLS.value)
+        if str(call.args[2][2]) == f"{project}.word.shift"
+    }
+    assert f"{project}.word.readWord" in callers, callers

--- a/codebase_rag/tests/test_js_duplicate_node_unification.py
+++ b/codebase_rag/tests/test_js_duplicate_node_unification.py
@@ -160,8 +160,7 @@ def test_true_anonymous_callback_still_gets_its_node(
 
     qns = _all_function_qns(mock_ingestor)
     assert any(
-        qn.rsplit(cs.SEPARATOR_DOT, 1)[-1].startswith(cs.PREFIX_ANONYMOUS)
-        for qn in qns
+        qn.rsplit(cs.SEPARATOR_DOT, 1)[-1].startswith(cs.PREFIX_ANONYMOUS) for qn in qns
     ), qns
     _assert_single_node_per_location(mock_ingestor)
 

--- a/codebase_rag/tests/test_js_duplicate_node_unification.py
+++ b/codebase_rag/tests/test_js_duplicate_node_unification.py
@@ -62,6 +62,26 @@ exports.readWord = function (b) {
 };
 """
 
+NESTED_RETURN_JS = """
+exports.receiver = function (callback) {
+  return function (data) {
+    return callback(data);
+  };
+};
+"""
+
+SAME_NAME_EXPR_JS = """
+register("first", function t(x) {
+  return x;
+});
+
+register("second", function t(y) {
+  return function inner() {
+    return y;
+  };
+});
+"""
+
 
 def _function_nodes_by_location(
     mock_ingestor: MagicMock,
@@ -163,6 +183,53 @@ def test_true_anonymous_callback_still_gets_its_node(
         qn.rsplit(cs.SEPARATOR_DOT, 1)[-1].startswith(cs.PREFIX_ANONYMOUS) for qn in qns
     ), qns
     _assert_single_node_per_location(mock_ingestor)
+
+
+def _defines_pairs(mock_ingestor: MagicMock) -> set[tuple[str, str]]:
+    return {
+        (str(call.args[0][2]), str(call.args[2][2]))
+        for call in get_relationships(
+            mock_ingestor, cs.RelationshipType.DEFINES.value
+        )
+    }
+
+
+def test_nested_function_parents_to_claimed_named_node(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) The enclosing function's span is claimed under `receiver`; deriving
+    # (H) the nested function's parent structurally would produce the
+    # (H) since-unregistered anonymous qn and hoist the child to the module.
+    # (H) The parent derivation must reuse the claimed identity.
+    (temp_repo / "transport.js").write_text(NESTED_RETURN_JS)
+    run_updater(temp_repo, mock_ingestor, skip_if_missing="javascript")
+
+    assert any(
+        parent.endswith(".receiver")
+        and cs.PREFIX_ANONYMOUS in child.rsplit(cs.SEPARATOR_DOT, 1)[-1]
+        for parent, child in _defines_pairs(mock_ingestor)
+    ), _defines_pairs(mock_ingestor)
+
+
+def test_nested_function_parents_to_its_own_same_name_enclosing(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) Two function expressions share the name `t`; the second registers as
+    # (H) `t@line`. A function nested in the SECOND must parent to `t@line`,
+    # (H) not to the first `t` (structural re-derivation binds the wrong
+    # (H) function; the span record knows which one encloses the child).
+    (temp_repo / "suite.js").write_text(SAME_NAME_EXPR_JS)
+    run_updater(temp_repo, mock_ingestor, skip_if_missing="javascript")
+
+    inner_parents = {
+        parent
+        for parent, child in _defines_pairs(mock_ingestor)
+        if child.endswith(".inner")
+    }
+    assert any(cs.DUP_QN_MARKER in parent for parent in inner_parents), (
+        inner_parents,
+        _defines_pairs(mock_ingestor),
+    )
 
 
 def test_calls_from_exported_function_attribute_to_named_node(

--- a/codebase_rag/tests/test_js_duplicate_node_unification.py
+++ b/codebase_rag/tests/test_js_duplicate_node_unification.py
@@ -82,6 +82,15 @@ register("second", function t(y) {
 });
 """
 
+NAMED_NESTED_JS = """
+exports.receiver = function (callback) {
+  function helper(data) {
+    return callback(data);
+  }
+  return helper;
+};
+"""
+
 
 def _function_nodes_by_location(
     mock_ingestor: MagicMock,
@@ -228,6 +237,28 @@ def test_nested_function_parents_to_its_own_same_name_enclosing(
     }
     assert any(cs.DUP_QN_MARKER in parent for parent in inner_parents), (
         inner_parents,
+        _defines_pairs(mock_ingestor),
+    )
+
+
+def test_named_nested_function_parents_to_later_claimed_node(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) `helper` registers EAGERLY (generic pass) while its enclosing
+    # (H) function expression is still unnamed; the parent guess is the
+    # (H) anonymous placeholder, deferred. By resolve time the enclosing span
+    # (H) is claimed under `receiver`; the resolver must re-consult the claim
+    # (H) (the placeholder embeds the span) instead of falling back to module.
+    (temp_repo / "eager.js").write_text(NAMED_NESTED_JS)
+    run_updater(temp_repo, mock_ingestor, skip_if_missing="javascript")
+
+    helper_parents = {
+        parent
+        for parent, child in _defines_pairs(mock_ingestor)
+        if child.endswith(".helper")
+    }
+    assert any(parent.endswith(".receiver") for parent in helper_parents), (
+        helper_parents,
         _defines_pairs(mock_ingestor),
     )
 

--- a/codebase_rag/tests/test_js_duplicate_node_unification.py
+++ b/codebase_rag/tests/test_js_duplicate_node_unification.py
@@ -197,9 +197,7 @@ def test_true_anonymous_callback_still_gets_its_node(
 def _defines_pairs(mock_ingestor: MagicMock) -> set[tuple[str, str]]:
     return {
         (str(call.args[0][2]), str(call.args[2][2]))
-        for call in get_relationships(
-            mock_ingestor, cs.RelationshipType.DEFINES.value
-        )
+        for call in get_relationships(mock_ingestor, cs.RelationshipType.DEFINES.value)
     }
 
 

--- a/codebase_rag/tests/test_js_duplicate_node_unification.py
+++ b/codebase_rag/tests/test_js_duplicate_node_unification.py
@@ -91,6 +91,10 @@ exports.receiver = function (callback) {
 };
 """
 
+SAME_LINE_EXPORTS_JS = (
+    "exports.a = function () { return 1; }; exports.b = function () { return 2; };\n"
+)
+
 
 def _function_nodes_by_location(
     mock_ingestor: MagicMock,
@@ -277,3 +281,24 @@ def test_calls_from_exported_function_attribute_to_named_node(
         if str(call.args[2][2]) == f"{project}.word.shift"
     }
     assert f"{project}.word.readWord" in callers, callers
+
+
+def test_same_line_named_functions_each_keep_one_node(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) Two named functions on ONE line must each claim their own span: a
+    # (H) line-only claim record lets the first claim block the second, so the
+    # (H) second function's named passes collide into a `b@line` twin AND its
+    # (H) deferred anonymous registration flushes as an `anonymous_row_col`
+    # (H) twin (minified/one-line code).
+    (temp_repo / "same_line.js").write_text(SAME_LINE_EXPORTS_JS)
+    run_updater(temp_repo, mock_ingestor, skip_if_missing="javascript")
+
+    project = temp_repo.name
+    qns = _all_function_qns(mock_ingestor)
+    assert f"{project}.same_line.a" in qns, qns
+    assert f"{project}.same_line.b" in qns, qns
+    assert not any(cs.DUP_QN_MARKER in qn for qn in qns), qns
+    assert not any(
+        qn.rsplit(cs.SEPARATOR_DOT, 1)[-1].startswith(cs.PREFIX_ANONYMOUS) for qn in qns
+    ), qns

--- a/codebase_rag/tests/test_object_literal_callback_references.py
+++ b/codebase_rag/tests/test_object_literal_callback_references.py
@@ -149,9 +149,11 @@ def test_function_expression_assigned_to_property_is_referenced(
     tmp_path: Path,
 ) -> None:
     # (H) `OpenAPI.TOKEN = async () => {...}` stores a function on an object property
-    # (H) for a library to invoke later (the openapi-ts token provider); the arrow is
-    # (H) anonymous with no incoming edge. The assigning scope must reference it or it
-    # (H) reports as dead (the last frontend false positive on the template).
+    # (H) for a library to invoke later (the openapi-ts token provider); the arrow
+    # (H) has no incoming edge. The assigning scope must reference it or it reports
+    # (H) as dead (the last frontend false positive on the template). Span-claim
+    # (H) unification leaves ONE node for the arrow (the property-named TOKEN, no
+    # (H) anonymous twin), so that node is the one that must be referenced.
     files = {
         "main.tsx": (
             "import { OpenAPI } from './client'\n\n"
@@ -166,7 +168,7 @@ def test_function_expression_assigned_to_property_is_referenced(
     }
     rels = _run_rels(tmp_path, files, "tsx")
     refs = {b for a, r, b in rels if r == REFERENCES and a.endswith(".main")}
-    assert any(".main.anonymous_" in b for b in refs), (
+    assert any(b.endswith(".main.TOKEN") for b in refs), (
         f"function-expression assigned to a property not referenced; refs={refs}"
     )
 

--- a/codebase_rag/tests/test_ts_member_assigned_function_references.py
+++ b/codebase_rag/tests/test_ts_member_assigned_function_references.py
@@ -2,9 +2,10 @@
 # (H) (state, replace) => {...}`, zustand's middleware store-patching shape) was
 # (H) orphaned two ways: (a) the assignment-reference walk stopped at EVERY function
 # (H) boundary, so an assignment inside an anonymous curried arrow (which gets no
-# (H) caller pass of its own) was scanned by nobody; (b) the def pass registers the
-# (H) assigned arrow by PROPERTY NAME (scope.setState), which the position-only
-# (H) anonymous candidate never matches. Both registrations must be referenced.
+# (H) caller pass of its own) was scanned by nobody; (b) the def pass used to ALSO
+# (H) register a position-named anonymous twin for the assigned arrow. Span-claim
+# (H) unification cured (b) at the root (one node per source function), so only
+# (H) the property-named node exists and it must be referenced.
 from __future__ import annotations
 
 from pathlib import Path
@@ -37,14 +38,17 @@ def test_member_assigned_arrow_in_curried_anon_is_referenced(
     )
     create_and_run_updater(root, mock_ingestor, skip_if_missing="typescript")
     refs = _refs(mock_ingestor)
-    # (H) both registrations of the assigned arrow must be reachable: the
-    # (H) property-named node and the position-named anonymous node.
+    # (H) the single (property-named) registration of the assigned arrow must
+    # (H) be reachable, and the position-named anonymous twin must not exist.
     assert any(t.endswith(".persistImpl.setState") for _, t in refs), sorted(
         t for _, t in refs if "persistImpl" in t
     )
-    assert any(".persistImpl.anonymous_1_" in t for _, t in refs), sorted(
-        t for _, t in refs if "persistImpl" in t
-    )
+    nodes = {
+        c.args[1]["qualified_name"]
+        for c in mock_ingestor.ensure_node_batch.call_args_list
+        if str(c.args[0]) == "Function"
+    }
+    assert not any(".persistImpl.anonymous_1_" in qn for qn in nodes), sorted(nodes)
 
 
 def test_cast_wrapped_member_assignment_rhs_is_referenced(

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -531,6 +531,11 @@ class FunctionLocation(NamedTuple):
     # (H) a mismatch instead of adopting the WRONG function's qn. None (the
     # (H) deferred C++ out-of-class path, which has no node) skips the check.
     start_col: int | None = None
+    # (H) False when the qn was GENERATED (anonymous_row_col, iife_*): Pass-3
+    # (H) lets an unnamed JS/TS function expression adopt a NAMED record (the
+    # (H) node a named pass registered for `exports.f = function`), while a
+    # (H) generated record keeps the historical bubble-to-module attribution.
+    is_named: bool = True
 
 
 class DeferredCppInherit(NamedTuple):

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -512,25 +512,26 @@ class DeferredParentLink(NamedTuple):
     fallback_qn: str | None = None
 
 
+# (H) (module_qn, 1-based start line, 0-based start column) of a function
+# (H) node; the full span identifies the function even on shared lines.
+type FunctionSpanKey = tuple[str, int, int]
+
+
 class FunctionLocation(NamedTuple):
     """Where the definition pass put a C++ function/method node.
 
-    Keyed by (module_qn, start_line) so Pass-3 call attribution reuses the
-    exact label and qn Pass 2 registered instead of re-deriving them from the
-    AST; the two walks diverge on preprocessor-distorted class bodies and
-    every divergence is a phantom caller the database drops (issue #652).
+    Keyed by (module_qn, start_line, start_col) so Pass-3 call attribution
+    reuses the exact label and qn Pass 2 registered instead of re-deriving
+    them from the AST; the two walks diverge on preprocessor-distorted class
+    bodies and every divergence is a phantom caller the database drops
+    (issue #652). The column in the key keeps same-line functions (a one-line
+    curried arrow, minified `exports.a = ...; exports.b = ...`) from evicting
+    or masking each other's records.
     """
 
     label: str
     qualified_name: str
     container_qn: str | None
-    # (H) Start COLUMN of the recorded node. Two functions can share a start line
-    # (H) (a one-line curried arrow `const f = (a) => (b) => ...` records both the
-    # (H) outer and inner arrow at line 1), and the line-keyed map keeps only one;
-    # (H) the reader compares columns and falls back to name-based attribution on
-    # (H) a mismatch instead of adopting the WRONG function's qn. None (the
-    # (H) deferred C++ out-of-class path, which has no node) skips the check.
-    start_col: int | None = None
     # (H) False when the qn was GENERATED (anonymous_row_col, iife_*): Pass-3
     # (H) lets an unnamed JS/TS function expression adopt a NAMED record (the
     # (H) node a named pass registered for `exports.f = function`), while a

--- a/evals/oracles/ts_oracle/ts_ast.js
+++ b/evals/oracles/ts_oracle/ts_ast.js
@@ -116,6 +116,84 @@ function bindingName(node) {
   return "anonymous";
 }
 
+// (H) cgr models `X.prototype.m = function` as the CONSTRUCTOR node DEFINES the
+// (H) method (the prototype pass registers `module.X.m` under the constructor,
+// (H) resolved by module-flat name), so the oracle mirrors it: the file's
+// (H) declared functions (declarations and var-assigned expressions) are the
+// (H) constructor candidates. First declaration wins, matching cgr's registry.
+let declaredFns = new Map();
+
+// (H) Unwrap `( ... )` and `lhs = ...` chains so `var X = (exports.X =
+// (H) function ...)` resolves to the function expression, matching cgr's
+// (H) nameless-binding registration of X at the function node.
+function unwrapInitializer(node) {
+  while (node) {
+    if (ts.isParenthesizedExpression(node)) {
+      node = node.expression;
+    } else if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken
+    ) {
+      node = node.right;
+    } else {
+      return node;
+    }
+  }
+  return node;
+}
+
+function collectDeclaredFunctions(sf) {
+  const decls = new Map();
+  function scan(node) {
+    // (H) cgr resolves prototype constructors MODULE-FLAT (module.X); a
+    // (H) function declared inside another function registers nested and
+    // (H) never matches, so the scan must not descend past function or
+    // (H) class boundaries.
+    if (
+      ts.isFunctionDeclaration(node) ||
+      ts.isFunctionExpression(node) ||
+      ts.isArrowFunction(node) ||
+      ts.isMethodDeclaration(node) ||
+      ts.isClassDeclaration(node)
+    ) {
+      if (ts.isFunctionDeclaration(node) && node.name && !decls.has(node.name.text)) {
+        decls.set(node.name.text, lineOf(sf, node));
+      }
+      return;
+    }
+    if (
+      ts.isVariableDeclaration(node) &&
+      node.name &&
+      ts.isIdentifier(node.name) &&
+      node.initializer &&
+      !decls.has(node.name.text)
+    ) {
+      const init = unwrapInitializer(node.initializer);
+      if (init && (ts.isFunctionExpression(init) || ts.isArrowFunction(init))) {
+        decls.set(node.name.text, lineOf(sf, init));
+        return;
+      }
+    }
+    node.forEachChild(scan);
+  }
+  sf.forEachChild(scan);
+  return decls;
+}
+
+// (H) `X.prototype.m = <fn expr>`: the shape cgr's prototype-method pass owns.
+function prototypeAssignment(node) {
+  if (!ts.isBinaryExpression(node)) return null;
+  if (node.operatorToken.kind !== ts.SyntaxKind.EqualsToken) return null;
+  const lhs = node.left;
+  if (!ts.isPropertyAccessExpression(lhs) || !ts.isIdentifier(lhs.name)) return null;
+  const obj = lhs.expression;
+  if (!ts.isPropertyAccessExpression(obj) || !ts.isIdentifier(obj.name)) return null;
+  if (obj.name.text !== "prototype" || !ts.isIdentifier(obj.expression)) return null;
+  const rhs = node.right;
+  if (!ts.isFunctionExpression(rhs) && !ts.isArrowFunction(rhs)) return null;
+  return { ctorName: obj.expression.text, methodName: lhs.name.text, fn: rhs };
+}
+
 // ctx carries the file, the enclosing class/namespace ref (for Methods) and the
 // enclosing function ref (for nested Functions).
 function defineFunction(node, sf, file, container, ctx, kind, line) {
@@ -194,6 +272,23 @@ function walk(node, sf, file, container, ctx) {
     if (node.body) node.body.forEachChild((c) => walk(c, sf, file, "function", sub));
     return;
   }
+  const proto = prototypeAssignment(node);
+  if (proto) {
+    const line = lineOf(sf, proto.fn);
+    emit("Function", file, line, proto.methodName, endLineOf(sf, proto.fn));
+    const ctorLine = declaredFns.get(proto.ctorName);
+    if (ctorLine !== undefined) {
+      emitEdge("DEFINES", file, "Function", ctorLine, "Function", line);
+    } else {
+      // (H) Unregistered constructor: cgr's deferred parent falls back to the
+      // (H) lexical enclosing function, then the module.
+      const parent = ctx.funcRef || { kind: "Module", line: MODULE_LINE };
+      emitEdge("DEFINES", file, parent.kind, parent.line, "Function", line);
+    }
+    const sub = { typeRef: null, funcRef: { kind: "Function", line } };
+    proto.fn.forEachChild((c) => walk(c, sf, file, "function", sub));
+    return;
+  }
   if (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) {
     // (H) cgr captures every arrow/function expression as a Function node (named
     // by its variable when assigned, else anonymous), at the expression's own
@@ -235,6 +330,7 @@ function visitDir(dir, root, exts) {
       const src = fs.readFileSync(p, "utf8");
       const sf = ts.createSourceFile(p, src, ts.ScriptTarget.Latest, true);
       const rel = path.relative(root, p).split(path.sep).join("/");
+      declaredFns = collectDeclaredFunctions(sf);
       const ctx = { typeRef: null, funcRef: null };
       sf.forEachChild((c) => walk(c, sf, rel, "module", ctx));
     }

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.268"
+version = "0.0.270"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Problem

A census over thrift's four JS/TS corpora found **521 source locations minting more than one Function node** (384 in lib/nodejs, 114 in lib/js, 22 in lib/ts, 1 in lib/nodets). Three symptoms, one root cause:

1. **`anonymous_R_C` twins (515 locations)**: the generic function pass registers every unnamed function expression as `anonymous_row_col` BEFORE the named JS passes (object literals, commonjs/es6 exports, assignment arrows, prototype methods) register the same source function under its real name.
2. **`name@line` self-collisions (53 locations)**: two named passes derive the same qn for the same function node (`exports.readByte = function` is matched by both the commonjs-exports and the assignment-function queries), and `register_unique_qn` "disambiguates" the second registration against the first as if it were a different function.
3. **Split attribution**: `function_locations` only recorded the generic pass's registration, so Pass-3 call attribution bound body calls to the anonymous twin (or bubbled them to the module) while DEFINES pointed at the named node.

The root cause is shared: registration passes never consulted a common record of which source spans already had a node.

## Fix

One mechanism, the span claim, built on the existing `function_locations` record:

- **Named passes claim their function node's span** (line + column, mirroring Pass-3's ownership check) after registering, and skip registration when the span is already claimed **under the same base qn**. A different qn still registers: `X.prototype.m = function m()` deliberately keeps both the fn-expr's own-name node and the member-name node (the established duplicate-QN twin design).
- **The generic pass defers unnamed JS/TS function expressions** (`FunctionResolution.is_anonymous`) and a per-file flush registers only spans no named pass claimed, so genuine anonymous callbacks and IIFEs keep their nodes.
- **Pass-3 attribution**: an unnamed function expression whose span carries a NAMED claim adopts the record (calls inside `exports.f = function` now come FROM `f`); generated records keep the historical bubble-to-module attribution (`FunctionLocation.is_named`).
- **Nested parent derivation reuses claims**: `_determine_function_parent` consults the span record before structurally re-deriving the enclosing function's identity, fixing two defects the unification exposed: a nested function inside `exports.receiver = function` hoisted to the module, and a function nested in the second of two same-name fn exprs (`function t` twice) parenting to the FIRST `t` instead of `t@line`. The deferred parent-link resolver additionally recovers claims for eagerly-registered children via the `anonymous_row_col` placeholder's embedded span.
- **JS oracle models the cured contract**: the tsc oracle now emits constructor-parented DEFINES for `X.prototype.m = function` (module-flat constructor lookup mirroring cgr's registry, unwrapping `var X = (exports.X = function ...)`, falling back lexical-then-module for constructors that only register nested), instead of the module-parented edges that only ever matched the anonymous twins.

## Results on thrift

| corpus | duplicated locations | js/ts L1 (node / DEFINES / span) |
|---|---|---|
| lib/nodejs | 384 -> **0** | 1.0 / **0.8070 -> 1.0** / 1.0 |
| lib/js | 114 -> **0** | 1.0 / 1.0 / 1.0 |
| lib/ts | 22 -> **0** | 1.0 / 1.0 / 1.0 |
| lib/nodets | 1 -> **0** | 1.0 / 1.0 / 1.0 |

lib/nodejs DEFINES had never been 1.0: the oracle's module-parent expectation was satisfied only by the anonymous twins' module edges while cgr's constructor edges scored as false positives. Mutual blindness, now both sides truthful.

Node counts collapsed to exactly one per source location (nodejs 1088 -> 670) with node/span joins unchanged at 1.0.

## Tests

Strict red -> green throughout (each fix commit is preceded by its failing-test commit): nine unification fixture tests (exports, object literal, parenthesized export, prototype, true-anonymous survival, calls attribution, three nested-parent shapes) plus the extended JS containment oracle test. Two existing tests that asserted the disease's compensations (REFERENCES to the anonymous twin so it would not report dead) are updated to assert the twin no longer exists and the surviving named node is referenced.

Full suite: 4700 passed, 0 failed on the branch rebased onto current main (includes the macros-as-Function-nodes work), plus 146 memgraph integration tests passed against a live container. ruff and ty clean (ty diagnostic count unchanged from main).