### PR TITLE
feat(embedder): OpenAI-compatible embedding provider

### DIFF
--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -25,6 +25,11 @@ install `code-graph-rag[semantic,milvus]`, then set
 `CGR_VECTOR_STORE_BACKEND=milvus` and `MILVUS_URI=./.milvus_code_embeddings.db`
 before indexing.
 
+To compute embeddings on an OpenAI-compatible endpoint (OpenAI, Ollama, vLLM)
+instead of locally, set `CGR_EMBEDDING_PROVIDER=openai` with
+`OPENAI_EMBEDDING_BASE_URL` and `OPENAI_EMBEDDING_MODEL`; torch and
+transformers are then not required locally.
+
 ### Prerequisites
 
 - Python 3.12+

--- a/README.md
+++ b/README.md
@@ -202,6 +202,20 @@ cgr start
 For a self-hosted open-source Milvus endpoint, set `MILVUS_URI` to the endpoint,
 for example `http://localhost:19530`.
 
+Embeddings are computed locally with UniXcoder by default. To use an
+OpenAI-compatible embeddings endpoint instead (OpenAI, Ollama, vLLM, LM
+Studio), which drops the local torch/transformers requirement:
+
+```bash
+export CGR_EMBEDDING_PROVIDER=openai
+export OPENAI_EMBEDDING_BASE_URL="http://localhost:11434/v1"
+export OPENAI_EMBEDDING_MODEL="nomic-embed-text"
+export QDRANT_VECTOR_DIM=768  # must match the model's output dimension
+```
+
+`OPENAI_EMBEDDING_API_KEY` (falling back to `OPENAI_API_KEY`) is sent as a
+bearer token when set; local servers that need no key work without one.
+
 ### Local development install
 
 ```bash

--- a/codebase_rag/config.py
+++ b/codebase_rag/config.py
@@ -286,6 +286,15 @@ class AppConfig(BaseSettings):
     MILVUS_VECTOR_DIM: int = 768
     MILVUS_TOP_K: int = 5
     MILVUS_CONSISTENCY_LEVEL: str = "Strong"
+    EMBEDDING_PROVIDER: cs.EmbeddingProvider = Field(
+        cs.EmbeddingProvider.UNIXCODER, validation_alias="CGR_EMBEDDING_PROVIDER"
+    )
+    OPENAI_EMBEDDING_BASE_URL: str = cs.OPENAI_DEFAULT_ENDPOINT
+    OPENAI_EMBEDDING_MODEL: str = cs.OPENAI_EMBEDDING_DEFAULT_MODEL
+    OPENAI_EMBEDDING_API_KEY: str | None = None
+    OPENAI_EMBEDDING_DIMENSIONS: int | None = Field(default=None, gt=0)
+    OPENAI_EMBEDDING_BATCH_SIZE: int = Field(default=128, gt=0)
+    OPENAI_EMBEDDING_TIMEOUT: float = Field(default=60.0, gt=0)
     EMBEDDING_MAX_LENGTH: int = 512
     EMBEDDING_PROGRESS_INTERVAL: int = 10
     SKIP_EMBEDDINGS: bool = Field(False, validation_alias="CGR_SKIP_EMBEDDINGS")

--- a/codebase_rag/constants/providers.py
+++ b/codebase_rag/constants/providers.py
@@ -53,6 +53,14 @@ UNIXCODER_MODEL = "microsoft/unixcoder-base"
 EMBEDDING_DEFAULT_BATCH_SIZE = 64
 EMBEDDING_CACHE_FILENAME = ".embedding_cache.json"
 
+OPENAI_EMBEDDING_DEFAULT_MODEL = "text-embedding-3-small"
+OPENAI_EMBEDDINGS_PATH = "/embeddings"
+
+
+class EmbeddingProvider(StrEnum):
+    UNIXCODER = "unixcoder"
+    OPENAI = "openai"
+
 
 class EmbeddingDevice(StrEnum):
     CUDA = "cuda"

--- a/codebase_rag/embedder.py
+++ b/codebase_rag/embedder.py
@@ -2,16 +2,28 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 from functools import lru_cache
+from operator import itemgetter
 from pathlib import Path
 
+import httpx
 from loguru import logger
 
 from . import constants as cs
 from . import exceptions as ex
 from . import logs as ls
-from .config import settings
+from .config import API_KEY_INFO, settings
 from .utils.dependencies import has_torch, has_transformers
+
+
+def _cache_namespace() -> str:
+    # (H) Embeddings from different providers/models live in different vector
+    # (H) spaces (and dimensions); namespacing cache keys prevents a provider
+    # (H) or model switch from replaying stale vectors of the wrong space.
+    if settings.EMBEDDING_PROVIDER == cs.EmbeddingProvider.OPENAI:
+        return f"{cs.EmbeddingProvider.OPENAI}:{settings.OPENAI_EMBEDDING_MODEL}"
+    return f"{cs.EmbeddingProvider.UNIXCODER}:{cs.UNIXCODER_MODEL}"
 
 
 class EmbeddingCache:
@@ -23,7 +35,7 @@ class EmbeddingCache:
 
     @staticmethod
     def _content_hash(content: str) -> str:
-        return hashlib.sha256(content.encode()).hexdigest()
+        return hashlib.sha256(f"{_cache_namespace()}\x00{content}".encode()).hexdigest()
 
     def get(self, content: str) -> list[float] | None:
         return self._cache.get(self._content_hash(content))
@@ -91,6 +103,51 @@ def clear_embedding_cache() -> None:
         _embedding_cache = None
 
 
+def _openai_client() -> httpx.Client:
+    headers: dict[str, str] = {}
+    api_key = settings.OPENAI_EMBEDDING_API_KEY or os.environ.get(
+        API_KEY_INFO[cs.Provider.OPENAI]["env_var"]
+    )
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    return httpx.Client(
+        base_url=settings.OPENAI_EMBEDDING_BASE_URL,
+        headers=headers,
+        timeout=settings.OPENAI_EMBEDDING_TIMEOUT,
+    )
+
+
+def _openai_embed_batch(snippets: list[str]) -> list[list[float]]:
+    embeddings: list[list[float]] = []
+    batch_size = settings.OPENAI_EMBEDDING_BATCH_SIZE
+    with _openai_client() as client:
+        for start in range(0, len(snippets), batch_size):
+            batch = snippets[start : start + batch_size]
+            payload: dict[str, object] = {
+                "model": settings.OPENAI_EMBEDDING_MODEL,
+                "input": batch,
+            }
+            if settings.OPENAI_EMBEDDING_DIMENSIONS is not None:
+                payload["dimensions"] = settings.OPENAI_EMBEDDING_DIMENSIONS
+            response = client.post(cs.OPENAI_EMBEDDINGS_PATH, json=payload)
+            if response.status_code != cs.HTTP_OK:
+                raise RuntimeError(
+                    ex.OPENAI_EMBEDDING_HTTP_ERROR.format(
+                        status=response.status_code, body=response.text[:500]
+                    )
+                )
+            rows = response.json()["data"]
+            if len(rows) != len(batch):
+                raise RuntimeError(
+                    ex.OPENAI_EMBEDDING_COUNT_MISMATCH.format(
+                        got=len(rows), expected=len(batch)
+                    )
+                )
+            rows.sort(key=itemgetter("index"))
+            embeddings.extend(row["embedding"] for row in rows)
+    return embeddings
+
+
 if has_torch() and has_transformers():
     import numpy as np
     import torch
@@ -144,57 +201,31 @@ if has_torch() and has_transformers():
             model = model.to(device)
         return model
 
-    def embed_code(code: str, max_length: int | None = None) -> list[float]:
-        try:
-            cache = get_embedding_cache()
-            if (cached := cache.get(code)) is not None:
-                return cached
-
-            if max_length is None:
-                max_length = settings.EMBEDDING_MAX_LENGTH
-            model = get_model()
-            device = next(model.parameters()).device
-            tokens = model.tokenize([code], max_length=max_length)
-            tokens_tensor = torch.tensor(tokens).to(device)
-            with torch.no_grad():
-                _, sentence_embeddings = model(tokens_tensor)
-                embedding: NDArray[np.float32] = sentence_embeddings.cpu().numpy()
-            _sync_after_batch(device)
-            result: list[float] = embedding[0].tolist()
-
-            cache.put(code, result)
-            return result
-        except Exception:
-            logger.exception(ls.EMBEDDING_SNIPPET_FAILED, length=len(code))
-            raise
-
-    def embed_code_batch(
-        snippets: list[str],
-        max_length: int | None = None,
-        batch_size: int = cs.EMBEDDING_DEFAULT_BATCH_SIZE,
-    ) -> list[list[float]]:
-        if not snippets:
-            return []
-
+    def _unixcoder_embed_code(code: str, max_length: int | None) -> list[float]:
         if max_length is None:
             max_length = settings.EMBEDDING_MAX_LENGTH
+        model = get_model()
+        device = next(model.parameters()).device
+        tokens = model.tokenize([code], max_length=max_length)
+        tokens_tensor = torch.tensor(tokens).to(device)
+        with torch.no_grad():
+            _, sentence_embeddings = model(tokens_tensor)
+            embedding: NDArray[np.float32] = sentence_embeddings.cpu().numpy()
+        _sync_after_batch(device)
+        result: list[float] = embedding[0].tolist()
+        return result
 
-        cache = get_embedding_cache()
-        cached_results = cache.get_many(snippets)
-
-        if len(cached_results) == len(snippets):
-            logger.debug(ls.EMBEDDING_CACHE_HIT, count=len(snippets))
-            return [cached_results[i] for i in range(len(snippets))]
-
-        uncached_indices = [i for i in range(len(snippets)) if i not in cached_results]
-        uncached_snippets = [snippets[i] for i in uncached_indices]
-
+    def _unixcoder_embed_batch(
+        snippets: list[str], max_length: int | None, batch_size: int
+    ) -> list[list[float]]:
+        if max_length is None:
+            max_length = settings.EMBEDDING_MAX_LENGTH
         model = get_model()
         device = next(model.parameters()).device
 
         all_new_embeddings: list[list[float]] = []
-        for start in range(0, len(uncached_snippets), batch_size):
-            batch = uncached_snippets[start : start + batch_size]
+        for start in range(0, len(snippets), batch_size):
+            batch = snippets[start : start + batch_size]
             tokens_list = model.tokenize(batch, max_length=max_length, padding=True)
             tokens_tensor = torch.tensor(tokens_list).to(device)
             with torch.no_grad():
@@ -203,25 +234,66 @@ if has_torch() and has_transformers():
             _sync_after_batch(device)
             for row in batch_np:
                 all_new_embeddings.append(row.tolist())
-
-        cache.put_many(uncached_snippets, all_new_embeddings)
-
-        results: list[list[float]] = [[] for _ in snippets]
-        for i, emb in cached_results.items():
-            results[i] = emb
-        for idx, orig_i in enumerate(uncached_indices):
-            results[orig_i] = all_new_embeddings[idx]
-
-        return results
+        return all_new_embeddings
 
 else:
 
-    def embed_code(code: str, max_length: int | None = None) -> list[float]:
+    def _unixcoder_embed_code(code: str, max_length: int | None) -> list[float]:
         raise RuntimeError(ex.SEMANTIC_EXTRA)
 
-    def embed_code_batch(
-        snippets: list[str],
-        max_length: int | None = None,
-        batch_size: int = cs.EMBEDDING_DEFAULT_BATCH_SIZE,
+    def _unixcoder_embed_batch(
+        snippets: list[str], max_length: int | None, batch_size: int
     ) -> list[list[float]]:
         raise RuntimeError(ex.SEMANTIC_EXTRA)
+
+
+def embed_code(code: str, max_length: int | None = None) -> list[float]:
+    cache = get_embedding_cache()
+    if (cached := cache.get(code)) is not None:
+        return cached
+    try:
+        if settings.EMBEDDING_PROVIDER == cs.EmbeddingProvider.OPENAI:
+            result = _openai_embed_batch([code])[0]
+        else:
+            result = _unixcoder_embed_code(code, max_length)
+    except Exception:
+        logger.exception(ls.EMBEDDING_SNIPPET_FAILED, length=len(code))
+        raise
+    cache.put(code, result)
+    return result
+
+
+def embed_code_batch(
+    snippets: list[str],
+    max_length: int | None = None,
+    batch_size: int = cs.EMBEDDING_DEFAULT_BATCH_SIZE,
+) -> list[list[float]]:
+    if not snippets:
+        return []
+
+    cache = get_embedding_cache()
+    cached_results = cache.get_many(snippets)
+
+    if len(cached_results) == len(snippets):
+        logger.debug(ls.EMBEDDING_CACHE_HIT, count=len(snippets))
+        return [cached_results[i] for i in range(len(snippets))]
+
+    uncached_indices = [i for i in range(len(snippets)) if i not in cached_results]
+    uncached_snippets = [snippets[i] for i in uncached_indices]
+
+    if settings.EMBEDDING_PROVIDER == cs.EmbeddingProvider.OPENAI:
+        all_new_embeddings = _openai_embed_batch(uncached_snippets)
+    else:
+        all_new_embeddings = _unixcoder_embed_batch(
+            uncached_snippets, max_length, batch_size
+        )
+
+    cache.put_many(uncached_snippets, all_new_embeddings)
+
+    results: list[list[float]] = [[] for _ in snippets]
+    for i, emb in cached_results.items():
+        results[i] = emb
+    for idx, orig_i in enumerate(uncached_indices):
+        results[orig_i] = all_new_embeddings[idx]
+
+    return results

--- a/codebase_rag/embedder.py
+++ b/codebase_rag/embedder.py
@@ -4,7 +4,6 @@ import hashlib
 import json
 import os
 from functools import lru_cache
-from operator import itemgetter
 from pathlib import Path
 
 import httpx
@@ -22,7 +21,10 @@ def _cache_namespace() -> str:
     # (H) spaces (and dimensions); namespacing cache keys prevents a provider
     # (H) or model switch from replaying stale vectors of the wrong space.
     if settings.EMBEDDING_PROVIDER == cs.EmbeddingProvider.OPENAI:
-        return f"{cs.EmbeddingProvider.OPENAI}:{settings.OPENAI_EMBEDDING_MODEL}"
+        namespace = f"{cs.EmbeddingProvider.OPENAI}:{settings.OPENAI_EMBEDDING_MODEL}"
+        if settings.OPENAI_EMBEDDING_DIMENSIONS is not None:
+            namespace = f"{namespace}:{settings.OPENAI_EMBEDDING_DIMENSIONS}"
+        return namespace
     return f"{cs.EmbeddingProvider.UNIXCODER}:{cs.UNIXCODER_MODEL}"
 
 
@@ -136,16 +138,44 @@ def _openai_embed_batch(snippets: list[str]) -> list[list[float]]:
                         status=response.status_code, body=response.text[:500]
                     )
                 )
-            rows = response.json()["data"]
-            if len(rows) != len(batch):
-                raise RuntimeError(
-                    ex.OPENAI_EMBEDDING_COUNT_MISMATCH.format(
-                        got=len(rows), expected=len(batch)
-                    )
-                )
-            rows.sort(key=itemgetter("index"))
-            embeddings.extend(row["embedding"] for row in rows)
+            embeddings.extend(_parse_embedding_rows(response, len(batch)))
     return embeddings
+
+
+def _parse_embedding_rows(response: httpx.Response, expected: int) -> list[list[float]]:
+    try:
+        rows = response.json()["data"]
+    except (json.JSONDecodeError, KeyError, TypeError) as e:
+        raise RuntimeError(
+            ex.OPENAI_EMBEDDING_MALFORMED_RESPONSE.format(error=e)
+        ) from e
+    if not isinstance(rows, list):
+        raise RuntimeError(
+            ex.OPENAI_EMBEDDING_MALFORMED_RESPONSE.format(error="'data' is not a list")
+        )
+    if len(rows) != expected:
+        raise RuntimeError(
+            ex.OPENAI_EMBEDDING_COUNT_MISMATCH.format(got=len(rows), expected=expected)
+        )
+    # (H) Place each row at its declared index instead of sorting: a buggy
+    # (H) server emitting duplicate or out-of-range indices must fail loudly
+    # (H) rather than silently pair snippets with the wrong vectors.
+    placed: list[list[float] | None] = [None] * expected
+    for row in rows:
+        try:
+            index, embedding = row["index"], row["embedding"]
+        except (KeyError, TypeError) as e:
+            raise RuntimeError(
+                ex.OPENAI_EMBEDDING_MALFORMED_RESPONSE.format(error=e)
+            ) from e
+        if (
+            not isinstance(index, int)
+            or not 0 <= index < expected
+            or placed[index] is not None
+        ):
+            raise RuntimeError(ex.OPENAI_EMBEDDING_BAD_INDEX.format(index=index))
+        placed[index] = embedding
+    return [row for row in placed if row is not None]
 
 
 if has_torch() and has_transformers():

--- a/codebase_rag/exceptions.py
+++ b/codebase_rag/exceptions.py
@@ -40,6 +40,15 @@ UNKNOWN_PROVIDER = "Unknown provider '{provider}'. Available providers: {availab
 # (H) Dependency errors
 SEMANTIC_EXTRA = "Semantic search requires 'semantic' extra: uv sync --extra semantic"
 
+# (H) OpenAI-compatible embedding errors
+OPENAI_EMBEDDING_HTTP_ERROR = (
+    "OpenAI-compatible embedding request failed with status {status}: {body}"
+)
+OPENAI_EMBEDDING_COUNT_MISMATCH = (
+    "OpenAI-compatible embedding response returned {got} embeddings "
+    "for {expected} inputs"
+)
+
 # (H) Configuration errors
 PROVIDER_EMPTY = "Provider name cannot be empty in 'provider:model' format."
 MODEL_ID_EMPTY = "Model ID cannot be empty."

--- a/codebase_rag/exceptions.py
+++ b/codebase_rag/exceptions.py
@@ -48,6 +48,12 @@ OPENAI_EMBEDDING_COUNT_MISMATCH = (
     "OpenAI-compatible embedding response returned {got} embeddings "
     "for {expected} inputs"
 )
+OPENAI_EMBEDDING_MALFORMED_RESPONSE = (
+    "OpenAI-compatible embedding response is malformed: {error}"
+)
+OPENAI_EMBEDDING_BAD_INDEX = (
+    "OpenAI-compatible embedding response has an invalid or duplicate index: {index}"
+)
 
 # (H) Configuration errors
 PROVIDER_EMPTY = "Provider name cannot be empty in 'provider:model' format."

--- a/codebase_rag/tests/test_embedder_openai.py
+++ b/codebase_rag/tests/test_embedder_openai.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Generator
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.config import AppConfig, settings
+from codebase_rag.embedder import clear_embedding_cache
+
+
+class RecordingHandler:
+    # (H) MockTransport handler that answers like an OpenAI-compatible
+    # (H) /embeddings endpoint and records every request payload; rows are
+    # (H) returned in reverse index order so callers must sort by index.
+    def __init__(self, dim: int = 4, status_code: int = 200) -> None:
+        self.dim = dim
+        self.status_code = status_code
+        self.requests: list[dict[str, object]] = []
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        self.requests.append(payload)
+        if self.status_code != 200:
+            return httpx.Response(self.status_code, text="upstream boom")
+        rows = [
+            {"index": i, "embedding": [float(i + 1)] * self.dim}
+            for i in range(len(payload["input"]))
+        ]
+        rows.reverse()
+        return httpx.Response(200, json={"data": rows})
+
+
+def _client_for(handler: RecordingHandler) -> httpx.Client:
+    return httpx.Client(
+        transport=httpx.MockTransport(handler), base_url="http://embeddings.test/v1"
+    )
+
+
+@pytest.fixture
+def openai_provider(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: object
+) -> Generator[None, None, None]:
+    monkeypatch.setattr(settings, "EMBEDDING_PROVIDER", cs.EmbeddingProvider.OPENAI)
+    monkeypatch.setattr(settings, "QDRANT_DB_PATH", str(tmp_path))
+    monkeypatch.setattr(settings, "OPENAI_EMBEDDING_MODEL", "test-embed")
+    monkeypatch.setattr(settings, "OPENAI_EMBEDDING_API_KEY", None)
+    monkeypatch.setattr(settings, "OPENAI_EMBEDDING_DIMENSIONS", None)
+    monkeypatch.setattr(settings, "OPENAI_EMBEDDING_BATCH_SIZE", 128)
+    clear_embedding_cache()
+    yield
+    clear_embedding_cache()
+
+
+def test_default_embedding_provider_is_unixcoder() -> None:
+    assert (
+        AppConfig.model_fields["EMBEDDING_PROVIDER"].default
+        == cs.EmbeddingProvider.UNIXCODER
+    )
+
+
+def test_openai_batch_returns_embeddings_in_request_order(
+    openai_provider: None,
+) -> None:
+    from codebase_rag.embedder import embed_code_batch
+
+    handler = RecordingHandler()
+    with patch(
+        "codebase_rag.embedder._openai_client", side_effect=lambda: _client_for(handler)
+    ):
+        results = embed_code_batch(["def a(): pass", "def b(): pass"])
+
+    assert results == [[1.0] * 4, [2.0] * 4]
+    assert len(handler.requests) == 1
+    assert handler.requests[0]["model"] == "test-embed"
+    assert handler.requests[0]["input"] == ["def a(): pass", "def b(): pass"]
+
+
+def test_openai_batch_respects_batch_size(
+    openai_provider: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from codebase_rag.embedder import embed_code_batch
+
+    monkeypatch.setattr(settings, "OPENAI_EMBEDDING_BATCH_SIZE", 2)
+    handler = RecordingHandler()
+    with patch(
+        "codebase_rag.embedder._openai_client", side_effect=lambda: _client_for(handler)
+    ):
+        results = embed_code_batch([f"def f{i}(): pass" for i in range(5)])
+
+    assert len(results) == 5
+    assert [len(req["input"]) for req in handler.requests] == [2, 2, 1]
+
+
+def test_openai_single_embed_uses_endpoint(openai_provider: None) -> None:
+    from codebase_rag.embedder import embed_code
+
+    handler = RecordingHandler()
+    with patch(
+        "codebase_rag.embedder._openai_client", side_effect=lambda: _client_for(handler)
+    ):
+        result = embed_code("def solo(): pass")
+
+    assert result == [1.0] * 4
+    assert len(handler.requests) == 1
+
+
+def test_openai_embeddings_are_cached(openai_provider: None) -> None:
+    from codebase_rag.embedder import embed_code
+
+    handler = RecordingHandler()
+    with patch(
+        "codebase_rag.embedder._openai_client", side_effect=lambda: _client_for(handler)
+    ):
+        first = embed_code("def cached(): pass")
+        second = embed_code("def cached(): pass")
+
+    assert first == second
+    assert len(handler.requests) == 1
+
+
+def test_openai_cache_is_namespaced_by_model(
+    openai_provider: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from codebase_rag.embedder import embed_code
+
+    handler = RecordingHandler()
+    with patch(
+        "codebase_rag.embedder._openai_client", side_effect=lambda: _client_for(handler)
+    ):
+        embed_code("def ns(): pass")
+        monkeypatch.setattr(settings, "OPENAI_EMBEDDING_MODEL", "other-embed")
+        embed_code("def ns(): pass")
+
+    assert len(handler.requests) == 2
+
+
+def test_openai_dimensions_forwarded_when_set(
+    openai_provider: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from codebase_rag.embedder import embed_code
+
+    monkeypatch.setattr(settings, "OPENAI_EMBEDDING_DIMENSIONS", 4)
+    handler = RecordingHandler()
+    with patch(
+        "codebase_rag.embedder._openai_client", side_effect=lambda: _client_for(handler)
+    ):
+        embed_code("def dims(): pass")
+
+    assert handler.requests[0]["dimensions"] == 4
+
+
+def test_openai_dimensions_omitted_by_default(openai_provider: None) -> None:
+    from codebase_rag.embedder import embed_code
+
+    handler = RecordingHandler()
+    with patch(
+        "codebase_rag.embedder._openai_client", side_effect=lambda: _client_for(handler)
+    ):
+        embed_code("def nodims(): pass")
+
+    assert "dimensions" not in handler.requests[0]
+
+
+def test_openai_http_error_raises_runtime_error(openai_provider: None) -> None:
+    from codebase_rag.embedder import embed_code_batch
+
+    handler = RecordingHandler(status_code=500)
+    with patch(
+        "codebase_rag.embedder._openai_client", side_effect=lambda: _client_for(handler)
+    ):
+        with pytest.raises(RuntimeError, match="500"):
+            embed_code_batch(["def broken(): pass"])
+
+
+def test_openai_count_mismatch_raises_runtime_error(openai_provider: None) -> None:
+    from codebase_rag.embedder import embed_code_batch
+
+    def short_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"data": [{"index": 0, "embedding": [1.0]}]})
+
+    client = httpx.Client(
+        transport=httpx.MockTransport(short_handler), base_url="http://embeddings.test"
+    )
+    with patch("codebase_rag.embedder._openai_client", return_value=client):
+        with pytest.raises(RuntimeError, match="2"):
+            embed_code_batch(["def a(): pass", "def b(): pass"])
+
+
+def test_openai_client_sends_bearer_token_when_key_set(
+    openai_provider: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from codebase_rag.embedder import _openai_client
+
+    monkeypatch.setattr(settings, "OPENAI_EMBEDDING_API_KEY", "sk-test-123")
+    with _openai_client() as client:
+        assert client.headers["Authorization"] == "Bearer sk-test-123"
+
+
+def test_openai_client_falls_back_to_openai_api_key_env(
+    openai_provider: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from codebase_rag.embedder import _openai_client
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-env-456")
+    with _openai_client() as client:
+        assert client.headers["Authorization"] == "Bearer sk-env-456"
+
+
+def test_openai_client_omits_auth_header_without_key(
+    openai_provider: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from codebase_rag.embedder import _openai_client
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with _openai_client() as client:
+        assert "Authorization" not in client.headers
+
+
+def test_openai_client_uses_configured_base_url(
+    openai_provider: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from codebase_rag.embedder import _openai_client
+
+    monkeypatch.setattr(
+        settings, "OPENAI_EMBEDDING_BASE_URL", "http://localhost:11434/v1"
+    )
+    with _openai_client() as client:
+        assert str(client.base_url).startswith("http://localhost:11434/v1")
+
+
+def test_semantic_dependencies_do_not_require_torch_for_openai(
+    openai_provider: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from codebase_rag.utils import dependencies
+
+    monkeypatch.setattr(dependencies, "has_torch", lambda: False)
+    monkeypatch.setattr(dependencies, "has_transformers", lambda: False)
+    monkeypatch.setattr(dependencies, "has_qdrant_client", lambda: True)
+
+    assert dependencies.has_semantic_dependencies() is True
+
+
+def test_semantic_dependencies_still_require_torch_for_unixcoder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codebase_rag.utils import dependencies
+
+    monkeypatch.setattr(settings, "EMBEDDING_PROVIDER", cs.EmbeddingProvider.UNIXCODER)
+    monkeypatch.setattr(dependencies, "has_torch", lambda: False)
+    monkeypatch.setattr(dependencies, "has_qdrant_client", lambda: True)
+
+    assert dependencies.has_semantic_dependencies() is False
+
+
+def test_openai_batch_mixes_cache_hits_and_misses(openai_provider: None) -> None:
+    from codebase_rag.embedder import embed_code_batch
+
+    handler = RecordingHandler()
+    with patch(
+        "codebase_rag.embedder._openai_client", side_effect=lambda: _client_for(handler)
+    ):
+        first = embed_code_batch(["def a(): pass", "def b(): pass"])
+        second = embed_code_batch(["def a(): pass", "def c(): pass"])
+
+    assert second[0] == first[0]
+    assert handler.requests[1]["input"] == ["def c(): pass"]

--- a/codebase_rag/tests/test_embedder_openai.py
+++ b/codebase_rag/tests/test_embedder_openai.py
@@ -256,6 +256,100 @@ def test_semantic_dependencies_still_require_torch_for_unixcoder(
     assert dependencies.has_semantic_dependencies() is False
 
 
+def test_openai_cache_namespace_includes_dimensions(
+    openai_provider: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from codebase_rag.embedder import embed_code
+
+    handler = RecordingHandler()
+    with patch(
+        "codebase_rag.embedder._openai_client", side_effect=lambda: _client_for(handler)
+    ):
+        embed_code("def dimswitch(): pass")
+        monkeypatch.setattr(settings, "OPENAI_EMBEDDING_DIMENSIONS", 4)
+        embed_code("def dimswitch(): pass")
+
+    assert len(handler.requests) == 2
+
+
+def test_openai_request_url_joins_base_path(openai_provider: None) -> None:
+    from codebase_rag.embedder import embed_code
+
+    seen_urls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_urls.append(str(request.url))
+        return httpx.Response(200, json={"data": [{"index": 0, "embedding": [1.0]}]})
+
+    client = httpx.Client(
+        transport=httpx.MockTransport(handler), base_url="http://embeddings.test/v1"
+    )
+    with patch("codebase_rag.embedder._openai_client", return_value=client):
+        embed_code("def urljoin(): pass")
+
+    assert seen_urls == ["http://embeddings.test/v1/embeddings"]
+
+
+def test_openai_non_json_response_raises_runtime_error(openai_provider: None) -> None:
+    from codebase_rag.embedder import embed_code_batch
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text="<html>gateway error</html>")
+
+    client = httpx.Client(
+        transport=httpx.MockTransport(handler), base_url="http://embeddings.test"
+    )
+    with patch("codebase_rag.embedder._openai_client", return_value=client):
+        with pytest.raises(RuntimeError, match="malformed"):
+            embed_code_batch(["def a(): pass"])
+
+
+def test_openai_missing_data_key_raises_runtime_error(openai_provider: None) -> None:
+    from codebase_rag.embedder import embed_code_batch
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"error": "wrong shape"})
+
+    client = httpx.Client(
+        transport=httpx.MockTransport(handler), base_url="http://embeddings.test"
+    )
+    with patch("codebase_rag.embedder._openai_client", return_value=client):
+        with pytest.raises(RuntimeError, match="malformed"):
+            embed_code_batch(["def a(): pass"])
+
+
+def test_openai_duplicate_index_raises_runtime_error(openai_provider: None) -> None:
+    from codebase_rag.embedder import embed_code_batch
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        rows = [
+            {"index": 0, "embedding": [1.0]},
+            {"index": 0, "embedding": [2.0]},
+        ]
+        return httpx.Response(200, json={"data": rows})
+
+    client = httpx.Client(
+        transport=httpx.MockTransport(handler), base_url="http://embeddings.test"
+    )
+    with patch("codebase_rag.embedder._openai_client", return_value=client):
+        with pytest.raises(RuntimeError, match="index"):
+            embed_code_batch(["def a(): pass", "def b(): pass"])
+
+
+def test_openai_out_of_range_index_raises_runtime_error(openai_provider: None) -> None:
+    from codebase_rag.embedder import embed_code_batch
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"data": [{"index": 5, "embedding": [1.0]}]})
+
+    client = httpx.Client(
+        transport=httpx.MockTransport(handler), base_url="http://embeddings.test"
+    )
+    with patch("codebase_rag.embedder._openai_client", return_value=client):
+        with pytest.raises(RuntimeError, match="index"):
+            embed_code_batch(["def a(): pass"])
+
+
 def test_openai_batch_mixes_cache_hits_and_misses(openai_provider: None) -> None:
     from codebase_rag.embedder import embed_code_batch
 

--- a/codebase_rag/utils/dependencies.py
+++ b/codebase_rag/utils/dependencies.py
@@ -8,6 +8,7 @@ from codebase_rag.constants import (
     MODULE_QDRANT_CLIENT,
     MODULE_TORCH,
     MODULE_TRANSFORMERS,
+    EmbeddingProvider,
     VectorStoreBackend,
 )
 
@@ -48,6 +49,12 @@ def has_vector_store_dependencies() -> bool:
 
 
 def has_semantic_dependencies() -> bool:
+    from codebase_rag.config import settings
+
+    # (H) An OpenAI-compatible endpoint computes embeddings server-side, so
+    # (H) only the vector store dependency is needed locally.
+    if settings.EMBEDDING_PROVIDER == EmbeddingProvider.OPENAI:
+        return has_vector_store_dependencies()
     return has_vector_store_dependencies() and has_torch() and has_transformers()
 
 

--- a/docs/guide/interactive-querying.md
+++ b/docs/guide/interactive-querying.md
@@ -66,6 +66,10 @@ vectors, install the `milvus` extra (`code-graph-rag[semantic,milvus]`), then
 set `CGR_VECTOR_STORE_BACKEND=milvus` and `MILVUS_URI` to a local `.db` file
 before indexing.
 
+To compute embeddings on an OpenAI-compatible endpoint (OpenAI, Ollama, vLLM)
+instead of locally, set `CGR_EMBEDDING_PROVIDER=openai`; see
+[Semantic Search](../sdk/semantic-search.md) for configuration.
+
 ## Agentic Tools
 
 The interactive agent has access to these tools:

--- a/docs/sdk/semantic-search.md
+++ b/docs/sdk/semantic-search.md
@@ -26,6 +26,37 @@ export MILVUS_URI="./.milvus_code_embeddings.db"
 You can also point `MILVUS_URI` at a self-hosted open-source Milvus endpoint,
 such as `http://localhost:19530`.
 
+## OpenAI-Compatible Embedding Providers
+
+By default embeddings are computed locally with UniXcoder (requires the
+`semantic` extra's torch/transformers). Alternatively, any OpenAI-compatible
+embeddings endpoint (OpenAI, Ollama, vLLM, LM Studio, and others) can compute
+them server-side, so torch and transformers are not needed locally; only the
+vector store dependency (`qdrant-client` or the `milvus` extra) is required:
+
+```bash
+pip install 'code-graph-rag' qdrant-client
+export CGR_EMBEDDING_PROVIDER=openai
+export OPENAI_EMBEDDING_BASE_URL="http://localhost:11434/v1"  # default: https://api.openai.com/v1
+export OPENAI_EMBEDDING_MODEL="nomic-embed-text"              # default: text-embedding-3-small
+export OPENAI_EMBEDDING_API_KEY="sk-..."                      # optional; falls back to OPENAI_API_KEY
+```
+
+Additional settings:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `OPENAI_EMBEDDING_DIMENSIONS` | unset | Forwarded as the `dimensions` request parameter for models that support truncated output |
+| `OPENAI_EMBEDDING_BATCH_SIZE` | `128` | Snippets per HTTP request |
+| `OPENAI_EMBEDDING_TIMEOUT` | `60` | Request timeout in seconds |
+
+The vector store dimension must match the embedding model's output. UniXcoder
+produces 768-dimensional vectors (the default), while `text-embedding-3-small`
+produces 1536; set `QDRANT_VECTOR_DIM` (or `MILVUS_VECTOR_DIM`) accordingly, or
+use `OPENAI_EMBEDDING_DIMENSIONS` to request 768-dimensional output. Cached
+embeddings are keyed per provider and model, so switching models never replays
+vectors from another embedding space.
+
 ## Usage
 
 ### Generate Code Embeddings

--- a/uv.lock
+++ b/uv.lock
@@ -540,7 +540,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.383"
+version = "0.0.385"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #267.

Adds an OpenAI-compatible embedding provider so embeddings can be computed by any server implementing the OpenAI embeddings API (OpenAI, Ollama, vLLM, LM Studio), removing the local torch/transformers requirement for semantic search.

## Configuration

- `CGR_EMBEDDING_PROVIDER=openai` selects the provider (`unixcoder` remains the default; fully backward compatible).
- `OPENAI_EMBEDDING_BASE_URL` (default `https://api.openai.com/v1`), `OPENAI_EMBEDDING_MODEL` (default `text-embedding-3-small`).
- `OPENAI_EMBEDDING_API_KEY` sent as a bearer token when set, falling back to the `OPENAI_API_KEY` env var; local servers needing no key work without one.
- `OPENAI_EMBEDDING_DIMENSIONS` forwarded as the `dimensions` request parameter, `OPENAI_EMBEDDING_BATCH_SIZE` (default 128), `OPENAI_EMBEDDING_TIMEOUT` (default 60s).

## Implementation

- Provider dispatch in `embedder.py`; the UniXcoder torch path is unchanged and stays behind the existing dependency gate. The HTTP client is httpx, already a guaranteed transitive dependency, so no new packages.
- Batch requests chunk by the configured batch size, validate the returned count, and sort rows by `index` so out-of-order responses cannot scramble embeddings. Non-200 responses raise with status and body excerpt.
- The embedding cache is now namespaced by provider and model, so switching models never replays cached vectors from a different embedding space.
- `has_semantic_dependencies()` requires only the vector store dependency under the openai provider since embeddings are computed server-side.

## Tests

Strict RED then GREEN: commit one adds 17 failing specs (request shape, batching, ordering, caching, namespacing, auth header, base URL, error paths, dependency gating) driven through `httpx.MockTransport`; commit two implements. Full suite: 5182 passed, 5 skipped.

## Docs

README, PYPI_README, `docs/sdk/semantic-search.md` (full configuration table plus vector-dimension guidance), and `docs/guide/interactive-querying.md`.