### PR TITLE
fix(parsers): reference first-party functions passed to unnamed callees

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1717,6 +1717,23 @@ class CallProcessor:
                     call_node, caller_spec, ensure_rel, caller_qn, module_qn
                 )
             if not call_name:
+                # (H) A callee that is itself a call (`wraps(view_func)(_view_wrapper)`)
+                # (H) or otherwise yields no name still consumes its arguments through
+                # (H) whatever callable it produced; reference first-party functions
+                # (H) passed to it or dead-code flags every django-style view
+                # (H) decorator wrapper.
+                if is_flow_lang:
+                    self._ingest_argument_function_references(
+                        call_node,
+                        caller_spec,
+                        module_qn,
+                        local_var_types,
+                        class_context,
+                        resolve_func,
+                        ensure_rel,
+                        caller_qn,
+                        cs.RelationshipType.REFERENCES,
+                    )
                 continue
 
             call_var_types = local_var_types

--- a/codebase_rag/tests/test_callback_reference_edges.py
+++ b/codebase_rag/tests/test_callback_reference_edges.py
@@ -236,3 +236,21 @@ def test_annotated_assignment_is_referenced(tmp_path: Path) -> None:
     }
     rels = _run_rels(tmp_path, files)
     assert _has(rels, "registry", REFERENCES, "handlers.handle_event")
+
+
+def test_argument_to_call_expression_callee_is_referenced(tmp_path: Path) -> None:
+    # (H) `wraps(view_func)(_view_wrapper)` consumes _view_wrapper through the
+    # (H) callable the inner call returns. The callee has no extractable name (it
+    # (H) is itself a call), but the passed function must still be referenced or
+    # (H) dead-code flags every django-style view decorator wrapper.
+    files = {
+        "deco.py": (
+            "from functools import wraps\n\n"
+            "def csrf_exempt(view_func):\n"
+            "    def _view_wrapper(request):\n"
+            "        return view_func(request)\n"
+            "    return wraps(view_func)(_view_wrapper)\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files)
+    assert _has(rels, "deco.csrf_exempt", REFERENCES, "csrf_exempt._view_wrapper")


### PR DESCRIPTION
## Problem

Found dogfooding dead-code detection on django (issue class: missing value references).

A call whose callee is itself a call yields no extractable call name, and the call-site loop bailed on `if not call_name: continue` before argument processing. First-party functions passed as arguments to such calls got no REFERENCES edge at all, so dead-code reported them.

This is the canonical django view-decorator idiom, so it hit every one of them (~20 findings, both duplicate-QN twins each):

    if iscoroutinefunction(view_func):
        async def _view_wrapper(request, *args, **kwargs): ...
    else:
        def _view_wrapper(request, *args, **kwargs): ...
    return wraps(view_func)(_view_wrapper)

Affected in django: `csrf_exempt`, `never_cache`, `cache_control`, all three `xframe_options_*`, `no_append_slash`, `vary_on_headers`, `user_passes_test`, `make_middleware_decorator`, plus name-mangled private methods passed as arguments (`DatabaseOperations.__foreign_key_constraints`, `__references_graph`).

## Fix

Before the no-name bail, flow-traced languages now ingest argument function references as REFERENCES: whatever callable the unnamed callee produced still consumes the arguments. The emission path is registry-guarded (only resolved first-party Function/Method arguments get an edge) and expands duplicate-QN variants.

## Verification

- RED first: `test_argument_to_call_expression_callee_is_referenced` (the `wraps(view_func)(_view_wrapper)` shape); failed with no edge before the fix.
- django corpus: dead-code report drops from 122 to 100 findings, all 22 removed symbols verified live (the view-decorator wrappers and the two name-mangled methods), zero regressions.
- Unit suite: 4600 passed, 0 failed.
