### PR TITLE
feat(io): process.env.X environment reads for JavaScript/TypeScript (#714)

### DIFF
--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -173,6 +173,9 @@ TS_ARRAY_PATTERN = "array_pattern"
 TS_REST_PATTERN = "rest_pattern"
 TS_SHORTHAND_PROPERTY_IDENTIFIER_PATTERN = "shorthand_property_identifier_pattern"
 TS_PAIR_PATTERN = "pair_pattern"
+# (H) `process.env.X` is a member_expression; `process.env['X']` a subscript, used
+# (H) to detect environment-variable reads (issue #714 process.env follow-up).
+TS_SUBSCRIPT_EXPRESSION = "subscript_expression"
 TS_FUNCTION_DECLARATION = "function_declaration"
 TS_GENERATOR_FUNCTION_DECLARATION = "generator_function_declaration"
 

--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -176,6 +176,7 @@ TS_PAIR_PATTERN = "pair_pattern"
 # (H) `process.env.X` is a member_expression; `process.env['X']` a subscript, used
 # (H) to detect environment-variable reads (issue #714 process.env follow-up).
 TS_SUBSCRIPT_EXPRESSION = "subscript_expression"
+TS_FIELD_INDEX = "index"
 TS_FUNCTION_DECLARATION = "function_declaration"
 TS_GENERATOR_FUNCTION_DECLARATION = "generator_function_declaration"
 

--- a/codebase_rag/parsers/io_access/descriptor.py
+++ b/codebase_rag/parsers/io_access/descriptor.py
@@ -35,6 +35,7 @@ class LanguageDescriptor:
     subscript_type: str
     object_field: str
     property_field: str
+    subscript_index_field: str
 
 
 _JS_TS_DESCRIPTOR = LanguageDescriptor(
@@ -59,6 +60,7 @@ _JS_TS_DESCRIPTOR = LanguageDescriptor(
     subscript_type=cs.TS_SUBSCRIPT_EXPRESSION,
     object_field=cs.FIELD_OBJECT,
     property_field=cs.FIELD_PROPERTY,
+    subscript_index_field=cs.TS_FIELD_INDEX,
 )
 
 # (H) Non-Python languages with a direct-sink descriptor. Python keeps its own

--- a/codebase_rag/parsers/io_access/descriptor.py
+++ b/codebase_rag/parsers/io_access/descriptor.py
@@ -29,6 +29,12 @@ class LanguageDescriptor:
     # (H) A nested block introduces a new lexical scope: const/let declared inside
     # (H) it do not shadow the enclosing scope, so declarator collection stops here.
     block_scope_type: str
+    # (H) Member/subscript access node types + fields, for env reads like
+    # (H) `process.env.X` (member) and `process.env['X']` (subscript).
+    member_expression_type: str
+    subscript_type: str
+    object_field: str
+    property_field: str
 
 
 _JS_TS_DESCRIPTOR = LanguageDescriptor(
@@ -49,6 +55,10 @@ _JS_TS_DESCRIPTOR = LanguageDescriptor(
     declarator_type=cs.TS_VARIABLE_DECLARATOR,
     params_field=cs.TS_FIELD_PARAMETERS,
     block_scope_type=cs.TS_STATEMENT_BLOCK,
+    member_expression_type=cs.TS_MEMBER_EXPRESSION,
+    subscript_type=cs.TS_SUBSCRIPT_EXPRESSION,
+    object_field=cs.FIELD_OBJECT,
+    property_field=cs.FIELD_PROPERTY,
 )
 
 # (H) Non-Python languages with a direct-sink descriptor. Python keeps its own

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -24,9 +24,15 @@ from .extract import (
     normalise,
     registry_match,
     scope_seed_nodes,
+    string_literal,
 )
 from .models import HandleBinding, HandleConstructor, IOSink
-from .registry import IO_HANDLE_CONSTRUCTORS, IO_HANDLE_METHODS, IO_SINKS
+from .registry import (
+    IO_HANDLE_CONSTRUCTORS,
+    IO_HANDLE_METHODS,
+    IO_MEMBER_READS,
+    IO_SINKS,
+)
 
 _DIRECTION_REL = {
     IODirection.READ: cs.RelationshipType.READS_FROM,
@@ -74,7 +80,12 @@ class IOAccessProcessor:
             descriptor = LANGUAGE_DESCRIPTORS.get(language)
             if descriptor is not None:
                 self._emit_direct_sinks(
-                    caller_node, caller_spec, import_map, sink_by_name, descriptor
+                    caller_node,
+                    caller_spec,
+                    import_map,
+                    sink_by_name,
+                    IO_MEMBER_READS.get(language, ()),
+                    descriptor,
                 )
             return
         ctor_by_name = {c.callee: c for c in constructors}
@@ -259,6 +270,7 @@ class IOAccessProcessor:
         caller_spec: tuple[str, str, str],
         import_map: dict[str, str],
         sink_by_name: dict[str, IOSink],
+        member_reads: tuple[tuple[str, ResourceKind], ...],
         descriptor: LanguageDescriptor,
     ) -> None:
         # (H) Lean non-Python walk (issue #714): find call sinks in the caller body,
@@ -289,6 +301,7 @@ class IOAccessProcessor:
             caller_spec,
             import_map,
             sink_by_name,
+            member_reads,
             descriptor,
         )
 
@@ -299,6 +312,7 @@ class IOAccessProcessor:
         caller_spec: tuple[str, str, str],
         import_map: dict[str, str],
         sink_by_name: dict[str, IOSink],
+        member_reads: tuple[tuple[str, ResourceKind], ...],
         descriptor: LanguageDescriptor,
     ) -> None:
         # (H) Names in scope for calls in THESE statements: the enclosing scopes' names
@@ -326,6 +340,7 @@ class IOAccessProcessor:
                     caller_spec,
                     import_map,
                     sink_by_name,
+                    member_reads,
                     descriptor,
                 )
                 continue
@@ -333,7 +348,63 @@ class IOAccessProcessor:
                 self._emit_direct_call(
                     node, caller_spec, import_map, sink_by_name, descriptor, in_scope
                 )
+            elif member_reads and node.type in (
+                descriptor.member_expression_type,
+                descriptor.subscript_type,
+            ):
+                self._emit_member_read(
+                    node, caller_spec, member_reads, in_scope, import_map, descriptor
+                )
             stack.extend(node.named_children)
+
+    def _emit_member_read(
+        self,
+        node: Node,
+        caller_spec: tuple[str, str, str],
+        member_reads: tuple[tuple[str, ResourceKind], ...],
+        in_scope: frozenset[str],
+        import_map: dict[str, str],
+        descriptor: LanguageDescriptor,
+    ) -> None:
+        # (H) Env-style member reads: `process.env.X` (member) / `process.env['X']`
+        # (H) (subscript) read env var X. Match on the object prefix; skip when the
+        # (H) prefix head (`process`) is shadowed by a local binding or a non-global
+        # (H) import, mirroring the call-sink shadow rules.
+        obj = node.child_by_field_name(descriptor.object_field)
+        if obj is None or obj.text is None:
+            return
+        obj_text = obj.text.decode(cs.ENCODING_UTF8)
+        for prefix, kind in member_reads:
+            if obj_text != prefix:
+                continue
+            head = prefix.partition(cs.SEPARATOR_DOT)[0]
+            if head in in_scope:
+                return
+            base = import_map.get(head)
+            if base is not None and (
+                base.split(cs.SEPARATOR_DOT)[0].removeprefix(cs.NODE_BUILTIN_PREFIX)
+                != head
+            ):
+                return
+            identity = self._member_identity(node, descriptor)
+            self._emit(caller_spec, IODirection.READ, kind, identity)
+            return
+
+    def _member_identity(self, node: Node, descriptor: LanguageDescriptor) -> str:
+        # (H) The accessed key: a member's `property` (`process.env.SECRET` -> SECRET),
+        # (H) or a subscript's string index (`process.env['T']` -> T); else <dynamic>.
+        if node.type == descriptor.member_expression_type:
+            prop = node.child_by_field_name(descriptor.property_field)
+            if prop is not None and prop.text is not None:
+                return prop.text.decode(cs.ENCODING_UTF8)
+            return DYNAMIC_TARGET
+        obj = node.child_by_field_name(descriptor.object_field)
+        for child in node.named_children:
+            if child is not obj and child.type == descriptor.string_type:
+                return string_literal(
+                    child, descriptor.string_type, descriptor.string_content_type
+                )
+        return DYNAMIC_TARGET
 
     def _block_declarations(
         self, statements: list[Node], descriptor: LanguageDescriptor

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -398,12 +398,11 @@ class IOAccessProcessor:
             if prop is not None and prop.text is not None:
                 return prop.text.decode(cs.ENCODING_UTF8)
             return DYNAMIC_TARGET
-        obj = node.child_by_field_name(descriptor.object_field)
-        for child in node.named_children:
-            if child is not obj and child.type == descriptor.string_type:
-                return string_literal(
-                    child, descriptor.string_type, descriptor.string_content_type
-                )
+        index = node.child_by_field_name(descriptor.subscript_index_field)
+        if index is not None and index.type == descriptor.string_type:
+            return string_literal(
+                index, descriptor.string_type, descriptor.string_content_type
+            )
         return DYNAMIC_TARGET
 
     def _block_declarations(

--- a/codebase_rag/parsers/io_access/registry.py
+++ b/codebase_rag/parsers/io_access/registry.py
@@ -166,6 +166,20 @@ IO_SINKS: dict[cs.SupportedLanguage, tuple[IOSink, ...]] = {
     cs.SupportedLanguage.TSX: _JS_TS_SINKS,
 }
 
+# (H) Member/subscript accesses that are I/O reads, keyed by the object prefix:
+# (H) `process.env.X` / `process.env['X']` reads env var X (issue #714). The head
+# (H) token (`process`) is shadow-checked like a sink, so a local `process` is
+# (H) not the Node global.
+_JS_TS_MEMBER_READS: tuple[tuple[str, ResourceKind], ...] = (
+    ("process.env", ResourceKind.ENV),
+)
+
+IO_MEMBER_READS: dict[cs.SupportedLanguage, tuple[tuple[str, ResourceKind], ...]] = {
+    cs.SupportedLanguage.JS: _JS_TS_MEMBER_READS,
+    cs.SupportedLanguage.TS: _JS_TS_MEMBER_READS,
+    cs.SupportedLanguage.TSX: _JS_TS_MEMBER_READS,
+}
+
 # (H) Calls whose result is a resource handle; later method calls on the bound
 # (H) variable are attributed to the same resource.
 _PYTHON_HANDLE_CONSTRUCTORS: tuple[HandleConstructor, ...] = (

--- a/codebase_rag/tests/integration/test_jsts_env_e2e.py
+++ b/codebase_rag/tests/integration/test_jsts_env_e2e.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.capture import resolve_capture
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+if TYPE_CHECKING:
+    from codebase_rag.services.graph_service import MemgraphIngestor
+
+pytestmark = [pytest.mark.integration]
+
+_READS = cs.RelationshipType.READS_FROM.value
+
+
+def _build(
+    ingestor: MemgraphIngestor, tmp_path: Path, filename: str, code: str
+) -> None:
+    project = tmp_path / "env_project"
+    project.mkdir()
+    (project / filename).write_text(code, encoding="utf-8")
+    parsers, queries = load_parsers()
+    GraphUpdater(
+        ingestor=ingestor,
+        repo_path=project,
+        parsers=parsers,
+        queries=queries,
+        capture=resolve_capture([cs.CaptureGroup.IO.value]),
+    ).run()
+
+
+def _reads(ingestor: MemgraphIngestor) -> set[str]:
+    rows = ingestor.fetch_all(
+        f"MATCH ()-[:{_READS}]->(res:{cs.NodeLabel.RESOURCE.value}) "
+        "RETURN res.qualified_name AS qn"
+    )
+    return {str(row["qn"]) for row in rows}
+
+
+def test_process_env_member_and_subscript_reads(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "app.js",
+        "function boot() {\n"
+        "  const a = process.env.SECRET;\n"
+        "  const b = process.env['TOKEN'];\n"
+        "  fetch(process.env.URL);\n"
+        "}\n",
+    )
+    reads = _reads(memgraph_ingestor)
+    assert "resource::ENV::SECRET" in reads
+    assert "resource::ENV::TOKEN" in reads
+    assert "resource::ENV::URL" in reads
+
+
+def test_process_env_typescript(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "app.ts",
+        "function boot() {\n  const a = process.env.HOME;\n}\n",
+    )
+    assert "resource::ENV::HOME" in _reads(memgraph_ingestor)
+
+
+def test_shadowed_process_emits_no_env_read(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) `process` bound locally (a parameter) is not the Node global, so
+    # (H) process.env.X must not emit an ENV read.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "app.js",
+        "function run(process) {\n  const a = process.env.SECRET;\n}\n",
+    )
+    assert "resource::ENV::SECRET" not in _reads(memgraph_ingestor)

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.325"
+version = "0.0.326"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Follow-up to #714 (JS/TS I/O). The first JS/TS increment (#736) covered **call** sinks; this adds the other idiomatic JS read: **`process.env.X`** environment access, which is a `member_expression` / `subscript_expression`, not a call.

```js
function boot() {
  const a = process.env.SECRET;      // READS_FROM ENV::SECRET
  const b = process.env['TOKEN'];    // READS_FROM ENV::TOKEN  (subscript)
  fetch(process.env.URL);            // READS_FROM ENV::URL  (in an argument)
}
```

## Design

- A small per-language member-read registry `IO_MEMBER_READS` maps an object prefix to a `ResourceKind` — for JS/TS: `process.env → ENV`. Each future language/prefix is one row.
- The `LanguageDescriptor` gains the member/subscript node types + `object`/`property` fields.
- The scope-aware JS walk now also inspects `member_expression` / `subscript_expression` nodes: when the object text matches a prefix, it emits a `READS_FROM` to `ENV::<key>` (the member property, or the string subscript index; else `<dynamic>`).

**Shadowing:** the prefix head (`process`) is shadow-checked exactly like a call sink — a local `const process` / `function process` / a `process` **parameter**, or an `import process from './x'`, suppresses the read (it isn't the Node global). Reuses the same lexical `in_scope` set and `node:`-aware import check from #736.

## Test (RED → GREEN)

New `test_jsts_env_e2e.py`: member access, string subscript, and env-in-argument all emit `ENV::<key>`; a TS file works the same; a `process` parameter emits nothing.

Full suite: 5081 passed (one Rust-eval flake, passes in isolation), 10 skipped. ruff + ty clean; Python I/O unchanged.

Next #714 follow-up: JS `FLOWS_TO` (taint), which will use `process.env` as a source.