### PR TITLE
feat(csharp): Roslyn external-site facts eliminate untypeable-receiver phantom calls

### DIFF
--- a/codebase_rag/constants/ast_csharp.py
+++ b/codebase_rag/constants/ast_csharp.py
@@ -175,6 +175,10 @@ TS_CSHARP_MEMBER_BINDING_EXPRESSION = "member_binding_expression"
 TS_CSHARP_FIELD_EXPRESSION = "expression"
 TS_CSHARP_THIS = "this"
 TS_CSHARP_ARGUMENT = "argument"
+# (H) implicit_object_creation_expression (`new(...)`) exposes NO field names;
+# (H) its argument_list is an unfielded named child, so argument parsing needs
+# (H) a typed fallback where the `arguments` field lookup returns nothing.
+TS_CSHARP_ARGUMENT_LIST = "argument_list"
 
 # (H) Nested scopes that own their own locals; the variable-type walk stops at
 # (H) these so a lambda/local-function local cannot leak into (or shadow) the

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -649,6 +649,7 @@ class GraphUpdater:
         dp = self.factory.definition_processor
         dp.csharp_base_kinds = {}
         dp.csharp_call_sites.clear()
+        dp.csharp_external_sites.clear()
         self._csharp_partial_decls = []
         self._csharp_query_calls = []
         if settings.CSHARP_FRONTEND == cs.CSharpFrontend.TREESITTER:
@@ -665,6 +666,7 @@ class GraphUpdater:
         facts = run_csharp_frontend(self.repo_path)
         dp.csharp_base_kinds = facts.base_kinds
         dp.csharp_call_sites.update(facts.call_sites)
+        dp.csharp_external_sites.update(facts.external_sites)
         self._csharp_partial_decls = facts.partial_groups
         self._csharp_query_calls = facts.query_calls
         logger.info(ls.CSHARP_FRONTEND_TYPES.format(count=len(facts.base_kinds)))
@@ -673,6 +675,7 @@ class GraphUpdater:
                 calls=len(facts.call_sites),
                 partials=len(facts.partial_groups),
                 queries=len(facts.query_calls),
+                externals=len(facts.external_sites),
             )
         )
 

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -40,7 +40,7 @@ CSHARP_FRONTEND_BUILD_FAILED = (
 CSHARP_FRONTEND_TYPES = "C# Roslyn frontend classified {count} type base list(s)"
 CSHARP_FRONTEND_FACTS = (
     "C# Roslyn frontend facts: {calls} call site(s), {partials} partial group(s), "
-    "{queries} query call(s)"
+    "{queries} query call(s), {externals} external site(s)"
 )
 CSHARP_FRONTEND_PARTIALS_JOINED = (
     "C# Roslyn frontend merged {count} partial-type group(s)"

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -3687,6 +3687,19 @@ class CallProcessor:
         keyword: dict[str, Node] = {}
         args_node = call_node.child_by_field_name(cs.FIELD_ARGUMENTS)
         if args_node is None:
+            # (H) C# target-typed `new(...)` exposes NO fields at all; its
+            # (H) argument_list is an unfielded named child (Serilog hands its
+            # (H) CreateLogger local functions to `return new(...)`, which the
+            # (H) fielded lookup silently dropped).
+            args_node = next(
+                (
+                    child
+                    for child in call_node.named_children
+                    if child.type == cs.TS_CSHARP_ARGUMENT_LIST
+                ),
+                None,
+            )
+        if args_node is None:
             return positional, keyword
         for child in args_node.named_children:
             # (H) C# wraps every argument expression in an `argument` node (which
@@ -3751,6 +3764,24 @@ class CallProcessor:
             # (H) enclosing type has no such member.
             if cs.SEPARATOR_DOT not in arg_text:
                 engine = self._resolver.type_inference.csharp_type_inference
+                # (H) An in-scope LOCAL FUNCTION shadows any same-name member
+                # (H) (C# scoping) and the trie cannot see it at all: reference
+                # (H) the local group first (Serilog's CreateLogger passes its
+                # (H) Dispose/DisposeAsync locals to the Logger ctor).
+                if locals_group := engine.csharp_local_function_group(
+                    arg_text, caller_qn, module_qn
+                ):
+                    for target_qn in locals_group:
+                        ensure_rel(
+                            source_spec,
+                            rel_type,
+                            (
+                                cs.NodeLabel.FUNCTION,
+                                cs.KEY_QUALIFIED_NAME,
+                                target_qn,
+                            ),
+                        )
+                    return
                 if family := engine.csharp_method_group_family(arg_text, caller_qn):
                     for target_qn in family:
                         ensure_rel(

--- a/codebase_rag/parsers/csharp/type_inference.py
+++ b/codebase_rag/parsers/csharp/type_inference.py
@@ -546,6 +546,36 @@ class CSharpTypeInferenceEngine:
             scope = stripped.rsplit(cs.SEPARATOR_DOT, 1)[0]
         return None
 
+    def csharp_local_function_group(
+        self, name: str, caller_qn: str | None, module_qn: str
+    ) -> list[str]:
+        # (H) Every in-scope local function with this name, arity-blind: a
+        # (H) method GROUP argument (`return new(..., Dispose)` handing
+        # (H) Serilog's CreateLogger locals to the Logger ctor) carries no call
+        # (H) arity, so the whole registered group at the nearest declaring
+        # (H) scope is the referenced set. Locals shadow members, matching
+        # (H) _find_in_scope_local_function's scope-chain discipline.
+        if not caller_qn:
+            return []
+        scope = caller_qn
+        while len(scope) > len(module_qn):
+            stripped = scope.split(cs.CHAR_PAREN_OPEN, 1)[0]
+            matches: list[str] = []
+            for probe_scope in dict.fromkeys((scope, stripped)):
+                candidate = f"{probe_scope}{cs.SEPARATOR_DOT}{name}"
+                for variant in self.function_registry.variants(candidate):
+                    entry = self.csharp_local_functions.get(variant)
+                    if entry is not None and self._caller_within_host(
+                        caller_qn, entry[0]
+                    ):
+                        matches.append(variant)
+            if matches:
+                return matches
+            if cs.SEPARATOR_DOT not in stripped:
+                return []
+            scope = stripped.rsplit(cs.SEPARATOR_DOT, 1)[0]
+        return []
+
     def _caller_within_host(self, caller_qn: str, host_key: FunctionSpanKey) -> bool:
         # (H) True when the caller IS the local function's host scope or a local
         # (H) function transitively hosted inside it (a sibling or nested local

--- a/codebase_rag/parsers/csharp/type_inference.py
+++ b/codebase_rag/parsers/csharp/type_inference.py
@@ -560,21 +560,26 @@ class CSharpTypeInferenceEngine:
         scope = caller_qn
         while len(scope) > len(module_qn):
             stripped = scope.split(cs.CHAR_PAREN_OPEN, 1)[0]
-            matches: list[str] = []
-            for probe_scope in dict.fromkeys((scope, stripped)):
-                candidate = f"{probe_scope}{cs.SEPARATOR_DOT}{name}"
-                for variant in self.function_registry.variants(candidate):
-                    entry = self.csharp_local_functions.get(variant)
-                    if entry is not None and self._caller_within_host(
-                        caller_qn, entry[0]
-                    ):
-                        matches.append(variant)
-            if matches:
+            if matches := self._local_function_group_at_scope(
+                name, caller_qn, scope, stripped
+            ):
                 return matches
             if cs.SEPARATOR_DOT not in stripped:
                 return []
             scope = stripped.rsplit(cs.SEPARATOR_DOT, 1)[0]
         return []
+
+    def _local_function_group_at_scope(
+        self, name: str, caller_qn: str, scope: str, stripped: str
+    ) -> list[str]:
+        matches: list[str] = []
+        for probe_scope in dict.fromkeys((scope, stripped)):
+            candidate = f"{probe_scope}{cs.SEPARATOR_DOT}{name}"
+            for variant in self.function_registry.variants(candidate):
+                entry = self.csharp_local_functions.get(variant)
+                if entry is not None and self._caller_within_host(caller_qn, entry[0]):
+                    matches.append(variant)
+        return matches
 
     def _caller_within_host(self, caller_qn: str, host_key: FunctionSpanKey) -> bool:
         # (H) True when the caller IS the local function's host scope or a local

--- a/codebase_rag/parsers/csharp/type_inference.py
+++ b/codebase_rag/parsers/csharp/type_inference.py
@@ -76,6 +76,7 @@ class CSharpTypeInferenceEngine:
         "csharp_partial_groups",
         "csharp_extension_methods",
         "csharp_call_sites",
+        "csharp_external_sites",
         "csharp_local_functions",
         "csharp_generic_methods",
         "csharp_class_generic_arity",
@@ -101,6 +102,7 @@ class CSharpTypeInferenceEngine:
         csharp_extension_methods: dict[str, list[tuple[str, str, str, int]]]
         | None = None,
         csharp_call_sites: dict[CallSiteKey, CSharpCallSite] | None = None,
+        csharp_external_sites: set[CallSiteKey] | None = None,
         csharp_local_functions: dict[str, tuple[FunctionSpanKey, int]] | None = None,
         csharp_generic_methods: set[str] | None = None,
         csharp_class_generic_arity: dict[str, int] | None = None,
@@ -128,6 +130,9 @@ class CSharpTypeInferenceEngine:
         # (H) this engine is constructed), so `or {}` would lose them.
         self.csharp_call_sites = (
             csharp_call_sites if csharp_call_sites is not None else {}
+        )
+        self.csharp_external_sites = (
+            csharp_external_sites if csharp_external_sites is not None else set()
         )
         self.csharp_local_functions = (
             csharp_local_functions if csharp_local_functions is not None else {}
@@ -621,8 +626,25 @@ class CSharpTypeInferenceEngine:
     def _semantic_call_target(
         self, call_node: Node, module_qn: str
     ) -> tuple[str, str] | None:
-        if not self.csharp_call_sites:
+        if not (self.csharp_call_sites or self.csharp_external_sites):
             return None
+        key = self._call_site_key(call_node, module_qn)
+        if key is None:
+            return None
+        fact = self.csharp_call_sites.get(key)
+        if fact is not None:
+            return self._declared_location(
+                fact.target_file, fact.target_line, fact.target_col
+            )
+        if key in self.csharp_external_sites:
+            # (H) Roslyn resolved this site to a METADATA method: the call
+            # (H) provably leaves the repo, so return the external sentinel and
+            # (H) keep the name trie from fabricating a first-party edge (the
+            # (H) untypeable-receiver fp class the pure frontend cannot see).
+            return CSHARP_EXTERNAL_TARGET
+        return None
+
+    def _call_site_key(self, call_node: Node, module_qn: str) -> CallSiteKey | None:
         name_node = self._callee_name_node(call_node)
         if name_node is None:
             return None
@@ -636,17 +658,11 @@ class CSharpTypeInferenceEngine:
         # (H) Keyed on the callee NAME token (nested invocations share an
         # (H) expression start, never a name token), with generic arguments
         # (H) stripped to match Roslyn's symbol name.
-        key: CallSiteKey = (
+        return (
             rel,
             name_node.start_point[0] + 1,
             name_node.start_point[1],
             name.split(cs.CHAR_ANGLE_OPEN, 1)[0],
-        )
-        fact = self.csharp_call_sites.get(key)
-        if fact is None:
-            return None
-        return self._declared_location(
-            fact.target_file, fact.target_line, fact.target_col
         )
 
     def _callee_name_node(self, call_node: Node) -> Node | None:

--- a/codebase_rag/parsers/csharp_frontend/frontend.py
+++ b/codebase_rag/parsers/csharp_frontend/frontend.py
@@ -63,12 +63,16 @@ class CSharpSemanticFacts(NamedTuple):
     call_sites: dict[CallSiteKey, CSharpCallSite]
     partial_groups: list[list[tuple[str, int]]]
     query_calls: list[CSharpQueryCall]
+    # (H) Sites Roslyn resolved to a METADATA method (no first-party
+    # (H) declaration): the compiler proof that the call leaves the repo, so
+    # (H) the name-trie fallback must not fabricate a first-party edge there.
+    external_sites: set[CallSiteKey]
 
 
 def _empty_facts() -> CSharpSemanticFacts:
     # (H) A fresh instance per failure path: the maps are handed to mutable
     # (H) processor state, so a shared constant would alias across runs.
-    return CSharpSemanticFacts({}, {}, [], [])
+    return CSharpSemanticFacts({}, {}, [], [], set())
 
 
 _DOTNET = "dotnet"
@@ -253,6 +257,10 @@ def _parse_payload(stdout: str, stderr: str = "") -> CSharpSemanticFacts:
             )
             for query in payload.get("queries", [])
         ],
+        external_sites={
+            (site["file"], int(site["line"]), int(site["col"]), site["name"])
+            for site in payload.get("externals", [])
+        },
     )
     if not any(facts) and stderr.strip():
         # (H) A well-formed but entirely empty payload means the workspace load

--- a/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
@@ -268,6 +268,20 @@ public static class Frontend
                     return loc;
                 }
             }
+            // A source-generated partial ([LoggerMessage]) implements the
+            // method in a generated tree with no first-party path, but its
+            // DEFINITION part is the declaration cgr ingested (Polly's Log.cs):
+            // probe it before concluding the method lives outside the repo.
+            if (method.PartialDefinitionPart is { } definition)
+            {
+                foreach (var reference in definition.DeclaringSyntaxReferences)
+                {
+                    if (FirstPartyDecl(reference) is { } loc)
+                    {
+                        return loc;
+                    }
+                }
+            }
             return null;
         }
 

--- a/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
@@ -84,10 +84,12 @@ public static class Frontend
         private readonly HashSet<string> _ignoredDirs;
         private readonly List<TypeFact> _types = new();
         private readonly List<CallFact> _calls = new();
+        private readonly List<ExternalFact> _externals = new();
         private readonly List<QueryFact> _queries = new();
         private readonly Dictionary<string, List<DeclLoc>> _partials = new(StringComparer.Ordinal);
         private readonly HashSet<(string, int)> _seenTypes = new();
         private readonly HashSet<(string, int, int, string)> _seenCalls = new();
+        private readonly HashSet<(string, int, int, string)> _seenExternals = new();
         private readonly HashSet<(string, int, int, string, int, string)> _seenQueries = new();
 
         public FactCollector(string rootFull, HashSet<string> ignoredDirs)
@@ -139,7 +141,7 @@ public static class Frontend
             }
         }
 
-        public Payload ToPayload() => new(_types, _calls, _partials.Values.ToList(), _queries);
+        public Payload ToPayload() => new(_types, _calls, _partials.Values.ToList(), _queries, _externals);
 
         private string Rel(string path) =>
             Path.GetRelativePath(_rootFull, path).Replace(Path.DirectorySeparatorChar, '/');
@@ -205,14 +207,25 @@ public static class Frontend
             {
                 return;
             }
-            if (FirstPartyDecl(DeclaredMethod(symbol)) is not { } target)
-            {
-                return;
-            }
             var location = nameToken.GetLocation();
             var pos = location.GetLineSpan().StartLinePosition;
             var col = ByteCol(location, pos);
             var name = nameToken.ValueText;
+            if (FirstPartyDecl(DeclaredMethod(symbol)) is not { } target)
+            {
+                // A successfully resolved symbol with no first-party declaration
+                // lives in metadata: the call provably leaves the repo, and the
+                // Python side must suppress its heuristic fallback there. Only
+                // resolved symbols count; an error site keeps the heuristics.
+                // A site that is first-party under another target framework's
+                // compilation still wins: the Python lookup consults the
+                // positive call facts before the external set.
+                if (_seenExternals.Add((rel, pos.Line + 1, col, name)))
+                {
+                    _externals.Add(new ExternalFact(rel, pos.Line + 1, col, name));
+                }
+                return;
+            }
             if (!_seenCalls.Add((rel, pos.Line + 1, col, name)))
             {
                 return;
@@ -486,9 +499,16 @@ public static class Frontend
         [property: JsonPropertyName("tline")] int TargetLine,
         [property: JsonPropertyName("tcol")] int TargetCol);
 
+    private record ExternalFact(
+        [property: JsonPropertyName("file")] string File,
+        [property: JsonPropertyName("line")] int Line,
+        [property: JsonPropertyName("col")] int Col,
+        [property: JsonPropertyName("name")] string Name);
+
     private record Payload(
         [property: JsonPropertyName("types")] List<TypeFact> Types,
         [property: JsonPropertyName("calls")] List<CallFact> Calls,
         [property: JsonPropertyName("partials")] List<List<DeclLoc>> Partials,
-        [property: JsonPropertyName("queries")] List<QueryFact> Queries);
+        [property: JsonPropertyName("queries")] List<QueryFact> Queries,
+        [property: JsonPropertyName("externals")] List<ExternalFact> Externals);
 }

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -134,6 +134,11 @@ class DefinitionProcessor(
         # (H) consults this before any heuristic; MUTATED IN PLACE across runs
         # (H) because the type-inference engine holds a reference.
         self.csharp_call_sites: dict[CallSiteKey, CSharpCallSite] = {}
+        # (H) Sites Roslyn resolved to METADATA (external) methods: the resolver
+        # (H) returns the external sentinel there instead of letting the
+        # (H) name-trie fabricate a first-party edge. Same in-place mutation
+        # (H) discipline as csharp_call_sites.
+        self.csharp_external_sites: set[CallSiteKey] = set()
         # (H) (rel_file, type_start_line) -> class qn for every ingested C# type,
         # (H) the reverse of the Roslyn fact keys, so partial declaration groups
         # (H) join back to the Pass-2 Class nodes.

--- a/codebase_rag/parsers/factory.py
+++ b/codebase_rag/parsers/factory.py
@@ -128,6 +128,7 @@ class ProcessorFactory:
                 csharp_partial_groups=self.definition_processor.csharp_partial_groups,
                 csharp_extension_methods=self.definition_processor.csharp_extension_methods,
                 csharp_call_sites=self.definition_processor.csharp_call_sites,
+                csharp_external_sites=self.definition_processor.csharp_external_sites,
                 csharp_local_functions=self.definition_processor.csharp_local_functions,
                 csharp_generic_methods=self.definition_processor.csharp_generic_methods,
                 csharp_class_generic_arity=self.definition_processor.csharp_class_generic_arity,

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -43,6 +43,7 @@ class TypeInferenceEngine:
         "csharp_partial_groups",
         "csharp_extension_methods",
         "csharp_call_sites",
+        "csharp_external_sites",
         "csharp_local_functions",
         "csharp_generic_methods",
         "csharp_class_generic_arity",
@@ -76,6 +77,7 @@ class TypeInferenceEngine:
         csharp_extension_methods: dict[str, list[tuple[str, str, str, int]]]
         | None = None,
         csharp_call_sites: dict[CallSiteKey, CSharpCallSite] | None = None,
+        csharp_external_sites: set[CallSiteKey] | None = None,
         csharp_local_functions: dict[str, tuple[FunctionSpanKey, int]] | None = None,
         csharp_generic_methods: set[str] | None = None,
         csharp_class_generic_arity: dict[str, int] | None = None,
@@ -127,6 +129,9 @@ class TypeInferenceEngine:
         # (H) after construction and read by the C# resolver's semantic path.
         self.csharp_call_sites = (
             csharp_call_sites if csharp_call_sites is not None else {}
+        )
+        self.csharp_external_sites = (
+            csharp_external_sites if csharp_external_sites is not None else set()
         )
         # (H) Shared reference (as with class_field_types): C# local-function
         # (H) host/arity index, populated during ingestion and read by the C#
@@ -209,6 +214,7 @@ class TypeInferenceEngine:
                 csharp_partial_groups=self.csharp_partial_groups,
                 csharp_extension_methods=self.csharp_extension_methods,
                 csharp_call_sites=self.csharp_call_sites,
+                csharp_external_sites=self.csharp_external_sites,
                 csharp_local_functions=self.csharp_local_functions,
                 csharp_generic_methods=self.csharp_generic_methods,
                 csharp_class_generic_arity=self.csharp_class_generic_arity,

--- a/codebase_rag/tests/test_csharp_calls.py
+++ b/codebase_rag/tests/test_csharp_calls.py
@@ -750,3 +750,39 @@ public class Fmt {
     pairs = _call_pairs(mock_ingestor)
     assert any(t.endswith("N.Fmt.FormatExact(int, int)") for s, t in pairs), pairs
     assert any(t.endswith("N.Fmt.FormatExact(string, int)") for s, t in pairs), pairs
+
+
+def test_local_function_method_group_argument_referenced(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) A LOCAL FUNCTION passed as a method-group argument to a target-typed
+    # (H) `new(...)` is stored for later delegate dispatch (Serilog's
+    # (H) CreateLogger hands Dispose/DisposeAsync to the Logger ctor): the
+    # (H) passing scope must reference the in-scope local, never an unrelated
+    # (H) same-name member picked from the trie.
+    (csharp_project / "Factory.cs").write_text(
+        """
+namespace N;
+public class Widget {
+    public Widget(System.Action a) { }
+}
+public class Decoy {
+    public void Cleanup() { }
+}
+public class Factory {
+    public Widget Make() {
+        void Cleanup()
+        {
+        }
+
+        return new(Cleanup);
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+
+    refs = _reference_targets(mock_ingestor)
+    assert any(t.endswith("N.Factory.Make.Cleanup") for t in refs), refs
+    assert not any(t.endswith("N.Decoy.Cleanup") for t in refs), refs

--- a/codebase_rag/tests/test_csharp_semantic_facts.py
+++ b/codebase_rag/tests/test_csharp_semantic_facts.py
@@ -92,6 +92,7 @@ def test_parse_payload_reads_semantic_fact_sections() -> None:
                     "tcol": 4,
                 }
             ],
+            "externals": [{"file": "A.cs", "line": 11, "col": 8, "name": "WriteLine"}],
         }
     )
     facts = _parse_payload(payload)
@@ -101,6 +102,7 @@ def test_parse_payload_reads_semantic_fact_sections() -> None:
     )
     assert facts.partial_groups == [[("A.cs", 1), ("C.cs", 2)]]
     assert facts.query_calls == [CSharpQueryCall("A.cs", 9, 4, "B.cs", 7, 4)]
+    assert facts.external_sites == {("A.cs", 11, 8, "WriteLine")}
 
 
 def test_parse_payload_without_new_sections_yields_empty_facts() -> None:
@@ -258,6 +260,60 @@ def test_call_fact_suppresses_same_arity_family_fanout(
     calls = _pairs(ingestor, "CALLS")
     assert _has(calls, "N.C.Go", "N.C.Format(int)"), calls
     assert not _has(calls, "N.C.Go", "N.C.Format(string)"), calls
+
+
+_EXTERNAL_SITE_SRC = """namespace N;
+
+public class Helper
+{
+    public void Dispose() { }
+}
+
+public class App
+{
+    public void Ping() { }
+
+    public void Run(object value)
+    {
+        Ping();
+        if (value is System.IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+    }
+}
+"""
+
+
+def test_external_site_fact_suppresses_name_trie_fallback(
+    temp_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # (H) `disposable.Dispose()` on a pattern variable: the local-type collector
+    # (H) never tracks it, so the name trie fabricates a CALLS edge onto the
+    # (H) unrelated first-party Helper.Dispose. Roslyn KNOWS the site resolves
+    # (H) to metadata; its external-site fact must suppress the fallback (the
+    # (H) measured Polly residual: 55 fps, all of this class).
+    root = temp_repo / "extsiteproj"
+    root.mkdir()
+    (root / "Code.cs").write_text(_EXTERNAL_SITE_SRC, encoding="utf-8")
+    (root / "Sample.csproj").write_text(_CSPROJ, encoding="utf-8")
+
+    call_line, call_col = _loc(_EXTERNAL_SITE_SRC, "Dispose();")
+    facts = CSharpSemanticFacts(
+        base_kinds={},
+        call_sites={},
+        partial_groups=[],
+        query_calls=[],
+        external_sites={("Code.cs", call_line, call_col, "Dispose")},
+    )
+    _hybrid(monkeypatch, facts)
+
+    ingestor = MagicMock()
+    run_updater(root, ingestor, skip_if_missing=SKIP)
+
+    calls = _pairs(ingestor, "CALLS")
+    assert not _has(calls, "N.App.Run(object)", "N.Helper.Dispose"), calls
+    assert _has(calls, "N.App.Run(object)", "N.App.Ping"), calls
 
 
 _PART_A = """namespace N;

--- a/codebase_rag/tests/test_csharp_semantic_facts.py
+++ b/codebase_rag/tests/test_csharp_semantic_facts.py
@@ -479,6 +479,35 @@ public class App
 }
 """
 
+_LOGGING_CSPROJ = """<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+  </ItemGroup>
+</Project>
+"""
+
+_E2E_LOGGER_MESSAGE = """using Microsoft.Extensions.Logging;
+
+namespace N;
+
+public static partial class TestLog
+{
+    [LoggerMessage(EventId = 1, Level = LogLevel.Warning, Message = "hi")]
+    public static partial void Hi(this ILogger logger);
+}
+
+public class LogUser
+{
+    public void Emit(ILogger logger)
+    {
+        logger.Hi();
+    }
+}
+"""
+
 _E2E_LINQ = """using System;
 
 namespace N;
@@ -522,9 +551,10 @@ def test_roslyn_tool_emits_semantic_facts(temp_repo: Path) -> None:
     (root / "dirB").mkdir()
     (root / "E2E.cs").write_text(_E2E_CODE, encoding="utf-8")
     (root / "Linq.cs").write_text(_E2E_LINQ, encoding="utf-8")
+    (root / "Gen.cs").write_text(_E2E_LOGGER_MESSAGE, encoding="utf-8")
     (root / "dirA" / "PartA.cs").write_text(_PART_A, encoding="utf-8")
     (root / "dirB" / "PartB.cs").write_text(_PART_B, encoding="utf-8")
-    (root / "Sample.csproj").write_text(_CSPROJ, encoding="utf-8")
+    (root / "Sample.csproj").write_text(_LOGGING_CSPROJ, encoding="utf-8")
 
     facts = run_csharp_frontend(root)
     if not (
@@ -572,6 +602,17 @@ def test_roslyn_tool_emits_semantic_facts(temp_repo: Path) -> None:
         for k in facts.external_sites
     ), facts.external_sites
     assert not any(k[3] == "WriteLine" for k in facts.call_sites), facts.call_sites
+
+    # (H) A [LoggerMessage] partial's IMPLEMENTATION lives in a generated tree,
+    # (H) but its DEFINITION is first-party (Polly's Log.cs): the call must be
+    # (H) a positive fact targeting the definition, never an external site.
+    hi_line, _ = _loc(_E2E_LOGGER_MESSAGE, "public static partial void Hi(")
+    hi = [f for k, f in facts.call_sites.items() if k[3] == "Hi"]
+    assert any(f.target_file == "Gen.cs" and f.target_line == hi_line for f in hi), (
+        facts.call_sites,
+        facts.external_sites,
+    )
+    assert not any(k[3] == "Hi" for k in facts.external_sites), facts.external_sites
 
 
 def test_hybrid_end_to_end_produces_semantic_edges(

--- a/codebase_rag/tests/test_csharp_semantic_facts.py
+++ b/codebase_rag/tests/test_csharp_semantic_facts.py
@@ -163,6 +163,7 @@ def test_call_fact_resolves_chained_receiver_to_exact_overload(
         },
         partial_groups=[],
         query_calls=[],
+        external_sites=set(),
     )
     _hybrid(monkeypatch, facts)
 
@@ -201,6 +202,7 @@ def test_call_fact_resolves_conditional_access_invocation(
         },
         partial_groups=[],
         query_calls=[],
+        external_sites=set(),
     )
     _hybrid(monkeypatch, facts)
 
@@ -251,6 +253,7 @@ def test_call_fact_suppresses_same_arity_family_fanout(
         },
         partial_groups=[],
         query_calls=[],
+        external_sites=set(),
     )
     _hybrid(monkeypatch, facts)
 
@@ -373,6 +376,7 @@ def test_partial_fact_merges_parts_across_directories(
         call_sites={},
         partial_groups=[[("dirA/Part1.cs", line_a), ("dirB/Part2.cs", line_b)]],
         query_calls=[],
+        external_sites=set(),
     )
     _hybrid(monkeypatch, facts)
 
@@ -438,6 +442,7 @@ def test_query_fact_emits_calls_edge_for_linq_operator(
                 "Q.cs", caller_line, caller_col, "Ops.cs", target_line, target_col
             )
         ],
+        external_sites=set(),
     )
     _hybrid(monkeypatch, facts)
 
@@ -469,6 +474,7 @@ public class App
     {
         Make().Handle("x");
         Make().Twice();
+        System.Console.WriteLine("done");
     }
 }
 """
@@ -557,6 +563,15 @@ def test_roslyn_tool_emits_semantic_facts(temp_repo: Path) -> None:
         and q.target_line == select_line
         for q in facts.query_calls
     ), facts.query_calls
+
+    # (H) `System.Console.WriteLine` resolves to metadata: the tool must report
+    # (H) it as an external site (and never as a positive call fact).
+    writeline_line, _ = _loc(_E2E_CODE, 'System.Console.WriteLine("done");')
+    assert any(
+        k[0] == "E2E.cs" and k[1] == writeline_line and k[3] == "WriteLine"
+        for k in facts.external_sites
+    ), facts.external_sites
+    assert not any(k[3] == "WriteLine" for k in facts.call_sites), facts.call_sites
 
 
 def test_hybrid_end_to_end_produces_semantic_edges(

--- a/codebase_rag/tests/test_csharp_semantic_facts.py
+++ b/codebase_rag/tests/test_csharp_semantic_facts.py
@@ -605,8 +605,11 @@ def test_roslyn_tool_emits_semantic_facts(temp_repo: Path) -> None:
 
     # (H) A [LoggerMessage] partial's IMPLEMENTATION lives in a generated tree,
     # (H) but its DEFINITION is first-party (Polly's Log.cs): the call must be
-    # (H) a positive fact targeting the definition, never an external site.
-    hi_line, _ = _loc(_E2E_LOGGER_MESSAGE, "public static partial void Hi(")
+    # (H) a positive fact targeting the definition, never an external site. The
+    # (H) target anchors at the ATTRIBUTE line: both Roslyn's declaration span
+    # (H) and tree-sitter's method_declaration include the attribute list, so
+    # (H) that line is what the location join matches.
+    hi_line, _ = _loc(_E2E_LOGGER_MESSAGE, "[LoggerMessage(EventId = 1")
     hi = [f for k, f in facts.call_sites.items() if k[3] == "Hi"]
     assert any(f.target_file == "Gen.cs" and f.target_line == hi_line for f in hi), (
         facts.call_sites,

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.374"
+version = "0.0.375"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
# C# hybrid: Roslyn external-site facts kill the untypeable-receiver phantom class

## Context

The C# recall campaign (#789) measured the pure tree-sitter frontend's honest ceiling on Polly: precision 0.9815 with 55 false positives, all one class. A receiver the syntax walk cannot type (pattern variables, `var` from unresolvable chains, reflection locals) falls to the name-trie fallback, which binds the member name to an unrelated first-party method (`disposable.Dispose()` onto a first-party `Dispose`). Three gating experiments each traded roughly 300 true edges for 30 false ones and were reverted: the pure frontend cannot see which of those sites actually leave the repo.

The hybrid frontend can. Measured on Polly before this change, `CSHARP_FRONTEND=hybrid` lifts recall 0.8473 to 0.9575 but leaves all 55 false positives standing, because the Roslyn tool only emitted facts for calls it resolved to in-source declarations. A site the compiler resolves to a metadata method produced no fact at all, so the resolver fell back to the same trie.

## Changes

**1. External-site facts (the headline).** The Roslyn tool now also reports external sites: invocations whose symbol resolved successfully but whose declaring method has no first-party declaration. Only resolved symbols count; error sites keep the heuristics, and a site that is first-party under another target framework's compilation still wins because the resolver consults the positive call facts before the external set.

- `Frontend.cs`: `CollectCall` records `(file, line, col, name)` into a new `externals` payload section when the resolved method lives in metadata.
- `frontend.py`: `CSharpSemanticFacts.external_sites` parses the new section; empty on any fallback path.
- `csharp/type_inference.py`: the semantic path returns the `CSHARP_EXTERNAL_TARGET` sentinel for external sites, so the dispatcher emits nothing and skips the name-trie fallback. Key computation is shared with the positive-fact lookup (`_call_site_key`).
- `graph_updater.py`: external sites reset and update in place alongside the call-site facts (watch-mode discipline), and the frontend log line reports the external count.

**2. LoggerMessage partials stay first-party.** The first measurement run exposed a regression: a `[LoggerMessage]` partial's implementation part lives in a source-generated tree, so `FirstPartyDecl` concluded the method was external and suppressed real edges into Polly's `Log.cs`. The tool now probes the partial definition part before declaring a site external. The dotnet end-to-end test pins both directions: `System.Console.WriteLine` must surface as external, and a LoggerMessage call must be a positive fact anchored at the attribute line (the same line tree-sitter's `method_declaration` starts on, which is what the location join matches).

**3. Local-function method groups survive without the phantoms.** With the phantoms gone, Serilog's dead-code briefly reported `LoggerConfiguration.CreateLogger`'s `Dispose`/`DisposeAsync` local functions, which are passed to `return new(...)` and had NO legitimate incoming edge; the phantom trie edges had been masking two pre-existing bugs:

- `implicit_object_creation_expression` exposes no fields in the tree-sitter grammar, so `_parse_call_arguments`'s `arguments`-field lookup silently dropped every target-typed `new(...)` argument list. A typed fallback now finds the unfielded `argument_list` child.
- Method-group arguments never probed in-scope local functions; `_emit_callback_edge` went straight from the enclosing type's member family to the trie, whose lexicographic pick can land on an unrelated class. The new `csharp_local_function_group` walks the same scope chain as bare-call resolution (locals shadow members, arity-blind because a method group carries no call arity) and references the whole group.

## Validation (every fix RED to GREEN in commit history)

- `test_external_site_fact_suppresses_name_trie_fallback`: pattern-variable receiver phantom, suppressed by a synthetic external fact.
- `test_roslyn_tool_emits_semantic_facts`: extended for both the external-site emission and the LoggerMessage positive fact (real dotnet build, LoggerMessage source generator restored from nuget).
- `test_local_function_method_group_argument_referenced`: local function passed to target-typed `new(...)` referenced, decoy member untouched.

Polly retrieval eval, hybrid frontend (semantic oracle):

| frontend | tp | fp | fn | precision | recall | f1 |
|---|---|---|---|---|---|---|
| pure (main) | 2914 | 55 | 525 | 0.9815 | 0.8473 | 0.9095 |
| hybrid before this PR | 3293 | 55 | 146 | 0.9836 | 0.9575 | 0.9704 |
| hybrid with this PR | 3272 | 0 | 167 | 1.0000 | 0.9514 | 0.9751 |

The 21 suppressed pairs that moved from tp to fn were hand-verified as eval-oracle artifacts, not regressions: sites like `FakeTimeProvider.Advance`, `loggerFactory.CreateLogger`, configuration `.Add`, and Shouldly-lambda `StackTrace.Contains` resolve to nuget metadata under the frontend's real MSBuild references, but the TPA-only eval oracle cannot resolve those receivers and counts them via its name-collision fallback. The frontend is the more accurate side of that disagreement; hybrid recall is correspondingly understated.

Dead-code dogfood (regression guard): Polly hybrid 1 (the verified `private PolicyBuilder()` true positive, unchanged), Serilog hybrid 0, Serilog pure 0. Pure-frontend eval and graphs are untouched: external sites are empty when the frontend is off. Full suite green.
