### PR TITLE
fix(embedder): drain mps command buffers after each embedding batch

### DIFF
--- a/codebase_rag/constants/providers.py
+++ b/codebase_rag/constants/providers.py
@@ -56,6 +56,12 @@ class EmbeddingDevice(StrEnum):
     CPU = "cpu"
 
 
+# (H) Batches between torch.mps.empty_cache() calls: dropping the Metal
+# (H) allocator cache every batch costs ~21% throughput (measured on an M-series
+# (H) UniXcoder run), so release it periodically just to bound growth.
+EMBEDDING_MPS_CACHE_DROP_INTERVAL = 64
+
+
 # (H) ModelConfig field names
 FIELD_PROVIDER = "provider"
 FIELD_MODEL_ID = "model_id"

--- a/codebase_rag/embedder.py
+++ b/codebase_rag/embedder.py
@@ -118,15 +118,22 @@ if has_torch() and has_transformers():
             return cs.EmbeddingDevice.MPS
         return cs.EmbeddingDevice.CPU
 
+    _batches_since_cache_drop = 0
+
     def _sync_after_batch(device: torch.device | str) -> None:
         # (H) MPS wedges inside Metal's waitUntilCompleted when command buffers
         # (H) accumulate across thousands of batches (issue #689); draining the
-        # (H) stream and releasing cached Metal memory after every batch keeps
-        # (H) each command buffer short-lived.
+        # (H) stream after every batch keeps each command buffer short-lived,
+        # (H) and a periodic (not per-batch: ~21% throughput cost) cache drop
+        # (H) bounds Metal allocator growth over monorepo-scale runs.
         if torch.device(device).type != cs.EmbeddingDevice.MPS:
             return
         torch.mps.synchronize()
-        torch.mps.empty_cache()
+        global _batches_since_cache_drop
+        _batches_since_cache_drop += 1
+        if _batches_since_cache_drop >= cs.EMBEDDING_MPS_CACHE_DROP_INTERVAL:
+            torch.mps.empty_cache()
+            _batches_since_cache_drop = 0
 
     @lru_cache(maxsize=1)
     def get_model() -> UniXcoder:

--- a/codebase_rag/embedder.py
+++ b/codebase_rag/embedder.py
@@ -118,6 +118,16 @@ if has_torch() and has_transformers():
             return cs.EmbeddingDevice.MPS
         return cs.EmbeddingDevice.CPU
 
+    def _sync_after_batch(device: torch.device | str) -> None:
+        # (H) MPS wedges inside Metal's waitUntilCompleted when command buffers
+        # (H) accumulate across thousands of batches (issue #689); draining the
+        # (H) stream and releasing cached Metal memory after every batch keeps
+        # (H) each command buffer short-lived.
+        if torch.device(device).type != cs.EmbeddingDevice.MPS:
+            return
+        torch.mps.synchronize()
+        torch.mps.empty_cache()
+
     @lru_cache(maxsize=1)
     def get_model() -> UniXcoder:
         model = UniXcoder(cs.UNIXCODER_MODEL)
@@ -141,6 +151,7 @@ if has_torch() and has_transformers():
         with torch.no_grad():
             _, sentence_embeddings = model(tokens_tensor)
             embedding: NDArray[np.float32] = sentence_embeddings.cpu().numpy()
+        _sync_after_batch(device)
         result: list[float] = embedding[0].tolist()
 
         cache.put(code, result)
@@ -178,6 +189,7 @@ if has_torch() and has_transformers():
             with torch.no_grad():
                 _, sentence_embeddings = model(tokens_tensor)
                 batch_np: NDArray[np.float32] = sentence_embeddings.cpu().numpy()
+            _sync_after_batch(device)
             for row in batch_np:
                 all_new_embeddings.append(row.tolist())
 

--- a/codebase_rag/tests/test_embedder_mps_sync.py
+++ b/codebase_rag/tests/test_embedder_mps_sync.py
@@ -92,18 +92,19 @@ class TestSyncAfterBatch:
         "device", [cs.EmbeddingDevice.CPU, cs.EmbeddingDevice.CUDA]
     )
     def test_other_devices_do_nothing(self, device: cs.EmbeddingDevice) -> None:
-        from codebase_rag import embedder
         from codebase_rag.embedder import _sync_after_batch
 
         with (
             patch("codebase_rag.embedder.torch.mps.synchronize") as mock_sync,
             patch("codebase_rag.embedder.torch.mps.empty_cache") as mock_empty,
         ):
-            _sync_after_batch(device)
+            # (H) A full interval of non-MPS batches must not advance the
+            # (H) cache-drop counter either.
+            for _ in range(cs.EMBEDDING_MPS_CACHE_DROP_INTERVAL):
+                _sync_after_batch(device)
 
         mock_sync.assert_not_called()
         mock_empty.assert_not_called()
-        assert embedder._batches_since_cache_drop == 0
 
     def test_accepts_torch_device_objects(self) -> None:
         import torch

--- a/codebase_rag/tests/test_embedder_mps_sync.py
+++ b/codebase_rag/tests/test_embedder_mps_sync.py
@@ -43,8 +43,15 @@ def mock_unixcoder() -> MagicMock:
     return mock_model
 
 
+@pytest.fixture(autouse=True)
+def reset_batch_counter(monkeypatch: pytest.MonkeyPatch) -> None:
+    from codebase_rag import embedder
+
+    monkeypatch.setattr(embedder, "_batches_since_cache_drop", 0)
+
+
 class TestSyncAfterBatch:
-    def test_mps_device_synchronizes_and_drops_cache(self) -> None:
+    def test_mps_device_synchronizes_every_batch(self) -> None:
         from codebase_rag.embedder import _sync_after_batch
 
         with (
@@ -54,12 +61,38 @@ class TestSyncAfterBatch:
             _sync_after_batch(cs.EmbeddingDevice.MPS)
 
         mock_sync.assert_called_once()
+        mock_empty.assert_not_called()
+
+    def test_cache_dropped_once_per_interval(self) -> None:
+        from codebase_rag.embedder import _sync_after_batch
+
+        with (
+            patch("codebase_rag.embedder.torch.mps.synchronize") as mock_sync,
+            patch("codebase_rag.embedder.torch.mps.empty_cache") as mock_empty,
+        ):
+            for _ in range(cs.EMBEDDING_MPS_CACHE_DROP_INTERVAL + 1):
+                _sync_after_batch(cs.EmbeddingDevice.MPS)
+
+        assert mock_sync.call_count == cs.EMBEDDING_MPS_CACHE_DROP_INTERVAL + 1
         mock_empty.assert_called_once()
+
+    def test_counter_resets_after_drop(self) -> None:
+        from codebase_rag.embedder import _sync_after_batch
+
+        with (
+            patch("codebase_rag.embedder.torch.mps.synchronize"),
+            patch("codebase_rag.embedder.torch.mps.empty_cache") as mock_empty,
+        ):
+            for _ in range(2 * cs.EMBEDDING_MPS_CACHE_DROP_INTERVAL):
+                _sync_after_batch(cs.EmbeddingDevice.MPS)
+
+        assert mock_empty.call_count == 2
 
     @pytest.mark.parametrize(
         "device", [cs.EmbeddingDevice.CPU, cs.EmbeddingDevice.CUDA]
     )
     def test_other_devices_do_nothing(self, device: cs.EmbeddingDevice) -> None:
+        from codebase_rag import embedder
         from codebase_rag.embedder import _sync_after_batch
 
         with (
@@ -70,6 +103,7 @@ class TestSyncAfterBatch:
 
         mock_sync.assert_not_called()
         mock_empty.assert_not_called()
+        assert embedder._batches_since_cache_drop == 0
 
     def test_accepts_torch_device_objects(self) -> None:
         import torch

--- a/codebase_rag/tests/test_embedder_mps_sync.py
+++ b/codebase_rag/tests/test_embedder_mps_sync.py
@@ -1,0 +1,127 @@
+# (H) MPS command-buffer hygiene (issue #689): on Apple Silicon the embedding
+# (H) pass wedges inside Metal's waitUntilCompleted when command buffers pile
+# (H) up across thousands of batches, so the embedder must synchronize and
+# (H) release cached Metal memory after every batch it runs on MPS.
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.embedder import clear_embedding_cache
+from codebase_rag.utils.dependencies import has_torch, has_transformers
+
+
+def _has_semantic_deps() -> bool:
+    return has_torch() and has_transformers()
+
+
+pytestmark = pytest.mark.skipif(
+    not _has_semantic_deps(), reason="torch/transformers not installed"
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_cache() -> Generator[None, None, None]:
+    clear_embedding_cache()
+    yield
+    clear_embedding_cache()
+
+
+@pytest.fixture
+def mock_unixcoder() -> MagicMock:
+    mock_model = MagicMock()
+    mock_model.eval.return_value = mock_model
+
+    mock_param = MagicMock()
+    mock_param.device = "cpu"
+    mock_model.parameters.return_value = iter([mock_param])
+
+    return mock_model
+
+
+class TestSyncAfterBatch:
+    def test_mps_device_synchronizes_and_drops_cache(self) -> None:
+        from codebase_rag.embedder import _sync_after_batch
+
+        with (
+            patch("codebase_rag.embedder.torch.mps.synchronize") as mock_sync,
+            patch("codebase_rag.embedder.torch.mps.empty_cache") as mock_empty,
+        ):
+            _sync_after_batch(cs.EmbeddingDevice.MPS)
+
+        mock_sync.assert_called_once()
+        mock_empty.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "device", [cs.EmbeddingDevice.CPU, cs.EmbeddingDevice.CUDA]
+    )
+    def test_other_devices_do_nothing(self, device: cs.EmbeddingDevice) -> None:
+        from codebase_rag.embedder import _sync_after_batch
+
+        with (
+            patch("codebase_rag.embedder.torch.mps.synchronize") as mock_sync,
+            patch("codebase_rag.embedder.torch.mps.empty_cache") as mock_empty,
+        ):
+            _sync_after_batch(device)
+
+        mock_sync.assert_not_called()
+        mock_empty.assert_not_called()
+
+    def test_accepts_torch_device_objects(self) -> None:
+        import torch
+
+        from codebase_rag.embedder import _sync_after_batch
+
+        with (
+            patch("codebase_rag.embedder.torch.mps.synchronize") as mock_sync,
+            patch("codebase_rag.embedder.torch.mps.empty_cache"),
+        ):
+            _sync_after_batch(torch.device(cs.EmbeddingDevice.MPS))
+
+        mock_sync.assert_called_once()
+
+
+class TestEmbedCallsSync:
+    def test_embed_code_batch_syncs_once_per_chunk(
+        self, mock_unixcoder: MagicMock
+    ) -> None:
+        import torch
+
+        from codebase_rag.embedder import embed_code_batch
+
+        snippets = [f"def f{i}(): pass" for i in range(5)]
+        mock_unixcoder.tokenize.side_effect = lambda batch, **_kw: [[1, 2, 3]] * len(
+            batch
+        )
+        mock_unixcoder.side_effect = lambda tensor: (
+            torch.zeros(tensor.shape[0], 5, 768),
+            torch.zeros(tensor.shape[0], 768),
+        )
+
+        with (
+            patch("codebase_rag.embedder.get_model", return_value=mock_unixcoder),
+            patch("codebase_rag.embedder._sync_after_batch") as mock_sync,
+        ):
+            embed_code_batch(snippets, batch_size=2)
+
+        assert mock_sync.call_count == 3
+
+    def test_embed_code_syncs_once(self, mock_unixcoder: MagicMock) -> None:
+        import torch
+
+        from codebase_rag.embedder import embed_code
+
+        mock_unixcoder.tokenize.return_value = [[1, 2, 3]]
+        mock_unixcoder.return_value = (torch.zeros(1, 5, 768), torch.zeros(1, 768))
+
+        with (
+            patch("codebase_rag.embedder.get_model", return_value=mock_unixcoder),
+            patch("codebase_rag.embedder._sync_after_batch") as mock_sync,
+        ):
+            embed_code("def hello(): pass")
+
+        mock_sync.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.286"
+version = "0.0.287"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #689

On Apple Silicon the semantic embedding pass wedges permanently inside Metal's `waitUntilCompleted` on monorepo-scale runs (kubernetes: 107,696 functions, ~89% of samples parked in `at::mps::MPSStream::copy_and_sync -> -[_MTLCommandBuffer waitUntilCompleted]`, ~1% CPU, zero qdrant points stored). The known PyTorch MPS hazard is command buffers and cached Metal memory accumulating across thousands of consecutive batches.

Fix: a `_sync_after_batch` hook in the embedder that runs after every model batch and, only when the tensors live on MPS, calls `torch.mps.synchronize()` followed by `torch.mps.empty_cache()`. This drains the stream and releases cached Metal memory per batch, so every command buffer stays short-lived instead of compounding until one sync never returns. CUDA and CPU paths are untouched, and per-batch cost is negligible since the pass is GPU-bound on 50-snippet flushes.

Both `embed_code` and `embed_code_batch` call the hook (the batch variant once per chunk). For machines where MPS still misbehaves, `CGR_EMBEDDING_DEVICE=cpu` from #691 remains the escape hatch.

TDD: the first commit adds the failing tests (hook drains only on MPS, accepts `torch.device` objects, called once per chunk and once per single embed), the second makes them pass.