### PR TITLE
fix(csharp): reference property reads and type cast receivers so read-only members stay reachable

### DIFF
--- a/codebase_rag/constants/ast_csharp.py
+++ b/codebase_rag/constants/ast_csharp.py
@@ -99,6 +99,8 @@ TS_CSHARP_GENERIC_NAME = "generic_name"
 TS_CSHARP_CAST_EXPRESSION = "cast_expression"
 TS_CSHARP_POSTFIX_UNARY_EXPRESSION = "postfix_unary_expression"
 TS_CSHARP_IMPLICIT_PARAMETER = "implicit_parameter"
+TS_CSHARP_LAMBDA_EXPRESSION = "lambda_expression"
+TS_CSHARP_BLOCK = "block"
 TS_CSHARP_PRIMARY_CONSTRUCTOR_BASE_TYPE = "primary_constructor_base_type"
 TS_CSHARP_PREDEFINED_TYPE = "predefined_type"
 

--- a/codebase_rag/constants/ast_csharp.py
+++ b/codebase_rag/constants/ast_csharp.py
@@ -97,6 +97,7 @@ TS_CSHARP_BASE_LIST = "base_list"
 # (H) or a `predefined_type` (an enum's underlying integral type -> not a base).
 TS_CSHARP_GENERIC_NAME = "generic_name"
 TS_CSHARP_CAST_EXPRESSION = "cast_expression"
+TS_CSHARP_POSTFIX_UNARY_EXPRESSION = "postfix_unary_expression"
 TS_CSHARP_PRIMARY_CONSTRUCTOR_BASE_TYPE = "primary_constructor_base_type"
 TS_CSHARP_PREDEFINED_TYPE = "predefined_type"
 

--- a/codebase_rag/constants/ast_csharp.py
+++ b/codebase_rag/constants/ast_csharp.py
@@ -98,6 +98,7 @@ TS_CSHARP_BASE_LIST = "base_list"
 TS_CSHARP_GENERIC_NAME = "generic_name"
 TS_CSHARP_CAST_EXPRESSION = "cast_expression"
 TS_CSHARP_POSTFIX_UNARY_EXPRESSION = "postfix_unary_expression"
+TS_CSHARP_IMPLICIT_PARAMETER = "implicit_parameter"
 TS_CSHARP_PRIMARY_CONSTRUCTOR_BASE_TYPE = "primary_constructor_base_type"
 TS_CSHARP_PREDEFINED_TYPE = "predefined_type"
 

--- a/codebase_rag/constants/ast_csharp.py
+++ b/codebase_rag/constants/ast_csharp.py
@@ -96,6 +96,7 @@ TS_CSHARP_BASE_LIST = "base_list"
 # (H) a record positional base `primary_constructor_base_type` (`Animal(Name)`),
 # (H) or a `predefined_type` (an enum's underlying integral type -> not a base).
 TS_CSHARP_GENERIC_NAME = "generic_name"
+TS_CSHARP_CAST_EXPRESSION = "cast_expression"
 TS_CSHARP_PRIMARY_CONSTRUCTOR_BASE_TYPE = "primary_constructor_base_type"
 TS_CSHARP_PREDEFINED_TYPE = "predefined_type"
 

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -4200,6 +4200,21 @@ class CallProcessor:
         shadowed: set[str] | None = None
         seen: set[str] = set()
 
+        def try_emit(name: str | None, this_read: bool) -> None:
+            nonlocal shadowed
+            if not name or name not in prop_names or name in seen:
+                return
+            if shadowed is None:
+                shadowed = self._csharp_declared_names(
+                    caller_node, function_types, class_types
+                )
+            if (this_read or name not in shadowed) and (
+                prop_qn := engine.resolve_property_read(name, caller_qn)
+            ):
+                seen.add(name)
+                if prop_qn != caller_qn:
+                    ensure_rel(caller_spec, refs_rel, (method_label, qn_key, prop_qn))
+
         stack = list(caller_node.children)
         while stack:
             node = stack.pop()
@@ -4212,26 +4227,29 @@ class CallProcessor:
                 # (H) shadow a this-qualified read), so the read is the NAME
                 # (H) field and the shadow check does not apply.
                 this_read = receiver is not None and receiver.type == cs.TS_CSHARP_THIS
-                name = (
+                try_emit(
                     safe_decode_text(node.child_by_field_name(cs.FIELD_NAME))
                     if this_read
-                    else self._csharp_read_identifier(receiver)
+                    else self._csharp_read_identifier(receiver),
+                    this_read,
                 )
-                if name and name in prop_names and name not in seen:
-                    if shadowed is None:
-                        shadowed = self._csharp_declared_names(
-                            caller_node, function_types, class_types
-                        )
-                    if (this_read or name not in shadowed) and (
-                        prop_qn := engine.resolve_property_read(name, caller_qn)
-                    ):
-                        seen.add(name)
-                        if prop_qn != caller_qn:
-                            ensure_rel(
-                                caller_spec,
-                                refs_rel,
-                                (method_label, qn_key, prop_qn),
-                            )
+            elif node_type == cs.TS_CSHARP_IDENTIFIER:
+                # (H) A bare identifier expression (`return Size;`, `Use(Size)`,
+                # (H) `var n = Size;`) reads the getter just the same. NOT a
+                # (H) read: any member-access position (receiver/name handled
+                # (H) above), a parent's NAME field (a declarator/parameter's
+                # (H) own name, a named-argument label `Use(Size: 3)`), or a
+                # (H) parent's TYPE field (`new Size()`, `(Size)x`).
+                # (H) `==`, not `is`: child_by_field_name returns a fresh Node
+                # (H) wrapper each call, so identity never matches.
+                parent = node.parent
+                if (
+                    parent is not None
+                    and parent.type != cs.TS_CSHARP_MEMBER_ACCESS_EXPRESSION
+                    and parent.child_by_field_name(cs.FIELD_NAME) != node
+                    and parent.child_by_field_name(cs.FIELD_TYPE) != node
+                ):
+                    try_emit(safe_decode_text(node), False)
             stack.extend(node.children)
 
     def _build_nested_qualified_name(

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -4144,18 +4144,35 @@ class CallProcessor:
             return safe_decode_text(receiver)
         return None
 
-    def _csharp_declared_names(self, caller_node: Node) -> set[str]:
-        # (H) Every name declared anywhere in the body (locals incl. untyped
-        # (H) `var x = 3`, parameters, lambda params): a declaration shadows a
-        # (H) same-name property for the read pass. Method-wide rather than
-        # (H) block-precise -- suppression can only drop a REFERENCES edge,
-        # (H) never fabricate one.
+    def _csharp_declared_names(
+        self,
+        caller_node: Node,
+        function_types: tuple[str, ...],
+        class_types: tuple[str, ...],
+    ) -> set[str]:
+        # (H) Every name declared in the scopes the READ WALK descends into
+        # (H) (locals incl. untyped `var x = 3`, parameters, lambda params): a
+        # (H) declaration shadows a same-name property for the read pass. The
+        # (H) two walks must skip the SAME nested scopes: a local declared in a
+        # (H) nested local function must not suppress the outer body's reads
+        # (H) (that scope has its own pass), and a lambda body -- which the
+        # (H) read walk does descend into -- must contribute its params,
+        # (H) including a simple lambda's bare-identifier parameter, or an
+        # (H) in-lambda shadowed read fabricates a property reference.
         names: set[str] = set()
-        stack = [caller_node]
+        stack = list(caller_node.children)
         while stack:
             node = stack.pop()
-            if node.type in (cs.TS_CSHARP_VARIABLE_DECLARATOR, cs.TS_CSHARP_PARAMETER):
+            node_type = node.type
+            if node_type in function_types or node_type in class_types:
+                continue
+            if node_type in (cs.TS_CSHARP_VARIABLE_DECLARATOR, cs.TS_CSHARP_PARAMETER):
                 if name := safe_decode_text(node.child_by_field_name(cs.FIELD_NAME)):
+                    names.add(name)
+            elif node_type == cs.TS_CSHARP_IMPLICIT_PARAMETER:
+                # (H) A simple lambda's parameter (`Size => ...`) is an
+                # (H) implicit_parameter whose text IS the name.
+                if name := safe_decode_text(node):
                     names.add(name)
             stack.extend(node.children)
         return names
@@ -4191,11 +4208,21 @@ class CallProcessor:
                 continue
             if node_type == cs.TS_CSHARP_MEMBER_ACCESS_EXPRESSION:
                 receiver = node.child_by_field_name(cs.TS_CSHARP_FIELD_EXPRESSION)
-                name = self._csharp_read_identifier(receiver)
+                # (H) `this.Size` is ALWAYS the member (a local can never
+                # (H) shadow a this-qualified read), so the read is the NAME
+                # (H) field and the shadow check does not apply.
+                this_read = receiver is not None and receiver.type == cs.TS_CSHARP_THIS
+                name = (
+                    safe_decode_text(node.child_by_field_name(cs.FIELD_NAME))
+                    if this_read
+                    else self._csharp_read_identifier(receiver)
+                )
                 if name and name in prop_names and name not in seen:
                     if shadowed is None:
-                        shadowed = self._csharp_declared_names(caller_node)
-                    if name not in shadowed and (
+                        shadowed = self._csharp_declared_names(
+                            caller_node, function_types, class_types
+                        )
+                    if (this_read or name not in shadowed) and (
                         prop_qn := engine.resolve_property_read(name, caller_qn)
                     ):
                         seen.add(name)

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -4252,13 +4252,27 @@ class CallProcessor:
                     recv_name = self._csharp_read_identifier(receiver)
                     try_emit(recv_name, node, False)
                     # (H) The NAME field can be a property of the RECEIVER's
-                    # (H) type: `Cfg.Value` (static, class-name receiver) or
-                    # (H) `w.Inner` (instance, local of inferred type). An
-                    # (H) unresolvable receiver yields nothing, so unrelated
+                    # (H) type: `Cfg.Value` (static, class-name receiver),
+                    # (H) `w.Inner` (instance, local of inferred type), or
+                    # (H) `N.Cfg.Value` (namespace/type-qualified: a dotted
+                    # (H) receiver of all-PascalCase segments names a type, a
+                    # (H) camelCase head is an expression chain and is skipped).
+                    # (H) An unresolvable receiver yields nothing, so unrelated
                     # (H) chains never fabricate an edge.
                     member = safe_decode_text(node.child_by_field_name(cs.FIELD_NAME))
-                    if recv_name and member and member in prop_names:
+                    recv_type = None
+                    if recv_name:
                         recv_type = (local_var_types or {}).get(recv_name, recv_name)
+                    elif (
+                        receiver is not None
+                        and receiver.type == cs.TS_CSHARP_MEMBER_ACCESS_EXPRESSION
+                    ):
+                        dotted = safe_decode_text(receiver)
+                        if dotted and all(
+                            seg[:1].isupper() for seg in dotted.split(cs.SEPARATOR_DOT)
+                        ):
+                            recv_type = dotted
+                    if recv_type and member and member in prop_names:
                         prop_qn = engine.resolve_member_property_read(
                             recv_type, member, module_qn
                         )

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1790,6 +1790,7 @@ class CallProcessor:
                 caller_node,
                 caller_spec,
                 caller_qn,
+                module_qn,
                 local_var_types,
                 queries[language][cs.QUERY_CONFIG],
                 csharp_prop_names,
@@ -4193,6 +4194,7 @@ class CallProcessor:
         caller_node: Node,
         caller_spec: tuple[str, str, str],
         caller_qn: str,
+        module_qn: str,
         local_var_types: dict[str, str] | None,
         lang_config: LanguageSpec,
         prop_names: set[str],
@@ -4240,13 +4242,35 @@ class CallProcessor:
                 # (H) shadow a this-qualified read), so the read is the NAME
                 # (H) field and the shadow check does not apply.
                 this_read = receiver is not None and receiver.type == cs.TS_CSHARP_THIS
-                try_emit(
-                    safe_decode_text(node.child_by_field_name(cs.FIELD_NAME))
-                    if this_read
-                    else self._csharp_read_identifier(receiver),
-                    node,
-                    this_read,
-                )
+                if this_read:
+                    try_emit(
+                        safe_decode_text(node.child_by_field_name(cs.FIELD_NAME)),
+                        node,
+                        True,
+                    )
+                else:
+                    recv_name = self._csharp_read_identifier(receiver)
+                    try_emit(recv_name, node, False)
+                    # (H) The NAME field can be a property of the RECEIVER's
+                    # (H) type: `Cfg.Value` (static, class-name receiver) or
+                    # (H) `w.Inner` (instance, local of inferred type). An
+                    # (H) unresolvable receiver yields nothing, so unrelated
+                    # (H) chains never fabricate an edge.
+                    member = safe_decode_text(node.child_by_field_name(cs.FIELD_NAME))
+                    if recv_name and member and member in prop_names:
+                        recv_type = (local_var_types or {}).get(recv_name, recv_name)
+                        prop_qn = engine.resolve_member_property_read(
+                            recv_type, member, module_qn
+                        )
+                        if (
+                            prop_qn is not None
+                            and prop_qn != caller_qn
+                            and prop_qn not in seen
+                        ):
+                            seen.add(prop_qn)
+                            ensure_rel(
+                                caller_spec, refs_rel, (method_label, qn_key, prop_qn)
+                            )
             elif node_type == cs.TS_CSHARP_IDENTIFIER:
                 # (H) A bare identifier expression (`return Size;`, `Use(Size)`,
                 # (H) `var n = Size;`) reads the getter just the same. NOT a

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -786,7 +786,11 @@ class CallProcessor:
                         root_node,
                         queries[language][cs.QUERY_CONFIG],
                     )
-            if not all_call_nodes:
+            if not all_call_nodes and language != cs.SupportedLanguage.CSHARP:
+                # (H) A file with no call expressions has nothing further to
+                # (H) process -- except in C#, where a class can still READ
+                # (H) properties (`return Size;`); the member-read pass runs
+                # (H) per caller inside class processing, so C# proceeds.
                 return
             self._process_calls_in_classes(
                 root_node,
@@ -4144,38 +4148,45 @@ class CallProcessor:
             return safe_decode_text(receiver)
         return None
 
-    def _csharp_declared_names(
+    def _csharp_shadow_spans(
         self,
         caller_node: Node,
         function_types: tuple[str, ...],
         class_types: tuple[str, ...],
-    ) -> set[str]:
-        # (H) Every name declared in the scopes the READ WALK descends into
-        # (H) (locals incl. untyped `var x = 3`, parameters, lambda params): a
-        # (H) declaration shadows a same-name property for the read pass. The
-        # (H) two walks must skip the SAME nested scopes: a local declared in a
-        # (H) nested local function must not suppress the outer body's reads
-        # (H) (that scope has its own pass), and a lambda body -- which the
-        # (H) read walk does descend into -- must contribute its params,
-        # (H) including a simple lambda's bare-identifier parameter, or an
-        # (H) in-lambda shadowed read fabricates a property reference.
-        names: set[str] = set()
+    ) -> dict[str, list[tuple[int, int]]]:
+        # (H) {declared name: [byte span of each declaring SCOPE]} for every
+        # (H) declaration in the scopes the READ WALK descends into (locals
+        # (H) incl. untyped `var x = 3`, parameters, and a simple lambda's
+        # (H) bare implicit_parameter). A declaration shadows a same-name
+        # (H) property only for reads INSIDE its declaring scope -- a lambda
+        # (H) param or a sibling block's local must not suppress an outer
+        # (H) read, while an in-lambda shadowed read must not fabricate a
+        # (H) property reference. The two walks skip the SAME nested
+        # (H) function/class scopes (each of those has its own pass).
+        def scope_span(decl: Node) -> tuple[int, int]:
+            anc = decl.parent
+            while anc is not None and anc != caller_node:
+                if anc.type in (cs.TS_CSHARP_BLOCK, cs.TS_CSHARP_LAMBDA_EXPRESSION):
+                    return (anc.start_byte, anc.end_byte)
+                anc = anc.parent
+            return (caller_node.start_byte, caller_node.end_byte)
+
+        spans: dict[str, list[tuple[int, int]]] = {}
         stack = list(caller_node.children)
         while stack:
             node = stack.pop()
             node_type = node.type
             if node_type in function_types or node_type in class_types:
                 continue
+            name = None
             if node_type in (cs.TS_CSHARP_VARIABLE_DECLARATOR, cs.TS_CSHARP_PARAMETER):
-                if name := safe_decode_text(node.child_by_field_name(cs.FIELD_NAME)):
-                    names.add(name)
+                name = safe_decode_text(node.child_by_field_name(cs.FIELD_NAME))
             elif node_type == cs.TS_CSHARP_IMPLICIT_PARAMETER:
-                # (H) A simple lambda's parameter (`Size => ...`) is an
-                # (H) implicit_parameter whose text IS the name.
-                if name := safe_decode_text(node):
-                    names.add(name)
+                name = safe_decode_text(node)
+            if name:
+                spans.setdefault(name, []).append(scope_span(node))
             stack.extend(node.children)
-        return names
+        return spans
 
     def _ingest_csharp_property_reads(
         self,
@@ -4197,18 +4208,20 @@ class CallProcessor:
         method_label = cs.NodeLabel.METHOD
         function_types = lang_config.function_node_types
         class_types = lang_config.class_node_types
-        shadowed: set[str] | None = None
+        shadowed: dict[str, list[tuple[int, int]]] | None = None
         seen: set[str] = set()
 
-        def try_emit(name: str | None, this_read: bool) -> None:
+        def try_emit(name: str | None, read_node: Node, this_read: bool) -> None:
             nonlocal shadowed
             if not name or name not in prop_names or name in seen:
                 return
             if shadowed is None:
-                shadowed = self._csharp_declared_names(
+                shadowed = self._csharp_shadow_spans(
                     caller_node, function_types, class_types
                 )
-            if (this_read or name not in shadowed) and (
+            pos = read_node.start_byte
+            is_shadowed = any(lo <= pos < hi for lo, hi in shadowed.get(name, ()))
+            if (this_read or not is_shadowed) and (
                 prop_qn := engine.resolve_property_read(name, caller_qn)
             ):
                 seen.add(name)
@@ -4231,6 +4244,7 @@ class CallProcessor:
                     safe_decode_text(node.child_by_field_name(cs.FIELD_NAME))
                     if this_read
                     else self._csharp_read_identifier(receiver),
+                    node,
                     this_read,
                 )
             elif node_type == cs.TS_CSHARP_IDENTIFIER:
@@ -4249,7 +4263,7 @@ class CallProcessor:
                     and parent.child_by_field_name(cs.FIELD_NAME) != node
                     and parent.child_by_field_name(cs.FIELD_TYPE) != node
                 ):
-                    try_emit(safe_decode_text(node), False)
+                    try_emit(safe_decode_text(node), node, False)
             stack.extend(node.children)
 
     def _build_nested_qualified_name(

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1774,6 +1774,23 @@ class CallProcessor:
                 prop_names,
             )
 
+        # (H) Same need as the Python pass above, C# shape: a property getter
+        # (H) access is a member_access_expression (usually in RECEIVER
+        # (H) position), never an invocation, so callers that only READ a
+        # (H) property emit no edge to it and dead-code flags it (Polly's
+        # (H) Context.WrappedDictionary, ResiliencePipeline<T>.Pipeline).
+        if language == cs.SupportedLanguage.CSHARP and (
+            csharp_prop_names := self._resolver.function_registry.property_names()
+        ):
+            self._ingest_csharp_property_reads(
+                caller_node,
+                caller_spec,
+                caller_qn,
+                local_var_types,
+                queries[language][cs.QUERY_CONFIG],
+                csharp_prop_names,
+            )
+
         # (H) Operator syntax (k in r, r[k], r[k]=v, len(r)) dispatches to dunder
         # (H) methods; emit those edges when the operand is a first-party type.
         if language == cs.SupportedLanguage.PYTHON:
@@ -4102,6 +4119,92 @@ class CallProcessor:
                                     calls_rel,
                                     (method_label, qn_key, target_qn),
                                 )
+            stack.extend(node.children)
+
+    def _csharp_read_identifier(self, receiver: Node | None) -> str | None:
+        # (H) The identifier actually being READ in receiver position: unwrap
+        # (H) parens, a cast's VALUE (`((IDictionary<...>)WrappedDictionary)`),
+        # (H) and a null-forgiving postfix (`s!`) down to a bare identifier.
+        while receiver is not None:
+            if receiver.type == cs.TS_PARENTHESIZED_EXPRESSION:
+                receiver = (
+                    receiver.named_children[0] if receiver.named_children else None
+                )
+                continue
+            if receiver.type == cs.TS_CSHARP_CAST_EXPRESSION:
+                receiver = receiver.child_by_field_name(cs.FIELD_VALUE)
+                continue
+            if receiver.type == cs.TS_CSHARP_POSTFIX_UNARY_EXPRESSION:
+                receiver = (
+                    receiver.named_children[0] if receiver.named_children else None
+                )
+                continue
+            break
+        if receiver is not None and receiver.type == cs.TS_CSHARP_IDENTIFIER:
+            return safe_decode_text(receiver)
+        return None
+
+    def _csharp_declared_names(self, caller_node: Node) -> set[str]:
+        # (H) Every name declared anywhere in the body (locals incl. untyped
+        # (H) `var x = 3`, parameters, lambda params): a declaration shadows a
+        # (H) same-name property for the read pass. Method-wide rather than
+        # (H) block-precise -- suppression can only drop a REFERENCES edge,
+        # (H) never fabricate one.
+        names: set[str] = set()
+        stack = [caller_node]
+        while stack:
+            node = stack.pop()
+            if node.type in (cs.TS_CSHARP_VARIABLE_DECLARATOR, cs.TS_CSHARP_PARAMETER):
+                if name := safe_decode_text(node.child_by_field_name(cs.FIELD_NAME)):
+                    names.add(name)
+            stack.extend(node.children)
+        return names
+
+    def _ingest_csharp_property_reads(
+        self,
+        caller_node: Node,
+        caller_spec: tuple[str, str, str],
+        caller_qn: str,
+        local_var_types: dict[str, str] | None,
+        lang_config: LanguageSpec,
+        prop_names: set[str],
+    ) -> None:
+        # (H) Emit a REFERENCES edge (a read is not an invocation; the call
+        # (H) graph stays invocation-only) from the caller to each property of
+        # (H) its enclosing type read in receiver position. Registry-guarded via
+        # (H) resolve_property_read, which accepts only marked properties.
+        engine = self._resolver.type_inference.csharp_type_inference
+        ensure_rel = self.ingestor.ensure_relationship_batch
+        refs_rel = cs.RelationshipType.REFERENCES
+        qn_key = cs.KEY_QUALIFIED_NAME
+        method_label = cs.NodeLabel.METHOD
+        function_types = lang_config.function_node_types
+        class_types = lang_config.class_node_types
+        shadowed: set[str] | None = None
+        seen: set[str] = set()
+
+        stack = list(caller_node.children)
+        while stack:
+            node = stack.pop()
+            node_type = node.type
+            if node_type in function_types or node_type in class_types:
+                continue
+            if node_type == cs.TS_CSHARP_MEMBER_ACCESS_EXPRESSION:
+                receiver = node.child_by_field_name(cs.TS_CSHARP_FIELD_EXPRESSION)
+                name = self._csharp_read_identifier(receiver)
+                if name and name in prop_names and name not in seen:
+                    if shadowed is None:
+                        shadowed = self._csharp_declared_names(caller_node)
+                    if name not in shadowed and (
+                        prop_qn := engine.resolve_property_read(name, caller_qn)
+                    ):
+                        seen.add(name)
+                        if prop_qn != caller_qn:
+                            ensure_rel(
+                                caller_spec,
+                                refs_rel,
+                                (method_label, qn_key, prop_qn),
+                            )
             stack.extend(node.children)
 
     def _build_nested_qualified_name(

--- a/codebase_rag/parsers/csharp/type_inference.py
+++ b/codebase_rag/parsers/csharp/type_inference.py
@@ -398,6 +398,22 @@ class CSharpTypeInferenceEngine:
             return qn
         return None
 
+    def resolve_member_property_read(
+        self, receiver_type: str, name: str, module_qn: str
+    ) -> str | None:
+        # (H) `Cfg.Value` / `w.Inner`: the NAME field read resolved against the
+        # (H) receiver's type (a class name for a static read, an inferred
+        # (H) local/parameter type for an instance read). Accepts ONLY a
+        # (H) registered property; an unresolvable receiver yields nothing, so
+        # (H) unrelated `x.Value` chains never fabricate an edge.
+        class_qn = self._type_name_to_qn(receiver_type, module_qn)
+        if class_qn is None:
+            return None
+        qn = self._find_name_across_parts(class_qn, name)
+        if qn is not None and self.function_registry.is_property(qn):
+            return qn
+        return None
+
     def _semantic_call_target(
         self, call_node: Node, module_qn: str
     ) -> tuple[str, str] | None:

--- a/codebase_rag/parsers/csharp/type_inference.py
+++ b/codebase_rag/parsers/csharp/type_inference.py
@@ -384,6 +384,20 @@ class CSharpTypeInferenceEngine:
                 return
             yield scope
 
+    def resolve_property_read(self, name: str, caller_qn: str | None) -> str | None:
+        # (H) A bare-identifier read (`WrappedDictionary.Keys`) targets a
+        # (H) property of the caller's enclosing type (implicit this); resolve
+        # (H) across partial parts and base classes and accept ONLY a
+        # (H) registered property, so same-name methods stay out of the read
+        # (H) pass.
+        class_qn = self._containing_class_qn(caller_qn)
+        if class_qn is None:
+            return None
+        qn = self._find_name_across_parts(class_qn, name)
+        if qn is not None and self.function_registry.is_property(qn):
+            return qn
+        return None
+
     def _semantic_call_target(
         self, call_node: Node, module_qn: str
     ) -> tuple[str, str] | None:

--- a/codebase_rag/parsers/csharp/type_inference.py
+++ b/codebase_rag/parsers/csharp/type_inference.py
@@ -632,10 +632,14 @@ class CSharpTypeInferenceEngine:
         # (H) A cast receiver `((Component)s!).Reload()` (Polly's
         # (H) CancellationToken.Register callback) arrives as
         # (H) parenthesized_expression > cast_expression; the cast TYPE is the
-        # (H) receiver's type by construction, so unwrap parens and read it
-        # (H) (mirrors the Java cast-receiver handling). The null-forgiving `s!`
-        # (H) sits INSIDE the cast, so no postfix peeling is needed.
-        while receiver.type == cs.TS_PARENTHESIZED_EXPRESSION:
+        # (H) receiver's type by construction, so peel interleaved parens and
+        # (H) null-forgiving postfix wrappers (`((Component)s)!` puts the `!`
+        # (H) OUTSIDE the parens) to a fixpoint and read it (mirrors the Java
+        # (H) cast-receiver handling).
+        while receiver.type in (
+            cs.TS_PARENTHESIZED_EXPRESSION,
+            cs.TS_CSHARP_POSTFIX_UNARY_EXPRESSION,
+        ):
             inner = receiver.named_children[0] if receiver.named_children else None
             if inner is None:
                 return None

--- a/codebase_rag/parsers/csharp/type_inference.py
+++ b/codebase_rag/parsers/csharp/type_inference.py
@@ -523,6 +523,14 @@ class CSharpTypeInferenceEngine:
         # (H) (`string`, `int`) that are never registered as classes, so the raw
         # (H) type name is all we can match on. Mirrors _resolve_receiver_class_qn's
         # (H) branches but stops at the name.
+        unwrapped = self._unwrap_receiver(receiver)
+        if unwrapped is None:
+            return None
+        receiver = unwrapped
+        # (H) `((Widget)o).Ext()`: the cast target IS the receiver type, so an
+        # (H) extension-only method still binds on a cast receiver.
+        if receiver.type == cs.TS_CSHARP_CAST_EXPRESSION:
+            return self._cast_type_name(receiver)
         if receiver.type == cs.TS_CSHARP_THIS:
             return self._this_receiver_type(module_qn, caller_qn)
         if receiver.type == cs.TS_CSHARP_MEMBER_ACCESS_EXPRESSION:
@@ -530,6 +538,23 @@ class CSharpTypeInferenceEngine:
         if receiver.type == cs.TS_CSHARP_IDENTIFIER:
             return self._identifier_receiver_type(receiver, local_var_types, caller_qn)
         return None
+
+    def _unwrap_receiver(self, receiver: Node) -> Node | None:
+        # (H) Peel interleaved parens and null-forgiving postfix wrappers
+        # (H) (`((Component)s)!` puts the `!` OUTSIDE the parens) to a fixpoint.
+        while receiver.type in (
+            cs.TS_PARENTHESIZED_EXPRESSION,
+            cs.TS_CSHARP_POSTFIX_UNARY_EXPRESSION,
+        ):
+            inner = receiver.named_children[0] if receiver.named_children else None
+            if inner is None:
+                return None
+            receiver = inner
+        return receiver
+
+    def _cast_type_name(self, cast_node: Node) -> str | None:
+        cast_type = safe_decode_text(cast_node.child_by_field_name(cs.FIELD_TYPE))
+        return _normalize_type_name(cast_type) if cast_type else None
 
     def _this_receiver_type(self, module_qn: str, caller_qn: str | None) -> str | None:
         qn = self._containing_class_qn(caller_qn)
@@ -646,25 +671,17 @@ class CSharpTypeInferenceEngine:
         caller_qn: str | None,
     ) -> str | None:
         # (H) A cast receiver `((Component)s!).Reload()` (Polly's
-        # (H) CancellationToken.Register callback) arrives as
-        # (H) parenthesized_expression > cast_expression; the cast TYPE is the
-        # (H) receiver's type by construction, so peel interleaved parens and
-        # (H) null-forgiving postfix wrappers (`((Component)s)!` puts the `!`
-        # (H) OUTSIDE the parens) to a fixpoint and read it (mirrors the Java
-        # (H) cast-receiver handling).
-        while receiver.type in (
-            cs.TS_PARENTHESIZED_EXPRESSION,
-            cs.TS_CSHARP_POSTFIX_UNARY_EXPRESSION,
-        ):
-            inner = receiver.named_children[0] if receiver.named_children else None
-            if inner is None:
-                return None
-            receiver = inner
+        # (H) CancellationToken.Register callback): the cast TYPE is the
+        # (H) receiver's type by construction (mirrors the Java cast-receiver
+        # (H) handling).
+        unwrapped = self._unwrap_receiver(receiver)
+        if unwrapped is None:
+            return None
+        receiver = unwrapped
         if receiver.type == cs.TS_CSHARP_CAST_EXPRESSION:
-            cast_type = safe_decode_text(receiver.child_by_field_name(cs.FIELD_TYPE))
-            if not cast_type:
-                return None
-            return self._type_name_to_qn(_normalize_type_name(cast_type), module_qn)
+            if cast_type := self._cast_type_name(receiver):
+                return self._type_name_to_qn(cast_type, module_qn)
+            return None
         if receiver.type == cs.TS_CSHARP_THIS:
             return self._containing_class_qn(caller_qn)
         # (H) An explicit `this.field` receiver: the field's (possibly inherited)

--- a/codebase_rag/parsers/csharp/type_inference.py
+++ b/codebase_rag/parsers/csharp/type_inference.py
@@ -615,6 +615,22 @@ class CSharpTypeInferenceEngine:
         module_qn: str,
         caller_qn: str | None,
     ) -> str | None:
+        # (H) A cast receiver `((Component)s!).Reload()` (Polly's
+        # (H) CancellationToken.Register callback) arrives as
+        # (H) parenthesized_expression > cast_expression; the cast TYPE is the
+        # (H) receiver's type by construction, so unwrap parens and read it
+        # (H) (mirrors the Java cast-receiver handling). The null-forgiving `s!`
+        # (H) sits INSIDE the cast, so no postfix peeling is needed.
+        while receiver.type == cs.TS_PARENTHESIZED_EXPRESSION:
+            inner = receiver.named_children[0] if receiver.named_children else None
+            if inner is None:
+                return None
+            receiver = inner
+        if receiver.type == cs.TS_CSHARP_CAST_EXPRESSION:
+            cast_type = safe_decode_text(receiver.child_by_field_name(cs.FIELD_TYPE))
+            if not cast_type:
+                return None
+            return self._type_name_to_qn(_normalize_type_name(cast_type), module_qn)
         if receiver.type == cs.TS_CSHARP_THIS:
             return self._containing_class_qn(caller_qn)
         # (H) An explicit `this.field` receiver: the field's (possibly inherited)

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -798,7 +798,12 @@ def ingest_method(
     # (H) the registry's property-name set for unchanged files (it re-marks from this
     # (H) flag rather than re-parsing decorators); property-dispatch call resolution
     # (H) depends on it, so without persistence those edges drop (issue #532 parity).
-    is_property = _is_property_decorator(decorators)
+    # (H) A C# property_declaration IS a property by grammar (no decorator to
+    # (H) inspect); marking it lets the C# member-read pass find it, exactly as
+    # (H) Python's @property marking feeds its attribute-access pass.
+    is_property = _is_property_decorator(decorators) or (
+        method_node.type == cs.TS_CSHARP_PROPERTY_DECLARATION
+    )
     if is_property:
         method_props[cs.KEY_IS_PROPERTY] = True
 

--- a/codebase_rag/tests/test_csharp_extension_methods.py
+++ b/codebase_rag/tests/test_csharp_extension_methods.py
@@ -349,3 +349,28 @@ public class App {
     # (H) path this test guards.
     targets = _call_targets(mock_ingestor)
     assert not any(t.endswith("N.WidgetExt.Poke(Widget)") for t in targets), targets
+
+
+def test_cast_receiver_binds_extension_method(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) `((Widget)o).Poke()` types its receiver by the CAST target; the
+    # (H) extension path's receiver-type lookup must unwrap the cast like the
+    # (H) instance path does, or an extension-only method loses its CALLS edge.
+    (csharp_project / "E.cs").write_text(
+        """
+namespace N;
+public class Widget { }
+public static class WidgetExt {
+    public static void Poke(this Widget w) { }
+}
+public class App {
+    public void Run(object o) { ((Widget)o).Poke(); }
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    targets = _call_targets(mock_ingestor)
+    assert any(t.endswith("N.WidgetExt.Poke(Widget)") for t in targets), targets

--- a/codebase_rag/tests/test_csharp_property_reads.py
+++ b/codebase_rag/tests/test_csharp_property_reads.py
@@ -210,3 +210,56 @@ public class Component {
 
     calls = {c.args[2][2] for c in get_relationships(mock_ingestor, "CALLS")}
     assert any(t.endswith("N.Component.Reload") for t in calls), calls
+
+
+def test_bare_identifier_property_reads_are_referenced(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) A property read need not be a member access: `return Size;`,
+    # (H) `Use(Size)`, and `var n = Size;` are bare identifier expressions
+    # (H) that read the getter just the same.
+    (csharp_project / "B.cs").write_text(
+        """
+namespace N;
+public class Bare {
+    private int SizeR { get; }
+    private int SizeA { get; }
+    private int SizeI { get; }
+    public int Ret() { return SizeR; }
+    public void Arg() { Use(SizeA); }
+    public int Init() { var n = SizeI; return n; }
+    private void Use(int x) {}
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    refs = _reference_targets(mock_ingestor)
+    for prop in ("N.Bare.SizeR", "N.Bare.SizeA", "N.Bare.SizeI"):
+        assert any(t.endswith(prop) for t in refs), (prop, refs)
+
+
+def test_named_argument_label_and_type_position_do_not_reference(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) Guards for the bare-identifier read: a named-argument LABEL
+    # (H) (`Use(Size: 3)`) and a TYPE position (`new Size()`) are not reads of
+    # (H) a same-name property.
+    (csharp_project / "NG.cs").write_text(
+        """
+namespace N;
+public class Size { }
+public class Guards {
+    private int Size { get; }
+    public void Lab() { Use(Size: 3); }
+    public object Mk() { return new Size(); }
+    private void Use(int Size) {}
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    refs = _reference_targets(mock_ingestor)
+    assert not any(t.endswith("N.Guards.Size") for t in refs), refs

--- a/codebase_rag/tests/test_csharp_property_reads.py
+++ b/codebase_rag/tests/test_csharp_property_reads.py
@@ -263,3 +263,51 @@ public class Guards {
 
     refs = _reference_targets(mock_ingestor)
     assert not any(t.endswith("N.Guards.Size") for t in refs), refs
+
+
+def test_lambda_shadow_does_not_suppress_outer_read(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) A shadow only covers reads INSIDE its declaring scope: the lambda
+    # (H) parameter must not suppress the OUTER `Size` getter read in the same
+    # (H) expression.
+    (csharp_project / "OS.cs").write_text(
+        """
+namespace N;
+public class OuterShadow {
+    private int Size { get; }
+    public int Mix(System.Collections.Generic.List<int> xs)
+        => Size + System.Linq.Enumerable.First(
+               System.Linq.Enumerable.Select(xs, Size => Size));
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    refs = _reference_targets(mock_ingestor)
+    assert any(t.endswith("N.OuterShadow.Size") for t in refs), refs
+
+
+def test_sibling_block_local_does_not_suppress_outer_read(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) A local declared in one BLOCK must not suppress a read outside that
+    # (H) block: shadowing is scoped to the declaring block's span.
+    (csharp_project / "SB.cs").write_text(
+        """
+namespace N;
+public class BlockShadow {
+    private int Size { get; }
+    public int Mix() {
+        { var Size = 3; Size += 1; }
+        return Size;
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    refs = _reference_targets(mock_ingestor)
+    assert any(t.endswith("N.BlockShadow.Size") for t in refs), refs

--- a/codebase_rag/tests/test_csharp_property_reads.py
+++ b/codebase_rag/tests/test_csharp_property_reads.py
@@ -359,3 +359,25 @@ public class App {
 
     refs = _reference_targets(mock_ingestor)
     assert any(t.endswith("N.Widget.Inner") for t in refs), refs
+
+
+def test_namespace_qualified_static_property_read_is_referenced(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) `N.Cfg.Value`: the outer receiver is itself a member access naming a
+    # (H) TYPE through its namespace; the dotted qualifier (all PascalCase
+    # (H) segments) resolves to the class and the name field is the read.
+    (csharp_project / "NQ.cs").write_text(
+        """
+namespace N;
+public class Cfg {
+    private static int Value { get; }
+    public static int Get() { return N.Cfg.Value; }
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    refs = _reference_targets(mock_ingestor)
+    assert any(t.endswith("N.Cfg.Value") for t in refs), refs

--- a/codebase_rag/tests/test_csharp_property_reads.py
+++ b/codebase_rag/tests/test_csharp_property_reads.py
@@ -116,3 +116,97 @@ public class Guard {
 
     refs = _reference_targets(mock_ingestor)
     assert not any(t.endswith("N.Guard.Size") for t in refs), refs
+
+
+def test_explicit_this_property_read_is_referenced(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) `this.Size` is always the member (locals can never shadow a
+    # (H) this-qualified read), so the read pass must record the NAME field
+    # (H) when the receiver is `this`.
+    (csharp_project / "T.cs").write_text(
+        """
+namespace N;
+public class Ctx {
+    private int Size { get; }
+    public string Show() => this.Size.ToString();
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    refs = _reference_targets(mock_ingestor)
+    assert any(t.endswith("N.Ctx.Size") for t in refs), refs
+
+
+def test_nested_local_function_shadow_does_not_suppress_outer_read(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) A local declared inside a NESTED local function must not shadow the
+    # (H) outer body's property read: the read walk skips nested function
+    # (H) scopes, so the shadow walk must skip them symmetrically.
+    (csharp_project / "S.cs").write_text(
+        """
+namespace N;
+public class Outer {
+    private int Size { get; }
+    public string Show() {
+        string Local() {
+            var Size = 3;
+            return Size.ToString();
+        }
+        return Local() + Size.ToString();
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    refs = _reference_targets(mock_ingestor)
+    assert any(t.endswith("N.Outer.Size") for t in refs), refs
+
+
+def test_simple_lambda_parameter_shadows_property(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) A simple (untyped) lambda parameter is a bare identifier, not a
+    # (H) `parameter` node; it still shadows a same-name property for reads
+    # (H) inside the lambda body, which the read walk descends into.
+    (csharp_project / "L.cs").write_text(
+        """
+namespace N;
+public class Lam {
+    private int Size { get; }
+    public System.Func<int, string> Make() => Size => Size.ToString();
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    refs = _reference_targets(mock_ingestor)
+    assert not any(t.endswith("N.Lam.Size") for t in refs), refs
+
+
+def test_postfix_wrapped_cast_receiver_resolves(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) The null-forgiving postfix can sit OUTSIDE the parenthesized cast
+    # (H) (`((Component)s)!.Reload()`); the receiver unwrap must peel
+    # (H) interleaved postfix/paren wrappers to a fixpoint before the cast.
+    (csharp_project / "P.cs").write_text(
+        """
+namespace N;
+public class Component {
+    public void Reload() {}
+    public void Wire(object s) { ((Component)s)!.Reload(); }
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    calls = {c.args[2][2] for c in get_relationships(mock_ingestor, "CALLS")}
+    assert any(t.endswith("N.Component.Reload") for t in calls), calls

--- a/codebase_rag/tests/test_csharp_property_reads.py
+++ b/codebase_rag/tests/test_csharp_property_reads.py
@@ -311,3 +311,51 @@ public class BlockShadow {
 
     refs = _reference_targets(mock_ingestor)
     assert any(t.endswith("N.BlockShadow.Size") for t in refs), refs
+
+
+def test_class_qualified_static_property_read_is_referenced(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) `Cfg.Value` reads a STATIC property through the class name; the NAME
+    # (H) field is the read, resolved against the receiver TYPE rather than
+    # (H) the caller's enclosing class.
+    (csharp_project / "ST.cs").write_text(
+        """
+namespace N;
+public class Cfg {
+    private static int Value { get; }
+    public static int Get() { return Cfg.Value; }
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    refs = _reference_targets(mock_ingestor)
+    assert any(t.endswith("N.Cfg.Value") for t in refs), refs
+
+
+def test_typed_receiver_instance_property_read_is_referenced(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) `w.Inner` on a local whose type is known reads Widget.Inner; resolve
+    # (H) the name field against the receiver's inferred type.
+    (csharp_project / "TR.cs").write_text(
+        """
+namespace N;
+public class Widget {
+    internal int Inner { get; }
+}
+public class App {
+    public int Run() {
+        var w = new Widget();
+        return w.Inner;
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    refs = _reference_targets(mock_ingestor)
+    assert any(t.endswith("N.Widget.Inner") for t in refs), refs

--- a/codebase_rag/tests/test_csharp_property_reads.py
+++ b/codebase_rag/tests/test_csharp_property_reads.py
@@ -1,0 +1,118 @@
+# (H) C# property READS: a getter access is a member_access_expression, not an
+# (H) invocation, so without a read pass a heavily-read property has zero
+# (H) inbound edges and dead-code flags it (Polly's Context.WrappedDictionary
+# (H) and ResiliencePipeline<T>.Pipeline).
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag.tests.conftest import get_relationships, run_updater
+
+SKIP = "c_sharp"
+
+
+@pytest.fixture
+def csharp_project(temp_repo: Path) -> Path:
+    project = temp_repo / "csharp_prop_reads"
+    project.mkdir()
+    return project
+
+
+def _reference_targets(mock_ingestor: MagicMock) -> set[str]:
+    return {c.args[2][2] for c in get_relationships(mock_ingestor, "REFERENCES")}
+
+
+def _call_targets(mock_ingestor: MagicMock) -> set[str]:
+    return {c.args[2][2] for c in get_relationships(mock_ingestor, "CALLS")}
+
+
+def test_receiver_position_property_read_is_referenced(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) `WrappedDictionary.Keys` reads the property as the RECEIVER of a
+    # (H) member access; the read must land a REFERENCES edge on the property
+    # (H) node (REFERENCES, not CALLS: the call graph stays invocation-only).
+    (csharp_project / "R.cs").write_text(
+        """
+namespace N;
+public class Ctx {
+    private int Size { get; }
+    public string Show() => Size.ToString();
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    refs = _reference_targets(mock_ingestor)
+    assert any(t.endswith("N.Ctx.Size") for t in refs), refs
+    assert not any(t.endswith("N.Ctx.Size") for t in _call_targets(mock_ingestor))
+
+
+def test_cast_wrapped_property_read_is_referenced(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) `((IDictionary<...>)WrappedDictionary).Clear()` wraps the property
+    # (H) read in a cast; the cast VALUE is still a read of the property.
+    (csharp_project / "C.cs").write_text(
+        """
+namespace N;
+public class Ctx {
+    private object Bag { get; }
+    public string Dump() => ((System.Collections.IEnumerable)Bag).ToString();
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    refs = _reference_targets(mock_ingestor)
+    assert any(t.endswith("N.Ctx.Bag") for t in refs), refs
+
+
+def test_invocation_receiver_property_read_is_referenced(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) `Pipeline.Execute(...)`: the invocation edge targets Execute, but the
+    # (H) receiver position is itself a READ of the Pipeline property that must
+    # (H) keep the property reachable.
+    (csharp_project / "I.cs").write_text(
+        """
+namespace N;
+public class Widget { public void Area() {} }
+public class Pipe {
+    private Widget Inner { get; }
+    public void Go() { Inner.Area(); }
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    refs = _reference_targets(mock_ingestor)
+    assert any(t.endswith("N.Pipe.Inner") for t in refs), refs
+
+
+def test_local_shadow_and_methods_are_not_referenced(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) Guards: a local variable shadowing a property name is NOT a property
+    # (H) read, and a same-name METHOD receiver stays out of the read pass.
+    (csharp_project / "G.cs").write_text(
+        """
+namespace N;
+public class Guard {
+    private int Size { get; }
+    public string Show() {
+        var Size = 3;
+        return Size.ToString();
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    refs = _reference_targets(mock_ingestor)
+    assert not any(t.endswith("N.Guard.Size") for t in refs), refs

--- a/codebase_rag/tests/test_csharp_type_inference.py
+++ b/codebase_rag/tests/test_csharp_type_inference.py
@@ -292,3 +292,30 @@ public class App { public void Run() { var c = new Calc(); c.Add(1, 2); } }
     # (H) c.Add(1, 2) binds the two-argument overload, not the one-argument one.
     assert any(t.endswith("N.Calc.Add(int, int)") for t in targets), targets
     assert not any(t.endswith("N.Calc.Add(int)") for t in targets), targets
+
+
+def test_cast_expression_receiver_resolves(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) A cast receiver `((ReloadableComponent)s!).Reload()` (Polly's
+    # (H) CancellationToken.Register callback pattern) hands the resolver a
+    # (H) parenthesized_expression wrapping a cast_expression; without
+    # (H) unwrapping to the cast TYPE the receiver is untypable, no CALLS edge
+    # (H) is emitted, and the callback target is flagged dead.
+    (csharp_project / "C.cs").write_text(
+        """
+namespace N;
+public class Component {
+    public void Reload() {}
+    public void Wire(System.Threading.CancellationToken token) {
+        token.Register(static s => ((Component)s!).Reload(), this);
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    assert any(
+        t.endswith("N.Component.Reload") for t in _call_targets(mock_ingestor)
+    ), _call_targets(mock_ingestor)

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.365"
+version = "0.0.366"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

Round 3 of the C# dead-code dogfood on Polly (follows #782 and #784): non-invocation property reads now emit REFERENCES edges, and cast-expression receivers resolve through their cast type. Polly false flags drop from 12 to 8; the retrieval eval gains 2 true-positive call edges with precision staying 1.0000.

## Root causes

1. **Property reads produced no edge at all.** A C# property ingests as a Method node and is a full dead-code candidate, but a getter access is a `member_access_expression`, never an invocation, and the only member-read pass in the codebase is gated to Python. A property that is only ever read (Polly's `Context.WrappedDictionary`, read at roughly 40 sites in one file, and `ResiliencePipeline<T>.Pipeline`) had zero inbound edges and was flagged dead.
2. **Cast receivers were untypable.** `((ReloadableComponent)s!).Reload()` inside a `CancellationToken.Register` callback hands the resolver a `parenthesized_expression` wrapping a `cast_expression`; `_resolve_receiver_class_qn` had no unwrap for either, returned None, and the call emitted no edge, so `Reload` and everything only it reaches (`DisposeDiscardedComponentSafeAsync`) reported dead.

## Fix

All C#-scoped:

- `ingest_method` marks a C# `property_declaration` with the same registry property flag Python's `@property` uses, including the persisted `is_property` node property for incremental rehydration.
- A new C# member-read pass (mirroring the Python attribute pass) walks each caller body for `member_access_expression` receivers, unwraps parens, a cast's value, and a null-forgiving postfix down to a bare identifier, and emits a REFERENCES edge to the enclosing type's registered property (resolved across partial parts and base classes, accepting only marked properties). A name declared anywhere in the body (locals including untyped `var`, parameters) shadows the property and suppresses the edge. REFERENCES rather than CALLS keeps the call graph invocation-only, so the retrieval eval is untouched by design.
- `_resolve_receiver_class_qn` unwraps parenthesized receivers and types a `cast_expression` receiver by its cast target, mirroring the existing Java cast-receiver handling.

## Validation

- RED demonstrated in commit history for both fixes: three failing property-read shapes (receiver position, cast-wrapped, invocation receiver) plus a shadow/method guard, and a failing cast-receiver call-edge test.
- Full suite green; all 123 C# tests pass.
- Polly dead-code: 12 -> 8, zero new findings. Cleared exactly the four predicted: `WrappedDictionary`, `Pipeline`, `Reload`, `DisposeDiscardedComponentSafeAsync`.
- C# retrieval eval (full Polly, Roslyn oracle): tp 3111 -> 3113, fp 0, recall 0.7822 -> 0.7828, precision 1.0000.

## Remaining 8

Method-group references binding one overload of a family (`EmptyAction`, `EmptyHandler`, `EmptyHandlerOfT`, `Snippets.Docs.Fallback.Action`), generic/non-generic cross-type delegation (`GetAsyncContext`, `GetSyncContext`, `InitializeAsyncContext`), and one confirmed true positive (`PolicyBuilder@73`, a private parameterless constructor with no instantiation anywhere in src).
