### PR TITLE
feat(sync): warn when incremental sync runs against a graph built by a different parser

### DIFF
--- a/codebase_rag/cli.py
+++ b/codebase_rag/cli.py
@@ -262,8 +262,8 @@ def _delete_hash_cache(repo_path: Path) -> None:
             )
         )
         cache_path.unlink(missing_ok=True)
-    dir_mtimes_path = repo_path / cs.DIR_MTIMES_FILENAME
-    dir_mtimes_path.unlink(missing_ok=True)
+    (repo_path / cs.DIR_MTIMES_FILENAME).unlink(missing_ok=True)
+    (repo_path / cs.PARSER_FINGERPRINT_FILENAME).unlink(missing_ok=True)
 
 
 def _resolve_and_validate_repo(repo_path: str | None) -> Path:

--- a/codebase_rag/constants/core.py
+++ b/codebase_rag/constants/core.py
@@ -121,6 +121,23 @@ KEYWORD_CONSTRUCTOR = "constructor"
 # (H) Incremental update hash cache
 HASH_CACHE_FILENAME = ".cgr-hash-cache.json"
 DIR_MTIMES_FILENAME = ".cgr-dir-mtimes.json"
+PARSER_FINGERPRINT_FILENAME = ".cgr-parser-fingerprint"
+CGR_STATE_FILENAMES: frozenset[str] = frozenset(
+    {HASH_CACHE_FILENAME, DIR_MTIMES_FILENAME, PARSER_FINGERPRINT_FILENAME}
+)
+
+# (H) Inputs to the parser fingerprint: everything that changes how source
+# (H) files are turned into graph nodes and edges, plus the installed grammar
+# (H) wheels. Paths are relative to the codebase_rag package root.
+PARSER_FINGERPRINT_SOURCE_DIRS: tuple[str, ...] = ("parsers", "constants")
+PARSER_FINGERPRINT_SOURCE_FILES: tuple[str, ...] = (
+    "graph_updater.py",
+    "language_spec.py",
+    "parser_loader.py",
+)
+PY_SOURCE_GLOB = "*.py"
+GRAMMAR_DIST_PREFIX = "tree-sitter"
+GRAMMAR_VERSION_FMT = "{name}=={version}"
 GIT_DIR_NAME = ".git"
 ROOT_DIR_KEY = "."
 JSON_EMPTY_OBJECT = "{}"

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -14,6 +14,7 @@ from . import constants as cs
 from . import logs as ls
 from .config import settings
 from .language_spec import LANGUAGE_FQN_SPECS, get_language_spec
+from .parser_fingerprint import compute_parser_fingerprint
 from .parser_loader import COMBINED_FUNC_CLASS_IMPORT_QUERIES
 from .parsers.cpp_frontend import (
     cpp_frontend_available,
@@ -401,6 +402,20 @@ def _save_hash_cache(cache_path: Path, hashes: FileHashCache) -> None:
         logger.warning(ls.HASH_CACHE_SAVE_FAILED, path=cache_path, error=e)
 
 
+def _load_parser_fingerprint(stamp_path: Path) -> str | None:
+    try:
+        return stamp_path.read_text(encoding="utf-8").strip() or None
+    except OSError:
+        return None
+
+
+def _save_parser_fingerprint(stamp_path: Path, fingerprint: str) -> None:
+    try:
+        stamp_path.write_text(fingerprint, encoding="utf-8")
+    except OSError as e:
+        logger.warning(ls.PARSER_FINGERPRINT_SAVE_FAILED, path=stamp_path, error=e)
+
+
 def _load_dir_mtimes(cache_path: Path) -> DirMtimesCache:
     if not cache_path.is_file():
         return {}
@@ -612,6 +627,9 @@ class GraphUpdater:
             cs.NODE_PROJECT, {cs.KEY_NAME: self.project_name}
         )
         logger.info(ls.ENSURING_PROJECT, name=self.project_name)
+
+        if not force and self._single_file is None:
+            self._warn_if_parser_changed()
 
         if not force and self._is_already_in_sync():
             logger.info(ls.GRAPH_ALREADY_IN_SYNC)
@@ -960,7 +978,7 @@ class GraphUpdater:
             with os.scandir(dir_path_str) as it:
                 for entry in it:
                     name = entry.name
-                    if name in (cs.HASH_CACHE_FILENAME, cs.DIR_MTIMES_FILENAME):
+                    if name in cs.CGR_STATE_FILENAMES:
                         continue
                     try:
                         is_symlink = entry.is_symlink()
@@ -1025,6 +1043,18 @@ class GraphUpdater:
             )
         )
 
+    def _warn_if_parser_changed(self) -> None:
+        # (H) No hash cache means a full build is coming: nothing to compare.
+        if not (self.repo_path / cs.HASH_CACHE_FILENAME).is_file():
+            return
+        stored = _load_parser_fingerprint(
+            self.repo_path / cs.PARSER_FINGERPRINT_FILENAME
+        )
+        # (H) A missing stamp on an existing graph means it was built by an
+        # (H) unknown (pre-fingerprint) parser: treat it as stale too.
+        if stored != compute_parser_fingerprint():
+            logger.warning(ls.PARSER_FINGERPRINT_MISMATCH)
+
     def _is_already_in_sync(self) -> bool:
         if self._single_file is not None:
             return False
@@ -1081,8 +1111,7 @@ class GraphUpdater:
             return []
 
         eligible: list[tuple[Path, str]] = []
-        hash_name = cs.HASH_CACHE_FILENAME
-        dir_mtimes_name = cs.DIR_MTIMES_FILENAME
+        state_filenames = cs.CGR_STATE_FILENAMES
         repo_str = str(self.repo_path)
         repo_prefix_len = len(repo_str) + 1
         exclude_paths = self.exclude_paths
@@ -1106,7 +1135,7 @@ class GraphUpdater:
                 d for d in dirnames if self._should_keep_dir(d, dir_prefix)
             )
             for fname in sorted(filenames):
-                if fname in (hash_name, dir_mtimes_name):
+                if fname in state_filenames:
                     continue
                 dot = fname.rfind(".")
                 suffix = fname[dot:] if dot != -1 else ""
@@ -1125,6 +1154,7 @@ class GraphUpdater:
         cache_path = self.repo_path / cs.HASH_CACHE_FILENAME
         dir_mtimes_path = self.repo_path / cs.DIR_MTIMES_FILENAME
         old_hashes = _load_hash_cache(cache_path) if not force else {}
+        is_full_build = (force or not old_hashes) and self._single_file is None
         cache_mtime = cache_path.stat().st_mtime if cache_path.is_file() else 0.0
         if force:
             logger.info(ls.INCREMENTAL_FORCE)
@@ -1254,6 +1284,14 @@ class GraphUpdater:
 
         _save_hash_cache(cache_path, new_hashes)
         _save_dir_mtimes(dir_mtimes_path, self._collected_dir_mtimes)
+        # (H) Stamp only full builds: re-stamping an incremental run would
+        # (H) silence the staleness warning while unchanged files still carry
+        # (H) the old parser's edges.
+        if is_full_build:
+            _save_parser_fingerprint(
+                self.repo_path / cs.PARSER_FINGERPRINT_FILENAME,
+                compute_parser_fingerprint(),
+            )
 
     def _pre_parse_changed_files(
         self,

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1051,8 +1051,9 @@ class GraphUpdater:
             self.repo_path / cs.PARSER_FINGERPRINT_FILENAME
         )
         # (H) A missing stamp on an existing graph means it was built by an
-        # (H) unknown (pre-fingerprint) parser: treat it as stale too.
-        if stored != compute_parser_fingerprint():
+        # (H) unknown (pre-fingerprint) parser: treat it as stale too, without
+        # (H) paying for a fingerprint computation that cannot match.
+        if stored is None or stored != compute_parser_fingerprint():
             logger.warning(ls.PARSER_FINGERPRINT_MISMATCH)
 
     def _is_already_in_sync(self) -> bool:

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -725,6 +725,12 @@ INCREMENTAL_SKIPPED = "Skipped {count} unchanged files"
 INCREMENTAL_CHANGED = "Re-indexing {count} changed files"
 INCREMENTAL_DELETED = "Removed state for {count} deleted files"
 INCREMENTAL_FORCE = "Force mode enabled, bypassing hash cache"
+PARSER_FINGERPRINT_SAVE_FAILED = "Failed to save parser fingerprint to {path}: {error}"
+PARSER_FINGERPRINT_MISMATCH = (
+    "Parser code changed since this graph was built. Incremental sync keeps "
+    "results from the old parser for unchanged files, so the graph may be "
+    "stale. Run 'cgr start --clean' to rebuild it from scratch."
+)
 
 # (H) Orphan pruning logs
 PRUNE_START = "--- Pruning orphan nodes from graph ---"

--- a/codebase_rag/parser_fingerprint.py
+++ b/codebase_rag/parser_fingerprint.py
@@ -1,0 +1,44 @@
+# (H) A graph is a function of (source files, parser code). The incremental
+# (H) hash cache keys only the source files, so a parser change with unchanged
+# (H) sources leaves stale old-parser edges in the graph. This fingerprint
+# (H) keys the second input: it hashes every parse-relevant source file of the
+# (H) installed package plus the pinned grammar wheel versions, so a sync can
+# (H) detect that the graph was built by a different parser.
+import hashlib
+from importlib import metadata
+from pathlib import Path
+
+from . import constants as cs
+
+
+def compute_parser_fingerprint(package_root: Path | None = None) -> str:
+    root = package_root if package_root is not None else Path(__file__).resolve().parent
+    hasher = hashlib.md5(usedforsecurity=False)
+    for source in _fingerprint_sources(root):
+        hasher.update(source.relative_to(root).as_posix().encode())
+        hasher.update(source.read_bytes())
+    for entry in _grammar_versions():
+        hasher.update(entry.encode())
+    return hasher.hexdigest()
+
+
+def _fingerprint_sources(root: Path) -> list[Path]:
+    sources: list[Path] = []
+    for dirname in cs.PARSER_FINGERPRINT_SOURCE_DIRS:
+        sources.extend(
+            path for path in (root / dirname).rglob(cs.PY_SOURCE_GLOB) if path.is_file()
+        )
+    sources.extend(
+        path
+        for name in cs.PARSER_FINGERPRINT_SOURCE_FILES
+        if (path := root / name).is_file()
+    )
+    return sorted(sources)
+
+
+def _grammar_versions() -> list[str]:
+    return sorted(
+        cs.GRAMMAR_VERSION_FMT.format(name=dist.name.lower(), version=dist.version)
+        for dist in metadata.distributions()
+        if dist.name and dist.name.lower().startswith(cs.GRAMMAR_DIST_PREFIX)
+    )

--- a/codebase_rag/tests/test_parser_fingerprint.py
+++ b/codebase_rag/tests/test_parser_fingerprint.py
@@ -186,6 +186,22 @@ class TestStalenessWarning:
         assert any(ls.PARSER_FINGERPRINT_MISMATCH in m for m in warnings_sink)
 
 
+class TestStampIO:
+    def test_unwritable_stamp_warns_without_raising(
+        self, tmp_path: Path, warnings_sink: list[str]
+    ) -> None:
+        # (H) The stamp is a best-effort safeguard: a failed write must not
+        # (H) abort the sync that just succeeded.
+        from codebase_rag.graph_updater import _save_parser_fingerprint
+
+        stamp_dir = tmp_path / cs.PARSER_FINGERPRINT_FILENAME
+        stamp_dir.mkdir()
+
+        _save_parser_fingerprint(stamp_dir, STALE_FINGERPRINT)
+
+        assert any(str(stamp_dir) in m for m in warnings_sink)
+
+
 class TestCleanRemovesStamp:
     def test_delete_hash_cache_removes_fingerprint_stamp(self, tmp_path: Path) -> None:
         for name in (

--- a/codebase_rag/tests/test_parser_fingerprint.py
+++ b/codebase_rag/tests/test_parser_fingerprint.py
@@ -1,0 +1,202 @@
+# (H) A graph is a function of (source files, parser code) but the incremental
+# (H) hash cache keys only the source files: after a parser change an
+# (H) incremental sync silently keeps every edge the OLD parser produced for
+# (H) unchanged files. These tests pin the parser-fingerprint safeguard: full
+# (H) syncs stamp the fingerprint of the parser that built the graph, and any
+# (H) later sync against a different parser warns loudly until a clean rebuild.
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from loguru import logger
+
+from codebase_rag import constants as cs
+from codebase_rag import logs as ls
+from codebase_rag.cli import _delete_hash_cache
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_fingerprint import compute_parser_fingerprint
+from codebase_rag.parser_loader import load_parsers
+
+STALE_FINGERPRINT = "0" * 32
+
+
+@pytest.fixture
+def py_project(temp_repo: Path) -> Path:
+    (temp_repo / "module_a.py").write_text("def func_a():\n    pass\n")
+    return temp_repo
+
+
+@pytest.fixture
+def warnings_sink() -> Iterator[list[str]]:
+    messages: list[str] = []
+    handler_id = logger.add(
+        lambda m: messages.append(str(m)), level="WARNING", format="{message}"
+    )
+    yield messages
+    logger.remove(handler_id)
+
+
+def _make_updater(repo: Path, mock_ingestor: MagicMock) -> GraphUpdater:
+    parsers, queries = load_parsers()
+    return GraphUpdater(
+        ingestor=mock_ingestor,
+        repo_path=repo,
+        parsers=parsers,
+        queries=queries,
+    )
+
+
+def _fingerprint_path(repo: Path) -> Path:
+    return repo / cs.PARSER_FINGERPRINT_FILENAME
+
+
+class TestComputeParserFingerprint:
+    def test_deterministic_hex_digest(self) -> None:
+        first = compute_parser_fingerprint()
+        second = compute_parser_fingerprint()
+        assert first == second
+        assert len(first) == 32
+        int(first, 16)
+
+    def test_changes_when_parser_source_changes(self, tmp_path: Path) -> None:
+        pkg = tmp_path / "pkg"
+        parsers_dir = pkg / cs.PARSER_FINGERPRINT_SOURCE_DIRS[0]
+        parsers_dir.mkdir(parents=True)
+        source = parsers_dir / "some_parser.py"
+        source.write_text("A = 1\n")
+        before = compute_parser_fingerprint(pkg)
+        source.write_text("A = 2\n")
+        assert compute_parser_fingerprint(pkg) != before
+
+    def test_unchanged_tree_same_fingerprint(self, tmp_path: Path) -> None:
+        pkg = tmp_path / "pkg"
+        parsers_dir = pkg / cs.PARSER_FINGERPRINT_SOURCE_DIRS[0]
+        parsers_dir.mkdir(parents=True)
+        (parsers_dir / "some_parser.py").write_text("A = 1\n")
+        assert compute_parser_fingerprint(pkg) == compute_parser_fingerprint(pkg)
+
+
+class TestFingerprintStamping:
+    def test_full_sync_stamps_current_fingerprint(
+        self, py_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        _make_updater(py_project, mock_ingestor).run()
+
+        stamp = _fingerprint_path(py_project)
+        assert stamp.is_file()
+        assert stamp.read_text(encoding="utf-8").strip() == (
+            compute_parser_fingerprint()
+        )
+
+    def test_incremental_sync_does_not_overwrite_stale_stamp(
+        self, py_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        # (H) Incremental syncs keep old-parser edges for unchanged files, so
+        # (H) re-stamping would silence the warning while the graph stays stale.
+        _make_updater(py_project, mock_ingestor).run()
+        _fingerprint_path(py_project).write_text(STALE_FINGERPRINT, encoding="utf-8")
+
+        (py_project / "module_b.py").write_text("def func_b():\n    pass\n")
+        _make_updater(py_project, mock_ingestor).run()
+
+        stored = _fingerprint_path(py_project).read_text(encoding="utf-8").strip()
+        assert stored == STALE_FINGERPRINT
+
+    def test_forced_rebuild_refreshes_stale_stamp(
+        self, py_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        _make_updater(py_project, mock_ingestor).run()
+        _fingerprint_path(py_project).write_text(STALE_FINGERPRINT, encoding="utf-8")
+
+        _make_updater(py_project, mock_ingestor).run(force=True)
+
+        stored = _fingerprint_path(py_project).read_text(encoding="utf-8").strip()
+        assert stored == compute_parser_fingerprint()
+
+    def test_stamp_file_is_not_indexed(
+        self, py_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        _make_updater(py_project, mock_ingestor).run()
+        _make_updater(py_project, mock_ingestor).run()
+
+        from codebase_rag.graph_updater import _load_hash_cache
+
+        hashes = _load_hash_cache(py_project / cs.HASH_CACHE_FILENAME)
+        assert cs.PARSER_FINGERPRINT_FILENAME not in hashes
+
+    def test_stamp_file_does_not_break_fast_path(
+        self, py_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        _make_updater(py_project, mock_ingestor).run()
+        assert _fingerprint_path(py_project).is_file()
+
+        updater = _make_updater(py_project, mock_ingestor)
+        assert updater._is_already_in_sync() is True
+
+
+class TestStalenessWarning:
+    def test_fresh_sync_does_not_warn(
+        self, py_project: Path, mock_ingestor: MagicMock, warnings_sink: list[str]
+    ) -> None:
+        _make_updater(py_project, mock_ingestor).run()
+        assert not any(ls.PARSER_FINGERPRINT_MISMATCH in m for m in warnings_sink)
+
+    def test_incremental_sync_with_matching_stamp_does_not_warn(
+        self, py_project: Path, mock_ingestor: MagicMock, warnings_sink: list[str]
+    ) -> None:
+        _make_updater(py_project, mock_ingestor).run()
+        _make_updater(py_project, mock_ingestor).run()
+        assert not any(ls.PARSER_FINGERPRINT_MISMATCH in m for m in warnings_sink)
+
+    def test_incremental_sync_with_stale_stamp_warns(
+        self, py_project: Path, mock_ingestor: MagicMock, warnings_sink: list[str]
+    ) -> None:
+        _make_updater(py_project, mock_ingestor).run()
+        _fingerprint_path(py_project).write_text(STALE_FINGERPRINT, encoding="utf-8")
+
+        _make_updater(py_project, mock_ingestor).run()
+
+        assert any(ls.PARSER_FINGERPRINT_MISMATCH in m for m in warnings_sink)
+
+    def test_in_sync_fast_path_still_warns_on_stale_stamp(
+        self, py_project: Path, mock_ingestor: MagicMock, warnings_sink: list[str]
+    ) -> None:
+        # (H) The fast path skips all passes, which is exactly the silent
+        # (H) no-op that must not hide a stale graph.
+        _make_updater(py_project, mock_ingestor).run()
+        _fingerprint_path(py_project).write_text(STALE_FINGERPRINT, encoding="utf-8")
+
+        updater = _make_updater(py_project, mock_ingestor)
+        assert updater._is_already_in_sync() is True
+        updater.run()
+
+        assert any(ls.PARSER_FINGERPRINT_MISMATCH in m for m in warnings_sink)
+
+    def test_missing_stamp_with_existing_cache_warns(
+        self, py_project: Path, mock_ingestor: MagicMock, warnings_sink: list[str]
+    ) -> None:
+        # (H) A graph synced before this safeguard existed was built by an
+        # (H) unknown parser: treat it as stale until a clean rebuild.
+        _make_updater(py_project, mock_ingestor).run()
+        _fingerprint_path(py_project).unlink()
+
+        _make_updater(py_project, mock_ingestor).run()
+
+        assert any(ls.PARSER_FINGERPRINT_MISMATCH in m for m in warnings_sink)
+
+
+class TestCleanRemovesStamp:
+    def test_delete_hash_cache_removes_fingerprint_stamp(self, tmp_path: Path) -> None:
+        for name in (
+            cs.HASH_CACHE_FILENAME,
+            cs.DIR_MTIMES_FILENAME,
+            cs.PARSER_FINGERPRINT_FILENAME,
+        ):
+            (tmp_path / name).write_text(cs.JSON_EMPTY_OBJECT, encoding="utf-8")
+
+        _delete_hash_cache(tmp_path)
+
+        assert not (tmp_path / cs.PARSER_FINGERPRINT_FILENAME).exists()
+        assert not (tmp_path / cs.HASH_CACHE_FILENAME).exists()
+        assert not (tmp_path / cs.DIR_MTIMES_FILENAME).exists()

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.291"
+version = "0.0.293"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Problem

The incremental hash cache keys graph state on one input only: source file content. A graph is really a function of two inputs, the source files and the parser that interpreted them. After a parser change, an incremental sync sees zero changed files and silently keeps every edge the old parser produced. The result looks current but is stale, and nothing tells the user.

This bit us directly during the dead-code campaign: a remembered django baseline of 72 findings turned out to come from a stale mixed-parser graph; the true clean baseline was 82.

## Fix

Key the second input with a parser fingerprint:

- New `parser_fingerprint.py` computes an md5 over every parse-relevant source file of the installed package (`parsers/`, `constants/`, `graph_updater.py`, `language_spec.py`, `parser_loader.py`) plus the installed `tree-sitter*` distribution versions. Computation costs ~100ms, negligible against any sync.
- Full builds stamp the fingerprint to `.cgr-parser-fingerprint` next to the existing two cache files.
- Any later non-forced sync compares the stamp against the current fingerprint and warns loudly on mismatch, pointing at `cgr start --clean`. A missing stamp on an existing graph (built before this safeguard) is treated as stale too.
- Incremental syncs never re-stamp: re-stamping would silence the warning while unchanged files still carry the old parser's edges. The warning persists until a clean rebuild.
- The check runs before the in-sync fast path, so the silent no-op case warns as well.
- `--clean` and `delete-project` remove the stamp along with the hash cache; the stamp file is excluded from indexing and from the fast-path directory diff via a shared `CGR_STATE_FILENAMES` constant.

Detection is automatic, the rebuild stays opt-in: no surprise hour-long full re-syncs.

## Testing

RED first: `test_parser_fingerprint.py` (14 tests) committed failing, covering determinism, change sensitivity, stamping on full/forced builds, stale-stamp preservation on incremental runs, warning on mismatch/missing stamp (including the fast-path case), no warning on fresh or matching syncs, fast-path preservation, and `--clean` removal. Full suite: 4812 passed, 10 skipped. `ruff` clean, `ty` at the main baseline.