### PR TITLE
fix(evals): classify C# interface bases as INHERITS in the structure oracle

### DIFF
--- a/codebase_rag/tests/test_csharp_structure_oracle.py
+++ b/codebase_rag/tests/test_csharp_structure_oracle.py
@@ -47,6 +47,7 @@ public class Sample {
 }
 
 public interface IDrawable { void Draw(); }
+public interface IBig : IDrawable { }
 public enum Direction { North, South }
 public struct Vec { public int X; }
 public record Person(string Name);
@@ -161,6 +162,26 @@ def test_oracle_ignores_cgr_ignored_dirs_for_classification(
     rels = {(e.rel_type, e.target_name) for e in oracle.name_edges}
     assert (cs.RelationshipType.INHERITS.value, "Drawable") in rels, rels
     assert (cs.RelationshipType.IMPLEMENTS.value, "Drawable") not in rels, rels
+
+
+def test_oracle_interface_bases_are_inherits(tmp_path: Path) -> None:
+    # (H) An interface extending an interface is INHERITS in cgr's model (the
+    # (H) Java oracle already matches this), so the oracle must classify a base
+    # (H) by the DECLARING type, not by the base's own kind; otherwise every
+    # (H) interface-to-interface edge grades as a false positive (26 on Polly).
+    _require_csharp()
+    project = tmp_path / "csharp_iface_bases"
+    project.mkdir()
+    (project / "I.cs").write_text(
+        "namespace N;\n"
+        "public interface IShape { }\n"
+        "public interface IExtended : IShape { }\n",
+        encoding="utf-8",
+    )
+    oracle = run_csharp_oracle(project)
+    rels = {(e.rel_type, e.target_name) for e in oracle.name_edges}
+    assert (cs.RelationshipType.INHERITS.value, "IShape") in rels, rels
+    assert (cs.RelationshipType.IMPLEMENTS.value, "IShape") not in rels, rels
 
 
 def test_oracle_includes_declarations_in_inactive_if_regions(

--- a/evals/oracles/csharp_oracle/Program.cs
+++ b/evals/oracles/csharp_oracle/Program.cs
@@ -164,6 +164,7 @@ void EmitBases(string rel, string kind, int line, BaseTypeDeclarationSyntax type
     {
         return;
     }
+    var isInterface = typeDecl is InterfaceDeclarationSyntax;
     var source = new NodeRef(kind, rel, line);
     var index = 0;
     foreach (var baseType in typeDecl.BaseList.Types)
@@ -171,17 +172,23 @@ void EmitBases(string rel, string kind, int line, BaseTypeDeclarationSyntax type
         var name = TypeSimpleName(baseType.Type);
         if (!string.IsNullOrEmpty(name))
         {
-            nameEdges.Add(new NameEdge(BaseRel(name, index), source, name));
+            nameEdges.Add(new NameEdge(BaseRel(name, index, isInterface), source, name));
         }
         index++;
     }
 }
 
-// C# permits at most one base class and it must be first; every later base is an
-// interface. For the first base, prefer what the sources declare it as, then
-// fall back to the I-prefix convention cgr uses for external bases.
-string BaseRel(string name, int index)
+// An interface's bases are all inheritance (interface extends interface),
+// matching cgr's model and the Java oracle. Otherwise C# permits at most one
+// base class and it must be first; every later base is an interface. For the
+// first base, prefer what the sources declare it as, then fall back to the
+// I-prefix convention cgr uses for external bases.
+string BaseRel(string name, int index, bool isInterface)
 {
+    if (isInterface)
+    {
+        return RelInherits;
+    }
     if (index > 0)
     {
         return RelImplements;


### PR DESCRIPTION
## Problem

The C# structure oracle classifies every base that is a declared (or I-prefixed) interface as IMPLEMENTS, regardless of the declaring type. cgr's model — shared with the Java oracle ("an interface's superinterfaces -> INHERITS, like cgr") and the parser's documented behavior — is that an **interface's bases are all INHERITS** (interface extends interface).

On Polly this convention mismatch graded every interface-to-interface edge as both a false positive (26 INHERITS "extra") and a false negative (26 IMPLEMENTS "missing"), hiding the parser's real accuracy: it made INHERITS precision look like 0.88 when the edges were correct.

## Fix

`BaseRel` now takes the declaring type into account: an `InterfaceDeclarationSyntax`'s bases are always INHERITS. Class/struct/record classification is unchanged (first base by declared kind, then the I-prefix fallback; later bases IMPLEMENTS).

## Validation

RED → GREEN in commit history: a direct oracle assertion (interface extends interface must be INHERITS, not IMPLEMENTS) plus an interface-extends-interface line added to the shared cgr-vs-oracle fixture, both failing before the fix.

On Polly, IMPLEMENTS becomes perfect (147 tp, 0 fp, 0 fn) and INHERITS false positives drop from 26 to 0 (F1 0.9253 → 0.9864; the remaining 6 fn are parser-side arity-pair drops addressed in #762 and the known duplicate-QN collision). Full suite: 5222 passed, 10 skipped.
