### PR TITLE
fix(deadcode): root property-family accessors invoked by attribute syntax

### DIFF
--- a/codebase_rag/constants/deadcode_roots.py
+++ b/codebase_rag/constants/deadcode_roots.py
@@ -44,6 +44,7 @@ DEFAULT_ROOT_DECORATORS: frozenset[str] = frozenset(
         "property",
         "cached_property",
         "classproperty",
+        "hybrid_property",
         "setter",
         "deleter",
     }

--- a/codebase_rag/constants/deadcode_roots.py
+++ b/codebase_rag/constants/deadcode_roots.py
@@ -36,6 +36,16 @@ DEFAULT_ROOT_DECORATORS: frozenset[str] = frozenset(
         "model_serializer",
         "computed_field",
         "abstractmethod",
+        # (H) Property-family accessors are invoked by ATTRIBUTE syntax -- a bare
+        # (H) read/write like `obj._output_field_or_none` produces no call node,
+        # (H) so no CALLS edge can ever land on them (django WhereNode.
+        # (H) _output_field_or_none, Expression._constructor_signature). The same
+        # (H) invisible-invocation argument as dunders: roots, not dead code.
+        "property",
+        "cached_property",
+        "classproperty",
+        "setter",
+        "deleter",
     }
 )
 

--- a/codebase_rag/tests/test_dead_code_eval.py
+++ b/codebase_rag/tests/test_dead_code_eval.py
@@ -1096,6 +1096,7 @@ def test_property_family_decorated_methods_are_roots() -> None:
                 decorators=["@functools.cached_property"],
             ),
             _method("proj.m.Expr.sig", decorators=["@classproperty"]),
+            _method("proj.m.Model.hybrid", decorators=["@hybrid_property"]),
             _method("proj.m.Options.value", decorators=["@value.setter"]),
             _method("proj.m.Options.gone", decorators=["@gone.deleter"]),
             _method("proj.m.Options._helper"),

--- a/codebase_rag/tests/test_dead_code_eval.py
+++ b/codebase_rag/tests/test_dead_code_eval.py
@@ -38,14 +38,16 @@ def _fn(uid: str, path: str = "m.py", decorators: list[str] | None = None) -> tu
     )
 
 
-def _method(uid: str, path: str = "m.py") -> tuple:
+def _method(
+    uid: str, path: str = "m.py", decorators: list[str] | None = None
+) -> tuple:
     return (
         (cs.NodeLabel.METHOD.value, uid),
         {
             cs.KEY_QUALIFIED_NAME: uid,
             cs.KEY_NAME: uid.rsplit(cs.SEPARATOR_DOT, 1)[-1],
             cs.KEY_PATH: path,
-            cs.KEY_DECORATORS: [],
+            cs.KEY_DECORATORS: decorators or [],
             cs.KEY_IS_EXPORTED: False,
         },
     )
@@ -1073,3 +1075,44 @@ def test_enum_protocol_hooks_are_roots() -> None:
     )
     dead = dead_code_from_graph(nodes, [], _PREFIX, _CONFIG)
     assert dead == {"proj.m.Color._custom_sunder_", "proj.m.Color._order_"}
+
+
+def test_property_family_decorated_methods_are_roots() -> None:
+    # (H) A @property/@cached_property/@classproperty method (and @x.setter /
+    # (H) @x.deleter) is invoked by ATTRIBUTE syntax -- a bare read like
+    # (H) `self.app_config._is_default_auto_field_overridden` produces no call
+    # (H) node, so no CALLS edge can ever land on it (django's
+    # (H) WhereNode._output_field_or_none, Expression._constructor_signature).
+    # (H) Same invisible-invocation situation as dunders: roots, not dead code.
+    # (H) Its callees revive through the normal walk.
+    config = default_dead_code_config(include_tests=False, include_classes=False)
+    nodes = dict(
+        [
+            (
+                (_MODULE, "proj.m"),
+                {cs.KEY_QUALIFIED_NAME: "proj.m", cs.KEY_PATH: "m.py"},
+            ),
+            _method("proj.m.Options.plain_prop", decorators=["@property"]),
+            _method(
+                "proj.m.Options.cached",
+                decorators=["@functools.cached_property"],
+            ),
+            _method("proj.m.Expr.sig", decorators=["@classproperty"]),
+            _method("proj.m.Options.value", decorators=["@value.setter"]),
+            _method("proj.m.Options.gone", decorators=["@gone.deleter"]),
+            _method("proj.m.Options._helper"),
+            _method("proj.m.Options.undecorated"),
+            _method("proj.m.Options.custom", decorators=["@deprecated"]),
+        ]
+    )
+    rels = [
+        (
+            cs.NodeLabel.METHOD.value,
+            "proj.m.Options.plain_prop",
+            _CALLS,
+            cs.NodeLabel.METHOD.value,
+            "proj.m.Options._helper",
+        ),
+    ]
+    dead = dead_code_from_graph(nodes, rels, _PREFIX, config)
+    assert dead == {"proj.m.Options.undecorated", "proj.m.Options.custom"}

--- a/codebase_rag/tests/test_dead_code_eval.py
+++ b/codebase_rag/tests/test_dead_code_eval.py
@@ -38,9 +38,7 @@ def _fn(uid: str, path: str = "m.py", decorators: list[str] | None = None) -> tu
     )
 
 
-def _method(
-    uid: str, path: str = "m.py", decorators: list[str] | None = None
-) -> tuple:
+def _method(uid: str, path: str = "m.py", decorators: list[str] | None = None) -> tuple:
     return (
         (cs.NodeLabel.METHOD.value, uid),
         {

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.291"
+version = "0.0.293"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Problem

A method decorated `@property`, `@functools.cached_property`, `@classproperty`, `@x.setter`, or `@x.deleter` is invoked by ATTRIBUTE syntax: a bare read like `if self.app_config._is_default_auto_field_overridden:` or `self._constructor_signature.bind_partial(...)` produces no call node, so no CALLS edge can ever land on the accessor. This is the same invisible-invocation situation as Python dunders, Rust trait methods, and C++ operator overloads, all of which are already reachability roots.

django dogfood surfaced three false positives of this class: `AppConfig._is_default_auto_field_overridden` (@property read in a condition), `Expression._constructor_signature` (@classproperty used as a chain receiver), and `WhereNode._output_field_or_none` (@property read as a boolean operand).

## Fix

Add the five property-family decorator names to `DEFAULT_ROOT_DECORATORS`. `_norm_decorator` already lowercases and takes the last dotted segment, so `@functools.cached_property` and `@value.setter` normalize correctly. Engine-only change: existing graphs get the fix without a re-sync.

The trade-off is the same one accepted for dunders: a genuinely never-read property is under-reported rather than attribute reads being mis-reported. Most property reads already revive through the value-reference walkers (assignment RHS, arguments, boolean operands); rooting closes the residual contexts (bare condition reads, chain receivers) that no walker models.

## Measurements

django (fresh shallow clone, whole repo, tests excluded): 23 -> 20 findings, exactly the three property accessors revived, zero newly dead. All other dogfood baselines unaffected (revive-only change).

## Testing

RED first: `test_property_family_decorated_methods_are_roots` committed failing, covering all five decorator forms, callee revival through the walk, and the negatives (an undecorated method and a `@deprecated` method stay dead). Full suite 4799 passed, 10 skipped. ruff clean, ty at the main baseline.
