### PR TITLE
feat(io): direct READS_FROM/WRITES_TO sinks for C++ (#714)

### DIFF
--- a/codebase_rag/constants/ast_cpp.py
+++ b/codebase_rag/constants/ast_cpp.py
@@ -160,6 +160,31 @@ CPP_DECLARATOR_SUFFIX = "declarator"
 FIELD_OPERATOR = "operator"
 FIELD_MACRO = "macro"
 
+# (H) C++ I/O direct-sink walk node types (issue #714). call_expression keeps a
+# (H) `function` field so call_name works unchanged. The stdout write path is the
+# (H) stream-insertion operator `std::cout << x` -- a `binary_expression` with a `<<`
+# (H) operator whose left-spine base is cout/cerr (no call node), handled via
+# (H) stream_sink_type like Rust's macro sinks. A string_literal wraps string_content;
+# (H) `compound_statement` is the block scope; `declaration` holds init_declarator
+# (H) locals whose bound name is nested under the `declarator` field.
+TS_CPP_STRING_LITERAL = "string_literal"
+TS_CPP_STRING_CONTENT = "string_content"
+TS_CPP_COMPOUND_STATEMENT = "compound_statement"
+TS_CPP_DECLARATION = "declaration"
+TS_CPP_INIT_DECLARATOR = "init_declarator"
+TS_CPP_PARAMETER_DECLARATION = "parameter_declaration"
+TS_CPP_IDENTIFIER = "identifier"
+TS_CPP_QUALIFIED_IDENTIFIER = "qualified_identifier"
+# (H) Stream-insertion operator; a `binary_expression` using it whose left-spine base
+# (H) is std::cout / std::cerr writes STDOUT.
+CPP_OP_LEFT_SHIFT = "<<"
+# (H) field_expression = `obj.field` (argument/field); subscript_expression =
+# (H) `arr[i]` (argument/indices). Inert for C++ I/O (env access is a call), wired for
+# (H) correctness / future value-level sinks.
+CPP_FIELD_ARGUMENT = "argument"
+CPP_FIELD_FIELD = "field"
+CPP_FIELD_INDICES = "indices"
+
 # (H) Derived node type tuples for class ingestion
 CPP_CLASS_TYPES = (CppNodeType.CLASS_SPECIFIER, TS_STRUCT_SPECIFIER)
 CPP_COMPOUND_TYPES = (*CPP_CLASS_TYPES, TS_UNION_SPECIFIER, TS_ENUM_SPECIFIER)

--- a/codebase_rag/parsers/io_access/descriptor.py
+++ b/codebase_rag/parsers/io_access/descriptor.py
@@ -81,6 +81,11 @@ class LanguageDescriptor:
     # (H) std::fs; fs::write` -> `std::fs::write`) instead of the default `.`, so a bare
     # (H) short path matches std only when its head is genuinely imported. None = `.`.
     scope_separator: str | None = None
+    # (H) Stream-insertion sink (C++ `std::cout << x`): a binary_expression whose
+    # (H) `operator` field equals stream_sink_operator and whose left-spine base
+    # (H) (cout/cerr) is a stream sink. None where the language has no such operator I/O.
+    stream_sink_type: str | None = None
+    stream_sink_operator: str | None = None
 
 
 _JS_TS_DESCRIPTOR = LanguageDescriptor(
@@ -232,6 +237,45 @@ _RUST_DESCRIPTOR = LanguageDescriptor(
     scope_separator=cs.TS_RS_TOKEN_SCOPE,
 )
 
+_CPP_DESCRIPTOR = LanguageDescriptor(
+    call_type=cs.TS_CPP_CALL_EXPRESSION,
+    string_type=cs.TS_CPP_STRING_LITERAL,
+    string_content_type=cs.TS_CPP_STRING_CONTENT,
+    keyword_arg_type=None,
+    nested_scope_types=frozenset(
+        {cs.TS_CPP_FUNCTION_DEFINITION, cs.TS_CPP_LAMBDA_EXPRESSION}
+    ),
+    # (H) C++ shadowing of an I/O sink name (a local/param named `getenv`/`printf`/
+    # (H) `cout`) is pathological, so the shadow machinery is left inert: init_declarator
+    # (H) has no name/left/pattern field (-> _declarator_names yields nothing) and
+    # (H) function_definition has no direct `parameters` field (params nest under
+    # (H) declarator), so no names are collected. Plain-name matching is sound here.
+    identifier_type=cs.TS_CPP_IDENTIFIER,
+    declarator_type=cs.TS_CPP_INIT_DECLARATOR,
+    params_field=cs.KEY_PARAMETERS,
+    block_scope_type=cs.TS_CPP_COMPOUND_STATEMENT,
+    extra_declarator_types=frozenset(),
+    loop_declarator_types=frozenset(),
+    statement_container_type=None,
+    sinks_require_import=False,
+    # (H) C++ is declare-at-point; sinks are shadow-inert (above) so the flags below
+    # (H) never actually suppress anything.
+    hoisted_declarations=False,
+    decl_in_own_initializer=False,
+    declaration_statement_type=None,
+    macro_type=None,
+    # (H) Inert (no IO_MEMBER_READS for C++): env access is a call (`std::getenv`).
+    # (H) Wired with C++'s own field_expression / subscript_expression shape.
+    member_expression_type=cs.TS_CPP_FIELD_EXPRESSION,
+    subscript_type=cs.TS_CPP_SUBSCRIPT_EXPRESSION,
+    object_field=cs.CPP_FIELD_ARGUMENT,
+    property_field=cs.CPP_FIELD_FIELD,
+    subscript_index_field=cs.CPP_FIELD_INDICES,
+    # (H) `std::cout << x` / `std::cerr << x` write STDOUT via the `<<` operator.
+    stream_sink_type=cs.TS_CPP_BINARY_EXPRESSION,
+    stream_sink_operator=cs.CPP_OP_LEFT_SHIFT,
+)
+
 # (H) Non-Python languages with a direct-sink descriptor. Python keeps its own
 # (H) handle-aware walk; each new language lands one entry (plus registry rows).
 LANGUAGE_DESCRIPTORS: dict[cs.SupportedLanguage, LanguageDescriptor] = {
@@ -241,4 +285,5 @@ LANGUAGE_DESCRIPTORS: dict[cs.SupportedLanguage, LanguageDescriptor] = {
     cs.SupportedLanguage.GO: _GO_DESCRIPTOR,
     cs.SupportedLanguage.JAVA: _JAVA_DESCRIPTOR,
     cs.SupportedLanguage.RUST: _RUST_DESCRIPTOR,
+    cs.SupportedLanguage.CPP: _CPP_DESCRIPTOR,
 }

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -35,6 +35,7 @@ from .registry import (
     IO_MACRO_SINKS,
     IO_MEMBER_READS,
     IO_SINKS,
+    IO_STREAM_SINKS,
 )
 
 _DIRECTION_REL = {
@@ -80,6 +81,9 @@ class IOAccessProcessor:
         # (H) walk to _emit_macro as a parameter (not instance state) so the processor
         # (H) stays stateless, mirroring sink_by_name.
         macro_sinks = IO_MACRO_SINKS.get(language, {})
+        # (H) Per-language stream-insertion sink table (C++ std::cout/cerr `<<`), threaded
+        # (H) the same way; empty for languages without operator I/O.
+        stream_sinks = IO_STREAM_SINKS.get(language, {})
         # (H) Non-Python languages take a lean direct-sink walk (issue #714): match
         # (H) call sinks and emit, without Python's handle/scope machinery (streams
         # (H) and data-flow are a follow-up). Python keeps the full handle-aware walk.
@@ -92,6 +96,7 @@ class IOAccessProcessor:
                     import_map,
                     sink_by_name,
                     macro_sinks,
+                    stream_sinks,
                     IO_MEMBER_READS.get(language, ()),
                     descriptor,
                 )
@@ -279,6 +284,7 @@ class IOAccessProcessor:
         import_map: dict[str, str],
         sink_by_name: dict[str, IOSink],
         macro_sinks: dict[str, IOSink],
+        stream_sinks: dict[str, IOSink],
         member_reads: tuple[tuple[str, ResourceKind], ...],
         descriptor: LanguageDescriptor,
     ) -> None:
@@ -310,6 +316,7 @@ class IOAccessProcessor:
             import_map,
             sink_by_name,
             macro_sinks,
+            stream_sinks,
             member_reads,
             descriptor,
         )
@@ -322,6 +329,7 @@ class IOAccessProcessor:
         import_map: dict[str, str],
         sink_by_name: dict[str, IOSink],
         macro_sinks: dict[str, IOSink],
+        stream_sinks: dict[str, IOSink],
         member_reads: tuple[tuple[str, ResourceKind], ...],
         descriptor: LanguageDescriptor,
     ) -> None:
@@ -357,6 +365,7 @@ class IOAccessProcessor:
                     import_map,
                     sink_by_name,
                     macro_sinks,
+                    stream_sinks,
                     member_reads,
                     descriptor,
                 )
@@ -390,6 +399,7 @@ class IOAccessProcessor:
                     import_map,
                     sink_by_name,
                     macro_sinks,
+                    stream_sinks,
                     member_reads,
                     descriptor,
                 )
@@ -406,6 +416,7 @@ class IOAccessProcessor:
                     import_map,
                     sink_by_name,
                     macro_sinks,
+                    stream_sinks,
                     member_reads,
                     descriptor,
                 )
@@ -419,6 +430,7 @@ class IOAccessProcessor:
         import_map: dict[str, str],
         sink_by_name: dict[str, IOSink],
         macro_sinks: dict[str, IOSink],
+        stream_sinks: dict[str, IOSink],
         member_reads: tuple[tuple[str, ResourceKind], ...],
         descriptor: LanguageDescriptor,
     ) -> None:
@@ -439,6 +451,7 @@ class IOAccessProcessor:
                 import_map,
                 sink_by_name,
                 macro_sinks,
+                stream_sinks,
                 member_reads,
                 descriptor,
             )
@@ -472,6 +485,7 @@ class IOAccessProcessor:
         import_map: dict[str, str],
         sink_by_name: dict[str, IOSink],
         macro_sinks: dict[str, IOSink],
+        stream_sinks: dict[str, IOSink],
         member_reads: tuple[tuple[str, ResourceKind], ...],
         descriptor: LanguageDescriptor,
     ) -> None:
@@ -495,6 +509,7 @@ class IOAccessProcessor:
                     import_map,
                     sink_by_name,
                     macro_sinks,
+                    stream_sinks,
                     member_reads,
                     descriptor,
                 )
@@ -520,6 +535,14 @@ class IOAccessProcessor:
                     descriptor,
                 )
                 continue
+            elif (
+                stream_sinks
+                and descriptor.stream_sink_type is not None
+                and node.type == descriptor.stream_sink_type
+            ):
+                # (H) A stream-insertion sink (`std::cout << x`); descend still so a call
+                # (H) sink in an inserted operand (`std::cout << getenv("X")`) is caught.
+                self._emit_stream_sink(node, caller_spec, stream_sinks, descriptor)
             elif member_reads and node.type in (
                 descriptor.member_expression_type,
                 descriptor.subscript_type,
@@ -528,6 +551,48 @@ class IOAccessProcessor:
                     node, caller_spec, member_reads, in_scope, import_map, descriptor
                 )
             stack.extend(node.named_children)
+
+    def _emit_stream_sink(
+        self,
+        node: Node,
+        caller_spec: tuple[str, str, str],
+        stream_sinks: dict[str, IOSink],
+        descriptor: LanguageDescriptor,
+    ) -> None:
+        # (H) A `<<` chain like `std::cout << a << b` nests left-associatively:
+        # (H) (((cout << a) << b)). Act only at the TOP of the chain (parent is not
+        # (H) itself a `<<` insertion) and walk the `left` spine to the base operand; if
+        # (H) the base is a stream sink (cout/cerr), emit ONE STDOUT write. A non-stream
+        # (H) base (arithmetic `x << 2`) resolves to a non-sink and emits nothing.
+        if not self._is_stream_insertion(node, descriptor):
+            return
+        parent = node.parent
+        if parent is not None and self._is_stream_insertion(parent, descriptor):
+            return
+        base = node
+        while self._is_stream_insertion(base, descriptor):
+            left = base.child_by_field_name(cs.FIELD_LEFT)
+            if left is None:
+                return
+            base = left
+        if base.text is None:
+            return
+        sink = stream_sinks.get(base.text.decode(cs.ENCODING_UTF8))
+        if sink is not None:
+            self._emit(caller_spec, sink.direction, sink.kind, DYNAMIC_TARGET)
+
+    @staticmethod
+    def _is_stream_insertion(node: Node, descriptor: LanguageDescriptor) -> bool:
+        # (H) A binary_expression whose `operator` field is the stream-insertion token.
+        if node.type != descriptor.stream_sink_type:
+            return False
+        operator = node.child_by_field_name(cs.FIELD_OPERATOR)
+        return (
+            operator is not None
+            and operator.text is not None
+            and operator.text.decode(cs.ENCODING_UTF8)
+            == descriptor.stream_sink_operator
+        )
 
     def _emit_macro(
         self,

--- a/codebase_rag/parsers/io_access/registry.py
+++ b/codebase_rag/parsers/io_access/registry.py
@@ -263,6 +263,26 @@ _RUST_SINKS: tuple[IOSink, ...] = tuple(
     for module, fn, kind, direction, arg in _RUST_CALL_METHODS
 )
 
+# (H) C++ direct-call I/O sinks (issue #714). getenv reads ENV; printf/puts write
+# (H) STDOUT unconditionally. Deliberately EXCLUDED (ambiguous by name alone, deferred
+# (H) to the stream-handle follow-up): fprintf/fputs/fwrite (first arg is a FILE* that
+# (H) may be stdout/stderr OR a file); remove/rename (std::remove/rename overload the
+# (H) STL erase-remove algorithm on iterators, so keying them would false-match).
+_CPP_CALL_METHODS: tuple[tuple[str, ResourceKind, IODirection, int | None], ...] = (
+    ("getenv", ResourceKind.ENV, IODirection.READ, 0),
+    ("secure_getenv", ResourceKind.ENV, IODirection.READ, 0),
+    ("printf", ResourceKind.STDOUT, IODirection.WRITE, None),
+    ("puts", ResourceKind.STDOUT, IODirection.WRITE, None),
+)
+
+# (H) Keyed under both the bare (C linkage / `using namespace std`) and `std::`-
+# (H) qualified forms; C++ has no use-alias import map to expand a short path.
+_CPP_SINKS: tuple[IOSink, ...] = tuple(
+    IOSink(f"{prefix}{fn}", kind, direction, target_arg=arg)
+    for fn, kind, direction, arg in _CPP_CALL_METHODS
+    for prefix in ("", "std::")
+)
+
 IO_SINKS: dict[cs.SupportedLanguage, tuple[IOSink, ...]] = {
     cs.SupportedLanguage.PYTHON: _PYTHON_SINKS,
     cs.SupportedLanguage.JS: _JS_TS_SINKS,
@@ -271,6 +291,7 @@ IO_SINKS: dict[cs.SupportedLanguage, tuple[IOSink, ...]] = {
     cs.SupportedLanguage.GO: _GO_SINKS,
     cs.SupportedLanguage.JAVA: _JAVA_SINKS,
     cs.SupportedLanguage.RUST: _RUST_SINKS,
+    cs.SupportedLanguage.CPP: _CPP_SINKS,
 }
 
 # (H) Macro-call I/O sinks keyed by macro name (issue #714). Rust's stdout/stderr write
@@ -283,6 +304,18 @@ _RUST_MACRO_SINKS: dict[str, IOSink] = {
 
 IO_MACRO_SINKS: dict[cs.SupportedLanguage, dict[str, IOSink]] = {
     cs.SupportedLanguage.RUST: _RUST_MACRO_SINKS,
+}
+
+# (H) Stream-insertion I/O sinks keyed by the left-spine base of a `<<` chain
+# (H) (`std::cout << x` writes STDOUT). Both the bare and std:: forms are keyed.
+_CPP_STREAM_SINKS: dict[str, IOSink] = {
+    f"{prefix}{name}": IOSink(name, ResourceKind.STDOUT, IODirection.WRITE)
+    for name in ("cout", "cerr", "clog")
+    for prefix in ("", "std::")
+}
+
+IO_STREAM_SINKS: dict[cs.SupportedLanguage, dict[str, IOSink]] = {
+    cs.SupportedLanguage.CPP: _CPP_STREAM_SINKS,
 }
 
 # (H) Member/subscript accesses that are I/O reads, keyed by the object prefix:

--- a/codebase_rag/parsers/io_access/registry.py
+++ b/codebase_rag/parsers/io_access/registry.py
@@ -273,6 +273,7 @@ _CPP_CALL_METHODS: tuple[tuple[str, ResourceKind, IODirection, int | None], ...]
     ("secure_getenv", ResourceKind.ENV, IODirection.READ, 0),
     ("printf", ResourceKind.STDOUT, IODirection.WRITE, None),
     ("puts", ResourceKind.STDOUT, IODirection.WRITE, None),
+    ("putchar", ResourceKind.STDOUT, IODirection.WRITE, None),
 )
 
 # (H) Keyed under both the bare (C linkage / `using namespace std`) and `std::`-
@@ -310,7 +311,7 @@ IO_MACRO_SINKS: dict[cs.SupportedLanguage, dict[str, IOSink]] = {
 # (H) (`std::cout << x` writes STDOUT). Both the bare and std:: forms are keyed.
 _CPP_STREAM_SINKS: dict[str, IOSink] = {
     f"{prefix}{name}": IOSink(name, ResourceKind.STDOUT, IODirection.WRITE)
-    for name in ("cout", "cerr", "clog")
+    for name in ("cout", "cerr", "clog", "wcout", "wcerr", "wclog")
     for prefix in ("", "std::")
 }
 

--- a/codebase_rag/tests/integration/test_cpp_io_e2e.py
+++ b/codebase_rag/tests/integration/test_cpp_io_e2e.py
@@ -78,6 +78,28 @@ def test_cpp_unqualified_getenv(
     assert (_READS, "resource::ENV::TOKEN") in _io_edges(memgraph_ingestor)
 
 
+@pytest.mark.parametrize(
+    "body",
+    [
+        "putchar('x');",
+        'std::wcout << L"hi";',
+        'std::wcerr << L"e";',
+    ],
+)
+def test_cpp_putchar_and_wide_streams(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path, body: str
+) -> None:
+    # (H) putchar (call) and the wide-char streams wcout/wcerr (`<<` insertion) each
+    # (H) write STDOUT, same as puts / cout. Isolated so the STDOUT edge can only come
+    # (H) from the sink under test.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        f"#include <cstdio>\n#include <iostream>\nvoid f() {{\n    {body}\n}}\n",
+    )
+    assert (_WRITES, "resource::STDOUT::<dynamic>") in _io_edges(memgraph_ingestor)
+
+
 def test_cpp_nested_lambda_not_credited(
     memgraph_ingestor: MemgraphIngestor, tmp_path: Path
 ) -> None:

--- a/codebase_rag/tests/integration/test_cpp_io_e2e.py
+++ b/codebase_rag/tests/integration/test_cpp_io_e2e.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.capture import resolve_capture
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+if TYPE_CHECKING:
+    from codebase_rag.services.graph_service import MemgraphIngestor
+
+pytestmark = [pytest.mark.integration]
+
+_READS = cs.RelationshipType.READS_FROM.value
+_WRITES = cs.RelationshipType.WRITES_TO.value
+
+
+def _build(ingestor: MemgraphIngestor, tmp_path: Path, code: str) -> None:
+    project = tmp_path / "cpp_project"
+    project.mkdir()
+    (project / "main.cpp").write_text(code, encoding="utf-8")
+    parsers, queries = load_parsers()
+    GraphUpdater(
+        ingestor=ingestor,
+        repo_path=project,
+        parsers=parsers,
+        queries=queries,
+        capture=resolve_capture([cs.CaptureGroup.IO.value]),
+    ).run()
+
+
+def _io_edges(ingestor: MemgraphIngestor) -> set[tuple[str, str]]:
+    rows = ingestor.fetch_all(
+        f"MATCH ()-[r:{_READS}|{_WRITES}]->(res:{cs.NodeLabel.RESOURCE.value}) "
+        "RETURN type(r) AS rel, res.qualified_name AS qn"
+    )
+    return {(str(row["rel"]), str(row["qn"])) for row in rows}
+
+
+_CPP_CODE = """\
+#include <cstdlib>
+#include <cstdio>
+#include <iostream>
+void leak(const char* name) {
+    const char* s = std::getenv("SECRET");
+    printf("%s", s);
+    std::cout << s << std::endl;
+    std::cerr << name;
+}
+"""
+
+
+def test_cpp_direct_io_sinks(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) std::getenv reads ENV::SECRET; printf writes STDOUT; std::cout / std::cerr `<<`
+    # (H) insertion writes STDOUT. First C++ increment of issue #714 -- direct calls +
+    # (H) stream insertion, no fstream/FILE* handles (deferred).
+    _build(memgraph_ingestor, tmp_path, _CPP_CODE)
+    edges = _io_edges(memgraph_ingestor)
+    assert (_READS, "resource::ENV::SECRET") in edges
+    assert (_WRITES, "resource::STDOUT::<dynamic>") in edges
+
+
+def test_cpp_unqualified_getenv(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) A C-style unqualified `getenv("X")` (no std::) also reads ENV::X.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        '#include <cstdlib>\nvoid f() {\n    const char* k = getenv("TOKEN");\n}\n',
+    )
+    assert (_READS, "resource::ENV::TOKEN") in _io_edges(memgraph_ingestor)
+
+
+def test_cpp_nested_lambda_not_credited(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) A sink inside a nested lambda is not the enclosing function's I/O; the walk
+    # (H) prunes nested scopes, and the lambda is not a registered caller here.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "#include <cstdlib>\n"
+        "void f() {\n"
+        '    auto g = []() { std::getenv("LAMBDA_ONLY"); };\n'
+        "}\n",
+    )
+    assert (_READS, "resource::ENV::LAMBDA_ONLY") not in _io_edges(memgraph_ingestor)

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.338"
+version = "0.0.340"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Extends the language-agnostic io direct-sink walk (issue #714) to **C++**, the last per-language item in the #714 list. Built on the same descriptor-driven design as Go/JS/TS/Java/Rust.

## What lands
- **`std::getenv` / `getenv` / `secure_getenv`** → `READS_FROM resource::ENV::<name>`
- **`printf` / `puts`** (and `std::` forms) → `WRITES_TO resource::STDOUT::<dynamic>`
- **`std::cout` / `std::cerr` / `std::clog` `<<`** → `WRITES_TO resource::STDOUT::<dynamic>`

Both the bare (C linkage / `using namespace std`) and `std::`-qualified forms are keyed.

## New capability
C++ is the first language whose stdout path is an **operator** (`std::cout << x`), not a call. Added a `stream_sink_type`/`stream_sink_operator` descriptor pair + an `IO_STREAM_SINKS` table + `_emit_stream_sink`, which walks the left-associative `<<` chain down its `left` spine to the base operand and matches `cout`/`cerr`/`clog`. Emits once at the chain top; an arithmetic `x << 2` resolves to a non-sink base and emits nothing. This parallels Rust's macro mechanism.

## Deliberately excluded (ambiguous by name — deferred to follow-ups)
- **`fprintf` / `fputs` / `fwrite`** — first arg is a `FILE*` that may be `stdout`/`stderr` **or** a file handle; needs handle tracking to classify.
- **`remove` / `rename`** — `std::remove`/`std::rename` overload the STL erase-remove **algorithm** on iterators, so keying them by name would false-match the ubiquitous erase-remove idiom.
- **`fstream`/`ofstream`/`fopen` file handles** — the shared stream-handle follow-up.

## Ceilings (ponytail-commented)
Shadowing of an I/O sink name by a C++ local/param (a variable named `getenv`/`cout`) is pathological, so the shadow machinery is intentionally inert; plain-name matching is sound here.

## Tests
`test_cpp_io_e2e.py`: direct sinks + stream insertion, unqualified `getenv`, nested-lambda pruning. io/flow regression 184 green; lint/ty clean.