### PR TITLE
fix(rust): type free-function factory results from recorded return types

### DIFF
--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -20,8 +20,11 @@ _QN_SPLIT_CACHE: dict[str, tuple[list[str], int]] = {}
 _CHAIN_OPEN_BRACKETS = "([{"
 _CHAIN_CLOSE_BRACKETS = ")]}"
 # (H) Node labels a Rust receiver type name may resolve to: a struct (Class), an
-# (H) enum, or a type alias -- all can carry impl methods.
-_RS_TYPE_NODE_TYPES = frozenset({NodeType.CLASS, NodeType.ENUM, NodeType.TYPE})
+# (H) enum, a type alias, or a trait (Interface, when the receiver is typed to a
+# (H) `dyn`/`impl` trait or a trait-returning factory) -- all can carry methods.
+_RS_TYPE_NODE_TYPES = frozenset(
+    {NodeType.CLASS, NodeType.ENUM, NodeType.TYPE, NodeType.INTERFACE}
+)
 
 
 def _split_receiver_chain(expr: str) -> list[str]:

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -252,6 +252,14 @@ class FunctionIngestMixin:
             ):
                 self.method_return_types[resolution.qualified_name] = return_type
 
+            # (H) Same for a free Rust fn (impl methods are recorded in class
+            # (H) ingest): a call-bound local (`let s = make()`) types from
+            # (H) this map. No impl target here, so a `Self` return stays None.
+            if language == cs.SupportedLanguage.RUST and (
+                return_type := rs_utils.extract_return_type_name(func_node, None)
+            ):
+                self.method_return_types[resolution.qualified_name] = return_type
+
     def _function_span_claimed(self, module_qn: str, func_node: Node) -> bool:
         # (H) A span is claimed when a pass recorded THIS function node's
         # (H) location; the column in the key keeps a same-line neighbour's

--- a/codebase_rag/parsers/rs/type_inference.py
+++ b/codebase_rag/parsers/rs/type_inference.py
@@ -215,7 +215,13 @@ class RustTypeInferenceEngine:
         name = safe_decode_text(pattern)
         if not name:
             return
-        if segments := self._callee_chain_segments(self._unwrap_try(value)):
+        value_expr = self._unwrap_try(value)
+        if segments := self._callee_chain_segments(value_expr):
+            # (H) A single bare identifier is a move or fn-pointer binding
+            # (H) (`let f = make;`), not a call: `f` holds the function itself,
+            # (H) not a value of its return type. Only an invoked base counts.
+            if len(segments) == 1 and value_expr.type not in cs.RS_CALL_OR_GENERIC_FN:
+                return
             bindings.append((name, segments))
 
     def _callee_chain_segments(self, node: Node) -> list[str] | None:

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -265,19 +265,13 @@ class TypeInferenceEngine:
         # (H)   ['self','shared','state','lock','unwrap'] -> base local self (Db),
         # (H)     field shared (Arc<Shared>->Shared), field state (Mutex<State>, guard
         # (H)     inner State), lock unwraps the guard -> State, unwrap identity -> State.
-        # (H) The base is a typed local (self/var) when present in var_types, else a
-        # (H) free fn called by bare name (`let s = make()`), else a type name. Each
-        # (H) hop tries: guard-unwrap (a guard accessor right after a guard-wrapped
-        # (H) field) -> field-type -> method-return -> identity.
+        # (H) Each hop tries: guard-unwrap (a guard accessor right after a guard-
+        # (H) wrapped field) -> field-type -> method-return -> identity.
         if not segments:
             return None
-        current_type: str | None = var_types.get(
-            segments[0]
-        ) or self._rust_free_fn_return_type(segments[0], module_qn)
+        current_type = self._rust_chain_base_type(segments, module_qn, var_types)
         if current_type is None:
-            if len(segments) < 2:
-                return None
-            current_type = segments[0]
+            return None
         # (H) Inner type of the guard-wrapped field just hopped through, pending a guard
         # (H) accessor to unwrap it (None otherwise).
         guard_inner: str | None = None
@@ -305,6 +299,20 @@ class TypeInferenceEngine:
             elif hop not in cs.RS_IDENTITY_METHODS:
                 return None
         return current_type
+
+    def _rust_chain_base_type(
+        self, segments: list[str], module_qn: str, var_types: dict[str, str]
+    ) -> str | None:
+        # (H) Base of a flattened chain: a typed local (self/var) when present in
+        # (H) var_types, else a free fn called by bare name (`let s = make()`),
+        # (H) else the segment itself as a type name -- only useful when there are
+        # (H) hops to walk, so a bare unresolved name types nothing.
+        base = var_types.get(segments[0]) or self._rust_free_fn_return_type(
+            segments[0], module_qn
+        )
+        if base is not None:
+            return base
+        return segments[0] if len(segments) > 1 else None
 
     def _resolve_rust_type_qn(self, type_name: str, module_qn: str) -> str:
         # (H) Resolve a Rust type name to its class-node qn, honoring imports: a `use`

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -266,11 +266,18 @@ class TypeInferenceEngine:
         # (H)     field shared (Arc<Shared>->Shared), field state (Mutex<State>, guard
         # (H)     inner State), lock unwraps the guard -> State, unwrap identity -> State.
         # (H) The base is a typed local (self/var) when present in var_types, else a
-        # (H) type name. Each hop tries: guard-unwrap (a guard accessor right after a
-        # (H) guard-wrapped field) -> field-type -> method-return -> identity.
-        if len(segments) < 2:
+        # (H) free fn called by bare name (`let s = make()`), else a type name. Each
+        # (H) hop tries: guard-unwrap (a guard accessor right after a guard-wrapped
+        # (H) field) -> field-type -> method-return -> identity.
+        if not segments:
             return None
-        current_type: str | None = var_types.get(segments[0]) or segments[0]
+        current_type: str | None = var_types.get(
+            segments[0]
+        ) or self._rust_free_fn_return_type(segments[0], module_qn)
+        if current_type is None:
+            if len(segments) < 2:
+                return None
+            current_type = segments[0]
         # (H) Inner type of the guard-wrapped field just hopped through, pending a guard
         # (H) accessor to unwrap it (None otherwise).
         guard_inner: str | None = None
@@ -314,7 +321,33 @@ class TypeInferenceEngine:
             return self._resolve_rust_import_path(target)
         return self._resolve_class_name(type_name, module_qn) or type_name
 
-    def _resolve_rust_import_path(self, target: str) -> str:
+    def _rust_free_fn_return_type(self, name: str, module_qn: str) -> str | None:
+        # (H) Return type of a free fn called by bare name: same-module first, then
+        # (H) a `use`-imported fn resolved through its raw `::` path. A type-name
+        # (H) base (`Maker::make`) misses here because a bare type is never a
+        # (H) recorded key (fns and types share a name only across Rust's separate
+        # (H) fn/type namespaces, which idiomatic code never does).
+        if return_type := self.method_return_types.get(
+            f"{module_qn}{cs.SEPARATOR_DOT}{name}"
+        ):
+            return return_type
+        import_map = self.import_processor.import_mapping.get(module_qn, {})
+        if (target := import_map.get(name)) and cs.SEPARATOR_DOUBLE_COLON in target:
+            fn_qn = self._resolve_rust_import_path(
+                target, node_types=(NodeType.FUNCTION,)
+            )
+            return self.method_return_types.get(fn_qn)
+        return None
+
+    def _resolve_rust_import_path(
+        self,
+        target: str,
+        node_types: tuple[NodeType, ...] = (
+            NodeType.CLASS,
+            NodeType.ENUM,
+            NodeType.TYPE,
+        ),
+    ) -> str:
         # (H) Map a `use` target (`crate::cmd::Command`) to its registry qn. Prefer the
         # (H) candidate whose qn ends with the import's module path (`.cmd.Command`),
         # (H) so two same-named types in different modules disambiguate by path; fall
@@ -331,8 +364,7 @@ class TypeInferenceEngine:
         candidates = [
             qn
             for qn in self.function_registry.find_ending_with(simple)
-            if self.function_registry.get(qn)
-            in (NodeType.CLASS, NodeType.ENUM, NodeType.TYPE)
+            if self.function_registry.get(qn) in node_types
         ]
         if not candidates:
             return target

--- a/codebase_rag/tests/test_rust_free_function_return_types.py
+++ b/codebase_rag/tests/test_rust_free_function_return_types.py
@@ -1,0 +1,108 @@
+# (H) Two adjacent gaps left open by the trait-object receiver fix: a free
+# (H) Rust fn's return type was never recorded in method_return_types (only
+# (H) impl methods were, in class ingest), and a bare `let s = make()`
+# (H) single-segment chain bailed out of call-return inference. Together they
+# (H) left a free-function factory's result untyped, so a call on it fell to
+# (H) the name-only trie fallback (or was dropped as external) instead of
+# (H) binding the trait method.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from tree_sitter import Language, Parser
+
+from codebase_rag import constants as cs
+from codebase_rag.parsers.rs import type_inference as rs_ti
+from codebase_rag.tests.conftest import run_updater
+from evals.dead_code import cgr_dead_code, default_dead_code_config
+
+try:
+    import tree_sitter_rust as tsrust
+
+    RUST_AVAILABLE = True
+except ImportError:
+    RUST_AVAILABLE = False
+
+TRAIT_AND_IMPLS = (
+    "trait Svc { fn run(&self) -> i32; }\n"
+    "struct Alpha;\n"
+    "impl Svc for Alpha { fn run(&self) -> i32 { 1 } }\n"
+    "struct Beta;\n"
+    "impl Svc for Beta { fn run(&self) -> i32 { 2 } }\n"
+)
+
+FREE_FN_FACTORY = TRAIT_AND_IMPLS + (
+    "pub fn make() -> Box<dyn Svc> { Box::new(Alpha) }\n"
+    "pub fn try_make() -> Result<Box<dyn Svc>, ()> { Ok(make()) }\n"
+    "pub fn use_made() -> i32 { let s = make(); s.run() }\n"
+    "pub fn use_tried() -> i32 { let s = try_make().unwrap(); s.run() }\n"
+)
+
+
+def _run_calls(
+    temp_repo: Path, mock_ingestor: MagicMock, files: dict[str, str]
+) -> set[tuple[str, str]]:
+    for name, source in files.items():
+        (temp_repo / name).write_text(source, encoding="utf-8")
+    run_updater(temp_repo, mock_ingestor, skip_if_missing="rust")
+    return {
+        (c.args[0][2], c.args[2][2])
+        for c in mock_ingestor.ensure_relationship_batch.call_args_list
+        if c.args[1] == cs.RelationshipType.CALLS and c.args[2][2].endswith(".run")
+    }
+
+
+@pytest.mark.parametrize("caller", ["use_made", "use_tried"])
+def test_free_fn_factory_result_binds_to_trait_method(
+    temp_repo: Path, mock_ingestor: MagicMock, caller: str
+) -> None:
+    calls = _run_calls(temp_repo, mock_ingestor, {"m.rs": FREE_FN_FACTORY})
+    bound = {callee for c, callee in calls if c.endswith(f".{caller}")}
+    assert bound == {f"{temp_repo.name}.m.Svc.run"}, sorted(calls)
+
+
+def test_imported_free_fn_factory_result_binds_to_trait_method(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) The factory lives in another module and is brought in by `use`; the
+    # (H) bare-name call must resolve through the import's `::` path to the
+    # (H) function's registry qn before the return-type lookup.
+    files = {
+        "factory.rs": TRAIT_AND_IMPLS
+        + "pub fn make() -> Box<dyn Svc> { Box::new(Alpha) }\n",
+        "m.rs": (
+            "use crate::factory::{make, Svc};\n"
+            "pub fn use_made() -> i32 { let s = make(); s.run() }\n"
+        ),
+    }
+    calls = _run_calls(temp_repo, mock_ingestor, files)
+    bound = {callee for c, callee in calls if c.endswith(".use_made")}
+    assert bound == {f"{temp_repo.name}.factory.Svc.run"}, sorted(calls)
+
+
+def test_free_fn_factory_keeps_all_impls_alive(tmp_path: Path) -> None:
+    root = tmp_path / "rfree"
+    root.mkdir()
+    (root / "m.rs").write_text(
+        TRAIT_AND_IMPLS
+        + "pub fn make() -> Box<dyn Svc> { Box::new(Alpha) }\n"
+        + "pub fn use_made() -> i32 { let s = make(); s.run() }\n",
+        encoding="utf-8",
+    )
+    dead = cgr_dead_code(root, "proj", default_dead_code_config(False, False))
+    assert not [d for d in dead if d.endswith(".run")], sorted(dead)
+
+
+@pytest.mark.skipif(not RUST_AVAILABLE, reason="tree-sitter-rust not installed")
+def test_bare_identifier_binding_is_not_a_call() -> None:
+    # (H) `let f = make;` is a move/fn-pointer binding, not a call: `f` holds
+    # (H) the function itself, not a value of its return type, so no chain
+    # (H) binding may be collected for it. Only an invoked base qualifies.
+    parser = Parser(Language(tsrust.language()))
+    src = b"fn user() { let f = make; let s = make(); }\n"
+    fn_node = parser.parse(src).root_node.children[0]
+    bindings = dict(rs_ti.RustTypeInferenceEngine().collect_call_var_bindings(fn_node))
+    assert "f" not in bindings, bindings
+    assert bindings.get("s") == ["make"]


### PR DESCRIPTION
## Problem

Two adjacent gaps left open by #679 meant a free-function trait-object factory still did not type its result:

1. A free Rust fn's return type was never recorded in `method_return_types`; only impl methods were (in class ingest). `fn make() -> Box<dyn Svc>` left no entry.
2. `_infer_rust_call_return_type` bailed on single-segment chains, so `let s = make()` could never be typed even with a recorded return type.

With `s` untyped, `s.run()` fell to the name-only trie fallback and its lexicographic tie-break bound an arbitrary same-named impl method (`Alpha.run`), leaving the trait method and the other impls reported dead.

Fixing those exposed a third defect on the cross-module path: `_RS_TYPE_NODE_TYPES` in the call resolver only matched `{Class, Enum, Type}`, so an imported trait-typed receiver (`Svc` is registered as `Interface`) resolved to nothing and `_receiver_type_is_external` suppressed the call edge entirely.

## Fix

- `function_ingest.py`: record a free Rust fn's return type after registration, mirroring the existing C++ block directly above it (`Self` stays unrecorded: no impl target).
- `type_inference.py`: resolve an untyped chain base as a free fn called by bare name (same module first, then a `use`-imported fn through its raw `::` path via `_resolve_rust_import_path`, now parameterized by node type), and stop bailing on single-segment chains.
- `rs/type_inference.py`: gate the binding collector so a single bare identifier (`let f = make;`, a move or fn-pointer binding) is not treated as a call; only an invoked base yields a value of its return type.
- `call_resolver.py`: add `Interface` to `_RS_TYPE_NODE_TYPES` so a trait-typed receiver resolves like any other Rust type that carries methods.

## Validation

RED first (commit `edcc8e1`, all 5 tests failing with the arbitrary `Alpha.run` binding), GREEN in `78a70b8`. Covered shapes: same-module `let s = make()`, `try_make().unwrap()` through Result stripping and identity hops, a `use`-imported factory in another module, dead-code keeping all impls alive, and the fn-pointer non-binding guard. Full suite 4730 passed, ruff and ty clean.