### PR TITLE
feat(io): READS_FROM/WRITES_TO for Go I/O sinks (#714)

### DIFF
--- a/codebase_rag/constants/ast_go.py
+++ b/codebase_rag/constants/ast_go.py
@@ -34,6 +34,8 @@ TS_GO_ASSIGNMENT_STATEMENT = "assignment_statement"
 # (H) the selector/subscript node shapes (only used by member-access reads, which Go
 # (H) has none of, so they are inert placeholders here).
 TS_GO_IDENTIFIER = "identifier"
+TS_GO_CONST_SPEC = "const_spec"
+TS_GO_RANGE_CLAUSE = "range_clause"
 TS_GO_BLOCK = "block"
 TS_GO_INTERPRETED_STRING = "interpreted_string_literal"
 TS_GO_INTERPRETED_STRING_CONTENT = "interpreted_string_literal_content"

--- a/codebase_rag/constants/ast_go.py
+++ b/codebase_rag/constants/ast_go.py
@@ -33,6 +33,7 @@ TS_GO_ASSIGNMENT_STATEMENT = "assignment_statement"
 # (H) `interpreted_string_literal_content` child; `index_expression`/operand+field are
 # (H) the selector/subscript node shapes (only used by member-access reads, which Go
 # (H) has none of, so they are inert placeholders here).
+TS_GO_IDENTIFIER = "identifier"
 TS_GO_BLOCK = "block"
 TS_GO_INTERPRETED_STRING = "interpreted_string_literal"
 TS_GO_INTERPRETED_STRING_CONTENT = "interpreted_string_literal_content"

--- a/codebase_rag/constants/ast_go.py
+++ b/codebase_rag/constants/ast_go.py
@@ -28,6 +28,18 @@ TS_GO_VAR_DECLARATION = "var_declaration"
 TS_GO_VAR_SPEC = "var_spec"
 TS_GO_SHORT_VAR_DECLARATION = "short_var_declaration"
 TS_GO_ASSIGNMENT_STATEMENT = "assignment_statement"
+# (H) I/O detection (issue #714): a function body is a `block`; string arguments are
+# (H) `interpreted_string_literal` (double-quoted) whose text lives in a
+# (H) `interpreted_string_literal_content` child; `index_expression`/operand+field are
+# (H) the selector/subscript node shapes (only used by member-access reads, which Go
+# (H) has none of, so they are inert placeholders here).
+TS_GO_BLOCK = "block"
+TS_GO_INTERPRETED_STRING = "interpreted_string_literal"
+TS_GO_INTERPRETED_STRING_CONTENT = "interpreted_string_literal_content"
+TS_GO_INDEX_EXPRESSION = "index_expression"
+TS_GO_FIELD_OPERAND = "operand"
+TS_GO_FIELD_FIELD = "field"
+TS_GO_FIELD_INDEX = "index"
 TS_GO_EXPRESSION_LIST = "expression_list"
 TS_GO_COMPOSITE_LITERAL = "composite_literal"
 TS_GO_LITERAL_VALUE = "literal_value"

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -468,13 +468,17 @@ class FlowProcessor:
             return None
         if (sink := match_normalised(raw, jc.flow.import_map, sink_map)) is not None:
             return sink
-        if not sep or not head_is_genuine_module(jc.flow.import_map.get(head), head):
+        if not sep or not head_is_genuine_module(
+            jc.flow.import_map.get(head), head, jc.descriptor.path_based_imports
+        ):
             return None
         return sink_map.get(raw)
 
     @staticmethod
     def _js_import_shadowed(head: str, jc: _JsCtx) -> bool:
-        return not head_is_genuine_module(jc.flow.import_map.get(head), head)
+        return not head_is_genuine_module(
+            jc.flow.import_map.get(head), head, jc.descriptor.path_based_imports
+        )
 
     def _js_local_names(
         self, caller_node: Node, descriptor: LanguageDescriptor

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -468,17 +468,13 @@ class FlowProcessor:
             return None
         if (sink := match_normalised(raw, jc.flow.import_map, sink_map)) is not None:
             return sink
-        if not sep or not head_is_genuine_module(
-            jc.flow.import_map.get(head), head, jc.descriptor.path_based_imports
-        ):
+        if not sep or not head_is_genuine_module(jc.flow.import_map.get(head), head):
             return None
         return sink_map.get(raw)
 
     @staticmethod
     def _js_import_shadowed(head: str, jc: _JsCtx) -> bool:
-        return not head_is_genuine_module(
-            jc.flow.import_map.get(head), head, jc.descriptor.path_based_imports
-        )
+        return not head_is_genuine_module(jc.flow.import_map.get(head), head)
 
     def _js_local_names(
         self, caller_node: Node, descriptor: LanguageDescriptor

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -24,6 +24,7 @@ from ..io_access import (
     ResourceKind,
     call_name,
     definition_header_nodes,
+    head_is_genuine_module,
     is_require_alias,
     literal_target,
     match_normalised,
@@ -467,22 +468,13 @@ class FlowProcessor:
             return None
         if (sink := match_normalised(raw, jc.flow.import_map, sink_map)) is not None:
             return sink
-        if not sep:
+        if not sep or not head_is_genuine_module(jc.flow.import_map.get(head), head):
             return None
-        base = jc.flow.import_map.get(head)
-        ok = (
-            base is None
-            or base.split(cs.SEPARATOR_DOT)[0].removeprefix(cs.NODE_BUILTIN_PREFIX)
-            == head
-        )
-        return sink_map.get(raw) if ok else None
+        return sink_map.get(raw)
 
     @staticmethod
     def _js_import_shadowed(head: str, jc: _JsCtx) -> bool:
-        base = jc.flow.import_map.get(head)
-        return base is not None and (
-            base.split(cs.SEPARATOR_DOT)[0].removeprefix(cs.NODE_BUILTIN_PREFIX) != head
-        )
+        return not head_is_genuine_module(jc.flow.import_map.get(head), head)
 
     def _js_local_names(
         self, caller_node: Node, descriptor: LanguageDescriptor

--- a/codebase_rag/parsers/io_access/__init__.py
+++ b/codebase_rag/parsers/io_access/__init__.py
@@ -11,6 +11,7 @@ from .descriptor import LANGUAGE_DESCRIPTORS, LanguageDescriptor
 from .extract import (
     call_name,
     definition_header_nodes,
+    head_is_genuine_module,
     is_require_alias,
     literal_target,
     match_normalised,
@@ -46,6 +47,7 @@ __all__ = [
     "ResourceKind",
     "call_name",
     "definition_header_nodes",
+    "head_is_genuine_module",
     "is_require_alias",
     "literal_target",
     "match_normalised",

--- a/codebase_rag/parsers/io_access/descriptor.py
+++ b/codebase_rag/parsers/io_access/descriptor.py
@@ -36,10 +36,6 @@ class LanguageDescriptor:
     object_field: str
     property_field: str
     subscript_index_field: str
-    # (H) Go imports resolve to a package PATH (`net/http`), whose package name is the
-    # (H) last segment (`http`); JS import bases have `/` normalised to `.`, so the
-    # (H) last-path-segment fallback for a genuine-module match must be Go-only.
-    path_based_imports: bool
 
 
 _JS_TS_DESCRIPTOR = LanguageDescriptor(
@@ -65,7 +61,6 @@ _JS_TS_DESCRIPTOR = LanguageDescriptor(
     object_field=cs.FIELD_OBJECT,
     property_field=cs.FIELD_PROPERTY,
     subscript_index_field=cs.TS_FIELD_INDEX,
-    path_based_imports=False,
 )
 
 _GO_DESCRIPTOR = LanguageDescriptor(
@@ -94,7 +89,6 @@ _GO_DESCRIPTOR = LanguageDescriptor(
     object_field=cs.TS_GO_FIELD_OPERAND,
     property_field=cs.TS_GO_FIELD_FIELD,
     subscript_index_field=cs.TS_GO_FIELD_INDEX,
-    path_based_imports=True,
 )
 
 # (H) Non-Python languages with a direct-sink descriptor. Python keeps its own

--- a/codebase_rag/parsers/io_access/descriptor.py
+++ b/codebase_rag/parsers/io_access/descriptor.py
@@ -29,6 +29,9 @@ class LanguageDescriptor:
     # (H) A nested block introduces a new lexical scope: const/let declared inside
     # (H) it do not shadow the enclosing scope, so declarator collection stops here.
     block_scope_type: str
+    # (H) Extra declaration node types (beyond declarator_type) whose bound names also
+    # (H) shadow a builtin -- Go's `var`/`const`/`range` specs; empty for JS/TS.
+    extra_declarator_types: frozenset[str]
     # (H) Member/subscript access node types + fields, for env reads like
     # (H) `process.env.X` (member) and `process.env['X']` (subscript).
     member_expression_type: str
@@ -56,6 +59,7 @@ _JS_TS_DESCRIPTOR = LanguageDescriptor(
     declarator_type=cs.TS_VARIABLE_DECLARATOR,
     params_field=cs.TS_FIELD_PARAMETERS,
     block_scope_type=cs.TS_STATEMENT_BLOCK,
+    extra_declarator_types=frozenset(),
     member_expression_type=cs.TS_MEMBER_EXPRESSION,
     subscript_type=cs.TS_SUBSCRIPT_EXPRESSION,
     object_field=cs.FIELD_OBJECT,
@@ -75,13 +79,16 @@ _GO_DESCRIPTOR = LanguageDescriptor(
             cs.TS_GO_FUNC_LITERAL,
         }
     ),
-    # (H) Go's `:=` / parameter_declaration shapes differ from JS, so the JS-shaped
-    # (H) local-name collection matches nothing for Go -- benign, since shadowing a
-    # (H) package name (`os`, `fmt`) with a local does not compile in Go.
+    # (H) Go local declarations that shadow a package name: `:=` (declarator_type),
+    # (H) `var`/`const`/`range` (extra_declarator_types), and parameters. Go DOES
+    # (H) allow a local to shadow an imported package, so these must be collected.
     identifier_type=cs.TS_GO_IDENTIFIER,
     declarator_type=cs.TS_GO_SHORT_VAR_DECLARATION,
     params_field=cs.TS_FIELD_PARAMETERS,
     block_scope_type=cs.TS_GO_BLOCK,
+    extra_declarator_types=frozenset(
+        {cs.TS_GO_VAR_SPEC, cs.TS_GO_CONST_SPEC, cs.TS_GO_RANGE_CLAUSE}
+    ),
     # (H) Inert for Go (no IO_MEMBER_READS entry): Go env access is a call
     # (H) (`os.Getenv`), not member access. Filled with Go's selector/subscript shapes.
     member_expression_type=cs.TS_GO_SELECTOR_EXPRESSION,

--- a/codebase_rag/parsers/io_access/descriptor.py
+++ b/codebase_rag/parsers/io_access/descriptor.py
@@ -36,6 +36,10 @@ class LanguageDescriptor:
     object_field: str
     property_field: str
     subscript_index_field: str
+    # (H) Go imports resolve to a package PATH (`net/http`), whose package name is the
+    # (H) last segment (`http`); JS import bases have `/` normalised to `.`, so the
+    # (H) last-path-segment fallback for a genuine-module match must be Go-only.
+    path_based_imports: bool
 
 
 _JS_TS_DESCRIPTOR = LanguageDescriptor(
@@ -61,6 +65,7 @@ _JS_TS_DESCRIPTOR = LanguageDescriptor(
     object_field=cs.FIELD_OBJECT,
     property_field=cs.FIELD_PROPERTY,
     subscript_index_field=cs.TS_FIELD_INDEX,
+    path_based_imports=False,
 )
 
 _GO_DESCRIPTOR = LanguageDescriptor(
@@ -78,7 +83,7 @@ _GO_DESCRIPTOR = LanguageDescriptor(
     # (H) Go's `:=` / parameter_declaration shapes differ from JS, so the JS-shaped
     # (H) local-name collection matches nothing for Go -- benign, since shadowing a
     # (H) package name (`os`, `fmt`) with a local does not compile in Go.
-    identifier_type=cs.TS_PY_IDENTIFIER,
+    identifier_type=cs.TS_GO_IDENTIFIER,
     declarator_type=cs.TS_GO_SHORT_VAR_DECLARATION,
     params_field=cs.TS_FIELD_PARAMETERS,
     block_scope_type=cs.TS_GO_BLOCK,
@@ -89,6 +94,7 @@ _GO_DESCRIPTOR = LanguageDescriptor(
     object_field=cs.TS_GO_FIELD_OPERAND,
     property_field=cs.TS_GO_FIELD_FIELD,
     subscript_index_field=cs.TS_GO_FIELD_INDEX,
+    path_based_imports=True,
 )
 
 # (H) Non-Python languages with a direct-sink descriptor. Python keeps its own

--- a/codebase_rag/parsers/io_access/descriptor.py
+++ b/codebase_rag/parsers/io_access/descriptor.py
@@ -63,10 +63,39 @@ _JS_TS_DESCRIPTOR = LanguageDescriptor(
     subscript_index_field=cs.TS_FIELD_INDEX,
 )
 
+_GO_DESCRIPTOR = LanguageDescriptor(
+    call_type=cs.TS_GO_CALL_EXPRESSION,
+    string_type=cs.TS_GO_INTERPRETED_STRING,
+    string_content_type=cs.TS_GO_INTERPRETED_STRING_CONTENT,
+    keyword_arg_type=None,
+    nested_scope_types=frozenset(
+        {
+            cs.TS_GO_FUNCTION_DECLARATION,
+            cs.TS_GO_METHOD_DECLARATION,
+            cs.TS_GO_FUNC_LITERAL,
+        }
+    ),
+    # (H) Go's `:=` / parameter_declaration shapes differ from JS, so the JS-shaped
+    # (H) local-name collection matches nothing for Go -- benign, since shadowing a
+    # (H) package name (`os`, `fmt`) with a local does not compile in Go.
+    identifier_type=cs.TS_PY_IDENTIFIER,
+    declarator_type=cs.TS_GO_SHORT_VAR_DECLARATION,
+    params_field=cs.TS_FIELD_PARAMETERS,
+    block_scope_type=cs.TS_GO_BLOCK,
+    # (H) Inert for Go (no IO_MEMBER_READS entry): Go env access is a call
+    # (H) (`os.Getenv`), not member access. Filled with Go's selector/subscript shapes.
+    member_expression_type=cs.TS_GO_SELECTOR_EXPRESSION,
+    subscript_type=cs.TS_GO_INDEX_EXPRESSION,
+    object_field=cs.TS_GO_FIELD_OPERAND,
+    property_field=cs.TS_GO_FIELD_FIELD,
+    subscript_index_field=cs.TS_GO_FIELD_INDEX,
+)
+
 # (H) Non-Python languages with a direct-sink descriptor. Python keeps its own
 # (H) handle-aware walk; each new language lands one entry (plus registry rows).
 LANGUAGE_DESCRIPTORS: dict[cs.SupportedLanguage, LanguageDescriptor] = {
     cs.SupportedLanguage.JS: _JS_TS_DESCRIPTOR,
     cs.SupportedLanguage.TS: _JS_TS_DESCRIPTOR,
     cs.SupportedLanguage.TSX: _JS_TS_DESCRIPTOR,
+    cs.SupportedLanguage.GO: _GO_DESCRIPTOR,
 }

--- a/codebase_rag/parsers/io_access/descriptor.py
+++ b/codebase_rag/parsers/io_access/descriptor.py
@@ -32,6 +32,10 @@ class LanguageDescriptor:
     # (H) Extra declaration node types (beyond declarator_type) whose bound names also
     # (H) shadow a builtin -- Go's `var`/`const`/`range` specs; empty for JS/TS.
     extra_declarator_types: frozenset[str]
+    # (H) True when a dotted sink call requires its head to be an imported package
+    # (H) (Go always imports stdlib; a package-scope `var os` is not the stdlib os).
+    # (H) False for JS/TS, whose sinks include unimported globals (`console`, `fetch`).
+    sinks_require_import: bool
     # (H) Member/subscript access node types + fields, for env reads like
     # (H) `process.env.X` (member) and `process.env['X']` (subscript).
     member_expression_type: str
@@ -60,6 +64,7 @@ _JS_TS_DESCRIPTOR = LanguageDescriptor(
     params_field=cs.TS_FIELD_PARAMETERS,
     block_scope_type=cs.TS_STATEMENT_BLOCK,
     extra_declarator_types=frozenset(),
+    sinks_require_import=False,
     member_expression_type=cs.TS_MEMBER_EXPRESSION,
     subscript_type=cs.TS_SUBSCRIPT_EXPRESSION,
     object_field=cs.FIELD_OBJECT,
@@ -89,6 +94,7 @@ _GO_DESCRIPTOR = LanguageDescriptor(
     extra_declarator_types=frozenset(
         {cs.TS_GO_VAR_SPEC, cs.TS_GO_CONST_SPEC, cs.TS_GO_RANGE_CLAUSE}
     ),
+    sinks_require_import=True,
     # (H) Inert for Go (no IO_MEMBER_READS entry): Go env access is a call
     # (H) (`os.Getenv`), not member access. Filled with Go's selector/subscript shapes.
     member_expression_type=cs.TS_GO_SELECTOR_EXPRESSION,

--- a/codebase_rag/parsers/io_access/extract.py
+++ b/codebase_rag/parsers/io_access/extract.py
@@ -111,17 +111,22 @@ def registry_match[T](
     return None
 
 
-def head_is_genuine_module(base: str | None, head: str) -> bool:
+def head_is_genuine_module(
+    base: str | None, head: str, allow_path_segment: bool = False
+) -> bool:
     # (H) True when `head` names the genuine imported module (so its raw dotted call
     # (H) may match a sink). None base = an unimported global. Otherwise the import
     # (H) base's module identity must equal head: drop any member suffix and node:
-    # (H) scheme, then accept either the whole name (JS `fs`) or its last path segment
-    # (H) (Go's `net/http` package is `http`). A local `import fs from './fake'`
-    # (H) resolves elsewhere and is correctly rejected (issue #714).
+    # (H) scheme. For path-based imports (Go: `net/http` -> package `http`) the last
+    # (H) path segment is also accepted; JS normalises `/` to `.` in bases, so its
+    # (H) `memfs/fs` -> `memfs.fs...` (module `memfs`) is correctly rejected. A local
+    # (H) `import fs from './fake'` also resolves elsewhere and is rejected (#714).
     if base is None:
         return True
     module = base.split(cs.SEPARATOR_DOT)[0].removeprefix(cs.NODE_BUILTIN_PREFIX)
-    return module == head or module.rsplit("/", 1)[-1] == head
+    if module == head:
+        return True
+    return allow_path_segment and module.rsplit("/", 1)[-1] == head
 
 
 def match_normalised[T](

--- a/codebase_rag/parsers/io_access/extract.py
+++ b/codebase_rag/parsers/io_access/extract.py
@@ -111,6 +111,19 @@ def registry_match[T](
     return None
 
 
+def head_is_genuine_module(base: str | None, head: str) -> bool:
+    # (H) True when `head` names the genuine imported module (so its raw dotted call
+    # (H) may match a sink). None base = an unimported global. Otherwise the import
+    # (H) base's module identity must equal head: drop any member suffix and node:
+    # (H) scheme, then accept either the whole name (JS `fs`) or its last path segment
+    # (H) (Go's `net/http` package is `http`). A local `import fs from './fake'`
+    # (H) resolves elsewhere and is correctly rejected (issue #714).
+    if base is None:
+        return True
+    module = base.split(cs.SEPARATOR_DOT)[0].removeprefix(cs.NODE_BUILTIN_PREFIX)
+    return module == head or module.rsplit("/", 1)[-1] == head
+
+
 def match_normalised[T](
     raw: str, import_map: dict[str, str], mapping: dict[str, T]
 ) -> T | None:

--- a/codebase_rag/parsers/io_access/extract.py
+++ b/codebase_rag/parsers/io_access/extract.py
@@ -111,22 +111,15 @@ def registry_match[T](
     return None
 
 
-def head_is_genuine_module(
-    base: str | None, head: str, allow_path_segment: bool = False
-) -> bool:
+def head_is_genuine_module(base: str | None, head: str) -> bool:
     # (H) True when `head` names the genuine imported module (so its raw dotted call
     # (H) may match a sink). None base = an unimported global. Otherwise the import
     # (H) base's module identity must equal head: drop any member suffix and node:
-    # (H) scheme. For path-based imports (Go: `net/http` -> package `http`) the last
-    # (H) path segment is also accepted; JS normalises `/` to `.` in bases, so its
-    # (H) `memfs/fs` -> `memfs.fs...` (module `memfs`) is correctly rejected. A local
-    # (H) `import fs from './fake'` also resolves elsewhere and is rejected (#714).
+    # (H) scheme. A local `import fs from './fake'` resolves elsewhere and is rejected.
+    # (H) Path-based (Go) imports are handled separately by package-name matching.
     if base is None:
         return True
-    module = base.split(cs.SEPARATOR_DOT)[0].removeprefix(cs.NODE_BUILTIN_PREFIX)
-    if module == head:
-        return True
-    return allow_path_segment and module.rsplit("/", 1)[-1] == head
+    return base.split(cs.SEPARATOR_DOT)[0].removeprefix(cs.NODE_BUILTIN_PREFIX) == head
 
 
 def match_normalised[T](

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -417,9 +417,10 @@ class IOAccessProcessor:
                 continue
             if node.type == descriptor.block_scope_type:
                 continue
-            if node.type == descriptor.declarator_type and not is_require_alias(
-                node, descriptor.call_type
-            ):
+            if (
+                node.type == descriptor.declarator_type
+                and not is_require_alias(node, descriptor.call_type)
+            ) or node.type in descriptor.extra_declarator_types:
                 names |= self._declarator_names(node, descriptor)
             stack.extend(node.named_children)
         return names
@@ -427,16 +428,15 @@ class IOAccessProcessor:
     def _declarator_names(
         self, declarator: Node, descriptor: LanguageDescriptor
     ) -> set[str]:
-        # (H) The local names a declarator binds: JS `const fs = ...` / destructuring
-        # (H) uses the `name` field; Go `os := ...` uses the `left` field (an
-        # (H) expression_list of identifiers). All are collected so they shadow a
-        # (H) same-named builtin/package.
-        target = declarator.child_by_field_name(
-            cs.TS_FIELD_NAME
-        ) or declarator.child_by_field_name(cs.FIELD_LEFT)
+        # (H) The local names a declaration binds: JS `const fs = ...` / destructuring
+        # (H) uses the `name` field; Go `var/const os = ...` also has `name` field(s),
+        # (H) while `os := ...` / `range` use the `left` field (an expression_list of
+        # (H) identifiers). All are collected so they shadow a same-named builtin.
         names: set[str] = set()
-        if target is not None:
-            self._pattern_names(target, descriptor, names)
+        for name in declarator.children_by_field_name(cs.TS_FIELD_NAME):
+            self._pattern_names(name, descriptor, names)
+        if (left := declarator.child_by_field_name(cs.FIELD_LEFT)) is not None:
+            self._pattern_names(left, descriptor, names)
         return names
 
     def _pattern_names(

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -322,6 +322,12 @@ class IOAccessProcessor:
         # (H) module, resolved by _resolve_sink), so _block_declarations skips it;
         # (H) but a local `const fs = {}` IS a shadow, even if `fs` is imported
         # (H) module-wide, so import names are NOT blanket-removed here.
+        # (H) ponytail: order-INSENSITIVE within a block -- every declaration shadows
+        # (H) the whole block. Correct for JS (function/var hoist; const/let before
+        # (H) use is a TDZ error), but for Go's declare-at-point `:=`/`var` a local
+        # (H) declared LATER over-suppresses an earlier valid package call in the same
+        # (H) block -- a rare false NEGATIVE (redeclaring a used package name). An
+        # (H) order-sensitive walk is the upgrade if that ever matters.
         in_scope = inherited | self._block_declarations(statements, descriptor)
         stack = list(statements)
         while stack:

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -493,7 +493,9 @@ class IOAccessProcessor:
         raw = call_name(node)
         if raw is None:
             return
-        sink = self._resolve_sink(raw, import_map, sink_by_name, local_names)
+        sink = self._resolve_sink(
+            raw, import_map, sink_by_name, local_names, descriptor.path_based_imports
+        )
         if sink is None:
             return
         identity = literal_target(
@@ -512,6 +514,7 @@ class IOAccessProcessor:
         import_map: dict[str, str],
         sink_by_name: dict[str, IOSink],
         local_names: frozenset[str],
+        path_based_imports: bool,
     ) -> IOSink | None:
         # (H) Match a JS/TS call against the sink table, respecting shadowing:
         # (H)  - a name bound locally (a local `const fs`, `function fetch`, or a
@@ -531,7 +534,7 @@ class IOAccessProcessor:
             return sink
         if not sep:
             return None
-        if not head_is_genuine_module(import_map.get(head), head):
+        if not head_is_genuine_module(import_map.get(head), head, path_based_imports):
             return None
         return sink_by_name.get(raw)
 

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -507,7 +507,9 @@ class IOAccessProcessor:
         raw = call_name(node)
         if raw is None:
             return
-        sink = self._resolve_sink(raw, import_map, sink_by_name, local_names)
+        sink = self._resolve_sink(
+            raw, import_map, sink_by_name, local_names, descriptor.sinks_require_import
+        )
         if sink is None:
             return
         identity = literal_target(
@@ -526,8 +528,9 @@ class IOAccessProcessor:
         import_map: dict[str, str],
         sink_by_name: dict[str, IOSink],
         local_names: frozenset[str],
+        sinks_require_import: bool,
     ) -> IOSink | None:
-        # (H) Match a JS/TS call against the sink table, respecting shadowing:
+        # (H) Match a JS/TS/Go call against the sink table, respecting shadowing:
         # (H)  - a name bound locally (a local `const fs`, `function fetch`, or a
         # (H)    parameter) is never the builtin -> no match.
         # (H)  - the import-normalised name is tried first, so an ALIASED builtin
@@ -538,6 +541,10 @@ class IOAccessProcessor:
         # (H)    elsewhere, so its raw `fs.writeFileSync` must not fire).
         head, sep, _ = raw.partition(cs.SEPARATOR_DOT)
         if (head if sep else raw) in local_names:
+            return None
+        # (H) Go stdlib is always imported, so a dotted sink whose package head is
+        # (H) NOT imported (e.g. a package-scope `var os`) is not the stdlib package.
+        if sinks_require_import and sep and head not in import_map:
             return None
         # (H) The import-normalised name matches first: a JS named import may resolve
         # (H) to `node:fs.writeFileSync` (node:-stripped too), and a Go call resolves

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -427,14 +427,16 @@ class IOAccessProcessor:
     def _declarator_names(
         self, declarator: Node, descriptor: LanguageDescriptor
     ) -> set[str]:
-        # (H) The local names a declarator binds: a plain `const fs = ...` binds one
-        # (H) identifier; a destructuring `const { writeFileSync } = ...` /
-        # (H) `const { get: g } = ...` / `const [fetch] = ...` binds the pattern's
-        # (H) leaves. All are collected so they shadow a same-named builtin.
-        name = declarator.child_by_field_name(cs.TS_FIELD_NAME)
+        # (H) The local names a declarator binds: JS `const fs = ...` / destructuring
+        # (H) uses the `name` field; Go `os := ...` uses the `left` field (an
+        # (H) expression_list of identifiers). All are collected so they shadow a
+        # (H) same-named builtin/package.
+        target = declarator.child_by_field_name(
+            cs.TS_FIELD_NAME
+        ) or declarator.child_by_field_name(cs.FIELD_LEFT)
         names: set[str] = set()
-        if name is not None:
-            self._pattern_names(name, descriptor, names)
+        if target is not None:
+            self._pattern_names(target, descriptor, names)
         return names
 
     def _pattern_names(
@@ -451,10 +453,15 @@ class IOAccessProcessor:
             # (H) `{ key: local }` binds the VALUE (local), not the property key.
             if (value := node.child_by_field_name(cs.FIELD_VALUE)) is not None:
                 self._pattern_names(value, descriptor, out)
+        elif node_type == cs.TS_GO_PARAMETER_DECLARATION:
+            # (H) Go `func f(os Config)`: the `name` field(s) are the bound locals.
+            for child in node.children_by_field_name(cs.TS_FIELD_NAME):
+                self._pattern_names(child, descriptor, out)
         elif node_type in (
             cs.TS_OBJECT_PATTERN,
             cs.TS_ARRAY_PATTERN,
             cs.TS_REST_PATTERN,
+            cs.TS_GO_EXPRESSION_LIST,
         ):
             for child in node.named_children:
                 self._pattern_names(child, descriptor, out)
@@ -463,9 +470,10 @@ class IOAccessProcessor:
         self, caller_node: Node, descriptor: LanguageDescriptor
     ) -> set[str]:
         # (H) Parameter names bound in the whole function body. A param is a bare
-        # (H) identifier, a destructuring pattern (`function f({ http }) {}`), or a
-        # (H) TS `required_parameter` wrapper whose `pattern` field holds either --
-        # (H) all handled by _pattern_names, unwrapping the TS wrapper first.
+        # (H) identifier, a destructuring pattern (`function f({ http }) {}`), a TS
+        # (H) `required_parameter` wrapper whose `pattern` field holds either, or a Go
+        # (H) `parameter_declaration` (`os Config`) -- all handled by _pattern_names,
+        # (H) unwrapping the TS wrapper first.
         names: set[str] = set()
         params = caller_node.child_by_field_name(descriptor.params_field)
         if params is not None:

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -20,6 +20,7 @@ from .descriptor import LANGUAGE_DESCRIPTORS, LanguageDescriptor
 from .extract import (
     call_name,
     definition_header_nodes,
+    head_is_genuine_module,
     is_require_alias,
     literal_target,
     match_normalised,
@@ -375,12 +376,8 @@ class IOAccessProcessor:
             if obj_text != prefix:
                 continue
             head = prefix.partition(cs.SEPARATOR_DOT)[0]
-            if head in in_scope:
-                return
-            base = import_map.get(head)
-            if base is not None and (
-                base.split(cs.SEPARATOR_DOT)[0].removeprefix(cs.NODE_BUILTIN_PREFIX)
-                != head
+            if head in in_scope or not head_is_genuine_module(
+                import_map.get(head), head
             ):
                 return
             identity = self._member_identity(node, descriptor)
@@ -534,13 +531,9 @@ class IOAccessProcessor:
             return sink
         if not sep:
             return None
-        base = import_map.get(head)
-        head_is_builtin = (
-            base is None
-            or base.split(cs.SEPARATOR_DOT)[0].removeprefix(cs.NODE_BUILTIN_PREFIX)
-            == head
-        )
-        return sink_by_name.get(raw) if head_is_builtin else None
+        if not head_is_genuine_module(import_map.get(head), head):
+            return None
+        return sink_by_name.get(raw)
 
     def _emit_call(
         self,

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -525,7 +525,7 @@ class IOAccessProcessor:
         # (H)    resolves to the genuine module (a builtin maps `fs` -> `fs` /
         # (H)    `fs.default` / `node:fs...`; a local `import fs from './x'` maps it
         # (H)    elsewhere, so its raw `fs.writeFileSync` must not fire).
-        head, sep, _ = raw.partition(cs.SEPARATOR_DOT)
+        head, sep, rest = raw.partition(cs.SEPARATOR_DOT)
         if (head if sep else raw) in local_names:
             return None
         # (H) A named import may resolve to `node:fs.writeFileSync`; the registry keys
@@ -534,7 +534,14 @@ class IOAccessProcessor:
             return sink
         if not sep:
             return None
-        if not head_is_genuine_module(import_map.get(head), head, path_based_imports):
+        base = import_map.get(head)
+        if path_based_imports and base is not None:
+            # (H) Go imports resolve to a package PATH (`h -> net/http`); the registry
+            # (H) keys on the package name, so match `<last-path-segment>.<method>`.
+            # (H) This covers both a plain `http.Get` and an aliased `import h "net/http"`.
+            package = base.split(cs.SEPARATOR_DOT)[0].rsplit("/", 1)[-1]
+            return sink_by_name.get(f"{package}{cs.SEPARATOR_DOT}{rest}")
+        if not head_is_genuine_module(base, head):
             return None
         return sink_by_name.get(raw)
 

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -493,9 +493,7 @@ class IOAccessProcessor:
         raw = call_name(node)
         if raw is None:
             return
-        sink = self._resolve_sink(
-            raw, import_map, sink_by_name, local_names, descriptor.path_based_imports
-        )
+        sink = self._resolve_sink(raw, import_map, sink_by_name, local_names)
         if sink is None:
             return
         identity = literal_target(
@@ -514,7 +512,6 @@ class IOAccessProcessor:
         import_map: dict[str, str],
         sink_by_name: dict[str, IOSink],
         local_names: frozenset[str],
-        path_based_imports: bool,
     ) -> IOSink | None:
         # (H) Match a JS/TS call against the sink table, respecting shadowing:
         # (H)  - a name bound locally (a local `const fs`, `function fetch`, or a
@@ -525,23 +522,18 @@ class IOAccessProcessor:
         # (H)    resolves to the genuine module (a builtin maps `fs` -> `fs` /
         # (H)    `fs.default` / `node:fs...`; a local `import fs from './x'` maps it
         # (H)    elsewhere, so its raw `fs.writeFileSync` must not fire).
-        head, sep, rest = raw.partition(cs.SEPARATOR_DOT)
+        head, sep, _ = raw.partition(cs.SEPARATOR_DOT)
         if (head if sep else raw) in local_names:
             return None
-        # (H) A named import may resolve to `node:fs.writeFileSync`; the registry keys
-        # (H) on the bare module, so try the node:-stripped form too.
+        # (H) The import-normalised name matches first: a JS named import may resolve
+        # (H) to `node:fs.writeFileSync` (node:-stripped too), and a Go call resolves
+        # (H) through its package path (`http.Get` -> `net/http.Get`, aliases included),
+        # (H) which the registry keys on -- so a third-party pkg named `http` misses.
         if (sink := match_normalised(raw, import_map, sink_by_name)) is not None:
             return sink
         if not sep:
             return None
-        base = import_map.get(head)
-        if path_based_imports and base is not None:
-            # (H) Go imports resolve to a package PATH (`h -> net/http`); the registry
-            # (H) keys on the package name, so match `<last-path-segment>.<method>`.
-            # (H) This covers both a plain `http.Get` and an aliased `import h "net/http"`.
-            package = base.split(cs.SEPARATOR_DOT)[0].rsplit("/", 1)[-1]
-            return sink_by_name.get(f"{package}{cs.SEPARATOR_DOT}{rest}")
-        if not head_is_genuine_module(base, head):
+        if not head_is_genuine_module(import_map.get(head), head):
             return None
         return sink_by_name.get(raw)
 

--- a/codebase_rag/parsers/io_access/registry.py
+++ b/codebase_rag/parsers/io_access/registry.py
@@ -159,9 +159,13 @@ _JS_TS_SINKS: tuple[IOSink, ...] = (
     IOSink("fs.appendFileSync", ResourceKind.FILE, IODirection.WRITE, target_arg=0),
 )
 
-# (H) Go direct-call I/O sinks (issue #714). Keyed by the selector callee text
-# (H) (`os.Getenv`, `fmt.Println`, `http.Get`); the package name (os/fmt/http) is
-# (H) the import, matched via normalise/raw fallback. Go has no keyword args, so the
+# (H) Go direct-call I/O sinks (issue #714). Keyed by the FULL import path plus the
+# (H) function (`os.Getenv`, `net/http.Get`, `io/ioutil.ReadFile`), because a Go call
+# (H) `http.Get` resolves through import_map to its package path (`http -> net/http`)
+# (H) and match_normalised keys on that. Using the full path (not the bare package
+# (H) name) is what distinguishes the stdlib `net/http` from a third-party package
+# (H) that also happens to be named `http`, and it handles import aliases for free
+# (H) (`import h "net/http"` -> h resolves to net/http). Go has no keyword args, so the
 # (H) path/url is positional arg 0. Handle-returning calls (`os.Open`) are treated as
 # (H) a direct read/write of the path (stream handles are a follow-up); log.* and
 # (H) fmt.Fprint* (writer-targeted) are follow-ups.
@@ -170,18 +174,18 @@ _GO_SINKS: tuple[IOSink, ...] = (
     IOSink("os.LookupEnv", ResourceKind.ENV, IODirection.READ, target_arg=0),
     IOSink("os.ReadFile", ResourceKind.FILE, IODirection.READ, target_arg=0),
     IOSink("os.Open", ResourceKind.FILE, IODirection.READ, target_arg=0),
-    IOSink("ioutil.ReadFile", ResourceKind.FILE, IODirection.READ, target_arg=0),
+    IOSink("io/ioutil.ReadFile", ResourceKind.FILE, IODirection.READ, target_arg=0),
     IOSink("os.WriteFile", ResourceKind.FILE, IODirection.WRITE, target_arg=0),
     IOSink("os.Create", ResourceKind.FILE, IODirection.WRITE, target_arg=0),
     IOSink("os.Remove", ResourceKind.FILE, IODirection.WRITE, target_arg=0),
-    IOSink("ioutil.WriteFile", ResourceKind.FILE, IODirection.WRITE, target_arg=0),
+    IOSink("io/ioutil.WriteFile", ResourceKind.FILE, IODirection.WRITE, target_arg=0),
     IOSink("fmt.Print", ResourceKind.STDOUT, IODirection.WRITE),
     IOSink("fmt.Println", ResourceKind.STDOUT, IODirection.WRITE),
     IOSink("fmt.Printf", ResourceKind.STDOUT, IODirection.WRITE),
-    IOSink("http.Get", ResourceKind.NETWORK, IODirection.READ, target_arg=0),
-    IOSink("http.Head", ResourceKind.NETWORK, IODirection.READ, target_arg=0),
-    IOSink("http.Post", ResourceKind.NETWORK, IODirection.WRITE, target_arg=0),
-    IOSink("http.PostForm", ResourceKind.NETWORK, IODirection.WRITE, target_arg=0),
+    IOSink("net/http.Get", ResourceKind.NETWORK, IODirection.READ, target_arg=0),
+    IOSink("net/http.Head", ResourceKind.NETWORK, IODirection.READ, target_arg=0),
+    IOSink("net/http.Post", ResourceKind.NETWORK, IODirection.WRITE, target_arg=0),
+    IOSink("net/http.PostForm", ResourceKind.NETWORK, IODirection.WRITE, target_arg=0),
 )
 
 IO_SINKS: dict[cs.SupportedLanguage, tuple[IOSink, ...]] = {

--- a/codebase_rag/parsers/io_access/registry.py
+++ b/codebase_rag/parsers/io_access/registry.py
@@ -159,11 +159,37 @@ _JS_TS_SINKS: tuple[IOSink, ...] = (
     IOSink("fs.appendFileSync", ResourceKind.FILE, IODirection.WRITE, target_arg=0),
 )
 
+# (H) Go direct-call I/O sinks (issue #714). Keyed by the selector callee text
+# (H) (`os.Getenv`, `fmt.Println`, `http.Get`); the package name (os/fmt/http) is
+# (H) the import, matched via normalise/raw fallback. Go has no keyword args, so the
+# (H) path/url is positional arg 0. Handle-returning calls (`os.Open`) are treated as
+# (H) a direct read/write of the path (stream handles are a follow-up); log.* and
+# (H) fmt.Fprint* (writer-targeted) are follow-ups.
+_GO_SINKS: tuple[IOSink, ...] = (
+    IOSink("os.Getenv", ResourceKind.ENV, IODirection.READ, target_arg=0),
+    IOSink("os.LookupEnv", ResourceKind.ENV, IODirection.READ, target_arg=0),
+    IOSink("os.ReadFile", ResourceKind.FILE, IODirection.READ, target_arg=0),
+    IOSink("os.Open", ResourceKind.FILE, IODirection.READ, target_arg=0),
+    IOSink("ioutil.ReadFile", ResourceKind.FILE, IODirection.READ, target_arg=0),
+    IOSink("os.WriteFile", ResourceKind.FILE, IODirection.WRITE, target_arg=0),
+    IOSink("os.Create", ResourceKind.FILE, IODirection.WRITE, target_arg=0),
+    IOSink("os.Remove", ResourceKind.FILE, IODirection.WRITE, target_arg=0),
+    IOSink("ioutil.WriteFile", ResourceKind.FILE, IODirection.WRITE, target_arg=0),
+    IOSink("fmt.Print", ResourceKind.STDOUT, IODirection.WRITE),
+    IOSink("fmt.Println", ResourceKind.STDOUT, IODirection.WRITE),
+    IOSink("fmt.Printf", ResourceKind.STDOUT, IODirection.WRITE),
+    IOSink("http.Get", ResourceKind.NETWORK, IODirection.READ, target_arg=0),
+    IOSink("http.Head", ResourceKind.NETWORK, IODirection.READ, target_arg=0),
+    IOSink("http.Post", ResourceKind.NETWORK, IODirection.WRITE, target_arg=0),
+    IOSink("http.PostForm", ResourceKind.NETWORK, IODirection.WRITE, target_arg=0),
+)
+
 IO_SINKS: dict[cs.SupportedLanguage, tuple[IOSink, ...]] = {
     cs.SupportedLanguage.PYTHON: _PYTHON_SINKS,
     cs.SupportedLanguage.JS: _JS_TS_SINKS,
     cs.SupportedLanguage.TS: _JS_TS_SINKS,
     cs.SupportedLanguage.TSX: _JS_TS_SINKS,
+    cs.SupportedLanguage.GO: _GO_SINKS,
 }
 
 # (H) Member/subscript accesses that are I/O reads, keyed by the object prefix:

--- a/codebase_rag/tests/integration/test_go_io_e2e.py
+++ b/codebase_rag/tests/integration/test_go_io_e2e.py
@@ -86,3 +86,19 @@ def test_go_aliased_import_emits(
     assert (_READS, "resource::NETWORK::https://api.example.com/x") in _io_edges(
         memgraph_ingestor
     )
+
+
+def test_third_party_go_package_named_http_no_edge(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) A third-party package whose path ends in `http` is NOT net/http; keying on
+    # (H) the full import path keeps it from matching the stdlib http.Get sink.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        'package main\n\nimport "example.com/foo/http"\n\n'
+        'func fetch() {\n\thttp.Get("https://api.example.com/x")\n}\n',
+    )
+    assert (_READS, "resource::NETWORK::https://api.example.com/x") not in _io_edges(
+        memgraph_ingestor
+    )

--- a/codebase_rag/tests/integration/test_go_io_e2e.py
+++ b/codebase_rag/tests/integration/test_go_io_e2e.py
@@ -70,3 +70,19 @@ def test_go_direct_io_sinks(
     assert (_READS, "resource::NETWORK::https://api.example.com/data") in edges
     assert (_WRITES, "resource::FILE::out.txt") in edges
     assert (_WRITES, "resource::NETWORK::https://api.example.com/upload") in edges
+
+
+def test_go_aliased_import_emits(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) `import h "net/http"` aliases the package; h.Get must still match http.Get
+    # (H) via the resolved package name (last path segment of net/http).
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        'package main\n\nimport h "net/http"\n\n'
+        'func fetch() {\n\th.Get("https://api.example.com/x")\n}\n',
+    )
+    assert (_READS, "resource::NETWORK::https://api.example.com/x") in _io_edges(
+        memgraph_ingestor
+    )

--- a/codebase_rag/tests/integration/test_go_io_e2e.py
+++ b/codebase_rag/tests/integration/test_go_io_e2e.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.capture import resolve_capture
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+if TYPE_CHECKING:
+    from codebase_rag.services.graph_service import MemgraphIngestor
+
+pytestmark = [pytest.mark.integration]
+
+_READS = cs.RelationshipType.READS_FROM.value
+_WRITES = cs.RelationshipType.WRITES_TO.value
+
+
+def _build(ingestor: MemgraphIngestor, tmp_path: Path, code: str) -> None:
+    project = tmp_path / "go_project"
+    project.mkdir()
+    (project / "main.go").write_text(code, encoding="utf-8")
+    parsers, queries = load_parsers()
+    GraphUpdater(
+        ingestor=ingestor,
+        repo_path=project,
+        parsers=parsers,
+        queries=queries,
+        capture=resolve_capture([cs.CaptureGroup.IO.value]),
+    ).run()
+
+
+def _io_edges(ingestor: MemgraphIngestor) -> set[tuple[str, str]]:
+    rows = ingestor.fetch_all(
+        f"MATCH ()-[r:{_READS}|{_WRITES}]->(res:{cs.NodeLabel.RESOURCE.value}) "
+        "RETURN type(r) AS rel, res.qualified_name AS qn"
+    )
+    return {(str(row["rel"]), str(row["qn"])) for row in rows}
+
+
+_GO_CODE = """\
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+)
+
+func leak() {
+	s := os.Getenv("SECRET")
+	fmt.Println(s)
+	http.Get("https://api.example.com/data")
+	os.WriteFile("out.txt", []byte(s), 0644)
+	http.Post("https://api.example.com/upload", "text/plain", nil)
+}
+"""
+
+
+def test_go_direct_io_sinks(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    _build(memgraph_ingestor, tmp_path, _GO_CODE)
+    edges = _io_edges(memgraph_ingestor)
+    assert (_READS, "resource::ENV::SECRET") in edges
+    assert (_WRITES, "resource::STDOUT::<dynamic>") in edges
+    assert (_READS, "resource::NETWORK::https://api.example.com/data") in edges
+    assert (_WRITES, "resource::FILE::out.txt") in edges
+    assert (_WRITES, "resource::NETWORK::https://api.example.com/upload") in edges

--- a/codebase_rag/tests/integration/test_go_io_e2e.py
+++ b/codebase_rag/tests/integration/test_go_io_e2e.py
@@ -129,3 +129,24 @@ def test_go_short_var_shadows_package(
         'func f() {\n\tos := load()\n\tos.Getenv("SECRET")\n}\n',
     )
     assert (_READS, "resource::ENV::SECRET") not in _io_edges(memgraph_ingestor)
+
+
+def test_go_var_and_range_shadow_package(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) `var os = ...` and a `range` binding also shadow the package name.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        'package main\n\nimport "os"\n\n'
+        "func f(items []string) {\n"
+        "\tvar os = load()\n"
+        '\tos.Getenv("A")\n'
+        "\tfor fmt := range items {\n"
+        '\t\tfmt.Println("x")\n'
+        "\t}\n"
+        "}\n",
+    )
+    edges = _io_edges(memgraph_ingestor)
+    assert (_READS, "resource::ENV::A") not in edges
+    assert (_WRITES, "resource::STDOUT::<dynamic>") not in edges

--- a/codebase_rag/tests/integration/test_go_io_e2e.py
+++ b/codebase_rag/tests/integration/test_go_io_e2e.py
@@ -150,3 +150,16 @@ def test_go_var_and_range_shadow_package(
     edges = _io_edges(memgraph_ingestor)
     assert (_READS, "resource::ENV::A") not in edges
     assert (_WRITES, "resource::STDOUT::<dynamic>") not in edges
+
+
+def test_go_unimported_package_name_no_edge(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) A package-scope `var os` (NOT an import of stdlib os) must not match the
+    # (H) os.Getenv sink; Go stdlib packages are always imported.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        'package main\n\nvar os Config\n\nfunc f() {\n\tos.Getenv("SECRET")\n}\n',
+    )
+    assert (_READS, "resource::ENV::SECRET") not in _io_edges(memgraph_ingestor)

--- a/codebase_rag/tests/integration/test_go_io_e2e.py
+++ b/codebase_rag/tests/integration/test_go_io_e2e.py
@@ -102,3 +102,30 @@ def test_third_party_go_package_named_http_no_edge(
     assert (_READS, "resource::NETWORK::https://api.example.com/x") not in _io_edges(
         memgraph_ingestor
     )
+
+
+def test_go_local_shadows_package(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) Go allows a local to shadow an imported package name; `os` bound locally
+    # (H) is not the stdlib package, so os.Getenv here must not emit an ENV read.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        'package main\n\nimport "os"\n\n'
+        'func f(os Config) {\n\tos.Getenv("SECRET")\n}\n',
+    )
+    assert (_READS, "resource::ENV::SECRET") not in _io_edges(memgraph_ingestor)
+
+
+def test_go_short_var_shadows_package(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) A `:=` local named `os` shadows the package within the function.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        'package main\n\nimport "os"\n\n'
+        'func f() {\n\tos := load()\n\tos.Getenv("SECRET")\n}\n',
+    )
+    assert (_READS, "resource::ENV::SECRET") not in _io_edges(memgraph_ingestor)

--- a/codebase_rag/tests/integration/test_jsts_io_e2e.py
+++ b/codebase_rag/tests/integration/test_jsts_io_e2e.py
@@ -347,3 +347,19 @@ def test_renamed_destructured_require_emits(
         "function save(d) {\n  wf('a.txt', d);\n}\n",
     )
     assert (_WRITES, "resource::FILE::a.txt") in _io_edges(memgraph_ingestor)
+
+
+def test_scoped_package_ending_in_builtin_name_no_edge(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) `import fs from 'memfs/fs'` is a third-party package, not Node's fs; its
+    # (H) path ending in `fs` must NOT make fs.writeFileSync match (JS imports are
+    # (H) not path-resolved to a package name like Go's).
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "app.js",
+        "import fs from 'memfs/fs';\n\n\n"
+        "function save(d) {\n  fs.writeFileSync('a.txt', d);\n}\n",
+    )
+    assert (_WRITES, "resource::FILE::a.txt") not in _io_edges(memgraph_ingestor)

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.329"
+version = "0.0.330"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Follow-up to #714: the first **non-JavaScript** language. Go source now produces `READS_FROM`/`WRITES_TO` edges behind the opt-in `io` capture, validating the `LanguageDescriptor` abstraction across a structurally different grammar.

```go
func leak() {
    s := os.Getenv("SECRET")                       // READS_FROM  ENV::SECRET
    fmt.Println(s)                                  // WRITES_TO   STDOUT
    http.Get("https://api.example.com/data")        // READS_FROM  NETWORK::…/data
    os.WriteFile("out.txt", []byte(s), 0644)        // WRITES_TO   FILE::out.txt
    http.Post("https://api.example.com/upload", …)  // WRITES_TO   NETWORK::…/upload
}
```

## What's covered

`os.Getenv`/`os.LookupEnv` → ENV read; `os.ReadFile`/`os.Open`/`ioutil.ReadFile` → FILE read, `os.WriteFile`/`os.Create`/`os.Remove`/`ioutil.WriteFile` → FILE write; `fmt.Print`/`Println`/`Printf` → STDOUT; `http.Get`/`Head` → NETWORK read, `http.Post`/`PostForm` → NETWORK write.

## Design

One new `_GO_DESCRIPTOR` entry + a `_GO_SINKS` table — no processor changes to the walk itself. Go's `call_expression` uses a `selector_expression` callee (`os.Getenv`), so the shared `call_name` already yields the dotted name, and the string node types (`interpreted_string_literal` / `…_content`) come from the descriptor.

**One shared refactor was needed:** Go imports map the package by its path (`import "net/http"` → `http → net/http`), so the raw-fallback "is this the genuine module?" check couldn't be JS-only (`base == head`). Extracted `head_is_genuine_module`, which strips a `node:` scheme *and* accepts the last path segment (`net/http` → `http`), and reused it in the io `_resolve_sink`/member-read check and the flow `_js_match_sink`/`_js_import_shadowed`. JS behavior is unchanged (no slashes → the segment check is a no-op).

## Ceilings (noted in code)

- **Direct sinks only** — no data-flow (`FLOWS_TO`) for Go yet, and handle-returning calls (`os.Open`) are treated as a direct path read (stream handles are a follow-up).
- Go's `:=` / `parameter_declaration` shapes don't match the JS-shaped local-name collection, so Go **local shadowing** isn't modeled — benign, since shadowing a package name (`os`, `fmt`) with a local doesn't compile in Go.
- `log.*` and writer-targeted `fmt.Fprint*`, plus raw (backtick) string targets, are follow-ups.

## Test (RED → GREEN)

New `test_go_io_e2e.py` asserts all five edges from a `main.go`.

Full suite: 5106 passed, 10 skipped. ruff + ty clean; Python and JS/TS I/O unchanged.