### PR TITLE
chore: make pre-commit --all-files pass repo-wide

### DIFF
--- a/codebase_rag/main.py
+++ b/codebase_rag/main.py
@@ -347,7 +347,7 @@ async def _confirm_with_toggle(question: str) -> bool:
                 prompt_text,
                 key_bindings=bindings,
                 style=ORANGE_STYLE,
-                bottom_toolbar=lambda: _status_bar_label(),
+                bottom_toolbar=_status_bar_label,
                 refresh_interval=0.5,
             )
         except (KeyboardInterrupt, EOFError):
@@ -372,7 +372,7 @@ async def _prompt_with_toggle(question: str) -> str:
             prompt_text,
             key_bindings=bindings,
             style=ORANGE_STYLE,
-            bottom_toolbar=lambda: _status_bar_label(),
+            bottom_toolbar=_status_bar_label,
             refresh_interval=0.5,
         )
     except (KeyboardInterrupt, EOFError):
@@ -1087,7 +1087,7 @@ def get_multiline_input(prompt_text: str = cs.PROMPT_ASK_QUESTION) -> str:
         key_bindings=bindings,
         wrap_lines=True,
         style=ORANGE_STYLE,
-        bottom_toolbar=lambda: _status_bar_label(),
+        bottom_toolbar=_status_bar_label,
         refresh_interval=0.5,
     )
     if result is None:

--- a/codebase_rag/parsers/class_ingest/parent_extraction.py
+++ b/codebase_rag/parsers/class_ingest/parent_extraction.py
@@ -282,7 +282,7 @@ def parse_cpp_base_classes(
 
 def extract_cpp_base_class_name(parent_text: str) -> str:
     if cs.CHAR_ANGLE_OPEN in parent_text:
-        parent_text = parent_text.split(cs.CHAR_ANGLE_OPEN)[0]
+        parent_text = parent_text.split(cs.CHAR_ANGLE_OPEN, maxsplit=1)[0]
 
     if cs.SEPARATOR_DOUBLE_COLON in parent_text:
         parent_text = parent_text.split(cs.SEPARATOR_DOUBLE_COLON)[-1]

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -335,7 +335,7 @@ class ImportProcessor:
 
         @lru_cache(maxsize=4096)
         def _is_local_java_import_cached(import_path: str) -> bool:
-            top_level = import_path.split(cs.SEPARATOR_DOT)[0]
+            top_level = import_path.split(cs.SEPARATOR_DOT, maxsplit=1)[0]
             return (repo_path / top_level).is_dir()
 
         self._is_local_module_cached = _is_local_module_cached
@@ -861,7 +861,7 @@ class ImportProcessor:
         # (H) The old `startswith(project_name)` as-is shortcut is subsumed by
         # (H) _resolve_import_full_name's first branch, which additionally
         # (H) handles the project-named-package collision.
-        top_level = module_name.split(cs.SEPARATOR_DOT)[0]
+        top_level = module_name.split(cs.SEPARATOR_DOT, maxsplit=1)[0]
         return self._resolve_import_full_name(module_name, top_level)
 
     def _register_python_from_imports(

--- a/codebase_rag/parsers/java/method_resolver.py
+++ b/codebase_rag/parsers/java/method_resolver.py
@@ -106,7 +106,7 @@ def _callable_visible_to_caller(
         return True
     if not caller_qn:
         return False
-    owner = qn.split(cs.CHAR_PAREN_OPEN)[0].rsplit(cs.SEPARATOR_DOT, 1)[0]
+    owner = qn.split(cs.CHAR_PAREN_OPEN, maxsplit=1)[0].rsplit(cs.SEPARATOR_DOT, 1)[0]
     return caller_qn == owner or caller_qn.startswith(f"{owner}{cs.SEPARATOR_DOT}")
 
 
@@ -463,7 +463,7 @@ class JavaMethodResolverMixin:
             candidate_modules, class_qn, current_module_qn
         )
 
-        simple_class_name = class_qn.split(cs.SEPARATOR_DOT)[-1]
+        simple_class_name = class_qn.rsplit(cs.SEPARATOR_DOT, maxsplit=1)[-1]
 
         for module_qn in ranked_candidates:
             registry_class_qn = f"{module_qn}{cs.SEPARATOR_DOT}{simple_class_name}"

--- a/codebase_rag/parsers/java/type_resolver.py
+++ b/codebase_rag/parsers/java/type_resolver.py
@@ -145,7 +145,7 @@ class JavaTypeResolverMixin:
             return f"{resolved_base}{cs.JAVA_ARRAY_SUFFIX}"
 
         if cs.CHAR_ANGLE_OPEN in type_name and cs.CHAR_ANGLE_CLOSE in type_name:
-            base_type = type_name.split(cs.CHAR_ANGLE_OPEN)[0]
+            base_type = type_name.split(cs.CHAR_ANGLE_OPEN, maxsplit=1)[0]
             return self._resolve_java_type_name(base_type, module_qn)
 
         if module_qn in self.import_processor.import_mapping:

--- a/codebase_rag/parsers/py/expression_analyzer.py
+++ b/codebase_rag/parsers/py/expression_analyzer.py
@@ -146,11 +146,9 @@ class PythonExpressionAnalyzerMixin(_ExprBase):
         return safe_decode_text(attr_node) if attr_node.text else None
 
     @recursion_guard(
-        key_func=lambda self,
-        method_call,
-        module_qn,
-        *_,
-        **__: f"{module_qn}:{method_call}",
+        key_func=lambda self, method_call, module_qn, *_, **__: (
+            f"{module_qn}:{method_call}"
+        ),
         guard_name=cs.ATTR_TYPE_INFERENCE_IN_PROGRESS,
     )
     def _infer_method_call_return_type(

--- a/codebase_rag/parsers/py/variable_analyzer.py
+++ b/codebase_rag/parsers/py/variable_analyzer.py
@@ -556,7 +556,7 @@ class PythonVariableAnalyzerMixin(_VarBase):
 
     def _analyze_repository_item_type(self, module_qn: str) -> str | None:
         repo_qn_patterns = [
-            f"{module_qn.split(cs.SEPARATOR_DOT)[0]}{cs.PY_MODELS_BASE_PATH}{cs.PY_CLASS_REPOSITORY}",
+            f"{module_qn.split(cs.SEPARATOR_DOT, maxsplit=1)[0]}{cs.PY_MODELS_BASE_PATH}{cs.PY_CLASS_REPOSITORY}",
             cs.PY_CLASS_REPOSITORY,
         ]
 

--- a/codebase_rag/parsers/python_source_roots.py
+++ b/codebase_rag/parsers/python_source_roots.py
@@ -76,7 +76,7 @@ def discover_python_source_roots(repo_path: Path) -> dict[str, list[tuple[str, s
     def _add(name: str, dotted_dir: str) -> None:
         if dotted_dir == name:
             return
-        top_level = name.split(cs.SEPARATOR_DOT)[0]
+        top_level = name.split(cs.SEPARATOR_DOT, maxsplit=1)[0]
         candidates = roots.setdefault(top_level, [])
         if (name, dotted_dir) not in candidates:
             candidates.append((name, dotted_dir))
@@ -121,7 +121,7 @@ def resolve_via_source_roots(
     # (H) remap answers `acme.widgets.impl`). Among matching roots, the one that
     # (H) actually contains the imported submodule on disk wins; with no on-disk
     # (H) confirmation, a sole match is trusted.
-    top_level = module_name.split(cs.SEPARATOR_DOT)[0]
+    top_level = module_name.split(cs.SEPARATOR_DOT, maxsplit=1)[0]
     candidates = roots.get(top_level)
     if not candidates:
         return None

--- a/codebase_rag/providers/litellm.py
+++ b/codebase_rag/providers/litellm.py
@@ -1,5 +1,4 @@
-"""LiteLLM provider using pydantic-ai's native LiteLLMProvider."""
-
+# (H) LiteLLM provider using pydantic-ai's native LiteLLMProvider.
 from __future__ import annotations
 
 from loguru import logger

--- a/codebase_rag/tests/test_ast_cache_eviction_calls.py
+++ b/codebase_rag/tests/test_ast_cache_eviction_calls.py
@@ -37,7 +37,7 @@ def test_calls_survive_ast_cache_eviction(tmp_path: Path) -> None:
     updater = GraphUpdater(
         ingestor=mock, repo_path=tmp_path, parsers=parsers, queries=queries
     )
-    updater.ast_cache.max_entries = 1  # force eviction of all but the last file
+    updater.ast_cache.max_entries = 1  # (H) force eviction of all but the last file
     updater.run()
 
     calls = _calls(mock)

--- a/codebase_rag/tests/test_callable_flow_tracing.py
+++ b/codebase_rag/tests/test_callable_flow_tracing.py
@@ -171,8 +171,8 @@ def test_first_party_callee_keeps_precise_attribution(tmp_path: Path) -> None:
         "    return apply(_cb)\n"
     )
     calls = _run_calls(tmp_path, {"m.py": src})
-    assert _has(calls, "m.apply", "m._cb")  # precise: callee -> callback
-    assert not _has(calls, "m.caller", "m._cb")  # not the enclosing scope
+    assert _has(calls, "m.apply", "m._cb")  # (H) precise: callee -> callback
+    assert not _has(calls, "m.caller", "m._cb")  # (H) not the enclosing scope
 
 
 def test_self_method_callback_in_closure_is_traced(tmp_path: Path) -> None:

--- a/codebase_rag/tests/test_cpp_cross_file_methods.py
+++ b/codebase_rag/tests/test_cpp_cross_file_methods.py
@@ -1,11 +1,10 @@
-"""Tests for C++ cross-file out-of-class method resolution (issue #496).
-
-When a class is declared in a header (.h) and methods are implemented
-out-of-class in a source file (.cpp) using ``ClassName::method`` syntax,
-the Method nodes must link back to the correct Class node via
-DEFINES_METHOD edges -- not to a phantom class constructed from the
-.cpp module's qualified name.
-"""
+# (H) Tests for C++ cross-file out-of-class method resolution (issue #496).
+# (H)
+# (H) When a class is declared in a header (.h) and methods are implemented
+# (H) out-of-class in a source file (.cpp) using ``ClassName::method`` syntax,
+# (H) the Method nodes must link back to the correct Class node via
+# (H) DEFINES_METHOD edges -- not to a phantom class constructed from the
+# (H) .cpp module's qualified name.
 
 from __future__ import annotations
 
@@ -20,10 +19,6 @@ from codebase_rag.tests.conftest import (
     get_relationships,
     run_updater,
 )
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
 
 
 def _get_method_qns(mock_ingestor: MagicMock) -> set[str]:
@@ -58,21 +53,11 @@ def _method_names_for_class(mock_ingestor: MagicMock, class_name: str) -> set[st
     return names
 
 
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
 @pytest.fixture
 def cpp_cross_file_project(temp_repo: Path) -> Path:
     project = temp_repo / "cpp_cross_file"
     project.mkdir()
     return project
-
-
-# ---------------------------------------------------------------------------
-# Test: basic header + source cross-file methods
-# ---------------------------------------------------------------------------
 
 
 def test_header_source_method_resolution(
@@ -121,15 +106,12 @@ double Calculator::divide(int a, int b) {
 
     run_updater(cpp_cross_file_project, mock_ingestor)
 
-    # The class should exist in the header module.
     class_qns = _get_class_qns(mock_ingestor)
     header_class = [qn for qn in class_qns if "include" in qn and "Calculator" in qn]
     assert header_class, (
         f"Expected a Calculator class in include/, got classes: {class_qns}"
     )
 
-    # All three out-of-class methods should have DEFINES_METHOD edges
-    # pointing to the *header* class, not to a phantom class in src/.
     edges = _get_defines_method_edges(mock_ingestor)
     header_class_qn = header_class[0]
     methods_linked_to_header = {
@@ -146,8 +128,6 @@ double Calculator::divide(int a, int b) {
         f"'divide' not linked to header class. Edges: {edges}"
     )
 
-    # There should be NO orphan Method nodes (methods whose container_qn
-    # uses the .cpp module instead of the .h module).
     method_qns = _get_method_qns(mock_ingestor)
     orphan_methods = {
         qn
@@ -157,11 +137,6 @@ double Calculator::divide(int a, int b) {
     assert not orphan_methods, (
         f"Found orphan methods with .cpp module QN: {orphan_methods}"
     )
-
-
-# ---------------------------------------------------------------------------
-# Test: multiple source files implementing one header class
-# ---------------------------------------------------------------------------
 
 
 def test_multiple_source_files_one_class(
@@ -226,11 +201,6 @@ void Engine::brake() { /* ... */ }
             f"'{method_name}' not linked to header Engine class. "
             f"Linked methods: {methods_linked}"
         )
-
-
-# ---------------------------------------------------------------------------
-# Test: constructor and destructor out-of-class across files
-# ---------------------------------------------------------------------------
 
 
 def test_cross_file_constructor_destructor(
@@ -305,11 +275,6 @@ void Resource::reset() {
     )
 
 
-# ---------------------------------------------------------------------------
-# Test: nested namespace cross-file methods
-# ---------------------------------------------------------------------------
-
-
 def test_nested_namespace_cross_file(
     cpp_cross_file_project: Path,
     mock_ingestor: MagicMock,
@@ -375,11 +340,6 @@ void Logger::error(const char* msg) { /* ... */ }
     )
 
 
-# ---------------------------------------------------------------------------
-# Test: no orphan methods remain (aggregate check)
-# ---------------------------------------------------------------------------
-
-
 def test_no_orphan_methods_across_files(
     cpp_cross_file_project: Path,
     mock_ingestor: MagicMock,
@@ -422,18 +382,11 @@ void Widget::hide() { /* ... */ }
     methods_with_edges = {mq for _, mq in edges}
 
     orphans = method_qns - methods_with_edges
-    # Filter to only methods belonging to Widget (other methods from inline
-    # definitions always have edges).
     widget_orphans = {qn for qn in orphans if "Widget" in qn}
     assert not widget_orphans, (
         f"Found orphan Widget Method nodes with no DEFINES_METHOD edge: "
         f"{widget_orphans}"
     )
-
-
-# ---------------------------------------------------------------------------
-# Test: same-file out-of-class still works (regression)
-# ---------------------------------------------------------------------------
 
 
 def test_same_file_out_of_class_still_works(

--- a/codebase_rag/tests/test_cpp_cross_file_singleton.py
+++ b/codebase_rag/tests/test_cpp_cross_file_singleton.py
@@ -148,8 +148,8 @@ def test_cpp_singleton_pattern_cross_file_calls(
         found_calls.add((caller_short, callee_short))
 
     # (H) Calls are attributed to the enclosing method/function, not the file:
-    # the singleton calls live inside SceneController's methods and
-    # Application.start(), so those are the callers (not the module nodes).
+    # (H) the singleton calls live inside SceneController's methods and
+    # (H) Application.start(), so those are the callers (not the module nodes).
     sc = "controllers.SceneController.SceneController"
     expected_calls = [
         (f"{sc}.loadMenuScene", "storage.Storage.Storage.getInstance"),

--- a/codebase_rag/tests/test_decorators.py
+++ b/codebase_rag/tests/test_decorators.py
@@ -354,11 +354,9 @@ class TestRecursionGuard:
 
         class Analyzer:
             @recursion_guard(
-                key_func=lambda self,
-                method_call,
-                module_qn,
-                *_,
-                **__: f"{module_qn}:{method_call}"
+                key_func=lambda self, method_call, module_qn, *_, **__: (
+                    f"{module_qn}:{method_call}"
+                )
             )
             def infer_type(
                 self,

--- a/codebase_rag/tests/test_embedder_mps_sync.py
+++ b/codebase_rag/tests/test_embedder_mps_sync.py
@@ -129,8 +129,8 @@ class TestEmbedCallsSync:
         from codebase_rag.embedder import embed_code_batch
 
         snippets = [f"def f{i}(): pass" for i in range(5)]
-        mock_unixcoder.tokenize.side_effect = lambda batch, **_kw: [[1, 2, 3]] * len(
-            batch
+        mock_unixcoder.tokenize.side_effect = lambda batch, **_kw: (
+            [[1, 2, 3]] * len(batch)
         )
         mock_unixcoder.side_effect = lambda tensor: (
             torch.zeros(tensor.shape[0], 5, 768),

--- a/codebase_rag/tests/test_graph_updater_embeddings.py
+++ b/codebase_rag/tests/test_graph_updater_embeddings.py
@@ -23,7 +23,7 @@ _PATCH_EMBED_BATCH = patch(
     "codebase_rag.embedder.embed_code_batch", side_effect=_fake_embed_batch
 )
 _PATCH_STORE_BATCH = patch(
-    "codebase_rag.vector_store.store_embedding_batch", side_effect=lambda pts: len(pts)
+    "codebase_rag.vector_store.store_embedding_batch", side_effect=len
 )
 _PATCH_RECONCILE = patch(
     "codebase_rag.vector_store.verify_stored_ids", side_effect=lambda ids: ids

--- a/codebase_rag/tests/test_lua_type_inference_integration.py
+++ b/codebase_rag/tests/test_lua_type_inference_integration.py
@@ -73,8 +73,9 @@ class TestLuaTypeInferenceWithRealParsing:
         mock_function_registry: MagicMock,
     ) -> None:
         mock_function_registry.__contains__ = MagicMock(
-            side_effect=lambda x: x
-            in {"myapp.main.Person", "myapp.main.Logger", "myapp.main.Config"}
+            side_effect=lambda x: (
+                x in {"myapp.main.Person", "myapp.main.Logger", "myapp.main.Config"}
+            )
         )
 
         code = b"""

--- a/codebase_rag/tests/test_lua_type_inference_unit.py
+++ b/codebase_rag/tests/test_lua_type_inference_unit.py
@@ -272,11 +272,13 @@ class TestBuildLuaLocalVariableTypeMap:
         mock_function_registry: MagicMock,
     ) -> None:
         mock_function_registry.__contains__ = MagicMock(
-            side_effect=lambda x: x
-            in {
-                "myapp.main.Person",
-                "myapp.main.Logger",
-            }
+            side_effect=lambda x: (
+                x
+                in {
+                    "myapp.main.Person",
+                    "myapp.main.Logger",
+                }
+            )
         )
 
         var_decl1 = create_lua_variable_declaration("person", "Person", "new")

--- a/codebase_rag/tests/test_py_variable_analyzer_integration.py
+++ b/codebase_rag/tests/test_py_variable_analyzer_integration.py
@@ -75,7 +75,7 @@ def engine(
         module_qn_to_file_path={},
         class_inheritance={},
         simple_name_lookup=defaultdict(set),
-        js_type_inference_getter=lambda: MagicMock(),
+        js_type_inference_getter=MagicMock,
     )
 
 
@@ -635,7 +635,7 @@ class TestTraverseSinglePassWithQueries:
             module_qn_to_file_path={},
             class_inheritance={},
             simple_name_lookup=defaultdict(set),
-            js_type_inference_getter=lambda: MagicMock(),
+            js_type_inference_getter=MagicMock,
         )
 
     def test_traverse_with_query_path(

--- a/codebase_rag/tests/test_py_variable_analyzer_unit.py
+++ b/codebase_rag/tests/test_py_variable_analyzer_unit.py
@@ -53,7 +53,7 @@ def engine(
         module_qn_to_file_path={},
         class_inheritance={},
         simple_name_lookup=defaultdict(set),
-        js_type_inference_getter=lambda: MagicMock(),
+        js_type_inference_getter=MagicMock,
     )
 
 

--- a/codebase_rag/tests/test_python_standard_library_imports.py
+++ b/codebase_rag/tests/test_python_standard_library_imports.py
@@ -45,9 +45,9 @@ class TestStandardLibraryImports:
         mock_name_node.type = "dotted_name"
         mock_name_node.text = b"path"
 
-        mock_import_node.child_by_field_name.side_effect = lambda field: {
+        mock_import_node.child_by_field_name.side_effect = {
             "module_name": mock_module_name_node,
-        }.get(field)
+        }.get
 
         mock_import_node.children_by_field_name.side_effect = lambda field: {
             "name": [mock_name_node] if field == "name" else []
@@ -78,9 +78,9 @@ class TestStandardLibraryImports:
         mock_name_node.type = "dotted_name"
         mock_name_node.text = b"array"
 
-        mock_import_node.child_by_field_name.side_effect = lambda field: {
+        mock_import_node.child_by_field_name.side_effect = {
             "module_name": mock_module_name_node,
-        }.get(field)
+        }.get
 
         mock_import_node.children_by_field_name.side_effect = lambda field: {
             "name": [mock_name_node] if field == "name" else []
@@ -113,9 +113,9 @@ class TestStandardLibraryImports:
         mock_name_node.type = "dotted_name"
         mock_name_node.text = b"helper"
 
-        mock_import_node.child_by_field_name.side_effect = lambda field: {
+        mock_import_node.child_by_field_name.side_effect = {
             "module_name": mock_module_name_node,
-        }.get(field)
+        }.get
 
         mock_import_node.children_by_field_name.side_effect = lambda field: {
             "name": [mock_name_node] if field == "name" else []
@@ -146,9 +146,9 @@ class TestStandardLibraryImports:
         mock_name_node.type = "dotted_name"
         mock_name_node.text = b"settings"
 
-        mock_import_node.child_by_field_name.side_effect = lambda field: {
+        mock_import_node.child_by_field_name.side_effect = {
             "module_name": mock_module_name_node,
-        }.get(field)
+        }.get
 
         mock_import_node.children_by_field_name.side_effect = lambda field: {
             "name": [mock_name_node] if field == "name" else []
@@ -181,9 +181,9 @@ class TestStandardLibraryImports:
         mock_name_node.type = "dotted_name"
         mock_name_node.text = b"helper"
 
-        mock_import_node.child_by_field_name.side_effect = lambda field: {
+        mock_import_node.child_by_field_name.side_effect = {
             "module_name": mock_module_name_node,
-        }.get(field)
+        }.get
 
         mock_import_node.children_by_field_name.side_effect = lambda field: {
             "name": [mock_name_node] if field == "name" else []
@@ -214,9 +214,9 @@ class TestStandardLibraryImports:
         mock_name_node.type = "dotted_name"
         mock_name_node.text = b"database"
 
-        mock_import_node.child_by_field_name.side_effect = lambda field: {
+        mock_import_node.child_by_field_name.side_effect = {
             "module_name": mock_module_name_node,
-        }.get(field)
+        }.get
 
         mock_import_node.children_by_field_name.side_effect = lambda field: {
             "name": [mock_name_node] if field == "name" else []
@@ -318,10 +318,10 @@ class TestStandardLibraryImports:
         mock_alias_node = MagicMock()
         mock_alias_node.text = b"operating_system"
 
-        mock_aliased_import.child_by_field_name.side_effect = lambda field: {
+        mock_aliased_import.child_by_field_name.side_effect = {
             "name": mock_name_node,
             "alias": mock_alias_node,
-        }.get(field)
+        }.get
 
         mock_import_node.named_children = [mock_aliased_import]
 
@@ -350,10 +350,10 @@ class TestStandardLibraryImports:
         mock_alias_node = MagicMock()
         mock_alias_node.text = b"helpers"
 
-        mock_aliased_import.child_by_field_name.side_effect = lambda field: {
+        mock_aliased_import.child_by_field_name.side_effect = {
             "name": mock_name_node,
             "alias": mock_alias_node,
-        }.get(field)
+        }.get
 
         mock_import_node.named_children = [mock_aliased_import]
 

--- a/codebase_rag/tests/test_realtime_debounce.py
+++ b/codebase_rag/tests/test_realtime_debounce.py
@@ -1,9 +1,7 @@
-"""
-Tests for the realtime_updater debouncing functionality.
-
-These tests verify the hybrid debounce strategy that prevents redundant
-graph updates during rapid file saves.
-"""
+# (H) Tests for the realtime_updater debouncing functionality.
+# (H)
+# (H) These tests verify the hybrid debounce strategy that prevents redundant
+# (H) graph updates during rapid file saves.
 
 from __future__ import annotations
 
@@ -35,7 +33,7 @@ class MockQueryIngestor:
         pass
 
 
-# Register MockQueryIngestor as implementing QueryProtocol for isinstance checks
+# (H) Register MockQueryIngestor as implementing QueryProtocol for isinstance checks
 QueryProtocol.register(MockQueryIngestor)
 
 
@@ -117,12 +115,10 @@ class TestCodeChangeEventHandlerDebounce:
 
         handler = CodeChangeEventHandler(mock_updater)
 
-        # Should be ignored (directories in ignore patterns)
         assert handler._is_relevant(str(tmp_path / ".git" / "config")) is False
         assert handler._is_relevant(str(tmp_path / "node_modules" / "pkg.js")) is False
         assert handler._is_relevant(str(tmp_path / "__pycache__" / "mod.pyc")) is False
 
-        # Should be relevant
         assert handler._is_relevant(str(tmp_path / "main.py")) is True
         assert handler._is_relevant(str(tmp_path / "src" / "lib.rs")) is True
         assert handler._is_relevant(str(tmp_path / "app.js")) is True
@@ -136,15 +132,13 @@ class TestCodeChangeEventHandlerDebounce:
             mock_updater, debounce_seconds=0.1, max_wait_seconds=1
         )
 
-        # Create event that is marked as directory
         event = FileModifiedEvent(str(tmp_path / "some_dir"))
-        # The is_directory property is set by watchdog based on the event type
-        # For FileModifiedEvent, we need to check is_directory attribute
+        # (H) The is_directory property is set by watchdog based on the event type
+        # (H) For FileModifiedEvent, we need to check is_directory attribute
         object.__setattr__(event, "is_directory", True)
 
         handler.dispatch(event)
 
-        # No timer should be created for directory events
         assert len(handler.timers) == 0
         mock_ingestor.execute_write.assert_not_called()
 
@@ -160,19 +154,15 @@ class TestCodeChangeEventHandlerDebounce:
             mock_updater, debounce_seconds=0.2, max_wait_seconds=5
         )
 
-        # Simulate 5 rapid saves
         for _ in range(5):
             event = FileModifiedEvent(str(sample_file))
             handler.dispatch(event)
-            time.sleep(0.05)  # 50ms between saves
+            time.sleep(0.05)
 
-        # Should have one pending event
         assert len(handler.pending_events) == 1
 
-        # Wait for debounce to complete
         time.sleep(0.4)
 
-        # After debounce, ingestor should have been called only once
         mock_ingestor.flush_all.assert_called_once()
 
     def test_no_debounce_processes_immediately(
@@ -190,7 +180,6 @@ class TestCodeChangeEventHandlerDebounce:
         event = FileModifiedEvent(str(sample_file))
         handler.dispatch(event)
 
-        # Should process immediately (no pending events)
         assert len(handler.pending_events) == 0
         assert len(handler.timers) == 0
         mock_ingestor.flush_all.assert_called_once()
@@ -207,21 +196,16 @@ class TestCodeChangeEventHandlerDebounce:
             mock_updater, debounce_seconds=0.5, max_wait_seconds=0.3
         )
 
-        # First event
         event = FileModifiedEvent(str(sample_file))
         handler.dispatch(event)
 
-        # Wait until max_wait is exceeded
         time.sleep(0.4)
 
-        # Second event should trigger immediate processing due to max_wait
         event2 = FileModifiedEvent(str(sample_file))
         handler.dispatch(event2)
 
-        # Give time for processing
         time.sleep(0.15)
 
-        # Should have processed at least once due to max_wait
         assert mock_ingestor.flush_all.call_count >= 1
 
     def test_different_files_tracked_separately(
@@ -238,14 +222,12 @@ class TestCodeChangeEventHandlerDebounce:
             mock_updater, debounce_seconds=0.2, max_wait_seconds=5
         )
 
-        # Events for different files
         event1 = FileModifiedEvent(str(file1))
         event2 = FileModifiedEvent(str(file2))
 
         handler.dispatch(event1)
         handler.dispatch(event2)
 
-        # Should have two pending events
         assert len(handler.pending_events) == 2
         assert len(handler.timers) == 2
 
@@ -264,14 +246,11 @@ class TestCodeChangeEventHandlerDebounce:
         event = FileModifiedEvent(str(sample_file))
         handler.dispatch(event)
 
-        # Should have pending state
         assert len(handler.pending_events) == 1
         assert len(handler.first_event_time) == 1
 
-        # Wait for processing
         time.sleep(0.25)
 
-        # State should be cleaned up
         assert len(handler.pending_events) == 0
         assert len(handler.first_event_time) == 0
         assert len(handler.timers) == 0
@@ -326,14 +305,12 @@ class TestCodeChangeEventHandlerDebounce:
                 handler.dispatch(event)
                 time.sleep(0.02)
 
-        # Send events from multiple threads
         threads = [threading.Thread(target=send_events, args=(f,)) for f in files[:5]]
         for t in threads:
             t.start()
         for t in threads:
             t.join()
 
-        # Should have 5 pending events (one per file)
         assert len(handler.pending_events) == 5
 
 
@@ -409,17 +386,14 @@ class TestDebounceIntegration:
             mock_updater, debounce_seconds=0.5, max_wait_seconds=2
         )
 
-        # Simulate 10 saves over 3 seconds
         for i in range(10):
             event = FileModifiedEvent(str(test_file))
             handler.dispatch(event)
             time.sleep(0.3)
 
-        # Wait for final debounce
         time.sleep(0.7)
 
-        # Should have batched into fewer updates due to max_wait and debounce
-        # With max_wait=2s and 3s total time, expect ~2-4 updates
+        # (H) With max_wait=2s and 3s total time, expect ~2-4 updates
         call_count = mock_ingestor.flush_all.call_count
         assert 1 <= call_count <= 4, f"Expected 1-4 updates, got {call_count}"
 
@@ -438,8 +412,6 @@ class TestDebounceIntegration:
         event = FileModifiedEvent(str(test_file))
         handler.dispatch(event)
 
-        # Wait for debounce
         time.sleep(0.25)
 
-        # Should have exactly one update
         mock_ingestor.flush_all.assert_called_once()

--- a/evals/score.py
+++ b/evals/score.py
@@ -1,5 +1,4 @@
 from statistics import fmean
-from typing import TypeVar
 
 from codebase_rag import constants as cs
 
@@ -14,8 +13,6 @@ from .types_defs import (
     ScoreResult,
     ScoreRow,
 )
-
-T = TypeVar("T")
 
 
 def score(cgr: GraphData, oracle: GraphData) -> ScoreResult:
@@ -247,7 +244,7 @@ def _name_edge_bucket(cgr_set: set[NameEdge], oracle_set: set[NameEdge]) -> Diff
     return DiffBucket(missing=missing, extra=extra)
 
 
-def _prf(category: str, label: str, cgr: set[T], oracle: set[T]) -> ScoreRow | None:
+def _prf[T](category: str, label: str, cgr: set[T], oracle: set[T]) -> ScoreRow | None:
     tp = len(cgr & oracle)
     fp = len(cgr - oracle)
     fn = len(oracle - cgr)

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.378"
+version = "0.0.383"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Problem

`pre-commit run --all-files` fails on main, so any contributor running the full hook locally hits red unrelated to their change. Two independent causes: the pre-commit ruff pin (v0.15.22) enforces rules the locked CI ruff (0.14.14) does not yet flag (`maxsplit`-less splits, unnecessary lambdas PLW0108, PEP 695 UP047, plus formatting drift), and five test files plus one provider carried plain comments and module docstrings that violate the repo's `(H)` comment convention (`scripts/check_no_docs.py`).

## Fix

- ruff auto-fixes applied repo-wide (`split(..., maxsplit=1)`, formatting), and the 16 non-auto-fixable items resolved by hand: three `bottom_toolbar=lambda: _status_bar_label()` become direct function references, mock `side_effect` lambdas inline to `len` / `MagicMock` / bound `dict.get`, and `evals/score.py`'s `_prf` converts to a PEP 695 type parameter (dropping the module `TypeVar`).
- No-docs cleanup: module docstrings convert to `# (H)` headers, banner separators and narration comments that restate the adjacent line are deleted, and comments carrying real constraints (watchdog `is_directory` semantics, debounce timing math, eviction forcing, caller-attribution nuances) keep their content under the `(H)` marker.
- `uv.lock` self-version syncs to the auto-bumped 0.0.383 (it had drifted to 0.0.378 since the bump workflow edits only `pyproject.toml`).

## Validation

- `pre-commit run --all-files` exits 0, twice consecutively (stable, no ping-pong between hooks).
- Full suite: 5432 passed; the single failure is the documented memgraph-integration environmental flake, identical on clean main.
- All lambda inlinings are behavior-preserving: no captured variables are rebound after the assignment sites, and `MagicMock` as a factory produces a fresh instance per call exactly like the lambda did.