### PR TITLE
fix(resolver): keep the static interface-method edge on sole-impl dispatch

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -2047,6 +2047,19 @@ class CallProcessor:
                             caller_spec, calls_rel, (sibling_type, qn_key, variant)
                         )
 
+            if callee_type == cs.NodeLabel.METHOD:
+                # (H) A call bound to an interface/trait method (the static callee;
+                # (H) removing its declaration breaks the call) with exactly ONE
+                # (H) implementer also runs the concrete method, so edge both. The
+                # (H) old REPLACING redirect orphaned the interface stub (gson's
+                # (H) FieldNamingStrategy.translateName reported dead); sorted():
+                # (H) the target label is a hash-randomized StrEnum.
+                for impl_type, impl_qn in sorted(
+                    resolver.interface_sole_impl_targets(callee_qn)
+                ):
+                    for variant in resolver.function_registry.variants(impl_qn):
+                        ensure_rel(caller_spec, calls_rel, (impl_type, qn_key, variant))
+
             if (
                 is_js_ts
                 and cs.SEPARATOR_DOT in call_name

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -538,11 +538,11 @@ class CallResolver:
 
     def _interface_impl_map(self) -> dict[str, str]:
         # (H) Map an interface to its SOLE first-party implementer. A call typed to an
-        # (H) interface resolves to the interface's own method declaration; when the
-        # (H) interface has exactly one implementer the concrete method is the one that
-        # (H) runs, so redirect to it (call-graph accuracy). >1 implementer is
-        # (H) ambiguous -> not mapped -> the call stays on the interface method (no
-        # (H) precision risk, recall preserved).
+        # (H) interface resolves to the interface's own method declaration (the static
+        # (H) callee); when the interface has exactly one implementer the concrete
+        # (H) method is the one that runs, so ALSO edge it (call-graph accuracy).
+        # (H) >1 implementer is ambiguous -> not mapped -> the call stays on the
+        # (H) interface method alone (no precision risk, recall preserved).
         if self._interface_impl_cache is None:
             self._interface_impl_cache = {
                 interface_qn: next(iter(implementers))
@@ -551,17 +551,38 @@ class CallResolver:
             }
         return self._interface_impl_cache
 
+    def interface_sole_impl_targets(self, callee_qn: str) -> set[tuple[str, str]]:
+        # (H) A callee that IS an interface/trait method (the receiver was typed to
+        # (H) the interface -- a concrete receiver dispatches to the impl directly)
+        # (H) with exactly one implementer also runs the concrete method, so return
+        # (H) it for an additional CALLS edge. REPLACING the interface edge instead
+        # (H) (the pre-#665-era redirect) orphaned the interface stub: OVERRIDES
+        # (H) expansion only walks interface -> impl, so the stub's declaration
+        # (H) (gson's FieldNamingStrategy.translateName) reported dead.
+        class_qn, sep, method_name = callee_qn.rpartition(cs.SEPARATOR_DOT)
+        if not sep:
+            return set()
+        impl_qn = self._interface_impl_map().get(class_qn)
+        if impl_qn is None:
+            return set()
+        if result := self._try_resolve_method(impl_qn, method_name):
+            return {result}
+        return set()
+
     def _redirect_protocol_method(
         self, result: tuple[str, str] | None
     ) -> tuple[str, str] | None:
+        # (H) Only Python Protocol stubs REPLACE the resolved target: a Protocol
+        # (H) method body never runs (it is `...`), so the concrete method is the
+        # (H) sole real callee. An interface/trait method is a live declaration the
+        # (H) call depends on, so its sole-impl companion edge is ADDITIVE
+        # (H) (interface_sole_impl_targets), never a replacement.
         if result is None:
             return result
         class_qn, sep, method_name = result[1].rpartition(cs.SEPARATOR_DOT)
         if not sep:
             return result
-        impl_qn = self._protocol_impl_map().get(
-            class_qn
-        ) or self._interface_impl_map().get(class_qn)
+        impl_qn = self._protocol_impl_map().get(class_qn)
         if impl_qn is None:
             return result
         redirected = f"{impl_qn}{cs.SEPARATOR_DOT}{method_name}"

--- a/codebase_rag/tests/test_interface_dispatch_single_impl.py
+++ b/codebase_rag/tests/test_interface_dispatch_single_impl.py
@@ -1,5 +1,9 @@
 from pathlib import Path
+from unittest.mock import MagicMock
 
+from codebase_rag.graph_updater import FunctionRegistryTrie
+from codebase_rag.parsers.call_resolver import CallResolver
+from codebase_rag.types_defs import NodeType
 from evals.cgr_graph import _capture
 
 
@@ -59,6 +63,24 @@ def test_rust_single_trait_impl_dispatches_to_concrete(tmp_path: Path) -> None:
     )
     assert ("proj.m.use_it", "proj.m.SvcImpl.run") in calls
     assert ("proj.m.use_it", "proj.m.Svc.run") in calls
+
+
+def test_sole_impl_targets_guard_branches() -> None:
+    # (H) Contract guards of interface_sole_impl_targets: a dot-less callee qn
+    # (H) has no interface component, and a mapped sole implementer that neither
+    # (H) defines nor inherits the method offers no concrete target -- both
+    # (H) return empty rather than fabricating an edge.
+    registry = FunctionRegistryTrie()
+    registry["m.Svc.run"] = NodeType.METHOD
+    resolver = CallResolver(
+        registry,
+        MagicMock(),
+        MagicMock(),
+        {},
+        interface_implementers={"m.Svc": {"m.Impl"}},
+    )
+    assert resolver.interface_sole_impl_targets("bare") == set()
+    assert resolver.interface_sole_impl_targets("m.Svc.run") == set()
 
 
 def test_cross_file_interface_field_keeps_interface_edge(tmp_path: Path) -> None:

--- a/codebase_rag/tests/test_interface_dispatch_single_impl.py
+++ b/codebase_rag/tests/test_interface_dispatch_single_impl.py
@@ -12,9 +12,12 @@ def _calls(tmp_path: Path, name: str, body: str) -> set[tuple[str, str]]:
 def test_single_implementer_interface_call_dispatches_to_concrete(
     tmp_path: Path,
 ) -> None:
-    # (H) `s.run()` on an interface-typed receiver resolves to the interface method;
-    # (H) since Svc has exactly ONE implementer, redirect to the concrete SvcImpl.run
-    # (H) (the method that actually runs).
+    # (H) `s.run()` on an interface-typed receiver: the STATIC callee is the
+    # (H) interface method (removing its declaration breaks the call), and with
+    # (H) exactly ONE implementer the concrete SvcImpl.run is what runs. Emit
+    # (H) BOTH edges: interface-only binding orphaned the sole impl in Rust (no
+    # (H) OVERRIDES there), impl-only binding orphaned the interface stub
+    # (H) (gson's FieldNamingStrategy.translateName reported dead).
     calls = _calls(
         tmp_path,
         "Svc.java",
@@ -23,13 +26,12 @@ def test_single_implementer_interface_call_dispatches_to_concrete(
         "class Client { int use(Svc s) { return s.run(); } }\n",
     )
     assert ("proj.Svc.Client.use(Svc)", "proj.Svc.SvcImpl.run()") in calls
-    # (H) it must NOT stay on the interface method when a unique impl exists.
-    assert ("proj.Svc.Client.use(Svc)", "proj.Svc.Svc.run()") not in calls
+    assert ("proj.Svc.Client.use(Svc)", "proj.Svc.Svc.run()") in calls
 
 
 def test_multi_implementer_interface_call_stays_on_interface(tmp_path: Path) -> None:
-    # (H) Two implementers -> ambiguous -> no redirect; the call stays on the
-    # (H) interface method (no wrong-impl edge). Recall preserved.
+    # (H) Two implementers -> ambiguous -> no concrete fan-out; the call stays on
+    # (H) the interface method (no wrong-impl edge). Recall preserved.
     calls = _calls(
         tmp_path,
         "Svc.java",
@@ -44,8 +46,9 @@ def test_multi_implementer_interface_call_stays_on_interface(tmp_path: Path) -> 
 
 
 def test_rust_single_trait_impl_dispatches_to_concrete(tmp_path: Path) -> None:
-    # (H) The Rust `impl Trait for Type` path must also feed the implementers map, so
-    # (H) a trait-typed call redirects to the sole concrete impl.
+    # (H) The Rust `impl Trait for Type` path must also feed the implementers map:
+    # (H) a trait-typed call keeps its static edge to the trait method AND fans
+    # (H) out to the sole concrete impl (Rust has no OVERRIDES edges to revive it).
     calls = _calls(
         tmp_path,
         "m.rs",
@@ -55,3 +58,54 @@ def test_rust_single_trait_impl_dispatches_to_concrete(tmp_path: Path) -> None:
         "fn use_it(s: &dyn Svc) -> i32 { s.run() }\n",
     )
     assert ("proj.m.use_it", "proj.m.SvcImpl.run") in calls
+    assert ("proj.m.use_it", "proj.m.Svc.run") in calls
+
+
+def test_cross_file_interface_field_keeps_interface_edge(tmp_path: Path) -> None:
+    # (H) The gson regression shape: a field declared with a CROSS-FILE interface
+    # (H) type (`private final FieldNamingStrategy fieldNamingPolicy;`) whose sole
+    # (H) implementer is an enum. #665's deferred-inherits resolver keys
+    # (H) interface_implementers by the RESOLVED interface qn, so the sole-impl
+    # (H) redirect started firing and stole the interface stub's only CALLS edge
+    # (H) -> FieldNamingStrategy.translateName reported dead. Both edges must exist.
+    pkg = tmp_path / "com" / "example"
+    pkg.mkdir(parents=True)
+    (pkg / "Namer.java").write_text(
+        "package com.example;\n"
+        "public interface Namer { String translateName(String f); }\n",
+        encoding="utf-8",
+    )
+    (pkg / "NamerPolicy.java").write_text(
+        "package com.example;\n"
+        "public enum NamerPolicy implements Namer {\n"
+        "  IDENTITY {\n"
+        "    @Override public String translateName(String f) { return f; }\n"
+        "  };\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    (pkg / "Factory.java").write_text(
+        "package com.example;\n"
+        "public final class Factory {\n"
+        "  private final Namer fieldNamingPolicy;\n"
+        "  public Factory(Namer fieldNamingPolicy) {\n"
+        "    this.fieldNamingPolicy = fieldNamingPolicy;\n"
+        "  }\n"
+        "  private String getFieldName(String f) {\n"
+        "    return fieldNamingPolicy.translateName(f);\n"
+        "  }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    ingestor = _capture(tmp_path, "proj")
+    calls = {
+        (str(f), str(t)) for _fl, f, rel, _tl, t in ingestor.rels if rel == "CALLS"
+    }
+    assert (
+        "proj.com.example.Factory.Factory.getFieldName(String)",
+        "proj.com.example.Namer.Namer.translateName(String)",
+    ) in calls, sorted(t for _f, t in calls if "translateName" in t)
+    assert (
+        "proj.com.example.Factory.Factory.getFieldName(String)",
+        "proj.com.example.NamerPolicy.NamerPolicy.translateName(String)",
+    ) in calls, sorted(t for _f, t in calls if "translateName" in t)

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.270"
+version = "0.0.271"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Fixes the dead-code regression introduced by #665: interface method declarations (gson's `FieldNamingStrategy.translateName`, `ToNumberStrategy.readNumber`, `TypeAdapters.FactorySupplier.get`, `InstanceCreator.createInstance`, `TypeAdapterFactory.create`) reported dead because the single-implementer dispatch redirect REPLACED the interface-method callee with the concrete impl, stealing the interface stub's only CALLS edge.

## Root cause

`_redirect_protocol_method` rewrote a resolved interface-method target to its sole implementer's method. Before #665 this rarely fired: `interface_implementers` was keyed by module-anchored guess qns recorded at class-ingest time, which did not match the resolved interface qn. #665's `resolve_deferred_inherits` (correctly) records the RESOLVED interface qn, so the redirect started firing, and OVERRIDES expansion only walks interface -> impl, never backwards, leaving the interface declaration unreachable.

The interface method is the STATIC callee: removing its declaration breaks the call, so it can never be dead while the call exists.

## Fix

Both edges are real, so emit both:

- The resolved callee stays on the interface/trait method (the static target), consistent with the existing >1-implementer design.
- The sole concrete impl becomes an additional fan-out edge (`interface_sole_impl_targets`) in `call_processor`, next to the Go build-variant and JS twin fan-outs. This keeps call-graph accuracy AND keeps Rust sole-impl trait methods alive (Rust has no OVERRIDES edges, so an interface-only binding would have orphaned them).
- The Python Protocol redirect is untouched: a Protocol stub body never runs, so replacement remains correct there.

## Verification

- Red -> green in history: interface-edge assertions on the Java single-impl, Rust trait, and cross-file enum-implementer (exact gson shape) fixtures fail on main, pass with the fix.
- gson dead-code eval: 42 -> 37, exactly the five interface stubs revived; remaining 37 are the known genuine categories (private-utility constructors, caliper benchmark methods, R8 shrinker fixtures).
- mini-redis 0, gin 0 (unchanged; no cross-language regression).
- Full suite: 4693 passed via `pytest -n auto`; ruff clean; ty at the 352-diagnostic baseline.
