### PR TITLE
fix(evals): suppress Roslyn error-recovery phantom members in the C# oracle

### DIFF
--- a/codebase_rag/tests/test_csharp_structure_oracle.py
+++ b/codebase_rag/tests/test_csharp_structure_oracle.py
@@ -243,6 +243,31 @@ def test_oracle_suppresses_preprocessor_split_phantom_members(
     assert "Substring" not in names, names
 
 
+def test_oracle_keeps_members_with_warning_diagnostics(tmp_path: Path) -> None:
+    # (H) The phantom filter must key on ERROR severity only: `#warning` inside
+    # (H) a member body attaches a Warning diagnostic to the member's subtree,
+    # (H) and blanket ContainsDiagnostics would wrongly suppress the valid,
+    # (H) compiling member.
+    _require_csharp()
+    project = tmp_path / "csharp_warning_member"
+    project.mkdir()
+    (project / "W.cs").write_text(
+        "namespace N;\n"
+        "public class W\n"
+        "{\n"
+        "    public int Warned()\n"
+        "    {\n"
+        "#warning still to tune\n"
+        "        return 1;\n"
+        "    }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    oracle = run_csharp_oracle(project)
+    names = {n.name for n in oracle.nodes.values()}
+    assert "Warned" in names, names
+
+
 def test_oracle_anchors_top_level_functions_to_module(tmp_path: Path) -> None:
     # (H) A Cake-style build script declares functions at the top level
     # (H) (local functions of the implicit main); cgr anchors them

--- a/codebase_rag/tests/test_csharp_structure_oracle.py
+++ b/codebase_rag/tests/test_csharp_structure_oracle.py
@@ -208,6 +208,41 @@ def test_same_scope_arity_pair_inherits_grades_clean(tmp_path: Path) -> None:
     assert row["precision"] == 1.0 and row["recall"] == 1.0, row
 
 
+def test_oracle_suppresses_preprocessor_split_phantom_members(
+    tmp_path: Path,
+) -> None:
+    # (H) Issue #768: an expression-bodied member whose body is split across
+    # (H) #if/#else has TWO bodies once the directives are neutralized, which is
+    # (H) ill-formed C#; Roslyn ends the member at the first branch's `;` and
+    # (H) error-recovers the second branch's expression as a phantom member
+    # (H) declaration (a Method named `Substring` on Polly's KeyHelper). Error
+    # (H) recovery artifacts are never something cgr should be graded against,
+    # (H) so the oracle must drop them while keeping the real member.
+    _require_csharp()
+    project = tmp_path / "csharp_split_body"
+    project.mkdir()
+    (project / "KeyHelper.cs").write_text(
+        "using System;\n"
+        "namespace N;\n"
+        "public static class KeyHelper\n"
+        "{\n"
+        "    private const int GuidPartLength = 8;\n"
+        "\n"
+        "    public static string GuidPart() =>\n"
+        "#if NET6_0_OR_GREATER\n"
+        "        Guid.NewGuid().ToString()[..GuidPartLength];\n"
+        "#else\n"
+        "        Guid.NewGuid().ToString().Substring(0, GuidPartLength);\n"
+        "#endif\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    oracle = run_csharp_oracle(project)
+    names = {n.name for n in oracle.nodes.values()}
+    assert "GuidPart" in names, names
+    assert "Substring" not in names, names
+
+
 def test_oracle_anchors_top_level_functions_to_module(tmp_path: Path) -> None:
     # (H) A Cake-style build script declares functions at the top level
     # (H) (local functions of the implicit main); cgr anchors them

--- a/evals/README.md
+++ b/evals/README.md
@@ -1000,6 +1000,21 @@ uv run python -m evals.php_l1 --target /path/to/php/repo --project-name myrepo
 
 Validated on `apache/thrift`'s PHP (`lib/php`): 1295 cgr nodes vs 1295 oracle nodes — exact, all kinds 1.0. No cgr gap found.
 
+## L1 (C#) — structure against the Roslyn syntax API
+
+The ninth native oracle is C#, checked against Roslyn's own syntax parser (independent of cgr's tree-sitter frontend and of the opt-in Roslyn semantic frontend).
+
+```bash
+uv run python -m evals.csharp_l1 --target /path/to/csharp/repo --project-name myrepo
+```
+
+- **Oracle** (`evals/oracles/csharp_oracle/`): a .NET program parsing every `.cs` file with `CSharpSyntaxTree` and emitting nodes (`Class`/`Interface`/`Enum`/`Method`/`Function`), containment (`DEFINES`, `DEFINES_METHOD`), and inheritance name-edges. Conventions match cgr's model: interface bases are `INHERITS`, class-declared interface bases are `IMPLEMENTS`, top-level script functions anchor to the file `Module`, and `#if`/`#elif`/`#else` directives are neutralized so every branch parses (cgr has no preprocessor and indexes all branches).
+- **Phantom-member suppression** (issue #768): an expression-bodied member whose body is split across `#if`/`#else` has two bodies once the directives are neutralized, which is ill-formed C#; Roslyn ends the member at the first branch's `;` and error-recovers the second branch's expression as a phantom member declaration. Members carrying parse diagnostics are dropped — real repos compile, so genuine members are diagnostic-free. Calls inside every branch still count (the walk visits the recovered expression's descendants).
+- **Known residual**: on such split members the two parsers' recoveries legitimately disagree — tree-sitter stretches the member's span across both branches and can swallow the next member's attribute into the garbled region. On Polly this leaves 1 member start-line disagreement and 2 span mismatches out of 6,551 nodes; neither view of the ill-formed neutralized source is "correct", so this is documented rather than bent to either parser.
+- **cgr side** (`cgr_graph.extract_cgr_csharp_graph`), output to `csharp_scores.csv` / `csharp_diff.json`.
+
+Validated on `App-vNext/Polly` (~6,550 nodes): nodes/DEFINES/DEFINES_METHOD 0.9998, INHERITS and IMPLEMENTS exact 1.0 (224 and 147 edges, same-scope arity pairs included per #764), spans 0.9997. The residual is exactly the documented preprocessor-split artifact.
+
 ## Latest results (target: `codebase_rag`)
 
 Committed snapshots live in `evals/results/` — `scores.csv` (L1), `diff.json` (L1 per-label missing/extra), `calls_diff.json` (L3 missed edges). Regenerate with the commands above.

--- a/evals/oracles/csharp_oracle/Program.cs
+++ b/evals/oracles/csharp_oracle/Program.cs
@@ -208,6 +208,16 @@ string BaseRel(string name, int index, bool isInterface)
 
 void EmitMember(string rel, MemberDeclarationSyntax member)
 {
+    // A directive-split expression body is ill-formed once the directives are
+    // neutralized (two bodies); Roslyn error-recovers the second branch's
+    // expression as a phantom member declaration (issue #768). A declaration
+    // carrying parse errors is a recovery artifact, never a source fact cgr
+    // should be graded against; real repos compile, so genuine members are
+    // diagnostic-free.
+    if (member.ContainsDiagnostics)
+    {
+        return;
+    }
     var (line, endLine) = Span(member);
     nodes.Add(new Def(KindMethod, rel, line, endLine, MemberName(member)));
     var owner = EnclosingType(member);

--- a/evals/oracles/csharp_oracle/Program.cs
+++ b/evals/oracles/csharp_oracle/Program.cs
@@ -211,10 +211,12 @@ void EmitMember(string rel, MemberDeclarationSyntax member)
     // A directive-split expression body is ill-formed once the directives are
     // neutralized (two bodies); Roslyn error-recovers the second branch's
     // expression as a phantom member declaration (issue #768). A declaration
-    // carrying parse errors is a recovery artifact, never a source fact cgr
+    // carrying parse ERRORS is a recovery artifact, never a source fact cgr
     // should be graded against; real repos compile, so genuine members are
-    // diagnostic-free.
-    if (member.ContainsDiagnostics)
+    // error-free. Warning-severity diagnostics (a `#warning` in the body) are
+    // legal in compiling code and must not suppress the member.
+    if (member.ContainsDiagnostics
+        && member.GetDiagnostics().Any(d => d.Severity == DiagnosticSeverity.Error))
     {
         return;
     }


### PR DESCRIPTION
## What

Fixes #768 with the option the issue recommends (option 2): the C# oracle now drops member declarations that carry parse diagnostics.

An expression-bodied member whose body is split across `#if`/`#else` has two bodies once the oracle's directive neutralization makes every branch parse, which is ill-formed C#. Roslyn ends the member at the first branch's `;` and error-recovers the second branch's expression as a phantom member declaration (`Substring` on Polly's `KeyHelper`, `ExecuteComponent` on `DelegatingComponent`). Those phantoms are recovery artifacts, never source facts cgr should be graded against; real repos compile, so genuine members are diagnostic-free. Calls inside every branch still count — the walk visits the recovered expression's descendants, so invocation parity with cgr (which indexes all branches) is preserved.

## Known residual, documented not bent

On the same split members the two parsers' recoveries legitimately disagree: tree-sitter stretches the member's span across both branches and swallows the next member's attribute into the garbled region (verified in the AST: the `arrow_expression_clause` runs to the attribute line and the following `method_declaration` starts past it). Neither view of ill-formed neutralized source is "correct", so the residual — on Polly, 1 member start-line disagreement and 2 span mismatches out of 6,551 nodes — is documented in the README rather than bent to either parser.

## Polly L1

| label | before | after |
|---|---|---|
| Method nodes | tp 5549, fp 1, fn 3 | tp 5549, fp 1, fn 1 |
| DEFINES_METHOD | tp 5549, fp 1, fn 3 | tp 5549, fp 1, fn 1 |

Everything else (Class/Interface/Enum/Function nodes, DEFINES, INHERITS, IMPLEMENTS) is exact 1.0.

Also adds the missing README section for the C# L1 eval (every other language already had one), covering the oracle's conventions, the phantom suppression, and the residual.

## Validation

RED → GREEN in commit history: the phantom-member fixture test fails on main, then the `ContainsDiagnostics` filter turns it green. Full suite: 5303 passed.
