### PR TITLE
feat(docs): generate language and MCP tool tables from code and fix stale guides

### DIFF
--- a/codebase_rag/tests/test_generate_readme.py
+++ b/codebase_rag/tests/test_generate_readme.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.generate_readme import TARGET_FILES, replace_sections, update_file
+
+
+class TestReplaceSections:
+    def test_replaces_marked_section(self) -> None:
+        content = "<!-- SECTION:foo -->\nold\n<!-- /SECTION:foo -->"
+        result = replace_sections(content, {"foo": "new"})
+        assert "new" in result
+        assert "old" not in result
+
+    def test_ignores_unknown_section(self) -> None:
+        content = "<!-- SECTION:foo -->\nold\n<!-- /SECTION:foo -->"
+        result = replace_sections(content, {"bar": "new"})
+        assert result == content
+
+
+class TestDocsTargets:
+    def test_docs_pages_are_generated(self) -> None:
+        assert "README.md" in TARGET_FILES
+        assert "docs/architecture/language-support.md" in TARGET_FILES
+        assert "docs/guide/mcp-server.md" in TARGET_FILES
+
+    def test_update_file_rewrites_sections(self, tmp_path: Path) -> None:
+        page = tmp_path / "page.md"
+        page.write_text(
+            "<!-- SECTION:mcp_tools -->\nstale\n<!-- /SECTION:mcp_tools -->",
+            encoding="utf-8",
+        )
+        update_file(page, {"mcp_tools": "fresh"})
+        updated = page.read_text(encoding="utf-8")
+        assert "fresh" in updated
+        assert "stale" not in updated

--- a/codebase_rag/tests/test_generate_readme.py
+++ b/codebase_rag/tests/test_generate_readme.py
@@ -30,7 +30,19 @@ class TestDocsTargets:
             "<!-- SECTION:mcp_tools -->\nstale\n<!-- /SECTION:mcp_tools -->",
             encoding="utf-8",
         )
-        update_file(page, {"mcp_tools": "fresh"})
+        assert update_file(page, {"mcp_tools": "fresh"}) is True
         updated = page.read_text(encoding="utf-8")
         assert "fresh" in updated
         assert "stale" not in updated
+
+    def test_update_file_skips_write_when_unchanged(self, tmp_path: Path) -> None:
+        page = tmp_path / "page.md"
+        page.write_text(
+            "<!-- SECTION:mcp_tools -->\nfresh\n<!-- /SECTION:mcp_tools -->",
+            encoding="utf-8",
+        )
+        page.chmod(0o444)
+        try:
+            assert update_file(page, {"mcp_tools": "fresh"}) is False
+        finally:
+            page.chmod(0o644)

--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -8,20 +8,24 @@ Code-Graph-RAG uses Tree-sitter for language-agnostic AST parsing with a unified
 
 ## Support Matrix
 
+<!-- SECTION:supported_languages -->
 | Language | Status | Extensions | Functions | Classes/Structs | Modules | Package Detection | Additional Features |
-|----------|--------|------------|-----------|-----------------|---------|-------------------|---------------------|
-| C++ | Fully Supported | .cpp, .h, .hpp, .cc, .cxx, .hxx, .hh, .ixx, .cppm, .ccm | Yes | Yes | Yes | Yes | Constructors, destructors, operator overloading, templates, lambdas, C++20 modules, namespaces, preprocessor macros |
-| Dart | Fully Supported | .dart | Yes | Yes | Yes | Yes | Classes, mixins, extensions, enhanced enums, factory/named constructors, Flutter widgets, package/relative/dart: imports, part directives, pubspec dependencies |
-| Java | Fully Supported | .java | Yes | Yes | Yes | No | Generics, annotations, modern features (records/sealed classes), concurrency, reflection |
-| JavaScript | Fully Supported | .js, .jsx | Yes | Yes | Yes | No | ES6 modules, CommonJS, prototype methods, object methods, arrow functions |
-| Lua | Fully Supported | .lua | Yes | No | Yes | No | Local/global functions, metatables, closures, coroutines |
-| Python | Fully Supported | .py | Yes | Yes | Yes | Yes | Type inference, decorators, nested functions |
-| Rust | Fully Supported | .rs | Yes | Yes | Yes | Yes | impl blocks, associated functions, macro_rules! macros |
-| TypeScript | Fully Supported | .ts, .tsx | Yes | Yes | Yes | No | Interfaces, type aliases, enums, namespaces, ES6/CommonJS modules |
-| C# | In Development | .cs | Yes | Yes | Yes | No | Classes, interfaces, generics (planned) |
-| Go | In Development | .go | Yes | Yes | Yes | No | Methods, type declarations |
-| PHP | Fully Supported | .php | Yes | Yes | Yes | No | Classes, interfaces, traits, enums, namespaces, PHP 8 attributes |
-| Scala | In Development | .scala, .sc | Yes | Yes | Yes | No | Case classes, objects |
+|--------|------|----------|---------|---------------|-------|-----------------|-------------------|
+| C | Fully Supported | .c | ✓ | ✓ | ✓ | ✓ | Functions, structs, unions, enums, preprocessor includes |
+| C# | Fully Supported | .cs | ✓ | ✓ | ✓ | - | Namespaces (block and file-scoped), classes/structs/records/interfaces/enums, generics, inheritance/interfaces/overrides, typed call resolution with overloads, using directives |
+| C++ | Fully Supported | .cpp, .h, .hpp, .cc, .cxx, .hxx, .hh, .ixx, .cppm, .ccm | ✓ | ✓ | ✓ | ✓ | Constructors, destructors, operator overloading, templates, lambdas, C++20 modules, namespaces, preprocessor macros |
+| Dart | Fully Supported | .dart | ✓ | ✓ | ✓ | - | Classes, mixins, extensions, enhanced enums, factory/named constructors, Flutter widgets, package/relative/dart: imports, part directives, pubspec dependencies |
+| Go | Fully Supported | .go | ✓ | ✓ | ✓ | - | Receiver methods with cross-file binding, structs, interfaces, type declarations, function-local types |
+| Java | Fully Supported | .java | ✓ | ✓ | ✓ | - | Generics, annotations, modern features (records/sealed classes), concurrency, reflection |
+| JavaScript | Fully Supported | .js, .jsx | ✓ | ✓ | ✓ | - | ES6 modules, CommonJS, prototype methods, object methods, arrow functions |
+| Lua | Fully Supported | .lua | ✓ | - | ✓ | - | Local/global functions, metatables, closures, coroutines |
+| PHP | Fully Supported | .php | ✓ | ✓ | ✓ | - | Classes, interfaces, traits, enums, namespaces, PHP 8 attributes |
+| Python | Fully Supported | .py | ✓ | ✓ | ✓ | ✓ | Type inference, decorators, nested functions |
+| Rust | Fully Supported | .rs | ✓ | ✓ | ✓ | ✓ | impl blocks, associated functions, macro_rules! macros |
+| TypeScript (TSX) | Fully Supported | .tsx | ✓ | ✓ | ✓ | - | All TypeScript features plus JSX elements and components |
+| TypeScript | Fully Supported | .ts | ✓ | ✓ | ✓ | - | Interfaces, type aliases, enums, namespaces, ES6/CommonJS modules |
+| Scala | In Development | .scala, .sc | ✓ | ✓ | ✓ | - | Case classes, objects |
+<!-- /SECTION:supported_languages -->
 
 ## Language-Agnostic Design
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -44,7 +44,7 @@ description: "Install Code-Graph-RAG and set up Memgraph for multi-language code
 pip install code-graph-rag
 ```
 
-With all Tree-sitter grammars (Python, JS, TS, Rust, Go, Java, Scala, C++, Lua):
+With all Tree-sitter grammars (Python, JS, TS, Rust, Go, Java, Scala, C, C++, Lua, PHP, C#, Dart):
 
 ```bash
 pip install 'code-graph-rag[treesitter-full]'

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -49,7 +49,7 @@ cgr optimize <language> --repo-path /path/to/repo [OPTIONS]
 | `--batch-size` | Override Memgraph flush batch size |
 | `--reference-document` | Path to reference documentation for guided optimization |
 
-Supported languages: `python`, `javascript`, `typescript`, `rust`, `go`, `java`, `scala`, `cpp`
+Supported languages: `python`, `javascript`, `typescript`, `rust`, `go`, `java`, `scala`, `c`, `cpp`
 
 ### `cgr dead-code`
 

--- a/docs/guide/code-optimization.md
+++ b/docs/guide/code-optimization.md
@@ -49,7 +49,7 @@ cgr optimize javascript --repo-path /path/to/frontend \
 
 ## Supported Languages
 
-All supported languages: `python`, `javascript`, `typescript`, `rust`, `go`, `java`, `scala`, `cpp`
+All supported languages: `python`, `javascript`, `typescript`, `rust`, `go`, `java`, `scala`, `c`, `cpp`
 
 ## How It Works
 

--- a/docs/guide/mcp-server.md
+++ b/docs/guide/mcp-server.md
@@ -55,18 +55,23 @@ docker run -p 7687:7687 -p 7444:7444 memgraph/memgraph-platform
 
 ## Available Tools
 
+<!-- SECTION:mcp_tools -->
 | Tool | Description |
-|------|-------------|
-| `list_projects` | List all indexed projects in the knowledge graph database |
-| `delete_project` | Delete a specific project from the knowledge graph database |
-| `wipe_database` | Completely wipe the entire database (cannot be undone) |
-| `index_repository` | Parse and ingest the repository into the knowledge graph |
-| `query_code_graph` | Query the codebase knowledge graph using natural language |
-| `get_code_snippet` | Retrieve source code for a function, class, or method by qualified name |
-| `surgical_replace_code` | Surgically replace an exact code block using diff-match-patch |
-| `read_file` | Read file contents with pagination support |
-| `write_file` | Write content to a file |
-| `list_directory` | List directory contents |
+|----|-----------|
+| `list_projects` | List all indexed projects in the knowledge graph database. Returns a list of project names that have been indexed. |
+| `delete_project` | Delete a specific project from the knowledge graph database. This removes all nodes associated with the project while preserving other projects. Use list_projects first to see available projects. |
+| `wipe_database` | WARNING: Completely wipe the entire database, removing ALL indexed projects. This cannot be undone. Use delete_project for removing individual projects. |
+| `index_repository` | WARNING: Clears all data for the current project including its embeddings. Parse and ingest the repository into the Memgraph knowledge graph. Use update_repository for incremental updates. Only use when explicitly requested. |
+| `update_repository` | Update the repository in the Memgraph knowledge graph without clearing existing data. Use this for incremental updates. |
+| `query_code_graph` | Query the codebase knowledge graph using natural language. Use semantic_search unless you know the exact names of classes/functions you are searching for. Ask questions like 'What functions call UserService.create_user?' or 'Show me all classes that implement the Repository interface'. |
+| `get_code_snippet` | Retrieve source code for a function, class, or method by its qualified name. Returns the source code, file path, line numbers, and docstring. |
+| `surgical_replace_code` | Surgically replace an exact code block in a file using diff-match-patch. Only modifies the exact target block, leaving the rest unchanged. |
+| `read_file` | Read the contents of a file from the project. Supports pagination for large files. |
+| `write_file` | Write content to a file, creating it if it doesn't exist. |
+| `list_directory` | List contents of a directory in the project. |
+| `semantic_search` | Performs a semantic search for functions based on a natural language query describing their purpose, returning a list of potential matches with similarity scores. Requires the 'semantic' extra to be installed. |
+| `ask_agent` | Ask the Code Graph RAG agent a question about the codebase. Uses the full RAG pipeline to analyze the code graph and provide a detailed answer. Use this for general questions about architecture, functionality, and code relationships. |
+<!-- /SECTION:mcp_tools -->
 
 ## Example Usage
 

--- a/scripts/generate_readme.py
+++ b/scripts/generate_readme.py
@@ -33,9 +33,13 @@ def replace_sections(readme_content: str, sections: dict[str, str]) -> str:
     return SECTION_PATTERN.sub(replacer, readme_content)
 
 
-def update_file(path: Path, sections: dict[str, str]) -> None:
+def update_file(path: Path, sections: dict[str, str]) -> bool:
     content = path.read_text(encoding="utf-8")
-    path.write_text(replace_sections(content, sections), encoding="utf-8")
+    new_content = replace_sections(content, sections)
+    if new_content == content:
+        return False
+    path.write_text(new_content, encoding="utf-8")
+    return True
 
 
 def main() -> None:
@@ -44,8 +48,8 @@ def main() -> None:
     sections = generate_all_sections(PROJECT_ROOT)
     for relative_path in TARGET_FILES:
         target = PROJECT_ROOT / relative_path
-        update_file(target, sections)
-        logger.success(f"Updated {target}")
+        if update_file(target, sections):
+            logger.success(f"Updated {target}")
 
 
 if __name__ == "__main__":

--- a/scripts/generate_readme.py
+++ b/scripts/generate_readme.py
@@ -8,6 +8,12 @@ from loguru import logger
 
 PROJECT_ROOT = Path(__file__).parent.parent
 
+TARGET_FILES = (
+    "README.md",
+    "docs/architecture/language-support.md",
+    "docs/guide/mcp-server.md",
+)
+
 SECTION_PATTERN = re.compile(
     r"(<!-- SECTION:(\w+) -->)\n(.*?)(<!-- /SECTION:\2 -->)",
     re.DOTALL,
@@ -27,17 +33,19 @@ def replace_sections(readme_content: str, sections: dict[str, str]) -> str:
     return SECTION_PATTERN.sub(replacer, readme_content)
 
 
+def update_file(path: Path, sections: dict[str, str]) -> None:
+    content = path.read_text(encoding="utf-8")
+    path.write_text(replace_sections(content, sections), encoding="utf-8")
+
+
 def main() -> None:
     from codebase_rag.readme_sections import generate_all_sections
 
-    readme_path = PROJECT_ROOT / "README.md"
-    readme_content = readme_path.read_text(encoding="utf-8")
-
     sections = generate_all_sections(PROJECT_ROOT)
-    updated_content = replace_sections(readme_content, sections)
-
-    readme_path.write_text(updated_content, encoding="utf-8")
-    logger.success(f"Updated {readme_path}")
+    for relative_path in TARGET_FILES:
+        target = PROJECT_ROOT / relative_path
+        update_file(target, sections)
+        logger.success(f"Updated {target}")
 
 
 if __name__ == "__main__":

--- a/scripts/hooks/generate-readme.sh
+++ b/scripts/hooks/generate-readme.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-uv run python scripts/generate_readme.py && git add README.md

--- a/scripts/hooks/generate_readme.py
+++ b/scripts/hooks/generate_readme.py
@@ -5,9 +5,17 @@ import sys
 from pathlib import Path
 
 repo_root = Path(__file__).parent.parent.parent
-readme_path = repo_root / "README.md"
+sys.path.insert(0, str(repo_root))
 
-before = hashlib.sha256(readme_path.read_bytes()).hexdigest()
+from scripts.generate_readme import TARGET_FILES  # noqa: E402
+
+
+def digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+targets = [repo_root / relative for relative in TARGET_FILES]
+before = [digest(target) for target in targets]
 
 result = subprocess.run(
     ["uv", "run", "python", "scripts/generate_readme.py"],
@@ -21,9 +29,13 @@ if result.returncode != 0:
     sys.stderr.write(result.stderr)
     sys.exit(result.returncode)
 
-after = hashlib.sha256(readme_path.read_bytes()).hexdigest()
+changed = [
+    str(target.relative_to(repo_root))
+    for target, old in zip(targets, before, strict=True)
+    if digest(target) != old
+]
 
-if before != after:
-    subprocess.run(["git", "add", "README.md"], cwd=repo_root, check=True)
+if changed:
+    subprocess.run(["git", "add", *changed], cwd=repo_root, check=True)
     sys.exit(1)
 sys.exit(0)

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.348"
+version = "0.0.349"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

The docs site had drifted from the code because its pages are hand maintained while the README tables are generated. This PR makes the two drift prone docs pages generated from the same source as the README and fixes the remaining stale claims by hand.

- `docs/architecture/language-support.md`: the support matrix is now a generated `SECTION:supported_languages` block. It previously showed C# and Go as In Development with ancient feature lists; both are fully supported in code.
- `docs/guide/mcp-server.md`: the tools table is now a generated `SECTION:mcp_tools` block. It previously documented 10 of the 13 tools, omitting `update_repository`, `semantic_search`, and `ask_agent`.
- `scripts/generate_readme.py`: processes a `TARGET_FILES` tuple (README plus the two docs pages) instead of README only.
- `scripts/hooks/generate_readme.py`: hashes and stages every target file, so pre-commit keeps the docs pages in sync exactly like the README.
- `scripts/hooks/generate-readme.sh`: deleted; referenced nowhere.
- `docs/getting-started/installation.md`: grammar list now includes C, PHP, C#, and Dart.
- `docs/guide/code-optimization.md`, `docs/guide/cli-reference.md`: optimize language list now includes `c`, matching the README.

## TDD

RED commit adds failing specs for `TARGET_FILES` and `update_file`; GREEN commit implements them.

## Verification

- Full suite: 5149 passed, 85 skipped (one LLM integration test hit a provider rate limit under parallel load and passes on rerun).
- `uv run mkdocs build --strict` passes and the built HTML contains the generated tables.

