### PR TITLE
fix(cpp): reattach recovery-orphaned ctors as class methods and redirect construction CALLS to C++ ctors

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -2350,14 +2350,16 @@ class CallProcessor:
                 if language in (
                     cs.SupportedLanguage.JAVA,
                     cs.SupportedLanguage.CSHARP,
+                    cs.SupportedLanguage.CPP,
                 ):
-                    # (H) A Java/C# constructor is a method named like its class
-                    # (H) (`Foo.Foo`), not `__init__`; `new Foo(...)` runs one, so
-                    # (H) redirect a CALLS edge to every declared constructor (overload
-                    # (H) selection is unneeded for reachability). C# constructors use
-                    # (H) the same class-simple-name convention, so java_constructor_targets
-                    # (H) selects them too. sorted(): the target label is a hash-randomized
-                    # (H) StrEnum, so sort for deterministic output.
+                    # (H) A Java/C#/C++ constructor is a method named like its class
+                    # (H) (`Foo.Foo`), not `__init__`; `new Foo(...)` / `Foo(...)`
+                    # (H) runs one, so redirect a CALLS edge to every declared
+                    # (H) constructor (overload selection is unneeded for
+                    # (H) reachability). C# and C++ constructors use the same
+                    # (H) class-simple-name convention, so java_constructor_targets
+                    # (H) selects them too. sorted(): the target label is a
+                    # (H) hash-randomized StrEnum, so sort for deterministic output.
                     for ctor_type, ctor_qn in sorted(
                         resolver.java_constructor_targets(callee_qn)
                     ):

--- a/codebase_rag/parsers/cpp/utils.py
+++ b/codebase_rag/parsers/cpp/utils.py
@@ -321,17 +321,16 @@ def _has_named_parameter(declarator: Node) -> bool:
     return False
 
 
-def is_macro_invocation_artifact(func_node: Node) -> bool:
+def is_recovery_artifact_shape(func_node: Node) -> bool:
     # (H) `FMT_CATCH(...) {}` -- a macro invocation followed by a block -- parses
     # (H) as a TYPE-LESS function_definition (or declaration, when member-init
     # (H) recovery sweeps it into a class body) named after the macro. Valid C++
     # (H) only omits the return type on a constructor, whose plain-identifier
-    # (H) declarator repeats the enclosing class name; any other type-less
-    # (H) plain-identifier definition with no named parameter is a parse
-    # (H) artifact, not a definition. A recovery-ORPHANED ctor (its class
-    # (H) ancestor destroyed by the same recovery) is distinguished by its named
-    # (H) parameters, or -- for the zero/unnamed-param shape -- by the caller
-    # (H) checking the class registry before dropping the node.
+    # (H) declarator repeats the enclosing class name; every OTHER type-less
+    # (H) plain-identifier definition shares one shape with two meanings: a
+    # (H) macro invocation, or a real definition the recovery orphaned from its
+    # (H) class / stripped of its type. The registered-class tiebreak and the
+    # (H) named-parameter evidence (see is_macro_invocation_artifact) decide.
     if func_node.type not in (
         cs.CppNodeType.FUNCTION_DEFINITION,
         cs.CppNodeType.DECLARATION,
@@ -345,9 +344,20 @@ def is_macro_invocation_artifact(func_node: Node) -> bool:
     inner = declarator.child_by_field_name(cs.FIELD_DECLARATOR)
     if inner is None or inner.type != cs.CppNodeType.IDENTIFIER or not inner.text:
         return False
-    if safe_decode_text(inner) == _enclosing_class_name(func_node):
-        return False
-    return not _has_named_parameter(declarator)
+    return safe_decode_text(inner) != _enclosing_class_name(func_node)
+
+
+def has_named_parameter(func_node: Node) -> bool:
+    declarator = func_node.child_by_field_name(cs.FIELD_DECLARATOR)
+    return declarator is not None and _has_named_parameter(declarator)
+
+
+def is_macro_invocation_artifact(func_node: Node) -> bool:
+    # (H) A macro invocation's "parameters" are expressions, so the artifact
+    # (H) shape WITH a named parameter is proof of a genuine (recovery-mangled)
+    # (H) definition; without one, only a registered class bearing the name
+    # (H) (an orphaned zero-param ctor) saves the node from being dropped.
+    return is_recovery_artifact_shape(func_node) and not has_named_parameter(func_node)
 
 
 def extract_function_name(func_node: Node) -> str | None:

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -771,56 +771,56 @@ class FunctionIngestMixin:
         invocation. Returns the number registered.
         """
         deferred = self._deferred_cpp_artifacts
-        if not deferred:
-            return 0
-
-        registered = 0
-        for entry in deferred:
-            name = cpp_utils.extract_function_name(entry.func_node)
-            if not name:
-                continue
-            # (H) Scope-first, mirroring resolve_deferred_cpp_methods: the
-            # (H) namespace-qualified candidate disambiguates same-leaf classes.
-            candidates = [name]
-            if namespace_path := cs.SEPARATOR_DOT.join(
-                cpp_utils.extract_namespace_path(entry.func_node)
-            ):
-                candidates.insert(0, f"{namespace_path}{cs.SEPARATOR_DOT}{name}")
-            class_qn = ""
-            resolved = False
-            for candidate in candidates:
-                class_qn, resolved = self._resolve_cpp_class_qn(
-                    candidate, entry.module_qn
-                )
-                if resolved:
-                    break
-            file_path = self.module_qn_to_file_path.get(entry.module_qn)
-            if resolved:
-                if self._reattach_orphan_cpp_ctor(entry, class_qn, file_path):
-                    registered += 1
-                continue
-            if not cpp_utils.has_named_parameter(entry.func_node):
-                continue
-            resolution = self._resolve_function_identity(
-                entry.func_node,
-                entry.module_qn,
-                cs.SupportedLanguage.CPP,
-                entry.lang_config,
-                file_path,
-            )
-            if not resolution:
-                continue
-            self._register_function(
-                entry.func_node,
-                resolution,
-                entry.module_qn,
-                cs.SupportedLanguage.CPP,
-                entry.lang_config,
-                entry.lang_queries,
-            )
-            registered += 1
+        registered = sum(
+            1 for entry in deferred if self._resolve_one_cpp_artifact(entry)
+        )
         deferred.clear()
         return registered
+
+    def _resolve_one_cpp_artifact(self, entry: _DeferredCppArtifact) -> bool:
+        name = cpp_utils.extract_function_name(entry.func_node)
+        if not name:
+            return False
+        class_qn = self._lookup_cpp_artifact_class(entry, name)
+        file_path = self.module_qn_to_file_path.get(entry.module_qn)
+        if class_qn is not None:
+            return self._reattach_orphan_cpp_ctor(entry, class_qn, file_path)
+        if not cpp_utils.has_named_parameter(entry.func_node):
+            return False
+        resolution = self._resolve_function_identity(
+            entry.func_node,
+            entry.module_qn,
+            cs.SupportedLanguage.CPP,
+            entry.lang_config,
+            file_path,
+        )
+        if not resolution:
+            return False
+        self._register_function(
+            entry.func_node,
+            resolution,
+            entry.module_qn,
+            cs.SupportedLanguage.CPP,
+            entry.lang_config,
+            entry.lang_queries,
+        )
+        return True
+
+    def _lookup_cpp_artifact_class(
+        self, entry: _DeferredCppArtifact, name: str
+    ) -> str | None:
+        # (H) Scope-first, mirroring resolve_deferred_cpp_methods: the
+        # (H) namespace-qualified candidate disambiguates same-leaf classes.
+        candidates = [name]
+        if namespace_path := cs.SEPARATOR_DOT.join(
+            cpp_utils.extract_namespace_path(entry.func_node)
+        ):
+            candidates.insert(0, f"{namespace_path}{cs.SEPARATOR_DOT}{name}")
+        for candidate in candidates:
+            class_qn, resolved = self._resolve_cpp_class_qn(candidate, entry.module_qn)
+            if resolved:
+                return class_qn
+        return None
 
     def _reattach_orphan_cpp_ctor(
         self,

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -851,12 +851,12 @@ class FunctionIngestMixin:
         self.cpp_out_of_class_methods[
             (entry.module_qn, entry.func_node.start_point[0] + 1)
         ] = (method_qn, class_qn)
-        self.function_locations[
-            function_span_key(entry.module_qn, entry.func_node)
-        ] = FunctionLocation(
-            label=cs.NodeLabel.METHOD.value,
-            qualified_name=method_qn,
-            container_qn=class_qn,
+        self.function_locations[function_span_key(entry.module_qn, entry.func_node)] = (
+            FunctionLocation(
+                label=cs.NodeLabel.METHOD.value,
+                qualified_name=method_qn,
+                container_qn=class_qn,
+            )
         )
         record_cpp_definition_span(
             self.cpp_definition_spans,

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -102,14 +102,16 @@ class FunctionResolution(NamedTuple):
 
 
 class _DeferredCppArtifact(NamedTuple):
-    """Macro-invocation-shaped C++ node held until every class is registered.
+    """Artifact-shaped C++ node held until every class is registered.
 
-    A type-less plain-identifier definition with no named parameter is either
-    a macro invocation (`FMT_CATCH(...) {}`) or a recovery-orphaned zero-param
-    constructor (`file() {}` whose class ancestor the parse recovery
-    destroyed). The tiebreak is whether a registered class bears the name, and
-    the class pass for the SAME file runs after the function pass, so the
-    decision must wait for resolve_deferred_cpp_artifacts.
+    A type-less plain-identifier definition is either a macro invocation
+    (`FMT_CATCH(...) {}`) or a recovery-mangled real definition (`file(int fd)
+    {}` whose class ancestor the parse recovery destroyed). A registered class
+    bearing the name reattaches the node as that class's ctor METHOD; failing
+    that, a named parameter keeps it as a module Function; failing both it is
+    dropped as a macro. The class pass for the SAME file runs after the
+    function pass, so every branch of the decision must wait for
+    resolve_deferred_cpp_artifacts.
     """
 
     func_node: Node
@@ -297,13 +299,14 @@ class FunctionIngestMixin:
                 ):
                     continue
                 # (H) A macro invocation parsed as a type-less definition
-                # (H) (`FMT_CATCH(...) {}`) must not mint a phantom Function.
-                # (H) A recovery-orphaned zero-param ctor shares the shape, so
-                # (H) the class registry is the tiebreak: a registered class
-                # (H) bearing the name means ctor (keep), no class means macro
-                # (H) (drop). Same-file classes register after this pass, so
-                # (H) the decision is deferred, not made here.
-                if cpp_utils.is_macro_invocation_artifact(func_node):
+                # (H) (`FMT_CATCH(...) {}`) must not mint a phantom Function,
+                # (H) and a recovery-orphaned ctor sharing the shape must
+                # (H) register as a METHOD of its class, not a module Function
+                # (H) that steals the class's qualified name. Same-file classes
+                # (H) register after this pass, so EVERY artifact-shaped node
+                # (H) (named-param or not) is deferred; the flush applies the
+                # (H) class-registry tiebreak and the named-param evidence.
+                if cpp_utils.is_recovery_artifact_shape(func_node):
                     self._deferred_cpp_artifacts.append(
                         _DeferredCppArtifact(
                             func_node, module_qn, lang_config, lang_queries
@@ -759,11 +762,13 @@ class FunctionIngestMixin:
         return True
 
     def resolve_deferred_cpp_artifacts(self) -> int:
-        """Decide held-back macro-invocation-shaped nodes now classes are known.
+        """Decide held-back artifact-shaped nodes now every class is known.
 
-        Registers each deferred node whose name a registered class bears (a
-        recovery-orphaned constructor); drops the rest as macro invocations.
-        Returns the number registered.
+        A registered class bearing the node's name reattaches it as that
+        class's ctor METHOD (a recovery-orphaned constructor); otherwise a
+        named parameter keeps it as a module Function (a real definition whose
+        type recovery destroyed); otherwise it is dropped as a macro
+        invocation. Returns the number registered.
         """
         deferred = self._deferred_cpp_artifacts
         if not deferred:
@@ -781,12 +786,21 @@ class FunctionIngestMixin:
                 cpp_utils.extract_namespace_path(entry.func_node)
             ):
                 candidates.insert(0, f"{namespace_path}{cs.SEPARATOR_DOT}{name}")
-            if not any(
-                self._resolve_cpp_class_qn(candidate, entry.module_qn)[1]
-                for candidate in candidates
-            ):
-                continue
+            class_qn = ""
+            resolved = False
+            for candidate in candidates:
+                class_qn, resolved = self._resolve_cpp_class_qn(
+                    candidate, entry.module_qn
+                )
+                if resolved:
+                    break
             file_path = self.module_qn_to_file_path.get(entry.module_qn)
+            if resolved:
+                if self._reattach_orphan_cpp_ctor(entry, class_qn, file_path):
+                    registered += 1
+                continue
+            if not cpp_utils.has_named_parameter(entry.func_node):
+                continue
             resolution = self._resolve_function_identity(
                 entry.func_node,
                 entry.module_qn,
@@ -807,6 +821,53 @@ class FunctionIngestMixin:
             registered += 1
         deferred.clear()
         return registered
+
+    def _reattach_orphan_cpp_ctor(
+        self,
+        entry: _DeferredCppArtifact,
+        class_qn: str,
+        file_path: Path | None,
+    ) -> bool:
+        # (H) Mirror of the resolved branch of _handle_cpp_out_of_class_method:
+        # (H) the recorded location and span let Pass-3 attribute the ctor
+        # (H) body's calls to the METHOD qn instead of re-deciding (and
+        # (H) diverging into the artifact-skip).
+        method_qn = ingest_method(
+            method_node=entry.func_node,
+            container_qn=class_qn,
+            container_type=cs.NodeLabel.CLASS,
+            ingestor=self.ingestor,
+            function_registry=self.function_registry,
+            simple_name_lookup=self.simple_name_lookup,
+            get_docstring_func=self._get_docstring,
+            language=cs.SupportedLanguage.CPP,
+            lang_queries=entry.lang_queries,
+            file_path=file_path,
+            repo_path=self.repo_path,
+            skip_cpp_artifact_check=True,
+        )
+        if method_qn is None:
+            return False
+        self.cpp_out_of_class_methods[
+            (entry.module_qn, entry.func_node.start_point[0] + 1)
+        ] = (method_qn, class_qn)
+        self.function_locations[
+            function_span_key(entry.module_qn, entry.func_node)
+        ] = FunctionLocation(
+            label=cs.NodeLabel.METHOD.value,
+            qualified_name=method_qn,
+            container_qn=class_qn,
+        )
+        record_cpp_definition_span(
+            self.cpp_definition_spans,
+            cs.SupportedLanguage.CPP,
+            file_path,
+            self.repo_path,
+            entry.func_node,
+            cs.NodeLabel.METHOD.value,
+            method_qn,
+        )
+        return True
 
     def _resolve_go_container_qn(self, module_qn: str, receiver_type: str) -> str:
         # (H) A method binds to its receiver type. Prefer the same-file type, but

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -711,6 +711,7 @@ def ingest_method(
     defer_containment: list[DeferredParentLink] | None = None,
     module_qn: str | None = None,
     external_override_names: frozenset[str] = frozenset(),
+    skip_cpp_artifact_check: bool = False,
 ) -> str | None:
     # (H) Returns the registered method qn (post register_unique_qn, so with any
     # (H) @line dedup suffix) so a caller can wire further edges to the exact node --
@@ -722,7 +723,12 @@ def ingest_method(
         # (H) Inside an intact class body a macro invocation parsed as a
         # (H) type-less member (`FMT_CATCH(...) {}`) can never be a ctor of
         # (H) another class, so the shape check alone is decisive here.
-        if cpp_utils.is_macro_invocation_artifact(method_node):
+        # (H) skip_cpp_artifact_check: the orphan-ctor flush has already run
+        # (H) the class-registry tiebreak (a zero-param orphan ctor SHARES the
+        # (H) artifact shape and must not be re-dropped here).
+        if not skip_cpp_artifact_check and cpp_utils.is_macro_invocation_artifact(
+            method_node
+        ):
             return None
         method_name = cpp_utils.extract_function_name(method_node)
         if not method_name:

--- a/codebase_rag/tests/test_cpp_macro_invocation_phantoms.py
+++ b/codebase_rag/tests/test_cpp_macro_invocation_phantoms.py
@@ -222,11 +222,12 @@ def test_incremental_reparse_keeps_orphan_ctor_from_unchanged_header(
         ).run(force=force)
 
     def ctor_nodes(store: _StatefulIngestor) -> set[str]:
+        # (H) The kept orphan ctor registers as a METHOD reattached under the
+        # (H) rehydrated class (`...pipe.pipe`), no longer a module Function.
         return {
             str(qn)
             for (label, qn) in store.nodes
-            if label == cs.NodeLabel.FUNCTION.value
-            and (str(qn).endswith(".pipe") or ".pipe@" in str(qn))
+            if label == cs.NodeLabel.METHOD.value and str(qn).endswith(".pipe.pipe")
         }
 
     store = _StatefulIngestor()

--- a/codebase_rag/tests/test_cpp_orphan_ctor_reattachment.py
+++ b/codebase_rag/tests/test_cpp_orphan_ctor_reattachment.py
@@ -90,9 +90,9 @@ def test_named_param_orphan_ctor_registers_as_class_method(
     # (H) registration ran before the class pass and stole it, leaving the
     # (H) CLASS node with a `@line` dedup suffix.
     classes = _nodes(mock_ingestor, cs.NodeLabel.CLASS)
-    assert any(
-        qn.endswith(".file") and cs.DUP_QN_MARKER not in qn for qn in classes
-    ), classes
+    assert any(qn.endswith(".file") and cs.DUP_QN_MARKER not in qn for qn in classes), (
+        classes
+    )
     functions = _nodes(mock_ingestor, cs.NodeLabel.FUNCTION)
     assert not any(qn.endswith(".os.file") for qn in functions), functions
 
@@ -142,8 +142,7 @@ def test_construction_call_reaches_reattached_orphan_ctor(
 
     calls = _calls(mock_ingestor)
     assert any(
-        src.endswith(".use_file") and dst.endswith(".file.file")
-        for src, dst in calls
+        src.endswith(".use_file") and dst.endswith(".file.file") for src, dst in calls
     ), calls
 
 

--- a/codebase_rag/tests/test_cpp_orphan_ctor_reattachment.py
+++ b/codebase_rag/tests/test_cpp_orphan_ctor_reattachment.py
@@ -1,0 +1,171 @@
+# (H) Parse recovery that destroys a class specifier orphans the class's
+# (H) out-of-line ctors at module scope as TYPE-LESS plain-identifier
+# (H) definitions. Registering them as module Functions (a) steals the class's
+# (H) qualified name when the ctor precedes the class pass (the CLASS node gets
+# (H) a `@line` dedup suffix, breaking type resolution), and (b) leaves the
+# (H) ctor with no reachable qn: construction sites resolve to the CLASS and
+# (H) emit INSTANTIATES only, so the ctor reports dead (fmt base.basic_appender
+# (H) et al.). The fix: a name-matching registered class reattaches the orphan
+# (H) as a METHOD under the class, and C++ construction sites redirect a CALLS
+# (H) edge to the class's ctor methods exactly as Java/C# construction does.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import run_updater
+
+ORPHANED_CTOR_CC = """
+struct file {
+  int fd_;
+};
+
+file(int fd) { helper(fd); }
+
+void helper(int fd) {}
+
+void use_file() {
+  auto f = file(1);
+}
+"""
+
+ORPHANED_ZERO_PARAM_CTOR_CC = """
+struct pipe {
+  int fd_;
+};
+
+pipe() {}
+"""
+
+IN_CLASS_CTOR_CC = """
+struct widget {
+  int x_;
+  widget(int x) : x_(x) {}
+};
+
+void use_widget() {
+  auto w = widget(1);
+}
+"""
+
+NO_CLASS_NAMED_PARAM_CC = """
+write2digits(char* buf) { buf[0] = '0'; }
+"""
+
+
+def _nodes(mock_ingestor: MagicMock, label: cs.NodeLabel) -> set[str]:
+    return {
+        c.args[1].get("qualified_name")
+        for c in mock_ingestor.ensure_node_batch.call_args_list
+        if str(c.args[0]) == label.value
+    }
+
+
+def _calls(mock_ingestor: MagicMock) -> set[tuple[str, str]]:
+    return {
+        (str(c.args[0][2]), str(c.args[2][2]))
+        for c in mock_ingestor.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) == cs.RelationshipType.CALLS.value
+    }
+
+
+def _defines_method(mock_ingestor: MagicMock) -> set[tuple[str, str]]:
+    return {
+        (str(c.args[0][2]), str(c.args[2][2]))
+        for c in mock_ingestor.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) == cs.RelationshipType.DEFINES_METHOD.value
+    }
+
+
+def test_named_param_orphan_ctor_registers_as_class_method(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "os.cc").write_text(ORPHANED_CTOR_CC)
+    run_updater(temp_repo, mock_ingestor)
+
+    methods = _nodes(mock_ingestor, cs.NodeLabel.METHOD)
+    assert any(qn.endswith(".file.file") for qn in methods), methods
+    # (H) The class must keep its plain qualified name: the old module-Function
+    # (H) registration ran before the class pass and stole it, leaving the
+    # (H) CLASS node with a `@line` dedup suffix.
+    classes = _nodes(mock_ingestor, cs.NodeLabel.CLASS)
+    assert any(
+        qn.endswith(".file") and cs.DUP_QN_MARKER not in qn for qn in classes
+    ), classes
+    functions = _nodes(mock_ingestor, cs.NodeLabel.FUNCTION)
+    assert not any(qn.endswith(".os.file") for qn in functions), functions
+
+
+def test_zero_param_orphan_ctor_registers_as_class_method(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "pipe.cc").write_text(ORPHANED_ZERO_PARAM_CTOR_CC)
+    run_updater(temp_repo, mock_ingestor)
+
+    methods = _nodes(mock_ingestor, cs.NodeLabel.METHOD)
+    assert any(qn.endswith(".pipe.pipe") for qn in methods), methods
+
+
+def test_defines_method_edge_links_class_to_reattached_ctor(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "os.cc").write_text(ORPHANED_CTOR_CC)
+    run_updater(temp_repo, mock_ingestor)
+
+    edges = _defines_method(mock_ingestor)
+    assert any(
+        src.endswith(".file") and dst.endswith(".file.file") for src, dst in edges
+    ), edges
+
+
+def test_construction_call_emits_calls_to_ctor(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "w.cc").write_text(IN_CLASS_CTOR_CC)
+    run_updater(temp_repo, mock_ingestor)
+
+    calls = _calls(mock_ingestor)
+    # (H) `auto w = widget(1)` runs the ctor; INSTANTIATES to the class alone
+    # (H) leaves the ctor unreachable (the fmt buffer.buffer dead-list class).
+    assert any(
+        src.endswith(".use_widget") and dst.endswith(".widget.widget")
+        for src, dst in calls
+    ), calls
+
+
+def test_construction_call_reaches_reattached_orphan_ctor(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "os.cc").write_text(ORPHANED_CTOR_CC)
+    run_updater(temp_repo, mock_ingestor)
+
+    calls = _calls(mock_ingestor)
+    assert any(
+        src.endswith(".use_file") and dst.endswith(".file.file")
+        for src, dst in calls
+    ), calls
+
+
+def test_orphan_ctor_body_calls_attributed_to_method(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "os.cc").write_text(ORPHANED_CTOR_CC)
+    run_updater(temp_repo, mock_ingestor)
+
+    calls = _calls(mock_ingestor)
+    assert any(
+        src.endswith(".file.file") and dst.endswith(".helper") for src, dst in calls
+    ), calls
+
+
+def test_named_param_orphan_without_class_stays_module_function(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "fmt.cc").write_text(NO_CLASS_NAMED_PARAM_CC)
+    run_updater(temp_repo, mock_ingestor)
+
+    functions = _nodes(mock_ingestor, cs.NodeLabel.FUNCTION)
+    # (H) Named parameters prove the definition real even when no class bears
+    # (H) the name (a free function whose return type recovery destroyed).
+    assert any(qn.endswith(".write2digits") for qn in functions), functions

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.370"
+version = "0.0.373"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Problem

Two related false-positive classes in C++ dead-code, both downstream of parse recovery destroying class specifiers (follow-up to #788):

1. **Orphaned ctors registered as module Functions.** A recovery-orphaned constructor (`file(int fd) { ... }` at module scope, its class ancestor destroyed) registered as a module-level `Function`. Because the function pass runs before the class pass, the orphan **stole the class's qualified name**: the `Class` node got a `@line` dedup suffix (fmt's `basic_appender` class registered as `basic_appender@2`), breaking type resolution, and the ctor sat at a qn nothing resolves to, so it reported dead (`base.basic_appender`, `base.buffer@1776/@1788`).

2. **Ctors of instantiated classes reported dead.** A C++ construction call (`auto w = widget(1)`) resolved to the CLASS and emitted `INSTANTIATES` only. Java/C# constructions redirect a `CALLS` edge to the class's constructors; C++ did not, so the ctor of a class constructed everywhere had zero incoming call edges (fmt `value.value`, `format_specs.format_specs`, `monostate.monostate`, nlohmann `input_stream_adapter.input_stream_adapter`).

## Fix

- `cpp/utils.py`: split `is_macro_invocation_artifact` into the shape test (`is_recovery_artifact_shape`) and the named-parameter evidence (`has_named_parameter`); the composed predicate is unchanged.
- `function_ingest.py`: **every** artifact-shaped module-scope node now defers (named-param or not). The flush decides three ways: a registered class bearing the name reattaches the node as that class's ctor `METHOD` via `ingest_method` (with recorded location/span/binding so Pass-3 attributes the ctor body's calls to the method qn); otherwise a named parameter keeps it as a module `Function` (recovery-stripped free function, unchanged behavior); otherwise it drops as a macro invocation. Deferring the named-param shapes is also what stops the class-qn theft: the class pass now always runs first.
- `call_processor.py`: the construction-site constructor redirect (`java_constructor_targets`) now includes C++ — same class-simple-name convention (`Foo.Foo`), same overload-agnostic reachability semantics. Precedent: #783 already used exactly this redirect for C++ braced returns.
- `utils.py ingest_method`: `skip_cpp_artifact_check` flag for the flush path, where the class-registry tiebreak has already decided (a zero-param orphan ctor shares the macro shape and must not be re-dropped).

## Validation

**Node-level QN diff (fmt + nlohmann, main vs branch)** — zero real definitions lost:
- every removed module-Function orphan reappears as a `Method` under its class;
- stolen class qns restored to plain form (`basic_appender`, `generic_context`, gtest's `ThreadLocal`/`Message`/`TestPartResult`);
- fmt's `generic_context` class (unregisterable in #788) now registers, with 3 ctor fragments reattached;
- remainder are `@line` dedup-suffix shifts from the changed registration order.

**Dead-code scoreboard** — fmt **642 -> 630**, nlohmann **262 -> 261**, zero newly-dead entries:
- revived: 9 in-class ctors of constructed classes + `system_message.system_message` with its callee `is_whitespace` (closure revival);
- net-neutral structural movements: `basic_appender`/`generic_context` orphan Functions became properly attached ctor Methods that remain honestly dead (`appender` is a using-alias construction the resolver does not map; `generic_context` is public-API residual).

## Tests

RED -> GREEN: `test_cpp_orphan_ctor_reattachment.py` (7 tests: named-param and zero-param reattachment, class-qn preservation, DEFINES_METHOD edge, construction CALLS for in-class and reattached ctors, ctor-body call attribution, no-class named-param control). The incremental phantom test's label filter updated: the surviving orphan ctor is now a `METHOD` under the rehydrated class.
