### PR TITLE
fix(cpp): resolve using-alias and typedef constructions to the aliased class

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1977,7 +1977,7 @@ class CallProcessor:
         )
         alias_map: dict[str, str] | None = None
         factory_aliases: dict[str, str] | None = None
-        cpp_local_aliases: dict[str, tuple[str, int]] | None = None
+        cpp_local_aliases: dict[str, tuple[str, int, int]] | None = None
 
         for call_node in call_nodes:
             node_id = _id(call_node)
@@ -2161,9 +2161,13 @@ class CallProcessor:
                     )
                 lookup_name = call_name
                 local_entry = cpp_local_aliases.get(call_name)
-                # (H) Declaration-ordered lookup: a call BEFORE the body-local
-                # (H) alias's declaration can never mean it.
-                if local_entry is not None and call_node.start_byte >= local_entry[1]:
+                # (H) Declaration-ordered AND lexically-scoped lookup: a call
+                # (H) BEFORE the body-local alias's declaration or AFTER its
+                # (H) enclosing block/lambda closes can never mean it.
+                if (
+                    local_entry is not None
+                    and local_entry[1] <= call_node.start_byte < local_entry[2]
+                ):
                     lookup_name = local_entry[0]
                 if (
                     lookup_name != call_name or call_name in resolver.type_aliases

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -2140,6 +2140,22 @@ class CallProcessor:
                 callee_info = resolve_builtin(call_name)
             if not callee_info and resolve_cpp_op is not None:
                 callee_info = resolve_cpp_op(call_name, module_qn)
+            if (
+                not callee_info
+                and language == cs.SupportedLanguage.CPP
+                and call_name in resolver.type_aliases
+                and (aliased_qn := resolver._resolve_class_name(call_name, module_qn))
+            ):
+                # (H) `using appender = basic_appender<char>; appender(out)`:
+                # (H) the alias is no registered node, so the bare call resolves
+                # (H) to nothing and the constructed class's ctor stays
+                # (H) edge-free. The collected typedef/using map names the
+                # (H) class (_resolve_class_name follows alias chains); binding
+                # (H) the callee to it drops into the class branch below, which
+                # (H) emits INSTANTIATES + ctor CALLS like any construction.
+                # (H) Gated on alias-map membership so genuinely unknown names
+                # (H) keep their unresolved handling.
+                callee_info = (cs.NodeLabel.CLASS, aliased_qn)
             if not callee_info and cs.SEPARATOR_DOT not in call_name:
                 if is_python:
                     # (H) A bare name that resolves to nothing may be a local alias of a

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1977,7 +1977,7 @@ class CallProcessor:
         )
         alias_map: dict[str, str] | None = None
         factory_aliases: dict[str, str] | None = None
-        cpp_local_aliases: dict[str, str] | None = None
+        cpp_local_aliases: dict[str, tuple[str, int]] | None = None
 
         for call_node in call_nodes:
             node_id = _id(call_node)
@@ -2159,7 +2159,12 @@ class CallProcessor:
                     cpp_local_aliases = (
                         CppTypeInferenceEngine().collect_local_type_aliases(caller_node)
                     )
-                lookup_name = cpp_local_aliases.get(call_name, call_name)
+                lookup_name = call_name
+                local_entry = cpp_local_aliases.get(call_name)
+                # (H) Declaration-ordered lookup: a call BEFORE the body-local
+                # (H) alias's declaration can never mean it.
+                if local_entry is not None and call_node.start_byte >= local_entry[1]:
+                    lookup_name = local_entry[0]
                 if (
                     lookup_name != call_name or call_name in resolver.type_aliases
                 ) and (

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1977,7 +1977,7 @@ class CallProcessor:
         )
         alias_map: dict[str, str] | None = None
         factory_aliases: dict[str, str] | None = None
-        cpp_local_aliases: dict[str, tuple[str, int, int]] | None = None
+        cpp_local_aliases: dict[str, list[tuple[str, int, int]]] | None = None
 
         for call_node in call_nodes:
             node_id = _id(call_node)
@@ -2160,15 +2160,21 @@ class CallProcessor:
                         CppTypeInferenceEngine().collect_local_type_aliases(caller_node)
                     )
                 lookup_name = call_name
-                local_entry = cpp_local_aliases.get(call_name)
                 # (H) Declaration-ordered AND lexically-scoped lookup: a call
                 # (H) BEFORE the body-local alias's declaration or AFTER its
-                # (H) enclosing block/lambda closes can never mean it.
-                if (
-                    local_entry is not None
-                    and local_entry[1] <= call_node.start_byte < local_entry[2]
+                # (H) enclosing block/lambda closes can never mean it; among
+                # (H) windows that do contain the call, the latest declaration
+                # (H) wins (C++ shadowing).
+                best_decl_end = -1
+                for underlying, decl_end, scope_end in cpp_local_aliases.get(
+                    call_name, ()
                 ):
-                    lookup_name = local_entry[0]
+                    if (
+                        decl_end <= call_node.start_byte < scope_end
+                        and decl_end > best_decl_end
+                    ):
+                        lookup_name = underlying
+                        best_decl_end = decl_end
                 if (
                     lookup_name != call_name or call_name in resolver.type_aliases
                 ) and (

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -25,6 +25,7 @@ from ..utils.path_utils import cached_relative_path
 from .call_resolver import CallResolver
 from .class_ingest.identity import build_nested_qualified_name_for_class
 from .cpp import utils as cpp_utils
+from .cpp.type_inference import CppTypeInferenceEngine
 from .csharp import type_inference as csharp_ti
 from .flow_access import FlowProcessor
 from .go import utils as go_utils
@@ -1976,6 +1977,7 @@ class CallProcessor:
         )
         alias_map: dict[str, str] | None = None
         factory_aliases: dict[str, str] | None = None
+        cpp_local_aliases: dict[str, str] | None = None
 
         for call_node in call_nodes:
             node_id = _id(call_node)
@@ -2140,22 +2142,30 @@ class CallProcessor:
                 callee_info = resolve_builtin(call_name)
             if not callee_info and resolve_cpp_op is not None:
                 callee_info = resolve_cpp_op(call_name, module_qn)
-            if (
-                not callee_info
-                and language == cs.SupportedLanguage.CPP
-                and call_name in resolver.type_aliases
-                and (aliased_qn := resolver._resolve_class_name(call_name, module_qn))
-            ):
+            if not callee_info and language == cs.SupportedLanguage.CPP:
                 # (H) `using appender = basic_appender<char>; appender(out)`:
                 # (H) the alias is no registered node, so the bare call resolves
                 # (H) to nothing and the constructed class's ctor stays
-                # (H) edge-free. The collected typedef/using map names the
-                # (H) class (_resolve_class_name follows alias chains); binding
-                # (H) the callee to it drops into the class branch below, which
-                # (H) emits INSTANTIATES + ctor CALLS like any construction.
-                # (H) Gated on alias-map membership so genuinely unknown names
-                # (H) keep their unresolved handling.
-                callee_info = (cs.NodeLabel.CLASS, aliased_qn)
+                # (H) edge-free. The cross-file typedef/using map covers
+                # (H) file/namespace-scope aliases; a BODY-local alias is
+                # (H) exactly what that collector skips, so it comes from the
+                # (H) caller-scoped map (_resolve_class_name then follows any
+                # (H) further alias chain). Binding the callee to the class
+                # (H) drops into the class branch below, which emits
+                # (H) INSTANTIATES + ctor CALLS like any construction. Gated on
+                # (H) alias-map membership so genuinely unknown names keep
+                # (H) their unresolved handling.
+                if cpp_local_aliases is None:
+                    cpp_local_aliases = (
+                        CppTypeInferenceEngine().collect_local_type_aliases(caller_node)
+                    )
+                lookup_name = cpp_local_aliases.get(call_name, call_name)
+                if (
+                    lookup_name != call_name or call_name in resolver.type_aliases
+                ) and (
+                    aliased_qn := resolver._resolve_class_name(lookup_name, module_qn)
+                ):
+                    callee_info = (cs.NodeLabel.CLASS, aliased_qn)
             if not callee_info and cs.SEPARATOR_DOT not in call_name:
                 if is_python:
                     # (H) A bare name that resolves to nothing may be a local alias of a

--- a/codebase_rag/parsers/cpp/type_inference.py
+++ b/codebase_rag/parsers/cpp/type_inference.py
@@ -69,6 +69,26 @@ class CppTypeInferenceEngine:
                     # (H) (and extern "C" blocks), so recurse to reach nested ones.
                     self.collect_type_aliases(child, aliases, conflicts)
 
+    def collect_local_type_aliases(self, caller_node: Node) -> dict[str, str]:
+        # (H) Aliases declared INSIDE a caller's body (`void f() { using w =
+        # (H) basic_writer; w(1); }`) are exactly what collect_type_aliases
+        # (H) skips, so construction-site resolution collects them per caller.
+        # (H) Conflicting redefinitions (a nested lambda re-aliasing the name)
+        # (H) drop, mirroring the cross-file map's conflict rule.
+        aliases: dict[str, str] = {}
+        conflicts: set[str] = set()
+        stack = list(caller_node.children)
+        while stack:
+            node = stack.pop()
+            match node.type:
+                case cs.CppNodeType.TYPE_DEFINITION:
+                    self._record_alias(self._typedef_pair(node), aliases, conflicts)
+                case cs.CppNodeType.ALIAS_DECLARATION:
+                    self._record_alias(self._using_pair(node), aliases, conflicts)
+                case _:
+                    stack.extend(node.children)
+        return aliases
+
     def _record_alias(
         self,
         pair: tuple[str, str] | None,

--- a/codebase_rag/parsers/cpp/type_inference.py
+++ b/codebase_rag/parsers/cpp/type_inference.py
@@ -71,18 +71,18 @@ class CppTypeInferenceEngine:
 
     def collect_local_type_aliases(
         self, caller_node: Node
-    ) -> dict[str, tuple[str, int, int]]:
+    ) -> dict[str, list[tuple[str, int, int]]]:
         # (H) Aliases declared INSIDE a caller's body (`void f() { using w =
         # (H) basic_writer; w(1); }`) are exactly what collect_type_aliases
         # (H) skips, so construction-site resolution collects them per caller.
         # (H) Each entry carries the declaration's end byte and the enclosing
         # (H) block's end byte: C++ name lookup is declaration-ordered AND
         # (H) lexically scoped, so a call before the alias or after its
-        # (H) block/lambda closes must not bind to it. Conflicting
-        # (H) redefinitions (a nested lambda re-aliasing the name) drop,
-        # (H) mirroring the cross-file map's conflict rule.
-        aliases: dict[str, tuple[str, int, int]] = {}
-        conflicts: set[str] = set()
+        # (H) block/lambda closes must not bind to it. Same-name entries from
+        # (H) different blocks all survive -- disjoint windows never compete
+        # (H) for one call, and among overlapping windows the binder picks the
+        # (H) latest declaration, which is exactly C++ shadowing.
+        aliases: dict[str, list[tuple[str, int, int]]] = {}
         stack = [(child, caller_node.end_byte) for child in caller_node.children]
         while stack:
             node, scope_end = stack.pop()
@@ -99,13 +99,9 @@ class CppTypeInferenceEngine:
             if pair is None:
                 continue
             alias_name, underlying = pair
-            if alias_name in conflicts:
-                continue
-            if alias_name in aliases and aliases[alias_name][0] != underlying:
-                conflicts.add(alias_name)
-                del aliases[alias_name]
-                continue
-            aliases[alias_name] = (underlying, node.end_byte, scope_end)
+            aliases.setdefault(alias_name, []).append(
+                (underlying, node.end_byte, scope_end)
+            )
         return aliases
 
     def _record_alias(

--- a/codebase_rag/parsers/cpp/type_inference.py
+++ b/codebase_rag/parsers/cpp/type_inference.py
@@ -69,24 +69,39 @@ class CppTypeInferenceEngine:
                     # (H) (and extern "C" blocks), so recurse to reach nested ones.
                     self.collect_type_aliases(child, aliases, conflicts)
 
-    def collect_local_type_aliases(self, caller_node: Node) -> dict[str, str]:
+    def collect_local_type_aliases(
+        self, caller_node: Node
+    ) -> dict[str, tuple[str, int]]:
         # (H) Aliases declared INSIDE a caller's body (`void f() { using w =
         # (H) basic_writer; w(1); }`) are exactly what collect_type_aliases
         # (H) skips, so construction-site resolution collects them per caller.
-        # (H) Conflicting redefinitions (a nested lambda re-aliasing the name)
-        # (H) drop, mirroring the cross-file map's conflict rule.
-        aliases: dict[str, str] = {}
+        # (H) Each entry carries the declaration's end byte: C++ name lookup is
+        # (H) declaration-ordered, so a call BEFORE the alias must not bind to
+        # (H) it. Conflicting redefinitions (a nested lambda re-aliasing the
+        # (H) name) drop, mirroring the cross-file map's conflict rule.
+        aliases: dict[str, tuple[str, int]] = {}
         conflicts: set[str] = set()
         stack = list(caller_node.children)
         while stack:
             node = stack.pop()
             match node.type:
                 case cs.CppNodeType.TYPE_DEFINITION:
-                    self._record_alias(self._typedef_pair(node), aliases, conflicts)
+                    pair = self._typedef_pair(node)
                 case cs.CppNodeType.ALIAS_DECLARATION:
-                    self._record_alias(self._using_pair(node), aliases, conflicts)
+                    pair = self._using_pair(node)
                 case _:
                     stack.extend(node.children)
+                    continue
+            if pair is None:
+                continue
+            alias_name, underlying = pair
+            if alias_name in conflicts:
+                continue
+            if alias_name in aliases and aliases[alias_name][0] != underlying:
+                conflicts.add(alias_name)
+                del aliases[alias_name]
+                continue
+            aliases[alias_name] = (underlying, node.end_byte)
         return aliases
 
     def _record_alias(

--- a/codebase_rag/parsers/cpp/type_inference.py
+++ b/codebase_rag/parsers/cpp/type_inference.py
@@ -92,7 +92,14 @@ class CppTypeInferenceEngine:
                 case cs.CppNodeType.ALIAS_DECLARATION:
                     pair = self._using_pair(node)
                 case _:
-                    if node.type == cs.CppNodeType.COMPOUND_STATEMENT:
+                    # (H) blocks and lambdas narrow visibility to their span;
+                    # (H) so does a local class/struct body, whose member
+                    # (H) aliases never escape it (only member functions,
+                    # (H) which sit inside the same span, can use them).
+                    if (
+                        node.type == cs.CppNodeType.COMPOUND_STATEMENT
+                        or node.type in cs.CPP_COMPOUND_TYPES
+                    ):
                         scope_end = node.end_byte
                     stack.extend((child, scope_end) for child in node.children)
                     continue

--- a/codebase_rag/parsers/cpp/type_inference.py
+++ b/codebase_rag/parsers/cpp/type_inference.py
@@ -71,26 +71,30 @@ class CppTypeInferenceEngine:
 
     def collect_local_type_aliases(
         self, caller_node: Node
-    ) -> dict[str, tuple[str, int]]:
+    ) -> dict[str, tuple[str, int, int]]:
         # (H) Aliases declared INSIDE a caller's body (`void f() { using w =
         # (H) basic_writer; w(1); }`) are exactly what collect_type_aliases
         # (H) skips, so construction-site resolution collects them per caller.
-        # (H) Each entry carries the declaration's end byte: C++ name lookup is
-        # (H) declaration-ordered, so a call BEFORE the alias must not bind to
-        # (H) it. Conflicting redefinitions (a nested lambda re-aliasing the
-        # (H) name) drop, mirroring the cross-file map's conflict rule.
-        aliases: dict[str, tuple[str, int]] = {}
+        # (H) Each entry carries the declaration's end byte and the enclosing
+        # (H) block's end byte: C++ name lookup is declaration-ordered AND
+        # (H) lexically scoped, so a call before the alias or after its
+        # (H) block/lambda closes must not bind to it. Conflicting
+        # (H) redefinitions (a nested lambda re-aliasing the name) drop,
+        # (H) mirroring the cross-file map's conflict rule.
+        aliases: dict[str, tuple[str, int, int]] = {}
         conflicts: set[str] = set()
-        stack = list(caller_node.children)
+        stack = [(child, caller_node.end_byte) for child in caller_node.children]
         while stack:
-            node = stack.pop()
+            node, scope_end = stack.pop()
             match node.type:
                 case cs.CppNodeType.TYPE_DEFINITION:
                     pair = self._typedef_pair(node)
                 case cs.CppNodeType.ALIAS_DECLARATION:
                     pair = self._using_pair(node)
                 case _:
-                    stack.extend(node.children)
+                    if node.type == cs.CppNodeType.COMPOUND_STATEMENT:
+                        scope_end = node.end_byte
+                    stack.extend((child, scope_end) for child in node.children)
                     continue
             if pair is None:
                 continue
@@ -101,7 +105,7 @@ class CppTypeInferenceEngine:
                 conflicts.add(alias_name)
                 del aliases[alias_name]
                 continue
-            aliases[alias_name] = (underlying, node.end_byte)
+            aliases[alias_name] = (underlying, node.end_byte, scope_end)
         return aliases
 
     def _record_alias(

--- a/codebase_rag/tests/test_cpp_alias_construction.py
+++ b/codebase_rag/tests/test_cpp_alias_construction.py
@@ -1,0 +1,122 @@
+# (H) `using appender = basic_appender<char>; appender(out)` constructs the
+# (H) aliased class, but the alias is no registered node, so the call resolved
+# (H) to nothing and the class's ctor kept zero incoming edges (fmt's
+# (H) basic_appender.basic_appender dead-list residual from PR #791). A bare
+# (H) unresolved C++ call name that the collected typedef/using alias map
+# (H) resolves to a registered class is a construction: INSTANTIATES + ctor
+# (H) CALLS, exactly like a direct class-name construction.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import run_updater
+
+USING_ALIAS_CC = """
+struct basic_appender {
+  basic_appender(int b) {}
+};
+using appender = basic_appender;
+
+void use_it() {
+  auto a = appender(1);
+}
+"""
+
+TEMPLATE_ALIAS_CC = """
+template <typename T> struct basic_view {
+  basic_view(T v) {}
+};
+using view = basic_view<int>;
+
+void use_view() {
+  auto v = view(2);
+}
+"""
+
+TYPEDEF_ALIAS_CC = """
+struct mutex_impl {
+  mutex_impl(int m) {}
+};
+typedef mutex_impl mutex_t;
+
+void lock_it() {
+  auto m = mutex_t(3);
+}
+"""
+
+UNRELATED_ALIAS_CC = """
+using count_t = int;
+
+void tally() {
+  auto c = count_t(4);
+}
+"""
+
+
+def _edges(mock_ingestor: MagicMock, rel: cs.RelationshipType) -> set[tuple[str, str]]:
+    return {
+        (str(c.args[0][2]), str(c.args[2][2]))
+        for c in mock_ingestor.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) == rel.value
+    }
+
+
+def test_using_alias_construction_emits_instantiates_and_ctor_call(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "a.cc").write_text(USING_ALIAS_CC)
+    run_updater(temp_repo, mock_ingestor)
+
+    calls = _edges(mock_ingestor, cs.RelationshipType.CALLS)
+    inst = _edges(mock_ingestor, cs.RelationshipType.INSTANTIATES)
+    assert any(
+        src.endswith(".use_it") and dst.endswith(".basic_appender.basic_appender")
+        for src, dst in calls
+    ), calls
+    assert any(
+        src.endswith(".use_it") and dst.endswith(".basic_appender")
+        for src, dst in inst
+    ), inst
+
+
+def test_template_alias_construction_emits_ctor_call(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "v.cc").write_text(TEMPLATE_ALIAS_CC)
+    run_updater(temp_repo, mock_ingestor)
+
+    calls = _edges(mock_ingestor, cs.RelationshipType.CALLS)
+    assert any(
+        src.endswith(".use_view") and dst.endswith(".basic_view.basic_view")
+        for src, dst in calls
+    ), calls
+
+
+def test_typedef_alias_construction_emits_ctor_call(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "m.cc").write_text(TYPEDEF_ALIAS_CC)
+    run_updater(temp_repo, mock_ingestor)
+
+    calls = _edges(mock_ingestor, cs.RelationshipType.CALLS)
+    assert any(
+        src.endswith(".lock_it") and dst.endswith(".mutex_impl.mutex_impl")
+        for src, dst in calls
+    ), calls
+
+
+def test_alias_to_non_class_emits_nothing(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "c.cc").write_text(UNRELATED_ALIAS_CC)
+    run_updater(temp_repo, mock_ingestor)
+
+    calls = _edges(mock_ingestor, cs.RelationshipType.CALLS)
+    inst = _edges(mock_ingestor, cs.RelationshipType.INSTANTIATES)
+    # (H) `count_t(4)` is a primitive functional cast; the alias resolves to no
+    # (H) registered class and must stay edge-free.
+    assert not any("count_t" in dst or "int" in dst for _, dst in calls | inst), (
+        calls | inst
+    )

--- a/codebase_rag/tests/test_cpp_alias_construction.py
+++ b/codebase_rag/tests/test_cpp_alias_construction.py
@@ -76,8 +76,7 @@ def test_using_alias_construction_emits_instantiates_and_ctor_call(
         for src, dst in calls
     ), calls
     assert any(
-        src.endswith(".use_it") and dst.endswith(".basic_appender")
-        for src, dst in inst
+        src.endswith(".use_it") and dst.endswith(".basic_appender") for src, dst in inst
     ), inst
 
 

--- a/codebase_rag/tests/test_cpp_alias_construction.py
+++ b/codebase_rag/tests/test_cpp_alias_construction.py
@@ -292,3 +292,34 @@ def test_same_name_aliases_in_disjoint_scopes_both_bind(
         src.endswith(".shadowed") and dst.endswith(".real_one.real_one")
         for src, dst in calls
     ), calls
+
+
+MEMBER_ALIAS_CC = """
+struct real_gadget {
+  real_gadget(int x) {}
+};
+
+void local_struct() {
+  struct holder {
+    using held_t = real_gadget;
+  };
+  held_t(6);
+}
+"""
+
+
+def test_local_struct_member_alias_does_not_leak_to_function(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "member.cc").write_text(MEMBER_ALIAS_CC)
+    run_updater(temp_repo, mock_ingestor)
+
+    calls = _edges(mock_ingestor, cs.RelationshipType.CALLS)
+    inst = _edges(mock_ingestor, cs.RelationshipType.INSTANTIATES)
+    # (H) a member type alias of a local struct is scoped to the struct body;
+    # (H) an unqualified call in the enclosing function can never mean it
+    # (H) (PR #797 review round 6).
+    assert not any(
+        src.endswith(".local_struct") and "real_gadget" in dst
+        for src, dst in calls | inst
+    ), calls | inst

--- a/codebase_rag/tests/test_cpp_alias_construction.py
+++ b/codebase_rag/tests/test_cpp_alias_construction.py
@@ -232,3 +232,63 @@ def test_alias_out_of_lexical_scope_does_not_bind(
         src.endswith(".inside") and dst.endswith(".real_widget.real_widget")
         for src, dst in calls
     ), calls
+
+
+DISJOINT_ALIAS_CC = """
+struct real_one {
+  real_one(int x) {}
+};
+struct real_two {
+  real_two(int x) {}
+};
+
+void two_blocks() {
+  {
+    using block_t = real_one;
+    auto a = block_t(1);
+  }
+  {
+    using block_t = real_two;
+    auto b = block_t(2);
+  }
+}
+
+void shadowed() {
+  using sh_t = real_one;
+  {
+    using sh_t = real_two;
+    auto s = sh_t(3);
+  }
+  auto o = sh_t(4);
+}
+"""
+
+
+def test_same_name_aliases_in_disjoint_scopes_both_bind(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "disjoint.cc").write_text(DISJOINT_ALIAS_CC)
+    run_updater(temp_repo, mock_ingestor)
+
+    calls = _edges(mock_ingestor, cs.RelationshipType.CALLS)
+    # (H) disjoint blocks each own their alias: neither is a conflict of the
+    # (H) other, and each call binds to its own block's target (PR #797 review
+    # (H) round 5).
+    assert any(
+        src.endswith(".two_blocks") and dst.endswith(".real_one.real_one")
+        for src, dst in calls
+    ), calls
+    assert any(
+        src.endswith(".two_blocks") and dst.endswith(".real_two.real_two")
+        for src, dst in calls
+    ), calls
+    # (H) shadowing: the innermost alias wins inside its block, the outer one
+    # (H) resumes after the block closes
+    assert any(
+        src.endswith(".shadowed") and dst.endswith(".real_two.real_two")
+        for src, dst in calls
+    ), calls
+    assert any(
+        src.endswith(".shadowed") and dst.endswith(".real_one.real_one")
+        for src, dst in calls
+    ), calls

--- a/codebase_rag/tests/test_cpp_alias_construction.py
+++ b/codebase_rag/tests/test_cpp_alias_construction.py
@@ -182,3 +182,53 @@ def test_alias_declared_after_call_site_does_not_bind(
     assert not any(
         src.endswith(".confused") and "real_thing" in dst for src, dst in calls
     ), calls
+
+
+SCOPED_ALIAS_CC = """
+struct real_widget {
+  real_widget(int x) {}
+};
+
+void blocked() {
+  {
+    using widget_t = real_widget;
+  }
+  widget_t(1);
+}
+
+void lambda_leak() {
+  auto fn = [] {
+    using lam_t = real_widget;
+  };
+  lam_t(2);
+}
+
+void inside() {
+  {
+    using in_t = real_widget;
+    auto w = in_t(3);
+  }
+}
+"""
+
+
+def test_alias_out_of_lexical_scope_does_not_bind(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "scoped.cc").write_text(SCOPED_ALIAS_CC)
+    run_updater(temp_repo, mock_ingestor)
+
+    calls = _edges(mock_ingestor, cs.RelationshipType.CALLS)
+    # (H) A block/lambda-local alias dies at its closing brace: a later call in
+    # (H) the enclosing scope can never mean it (PR #797 review round 4).
+    assert not any(
+        src.endswith(".blocked") and "real_widget" in dst for src, dst in calls
+    ), calls
+    assert not any(
+        src.endswith(".lambda_leak") and "real_widget" in dst for src, dst in calls
+    ), calls
+    # (H) inside its own block the alias still binds
+    assert any(
+        src.endswith(".inside") and dst.endswith(".real_widget.real_widget")
+        for src, dst in calls
+    ), calls

--- a/codebase_rag/tests/test_cpp_alias_construction.py
+++ b/codebase_rag/tests/test_cpp_alias_construction.py
@@ -156,3 +156,29 @@ def test_function_local_alias_construction_emits_ctor_call(
         src.endswith(".type_it") and dst.endswith(".basic_writer.basic_writer")
         for src, dst in calls
     ), calls
+
+
+LATE_ALIAS_CC = """
+struct real_thing {
+  real_thing(int x) {}
+};
+
+void confused() {
+  later_alias(1);
+  using later_alias = real_thing;
+}
+"""
+
+
+def test_alias_declared_after_call_site_does_not_bind(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "late.cc").write_text(LATE_ALIAS_CC)
+    run_updater(temp_repo, mock_ingestor)
+
+    calls = _edges(mock_ingestor, cs.RelationshipType.CALLS)
+    # (H) C++ name lookup is declaration-ordered: `later_alias(1)` precedes the
+    # (H) using-declaration and can never mean real_thing (PR #797 review).
+    assert not any(
+        src.endswith(".confused") and "real_thing" in dst for src, dst in calls
+    ), calls

--- a/codebase_rag/tests/test_cpp_alias_construction.py
+++ b/codebase_rag/tests/test_cpp_alias_construction.py
@@ -119,3 +119,40 @@ def test_alias_to_non_class_emits_nothing(
     assert not any("count_t" in dst or "int" in dst for _, dst in calls | inst), (
         calls | inst
     )
+
+
+LOCAL_ALIAS_CC = """
+struct basic_writer {
+  basic_writer(int b) {}
+};
+
+void write_it() {
+  using writer = basic_writer;
+  auto w = writer(1);
+}
+
+void type_it() {
+  typedef basic_writer writer_t;
+  auto w = writer_t(2);
+}
+"""
+
+
+def test_function_local_alias_construction_emits_ctor_call(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "l.cc").write_text(LOCAL_ALIAS_CC)
+    run_updater(temp_repo, mock_ingestor)
+
+    calls = _edges(mock_ingestor, cs.RelationshipType.CALLS)
+    # (H) The cross-file alias collector deliberately skips function bodies, so
+    # (H) a body-local `using writer = basic_writer;` needs the caller-scoped
+    # (H) map (PR #797 review).
+    assert any(
+        src.endswith(".write_it") and dst.endswith(".basic_writer.basic_writer")
+        for src, dst in calls
+    ), calls
+    assert any(
+        src.endswith(".type_it") and dst.endswith(".basic_writer.basic_writer")
+        for src, dst in calls
+    ), calls

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.377"
+version = "0.0.378"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Problem

`using appender = basic_appender<char>; appender(out)` constructs the aliased class, but the alias is not a registered node, so the bare call resolved to nothing and the class's constructor kept zero incoming edges. fmt's `basic_appender.basic_appender` stayed on the dead list after #791 for exactly this reason (every construction site spells the alias). Third follow-up from the #791 residual audit.

## Fix

`call_processor.py`: in the unresolved-bare-name fallback chain, a C++ call name that appears in the collected typedef/using alias map and that `_resolve_class_name` (which follows alias chains and requires registration) binds to a registered class becomes a class callee. It then drops into the existing class branch, which emits `INSTANTIATES` plus the constructor `CALLS` redirect like any direct construction. Gated on alias-map membership, so genuinely unknown names keep their unresolved handling, and an alias to a non-class (`using count_t = int;` functional casts) stays edge-free.

## Validation

- Dead-code scoreboard: fmt **629 -> 628** (`basic_appender.basic_appender` revived — the predicted FP), nlohmann stable at 261. Zero newly-dead entries; revive-only change.
- Full C++ test subset (420) green.

## Tests

RED -> GREEN: `test_cpp_alias_construction.py` — `using` alias, template alias (`using view = basic_view<int>`), `typedef`, and the alias-to-primitive negative control.
