### PR TITLE
fix(parsers): link returned closures to every duplicate-QN twin

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -2983,17 +2983,20 @@ class CallProcessor:
                     if not (name := safe_decode_text(child)):
                         continue
                     nested_qn = f"{caller_qn}{cs.SEPARATOR_DOT}{name}"
+                    # (H) A duplicated name (if/else twin definitions) returns
+                    # (H) whichever branch ran, so record EVERY twin; recording one
+                    # (H) leaves the others unreachable and falsely dead.
                     if nested_qn in registry:
-                        self._returned_callables.setdefault(caller_qn, set()).add(
-                            nested_qn
+                        self._returned_callables.setdefault(caller_qn, set()).update(
+                            registry.variants(nested_qn)
                         )
                     elif (
                         resolved := resolve_func(
                             name, module_qn, local_var_types, class_context, caller_qn
                         )
                     ) is not None and resolved[0] in _CALLABLE_NODE_LABELS:
-                        self._returned_callables.setdefault(caller_qn, set()).add(
-                            resolved[1]
+                        self._returned_callables.setdefault(caller_qn, set()).update(
+                            registry.variants(resolved[1])
                         )
             stack.extend(node.children)
 

--- a/codebase_rag/tests/test_duplicate_qn_definitions.py
+++ b/codebase_rag/tests/test_duplicate_qn_definitions.py
@@ -182,3 +182,39 @@ class TestDuplicateQualifiedNameMethodsInOneClass:
             and props.get(cs.KEY_START_LINE) is not None
         )
         assert run_start_lines == [8, 13], run_start_lines
+
+
+FACTORY_SRC = """def factory(value):
+    if callable(value):
+
+        def handler(arg):
+            return value()
+
+    else:
+
+        def handler(arg):
+            return value
+
+    return handler
+"""
+
+
+class TestDuplicateQualifiedNameReturnedClosures:
+    def test_returned_closure_links_both_duplicate_definitions(
+        self, tmp_path: Path
+    ) -> None:
+        # (H) `return handler` hands back whichever branch defined handler, so the
+        # (H) producer edge must link BOTH twins; linking one leaves the other
+        # (H) unreachable and falsely dead (django's SET.set_on_delete@60).
+        cap = _build(tmp_path, FACTORY_SRC)
+        returned_edges = sorted(
+            str(target)
+            for (_fl, from_val, rel_type, _tl, target) in cap.rels
+            if rel_type == cs.RelationshipType.CALLS
+            and str(from_val).endswith(".factory")
+            and ".handler" in str(target)
+        )
+        assert returned_edges == [
+            f"{PROJECT}.m.factory.handler",
+            f"{PROJECT}.m.factory.handler{cs.DUP_QN_MARKER}9",
+        ], returned_edges


### PR DESCRIPTION
## Problem

Found dogfooding dead-code detection on django (issue class: duplicate-QN twins).

When the same name is defined twice via the if/else idiom, both definitions survive as distinct nodes (`name` and `name@LINE`) and call resolution links CALLS to both twins. The returned-closure producer path did not: `_collect_returned_callables` recorded only the natural qualified name for `return handler`, so the producer edge reached one twin and the `@LINE` twin had no incoming edge at all.

Dead-code consequence on django (both false positives, gone after this fix with zero changes elsewhere in the 122-finding report):

- `django.db.models.deletion.SET.set_on_delete@60` (`if callable(value): def set_on_delete ... else: def set_on_delete ...; return set_on_delete`)
- `django.db.backends.sqlite3.operations.DatabaseOperations.get_decimalfield_converter.converter@331`

## Fix

`_collect_returned_callables` now records `registry.variants(qn)` (every twin) in both branches: the nested-closure fast path and the resolver fallback. Either branch's definition is the runtime referent of the returned name, so the producer edge must reach all of them, mirroring the CALLS-to-both decision.

## Tests

- RED first: `test_returned_closure_links_both_duplicate_definitions` on the deletion.py shape (producer must link `handler` and `handler@9`); failed with only the unsuffixed twin before the fix.
- Verified on the django corpus: the offline dead-code report drops exactly the two symbols above, no regressions (122 -> 120).
- Full suite: 4742 passed, 0 failed.
