### PR TITLE
fix(parsers): unwrap bind, call, and apply to reference the underlying function

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -2348,12 +2348,10 @@ class CallProcessor:
                     # (H) interleaves parens (`api.setState = ((s, r) => {...}) as
                     # (H) SetState`); peel both so the bare name/arrow underneath is
                     # (H) what we reference.
-                    value = self._unwrap_ts_value(value)
                     # (H) `const bound = handler.bind(null)` stores the bound
                     # (H) handler; .bind/.call/.apply are transparent for
                     # (H) reference resolution like a cast.
-                    if (bound := self._unwrap_bound_function(value)) is not None:
-                        value = bound
+                    value = self._peel_bound_callable(value, peel_parens=True)
                     # (H) A bare-name RHS names a callable; an inline arrow/function-expr
                     # (H) RHS (`OpenAPI.TOKEN = async () => {}`) stores an anonymous
                     # (H) function on the target for later invocation --
@@ -2802,14 +2800,10 @@ class CallProcessor:
         ensure_rel,
     ) -> None:
         # (H) A value cast for typing (`persistImpl as unknown as Persist`) is
-        # (H) transparent for reference resolution; unwrap it first.
-        node = self._unwrap_ts_cast(node)
-        # (H) `fn.bind(ctx)` / `fn.call(...)` / `fn.apply(...)` in value position
-        # (H) (onError: handleError.bind(toast)) hands off `fn`; the call resolves to
-        # (H) the Function.prototype builtin, so unwrap to the bound function and
-        # (H) reference it instead, or it reports as dead.
-        if (bound := self._unwrap_bound_function(node)) is not None:
-            node = bound
+        # (H) transparent for reference resolution, and `fn.bind(ctx)` /
+        # (H) `fn.call(...)` / `fn.apply(...)` in value position (onError:
+        # (H) handleError.bind(toast)) hands off `fn`; peel both to a fixpoint.
+        node = self._peel_bound_callable(node)
         # (H) Only a bare name / attribute / member-expression in value position names
         # (H) a function; a call, comprehension or literal is not a reference to a
         # (H) callable itself. Reuses the flow-arg ref types (identifier, Python
@@ -2848,6 +2842,22 @@ class CallProcessor:
                 break
             current = inner
         return current
+
+    def _peel_bound_callable(self, node: Node, peel_parens: bool = False) -> Node:
+        # (H) Iterate cast (and optionally paren) unwraps with the bound-call
+        # (H) unwrap to a FIXPOINT: `(handler as any).bind(null)` interleaves a
+        # (H) cast INSIDE the bind receiver and `h.bind(a).bind(b)` chains, so
+        # (H) a single pass of either unwrap leaves a wrapper behind.
+        while True:
+            node = (
+                self._unwrap_ts_value(node)
+                if peel_parens
+                else self._unwrap_ts_cast(node)
+            )
+            bound = self._unwrap_bound_function(node)
+            if bound is None:
+                return node
+            node = bound
 
     def _unwrap_bound_function(self, node: Node) -> Node | None:
         # (H) For `fn.bind(ctx)` (a call_expression whose function is `fn.bind`),
@@ -3313,15 +3323,12 @@ class CallProcessor:
         caller_qn: str | None = None,
         rel_type: cs.RelationshipType = cs.RelationshipType.CALLS,
     ) -> None:
-        # (H) A TS cast (`handler as any`, `fn satisfies T`, `cb!`) is transparent for
-        # (H) reference resolution; unwrap it so the callable underneath resolves.
-        arg_node = self._unwrap_ts_cast(arg_node)
-        # (H) `fn.bind(ctx)` / `.call` / `.apply` in argument position
-        # (H) (addEventListener("click", handler.bind(this)), django admin's
-        # (H) inlines.js) hands off `fn`; the call itself resolves to the
-        # (H) Function.prototype builtin, so unwrap to the bound function.
-        if (bound := self._unwrap_bound_function(arg_node)) is not None:
-            arg_node = bound
+        # (H) A TS cast (`handler as any`, `fn satisfies T`, `cb!`) is transparent
+        # (H) for reference resolution, and `fn.bind(ctx)` / `.call` / `.apply` in
+        # (H) argument position (addEventListener("click", handler.bind(this)),
+        # (H) django admin's inlines.js) hands off `fn` while the call itself
+        # (H) resolves to the Function.prototype builtin; peel both to a fixpoint.
+        arg_node = self._peel_bound_callable(arg_node)
         # (H) An arrow/function-expression passed DIRECTLY as a call argument
         # (H) (useCallback(() => {}), setTimeout(() => {}), arr.map(x => ...)) is
         # (H) registered anonymously in the enclosing scope but named after no
@@ -3420,7 +3427,10 @@ class CallProcessor:
         for position, keyword_name, raw_arg in items:
             # (H) `f(callback as any)` casts the argument; unwrap so a cast callable
             # (H) argument still flows.
-            arg_node = self._unwrap_ts_cast(raw_arg)
+            # (H) `outer(handler.bind(this))` forwards the bound handler through
+            # (H) a pass-through param; peel .bind like the direct-argument path
+            # (H) or the propagated flow edge is lost.
+            arg_node = self._peel_bound_callable(raw_arg)
             if arg_node.type not in _FLOW_ARG_REF_TYPES:
                 continue
             arg_text = safe_decode_text(arg_node)

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -2349,6 +2349,11 @@ class CallProcessor:
                     # (H) SetState`); peel both so the bare name/arrow underneath is
                     # (H) what we reference.
                     value = self._unwrap_ts_value(value)
+                    # (H) `const bound = handler.bind(null)` stores the bound
+                    # (H) handler; .bind/.call/.apply are transparent for
+                    # (H) reference resolution like a cast.
+                    if (bound := self._unwrap_bound_function(value)) is not None:
+                        value = bound
                     # (H) A bare-name RHS names a callable; an inline arrow/function-expr
                     # (H) RHS (`OpenAPI.TOKEN = async () => {}`) stores an anonymous
                     # (H) function on the target for later invocation --
@@ -3311,6 +3316,12 @@ class CallProcessor:
         # (H) A TS cast (`handler as any`, `fn satisfies T`, `cb!`) is transparent for
         # (H) reference resolution; unwrap it so the callable underneath resolves.
         arg_node = self._unwrap_ts_cast(arg_node)
+        # (H) `fn.bind(ctx)` / `.call` / `.apply` in argument position
+        # (H) (addEventListener("click", handler.bind(this)), django admin's
+        # (H) inlines.js) hands off `fn`; the call itself resolves to the
+        # (H) Function.prototype builtin, so unwrap to the bound function.
+        if (bound := self._unwrap_bound_function(arg_node)) is not None:
+            arg_node = bound
         # (H) An arrow/function-expression passed DIRECTLY as a call argument
         # (H) (useCallback(() => {}), setTimeout(() => {}), arr.map(x => ...)) is
         # (H) registered anonymously in the enclosing scope but named after no

--- a/codebase_rag/tests/test_callback_reference_edges.py
+++ b/codebase_rag/tests/test_callback_reference_edges.py
@@ -328,3 +328,45 @@ def test_ternary_condition_is_not_referenced(tmp_path: Path) -> None:
     assert _has(rels, "picker.pick", REFERENCES, "picker.first")
     assert _has(rels, "picker.pick", REFERENCES, "picker.second")
     assert not _has(rels, "picker.pick", REFERENCES, "picker.check")
+
+
+def test_bound_function_argument_is_referenced(tmp_path: Path) -> None:
+    # (H) `el.addEventListener("click", handler.bind(this))` hands off `handler`;
+    # (H) the .bind call itself resolves to the Function.prototype builtin, so the
+    # (H) bound function must be referenced from the passing scope or it reports
+    # (H) dead (django admin's inlines.js inlineDeleteHandler).
+    files = {
+        "inlines.js": (
+            "function formset(row) {\n"
+            "    const inlineDeleteHandler = function (e1) {\n"
+            "        return e1;\n"
+            "    };\n"
+            '    row.addEventListener("click", inlineDeleteHandler.bind(this));\n'
+            "}\n"
+            "module.exports = formset;\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files)
+    assert _has(
+        rels, "inlines.formset", REFERENCES, "inlines.formset.inlineDeleteHandler"
+    ) or _has(rels, "inlines.formset", "CALLS", "inlines.formset.inlineDeleteHandler")
+
+
+def test_bound_function_assignment_rhs_is_referenced(tmp_path: Path) -> None:
+    # (H) `const bound = handler.bind(null)` stores the bound handler for later
+    # (H) invocation; the assignment walk must peel .bind like a cast so the
+    # (H) underlying function is referenced.
+    files = {
+        "store.js": (
+            "function attach() {\n"
+            "    const onSave = function (e) {\n"
+            "        return e;\n"
+            "    };\n"
+            "    const bound = onSave.bind(null);\n"
+            "    return bound;\n"
+            "}\n"
+            "module.exports = attach;\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files)
+    assert _has(rels, "store.attach", REFERENCES, "store.attach.onSave")

--- a/codebase_rag/tests/test_callback_reference_edges.py
+++ b/codebase_rag/tests/test_callback_reference_edges.py
@@ -370,3 +370,74 @@ def test_bound_function_assignment_rhs_is_referenced(tmp_path: Path) -> None:
     }
     rels = _run_rels(tmp_path, files)
     assert _has(rels, "store.attach", REFERENCES, "store.attach.onSave")
+
+
+def test_cast_wrapped_bound_function_argument_is_referenced(tmp_path: Path) -> None:
+    # (H) `(handler as any).bind(this)` interleaves a cast INSIDE the bind
+    # (H) receiver; a single unwrap pass leaves the cast node behind, so the
+    # (H) peel must iterate cast/paren and bind unwraps to a fixpoint. Chained
+    # (H) binds (`h.bind(a).bind(b)`) peel the same way.
+    files = {
+        "wrapped.ts": (
+            "function attach(el: { on: (cb: unknown) => void }) {\n"
+            "    const onSave = function (e: number) {\n"
+            "        return e;\n"
+            "    };\n"
+            "    el.on((onSave as any).bind(null));\n"
+            "    const rebound = onSave.bind(null).bind(null);\n"
+            "    return rebound;\n"
+            "}\n"
+            "export default attach;\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files)
+    assert _has(rels, "wrapped.attach", REFERENCES, "wrapped.attach.onSave") or _has(
+        rels, "wrapped.attach", "CALLS", "wrapped.attach.onSave"
+    )
+
+
+def test_bound_function_argument_flows_to_callable_param(tmp_path: Path) -> None:
+    # (H) A bound function passed to a FIRST-PARTY callee that invokes its
+    # (H) parameter must produce the callable-flow CALLS edge (run -> handler),
+    # (H) not just the passing scope's REFERENCES edge.
+    files = {
+        "flow.js": (
+            "function run(cb) {\n"
+            "    return cb();\n"
+            "}\n"
+            "function handler() {\n"
+            "    return 1;\n"
+            "}\n"
+            "function main() {\n"
+            "    return run(handler.bind(this));\n"
+            "}\n"
+            "module.exports = main;\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files)
+    assert _has(rels, "flow.run", "CALLS", "flow.handler")
+
+
+def test_bound_function_flows_through_passthrough_param(tmp_path: Path) -> None:
+    # (H) The callable-flow fixpoint (outer forwards its param to run) records
+    # (H) seeds in _collect_callable_flow, which must peel .bind like the
+    # (H) direct-argument path or the propagated CALLS edge is lost.
+    files = {
+        "flow2.js": (
+            "function run(cb) {\n"
+            "    return cb();\n"
+            "}\n"
+            "function outer(cb2) {\n"
+            "    return run(cb2);\n"
+            "}\n"
+            "function handler() {\n"
+            "    return 1;\n"
+            "}\n"
+            "function main() {\n"
+            "    return outer(handler.bind(this));\n"
+            "}\n"
+            "module.exports = main;\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files)
+    assert _has(rels, "flow2.run", "CALLS", "flow2.handler")

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.291"
+version = "0.0.293"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Problem

`el.addEventListener("click", handler.bind(this))` hands `handler` off for later invocation, but the argument node is a call expression whose callee resolves to the `Function.prototype` builtin, so the reference walkers dropped it and `handler` reported dead (django admin's `inlines.js` `inlineDeleteHandler`).

`_unwrap_bound_function` already existed and was applied in object-value position (`onError: handleError.bind(toast)`), but not in argument position or assignment RHS position.

## Fix

Two sites, both reusing the existing unwrap:

- `_emit_callback_edge` peels `.bind`/`.call`/`.apply` right after the TS-cast unwrap, so every path funneling through it (call arguments, returns, JSX expression values, callable-param flow) treats the wrapper as transparent.
- The assignment walk peels it after `_unwrap_ts_value`, covering `const bound = handler.bind(null)`.

Emits only when the unwrapped node resolves to a registered callable, so the change can only revive, never inflate the dead count.

## Measurements

django (fresh shallow clone, tests excluded): revives `inlineDeleteHandler`. Combined with the two sibling PRs the django report goes 23 -> 13, zero newly dead; the remaining 13 are verified genuine (dynamic `getattr("%s" % ...)` dispatch, vestigial no-caller hooks, test-only callers, untyped metaclass receivers).

## Testing

RED first: two tests committed failing in `test_callback_reference_edges.py` (argument position and assignment RHS). Full suite 4800 passed, 10 skipped. ruff clean, ty at the main baseline.
