### PR TITLE
ci(sonarcloud): raise job timeout to 30 minutes

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -14,7 +14,7 @@ jobs:
     name: SonarCloud Analysis
     if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.347"
+version = "0.0.348"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
The SonarCloud Analysis job has a 15 minute `timeout-minutes` cap, and the coverage test step (`pytest -n auto -m "not integration" --cov`) now exceeds it, so the job is CANCELLED on every run. The last several runs on `main` were all cancelled this way, which means no analysis or coverage report ever reaches SonarCloud.

This bumps the job timeout to 30 minutes so the coverage run and scan can complete.