### PR TITLE
fix(csharp): start line skips leading #if-wrapped attribute directive

### DIFF
--- a/codebase_rag/constants/ast_csharp.py
+++ b/codebase_rag/constants/ast_csharp.py
@@ -25,6 +25,14 @@ TS_CSHARP_RECORD_DECLARATION = "record_declaration"
 TS_CSHARP_INTERFACE_DECLARATION = "interface_declaration"
 TS_CSHARP_ENUM_DECLARATION = "enum_declaration"
 
+# (H) A conditional-compilation block wrapping a declaration's attributes
+# (H) (`#if SYMBOL [Attr] #endif`) parses as this node, which sits as the leading
+# (H) child of the declaration -- so the declaration's start_point is the `#if`
+# (H) directive line. The real first token (Roslyn's span start) is the
+# (H) attribute_list nested inside it.
+TS_CSHARP_PREPROC_IF_IN_ATTR_LIST = "preproc_if_in_attribute_list"
+TS_CSHARP_ATTRIBUTE_LIST = "attribute_list"
+
 # (H) Member declarations -> Function/Method nodes.
 TS_CSHARP_METHOD_DECLARATION = "method_declaration"
 TS_CSHARP_CONSTRUCTOR_DECLARATION = "constructor_declaration"

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -697,9 +697,15 @@ class ClassIngestMixin:
             return
 
         class_qn, class_name, is_exported = identity
-        class_qn = self.function_registry.register_unique_qn(
-            class_qn, class_node.start_point[0] + 1
-        )
+        if language == cs.SupportedLanguage.CSHARP:
+            # (H) Skip a leading `#if [Attr] #endif` directive so the start line is
+            # (H) the conditional attribute, not the `#if` line (matches Roslyn).
+            from ..csharp import utils as csharp_utils
+
+            class_start_line = csharp_utils.definition_start_line(class_node)
+        else:
+            class_start_line = class_node.start_point[0] + 1
+        class_qn = self.function_registry.register_unique_qn(class_qn, class_start_line)
         node_type = nt.determine_node_type(class_node, class_name, class_qn, language)
 
         modifiers, decorators = extract_modifiers_and_decorators(
@@ -711,7 +717,7 @@ class ClassIngestMixin:
             cs.KEY_NAME: class_name,
             cs.KEY_MODIFIERS: modifiers,
             cs.KEY_DECORATORS: decorators,
-            cs.KEY_START_LINE: class_node.start_point[0] + 1,
+            cs.KEY_START_LINE: class_start_line,
             cs.KEY_END_LINE: class_node.end_point[0] + 1,
             cs.KEY_DOCSTRING: self._get_docstring(class_node),
             cs.KEY_IS_EXPORTED: is_exported,

--- a/codebase_rag/parsers/csharp/utils.py
+++ b/codebase_rag/parsers/csharp/utils.py
@@ -6,6 +6,18 @@ from ... import constants as cs
 from ..utils import safe_decode_text
 
 
+def _first_attribute_list(node: Node) -> Node | None:
+    # (H) First attribute_list in document order anywhere under `node` (pre-order
+    # (H) DFS), so an attribute nested in an inner `#if` (a conditional block
+    # (H) inside another) is still found, not only an immediate grandchild.
+    if node.type == cs.TS_CSHARP_ATTRIBUTE_LIST:
+        return node
+    for child in node.children:
+        if (found := _first_attribute_list(child)) is not None:
+            return found
+    return None
+
+
 def definition_start_line(node: Node) -> int:
     # (H) The 1-based line a declaration truly starts on. When its attributes are
     # (H) wrapped in a conditional-compilation block (`#if SYMBOL [Attr] #endif`),
@@ -17,9 +29,8 @@ def definition_start_line(node: Node) -> int:
     # (H) with no leading directive.
     for child in node.children:
         if child.type == cs.TS_CSHARP_PREPROC_IF_IN_ATTR_LIST:
-            for grandchild in child.children:
-                if grandchild.type == cs.TS_CSHARP_ATTRIBUTE_LIST:
-                    return grandchild.start_point[0] + 1
+            if (attr_list := _first_attribute_list(child)) is not None:
+                return attr_list.start_point[0] + 1
             continue
         return child.start_point[0] + 1
     return node.start_point[0] + 1

--- a/codebase_rag/parsers/csharp/utils.py
+++ b/codebase_rag/parsers/csharp/utils.py
@@ -6,6 +6,25 @@ from ... import constants as cs
 from ..utils import safe_decode_text
 
 
+def definition_start_line(node: Node) -> int:
+    # (H) The 1-based line a declaration truly starts on. When its attributes are
+    # (H) wrapped in a conditional-compilation block (`#if SYMBOL [Attr] #endif`),
+    # (H) tree-sitter nests a leading preproc_if_in_attribute_list child, so the
+    # (H) declaration's own start_point is the `#if` directive line. Roslyn treats
+    # (H) the directives as trivia and starts the span at the conditional
+    # (H) attribute, so return that attribute's line (else the first non-directive
+    # (H) child's line). Falls back to the node's own start for the common case
+    # (H) with no leading directive.
+    for child in node.children:
+        if child.type == cs.TS_CSHARP_PREPROC_IF_IN_ATTR_LIST:
+            for grandchild in child.children:
+                if grandchild.type == cs.TS_CSHARP_ATTRIBUTE_LIST:
+                    return grandchild.start_point[0] + 1
+            continue
+        return child.start_point[0] + 1
+    return node.start_point[0] + 1
+
+
 def _normalize_type_name(text: str) -> str:
     # (H) Strip generic arguments (`List<int>` -> `List`), a nullable suffix
     # (H) (`Widget?`/`int?` -> the underlying type, so a nullable receiver still

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -740,11 +740,18 @@ def ingest_method(
     else:
         method_name = text.decode(cs.ENCODING_UTF8)
 
+    if language == cs.SupportedLanguage.CSHARP:
+        # (H) Skip a leading `#if [Attr] #endif` directive so the start line is the
+        # (H) conditional attribute, not the `#if` line (matches Roslyn's span).
+        from .csharp import utils as csharp_utils
+
+        method_start_line = csharp_utils.definition_start_line(method_node)
+    else:
+        method_start_line = method_node.start_point[0] + 1
+
     method_qn = method_qualified_name or f"{container_qn}.{method_name}"
     if language != cs.SupportedLanguage.CPP:
-        method_qn = function_registry.register_unique_qn(
-            method_qn, method_node.start_point[0] + 1
-        )
+        method_qn = function_registry.register_unique_qn(method_qn, method_start_line)
 
     decorators = []
     modifiers = []
@@ -761,7 +768,7 @@ def ingest_method(
         cs.KEY_NAME: method_name,
         cs.KEY_MODIFIERS: modifiers,
         cs.KEY_DECORATORS: decorators,
-        cs.KEY_START_LINE: method_node.start_point[0] + 1,
+        cs.KEY_START_LINE: method_start_line,
         # (H) Dart method signatures end before their sibling function_body;
         # (H) extend the span over the body (no-op for other languages).
         cs.KEY_END_LINE: _method_end_line(method_node, language),

--- a/codebase_rag/tests/test_csharp_preproc_start_line.py
+++ b/codebase_rag/tests/test_csharp_preproc_start_line.py
@@ -1,0 +1,79 @@
+# (H) A C# declaration whose attribute is wrapped in a conditional-compilation
+# (H) block (`#if ... [Attr] ... #endif`) parses with a leading
+# (H) preproc_if_in_attribute_list child, so the raw declaration node starts on
+# (H) the `#if` line. cgr must record the declaration's start line as the real
+# (H) first token (the conditional attribute), matching Roslyn's span, not the
+# (H) `#if` directive line.
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import get_nodes, run_updater
+
+SKIP = "c_sharp"
+
+
+def _start_line(mock_ingestor: MagicMock, node_type: str, leaf: str) -> int:
+    for call in get_nodes(mock_ingestor, node_type):
+        props = call[0][1]
+        if props[cs.KEY_QUALIFIED_NAME].split("(", 1)[0].endswith(leaf):
+            return props[cs.KEY_START_LINE]
+    raise AssertionError(f"{node_type} {leaf} not found")
+
+
+def test_class_start_line_skips_leading_if_directive(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    project = temp_repo / "cs_preproc_class"
+    project.mkdir()
+    # (H) Lines: 1 ns, 2 blank, 3 doc, 4 #if, 5 [attr], 6 #endif, 7 class.
+    (project / "Broken.cs").write_text(
+        "namespace N;\n"
+        "\n"
+        "/// <summary>doc</summary>\n"
+        "#if !NETCOREAPP\n"
+        "[System.Serializable]\n"
+        "#endif\n"
+        "public class Broken { }\n",
+        encoding="utf-8",
+    )
+    run_updater(project, mock_ingestor, skip_if_missing=SKIP)
+    # (H) The conditional attribute is on line 5; the `#if` directive on line 4
+    # (H) must not be counted as the class's start.
+    assert _start_line(mock_ingestor, cs.NodeLabel.CLASS.value, "Broken") == 5
+
+
+def test_method_start_line_skips_leading_if_directive(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    project = temp_repo / "cs_preproc_method"
+    project.mkdir()
+    # (H) Lines: 1 ns, 2 class, 3 #if, 4 [attr], 5 #endif, 6 method.
+    (project / "Host.cs").write_text(
+        "namespace N;\n"
+        "public class Host {\n"
+        "#if DEBUG\n"
+        "[System.Obsolete]\n"
+        "#endif\n"
+        "public void M() { }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    run_updater(project, mock_ingestor, skip_if_missing=SKIP)
+    assert _start_line(mock_ingestor, cs.NodeLabel.METHOD.value, "M") == 4
+
+
+def test_plain_attribute_start_line_unchanged(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) Guard the fix does not shift the normal (non-conditional) attribute case:
+    # (H) a plain `[Attr]` above a class is already the class's first token.
+    project = temp_repo / "cs_plain_attr"
+    project.mkdir()
+    # (H) Lines: 1 ns, 2 [attr], 3 class.
+    (project / "Tagged.cs").write_text(
+        "namespace N;\n[System.Serializable]\npublic class Tagged { }\n",
+        encoding="utf-8",
+    )
+    run_updater(project, mock_ingestor, skip_if_missing=SKIP)
+    assert _start_line(mock_ingestor, cs.NodeLabel.CLASS.value, "Tagged") == 2

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.327"
+version = "0.0.329"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

Fixes cgr's C# declaration start line when the declaration's attributes are wrapped in a conditional-compilation block (`#if SYMBOL [Attr] #endif`). tree-sitter-c-sharp nests a leading `preproc_if_in_attribute_list` child in that case, so the declaration node's `start_point` is the `#if` directive line instead of the real first token. Roslyn treats the directives as trivia and starts the span at the conditional attribute; cgr now matches.

## Why it's a cgr fix, not a grammar fork

The grammar's behavior is reasonable: a conditionally-compiled attribute genuinely belongs to the declaration, so it nests under it. Only the reported start line is wrong. A new `csharp/utils.definition_start_line()` helper skips the leading directive tokens to the conditional attribute (else the first non-directive child), applied at the C# class and method ingestion sites. It is a no-op for the common case and for every other language.

## Found by the C# eval oracle

The just-merged C# L1 oracle (#737) surfaced this: on Polly, the ~1% node/containment misses clustered on `#if`-wrapped exception classes (e.g. `BrokenCircuitException`), where cgr reported the class at the `#if` line and Roslyn at the attribute line.

## Result (Polly src, 416 files)

| category | before | after |
|---|---|---|
| nodes ALL F1 | 0.9945 | **0.9964** |
| Class F1 | 0.9817 | **0.9925** |
| containment ALL F1 | 0.9756 | **0.9905** |
| INHERITS F1 | 0.8470 | **0.8754** |

Containment jumped the most because the wrong start lines were also breaking the `(kind, file, line)` join for `DEFINES`/`DEFINES_METHOD` edges.

## Tests

`test_csharp_preproc_start_line.py` (RED->GREEN): a `#if`-wrapped attribute before a class and before a method must report the attribute line, plus a guard that the plain (non-conditional) attribute case is unchanged. Full suite: 5095 passed.
