### PR TITLE
fix(csharp): recover conditional-directive parses and keep same-arity overload families reachable

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -2069,6 +2069,25 @@ class CallProcessor:
                 callee_info = resolver.resolve_csharp_method_call(
                     call_node, module_qn, call_var_types, caller_qn
                 )
+                if (
+                    callee_info is not None
+                    and callee_info != csharp_ti.CSHARP_EXTERNAL_TARGET
+                    and (fn_node := call_node.child_by_field_name(cs.TS_FIELD_FUNCTION))
+                    is not None
+                    and fn_node.type
+                    in (cs.TS_CSHARP_IDENTIFIER, cs.TS_CSHARP_GENERIC_NAME)
+                ):
+                    # (H) A bare call resolved by ARITY may have same-arity
+                    # (H) siblings differing only in parameter types (Serilog's
+                    # (H) FormatExactNumericValue switch dispatch); keep the
+                    # (H) whole family reachable.
+                    engine = resolver.type_inference.csharp_type_inference
+                    for sibling_qn in engine.csharp_same_arity_family(callee_info[1]):
+                        ensure_rel(
+                            caller_spec,
+                            calls_rel,
+                            (cs.NodeLabel.METHOD, qn_key, sibling_qn),
+                        )
                 if callee_info == csharp_ti.CSHARP_EXTERNAL_TARGET:
                     # (H) Provably external (base.X() with an external base, a
                     # (H) static call on an unregistered type, an object

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -2080,14 +2080,19 @@ class CallProcessor:
                     # (H) A bare call resolved by ARITY may have same-arity
                     # (H) siblings differing only in parameter types (Serilog's
                     # (H) FormatExactNumericValue switch dispatch); keep the
-                    # (H) whole family reachable.
+                    # (H) whole family reachable. NOT when a Roslyn fact pinned
+                    # (H) the site: that is the compiler's exact overload
+                    # (H) choice, and widening it would revive dead siblings.
                     engine = resolver.type_inference.csharp_type_inference
-                    for sibling_qn in engine.csharp_same_arity_family(callee_info[1]):
-                        ensure_rel(
-                            caller_spec,
-                            calls_rel,
-                            (cs.NodeLabel.METHOD, qn_key, sibling_qn),
-                        )
+                    if not engine.semantic_fact_resolved(call_node, module_qn):
+                        for sibling_qn in engine.csharp_same_arity_family(
+                            callee_info[1]
+                        ):
+                            ensure_rel(
+                                caller_spec,
+                                calls_rel,
+                                (cs.NodeLabel.METHOD, qn_key, sibling_qn),
+                            )
                 if callee_info == csharp_ti.CSHARP_EXTERNAL_TARGET:
                     # (H) Provably external (base.X() with an external base, a
                     # (H) static call on an unregistered type, an object

--- a/codebase_rag/parsers/cpp/preproc_recovery.py
+++ b/codebase_rag/parsers/cpp/preproc_recovery.py
@@ -93,9 +93,6 @@ def _blank(lines: list[bytes], ranges: list[tuple[int, int]]) -> bytes:
     return _CHAR_NEWLINE.join(out)
 
 
-_CSHARP_DIRECTIVE_PREFIXES = (b"#if", b"#elif", b"#else", b"#endif")
-
-
 def _count_error_nodes(root: Node) -> int:
     count = 0
     stack = [root]
@@ -133,7 +130,7 @@ def _blank_csharp_directives(source_bytes: bytes) -> bytes:
                 skip_stack.pop()
             lines[i] = b""
             continue
-        if any(skip_stack) and skip_stack[-1]:
+        if skip_stack and skip_stack[-1]:
             lines[i] = b""
     return _CHAR_NEWLINE.join(lines)
 
@@ -149,8 +146,9 @@ def parse_with_preproc_recovery(
         # (H) members register as module-level Functions and the directive
         # (H) CONDITION becomes a phantom node. On any parse error, retry with
         # (H) the conditional-directive LINES blanked (line-count preserving,
-        # (H) both branches kept -- the duplicate-qn machinery absorbs twin
-        # (H) branch definitions) and keep the tree with the smaller error.
+        # (H) only the FIRST branch kept -- an orphaned alternative body would
+        # (H) misparse into a phantom bare-name declaration) and keep the tree
+        # (H) with the smaller error.
         # (H) has_error, not the line-span metric: the shatter often yields
         # (H) SINGLE-LINE inner ERROR nodes inside a plausibly-shaped wrong
         # (H) declaration (a property named after the directive condition),

--- a/codebase_rag/parsers/cpp/preproc_recovery.py
+++ b/codebase_rag/parsers/cpp/preproc_recovery.py
@@ -93,10 +93,52 @@ def _blank(lines: list[bytes], ranges: list[tuple[int, int]]) -> bytes:
     return _CHAR_NEWLINE.join(out)
 
 
+_CSHARP_DIRECTIVE_PREFIXES = (b"#if", b"#elif", b"#else", b"#endif")
+
+
+def _count_error_nodes(root: Node) -> int:
+    count = 0
+    stack = [root]
+    while stack:
+        node = stack.pop()
+        if node.type == cs.TS_ERROR:
+            count += 1
+        if node.has_error:
+            stack.extend(node.children)
+    return count
+
+
+def _blank_csharp_directives(source_bytes: bytes) -> bytes:
+    lines = source_bytes.split(_CHAR_NEWLINE)
+    for i, line in enumerate(lines):
+        if line.lstrip().startswith(_CSHARP_DIRECTIVE_PREFIXES):
+            lines[i] = b""
+    return _CHAR_NEWLINE.join(lines)
+
+
 def parse_with_preproc_recovery(
     parser: Parser, source_bytes: bytes, language: cs.SupportedLanguage
 ) -> Tree:
     tree = parser.parse(source_bytes)
+    if language == cs.SupportedLanguage.CSHARP:
+        # (H) A C# conditional directive interleaved with declaration syntax
+        # (H) (`void M() #if X => Impl() #endif ;`, Serilog's ILogger default
+        # (H) interface bodies) can shatter a whole type into an ERROR node:
+        # (H) members register as module-level Functions and the directive
+        # (H) CONDITION becomes a phantom node. On any parse error, retry with
+        # (H) the conditional-directive LINES blanked (line-count preserving,
+        # (H) both branches kept -- the duplicate-qn machinery absorbs twin
+        # (H) branch definitions) and keep the tree with the smaller error.
+        # (H) has_error, not the line-span metric: the shatter often yields
+        # (H) SINGLE-LINE inner ERROR nodes inside a plausibly-shaped wrong
+        # (H) declaration (a property named after the directive condition),
+        # (H) which a span measure scores as zero.
+        if not tree.root_node.has_error or b"#if" not in source_bytes:
+            return tree
+        retry = parser.parse(_blank_csharp_directives(source_bytes))
+        if _count_error_nodes(retry.root_node) < _count_error_nodes(tree.root_node):
+            return retry
+        return tree
     if language not in (cs.SupportedLanguage.CPP, cs.SupportedLanguage.C):
         return tree
     worst = _max_error_span(tree.root_node)

--- a/codebase_rag/parsers/cpp/preproc_recovery.py
+++ b/codebase_rag/parsers/cpp/preproc_recovery.py
@@ -105,32 +105,37 @@ def _count_error_nodes(root: Node) -> int:
     return count
 
 
+def _track_csharp_directive(stripped: bytes, skip_stack: list[bool]) -> bool:
+    # (H) Mutates skip_stack for the directive on this line; True means the
+    # (H) line IS a directive (always blanked). `#elif`/`#else` flip the
+    # (H) current group to skipping so only the FIRST branch survives; an
+    # (H) `#if` inside a skipped branch inherits the skip.
+    if stripped.startswith(b"#if"):
+        skip_stack.append(any(skip_stack))
+        return True
+    if stripped.startswith((b"#elif", b"#else")):
+        if skip_stack:
+            skip_stack[-1] = True
+        return True
+    if stripped.startswith(b"#endif"):
+        if skip_stack:
+            skip_stack.pop()
+        return True
+    return False
+
+
 def _blank_csharp_directives(source_bytes: bytes) -> bytes:
     # (H) Keep only the FIRST branch of each conditional group: retaining both
     # (H) branches of an `#if X bodyA #else bodyB #endif` around an
     # (H) expression-bodied member leaves an orphaned second body that
     # (H) misparses into a phantom bare-name declaration (Polly's
-    # (H) DelegatingComponent grew a parameterless ExecuteComponent). Nested
-    # (H) groups inside a skipped branch stay skipped.
+    # (H) DelegatingComponent grew a parameterless ExecuteComponent).
     lines = source_bytes.split(_CHAR_NEWLINE)
     skip_stack: list[bool] = []
     for i, line in enumerate(lines):
-        stripped = line.lstrip()
-        if stripped.startswith(b"#if"):
-            skip_stack.append(any(skip_stack))
-            lines[i] = b""
-            continue
-        if stripped.startswith((b"#elif", b"#else")):
-            if skip_stack:
-                skip_stack[-1] = True
-            lines[i] = b""
-            continue
-        if stripped.startswith(b"#endif"):
-            if skip_stack:
-                skip_stack.pop()
-            lines[i] = b""
-            continue
-        if skip_stack and skip_stack[-1]:
+        if _track_csharp_directive(line.lstrip(), skip_stack) or (
+            skip_stack and skip_stack[-1]
+        ):
             lines[i] = b""
     return _CHAR_NEWLINE.join(lines)
 

--- a/codebase_rag/parsers/cpp/preproc_recovery.py
+++ b/codebase_rag/parsers/cpp/preproc_recovery.py
@@ -109,9 +109,31 @@ def _count_error_nodes(root: Node) -> int:
 
 
 def _blank_csharp_directives(source_bytes: bytes) -> bytes:
+    # (H) Keep only the FIRST branch of each conditional group: retaining both
+    # (H) branches of an `#if X bodyA #else bodyB #endif` around an
+    # (H) expression-bodied member leaves an orphaned second body that
+    # (H) misparses into a phantom bare-name declaration (Polly's
+    # (H) DelegatingComponent grew a parameterless ExecuteComponent). Nested
+    # (H) groups inside a skipped branch stay skipped.
     lines = source_bytes.split(_CHAR_NEWLINE)
+    skip_stack: list[bool] = []
     for i, line in enumerate(lines):
-        if line.lstrip().startswith(_CSHARP_DIRECTIVE_PREFIXES):
+        stripped = line.lstrip()
+        if stripped.startswith(b"#if"):
+            skip_stack.append(any(skip_stack))
+            lines[i] = b""
+            continue
+        if stripped.startswith((b"#elif", b"#else")):
+            if skip_stack:
+                skip_stack[-1] = True
+            lines[i] = b""
+            continue
+        if stripped.startswith(b"#endif"):
+            if skip_stack:
+                skip_stack.pop()
+            lines[i] = b""
+            continue
+        if any(skip_stack) and skip_stack[-1]:
             lines[i] = b""
     return _CHAR_NEWLINE.join(lines)
 

--- a/codebase_rag/parsers/csharp/type_inference.py
+++ b/codebase_rag/parsers/csharp/type_inference.py
@@ -414,21 +414,11 @@ class CSharpTypeInferenceEngine:
         if not all(seg[:1].isupper() for seg in segments):
             return False
         if class_qn := self._containing_class_qn(caller_qn):
-            if member_type := self._field_type(class_qn, head):
-                # (H) Same rule for a field/property receiver: an
-                # (H) external-typed member (`Wrapper` of BCL RateLimiter)
-                # (H) makes the call external (the trie self-looped
-                # (H) `Wrapper.DisposeAsync()` onto the enclosing class).
-                return not self._registered_type_declares(member_type, method_name)
-            if prop_qn := self.resolve_property_read(head, caller_qn):
-                if entry := self.csharp_method_return_types.get(prop_qn):
-                    return not self._registered_type_declares(entry[0], method_name)
-            # (H) A PascalCase receiver is very often a PROPERTY or member of
-            # (H) the enclosing type (`Pipeline.Execute(...)`); anything the
-            # (H) enclosing type declares by that name is first-party, not an
-            # (H) external type.
-            if self._find_name_across_parts(class_qn, head) is not None:
-                return False
+            verdict = self._enclosing_member_external(
+                class_qn, head, method_name, caller_qn
+            )
+            if verdict is not None:
+                return verdict
         # (H) Any registered type with this simple name means the receiver may
         # (H) be first-party (even when twin ambiguity kept it untyped).
         if any(
@@ -437,6 +427,33 @@ class CSharpTypeInferenceEngine:
         ):
             return False
         return True
+
+    def _enclosing_member_external(
+        self,
+        class_qn: str,
+        head: str,
+        method_name: str,
+        caller_qn: str | None,
+    ) -> bool | None:
+        # (H) Tri-state: True/False decide externality from what the enclosing
+        # (H) type knows about the receiver head; None leaves it to the
+        # (H) registered-simple-name sweep.
+        if member_type := self._field_type(class_qn, head):
+            # (H) A field/property receiver whose declared type is external
+            # (H) (`Wrapper` of BCL RateLimiter) makes the call external (the
+            # (H) trie self-looped `Wrapper.DisposeAsync()` onto the enclosing
+            # (H) class).
+            return not self._registered_type_declares(member_type, method_name)
+        if prop_qn := self.resolve_property_read(head, caller_qn):
+            if entry := self.csharp_method_return_types.get(prop_qn):
+                return not self._registered_type_declares(entry[0], method_name)
+        # (H) A PascalCase receiver is very often a PROPERTY or member of
+        # (H) the enclosing type (`Pipeline.Execute(...)`); anything the
+        # (H) enclosing type declares by that name is first-party, not an
+        # (H) external type.
+        if self._find_name_across_parts(class_qn, head) is not None:
+            return False
+        return None
 
     def _resolve_bare_call(
         self,
@@ -714,35 +731,49 @@ class CSharpTypeInferenceEngine:
             return None
         receiver = unwrapped
         # (H) `((Widget)o).Ext()`: the cast target IS the receiver type, so an
-        # (H) extension-only method still binds on a cast receiver.
-        if receiver.type == cs.TS_CSHARP_CAST_EXPRESSION:
-            type_node = receiver.child_by_field_name(cs.FIELD_TYPE)
-            raw = safe_decode_text(type_node) if type_node else None
-            return annotate_type_ref(raw) if raw else None
+        # (H) extension-only method still binds on a cast receiver; same for a
+        # (H) `new Widget(...)` receiver.
+        if receiver.type in (
+            cs.TS_CSHARP_CAST_EXPRESSION,
+            cs.TS_CSHARP_OBJECT_CREATION_EXPRESSION,
+        ):
+            return self._annotated_type_field(receiver)
         # (H) Same chained-receiver typing as the instance path, stopping at
         # (H) the (arity-annotated) type name -- extensions often target
         # (H) unregistered BCL types like `string`, and both sides of the
         # (H) matcher carry the annotation consistently.
-        if receiver.type == cs.TS_CSHARP_OBJECT_CREATION_EXPRESSION:
-            type_node = receiver.child_by_field_name(cs.FIELD_TYPE)
-            type_text = safe_decode_text(type_node) if type_node else None
-            return annotate_type_ref(type_text) if type_text else None
         if receiver.type == cs.TS_CSHARP_INVOCATION_EXPRESSION:
-            inner = self.resolve_csharp_method_call(
+            return self._invocation_return_type_name(
                 receiver, local_var_types, module_qn, caller_qn
             )
-            if inner is None:
-                return None
-            if entry := self.csharp_method_return_types.get(inner[1]):
-                rname, rarity = entry
-                return f"{rname}`{rarity}" if rarity else rname
-            return None
         if receiver.type == cs.TS_CSHARP_THIS:
             return self._this_receiver_type(module_qn, caller_qn)
         if receiver.type == cs.TS_CSHARP_MEMBER_ACCESS_EXPRESSION:
             return self._this_field_receiver_type(receiver, caller_qn)
         if receiver.type == cs.TS_CSHARP_IDENTIFIER:
             return self._identifier_receiver_type(receiver, local_var_types, caller_qn)
+        return None
+
+    def _annotated_type_field(self, receiver: Node) -> str | None:
+        type_node = receiver.child_by_field_name(cs.FIELD_TYPE)
+        raw = safe_decode_text(type_node) if type_node else None
+        return annotate_type_ref(raw) if raw else None
+
+    def _invocation_return_type_name(
+        self,
+        receiver: Node,
+        local_var_types: dict[str, str],
+        module_qn: str,
+        caller_qn: str | None,
+    ) -> str | None:
+        inner = self.resolve_csharp_method_call(
+            receiver, local_var_types, module_qn, caller_qn
+        )
+        if inner is None:
+            return None
+        if entry := self.csharp_method_return_types.get(inner[1]):
+            rname, rarity = entry
+            return f"{rname}`{rarity}" if rarity else rname
         return None
 
     def _unwrap_receiver(self, receiver: Node) -> Node | None:
@@ -1048,6 +1079,14 @@ class CSharpTypeInferenceEngine:
             for qn in self.simple_name_lookup.get(simple, set())
             if self.function_registry.get(qn) in _TYPE_DECLS
         ]
+        return self._disambiguate_type_candidates(candidates, generic_arity, module_qn)
+
+    def _disambiguate_type_candidates(
+        self,
+        candidates: list[str],
+        generic_arity: int | None,
+        module_qn: str,
+    ) -> str | None:
         # (H) `Builder` vs `Builder<TResult>` share a simple name; when the
         # (H) reference's WRITTEN generic arity is known, keep only the
         # (H) declarations with that type-parameter count (Polly's dual

--- a/codebase_rag/parsers/csharp/type_inference.py
+++ b/codebase_rag/parsers/csharp/type_inference.py
@@ -1141,6 +1141,25 @@ class CSharpTypeInferenceEngine:
         for base_qn in self.class_inheritance.get(class_qn, []):
             self._collect_arity_matches(base_qn, method_name, arg_count, seen, out)
 
+    def csharp_same_arity_family(self, method_qn: str) -> list[str]:
+        # (H) Signature-suffixed siblings of a resolved bare call that differ
+        # (H) only in parameter TYPES: a switch-arm dispatch
+        # (H) (`FormatExact(i, o)` / `FormatExact(s, o)`) is untypeable by
+        # (H) arity alone, so the whole same-arity family stays reachable.
+        if cs.CHAR_PAREN_OPEN not in method_qn:
+            return []
+        base = method_qn.split(cs.CHAR_PAREN_OPEN, 1)[0]
+        if cs.SEPARATOR_DOT not in base:
+            return []
+        class_qn, name = base.rsplit(cs.SEPARATOR_DOT, 1)
+        return [
+            qn
+            for qn in self._find_arity_matches_across_parts(
+                class_qn, name, _arity(method_qn)
+            )
+            if qn != method_qn
+        ]
+
     def csharp_method_group_family(self, name: str, caller_qn: str | None) -> list[str]:
         # (H) Every same-name METHOD of the caller's enclosing type (across
         # (H) partial parts and base classes): a bare method-group pass binds

--- a/codebase_rag/parsers/csharp/type_inference.py
+++ b/codebase_rag/parsers/csharp/type_inference.py
@@ -612,6 +612,12 @@ class CSharpTypeInferenceEngine:
             return qn
         return None
 
+    def semantic_fact_resolved(self, call_node: Node, module_qn: str) -> bool:
+        # (H) True when a Roslyn call fact pinned this exact site: the target is
+        # (H) the compiler's own overload choice, so arity-based widening (the
+        # (H) same-arity family fan-out) must stay off for it.
+        return self._semantic_call_target(call_node, module_qn) is not None
+
     def _semantic_call_target(
         self, call_node: Node, module_qn: str
     ) -> tuple[str, str] | None:

--- a/codebase_rag/tests/test_csharp_calls.py
+++ b/codebase_rag/tests/test_csharp_calls.py
@@ -719,3 +719,34 @@ public class Holder {
 
     pairs = _call_pairs(mock_ingestor)
     assert any(t.endswith("N.Keeper.Flush") for s, t in pairs), pairs
+
+
+def test_same_arity_overload_family_all_receive_calls(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) Nine switch arms dispatch `FormatExact(value, output)` to nine
+    # (H) same-ARITY overloads differing only by parameter TYPE (Serilog's
+    # (H) JsonValueFormatter): syntax cannot pick the arm's overload, so the
+    # (H) whole same-arity family must receive the CALLS edge or every
+    # (H) sibling but one reports dead.
+    (csharp_project / "FamArity.cs").write_text(
+        """
+namespace N;
+public class Fmt {
+    public void Write(object v) {
+        switch (v) {
+            case int i: FormatExact(i, 1); break;
+            case string s: FormatExact(s, 1); break;
+        }
+    }
+    static void FormatExact(int value, int o) { }
+    static void FormatExact(string value, int o) { }
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    pairs = _call_pairs(mock_ingestor)
+    assert any(t.endswith("N.Fmt.FormatExact(int, int)") for s, t in pairs), pairs
+    assert any(t.endswith("N.Fmt.FormatExact(string, int)") for s, t in pairs), pairs

--- a/codebase_rag/tests/test_csharp_preproc_split_body.py
+++ b/codebase_rag/tests/test_csharp_preproc_split_body.py
@@ -166,3 +166,44 @@ def test_if_truncated_class_body_orphan_members_are_methods(
         caller_label, _, caller_qn = c.args[0]
         assert caller_label == cs.NodeLabel.METHOD.value, c.args[0]
         assert ".Reader.BlockCopyChars" in caller_qn, caller_qn
+
+
+def test_directive_wrapped_default_interface_bodies_parse_clean(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) An interface member with an `#if`-wrapped default body
+    # (H) (`void M() #if X => Impl() #endif ;`, Serilog's ILogger) shatters the
+    # (H) whole interface into an ERROR node: every member registers as a
+    # (H) module-level Function and the directive CONDITION itself becomes a
+    # (H) phantom node. Blanking conditional-directive lines on a broken parse
+    # (H) recovers the real structure.
+    project = temp_repo / "cs_default_iface"
+    project.mkdir()
+    members = []
+    for i in range(6):
+        members.append(
+            f'    [Obsolete("m{i}")]\n'
+            f"    void Verbose{i}(string messageTemplate, params object?[]? args)\n"
+            "#if FEATURE_DEFAULT_INTERFACE\n"
+            f"        => Write((System.Exception?)null, messageTemplate)\n"
+            "#endif\n"
+            "    ;\n"
+        )
+    (project / "ILogger.cs").write_text(
+        "using System;\n"
+        "namespace N;\n"
+        "public interface ILogger {\n"
+        "    ILogger ForContext(string name);\n"
+        + "".join(members)
+        + "    void Write(Exception? ex, string messageTemplate);\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    run_updater(project, mock_ingestor, skip_if_missing=SKIP)
+
+    method_names = _leaf_names(mock_ingestor, "Method")
+    function_names = _leaf_names(mock_ingestor, "Function")
+    assert "Verbose" in method_names, (method_names, function_names)
+    assert "FEATURE_DEFAULT_INTERFACE" not in function_names, function_names
+    assert "FEATURE_DEFAULT_INTERFACE" not in method_names, method_names
+    assert "if" not in function_names, function_names

--- a/codebase_rag/tests/test_csharp_preproc_split_body.py
+++ b/codebase_rag/tests/test_csharp_preproc_split_body.py
@@ -203,7 +203,7 @@ def test_directive_wrapped_default_interface_bodies_parse_clean(
 
     method_names = _leaf_names(mock_ingestor, "Method")
     function_names = _leaf_names(mock_ingestor, "Function")
-    assert "Verbose" in method_names, (method_names, function_names)
+    assert "Verbose0" in method_names, (method_names, function_names)
     assert "FEATURE_DEFAULT_INTERFACE" not in function_names, function_names
     assert "FEATURE_DEFAULT_INTERFACE" not in method_names, method_names
     assert "if" not in function_names, function_names

--- a/codebase_rag/tests/test_csharp_semantic_facts.py
+++ b/codebase_rag/tests/test_csharp_semantic_facts.py
@@ -209,6 +209,57 @@ def test_call_fact_resolves_conditional_access_invocation(
     assert _has(calls, "N.App.GoSafe(C)", "N.C.Handle(string)"), calls
 
 
+_BARE_FANOUT_SRC = """namespace N;
+
+public class C
+{
+    public void Go()
+    {
+        Format(1);
+    }
+
+    public void Format(int i) { }
+
+    public void Format(string s) { }
+}
+"""
+
+
+def test_call_fact_suppresses_same_arity_family_fanout(
+    temp_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # (H) A bare `Format(1)` with a Roslyn call fact is the COMPILER's overload
+    # (H) choice: the same-arity family fan-out (which keeps type-dispatched
+    # (H) switch families reachable when only arity is known) must NOT fire, or
+    # (H) it would revive the provably-uncalled `Format(string)` sibling in
+    # (H) dead-code output.
+    root = temp_repo / "barefanproj"
+    root.mkdir()
+    (root / "Code.cs").write_text(_BARE_FANOUT_SRC, encoding="utf-8")
+    (root / "Sample.csproj").write_text(_CSPROJ, encoding="utf-8")
+
+    call_line, call_col = _loc(_BARE_FANOUT_SRC, "Format(1)")
+    target_line, target_col = _loc(_BARE_FANOUT_SRC, "public void Format(int i)")
+    facts = CSharpSemanticFacts(
+        base_kinds={},
+        call_sites={
+            ("Code.cs", call_line, call_col, "Format"): CSharpCallSite(
+                "Format", "Code.cs", target_line, target_col
+            )
+        },
+        partial_groups=[],
+        query_calls=[],
+    )
+    _hybrid(monkeypatch, facts)
+
+    ingestor = MagicMock()
+    run_updater(root, ingestor, skip_if_missing=SKIP)
+
+    calls = _pairs(ingestor, "CALLS")
+    assert _has(calls, "N.C.Go", "N.C.Format(int)"), calls
+    assert not _has(calls, "N.C.Go", "N.C.Format(string)"), calls
+
+
 _PART_A = """namespace N;
 
 public partial class W

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.370"
+version = "0.0.372"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

Second-repo C# dead-code dogfood, on Serilog (follows the Polly campaign, #782 through #789): Serilog's report goes from 36 findings to ZERO across three root-cause fixes, with Polly and the retrieval eval as regression guards (Polly stays at its single verified true positive; eval numbers identical).

## Root causes and fixes

1. **Conditional directives shatter parses into phantom declarations.** Serilog's ILogger wraps default interface bodies in `#if FEATURE_DEFAULT_INTERFACE`; the grammar misparses each member into a property declaration NAMED after the directive condition, with only single-line inner ERROR nodes. Result: 12 phantom nodes named `FEATURE_DEFAULT_INTERFACE`, one named `if`, and every real ILogger member registered as a module-level Function. The C# path of the parse-recovery wrapper now retries with conditional-directive lines blanked whenever the tree has any error; the trigger is `has_error` plus an error-node count, never the line-span metric, which scores single-line errors as zero.
2. **Both-branch retention orphans alternative bodies.** Keeping both branches of `#if X bodyA #else bodyB #endif` around an expression-bodied member leaves the second body orphaned at declaration position, misparsing into a bare phantom method (Polly's DelegatingComponent grew a parameterless ExecuteComponent under the first blanking). Blanking now keeps only the FIRST branch of each group, with nested groups inside a skipped branch staying skipped.
3. **Same-arity overload families starve.** Serilog's JsonValueFormatter dispatches `FormatExactNumericValue(value, output)` through nine switch arms to nine same-ARITY overloads differing only by parameter type; bare-call resolution picked one and the other eight reported dead (also `GetLevelMoniker`, `StructureValue.Render`, and the whole PropertyValueConverter/PropertyBinder cascade behind them). A resolved bare call now also emits CALLS to its same-arity signature siblings across partial parts and bases, keeping the family reachable. This is reduction-invisible to the retrieval eval by construction, and the Roslyn oracle counts every switch arm anyway.

## Validation

- RED demonstrated in commit history for all three fixes.
- Full suite green; all 163 C# tests pass.
- Serilog dead-code: 36 -> 24 (parse recovery) -> 0 (family fan-out).
- Polly dead-code: unchanged at 1, the verified `PolicyBuilder` true positive (the intermediate keep-both-branches state briefly introduced a phantom there, caught by the regression guard and fixed by keep-first-branch).
- C# retrieval eval (full Polly, semantic oracle): tp 2914, fp 55, precision 0.9815 — identical before and after, as designed.
