### PR TITLE
fix(csharp): dead-code dogfood round 1 on Polly, 190 false flags down to 23

### DIFF
--- a/codebase_rag/constants/ast_csharp.py
+++ b/codebase_rag/constants/ast_csharp.py
@@ -14,6 +14,7 @@ TS_CSHARP_FILE_SCOPED_NAMESPACE_DECLARATION = "file_scoped_namespace_declaration
 # (H) one. Used to tell a top-level type (default `internal`) from a nested type
 # (H) or member (default `private`) for export detection.
 TS_CSHARP_DECLARATION_LIST = "declaration_list"
+TS_CSHARP_EXPLICIT_INTERFACE_SPECIFIER = "explicit_interface_specifier"
 
 # (H) Type declarations -> Class nodes.
 TS_CSHARP_CLASS_DECLARATION = "class_declaration"

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1935,7 +1935,9 @@ class CallProcessor:
                 # (H) or otherwise yields no name still consumes its arguments through
                 # (H) whatever callable it produced; reference first-party functions
                 # (H) passed to it or dead-code flags every django-style view
-                # (H) decorator wrapper.
+                # (H) decorator wrapper. REFERENCES (not arg_ref_rel) is
+                # (H) deliberate and predates the C# split: with no callee name
+                # (H) there is no invocation to assert, for ANY language.
                 if is_arg_ref_lang:
                     self._ingest_argument_function_references(
                         call_node,

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1899,6 +1899,15 @@ class CallProcessor:
         # (H) EmptyHandler family, 16 dead-code false flags) without the
         # (H) interprocedural callable-param flow, which is untuned for C#.
         is_arg_ref_lang = is_flow_lang or language == cs.SupportedLanguage.CSHARP
+        # (H) A method-group pass is not an invocation: C# records it as
+        # (H) REFERENCES everywhere (CALLS here put 282 phantom edges into the
+        # (H) Polly call graph, retrieval precision 1.0 -> 0.92); flow languages
+        # (H) keep their historical CALLS form for external/builtin callees.
+        arg_ref_rel = (
+            cs.RelationshipType.CALLS
+            if is_flow_lang
+            else cs.RelationshipType.REFERENCES
+        )
         alias_map: dict[str, str] | None = None
         factory_aliases: dict[str, str] | None = None
 
@@ -2110,6 +2119,7 @@ class CallProcessor:
                         resolve_func,
                         ensure_rel,
                         caller_qn,
+                        arg_ref_rel,
                     )
                 continue
 
@@ -2135,6 +2145,7 @@ class CallProcessor:
                         resolve_func,
                         ensure_rel,
                         caller_qn,
+                        arg_ref_rel,
                     )
                 continue
 

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1894,6 +1894,11 @@ class CallProcessor:
             or language in _JS_TS_LANGUAGES
             or is_cpp
         )
+        # (H) C# gets the argument-REFERENCE half only (a method group passed as
+        # (H) a delegate argument keeps its target reachable -- Polly's
+        # (H) EmptyHandler family, 16 dead-code false flags) without the
+        # (H) interprocedural callable-param flow, which is untuned for C#.
+        is_arg_ref_lang = is_flow_lang or language == cs.SupportedLanguage.CSHARP
         alias_map: dict[str, str] | None = None
         factory_aliases: dict[str, str] | None = None
 
@@ -1922,7 +1927,7 @@ class CallProcessor:
                 # (H) whatever callable it produced; reference first-party functions
                 # (H) passed to it or dead-code flags every django-style view
                 # (H) decorator wrapper.
-                if is_flow_lang:
+                if is_arg_ref_lang:
                     self._ingest_argument_function_references(
                         call_node,
                         caller_spec,
@@ -2089,7 +2094,7 @@ class CallProcessor:
                 )
 
             if not callee_info:
-                if is_flow_lang:
+                if is_arg_ref_lang:
                     # (H) The callee is not first-party (a framework/stdlib call such as
                     # (H) grpclib Handler(self.__rpc_x), JS setTimeout(target), or a
                     # (H) runtime dispatcher), so the call chain cannot be followed into
@@ -2120,7 +2125,7 @@ class CallProcessor:
             # (H) operator rule and emit no edge at all.
             callee_is_builtin = callee_qn.startswith(_BUILTIN_QN_PREFIX)
             if callee_is_builtin:
-                if is_flow_lang:
+                if is_arg_ref_lang:
                     self._ingest_argument_function_references(
                         call_node,
                         caller_spec,
@@ -2143,6 +2148,7 @@ class CallProcessor:
                     local_var_types,
                     class_context,
                 )
+            if is_arg_ref_lang:
                 # (H) Functions are first-class values: a first-party callee may STORE
                 # (H) a passed callback for later dynamic dispatch (config objects,
                 # (H) codecs, registries), which callable-param flow cannot trace, or
@@ -3519,6 +3525,12 @@ class CallProcessor:
         if args_node is None:
             return positional, keyword
         for child in args_node.named_children:
+            # (H) C# wraps every argument expression in an `argument` node (which
+            # (H) may carry a ref/out modifier or a name: colon); unwrap to the
+            # (H) expression itself -- its LAST named child -- so downstream
+            # (H) reference-type checks see the identifier, not the wrapper.
+            if child.type == cs.TS_CSHARP_ARGUMENT and child.named_children:
+                child = child.named_children[-1]
             if child.type == cs.TS_PY_KEYWORD_ARGUMENT:
                 name_node = child.child_by_field_name(cs.FIELD_NAME)
                 value_node = child.child_by_field_name(cs.FIELD_VALUE)

--- a/codebase_rag/parsers/export_detection.py
+++ b/codebase_rag/parsers/export_detection.py
@@ -234,6 +234,17 @@ def _csharp_exported(node: Node) -> bool:
         if child.type == cs.TS_CSHARP_MODIFIER and child.text is not None:
             if child.text.decode(cs.ENCODING_UTF8) in _CSHARP_PUBLIC_MODIFIERS:
                 return True
+    # (H) An interface member carries no visibility modifier and is implicitly
+    # (H) PUBLIC -- it IS the interface's API surface (Polly's
+    # (H) IAsyncPolicy.ExecuteAsync overloads, flagged dead without this).
+    parent = node.parent
+    if (
+        parent is not None
+        and parent.type == cs.TS_CSHARP_DECLARATION_LIST
+        and parent.parent is not None
+        and parent.parent.type == cs.TS_CSHARP_INTERFACE_DECLARATION
+    ):
+        return True
     # (H) With no explicit visibility a TOP-LEVEL type defaults to `internal`
     # (H) (API surface -> exported); a nested type or any member defaults to
     # (H) `private` -> not exported.

--- a/codebase_rag/parsers/export_detection.py
+++ b/codebase_rag/parsers/export_detection.py
@@ -234,6 +234,12 @@ def _csharp_exported(node: Node) -> bool:
         if child.type == cs.TS_CSHARP_MODIFIER and child.text is not None:
             if child.text.decode(cs.ENCODING_UTF8) in _CSHARP_PUBLIC_MODIFIERS:
                 return True
+    # (H) An explicit interface implementation (`IThing IThing.WithKey(...)`)
+    # (H) carries no modifier but is invocable from outside via the interface --
+    # (H) API surface (Polly's `IAsyncPolicy.WithPolicyKey`, `IDictionary.Keys`).
+    for child in node.children:
+        if child.type == cs.TS_CSHARP_EXPLICIT_INTERFACE_SPECIFIER:
+            return True
     # (H) An interface member carries no visibility modifier and is implicitly
     # (H) PUBLIC -- it IS the interface's API surface (Polly's
     # (H) IAsyncPolicy.ExecuteAsync overloads, flagged dead without this).

--- a/codebase_rag/tests/test_csharp_calls.py
+++ b/codebase_rag/tests/test_csharp_calls.py
@@ -85,3 +85,29 @@ public class Grp {
 
     referenced = _reference_targets(mock_ingestor) | _call_targets(mock_ingestor)
     assert any(t.endswith("N.Grp.EmptyHandler") for t in referenced), referenced
+
+
+def test_method_group_to_external_callee_is_reference_not_call(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) A method group handed to an EXTERNAL callee (Array.ForEach) keeps its
+    # (H) target reachable, but the pass is NOT an invocation: emitting CALLS
+    # (H) here polluted the C# call graph with 282 phantom Polly call edges
+    # (H) (retrieval precision 1.0 -> 0.92). C# records the pass as REFERENCES
+    # (H) at every site; only flow languages keep their historical CALLS form.
+    (csharp_project / "Ext.cs").write_text(
+        """
+namespace N;
+public class Ext {
+    public void Wire(int[] xs) { System.Array.ForEach(xs, Sink); }
+    private static void Sink(int x) { }
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    calls = _call_targets(mock_ingestor)
+    refs = _reference_targets(mock_ingestor)
+    assert any(t.endswith("N.Ext.Sink(int)") for t in refs), refs
+    assert not any(t.endswith("N.Ext.Sink(int)") for t in calls), calls

--- a/codebase_rag/tests/test_csharp_calls.py
+++ b/codebase_rag/tests/test_csharp_calls.py
@@ -57,3 +57,31 @@ public class Calc {
     targets = _call_targets(mock_ingestor)
     # (H) Square takes one parameter, so it registers with a signature (Phase 3).
     assert any(t.endswith("N.Calc.Square(int)") for t in targets), targets
+
+
+def _reference_targets(mock_ingestor: MagicMock) -> set[str]:
+    return {c.args[2][2] for c in get_relationships(mock_ingestor, "REFERENCES")}
+
+
+def test_method_group_argument_is_referenced(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) A method passed as a METHOD GROUP argument (`Retry(3, EmptyHandler)`)
+    # (H) is never an invocation_expression, so it gets no CALLS edge; without a
+    # (H) REFERENCES edge every delegate-style default handler reports dead
+    # (H) (16 of Polly's first C# dead-code findings, the EmptyHandler family).
+    (csharp_project / "Grp.cs").write_text(
+        """
+namespace N;
+public class Grp {
+    public void Configure() { Retry(3, EmptyHandler); }
+    public void Retry(int count, System.Action handler) { handler(); }
+    private static void EmptyHandler() { }
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    referenced = _reference_targets(mock_ingestor) | _call_targets(mock_ingestor)
+    assert any(t.endswith("N.Grp.EmptyHandler") for t in referenced), referenced

--- a/codebase_rag/tests/test_csharp_exports.py
+++ b/codebase_rag/tests/test_csharp_exports.py
@@ -58,6 +58,36 @@ public class C {
     assert flag("N.C.Implicit") is False
 
 
+def test_interface_members_are_implicitly_public(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) C# interface members carry NO visibility modifier and are implicitly
+    # (H) public: they ARE the type's API surface. The modifier scan alone
+    # (H) leaves them is_exported=False, which turned every interface member
+    # (H) into a dead-code candidate (all 190 findings of the first Polly
+    # (H) dead-code dogfood, dominated by IAsyncPolicy.ExecuteAsync overloads
+    # (H) and IPolicyWrap properties).
+    (csharp_project / "I.cs").write_text(
+        """
+namespace N;
+public interface IPolicy {
+    int Execute(int x);
+    int Retries { get; }
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    exported = _exported_by_suffix(mock_ingestor)
+
+    def flag(suffix: str) -> bool:
+        return next(v for qn, v in exported.items() if qn.endswith(suffix))
+
+    assert flag("N.IPolicy.Execute(int)") is True
+    assert flag("N.IPolicy.Retries") is True
+
+
 def _class_exported(mock_ingestor: MagicMock) -> dict[str, bool]:
     result: dict[str, bool] = {}
     for call in get_nodes(mock_ingestor, NodeType.CLASS):

--- a/codebase_rag/tests/test_csharp_exports.py
+++ b/codebase_rag/tests/test_csharp_exports.py
@@ -88,6 +88,39 @@ public interface IPolicy {
     assert flag("N.IPolicy.Retries") is True
 
 
+def test_explicit_interface_implementations_are_exported(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) An explicit interface implementation (`IThing IThing.WithKey(...)`)
+    # (H) carries no modifier and lives in a class, but it is invocable from
+    # (H) outside through the interface -- API surface, not a private member
+    # (H) (Polly's AsyncPolicy `IAsyncPolicy.WithPolicyKey` and the
+    # (H) Context.Dictionary `IDictionary.Keys` family, all flagged dead).
+    (csharp_project / "E.cs").write_text(
+        """
+namespace N;
+public interface IThing {
+    IThing WithKey(string k);
+}
+public class C : IThing {
+    IThing IThing.WithKey(string k) => this;
+    void Plain() {}
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    exported = _exported_by_suffix(mock_ingestor)
+
+    def flag(suffix: str) -> bool:
+        return next(v for qn, v in exported.items() if qn.endswith(suffix))
+
+    assert flag("N.C.WithKey(string)") is True
+    # (H) A plain modifier-less class member stays private.
+    assert flag("N.C.Plain") is False
+
+
 def _class_exported(mock_ingestor: MagicMock) -> dict[str, bool]:
     result: dict[str, bool] = {}
     for call in get_nodes(mock_ingestor, NodeType.CLASS):

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.363"
+version = "0.0.365"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

First round of the C# dead-code dogfood on Polly (the #726 dead-code support had only ever seen fixture tests). Polly's report drops **190 → 23** via three root-cause fixes, each RED → GREEN:

1. **Interface members are implicitly public** (`export_detection`): C# interface members carry no visibility modifier, so the modifier scan left them `is_exported=False` and every interface member became a dead-code candidate. All 190 initial findings had `is_exported=false`, dominated by `IAsyncPolicy.ExecuteAsync` overloads. Interface members now export as the API surface they are (190 → 65).
2. **Explicit interface implementations are API surface** (`export_detection`): `IAsyncPolicy IAsyncPolicy.WithPolicyKey(...)` has no modifier and lives in a class, but is invocable from outside via the interface. Detected by the `explicit_interface_specifier` child (65 → 49).
3. **Method-group delegate arguments get REFERENCES edges** (`call_processor`): `WaitAndRetry(retryCount, sleepDurationProvider, EmptyHandler)` passes a private method as a method group — never an `invocation_expression`, so no CALLS edge existed and Polly's whole `EmptyHandler` default-handler family (16 findings) reported dead. C# now runs the argument-function-reference half of the first-class-callable machinery (the interprocedural callable-param flow stays off for C#), with C#'s `argument` wrapper nodes unwrapped to their expressions (49 → 23).

4. **Method-group passes are REFERENCES, never CALLS** (`call_processor`): the first version of fix 3 reused the flow-language convention of emitting CALLS when the callee is external, which put 282 phantom edges into Polly's call graph (C# retrieval precision 1.0 -> 0.92, caught by re-running the eval before shipping). A method-group pass is not an invocation: C# now records REFERENCES at every site, flow languages keep their historical CALLS form, and the retrieval eval is back to precision 1.0.

## Remaining 23, classified

Real residual classes, each its own follow-up: local functions shadowed by same-name method overloads (`PredicateBuilder.HandleInner`), property-read references (private `Context.WrappedDictionary`), extension-method call resolution (the known #102 follow-up; `GetPipelineDescriptor`), generic/non-generic same-name resolution across partial files (`GetAsyncContext`), cast-expression receivers (`((ReloadableComponent)s!).Reload()`), and method-group references binding one overload of a family. The rest are plausible true positives (legacy `TimedLock`, docs snippets, bench helpers).

## Validation

Strict RED → GREEN per fix in commit history. Polly reindexed and re-measured after each fix (190 → 65 → 49 → 23). Full suite green.
