### PR TITLE
fix(cpp): destructor reachability from construction sites

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -2429,8 +2429,14 @@ class CallProcessor:
                     # (H) constructor (overload selection is unneeded for
                     # (H) reachability). C# and C++ constructors use the same
                     # (H) class-simple-name convention, so java_constructor_targets
-                    # (H) selects them too. sorted(): the target label is a
-                    # (H) hash-randomized StrEnum, so sort for deterministic output.
+                    # (H) selects them too. C++ additionally redirects to the
+                    # (H) destructor: the constructed object's `~X` runs at end
+                    # (H) of lifetime with no call node of its own. sorted():
+                    # (H) the target label is a hash-randomized StrEnum, so
+                    # (H) sort for deterministic output.
+                    if language == cs.SupportedLanguage.CPP:
+                        self._emit_cpp_ctor_calls(caller_spec, callee_qn)
+                        continue
                     for ctor_type, ctor_qn in sorted(
                         resolver.java_constructor_targets(callee_qn)
                     ):
@@ -3171,15 +3177,7 @@ class CallProcessor:
                 cs.RelationshipType.INSTANTIATES,
                 (cs.NodeLabel.CLASS, cs.KEY_QUALIFIED_NAME, class_variant),
             )
-        for ctor_type, ctor_qn in sorted(
-            self._resolver.java_constructor_targets(class_qn)
-        ):
-            for variant in registry.variants(ctor_qn):
-                ensure_rel(
-                    caller_spec,
-                    cs.RelationshipType.CALLS,
-                    (ctor_type, cs.KEY_QUALIFIED_NAME, variant),
-                )
+        self._emit_cpp_ctor_calls(caller_spec, class_qn)
 
     def _ingest_cpp_member_init_ctor_calls(
         self,
@@ -3216,17 +3214,20 @@ class CallProcessor:
     def _emit_cpp_ctor_calls(
         self, caller_spec: tuple[str, str, str], class_qn: str
     ) -> None:
-        # (H) sorted(): the target label is a hash-randomized StrEnum, so sort
-        # (H) for deterministic output.
+        # (H) Construction runs a ctor now and the dtor at end of lifetime;
+        # (H) neither has a call node, so both get the redirect. sorted(): the
+        # (H) target label is a hash-randomized StrEnum, so sort for
+        # (H) deterministic output.
         registry = self._resolver.function_registry
-        for ctor_type, ctor_qn in sorted(
-            self._resolver.java_constructor_targets(class_qn)
-        ):
-            for variant in registry.variants(ctor_qn):
+        targets = self._resolver.java_constructor_targets(
+            class_qn
+        ) | self._resolver.cpp_destructor_targets(class_qn)
+        for target_type, target_qn in sorted(targets):
+            for variant in registry.variants(target_qn):
                 self.ingestor.ensure_relationship_batch(
                     caller_spec,
                     cs.RelationshipType.CALLS,
-                    (ctor_type, cs.KEY_QUALIFIED_NAME, variant),
+                    (target_type, cs.KEY_QUALIFIED_NAME, variant),
                 )
 
     @staticmethod

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -507,6 +507,22 @@ class CallResolver:
                 targets.add((node_type, qn))
         return targets
 
+    def cpp_destructor_targets(self, class_qn: str) -> set[tuple[str, str]]:
+        # (H) Constructing a C++ object guarantees `~X` runs at end of
+        # (H) lifetime, but no call node ever names it, so construction sites
+        # (H) redirect a CALLS edge to the class's destructor exactly as they
+        # (H) do to its constructors (same direct-member gate as
+        # (H) java_constructor_targets: a nested class's dtor has an extra qn
+        # (H) segment and is excluded).
+        simple = class_qn.rsplit(cs.SEPARATOR_DOT, 1)[-1]
+        dtor_leaf = f"{cs.CPP_DESTRUCTOR_PREFIX}{simple}"
+        targets: set[tuple[str, str]] = set()
+        for qn, node_type in self.function_registry.find_with_prefix(class_qn):
+            parent, dot, mname = qn.rpartition(cs.SEPARATOR_DOT)
+            if dot and parent == class_qn and mname == dtor_leaf:
+                targets.add((node_type, qn))
+        return targets
+
     def cpp_braced_return_class(self, caller_qn: str, module_qn: str) -> str | None:
         # (H) The class constructed by a `return {...};` inside caller_qn: the
         # (H) caller's recorded return type, resolved to a registered class

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -518,9 +518,7 @@ class CallResolver:
         # (H) A destructor cannot be overloaded, so its qualified name is fully
         # (H) determined by the class: one direct registry lookup replaces a
         # (H) prefix scan over every member (Gemini review, PR #799).
-        dtor_qn = (
-            f"{class_qn}{cs.SEPARATOR_DOT}{cs.CPP_DESTRUCTOR_PREFIX}{simple}"
-        )
+        dtor_qn = f"{class_qn}{cs.SEPARATOR_DOT}{cs.CPP_DESTRUCTOR_PREFIX}{simple}"
         dtor_type = self.function_registry.get(dtor_qn)
         if dtor_type is None:
             return set()

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -515,13 +515,16 @@ class CallResolver:
         # (H) java_constructor_targets: a nested class's dtor has an extra qn
         # (H) segment and is excluded).
         simple = class_qn.rsplit(cs.SEPARATOR_DOT, 1)[-1]
-        dtor_leaf = f"{cs.CPP_DESTRUCTOR_PREFIX}{simple}"
-        targets: set[tuple[str, str]] = set()
-        for qn, node_type in self.function_registry.find_with_prefix(class_qn):
-            parent, dot, mname = qn.rpartition(cs.SEPARATOR_DOT)
-            if dot and parent == class_qn and mname == dtor_leaf:
-                targets.add((node_type, qn))
-        return targets
+        # (H) A destructor cannot be overloaded, so its qualified name is fully
+        # (H) determined by the class: one direct registry lookup replaces a
+        # (H) prefix scan over every member (Gemini review, PR #799).
+        dtor_qn = (
+            f"{class_qn}{cs.SEPARATOR_DOT}{cs.CPP_DESTRUCTOR_PREFIX}{simple}"
+        )
+        dtor_type = self.function_registry.get(dtor_qn)
+        if dtor_type is None:
+            return set()
+        return {(dtor_type, dtor_qn)}
 
     def cpp_braced_return_class(self, caller_qn: str, module_qn: str) -> str | None:
         # (H) The class constructed by a `return {...};` inside caller_qn: the

--- a/codebase_rag/tests/test_cpp_dtor_reachability.py
+++ b/codebase_rag/tests/test_cpp_dtor_reachability.py
@@ -103,9 +103,7 @@ def test_unconstructed_class_dtor_gets_no_edge(
     assert not any("~orphaned" in dst for _, dst in calls), calls
 
 
-def test_braced_return_reaches_dtor(
-    temp_repo: Path, mock_ingestor: MagicMock
-) -> None:
+def test_braced_return_reaches_dtor(temp_repo: Path, mock_ingestor: MagicMock) -> None:
     (temp_repo / "e.cc").write_text(BRACED_RETURN_DTOR_CC)
     run_updater(temp_repo, mock_ingestor)
 

--- a/codebase_rag/tests/test_cpp_dtor_reachability.py
+++ b/codebase_rag/tests/test_cpp_dtor_reachability.py
@@ -1,0 +1,116 @@
+# (H) Constructing a C++ object guarantees its destructor runs at end of
+# (H) lifetime, but no call node ever names `~X`, so a dtor whose class is
+# (H) constructed everywhere still reported dead (fmt's args node.~node).
+# (H) Every construction site that redirects CALLS to the class's ctors now
+# (H) redirects to its destructor too: call-expression constructions,
+# (H) member-initializer base/delegated ctor runs, and braced returns.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import run_updater
+
+CONSTRUCTED_DTOR_CC = """
+struct widget {
+  int x_;
+  widget(int x) : x_(x) {}
+  ~widget() {}
+};
+
+void use_widget() {
+  auto w = widget(1);
+}
+"""
+
+MEMBER_INIT_DTOR_CC = """
+struct buffer {
+  buffer(int g) {}
+  ~buffer() {}
+};
+
+struct container_buffer : buffer {
+  container_buffer(int g) : buffer(g) {}
+};
+"""
+
+UNCONSTRUCTED_DTOR_CC = """
+struct orphaned {
+  orphaned(int x) {}
+  ~orphaned() {}
+};
+
+void unrelated() {}
+"""
+
+BRACED_RETURN_DTOR_CC = """
+struct error_box {
+  error_box(int code) {}
+  ~error_box() {}
+};
+
+error_box make_error(int code) {
+  return {code};
+}
+"""
+
+
+def _calls(mock_ingestor: MagicMock) -> set[tuple[str, str]]:
+    return {
+        (str(c.args[0][2]), str(c.args[2][2]))
+        for c in mock_ingestor.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) == cs.RelationshipType.CALLS.value
+    }
+
+
+def test_construction_call_reaches_dtor(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "w.cc").write_text(CONSTRUCTED_DTOR_CC)
+    run_updater(temp_repo, mock_ingestor)
+
+    calls = _calls(mock_ingestor)
+    assert any(
+        src.endswith(".use_widget") and dst.endswith(".widget.~widget")
+        for src, dst in calls
+    ), calls
+
+
+def test_member_init_base_reaches_base_dtor(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "b.cc").write_text(MEMBER_INIT_DTOR_CC)
+    run_updater(temp_repo, mock_ingestor)
+
+    calls = _calls(mock_ingestor)
+    # (H) A derived object's destruction runs the base dtor; the derived ctor
+    # (H) is the construction site the graph can see.
+    assert any(
+        src.endswith(".container_buffer.container_buffer")
+        and dst.endswith(".buffer.~buffer")
+        for src, dst in calls
+    ), calls
+
+
+def test_unconstructed_class_dtor_gets_no_edge(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "o.cc").write_text(UNCONSTRUCTED_DTOR_CC)
+    run_updater(temp_repo, mock_ingestor)
+
+    calls = _calls(mock_ingestor)
+    assert not any("~orphaned" in dst for _, dst in calls), calls
+
+
+def test_braced_return_reaches_dtor(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "e.cc").write_text(BRACED_RETURN_DTOR_CC)
+    run_updater(temp_repo, mock_ingestor)
+
+    calls = _calls(mock_ingestor)
+    assert any(
+        src.endswith(".make_error") and dst.endswith(".error_box.~error_box")
+        for src, dst in calls
+    ), calls


### PR DESCRIPTION
## Problem

Constructing a C++ object guarantees its destructor runs at end of lifetime, but no call node ever names `~X`, so a destructor whose class is constructed from live code still reported dead (fmt `system_message.~system_message`, nlohmann `input_stream_adapter.~input_stream_adapter`, `json.data.~data`). Fourth follow-up from the #791 residual audit.

## Fix

- `call_resolver.py`: `cpp_destructor_targets(class_qn)` — direct members whose leaf is `~<class simple name>`, same direct-member gate as `java_constructor_targets` (a nested class's dtor has an extra qn segment and is excluded).
- `call_processor.py`: `_emit_cpp_ctor_calls` now redirects to constructors AND the destructor, and all three C++ construction-emission sites route through it: the call-expression class branch (previously an inline Java/C#/C++ loop; Java/C# keep their existing behavior), the braced-return path, and member-initializer base/delegated ctor runs.

## Validation

- Dead-code scoreboard against post-#797 main: fmt **627 -> 626**, nlohmann **261 -> 259** — exactly the three predicted `~X` false positives revived (`system_message.~system_message`, `input_stream_adapter.~input_stream_adapter`, `json.data.~data`), zero newly-dead entries (revive-only change).
- cpp/java/csharp subset (1190) green; full suite previously green on the stacked branch (two documented memgraph-integration environmental flakes only).

## Tests

RED -> GREEN: `test_cpp_dtor_reachability.py` — call-expression construction, member-init base (derived construction reaches the base dtor), braced return, and the unconstructed-class negative control.
