### PR TITLE
fix(cpp): constructor-temporary chains and macro-attributed definition names

### DIFF
--- a/codebase_rag/constants/ast_cpp.py
+++ b/codebase_rag/constants/ast_cpp.py
@@ -20,6 +20,10 @@ class CppNodeType(StrEnum):
     FUNCTION_DECLARATOR = "function_declarator"
     POINTER_DECLARATOR = "pointer_declarator"
     REFERENCE_DECLARATOR = "reference_declarator"
+    # (H) An attribute MACRO before a definition (`JSON_HEDLEY_NON_NULL(3)
+    # (H) bool sax_parse(...)`) parses as a parenthesized_declarator wrapping
+    # (H) an ERROR plus the real function_declarator; the name walk descends it.
+    PARENTHESIZED_DECLARATOR = "parenthesized_declarator"
     FIELD_DECLARATION = "field_declaration"
     FIELD_IDENTIFIER = "field_identifier"
     QUALIFIED_IDENTIFIER = "qualified_identifier"
@@ -175,6 +179,8 @@ TS_CPP_INIT_DECLARATOR = "init_declarator"
 TS_CPP_PARAMETER_DECLARATION = "parameter_declaration"
 TS_CPP_IDENTIFIER = "identifier"
 TS_CPP_QUALIFIED_IDENTIFIER = "qualified_identifier"
+# (H) `Reader<T>(...)` as a call target: the callee wraps name + template args.
+TS_CPP_TEMPLATE_FUNCTION = "template_function"
 # (H) Stream-insertion operator; a `binary_expression` using it whose left-spine base
 # (H) is std::cout / std::cerr writes STDOUT.
 CPP_OP_LEFT_SHIFT = "<<"

--- a/codebase_rag/constants/ast_cpp.py
+++ b/codebase_rag/constants/ast_cpp.py
@@ -181,6 +181,8 @@ TS_CPP_IDENTIFIER = "identifier"
 TS_CPP_QUALIFIED_IDENTIFIER = "qualified_identifier"
 # (H) `Reader<T>(...)` as a call target: the callee wraps name + template args.
 TS_CPP_TEMPLATE_FUNCTION = "template_function"
+# (H) `return {args};` -- a braced construction of the declared return type.
+TS_CPP_INITIALIZER_LIST = "initializer_list"
 # (H) Stream-insertion operator; a `binary_expression` using it whose left-spine base
 # (H) is std::cout / std::cerr writes STDOUT.
 CPP_OP_LEFT_SHIFT = "<<"

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1460,9 +1460,11 @@ class CallProcessor:
                         # (H) A factory-call receiver (`parser(ia, cb).parse(...)`,
                         # (H) nlohmann's basic_json::parse) is a call_expression on a
                         # (H) bare identifier: emit the chain form so the resolver can
-                        # (H) type the factory's return and bind the method on it. Only
-                        # (H) a simple-identifier callee qualifies -- deeper receiver
-                        # (H) chains keep the bare method-name trie fallback.
+                        # (H) type the factory's return and bind the method on it. A
+                        # (H) template/qualified callee (`Reader<T>(...)`,
+                        # (H) `detail::Reader<T>(...)`) is a CONSTRUCTOR TEMPORARY --
+                        # (H) the callee names the receiver's class directly. Deeper
+                        # (H) receiver chains keep the bare method-name trie fallback.
                         if (
                             arg is not None
                             and arg.type == cs.TS_CPP_CALL_EXPRESSION
@@ -1470,7 +1472,12 @@ class CallProcessor:
                                 callee := arg.child_by_field_name(cs.TS_FIELD_FUNCTION)
                             )
                             is not None
-                            and callee.type == cs.TS_IDENTIFIER
+                            and callee.type
+                            in (
+                                cs.TS_IDENTIFIER,
+                                cs.TS_CPP_TEMPLATE_FUNCTION,
+                                cs.TS_CPP_QUALIFIED_IDENTIFIER,
+                            )
                             and arg.text
                         ):
                             receiver = arg.text.decode(cs.ENCODING_UTF8)

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1854,6 +1854,10 @@ class CallProcessor:
                 class_context,
                 self._flow_scope_boundaries(queries[language][cs.QUERY_CONFIG]),
             )
+        if language == cs.SupportedLanguage.CPP:
+            self._ingest_cpp_braced_return_instantiations(
+                caller_node, caller_spec, caller_qn, module_qn
+            )
 
         if call_nodes is None:
             calls_query = queries[language].get(cs.QUERY_CALLS)
@@ -2970,6 +2974,60 @@ class CallProcessor:
                             ensure_rel,
                         )
             stack.extend(node.children)
+
+    def _ingest_cpp_braced_return_instantiations(
+        self,
+        caller_node: Node,
+        caller_spec: tuple[str, str, str],
+        caller_qn: str,
+        module_qn: str,
+    ) -> None:
+        # (H) `return {args};` (nlohmann's exception factories) constructs the
+        # (H) caller's DECLARED return type through a bare initializer_list --
+        # (H) no call node exists, so the constructed class's ctor gets no edge
+        # (H) and reports dead even when its only factory is alive. Emit
+        # (H) INSTANTIATES to the class and CALLS to its ctors, exactly like an
+        # (H) explicit construction. A lambda body is skipped: its returns are
+        # (H) not the caller's. Revive-only: nothing is emitted unless the
+        # (H) return type resolves to a registered first-party class.
+        has_braced_return = False
+        stack: list[Node] = list(caller_node.children)
+        while stack:
+            node = stack.pop()
+            if node.type == cs.TS_CPP_LAMBDA_EXPRESSION:
+                continue
+            if node.type == cs.TS_RETURN_STATEMENT and any(
+                child.type == cs.TS_CPP_INITIALIZER_LIST
+                for child in node.named_children
+            ):
+                has_braced_return = True
+                break
+            stack.extend(node.children)
+        if not has_braced_return:
+            return
+        class_qn = self._resolver.cpp_braced_return_class(caller_qn, module_qn)
+        if class_qn is None:
+            return
+        registry = self._resolver.function_registry
+        ensure_rel = self.ingestor.ensure_relationship_batch
+        for class_variant in registry.variants(class_qn):
+            variant_type = registry.get(class_variant)
+            if variant_type is not None and variant_type != NodeType.CLASS:
+                continue
+            ensure_rel(
+                caller_spec,
+                cs.RelationshipType.INSTANTIATES,
+                (cs.NodeLabel.CLASS, cs.KEY_QUALIFIED_NAME, class_variant),
+            )
+        for ctor_type, ctor_qn in sorted(
+            self._resolver.java_constructor_targets(class_qn)
+        ):
+            for variant in registry.variants(ctor_qn):
+                ensure_rel(
+                    caller_spec,
+                    cs.RelationshipType.CALLS,
+                    (ctor_type, cs.KEY_QUALIFIED_NAME, variant),
+                )
 
     def _ingest_go_composite_function_references(
         self,

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -1606,9 +1606,9 @@ class CallResolver:
         # (H) each `.method()` hop advances the type by that method's return type
         # (H) (Root() -> Command). Language-agnostic; returns the bare type name of the
         # (H) final hop, or None if any hop is untyped/unknown (then the chain stays
-        # (H) unresolved, never mis-resolved).
-        if not self.type_inference.method_return_types:
-            return None
+        # (H) unresolved, never mis-resolved). No early-out on an empty
+        # (H) method_return_types map: a constructor-temporary base
+        # (H) (`Reader<T>(...).m()`) types itself from the class registry alone.
         parts = _split_receiver_chain(object_expr)
         base = parts[0]
         if not base:
@@ -1658,22 +1658,39 @@ class CallResolver:
         language: cs.SupportedLanguage | None = None,
     ) -> str | None:
         # (H) `parser(ia, cb).parse()`: the receiver is a bare-identifier factory call.
-        # (H) Resolve the callee to its function/method qn (a sibling static method
-        # (H) `Owner.parser` or a free `make`, never the same-named class -- the
-        # (H) registry holds only callables) and return its recorded return type. A
-        # (H) `::`-qualified callee is the Rust assoc path's job, handled by the caller.
-        callee = base.split(cs.CHAR_PAREN_OPEN, 1)[0]
-        if not callee or cs.SEPARATOR_DOUBLE_COLON in callee:
+        # (H) Resolve the callee to its function/method qn and return its recorded
+        # (H) return type. When no return type resolves, a C++ callee may instead be a
+        # (H) CONSTRUCTOR TEMPORARY (`Reader<decltype(ia)>(...)`, nlohmann's
+        # (H) from_cbor): the callee names the receiver's class itself. The callee is
+        # (H) cut at `<` or `(`, whichever comes first, since template args can carry
+        # (H) their own parens.
+        cut = len(base)
+        for bracket in (cs.CHAR_ANGLE_OPEN, cs.CHAR_PAREN_OPEN):
+            idx = base.find(bracket)
+            if idx != -1 and idx < cut:
+                cut = idx
+        callee = base[:cut]
+        if not callee:
             return None
+        if cs.SEPARATOR_DOUBLE_COLON in callee:
+            # (H) A `::`-qualified non-C++ callee is the Rust assoc path's job,
+            # (H) handled by the caller; C++ namespace paths normalize to dots.
+            if language != cs.SupportedLanguage.CPP:
+                return None
+            callee = callee.replace(cs.SEPARATOR_DOUBLE_COLON, cs.SEPARATOR_DOT)
         resolved = self.resolve_function_call(
             callee, module_qn, local_var_types, class_context, caller_qn, language
         )
-        if resolved is None:
-            return None
-        return_type = self.type_inference.method_return_types.get(resolved[1])
-        if not return_type:
-            return None
-        return self._resolve_type_to_class_qn(return_type, module_qn)
+        if resolved is not None:
+            return_type = self.type_inference.method_return_types.get(resolved[1])
+            if return_type:
+                return self._resolve_type_to_class_qn(return_type, module_qn)
+        if language == cs.SupportedLanguage.CPP:
+            # (H) Constructor temporary: `X(...)` resolved to a ctor (never a
+            # (H) recorded return) or to nothing at all; if X names a registered
+            # (H) class, that class IS the receiver type.
+            return self._resolve_type_to_class_qn(callee, module_qn)
+        return None
 
     def _resolve_type_to_class_qn(self, type_path: str, module_qn: str) -> str | None:
         # (H) Resolve a recorded return-type path to a registered CLASS qn. A factory

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -507,6 +507,15 @@ class CallResolver:
                 targets.add((node_type, qn))
         return targets
 
+    def cpp_braced_return_class(self, caller_qn: str, module_qn: str) -> str | None:
+        # (H) The class constructed by a `return {...};` inside caller_qn: the
+        # (H) caller's recorded return type, resolved to a registered class
+        # (H) (None for primitives/auto/unrecorded).
+        return_type = self.type_inference.method_return_types.get(caller_qn)
+        if not return_type:
+            return None
+        return self._resolve_type_to_class_qn(return_type, module_qn)
+
     def cpp_dispatch_targets(
         self,
         call_name: str,

--- a/codebase_rag/parsers/cpp/utils.py
+++ b/codebase_rag/parsers/cpp/utils.py
@@ -156,6 +156,7 @@ def _extract_name_from_function_definition(func_node: Node) -> str | None:
                 cs.CppNodeType.POINTER_DECLARATOR,
                 cs.CppNodeType.REFERENCE_DECLARATOR,
                 cs.CppNodeType.FUNCTION_DECLARATOR,
+                cs.CppNodeType.PARENTHESIZED_DECLARATOR,
             ):
                 result = find_function_declarator(child)
                 if result:

--- a/codebase_rag/parsers/cpp/utils.py
+++ b/codebase_rag/parsers/cpp/utils.py
@@ -157,6 +157,11 @@ def _extract_name_from_function_definition(func_node: Node) -> str | None:
                 cs.CppNodeType.REFERENCE_DECLARATOR,
                 cs.CppNodeType.FUNCTION_DECLARATOR,
                 cs.CppNodeType.PARENTHESIZED_DECLARATOR,
+                # (H) A macro-attributed ctor buries its REAL declarator inside
+                # (H) the ERROR while the base-initializer (`: exception(...)`)
+                # (H) survives as a sibling declarator; depth-first source order
+                # (H) must enter the ERROR so the ctor's own name wins.
+                cs.TS_ERROR,
             ):
                 result = find_function_declarator(child)
                 if result:

--- a/codebase_rag/tests/test_cpp_factory_return_chain.py
+++ b/codebase_rag/tests/test_cpp_factory_return_chain.py
@@ -243,3 +243,23 @@ def test_macro_attributed_definition_name_extracted() -> None:
     # (H) parsing the macro cleanly, this guard flags the test for revisit.
     assert find(defn, "parenthesized_declarator") is not None
     assert cpp_utils.extract_function_name(defn) == "sax_parse"
+
+    # (H) Macro-attributed CONSTRUCTOR with a member-initializer list
+    # (H) (nlohmann's exception hierarchy): recovery buries the REAL ctor
+    # (H) declarator inside the ERROR and leaves the base-initializer
+    # (H) (`: exception(...)`) as the sibling function_declarator. The walk
+    # (H) must take the first declarator in SOURCE order, entering the ERROR,
+    # (H) or every such ctor registers under the base class's name.
+    ctor_src = (
+        "class invalid_iterator : public exception {\n"
+        "  private:\n"
+        "    HEDLEY_NON_NULL(3)\n"
+        "    invalid_iterator(int id_, const char* what_arg)\n"
+        "        : exception(id_, what_arg) {}\n"
+        "};\n"
+    )
+    ctor_tree = parsers["cpp"].parse(ctor_src.encode())
+    ctor_defn = find(ctor_tree.root_node, "function_definition")
+    assert ctor_defn is not None
+    assert find(ctor_defn, "parenthesized_declarator") is not None
+    assert cpp_utils.extract_function_name(ctor_defn) == "invalid_iterator"

--- a/codebase_rag/tests/test_cpp_factory_return_chain.py
+++ b/codebase_rag/tests/test_cpp_factory_return_chain.py
@@ -6,6 +6,8 @@
 # (H) resolve the chained method on it.
 from pathlib import Path
 
+from codebase_rag import constants as cs
+
 from evals.cgr_graph import _capture
 
 
@@ -136,7 +138,7 @@ def test_return_type_path_normalizes_template_qualified_scope() -> None:
     from codebase_rag.parsers.cpp.utils import extract_return_type_name
 
     parsers, _ = load_parsers()
-    tree = parsers["cpp"].parse(b"Outer<T>::Inner make() { return {}; }\n")
+    tree = parsers[cs.SupportedLanguage.CPP].parse(b"Outer<T>::Inner make() { return {}; }\n")
 
     def find_fn(node):
         if node.type == "function_definition":
@@ -229,7 +231,7 @@ def test_macro_attributed_definition_name_extracted() -> None:
         "    bool other() { return true; }\n"
         "};\n"
     )
-    tree = parsers["cpp"].parse(src.encode())
+    tree = parsers[cs.SupportedLanguage.CPP].parse(src.encode())
 
     def find(node: Node, node_type: str) -> Node | None:
         if node.type == node_type:
@@ -260,7 +262,7 @@ def test_macro_attributed_definition_name_extracted() -> None:
         "        : exception(id_, what_arg) {}\n"
         "};\n"
     )
-    ctor_tree = parsers["cpp"].parse(ctor_src.encode())
+    ctor_tree = parsers[cs.SupportedLanguage.CPP].parse(ctor_src.encode())
     ctor_defn = find(ctor_tree.root_node, "function_definition")
     assert ctor_defn is not None
     assert find(ctor_defn, "parenthesized_declarator") is not None

--- a/codebase_rag/tests/test_cpp_factory_return_chain.py
+++ b/codebase_rag/tests/test_cpp_factory_return_chain.py
@@ -205,40 +205,41 @@ def test_qualified_constructor_temporary_chain_resolves(tmp_path: Path) -> None:
     assert ("crate.f.driver", "crate.f.Aaa.sax_parse") not in calls
 
 
-def test_macro_attributed_method_registers_and_resolves(tmp_path: Path) -> None:
+def test_macro_attributed_definition_name_extracted() -> None:
     # (H) nlohmann shape (JSON_HEDLEY_NON_NULL(3) before bool sax_parse(...)):
     # (H) tree-sitter merges the attribute macro into the definition as a
     # (H) parenthesized_declarator wrapping an ERROR plus the REAL
     # (H) function_declarator. The name walk must descend through it, or the
-    # (H) method never registers and its whole callee cluster reads as dead.
-    # (H) The NAMESPACE_BEGIN macro wrapper matters: it puts the class inside a
-    # (H) top-level ERROR node (nlohmann's real file shape), routing members
-    # (H) through the class-method ingestion path.
-    _make(
-        tmp_path,
-        "NAMESPACE_BEGIN\n"
+    # (H) method never registers and its whole callee cluster (binary_reader's
+    # (H) 37 methods) reads as dead.
+    from codebase_rag.parser_loader import load_parsers
+    from codebase_rag.parsers.cpp import utils as cpp_utils
+
+    parsers, _queries = load_parsers()
+    src = (
         "class Reader {\n"
         "  public:\n"
         "    HEDLEY_NON_NULL(2)\n"
-        "    bool sax_parse(int format, void* sax_)\n"
+        "    bool sax_parse(const int format, void* sax_, const bool strict = true)\n"
         "    {\n"
-        "        return helper();\n"
+        "        return true;\n"
         "    }\n"
-        "    bool helper() { return true; }\n"
+        "    bool other() { return true; }\n"
         "};\n"
-        "void driver(Reader& r, void* s) {\n"
-        "    r.sax_parse(1, s);\n"
-        "}\n"
-        "NAMESPACE_END\n",
     )
-    ingestor = _capture(tmp_path, "crate")
-    qns = {
-        str(props.get("qualified_name", "")) for props in ingestor.nodes.values()
-    }
-    assert "crate.f.Reader.sax_parse" in qns, sorted(
-        q for q in qns if "Reader" in q
-    )
-    calls = _calls(tmp_path)
-    assert ("crate.f.driver", "crate.f.Reader.sax_parse") in calls, sorted(
-        c for c in calls if "sax_parse" in c[1]
-    )
+    tree = parsers["cpp"].parse(src.encode())
+
+    def find(node: object, node_type: str) -> object | None:
+        if node.type == node_type:
+            return node
+        for child in node.named_children:
+            if (hit := find(child, node_type)) is not None:
+                return hit
+        return None
+
+    defn = find(tree.root_node, "function_definition")
+    assert defn is not None
+    # (H) Pin the mangled shape this test exists for: if a grammar bump starts
+    # (H) parsing the macro cleanly, this guard flags the test for revisit.
+    assert find(defn, "parenthesized_declarator") is not None
+    assert cpp_utils.extract_function_name(defn) == "sax_parse"

--- a/codebase_rag/tests/test_cpp_factory_return_chain.py
+++ b/codebase_rag/tests/test_cpp_factory_return_chain.py
@@ -149,3 +149,57 @@ def test_return_type_path_normalizes_template_qualified_scope() -> None:
     fn = find_fn(tree.root_node)
     assert fn is not None
     assert extract_return_type_name(fn) == "Outer.Inner"
+
+
+def test_constructor_temporary_chain_resolves(tmp_path: Path) -> None:
+    # (H) nlohmann from_cbor shape: `Reader<decltype(ia)>(std::move(ia), fmt)
+    # (H) .sax_parse(...)` chains a method on a CONSTRUCTOR TEMPORARY -- the
+    # (H) callee is the class itself, so the receiver type IS that class. Aaa
+    # (H) is the alphabetical trie decoy.
+    _make(
+        tmp_path,
+        "struct Aaa {\n"
+        "    bool sax_parse(int f) { return true; }\n"
+        "};\n"
+        "template<typename T>\n"
+        "struct Reader {\n"
+        "    Reader(T&& t, int f) {}\n"
+        "    bool sax_parse(int f) { return true; }\n"
+        "};\n"
+        "template<typename T>\n"
+        "bool driver(T&& ia) {\n"
+        "    return Reader<T>(static_cast<T&&>(ia), 1).sax_parse(1);\n"
+        "}\n",
+    )
+    calls = _calls(tmp_path)
+    assert ("crate.f.driver", "crate.f.Reader.sax_parse") in calls, sorted(
+        c for c in calls if "sax_parse" in c[1]
+    )
+    assert ("crate.f.driver", "crate.f.Aaa.sax_parse") not in calls
+
+
+def test_qualified_constructor_temporary_chain_resolves(tmp_path: Path) -> None:
+    # (H) The namespace-qualified form `detail::Reader<...>(...).sax_parse(...)`
+    # (H) (nlohmann json.hpp:4159) must resolve through the qualified path too.
+    _make(
+        tmp_path,
+        "struct Aaa {\n"
+        "    bool sax_parse(int f) { return true; }\n"
+        "};\n"
+        "namespace detail {\n"
+        "template<typename T>\n"
+        "struct Reader {\n"
+        "    Reader(T&& t, int f) {}\n"
+        "    bool sax_parse(int f) { return true; }\n"
+        "};\n"
+        "}\n"
+        "template<typename T>\n"
+        "bool driver(T&& ia) {\n"
+        "    return detail::Reader<T>(static_cast<T&&>(ia), 1).sax_parse(1);\n"
+        "}\n",
+    )
+    calls = _calls(tmp_path)
+    assert ("crate.f.driver", "crate.f.detail.Reader.sax_parse") in calls, sorted(
+        c for c in calls if "sax_parse" in c[1]
+    )
+    assert ("crate.f.driver", "crate.f.Aaa.sax_parse") not in calls

--- a/codebase_rag/tests/test_cpp_factory_return_chain.py
+++ b/codebase_rag/tests/test_cpp_factory_return_chain.py
@@ -7,7 +7,6 @@
 from pathlib import Path
 
 from codebase_rag import constants as cs
-
 from evals.cgr_graph import _capture
 
 
@@ -138,7 +137,9 @@ def test_return_type_path_normalizes_template_qualified_scope() -> None:
     from codebase_rag.parsers.cpp.utils import extract_return_type_name
 
     parsers, _ = load_parsers()
-    tree = parsers[cs.SupportedLanguage.CPP].parse(b"Outer<T>::Inner make() { return {}; }\n")
+    tree = parsers[cs.SupportedLanguage.CPP].parse(
+        b"Outer<T>::Inner make() { return {}; }\n"
+    )
 
     def find_fn(node):
         if node.type == "function_definition":
@@ -283,7 +284,7 @@ def test_braced_init_return_emits_ctor_call(tmp_path: Path) -> None:
         "struct Widget {\n"
         "    Widget(int a, const char* b) {}\n"
         "    static Widget create(int a) {\n"
-        "        return {a, \"x\"};\n"
+        '        return {a, "x"};\n'
         "    }\n"
         "};\n"
         "int helper() { return 1; }\n"

--- a/codebase_rag/tests/test_cpp_factory_return_chain.py
+++ b/codebase_rag/tests/test_cpp_factory_return_chain.py
@@ -203,3 +203,42 @@ def test_qualified_constructor_temporary_chain_resolves(tmp_path: Path) -> None:
         c for c in calls if "sax_parse" in c[1]
     )
     assert ("crate.f.driver", "crate.f.Aaa.sax_parse") not in calls
+
+
+def test_macro_attributed_method_registers_and_resolves(tmp_path: Path) -> None:
+    # (H) nlohmann shape (JSON_HEDLEY_NON_NULL(3) before bool sax_parse(...)):
+    # (H) tree-sitter merges the attribute macro into the definition as a
+    # (H) parenthesized_declarator wrapping an ERROR plus the REAL
+    # (H) function_declarator. The name walk must descend through it, or the
+    # (H) method never registers and its whole callee cluster reads as dead.
+    # (H) The NAMESPACE_BEGIN macro wrapper matters: it puts the class inside a
+    # (H) top-level ERROR node (nlohmann's real file shape), routing members
+    # (H) through the class-method ingestion path.
+    _make(
+        tmp_path,
+        "NAMESPACE_BEGIN\n"
+        "class Reader {\n"
+        "  public:\n"
+        "    HEDLEY_NON_NULL(2)\n"
+        "    bool sax_parse(int format, void* sax_)\n"
+        "    {\n"
+        "        return helper();\n"
+        "    }\n"
+        "    bool helper() { return true; }\n"
+        "};\n"
+        "void driver(Reader& r, void* s) {\n"
+        "    r.sax_parse(1, s);\n"
+        "}\n"
+        "NAMESPACE_END\n",
+    )
+    ingestor = _capture(tmp_path, "crate")
+    qns = {
+        str(props.get("qualified_name", "")) for props in ingestor.nodes.values()
+    }
+    assert "crate.f.Reader.sax_parse" in qns, sorted(
+        q for q in qns if "Reader" in q
+    )
+    calls = _calls(tmp_path)
+    assert ("crate.f.driver", "crate.f.Reader.sax_parse") in calls, sorted(
+        c for c in calls if "sax_parse" in c[1]
+    )

--- a/codebase_rag/tests/test_cpp_factory_return_chain.py
+++ b/codebase_rag/tests/test_cpp_factory_return_chain.py
@@ -267,3 +267,36 @@ def test_macro_attributed_definition_name_extracted() -> None:
     assert ctor_defn is not None
     assert find(ctor_defn, "parenthesized_declarator") is not None
     assert cpp_utils.extract_function_name(ctor_defn) == "invalid_iterator"
+
+
+def test_braced_init_return_emits_ctor_call(tmp_path: Path) -> None:
+    # (H) nlohmann's exception factories: `static invalid_iterator create(...)
+    # (H) { return {id_, w.c_str()}; }` constructs via a braced initializer
+    # (H) list -- no call node exists, so the private ctor gets no CALLS edge
+    # (H) and reports dead even though its only factory is alive. The declared
+    # (H) return type names the constructed class.
+    _make(
+        tmp_path,
+        "struct Aaa {\n"
+        "    Aaa(int a, const char* b) {}\n"
+        "};\n"
+        "struct Widget {\n"
+        "    Widget(int a, const char* b) {}\n"
+        "    static Widget create(int a) {\n"
+        "        return {a, \"x\"};\n"
+        "    }\n"
+        "};\n",
+    )
+    ingestor = _capture(tmp_path, "crate")
+    calls = {
+        (str(f), str(r), str(t))
+        for _fl, f, r, _tl, t in ingestor.rels
+        if str(r) in ("CALLS", "INSTANTIATES")
+    }
+    assert ("crate.f.Widget.create", "INSTANTIATES", "crate.f.Widget") in calls, sorted(
+        c for c in calls if "create" in c[0]
+    )
+    assert ("crate.f.Widget.create", "CALLS", "crate.f.Widget.Widget") in calls, sorted(
+        c for c in calls if "create" in c[0]
+    )
+    assert not any("Aaa" in t for _f, _r, t in calls if _f.endswith("create"))

--- a/codebase_rag/tests/test_cpp_factory_return_chain.py
+++ b/codebase_rag/tests/test_cpp_factory_return_chain.py
@@ -212,6 +212,8 @@ def test_macro_attributed_definition_name_extracted() -> None:
     # (H) function_declarator. The name walk must descend through it, or the
     # (H) method never registers and its whole callee cluster (binary_reader's
     # (H) 37 methods) reads as dead.
+    from tree_sitter import Node
+
     from codebase_rag.parser_loader import load_parsers
     from codebase_rag.parsers.cpp import utils as cpp_utils
 
@@ -229,7 +231,7 @@ def test_macro_attributed_definition_name_extracted() -> None:
     )
     tree = parsers["cpp"].parse(src.encode())
 
-    def find(node: object, node_type: str) -> object | None:
+    def find(node: Node, node_type: str) -> Node | None:
         if node.type == node_type:
             return node
         for child in node.named_children:

--- a/codebase_rag/tests/test_cpp_factory_return_chain.py
+++ b/codebase_rag/tests/test_cpp_factory_return_chain.py
@@ -285,7 +285,9 @@ def test_braced_init_return_emits_ctor_call(tmp_path: Path) -> None:
         "    static Widget create(int a) {\n"
         "        return {a, \"x\"};\n"
         "    }\n"
-        "};\n",
+        "};\n"
+        "int helper() { return 1; }\n"
+        "void unrelated() { helper(); }\n",
     )
     ingestor = _capture(tmp_path, "crate")
     calls = {

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.363"
+version = "0.0.365"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Part of the C++ dead-code tail campaign (nlohmann 325 false flags on main). Three composing root-cause fixes, no exclusions:

## 1. Constructor-temporary chained calls

`detail::binary_reader<basic_json, decltype(ia), SAX>(std::move(ia), format).sax_parse(...)` (nlohmann's `from_cbor`/`from_msgpack`/`from_ubjson`/`from_bson` and `basic_json::sax_parse`) chains a method on a constructor temporary. #640's factory-chain typing only handled bare-identifier callees with a recorded return type; a template/qualified constructor callee emitted no chain at all, so the call fell to the bare-method trie and mis-bound to `basic_json::sax_parse` — a false edge that both hid the real target and kept the wrong method alive.

- The C++ `field_expression` chain emission now accepts `template_function` and `qualified_identifier` callees.
- `_infer_call_base_type` cuts the callee at `<` or `(` (template args can carry their own parens: `Reader<decltype(ia)>(...)`), normalizes C++ `::` paths, and when the callee resolves to no recorded return type, resolves it as a registered CLASS — a constructor temporary's receiver type is the class itself. C++-gated; Rust/Go behavior unchanged.
- The `method_return_types`-empty early-out in `_infer_chained_object_type` is removed: constructor-temporary typing needs no recorded return types.

## 2. Macro-attributed definition names

`JSON_HEDLEY_NON_NULL(3)` directly before `bool sax_parse(...)` makes tree-sitter merge the attribute macro into the definition as a `parenthesized_declarator` wrapping an ERROR plus the real `function_declarator`. The name walk never descended it, so the method never registered — and `binary_reader`'s entire 37-method cluster hung off the missing `sax_parse` entry point.

## 3. Macro-attributed constructors with member initializers

Same macro on a constructor (`nlohmann`'s exception hierarchy) recovers differently: the REAL ctor declarator is buried inside the ERROR while the base-initializer (`: exception(...)`) survives as a sibling declarator. Fix 2 alone extracted the base class's name, registering `invalid_iterator.exception` phantoms. The walk now descends ERROR nodes depth-first in source order, so the ctor's own name wins in both recovery shapes.

## Validation (fresh shallow clones, full dead-code eval)

| repo | before | after |
|------|--------|-------|
| nlohmann/json (include/nlohmann) | 325 | 271 |
| fmt | 650 | 648 |
| gin | 0 | 0 |
| mini-redis | 0 | 0 |

The 62 revived are exactly the predicted `detail.input` cluster (binary_reader 34, lexer, input_adapters, plus cascades). The 8 newly dead are all principled: 3 `basic_json::sax_parse` overloads had been kept alive only by the false trie edge (they join the known public-API-entry residual class), 4 exception ctors were previously mis-invisible and now register under their correct names (their reachability needs braced-init-return ctor modeling, a separate pre-existing gap), and `grisu2@886` is a previously invisible macro-attributed overload now honestly registered.

## Tests (RED first, each commit pair in history)

- `test_constructor_temporary_chain_resolves` / `test_qualified_constructor_temporary_chain_resolves` (alphabetical `Aaa` decoys defeat the trie)
- `test_macro_attributed_definition_name_extracted` (pins the mangled `parenthesized_declarator` shape, plus the ctor-vs-base-initializer case)
