### PR TITLE
feat(io): direct READS_FROM/WRITES_TO sinks for Java (#714)

### DIFF
--- a/codebase_rag/constants/ast_go.py
+++ b/codebase_rag/constants/ast_go.py
@@ -37,6 +37,10 @@ TS_GO_IDENTIFIER = "identifier"
 TS_GO_CONST_SPEC = "const_spec"
 TS_GO_RANGE_CLAUSE = "range_clause"
 TS_GO_BLOCK = "block"
+# (H) Go wraps a block's statements in a single `statement_list` node (unlike JS/Java,
+# (H) whose block children are the statements directly); the source-order I/O walk
+# (H) unwraps it so per-statement shadowing sees the real statement boundaries.
+TS_GO_STATEMENT_LIST = "statement_list"
 TS_GO_INTERPRETED_STRING = "interpreted_string_literal"
 TS_GO_INTERPRETED_STRING_CONTENT = "interpreted_string_literal_content"
 TS_GO_INDEX_EXPRESSION = "index_expression"

--- a/codebase_rag/constants/ast_java.py
+++ b/codebase_rag/constants/ast_java.py
@@ -35,6 +35,18 @@ TS_RECORD_DECLARATION = "record_declaration"
 TS_TRUE = "true"
 TS_FALSE = "false"
 
+# (H) Java I/O direct-sink walk node types (issue #714). string_literal wraps a
+# (H) `string_fragment` (shared with JS); `block` is the method-body lexical scope;
+# (H) `lambda_expression` is a nested scope pruned from the enclosing walk. field_access
+# (H) / array_access describe member/subscript access (inert for Java, which has no
+# (H) IO_MEMBER_READS entry -- Java env access is a call, System.getenv, not a member).
+TS_JAVA_STRING_LITERAL = "string_literal"
+TS_JAVA_BLOCK = "block"
+TS_JAVA_LAMBDA_EXPRESSION = "lambda_expression"
+TS_JAVA_ARRAY_ACCESS = "array_access"
+JAVA_FIELD_FIELD = "field"
+JAVA_FIELD_INDEX = "index"
+
 # (H) Tree-sitter field names for child_by_field_name
 TS_FIELD_NAME = "name"
 TS_FIELD_TYPE = "type"

--- a/codebase_rag/parsers/io_access/descriptor.py
+++ b/codebase_rag/parsers/io_access/descriptor.py
@@ -32,6 +32,16 @@ class LanguageDescriptor:
     # (H) Extra declaration node types (beyond declarator_type) whose bound names also
     # (H) shadow a builtin -- Go's `var`/`const`/`range` specs; empty for JS/TS.
     extra_declarator_types: frozenset[str]
+    # (H) Loop-clause declaration nodes (Java for-each, Go `range`) whose bound var is
+    # (H) in scope in the loop BODY only -- NOT the iterable header (evaluated before
+    # (H) the var binds) nor sibling statements. The source-order walk seeds only the
+    # (H) body with these, so a sink in the iterable still resolves to the global.
+    loop_declarator_types: frozenset[str]
+    # (H) A wrapper node that holds a block's statements as its children (Go's
+    # (H) `statement_list`); None where a block's children ARE the statements (JS,
+    # (H) Java). The source-order walk unwraps it so per-statement shadowing sees the
+    # (H) real statement boundaries instead of one giant container "statement".
+    statement_container_type: str | None
     # (H) True when a dotted sink call requires its head to be an imported package
     # (H) (Go always imports stdlib; a package-scope `var os` is not the stdlib os).
     # (H) False for JS/TS, whose sinks include unimported globals (`console`, `fetch`).
@@ -70,6 +80,8 @@ _JS_TS_DESCRIPTOR = LanguageDescriptor(
     params_field=cs.TS_FIELD_PARAMETERS,
     block_scope_type=cs.TS_STATEMENT_BLOCK,
     extra_declarator_types=frozenset(),
+    loop_declarator_types=frozenset(),
+    statement_container_type=None,
     sinks_require_import=False,
     hoisted_declarations=True,
     member_expression_type=cs.TS_MEMBER_EXPRESSION,
@@ -101,6 +113,8 @@ _GO_DESCRIPTOR = LanguageDescriptor(
     extra_declarator_types=frozenset(
         {cs.TS_GO_VAR_SPEC, cs.TS_GO_CONST_SPEC, cs.TS_GO_RANGE_CLAUSE}
     ),
+    loop_declarator_types=frozenset({cs.TS_GO_RANGE_CLAUSE}),
+    statement_container_type=cs.TS_GO_STATEMENT_LIST,
     sinks_require_import=True,
     # (H) Go is declare-at-point (`:=`/`var` bind from that line on), so a local named
     # (H) after a valid package call must not retroactively shadow it -- source order.
@@ -135,6 +149,8 @@ _JAVA_DESCRIPTOR = LanguageDescriptor(
     params_field=cs.TS_FIELD_PARAMETERS,
     block_scope_type=cs.TS_JAVA_BLOCK,
     extra_declarator_types=frozenset({cs.TS_ENHANCED_FOR_STATEMENT}),
+    loop_declarator_types=frozenset({cs.TS_ENHANCED_FOR_STATEMENT}),
+    statement_container_type=None,
     # (H) Java's System/Files sink heads are java.lang / java.nio globals that never
     # (H) appear in import_map, so requiring an import would reject every sink.
     sinks_require_import=False,

--- a/codebase_rag/parsers/io_access/descriptor.py
+++ b/codebase_rag/parsers/io_access/descriptor.py
@@ -58,6 +58,13 @@ class LanguageDescriptor:
     # (H) (scope starts AFTER the ShortVarDecl: `os := os.Getenv()` reads the package)
     # (H) -> add it AFTER. Only consulted when hoisted_declarations is False.
     decl_in_own_initializer: bool
+    # (H) The declaration-statement node whose declarators must be scoped in source
+    # (H) order within the statement (Java `local_variable_declaration`): in
+    # (H) `T x = sink(), System = ...` the first initializer runs before `System` binds,
+    # (H) so each declarator's initializer sees only the declarators up to itself. None
+    # (H) where no such per-declarator ordering is needed (Go's list-assign RHS is
+    # (H) evaluated wholesale; JS is hoisted).
+    declaration_statement_type: str | None
     # (H) Member/subscript access node types + fields, for env reads like
     # (H) `process.env.X` (member) and `process.env['X']` (subscript).
     member_expression_type: str
@@ -91,6 +98,7 @@ _JS_TS_DESCRIPTOR = LanguageDescriptor(
     sinks_require_import=False,
     hoisted_declarations=True,
     decl_in_own_initializer=True,
+    declaration_statement_type=None,
     member_expression_type=cs.TS_MEMBER_EXPRESSION,
     subscript_type=cs.TS_SUBSCRIPT_EXPRESSION,
     object_field=cs.FIELD_OBJECT,
@@ -127,6 +135,7 @@ _GO_DESCRIPTOR = LanguageDescriptor(
     # (H) after a valid package call must not retroactively shadow it -- source order.
     hoisted_declarations=False,
     decl_in_own_initializer=False,
+    declaration_statement_type=None,
     # (H) Inert for Go (no IO_MEMBER_READS entry): Go env access is a call
     # (H) (`os.Getenv`), not member access. Filled with Go's selector/subscript shapes.
     member_expression_type=cs.TS_GO_SELECTOR_EXPRESSION,
@@ -166,6 +175,7 @@ _JAVA_DESCRIPTOR = LanguageDescriptor(
     # (H) later local must not shadow an earlier same-named sink call -- source order.
     hoisted_declarations=False,
     decl_in_own_initializer=True,
+    declaration_statement_type=cs.TS_LOCAL_VARIABLE_DECLARATION,
     # (H) Inert (no IO_MEMBER_READS for Java): env access is a call. Filled with Java's
     # (H) field_access (object/field) and array_access (index) shapes for correctness.
     member_expression_type=cs.TS_FIELD_ACCESS,

--- a/codebase_rag/parsers/io_access/descriptor.py
+++ b/codebase_rag/parsers/io_access/descriptor.py
@@ -36,6 +36,12 @@ class LanguageDescriptor:
     # (H) (Go always imports stdlib; a package-scope `var os` is not the stdlib os).
     # (H) False for JS/TS, whose sinks include unimported globals (`console`, `fetch`).
     sinks_require_import: bool
+    # (H) True when declarations hoist over the whole block (JS `function`/`var`, and
+    # (H) const/let are lexically in scope before their line via the TDZ), so a local
+    # (H) shadows every use in the block. False for declare-at-point languages (Go,
+    # (H) Java), where a local shadows only the uses that FOLLOW its declaration -- so
+    # (H) the walk must add declarations in source order, not block-wide up front.
+    hoisted_declarations: bool
     # (H) Member/subscript access node types + fields, for env reads like
     # (H) `process.env.X` (member) and `process.env['X']` (subscript).
     member_expression_type: str
@@ -65,6 +71,7 @@ _JS_TS_DESCRIPTOR = LanguageDescriptor(
     block_scope_type=cs.TS_STATEMENT_BLOCK,
     extra_declarator_types=frozenset(),
     sinks_require_import=False,
+    hoisted_declarations=True,
     member_expression_type=cs.TS_MEMBER_EXPRESSION,
     subscript_type=cs.TS_SUBSCRIPT_EXPRESSION,
     object_field=cs.FIELD_OBJECT,
@@ -95,6 +102,9 @@ _GO_DESCRIPTOR = LanguageDescriptor(
         {cs.TS_GO_VAR_SPEC, cs.TS_GO_CONST_SPEC, cs.TS_GO_RANGE_CLAUSE}
     ),
     sinks_require_import=True,
+    # (H) Go is declare-at-point (`:=`/`var` bind from that line on), so a local named
+    # (H) after a valid package call must not retroactively shadow it -- source order.
+    hoisted_declarations=False,
     # (H) Inert for Go (no IO_MEMBER_READS entry): Go env access is a call
     # (H) (`os.Getenv`), not member access. Filled with Go's selector/subscript shapes.
     member_expression_type=cs.TS_GO_SELECTOR_EXPRESSION,
@@ -120,7 +130,7 @@ _JAVA_DESCRIPTOR = LanguageDescriptor(
     # (H) Java locals that shadow the `System`/`Files` global head: a
     # (H) `variable_declarator` (`Object System = ...`), a `formal_parameter`, and an
     # (H) `enhanced_for_statement` (for-each) loop var (extra_declarator_types).
-    identifier_type=cs.TS_PY_IDENTIFIER,
+    identifier_type=cs.TS_IDENTIFIER,
     declarator_type=cs.TS_VARIABLE_DECLARATOR,
     params_field=cs.TS_FIELD_PARAMETERS,
     block_scope_type=cs.TS_JAVA_BLOCK,
@@ -128,6 +138,9 @@ _JAVA_DESCRIPTOR = LanguageDescriptor(
     # (H) Java's System/Files sink heads are java.lang / java.nio globals that never
     # (H) appear in import_map, so requiring an import would reject every sink.
     sinks_require_import=False,
+    # (H) Java locals are declare-at-point (in scope from their statement on), so a
+    # (H) later local must not shadow an earlier same-named sink call -- source order.
+    hoisted_declarations=False,
     # (H) Inert (no IO_MEMBER_READS for Java): env access is a call. Filled with Java's
     # (H) field_access (object/field) and array_access (index) shapes for correctness.
     member_expression_type=cs.TS_FIELD_ACCESS,

--- a/codebase_rag/parsers/io_access/descriptor.py
+++ b/codebase_rag/parsers/io_access/descriptor.py
@@ -52,6 +52,12 @@ class LanguageDescriptor:
     # (H) Java), where a local shadows only the uses that FOLLOW its declaration -- so
     # (H) the walk must add declarations in source order, not block-wide up front.
     hoisted_declarations: bool
+    # (H) Whether a local is in scope in its OWN initializer (and later comma-declarators
+    # (H) in the same statement). True for Java (JLS 6.3: `T System = System.getenv()`
+    # (H) resolves the local) -> add the name BEFORE walking the statement. False for Go
+    # (H) (scope starts AFTER the ShortVarDecl: `os := os.Getenv()` reads the package)
+    # (H) -> add it AFTER. Only consulted when hoisted_declarations is False.
+    decl_in_own_initializer: bool
     # (H) Member/subscript access node types + fields, for env reads like
     # (H) `process.env.X` (member) and `process.env['X']` (subscript).
     member_expression_type: str
@@ -84,6 +90,7 @@ _JS_TS_DESCRIPTOR = LanguageDescriptor(
     statement_container_type=None,
     sinks_require_import=False,
     hoisted_declarations=True,
+    decl_in_own_initializer=True,
     member_expression_type=cs.TS_MEMBER_EXPRESSION,
     subscript_type=cs.TS_SUBSCRIPT_EXPRESSION,
     object_field=cs.FIELD_OBJECT,
@@ -119,6 +126,7 @@ _GO_DESCRIPTOR = LanguageDescriptor(
     # (H) Go is declare-at-point (`:=`/`var` bind from that line on), so a local named
     # (H) after a valid package call must not retroactively shadow it -- source order.
     hoisted_declarations=False,
+    decl_in_own_initializer=False,
     # (H) Inert for Go (no IO_MEMBER_READS entry): Go env access is a call
     # (H) (`os.Getenv`), not member access. Filled with Go's selector/subscript shapes.
     member_expression_type=cs.TS_GO_SELECTOR_EXPRESSION,
@@ -157,6 +165,7 @@ _JAVA_DESCRIPTOR = LanguageDescriptor(
     # (H) Java locals are declare-at-point (in scope from their statement on), so a
     # (H) later local must not shadow an earlier same-named sink call -- source order.
     hoisted_declarations=False,
+    decl_in_own_initializer=True,
     # (H) Inert (no IO_MEMBER_READS for Java): env access is a call. Filled with Java's
     # (H) field_access (object/field) and array_access (index) shapes for correctness.
     member_expression_type=cs.TS_FIELD_ACCESS,

--- a/codebase_rag/parsers/io_access/descriptor.py
+++ b/codebase_rag/parsers/io_access/descriptor.py
@@ -104,6 +104,39 @@ _GO_DESCRIPTOR = LanguageDescriptor(
     subscript_index_field=cs.TS_GO_FIELD_INDEX,
 )
 
+_JAVA_DESCRIPTOR = LanguageDescriptor(
+    call_type=cs.TS_JAVA_METHOD_INVOCATION,
+    string_type=cs.TS_JAVA_STRING_LITERAL,
+    string_content_type=cs.TS_STRING_FRAGMENT,
+    keyword_arg_type=None,
+    nested_scope_types=frozenset(
+        {
+            cs.TS_METHOD_DECLARATION,
+            cs.TS_CONSTRUCTOR_DECLARATION,
+            cs.TS_JAVA_LAMBDA_EXPRESSION,
+        }
+    )
+    | cs.JAVA_CLASS_NODE_TYPES,
+    # (H) Java locals that shadow the `System`/`Files` global head: a
+    # (H) `variable_declarator` (`Object System = ...`), a `formal_parameter`, and an
+    # (H) `enhanced_for_statement` (for-each) loop var (extra_declarator_types).
+    identifier_type=cs.TS_PY_IDENTIFIER,
+    declarator_type=cs.TS_VARIABLE_DECLARATOR,
+    params_field=cs.TS_FIELD_PARAMETERS,
+    block_scope_type=cs.TS_JAVA_BLOCK,
+    extra_declarator_types=frozenset({cs.TS_ENHANCED_FOR_STATEMENT}),
+    # (H) Java's System/Files sink heads are java.lang / java.nio globals that never
+    # (H) appear in import_map, so requiring an import would reject every sink.
+    sinks_require_import=False,
+    # (H) Inert (no IO_MEMBER_READS for Java): env access is a call. Filled with Java's
+    # (H) field_access (object/field) and array_access (index) shapes for correctness.
+    member_expression_type=cs.TS_FIELD_ACCESS,
+    subscript_type=cs.TS_JAVA_ARRAY_ACCESS,
+    object_field=cs.FIELD_OBJECT,
+    property_field=cs.JAVA_FIELD_FIELD,
+    subscript_index_field=cs.JAVA_FIELD_INDEX,
+)
+
 # (H) Non-Python languages with a direct-sink descriptor. Python keeps its own
 # (H) handle-aware walk; each new language lands one entry (plus registry rows).
 LANGUAGE_DESCRIPTORS: dict[cs.SupportedLanguage, LanguageDescriptor] = {
@@ -111,4 +144,5 @@ LANGUAGE_DESCRIPTORS: dict[cs.SupportedLanguage, LanguageDescriptor] = {
     cs.SupportedLanguage.TS: _JS_TS_DESCRIPTOR,
     cs.SupportedLanguage.TSX: _JS_TS_DESCRIPTOR,
     cs.SupportedLanguage.GO: _GO_DESCRIPTOR,
+    cs.SupportedLanguage.JAVA: _JAVA_DESCRIPTOR,
 }

--- a/codebase_rag/parsers/io_access/extract.py
+++ b/codebase_rag/parsers/io_access/extract.py
@@ -60,9 +60,20 @@ def definition_header_nodes(node: Node) -> list[Node]:
 
 def call_name(call_node: Node) -> str | None:
     fn = call_node.child_by_field_name(cs.TS_FIELD_FUNCTION)
-    if fn is None or fn.text is None:
+    if fn is not None:
+        return fn.text.decode(cs.ENCODING_UTF8) if fn.text is not None else None
+    # (H) Java `method_invocation` has no `function` field: it exposes `object` (the
+    # (H) receiver, absent for an unqualified/static-imported call) and `name`.
+    # (H) Reconstruct the dotted callee (`System.out.println`) so it matches the
+    # (H) registry keys, exactly as the `function` field's text would for other langs.
+    name = call_node.child_by_field_name(cs.TS_FIELD_NAME)
+    if name is None or name.text is None:
         return None
-    return fn.text.decode(cs.ENCODING_UTF8)
+    method = name.text.decode(cs.ENCODING_UTF8)
+    obj = call_node.child_by_field_name(cs.FIELD_OBJECT)
+    if obj is not None and obj.text is not None:
+        return f"{obj.text.decode(cs.ENCODING_UTF8)}{cs.SEPARATOR_DOT}{method}"
+    return method
 
 
 def is_require_alias(declarator: Node, call_type: str) -> bool:

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -316,6 +316,18 @@ class IOAccessProcessor:
         member_reads: tuple[tuple[str, ResourceKind], ...],
         descriptor: LanguageDescriptor,
     ) -> None:
+        # (H) Go wraps a block's statements in a single `statement_list`; unwrap it so
+        # (H) the source-order walk iterates the real statements, not one container.
+        if descriptor.statement_container_type is not None:
+            statements = [
+                child
+                for stmt in statements
+                for child in (
+                    stmt.named_children
+                    if stmt.type == descriptor.statement_container_type
+                    else (stmt,)
+                )
+            ]
         # (H) Names in scope for calls in these statements: the enclosing scopes'
         # (H) names plus this block's own declarations. A `const fs = require('fs')`
         # (H) declarator is an import alias (the genuine module, resolved by
@@ -331,6 +343,7 @@ class IOAccessProcessor:
                 self._walk_stmt_sinks(
                     stmt,
                     in_scope,
+                    frozenset(),
                     caller_spec,
                     import_map,
                     sink_by_name,
@@ -341,24 +354,51 @@ class IOAccessProcessor:
         # (H) Declare-at-point languages (Go, Java): a local is in scope only from its
         # (H) own statement onward, so grow the shadow set in SOURCE ORDER. A call
         # (H) BEFORE a later same-named local is the real global and still emits; the
-        # (H) local shadows only the calls that follow it.
+        # (H) local shadows only the calls that follow it. Declarations are added AFTER
+        # (H) the statement is walked, so a sink in the statement's own header (a
+        # (H) `T x = <init>`, a for-each iterable) is not shadowed by the name it binds.
+        # (H) Loop-clause vars are the exception: scoped to the BODY only, seeded there
+        # (H) via body_extra, and never leaked to sibling statements.
         live = set(inherited)
         for stmt in statements:
-            live |= self._block_declarations([stmt], descriptor)
+            loop_vars = self._loop_declarations(stmt, descriptor)
             self._walk_stmt_sinks(
                 stmt,
                 frozenset(live),
+                loop_vars,
                 caller_spec,
                 import_map,
                 sink_by_name,
                 member_reads,
                 descriptor,
             )
+            live |= self._block_declarations([stmt], descriptor) - loop_vars
+
+    def _loop_declarations(
+        self, stmt: Node, descriptor: LanguageDescriptor
+    ) -> frozenset[str]:
+        # (H) Names bound by a loop clause (Java for-each var, Go `range` var) within
+        # (H) this statement: in scope in the loop body only. Stops at nested scopes /
+        # (H) blocks so an inner loop's var is not hoisted to the outer statement.
+        names: set[str] = set()
+        stack = [stmt]
+        while stack:
+            node = stack.pop()
+            if (
+                node.type in descriptor.nested_scope_types
+                or node.type == descriptor.block_scope_type
+            ):
+                continue
+            if node.type in descriptor.loop_declarator_types:
+                names |= self._declarator_names(node, descriptor)
+            stack.extend(node.named_children)
+        return frozenset(names)
 
     def _walk_stmt_sinks(
         self,
         stmt: Node,
         in_scope: frozenset[str],
+        body_extra: frozenset[str],
         caller_spec: tuple[str, str, str],
         import_map: dict[str, str],
         sink_by_name: dict[str, IOSink],
@@ -368,7 +408,9 @@ class IOAccessProcessor:
         # (H) Emit the direct sinks / member reads within one statement subtree, under
         # (H) the given in-scope shadow set. A nested { } is a child lexical scope:
         # (H) recurse via _walk_scope so its declarations shadow only inside it (and,
-        # (H) for declare-at-point langs, in its own source order).
+        # (H) for declare-at-point langs, in its own source order). body_extra seeds a
+        # (H) loop var into the body scope (the loop's own block) without exposing it to
+        # (H) the header expressions walked in this flat pass.
         stack = [stmt]
         while stack:
             node = stack.pop()
@@ -378,7 +420,7 @@ class IOAccessProcessor:
             if node.type == descriptor.block_scope_type:
                 self._walk_scope(
                     list(node.named_children),
-                    in_scope,
+                    in_scope | body_extra,
                     caller_spec,
                     import_map,
                     sink_by_name,

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -354,16 +354,21 @@ class IOAccessProcessor:
         # (H) Declare-at-point languages (Go, Java): a local is in scope only from its
         # (H) own declaration onward, so grow the shadow set in SOURCE ORDER. A call
         # (H) BEFORE a later same-named local is the real global and still emits; the
-        # (H) local shadows only the statements from its own on. A plain local is in
-        # (H) scope from its own initializer (JLS 6.3: `T System = System.getenv()` and
-        # (H) later comma-declarators see it), so its name is added to `live` BEFORE the
-        # (H) statement is walked. Loop-clause vars are the exception: in scope in the
-        # (H) BODY only (not the iterable header, evaluated before the var binds, nor
-        # (H) sibling statements), so they are seeded via body_extra and NOT added here.
+        # (H) local shadows only the statements from its own on. Whether the declaring
+        # (H) statement's OWN initializer sees the name is language-specific
+        # (H) (decl_in_own_initializer): Java adds it BEFORE walking (JLS 6.3:
+        # (H) `T System = System.getenv()` and later comma-declarators resolve the
+        # (H) local); Go adds it AFTER (scope starts after the ShortVarDecl, so
+        # (H) `os := os.Getenv()` still reads the package). Loop-clause vars are always
+        # (H) the exception: in scope in the BODY only (not the iterable header,
+        # (H) evaluated before the var binds, nor sibling statements), so they are
+        # (H) seeded via body_extra and never added to `live` here.
         live = set(inherited)
         for stmt in statements:
             loop_vars = self._loop_declarations(stmt, descriptor)
-            live |= self._block_declarations([stmt], descriptor) - loop_vars
+            plain = self._block_declarations([stmt], descriptor) - loop_vars
+            if descriptor.decl_in_own_initializer:
+                live |= plain
             self._walk_stmt_sinks(
                 stmt,
                 frozenset(live),
@@ -374,6 +379,8 @@ class IOAccessProcessor:
                 member_reads,
                 descriptor,
             )
+            if not descriptor.decl_in_own_initializer:
+                live |= plain
 
     def _loop_declarations(
         self, stmt: Node, descriptor: LanguageDescriptor

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -367,20 +367,67 @@ class IOAccessProcessor:
         for stmt in statements:
             loop_vars = self._loop_declarations(stmt, descriptor)
             plain = self._block_declarations([stmt], descriptor) - loop_vars
-            if descriptor.decl_in_own_initializer:
-                live |= plain
+            if (
+                descriptor.declaration_statement_type is not None
+                and stmt.type == descriptor.declaration_statement_type
+            ):
+                # (H) Java multi-declarator: each declarator's initializer sees only the
+                # (H) declarators up to and including itself, so walk them in source order.
+                self._walk_declaration_ordered(
+                    stmt,
+                    frozenset(live),
+                    caller_spec,
+                    import_map,
+                    sink_by_name,
+                    member_reads,
+                    descriptor,
+                )
+            else:
+                # (H) decl_in_own_initializer (Java): the name is in scope in its own
+                # (H) initializer, so seed BEFORE walking; Go (=False): the initializer
+                # (H) still reads the global, so the name is added only AFTER (below).
+                pre = live | plain if descriptor.decl_in_own_initializer else live
+                self._walk_stmt_sinks(
+                    stmt,
+                    frozenset(pre),
+                    loop_vars,
+                    caller_spec,
+                    import_map,
+                    sink_by_name,
+                    member_reads,
+                    descriptor,
+                )
+            live |= plain
+
+    def _walk_declaration_ordered(
+        self,
+        stmt: Node,
+        base_scope: frozenset[str],
+        caller_spec: tuple[str, str, str],
+        import_map: dict[str, str],
+        sink_by_name: dict[str, IOSink],
+        member_reads: tuple[tuple[str, ResourceKind], ...],
+        descriptor: LanguageDescriptor,
+    ) -> None:
+        # (H) Walk a declaration statement's declarators in SOURCE ORDER (Java
+        # (H) `local_variable_declaration`): a declarator's name enters scope for its own
+        # (H) initializer (JLS 6.3) and the following declarators, so an EARLIER
+        # (H) initializer's sink is not shadowed by a LATER declarator's name.
+        cur = set(base_scope)
+        for child in stmt.named_children:
+            if child.type != descriptor.declarator_type:
+                continue
+            cur |= self._declarator_names(child, descriptor)
             self._walk_stmt_sinks(
-                stmt,
-                frozenset(live),
-                loop_vars,
+                child,
+                frozenset(cur),
+                frozenset(),
                 caller_spec,
                 import_map,
                 sink_by_name,
                 member_reads,
                 descriptor,
             )
-            if not descriptor.decl_in_own_initializer:
-                live |= plain
 
     def _loop_declarations(
         self, stmt: Node, descriptor: LanguageDescriptor

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -316,27 +316,65 @@ class IOAccessProcessor:
         member_reads: tuple[tuple[str, ResourceKind], ...],
         descriptor: LanguageDescriptor,
     ) -> None:
-        # (H) Names in scope for calls in THESE statements: the enclosing scopes'
-        # (H) names plus this block's own const/let/function declarations. A
-        # (H) `const fs = require('fs')` declarator is an import alias (the genuine
-        # (H) module, resolved by _resolve_sink), so _block_declarations skips it;
-        # (H) but a local `const fs = {}` IS a shadow, even if `fs` is imported
-        # (H) module-wide, so import names are NOT blanket-removed here.
-        # (H) ponytail: order-INSENSITIVE within a block -- every declaration shadows
-        # (H) the whole block. Correct for JS (function/var hoist; const/let before
-        # (H) use is a TDZ error), but for Go's declare-at-point `:=`/`var` a local
-        # (H) declared LATER over-suppresses an earlier valid package call in the same
-        # (H) block -- a rare false NEGATIVE (redeclaring a used package name). An
-        # (H) order-sensitive walk is the upgrade if that ever matters.
-        in_scope = inherited | self._block_declarations(statements, descriptor)
-        stack = list(statements)
+        # (H) Names in scope for calls in these statements: the enclosing scopes'
+        # (H) names plus this block's own declarations. A `const fs = require('fs')`
+        # (H) declarator is an import alias (the genuine module, resolved by
+        # (H) _resolve_sink), so _block_declarations skips it; but a local
+        # (H) `const fs = {}` IS a shadow, even if `fs` is imported module-wide, so
+        # (H) import names are NOT blanket-removed here.
+        if descriptor.hoisted_declarations:
+            # (H) JS/TS: declarations hoist / are lexically in scope block-wide (a use
+            # (H) before a const/let is a TDZ error, not the outer name), so every
+            # (H) declaration shadows the whole block at once.
+            in_scope = inherited | self._block_declarations(statements, descriptor)
+            for stmt in statements:
+                self._walk_stmt_sinks(
+                    stmt,
+                    in_scope,
+                    caller_spec,
+                    import_map,
+                    sink_by_name,
+                    member_reads,
+                    descriptor,
+                )
+            return
+        # (H) Declare-at-point languages (Go, Java): a local is in scope only from its
+        # (H) own statement onward, so grow the shadow set in SOURCE ORDER. A call
+        # (H) BEFORE a later same-named local is the real global and still emits; the
+        # (H) local shadows only the calls that follow it.
+        live = set(inherited)
+        for stmt in statements:
+            live |= self._block_declarations([stmt], descriptor)
+            self._walk_stmt_sinks(
+                stmt,
+                frozenset(live),
+                caller_spec,
+                import_map,
+                sink_by_name,
+                member_reads,
+                descriptor,
+            )
+
+    def _walk_stmt_sinks(
+        self,
+        stmt: Node,
+        in_scope: frozenset[str],
+        caller_spec: tuple[str, str, str],
+        import_map: dict[str, str],
+        sink_by_name: dict[str, IOSink],
+        member_reads: tuple[tuple[str, ResourceKind], ...],
+        descriptor: LanguageDescriptor,
+    ) -> None:
+        # (H) Emit the direct sinks / member reads within one statement subtree, under
+        # (H) the given in-scope shadow set. A nested { } is a child lexical scope:
+        # (H) recurse via _walk_scope so its declarations shadow only inside it (and,
+        # (H) for declare-at-point langs, in its own source order).
+        stack = [stmt]
         while stack:
             node = stack.pop()
             # (H) Nested function/method: its own caller, walked separately.
             if node.type in descriptor.nested_scope_types:
                 continue
-            # (H) A nested { } is a child lexical scope: recurse with this block's
-            # (H) names inherited, so its declarations shadow only inside it.
             if node.type == descriptor.block_scope_type:
                 self._walk_scope(
                     list(node.named_children),
@@ -464,6 +502,13 @@ class IOAccessProcessor:
             # (H) field(s) are the bound locals.
             for child in node.children_by_field_name(cs.TS_FIELD_NAME):
                 self._pattern_names(child, descriptor, out)
+        elif node_type == cs.TS_SPREAD_PARAMETER:
+            # (H) Java varargs `void f(Object... System)`: the type is a sibling and the
+            # (H) bound name lives in a `variable_declarator` child (its `name` field).
+            for child in node.named_children:
+                if child.type == descriptor.declarator_type:
+                    for name in child.children_by_field_name(cs.TS_FIELD_NAME):
+                        self._pattern_names(name, descriptor, out)
         elif node_type in (
             cs.TS_OBJECT_PATTERN,
             cs.TS_ARRAY_PATTERN,

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -459,8 +459,9 @@ class IOAccessProcessor:
             # (H) `{ key: local }` binds the VALUE (local), not the property key.
             if (value := node.child_by_field_name(cs.FIELD_VALUE)) is not None:
                 self._pattern_names(value, descriptor, out)
-        elif node_type == cs.TS_GO_PARAMETER_DECLARATION:
-            # (H) Go `func f(os Config)`: the `name` field(s) are the bound locals.
+        elif node_type in (cs.TS_GO_PARAMETER_DECLARATION, cs.TS_FORMAL_PARAMETER):
+            # (H) Go `func f(os Config)` / Java `void f(Object System)`: the `name`
+            # (H) field(s) are the bound locals.
             for child in node.children_by_field_name(cs.TS_FIELD_NAME):
                 self._pattern_names(child, descriptor, out)
         elif node_type in (

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -352,16 +352,18 @@ class IOAccessProcessor:
                 )
             return
         # (H) Declare-at-point languages (Go, Java): a local is in scope only from its
-        # (H) own statement onward, so grow the shadow set in SOURCE ORDER. A call
+        # (H) own declaration onward, so grow the shadow set in SOURCE ORDER. A call
         # (H) BEFORE a later same-named local is the real global and still emits; the
-        # (H) local shadows only the calls that follow it. Declarations are added AFTER
-        # (H) the statement is walked, so a sink in the statement's own header (a
-        # (H) `T x = <init>`, a for-each iterable) is not shadowed by the name it binds.
-        # (H) Loop-clause vars are the exception: scoped to the BODY only, seeded there
-        # (H) via body_extra, and never leaked to sibling statements.
+        # (H) local shadows only the statements from its own on. A plain local is in
+        # (H) scope from its own initializer (JLS 6.3: `T System = System.getenv()` and
+        # (H) later comma-declarators see it), so its name is added to `live` BEFORE the
+        # (H) statement is walked. Loop-clause vars are the exception: in scope in the
+        # (H) BODY only (not the iterable header, evaluated before the var binds, nor
+        # (H) sibling statements), so they are seeded via body_extra and NOT added here.
         live = set(inherited)
         for stmt in statements:
             loop_vars = self._loop_declarations(stmt, descriptor)
+            live |= self._block_declarations([stmt], descriptor) - loop_vars
             self._walk_stmt_sinks(
                 stmt,
                 frozenset(live),
@@ -372,7 +374,6 @@ class IOAccessProcessor:
                 member_reads,
                 descriptor,
             )
-            live |= self._block_declarations([stmt], descriptor) - loop_vars
 
     def _loop_declarations(
         self, stmt: Node, descriptor: LanguageDescriptor

--- a/codebase_rag/parsers/io_access/registry.py
+++ b/codebase_rag/parsers/io_access/registry.py
@@ -188,12 +188,37 @@ _GO_SINKS: tuple[IOSink, ...] = (
     IOSink("net/http.PostForm", ResourceKind.NETWORK, IODirection.WRITE, target_arg=0),
 )
 
+# (H) Java direct-call I/O sinks (issue #714). Keyed by the dotted callee text
+# (H) reconstructed from `method_invocation` (`System.getenv`, `System.out.println`):
+# (H) `System` (java.lang) and `Files` (java.nio.file) are effective globals, so the
+# (H) sink table is not import-gated (sinks_require_import=False); a local named
+# (H) `System`/`Files` still shadows it. Java has no keyword args, so the env key /
+# (H) path is positional arg 0. Handle-based I/O (java.io/java.nio streams, java.sql
+# (H) Statement.execute*, HttpClient) and static-imported bare calls are a follow-up.
+_JAVA_SINKS: tuple[IOSink, ...] = (
+    IOSink("System.getenv", ResourceKind.ENV, IODirection.READ, target_arg=0),
+    IOSink("System.out.println", ResourceKind.STDOUT, IODirection.WRITE),
+    IOSink("System.out.print", ResourceKind.STDOUT, IODirection.WRITE),
+    IOSink("System.out.printf", ResourceKind.STDOUT, IODirection.WRITE),
+    IOSink("System.out.write", ResourceKind.STDOUT, IODirection.WRITE),
+    IOSink("System.err.println", ResourceKind.STDOUT, IODirection.WRITE),
+    IOSink("System.err.print", ResourceKind.STDOUT, IODirection.WRITE),
+    IOSink("System.err.printf", ResourceKind.STDOUT, IODirection.WRITE),
+    IOSink("Files.readString", ResourceKind.FILE, IODirection.READ, target_arg=0),
+    IOSink("Files.readAllLines", ResourceKind.FILE, IODirection.READ, target_arg=0),
+    IOSink("Files.readAllBytes", ResourceKind.FILE, IODirection.READ, target_arg=0),
+    IOSink("Files.lines", ResourceKind.FILE, IODirection.READ, target_arg=0),
+    IOSink("Files.writeString", ResourceKind.FILE, IODirection.WRITE, target_arg=0),
+    IOSink("Files.write", ResourceKind.FILE, IODirection.WRITE, target_arg=0),
+)
+
 IO_SINKS: dict[cs.SupportedLanguage, tuple[IOSink, ...]] = {
     cs.SupportedLanguage.PYTHON: _PYTHON_SINKS,
     cs.SupportedLanguage.JS: _JS_TS_SINKS,
     cs.SupportedLanguage.TS: _JS_TS_SINKS,
     cs.SupportedLanguage.TSX: _JS_TS_SINKS,
     cs.SupportedLanguage.GO: _GO_SINKS,
+    cs.SupportedLanguage.JAVA: _JAVA_SINKS,
 }
 
 # (H) Member/subscript accesses that are I/O reads, keyed by the object prefix:

--- a/codebase_rag/parsers/io_access/registry.py
+++ b/codebase_rag/parsers/io_access/registry.py
@@ -195,21 +195,41 @@ _GO_SINKS: tuple[IOSink, ...] = (
 # (H) `System`/`Files` still shadows it. Java has no keyword args, so the env key /
 # (H) path is positional arg 0. Handle-based I/O (java.io/java.nio streams, java.sql
 # (H) Statement.execute*, HttpClient) and static-imported bare calls are a follow-up.
-_JAVA_SINKS: tuple[IOSink, ...] = (
+_JAVA_SYSTEM_SINKS: tuple[IOSink, ...] = (
     IOSink("System.getenv", ResourceKind.ENV, IODirection.READ, target_arg=0),
     IOSink("System.out.println", ResourceKind.STDOUT, IODirection.WRITE),
     IOSink("System.out.print", ResourceKind.STDOUT, IODirection.WRITE),
     IOSink("System.out.printf", ResourceKind.STDOUT, IODirection.WRITE),
+    IOSink("System.out.format", ResourceKind.STDOUT, IODirection.WRITE),
     IOSink("System.out.write", ResourceKind.STDOUT, IODirection.WRITE),
     IOSink("System.err.println", ResourceKind.STDOUT, IODirection.WRITE),
     IOSink("System.err.print", ResourceKind.STDOUT, IODirection.WRITE),
     IOSink("System.err.printf", ResourceKind.STDOUT, IODirection.WRITE),
-    IOSink("Files.readString", ResourceKind.FILE, IODirection.READ, target_arg=0),
-    IOSink("Files.readAllLines", ResourceKind.FILE, IODirection.READ, target_arg=0),
-    IOSink("Files.readAllBytes", ResourceKind.FILE, IODirection.READ, target_arg=0),
-    IOSink("Files.lines", ResourceKind.FILE, IODirection.READ, target_arg=0),
-    IOSink("Files.writeString", ResourceKind.FILE, IODirection.WRITE, target_arg=0),
-    IOSink("Files.write", ResourceKind.FILE, IODirection.WRITE, target_arg=0),
+    IOSink("System.err.format", ResourceKind.STDOUT, IODirection.WRITE),
+    IOSink("System.err.write", ResourceKind.STDOUT, IODirection.WRITE),
+)
+
+# (H) java.nio.file.Files static sinks. Registered under BOTH the simple `Files.X`
+# (H) (bare call, Files not in import_map) and the fully-qualified
+# (H) `java.nio.file.Files.X` key: with `import java.nio.file.Files` the call
+# (H) normalises to the FQN, and a fully-qualified call carries the FQN in its text --
+# (H) so both the imported and the qualified-call cases resolve.
+_JAVA_FILES_METHODS: tuple[tuple[str, IODirection], ...] = (
+    ("readString", IODirection.READ),
+    ("readAllLines", IODirection.READ),
+    ("readAllBytes", IODirection.READ),
+    ("lines", IODirection.READ),
+    ("writeString", IODirection.WRITE),
+    ("write", IODirection.WRITE),
+)
+
+_JAVA_SINKS: tuple[IOSink, ...] = (
+    *_JAVA_SYSTEM_SINKS,
+    *(
+        IOSink(f"{prefix}.{method}", ResourceKind.FILE, direction, target_arg=0)
+        for method, direction in _JAVA_FILES_METHODS
+        for prefix in ("Files", "java.nio.file.Files")
+    ),
 )
 
 IO_SINKS: dict[cs.SupportedLanguage, tuple[IOSink, ...]] = {

--- a/codebase_rag/tests/integration/test_go_io_e2e.py
+++ b/codebase_rag/tests/integration/test_go_io_e2e.py
@@ -152,6 +152,21 @@ def test_go_var_and_range_shadow_package(
     assert (_WRITES, "resource::STDOUT::<dynamic>") not in edges
 
 
+def test_go_self_referential_init_emits(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) Go scope starts AFTER the declaration (unlike Java), so in `os := os.Getenv(..)`
+    # (H) the RHS os is still the imported package -- the ENV read must emit; the new
+    # (H) local os shadows only the statements that follow.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        'package main\n\nimport "os"\n\n'
+        'func f() {\n\tos := os.Getenv("PATH")\n\t_ = os\n}\n',
+    )
+    assert (_READS, "resource::ENV::PATH") in _io_edges(memgraph_ingestor)
+
+
 def test_go_unimported_package_name_no_edge(
     memgraph_ingestor: MemgraphIngestor, tmp_path: Path
 ) -> None:

--- a/codebase_rag/tests/integration/test_java_io_e2e.py
+++ b/codebase_rag/tests/integration/test_java_io_e2e.py
@@ -114,3 +114,85 @@ def test_java_local_var_shadows_system(
         "}\n",
     )
     assert (_READS, "resource::ENV::SECRET") not in _io_edges(memgraph_ingestor)
+
+
+def test_java_call_before_decl_still_emits(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) Java locals are declare-at-point: a call BEFORE a same-named local is the
+    # (H) real global, so it must still emit. A later `Object System` shadows only the
+    # (H) calls that follow it, not this earlier System.getenv (source-order shadowing).
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "class App {\n"
+        "    void f() {\n"
+        '        System.getenv("A");\n'
+        "        Object System = make();\n"
+        '        System.getenv("B");\n'
+        "    }\n"
+        "}\n",
+    )
+    edges = _io_edges(memgraph_ingestor)
+    assert (_READS, "resource::ENV::A") in edges
+    assert (_READS, "resource::ENV::B") not in edges
+
+
+def test_java_imported_files_emits(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) `import java.nio.file.Files` maps Files -> java.nio.file.Files, so the call
+    # (H) normalises to java.nio.file.Files.readString; the FQN sink key must match so
+    # (H) the FILE read still emits (the common, imported case).
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "import java.nio.file.Files;\n"
+        "class App {\n"
+        "    void load() {\n"
+        "        String cfg = Files.readString(configPath());\n"
+        "    }\n"
+        "}\n",
+    )
+    assert any(
+        rel == _READS and qn.endswith("FILE::<dynamic>")
+        for rel, qn in _io_edges(memgraph_ingestor)
+    )
+
+
+def test_java_fully_qualified_files_emits(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) A fully-qualified call `java.nio.file.Files.write(...)` (no import) also hits
+    # (H) the FQN sink key.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "class App {\n"
+        "    void save(byte[] b) {\n"
+        "        java.nio.file.Files.write(outPath(), b);\n"
+        "    }\n"
+        "}\n",
+    )
+    assert any(
+        rel == _WRITES and qn.endswith("FILE::<dynamic>")
+        for rel, qn in _io_edges(memgraph_ingestor)
+    )
+
+
+def test_java_varargs_shadows_system(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) A varargs parameter `Object... System` is a `spread_parameter` (no `name`
+    # (H) field; the bound name is its plain identifier child). It shadows the global
+    # (H) just like a plain parameter, so no ENV read may be emitted.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "class App {\n"
+        "    void f(Object... System) {\n"
+        '        System.getenv("SECRET");\n'
+        "    }\n"
+        "}\n",
+    )
+    assert (_READS, "resource::ENV::SECRET") not in _io_edges(memgraph_ingestor)

--- a/codebase_rag/tests/integration/test_java_io_e2e.py
+++ b/codebase_rag/tests/integration/test_java_io_e2e.py
@@ -180,6 +180,45 @@ def test_java_fully_qualified_files_emits(
     )
 
 
+def test_java_foreach_iterable_call_not_shadowed(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) The for-each loop variable is NOT in scope in the iterable expression, so a
+    # (H) sink there is the real global and must emit even when the loop var name
+    # (H) collides with the sink head.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "class App {\n"
+        "    void f() {\n"
+        '        for (String System : System.getenv("PATH").split(":")) {\n'
+        "            use(System);\n"
+        "        }\n"
+        "    }\n"
+        "}\n",
+    )
+    assert (_READS, "resource::ENV::PATH") in _io_edges(memgraph_ingestor)
+
+
+def test_java_foreach_loopvar_shadows_in_body(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) The for-each loop variable IS in scope in the loop body, so a call on it
+    # (H) there is shadowed (not the global).
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "class App {\n"
+        "    void f(Object[] items) {\n"
+        "        for (Object System : items) {\n"
+        '            System.getenv("X");\n'
+        "        }\n"
+        "    }\n"
+        "}\n",
+    )
+    assert (_READS, "resource::ENV::X") not in _io_edges(memgraph_ingestor)
+
+
 def test_java_varargs_shadows_system(
     memgraph_ingestor: MemgraphIngestor, tmp_path: Path
 ) -> None:

--- a/codebase_rag/tests/integration/test_java_io_e2e.py
+++ b/codebase_rag/tests/integration/test_java_io_e2e.py
@@ -198,6 +198,25 @@ def test_java_multi_declarator_second_init_shadowed(
     assert (_READS, "resource::ENV::SECRET") not in _io_edges(memgraph_ingestor)
 
 
+def test_java_earlier_declarator_init_not_shadowed(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) In `Object x = System.getenv("A"), System = make()` the sink is in the FIRST
+    # (H) declarator's initializer, which runs BEFORE the second declarator binds
+    # (H) `System` (JLS 6.3: a name is in scope only from its own declarator on), so
+    # (H) System.getenv there is the global and must emit.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "class App {\n"
+        "    void f() {\n"
+        '        Object x = System.getenv("A"), System = make();\n'
+        "    }\n"
+        "}\n",
+    )
+    assert (_READS, "resource::ENV::A") in _io_edges(memgraph_ingestor)
+
+
 def test_java_foreach_iterable_call_not_shadowed(
     memgraph_ingestor: MemgraphIngestor, tmp_path: Path
 ) -> None:

--- a/codebase_rag/tests/integration/test_java_io_e2e.py
+++ b/codebase_rag/tests/integration/test_java_io_e2e.py
@@ -180,6 +180,24 @@ def test_java_fully_qualified_files_emits(
     )
 
 
+def test_java_multi_declarator_second_init_shadowed(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) In `Object System = make(), x = System.getenv(...)` the first declarator binds
+    # (H) `System`, which is in scope for the second declarator's initializer (JLS 6.3),
+    # (H) so System.getenv there is the local, not the global -- no ENV read.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "class App {\n"
+        "    void f() {\n"
+        '        Object System = make(), x = System.getenv("SECRET");\n'
+        "    }\n"
+        "}\n",
+    )
+    assert (_READS, "resource::ENV::SECRET") not in _io_edges(memgraph_ingestor)
+
+
 def test_java_foreach_iterable_call_not_shadowed(
     memgraph_ingestor: MemgraphIngestor, tmp_path: Path
 ) -> None:

--- a/codebase_rag/tests/integration/test_java_io_e2e.py
+++ b/codebase_rag/tests/integration/test_java_io_e2e.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.capture import resolve_capture
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+if TYPE_CHECKING:
+    from codebase_rag.services.graph_service import MemgraphIngestor
+
+pytestmark = [pytest.mark.integration]
+
+_READS = cs.RelationshipType.READS_FROM.value
+_WRITES = cs.RelationshipType.WRITES_TO.value
+
+
+def _build(ingestor: MemgraphIngestor, tmp_path: Path, code: str) -> None:
+    project = tmp_path / "java_project"
+    project.mkdir()
+    (project / "App.java").write_text(code, encoding="utf-8")
+    parsers, queries = load_parsers()
+    GraphUpdater(
+        ingestor=ingestor,
+        repo_path=project,
+        parsers=parsers,
+        queries=queries,
+        capture=resolve_capture([cs.CaptureGroup.IO.value]),
+    ).run()
+
+
+def _io_edges(ingestor: MemgraphIngestor) -> set[tuple[str, str]]:
+    rows = ingestor.fetch_all(
+        f"MATCH ()-[r:{_READS}|{_WRITES}]->(res:{cs.NodeLabel.RESOURCE.value}) "
+        "RETURN type(r) AS rel, res.qualified_name AS qn"
+    )
+    return {(str(row["rel"]), str(row["qn"])) for row in rows}
+
+
+_JAVA_CODE = """\
+class App {
+    void leak() {
+        String s = System.getenv("SECRET");
+        System.out.println(s);
+        System.err.print(s);
+        Files.writeString(configPath(), s);
+    }
+}
+"""
+
+
+def test_java_direct_io_sinks(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) System.getenv reads ENV::SECRET (literal arg); System.out/err.print* write
+    # (H) STDOUT (arg is an identifier -> <dynamic>); Files.writeString writes a FILE
+    # (H) (its arg is a Path, so the path identity is <dynamic>). First Java increment
+    # (H) of issue #714 -- direct, non-handle sinks only.
+    _build(memgraph_ingestor, tmp_path, _JAVA_CODE)
+    edges = _io_edges(memgraph_ingestor)
+    assert (_READS, "resource::ENV::SECRET") in edges
+    assert (_WRITES, "resource::STDOUT::<dynamic>") in edges
+    assert (_WRITES, "resource::FILE::<dynamic>") in edges
+
+
+def test_java_files_read(memgraph_ingestor: MemgraphIngestor, tmp_path: Path) -> None:
+    # (H) Files.readString / readAllLines are direct FILE reads.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "class App {\n"
+        "    void load() {\n"
+        "        String cfg = Files.readString(configPath());\n"
+        "    }\n"
+        "}\n",
+    )
+    edges = _io_edges(memgraph_ingestor)
+    assert any(rel == _READS and qn.endswith("FILE::<dynamic>") for rel, qn in edges)
+
+
+def test_java_local_shadows_system(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) A parameter named `System` shadows the java.lang.System global, so
+    # (H) System.getenv here is not the stdlib sink -- no ENV read may be emitted.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "class App {\n"
+        "    void f(Object System) {\n"
+        '        System.getenv("SECRET");\n'
+        "    }\n"
+        "}\n",
+    )
+    assert (_READS, "resource::ENV::SECRET") not in _io_edges(memgraph_ingestor)
+
+
+def test_java_local_var_shadows_system(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) A local variable named `System` also shadows the global within its scope.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "class App {\n"
+        "    void f() {\n"
+        "        Object System = make();\n"
+        '        System.getenv("SECRET");\n'
+        "    }\n"
+        "}\n",
+    )
+    assert (_READS, "resource::ENV::SECRET") not in _io_edges(memgraph_ingestor)

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.335"
+version = "0.0.336"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

First Java increment of #714: emit `READS_FROM` / `WRITES_TO` I/O edges for Java direct-call sinks, under the opt-in `io` capture group (off by default). Until now every non-Python language except JS/TS/Go produced zero I/O edges.

## Sinks (direct, non-handle)

- `System.getenv` -> ENV read
- `System.out`/`System.err` `.println`/`.print`/`.printf`/`.write` -> STDOUT write
- `Files.readString`/`readAllLines`/`readAllBytes`/`lines` -> FILE read
- `Files.writeString`/`write` -> FILE write

## How

Java reuses the language-agnostic direct-sink walk (`_emit_direct_sinks`) added for JS/TS/Go. The only Java-specific pieces:

- **`call_name`** now reconstructs the dotted callee from a `method_invocation`'s `object` + `name` fields (Java has no `function` field like the other grammars), so `System.out.println` matches the registry key. Unchanged for Python/JS/Go (their call nodes always have a `function` field).
- **`_JAVA_DESCRIPTOR`** (node types: `method_invocation`, `string_literal`/`string_fragment`, `block` scope, `variable_declarator`, `enhanced_for_statement` loop var, nested `lambda`/method/class scopes). `sinks_require_import=False` because `System` (java.lang) and `Files` (java.nio.file) are effective globals never in the import map; a local named `System`/`Files` still shadows the sink.
- **`_pattern_names`** gained a `formal_parameter` branch so Java method params shadow-collect (mirrors Go's `parameter_declaration`).

## Tests (RED -> GREEN)

`test_java_io_e2e.py`: direct sinks (ENV/STDOUT/FILE), `Files` read, and two shadow cases (param-named and local-var-named `System` suppress the ENV read).

## Ceilings (follow-ups)

- Handle-based I/O (`java.io`/`java.nio` streams, `java.sql` `Statement.execute*`, `HttpClient`) is not modeled (same stance as JS/Go stream handles).
- Static-imported bare calls (`getenv(...)` after `import static`) do not match; direct network sinks are absent (Java HTTP is handle-based).
- `Files.*` path identity is `<dynamic>` because the argument is a `Path`, not a string literal.
- FLOWS_TO for Java is a separate follow-up (the lean flow walk already dispatches on the descriptor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)