### PR TITLE
fix(parsers): compile JS highlights and add Dart highlights so modifiers and decorators populate

### DIFF
--- a/codebase_rag/constants/ast_dart.py
+++ b/codebase_rag/constants/ast_dart.py
@@ -29,6 +29,10 @@ TS_DART_METHOD_SIGNATURE = "method_signature"
 TS_DART_DECLARATION = "declaration"
 TS_DART_FUNCTION_BODY = "function_body"
 
+# (H) `@override`-style metadata: a preceding SIBLING of the (wrapped)
+# (H) signature, not a child, so the highlights walk collects it explicitly.
+TS_DART_ANNOTATION = "annotation"
+
 # (H) Module and import/directive nodes
 TS_DART_PROGRAM = "program"
 TS_DART_IMPORT_OR_EXPORT = "import_or_export"

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -173,6 +173,9 @@ def extract_modifiers_and_decorators(
     if node.parent and node.parent.type in (
         cs.TS_PY_DECORATED_DEFINITION,
         cs.TS_EXPORT_STATEMENT,
+        # (H) Dart wraps a class member's function_signature in a
+        # (H) method_signature that owns the `static` token.
+        cs.TS_DART_METHOD_SIGNATURE,
     ):
         target_node = node.parent
 
@@ -183,6 +186,12 @@ def extract_modifiers_and_decorators(
         or (
             target_node.type == cs.TS_METHOD_DEFINITION
             and curr_sibling.type == cs.TS_DECORATOR
+        )
+        # (H) Dart metadata precedes the signature as annotation siblings.
+        or (
+            target_node.type
+            in (cs.TS_DART_METHOD_SIGNATURE, cs.TS_DART_FUNCTION_SIGNATURE)
+            and curr_sibling.type == cs.TS_DART_ANNOTATION
         )
     ):
         query_nodes.insert(0, curr_sibling)

--- a/codebase_rag/queries/highlights/dart.scm
+++ b/codebase_rag/queries/highlights/dart.scm
@@ -1,12 +1,15 @@
 ; tree-sitter-dart ships no HIGHLIGHTS_QUERY in its pip package, so this
 ; fallback is Dart's only highlights source. Annotations (`@override`,
-; `@deprecated`) are `annotation` nodes; `const` is not a named token kind in
-; this grammar, so it is not listed.
+; `@deprecated`) are `annotation` nodes. `const` and `final` are NAMED nodes
+; (const_builtin/final_builtin), not anonymous keyword tokens: a quoted
+; "const" fails to compile (and one invalid token kills the whole query).
 (annotation) @attribute
+
+(const_builtin) @keyword.modifier
+(final_builtin) @keyword.modifier
 
 [
   "static"
-  "final"
   "abstract"
   "late"
   "external"

--- a/codebase_rag/queries/highlights/dart.scm
+++ b/codebase_rag/queries/highlights/dart.scm
@@ -1,0 +1,16 @@
+; tree-sitter-dart ships no HIGHLIGHTS_QUERY in its pip package, so this
+; fallback is Dart's only highlights source. Annotations (`@override`,
+; `@deprecated`) are `annotation` nodes; `const` is not a named token kind in
+; this grammar, so it is not listed.
+(annotation) @attribute
+
+[
+  "static"
+  "final"
+  "abstract"
+  "late"
+  "external"
+  "covariant"
+  "get"
+  "set"
+] @keyword.modifier

--- a/codebase_rag/queries/highlights/javascript.scm
+++ b/codebase_rag/queries/highlights/javascript.scm
@@ -1,3 +1,7 @@
+; Plain-JS modifier tokens only: public/private/protected/readonly/abstract/
+; declare/override are TypeScript-only node kinds, and one invalid token makes
+; the WHOLE concatenated highlights query fail to compile, silently zeroing
+; modifiers and decorators for the language (issue #525).
 (decorator) @function.decorator
 
 [
@@ -7,11 +11,4 @@
   "static"
   "get"
   "set"
-  "public"
-  "private"
-  "protected"
-  "readonly"
-  "abstract"
-  "declare"
-  "override"
 ] @keyword.modifier

--- a/codebase_rag/tests/test_modifiers_and_decorators.py
+++ b/codebase_rag/tests/test_modifiers_and_decorators.py
@@ -195,3 +195,49 @@ def test_php_multiple_distinct_attributes() -> None:
     lang_queries = queries[cs.SupportedLanguage.PHP]
     _, decorators = extract_modifiers_and_decorators(func_node, lang_queries)
     assert decorators == ["#[Route('/x')]", "#[Deprecated]"]
+
+
+def test_every_language_loads_a_highlights_query() -> None:
+    # (H) A highlights query that fails to compile degrades SILENTLY to None
+    # (H) (a debug log at startup), zeroing modifiers and decorators for the
+    # (H) whole language -- javascript.scm shipped TS-only tokens for months
+    # (H) unnoticed (issue #525). Every parsed language must load one.
+    parsers, queries = load_parsers()
+    missing = [
+        str(lang)
+        for lang, lq in queries.items()
+        if lang in parsers and lq.get(cs.QUERY_HIGHLIGHTS) is None
+    ]
+    assert missing == [], missing
+
+
+def test_js_method_modifiers_and_decorators_captured() -> None:
+    # (H) The JS grammar has no public/private/protected tokens (those are
+    # (H) TS-only); the fallback query must still capture the JS-valid
+    # (H) modifiers and decorators.
+    parsers, queries = load_parsers()
+    code = "class A {\n  @dec\n  static async foo() {}\n}"
+    root = parse_code(code, cs.SupportedLanguage.JS, parsers)
+    method_node = find_first_node_of_type(root, "method_definition")
+    assert method_node is not None
+    lang_queries = queries[cs.SupportedLanguage.JS]
+    modifiers, decorators = extract_modifiers_and_decorators(
+        method_node, lang_queries
+    )
+    assert "static" in modifiers, (modifiers, decorators)
+    assert "async" in modifiers, (modifiers, decorators)
+    assert "@dec" in decorators, (modifiers, decorators)
+
+
+def test_dart_annotations_and_modifiers_captured() -> None:
+    parsers, queries = load_parsers()
+    code = "class A {\n  @override\n  static void foo() {}\n}"
+    root = parse_code(code, cs.SupportedLanguage.DART, parsers)
+    func_node = find_first_node_of_type(root, "function_signature")
+    assert func_node is not None
+    lang_queries = queries[cs.SupportedLanguage.DART]
+    modifiers, decorators = extract_modifiers_and_decorators(
+        func_node, lang_queries
+    )
+    assert "static" in modifiers, (modifiers, decorators)
+    assert "@override" in decorators, (modifiers, decorators)

--- a/codebase_rag/tests/test_modifiers_and_decorators.py
+++ b/codebase_rag/tests/test_modifiers_and_decorators.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from codebase_rag import constants as cs
@@ -80,6 +82,7 @@ def test_fallback_scm_loads_on_import_failure(monkeypatch: pytest.MonkeyPatch) -
     parsers, queries = load_parsers()
 
     real_lang = parsers[cs.SupportedLanguage.PYTHON].language
+    assert real_lang is not None
 
     def mock_import_module(name: str) -> None:
         raise ImportError("Mocked import failure")
@@ -94,6 +97,7 @@ def test_fallback_scm_missing_and_import_fails(monkeypatch: pytest.MonkeyPatch) 
     parsers, queries = load_parsers()
 
     real_lang = parsers[cs.SupportedLanguage.PYTHON].language
+    assert real_lang is not None
 
     def mock_import_module(name: str) -> None:
         raise ImportError("Mocked import failure")
@@ -119,6 +123,7 @@ def test_fallback_scm_read_fails(monkeypatch: pytest.MonkeyPatch) -> None:
     parsers, queries = load_parsers()
 
     real_lang = parsers[cs.SupportedLanguage.PYTHON].language
+    assert real_lang is not None
 
     def mock_import_module(name: str) -> None:
         raise ImportError("Mocked import failure")
@@ -129,7 +134,7 @@ def test_fallback_scm_read_fails(monkeypatch: pytest.MonkeyPatch) -> None:
 
     original_read_text = Path.read_text
 
-    def mock_read_text(self: Path, *args: any, **kwargs: any) -> str:
+    def mock_read_text(self: Path, *args: Any, **kwargs: Any) -> str:
         if "highlights" in str(self) and "python.scm" in str(self):
             raise OSError("Mocked read failure")
         return original_read_text(self, *args, **kwargs)
@@ -221,9 +226,7 @@ def test_js_method_modifiers_and_decorators_captured() -> None:
     method_node = find_first_node_of_type(root, "method_definition")
     assert method_node is not None
     lang_queries = queries[cs.SupportedLanguage.JS]
-    modifiers, decorators = extract_modifiers_and_decorators(
-        method_node, lang_queries
-    )
+    modifiers, decorators = extract_modifiers_and_decorators(method_node, lang_queries)
     assert "static" in modifiers, (modifiers, decorators)
     assert "async" in modifiers, (modifiers, decorators)
     assert "@dec" in decorators, (modifiers, decorators)
@@ -236,8 +239,6 @@ def test_dart_annotations_and_modifiers_captured() -> None:
     func_node = find_first_node_of_type(root, "function_signature")
     assert func_node is not None
     lang_queries = queries[cs.SupportedLanguage.DART]
-    modifiers, decorators = extract_modifiers_and_decorators(
-        func_node, lang_queries
-    )
+    modifiers, decorators = extract_modifiers_and_decorators(func_node, lang_queries)
     assert "static" in modifiers, (modifiers, decorators)
     assert "@override" in decorators, (modifiers, decorators)

--- a/codebase_rag/tests/test_modifiers_and_decorators.py
+++ b/codebase_rag/tests/test_modifiers_and_decorators.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 import pytest
 
 from codebase_rag import constants as cs
@@ -134,10 +132,12 @@ def test_fallback_scm_read_fails(monkeypatch: pytest.MonkeyPatch) -> None:
 
     original_read_text = Path.read_text
 
-    def mock_read_text(self: Path, *args: Any, **kwargs: Any) -> str:
+    def mock_read_text(
+        self: Path, encoding: str | None = None, errors: str | None = None
+    ) -> str:
         if "highlights" in str(self) and "python.scm" in str(self):
             raise OSError("Mocked read failure")
-        return original_read_text(self, *args, **kwargs)
+        return original_read_text(self, encoding=encoding, errors=errors)
 
     monkeypatch.setattr(Path, "read_text", mock_read_text)
 
@@ -208,11 +208,13 @@ def test_every_language_loads_a_highlights_query() -> None:
     # (H) whole language -- javascript.scm shipped TS-only tokens for months
     # (H) unnoticed (issue #525). Every parsed language must load one.
     parsers, queries = load_parsers()
-    missing = [
+    # (H) Iterate parsers, not queries: a language absent from the queries
+    # (H) dict entirely must fail here too, not be skipped.
+    missing = sorted(
         str(lang)
-        for lang, lq in queries.items()
-        if lang in parsers and lq.get(cs.QUERY_HIGHLIGHTS) is None
-    ]
+        for lang in parsers
+        if (lq := queries.get(lang)) is None or lq.get(cs.QUERY_HIGHLIGHTS) is None
+    )
     assert missing == [], missing
 
 

--- a/codebase_rag/tests/test_modifiers_and_decorators.py
+++ b/codebase_rag/tests/test_modifiers_and_decorators.py
@@ -242,3 +242,18 @@ def test_dart_annotations_and_modifiers_captured() -> None:
     modifiers, decorators = extract_modifiers_and_decorators(func_node, lang_queries)
     assert "static" in modifiers, (modifiers, decorators)
     assert "@override" in decorators, (modifiers, decorators)
+
+
+def test_dart_const_and_final_builtins_captured() -> None:
+    # (H) Dart `const`/`final` are NAMED nodes (const_builtin/final_builtin),
+    # (H) not anonymous keyword tokens: a quoted "const" fails to compile and
+    # (H) a quoted "final" compiles but never matches, so both must be
+    # (H) captured via their named forms.
+    parsers, queries = load_parsers()
+    code = "class A {\n  const A();\n}"
+    root = parse_code(code, cs.SupportedLanguage.DART, parsers)
+    ctor_node = find_first_node_of_type(root, "constant_constructor_signature")
+    assert ctor_node is not None
+    lang_queries = queries[cs.SupportedLanguage.DART]
+    modifiers, _ = extract_modifiers_and_decorators(ctor_node, lang_queries)
+    assert "const" in modifiers, modifiers

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.360"
+version = "0.0.362"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.358"
+version = "0.0.360"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #525.

## What was actually missing

The modifier/decorator extraction pipeline this issue asks for already exists end to end: `_create_highlights_query` loads a highlights query per language (pip package `HIGHLIGHTS_QUERY` plus a `queries/highlights/*.scm` fallback), `extract_modifiers_and_decorators` turns `@keyword.modifier` and `@attribute`/`@function.decorator` captures into the `modifiers` and `decorators` node properties, and function/method/class ingestion attaches them. What remained were two silent per-language holes:

- **JavaScript had no highlights query at all.** `javascript.scm` listed TypeScript-only tokens (`public`, `private`, `protected`, `readonly`, `abstract`, `declare`, `override`) that are not node kinds in the JS grammar. One invalid token makes the whole concatenated query fail to compile, and the loader degrades to `None` with only a startup debug log, so JS lost decorators and its real modifiers (`static`, `async`, ...) too.
- **Dart had no highlights source.** The pip package ships no `HIGHLIGHTS_QUERY` and no fallback file existed. Dart also needed two shape rules in the generic walk: a class member's `static` token belongs to the `method_signature` wrapper (not the captured `function_signature`), and `@override`-style metadata precedes the signature as sibling `annotation` nodes.

## Fix

- `javascript.scm` trimmed to JS-valid tokens (`async`, `export`, `default`, `static`, `get`, `set`) plus `(decorator)`.
- New `dart.scm` (annotations + `static`/`final`/`abstract`/`late`/`external`/`covariant`/`get`/`set`).
- `extract_modifiers_and_decorators` promotes a Dart `function_signature` to its wrapping `method_signature` and collects preceding `annotation` siblings.

## Tests (RED first)

- `test_every_language_loads_a_highlights_query` — the loud regression gate: a highlights query that fails to compile can no longer degrade silently for months.
- `test_js_method_modifiers_and_decorators_captured` — `static`/`async`/`@dec` on a JS class method.
- `test_dart_annotations_and_modifiers_captured` — `static`/`@override` on a Dart class method.

With this, all 12 supported languages (plus TSX) load a compiling highlights query and populate the `modifiers`/`decorators` properties, which completes the remaining open sub-issue of #521 (#523 already delivered scope tracking).
