### PR TITLE
fix(csharp): resolve bare-name calls to in-scope local functions and arity-matched overloads

### DIFF
--- a/codebase_rag/constants/ast_csharp.py
+++ b/codebase_rag/constants/ast_csharp.py
@@ -43,6 +43,19 @@ TS_CSHARP_OPERATOR_DECLARATION = "operator_declaration"
 TS_CSHARP_CONVERSION_OPERATOR_DECLARATION = "conversion_operator_declaration"
 TS_CSHARP_PROPERTY_DECLARATION = "property_declaration"
 
+# (H) The scopes a local function can be declared in (and therefore be
+# (H) call-visible from): a method/constructor body or an enclosing local
+# (H) function. Used to pin each local function to its HOST so bare-name
+# (H) resolution honors C# scoping (a local fn in one overload's body is not
+# (H) in scope in a sibling overload).
+CSHARP_LOCAL_FN_HOST_TYPES = frozenset(
+    {
+        TS_CSHARP_METHOD_DECLARATION,
+        TS_CSHARP_CONSTRUCTOR_DECLARATION,
+        TS_CSHARP_LOCAL_FUNCTION_STATEMENT,
+    }
+)
+
 # (H) Members whose registered leaf name is synthesized (no usable `name` field,
 # (H) or one that collides), routed through csharp.utils.synthesize_method_name.
 CSHARP_SYNTHESIZED_NAME_TYPES = frozenset(

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1476,6 +1476,18 @@ class CallProcessor:
                             receiver = arg.text.decode(cs.ENCODING_UTF8)
                             return f"{receiver}{cs.SEPARATOR_DOT}{method}"
                         return method
+                case cs.TS_CSHARP_GENERIC_NAME if (
+                    language == cs.SupportedLanguage.CSHARP
+                ):
+                    # (H) Bare generic call `Handle<TException>(...)`: the callee
+                    # (H) name is the identifier without its type arguments
+                    # (H) (methods register generic-free). Leaving the `<...>` on
+                    # (H) yielded no call name at all, so the call site vanished
+                    # (H) from the graph (Polly's parameterless HandleInner
+                    # (H) overload delegating to its Func sibling).
+                    if func_child.text is not None:
+                        full = func_child.text.decode(cs.ENCODING_UTF8)
+                        return full.split(cs.CHAR_ANGLE_OPEN, 1)[0]
                 case cs.TS_CSHARP_MEMBER_ACCESS_EXPRESSION if (
                     language == cs.SupportedLanguage.CSHARP
                 ):

--- a/codebase_rag/parsers/csharp/type_inference.py
+++ b/codebase_rag/parsers/csharp/type_inference.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections import deque
+from collections.abc import Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -64,6 +65,7 @@ class CSharpTypeInferenceEngine:
         "csharp_partial_groups",
         "csharp_extension_methods",
         "csharp_call_sites",
+        "csharp_local_functions",
         "function_locations",
         "_rel_to_module",
     )
@@ -83,6 +85,7 @@ class CSharpTypeInferenceEngine:
         csharp_partial_groups: dict[str, list[str]] | None = None,
         csharp_extension_methods: dict[str, list[tuple[str, str, str]]] | None = None,
         csharp_call_sites: dict[CallSiteKey, CSharpCallSite] | None = None,
+        csharp_local_functions: dict[str, tuple[FunctionSpanKey, int]] | None = None,
         function_locations: dict[FunctionSpanKey, FunctionLocation] | None = None,
     ):
         self.import_processor = import_processor
@@ -105,6 +108,9 @@ class CSharpTypeInferenceEngine:
         # (H) this engine is constructed), so `or {}` would lose them.
         self.csharp_call_sites = (
             csharp_call_sites if csharp_call_sites is not None else {}
+        )
+        self.csharp_local_functions = (
+            csharp_local_functions if csharp_local_functions is not None else {}
         )
         self.function_locations = (
             function_locations if function_locations is not None else {}
@@ -230,8 +236,15 @@ class CSharpTypeInferenceEngine:
         if semantic := self._semantic_call_target(call_node, module_qn):
             return semantic
         func = call_node.child_by_field_name(cs.TS_FIELD_FUNCTION)
-        if func is None or func.type != cs.TS_CSHARP_MEMBER_ACCESS_EXPRESSION:
-            # (H) A bare `Foo(...)` is resolved by the generic simple-name path.
+        if func is None:
+            return None
+        if func.type != cs.TS_CSHARP_MEMBER_ACCESS_EXPRESSION:
+            # (H) A bare `Foo(...)`/`Foo<T>(...)` follows C# simple-name lookup:
+            # (H) an in-scope local function first (it shadows same-name method
+            # (H) overloads), then an arity-matched member of the enclosing
+            # (H) type. A miss falls to the generic simple-name path.
+            if func.type in (cs.TS_CSHARP_IDENTIFIER, cs.TS_CSHARP_GENERIC_NAME):
+                return self._resolve_bare_call(func, call_node, module_qn, caller_qn)
             return None
         method_name = safe_decode_text(func.child_by_field_name(cs.FIELD_NAME))
         receiver = func.child_by_field_name(cs.TS_CSHARP_FIELD_EXPRESSION)
@@ -268,6 +281,101 @@ class CSharpTypeInferenceEngine:
             if name_hit := self._find_name_across_parts(receiver_class_qn, method_name):
                 return cs.NodeLabel.METHOD.value, name_hit
         return None
+
+    def _resolve_bare_call(
+        self,
+        func: Node,
+        call_node: Node,
+        module_qn: str,
+        caller_qn: str | None,
+    ) -> tuple[str, str] | None:
+        name = safe_decode_text(func)
+        if not name:
+            return None
+        # (H) `Handle<TException>(...)`: the callee name is the identifier
+        # (H) without its type arguments (matching how methods register).
+        name = name.split(cs.CHAR_ANGLE_OPEN, 1)[0]
+        arg_count = self._count_arguments(call_node)
+        if local := self._find_in_scope_local_function(
+            name, arg_count, caller_qn, module_qn
+        ):
+            return cs.NodeLabel.FUNCTION.value, local
+        for class_qn in self._caller_class_candidates(caller_qn, module_qn):
+            if hit := self._find_arity_across_parts(class_qn, name, arg_count):
+                return cs.NodeLabel.METHOD.value, hit
+        return None
+
+    def _find_in_scope_local_function(
+        self, name: str, arg_count: int, caller_qn: str | None, module_qn: str
+    ) -> str | None:
+        # (H) Walk the caller's scope chain probing for a registered local
+        # (H) function. Each level is probed both as-is and with the overload
+        # (H) signature suffix stripped, because local functions register under
+        # (H) the BARE method scope name while the caller_qn carries the host
+        # (H) overload's signatured identity (`Handle(System.Func)` hosts
+        # (H) `Handle.Handle`). A hit must match the call's arity AND be
+        # (H) declared in a host the caller sits inside -- C# scoping, without
+        # (H) which the parameterless sibling overload would capture the local
+        # (H) fn textually nested under its own bare qn.
+        if not caller_qn:
+            return None
+        scope = caller_qn
+        while len(scope) > len(module_qn):
+            stripped = scope.split(cs.CHAR_PAREN_OPEN, 1)[0]
+            for probe_scope in dict.fromkeys((scope, stripped)):
+                candidate = f"{probe_scope}{cs.SEPARATOR_DOT}{name}"
+                entry = self.csharp_local_functions.get(candidate)
+                if (
+                    entry is not None
+                    and entry[1] == arg_count
+                    and self._caller_within_host(caller_qn, entry[0])
+                ):
+                    return candidate
+            if cs.SEPARATOR_DOT not in stripped:
+                return None
+            scope = stripped.rsplit(cs.SEPARATOR_DOT, 1)[0]
+        return None
+
+    def _caller_within_host(self, caller_qn: str, host_key: FunctionSpanKey) -> bool:
+        # (H) True when the caller IS the local function's host scope or a local
+        # (H) function transitively hosted inside it (a sibling or nested local
+        # (H) fn calling across/into its own nest). Spans join lazily against
+        # (H) function_locations because the host's signatured identity was not
+        # (H) registered yet when the local function was pinned.
+        host_loc = self.function_locations.get(host_key)
+        if host_loc is None:
+            return False
+        host_qn = host_loc.qualified_name
+        seen: set[str] = set()
+        current = caller_qn
+        while current not in seen:
+            seen.add(current)
+            if current == host_qn:
+                return True
+            entry = self.csharp_local_functions.get(current)
+            if entry is None:
+                return False
+            next_loc = self.function_locations.get(entry[0])
+            if next_loc is None:
+                return False
+            current = next_loc.qualified_name
+        return False
+
+    def _caller_class_candidates(
+        self, caller_qn: str | None, module_qn: str
+    ) -> Iterator[str]:
+        # (H) Enclosing-type candidates for a bare member call, outermost last:
+        # (H) strip the overload signature (only the leaf carries one, and its
+        # (H) qualified parameter types contain dots that would break a plain
+        # (H) rsplit), then peel scope segments down to the module boundary.
+        if not caller_qn:
+            return
+        scope = caller_qn.split(cs.CHAR_PAREN_OPEN, 1)[0]
+        while cs.SEPARATOR_DOT in scope:
+            scope = scope.rsplit(cs.SEPARATOR_DOT, 1)[0]
+            if len(scope) <= len(module_qn):
+                return
+            yield scope
 
     def _semantic_call_target(
         self, call_node: Node, module_qn: str

--- a/codebase_rag/parsers/csharp/type_inference.py
+++ b/codebase_rag/parsers/csharp/type_inference.py
@@ -324,13 +324,20 @@ class CSharpTypeInferenceEngine:
             stripped = scope.split(cs.CHAR_PAREN_OPEN, 1)[0]
             for probe_scope in dict.fromkeys((scope, stripped)):
                 candidate = f"{probe_scope}{cs.SEPARATOR_DOT}{name}"
-                entry = self.csharp_local_functions.get(candidate)
-                if (
-                    entry is not None
-                    and entry[1] == arg_count
-                    and self._caller_within_host(caller_qn, entry[0])
-                ):
-                    return candidate
+                # (H) Same-name local fns in SIBLING BLOCKS flatten to one scope
+                # (H) qn; later declarations carry an `@line` duplicate suffix,
+                # (H) so probe every registered variant, not just the natural qn
+                # (H) (else an arity-matched later declaration is missed and the
+                # (H) arity-blind fallback's duplicate fan-out fabricates a
+                # (H) phantom edge onto the uncalled sibling).
+                for variant in self.function_registry.variants(candidate):
+                    entry = self.csharp_local_functions.get(variant)
+                    if (
+                        entry is not None
+                        and entry[1] == arg_count
+                        and self._caller_within_host(caller_qn, entry[0])
+                    ):
+                        return variant
             if cs.SEPARATOR_DOT not in stripped:
                 return None
             scope = stripped.rsplit(cs.SEPARATOR_DOT, 1)[0]

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -102,6 +102,14 @@ class DefinitionProcessor(
         # (H) make (the method lives on an unrelated static class). Populated at
         # (H) method ingestion, read by the type-inference engine as a fallback.
         self.csharp_extension_methods: dict[str, list[tuple[str, str, str]]] = {}
+        # (H) C# local functions: {local_fn_qn: (host span key, parameter count)}.
+        # (H) The host (method/ctor/enclosing local fn) is pinned by SPAN because
+        # (H) at Function-pass time the host method's signatured identity may not
+        # (H) be registered yet; the resolver joins the span to function_locations
+        # (H) lazily. Bare-name resolution uses this to honor C# scoping: a local
+        # (H) fn is callable only from inside its host, and shadows same-name
+        # (H) method overloads there (Polly's PredicateBuilder.HandleInner).
+        self.csharp_local_functions: dict[str, tuple[FunctionSpanKey, int]] = {}
         # (H) C# Roslyn hybrid frontend (issue #738): {(rel_file, type_start_line):
         # (H) {base_simple_name: "class"|"interface"}}. When the opt-in Roslyn
         # (H) frontend ran, split_csharp_bases reads a base's kind here (exact,

--- a/codebase_rag/parsers/factory.py
+++ b/codebase_rag/parsers/factory.py
@@ -128,6 +128,7 @@ class ProcessorFactory:
                 csharp_partial_groups=self.definition_processor.csharp_partial_groups,
                 csharp_extension_methods=self.definition_processor.csharp_extension_methods,
                 csharp_call_sites=self.definition_processor.csharp_call_sites,
+                csharp_local_functions=self.definition_processor.csharp_local_functions,
                 function_locations=self.definition_processor.function_locations,
             )
         return self._type_inference

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -200,6 +200,7 @@ class FunctionIngestMixin:
     csharp_methods: set[str]
     csharp_override_methods: set[str]
     csharp_extension_methods: dict[str, list[tuple[str, str, str]]]
+    csharp_local_functions: dict[str, tuple[FunctionSpanKey, int]]
 
     @abstractmethod
     def _get_docstring(self, node: ASTNode) -> str | None: ...
@@ -897,6 +898,24 @@ class FunctionIngestMixin:
             is_named=not resolution.is_anonymous,
         )
         self.function_locations[function_span_key(module_qn, func_node)] = location
+        # (H) Pin a C# local function to its HOST scope (method/ctor/enclosing
+        # (H) local fn) by span, plus its declared parameter count, so bare-name
+        # (H) call resolution can honor C# scoping and arity (the host's
+        # (H) signatured identity is not registered yet at this point).
+        if (
+            language == cs.SupportedLanguage.CSHARP
+            and func_node.type == cs.TS_CSHARP_LOCAL_FUNCTION_STATEMENT
+        ):
+            host = func_node.parent
+            while host is not None and host.type not in cs.CSHARP_LOCAL_FN_HOST_TYPES:
+                host = host.parent
+            if host is not None:
+                from .csharp import utils as csharp_utils
+
+                self.csharp_local_functions[resolution.qualified_name] = (
+                    function_span_key(module_qn, host),
+                    len(csharp_utils.extract_parameter_type_names(func_node)),
+                )
         record_cpp_definition_span(
             self.cpp_definition_spans,
             language,

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -43,6 +43,7 @@ class TypeInferenceEngine:
         "csharp_partial_groups",
         "csharp_extension_methods",
         "csharp_call_sites",
+        "csharp_local_functions",
         "function_locations",
         "_java_type_inference",
         "_csharp_type_inference",
@@ -71,6 +72,7 @@ class TypeInferenceEngine:
         csharp_partial_groups: dict[str, list[str]] | None = None,
         csharp_extension_methods: dict[str, list[tuple[str, str, str]]] | None = None,
         csharp_call_sites: dict[CallSiteKey, CSharpCallSite] | None = None,
+        csharp_local_functions: dict[str, tuple[FunctionSpanKey, int]] | None = None,
         function_locations: dict[FunctionSpanKey, FunctionLocation] | None = None,
     ):
         self.import_processor = import_processor
@@ -118,6 +120,12 @@ class TypeInferenceEngine:
         # (H) after construction and read by the C# resolver's semantic path.
         self.csharp_call_sites = (
             csharp_call_sites if csharp_call_sites is not None else {}
+        )
+        # (H) Shared reference (as with class_field_types): C# local-function
+        # (H) host/arity index, populated during ingestion and read by the C#
+        # (H) resolver's bare-name path.
+        self.csharp_local_functions = (
+            csharp_local_functions if csharp_local_functions is not None else {}
         )
         self.function_locations = (
             function_locations if function_locations is not None else {}
@@ -183,6 +191,7 @@ class TypeInferenceEngine:
                 csharp_partial_groups=self.csharp_partial_groups,
                 csharp_extension_methods=self.csharp_extension_methods,
                 csharp_call_sites=self.csharp_call_sites,
+                csharp_local_functions=self.csharp_local_functions,
                 function_locations=self.function_locations,
             )
         return self._csharp_type_inference

--- a/codebase_rag/tests/test_csharp_calls.py
+++ b/codebase_rag/tests/test_csharp_calls.py
@@ -146,6 +146,44 @@ def test_bare_call_prefers_in_scope_local_function(
     ), pairs
 
 
+def test_sibling_block_local_function_variants_resolve_by_arity(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) Two sibling BLOCKS of one method may each declare a same-name local
+    # (H) function; both flatten to the same scope qn, so the second registers
+    # (H) with an `@line` duplicate suffix. The bare-name probe must consult the
+    # (H) registry's duplicate VARIANTS: without that, the arity-2 call misses
+    # (H) the in-scope path, falls to the arity-blind enclosing-scope walk, and
+    # (H) the duplicate fan-out fabricates a phantom CALLS edge onto the
+    # (H) UNCALLED arity-1 declaration.
+    (csharp_project / "Blocks.cs").write_text(
+        """
+namespace N;
+public class Blocks {
+    public void Run() {
+        {
+            string Fmt(int a) => a.ToString();
+        }
+        {
+            string Fmt(int a, int b) => (a + b).ToString();
+            System.Console.WriteLine(Fmt(1, 2));
+        }
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    pairs = _call_pairs(mock_ingestor)
+    assert any(
+        s.endswith("N.Blocks.Run") and "N.Blocks.Run.Fmt@" in t for s, t in pairs
+    ), pairs
+    assert not any(
+        s.endswith("N.Blocks.Run") and t.endswith("N.Blocks.Run.Fmt") for s, t in pairs
+    ), pairs
+
+
 def test_nested_local_function_calls_keep_resolving(
     csharp_project: Path, mock_ingestor: MagicMock
 ) -> None:

--- a/codebase_rag/tests/test_csharp_calls.py
+++ b/codebase_rag/tests/test_csharp_calls.py
@@ -63,6 +63,109 @@ def _reference_targets(mock_ingestor: MagicMock) -> set[str]:
     return {c.args[2][2] for c in get_relationships(mock_ingestor, "REFERENCES")}
 
 
+def _call_pairs(mock_ingestor: MagicMock) -> set[tuple[str, str]]:
+    return {
+        (c.args[0][2], c.args[2][2]) for c in get_relationships(mock_ingestor, "CALLS")
+    }
+
+
+LOCAL_FN_SHADOW_SRC = """
+namespace N;
+public class Builder {
+    public Builder Handle<TException>() where TException : System.Exception
+        => Handle<TException>(static _ => true);
+
+    public Builder Handle<TException>(System.Func<TException, bool> predicate)
+        where TException : System.Exception {
+        return Add(outcome => Handle(outcome, predicate));
+
+        static bool Handle(System.Exception? outcome,
+                           System.Func<TException, bool> predicate) {
+            if (outcome != null) {
+                return Nested(predicate, outcome);
+            }
+            return Nested(predicate, outcome);
+
+            static bool Nested(System.Func<TException, bool> predicate,
+                               System.Exception? current) {
+                if (current == null) { return false; }
+                return Nested(predicate, null);
+            }
+        }
+    }
+
+    private Builder Add(System.Func<System.Exception?, bool> p) => this;
+}
+"""
+
+
+def test_generic_bare_call_binds_arity_matched_overload(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) `Handle<TException>(static _ => true)` in the parameterless overload is
+    # (H) a bare generic_name callee: without stripping the type arguments the
+    # (H) call name never resolves (no edge at all), and a naive bare-name
+    # (H) lookup would bind it to the 2-param LOCAL FUNCTION `Handle` textually
+    # (H) nested under this overload's own qn. Overload dispatch must pick the
+    # (H) arity-1 METHOD (Polly's PredicateBuilder.HandleInner shape).
+    (csharp_project / "Builder.cs").write_text(LOCAL_FN_SHADOW_SRC, encoding="utf-8")
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    pairs = _call_pairs(mock_ingestor)
+    assert any(
+        s.endswith("N.Builder.Handle") and t.endswith("N.Builder.Handle(System.Func)")
+        for s, t in pairs
+    ), pairs
+    assert not any(
+        s.endswith("N.Builder.Handle") and t.endswith("N.Builder.Handle.Handle")
+        for s, t in pairs
+    ), pairs
+
+
+def test_bare_call_prefers_in_scope_local_function(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) The 2-arg `Handle(outcome, predicate)` inside the Func overload's
+    # (H) lambda must bind to the local function declared in the SAME body, not
+    # (H) to the parameterless method overload the trie falls back to (the
+    # (H) enclosing-scope walk cannot see through the caller's `(System.Func)`
+    # (H) signature suffix). That mis-bind left Polly's HandleInner/HandleNested
+    # (H) local functions with zero incoming edges -- flagged dead.
+    (csharp_project / "Builder.cs").write_text(LOCAL_FN_SHADOW_SRC, encoding="utf-8")
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    pairs = _call_pairs(mock_ingestor)
+    assert any(
+        s.endswith("N.Builder.Handle(System.Func)")
+        and t.endswith("N.Builder.Handle.Handle")
+        for s, t in pairs
+    ), pairs
+    assert not any(
+        s.endswith("N.Builder.Handle(System.Func)") and t.endswith("N.Builder.Handle")
+        for s, t in pairs
+    ), pairs
+
+
+def test_nested_local_function_calls_keep_resolving(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) Guard: a local function calling its own nested local function (and
+    # (H) that one recursing) already resolves via the enclosing-scope walk;
+    # (H) the C# bare-name path must not regress it.
+    (csharp_project / "Builder.cs").write_text(LOCAL_FN_SHADOW_SRC, encoding="utf-8")
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    pairs = _call_pairs(mock_ingestor)
+    assert any(
+        s.endswith("N.Builder.Handle.Handle") and t.endswith("N.Builder.Handle.Nested")
+        for s, t in pairs
+    ), pairs
+    assert any(
+        s.endswith("N.Builder.Handle.Nested") and t.endswith("N.Builder.Handle.Nested")
+        for s, t in pairs
+    ), pairs
+
+
 def test_method_group_argument_is_referenced(
     csharp_project: Path, mock_ingestor: MagicMock
 ) -> None:


### PR DESCRIPTION
## What

Round 2 of the C# dead-code dogfood on Polly (follows #782): bare-name (unqualified) call resolution now follows C# simple-name lookup instead of falling through to the arity-blind trie. Polly false flags drop from 23 to 12, and the call-graph retrieval eval gains 17 true-positive edges with zero new false positives.

## Root cause

Polly's `PredicateBuilder.HandleInner` exposed three interacting defects, reproduced and pinned by a minimal fixture:

1. **Generic callee names never resolved.** A bare generic call `Handle<TException>(...)` has a `generic_name` callee node, which `_get_call_target_name` had no case for: the call site produced no call name and vanished from the graph entirely.
2. **Local functions were invisible to their own host overload.** A local function registers under the bare method scope (`...Handle.Handle`) while the hosting overload's identity carries a signature suffix (`...Handle(System.Func)`). The enclosing-scope walk probes with the suffixed caller qn, misses, and the trie then binds the call to the parameterless sibling overload. The local function ends up with zero incoming edges, so dead-code flags it plus everything only it reaches (`HandleNested`).
3. **Bare-name resolution was arity-blind.** The trie picks among same-name candidates by import distance, so a 1-arg call could bind to a 2-param local function or a 0-arg overload.

## Fix

All C#-scoped; no other language's resolution path changes:

- `_get_call_target_name` gains a `generic_name` case: the callee name is the identifier without its type arguments, matching how methods register.
- Each C# local function is pinned at registration to its **host scope span** (method/ctor/enclosing local function) plus its declared **parameter count** (`csharp_local_functions`, shared through the factory like `csharp_partial_groups`). Spans join lazily against `function_locations` because the host's signatured identity is not yet registered at Function-pass time.
- `resolve_csharp_method_call` handles bare `identifier`/`generic_name` callees with C# lookup order: an **in-scope local function** first (arity match plus host containment, so a local function in one overload's body is never visible from a sibling overload), then an **arity-matched member** of the enclosing type across partial parts and base classes. A miss falls through to the generic path unchanged.

## Validation

- RED demonstrated in commit history: the fixture asserts the generic 1-arg call binds the arity-1 method overload (was: no edge), the 2-arg body call binds the local function (was: bound to the parameterless overload), and nested local-function calls keep resolving (guard).
- Full suite: 5323 passed, 10 skipped.
- Polly dead-code: 23 -> 12, zero new findings. Cleared beyond `HandleInner`/`HandleNested`: the `TimedLock` trio, `GetGenericRegistry`, `InitializeSyncContext`, `TelemetryListenerImpl.GetArgs`, and the three `ResiliencePipelineExtensions` helpers were all the same arity-blindness in disguise.
- C# retrieval eval (full Polly, Roslyn oracle): tp 3094 -> 3111, fp 0 -> 0, recall 0.7780 -> 0.7822, precision stays 1.0000.

## Remaining 12 (follow-up classes)

Property-read references (`Context.WrappedDictionary`, `ResiliencePipeline.Pipeline`), generic/non-generic same-name resolution across partial files (`GetAsyncContext`/`GetSyncContext`/`InitializeAsyncContext`), cast-expression receivers (`ReloadableComponent.Reload`/`DisposeDiscardedComponentSafeAsync`), method-group references binding one overload of a family (`EmptyAction`/`EmptyHandler`/`EmptyHandlerOfT`), and plausible true positives (`PolicyBuilder@73`, `Snippets.Docs.Fallback.Action`).
