### PR TITLE
fix(cpp): drop macro-invocation phantom Function nodes, keep recovery-orphaned ctors

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -900,6 +900,12 @@ class GraphUpdater:
         if corrected:
             logger.info("Resolved {} deferred C++ out-of-class methods", corrected)
 
+        orphan_ctors = (
+            self.factory.definition_processor.resolve_deferred_cpp_artifacts()
+        )
+        if orphan_ctors:
+            logger.info("Registered {} recovery-orphaned C++ ctors", orphan_ctors)
+
         contained = self.factory.definition_processor.resolve_deferred_cpp_containment()
         if contained:
             logger.info("Resolved {} deferred C++ nested containments", contained)

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -900,12 +900,6 @@ class GraphUpdater:
         if corrected:
             logger.info("Resolved {} deferred C++ out-of-class methods", corrected)
 
-        orphan_ctors = (
-            self.factory.definition_processor.resolve_deferred_cpp_artifacts()
-        )
-        if orphan_ctors:
-            logger.info("Registered {} recovery-orphaned C++ ctors", orphan_ctors)
-
         contained = self.factory.definition_processor.resolve_deferred_cpp_containment()
         if contained:
             logger.info("Resolved {} deferred C++ nested containments", contained)
@@ -938,6 +932,16 @@ class GraphUpdater:
                 "Registered {} forward-declared C/C++ types with no definition",
                 kept_forwards,
             )
+
+        # (H) After rehydration (an incremental run's class may live in an
+        # (H) unchanged header) and after forward declarations (a kept
+        # (H) forward-declared TYPE also proves the name is a class, not a
+        # (H) macro).
+        orphan_ctors = (
+            self.factory.definition_processor.resolve_deferred_cpp_artifacts()
+        )
+        if orphan_ctors:
+            logger.info("Registered {} recovery-orphaned C++ ctors", orphan_ctors)
 
         # (H) After forward declarations so a base whose only representation is
         # (H) a kept forward declaration still resolves to a real node.

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -869,6 +869,16 @@ class CallProcessor:
                 continue
 
             if language in _C_FAMILY_LANGUAGES:
+                # (H) A macro-invocation artifact the ingest pass declined to
+                # (H) register (no class bears its name) must not become a call
+                # (H) attribution target either; mirror ingest's decision via
+                # (H) the recorded locations so the two passes never diverge.
+                if (
+                    language == cs.SupportedLanguage.CPP
+                    and cpp_utils.is_macro_invocation_artifact(func_node)
+                    and self._recorded_caller(func_node, module_qn) is None
+                ):
+                    continue
                 func_name = cpp_utils.extract_function_name(func_node)
             else:
                 func_name = self._get_node_name(func_node)

--- a/codebase_rag/parsers/cpp/utils.py
+++ b/codebase_rag/parsers/cpp/utils.py
@@ -305,9 +305,7 @@ def _has_named_parameter(declarator: Node) -> bool:
             cs.CppNodeType.PARENTHESIZED_DECLARATOR,
         ):
             return any(
-                declares_identifier(child)
-                for child in node.children
-                if child.is_named
+                declares_identifier(child) for child in node.children if child.is_named
             )
         return False
 

--- a/codebase_rag/parsers/cpp/utils.py
+++ b/codebase_rag/parsers/cpp/utils.py
@@ -289,10 +289,27 @@ def _has_named_parameter(declarator: Node) -> bool:
     if params is None:
         return False
 
-    def contains_identifier(node: Node) -> bool:
+    def declares_identifier(node: Node) -> bool:
+        # (H) Follow only the declarator-field spine (plus the two wrapper
+        # (H) nodes that hold their declarator as a bare child): identifiers
+        # (H) reachable ONLY off that path are array bounds (`int[MAX_SIZE]`)
+        # (H) or an inner fn-ptr's parameter names (`void (*)(int x)`), not
+        # (H) names of THIS parameter.
         if node.type in (cs.CppNodeType.IDENTIFIER, cs.CppNodeType.FIELD_IDENTIFIER):
             return True
-        return any(contains_identifier(child) for child in node.children)
+        inner = node.child_by_field_name(cs.FIELD_DECLARATOR)
+        if inner is not None:
+            return declares_identifier(inner)
+        if node.type in (
+            cs.CppNodeType.REFERENCE_DECLARATOR,
+            cs.CppNodeType.PARENTHESIZED_DECLARATOR,
+        ):
+            return any(
+                declares_identifier(child)
+                for child in node.children
+                if child.is_named
+            )
+        return False
 
     for param in params.children:
         if param.type not in (
@@ -301,7 +318,7 @@ def _has_named_parameter(declarator: Node) -> bool:
         ):
             continue
         inner = param.child_by_field_name(cs.FIELD_DECLARATOR)
-        if inner is not None and contains_identifier(inner):
+        if inner is not None and declares_identifier(inner):
             return True
     return False
 

--- a/codebase_rag/parsers/cpp/utils.py
+++ b/codebase_rag/parsers/cpp/utils.py
@@ -262,6 +262,79 @@ def _extract_name_from_template_declaration(func_node: Node) -> str | None:
     )
 
 
+def _enclosing_class_name(node: Node) -> str | None:
+    current = node.parent
+    while current is not None:
+        if current.type in cs.CPP_TYPE_SPECIFIER_NODE_TYPES:
+            name = current.child_by_field_name(cs.FIELD_NAME)
+            if name is None:
+                return None
+            # (H) A specialization's name (`formatter<T, char>`) is a
+            # (H) template_type; the ctor identifier repeats only the bare name.
+            if name.type == cs.CppNodeType.TEMPLATE_TYPE:
+                inner = name.child_by_field_name(cs.FIELD_NAME)
+                return safe_decode_text(inner) if inner is not None else None
+            return safe_decode_text(name)
+        current = current.parent
+    return None
+
+
+def _has_named_parameter(declarator: Node) -> bool:
+    # (H) A macro invocation's "parameters" are expressions -- `(...)`, bare
+    # (H) identifiers (parsed as type-only declarations), or call shapes -- so
+    # (H) none of them ever carries a NAMED declarator. A real definition's
+    # (H) `int fd` / `const S& s` does. One named parameter is proof of a
+    # (H) genuine declaration even when recovery orphaned it from its class.
+    params = declarator.child_by_field_name(cs.FIELD_PARAMETERS)
+    if params is None:
+        return False
+
+    def contains_identifier(node: Node) -> bool:
+        if node.type in (cs.CppNodeType.IDENTIFIER, cs.CppNodeType.FIELD_IDENTIFIER):
+            return True
+        return any(contains_identifier(child) for child in node.children)
+
+    for param in params.children:
+        if param.type not in (
+            cs.CppNodeType.PARAMETER_DECLARATION,
+            cs.CppNodeType.OPTIONAL_PARAMETER_DECLARATION,
+        ):
+            continue
+        inner = param.child_by_field_name(cs.FIELD_DECLARATOR)
+        if inner is not None and contains_identifier(inner):
+            return True
+    return False
+
+
+def is_macro_invocation_artifact(func_node: Node) -> bool:
+    # (H) `FMT_CATCH(...) {}` -- a macro invocation followed by a block -- parses
+    # (H) as a TYPE-LESS function_definition (or declaration, when member-init
+    # (H) recovery sweeps it into a class body) named after the macro. Valid C++
+    # (H) only omits the return type on a constructor, whose plain-identifier
+    # (H) declarator repeats the enclosing class name; any other type-less
+    # (H) plain-identifier definition with no named parameter is a parse
+    # (H) artifact, not a definition. A recovery-ORPHANED ctor (its class
+    # (H) ancestor destroyed by the same recovery) is distinguished by its named
+    # (H) parameters, or -- for the zero/unnamed-param shape -- by the caller
+    # (H) checking the class registry before dropping the node.
+    if func_node.type not in (
+        cs.CppNodeType.FUNCTION_DEFINITION,
+        cs.CppNodeType.DECLARATION,
+    ):
+        return False
+    if func_node.child_by_field_name(cs.FIELD_TYPE) is not None:
+        return False
+    declarator = func_node.child_by_field_name(cs.FIELD_DECLARATOR)
+    if declarator is None or declarator.type != cs.CppNodeType.FUNCTION_DECLARATOR:
+        return False
+    inner = declarator.child_by_field_name(cs.FIELD_DECLARATOR)
+    if inner is None or inner.type != cs.CppNodeType.IDENTIFIER or not inner.text:
+        return False
+    if safe_decode_text(inner) == _enclosing_class_name(func_node):
+        return False
+    return not _has_named_parameter(declarator)
+
+
 def extract_function_name(func_node: Node) -> str | None:
     name = _extract_function_name_by_type(func_node)
     # (H) A reserved keyword in declarator position is an error-recovery

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -155,6 +155,10 @@ class DefinitionProcessor(
         # (H) Unnamed JS/TS function expressions held back until the named
         # (H) JS passes have claimed their spans (one node per source function).
         self._deferred_js_anonymous: list = []
+        # (H) Macro-invocation-shaped C++ nodes held until every class (incl.
+        # (H) rehydrated ones) is known; resolve_deferred_cpp_artifacts decides
+        # (H) orphaned-ctor vs macro.
+        self._deferred_cpp_artifacts: list = []
         # (H) (module_qn, def start_line) -> (method_qn, class_qn) for every
         # (H) out-of-class C++ method the definition pass bound; Pass-3 call
         # (H) attribution reuses these decisions instead of re-resolving.

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -804,7 +804,7 @@ class FunctionIngestMixin:
                 entry.lang_queries,
             )
             registered += 1
-        self._deferred_cpp_artifacts = []
+        deferred.clear()
         return registered
 
     def _resolve_go_container_qn(self, module_qn: str, receiver_type: str) -> str:

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -303,8 +303,6 @@ class FunctionIngestMixin:
                 # (H) (drop). Same-file classes register after this pass, so
                 # (H) the decision is deferred, not made here.
                 if cpp_utils.is_macro_invocation_artifact(func_node):
-                    if not hasattr(self, "_deferred_cpp_artifacts"):
-                        self._deferred_cpp_artifacts = []
                     self._deferred_cpp_artifacts.append(
                         _DeferredCppArtifact(
                             func_node, module_qn, lang_config, lang_queries
@@ -766,7 +764,7 @@ class FunctionIngestMixin:
         recovery-orphaned constructor); drops the rest as macro invocations.
         Returns the number registered.
         """
-        deferred = getattr(self, "_deferred_cpp_artifacts", None)
+        deferred = self._deferred_cpp_artifacts
         if not deferred:
             return 0
 

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -781,9 +781,7 @@ class FunctionIngestMixin:
             if namespace_path := cs.SEPARATOR_DOT.join(
                 cpp_utils.extract_namespace_path(entry.func_node)
             ):
-                candidates.insert(
-                    0, f"{namespace_path}{cs.SEPARATOR_DOT}{name}"
-                )
+                candidates.insert(0, f"{namespace_path}{cs.SEPARATOR_DOT}{name}")
             if not any(
                 self._resolve_cpp_class_qn(candidate, entry.module_qn)[1]
                 for candidate in candidates

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -101,6 +101,23 @@ class FunctionResolution(NamedTuple):
     is_anonymous: bool = False
 
 
+class _DeferredCppArtifact(NamedTuple):
+    """Macro-invocation-shaped C++ node held until every class is registered.
+
+    A type-less plain-identifier definition with no named parameter is either
+    a macro invocation (`FMT_CATCH(...) {}`) or a recovery-orphaned zero-param
+    constructor (`file() {}` whose class ancestor the parse recovery
+    destroyed). The tiebreak is whether a registered class bears the name, and
+    the class pass for the SAME file runs after the function pass, so the
+    decision must wait for resolve_deferred_cpp_artifacts.
+    """
+
+    func_node: Node
+    module_qn: str
+    lang_config: LanguageSpec
+    lang_queries: LanguageQueries
+
+
 class _DeferredJsAnonymous(NamedTuple):
     """Unnamed JS/TS function expression held back until named passes claim.
 
@@ -194,6 +211,7 @@ class FunctionIngestMixin:
     cpp_definition_spans: dict[str, list[CppDefinitionSpan]]
     macro_qns: set[str]
     _deferred_js_anonymous: list[_DeferredJsAnonymous]
+    _deferred_cpp_artifacts: list[_DeferredCppArtifact]
     class_inheritance: dict[str, list[str]]
     _deferred_cpp_inherits: list[DeferredCppInherit]
     rehydrated_definition_paths: dict[str, str]
@@ -276,6 +294,22 @@ class FunctionIngestMixin:
                     and func_node.parent is not None
                     and func_node.parent.type == cs.CppNodeType.TEMPLATE_DECLARATION
                 ):
+                    continue
+                # (H) A macro invocation parsed as a type-less definition
+                # (H) (`FMT_CATCH(...) {}`) must not mint a phantom Function.
+                # (H) A recovery-orphaned zero-param ctor shares the shape, so
+                # (H) the class registry is the tiebreak: a registered class
+                # (H) bearing the name means ctor (keep), no class means macro
+                # (H) (drop). Same-file classes register after this pass, so
+                # (H) the decision is deferred, not made here.
+                if cpp_utils.is_macro_invocation_artifact(func_node):
+                    if not hasattr(self, "_deferred_cpp_artifacts"):
+                        self._deferred_cpp_artifacts = []
+                    self._deferred_cpp_artifacts.append(
+                        _DeferredCppArtifact(
+                            func_node, module_qn, lang_config, lang_queries
+                        )
+                    )
                     continue
 
             if language == cs.SupportedLanguage.GO and self._defer_go_receiver_method(
@@ -724,6 +758,58 @@ class FunctionIngestMixin:
             )
         )
         return True
+
+    def resolve_deferred_cpp_artifacts(self) -> int:
+        """Decide held-back macro-invocation-shaped nodes now classes are known.
+
+        Registers each deferred node whose name a registered class bears (a
+        recovery-orphaned constructor); drops the rest as macro invocations.
+        Returns the number registered.
+        """
+        deferred = getattr(self, "_deferred_cpp_artifacts", None)
+        if not deferred:
+            return 0
+
+        registered = 0
+        for entry in deferred:
+            name = cpp_utils.extract_function_name(entry.func_node)
+            if not name:
+                continue
+            # (H) Scope-first, mirroring resolve_deferred_cpp_methods: the
+            # (H) namespace-qualified candidate disambiguates same-leaf classes.
+            candidates = [name]
+            if namespace_path := cs.SEPARATOR_DOT.join(
+                cpp_utils.extract_namespace_path(entry.func_node)
+            ):
+                candidates.insert(
+                    0, f"{namespace_path}{cs.SEPARATOR_DOT}{name}"
+                )
+            if not any(
+                self._resolve_cpp_class_qn(candidate, entry.module_qn)[1]
+                for candidate in candidates
+            ):
+                continue
+            file_path = self.module_qn_to_file_path.get(entry.module_qn)
+            resolution = self._resolve_function_identity(
+                entry.func_node,
+                entry.module_qn,
+                cs.SupportedLanguage.CPP,
+                entry.lang_config,
+                file_path,
+            )
+            if not resolution:
+                continue
+            self._register_function(
+                entry.func_node,
+                resolution,
+                entry.module_qn,
+                cs.SupportedLanguage.CPP,
+                entry.lang_config,
+                entry.lang_queries,
+            )
+            registered += 1
+        self._deferred_cpp_artifacts = []
+        return registered
 
     def _resolve_go_container_qn(self, module_qn: str, receiver_type: str) -> str:
         # (H) A method binds to its receiver type. Prefer the same-file type, but

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -719,6 +719,11 @@ def ingest_method(
     if language == cs.SupportedLanguage.CPP:
         from .cpp import utils as cpp_utils
 
+        # (H) Inside an intact class body a macro invocation parsed as a
+        # (H) type-less member (`FMT_CATCH(...) {}`) can never be a ctor of
+        # (H) another class, so the shape check alone is decisive here.
+        if cpp_utils.is_macro_invocation_artifact(method_node):
+            return None
         method_name = cpp_utils.extract_function_name(method_node)
         if not method_name:
             return None

--- a/codebase_rag/tests/test_cpp_macro_invocation_phantoms.py
+++ b/codebase_rag/tests/test_cpp_macro_invocation_phantoms.py
@@ -160,3 +160,56 @@ def test_orphaned_zero_param_ctor_kept_via_class_registry(
     # (H) `pipe() {}` shares the macro-invocation shape; the registered class
     # (H) `pipe` is what keeps it alive.
     assert any(qn.endswith(".pipe") or ".pipe@" in qn for qn in qns), qns
+
+
+PIPE_HDR = """
+#pragma once
+struct pipe {
+  int fd_;
+};
+"""
+
+PIPE_CC = """
+#include "pipe.h"
+
+pipe() {}
+"""
+
+
+def test_incremental_reparse_keeps_orphan_ctor_from_unchanged_header(
+    temp_repo: Path,
+) -> None:
+    # (H) Incremental runs rehydrate the registry from the graph AFTER the
+    # (H) per-file passes; the artifact tiebreak must wait for rehydration or a
+    # (H) re-parsed file's orphaned ctor whose class lives in an UNCHANGED
+    # (H) header is dropped as a macro artifact (PR #788 review finding).
+    from codebase_rag.graph_updater import GraphUpdater
+    from codebase_rag.parser_loader import load_parsers
+    from evals.cgr_graph import _StatefulIngestor
+
+    (temp_repo / "pipe.h").write_text(PIPE_HDR)
+    (temp_repo / "pipe.cc").write_text(PIPE_CC)
+
+    def index(store: _StatefulIngestor, force: bool) -> None:
+        parsers, queries = load_parsers()
+        GraphUpdater(
+            ingestor=store, repo_path=temp_repo, parsers=parsers, queries=queries
+        ).run(force=force)
+
+    def ctor_nodes(store: _StatefulIngestor) -> set[str]:
+        return {
+            str(qn)
+            for (label, qn) in store.nodes
+            if label == cs.NodeLabel.FUNCTION.value
+            and (str(qn).endswith(".pipe") or ".pipe@" in str(qn))
+        }
+
+    store = _StatefulIngestor()
+    index(store, force=True)
+    assert ctor_nodes(store), sorted(store.nodes)
+
+    # (H) A trailing comment changes the hash but not the AST, so only
+    # (H) pipe.cc re-parses; the class comes from rehydration alone.
+    (temp_repo / "pipe.cc").write_text(PIPE_CC + "// touched\n")
+    index(store, force=False)
+    assert ctor_nodes(store), sorted(store.nodes)

--- a/codebase_rag/tests/test_cpp_macro_invocation_phantoms.py
+++ b/codebase_rag/tests/test_cpp_macro_invocation_phantoms.py
@@ -1,0 +1,116 @@
+# (H) A macro invocation followed by a block (`FMT_CATCH(...) {}`) or swept
+# (H) into member-init recovery (`FMT_APPLY_VARIADIC(expr);`) parses as a
+# (H) TYPE-LESS function_definition/declaration named after the macro. Valid
+# (H) C++ only omits the return type on a constructor, whose plain-identifier
+# (H) declarator repeats the enclosing class name; any other type-less
+# (H) plain-identifier definition is a parse artifact and must not mint a
+# (H) phantom Function/Method node (fmt's 5 FMT_CATCH + FMT_APPLY_VARIADIC
+# (H) dead-code false positives).
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import run_updater
+
+MODULE_SCOPE_CATCH_CC = """
+void format_system_error(int error_code, const char* message) noexcept {
+  FMT_TRY {
+    write(error_code, message);
+    return;
+  }
+  FMT_CATCH(...) {}
+  format_error_code(error_code, message);
+}
+"""
+
+IN_CLASS_CATCH_H = """
+template <typename T> struct formatter<T, char> {
+  auto format(const T& value) -> int {
+    FMT_TRY {
+      return write(value);
+    }
+    FMT_CATCH(...) {}
+    return 0;
+  }
+};
+"""
+
+IN_CLASS_VARIADIC_H = """
+template <typename Context, int NUM_ARGS>
+struct named_arg_store {
+  int args[NUM_ARGS + 1u];
+  int named_args[2];
+
+  template <typename... T>
+  FMT_CONSTEXPR FMT_ALWAYS_INLINE named_arg_store(T&... values)
+      : args{{named_args, NUM_NAMED_ARGS}, values...} {
+    int arg_index = 0, named_arg_index = 0;
+    FMT_APPLY_VARIADIC(
+        init_named_arg(named_args, arg_index, named_arg_index, values));
+  }
+};
+"""
+
+CTOR_CONTROL_CC = """
+struct widget {
+  widget(int x);
+  int x_;
+};
+widget::widget(int x) : x_(x) {}
+"""
+
+
+def _def_qns(mock_ingestor: MagicMock) -> set[str]:
+    labels = {cs.NodeLabel.FUNCTION.value, cs.NodeLabel.METHOD.value}
+    return {
+        c.args[1].get("qualified_name")
+        for c in mock_ingestor.ensure_node_batch.call_args_list
+        if str(c.args[0]) in labels
+    }
+
+
+def test_module_scope_macro_call_block_not_registered(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "err.cc").write_text(MODULE_SCOPE_CATCH_CC)
+    run_updater(temp_repo, mock_ingestor)
+
+    qns = _def_qns(mock_ingestor)
+    assert not any(qn.endswith(".FMT_CATCH") for qn in qns), qns
+    # (H) The mangled-but-real enclosing function must still register.
+    assert any(qn.endswith(".format_system_error") for qn in qns), qns
+
+
+def test_in_class_macro_call_block_not_registered(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "std.h").write_text(IN_CLASS_CATCH_H)
+    run_updater(temp_repo, mock_ingestor)
+
+    qns = _def_qns(mock_ingestor)
+    assert not any(qn.endswith(".FMT_CATCH") for qn in qns), qns
+    assert any(qn.endswith(".format") for qn in qns), qns
+
+
+def test_in_class_macro_call_declaration_not_registered(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "base.h").write_text(IN_CLASS_VARIADIC_H)
+    run_updater(temp_repo, mock_ingestor)
+
+    qns = _def_qns(mock_ingestor)
+    assert not any(qn.endswith(".FMT_APPLY_VARIADIC") for qn in qns), qns
+
+
+def test_type_less_ctor_still_registered(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "widget.cc").write_text(CTOR_CONTROL_CC)
+    run_updater(temp_repo, mock_ingestor)
+
+    qns = _def_qns(mock_ingestor)
+    # (H) Both the in-class type-less ctor declaration and the out-of-class
+    # (H) qualified definition must survive the artifact guard.
+    assert any(qn.endswith(".widget.widget") for qn in qns), qns

--- a/codebase_rag/tests/test_cpp_macro_invocation_phantoms.py
+++ b/codebase_rag/tests/test_cpp_macro_invocation_phantoms.py
@@ -61,6 +61,28 @@ struct widget {
 widget::widget(int x) : x_(x) {}
 """
 
+# (H) Simulates recovery-orphaned ctors: type-less plain-identifier definitions
+# (H) at module scope (fmt's os.h `file(int fd)` whose class ancestor the parse
+# (H) recovery destroyed). Named parameters prove `file(int fd)` real; the
+# (H) zero-param `file()` shares the macro shape and survives only because a
+# (H) registered class bears its name; UNKNOWN_MACRO() has neither and drops.
+ORPHANED_CTOR_CC = """
+struct file {
+  int fd_;
+};
+
+file(int fd) { helper(fd); }
+UNKNOWN_MACRO() {}
+"""
+
+ORPHANED_ZERO_PARAM_CTOR_CC = """
+struct pipe {
+  int fd_;
+};
+
+pipe() {}
+"""
+
 
 def _def_qns(mock_ingestor: MagicMock) -> set[str]:
     labels = {cs.NodeLabel.FUNCTION.value, cs.NodeLabel.METHOD.value}
@@ -114,3 +136,27 @@ def test_type_less_ctor_still_registered(
     # (H) Both the in-class type-less ctor declaration and the out-of-class
     # (H) qualified definition must survive the artifact guard.
     assert any(qn.endswith(".widget.widget") for qn in qns), qns
+
+
+def test_orphaned_ctor_shapes_kept_and_macro_dropped(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "os.cc").write_text(ORPHANED_CTOR_CC)
+    run_updater(temp_repo, mock_ingestor)
+
+    qns = _def_qns(mock_ingestor)
+    # (H) The named parameter proves `file(int fd)` is a real (orphaned) ctor.
+    assert any(qn.endswith(".file") or ".file@" in qn for qn in qns), qns
+    assert not any("UNKNOWN_MACRO" in qn for qn in qns), qns
+
+
+def test_orphaned_zero_param_ctor_kept_via_class_registry(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "pipe.cc").write_text(ORPHANED_ZERO_PARAM_CTOR_CC)
+    run_updater(temp_repo, mock_ingestor)
+
+    qns = _def_qns(mock_ingestor)
+    # (H) `pipe() {}` shares the macro-invocation shape; the registered class
+    # (H) `pipe` is what keeps it alive.
+    assert any(qn.endswith(".pipe") or ".pipe@" in qn for qn in qns), qns

--- a/codebase_rag/tests/test_cpp_macro_invocation_phantoms.py
+++ b/codebase_rag/tests/test_cpp_macro_invocation_phantoms.py
@@ -83,6 +83,19 @@ struct pipe {
 pipe() {}
 """
 
+# (H) Identifiers reachable only OUTSIDE the declarator-field path must not
+# (H) count as named parameters: `x` names the inner fn-ptr's parameter and
+# (H) `MAX_SIZE` is an array bound, so both callbacks stay macro artifacts.
+# (H) The reference-parameter ctor is the counter-control: `s` hangs off a
+# (H) reference_declarator as a bare child, not a `declarator` field, and must
+# (H) still register.
+NESTED_IDENTIFIER_MACROS_CC = """
+TRACE_CB(void (*)(int x)) {}
+DECLARE_POOL(int[MAX_SIZE]) {}
+
+view(const view& s) { helper(s); }
+"""
+
 
 def _def_qns(mock_ingestor: MagicMock) -> set[str]:
     labels = {cs.NodeLabel.FUNCTION.value, cs.NodeLabel.METHOD.value}
@@ -160,6 +173,18 @@ def test_orphaned_zero_param_ctor_kept_via_class_registry(
     # (H) `pipe() {}` shares the macro-invocation shape; the registered class
     # (H) `pipe` is what keeps it alive.
     assert any(qn.endswith(".pipe") or ".pipe@" in qn for qn in qns), qns
+
+
+def test_nested_identifiers_do_not_count_as_named_params(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "cb.cc").write_text(NESTED_IDENTIFIER_MACROS_CC)
+    run_updater(temp_repo, mock_ingestor)
+
+    qns = _def_qns(mock_ingestor)
+    assert not any("TRACE_CB" in qn for qn in qns), qns
+    assert not any("DECLARE_POOL" in qn for qn in qns), qns
+    assert any(qn.endswith(".view") or ".view@" in qn for qn in qns), qns
 
 
 PIPE_HDR = """

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.369"
+version = "0.0.370"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Problem

A C++ macro invocation followed by a block (`FMT_CATCH(...) {}`, `JSON_CATCH (std::out_of_range&)`) or swept into member-init recovery (`FMT_APPLY_VARIADIC(expr);`) parses as a **type-less** `function_definition`/`declaration` named after the macro. cgr registered these as Function/Method nodes, and since nothing ever calls a macro-named phantom, each one landed in the dead-code report as a false positive: 6 entries in fmt (5 `FMT_CATCH` + `FMT_APPLY_VARIADIC`), 3 in nlohmann (`JSON_CATCH`).

## Why the naive guard is wrong

Valid C++ only omits the return type on a constructor, so "type-less + plain identifier that is not the enclosing class name" looks decisive. It is not: the same parse recovery that mints the phantoms also **destroys class specifiers**, orphaning real constructors (`file(int fd)` in fmt's os.h, `basic_json(std::nullptr_t)` in nlohmann) at module scope with no class ancestor. A guard on shape alone silently deletes real definitions; a node-level audit against a first-cut implementation showed 14 real ctors being dropped.

## Fix (three layers, each verified against real-repo shapes)

1. **Parameter evidence** (`cpp/utils.is_macro_invocation_artifact`): a macro invocation's "parameters" are expressions, so none ever carries a named declarator. One named parameter (`int fd`, `const S& s`) proves a genuine declaration even when recovery orphaned it. Pure AST check, C path untouched.
2. **Class-registry tiebreak with deferral** (`function_ingest`): the zero/unnamed-param shape (`file() {}` vs `UNKNOWN_MACRO() {}`) is AST-ambiguous; a registered class bearing the name is the ground truth. Since the class pass for the same file runs after the function pass, the decision is deferred to a new `resolve_deferred_cpp_artifacts()` post-pass, mirroring `resolve_deferred_cpp_methods`.
3. **Attribution consistency** (`call_processor`): a node ingest declined to register must not become a call-attribution target; the skip mirrors ingest's decision via the recorded function locations, so the two passes cannot diverge.

The in-class path (`ingest_method`) needs no registry: inside an intact class body a mismatched type-less member can never be a ctor of another class, so the shape check alone is decisive there.

## Results (entry-by-entry verified, no exclusions)

- **fmt 648 → 642**: minus 6 macro phantoms; minus 2 `generic_context@line` move/copy-ctor fragments whose class itself never registers (same recovery victim, so no anchor exists — class-level recovery is the follow-up); plus 2 honestly de-collided `buffer` ctor nodes (previously QN-collided into one).
- **nlohmann 268 → 262**: minus 3 `JSON_CATCH` phantoms; minus 3 `ordered_map` zero-param/`= default` ctor fragments (class also unregistered, same follow-up).
- Zero new dead entries in either repo, i.e. no reachability regressions.
- A full artifact-shape enumeration across both repos was audited line-by-line: every flagged node is a macro phantom, a keyword-recovery artifact already dropped by the reserved-name guard, a registry-saved orphan ctor (visible re-registering, e.g. `buffer@1776/@1788`), or an unanchorable fragment.

## Tests (RED first)

`test_cpp_macro_invocation_phantoms.py`, six tests: module-scope and in-class macro-call-with-block, member-init-swept macro declaration, type-less ctor declaration + qualified definition control, named-param orphaned ctor kept, zero-param orphaned ctor kept via the class registry (this one specifically pins the deferral: it fails if the registry is consulted before the class pass runs).
