### PR TITLE
Add help command improvements to CLI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         args: [--unsafe]
       - id: check-toml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.2
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -41,14 +41,14 @@ repos:
         pass_filenames: false
         always_run: true
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.9.2
+    rev: 1.9.4
     hooks:
       - id: bandit
         args: ["-c", "pyproject.toml", "--severity-level", "high"]
         additional_dependencies: ["bandit[toml]"]
         exclude: ^(codebase_rag/tests/|scripts/|benchmarks/|optimize/)
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.2.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]

--- a/codebase_rag/cli.py
+++ b/codebase_rag/cli.py
@@ -7,6 +7,7 @@ from functools import partial
 from importlib.metadata import version as get_version
 from pathlib import Path
 
+import click
 import typer
 from loguru import logger
 from rich.console import Console
@@ -50,6 +51,7 @@ from .workspaces.cli import cli as workspace_cli
 app = typer.Typer(
     name=cs.PACKAGE_NAME,
     help=ch.APP_DESCRIPTION,
+    epilog=ch.APP_EPILOG,
     no_args_is_help=True,
     add_completion=False,
 )
@@ -102,7 +104,7 @@ def _global_options(
         False,
         "--quiet",
         "-q",
-        help="Suppress non-essential output (progress messages, banners, informational logs).",
+        help=ch.HELP_QUIET,
         is_eager=True,
     ),
 ) -> None:
@@ -309,7 +311,12 @@ def _cleanup_project_embeddings(ingestor: MemgraphIngestor, project_name: str) -
     delete_project_embeddings(project_name, node_ids)
 
 
-@app.command(help=ch.CMD_START)
+@app.command(
+    help=ch.CMD_START,
+    short_help=ch.CMD_START,
+    epilog=ch.EXAMPLES_START,
+    rich_help_panel=ch.PANEL_USE,
+)
 def start(
     repo_path: str | None = typer.Option(
         None, "--repo-path", help=ch.HELP_REPO_PATH_RETRIEVAL
@@ -538,7 +545,12 @@ def start(
         )
 
 
-@app.command(help=ch.CMD_INDEX)
+@app.command(
+    help=ch.CMD_INDEX,
+    short_help=ch.CMD_INDEX,
+    epilog=ch.EXAMPLES_INDEX,
+    rich_help_panel=ch.PANEL_GRAPH,
+)
 def index(
     repo_path: str | None = typer.Option(
         None, "--repo-path", help=ch.HELP_REPO_PATH_INDEX
@@ -611,7 +623,12 @@ def index(
         raise typer.Exit(1) from e
 
 
-@app.command(help=ch.CMD_EXPORT)
+@app.command(
+    help=ch.CMD_EXPORT,
+    short_help=ch.CMD_EXPORT,
+    epilog=ch.EXAMPLES_EXPORT,
+    rich_help_panel=ch.PANEL_GRAPH,
+)
 def export(
     output: str = typer.Option(..., "-o", "--output", help=ch.HELP_OUTPUT_PATH),
     format_json: bool = typer.Option(
@@ -647,7 +664,12 @@ def export(
         raise typer.Exit(1) from e
 
 
-@app.command(help=ch.CMD_OPTIMIZE)
+@app.command(
+    help=ch.CMD_OPTIMIZE,
+    short_help=ch.CMD_OPTIMIZE,
+    epilog=ch.EXAMPLES_OPTIMIZE,
+    rich_help_panel=ch.PANEL_USE,
+)
 def optimize(
     language: str = typer.Argument(
         ...,
@@ -714,7 +736,13 @@ def optimize(
         )
 
 
-@app.command(name=ch.CLICommandName.MCP_SERVER, help=ch.CMD_MCP_SERVER)
+@app.command(
+    name=ch.CLICommandName.MCP_SERVER,
+    help=ch.CMD_MCP_SERVER,
+    short_help=ch.CMD_MCP_SERVER,
+    epilog=ch.EXAMPLES_MCP_SERVER,
+    rich_help_panel=ch.PANEL_USE,
+)
 def mcp_server(
     transport: cs.MCPTransport = typer.Option(
         cs.MCPTransport.STDIO, help=ch.HELP_MCP_TRANSPORT
@@ -746,7 +774,13 @@ def mcp_server(
         )
 
 
-@app.command(name=ch.CLICommandName.GRAPH_LOADER, help=ch.CMD_GRAPH_LOADER)
+@app.command(
+    name=ch.CLICommandName.GRAPH_LOADER,
+    help=ch.CMD_GRAPH_LOADER,
+    short_help=ch.CMD_GRAPH_LOADER,
+    epilog=ch.EXAMPLES_GRAPH_LOADER,
+    rich_help_panel=ch.PANEL_GRAPH,
+)
 def graph_loader_command(
     graph_file: str = typer.Argument(..., help=ch.HELP_GRAPH_FILE),
 ) -> None:
@@ -778,34 +812,102 @@ def graph_loader_command(
         raise typer.Exit(1) from e
 
 
+_DELEGATED_GROUP_CONTEXT = {
+    "allow_extra_args": True,
+    "allow_interspersed_args": False,
+    "ignore_unknown_options": True,
+}
+
+
+def _run_delegated_group(group: click.Group, ctx: typer.Context) -> None:
+    group.main(
+        args=list(ctx.args),
+        prog_name=ctx.command_path,
+        standalone_mode=False,
+    )
+
+
 @app.command(
     name=ch.CLICommandName.LANGUAGE,
     help=ch.CMD_LANGUAGE,
-    context_settings={"allow_extra_args": True, "allow_interspersed_args": False},
+    short_help=ch.CMD_LANGUAGE,
+    add_help_option=False,
+    context_settings=_DELEGATED_GROUP_CONTEXT,
+    rich_help_panel=ch.PANEL_MANAGE,
 )
 def language_command(ctx: typer.Context) -> None:
-    language_cli(ctx.args, standalone_mode=False)
+    _run_delegated_group(language_cli, ctx)
 
 
 @app.command(
     name=ch.CLICommandName.DAEMON,
     help=ch.CMD_DAEMON,
-    context_settings={"allow_extra_args": True, "allow_interspersed_args": False},
+    short_help=ch.CMD_DAEMON,
+    add_help_option=False,
+    context_settings=_DELEGATED_GROUP_CONTEXT,
+    rich_help_panel=ch.PANEL_MANAGE,
 )
 def daemon_command(ctx: typer.Context) -> None:
-    daemon_cli(ctx.args, standalone_mode=False)
+    _run_delegated_group(daemon_cli, ctx)
 
 
 @app.command(
     name=ch.CLICommandName.WORKSPACE,
     help=ch.CMD_WORKSPACE,
-    context_settings={"allow_extra_args": True, "allow_interspersed_args": False},
+    short_help=ch.CMD_WORKSPACE,
+    add_help_option=False,
+    context_settings=_DELEGATED_GROUP_CONTEXT,
+    rich_help_panel=ch.PANEL_MANAGE,
 )
 def workspace_command(ctx: typer.Context) -> None:
-    workspace_cli(ctx.args, standalone_mode=False)
+    _run_delegated_group(workspace_cli, ctx)
 
 
-@app.command(name=ch.CLICommandName.STOP, help=ch.CMD_STOP)
+@app.command(
+    name=ch.CLICommandName.HELP,
+    help=ch.CMD_HELP,
+    short_help=ch.CMD_HELP,
+    epilog=ch.EXAMPLES_HELP,
+    rich_help_panel=ch.PANEL_HELP,
+)
+def help_command(
+    ctx: typer.Context,
+    command: list[str] | None = typer.Argument(None, help=ch.HELP_COMMAND),
+) -> None:
+    root_context = ctx.find_root()
+    requested = command or []
+    if not requested:
+        typer.echo(root_context.get_help())
+        return
+
+    root_command = root_context.command
+    command_name, *command_args = requested
+    if not isinstance(root_command, click.Group):
+        raise typer.Exit(1)
+
+    target = root_command.get_command(root_context, command_name)
+    if target is None:
+        typer.echo(f"cgr: '{command_name}' is not a cgr command.", err=True)
+        typer.echo("See 'cgr help'.", err=True)
+        raise typer.Exit(2)
+
+    try:
+        target.main(
+            args=[*command_args, "--help"],
+            prog_name=f"{root_context.command_path} {command_name}",
+            standalone_mode=False,
+        )
+    except click.ClickException as error:
+        error.show()
+        raise typer.Exit(error.exit_code) from error
+
+
+@app.command(
+    name=ch.CLICommandName.STOP,
+    help=ch.CMD_STOP,
+    short_help=ch.CMD_STOP,
+    rich_help_panel=ch.PANEL_MANAGE,
+)
 def stop_command() -> None:
     mgr = StackManager()
     try:
@@ -816,7 +918,12 @@ def stop_command() -> None:
     _info(style("stack stopped", cs.Color.GREEN))
 
 
-@app.command(name=ch.CLICommandName.STATUS, help=ch.CMD_STATUS)
+@app.command(
+    name=ch.CLICommandName.STATUS,
+    help=ch.CMD_STATUS,
+    short_help=ch.CMD_STATUS,
+    rich_help_panel=ch.PANEL_MANAGE,
+)
 def status_command() -> None:
     status = StackManager().status()
     app_context.console.print(
@@ -834,7 +941,12 @@ def status_command() -> None:
         app_context.console.print(f"  - {project}: last sync {ts}")
 
 
-@app.command(name=ch.CLICommandName.DOCTOR, help=ch.CMD_DOCTOR)
+@app.command(
+    name=ch.CLICommandName.DOCTOR,
+    help=ch.CMD_DOCTOR,
+    short_help=ch.CMD_DOCTOR,
+    rich_help_panel=ch.PANEL_MANAGE,
+)
 def doctor() -> None:
     checker = HealthChecker()
     results = checker.run_all_checks()
@@ -910,7 +1022,12 @@ def _build_stats_table(
     return table
 
 
-@app.command(name=ch.CLICommandName.STATS, help=ch.CMD_STATS)
+@app.command(
+    name=ch.CLICommandName.STATS,
+    help=ch.CMD_STATS,
+    short_help=ch.CMD_STATS,
+    rich_help_panel=ch.PANEL_GRAPH,
+)
 def stats() -> None:
     from .cypher_queries import (
         CYPHER_STATS_NODE_COUNTS,
@@ -1075,7 +1192,13 @@ def _emit_dead_code(
     )
 
 
-@app.command(name=ch.CLICommandName.DEAD_CODE, help=ch.CMD_DEAD_CODE)
+@app.command(
+    name=ch.CLICommandName.DEAD_CODE,
+    help=ch.CMD_DEAD_CODE,
+    short_help=ch.CMD_DEAD_CODE,
+    epilog=ch.EXAMPLES_DEAD_CODE,
+    rich_help_panel=ch.PANEL_GRAPH,
+)
 def dead_code(
     project_name: str | None = typer.Option(
         None, "--project-name", "-n", help=ch.HELP_DEADCODE_PROJECT_NAME
@@ -1154,7 +1277,13 @@ def dead_code(
         raise typer.Exit(1)
 
 
-@app.command(name=ch.CLICommandName.DELETE_PROJECT, help=ch.CMD_DELETE_PROJECT)
+@app.command(
+    name=ch.CLICommandName.DELETE_PROJECT,
+    help=ch.CMD_DELETE_PROJECT,
+    short_help=ch.CMD_DELETE_PROJECT,
+    epilog=ch.EXAMPLES_DELETE_PROJECT,
+    rich_help_panel=ch.PANEL_GRAPH,
+)
 def delete_project(
     name: str = typer.Option(
         ...,

--- a/codebase_rag/cli_help.py
+++ b/codebase_rag/cli_help.py
@@ -17,232 +17,222 @@ class CLICommandName(StrEnum):
     WORKSPACE = "workspace"
     STOP = "stop"
     STATUS = "status"
+    HELP = "help"
 
 
 APP_DESCRIPTION = (
-    "An accurate Retrieval-Augmented Generation (RAG) system that analyzes "
-    "multi-language codebases using Tree-sitter, builds comprehensive knowledge "
-    "graphs, and enables natural language querying of codebase structure and relationships."
+    "Analyze source code with Tree-sitter, store its structure in a shared "
+    "knowledge graph, and query it in natural language."
 )
+APP_EPILOG = "Run 'cgr help COMMAND' for details about a command."
 
-CMD_START = "Start interactive chat session with your codebase"
-CMD_INDEX = "Index codebase to protobuf files for offline use"
-CMD_EXPORT = "Export knowledge graph from Memgraph to JSON file"
-CMD_OPTIMIZE = "AI-guided codebase optimization session"
-CMD_MCP_SERVER = "Start the MCP server for Claude Code integration"
-CMD_GRAPH_LOADER = "Load and display summary of exported graph JSON"
-CMD_LANGUAGE = "Manage language grammars (add, remove, list)"
-CMD_DOCTOR = "Verify that all dependencies and configurations are properly set up"
-CMD_STATS = "Display node and relationship statistics for the indexed graph"
-CMD_DEAD_CODE = (
-    "Report functions/methods that are unreachable from any entry point "
-    "(candidates for review, not a guaranteed delete list)"
+PANEL_USE = "Query and improve code"
+PANEL_GRAPH = "Build and inspect the graph"
+PANEL_MANAGE = "Manage cgr"
+PANEL_HELP = "Help"
+
+CMD_START = "Open the code assistant for a repository or workspace"
+CMD_INDEX = "Write an offline protobuf index for a repository"
+CMD_EXPORT = "Export the shared graph database to JSON"
+CMD_OPTIMIZE = "Run a language-focused code optimization session"
+CMD_MCP_SERVER = "Serve cgr tools over stdio or HTTP"
+CMD_GRAPH_LOADER = "Summarize an exported graph JSON file"
+CMD_LANGUAGE = "Manage language grammars and parser metadata"
+CMD_DOCTOR = "Check dependencies, services, and configuration"
+CMD_STATS = "Show graph node and relationship counts"
+CMD_DEAD_CODE = "Report code that appears unreachable from known entry points"
+CMD_DELETE_PROJECT = "Delete one project without changing other indexed projects"
+CMD_HELP = "Show help for a command"
+
+CMD_LANGUAGE_GROUP = CMD_LANGUAGE
+CMD_LANGUAGE_ADD = "Add and register a Tree-sitter grammar"
+CMD_LANGUAGE_LIST = "List configured languages and their node mappings"
+CMD_LANGUAGE_REMOVE = "Remove a language from cgr configuration"
+CMD_LANGUAGE_CLEANUP = "Remove orphaned grammar entries under .git/modules"
+
+CMD_DAEMON = "Manage the shared Memgraph and Qdrant stack"
+CMD_DAEMON_GROUP = CMD_DAEMON
+CMD_DAEMON_UP = "Start the shared stack and wait until it is healthy"
+CMD_DAEMON_DOWN = "Stop the shared stack and preserve its data volumes"
+CMD_DAEMON_STATUS = "Show stack state and service reachability"
+CMD_DAEMON_LOGS = "Show Docker Compose logs for the shared stack"
+CMD_DAEMON_RESTART = "Restart the shared stack and wait for health checks"
+
+CMD_WORKSPACE = "Manage named groups of repositories"
+CMD_WORKSPACE_GROUP = CMD_WORKSPACE
+CMD_WORKSPACE_LIST = "List saved workspaces"
+CMD_WORKSPACE_CREATE = "Create an empty workspace definition"
+CMD_WORKSPACE_DELETE = "Delete a workspace definition but keep indexed graph data"
+CMD_WORKSPACE_SHOW = "Show the repositories and project names in a workspace"
+CMD_WORKSPACE_ADD_REPO = "Add a repository to a workspace"
+CMD_WORKSPACE_REMOVE_REPO = "Remove a repository from a workspace by path"
+
+CMD_STOP = "Stop the shared stack (alias for cgr daemon down)"
+CMD_STATUS = "Show stack state and the last sync time for each project"
+
+EXAMPLES_START = (
+    "EXAMPLES\n\n"
+    "  cgr start --repo-path ./my-repo\n\n"
+    "  cgr start --workspace backend\n\n"
+    '  cgr start --ask-agent "Where is authentication handled?"'
 )
-CMD_DELETE_PROJECT = "Delete a single project from the shared graph database (keeps other projects intact)"
+EXAMPLES_INDEX = "EXAMPLE\n\n  cgr index --repo-path ./my-repo -o ./index-out"
+EXAMPLES_EXPORT = "EXAMPLE\n\n  cgr export -o graph.json"
+EXAMPLES_OPTIMIZE = "EXAMPLE\n\n  cgr optimize python --repo-path ./my-repo"
+EXAMPLES_MCP_SERVER = (
+    "EXAMPLES\n\n  cgr mcp-server\n\n  cgr mcp-server --transport http --port 8080"
+)
+EXAMPLES_GRAPH_LOADER = "EXAMPLE\n\n  cgr graph-loader graph.json"
+EXAMPLES_LANGUAGE_ADD = "EXAMPLE\n\n  cgr language add-grammar ruby"
+EXAMPLES_LANGUAGE_REMOVE = "EXAMPLE\n\n  cgr language remove-language ruby"
+EXAMPLES_DEAD_CODE = (
+    "EXAMPLE\n\n  cgr dead-code --project-name my-project --format json"
+)
+EXAMPLES_DELETE_PROJECT = "EXAMPLE\n\n  cgr delete-project --name my-project"
+EXAMPLES_HELP = "EXAMPLES\n\n  cgr help start\n\n  cgr help daemon logs"
 
-CMD_LANGUAGE_GROUP = "CLI for managing language grammars"
-CMD_LANGUAGE_ADD = "Add a new language grammar to the project."
-CMD_LANGUAGE_LIST = "List all currently configured languages."
-CMD_LANGUAGE_REMOVE = "Remove a language from the project."
-CMD_LANGUAGE_CLEANUP = "Clean up orphaned git modules that weren't properly removed."
+EPILOG_LANGUAGE = "Run 'cgr help language COMMAND' for command-specific help."
+EPILOG_DAEMON = "Run 'cgr help daemon COMMAND' for command-specific help."
+EPILOG_WORKSPACE = "Run 'cgr help workspace COMMAND' for command-specific help."
 
-CMD_DAEMON = "Manage the shared cgr docker stack (memgraph + qdrant)"
-CMD_DAEMON_GROUP = "Manage the shared cgr docker stack (memgraph + qdrant)"
-CMD_DAEMON_UP = "Start the docker stack and wait until healthy."
-CMD_DAEMON_DOWN = "Stop the docker stack (preserves data volumes)."
-CMD_DAEMON_STATUS = "Show whether memgraph and qdrant are reachable."
-CMD_DAEMON_LOGS = "Tail docker compose logs for the stack."
-CMD_DAEMON_RESTART = "Restart the docker stack."
-
-CMD_WORKSPACE = "Manage cgr workspaces (named bundles of repos)"
-CMD_WORKSPACE_GROUP = "Manage cgr workspaces (named bundles of repos)"
-CMD_WORKSPACE_LIST = "List all workspaces."
-CMD_WORKSPACE_CREATE = "Create a new empty workspace."
-CMD_WORKSPACE_DELETE = "Delete a workspace TOML (does not touch indexed graph data)."
-CMD_WORKSPACE_SHOW = "Show a workspace's repos and project names."
-CMD_WORKSPACE_ADD_REPO = "Add a repo to a workspace."
-CMD_WORKSPACE_REMOVE_REPO = "Remove a repo from a workspace by path."
-
-HELP_WORKSPACE_DESCRIPTION = "Optional human-readable description."
+HELP_WORKSPACE_DESCRIPTION = "Optional short description for the workspace."
 HELP_WORKSPACE_FORCE = "Overwrite an existing workspace with the same name."
 HELP_WORKSPACE_REPO_PROJECT_NAME = (
-    "Project name to associate with this repo (defaults to derive_project_name(repo))."
+    "Project name to use for this repo. Defaults to the derived repo name."
 )
 
 MSG_NO_WORKSPACES = "(no workspaces; create one with 'cgr workspace create <name>')"
 
-CMD_STOP = "Alias for `cgr daemon down`: stop the shared docker stack."
-CMD_STATUS = "Show daemon stack state plus last-sync timestamp per project."
-
-HELP_DAEMON_LOGS_FOLLOW = "Stream logs continuously (Ctrl+C to stop)."
+HELP_DAEMON_LOGS_FOLLOW = "Continue printing new log entries until interrupted."
 HELP_DAEMON_LOGS_SERVICE = (
-    "Limit logs to a specific service (memgraph, qdrant, lab). Default: all."
+    "Show only SERVICE logs (memgraph, qdrant, or lab). By default, show all services."
 )
-HELP_NO_START_STACK = (
-    "Skip auto-starting the docker stack. Useful when memgraph/qdrant run elsewhere."
-)
-HELP_NO_SYNC = (
-    "Skip the automatic incremental graph sync that runs before the agent starts."
-)
+HELP_NO_START_STACK = "Do not start the shared stack automatically."
+HELP_NO_SYNC = "Do not synchronize the graph before starting the assistant."
 HELP_NO_EMBEDDINGS = (
-    "Skip the semantic embedding pass after graph sync; the graph itself still "
-    "builds fully. Env equivalent: CGR_SKIP_EMBEDDINGS=1."
+    "Do not generate semantic embeddings during sync. Graph nodes and relationships "
+    "are still updated. Equivalent env: CGR_SKIP_EMBEDDINGS=1."
 )
 HELP_PROJECTS = (
-    "Comma-separated list of project names to scope agent queries to. "
-    "Overrides --project-name. If omitted, defaults to the current repo's project."
+    "Limit queries to comma-separated project names. Overrides --project-name; "
+    "defaults to the selected repository or workspace."
 )
-HELP_WORKSPACE = (
-    "Open the agent over all projects defined in a cgr workspace TOML "
-    "(stored under ~/.cgr/workspaces/<name>.toml)."
-)
+HELP_WORKSPACE = "Query every project defined in workspace NAME."
 
-HELP_BATCH_SIZE = "Number of buffered nodes/relationships before flushing to Memgraph"
-HELP_MEMGRAPH_HOST = "Memgraph host"
-HELP_MEMGRAPH_PORT = "Memgraph port"
+HELP_BATCH_SIZE = "Flush to Memgraph after this many buffered nodes or relationships."
+HELP_MEMGRAPH_HOST = "Memgraph host."
+HELP_MEMGRAPH_PORT = "Memgraph port."
 HELP_ORCHESTRATOR = (
-    "Specify orchestrator as provider:model "
-    "(e.g., ollama:llama3.2, openai:gpt-4, google:gemini-3.1-pro-preview)"
+    "Model for the planning assistant, in provider:model form "
+    "(for example openai:gpt-4 or ollama:llama3.2)."
 )
-HELP_CYPHER_MODEL = (
-    "Specify cypher model as provider:model "
-    "(e.g., ollama:codellama, google:gemini-3-flash-preview)"
-)
-HELP_NO_CONFIRM = "Disable confirmation prompts for edit operations (YOLO mode)"
+HELP_CYPHER_MODEL = "Model used to generate Cypher, in provider:model form."
+HELP_NO_CONFIRM = "Skip edit confirmation prompts."
 HELP_NO_INSTRUCTIONS = (
-    "Skip loading project instructions from ~/.cgr.md and <repo>/.cgr.md "
-    "(useful when the consolidated memories are bloating the system prompt)"
+    "Do not load ~/.cgr.md or <repo>/.cgr.md into the session prompt."
 )
 
-HELP_REPO_PATH_RETRIEVAL = (
-    "Path to the target repository for code retrieval (defaults to current directory)"
-)
-HELP_REPO_PATH_INDEX = (
-    "Path to the target repository to index (defaults to current directory)."
-)
-HELP_REPO_PATH_OPTIMIZE = (
-    "Path to the repository to optimize (defaults to current directory)"
-)
-HELP_REPO_PATH_WATCH = "Path to the repository to watch."
+HELP_REPO_PATH_RETRIEVAL = "Repository to open. Defaults to the current directory."
+HELP_REPO_PATH_INDEX = "Repository to index. Defaults to the current directory."
+HELP_REPO_PATH_OPTIMIZE = "Repository to optimize. Defaults to the current directory."
+HELP_REPO_PATH_WATCH = "Repository to watch."
 HELP_VERSION = "Show the version and exit."
+HELP_QUIET = "Suppress progress, banners, and informational logs."
 
 HELP_DEBOUNCE = "Debounce delay in seconds. Set to 0 to disable debouncing."
 HELP_MAX_WAIT = (
     "Maximum wait time in seconds before forcing an update during continuous edits."
 )
 
-HELP_UPDATE_GRAPH = "Update the knowledge graph by parsing the repository"
-HELP_CLEAN_DB = "Clean the database before updating (use when adding first repo)"
-HELP_OUTPUT_GRAPH = "Export graph to JSON file after updating (requires --update-graph)"
-HELP_OUTPUT_PATH = "Output file path for the exported graph"
-HELP_OUTPUT_PROTO_DIR = (
-    "Required. Path to the output directory for the protobuf index file(s)."
+HELP_UPDATE_GRAPH = "Parse the repository and sync its graph before continuing."
+HELP_CLEAN_DB = (
+    "Delete every project from the shared graph and clear the selected repository's "
+    "sync cache. With --update-graph, rebuild after deletion."
 )
-HELP_SPLIT_INDEX = "Write index to separate nodes.bin and relationships.bin files."
-HELP_FORMAT_JSON = "Export in JSON format"
-HELP_LANGUAGE_ARG = (
-    "Programming language to optimize for (e.g., python, java, javascript, cpp)"
-)
-HELP_REFERENCE_DOC = "Path to reference document/book for optimization guidance"
-HELP_GRAPH_FILE = "Path to the exported graph JSON file"
+HELP_OUTPUT_GRAPH = "Write the updated graph to PATH as JSON. Requires --update-graph."
+HELP_OUTPUT_PATH = "Write the exported graph to PATH."
+HELP_OUTPUT_PROTO_DIR = "Write protobuf index files under DIRECTORY."
+HELP_SPLIT_INDEX = "Write separate nodes.bin and relationships.bin files."
+HELP_FORMAT_JSON = "Use JSON output. Other export formats are not supported."
+HELP_LANGUAGE_ARG = "Language to optimize, such as python, java, javascript, or cpp."
+HELP_REFERENCE_DOC = "Reference document to use during optimization."
+HELP_GRAPH_FILE = "Exported graph JSON file to load."
 HELP_EXPORTED_GRAPH_FILE = "Path to the exported_graph.json file."
 
 HELP_GRAMMAR_URL = (
-    "URL to the tree-sitter grammar repository. If not provided, "
-    "will use https://github.com/tree-sitter/tree-sitter-<language_name>"
+    "Tree-sitter grammar repository URL. Defaults to "
+    "https://github.com/tree-sitter/tree-sitter-<language_name>."
 )
-HELP_KEEP_SUBMODULE = "Keep the git submodule (default: remove it)"
+HELP_KEEP_SUBMODULE = (
+    "Keep the grammar git submodule when removing the language. By default, remove it."
+)
 
 HELP_PROJECT_NAME = (
-    "Override the project name used as qualified-name prefix for all nodes. "
-    "Defaults to the repo directory name."
+    "Project name to store in the graph. Defaults to the repo directory name."
 )
 HELP_EXCLUDE_PATTERNS = (
-    "Additional directories to exclude from indexing. Can be specified multiple times."
+    "Exclude paths matching PATTERN from indexing. Repeat the option to add patterns."
 )
-HELP_INTERACTIVE_SETUP = (
-    "Show interactive prompt to select which detected directories to keep. "
-    "Without this flag, all directories matching ignore patterns are automatically excluded."
-)
+HELP_INTERACTIVE_SETUP = "Choose which detected directories remain included."
 HELP_CAPTURE = (
-    "Which relationships to capture. Groups (structure, calls, types, imports, io), "
-    "'all'/'none' as a base, or +TYPE / -TYPE overrides. Repeatable. Overrides "
-    "CGR_CAPTURE for this run. Default: core groups on, io opt-in."
+    "Capture GROUP (structure, calls, types, imports, io), all/none, or a +TYPE/-TYPE "
+    "override. Repeatable; later values override CGR_CAPTURE."
 )
 
-HELP_ASK_AGENT = (
-    "Run a single query in non-interactive mode and exit. "
-    "Output is sent to stdout, useful for scripting."
-)
+HELP_ASK_AGENT = "Ask one question, write the answer to stdout, and exit."
 
-HELP_QUERY_OUTPUT_FORMAT = (
-    "Output format for --ask-agent: 'table' (default) prints the plain answer; "
-    '\'json\' wraps it as {"query": ..., "response": ...} for scripting.'
-)
+HELP_QUERY_OUTPUT_FORMAT = "Format --ask-agent output as table or json."
 
-HELP_MCP_TRANSPORT = "Transport mode: 'stdio' (default) or 'http'"
-HELP_MCP_HTTP_HOST = (
-    "Host to bind the HTTP server — only used when --transport http (default: 0.0.0.0)"
-)
-HELP_MCP_HTTP_PORT = (
-    "Port to bind the HTTP server — only used when --transport http (default: 8080)"
-)
+HELP_MCP_TRANSPORT = "Transport to serve: stdio or http."
+HELP_MCP_HTTP_HOST = "HTTP bind host. Used only with --transport http."
+HELP_MCP_HTTP_PORT = "HTTP bind port. Used only with --transport http."
 
 HELP_DEADCODE_PROJECT_NAME = (
-    "Project to scan (matches the Project node name). "
-    "If omitted, the sole indexed project is used."
+    "Project to scan. If omitted, cgr uses the only indexed project."
 )
 HELP_DEADCODE_ENTRY_POINT = (
-    "Treat functions/methods whose qualified name ends with this value as "
-    "reachable roots. Repeatable."
+    "Mark symbols ending with this qualified-name suffix as entry points. Repeatable."
 )
 HELP_DEADCODE_DECORATOR_ROOT = (
-    "Treat functions/methods carrying this decorator as reachable roots. "
-    "Extends the built-in set (route, task, fixture, command, ...). Repeatable."
+    "Mark symbols with this decorator as entry points. Extends the built-in set."
 )
 HELP_DEADCODE_EXCLUDE = (
-    "Glob matched against a symbol's file path to exclude from the report "
-    "(e.g. '*client/core*', '*.gen.*' for generated code). '*' spans '/'. "
-    "Repeatable."
+    "Exclude symbols whose file path matches GLOB. '*' spans directories. Repeatable."
 )
 HELP_DEADCODE_INCLUDE_TESTS = (
-    "Treat test code as reachable roots so production code it exercises is "
-    "not reported. On by default."
+    "Treat test code as reachable so exercised production code is not reported."
 )
 HELP_DEADCODE_CLASSES = (
-    "Also report unreachable classes. A class counts as used when it is "
-    "instantiated or subclassed by a reachable class, so a base whose only "
-    "subclass is itself unreachable is reported as part of the dead cluster. "
-    "Off by default: classes referenced only via type annotations, isinstance, "
-    "or dynamic lookups are not tracked and may be false positives."
+    "Also report unreachable classes. This can include false positives for "
+    "types used only by annotations or dynamic lookups."
 )
-HELP_DEADCODE_FORMAT = "Output format: 'table' (default) or 'json'."
+HELP_DEADCODE_FORMAT = "Report format: table or json."
 HELP_DEADCODE_OUTPUT = "Write the report to this file instead of stdout."
 HELP_DEADCODE_FAIL_ON_FOUND = (
-    "Exit with code 1 when any candidate is found (useful in CI)."
+    "Exit with status 1 when any candidate is found. Useful in CI."
 )
 
-HELP_DELETE_PROJECT_NAME = (
-    "Name of the project to delete (matches the Project node name in the graph)."
-)
+HELP_DELETE_PROJECT_NAME = "Project name to delete from the graph."
 HELP_DELETE_PROJECT_REPO_PATH = (
-    "Optional path to the project's repo. If supplied, its hash cache is removed too."
+    "Optional repo path. If set, the local hash cache is removed too."
 )
+HELP_COMMAND = "Command path to document, such as 'start' or 'daemon logs'."
 
 CLI_COMMANDS: dict[CLICommandName, str] = {
     CLICommandName.START: CMD_START,
-    CLICommandName.INDEX: CMD_INDEX,
-    CLICommandName.EXPORT: CMD_EXPORT,
     CLICommandName.OPTIMIZE: CMD_OPTIMIZE,
     CLICommandName.MCP_SERVER: CMD_MCP_SERVER,
+    CLICommandName.INDEX: CMD_INDEX,
+    CLICommandName.EXPORT: CMD_EXPORT,
     CLICommandName.GRAPH_LOADER: CMD_GRAPH_LOADER,
-    CLICommandName.LANGUAGE: CMD_LANGUAGE,
-    CLICommandName.DOCTOR: CMD_DOCTOR,
     CLICommandName.STATS: CMD_STATS,
     CLICommandName.DEAD_CODE: CMD_DEAD_CODE,
     CLICommandName.DELETE_PROJECT: CMD_DELETE_PROJECT,
+    CLICommandName.LANGUAGE: CMD_LANGUAGE,
     CLICommandName.DAEMON: CMD_DAEMON,
     CLICommandName.WORKSPACE: CMD_WORKSPACE,
     CLICommandName.STOP: CMD_STOP,
     CLICommandName.STATUS: CMD_STATUS,
+    CLICommandName.DOCTOR: CMD_DOCTOR,
+    CLICommandName.HELP: CMD_HELP,
 }

--- a/codebase_rag/stack/cli.py
+++ b/codebase_rag/stack/cli.py
@@ -9,7 +9,12 @@ from .. import cli_help as ch
 from .manager import StackError, StackManager
 
 
-@click.group(help=ch.CMD_DAEMON_GROUP)
+@click.group(
+    help=ch.CMD_DAEMON_GROUP,
+    short_help=ch.CMD_DAEMON_GROUP,
+    epilog=ch.EPILOG_DAEMON,
+    no_args_is_help=True,
+)
 def cli() -> None:
     pass
 
@@ -26,7 +31,7 @@ def _print_status(mgr: StackManager) -> None:
     click.echo(f"compose:  {status.compose_file}")
 
 
-@cli.command("up", help=ch.CMD_DAEMON_UP)
+@cli.command("up", help=ch.CMD_DAEMON_UP, short_help=ch.CMD_DAEMON_UP)
 def up_cmd() -> None:
     mgr = StackManager()
     try:
@@ -38,7 +43,7 @@ def up_cmd() -> None:
         sys.exit(1)
 
 
-@cli.command("down", help=ch.CMD_DAEMON_DOWN)
+@cli.command("down", help=ch.CMD_DAEMON_DOWN, short_help=ch.CMD_DAEMON_DOWN)
 def down_cmd() -> None:
     mgr = StackManager()
     try:
@@ -50,12 +55,12 @@ def down_cmd() -> None:
         sys.exit(1)
 
 
-@cli.command("status", help=ch.CMD_DAEMON_STATUS)
+@cli.command("status", help=ch.CMD_DAEMON_STATUS, short_help=ch.CMD_DAEMON_STATUS)
 def status_cmd() -> None:
     _print_status(StackManager())
 
 
-@cli.command("restart", help=ch.CMD_DAEMON_RESTART)
+@cli.command("restart", help=ch.CMD_DAEMON_RESTART, short_help=ch.CMD_DAEMON_RESTART)
 def restart_cmd() -> None:
     mgr = StackManager()
     try:
@@ -68,7 +73,7 @@ def restart_cmd() -> None:
         sys.exit(1)
 
 
-@cli.command("logs", help=ch.CMD_DAEMON_LOGS)
+@cli.command("logs", help=ch.CMD_DAEMON_LOGS, short_help=ch.CMD_DAEMON_LOGS)
 @click.option("--follow", "-f", is_flag=True, help=ch.HELP_DAEMON_LOGS_FOLLOW)
 @click.option("--service", "-s", default=None, help=ch.HELP_DAEMON_LOGS_SERVICE)
 def logs_cmd(follow: bool, service: str | None) -> None:

--- a/codebase_rag/tests/test_cli_smoke.py
+++ b/codebase_rag/tests/test_cli_smoke.py
@@ -5,10 +5,14 @@ from importlib.metadata import version as get_version
 from pathlib import Path
 
 import pytest
+from typer.testing import CliRunner
 
+from codebase_rag import cli_help as ch
 from codebase_rag import constants as cs
+from codebase_rag.cli import app
 
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+_RUNNER = CliRunner()
 
 
 def test_help_command_works() -> None:
@@ -63,3 +67,67 @@ def test_version_flag() -> None:
             f"{flag} output did not match expected format: {repr(result.stdout)}"
         )
         assert result.stderr == "", f"Unexpected stderr for {flag}: {result.stderr}"
+
+
+def test_help_command_shows_task_grouped_index() -> None:
+    result = _RUNNER.invoke(app, ["help"], prog_name="cgr")
+
+    assert result.exit_code == 0
+    assert "Usage: cgr [OPTIONS] COMMAND" in result.stdout
+    assert ch.PANEL_USE in result.stdout
+    assert ch.PANEL_GRAPH in result.stdout
+    assert ch.PANEL_MANAGE in result.stdout
+
+
+def test_help_command_shows_detailed_command_page() -> None:
+    result = _RUNNER.invoke(app, ["help", "start"], prog_name="cgr")
+    normalized_output = " ".join(result.stdout.split())
+
+    assert result.exit_code == 0
+    assert "Usage: cgr start [OPTIONS]" in normalized_output
+    assert "EXAMPLES" in normalized_output
+    assert "Delete every project from" in normalized_output
+    assert "Requires" in normalized_output
+    assert "--update-graph" in normalized_output
+
+
+@pytest.mark.parametrize(
+    ("args", "usage"),
+    [
+        (["daemon", "logs", "--help"], "Usage: cgr daemon logs [OPTIONS]"),
+        (
+            ["language", "add-grammar", "--help"],
+            "Usage: cgr language add-grammar",
+        ),
+        (
+            ["workspace", "create", "--help"],
+            "Usage: cgr workspace create [OPTIONS] NAME",
+        ),
+        (["help", "daemon", "logs"], "Usage: cgr daemon logs [OPTIONS]"),
+    ],
+)
+def test_nested_help_preserves_full_command_path(args: list[str], usage: str) -> None:
+    result = _RUNNER.invoke(app, args, prog_name="cgr")
+
+    assert result.exit_code == 0
+    assert usage in result.stdout
+
+
+@pytest.mark.parametrize("group", ["daemon", "language", "workspace"])
+def test_group_help_lists_subcommands(group: str) -> None:
+    result = _RUNNER.invoke(app, [group, "--help"], prog_name="cgr")
+
+    assert result.exit_code == 0
+    assert f"Usage: cgr {group} [OPTIONS] COMMAND" in result.stdout
+    assert "Commands:" in result.stdout
+
+
+def test_help_command_rejects_unknown_command() -> None:
+    result = _RUNNER.invoke(app, ["help", "not-a-command"], prog_name="cgr")
+
+    assert result.exit_code == 2
+    assert "not a cgr command" in result.stderr
+
+
+def test_command_summaries_are_single_line() -> None:
+    assert all("\n" not in summary for summary in ch.CLI_COMMANDS.values())

--- a/codebase_rag/tests/test_generate_readme.py
+++ b/codebase_rag/tests/test_generate_readme.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from codebase_rag import cli_help as ch
+from codebase_rag.readme_sections import format_cli_commands_table
 from scripts.generate_readme import TARGET_FILES, replace_sections, update_file
 
 
@@ -46,3 +48,10 @@ class TestDocsTargets:
             assert update_file(page, {"mcp_tools": "fresh"}) is False
         finally:
             page.chmod(0o644)
+
+
+def test_cli_command_table_has_one_markdown_row_per_command() -> None:
+    lines = format_cli_commands_table().splitlines()
+
+    assert len(lines) == len(ch.CLI_COMMANDS) + 2
+    assert all(line.startswith("|") and line.endswith("|") for line in lines)

--- a/codebase_rag/tools/language.py
+++ b/codebase_rag/tools/language.py
@@ -373,12 +373,21 @@ def _show_review_hints() -> None:
     click.echo(f"Hint: {cs.LANG_MSG_LIST_HINT}")
 
 
-@click.group(help=ch.CMD_LANGUAGE_GROUP)
+@click.group(
+    help=ch.CMD_LANGUAGE_GROUP,
+    short_help=ch.CMD_LANGUAGE_GROUP,
+    epilog=ch.EPILOG_LANGUAGE,
+    no_args_is_help=True,
+)
 def cli() -> None:
     pass
 
 
-@cli.command(help=ch.CMD_LANGUAGE_ADD)
+@cli.command(
+    help=ch.CMD_LANGUAGE_ADD,
+    short_help=ch.CMD_LANGUAGE_ADD,
+    epilog=ch.EXAMPLES_LANGUAGE_ADD,
+)
 @click.argument("language_name", required=False)
 @click.option(
     "--grammar-url",
@@ -462,7 +471,7 @@ def add_grammar(
     _update_config_file(language_name, new_language_spec)
 
 
-@cli.command(help=ch.CMD_LANGUAGE_LIST)
+@cli.command(help=ch.CMD_LANGUAGE_LIST, short_help=ch.CMD_LANGUAGE_LIST)
 def list_languages() -> None:
     console = Console()
 
@@ -500,7 +509,11 @@ def list_languages() -> None:
     console.print(table)
 
 
-@cli.command(help=ch.CMD_LANGUAGE_REMOVE)
+@cli.command(
+    help=ch.CMD_LANGUAGE_REMOVE,
+    short_help=ch.CMD_LANGUAGE_REMOVE,
+    epilog=ch.EXAMPLES_LANGUAGE_REMOVE,
+)
 @click.argument("language_name")
 @click.option("--keep-submodule", is_flag=True, help=ch.HELP_KEEP_SUBMODULE)
 def remove_language(language_name: str, keep_submodule: bool = False) -> None:
@@ -571,7 +584,7 @@ def remove_language(language_name: str, keep_submodule: bool = False) -> None:
     click.echo(f"Done: {cs.LANG_MSG_LANG_REMOVED.format(name=language_name)}")
 
 
-@cli.command(help=ch.CMD_LANGUAGE_CLEANUP)
+@cli.command(help=ch.CMD_LANGUAGE_CLEANUP, short_help=ch.CMD_LANGUAGE_CLEANUP)
 def cleanup_orphaned_modules() -> None:
     modules_dir = f".git/modules/{cs.LANG_GRAMMARS_DIR}"
     if not os.path.exists(modules_dir):

--- a/codebase_rag/workspaces/cli.py
+++ b/codebase_rag/workspaces/cli.py
@@ -11,12 +11,17 @@ from . import storage as st
 from .storage import WorkspaceError
 
 
-@click.group(help=ch.CMD_WORKSPACE_GROUP)
+@click.group(
+    help=ch.CMD_WORKSPACE_GROUP,
+    short_help=ch.CMD_WORKSPACE_GROUP,
+    epilog=ch.EPILOG_WORKSPACE,
+    no_args_is_help=True,
+)
 def cli() -> None:
     pass
 
 
-@cli.command("list", help=ch.CMD_WORKSPACE_LIST)
+@cli.command("list", help=ch.CMD_WORKSPACE_LIST, short_help=ch.CMD_WORKSPACE_LIST)
 def list_cmd() -> None:
     names = st.list_workspaces()
     if not names:
@@ -26,7 +31,7 @@ def list_cmd() -> None:
         click.echo(name)
 
 
-@cli.command("create", help=ch.CMD_WORKSPACE_CREATE)
+@cli.command("create", help=ch.CMD_WORKSPACE_CREATE, short_help=ch.CMD_WORKSPACE_CREATE)
 @click.argument("name")
 @click.option("--description", "-d", default="", help=ch.HELP_WORKSPACE_DESCRIPTION)
 @click.option("--force", is_flag=True, help=ch.HELP_WORKSPACE_FORCE)
@@ -40,7 +45,7 @@ def create_cmd(name: str, description: str, force: bool) -> None:
     click.echo(wcs.MSG_WORKSPACE_CREATED.format(name=name, path=path))
 
 
-@cli.command("delete", help=ch.CMD_WORKSPACE_DELETE)
+@cli.command("delete", help=ch.CMD_WORKSPACE_DELETE, short_help=ch.CMD_WORKSPACE_DELETE)
 @click.argument("name")
 def delete_cmd(name: str) -> None:
     try:
@@ -52,7 +57,7 @@ def delete_cmd(name: str) -> None:
     click.echo(wcs.MSG_WORKSPACE_DELETED.format(name=name, path=path))
 
 
-@cli.command("show", help=ch.CMD_WORKSPACE_SHOW)
+@cli.command("show", help=ch.CMD_WORKSPACE_SHOW, short_help=ch.CMD_WORKSPACE_SHOW)
 @click.argument("name")
 def show_cmd(name: str) -> None:
     try:
@@ -69,7 +74,11 @@ def show_cmd(name: str) -> None:
         click.echo(f"  - {repo.path} ({repo.project_name})")
 
 
-@cli.command("add-repo", help=ch.CMD_WORKSPACE_ADD_REPO)
+@cli.command(
+    "add-repo",
+    help=ch.CMD_WORKSPACE_ADD_REPO,
+    short_help=ch.CMD_WORKSPACE_ADD_REPO,
+)
 @click.argument("name")
 @click.argument("repo_path")
 @click.option(
@@ -89,7 +98,11 @@ def add_repo_cmd(name: str, repo_path: str, project_name: str | None) -> None:
     )
 
 
-@cli.command("remove-repo", help=ch.CMD_WORKSPACE_REMOVE_REPO)
+@cli.command(
+    "remove-repo",
+    help=ch.CMD_WORKSPACE_REMOVE_REPO,
+    short_help=ch.CMD_WORKSPACE_REMOVE_REPO,
+)
 @click.argument("name")
 @click.argument("repo_path")
 def remove_repo_cmd(name: str, repo_path: str) -> None:

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -6,6 +6,18 @@ description: "Complete CLI reference for Code-Graph-RAG commands and Makefile ta
 
 The `cgr` command is the main entry point for Code-Graph-RAG.
 
+## Built-in Help
+
+List commands by workflow or show the detailed page for a command:
+
+```bash
+cgr help
+cgr help start
+cgr help daemon logs
+```
+
+`cgr COMMAND --help` displays the same command-specific information.
+
 ## Core Commands
 
 ### `cgr start`
@@ -20,11 +32,11 @@ cgr start --repo-path /path/to/repo [OPTIONS]
 |--------|-------------|
 | `--repo-path` | Path to repository (defaults to current directory) |
 | `--update-graph` | Parse and ingest the repository into the knowledge graph |
-| `--clean` | Clear existing data before ingesting |
+| `--clean` | Delete every project from the shared graph and clear the selected repository's sync cache. With `--update-graph`, rebuild after deletion. |
 | `--batch-size` | Override Memgraph flush batch size |
 | `--orchestrator` | Specify provider:model for main operations (e.g., `google:gemini-2.5-pro`, `ollama:llama3.2`) |
 | `--cypher` | Specify provider:model for graph queries (e.g., `google:gemini-2.5-flash`, `ollama:codellama`) |
-| `-o` | Export graph to JSON file during update |
+| `-o`, `--output` | Write the updated graph to a JSON path. Requires `--update-graph`. |
 
 ### `cgr export`
 
@@ -74,7 +86,7 @@ cgr dead-code [OPTIONS]
 
 ### `cgr mcp-server`
 
-Start the MCP server for Claude Code integration.
+Serve cgr tools to MCP clients over stdio or HTTP.
 
 ```bash
 cgr mcp-server

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.370"
+version = "0.0.373"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Keep it brief: 1-3 bullet points. -->

Implemented Git/man-style help conventions directly in `cgr`:

- Grouped `cgr --help` commands by workflow for faster discovery.
- Added `cgr help`, `cgr help start`, and nested help such as `cgr help daemon logs`.
- Moved examples out of short summaries into detailed command pages.
- Fixed nested usage paths so they show `cgr daemon logs`, not `cgr logs`.
- Clarified destructive behavior for `--clean` and requirements such as `--output` needing `--update-graph`.
- Added regression tests for help routing and command summaries.
- Updated the CLI reference documentation.

## Type of Change

<!-- Check all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [x] Refactoring (no functional changes)
- [x] Documentation
- [ ] CI/CD or tooling
- [ ] Dependencies

## Related Issues

<!-- Link related issues: "Fixes #123", "Closes #456", or "Related to #789" -->
#238

## Test Plan

<!-- How was this tested? Check all that apply. -->

- [x] Unit tests pass (`make test-parallel` or `uv run pytest -n auto -m "not integration"`)
- [x] New tests added
- [x] Integration tests pass (`make test-integration`, requires Docker)
- [x] Manual testing (describe below)

<img width="896" height="643" alt="image" src="https://github.com/user-attachments/assets/0c89b045-c74b-45d1-b25e-26df611f2a46" />
<img width="896" height="874" alt="image" src="https://github.com/user-attachments/assets/15dc5823-ef87-4c28-a9f5-e2f455a66a98" />



## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [ ] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [x] No new comments or docstrings (code should be self-documenting)
