### PR TITLE
fix(evals): parse all #if branches in C# oracle to match cgr's no-preprocessor view

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,10 @@ jobs:
   test-unit:
     name: Unit Tests (${{ matrix.os }}, py${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    # (H) Slow runners (ubuntu/windows py3.13) can exceed 20 min on the full -n auto
+    # (H) suite and hit the cap as a spurious CANCELLED; 30 min absorbs the variance
+    # (H) while still bounding a genuine hang.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/codebase_rag/tests/test_csharp_structure_oracle.py
+++ b/codebase_rag/tests/test_csharp_structure_oracle.py
@@ -163,6 +163,39 @@ def test_oracle_ignores_cgr_ignored_dirs_for_classification(
     assert (cs.RelationshipType.IMPLEMENTS.value, "Drawable") not in rels, rels
 
 
+def test_oracle_includes_declarations_in_inactive_if_regions(
+    tmp_path: Path,
+) -> None:
+    # (H) cgr has no preprocessor: it parses every `#if`/`#else` branch, so a method
+    # (H) guarded by an undefined symbol IS in cgr's graph. The Roslyn oracle must
+    # (H) match that view (neutralize conditional directives so all branches parse),
+    # (H) otherwise real declarations inside `#if` blocks read as cgr false positives
+    # (H) (e.g. ~871 phantom Method FPs on Newtonsoft.Json).
+    _require_csharp()
+    project = tmp_path / "csharp_if"
+    project.mkdir()
+    (project / "Guarded.cs").write_text(
+        "namespace N;\n"
+        "public class Guarded {\n"
+        "    public void Active() { }\n"
+        "#if HAVE_SOMETHING\n"
+        "    public void OnlyWhenDefined() { }\n"
+        "#endif\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    cgr = extract_cgr_csharp_graph(project, project.name)
+    oracle = run_csharp_oracle(project)
+    oracle_keys = {(n.kind, n.start_line) for n in oracle.nodes}
+    cgr_keys = {(n.kind, n.start_line) for n in cgr.nodes}
+    # (H) OnlyWhenDefined() is on line 5, inside the undefined `#if HAVE_SOMETHING`.
+    assert (cs.NodeLabel.METHOD.value, 5) in oracle_keys, oracle_keys
+    assert cgr_keys == oracle_keys, {
+        "cgr_only": cgr_keys - oracle_keys,
+        "oracle_only": oracle_keys - cgr_keys,
+    }
+
+
 def test_cgr_matches_roslyn_oracle_on_spans(
     graphs: tuple[GraphData, GraphData],
 ) -> None:

--- a/evals/oracles/csharp_oracle/Program.cs
+++ b/evals/oracles/csharp_oracle/Program.cs
@@ -76,7 +76,7 @@ foreach (var path in EnumerateCsFiles(rootFull, ignoredDirs))
     string text;
     try { text = File.ReadAllText(path); }
     catch { continue; }
-    var tree = CSharpSyntaxTree.ParseText(text, path: path);
+    var tree = CSharpSyntaxTree.ParseText(NeutralizeConditionalDirectives(text), path: path);
     var rel = Path.GetRelativePath(rootFull, path).Replace(Path.DirectorySeparatorChar, '/');
     files.Add((rel, tree.GetRoot()));
 }
@@ -322,6 +322,38 @@ static string TypeSimpleName(TypeSyntax type)
         default:
             return "";
     }
+}
+
+// cgr has no preprocessor: tree-sitter parses every #if/#elif/#else branch, so a
+// declaration guarded by an undefined symbol IS in cgr's graph. Roslyn instead
+// treats an undefined #if branch as disabled trivia and never yields its
+// declarations, which would make every such real declaration read as a cgr false
+// positive. Blank the conditional directive LINES (keeping the line so 1-based line
+// numbers are stable for the join) so every branch parses as active code, matching
+// cgr's structural view. Non-conditional directives (#region, #pragma, #nullable,
+// #define/#undef) don't gate code and are left for Roslyn to handle.
+static string NeutralizeConditionalDirectives(string text)
+{
+    if (text.IndexOf("#if", StringComparison.Ordinal) < 0)
+    {
+        return text;
+    }
+    var lines = text.Split('\n');
+    for (var i = 0; i < lines.Length; i++)
+    {
+        var trimmed = lines[i].TrimStart();
+        if (trimmed.StartsWith("#if", StringComparison.Ordinal)
+            || trimmed.StartsWith("#elif", StringComparison.Ordinal)
+            || trimmed.StartsWith("#else", StringComparison.Ordinal)
+            || trimmed.StartsWith("#endif", StringComparison.Ordinal))
+        {
+            // ponytail: blanks a line that merely looks like a directive (e.g. `#if`
+            // at column 0 inside a multi-line verbatim string); vanishingly rare and
+            // cgr's tree-sitter mishandles the same case, so no eval bias.
+            lines[i] = "";
+        }
+    }
+    return string.Join('\n', lines);
 }
 
 static IEnumerable<string> EnumerateCsFiles(string root, HashSet<string> ignoredDirs)

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.331"
+version = "0.0.332"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

The C# eval oracle parsed each `.cs` file with default Roslyn options, which define **no** preprocessor symbols. So any `#if UNDEFINED_SYMBOL` block became disabled trivia and its declarations were never walked. cgr has no preprocessor at all: tree-sitter parses **every** `#if`/`#elif`/`#else` branch, so those declarations ARE in cgr's graph. The mismatch made real declarations inside `#if` regions read as cgr "false positives".

On Newtonsoft.Json (125/240 files use `#if`) this was ~**871 phantom Method FPs + 68 Class FPs**, dragging node precision to 0.71 — a pure measurement artifact, not a cgr defect.

## Fix

Neutralize the conditional directive lines (`#if`/`#elif`/`#else`/`#endif`) before parsing — blank the directive line while keeping the newline, so all branches parse as active code and 1-based line numbers stay stable for the `(kind, file, start_line)` join. Non-conditional directives (`#region`, `#pragma`, `#nullable`, `#define`/`#undef`) don't gate code and are left for Roslyn. This faithfully matches cgr's structural view.

## Verification

- RED→GREEN test (`test_oracle_includes_declarations_in_inactive_if_regions`): a method inside an undefined `#if` must appear in the oracle and agree with cgr on `(kind, start_line)`. Confirmed failing (oracle emitted only the active members), then passing.
- Full oracle test file: 7 passed. Full suite: **5101 passed, 19 skipped**.
- Re-ran Newtonsoft.Json eval: node ALL F1 **0.817 → 0.965**; Method precision **0.736 → 1.000** (867 phantom FPs → 0), Class **0.742 → 1.000** (68 → 0). Spans stay ~1.0.

## Follow-up surfaced (not in this PR)

With the oracle now accurate, ~133 remaining Function "FPs" are revealed to be real class methods (e.g. `JsonTextReader.BlockCopyChars`) that **cgr mislabels as module-level Functions** when a `#if` disrupts the class-body parse — a genuine cgr bug to fix next, analogous to the `if`-keyword artifact fixed in #745.

🤖 Generated with [Claude Code](https://claude.com/claude-code)