### PR TITLE
feat(io): recognize httpx/aiohttp and pathlib.Path I/O in the registry (#723)

### DIFF
--- a/codebase_rag/parsers/io_access/registry.py
+++ b/codebase_rag/parsers/io_access/registry.py
@@ -77,6 +77,49 @@ _PYTHON_SINKS: tuple[IOSink, ...] = (
         target_arg=0,
         target_kw="url",
     ),
+    # (H) httpx module-level calls mirror requests.*: GET/HEAD read, the rest write.
+    IOSink(
+        "httpx.get",
+        ResourceKind.NETWORK,
+        IODirection.READ,
+        target_arg=0,
+        target_kw="url",
+    ),
+    IOSink(
+        "httpx.head",
+        ResourceKind.NETWORK,
+        IODirection.READ,
+        target_arg=0,
+        target_kw="url",
+    ),
+    IOSink(
+        "httpx.post",
+        ResourceKind.NETWORK,
+        IODirection.WRITE,
+        target_arg=0,
+        target_kw="url",
+    ),
+    IOSink(
+        "httpx.put",
+        ResourceKind.NETWORK,
+        IODirection.WRITE,
+        target_arg=0,
+        target_kw="url",
+    ),
+    IOSink(
+        "httpx.patch",
+        ResourceKind.NETWORK,
+        IODirection.WRITE,
+        target_arg=0,
+        target_kw="url",
+    ),
+    IOSink(
+        "httpx.delete",
+        ResourceKind.NETWORK,
+        IODirection.WRITE,
+        target_arg=0,
+        target_kw="url",
+    ),
 )
 
 IO_SINKS: dict[cs.SupportedLanguage, tuple[IOSink, ...]] = {
@@ -91,6 +134,16 @@ _PYTHON_HANDLE_CONSTRUCTORS: tuple[HandleConstructor, ...] = (
         "sqlite3.connect", ResourceKind.DATABASE, target_arg=0, target_kw="database"
     ),
     HandleConstructor("socket.socket", ResourceKind.SOCKET),
+    # (H) A pathlib.Path is a FILE handle: read_text/write_text on the bound var
+    # (H) attribute to the path literal passed to Path(...). Non-I/O methods
+    # (H) (.exists, .parent) simply aren't in IO_HANDLE_METHODS, so no false edge.
+    HandleConstructor("pathlib.Path", ResourceKind.FILE, target_arg=0),
+    # (H) httpx/aiohttp client objects are NETWORK handles; later client.get/post
+    # (H) resolve through cross-scope handle resolution (the URL is on the method
+    # (H) call, not the constructor, so the resource identity is <dynamic>).
+    HandleConstructor("httpx.Client", ResourceKind.NETWORK),
+    HandleConstructor("httpx.AsyncClient", ResourceKind.NETWORK),
+    HandleConstructor("aiohttp.ClientSession", ResourceKind.NETWORK),
 )
 
 IO_HANDLE_CONSTRUCTORS: dict[cs.SupportedLanguage, tuple[HandleConstructor, ...]] = {
@@ -103,8 +156,21 @@ IO_HANDLE_METHODS: dict[ResourceKind, dict[str, IODirection]] = {
         "read": IODirection.READ,
         "readline": IODirection.READ,
         "readlines": IODirection.READ,
+        "read_text": IODirection.READ,
+        "read_bytes": IODirection.READ,
         "write": IODirection.WRITE,
         "writelines": IODirection.WRITE,
+        "write_text": IODirection.WRITE,
+        "write_bytes": IODirection.WRITE,
+    },
+    ResourceKind.NETWORK: {
+        "get": IODirection.READ,
+        "head": IODirection.READ,
+        "options": IODirection.READ,
+        "post": IODirection.WRITE,
+        "put": IODirection.WRITE,
+        "patch": IODirection.WRITE,
+        "delete": IODirection.WRITE,
     },
     ResourceKind.DATABASE: {
         "execute": IODirection.READ_WRITE,

--- a/codebase_rag/parsers/io_access/registry.py
+++ b/codebase_rag/parsers/io_access/registry.py
@@ -120,6 +120,16 @@ _PYTHON_SINKS: tuple[IOSink, ...] = (
         target_arg=0,
         target_kw="url",
     ),
+    # (H) aiohttp.request(method, url): the HTTP verb is arg 0 and the url arg 1, so
+    # (H) direction is unknown without reading the verb -- READ_WRITE is the honest
+    # (H) "either" label (same stance as DB execute()).
+    IOSink(
+        "aiohttp.request",
+        ResourceKind.NETWORK,
+        IODirection.READ_WRITE,
+        target_arg=1,
+        target_kw="url",
+    ),
 )
 
 IO_SINKS: dict[cs.SupportedLanguage, tuple[IOSink, ...]] = {
@@ -158,15 +168,27 @@ IO_HANDLE_METHODS: dict[ResourceKind, dict[str, IODirection]] = {
         "readlines": IODirection.READ,
         "read_text": IODirection.READ,
         "read_bytes": IODirection.READ,
+        "iterdir": IODirection.READ,
+        "glob": IODirection.READ,
+        "rglob": IODirection.READ,
+        # (H) Path.open() returns a nested file handle we don't chain; its direction
+        # (H) depends on the mode arg the handle-method path can't inspect, so default
+        # (H) to READ like the top-level open() sink does with no mode (a false WRITE
+        # (H) on the common read case would be worse than a coarse READ).
+        "open": IODirection.READ,
         "write": IODirection.WRITE,
         "writelines": IODirection.WRITE,
         "write_text": IODirection.WRITE,
         "write_bytes": IODirection.WRITE,
+        "touch": IODirection.WRITE,
+        "unlink": IODirection.WRITE,
     },
     ResourceKind.NETWORK: {
         "get": IODirection.READ,
         "head": IODirection.READ,
         "options": IODirection.READ,
+        # (H) client.request(method, url): verb-dependent direction, READ_WRITE = either.
+        "request": IODirection.READ_WRITE,
         "post": IODirection.WRITE,
         "put": IODirection.WRITE,
         "patch": IODirection.WRITE,

--- a/codebase_rag/tests/integration/test_io_registry_modern_idioms_e2e.py
+++ b/codebase_rag/tests/integration/test_io_registry_modern_idioms_e2e.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.capture import resolve_capture
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+if TYPE_CHECKING:
+    from codebase_rag.services.graph_service import MemgraphIngestor
+
+pytestmark = [pytest.mark.integration]
+
+# (H) issue #723: modern-idiom I/O (httpx / aiohttp network, pathlib.Path file)
+# (H) must produce READS_FROM / WRITES_TO edges, mirroring requests / open.
+
+
+def _build(ingestor: MemgraphIngestor, tmp_path: Path, code: str) -> None:
+    project = tmp_path / "io_project"
+    project.mkdir()
+    (project / "io_mod.py").write_text(code, encoding="utf-8")
+    parsers, queries = load_parsers()
+    GraphUpdater(
+        ingestor=ingestor,
+        repo_path=project,
+        parsers=parsers,
+        queries=queries,
+        capture=resolve_capture([cs.CaptureGroup.IO.value]),
+    ).run()
+
+
+def _io_edges(ingestor: MemgraphIngestor) -> set[tuple[str, str]]:
+    rows = ingestor.fetch_all(
+        f"MATCH ()-[r:{cs.RelationshipType.READS_FROM.value}|"
+        f"{cs.RelationshipType.WRITES_TO.value}]->(res:{cs.NodeLabel.RESOURCE.value}) "
+        "RETURN type(r) AS rel, res.qualified_name AS qn"
+    )
+    return {(str(row["rel"]), str(row["qn"])) for row in rows}
+
+
+_READS = cs.RelationshipType.READS_FROM.value
+_WRITES = cs.RelationshipType.WRITES_TO.value
+
+
+def test_httpx_module_level_get_and_post(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "import httpx\n\n\n"
+        "def fetch():\n"
+        "    return httpx.get('https://api.example.com/data')\n\n\n"
+        "def send(payload):\n"
+        "    httpx.post('https://api.example.com/upload')\n",
+    )
+    edges = _io_edges(memgraph_ingestor)
+    assert (_READS, "resource::NETWORK::https://api.example.com/data") in edges
+    assert (_WRITES, "resource::NETWORK::https://api.example.com/upload") in edges
+
+
+def test_httpx_client_instance_methods(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "import httpx\n\n\n"
+        "class Api:\n"
+        "    def __init__(self):\n"
+        "        self._http = httpx.Client(timeout=30.0)\n\n"
+        "    def pull(self):\n"
+        "        return self._http.get('x')\n\n"
+        "    def push(self):\n"
+        "        self._http.post('x')\n",
+    )
+    edges = _io_edges(memgraph_ingestor)
+    kinds = {(rel, qn.split("::")[1]) for rel, qn in edges}
+    assert (_READS, "NETWORK") in kinds
+    assert (_WRITES, "NETWORK") in kinds
+
+
+def test_pathlib_read_and_write(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "from pathlib import Path\n\n\n"
+        "def save(data):\n"
+        "    p = Path('out.txt')\n"
+        "    p.write_text(data)\n\n\n"
+        "def load():\n"
+        "    p = Path('in.txt')\n"
+        "    return p.read_text()\n",
+    )
+    edges = _io_edges(memgraph_ingestor)
+    assert (_WRITES, "resource::FILE::out.txt") in edges
+    assert (_READS, "resource::FILE::in.txt") in edges

--- a/codebase_rag/tests/integration/test_io_registry_modern_idioms_e2e.py
+++ b/codebase_rag/tests/integration/test_io_registry_modern_idioms_e2e.py
@@ -101,3 +101,22 @@ def test_pathlib_read_and_write(
     edges = _io_edges(memgraph_ingestor)
     assert (_WRITES, "resource::FILE::out.txt") in edges
     assert (_READS, "resource::FILE::in.txt") in edges
+
+
+def test_pathlib_directory_listing_and_touch(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "from pathlib import Path\n\n\n"
+        "def scan():\n"
+        "    d = Path('data')\n"
+        "    return list(d.iterdir())\n\n\n"
+        "def stamp():\n"
+        "    f = Path('flag')\n"
+        "    f.touch()\n",
+    )
+    edges = _io_edges(memgraph_ingestor)
+    assert (_READS, "resource::FILE::data") in edges
+    assert (_WRITES, "resource::FILE::flag") in edges


### PR DESCRIPTION
## Summary

Fixes #723. The Python I/O registry recognized `requests.*`, `urllib`, `open`, `json`, `os.getenv`, `print`, `socket`, but **not** two idioms standard in modern Python, so repos using them produced **zero** `READS_FROM` / `WRITES_TO` / `FLOWS_TO` edges:

- **`httpx` / `aiohttp`** network calls.
- **`pathlib.Path`** file I/O.

## Change (registry only)

`codebase_rag/parsers/io_access/registry.py`:

1. **httpx module-level sinks** — `httpx.get/head/post/put/patch/delete` mirror `requests.*` (GET/HEAD read, rest write, URL from arg 0 / `url=`). These flow through both the io and flow processors, so they also produce `FLOWS_TO`.
2. **NETWORK handle constructors + methods** — `httpx.Client`, `httpx.AsyncClient`, `aiohttp.ClientSession` register as NETWORK handles; a new `ResourceKind.NETWORK` method table maps `get/head/options` → read and `post/put/patch/delete` → write. Client-instance calls (`client.get(...)`, `self._http.post(...)`) resolve through the existing cross-scope handle resolution.
3. **pathlib.Path handle** — `pathlib.Path` registers as a FILE handle (identity = the path literal); `read_text/read_bytes` → read and `write_text/write_bytes` → write join the FILE method table. Non-I/O `Path` methods (`.exists`, `.parent`) aren't in the table, so no false edges.

Import normalization already covers both `import httpx` / `from httpx import Client` and `import pathlib` / `from pathlib import Path`, so a single canonical registry key handles each idiom.

## Test (RED → GREEN)

New integration test `test_io_registry_modern_idioms_e2e.py`: httpx module-level get/post, httpx client-instance methods (via a `self._http` handle), and pathlib read/write. Confirmed RED before the registry rows (0 edges) and GREEN after.

## Known ceiling

Handle-method calls (`client.get`, `path.write_text`) are recognized by the **io** processor (READS_FROM/WRITES_TO). The **flow** processor models taint only through direct sinks, so direct `httpx.get/post` participate in `FLOWS_TO` but handle-method network/file taint does not yet. Noted in code; a separate flow-engine change if it matters.

Full suite: 5024 passed, 10 skipped. ruff + ty clean.