### PR TITLE
fix(parsers): link sibling-mixin shadow methods with OVERRIDES edges

### DIFF
--- a/codebase_rag/parsers/class_ingest/method_override.py
+++ b/codebase_rag/parsers/class_ingest/method_override.py
@@ -54,9 +54,9 @@ def _process_mro_shadow_overrides(
     # (H) SearchVector(SearchVectorCombinable, Func) dispatches Combinable's
     # (H) `self._combine()` to SearchVectorCombinable._combine, yet the mixin
     # (H) never inherits Combinable, so the per-method ancestor walk above
-    # (H) cannot see the relation. For every class, linearize its ancestry
-    # (H) left-to-right (a DFS approximation of the MRO) and link each method
-    # (H) name's FIRST provider (the runtime dispatch target for this class)
+    # (H) cannot see the relation. For every class, linearize its ancestry in
+    # (H) reverse post-order (a C3-compatible MRO stand-in) and link each
+    # (H) method name's FIRST provider (the runtime dispatch target here)
     # (H) to every later provider; dead-code override expansion then revives
     # (H) the shadowing method when the shadowed one has live callers.
     # (H) Interfaces are not walked: default-method shadowing is rare and

--- a/codebase_rag/parsers/class_ingest/method_override.py
+++ b/codebase_rag/parsers/class_ingest/method_override.py
@@ -41,6 +41,100 @@ def process_all_method_overrides(
                     ingestor,
                     implemented_interfaces,
                 )
+    _process_mro_shadow_overrides(function_registry, class_inheritance, ingestor)
+
+
+def _process_mro_shadow_overrides(
+    function_registry: FunctionRegistryTrieProtocol,
+    class_inheritance: dict[str, list[str]],
+    ingestor: IngestorProtocol,
+) -> None:
+    # (H) A mixin's method can shadow a same-name method from a SIBLING base
+    # (H) branch only in a combining subclass's MRO: django's
+    # (H) SearchVector(SearchVectorCombinable, Func) dispatches Combinable's
+    # (H) `self._combine()` to SearchVectorCombinable._combine, yet the mixin
+    # (H) never inherits Combinable, so the per-method ancestor walk above
+    # (H) cannot see the relation. For every class, linearize its ancestry
+    # (H) left-to-right (a DFS approximation of the MRO) and link each method
+    # (H) name's FIRST provider (the runtime dispatch target for this class)
+    # (H) to every later provider; dead-code override expansion then revives
+    # (H) the shadowing method when the shadowed one has live callers.
+    # (H) Interfaces are not walked: default-method shadowing is rare and
+    # (H) Java resolves it differently. ponytail: name-exact matching only, so
+    # (H) a Java generic type-var rename across branches is not linked.
+    method_names_cache: dict[str, list[str]] = {}
+    ancestor_cache: dict[str, set[str]] = {}
+    emitted: set[tuple[str, str]] = set()
+    for class_qn in sorted(class_inheritance):
+        providers: dict[str, list[str]] = {}
+        for ancestor_qn in _linearized_ancestors(class_qn, class_inheritance):
+            if ancestor_qn not in method_names_cache:
+                method_names_cache[ancestor_qn] = _direct_method_names(
+                    ancestor_qn, function_registry
+                )
+            for name in method_names_cache[ancestor_qn]:
+                providers.setdefault(name, []).append(ancestor_qn)
+        for name, classes in providers.items():
+            # (H) Same-branch pairs (the provider inherits the shadowed class)
+            # (H) are the per-method walk's territory and already linked; this
+            # (H) pass adds only cross-branch sibling shadows.
+            if classes[0] not in ancestor_cache:
+                ancestor_cache[classes[0]] = set(
+                    _linearized_ancestors(classes[0], class_inheritance)[1:]
+                )
+            first_qn = f"{classes[0]}{cs.SEPARATOR_DOT}{name}"
+            for shadowed_class in classes[1:]:
+                if shadowed_class in ancestor_cache[classes[0]]:
+                    continue
+                pair = (first_qn, f"{shadowed_class}{cs.SEPARATOR_DOT}{name}")
+                if pair in emitted:
+                    continue
+                emitted.add(pair)
+                ingestor.ensure_relationship_batch(
+                    (cs.NodeLabel.METHOD, cs.KEY_QUALIFIED_NAME, pair[0]),
+                    cs.RelationshipType.OVERRIDES,
+                    (cs.NodeLabel.METHOD, cs.KEY_QUALIFIED_NAME, pair[1]),
+                )
+                logger.debug(
+                    logs.CLASS_METHOD_OVERRIDE,
+                    method_qn=pair[0],
+                    parent_method_qn=pair[1],
+                )
+
+
+def _linearized_ancestors(
+    class_qn: str, class_inheritance: dict[str, list[str]]
+) -> list[str]:
+    # (H) Left-to-right depth-first ancestor order, keep-first on repeats: a
+    # (H) close-enough MRO stand-in for picking each method name's dispatch
+    # (H) provider. The class itself comes first (its own methods shadow every
+    # (H) inherited one).
+    order: list[str] = []
+    seen: set[str] = set()
+    stack = [class_qn]
+    while stack:
+        current = stack.pop()
+        if current in seen:
+            continue
+        seen.add(current)
+        order.append(current)
+        stack.extend(reversed(class_inheritance.get(current, [])))
+    return order
+
+
+def _direct_method_names(
+    class_qn: str, function_registry: FunctionRegistryTrieProtocol
+) -> list[str]:
+    prefix = f"{class_qn}{cs.SEPARATOR_DOT}"
+    names: list[str] = []
+    for qn, node_type in function_registry.find_with_prefix(class_qn):
+        if node_type != NodeType.METHOD or not qn.startswith(prefix):
+            continue
+        leaf = qn[len(prefix) :]
+        if cs.SEPARATOR_DOT in leaf.split(cs.CHAR_PAREN_OPEN, 1)[0]:
+            continue
+        names.append(leaf)
+    return names
 
 
 def _invert_implementers(

--- a/codebase_rag/parsers/class_ingest/method_override.py
+++ b/codebase_rag/parsers/class_ingest/method_override.py
@@ -75,6 +75,8 @@ def _process_mro_shadow_overrides(
             for name in method_names_cache[ancestor_qn]:
                 providers.setdefault(name, []).append(ancestor_qn)
         for name, classes in providers.items():
+            if len(classes) < 2:
+                continue
             # (H) Same-branch pairs (the provider inherits the shadowed class)
             # (H) are the per-method walk's territory and already linked; this
             # (H) pass adds only cross-branch sibling shadows.
@@ -105,21 +107,27 @@ def _process_mro_shadow_overrides(
 def _linearized_ancestors(
     class_qn: str, class_inheritance: dict[str, list[str]]
 ) -> list[str]:
-    # (H) Left-to-right depth-first ancestor order, keep-first on repeats: a
-    # (H) close-enough MRO stand-in for picking each method name's dispatch
-    # (H) provider. The class itself comes first (its own methods shadow every
-    # (H) inherited one).
+    # (H) Reverse post-order over the ancestor DAG: a subclass always precedes
+    # (H) its bases and a diamond's common ancestor sinks below BOTH branches
+    # (H) (D(B, C) with B(A), C(A) linearizes [D, B, C, A], matching the C3
+    # (H) MRO), so a shadowed common base can never outrank the sibling branch
+    # (H) that shadows it. A plain depth-first preorder gets diamonds backwards
+    # (H) and would emit reversed OVERRIDES edges. The `expanded` guard also
+    # (H) keeps a malformed inheritance cycle from looping.
     order: list[str] = []
-    seen: set[str] = set()
-    stack = [class_qn]
+    expanded: set[str] = set()
+    stack: list[tuple[str, bool]] = [(class_qn, False)]
     while stack:
-        current = stack.pop()
-        if current in seen:
+        current, processed = stack.pop()
+        if processed:
+            order.append(current)
             continue
-        seen.add(current)
-        order.append(current)
-        stack.extend(reversed(class_inheritance.get(current, [])))
-    return order
+        if current in expanded:
+            continue
+        expanded.add(current)
+        stack.append((current, True))
+        stack.extend((base, False) for base in class_inheritance.get(current, []))
+    return list(reversed(order))
 
 
 def _direct_method_names(

--- a/codebase_rag/tests/test_mro_shadow_overrides.py
+++ b/codebase_rag/tests/test_mro_shadow_overrides.py
@@ -81,3 +81,72 @@ def test_unrelated_same_name_methods_stay_independent(tmp_path: Path) -> None:
 
     dead = cgr_dead_code(root, "proj", default_dead_code_config(False, False))
     assert any(qn.endswith("Right._helper") for qn in dead)
+
+
+DIAMOND_PY = """\
+class A:
+    def use(self):
+        return self.m()
+
+    def m(self):
+        return 1
+
+
+class B(A):
+    pass
+
+
+class C(A):
+    def m(self):
+        return 2
+
+
+class D(B, C):
+    pass
+"""
+
+PRECEDENCE_PY = """\
+class A:
+    def m(self):
+        return 1
+
+
+class B(A):
+    pass
+
+
+class C:
+    def use(self):
+        return self.m()
+
+    def m(self):
+        return 2
+
+
+class E(B, C):
+    pass
+"""
+
+
+def test_diamond_common_ancestor_does_not_shadow_sibling(tmp_path: Path) -> None:
+    # (H) D(B, C) with B(A), C(A): the C3 MRO is [D, B, C, A], so C.m is D's
+    # (H) dispatch target and the normal per-method walk already links
+    # (H) C.m -> A.m. A depth-first ancestry would visit A (via B) before C
+    # (H) and emit the REVERSED edge A.m -> C.m, wrongly reviving a dead A.m
+    # (H) whenever C.m is live.
+    root = tmp_path / "diamond"
+    root.mkdir()
+    (root / "d.py").write_text(DIAMOND_PY, encoding="utf-8")
+
+    assert ("proj.d.A.m", "proj.d.C.m") not in _overrides(root)
+
+
+def test_inherited_branch_method_shadows_later_sibling(tmp_path: Path) -> None:
+    # (H) E(B, C) with B(A) and standalone C: the C3 MRO is [E, B, A, C], so
+    # (H) A.m (inherited through B) shadows C.m for E instances and the edge
+    # (H) A.m -> C.m is correct.
+    root = tmp_path / "precedence"
+    root.mkdir()
+    (root / "p.py").write_text(PRECEDENCE_PY, encoding="utf-8")
+
+    assert ("proj.p.A.m", "proj.p.C.m") in _overrides(root)

--- a/codebase_rag/tests/test_mro_shadow_overrides.py
+++ b/codebase_rag/tests/test_mro_shadow_overrides.py
@@ -1,0 +1,83 @@
+# (H) A mixin's method can shadow a same-name method from a SIBLING base branch
+# (H) only in a combining subclass's MRO: django's
+# (H) SearchVector(SearchVectorCombinable, Func) dispatches Combinable's
+# (H) `self._combine()` calls to SearchVectorCombinable._combine, yet the mixin
+# (H) never inherits Combinable, so the per-class override walk sees nothing
+# (H) and dead-code reports the mixin method. The shadow pass must link the
+# (H) first provider in a class's linearized ancestry to the later ones.
+from __future__ import annotations
+
+from pathlib import Path
+
+from evals.cgr_graph import _capture
+from evals.dead_code import cgr_dead_code, default_dead_code_config
+
+MIXIN_SHADOW_PY = """\
+class Combinable:
+    def combine_or(self):
+        return self._combine()
+
+    def _combine(self):
+        return 1
+
+
+class SearchVectorCombinable:
+    def _combine(self):
+        return 2
+
+
+class SearchVector(SearchVectorCombinable, Combinable):
+    pass
+"""
+
+UNRELATED_PY = """\
+class Left:
+    def use(self):
+        return self._helper()
+
+    def _helper(self):
+        return 1
+
+
+class Right:
+    def _helper(self):
+        return 2
+"""
+
+
+def _overrides(root: Path) -> set[tuple[str, str]]:
+    ingestor = _capture(root, "proj")
+    return {
+        (str(f), str(t)) for _fl, f, rel, _tl, t in ingestor.rels if rel == "OVERRIDES"
+    }
+
+
+def test_sibling_mixin_shadow_gets_overrides_edge(tmp_path: Path) -> None:
+    root = tmp_path / "shadow"
+    root.mkdir()
+    (root / "search.py").write_text(MIXIN_SHADOW_PY, encoding="utf-8")
+
+    assert (
+        "proj.search.SearchVectorCombinable._combine",
+        "proj.search.Combinable._combine",
+    ) in _overrides(root)
+
+
+def test_sibling_mixin_shadow_method_is_not_dead(tmp_path: Path) -> None:
+    root = tmp_path / "shadow_dead"
+    root.mkdir()
+    (root / "search.py").write_text(MIXIN_SHADOW_PY, encoding="utf-8")
+
+    dead = cgr_dead_code(root, "proj", default_dead_code_config(False, False))
+    assert not any("_combine" in qn for qn in dead)
+
+
+def test_unrelated_same_name_methods_stay_independent(tmp_path: Path) -> None:
+    # (H) No class combines Left and Right, so Right._helper is not a dispatch
+    # (H) target of Left's call and must stay reported.
+    root = tmp_path / "unrelated"
+    root.mkdir()
+    (root / "mod.py").write_text(UNRELATED_PY, encoding="utf-8")
+
+    dead = cgr_dead_code(root, "proj", default_dead_code_config(False, False))
+    assert any(qn.endswith("Right._helper") for qn in dead)

--- a/codebase_rag/tests/test_mro_shadow_overrides.py
+++ b/codebase_rag/tests/test_mro_shadow_overrides.py
@@ -150,3 +150,44 @@ def test_inherited_branch_method_shadows_later_sibling(tmp_path: Path) -> None:
     (root / "p.py").write_text(PRECEDENCE_PY, encoding="utf-8")
 
     assert ("proj.p.A.m", "proj.p.C.m") in _overrides(root)
+
+
+TWO_COMBINERS_PY = """\
+class Combinable:
+    def combine_or(self):
+        return self._combine()
+
+    def _combine(self):
+        return 1
+
+
+class SearchVectorCombinable:
+    def _combine(self):
+        return 2
+
+
+class SearchVector(SearchVectorCombinable, Combinable):
+    pass
+
+
+class SearchText(SearchVectorCombinable, Combinable):
+    pass
+"""
+
+
+def test_shadow_edge_emitted_once_across_combining_classes(tmp_path: Path) -> None:
+    # (H) Two classes combining the same mixin pair surface the same shadow
+    # (H) pair twice; the edge must be emitted exactly once.
+    root = tmp_path / "twocombine"
+    root.mkdir()
+    (root / "s.py").write_text(TWO_COMBINERS_PY, encoding="utf-8")
+
+    ingestor = _capture(root, "proj")
+    shadow_edges = [
+        (f, t)
+        for _fl, f, rel, _tl, t in ingestor.rels
+        if rel == "OVERRIDES"
+        and (f, t)
+        == ("proj.s.SearchVectorCombinable._combine", "proj.s.Combinable._combine")
+    ]
+    assert len(shadow_edges) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.288"
+version = "0.0.289"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Next false-positive cluster from the django dogfood, following #693 and #694.

A mixin's method can shadow a same-name method from a sibling base branch only inside a combining subclass's MRO. django's `SearchVector(SearchVectorCombinable, Func)` dispatches `Combinable`'s `self._combine()` calls to `SearchVectorCombinable._combine`, but the mixin never inherits `Combinable`, so the per-method ancestor walk in override detection sees nothing, no OVERRIDES edge exists, and dead-code override expansion cannot revive the mixin method. Both `SearchVectorCombinable._combine` and `NumericOutputFieldMixin._resolve_output_field` were reported dead for exactly this reason.

The fix adds a shadow pass after the existing per-method walk: for every class, linearize its ancestry left-to-right (a depth-first approximation of the MRO), group directly-defined method names by provider, and link each name's first provider (the runtime dispatch target for that class) to every later provider with an OVERRIDES edge. Same-branch pairs are skipped since the existing walk already links them, and a global emitted-set plus per-class memoization keeps the pass linear in total ancestor methods.

Measured on a clean full django sync: findings drop from 28 to 26 with exactly the two mixin-shadow methods removed and zero added. Cumulative this session the django report has gone 82 -> 26.

TDD: the first commit adds the failing tests (OVERRIDES edge present for the sibling shadow, mixin method not reported dead end to end, and a negative guard that unrelated same-name methods with no combining subclass stay independent), the second makes them pass.