### PR TITLE
fix(csharp): recover same-scope arity-pair and partial-sibling INHERITS edges

### DIFF
--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -585,8 +585,25 @@ class ClassIngestMixin:
         # (H) ambiguity keeps the no-edge answer rather than guessing.
         if entry.language != cs.SupportedLanguage.CSHARP:
             return None
-        simple = entry.child_qn.rsplit(cs.SEPARATOR_DOT, 1)[-1]
         type_decls = (NodeType.CLASS, NodeType.INTERFACE, NodeType.ENUM)
+        # (H) Same-scope pair (issue #764): when both members share ONE file and
+        # (H) scope, they collide on natural qn and the later one registers as a
+        # (H) DUP_QN_MARKER variant. The variants bucket therefore holds exactly
+        # (H) the same-scope declarations of this simple name; the unique other
+        # (H) type declaration IS the written sibling, whichever of the pair the
+        # (H) child happens to be. More than one other means a 3+ arity family;
+        # (H) refuse rather than guess, matching every other ambiguity tier.
+        natural = entry.child_qn.split(cs.DUP_QN_MARKER, 1)[0]
+        same_scope = [
+            qn
+            for qn in self.function_registry.variants(natural)
+            if qn != entry.child_qn and self.function_registry.get(qn) in type_decls
+        ]
+        if len(same_scope) == 1:
+            return same_scope[0]
+        if same_scope:
+            return None
+        simple = natural.rsplit(cs.SEPARATOR_DOT, 1)[-1]
         candidates = {
             qn
             for qn in self.function_registry.find_ending_with(simple)
@@ -601,6 +618,17 @@ class ClassIngestMixin:
         if len(in_package) == 1:
             return in_package.pop()
         if in_package:
+            # (H) Multiple same-package candidates can still be ONE type: a
+            # (H) `partial` sibling split across files (Polly's PredicateBuilder,
+            # (H) issue #764 shape 3). When every candidate sits in a single
+            # (H) partial group, pick the deterministic representative; genuine
+            # (H) distinct types keep the no-edge answer.
+            groups = {
+                frozenset(self.csharp_partial_groups.get(qn, (qn,)))
+                for qn in in_package
+            }
+            if len(groups) == 1:
+                return min(in_package)
             return None
         # (H) No same-package sibling: the pair can span projects (Polly's
         # (H) legacy BrokenCircuitException<TResult> : the Polly.Core

--- a/codebase_rag/tests/test_csharp_inheritance.py
+++ b/codebase_rag/tests/test_csharp_inheritance.py
@@ -200,6 +200,103 @@ def test_arity_pair_across_directories_resolves_project_wide(
     ), inherits
 
 
+def test_same_file_arity_pair_child_first_recovers_variant_sibling(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) Issue #764 shape 1: both members of the arity pair in ONE file, child
+    # (H) declared first. The two types collide on natural qn (the second gets a
+    # (H) DUP_QN_MARKER variant), the base resolves to the child itself, and the
+    # (H) unique other same-scope variant IS the written sibling.
+    (csharp_project / "Ttl.cs").write_text(
+        "namespace N;\n"
+        "public interface ITtl : ITtl<object> { }\n"
+        "public interface ITtl<TResult> { int GetTtl(); }\n",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    inherits = _pairs(mock_ingestor, "INHERITS")
+    assert any(
+        ch.endswith("N.ITtl") and pa.split("@")[0].endswith("N.ITtl") and pa != ch
+        for ch, pa in inherits
+    ), inherits
+
+
+def test_same_file_arity_pair_generic_child_first_recovers_variant_sibling(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) Issue #764 shape 2 (Polly's ExecuteParameters, nested in a class): the
+    # (H) GENERIC member is the child and declares first (bare qn); the
+    # (H) non-generic base registers second as the variant.
+    (csharp_project / "Exec.cs").write_text(
+        "namespace N;\n"
+        "public class Outer {\n"
+        "    public class ExecuteParameters<T> : ExecuteParameters { }\n"
+        "    public class ExecuteParameters { }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    inherits = _pairs(mock_ingestor, "INHERITS")
+    assert any(
+        ch.endswith("Outer.ExecuteParameters")
+        and pa.split("@")[0].endswith("Outer.ExecuteParameters")
+        and pa != ch
+        for ch, pa in inherits
+    ), inherits
+
+
+def test_same_file_arity_pair_generic_first_still_resolves(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) Declaration-order regression pin: with the generic FIRST (bare qn),
+    # (H) the child registers as the variant and the base already resolves to
+    # (H) the bare sibling at parse time; the fix for the child-first order
+    # (H) must not disturb this.
+    (csharp_project / "Rev.cs").write_text(
+        "namespace N;\n"
+        "public interface IRev<TResult> { int GetIt(); }\n"
+        "public interface IRev : IRev<object> { }\n",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    inherits = _pairs(mock_ingestor, "INHERITS")
+    assert any(
+        ch.split("@")[0].endswith("N.IRev") and pa.endswith("N.IRev") and pa != ch
+        for ch, pa in inherits
+    ), inherits
+
+
+def test_arity_pair_with_partial_generic_sibling_resolves(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) Issue #764 shape 3 (Polly's PredicateBuilder): the non-generic child
+    # (H) sits alone in its file; the generic sibling is `partial` across TWO
+    # (H) other files, so the sibling recovery sees two candidate qns. The
+    # (H) partial group says they are one type; the edge must not be dropped.
+    (csharp_project / "Pred.cs").write_text(
+        "namespace N;\npublic sealed class Pred : Pred<object> { }\n",
+        encoding="utf-8",
+    )
+    (csharp_project / "Pred.TResult.cs").write_text(
+        "namespace N;\npublic partial class Pred<TResult> { public int A() => 1; }\n",
+        encoding="utf-8",
+    )
+    (csharp_project / "Pred.Operators.cs").write_text(
+        "namespace N;\npublic partial class Pred<TResult> { public int B() => 2; }\n",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    inherits = _pairs(mock_ingestor, "INHERITS")
+    assert any(
+        ch.endswith("N.Pred") and ("TResult" in pa or "Operators" in pa)
+        for ch, pa in inherits
+    ), inherits
+
+
 def test_enum_underlying_type_is_not_inheritance(
     csharp_project: Path, mock_ingestor: MagicMock
 ) -> None:

--- a/codebase_rag/tests/test_csharp_structure_oracle.py
+++ b/codebase_rag/tests/test_csharp_structure_oracle.py
@@ -184,6 +184,30 @@ def test_oracle_interface_bases_are_inherits(tmp_path: Path) -> None:
     assert (cs.RelationshipType.IMPLEMENTS.value, "IShape") not in rels, rels
 
 
+def test_same_scope_arity_pair_inherits_grades_clean(tmp_path: Path) -> None:
+    # (H) Issue #764: a same-file arity pair registers the second type as a
+    # (H) DUP_QN_MARKER variant (ITtl@3); the recovered INHERITS edge targets
+    # (H) that variant qn, and the eval's simple-name reduction must strip the
+    # (H) marker or the true edge grades as one fp + one fn against the
+    # (H) oracle's clean base name.
+    _require_csharp()
+    project = tmp_path / "csharp_arity_pair"
+    project.mkdir()
+    (project / "Ttl.cs").write_text(
+        "namespace N;\n"
+        "public interface ITtl : ITtl<object> { }\n"
+        "public interface ITtl<TResult> { int GetTtl(); }\n",
+        encoding="utf-8",
+    )
+    cgr = extract_cgr_csharp_graph(project, project.name)
+    oracle = run_csharp_oracle(project)
+    result = score_name_edge_types(cgr, oracle, ec.INHERITANCE_NAME_EDGE_TYPES)
+    by_label = {row["label"]: row for row in result.rows}
+    row = by_label.get("INHERITS")
+    assert row is not None, by_label
+    assert row["precision"] == 1.0 and row["recall"] == 1.0, row
+
+
 def test_oracle_anchors_top_level_functions_to_module(tmp_path: Path) -> None:
     # (H) A Cake-style build script declares functions at the top level
     # (H) (local functions of the implicit main); cgr anchors them

--- a/evals/cgr_graph.py
+++ b/evals/cgr_graph.py
@@ -427,9 +427,13 @@ def extract_cgr_lang_graph(
             if source is not None:
                 # (H) Base simple name: cgr's resolved target may be a dotted qn
                 # (H) (`module.Base`) or a Rust path (`std::io::Read`), so split on
-                # (H) both `.` and `::`.
+                # (H) both `.` and `::`. A same-scope collision registers the base
+                # (H) as a DUP_QN_MARKER variant (`ITtl@3`, issue #764); the oracle
+                # (H) grades by the written name, so strip the marker.
                 flat = str(to_val).replace(cs.SEPARATOR_DOUBLE_COLON, cs.SEPARATOR_DOT)
-                target_name = flat.rsplit(cs.SEPARATOR_DOT, 1)[-1]
+                target_name = flat.rsplit(cs.SEPARATOR_DOT, 1)[-1].split(
+                    cs.DUP_QN_MARKER, 1
+                )[0]
                 name_edges.add(NameEdge(rel_type, source, target_name))
     return GraphData(nodes=nodes, edges=edges, name_edges=name_edges)
 
@@ -656,7 +660,13 @@ def _to_graph_data(ingestor: _CapturingIngestor, project_name: str) -> GraphData
         if source is None:
             continue
         if rel_type == cs.RelationshipType.INHERITS.value:
-            target = str(to_val).rsplit(cs.SEPARATOR_DOT, 1)[-1]
+            # (H) Same DUP_QN_MARKER strip as the multi-language reducer: a base
+            # (H) registered as a duplicate variant grades by its written name.
+            target = (
+                str(to_val)
+                .rsplit(cs.SEPARATOR_DOT, 1)[-1]
+                .split(cs.DUP_QN_MARKER, 1)[0]
+            )
             name_edges.add(NameEdge(rel_type, source, target))
         elif rel_type == cs.RelationshipType.IMPORTS.value:
             target_path = _internal_target_file(str(to_val), internal_modules)

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.355"
+version = "0.0.357"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

Fixes #764: all three same-scope arity-pair shapes now emit their INHERITS edge.

1. **Same-file pair, child first** (`ITtlStrategy : ITtlStrategy<object>` + `ITtlStrategy<TResult>` in one file): the two types collide on natural qn and the second registers as a `DUP_QN_MARKER` variant. The base resolves to the child itself and the self-loop guard refused the edge. Now the sibling recovery consults `function_registry.variants(natural_qn)` first: the same-scope variants bucket holds exactly the file-scope declarations of that simple name, so the unique other type declaration IS the written sibling, whichever of the pair the child happens to be. A 3+ arity family stays conservatively refused.
2. **Same-file pair nested in a class** (`ExecuteParameters<T> : ExecuteParameters` inside a test class): same mechanism, one nesting level down.
3. **Partial sibling ambiguity** (`PredicateBuilder : PredicateBuilder<object>` where the generic is `partial` across two files): the recovery saw two candidate qns and refused. The existing `csharp_partial_groups` index already knows the parts are ONE type; when every in-package candidate sits in a single partial group, the recovery returns the deterministic representative (`min`).

The recovered edge targets a `@line` variant qn, which leaked into the eval's simple-name reduction (`ExecuteParameters@132` vs the oracle's `ExecuteParameters`), so both cgr-side name-edge reducers in `evals/cgr_graph.py` now strip the marker — the same normalization `dead_code.py` already applies to leaf names.

## Why the reversed order already worked

When the generic declares first it takes the bare qn and the child registers as the variant; the written base then resolves to the bare sibling at parse time and never hits the self-loop guard. A regression pin covers that order.

## Validation

Strict RED → GREEN in commit history: the three shape tests fail on main (`test(csharp): RED ...`), then the parser fix turns them green; the eval-normalization RED (`test(evals): RED ...`) demonstrates the marker leak with the parser fix applied, then the reducer fix turns it green.

Polly L1, both frontends (`treesitter` and `CSHARP_FRONTEND=hybrid`):

| edge | before | after |
|---|---|---|
| INHERITS | tp 221, fp 0, fn 3 | **tp 224, fp 0, fn 0 (p=1.0, r=1.0)** |
| IMPLEMENTS | 1.0 / 1.0 | 1.0 / 1.0 (unchanged) |

Full suite green.
