### PR TITLE
fix(csharp): recover #if-truncated class members as methods, not module functions

### DIFF
--- a/codebase_rag/constants/ast_csharp.py
+++ b/codebase_rag/constants/ast_csharp.py
@@ -52,6 +52,25 @@ CSHARP_SYNTHESIZED_NAME_TYPES = frozenset(
     }
 )
 
+# (H) Declaration node types that are grammatically ONLY ever a type member -- C#
+# (H) has no top-level method/constructor/operator/property (a real top-level
+# (H) function is a local_function_statement, deliberately excluded). When a `#if`
+# (H) split truncates a class_declaration node early, tree-sitter detaches the
+# (H) following members into the namespace's declaration_list with no class
+# (H) ancestor, so the generic is_method_node ancestor walk returns False and they
+# (H) would be mislabelled module Functions. This set drives their recovery as
+# (H) Methods (function_ingest), by grammar invariant.
+CSHARP_MEMBER_ONLY_TYPES = frozenset(
+    {
+        TS_CSHARP_METHOD_DECLARATION,
+        TS_CSHARP_CONSTRUCTOR_DECLARATION,
+        TS_CSHARP_DESTRUCTOR_DECLARATION,
+        TS_CSHARP_OPERATOR_DECLARATION,
+        TS_CSHARP_CONVERSION_OPERATOR_DECLARATION,
+        TS_CSHARP_PROPERTY_DECLARATION,
+    }
+)
+
 # (H) Base spec: `class C : Base, IShape` / `interface I : IOther` /
 # (H) `enum E : byte`. A single base_list lumps the base class and interfaces
 # (H) together (unlike Java's separate superclass/super_interfaces clauses), so

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -1046,33 +1046,13 @@ class ClassIngestMixin:
                 # (H) Index extension methods by simple name + receiver type so a
                 # (H) `recv.Ext()` call binds to the static method even though it
                 # (H) lives on an unrelated static class (not in recv's hierarchy).
-                if receiver_type := csharp_utils.extension_receiver_type(method_node):
-                    # (H) Strip the parameter signature BEFORE taking the leaf: a
-                    # (H) qualified param type (`Poke(N2.Widget)`) contains dots, so
-                    # (H) an rsplit-then-strip would key on `Widget)` instead of the
-                    # (H) method name `Poke` and the extension would never match.
-                    leaf = ingested_qn.split(cs.CHAR_PAREN_OPEN, 1)[0].rsplit(
-                        cs.SEPARATOR_DOT, 1
-                    )[-1]
-                    # (H) The extension's declaring namespace (its class's
-                    # (H) namespace-qualified name minus the class leaf) so an
-                    # (H) unqualified `this Widget` can be resolved to
-                    # (H) `<namespace>.Widget` when matching a qualified call
-                    # (H) receiver. Empty for a top-level (namespace-less) class.
-                    ns_qualified_class = (
-                        class_qn[len(module_qn) + 1 :]
-                        if module_qn is not None
-                        and class_qn.startswith(f"{module_qn}{cs.SEPARATOR_DOT}")
-                        else class_qn
-                    )
-                    ext_namespace = (
-                        ns_qualified_class.rsplit(cs.SEPARATOR_DOT, 1)[0]
-                        if cs.SEPARATOR_DOT in ns_qualified_class
-                        else ""
-                    )
-                    self.csharp_extension_methods.setdefault(leaf, []).append(
-                        (ingested_qn, receiver_type, ext_namespace)
-                    )
+                csharp_utils.index_extension_method(
+                    self.csharp_extension_methods,
+                    ingested_qn,
+                    method_node,
+                    class_qn,
+                    module_qn,
+                )
             # (H) A Java method declared inside an anonymous class body
             # (H) (`new Base(){ @Override m(){} }`) is ingested here under the enclosing
             # (H) class but really overrides the anon class's base type. Record it so a

--- a/codebase_rag/parsers/csharp/utils.py
+++ b/codebase_rag/parsers/csharp/utils.py
@@ -92,6 +92,43 @@ def extension_receiver_type(method_node: Node) -> str | None:
     return _normalize_type_name(name) if name else None
 
 
+def index_extension_method(
+    store: dict[str, list[tuple[str, str, str]]],
+    ingested_qn: str,
+    method_node: Node,
+    class_qn: str,
+    module_qn: str | None,
+) -> None:
+    # (H) Index an extension method by simple name + receiver type + declaring
+    # (H) namespace so a `recv.Ext()` call binds to the static method even though it
+    # (H) lives on an unrelated static class (not in recv's hierarchy). Shared by the
+    # (H) class-member pass and the `#if`-truncation recovery so both stay in sync.
+    # (H) No-op for a non-extension method (no `this` receiver).
+    receiver_type = extension_receiver_type(method_node)
+    if not receiver_type:
+        return
+    # (H) Strip the parameter signature BEFORE taking the leaf: a qualified param
+    # (H) type (`Poke(N2.Widget)`) contains dots, so an rsplit-then-strip would key
+    # (H) on `Widget)` instead of the method name `Poke` and never match.
+    leaf = ingested_qn.split(cs.CHAR_PAREN_OPEN, 1)[0].rsplit(cs.SEPARATOR_DOT, 1)[-1]
+    # (H) The extension's declaring namespace (its class's namespace-qualified name
+    # (H) minus the class leaf) so an unqualified `this Widget` can resolve to
+    # (H) `<namespace>.Widget` against a qualified call receiver. Empty for a
+    # (H) top-level (namespace-less) class.
+    ns_qualified_class = (
+        class_qn[len(module_qn) + 1 :]
+        if module_qn is not None
+        and class_qn.startswith(f"{module_qn}{cs.SEPARATOR_DOT}")
+        else class_qn
+    )
+    ext_namespace = (
+        ns_qualified_class.rsplit(cs.SEPARATOR_DOT, 1)[0]
+        if cs.SEPARATOR_DOT in ns_qualified_class
+        else ""
+    )
+    store.setdefault(leaf, []).append((ingested_qn, receiver_type, ext_namespace))
+
+
 def build_field_type_map(class_node: Node) -> dict[str, str]:
     # (H) {field-or-property name: type name} for members declared directly on
     # (H) this class body, recorded at ingestion so a receiver typed to a field

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -199,6 +199,7 @@ class FunctionIngestMixin:
     rehydrated_definition_paths: dict[str, str]
     csharp_methods: set[str]
     csharp_override_methods: set[str]
+    csharp_extension_methods: dict[str, list[tuple[str, str, str]]]
 
     @abstractmethod
     def _get_docstring(self, node: ASTNode) -> str | None: ...
@@ -1325,10 +1326,19 @@ class FunctionIngestMixin:
             )
         )
         # (H) Track it like an in-class C# method so the override walk can gate a
-        # (H) class-parent OVERRIDES on the `override` modifier.
+        # (H) class-parent OVERRIDES on the `override` modifier, and index it as an
+        # (H) extension method if it is one, so `recv.Ext()` still binds to a
+        # (H) recovered extension the same as the normal class-member pass would.
         self.csharp_methods.add(ingested_qn)
         if csharp_has_override_modifier(func_node):
             self.csharp_override_methods.add(ingested_qn)
+        csharp_utils.index_extension_method(
+            self.csharp_extension_methods,
+            ingested_qn,
+            func_node,
+            class_qn,
+            module_qn,
+        )
         return True
 
     def _find_enclosing_function_node(

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -1313,6 +1313,17 @@ class FunctionIngestMixin:
             cs.NodeLabel.METHOD.value,
             ingested_qn,
         )
+        # (H) Record where this method landed so Pass-3 call attribution reuses this
+        # (H) Method identity instead of re-deriving a module-Function qn from the
+        # (H) node (the FQN walk sees no class ancestor, so a call inside the
+        # (H) recovered member would otherwise source a phantom, dropped edge).
+        self.function_locations[function_span_key(module_qn, func_node)] = (
+            FunctionLocation(
+                label=cs.NodeLabel.METHOD.value,
+                qualified_name=ingested_qn,
+                container_qn=class_qn,
+            )
+        )
         # (H) Track it like an in-class C# method so the override walk can gate a
         # (H) class-parent OVERRIDES on the `override` modifier.
         self.csharp_methods.add(ingested_qn)

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -46,6 +46,25 @@ if TYPE_CHECKING:
     from .handlers import LanguageHandler
 
 
+def _nearest_preceding_csharp_type(
+    func_node: Node, class_node_types: frozenset[str]
+) -> Node | None:
+    # (H) Find the class a `#if`-detached member belongs to: scan preceding siblings
+    # (H) at each ancestor level (a `#if`-guarded member is wrapped in a preproc_if,
+    # (H) so its OWN siblings never include the truncated class) up to the root,
+    # (H) returning the nearest class-like node. For the truncation case this is the
+    # (H) class whose body ended early, spilling this member after it.
+    node: Node | None = func_node
+    while node is not None:
+        sib = node.prev_sibling
+        while sib is not None:
+            if sib.type in class_node_types:
+                return sib
+            sib = sib.prev_sibling
+        node = node.parent
+    return None
+
+
 def _java_anon_base_for_function(
     func_node: Node, class_node_types: frozenset[str]
 ) -> str | None:
@@ -178,6 +197,8 @@ class FunctionIngestMixin:
     class_inheritance: dict[str, list[str]]
     _deferred_cpp_inherits: list[DeferredCppInherit]
     rehydrated_definition_paths: dict[str, str]
+    csharp_methods: set[str]
+    csharp_override_methods: set[str]
 
     @abstractmethod
     def _get_docstring(self, node: ASTNode) -> str | None: ...
@@ -223,6 +244,19 @@ class FunctionIngestMixin:
                     and safe_decode_text(name_node) in cs.CSHARP_RESERVED_KEYWORDS
                 ):
                     continue
+
+            # (H) A C# member declaration (method/property/operator/ctor) that a
+            # (H) `#if`-truncated class node detached into the namespace's
+            # (H) declaration_list reaches here with no class ancestor. It is a real
+            # (H) class member by grammar invariant, so recover its class and emit it
+            # (H) as a Method rather than mislabelling it a module Function.
+            if (
+                language == cs.SupportedLanguage.CSHARP
+                and self._recover_csharp_orphan_method(
+                    func_node, module_qn, lang_config, lang_queries, file_path
+                )
+            ):
+                continue
 
             if language == cs.SupportedLanguage.CPP:
                 if self._handle_cpp_out_of_class_method(
@@ -1200,6 +1234,91 @@ class FunctionIngestMixin:
 
     def _is_method(self, func_node: Node, lang_config: LanguageSpec) -> bool:
         return is_method_node(func_node, lang_config)
+
+    def _csharp_scope_qn(self, node: Node, module_qn: str) -> str:
+        # (H) Qualified name of a C# scope node (class/namespace) via the same walk
+        # (H) the definition FQN pass uses, so a recovered class qn matches the one
+        # (H) the class-ingest pass registered. `node` is itself a scope type, so
+        # (H) start the walk at it (its own name is the innermost segment).
+        fqn_config = LANGUAGE_FQN_SPECS[cs.SupportedLanguage.CSHARP]
+        parts: list[str] = []
+        current: Node | None = node
+        while current is not None:
+            if current.type in fqn_config.scope_node_types and (
+                scope_name := fqn_config.get_name(current)
+            ):
+                parts.append(scope_name)
+            current = current.parent
+        if not parts:
+            return module_qn
+        parts.reverse()
+        return module_qn + cs.SEPARATOR_DOT + cs.SEPARATOR_DOT.join(parts)
+
+    def _recover_csharp_orphan_method(
+        self,
+        func_node: Node,
+        module_qn: str,
+        lang_config: LanguageSpec,
+        lang_queries: LanguageQueries,
+        file_path: Path | None,
+    ) -> bool:
+        # (H) A C# method/property/operator/ctor is grammatically only ever a type
+        # (H) member; a `local_function_statement` is the real top-level function, so
+        # (H) it is deliberately excluded and left to the Function path.
+        if func_node.type not in cs.CSHARP_MEMBER_ONLY_TYPES:
+            return False
+        class_node = _nearest_preceding_csharp_type(
+            func_node, frozenset(lang_config.class_node_types)
+        )
+        if class_node is None:
+            return False
+
+        from .class_ingest.utils import csharp_has_override_modifier
+        from .csharp import utils as csharp_utils
+
+        class_qn = self._csharp_scope_qn(class_node, module_qn)
+        cs_name, cs_params = csharp_utils.extract_method_signature(func_node)
+        method_qualified_name = None
+        if cs_name and cs_params:
+            param_sig = cs.SEPARATOR_COMMA_SPACE.join(cs_params)
+            method_qualified_name = f"{class_qn}.{cs_name}({param_sig})"
+
+        ingested_qn = ingest_method(
+            func_node,
+            class_qn,
+            cs.NodeLabel.CLASS,
+            self.ingestor,
+            self.function_registry,
+            self.simple_name_lookup,
+            self._get_docstring,
+            cs.SupportedLanguage.CSHARP,
+            lang_queries=lang_queries,
+            method_qualified_name=method_qualified_name,
+            file_path=file_path,
+            repo_path=self.repo_path,
+            # (H) The class node was parse-truncated; defer the containment so it
+            # (H) resolves to DEFINES_METHOD if the class registered, else an
+            # (H) audit-safe module DEFINES (never a dangling edge).
+            defer_containment=self._deferred_parent_links,
+            module_qn=module_qn,
+        )
+        if ingested_qn is None:
+            return False
+        record_cpp_definition_span(
+            self.cpp_definition_spans,
+            cs.SupportedLanguage.CSHARP,
+            file_path,
+            self.repo_path,
+            func_node,
+            cs.NodeLabel.METHOD.value,
+            ingested_qn,
+        )
+        # (H) Track it like an in-class C# method so the override walk can gate a
+        # (H) class-parent OVERRIDES on the `override` modifier.
+        self.csharp_methods.add(ingested_qn)
+        if csharp_has_override_modifier(func_node):
+            self.csharp_override_methods.add(ingested_qn)
+        return True
 
     def _find_enclosing_function_node(
         self, func_node: Node, lang_config: LanguageSpec

--- a/codebase_rag/tests/test_csharp_preproc_split_body.py
+++ b/codebase_rag/tests/test_csharp_preproc_split_body.py
@@ -7,9 +7,20 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 from codebase_rag import constants as cs
-from codebase_rag.tests.conftest import get_node_names, run_updater
+from codebase_rag.tests.conftest import (
+    get_node_names,
+    get_relationships,
+    run_updater,
+)
 
 SKIP = "c_sharp"
+
+
+def _leaf_names(mock_ingestor: MagicMock, label: str) -> set[str]:
+    return {
+        qn.rsplit(".", 1)[-1].split("(", 1)[0]
+        for qn in get_node_names(mock_ingestor, label)
+    }
 
 
 def test_if_split_body_emits_no_keyword_named_function(
@@ -32,8 +43,108 @@ def test_if_split_body_emits_no_keyword_named_function(
     )
     run_updater(project, mock_ingestor, skip_if_missing=SKIP)
     for label in (cs.NodeLabel.FUNCTION.value, cs.NodeLabel.METHOD.value):
-        names = {
-            qn.rsplit(".", 1)[-1].split("(", 1)[0]
-            for qn in get_node_names(mock_ingestor, label)
-        }
+        names = _leaf_names(mock_ingestor, label)
         assert "if" not in names, f"{label} node named 'if' leaked from #if-split body"
+
+
+# (H) When a `#if` splits a statement deep inside a method, tree-sitter's error
+# (H) recovery can TRUNCATE the enclosing class_declaration node early; every
+# (H) member after the truncation point detaches into the namespace's
+# (H) declaration_list with no class ancestor. A C# `method_declaration` /
+# (H) `property_declaration` is grammatically only ever a type member (a real
+# (H) top-level function is a local_function_statement), so such a detached node
+# (H) is still a class method and must be emitted as a Method, never mislabelled a
+# (H) module-level Function (this was ~133 phantom Function FPs on Newtonsoft.Json,
+# (H) e.g. JsonTextReader.BlockCopyChars, a private static member). The body below
+# (H) is a reduced slice of the real JsonTextReader.ParseReadString derailment.
+_ORPHAN_MEMBER_SRC = """\
+namespace N
+{
+    public class Reader
+    {
+        private void ParseReadString(int readType)
+        {
+            switch (readType)
+            {
+                default:
+                    if (_dateParseHandling != DateParseHandling.None)
+                    {
+                        DateParseHandling dateParseHandling;
+                        if (readType == ReadType.ReadAsDateTime)
+                        {
+                            dateParseHandling = DateParseHandling.DateTime;
+                        }
+#if HAVE_DATE_TIME_OFFSET
+                        else if (readType == ReadType.ReadAsDateTimeOffset)
+                        {
+                            dateParseHandling = DateParseHandling.DateTimeOffset;
+                        }
+#endif
+                        else
+                        {
+                            dateParseHandling = _dateParseHandling;
+                        }
+
+                        if (dateParseHandling == DateParseHandling.DateTime)
+                        {
+                            if (TryParse(out DateTime dt))
+                            {
+                                SetToken(dt);
+                                return;
+                            }
+                        }
+#if HAVE_DATE_TIME_OFFSET
+                        else
+                        {
+                            if (TryParseOffset(out DateTimeOffset dt))
+                            {
+                                SetToken(dt);
+                                return;
+                            }
+                        }
+#endif
+                    }
+
+                    SetToken(_stringReference.ToString());
+                    break;
+            }
+        }
+
+        private static void BlockCopyChars(char[] src, int srcOffset)
+        {
+            const int charByteCount = 2;
+            Buffer.BlockCopy(src, srcOffset, charByteCount);
+        }
+
+        public int Prop { get; set; }
+    }
+}
+"""
+
+
+def test_if_truncated_class_body_orphan_members_are_methods(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    project = temp_repo / "cs_orphan_members"
+    project.mkdir()
+    (project / "Reader.cs").write_text(_ORPHAN_MEMBER_SRC, encoding="utf-8")
+    run_updater(project, mock_ingestor, skip_if_missing=SKIP)
+
+    func_leaves = _leaf_names(mock_ingestor, cs.NodeLabel.FUNCTION.value)
+    method_leaves = _leaf_names(mock_ingestor, cs.NodeLabel.METHOD.value)
+
+    # (H) The method and property that the truncation detached from the class node
+    # (H) must be Methods, not module Functions.
+    for name in ("BlockCopyChars", "Prop"):
+        assert name not in func_leaves, f"{name} leaked as a module Function"
+        assert name in method_leaves, f"{name} missing as a Method"
+
+    # (H) They must attach to the recovered enclosing class, not orphan or vanish.
+    method_qns = get_node_names(mock_ingestor, cs.NodeLabel.METHOD.value)
+    assert any(".Reader.BlockCopyChars" in qn for qn in method_qns), method_qns
+    defines_method_targets = {
+        c.args[2][2] for c in get_relationships(mock_ingestor, "DEFINES_METHOD")
+    }
+    assert any(".Reader.BlockCopyChars" in qn for qn in defines_method_targets), (
+        defines_method_targets
+    )

--- a/codebase_rag/tests/test_csharp_preproc_split_body.py
+++ b/codebase_rag/tests/test_csharp_preproc_split_body.py
@@ -113,8 +113,11 @@ namespace N
         private static void BlockCopyChars(char[] src, int srcOffset)
         {
             const int charByteCount = 2;
+            Shift();
             Buffer.BlockCopy(src, srcOffset, charByteCount);
         }
+
+        private static void Shift() { }
 
         public int Prop { get; set; }
     }
@@ -148,3 +151,18 @@ def test_if_truncated_class_body_orphan_members_are_methods(
     assert any(".Reader.BlockCopyChars" in qn for qn in defines_method_targets), (
         defines_method_targets
     )
+
+    # (H) A call inside the recovered method must be attributed to its Method node,
+    # (H) not a re-derived module-Function qn (which would source a dropped edge).
+    # (H) The recovery records function_locations so Pass 3 reuses the Method
+    # (H) identity; the graph audit already rejects any dangling CALLS endpoint.
+    shift_calls = [
+        c
+        for c in get_relationships(mock_ingestor, "CALLS")
+        if ".Reader.Shift" in c.args[2][2]
+    ]
+    assert shift_calls, "expected a CALLS edge into Reader.Shift"
+    for c in shift_calls:
+        caller_label, _, caller_qn = c.args[0]
+        assert caller_label == cs.NodeLabel.METHOD.value, c.args[0]
+        assert ".Reader.BlockCopyChars" in caller_qn, caller_qn

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.332"
+version = "0.0.334"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Problem

When a `#if` directive splits a statement deep inside a C# method, tree-sitter's error recovery can **truncate the enclosing `class_declaration` node early** (its body ends at the split point). Every member declared after the truncation detaches into the namespace's `declaration_list` with no class ancestor. The generic `is_method_node` ancestor walk then returns `False`, so these members were mislabelled as **module-level Functions**.

Surfaced by the C# eval oracle: ~133 phantom "Function" false positives on Newtonsoft.Json were real class methods (e.g. `JsonTextReader.BlockCopyChars`, a `private static` member). Same family as the `if`-keyword artifact fixed in #745.

## Fix

A C# `method_declaration` / `property_declaration` / `constructor_declaration` / operator / `destructor_declaration` is **grammatically only ever a type member** — a real top-level function is a `local_function_statement` (deliberately excluded). So when such a node reaches the function-ingest pass with no class ancestor, recover its enclosing class from the nearest preceding type-declaration sibling and ingest it as a **Method**, deferring containment (DEFINES_METHOD to the recovered class, or an audit-safe module DEFINES fallback if the class never registers).

- New `CSHARP_MEMBER_ONLY_TYPES` constant (member-only declaration node types).
- `_nearest_preceding_csharp_type` scans preceding siblings at each ancestor level (a `#if`-guarded member is wrapped in a `preproc_if`, so its own siblings never include the class).
- `_recover_csharp_orphan_method` computes the class qn via the same scope walk the class pass uses, so the recovered method attaches to the exact registered Class node; tracked in `csharp_methods` / `csharp_override_methods` for the override walk.

## Results (Newtonsoft.Json `JsonTextReader.cs`)

| metric | before | after |
|---|---|---|
| Function nodes (FP) | 69 | **0** |
| Method nodes | 11 | **80** |
| node ALL F1 | 0.817 | **1.000** |
| Method precision | 0.736 | **1.000** |
| DEFINES_METHOD | mislabelled | **80/80 correct** |

All 69 orphans recover as Methods attached to the correct `JsonTextReader` class. The residual (truncated class node's `end_line` span) is a genuine tree-sitter limitation — the class node cannot span past its truncation point without re-parsing (Roslyn-hybrid territory) — and is unchanged by this PR.

## Tests

RED→GREEN test `test_if_truncated_class_body_orphan_members_are_methods` in `test_csharp_preproc_split_body.py`, built from a reduced slice of the real `JsonTextReader.ParseReadString` derailment; asserts the detached method + property are Methods (not Functions) and attach to the recovered class. Full suite: 4909 passed, 14 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)