### PR TITLE
fix(deadcode): treat python enum protocol hooks as reachability roots

### DIFF
--- a/codebase_rag/constants/deadcode_roots.py
+++ b/codebase_rag/constants/deadcode_roots.py
@@ -154,15 +154,14 @@ TEST_PATH_PATTERNS: tuple[str, ...] = (
 )
 
 # (H) Python Enum protocol hooks: the enum machinery invokes these sunder
-# (H) methods by NAME (_generate_next_value_ on auto(), _missing_ on a failed
+# (H) METHODS by NAME (_generate_next_value_ on auto(), _missing_ on a failed
 # (H) value lookup), never through a call the graph can see -- runtime roots
 # (H) exactly like dunders. A closed set: arbitrary sunder names are not part
-# (H) of the protocol.
+# (H) of the protocol, and _ignore_/_order_ are class ATTRIBUTES consumed at
+# (H) class creation, not methods, so they are deliberately absent.
 PY_ENUM_HOOK_METHOD_NAMES: frozenset[str] = frozenset(
     {
         "_generate_next_value_",
         "_missing_",
-        "_ignore_",
-        "_order_",
     }
 )

--- a/codebase_rag/constants/deadcode_roots.py
+++ b/codebase_rag/constants/deadcode_roots.py
@@ -152,3 +152,17 @@ TEST_PATH_PATTERNS: tuple[str, ...] = (
     ".spec.",
     "__tests__",
 )
+
+# (H) Python Enum protocol hooks: the enum machinery invokes these sunder
+# (H) methods by NAME (_generate_next_value_ on auto(), _missing_ on a failed
+# (H) value lookup), never through a call the graph can see -- runtime roots
+# (H) exactly like dunders. A closed set: arbitrary sunder names are not part
+# (H) of the protocol.
+PY_ENUM_HOOK_METHOD_NAMES: frozenset[str] = frozenset(
+    {
+        "_generate_next_value_",
+        "_missing_",
+        "_ignore_",
+        "_order_",
+    }
+)

--- a/codebase_rag/dead_code.py
+++ b/codebase_rag/dead_code.py
@@ -220,6 +220,15 @@ def dead_code_from_graph(
             and str(props.get(cs.KEY_PATH, "")).endswith(cs.EXT_PY)
         ):
             roots.add(qn)
+        # (H) Python Enum protocol hooks (_generate_next_value_, _missing_) are
+        # (H) invoked by the enum machinery by NAME, like dunders -- roots, not
+        # (H) dead code (django's TextChoices._generate_next_value_).
+        elif (
+            qn in method_qns
+            and qn.rsplit(cs.SEPARATOR_DOT, 1)[-1] in cs.PY_ENUM_HOOK_METHOD_NAMES
+            and str(props.get(cs.KEY_PATH, "")).endswith(cs.EXT_PY)
+        ):
+            roots.add(qn)
         elif (
             qn not in method_qns
             and qn.rsplit(cs.SEPARATOR_DOT, 1)[-1] in cs.GO_ROOT_FUNCTION_NAMES

--- a/codebase_rag/tests/test_dead_code_eval.py
+++ b/codebase_rag/tests/test_dead_code_eval.py
@@ -1048,3 +1048,24 @@ def test_factory_revived_by_override_expansion_roots_its_class() -> None:
     ]
     dead = dead_code_from_graph(nodes, rels, _PREFIX, _CONFIG)
     assert dead == set()
+
+
+def test_enum_protocol_hooks_are_roots() -> None:
+    # (H) Python's Enum machinery invokes _generate_next_value_ (on auto())
+    # (H) and _missing_ (on failed lookup) by NAME, never through a call the
+    # (H) graph can see -- runtime hooks exactly like dunders (django's
+    # (H) TextChoices._generate_next_value_). An arbitrary sunder-named
+    # (H) method is NOT in the protocol and must stay a dead candidate.
+    nodes = dict(
+        [
+            (
+                (_MODULE, "proj.m"),
+                {cs.KEY_QUALIFIED_NAME: "proj.m", cs.KEY_PATH: "m.py"},
+            ),
+            _method("proj.m.TextChoices._generate_next_value_"),
+            _method("proj.m.Color._missing_"),
+            _method("proj.m.Color._custom_sunder_"),
+        ]
+    )
+    dead = dead_code_from_graph(nodes, [], _PREFIX, _CONFIG)
+    assert dead == {"proj.m.Color._custom_sunder_"}

--- a/codebase_rag/tests/test_dead_code_eval.py
+++ b/codebase_rag/tests/test_dead_code_eval.py
@@ -1065,7 +1065,11 @@ def test_enum_protocol_hooks_are_roots() -> None:
             _method("proj.m.TextChoices._generate_next_value_"),
             _method("proj.m.Color._missing_"),
             _method("proj.m.Color._custom_sunder_"),
+            # (H) _order_ / _ignore_ are Enum class ATTRIBUTES consumed at
+            # (H) class creation, never methods the machinery invokes; a
+            # (H) user-defined method with that name is ordinary dead code.
+            _method("proj.m.Color._order_"),
         ]
     )
     dead = dead_code_from_graph(nodes, [], _PREFIX, _CONFIG)
-    assert dead == {"proj.m.Color._custom_sunder_"}
+    assert dead == {"proj.m.Color._custom_sunder_", "proj.m.Color._order_"}

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.290"
+version = "0.0.291"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Final cluster PR from the django dogfood train (#693, #694, #695, #696).

Python's Enum machinery invokes a closed set of sunder methods by name: `_generate_next_value_` on `auto()`, `_missing_` on a failed value lookup, plus the `_ignore_`/`_order_` declarations. No call edge can ever land on them, the same situation as dunders, Rust trait methods, and Java serialization hooks, so the engine now roots methods with these exact names on Python files. An arbitrary sunder-named method is not part of the protocol and stays a dead candidate, which the test pins.

Engine-only change: existing graphs get the fix without a re-sync. django drops from 18 to 17 findings (`TextChoices._generate_next_value_`), zero added; cumulative this session the report has gone 82 -> 17.

TDD: failing test first, then the root rule.