### PR TITLE
fix(deadcode): treat methods of factory-built classes as dispatch roots

### DIFF
--- a/codebase_rag/dead_code.py
+++ b/codebase_rag/dead_code.py
@@ -183,9 +183,12 @@ def dead_code_from_graph(
     defines_pairs: list[tuple[str, str]] = []
     protocol_classes: set[str] = set()
     class_methods: list[tuple[str, str]] = []
-    for from_label, from_val, rel_type, _to_label, to_val in rels:
+    nested_class_pairs: list[tuple[str, str]] = []
+    for from_label, from_val, rel_type, to_label, to_val in rels:
         if rel_type == _DEFINES and from_label in (_FUNCTION, _METHOD):
             defines_pairs.append((str(from_val), str(to_val)))
+            if to_label == _CLASS:
+                nested_class_pairs.append((str(from_val), str(to_val)))
         elif rel_type == _INHERITS and str(to_val) in cs.PROTOCOL_BASE_QNS:
             protocol_classes.add(str(from_val))
         elif rel_type == _DEFINES_METHOD:
@@ -280,6 +283,22 @@ def dead_code_from_graph(
     }
     live |= closure_roots
     _walk(closure_roots, adjacency, live)
+
+    # (H) Factory-class expansion: a class defined inside a LIVE function or
+    # (H) method (django's create_reverse_many_to_one_manager) escapes through
+    # (H) the factory's return value or arguments, so its instances live behind
+    # (H) receivers the call graph cannot type and no call edge ever lands on
+    # (H) the methods. Treat the methods as dispatch surface (like exported
+    # (H) API) and revive their callee closure; a DEAD factory's class stays
+    # (H) dead. ponytail: one round, so a factory first revived by the override
+    # (H) expansion below is missed -- iterate to fixed point if real code hits
+    # (H) that.
+    factory_classes = {c for owner, c in nested_class_pairs if owner in live}
+    factory_method_roots = {
+        m for c, m in class_methods if c in factory_classes and m not in live
+    }
+    live |= factory_classes | factory_method_roots
+    _walk(factory_method_roots, adjacency, live)
 
     # (H) Override expansion: a call to a base or interface method dispatches at
     # (H) runtime to any override, so every (transitive) override of a LIVE method

--- a/codebase_rag/dead_code.py
+++ b/codebase_rag/dead_code.py
@@ -30,11 +30,6 @@ _INHERITS = cs.RelationshipType.INHERITS.value
 _DEFINES = cs.RelationshipType.DEFINES.value
 _DEFINES_METHOD = cs.RelationshipType.DEFINES_METHOD.value
 _OVERRIDES = cs.RelationshipType.OVERRIDES.value
-# (H) Rounds of override-reachability expansion. Covers depth-N override/callee
-# (H) interleaving (a base revived via an override's callee, whose own overrides
-# (H) then need reviving); a round that adds nothing breaks out early.
-_OVERRIDE_EXPANSION_ROUNDS = 3
-
 _NodeId = tuple[str, PropertyValue]
 _RelTuple = tuple[str, PropertyValue, str, str, PropertyValue]
 
@@ -284,46 +279,62 @@ def dead_code_from_graph(
     live |= closure_roots
     _walk(closure_roots, adjacency, live)
 
-    # (H) Factory-class expansion: a class defined inside a LIVE function or
-    # (H) method (django's create_reverse_many_to_one_manager) escapes through
-    # (H) the factory's return value or arguments, so its instances live behind
+    # (H) Factory-class and override expansions, iterated together to a fixed
+    # (H) point because they feed each other (a factory revived only via an
+    # (H) override's callee still needs its class rooted, and vice versa).
+    # (H)
+    # (H) Factory-class rule: a class defined inside a LIVE function or method
+    # (H) (django's create_reverse_many_to_one_manager) escapes through the
+    # (H) factory's return value or arguments, so its instances live behind
     # (H) receivers the call graph cannot type and no call edge ever lands on
     # (H) the methods. Treat the methods as dispatch surface (like exported
     # (H) API) and revive their callee closure; a DEAD factory's class stays
-    # (H) dead. ponytail: one round, so a factory first revived by the override
-    # (H) expansion below is missed -- iterate to fixed point if real code hits
-    # (H) that.
-    factory_classes = {c for owner, c in nested_class_pairs if owner in live}
-    factory_method_roots = {
-        m for c, m in class_methods if c in factory_classes and m not in live
-    }
-    live |= factory_classes | factory_method_roots
-    _walk(factory_method_roots, adjacency, live)
+    # (H) dead.
+    # (H)
+    # (H) Override rule: a call to a base or interface method dispatches at
+    # (H) runtime to any override, so every (transitive) override of a LIVE
+    # (H) method is a reachable dispatch target, as is its callee closure.
+    # (H) `override_rev` walks all multi-level overriders (Base<-Sub<-SubSub);
+    # (H) an override of a DEAD base stays dead.
+    # (H)
+    # (H) Each round scans only the nodes revived since the last one (the pair
+    # (H) maps and override_rev are static, so a rescanned node cannot yield
+    # (H) anything new), keeping the loop O(live) total; a round that adds
+    # (H) nothing terminates it.
+    classes_by_owner: dict[str, set[str]] = defaultdict(set)
+    for owner, cls in nested_class_pairs:
+        classes_by_owner[owner].add(cls)
+    methods_by_class: dict[str, set[str]] = defaultdict(set)
+    for cls, m in class_methods:
+        methods_by_class[cls].add(m)
 
-    # (H) Override expansion: a call to a base or interface method dispatches at
-    # (H) runtime to any override, so every (transitive) override of a LIVE method
-    # (H) is a reachable dispatch target, as is its callee closure. `override_rev`
-    # (H) walks all multi-level overriders (Base<-Sub<-SubSub); an override of a
-    # (H) DEAD base stays dead. Run several rounds because a base can go live only
-    # (H) via a revived override's CALLEE (depth-2+ interleaving); one pass would
-    # (H) miss those. A round that adds nothing is a no-op. Each round scans only
-    # (H) the nodes that became live since the last one (override_rev is static,
-    # (H) so already-scanned nodes cannot yield new overriders), keeping the loop
-    # (H) O(live) total instead of O(rounds x live).
     frontier = set(live)
-    for _ in range(_OVERRIDE_EXPANSION_ROUNDS):
+    while frontier:
+        added: set[str] = set()
+
+        factory_method_roots: set[str] = set()
+        for owner in frontier:
+            for cls in classes_by_owner.get(owner, ()):
+                if cls not in live:
+                    live.add(cls)
+                    added.add(cls)
+                factory_method_roots |= methods_by_class[cls] - live
+        live |= factory_method_roots
+        added |= factory_method_roots
+        _walk(factory_method_roots, adjacency, live, added=added)
+
         override_roots: set[str] = set()
-        stack = list(frontier)
+        stack = list(frontier | added)
         while stack:
             for overrider in override_rev.get(stack.pop(), ()):
                 if overrider not in live and overrider not in override_roots:
                     override_roots.add(overrider)
                     stack.append(overrider)
-        if not override_roots:
-            break
         live |= override_roots
-        frontier = set(override_roots)
-        _walk(override_roots, adjacency, live, added=frontier)
+        added |= override_roots
+        _walk(override_roots, adjacency, live, added=added)
+
+        frontier = added
 
     dead = candidates - live
     # (H) Suppress generated files (openapi-ts client/core, routeTree.gen.ts) from

--- a/codebase_rag/tests/test_dead_code_eval.py
+++ b/codebase_rag/tests/test_dead_code_eval.py
@@ -899,3 +899,125 @@ def test_module_edge_to_non_candidate_is_ignored() -> None:
     rels = [(_MODULE, "proj.m", _CALLS, _CLASS, "proj.m.Widget")]
     dead = dead_code_from_graph(nodes, rels, _PREFIX, _CONFIG)
     assert dead == {"proj.m.orphan"}
+
+
+def test_factory_class_methods_are_dispatch_roots() -> None:
+    # (H) django-style class factory: create_manager() defines RelatedManager
+    # (H) inside itself and hands it out (return value / argument), so instances
+    # (H) surface behind dynamic receivers and no call edge ever lands on the
+    # (H) methods. Once the factory is LIVE its class's methods are dispatch
+    # (H) surface, and their callee closure revives with them.
+    method = cs.NodeLabel.METHOD.value
+    nodes = dict(
+        [
+            (
+                (_MODULE, "proj.m"),
+                {cs.KEY_QUALIFIED_NAME: "proj.m", cs.KEY_PATH: "m.py"},
+            ),
+            _fn("proj.m.create_manager"),
+            _class("proj.m.create_manager.RelatedManager"),
+            _method("proj.m.create_manager.RelatedManager.add"),
+            _method("proj.m.create_manager.RelatedManager._apply_filters"),
+        ]
+    )
+    rels = [
+        (_MODULE, "proj.m", _CALLS, _FUNCTION, "proj.m.create_manager"),
+        (
+            _FUNCTION,
+            "proj.m.create_manager",
+            _DEFINES,
+            _CLASS,
+            "proj.m.create_manager.RelatedManager",
+        ),
+        (
+            _CLASS,
+            "proj.m.create_manager.RelatedManager",
+            _DEFINES_METHOD,
+            method,
+            "proj.m.create_manager.RelatedManager.add",
+        ),
+        (
+            _CLASS,
+            "proj.m.create_manager.RelatedManager",
+            _DEFINES_METHOD,
+            method,
+            "proj.m.create_manager.RelatedManager._apply_filters",
+        ),
+        (
+            method,
+            "proj.m.create_manager.RelatedManager.add",
+            _CALLS,
+            method,
+            "proj.m.create_manager.RelatedManager._apply_filters",
+        ),
+    ]
+    dead = dead_code_from_graph(nodes, rels, _PREFIX, _CONFIG)
+    assert dead == set()
+
+
+def test_dead_factory_class_methods_stay_dead() -> None:
+    # (H) The factory itself is never called: neither it nor its nested class's
+    # (H) methods may be revived (the dispatch-surface rule applies only to LIVE
+    # (H) factories).
+    method = cs.NodeLabel.METHOD.value
+    nodes = dict(
+        [
+            (
+                (_MODULE, "proj.m"),
+                {cs.KEY_QUALIFIED_NAME: "proj.m", cs.KEY_PATH: "m.py"},
+            ),
+            _fn("proj.m.create_manager"),
+            _class("proj.m.create_manager.RelatedManager"),
+            _method("proj.m.create_manager.RelatedManager.add"),
+        ]
+    )
+    rels = [
+        (
+            _FUNCTION,
+            "proj.m.create_manager",
+            _DEFINES,
+            _CLASS,
+            "proj.m.create_manager.RelatedManager",
+        ),
+        (
+            _CLASS,
+            "proj.m.create_manager.RelatedManager",
+            _DEFINES_METHOD,
+            method,
+            "proj.m.create_manager.RelatedManager.add",
+        ),
+    ]
+    dead = dead_code_from_graph(nodes, rels, _PREFIX, _CONFIG)
+    assert dead == {
+        "proj.m.create_manager",
+        "proj.m.create_manager.RelatedManager.add",
+    }
+
+
+def test_module_level_class_methods_are_not_rooted_by_defines() -> None:
+    # (H) The dispatch-surface rule is scoped to classes nested in functions or
+    # (H) methods: a module-level class's uncalled method must stay dead.
+    method = cs.NodeLabel.METHOD.value
+    nodes = dict(
+        [
+            (
+                (_MODULE, "proj.m"),
+                {cs.KEY_QUALIFIED_NAME: "proj.m", cs.KEY_PATH: "m.py"},
+            ),
+            _class("proj.m.Plain"),
+            _method("proj.m.Plain.helper"),
+        ]
+    )
+    rels = [
+        (_MODULE, "proj.m", _DEFINES, _CLASS, "proj.m.Plain"),
+        (_MODULE, "proj.m", _CALLS, _CLASS, "proj.m.Plain"),
+        (
+            _CLASS,
+            "proj.m.Plain",
+            _DEFINES_METHOD,
+            method,
+            "proj.m.Plain.helper",
+        ),
+    ]
+    dead = dead_code_from_graph(nodes, rels, _PREFIX, _CONFIG)
+    assert dead == {"proj.m.Plain.helper"}

--- a/codebase_rag/tests/test_dead_code_eval.py
+++ b/codebase_rag/tests/test_dead_code_eval.py
@@ -38,11 +38,12 @@ def _fn(uid: str, path: str = "m.py", decorators: list[str] | None = None) -> tu
     )
 
 
-def _method(uid: str, path: str) -> tuple:
+def _method(uid: str, path: str = "m.py") -> tuple:
     return (
         (cs.NodeLabel.METHOD.value, uid),
         {
             cs.KEY_QUALIFIED_NAME: uid,
+            cs.KEY_NAME: uid.rsplit(cs.SEPARATOR_DOT, 1)[-1],
             cs.KEY_PATH: path,
             cs.KEY_DECORATORS: [],
             cs.KEY_IS_EXPORTED: False,
@@ -441,19 +442,6 @@ def test_cgr_dead_code_matches_known_dead_set(tmp_path: Path) -> None:
     assert "proj.m.orphan" not in dead
     assert "proj.m.main" not in dead
     assert "proj.m.helper" not in dead
-
-
-def _method(uid: str, path: str = "m.py") -> tuple:
-    return (
-        (cs.NodeLabel.METHOD.value, uid),
-        {
-            cs.KEY_QUALIFIED_NAME: uid,
-            cs.KEY_NAME: uid.rsplit(cs.SEPARATOR_DOT, 1)[-1],
-            cs.KEY_PATH: path,
-            cs.KEY_DECORATORS: [],
-            cs.KEY_IS_EXPORTED: False,
-        },
-    )
 
 
 def test_dunder_root_is_limited_to_methods() -> None:

--- a/codebase_rag/tests/test_dead_code_eval.py
+++ b/codebase_rag/tests/test_dead_code_eval.py
@@ -1009,3 +1009,42 @@ def test_module_level_class_methods_are_not_rooted_by_defines() -> None:
     ]
     dead = dead_code_from_graph(nodes, rels, _PREFIX, _CONFIG)
     assert dead == {"proj.m.Plain.helper"}
+
+
+def test_factory_revived_by_override_expansion_roots_its_class() -> None:
+    # (H) Interleaving: Sub.make only goes live as an OVERRIDE of the called
+    # (H) Base.make, and Sub.make is itself a class factory. The factory and
+    # (H) override expansions feed each other, so the nested class's methods
+    # (H) must still be revived (fixed point, not a fixed pass order).
+    method = cs.NodeLabel.METHOD.value
+    nodes = dict(
+        [
+            (
+                (_MODULE, "proj.m"),
+                {cs.KEY_QUALIFIED_NAME: "proj.m", cs.KEY_PATH: "m.py"},
+            ),
+            _method("proj.m.Base.make"),
+            _method("proj.m.Sub.make"),
+            _method("proj.m.Sub.make.Manager.run"),
+        ]
+    )
+    rels = [
+        (_MODULE, "proj.m", _CALLS, method, "proj.m.Base.make"),
+        (
+            method,
+            "proj.m.Sub.make",
+            cs.RelationshipType.OVERRIDES.value,
+            method,
+            "proj.m.Base.make",
+        ),
+        (method, "proj.m.Sub.make", _DEFINES, _CLASS, "proj.m.Sub.make.Manager"),
+        (
+            _CLASS,
+            "proj.m.Sub.make.Manager",
+            _DEFINES_METHOD,
+            method,
+            "proj.m.Sub.make.Manager.run",
+        ),
+    ]
+    dead = dead_code_from_graph(nodes, rels, _PREFIX, _CONFIG)
+    assert dead == set()

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.287"
+version = "0.0.288"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Dogfooding follow-up to the #683-#688 campaign: the largest remaining false-positive cluster on django.

A class defined inside a function and handed out through the factory's return value or arguments (django's `create_reverse_many_to_one_manager`, `create_forward_many_to_many_manager`, `create_generic_related_manager`) surfaces its instances behind receivers the call graph cannot type, so no call edge ever lands on the methods and every one of them was reported dead. The engine now runs a factory-class expansion after the closure round: a class defined by a LIVE function or method has its methods treated as dispatch surface (the same reasoning as exported API, `overrides_external`, and Protocol stubs), and their callee closure revives with them. A dead factory's class stays dead, and module-level classes are unaffected.

Measured on a clean full django sync with current parsers: findings drop from 82 to 44 (38 removed, zero added). The removed set is the three manager factories plus clusters previously tracked as separate future work that fall out of the same rule: `template.smartif` `Operator.eval` (Operator subclasses are built inside the `infix`/`prefix` factories), `lazy_number`'s `NumberAwareString.format`, `postgis_adapters`' `BaseDumper.dump`/`upgrade`, and `PermissionProtectedModelForm.has_changed`.

Engine-only change: the DEFINES and DEFINES_METHOD pairs were already fetched, so no parser or schema changes and no re-sync needed for existing graphs.

Also merges the duplicate `_method` test helper in the dead-code eval tests (the second definition shadowed the first and tripped ty on single-argument calls).

TDD: the first commit adds the failing test plus two negative guards (dead factory stays dead, module-level classes not rooted), the second makes it pass.