### PR TITLE
feat(cpp): hybrid frontend layering libclang macros and includes onto tree-sitter

### DIFF
--- a/codebase_rag/constants/languages.py
+++ b/codebase_rag/constants/languages.py
@@ -81,6 +81,7 @@ PKG_CONANFILE = "conanfile.txt"
 class CppFrontend(StrEnum):
     TREESITTER = "treesitter"
     LIBCLANG = "libclang"
+    HYBRID = "hybrid"
 
 
 # (H) JS/TS import specifier schemes that name genuinely external code (node

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -474,6 +474,9 @@ class GraphUpdater:
         # (H) Hybrid-mode macro uses awaiting a caller: attribution needs the
         # (H) tree-sitter definition spans, which exist only after Pass 2.
         self._pending_cpp_macro_calls: list[PendingMacroCall] = []
+        # (H) Files (re)parsed by Pass 2 this run: the only files whose
+        # (H) definition spans exist for hybrid macro-call attribution.
+        self._reparsed_file_keys: set[str] = set()
         # (H) Module qns read back from the graph on incremental runs; deferred
         # (H) import verification counts them as real internal targets.
         self._rehydrated_module_qns: set[str] = set()
@@ -556,6 +559,13 @@ class GraphUpdater:
         spans = self.factory.definition_processor.cpp_definition_spans
         emitted = 0
         for call in self._pending_cpp_macro_calls:
+            # (H) The frontend parses every TU each run, but an incremental
+            # (H) run records spans only for re-parsed files. An unchanged
+            # (H) file has no spans here AND already carries its caller->macro
+            # (H) edges in the graph, so resolving it would re-attribute
+            # (H) in-function uses to the Module.
+            if call.rel_path not in self._reparsed_file_keys:
+                continue
             containing = [
                 s
                 for s in spans.get(call.rel_path, ())
@@ -1164,6 +1174,9 @@ class GraphUpdater:
             file_key for _fp, file_key, is_new, _b in changed_entries if not is_new
         )
         captured_inbound = self._capture_inbound_edges(reindexed_keys)
+        self._reparsed_file_keys = {
+            file_key for _fp, file_key, _new, _b in changed_entries
+        }
 
         pre_parsed = self._pre_parse_changed_files(changed_entries)
 

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -19,6 +19,7 @@ from .parsers.cpp_frontend import (
     cpp_frontend_available,
     find_compile_commands,
     run_cpp_frontend,
+    run_cpp_frontend_hybrid,
 )
 from .parsers.factory import ProcessorFactory
 from .parsers.utils import sorted_captures
@@ -28,6 +29,7 @@ from .types_defs import (
     FunctionRegistry,
     LanguageQueries,
     NodeType,
+    PendingMacroCall,
     QualifiedName,
     ResultRow,
     SimpleNameLookup,
@@ -469,6 +471,9 @@ class GraphUpdater:
         self.skipped_because_in_sync = False
         self._collected_dir_mtimes: DirMtimesCache = {}
         self._cpp_frontend_covered: frozenset[str] = frozenset()
+        # (H) Hybrid-mode macro uses awaiting a caller: attribution needs the
+        # (H) tree-sitter definition spans, which exist only after Pass 2.
+        self._pending_cpp_macro_calls: list[PendingMacroCall] = []
         # (H) Module qns read back from the graph on incremental runs; deferred
         # (H) import verification counts them as real internal targets.
         self._rehydrated_module_qns: set[str] = set()
@@ -486,13 +491,20 @@ class GraphUpdater:
         )
 
     def _run_cpp_frontend(self) -> None:
-        # (H) Optional libclang C++ pre-pass: when CPP_FRONTEND=libclang and a
-        # (H) compile_commands.json is discoverable, emit macro-accurate C/C++
-        # (H) nodes/edges directly (tree-sitter cannot expand macros). Covered
-        # (H) files are then skipped by the tree-sitter definition pass. Missing
-        # (H) either condition falls back to tree-sitter with no change.
+        # (H) Optional libclang C++ pre-pass when a compile_commands.json is
+        # (H) discoverable. LIBCLANG: emit macro-accurate C/C++ nodes/edges
+        # (H) directly (tree-sitter cannot expand macros) and skip covered
+        # (H) files in the tree-sitter definition pass. HYBRID: tree-sitter
+        # (H) stays the backbone (nothing is skipped); libclang layers on only
+        # (H) macro Function nodes and #include IMPORTS, whose qns are
+        # (H) scheme-identical, and hands back macro uses for span attribution
+        # (H) after Pass 2. Missing either condition falls back to tree-sitter.
         self._cpp_frontend_covered = frozenset()
-        if settings.CPP_FRONTEND != cs.CppFrontend.LIBCLANG:
+        self._pending_cpp_macro_calls = []
+        if settings.CPP_FRONTEND not in (
+            cs.CppFrontend.LIBCLANG,
+            cs.CppFrontend.HYBRID,
+        ):
             return
         if not cpp_frontend_available():
             logger.warning(ls.CPP_FRONTEND_UNAVAILABLE)
@@ -502,6 +514,24 @@ class GraphUpdater:
             logger.warning(ls.CPP_FRONTEND_NO_COMPDB)
             return
         logger.info(ls.CPP_FRONTEND_RUNNING.format(path=compdb_dir))
+        if settings.CPP_FRONTEND == cs.CppFrontend.HYBRID:
+            self._pending_cpp_macro_calls = run_cpp_frontend_hybrid(
+                self.ingestor,
+                self.repo_path,
+                self.project_name,
+                compdb_dir,
+                function_registry=self.function_registry,
+                simple_name_lookup=self.simple_name_lookup,
+                structural_elements=(
+                    self.factory.structure_processor.structural_elements
+                ),
+            )
+            logger.info(
+                ls.CPP_FRONTEND_HYBRID_PENDING.format(
+                    count=len(self._pending_cpp_macro_calls)
+                )
+            )
+            return
         self._cpp_frontend_covered = run_cpp_frontend(
             self.ingestor,
             self.repo_path,
@@ -514,6 +544,37 @@ class GraphUpdater:
         logger.info(
             ls.CPP_FRONTEND_COVERED.format(count=len(self._cpp_frontend_covered))
         )
+
+    def _resolve_hybrid_macro_calls(self) -> None:
+        # (H) Attribute each hybrid macro use to the tightest enclosing
+        # (H) TREE-SITTER definition span (recorded during Pass 2), falling
+        # (H) back to the use site's Module -- the mirror of the libclang
+        # (H) frontend's own span resolution, but against the qn scheme the
+        # (H) rest of the graph actually uses.
+        if not self._pending_cpp_macro_calls:
+            return
+        spans = self.factory.definition_processor.cpp_definition_spans
+        emitted = 0
+        for call in self._pending_cpp_macro_calls:
+            containing = [
+                s
+                for s in spans.get(call.rel_path, ())
+                if s.start_line <= call.line <= s.end_line
+                and s.qualified_name != call.callee_qn
+            ]
+            if containing:
+                tightest = min(containing, key=lambda s: s.end_line - s.start_line)
+                caller_label, caller_qn = tightest.label, tightest.qualified_name
+            else:
+                caller_label = cs.NodeLabel.MODULE.value
+                caller_qn = call.fallback_module_qn
+            self.ingestor.ensure_relationship_batch(
+                (caller_label, cs.KEY_QUALIFIED_NAME, caller_qn),
+                cs.RelationshipType.CALLS,
+                (cs.NodeLabel.FUNCTION, cs.KEY_QUALIFIED_NAME, call.callee_qn),
+            )
+            emitted += 1
+        logger.info(ls.CPP_FRONTEND_MACRO_CALLS.format(count=emitted))
 
     def _is_dependency_file(self, file_name: str, filepath: Path) -> bool:
         return (
@@ -557,6 +618,11 @@ class GraphUpdater:
         contained = self.factory.definition_processor.resolve_deferred_cpp_containment()
         if contained:
             logger.info("Resolved {} deferred C++ nested containments", contained)
+
+        # (H) After resolve_deferred_cpp_methods: an out-of-class method's span
+        # (H) is recorded only once its class binding resolves, and a macro use
+        # (H) inside such a method must attribute to it, not the Module.
+        self._resolve_hybrid_macro_calls()
 
         go_methods = self.factory.definition_processor.resolve_deferred_go_methods()
         if go_methods:

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -616,10 +616,20 @@ class GraphUpdater:
         logger.info(ls.PASS_1_STRUCTURE)
         self.factory.structure_processor.identify_structure()
 
-        self._run_cpp_frontend()
+        # (H) LIBCLANG must run before Pass 2: _process_files consumes the
+        # (H) covered-file set to skip those files.
+        if settings.CPP_FRONTEND != cs.CppFrontend.HYBRID:
+            self._run_cpp_frontend()
 
         logger.info(ls.PASS_2_FILES)
         self._process_files(force=force)
+
+        # (H) HYBRID must run after Pass 2: an incremental run deletes each
+        # (H) changed file's Module subtree before re-parsing it, so macro
+        # (H) nodes and include IMPORTS emitted earlier would be deleted with
+        # (H) it and vanish until a forced rebuild.
+        if settings.CPP_FRONTEND == cs.CppFrontend.HYBRID:
+            self._run_cpp_frontend()
 
         corrected = self.factory.definition_processor.resolve_deferred_cpp_methods()
         if corrected:

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -15,12 +15,17 @@ PASS_3_CALLS = "--- Pass 3: Processing Function Calls from AST Cache ---"
 PASS_4_EMBEDDINGS = "--- Pass 4: Generating semantic embeddings ---"
 CPP_FRONTEND_RUNNING = "--- C/C++ libclang frontend: {path} ---"
 CPP_FRONTEND_UNAVAILABLE = (
-    "CPP_FRONTEND=libclang but libclang is unavailable; using tree-sitter"
+    "C/C++ libclang frontend enabled but libclang is unavailable; using tree-sitter"
 )
 CPP_FRONTEND_NO_COMPDB = (
-    "CPP_FRONTEND=libclang but no compile_commands.json found; using tree-sitter"
+    "C/C++ libclang frontend enabled but no compile_commands.json found; "
+    "using tree-sitter"
 )
 CPP_FRONTEND_COVERED = "C/C++ libclang frontend covered {count} file(s)"
+CPP_FRONTEND_HYBRID_PENDING = (
+    "C/C++ hybrid frontend queued {count} macro use(s) for span attribution"
+)
+CPP_FRONTEND_MACRO_CALLS = "Resolved {count} hybrid macro CALLS edge(s)"
 GRAPH_ALREADY_IN_SYNC = (
     "Knowledge graph already in sync (hash cache matches every file). Skipping passes."
 )

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -14,6 +14,7 @@ from ...config import settings
 from ...language_spec import LanguageSpec
 from ...types_defs import (
     ASTNode,
+    CppDefinitionSpan,
     DeferredCppInherit,
     DeferredInherit,
     FunctionLocation,
@@ -32,6 +33,7 @@ from ..rs import utils as rs_utils
 from ..utils import (
     function_span_key,
     ingest_method,
+    record_cpp_definition_span,
     safe_decode_text,
     sorted_captures,
 )
@@ -146,6 +148,7 @@ class ClassIngestMixin:
     method_return_types: dict[str, str]
     interface_implementers: dict[str, set[str]]
     function_locations: dict[FunctionSpanKey, FunctionLocation]
+    cpp_definition_spans: dict[str, list[CppDefinitionSpan]]
     _deferred_forward_decls: list[_DeferredForwardDecl]
     _deferred_parent_links: list[DeferredParentLink]
     _deferred_cpp_inherits: list[DeferredCppInherit]
@@ -915,6 +918,16 @@ class ClassIngestMixin:
                 repo_path=self.repo_path,
                 external_override_names=external_override_names,
             )
+            if ingested_qn is not None:
+                record_cpp_definition_span(
+                    self.cpp_definition_spans,
+                    language,
+                    file_path,
+                    self.repo_path,
+                    method_node,
+                    cs.NodeLabel.METHOD.value,
+                    ingested_qn,
+                )
             # (H) A Java method declared inside an anonymous class body
             # (H) (`new Base(){ @Override m(){} }`) is ingested here under the enclosing
             # (H) class but really overrides the anon class's base type. Record it so a

--- a/codebase_rag/parsers/cpp_frontend/__init__.py
+++ b/codebase_rag/parsers/cpp_frontend/__init__.py
@@ -2,6 +2,7 @@ from .frontend import (
     cpp_frontend_available,
     find_compile_commands,
     run_cpp_frontend,
+    run_cpp_frontend_hybrid,
 )
 from .qn import CppQnResolver, build_module_qn_map
 
@@ -11,4 +12,5 @@ __all__ = [
     "cpp_frontend_available",
     "find_compile_commands",
     "run_cpp_frontend",
+    "run_cpp_frontend_hybrid",
 ]

--- a/codebase_rag/parsers/cpp_frontend/constants.py
+++ b/codebase_rag/parsers/cpp_frontend/constants.py
@@ -34,6 +34,9 @@ METHOD_KIND_NAMES: frozenset[str] = frozenset(
 # (H) declarations (TS_TYPE_ALIAS_DECLARATION) and Go/Rust type decls.
 TYPE_KIND_NAMES: frozenset[str] = frozenset({"TYPE_ALIAS_DECL", "TYPEDEF_DECL"})
 
+TOKEN_LPAREN = "("
+TOKEN_RPAREN = ")"
+
 LABEL_MODULE = cs.NodeLabel.MODULE.value
 LABEL_CLASS = cs.NodeLabel.CLASS.value
 LABEL_FUNCTION = cs.NodeLabel.FUNCTION.value

--- a/codebase_rag/parsers/cpp_frontend/frontend.py
+++ b/codebase_rag/parsers/cpp_frontend/frontend.py
@@ -8,6 +8,7 @@ from ...services import IngestorProtocol
 from ...types_defs import (
     FunctionRegistryTrieProtocol,
     NodeType,
+    PendingMacroCall,
     PropertyDict,
     SimpleNameLookup,
 )
@@ -77,8 +78,16 @@ class _Collector:
         function_registry: FunctionRegistryTrieProtocol | None = None,
         simple_name_lookup: SimpleNameLookup | None = None,
         structural_elements: dict[Path, str | None] | None = None,
+        hybrid: bool = False,
     ) -> None:
         self.resolver = resolver
+        # (H) Hybrid mode: tree-sitter remains the backbone (its definitions
+        # (H) and CALLS stand), so collect ONLY the facts libclang is uniquely
+        # (H) right about -- macro definitions/uses and includes. Definition qns
+        # (H) diverge from tree-sitter's wherever macros hide namespaces, so no
+        # (H) definition node may be emitted; macro and Module qns are
+        # (H) scheme-identical (module_qn parity) and safe.
+        self.hybrid = hybrid
         self.function_registry = function_registry
         self.simple_name_lookup = simple_name_lookup
         self.structural_elements = structural_elements
@@ -137,14 +146,18 @@ class _Collector:
         # (H) Returns the scope its subtree should attribute calls to: the node's
         # (H) own (label, qn) when it is a function/method, else the unchanged
         # (H) enclosing scope.
-        if cursor.kind.name == fc.KIND_CALL_EXPR:
-            self._process_call(cursor, enclosing)
-            return None
         if cursor.kind.name == fc.KIND_MACRO_DEFINITION:
             self._process_macro_definition(cursor)
             return None
         if cursor.kind.name == fc.KIND_MACRO_INSTANTIATION:
             self._queue_macro_call(cursor)
+            return None
+        if self.hybrid:
+            # (H) Everything below emits definition nodes or CALLS with
+            # (H) libclang-scheme qns -- tree-sitter's territory in hybrid.
+            return None
+        if cursor.kind.name == fc.KIND_CALL_EXPR:
+            self._process_call(cursor, enclosing)
             return None
         label = _classify(cursor)
         if label is None or cursor.location.file is None:
@@ -471,8 +484,22 @@ class _Collector:
         if self.simple_name_lookup is not None and isinstance(name, str):
             self.simple_name_lookup[name].add(qn)
 
+    def pending_macro_calls(self) -> list[PendingMacroCall]:
+        # (H) Hybrid: callers are unknowable until the tree-sitter pass has
+        # (H) recorded its definition spans, so hand the uses back with the
+        # (H) Module fallback pre-resolved. A use site whose file has no
+        # (H) module qn (an ignored dir, e.g. build/) can never carry an edge.
+        pending: list[PendingMacroCall] = []
+        for rel, line, callee_qn, _file_name in sorted(self._pending_macro_calls):
+            module_qn = self.resolver.module_qn_for_rel(rel)
+            if module_qn is None:
+                continue
+            pending.append(PendingMacroCall(rel, line, callee_qn, module_qn))
+        return pending
+
     def flush(self, ingestor: IngestorProtocol) -> None:
-        self._resolve_macro_calls()
+        if not self.hybrid:
+            self._resolve_macro_calls()
         for module_qn, props in self.modules.items():
             ingestor.ensure_node_batch(fc.LABEL_MODULE, props)
             path = props[cs.KEY_PATH]
@@ -524,12 +551,50 @@ def run_cpp_frontend(
     ``structural_elements`` is supplied, each Module is linked to its parent via
     CONTAINS_MODULE (the full-replace path used by GraphUpdater).
     """
-    import clang.cindex as ci
-
-    resolver = CppQnResolver(repo_path, project_name)
     collector = _Collector(
-        resolver, function_registry, simple_name_lookup, structural_elements
+        CppQnResolver(repo_path, project_name),
+        function_registry,
+        simple_name_lookup,
+        structural_elements,
     )
+    _parse_and_collect(collector, compdb_dir)
+    collector.flush(ingestor)
+    return frozenset(collector.covered)
+
+
+def run_cpp_frontend_hybrid(
+    ingestor: IngestorProtocol,
+    repo_path: Path,
+    project_name: str,
+    compdb_dir: Path,
+    function_registry: FunctionRegistryTrieProtocol | None = None,
+    simple_name_lookup: SimpleNameLookup | None = None,
+    structural_elements: dict[Path, str | None] | None = None,
+) -> list[PendingMacroCall]:
+    """Layer libclang's macro and include facts onto a tree-sitter index.
+
+    Parses every translation unit like :func:`run_cpp_frontend` but emits ONLY
+    macro Function nodes (with their Module DEFINES) and ``#include`` IMPORTS
+    edges -- the facts whose qns are scheme-identical between libclang and
+    tree-sitter. No definition nodes and no CALLS are emitted: tree-sitter
+    remains the backbone and covers every file, so nothing is skipped. Returns
+    the macro uses it saw; the caller attributes each to the tightest enclosing
+    tree-sitter definition span after Pass 2.
+    """
+    collector = _Collector(
+        CppQnResolver(repo_path, project_name),
+        function_registry,
+        simple_name_lookup,
+        structural_elements,
+        hybrid=True,
+    )
+    _parse_and_collect(collector, compdb_dir)
+    collector.flush(ingestor)
+    return collector.pending_macro_calls()
+
+
+def _parse_and_collect(collector: _Collector, compdb_dir: Path) -> None:
+    import clang.cindex as ci
 
     db = ci.CompilationDatabase.fromDirectory(str(Path(compdb_dir).resolve()))
     index = ci.Index.create()
@@ -548,6 +613,3 @@ def run_cpp_frontend(
             continue
         _walk(tu.cursor, collector)
         collector.process_includes(tu)
-
-    collector.flush(ingestor)
-    return frozenset(collector.covered)

--- a/codebase_rag/parsers/cpp_frontend/frontend.py
+++ b/codebase_rag/parsers/cpp_frontend/frontend.py
@@ -504,6 +504,8 @@ class _Collector:
         # (H) Macros share one global, unscoped namespace, so match body
         # (H) identifiers by simple name; a name defined in several files gets
         # (H) an edge to each candidate (the duplicate-qn CALLS-to-both rule).
+        # (H) No self-loop is possible: a macro's collected refs exclude its
+        # (H) own spelling, and qn equality would imply name equality.
         macros_by_name: dict[str, list[str]] = {}
         for label, props, _ in self.nodes.values():
             name = props.get(cs.KEY_NAME)
@@ -517,8 +519,6 @@ class _Collector:
         for macro_qn, refs in self._macro_body_refs.items():
             for name in refs:
                 for target_qn in macros_by_name.get(name, ()):
-                    if target_qn == macro_qn:
-                        continue
                     self._add_edge(
                         cs.RelationshipType.CALLS,
                         fc.LABEL_FUNCTION,

--- a/codebase_rag/parsers/cpp_frontend/frontend.py
+++ b/codebase_rag/parsers/cpp_frontend/frontend.py
@@ -104,6 +104,12 @@ class _Collector:
         # (H) enclosing caller is only recoverable by span once ALL definitions
         # (H) are collected -- resolved at flush.
         self._pending_macro_calls: set[tuple[str, int, str, str]] = set()
+        # (H) {macro qn: identifier tokens in its definition body}: a macro
+        # (H) expanded only inside another macro's body is a NESTED expansion
+        # (H) the preprocessing record never reports, so the body reference is
+        # (H) the only evidence of use -- resolved to macro -> macro CALLS at
+        # (H) flush, once every macro node is known.
+        self._macro_body_refs: dict[str, set[str]] = {}
 
     def _node_props(self, cursor: Cursor, qn: str, name: str, rel: str) -> PropertyDict:
         return {
@@ -340,6 +346,16 @@ class _Collector:
             fc.LABEL_FUNCTION,
             qn,
         )
+        # (H) Body tokens after the macro's own name; parameters and keywords
+        # (H) also pass isidentifier but can never match a macro node's name
+        # (H) at flush, so no further filtering is needed here.
+        refs = {
+            t.spelling
+            for t in list(cursor.get_tokens())[1:]
+            if t.spelling.isidentifier() and t.spelling != cursor.spelling
+        }
+        if refs:
+            self._macro_body_refs.setdefault(qn, set()).update(refs)
 
     def _queue_macro_call(self, cursor: Cursor) -> None:
         # (H) MACRO_INSTANTIATION.referenced is the exact MACRO_DEFINITION
@@ -484,6 +500,33 @@ class _Collector:
         if self.simple_name_lookup is not None and isinstance(name, str):
             self.simple_name_lookup[name].add(qn)
 
+    def _resolve_macro_body_refs(self) -> None:
+        # (H) Macros share one global, unscoped namespace, so match body
+        # (H) identifiers by simple name; a name defined in several files gets
+        # (H) an edge to each candidate (the duplicate-qn CALLS-to-both rule).
+        macros_by_name: dict[str, list[str]] = {}
+        for label, props, _ in self.nodes.values():
+            name = props.get(cs.KEY_NAME)
+            qn = props.get(cs.KEY_QUALIFIED_NAME)
+            if (
+                props.get(cs.KEY_IS_MACRO)
+                and isinstance(name, str)
+                and isinstance(qn, str)
+            ):
+                macros_by_name.setdefault(name, []).append(qn)
+        for macro_qn, refs in self._macro_body_refs.items():
+            for name in refs:
+                for target_qn in macros_by_name.get(name, ()):
+                    if target_qn == macro_qn:
+                        continue
+                    self._add_edge(
+                        cs.RelationshipType.CALLS,
+                        fc.LABEL_FUNCTION,
+                        macro_qn,
+                        fc.LABEL_FUNCTION,
+                        target_qn,
+                    )
+
     def pending_macro_calls(self) -> list[PendingMacroCall]:
         # (H) Hybrid: callers are unknowable until the tree-sitter pass has
         # (H) recorded its definition spans, so hand the uses back with the
@@ -498,6 +541,7 @@ class _Collector:
         return pending
 
     def flush(self, ingestor: IngestorProtocol) -> None:
+        self._resolve_macro_body_refs()
         if not self.hybrid:
             self._resolve_macro_calls()
         for module_qn, props in self.modules.items():

--- a/codebase_rag/parsers/cpp_frontend/frontend.py
+++ b/codebase_rag/parsers/cpp_frontend/frontend.py
@@ -346,13 +346,35 @@ class _Collector:
             fc.LABEL_FUNCTION,
             qn,
         )
-        # (H) Body tokens after the macro's own name; parameters and keywords
-        # (H) also pass isidentifier but can never match a macro node's name
-        # (H) at flush, so no further filtering is needed here.
+        # (H) Body tokens after the macro's own name. A function-like macro
+        # (H) ('(' abutting the name -- the standard's distinction from an
+        # (H) object-like body that starts with a parenthesis) has its
+        # (H) parameter list skipped and those names excluded from the body:
+        # (H) a parameter is substituted by the caller's argument, so one
+        # (H) named like a real macro is not a reference to it.
+        tokens = list(cursor.get_tokens())
+        body_start = 1
+        params: set[str] = set()
+        name_end = tokens[0].extent.end
+        if (
+            len(tokens) > 1
+            and tokens[1].spelling == fc.TOKEN_LPAREN
+            and tokens[1].extent.start.line == name_end.line
+            and tokens[1].extent.start.column == name_end.column
+        ):
+            body_start = len(tokens)
+            for i, tok in enumerate(tokens[2:], start=2):
+                if tok.spelling == fc.TOKEN_RPAREN:
+                    body_start = i + 1
+                    break
+                if tok.spelling.isidentifier():
+                    params.add(tok.spelling)
         refs = {
             t.spelling
-            for t in list(cursor.get_tokens())[1:]
-            if t.spelling.isidentifier() and t.spelling != cursor.spelling
+            for t in tokens[body_start:]
+            if t.spelling.isidentifier()
+            and t.spelling != cursor.spelling
+            and t.spelling not in params
         }
         if refs:
             self._macro_body_refs.setdefault(qn, set()).update(refs)

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -11,6 +11,7 @@ from .. import logs as ls
 from ..parser_loader import COMBINED_FUNC_CLASS_IMPORT_QUERIES
 from ..types_defs import (
     ASTNode,
+    CppDefinitionSpan,
     DeferredCppInherit,
     DeferredInherit,
     FunctionLocation,
@@ -110,6 +111,10 @@ class DefinitionProcessor(
         # (H) the registered label/qn instead of re-deriving them structurally
         # (H) (the walks diverge on preprocessor-distorted class bodies).
         self.function_locations: dict[FunctionSpanKey, FunctionLocation] = {}
+        # (H) {rel path: [full line spans]} of every C/C++ function/method the
+        # (H) tree-sitter pass ingested; the hybrid C++ frontend's macro-use
+        # (H) CALLS resolve against these after Pass 2 (see CppDefinitionSpan).
+        self.cpp_definition_spans: dict[str, list[CppDefinitionSpan]] = {}
         self._deferred_cpp_inherits: list[DeferredCppInherit] = []
         # (H) Non-C++ INHERITS/IMPLEMENTS held back until every class is
         # (H) registered; resolve_deferred_inherits re-resolves the guesses.

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -12,6 +12,7 @@ from .. import logs as ls
 from ..language_spec import LANGUAGE_FQN_SPECS, LanguageSpec
 from ..types_defs import (
     ASTNode,
+    CppDefinitionSpan,
     DeferredCppInherit,
     DeferredParentLink,
     FunctionLocation,
@@ -33,6 +34,7 @@ from .utils import (
     get_function_captures,
     ingest_method,
     is_method_node,
+    record_cpp_definition_span,
     safe_decode_text,
 )
 
@@ -112,6 +114,7 @@ class _DeferredMethod(NamedTuple):
     namespace_path: str
     start_line: int
     start_col: int
+    end_line: int
 
 
 class _DeferredGoMethod(NamedTuple):
@@ -164,6 +167,7 @@ class FunctionIngestMixin:
     method_return_types: dict[str, str]
     cpp_out_of_class_methods: dict[tuple[str, int], tuple[str, str]]
     function_locations: dict[FunctionSpanKey, FunctionLocation]
+    cpp_definition_spans: dict[str, list[CppDefinitionSpan]]
     macro_qns: set[str]
     _deferred_js_anonymous: list[_DeferredJsAnonymous]
     class_inheritance: dict[str, list[str]]
@@ -485,6 +489,15 @@ class FunctionIngestMixin:
                         container_qn=class_qn,
                     )
                 )
+                record_cpp_definition_span(
+                    self.cpp_definition_spans,
+                    cs.SupportedLanguage.CPP,
+                    file_path,
+                    self.repo_path,
+                    func_node,
+                    cs.NodeLabel.METHOD.value,
+                    bound_qn,
+                )
             if return_type and (
                 method_name := cpp_utils.extract_function_name(func_node)
             ):
@@ -523,6 +536,7 @@ class FunctionIngestMixin:
                     ),
                     start_line=func_node.start_point[0] + 1,
                     start_col=func_node.start_point[1],
+                    end_line=func_node.end_point[0] + 1,
                 )
             )
 
@@ -573,6 +587,15 @@ class FunctionIngestMixin:
 
             props = dict(entry.method_props)
             props[cs.KEY_QUALIFIED_NAME] = method_qn
+            if isinstance(path := props.get(cs.KEY_PATH), str):
+                self.cpp_definition_spans.setdefault(path, []).append(
+                    CppDefinitionSpan(
+                        entry.start_line,
+                        entry.end_line,
+                        cs.NodeLabel.METHOD.value,
+                        method_qn,
+                    )
+                )
 
             logger.info(ls.METHOD_FOUND.format(name=entry.method_name, qn=method_qn))
             self.ingestor.ensure_node_batch(cs.NodeLabel.METHOD, props)
@@ -791,6 +814,15 @@ class FunctionIngestMixin:
             is_named=not resolution.is_anonymous,
         )
         self.function_locations[function_span_key(module_qn, func_node)] = location
+        record_cpp_definition_span(
+            self.cpp_definition_spans,
+            language,
+            self.module_qn_to_file_path.get(module_qn),
+            self.repo_path,
+            func_node,
+            cs.NodeLabel.FUNCTION.value,
+            resolution.qualified_name,
+        )
         if (
             language == cs.SupportedLanguage.CPP
             and func_node.type == cs.CppNodeType.TEMPLATE_DECLARATION

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -12,6 +12,7 @@ from .. import constants as cs
 from .. import logs
 from ..types_defs import (
     ASTNode,
+    CppDefinitionSpan,
     DeferredParentLink,
     FunctionSpanKey,
     LanguageQueries,
@@ -31,6 +32,33 @@ if TYPE_CHECKING:
 def function_span_key(module_qn: str, node: Node) -> FunctionSpanKey:
     # (H) tree-sitter points are 0-based; recorded lines are 1-based.
     return (module_qn, node.start_point[0] + 1, node.start_point[1])
+
+
+_CPP_SPAN_LANGUAGES = frozenset({cs.SupportedLanguage.C, cs.SupportedLanguage.CPP})
+
+
+def record_cpp_definition_span(
+    spans: dict[str, list[CppDefinitionSpan]],
+    language: cs.SupportedLanguage | None,
+    file_path: Path | None,
+    repo_path: Path,
+    node: ASTNode,
+    label: str,
+    qualified_name: str,
+) -> None:
+    # (H) Record the full line span of a C/C++ definition the tree-sitter pass
+    # (H) ingested, keyed by relative path: the hybrid C++ frontend attributes
+    # (H) each macro use to the tightest enclosing tree-sitter span after
+    # (H) Pass 2 (macro cursors are TU-level, and libclang's own spans carry
+    # (H) wrong-scheme qns wherever macros hide namespaces).
+    if language not in _CPP_SPAN_LANGUAGES or file_path is None:
+        return
+    rel = cached_relative_path(file_path, repo_path).as_posix()
+    spans.setdefault(rel, []).append(
+        CppDefinitionSpan(
+            node.start_point[0] + 1, node.end_point[0] + 1, label, qualified_name
+        )
+    )
 
 
 _QUERY_CACHE: dict[tuple[Language, str], Query] = {}

--- a/codebase_rag/tests/test_cpp_frontend_hybrid.py
+++ b/codebase_rag/tests/test_cpp_frontend_hybrid.py
@@ -178,7 +178,8 @@ def test_hybrid_emits_no_libclang_scheme_definitions(
     assert not any(q.endswith(".ui.helper") for q in functions | methods), sorted(
         functions | methods
     )
-    assert "hybns.ns.h.NS_BEGIN" in functions, sorted(functions)
+    # (H) no ns.cpp in this fixture, so ns.h claims the plain module qn
+    assert "hybns.ns.NS_BEGIN" in functions, sorted(functions)
 
 
 def test_run_hybrid_emits_only_macros_and_returns_pending_calls(

--- a/codebase_rag/tests/test_cpp_frontend_hybrid.py
+++ b/codebase_rag/tests/test_cpp_frontend_hybrid.py
@@ -216,9 +216,9 @@ def test_hybrid_macro_body_reference_emits_macro_to_macro_call(
     _write_nested(root)
     ingestor = _run_hybrid(root, monkeypatch)
     calls = _calls(ingestor)
-    assert ("hybnest.nested.QUAD", "hybnest.nested.SQUARE") in calls, sorted(calls)
+    assert ("hybnest.nested.h.QUAD", "hybnest.nested.h.SQUARE") in calls, sorted(calls)
     # (H) a macro does not call itself
-    assert ("hybnest.nested.SQUARE", "hybnest.nested.SQUARE") not in calls
+    assert ("hybnest.nested.h.SQUARE", "hybnest.nested.h.SQUARE") not in calls
 
 
 def test_run_hybrid_emits_only_macros_and_returns_pending_calls(

--- a/codebase_rag/tests/test_cpp_frontend_hybrid.py
+++ b/codebase_rag/tests/test_cpp_frontend_hybrid.py
@@ -121,6 +121,35 @@ def _write_widget(root: Path) -> None:
     )
 
 
+# (H) WRAP's parameter shadows the SQUARE macro: the body's SQUARE token is
+# (H) substituted by the caller's argument, never an expansion of the macro,
+# (H) so WRAP -> SQUARE must not exist. ALIAS is the positive control: an
+# (H) object-like macro whose parenthesized body genuinely references SQUARE.
+_PARAM_H = """\
+#ifndef PARAM_H
+#define PARAM_H
+#define SQUARE(x) ((x)*(x))
+#define WRAP(SQUARE) (SQUARE + 1)
+#define ALIAS (SQUARE(2))
+int compute(int v);
+#endif
+"""
+
+_PARAM_SRC = """\
+#include "param.h"
+int compute(int v) { return WRAP(v) + ALIAS; }
+"""
+
+
+def _write_param(root: Path) -> None:
+    root.mkdir()
+    (root / "param.h").write_text(_PARAM_H, encoding="utf-8")
+    (root / "param.cpp").write_text(_PARAM_SRC, encoding="utf-8")
+    (root / "compile_commands.json").write_text(
+        json.dumps([_compdb_entry(root, root / "param.cpp")]), encoding="utf-8"
+    )
+
+
 def _calls(ingestor: MagicMock) -> set[tuple[str, str]]:
     return {
         (c.args[0][2], c.args[2][2])
@@ -221,6 +250,19 @@ def test_hybrid_macro_body_reference_emits_macro_to_macro_call(
     assert ("hybnest.nested.h.QUAD", "hybnest.nested.h.SQUARE") in calls, sorted(calls)
     # (H) a macro does not call itself
     assert ("hybnest.nested.h.SQUARE", "hybnest.nested.h.SQUARE") not in calls
+
+
+def test_hybrid_macro_parameter_shadowing_a_macro_is_not_a_call(
+    temp_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = temp_repo / "hybparam"
+    _write_param(root)
+    ingestor = _run_hybrid(root, monkeypatch)
+    calls = _calls(ingestor)
+    assert ("hybparam.param.h.WRAP", "hybparam.param.h.SQUARE") not in calls, sorted(
+        calls
+    )
+    assert ("hybparam.param.h.ALIAS", "hybparam.param.h.SQUARE") in calls, sorted(calls)
 
 
 def test_hybrid_incremental_run_keeps_macro_callers_for_unchanged_files(

--- a/codebase_rag/tests/test_cpp_frontend_hybrid.py
+++ b/codebase_rag/tests/test_cpp_frontend_hybrid.py
@@ -47,6 +47,24 @@ int compute(int v) {
 int global_limit = MAX_SIZE;
 """
 
+# (H) QUAD expands SQUARE only when QUAD itself expands -- a NESTED expansion,
+# (H) which the preprocessing record does not report as a MACRO_INSTANTIATION.
+# (H) The definition-body reference is the only evidence SQUARE is used, so it
+# (H) must carry a macro -> macro CALLS edge or SQUARE reports dead.
+_NESTED_H = """\
+#ifndef NESTED_H
+#define NESTED_H
+#define SQUARE(x) ((x)*(x))
+#define QUAD(x) (SQUARE(x)*SQUARE(x))
+int compute(int v);
+#endif
+"""
+
+_NESTED_SRC = """\
+#include "nested.h"
+int compute(int v) { return QUAD(v); }
+"""
+
 
 def _compdb_entry(root: Path, source: Path) -> dict[str, str | list[str]]:
     return {
@@ -54,6 +72,15 @@ def _compdb_entry(root: Path, source: Path) -> dict[str, str | list[str]]:
         "arguments": ["c++", "-std=c++17", f"-I{root}", str(source)],
         "file": str(source),
     }
+
+
+def _write_nested(root: Path) -> None:
+    root.mkdir()
+    (root / "nested.h").write_text(_NESTED_H, encoding="utf-8")
+    (root / "nested.cpp").write_text(_NESTED_SRC, encoding="utf-8")
+    (root / "compile_commands.json").write_text(
+        json.dumps([_compdb_entry(root, root / "nested.cpp")]), encoding="utf-8"
+    )
 
 
 def _write_calc(root: Path) -> None:
@@ -180,6 +207,18 @@ def test_hybrid_emits_no_libclang_scheme_definitions(
     )
     # (H) no ns.cpp in this fixture, so ns.h claims the plain module qn
     assert "hybns.ns.NS_BEGIN" in functions, sorted(functions)
+
+
+def test_hybrid_macro_body_reference_emits_macro_to_macro_call(
+    temp_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = temp_repo / "hybnest"
+    _write_nested(root)
+    ingestor = _run_hybrid(root, monkeypatch)
+    calls = _calls(ingestor)
+    assert ("hybnest.nested.QUAD", "hybnest.nested.SQUARE") in calls, sorted(calls)
+    # (H) a macro does not call itself
+    assert ("hybnest.nested.SQUARE", "hybnest.nested.SQUARE") not in calls
 
 
 def test_run_hybrid_emits_only_macros_and_returns_pending_calls(

--- a/codebase_rag/tests/test_cpp_frontend_hybrid.py
+++ b/codebase_rag/tests/test_cpp_frontend_hybrid.py
@@ -8,11 +8,13 @@ import pytest
 
 from codebase_rag import constants as cs
 from codebase_rag import graph_updater as gu
+from codebase_rag.parser_loader import load_parsers
 from codebase_rag.parsers.cpp_frontend import (
     cpp_frontend_available,
     run_cpp_frontend_hybrid,
 )
 from codebase_rag.tests.conftest import get_nodes, get_qualified_names, run_updater
+from evals.cgr_graph import _StatefulIngestor
 
 pytestmark = pytest.mark.skipif(
     not cpp_frontend_available(),
@@ -219,6 +221,38 @@ def test_hybrid_macro_body_reference_emits_macro_to_macro_call(
     assert ("hybnest.nested.h.QUAD", "hybnest.nested.h.SQUARE") in calls, sorted(calls)
     # (H) a macro does not call itself
     assert ("hybnest.nested.h.SQUARE", "hybnest.nested.h.SQUARE") not in calls
+
+
+def test_hybrid_incremental_run_keeps_macro_callers_for_unchanged_files(
+    temp_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = temp_repo / "hybinc"
+    _write_calc(root)
+    monkeypatch.setattr(gu.settings, "CPP_FRONTEND", cs.CppFrontend.HYBRID)
+    parsers, queries = load_parsers()
+    store = _StatefulIngestor()
+    gu.GraphUpdater(
+        ingestor=store, repo_path=root, parsers=parsers, queries=queries
+    ).run(force=True)
+
+    # (H) A new unrelated file makes the second run incremental-but-dirty
+    # (H) while calc.cpp itself stays unchanged, so Pass 2 records no spans
+    # (H) for it; the frontend still queues its macro uses (libclang parses
+    # (H) every TU each run).
+    (root / "other.cpp").write_text("int other_fn() { return 0; }\n", encoding="utf-8")
+    gu.GraphUpdater(
+        ingestor=store, repo_path=root, parsers=parsers, queries=queries
+    ).run(force=False)
+
+    calls = {
+        (str(from_val), str(to_val))
+        for _fl, from_val, rel_type, _tl, to_val in store.edges
+        if rel_type == cs.RelationshipType.CALLS.value
+    }
+    # (H) SQUARE's only use is inside compute(); span-less resolution on the
+    # (H) incremental run would wrongly re-attribute it to the Module
+    assert ("hybinc.calc", "hybinc.calc.h.SQUARE") not in calls, sorted(calls)
+    assert ("hybinc.calc.compute", "hybinc.calc.h.SQUARE") in calls, sorted(calls)
 
 
 def test_run_hybrid_emits_only_macros_and_returns_pending_calls(

--- a/codebase_rag/tests/test_cpp_frontend_hybrid.py
+++ b/codebase_rag/tests/test_cpp_frontend_hybrid.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag import graph_updater as gu
+from codebase_rag.parsers.cpp_frontend import (
+    cpp_frontend_available,
+    run_cpp_frontend_hybrid,
+)
+from codebase_rag.tests.conftest import get_nodes, get_qualified_names, run_updater
+
+pytestmark = pytest.mark.skipif(
+    not cpp_frontend_available(),
+    reason="libclang not available",
+)
+
+# (H) HYBRID mode: tree-sitter stays the backbone (every file gets its
+# (H) tree-sitter definitions and CALLS; nothing is skipped) and libclang
+# (H) layers on only the facts it is uniquely right about -- macro Function
+# (H) nodes and #include IMPORTS. libclang/tree-sitter definition qns diverge
+# (H) wherever macros hide namespaces, so the frontend must emit NO definition
+# (H) nodes of its own; macro-use CALLS attribute to the tightest enclosing
+# (H) TREE-SITTER definition span after Pass 2 (only module-level qns --
+# (H) macros, Modules -- are scheme-identical and safe to emit directly).
+_CALC_H = """\
+#ifndef CALC_H
+#define CALC_H
+#define SQUARE(x) ((x)*(x))
+#define MAX_SIZE 100
+int compute(int v);
+#endif
+"""
+
+# (H) MAX_SIZE is object-like: tree-sitter sees a bare identifier (not a call
+# (H) expression), so the CALLS edge can only come from the hybrid span
+# (H) resolution -- the test cannot pass via tree-sitter call binding.
+_CALC_SRC = """\
+#include "calc.h"
+int compute(int v) {
+    return MAX_SIZE + SQUARE(v);
+}
+int global_limit = MAX_SIZE;
+"""
+
+
+def _compdb_entry(root: Path, source: Path) -> dict[str, str | list[str]]:
+    return {
+        "directory": str(root),
+        "arguments": ["c++", "-std=c++17", f"-I{root}", str(source)],
+        "file": str(source),
+    }
+
+
+def _write_calc(root: Path) -> None:
+    root.mkdir()
+    (root / "calc.h").write_text(_CALC_H, encoding="utf-8")
+    (root / "calc.cpp").write_text(_CALC_SRC, encoding="utf-8")
+    (root / "compile_commands.json").write_text(
+        json.dumps([_compdb_entry(root, root / "calc.cpp")]), encoding="utf-8"
+    )
+
+
+# (H) A macro-hidden namespace is exactly where the two qn schemes diverge:
+# (H) libclang would emit widget.ui.helper, tree-sitter emits widget.helper.
+_NS_H = """\
+#ifndef NS_H
+#define NS_H
+#define NS_BEGIN namespace ui {
+#define NS_END }
+#endif
+"""
+
+_WIDGET_SRC = """\
+#include "ns.h"
+NS_BEGIN
+int helper(int v) { return v + 1; }
+NS_END
+"""
+
+
+def _write_widget(root: Path) -> None:
+    root.mkdir()
+    (root / "ns.h").write_text(_NS_H, encoding="utf-8")
+    (root / "widget.cpp").write_text(_WIDGET_SRC, encoding="utf-8")
+    (root / "compile_commands.json").write_text(
+        json.dumps([_compdb_entry(root, root / "widget.cpp")]), encoding="utf-8"
+    )
+
+
+def _calls(ingestor: MagicMock) -> set[tuple[str, str]]:
+    return {
+        (c.args[0][2], c.args[2][2])
+        for c in ingestor.ensure_relationship_batch.call_args_list
+        if c.args[1] == "CALLS"
+    }
+
+
+def _imports(ingestor: MagicMock) -> set[tuple[str, str]]:
+    return {
+        (c.args[0][2], c.args[2][2])
+        for c in ingestor.ensure_relationship_batch.call_args_list
+        if c.args[1] == "IMPORTS"
+    }
+
+
+def _run_hybrid(root: Path, monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    monkeypatch.setattr(gu.settings, "CPP_FRONTEND", cs.CppFrontend.HYBRID)
+    ingestor = MagicMock()
+    run_updater(root, ingestor)
+    return ingestor
+
+
+def test_hybrid_macro_nodes_coexist_with_treesitter_definitions(
+    temp_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = temp_repo / "hybproj"
+    _write_calc(root)
+    ingestor = _run_hybrid(root, monkeypatch)
+    functions = get_qualified_names(get_nodes(ingestor, "Function"))
+    # (H) frontend macro nodes AND the tree-sitter definition for the SAME
+    # (H) file: covered files are not skipped in hybrid mode
+    assert "hybproj.calc.h.SQUARE" in functions, sorted(functions)
+    assert "hybproj.calc.h.MAX_SIZE" in functions, sorted(functions)
+    assert "hybproj.calc.compute" in functions, sorted(functions)
+
+
+def test_hybrid_macro_use_calls_from_treesitter_enclosing_function(
+    temp_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = temp_repo / "hybcalls"
+    _write_calc(root)
+    ingestor = _run_hybrid(root, monkeypatch)
+    calls = _calls(ingestor)
+    assert ("hybcalls.calc.compute", "hybcalls.calc.h.MAX_SIZE") in calls, sorted(calls)
+    assert ("hybcalls.calc.compute", "hybcalls.calc.h.SQUARE") in calls, sorted(calls)
+
+
+def test_hybrid_file_scope_macro_use_attributes_to_module(
+    temp_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = temp_repo / "hybmod"
+    _write_calc(root)
+    ingestor = _run_hybrid(root, monkeypatch)
+    # (H) `int global_limit = MAX_SIZE;` expands outside every tree-sitter
+    # (H) definition span -> the Module, mirroring the module-caller rule
+    assert ("hybmod.calc", "hybmod.calc.h.MAX_SIZE") in _calls(ingestor), sorted(
+        _calls(ingestor)
+    )
+
+
+def test_hybrid_emits_include_imports(
+    temp_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = temp_repo / "hybimp"
+    _write_calc(root)
+    ingestor = _run_hybrid(root, monkeypatch)
+    assert ("hybimp.calc", "hybimp.calc.h") in _imports(ingestor), sorted(
+        _imports(ingestor)
+    )
+
+
+def test_hybrid_emits_no_libclang_scheme_definitions(
+    temp_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = temp_repo / "hybns"
+    _write_widget(root)
+    ingestor = _run_hybrid(root, monkeypatch)
+    functions = get_qualified_names(get_nodes(ingestor, "Function"))
+    methods = get_qualified_names(get_nodes(ingestor, "Method"))
+    # (H) the libclang scheme sees through NS_BEGIN and would emit
+    # (H) widget.ui.helper -- a duplicate of tree-sitter's widget.helper under
+    # (H) a qn no tree-sitter edge can ever reach
+    assert not any(q.endswith(".ui.helper") for q in functions | methods), sorted(
+        functions | methods
+    )
+    assert "hybns.ns.h.NS_BEGIN" in functions, sorted(functions)
+
+
+def test_run_hybrid_emits_only_macros_and_returns_pending_calls(
+    temp_repo: Path,
+) -> None:
+    root = temp_repo / "hybunit"
+    _write_calc(root)
+    ingestor = MagicMock()
+    pending = run_cpp_frontend_hybrid(ingestor, root, root.name, root)
+    # (H) macros only: no definition nodes, no CALLS (callers are unknowable
+    # (H) until the tree-sitter pass has run), includes still emitted
+    functions = get_qualified_names(get_nodes(ingestor, "Function"))
+    assert "hybunit.calc.h.SQUARE" in functions, sorted(functions)
+    assert "hybunit.calc.compute" not in functions, sorted(functions)
+    assert not get_nodes(ingestor, "Class")
+    assert not get_nodes(ingestor, "Method")
+    assert not _calls(ingestor)
+    assert ("hybunit.calc", "hybunit.calc.h") in _imports(ingestor)
+    pending_callees = {p.callee_qn for p in pending}
+    assert "hybunit.calc.h.SQUARE" in pending_callees, pending
+    assert "hybunit.calc.h.MAX_SIZE" in pending_callees, pending
+    assert all(p.rel_path == "calc.cpp" for p in pending), pending

--- a/codebase_rag/tests/test_cpp_frontend_hybrid.py
+++ b/codebase_rag/tests/test_cpp_frontend_hybrid.py
@@ -255,6 +255,33 @@ def test_hybrid_incremental_run_keeps_macro_callers_for_unchanged_files(
     assert ("hybinc.calc.compute", "hybinc.calc.h.SQUARE") in calls, sorted(calls)
 
 
+def test_hybrid_incremental_header_edit_keeps_macro_nodes(
+    temp_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = temp_repo / "hybedit"
+    _write_calc(root)
+    monkeypatch.setattr(gu.settings, "CPP_FRONTEND", cs.CppFrontend.HYBRID)
+    parsers, queries = load_parsers()
+    store = _StatefulIngestor()
+    gu.GraphUpdater(
+        ingestor=store, repo_path=root, parsers=parsers, queries=queries
+    ).run(force=True)
+    macro_node = (cs.NodeLabel.FUNCTION.value, "hybedit.calc.h.SQUARE")
+    assert macro_node in store.nodes
+
+    # (H) Editing the header makes it a changed file: Pass 2 deletes its
+    # (H) Module subtree before re-parsing, so macro nodes emitted BEFORE the
+    # (H) delete would vanish until a forced rebuild -- the frontend must run
+    # (H) after the deletes.
+    (root / "calc.h").write_text(_CALC_H + "// touched\n", encoding="utf-8")
+    gu.GraphUpdater(
+        ingestor=store, repo_path=root, parsers=parsers, queries=queries
+    ).run(force=False)
+    assert macro_node in store.nodes, sorted(
+        uid for label, uid in store.nodes if label == cs.NodeLabel.FUNCTION.value
+    )
+
+
 def test_hybrid_drops_macro_uses_in_ignored_directories(temp_repo: Path) -> None:
     root = temp_repo / "hybskip"
     _write_calc(root)

--- a/codebase_rag/tests/test_cpp_frontend_hybrid.py
+++ b/codebase_rag/tests/test_cpp_frontend_hybrid.py
@@ -278,7 +278,7 @@ def test_hybrid_incremental_header_edit_keeps_macro_nodes(
         ingestor=store, repo_path=root, parsers=parsers, queries=queries
     ).run(force=False)
     assert macro_node in store.nodes, sorted(
-        uid for label, uid in store.nodes if label == cs.NodeLabel.FUNCTION.value
+        str(uid) for label, uid in store.nodes if label == cs.NodeLabel.FUNCTION.value
     )
 
 

--- a/codebase_rag/tests/test_cpp_frontend_hybrid.py
+++ b/codebase_rag/tests/test_cpp_frontend_hybrid.py
@@ -255,6 +255,23 @@ def test_hybrid_incremental_run_keeps_macro_callers_for_unchanged_files(
     assert ("hybinc.calc.compute", "hybinc.calc.h.SQUARE") in calls, sorted(calls)
 
 
+def test_hybrid_drops_macro_uses_in_ignored_directories(temp_repo: Path) -> None:
+    root = temp_repo / "hybskip"
+    _write_calc(root)
+    (root / "build").mkdir()
+    (root / "build" / "gen.h").write_text(
+        '#include "calc.h"\nstatic int cap = MAX_SIZE;\n', encoding="utf-8"
+    )
+    (root / "calc.cpp").write_text(
+        '#include "build/gen.h"\n' + _CALC_SRC, encoding="utf-8"
+    )
+    pending = run_cpp_frontend_hybrid(MagicMock(), root, root.name, root)
+    # (H) build/ is an ignored directory: its files carry no module qn, so a
+    # (H) macro use there has no possible Module fallback and must be dropped
+    assert all(p.rel_path != "build/gen.h" for p in pending), pending
+    assert any(p.rel_path == "calc.cpp" for p in pending), pending
+
+
 def test_run_hybrid_emits_only_macros_and_returns_pending_calls(
     temp_repo: Path,
 ) -> None:

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -539,6 +539,35 @@ class FunctionLocation(NamedTuple):
     is_named: bool = True
 
 
+class CppDefinitionSpan(NamedTuple):
+    """Full line span of a C/C++ function or method the tree-sitter pass ingested.
+
+    Recorded per relative file path so the hybrid C++ frontend can attribute a
+    macro use (a TU-level preprocessing entity with only a location) to the
+    tightest enclosing TREE-SITTER definition after Pass 2; libclang's own
+    spans carry wrong-scheme qns wherever macros hide namespaces.
+    """
+
+    start_line: int
+    end_line: int
+    label: str
+    qualified_name: str
+
+
+class PendingMacroCall(NamedTuple):
+    """A macro use the hybrid C++ frontend saw but cannot attribute yet.
+
+    The caller is resolvable only after the tree-sitter pass has recorded its
+    definition spans; a use outside every span attributes to the fallback
+    Module, mirroring the module-caller rule for ordinary calls.
+    """
+
+    rel_path: str
+    line: int
+    callee_qn: str
+    fallback_module_qn: str
+
+
 class DeferredCppInherit(NamedTuple):
     """C++ INHERITS edge held back until every class is registered.
 

--- a/docs/architecture/graph-schema.md
+++ b/docs/architecture/graph-schema.md
@@ -68,7 +68,8 @@ Macro definitions map onto the existing `Function` label rather than a dedicated
 Language notes:
 
 - **Rust**: macros and functions live in separate namespaces, so a macro invocation (`write!`) never binds a same-named `fn` and a function call never binds a same-named macro. `#[macro_export]` sets `is_exported` (macros take no `pub`).
-- **C/C++** (libclang frontend): compiler builtins, system-header macros, and empty-bodied object-like macros (include guards, feature flags) are not nodes. A macro use inside a function body emits `CALLS` from that function; a use outside any function attributes to the `Module`.
+- **C/C++** (libclang frontend): compiler builtins, system-header macros, and empty-bodied object-like macros (include guards, feature flags) are not nodes. A macro use inside a function body emits `CALLS` from that function; a use outside any function attributes to the `Module`. A macro whose definition body references another macro emits a macro-to-macro `CALLS` edge, since nested expansions are never reported as individual uses.
+- **C/C++ hybrid mode** (`CPP_FRONTEND=hybrid`): tree-sitter remains the backbone (every file gets its tree-sitter definitions and calls; nothing is skipped) and libclang layers on only macro `Function` nodes and `#include` `IMPORTS` edges, whose qualified names are identical between the two schemes. Macro uses are attributed to the tightest enclosing tree-sitter definition span after the definition pass, so macro `CALLS` edges join the qualified-name scheme the rest of the graph uses.
 
 ## Language-Specific AST Mappings
 

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.277"
+version = "0.0.278"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

Adds `CPP_FRONTEND=hybrid`: tree-sitter stays the backbone (every file gets its tree-sitter definitions and CALLS; nothing is skipped) and libclang, when a `compile_commands.json` is discoverable, layers on only the facts it is uniquely right about:

- macro `Function` nodes (`is_macro: true`) with Module `DEFINES`, registered in the function registry
- `#include` `IMPORTS` edges (correct at any depth, without the tree-sitter self-import bug)
- macro-use `CALLS` edges attributed to the tightest enclosing tree-sitter definition span
- macro-to-macro `CALLS` from definition-body references (nested expansions are never reported as `MACRO_INSTANTIATION`, so the body reference is the only evidence of use); this also applies in pure libclang mode

## Why

libclang and tree-sitter qualified names diverge exactly where macros hide namespaces (fmt's `FMT_BEGIN_NAMESPACE` expands to `namespace fmt { inline namespace v12 {`), so string translation between the schemes is impossible in general. Module-level entities (macros, Modules) are scheme-identical, so hybrid emits those directly and joins everything else by source location: the frontend hands back pending macro uses, and `GraphUpdater` resolves each against a new span index (`cpp_definition_spans`) recorded by the tree-sitter pass, after deferred C++ out-of-class methods have bound.

## How

- `run_cpp_frontend_hybrid` parses every TU with `PARSE_DETAILED_PROCESSING_RECORD`, emits no definition nodes and no libclang CALLS, and returns `PendingMacroCall` entries with a pre-resolved Module fallback
- `cpp_definition_spans` records `(start_line, end_line, label, qn)` per relative path for every C/C++ function and method the tree-sitter pass ingests (free functions, in-class methods, resolved and deferred out-of-class methods)
- `GraphUpdater._resolve_hybrid_macro_calls` picks the tightest containing span, else the Module, mirroring the libclang frontend's own resolution but in the qn scheme the rest of the graph uses
- pure libclang mode is untouched apart from gaining the macro-to-macro edges

## Benchmarks (dead-code eval, `include_tests=False`)

| repo | treesitter | hybrid | pre-existing nodes changed |
|---|---|---|---|
| fmt (53-file compdb, FMT_TEST=ON) | 664 | 705 | 0 |
| nlohmann (`include/nlohmann`, 98-TU compdb) | 331 | 546 | 0 |

Every delta entry is a newly modeled macro; per-class inspection: consumer-facing API macros (`NLOHMANN_DEFINE_TYPE_*`, `fmt_print`), test-only chains (fmt-c `FMT_MAP_*`), macros whose only callers were already dead (`FMT_TRY` under `format_system_error`), and macros referenced only in `#if` directives. These match the accepted public-API dead-code classes; zero regressions and zero revivals on all pre-existing nodes in both repos. Pure libclang mode on fmt previously reported 899.

## Known B1 scope cuts (planned B2)

- tree-sitter's `#include` IMPORTS (with its self-import bug) are still emitted alongside the frontend's correct ones for covered files; duplicates are idempotent
- `#if`/`#ifdef` directive references are not macro uses yet (they are not `MACRO_INSTANTIATION` cursors), so config-flag macros can report dead
- libclang Type-alias nodes and post-expansion call sites are not layered on in hybrid yet
