### PR TITLE
fix(parsers): treat top-level browser-script symbols as page-global roots

### DIFF
--- a/codebase_rag/parsers/export_detection.py
+++ b/codebase_rag/parsers/export_detection.py
@@ -113,7 +113,26 @@ def _is_script_global(node: Node) -> bool:
             return False
         root = current
         current = current.parent
-    return not any(_is_module_construct(stmt) for stmt in root.children)
+    return not _has_module_construct(root)
+
+
+# (H) 1-slot memo of the last root's module-construct scan: files are ingested
+# (H) sequentially, so consecutive symbols of one file hit the slot and the
+# (H) O(top-level statements) scan runs once per FILE instead of once per
+# (H) symbol. The slot holds the root Node itself, which keeps its tree alive,
+# (H) so the entry can never alias a recycled node address; retaining one
+# (H) parse tree is the bounded cost (an unbounded Node-keyed lru_cache would
+# (H) pin every cached tree in memory).
+_last_script_scan: tuple[Node, bool] | None = None
+
+
+def _has_module_construct(root: Node) -> bool:
+    global _last_script_scan
+    if _last_script_scan is not None and _last_script_scan[0] == root:
+        return _last_script_scan[1]
+    result = any(_is_module_construct(stmt) for stmt in root.children)
+    _last_script_scan = (root, result)
+    return result
 
 
 def _is_module_construct(statement: Node) -> bool:

--- a/codebase_rag/parsers/export_detection.py
+++ b/codebase_rag/parsers/export_detection.py
@@ -8,6 +8,13 @@ from .cpp import utils as cpp_utils
 # (H) Once inside a function body the declaration is a local, not a module-level
 # (H) export, so an `export` ancestor beyond this boundary must not count.
 _JS_TS_EXPORT_STOP_TYPES = frozenset({cs.TS_STATEMENT_BLOCK})
+# (H) Textual markers whose presence in a top-level statement makes a JS file a
+# (H) CommonJS module rather than a classic page-scope script.
+_JS_REQUIRE_CALL = (cs.JS_REQUIRE_KEYWORD + cs.CHAR_PAREN_OPEN).encode()
+_JS_MODULE_EXPORTS = (
+    cs.JS_MODULE_KEYWORD + cs.SEPARATOR_DOT + cs.JS_EXPORTS_KEYWORD
+).encode()
+_JS_EXPORTS_MEMBER = (cs.JS_EXPORTS_KEYWORD + cs.SEPARATOR_DOT).encode()
 _JAVA_PUBLIC_MODIFIERS = frozenset(
     {cs.JAVA_MODIFIER_PUBLIC, cs.JAVA_MODIFIER_PROTECTED}
 )
@@ -74,7 +81,37 @@ def _js_ts_exported(node: Node, name: str) -> bool:
     # (H) must be matched by name against the module's export clauses.
     if _has_export_ancestor(node):
         return True
-    return bool(name) and name in _module_export_list_names(node)
+    if bool(name) and name in _module_export_list_names(node):
+        return True
+    return _is_script_global(node)
+
+
+def _is_script_global(node: Node) -> bool:
+    # (H) Classic browser script: a JS/TS file with no import/export statement
+    # (H) and no CommonJS require/module.exports construct runs in page scope,
+    # (H) so every module-level declaration (and its class members) is a global
+    # (H) reachable from HTML/templates the graph cannot see (django's
+    # (H) OLMapWidget classes, core.js helpers). Function-local declarations
+    # (H) are still reached only through their enclosing scope.
+    root = node
+    current = node.parent
+    while current is not None:
+        if current.type in _JS_TS_EXPORT_STOP_TYPES:
+            return False
+        root = current
+        current = current.parent
+    return not any(_is_module_construct(stmt) for stmt in root.children)
+
+
+def _is_module_construct(statement: Node) -> bool:
+    if statement.type in (cs.TS_IMPORT_STATEMENT, cs.TS_EXPORT_STATEMENT):
+        return True
+    text = statement.text or b""
+    return (
+        _JS_REQUIRE_CALL in text
+        or _JS_MODULE_EXPORTS in text
+        or text.startswith(_JS_EXPORTS_MEMBER)
+    )
 
 
 def _js_ts_private_member(node: Node) -> bool:

--- a/codebase_rag/parsers/export_detection.py
+++ b/codebase_rag/parsers/export_detection.py
@@ -15,6 +15,19 @@ _JS_MODULE_EXPORTS = (
     cs.JS_MODULE_KEYWORD + cs.SEPARATOR_DOT + cs.JS_EXPORTS_KEYWORD
 ).encode()
 _JS_EXPORTS_MEMBER = (cs.JS_EXPORTS_KEYWORD + cs.SEPARATOR_DOT).encode()
+# (H) Real function scopes. A bare `{ ... }` statement_block at top level
+# (H) (django's core.js) is NOT one: prototype mutations and var/function
+# (H) declarations inside it still land in page scope, so only a function
+# (H) ancestor makes a script declaration local.
+_JS_TS_FUNCTION_SCOPE_TYPES = frozenset(
+    {
+        cs.TS_FUNCTION_DECLARATION,
+        cs.TS_GENERATOR_FUNCTION_DECLARATION,
+        cs.TS_FUNCTION_EXPRESSION,
+        cs.TS_ARROW_FUNCTION,
+        cs.TS_METHOD_DEFINITION,
+    }
+)
 _JAVA_PUBLIC_MODIFIERS = frozenset(
     {cs.JAVA_MODIFIER_PUBLIC, cs.JAVA_MODIFIER_PROTECTED}
 )
@@ -96,7 +109,7 @@ def _is_script_global(node: Node) -> bool:
     root = node
     current = node.parent
     while current is not None:
-        if current.type in _JS_TS_EXPORT_STOP_TYPES:
+        if current.type in _JS_TS_FUNCTION_SCOPE_TYPES:
             return False
         root = current
         current = current.parent

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -716,6 +716,10 @@ def module_function_props(
     repo_path: Path | None,
 ) -> PropertyDict:
     """Standard Function node properties for module-scoped JS/TS functions."""
+    # (H) Lazy import: export_detection reaches back into this module through
+    # (H) cpp.utils, so a top-level import would be circular.
+    from . import export_detection
+
     props: PropertyDict = {
         cs.KEY_QUALIFIED_NAME: function_qn,
         cs.KEY_NAME: function_name,
@@ -723,6 +727,11 @@ def module_function_props(
         cs.KEY_START_LINE: function_node.start_point[0] + 1,
         cs.KEY_END_LINE: function_node.end_point[0] + 1,
         cs.KEY_DOCSTRING: docstring,
+        # (H) JS/TS only (per this helper's contract), so the JS branch of the
+        # (H) language dispatch applies regardless of which of the two it is.
+        cs.KEY_IS_EXPORTED: export_detection.is_exported(
+            function_node, function_name, cs.SupportedLanguage.JS
+        ),
     }
     if file_path is not None and repo_path is not None:
         props[cs.KEY_PATH] = cached_relative_path(file_path, repo_path).as_posix()

--- a/codebase_rag/tests/test_is_exported_roots.py
+++ b/codebase_rag/tests/test_is_exported_roots.py
@@ -238,3 +238,60 @@ def test_js_hash_private_method_of_exported_class_is_not_exported(
     exported = _run(tmp_path, {"store.js": JS_CLASS_HASH_PRIVATE_SRC})
     assert _one(exported, ".Store.read") is True
     assert _one(exported, ".Store.#load") is False
+
+
+SCRIPT_JS_SRC = """\
+class MapWidget {
+    constructor(options) {
+        this.options = options;
+    }
+
+    createMap() {
+        return 1;
+    }
+}
+
+function quickElement() {
+    return 1;
+}
+
+function pageInit() {
+    const localFn = function () {
+        return 2;
+    };
+    return localFn();
+}
+"""
+
+COMMONJS_SRC = """\
+const util = require("./util");
+
+function helper() {
+    return util;
+}
+"""
+
+
+def test_browser_script_top_level_symbols_are_exported(tmp_path: Path) -> None:
+    # (H) A JS file with no import/export/require runs in page scope: every
+    # (H) top-level declaration (and its class members) is a page-global the
+    # (H) HTML can call, so it is a reachability root (django's OLMapWidget).
+    exported = _run(tmp_path, {"widget.js": SCRIPT_JS_SRC})
+    assert _one(exported, "widget.MapWidget.constructor") is True
+    assert _one(exported, "widget.MapWidget.createMap") is True
+    assert _one(exported, "widget.quickElement") is True
+    assert _one(exported, "widget.pageInit") is True
+
+
+def test_browser_script_function_locals_stay_private(tmp_path: Path) -> None:
+    # (H) Declarations inside a function body are locals reached only through
+    # (H) their enclosing scope, even in a page-scope script.
+    exported = _run(tmp_path, {"widget.js": SCRIPT_JS_SRC})
+    assert _one(exported, "pageInit.localFn") is False
+
+
+def test_commonjs_module_symbols_stay_private(tmp_path: Path) -> None:
+    # (H) A require() call marks the file as a CommonJS module, so an
+    # (H) unexported top-level function is module-private, not a page-global.
+    exported = _run(tmp_path, {"mod.js": COMMONJS_SRC})
+    assert _one(exported, "mod.helper") is False

--- a/codebase_rag/tests/test_is_exported_roots.py
+++ b/codebase_rag/tests/test_is_exported_roots.py
@@ -295,3 +295,31 @@ def test_commonjs_module_symbols_stay_private(tmp_path: Path) -> None:
     # (H) unexported top-level function is module-private, not a page-global.
     exported = _run(tmp_path, {"mod.js": COMMONJS_SRC})
     assert _one(exported, "mod.helper") is False
+
+
+PROTO_SCRIPT_JS_SRC = """\
+String.prototype.strptime = function (format) {
+    return format;
+};
+"""
+
+PROTO_COMMONJS_SRC = """\
+const util = require("./util");
+
+String.prototype.strptime = function (format) {
+    return util.parse(format);
+};
+"""
+
+
+def test_browser_script_prototype_method_is_exported(tmp_path: Path) -> None:
+    # (H) A prototype-assigned method in a page-scope script (django admin's
+    # (H) core.js String.prototype.strptime) extends a global builtin, so it is
+    # (H) callable from any other script or template: a reachability root.
+    exported = _run(tmp_path, {"core.js": PROTO_SCRIPT_JS_SRC})
+    assert _one(exported, "core.String.strptime") is True
+
+
+def test_commonjs_prototype_method_stays_private(tmp_path: Path) -> None:
+    exported = _run(tmp_path, {"mod.js": PROTO_COMMONJS_SRC})
+    assert _one(exported, "mod.String.strptime") is False

--- a/codebase_rag/tests/test_is_exported_roots.py
+++ b/codebase_rag/tests/test_is_exported_roots.py
@@ -323,3 +323,26 @@ def test_browser_script_prototype_method_is_exported(tmp_path: Path) -> None:
 def test_commonjs_prototype_method_stays_private(tmp_path: Path) -> None:
     exported = _run(tmp_path, {"mod.js": PROTO_COMMONJS_SRC})
     assert _one(exported, "mod.String.strptime") is False
+
+
+BLOCK_SCRIPT_JS_SRC = """\
+{
+    String.prototype.strptime = function (format) {
+        return format;
+    };
+}
+
+function helper() {
+    return 1;
+}
+"""
+
+
+def test_bare_block_in_script_is_not_a_scope_boundary(tmp_path: Path) -> None:
+    # (H) django admin's core.js wraps its prototype extensions in bare
+    # (H) top-level `{ ... }` blocks. A block is not a function scope: the
+    # (H) prototype mutation still lands on the page-global builtin, so the
+    # (H) method must stay a reachability root.
+    exported = _run(tmp_path, {"core.js": BLOCK_SCRIPT_JS_SRC})
+    assert _one(exported, "core.String.strptime") is True
+    assert _one(exported, "core.helper") is True

--- a/codebase_rag/tests/test_is_exported_roots.py
+++ b/codebase_rag/tests/test_is_exported_roots.py
@@ -346,3 +346,31 @@ def test_bare_block_in_script_is_not_a_scope_boundary(tmp_path: Path) -> None:
     exported = _run(tmp_path, {"core.js": BLOCK_SCRIPT_JS_SRC})
     assert _one(exported, "core.String.strptime") is True
     assert _one(exported, "core.helper") is True
+
+
+def test_script_module_scan_runs_once_per_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # (H) The module-construct scan walks every top-level statement; it must
+    # (H) run once per FILE (memoized on the tree root), not once per symbol,
+    # (H) or export detection on a bundle with thousands of top-level
+    # (H) declarations goes quadratic.
+    from unittest.mock import patch
+
+    from codebase_rag import constants as cs
+    from codebase_rag.parser_loader import load_parsers
+    from codebase_rag.parsers import export_detection
+
+    parsers, _ = load_parsers()
+    tree = parsers[cs.SupportedLanguage.JS].parse(b"function a() {}\nfunction b() {}\n")
+    declarations = [
+        c for c in tree.root_node.children if c.type == cs.TS_FUNCTION_DECLARATION
+    ]
+    with patch.object(
+        export_detection,
+        "_is_module_construct",
+        wraps=export_detection._is_module_construct,
+    ) as spy:
+        for declaration in declarations:
+            assert export_detection._is_script_global(declaration) is True
+    assert spy.call_count <= len(declarations)


### PR DESCRIPTION
Next false-positive cluster from the django dogfood after #693.

A classic browser script (a JS file with no import/export statement and no CommonJS require/module.exports construct) runs in page scope: every top-level declaration, every member of a top-level class, and every prototype extension is a global that HTML and templates call without any edge the graph can see. django admin's OLMapWidget.js (two ES6 classes instantiated from inline template scripts) and core.js (String.prototype.strptime, wrapped in a bare top-level block) were reported dead wholesale.

Three changes, each with its RED test first:

- `export_detection` gains a script-global rule: when a JS/TS file contains no module construct, a declaration outside any function scope is exported. Function-local declarations stay private, and a single require or export anywhere at top level keeps the file on module semantics.
- `module_function_props` (the shared property builder for prototype-assigned, assignment-arrow, and object-literal JS functions) now computes `is_exported` instead of omitting it, so those ingest paths participate in the same rule.
- The script-global walk stops only at real function scopes (function declarations/expressions, arrows, method definitions), not at bare `{ ... }` statement blocks: core.js wraps its prototype extensions in such blocks, and prototype mutation lands on the page-global builtin regardless of block depth.

Measured on a clean full django sync: findings drop from 44 to 28 (16 removed, zero added) — both OLMapWidget classes with all methods and constructor closures, plus core.js's strptime. Cumulative with #693 the django report has gone 82 -> 28 this session.

Module-detection is textual per top-level statement (`require(`, `module.exports`, leading `exports.`), so a string literal containing those markers conservatively keeps the file treated as a module; that direction only costs roots, never invents dead code.