### PR TITLE
fix(deps): patched grammar forks for comment-in-define declaration drop

### DIFF
--- a/codebase_rag/tests/test_macro_comment_function_capture.py
+++ b/codebase_rag/tests/test_macro_comment_function_capture.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import get_node_names, run_updater
+
+BISON_STYLE_MACRO = (
+    "#define FAIL(loc, msg)   \\\n"
+    "  do {                   \\\n"
+    "    handle(loc, msg);    \\\n"
+    "    /*YYERROR*/;         \\\n"
+    "  } while (0)\n"
+    "\n"
+    "void yyerror(int* loc, const char* msg) { }\n"
+)
+
+
+@pytest.fixture
+def c_macro_comment_project(temp_repo: Path) -> Path:
+    project_path = temp_repo / "c_macro_comment_project"
+    project_path.mkdir()
+    (project_path / "Makefile").write_text("all:\n\tgcc -o parser parser.c\n")
+    (project_path / "parser.c").write_text(BISON_STYLE_MACRO)
+    return project_path
+
+
+@pytest.fixture
+def cpp_macro_comment_project(temp_repo: Path) -> Path:
+    project_path = temp_repo / "cpp_macro_comment_project"
+    project_path.mkdir()
+    (project_path / "CMakeLists.txt").write_text(
+        "cmake_minimum_required(VERSION 3.10)\nproject(parser)\n"
+    )
+    (project_path / "parser.cpp").write_text(BISON_STYLE_MACRO)
+    return project_path
+
+
+def test_c_function_after_comment_bearing_macro_is_ingested(
+    c_macro_comment_project: Path,
+    mock_ingestor: MagicMock,
+) -> None:
+    run_updater(c_macro_comment_project, mock_ingestor, skip_if_missing="c")
+    func_names = get_node_names(mock_ingestor, cs.NodeLabel.FUNCTION)
+    assert any("yyerror" in name for name in func_names)
+
+
+def test_cpp_function_after_comment_bearing_macro_is_ingested(
+    cpp_macro_comment_project: Path,
+    mock_ingestor: MagicMock,
+) -> None:
+    run_updater(cpp_macro_comment_project, mock_ingestor, skip_if_missing="cpp")
+    func_names = get_node_names(mock_ingestor, cs.NodeLabel.FUNCTION)
+    assert any("yyerror" in name for name in func_names)

--- a/evals/README.md
+++ b/evals/README.md
@@ -674,18 +674,24 @@ directions:
   and bison's `api.prefix {jq_yy}` rename (`libclang` records `jq_yylex` after the
   `#define`; cgr resolves the same call under the textual name `yylex`).
 
-**The rest is a genuine cgr limitation, not the preprocessor:** in the
-bison-generated `parser.c`, tree-sitter produces 20 `ERROR` nodes, and the normal
-`yyerror` definition (a plain `void yyerror(...)` at `parser.c:406`) falls inside
-one. cgr therefore never registers `yyerror` as a function, so every call to it is
-unresolved. cgr silently drops real definitions that land inside a tree-sitter
-parse-error region on machine-generated code. The trigger was reduced to a
-`tree-sitter-c` grammar bug (a block comment inside a `#define` body breaks the
-parse and drops the following declaration, present through the latest 0.24.2);
-tracked in issue #555 and upstream as
-[tree-sitter-c #319](https://github.com/tree-sitter/tree-sitter-c/issues/319).
-It is rooted in the grammar, not in cgr's resolution logic, so it is reported
-here, not hidden.
+**The rest was a `tree-sitter-c` grammar bug, now fixed in cgr via patched
+forks:** in the bison-generated `parser.c`, tree-sitter produced 20 `ERROR`
+nodes, and the normal `yyerror` definition (a plain `void yyerror(...)` at
+`parser.c:406`) fell inside one, so cgr never registered `yyerror` as a function
+and every call to it was unresolved. The trigger was reduced to a block comment
+between two tokens of a `#define` value: `preproc_arg` is a single token whose
+regex stops before `/*`, but the grammar allowed only one value token, so the
+text after the comment had no rule to attach to. Tracked in issue #555 and
+upstream as
+[tree-sitter-c #319](https://github.com/tree-sitter/tree-sitter-c/issues/319)
+(open, unreviewed). Because upstream review is slow, cgr sources its grammars
+from patched forks ([tree-sitter-c](https://github.com/vitali87/tree-sitter-c)
+and [tree-sitter-cpp](https://github.com/vitali87/tree-sitter-cpp), pinned via
+`[tool.uv.sources]`) that change the value to `repeat($.preproc_arg)` so comment
+`extras` can sit between segments. With the patched grammar, `yyerror` is
+captured (`parser.c` ERROR count drops from 20 to 12; the remainder are
+attribute-macro constructs that only preprocessing can resolve). Drop the
+overrides once the fix lands upstream.
 
 ## Multi-language retrieval (C++) — C++ CALLS vs `libclang`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,13 @@ cgr = "codebase_rag.cli:app"
 [tool.uv]
 package = true
 
+# (H) Patched grammars: upstream tree-sitter-c drops declarations after a
+# (H) #define whose value embeds a block comment (issue #555). Our forks carry
+# (H) the repeat(preproc_arg) fix; drop these overrides once upstream releases it.
+[tool.uv.sources]
+tree-sitter-c = { git = "https://github.com/vitali87/tree-sitter-c", rev = "fa327ad98f847f8173fc46926be4165c7971f960" }
+tree-sitter-cpp = { git = "https://github.com/vitali87/tree-sitter-cpp", rev = "b4a7be2f62f36dd460a14b2d1728d42d81d2c486" }
+
 [tool.setuptools.packages.find]
 include = ["codebase_rag*", "codec*", "cgr*"]
 exclude = ["*.tests", "*.tests.*"]

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.271"
+version = "0.0.274"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -643,8 +643,8 @@ requires-dist = [
     { name = "torch", marker = "extra == 'semantic'", specifier = ">=2.6.0" },
     { name = "transformers", marker = "extra == 'semantic'", specifier = ">=4.0.0" },
     { name = "tree-sitter", specifier = "==0.25.2" },
-    { name = "tree-sitter-c", marker = "extra == 'treesitter-full'", specifier = ">=0.24.1" },
-    { name = "tree-sitter-cpp", marker = "extra == 'treesitter-full'", specifier = ">=0.23.0" },
+    { name = "tree-sitter-c", marker = "extra == 'treesitter-full'", git = "https://github.com/vitali87/tree-sitter-c?rev=fa327ad98f847f8173fc46926be4165c7971f960" },
+    { name = "tree-sitter-cpp", marker = "extra == 'treesitter-full'", git = "https://github.com/vitali87/tree-sitter-cpp?rev=b4a7be2f62f36dd460a14b2d1728d42d81d2c486" },
     { name = "tree-sitter-go", marker = "extra == 'treesitter-full'", specifier = ">=0.23.4" },
     { name = "tree-sitter-java", marker = "extra == 'treesitter-full'", specifier = ">=0.23.5" },
     { name = "tree-sitter-javascript", marker = "extra == 'treesitter-full'", specifier = ">=0.23.1" },
@@ -4266,32 +4266,12 @@ wheels = [
 [[package]]
 name = "tree-sitter-c"
 version = "0.24.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f1/f5/ba8cd08d717277551ade8537d3aa2a94b907c6c6e0fbcf4e4d8b1c747fa3/tree_sitter_c-0.24.1.tar.gz", hash = "sha256:7d2d0cda0b8dda428c81440c1e94367f9f13548eedca3f49768bde66b1422ad6", size = 228014, upload-time = "2025-05-24T17:32:58.384Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/c7/c817be36306e457c2d36cc324789046390d9d8c555c38772429ffdb7d361/tree_sitter_c-0.24.1-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9c06ac26a1efdcc8b26a8a6970fbc6997c4071857359e5837d4c42892d45fe1e", size = 80940, upload-time = "2025-05-24T17:32:49.967Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/42/283909467290b24fdbc29bb32ee20e409a19a55002b43175d66d091ca1a4/tree_sitter_c-0.24.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:942bcd7cbecd810dcf7ca6f8f834391ebf0771a89479646d891ba4ca2fdfdc88", size = 86304, upload-time = "2025-05-24T17:32:51.271Z" },
-    { url = "https://files.pythonhosted.org/packages/94/53/fb4f61d4e5f15ec3da85774a4df8e58d3b5b73036cf167f0203b4dd9d158/tree_sitter_c-0.24.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9a74cfd7a11ca5a961fafd4d751892ee65acae667d2818968a6f079397d8d28c", size = 109996, upload-time = "2025-05-24T17:32:52.119Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/e8/fc541d34ee81c386c5453c2596c1763e8e9cd7cb0725f39d7dfa2276afa4/tree_sitter_c-0.24.1-cp310-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a6a807705a3978911dc7ee26a7ad36dcfacb6adfc13c190d496660ec9bd66707", size = 98137, upload-time = "2025-05-24T17:32:53.361Z" },
-    { url = "https://files.pythonhosted.org/packages/32/c6/d0563319cae0d5b5780a92e2806074b24afea2a07aa4c10599b899bda3ec/tree_sitter_c-0.24.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:789781afcb710df34144f7e2a20cd80e325114b9119e3956c6bd1dd2d365df98", size = 94148, upload-time = "2025-05-24T17:32:54.855Z" },
-    { url = "https://files.pythonhosted.org/packages/50/5a/6361df7f3fa2310c53a0d26b4702a261c332da16fa9d801e381e3a86e25f/tree_sitter_c-0.24.1-cp310-abi3-win_amd64.whl", hash = "sha256:290bff0f9c79c966496ebae45042f77543e6e4aea725f40587a8611d566231a8", size = 84703, upload-time = "2025-05-24T17:32:56.084Z" },
-    { url = "https://files.pythonhosted.org/packages/22/6a/210a302e8025ac492cbaea58d3720d66b7d8034c5d747ac5e4d2d235aa25/tree_sitter_c-0.24.1-cp310-abi3-win_arm64.whl", hash = "sha256:d46bbda06f838c2dcb91daf767813671fd366b49ad84ff37db702129267b46e1", size = 82715, upload-time = "2025-05-24T17:32:57.248Z" },
-]
+source = { git = "https://github.com/vitali87/tree-sitter-c?rev=fa327ad98f847f8173fc46926be4165c7971f960#fa327ad98f847f8173fc46926be4165c7971f960" }
 
 [[package]]
 name = "tree-sitter-cpp"
 version = "0.23.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/20/2c/4dd63d705a8933543cad9b92ff31be849b164fec91a6eb63475ebc9ce668/tree_sitter_cpp-0.23.4.tar.gz", hash = "sha256:6a59c4cebb1ad1dc2e8d586cf8a72b39d21b8108b7b139d089719e81a339e41d", size = 940358, upload-time = "2024-11-11T06:59:24.934Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/ac/11d56670f7b048362db872ca866fd00ba2002a322ab179f047b7c0fb2910/tree_sitter_cpp-0.23.4-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:aacb1759f0efd9dbc25bd8ee88184a340483018869f75412d9c3bc32c039a520", size = 287861, upload-time = "2024-11-11T06:59:15.005Z" },
-    { url = "https://files.pythonhosted.org/packages/12/1c/0337c016bdc00a77a3326d12f10ee836401dd28f27db6fd5b7734bfb21ed/tree_sitter_cpp-0.23.4-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:bc3c404d9f0cbd87951213a85440afbf4c31e718f8d907fa9ee12bea4b8d276f", size = 315513, upload-time = "2024-11-11T06:59:16.679Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/7b/dd38c049b10ed7fda118b903a1d28a8b55a36b98c30606ef90e8f374c6de/tree_sitter_cpp-0.23.4-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ccc43ddf1279d5d5a4ef190373f4cb16522801bec4492bcd4754edf2aeba2b7b", size = 334813, upload-time = "2024-11-11T06:59:18.253Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/4d/23e390234d2acd351f5563b1079c515d7c1fe13ddb7392cee543be74dda3/tree_sitter_cpp-0.23.4-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:773d2cafc08bbc0f998687fa33f42f378c1a371cdb582870c4d13abb06092706", size = 316110, upload-time = "2024-11-11T06:59:19.823Z" },
-    { url = "https://files.pythonhosted.org/packages/32/c7/b94a7e0e803af9d3bd4608fb4f0cfb2e9e233abaf0a38c928bfb0b1a025d/tree_sitter_cpp-0.23.4-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:247d127f0eb6574b0f6b30c0151e0bd0774e2e7acf9c558bdf9fbb8adc2e80c0", size = 308242, upload-time = "2024-11-11T06:59:21.466Z" },
-    { url = "https://files.pythonhosted.org/packages/37/7e/909e52b3dec09c475140b0e175511e275d0d00ba2dbd7c68102d377ae0f6/tree_sitter_cpp-0.23.4-cp39-abi3-win_amd64.whl", hash = "sha256:68606a45bea92669d155399e1239f771a7767d8683cd8f8e30e7d813107030ca", size = 290997, upload-time = "2024-11-11T06:59:22.432Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/6a/65435d4d1f4c735be7ffe52d7c2e7b8a7f7c2790343a2719c60c548611c8/tree_sitter_cpp-0.23.4-cp39-abi3-win_arm64.whl", hash = "sha256:712f84f18be94cbe2a148fa4fdf40fcf4a8c25a8f7670efb9f8a47ddec2fc281", size = 288203, upload-time = "2024-11-11T06:59:23.404Z" },
-]
+source = { git = "https://github.com/vitali87/tree-sitter-cpp?rev=b4a7be2f62f36dd460a14b2d1728d42d81d2c486#b4a7be2f62f36dd460a14b2d1728d42d81d2c486" }
 
 [[package]]
 name = "tree-sitter-go"


### PR DESCRIPTION
## Summary

tree-sitter-c drops real declarations that follow a `#define` whose value embeds a block comment (issue #555, upstream [tree-sitter-c#319](https://github.com/tree-sitter/tree-sitter-c/issues/319)). The trigger is token, comment, token inside a macro value: `preproc_arg` is a single token whose regex stops before `/*`, and the grammar allows only one value token, so the text after the comment has no rule to attach to. With the common bison `do { ... /*YYERROR*/; } while (0)` shape, error recovery turns the trailing `} while (0)` into a real `while_statement` that consumes the next top-level declaration, which is how `yyerror` vanishes from every bison-generated parser. tree-sitter-cpp inherits the identical bug through the shared C grammar.

Upstream review is slow, so cgr now sources both grammars from patched forks pinned by commit in `[tool.uv.sources]`:

* [vitali87/tree-sitter-c@fa327ad](https://github.com/vitali87/tree-sitter-c/commit/fa327ad98f847f8173fc46926be4165c7971f960), branch `fix/preproc-arg-embedded-comment-0.24.1`: the v0.24.1 release plus a one-line-per-site grammar change, `optional($.preproc_arg)` to `repeat($.preproc_arg)` at the three value/argument sites, so comment `extras` can sit between value segments. Regenerated with the same CLI line as the tag (0.25.4) and carrying a new corpus test; all 86 corpus tests pass.
* [vitali87/tree-sitter-cpp@b4a7be2](https://github.com/vitali87/tree-sitter-cpp/commit/b4a7be2f62f36dd460a14b2d1728d42d81d2c486), branch `fix/preproc-arg-embedded-comment-0.23.4`: the v0.23.4 release regenerated against a 0.23.1-based patched C grammar (matching the lockfile pin of the tag), with a corpus test; all 199 corpus tests pass.

Both forks are based on the exact release tags cgr already pinned, not on upstream master, so the only behavioral delta versus the previous wheels is the fix. A first attempt based on master regressed three C++20 module tests because master carries unreleased grammar changes; the tag-based rebuild keeps the full suite green. The overrides are documented in `pyproject.toml` for removal once upstream lands the fix.

## TDD

The first commit adds the failing tests: C and C++ projects containing a bison-style macro with an embedded `/*YYERROR*/` comment followed by `void yyerror(...)`, asserting the function node is ingested. Both fail on the pinned PyPI grammars and pass with the forks.

## Validation

* Full suite: 4711 passed, 10 skipped (environment), zero failures.
* `ruff check` and `ruff format` clean; `ty` at the 352 baseline.
* Real-world check on jq's bison-generated `parser.c`: `yyerror` at line 406 is now a proper `function_definition`; ERROR nodes drop from 20 to 12, and the remainder are attribute-macro constructs that only preprocessing can resolve (the documented libclang frontend territory).
* `evals/README.md` updated where the limitation was documented.

Refs #555