### PR TITLE
feat(csharp): INHERITS, IMPLEMENTS and OVERRIDES (Phase 2 of 4, #102)

### DIFF
--- a/codebase_rag/constants/ast_csharp.py
+++ b/codebase_rag/constants/ast_csharp.py
@@ -44,12 +44,11 @@ TS_CSHARP_GENERIC_NAME = "generic_name"
 TS_CSHARP_PRIMARY_CONSTRUCTOR_BASE_TYPE = "primary_constructor_base_type"
 TS_CSHARP_PREDEFINED_TYPE = "predefined_type"
 
-# (H) A `modifier` child wraps a single keyword token (`public`, `override`,
-# (H) `new`, `virtual`). Override detection reads these to tell a real override
-# (H) (`override`) from an explicit hide (`new`).
+# (H) A `modifier` child wraps a single keyword (`public`, `override`, `new`,
+# (H) `virtual`). Override detection reads it to tell a real override
+# (H) (`override`) from an explicit `new` hide (which must not become OVERRIDES).
 TS_CSHARP_MODIFIER = "modifier"
 TS_CSHARP_MODIFIER_OVERRIDE = "override"
-TS_CSHARP_MODIFIER_NEW = "new"
 
 # (H) Call forms.
 TS_CSHARP_INVOCATION_EXPRESSION = "invocation_expression"

--- a/codebase_rag/constants/ast_csharp.py
+++ b/codebase_rag/constants/ast_csharp.py
@@ -30,6 +30,27 @@ TS_CSHARP_OPERATOR_DECLARATION = "operator_declaration"
 TS_CSHARP_CONVERSION_OPERATOR_DECLARATION = "conversion_operator_declaration"
 TS_CSHARP_PROPERTY_DECLARATION = "property_declaration"
 
+# (H) Base spec: `class C : Base, IShape` / `interface I : IOther` /
+# (H) `enum E : byte`. A single base_list lumps the base class and interfaces
+# (H) together (unlike Java's separate superclass/super_interfaces clauses), so
+# (H) the split is heuristic. base_list is unique to C# among the grammars, so
+# (H) its presence identifies a C# type node without a language argument.
+TS_CSHARP_BASE_LIST = "base_list"
+# (H) A base type may be a bare `identifier`, a `generic_name` (`List<int>` ->
+# (H) strip type args to the identifier), a `qualified_name` (`System.Exception`),
+# (H) a record positional base `primary_constructor_base_type` (`Animal(Name)`),
+# (H) or a `predefined_type` (an enum's underlying integral type -> not a base).
+TS_CSHARP_GENERIC_NAME = "generic_name"
+TS_CSHARP_PRIMARY_CONSTRUCTOR_BASE_TYPE = "primary_constructor_base_type"
+TS_CSHARP_PREDEFINED_TYPE = "predefined_type"
+
+# (H) A `modifier` child wraps a single keyword token (`public`, `override`,
+# (H) `new`, `virtual`). Override detection reads these to tell a real override
+# (H) (`override`) from an explicit hide (`new`).
+TS_CSHARP_MODIFIER = "modifier"
+TS_CSHARP_MODIFIER_OVERRIDE = "override"
+TS_CSHARP_MODIFIER_NEW = "new"
+
 # (H) Call forms.
 TS_CSHARP_INVOCATION_EXPRESSION = "invocation_expression"
 TS_CSHARP_OBJECT_CREATION_EXPRESSION = "object_creation_expression"

--- a/codebase_rag/parsers/class_ingest/method_override.py
+++ b/codebase_rag/parsers/class_ingest/method_override.py
@@ -20,6 +20,8 @@ def process_all_method_overrides(
     class_inheritance: dict[str, list[str]],
     ingestor: IngestorProtocol,
     interface_implementers: dict[str, set[str]] | None = None,
+    csharp_methods: set[str] | None = None,
+    csharp_override_methods: set[str] | None = None,
 ) -> None:
     logger.info(logs.CLASS_PASS_4)
 
@@ -40,6 +42,8 @@ def process_all_method_overrides(
                     class_inheritance,
                     ingestor,
                     implemented_interfaces,
+                    csharp_methods,
+                    csharp_override_methods,
                 )
     _process_mro_shadow_overrides(function_registry, class_inheritance, ingestor)
 
@@ -222,10 +226,23 @@ def check_method_overrides(
     class_inheritance: dict[str, list[str]],
     ingestor: IngestorProtocol,
     implemented_interfaces: dict[str, list[str]] | None = None,
+    csharp_methods: set[str] | None = None,
+    csharp_override_methods: set[str] | None = None,
 ) -> None:
     implemented = implemented_interfaces or {}
     if class_qn not in class_inheritance and class_qn not in implemented:
         return
+
+    # (H) A C# method overrides a base CLASS member only with the explicit
+    # (H) `override` modifier; a `new`/implicit-hide member must not. Interface
+    # (H) members need no modifier, so gate only class-parent matches.
+    csharp_gated = (
+        csharp_methods is not None
+        and method_qn in csharp_methods
+        and (
+            csharp_override_methods is None or method_qn not in csharp_override_methods
+        )
+    )
 
     queue = deque([class_qn])
     visited = {class_qn}
@@ -250,17 +267,27 @@ def check_method_overrides(
             # (H) its name with the nested CLASS registered at parent.name, and
             # (H) an OVERRIDES onto that class qn is a label-mismatched phantom.
             if function_registry.get(parent_method_qn) == NodeType.METHOD:
-                ingestor.ensure_relationship_batch(
-                    (cs.NodeLabel.METHOD, cs.KEY_QUALIFIED_NAME, method_qn),
-                    cs.RelationshipType.OVERRIDES,
-                    (cs.NodeLabel.METHOD, cs.KEY_QUALIFIED_NAME, parent_method_qn),
+                # (H) Skip a gated C# member's CLASS-parent match, but keep
+                # (H) walking: it may still implement an interface member deeper.
+                parent_is_interface = (
+                    function_registry.get(current_class) == NodeType.INTERFACE
                 )
-                logger.debug(
-                    logs.CLASS_METHOD_OVERRIDE,
-                    method_qn=method_qn,
-                    parent_method_qn=parent_method_qn,
-                )
-                return
+                if not (csharp_gated and not parent_is_interface):
+                    ingestor.ensure_relationship_batch(
+                        (cs.NodeLabel.METHOD, cs.KEY_QUALIFIED_NAME, method_qn),
+                        cs.RelationshipType.OVERRIDES,
+                        (
+                            cs.NodeLabel.METHOD,
+                            cs.KEY_QUALIFIED_NAME,
+                            parent_method_qn,
+                        ),
+                    )
+                    logger.debug(
+                        logs.CLASS_METHOD_OVERRIDE,
+                        method_qn=method_qn,
+                        parent_method_qn=parent_method_qn,
+                    )
+                    return
 
         # (H) Superclasses first: when both a base class and an interface declare
         # (H) the method, the edge lands on the base, matching Java resolution.

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -43,6 +43,7 @@ from . import identity as id_
 from . import method_override as mo
 from . import node_type as nt
 from . import relationships as rel
+from .utils import csharp_has_override_modifier
 
 if TYPE_CHECKING:
     from ...services import IngestorProtocol
@@ -145,6 +146,8 @@ class ClassIngestMixin:
     class_inheritance: dict[str, list[str]]
     class_field_types: dict[str, dict[str, str]]
     java_anon_overrides: list[tuple[str, str, str, str]]
+    csharp_methods: set[str]
+    csharp_override_methods: set[str]
     class_field_guard_inner: dict[str, dict[str, str]]
     method_return_types: dict[str, str]
     interface_implementers: dict[str, set[str]]
@@ -978,6 +981,13 @@ class ClassIngestMixin:
                     cs.NodeLabel.METHOD.value,
                     ingested_qn,
                 )
+            # (H) Track C# methods (and the `override`-modified subset) so the
+            # (H) override walk gates class-parent matches: an implicit hide or a
+            # (H) `new` shadow is not an override, unlike an interface impl.
+            if language == cs.SupportedLanguage.CSHARP and ingested_qn is not None:
+                self.csharp_methods.add(ingested_qn)
+                if csharp_has_override_modifier(method_node):
+                    self.csharp_override_methods.add(ingested_qn)
             # (H) A Java method declared inside an anonymous class body
             # (H) (`new Base(){ @Override m(){} }`) is ingested here under the enclosing
             # (H) class but really overrides the anon class's base type. Record it so a
@@ -1089,6 +1099,8 @@ class ClassIngestMixin:
             self.class_inheritance,
             self.ingestor,
             self.interface_implementers,
+            self.csharp_methods,
+            self.csharp_override_methods,
         )
         self._resolve_java_anon_overrides()
 

--- a/codebase_rag/parsers/class_ingest/parent_extraction.py
+++ b/codebase_rag/parsers/class_ingest/parent_extraction.py
@@ -31,6 +31,73 @@ def php_base_simple_name(node: Node) -> str | None:
     return None
 
 
+def _csharp_base_written_name(node: Node) -> str | None:
+    # (H) The written base name for resolution: bare identifier, a generic base
+    # (H) stripped to its identifier (`List<int>` -> `List`), a dotted
+    # (H) qualified_name kept whole (`System.Exception`), or a record positional
+    # (H) base unwrapped to its type. predefined_type (an enum's underlying type)
+    # (H) and punctuation (`:`, `,`) yield None so they are dropped.
+    if node.type == cs.TS_CSHARP_IDENTIFIER and node.text:
+        return safe_decode_text(node)
+    if node.type == cs.TS_CSHARP_GENERIC_NAME:
+        ident = find_child_by_type(node, cs.TS_CSHARP_IDENTIFIER)
+        return safe_decode_text(ident) if ident and ident.text else None
+    if node.type == cs.TS_CSHARP_QUALIFIED_NAME and node.text:
+        return safe_decode_text(node)
+    if node.type == cs.TS_CSHARP_PRIMARY_CONSTRUCTOR_BASE_TYPE:
+        for child in node.children:
+            if name := _csharp_base_written_name(child):
+                return name
+    return None
+
+
+def _csharp_looks_like_interface(simple_name: str) -> bool:
+    # (H) The C# `I`-prefix convention (IShape, IDisposable) is the only signal
+    # (H) available at parse time to tell an interface from the base class inside
+    # (H) one base_list. Exact class-vs-interface binding is Phase 3 / Roslyn work.
+    return len(simple_name) >= 2 and simple_name[0] == "I" and simple_name[1].isupper()
+
+
+def split_csharp_bases(
+    class_node: Node,
+    module_qn: str,
+    resolve_to_qn: Callable[[str, str], str],
+) -> tuple[list[str], list[str]]:
+    # (H) Return (inherited_qns, implemented_qns). C# folds the base class and all
+    # (H) interfaces into one base_list; the base class, if any, is the FIRST entry
+    # (H) (grammar-enforced) and must not look like an interface. An interface's
+    # (H) bases are all inheritance; a struct/record/class implements the rest.
+    if class_node.type == cs.TS_CSHARP_ENUM_DECLARATION:
+        return [], []
+    base_list = find_child_by_type(class_node, cs.TS_CSHARP_BASE_LIST)
+    if base_list is None:
+        return [], []
+
+    written = [
+        name
+        for child in base_list.children
+        if (name := _csharp_base_written_name(child))
+    ]
+    is_interface = class_node.type == cs.TS_CSHARP_INTERFACE_DECLARATION
+    is_struct = class_node.type == cs.TS_CSHARP_STRUCT_DECLARATION
+
+    inherited: list[str] = []
+    implemented: list[str] = []
+    for index, name in enumerate(written):
+        resolved = resolve_to_qn(name, module_qn)
+        if is_interface:
+            inherited.append(resolved)
+        elif (
+            index == 0
+            and not is_struct
+            and not _csharp_looks_like_interface(name.rsplit(cs.SEPARATOR_DOT, 1)[-1])
+        ):
+            inherited.append(resolved)
+        else:
+            implemented.append(resolved)
+    return inherited, implemented
+
+
 def extract_parent_classes(
     class_node: Node,
     module_qn: str,
@@ -39,6 +106,14 @@ def extract_parent_classes(
 ) -> list[str]:
     if class_node.type in cs.CPP_CLASS_TYPES:
         return extract_cpp_parent_classes(class_node, module_qn)
+
+    # (H) C# base_list (unique to C#): the base class, or an interface's base
+    # (H) interfaces, are INHERITS; the implemented interfaces are handled by
+    # (H) extract_implemented_interfaces. Return early so the Java/TS clause
+    # (H) walks below never touch a C# node (class_declaration is shared).
+    if find_child_by_type(class_node, cs.TS_CSHARP_BASE_LIST) is not None:
+        inherited, _ = split_csharp_bases(class_node, module_qn, resolve_to_qn)
+        return inherited
 
     parent_classes: list[str] = []
 
@@ -397,6 +472,13 @@ def extract_implemented_interfaces(
     module_qn: str,
     resolve_to_qn: Callable[[str, str], str],
 ) -> list[str]:
+    # (H) C# implemented interfaces come from the shared base_list (the base
+    # (H) class, if any, is stripped by split_csharp_bases). Return early so the
+    # (H) Java/TS/PHP clause walks never run on a C# node.
+    if find_child_by_type(class_node, cs.TS_CSHARP_BASE_LIST) is not None:
+        _, implemented = split_csharp_bases(class_node, module_qn, resolve_to_qn)
+        return implemented
+
     implemented_interfaces: list[str] = []
 
     interfaces_node = class_node.child_by_field_name(cs.FIELD_INTERFACES)

--- a/codebase_rag/parsers/class_ingest/parent_extraction.py
+++ b/codebase_rag/parsers/class_ingest/parent_extraction.py
@@ -34,16 +34,20 @@ def php_base_simple_name(node: Node) -> str | None:
 def _csharp_base_written_name(node: Node) -> str | None:
     # (H) The written base name for resolution: bare identifier, a generic base
     # (H) stripped to its identifier (`List<int>` -> `List`), a dotted
-    # (H) qualified_name kept whole (`System.Exception`), or a record positional
-    # (H) base unwrapped to its type. predefined_type (an enum's underlying type)
-    # (H) and punctuation (`:`, `,`) yield None so they are dropped.
+    # (H) qualified_name (`System.Exception`), or a record positional base
+    # (H) unwrapped to its type. predefined_type (an enum's underlying type) and
+    # (H) punctuation (`:`, `,`) yield None so they are dropped.
     if node.type == cs.TS_CSHARP_IDENTIFIER and node.text:
         return safe_decode_text(node)
     if node.type == cs.TS_CSHARP_GENERIC_NAME:
         ident = find_child_by_type(node, cs.TS_CSHARP_IDENTIFIER)
         return safe_decode_text(ident) if ident and ident.text else None
     if node.type == cs.TS_CSHARP_QUALIFIED_NAME and node.text:
-        return safe_decode_text(node)
+        # (H) A qualified generic base (`System.Collections.Generic.List<int>`)
+        # (H) is one qualified_name whose text carries the type arguments; strip
+        # (H) them so the written name matches the registered, generic-free qn.
+        text = safe_decode_text(node)
+        return text.split(cs.CHAR_ANGLE_OPEN, 1)[0] if text else None
     if node.type == cs.TS_CSHARP_PRIMARY_CONSTRUCTOR_BASE_TYPE:
         for child in node.children:
             if name := _csharp_base_written_name(child):

--- a/codebase_rag/parsers/class_ingest/relationships.py
+++ b/codebase_rag/parsers/class_ingest/relationships.py
@@ -100,8 +100,16 @@ def create_class_relationships(
             )
 
     # (H) A class OR an enum can `implements` interfaces; both expose them via the
-    # (H) `interfaces` field (a super_interfaces clause), so handle both.
-    if class_node.type in (cs.TS_CLASS_DECLARATION, cs.TS_ENUM_DECLARATION):
+    # (H) `interfaces` field (a super_interfaces clause), so handle both. C#
+    # (H) struct/record types implement interfaces through their base_list too
+    # (H) (a C# class reuses the class_declaration node type already listed);
+    # (H) a C# interface's base_list is inheritance, so it is excluded here.
+    if class_node.type in (
+        cs.TS_CLASS_DECLARATION,
+        cs.TS_ENUM_DECLARATION,
+        cs.TS_CSHARP_STRUCT_DECLARATION,
+        cs.TS_CSHARP_RECORD_DECLARATION,
+    ):
         for interface_qn in pe.extract_implemented_interfaces(
             class_node, module_qn, resolve_to_qn
         ):

--- a/codebase_rag/parsers/class_ingest/utils.py
+++ b/codebase_rag/parsers/class_ingest/utils.py
@@ -15,12 +15,13 @@ def find_child_by_type(node: Node, node_type: str) -> Node | None:
 
 
 def csharp_has_override_modifier(method_node: Node) -> bool:
-    # (H) A C# member declares `override` via a `modifier` child wrapping the
-    # (H) `override` keyword token. Its presence is what separates a real base
-    # (H) override from an explicit `new` hide (which must not become OVERRIDES).
+    # (H) A C# member declares `override` via a `modifier` child that wraps
+    # (H) exactly one keyword; its stripped text IS the keyword. Its presence is
+    # (H) what separates a real base override from an explicit `new` hide (which
+    # (H) must not become OVERRIDES).
     for child in method_node.children:
-        if child.type == cs.TS_CSHARP_MODIFIER and any(
-            tok.type == cs.TS_CSHARP_MODIFIER_OVERRIDE for tok in child.children
+        if child.type == cs.TS_CSHARP_MODIFIER and (
+            decode_node_stripped(child) == cs.TS_CSHARP_MODIFIER_OVERRIDE
         ):
             return True
     return False

--- a/codebase_rag/parsers/class_ingest/utils.py
+++ b/codebase_rag/parsers/class_ingest/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from tree_sitter import Node
 
+from ... import constants as cs
 from ..utils import safe_decode_with_fallback
 
 
@@ -11,3 +12,15 @@ def decode_node_stripped(node: Node) -> str:
 
 def find_child_by_type(node: Node, node_type: str) -> Node | None:
     return next((c for c in node.children if c.type == node_type), None)
+
+
+def csharp_has_override_modifier(method_node: Node) -> bool:
+    # (H) A C# member declares `override` via a `modifier` child wrapping the
+    # (H) `override` keyword token. Its presence is what separates a real base
+    # (H) override from an explicit `new` hide (which must not become OVERRIDES).
+    for child in method_node.children:
+        if child.type == cs.TS_CSHARP_MODIFIER and any(
+            tok.type == cs.TS_CSHARP_MODIFIER_OVERRIDE for tok in child.children
+        ):
+            return True
+    return False

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -78,6 +78,14 @@ class DefinitionProcessor(
         # (H) enclosing class with no OVERRIDES edge and look dead. Recorded at method
         # (H) ingestion, resolved to OVERRIDES edges once every base type is registered.
         self.java_anon_overrides: list[tuple[str, str, str, str]] = []
+        # (H) C# override tracking. `csharp_methods` is every C# method qn;
+        # (H) `csharp_override_methods` the subset carrying the `override` modifier.
+        # (H) C# base-CLASS overrides require `override` (a `new`/implicit-hide
+        # (H) member is not an override), so the shared override walk emits a
+        # (H) class-parent match only for C# methods in the override subset;
+        # (H) interface implementations need no modifier and are unaffected.
+        self.csharp_methods: set[str] = set()
+        self.csharp_override_methods: set[str] = set()
         # (H) {class_qn: {field_name: inner_type}} for Rust guard-container fields
         # (H) (`state: Mutex<State>` -> {"state": "State"}). The field map above keeps
         # (H) the WRAPPER; this inner is applied only when a receiver chain reaches a

--- a/codebase_rag/tests/test_csharp_inheritance.py
+++ b/codebase_rag/tests/test_csharp_inheritance.py
@@ -107,6 +107,25 @@ public struct Val : IShape { }
     assert _has(implements, "N.Val", "N.IShape"), implements
 
 
+def test_qualified_generic_base_strips_type_arguments(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    (csharp_project / "Gen.cs").write_text(
+        """
+namespace N;
+public class C : System.Collections.Generic.List<int> { }
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    inherits = _pairs(mock_ingestor, "INHERITS")
+    # (H) The generic type arguments must not leak into the base's qn, or it
+    # (H) can never match the registered (generic-free) List type.
+    assert _has(inherits, "N.C", "System.Collections.Generic.List"), inherits
+    assert not any("<" in parent for _, parent in inherits), inherits
+
+
 def test_enum_underlying_type_is_not_inheritance(
     csharp_project: Path, mock_ingestor: MagicMock
 ) -> None:

--- a/codebase_rag/tests/test_csharp_inheritance.py
+++ b/codebase_rag/tests/test_csharp_inheritance.py
@@ -1,0 +1,123 @@
+# (H) C# Phase 2: INHERITS (base class, interface-extends-interface) and
+# (H) IMPLEMENTS (class/struct/record implementing interfaces).
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag.tests.conftest import get_relationships, run_updater
+
+SKIP = "c_sharp"
+
+
+@pytest.fixture
+def csharp_project(temp_repo: Path) -> Path:
+    project = temp_repo / "csharp_inherit"
+    project.mkdir()
+    return project
+
+
+def _pairs(mock_ingestor: MagicMock, rel_type: str) -> set[tuple[str, str]]:
+    return {
+        (c.args[0][2], c.args[2][2]) for c in get_relationships(mock_ingestor, rel_type)
+    }
+
+
+def _has(pairs: set[tuple[str, str]], child_suffix: str, parent_suffix: str) -> bool:
+    return any(
+        ch.endswith(child_suffix) and pa.endswith(parent_suffix) for ch, pa in pairs
+    )
+
+
+def test_base_class_emits_inherits(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    (csharp_project / "Base.cs").write_text(
+        """
+namespace N;
+public class Base { }
+public class Derived : Base { }
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    inherits = _pairs(mock_ingestor, "INHERITS")
+    assert _has(inherits, "N.Derived", "N.Base"), inherits
+
+
+def test_interfaces_emit_implements_not_inherits(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    (csharp_project / "Shapes.cs").write_text(
+        """
+namespace N;
+public class Base { }
+public interface IShape { }
+public interface IColor { }
+public class Derived : Base, IShape, IColor { }
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    inherits = _pairs(mock_ingestor, "INHERITS")
+    implements = _pairs(mock_ingestor, "IMPLEMENTS")
+    # (H) The base class is inheritance; the interfaces are implementation.
+    assert _has(inherits, "N.Derived", "N.Base"), inherits
+    assert _has(implements, "N.Derived", "N.IShape"), implements
+    assert _has(implements, "N.Derived", "N.IColor"), implements
+    # (H) An interface must never be recorded as a base class.
+    assert not _has(inherits, "N.Derived", "N.IShape"), inherits
+
+
+def test_interface_extends_interface_is_inherits(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    (csharp_project / "Extend.cs").write_text(
+        """
+namespace N;
+public interface IShape { }
+public interface IColor { }
+public interface IExtended : IShape, IColor { }
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    inherits = _pairs(mock_ingestor, "INHERITS")
+    assert _has(inherits, "N.IExtended", "N.IShape"), inherits
+    assert _has(inherits, "N.IExtended", "N.IColor"), inherits
+
+
+def test_struct_implements_interface(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    (csharp_project / "Val.cs").write_text(
+        """
+namespace N;
+public interface IShape { }
+public struct Val : IShape { }
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    implements = _pairs(mock_ingestor, "IMPLEMENTS")
+    assert _has(implements, "N.Val", "N.IShape"), implements
+
+
+def test_enum_underlying_type_is_not_inheritance(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    (csharp_project / "Color.cs").write_text(
+        "namespace N;\npublic enum Color : byte { R, G }\n",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    inherits = _pairs(mock_ingestor, "INHERITS")
+    implements = _pairs(mock_ingestor, "IMPLEMENTS")
+    # (H) `enum Color : byte` names an underlying integral type, not a base.
+    assert not any(ch.endswith("N.Color") for ch, _ in inherits), inherits
+    assert not any(ch.endswith("N.Color") for ch, _ in implements), implements

--- a/codebase_rag/tests/test_csharp_overrides.py
+++ b/codebase_rag/tests/test_csharp_overrides.py
@@ -1,0 +1,84 @@
+# (H) C# Phase 2: OVERRIDES for `override` methods and interface
+# (H) implementations; `new` shadowing must NOT be recorded as an override.
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag.tests.conftest import get_relationships, run_updater
+
+SKIP = "c_sharp"
+
+
+@pytest.fixture
+def csharp_project(temp_repo: Path) -> Path:
+    project = temp_repo / "csharp_override"
+    project.mkdir()
+    return project
+
+
+def _pairs(mock_ingestor: MagicMock) -> set[tuple[str, str]]:
+    return {
+        (c.args[0][2], c.args[2][2])
+        for c in get_relationships(mock_ingestor, "OVERRIDES")
+    }
+
+
+def _has(pairs: set[tuple[str, str]], child_suffix: str, parent_suffix: str) -> bool:
+    return any(
+        ch.endswith(child_suffix) and pa.endswith(parent_suffix) for ch, pa in pairs
+    )
+
+
+def test_override_modifier_emits_overrides(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    (csharp_project / "Ov.cs").write_text(
+        """
+namespace N;
+public class Base { public virtual void M() {} }
+public class Derived : Base { public override void M() {} }
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    assert _has(_pairs(mock_ingestor), "N.Derived.M", "N.Base.M"), _pairs(mock_ingestor)
+
+
+def test_interface_implementation_emits_overrides(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    (csharp_project / "Impl.cs").write_text(
+        """
+namespace N;
+public interface IShape { void Draw(); }
+public class Circle : IShape { public void Draw() {} }
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    # (H) Implementing an interface member is an override (no modifier needed).
+    assert _has(_pairs(mock_ingestor), "N.Circle.Draw", "N.IShape.Draw"), _pairs(
+        mock_ingestor
+    )
+
+
+def test_new_shadowing_does_not_emit_overrides(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    (csharp_project / "Hide.cs").write_text(
+        """
+namespace N;
+public class Base { public void Hidden() {} }
+public class Derived : Base { public new void Hidden() {} }
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    # (H) `new` explicitly hides, it does not override: no OVERRIDES edge.
+    assert not _has(_pairs(mock_ingestor), "N.Derived.Hidden", "N.Base.Hidden"), _pairs(
+        mock_ingestor
+    )


### PR DESCRIPTION
## C# support, Phase 2 of 4 (issue #102): class hierarchy edges

Builds on Phase 1 (#716). Emits the three C# type-relationship edges:

- **INHERITS** — a class/struct/record base class, and interface-extends-interface.
- **IMPLEMENTS** — interfaces a class/struct/record implements.
- **OVERRIDES** — `override` methods and interface-member implementations.

### How the single `base_list` is split

C# folds the base class and all interfaces into one `base_list` (unlike Java's separate `superclass`/`super_interfaces` clauses). The base class, when present, is the first entry (grammar-enforced) and must not match the `I`-prefix interface convention; everything else is an interface. Enum underlying types (`enum E : byte`) are integral, not bases, and are dropped. `base_list` is unique to C# among the grammars, so its presence identifies a C# node without threading a language argument through the extractors. Exact class-vs-interface binding is Phase 3 / Roslyn work.

### `new` shadowing is not an override

C# overrides a base **class** member only with the explicit `override` modifier; a `new` (or implicit) hide is not an override. Interface members need no modifier. The shared override walk now emits a class-parent match only for C# methods carrying `override`, while interface implementations stay unaffected (detected by the parent node's `Interface` label).

### Tests (red → green)

- `test_csharp_inheritance.py` — base class, interfaces vs base split, interface-extends-interface, struct implements, enum underlying type is not a base.
- `test_csharp_overrides.py` — `override` emits, interface impl emits, `new` shadowing does not.

Full suite green (4986 passed, 10 skipped) with the orphan/dangling-edge graph audit on every C# fixture. Dogfooded on Polly (797 `.cs` files, clean parse): 218 INHERITS, 148 IMPLEMENTS, 214 OVERRIDES.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
