### PR TITLE
fix(parsers): prefix absolute imports when the top-level package shares the repo name

### DIFF
--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -199,6 +199,7 @@ class ImportProcessor:
         "stdlib_extractor",
         "_is_local_module_cached",
         "_is_local_java_import_cached",
+        "_project_named_package",
         "_map_py_source_root",
         "_map_go_import_path",
         "_cpp_module_qn_map",
@@ -262,6 +263,16 @@ class ImportProcessor:
         )
 
         repo_is_package = (repo_path / cs.INIT_PY).is_file()
+
+        # (H) A repo whose top-level package shares the repo's name (a django
+        # (H) clone is django/django, celery is celery/celery) makes written
+        # (H) absolute imports collide with the project prefix: `django.http`
+        # (H) names the package dir and needs the project prefix on top
+        # (H) (django.django.http), while in a flat layout (repo root doubles
+        # (H) as the installed package) the written path already IS the qn.
+        self._project_named_package = (
+            not repo_is_package and (repo_path / project_name).is_dir()
+        )
 
         # (H) Python packages under nested source roots (src-layout, monorepo
         # (H) packages, pyproject package-dir remaps) are importable by a name that
@@ -629,6 +640,8 @@ class ImportProcessor:
         if module_name == self.project_name or module_name.startswith(
             self.project_name + cs.SEPARATOR_DOT
         ):
+            if self._project_named_package:
+                return f"{self.project_name}{cs.SEPARATOR_DOT}{module_name}"
             return module_name
         if self._is_local_module(top_level):
             return f"{self.project_name}{cs.SEPARATOR_DOT}{module_name}"
@@ -772,9 +785,8 @@ class ImportProcessor:
         if not imported_items and not is_wildcard:
             return
 
-        base_module = self._resolve_python_base_module(module_name)
         self._register_python_from_imports(
-            module_qn, base_module, imported_items, is_wildcard
+            module_qn, module_name, imported_items, is_wildcard
         )
 
     def _extract_python_from_module_name(
@@ -785,7 +797,13 @@ class ImportProcessor:
             return None
 
         if module_name_node.type == cs.TS_DOTTED_NAME:
-            return safe_decode_text(module_name_node)
+            # (H) A written absolute path resolves through the same collision-
+            # (H) aware mapping as plain imports; a relative import is already
+            # (H) project-prefixed by construction and must NOT re-enter it (a
+            # (H) second prefixing would double the project segment).
+            if written := safe_decode_text(module_name_node):
+                return self._resolve_python_base_module(written)
+            return None
         if module_name_node.type == cs.TS_RELATIVE_IMPORT:
             return self._resolve_relative_import(module_name_node, module_qn)
         return None
@@ -816,8 +834,9 @@ class ImportProcessor:
         return None
 
     def _resolve_python_base_module(self, module_name: str) -> str:
-        if module_name.startswith(self.project_name):
-            return module_name
+        # (H) The old `startswith(project_name)` as-is shortcut is subsumed by
+        # (H) _resolve_import_full_name's first branch, which additionally
+        # (H) handles the project-named-package collision.
         top_level = module_name.split(cs.SEPARATOR_DOT)[0]
         return self._resolve_import_full_name(module_name, top_level)
 

--- a/codebase_rag/tests/test_project_named_package_imports.py
+++ b/codebase_rag/tests/test_project_named_package_imports.py
@@ -1,0 +1,147 @@
+# (H) When the repo directory and its top-level package share a name (a django
+# (H) clone is django/django/..., celery is celery/celery/...), a written
+# (H) absolute import like `from django.http import HttpRequest` collides with
+# (H) the project prefix: the import processor trusted the written path as an
+# (H) already-qualified qn and returned it as-is, while every real node lives
+# (H) under the DOUBLED prefix (django.django.http.request.HttpRequest). Every
+# (H) absolute import in such a repo mapped to a nonexistent qn, severing
+# (H) INHERITS (and with it OVERRIDES dispatch revival: django's
+# (H) ASGIRequest._get_scheme, BaseUserCreationForm._post_clean,
+# (H) ArrayField._choices_is_value all reported dead). The as-is reading is
+# (H) only correct when NO project-named top-level directory exists (flat
+# (H) layout where the repo root doubles as the installed package).
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.conftest import get_relationships, run_updater
+
+REQUEST_PY = """class HttpRequest:
+    @property
+    def scheme(self):
+        return self._get_scheme()
+
+    def _get_scheme(self):
+        return "http"
+"""
+
+ASGI_PY = """from pkgrepo.http import HttpRequest
+
+
+class ASGIRequest(HttpRequest):
+    def _get_scheme(self):
+        return super()._get_scheme()
+"""
+
+FORMS_MODELS_PY = """class BaseModelForm:
+    def _post_clean(self):
+        return 1
+
+
+class ModelForm(BaseModelForm):
+    pass
+"""
+
+AUTH_FORMS_PY = """from pkgrepo import forms
+
+
+class BaseUserCreationForm(forms.ModelForm):
+    def _post_clean(self):
+        return 2
+"""
+
+
+def _edges(mock_ingestor: MagicMock, rel_type: str) -> set[tuple[str, str]]:
+    return {
+        (c.args[0][2], c.args[2][2]) for c in get_relationships(mock_ingestor, rel_type)
+    }
+
+
+def _build(temp_repo: Path, mock_ingestor: MagicMock) -> None:
+    project = temp_repo / "pkgrepo"
+    pkg = project / "pkgrepo"
+    (pkg / "http").mkdir(parents=True)
+    (pkg / "forms").mkdir()
+    (pkg / "auth").mkdir()
+    (project / "docs").mkdir()
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (pkg / "http" / "__init__.py").write_text(
+        "from pkgrepo.http.request import HttpRequest\n", encoding="utf-8"
+    )
+    (pkg / "http" / "request.py").write_text(REQUEST_PY, encoding="utf-8")
+    (pkg / "asgi.py").write_text(ASGI_PY, encoding="utf-8")
+    (pkg / "forms" / "__init__.py").write_text(
+        "from pkgrepo.forms.models import *  # noqa: F403\n", encoding="utf-8"
+    )
+    (pkg / "forms" / "models.py").write_text(FORMS_MODELS_PY, encoding="utf-8")
+    (pkg / "auth" / "__init__.py").write_text("", encoding="utf-8")
+    (pkg / "auth" / "forms.py").write_text(AUTH_FORMS_PY, encoding="utf-8")
+    run_updater(project, mock_ingestor, skip_if_missing="python")
+
+
+def test_bare_name_base_imported_through_package_reexport_resolves(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) `from pkgrepo.http import HttpRequest` + `class ASGIRequest(HttpRequest)`
+    # (H) must land on the class behind the package __init__'s explicit re-export.
+    _build(temp_repo, mock_ingestor)
+
+    assert (
+        "pkgrepo.pkgrepo.asgi.ASGIRequest",
+        "pkgrepo.pkgrepo.http.request.HttpRequest",
+    ) in _edges(mock_ingestor, "INHERITS")
+
+
+def test_override_through_collided_import_is_recorded(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    _build(temp_repo, mock_ingestor)
+
+    assert (
+        "pkgrepo.pkgrepo.asgi.ASGIRequest._get_scheme",
+        "pkgrepo.pkgrepo.http.request.HttpRequest._get_scheme",
+    ) in _edges(mock_ingestor, "OVERRIDES")
+
+
+def test_package_attribute_base_through_collided_import_resolves(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) `from pkgrepo import forms` + `forms.ModelForm`: the #688 star-reexport
+    # (H) machinery only fires once the import maps to the project-prefixed
+    # (H) package qn instead of the written path.
+    _build(temp_repo, mock_ingestor)
+
+    assert (
+        "pkgrepo.pkgrepo.auth.forms.BaseUserCreationForm",
+        "pkgrepo.pkgrepo.forms.models.ModelForm",
+    ) in _edges(mock_ingestor, "INHERITS")
+    assert (
+        "pkgrepo.pkgrepo.auth.forms.BaseUserCreationForm._post_clean",
+        "pkgrepo.pkgrepo.forms.models.BaseModelForm._post_clean",
+    ) in _edges(mock_ingestor, "OVERRIDES")
+
+
+def test_flat_layout_self_named_import_keeps_written_path(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) No project-named top-level dir: the repo root itself doubles as the
+    # (H) installed package (package_dir={'flatpkg': '.'}), so the written path
+    # (H) already IS the qn and must stay untouched.
+    project = temp_repo / "flatpkg"
+    project.mkdir()
+    (project / "models.py").write_text(
+        "class Base:\n    def hook(self):\n        return 1\n", encoding="utf-8"
+    )
+    (project / "user.py").write_text(
+        "from flatpkg.models import Base\n\n\n"
+        "class User(Base):\n"
+        "    def hook(self):\n"
+        "        return 2\n",
+        encoding="utf-8",
+    )
+    run_updater(project, mock_ingestor, skip_if_missing="python")
+
+    assert ("flatpkg.user.User", "flatpkg.models.Base") in _edges(
+        mock_ingestor, "INHERITS"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.291"
+version = "0.0.293"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Problem

When a repo's top-level package shares the repo directory's name (a django clone is `django/django/...`, celery is `celery/celery/...`), every written absolute import collides with the project prefix. `_resolve_import_full_name` trusted any written path starting with the project name as an already-qualified qn and returned it as-is, so `from django.http import HttpRequest` mapped to `django.http.HttpRequest` while every real node lives under the doubled prefix (`django.django.http.request.HttpRequest`).

The as-is reading is only correct for the flat layout, where the repo root itself doubles as the installed package and the written path really is the qn.

In a collided repo this silently severed INHERITS for every base imported absolutely, and with it the OVERRIDES dispatch revival in dead-code analysis. django dogfood reported six overrides of live base hooks as dead: `ASGIRequest._get_scheme`, `WSGIRequest._get_scheme`, `BaseUserCreationForm._post_clean`, `ArrayField._choices_is_value`, `RangeField._choices_is_value`, `CompositePrimaryKey._check_field_name`. The #688 package-reexport machinery was already correct but never fired because the import map fed it nonexistent qns.

## Fix

- `ImportProcessor.__init__` computes `_project_named_package` once: the repo root is not itself a package and contains a top-level directory named after the project.
- `_resolve_import_full_name`'s first branch prefixes the written path with the project name when that flag is set; flat layouts keep the as-is behavior.
- `_resolve_python_base_module` loses its own `startswith(project_name)` as-is shortcut (subsumed by the branch above), and `_extract_python_from_module_name` resolves written absolute dotted names through it while relative imports keep bypassing it entirely, since they are already project-prefixed by construction and a second prefixing would double the segment.

## Measurements

django (fresh shallow clone, whole repo, tests excluded): 23 -> 17 findings, exactly the six predicted overrides revived, zero newly dead. Other dogfood repos have no project-named top-level package, so the flag is false and behavior is byte-identical there.

## Testing

RED first: `test_project_named_package_imports.py` committed failing, covering the bare-name base behind an explicit package re-export, the OVERRIDES edge through the collided import, the package-attribute base behind a star re-export (`from pkgrepo import forms` + `forms.ModelForm`), and the flat-layout guard (self-named import keeps the written path). Full suite 4802 passed, 10 skipped. ruff clean, ty at the main baseline.
