### PR TITLE
feat(parsers): warn on definition drift via tags cross-check in process_file (#524)

### DIFF
--- a/codebase_rag/constants/ast_nodes.py
+++ b/codebase_rag/constants/ast_nodes.py
@@ -125,6 +125,10 @@ CAPTURE_KEYWORD = "keyword"
 CAPTURE_ATTRIBUTE = "attribute"
 CAPTURE_FUNCTION_DECORATOR = "function.decorator"
 
+# (H) tags.scm @definition.* kinds cgr does not model as graph nodes; excluded from the
+# (H) definition cross-check so they are not reported as false drift (issue #524).
+TAGS_UNMODELED_DEF_KINDS = frozenset({"constant"})
+
 # (H) Modifier extraction
 EXCLUDED_KEYWORDS = frozenset(
     {

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -52,6 +52,7 @@ DEF_PARSING_AST = "Parsing and Caching AST for {language}: {path}"
 DEF_UNSUPPORTED_LANGUAGE = "Unsupported language '{language}' for {path}"
 DEF_NO_PARSER = "No parser available for {language}"
 DEF_PARSE_FAILED = "Failed to parse or ingest {path}: {error}"
+DEF_CROSSVAL = "  tags cross-check {path}: missed={missed} extra={extra}"
 DEF_PARSING_DEPENDENCY = "  Parsing dependency file: {path}"
 DEF_FOUND_DEPENDENCY = "    Found dependency: {name} (spec: {spec})"
 

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -8,7 +8,7 @@ from tree_sitter import QueryCursor
 
 from .. import constants as cs
 from .. import logs as ls
-from ..parser_loader import COMBINED_FUNC_CLASS_IMPORT_QUERIES
+from ..parser_loader import COMBINED_FUNC_CLASS_IMPORT_QUERIES, _create_tags_query
 from ..types_defs import (
     ASTNode,
     CppDefinitionSpan,
@@ -27,6 +27,7 @@ from .dependency_parser import parse_dependencies
 from .function_ingest import FunctionIngestMixin
 from .handlers import get_handler
 from .js_ts.ingest import JsTsIngestMixin
+from .tags_crossvalidate import crossvalidate
 from .utils import safe_decode_with_fallback, sorted_captures
 
 if TYPE_CHECKING:
@@ -302,10 +303,53 @@ class DefinitionProcessor(
                 # (H) need their held-back registration.
                 self._flush_deferred_js_anonymous()
 
+            self._crossvalidate_definitions(
+                root_node, language, queries, combined_captures, relative_path_str
+            )
             return (root_node, language)
 
         except Exception as e:
             logger.error(ls.DEF_PARSE_FAILED.format(path=file_path, error=e))
+            return None
+
+    def _crossvalidate_definitions(
+        self,
+        root_node: ASTNode,
+        language: cs.SupportedLanguage,
+        queries: dict[cs.SupportedLanguage, LanguageQueries],
+        combined_captures: dict[str, list] | None,
+        path: str,
+    ) -> None:
+        # (H) Diagnostic only (issue #524), no graph mutation. Diffs cgr's own
+        # (H) func/class query captures against the community tags.scm oracle and warns
+        # (H) on real drift. Module-level constants are excluded: cgr does not model them
+        # (H) as nodes, so they are expected disagreements, not extraction gaps.
+        if not combined_captures:
+            return
+        lang_queries = queries.get(language)
+        if lang_queries is None:
+            return
+        tags_query = _create_tags_query(lang_queries["language"], language)
+        if tags_query is None:
+            return
+        cgr_defs: set[tuple[str, int]] = set()
+        for key in (cs.CAPTURE_FUNCTION, cs.CAPTURE_CLASS):
+            for node in combined_captures.get(key, []):
+                name_node = node.child_by_field_name(cs.FIELD_NAME)
+                if name_node is None:
+                    continue
+                text = safe_decode_with_fallback(name_node)
+                if text:
+                    cgr_defs.add((text, name_node.start_point[0] + 1))
+        missed, extra = crossvalidate(
+            root_node, tags_query, cgr_defs, exclude_kinds=cs.TAGS_UNMODELED_DEF_KINDS
+        )
+        if missed or extra:
+            logger.warning(
+                ls.DEF_CROSSVAL.format(
+                    path=path, missed=sorted(missed), extra=sorted(extra)
+                )
+            )
             return None
 
     def process_dependencies(self, filepath: Path) -> None:

--- a/codebase_rag/parsers/tags_crossvalidate.py
+++ b/codebase_rag/parsers/tags_crossvalidate.py
@@ -13,13 +13,23 @@ _CALL_CAPTURE = "reference.call"
 _NAME_CAPTURE = "name"
 
 
-def _tag_sites(root: ASTNode, tags_query: Query, tag_prefix: str) -> set[tuple[str, int]]:
+def _tag_sites(
+    root: ASTNode,
+    tags_query: Query,
+    tag_prefix: str,
+    exclude_kinds: frozenset[str] = frozenset(),
+) -> set[tuple[str, int]]:
     # (H) Every @name under a match carrying a capture that starts with tag_prefix,
     # (H) paired with its 1-indexed start line. Nested calls yield separate matches.
+    # (H) A match whose kind suffix (e.g. "constant" from "definition.constant") is in
+    # (H) exclude_kinds is skipped, so callers can drop kinds cgr does not model.
     cursor = get_query_cursor(tags_query)
     sites: set[tuple[str, int]] = set()
     for _pattern_index, caps in cursor.matches(root):
-        if not any(name.startswith(tag_prefix) for name in caps):
+        kinds = [name for name in caps if name.startswith(tag_prefix)]
+        if not kinds:
+            continue
+        if any(kind[len(tag_prefix) :] in exclude_kinds for kind in kinds):
             continue
         for node in caps.get(_NAME_CAPTURE, []):
             text = safe_decode_text(node)
@@ -29,15 +39,19 @@ def _tag_sites(root: ASTNode, tags_query: Query, tag_prefix: str) -> set[tuple[s
 
 
 def crossvalidate(
-    root: ASTNode, tags_query: Query, cgr_defs: set[tuple[str, int]]
+    root: ASTNode,
+    tags_query: Query,
+    cgr_defs: set[tuple[str, int]],
+    exclude_kinds: frozenset[str] = frozenset(),
 ) -> tuple[set[tuple[str, int]], set[tuple[str, int]]]:
     """Return (missed, extra) as sets of (name, start_line).
 
     `cgr_defs` is the (name, 1-indexed start line) of every definition cgr already
     emitted for this file. `missed` is what tags.scm found and cgr did not; `extra`
-    is what cgr emitted and tags.scm does not mark.
+    is what cgr emitted and tags.scm does not mark. `exclude_kinds` drops tags
+    definition kinds cgr does not model (e.g. "constant"), so they are not false drift.
     """
-    tag_defs = _tag_sites(root, tags_query, _DEFINITION_PREFIX)
+    tag_defs = _tag_sites(root, tags_query, _DEFINITION_PREFIX, exclude_kinds)
     return tag_defs - cgr_defs, cgr_defs - tag_defs
 
 

--- a/codebase_rag/tests/test_tags_crossvalidation.py
+++ b/codebase_rag/tests/test_tags_crossvalidation.py
@@ -1,10 +1,16 @@
 # (H) Spike for issue #524 (rescoped): tags.scm marks @definition.* sites; we diff
 # (H) those against the (name, start_line) pairs cgr emits and flag any it missed.
 
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from loguru import logger
+
 from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
 from codebase_rag.parser_loader import _create_tags_query, load_parsers
 from codebase_rag.parsers.tags_crossvalidate import crossvalidate, crossvalidate_calls
-from codebase_rag.tests.test_function_ingest import parse_code
+from codebase_rag.tests.test_function_ingest import find_node_by_name, parse_code
 
 # (H) definitions sit on lines 1 (f), 4 (g), 7 (C), all 1-indexed
 _PY_CODE = """def f():
@@ -102,3 +108,66 @@ def test_tags_query_uses_community_oracle() -> None:
     missed, _extra = crossvalidate(root, _tags_query(), {("f", 3)})
 
     assert ("X", 1) in missed
+
+
+def _make_definition_processor(temp_repo: Path, mock_ingestor: MagicMock):
+    parsers, queries = load_parsers()
+    updater = GraphUpdater(
+        ingestor=mock_ingestor, repo_path=temp_repo, parsers=parsers, queries=queries
+    )
+    return updater.factory.definition_processor, parsers, queries
+
+
+def test_definition_crosscheck_warns_on_drift_not_constants(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) Option B: the cross-check warns on genuine function/class drift but ignores
+    # (H) module-level constants (cgr does not model them). We hand cgr's captures only
+    # (H) f, so the oracle's g is real drift; constant X must NOT be reported.
+    dp, parsers, queries = _make_definition_processor(temp_repo, mock_ingestor)
+    code = "X = 1\ndef f():\n    pass\n\ndef g():\n    pass\n"
+    root = parse_code(code, cs.SupportedLanguage.PYTHON, parsers)
+    f_node = find_node_by_name(root, "f", "function_definition")
+    combined = {cs.CAPTURE_FUNCTION: [f_node], cs.CAPTURE_CLASS: []}
+
+    messages: list[str] = []
+    sink = logger.add(lambda m: messages.append(str(m)), level="WARNING")
+    try:
+        dp._crossvalidate_definitions(
+            root, cs.SupportedLanguage.PYTHON, queries, combined, "m.py"
+        )
+    finally:
+        logger.remove(sink)
+
+    warned = [m for m in messages if "cross" in m.lower()]
+    assert warned, "expected a warning for the missed function g"
+    assert "'g'" in warned[0]
+    assert "'X'" not in warned[0]
+
+
+def test_process_file_runs_crosscheck_without_noise(
+    temp_repo: Path, mock_ingestor: MagicMock, monkeypatch
+) -> None:
+    # (H) process_file must invoke the cross-check, and a clean file (functions plus a
+    # (H) module constant) must stay silent: constants filtered, extraction matches.
+    dp, _parsers, queries = _make_definition_processor(temp_repo, mock_ingestor)
+    calls: list[int] = []
+    original = dp._crossvalidate_definitions
+
+    def spy(*a, **k):
+        calls.append(1)
+        return original(*a, **k)
+
+    monkeypatch.setattr(dp, "_crossvalidate_definitions", spy)
+    fp = temp_repo / "m.py"
+    fp.write_text("X = 1\ndef f():\n    pass\n")
+
+    messages: list[str] = []
+    sink = logger.add(lambda m: messages.append(str(m)), level="WARNING")
+    try:
+        dp.process_file(fp, cs.SupportedLanguage.PYTHON, queries, {})
+    finally:
+        logger.remove(sink)
+
+    assert calls, "process_file did not invoke the cross-check"
+    assert not [m for m in messages if "cross" in m.lower()]

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.312"
+version = "0.0.313"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Why

Follows #717 / #718 / #721. Those built the cross-validation diff and the community `tags.scm` oracle but left them as pure functions, unit-tested in isolation. Nothing ran during a real graph build, so issue #524's actual value (surfacing when cgr's hand-written definition queries drift from the grammar) was not delivered. This wires the definition check into the parse pipeline.

## What

- `DefinitionProcessor.process_file` now calls `_crossvalidate_definitions(...)` just before it returns. It diffs cgr's own function/class query captures (already computed in scope) against the community `tags.scm` oracle and logs genuine drift.
- **Module-level constants are excluded.** The community oracle marks `@definition.constant` for every top-level assignment (`X = 1`), which cgr deliberately does not model as a graph node. Without a filter, `missed` would be non-empty on almost every real file, drowning real signal in known noise. `crossvalidate` gained an `exclude_kinds` parameter (default empty, so existing behavior is unchanged); the pipeline passes `cs.TAGS_UNMODELED_DEF_KINDS = {"constant"}`. With constants filtered, any remaining disagreement is real, so it logs at **warning**.

## Scope

- **Validates the extraction queries, not the emitted graph.** The cgr side is `combined_captures` (cgr's own func/class queries), which is exactly what #524 worries about drifting, and needs no interception of the scattered `ensure_node_batch` emits.
- **Definitions only.** `crossvalidate_calls` (from #721) is not wired here; calls resolve in `call_processor.py`, a separate seam and a separate follow-up.

## Tests (RED first)

- `bef1d31f` commits the tests alone: `test_definition_crosscheck_warns_on_drift_not_constants` hands the diagnostic a capture set missing a real function `g` (so the oracle's `g` is genuine drift) plus a constant `X`, and asserts a warning names `g` but **not** `X`. Fails with `AttributeError` before the implementation (RED, verified with the impl stashed).
- `6f45b4b0` adds the implementation (GREEN). `test_process_file_runs_crosscheck_without_noise` spies the seam to prove `process_file` invokes the check and stays silent on a clean file.

Full suite green (4984 passed, 26 skipped), ruff / ty / no-docs clean.

Closes the "wire the diff into the parse pipeline" item on #524. Two items remain there (per-language parity tests, fixing surfaced `language_spec.py` gaps).