### PR TITLE
fix(parsers): resolve this-calls in js prototype methods to sibling methods

### DIFF
--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -39,6 +39,10 @@ TS_LOCALS_PATTERN = """
 # (H) only these may bind a dotted call to a same-module free function; an
 # (H) ordinary identifier receiver (`view.render()`) is an instance call.
 JS_MODULE_RECEIVERS = frozenset({"exports", "module", "this"})
+# (H) `this.` receiver prefix of a call name; a prototype-assigned function
+# (H) (`Date.prototype.strftime`) dispatches such calls to a sibling method of
+# (H) the same prototype target before the module-receiver fallback applies.
+JS_THIS_CALL_PREFIX = "this."
 
 JS_TS_PARENT_REF_TYPES = (TS_IDENTIFIER, TS_MEMBER_EXPRESSION)
 # (H) JSX element nodes that carry a component name (javascript and tsx

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -290,6 +290,29 @@ class CallResolver:
             )
         )
 
+    def _resolve_js_prototype_sibling(
+        self,
+        call_name: str,
+        caller_qn: str | None,
+        language: cs.SupportedLanguage | None,
+    ) -> tuple[str, str] | None:
+        # (H) Only a two-part `this.m` call in a JS/TS caller qualifies; the caller's
+        # (H) parent scope (module.Date for Date.prototype.strftime) is where the
+        # (H) prototype siblings were registered. A module-level caller degrades to
+        # (H) the same module-method lookup the CommonJS fallback performs.
+        if language not in cs.JS_TS_LANGUAGES or not caller_qn:
+            return None
+        if not call_name.startswith(cs.JS_THIS_CALL_PREFIX):
+            return None
+        method_name = call_name[len(cs.JS_THIS_CALL_PREFIX) :]
+        if not method_name or cs.SEPARATOR_DOT in method_name:
+            return None
+        parent_scope = caller_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
+        method_qn = f"{parent_scope}{cs.SEPARATOR_DOT}{method_name}"
+        if func_type := self.function_registry.get(method_qn):
+            return func_type, method_qn
+        return None
+
     def _resolve_enclosing_scope(
         self, call_name: str, caller_qn: str | None, module_qn: str
     ) -> tuple[str, str] | None:
@@ -606,6 +629,14 @@ class CallResolver:
         # (H) before the module-keyed cache/trie, which would otherwise return a sibling
         # (H) scope's same-named nested function.
         if result := self._resolve_enclosing_scope(call_name, caller_qn, module_qn):
+            return result
+
+        # (H) `this.m()` inside a prototype-assigned function dispatches to a sibling
+        # (H) method of the same prototype target (Date.prototype.strftime calling
+        # (H) this.getTwoDigitMonth()); the caller's parent scope names that target.
+        # (H) Caller-specific, so it too must run before the module-keyed cache; the
+        # (H) CommonJS module-receiver fallback still applies when no sibling exists.
+        if result := self._resolve_js_prototype_sibling(call_name, caller_qn, language):
             return result
 
         use_cache = not local_var_types

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -300,7 +300,12 @@ class CallResolver:
         # (H) parent scope (module.Date for Date.prototype.strftime) is where the
         # (H) prototype siblings were registered. A module-level caller degrades to
         # (H) the same module-method lookup the CommonJS fallback performs.
+        # (H) A dotless caller_qn has no parent scope to consult: rsplit would
+        # (H) return the caller itself and the lookup would land on the caller's
+        # (H) own NESTED function, which `this.m` never names.
         if language not in cs.JS_TS_LANGUAGES or not caller_qn:
+            return None
+        if cs.SEPARATOR_DOT not in caller_qn:
             return None
         if not call_name.startswith(cs.JS_THIS_CALL_PREFIX):
             return None

--- a/codebase_rag/tests/test_js_prototype_this_dispatch.py
+++ b/codebase_rag/tests/test_js_prototype_this_dispatch.py
@@ -1,0 +1,66 @@
+# (H) `this.method()` inside a prototype-assigned function dispatches to a
+# (H) sibling method of the same prototype target (Date.prototype.strftime
+# (H) calling this.getTwoDigitMonth(), django admin's core.js). Binding `this`
+# (H) only to module-level functions (the CommonJS pattern) leaves every such
+# (H) sibling call unresolved and the methods falsely dead.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.conftest import get_relationships, run_updater
+
+CORE_JS = """Date.prototype.getTwoDigitMonth = function () {
+    return this.getMonth() + 1;
+};
+
+Date.prototype.strftime = function (format) {
+    if (format === "m") {
+        return this.getTwoDigitMonth();
+    }
+    return "";
+};
+"""
+
+
+def _calls(mock_ingestor: MagicMock) -> set[tuple[str, str]]:
+    return {
+        (c.args[0][2], c.args[2][2]) for c in get_relationships(mock_ingestor, "CALLS")
+    }
+
+
+def test_prototype_this_call_resolves_to_sibling_method(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    project = temp_repo / "proto_this"
+    project.mkdir()
+    (project / "core.js").write_text(CORE_JS, encoding="utf-8")
+
+    run_updater(project, mock_ingestor, skip_if_missing="javascript")
+
+    assert (
+        "proto_this.core.Date.strftime",
+        "proto_this.core.Date.getTwoDigitMonth",
+    ) in _calls(mock_ingestor)
+
+
+def test_module_this_call_still_resolves_to_free_function(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) The CommonJS module pattern (`this.render()` at module scope binding a
+    # (H) free function) must keep resolving as before.
+    project = temp_repo / "module_this"
+    project.mkdir()
+    (project / "app.js").write_text(
+        "function render() {\n"
+        "    return 1;\n"
+        "}\n\n"
+        "function page() {\n"
+        "    return this.render();\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    run_updater(project, mock_ingestor, skip_if_missing="javascript")
+
+    assert ("module_this.app.page", "module_this.app.render") in _calls(mock_ingestor)


### PR DESCRIPTION
## Problem

Found dogfooding dead-code detection on django (issue class: JS prototype dispatch, 11 false positives).

`this` in a dotted JS call is treated only as a MODULE receiver (the CommonJS pattern), so `this.getTwoDigitMonth()` inside `Date.prototype.strftime` looked up a module-level `getTwoDigitMonth`, found nothing, and emitted no edge. Every prototype-assigned method invoked only through sibling `this.` calls reported dead: all 11 `Date.prototype.*` helpers in django's admin `core.js` (getTwoDigitMonth, getAbbrevDayName, getTwelveHours, ...), which are called by `Date.prototype.strftime`.

## Fix

A caller-specific resolution step (before the module-keyed cache, like the enclosing-scope lookup) resolves a two-part `this.m` call against the caller's parent scope: for `module.Date.strftime` that is `module.Date`, where the prototype siblings were registered. When no sibling exists the CommonJS module-receiver fallback applies unchanged.

## Verification

- RED first: `test_prototype_this_call_resolves_to_sibling_method`; a companion test pins the CommonJS `this.render()` -> module free-function behavior.
- django corpus: dead-code report drops all 11 admin core.js Date prototype methods, zero regressions.
- Unit suite: 4602 passed, 0 failed.
