### PR TITLE
fix(parsers): load community tags.scm as the cross-validation oracle (#524)

### DIFF
--- a/codebase_rag/parser_loader.py
+++ b/codebase_rag/parser_loader.py
@@ -289,18 +289,23 @@ def _create_highlights_query(
 def _create_tags_query(
     language: Language, lang_name: cs.SupportedLanguage
 ) -> Query | None:
-    # (H) Vendored-only oracle for definition cross-validation (issue #524);
-    # (H) TSX shares the TypeScript grammar, like highlights.
+    # (H) Independent cross-validation oracle (issue #524): the community tags.scm that
+    # (H) ships inside each grammar package, NOT a copy we author. TSX shares the
+    # (H) TypeScript grammar, like highlights.
     query_lang_name = (
         cs.SupportedLanguage.TS if lang_name == cs.SupportedLanguage.TSX else lang_name
     )
-    path = Path(__file__).parent / "queries" / "tags" / f"{query_lang_name}.scm"
-    if not path.exists():
-        return None
+    module_name = f"{cs.TREE_SITTER_MODULE_PREFIX}{query_lang_name.replace('-', '_')}"
     try:
+        module = importlib.import_module(module_name)
+        if module.__file__ is None:
+            return None
+        path = Path(module.__file__).parent / "queries" / "tags.scm"
+        if not path.exists():
+            return None
         return Query(language, path.read_text(encoding="utf-8"))
     except Exception as e:
-        logger.debug(f"Failed to load tags query for {query_lang_name}: {e}")
+        logger.debug(f"Failed to load community tags query for {query_lang_name}: {e}")
         return None
 
 

--- a/codebase_rag/queries/tags/python.scm
+++ b/codebase_rag/queries/tags/python.scm
@@ -1,6 +1,0 @@
-; Python definition captures for cross-validation (issue #524).
-(function_definition
-  name: (identifier) @name) @definition.function
-
-(class_definition
-  name: (identifier) @name) @definition.class

--- a/codebase_rag/tests/test_tags_crossvalidation.py
+++ b/codebase_rag/tests/test_tags_crossvalidation.py
@@ -61,3 +61,15 @@ def test_crossvalidate_flags_cgr_over_capture() -> None:
 
     assert missed == set()
     assert extra == {("ghost", 99)}
+
+
+def test_tags_query_uses_community_oracle() -> None:
+    # (H) The grammar-shipped community tags.scm captures @definition.constant for
+    # (H) module-level assignments; the earlier hand-written oracle did not. This pins
+    # (H) that the loader reads the real independent oracle, not a local copy.
+    parsers, _ = load_parsers()
+    root = parse_code("X = 1\n\ndef f():\n    pass\n", cs.SupportedLanguage.PYTHON, parsers)
+
+    missed, _extra = crossvalidate(root, _tags_query(), {("f", 3)})
+
+    assert ("X", 1) in missed

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.307"
+version = "0.0.308"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Why

PR #717 shipped the cross-validation diff (`crossvalidate`) but pointed the tags oracle at a **hand-written** `codebase_rag/queries/tags/python.scm`. That defeats the purpose of #524: an oracle you author yourself is not independent. A blind spot in cgr's extraction can be mirrored in a hand-written scm, so the diff goes green while both sides are wrong.

## What

- `_create_tags_query` now loads the community `queries/tags.scm` that ships **inside each grammar package** (resolved via `importlib`), not a local copy.
- Deleted the toy `codebase_rag/queries/tags/python.scm`.
- All 12 vendored grammars ship a `tags.scm` and every one compiles with py-tree-sitter's `Query`, so the oracle is available for every supported language, not just Python.

The community python oracle is genuinely richer and independent: it captures `@definition.constant` (module-level assignments) and `@reference.call` on top of function/class definitions. The hand-written version had only function + class.

## Test (RED first)

`test_tags_query_uses_community_oracle` parses `X = 1` + `def f()` and asserts the module constant `X` shows up in `missed`. This is a clean discriminator: only the community oracle captures `@definition.constant`, so the test fails against the old hand-written scm (RED) and passes once the loader reads the real grammar-shipped file (GREEN). Confirmed failing before the loader change, passing after.

Follow-up to #717. Refs #524.