### PR TITLE
fix(csharp): bind local functions to their exact hosting overload via recorded node spans

### DIFF
--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -203,6 +203,9 @@ class ClassIngestMixin:
         child_label: str,
         child_qn: str,
         module_qn: str,
+        fallback_label: str | None = None,
+        fallback_qn: str | None = None,
+        parent_span: FunctionSpanKey | None = None,
     ) -> None: ...
 
     @abstractmethod
@@ -213,7 +216,7 @@ class ClassIngestMixin:
         module_qn: str,
         lang_config: LanguageSpec,
         language: cs.SupportedLanguage | None = None,
-    ) -> tuple[str, str]: ...
+    ) -> tuple[str, str, FunctionSpanKey | None]: ...
 
     @abstractmethod
     def _resolve_cpp_class_qn(
@@ -777,11 +780,16 @@ class ClassIngestMixin:
                 leaf = class_name.rsplit(cs.SEPARATOR_DOUBLE_COLON, 1)[-1]
                 self.simple_name_lookup[leaf].add(class_qn)
 
-        parent_label, parent_qn = self._determine_function_parent(
+        parent_label, parent_qn, parent_span = self._determine_function_parent(
             class_node, class_qn, module_qn, lang_config, language
         )
         self._emit_or_defer_defines(
-            parent_label, parent_qn, node_type, class_qn, module_qn
+            parent_label,
+            parent_qn,
+            node_type,
+            class_qn,
+            module_qn,
+            parent_span=parent_span,
         )
         # (H) For a templated class the canonical node is the template_declaration
         # (H) wrapper, which has no `body` field. Its members -- base clause, fields,

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -994,7 +994,7 @@ class FunctionIngestMixin:
         ):
             return
 
-        parent_type, parent_qn = self._determine_function_parent(
+        parent_type, parent_qn, parent_span = self._determine_function_parent(
             func_node, resolution.qualified_name, module_qn, lang_config, language
         )
         self._emit_or_defer_defines(
@@ -1003,6 +1003,7 @@ class FunctionIngestMixin:
             cs.NodeLabel.FUNCTION,
             resolution.qualified_name,
             module_qn,
+            parent_span=parent_span,
         )
 
         # (H) A Rust closure is a value constructed at its definition site (a `.map`
@@ -1394,6 +1395,7 @@ class FunctionIngestMixin:
         module_qn: str,
         fallback_label: str | None = None,
         fallback_qn: str | None = None,
+        parent_span: FunctionSpanKey | None = None,
     ) -> None:
         # (H) Module nodes always exist, so module-parented edges emit directly.
         # (H) Any other parent may be registered by a later pass (methods land
@@ -1417,6 +1419,7 @@ class FunctionIngestMixin:
                 module_qn=module_qn,
                 fallback_label=fallback_label,
                 fallback_qn=fallback_qn,
+                parent_span=parent_span,
             )
         )
 
@@ -1438,23 +1441,19 @@ class FunctionIngestMixin:
             return None
         return loc.label, loc.qualified_name
 
-    def _unique_overload_variant(self, parent_qn: str) -> tuple[str, NodeType] | None:
-        # (H) Only signature-suffixed registrations (C# overloads) can match:
-        # (H) the leaf must be the guessed name plus a parenthesized suffix, as
-        # (H) a DIRECT child of the guessed scope (the trie is segment-keyed,
-        # (H) so the paren can't be navigated as a prefix), so plain nested
-        # (H) scopes never collide.
-        scope, _, leaf = parent_qn.rpartition(cs.SEPARATOR_DOT)
-        if not scope:
+    def _recorded_parent_at_span(
+        self, entry: DeferredParentLink
+    ) -> FunctionLocation | None:
+        # (H) The span pins the parent NODE, so the location recorded for it in
+        # (H) the class pass carries the exact registered identity, including a
+        # (H) C# overload's signature suffix that the guessed qn cannot (and
+        # (H) that a parameterless sibling overload exactly shadows).
+        if entry.parent_span is None:
             return None
-        wanted = f"{leaf}{cs.CHAR_PAREN_OPEN}"
-        matches = [
-            (qn, node_type)
-            for qn, node_type in self.function_registry.find_with_prefix(scope)
-            if qn.rsplit(cs.SEPARATOR_DOT, 1)[0] == scope
-            and qn.rsplit(cs.SEPARATOR_DOT, 1)[-1].startswith(wanted)
-        ]
-        return matches[0] if len(matches) == 1 else None
+        recorded = self.function_locations.get(entry.parent_span)
+        if recorded is None or recorded.qualified_name not in self.function_registry:
+            return None
+        return recorded
 
     def resolve_deferred_parent_links(self) -> int:
         """Emit deferred non-module DEFINES once every pass has registered.
@@ -1468,25 +1467,18 @@ class FunctionIngestMixin:
             return 0
         emitted = 0
         for entry in deferred:
-            if registered := self.function_registry.get(entry.parent_qn):
+            if recorded := self._recorded_parent_at_span(entry):
+                parent_spec = (
+                    cs.NodeLabel(recorded.label),
+                    cs.KEY_QUALIFIED_NAME,
+                    recorded.qualified_name,
+                )
+                rel_type = entry.rel_type
+            elif registered := self.function_registry.get(entry.parent_qn):
                 parent_spec = (
                     cs.NodeLabel(registered.value),
                     cs.KEY_QUALIFIED_NAME,
                     entry.parent_qn,
-                )
-                rel_type = entry.rel_type
-            elif overload := self._unique_overload_variant(entry.parent_qn):
-                # (H) A C# method registers with an overload-suffixed qn
-                # (H) (`Run(int)`) the structural guess cannot reproduce, so a
-                # (H) local function inside a parameterized method would
-                # (H) otherwise degrade to the module; a UNIQUE suffixed
-                # (H) variant IS that method (ambiguous overloads keep the
-                # (H) module fallback rather than guessing).
-                overload_qn, overload_type = overload
-                parent_spec = (
-                    cs.NodeLabel(overload_type.value),
-                    cs.KEY_QUALIFIED_NAME,
-                    overload_qn,
                 )
                 rel_type = entry.rel_type
             elif (
@@ -1590,10 +1582,10 @@ class FunctionIngestMixin:
         module_qn: str,
         lang_config: LanguageSpec,
         language: cs.SupportedLanguage | None = None,
-    ) -> tuple[str, str]:
+    ) -> tuple[str, str, FunctionSpanKey | None]:
         current = func_node.parent
         if not isinstance(current, Node):
-            return cs.NodeLabel.MODULE, module_qn
+            return cs.NodeLabel.MODULE, module_qn, None
 
         file_path = self.module_qn_to_file_path.get(module_qn)
         while current and current.type not in lang_config.module_node_types:
@@ -1627,6 +1619,7 @@ class FunctionIngestMixin:
                     return (
                         cs.NodeLabel.METHOD,
                         f"{container_qn}{cs.SEPARATOR_DOT}{method_name}",
+                        None,
                     )
                 # (H) Reuse the enclosing function's REGISTERED identity when
                 # (H) its span is claimed: structural re-derivation produces
@@ -1643,7 +1636,11 @@ class FunctionIngestMixin:
                         and recorded.qualified_name != func_qn
                         and recorded.qualified_name in self.function_registry
                     ):
-                        return cs.NodeLabel(recorded.label), recorded.qualified_name
+                        return (
+                            cs.NodeLabel(recorded.label),
+                            recorded.qualified_name,
+                            None,
+                        )
                 resolution = (
                     self._resolve_function_identity(
                         current, module_qn, language, lang_config, file_path
@@ -1658,7 +1655,18 @@ class FunctionIngestMixin:
                 )
                 if not parent_qn or parent_qn == func_qn:
                     break
-                return parent_label, parent_qn
+                # (H) A C# method registers signature-suffixed (`Run(int)`), a
+                # (H) shape structural re-derivation cannot reproduce, and its
+                # (H) parameterless overload sibling exactly SHADOWS the guess.
+                # (H) Methods register in the class pass after this one, so the
+                # (H) guess carries the parent NODE's span for the deferred
+                # (H) resolver to swap in the recorded identity.
+                span = (
+                    function_span_key(module_qn, current)
+                    if language == cs.SupportedLanguage.CSHARP
+                    else None
+                )
+                return parent_label, parent_qn, span
 
             current = current.parent
 
@@ -1669,6 +1677,6 @@ class FunctionIngestMixin:
             mod_parts := rs_utils.build_module_path(func_node)
         ):
             nested = module_qn + cs.SEPARATOR_DOT + cs.SEPARATOR_DOT.join(mod_parts)
-            return cs.NodeLabel.MODULE, nested
+            return cs.NodeLabel.MODULE, nested, None
 
-        return cs.NodeLabel.MODULE, module_qn
+        return cs.NodeLabel.MODULE, module_qn, None

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -1438,6 +1438,24 @@ class FunctionIngestMixin:
             return None
         return loc.label, loc.qualified_name
 
+    def _unique_overload_variant(self, parent_qn: str) -> tuple[str, NodeType] | None:
+        # (H) Only signature-suffixed registrations (C# overloads) can match:
+        # (H) the leaf must be the guessed name plus a parenthesized suffix, as
+        # (H) a DIRECT child of the guessed scope (the trie is segment-keyed,
+        # (H) so the paren can't be navigated as a prefix), so plain nested
+        # (H) scopes never collide.
+        scope, _, leaf = parent_qn.rpartition(cs.SEPARATOR_DOT)
+        if not scope:
+            return None
+        wanted = f"{leaf}{cs.CHAR_PAREN_OPEN}"
+        matches = [
+            (qn, node_type)
+            for qn, node_type in self.function_registry.find_with_prefix(scope)
+            if qn.rsplit(cs.SEPARATOR_DOT, 1)[0] == scope
+            and qn.rsplit(cs.SEPARATOR_DOT, 1)[-1].startswith(wanted)
+        ]
+        return matches[0] if len(matches) == 1 else None
+
     def resolve_deferred_parent_links(self) -> int:
         """Emit deferred non-module DEFINES once every pass has registered.
 
@@ -1455,6 +1473,20 @@ class FunctionIngestMixin:
                     cs.NodeLabel(registered.value),
                     cs.KEY_QUALIFIED_NAME,
                     entry.parent_qn,
+                )
+                rel_type = entry.rel_type
+            elif overload := self._unique_overload_variant(entry.parent_qn):
+                # (H) A C# method registers with an overload-suffixed qn
+                # (H) (`Run(int)`) the structural guess cannot reproduce, so a
+                # (H) local function inside a parameterized method would
+                # (H) otherwise degrade to the module; a UNIQUE suffixed
+                # (H) variant IS that method (ambiguous overloads keep the
+                # (H) module fallback rather than guessing).
+                overload_qn, overload_type = overload
+                parent_spec = (
+                    cs.NodeLabel(overload_type.value),
+                    cs.KEY_QUALIFIED_NAME,
+                    overload_qn,
                 )
                 rel_type = entry.rel_type
             elif (

--- a/codebase_rag/parsers/js_ts/ingest.py
+++ b/codebase_rag/parsers/js_ts/ingest.py
@@ -58,6 +58,7 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
         module_qn: str,
         fallback_label: str | None = None,
         fallback_qn: str | None = None,
+        parent_span: tuple[str, int, int] | None = None,
     ) -> None: ...
 
     @abstractmethod
@@ -78,7 +79,7 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
         module_qn: str,
         lang_config: LanguageSpec,
         language: cs.SupportedLanguage | None = None,
-    ) -> tuple[str, str]: ...
+    ) -> tuple[str, str, tuple[str, int, int] | None]: ...
 
     def _ingest_prototype_inheritance(
         self,
@@ -191,7 +192,7 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
         # (H) already correct there).
         if lang_config is None:
             return None, None
-        parent_label, parent_qn = self._determine_function_parent(
+        parent_label, parent_qn, _ = self._determine_function_parent(
             func_node, child_qn, module_qn, lang_config, language
         )
         if str(parent_label) == cs.NodeLabel.MODULE.value:

--- a/codebase_rag/tests/test_csharp_definitions.py
+++ b/codebase_rag/tests/test_csharp_definitions.py
@@ -185,3 +185,34 @@ public class Sample {
     assert not any(
         label == "Module" for label, _, child in defines if child.endswith("Run.Local")
     ), defines
+
+
+def test_local_function_binds_to_the_hosting_overload(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) Polly's PredicateBuilder shape: a parameterless overload registers
+    # (H) WITHOUT a signature suffix, exactly matching the structural parent
+    # (H) guess, so a local function inside the parameterized overload was
+    # (H) attached to the wrong method. The recorded span identity must win.
+    (csharp_project / "Overloads.cs").write_text(
+        """
+namespace N;
+public class Builder {
+    public int Go() => 1;
+    public int Go(int x) {
+        int Helper() { return x; }
+        return Helper();
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    defines = {
+        (c.args[0][2], c.args[2][2])
+        for c in get_relationships(mock_ingestor, "DEFINES")
+    }
+    parents = {parent for parent, child in defines if child.endswith("Go.Helper")}
+    assert any(p.endswith("N.Builder.Go(int)") for p in parents), defines
+    assert not any(p.endswith("N.Builder.Go") for p in parents), defines

--- a/codebase_rag/tests/test_csharp_definitions.py
+++ b/codebase_rag/tests/test_csharp_definitions.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from codebase_rag.tests.conftest import get_node_names, run_updater
+from codebase_rag.tests.conftest import get_node_names, get_relationships, run_updater
 from codebase_rag.types_defs import NodeType
 
 SKIP = "c_sharp"
@@ -149,3 +149,39 @@ def test_nested_types(csharp_project: Path, mock_ingestor: MagicMock) -> None:
     )
     assert _endswith_any(classes, "N.Outer.Inner")
     assert _endswith_any(methods, "N.Outer.Inner.M")
+
+
+def test_local_function_in_parameterized_method_parents_to_method(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) A parameterized method registers with an overload-suffixed qn
+    # (H) (`Run(int)`), so the local function's structurally re-derived parent
+    # (H) (`Run`) misses the registry and the DEFINES edge silently degrades to
+    # (H) the Module (Polly's BulkheadEngine shape). The recorded method
+    # (H) identity must be reused instead.
+    (csharp_project / "Engine.cs").write_text(
+        """
+namespace N;
+public class Sample {
+    public static int Run(int x) {
+        int Local() { return 1; }
+        return Local();
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    defines = {
+        (c.args[0][0], c.args[0][2], c.args[2][2])
+        for c in get_relationships(mock_ingestor, "DEFINES")
+    }
+    assert any(
+        label == "Method" and parent.endswith("N.Sample.Run(int)")
+        for label, parent, child in defines
+        if child.endswith("Run.Local")
+    ), defines
+    assert not any(
+        label == "Module" for label, _, child in defines if child.endswith("Run.Local")
+    ), defines

--- a/codebase_rag/tests/test_function_ingest.py
+++ b/codebase_rag/tests/test_function_ingest.py
@@ -316,7 +316,7 @@ class TestDetermineFunctionParent:
         assert func_node is not None
 
         lang_config = queries[cs.SupportedLanguage.PYTHON]["config"]
-        parent_type, parent_qn = definition_processor._determine_function_parent(
+        parent_type, parent_qn, _ = definition_processor._determine_function_parent(
             func_node, "proj.module.my_function", "proj.module", lang_config
         )
         assert parent_type == "Module"
@@ -341,7 +341,7 @@ def outer():
         assert inner_func is not None
 
         lang_config = queries[cs.SupportedLanguage.PYTHON]["config"]
-        parent_type, parent_qn = definition_processor._determine_function_parent(
+        parent_type, parent_qn, _ = definition_processor._determine_function_parent(
             inner_func, "proj.module.outer.inner", "proj.module", lang_config
         )
         assert parent_type == "Function"

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -527,6 +527,11 @@ class DeferredParentLink(NamedTuple):
     rel_type: str = RelationshipType.DEFINES.value
     fallback_label: str | None = None
     fallback_qn: str | None = None
+    # (H) Span key of the parent's NODE when the guess qn cannot carry the
+    # (H) registered identity (a C# overload registers signature-suffixed, so
+    # (H) the parameterless sibling exactly shadows the guess); the resolver
+    # (H) prefers the location recorded for this span over the qn match.
+    parent_span: tuple[str, int, int] | None = None
 
 
 # (H) (module_qn, 1-based start line, 0-based start column) of a function

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.348"
+version = "0.0.351"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Problem

Two related C# containment-attribution defects, found by the L1 structure eval on Polly:

1. **Local functions inside parameterized methods anchored to the Module.** A C# method with parameters registers with an overload-suffixed qn (`Run(int)`), which the deferred-DEFINES resolver's structurally re-derived parent guess (`Run`) can never match, so the edge silently degraded to `Module DEFINES Function` (8 sites on Polly, e.g. `BulkheadEngine.SafeRelease`).
2. **When a parameterless overload exists, the local function bound to the wrong method.** `PredicateBuilder<TResult>` declares `HandleInner<TException>()` and `HandleInner<TException>(Func<...>)`; the parameterless overload registers without a suffix, exactly matching the guess, so the local function inside the parameterized overload attached to its sibling.

## Fix

The parent guess now carries the enclosing method **node's span** (C# only; other languages pass `None` and keep their existing behavior). At deferred-resolution time, the location recorded for that span in the class pass — which holds the exact registered identity, signature suffix included — wins over the qn match. This binds the local function to the precise overload that lexically contains it, with no name-based guessing.

Plumbing: `_determine_function_parent` returns the span alongside the label/qn, `DeferredParentLink` gains an optional `parent_span`, and `resolve_deferred_parent_links` prefers the span-recorded identity.

An earlier attempt on this branch used a unique-suffixed-variant registry probe; the full suite caught it rebinding a Java anonymous-class member that must stay module-anchored, so it was replaced by the span mechanism, which cannot cross files or languages by construction.

## Validation

RED → GREEN in commit history for both shapes (module degradation, wrong-overload binding).

On Polly, DEFINES goes from tp 990 / fp 10 / fn 8 to tp 998 / fp 2 / fn 0 (recall 1.0); the 2 remaining false positives are an eval-oracle gap for top-level script functions in `cake.cs` (oracle emits no containment for them), addressed separately. Full suite: 5231 passed, 10 skipped.
