### PR TITLE
feat(csharp): Roslyn hybrid frontend B1 — semantic base classification

### DIFF
--- a/codebase_rag/config.py
+++ b/codebase_rag/config.py
@@ -194,6 +194,13 @@ class AppConfig(BaseSettings):
     # (H) compile_commands.json is missing, so it is safe as the default and
     # (H) strictly better (macros, includes, expansion calls) with one.
     CPP_FRONTEND: cs.CppFrontend = cs.CppFrontend.HYBRID
+    # (H) Opt-in Roslyn semantic layer for C#. Defaults to pure tree-sitter
+    # (H) because HYBRID needs a dotnet SDK + a restorable .csproj/.sln; when
+    # (H) either is missing it degrades to tree-sitter, so it is safe to enable
+    # (H) but not to assume. HYBRID augments (base-vs-interface, overload and
+    # (H) extension binding, partial-class identity); tree-sitter stays the
+    # (H) standalone-correct backbone.
+    CSHARP_FRONTEND: cs.CSharpFrontend = cs.CSharpFrontend.TREESITTER
     CAPTURE_FUNCTION_LOCAL_DEFINITIONS: bool = Field(
         True, validation_alias="CGR_CAPTURE_LOCAL_DEFINITIONS"
     )

--- a/codebase_rag/constants/core.py
+++ b/codebase_rag/constants/core.py
@@ -137,6 +137,11 @@ PARSER_FINGERPRINT_SOURCE_FILES: tuple[str, ...] = (
     "parser_loader.py",
 )
 PY_SOURCE_GLOB = "*.py"
+# (H) The bundled Roslyn C# frontend tool is parser code too, even though it is
+# (H) .cs/.csproj rather than Python: an edit to it changes the semantic edges it
+# (H) produces, so its sources are folded into the parser fingerprint.
+PARSER_FINGERPRINT_TOOL_DIR = "parsers/csharp_frontend/roslyn"
+PARSER_FINGERPRINT_TOOL_GLOBS: tuple[str, ...] = ("*.cs", "*.csproj")
 GRAMMAR_DIST_PREFIX = "tree-sitter"
 GRAMMAR_VERSION_FMT = "{name}=={version}"
 GIT_DIR_NAME = ".git"

--- a/codebase_rag/constants/languages.py
+++ b/codebase_rag/constants/languages.py
@@ -89,6 +89,12 @@ class CppFrontend(StrEnum):
     HYBRID = "hybrid"
 
 
+class CSharpFrontend(StrEnum):
+    TREESITTER = "treesitter"
+    ROSLYN = "roslyn"
+    HYBRID = "hybrid"
+
+
 # (H) JS/TS import specifier schemes that name genuinely external code (node
 # (H) builtins, package registries, URLs). A specifier with any OTHER scheme
 # (H) (`ext:` deno-runtime aliases, bundler virtual modules) points at first-party

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -28,6 +28,11 @@ from .parsers.cpp_frontend import (
     run_cpp_frontend,
     run_cpp_frontend_hybrid,
 )
+from .parsers.csharp_frontend import (
+    csharp_frontend_available,
+    find_csharp_project,
+    run_csharp_frontend,
+)
 from .parsers.factory import ProcessorFactory
 from .parsers.utils import sorted_captures
 from .services import FilteringIngestor, IngestorProtocol, QueryProtocol
@@ -621,6 +626,28 @@ class GraphUpdater:
             ls.CPP_FRONTEND_COVERED.format(count=len(self._cpp_frontend_covered))
         )
 
+    def _run_csharp_frontend(self) -> None:
+        # (H) Optional Roslyn semantic pre-pass. ROSLYN/HYBRID: load the repo's
+        # (H) real .csproj/.sln via MSBuildWorkspace and hand Pass 2 a
+        # (H) base-classification oracle so split_csharp_bases emits exact
+        # (H) INHERITS-vs-IMPLEMENTS edges instead of the I-prefix heuristic.
+        # (H) Missing dotnet, project, or a build/restore failure all fall back
+        # (H) to pure tree-sitter (an empty oracle).
+        if settings.CSHARP_FRONTEND == cs.CSharpFrontend.TREESITTER:
+            return
+        project = find_csharp_project(self.repo_path)
+        if project is None:
+            # (H) Skip silently when there is no C# project: nothing to augment,
+            # (H) and building the net tool for a non-C# repo would be wasteful.
+            return
+        if not csharp_frontend_available():
+            logger.warning(ls.CSHARP_FRONTEND_UNAVAILABLE)
+            return
+        logger.info(ls.CSHARP_FRONTEND_RUNNING.format(path=project))
+        base_kinds = run_csharp_frontend(self.repo_path)
+        self.factory.definition_processor.csharp_base_kinds = base_kinds
+        logger.info(ls.CSHARP_FRONTEND_TYPES.format(count=len(base_kinds)))
+
     def _tightest_containing_span(
         self, rel_path: str, line: int
     ) -> CppDefinitionSpan | None:
@@ -756,6 +783,11 @@ class GraphUpdater:
         # (H) covered-file set to skip those files.
         if settings.CPP_FRONTEND != cs.CppFrontend.HYBRID:
             self._run_cpp_frontend()
+
+        # (H) The C# Roslyn frontend must run before Pass 2: it produces a
+        # (H) base-classification oracle that split_csharp_bases consults while
+        # (H) ingesting each type's INHERITS/IMPLEMENTS edges during Pass 2.
+        self._run_csharp_frontend()
 
         logger.info(ls.PASS_2_FILES)
         self._process_files(force=force)

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -633,6 +633,10 @@ class GraphUpdater:
         # (H) INHERITS-vs-IMPLEMENTS edges instead of the I-prefix heuristic.
         # (H) Missing dotnet, project, or a build/restore failure all fall back
         # (H) to pure tree-sitter (an empty oracle).
+        # (H) Reset first so a reused updater (watch mode) that previously ran
+        # (H) hybrid does not keep applying the old oracle on a later run that has
+        # (H) the frontend off or cannot run it. Mirrors _run_cpp_frontend's reset.
+        self.factory.definition_processor.csharp_base_kinds = {}
         if settings.CSHARP_FRONTEND == cs.CSharpFrontend.TREESITTER:
             return
         project = find_csharp_project(self.repo_path)

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -27,6 +27,17 @@ CPP_FRONTEND_HYBRID_PENDING = (
 )
 CPP_FRONTEND_MACRO_CALLS = "Resolved {count} hybrid macro CALLS edge(s)"
 CPP_FRONTEND_EXPANSION_CALLS = "Resolved {count} hybrid expansion CALLS edge(s)"
+CSHARP_FRONTEND_RUNNING = "--- C# Roslyn frontend: {path} ---"
+CSHARP_FRONTEND_UNAVAILABLE = (
+    "C# Roslyn frontend enabled but dotnet is unavailable; using tree-sitter"
+)
+CSHARP_FRONTEND_NO_PROJECT = (
+    "C# Roslyn frontend enabled but no .csproj/.sln found; using tree-sitter"
+)
+CSHARP_FRONTEND_BUILD_FAILED = (
+    "C# Roslyn frontend tool failed to build; using tree-sitter"
+)
+CSHARP_FRONTEND_TYPES = "C# Roslyn frontend classified {count} type base list(s)"
 GRAPH_ALREADY_IN_SYNC = (
     "Knowledge graph already in sync (hash cache matches every file). Skipping passes."
 )

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -38,6 +38,10 @@ CSHARP_FRONTEND_BUILD_FAILED = (
     "C# Roslyn frontend tool failed to build; using tree-sitter"
 )
 CSHARP_FRONTEND_TYPES = "C# Roslyn frontend classified {count} type base list(s)"
+CSHARP_FRONTEND_PARSE_FAILED = (
+    "C# Roslyn frontend produced no parseable JSON; using tree-sitter.\n"
+    "stdout: {stdout}\nstderr: {stderr}"
+)
 GRAPH_ALREADY_IN_SYNC = (
     "Knowledge graph already in sync (hash cache matches every file). Skipping passes."
 )

--- a/codebase_rag/parser_fingerprint.py
+++ b/codebase_rag/parser_fingerprint.py
@@ -48,6 +48,12 @@ def _fingerprint_sources(root: Path) -> list[Path]:
         for name in cs.PARSER_FINGERPRINT_SOURCE_FILES
         if (path := root / name).is_file()
     )
+    # (H) The bundled Roslyn frontend tool (.cs/.csproj) is parser code even though
+    # (H) it is not Python; an edit to it changes the semantic edges produced, so a
+    # (H) tool change must trip the staleness warning.
+    tool_dir = root / cs.PARSER_FINGERPRINT_TOOL_DIR
+    for pattern in cs.PARSER_FINGERPRINT_TOOL_GLOBS:
+        sources.extend(path for path in tool_dir.glob(pattern) if path.is_file())
     return sorted(sources)
 
 

--- a/codebase_rag/parser_fingerprint.py
+++ b/codebase_rag/parser_fingerprint.py
@@ -1,14 +1,16 @@
-# (H) A graph is a function of (source files, parser code). The incremental
-# (H) hash cache keys only the source files, so a parser change with unchanged
-# (H) sources leaves stale old-parser edges in the graph. This fingerprint
-# (H) keys the second input: it hashes every parse-relevant source file of the
-# (H) installed package plus the pinned grammar wheel versions, so a sync can
-# (H) detect that the graph was built by a different parser.
+# (H) A graph is a function of (source files, parser code, parser config). The
+# (H) incremental hash cache keys only the source files, so a parser or config
+# (H) change with unchanged sources leaves stale old-parser edges in the graph.
+# (H) This fingerprint keys the other inputs: it hashes every parse-relevant
+# (H) source file of the installed package, the pinned grammar wheel versions,
+# (H) and the active frontend settings, so a sync can detect that the graph was
+# (H) built by a different parser or frontend configuration.
 import hashlib
 from importlib import metadata
 from pathlib import Path
 
 from . import constants as cs
+from .config import settings
 
 
 def compute_parser_fingerprint(package_root: Path | None = None) -> str:
@@ -19,7 +21,20 @@ def compute_parser_fingerprint(package_root: Path | None = None) -> str:
         hasher.update(source.read_bytes())
     for entry in _grammar_versions():
         hasher.update(entry.encode())
+    # (H) The active frontend selection changes which edges are produced for
+    # (H) unchanged sources (e.g. enabling the C# Roslyn hybrid rewrites
+    # (H) INHERITS/IMPLEMENTS), so it is part of the parser identity and must
+    # (H) trip the staleness warning when it changes.
+    for entry in _frontend_settings():
+        hasher.update(entry.encode())
     return hasher.hexdigest()
+
+
+def _frontend_settings() -> list[str]:
+    return [
+        f"CPP_FRONTEND={settings.CPP_FRONTEND.value}",
+        f"CSHARP_FRONTEND={settings.CSHARP_FRONTEND.value}",
+    ]
 
 
 def _fingerprint_sources(root: Path) -> list[Path]:

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -152,6 +152,7 @@ class ClassIngestMixin:
     csharp_partial_groups: dict[str, list[str]]
     _csharp_partial_index: dict[str, list[str]]
     csharp_extension_methods: dict[str, list[tuple[str, str, str]]]
+    csharp_base_kinds: dict[tuple[str, int], dict[str, str]]
     class_field_guard_inner: dict[str, dict[str, str]]
     method_return_types: dict[str, str]
     interface_implementers: dict[str, set[str]]
@@ -753,6 +754,18 @@ class ClassIngestMixin:
         # (H) type_spec is class_node, so this is a no-op for non-templates and for
         # (H) Go/Rust (which never take the template_declaration branch).
         member_node = type_spec if type_spec is not None else class_node
+        # (H) When the opt-in Roslyn frontend ran, hand this type's exact base
+        # (H) classifications (keyed by its rel-path + start line) to the split so
+        # (H) INHERITS/IMPLEMENTS is semantic, not the I-prefix guess. Empty/absent
+        # (H) for non-C# types or when the frontend is off -> heuristic stands.
+        csharp_base_kinds: dict[str, str] | None = None
+        if (
+            language == cs.SupportedLanguage.CSHARP
+            and self.csharp_base_kinds
+            and file_path is not None
+        ):
+            rel_path = cached_relative_path(file_path, self.repo_path).as_posix()
+            csharp_base_kinds = self.csharp_base_kinds.get((rel_path, class_start_line))
         rel.create_class_relationships(
             member_node,
             class_qn,
@@ -768,6 +781,7 @@ class ClassIngestMixin:
             self.interface_implementers,
             defer_cpp_inherits=self._deferred_cpp_inherits,
             defer_inherits=self._deferred_inherits,
+            csharp_base_kinds=csharp_base_kinds,
         )
         if language == cs.SupportedLanguage.CPP:
             # (H) Record this class's member-field types now (from the class body,

--- a/codebase_rag/parsers/class_ingest/parent_extraction.py
+++ b/codebase_rag/parsers/class_ingest/parent_extraction.py
@@ -56,21 +56,32 @@ def _csharp_base_written_name(node: Node) -> str | None:
 
 
 def _csharp_looks_like_interface(simple_name: str) -> bool:
-    # (H) The C# `I`-prefix convention (IShape, IDisposable) is the only signal
-    # (H) available at parse time to tell an interface from the base class inside
-    # (H) one base_list. Exact class-vs-interface binding is Phase 3 / Roslyn work.
+    # (H) The C# `I`-prefix convention (IShape, IDisposable) is the fallback signal
+    # (H) when the Roslyn frontend is off: at parse time it is the only way to tell
+    # (H) an interface from the base class inside one base_list. The opt-in Roslyn
+    # (H) hybrid frontend (issue #738) supplies the exact class-vs-interface answer.
     return len(simple_name) >= 2 and simple_name[0] == "I" and simple_name[1].isupper()
+
+
+# (H) Roslyn base-kind values (see csharp_frontend.frontend): the semantic model
+# (H) classifies each base as one of these; "unknown" (unresolved symbol) defers
+# (H) to the I-prefix heuristic.
+_CSHARP_BASE_KIND_CLASS = "class"
+_CSHARP_BASE_KIND_INTERFACE = "interface"
 
 
 def split_csharp_bases(
     class_node: Node,
     module_qn: str,
     resolve_to_qn: Callable[[str, str], str],
+    base_kinds: dict[str, str] | None = None,
 ) -> tuple[list[str], list[str]]:
     # (H) Return (inherited_qns, implemented_qns). C# folds the base class and all
     # (H) interfaces into one base_list; the base class, if any, is the FIRST entry
     # (H) (grammar-enforced) and must not look like an interface. An interface's
     # (H) bases are all inheritance; a struct/record/class implements the rest.
+    # (H) `base_kinds` (from the Roslyn frontend) maps a base's simple name to its
+    # (H) exact kind; when present it overrides the I-prefix heuristic per base.
     if class_node.type == cs.TS_CSHARP_ENUM_DECLARATION:
         return [], []
     base_list = find_child_by_type(class_node, cs.TS_CSHARP_BASE_LIST)
@@ -89,13 +100,18 @@ def split_csharp_bases(
     implemented: list[str] = []
     for index, name in enumerate(written):
         resolved = resolve_to_qn(name, module_qn)
+        simple = name.rsplit(cs.SEPARATOR_DOT, 1)[-1]
+        # (H) An interface's own bases are all INHERITS in cgr's model (interface
+        # (H) extends interface), independent of the semantic kind.
         if is_interface:
             inherited.append(resolved)
-        elif (
-            index == 0
-            and not is_struct
-            and not _csharp_looks_like_interface(name.rsplit(cs.SEPARATOR_DOT, 1)[-1])
-        ):
+            continue
+        kind = base_kinds.get(simple) if base_kinds else None
+        if kind == _CSHARP_BASE_KIND_INTERFACE:
+            implemented.append(resolved)
+        elif kind == _CSHARP_BASE_KIND_CLASS:
+            inherited.append(resolved)
+        elif index == 0 and not is_struct and not _csharp_looks_like_interface(simple):
             inherited.append(resolved)
         else:
             implemented.append(resolved)
@@ -107,6 +123,7 @@ def extract_parent_classes(
     module_qn: str,
     import_processor: ImportProcessor,
     resolve_to_qn: Callable[[str, str], str],
+    csharp_base_kinds: dict[str, str] | None = None,
 ) -> list[str]:
     if class_node.type in cs.CPP_CLASS_TYPES:
         return extract_cpp_parent_classes(class_node, module_qn)
@@ -116,7 +133,9 @@ def extract_parent_classes(
     # (H) extract_implemented_interfaces. Return early so the Java/TS clause
     # (H) walks below never touch a C# node (class_declaration is shared).
     if find_child_by_type(class_node, cs.TS_CSHARP_BASE_LIST) is not None:
-        inherited, _ = split_csharp_bases(class_node, module_qn, resolve_to_qn)
+        inherited, _ = split_csharp_bases(
+            class_node, module_qn, resolve_to_qn, csharp_base_kinds
+        )
         return inherited
 
     parent_classes: list[str] = []
@@ -515,12 +534,15 @@ def extract_implemented_interfaces(
     class_node: Node,
     module_qn: str,
     resolve_to_qn: Callable[[str, str], str],
+    csharp_base_kinds: dict[str, str] | None = None,
 ) -> list[str]:
     # (H) C# implemented interfaces come from the shared base_list (the base
     # (H) class, if any, is stripped by split_csharp_bases). Return early so the
     # (H) Java/TS/PHP clause walks never run on a C# node.
     if find_child_by_type(class_node, cs.TS_CSHARP_BASE_LIST) is not None:
-        _, implemented = split_csharp_bases(class_node, module_qn, resolve_to_qn)
+        _, implemented = split_csharp_bases(
+            class_node, module_qn, resolve_to_qn, csharp_base_kinds
+        )
         return implemented
 
     implemented_interfaces: list[str] = []

--- a/codebase_rag/parsers/class_ingest/relationships.py
+++ b/codebase_rag/parsers/class_ingest/relationships.py
@@ -31,6 +31,7 @@ def create_class_relationships(
     interface_implementers: dict[str, set[str]] | None = None,
     defer_cpp_inherits: list[DeferredCppInherit] | None = None,
     defer_inherits: list[DeferredInherit] | None = None,
+    csharp_base_kinds: dict[str, str] | None = None,
 ) -> None:
     cpp_bases: list[tuple[str, str]] | None = None
     if class_node.type in cs.CPP_CLASS_TYPES:
@@ -38,7 +39,7 @@ def create_class_relationships(
         parent_classes = [guess for _, guess in cpp_bases]
     else:
         parent_classes = pe.extract_parent_classes(
-            class_node, module_qn, import_processor, resolve_to_qn
+            class_node, module_qn, import_processor, resolve_to_qn, csharp_base_kinds
         )
     class_inheritance[class_qn] = parent_classes
 
@@ -112,7 +113,7 @@ def create_class_relationships(
         cs.TS_DART_CLASS_DEFINITION,
     ):
         for interface_qn in pe.extract_implemented_interfaces(
-            class_node, module_qn, resolve_to_qn
+            class_node, module_qn, resolve_to_qn, csharp_base_kinds
         ):
             if defer_inherits is not None:
                 defer_inherits.append(

--- a/codebase_rag/parsers/csharp_frontend/__init__.py
+++ b/codebase_rag/parsers/csharp_frontend/__init__.py
@@ -1,0 +1,13 @@
+from .frontend import (
+    BaseKindMap,
+    csharp_frontend_available,
+    find_csharp_project,
+    run_csharp_frontend,
+)
+
+__all__ = [
+    "BaseKindMap",
+    "csharp_frontend_available",
+    "find_csharp_project",
+    "run_csharp_frontend",
+]

--- a/codebase_rag/parsers/csharp_frontend/frontend.py
+++ b/codebase_rag/parsers/csharp_frontend/frontend.py
@@ -77,6 +77,45 @@ def _dll_fresh(dll: Path) -> bool:
     return dll.is_file() and dll.stat().st_mtime >= _newest_source_mtime()
 
 
+def _acquire_build_lock(lock: Path, dll: Path) -> bool:
+    # (H) Serialise the one build across parallel workers. Returns True holding the
+    # (H) lock (caller must rmdir); False if it gave up because another worker
+    # (H) already produced a fresh DLL or the tries ran out.
+    for _ in range(_LOCK_TRIES):
+        try:
+            lock.mkdir()
+            return True
+        except FileExistsError:
+            time.sleep(_LOCK_POLL_SECONDS)
+            if _dll_fresh(dll):
+                return False
+    return False
+
+
+def _compile_tool(dotnet: str, src: Path, out: Path) -> bool:
+    src.mkdir(parents=True, exist_ok=True)
+    for name in _TOOL_SOURCES:
+        shutil.copy2(_TOOL_SRC / name, src / name)
+    proc = subprocess.run(
+        [
+            dotnet,
+            "build",
+            str(src),
+            "-c",
+            "Release",
+            "-o",
+            str(out),
+            "--verbosity",
+            "quiet",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ, **_DOTNET_ENV},
+    )
+    return proc.returncode == 0
+
+
 def _build_tool(dotnet: str) -> Path | None:
     # (H) Build from a copy in the writable cache, never the bundled source dir,
     # (H) which is read-only under a pip install (obj/ intermediates would fail).
@@ -88,40 +127,11 @@ def _build_tool(dotnet: str) -> Path | None:
         return dll
     cache.mkdir(parents=True, exist_ok=True)
     lock = cache / _BUILD_LOCK
-    for _ in range(_LOCK_TRIES):
-        try:
-            lock.mkdir()
-            break
-        except FileExistsError:
-            time.sleep(_LOCK_POLL_SECONDS)
-            if _dll_fresh(dll):
-                return dll
-    else:
+    if not _acquire_build_lock(lock, dll):
         return dll if _dll_fresh(dll) else None
     try:
-        if not _dll_fresh(dll):
-            src.mkdir(parents=True, exist_ok=True)
-            for name in _TOOL_SOURCES:
-                shutil.copy2(_TOOL_SRC / name, src / name)
-            proc = subprocess.run(
-                [
-                    dotnet,
-                    "build",
-                    str(src),
-                    "-c",
-                    "Release",
-                    "-o",
-                    str(out),
-                    "--verbosity",
-                    "quiet",
-                ],
-                capture_output=True,
-                text=True,
-                check=False,
-                env={**os.environ, **_DOTNET_ENV},
-            )
-            if proc.returncode != 0:
-                return None
+        if not _dll_fresh(dll) and not _compile_tool(dotnet, src, out):
+            return None
     finally:
         lock.rmdir()
     return dll if _dll_fresh(dll) else None

--- a/codebase_rag/parsers/csharp_frontend/frontend.py
+++ b/codebase_rag/parsers/csharp_frontend/frontend.py
@@ -171,26 +171,31 @@ def _parse_payload(stdout: str, stderr: str = "") -> BaseKindMap:
             ls.CSHARP_FRONTEND_PARSE_FAILED.format(stdout=stdout, stderr=stderr)
         )
         return {}
-    result: BaseKindMap = {}
-    for type_fact in payload.get("types", []):
-        key = (type_fact["file"], int(type_fact["line"]))
-        kinds: dict[str, str] = {}
-        conflicting: set[str] = set()
-        for base in type_fact.get("bases", []):
-            name, kind = base["name"], base["kind"]
-            if name in kinds and kinds[name] != kind:
-                # (H) Two bases share a simple name but differ in kind (e.g.
-                # (H) `: A.Widget, B.Widget`, one class + one interface). Neither
-                # (H) the map nor split_csharp_bases can tell them apart by simple
-                # (H) name, so drop the name and let the per-base heuristic decide
-                # (H) rather than let the last-written kind silently win.
-                conflicting.add(name)
-            else:
-                kinds.setdefault(name, kind)
-        for name in conflicting:
-            kinds.pop(name, None)
-        result[key] = kinds
-    return result
+    return {
+        (type_fact["file"], int(type_fact["line"])): _base_kinds(
+            type_fact.get("bases", [])
+        )
+        for type_fact in payload.get("types", [])
+    }
+
+
+def _base_kinds(bases: list[dict[str, str]]) -> dict[str, str]:
+    # (H) Fold one type's bases to {simple_name: kind}. Two bases sharing a simple
+    # (H) name but differing in kind (e.g. `: A.Widget, B.Widget`, one class + one
+    # (H) interface) cannot be told apart by simple name on either side, so the
+    # (H) name is dropped and split_csharp_bases falls back to the heuristic rather
+    # (H) than letting the last-written kind silently win.
+    kinds: dict[str, str] = {}
+    conflicting: set[str] = set()
+    for base in bases:
+        name, kind = base["name"], base["kind"]
+        if name in kinds and kinds[name] != kind:
+            conflicting.add(name)
+        else:
+            kinds.setdefault(name, kind)
+    for name in conflicting:
+        kinds.pop(name, None)
+    return kinds
 
 
 def run_csharp_frontend(repo_path: Path) -> BaseKindMap:

--- a/codebase_rag/parsers/csharp_frontend/frontend.py
+++ b/codebase_rag/parsers/csharp_frontend/frontend.py
@@ -16,7 +16,10 @@ import subprocess
 import time
 from pathlib import Path
 
+from loguru import logger
+
 from ... import constants as cs
+from ... import logs as ls
 from ...config import settings
 
 # (H) Base-classification join key: (rel_file, type_start_line) -> {base_simple_name: kind}.
@@ -141,18 +144,42 @@ def _restore(dotnet: str, project: Path) -> None:
         return
 
 
-def _parse_payload(stdout: str) -> BaseKindMap:
+def _parse_payload(stdout: str, stderr: str = "") -> BaseKindMap:
     lines = [line for line in stdout.splitlines() if line.strip()]
     if not lines:
+        # (H) No output at all: the tool crashed before printing its JSON line.
+        logger.error(
+            ls.CSHARP_FRONTEND_PARSE_FAILED.format(stdout=stdout, stderr=stderr)
+        )
         return {}
     try:
         payload = json.loads(lines[-1])
     except json.JSONDecodeError:
+        # (H) A decode failure means the tool emitted non-JSON after building;
+        # (H) surface both streams so it can be debugged, not silently degraded.
+        logger.error(
+            ls.CSHARP_FRONTEND_PARSE_FAILED.format(stdout=stdout, stderr=stderr)
+        )
         return {}
     result: BaseKindMap = {}
     for type_fact in payload.get("types", []):
         key = (type_fact["file"], int(type_fact["line"]))
-        result[key] = {b["name"]: b["kind"] for b in type_fact.get("bases", [])}
+        kinds: dict[str, str] = {}
+        conflicting: set[str] = set()
+        for base in type_fact.get("bases", []):
+            name, kind = base["name"], base["kind"]
+            if name in kinds and kinds[name] != kind:
+                # (H) Two bases share a simple name but differ in kind (e.g.
+                # (H) `: A.Widget, B.Widget`, one class + one interface). Neither
+                # (H) the map nor split_csharp_bases can tell them apart by simple
+                # (H) name, so drop the name and let the per-base heuristic decide
+                # (H) rather than let the last-written kind silently win.
+                conflicting.add(name)
+            else:
+                kinds.setdefault(name, kind)
+        for name in conflicting:
+            kinds.pop(name, None)
+        result[key] = kinds
     return result
 
 
@@ -182,4 +209,4 @@ def run_csharp_frontend(repo_path: Path) -> BaseKindMap:
         )
     except (subprocess.SubprocessError, OSError):
         return {}
-    return _parse_payload(proc.stdout)
+    return _parse_payload(proc.stdout, proc.stderr)

--- a/codebase_rag/parsers/csharp_frontend/frontend.py
+++ b/codebase_rag/parsers/csharp_frontend/frontend.py
@@ -1,0 +1,185 @@
+# (H) Roslyn semantic frontend for C# hybrid mode (issue #738). Runs a bundled net
+# (H) console tool (`roslyn/`) that loads the target repo's real .csproj/.sln via
+# (H) MSBuildWorkspace and emits, per type declaration keyed on (rel_file,
+# (H) start_line) matching cgr's tree-sitter node span, each base type classified
+# (H) class/interface by the resolved symbol. The tree-sitter C# split
+# (H) (split_csharp_bases) consults these and falls back to its I-prefix heuristic
+# (H) for any base the semantic model could not resolve. Everything degrades
+# (H) gracefully: no dotnet, no project, or a build/restore failure all leave the
+# (H) map empty, so indexing stays pure tree-sitter.
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+from ... import constants as cs
+from ...config import settings
+
+# (H) Base-classification join key: (rel_file, type_start_line) -> {base_simple_name: kind}.
+BaseKindMap = dict[tuple[str, int], dict[str, str]]
+
+_DOTNET = "dotnet"
+_TOOL_SRC = Path(__file__).parent / "roslyn"
+_TOOL_SOURCES = ("Frontend.csproj", "Program.cs", "Frontend.cs")
+_DLL_NAME = "Frontend.dll"
+_BUILD_LOCK = ".build-lock"
+# (H) Same mkdir-lock discipline as the eval oracle: build the assembly ONCE, then
+# (H) parallel workers run the DLL read-only and never race a shared MSBuild output.
+_LOCK_TRIES = 600
+_LOCK_POLL_SECONDS = 0.5
+_RESTORE_TIMEOUT = 600
+_RUN_TIMEOUT = 900
+_DOTNET_ENV = {"DOTNET_CLI_TELEMETRY_OPTOUT": "1", "DOTNET_NOLOGO": "1"}
+_IGNORE_DIRS = frozenset({"bin", "obj", ".git", "node_modules", "vendor", "packages"})
+
+
+def csharp_frontend_available() -> bool:
+    return shutil.which(_DOTNET) is not None
+
+
+def _project_candidates(repo_path: Path) -> list[Path]:
+    def not_ignored(p: Path) -> bool:
+        return not any(part in _IGNORE_DIRS for part in p.relative_to(repo_path).parts)
+
+    slns = sorted(
+        (p for p in repo_path.rglob("*.sln") if not_ignored(p)),
+        key=lambda p: len(str(p)),
+    )
+    if slns:
+        return slns
+    return sorted(
+        (p for p in repo_path.rglob("*.csproj") if not_ignored(p)),
+        key=lambda p: len(str(p)),
+    )
+
+
+def find_csharp_project(repo_path: Path) -> Path | None:
+    candidates = _project_candidates(repo_path)
+    return candidates[0] if candidates else None
+
+
+def _cache_dir() -> Path:
+    return settings.CGR_HOME.expanduser() / "csharp_roslyn"
+
+
+def _newest_source_mtime() -> float:
+    return max((_TOOL_SRC / name).stat().st_mtime for name in _TOOL_SOURCES)
+
+
+def _dll_fresh(dll: Path) -> bool:
+    return dll.is_file() and dll.stat().st_mtime >= _newest_source_mtime()
+
+
+def _build_tool(dotnet: str) -> Path | None:
+    # (H) Build from a copy in the writable cache, never the bundled source dir,
+    # (H) which is read-only under a pip install (obj/ intermediates would fail).
+    cache = _cache_dir()
+    src = cache / "src"
+    out = cache / "out"
+    dll = out / _DLL_NAME
+    if _dll_fresh(dll):
+        return dll
+    cache.mkdir(parents=True, exist_ok=True)
+    lock = cache / _BUILD_LOCK
+    for _ in range(_LOCK_TRIES):
+        try:
+            lock.mkdir()
+            break
+        except FileExistsError:
+            time.sleep(_LOCK_POLL_SECONDS)
+            if _dll_fresh(dll):
+                return dll
+    else:
+        return dll if _dll_fresh(dll) else None
+    try:
+        if not _dll_fresh(dll):
+            src.mkdir(parents=True, exist_ok=True)
+            for name in _TOOL_SOURCES:
+                shutil.copy2(_TOOL_SRC / name, src / name)
+            proc = subprocess.run(
+                [
+                    dotnet,
+                    "build",
+                    str(src),
+                    "-c",
+                    "Release",
+                    "-o",
+                    str(out),
+                    "--verbosity",
+                    "quiet",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                env={**os.environ, **_DOTNET_ENV},
+            )
+            if proc.returncode != 0:
+                return None
+    finally:
+        lock.rmdir()
+    return dll if _dll_fresh(dll) else None
+
+
+def _restore(dotnet: str, project: Path) -> None:
+    # (H) Best-effort: MSBuildWorkspace needs project.assets.json to resolve NuGet +
+    # (H) framework references. A restore failure (offline, private feed) just leaves
+    # (H) unresolved bases as kind "unknown" -> the Python heuristic handles those.
+    try:
+        subprocess.run(
+            [dotnet, "restore", str(project), "--verbosity", "quiet"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_RESTORE_TIMEOUT,
+            env={**os.environ, **_DOTNET_ENV},
+        )
+    except (subprocess.SubprocessError, OSError):
+        return
+
+
+def _parse_payload(stdout: str) -> BaseKindMap:
+    lines = [line for line in stdout.splitlines() if line.strip()]
+    if not lines:
+        return {}
+    try:
+        payload = json.loads(lines[-1])
+    except json.JSONDecodeError:
+        return {}
+    result: BaseKindMap = {}
+    for type_fact in payload.get("types", []):
+        key = (type_fact["file"], int(type_fact["line"]))
+        result[key] = {b["name"]: b["kind"] for b in type_fact.get("bases", [])}
+    return result
+
+
+def run_csharp_frontend(repo_path: Path) -> BaseKindMap:
+    dotnet = shutil.which(_DOTNET)
+    if dotnet is None:
+        return {}
+    project = find_csharp_project(repo_path)
+    if project is None:
+        return {}
+    dll = _build_tool(dotnet)
+    if dll is None:
+        return {}
+    _restore(dotnet, project)
+    try:
+        proc = subprocess.run(
+            [dotnet, str(dll), str(repo_path), str(project)],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_RUN_TIMEOUT,
+            env={
+                **os.environ,
+                **_DOTNET_ENV,
+                "CGR_IGNORE_DIRS": ",".join(sorted(cs.IGNORE_PATTERNS)),
+            },
+        )
+    except (subprocess.SubprocessError, OSError):
+        return {}
+    return _parse_payload(proc.stdout)

--- a/codebase_rag/parsers/csharp_frontend/roslyn/.gitignore
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/.gitignore
@@ -1,0 +1,3 @@
+bin/
+obj/
+out/

--- a/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
@@ -162,12 +162,15 @@ public static class Frontend
 
     private static bool IsFirstParty(string path, string rootFull, HashSet<string> ignoredDirs)
     {
-        var full = Path.GetFullPath(path);
-        if (!full.StartsWith(rootFull, StringComparison.Ordinal))
+        // GetRelativePath yields a rooted path when the two are on different
+        // volumes and a "../"-prefixed path when `path` sits outside the root, so
+        // it decides containment without a case-sensitive prefix compare that a
+        // drive/folder casing mismatch on Windows would break.
+        var rel = Path.GetRelativePath(rootFull, Path.GetFullPath(path));
+        if (Path.IsPathRooted(rel) || rel == ".." || rel.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal))
         {
             return false;
         }
-        var rel = Path.GetRelativePath(rootFull, full);
         foreach (var part in rel.Split(Path.DirectorySeparatorChar, '/'))
         {
             if (ignoredDirs.Contains(part))

--- a/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
@@ -1,0 +1,208 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.MSBuild;
+
+namespace CsharpFrontend;
+
+public static class Frontend
+{
+    private const string KindClass = "class";
+    private const string KindInterface = "interface";
+    private const string KindUnknown = "unknown";
+
+    public static async Task<int> RunAsync(string[] args)
+    {
+        if (args.Length < 1)
+        {
+            await Console.Error.WriteLineAsync("usage: Frontend <repo-root> [project-or-solution]");
+            return 2;
+        }
+
+        var rootFull = Path.GetFullPath(args[0]);
+        var projectOrSolution = args.Length > 1 ? Path.GetFullPath(args[1]) : null;
+        var ignoredDirs = IgnoredDirs();
+
+        var debug = Environment.GetEnvironmentVariable("CGR_FE_DEBUG") == "1";
+        using var workspace = MSBuildWorkspace.Create();
+        // A failed reference or an unloadable project must not abort the whole run;
+        // degrade to whatever loaded and let the Python side fall back per-type.
+        workspace.WorkspaceFailed += (_, e) =>
+        {
+            if (debug)
+            {
+                Console.Error.WriteLine($"[WorkspaceFailed] {e.Diagnostic.Kind}: {e.Diagnostic.Message}");
+            }
+        };
+
+        var projects = await LoadProjectsAsync(workspace, projectOrSolution, rootFull);
+        if (debug)
+        {
+            Console.Error.WriteLine($"[projects] {projects.Count}");
+        }
+
+        var types = new List<TypeFact>();
+        var seen = new HashSet<(string, int)>();
+        foreach (var project in projects)
+        {
+            var compilation = await project.GetCompilationAsync();
+            if (compilation is null)
+            {
+                continue;
+            }
+            foreach (var tree in compilation.SyntaxTrees)
+            {
+                var path = tree.FilePath;
+                if (string.IsNullOrEmpty(path) || !IsFirstParty(path, rootFull, ignoredDirs))
+                {
+                    continue;
+                }
+                var rel = Path.GetRelativePath(rootFull, path).Replace(Path.DirectorySeparatorChar, '/');
+                var model = compilation.GetSemanticModel(tree);
+                foreach (var node in tree.GetRoot().DescendantNodes())
+                {
+                    if (node is not TypeDeclarationSyntax typeDecl || typeDecl.BaseList is null)
+                    {
+                        continue;
+                    }
+                    var line = typeDecl.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+                    // A type appears once per compilation it belongs to; a file shared
+                    // by multi-targeted projects would emit duplicate (rel,line) keys.
+                    if (!seen.Add((rel, line)))
+                    {
+                        continue;
+                    }
+                    types.Add(new TypeFact(rel, line, typeDecl.Identifier.Text, ClassifyBases(model, typeDecl)));
+                }
+            }
+        }
+
+        var options = new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.Never };
+        Console.WriteLine(JsonSerializer.Serialize(new Payload(types), options));
+        return 0;
+    }
+
+    private static List<BaseFact> ClassifyBases(SemanticModel model, TypeDeclarationSyntax typeDecl)
+    {
+        var bases = new List<BaseFact>();
+        foreach (var baseType in typeDecl.BaseList!.Types)
+        {
+            var symbol = model.GetSymbolInfo(baseType.Type).Symbol as INamedTypeSymbol;
+            var name = symbol?.Name ?? SimpleName(baseType.Type);
+            if (string.IsNullOrEmpty(name))
+            {
+                continue;
+            }
+            var kind = symbol?.TypeKind switch
+            {
+                TypeKind.Interface => KindInterface,
+                TypeKind.Class => KindClass,
+                TypeKind.Struct => KindClass,
+                _ => KindUnknown,
+            };
+            bases.Add(new BaseFact(name, kind));
+        }
+        return bases;
+    }
+
+    // The simple name Roslyn could not resolve to a symbol: strip namespace
+    // qualifiers and generic arguments to match tree-sitter's base simple names.
+    private static string SimpleName(TypeSyntax type)
+    {
+        var text = type switch
+        {
+            GenericNameSyntax g => g.Identifier.Text,
+            QualifiedNameSyntax q => q.Right.Identifier.Text,
+            IdentifierNameSyntax i => i.Identifier.Text,
+            _ => type.ToString(),
+        };
+        return text;
+    }
+
+    private static async Task<List<Project>> LoadProjectsAsync(
+        MSBuildWorkspace workspace, string? projectOrSolution, string rootFull)
+    {
+        var input = projectOrSolution ?? FindProjectOrSolution(rootFull);
+        if (input is null)
+        {
+            return new List<Project>();
+        }
+        try
+        {
+            if (input.EndsWith(".sln", StringComparison.OrdinalIgnoreCase))
+            {
+                var solution = await workspace.OpenSolutionAsync(input);
+                return solution.Projects.ToList();
+            }
+            var project = await workspace.OpenProjectAsync(input);
+            return new List<Project> { project };
+        }
+        catch (Exception ex)
+        {
+            if (Environment.GetEnvironmentVariable("CGR_FE_DEBUG") == "1")
+            {
+                Console.Error.WriteLine($"[LoadProjects] {input}: {ex.Message}");
+            }
+            return new List<Project>();
+        }
+    }
+
+    private static string? FindProjectOrSolution(string rootFull)
+    {
+        var sln = Directory.EnumerateFiles(rootFull, "*.sln", SearchOption.AllDirectories)
+            .OrderBy(p => p.Length).FirstOrDefault();
+        if (sln is not null)
+        {
+            return sln;
+        }
+        return Directory.EnumerateFiles(rootFull, "*.csproj", SearchOption.AllDirectories)
+            .OrderBy(p => p.Length).FirstOrDefault();
+    }
+
+    private static bool IsFirstParty(string path, string rootFull, HashSet<string> ignoredDirs)
+    {
+        var full = Path.GetFullPath(path);
+        if (!full.StartsWith(rootFull, StringComparison.Ordinal))
+        {
+            return false;
+        }
+        var rel = Path.GetRelativePath(rootFull, full);
+        foreach (var part in rel.Split(Path.DirectorySeparatorChar, '/'))
+        {
+            if (ignoredDirs.Contains(part))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static HashSet<string> IgnoredDirs()
+    {
+        var ignored = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ".git", "node_modules", "bin", "obj", "vendor", "testdata",
+        };
+        var env = Environment.GetEnvironmentVariable("CGR_IGNORE_DIRS");
+        if (!string.IsNullOrEmpty(env))
+        {
+            ignored = new HashSet<string>(
+                env.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries),
+                StringComparer.OrdinalIgnoreCase);
+        }
+        return ignored;
+    }
+
+    private record BaseFact(
+        [property: JsonPropertyName("name")] string Name,
+        [property: JsonPropertyName("kind")] string Kind);
+
+    private record TypeFact(
+        [property: JsonPropertyName("file")] string File,
+        [property: JsonPropertyName("line")] int Line,
+        [property: JsonPropertyName("name")] string Name,
+        [property: JsonPropertyName("bases")] List<BaseFact> Bases);
+
+    private record Payload([property: JsonPropertyName("types")] List<TypeFact> Types);
+}

--- a/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.csproj
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>Frontend</AssemblyName>
+    <RootNamespace>CsharpFrontend</RootNamespace>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.7.8" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.11.0" />
+  </ItemGroup>
+
+  <!-- The workspace package pulls a transitive Microsoft.Build.Tasks.Core flagged
+       by a package advisory (NU1903, GHSA-h4j7-5rxr-p4wc). MSBuildLocator redirects
+       every Microsoft.Build.* type to the installed SDK's own (patched) assemblies
+       at runtime, so the transitive that ships in this build graph is never the one
+       loaded or executed. Auditing a local, build-time-only analyzer's compile graph
+       adds no security value here, and this tool only ever processes the user's own
+       trusted repository, so the audit is disabled for the tool build. -->
+  <PropertyGroup>
+    <NuGetAudit>false</NuGetAudit>
+  </PropertyGroup>
+
+</Project>

--- a/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.csproj
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.csproj
@@ -2,7 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <!-- Target the net8.0 LTS so the tool builds on the SDK most users have.
+         RollForward=Major lets the net8.0 assembly also run on a machine that
+         only has a newer (net9/net10) runtime, so a single build covers every
+         supported runtime. -->
+    <TargetFramework>net8.0</TargetFramework>
+    <RollForward>Major</RollForward>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AssemblyName>Frontend</AssemblyName>

--- a/codebase_rag/parsers/csharp_frontend/roslyn/Program.cs
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/Program.cs
@@ -1,0 +1,22 @@
+// Roslyn semantic frontend for cgr's C# hybrid mode (issue #738).
+//
+// Loads the real .csproj/.sln via MSBuildWorkspace (so third-party + BCL types
+// resolve), then for every first-party type declaration emits, keyed on
+// (file, line) matching cgr's tree-sitter node span, each base classified as
+// "class" or "interface" by the resolved symbol -- the fact syntax alone gets
+// wrong (~0.85 F1 in the eval). tree-sitter stays the backbone; the Python side
+// consults these classifications and falls back to its I-prefix heuristic for any
+// base the semantic model could not resolve.
+//
+// MSBuildLocator.RegisterDefaults() MUST run before any Microsoft.CodeAnalysis
+// .MSBuild type is touched, so Main only references the locator + Frontend; the
+// workspace types JIT-load when Frontend.RunAsync is first called, after registration.
+
+using Microsoft.Build.Locator;
+
+if (!MSBuildLocator.IsRegistered)
+{
+    MSBuildLocator.RegisterDefaults();
+}
+
+return await CsharpFrontend.Frontend.RunAsync(args);

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -101,6 +101,12 @@ class DefinitionProcessor(
         # (H) make (the method lives on an unrelated static class). Populated at
         # (H) method ingestion, read by the type-inference engine as a fallback.
         self.csharp_extension_methods: dict[str, list[tuple[str, str, str]]] = {}
+        # (H) C# Roslyn hybrid frontend (issue #738): {(rel_file, type_start_line):
+        # (H) {base_simple_name: "class"|"interface"}}. When the opt-in Roslyn
+        # (H) frontend ran, split_csharp_bases reads a base's kind here (exact,
+        # (H) from the semantic model) instead of guessing by the I-prefix
+        # (H) convention; empty when the frontend is off or unavailable.
+        self.csharp_base_kinds: dict[tuple[str, int], dict[str, str]] = {}
         # (H) {class_qn: {field_name: inner_type}} for Rust guard-container fields
         # (H) (`state: Mutex<State>` -> {"state": "State"}). The field map above keeps
         # (H) the WRAPPER; this inner is applied only when a receiver chain reaches a

--- a/codebase_rag/tests/test_csharp_frontend_wiring.py
+++ b/codebase_rag/tests/test_csharp_frontend_wiring.py
@@ -2,6 +2,7 @@
 # (H) corrects INHERITS-vs-IMPLEMENTS where the parse-time I-prefix heuristic is
 # (H) wrong. The wiring decides which path runs, gated on CSHARP_FRONTEND + a
 # (H) discoverable .csproj + a usable dotnet toolchain.
+import json
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -13,6 +14,7 @@ from codebase_rag.parsers.csharp_frontend import (
     csharp_frontend_available,
     run_csharp_frontend,
 )
+from codebase_rag.parsers.csharp_frontend.frontend import _parse_payload
 from codebase_rag.tests.conftest import get_relationships, run_updater
 
 SKIP = "c_sharp"
@@ -37,7 +39,7 @@ public class Button : IWidget, Renderer
 
 _CSPROJ = """<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 </Project>
@@ -60,6 +62,43 @@ def _has(pairs: set[tuple[str, str]], child_suffix: str, parent_suffix: str) -> 
     return any(
         ch.endswith(child_suffix) and pa.endswith(parent_suffix) for ch, pa in pairs
     )
+
+
+def test_parse_payload_drops_conflicting_duplicate_simple_names() -> None:
+    # (H) Two bases with the same simple name but different kinds (`: A.Widget,
+    # (H) B.Widget`, one class + one interface) cannot be told apart by simple
+    # (H) name, so the name is dropped from the map and the heuristic decides;
+    # (H) a same-kind duplicate is kept.
+    payload = json.dumps(
+        {
+            "types": [
+                {
+                    "file": "F.cs",
+                    "line": 3,
+                    "name": "Button",
+                    "bases": [
+                        {"name": "Widget", "kind": "class"},
+                        {"name": "Widget", "kind": "interface"},
+                        {"name": "Handler", "kind": "interface"},
+                    ],
+                },
+                {
+                    "file": "G.cs",
+                    "line": 5,
+                    "name": "Panel",
+                    "bases": [
+                        {"name": "Base", "kind": "class"},
+                        {"name": "Base", "kind": "class"},
+                    ],
+                },
+            ]
+        }
+    )
+    result = _parse_payload(payload)
+    assert "Widget" not in result[("F.cs", 3)]
+    assert result[("F.cs", 3)]["Handler"] == "interface"
+    # (H) A duplicate that agrees on kind is unambiguous, so it survives.
+    assert result[("G.cs", 5)]["Base"] == "class"
 
 
 def test_default_treesitter_keeps_iprefix_heuristic(temp_repo: Path) -> None:

--- a/codebase_rag/tests/test_csharp_frontend_wiring.py
+++ b/codebase_rag/tests/test_csharp_frontend_wiring.py
@@ -101,6 +101,28 @@ def test_parse_payload_drops_conflicting_duplicate_simple_names() -> None:
     assert result[("G.cs", 5)]["Base"] == "class"
 
 
+def test_frontend_off_clears_stale_base_kinds(
+    temp_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # (H) A reused updater (watch mode) that ran hybrid must not keep applying the
+    # (H) old oracle when a later run has the frontend off: the early return still
+    # (H) resets the map to empty so Pass 2 falls back to the heuristic.
+    from codebase_rag.parser_loader import load_parsers
+
+    parsers, queries = load_parsers()
+    updater = gu.GraphUpdater(
+        ingestor=MagicMock(), repo_path=temp_repo, parsers=parsers, queries=queries
+    )
+    updater.factory.definition_processor.csharp_base_kinds = {
+        ("Stale.cs", 1): {"Old": "class"}
+    }
+    monkeypatch.setattr(gu.settings, "CSHARP_FRONTEND", cs.CSharpFrontend.TREESITTER)
+
+    updater._run_csharp_frontend()
+
+    assert updater.factory.definition_processor.csharp_base_kinds == {}
+
+
 def test_default_treesitter_keeps_iprefix_heuristic(temp_repo: Path) -> None:
     root = temp_repo / "defaultproj"
     _write_project(root)

--- a/codebase_rag/tests/test_csharp_frontend_wiring.py
+++ b/codebase_rag/tests/test_csharp_frontend_wiring.py
@@ -1,0 +1,105 @@
+# (H) C# Roslyn hybrid frontend (issue #738), phase B1: the opt-in semantic layer
+# (H) corrects INHERITS-vs-IMPLEMENTS where the parse-time I-prefix heuristic is
+# (H) wrong. The wiring decides which path runs, gated on CSHARP_FRONTEND + a
+# (H) discoverable .csproj + a usable dotnet toolchain.
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag import graph_updater as gu
+from codebase_rag.parsers.csharp_frontend import (
+    csharp_frontend_available,
+    run_csharp_frontend,
+)
+from codebase_rag.tests.conftest import get_relationships, run_updater
+
+SKIP = "c_sharp"
+
+# (H) A base list the I-prefix heuristic gets exactly backwards: IWidget is a
+# (H) class (heuristic reads the I-prefix as an interface) and Renderer is an
+# (H) interface (heuristic, seeing no I-prefix on the first base, reads it as the
+# (H) base class). C# requires the base class first, so `Button : IWidget, Renderer`
+# (H) is valid with IWidget the base class.
+_TYPES = """
+namespace N;
+
+public interface Renderer { void Render(); }
+
+public class IWidget { public int Handle; }
+
+public class Button : IWidget, Renderer
+{
+    public void Render() { }
+}
+"""
+
+_CSPROJ = """<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>
+"""
+
+
+def _write_project(root: Path) -> None:
+    root.mkdir()
+    (root / "Types.cs").write_text(_TYPES, encoding="utf-8")
+    (root / "Sample.csproj").write_text(_CSPROJ, encoding="utf-8")
+
+
+def _pairs(mock_ingestor: MagicMock, rel_type: str) -> set[tuple[str, str]]:
+    return {
+        (c.args[0][2], c.args[2][2]) for c in get_relationships(mock_ingestor, rel_type)
+    }
+
+
+def _has(pairs: set[tuple[str, str]], child_suffix: str, parent_suffix: str) -> bool:
+    return any(
+        ch.endswith(child_suffix) and pa.endswith(parent_suffix) for ch, pa in pairs
+    )
+
+
+def test_default_treesitter_keeps_iprefix_heuristic(temp_repo: Path) -> None:
+    root = temp_repo / "defaultproj"
+    _write_project(root)
+
+    ingestor = MagicMock()
+    run_updater(root, ingestor, skip_if_missing=SKIP)
+
+    inherits = _pairs(ingestor, "INHERITS")
+    # (H) With the default flag the frontend never runs: the heuristic reads the
+    # (H) I-prefixed base class IWidget as an interface, so it is NOT an INHERITS.
+    assert not _has(inherits, "N.Button", "N.IWidget"), inherits
+
+
+def test_roslyn_frontend_corrects_base_classification(
+    temp_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    if not csharp_frontend_available():
+        pytest.skip("dotnet not available")
+    root = temp_repo / "roslynproj"
+    _write_project(root)
+
+    # (H) Self-gate on the toolchain actually producing facts: a missing SDK
+    # (H) workload, offline NuGet, or a build failure yields an empty map, in
+    # (H) which case there is nothing to assert (the frontend degraded to
+    # (H) tree-sitter, covered by the default-path test above).
+    facts = run_csharp_frontend(root)
+    if not facts:
+        pytest.skip("Roslyn frontend could not build/restore in this environment")
+
+    monkeypatch.setattr(gu.settings, "CSHARP_FRONTEND", cs.CSharpFrontend.HYBRID)
+    ingestor = MagicMock()
+    run_updater(root, ingestor, skip_if_missing=SKIP)
+
+    inherits = _pairs(ingestor, "INHERITS")
+    implements = _pairs(ingestor, "IMPLEMENTS")
+    # (H) The semantic model fixes both: IWidget is the base class (INHERITS),
+    # (H) Renderer is the interface (IMPLEMENTS), the reverse of the heuristic.
+    assert _has(inherits, "N.Button", "N.IWidget"), inherits
+    assert _has(implements, "N.Button", "N.Renderer"), implements
+    assert not _has(implements, "N.Button", "N.IWidget"), implements
+    assert not _has(inherits, "N.Button", "N.Renderer"), inherits

--- a/codebase_rag/tests/test_parser_fingerprint.py
+++ b/codebase_rag/tests/test_parser_fingerprint.py
@@ -76,6 +76,19 @@ class TestComputeParserFingerprint:
         (parsers_dir / "some_parser.py").write_text("A = 1\n")
         assert compute_parser_fingerprint(pkg) == compute_parser_fingerprint(pkg)
 
+    def test_changes_when_csharp_frontend_setting_changes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # (H) The frontend selection is part of the parser identity: flipping it
+        # (H) rewrites edges for unchanged sources, so it must change the
+        # (H) fingerprint and trip the staleness warning (issue #738).
+        from codebase_rag.config import settings as cfg
+
+        monkeypatch.setattr(cfg, "CSHARP_FRONTEND", cs.CSharpFrontend.TREESITTER)
+        before = compute_parser_fingerprint()
+        monkeypatch.setattr(cfg, "CSHARP_FRONTEND", cs.CSharpFrontend.HYBRID)
+        assert compute_parser_fingerprint() != before
+
 
 class TestFingerprintStamping:
     def test_full_sync_stamps_current_fingerprint(

--- a/codebase_rag/tests/test_parser_fingerprint.py
+++ b/codebase_rag/tests/test_parser_fingerprint.py
@@ -76,6 +76,19 @@ class TestComputeParserFingerprint:
         (parsers_dir / "some_parser.py").write_text("A = 1\n")
         assert compute_parser_fingerprint(pkg) == compute_parser_fingerprint(pkg)
 
+    def test_changes_when_roslyn_tool_source_changes(self, tmp_path: Path) -> None:
+        # (H) The bundled Roslyn frontend tool (.cs/.csproj) is parser code: an
+        # (H) edit to it must change the fingerprint so a re-index warns even when
+        # (H) the user's C# sources are unchanged (issue #738).
+        pkg = tmp_path / "pkg"
+        tool_dir = pkg / cs.PARSER_FINGERPRINT_TOOL_DIR
+        tool_dir.mkdir(parents=True)
+        source = tool_dir / "Frontend.cs"
+        source.write_text("class A { }\n")
+        before = compute_parser_fingerprint(pkg)
+        source.write_text("class A { void M() { } }\n")
+        assert compute_parser_fingerprint(pkg) != before
+
     def test_changes_when_csharp_frontend_setting_changes(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,11 @@ include = ["codebase_rag*", "codec*", "cgr*"]
 exclude = ["*.tests", "*.tests.*"]
 
 [tool.setuptools.package-data]
-codebase_rag = ["docker-compose.yaml"]
+codebase_rag = [
+    "docker-compose.yaml",
+    "parsers/csharp_frontend/roslyn/*.cs",
+    "parsers/csharp_frontend/roslyn/*.csproj",
+]
 
 [project.optional-dependencies]
 test = [

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.341"
+version = "0.0.343"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

First phase (B1) of the **C# Roslyn hybrid frontend** (issue #738), the C# analog of `CPP_FRONTEND=hybrid`. C# is already Fully Supported on tree-sitter (#102); this adds an **opt-in** Roslyn semantic layer that corrects facts a syntax-only parser gets wrong, wired seam-for-seam like the C++ hybrid frontend. tree-sitter stays the default and standalone-correct backbone.

B1 delivers the full frontend pipeline plus its first correctness win: **exact INHERITS-vs-IMPLEMENTS base classification** — the measured ~0.85-F1 gap in the C# L1 eval, where the parse-time I-prefix heuristic (`IShape` looks like an interface) mis-reads a base.

## What's here

- **Net tool** (`codebase_rag/parsers/csharp_frontend/roslyn/`) — loads the repo's real `.csproj`/`.sln` via **MSBuildWorkspace** and, per type declaration keyed on `(rel_file, start_line)` matching cgr's tree-sitter node span, emits each base classified `class`/`interface` by the resolved `INamedTypeSymbol` (exact for repo, BCL, and restored third-party types).
- **Python frontend** (`frontend.py`) — build-once-under-mkdir-lock into `~/.cgr/csharp_roslyn/` (never the read-only package dir), best-effort `dotnet restore`, subprocess invoke, JSON → `{(rel_file, line): {base: kind}}`. Degrades gracefully (empty map → pure tree-sitter) on missing dotnet, no project, or build/restore failure.
- **Config** — `CSharpFrontend` StrEnum (`treesitter`/`roslyn`/`hybrid`) + `CSHARP_FRONTEND` setting, **default `treesitter`** (opt-in).
- **Wiring** — `_run_csharp_frontend()` runs before Pass 2 (the classification is consumed during ingestion); `split_csharp_bases` consults the map, falling back to the I-prefix heuristic per-base when the symbol didn't resolve. Threaded through `extract_parent_classes` / `extract_implemented_interfaces` / `create_class_relationships` as an optional arg (zero behavior change when off).

## Testing

- `test_csharp_frontend_wiring.py`: the default-path test proves the heuristic baseline is unchanged (frontend never runs); the frontend-engaged test (self-gating — skips if the toolchain can't build/restore) proves `class Button : IWidget, Renderer` resolves to `IWidget`=INHERITS, `Renderer`=IMPLEMENTS, the reverse of the heuristic. That contrast is the RED→GREEN.
- Full suite: **5177 passed, 10 skipped, 0 failed**; ruff/ty/no-docs/pre-commit clean.

## Notes

- MSBuildWorkspace pulls a transitively-flagged `Microsoft.Build.Tasks.Core` (NU1903). At runtime MSBuildLocator redirects `Microsoft.Build.*` to the SDK's patched assemblies, so the flagged transitive is never loaded; audit is disabled on the build-time-only tool with an explanatory comment (0 warnings).
- A repo with multiple `.csproj` but no `.sln` currently analyzes only the shortest-path project; broadening to all projects is a later refinement.

## Next phases (this epic)

- B2: exact overload + extension-method + typed-receiver CALLS binding via `SemanticModel.GetSymbolInfo`.
- B3: partial-class symbol-identity merge, explicit-interface impl, delegates/events.

Part of #738.
