### PR TITLE
feat(io): path-sensitive FLOWS_TO taint for JS/TS (#714)

### DIFF
--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -168,6 +168,24 @@ JS_ASSIGNMENT_FUNCTION_QUERY = """
   (function_expression) @function_expr)
 """
 
+# (H) JS/TS control-flow node types + fields for the path-sensitive taint walk
+# (H) (issue #714 follow-up). Each if/else, loop, and try branch is evaluated against
+# (H) a COPY of the incoming taint state and unioned at the merge, so taint surviving
+# (H) on ANY path survives and a kill counts only when it happens on EVERY path. The
+# (H) values coincide with the Python grammar's but stay JS-scoped per the per-language
+# (H) constants convention.
+TS_JS_IF_STATEMENT = "if_statement"
+TS_JS_ELSE_CLAUSE = "else_clause"
+TS_JS_WHILE_STATEMENT = "while_statement"
+TS_JS_FOR_STATEMENT = "for_statement"
+TS_JS_FOR_IN_STATEMENT = "for_in_statement"
+TS_JS_TRY_STATEMENT = "try_statement"
+TS_JS_CATCH_CLAUSE = "catch_clause"
+TS_JS_FINALLY_CLAUSE = "finally_clause"
+FIELD_ALTERNATIVE = "alternative"
+FIELD_HANDLER = "handler"
+FIELD_FINALIZER = "finalizer"
+
 # (H) JS/TS module system node types
 TS_OBJECT_PATTERN = "object_pattern"
 TS_ARRAY_PATTERN = "array_pattern"

--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -185,6 +185,10 @@ TS_JS_FINALLY_CLAUSE = "finally_clause"
 FIELD_ALTERNATIVE = "alternative"
 FIELD_HANDLER = "handler"
 FIELD_FINALIZER = "finalizer"
+# (H) The C-style `for (init; cond; increment)` update clause, which runs AFTER the
+# (H) body each iteration (not in the header), so taint the body carries into it
+# (H) reaches the next iteration.
+FIELD_INCREMENT = "increment"
 
 # (H) JS/TS module system node types
 TS_OBJECT_PATTERN = "object_pattern"

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -253,40 +253,138 @@ class FlowProcessor:
         else:
             statements = [body]
         tainted: _TaintMap = {}
-        # (H) ponytail: flat source-order walk, not path-sensitive (that is the JS
-        # (H) follow-up); a single taint map, nested functions pruned as their own
-        # (H) callers. Reuses the shared summary/deferred/finalize machinery (#712).
+        if ctx.language in _HOISTED_DECL_LANGS:
+            # (H) Path-sensitive MAY walk (issue #714 follow-up): each JS/TS if/else,
+            # (H) loop, and try branch is evaluated against a COPY of the incoming
+            # (H) state and unioned at the merge, so taint surviving on ANY path
+            # (H) survives and a kill counts only when it happens on EVERY path.
+            for node in statements:
+                tainted = self._walk_js_stmt(node, tainted, jc)
+        else:
+            # (H) Go keeps the flat source-order walk: its shadow set is grown in
+            # (H) source order (_register_shadows), which a branch-copying walk would
+            # (H) break. Path-sensitivity for Go is a separate follow-up.
+            self._flat_flow_walk(statements, tainted, jc)
+        if self._acc_returns_taint:
+            self._summaries[ctx.caller_qn] = self._acc_return_taint
+
+    def _flat_flow_walk(
+        self, statements: list[Node], tainted: _TaintMap, jc: _JsCtx
+    ) -> None:
+        # (H) Flat source-order DFS (Go): a single taint map, nested functions pruned
+        # (H) as their own callers. Reuses the shared summary/deferred/finalize (#712).
         stack = list(reversed(statements))
         while stack:
             node = stack.pop()
-            node_type = node.type
-            if node_type in descriptor.nested_scope_types:
+            if node.type in jc.descriptor.nested_scope_types:
                 continue
-            if node_type == descriptor.declarator_type or node_type in (
-                cs.TS_ASSIGNMENT_EXPRESSION,
-                cs.TS_GO_ASSIGNMENT_STATEMENT,
-            ):
-                self._lean_bind(node, tainted, jc)
-            elif node_type in descriptor.extra_declarator_types:
-                # (H) Go `var`/`const` bind like a declarator; a `range` clause rebinds
-                # (H) its loop vars to (untainted) iteration elements, so kill any taint
-                # (H) they carried under those names before the loop.
-                if node_type == cs.TS_GO_RANGE_CLAUSE:
-                    self._lean_kill(node, tainted, jc)
-                else:
-                    self._lean_bind(node, tainted, jc)
-            elif node_type == descriptor.call_type:
-                self._js_call(node, tainted, jc)
-            elif node_type == cs.TS_RETURN_STATEMENT:
-                returned = self._js_return_taint(node, tainted, jc)
-                if returned is not None:
-                    self._acc_returns_taint = True
-                    self._acc_return_taint = _merge_taint(
-                        self._acc_return_taint, returned
-                    )
+            self._apply_js_leaf(node, tainted, jc)
             stack.extend(reversed(node.named_children))
-        if self._acc_returns_taint:
-            self._summaries[ctx.caller_qn] = self._acc_return_taint
+
+    def _walk_js_stmt(self, node: Node, state: _TaintMap, jc: _JsCtx) -> _TaintMap:
+        # (H) Path-sensitive walk for JS/TS: control-flow nodes branch-and-merge, every
+        # (H) other node applies its leaf effect and threads state through its children
+        # (H) in source order (so a nested call in an argument is still seen).
+        node_type = node.type
+        if node_type in jc.descriptor.nested_scope_types:
+            return state
+        if node_type == cs.TS_JS_IF_STATEMENT:
+            return self._walk_js_if(node, state, jc)
+        if node_type in (
+            cs.TS_JS_WHILE_STATEMENT,
+            cs.TS_JS_FOR_STATEMENT,
+            cs.TS_JS_FOR_IN_STATEMENT,
+        ):
+            return self._walk_js_loop(node, state, jc)
+        if node_type == cs.TS_JS_TRY_STATEMENT:
+            return self._walk_js_try(node, state, jc)
+        self._apply_js_leaf(node, state, jc)
+        for child in node.named_children:
+            state = self._walk_js_stmt(child, state, jc)
+        return state
+
+    def _walk_js_if(self, node: Node, state: _TaintMap, jc: _JsCtx) -> _TaintMap:
+        # (H) The condition runs on all paths; each of the then / else(-if) / implicit
+        # (H) skip paths is walked against a copy and unioned (MAY join).
+        cond = node.child_by_field_name(cs.TS_FIELD_CONDITION)
+        if cond is not None:
+            state = self._walk_js_stmt(cond, state, jc)
+        branch_exits: list[_TaintMap] = []
+        consequence = node.child_by_field_name(cs.TS_FIELD_CONSEQUENCE)
+        if consequence is not None:
+            branch_exits.append(self._walk_js_stmt(consequence, dict(state), jc))
+        alternative = node.child_by_field_name(cs.FIELD_ALTERNATIVE)
+        if alternative is not None:
+            # (H) else_clause holds either a block or a nested if (else-if chain); the
+            # (H) recursion handles both and merges within.
+            branch_exits.append(self._walk_js_stmt(alternative, dict(state), jc))
+        else:
+            # (H) No else: the skip path preserves the incoming state.
+            branch_exits.append(dict(state))
+        return self._merge(branch_exits)
+
+    def _walk_js_loop(self, node: Node, state: _TaintMap, jc: _JsCtx) -> _TaintMap:
+        # (H) The initializer/condition/iterable runs before the body; the body runs
+        # (H) zero or more times, so union the skip path with one pass, then re-walk
+        # (H) once from that merge to catch taint carried from a later iteration into
+        # (H) an earlier statement. ponytail: two passes, not a full fixpoint; edges
+        # (H) are MERGE-idempotent so the re-walk never duplicates them.
+        body = node.child_by_field_name(cs.FIELD_BODY)
+        for child in node.named_children:
+            if body is not None and child.id == body.id:
+                continue
+            state = self._walk_js_stmt(child, state, jc)
+        if body is not None:
+            once = self._walk_js_stmt(body, dict(state), jc)
+            merged = self._merge([state, once])
+            twice = self._walk_js_stmt(body, dict(merged), jc)
+            state = self._merge([state, twice])
+        return state
+
+    def _walk_js_try(self, node: Node, state: _TaintMap, jc: _JsCtx) -> _TaintMap:
+        # (H) The try body may run fully (no-throw path) or partially before a catch;
+        # (H) seed the handler with union(pre, body_exit) so taint introduced before a
+        # (H) throw still reaches it. A finally runs on the merged state of both.
+        body = node.child_by_field_name(cs.FIELD_BODY)
+        body_exit = (
+            self._walk_js_stmt(body, dict(state), jc)
+            if body is not None
+            else dict(state)
+        )
+        branch_exits: list[_TaintMap] = [body_exit]
+        handler = node.child_by_field_name(cs.FIELD_HANDLER)
+        if handler is not None:
+            branch_exits.append(
+                self._walk_js_stmt(handler, self._merge([state, body_exit]), jc)
+            )
+        merged = self._merge(branch_exits)
+        finalizer = node.child_by_field_name(cs.FIELD_FINALIZER)
+        if finalizer is not None:
+            merged = self._walk_js_stmt(finalizer, merged, jc)
+        return merged
+
+    def _apply_js_leaf(self, node: Node, tainted: _TaintMap, jc: _JsCtx) -> None:
+        # (H) The leaf effect of one node on the taint map: bind (JS/Go), Go range
+        # (H) kill, a call's sink/arg edges, or a return's contribution to the summary.
+        node_type = node.type
+        d = jc.descriptor
+        if node_type == d.declarator_type or node_type in (
+            cs.TS_ASSIGNMENT_EXPRESSION,
+            cs.TS_GO_ASSIGNMENT_STATEMENT,
+        ):
+            self._lean_bind(node, tainted, jc)
+        elif node_type in d.extra_declarator_types:
+            if node_type == cs.TS_GO_RANGE_CLAUSE:
+                self._lean_kill(node, tainted, jc)
+            else:
+                self._lean_bind(node, tainted, jc)
+        elif node_type == d.call_type:
+            self._js_call(node, tainted, jc)
+        elif node_type == cs.TS_RETURN_STATEMENT:
+            returned = self._js_return_taint(node, tainted, jc)
+            if returned is not None:
+                self._acc_returns_taint = True
+                self._acc_return_taint = _merge_taint(self._acc_return_taint, returned)
 
     def _lean_bind(self, node: Node, tainted: _TaintMap, jc: _JsCtx) -> None:
         # (H) Bind LHS name(s) to their RHS taint across the grammars: JS uses a single

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -330,14 +330,26 @@ class FlowProcessor:
         # (H) an earlier statement. ponytail: two passes, not a full fixpoint; edges
         # (H) are MERGE-idempotent so the re-walk never duplicates them.
         body = node.child_by_field_name(cs.FIELD_BODY)
+        # (H) A C-style for's `increment` runs AFTER the body each iteration, not in
+        # (H) the header, so skip it below and walk it after each body pass instead.
+        increment = (
+            node.child_by_field_name(cs.FIELD_INCREMENT)
+            if node.type == cs.TS_JS_FOR_STATEMENT
+            else None
+        )
+        skip_ids = {n.id for n in (body, increment) if n is not None}
         for child in node.named_children:
-            if body is not None and child.id == body.id:
+            if child.id in skip_ids:
                 continue
             state = self._walk_js_stmt(child, state, jc)
         if body is not None:
             once = self._walk_js_stmt(body, dict(state), jc)
+            if increment is not None:
+                once = self._walk_js_stmt(increment, once, jc)
             merged = self._merge([state, once])
             twice = self._walk_js_stmt(body, dict(merged), jc)
+            if increment is not None:
+                twice = self._walk_js_stmt(increment, twice, jc)
             state = self._merge([state, twice])
         return state
 

--- a/codebase_rag/tests/integration/test_jsts_path_sensitive_flow_e2e.py
+++ b/codebase_rag/tests/integration/test_jsts_path_sensitive_flow_e2e.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.capture import resolve_capture
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.parsers.flow_access import FlowKind
+
+if TYPE_CHECKING:
+    from codebase_rag.services.graph_service import MemgraphIngestor
+
+pytestmark = [pytest.mark.integration]
+
+_FLOWS = cs.RelationshipType.FLOWS_TO.value
+
+
+def _build(
+    ingestor: MemgraphIngestor, tmp_path: Path, filename: str, code: str
+) -> None:
+    project = tmp_path / "flow_ps"
+    project.mkdir()
+    (project / filename).write_text(code, encoding="utf-8")
+    parsers, queries = load_parsers()
+    GraphUpdater(
+        ingestor=ingestor,
+        repo_path=project,
+        parsers=parsers,
+        queries=queries,
+        capture=resolve_capture([cs.CaptureGroup.IO.value]),
+    ).run()
+
+
+def _flows(ingestor: MemgraphIngestor) -> list[dict[str, str | None]]:
+    rows = ingestor.fetch_all(
+        f"MATCH (a)-[r:{_FLOWS}]->(b) "
+        "RETURN a.qualified_name AS frm, b.qualified_name AS to, r.kind AS kind"
+    )
+    return [{k: None if v is None else str(v) for k, v in row.items()} for row in rows]
+
+
+def _has(flows: list[dict[str, str | None]], frm: str, to: str, **props: str) -> bool:
+    return any(
+        (f["frm"] or "").endswith(frm)
+        and (f["to"] or "").endswith(to)
+        and all(f.get(k) == v for k, v in props.items())
+        for f in flows
+    )
+
+
+def _has_resource(flows: list[dict[str, str | None]], frm: str, to: str) -> bool:
+    return _has(flows, frm, to, kind=FlowKind.RESOURCE.value)
+
+
+def test_conditional_kill_survives_skip_path(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) MAY: the kill happens only on the if-path, so the skip path keeps the taint;
+    # (H) after the merge `secret` is still tainted and the flow must survive. The flat
+    # (H) walk wrongly applied the kill unconditionally (false negative).
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "app.js",
+        "function boot(cond) {\n"
+        "  let secret = process.env.SECRET;\n"
+        "  if (cond) { secret = 'safe'; }\n"
+        "  console.log(secret);\n"
+        "}\n",
+    )
+    assert _has_resource(
+        _flows(memgraph_ingestor),
+        "resource::ENV::SECRET",
+        "resource::STDOUT::<dynamic>",
+    )
+
+
+def test_kill_on_all_branches_no_flow(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) Killed on BOTH the if and the else path, so after the merge `secret` carries
+    # (H) no taint and no resource flow may appear.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "app.js",
+        "function boot(cond) {\n"
+        "  let secret = process.env.SECRET;\n"
+        "  if (cond) { secret = 'a'; } else { secret = 'b'; }\n"
+        "  console.log(secret);\n"
+        "}\n",
+    )
+    flows = _flows(memgraph_ingestor)
+    assert not any(f["kind"] == FlowKind.RESOURCE.value for f in flows)
+
+
+def test_taint_introduced_in_one_branch_survives(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) Taint introduced on only the if-path still reaches the sink after the merge.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "app.js",
+        "function boot(cond) {\n"
+        "  let secret = '';\n"
+        "  if (cond) { secret = process.env.SECRET; }\n"
+        "  console.log(secret);\n"
+        "}\n",
+    )
+    assert _has_resource(
+        _flows(memgraph_ingestor),
+        "resource::ENV::SECRET",
+        "resource::STDOUT::<dynamic>",
+    )
+
+
+def test_else_if_branch_taint_survives(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) An else-if chain: taint introduced in the middle branch survives the merge.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "app.js",
+        "function boot(a, b) {\n"
+        "  let secret = '';\n"
+        "  if (a) { secret = 'x'; }\n"
+        "  else if (b) { secret = process.env.SECRET; }\n"
+        "  else { secret = 'y'; }\n"
+        "  console.log(secret);\n"
+        "}\n",
+    )
+    assert _has_resource(
+        _flows(memgraph_ingestor),
+        "resource::ENV::SECRET",
+        "resource::STDOUT::<dynamic>",
+    )
+
+
+def test_loop_carried_taint_reaches_earlier_sink(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) The write happens BEFORE the tainting assignment in source order, but a later
+    # (H) loop iteration carries the taint back to it; the body is walked twice so the
+    # (H) NETWORK -> FILE flow is caught. The flat walk missed this (false negative).
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "app.js",
+        "function sync(items) {\n"
+        "  let data = '';\n"
+        "  for (const it of items) {\n"
+        "    fs.writeFileSync('out.txt', data);\n"
+        "    data = fetch('https://api.example.com/x');\n"
+        "  }\n"
+        "}\n",
+    )
+    assert _has_resource(
+        _flows(memgraph_ingestor),
+        "resource::NETWORK::https://api.example.com/x",
+        "resource::FILE::out.txt",
+    )
+
+
+def test_try_body_taint_survives_to_after(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) Taint assigned in the try body reaches the sink after the try/catch merge.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "app.js",
+        "function boot() {\n"
+        "  let secret = '';\n"
+        "  try { secret = process.env.SECRET; } catch (e) {}\n"
+        "  console.log(secret);\n"
+        "}\n",
+    )
+    assert _has_resource(
+        _flows(memgraph_ingestor),
+        "resource::ENV::SECRET",
+        "resource::STDOUT::<dynamic>",
+    )
+
+
+def test_straight_line_still_works(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) No branches: behaves exactly like the old flat walk.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "app.js",
+        "function boot() {\n"
+        "  const secret = process.env.SECRET;\n"
+        "  console.log(secret);\n"
+        "}\n",
+    )
+    assert _has_resource(
+        _flows(memgraph_ingestor),
+        "resource::ENV::SECRET",
+        "resource::STDOUT::<dynamic>",
+    )

--- a/codebase_rag/tests/integration/test_jsts_path_sensitive_flow_e2e.py
+++ b/codebase_rag/tests/integration/test_jsts_path_sensitive_flow_e2e.py
@@ -167,6 +167,33 @@ def test_loop_carried_taint_reaches_earlier_sink(
     )
 
 
+def test_for_increment_carries_taint_to_next_iteration(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) The C-style `for` increment `x = y` runs AFTER the body each iteration: it
+    # (H) picks up the taint the body put on `y` and carries it into `x` for the next
+    # (H) iteration's write. Walking the increment in the header (before the body)
+    # (H) missed this; it is now walked after each body pass.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "app.js",
+        "function sync() {\n"
+        "  let x = '';\n"
+        "  let y = '';\n"
+        "  for (let i = 0; i < 3; x = y) {\n"
+        "    y = fetch('https://api.example.com/x');\n"
+        "    fs.writeFileSync('out.txt', x);\n"
+        "  }\n"
+        "}\n",
+    )
+    assert _has_resource(
+        _flows(memgraph_ingestor),
+        "resource::NETWORK::https://api.example.com/x",
+        "resource::FILE::out.txt",
+    )
+
+
 def test_try_body_taint_survives_to_after(
     memgraph_ingestor: MemgraphIngestor, tmp_path: Path
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.333"
+version = "0.0.335"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Ports the path-sensitive MAY taint walk (from #734/#713, Python) into the JS/TS lean `FLOWS_TO` flow, replacing the flat source-order walk introduced for JS in #740. Part of the opt-in `io` capture group.

## What

The JS/TS lean walk was flat: a single taint map mutated in source order, with no notion of branches. That over-approximated in one direction (kept taint that a branch killed) and under-approximated in another (applied a conditional kill unconditionally, and missed loop-carried taint). Now each `if`/`else`(-if), loop (`for`/`for..of`/`for..in`/`while`), and `try`/`catch`/`finally` branch is evaluated against a **copy** of the incoming state and unioned at the merge:

- **MAY join** — taint surviving on ANY path survives the merge; a variable is killed only when reassigned to an untainted value on EVERY path.
- No-else adds the implicit skip path; loops walk the body twice (skip ∪ body, then re-walk) for loop-carried taint; a `catch` is seeded with `union(pre, body_exit)` and `finally` applied to the merge — mirroring the Python `_walk_if`/`_walk_loop`/`_walk_try`.

Structure: `_walk_js_stmt` dispatches control-flow to `_walk_js_if`/`_walk_js_loop`/`_walk_js_try` and threads state through every other node's children; a shared `_apply_js_leaf` holds the bind/call/return leaf effect. **Go keeps the flat walk** (its shadow set grows in source order via `_register_shadows`, which a branch-copying walk would break) — gated on `_HOISTED_DECL_LANGS`. Reuses the existing `_merge` and the shared summary/deferred/finalize fixpoint (#712).

## Tests (RED → GREEN)

`test_jsts_path_sensitive_flow_e2e.py` (7). The three the flat walk got wrong (now fixed): conditional kill on one branch → taint survives the skip path; taint introduced in an else-if branch survives the merge; loop-carried taint reaches a write that precedes the tainting assignment in source order. Plus precision/parity: kill-on-all-branches → no flow, single-branch taint survives, try-body taint survives, straight-line unchanged.

## Ceiling

Two-pass loops (not a full fixpoint) and no `switch` branch-merge yet (falls through as straight-line) — both noted in code; deeper cases are follow-ups.