### PR TITLE
feat(io): direct READS_FROM/WRITES_TO sinks for Rust (#714)

### DIFF
--- a/codebase_rag/constants/ast_rust.py
+++ b/codebase_rag/constants/ast_rust.py
@@ -45,6 +45,16 @@ TS_RS_STRING_LITERAL = "string_literal"
 TS_RS_STRING_CONTENT = "string_content"
 TS_RS_BLOCK = "block"
 TS_RS_FIELD_MACRO = "macro"
+# (H) A macro body is a flat `token_tree` of raw tokens (`::` and `(...)` included),
+# (H) not a parse tree, so a call inside `println!(..)` has no call_expression node.
+TS_RS_TOKEN_TREE = "token_tree"
+TS_RS_TOKEN_SCOPE = "::"
+# (H) `s.field` is a field_expression (value/field); `arr[i]` an index_expression
+# (H) (unnamed children in this grammar). Inert for I/O (Rust env access is a call),
+# (H) wired for correctness / future value-level sinks.
+TS_RS_INDEX_EXPRESSION = "index_expression"
+RS_FIELD_FIELD = "field"
+RS_FIELD_INDEX = "index"
 
 # (H) Rust node types for local-variable type inference (receiver-dispatch)
 TS_RS_LET_DECLARATION = "let_declaration"

--- a/codebase_rag/constants/ast_rust.py
+++ b/codebase_rag/constants/ast_rust.py
@@ -37,6 +37,15 @@ RS_COMMENT_TYPES = (TS_RS_LINE_COMMENT, TS_RS_BLOCK_COMMENT)
 TS_RS_ATTRIBUTE_ITEM = "attribute_item"
 TS_RS_INNER_ATTRIBUTE_ITEM = "inner_attribute_item"
 
+# (H) Rust I/O direct-sink walk node types (issue #714). call_expression keeps a
+# (H) `function` field (a scoped_identifier like `std::fs::write`), so call_name works
+# (H) unchanged; `macro_invocation` (`println!`) needs its own handling via macro_type.
+# (H) A string_literal wraps a `string_content`; `block` is the fn-body lexical scope.
+TS_RS_STRING_LITERAL = "string_literal"
+TS_RS_STRING_CONTENT = "string_content"
+TS_RS_BLOCK = "block"
+TS_RS_FIELD_MACRO = "macro"
+
 # (H) Rust node types for local-variable type inference (receiver-dispatch)
 TS_RS_LET_DECLARATION = "let_declaration"
 TS_RS_PARAMETER = "parameter"

--- a/codebase_rag/parsers/io_access/descriptor.py
+++ b/codebase_rag/parsers/io_access/descriptor.py
@@ -76,6 +76,11 @@ class LanguageDescriptor:
     object_field: str
     property_field: str
     subscript_index_field: str
+    # (H) Path separator for scoped call names (Rust `::`). When set, sink resolution
+    # (H) expands the head segment through the import map on THIS separator (`use
+    # (H) std::fs; fs::write` -> `std::fs::write`) instead of the default `.`, so a bare
+    # (H) short path matches std only when its head is genuinely imported. None = `.`.
+    scope_separator: str | None = None
 
 
 _JS_TS_DESCRIPTOR = LanguageDescriptor(
@@ -224,6 +229,7 @@ _RUST_DESCRIPTOR = LanguageDescriptor(
     object_field=cs.FIELD_VALUE,
     property_field=cs.RS_FIELD_FIELD,
     subscript_index_field=cs.RS_FIELD_INDEX,
+    scope_separator=cs.TS_RS_TOKEN_SCOPE,
 )
 
 # (H) Non-Python languages with a direct-sink descriptor. Python keeps its own

--- a/codebase_rag/parsers/io_access/descriptor.py
+++ b/codebase_rag/parsers/io_access/descriptor.py
@@ -217,12 +217,13 @@ _RUST_DESCRIPTOR = LanguageDescriptor(
     declaration_statement_type=None,
     macro_type=cs.TS_RS_MACRO_INVOCATION,
     # (H) Inert (no IO_MEMBER_READS for Rust): env access is a call (`std::env::var`).
-    # (H) Filled with Rust's field_expression shape for correctness.
+    # (H) Filled with Rust's own field_expression / index_expression shape for
+    # (H) correctness (not Java's field_access), so a future value-level sink is right.
     member_expression_type=cs.TS_RS_FIELD_EXPRESSION,
-    subscript_type=cs.TS_RS_FIELD_EXPRESSION,
+    subscript_type=cs.TS_RS_INDEX_EXPRESSION,
     object_field=cs.FIELD_VALUE,
-    property_field=cs.JAVA_FIELD_FIELD,
-    subscript_index_field=cs.JAVA_FIELD_INDEX,
+    property_field=cs.RS_FIELD_FIELD,
+    subscript_index_field=cs.RS_FIELD_INDEX,
 )
 
 # (H) Non-Python languages with a direct-sink descriptor. Python keeps its own

--- a/codebase_rag/parsers/io_access/descriptor.py
+++ b/codebase_rag/parsers/io_access/descriptor.py
@@ -65,6 +65,10 @@ class LanguageDescriptor:
     # (H) where no such per-declarator ordering is needed (Go's list-assign RHS is
     # (H) evaluated wholesale; JS is hoisted).
     declaration_statement_type: str | None
+    # (H) Macro-call node whose name is matched against a per-language macro sink table
+    # (H) (Rust `println!`/`eprintln!` write STDOUT); None where the language has no such
+    # (H) macro I/O. The macro name lives in the `macro` field.
+    macro_type: str | None
     # (H) Member/subscript access node types + fields, for env reads like
     # (H) `process.env.X` (member) and `process.env['X']` (subscript).
     member_expression_type: str
@@ -99,6 +103,7 @@ _JS_TS_DESCRIPTOR = LanguageDescriptor(
     hoisted_declarations=True,
     decl_in_own_initializer=True,
     declaration_statement_type=None,
+    macro_type=None,
     member_expression_type=cs.TS_MEMBER_EXPRESSION,
     subscript_type=cs.TS_SUBSCRIPT_EXPRESSION,
     object_field=cs.FIELD_OBJECT,
@@ -138,6 +143,7 @@ _GO_DESCRIPTOR = LanguageDescriptor(
     declaration_statement_type=None,
     # (H) Inert for Go (no IO_MEMBER_READS entry): Go env access is a call
     # (H) (`os.Getenv`), not member access. Filled with Go's selector/subscript shapes.
+    macro_type=None,
     member_expression_type=cs.TS_GO_SELECTOR_EXPRESSION,
     subscript_type=cs.TS_GO_INDEX_EXPRESSION,
     object_field=cs.TS_GO_FIELD_OPERAND,
@@ -178,9 +184,43 @@ _JAVA_DESCRIPTOR = LanguageDescriptor(
     declaration_statement_type=cs.TS_LOCAL_VARIABLE_DECLARATION,
     # (H) Inert (no IO_MEMBER_READS for Java): env access is a call. Filled with Java's
     # (H) field_access (object/field) and array_access (index) shapes for correctness.
+    macro_type=None,
     member_expression_type=cs.TS_FIELD_ACCESS,
     subscript_type=cs.TS_JAVA_ARRAY_ACCESS,
     object_field=cs.FIELD_OBJECT,
+    property_field=cs.JAVA_FIELD_FIELD,
+    subscript_index_field=cs.JAVA_FIELD_INDEX,
+)
+
+_RUST_DESCRIPTOR = LanguageDescriptor(
+    call_type=cs.TS_RS_CALL_EXPRESSION,
+    string_type=cs.TS_RS_STRING_LITERAL,
+    string_content_type=cs.TS_RS_STRING_CONTENT,
+    keyword_arg_type=None,
+    nested_scope_types=frozenset({cs.TS_RS_FUNCTION_ITEM, cs.TS_RS_CLOSURE_EXPRESSION}),
+    # (H) Rust `let x = ...` binds via a `pattern` field; params via `parameter`'s
+    # (H) `pattern` field (handled by _param_names' pattern unwrap). Shadowing is inert
+    # (H) for Rust's `::`-path and macro sinks (a local can't shadow `std::fs::write`
+    # (H) or `println!`), but wired for correctness / future value-level sinks.
+    identifier_type=cs.TS_IDENTIFIER,
+    declarator_type=cs.TS_RS_LET_DECLARATION,
+    params_field=cs.TS_FIELD_PARAMETERS,
+    block_scope_type=cs.TS_RS_BLOCK,
+    extra_declarator_types=frozenset(),
+    loop_declarator_types=frozenset(),
+    statement_container_type=None,
+    sinks_require_import=False,
+    # (H) Rust `let` is declare-at-point and its scope starts AFTER the statement
+    # (H) (`let x = x` reads the outer x), like Go: source-order, add name after.
+    hoisted_declarations=False,
+    decl_in_own_initializer=False,
+    declaration_statement_type=None,
+    macro_type=cs.TS_RS_MACRO_INVOCATION,
+    # (H) Inert (no IO_MEMBER_READS for Rust): env access is a call (`std::env::var`).
+    # (H) Filled with Rust's field_expression shape for correctness.
+    member_expression_type=cs.TS_RS_FIELD_EXPRESSION,
+    subscript_type=cs.TS_RS_FIELD_EXPRESSION,
+    object_field=cs.FIELD_VALUE,
     property_field=cs.JAVA_FIELD_FIELD,
     subscript_index_field=cs.JAVA_FIELD_INDEX,
 )
@@ -193,4 +233,5 @@ LANGUAGE_DESCRIPTORS: dict[cs.SupportedLanguage, LanguageDescriptor] = {
     cs.SupportedLanguage.TSX: _JS_TS_DESCRIPTOR,
     cs.SupportedLanguage.GO: _GO_DESCRIPTOR,
     cs.SupportedLanguage.JAVA: _JAVA_DESCRIPTOR,
+    cs.SupportedLanguage.RUST: _RUST_DESCRIPTOR,
 }

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -32,6 +32,7 @@ from .models import HandleBinding, HandleConstructor, IOSink
 from .registry import (
     IO_HANDLE_CONSTRUCTORS,
     IO_HANDLE_METHODS,
+    IO_MACRO_SINKS,
     IO_MEMBER_READS,
     IO_SINKS,
 )
@@ -59,6 +60,8 @@ class IOAccessProcessor:
         # (H) When neither I/O edge is enabled, skip the body walk entirely.
         self._selection = selection
         self._enabled = selection.io_enabled
+        # (H) Per-language macro sink table, (re)set at the start of each caller walk.
+        self._macro_sinks: dict[str, IOSink] = {}
 
     def process_io_for_caller(
         self,
@@ -75,6 +78,9 @@ class IOAccessProcessor:
             return
         import_map = self._import_processor.import_mapping.get(module_qn, {})
         sink_by_name = {s.callee: s for s in sinks}
+        # (H) Per-language macro sink table (Rust print macros), read during the walk by
+        # (H) _emit_macro. Set per caller; the walk is single-threaded, so no re-entrancy.
+        self._macro_sinks = IO_MACRO_SINKS.get(language, {})
         # (H) Non-Python languages take a lean direct-sink walk (issue #714): match
         # (H) call sinks and emit, without Python's handle/scope machinery (streams
         # (H) and data-flow are a follow-up). Python keeps the full handle-aware walk.
@@ -487,6 +493,13 @@ class IOAccessProcessor:
                 self._emit_direct_call(
                     node, caller_spec, import_map, sink_by_name, descriptor, in_scope
                 )
+            elif (
+                descriptor.macro_type is not None and node.type == descriptor.macro_type
+            ):
+                # (H) A macro sink (`println!`) writes STDOUT; still descend so a real
+                # (H) call sink inside the macro args (`println!("{}", env::var("X"))`)
+                # (H) is also caught.
+                self._emit_macro(node, caller_spec)
             elif member_reads and node.type in (
                 descriptor.member_expression_type,
                 descriptor.subscript_type,
@@ -495,6 +508,17 @@ class IOAccessProcessor:
                     node, caller_spec, member_reads, in_scope, import_map, descriptor
                 )
             stack.extend(node.named_children)
+
+    def _emit_macro(self, node: Node, caller_spec: tuple[str, str, str]) -> None:
+        # (H) Match a macro invocation's name (`macro` field) against the per-language
+        # (H) macro sink table (Rust `println!`/`eprintln!` -> STDOUT). The target is a
+        # (H) format template, so the resource identity is always <dynamic>.
+        macro = node.child_by_field_name(cs.TS_RS_FIELD_MACRO)
+        if macro is None or macro.text is None:
+            return
+        sink = self._macro_sinks.get(macro.text.decode(cs.ENCODING_UTF8))
+        if sink is not None:
+            self._emit(caller_spec, sink.direction, sink.kind, DYNAMIC_TARGET)
 
     def _emit_member_read(
         self,
@@ -572,12 +596,15 @@ class IOAccessProcessor:
         # (H) The local names a declaration binds: JS `const fs = ...` / destructuring
         # (H) uses the `name` field; Go `var/const os = ...` also has `name` field(s),
         # (H) while `os := ...` / `range` use the `left` field (an expression_list of
-        # (H) identifiers). All are collected so they shadow a same-named builtin.
+        # (H) identifiers); Rust `let s = ...` uses the `pattern` field. All are
+        # (H) collected so they shadow a same-named builtin.
         names: set[str] = set()
         for name in declarator.children_by_field_name(cs.TS_FIELD_NAME):
             self._pattern_names(name, descriptor, names)
         if (left := declarator.child_by_field_name(cs.FIELD_LEFT)) is not None:
             self._pattern_names(left, descriptor, names)
+        for pattern in declarator.children_by_field_name(cs.TS_FIELD_PATTERN):
+            self._pattern_names(pattern, descriptor, names)
         return names
 
     def _pattern_names(

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -60,8 +60,6 @@ class IOAccessProcessor:
         # (H) When neither I/O edge is enabled, skip the body walk entirely.
         self._selection = selection
         self._enabled = selection.io_enabled
-        # (H) Per-language macro sink table, (re)set at the start of each caller walk.
-        self._macro_sinks: dict[str, IOSink] = {}
 
     def process_io_for_caller(
         self,
@@ -78,9 +76,10 @@ class IOAccessProcessor:
             return
         import_map = self._import_processor.import_mapping.get(module_qn, {})
         sink_by_name = {s.callee: s for s in sinks}
-        # (H) Per-language macro sink table (Rust print macros), read during the walk by
-        # (H) _emit_macro. Set per caller; the walk is single-threaded, so no re-entrancy.
-        self._macro_sinks = IO_MACRO_SINKS.get(language, {})
+        # (H) Per-language macro sink table (Rust print macros), threaded through the
+        # (H) walk to _emit_macro as a parameter (not instance state) so the processor
+        # (H) stays stateless, mirroring sink_by_name.
+        macro_sinks = IO_MACRO_SINKS.get(language, {})
         # (H) Non-Python languages take a lean direct-sink walk (issue #714): match
         # (H) call sinks and emit, without Python's handle/scope machinery (streams
         # (H) and data-flow are a follow-up). Python keeps the full handle-aware walk.
@@ -92,6 +91,7 @@ class IOAccessProcessor:
                     caller_spec,
                     import_map,
                     sink_by_name,
+                    macro_sinks,
                     IO_MEMBER_READS.get(language, ()),
                     descriptor,
                 )
@@ -278,6 +278,7 @@ class IOAccessProcessor:
         caller_spec: tuple[str, str, str],
         import_map: dict[str, str],
         sink_by_name: dict[str, IOSink],
+        macro_sinks: dict[str, IOSink],
         member_reads: tuple[tuple[str, ResourceKind], ...],
         descriptor: LanguageDescriptor,
     ) -> None:
@@ -308,6 +309,7 @@ class IOAccessProcessor:
             caller_spec,
             import_map,
             sink_by_name,
+            macro_sinks,
             member_reads,
             descriptor,
         )
@@ -319,6 +321,7 @@ class IOAccessProcessor:
         caller_spec: tuple[str, str, str],
         import_map: dict[str, str],
         sink_by_name: dict[str, IOSink],
+        macro_sinks: dict[str, IOSink],
         member_reads: tuple[tuple[str, ResourceKind], ...],
         descriptor: LanguageDescriptor,
     ) -> None:
@@ -353,6 +356,7 @@ class IOAccessProcessor:
                     caller_spec,
                     import_map,
                     sink_by_name,
+                    macro_sinks,
                     member_reads,
                     descriptor,
                 )
@@ -385,6 +389,7 @@ class IOAccessProcessor:
                     caller_spec,
                     import_map,
                     sink_by_name,
+                    macro_sinks,
                     member_reads,
                     descriptor,
                 )
@@ -400,6 +405,7 @@ class IOAccessProcessor:
                     caller_spec,
                     import_map,
                     sink_by_name,
+                    macro_sinks,
                     member_reads,
                     descriptor,
                 )
@@ -412,6 +418,7 @@ class IOAccessProcessor:
         caller_spec: tuple[str, str, str],
         import_map: dict[str, str],
         sink_by_name: dict[str, IOSink],
+        macro_sinks: dict[str, IOSink],
         member_reads: tuple[tuple[str, ResourceKind], ...],
         descriptor: LanguageDescriptor,
     ) -> None:
@@ -431,6 +438,7 @@ class IOAccessProcessor:
                 caller_spec,
                 import_map,
                 sink_by_name,
+                macro_sinks,
                 member_reads,
                 descriptor,
             )
@@ -463,6 +471,7 @@ class IOAccessProcessor:
         caller_spec: tuple[str, str, str],
         import_map: dict[str, str],
         sink_by_name: dict[str, IOSink],
+        macro_sinks: dict[str, IOSink],
         member_reads: tuple[tuple[str, ResourceKind], ...],
         descriptor: LanguageDescriptor,
     ) -> None:
@@ -485,6 +494,7 @@ class IOAccessProcessor:
                     caller_spec,
                     import_map,
                     sink_by_name,
+                    macro_sinks,
                     member_reads,
                     descriptor,
                 )
@@ -496,10 +506,14 @@ class IOAccessProcessor:
             elif (
                 descriptor.macro_type is not None and node.type == descriptor.macro_type
             ):
-                # (H) A macro sink (`println!`) writes STDOUT; still descend so a real
-                # (H) call sink inside the macro args (`println!("{}", env::var("X"))`)
-                # (H) is also caught.
-                self._emit_macro(node, caller_spec)
+                # (H) A macro sink (`println!`) writes STDOUT AND may inline a real call
+                # (H) sink in its args (`println!("{}", env::var("X"))`); tree-sitter
+                # (H) flattens the macro body to raw tokens (no call_expression node), so
+                # (H) _emit_macro reconstructs scoped calls from the token stream itself.
+                self._emit_macro(
+                    node, caller_spec, import_map, sink_by_name, macro_sinks, in_scope
+                )
+                continue
             elif member_reads and node.type in (
                 descriptor.member_expression_type,
                 descriptor.subscript_type,
@@ -509,16 +523,111 @@ class IOAccessProcessor:
                 )
             stack.extend(node.named_children)
 
-    def _emit_macro(self, node: Node, caller_spec: tuple[str, str, str]) -> None:
+    def _emit_macro(
+        self,
+        node: Node,
+        caller_spec: tuple[str, str, str],
+        import_map: dict[str, str],
+        sink_by_name: dict[str, IOSink],
+        macro_sinks: dict[str, IOSink],
+        in_scope: frozenset[str],
+    ) -> None:
         # (H) Match a macro invocation's name (`macro` field) against the per-language
-        # (H) macro sink table (Rust `println!`/`eprintln!` -> STDOUT). The target is a
-        # (H) format template, so the resource identity is always <dynamic>.
+        # (H) macro sink table (Rust `println!`/`eprintln!` -> STDOUT); the target is a
+        # (H) format template, so the STDOUT identity is always <dynamic>. Then scan the
+        # (H) macro's token_tree for an inlined call sink (`println!("{}", env::var("X"))`).
+        # (H) ponytail: a macro name is matched by text alone; a locally redefined macro
+        # (H) (`macro_rules! println`) would false-match. Tracking macro shadowing is the
+        # (H) upgrade path if that pathological case ever matters.
         macro = node.child_by_field_name(cs.TS_RS_FIELD_MACRO)
         if macro is None or macro.text is None:
             return
-        sink = self._macro_sinks.get(macro.text.decode(cs.ENCODING_UTF8))
+        sink = macro_sinks.get(macro.text.decode(cs.ENCODING_UTF8))
         if sink is not None:
             self._emit(caller_spec, sink.direction, sink.kind, DYNAMIC_TARGET)
+        for child in node.named_children:
+            if child.type == cs.TS_RS_TOKEN_TREE:
+                self._scan_token_tree_calls(
+                    child, caller_spec, import_map, sink_by_name, in_scope
+                )
+
+    def _scan_token_tree_calls(
+        self,
+        token_tree: Node,
+        caller_spec: tuple[str, str, str],
+        import_map: dict[str, str],
+        sink_by_name: dict[str, IOSink],
+        in_scope: frozenset[str],
+    ) -> None:
+        # (H) tree-sitter flattens a Rust macro body to raw tokens, so an inlined call
+        # (H) (`std::env::var("X")`) is a run of `identifier` joined by `::` tokens
+        # (H) followed by its args `token_tree` -- no call_expression node. Rebuild the
+        # (H) scoped name from that run, resolve it against the sink table (respecting
+        # (H) shadowing), and take arg0's string literal as the resource identity.
+        path: list[str] = []
+        expect_sep = False
+        for child in token_tree.children:
+            if child.type == cs.TS_IDENTIFIER and not expect_sep and child.text:
+                path.append(child.text.decode(cs.ENCODING_UTF8))
+                expect_sep = True
+            elif child.type == cs.TS_RS_TOKEN_SCOPE and expect_sep:
+                expect_sep = False
+            elif child.type == cs.TS_RS_TOKEN_TREE:
+                if path:
+                    self._emit_token_tree_call(
+                        "::".join(path),
+                        child,
+                        caller_spec,
+                        import_map,
+                        sink_by_name,
+                        in_scope,
+                    )
+                path, expect_sep = [], False
+                # (H) Recurse for a nested macro / grouped call in the arguments.
+                self._scan_token_tree_calls(
+                    child, caller_spec, import_map, sink_by_name, in_scope
+                )
+            else:
+                path, expect_sep = [], False
+
+    def _emit_token_tree_call(
+        self,
+        raw: str,
+        args: Node,
+        caller_spec: tuple[str, str, str],
+        import_map: dict[str, str],
+        sink_by_name: dict[str, IOSink],
+        in_scope: frozenset[str],
+    ) -> None:
+        # (H) A reconstructed scoped call (name `raw`, `args` = its token_tree). Rust
+        # (H) sinks never require an import, so pass sinks_require_import=False.
+        sink = self._resolve_sink(raw, import_map, sink_by_name, in_scope, False)
+        if sink is None:
+            return
+        # (H) ponytail: only arg0 (or a kwless <dynamic>) is resolved from the flat
+        # (H) token stream -- every Rust I/O sink targets arg 0 or nothing. A sink at a
+        # (H) higher arg index would need positional token counting (upgrade path).
+        identity = DYNAMIC_TARGET
+        if sink.target_arg == 0:
+            identity = self._first_token_arg_string(args)
+        self._emit(caller_spec, sink.direction, sink.kind, identity)
+
+    def _first_token_arg_string(self, args: Node) -> str:
+        # (H) arg0 of a flattened call's token_tree: the tokens before the first
+        # (H) top-level comma. It is the resource path only when it is a lone string
+        # (H) literal (`write(path, "x")` has a variable arg0 -> <dynamic>, not "x").
+        arg0: list[Node] = []
+        for child in args.children:
+            if child.type in (cs.CHAR_PAREN_OPEN, cs.CHAR_PAREN_CLOSE):
+                continue
+            if child.type == cs.CHAR_COMMA:
+                break
+            arg0.append(child)
+        if len(arg0) == 1 and arg0[0].type == cs.TS_RS_STRING_LITERAL:
+            return string_literal(
+                arg0[0], cs.TS_RS_STRING_LITERAL, cs.TS_RS_STRING_CONTENT
+            )
+        return DYNAMIC_TARGET
 
     def _emit_member_read(
         self,

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -511,7 +511,13 @@ class IOAccessProcessor:
                 # (H) flattens the macro body to raw tokens (no call_expression node), so
                 # (H) _emit_macro reconstructs scoped calls from the token stream itself.
                 self._emit_macro(
-                    node, caller_spec, import_map, sink_by_name, macro_sinks, in_scope
+                    node,
+                    caller_spec,
+                    import_map,
+                    sink_by_name,
+                    macro_sinks,
+                    in_scope,
+                    descriptor,
                 )
                 continue
             elif member_reads and node.type in (
@@ -531,6 +537,7 @@ class IOAccessProcessor:
         sink_by_name: dict[str, IOSink],
         macro_sinks: dict[str, IOSink],
         in_scope: frozenset[str],
+        descriptor: LanguageDescriptor,
     ) -> None:
         # (H) Match a macro invocation's name (`macro` field) against the per-language
         # (H) macro sink table (Rust `println!`/`eprintln!` -> STDOUT); the target is a
@@ -548,7 +555,7 @@ class IOAccessProcessor:
         for child in node.named_children:
             if child.type == cs.TS_RS_TOKEN_TREE:
                 self._scan_token_tree_calls(
-                    child, caller_spec, import_map, sink_by_name, in_scope
+                    child, caller_spec, import_map, sink_by_name, in_scope, descriptor
                 )
 
     def _scan_token_tree_calls(
@@ -558,6 +565,7 @@ class IOAccessProcessor:
         import_map: dict[str, str],
         sink_by_name: dict[str, IOSink],
         in_scope: frozenset[str],
+        descriptor: LanguageDescriptor,
     ) -> None:
         # (H) tree-sitter flattens a Rust macro body to raw tokens, so an inlined call
         # (H) (`std::env::var("X")`) is a run of `identifier` joined by `::` tokens
@@ -575,17 +583,18 @@ class IOAccessProcessor:
             elif child.type == cs.TS_RS_TOKEN_TREE:
                 if path:
                     self._emit_token_tree_call(
-                        "::".join(path),
+                        cs.TS_RS_TOKEN_SCOPE.join(path),
                         child,
                         caller_spec,
                         import_map,
                         sink_by_name,
                         in_scope,
+                        descriptor,
                     )
                 path, expect_sep = [], False
                 # (H) Recurse for a nested macro / grouped call in the arguments.
                 self._scan_token_tree_calls(
-                    child, caller_spec, import_map, sink_by_name, in_scope
+                    child, caller_spec, import_map, sink_by_name, in_scope, descriptor
                 )
             else:
                 path, expect_sep = [], False
@@ -598,10 +607,18 @@ class IOAccessProcessor:
         import_map: dict[str, str],
         sink_by_name: dict[str, IOSink],
         in_scope: frozenset[str],
+        descriptor: LanguageDescriptor,
     ) -> None:
-        # (H) A reconstructed scoped call (name `raw`, `args` = its token_tree). Rust
-        # (H) sinks never require an import, so pass sinks_require_import=False.
-        sink = self._resolve_sink(raw, import_map, sink_by_name, in_scope, False)
+        # (H) A reconstructed scoped call (name `raw`, `args` = its token_tree),
+        # (H) resolved with the same import-expansion / shadow rules as a real call.
+        sink = self._resolve_sink(
+            raw,
+            import_map,
+            sink_by_name,
+            in_scope,
+            descriptor.sinks_require_import,
+            descriptor.scope_separator,
+        )
         if sink is None:
             return
         # (H) ponytail: only arg0 (or a kwless <dynamic>) is resolved from the flat
@@ -787,7 +804,12 @@ class IOAccessProcessor:
         if raw is None:
             return
         sink = self._resolve_sink(
-            raw, import_map, sink_by_name, local_names, descriptor.sinks_require_import
+            raw,
+            import_map,
+            sink_by_name,
+            local_names,
+            descriptor.sinks_require_import,
+            descriptor.scope_separator,
         )
         if sink is None:
             return
@@ -808,7 +830,22 @@ class IOAccessProcessor:
         sink_by_name: dict[str, IOSink],
         local_names: frozenset[str],
         sinks_require_import: bool,
+        scope_separator: str | None = None,
     ) -> IOSink | None:
+        # (H) Rust (scope_separator="::"): sinks are keyed only under the full `std::`
+        # (H) form. Expand the head segment through the import map on `::` (`use std::fs;
+        # (H) fs::write` -> `std::fs::write`; a fully-qualified `std::fs::write` has an
+        # (H) unimported `std` head and stays as-is). A bare `fs::write` with no import
+        # (H) does not expand and misses -> no false match on a local `mod fs`. A head
+        # (H) bound to a local name is shadowed.
+        if scope_separator is not None:
+            head, _, rest = raw.partition(scope_separator)
+            if head in local_names:
+                return None
+            base = import_map.get(head)
+            if base is not None:
+                raw = f"{base}{scope_separator}{rest}" if rest else base
+            return sink_by_name.get(raw)
         # (H) Match a JS/TS/Go call against the sink table, respecting shadowing:
         # (H)  - a name bound locally (a local `const fs`, `function fetch`, or a
         # (H)    parameter) is never the builtin -> no match.

--- a/codebase_rag/parsers/io_access/registry.py
+++ b/codebase_rag/parsers/io_access/registry.py
@@ -248,6 +248,10 @@ _RUST_CALL_METHODS: tuple[
     ("fs", "read", ResourceKind.FILE, IODirection.READ, 0),
     ("fs", "write", ResourceKind.FILE, IODirection.WRITE, 0),
     ("fs", "remove_file", ResourceKind.FILE, IODirection.WRITE, 0),
+    ("fs", "create_dir", ResourceKind.FILE, IODirection.WRITE, 0),
+    ("fs", "create_dir_all", ResourceKind.FILE, IODirection.WRITE, 0),
+    ("fs", "remove_dir", ResourceKind.FILE, IODirection.WRITE, 0),
+    ("fs", "remove_dir_all", ResourceKind.FILE, IODirection.WRITE, 0),
 )
 
 _RUST_SINKS: tuple[IOSink, ...] = tuple(

--- a/codebase_rag/parsers/io_access/registry.py
+++ b/codebase_rag/parsers/io_access/registry.py
@@ -232,6 +232,30 @@ _JAVA_SINKS: tuple[IOSink, ...] = (
     ),
 )
 
+# (H) Rust direct-call I/O sinks (issue #714). call_name yields the callee's path text
+# (H) with `::` separators (`std::env::var`, `std::fs::write`); Rust code reaches these
+# (H) either fully-qualified or via `use std::fs;` + `fs::write(..)`, so each sink is
+# (H) keyed under BOTH the full `std::MODULE::fn` and the short `MODULE::fn` form (the
+# (H) `::` path is not shadowable by a local, so no import-gating needed). Rust has no
+# (H) keyword args -> path/key is positional arg 0. File handles (`File::open`,
+# (H) `BufReader`) and the print macros (handled separately) are follow-ups here.
+_RUST_CALL_METHODS: tuple[
+    tuple[str, str, ResourceKind, IODirection, int | None], ...
+] = (
+    ("env", "var", ResourceKind.ENV, IODirection.READ, 0),
+    ("env", "vars", ResourceKind.ENV, IODirection.READ, None),
+    ("fs", "read_to_string", ResourceKind.FILE, IODirection.READ, 0),
+    ("fs", "read", ResourceKind.FILE, IODirection.READ, 0),
+    ("fs", "write", ResourceKind.FILE, IODirection.WRITE, 0),
+    ("fs", "remove_file", ResourceKind.FILE, IODirection.WRITE, 0),
+)
+
+_RUST_SINKS: tuple[IOSink, ...] = tuple(
+    IOSink(f"{prefix}{module}::{fn}", kind, direction, target_arg=arg)
+    for module, fn, kind, direction, arg in _RUST_CALL_METHODS
+    for prefix in ("", "std::")
+)
+
 IO_SINKS: dict[cs.SupportedLanguage, tuple[IOSink, ...]] = {
     cs.SupportedLanguage.PYTHON: _PYTHON_SINKS,
     cs.SupportedLanguage.JS: _JS_TS_SINKS,
@@ -239,6 +263,19 @@ IO_SINKS: dict[cs.SupportedLanguage, tuple[IOSink, ...]] = {
     cs.SupportedLanguage.TSX: _JS_TS_SINKS,
     cs.SupportedLanguage.GO: _GO_SINKS,
     cs.SupportedLanguage.JAVA: _JAVA_SINKS,
+    cs.SupportedLanguage.RUST: _RUST_SINKS,
+}
+
+# (H) Macro-call I/O sinks keyed by macro name (issue #714). Rust's stdout/stderr write
+# (H) path is the `println!`/`print!`/`eprintln!`/`eprint!` macros, not calls; the target
+# (H) is a format template, so the resource identity is always <dynamic> (STDOUT).
+_RUST_MACRO_SINKS: dict[str, IOSink] = {
+    name: IOSink(name, ResourceKind.STDOUT, IODirection.WRITE)
+    for name in ("println", "print", "eprintln", "eprint")
+}
+
+IO_MACRO_SINKS: dict[cs.SupportedLanguage, dict[str, IOSink]] = {
+    cs.SupportedLanguage.RUST: _RUST_MACRO_SINKS,
 }
 
 # (H) Member/subscript accesses that are I/O reads, keyed by the object prefix:

--- a/codebase_rag/parsers/io_access/registry.py
+++ b/codebase_rag/parsers/io_access/registry.py
@@ -254,10 +254,13 @@ _RUST_CALL_METHODS: tuple[
     ("fs", "remove_dir_all", ResourceKind.FILE, IODirection.WRITE, 0),
 )
 
+# (H) Keyed only under the fully `std::`-qualified form. A bare short path
+# (H) (`use std::fs; fs::write`) resolves by expanding its head segment through the
+# (H) import map (fs -> std::fs); keying the bare `fs::write` too would overmatch a
+# (H) local `mod fs { fn write() }` that never touches std.
 _RUST_SINKS: tuple[IOSink, ...] = tuple(
-    IOSink(f"{prefix}{module}::{fn}", kind, direction, target_arg=arg)
+    IOSink(f"std::{module}::{fn}", kind, direction, target_arg=arg)
     for module, fn, kind, direction, arg in _RUST_CALL_METHODS
-    for prefix in ("", "std::")
 )
 
 IO_SINKS: dict[cs.SupportedLanguage, tuple[IOSink, ...]] = {

--- a/codebase_rag/tests/integration/test_rust_io_e2e.py
+++ b/codebase_rag/tests/integration/test_rust_io_e2e.py
@@ -45,8 +45,11 @@ _RUST_CODE = """\
 fn leak(name: String) {
     let s = std::env::var("SECRET").unwrap();
     println!("{}", s);
+    print!("{}", s);
     eprintln!("err {}", name);
+    eprint!("err {}", name);
     std::fs::write("out.txt", s);
+    std::fs::create_dir("d");
     let c = std::fs::read_to_string("in.txt");
 }
 """
@@ -55,14 +58,36 @@ fn leak(name: String) {
 def test_rust_direct_io_sinks(
     memgraph_ingestor: MemgraphIngestor, tmp_path: Path
 ) -> None:
-    # (H) std::env::var reads ENV::SECRET; println!/eprintln! macros write STDOUT;
-    # (H) std::fs::write / read_to_string are direct FILE write/read. First Rust
-    # (H) increment of issue #714 -- direct calls + print macros, no handles.
+    # (H) std::env::var reads ENV::SECRET; println!/print!/eprintln!/eprint! macros
+    # (H) write STDOUT; std::fs::write / create_dir / read_to_string are direct FILE
+    # (H) write/read. First Rust increment of issue #714 -- direct calls + print
+    # (H) macros, no handles.
     _build(memgraph_ingestor, tmp_path, _RUST_CODE)
     edges = _io_edges(memgraph_ingestor)
     assert (_READS, "resource::ENV::SECRET") in edges
     assert (_WRITES, "resource::STDOUT::<dynamic>") in edges
     assert (_WRITES, "resource::FILE::out.txt") in edges
+    assert (_WRITES, "resource::FILE::d") in edges
+    assert (_READS, "resource::FILE::in.txt") in edges
+
+
+def test_rust_call_inside_print_macro_emits(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) A sink call written INLINE in macro args -- `println!("{}", env::var("X"))`
+    # (H) -- must still emit its READS_FROM. tree-sitter flattens macro bodies into a
+    # (H) token_tree of raw tokens (no call_expression node), so the walk reconstructs
+    # (H) scoped calls from the token stream. The canonical "log a secret" taint case.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "fn f() {\n"
+        '    println!("{}", std::env::var("SECRET"));\n'
+        '    eprintln!("{}", std::fs::read_to_string("in.txt").unwrap());\n'
+        "}\n",
+    )
+    edges = _io_edges(memgraph_ingestor)
+    assert (_READS, "resource::ENV::SECRET") in edges
     assert (_READS, "resource::FILE::in.txt") in edges
 
 

--- a/codebase_rag/tests/integration/test_rust_io_e2e.py
+++ b/codebase_rag/tests/integration/test_rust_io_e2e.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.capture import resolve_capture
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+if TYPE_CHECKING:
+    from codebase_rag.services.graph_service import MemgraphIngestor
+
+pytestmark = [pytest.mark.integration]
+
+_READS = cs.RelationshipType.READS_FROM.value
+_WRITES = cs.RelationshipType.WRITES_TO.value
+
+
+def _build(ingestor: MemgraphIngestor, tmp_path: Path, code: str) -> None:
+    project = tmp_path / "rust_project"
+    project.mkdir()
+    (project / "main.rs").write_text(code, encoding="utf-8")
+    parsers, queries = load_parsers()
+    GraphUpdater(
+        ingestor=ingestor,
+        repo_path=project,
+        parsers=parsers,
+        queries=queries,
+        capture=resolve_capture([cs.CaptureGroup.IO.value]),
+    ).run()
+
+
+def _io_edges(ingestor: MemgraphIngestor) -> set[tuple[str, str]]:
+    rows = ingestor.fetch_all(
+        f"MATCH ()-[r:{_READS}|{_WRITES}]->(res:{cs.NodeLabel.RESOURCE.value}) "
+        "RETURN type(r) AS rel, res.qualified_name AS qn"
+    )
+    return {(str(row["rel"]), str(row["qn"])) for row in rows}
+
+
+_RUST_CODE = """\
+fn leak(name: String) {
+    let s = std::env::var("SECRET").unwrap();
+    println!("{}", s);
+    eprintln!("err {}", name);
+    std::fs::write("out.txt", s);
+    let c = std::fs::read_to_string("in.txt");
+}
+"""
+
+
+def test_rust_direct_io_sinks(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) std::env::var reads ENV::SECRET; println!/eprintln! macros write STDOUT;
+    # (H) std::fs::write / read_to_string are direct FILE write/read. First Rust
+    # (H) increment of issue #714 -- direct calls + print macros, no handles.
+    _build(memgraph_ingestor, tmp_path, _RUST_CODE)
+    edges = _io_edges(memgraph_ingestor)
+    assert (_READS, "resource::ENV::SECRET") in edges
+    assert (_WRITES, "resource::STDOUT::<dynamic>") in edges
+    assert (_WRITES, "resource::FILE::out.txt") in edges
+    assert (_READS, "resource::FILE::in.txt") in edges
+
+
+def test_rust_use_imported_short_path(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) `use std::fs;` then `fs::write(..)` is the idiomatic short form; the sink is
+    # (H) keyed on both the full `std::fs::write` and the `fs::write` short path.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "use std::fs;\nuse std::env;\n"
+        "fn f() {\n"
+        '    let k = env::var("TOKEN");\n'
+        '    fs::write("o.txt", k);\n'
+        "}\n",
+    )
+    edges = _io_edges(memgraph_ingestor)
+    assert (_READS, "resource::ENV::TOKEN") in edges
+    assert (_WRITES, "resource::FILE::o.txt") in edges
+
+
+def test_rust_nested_closure_not_credited(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) A macro sink inside a nested closure is not the enclosing fn's I/O; the walk
+    # (H) prunes nested scopes, and the closure is not a registered caller here.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        'fn f() {\n    let g = || { std::fs::write("secret.txt", "x"); };\n}\n',
+    )
+    assert (_WRITES, "resource::FILE::secret.txt") not in _io_edges(memgraph_ingestor)

--- a/codebase_rag/tests/integration/test_rust_io_e2e.py
+++ b/codebase_rag/tests/integration/test_rust_io_e2e.py
@@ -110,6 +110,25 @@ def test_rust_use_imported_short_path(
     assert (_WRITES, "resource::FILE::o.txt") in edges
 
 
+def test_rust_local_module_does_not_match_std_sink(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) A local `mod fs` with its own write() must NOT be mistaken for std::fs::write.
+    # (H) A bare short path (`fs::write`) resolves to std only when `fs` is imported
+    # (H) (`use std::fs;`); with a local module and no import, no FILE edge is emitted.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "mod fs {\n"
+        "    pub fn write(_p: &str, _d: &str) {}\n"
+        "}\n"
+        "fn f() {\n"
+        '    fs::write("out.txt", "x");\n'
+        "}\n",
+    )
+    assert (_WRITES, "resource::FILE::out.txt") not in _io_edges(memgraph_ingestor)
+
+
 def test_rust_nested_closure_not_credited(
     memgraph_ingestor: MemgraphIngestor, tmp_path: Path
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.336"
+version = "0.0.338"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Extends the language-agnostic io direct-sink walk (issue #714) to **Rust**, following the same descriptor-driven design used for Go, JS/TS, and Java.

## What lands
- **`std::env::var` / `env::var`** → `READS_FROM resource::ENV::<name>`
- **`std::fs::read_to_string` / `fs::read`** → `READS_FROM resource::FILE::<path>`
- **`std::fs::write` / `fs::remove_file`** → `WRITES_TO resource::FILE::<path>`
- **`println!` / `print!` / `eprintln!` / `eprint!`** → `WRITES_TO resource::STDOUT::<dynamic>`

Both the full `std::`-prefixed path and the idiomatic `use std::fs;` short form (`fs::write(..)`) are keyed.

## New capability
Rust is the first language whose io sinks include a **macro** (`println!`). Added a `macro_type` descriptor field + an `IO_MACRO_SINKS` table + `_emit_macro`, keeping the call-sink path untouched. `let` bindings are read via the `pattern` field (Rust has no `declarator`), and Rust follows the declare-at-point / scope-starts-after-decl model (`decl_in_own_initializer=False`).

## Ceilings (follow-ups, not this PR)
- File/network **handles** (`File::open(..)` then `.read`/`.write` on the handle) — deferred to the shared stream-handle follow-up.
- **Third-party crate** sinks (tokio, reqwest, etc.) — only `std` is keyed.
- **Closures as callers** — a sink inside a nested closure is pruned (closures are not registered io callers here).

## Tests
`test_rust_io_e2e.py`: direct sinks, `use`-imported short path, nested-closure pruning. Full suite green (5154 passed; the one oracle flake passes in isolation and is unrelated to io).