### PR TITLE
fix(deadcode): strip the duplicate-qn marker before name-scoped root rules

### DIFF
--- a/codebase_rag/dead_code.py
+++ b/codebase_rag/dead_code.py
@@ -203,6 +203,11 @@ def dead_code_from_graph(
         if qn in roots:
             continue
         props = props_by_qn[qn]
+        # (H) The duplicate-qn marker (`init@51`, a SECOND Go init() in one
+        # (H) file) is a registration artifact, never part of the written
+        # (H) name; strip it so every name-scoped root rule sees the real leaf
+        # (H) (kubernetes pkg.apis.abac register.init@51 reported dead).
+        leaf = qn.rsplit(cs.SEPARATOR_DOT, 1)[-1].split(cs.DUP_QN_MARKER, 1)[0]
         if _has_root_decorator(props, config.root_decorators):
             roots.add(qn)
         elif props.get(cs.KEY_IS_EXPORTED) is True:
@@ -216,7 +221,7 @@ def dead_code_from_graph(
             roots.add(qn)
         elif (
             qn in method_qns
-            and _is_dunder(qn.rsplit(cs.SEPARATOR_DOT, 1)[-1])
+            and _is_dunder(leaf)
             and str(props.get(cs.KEY_PATH, "")).endswith(cs.EXT_PY)
         ):
             roots.add(qn)
@@ -225,28 +230,24 @@ def dead_code_from_graph(
         # (H) dead code (django's TextChoices._generate_next_value_).
         elif (
             qn in method_qns
-            and qn.rsplit(cs.SEPARATOR_DOT, 1)[-1] in cs.PY_ENUM_HOOK_METHOD_NAMES
+            and leaf in cs.PY_ENUM_HOOK_METHOD_NAMES
             and str(props.get(cs.KEY_PATH, "")).endswith(cs.EXT_PY)
         ):
             roots.add(qn)
         elif (
             qn not in method_qns
-            and qn.rsplit(cs.SEPARATOR_DOT, 1)[-1] in cs.GO_ROOT_FUNCTION_NAMES
+            and leaf in cs.GO_ROOT_FUNCTION_NAMES
             and str(props.get(cs.KEY_PATH, "")).endswith(cs.EXT_GO)
         ):
             roots.add(qn)
         elif _is_rust_runtime_root(
-            qn.rsplit(cs.SEPARATOR_DOT, 1)[-1],
-            qn in method_qns,
-            str(props.get(cs.KEY_PATH, "")),
+            leaf, qn in method_qns, str(props.get(cs.KEY_PATH, ""))
         ):
             roots.add(qn)
-        elif _is_cpp_operator_root(
-            qn.rsplit(cs.SEPARATOR_DOT, 1)[-1], str(props.get(cs.KEY_PATH, ""))
-        ):
+        elif _is_cpp_operator_root(leaf, str(props.get(cs.KEY_PATH, ""))):
             roots.add(qn)
         elif _is_java_serialization_root(
-            qn.rsplit(cs.SEPARATOR_DOT, 1)[-1].split(cs.CHAR_PAREN_OPEN, 1)[0],
+            leaf.split(cs.CHAR_PAREN_OPEN, 1)[0],
             qn in method_qns,
             str(props.get(cs.KEY_PATH, "")),
         ):

--- a/codebase_rag/tests/test_dead_code_eval.py
+++ b/codebase_rag/tests/test_dead_code_eval.py
@@ -1115,3 +1115,31 @@ def test_property_family_decorated_methods_are_roots() -> None:
     ]
     dead = dead_code_from_graph(nodes, rels, _PREFIX, config)
     assert dead == {"proj.m.Options.undecorated", "proj.m.Options.custom"}
+
+
+def test_duplicate_variant_leaf_still_matches_name_roots() -> None:
+    # (H) Go allows several init() in ONE file; the duplicate-qn machinery
+    # (H) renames the second to `init@51`, whose leaf failed the name-based
+    # (H) root checks and reported the runtime-invoked initializer dead
+    # (H) (kubernetes pkg.apis.abac register.init@51). The marker suffix is a
+    # (H) registration artifact, never part of the written name -- strip it
+    # (H) before every name-scoped root rule.
+    nodes = dict(
+        [
+            (
+                (_MODULE, "proj.register"),
+                {cs.KEY_QUALIFIED_NAME: "proj.register", cs.KEY_PATH: "register.go"},
+            ),
+            _fn("proj.register.init", path="register.go"),
+            _fn("proj.register.init@51", path="register.go"),
+            _fn("proj.register.helper@60", path="register.go"),
+            _method("proj.frame.Frame.fmt@12", "frame.rs"),
+        ]
+    )
+    dead = dead_code_from_graph(nodes, [], _PREFIX, _CONFIG)
+    assert "proj.register.init" not in dead
+    assert "proj.register.init@51" not in dead
+    assert "proj.frame.Frame.fmt@12" not in dead
+    # (H) a non-root name keeps its variant dead -- stripping the marker must
+    # (H) not accidentally widen any rule
+    assert "proj.register.helper@60" in dead

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.293"
+version = "0.0.297"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Problem

Go allows several `init()` functions in ONE file. The duplicate-qn machinery renames the second to `init@51`, and every name-scoped dead-code root rule compared the raw leaf, so the runtime-invoked initializer failed the `GO_ROOT_FUNCTION_NAMES` check and reported dead. First giant-scale dogfood (kubernetes, 139k nodes) surfaced three: `pkg.apis.abac.v0.register.init@51`, `pkg.apis.abac.v1beta1.register.init@51`, `apiserver tracing.init@58`.

## Fix

`dead_code_from_graph` computes the leaf once per candidate with the duplicate-qn marker stripped; every name-scoped rule (dunders, enum hooks, Go init/main, Rust main/trait methods, C++ operators, Java serialization hooks) now sees the real written name. The marker is a registration artifact, never part of the source name. Engine-only: existing graphs get the fix without a re-sync.

## Testing

RED first: variants of `init` and a Rust trait method must stay roots, while a non-root name keeps its variant dead (the strip must not widen any rule). Full suite 4824 passed, 10 skipped. ruff clean, ty at the main baseline.
