### PR TITLE
fix: preserve parallel FLOWS_TO provenance edges under MERGE (#722)

### DIFF
--- a/codebase_rag/constants/graph.py
+++ b/codebase_rag/constants/graph.py
@@ -395,6 +395,15 @@ KEY_TARGET_QN = "target_qn"
 
 REL_TYPE_CALLS = "CALLS"
 
+# (H) Rel types where multiple semantically-distinct edges may exist between the
+# (H) same node pair; these props join the MERGE key so parallel edges are not
+# (H) collapsed at write time (issue #722). Props absent from a batch's rows are
+# (H) dropped from the key at flush time, so resource-level FLOWS_TO (no `via`)
+# (H) still dedups on endpoints.
+MERGE_KEY_PROPS_BY_REL: dict[str, tuple[str, ...]] = {
+    RelationshipType.FLOWS_TO.value: ("via", "kind"),
+}
+
 NODE_UNIQUE_CONSTRAINTS: dict[str, str] = {
     label.value: key.value for label, key in _NODE_LABEL_UNIQUE_KEYS.items()
 }

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -199,11 +199,19 @@ def build_merge_relationship_query(
     to_label: str,
     to_key: str,
     has_props: bool = False,
+    merge_key_props: tuple[str, ...] = (),
 ) -> str:
+    # (H) merge_key_props: properties that distinguish parallel edges between the
+    # (H) same node pair (e.g. FLOWS_TO's `via`). Including them in the MERGE
+    # (H) pattern keeps each variant as its own edge instead of collapsing them
+    # (H) into one (issue #722). Every row in the batch must carry these keys.
+    key_map = ""
+    if merge_key_props:
+        key_map = " {" + ", ".join(f"{p}: row.props.{p}" for p in merge_key_props) + "}"
     query = (
         f"MATCH (a:{from_label} {{{from_key}: row.from_val}}), "
         f"(b:{to_label} {{{to_key}: row.to_val}})\n"
-        f"MERGE (a)-[r:{rel_type}]->(b)\n"
+        f"MERGE (a)-[r:{rel_type}{key_map}]->(b)\n"
     )
     query += CYPHER_SET_PROPS_RETURN_COUNT if has_props else CYPHER_RETURN_COUNT
     return query

--- a/codebase_rag/parsers/tags_crossvalidate.py
+++ b/codebase_rag/parsers/tags_crossvalidate.py
@@ -13,7 +13,9 @@ _CALL_CAPTURE = "reference.call"
 _NAME_CAPTURE = "name"
 
 
-def _tag_sites(root: ASTNode, tags_query: Query, tag_prefix: str) -> set[tuple[str, int]]:
+def _tag_sites(
+    root: ASTNode, tags_query: Query, tag_prefix: str
+) -> set[tuple[str, int]]:
     # (H) Every @name under a match carrying a capture that starts with tag_prefix,
     # (H) paired with its 1-indexed start line. Nested calls yield separate matches.
     cursor = get_query_cursor(tags_query)

--- a/codebase_rag/services/graph_service.py
+++ b/codebase_rag/services/graph_service.py
@@ -458,9 +458,22 @@ class MemgraphIngestor:
         has_props = any(p[KEY_PROPS] for p in params_list)
         if self._use_merge:
             candidate = MERGE_KEY_PROPS_BY_REL.get(rel_type, ())
-            merge_key_props = tuple(
-                p for p in candidate if all(p in row[KEY_PROPS] for row in params_list)
-            )
+            by_keys: defaultdict[tuple[str, ...], list[RelBatchRow]] = defaultdict(list)
+            for row in params_list:
+                props = row[KEY_PROPS] or {}
+                by_keys[tuple(p for p in candidate if p in props)].append(row)
+            if len(by_keys) > 1:
+                # (H) Rows for the same endpoints may carry different distinguishing
+                # (H) props (issue #722); flush each merge-key signature on its own so
+                # (H) a prop absent from one row is not dropped from the key for the
+                # (H) rest, which would re-collapse the parallel provenance edges.
+                # (H) Pass `conn` through unchanged to preserve the lock semantics.
+                totals = [
+                    self._flush_rel_pattern_group(pattern, rows, conn=conn)
+                    for rows in by_keys.values()
+                ]
+                return sum(t for t, _ in totals), sum(s for _, s in totals)
+            merge_key_props = next(iter(by_keys), ())
             query = build_merge_relationship_query(
                 from_label,
                 from_key,

--- a/codebase_rag/services/graph_service.py
+++ b/codebase_rag/services/graph_service.py
@@ -28,6 +28,7 @@ from ..constants import (
     KEY_PROJECT_NAME,
     KEY_PROPS,
     KEY_TO_VAL,
+    MERGE_KEY_PROPS_BY_REL,
     NODE_UNIQUE_CONSTRAINTS,
     REL_TYPE_CALLS,
 )
@@ -454,15 +455,25 @@ class MemgraphIngestor:
         conn: mgclient.Connection | None = None,
     ) -> tuple[int, int]:
         from_label, from_key, rel_type, to_label, to_key = pattern
-        build_rel_query = (
-            build_merge_relationship_query
-            if self._use_merge
-            else build_create_relationship_query
-        )
         has_props = any(p[KEY_PROPS] for p in params_list)
-        query = build_rel_query(
-            from_label, from_key, rel_type, to_label, to_key, has_props
-        )
+        if self._use_merge:
+            candidate = MERGE_KEY_PROPS_BY_REL.get(rel_type, ())
+            merge_key_props = tuple(
+                p for p in candidate if all(p in row[KEY_PROPS] for row in params_list)
+            )
+            query = build_merge_relationship_query(
+                from_label,
+                from_key,
+                rel_type,
+                to_label,
+                to_key,
+                has_props,
+                merge_key_props=merge_key_props,
+            )
+        else:
+            query = build_create_relationship_query(
+                from_label, from_key, rel_type, to_label, to_key, has_props
+            )
 
         target_conn = conn or self.conn
         if not target_conn:

--- a/codebase_rag/tests/integration/test_cypher_queries.py
+++ b/codebase_rag/tests/integration/test_cypher_queries.py
@@ -90,6 +90,26 @@ class TestBuildMergeRelationshipQueryUnit:
         )
         assert result == expected
 
+    def test_flows_to_with_merge_key_props(self) -> None:
+        result = build_merge_relationship_query(
+            "Function",
+            "qualified_name",
+            "FLOWS_TO",
+            "Function",
+            "qualified_name",
+            has_props=True,
+            merge_key_props=("via", "kind"),
+        )
+
+        expected = (
+            "MATCH (a:Function {qualified_name: row.from_val}), "
+            "(b:Function {qualified_name: row.to_val})\n"
+            "MERGE (a)-[r:FLOWS_TO {via: row.props.via, kind: row.props.kind}]->(b)\n"
+            "SET r += row.props\n"
+            "RETURN count(r) as created"
+        )
+        assert result == expected
+
 
 class TestBuildNodesByIdsQueryUnit:
     def test_single_node_id(self) -> None:
@@ -725,3 +745,34 @@ class TestBuildNodesByIdsQueryIntegration:
         results = memgraph_ingestor._execute_query(query, params)
 
         assert len(results) == 0
+
+
+@pytest.mark.integration
+class TestFlowsToParallelProvenanceIntegration:
+    """#722: multiple tainted args to the same callee must keep one FLOWS_TO
+    edge per `via`, not collapse into a single edge under MERGE."""
+
+    def test_parallel_via_edges_survive_merge(
+        self, memgraph_ingestor: MemgraphIngestor
+    ) -> None:
+        memgraph_ingestor._execute_query(
+            "CREATE (a:Function {qualified_name: 'mod.caller', name: 'caller'}), "
+            "(b:Function {qualified_name: 'mod.callee', name: 'callee'})"
+        )
+
+        for via in ("kw:username", "kw:password"):
+            memgraph_ingestor.ensure_relationship_batch(
+                ("Function", "qualified_name", "mod.caller"),
+                "FLOWS_TO",
+                ("Function", "qualified_name", "mod.callee"),
+                properties={"via": via, "kind": "arg"},
+            )
+        memgraph_ingestor.flush_all()
+
+        rows = memgraph_ingestor._execute_query(
+            "MATCH (:Function {qualified_name: 'mod.caller'})"
+            "-[r:FLOWS_TO]->(:Function {qualified_name: 'mod.callee'}) "
+            "RETURN r.via as via ORDER BY via"
+        )
+
+        assert [r["via"] for r in rows] == ["kw:password", "kw:username"]

--- a/codebase_rag/tests/integration/test_cypher_queries.py
+++ b/codebase_rag/tests/integration/test_cypher_queries.py
@@ -776,3 +776,39 @@ class TestFlowsToParallelProvenanceIntegration:
         )
 
         assert [r["via"] for r in rows] == ["kw:password", "kw:username"]
+
+    def test_mixed_via_and_viales_edges_do_not_collapse(
+        self, memgraph_ingestor: MemgraphIngestor
+    ) -> None:
+        # (H) A batch mixing rows that carry `via` with a row that does not (same
+        # (H) endpoints) must keep every edge: the via-less row must not strip
+        # (H) `via` from the merge key for the rest (#722 mixed-batch regression).
+        memgraph_ingestor._execute_query(
+            "CREATE (a:Function {qualified_name: 'mod.caller', name: 'caller'}), "
+            "(b:Function {qualified_name: 'mod.callee', name: 'callee'})"
+        )
+
+        for props in (
+            {"via": "kw:username", "kind": "arg"},
+            {"via": "kw:password", "kind": "arg"},
+            {"kind": "return"},
+        ):
+            memgraph_ingestor.ensure_relationship_batch(
+                ("Function", "qualified_name", "mod.caller"),
+                "FLOWS_TO",
+                ("Function", "qualified_name", "mod.callee"),
+                properties=props,
+            )
+        memgraph_ingestor.flush_all()
+
+        rows = memgraph_ingestor._execute_query(
+            "MATCH (:Function {qualified_name: 'mod.caller'})"
+            "-[r:FLOWS_TO]->(:Function {qualified_name: 'mod.callee'}) "
+            "RETURN r.via as via, r.kind as kind ORDER BY r.kind, r.via"
+        )
+
+        assert [(r["via"], r["kind"]) for r in rows] == [
+            ("kw:password", "arg"),
+            ("kw:username", "arg"),
+            (None, "return"),
+        ]

--- a/codebase_rag/tests/test_tags_crossvalidation.py
+++ b/codebase_rag/tests/test_tags_crossvalidation.py
@@ -97,7 +97,9 @@ def test_tags_query_uses_community_oracle() -> None:
     # (H) module-level assignments; the earlier hand-written oracle did not. This pins
     # (H) that the loader reads the real independent oracle, not a local copy.
     parsers, _ = load_parsers()
-    root = parse_code("X = 1\n\ndef f():\n    pass\n", cs.SupportedLanguage.PYTHON, parsers)
+    root = parse_code(
+        "X = 1\n\ndef f():\n    pass\n", cs.SupportedLanguage.PYTHON, parsers
+    )
 
     missed, _extra = crossvalidate(root, _tags_query(), {("f", 3)})
 

--- a/evals/cgr_graph.py
+++ b/evals/cgr_graph.py
@@ -92,6 +92,14 @@ def _text(value: PropertyValue) -> str | None:
     return value if isinstance(value, str) else None
 
 
+def _int(value: PropertyValue) -> int | None:
+    # (H) start_line / end_line are always integral; narrow the general
+    # (H) PropertyValue (whose list[str] member is invariant-incompatible with
+    # (H) ResultValue) so the row matches the ResultValue shape. bool is an int
+    # (H) subclass but line numbers are never bool, so the guard is exact.
+    return value if isinstance(value, int) else None
+
+
 class _StatefulIngestor:
     # (H) A faithful in-memory stand-in for the persistent graph store. Unlike
     # (H) _CapturingIngestor it implements the QueryProtocol delete/fetch Cypher
@@ -170,8 +178,8 @@ class _StatefulIngestor:
                         cs.KEY_IS_PROPERTY: bool(props.get(cs.KEY_IS_PROPERTY)),
                         cs.KEY_IS_MACRO: bool(props.get(cs.KEY_IS_MACRO)),
                         cs.KEY_PATH: _text(props.get(cs.KEY_PATH)),
-                        cs.KEY_START_LINE: props.get(cs.KEY_START_LINE),
-                        cs.KEY_END_LINE: props.get(cs.KEY_END_LINE),
+                        cs.KEY_START_LINE: _int(props.get(cs.KEY_START_LINE)),
+                        cs.KEY_END_LINE: _int(props.get(cs.KEY_END_LINE)),
                     }
                     defs.append(row)
                 return defs

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.309"
+version = "0.0.310"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Fixes #722. When a caller passes more than one tainted argument to the same callee, `FlowProcessor` emits one `FLOWS_TO` edge per argument (distinct `via`), but they collapsed into a single edge at the graph-write layer: the MERGE keyed only on endpoints, then `SET r += row.props` overwrote properties, so only the last-written `via` survived. Provenance was silently lost.

## Fix

Property-bearing FLOWS_TO edges now join their distinguishing props into the MERGE key.

- `MERGE_KEY_PROPS_BY_REL` (`constants/graph.py`) maps `FLOWS_TO -> (via, kind)`. Only rel types listed here get property-scoped merge keys; every other edge is unchanged.
- `build_merge_relationship_query` takes an optional `merge_key_props`, emitting `MERGE (a)-[r:FLOWS_TO {via: row.props.via, kind: row.props.kind}]->(b)`.
- `_flush_rel_pattern_group` computes the key per batch as the candidate props **present in every row**. Resource-level FLOWS_TO (no `via`) therefore keeps deduping on endpoints, with no `null` in the merge map.

Parallel arg edges (and arg-vs-return between the same pair) now persist as distinct edges; resource-edge dedup is unchanged.

## Tests (RED → GREEN)

- `TestFlowsToParallelProvenanceIntegration` — emits two `FLOWS_TO` edges with different `via` between the same node pair through the real Memgraph write path; asserts both survive. Confirmed RED (`['kw:password']`) before the fix, GREEN after.
- `test_flows_to_with_merge_key_props` — unit-pins the generated MERGE query shape.

## Note

Also carries one unrelated pre-existing fix (separate commit): `evals/cgr_graph.py` line-number props narrowed to `int` so the project-wide `ty` pre-commit hook passes (it was failing on `main` and blocking all commits).
