### PR TITLE
test(cpp): pin module attribution for macros used only in evaluated directives

### DIFF
--- a/codebase_rag/tests/test_cpp_frontend_hybrid.py
+++ b/codebase_rag/tests/test_cpp_frontend_hybrid.py
@@ -361,3 +361,43 @@ def test_run_hybrid_emits_only_macros_and_returns_pending_calls(
     assert "hybunit.calc.h.SQUARE" in pending_callees, pending
     assert "hybunit.calc.h.MAX_SIZE" in pending_callees, pending
     assert all(p.rel_path == "calc.cpp" for p in pending), pending
+
+
+# (H) A config macro consumed ONLY by preprocessor conditionals (fmt's
+# (H) FMT_USE_FULL_CACHE_DRAGONBOX shape): libclang reports a
+# (H) MACRO_INSTANTIATION for every EVALUATED directive condition (#if X,
+# (H) #ifdef X, #if defined(X), a reached #elif), and the use sits outside
+# (H) every definition span, so it must attribute to the Module and keep the
+# (H) macro reachable. A condition in a SKIPPED branch is never evaluated and
+# (H) carries no edge -- the graph mirrors the build configuration.
+_FLAGS_SRC = """\
+#define USE_CACHE 1
+#define HAS_MODE 2
+int base = 1;
+#if USE_CACHE
+int cache = 1;
+#endif
+#ifdef HAS_MODE
+int mode = 1;
+#endif
+int main() { return base; }
+"""
+
+
+def _write_flags(root: Path) -> None:
+    root.mkdir()
+    (root / "conf.cpp").write_text(_FLAGS_SRC, encoding="utf-8")
+    (root / "compile_commands.json").write_text(
+        json.dumps([_compdb_entry(root, root / "conf.cpp")]), encoding="utf-8"
+    )
+
+
+def test_hybrid_directive_only_macro_use_attributes_to_module(
+    temp_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = temp_repo / "hybdirective"
+    _write_flags(root)
+    ingestor = _run_hybrid(root, monkeypatch)
+    calls = _calls(ingestor)
+    assert ("hybdirective.conf", "hybdirective.conf.USE_CACHE") in calls, sorted(calls)
+    assert ("hybdirective.conf", "hybdirective.conf.HAS_MODE") in calls, sorted(calls)

--- a/codebase_rag/tests/test_cpp_frontend_hybrid.py
+++ b/codebase_rag/tests/test_cpp_frontend_hybrid.py
@@ -373,12 +373,18 @@ def test_run_hybrid_emits_only_macros_and_returns_pending_calls(
 _FLAGS_SRC = """\
 #define USE_CACHE 1
 #define HAS_MODE 2
+#define SKIPPED_FLAG 3
 int base = 1;
 #if USE_CACHE
 int cache = 1;
 #endif
 #ifdef HAS_MODE
 int mode = 1;
+#endif
+#if 0
+#if SKIPPED_FLAG
+int never = 1;
+#endif
 #endif
 int main() { return base; }
 """
@@ -401,3 +407,7 @@ def test_hybrid_directive_only_macro_use_attributes_to_module(
     calls = _calls(ingestor)
     assert ("hybdirective.conf", "hybdirective.conf.USE_CACHE") in calls, sorted(calls)
     assert ("hybdirective.conf", "hybdirective.conf.HAS_MODE") in calls, sorted(calls)
+    # (H) a condition inside a SKIPPED branch (#if 0) is never evaluated, so
+    # (H) it is never tokenized and carries no edge -- the graph mirrors the
+    # (H) build configuration
+    assert not any(t.endswith(".SKIPPED_FLAG") for _, t in calls), sorted(calls)

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.293"
+version = "0.0.297"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Test-only. Pins that a config macro consumed ONLY by preprocessor conditionals (`#if X`, `#ifdef X`) keeps a Module-attributed CALLS edge in hybrid mode and stays reachable.

Investigation background: the B1 benchmark notes hypothesized a "directive references are not MACRO_INSTANTIATION" false-positive class. Empirical probing refuted that: libclang with `PARSE_DETAILED_PROCESSING_RECORD` reports a MACRO_INSTANTIATION (with `.referenced` resolved) for every EVALUATED directive condition, including reached `#elif`s; only conditions in skipped branches are silent, so the graph mirrors the build configuration. The hybrid pipeline already turns these into Module-attributed CALLS. All 38 fmt hybrid-vs-treesitter macro deltas were re-verified as correct reports (cascade from dead enclosing code, test-only chains, public-API consumer macros, one config-skipped `#elif`). Nothing needed fixing; this test locks the property so a regression cannot silently recreate the class.
