### PR TITLE
feat(cli): flag and settings to skip the semantic embedding pass

### DIFF
--- a/codebase_rag/cli.py
+++ b/codebase_rag/cli.py
@@ -130,6 +130,7 @@ def _sync_workspace(
     config: WorkspaceConfig,
     batch_size: int,
     exclude: list[str] | None,
+    skip_embeddings: bool | None = None,
 ) -> None:
     total = len(config.repos)
     if total == 0:
@@ -162,6 +163,7 @@ def _sync_workspace(
             batch_size=batch_size,
             exclude=exclude,
             interactive_setup=False,
+            skip_embeddings=skip_embeddings,
         )
 
 
@@ -192,6 +194,7 @@ def _run_graph_sync(
     interactive_setup: bool,
     clean: bool = False,
     output: str | None = None,
+    skip_embeddings: bool | None = None,
 ) -> None:
     cgrignore = load_ignore_patterns(repo)
     cli_excludes = frozenset(exclude) if exclude else frozenset()
@@ -221,6 +224,7 @@ def _run_graph_sync(
             unignore_paths=unignore_paths,
             exclude_paths=exclude_paths,
             project_name=project_name,
+            skip_embeddings=skip_embeddings,
         )
         updater.run()
         cgr_state.record_sync(project_name)
@@ -377,6 +381,11 @@ def start(
         "--no-sync",
         help=ch.HELP_NO_SYNC,
     ),
+    no_embeddings: bool = typer.Option(
+        False,
+        "--no-embeddings",
+        help=ch.HELP_NO_EMBEDDINGS,
+    ),
     projects: str | None = typer.Option(
         None,
         "--projects",
@@ -441,6 +450,7 @@ def start(
             interactive_setup=interactive_setup,
             clean=clean,
             output=output,
+            skip_embeddings=no_embeddings or None,
         )
         _info(style(cs.CLI_MSG_GRAPH_UPDATED, cs.Color.GREEN))
         return
@@ -452,7 +462,11 @@ def start(
     if not no_sync:
         if workspace_config is not None:
             sync_task = partial(
-                _sync_workspace, workspace_config, effective_batch_size, exclude
+                _sync_workspace,
+                workspace_config,
+                effective_batch_size,
+                exclude,
+                skip_embeddings=no_embeddings or None,
             )
             sync_message = cs.MSG_SYNCING_WORKSPACE.format(
                 name=workspace_config.name, count=len(workspace_config.repos)
@@ -465,6 +479,7 @@ def start(
                 batch_size=effective_batch_size,
                 exclude=exclude,
                 interactive_setup=interactive_setup,
+                skip_embeddings=no_embeddings or None,
             )
 
     if workspace_config is not None:

--- a/codebase_rag/cli_help.py
+++ b/codebase_rag/cli_help.py
@@ -84,6 +84,10 @@ HELP_NO_START_STACK = (
 HELP_NO_SYNC = (
     "Skip the automatic incremental graph sync that runs before the agent starts."
 )
+HELP_NO_EMBEDDINGS = (
+    "Skip the semantic embedding pass after graph sync; the graph itself still "
+    "builds fully. Env equivalent: CGR_SKIP_EMBEDDINGS=1."
+)
 HELP_PROJECTS = (
     "Comma-separated list of project names to scope agent queries to. "
     "Overrides --project-name. If omitted, defaults to the current repo's project."

--- a/codebase_rag/config.py
+++ b/codebase_rag/config.py
@@ -262,6 +262,10 @@ class AppConfig(BaseSettings):
     QDRANT_BATCH_SIZE: int = Field(default=50, gt=0)
     EMBEDDING_MAX_LENGTH: int = 512
     EMBEDDING_PROGRESS_INTERVAL: int = 10
+    SKIP_EMBEDDINGS: bool = Field(False, validation_alias="CGR_SKIP_EMBEDDINGS")
+    EMBEDDING_DEVICE: cs.EmbeddingDevice | None = Field(
+        None, validation_alias="CGR_EMBEDDING_DEVICE"
+    )
 
     FLUSH_THREAD_POOL_SIZE: int = Field(default=4, gt=0)
     FILE_FLUSH_INTERVAL: int = Field(default=500, gt=0)

--- a/codebase_rag/constants/providers.py
+++ b/codebase_rag/constants/providers.py
@@ -49,6 +49,13 @@ UNIXCODER_MODEL = "microsoft/unixcoder-base"
 EMBEDDING_DEFAULT_BATCH_SIZE = 64
 EMBEDDING_CACHE_FILENAME = ".embedding_cache.json"
 
+
+class EmbeddingDevice(StrEnum):
+    CUDA = "cuda"
+    MPS = "mps"
+    CPU = "cpu"
+
+
 # (H) ModelConfig field names
 FIELD_PROVIDER = "provider"
 FIELD_MODEL_ID = "model_id"

--- a/codebase_rag/embedder.py
+++ b/codebase_rag/embedder.py
@@ -98,22 +98,33 @@ if has_torch() and has_transformers():
 
     from .unixcoder import UniXcoder
 
-    def _select_device() -> str:
+    def _device_available(device: cs.EmbeddingDevice) -> bool:
+        match device:
+            case cs.EmbeddingDevice.CUDA:
+                return torch.cuda.is_available()
+            case cs.EmbeddingDevice.MPS:
+                return torch.backends.mps.is_available()
+            case _:
+                return True
+
+    def _select_device() -> cs.EmbeddingDevice:
+        if (override := settings.EMBEDDING_DEVICE) is not None:
+            if _device_available(override):
+                return override
+            logger.warning(ls.EMBEDDING_DEVICE_UNAVAILABLE.format(device=override))
         if torch.cuda.is_available():
-            return "cuda"
+            return cs.EmbeddingDevice.CUDA
         if torch.backends.mps.is_available():
-            return "mps"
-        return "cpu"
+            return cs.EmbeddingDevice.MPS
+        return cs.EmbeddingDevice.CPU
 
     @lru_cache(maxsize=1)
     def get_model() -> UniXcoder:
         model = UniXcoder(cs.UNIXCODER_MODEL)
         model.eval()
         device = _select_device()
-        if device == "cuda":
-            model = model.cuda()
-        elif device == "mps":
-            model = model.to("mps")
+        if device != cs.EmbeddingDevice.CPU:
+            model = model.to(device)
         return model
 
     def embed_code(code: str, max_length: int | None = None) -> list[float]:

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -444,6 +444,7 @@ class GraphUpdater:
         unignore_paths: frozenset[str] | None = None,
         exclude_paths: frozenset[str] | None = None,
         project_name: str | None = None,
+        skip_embeddings: bool | None = None,
     ):
         self.ingestor = ingestor
         self._single_file: Path | None = None
@@ -468,6 +469,11 @@ class GraphUpdater:
         self._parsed_files: list[tuple[Path, cs.SupportedLanguage]] = []
         self.unignore_paths = unignore_paths
         self.exclude_paths = exclude_paths
+        # (H) None defers to the CGR_SKIP_EMBEDDINGS setting so env-configured
+        # (H) callers (MCP, workspace sync) opt out without a CLI flag.
+        self.skip_embeddings = (
+            settings.SKIP_EMBEDDINGS if skip_embeddings is None else skip_embeddings
+        )
         self.skipped_because_in_sync = False
         self._collected_dir_mtimes: DirMtimesCache = {}
         self._cpp_frontend_covered: frozenset[str] = frozenset()
@@ -1432,6 +1438,10 @@ class GraphUpdater:
             logger.info(ls.PRUNE_SKIP)
 
     def _generate_semantic_embeddings(self) -> None:
+        if self.skip_embeddings:
+            logger.info(ls.EMBEDDINGS_SKIPPED)
+            return
+
         if not has_semantic_dependencies():
             logger.info(ls.SEMANTIC_NOT_AVAILABLE)
             return

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -59,6 +59,13 @@ SEMANTIC_NOT_AVAILABLE = (
     "Semantic search dependencies not available, skipping embedding generation"
 )
 INGESTOR_NO_QUERY = "Ingestor does not support querying, skipping embedding generation"
+EMBEDDINGS_SKIPPED = (
+    "Skipping semantic embedding generation (--no-embeddings / CGR_SKIP_EMBEDDINGS)"
+)
+EMBEDDING_DEVICE_UNAVAILABLE = (
+    "Requested embedding device '{device}' is unavailable, falling back to"
+    " automatic selection"
+)
 NO_FUNCTIONS_FOR_EMBEDDING = "No functions or methods found for embedding generation"
 GENERATING_EMBEDDINGS = "Generating embeddings for {count} functions/methods"
 EMBEDDING_PROGRESS = "Generated {done}/{total} embeddings"

--- a/codebase_rag/tests/test_embedder.py
+++ b/codebase_rag/tests/test_embedder.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from codebase_rag import constants as cs
 from codebase_rag.embedder import EmbeddingCache, clear_embedding_cache
 from codebase_rag.utils.dependencies import has_torch, has_transformers
 
@@ -132,13 +133,13 @@ def test_get_model_uses_cuda_when_available(reset_model_cache: None) -> None:
     with patch("codebase_rag.embedder.UniXcoder") as mock_unixcoder_class:
         mock_instance = MagicMock()
         mock_instance.eval.return_value = mock_instance
-        mock_instance.cuda.return_value = mock_instance
+        mock_instance.to.return_value = mock_instance
         mock_unixcoder_class.return_value = mock_instance
 
         with patch("codebase_rag.embedder.torch.cuda.is_available", return_value=True):
             get_model()
 
-    mock_instance.cuda.assert_called_once()
+    mock_instance.to.assert_called_once_with(cs.EmbeddingDevice.CUDA)
 
 
 @pytest.mark.skipif(not _has_semantic_deps(), reason="torch/transformers not installed")

--- a/codebase_rag/tests/test_skip_embeddings.py
+++ b/codebase_rag/tests/test_skip_embeddings.py
@@ -1,0 +1,173 @@
+# (H) Opting out of the semantic embedding pass (issue #690): the
+# (H) --no-embeddings CLI flag, the CGR_SKIP_EMBEDDINGS setting, and the
+# (H) CGR_EMBEDDING_DEVICE override for the embedder's device selection.
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from codebase_rag import constants as cs
+from codebase_rag.cli import app
+from codebase_rag.config import AppConfig, settings
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.services.graph_service import MemgraphIngestor
+from codebase_rag.utils.dependencies import has_torch, has_transformers
+
+runner = CliRunner()
+
+_PATCH_DEPS = patch(
+    "codebase_rag.graph_updater.has_semantic_dependencies", return_value=True
+)
+
+
+def _has_semantic_deps() -> bool:
+    return has_torch() and has_transformers()
+
+
+@pytest.fixture
+def query_ingestor() -> MagicMock:
+    mock = MagicMock(spec=MemgraphIngestor)
+    mock.fetch_all = MagicMock(return_value=[])
+    mock.execute_write = MagicMock()
+    return mock
+
+
+def _make_updater(
+    temp_repo: Path, ingestor: MagicMock, **kwargs: bool | None
+) -> GraphUpdater:
+    parsers, queries = load_parsers()
+    return GraphUpdater(
+        ingestor=ingestor,
+        repo_path=temp_repo,
+        parsers=parsers,
+        queries=queries,
+        **kwargs,
+    )
+
+
+class TestGraphUpdaterSkipEmbeddings:
+    @_PATCH_DEPS
+    def test_skip_flag_skips_embedding_pass(
+        self, _deps: MagicMock, temp_repo: Path, query_ingestor: MagicMock
+    ) -> None:
+        updater = _make_updater(temp_repo, query_ingestor, skip_embeddings=True)
+        updater._generate_semantic_embeddings()
+        query_ingestor.fetch_all.assert_not_called()
+
+    @_PATCH_DEPS
+    def test_default_runs_embedding_pass(
+        self, _deps: MagicMock, temp_repo: Path, query_ingestor: MagicMock
+    ) -> None:
+        updater = _make_updater(temp_repo, query_ingestor)
+        assert updater.skip_embeddings is False
+        updater._generate_semantic_embeddings()
+        query_ingestor.fetch_all.assert_called_once()
+
+    @_PATCH_DEPS
+    def test_env_setting_skips_by_default(
+        self,
+        _deps: MagicMock,
+        temp_repo: Path,
+        query_ingestor: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(settings, "SKIP_EMBEDDINGS", True)
+        updater = _make_updater(temp_repo, query_ingestor)
+        assert updater.skip_embeddings is True
+        updater._generate_semantic_embeddings()
+        query_ingestor.fetch_all.assert_not_called()
+
+    @_PATCH_DEPS
+    def test_explicit_false_overrides_env_setting(
+        self,
+        _deps: MagicMock,
+        temp_repo: Path,
+        query_ingestor: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(settings, "SKIP_EMBEDDINGS", True)
+        updater = _make_updater(temp_repo, query_ingestor, skip_embeddings=False)
+        updater._generate_semantic_embeddings()
+        query_ingestor.fetch_all.assert_called_once()
+
+
+class TestCliNoEmbeddingsFlag:
+    def _invoke_start(self, tmp_path: Path, *extra: str) -> MagicMock:
+        with (
+            patch("codebase_rag.cli.GraphUpdater") as mock_updater_cls,
+            patch("codebase_rag.cli.connect_memgraph") as mock_connect,
+            patch("codebase_rag.cli.load_parsers", return_value=({}, {})),
+            patch("codebase_rag.cli.cgr_state"),
+            patch("codebase_rag.cli._update_and_validate_models"),
+        ):
+            mock_connect.return_value.__enter__ = MagicMock(return_value=MagicMock())
+            mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+            result = runner.invoke(
+                app,
+                [
+                    "start",
+                    "--update-graph",
+                    "--no-start-stack",
+                    "--repo-path",
+                    str(tmp_path),
+                    *extra,
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        return mock_updater_cls
+
+    def test_no_embeddings_flag_reaches_updater(self, tmp_path: Path) -> None:
+        mock_updater_cls = self._invoke_start(tmp_path, "--no-embeddings")
+        assert mock_updater_cls.call_args.kwargs["skip_embeddings"] is True
+
+    def test_without_flag_defers_to_settings(self, tmp_path: Path) -> None:
+        mock_updater_cls = self._invoke_start(tmp_path)
+        assert mock_updater_cls.call_args.kwargs["skip_embeddings"] is None
+
+
+class TestSkipEmbeddingsConfig:
+    def test_env_vars_parse(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CGR_SKIP_EMBEDDINGS", "1")
+        monkeypatch.setenv("CGR_EMBEDDING_DEVICE", "cpu")
+        config = AppConfig()
+        assert config.SKIP_EMBEDDINGS is True
+        assert config.EMBEDDING_DEVICE == cs.EmbeddingDevice.CPU
+
+    def test_defaults(self) -> None:
+        config = AppConfig()
+        assert config.SKIP_EMBEDDINGS is False
+        assert config.EMBEDDING_DEVICE is None
+
+
+@pytest.mark.skipif(not _has_semantic_deps(), reason="torch/transformers not installed")
+class TestEmbeddingDeviceOverride:
+    def test_override_wins_when_available(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from codebase_rag.embedder import (
+            _select_device,  # ty: ignore[possibly-missing-import]
+        )
+
+        monkeypatch.setattr(settings, "EMBEDDING_DEVICE", cs.EmbeddingDevice.CPU)
+        assert _select_device() == cs.EmbeddingDevice.CPU
+
+    def test_unavailable_override_falls_back_to_auto(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import torch
+
+        from codebase_rag.embedder import (
+            _select_device,  # ty: ignore[possibly-missing-import]
+        )
+
+        monkeypatch.setattr(settings, "EMBEDDING_DEVICE", cs.EmbeddingDevice.CUDA)
+        with (
+            patch.object(torch.cuda, "is_available", return_value=False),
+            patch.object(torch.backends.mps, "is_available", return_value=False),
+        ):
+            assert _select_device() == cs.EmbeddingDevice.CPU

--- a/codebase_rag/tests/test_skip_embeddings.py
+++ b/codebase_rag/tests/test_skip_embeddings.py
@@ -38,7 +38,7 @@ def query_ingestor() -> MagicMock:
 
 
 def _make_updater(
-    temp_repo: Path, ingestor: MagicMock, **kwargs: bool | None
+    temp_repo: Path, ingestor: MagicMock, skip_embeddings: bool | None = None
 ) -> GraphUpdater:
     parsers, queries = load_parsers()
     return GraphUpdater(
@@ -46,7 +46,7 @@ def _make_updater(
         repo_path=temp_repo,
         parsers=parsers,
         queries=queries,
-        **kwargs,
+        skip_embeddings=skip_embeddings,
     )
 
 
@@ -149,9 +149,7 @@ class TestEmbeddingDeviceOverride:
     def test_override_wins_when_available(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        from codebase_rag.embedder import (
-            _select_device,  # ty: ignore[possibly-missing-import]
-        )
+        from codebase_rag.embedder import _select_device
 
         monkeypatch.setattr(settings, "EMBEDDING_DEVICE", cs.EmbeddingDevice.CPU)
         assert _select_device() == cs.EmbeddingDevice.CPU
@@ -161,9 +159,7 @@ class TestEmbeddingDeviceOverride:
     ) -> None:
         import torch
 
-        from codebase_rag.embedder import (
-            _select_device,  # ty: ignore[possibly-missing-import]
-        )
+        from codebase_rag.embedder import _select_device
 
         monkeypatch.setattr(settings, "EMBEDDING_DEVICE", cs.EmbeddingDevice.CUDA)
         with (

--- a/codebase_rag/tests/test_skip_embeddings.py
+++ b/codebase_rag/tests/test_skip_embeddings.py
@@ -154,14 +154,17 @@ class TestEmbeddingDeviceOverride:
         monkeypatch.setattr(settings, "EMBEDDING_DEVICE", cs.EmbeddingDevice.CPU)
         assert _select_device() == cs.EmbeddingDevice.CPU
 
+    @pytest.mark.parametrize(
+        "override", [cs.EmbeddingDevice.CUDA, cs.EmbeddingDevice.MPS]
+    )
     def test_unavailable_override_falls_back_to_auto(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, monkeypatch: pytest.MonkeyPatch, override: cs.EmbeddingDevice
     ) -> None:
         import torch
 
         from codebase_rag.embedder import _select_device
 
-        monkeypatch.setattr(settings, "EMBEDDING_DEVICE", cs.EmbeddingDevice.CUDA)
+        monkeypatch.setattr(settings, "EMBEDDING_DEVICE", override)
         with (
             patch.object(torch.cuda, "is_available", return_value=False),
             patch.object(torch.backends.mps, "is_available", return_value=False),

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.278"
+version = "0.0.286"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #690

Adds an off switch for the semantic embedding pass and an escape hatch for the device it runs on:

- `cgr start --no-embeddings` skips pass 4 after graph sync, for both single-repo sync and workspace sync. The graph itself still builds fully.
- `CGR_SKIP_EMBEDDINGS=1` (settings/env equivalent) does the same for env-configured callers; an explicit constructor argument on `GraphUpdater` overrides it in either direction.
- `CGR_EMBEDDING_DEVICE=cpu|cuda|mps` overrides the hardcoded cuda -> mps -> cpu auto-selection in the embedder. An unavailable requested device logs a warning and falls back to auto-selection instead of crashing.
- Device strings are now a `cs.EmbeddingDevice` StrEnum; `get_model` uses one `.to(device)` path instead of separate cuda/mps branches.

Motivation: on monorepo-scale repos the embedding pass dominates sync time, and with #689 it can wedge entirely on Apple Silicon. Workflows that only need the graph (dead-code, stats, structural queries) previously had no way to opt out short of uninstalling the semantic extras.

TDD: the first commit adds the failing tests (flag threading through the CLI, settings fallback and override precedence, env parsing, device override honored and unavailable-device fallback), the second makes them pass.