### PR TITLE
fix(evals): anchor top-level C# script functions to the module in the structure oracle

### DIFF
--- a/codebase_rag/tests/test_csharp_structure_oracle.py
+++ b/codebase_rag/tests/test_csharp_structure_oracle.py
@@ -184,6 +184,33 @@ def test_oracle_interface_bases_are_inherits(tmp_path: Path) -> None:
     assert (cs.RelationshipType.IMPLEMENTS.value, "IShape") not in rels, rels
 
 
+def test_oracle_anchors_top_level_functions_to_module(tmp_path: Path) -> None:
+    # (H) A Cake-style build script declares functions at the top level
+    # (H) (local functions of the implicit main); cgr anchors them
+    # (H) Module -> Function, so the oracle must emit the same containment
+    # (H) instead of nothing (which graded cgr's correct edges as false
+    # (H) positives on Polly's cake.cs).
+    _require_csharp()
+    project = tmp_path / "csharp_script"
+    project.mkdir()
+    (project / "build.cs").write_text(
+        "int Twice(int x) => 2 * x;\nSystem.Console.WriteLine(Twice(21));\n",
+        encoding="utf-8",
+    )
+    cgr = extract_cgr_csharp_graph(project, project.name)
+    oracle = run_csharp_oracle(project)
+    wanted = {
+        e
+        for e in oracle.edges
+        if e.rel_type == cs.RelationshipType.DEFINES.value
+        and e.child.kind == cs.NodeLabel.FUNCTION.value
+    }
+    assert {
+        (e.parent.kind, e.parent.start_line, e.child.start_line) for e in wanted
+    } == {(cs.NodeLabel.MODULE.value, 0, 1)}, oracle.edges
+    assert wanted <= cgr.edges, {"oracle_only": wanted - cgr.edges}
+
+
 def test_oracle_includes_declarations_in_inactive_if_regions(
     tmp_path: Path,
 ) -> None:

--- a/evals/oracles/csharp_oracle/Program.cs
+++ b/evals/oracles/csharp_oracle/Program.cs
@@ -224,12 +224,15 @@ void EmitLocalFunction(string rel, LocalFunctionStatementSyntax local)
     var (line, endLine) = Span(local);
     nodes.Add(new Def(KindFunction, rel, line, endLine, local.Identifier.Text));
     var parent = EnclosingCallable(local);
-    if (parent is null)
-    {
-        return;
-    }
-    var parentKind = parent is LocalFunctionStatementSyntax ? KindFunction : KindMethod;
-    var parentRef = new NodeRef(parentKind, rel, Span(parent).Line);
+    // A top-level script function (a Cake build script's helpers) has no
+    // enclosing callable; cgr anchors it to the file module, so mirror that
+    // instead of dropping the containment edge.
+    var parentRef = parent is null
+        ? new NodeRef(KindModule, rel, ModuleLine)
+        : new NodeRef(
+            parent is LocalFunctionStatementSyntax ? KindFunction : KindMethod,
+            rel,
+            Span(parent).Line);
     edges.Add(new Edge(RelDefines, parentRef, new NodeRef(KindFunction, rel, line)));
 }
 


### PR DESCRIPTION
## Problem

The C# structure oracle emits no containment edge for a local function with no enclosing callable — i.e. a top-level script function (Cake build scripts declare their helpers this way). cgr correctly anchors those functions `Module DEFINES Function`, so on Polly the oracle graded cgr's two correct `cake.cs` edges as false positives (the final DEFINES imprecision left after #767).

## Fix

`EmitLocalFunction` anchors a local function with no enclosing callable to the file module (line 0), matching cgr's model, instead of dropping the edge.

## Validation

RED → GREEN in commit history: a Cake-style top-level function fixture asserting the oracle emits exactly `Module(0) DEFINES Function(1)` and that the edge set is a subset of cgr's.

With this and #767, DEFINES on Polly grades 1.0/1.0 (fp 0, fn 0). Full suite: 5222 passed, 10 skipped.
