### PR TITLE
feat(flow): add opt-in FLOWS_TO data-flow edges for intra-procedural taint

### DIFF
--- a/README.md
+++ b/README.md
@@ -771,6 +771,7 @@ The knowledge graph uses the following node types and relationships:
 | Module, Function, Method | INSTANTIATES | Class |
 | Module, Function, Method | READS_FROM | Resource |
 | Module, Function, Method | WRITES_TO | Resource |
+| Module, Function, Method, Resource | FLOWS_TO | Module, Function, Method, Resource |
 <!-- /SECTION:relationship_schemas -->
 
 ## 🔧 Configuration

--- a/README.md
+++ b/README.md
@@ -715,13 +715,13 @@ The knowledge graph uses the following node types and relationships:
 | Folder | `{path: string, name: string, absolute_path: string}` |
 | File | `{path: string, name: string, extension: string?, absolute_path: string}` |
 | Module | `{qualified_name: string, name: string, path: string, absolute_path: string, start_line: int?, end_line: int?}` |
-| Class | `{qualified_name: string, name: string, decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
-| Function | `{qualified_name: string, name: string, decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?, is_macro: boolean?}` |
-| Method | `{qualified_name: string, name: string, decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?, is_property: boolean?, overrides_external: boolean?}` |
-| Interface | `{qualified_name: string, name: string, path: string, absolute_path: string, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
-| Enum | `{qualified_name: string, name: string, path: string, absolute_path: string, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
-| Type | `{qualified_name: string, name: string, path: string?, absolute_path: string?, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
-| Union | `{qualified_name: string, name: string, path: string?, absolute_path: string?, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
+| Class | `{qualified_name: string, name: string, modifiers: list[string], decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
+| Function | `{qualified_name: string, name: string, modifiers: list[string], decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?, is_macro: boolean?}` |
+| Method | `{qualified_name: string, name: string, modifiers: list[string], decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?, is_property: boolean?, overrides_external: boolean?}` |
+| Interface | `{qualified_name: string, name: string, path: string, absolute_path: string, modifiers: list[string]?, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
+| Enum | `{qualified_name: string, name: string, path: string, absolute_path: string, modifiers: list[string]?, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
+| Type | `{qualified_name: string, name: string, path: string?, absolute_path: string?, modifiers: list[string]?, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
+| Union | `{qualified_name: string, name: string, path: string?, absolute_path: string?, modifiers: list[string]?, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
 | ModuleInterface | `{qualified_name: string, name: string, path: string, absolute_path: string, module_type: string}` |
 | ModuleImplementation | `{qualified_name: string, name: string, path: string, absolute_path: string, implements_module: string, module_type: string}` |
 | ExternalPackage | `{name: string}` |

--- a/codebase_rag/constants/graph.py
+++ b/codebase_rag/constants/graph.py
@@ -147,6 +147,7 @@ class RelationshipType(StrEnum):
     DEPENDS_ON_EXTERNAL = "DEPENDS_ON_EXTERNAL"
     READS_FROM = "READS_FROM"
     WRITES_TO = "WRITES_TO"
+    FLOWS_TO = "FLOWS_TO"
 
 
 class CaptureGroup(StrEnum):
@@ -198,6 +199,7 @@ CAPTURE_GROUP_RELS: dict[CaptureGroup, frozenset[RelationshipType]] = {
         {
             RelationshipType.READS_FROM,
             RelationshipType.WRITES_TO,
+            RelationshipType.FLOWS_TO,
         }
     ),
 }

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -25,6 +25,7 @@ from ..utils.path_utils import cached_relative_path
 from .call_resolver import CallResolver
 from .class_ingest.identity import build_nested_qualified_name_for_class
 from .cpp import utils as cpp_utils
+from .flow_access import FlowProcessor
 from .go import utils as go_utils
 from .import_processor import ImportProcessor
 from .io_access import IOAccessProcessor
@@ -199,6 +200,7 @@ class CallProcessor:
         "_returned_callables",
         "_factory_calls",
         "_io_processor",
+        "_flow_processor",
     )
 
     def __init__(
@@ -245,10 +247,17 @@ class CallProcessor:
         # (H) fixpoint in finalize, so factory and call site may be in any file order.
         self._returned_callables: dict[str, set[str]] = {}
         self._factory_calls: list[_FactoryCall] = []
+        selection = capture if capture is not None else ALL_ENABLED
         self._io_processor = IOAccessProcessor(
             ingestor,
             import_processor,
-            selection=capture if capture is not None else ALL_ENABLED,
+            selection=selection,
+        )
+        self._flow_processor = FlowProcessor(
+            ingestor,
+            import_processor,
+            self._resolver,
+            selection=selection,
         )
 
     def _get_node_name(self, node: Node, field: str = cs.FIELD_NAME) -> str | None:
@@ -1558,6 +1567,9 @@ class CallProcessor:
 
         self._io_processor.process_io_for_caller(
             caller_node, caller_spec, module_qn, language
+        )
+        self._flow_processor.process_flow_for_caller(
+            caller_node, caller_spec, caller_qn, module_qn, language, class_context
         )
 
         caller_params: frozenset[str] = frozenset()

--- a/codebase_rag/parsers/flow_access/__init__.py
+++ b/codebase_rag/parsers/flow_access/__init__.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from .constants import FlowKind
+from .processor import FlowProcessor
+
+__all__ = [
+    "FlowKind",
+    "FlowProcessor",
+]

--- a/codebase_rag/parsers/flow_access/constants.py
+++ b/codebase_rag/parsers/flow_access/constants.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class FlowKind(StrEnum):
+    ARG = "arg"
+    RETURN = "return"
+    RESOURCE = "resource"
+
+
+KEY_VIA = "via"
+KEY_KIND = "kind"
+
+VIA_ARG_FORMAT = "arg:{index}"
+VIA_KW_FORMAT = "kw:{name}"
+VIA_RETURN = "return"

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -70,11 +70,13 @@ class FlowProcessor:
         self._resolver = resolver
         self._selection = selection
         self._enabled = selection.rel_enabled(cs.RelationshipType.FLOWS_TO)
-        # (H) QNs whose body returns a tainted value; consulted for return-flow.
+        # (H) QN -> the source binding its body returns (None when the source is
+        # (H) itself unknown, e.g. a chained return). Consulted for return-flow so a
+        # (H) returned value keeps its origin resource through the call boundary.
         # (H) ponytail: single-pass and source-order dependent (a callee defined
         # (H) after its caller is missed), exactly like CallProcessor._returned_callables;
         # (H) a finalize/fixpoint pass is the upgrade if cross-file recall matters.
-        self._returns_taint: set[str] = set()
+        self._returns_taint: dict[str, HandleBinding | None] = {}
 
     def process_flow_for_caller(
         self,
@@ -116,6 +118,7 @@ class FlowProcessor:
         # (H) if branch precision ever matters.
         tainted: dict[str, HandleBinding | None] = {}
         body_returns_taint = False
+        body_return_source: HandleBinding | None = None
         stack = list(reversed(caller_node.children))
         while stack:
             node = stack.pop()
@@ -126,13 +129,15 @@ class FlowProcessor:
                 self._apply_assignment(node, tainted, ctx)
             elif node_type == cs.TS_PY_CALL:
                 self._apply_call(node, tainted, ctx)
-            elif node_type == cs.TS_PY_RETURN_STATEMENT:
-                if self._return_is_tainted(node, tainted, ctx):
+            elif node_type == cs.TS_PY_RETURN_STATEMENT and not body_returns_taint:
+                is_tainted, source = self._return_taint_source(node, tainted, ctx)
+                if is_tainted:
                     body_returns_taint = True
+                    body_return_source = source
             stack.extend(reversed(node.children))
 
         if body_returns_taint:
-            self._returns_taint.add(caller_qn)
+            self._returns_taint[caller_qn] = body_return_source
 
     def _apply_assignment(
         self, node: Node, tainted: dict[str, HandleBinding | None], ctx: _FlowCtx
@@ -162,7 +167,7 @@ class FlowProcessor:
                 raw, ctx.module_qn, ctx.class_context, ctx.caller_qn, ctx.language
             )
             if callee is not None and callee[1] in self._returns_taint:
-                tainted[lhs] = None
+                tainted[lhs] = self._returns_taint[callee[1]]
                 self._emit_return_edge(callee, ctx.caller_spec)
                 return
         # (H) Any other RHS (literal, expression, untainted call) leaves lhs clean.
@@ -202,17 +207,27 @@ class FlowProcessor:
                 properties={KEY_VIA: via, KEY_KIND: FlowKind.ARG.value},
             )
 
-    def _return_is_tainted(
+    def _return_taint_source(
         self, node: Node, tainted: dict[str, HandleBinding | None], ctx: _FlowCtx
-    ) -> bool:
+    ) -> tuple[bool, HandleBinding | None]:
+        # (H) Whether this return yields a tainted value and, if so, its origin
+        # (H) resource binding (None when the origin is itself unknown).
         for child in node.named_children:
             if child.type == cs.TS_PY_IDENTIFIER and child.text is not None:
-                if child.text.decode(cs.ENCODING_UTF8) in tainted:
-                    return True
+                name = child.text.decode(cs.ENCODING_UTF8)
+                if name in tainted:
+                    return True, tainted[name]
             elif child.type == cs.TS_PY_CALL and (raw := call_name(child)) is not None:
-                if self._source_binding(child, raw, ctx.import_map, ctx.read_sinks):
-                    return True
-        return False
+                if seed := self._source_binding(
+                    child, raw, ctx.import_map, ctx.read_sinks
+                ):
+                    return True, seed
+                callee = self._resolve(
+                    raw, ctx.module_qn, ctx.class_context, ctx.caller_qn, ctx.language
+                )
+                if callee is not None and callee[1] in self._returns_taint:
+                    return True, self._returns_taint[callee[1]]
+        return False, None
 
     def _emit_return_edge(
         self, callee: tuple[str, str], caller_spec: tuple[str, str, str]

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import NamedTuple
+
 from tree_sitter import Node
 
 from ... import constants as cs
@@ -37,11 +39,17 @@ _SCOPE_BOUNDARIES = (
     cs.TS_PY_DECORATED_DEFINITION,
 )
 
-# (H) One collected assignment `lhs = <call>` whose callee is not a read source;
-# (H) resolved later against _returns_taint for return-flow.
-_CallAssign = tuple[str, Node, str]
-# (H) One collected call site as (node, raw callee name).
-_CallSite = tuple[Node, str]
+
+class _FlowCtx(NamedTuple):
+    # (H) Per-caller constants threaded through the source-ordered walk.
+    caller_spec: tuple[str, str, str]
+    caller_qn: str
+    module_qn: str
+    class_context: str | None
+    language: cs.SupportedLanguage
+    import_map: dict[str, str]
+    read_sinks: dict[str, IOSink]
+    write_sinks: dict[str, IOSink]
 
 
 class FlowProcessor:
@@ -86,90 +94,48 @@ class FlowProcessor:
         sinks = IO_SINKS.get(language, ())
         if not sinks:
             return
-        import_map = self._import_processor.import_mapping.get(module_qn, {})
-        read_sinks = {s.callee: s for s in sinks if s.direction == IODirection.READ}
-        write_sinks = {s.callee: s for s in sinks if s.direction == IODirection.WRITE}
+        ctx = _FlowCtx(
+            caller_spec=caller_spec,
+            caller_qn=caller_qn,
+            module_qn=module_qn,
+            class_context=class_context,
+            language=language,
+            import_map=self._import_processor.import_mapping.get(module_qn, {}),
+            read_sinks={s.callee: s for s in sinks if s.direction == IODirection.READ},
+            write_sinks={
+                s.callee: s for s in sinks if s.direction == IODirection.WRITE
+            },
+        )
 
-        plain_assigns: list[tuple[str, str]] = []
-        source_seeds: dict[str, HandleBinding] = {}
-        call_assigns: list[_CallAssign] = []
-        all_calls: list[_CallSite] = []
-        returned_names: list[str] = []
-        returned_source = False
-
-        stack = list(caller_node.children)
+        # (H) Source-ordered pre-order walk with a live taint map: push children
+        # (H) reversed so the leftmost is visited first, giving straight-line
+        # (H) statement order. Each assignment retaints or KILLS its target, so a
+        # (H) later overwrite with an untainted value removes stale taint (no
+        # (H) monotonic false positive). ponytail: not path-sensitive; a KILL on one
+        # (H) branch of an if/else drops taint conservatively -- add a CFG pass only
+        # (H) if branch precision ever matters.
+        tainted: dict[str, HandleBinding | None] = {}
+        body_returns_taint = False
+        stack = list(reversed(caller_node.children))
         while stack:
             node = stack.pop()
             node_type = node.type
             if node_type in _SCOPE_BOUNDARIES:
                 continue
-            stack.extend(node.children)
             if node_type == cs.TS_PY_ASSIGNMENT:
-                self._collect_assignment(
-                    node,
-                    import_map,
-                    read_sinks,
-                    plain_assigns,
-                    source_seeds,
-                    call_assigns,
-                )
+                self._apply_assignment(node, tainted, ctx)
             elif node_type == cs.TS_PY_CALL:
-                if (raw := call_name(node)) is not None:
-                    all_calls.append((node, raw))
+                self._apply_call(node, tainted, ctx)
             elif node_type == cs.TS_PY_RETURN_STATEMENT:
-                returned_source = (
-                    self._collect_return(node, import_map, read_sinks, returned_names)
-                    or returned_source
-                )
+                if self._return_is_tainted(node, tainted, ctx):
+                    body_returns_taint = True
+            stack.extend(reversed(node.children))
 
-        tainted: dict[str, HandleBinding | None] = dict(source_seeds)
-        return_edges: list[tuple[str, str]] = []
-        for lhs, _node, raw in call_assigns:
-            callee = self._resolve(raw, module_qn, class_context, caller_qn, language)
-            if callee is not None and callee[1] in self._returns_taint:
-                tainted.setdefault(lhs, None)
-                return_edges.append(callee)
-
-        # (H) ponytail: order-insensitive worklist to a fixpoint; a var read before its
-        # (H) assignment is over-tainted. Bodies are small; add source-order/CFG
-        # (H) sensitivity only if false positives from that ever show up.
-        changed = True
-        while changed:
-            changed = False
-            for lhs, rhs in plain_assigns:
-                if rhs in tainted and lhs not in tainted:
-                    tainted[lhs] = tainted[rhs]
-                    changed = True
-
-        self._emit_resource_flows(all_calls, write_sinks, import_map, tainted)
-        self._emit_arg_flows(
-            all_calls,
-            caller_spec,
-            tainted,
-            module_qn,
-            class_context,
-            caller_qn,
-            language,
-        )
-        for callee_type, callee_qn in return_edges:
-            self.ingestor.ensure_relationship_batch(
-                (callee_type, cs.KEY_QUALIFIED_NAME, callee_qn),
-                cs.RelationshipType.FLOWS_TO,
-                caller_spec,
-                properties={KEY_VIA: VIA_RETURN, KEY_KIND: FlowKind.RETURN.value},
-            )
-
-        if returned_source or any(name in tainted for name in returned_names):
+        if body_returns_taint:
             self._returns_taint.add(caller_qn)
 
-    def _collect_assignment(
-        self,
-        node: Node,
-        import_map: dict[str, str],
-        read_sinks: dict[str, IOSink],
-        plain_assigns: list[tuple[str, str]],
-        source_seeds: dict[str, HandleBinding],
-        call_assigns: list[_CallAssign],
+    def _apply_assignment(
+        self, node: Node, tainted: dict[str, HandleBinding | None], ctx: _FlowCtx
     ) -> None:
         left = node.child_by_field_name(cs.TS_FIELD_LEFT)
         right = node.child_by_field_name(cs.TS_FIELD_RIGHT)
@@ -182,12 +148,82 @@ class FlowProcessor:
             return
         lhs = left.text.decode(cs.ENCODING_UTF8)
         if right.type == cs.TS_PY_IDENTIFIER and right.text is not None:
-            plain_assigns.append((lhs, right.text.decode(cs.ENCODING_UTF8)))
-        elif right.type == cs.TS_PY_CALL and (raw := call_name(right)) is not None:
-            if seed := self._source_binding(right, raw, import_map, read_sinks):
-                source_seeds[lhs] = seed
+            rhs = right.text.decode(cs.ENCODING_UTF8)
+            if rhs in tainted:
+                tainted[lhs] = tainted[rhs]
             else:
-                call_assigns.append((lhs, right, raw))
+                tainted.pop(lhs, None)
+            return
+        if right.type == cs.TS_PY_CALL and (raw := call_name(right)) is not None:
+            if seed := self._source_binding(right, raw, ctx.import_map, ctx.read_sinks):
+                tainted[lhs] = seed
+                return
+            callee = self._resolve(
+                raw, ctx.module_qn, ctx.class_context, ctx.caller_qn, ctx.language
+            )
+            if callee is not None and callee[1] in self._returns_taint:
+                tainted[lhs] = None
+                self._emit_return_edge(callee, ctx.caller_spec)
+                return
+        # (H) Any other RHS (literal, expression, untainted call) leaves lhs clean.
+        tainted.pop(lhs, None)
+
+    def _apply_call(
+        self, node: Node, tainted: dict[str, HandleBinding | None], ctx: _FlowCtx
+    ) -> None:
+        raw = call_name(node)
+        if raw is None:
+            return
+        arg_names = self._arg_names(node)
+        if not arg_names:
+            return
+        name = normalise(raw, ctx.import_map)
+        sink = ctx.write_sinks.get(name) if name else None
+        if sink is not None:
+            dst_identity = literal_target(node, sink.target_arg, sink.target_kw)
+            for arg_name, _via in arg_names:
+                if (source := tainted.get(arg_name)) is not None:
+                    self._emit_resource_flow(source, sink.kind, dst_identity)
+            return
+        vias = [via for arg_name, via in arg_names if arg_name in tainted]
+        if not vias:
+            return
+        callee = self._resolve(
+            raw, ctx.module_qn, ctx.class_context, ctx.caller_qn, ctx.language
+        )
+        if callee is None:
+            return
+        callee_type, callee_qn = callee
+        for via in vias:
+            self.ingestor.ensure_relationship_batch(
+                ctx.caller_spec,
+                cs.RelationshipType.FLOWS_TO,
+                (callee_type, cs.KEY_QUALIFIED_NAME, callee_qn),
+                properties={KEY_VIA: via, KEY_KIND: FlowKind.ARG.value},
+            )
+
+    def _return_is_tainted(
+        self, node: Node, tainted: dict[str, HandleBinding | None], ctx: _FlowCtx
+    ) -> bool:
+        for child in node.named_children:
+            if child.type == cs.TS_PY_IDENTIFIER and child.text is not None:
+                if child.text.decode(cs.ENCODING_UTF8) in tainted:
+                    return True
+            elif child.type == cs.TS_PY_CALL and (raw := call_name(child)) is not None:
+                if self._source_binding(child, raw, ctx.import_map, ctx.read_sinks):
+                    return True
+        return False
+
+    def _emit_return_edge(
+        self, callee: tuple[str, str], caller_spec: tuple[str, str, str]
+    ) -> None:
+        callee_type, callee_qn = callee
+        self.ingestor.ensure_relationship_batch(
+            (callee_type, cs.KEY_QUALIFIED_NAME, callee_qn),
+            cs.RelationshipType.FLOWS_TO,
+            caller_spec,
+            properties={KEY_VIA: VIA_RETURN, KEY_KIND: FlowKind.RETURN.value},
+        )
 
     @staticmethod
     def _source_binding(
@@ -202,39 +238,6 @@ class FlowProcessor:
             return None
         identity = literal_target(call_node, sink.target_arg, sink.target_kw)
         return HandleBinding(kind=sink.kind, identity=identity)
-
-    def _collect_return(
-        self,
-        node: Node,
-        import_map: dict[str, str],
-        read_sinks: dict[str, IOSink],
-        returned_names: list[str],
-    ) -> bool:
-        returned_source = False
-        for child in node.named_children:
-            if child.type == cs.TS_PY_IDENTIFIER and child.text is not None:
-                returned_names.append(child.text.decode(cs.ENCODING_UTF8))
-            elif child.type == cs.TS_PY_CALL and (raw := call_name(child)) is not None:
-                if self._source_binding(child, raw, import_map, read_sinks):
-                    returned_source = True
-        return returned_source
-
-    def _emit_resource_flows(
-        self,
-        all_calls: list[_CallSite],
-        write_sinks: dict[str, IOSink],
-        import_map: dict[str, str],
-        tainted: dict[str, HandleBinding | None],
-    ) -> None:
-        for node, raw in all_calls:
-            name = normalise(raw, import_map)
-            sink = write_sinks.get(name) if name else None
-            if sink is None:
-                continue
-            dst_identity = literal_target(node, sink.target_arg, sink.target_kw)
-            for arg_name, _via in self._arg_names(node):
-                if (source := tainted.get(arg_name)) is not None:
-                    self._emit_resource_flow(source, sink.kind, dst_identity)
 
     def _emit_resource_flow(
         self, source: HandleBinding, dst_kind: ResourceKind, dst_identity: str
@@ -259,32 +262,6 @@ class FlowProcessor:
             },
         )
         return qn
-
-    def _emit_arg_flows(
-        self,
-        all_calls: list[_CallSite],
-        caller_spec: tuple[str, str, str],
-        tainted: dict[str, HandleBinding | None],
-        module_qn: str,
-        class_context: str | None,
-        caller_qn: str,
-        language: cs.SupportedLanguage,
-    ) -> None:
-        for node, raw in all_calls:
-            vias = [via for name, via in self._arg_names(node) if name in tainted]
-            if not vias:
-                continue
-            callee = self._resolve(raw, module_qn, class_context, caller_qn, language)
-            if callee is None:
-                continue
-            callee_type, callee_qn = callee
-            for via in vias:
-                self.ingestor.ensure_relationship_batch(
-                    caller_spec,
-                    cs.RelationshipType.FLOWS_TO,
-                    (callee_type, cs.KEY_QUALIFIED_NAME, callee_qn),
-                    properties={KEY_VIA: via, KEY_KIND: FlowKind.ARG.value},
-                )
 
     def _resolve(
         self,

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -1,0 +1,339 @@
+from __future__ import annotations
+
+from tree_sitter import Node
+
+from ... import constants as cs
+from ...capture import CaptureSelection
+from ...services import IngestorProtocol
+from ..call_resolver import CallResolver
+from ..import_processor import ImportProcessor
+from ..io_access import (
+    IO_SINKS,
+    RESOURCE_QN_FORMAT,
+    HandleBinding,
+    IODirection,
+    IOSink,
+    ResourceKind,
+    call_name,
+    literal_target,
+    normalise,
+)
+from .constants import (
+    KEY_KIND,
+    KEY_VIA,
+    VIA_ARG_FORMAT,
+    VIA_KW_FORMAT,
+    VIA_RETURN,
+    FlowKind,
+)
+
+_BUILTIN_QN_PREFIX = f"{cs.BUILTIN_PREFIX}{cs.SEPARATOR_DOT}"
+
+# (H) Nested defs/classes are separate callers processed on their own; pruning them
+# (H) keeps a nested body's taint out of this caller's flow.
+_SCOPE_BOUNDARIES = (
+    cs.TS_PY_FUNCTION_DEFINITION,
+    cs.TS_PY_CLASS_DEFINITION,
+    cs.TS_PY_DECORATED_DEFINITION,
+)
+
+# (H) One collected assignment `lhs = <call>` whose callee is not a read source;
+# (H) resolved later against _returns_taint for return-flow.
+_CallAssign = tuple[str, Node, str]
+# (H) One collected call site as (node, raw callee name).
+_CallSite = tuple[Node, str]
+
+
+class FlowProcessor:
+    """Detects intra-procedural value flow in a function body and emits FLOWS_TO
+    edges: resource->resource (a read source reaches a write sink), caller->callee
+    (a tainted value is passed as an argument), and callee->caller (a callee whose
+    return value is tainted)."""
+
+    def __init__(
+        self,
+        ingestor: IngestorProtocol,
+        import_processor: ImportProcessor,
+        resolver: CallResolver,
+        selection: CaptureSelection,
+    ) -> None:
+        self.ingestor = ingestor
+        self._import_processor = import_processor
+        self._resolver = resolver
+        self._selection = selection
+        self._enabled = selection.rel_enabled(cs.RelationshipType.FLOWS_TO)
+        # (H) QNs whose body returns a tainted value; consulted for return-flow.
+        # (H) ponytail: single-pass and source-order dependent (a callee defined
+        # (H) after its caller is missed), exactly like CallProcessor._returned_callables;
+        # (H) a finalize/fixpoint pass is the upgrade if cross-file recall matters.
+        self._returns_taint: set[str] = set()
+
+    def process_flow_for_caller(
+        self,
+        caller_node: Node,
+        caller_spec: tuple[str, str, str],
+        caller_qn: str,
+        module_qn: str,
+        language: cs.SupportedLanguage,
+        class_context: str | None,
+    ) -> None:
+        if not self._enabled:
+            return
+        # (H) ponytail: Python-only in phase 1, mirroring io_access; other languages
+        # (H) need their own source/sink tables and node types first.
+        if language != cs.SupportedLanguage.PYTHON:
+            return
+        sinks = IO_SINKS.get(language, ())
+        if not sinks:
+            return
+        import_map = self._import_processor.import_mapping.get(module_qn, {})
+        read_sinks = {s.callee: s for s in sinks if s.direction == IODirection.READ}
+        write_sinks = {s.callee: s for s in sinks if s.direction == IODirection.WRITE}
+
+        plain_assigns: list[tuple[str, str]] = []
+        source_seeds: dict[str, HandleBinding] = {}
+        call_assigns: list[_CallAssign] = []
+        all_calls: list[_CallSite] = []
+        returned_names: list[str] = []
+        returned_source = False
+
+        stack = list(caller_node.children)
+        while stack:
+            node = stack.pop()
+            node_type = node.type
+            if node_type in _SCOPE_BOUNDARIES:
+                continue
+            stack.extend(node.children)
+            if node_type == cs.TS_PY_ASSIGNMENT:
+                self._collect_assignment(
+                    node,
+                    import_map,
+                    read_sinks,
+                    plain_assigns,
+                    source_seeds,
+                    call_assigns,
+                )
+            elif node_type == cs.TS_PY_CALL:
+                if (raw := call_name(node)) is not None:
+                    all_calls.append((node, raw))
+            elif node_type == cs.TS_PY_RETURN_STATEMENT:
+                returned_source = (
+                    self._collect_return(node, import_map, read_sinks, returned_names)
+                    or returned_source
+                )
+
+        tainted: dict[str, HandleBinding | None] = dict(source_seeds)
+        return_edges: list[tuple[str, str]] = []
+        for lhs, _node, raw in call_assigns:
+            callee = self._resolve(raw, module_qn, class_context, caller_qn, language)
+            if callee is not None and callee[1] in self._returns_taint:
+                tainted.setdefault(lhs, None)
+                return_edges.append(callee)
+
+        # (H) ponytail: order-insensitive worklist to a fixpoint; a var read before its
+        # (H) assignment is over-tainted. Bodies are small; add source-order/CFG
+        # (H) sensitivity only if false positives from that ever show up.
+        changed = True
+        while changed:
+            changed = False
+            for lhs, rhs in plain_assigns:
+                if rhs in tainted and lhs not in tainted:
+                    tainted[lhs] = tainted[rhs]
+                    changed = True
+
+        self._emit_resource_flows(all_calls, write_sinks, import_map, tainted)
+        self._emit_arg_flows(
+            all_calls,
+            caller_spec,
+            tainted,
+            module_qn,
+            class_context,
+            caller_qn,
+            language,
+        )
+        for callee_type, callee_qn in return_edges:
+            self.ingestor.ensure_relationship_batch(
+                (callee_type, cs.KEY_QUALIFIED_NAME, callee_qn),
+                cs.RelationshipType.FLOWS_TO,
+                caller_spec,
+                properties={KEY_VIA: VIA_RETURN, KEY_KIND: FlowKind.RETURN.value},
+            )
+
+        if returned_source or any(name in tainted for name in returned_names):
+            self._returns_taint.add(caller_qn)
+
+    def _collect_assignment(
+        self,
+        node: Node,
+        import_map: dict[str, str],
+        read_sinks: dict[str, IOSink],
+        plain_assigns: list[tuple[str, str]],
+        source_seeds: dict[str, HandleBinding],
+        call_assigns: list[_CallAssign],
+    ) -> None:
+        left = node.child_by_field_name(cs.TS_FIELD_LEFT)
+        right = node.child_by_field_name(cs.TS_FIELD_RIGHT)
+        if (
+            left is None
+            or right is None
+            or left.type != cs.TS_PY_IDENTIFIER
+            or left.text is None
+        ):
+            return
+        lhs = left.text.decode(cs.ENCODING_UTF8)
+        if right.type == cs.TS_PY_IDENTIFIER and right.text is not None:
+            plain_assigns.append((lhs, right.text.decode(cs.ENCODING_UTF8)))
+        elif right.type == cs.TS_PY_CALL and (raw := call_name(right)) is not None:
+            if seed := self._source_binding(right, raw, import_map, read_sinks):
+                source_seeds[lhs] = seed
+            else:
+                call_assigns.append((lhs, right, raw))
+
+    @staticmethod
+    def _source_binding(
+        call_node: Node,
+        raw_name: str,
+        import_map: dict[str, str],
+        read_sinks: dict[str, IOSink],
+    ) -> HandleBinding | None:
+        name = normalise(raw_name, import_map)
+        sink = read_sinks.get(name) if name else None
+        if sink is None:
+            return None
+        identity = literal_target(call_node, sink.target_arg, sink.target_kw)
+        return HandleBinding(kind=sink.kind, identity=identity)
+
+    def _collect_return(
+        self,
+        node: Node,
+        import_map: dict[str, str],
+        read_sinks: dict[str, IOSink],
+        returned_names: list[str],
+    ) -> bool:
+        returned_source = False
+        for child in node.named_children:
+            if child.type == cs.TS_PY_IDENTIFIER and child.text is not None:
+                returned_names.append(child.text.decode(cs.ENCODING_UTF8))
+            elif child.type == cs.TS_PY_CALL and (raw := call_name(child)) is not None:
+                if self._source_binding(child, raw, import_map, read_sinks):
+                    returned_source = True
+        return returned_source
+
+    def _emit_resource_flows(
+        self,
+        all_calls: list[_CallSite],
+        write_sinks: dict[str, IOSink],
+        import_map: dict[str, str],
+        tainted: dict[str, HandleBinding | None],
+    ) -> None:
+        for node, raw in all_calls:
+            name = normalise(raw, import_map)
+            sink = write_sinks.get(name) if name else None
+            if sink is None:
+                continue
+            dst_identity = literal_target(node, sink.target_arg, sink.target_kw)
+            for arg_name, _via in self._arg_names(node):
+                if (source := tainted.get(arg_name)) is not None:
+                    self._emit_resource_flow(source, sink.kind, dst_identity)
+
+    def _emit_resource_flow(
+        self, source: HandleBinding, dst_kind: ResourceKind, dst_identity: str
+    ) -> None:
+        src_qn = self._ensure_resource(source.kind, source.identity)
+        dst_qn = self._ensure_resource(dst_kind, dst_identity)
+        self.ingestor.ensure_relationship_batch(
+            (cs.NodeLabel.RESOURCE, cs.KEY_QUALIFIED_NAME, src_qn),
+            cs.RelationshipType.FLOWS_TO,
+            (cs.NodeLabel.RESOURCE, cs.KEY_QUALIFIED_NAME, dst_qn),
+            properties={KEY_KIND: FlowKind.RESOURCE.value},
+        )
+
+    def _ensure_resource(self, kind: ResourceKind, identity: str) -> str:
+        qn = RESOURCE_QN_FORMAT.format(kind=kind.value, identity=identity)
+        self.ingestor.ensure_node_batch(
+            cs.NodeLabel.RESOURCE,
+            {
+                cs.KEY_QUALIFIED_NAME: qn,
+                cs.KEY_NAME: identity,
+                KEY_KIND: kind.value,
+            },
+        )
+        return qn
+
+    def _emit_arg_flows(
+        self,
+        all_calls: list[_CallSite],
+        caller_spec: tuple[str, str, str],
+        tainted: dict[str, HandleBinding | None],
+        module_qn: str,
+        class_context: str | None,
+        caller_qn: str,
+        language: cs.SupportedLanguage,
+    ) -> None:
+        for node, raw in all_calls:
+            vias = [via for name, via in self._arg_names(node) if name in tainted]
+            if not vias:
+                continue
+            callee = self._resolve(raw, module_qn, class_context, caller_qn, language)
+            if callee is None:
+                continue
+            callee_type, callee_qn = callee
+            for via in vias:
+                self.ingestor.ensure_relationship_batch(
+                    caller_spec,
+                    cs.RelationshipType.FLOWS_TO,
+                    (callee_type, cs.KEY_QUALIFIED_NAME, callee_qn),
+                    properties={KEY_VIA: via, KEY_KIND: FlowKind.ARG.value},
+                )
+
+    def _resolve(
+        self,
+        raw_name: str,
+        module_qn: str,
+        class_context: str | None,
+        caller_qn: str,
+        language: cs.SupportedLanguage,
+    ) -> tuple[str, str] | None:
+        info = self._resolver.resolve_function_call(
+            raw_name, module_qn, None, class_context, caller_qn, language
+        )
+        if info is None or info[1].startswith(_BUILTIN_QN_PREFIX):
+            return None
+        return info
+
+    @staticmethod
+    def _arg_names(call_node: Node) -> list[tuple[str, str]]:
+        args = call_node.child_by_field_name(cs.TS_FIELD_ARGUMENTS)
+        if args is None:
+            return []
+        names: list[tuple[str, str]] = []
+        index = 0
+        for child in args.named_children:
+            if child.type == cs.TS_PY_KEYWORD_ARGUMENT:
+                key = child.child_by_field_name(cs.TS_FIELD_NAME)
+                value = child.child_by_field_name(cs.FIELD_VALUE)
+                if (
+                    key is not None
+                    and key.text is not None
+                    and value is not None
+                    and value.type == cs.TS_PY_IDENTIFIER
+                    and value.text is not None
+                ):
+                    names.append(
+                        (
+                            value.text.decode(cs.ENCODING_UTF8),
+                            VIA_KW_FORMAT.format(
+                                name=key.text.decode(cs.ENCODING_UTF8)
+                            ),
+                        )
+                    )
+                continue
+            if child.type == cs.TS_PY_IDENTIFIER and child.text is not None:
+                names.append(
+                    (
+                        child.text.decode(cs.ENCODING_UTF8),
+                        VIA_ARG_FORMAT.format(index=index),
+                    )
+                )
+            index += 1
+        return names

--- a/codebase_rag/parsers/io_access/__init__.py
+++ b/codebase_rag/parsers/io_access/__init__.py
@@ -1,18 +1,24 @@
 from __future__ import annotations
 
-from .constants import IODirection, ResourceKind
+from .constants import DYNAMIC_TARGET, RESOURCE_QN_FORMAT, IODirection, ResourceKind
+from .extract import call_name, literal_target, normalise
 from .models import HandleBinding, HandleConstructor, IOSink
 from .processor import IOAccessProcessor
 from .registry import IO_HANDLE_CONSTRUCTORS, IO_HANDLE_METHODS, IO_SINKS
 
 __all__ = [
+    "DYNAMIC_TARGET",
     "IO_HANDLE_CONSTRUCTORS",
     "IO_HANDLE_METHODS",
     "IO_SINKS",
+    "RESOURCE_QN_FORMAT",
     "HandleBinding",
     "HandleConstructor",
     "IOAccessProcessor",
     "IODirection",
     "IOSink",
     "ResourceKind",
+    "call_name",
+    "literal_target",
+    "normalise",
 ]

--- a/codebase_rag/parsers/io_access/extract.py
+++ b/codebase_rag/parsers/io_access/extract.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from tree_sitter import Node
+
+from ... import constants as cs
+from .constants import DYNAMIC_TARGET
+
+
+def call_name(call_node: Node) -> str | None:
+    fn = call_node.child_by_field_name(cs.TS_FIELD_FUNCTION)
+    if fn is None or fn.text is None:
+        return None
+    return fn.text.decode(cs.ENCODING_UTF8)
+
+
+def normalise(name: str | None, import_map: dict[str, str]) -> str | None:
+    if name is None:
+        return None
+    head, sep, rest = name.partition(cs.SEPARATOR_DOT)
+    base = import_map.get(head)
+    if base is None:
+        return name
+    return f"{base}{cs.SEPARATOR_DOT}{rest}" if rest else base
+
+
+def string_literal(arg: Node | None) -> str:
+    if arg is None or arg.type != cs.TS_PY_STRING:
+        return DYNAMIC_TARGET
+    for child in arg.named_children:
+        if child.type == cs.TS_PY_STRING_CONTENT and child.text is not None:
+            return child.text.decode(cs.ENCODING_UTF8)
+    return DYNAMIC_TARGET
+
+
+def keyword_value(args: Node, keyword: str) -> Node | None:
+    for child in args.named_children:
+        if child.type != cs.TS_PY_KEYWORD_ARGUMENT:
+            continue
+        name = child.child_by_field_name(cs.TS_FIELD_NAME)
+        if name is not None and name.text is not None:
+            if name.text.decode(cs.ENCODING_UTF8) == keyword:
+                return child.child_by_field_name(cs.FIELD_VALUE)
+    return None
+
+
+def literal_target(
+    call_node: Node, arg_index: int | None, arg_keyword: str | None = None
+) -> str:
+    if arg_index is None and arg_keyword is None:
+        return DYNAMIC_TARGET
+    args = call_node.child_by_field_name(cs.TS_FIELD_ARGUMENTS)
+    if args is None:
+        return DYNAMIC_TARGET
+    positional = [c for c in args.named_children if c.type != cs.TS_PY_KEYWORD_ARGUMENT]
+    if arg_index is not None and arg_index < len(positional):
+        return string_literal(positional[arg_index])
+    if arg_keyword is not None:
+        return string_literal(keyword_value(args, arg_keyword))
+    return DYNAMIC_TARGET

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -15,6 +15,7 @@ from .constants import (
     IODirection,
     ResourceKind,
 )
+from .extract import call_name, literal_target, normalise
 from .models import HandleBinding, HandleConstructor, IOSink
 from .registry import IO_HANDLE_CONSTRUCTORS, IO_HANDLE_METHODS, IO_SINKS
 
@@ -109,11 +110,11 @@ class IOAccessProcessor:
             or target.text is None
         ):
             return None
-        name = self._normalise(self._call_name(call), import_map)
+        name = normalise(call_name(call), import_map)
         ctor = ctor_by_name.get(name) if name else None
         if ctor is None:
             return None
-        identity = self._literal_target(call, ctor.target_arg, ctor.target_kw)
+        identity = literal_target(call, ctor.target_arg, ctor.target_kw)
         return target.text.decode(cs.ENCODING_UTF8), HandleBinding(
             kind=ctor.kind, identity=identity
         )
@@ -126,23 +127,23 @@ class IOAccessProcessor:
         sink_by_name: dict[str, IOSink],
         handles: dict[str, HandleBinding],
     ) -> None:
-        raw = self._call_name(node)
+        raw = call_name(node)
         if raw is None:
             return
         if self._emit_handle_method(node, caller_spec, raw, handles):
             return
-        normalised = self._normalise(raw, import_map)
+        normalised = normalise(raw, import_map)
         sink = sink_by_name.get(normalised) if normalised else None
         if sink is None:
             return
         mode = (
-            self._literal_target(node, sink.mode_arg, sink.mode_kw)
+            literal_target(node, sink.mode_arg, sink.mode_kw)
             if sink.mode_arg is not None or sink.mode_kw is not None
             else None
         )
         mode_literal = None if mode == DYNAMIC_TARGET else mode
         direction = sink.effective_direction(mode_literal)
-        identity = self._literal_target(node, sink.target_arg, sink.target_kw)
+        identity = literal_target(node, sink.target_arg, sink.target_kw)
         self._emit(caller_spec, direction, sink.kind, identity)
 
     def _emit_handle_method(
@@ -170,7 +171,7 @@ class IOAccessProcessor:
     def _sql_direction(self, call_node: Node, fallback: IODirection) -> IODirection:
         # (H) ponytail: first-keyword heuristic only; a full SQL parse is the
         # (H) upgrade path if execute() direction precision ever matters.
-        sql = self._literal_target(call_node, 0)
+        sql = literal_target(call_node, 0)
         if sql == DYNAMIC_TARGET:
             return fallback
         head = sql.strip().split(maxsplit=1)[0].upper() if sql.strip() else ""
@@ -216,60 +217,3 @@ class IOAccessProcessor:
                 cs.RelationshipType.WRITES_TO,
             )
         return (_DIRECTION_REL[direction],)
-
-    @staticmethod
-    def _call_name(call_node: Node) -> str | None:
-        fn = call_node.child_by_field_name(cs.TS_FIELD_FUNCTION)
-        if fn is None or fn.text is None:
-            return None
-        return fn.text.decode(cs.ENCODING_UTF8)
-
-    @staticmethod
-    def _normalise(name: str | None, import_map: dict[str, str]) -> str | None:
-        if name is None:
-            return None
-        head, sep, rest = name.partition(cs.SEPARATOR_DOT)
-        base = import_map.get(head)
-        if base is None:
-            return name
-        return f"{base}{cs.SEPARATOR_DOT}{rest}" if rest else base
-
-    @staticmethod
-    def _literal_target(
-        call_node: Node, arg_index: int | None, arg_keyword: str | None = None
-    ) -> str:
-        if arg_index is None and arg_keyword is None:
-            return DYNAMIC_TARGET
-        args = call_node.child_by_field_name(cs.TS_FIELD_ARGUMENTS)
-        if args is None:
-            return DYNAMIC_TARGET
-        positional = [
-            c for c in args.named_children if c.type != cs.TS_PY_KEYWORD_ARGUMENT
-        ]
-        if arg_index is not None and arg_index < len(positional):
-            return IOAccessProcessor._string_literal(positional[arg_index])
-        if arg_keyword is not None:
-            return IOAccessProcessor._string_literal(
-                IOAccessProcessor._keyword_value(args, arg_keyword)
-            )
-        return DYNAMIC_TARGET
-
-    @staticmethod
-    def _keyword_value(args: Node, keyword: str) -> Node | None:
-        for child in args.named_children:
-            if child.type != cs.TS_PY_KEYWORD_ARGUMENT:
-                continue
-            name = child.child_by_field_name(cs.TS_FIELD_NAME)
-            if name is not None and name.text is not None:
-                if name.text.decode(cs.ENCODING_UTF8) == keyword:
-                    return child.child_by_field_name(cs.FIELD_VALUE)
-        return None
-
-    @staticmethod
-    def _string_literal(arg: Node | None) -> str:
-        if arg is None or arg.type != cs.TS_PY_STRING:
-            return DYNAMIC_TARGET
-        for child in arg.named_children:
-            if child.type == cs.TS_PY_STRING_CONTENT and child.text is not None:
-                return child.text.decode(cs.ENCODING_UTF8)
-        return DYNAMIC_TARGET

--- a/codebase_rag/tests/test_capture_resolver.py
+++ b/codebase_rag/tests/test_capture_resolver.py
@@ -26,6 +26,11 @@ def test_io_is_opt_in() -> None:
     assert sel.rel_enabled(RT.CALLS)
 
 
+def test_flows_to_is_in_io_group_and_opt_in() -> None:
+    assert not resolve_capture([]).rel_enabled(RT.FLOWS_TO)
+    assert resolve_capture(["io"]).rel_enabled(RT.FLOWS_TO)
+
+
 def test_resource_node_gated_on_io() -> None:
     assert not resolve_capture([]).node_enabled(NL.RESOURCE)
     assert resolve_capture(["io"]).node_enabled(NL.RESOURCE)

--- a/codebase_rag/tests/test_flow_edges.py
+++ b/codebase_rag/tests/test_flow_edges.py
@@ -113,6 +113,25 @@ def test_return_value_flows_from_callee_to_caller(tmp_path: Path) -> None:
     assert _has(edges, "m.build", "m.caller", via="return", kind=FlowKind.RETURN.value)
 
 
+def test_return_taint_reaches_resource_sink(tmp_path: Path) -> None:
+    # (H) A value returned from a tainted callee carries its source resource, so a
+    # (H) later sink emits the full resource->resource flow, not just the return edge.
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "def build():\n    return os.getenv('K')\n\n"
+            "def caller():\n    v = build()\n    print(v)\n"
+        )
+    }
+    edges = _run_flow(tmp_path, files)
+    assert _has(
+        edges,
+        "resource::ENV::K",
+        "resource::STDOUT::<dynamic>",
+        kind=FlowKind.RESOURCE.value,
+    )
+
+
 def test_taint_propagates_through_plain_assignment(tmp_path: Path) -> None:
     files = {
         "m.py": (

--- a/codebase_rag/tests/test_flow_edges.py
+++ b/codebase_rag/tests/test_flow_edges.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.capture import CaptureSelection, resolve_capture
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.parsers.flow_access import FlowKind
+
+FLOWS_TO = cs.RelationshipType.FLOWS_TO.value
+_CAPTURE_IO = resolve_capture([cs.CaptureGroup.IO.value])
+
+# (H) One FLOWS_TO edge as (from_qn, to_qn, properties).
+FlowEdge = tuple[str, str, dict[str, str]]
+
+
+def _run_flow(
+    tmp_path: Path,
+    files: dict[str, str],
+    capture: CaptureSelection = _CAPTURE_IO,
+) -> list[FlowEdge]:
+    parsers, queries = load_parsers()
+    if "python" not in parsers:
+        pytest.skip("python parser not available")
+    for rel, content in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        capture=capture,
+    ).run()
+    edges: list[FlowEdge] = []
+    for c in mock.ensure_relationship_batch.call_args_list:
+        if str(c.args[1]) != FLOWS_TO:
+            continue
+        props = c.kwargs.get("properties")
+        if props is None and len(c.args) > 3:
+            props = c.args[3]
+        edges.append((c.args[0][2], c.args[2][2], dict(props or {})))
+    return edges
+
+
+def _node_qns(mock: MagicMock) -> set[str]:
+    return {
+        c.args[1].get(cs.KEY_QUALIFIED_NAME)
+        for c in mock.ensure_node_batch.call_args_list
+        if len(c.args) >= 2
+    }
+
+
+def _has(edges: list[FlowEdge], frm: str, to: str, **props: str) -> bool:
+    return any(
+        a.endswith(frm)
+        and b.endswith(to)
+        and all(p.get(k) == v for k, v in props.items())
+        for a, b, p in edges
+    )
+
+
+def test_resource_to_resource_env_to_stdout(tmp_path: Path) -> None:
+    files = {"m.py": "import os\n\ndef leak():\n    x = os.getenv('K')\n    print(x)\n"}
+    edges = _run_flow(tmp_path, files)
+    assert _has(
+        edges,
+        "resource::ENV::K",
+        "resource::STDOUT::<dynamic>",
+        kind=FlowKind.RESOURCE.value,
+    )
+
+
+def test_tainted_positional_arg_flows_to_callee(tmp_path: Path) -> None:
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "def helper(v):\n    pass\n\n"
+            "def caller():\n    t = os.getenv('K')\n    helper(t)\n"
+        )
+    }
+    edges = _run_flow(tmp_path, files)
+    assert _has(edges, "m.caller", "m.helper", via="arg:0", kind=FlowKind.ARG.value)
+
+
+def test_tainted_keyword_arg_flows_to_callee(tmp_path: Path) -> None:
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "def helper(v):\n    pass\n\n"
+            "def caller():\n    t = os.getenv('K')\n    helper(v=t)\n"
+        )
+    }
+    edges = _run_flow(tmp_path, files)
+    assert _has(edges, "m.caller", "m.helper", via="kw:v", kind=FlowKind.ARG.value)
+
+
+def test_return_value_flows_from_callee_to_caller(tmp_path: Path) -> None:
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "def build():\n    return os.getenv('K')\n\n"
+            "def caller():\n    v = build()\n    print(v)\n"
+        )
+    }
+    edges = _run_flow(tmp_path, files)
+    assert _has(edges, "m.build", "m.caller", via="return", kind=FlowKind.RETURN.value)
+
+
+def test_taint_propagates_through_plain_assignment(tmp_path: Path) -> None:
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "def leak():\n    a = os.getenv('K')\n    b = a\n    print(b)\n"
+        )
+    }
+    edges = _run_flow(tmp_path, files)
+    assert _has(
+        edges,
+        "resource::ENV::K",
+        "resource::STDOUT::<dynamic>",
+        kind=FlowKind.RESOURCE.value,
+    )
+
+
+def test_untainted_arg_emits_no_flow(tmp_path: Path) -> None:
+    # (H) Co-occurrence of a read source and an unrelated call is not flow.
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "def helper(v):\n    pass\n\n"
+            "def caller():\n    u = 1\n    helper(u)\n    os.getenv('K')\n"
+        )
+    }
+    edges = _run_flow(tmp_path, files)
+    assert not any(b.endswith("m.helper") for _, b, _ in edges)
+
+
+def test_default_capture_emits_no_flow(tmp_path: Path) -> None:
+    files = {"m.py": "import os\n\ndef leak():\n    x = os.getenv('K')\n    print(x)\n"}
+    edges = _run_flow(tmp_path, files, capture=resolve_capture([]))
+    assert edges == []
+
+
+def test_flow_only_capture_still_ensures_resource_nodes(tmp_path: Path) -> None:
+    # (H) FLOWS_TO enabled, READS_FROM/WRITES_TO dropped: the resource endpoints of a
+    # (H) FLOWS_TO edge must still be ensured so no edge dangles to a missing node.
+    capture = resolve_capture(
+        [cs.CAPTURE_TOKEN_NONE, f"{cs.CAPTURE_ADD_PREFIX}{FLOWS_TO}"]
+    )
+    parsers, queries = load_parsers()
+    if "python" not in parsers:
+        pytest.skip("python parser not available")
+    (tmp_path / "m.py").write_text(
+        "import os\n\ndef leak():\n    x = os.getenv('K')\n    print(x)\n",
+        encoding="utf-8",
+    )
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        capture=capture,
+    ).run()
+    node_qns = _node_qns(mock)
+    assert "resource::ENV::K" in node_qns
+    assert "resource::STDOUT::<dynamic>" in node_qns

--- a/codebase_rag/tests/test_flow_edges.py
+++ b/codebase_rag/tests/test_flow_edges.py
@@ -142,6 +142,37 @@ def test_untainted_arg_emits_no_flow(tmp_path: Path) -> None:
     assert not any(b.endswith("m.helper") for _, b, _ in edges)
 
 
+def test_overwrite_with_literal_kills_taint(tmp_path: Path) -> None:
+    # (H) Reassigning a tainted local to a safe literal kills its taint; the later
+    # (H) sink must not emit a resource->resource flow (no stale-taint false positive).
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "def leak():\n    x = os.getenv('K')\n    x = 'safe'\n    print(x)\n"
+        )
+    }
+    edges = _run_flow(tmp_path, files)
+    assert not any(
+        a.endswith("resource::ENV::K") and b.endswith("resource::STDOUT::<dynamic>")
+        for a, b, _ in edges
+    )
+
+
+def test_overwrite_with_untainted_name_kills_taint(tmp_path: Path) -> None:
+    # (H) Reassigning a tainted local from an untainted variable also kills taint.
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "def leak():\n    x = os.getenv('K')\n    y = 1\n    x = y\n    print(x)\n"
+        )
+    }
+    edges = _run_flow(tmp_path, files)
+    assert not any(
+        a.endswith("resource::ENV::K") and b.endswith("resource::STDOUT::<dynamic>")
+        for a, b, _ in edges
+    )
+
+
 def test_default_capture_emits_no_flow(tmp_path: Path) -> None:
     files = {"m.py": "import os\n\ndef leak():\n    x = os.getenv('K')\n    print(x)\n"}
     edges = _run_flow(tmp_path, files, capture=resolve_capture([]))

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -826,4 +826,9 @@ RELATIONSHIP_SCHEMAS: tuple[RelationshipSchema, ...] = (
         RelationshipType.WRITES_TO,
         (NodeLabel.RESOURCE,),
     ),
+    RelationshipSchema(
+        (NodeLabel.MODULE, NodeLabel.FUNCTION, NodeLabel.METHOD, NodeLabel.RESOURCE),
+        RelationshipType.FLOWS_TO,
+        (NodeLabel.MODULE, NodeLabel.FUNCTION, NodeLabel.METHOD, NodeLabel.RESOURCE),
+    ),
 )

--- a/docs/architecture/graph-schema.md
+++ b/docs/architecture/graph-schema.md
@@ -25,6 +25,9 @@ The knowledge graph uses a unified schema across all supported languages.
 | ModuleInterface | `{qualified_name: string, name: string, path: string}` |
 | ModuleImplementation | `{qualified_name: string, name: string, path: string, implements_module: string}` |
 | ExternalPackage | `{name: string, version_spec: string}` |
+| Resource | `{qualified_name: string, name: string, kind: string}` |
+
+`Resource` is a synthetic node standing for an external I/O target (a file, environment variable, network endpoint, database, standard stream, socket). Its `qualified_name` has the form `resource::<KIND>::<identity>`, where `identity` is a static string literal when one is available and `<dynamic>` otherwise, and `kind` is one of `FILE`, `NETWORK`, `DATABASE`, `STDIN`, `STDOUT`, `STDERR`, `ENV`, `SOCKET`. Resource nodes are captured only when the `io` capture group is enabled (see below).
 
 ## Relationships
 
@@ -46,6 +49,23 @@ The knowledge graph uses a unified schema across all supported languages.
 | ModuleImplementation | IMPLEMENTS | ModuleInterface |
 | Project | DEPENDS_ON_EXTERNAL | ExternalPackage |
 | Function, Method | CALLS | Function, Method |
+| Module, Function, Method | READS_FROM | Resource |
+| Module, Function, Method | WRITES_TO | Resource |
+| Module, Function, Method, Resource | FLOWS_TO | Module, Function, Method, Resource |
+
+## I/O and Data-Flow Edges
+
+The `io` capture group (opt-in; excluded from the default capture set) adds three relationships that model how code touches external resources and how values move between them.
+
+`READS_FROM` and `WRITES_TO` connect a callable to a `Resource` it reads from or writes to (for example `os.getenv("K")` reads the `ENV` resource, `print(x)` writes the `STDOUT` resource).
+
+`FLOWS_TO` records intra-procedural value flow, turning provenance questions into graph reachability. It is emitted in three shapes, distinguished by a `kind` edge property:
+
+- **resource → resource** (`kind = resource`): a value read from one resource reaches a write to another within a function body, e.g. `x = os.getenv("K"); print(x)` yields `Resource(ENV::K) -FLOWS_TO-> Resource(STDOUT)`.
+- **caller → callee** (`kind = arg`): a tainted local value is passed as an argument to a first-party callee. A `via` edge property names the conduit as `arg:<index>` or `kw:<name>`.
+- **callee → caller** (`kind = return`, `via = return`): a callee whose return value is tainted flows that value back to the assignment in its caller.
+
+Taint is propagated through plain `x = y` assignments. `FLOWS_TO` is intentionally conservative and intra-procedural in this phase; a tainted value is only tracked within a single function body plus one level of argument/return hand-off.
 
 ## Nested Definitions
 

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.300"
+version = "0.0.301"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

Adds `FLOWS_TO`, an opt-in relationship type that records intra-procedural value flow (taint/provenance) between resources and callables. Turns questions like "does a value read here reach a write over there?" into graph reachability, which coarse `CALLS` co-occurrence cannot answer.

Stacked on #638 (base branch `feat/relationship-capture-io`): `FLOWS_TO` builds on that PR's `Resource` nodes and I/O source/sink registry, so it must land after #638. When #638 merges this PR auto-retargets to `main`.

## Behavior

`FLOWS_TO` is emitted in three shapes, distinguished by a `kind` edge property (plus a `via` conduit label):

- **resource → resource** (`kind=resource`): a value read from one resource reaches a write to another within a body, e.g. `x = os.getenv("K"); print(x)` yields `Resource(ENV::K) -FLOWS_TO-> Resource(STDOUT)`.
- **caller → callee** (`kind=arg`, `via=arg:<i>` / `kw:<name>`): a tainted local is passed as an argument to a first-party callee.
- **callee → caller** (`kind=return`, `via=return`): a callee whose return value is tainted flows it back to the assignment in its caller.

Taint propagates through plain `x = y` assignments.

## Opt-in / zero default cost

`FLOWS_TO` joins the existing `io` capture group, which is excluded from the default capture set. A default build emits zero `FLOWS_TO` edges and skips the body pass entirely. Enable with `--capture io` (or `CGR_CAPTURE=io`).

## Design

Self-contained `codebase_rag/parsers/flow_access/` submodule mirroring `io_access/`: one scope-pruned body DFS per caller, invoked once beside `process_io_for_caller`, reusing the resolver for callee resolution. Pure extractors shared with `io_access` were promoted to `io_access/extract.py` (no behavior change; the io suite is unchanged). No new node types: `FLOWS_TO` connects existing `Function`/`Method`/`Module`/`Resource` nodes.

Phase-1 scope is deliberately conservative and documented inline: Python-only, single function body plus one level of argument/return hand-off, direct source/sink calls, no SSA/parameter nodes. Upgrade paths are noted at each ceiling.

## Tests

RED → GREEN: failing tests committed first (`2c3f1fe`), then the implementation (`2cc78d2`). Eight `test_flow_edges.py` cases cover each edge shape, taint propagation, the anti-false-positive negative case (co-occurrence is not flow), default-off gating, and the dangling-endpoint guard, plus capture-selection membership. Full suite green (4853 passed); `ty` and `ruff` clean; relationship `properties` confirmed to round-trip the protobuf path.

## Docs

`docs/architecture/graph-schema.md` gains the `Resource` node row, the `READS_FROM`/`WRITES_TO`/`FLOWS_TO` relationship rows, and an I/O and data-flow section.
