### PR TITLE
fix(csharp): semantic calls oracle and precision gates for name-trie fabrications

### DIFF
--- a/codebase_rag/constants/ast_csharp.py
+++ b/codebase_rag/constants/ast_csharp.py
@@ -146,6 +146,7 @@ TS_CSHARP_MODIFIER_PROTECTED = "protected"
 # (H) of the parameter_list (grammar quirk), captured directly.
 TS_CSHARP_PARAMETER = "parameter"
 TS_CSHARP_ARRAY_TYPE = "array_type"
+TS_CSHARP_PARAMETER_LIST = "parameter_list"
 
 # (H) Local/field declarations for type inference. A local is a
 # (H) variable_declaration (type field + variable_declarator[s]); `var` makes the

--- a/codebase_rag/constants/ast_csharp.py
+++ b/codebase_rag/constants/ast_csharp.py
@@ -101,6 +101,25 @@ TS_CSHARP_POSTFIX_UNARY_EXPRESSION = "postfix_unary_expression"
 TS_CSHARP_IMPLICIT_PARAMETER = "implicit_parameter"
 TS_CSHARP_FIELD_TYPE_PARAMETERS = "type_parameters"
 TS_CSHARP_TYPE_PARAMETER_LIST = "type_parameter_list"
+# (H) The `base` receiver keyword parses as a bare "base" node in this
+# (H) grammar version (not "base_expression").
+TS_CSHARP_BASE_EXPRESSION = "base"
+
+# (H) object's virtual/universal members: a call to one of these on an UNTYPED
+# (H) receiver resolves to System.Object (or a BCL override), so binding it by
+# (H) bare name to whatever first-party override happens to exist fabricates
+# (H) an edge (exposed by the semantic calls oracle on Polly's
+# (H) hide-object-members regions).
+CSHARP_OBJECT_VIRTUALS = frozenset(
+    {
+        "Equals",
+        "GetHashCode",
+        "GetType",
+        "ToString",
+        "ReferenceEquals",
+        "MemberwiseClone",
+    }
+)
 TS_CSHARP_LAMBDA_EXPRESSION = "lambda_expression"
 TS_CSHARP_BLOCK = "block"
 TS_CSHARP_PRIMARY_CONSTRUCTOR_BASE_TYPE = "primary_constructor_base_type"

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -25,6 +25,7 @@ from ..utils.path_utils import cached_relative_path
 from .call_resolver import CallResolver
 from .class_ingest.identity import build_nested_qualified_name_for_class
 from .cpp import utils as cpp_utils
+from .csharp import type_inference as csharp_ti
 from .flow_access import FlowProcessor
 from .go import utils as go_utils
 from .import_processor import ImportProcessor
@@ -2058,7 +2059,14 @@ class CallProcessor:
                 callee_info = resolver.resolve_csharp_method_call(
                     call_node, module_qn, call_var_types, caller_qn
                 )
-                if callee_info is None:
+                if callee_info == csharp_ti.CSHARP_EXTERNAL_TARGET:
+                    # (H) Provably external (base.X() with an external base, a
+                    # (H) static call on an unregistered type, an object
+                    # (H) virtual on an untyped receiver): no edge, and no
+                    # (H) name-trie fallback that would fabricate one onto an
+                    # (H) unrelated same-name first-party member.
+                    callee_info = None
+                elif callee_info is None:
                     # (H) A C# member call whose receiver could not be typed (or a
                     # (H) bare call) falls back to the generic simple-name resolver,
                     # (H) which keeps Phase 1 intra-file resolution working.

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -906,7 +906,7 @@ class ClassIngestMixin:
                         ptype = safe_decode_text(prm.child_by_field_name(cs.FIELD_TYPE))
                         if pname and ptype:
                             field_types.setdefault(
-                                pname, csharp_utils._normalize_type_name(ptype)
+                                pname, csharp_utils.annotate_type_ref(ptype)
                             )
             if field_types:
                 self.class_field_types[class_qn] = field_types

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -890,7 +890,25 @@ class ClassIngestMixin:
             # (H) (`_w.M()`, `this._w.M()`) resolves, including a field inherited
             # (H) from a base class in another file (the resolver walks
             # (H) class_inheritance over these per-class maps).
-            if field_types := csharp_utils.build_field_type_map(member_node):
+            field_types = csharp_utils.build_field_type_map(member_node) or {}
+            # (H) A record's positional parameters ARE public properties of
+            # (H) the record type; record them as members so receiver typing
+            # (H) and the delegate-invoke gate see them (`Callback();` on a
+            # (H) record param is Action.Invoke, not a first-party call).
+            if member_node.type == cs.TS_CSHARP_RECORD_DECLARATION:
+                for pl in member_node.children:
+                    if pl.type != cs.TS_CSHARP_PARAMETER_LIST:
+                        continue
+                    for prm in pl.children:
+                        if prm.type != cs.TS_CSHARP_PARAMETER:
+                            continue
+                        pname = safe_decode_text(prm.child_by_field_name(cs.FIELD_NAME))
+                        ptype = safe_decode_text(prm.child_by_field_name(cs.FIELD_TYPE))
+                        if pname and ptype:
+                            field_types.setdefault(
+                                pname, csharp_utils._normalize_type_name(ptype)
+                            )
+            if field_types:
                 self.class_field_types[class_qn] = field_types
             # (H) Declared type-parameter count: `Builder<TResult>` -> 1;
             # (H) unrecorded means 0, so only generics are stored. A class
@@ -1210,6 +1228,10 @@ class ClassIngestMixin:
                     rt_node := method_node.child_by_field_name(
                         cs.TS_CSHARP_FIELD_RETURNS
                     )
+                    # (H) property_declaration exposes its type via `type`,
+                    # (H) not `returns`; recording it lets chained typing and
+                    # (H) the external-member gate see through properties.
+                    or method_node.child_by_field_name(cs.FIELD_TYPE)
                 )
                 is not None
             ):

--- a/codebase_rag/parsers/csharp/type_inference.py
+++ b/codebase_rag/parsers/csharp/type_inference.py
@@ -375,6 +375,19 @@ class CSharpTypeInferenceEngine:
         if class_qn := self._containing_class_qn(caller_qn):
             if self._field_type(class_qn, head):
                 return False
+            # (H) A PascalCase receiver is very often a PROPERTY or member of
+            # (H) the enclosing type (`Pipeline.Execute(...)`); anything the
+            # (H) enclosing type declares by that name is first-party, not an
+            # (H) external type.
+            if self._find_name_across_parts(class_qn, head) is not None:
+                return False
+        # (H) Any registered type with this simple name means the receiver may
+        # (H) be first-party (even when twin ambiguity kept it untyped).
+        if any(
+            self.function_registry.get(qn) in _TYPE_DECLS
+            for qn in self.simple_name_lookup.get(head, set())
+        ):
+            return False
         return True
 
     def _resolve_bare_call(

--- a/codebase_rag/parsers/csharp/type_inference.py
+++ b/codebase_rag/parsers/csharp/type_inference.py
@@ -758,10 +758,6 @@ class CSharpTypeInferenceEngine:
             receiver = inner
         return receiver
 
-    def _cast_type_name(self, cast_node: Node) -> str | None:
-        cast_type = safe_decode_text(cast_node.child_by_field_name(cs.FIELD_TYPE))
-        return _normalize_type_name(cast_type) if cast_type else None
-
     def _this_receiver_type(self, module_qn: str, caller_qn: str | None) -> str | None:
         qn = self._containing_class_qn(caller_qn)
         if qn is None:
@@ -956,8 +952,16 @@ class CSharpTypeInferenceEngine:
             return None
         receiver = unwrapped
         if receiver.type == cs.TS_CSHARP_CAST_EXPRESSION:
-            if cast_type := self._cast_type_name(receiver):
-                return self._type_name_to_qn(cast_type, module_qn)
+            type_node = receiver.child_by_field_name(cs.FIELD_TYPE)
+            raw = safe_decode_text(type_node) if type_node else None
+            if raw:
+                # (H) The cast's WRITTEN arity picks between simple-name twins
+                # (H) (`(Opt<int>)o` names the generic Opt<T>, never plain Opt).
+                return self._type_name_to_qn(
+                    _normalize_type_name(raw),
+                    module_qn,
+                    generic_arity_of_type_text(raw),
+                )
             return None
         # (H) `new Builder().Add()`: an object-creation receiver IS its type.
         if receiver.type == cs.TS_CSHARP_OBJECT_CREATION_EXPRESSION:

--- a/codebase_rag/parsers/csharp/type_inference.py
+++ b/codebase_rag/parsers/csharp/type_inference.py
@@ -841,13 +841,6 @@ class CSharpTypeInferenceEngine:
                 return self.csharp_class_generic_arity.get(class_qn, 0)
         return None
 
-    def _type_simple_name_registered(self, type_name: str) -> bool:
-        simple = split_type_ref(type_name)[0].rsplit(cs.SEPARATOR_DOT, 1)[-1]
-        return any(
-            self.function_registry.get(qn) in _TYPE_DECLS
-            for qn in self.simple_name_lookup.get(simple, set())
-        )
-
     def _registered_type_declares(self, type_name: str, method_name: str) -> bool:
         # (H) A registered type merely SHARING the receiver type's simple name
         # (H) (Polly's Snippets.Docs.RateLimiter demo class vs BCL RateLimiter)

--- a/codebase_rag/parsers/csharp/type_inference.py
+++ b/codebase_rag/parsers/csharp/type_inference.py
@@ -20,7 +20,12 @@ from ...utils.path_utils import cached_relative_path
 from ..csharp_frontend import CallSiteKey, CSharpCallSite
 from ..import_processor import ImportProcessor
 from ..utils import safe_decode_text
-from .utils import _normalize_type_name, generic_arity_of_type_text
+from .utils import (
+    _normalize_type_name,
+    annotate_type_ref,
+    generic_arity_of_type_text,
+    split_type_ref,
+)
 
 if TYPE_CHECKING:
     from ..factory import ASTCacheProtocol
@@ -172,7 +177,7 @@ class CSharpTypeInferenceEngine:
                 continue
             if child.type == cs.TS_CSHARP_IDENTIFIER and prev_loose_type:
                 if name := safe_decode_text(child):
-                    types[name] = _normalize_type_name(prev_loose_type)
+                    types[name] = annotate_type_ref(prev_loose_type)
                 prev_loose_type = None
                 continue
             if child.type != cs.TS_CSHARP_PARAMETER:
@@ -180,7 +185,7 @@ class CSharpTypeInferenceEngine:
             name = safe_decode_text(child.child_by_field_name(cs.FIELD_NAME))
             type_text = safe_decode_text(child.child_by_field_name(cs.FIELD_TYPE))
             if name and type_text:
-                types[name] = _normalize_type_name(type_text)
+                types[name] = annotate_type_ref(type_text)
 
     def _collect_locals(self, scope_node: Node, types: dict[str, str]) -> None:
         # (H) One type map per method (as every language engine here builds), so
@@ -202,7 +207,7 @@ class CSharpTypeInferenceEngine:
         if type_node is None or type_node.type == cs.TS_CSHARP_IMPLICIT_TYPE:
             return None
         if type_text := safe_decode_text(type_node):
-            return _normalize_type_name(type_text)
+            return annotate_type_ref(type_text)
         return None
 
     def _record_local(
@@ -237,7 +242,7 @@ class CSharpTypeInferenceEngine:
             declarator, cs.TS_CSHARP_OBJECT_CREATION_EXPRESSION
         ):
             if type_text := safe_decode_text(node.child_by_field_name(cs.FIELD_TYPE)):
-                return _normalize_type_name(type_text)
+                return annotate_type_ref(type_text)
         return None
 
     def _field_type(self, class_qn: str, field_name: str) -> str | None:
@@ -330,6 +335,12 @@ class CSharpTypeInferenceEngine:
             if arity_hit := self._find_arity_across_parts(
                 receiver_class_qn, method_name, arg_count
             ):
+                # (H) A delegate-typed PROPERTY registers as a METHOD node with
+                # (H) a bare (arity-0) qn, so a 0-arg invoke slips through the
+                # (H) ARITY path too: `entry.Callback()` is Delegate.Invoke,
+                # (H) not a call to the property node.
+                if self.function_registry.is_property(arity_hit):
+                    return CSHARP_EXTERNAL_TARGET
                 return cs.NodeLabel.METHOD.value, arity_hit
         # (H) An extension method (`static M(this T x, ...)` on an unrelated static
         # (H) class) whose `this` receiver type matches the call's receiver -- the
@@ -397,7 +408,9 @@ class CSharpTypeInferenceEngine:
             # (H) no registered type (`string[]`, reflection FieldInfo) is
             # (H) external; its members cannot be attributed by name
             # (H) (`names.Contains(x)` bound Context.Contains).
-            return not self._type_simple_name_registered(local_var_types[head])
+            return not self._registered_type_declares(
+                local_var_types[head], method_name
+            )
         if not all(seg[:1].isupper() for seg in segments):
             return False
         if class_qn := self._containing_class_qn(caller_qn):
@@ -406,10 +419,10 @@ class CSharpTypeInferenceEngine:
                 # (H) external-typed member (`Wrapper` of BCL RateLimiter)
                 # (H) makes the call external (the trie self-looped
                 # (H) `Wrapper.DisposeAsync()` onto the enclosing class).
-                return not self._type_simple_name_registered(member_type)
+                return not self._registered_type_declares(member_type, method_name)
             if prop_qn := self.resolve_property_read(head, caller_qn):
                 if entry := self.csharp_method_return_types.get(prop_qn):
-                    return not self._type_simple_name_registered(entry[0])
+                    return not self._registered_type_declares(entry[0], method_name)
             # (H) A PascalCase receiver is very often a PROPERTY or member of
             # (H) the enclosing type (`Pipeline.Execute(...)`); anything the
             # (H) enclosing type declares by that name is first-party, not an
@@ -703,14 +716,17 @@ class CSharpTypeInferenceEngine:
         # (H) `((Widget)o).Ext()`: the cast target IS the receiver type, so an
         # (H) extension-only method still binds on a cast receiver.
         if receiver.type == cs.TS_CSHARP_CAST_EXPRESSION:
-            return self._cast_type_name(receiver)
+            type_node = receiver.child_by_field_name(cs.FIELD_TYPE)
+            raw = safe_decode_text(type_node) if type_node else None
+            return annotate_type_ref(raw) if raw else None
         # (H) Same chained-receiver typing as the instance path, stopping at
-        # (H) the raw type name (extensions often target unregistered BCL
-        # (H) types like `string`).
+        # (H) the (arity-annotated) type name -- extensions often target
+        # (H) unregistered BCL types like `string`, and both sides of the
+        # (H) matcher carry the annotation consistently.
         if receiver.type == cs.TS_CSHARP_OBJECT_CREATION_EXPRESSION:
             type_node = receiver.child_by_field_name(cs.FIELD_TYPE)
             type_text = safe_decode_text(type_node) if type_node else None
-            return _normalize_type_name(type_text) if type_text else None
+            return annotate_type_ref(type_text) if type_text else None
         if receiver.type == cs.TS_CSHARP_INVOCATION_EXPRESSION:
             inner = self.resolve_csharp_method_call(
                 receiver, local_var_types, module_qn, caller_qn
@@ -718,7 +734,8 @@ class CSharpTypeInferenceEngine:
             if inner is None:
                 return None
             if entry := self.csharp_method_return_types.get(inner[1]):
-                return entry[0]
+                rname, rarity = entry
+                return f"{rname}`{rarity}" if rarity else rname
             return None
         if receiver.type == cs.TS_CSHARP_THIS:
             return self._this_receiver_type(module_qn, caller_qn)
@@ -825,11 +842,24 @@ class CSharpTypeInferenceEngine:
         return None
 
     def _type_simple_name_registered(self, type_name: str) -> bool:
-        simple = type_name.rsplit(cs.SEPARATOR_DOT, 1)[-1]
+        simple = split_type_ref(type_name)[0].rsplit(cs.SEPARATOR_DOT, 1)[-1]
         return any(
             self.function_registry.get(qn) in _TYPE_DECLS
             for qn in self.simple_name_lookup.get(simple, set())
         )
+
+    def _registered_type_declares(self, type_name: str, method_name: str) -> bool:
+        # (H) A registered type merely SHARING the receiver type's simple name
+        # (H) (Polly's Snippets.Docs.RateLimiter demo class vs BCL RateLimiter)
+        # (H) must not defeat the external gate: the candidate counts only if
+        # (H) it actually DECLARES the called member somewhere in its
+        # (H) parts/bases.
+        simple = split_type_ref(type_name)[0].rsplit(cs.SEPARATOR_DOT, 1)[-1]
+        for qn in self.simple_name_lookup.get(simple, set()):
+            if self.function_registry.get(qn) in _TYPE_DECLS:
+                if self._find_name_across_parts(qn, method_name) is not None:
+                    return True
+        return False
 
     def _find_extension_method(
         self,
@@ -1002,6 +1032,11 @@ class CSharpTypeInferenceEngine:
         module_qn: str,
         generic_arity: int | None = None,
     ) -> str | None:
+        # (H) Stored type refs carry their written generic arity CLR-style
+        # (H) (`Options`0` is implicit: plain means arity 0); parse it so twin
+        # (H) filtering works for every map-sourced reference.
+        if generic_arity is None:
+            type_name, generic_arity = split_type_ref(type_name)
         # (H) An already-qualified name that IS a registered type resolves directly,
         # (H) skipping the ambiguous simple-name sweep.
         if self.function_registry.get(type_name) in _TYPE_DECLS:

--- a/codebase_rag/parsers/csharp/type_inference.py
+++ b/codebase_rag/parsers/csharp/type_inference.py
@@ -27,6 +27,12 @@ if TYPE_CHECKING:
 
 _TYPE_DECLS = (NodeType.CLASS, NodeType.INTERFACE, NodeType.ENUM)
 
+# (H) Sentinel: the call's target is provably EXTERNAL (a BCL/base member, a
+# (H) static call on an unregistered type). The dispatcher must emit nothing
+# (H) and must NOT fall back to the name-only trie, which would fabricate an
+# (H) edge onto an unrelated same-name first-party member.
+CSHARP_EXTERNAL_TARGET: tuple[str, str] = ("", "")
+
 
 def _arity(leaf: str) -> int:
     # (H) Parameter count of a (possibly signatured) method leaf: `M(int, string)`
@@ -279,6 +285,27 @@ class CSharpTypeInferenceEngine:
         method_name = method_name.split(cs.CHAR_ANGLE_OPEN, 1)[0]
         arg_count = self._count_arguments(call_node)
 
+        # (H) `base.X()` binds the BASE chain only: a first-party base's member
+        # (H) when one exists, otherwise the base is external (object.Equals in
+        # (H) Polly's hide-object-members regions) and the call must emit
+        # (H) nothing -- the trie fallback was self-looping it onto the
+        # (H) caller's own override.
+        if receiver.type == cs.TS_CSHARP_BASE_EXPRESSION:
+            if class_qn := self._containing_class_qn(caller_qn):
+                seen: set[str] = set()
+                for root in self._partial_roots(class_qn):
+                    for base_qn in self.class_inheritance.get(root, []):
+                        if hit := self._find_method_by_arity(
+                            base_qn, method_name, arg_count, seen
+                        ):
+                            return cs.NodeLabel.METHOD.value, hit
+                seen = set()
+                for root in self._partial_roots(class_qn):
+                    for base_qn in self.class_inheritance.get(root, []):
+                        if hit := self._find_method_by_name(base_qn, method_name, seen):
+                            return cs.NodeLabel.METHOD.value, hit
+            return CSHARP_EXTERNAL_TARGET
+
         receiver_class_qn = self._resolve_receiver_class_qn(
             receiver, local_var_types or {}, module_qn, caller_qn
         )
@@ -307,7 +334,48 @@ class CSharpTypeInferenceEngine:
         if receiver_class_qn is not None:
             if name_hit := self._find_name_across_parts(receiver_class_qn, method_name):
                 return cs.NodeLabel.METHOD.value, name_hit
+        if receiver_class_qn is None and self._externally_targeted(
+            receiver, method_name, local_var_types or {}, caller_qn
+        ):
+            return CSHARP_EXTERNAL_TARGET
         return None
+
+    def _externally_targeted(
+        self,
+        receiver: Node,
+        method_name: str,
+        local_var_types: dict[str, str],
+        caller_qn: str | None,
+    ) -> bool:
+        # (H) Only for UNTYPED receivers (a typed miss keeps today's trie
+        # (H) rescue): (a) a PascalCase identifier/dotted path that is no
+        # (H) local, no field, and no registered type is an external TYPE
+        # (H) (`Console`, `System.Console`); (b) an object-virtual member name
+        # (H) on an untyped receiver resolves to System.Object.
+        if method_name in cs.CSHARP_OBJECT_VIRTUALS:
+            return True
+        unwrapped = self._unwrap_receiver(receiver)
+        if unwrapped is None:
+            return False
+        receiver = unwrapped
+        if receiver.type not in (
+            cs.TS_CSHARP_IDENTIFIER,
+            cs.TS_CSHARP_MEMBER_ACCESS_EXPRESSION,
+        ):
+            return False
+        text = safe_decode_text(receiver)
+        if not text:
+            return False
+        segments = text.split(cs.SEPARATOR_DOT)
+        if not all(seg[:1].isupper() for seg in segments):
+            return False
+        head = segments[0]
+        if head in local_var_types:
+            return False
+        if class_qn := self._containing_class_qn(caller_qn):
+            if self._field_type(class_qn, head):
+                return False
+        return True
 
     def _resolve_bare_call(
         self,

--- a/codebase_rag/parsers/csharp/type_inference.py
+++ b/codebase_rag/parsers/csharp/type_inference.py
@@ -162,7 +162,19 @@ class CSharpTypeInferenceEngine:
         param_list = scope_node.child_by_field_name(cs.FIELD_PARAMETERS)
         if param_list is None:
             return
+        prev_loose_type: str | None = None
         for child in param_list.children:
+            # (H) A `params string[] xs` tail is not wrapped in a `parameter`
+            # (H) node (grammar quirk, same as extract_parameter_type_names):
+            # (H) its array_type and identifier sit loose under the list.
+            if child.type == cs.TS_CSHARP_ARRAY_TYPE:
+                prev_loose_type = safe_decode_text(child)
+                continue
+            if child.type == cs.TS_CSHARP_IDENTIFIER and prev_loose_type:
+                if name := safe_decode_text(child):
+                    types[name] = _normalize_type_name(prev_loose_type)
+                prev_loose_type = None
+                continue
             if child.type != cs.TS_CSHARP_PARAMETER:
                 continue
             name = safe_decode_text(child.child_by_field_name(cs.FIELD_NAME))
@@ -333,7 +345,19 @@ class CSharpTypeInferenceEngine:
             return cs.NodeLabel.METHOD.value, ext
         if receiver_class_qn is not None:
             if name_hit := self._find_name_across_parts(receiver_class_qn, method_name):
+                # (H) A delegate-typed PROPERTY invoked with call syntax
+                # (H) (`options.ShouldHandle(args)`) is Delegate.Invoke, not a
+                # (H) method call; binding the property as a METHOD fabricates
+                # (H) an edge. Its reachability comes from the read pass.
+                if self.function_registry.is_property(name_hit):
+                    return CSHARP_EXTERNAL_TARGET
                 return cs.NodeLabel.METHOD.value, name_hit
+        # (H) An object-virtual miss on a TYPED receiver (`severity.ToString()`
+        # (H) on an enum, `options.GetType()`) resolves to System.Object/Enum;
+        # (H) falling to the trie lands on whatever unrelated
+        # (H) hide-object-members override exists (Polly's PolicyBuilder).
+        if method_name in cs.CSHARP_OBJECT_VIRTUALS:
+            return CSHARP_EXTERNAL_TARGET
         if receiver_class_qn is None and self._externally_targeted(
             receiver, method_name, local_var_types or {}, caller_qn
         ):
@@ -367,14 +391,25 @@ class CSharpTypeInferenceEngine:
         if not text:
             return False
         segments = text.split(cs.SEPARATOR_DOT)
-        if not all(seg[:1].isupper() for seg in segments):
-            return False
         head = segments[0]
         if head in local_var_types:
+            # (H) A local/param (any casing) whose DECLARED type resolves to
+            # (H) no registered type (`string[]`, reflection FieldInfo) is
+            # (H) external; its members cannot be attributed by name
+            # (H) (`names.Contains(x)` bound Context.Contains).
+            return not self._type_simple_name_registered(local_var_types[head])
+        if not all(seg[:1].isupper() for seg in segments):
             return False
         if class_qn := self._containing_class_qn(caller_qn):
-            if self._field_type(class_qn, head):
-                return False
+            if member_type := self._field_type(class_qn, head):
+                # (H) Same rule for a field/property receiver: an
+                # (H) external-typed member (`Wrapper` of BCL RateLimiter)
+                # (H) makes the call external (the trie self-looped
+                # (H) `Wrapper.DisposeAsync()` onto the enclosing class).
+                return not self._type_simple_name_registered(member_type)
+            if prop_qn := self.resolve_property_read(head, caller_qn):
+                if entry := self.csharp_method_return_types.get(prop_qn):
+                    return not self._type_simple_name_registered(entry[0])
             # (H) A PascalCase receiver is very often a PROPERTY or member of
             # (H) the enclosing type (`Pipeline.Execute(...)`); anything the
             # (H) enclosing type declares by that name is first-party, not an
@@ -423,6 +458,19 @@ class CSharpTypeInferenceEngine:
                     if (m in self.csharp_generic_methods) == generic_call
                 ]
                 return cs.NodeLabel.METHOD.value, (preferred or matches)[0]
+        # (H) A bare object-virtual with no local declaration is
+        # (H) `this.GetType()` -> System.Object (Polly's PolicyBase.PolicyKey);
+        # (H) a bare name that IS a delegate-typed member of the enclosing type
+        # (H) (`Callback();` on a record positional property) is
+        # (H) Delegate.Invoke. Neither may fall to the bare-name trie.
+        if name in cs.CSHARP_OBJECT_VIRTUALS:
+            return CSHARP_EXTERNAL_TARGET
+        if self.resolve_property_read(name, caller_qn) is not None:
+            return CSHARP_EXTERNAL_TARGET
+        if (class_qn := self._containing_class_qn(caller_qn)) and self._field_type(
+            class_qn, name
+        ):
+            return CSHARP_EXTERNAL_TARGET
         return None
 
     def _find_in_scope_local_function(
@@ -775,6 +823,13 @@ class CSharpTypeInferenceEngine:
             if class_qn is not None:
                 return self.csharp_class_generic_arity.get(class_qn, 0)
         return None
+
+    def _type_simple_name_registered(self, type_name: str) -> bool:
+        simple = type_name.rsplit(cs.SEPARATOR_DOT, 1)[-1]
+        return any(
+            self.function_registry.get(qn) in _TYPE_DECLS
+            for qn in self.simple_name_lookup.get(simple, set())
+        )
 
     def _find_extension_method(
         self,

--- a/codebase_rag/parsers/csharp/utils.py
+++ b/codebase_rag/parsers/csharp/utils.py
@@ -68,6 +68,27 @@ def generic_arity_of_type_text(text: str) -> int:
     return count
 
 
+GENERIC_ARITY_MARKER = "`"
+
+
+def annotate_type_ref(text: str) -> str:
+    # (H) Normalized type reference carrying its WRITTEN generic arity in CLR
+    # (H) style (`Builder<T>` -> "Builder`1", `Builder` -> "Builder"): a plain
+    # (H) name always means arity 0, so simple-name twins stay distinguishable
+    # (H) through every stored type map without touching method signatures.
+    base = _normalize_type_name(text)
+    arity = generic_arity_of_type_text(text)
+    return f"{base}{GENERIC_ARITY_MARKER}{arity}" if arity else base
+
+
+def split_type_ref(name: str) -> tuple[str, int]:
+    if GENERIC_ARITY_MARKER in name:
+        base, _, tail = name.rpartition(GENERIC_ARITY_MARKER)
+        if tail.isdigit():
+            return base, int(tail)
+    return name, 0
+
+
 def normalize_csharp_type_name(type_node: Node) -> str | None:
     # (H) A type node's normalized name (generic-free, nullable-stripped) or
     # (H) None for unnameable types (`void` callers never chain off it, but a
@@ -120,7 +141,7 @@ def extension_receiver_type(method_node: Node) -> str | None:
         return None
     type_node = first.child_by_field_name(cs.FIELD_TYPE)
     name = safe_decode_text(type_node) if type_node and type_node.text else None
-    return _normalize_type_name(name) if name else None
+    return annotate_type_ref(name) if name else None
 
 
 def index_extension_method(
@@ -190,7 +211,7 @@ def build_field_type_map(class_node: Node) -> dict[str, str]:
             name = safe_decode_text(member.child_by_field_name(cs.FIELD_NAME))
             type_text = safe_decode_text(member.child_by_field_name(cs.FIELD_TYPE))
             if name and type_text:
-                fields[name] = _normalize_type_name(type_text)
+                fields[name] = annotate_type_ref(type_text)
         elif member.type == cs.TS_CSHARP_FIELD_DECLARATION:
             var_decl = next(
                 (
@@ -210,7 +231,7 @@ def build_field_type_map(class_node: Node) -> dict[str, str]:
                     continue
                 name = safe_decode_text(declarator.child_by_field_name(cs.FIELD_NAME))
                 if name:
-                    fields[name] = _normalize_type_name(type_text)
+                    fields[name] = annotate_type_ref(type_text)
     return fields
 
 

--- a/codebase_rag/tests/test_csharp_calls.py
+++ b/codebase_rag/tests/test_csharp_calls.py
@@ -400,3 +400,97 @@ public class App {
 
     targets = _call_targets(mock_ingestor)
     assert any(t.endswith("N.Policy.Handle") for t in targets), targets
+
+
+def test_base_receiver_binds_base_chain_never_own_override(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) `base.X()` inside an override must bind the BASE chain: a first-party
+    # (H) base's member when one exists, and NOTHING when the base is external
+    # (H) (object.Equals) -- the trie fallback was binding the call to the
+    # (H) caller's OWN override (a self-loop false positive on every
+    # (H) hide-object-members region, Polly's PolicyBuilder).
+    (csharp_project / "BaseRecv.cs").write_text(
+        """
+namespace N;
+public class Root {
+    public virtual string Report() => "r";
+}
+public class Mid : Root {
+    public override string Report() => base.Report();
+    public override string ToString() => base.ToString();
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    pairs = _call_pairs(mock_ingestor)
+    assert any(
+        s.endswith("N.Mid.Report") and t.endswith("N.Root.Report") for s, t in pairs
+    ), pairs
+    assert not any(t.endswith("N.Mid.ToString") for s, t in pairs), pairs
+    assert not any(
+        s.endswith("N.Mid.Report") and t.endswith("N.Mid.Report") for s, t in pairs
+    ), pairs
+
+
+def test_unresolvable_type_receiver_does_not_fall_to_name_trie(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) `Console.WriteLine(x)`: the receiver is a PascalCase identifier that
+    # (H) is no local, field, or registered type -- an external static type.
+    # (H) The name-only trie must not bind the call to an unrelated
+    # (H) first-party `WriteLine`.
+    (csharp_project / "ConsoleLike.cs").write_text(
+        """
+namespace N;
+public class Logger {
+    public void WriteLine(string s) { }
+}
+public class App {
+    public void Run() { System.Console.WriteLine("x"); }
+    public void Run2() { Console.WriteLine("y"); }
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    pairs = _call_pairs(mock_ingestor)
+    assert not any(t.endswith("N.Logger.WriteLine(string)") for s, t in pairs), pairs
+
+
+def test_object_virtual_names_never_bind_by_name_only(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) `x.GetType()` / `y.ToString()` on untyped receivers resolve to
+    # (H) object's virtuals; binding them BY NAME to whatever first-party
+    # (H) override exists fabricates edges (19 exposed by the semantic
+    # (H) oracle). A typed receiver still binds via the arity path.
+    (csharp_project / "ObjVirt.cs").write_text(
+        """
+namespace N;
+public class Weird {
+    public new System.Type GetType() => base.GetType();
+    public override string ToString() => "w";
+}
+public class App {
+    public string Run(object x) { return x.GetType().ToString(); }
+    public string Typed(Weird w) { return w.ToString(); }
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    pairs = _call_pairs(mock_ingestor)
+    assert not any(
+        s.endswith("N.App.Run(object)") and t.endswith("N.Weird.GetType")
+        for s, t in pairs
+    ), pairs
+    # (H) The TYPED receiver keeps its correct override binding.
+    assert any(
+        s.endswith("N.App.Typed(Weird)") and t.endswith("N.Weird.ToString")
+        for s, t in pairs
+    ), pairs

--- a/codebase_rag/tests/test_csharp_calls.py
+++ b/codebase_rag/tests/test_csharp_calls.py
@@ -494,3 +494,111 @@ public class App {
         s.endswith("N.App.Typed(Weird)") and t.endswith("N.Weird.ToString")
         for s, t in pairs
     ), pairs
+
+
+def test_typed_receiver_object_virtual_miss_is_external(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) `severity.ToString()` on a first-party enum binds Enum.ToString
+    # (H) (metadata); when the receiver's own hierarchy declares no override
+    # (H) the call must NOT fall to the trie and land on an unrelated
+    # (H) hide-object-members override (Polly's PolicyBuilder attractor).
+    (csharp_project / "OV.cs").write_text(
+        """
+namespace N;
+public enum Severity { Low, High }
+public class Hider {
+    public override string ToString() => "h";
+    public new System.Type GetType() => base.GetType();
+}
+public class App {
+    public string Fmt(Severity s) => s.ToString();
+    public string Key() => GetType().Name;
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    pairs = _call_pairs(mock_ingestor)
+    assert not any(t.endswith("N.Hider.ToString") for s, t in pairs), pairs
+    assert not any(t.endswith("N.Hider.GetType") for s, t in pairs), pairs
+
+
+def test_untyped_member_receiver_never_falls_to_name_trie(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) `Wrapper.DisposeAsync()` where Wrapper is a property of an
+    # (H) UNREGISTERED (BCL) type: a member call whose receiver cannot be
+    # (H) typed must not be attributed by bare name -- the trie self-looped it
+    # (H) onto the enclosing class's own DisposeAsync (Polly's
+    # (H) RateLimiterResilienceStrategy).
+    (csharp_project / "UM.cs").write_text(
+        """
+namespace N;
+public class Strategy {
+    private System.Threading.RateLimiting.RateLimiter Wrapper { get; }
+    public System.Threading.Tasks.ValueTask DisposeAsync() {
+        return Wrapper.DisposeAsync();
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    pairs = _call_pairs(mock_ingestor)
+    assert not any(
+        s.endswith("N.Strategy.DisposeAsync") and t.endswith("N.Strategy.DisposeAsync")
+        for s, t in pairs
+    ), pairs
+
+
+def test_bare_delegate_member_invoke_is_external(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) `Callback();` where Callback is a delegate-typed PROPERTY of the
+    # (H) enclosing type is Action.Invoke, not a method call; the bare-name
+    # (H) trie must not bind it to an unrelated first-party member named
+    # (H) Callback. The property read stays covered by the read pass.
+    (csharp_project / "DI.cs").write_text(
+        """
+namespace N;
+public class OtherArgs {
+    public System.Action Callback { get; }
+}
+public class Timer {
+    public System.Action Callback { get; }
+    public void Fire() { Callback(); }
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    pairs = _call_pairs(mock_ingestor)
+    assert not any(t.endswith("Callback") and "OtherArgs" in t for s, t in pairs), pairs
+
+
+def test_delegate_property_on_typed_receiver_not_bound_as_method(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) `options.ShouldHandle(args)`: ShouldHandle is a delegate PROPERTY;
+    # (H) the typed-receiver name fallback must not emit a CALLS edge binding
+    # (H) the property as a method (Polly's CircuitBreakerStrategyOptions).
+    (csharp_project / "DP.cs").write_text(
+        """
+namespace N;
+public class Options {
+    public System.Func<int, bool> ShouldHandle { get; set; }
+}
+public class App {
+    public bool Run(Options options) { return options.ShouldHandle(3); }
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    pairs = _call_pairs(mock_ingestor)
+    assert not any(t.endswith("N.Options.ShouldHandle") for s, t in pairs), pairs

--- a/codebase_rag/tests/test_csharp_calls.py
+++ b/codebase_rag/tests/test_csharp_calls.py
@@ -602,3 +602,67 @@ public class App {
 
     pairs = _call_pairs(mock_ingestor)
     assert not any(t.endswith("N.Options.ShouldHandle") for s, t in pairs), pairs
+
+
+def test_bcl_typed_member_receiver_with_name_colliding_decoy_is_external(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) `Wrapper.DisposeAsync()` where Wrapper is typed to BCL RateLimiter:
+    # (H) an unrelated first-party class that merely SHARES the simple name
+    # (H) (Polly's Snippets.Docs.RateLimiter demo) must not defeat the
+    # (H) external gate; the candidate type must actually DECLARE the member.
+    (csharp_project / "Decoy.cs").write_text(
+        "namespace N.Docs;\npublic static class RateLimiter {\n"
+        "    public static void Snippet() { }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    (csharp_project / "Strat.cs").write_text(
+        """
+namespace N;
+public class Strategy {
+    private System.Threading.RateLimiting.RateLimiter Wrapper { get; }
+    public System.Threading.Tasks.ValueTask DisposeAsync() {
+        return Wrapper.DisposeAsync();
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    pairs = _call_pairs(mock_ingestor)
+    assert not any(
+        s.endswith("N.Strategy.DisposeAsync") and t.endswith("DisposeAsync")
+        for s, t in pairs
+    ), pairs
+
+
+def test_var_from_plain_twin_ctor_respects_property_guard(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) `var options = new Options();` where Options : Options<object> are
+    # (H) simple-name twins: the local's WRITTEN type has generic arity 0, so
+    # (H) receiver typing must pick the non-generic twin, reach the delegate
+    # (H) property guard, and emit no CALLS edge for
+    # (H) `options.ShouldHandle(...)` (Polly's CircuitBreakerStrategyOptions).
+    (csharp_project / "TwinOpt.cs").write_text(
+        """
+namespace N;
+public class Options<TResult> {
+    public System.Func<TResult, bool> ShouldHandle { get; set; }
+}
+public class Options : Options<object> { }
+public class App {
+    public bool Run() {
+        var options = new Options();
+        return options.ShouldHandle(3);
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    pairs = _call_pairs(mock_ingestor)
+    assert not any(t.endswith(".ShouldHandle") for s, t in pairs), pairs

--- a/codebase_rag/tests/test_csharp_calls.py
+++ b/codebase_rag/tests/test_csharp_calls.py
@@ -666,3 +666,56 @@ public class App {
 
     pairs = _call_pairs(mock_ingestor)
     assert not any(t.endswith(".ShouldHandle") for s, t in pairs), pairs
+
+
+def test_base_call_binds_first_party_base_by_name_when_arity_differs(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) `base.Report(1, 2)` with a first-party base declaring only an
+    # (H) optional-parameter overload: the arity pass misses, and the
+    # (H) name-only base-chain pass must still bind the base member rather
+    # (H) than suppress a genuine first-party call.
+    (csharp_project / "BaseName.cs").write_text(
+        """
+namespace N;
+public class Root2 {
+    public virtual string Report(int a, int b = 0, int c = 0) => "r";
+}
+public class Mid2 : Root2 {
+    public override string Report(int a, int b, int c) => base.Report(1, 2);
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    pairs = _call_pairs(mock_ingestor)
+    assert any(
+        s.endswith("Mid2.Report(int, int, int)") and "Root2.Report" in t
+        for s, t in pairs
+    ), pairs
+
+
+def test_bcl_member_receiver_with_declaring_first_party_candidate_keeps_fallback(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) The declares-member refinement must NOT suppress when a first-party
+    # (H) type sharing the receiver type's simple name actually DECLARES the
+    # (H) called member: the trie may then legitimately attribute the call.
+    (csharp_project / "DK.cs").write_text(
+        """
+namespace N;
+public class Keeper {
+    public void Flush() { }
+}
+public class Holder {
+    private Keeper Inner2 { get; }
+    public void Go() { Inner2.Flush(); }
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    pairs = _call_pairs(mock_ingestor)
+    assert any(t.endswith("N.Keeper.Flush") for s, t in pairs), pairs

--- a/codebase_rag/tests/test_csharp_extension_methods.py
+++ b/codebase_rag/tests/test_csharp_extension_methods.py
@@ -410,3 +410,30 @@ public class App {
     assert not any(
         t.endswith("N.BuilderExtensions.AddRetry(Builder, int)") for t in targets
     ), targets
+
+
+def test_cast_receiver_binds_generic_extension_by_arity(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) `((Widget<int>)o).Poke()` carries written arity 1; with BOTH a plain
+    # (H) and a generic extension registered, the cast receiver must bind the
+    # (H) generic one (the annotation flows through the extension matcher).
+    (csharp_project / "GC.cs").write_text(
+        """
+namespace N;
+public class Widget { }
+public class Widget<T> { }
+public static class WidgetExt {
+    public static void Poke(this Widget w) { }
+    public static void Poke<T>(this Widget<T> w) { }
+}
+public class App {
+    public void Run(object o) { ((Widget<int>)o).Poke(); }
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    targets = _call_targets(mock_ingestor)
+    assert any("WidgetExt.Poke" in t for t in targets), targets

--- a/codebase_rag/tests/test_csharp_retrieval_eval.py
+++ b/codebase_rag/tests/test_csharp_retrieval_eval.py
@@ -193,3 +193,27 @@ def test_oracle_excludes_bcl_calls_colliding_with_first_party_names(
     assert ("OnlyBcl.cs", "Clear") not in edges2, edges2
     assert ("App.cs", "Clear") in edges2
     assert site_count == 1
+
+
+@needs_dotnet
+def test_oracle_resolves_across_namespaces_without_usings(tmp_path: Path) -> None:
+    # (H) SDK ImplicitUsings materialize as generated GlobalUsings.g.cs under
+    # (H) obj/, which the oracle's file walk rightly skips; the oracle must
+    # (H) synthesize global usings for every in-source namespace or a
+    # (H) cross-namespace call (Polly's bench GetPipeline) becomes an
+    # (H) unresolvable receiver and silently drops from the truth set.
+    (tmp_path / "Prov.cs").write_text(
+        "namespace Lib.Registry;\npublic class Provider {\n"
+        "    public int GetPipeline(string key) { return 1; }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "Bench.cs").write_text(
+        "namespace App.Benchmarks;\npublic class Bench {\n"
+        "    private Provider? _provider;\n"
+        '    public int Run() { return _provider!.GetPipeline("k"); }\n'
+        "}\n",
+        encoding="utf-8",
+    )
+    edges, _declared = oracle_csharp_call_edges(tmp_path)
+    assert ("Bench.cs", "GetPipeline") in edges, edges

--- a/codebase_rag/tests/test_csharp_retrieval_eval.py
+++ b/codebase_rag/tests/test_csharp_retrieval_eval.py
@@ -149,3 +149,47 @@ def test_score_csharp_retrieval_prf() -> None:
     )
     row = next(r for r in result.rows if r["label"] == ec.CSHARP_RETRIEVAL_LABEL)
     assert (row["tp"], row["fp"], row["fn"]) == (1, 1, 1)
+
+
+@needs_dotnet
+def test_oracle_excludes_bcl_calls_colliding_with_first_party_names(
+    tmp_path: Path,
+) -> None:
+    # (H) `sb.Clear()` resolves to BCL StringBuilder.Clear; the oracle must not
+    # (H) count it just because an unrelated first-party `Clear` exists (Polly:
+    # (H) ~130 phantom "missing" edges from cts.Cancel/HashSet.Add/Dispose
+    # (H) colliding with first-party names). The first-party call in the same
+    # (H) project must still count.
+    (tmp_path / "Own.cs").write_text(
+        "namespace N;\npublic class Own {\n    public void Clear() { }\n}\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "App.cs").write_text(
+        "namespace N;\npublic class App {\n"
+        "    public void Bcl() {\n"
+        "        var sb = new System.Text.StringBuilder();\n"
+        "        sb.Clear();\n"
+        "    }\n"
+        "    public void Own2(Own o) { o.Clear(); }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    edges, _declared = oracle_csharp_call_edges(tmp_path)
+
+    assert ("App.cs", "Clear") in edges
+    site_count = sum(1 for e in edges if e == ("App.cs", "Clear"))
+    # (H) Edges are a SET of (file, name); the reduction cannot distinguish the
+    # (H) two Clear sites, so instead pin the BCL-only file shape directly:
+    (tmp_path / "OnlyBcl.cs").write_text(
+        "namespace N;\npublic class OnlyBcl {\n"
+        "    public void Run() {\n"
+        "        var sb = new System.Text.StringBuilder();\n"
+        "        sb.Clear();\n"
+        "    }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    edges2, _ = oracle_csharp_call_edges(tmp_path)
+    assert ("OnlyBcl.cs", "Clear") not in edges2, edges2
+    assert ("App.cs", "Clear") in edges2
+    assert site_count == 1

--- a/codebase_rag/tests/test_csharp_type_inference.py
+++ b/codebase_rag/tests/test_csharp_type_inference.py
@@ -418,3 +418,33 @@ public class App {
 
     targets = _call_targets(mock_ingestor)
     assert any(t.endswith("Core.N.Builder.Build") for t in targets), targets
+
+
+def test_cast_to_generic_twin_binds_the_generic_member(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) `((Opt<int>)o).M()` writes arity 1: with twins `Opt` and `Opt<T>`
+    # (H) registered, the cast receiver must resolve the GENERIC twin and bind
+    # (H) its member (the instance-path cast branch dropped the arity that
+    # (H) object-creation and extension paths already carry).
+    (csharp_project / "CastTwinA.cs").write_text(
+        "namespace N;\npublic class Opt {\n    public void M() { }\n}\n",
+        encoding="utf-8",
+    )
+    (csharp_project / "CastTwinB.cs").write_text(
+        "namespace N;\npublic class Opt<T> {\n    public void M() { }\n}\n",
+        encoding="utf-8",
+    )
+    (csharp_project / "CastTwinApp.cs").write_text(
+        """
+namespace N;
+public class App {
+    public void Run(object o) { ((Opt<int>)o).M(); }
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    targets = _call_targets(mock_ingestor)
+    assert any("CastTwinB" in t and t.endswith("N.Opt.M") for t in targets), targets

--- a/codebase_rag/tests/test_csharp_type_refs.py
+++ b/codebase_rag/tests/test_csharp_type_refs.py
@@ -1,0 +1,26 @@
+# (H) Pure-function coverage for the C# type-reference helpers: the CLR-style
+# (H) arity annotation must round-trip through every stored type map, and the
+# (H) arity counter must ignore nested generics and array brackets.
+from codebase_rag.parsers.csharp.utils import (
+    annotate_type_ref,
+    generic_arity_of_type_text,
+    split_type_ref,
+)
+
+
+def test_generic_arity_counts_top_level_arguments_only() -> None:
+    assert generic_arity_of_type_text("Builder") == 0
+    assert generic_arity_of_type_text("Builder<T>") == 1
+    assert generic_arity_of_type_text("Map<K, List<V>>") == 2
+    assert generic_arity_of_type_text("Func<Tuple<A, B>, C>") == 2
+    assert generic_arity_of_type_text("string[]") == 0
+
+
+def test_annotate_and_split_round_trip() -> None:
+    assert annotate_type_ref("Builder") == "Builder"
+    assert annotate_type_ref("Builder<T>") == "Builder`1"
+    assert annotate_type_ref("Options<TResult>?") == "Options`1"
+    assert split_type_ref("Builder`1") == ("Builder", 1)
+    assert split_type_ref("Builder") == ("Builder", 0)
+    # (H) A backtick with a non-numeric tail is not an arity marker.
+    assert split_type_ref("Weird`name") == ("Weird`name", 0)

--- a/evals/oracles/csharp_oracle/Program.cs
+++ b/evals/oracles/csharp_oracle/Program.cs
@@ -81,6 +81,24 @@ foreach (var path in EnumerateCsFiles(rootFull, ignoredDirs))
     files.Add((rel, tree.GetRoot(), tree));
 }
 
+// Names of in-source EXTENSION methods (first parameter has a `this`
+// modifier): an extension targets a receiver whose type is typically
+// metadata (string, Exception), so the receiver-type fallback below must not
+// exclude calls to these names when overload resolution failed.
+var declaredExtensionNames = new HashSet<string>(StringComparer.Ordinal);
+foreach (var (_, fileRoot, _) in files)
+{
+    foreach (var node in fileRoot.DescendantNodes())
+    {
+        if (node is MethodDeclarationSyntax m
+            && m.ParameterList.Parameters.Count > 0
+            && m.ParameterList.Parameters[0].Modifiers.Any(SyntaxKind.ThisKeyword))
+        {
+            declaredExtensionNames.Add(m.Identifier.Text);
+        }
+    }
+}
+
 // A compilation over every first-party tree plus the host runtime's reference
 // set, so a call site's target can be RESOLVED rather than name-matched: a
 // syntactic reduction counts `cts.Cancel()` (BCL) as a first-party call
@@ -116,6 +134,36 @@ bool ResolvesOutsideSource(SemanticModel model, SyntaxNode node)
         // argument type, say): count the call unless EVERY candidate is
         // metadata, in which case the target family is certainly external.
         return info.CandidateSymbols.All(c => !c.Locations.Any(l => l.IsInSource));
+    }
+    // The member symbol is unresolved (third-party refs missing in test/bench
+    // files), but the RECEIVER's type may still resolve: a provably metadata
+    // receiver (Console, Task, a BCL field type) makes the call external even
+    // without overload resolution. An unresolved or in-source receiver keeps
+    // the historical name-based counting.
+    if (node is InvocationExpressionSyntax unresolvedInv
+        && unresolvedInv.Expression is MemberAccessExpressionSyntax ma)
+    {
+        // An in-source extension's receiver type is usually metadata
+        // (string, Exception); its calls must stay counted.
+        if (declaredExtensionNames.Contains(ma.Name.Identifier.Text))
+        {
+            return false;
+        }
+        var recvType = model.GetTypeInfo(ma.Expression).Type;
+        if (recvType is not null
+            && recvType.TypeKind != Microsoft.CodeAnalysis.TypeKind.Error
+            && !recvType.Locations.Any(l => l.IsInSource))
+        {
+            return true;
+        }
+        // A static call on a type name (`Console.WriteLine`): the receiver is
+        // not an expression with a type but a symbol; resolve it directly.
+        var recvSymbol = model.GetSymbolInfo(ma.Expression).Symbol;
+        if (recvSymbol is INamedTypeSymbol named
+            && !named.Locations.Any(l => l.IsInSource))
+        {
+            return true;
+        }
     }
     return false;
 }

--- a/evals/oracles/csharp_oracle/Program.cs
+++ b/evals/oracles/csharp_oracle/Program.cs
@@ -114,9 +114,34 @@ foreach (var asmPath in tpa.Split(Path.PathSeparator, StringSplitOptions.RemoveE
     try { references.Add(MetadataReference.CreateFromFile(asmPath)); }
     catch { }
 }
+// SDK ImplicitUsings live in generated obj/GlobalUsings.g.cs, which the file
+// walk rightly skips; synthesize a global using for every in-source namespace
+// (plus the SDK defaults) so cross-project receivers resolve exactly as the
+// real build sees them (a bench file referencing Polly.Registry without a
+// using dropped its GetPipeline calls from the truth set).
+var namespaceNames = new HashSet<string>(StringComparer.Ordinal)
+{
+    "System", "System.Collections.Generic", "System.IO", "System.Linq",
+    "System.Net.Http", "System.Threading", "System.Threading.Tasks",
+};
+foreach (var (_, fileRoot, _) in files)
+{
+    foreach (var node in fileRoot.DescendantNodes())
+    {
+        if (node is BaseNamespaceDeclarationSyntax ns)
+        {
+            namespaceNames.Add(ns.Name.ToString());
+        }
+    }
+}
+var globalUsings = string.Concat(
+    namespaceNames.OrderBy(n => n, StringComparer.Ordinal)
+        .Select(n => $"global using {n};\n"));
+var usingsTree = CSharpSyntaxTree.ParseText(globalUsings, path: "cgr-global-usings.g.cs");
+
 var compilation = CSharpCompilation.Create(
     "cgr-oracle",
-    files.Select(f => f.Tree),
+    files.Select(f => f.Tree).Append(usingsTree),
     references,
     new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
 

--- a/evals/oracles/csharp_oracle/Program.cs
+++ b/evals/oracles/csharp_oracle/Program.cs
@@ -70,7 +70,7 @@ if (!string.IsNullOrEmpty(ignoreEnv))
 var root = args.Length > 0 ? args[0] : ".";
 var rootFull = Path.GetFullPath(root);
 
-var files = new List<(string Rel, SyntaxNode Root)>();
+var files = new List<(string Rel, SyntaxNode Root, SyntaxTree Tree)>();
 foreach (var path in EnumerateCsFiles(rootFull, ignoredDirs))
 {
     string text;
@@ -78,14 +78,53 @@ foreach (var path in EnumerateCsFiles(rootFull, ignoredDirs))
     catch { continue; }
     var tree = CSharpSyntaxTree.ParseText(NeutralizeConditionalDirectives(text), path: path);
     var rel = Path.GetRelativePath(rootFull, path).Replace(Path.DirectorySeparatorChar, '/');
-    files.Add((rel, tree.GetRoot()));
+    files.Add((rel, tree.GetRoot(), tree));
+}
+
+// A compilation over every first-party tree plus the host runtime's reference
+// set, so a call site's target can be RESOLVED rather than name-matched: a
+// syntactic reduction counts `cts.Cancel()` (BCL) as a first-party call
+// whenever any unrelated first-party `Cancel` exists. Resolution to a metadata
+// (non-source) symbol excludes the call; an UNRESOLVED site (third-party
+// packages such as test frameworks are not referenced here) falls back to the
+// historical name-based counting so real first-party calls in those files are
+// not lost.
+var tpa = (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string) ?? string.Empty;
+var references = new List<MetadataReference>();
+foreach (var asmPath in tpa.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+{
+    try { references.Add(MetadataReference.CreateFromFile(asmPath)); }
+    catch { }
+}
+var compilation = CSharpCompilation.Create(
+    "cgr-oracle",
+    files.Select(f => f.Tree),
+    references,
+    new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+bool ResolvesOutsideSource(SemanticModel model, SyntaxNode node)
+{
+    var info = model.GetSymbolInfo(node);
+    var symbol = info.Symbol;
+    if (symbol is not null)
+    {
+        return !symbol.Locations.Any(l => l.IsInSource);
+    }
+    if (!info.CandidateSymbols.IsDefaultOrEmpty)
+    {
+        // Overload candidates exist but none won (missing refs for an
+        // argument type, say): count the call unless EVERY candidate is
+        // metadata, in which case the target family is certainly external.
+        return info.CandidateSymbols.All(c => !c.Locations.Any(l => l.IsInSource));
+    }
+    return false;
 }
 
 // First pass: the declared type-name universe, so a base type can be classed as
 // a base class (INHERITS) or interface (IMPLEMENTS) by what it is declared as.
 var declaredInterfaces = new HashSet<string>(StringComparer.Ordinal);
 var declaredClasses = new HashSet<string>(StringComparer.Ordinal);
-foreach (var (_, fileRoot) in files)
+foreach (var (_, fileRoot, _) in files)
 {
     foreach (var node in fileRoot.DescendantNodes())
     {
@@ -112,9 +151,10 @@ var edges = new List<Edge>();
 var nameEdges = new List<NameEdge>();
 var calls = new List<Call>();
 
-foreach (var (rel, fileRoot) in files)
+foreach (var (rel, fileRoot, fileTree) in files)
 {
     var module = new NodeRef(KindModule, rel, ModuleLine);
+    var semanticModel = compilation.GetSemanticModel(fileTree);
     foreach (var node in fileRoot.DescendantNodes())
     {
         switch (node)
@@ -134,13 +174,22 @@ foreach (var (rel, fileRoot) in files)
                 EmitLocalFunction(rel, local);
                 break;
             case InvocationExpressionSyntax invocation:
-                AddCall(rel, InvocationName(invocation));
+                if (!ResolvesOutsideSource(semanticModel, invocation))
+                {
+                    AddCall(rel, InvocationName(invocation));
+                }
                 break;
             case ObjectCreationExpressionSyntax creation:
-                AddCall(rel, TypeSimpleName(creation.Type));
+                if (!ResolvesOutsideSource(semanticModel, creation))
+                {
+                    AddCall(rel, TypeSimpleName(creation.Type));
+                }
                 break;
             case ImplicitObjectCreationExpressionSyntax implicitCreation:
-                AddCall(rel, TargetTypedNewName(implicitCreation));
+                if (!ResolvesOutsideSource(semanticModel, implicitCreation))
+                {
+                    AddCall(rel, TargetTypedNewName(implicitCreation));
+                }
                 break;
         }
     }


### PR DESCRIPTION
## What

Recall round 2 of the C# calls campaign (follows #787): the calls oracle becomes SEMANTIC, and the graph gains a set of precision gates for the fabrication classes the truthful oracle exposed. This re-baselines the C# retrieval eval on honest ground: the previous precision 1.0000 was partly an artifact of a syntax-only oracle that counted BCL calls whenever their simple name collided with any first-party declaration, silently matching cgr's own name-guessed edges.

## Oracle (evals/oracles/csharp_oracle)

Three changes, each RED-first:

1. **Semantic emission.** The oracle builds a real `CSharpCompilation` over every first-party tree with the host runtime's reference set and emits a call only when it resolves in-source. `cts.Cancel()` (BCL CancellationTokenSource) no longer counts as a first-party `Cancel` because Polly's TaskExecution happens to declare one; ~130 such collisions existed.
2. **Unresolved-site fallback with receiver typing.** Test and bench files reference packages we do not have (xunit, BenchmarkDotNet), so unresolved sites keep the historical name-based counting, EXCEPT when the receiver's type resolves to metadata, with in-source extension names exempted (an extension's receiver is typically BCL: `exception.RethrowWithOriginalStackTraceIfDiffersFrom(...)` stays counted).
3. **Synthesized global usings.** SDK ImplicitUsings live in generated obj/GlobalUsings.g.cs, which the file walk rightly skips; the oracle now synthesizes a `global using` for every in-source namespace plus SDK defaults. Without this, Polly's bench files could not resolve `ResiliencePipelineProvider` at all and their calls dropped out of the truth set.

## Graph precision gates (all C#-scoped, each RED-first)

- `base.X()` binds the base chain only: a first-party base member when one exists, otherwise nothing. The trie was self-looping `base.Equals(obj)` bodies onto the caller's own override in every hide-object-members region.
- Object-virtual names (`GetType`, `ToString`, `Equals`, ...) never bind by name: a miss on the receiver's own hierarchy resolves to System.Object, and the trie fallback landed on Polly's PolicyBuilder attractor (the only first-party declarer).
- A delegate-typed property invoked with call syntax is Delegate.Invoke, not a method call, on both the name and arity resolution paths (properties register as arity-0 METHOD nodes); reachability stays covered by the property-read pass.
- A bare name that is a delegate-typed member of the enclosing type (`Callback();` on a record positional property) is likewise Invoke; record positional parameters now register as members.
- Static calls on unresolvable PascalCase types (`Console.WriteLine`) and members whose receiver type declares no such member anywhere first-party (`Wrapper.DisposeAsync()` on BCL RateLimiter, undefeated by Polly's Snippets demo class that merely shares the simple name) are suppressed instead of name-bound.
- Type references now carry their written generic arity CLR-style through every stored type map (`Options` vs `Options<TResult>` twins stay distinguishable in locals, fields, params, and extension receivers), which fixed the twin-ctor receiver typing and made the extension matcher arity-exact on both sides.
- `params` array parameters (loose grammar tokens, not `parameter` nodes) now enter the local type map.

## Honest numbers (Polly, pure tree-sitter frontend)

Under the truthful oracle: tp 2914, fp 55, fn 525 (precision 0.9815, recall 0.8473, f1 0.9095). The 55 residual false positives are ONE class: member calls on receivers whose type is genuinely uninferable from syntax (`var e = x.GetEnumerator(); e.MoveNext()`, reflection locals), where the name-trie fallback guesses first-party. Two measured attempts to gate that class each traded roughly 300 true edges for 30 false ones and were reverted; the correct instrument is the Roslyn hybrid frontend, whose exact call facts override every heuristic here. Dead-code on Polly is unchanged at its single verified true positive; all 155 C# tests pass.
