### PR TITLE
fix(parsers): resolve package-attribute bases through star re-exports

### DIFF
--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -502,13 +502,28 @@ class ClassIngestMixin:
             tail = entry.parent_qn[len(project_prefix) :]
             simple = tail.rsplit(cs.SEPARATOR_DOT, 1)[-1]
             suffix = f"{cs.SEPARATOR_DOT}{tail}"
+            candidates = self.function_registry.find_ending_with(simple)
             matches = {
-                qn
-                for qn in self.function_registry.find_ending_with(simple)
-                if qn.endswith(suffix) and qn != entry.child_qn
+                qn for qn in candidates if qn.endswith(suffix) and qn != entry.child_qn
             }
             if len(matches) == 1:
                 return matches.pop(), False
+            # (H) A base written as a PACKAGE attribute (`forms.ModelForm` via
+            # (H) `from django import forms`) names the re-exporting package, not
+            # (H) the defining module (django.forms.models.ModelForm behind the
+            # (H) package __init__'s star import), so the suffix match cannot
+            # (H) bridge the missing segment. A UNIQUE same-named class UNDER the
+            # (H) written package path is that re-export; ambiguity means no edge.
+            package_prefix = (
+                entry.parent_qn.rsplit(cs.SEPARATOR_DOT, 1)[0] + cs.SEPARATOR_DOT
+            )
+            package_matches = {
+                qn
+                for qn in candidates
+                if qn.startswith(package_prefix) and qn != entry.child_qn
+            }
+            if len(package_matches) == 1:
+                return package_matches.pop(), False
             return None
         # (H) The module-anchored fallback shape carries the raw written name
         # (H) as the remainder after the module qn.

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -517,10 +517,17 @@ class ClassIngestMixin:
             package_prefix = (
                 entry.parent_qn.rsplit(cs.SEPARATOR_DOT, 1)[0] + cs.SEPARATOR_DOT
             )
+            # (H) The registry also holds functions/methods with the same simple
+            # (H) name; only a TYPE declaration is a valid inheritance target, so
+            # (H) filter before the uniqueness check (a same-named factory function
+            # (H) under the package must not corrupt the class hierarchy).
+            type_decls = (NodeType.CLASS, NodeType.INTERFACE, NodeType.ENUM)
             package_matches = {
                 qn
                 for qn in candidates
-                if qn.startswith(package_prefix) and qn != entry.child_qn
+                if qn.startswith(package_prefix)
+                and qn != entry.child_qn
+                and self.function_registry.get(qn) in type_decls
             }
             if len(package_matches) == 1:
                 return package_matches.pop(), False

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -520,14 +520,19 @@ class ClassIngestMixin:
             # (H) The registry also holds functions/methods with the same simple
             # (H) name; only a TYPE declaration is a valid inheritance target, so
             # (H) filter before the uniqueness check (a same-named factory function
-            # (H) under the package must not corrupt the class hierarchy).
+            # (H) under the package must not corrupt the class hierarchy). The
+            # (H) package must also actually EXPOSE the name (its __init__ imports
+            # (H) it explicitly or star-imports the defining module); a same-named
+            # (H) internal class the package never re-exports is not the referent.
             type_decls = (NodeType.CLASS, NodeType.INTERFACE, NodeType.ENUM)
+            package_qn = package_prefix[: -len(cs.SEPARATOR_DOT)]
             package_matches = {
                 qn
                 for qn in candidates
                 if qn.startswith(package_prefix)
                 and qn != entry.child_qn
                 and self.function_registry.get(qn) in type_decls
+                and self._package_exposes(package_qn, simple, qn)
             }
             if len(package_matches) == 1:
                 return package_matches.pop(), False
@@ -545,6 +550,23 @@ class ClassIngestMixin:
         ):
             return resolved, False
         return self._externalize_written_base(raw_name, entry.language)
+
+    def _package_exposes(self, package_qn: str, simple: str, class_qn: str) -> bool:
+        # (H) True when the package __init__ makes `simple` an attribute of the
+        # (H) package: an explicit import binding the name to this class (or its
+        # (H) defining module member), or a star import of the module that
+        # (H) defines it. Star-import keys carry a leading GLOB_ALL marker,
+        # (H) matching the call resolver's wildcard convention.
+        imports = self.import_processor.import_mapping.get(package_qn)
+        if not imports:
+            return False
+        if imports.get(simple) == class_qn:
+            return True
+        star_member = f"{cs.SEPARATOR_DOT}{simple}"
+        return any(
+            key.startswith(cs.GLOB_ALL) and class_qn == f"{target}{star_member}"
+            for key, target in imports.items()
+        )
 
     def _externalize_written_base(
         self, raw_name: str, language: cs.SupportedLanguage

--- a/codebase_rag/tests/test_package_reexport_inheritance.py
+++ b/codebase_rag/tests/test_package_reexport_inheritance.py
@@ -1,0 +1,81 @@
+# (H) A base written as a PACKAGE attribute (`forms.ModelForm` via `from django
+# (H) import forms`) names the re-exporting package, not the defining module
+# (H) (django.forms.models.ModelForm re-exported by django/forms/__init__'s
+# (H) star import). The deferred-INHERITS suffix match cannot bridge the missing
+# (H) `.models` segment, so the edge was dropped -- and with it every OVERRIDES
+# (H) relationship of the subclass (django BaseUserCreationForm._post_clean
+# (H) reported dead).
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.conftest import get_relationships, run_updater
+
+FORMS_MODELS = """class BaseModelForm:
+    def _post_clean(self):
+        return 1
+
+
+class ModelForm(BaseModelForm):
+    pass
+"""
+
+FORMS_INIT = "from .models import *  # noqa: F403\n"
+
+AUTH_FORMS = """from pkg import formslib as forms
+
+
+class SetPasswordMixin:
+    pass
+
+
+class BaseUserCreationForm(SetPasswordMixin, forms.ModelForm):
+    def _post_clean(self):
+        return 2
+"""
+
+
+def _edges(mock_ingestor: MagicMock, rel_type: str) -> set[tuple[str, str]]:
+    return {
+        (c.args[0][2], c.args[2][2])
+        for c in get_relationships(mock_ingestor, rel_type)
+    }
+
+
+def _build(temp_repo: Path, mock_ingestor: MagicMock) -> None:
+    project = temp_repo / "reexp"
+    (project / "pkg" / "formslib").mkdir(parents=True)
+    (project / "pkg" / "auth").mkdir(parents=True)
+    (project / "pkg" / "__init__.py").write_text("", encoding="utf-8")
+    (project / "pkg" / "formslib" / "__init__.py").write_text(
+        FORMS_INIT, encoding="utf-8"
+    )
+    (project / "pkg" / "formslib" / "models.py").write_text(
+        FORMS_MODELS, encoding="utf-8"
+    )
+    (project / "pkg" / "auth" / "__init__.py").write_text("", encoding="utf-8")
+    (project / "pkg" / "auth" / "forms.py").write_text(AUTH_FORMS, encoding="utf-8")
+    run_updater(project, mock_ingestor, skip_if_missing="python")
+
+
+def test_package_attribute_base_resolves_to_reexported_class(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    _build(temp_repo, mock_ingestor)
+
+    assert (
+        "reexp.pkg.auth.forms.BaseUserCreationForm",
+        "reexp.pkg.formslib.models.ModelForm",
+    ) in _edges(mock_ingestor, "INHERITS")
+
+
+def test_override_of_reexported_base_method_is_recorded(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    _build(temp_repo, mock_ingestor)
+
+    assert (
+        "reexp.pkg.auth.forms.BaseUserCreationForm._post_clean",
+        "reexp.pkg.formslib.models.BaseModelForm._post_clean",
+    ) in _edges(mock_ingestor, "OVERRIDES")

--- a/codebase_rag/tests/test_package_reexport_inheritance.py
+++ b/codebase_rag/tests/test_package_reexport_inheritance.py
@@ -108,3 +108,31 @@ def test_same_named_function_under_package_is_not_an_inheritance_target(
         and parent == "reexp2.pkg.formslib.factory.ModelForm"
         for child, parent in inherits
     )
+
+
+def test_non_exported_internal_class_is_not_an_inheritance_target(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) The package __init__ exports nothing, so `forms.ModelForm` cannot
+    # (H) refer to the internal class; no INHERITS edge may be minted to it.
+    project = temp_repo / "reexp3"
+    (project / "pkg" / "formslib").mkdir(parents=True)
+    (project / "pkg" / "__init__.py").write_text("", encoding="utf-8")
+    (project / "pkg" / "formslib" / "__init__.py").write_text("", encoding="utf-8")
+    (project / "pkg" / "formslib" / "models.py").write_text(
+        FORMS_MODELS, encoding="utf-8"
+    )
+    (project / "pkg" / "user.py").write_text(
+        "from pkg import formslib as forms\n\n\n"
+        "class UserForm(forms.ModelForm):\n"
+        "    pass\n",
+        encoding="utf-8",
+    )
+    run_updater(project, mock_ingestor, skip_if_missing="python")
+
+    inherits = _edges(mock_ingestor, "INHERITS")
+    assert not any(
+        child == "reexp3.pkg.user.UserForm"
+        and parent == "reexp3.pkg.formslib.models.ModelForm"
+        for child, parent in inherits
+    )

--- a/codebase_rag/tests/test_package_reexport_inheritance.py
+++ b/codebase_rag/tests/test_package_reexport_inheritance.py
@@ -38,8 +38,7 @@ class BaseUserCreationForm(SetPasswordMixin, forms.ModelForm):
 
 def _edges(mock_ingestor: MagicMock, rel_type: str) -> set[tuple[str, str]]:
     return {
-        (c.args[0][2], c.args[2][2])
-        for c in get_relationships(mock_ingestor, rel_type)
+        (c.args[0][2], c.args[2][2]) for c in get_relationships(mock_ingestor, rel_type)
     }
 
 

--- a/codebase_rag/tests/test_package_reexport_inheritance.py
+++ b/codebase_rag/tests/test_package_reexport_inheritance.py
@@ -78,3 +78,33 @@ def test_override_of_reexported_base_method_is_recorded(
         "reexp.pkg.auth.forms.BaseUserCreationForm._post_clean",
         "reexp.pkg.formslib.models.BaseModelForm._post_clean",
     ) in _edges(mock_ingestor, "OVERRIDES")
+
+
+def test_same_named_function_under_package_is_not_an_inheritance_target(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) A factory FUNCTION with the base's simple name under the written
+    # (H) package must not be picked as the re-export target; with no class
+    # (H) candidate the base stays unresolved rather than corrupting the
+    # (H) hierarchy with an INHERITS edge onto a Function node.
+    project = temp_repo / "reexp2"
+    (project / "pkg" / "formslib").mkdir(parents=True)
+    (project / "pkg" / "__init__.py").write_text("", encoding="utf-8")
+    (project / "pkg" / "formslib" / "__init__.py").write_text("", encoding="utf-8")
+    (project / "pkg" / "formslib" / "factory.py").write_text(
+        "def ModelForm():\n    return 1\n", encoding="utf-8"
+    )
+    (project / "pkg" / "user.py").write_text(
+        "from pkg import formslib as forms\n\n\n"
+        "class UserForm(forms.ModelForm):\n"
+        "    pass\n",
+        encoding="utf-8",
+    )
+    run_updater(project, mock_ingestor, skip_if_missing="python")
+
+    inherits = _edges(mock_ingestor, "INHERITS")
+    assert not any(
+        child == "reexp2.pkg.user.UserForm"
+        and parent == "reexp2.pkg.formslib.factory.ModelForm"
+        for child, parent in inherits
+    )


### PR DESCRIPTION
## Problem

Found dogfooding dead-code detection on django (issue class: missing INHERITS through package re-exports, 4 false positives).

A base written as a PACKAGE attribute (`class BaseUserCreationForm(SetPasswordMixin, forms.ModelForm)` after `from django import forms`) resolves to the package path `django.forms.ModelForm`, but the class node lives at `django.forms.models.ModelForm` behind the package `__init__`'s star re-export. The deferred-INHERITS suffix match cannot bridge the missing `.models` segment, so no INHERITS edge was emitted, the class hierarchy broke, and every OVERRIDES relationship of the subclass vanished. Dead-code then reported live framework-invoked overrides:

- `django.contrib.auth.forms.BaseUserCreationForm._post_clean`
- `django.contrib.postgres.fields.array.ArrayField._choices_is_value`
- `django.contrib.postgres.fields.ranges.RangeField._choices_is_value`
- `django.db.models.fields.composite.CompositePrimaryKey._check_field_name`

## Fix

When the exact whole-segment suffix match fails, `_resolve_deferred_parent_qn` now tries a package-anchored match: a UNIQUE class under the written package path with the same simple name is the re-export target; ambiguity still emits no edge.

## Verification

- RED first: `test_package_reexport_inheritance.py` reproducing the django shape (star-re-exporting package, mixin-first bases); both INHERITS and the resulting OVERRIDES edge asserted.
- django corpus: the four symbols above drop from the dead-code report, zero regressions.
- Unit suite: 4603 passed, 0 failed.
