### PR TITLE
feat(flow): path-sensitive if-branch taint for Go and Java (#714)

### DIFF
--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -261,25 +261,67 @@ class FlowProcessor:
             for node in statements:
                 tainted = self._walk_js_stmt(node, tainted, jc)
         else:
-            # (H) Go keeps the flat source-order walk: its shadow set is grown in
-            # (H) source order (_register_shadows), which a branch-copying walk would
-            # (H) break. Path-sensitivity for Go is a separate follow-up.
-            self._flat_flow_walk(statements, tainted, jc)
+            # (H) Go/Java path-sensitive MAY walk (issue #714 follow-up): an
+            # (H) if_statement branches-and-merges like the JS walk (its condition/
+            # (H) consequence/alternative fields are shared across the grammars), and
+            # (H) the live shadow set is snapshotted per branch and restored at the
+            # (H) merge, so a block-scoped Go/Java declaration inside a branch does not
+            # (H) leak its shadow past the join. Loops and try are walked straight-line
+            # (H) (one source-order pass), matching the previous flat behaviour --
+            # (H) loop-carried and per-branch try taint stay a follow-up.
+            for node in statements:
+                tainted = self._walk_flat_stmt(node, tainted, jc)
         if self._acc_returns_taint:
             self._summaries[ctx.caller_qn] = self._acc_return_taint
 
-    def _flat_flow_walk(
-        self, statements: list[Node], tainted: _TaintMap, jc: _JsCtx
-    ) -> None:
-        # (H) Flat source-order DFS (Go): a single taint map, nested functions pruned
-        # (H) as their own callers. Reuses the shared summary/deferred/finalize (#712).
-        stack = list(reversed(statements))
-        while stack:
-            node = stack.pop()
-            if node.type in jc.descriptor.nested_scope_types:
-                continue
-            self._apply_js_leaf(node, tainted, jc)
-            stack.extend(reversed(node.named_children))
+    def _walk_flat_stmt(self, node: Node, state: _TaintMap, jc: _JsCtx) -> _TaintMap:
+        # (H) Structured walk for the non-hoisted flat languages (Go, Java): only
+        # (H) if_statement branches-and-merges; every other node applies its leaf effect
+        # (H) and threads state through its children in source order (so a nested call in
+        # (H) an argument, or a loop/try body, is still seen -- one pass, as before).
+        node_type = node.type
+        if node_type in jc.descriptor.nested_scope_types:
+            return state
+        if node_type == cs.TS_JS_IF_STATEMENT:
+            return self._walk_flat_if(node, state, jc)
+        self._apply_js_leaf(node, state, jc)
+        for child in node.named_children:
+            state = self._walk_flat_stmt(child, state, jc)
+        return state
+
+    def _walk_flat_if(self, node: Node, state: _TaintMap, jc: _JsCtx) -> _TaintMap:
+        # (H) The header (any initializer + condition) runs on all paths; each of the
+        # (H) then / else(-if) / implicit skip paths is walked against a copy and
+        # (H) unioned (MAY join). A branch grows the live shadow set with its own
+        # (H) block-scoped declarations; snapshot it before each branch and restore it
+        # (H) after, so those declarations never shadow a source/sink past the join.
+        consequence = node.child_by_field_name(cs.TS_FIELD_CONSEQUENCE)
+        alternative = node.child_by_field_name(cs.FIELD_ALTERNATIVE)
+        skip = {n.id for n in (consequence, alternative) if n is not None}
+        for child in node.named_children:
+            if child.id not in skip:
+                state = self._walk_flat_stmt(child, state, jc)
+        pre_shadows = set(jc.local_names)
+        branch_exits: list[_TaintMap] = []
+        if consequence is not None:
+            branch_exits.append(self._walk_flat_stmt(consequence, dict(state), jc))
+            self._restore_shadows(pre_shadows, jc)
+        if alternative is not None:
+            # (H) else_clause holds either a block or a nested if (else-if chain); the
+            # (H) recursion handles both and merges within.
+            branch_exits.append(self._walk_flat_stmt(alternative, dict(state), jc))
+            self._restore_shadows(pre_shadows, jc)
+        else:
+            # (H) No else: the skip path preserves the incoming state.
+            branch_exits.append(dict(state))
+        return self._merge(branch_exits)
+
+    @staticmethod
+    def _restore_shadows(pre_shadows: set[str], jc: _JsCtx) -> None:
+        # (H) Reset the mutable live shadow set to a pre-branch snapshot in place (jc is
+        # (H) a NamedTuple, so the set object is shared -- mutate, do not rebind).
+        jc.local_names.clear()
+        jc.local_names.update(pre_shadows)
 
     def _walk_js_stmt(self, node: Node, state: _TaintMap, jc: _JsCtx) -> _TaintMap:
         # (H) Path-sensitive walk for JS/TS: control-flow nodes branch-and-merge, every

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -292,9 +292,12 @@ class FlowProcessor:
     def _walk_flat_if(self, node: Node, state: _TaintMap, jc: _JsCtx) -> _TaintMap:
         # (H) The header (any initializer + condition) runs on all paths; each of the
         # (H) then / else(-if) / implicit skip paths is walked against a copy and
-        # (H) unioned (MAY join). A branch grows the live shadow set with its own
-        # (H) block-scoped declarations; snapshot it before each branch and restore it
-        # (H) after, so those declarations never shadow a source/sink past the join.
+        # (H) unioned (MAY join). Two shadow scopes are restored: a branch grows the
+        # (H) live shadow set with its own block-scoped declarations (restored between
+        # (H) branches), and a Go `if` initializer (`if x := f(); cond {}`) is scoped
+        # (H) to the whole if statement (restored on exit) -- so neither shadows a
+        # (H) source/sink past its scope.
+        pre_if_shadows = set(jc.local_names)
         consequence = node.child_by_field_name(cs.TS_FIELD_CONSEQUENCE)
         alternative = node.child_by_field_name(cs.FIELD_ALTERNATIVE)
         skip = {n.id for n in (consequence, alternative) if n is not None}
@@ -314,6 +317,7 @@ class FlowProcessor:
         else:
             # (H) No else: the skip path preserves the incoming state.
             branch_exits.append(dict(state))
+        self._restore_shadows(pre_if_shadows, jc)
         return self._merge(branch_exits)
 
     @staticmethod

--- a/codebase_rag/tests/integration/test_flat_path_sensitive_flow_e2e.py
+++ b/codebase_rag/tests/integration/test_flat_path_sensitive_flow_e2e.py
@@ -137,6 +137,32 @@ def test_go_branch_local_shadow_does_not_leak(
     )
 
 
+def test_go_if_initializer_shadow_does_not_leak(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) A Go `if` initializer (`if os := load(); ...`) is scoped to the whole if
+    # (H) statement and must not leak past it, so os.Getenv AFTER the if is the real
+    # (H) env source. The shadow set must be restored to its pre-if state on exit.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "main.go",
+        "package main\n\n"
+        'import (\n\t"fmt"\n\t"os"\n)\n\n'
+        "func boot() {\n"
+        "\tif os := load(); os != nil {\n"
+        "\t\t_ = os\n"
+        "\t}\n"
+        '\tfmt.Println(os.Getenv("SECRET"))\n'
+        "}\n",
+    )
+    assert _resource_flow(
+        _flows(memgraph_ingestor),
+        "resource::ENV::SECRET",
+        "resource::STDOUT::<dynamic>",
+    )
+
+
 # (H) Java
 
 

--- a/codebase_rag/tests/integration/test_flat_path_sensitive_flow_e2e.py
+++ b/codebase_rag/tests/integration/test_flat_path_sensitive_flow_e2e.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.capture import resolve_capture
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.parsers.flow_access import FlowKind
+
+if TYPE_CHECKING:
+    from codebase_rag.services.graph_service import MemgraphIngestor
+
+pytestmark = [pytest.mark.integration]
+
+_FLOWS = cs.RelationshipType.FLOWS_TO.value
+
+
+def _build(
+    ingestor: MemgraphIngestor, tmp_path: Path, filename: str, code: str
+) -> None:
+    project = tmp_path / "flat_ps"
+    project.mkdir()
+    (project / filename).write_text(code, encoding="utf-8")
+    parsers, queries = load_parsers()
+    GraphUpdater(
+        ingestor=ingestor,
+        repo_path=project,
+        parsers=parsers,
+        queries=queries,
+        capture=resolve_capture([cs.CaptureGroup.IO.value]),
+    ).run()
+
+
+def _flows(ingestor: MemgraphIngestor) -> list[dict[str, str | None]]:
+    rows = ingestor.fetch_all(
+        f"MATCH (a)-[r:{_FLOWS}]->(b) "
+        "RETURN a.qualified_name AS frm, b.qualified_name AS to, "
+        "r.kind AS kind, r.via AS via"
+    )
+    return [{k: None if v is None else str(v) for k, v in row.items()} for row in rows]
+
+
+def _resource_flow(flows: list[dict[str, str | None]], frm: str, to: str) -> bool:
+    return any(
+        (f["frm"] or "").endswith(frm)
+        and (f["to"] or "").endswith(to)
+        and f["kind"] == FlowKind.RESOURCE.value
+        for f in flows
+    )
+
+
+def _any_resource(flows: list[dict[str, str | None]]) -> bool:
+    return any(f["kind"] == FlowKind.RESOURCE.value for f in flows)
+
+
+# (H) Go
+
+
+def test_go_kill_on_one_branch_taint_survives(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) secret is killed only inside the if; on the fall-through path it is still the
+    # (H) env source, so a MAY analysis keeps ENV -> STDOUT. The flat walk over-kills.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "main.go",
+        "package main\n\n"
+        'import (\n\t"fmt"\n\t"os"\n)\n\n'
+        "func boot(cond bool) {\n"
+        '\tsecret := os.Getenv("SECRET")\n'
+        "\tif cond {\n"
+        '\t\tsecret = "redacted"\n'
+        "\t}\n"
+        "\tfmt.Println(secret)\n"
+        "}\n",
+    )
+    assert _resource_flow(
+        _flows(memgraph_ingestor),
+        "resource::ENV::SECRET",
+        "resource::STDOUT::<dynamic>",
+    )
+
+
+def test_go_kill_on_all_branches_no_flow(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) secret is reassigned to a clean value on BOTH the then and else paths, so no
+    # (H) tainted path reaches the sink -- MAY still yields no flow.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "main.go",
+        "package main\n\n"
+        'import (\n\t"fmt"\n\t"os"\n)\n\n'
+        "func boot(cond bool) {\n"
+        '\tsecret := os.Getenv("SECRET")\n'
+        "\tif cond {\n"
+        '\t\tsecret = "a"\n'
+        "\t} else {\n"
+        '\t\tsecret = "b"\n'
+        "\t}\n"
+        "\tfmt.Println(secret)\n"
+        "}\n",
+    )
+    assert not _any_resource(_flows(memgraph_ingestor))
+
+
+def test_go_branch_local_shadow_does_not_leak(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) `os := load()` is scoped to the if block; after the block the imported package
+    # (H) `os` is back in scope, so os.Getenv is the real env source. The flat walk grows
+    # (H) its shadow set function-wide and wrongly suppresses the later read.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "main.go",
+        "package main\n\n"
+        'import (\n\t"fmt"\n\t"os"\n)\n\n'
+        "func boot(cond bool) {\n"
+        "\tif cond {\n"
+        "\t\tos := load()\n"
+        "\t\t_ = os\n"
+        "\t}\n"
+        '\tfmt.Println(os.Getenv("SECRET"))\n'
+        "}\n",
+    )
+    assert _resource_flow(
+        _flows(memgraph_ingestor),
+        "resource::ENV::SECRET",
+        "resource::STDOUT::<dynamic>",
+    )
+
+
+# (H) Java
+
+
+def test_java_kill_on_one_branch_taint_survives(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) Java parity: the reassignment inside the if is one path only; the else path
+    # (H) still carries the env source, so MAY keeps ENV -> STDOUT.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "App.java",
+        "class App {\n"
+        "    void leak(boolean cond) {\n"
+        '        String s = System.getenv("SECRET");\n'
+        "        if (cond) {\n"
+        '            s = "redacted";\n'
+        "        }\n"
+        "        System.out.println(s);\n"
+        "    }\n"
+        "}\n",
+    )
+    assert _resource_flow(
+        _flows(memgraph_ingestor),
+        "resource::ENV::SECRET",
+        "resource::STDOUT::<dynamic>",
+    )
+
+
+def test_java_kill_on_all_branches_no_flow(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) Clean reassignment on both paths -> no tainted path reaches the sink.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "App.java",
+        "class App {\n"
+        "    void leak(boolean cond) {\n"
+        '        String s = System.getenv("SECRET");\n'
+        "        if (cond) {\n"
+        '            s = "a";\n'
+        "        } else {\n"
+        '            s = "b";\n'
+        "        }\n"
+        "        System.out.println(s);\n"
+        "    }\n"
+        "}\n",
+    )
+    assert not _any_resource(_flows(memgraph_ingestor))

--- a/codebase_rag/tests/unit/test_flat_flow_path_sensitive_unit.py
+++ b/codebase_rag/tests/unit/test_flat_flow_path_sensitive_unit.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+from tree_sitter import Node
+
+from codebase_rag import constants as cs
+from codebase_rag.capture import resolve_capture
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.parsers.flow_access import FlowKind
+from codebase_rag.parsers.flow_access.processor import FlowProcessor
+
+# (H) Fast unit coverage for the Go/Java path-sensitive flat walk (issue #714): drives
+# (H) FlowProcessor directly on a parsed snippet with recording fakes, no Memgraph. The
+# (H) integration suite (test_flat_path_sensitive_flow_e2e.py) asserts the same behavior
+# (H) end to end; these run under `pytest -m "not integration"` so the coverage counts.
+
+_FUNC_TYPES = {"function_declaration", "method_declaration"}
+_LANG_BY_FILE = {
+    "main.go": cs.SupportedLanguage.GO,
+    "App.java": cs.SupportedLanguage.JAVA,
+}
+
+
+_Spec = tuple[object, object, object]
+
+
+class _RecordingIngestor:
+    def __init__(self) -> None:
+        self.rels: list[tuple[_Spec, object, _Spec, dict[str, object]]] = []
+
+    def ensure_node_batch(self, label: object, properties: object) -> None:
+        pass
+
+    def ensure_relationship_batch(
+        self,
+        start: _Spec,
+        rel_type: object,
+        end: _Spec,
+        properties: dict[str, object] | None = None,
+    ) -> None:
+        self.rels.append((start, rel_type, end, properties or {}))
+
+    def flush_all(self) -> None:
+        pass
+
+
+class _NoResolver:
+    def resolve_function_call(self, *args: object, **kwargs: object) -> None:
+        return None
+
+
+class _EmptyImports:
+    def __init__(self) -> None:
+        self.import_mapping: dict[str, dict[str, str]] = {}
+
+
+def _first_function(node: Node) -> Node | None:
+    if node.type in _FUNC_TYPES:
+        return node
+    for child in node.named_children:
+        found = _first_function(child)
+        if found is not None:
+            return found
+    return None
+
+
+def _resource_flows(code: str, filename: str) -> list[tuple[str, str]]:
+    language = _LANG_BY_FILE[filename]
+    parsers, _ = load_parsers()
+    tree = parsers[language.value].parse(code.encode("utf-8"))
+    func = _first_function(tree.root_node)
+    assert func is not None
+    module_qn = "proj.mod"
+    caller_qn = f"{module_qn}.f"
+    ingestor = _RecordingIngestor()
+    processor = FlowProcessor(
+        ingestor,  # type: ignore[arg-type]
+        _EmptyImports(),  # type: ignore[arg-type]
+        _NoResolver(),  # type: ignore[arg-type]
+        resolve_capture([cs.CaptureGroup.IO.value]),
+    )
+    processor.process_flow_for_caller(
+        func,
+        (cs.NodeLabel.FUNCTION, cs.KEY_QUALIFIED_NAME, caller_qn),
+        caller_qn,
+        module_qn,
+        language,
+        None,
+    )
+    processor.finalize()
+    out: list[tuple[str, str]] = []
+    for start, rel_type, end, props in ingestor.rels:
+        if (
+            rel_type == cs.RelationshipType.FLOWS_TO
+            and props.get("kind") == FlowKind.RESOURCE.value
+        ):
+            out.append((str(start[2]), str(end[2])))
+    return out
+
+
+def test_go_kill_on_one_branch_taint_survives() -> None:
+    flows = _resource_flows(
+        "package main\n\n"
+        'import (\n\t"fmt"\n\t"os"\n)\n\n'
+        "func f(cond bool) {\n"
+        '\tsecret := os.Getenv("SECRET")\n'
+        "\tif cond {\n"
+        '\t\tsecret = "redacted"\n'
+        "\t}\n"
+        "\tfmt.Println(secret)\n"
+        "}\n",
+        "main.go",
+    )
+    assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") in flows
+
+
+def test_go_kill_on_all_branches_no_flow() -> None:
+    flows = _resource_flows(
+        "package main\n\n"
+        'import (\n\t"fmt"\n\t"os"\n)\n\n'
+        "func f(cond bool) {\n"
+        '\tsecret := os.Getenv("SECRET")\n'
+        "\tif cond {\n"
+        '\t\tsecret = "a"\n'
+        "\t} else {\n"
+        '\t\tsecret = "b"\n'
+        "\t}\n"
+        "\tfmt.Println(secret)\n"
+        "}\n",
+        "main.go",
+    )
+    assert flows == []
+
+
+def test_go_branch_local_shadow_does_not_leak() -> None:
+    flows = _resource_flows(
+        "package main\n\n"
+        'import (\n\t"fmt"\n\t"os"\n)\n\n'
+        "func f(cond bool) {\n"
+        "\tif cond {\n"
+        "\t\tos := load()\n"
+        "\t\t_ = os\n"
+        "\t}\n"
+        '\tfmt.Println(os.Getenv("SECRET"))\n'
+        "}\n",
+        "main.go",
+    )
+    assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") in flows
+
+
+def test_go_if_initializer_shadow_does_not_leak() -> None:
+    flows = _resource_flows(
+        "package main\n\n"
+        'import (\n\t"fmt"\n\t"os"\n)\n\n'
+        "func f() {\n"
+        "\tif os := load(); os != nil {\n"
+        "\t\t_ = os\n"
+        "\t}\n"
+        '\tfmt.Println(os.Getenv("SECRET"))\n'
+        "}\n",
+        "main.go",
+    )
+    assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") in flows
+
+
+def test_java_kill_on_one_branch_taint_survives() -> None:
+    flows = _resource_flows(
+        "class App {\n"
+        "    void f(boolean cond) {\n"
+        '        String s = System.getenv("SECRET");\n'
+        "        if (cond) {\n"
+        '            s = "redacted";\n'
+        "        }\n"
+        "        System.out.println(s);\n"
+        "    }\n"
+        "}\n",
+        "App.java",
+    )
+    assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") in flows
+
+
+def test_java_kill_on_all_branches_no_flow() -> None:
+    flows = _resource_flows(
+        "class App {\n"
+        "    void f(boolean cond) {\n"
+        '        String s = System.getenv("SECRET");\n'
+        "        if (cond) {\n"
+        '            s = "a";\n'
+        "        } else {\n"
+        '            s = "b";\n'
+        "        }\n"
+        "        System.out.println(s);\n"
+        "    }\n"
+        "}\n",
+        "App.java",
+    )
+    assert flows == []

--- a/codebase_rag/tests/unit/test_flat_flow_path_sensitive_unit.py
+++ b/codebase_rag/tests/unit/test_flat_flow_path_sensitive_unit.py
@@ -1,110 +1,85 @@
 from __future__ import annotations
 
-from typing import cast
-
-from tree_sitter import Node
+from pathlib import Path
 
 from codebase_rag import constants as cs
 from codebase_rag.capture import resolve_capture
+from codebase_rag.graph_updater import GraphUpdater
 from codebase_rag.parser_loader import load_parsers
-from codebase_rag.parsers.call_resolver import CallResolver
 from codebase_rag.parsers.flow_access import FlowKind
-from codebase_rag.parsers.flow_access.processor import FlowProcessor
-from codebase_rag.parsers.import_processor import ImportProcessor
-from codebase_rag.services import IngestorProtocol
+from codebase_rag.types_defs import PropertyDict, PropertyValue, ResultRow
 
-# (H) Fast unit coverage for the Go/Java path-sensitive flat walk (issue #714): drives
-# (H) FlowProcessor directly on a parsed snippet with recording fakes, no Memgraph. The
-# (H) integration suite (test_flat_path_sensitive_flow_e2e.py) asserts the same behavior
-# (H) end to end; these run under `pytest -m "not integration"` so the coverage counts.
+# (H) Fast unit coverage for the Go/Java path-sensitive flat walk (issue #714): runs the
+# (H) real GraphUpdater against a one-file project with a recording in-memory ingestor
+# (H) (no Memgraph), so it is collected under `pytest -m "not integration"` and its
+# (H) coverage counts toward SonarCloud. The integration suite
+# (H) (test_flat_path_sensitive_flow_e2e.py) asserts the same behavior end to end.
 
-_FUNC_TYPES = {"function_declaration", "method_declaration"}
-_LANG_BY_FILE = {
-    "main.go": cs.SupportedLanguage.GO,
-    "App.java": cs.SupportedLanguage.JAVA,
-}
-
-
-_Spec = tuple[object, object, object]
+_LANG_BY_FILE = {"main.go": "flow_go", "App.java": "flow_java"}
 
 
 class _RecordingIngestor:
+    # (H) Structural IngestorProtocol stand-in that records FLOWS_TO relationships; the
+    # (H) query-side methods are no-ops (a single fresh project needs no rehydration).
     def __init__(self) -> None:
-        self.rels: list[tuple[_Spec, object, _Spec, dict[str, object]]] = []
+        self.rels: list[
+            tuple[
+                tuple[str, str, PropertyValue],
+                str,
+                tuple[str, str, PropertyValue],
+                PropertyDict,
+            ]
+        ] = []
 
-    def ensure_node_batch(self, label: object, properties: object) -> None:
+    def ensure_node_batch(self, label: str, properties: PropertyDict) -> None:
         pass
 
     def ensure_relationship_batch(
         self,
-        start: _Spec,
-        rel_type: object,
-        end: _Spec,
-        properties: dict[str, object] | None = None,
+        from_spec: tuple[str, str, PropertyValue],
+        rel_type: str,
+        to_spec: tuple[str, str, PropertyValue],
+        properties: PropertyDict | None = None,
     ) -> None:
-        self.rels.append((start, rel_type, end, properties or {}))
+        self.rels.append((from_spec, rel_type, to_spec, properties or {}))
 
     def flush_all(self) -> None:
         pass
 
+    def execute_write(self, query: str, params: PropertyDict | None = None) -> None:
+        pass
 
-class _NoResolver:
-    def resolve_function_call(self, *args: object, **kwargs: object) -> None:
-        return None
-
-
-class _EmptyImports:
-    def __init__(self) -> None:
-        self.import_mapping: dict[str, dict[str, str]] = {}
+    def fetch_all(
+        self, query: str, params: PropertyDict | None = None
+    ) -> list[ResultRow]:
+        return []
 
 
-def _first_function(node: Node) -> Node | None:
-    if node.type in _FUNC_TYPES:
-        return node
-    for child in node.named_children:
-        found = _first_function(child)
-        if found is not None:
-            return found
-    return None
-
-
-def _resource_flows(code: str, filename: str) -> list[tuple[str, str]]:
-    language = _LANG_BY_FILE[filename]
-    parsers, _ = load_parsers()
-    tree = parsers[language.value].parse(code.encode("utf-8"))
-    func = _first_function(tree.root_node)
-    assert func is not None
-    module_qn = "proj.mod"
-    caller_qn = f"{module_qn}.f"
+def _resource_flows(code: str, filename: str, tmp_path: Path) -> list[tuple[str, str]]:
+    project = tmp_path / _LANG_BY_FILE[filename]
+    project.mkdir()
+    (project / filename).write_text(code, encoding="utf-8")
+    parsers, queries = load_parsers()
     ingestor = _RecordingIngestor()
-    # (H) The fakes are structural stand-ins for concrete-typed constructor params;
-    # (H) cast keeps the harness type-clean without blanket suppressions.
-    processor = FlowProcessor(
-        cast(IngestorProtocol, ingestor),
-        cast(ImportProcessor, _EmptyImports()),
-        cast(CallResolver, _NoResolver()),
-        resolve_capture([cs.CaptureGroup.IO.value]),
-    )
-    processor.process_flow_for_caller(
-        func,
-        (cs.NodeLabel.FUNCTION, cs.KEY_QUALIFIED_NAME, caller_qn),
-        caller_qn,
-        module_qn,
-        language,
-        None,
-    )
-    processor.finalize()
+    GraphUpdater(
+        ingestor=ingestor,
+        repo_path=project,
+        parsers=parsers,
+        queries=queries,
+        capture=resolve_capture([cs.CaptureGroup.IO.value]),
+        skip_embeddings=True,
+    ).run()
     out: list[tuple[str, str]] = []
-    for start, rel_type, end, props in ingestor.rels:
+    for from_spec, rel_type, to_spec, props in ingestor.rels:
         if (
             rel_type == cs.RelationshipType.FLOWS_TO
             and props.get("kind") == FlowKind.RESOURCE.value
         ):
-            out.append((str(start[2]), str(end[2])))
+            out.append((str(from_spec[2]), str(to_spec[2])))
     return out
 
 
-def test_go_kill_on_one_branch_taint_survives() -> None:
+def test_go_kill_on_one_branch_taint_survives(tmp_path: Path) -> None:
     flows = _resource_flows(
         "package main\n\n"
         'import (\n\t"fmt"\n\t"os"\n)\n\n'
@@ -116,11 +91,12 @@ def test_go_kill_on_one_branch_taint_survives() -> None:
         "\tfmt.Println(secret)\n"
         "}\n",
         "main.go",
+        tmp_path,
     )
     assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") in flows
 
 
-def test_go_kill_on_all_branches_no_flow() -> None:
+def test_go_kill_on_all_branches_no_flow(tmp_path: Path) -> None:
     flows = _resource_flows(
         "package main\n\n"
         'import (\n\t"fmt"\n\t"os"\n)\n\n'
@@ -134,11 +110,12 @@ def test_go_kill_on_all_branches_no_flow() -> None:
         "\tfmt.Println(secret)\n"
         "}\n",
         "main.go",
+        tmp_path,
     )
     assert flows == []
 
 
-def test_go_branch_local_shadow_does_not_leak() -> None:
+def test_go_branch_local_shadow_does_not_leak(tmp_path: Path) -> None:
     flows = _resource_flows(
         "package main\n\n"
         'import (\n\t"fmt"\n\t"os"\n)\n\n'
@@ -150,11 +127,12 @@ def test_go_branch_local_shadow_does_not_leak() -> None:
         '\tfmt.Println(os.Getenv("SECRET"))\n'
         "}\n",
         "main.go",
+        tmp_path,
     )
     assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") in flows
 
 
-def test_go_if_initializer_shadow_does_not_leak() -> None:
+def test_go_if_initializer_shadow_does_not_leak(tmp_path: Path) -> None:
     flows = _resource_flows(
         "package main\n\n"
         'import (\n\t"fmt"\n\t"os"\n)\n\n'
@@ -165,11 +143,12 @@ def test_go_if_initializer_shadow_does_not_leak() -> None:
         '\tfmt.Println(os.Getenv("SECRET"))\n'
         "}\n",
         "main.go",
+        tmp_path,
     )
     assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") in flows
 
 
-def test_java_kill_on_one_branch_taint_survives() -> None:
+def test_java_kill_on_one_branch_taint_survives(tmp_path: Path) -> None:
     flows = _resource_flows(
         "class App {\n"
         "    void f(boolean cond) {\n"
@@ -181,11 +160,12 @@ def test_java_kill_on_one_branch_taint_survives() -> None:
         "    }\n"
         "}\n",
         "App.java",
+        tmp_path,
     )
     assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") in flows
 
 
-def test_java_kill_on_all_branches_no_flow() -> None:
+def test_java_kill_on_all_branches_no_flow(tmp_path: Path) -> None:
     flows = _resource_flows(
         "class App {\n"
         "    void f(boolean cond) {\n"
@@ -199,5 +179,6 @@ def test_java_kill_on_all_branches_no_flow() -> None:
         "    }\n"
         "}\n",
         "App.java",
+        tmp_path,
     )
     assert flows == []

--- a/codebase_rag/tests/unit/test_flat_flow_path_sensitive_unit.py
+++ b/codebase_rag/tests/unit/test_flat_flow_path_sensitive_unit.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
+from typing import cast
+
 from tree_sitter import Node
 
 from codebase_rag import constants as cs
 from codebase_rag.capture import resolve_capture
 from codebase_rag.parser_loader import load_parsers
+from codebase_rag.parsers.call_resolver import CallResolver
 from codebase_rag.parsers.flow_access import FlowKind
 from codebase_rag.parsers.flow_access.processor import FlowProcessor
+from codebase_rag.parsers.import_processor import ImportProcessor
+from codebase_rag.services import IngestorProtocol
 
 # (H) Fast unit coverage for the Go/Java path-sensitive flat walk (issue #714): drives
 # (H) FlowProcessor directly on a parsed snippet with recording fakes, no Memgraph. The
@@ -72,10 +77,12 @@ def _resource_flows(code: str, filename: str) -> list[tuple[str, str]]:
     module_qn = "proj.mod"
     caller_qn = f"{module_qn}.f"
     ingestor = _RecordingIngestor()
+    # (H) The fakes are structural stand-ins for concrete-typed constructor params;
+    # (H) cast keeps the harness type-clean without blanket suppressions.
     processor = FlowProcessor(
-        ingestor,  # type: ignore[arg-type]
-        _EmptyImports(),  # type: ignore[arg-type]
-        _NoResolver(),  # type: ignore[arg-type]
+        cast(IngestorProtocol, ingestor),
+        cast(ImportProcessor, _EmptyImports()),
+        cast(CallResolver, _NoResolver()),
         resolve_capture([cs.CaptureGroup.IO.value]),
     )
     processor.process_flow_for_caller(

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.341"
+version = "0.0.342"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

Gives the flat-walk FLOWS_TO languages (**Go, Java**) path-sensitive `if_statement` taint, matching what #713 (Python) and #749 (JS/TS) already do. Previously the flat walk used a single source-order taint map, so a kill inside one branch wrongly suppressed taint that survives on another path.

## Behavior change

- **MAY join on `if`/`else`**: taint that survives on *any* branch survives the join; a kill counts only when it happens on *every* path. So `secret := os.Getenv("X"); if cond { secret = "" }; print(secret)` now keeps the ENV -> STDOUT flow (the fall-through path is still tainted).
- **Block-scoped shadow no longer leaks**: a Go/Java local declared inside a branch (e.g. `if cond { os := load() }`) is block-scoped; its shadow of a package/builtin name no longer suppresses a source read *after* the block. The live shadow set is snapshotted per branch and restored at the merge.

## How

`if_statement` shares its node type and `condition`/`consequence`/`alternative` fields across the JS/Go/Java grammars, so the Go/Java walk branch-and-merges through the same shared `_merge` MAY-union used by the other languages. Loops and `try` are walked straight-line (one source-order pass), exactly as the previous flat walk did, so there is no behavior change there.

## Scope / ceilings (documented in code)

- Loop-carried taint and per-branch `try` taint for Go/Java remain a follow-up (Go `for` and Java `enhanced_for`/`try` have divergent grammars: no shared `condition`/`increment` fields, unnamed catch/finally children). This PR deliberately covers only `if`, which is the shared, common case.

## Tests (`test_flat_path_sensitive_flow_e2e.py`, RED -> GREEN)

- `test_go_kill_on_one_branch_taint_survives` / `test_java_kill_on_one_branch_taint_survives` - MAY join keeps the surviving path
- `test_go_kill_on_all_branches_no_flow` / `test_java_kill_on_all_branches_no_flow` - kill on every path yields no flow
- `test_go_branch_local_shadow_does_not_leak` - block-scoped shadow dropped at the join

Full Go/Java flow + io suites (38) and the broader flow/io e2e set (112) pass unchanged; ruff + ty clean.