### PR TITLE
fix(parsers): reference ternary-assigned and returned method values in python

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -2356,14 +2356,21 @@ class CallProcessor:
                     # (H) A Python TERNARY / BOOLEAN-DEFAULT RHS (`get_response =
                     # (H) self._async if is_async else self._sync`, django's
                     # (H) BaseHandler; `f = handler or fallback`) binds one of its
-                    # (H) operands as the value; every operand naming a callable is
-                    # (H) a possible referent, so reference each (a non-callable
-                    # (H) operand such as the condition simply fails to resolve).
+                    # (H) RESULT operands as the value; each result operand naming
+                    # (H) a callable is a possible referent. A ternary's condition
+                    # (H) is only truthiness-tested, never bound, so it is excluded;
+                    # (H) both boolean operands are possible results.
                     if value.type in (
                         cs.TS_PY_CONDITIONAL_EXPRESSION,
                         cs.TS_PY_BOOLEAN_OPERATOR,
                     ):
-                        for operand in value.named_children:
+                        operands = list(value.named_children)
+                        if (
+                            value.type == cs.TS_PY_CONDITIONAL_EXPRESSION
+                            and len(operands) == 3
+                        ):
+                            operands = [operands[0], operands[2]]
+                        for operand in operands:
                             operand = self._unwrap_ts_value(operand)
                             if (
                                 operand.type in _ASSIGNMENT_RHS_REF_TYPES

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1612,10 +1612,15 @@ class CallProcessor:
             )
         # (H) A function handed back bare (`return defaultUsageFunc`) is a first-class
         # (H) value invoked by whoever receives it, never by a visible call -- Go leans
-        # (H) on this for factories/getters (cobra's getUsageFunc). Reference it so the
-        # (H) returned function is reachable. Go shares the `return_statement` node type
-        # (H) and the emit path already resolves bare Go identifiers.
-        if language in _JS_TS_LANGUAGES or language == cs.SupportedLanguage.GO:
+        # (H) on this for factories/getters (cobra's getUsageFunc), Python on returned
+        # (H) bound methods (django GEOSCoordSeq `return self._get_point_2d`).
+        # (H) Reference it so the returned function is reachable. These languages share
+        # (H) the `return_statement` node type and the emit path resolves bare names
+        # (H) and self-attributes alike.
+        if language in _JS_TS_LANGUAGES or language in (
+            cs.SupportedLanguage.GO,
+            cs.SupportedLanguage.PYTHON,
+        ):
             self._ingest_returned_function_references(
                 caller_node,
                 caller_spec,
@@ -2336,6 +2341,34 @@ class CallProcessor:
                         for operand in value.named_children:
                             operand = self._unwrap_ts_value(operand)
                             if operand.type in _INLINE_FUNC_VALUE_TYPES:
+                                self._emit_callback_edge(
+                                    caller_spec,
+                                    operand,
+                                    module_qn,
+                                    local_var_types,
+                                    class_context,
+                                    resolve_func,
+                                    ensure_rel,
+                                    caller_qn,
+                                    cs.RelationshipType.REFERENCES,
+                                )
+                        continue
+                    # (H) A Python TERNARY / BOOLEAN-DEFAULT RHS (`get_response =
+                    # (H) self._async if is_async else self._sync`, django's
+                    # (H) BaseHandler; `f = handler or fallback`) binds one of its
+                    # (H) operands as the value; every operand naming a callable is
+                    # (H) a possible referent, so reference each (a non-callable
+                    # (H) operand such as the condition simply fails to resolve).
+                    if value.type in (
+                        cs.TS_PY_CONDITIONAL_EXPRESSION,
+                        cs.TS_PY_BOOLEAN_OPERATOR,
+                    ):
+                        for operand in value.named_children:
+                            operand = self._unwrap_ts_value(operand)
+                            if (
+                                operand.type in _ASSIGNMENT_RHS_REF_TYPES
+                                or operand.type in _INLINE_FUNC_VALUE_TYPES
+                            ):
                                 self._emit_callback_edge(
                                     caller_spec,
                                     operand,

--- a/codebase_rag/tests/test_callback_reference_edges.py
+++ b/codebase_rag/tests/test_callback_reference_edges.py
@@ -306,3 +306,25 @@ def test_returned_method_attribute_is_referenced(tmp_path: Path) -> None:
     assert _has(
         rels, "GEOSCoordSeq._point_getter", REFERENCES, "GEOSCoordSeq._get_point_3d"
     )
+
+
+def test_ternary_condition_is_not_referenced(tmp_path: Path) -> None:
+    # (H) The ternary's condition is truthiness-tested, never bound to the LHS,
+    # (H) so a callable named there must NOT get an assignment reference.
+    files = {
+        "picker.py": (
+            "def check():\n"
+            "    return True\n\n"
+            "def first():\n"
+            "    return 1\n\n"
+            "def second():\n"
+            "    return 2\n\n"
+            "def pick():\n"
+            "    chosen = first if check else second\n"
+            "    return chosen()\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files)
+    assert _has(rels, "picker.pick", REFERENCES, "picker.first")
+    assert _has(rels, "picker.pick", REFERENCES, "picker.second")
+    assert not _has(rels, "picker.pick", REFERENCES, "picker.check")

--- a/codebase_rag/tests/test_callback_reference_edges.py
+++ b/codebase_rag/tests/test_callback_reference_edges.py
@@ -254,3 +254,55 @@ def test_argument_to_call_expression_callee_is_referenced(tmp_path: Path) -> Non
     }
     rels = _run_rels(tmp_path, files)
     assert _has(rels, "deco.csrf_exempt", REFERENCES, "csrf_exempt._view_wrapper")
+
+
+def test_ternary_assignment_references_both_methods(tmp_path: Path) -> None:
+    # (H) `get_response = self._async if flag else self._sync` binds one of two
+    # (H) methods as a value; both are possible referents and must be referenced
+    # (H) (django BaseHandler.load_middleware shape), or dead-code flags them.
+    files = {
+        "handler.py": (
+            "def convert(handler):\n"
+            "    return handler\n\n"
+            "class BaseHandler:\n"
+            "    def load_middleware(self, is_async):\n"
+            "        get_response = self._async if is_async else self._sync\n"
+            "        return convert(get_response)\n\n"
+            "    def _async(self, request):\n"
+            "        return request\n\n"
+            "    def _sync(self, request):\n"
+            "        return request\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files)
+    assert _has(rels, "BaseHandler.load_middleware", REFERENCES, "BaseHandler._async")
+    assert _has(rels, "BaseHandler.load_middleware", REFERENCES, "BaseHandler._sync")
+
+
+def test_returned_method_attribute_is_referenced(tmp_path: Path) -> None:
+    # (H) `return self._get_point_2d` hands the bound method to the caller for
+    # (H) later dispatch (django GEOSCoordSeq._point_getter shape); the returning
+    # (H) scope must reference it or dead-code flags the whole getter cluster.
+    files = {
+        "coordseq.py": (
+            "class GEOSCoordSeq:\n"
+            "    @property\n"
+            "    def _point_getter(self):\n"
+            "        if self.dims == 3:\n"
+            "            return self._get_point_3d\n"
+            "        return self._get_point_2d\n\n"
+            "    def _get_point_2d(self, index):\n"
+            "        return index\n\n"
+            "    def _get_point_3d(self, index):\n"
+            "        return index\n\n"
+            "    def use(self, index):\n"
+            "        return self._point_getter(index)\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files)
+    assert _has(
+        rels, "GEOSCoordSeq._point_getter", REFERENCES, "GEOSCoordSeq._get_point_2d"
+    )
+    assert _has(
+        rels, "GEOSCoordSeq._point_getter", REFERENCES, "GEOSCoordSeq._get_point_3d"
+    )


### PR DESCRIPTION
## Problem

Found dogfooding dead-code detection on django (issue class: methods used as values, 13 false positives).

Two Python shapes hand a method around as a first-class value without any edge being recorded:

1. Ternary/boolean assignment: `get_response = self._get_response_async if is_async else self._get_response` (django `BaseHandler.load_middleware`). The assignment-reference scan only handled a bare name/attribute RHS; a `conditional_expression` or `boolean_operator` RHS was skipped entirely, so BOTH methods reported dead.
2. Returned method: `return self._get_point_2d` (django `GEOSCoordSeq._point_getter`). The returned-function REFERENCES pass was gated to JS/TS and Go; Python returns of bound methods produced nothing, so the whole `_get_point_*`/`_get_x/y/z/m` cluster (8 symbols) reported dead.

## Fix

- The assignment scan now walks `conditional_expression` / `boolean_operator` RHS operands and references each operand that names a callable (non-callable operands such as the condition simply fail to resolve; the emission path is registry-guarded and variant-expanding).
- `_ingest_returned_function_references` now also runs for Python callers; the emit path already resolves bare names and self-attributes.

## Verification

- RED first: `test_ternary_assignment_references_both_methods` and `test_returned_method_attribute_is_referenced`, both failing with no edges before the fix.
- django corpus: dead-code report drops 122 -> 109; the 13 removed symbols are exactly the GEOSCoordSeq cluster, both BaseHandler response methods, `BaseExpression._convert_value_noop` (ternary shape), and the two duplicate-QN twins now also covered by the return walk. Zero regressions.
- Unit suite: 4601 passed, 0 failed.
