### PR TITLE
feat(flow): flow taint into Rust macro and C++ stream sinks

### DIFF
--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -12,8 +12,10 @@ from ..call_resolver import CallResolver
 from ..import_processor import ImportProcessor
 from ..io_access import (
     DYNAMIC_TARGET,
+    IO_MACRO_SINKS,
     IO_MEMBER_READS,
     IO_SINKS,
+    IO_STREAM_SINKS,
     LANGUAGE_DESCRIPTORS,
     PY_SCOPE_BOUNDARIES,
     RESOURCE_QN_FORMAT,
@@ -24,14 +26,17 @@ from ..io_access import (
     ResourceKind,
     call_name,
     definition_header_nodes,
+    first_token_arg_string,
     head_is_genuine_module,
     is_require_alias,
+    iter_token_tree_calls,
     literal_target,
     match_normalised,
     registry_match,
     scope_seed_nodes,
     string_literal,
 )
+from ..utils import cpp_declarator_name
 from .constants import (
     KEY_KIND,
     KEY_VIA,
@@ -99,6 +104,10 @@ class _FlowCtx(NamedTuple):
     import_map: dict[str, str]
     read_sinks: dict[str, IOSink]
     write_sinks: dict[str, IOSink]
+    # (H) Write sinks reached NOT by a plain call: Rust `println!` (macro) and C++
+    # (H) `std::cout << x` (stream insertion). Empty for languages without them.
+    macro_sinks: dict[str, IOSink]
+    stream_sinks: dict[str, IOSink]
 
 
 # (H) Languages whose local declarations hoist to the whole function scope (JS/TS
@@ -195,6 +204,8 @@ class FlowProcessor:
             write_sinks={
                 s.callee: s for s in sinks if s.direction == IODirection.WRITE
             },
+            macro_sinks=IO_MACRO_SINKS.get(language, {}),
+            stream_sinks=IO_STREAM_SINKS.get(language, {}),
         )
         # (H) Non-Python languages take a lean STRAIGHT-LINE flow walk (issue #714):
         # (H) taint from a read source (process.env, fetch, fs.readFile) reaching a
@@ -438,6 +449,10 @@ class FlowProcessor:
                 self._lean_bind(node, tainted, jc)
         elif node_type == d.call_type:
             self._js_call(node, tainted, jc)
+        elif d.macro_type is not None and node_type == d.macro_type:
+            self._flow_macro(node, tainted, jc)
+        elif d.stream_sink_type is not None and node_type == d.stream_sink_type:
+            self._flow_stream(node, tainted, jc)
         elif node_type == cs.TS_RETURN_STATEMENT:
             returned = self._js_return_taint(node, tainted, jc)
             if returned is not None:
@@ -453,6 +468,19 @@ class FlowProcessor:
         if left is not None:
             targets = self._lean_targets(left, d)
             values = self._lean_values(node.child_by_field_name(cs.FIELD_RIGHT), d)
+        elif d.declarator_name_field is not None and node.type == d.declarator_type:
+            # (H) The bound name lives under a language-specific field, not `name`/
+            # (H) `left`: Rust `let x = ..` uses `pattern` (a plain identifier), C++
+            # (H) `int x = ..` uses `declarator` (a nested pointer/reference declarator).
+            # (H) Try the plain-identifier path first, then the C++ declarator unwrap.
+            field_node = node.child_by_field_name(d.declarator_name_field)
+            if field_node is None:
+                targets = [None]
+            else:
+                targets = self._lean_targets(field_node, d)
+                if targets == [None]:
+                    targets = [cpp_declarator_name(field_node)]
+            values = self._lean_values(node.child_by_field_name(cs.FIELD_VALUE), d)
         else:
             targets = []
             for name in node.children_by_field_name(cs.TS_FIELD_NAME):
@@ -570,6 +598,15 @@ class FlowProcessor:
                     (callee[0], callee[1], jc.flow.caller_spec)
                 )
                 return Taint(frozenset(), frozenset({callee[1]}))
+            # (H) A method chain (`std::env::var("X").unwrap()`): the callee itself is
+            # (H) not a source, but its receiver call may be -- recurse the left spine.
+            # (H) Gated on the receiver being a call (not a bare identifier) so plain
+            # (H) variable taint is never propagated through an arbitrary method.
+            func = node.child_by_field_name(cs.TS_FIELD_FUNCTION)
+            if func is not None and func.type == d.member_expression_type:
+                receiver = func.child_by_field_name(d.object_field)
+                if receiver is not None and receiver.type == d.call_type:
+                    return self._js_expr_taint(receiver, tainted, jc)
         return None
 
     def _js_call(self, node: Node, tainted: _TaintMap, jc: _JsCtx) -> None:
@@ -622,6 +659,125 @@ class FlowProcessor:
                 self._deferred_arg_edges.append(
                     (taint.pending, jc.flow.caller_spec, callee_type, callee_qn, via)
                 )
+
+    def _emit_taint_to_sink(
+        self, taint: Taint, kind: ResourceKind, identity: str
+    ) -> None:
+        # (H) A tainted value reaching a write sink: emit resolved origins now, defer
+        # (H) pending callee returns to the fixpoint (mirrors the _js_call write branch).
+        for origin in taint.origins:
+            self._emit_resource_flow(origin, kind, identity)
+        if taint.pending:
+            self._deferred_resource_flows.append((taint.pending, kind, identity))
+
+    def _flow_macro(self, node: Node, tainted: _TaintMap, jc: _JsCtx) -> None:
+        # (H) A Rust macro sink (`println!(secret)`) writes STDOUT (identity <dynamic>,
+        # (H) the arg is a format template). tree-sitter flattens the macro body to raw
+        # (H) tokens, so taint reaches it two ways: a tainted local as a bare identifier
+        # (H) token, or a read source inlined as a scoped call in the token stream.
+        macro = node.child_by_field_name(cs.TS_RS_FIELD_MACRO)
+        if macro is None or macro.text is None:
+            return
+        sink = jc.flow.macro_sinks.get(macro.text.decode(cs.ENCODING_UTF8))
+        if sink is None:
+            return
+        for child in node.named_children:
+            if child.type == cs.TS_RS_TOKEN_TREE:
+                for taint in self._macro_arg_taints(child, tainted, jc):
+                    self._emit_taint_to_sink(taint, sink.kind, DYNAMIC_TARGET)
+
+    def _macro_arg_taints(
+        self, token_tree: Node, tainted: _TaintMap, jc: _JsCtx
+    ) -> list[Taint]:
+        out: list[Taint] = []
+        # (H) A tainted local used directly in the macro args (bare identifier token).
+        for name in self._token_identifiers(token_tree, jc.descriptor.identifier_type):
+            taint = tainted.get(name)
+            if taint is not None:
+                out.append(taint)
+        # (H) A read source inlined as a scoped call (`std::env::var("X")`).
+        for raw, args in iter_token_tree_calls(
+            token_tree,
+            cs.TS_RS_TOKEN_SCOPE,
+            jc.descriptor.identifier_type,
+            cs.TS_RS_TOKEN_TREE,
+        ):
+            sink = self._js_match_sink(raw, jc.flow.read_sinks, jc)
+            if sink is None:
+                continue
+            identity = DYNAMIC_TARGET
+            if sink.target_arg == 0:
+                identity = first_token_arg_string(
+                    args, jc.descriptor.string_type, jc.descriptor.string_content_type
+                )
+            out.append(
+                Taint(
+                    frozenset({HandleBinding(kind=sink.kind, identity=identity)}),
+                    frozenset(),
+                )
+            )
+        return out
+
+    @staticmethod
+    def _token_identifiers(token_tree: Node, identifier_type: str) -> set[str]:
+        # (H) Every identifier token in a flattened macro body. Path segments of an
+        # (H) inlined call (`std`, `env`) are here too but never appear in the taint
+        # (H) map, so matching against `tainted` only picks out real tainted locals.
+        out: set[str] = set()
+        stack = list(token_tree.children)
+        while stack:
+            n = stack.pop()
+            if n.type == identifier_type and n.text:
+                out.add(n.text.decode(cs.ENCODING_UTF8))
+            stack.extend(n.children)
+        return out
+
+    def _flow_stream(self, node: Node, tainted: _TaintMap, jc: _JsCtx) -> None:
+        # (H) A C++ stream sink (`std::cout << a << b`) nests left-associatively. Act
+        # (H) only at the TOP of the `<<` chain, walk the `left` spine to the base
+        # (H) operand; if it is a stream sink (cout/cerr), flow the taint of every
+        # (H) inserted operand to STDOUT. A non-stream base (arithmetic `x << 2`) misses.
+        d = jc.descriptor
+        if not self._is_stream_insertion(node, d):
+            return
+        parent = node.parent
+        if parent is not None and self._is_stream_insertion(parent, d):
+            return
+        operands: list[Node] = []
+        base = node
+        while self._is_stream_insertion(base, d):
+            right = base.child_by_field_name(cs.FIELD_RIGHT)
+            if right is not None:
+                operands.append(right)
+            left = base.child_by_field_name(cs.FIELD_LEFT)
+            if left is None:
+                return
+            base = left
+        if base.text is None:
+            return
+        sink = jc.flow.stream_sinks.get(base.text.decode(cs.ENCODING_UTF8))
+        if sink is None:
+            return
+        for operand in operands:
+            taint = self._js_expr_taint(operand, tainted, jc)
+            if taint is not None:
+                self._emit_taint_to_sink(taint, sink.kind, DYNAMIC_TARGET)
+
+    @staticmethod
+    def _is_stream_insertion(node: Node, descriptor: LanguageDescriptor) -> bool:
+        # (H) A binary_expression whose `operator` field is the stream-insertion token.
+        if (
+            descriptor.stream_sink_type is None
+            or node.type != descriptor.stream_sink_type
+        ):
+            return False
+        operator = node.child_by_field_name(cs.FIELD_OPERATOR)
+        return (
+            operator is not None
+            and operator.text is not None
+            and operator.text.decode(cs.ENCODING_UTF8)
+            == descriptor.stream_sink_operator
+        )
 
     def _js_arg_taints(
         self, node: Node, tainted: _TaintMap, jc: _JsCtx
@@ -725,6 +881,19 @@ class FlowProcessor:
         # (H) the builtin; the import-normalised name matches first (so an aliased
         # (H) builtin resolves), then the raw dotted name only when its head resolves
         # (H) to the genuine module (node:/require/ESM), never a shadowing local module.
+        # (H) Rust (scope_separator="::") keys sinks under the full `std::` form: expand
+        # (H) the head through the import map on `::` (`use std::env; env::var` ->
+        # (H) `std::env::var`; a fully-qualified `std::env::var` has an unimported `std`
+        # (H) head and stays as-is); a head bound to a local name is shadowed.
+        scope_sep = jc.descriptor.scope_separator
+        if scope_sep is not None:
+            scoped_head, _, scoped_rest = raw.partition(scope_sep)
+            if scoped_head in jc.local_names:
+                return None
+            base = jc.flow.import_map.get(scoped_head)
+            if base is not None:
+                raw = f"{base}{scope_sep}{scoped_rest}" if scoped_rest else base
+            return sink_map.get(raw)
         head, sep, _ = raw.partition(cs.SEPARATOR_DOT)
         if (head if sep else raw) in jc.local_names:
             return None

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -692,10 +692,14 @@ class FlowProcessor:
         self, token_tree: Node, tainted: _TaintMap, jc: _JsCtx
     ) -> list[Taint]:
         out: list[Taint] = []
-        # (H) A tainted local used directly in the macro args (bare identifier token).
-        for name in self._bare_arg_identifiers(
+        # (H) A tainted local reaching the macro args by name: either a bare identifier
+        # (H) token (`println!("{}", secret)`) or an inline format capture inside the
+        # (H) template string (`println!("{secret}")`, Rust 2021+), which has no
+        # (H) separate identifier token.
+        named = self._bare_arg_identifiers(
             token_tree, jc.descriptor.identifier_type, cs.TS_RS_TOKEN_SCOPE
-        ):
+        ) | self._macro_format_captures(token_tree, jc)
+        for name in named:
             taint = tainted.get(name)
             if taint is not None:
                 out.append(taint)
@@ -720,6 +724,50 @@ class FlowProcessor:
                     frozenset(),
                 )
             )
+        return out
+
+    def _macro_format_captures(self, token_tree: Node, jc: _JsCtx) -> set[str]:
+        # (H) Names captured inline by the format template (the FIRST string literal in
+        # (H) the macro args), e.g. `println!("{secret} {x:?}")`. Only the first string
+        # (H) is the template; later string args are values, not templates.
+        for child in token_tree.children:
+            if child.type == jc.descriptor.string_type:
+                content = string_literal(
+                    child, jc.descriptor.string_type, jc.descriptor.string_content_type
+                )
+                if content == DYNAMIC_TARGET:
+                    return set()
+                return self._format_capture_names(content)
+        return set()
+
+    @staticmethod
+    def _format_capture_names(template: str) -> set[str]:
+        # (H) Identifier names in `{name}` / `{name:spec}` placeholders of a Rust format
+        # (H) template. `{{`/`}}` are escaped braces; positional (`{}`, `{0}`) captures
+        # (H) reference no local, so only alphanumeric-identifier names are returned.
+        out: set[str] = set()
+        i, n = 0, len(template)
+        while i < n:
+            char = template[i]
+            if char == "{":
+                if i + 1 < n and template[i + 1] == "{":
+                    i += 2
+                    continue
+                close = template.find("}", i + 1)
+                if close == -1:
+                    break
+                name = template[i + 1 : close].split(":", 1)[0].strip()
+                if (
+                    name
+                    and (name[0].isalpha() or name[0] == "_")
+                    and all(c.isalnum() or c == "_" for c in name)
+                ):
+                    out.add(name)
+                i = close + 1
+            elif char == "}" and i + 1 < n and template[i + 1] == "}":
+                i += 2
+            else:
+                i += 1
         return out
 
     @staticmethod

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -678,7 +678,9 @@ class FlowProcessor:
         macro = node.child_by_field_name(cs.TS_RS_FIELD_MACRO)
         if macro is None or macro.text is None:
             return
-        sink = jc.flow.macro_sinks.get(macro.text.decode(cs.ENCODING_UTF8))
+        sink = self._js_match_sink(
+            macro.text.decode(cs.ENCODING_UTF8), jc.flow.macro_sinks, jc
+        )
         if sink is None:
             return
         for child in node.named_children:
@@ -691,7 +693,9 @@ class FlowProcessor:
     ) -> list[Taint]:
         out: list[Taint] = []
         # (H) A tainted local used directly in the macro args (bare identifier token).
-        for name in self._token_identifiers(token_tree, jc.descriptor.identifier_type):
+        for name in self._bare_arg_identifiers(
+            token_tree, jc.descriptor.identifier_type, cs.TS_RS_TOKEN_SCOPE
+        ):
             taint = tainted.get(name)
             if taint is not None:
                 out.append(taint)
@@ -719,17 +723,26 @@ class FlowProcessor:
         return out
 
     @staticmethod
-    def _token_identifiers(token_tree: Node, identifier_type: str) -> set[str]:
-        # (H) Every identifier token in a flattened macro body. Path segments of an
-        # (H) inlined call (`std`, `env`) are here too but never appear in the taint
-        # (H) map, so matching against `tainted` only picks out real tainted locals.
+    def _bare_arg_identifiers(
+        token_tree: Node, identifier_type: str, scope_separator: str
+    ) -> set[str]:
+        # (H) Identifiers in a flattened macro body that are NOT a segment of a scoped
+        # (H) path: a path segment (`std`/`env`/`var` in `std::env::var`) is adjacent to
+        # (H) a `::` token, so it is excluded and a tainted local that happens to share a
+        # (H) segment name (a local `env`) is not confused with the path (over-taint P1).
         out: set[str] = set()
-        stack = list(token_tree.children)
+        stack = [token_tree]
         while stack:
-            n = stack.pop()
-            if n.type == identifier_type and n.text:
-                out.add(n.text.decode(cs.ENCODING_UTF8))
-            stack.extend(n.children)
+            current = stack.pop()
+            kids = current.children
+            for i, child in enumerate(kids):
+                if child.type == identifier_type and child.text:
+                    prev_sep = i > 0 and kids[i - 1].type == scope_separator
+                    next_sep = i + 1 < len(kids) and kids[i + 1].type == scope_separator
+                    if not prev_sep and not next_sep:
+                        out.add(child.text.decode(cs.ENCODING_UTF8))
+                elif child.type == cs.TS_RS_TOKEN_TREE:
+                    stack.append(child)
         return out
 
     def _flow_stream(self, node: Node, tainted: _TaintMap, jc: _JsCtx) -> None:
@@ -755,7 +768,9 @@ class FlowProcessor:
             base = left
         if base.text is None:
             return
-        sink = jc.flow.stream_sinks.get(base.text.decode(cs.ENCODING_UTF8))
+        sink = self._js_match_sink(
+            base.text.decode(cs.ENCODING_UTF8), jc.flow.stream_sinks, jc
+        )
         if sink is None:
             return
         for operand in operands:

--- a/codebase_rag/parsers/io_access/__init__.py
+++ b/codebase_rag/parsers/io_access/__init__.py
@@ -11,8 +11,10 @@ from .descriptor import LANGUAGE_DESCRIPTORS, LanguageDescriptor
 from .extract import (
     call_name,
     definition_header_nodes,
+    first_token_arg_string,
     head_is_genuine_module,
     is_require_alias,
+    iter_token_tree_calls,
     literal_target,
     match_normalised,
     normalise,
@@ -25,16 +27,20 @@ from .processor import IOAccessProcessor
 from .registry import (
     IO_HANDLE_CONSTRUCTORS,
     IO_HANDLE_METHODS,
+    IO_MACRO_SINKS,
     IO_MEMBER_READS,
     IO_SINKS,
+    IO_STREAM_SINKS,
 )
 
 __all__ = [
     "DYNAMIC_TARGET",
     "IO_HANDLE_CONSTRUCTORS",
     "IO_HANDLE_METHODS",
+    "IO_MACRO_SINKS",
     "IO_MEMBER_READS",
     "IO_SINKS",
+    "IO_STREAM_SINKS",
     "LANGUAGE_DESCRIPTORS",
     "PY_SCOPE_BOUNDARIES",
     "RESOURCE_QN_FORMAT",
@@ -47,8 +53,10 @@ __all__ = [
     "ResourceKind",
     "call_name",
     "definition_header_nodes",
+    "first_token_arg_string",
     "head_is_genuine_module",
     "is_require_alias",
+    "iter_token_tree_calls",
     "literal_target",
     "match_normalised",
     "normalise",

--- a/codebase_rag/parsers/io_access/descriptor.py
+++ b/codebase_rag/parsers/io_access/descriptor.py
@@ -86,6 +86,11 @@ class LanguageDescriptor:
     # (H) (cout/cerr) is a stream sink. None where the language has no such operator I/O.
     stream_sink_type: str | None = None
     stream_sink_operator: str | None = None
+    # (H) Field on `declarator_type` holding the bound name when it is NOT a plain
+    # (H) `name`/`left` field but a nested declarator (C++ `init_declarator` ->
+    # (H) `declarator`, unwrapped through pointer/reference declarators). None = the
+    # (H) language binds via `name`/`left` (JS/Go/Java/Rust). Used by the flow walk.
+    declarator_name_field: str | None = None
 
 
 _JS_TS_DESCRIPTOR = LanguageDescriptor(
@@ -235,6 +240,9 @@ _RUST_DESCRIPTOR = LanguageDescriptor(
     property_field=cs.RS_FIELD_FIELD,
     subscript_index_field=cs.RS_FIELD_INDEX,
     scope_separator=cs.TS_RS_TOKEN_SCOPE,
+    # (H) `let x = env::var(..)` binds via the `pattern` field (a plain identifier for
+    # (H) a simple binding), the init under `value`. Used by the flow walk.
+    declarator_name_field=cs.TS_FIELD_PATTERN,
 )
 
 _CPP_DESCRIPTOR = LanguageDescriptor(
@@ -274,6 +282,9 @@ _CPP_DESCRIPTOR = LanguageDescriptor(
     # (H) `std::cout << x` / `std::cerr << x` write STDOUT via the `<<` operator.
     stream_sink_type=cs.TS_CPP_BINARY_EXPRESSION,
     stream_sink_operator=cs.CPP_OP_LEFT_SHIFT,
+    # (H) `int x = getenv(...)` binds via the `declarator` field (a nested
+    # (H) pointer/reference declarator unwrapped to its identifier), not `name`.
+    declarator_name_field=cs.FIELD_DECLARATOR,
 )
 
 # (H) Non-Python languages with a direct-sink descriptor. Python keeps its own

--- a/codebase_rag/parsers/io_access/extract.py
+++ b/codebase_rag/parsers/io_access/extract.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
+
 from tree_sitter import Node
 
 from ... import constants as cs
@@ -159,6 +161,53 @@ def string_literal(
     for child in arg.named_children:
         if child.type == content_type and child.text is not None:
             return child.text.decode(cs.ENCODING_UTF8)
+    return DYNAMIC_TARGET
+
+
+def iter_token_tree_calls(
+    token_tree: Node,
+    scope_separator: str,
+    identifier_type: str,
+    token_tree_type: str,
+) -> Iterator[tuple[str, Node]]:
+    # (H) tree-sitter flattens a Rust macro body to a token_tree of raw tokens, so an
+    # (H) inlined scoped call (`std::env::var("X")`) is a run of `identifier` joined by
+    # (H) the scope token (whose node type IS the separator, e.g. "::") followed by its
+    # (H) args token_tree -- no call_expression node. Yield (reconstructed dotted name,
+    # (H) args token_tree) for each such run, recursing into nested groups. Shared by
+    # (H) the io walk (sink emission) and the flow walk (taint into a macro sink).
+    path: list[str] = []
+    expect_sep = False
+    for child in token_tree.children:
+        if child.type == identifier_type and not expect_sep and child.text:
+            path.append(child.text.decode(cs.ENCODING_UTF8))
+            expect_sep = True
+        elif child.type == scope_separator and expect_sep:
+            expect_sep = False
+        elif child.type == token_tree_type:
+            if path:
+                yield scope_separator.join(path), child
+            path, expect_sep = [], False
+            yield from iter_token_tree_calls(
+                child, scope_separator, identifier_type, token_tree_type
+            )
+        else:
+            path, expect_sep = [], False
+
+
+def first_token_arg_string(args: Node, string_type: str, content_type: str) -> str:
+    # (H) arg0 of a flattened call's token_tree: the tokens before the first top-level
+    # (H) comma. It is a resource path only when it is a lone string literal
+    # (H) (`write(path, "x")` has a variable arg0 -> <dynamic>, not "x").
+    arg0: list[Node] = []
+    for child in args.children:
+        if child.type in (cs.CHAR_PAREN_OPEN, cs.CHAR_PAREN_CLOSE):
+            continue
+        if child.type == cs.CHAR_COMMA:
+            break
+        arg0.append(child)
+    if len(arg0) == 1 and arg0[0].type == string_type:
+        return string_literal(arg0[0], string_type, content_type)
     return DYNAMIC_TARGET
 
 

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -20,8 +20,10 @@ from .descriptor import LANGUAGE_DESCRIPTORS, LanguageDescriptor
 from .extract import (
     call_name,
     definition_header_nodes,
+    first_token_arg_string,
     head_is_genuine_module,
     is_require_alias,
+    iter_token_tree_calls,
     literal_target,
     match_normalised,
     registry_match,
@@ -632,37 +634,15 @@ class IOAccessProcessor:
         in_scope: frozenset[str],
         descriptor: LanguageDescriptor,
     ) -> None:
-        # (H) tree-sitter flattens a Rust macro body to raw tokens, so an inlined call
-        # (H) (`std::env::var("X")`) is a run of `identifier` joined by `::` tokens
-        # (H) followed by its args `token_tree` -- no call_expression node. Rebuild the
-        # (H) scoped name from that run, resolve it against the sink table (respecting
-        # (H) shadowing), and take arg0's string literal as the resource identity.
-        path: list[str] = []
-        expect_sep = False
-        for child in token_tree.children:
-            if child.type == cs.TS_IDENTIFIER and not expect_sep and child.text:
-                path.append(child.text.decode(cs.ENCODING_UTF8))
-                expect_sep = True
-            elif child.type == cs.TS_RS_TOKEN_SCOPE and expect_sep:
-                expect_sep = False
-            elif child.type == cs.TS_RS_TOKEN_TREE:
-                if path:
-                    self._emit_token_tree_call(
-                        cs.TS_RS_TOKEN_SCOPE.join(path),
-                        child,
-                        caller_spec,
-                        import_map,
-                        sink_by_name,
-                        in_scope,
-                        descriptor,
-                    )
-                path, expect_sep = [], False
-                # (H) Recurse for a nested macro / grouped call in the arguments.
-                self._scan_token_tree_calls(
-                    child, caller_spec, import_map, sink_by_name, in_scope, descriptor
-                )
-            else:
-                path, expect_sep = [], False
+        # (H) Rebuild each inlined scoped call from the flat token stream (shared with
+        # (H) the flow walk), resolve it against the sink table (respecting shadowing),
+        # (H) and take arg0's string literal as the resource identity.
+        for raw, args in iter_token_tree_calls(
+            token_tree, cs.TS_RS_TOKEN_SCOPE, cs.TS_IDENTIFIER, cs.TS_RS_TOKEN_TREE
+        ):
+            self._emit_token_tree_call(
+                raw, args, caller_spec, import_map, sink_by_name, in_scope, descriptor
+            )
 
     def _emit_token_tree_call(
         self,
@@ -691,25 +671,10 @@ class IOAccessProcessor:
         # (H) higher arg index would need positional token counting (upgrade path).
         identity = DYNAMIC_TARGET
         if sink.target_arg == 0:
-            identity = self._first_token_arg_string(args)
-        self._emit(caller_spec, sink.direction, sink.kind, identity)
-
-    def _first_token_arg_string(self, args: Node) -> str:
-        # (H) arg0 of a flattened call's token_tree: the tokens before the first
-        # (H) top-level comma. It is the resource path only when it is a lone string
-        # (H) literal (`write(path, "x")` has a variable arg0 -> <dynamic>, not "x").
-        arg0: list[Node] = []
-        for child in args.children:
-            if child.type in (cs.CHAR_PAREN_OPEN, cs.CHAR_PAREN_CLOSE):
-                continue
-            if child.type == cs.CHAR_COMMA:
-                break
-            arg0.append(child)
-        if len(arg0) == 1 and arg0[0].type == cs.TS_RS_STRING_LITERAL:
-            return string_literal(
-                arg0[0], cs.TS_RS_STRING_LITERAL, cs.TS_RS_STRING_CONTENT
+            identity = first_token_arg_string(
+                args, cs.TS_RS_STRING_LITERAL, cs.TS_RS_STRING_CONTENT
             )
-        return DYNAMIC_TARGET
+        self._emit(caller_spec, sink.direction, sink.kind, identity)
 
     def _emit_member_read(
         self,

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -394,7 +394,7 @@ def _cpp_scope_bound_names(scope_node: Node) -> set[str]:
     return set(_cpp_declarator_param_names(declarator))
 
 
-def _cpp_declarator_name(declarator: Node | None) -> str | None:
+def cpp_declarator_name(declarator: Node | None) -> str | None:
     # (H) Unwrap pointer/reference/parenthesized/function declarators down to the
     # (H) bound identifier (`int (*cb)()` -> cb, `T& x` -> x, `Fn cb` -> cb).
     current = declarator
@@ -439,7 +439,7 @@ def _cpp_declarator_param_names(declarator: Node | None) -> list[str]:
         if declaration.type not in _CPP_PARAMETER_DECLARATIONS:
             continue
         param_declarator = declaration.child_by_field_name(cs.FIELD_DECLARATOR)
-        if (name := _cpp_declarator_name(param_declarator)) is not None:
+        if (name := cpp_declarator_name(param_declarator)) is not None:
             names.append(name)
     return names
 

--- a/codebase_rag/tests/integration/test_rust_cpp_flow_e2e.py
+++ b/codebase_rag/tests/integration/test_rust_cpp_flow_e2e.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.capture import resolve_capture
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.parsers.flow_access import FlowKind
+
+if TYPE_CHECKING:
+    from codebase_rag.services.graph_service import MemgraphIngestor
+
+pytestmark = [pytest.mark.integration]
+
+_FLOWS = cs.RelationshipType.FLOWS_TO.value
+
+
+def _build(
+    ingestor: MemgraphIngestor, tmp_path: Path, filename: str, code: str
+) -> None:
+    project = tmp_path / "flow_rs_cpp"
+    project.mkdir()
+    (project / filename).write_text(code, encoding="utf-8")
+    parsers, queries = load_parsers()
+    GraphUpdater(
+        ingestor=ingestor,
+        repo_path=project,
+        parsers=parsers,
+        queries=queries,
+        capture=resolve_capture([cs.CaptureGroup.IO.value]),
+    ).run()
+
+
+def _flows(ingestor: MemgraphIngestor) -> list[dict[str, str | None]]:
+    rows = ingestor.fetch_all(
+        f"MATCH (a)-[r:{_FLOWS}]->(b) "
+        "RETURN a.qualified_name AS frm, b.qualified_name AS to, r.kind AS kind"
+    )
+    return [{k: None if v is None else str(v) for k, v in row.items()} for row in rows]
+
+
+def _resource_flow(flows: list[dict[str, str | None]], frm: str, to: str) -> bool:
+    return any(
+        (f["frm"] or "").endswith(frm)
+        and (f["to"] or "").endswith(to)
+        and f["kind"] == FlowKind.RESOURCE.value
+        for f in flows
+    )
+
+
+def _any_resource(flows: list[dict[str, str | None]]) -> bool:
+    return any(f["kind"] == FlowKind.RESOURCE.value for f in flows)
+
+
+# (H) Rust
+
+
+def test_rust_env_var_to_println(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) A `let` carries the env source into a println! macro sink: ENV -> STDOUT.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "main.rs",
+        "fn boot() {\n"
+        '    let secret = std::env::var("SECRET").unwrap();\n'
+        '    println!("{}", secret);\n'
+        "}\n",
+    )
+    assert _resource_flow(
+        _flows(memgraph_ingestor),
+        "resource::ENV::SECRET",
+        "resource::STDOUT::<dynamic>",
+    )
+
+
+def test_rust_inlined_env_in_println(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) The env read is inlined directly into the macro args: ENV -> STDOUT.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "main.rs",
+        'fn boot() {\n    println!("{}", std::env::var("SECRET").unwrap());\n}\n',
+    )
+    assert _resource_flow(
+        _flows(memgraph_ingestor),
+        "resource::ENV::SECRET",
+        "resource::STDOUT::<dynamic>",
+    )
+
+
+def test_rust_untainted_println_no_flow(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) A println! of a clean literal produces no resource flow.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "main.rs",
+        'fn boot() {\n    println!("hello");\n}\n',
+    )
+    assert not _any_resource(_flows(memgraph_ingestor))
+
+
+# (H) C++
+
+
+def test_cpp_getenv_to_cout(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) A local carries getenv into a cout stream sink: ENV -> STDOUT.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "main.cpp",
+        "#include <iostream>\n"
+        "#include <cstdlib>\n"
+        "void boot() {\n"
+        '    const char* secret = getenv("SECRET");\n'
+        "    std::cout << secret;\n"
+        "}\n",
+    )
+    assert _resource_flow(
+        _flows(memgraph_ingestor),
+        "resource::ENV::SECRET",
+        "resource::STDOUT::<dynamic>",
+    )
+
+
+def test_cpp_inlined_getenv_in_cout(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) getenv inlined directly into the stream insertion: ENV -> STDOUT.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "main.cpp",
+        "#include <iostream>\n"
+        "#include <cstdlib>\n"
+        "void boot() {\n"
+        '    std::cout << getenv("SECRET");\n'
+        "}\n",
+    )
+    assert _resource_flow(
+        _flows(memgraph_ingestor),
+        "resource::ENV::SECRET",
+        "resource::STDOUT::<dynamic>",
+    )
+
+
+def test_cpp_untainted_cout_no_flow(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) A cout of a clean literal produces no resource flow.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "main.cpp",
+        '#include <iostream>\nvoid boot() {\n    std::cout << "hello";\n}\n',
+    )
+    assert not _any_resource(_flows(memgraph_ingestor))

--- a/codebase_rag/tests/integration/test_rust_cpp_flow_e2e.py
+++ b/codebase_rag/tests/integration/test_rust_cpp_flow_e2e.py
@@ -118,6 +118,27 @@ def test_rust_tainted_path_name_no_over_taint(
     )
 
 
+def test_rust_inline_format_capture_to_println(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) Rust inline format capture: `println!("{secret}")` reads the local through
+    # (H) the format string with no separate identifier token. ENV -> STDOUT.
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "main.rs",
+        "fn boot() {\n"
+        '    let secret = std::env::var("SECRET").unwrap();\n'
+        '    println!("{secret}");\n'
+        "}\n",
+    )
+    assert _resource_flow(
+        _flows(memgraph_ingestor),
+        "resource::ENV::SECRET",
+        "resource::STDOUT::<dynamic>",
+    )
+
+
 def test_rust_untainted_println_no_flow(
     memgraph_ingestor: MemgraphIngestor, tmp_path: Path
 ) -> None:

--- a/codebase_rag/tests/integration/test_rust_cpp_flow_e2e.py
+++ b/codebase_rag/tests/integration/test_rust_cpp_flow_e2e.py
@@ -96,6 +96,28 @@ def test_rust_inlined_env_in_println(
     )
 
 
+def test_rust_tainted_path_name_no_over_taint(
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+) -> None:
+    # (H) A local named `env` shadows nothing in the fully-qualified `std::env::var`
+    # (H) path, and it is never printed -- only CLEAN is. The bare-identifier scan must
+    # (H) not treat the `env` path segment as the tainted local (over-taint P1).
+    _build(
+        memgraph_ingestor,
+        tmp_path,
+        "main.rs",
+        "fn boot() {\n"
+        '    let env = std::env::var("SECRET").unwrap();\n'
+        '    println!("{}", std::env::var("CLEAN").unwrap());\n'
+        "}\n",
+    )
+    flows = _flows(memgraph_ingestor)
+    assert _resource_flow(flows, "resource::ENV::CLEAN", "resource::STDOUT::<dynamic>")
+    assert not _resource_flow(
+        flows, "resource::ENV::SECRET", "resource::STDOUT::<dynamic>"
+    )
+
+
 def test_rust_untainted_println_no_flow(
     memgraph_ingestor: MemgraphIngestor, tmp_path: Path
 ) -> None:

--- a/codebase_rag/tests/unit/test_rust_cpp_flow_unit.py
+++ b/codebase_rag/tests/unit/test_rust_cpp_flow_unit.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from codebase_rag import constants as cs
+from codebase_rag.capture import resolve_capture
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.parsers.flow_access import FlowKind
+from codebase_rag.types_defs import PropertyDict, PropertyValue, ResultRow
+
+# (H) Fast unit coverage for the Rust macro-sink / C++ stream-sink FLOWS_TO walk
+# (H) (issue #714): drives the real GraphUpdater against a one-file project with a
+# (H) recording in-memory ingestor (no Memgraph), so it is collected under
+# (H) `pytest -m "not integration"` and its coverage counts toward SonarCloud. The
+# (H) integration suite (test_rust_cpp_flow_e2e.py) asserts the same behavior e2e.
+
+_LANG_BY_FILE = {"main.rs": "flow_rs", "main.cpp": "flow_cpp"}
+
+
+class _RecordingIngestor:
+    # (H) Structural IngestorProtocol stand-in that records FLOWS_TO relationships; the
+    # (H) query-side methods are no-ops (a single fresh project needs no rehydration).
+    def __init__(self) -> None:
+        self.rels: list[
+            tuple[
+                tuple[str, str, PropertyValue],
+                str,
+                tuple[str, str, PropertyValue],
+                PropertyDict,
+            ]
+        ] = []
+
+    def ensure_node_batch(self, label: str, properties: PropertyDict) -> None:
+        pass
+
+    def ensure_relationship_batch(
+        self,
+        from_spec: tuple[str, str, PropertyValue],
+        rel_type: str,
+        to_spec: tuple[str, str, PropertyValue],
+        properties: PropertyDict | None = None,
+    ) -> None:
+        self.rels.append((from_spec, rel_type, to_spec, properties or {}))
+
+    def flush_all(self) -> None:
+        pass
+
+    def execute_write(self, query: str, params: PropertyDict | None = None) -> None:
+        pass
+
+    def fetch_all(
+        self, query: str, params: PropertyDict | None = None
+    ) -> list[ResultRow]:
+        return []
+
+
+def _resource_flows(code: str, filename: str, tmp_path: Path) -> list[tuple[str, str]]:
+    project = tmp_path / _LANG_BY_FILE[filename]
+    project.mkdir()
+    (project / filename).write_text(code, encoding="utf-8")
+    parsers, queries = load_parsers()
+    ingestor = _RecordingIngestor()
+    GraphUpdater(
+        ingestor=ingestor,
+        repo_path=project,
+        parsers=parsers,
+        queries=queries,
+        capture=resolve_capture([cs.CaptureGroup.IO.value]),
+        skip_embeddings=True,
+    ).run()
+    out: list[tuple[str, str]] = []
+    for from_spec, rel_type, to_spec, props in ingestor.rels:
+        if (
+            rel_type == cs.RelationshipType.FLOWS_TO
+            and props.get("kind") == FlowKind.RESOURCE.value
+        ):
+            out.append((str(from_spec[2]), str(to_spec[2])))
+    return out
+
+
+def test_rust_env_var_to_println(tmp_path: Path) -> None:
+    flows = _resource_flows(
+        "fn boot() {\n"
+        '    let secret = std::env::var("SECRET").unwrap();\n'
+        '    println!("{}", secret);\n'
+        "}\n",
+        "main.rs",
+        tmp_path,
+    )
+    assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") in flows
+
+
+def test_rust_inlined_env_in_println(tmp_path: Path) -> None:
+    flows = _resource_flows(
+        'fn boot() {\n    println!("{}", std::env::var("SECRET").unwrap());\n}\n',
+        "main.rs",
+        tmp_path,
+    )
+    assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") in flows
+
+
+def test_rust_untainted_println_no_flow(tmp_path: Path) -> None:
+    flows = _resource_flows(
+        'fn boot() {\n    println!("hello");\n}\n',
+        "main.rs",
+        tmp_path,
+    )
+    assert flows == []
+
+
+def test_cpp_getenv_to_cout(tmp_path: Path) -> None:
+    flows = _resource_flows(
+        "#include <iostream>\n"
+        "#include <cstdlib>\n"
+        "void boot() {\n"
+        '    const char* secret = getenv("SECRET");\n'
+        "    std::cout << secret;\n"
+        "}\n",
+        "main.cpp",
+        tmp_path,
+    )
+    assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") in flows
+
+
+def test_cpp_inlined_getenv_in_cout(tmp_path: Path) -> None:
+    flows = _resource_flows(
+        "#include <iostream>\n"
+        "#include <cstdlib>\n"
+        "void boot() {\n"
+        '    std::cout << getenv("SECRET");\n'
+        "}\n",
+        "main.cpp",
+        tmp_path,
+    )
+    assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") in flows
+
+
+def test_cpp_untainted_cout_no_flow(tmp_path: Path) -> None:
+    flows = _resource_flows(
+        '#include <iostream>\nvoid boot() {\n    std::cout << "hello";\n}\n',
+        "main.cpp",
+        tmp_path,
+    )
+    assert flows == []

--- a/codebase_rag/tests/unit/test_rust_cpp_flow_unit.py
+++ b/codebase_rag/tests/unit/test_rust_cpp_flow_unit.py
@@ -100,6 +100,19 @@ def test_rust_inlined_env_in_println(tmp_path: Path) -> None:
     assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") in flows
 
 
+def test_rust_tainted_path_name_no_over_taint(tmp_path: Path) -> None:
+    flows = _resource_flows(
+        "fn boot() {\n"
+        '    let env = std::env::var("SECRET").unwrap();\n'
+        '    println!("{}", std::env::var("CLEAN").unwrap());\n'
+        "}\n",
+        "main.rs",
+        tmp_path,
+    )
+    assert ("resource::ENV::CLEAN", "resource::STDOUT::<dynamic>") in flows
+    assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") not in flows
+
+
 def test_rust_untainted_println_no_flow(tmp_path: Path) -> None:
     flows = _resource_flows(
         'fn boot() {\n    println!("hello");\n}\n',

--- a/codebase_rag/tests/unit/test_rust_cpp_flow_unit.py
+++ b/codebase_rag/tests/unit/test_rust_cpp_flow_unit.py
@@ -113,6 +113,18 @@ def test_rust_tainted_path_name_no_over_taint(tmp_path: Path) -> None:
     assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") not in flows
 
 
+def test_rust_inline_format_capture_to_println(tmp_path: Path) -> None:
+    flows = _resource_flows(
+        "fn boot() {\n"
+        '    let secret = std::env::var("SECRET").unwrap();\n'
+        '    println!("{secret}");\n'
+        "}\n",
+        "main.rs",
+        tmp_path,
+    )
+    assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") in flows
+
+
 def test_rust_untainted_println_no_flow(tmp_path: Path) -> None:
     flows = _resource_flows(
         'fn boot() {\n    println!("hello");\n}\n',

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.342"
+version = "0.0.344"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Extends FLOWS_TO taint tracking (issue #714 follow-up) to the two remaining non-Python sink shapes: Rust `println!` macros and C++ `std::cout << x` stream insertions. Previously the lean flow walk only followed plain call sinks, so a tainted value reaching a macro or stream sink emitted no FLOWS_TO edge even though the io walk already recognized those sinks.

## What changed
- **`_FlowCtx`** now carries `macro_sinks`/`stream_sinks` (from `IO_MACRO_SINKS`/`IO_STREAM_SINKS`).
- **`_apply_js_leaf`** gained a `macro_type` branch (`_flow_macro`) and a `stream_sink_type` branch (`_flow_stream`).
  - Rust: a tainted local used as a bare identifier token, or a read source inlined as a scoped call in the flattened macro body, flows to the STDOUT sink.
  - C++: walks the left-associative `<<` chain to its base (cout/cerr) and flows the taint of every inserted operand.
- **`_js_match_sink`** now honours the descriptor `scope_separator`, so Rust `use std::env; env::var` resolves like the io walk (parity with `_resolve_sink`).
- **`_lean_bind`** now binds Rust `let` (`pattern` field) and C++ `int x = ...` (`declarator` field, unwrapped through pointer/reference declarators via the promoted `cpp_declarator_name`) locals.
- **`_js_expr_taint`** unwraps method chains (`env::var("X").unwrap()`) down the receiver spine when the receiver is itself a call.
- **DRY:** the token-tree call reconstruction and arg0-string extraction moved to shared `io_access/extract.py` helpers (`iter_token_tree_calls`, `first_token_arg_string`), reused by both the io and flow walks.

## Tests (RED → GREEN)
- `test_rust_cpp_flow_e2e.py` (6 integration): Rust env→println (variable + inlined), C++ getenv→cout (variable + inlined), and untainted-no-flow for each.
- `test_rust_cpp_flow_unit.py` (6 fast unit, non-integration) mirror the same, driving the real GraphUpdater with a recording ingestor so coverage counts toward SonarCloud.

Full flow + io integration suite: 273 passed. Non-integration suite: 4936 passed.