### PR TITLE
feat(parsers): initialize language grammars lazily (#68)

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -3,7 +3,7 @@ import json
 import os
 import sys
 from collections import OrderedDict, defaultdict
-from collections.abc import Callable, ItemsView, KeysView
+from collections.abc import Callable, ItemsView, KeysView, Mapping
 from pathlib import Path
 
 from loguru import logger
@@ -488,8 +488,8 @@ class GraphUpdater:
         self,
         ingestor: IngestorProtocol,
         repo_path: Path,
-        parsers: dict[cs.SupportedLanguage, Parser],
-        queries: dict[cs.SupportedLanguage, LanguageQueries],
+        parsers: Mapping[cs.SupportedLanguage, Parser],
+        queries: Mapping[cs.SupportedLanguage, LanguageQueries],
         unignore_paths: frozenset[str] | None = None,
         exclude_paths: frozenset[str] | None = None,
         project_name: str | None = None,

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -190,7 +190,7 @@ LIB_NOT_AVAILABLE = "Tree-sitter library for {lang} not available."
 LOCALS_QUERY_FAILED = "Failed to create locals query for {lang}: {error}"
 GRAMMAR_LOADED = "Successfully loaded {lang} grammar."
 GRAMMAR_LOAD_FAILED = "Failed to load {lang} grammar: {error}"
-INITIALIZED_PARSERS = "Initialized parsers for: {languages}"
+PARSERS_LAZY_READY = "Parser registry ready; grammars load on first use."
 
 # (H) Ignore pattern logs
 CGRIGNORE_LOADED = (

--- a/codebase_rag/parser_loader.py
+++ b/codebase_rag/parser_loader.py
@@ -379,6 +379,9 @@ def _process_language(
         logger.success(ls.GRAMMAR_LOADED.format(lang=lang_name))
         return True
     except Exception as e:
+        # (H) query compilation can fail AFTER the parser insert; drop the
+        # (H) orphan so the store never exposes a parser without its queries
+        parsers.pop(lang_name, None)
         logger.warning(ls.GRAMMAR_LOAD_FAILED.format(lang=lang_name, error=e))
         return False
 
@@ -436,11 +439,16 @@ class _LazyGrammarStore:
         )
 
     def _ensure(self, lang_name: object) -> bool:
-        if lang_name in self._parser_data:
+        # (H) the lock-free fast path must see BOTH twin entries: the loader
+        # (H) writes the parser before the queries, so a lone parser entry is a
+        # (H) mid-load (or failed-load) state, not a completed language
+        if lang_name in self._parser_data and lang_name in self._query_data:
             return True
         with self._lock:
             if lang_name in self._attempted:
-                return lang_name in self._parser_data
+                return (
+                    lang_name in self._parser_data and lang_name in self._query_data
+                )
             self._attempted.add(lang_name)
             if not isinstance(lang_name, str):
                 return False

--- a/codebase_rag/parser_loader.py
+++ b/codebase_rag/parser_loader.py
@@ -3,8 +3,8 @@ import subprocess
 import sys
 from collections.abc import Callable, ItemsView, Iterator, KeysView, ValuesView
 from copy import deepcopy
-from typing import cast
 from pathlib import Path
+from typing import cast
 
 from loguru import logger
 from tree_sitter import Language, Parser, Query

--- a/codebase_rag/parser_loader.py
+++ b/codebase_rag/parser_loader.py
@@ -1,10 +1,10 @@
 import importlib
 import subprocess
 import sys
-from collections.abc import Callable, ItemsView, Iterator, KeysView, ValuesView
+import threading
+from collections.abc import Callable, Iterator, Mapping
 from copy import deepcopy
 from pathlib import Path
-from typing import cast
 
 from loguru import logger
 from tree_sitter import Language, Parser, Query
@@ -383,103 +383,107 @@ def _process_language(
         return False
 
 
-class _LazyLanguageDict[V](dict[cs.SupportedLanguage, V]):
-    # (H) A real dict whose storage holds only the languages loaded so far; a
-    # (H) missing key triggers a one-time grammar load (issue #68). Subclassing
-    # (H) dict keeps every `dict[SupportedLanguage, ...]`-typed consumer
-    # (H) signature valid, and dict.__getitem__ routes misses through
-    # (H) __missing__. dict.get would BYPASS __missing__ (C fast path), so it
-    # (H) is overridden. Full-view operations (iteration, len, keys/values/
-    # (H) items) probe every spec first so no consumer ever sees a partial
-    # (H) availability picture.
-    def __init__(self, ensure: Callable[[object], bool]) -> None:
-        super().__init__()
+class _LazyLanguageView[V](Mapping[cs.SupportedLanguage, V]):
+    # (H) A read-only Mapping over the store's per-language dict; a missing key
+    # (H) triggers a one-time grammar load (issue #68). Mapping derives get,
+    # (H) keys, values, items, and __contains__ from the three methods below,
+    # (H) so laziness needs no dict-override tricks: membership and get load on
+    # (H) demand through __getitem__, and full-view operations (iteration, len,
+    # (H) and everything derived from them) probe every spec first so no
+    # (H) consumer ever sees a partial availability picture.
+    __slots__ = ("_data", "_ensure", "_probe_all")
+
+    def __init__(
+        self,
+        data: dict[cs.SupportedLanguage, V],
+        ensure: Callable[[object], bool],
+        probe_all: Callable[[], None],
+    ) -> None:
+        self._data = data
         self._ensure = ensure
+        self._probe_all = probe_all
 
-    def __missing__(self, lang_name: cs.SupportedLanguage) -> V:
-        if self._ensure(lang_name) and dict.__contains__(self, lang_name):
-            return dict.__getitem__(self, lang_name)
-        raise KeyError(lang_name)
-
-    def __contains__(self, lang_name: object) -> bool:
-        if dict.__contains__(self, lang_name):
-            return True
-        return self._ensure(lang_name) and dict.__contains__(self, lang_name)
-
-    def get(self, lang_name: object, default: V | None = None) -> V | None:  # ty: ignore[invalid-method-override]
-        if lang_name in self:
-            return dict.__getitem__(self, cast(cs.SupportedLanguage, lang_name))
-        return default
-
-    def _probe_all(self) -> None:
-        for lang_key in LANGUAGE_SPECS:
-            self._ensure(lang_key)
-        if not dict.__len__(self):
-            raise RuntimeError(ex.NO_LANGUAGES)
+    def __getitem__(self, lang_name: cs.SupportedLanguage) -> V:
+        if lang_name not in self._data:
+            self._ensure(lang_name)
+        return self._data[lang_name]
 
     def __iter__(self) -> Iterator[cs.SupportedLanguage]:
         self._probe_all()
-        return dict.__iter__(self)
+        return iter(self._data)
 
     def __len__(self) -> int:
         self._probe_all()
-        return dict.__len__(self)
-
-    def keys(self) -> KeysView[cs.SupportedLanguage]:  # ty: ignore[invalid-method-override]
-        self._probe_all()
-        return dict.keys(self)
-
-    def values(self) -> ValuesView[V]:  # ty: ignore[invalid-method-override]
-        self._probe_all()
-        return dict.values(self)
-
-    def items(self) -> ItemsView[cs.SupportedLanguage, V]:  # ty: ignore[invalid-method-override]
-        self._probe_all()
-        return dict.items(self)
+        return len(self._data)
 
 
 class _LazyGrammarStore:
     # (H) Process-wide cache: grammars load once per interpreter, not once per
     # (H) load_parsers() call (which previously recompiled EVERY language's
-    # (H) query set on every call).
+    # (H) query set on every call). The lock serializes loads: without it a
+    # (H) thread probing a language MID-LOAD would see it in _attempted but not
+    # (H) yet in the dict and wrongly report it unavailable (PR #802 review).
     def __init__(self) -> None:
-        self.parsers: _LazyLanguageDict[Parser] = _LazyLanguageDict(self._ensure)
-        self.queries: _LazyLanguageDict[LanguageQueries] = _LazyLanguageDict(
-            self._ensure
-        )
+        self._parser_data: dict[cs.SupportedLanguage, Parser] = {}
+        self._query_data: dict[cs.SupportedLanguage, LanguageQueries] = {}
         self._attempted: set[object] = set()
+        self._lock = threading.Lock()
+        self.parsers: Mapping[cs.SupportedLanguage, Parser] = _LazyLanguageView(
+            self._parser_data, self._ensure, self._probe_all
+        )
+        self.queries: Mapping[cs.SupportedLanguage, LanguageQueries] = (
+            _LazyLanguageView(self._query_data, self._ensure, self._probe_all)
+        )
 
     def _ensure(self, lang_name: object) -> bool:
-        if lang_name in self._attempted:
-            return dict.__contains__(self.parsers, lang_name)
-        self._attempted.add(lang_name)
-        if not isinstance(lang_name, str):
-            return False
-        try:
-            lang = cs.SupportedLanguage(lang_name)
-        except ValueError:
-            return False
-        spec = LANGUAGE_SPECS.get(lang)
-        if spec is None:
-            return False
-        return _process_language(lang, deepcopy(spec), self.parsers, self.queries)
+        if lang_name in self._parser_data:
+            return True
+        with self._lock:
+            if lang_name in self._attempted:
+                return lang_name in self._parser_data
+            self._attempted.add(lang_name)
+            if not isinstance(lang_name, str):
+                return False
+            try:
+                lang = cs.SupportedLanguage(lang_name)
+            except ValueError:
+                return False
+            spec = LANGUAGE_SPECS.get(lang)
+            if spec is None:
+                return False
+            return _process_language(
+                lang, deepcopy(spec), self._parser_data, self._query_data
+            )
+
+    def _probe_all(self) -> None:
+        for lang_key in LANGUAGE_SPECS:
+            self._ensure(lang_key)
+        if not self._parser_data:
+            raise RuntimeError(ex.NO_LANGUAGES)
 
 
 _store: _LazyGrammarStore | None = None
+_store_lock = threading.Lock()
 
 
 def _reset_parser_cache() -> None:
     # (H) Test hook: discard every cached grammar so laziness itself can be
     # (H) observed from a clean slate.
     global _store
-    _store = None
+    with _store_lock:
+        _store = None
 
 
 def load_parsers() -> tuple[
-    dict[cs.SupportedLanguage, Parser], dict[cs.SupportedLanguage, LanguageQueries]
+    Mapping[cs.SupportedLanguage, Parser],
+    Mapping[cs.SupportedLanguage, LanguageQueries],
 ]:
     global _store
-    if _store is None:
-        _store = _LazyGrammarStore()
-        logger.info(ls.PARSERS_LAZY_READY)
-    return _store.parsers, _store.queries
+    store = _store
+    if store is None:
+        with _store_lock:
+            if _store is None:
+                _store = _LazyGrammarStore()
+                logger.info(ls.PARSERS_LAZY_READY)
+            store = _store
+    return store.parsers, store.queries

--- a/codebase_rag/parser_loader.py
+++ b/codebase_rag/parser_loader.py
@@ -1,7 +1,9 @@
 import importlib
 import subprocess
 import sys
+from collections.abc import Callable, ItemsView, Iterator, KeysView, ValuesView
 from copy import deepcopy
+from typing import cast
 from pathlib import Path
 
 from loguru import logger
@@ -95,7 +97,7 @@ def _try_import_language(
         return _try_load_from_submodule(lang_name)
 
 
-def _import_language_loaders() -> dict[cs.SupportedLanguage, LanguageLoader]:
+def _language_imports() -> list[LanguageImport]:
     language_imports: list[LanguageImport] = [
         LanguageImport(
             cs.SupportedLanguage.PYTHON,
@@ -188,25 +190,33 @@ def _import_language_loaders() -> dict[cs.SupportedLanguage, LanguageLoader]:
         ),
     ]
 
-    loaders: dict[cs.SupportedLanguage, LanguageLoader] = {
-        lang_import.lang_key: _try_import_language(
+    return language_imports
+
+
+_IMPORT_SPECS: dict[cs.SupportedLanguage, LanguageImport] = {
+    lang_import.lang_key: lang_import for lang_import in _language_imports()
+}
+
+_loader_cache: dict[cs.SupportedLanguage, LanguageLoader] = {}
+
+
+def _get_language_library(lang_name: cs.SupportedLanguage) -> LanguageLoader:
+    # (H) One grammar module import per language, on first use, cached for the
+    # (H) process (issue #68: importing all 14 grammars up front made every
+    # (H) startup pay for languages the repo does not contain).
+    if lang_name in _loader_cache:
+        return _loader_cache[lang_name]
+    lang_import = _IMPORT_SPECS.get(lang_name)
+    if lang_import is not None:
+        loader = _try_import_language(
             lang_import.module_path,
             lang_import.attr_name,
             lang_import.submodule_name,
         )
-        for lang_import in language_imports
-    }
-    for lang_key in LANGUAGE_SPECS:
-        lang_name = cs.SupportedLanguage(lang_key)
-        if lang_name not in loaders or loaders[lang_name] is None:
-            loaders[lang_name] = _try_load_from_submodule(lang_name)
-
-    return loaders
-
-
-_language_loaders = _import_language_loaders()
-
-LANGUAGE_LIBRARIES: dict[cs.SupportedLanguage, LanguageLoader] = _language_loaders
+    else:
+        loader = _try_load_from_submodule(lang_name)
+    _loader_cache[lang_name] = loader
+    return loader
 
 
 def _build_query_pattern(node_types: tuple[str, ...], capture_name: str) -> str:
@@ -354,7 +364,7 @@ def _process_language(
     parsers: dict[cs.SupportedLanguage, Parser],
     queries: dict[cs.SupportedLanguage, LanguageQueries],
 ) -> bool:
-    lang_lib = LANGUAGE_LIBRARIES.get(lang_name)
+    lang_lib = _get_language_library(lang_name)
     if not lang_lib:
         logger.debug(ls.LIB_NOT_AVAILABLE, lang=lang_name)
         return False
@@ -373,20 +383,103 @@ def _process_language(
         return False
 
 
+class _LazyLanguageDict[V](dict[cs.SupportedLanguage, V]):
+    # (H) A real dict whose storage holds only the languages loaded so far; a
+    # (H) missing key triggers a one-time grammar load (issue #68). Subclassing
+    # (H) dict keeps every `dict[SupportedLanguage, ...]`-typed consumer
+    # (H) signature valid, and dict.__getitem__ routes misses through
+    # (H) __missing__. dict.get would BYPASS __missing__ (C fast path), so it
+    # (H) is overridden. Full-view operations (iteration, len, keys/values/
+    # (H) items) probe every spec first so no consumer ever sees a partial
+    # (H) availability picture.
+    def __init__(self, ensure: Callable[[object], bool]) -> None:
+        super().__init__()
+        self._ensure = ensure
+
+    def __missing__(self, lang_name: cs.SupportedLanguage) -> V:
+        if self._ensure(lang_name) and dict.__contains__(self, lang_name):
+            return dict.__getitem__(self, lang_name)
+        raise KeyError(lang_name)
+
+    def __contains__(self, lang_name: object) -> bool:
+        if dict.__contains__(self, lang_name):
+            return True
+        return self._ensure(lang_name) and dict.__contains__(self, lang_name)
+
+    def get(self, lang_name: object, default: V | None = None) -> V | None:  # ty: ignore[invalid-method-override]
+        if lang_name in self:
+            return dict.__getitem__(self, cast(cs.SupportedLanguage, lang_name))
+        return default
+
+    def _probe_all(self) -> None:
+        for lang_key in LANGUAGE_SPECS:
+            self._ensure(lang_key)
+        if not dict.__len__(self):
+            raise RuntimeError(ex.NO_LANGUAGES)
+
+    def __iter__(self) -> Iterator[cs.SupportedLanguage]:
+        self._probe_all()
+        return dict.__iter__(self)
+
+    def __len__(self) -> int:
+        self._probe_all()
+        return dict.__len__(self)
+
+    def keys(self) -> KeysView[cs.SupportedLanguage]:  # ty: ignore[invalid-method-override]
+        self._probe_all()
+        return dict.keys(self)
+
+    def values(self) -> ValuesView[V]:  # ty: ignore[invalid-method-override]
+        self._probe_all()
+        return dict.values(self)
+
+    def items(self) -> ItemsView[cs.SupportedLanguage, V]:  # ty: ignore[invalid-method-override]
+        self._probe_all()
+        return dict.items(self)
+
+
+class _LazyGrammarStore:
+    # (H) Process-wide cache: grammars load once per interpreter, not once per
+    # (H) load_parsers() call (which previously recompiled EVERY language's
+    # (H) query set on every call).
+    def __init__(self) -> None:
+        self.parsers: _LazyLanguageDict[Parser] = _LazyLanguageDict(self._ensure)
+        self.queries: _LazyLanguageDict[LanguageQueries] = _LazyLanguageDict(
+            self._ensure
+        )
+        self._attempted: set[object] = set()
+
+    def _ensure(self, lang_name: object) -> bool:
+        if lang_name in self._attempted:
+            return dict.__contains__(self.parsers, lang_name)
+        self._attempted.add(lang_name)
+        if not isinstance(lang_name, str):
+            return False
+        try:
+            lang = cs.SupportedLanguage(lang_name)
+        except ValueError:
+            return False
+        spec = LANGUAGE_SPECS.get(lang)
+        if spec is None:
+            return False
+        return _process_language(lang, deepcopy(spec), self.parsers, self.queries)
+
+
+_store: _LazyGrammarStore | None = None
+
+
+def _reset_parser_cache() -> None:
+    # (H) Test hook: discard every cached grammar so laziness itself can be
+    # (H) observed from a clean slate.
+    global _store
+    _store = None
+
+
 def load_parsers() -> tuple[
     dict[cs.SupportedLanguage, Parser], dict[cs.SupportedLanguage, LanguageQueries]
 ]:
-    parsers: dict[cs.SupportedLanguage, Parser] = {}
-    queries: dict[cs.SupportedLanguage, LanguageQueries] = {}
-    available_languages: list[cs.SupportedLanguage] = []
-
-    for lang_key, lang_config in deepcopy(LANGUAGE_SPECS).items():
-        lang_name = cs.SupportedLanguage(lang_key)
-        if _process_language(lang_name, lang_config, parsers, queries):
-            available_languages.append(lang_name)
-
-    if not available_languages:
-        raise RuntimeError(ex.NO_LANGUAGES)
-
-    logger.info(ls.INITIALIZED_PARSERS.format(languages=", ".join(available_languages)))
-    return parsers, queries
+    global _store
+    if _store is None:
+        _store = _LazyGrammarStore()
+        logger.info(ls.PARSERS_LAZY_READY)
+    return _store.parsers, _store.queries

--- a/codebase_rag/parser_loader.py
+++ b/codebase_rag/parser_loader.py
@@ -446,9 +446,7 @@ class _LazyGrammarStore:
             return True
         with self._lock:
             if lang_name in self._attempted:
-                return (
-                    lang_name in self._parser_data and lang_name in self._query_data
-                )
+                return lang_name in self._parser_data and lang_name in self._query_data
             self._attempted.add(lang_name)
             if not isinstance(lang_name, str):
                 return False

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from bisect import bisect_left, bisect_right
 from collections import defaultdict
+from collections.abc import Mapping
 from pathlib import Path
 from typing import NamedTuple
 
@@ -283,7 +284,7 @@ class CallProcessor:
         self,
         root_node: Node,
         language: cs.SupportedLanguage,
-        queries: dict[cs.SupportedLanguage, LanguageQueries],
+        queries: Mapping[cs.SupportedLanguage, LanguageQueries],
     ) -> tuple[list[Node], list[int]]:
         calls_query = queries[language].get(cs.QUERY_CALLS)
         if not calls_query:
@@ -424,7 +425,7 @@ class CallProcessor:
         file_path: Path,
         root_node: Node,
         language: cs.SupportedLanguage,
-        queries: dict[cs.SupportedLanguage, LanguageQueries],
+        queries: Mapping[cs.SupportedLanguage, LanguageQueries],
         func_class_captures_cache: dict[Path, dict] | None = None,
     ) -> None:
         # (H) Pre-pass: record which functions are bound to a class's callable
@@ -641,7 +642,7 @@ class CallProcessor:
         file_path: Path,
         root_node: Node,
         language: cs.SupportedLanguage,
-        queries: dict[cs.SupportedLanguage, LanguageQueries],
+        queries: Mapping[cs.SupportedLanguage, LanguageQueries],
         func_class_captures_cache: dict[Path, dict] | None = None,
     ) -> None:
         relative_path = cached_relative_path(file_path, self.repo_path)
@@ -848,7 +849,7 @@ class CallProcessor:
         root_node: Node,
         module_qn: str,
         language: cs.SupportedLanguage,
-        queries: dict[cs.SupportedLanguage, LanguageQueries],
+        queries: Mapping[cs.SupportedLanguage, LanguageQueries],
         all_call_nodes: list[Node] | None = None,
         call_starts: list[int] | None = None,
         call_name_cache: dict[int, str | None] | None = None,
@@ -1128,7 +1129,7 @@ class CallProcessor:
         class_qn: str,
         module_qn: str,
         language: cs.SupportedLanguage,
-        queries: dict[cs.SupportedLanguage, LanguageQueries],
+        queries: Mapping[cs.SupportedLanguage, LanguageQueries],
         all_call_nodes: list[Node] | None = None,
         call_starts: list[int] | None = None,
         call_name_cache: dict[int, str | None] | None = None,
@@ -1303,7 +1304,7 @@ class CallProcessor:
         root_node: Node,
         module_qn: str,
         language: cs.SupportedLanguage,
-        queries: dict[cs.SupportedLanguage, LanguageQueries],
+        queries: Mapping[cs.SupportedLanguage, LanguageQueries],
         all_call_nodes: list[Node] | None = None,
         call_starts: list[int] | None = None,
         call_name_cache: dict[int, str | None] | None = None,
@@ -1732,7 +1733,7 @@ class CallProcessor:
         caller_type: str,
         module_qn: str,
         language: cs.SupportedLanguage,
-        queries: dict[cs.SupportedLanguage, LanguageQueries],
+        queries: Mapping[cs.SupportedLanguage, LanguageQueries],
         class_context: str | None = None,
         call_nodes: list[Node] | None = None,
         call_name_cache: dict[int, str | None] | None = None,

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from bisect import bisect_left, bisect_right
+from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple
 
@@ -277,7 +278,7 @@ class ClassIngestMixin:
         root_node: Node,
         module_qn: str,
         language: cs.SupportedLanguage,
-        queries: dict[cs.SupportedLanguage, LanguageQueries],
+        queries: Mapping[cs.SupportedLanguage, LanguageQueries],
         combined_captures: dict[str, list] | None = None,
     ) -> None:
         lang_queries = queries[language]

--- a/codebase_rag/parsers/csharp/type_inference.py
+++ b/codebase_rag/parsers/csharp/type_inference.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import deque
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -93,7 +93,7 @@ class CSharpTypeInferenceEngine:
         repo_path: Path,
         project_name: str,
         ast_cache: ASTCacheProtocol,
-        queries: dict[cs.SupportedLanguage, LanguageQueries],
+        queries: Mapping[cs.SupportedLanguage, LanguageQueries],
         module_qn_to_file_path: dict[str, Path],
         class_inheritance: dict[str, list[str]],
         simple_name_lookup: SimpleNameLookup,

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -226,7 +227,7 @@ class DefinitionProcessor(
         self,
         file_path: Path,
         language: cs.SupportedLanguage,
-        queries: dict[cs.SupportedLanguage, LanguageQueries],
+        queries: Mapping[cs.SupportedLanguage, LanguageQueries],
         structural_elements: dict[Path, str | None],
         source_bytes: bytes | None = None,
         pre_parsed: tuple[ASTNode, dict[str, list] | None] | None = None,

--- a/codebase_rag/parsers/factory.py
+++ b/codebase_rag/parsers/factory.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from pathlib import Path
 
 from ..capture import ALL_ENABLED, CaptureSelection
@@ -42,7 +43,7 @@ class ProcessorFactory:
         ingestor: IngestorProtocol,
         repo_path: Path,
         project_name: str,
-        queries: dict[SupportedLanguage, LanguageQueries],
+        queries: Mapping[SupportedLanguage, LanguageQueries],
         function_registry: FunctionRegistryTrieProtocol,
         simple_name_lookup: SimpleNameLookup,
         ast_cache: ASTCacheProtocol,

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, NamedTuple
 
@@ -232,7 +233,7 @@ class FunctionIngestMixin:
         root_node: Node,
         module_qn: str,
         language: cs.SupportedLanguage,
-        queries: dict[cs.SupportedLanguage, LanguageQueries],
+        queries: Mapping[cs.SupportedLanguage, LanguageQueries],
         combined_captures: dict[str, list] | None = None,
     ) -> None:
         if combined_captures is not None:

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -2,6 +2,7 @@ import json
 import os
 import posixpath
 import re
+from collections.abc import Mapping
 from functools import lru_cache
 from pathlib import Path
 
@@ -366,7 +367,7 @@ class ImportProcessor:
         root_node: Node,
         module_qn: str,
         language: cs.SupportedLanguage,
-        queries: dict[cs.SupportedLanguage, LanguageQueries],
+        queries: Mapping[cs.SupportedLanguage, LanguageQueries],
         pre_captures: dict | None = None,
     ) -> None:
         if language not in queries:

--- a/codebase_rag/parsers/java/type_inference.py
+++ b/codebase_rag/parsers/java/type_inference.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -48,7 +49,7 @@ class JavaTypeInferenceEngine(
         repo_path: Path,
         project_name: str,
         ast_cache: "ASTCacheProtocol",
-        queries: dict[cs.SupportedLanguage, LanguageQueries],
+        queries: Mapping[cs.SupportedLanguage, LanguageQueries],
         module_qn_to_file_path: dict[str, Path],
         class_inheritance: dict[str, list[str]],
         simple_name_lookup: SimpleNameLookup,

--- a/codebase_rag/parsers/js_ts/ingest.py
+++ b/codebase_rag/parsers/js_ts/ingest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -86,7 +87,7 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
         root_node: ASTNode,
         module_qn: str,
         language: cs.SupportedLanguage,
-        queries: dict[cs.SupportedLanguage, LanguageQueries],
+        queries: Mapping[cs.SupportedLanguage, LanguageQueries],
     ) -> None:
         if language not in cs.JS_TS_LANGUAGES:
             return
@@ -104,7 +105,7 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
         root_node: ASTNode,
         module_qn: str,
         language: cs.SupportedLanguage,
-        queries: dict[cs.SupportedLanguage, LanguageQueries],
+        queries: Mapping[cs.SupportedLanguage, LanguageQueries],
     ) -> None:
         lang_queries = queries[language]
 
@@ -159,7 +160,7 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
         root_node: ASTNode,
         module_qn: str,
         language: cs.SupportedLanguage,
-        queries: dict[cs.SupportedLanguage, LanguageQueries],
+        queries: Mapping[cs.SupportedLanguage, LanguageQueries],
     ) -> None:
         lang_queries = queries[language]
 
@@ -284,7 +285,7 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
         root_node: ASTNode,
         module_qn: str,
         language: cs.SupportedLanguage,
-        queries: dict[cs.SupportedLanguage, LanguageQueries],
+        queries: Mapping[cs.SupportedLanguage, LanguageQueries],
     ) -> None:
         language_obj = get_js_ts_language_obj(language, queries)
         if not language_obj:
@@ -449,7 +450,7 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
         root_node: ASTNode,
         module_qn: str,
         language: cs.SupportedLanguage,
-        queries: dict[cs.SupportedLanguage, LanguageQueries],
+        queries: Mapping[cs.SupportedLanguage, LanguageQueries],
     ) -> None:
         if language not in cs.JS_TS_LANGUAGES:
             return

--- a/codebase_rag/parsers/js_ts/module_system.py
+++ b/codebase_rag/parsers/js_ts/module_system.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import textwrap
 from abc import abstractmethod
+from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -69,7 +70,7 @@ class JsTsModuleSystemMixin:
         root_node: ASTNode,
         module_qn: str,
         language: cs.SupportedLanguage,
-        queries: dict[cs.SupportedLanguage, LanguageQueries],
+        queries: Mapping[cs.SupportedLanguage, LanguageQueries],
     ) -> None:
         language_obj = get_js_ts_language_obj(language, queries)
         if not language_obj:
@@ -297,7 +298,7 @@ class JsTsModuleSystemMixin:
         root_node: ASTNode,
         module_qn: str,
         language: cs.SupportedLanguage,
-        queries: dict[cs.SupportedLanguage, LanguageQueries],
+        queries: Mapping[cs.SupportedLanguage, LanguageQueries],
     ) -> None:
         if language not in cs.JS_TS_LANGUAGES:
             return
@@ -339,7 +340,7 @@ class JsTsModuleSystemMixin:
         root_node: ASTNode,
         module_qn: str,
         language: cs.SupportedLanguage,
-        queries: dict[cs.SupportedLanguage, LanguageQueries],
+        queries: Mapping[cs.SupportedLanguage, LanguageQueries],
     ) -> None:
         try:
             lang_query = queries[language][cs.QUERY_LANGUAGE]

--- a/codebase_rag/parsers/js_ts/type_inference.py
+++ b/codebase_rag/parsers/js_ts/type_inference.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING
 
 from loguru import logger
@@ -34,7 +34,7 @@ class JsTypeInferenceEngine:
         function_registry: FunctionRegistryTrieProtocol,
         project_name: str,
         find_method_ast_node_func: Callable[[str], ASTNode | None],
-        queries: dict[cs.SupportedLanguage, LanguageQueries] | None = None,
+        queries: Mapping[cs.SupportedLanguage, LanguageQueries] | None = None,
     ):
         self.import_processor = import_processor
         self.function_registry = function_registry

--- a/codebase_rag/parsers/js_ts/utils.py
+++ b/codebase_rag/parsers/js_ts/utils.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
 from tree_sitter import Language, Node, QueryCursor
@@ -11,7 +12,7 @@ if TYPE_CHECKING:
 
 def get_js_ts_language_obj(
     language: cs.SupportedLanguage,
-    queries: dict[cs.SupportedLanguage, "LanguageQueries"],
+    queries: Mapping[cs.SupportedLanguage, "LanguageQueries"],
 ) -> Language | None:
     if language not in cs.JS_TS_LANGUAGES:
         return None

--- a/codebase_rag/parsers/py/ast_analyzer.py
+++ b/codebase_rag/parsers/py/ast_analyzer.py
@@ -20,7 +20,7 @@ _PY_TRAVERSE_QUERY = (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Mapping
     from pathlib import Path
 
     from ..factory import ASTCacheProtocol
@@ -53,7 +53,7 @@ else:
 
 class PythonAstAnalyzerMixin(_AstBase):
     __slots__ = ()
-    queries: dict[cs.SupportedLanguage, LanguageQueries]
+    queries: Mapping[cs.SupportedLanguage, LanguageQueries]
     module_qn_to_file_path: dict[str, Path]
     ast_cache: ASTCacheProtocol
     function_registry: FunctionRegistryTrieProtocol

--- a/codebase_rag/parsers/py/type_inference.py
+++ b/codebase_rag/parsers/py/type_inference.py
@@ -19,7 +19,7 @@ from .expression_analyzer import PythonExpressionAnalyzerMixin
 from .variable_analyzer import PythonVariableAnalyzerMixin
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Mapping
 
     from ..factory import ASTCacheProtocol
     from ..js_ts import JsTypeInferenceEngine
@@ -56,7 +56,7 @@ class PythonTypeInferenceEngine(
         repo_path: Path,
         project_name: str,
         ast_cache: ASTCacheProtocol,
-        queries: dict[cs.SupportedLanguage, LanguageQueries],
+        queries: Mapping[cs.SupportedLanguage, LanguageQueries],
         module_qn_to_file_path: dict[str, Path],
         class_inheritance: dict[str, list[str]],
         simple_name_lookup: SimpleNameLookup,

--- a/codebase_rag/parsers/structure_processor.py
+++ b/codebase_rag/parsers/structure_processor.py
@@ -4,6 +4,7 @@ from loguru import logger
 
 from .. import constants as cs
 from .. import logs
+from ..language_spec import LANGUAGE_SPECS
 from ..services import IngestorProtocol
 from ..types_defs import LanguageQueries, NodeIdentifier
 from ..utils.path_utils import (
@@ -61,9 +62,11 @@ class StructureProcessor:
             ):
                 directories.add(path)
 
+        # (H) Package detection needs only the static language specs, never a
+        # (H) loaded grammar; iterating self.queries.values() would force every
+        # (H) lazy grammar to load (issue #68).
         package_indicators: set[str] = set()
-        for lang_queries in self.queries.values():
-            lang_config = lang_queries[cs.QUERY_CONFIG]
+        for lang_config in LANGUAGE_SPECS.values():
             package_indicators.update(lang_config.package_indicators)
 
         for root in sorted(directories):

--- a/codebase_rag/parsers/structure_processor.py
+++ b/codebase_rag/parsers/structure_processor.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from pathlib import Path
 
 from loguru import logger
@@ -30,7 +31,7 @@ class StructureProcessor:
         ingestor: IngestorProtocol,
         repo_path: Path,
         project_name: str,
-        queries: dict[cs.SupportedLanguage, LanguageQueries],
+        queries: Mapping[cs.SupportedLanguage, LanguageQueries],
         unignore_paths: frozenset[str] | None = None,
         exclude_paths: frozenset[str] | None = None,
     ):

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -66,7 +67,7 @@ class TypeInferenceEngine:
         repo_path: Path,
         project_name: str,
         ast_cache: "ASTCacheProtocol",
-        queries: dict[cs.SupportedLanguage, LanguageQueries],
+        queries: Mapping[cs.SupportedLanguage, LanguageQueries],
         module_qn_to_file_path: dict[str, Path],
         class_inheritance: dict[str, list[str]],
         simple_name_lookup: SimpleNameLookup,

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple
@@ -144,7 +144,7 @@ def _span_key(n: ASTNode) -> tuple[int, int]:
 def get_function_captures(
     root_node: ASTNode,
     language: cs.SupportedLanguage,
-    queries: dict[cs.SupportedLanguage, LanguageQueries],
+    queries: Mapping[cs.SupportedLanguage, LanguageQueries],
 ) -> FunctionCapturesResult | None:
     lang_queries = queries[language]
     lang_config = lang_queries[cs.QUERY_CONFIG]

--- a/codebase_rag/tests/test_file_editor.py
+++ b/codebase_rag/tests/test_file_editor.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
 
 import pytest
 from pydantic_ai import Tool
 
+from codebase_rag import constants as cs
 from codebase_rag.tools.file_editor import (
     EditResult,
     FileEditor,
@@ -70,8 +72,11 @@ class TestFileEditorInit:
         assert file_editor.dmp is not None
 
     def test_init_loads_parsers(self, file_editor: FileEditor) -> None:
+        # (H) parsers is a lazy Mapping view since #68; membership loads the
+        # (H) grammar on demand
         assert file_editor.parsers is not None
-        assert isinstance(file_editor.parsers, dict)
+        assert isinstance(file_editor.parsers, Mapping)
+        assert cs.SupportedLanguage.PYTHON in file_editor.parsers
 
 
 class TestEditResult:

--- a/codebase_rag/tests/test_lazy_parser_loading.py
+++ b/codebase_rag/tests/test_lazy_parser_loading.py
@@ -114,6 +114,36 @@ def test_concurrent_first_load_is_thread_safe(monkeypatch) -> None:
         COMBINED_FUNC_CLASS_QUERIES.update(saved)
 
 
+def test_mid_load_window_never_exposes_a_partial_language() -> None:
+    # (H) _process_language writes the parser BEFORE the queries; the ensure
+    # (H) fast path must not treat a present parser as a completed load, or a
+    # (H) concurrent queries[lang] in that window raises KeyError
+    # (H) (PR #802 review round 3).
+    from unittest.mock import MagicMock
+
+    from codebase_rag import parser_loader
+
+    store = parser_loader._LazyGrammarStore()
+    store._parser_data[cs.SupportedLanguage.PYTHON] = MagicMock()
+    assert cs.SupportedLanguage.PYTHON in store.queries
+    assert store.queries[cs.SupportedLanguage.PYTHON] is not None
+
+
+def test_failed_load_leaves_no_orphan_parser(monkeypatch) -> None:
+    # (H) a query-compilation failure after the parser insert must not leave a
+    # (H) parser entry without its queries twin
+    from codebase_rag import parser_loader
+
+    store = parser_loader._LazyGrammarStore()
+
+    def boom(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("query compile failed")
+
+    monkeypatch.setattr(parser_loader, "_create_language_queries", boom)
+    assert cs.SupportedLanguage.PYTHON not in store.parsers
+    assert store.parsers.get(cs.SupportedLanguage.PYTHON) is None
+
+
 def test_full_views_still_cover_every_available_language() -> None:
     # (H) a consumer that iterates the mapping gets the complete availability
     # (H) picture, not just what happens to be loaded already

--- a/codebase_rag/tests/test_lazy_parser_loading.py
+++ b/codebase_rag/tests/test_lazy_parser_loading.py
@@ -66,6 +66,45 @@ def test_unknown_language_stays_absent() -> None:
     assert queries.get("cobol") is None
 
 
+def test_concurrent_first_load_is_thread_safe(monkeypatch) -> None:
+    # (H) An MCP server can probe the same language from several request
+    # (H) threads at once; the mid-load window (attempted but not yet loaded)
+    # (H) must not make a later thread see the language as unavailable
+    # (H) (PR #802 review).
+    import threading
+    import time
+
+    from codebase_rag import parser_loader
+
+    _reset_parser_cache()
+    saved = dict(COMBINED_FUNC_CLASS_QUERIES)
+    COMBINED_FUNC_CLASS_QUERIES.clear()
+    real = parser_loader._process_language
+
+    def slow_process(lang, spec, parsers, queries):  # type: ignore[no-untyped-def]
+        time.sleep(0.05)
+        return real(lang, spec, parsers, queries)
+
+    monkeypatch.setattr(parser_loader, "_process_language", slow_process)
+    try:
+        parsers, _ = load_parsers()
+        results: list[bool] = []
+
+        def probe() -> None:
+            results.append(cs.SupportedLanguage.PYTHON in parsers)
+
+        threads = [threading.Thread(target=probe) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert results == [True] * 8, results
+    finally:
+        _reset_parser_cache()
+        COMBINED_FUNC_CLASS_QUERIES.clear()
+        COMBINED_FUNC_CLASS_QUERIES.update(saved)
+
+
 def test_full_views_still_cover_every_available_language() -> None:
     # (H) a consumer that iterates the mapping gets the complete availability
     # (H) picture, not just what happens to be loaded already

--- a/codebase_rag/tests/test_lazy_parser_loading.py
+++ b/codebase_rag/tests/test_lazy_parser_loading.py
@@ -1,0 +1,75 @@
+# (H) Issue #68: a repo in one language paid for all 14 grammars anyway --
+# (H) every load_parsers() call imported every grammar module and compiled
+# (H) every language's query set up front (and re-compiled them on EVERY
+# (H) call). Grammars must load on first use per language, once per process.
+from __future__ import annotations
+
+from codebase_rag import constants as cs
+from codebase_rag.parser_loader import (
+    COMBINED_FUNC_CLASS_QUERIES,
+    _reset_parser_cache,
+    load_parsers,
+)
+
+
+def test_load_parsers_defers_grammar_work() -> None:
+    _reset_parser_cache()
+    saved = dict(COMBINED_FUNC_CLASS_QUERIES)
+    COMBINED_FUNC_CLASS_QUERIES.clear()
+    try:
+        parsers, queries = load_parsers()
+        # (H) nothing is compiled until a language is actually used
+        assert cs.SupportedLanguage.PYTHON not in COMBINED_FUNC_CLASS_QUERIES
+        assert cs.SupportedLanguage.RUST not in COMBINED_FUNC_CLASS_QUERIES
+
+        lang_queries = queries[cs.SupportedLanguage.PYTHON]
+        assert lang_queries[cs.KEY_PARSER] is parsers[cs.SupportedLanguage.PYTHON]
+        assert COMBINED_FUNC_CLASS_QUERIES.get(cs.SupportedLanguage.PYTHON) is not None
+        # (H) touching python must not have loaded rust
+        assert cs.SupportedLanguage.RUST not in COMBINED_FUNC_CLASS_QUERIES
+    finally:
+        _reset_parser_cache()
+        COMBINED_FUNC_CLASS_QUERIES.clear()
+        COMBINED_FUNC_CLASS_QUERIES.update(saved)
+
+
+def test_membership_check_loads_on_demand() -> None:
+    _reset_parser_cache()
+    saved = dict(COMBINED_FUNC_CLASS_QUERIES)
+    COMBINED_FUNC_CLASS_QUERIES.clear()
+    try:
+        parsers, _ = load_parsers()
+        # (H) conftest-style availability probe (`lang in parsers`) must load
+        # (H) that one language and answer truthfully
+        assert cs.SupportedLanguage.RUST in parsers
+        assert COMBINED_FUNC_CLASS_QUERIES.get(cs.SupportedLanguage.RUST) is not None
+        assert cs.SupportedLanguage.PYTHON not in COMBINED_FUNC_CLASS_QUERIES
+    finally:
+        _reset_parser_cache()
+        COMBINED_FUNC_CLASS_QUERIES.clear()
+        COMBINED_FUNC_CLASS_QUERIES.update(saved)
+
+
+def test_loaded_grammars_are_shared_across_calls() -> None:
+    # (H) parsers must be process-cached: a second load_parsers() reuses the
+    # (H) same Parser objects instead of recompiling every query set
+    first_parsers, _ = load_parsers()
+    first = first_parsers[cs.SupportedLanguage.PYTHON]
+    second_parsers, _ = load_parsers()
+    assert second_parsers[cs.SupportedLanguage.PYTHON] is first
+
+
+def test_unknown_language_stays_absent() -> None:
+    parsers, queries = load_parsers()
+    assert "cobol" not in parsers
+    assert parsers.get("cobol") is None
+    assert queries.get("cobol") is None
+
+
+def test_full_views_still_cover_every_available_language() -> None:
+    # (H) a consumer that iterates the mapping gets the complete availability
+    # (H) picture, not just what happens to be loaded already
+    parsers, queries = load_parsers()
+    assert cs.SupportedLanguage.PYTHON in set(parsers)
+    assert len(parsers) == len(queries)
+    assert set(parsers.keys()) == set(queries.keys())

--- a/codebase_rag/tests/test_lazy_parser_loading.py
+++ b/codebase_rag/tests/test_lazy_parser_loading.py
@@ -74,14 +74,23 @@ def test_concurrent_first_load_is_thread_safe(monkeypatch) -> None:
     import threading
     import time
 
+    from tree_sitter import Parser
+
     from codebase_rag import parser_loader
+    from codebase_rag.language_spec import LanguageSpec
+    from codebase_rag.types_defs import LanguageQueries
 
     _reset_parser_cache()
     saved = dict(COMBINED_FUNC_CLASS_QUERIES)
     COMBINED_FUNC_CLASS_QUERIES.clear()
     real = parser_loader._process_language
 
-    def slow_process(lang, spec, parsers, queries):  # type: ignore[no-untyped-def]
+    def slow_process(
+        lang: cs.SupportedLanguage,
+        spec: LanguageSpec,
+        parsers: dict[cs.SupportedLanguage, Parser],
+        queries: dict[cs.SupportedLanguage, LanguageQueries],
+    ) -> bool:
         time.sleep(0.05)
         return real(lang, spec, parsers, queries)
 

--- a/evals/incremental.py
+++ b/evals/incremental.py
@@ -7,6 +7,7 @@
 # (H) state. The clean re-index is the oracle, so any divergence is a real
 # (H) incremental-update bug (e.g. dropped inbound CALLS, issue #532).
 import os
+from collections.abc import Mapping
 import shutil
 import tempfile
 from pathlib import Path
@@ -31,8 +32,8 @@ from .types_defs import DiffBucket, GraphState, LocationStats, ScoreResult, Scor
 
 console_target = Path(ec.INCREMENTAL_DEFAULT_TARGET)
 
-_Parsers = dict[cs.SupportedLanguage, Parser]
-_Queries = dict[cs.SupportedLanguage, LanguageQueries]
+_Parsers = Mapping[cs.SupportedLanguage, Parser]
+_Queries = Mapping[cs.SupportedLanguage, LanguageQueries]
 _EMPTY_LOCATION = LocationStats(0, 0, 0, 0.0, 0)
 
 

--- a/evals/incremental.py
+++ b/evals/incremental.py
@@ -7,9 +7,9 @@
 # (H) state. The clean re-index is the oracle, so any divergence is a real
 # (H) incremental-update bug (e.g. dropped inbound CALLS, issue #532).
 import os
-from collections.abc import Mapping
 import shutil
 import tempfile
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Annotated
 


### PR DESCRIPTION
## Problem

Issue #68: a repo in one language paid for all 14 grammars anyway. `load_parsers()` imported every grammar module and compiled every language's full query set (functions, classes, calls, imports, locals, highlights, plus two combined queries) eagerly, and it did all of that again on EVERY call: the CLI, the MCP server, the file editor, and each of the test suite's hundreds of `load_parsers()` calls each recompiled the world.

## Fix

- `load_parsers()` now returns two lazy views over a process-wide store. The views subclass `dict`, so every `dict[SupportedLanguage, ...]`-typed consumer signature keeps working: a missing key routes through `__missing__` and triggers a one-time grammar load for exactly that language; `__contains__` and `get` (which must be overridden because `dict.get` bypasses `__missing__` in C) probe on demand. Full-view operations (iteration, `len`, `keys`/`values`/`items`) load every spec'd language first, so no consumer ever observes a partial availability picture, and an all-languages probe that finds nothing still raises `NO_LANGUAGES`.
- Grammar module imports moved from import time of `parser_loader` into a per-language cached resolver, so merely importing the module no longer touches any `tree_sitter_*` package.
- `StructureProcessor` collected `package_indicators` by iterating `queries.values()`, which would have forced every grammar to load; it now reads the static `LANGUAGE_SPECS` directly (grammar-independent data). Side effect: package detection now covers all spec'd languages even when a grammar is unavailable, which is the more correct behavior.
- The store is a process singleton: repeated `load_parsers()` calls share loaded parsers instead of recompiling. `_reset_parser_cache()` exists as a test hook.

## Validation

- Startup: `load_parsers()` alone drops from roughly 0.6 to 0.9s (eager, main) to interpreter-startup cost (about 0.3 to 0.5s total wall, nothing loaded); with one language actually used it stays around 0.4s. Per-language cost is now paid only for languages present in the repo.
- Full suite: 5441 passed with only the two documented memgraph-integration environmental flakes. Suite wall time dropped from 8m46s to 4m39s on the same machine, since workers stopped recompiling all query sets per `load_parsers()` call.
- The two extra skips vs older runs are the Milvus optional-dependency skips introduced by #780, unrelated to this change.

## Tests

RED -> GREEN: `test_lazy_parser_loading.py` — deferral (nothing compiles until first use, touching python does not load rust), on-demand membership (`lang in parsers` loads that one language truthfully), process-level sharing across `load_parsers()` calls, unknown-language absence, and full-view completeness (iteration covers every available language).