### PR TITLE
fix(providers): register the opus 4.8 1M context window

### DIFF
--- a/codebase_rag/constants/providers.py
+++ b/codebase_rag/constants/providers.py
@@ -84,6 +84,7 @@ DEFAULT_CONTEXT_WINDOW = 200_000
 MODEL_CONTEXT_WINDOWS: dict[str, int] = {
     "MiniMax-M3": 1_000_000,
     "MiniMax-M2.7": 204_800,
+    "claude-opus-4-8": 1_000_000,
     "claude-opus-4-7": 1_000_000,
     "claude-opus-4-6": 200_000,
     "claude-opus-4-5": 200_000,

--- a/codebase_rag/tests/test_provider_classes.py
+++ b/codebase_rag/tests/test_provider_classes.py
@@ -267,6 +267,18 @@ class TestAnthropicProvider:
         assert settings_arg["anthropic_cache_tool_definitions"] is True
         assert settings_arg["anthropic_cache_messages"] is True
 
+    @pytest.mark.parametrize(
+        ("model_id", "context_window"),
+        [("claude-opus-4-8", 1_000_000), ("claude-opus-4-7", 1_000_000)],
+    )
+    def test_anthropic_context_windows(
+        self, model_id: str, context_window: int
+    ) -> None:
+        # (H) The token gauge looks the bare model id up in
+        # (H) MODEL_CONTEXT_WINDOWS; a missing entry silently falls back to
+        # (H) 200k and misreports usage for 1M-context models (issue #705).
+        assert MODEL_CONTEXT_WINDOWS[model_id] == context_window
+
     def test_anthropic_api_key_from_env(self) -> None:
         with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "env-key"}):
             provider = AnthropicProvider()

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.358"
+version = "0.0.360"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #705.

The token gauge looks the active model's bare id up in MODEL_CONTEXT_WINDOWS and silently falls back to 200k on a miss, so claude-opus-4-8 sessions misreported context usage at 5x the real percentage. Registered at 1,000,000 like claude-opus-4-7.

Tests (RED first): test_anthropic_context_windows pins opus 4.8 and 4.7 at 1M.