### PR TITLE
feat(parsers): cross-validate reference.call sites against cgr (#524)

### DIFF
--- a/codebase_rag/parsers/tags_crossvalidate.py
+++ b/codebase_rag/parsers/tags_crossvalidate.py
@@ -1,5 +1,5 @@
-# (H) Diff cgr's own definitions against a tags.scm @definition.* oracle (issue #524);
-# (H) pure diagnostic, no graph mutation. See crossvalidate below.
+# (H) Diff cgr's own graph against a tags.scm oracle (issue #524); pure diagnostic,
+# (H) no graph mutation. crossvalidate covers @definition.*, crossvalidate_calls @reference.call.
 
 from __future__ import annotations
 
@@ -9,7 +9,23 @@ from codebase_rag.parsers.utils import get_query_cursor, safe_decode_text
 from codebase_rag.types_defs import ASTNode
 
 _DEFINITION_PREFIX = "definition."
+_CALL_CAPTURE = "reference.call"
 _NAME_CAPTURE = "name"
+
+
+def _tag_sites(root: ASTNode, tags_query: Query, tag_prefix: str) -> set[tuple[str, int]]:
+    # (H) Every @name under a match carrying a capture that starts with tag_prefix,
+    # (H) paired with its 1-indexed start line. Nested calls yield separate matches.
+    cursor = get_query_cursor(tags_query)
+    sites: set[tuple[str, int]] = set()
+    for _pattern_index, caps in cursor.matches(root):
+        if not any(name.startswith(tag_prefix) for name in caps):
+            continue
+        for node in caps.get(_NAME_CAPTURE, []):
+            text = safe_decode_text(node)
+            if text:
+                sites.add((text, node.start_point[0] + 1))
+    return sites
 
 
 def crossvalidate(
@@ -21,17 +37,18 @@ def crossvalidate(
     emitted for this file. `missed` is what tags.scm found and cgr did not; `extra`
     is what cgr emitted and tags.scm does not mark.
     """
-    cursor = get_query_cursor(tags_query)
-    tag_defs: set[tuple[str, int]] = set()
-    for _pattern_index, caps in cursor.matches(root):
-        if not any(name.startswith(_DEFINITION_PREFIX) for name in caps):
-            continue
-        name_nodes = caps.get(_NAME_CAPTURE)
-        if not name_nodes:
-            continue
-        node = name_nodes[0]
-        text = safe_decode_text(node)
-        if text:
-            tag_defs.add((text, node.start_point[0] + 1))
-
+    tag_defs = _tag_sites(root, tags_query, _DEFINITION_PREFIX)
     return tag_defs - cgr_defs, cgr_defs - tag_defs
+
+
+def crossvalidate_calls(
+    root: ASTNode, tags_query: Query, cgr_calls: set[tuple[str, int]]
+) -> tuple[set[tuple[str, int]], set[tuple[str, int]]]:
+    """Return (missed, extra) call sites as sets of (callee_name, start_line).
+
+    `cgr_calls` is the (callee name, 1-indexed line) of every call cgr resolved for
+    this file. `missed` is what tags.scm marks and cgr did not resolve; `extra` is
+    what cgr emitted and tags.scm does not mark.
+    """
+    tag_calls = _tag_sites(root, tags_query, _CALL_CAPTURE)
+    return tag_calls - cgr_calls, cgr_calls - tag_calls

--- a/codebase_rag/tests/test_tags_crossvalidation.py
+++ b/codebase_rag/tests/test_tags_crossvalidation.py
@@ -3,7 +3,7 @@
 
 from codebase_rag import constants as cs
 from codebase_rag.parser_loader import _create_tags_query, load_parsers
-from codebase_rag.parsers.tags_crossvalidate import crossvalidate
+from codebase_rag.parsers.tags_crossvalidate import crossvalidate, crossvalidate_calls
 from codebase_rag.tests.test_function_ingest import parse_code
 
 # (H) definitions sit on lines 1 (f), 4 (g), 7 (C), all 1-indexed
@@ -61,6 +61,35 @@ def test_crossvalidate_flags_cgr_over_capture() -> None:
 
     assert missed == set()
     assert extra == {("ghost", 99)}
+
+
+# (H) call sites: g@2, method@3 (attribute callee), h@4 and nested k@4
+_PY_CALLS = "def f():\n    g()\n    obj.method()\n    h(k())\n"
+
+
+def test_crossvalidate_calls_flags_missed_call() -> None:
+    parsers, _ = load_parsers()
+    root = parse_code(_PY_CALLS, cs.SupportedLanguage.PYTHON, parsers)
+
+    # (H) cgr resolved g() but dropped the obj.method() call site.
+    cgr_calls = {("g", 2), ("h", 4), ("k", 4)}
+
+    missed, extra = crossvalidate_calls(root, _tags_query(), cgr_calls)
+
+    assert missed == {("method", 3)}
+    assert extra == set()
+
+
+def test_crossvalidate_calls_parity_reports_nothing() -> None:
+    parsers, _ = load_parsers()
+    root = parse_code(_PY_CALLS, cs.SupportedLanguage.PYTHON, parsers)
+
+    cgr_calls = {("g", 2), ("method", 3), ("h", 4), ("k", 4)}
+
+    missed, extra = crossvalidate_calls(root, _tags_query(), cgr_calls)
+
+    assert missed == set()
+    assert extra == set()
 
 
 def test_tags_query_uses_community_oracle() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.308"
+version = "0.0.310"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Why

Follows #718 (community `tags.scm` as the cross-validation oracle). The community oracle also captures `@reference.call` for free, which is the relationship cross-check at the heart of #524. This adds the call-site diff alongside the existing definition diff.

## What

- `crossvalidate_calls(root, tags_query, cgr_calls)` diffs the oracle's `@reference.call` sites against cgr's resolved call sites, returning `(missed, extra)` keyed on `(callee_name, line)` — same shape as the definition check.
- Factored the shared match loop into `_tag_sites(root, query, prefix)` so the definition and call checks don't duplicate it (the definition path now iterates all `@name` captures per match instead of just the first, which is strictly more correct and leaves its behavior unchanged).

## Grounded, not invented

Expected values come from probing the real tree-sitter-python `tags.scm`: `obj.method()` captures `method@3` (the attribute, not `obj`), and nested `h(k())` yields separate `h@4` and `k@4` sites.

## Test (RED first)

- `2ee4b3c9` commits the failing test alone: it imports `crossvalidate_calls` before it exists, so collection errors (RED).
- `d946e680` adds the implementation (GREEN).

6 tests pass (4 definition + 2 call), ruff / ty / no-docs clean.

## Scope caveat

The oracle keys calls by `(name, line)`; cgr resolves calls to target nodes. So this checks "did cgr see a call at this site," not "did it resolve to the right target." That is the right first cut for a diagnostic; wiring it to a real cgr call extractor is the next piece.

Refs #524. Follows #717, #718.