### PR TITLE
fix: emit OVERRIDES edges for interface and trait implementations

### DIFF
--- a/codebase_rag/parsers/class_ingest/method_override.py
+++ b/codebase_rag/parsers/class_ingest/method_override.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections import deque
+from itertools import chain
 from typing import TYPE_CHECKING
 
 from loguru import logger
@@ -48,11 +49,13 @@ def _invert_implementers(
     # (H) class_inheritance holds only superclasses (an `implements` clause or a
     # (H) Rust `impl Trait for Type` never enters it), so the override walk needs
     # (H) the implementer -> interfaces direction too, or no interface/trait
-    # (H) implementation ever gets an OVERRIDES edge. Sorted outer iteration:
-    # (H) the map's sets are hash-ordered and edge emission must be deterministic.
+    # (H) implementation ever gets an OVERRIDES edge. Both loops sorted: the
+    # (H) map and its sets are hash-ordered and edge emission must be
+    # (H) deterministic (each implementer's interface list follows the outer
+    # (H) sort; the inner sort makes the dict order deterministic too).
     inverted: dict[str, list[str]] = {}
     for interface_qn, implementer_qns in sorted(interface_implementers.items()):
-        for implementer_qn in implementer_qns:
+        for implementer_qn in sorted(implementer_qns):
             inverted.setdefault(implementer_qn, []).append(interface_qn)
     return inverted
 
@@ -159,10 +162,11 @@ def check_method_overrides(
 
         # (H) Superclasses first: when both a base class and an interface declare
         # (H) the method, the edge lands on the base, matching Java resolution.
-        parents = class_inheritance.get(current_class, []) + implemented.get(
-            current_class, []
-        )
-        for parent_class_qn in parents:
+        # (H) chain() instead of list concat: this runs per BFS node per method.
+        for parent_class_qn in chain(
+            class_inheritance.get(current_class, ()),
+            implemented.get(current_class, ()),
+        ):
             if parent_class_qn not in visited:
                 visited.add(parent_class_qn)
                 queue.append(parent_class_qn)

--- a/codebase_rag/parsers/class_ingest/method_override.py
+++ b/codebase_rag/parsers/class_ingest/method_override.py
@@ -18,9 +18,11 @@ def process_all_method_overrides(
     function_registry: FunctionRegistryTrieProtocol,
     class_inheritance: dict[str, list[str]],
     ingestor: IngestorProtocol,
+    interface_implementers: dict[str, set[str]] | None = None,
 ) -> None:
     logger.info(logs.CLASS_PASS_4)
 
+    implemented_interfaces = _invert_implementers(interface_implementers or {})
     for method_qn in function_registry.keys():
         if (
             function_registry[method_qn] == NodeType.METHOD
@@ -36,7 +38,23 @@ def process_all_method_overrides(
                     function_registry,
                     class_inheritance,
                     ingestor,
+                    implemented_interfaces,
                 )
+
+
+def _invert_implementers(
+    interface_implementers: dict[str, set[str]],
+) -> dict[str, list[str]]:
+    # (H) class_inheritance holds only superclasses (an `implements` clause or a
+    # (H) Rust `impl Trait for Type` never enters it), so the override walk needs
+    # (H) the implementer -> interfaces direction too, or no interface/trait
+    # (H) implementation ever gets an OVERRIDES edge. Sorted outer iteration:
+    # (H) the map's sets are hash-ordered and edge emission must be deterministic.
+    inverted: dict[str, list[str]] = {}
+    for interface_qn, implementer_qns in sorted(interface_implementers.items()):
+        for implementer_qn in implementer_qns:
+            inverted.setdefault(implementer_qn, []).append(interface_qn)
+    return inverted
 
 
 def _signature_arity(method_name: str) -> int | None:
@@ -98,8 +116,10 @@ def check_method_overrides(
     function_registry: FunctionRegistryTrieProtocol,
     class_inheritance: dict[str, list[str]],
     ingestor: IngestorProtocol,
+    implemented_interfaces: dict[str, list[str]] | None = None,
 ) -> None:
-    if class_qn not in class_inheritance:
+    implemented = implemented_interfaces or {}
+    if class_qn not in class_inheritance and class_qn not in implemented:
         return
 
     queue = deque([class_qn])
@@ -137,8 +157,12 @@ def check_method_overrides(
                 )
                 return
 
-        if current_class in class_inheritance:
-            for parent_class_qn in class_inheritance[current_class]:
-                if parent_class_qn not in visited:
-                    visited.add(parent_class_qn)
-                    queue.append(parent_class_qn)
+        # (H) Superclasses first: when both a base class and an interface declare
+        # (H) the method, the edge lands on the base, matching Java resolution.
+        parents = class_inheritance.get(current_class, []) + implemented.get(
+            current_class, []
+        )
+        for parent_class_qn in parents:
+            if parent_class_qn not in visited:
+                visited.add(parent_class_qn)
+                queue.append(parent_class_qn)

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -1020,6 +1020,7 @@ class ClassIngestMixin:
             self.function_registry,
             self.class_inheritance,
             self.ingestor,
+            self.interface_implementers,
         )
         self._resolve_java_anon_overrides()
 

--- a/codebase_rag/tests/test_implements_overrides.py
+++ b/codebase_rag/tests/test_implements_overrides.py
@@ -1,0 +1,125 @@
+# (H) An `implements`/trait-impl relationship never reached class_inheritance
+# (H) (relationships.py stores only the superclass; interfaces feed
+# (H) interface_implementers and the IMPLEMENTS edge), so Pass-4 override
+# (H) detection walked past every interface and NO interface/trait
+# (H) implementation ever got an OVERRIDES edge -- named Java classes, enum
+# (H) constant bodies, and Rust trait impls alike (anonymous classes had their
+# (H) own dedicated pass). Dead-code override expansion walks overridden ->
+# (H) overriders, so with >1 implementers (no sole-impl CALLS fan-out) a live
+# (H) interface/trait method revived nothing and non-public impl methods
+# (H) (Rust trait impls) reported dead. The override walk must include the
+# (H) implemented interfaces.
+from __future__ import annotations
+
+from pathlib import Path
+
+from evals.cgr_graph import _capture
+from evals.dead_code import cgr_dead_code, default_dead_code_config
+
+
+def _java_project(tmp_path: Path, files: dict[str, str]) -> Path:
+    root = tmp_path / "impls"
+    pkg = root / "com" / "example"
+    pkg.mkdir(parents=True)
+    for name, body in files.items():
+        (pkg / name).write_text(f"package com.example;\n{body}", encoding="utf-8")
+    return root
+
+
+def _overrides(root: Path) -> set[tuple[str, str]]:
+    ingestor = _capture(root, "proj")
+    return {
+        (str(f), str(t)) for _fl, f, rel, _tl, t in ingestor.rels if rel == "OVERRIDES"
+    }
+
+
+NAMER = "public interface Namer { String translateName(String f); }\n"
+
+
+def test_java_class_implements_interface_gets_overrides_edge(tmp_path: Path) -> None:
+    # (H) The plain cross-file shape: the impl method must OVERRIDES the
+    # (H) interface method it implements, exactly as an `extends` override would.
+    overrides = _overrides(
+        _java_project(
+            tmp_path,
+            {
+                "Namer.java": NAMER,
+                "Other.java": (
+                    "public class OtherNamer implements Namer {\n"
+                    "  @Override public String translateName(String f)"
+                    " { return f; }\n"
+                    "}\n"
+                ),
+            },
+        )
+    )
+    assert (
+        "proj.com.example.Other.OtherNamer.translateName(String)",
+        "proj.com.example.Namer.Namer.translateName(String)",
+    ) in overrides, sorted(overrides)
+
+
+def test_java_enum_constant_body_override_gets_overrides_edge(tmp_path: Path) -> None:
+    # (H) Enum constant bodies hoist their methods to enum level (`P.m(Sig)` plus
+    # (H) `P.m(Sig)@line` duplicates); both hoisted variants must OVERRIDES the
+    # (H) interface method (the @line variant via the name+arity fallback).
+    overrides = _overrides(
+        _java_project(
+            tmp_path,
+            {
+                "Namer.java": NAMER,
+                "NamerPolicy.java": (
+                    "public enum NamerPolicy implements Namer {\n"
+                    "  IDENTITY {\n"
+                    "    @Override public String translateName(String f)"
+                    " { return f; }\n"
+                    "  },\n"
+                    "  UPPER {\n"
+                    "    @Override public String translateName(String f)"
+                    " { return f.toUpperCase(); }\n"
+                    "  };\n"
+                    "}\n"
+                ),
+            },
+        )
+    )
+    interface_qn = "proj.com.example.Namer.Namer.translateName(String)"
+    enum_prefix = "proj.com.example.NamerPolicy.NamerPolicy.translateName(String)"
+    assert (enum_prefix, interface_qn) in overrides, sorted(overrides)
+    assert any(
+        f.startswith(f"{enum_prefix}@") and t == interface_qn for f, t in overrides
+    ), sorted(overrides)
+
+
+RUST_TWO_IMPLS = (
+    "trait Svc { fn run(&self) -> i32; }\n"
+    "struct Zed;\n"
+    "impl Svc for Zed { fn run(&self) -> i32 { 1 } }\n"
+    "struct Zeta;\n"
+    "impl Svc for Zeta { fn run(&self) -> i32 { 2 } }\n"
+    "pub fn use_it(s: &dyn Svc) -> i32 { s.run() }\n"
+)
+
+
+def test_rust_trait_impl_gets_overrides_edge(tmp_path: Path) -> None:
+    # (H) `impl Svc for Zed` feeds the same implementers map, so each impl's
+    # (H) method must OVERRIDES the trait method regardless of impl count.
+    root = tmp_path / "rimpl"
+    root.mkdir()
+    (root / "m.rs").write_text(RUST_TWO_IMPLS, encoding="utf-8")
+    overrides = _overrides(root)
+    assert ("proj.m.Zed.run", "proj.m.Svc.run") in overrides, sorted(overrides)
+    assert ("proj.m.Zeta.run", "proj.m.Svc.run") in overrides, sorted(overrides)
+
+
+def test_rust_multi_impl_trait_methods_not_dead(tmp_path: Path) -> None:
+    # (H) The live false-positive class (mini-redis shape): the trait-typed call
+    # (H) binds to the trait method, the impls are non-pub (not exported roots)
+    # (H) and >1 (no sole-impl CALLS fan-out), so only OVERRIDES expansion from
+    # (H) the live trait method can keep them off the dead-code report.
+    root = tmp_path / "rdead"
+    root.mkdir()
+    (root / "m.rs").write_text(RUST_TWO_IMPLS, encoding="utf-8")
+    dead = cgr_dead_code(root, "proj", default_dead_code_config(False, False))
+    impl_dead = [d for d in dead if d.endswith(".run")]
+    assert not impl_dead, sorted(dead)

--- a/codebase_rag/tests/test_implements_overrides.py
+++ b/codebase_rag/tests/test_implements_overrides.py
@@ -12,7 +12,11 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import MagicMock
 
+from codebase_rag.graph_updater import FunctionRegistryTrie
+from codebase_rag.parsers.class_ingest.method_override import check_method_overrides
+from codebase_rag.types_defs import NodeType
 from evals.cgr_graph import _capture
 from evals.dead_code import cgr_dead_code, default_dead_code_config
 
@@ -123,3 +127,23 @@ def test_rust_multi_impl_trait_methods_not_dead(tmp_path: Path) -> None:
     dead = cgr_dead_code(root, "proj", default_dead_code_config(False, False))
     impl_dead = [d for d in dead if d.endswith(".run")]
     assert not impl_dead, sorted(dead)
+
+
+def test_guard_skips_method_of_unregistered_class() -> None:
+    # (H) A method whose class is in NEITHER map (a rehydrated class from an
+    # (H) unchanged file on an incremental run has no local entry) has no
+    # (H) hierarchy to walk; the guard must bail without emitting anything.
+    registry = FunctionRegistryTrie()
+    registry["m.Impl.run"] = NodeType.METHOD
+    ingestor = MagicMock()
+    check_method_overrides("m.Impl.run", "run", "m.Impl", registry, {}, ingestor)
+    ingestor.ensure_relationship_batch.assert_not_called()
+
+    # (H) The same class known ONLY as an implementer (empty class_inheritance)
+    # (H) must pass the guard and reach the interface method through the
+    # (H) implemented-interfaces side of the walk.
+    registry["m.Svc.run"] = NodeType.METHOD
+    check_method_overrides(
+        "m.Impl.run", "run", "m.Impl", registry, {}, ingestor, {"m.Impl": ["m.Svc"]}
+    )
+    ingestor.ensure_relationship_batch.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.271"
+version = "0.0.273"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Problem

No interface or trait implementation ever received an OVERRIDES edge. `class_inheritance` stores only superclasses (`relationships.py`); an `implements` clause and a Rust `impl Trait for Type` feed only `interface_implementers` and the IMPLEMENTS edge, so the Pass-4 override walk (`check_method_overrides`) never saw interfaces. Anonymous classes had their own dedicated pass and were unaffected, which made named classes, enum constant bodies, and Rust trait impls inconsistent with them.

Dead-code impact: override expansion walks overridden -> overriders, so a live interface/trait method revived nothing. Java impls are usually shielded because explicitly `public` methods are exported roots, but Rust trait-impl methods are not `pub`. With more than one implementer (no sole-impl CALLS fan-out from #676) they report dead even when the trait-typed call is live: the mini-redis "Rust traits" false-positive class.

```rust
trait Svc { fn run(&self) -> i32; }
struct Zed;  impl Svc for Zed  { fn run(&self) -> i32 { 1 } }
struct Zeta; impl Svc for Zeta { fn run(&self) -> i32 { 2 } }
pub fn use_it(s: &dyn Svc) -> i32 { s.run() }
// before: Zed.run and Zeta.run reported dead
```

## Fix

Invert `interface_implementers` (implementer -> interfaces) and include it in the Pass-4 override walk alongside `class_inheritance`, superclasses first so a method declared on both a base class and an interface keeps its edge on the base. Each impl method now gets `impl.m OVERRIDES interface.m`, including the hoisted `@line` variants of Java enum constant bodies (matched via the existing name+arity fallback).

## Validation

- RED -> GREEN in commit history: 4 new tests (Java class impl, Java enum constant bodies, Rust trait-impl edges, Rust multi-impl dead-code) all failed on main, all pass with the fix.
- Full suite: 4702 passed. ruff and formatting clean; ty at the 352 baseline.
- Dogfood: gson stays at exactly 37 dead (identical set, no false revivals), mini-redis and gin stay at 0.