### PR TITLE
test(parsers): spike tags.scm definition cross-validation (#524)

### DIFF
--- a/codebase_rag/parser_loader.py
+++ b/codebase_rag/parser_loader.py
@@ -286,6 +286,24 @@ def _create_highlights_query(
     return None
 
 
+def _create_tags_query(
+    language: Language, lang_name: cs.SupportedLanguage
+) -> Query | None:
+    # (H) Vendored-only oracle for definition cross-validation (issue #524);
+    # (H) TSX shares the TypeScript grammar, like highlights.
+    query_lang_name = (
+        cs.SupportedLanguage.TS if lang_name == cs.SupportedLanguage.TSX else lang_name
+    )
+    path = Path(__file__).parent / "queries" / "tags" / f"{query_lang_name}.scm"
+    if not path.exists():
+        return None
+    try:
+        return Query(language, path.read_text(encoding="utf-8"))
+    except Exception as e:
+        logger.debug(f"Failed to load tags query for {query_lang_name}: {e}")
+        return None
+
+
 COMBINED_FUNC_CLASS_QUERIES: dict[cs.SupportedLanguage, Query | None] = {}
 COMBINED_FUNC_CLASS_IMPORT_QUERIES: dict[cs.SupportedLanguage, Query | None] = {}
 

--- a/codebase_rag/parsers/tags_crossvalidate.py
+++ b/codebase_rag/parsers/tags_crossvalidate.py
@@ -1,0 +1,40 @@
+"""Diff cgr's own definitions against a tags.scm `@definition.*` oracle (issue #524).
+
+Pure diagnostic: no graph mutation. `crossvalidate` returns the definitions tags.scm
+saw that cgr missed, and the ones cgr emitted that tags.scm did not see.
+"""
+
+from __future__ import annotations
+
+from tree_sitter import Query
+
+from codebase_rag.parsers.utils import get_query_cursor, safe_decode_text
+from codebase_rag.types_defs import ASTNode
+
+_DEFINITION_PREFIX = "definition."
+_NAME_CAPTURE = "name"
+
+
+def crossvalidate(
+    root: ASTNode, tags_query: Query, cgr_defs: set[tuple[str, int]]
+) -> tuple[set[tuple[str, int]], set[tuple[str, int]]]:
+    """Return (missed, extra) as sets of (name, start_line).
+
+    `cgr_defs` is the (name, 1-indexed start line) of every definition cgr already
+    emitted for this file. `missed` is what tags.scm found and cgr did not; `extra`
+    is what cgr emitted and tags.scm does not mark.
+    """
+    cursor = get_query_cursor(tags_query)
+    tag_defs: set[tuple[str, int]] = set()
+    for _pattern_index, caps in cursor.matches(root):
+        if not any(name.startswith(_DEFINITION_PREFIX) for name in caps):
+            continue
+        name_nodes = caps.get(_NAME_CAPTURE)
+        if not name_nodes:
+            continue
+        node = name_nodes[0]
+        text = safe_decode_text(node)
+        if text:
+            tag_defs.add((text, node.start_point[0] + 1))
+
+    return tag_defs - cgr_defs, cgr_defs - tag_defs

--- a/codebase_rag/parsers/tags_crossvalidate.py
+++ b/codebase_rag/parsers/tags_crossvalidate.py
@@ -1,8 +1,5 @@
-"""Diff cgr's own definitions against a tags.scm `@definition.*` oracle (issue #524).
-
-Pure diagnostic: no graph mutation. `crossvalidate` returns the definitions tags.scm
-saw that cgr missed, and the ones cgr emitted that tags.scm did not see.
-"""
+# (H) Diff cgr's own definitions against a tags.scm @definition.* oracle (issue #524);
+# (H) pure diagnostic, no graph mutation. See crossvalidate below.
 
 from __future__ import annotations
 

--- a/codebase_rag/queries/tags/python.scm
+++ b/codebase_rag/queries/tags/python.scm
@@ -1,0 +1,6 @@
+; Python definition captures for cross-validation (issue #524).
+(function_definition
+  name: (identifier) @name) @definition.function
+
+(class_definition
+  name: (identifier) @name) @definition.class

--- a/codebase_rag/tests/test_tags_crossvalidation.py
+++ b/codebase_rag/tests/test_tags_crossvalidation.py
@@ -1,0 +1,66 @@
+"""Spike: tags.scm as an oracle to cross-validate cgr's own definition extraction.
+
+Issue #524 (rescoped). tags.scm marks `@definition.*` sites; we diff those against
+the (name, start_line) pairs cgr already emits and flag any the graph is missing.
+"""
+
+from codebase_rag import constants as cs
+from codebase_rag.parser_loader import _create_tags_query, load_parsers
+from codebase_rag.parsers.tags_crossvalidate import crossvalidate
+from codebase_rag.tests.test_function_ingest import parse_code
+
+# def f -> line 1, def g -> line 4, class C -> line 7 (1-indexed)
+_PY_CODE = """def f():
+    pass
+
+def g():
+    pass
+
+class C:
+    pass
+"""
+
+
+def _tags_query():
+    parsers, _ = load_parsers()
+    return _create_tags_query(
+        parsers[cs.SupportedLanguage.PYTHON].language, cs.SupportedLanguage.PYTHON
+    )
+
+
+def test_crossvalidate_flags_definition_cgr_missed() -> None:
+    parsers, _ = load_parsers()
+    root = parse_code(_PY_CODE, cs.SupportedLanguage.PYTHON, parsers)
+
+    # cgr's own extraction dropped `g` (simulating a language_spec.py query gap).
+    cgr_defs = {("f", 1), ("C", 7)}
+
+    missed, extra = crossvalidate(root, _tags_query(), cgr_defs)
+
+    assert missed == {("g", 4)}
+    assert extra == set()
+
+
+def test_crossvalidate_parity_reports_nothing() -> None:
+    parsers, _ = load_parsers()
+    root = parse_code(_PY_CODE, cs.SupportedLanguage.PYTHON, parsers)
+
+    cgr_defs = {("f", 1), ("g", 4), ("C", 7)}
+
+    missed, extra = crossvalidate(root, _tags_query(), cgr_defs)
+
+    assert missed == set()
+    assert extra == set()
+
+
+def test_crossvalidate_flags_cgr_over_capture() -> None:
+    parsers, _ = load_parsers()
+    root = parse_code(_PY_CODE, cs.SupportedLanguage.PYTHON, parsers)
+
+    # cgr emitted a phantom definition tags.scm does not see.
+    cgr_defs = {("f", 1), ("g", 4), ("C", 7), ("ghost", 99)}
+
+    missed, extra = crossvalidate(root, _tags_query(), cgr_defs)
+
+    assert missed == set()
+    assert extra == {("ghost", 99)}

--- a/codebase_rag/tests/test_tags_crossvalidation.py
+++ b/codebase_rag/tests/test_tags_crossvalidation.py
@@ -1,15 +1,12 @@
-"""Spike: tags.scm as an oracle to cross-validate cgr's own definition extraction.
-
-Issue #524 (rescoped). tags.scm marks `@definition.*` sites; we diff those against
-the (name, start_line) pairs cgr already emits and flag any the graph is missing.
-"""
+# (H) Spike for issue #524 (rescoped): tags.scm marks @definition.* sites; we diff
+# (H) those against the (name, start_line) pairs cgr emits and flag any it missed.
 
 from codebase_rag import constants as cs
 from codebase_rag.parser_loader import _create_tags_query, load_parsers
 from codebase_rag.parsers.tags_crossvalidate import crossvalidate
 from codebase_rag.tests.test_function_ingest import parse_code
 
-# def f -> line 1, def g -> line 4, class C -> line 7 (1-indexed)
+# (H) definitions sit on lines 1 (f), 4 (g), 7 (C), all 1-indexed
 _PY_CODE = """def f():
     pass
 
@@ -32,7 +29,7 @@ def test_crossvalidate_flags_definition_cgr_missed() -> None:
     parsers, _ = load_parsers()
     root = parse_code(_PY_CODE, cs.SupportedLanguage.PYTHON, parsers)
 
-    # cgr's own extraction dropped `g` (simulating a language_spec.py query gap).
+    # (H) cgr's own extraction dropped `g`, simulating a language_spec.py query gap.
     cgr_defs = {("f", 1), ("C", 7)}
 
     missed, extra = crossvalidate(root, _tags_query(), cgr_defs)
@@ -57,7 +54,7 @@ def test_crossvalidate_flags_cgr_over_capture() -> None:
     parsers, _ = load_parsers()
     root = parse_code(_PY_CODE, cs.SupportedLanguage.PYTHON, parsers)
 
-    # cgr emitted a phantom definition tags.scm does not see.
+    # (H) cgr emitted a phantom definition tags.scm does not see.
     cgr_defs = {("f", 1), ("g", 4), ("C", 7), ("ghost", 99)}
 
     missed, extra = crossvalidate(root, _tags_query(), cgr_defs)

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.302"
+version = "0.0.307"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Spike for the rescoped #524: use `tags.scm` `@definition.*` captures as an oracle to cross-validate cgr's own definition extraction. Diagnostic only, no graph mutation.

## What this proves

`crossvalidate(root, tags_query, cgr_defs) -> (missed, extra)` diffs the definitions tags.scm sees against the `(name, start_line)` pairs cgr already emits (`func_node.start_point[0] + 1`), so a gap in a hand-written `language_spec.py` query surfaces as `missed`, and an over-capture surfaces as `extra`.

Built RED first: the test dropped `g` from `cgr_defs` and asserted `missed == {("g", 4)}` before any implementation existed (`ImportError` on the missing symbols), then went GREEN.

## Files

- `codebase_rag/parsers/tags_crossvalidate.py` — the pure diff (`cursor.matches()` keeps each `@name` paired with its `@definition.*`, so future `@reference.*` captures are ignored cleanly).
- `codebase_rag/queries/tags/python.scm` — vendored `@definition.function` / `@definition.class`.
- `codebase_rag/parser_loader.py` — `_create_tags_query`, a vendored-only mirror of `_create_highlights_query`.
- `codebase_rag/tests/test_tags_crossvalidation.py` — RED-first test: miss case, parity case, over-capture case.

## Deliberately out of scope (the real #524 work)

- Only `python.scm` and only definitions; the other 11 languages and wiring `cgr_defs` from the live in-memory ingestor come next.
- `xfail` gap-tracking tests for the known misses (TS type alias, Rust trait impl).
- No upstream `TAGS_QUERY` merge; vendored-only for now.

Testing: `pytest codebase_rag/tests/test_tags_crossvalidation.py` → 3 passed; ruff + ty clean on the new files.

Refs #524.