### PR TITLE
fix(cpp): recover class and namespace heads swallowed by bare scope-marker macros

### DIFF
--- a/codebase_rag/parsers/cpp/preproc_recovery.py
+++ b/codebase_rag/parsers/cpp/preproc_recovery.py
@@ -24,6 +24,20 @@ _DIRECTIVE = re.compile(cs.CPP_PREPROC_CONDITIONAL_PATTERN)
 # (H) invocation without a trailing semicolon (NLOHMANN_JSON_NAMESPACE_BEGIN,
 # (H) FMT_BEGIN_NAMESPACE)
 _MACRO_MARKER = re.compile(rb"^[A-Z_][A-Z0-9_]{2,}$")
+# (H) node types whose content is payload, not code: a marker-shaped line
+# (H) inside one must never be blanked
+_PAYLOAD_NODE_TYPES = frozenset(
+    (
+        "comment",
+        "string_literal",
+        "raw_string_literal",
+        "raw_string_content",
+        "string_content",
+        "char_literal",
+        "concatenated_string",
+        "system_lib_string",
+    )
+)
 _CHAR_OPEN_BRACE = b"{"
 _CHAR_CLOSE_BRACE = b"}"
 _CHAR_SPACE = b" "
@@ -122,13 +136,31 @@ def _retry_without_macro_markers(
     # (H) class/namespace and every member are lost or leak to module scope.
     # (H) Blanking just the marker lines (space-filled, offsets preserved) and
     # (H) re-parsing recovers the real structure; the strict error-count
-    # (H) improvement guard keeps benign marker uses untouched.
+    # (H) improvement guard keeps benign marker uses untouched. A `//` comment
+    # (H) after the marker is prose, not part of the invocation. All gated
+    # (H) markers blank TOGETHER: per-marker subsets cannot work here, because
+    # (H) a marker glued into an otherwise well-formed neighbor (an attribute
+    # (H) macro between `template<...>` and the declarator) damages the tree
+    # (H) SILENTLY -- no error node -- so no per-subset metric can see which
+    # (H) single marker repairs it. Collateral is prevented structurally
+    # (H) instead: a marker-shaped line whose covering node is string or
+    # (H) comment payload is never a candidate.
     if not tree.root_node.has_error:
         return tree, source_bytes
     lines = source_bytes.split(_CHAR_NEWLINE)
-    markers = [
-        (i, i) for i, line in enumerate(lines) if _MACRO_MARKER.match(line.strip())
-    ]
+    markers: list[tuple[int, int]] = []
+    offset = 0
+    for i, line in enumerate(lines):
+        code = line.split(_LINE_COMMENT, 1)[0]
+        stripped = code.strip()
+        if _MACRO_MARKER.match(stripped):
+            start = offset + code.index(stripped)
+            covering = tree.root_node.named_descendant_for_byte_range(
+                start, start + len(stripped)
+            )
+            if covering is None or covering.type not in _PAYLOAD_NODE_TYPES:
+                markers.append((i, i))
+        offset += len(line) + 1
     if not markers:
         return tree, source_bytes
     blanked = _blank(lines, markers)

--- a/codebase_rag/parsers/cpp/preproc_recovery.py
+++ b/codebase_rag/parsers/cpp/preproc_recovery.py
@@ -20,6 +20,10 @@ from tree_sitter import Node, Parser, Tree
 from ... import constants as cs
 
 _DIRECTIVE = re.compile(cs.CPP_PREPROC_CONDITIONAL_PATTERN)
+# (H) a line holding nothing but an ALL_CAPS identifier: a scope-marker macro
+# (H) invocation without a trailing semicolon (NLOHMANN_JSON_NAMESPACE_BEGIN,
+# (H) FMT_BEGIN_NAMESPACE)
+_MACRO_MARKER = re.compile(rb"^[A-Z_][A-Z0-9_]{2,}$")
 _CHAR_OPEN_BRACE = b"{"
 _CHAR_CLOSE_BRACE = b"}"
 _CHAR_SPACE = b" "
@@ -105,6 +109,35 @@ def _count_error_nodes(root: Node) -> int:
     return count
 
 
+def _retry_without_macro_markers(
+    parser: Parser, tree: Tree, source_bytes: bytes
+) -> tuple[Tree, bytes]:
+    # (H) A bare scope-marker macro line (`NLOHMANN_JSON_NAMESPACE_BEGIN`, no
+    # (H) semicolon) glues onto the NEXT top-level construct: tree-sitter
+    # (H) parses macro + `template <...> struct ordered_map : base` as ONE
+    # (H) declaration whose struct head sinks into an init_declarator, and
+    # (H) macro + `namespace detail {` as a function_definition named
+    # (H) `namespace`. The damage is silent-ish -- a couple of SMALL error
+    # (H) nodes -- so the catastrophic whole-file pass never fires, yet the
+    # (H) class/namespace and every member are lost or leak to module scope.
+    # (H) Blanking just the marker lines (space-filled, offsets preserved) and
+    # (H) re-parsing recovers the real structure; the strict error-count
+    # (H) improvement guard keeps benign marker uses untouched.
+    if not tree.root_node.has_error:
+        return tree, source_bytes
+    lines = source_bytes.split(_CHAR_NEWLINE)
+    markers = [
+        (i, i) for i, line in enumerate(lines) if _MACRO_MARKER.match(line.strip())
+    ]
+    if not markers:
+        return tree, source_bytes
+    blanked = _blank(lines, markers)
+    retry = parser.parse(blanked)
+    if _count_error_nodes(retry.root_node) < _count_error_nodes(tree.root_node):
+        return retry, blanked
+    return tree, source_bytes
+
+
 def _track_csharp_directive(stripped: bytes, skip_stack: list[bool]) -> bool:
     # (H) Mutates skip_stack for the directive on this line; True means the
     # (H) line IS a directive (always blanked). `#elif`/`#else` flip the
@@ -166,6 +199,7 @@ def parse_with_preproc_recovery(
         return tree
     if language not in (cs.SupportedLanguage.CPP, cs.SupportedLanguage.C):
         return tree
+    tree, source_bytes = _retry_without_macro_markers(parser, tree, source_bytes)
     worst = _max_error_span(tree.root_node)
     total_lines = source_bytes.count(_CHAR_NEWLINE) + 1
     # (H) local errors recover fine through query matching; only a collapse

--- a/codebase_rag/tests/test_cpp_macro_swallowed_class.py
+++ b/codebase_rag/tests/test_cpp_macro_swallowed_class.py
@@ -120,6 +120,45 @@ SOME_NAMESPACE_END
     assert "mshealthy.scope.detail.helper" in functions, sorted(functions)
 
 
+def test_independent_marker_damage_sites_all_recover(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) two independent glue sites: the scope marker swallows the struct
+    # (H) head, and a bare attribute macro swallows the member after it
+    # (H) (nlohmann json_sax's JSON_HEDLEY_RETURNS_NON_NULL). Greedy
+    # (H) single-marker rounds must fix BOTH, not stop at the first
+    # (H) error-count tie (PR #800 review).
+    root = temp_repo / "msmulti"
+    root.mkdir()
+    (root / "sax.hpp").write_text(
+        """\
+LIB_SCOPE_BEGIN
+
+struct sax_like
+{
+    RETURNS_NON_NULL
+    int guarded()
+    {
+        return helper();
+    }
+
+    int helper()
+    {
+        return 2;
+    }
+};
+
+LIB_SCOPE_END
+""",
+        encoding="utf-8",
+    )
+    run_updater(root, mock_ingestor, skip_if_missing="cpp")
+
+    methods = get_qualified_names(get_nodes(mock_ingestor, "Method"))
+    assert "msmulti.sax.sax_like.guarded" in methods, sorted(methods)
+    assert "msmulti.sax.sax_like.helper" in methods, sorted(methods)
+
+
 def test_marker_retry_guard_shapes() -> None:
     import pytest as _pytest
 

--- a/codebase_rag/tests/test_cpp_macro_swallowed_class.py
+++ b/codebase_rag/tests/test_cpp_macro_swallowed_class.py
@@ -1,0 +1,154 @@
+# (H) nlohmann's ordered_map.hpp: a bare namespace-opening macro line
+# (H) (`NLOHMANN_JSON_NAMESPACE_BEGIN`, no semicolon) glues onto the following
+# (H) `template <...> struct ordered_map : std::vector<...>` and tree-sitter
+# (H) parses the pair as ONE declaration -- the struct head vanishes into an
+# (H) init_declarator/compound_literal_expression, the class never registers,
+# (H) and every member leaks to module scope. The error is LOCAL (a couple of
+# (H) small ERROR nodes), so the catastrophic whole-file recovery never fires.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.conftest import (
+    get_nodes,
+    get_qualified_names,
+    run_updater,
+)
+
+_SOURCE = """\
+#include <vector>
+
+NLOHMANN_JSON_NAMESPACE_BEGIN
+
+/// ordered_map: a minimal map-like container that preserves insertion order
+template <class Key, class T, class IgnoredLess = std::less<Key>,
+          class Allocator = std::allocator<std::pair<const Key, T>>>
+              struct ordered_map : std::vector<std::pair<const Key, T>, Allocator>
+{
+    using key_type = Key;
+    using Container = std::vector<std::pair<const Key, T>, Allocator>;
+
+    ordered_map() noexcept {}
+
+    T& at(const Key& key)
+    {
+        return locate(key);
+    }
+
+    T& locate(const Key& key)
+    {
+        return this->front().second;
+    }
+};
+
+NLOHMANN_JSON_NAMESPACE_END
+"""
+
+
+def _write(root: Path) -> None:
+    root.mkdir()
+    (root / "ordered_map.hpp").write_text(_SOURCE, encoding="utf-8")
+
+
+def test_macro_swallowed_struct_registers_as_class(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    root = temp_repo / "msproj"
+    _write(root)
+    run_updater(root, mock_ingestor, skip_if_missing="cpp")
+
+    classes = get_qualified_names(get_nodes(mock_ingestor, "Class"))
+    assert "msproj.ordered_map.ordered_map" in classes, sorted(classes)
+
+    methods = get_qualified_names(get_nodes(mock_ingestor, "Method"))
+    assert "msproj.ordered_map.ordered_map.at" in methods, sorted(methods)
+    assert "msproj.ordered_map.ordered_map.locate" in methods, sorted(methods)
+
+    # (H) members must not leak to module scope as free functions
+    functions = get_qualified_names(get_nodes(mock_ingestor, "Function"))
+    assert "msproj.ordered_map.at" not in functions, sorted(functions)
+
+
+def test_macro_swallowed_struct_keeps_member_call_edges(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    root = temp_repo / "mscalls"
+    _write(root)
+    run_updater(root, mock_ingestor, skip_if_missing="cpp")
+
+    calls = {
+        (c.args[0][2], c.args[2][2])
+        for c in mock_ingestor.ensure_relationship_batch.call_args_list
+        if c.args[1] == "CALLS"
+    }
+    assert (
+        "mscalls.ordered_map.ordered_map.at",
+        "mscalls.ordered_map.ordered_map.locate",
+    ) in calls, sorted(calls)
+
+
+def test_macro_swallowed_namespace_recovers_qualified_names(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # (H) the marker also swallows a following `namespace detail {` -- the pair
+    # (H) parses as a function_definition literally NAMED `namespace`, erasing
+    # (H) the namespace from every member's qualified name
+    root = temp_repo / "mshealthy"
+    root.mkdir()
+    (root / "scope.hpp").write_text(
+        """\
+SOME_NAMESPACE_BEGIN
+
+namespace detail
+{
+int helper()
+{
+    return 1;
+}
+}  // namespace detail
+
+SOME_NAMESPACE_END
+""",
+        encoding="utf-8",
+    )
+    run_updater(root, mock_ingestor, skip_if_missing="cpp")
+
+    functions = get_qualified_names(get_nodes(mock_ingestor, "Function"))
+    assert "mshealthy.scope.detail.helper" in functions, sorted(functions)
+
+
+def test_marker_retry_guard_shapes() -> None:
+    import pytest as _pytest
+
+    from codebase_rag.parser_loader import load_parsers
+    from codebase_rag.parsers.cpp.preproc_recovery import (
+        _retry_without_macro_markers,
+    )
+
+    parsers, _ = load_parsers()
+    if "cpp" not in parsers:
+        _pytest.skip("cpp parser not available")
+    cpp = parsers["cpp"]
+
+    # (H) a clean tree is returned untouched
+    clean = b"int x = 1;\n"
+    tree = cpp.parse(clean)
+    kept, kept_src = _retry_without_macro_markers(cpp, tree, clean)
+    assert kept is tree
+    assert kept_src is clean
+
+    # (H) an erroring file with no marker line has nothing to blank
+    broken = b"void f( {\n"
+    tree2 = cpp.parse(broken)
+    kept2, _ = _retry_without_macro_markers(cpp, tree2, broken)
+    assert kept2 is tree2
+
+    # (H) a marker that does NOT explain the error keeps the original tree via
+    # (H) the strict-improvement guard: the brace garbage errors identically
+    # (H) with or without the marker line
+    mixed = b"SOME_MARKER_MACRO\n}}}}\n"
+    tree3 = cpp.parse(mixed)
+    kept3, kept3_src = _retry_without_macro_markers(cpp, tree3, mixed)
+    assert kept3 is tree3
+    assert kept3_src is mixed

--- a/codebase_rag/tests/test_cpp_macro_swallowed_class.py
+++ b/codebase_rag/tests/test_cpp_macro_swallowed_class.py
@@ -96,9 +96,11 @@ def test_macro_swallowed_namespace_recovers_qualified_names(
     # (H) the namespace from every member's qualified name
     root = temp_repo / "mshealthy"
     root.mkdir()
+    # (H) the opening marker carries a trailing line comment: matching must
+    # (H) strip `//` prose first, like the brace counter does
     (root / "scope.hpp").write_text(
         """\
-SOME_NAMESPACE_BEGIN
+SOME_NAMESPACE_BEGIN  // opens the library scope
 
 namespace detail
 {
@@ -152,3 +154,19 @@ def test_marker_retry_guard_shapes() -> None:
     kept3, kept3_src = _retry_without_macro_markers(cpp, tree3, mixed)
     assert kept3 is tree3
     assert kept3_src is mixed
+
+    # (H) smallest subset wins: a marker-shaped line inside a raw string must
+    # (H) survive when blanking the single real offender already explains the
+    # (H) error (all-at-once would corrupt the string as collateral)
+    raw = (
+        b"SOME_MARKER_MACRO\n"
+        b"struct swallowed : base {\n"
+        b"  int x;\n"
+        b"};\n"
+        b'const char* payload = R"(\n'
+        b"INSIDE_A_RAW_STRING\n"
+        b')";\n'
+    )
+    tree4 = cpp.parse(raw)
+    kept4, kept4_src = _retry_without_macro_markers(cpp, tree4, raw)
+    assert b"INSIDE_A_RAW_STRING" in kept4_src


### PR DESCRIPTION
## Problem

A bare scope-marker macro line without a semicolon (`NLOHMANN_JSON_NAMESPACE_BEGIN`, `FMT_BEGIN_NAMESPACE`) glues onto the next top-level construct and silently destroys it:

- macro + `template <...> struct ordered_map : std::vector<...>` parses as ONE declaration whose struct head sinks into an `init_declarator`/`compound_literal_expression`; the class never registers and every member leaks to module scope (nlohmann's `ordered_map`),
- macro + `namespace detail {` parses as a `function_definition` literally named `namespace`; the namespace vanishes from every member's qualified name (most fmt and nlohmann headers).

The damage yields only a couple of SMALL error nodes, so the catastrophic whole-file recovery (which requires an ERROR spanning half the file) never fires. Fourth follow-up from the #791 residual audit.

## Fix

`preproc_recovery.py`: when a C/C++ parse has any error, blank every line consisting solely of an ALL_CAPS identifier (space-filled, so all byte offsets and line numbers survive) and re-parse, keeping the retry only when the error-node count strictly decreases. The pass runs before the existing conditional-brace recovery and threads the blanked source into it, so the two compose.

## Validation

- nlohmann (json/include/nlohmann), against post-#799 main: **259 -> 225**. The dead list restructures wholesale because qualified names are finally correct: entries move into their real `detail` namespace and orphaned members reattach to their classes (`ordered_map.count` -> `ordered_map.ordered_map.count`). Genuine revivals include the entire grisu2/dtoa cluster (`diyfp.mul`, `grisu2_digit_gen`, ...), lexer/parser helpers, and `handle_diagnostic_positions_for_json_value`.
- fmt, against post-#799 main: **626 -> 631**. 71 of the 87 new entries are pure namespace renames (`args.reserve` -> `args.detail.reserve`); the rest are accuracy corrections in both directions. Spot check: `dynamic_format_arg_store::push_back` flipping to dead is CORRECT public-API residual; it has zero internal callers (its prior liveness came from unqualified calls accidentally matching the misparse-orphaned free function).
- Non-C-family corpora are untouched by construction (the pass is gated to C/C++ before any work happens).
- cpp/java/csharp subset green; full suite green (documented memgraph-integration environmental flake only).

## Tests

RED -> GREEN: `test_cpp_macro_swallowed_class.py` — swallowed struct registers as Class with its Methods (no module-scope leak), member-to-member CALLS survive, swallowed namespace recovers qualified names, and guard shapes (clean tree untouched, no-marker file untouched, non-explanatory marker kept via the strict-improvement guard).
