### PR TITLE
fix(csharp): recover arity-sibling base types dropped by the self-loop guard

### DIFF
--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -583,19 +583,26 @@ class ClassIngestMixin:
         if entry.language != cs.SupportedLanguage.CSHARP:
             return None
         simple = entry.child_qn.rsplit(cs.SEPARATOR_DOT, 1)[-1]
-        package_prefix = (
-            entry.module_qn.rsplit(cs.SEPARATOR_DOT, 1)[0] + cs.SEPARATOR_DOT
-        )
         type_decls = (NodeType.CLASS, NodeType.INTERFACE, NodeType.ENUM)
-        matches = {
+        candidates = {
             qn
             for qn in self.function_registry.find_ending_with(simple)
             if qn != entry.child_qn
-            and qn.startswith(package_prefix)
             and simple in qn.split(cs.SEPARATOR_DOT)
             and self.function_registry.get(qn) in type_decls
         }
-        return matches.pop() if len(matches) == 1 else None
+        package_prefix = (
+            entry.module_qn.rsplit(cs.SEPARATOR_DOT, 1)[0] + cs.SEPARATOR_DOT
+        )
+        in_package = {qn for qn in candidates if qn.startswith(package_prefix)}
+        if len(in_package) == 1:
+            return in_package.pop()
+        if in_package:
+            return None
+        # (H) No same-package sibling: the pair can span projects (Polly's
+        # (H) legacy BrokenCircuitException<TResult> : the Polly.Core
+        # (H) non-generic), so fall back to a project-wide unique declaration.
+        return candidates.pop() if len(candidates) == 1 else None
 
     def _package_exposes(self, package_qn: str, simple: str, class_qn: str) -> bool:
         # (H) True when the package __init__ makes `simple` an attribute of the

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -488,13 +488,17 @@ class ClassIngestMixin:
         """
         if entry.parent_qn == entry.child_qn:
             # (H) Parse-time resolution can land on the child ITSELF. A
-            # (H) self-edge is never real, so the written base must refer to a
-            # (H) SHADOWED outer name (thrift's `pub enum Error` implementing
-            # (H) the std `Error` trait): when the module-anchored remainder is
-            # (H) a bare single segment it IS the written name and
-            # (H) externalizes. A dotted remainder (a nested child like
-            # (H) SimpleHashMap.Entry) was never written as such; derivation
-            # (H) would be a lie, so no edge.
+            # (H) self-edge is never real. In C# the written base can be an
+            # (H) ARITY sibling (`class Foo : Foo<object>`, a different type
+            # (H) sharing the simple name); recover it before falling back.
+            # (H) Otherwise the written base must refer to a SHADOWED outer
+            # (H) name (thrift's `pub enum Error` implementing the std `Error`
+            # (H) trait): when the module-anchored remainder is a bare single
+            # (H) segment it IS the written name and externalizes. A dotted
+            # (H) remainder (a nested child like SimpleHashMap.Entry) was
+            # (H) never written as such; derivation would be a lie, so no edge.
+            if (sibling := self._csharp_arity_sibling(entry)) is not None:
+                return sibling, False
             self_prefix = f"{entry.module_qn}{cs.SEPARATOR_DOT}"
             if entry.parent_qn.startswith(self_prefix):
                 raw = entry.parent_qn[len(self_prefix) :]
@@ -568,6 +572,30 @@ class ClassIngestMixin:
         ):
             return resolved, False
         return self._externalize_written_base(raw_name, entry.language)
+
+    def _csharp_arity_sibling(self, entry: DeferredInherit) -> str | None:
+        # (H) Only C# overloads type names by generic arity, so only there can a
+        # (H) base that resolves to the declaring type itself legally name a
+        # (H) DIFFERENT type. The sibling conventionally lives beside the child
+        # (H) (Polly's Foo.cs + Foo.TResult.cs), so only a UNIQUE same-simple-name
+        # (H) type declaration under the module's parent package qualifies;
+        # (H) ambiguity keeps the no-edge answer rather than guessing.
+        if entry.language != cs.SupportedLanguage.CSHARP:
+            return None
+        simple = entry.child_qn.rsplit(cs.SEPARATOR_DOT, 1)[-1]
+        package_prefix = (
+            entry.module_qn.rsplit(cs.SEPARATOR_DOT, 1)[0] + cs.SEPARATOR_DOT
+        )
+        type_decls = (NodeType.CLASS, NodeType.INTERFACE, NodeType.ENUM)
+        matches = {
+            qn
+            for qn in self.function_registry.find_ending_with(simple)
+            if qn != entry.child_qn
+            and qn.startswith(package_prefix)
+            and simple in qn.split(cs.SEPARATOR_DOT)
+            and self.function_registry.get(qn) in type_decls
+        }
+        return matches.pop() if len(matches) == 1 else None
 
     def _package_exposes(self, package_qn: str, simple: str, class_qn: str) -> bool:
         # (H) True when the package __init__ makes `simple` an attribute of the

--- a/codebase_rag/tests/test_csharp_inheritance.py
+++ b/codebase_rag/tests/test_csharp_inheritance.py
@@ -126,6 +126,52 @@ public class C : System.Collections.Generic.List<int> { }
     assert not any("<" in parent for _, parent in inherits), inherits
 
 
+def test_nongeneric_base_pair_resolves_to_generic_sibling(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) C# arity overloading: `class Widget : Widget<object>` names a DIFFERENT
+    # (H) type that shares the simple name (the Polly Foo.cs + Foo.TResult.cs
+    # (H) layout). Name resolution lands on the declaring type itself, and the
+    # (H) self-loop guard must recover the sibling instead of dropping the edge.
+    (csharp_project / "Widget.cs").write_text(
+        "namespace N;\npublic class Widget : Widget<object> { }\n",
+        encoding="utf-8",
+    )
+    (csharp_project / "Widget.TResult.cs").write_text(
+        "namespace N;\npublic class Widget<TResult> { }\n",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    inherits = _pairs(mock_ingestor, "INHERITS")
+    assert any(
+        ch.endswith("N.Widget") and "TResult" in pa and pa.endswith("N.Widget")
+        for ch, pa in inherits
+    ), inherits
+
+
+def test_nongeneric_interface_base_pair_resolves_to_generic_sibling(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) Same arity-pair shape on interfaces (Polly's ITtlStrategy :
+    # (H) ITtlStrategy<object>); an interface's bases are INHERITS.
+    (csharp_project / "ITtl.cs").write_text(
+        "namespace N;\npublic interface ITtl : ITtl<object> { }\n",
+        encoding="utf-8",
+    )
+    (csharp_project / "ITtl.TResult.cs").write_text(
+        "namespace N;\npublic interface ITtl<TResult> { }\n",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    inherits = _pairs(mock_ingestor, "INHERITS")
+    assert any(
+        ch.endswith("N.ITtl") and "TResult" in pa and pa.endswith("N.ITtl")
+        for ch, pa in inherits
+    ), inherits
+
+
 def test_enum_underlying_type_is_not_inheritance(
     csharp_project: Path, mock_ingestor: MagicMock
 ) -> None:

--- a/codebase_rag/tests/test_csharp_inheritance.py
+++ b/codebase_rag/tests/test_csharp_inheritance.py
@@ -172,6 +172,34 @@ def test_nongeneric_interface_base_pair_resolves_to_generic_sibling(
     ), inherits
 
 
+def test_arity_pair_across_directories_resolves_project_wide(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) Polly's BrokenCircuitException shape: the generic child lives in one
+    # (H) project directory, the non-generic base in another, so the
+    # (H) same-package tier finds nothing and the project-wide tier must
+    # (H) recover the single other declaration.
+    core = csharp_project / "Core"
+    legacy = csharp_project / "Legacy"
+    core.mkdir()
+    legacy.mkdir()
+    (core / "Broken.cs").write_text(
+        "namespace N.Core;\npublic class Broken { }\n",
+        encoding="utf-8",
+    )
+    (legacy / "Broken.TResult.cs").write_text(
+        "namespace N.Legacy;\npublic class Broken<TResult> : Broken { }\n",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    inherits = _pairs(mock_ingestor, "INHERITS")
+    assert any(
+        "TResult" in ch and ch.endswith("Broken") and ".Core." in pa
+        for ch, pa in inherits
+    ), inherits
+
+
 def test_enum_underlying_type_is_not_inheritance(
     csharp_project: Path, mock_ingestor: MagicMock
 ) -> None:


### PR DESCRIPTION
## Problem

C# overloads type names by generic arity: `public sealed class PredicateBuilder : PredicateBuilder<object>` declares a base that is a **different type sharing the simple name**. cgr's name resolution lands on the declaring type itself, and the deferred-inherits self-loop guard then drops the edge (dotted module-anchored remainder) or externalizes it. On Polly this silently lost 6 INHERITS edges (`RetryStrategyOptions`, `CircuitBreakerStrategyOptions`, `PredicateBuilder`, `BrokenCircuitException<TResult>`, `ITtlStrategy`, `ExecuteParameters`).

## Fix

When a deferred C# base resolves to the child itself, recover the arity sibling before falling back:

1. **Package tier**: a unique other type declaration (Class/Interface/Enum) with the same simple name under the module's parent package — the conventional `Foo.cs` + `Foo.TResult.cs` sibling layout.
2. **Project-wide tier**: only when the package tier finds **zero** candidates (the pair can span projects: Polly's legacy `BrokenCircuitException<TResult> : BrokenCircuitException` inherits from Polly.Core), accept a project-wide unique declaration.

Ambiguity at either tier keeps the no-edge answer rather than guessing, and the recovery is gated to C# — only C# can legally name a different type with the declaring type's own simple name, so other languages keep the existing shadowed-name semantics (e.g. thrift's `pub enum Error` implementing std `Error`).

## Validation

RED → GREEN in commit history: failing tests first for the same-directory pair (class and interface variants), then the cross-directory pair.

On Polly, INHERITS false negatives drop from 5 to 2 (tp 192 → 195, F1 0.9253 → 0.9330). The two remaining misses have distinct root causes, out of scope here:

- `PredicateBuilder<TResult>` is `partial` across two files, so the package tier sees two candidates and correctly refuses to guess; the opt-in Roslyn hybrid frontend's partial-group merge is the semantic answer for that shape.
- `ExecuteParameters<T> : ExecuteParameters` nests both types in one class, so their qualified names collide (the known duplicate-QN limitation; tracked separately).

Full suite: 5224 passed, 10 skipped.
