### PR TITLE
fix(cpp): recover whole-file parse collapse from unbalanced preprocessor branches

### DIFF
--- a/codebase_rag/constants/ast_cpp.py
+++ b/codebase_rag/constants/ast_cpp.py
@@ -173,3 +173,14 @@ CPP_NESTED_SCOPE_NODE_TYPES = frozenset(
         *CPP_COMPOUND_TYPES,
     )
 )
+
+# (H) Preprocessor conditional directive heads, matched at line start (C allows
+# (H) whitespace around '#'). Drives the whole-file-ERROR parse recovery: a
+# (H) conditional branch whose brace count does not balance (nlohmann's
+# (H) `#ifdef __cpp_lib_byteswap ... else { #endif`) breaks tree-sitter, which
+# (H) keeps every branch's tokens.
+CPP_PREPROC_CONDITIONAL_PATTERN = (
+    rb"^\s*#\s*(if|ifdef|ifndef|elif|elifdef|elifndef|else|endif)\b"
+)
+CPP_PREPROC_OPEN_DIRECTIVES = frozenset({b"if", b"ifdef", b"ifndef"})
+CPP_PREPROC_SPLIT_DIRECTIVES = frozenset({b"elif", b"elifdef", b"elifndef", b"else"})

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -16,6 +16,7 @@ from .config import settings
 from .language_spec import LANGUAGE_FQN_SPECS, get_language_spec
 from .parser_fingerprint import compute_parser_fingerprint
 from .parser_loader import COMBINED_FUNC_CLASS_IMPORT_QUERIES
+from .parsers.cpp.preproc_recovery import parse_with_preproc_recovery
 from .parsers.cpp_frontend import (
     cpp_frontend_available,
     find_compile_commands,
@@ -1311,7 +1312,7 @@ class GraphUpdater:
             parser = self.queries[language].get(cs.KEY_PARSER)
             if not parser:
                 continue
-            tree = parser.parse(file_bytes)
+            tree = parse_with_preproc_recovery(parser, file_bytes, language)
             root_node = tree.root_node
             combined_query = COMBINED_FUNC_CLASS_IMPORT_QUERIES.get(language)
             combined_captures: dict[str, list] | None = None
@@ -1376,7 +1377,7 @@ class GraphUpdater:
         except OSError as e:
             logger.error(ls.CALL_PROCESSING_FAILED, path=file_path, error=e)
             return None
-        root_node = parser.parse(file_bytes).root_node
+        root_node = parse_with_preproc_recovery(parser, file_bytes, language).root_node
         self.ast_cache[file_path] = (root_node, language)
         self.factory._func_class_captures_cache.pop(file_path, None)
         return root_node

--- a/codebase_rag/parsers/cpp/preproc_recovery.py
+++ b/codebase_rag/parsers/cpp/preproc_recovery.py
@@ -9,8 +9,10 @@
 # (H) methods degrade to free functions or vanish, orphaning whole dead-code
 # (H) clusters). When a parse comes back with a catastrophic ERROR, blank the
 # (H) net-unbalanced LEAF conditional branches (space-filled, so every byte
-# (H) offset and line number of the surviving code is preserved) and re-parse;
-# (H) the retry is kept only when it strictly shrinks the worst ERROR span.
+# (H) offset and line number of the surviving code is preserved) and re-parse,
+# (H) preferring the SMALLEST blanked subset: each candidate alone first, the
+# (H) full set as a last resort, keeping the retry only when it strictly
+# (H) shrinks the worst ERROR span.
 import re
 
 from tree_sitter import Node, Parser, Tree
@@ -22,6 +24,7 @@ _CHAR_OPEN_BRACE = b"{"
 _CHAR_CLOSE_BRACE = b"}"
 _CHAR_SPACE = b" "
 _CHAR_NEWLINE = b"\n"
+_LINE_COMMENT = b"//"
 
 # (H) A branch list plus whether the conditional contains nested conditionals:
 # (H) only LEAF conditionals are candidates. An outer region (an include guard
@@ -42,9 +45,16 @@ def _max_error_span(root: Node) -> int:
     )
 
 
-def _blank_unbalanced_leaf_branches(source: bytes) -> bytes | None:
-    lines = source.split(_CHAR_NEWLINE)
-    blanks: list[tuple[int, int]] = []
+def _code_brace_delta(line: bytes) -> int:
+    # (H) a brace after `//` is prose, not structure (a doc note `// { see
+    # (H) design` must not mark its branch unbalanced); block comments and
+    # (H) string literals are left to the strict-improvement guard
+    code = line.split(_LINE_COMMENT, 1)[0]
+    return code.count(_CHAR_OPEN_BRACE) - code.count(_CHAR_CLOSE_BRACE)
+
+
+def _unbalanced_leaf_branches(lines: list[bytes]) -> list[tuple[int, int]]:
+    candidates: list[tuple[int, int]] = []
     stack: list[_Frame] = []
     for index, line in enumerate(lines):
         match = _DIRECTIVE.match(line)
@@ -69,22 +79,18 @@ def _blank_unbalanced_leaf_branches(source: bytes) -> bytes | None:
             for start, end in branches:
                 if start > end:
                     continue
-                delta = sum(
-                    lines[i].count(_CHAR_OPEN_BRACE) - lines[i].count(_CHAR_CLOSE_BRACE)
-                    for i in range(start, end + 1)
-                )
-                # (H) brace counting is textual (a brace inside a comment or
-                # (H) string literal counts too); a false trigger only blanks a
-                # (H) branch of a file that already parses as one ERROR, and
-                # (H) the strict-improvement guard below discards a bad retry
+                delta = sum(_code_brace_delta(lines[i]) for i in range(start, end + 1))
                 if delta != 0:
-                    blanks.append((start, end))
-    if not blanks:
-        return None
-    for start, end in blanks:
+                    candidates.append((start, end))
+    return candidates
+
+
+def _blank(lines: list[bytes], ranges: list[tuple[int, int]]) -> bytes:
+    out = list(lines)
+    for start, end in ranges:
         for i in range(start, end + 1):
-            lines[i] = _CHAR_SPACE * len(lines[i])
-    return _CHAR_NEWLINE.join(lines)
+            out[i] = _CHAR_SPACE * len(out[i])
+    return _CHAR_NEWLINE.join(out)
 
 
 def parse_with_preproc_recovery(
@@ -99,10 +105,25 @@ def parse_with_preproc_recovery(
     # (H) covering most of the file warrants the blank-and-retry pass
     if worst * 2 < total_lines:
         return tree
-    blanked = _blank_unbalanced_leaf_branches(source_bytes)
-    if blanked is None:
+    lines = source_bytes.split(_CHAR_NEWLINE)
+    candidates = _unbalanced_leaf_branches(lines)
+    if not candidates:
         return tree
-    retry = parser.parse(blanked)
-    if _max_error_span(retry.root_node) < worst:
-        return retry
-    return tree
+    # (H) prefer the smallest blanked subset: an unrelated branch whose textual
+    # (H) imbalance survives comment stripping (a brace in a string or macro
+    # (H) payload) must not lose its definitions when a single real offender
+    # (H) explains the collapse; the full set stays as the last resort
+    subsets: list[list[tuple[int, int]]] = [[c] for c in candidates]
+    if len(candidates) > 1:
+        subsets.append(candidates)
+    best = tree
+    best_worst = worst
+    for subset in subsets:
+        retry = parser.parse(_blank(lines, subset))
+        retry_worst = _max_error_span(retry.root_node)
+        if retry_worst < best_worst:
+            best = retry
+            best_worst = retry_worst
+        if best_worst == 0:
+            break
+    return best

--- a/codebase_rag/parsers/cpp/preproc_recovery.py
+++ b/codebase_rag/parsers/cpp/preproc_recovery.py
@@ -1,0 +1,108 @@
+# (H) Recovery for the conditional-brace preprocessor pattern that collapses a
+# (H) whole C/C++ file into one tree-sitter ERROR node. A branch can open a
+# (H) brace that a LATER branch closes (nlohmann binary_reader.hpp:
+# (H) `#ifdef __cpp_lib_byteswap ... else { #endif` followed by
+# (H) `#ifdef __cpp_lib_byteswap } #endif`); the preprocessor keeps the braces
+# (H) balanced under every configuration, but tree-sitter keeps EVERY branch's
+# (H) tokens and sees an imbalance, which at file scale makes error recovery
+# (H) reinterpret the entire translation unit (3,125 lines -> one ERROR;
+# (H) methods degrade to free functions or vanish, orphaning whole dead-code
+# (H) clusters). When a parse comes back with a catastrophic ERROR, blank the
+# (H) net-unbalanced LEAF conditional branches (space-filled, so every byte
+# (H) offset and line number of the surviving code is preserved) and re-parse;
+# (H) the retry is kept only when it strictly shrinks the worst ERROR span.
+import re
+
+from tree_sitter import Node, Parser, Tree
+
+from ... import constants as cs
+
+_DIRECTIVE = re.compile(cs.CPP_PREPROC_CONDITIONAL_PATTERN)
+_CHAR_OPEN_BRACE = b"{"
+_CHAR_CLOSE_BRACE = b"}"
+_CHAR_SPACE = b" "
+_CHAR_NEWLINE = b"\n"
+
+# (H) A branch list plus whether the conditional contains nested conditionals:
+# (H) only LEAF conditionals are candidates. An outer region (an include guard
+# (H) spans the whole file) legitimately holds unbalanced fragments between its
+# (H) nested directives (a class body split by an inner #if), so blanking is
+# (H) restricted to branches whose entire content is directive-free.
+_Frame = tuple[list[bool], list[tuple[int, int]], list[int]]
+
+
+def _max_error_span(root: Node) -> int:
+    return max(
+        (
+            child.end_point[0] - child.start_point[0] + 1
+            for child in root.children
+            if child.type == cs.TS_ERROR
+        ),
+        default=0,
+    )
+
+
+def _blank_unbalanced_leaf_branches(source: bytes) -> bytes | None:
+    lines = source.split(_CHAR_NEWLINE)
+    blanks: list[tuple[int, int]] = []
+    stack: list[_Frame] = []
+    for index, line in enumerate(lines):
+        match = _DIRECTIVE.match(line)
+        if match is None:
+            continue
+        keyword = match.group(1)
+        if keyword in cs.CPP_PREPROC_OPEN_DIRECTIVES:
+            if stack:
+                stack[-1][0][0] = True
+            stack.append(([False], [], [index + 1]))
+        elif not stack:
+            continue
+        elif keyword in cs.CPP_PREPROC_SPLIT_DIRECTIVES:
+            _, branches, current = stack[-1]
+            branches.append((current[0], index - 1))
+            current[0] = index + 1
+        else:
+            has_nested, branches, current = stack.pop()
+            branches.append((current[0], index - 1))
+            if has_nested[0]:
+                continue
+            for start, end in branches:
+                if start > end:
+                    continue
+                delta = sum(
+                    lines[i].count(_CHAR_OPEN_BRACE) - lines[i].count(_CHAR_CLOSE_BRACE)
+                    for i in range(start, end + 1)
+                )
+                # (H) brace counting is textual (a brace inside a comment or
+                # (H) string literal counts too); a false trigger only blanks a
+                # (H) branch of a file that already parses as one ERROR, and
+                # (H) the strict-improvement guard below discards a bad retry
+                if delta != 0:
+                    blanks.append((start, end))
+    if not blanks:
+        return None
+    for start, end in blanks:
+        for i in range(start, end + 1):
+            lines[i] = _CHAR_SPACE * len(lines[i])
+    return _CHAR_NEWLINE.join(lines)
+
+
+def parse_with_preproc_recovery(
+    parser: Parser, source_bytes: bytes, language: cs.SupportedLanguage
+) -> Tree:
+    tree = parser.parse(source_bytes)
+    if language not in (cs.SupportedLanguage.CPP, cs.SupportedLanguage.C):
+        return tree
+    worst = _max_error_span(tree.root_node)
+    total_lines = source_bytes.count(_CHAR_NEWLINE) + 1
+    # (H) local errors recover fine through query matching; only a collapse
+    # (H) covering most of the file warrants the blank-and-retry pass
+    if worst * 2 < total_lines:
+        return tree
+    blanked = _blank_unbalanced_leaf_branches(source_bytes)
+    if blanked is None:
+        return tree
+    retry = parser.parse(blanked)
+    if _max_error_span(retry.root_node) < worst:
+        return retry
+    return tree

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -22,6 +22,7 @@ from ..types_defs import (
 from ..utils.path_utils import cached_relative_path, cached_resolve_posix
 from .class_ingest import ClassIngestMixin
 from .cpp import CppTypeInferenceEngine
+from .cpp.preproc_recovery import parse_with_preproc_recovery
 from .dependency_parser import parse_dependencies
 from .function_ingest import FunctionIngestMixin
 from .handlers import get_handler
@@ -189,7 +190,7 @@ class DefinitionProcessor(
                 if not parser:
                     logger.warning(ls.DEF_NO_PARSER.format(language=language))
                     return None
-                tree = parser.parse(source_bytes)
+                tree = parse_with_preproc_recovery(parser, source_bytes, language)
                 root_node = tree.root_node
                 pre_combined_captures = None
 

--- a/codebase_rag/tests/test_cpp_preproc_brace_recovery.py
+++ b/codebase_rag/tests/test_cpp_preproc_brace_recovery.py
@@ -138,3 +138,67 @@ def test_conditional_brace_file_keeps_call_edges(
         "brcalls.reader.detail.binary_reader.helper_3",
         "brcalls.reader.detail.binary_reader.read_one",
     ) in calls, sorted(calls)
+
+
+def test_blank_helper_edge_shapes() -> None:
+    from codebase_rag.parsers.cpp.preproc_recovery import (
+        _blank_unbalanced_leaf_branches,
+    )
+
+    # (H) balanced-only conditionals produce no rewrite
+    balanced = b"#if A\nint x = 1;\n#endif\n"
+    assert _blank_unbalanced_leaf_branches(balanced) is None
+
+    # (H) a stray #endif with no open conditional is ignored, not a crash
+    assert _blank_unbalanced_leaf_branches(b"#endif\nint x;\n") is None
+
+    # (H) an #else split: only the unbalanced branch is blanked, the balanced
+    # (H) one survives verbatim; an EMPTY branch (#if directly followed by
+    # (H) #else) is skipped
+    split = b"#if A\n#else\nvoid f() {\n#endif\nint keep = 1;\n"
+    blanked = _blank_unbalanced_leaf_branches(split)
+    assert blanked is not None
+    assert b"void f() {" not in blanked
+    assert b"int keep = 1;" in blanked
+    # (H) blanking is position-preserving: same byte length, same line count
+    assert len(blanked) == len(split)
+    assert blanked.count(b"\n") == split.count(b"\n")
+
+
+def test_parse_recovery_passthrough_shapes() -> None:
+    import pytest as _pytest
+
+    from codebase_rag import constants as cs
+    from codebase_rag.parser_loader import load_parsers
+    from codebase_rag.parsers.cpp.preproc_recovery import (
+        parse_with_preproc_recovery,
+    )
+
+    parsers, _ = load_parsers()
+    if "cpp" not in parsers or "python" not in parsers:
+        _pytest.skip("parsers not available")
+
+    # (H) a non-C-family language never enters the recovery path, even for
+    # (H) unparseable content
+    py = parsers["python"]
+    tree = parse_with_preproc_recovery(
+        py, b"def broken(:\n", cs.SupportedLanguage.PYTHON
+    )
+    assert tree.root_node is not None
+
+    cpp = parsers["cpp"]
+    # (H) a clean C++ file returns the first parse untouched
+    clean = parse_with_preproc_recovery(cpp, b"int x = 1;\n", cs.SupportedLanguage.CPP)
+    assert not clean.root_node.has_error
+
+    # (H) a catastrophic file with NO conditional directives has nothing to
+    # (H) blank and keeps the original tree
+    garbage = b"}}}} class {{{{\n" * 4
+    kept = parse_with_preproc_recovery(cpp, garbage, cs.SupportedLanguage.CPP)
+    assert kept.root_node.has_error
+
+    # (H) a catastrophic file whose unbalanced branch is NOT the cause keeps
+    # (H) the original tree via the strict-improvement guard
+    unrelated = b"#if A\nvoid g() {\n#endif\n" + b"}}}} class {{{{\n" * 4
+    kept2 = parse_with_preproc_recovery(cpp, unrelated, cs.SupportedLanguage.CPP)
+    assert kept2.root_node.has_error

--- a/codebase_rag/tests/test_cpp_preproc_brace_recovery.py
+++ b/codebase_rag/tests/test_cpp_preproc_brace_recovery.py
@@ -102,9 +102,9 @@ def test_conditional_brace_file_keeps_class_structure(
     methods = get_qualified_names(get_nodes(mock_ingestor, "Method"))
     # (H) every method after the unbalanced branch must stay a MEMBER of
     # (H) binary_reader, not degrade to a module-level free function
-    assert "brproj.reader.binary_reader.helper_0" in methods, sorted(methods)
-    assert "brproj.reader.binary_reader.helper_9" in methods, sorted(methods)
-    assert "brproj.reader.binary_reader.read_one" in methods, sorted(methods)
+    assert "brproj.reader.detail.binary_reader.helper_0" in methods, sorted(methods)
+    assert "brproj.reader.detail.binary_reader.helper_9" in methods, sorted(methods)
+    assert "brproj.reader.detail.binary_reader.read_one" in methods, sorted(methods)
 
     functions = get_qualified_names(get_nodes(mock_ingestor, "Function"))
     assert "brproj.reader.helper_0" not in functions, sorted(functions)
@@ -123,10 +123,10 @@ def test_conditional_brace_file_keeps_call_edges(
         if c.args[1] == "CALLS"
     }
     assert (
-        "brcalls.reader.binary_reader.parse_bson_internal",
-        "brcalls.reader.binary_reader.read_one",
+        "brcalls.reader.detail.binary_reader.parse_bson_internal",
+        "brcalls.reader.detail.binary_reader.read_one",
     ) in calls, sorted(calls)
     assert (
-        "brcalls.reader.binary_reader.helper_3",
-        "brcalls.reader.binary_reader.read_one",
+        "brcalls.reader.detail.binary_reader.helper_3",
+        "brcalls.reader.detail.binary_reader.read_one",
     ) in calls, sorted(calls)

--- a/codebase_rag/tests/test_cpp_preproc_brace_recovery.py
+++ b/codebase_rag/tests/test_cpp_preproc_brace_recovery.py
@@ -80,6 +80,9 @@ _TAIL = """
     {
         return true;
     }
+
+  private:
+    const decltype(JSON_MAKE_MARKERS_) type_markers = JSON_MAKE_MARKERS_;
 };
 
 }  // namespace detail
@@ -108,6 +111,11 @@ def test_conditional_brace_file_keeps_class_structure(
 
     functions = get_qualified_names(get_nodes(mock_ingestor, "Function"))
     assert "brproj.reader.helper_0" not in functions, sorted(functions)
+
+    # (H) `const decltype(SOME_MACRO_) field = ...` is a FIELD whose type uses
+    # (H) an unexpandable macro; the declarator must not register a phantom
+    # (H) method named after the reserved keyword
+    assert not any(q.endswith(".decltype") for q in methods), sorted(methods)
 
 
 def test_conditional_brace_file_keeps_call_edges(

--- a/codebase_rag/tests/test_cpp_preproc_brace_recovery.py
+++ b/codebase_rag/tests/test_cpp_preproc_brace_recovery.py
@@ -76,6 +76,14 @@ _BULK_METHOD = """
 """
 
 _TAIL = """
+#ifdef JSON_DOC_HELPERS
+    // extra doc notes: { see design doc
+    bool doc_helper()
+    {
+        return true;
+    }
+#endif
+
     bool read_one()
     {
         return true;
@@ -111,6 +119,11 @@ def test_conditional_brace_file_keeps_class_structure(
 
     functions = get_qualified_names(get_nodes(mock_ingestor, "Function"))
     assert "brproj.reader.helper_0" not in functions, sorted(functions)
+
+    # (H) an UNRELATED leaf branch whose only textual imbalance is a brace in
+    # (H) a comment must survive the recovery -- only the branch that causes
+    # (H) the collapse may be blanked
+    assert "brproj.reader.detail.binary_reader.doc_helper" in methods, sorted(methods)
 
     # (H) `const decltype(SOME_MACRO_) field = ...` is a FIELD whose type uses
     # (H) an unexpandable macro; the declarator must not register a phantom

--- a/codebase_rag/tests/test_cpp_preproc_brace_recovery.py
+++ b/codebase_rag/tests/test_cpp_preproc_brace_recovery.py
@@ -155,27 +155,32 @@ def test_conditional_brace_file_keeps_call_edges(
 
 def test_blank_helper_edge_shapes() -> None:
     from codebase_rag.parsers.cpp.preproc_recovery import (
-        _blank_unbalanced_leaf_branches,
+        _blank,
+        _unbalanced_leaf_branches,
     )
 
-    # (H) balanced-only conditionals produce no rewrite
-    balanced = b"#if A\nint x = 1;\n#endif\n"
-    assert _blank_unbalanced_leaf_branches(balanced) is None
+    # (H) balanced-only conditionals produce no candidates
+    balanced = b"#if A\nint x = 1;\n#endif\n".split(b"\n")
+    assert _unbalanced_leaf_branches(balanced) == []
 
     # (H) a stray #endif with no open conditional is ignored, not a crash
-    assert _blank_unbalanced_leaf_branches(b"#endif\nint x;\n") is None
+    assert _unbalanced_leaf_branches(b"#endif\nint x;\n".split(b"\n")) == []
 
-    # (H) an #else split: only the unbalanced branch is blanked, the balanced
-    # (H) one survives verbatim; an EMPTY branch (#if directly followed by
-    # (H) #else) is skipped
-    split = b"#if A\n#else\nvoid f() {\n#endif\nint keep = 1;\n"
-    blanked = _blank_unbalanced_leaf_branches(split)
-    assert blanked is not None
+    # (H) a brace after // is prose, not structure
+    commented = b"#if DOC\n// { see design\nint y = 1;\n#endif\n".split(b"\n")
+    assert _unbalanced_leaf_branches(commented) == []
+
+    # (H) an #else split: only the unbalanced branch is a candidate (the
+    # (H) empty #if branch is skipped), and blanking is position-preserving
+    split_src = b"#if A\n#else\nvoid f() {\n#endif\nint keep = 1;\n"
+    split = split_src.split(b"\n")
+    candidates = _unbalanced_leaf_branches(split)
+    assert candidates == [(2, 2)]
+    blanked = _blank(split, candidates)
     assert b"void f() {" not in blanked
     assert b"int keep = 1;" in blanked
-    # (H) blanking is position-preserving: same byte length, same line count
-    assert len(blanked) == len(split)
-    assert blanked.count(b"\n") == split.count(b"\n")
+    assert len(blanked) == len(split_src)
+    assert blanked.count(b"\n") == split_src.count(b"\n")
 
 
 def test_parse_recovery_passthrough_shapes() -> None:

--- a/codebase_rag/tests/test_cpp_preproc_brace_recovery.py
+++ b/codebase_rag/tests/test_cpp_preproc_brace_recovery.py
@@ -1,0 +1,132 @@
+# (H) nlohmann's binary_reader.hpp (3,125 lines) collapsed into ONE whole-file
+# (H) ERROR node: a preprocessor branch opens a brace that a LATER branch
+# (H) closes (`#ifdef __cpp_lib_byteswap ... else { #endif` ... `#ifdef
+# (H) __cpp_lib_byteswap } #endif`), and tree-sitter -- which keeps EVERY
+# (H) branch's tokens -- sees unbalanced braces. Query recovery inside the
+# (H) ERROR still surfaced most method NAMES but lost the class structure
+# (H) (methods registered as free functions, five definitions dropped
+# (H) entirely), orphaning the 41-node binary_reader dead-code cluster.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.conftest import (
+    get_nodes,
+    get_qualified_names,
+    run_updater,
+)
+
+_HEAD = """\
+namespace detail
+{
+
+template<typename BasicJsonType>
+class binary_reader
+{
+  public:
+    bool parse_bson_internal()
+    {
+        std::int32_t document_size{};
+        get_number<std::int32_t, true>(input_format_t::bson, document_size);
+        return read_one();
+    }
+
+    template<class NumberType>
+    static void byte_swap(NumberType& number)
+    {
+        constexpr std::size_t sz = sizeof(number);
+#ifdef __cpp_lib_byteswap
+        if constexpr (sz == 1)
+        {
+            return;
+        }
+        else
+        {
+#endif
+            auto* ptr = reinterpret_cast<std::uint8_t*>(&number);
+            for (std::size_t i = 0; i < sz / 2; ++i)
+            {
+                std::swap(ptr[i], ptr[sz - i - 1]);
+            }
+#ifdef __cpp_lib_byteswap
+        }
+#endif
+    }
+"""
+
+# (H) the collapse needs parse mass after the unbalanced branch; a handful of
+# (H) switch-bearing template methods reproduces the real file's behaviour
+_BULK_METHOD = """
+    template<typename NumberType>
+    bool helper_{i}(const input_format_t format, NumberType& result)
+    {{
+        if (format == input_format_t::bson)
+        {{
+            return read_one();
+        }}
+        switch (result)
+        {{
+            case 0x00:
+                return helper_call(static_cast<int>(result), "x");
+            default:
+                return false;
+        }}
+    }}
+"""
+
+_TAIL = """
+    bool read_one()
+    {
+        return true;
+    }
+};
+
+}  // namespace detail
+"""
+
+
+def _write(root: Path) -> None:
+    root.mkdir()
+    bulk = "".join(_BULK_METHOD.format(i=i) for i in range(10))
+    (root / "reader.hpp").write_text(_HEAD + bulk + _TAIL, encoding="utf-8")
+
+
+def test_conditional_brace_file_keeps_class_structure(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    root = temp_repo / "brproj"
+    _write(root)
+    run_updater(root, mock_ingestor, skip_if_missing="cpp")
+
+    methods = get_qualified_names(get_nodes(mock_ingestor, "Method"))
+    # (H) every method after the unbalanced branch must stay a MEMBER of
+    # (H) binary_reader, not degrade to a module-level free function
+    assert "brproj.reader.binary_reader.helper_0" in methods, sorted(methods)
+    assert "brproj.reader.binary_reader.helper_9" in methods, sorted(methods)
+    assert "brproj.reader.binary_reader.read_one" in methods, sorted(methods)
+
+    functions = get_qualified_names(get_nodes(mock_ingestor, "Function"))
+    assert "brproj.reader.helper_0" not in functions, sorted(functions)
+
+
+def test_conditional_brace_file_keeps_call_edges(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    root = temp_repo / "brcalls"
+    _write(root)
+    run_updater(root, mock_ingestor, skip_if_missing="cpp")
+
+    calls = {
+        (c.args[0][2], c.args[2][2])
+        for c in mock_ingestor.ensure_relationship_batch.call_args_list
+        if c.args[1] == "CALLS"
+    }
+    assert (
+        "brcalls.reader.binary_reader.parse_bson_internal",
+        "brcalls.reader.binary_reader.read_one",
+    ) in calls, sorted(calls)
+    assert (
+        "brcalls.reader.binary_reader.helper_3",
+        "brcalls.reader.binary_reader.read_one",
+    ) in calls, sorted(calls)

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.293"
+version = "0.0.297"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Problem

nlohmann's `binary_reader.hpp` (3,125 lines) parses as ONE whole-file tree-sitter ERROR node. The cause is the conditional-brace preprocessor pattern: a branch opens a brace that a LATER branch closes (`#ifdef __cpp_lib_byteswap ... else { #endif` followed by `#ifdef __cpp_lib_byteswap } #endif`). The preprocessor keeps braces balanced under every configuration, but tree-sitter keeps EVERY branch's tokens and sees an imbalance; at file scale, error recovery reinterprets the entire translation unit.

Query recovery inside the ERROR still surfaced most method names but broke structure: five definitions vanished entirely (`sax_parse`, `get_number`, `get_string`, `get_binary`, `get_bytes`), and in the reduced repro methods degrade to module-level free functions, losing class membership. That orphaned the whole binary_reader dead-code cluster.

## Fix

New `parsers/cpp/preproc_recovery.py`: when a C/C++ parse comes back catastrophic (worst root-child ERROR span covering at least half the file), blank the net-brace-unbalanced LEAF conditional branches (space-filled, so every byte offset and line number of surviving code is preserved) and re-parse; the retry is kept only when it strictly shrinks the worst ERROR span. Leaf-only scoping keeps an include guard (whose region legitimately holds unbalanced fragments between nested directives) untouched. Wired at the three tree-sitter parse sites (batch pre-parse, ast cache, definition processor).

Brace counting is textual (a brace inside a comment or string counts); a false trigger can only blank a branch of a file that already parses as one ERROR, and the strict-improvement guard discards a bad retry, so the result is never worse than the status quo.

## Measurements

nlohmann `include/nlohmann`: 330 -> 325, with the binary_reader cluster now structurally correct (the five recovered methods and their edges exist; the cluster remains dead as a correct cascade from the uncalled public API). fmt: 647 -> 647, byte-identical findings (regression guard). Known one-node artifact documented in the test: the real file still registers a phantom `decltype` method from a `const decltype(MACRO_) field = MACRO_;` inside a locally-unparseable macro region; the test pins that the simple form parses correctly.

## Testing

RED first: reduced 204-line repro committed failing (the collapse needs an explicit-template-argument call plus parse mass after the unbalanced branch; the minimal pattern alone recovers). Assertions: class membership preserved, no free-function twins, call edges across the recovered region. Full suite 4825 passed, 10 skipped. ruff clean, ty at the main baseline.
