### PR TITLE
fix(csharp): discover .slnx solutions and surface Roslyn frontend failures

### DIFF
--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -52,6 +52,13 @@ CSHARP_FRONTEND_PARSE_FAILED = (
     "C# Roslyn frontend produced no parseable JSON; using tree-sitter.\n"
     "stdout: {stdout}\nstderr: {stderr}"
 )
+CSHARP_FRONTEND_RUN_FAILED = (
+    "C# Roslyn frontend tool did not finish ({error}); using tree-sitter"
+)
+CSHARP_FRONTEND_NO_FACTS = (
+    "C# Roslyn frontend produced no facts; every join falls back to "
+    "tree-sitter. Tool diagnostics:\n{stderr}"
+)
 GRAPH_ALREADY_IN_SYNC = (
     "Knowledge graph already in sync (hash cache matches every file). Skipping passes."
 )

--- a/codebase_rag/parsers/csharp_frontend/frontend.py
+++ b/codebase_rag/parsers/csharp_frontend/frontend.py
@@ -94,16 +94,19 @@ def _project_candidates(repo_path: Path) -> list[Path]:
     def not_ignored(p: Path) -> bool:
         return not any(part in _IGNORE_DIRS for part in p.relative_to(repo_path).parts)
 
-    slns = sorted(
-        (p for p in repo_path.rglob("*.sln") if not_ignored(p)),
-        key=lambda p: len(str(p)),
-    )
-    if slns:
-        return slns
-    return sorted(
-        (p for p in repo_path.rglob("*.csproj") if not_ignored(p)),
-        key=lambda p: len(str(p)),
-    )
+    def shortest_first(pattern: str) -> list[Path]:
+        return sorted(
+            (p for p in repo_path.rglob(pattern) if not_ignored(p)),
+            key=lambda p: len(str(p)),
+        )
+
+    # (H) Both solution formats count: repos migrated to the XML format ship a
+    # (H) .slnx and no .sln (e.g. Polly), and missing it degrades the whole run
+    # (H) to the facts of one fallback csproj.
+    for pattern in ("*.sln", "*.slnx", "*.csproj"):
+        if candidates := shortest_first(pattern):
+            return candidates
+    return []
 
 
 def find_csharp_project(repo_path: Path) -> Path | None:
@@ -217,7 +220,7 @@ def _parse_payload(stdout: str, stderr: str = "") -> CSharpSemanticFacts:
             ls.CSHARP_FRONTEND_PARSE_FAILED.format(stdout=stdout, stderr=stderr)
         )
         return _empty_facts()
-    return CSharpSemanticFacts(
+    facts = CSharpSemanticFacts(
         base_kinds={
             (type_fact["file"], int(type_fact["line"])): _base_kinds(
                 type_fact.get("bases", [])
@@ -251,6 +254,12 @@ def _parse_payload(stdout: str, stderr: str = "") -> CSharpSemanticFacts:
             for query in payload.get("queries", [])
         ],
     )
+    if not any(facts) and stderr.strip():
+        # (H) A well-formed but entirely empty payload means the workspace load
+        # (H) went wrong (SDK pin mismatch, unloadable solution) -- surface the
+        # (H) tool's diagnostics instead of looking identical to success.
+        logger.warning(ls.CSHARP_FRONTEND_NO_FACTS.format(stderr=stderr.strip()))
+    return facts
 
 
 def _base_kinds(bases: list[dict[str, str]]) -> dict[str, str]:
@@ -281,6 +290,7 @@ def run_csharp_frontend(repo_path: Path) -> CSharpSemanticFacts:
         return _empty_facts()
     dll = _build_tool(dotnet)
     if dll is None:
+        logger.warning(ls.CSHARP_FRONTEND_BUILD_FAILED)
         return _empty_facts()
     _restore(dotnet, project)
     try:
@@ -296,6 +306,7 @@ def run_csharp_frontend(repo_path: Path) -> CSharpSemanticFacts:
                 "CGR_IGNORE_DIRS": ",".join(sorted(cs.IGNORE_PATTERNS)),
             },
         )
-    except (subprocess.SubprocessError, OSError):
+    except (subprocess.SubprocessError, OSError) as error:
+        logger.warning(ls.CSHARP_FRONTEND_RUN_FAILED.format(error=error))
         return _empty_facts()
     return _parse_payload(proc.stdout, proc.stderr)

--- a/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
@@ -29,19 +29,25 @@ public static class Frontend
         using var workspace = MSBuildWorkspace.Create();
         // A failed reference or an unloadable project must not abort the whole run;
         // degrade to whatever loaded and let the Python side fall back per-fact.
-        workspace.WorkspaceFailed += (_, e) =>
+        // Hard failures always reach stderr (capped) so a zero-fact run carries
+        // its cause; the full stream stays behind CGR_FE_DEBUG.
+        var failures = 0;
+        const int maxFailureLines = 5;
+        using var failedHandler = workspace.RegisterWorkspaceFailedHandler(e =>
         {
-            if (debug)
+            var hard = e.Diagnostic.Kind == WorkspaceDiagnosticKind.Failure;
+            if (hard)
+            {
+                failures++;
+            }
+            if (debug || (hard && failures <= maxFailureLines))
             {
                 Console.Error.WriteLine($"[WorkspaceFailed] {e.Diagnostic.Kind}: {e.Diagnostic.Message}");
             }
-        };
+        });
 
         var projects = await LoadProjectsAsync(workspace, projectOrSolution, rootFull);
-        if (debug)
-        {
-            Console.Error.WriteLine($"[projects] {projects.Count}");
-        }
+        Console.Error.WriteLine($"[projects] {projects.Count} loaded, {failures} workspace failure(s)");
 
         var collector = new FactCollector(rootFull, IgnoredDirs());
         foreach (var project in projects)
@@ -393,7 +399,8 @@ public static class Frontend
         }
         try
         {
-            if (input.EndsWith(".sln", StringComparison.OrdinalIgnoreCase))
+            if (input.EndsWith(".sln", StringComparison.OrdinalIgnoreCase)
+                || input.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase))
             {
                 var solution = await workspace.OpenSolutionAsync(input);
                 return solution.Projects.ToList();
@@ -403,24 +410,25 @@ public static class Frontend
         }
         catch (Exception ex)
         {
-            if (Environment.GetEnvironmentVariable("CGR_FE_DEBUG") == "1")
-            {
-                Console.Error.WriteLine($"[LoadProjects] {input}: {ex.Message}");
-            }
+            // Always on stderr: a load failure otherwise degrades the whole run
+            // to zero facts with no visible cause.
+            Console.Error.WriteLine($"[LoadProjects] {input}: {ex.Message}");
             return new List<Project>();
         }
     }
 
     private static string? FindProjectOrSolution(string rootFull)
     {
-        var sln = Directory.EnumerateFiles(rootFull, "*.sln", SearchOption.AllDirectories)
-            .OrderBy(p => p.Length).FirstOrDefault();
-        if (sln is not null)
+        foreach (var pattern in new[] { "*.sln", "*.slnx", "*.csproj" })
         {
-            return sln;
+            var found = Directory.EnumerateFiles(rootFull, pattern, SearchOption.AllDirectories)
+                .OrderBy(p => p.Length).FirstOrDefault();
+            if (found is not null)
+            {
+                return found;
+            }
         }
-        return Directory.EnumerateFiles(rootFull, "*.csproj", SearchOption.AllDirectories)
-            .OrderBy(p => p.Length).FirstOrDefault();
+        return null;
     }
 
     private static HashSet<string> IgnoredDirs()

--- a/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
@@ -35,12 +35,11 @@ public static class Frontend
         const int maxFailureLines = 5;
         using var failedHandler = workspace.RegisterWorkspaceFailedHandler(e =>
         {
+            // The handler fires from parallel project loads, so the counter
+            // must be atomic for the cap and the summary line to be exact.
             var hard = e.Diagnostic.Kind == WorkspaceDiagnosticKind.Failure;
-            if (hard)
-            {
-                failures++;
-            }
-            if (debug || (hard && failures <= maxFailureLines))
+            var count = hard ? Interlocked.Increment(ref failures) : 0;
+            if (debug || (hard && count <= maxFailureLines))
             {
                 Console.Error.WriteLine($"[WorkspaceFailed] {e.Diagnostic.Kind}: {e.Diagnostic.Message}");
             }
@@ -419,9 +418,16 @@ public static class Frontend
 
     private static string? FindProjectOrSolution(string rootFull)
     {
+        // Skip candidates under ignored directories (obj/ holds generated
+        // .csproj copies after a restore), matching the Python discovery.
+        var ignored = IgnoredDirs();
         foreach (var pattern in new[] { "*.sln", "*.slnx", "*.csproj" })
         {
             var found = Directory.EnumerateFiles(rootFull, pattern, SearchOption.AllDirectories)
+                .Where(p => !Path.GetRelativePath(rootFull, p)
+                    .Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                    .SkipLast(1)
+                    .Any(ignored.Contains))
                 .OrderBy(p => p.Length).FirstOrDefault();
             if (found is not null)
             {

--- a/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.csproj
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.csproj
@@ -17,8 +17,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Locator" Version="1.7.8" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.11.0" />
+    <!-- 5.0 is the floor for opening .slnx (XML solution format) solutions. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.0.0" />
   </ItemGroup>
 
   <!-- The workspace package pulls a transitive Microsoft.Build.Tasks.Core flagged

--- a/codebase_rag/tests/test_csharp_frontend_wiring.py
+++ b/codebase_rag/tests/test_csharp_frontend_wiring.py
@@ -14,7 +14,10 @@ from codebase_rag.parsers.csharp_frontend import (
     csharp_frontend_available,
     run_csharp_frontend,
 )
-from codebase_rag.parsers.csharp_frontend.frontend import _parse_payload
+from codebase_rag.parsers.csharp_frontend.frontend import (
+    _parse_payload,
+    find_csharp_project,
+)
 from codebase_rag.tests.conftest import get_relationships, run_updater
 
 SKIP = "c_sharp"
@@ -62,6 +65,89 @@ def _has(pairs: set[tuple[str, str]], child_suffix: str, parent_suffix: str) -> 
     return any(
         ch.endswith(child_suffix) and pa.endswith(parent_suffix) for ch, pa in pairs
     )
+
+
+_SLNX = """<Solution>
+  <Project Path="Sample.csproj" />
+</Solution>
+"""
+
+_EMPTY_PAYLOAD = '{"types":[],"calls":[],"partials":[],"queries":[]}'
+
+
+def test_find_csharp_project_discovers_slnx_solution(temp_repo: Path) -> None:
+    # (H) Repos migrated to the XML solution format ship a .slnx and no .sln
+    # (H) (e.g. Polly); missing it silently degrades hybrid to one csproj.
+    root = temp_repo / "slnxroot"
+    _write_project(root)
+    (root / "Sample.slnx").write_text(_SLNX, encoding="utf-8")
+
+    found = find_csharp_project(root)
+
+    assert found is not None
+    assert found.name == "Sample.slnx"
+
+
+def test_parse_payload_warns_with_tool_stderr_when_facts_empty() -> None:
+    # (H) A zero-fact run (SDK pin mismatch, unloadable solution) must surface
+    # (H) the tool's stderr diagnostics instead of looking identical to success.
+    from loguru import logger
+
+    records: list[str] = []
+    sink_id = logger.add(records.append, level="WARNING")
+    try:
+        facts = _parse_payload(_EMPTY_PAYLOAD, stderr="[projects] 0")
+    finally:
+        logger.remove(sink_id)
+
+    assert facts.base_kinds == {}
+    assert any("[projects] 0" in r for r in records), records
+
+
+def test_parse_payload_stays_quiet_when_facts_present() -> None:
+    from loguru import logger
+
+    payload = json.dumps(
+        {"types": [{"file": "F.cs", "line": 3, "name": "B", "bases": []}]}
+    )
+    records: list[str] = []
+    sink_id = logger.add(records.append, level="WARNING")
+    try:
+        _parse_payload(payload, stderr="[projects] 1")
+    finally:
+        logger.remove(sink_id)
+
+    assert not records, records
+
+
+def test_roslyn_tool_opens_slnx_solution(temp_repo: Path) -> None:
+    if not csharp_frontend_available():
+        pytest.skip("dotnet not available")
+    # (H) Environment self-gate on a sibling csproj-only project: only when the
+    # (H) plain path provably works may the .slnx path be required to work too,
+    # (H) so a .slnx regression cannot hide behind the skip.
+    plain = temp_repo / "plainproj"
+    _write_project(plain)
+    if not run_csharp_frontend(plain).base_kinds:
+        pytest.skip("Roslyn frontend could not build/restore in this environment")
+
+    # (H) Two projects under one .slnx: the csproj fallback loads exactly one of
+    # (H) them, so facts from BOTH prove the solution itself was opened.
+    root = temp_repo / "slnxproj"
+    root.mkdir()
+    for member in ("A", "B"):
+        sub = root / member
+        _write_project(sub)
+        (sub / "Sample.csproj").rename(sub / f"{member}.csproj")
+    (root / "Two.slnx").write_text(
+        '<Solution>\n  <Project Path="A/A.csproj" />\n'
+        '  <Project Path="B/B.csproj" />\n</Solution>\n',
+        encoding="utf-8",
+    )
+
+    fact_files = {file for file, _ in run_csharp_frontend(root).base_kinds}
+    assert any(f.startswith("A/") for f in fact_files), fact_files
+    assert any(f.startswith("B/") for f in fact_files), fact_files
 
 
 def test_parse_payload_drops_conflicting_duplicate_simple_names() -> None:


### PR DESCRIPTION
## Problem

Running the C# hybrid frontend on Polly produced **zero Roslyn facts, silently**: scores were byte-identical to pure tree-sitter and nothing in the logs said why. Three defects stacked:

1. **`.slnx` solutions were never discovered.** Polly migrated to the XML solution format (`Polly.slnx`, no `.sln`), so `find_csharp_project` fell back to a single `.csproj` and the tool loaded one project instead of the whole solution. Additionally, Roslyn 4.x cannot open `.slnx` at all ("No file format header found"); Microsoft.CodeAnalysis 5.0.0 is the floor.
2. **A repo `global.json` SDK pin mismatch loads 0 projects.** Polly pins an SDK patch version newer than the installed one; MSBuildWorkspace then loads nothing and emits an empty (but well-formed) payload.
3. **Every failure path was silent.** Workspace diagnostics were gated behind `CGR_FE_DEBUG`, Python ignored the tool's stderr whenever the JSON parsed, and both the build-failure and subprocess-exception paths returned empty facts without a log line.

## Fix

- `find_csharp_project` discovers `*.sln`, then `*.slnx`, then `*.csproj` (shortest-path-first within each format); the Roslyn tool's `FindProjectOrSolution` mirrors this and `LoadProjectsAsync` routes `.slnx` through `OpenSolutionAsync`.
- Bump `Microsoft.CodeAnalysis.CSharp.Workspaces` / `Microsoft.CodeAnalysis.Workspaces.MSBuild` to 5.0.0 (the `.slnx` floor). Roslyn 5.0 obsoletes the `Workspace.WorkspaceFailed` event, so the tool now uses `RegisterWorkspaceFailedHandler`.
- The tool always reports load health on stderr: hard workspace failures (capped at 5 lines outside debug mode) plus a final `[projects] N loaded, M workspace failure(s)` line; `[LoadProjects]` exceptions are no longer debug-gated.
- Python surfaces every degradation: a well-formed but fact-empty payload logs the tool's stderr as a warning (this is the SDK-pin case), a tool build failure warns instead of silently returning, and a subprocess timeout/OS error warns with the error.

## Validation

RED → GREEN in commit history: `test(csharp)` commit adds the failing tests first (slnx discovery, empty-payload warning with tool stderr, quiet-on-success, and a dotnet-gated end-to-end test that opens a two-project `.slnx` and requires facts from **both** projects, which the single-csproj fallback cannot produce).

On Polly with `CSHARP_FRONTEND=hybrid`, the frontend now loads the full solution: 318 type base lists, 12,447 resolved call sites, 25 partial-type groups merged (previously all zero). Full suite: 5225 passed, 10 skipped.
