### PR TITLE
feat(io): READS_FROM/WRITES_TO for JavaScript/TypeScript I/O sinks (#714)

### DIFF
--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -169,6 +169,8 @@ JS_ASSIGNMENT_FUNCTION_QUERY = """
 
 # (H) JS/TS module system node types
 TS_OBJECT_PATTERN = "object_pattern"
+TS_ARRAY_PATTERN = "array_pattern"
+TS_REST_PATTERN = "rest_pattern"
 TS_SHORTHAND_PROPERTY_IDENTIFIER_PATTERN = "shorthand_property_identifier_pattern"
 TS_PAIR_PATTERN = "pair_pattern"
 TS_FUNCTION_DECLARATION = "function_declaration"

--- a/codebase_rag/constants/ast_nodes.py
+++ b/codebase_rag/constants/ast_nodes.py
@@ -167,6 +167,9 @@ TS_STRING = "string"
 # (H) JS/TS string literals hold their text in a string_fragment child (the
 # (H) counterpart of Python's string_content), used for I/O target extraction.
 TS_STRING_FRAGMENT = "string_fragment"
+# (H) Modern Node builtin imports carry a node: scheme (`import fs from 'node:fs'`);
+# (H) stripped when checking whether an imported name is the genuine builtin module.
+NODE_BUILTIN_PREFIX = "node:"
 TS_IMPORT_CLAUSE = "import_clause"
 TS_LEXICAL_DECLARATION = "lexical_declaration"
 TS_VARIABLE_DECLARATION = "variable_declaration"

--- a/codebase_rag/constants/ast_nodes.py
+++ b/codebase_rag/constants/ast_nodes.py
@@ -164,6 +164,9 @@ TS_WILDCARD_IMPORT = "wildcard_import"
 
 # (H) Tree-sitter JS/TS import node types
 TS_STRING = "string"
+# (H) JS/TS string literals hold their text in a string_fragment child (the
+# (H) counterpart of Python's string_content), used for I/O target extraction.
+TS_STRING_FRAGMENT = "string_fragment"
 TS_IMPORT_CLAUSE = "import_clause"
 TS_LEXICAL_DECLARATION = "lexical_declaration"
 TS_VARIABLE_DECLARATION = "variable_declaration"

--- a/codebase_rag/parsers/io_access/descriptor.py
+++ b/codebase_rag/parsers/io_access/descriptor.py
@@ -26,6 +26,9 @@ class LanguageDescriptor:
     identifier_type: str
     declarator_type: str
     params_field: str
+    # (H) A nested block introduces a new lexical scope: const/let declared inside
+    # (H) it do not shadow the enclosing scope, so declarator collection stops here.
+    block_scope_type: str
 
 
 _JS_TS_DESCRIPTOR = LanguageDescriptor(
@@ -45,6 +48,7 @@ _JS_TS_DESCRIPTOR = LanguageDescriptor(
     identifier_type=cs.TS_PY_IDENTIFIER,
     declarator_type=cs.TS_VARIABLE_DECLARATOR,
     params_field=cs.TS_FIELD_PARAMETERS,
+    block_scope_type=cs.TS_STATEMENT_BLOCK,
 )
 
 # (H) Non-Python languages with a direct-sink descriptor. Python keeps its own

--- a/codebase_rag/parsers/io_access/descriptor.py
+++ b/codebase_rag/parsers/io_access/descriptor.py
@@ -21,6 +21,11 @@ class LanguageDescriptor:
     # (H) Nested definitions whose body is a separate caller: the walk prunes them
     # (H) so a nested function's I/O is not credited to the enclosing one.
     nested_scope_types: frozenset[str]
+    # (H) Local-binding detection so a name declared in the caller scope (a local
+    # (H) `const fs`, `function fetch`, or a parameter) shadows the builtin sink.
+    identifier_type: str
+    declarator_type: str
+    params_field: str
 
 
 _JS_TS_DESCRIPTOR = LanguageDescriptor(
@@ -37,6 +42,9 @@ _JS_TS_DESCRIPTOR = LanguageDescriptor(
             cs.TS_METHOD_DEFINITION,
         }
     ),
+    identifier_type=cs.TS_PY_IDENTIFIER,
+    declarator_type=cs.TS_VARIABLE_DECLARATOR,
+    params_field=cs.TS_FIELD_PARAMETERS,
 )
 
 # (H) Non-Python languages with a direct-sink descriptor. Python keeps its own

--- a/codebase_rag/parsers/io_access/descriptor.py
+++ b/codebase_rag/parsers/io_access/descriptor.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ... import constants as cs
+
+
+@dataclass(frozen=True)
+class LanguageDescriptor:
+    # (H) Per-language tree-sitter node types the I/O walk needs. Field names
+    # (H) (function/arguments/body) are shared across grammars, so only the node
+    # (H) types that actually differ from Python are captured here. Lets the
+    # (H) direct-sink walk (issue 714) run on non-Python languages without a
+    # (H) Python-specific rewrite.
+    call_type: str
+    string_type: str
+    string_content_type: str
+    # (H) None where the grammar has no keyword-argument node (JS/TS pass an
+    # (H) options object instead), so every positional arg counts.
+    keyword_arg_type: str | None
+    # (H) Nested definitions whose body is a separate caller: the walk prunes them
+    # (H) so a nested function's I/O is not credited to the enclosing one.
+    nested_scope_types: frozenset[str]
+
+
+_JS_TS_DESCRIPTOR = LanguageDescriptor(
+    call_type=cs.TS_CALL_EXPRESSION,
+    string_type=cs.TS_STRING,
+    string_content_type=cs.TS_STRING_FRAGMENT,
+    keyword_arg_type=None,
+    nested_scope_types=frozenset(
+        {
+            cs.TS_FUNCTION_DECLARATION,
+            cs.TS_GENERATOR_FUNCTION_DECLARATION,
+            cs.TS_FUNCTION_EXPRESSION,
+            cs.TS_ARROW_FUNCTION,
+            cs.TS_METHOD_DEFINITION,
+        }
+    ),
+)
+
+# (H) Non-Python languages with a direct-sink descriptor. Python keeps its own
+# (H) handle-aware walk; each new language lands one entry (plus registry rows).
+LANGUAGE_DESCRIPTORS: dict[cs.SupportedLanguage, LanguageDescriptor] = {
+    cs.SupportedLanguage.JS: _JS_TS_DESCRIPTOR,
+    cs.SupportedLanguage.TS: _JS_TS_DESCRIPTOR,
+    cs.SupportedLanguage.TSX: _JS_TS_DESCRIPTOR,
+}

--- a/codebase_rag/parsers/io_access/extract.py
+++ b/codebase_rag/parsers/io_access/extract.py
@@ -96,11 +96,15 @@ def registry_match[T](
     return None
 
 
-def string_literal(arg: Node | None) -> str:
-    if arg is None or arg.type != cs.TS_PY_STRING:
+def string_literal(
+    arg: Node | None,
+    string_type: str = cs.TS_PY_STRING,
+    content_type: str = cs.TS_PY_STRING_CONTENT,
+) -> str:
+    if arg is None or arg.type != string_type:
         return DYNAMIC_TARGET
     for child in arg.named_children:
-        if child.type == cs.TS_PY_STRING_CONTENT and child.text is not None:
+        if child.type == content_type and child.text is not None:
             return child.text.decode(cs.ENCODING_UTF8)
     return DYNAMIC_TARGET
 
@@ -117,16 +121,24 @@ def keyword_value(args: Node, keyword: str) -> Node | None:
 
 
 def literal_target(
-    call_node: Node, arg_index: int | None, arg_keyword: str | None = None
+    call_node: Node,
+    arg_index: int | None,
+    arg_keyword: str | None = None,
+    *,
+    string_type: str = cs.TS_PY_STRING,
+    content_type: str = cs.TS_PY_STRING_CONTENT,
+    keyword_arg_type: str | None = cs.TS_PY_KEYWORD_ARGUMENT,
 ) -> str:
     if arg_index is None and arg_keyword is None:
         return DYNAMIC_TARGET
     args = call_node.child_by_field_name(cs.TS_FIELD_ARGUMENTS)
     if args is None:
         return DYNAMIC_TARGET
-    positional = [c for c in args.named_children if c.type != cs.TS_PY_KEYWORD_ARGUMENT]
+    positional = [c for c in args.named_children if c.type != keyword_arg_type]
     if arg_index is not None and arg_index < len(positional):
-        return string_literal(positional[arg_index])
+        return string_literal(positional[arg_index], string_type, content_type)
     if arg_keyword is not None:
-        return string_literal(keyword_value(args, arg_keyword))
+        return string_literal(
+            keyword_value(args, arg_keyword), string_type, content_type
+        )
     return DYNAMIC_TARGET

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -267,7 +267,7 @@ class IOAccessProcessor:
         # (H) the module root (top-level calls) has no body field, so seed from its
         # (H) own children instead. named_children skips anonymous punctuation, which
         # (H) JS/TS grammars produce in bulk.
-        local_names = self._local_bindings(caller_node, descriptor)
+        local_names = self._local_bindings(caller_node, descriptor, import_map)
         body = caller_node.child_by_field_name(cs.FIELD_BODY)
         seed = body if body is not None else caller_node
         stack = list(seed.named_children)
@@ -286,13 +286,18 @@ class IOAccessProcessor:
             stack.extend(node.named_children)
 
     def _local_bindings(
-        self, caller_node: Node, descriptor: LanguageDescriptor
+        self,
+        caller_node: Node,
+        descriptor: LanguageDescriptor,
+        import_map: dict[str, str],
     ) -> frozenset[str]:
         # (H) Names bound in the caller's OWN scope, which shadow a same-named
         # (H) builtin sink: the caller's parameters, plus every local `const/let/var`
         # (H) declarator and hoisted `function` declaration in the body (nested
-        # (H) scopes pruned -- their locals are their own). No import entry exists
-        # (H) for these, so without this a local `fetch`/`fs` would match the sink.
+        # (H) scopes pruned -- their locals are their own). Names that are import
+        # (H) aliases (e.g. `const fs = require('fs')`, recorded in import_map) are
+        # (H) NOT shadows -- they are the genuine module, handled by the import
+        # (H) branch of _is_shadowed -- so they are excluded from the result.
         names: set[str] = set()
         params = caller_node.child_by_field_name(descriptor.params_field)
         if params is not None:
@@ -315,7 +320,7 @@ class IOAccessProcessor:
             ):
                 names.add(name)
             stack.extend(node.named_children)
-        return frozenset(names)
+        return frozenset(names - import_map.keys())
 
     @staticmethod
     def _named_child_text(node: Node, descriptor: LanguageDescriptor) -> str | None:

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -261,62 +261,77 @@ class IOAccessProcessor:
         sink_by_name: dict[str, IOSink],
         descriptor: LanguageDescriptor,
     ) -> None:
-        # (H) Lean non-Python walk (issue #714): DFS the caller body for call sinks,
-        # (H) pruning nested definitions (their body is a separate caller) so I/O is
-        # (H) credited to the scope that runs it. No handle/stream tracking yet.
-        # (H) A function/method caller exposes its statements under the `body` field;
-        # (H) the module root (top-level calls) has no body field, so seed from its
-        # (H) own children instead. named_children skips anonymous punctuation, which
-        # (H) JS/TS grammars produce in bulk.
-        local_names = self._local_bindings(caller_node, descriptor, import_map)
-        body = caller_node.child_by_field_name(cs.FIELD_BODY)
-        seed = body if body is not None else caller_node
-        stack = list(seed.named_children)
+        # (H) Lean non-Python walk (issue #714): find call sinks in the caller body,
+        # (H) crediting I/O to the scope that runs it. No handle/stream tracking yet.
+        # (H) The walk is lexically scope-aware so a same-named local (`const fs`,
+        # (H) `function fetch`, a parameter) shadows the builtin ONLY where it is in
+        # (H) scope: block-scoped const/let shadow inside their own block and nested
+        # (H) blocks, never a sibling/outer use. A function/method caller exposes its
+        # (H) statements under the `body` field; the module root (top-level calls) has
+        # (H) no body field, so seed from its own children.
+        seed = caller_node.child_by_field_name(cs.FIELD_BODY) or caller_node
+        # (H) Parameters are visible in every block of the function body. Import
+        # (H) aliases (`const fs = require('fs')`) are the genuine module, resolved by
+        # (H) the import branch of _resolve_sink, so they never count as shadows.
+        params = self._param_names(caller_node, descriptor) - import_map.keys()
+        self._walk_scope(
+            seed,
+            frozenset(params),
+            caller_spec,
+            import_map,
+            sink_by_name,
+            descriptor,
+        )
+
+    def _walk_scope(
+        self,
+        block_node: Node,
+        inherited: frozenset[str],
+        caller_spec: tuple[str, str, str],
+        import_map: dict[str, str],
+        sink_by_name: dict[str, IOSink],
+        descriptor: LanguageDescriptor,
+    ) -> None:
+        # (H) Names in scope for calls in THIS block: the enclosing scopes' names plus
+        # (H) this block's own const/let/function declarations (import aliases removed).
+        in_scope = (
+            inherited | self._block_declarations(block_node, descriptor)
+        ) - import_map.keys()
+        stack = list(block_node.named_children)
         while stack:
             node = stack.pop()
-            # (H) Nested defs are their own caller; skip entirely. JS default args and
-            # (H) decorators evaluate at call time in the nested scope (unlike Python's
-            # (H) definition-time headers), so crediting them here would be a false
-            # (H) positive -- full pruning is correct for these grammars.
+            # (H) Nested function/method: its own caller, walked separately.
             if node.type in descriptor.nested_scope_types:
+                continue
+            # (H) A nested { } is a child lexical scope: recurse with this block's
+            # (H) names inherited, so its declarations shadow only inside it.
+            if node.type == descriptor.block_scope_type:
+                self._walk_scope(
+                    node, in_scope, caller_spec, import_map, sink_by_name, descriptor
+                )
                 continue
             if node.type == descriptor.call_type:
                 self._emit_direct_call(
-                    node, caller_spec, import_map, sink_by_name, descriptor, local_names
+                    node, caller_spec, import_map, sink_by_name, descriptor, in_scope
                 )
             stack.extend(node.named_children)
 
-    def _local_bindings(
-        self,
-        caller_node: Node,
-        descriptor: LanguageDescriptor,
-        import_map: dict[str, str],
-    ) -> frozenset[str]:
-        # (H) Names bound in the caller's OWN scope, which shadow a same-named
-        # (H) builtin sink: the caller's parameters, plus every local `const/let/var`
-        # (H) declarator and hoisted `function` declaration in the body (nested
-        # (H) scopes pruned -- their locals are their own). Names that are import
-        # (H) aliases (e.g. `const fs = require('fs')`, recorded in import_map) are
-        # (H) NOT shadows -- they are the genuine module, handled by the import
-        # (H) branch of _is_shadowed -- so they are excluded from the result.
+    def _block_declarations(
+        self, block_node: Node, descriptor: LanguageDescriptor
+    ) -> set[str]:
+        # (H) Names declared directly in this block: const/let/var declarators and
+        # (H) hoisted `function` declarations. Nested blocks and nested functions are
+        # (H) their own scopes and are not descended into (their locals are theirs).
+        # (H) ponytail: `var` is really function-scoped, but a var redefining a
+        # (H) builtin name is rare enough to treat block-locally.
         names: set[str] = set()
-        params = caller_node.child_by_field_name(descriptor.params_field)
-        if params is not None:
-            for child in params.named_children:
-                if (name := self._binding_identifier(child, descriptor)) is not None:
-                    names.add(name)
-        body = caller_node.child_by_field_name(cs.FIELD_BODY)
-        stack = list((body or caller_node).named_children)
+        stack = list(block_node.named_children)
         while stack:
             node = stack.pop()
             if node.type in descriptor.nested_scope_types:
-                # (H) A hoisted `function foo` binds `foo` in THIS scope; record its
-                # (H) name but do not descend into its body.
                 if (name := self._named_child_text(node, descriptor)) is not None:
                     names.add(name)
                 continue
-            # (H) A nested { } block is its own lexical scope: const/let declared
-            # (H) inside it do not shadow this scope, so stop descending there.
             if node.type == descriptor.block_scope_type:
                 continue
             if (
@@ -325,7 +340,18 @@ class IOAccessProcessor:
             ):
                 names.add(name)
             stack.extend(node.named_children)
-        return frozenset(names - import_map.keys())
+        return names
+
+    def _param_names(
+        self, caller_node: Node, descriptor: LanguageDescriptor
+    ) -> set[str]:
+        names: set[str] = set()
+        params = caller_node.child_by_field_name(descriptor.params_field)
+        if params is not None:
+            for child in params.named_children:
+                if (name := self._binding_identifier(child, descriptor)) is not None:
+                    names.add(name)
+        return names
 
     @staticmethod
     def _named_child_text(node: Node, descriptor: LanguageDescriptor) -> str | None:

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -379,7 +379,14 @@ class IOAccessProcessor:
         if not sep:
             return False
         base = import_map.get(head)
-        return base is not None and base.split(cs.SEPARATOR_DOT)[0] != head
+        if base is None:
+            return False
+        # (H) `import fs from 'node:fs'` is a genuine builtin; strip the node: prefix
+        # (H) so the modern form is not mistaken for a shadowing local module.
+        base_module = base.split(cs.SEPARATOR_DOT)[0].removeprefix(
+            cs.NODE_BUILTIN_PREFIX
+        )
+        return base_module != head
 
     def _emit_call(
         self,

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -293,7 +293,7 @@ class IOAccessProcessor:
         descriptor: LanguageDescriptor,
     ) -> None:
         raw = call_name(node)
-        if raw is None:
+        if raw is None or self._head_is_shadowed(raw, import_map):
             return
         sink = registry_match(sink_by_name, raw, import_map)
         if sink is None:
@@ -307,6 +307,19 @@ class IOAccessProcessor:
             keyword_arg_type=descriptor.keyword_arg_type,
         )
         self._emit(caller_spec, sink.direction, sink.kind, identity)
+
+    @staticmethod
+    def _head_is_shadowed(raw: str, import_map: dict[str, str]) -> bool:
+        # (H) A dotted sink like `fs.writeFileSync` is only real I/O when `fs` is the
+        # (H) genuine module. A real builtin import maps the head to itself (`fs` /
+        # (H) `fs.default`), but importing `fs` from a LOCAL module maps it to a
+        # (H) project-qualified base, so the raw-dotted registry fallback must not
+        # (H) fire. A bare or unimported head is trusted (issue #714 precision).
+        head, sep, _ = raw.partition(cs.SEPARATOR_DOT)
+        if not sep:
+            return False
+        base = import_map.get(head)
+        return base is not None and base.split(cs.SEPARATOR_DOT)[0] != head
 
     def _emit_call(
         self,

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -382,12 +382,16 @@ class IOAccessProcessor:
     def _param_names(
         self, caller_node: Node, descriptor: LanguageDescriptor
     ) -> set[str]:
+        # (H) Parameter names bound in the whole function body. A param is a bare
+        # (H) identifier, a destructuring pattern (`function f({ http }) {}`), or a
+        # (H) TS `required_parameter` wrapper whose `pattern` field holds either --
+        # (H) all handled by _pattern_names, unwrapping the TS wrapper first.
         names: set[str] = set()
         params = caller_node.child_by_field_name(descriptor.params_field)
         if params is not None:
             for child in params.named_children:
-                if (name := self._binding_identifier(child, descriptor)) is not None:
-                    names.add(name)
+                target = child.child_by_field_name(cs.TS_FIELD_PATTERN) or child
+                self._pattern_names(target, descriptor, names)
         return names
 
     @staticmethod
@@ -395,21 +399,6 @@ class IOAccessProcessor:
         name = node.child_by_field_name(cs.TS_FIELD_NAME)
         if name is not None and name.type == descriptor.identifier_type and name.text:
             return name.text.decode(cs.ENCODING_UTF8)
-        return None
-
-    @staticmethod
-    def _binding_identifier(node: Node, descriptor: LanguageDescriptor) -> str | None:
-        # (H) A parameter is either a bare identifier or a typed/patterned wrapper
-        # (H) whose `pattern` field holds the identifier (TS required_parameter).
-        if node.type == descriptor.identifier_type and node.text:
-            return node.text.decode(cs.ENCODING_UTF8)
-        pattern = node.child_by_field_name(cs.TS_FIELD_PATTERN)
-        if (
-            pattern is not None
-            and pattern.type == descriptor.identifier_type
-            and pattern.text
-        ):
-            return pattern.text.decode(cs.ENCODING_UTF8)
         return None
 
     def _emit_direct_call(

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -16,6 +16,7 @@ from .constants import (
     IODirection,
     ResourceKind,
 )
+from .descriptor import LANGUAGE_DESCRIPTORS, LanguageDescriptor
 from .extract import (
     call_name,
     definition_header_nodes,
@@ -59,16 +60,22 @@ class IOAccessProcessor:
     ) -> None:
         if not self._enabled:
             return
-        # (H) ponytail: Python-only in phase 1; other languages need their own
-        # (H) node types, add when their IO_SINKS tables land.
-        if language != cs.SupportedLanguage.PYTHON:
-            return
         sinks = IO_SINKS.get(language, ())
         constructors = IO_HANDLE_CONSTRUCTORS.get(language, ())
         if not sinks and not constructors:
             return
         import_map = self._import_processor.import_mapping.get(module_qn, {})
         sink_by_name = {s.callee: s for s in sinks}
+        # (H) Non-Python languages take a lean direct-sink walk (issue #714): match
+        # (H) call sinks and emit, without Python's handle/scope machinery (streams
+        # (H) and data-flow are a follow-up). Python keeps the full handle-aware walk.
+        if language != cs.SupportedLanguage.PYTHON:
+            descriptor = LANGUAGE_DESCRIPTORS.get(language)
+            if descriptor is not None:
+                self._emit_direct_sinks(
+                    caller_node, caller_spec, import_map, sink_by_name, descriptor
+                )
+            return
         ctor_by_name = {c.callee: c for c in constructors}
 
         # (H) Single forward pre-order DFS: bindings and accesses interleave in
@@ -244,6 +251,55 @@ class IOAccessProcessor:
             if bound is not None and bound[0].startswith(cs.PY_SELF_PREFIX):
                 handles.setdefault(bound[0], bound[1])
             stack.extend(node.children)
+
+    def _emit_direct_sinks(
+        self,
+        caller_node: Node,
+        caller_spec: tuple[str, str, str],
+        import_map: dict[str, str],
+        sink_by_name: dict[str, IOSink],
+        descriptor: LanguageDescriptor,
+    ) -> None:
+        # (H) Lean non-Python walk (issue #714): DFS the caller body for call sinks,
+        # (H) pruning nested definitions (their body is a separate caller) so I/O is
+        # (H) credited to the scope that runs it. No handle/stream tracking yet.
+        body = caller_node.child_by_field_name(cs.FIELD_BODY)
+        if body is None:
+            return
+        stack = list(body.named_children)
+        while stack:
+            node = stack.pop()
+            if node.type in descriptor.nested_scope_types:
+                continue
+            if node.type == descriptor.call_type:
+                self._emit_direct_call(
+                    node, caller_spec, import_map, sink_by_name, descriptor
+                )
+            stack.extend(node.children)
+
+    def _emit_direct_call(
+        self,
+        node: Node,
+        caller_spec: tuple[str, str, str],
+        import_map: dict[str, str],
+        sink_by_name: dict[str, IOSink],
+        descriptor: LanguageDescriptor,
+    ) -> None:
+        raw = call_name(node)
+        if raw is None:
+            return
+        sink = registry_match(sink_by_name, raw, import_map)
+        if sink is None:
+            return
+        identity = literal_target(
+            node,
+            sink.target_arg,
+            sink.target_kw,
+            string_type=descriptor.string_type,
+            content_type=descriptor.string_content_type,
+            keyword_arg_type=descriptor.keyword_arg_type,
+        )
+        self._emit(caller_spec, sink.direction, sink.kind, identity)
 
     def _emit_call(
         self,

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -339,13 +339,45 @@ class IOAccessProcessor:
                 continue
             if node.type == descriptor.block_scope_type:
                 continue
-            if (
-                node.type == descriptor.declarator_type
-                and (name := self._named_child_text(node, descriptor)) is not None
-            ):
-                names.add(name)
+            if node.type == descriptor.declarator_type:
+                names |= self._declarator_names(node, descriptor)
             stack.extend(node.named_children)
         return names
+
+    def _declarator_names(
+        self, declarator: Node, descriptor: LanguageDescriptor
+    ) -> set[str]:
+        # (H) The local names a declarator binds: a plain `const fs = ...` binds one
+        # (H) identifier; a destructuring `const { writeFileSync } = ...` /
+        # (H) `const { get: g } = ...` / `const [fetch] = ...` binds the pattern's
+        # (H) leaves. All are collected so they shadow a same-named builtin.
+        name = declarator.child_by_field_name(cs.TS_FIELD_NAME)
+        names: set[str] = set()
+        if name is not None:
+            self._pattern_names(name, descriptor, names)
+        return names
+
+    def _pattern_names(
+        self, node: Node, descriptor: LanguageDescriptor, out: set[str]
+    ) -> None:
+        node_type = node.type
+        if node_type in (
+            descriptor.identifier_type,
+            cs.TS_SHORTHAND_PROPERTY_IDENTIFIER_PATTERN,
+        ):
+            if node.text:
+                out.add(node.text.decode(cs.ENCODING_UTF8))
+        elif node_type == cs.TS_PAIR_PATTERN:
+            # (H) `{ key: local }` binds the VALUE (local), not the property key.
+            if (value := node.child_by_field_name(cs.FIELD_VALUE)) is not None:
+                self._pattern_names(value, descriptor, out)
+        elif node_type in (
+            cs.TS_OBJECT_PATTERN,
+            cs.TS_ARRAY_PATTERN,
+            cs.TS_REST_PATTERN,
+        ):
+            for child in node.named_children:
+                self._pattern_names(child, descriptor, out)
 
     def _param_names(
         self, caller_node: Node, descriptor: LanguageDescriptor

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -21,6 +21,7 @@ from .extract import (
     call_name,
     definition_header_nodes,
     literal_target,
+    normalise,
     registry_match,
     scope_seed_nodes,
 )
@@ -354,9 +355,9 @@ class IOAccessProcessor:
         local_names: frozenset[str],
     ) -> None:
         raw = call_name(node)
-        if raw is None or self._is_shadowed(raw, import_map, local_names):
+        if raw is None:
             return
-        sink = registry_match(sink_by_name, raw, import_map)
+        sink = self._resolve_sink(raw, import_map, sink_by_name, local_names)
         if sink is None:
             return
         identity = literal_target(
@@ -370,28 +371,39 @@ class IOAccessProcessor:
         self._emit(caller_spec, sink.direction, sink.kind, identity)
 
     @staticmethod
-    def _is_shadowed(
-        raw: str, import_map: dict[str, str], local_names: frozenset[str]
-    ) -> bool:
-        # (H) A sink matches only when its name refers to the genuine builtin. The
-        # (H) head (dotted `fs.writeFileSync`) or the whole bare name (`fetch`) is
-        # (H) shadowed when it is bound locally, or when it is imported from a module
-        # (H) whose base is not itself (a real builtin import maps `fs` -> `fs` /
-        # (H) `fs.default`; a local `import fs from './x'` maps it elsewhere).
+    def _resolve_sink(
+        raw: str,
+        import_map: dict[str, str],
+        sink_by_name: dict[str, IOSink],
+        local_names: frozenset[str],
+    ) -> IOSink | None:
+        # (H) Match a JS/TS call against the sink table, respecting shadowing:
+        # (H)  - a name bound locally (a local `const fs`, `function fetch`, or a
+        # (H)    parameter) is never the builtin -> no match.
+        # (H)  - the import-normalised name is tried first, so an ALIASED builtin
+        # (H)    (`const myfs = require('fs')` -> myfs.x resolves to fs.x) matches.
+        # (H)  - the raw dotted name is a last resort, allowed only when the head
+        # (H)    resolves to the genuine module (a builtin maps `fs` -> `fs` /
+        # (H)    `fs.default` / `node:fs...`; a local `import fs from './x'` maps it
+        # (H)    elsewhere, so its raw `fs.writeFileSync` must not fire).
         head, sep, _ = raw.partition(cs.SEPARATOR_DOT)
         if (head if sep else raw) in local_names:
-            return True
+            return None
+        normalised = normalise(raw, import_map)
+        if (
+            normalised is not None
+            and (sink := sink_by_name.get(normalised)) is not None
+        ):
+            return sink
         if not sep:
-            return False
+            return None
         base = import_map.get(head)
-        if base is None:
-            return False
-        # (H) `import fs from 'node:fs'` is a genuine builtin; strip the node: prefix
-        # (H) so the modern form is not mistaken for a shadowing local module.
-        base_module = base.split(cs.SEPARATOR_DOT)[0].removeprefix(
-            cs.NODE_BUILTIN_PREFIX
+        head_is_builtin = (
+            base is None
+            or base.split(cs.SEPARATOR_DOT)[0].removeprefix(cs.NODE_BUILTIN_PREFIX)
+            == head
         )
-        return base_module != head
+        return sink_by_name.get(raw) if head_is_builtin else None
 
     def _emit_call(
         self,

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -263,19 +263,26 @@ class IOAccessProcessor:
         # (H) Lean non-Python walk (issue #714): DFS the caller body for call sinks,
         # (H) pruning nested definitions (their body is a separate caller) so I/O is
         # (H) credited to the scope that runs it. No handle/stream tracking yet.
+        # (H) A function/method caller exposes its statements under the `body` field;
+        # (H) the module root (top-level calls) has no body field, so seed from its
+        # (H) own children instead. named_children skips anonymous punctuation, which
+        # (H) JS/TS grammars produce in bulk.
         body = caller_node.child_by_field_name(cs.FIELD_BODY)
-        if body is None:
-            return
-        stack = list(body.named_children)
+        seed = body if body is not None else caller_node
+        stack = list(seed.named_children)
         while stack:
             node = stack.pop()
+            # (H) Nested defs are their own caller; skip entirely. JS default args and
+            # (H) decorators evaluate at call time in the nested scope (unlike Python's
+            # (H) definition-time headers), so crediting them here would be a false
+            # (H) positive -- full pruning is correct for these grammars.
             if node.type in descriptor.nested_scope_types:
                 continue
             if node.type == descriptor.call_type:
                 self._emit_direct_call(
                     node, caller_spec, import_map, sink_by_name, descriptor
                 )
-            stack.extend(node.children)
+            stack.extend(node.named_children)
 
     def _emit_direct_call(
         self,

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -293,7 +293,12 @@ class IOAccessProcessor:
         descriptor: LanguageDescriptor,
     ) -> None:
         # (H) Names in scope for calls in THIS block: the enclosing scopes' names plus
-        # (H) this block's own const/let/function declarations (import aliases removed).
+        # (H) this block's own const/let/function declarations (import aliases removed,
+        # (H) since they are the genuine module, resolved by _resolve_sink).
+        # (H) ponytail: import_map is module-scoped, so a block-local `require` alias
+        # (H) leaks module-wide -- but using such a name outside its block is a runtime
+        # (H) ReferenceError (dead code), so its edge precision is not modeled. Per-scope
+        # (H) import tracking is the upgrade if that ever matters.
         in_scope = (
             inherited | self._block_declarations(block_node, descriptor)
         ) - import_map.keys()

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -315,6 +315,10 @@ class IOAccessProcessor:
                 if (name := self._named_child_text(node, descriptor)) is not None:
                     names.add(name)
                 continue
+            # (H) A nested { } block is its own lexical scope: const/let declared
+            # (H) inside it do not shadow this scope, so stop descending there.
+            if node.type == descriptor.block_scope_type:
+                continue
             if (
                 node.type == descriptor.declarator_type
                 and (name := self._named_child_text(node, descriptor)) is not None

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -269,13 +269,22 @@ class IOAccessProcessor:
         # (H) blocks, never a sibling/outer use. A function/method caller exposes its
         # (H) statements under the `body` field; the module root (top-level calls) has
         # (H) no body field, so seed from its own children.
-        seed = caller_node.child_by_field_name(cs.FIELD_BODY) or caller_node
+        body = caller_node.child_by_field_name(cs.FIELD_BODY)
+        if body is None:
+            # (H) Module root (top-level calls): its own children are the statements.
+            statements = list(caller_node.named_children)
+        elif body.type == descriptor.block_scope_type:
+            statements = list(body.named_children)
+        else:
+            # (H) Expression-bodied arrow (`() => fetch(url)`): the body IS the
+            # (H) statement/expression, so walk it directly.
+            statements = [body]
         # (H) Parameters are visible in every block of the function body. Import
         # (H) aliases (`const fs = require('fs')`) are the genuine module, resolved by
         # (H) the import branch of _resolve_sink, so they never count as shadows.
         params = self._param_names(caller_node, descriptor) - import_map.keys()
         self._walk_scope(
-            seed,
+            statements,
             frozenset(params),
             caller_spec,
             import_map,
@@ -285,24 +294,24 @@ class IOAccessProcessor:
 
     def _walk_scope(
         self,
-        block_node: Node,
+        statements: list[Node],
         inherited: frozenset[str],
         caller_spec: tuple[str, str, str],
         import_map: dict[str, str],
         sink_by_name: dict[str, IOSink],
         descriptor: LanguageDescriptor,
     ) -> None:
-        # (H) Names in scope for calls in THIS block: the enclosing scopes' names plus
-        # (H) this block's own const/let/function declarations (import aliases removed,
-        # (H) since they are the genuine module, resolved by _resolve_sink).
+        # (H) Names in scope for calls in THESE statements: the enclosing scopes' names
+        # (H) plus this block's own const/let/function declarations (import aliases
+        # (H) removed, since they are the genuine module, resolved by _resolve_sink).
         # (H) ponytail: import_map is module-scoped, so a block-local `require` alias
         # (H) leaks module-wide -- but using such a name outside its block is a runtime
         # (H) ReferenceError (dead code), so its edge precision is not modeled. Per-scope
         # (H) import tracking is the upgrade if that ever matters.
         in_scope = (
-            inherited | self._block_declarations(block_node, descriptor)
+            inherited | self._block_declarations(statements, descriptor)
         ) - import_map.keys()
-        stack = list(block_node.named_children)
+        stack = list(statements)
         while stack:
             node = stack.pop()
             # (H) Nested function/method: its own caller, walked separately.
@@ -312,7 +321,12 @@ class IOAccessProcessor:
             # (H) names inherited, so its declarations shadow only inside it.
             if node.type == descriptor.block_scope_type:
                 self._walk_scope(
-                    node, in_scope, caller_spec, import_map, sink_by_name, descriptor
+                    list(node.named_children),
+                    in_scope,
+                    caller_spec,
+                    import_map,
+                    sink_by_name,
+                    descriptor,
                 )
                 continue
             if node.type == descriptor.call_type:
@@ -322,15 +336,15 @@ class IOAccessProcessor:
             stack.extend(node.named_children)
 
     def _block_declarations(
-        self, block_node: Node, descriptor: LanguageDescriptor
+        self, statements: list[Node], descriptor: LanguageDescriptor
     ) -> set[str]:
-        # (H) Names declared directly in this block: const/let/var declarators and
-        # (H) hoisted `function` declarations. Nested blocks and nested functions are
-        # (H) their own scopes and are not descended into (their locals are theirs).
+        # (H) Names declared directly in these statements: const/let/var declarators
+        # (H) and hoisted `function` declarations. Nested blocks and nested functions
+        # (H) are their own scopes and are not descended into (their locals are theirs).
         # (H) ponytail: `var` is really function-scoped, but a var redefining a
         # (H) builtin name is rare enough to treat block-locally.
         names: set[str] = set()
-        stack = list(block_node.named_children)
+        stack = list(statements)
         while stack:
             node = stack.pop()
             if node.type in descriptor.nested_scope_types:

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -267,6 +267,7 @@ class IOAccessProcessor:
         # (H) the module root (top-level calls) has no body field, so seed from its
         # (H) own children instead. named_children skips anonymous punctuation, which
         # (H) JS/TS grammars produce in bulk.
+        local_names = self._local_bindings(caller_node, descriptor)
         body = caller_node.child_by_field_name(cs.FIELD_BODY)
         seed = body if body is not None else caller_node
         stack = list(seed.named_children)
@@ -280,9 +281,63 @@ class IOAccessProcessor:
                 continue
             if node.type == descriptor.call_type:
                 self._emit_direct_call(
-                    node, caller_spec, import_map, sink_by_name, descriptor
+                    node, caller_spec, import_map, sink_by_name, descriptor, local_names
                 )
             stack.extend(node.named_children)
+
+    def _local_bindings(
+        self, caller_node: Node, descriptor: LanguageDescriptor
+    ) -> frozenset[str]:
+        # (H) Names bound in the caller's OWN scope, which shadow a same-named
+        # (H) builtin sink: the caller's parameters, plus every local `const/let/var`
+        # (H) declarator and hoisted `function` declaration in the body (nested
+        # (H) scopes pruned -- their locals are their own). No import entry exists
+        # (H) for these, so without this a local `fetch`/`fs` would match the sink.
+        names: set[str] = set()
+        params = caller_node.child_by_field_name(descriptor.params_field)
+        if params is not None:
+            for child in params.named_children:
+                if (name := self._binding_identifier(child, descriptor)) is not None:
+                    names.add(name)
+        body = caller_node.child_by_field_name(cs.FIELD_BODY)
+        stack = list((body or caller_node).named_children)
+        while stack:
+            node = stack.pop()
+            if node.type in descriptor.nested_scope_types:
+                # (H) A hoisted `function foo` binds `foo` in THIS scope; record its
+                # (H) name but do not descend into its body.
+                if (name := self._named_child_text(node, descriptor)) is not None:
+                    names.add(name)
+                continue
+            if (
+                node.type == descriptor.declarator_type
+                and (name := self._named_child_text(node, descriptor)) is not None
+            ):
+                names.add(name)
+            stack.extend(node.named_children)
+        return frozenset(names)
+
+    @staticmethod
+    def _named_child_text(node: Node, descriptor: LanguageDescriptor) -> str | None:
+        name = node.child_by_field_name(cs.TS_FIELD_NAME)
+        if name is not None and name.type == descriptor.identifier_type and name.text:
+            return name.text.decode(cs.ENCODING_UTF8)
+        return None
+
+    @staticmethod
+    def _binding_identifier(node: Node, descriptor: LanguageDescriptor) -> str | None:
+        # (H) A parameter is either a bare identifier or a typed/patterned wrapper
+        # (H) whose `pattern` field holds the identifier (TS required_parameter).
+        if node.type == descriptor.identifier_type and node.text:
+            return node.text.decode(cs.ENCODING_UTF8)
+        pattern = node.child_by_field_name(cs.TS_FIELD_PATTERN)
+        if (
+            pattern is not None
+            and pattern.type == descriptor.identifier_type
+            and pattern.text
+        ):
+            return pattern.text.decode(cs.ENCODING_UTF8)
+        return None
 
     def _emit_direct_call(
         self,
@@ -291,9 +346,10 @@ class IOAccessProcessor:
         import_map: dict[str, str],
         sink_by_name: dict[str, IOSink],
         descriptor: LanguageDescriptor,
+        local_names: frozenset[str],
     ) -> None:
         raw = call_name(node)
-        if raw is None or self._head_is_shadowed(raw, import_map):
+        if raw is None or self._is_shadowed(raw, import_map, local_names):
             return
         sink = registry_match(sink_by_name, raw, import_map)
         if sink is None:
@@ -309,13 +365,17 @@ class IOAccessProcessor:
         self._emit(caller_spec, sink.direction, sink.kind, identity)
 
     @staticmethod
-    def _head_is_shadowed(raw: str, import_map: dict[str, str]) -> bool:
-        # (H) A dotted sink like `fs.writeFileSync` is only real I/O when `fs` is the
-        # (H) genuine module. A real builtin import maps the head to itself (`fs` /
-        # (H) `fs.default`), but importing `fs` from a LOCAL module maps it to a
-        # (H) project-qualified base, so the raw-dotted registry fallback must not
-        # (H) fire. A bare or unimported head is trusted (issue #714 precision).
+    def _is_shadowed(
+        raw: str, import_map: dict[str, str], local_names: frozenset[str]
+    ) -> bool:
+        # (H) A sink matches only when its name refers to the genuine builtin. The
+        # (H) head (dotted `fs.writeFileSync`) or the whole bare name (`fetch`) is
+        # (H) shadowed when it is bound locally, or when it is imported from a module
+        # (H) whose base is not itself (a real builtin import maps `fs` -> `fs` /
+        # (H) `fs.default`; a local `import fs from './x'` maps it elsewhere).
         head, sep, _ = raw.partition(cs.SEPARATOR_DOT)
+        if (head if sep else raw) in local_names:
+            return True
         if not sep:
             return False
         base = import_map.get(head)

--- a/codebase_rag/parsers/io_access/registry.py
+++ b/codebase_rag/parsers/io_access/registry.py
@@ -132,8 +132,38 @@ _PYTHON_SINKS: tuple[IOSink, ...] = (
     ),
 )
 
+# (H) JS/TS direct-call I/O sinks (issue #714, first increment). Keyed by the
+# (H) dotted callee text (`console.log`, `fs.writeFileSync`, `axios.get`); a bare
+# (H) global like `fetch` matches when it is not shadowed by an import. Node has
+# (H) no keyword args, so the URL/path is always positional arg 0. Member-access
+# (H) reads (`process.env.X`) and stream handles are a follow-up.
+_JS_TS_SINKS: tuple[IOSink, ...] = (
+    IOSink("console.log", ResourceKind.STDOUT, IODirection.WRITE),
+    IOSink("console.info", ResourceKind.STDOUT, IODirection.WRITE),
+    IOSink("console.warn", ResourceKind.STDOUT, IODirection.WRITE),
+    IOSink("console.error", ResourceKind.STDOUT, IODirection.WRITE),
+    IOSink("fetch", ResourceKind.NETWORK, IODirection.READ, target_arg=0),
+    IOSink("axios.get", ResourceKind.NETWORK, IODirection.READ, target_arg=0),
+    IOSink("axios.head", ResourceKind.NETWORK, IODirection.READ, target_arg=0),
+    IOSink("axios.post", ResourceKind.NETWORK, IODirection.WRITE, target_arg=0),
+    IOSink("axios.put", ResourceKind.NETWORK, IODirection.WRITE, target_arg=0),
+    IOSink("axios.patch", ResourceKind.NETWORK, IODirection.WRITE, target_arg=0),
+    IOSink("axios.delete", ResourceKind.NETWORK, IODirection.WRITE, target_arg=0),
+    IOSink("http.get", ResourceKind.NETWORK, IODirection.READ, target_arg=0),
+    IOSink("https.get", ResourceKind.NETWORK, IODirection.READ, target_arg=0),
+    IOSink("fs.readFile", ResourceKind.FILE, IODirection.READ, target_arg=0),
+    IOSink("fs.readFileSync", ResourceKind.FILE, IODirection.READ, target_arg=0),
+    IOSink("fs.writeFile", ResourceKind.FILE, IODirection.WRITE, target_arg=0),
+    IOSink("fs.writeFileSync", ResourceKind.FILE, IODirection.WRITE, target_arg=0),
+    IOSink("fs.appendFile", ResourceKind.FILE, IODirection.WRITE, target_arg=0),
+    IOSink("fs.appendFileSync", ResourceKind.FILE, IODirection.WRITE, target_arg=0),
+)
+
 IO_SINKS: dict[cs.SupportedLanguage, tuple[IOSink, ...]] = {
     cs.SupportedLanguage.PYTHON: _PYTHON_SINKS,
+    cs.SupportedLanguage.JS: _JS_TS_SINKS,
+    cs.SupportedLanguage.TS: _JS_TS_SINKS,
+    cs.SupportedLanguage.TSX: _JS_TS_SINKS,
 }
 
 # (H) Calls whose result is a resource handle; later method calls on the bound

--- a/codebase_rag/tests/integration/test_jsts_io_e2e.py
+++ b/codebase_rag/tests/integration/test_jsts_io_e2e.py
@@ -72,3 +72,20 @@ def test_typescript_direct_io_sinks(
     assert (_WRITES, "resource::STDOUT::<dynamic>") in edges
     assert (_READS, "resource::NETWORK::https://api.example.com/data") in edges
     assert (_WRITES, "resource::FILE::out.txt") in edges
+    assert (_WRITES, "resource::NETWORK::https://api.example.com/upload") in edges
+
+
+def test_module_level_js_io_sinks(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) Top-level (module-scope) I/O: the caller is the module root, which has no
+    # (H) body field, so the walk must seed from its own statements (issue #714 P1).
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "main.js",
+        'console.log("boot");\nfs.writeFileSync("cfg.json", data);\n',
+    )
+    edges = _io_edges(memgraph_ingestor)
+    assert (_WRITES, "resource::STDOUT::<dynamic>") in edges
+    assert (_WRITES, "resource::FILE::cfg.json") in edges

--- a/codebase_rag/tests/integration/test_jsts_io_e2e.py
+++ b/codebase_rag/tests/integration/test_jsts_io_e2e.py
@@ -169,6 +169,23 @@ def test_node_prefixed_builtin_import_still_emits(
     assert (_WRITES, "resource::FILE::a.txt") in _io_edges(memgraph_ingestor)
 
 
+def test_block_scoped_local_does_not_over_shadow(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) `const`/`let` are block-scoped: a `const fs` inside a nested block does
+    # (H) NOT shadow a `fs.writeFileSync` outside that block, so the edge stands.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "app.js",
+        "function f(d) {\n"
+        "  {\n    const fs = {};\n  }\n"
+        "  fs.writeFileSync('out.txt', d);\n"
+        "}\n",
+    )
+    assert (_WRITES, "resource::FILE::out.txt") in _io_edges(memgraph_ingestor)
+
+
 def test_local_declarations_shadow_sinks(
     memgraph_ingestor: MemgraphIngestor, tmp_path: Path
 ) -> None:

--- a/codebase_rag/tests/integration/test_jsts_io_e2e.py
+++ b/codebase_rag/tests/integration/test_jsts_io_e2e.py
@@ -138,6 +138,22 @@ def test_commonjs_require_still_emits(
     assert (_WRITES, "resource::FILE::a.txt") in _io_edges(memgraph_ingestor)
 
 
+def test_aliased_builtin_import_still_emits(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) `const myfs = require('fs')` aliases the real builtin under a new name;
+    # (H) import normalization resolves myfs.writeFileSync -> fs.writeFileSync, so
+    # (H) it must still emit (the alias is not a shadowing local module).
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "app.js",
+        "const myfs = require('fs');\n\n\n"
+        "function save(d) {\n  myfs.writeFileSync('a.txt', d);\n}\n",
+    )
+    assert (_WRITES, "resource::FILE::a.txt") in _io_edges(memgraph_ingestor)
+
+
 def test_node_prefixed_builtin_import_still_emits(
     memgraph_ingestor: MemgraphIngestor, tmp_path: Path
 ) -> None:

--- a/codebase_rag/tests/integration/test_jsts_io_e2e.py
+++ b/codebase_rag/tests/integration/test_jsts_io_e2e.py
@@ -121,6 +121,21 @@ def test_real_builtin_import_still_emits(
     assert (_WRITES, "resource::FILE::a.txt") in _io_edges(memgraph_ingestor)
 
 
+def test_node_prefixed_builtin_import_still_emits(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) `import fs from 'node:fs'` is a genuine builtin (the modern form); the
+    # (H) node: prefix must not be mistaken for a shadowing local module.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "app.js",
+        "import fs from 'node:fs';\n\n\n"
+        "function save(d) {\n  fs.writeFileSync('a.txt', d);\n}\n",
+    )
+    assert (_WRITES, "resource::FILE::a.txt") in _io_edges(memgraph_ingestor)
+
+
 def test_local_declarations_shadow_sinks(
     memgraph_ingestor: MemgraphIngestor, tmp_path: Path
 ) -> None:

--- a/codebase_rag/tests/integration/test_jsts_io_e2e.py
+++ b/codebase_rag/tests/integration/test_jsts_io_e2e.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.capture import resolve_capture
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+if TYPE_CHECKING:
+    from codebase_rag.services.graph_service import MemgraphIngestor
+
+pytestmark = [pytest.mark.integration]
+
+_READS = cs.RelationshipType.READS_FROM.value
+_WRITES = cs.RelationshipType.WRITES_TO.value
+
+
+def _build(
+    ingestor: MemgraphIngestor, tmp_path: Path, filename: str, code: str
+) -> None:
+    project = tmp_path / "js_project"
+    project.mkdir()
+    (project / filename).write_text(code, encoding="utf-8")
+    parsers, queries = load_parsers()
+    GraphUpdater(
+        ingestor=ingestor,
+        repo_path=project,
+        parsers=parsers,
+        queries=queries,
+        capture=resolve_capture([cs.CaptureGroup.IO.value]),
+    ).run()
+
+
+def _io_edges(ingestor: MemgraphIngestor) -> set[tuple[str, str]]:
+    rows = ingestor.fetch_all(
+        f"MATCH ()-[r:{_READS}|{_WRITES}]->(res:{cs.NodeLabel.RESOURCE.value}) "
+        "RETURN type(r) AS rel, res.qualified_name AS qn"
+    )
+    return {(str(row["rel"]), str(row["qn"])) for row in rows}
+
+
+_JS_CODE = """\
+function leak(data) {
+  console.log(data);
+  fetch("https://api.example.com/data");
+  fs.writeFileSync("out.txt", data);
+  axios.post("https://api.example.com/upload");
+}
+"""
+
+
+def test_javascript_direct_io_sinks(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    _build(memgraph_ingestor, tmp_path, "app.js", _JS_CODE)
+    edges = _io_edges(memgraph_ingestor)
+    assert (_WRITES, "resource::STDOUT::<dynamic>") in edges
+    assert (_READS, "resource::NETWORK::https://api.example.com/data") in edges
+    assert (_WRITES, "resource::FILE::out.txt") in edges
+    assert (_WRITES, "resource::NETWORK::https://api.example.com/upload") in edges
+
+
+def test_typescript_direct_io_sinks(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    _build(memgraph_ingestor, tmp_path, "app.ts", _JS_CODE)
+    edges = _io_edges(memgraph_ingestor)
+    assert (_WRITES, "resource::STDOUT::<dynamic>") in edges
+    assert (_READS, "resource::NETWORK::https://api.example.com/data") in edges
+    assert (_WRITES, "resource::FILE::out.txt") in edges

--- a/codebase_rag/tests/integration/test_jsts_io_e2e.py
+++ b/codebase_rag/tests/integration/test_jsts_io_e2e.py
@@ -186,6 +186,24 @@ def test_block_scoped_local_does_not_over_shadow(
     assert (_WRITES, "resource::FILE::out.txt") in _io_edges(memgraph_ingestor)
 
 
+def test_block_local_shadows_within_its_block(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) A `const fs` used WITHIN its own block is shadowed there: no FILE edge.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "app.js",
+        "function f(d) {\n"
+        "  if (d) {\n"
+        "    const fs = {};\n"
+        "    fs.writeFileSync('out.txt', d);\n"
+        "  }\n"
+        "}\n",
+    )
+    assert (_WRITES, "resource::FILE::out.txt") not in _io_edges(memgraph_ingestor)
+
+
 def test_local_declarations_shadow_sinks(
     memgraph_ingestor: MemgraphIngestor, tmp_path: Path
 ) -> None:

--- a/codebase_rag/tests/integration/test_jsts_io_e2e.py
+++ b/codebase_rag/tests/integration/test_jsts_io_e2e.py
@@ -119,3 +119,27 @@ def test_real_builtin_import_still_emits(
         "function save(d) {\n  fs.writeFileSync('a.txt', d);\n}\n",
     )
     assert (_WRITES, "resource::FILE::a.txt") in _io_edges(memgraph_ingestor)
+
+
+def test_local_declarations_shadow_sinks(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) Names bound locally are not the builtins: a local `const fs`, a local
+    # (H) `function fetch`, and a `http` parameter must all suppress the sink match
+    # (H) (issue #714 precision -- no import entry exists for these).
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "app.js",
+        "function run(http) {\n"
+        "  const fs = {};\n"
+        "  function fetch(u) {}\n"
+        "  fs.writeFileSync('x.txt', d);\n"
+        "  fetch('https://n/a');\n"
+        "  http.get('https://n/b');\n"
+        "}\n",
+    )
+    edges = _io_edges(memgraph_ingestor)
+    assert (_WRITES, "resource::FILE::x.txt") not in edges
+    assert (_READS, "resource::NETWORK::https://n/a") not in edges
+    assert (_READS, "resource::NETWORK::https://n/b") not in edges

--- a/codebase_rag/tests/integration/test_jsts_io_e2e.py
+++ b/codebase_rag/tests/integration/test_jsts_io_e2e.py
@@ -89,3 +89,33 @@ def test_module_level_js_io_sinks(
     edges = _io_edges(memgraph_ingestor)
     assert (_WRITES, "resource::STDOUT::<dynamic>") in edges
     assert (_WRITES, "resource::FILE::cfg.json") in edges
+
+
+def test_shadowed_local_import_emits_no_edge(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) `fs` imported from a LOCAL module is not Node's fs: fs.writeFileSync must
+    # (H) NOT emit a FILE edge (the raw-dotted registry fallback would otherwise
+    # (H) misfire on the shadowed name). Issue #714 precision.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "app.js",
+        "import fs from './fake';\n\n\n"
+        "function save(d) {\n  fs.writeFileSync('a.txt', d);\n}\n",
+    )
+    assert (_WRITES, "resource::FILE::a.txt") not in _io_edges(memgraph_ingestor)
+
+
+def test_real_builtin_import_still_emits(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) The genuine `import fs from 'fs'` (maps to fs.default) must still emit.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "app.js",
+        "import fs from 'fs';\n\n\n"
+        "function save(d) {\n  fs.writeFileSync('a.txt', d);\n}\n",
+    )
+    assert (_WRITES, "resource::FILE::a.txt") in _io_edges(memgraph_ingestor)

--- a/codebase_rag/tests/integration/test_jsts_io_e2e.py
+++ b/codebase_rag/tests/integration/test_jsts_io_e2e.py
@@ -185,6 +185,22 @@ def test_destructured_local_shadows_sink(
     )
 
 
+def test_destructured_param_shadows_sink(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) A destructured parameter (`function run({ http }) {}`) binds `http`
+    # (H) locally, so `http.get(...)` must not emit a NETWORK edge.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "app.js",
+        "function run({ http }) {\n  http.get('https://n/b');\n}\n",
+    )
+    assert (_READS, "resource::NETWORK::https://n/b") not in _io_edges(
+        memgraph_ingestor
+    )
+
+
 def test_block_scoped_local_does_not_over_shadow(
     memgraph_ingestor: MemgraphIngestor, tmp_path: Path
 ) -> None:

--- a/codebase_rag/tests/integration/test_jsts_io_e2e.py
+++ b/codebase_rag/tests/integration/test_jsts_io_e2e.py
@@ -75,6 +75,22 @@ def test_typescript_direct_io_sinks(
     assert (_WRITES, "resource::NETWORK::https://api.example.com/upload") in edges
 
 
+def test_expression_bodied_arrow_emits(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) An expression-bodied arrow has no statement block -- its body IS the call
+    # (H) expression, which must still be walked for sinks (issue #714 recall).
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "app.js",
+        'const load = () => fetch("https://api.example.com/data");\n',
+    )
+    assert (_READS, "resource::NETWORK::https://api.example.com/data") in _io_edges(
+        memgraph_ingestor
+    )
+
+
 def test_module_level_js_io_sinks(
     memgraph_ingestor: MemgraphIngestor, tmp_path: Path
 ) -> None:

--- a/codebase_rag/tests/integration/test_jsts_io_e2e.py
+++ b/codebase_rag/tests/integration/test_jsts_io_e2e.py
@@ -169,6 +169,22 @@ def test_node_prefixed_builtin_import_still_emits(
     assert (_WRITES, "resource::FILE::a.txt") in _io_edges(memgraph_ingestor)
 
 
+def test_destructured_local_shadows_sink(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) A destructured local binding (`const { fetch } = obj`) is not the global
+    # (H) builtin, so `fetch(...)` in that scope must not emit a NETWORK edge.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "app.js",
+        "function run(obj) {\n  const { fetch } = obj;\n  fetch('https://n/a');\n}\n",
+    )
+    assert (_READS, "resource::NETWORK::https://n/a") not in _io_edges(
+        memgraph_ingestor
+    )
+
+
 def test_block_scoped_local_does_not_over_shadow(
     memgraph_ingestor: MemgraphIngestor, tmp_path: Path
 ) -> None:

--- a/codebase_rag/tests/integration/test_jsts_io_e2e.py
+++ b/codebase_rag/tests/integration/test_jsts_io_e2e.py
@@ -121,6 +121,23 @@ def test_real_builtin_import_still_emits(
     assert (_WRITES, "resource::FILE::a.txt") in _io_edges(memgraph_ingestor)
 
 
+def test_commonjs_require_still_emits(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) `const fs = require('fs')` binds fs via a declarator, but it is an import
+    # (H) alias (tracked in import_map), not a shadowing local -- it must still emit.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "app.js",
+        "function save(d) {\n"
+        "  const fs = require('fs');\n"
+        "  fs.writeFileSync('a.txt', d);\n"
+        "}\n",
+    )
+    assert (_WRITES, "resource::FILE::a.txt") in _io_edges(memgraph_ingestor)
+
+
 def test_node_prefixed_builtin_import_still_emits(
     memgraph_ingestor: MemgraphIngestor, tmp_path: Path
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.323"
+version = "0.0.325"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

First increment of #714 (I/O + data-flow beyond Python). Until now `READS_FROM`/`WRITES_TO`/`FLOWS_TO` were emitted for **Python only** — every other language parsed into the graph but produced zero I/O edges. This lands **JavaScript / TypeScript / TSX** direct-call I/O sinks behind the existing opt-in `io` capture group.

## What's covered

`console.log/info/warn/error` → STDOUT write; `fetch`, `axios.get/head/post/put/patch/delete`, `http.get`/`https.get` → NETWORK (GET/HEAD read, rest write, url = arg 0); `fs.readFile[Sync]` → FILE read, `fs.writeFile[Sync]`/`fs.appendFile[Sync]` → FILE write (path = arg 0).

```js
function leak(data) {
  console.log(data);                        // WRITES_TO STDOUT
  fetch("https://api.example.com/data");    // READS_FROM NETWORK::…/data
  fs.writeFileSync("out.txt", data);        // WRITES_TO FILE::out.txt
  axios.post("https://api.example.com/up");  // WRITES_TO NETWORK::…/up
}
```

## Design

The Python and JS/TS grammars share the **field** names the walk needs (`function`/`arguments`/`body`); only the **node types** differ (`call_expression` vs `call`, `string_fragment` vs `string_content`). So instead of rewriting the processor, a small **`LanguageDescriptor`** (`io_access/descriptor.py`) captures just those differing node types, and:

- `string_literal` / `literal_target` (`extract.py`) take optional per-language node-type args (Python defaults unchanged — every existing Python path is byte-for-byte the same).
- The processor's hard `if language != PYTHON: return` gate is replaced with a lean `_emit_direct_sinks` walk for languages that have a descriptor: DFS the caller body for call sinks, pruning nested function/arrow/method definitions (their body is a separate caller). Python keeps its full handle-aware walk untouched.

This gives each future language a bounded landing: one descriptor entry + registry rows + tests.

## Scope / follow-ups (noted in code)

- **io only** — JS/TS `FLOWS_TO` (taint) still gates on Python; data-flow for JS is a separate increment.
- **call sinks only** — `process.env.X` (member-access ENV read) and stream handles (`fs.createReadStream`, `http` client objects) are not yet covered.
- Other languages (Go, Java, Rust, C++) remain follow-ups under #714.

## Test (RED → GREEN)

New `test_jsts_io_e2e.py`: a `.js` and a `.ts` project each asserting the STDOUT/NETWORK/FILE edges appear (both RED before, GREEN after).

Full suite: 5067 passed, 10 skipped. ruff + ty clean. Every existing Python io/flow test unchanged.