### PR TITLE
feat(csharp): Roslyn facts for projects outside the solution

### DIFF
--- a/codebase_rag/parsers/csharp_frontend/frontend.py
+++ b/codebase_rag/parsers/csharp_frontend/frontend.py
@@ -13,12 +13,14 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import subprocess
 import time
 from pathlib import Path
 from typing import NamedTuple
 
+from defusedxml import ElementTree
 from loguru import logger
 
 from ... import constants as cs
@@ -133,6 +135,55 @@ def _project_candidates(repo_path: Path) -> list[Path]:
 def find_csharp_project(repo_path: Path) -> Path | None:
     candidates = _project_candidates(repo_path)
     return candidates[0] if candidates else None
+
+
+# (H) Matches the project path (second quoted field) of a classic .sln entry:
+# (H) Project("{type-guid}") = "Name", "rel\path.csproj", "{project-guid}".
+_SLN_PROJECT_RE = re.compile(r'^Project\("[^"]*"\)\s*=\s*"[^"]*",\s*"([^"]+)"', re.M)
+
+
+def _solution_member_projects(project: Path) -> set[Path]:
+    # (H) The set of .csproj files a solution covers, resolved absolute. A bare
+    # (H) .csproj input covers only itself.
+    suffix = project.suffix.lower()
+    base = project.parent
+    if suffix == ".sln":
+        text = project.read_text(encoding="utf-8", errors="replace")
+        rels = [
+            m.replace("\\", "/")
+            for m in _SLN_PROJECT_RE.findall(text)
+            if m.lower().endswith(".csproj")
+        ]
+        return {(base / rel).resolve() for rel in rels}
+    if suffix == ".slnx":
+        try:
+            tree = ElementTree.parse(project)
+        except (ElementTree.ParseError, OSError):
+            return set()
+        return {
+            (base / path.replace("\\", "/")).resolve()
+            for element in tree.iter("Project")
+            if (path := element.get("Path")) is not None
+            and path.lower().endswith(".csproj")
+        }
+    return {project.resolve()}
+
+
+def uncovered_csharp_projects(repo_path: Path, project: Path) -> list[Path]:
+    # (H) Repos routinely keep bench/samples projects OUTSIDE the solution
+    # (H) (Polly's bench/), so a solution-scoped workspace emits no facts for
+    # (H) their files and every call in them degrades to tree-sitter
+    # (H) heuristics. These uncovered projects load additively.
+    members = _solution_member_projects(project)
+
+    def not_ignored(p: Path) -> bool:
+        return not any(part in _IGNORE_DIRS for part in p.relative_to(repo_path).parts)
+
+    return sorted(
+        p
+        for p in repo_path.rglob("*.csproj")
+        if not_ignored(p) and p.resolve() not in members
+    )
 
 
 def _cache_dir() -> Path:
@@ -318,9 +369,12 @@ def run_csharp_frontend(repo_path: Path) -> CSharpSemanticFacts:
         logger.warning(ls.CSHARP_FRONTEND_BUILD_FAILED)
         return _empty_facts()
     _restore(dotnet, project)
+    uncovered = uncovered_csharp_projects(repo_path, project)
+    for extra in uncovered:
+        _restore(dotnet, extra)
     try:
         proc = subprocess.run(
-            [dotnet, str(dll), str(repo_path), str(project)],
+            [dotnet, str(dll), str(repo_path), str(project), *map(str, uncovered)],
             capture_output=True,
             text=True,
             check=False,

--- a/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
@@ -462,15 +462,11 @@ public static class Frontend
                 Console.Error.WriteLine($"[LoadProjects] {input}: {ex.Message}");
             }
         }
+        var loaded = LoadedProjectPaths(workspace);
         foreach (var extra in extraProjects)
         {
             // A supplemental project may already sit in the workspace as a
             // project-reference of an earlier load; re-opening it would throw.
-            var loaded = workspace.CurrentSolution.Projects
-                .Select(p => p.FilePath)
-                .OfType<string>()
-                .Select(Path.GetFullPath)
-                .ToHashSet(StringComparer.OrdinalIgnoreCase);
             if (loaded.Contains(extra))
             {
                 continue;
@@ -478,6 +474,9 @@ public static class Frontend
             try
             {
                 await workspace.OpenProjectAsync(extra);
+                // One open can pull in project-references, so refresh from the
+                // workspace rather than adding only the opened path.
+                loaded.UnionWith(LoadedProjectPaths(workspace));
             }
             catch (Exception ex)
             {
@@ -491,6 +490,13 @@ public static class Frontend
         // filtered per file by IsFirstParty.
         return workspace.CurrentSolution.Projects.ToList();
     }
+
+    private static HashSet<string> LoadedProjectPaths(MSBuildWorkspace workspace) =>
+        workspace.CurrentSolution.Projects
+            .Select(p => p.FilePath)
+            .OfType<string>()
+            .Select(Path.GetFullPath)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
     private static string? FindProjectOrSolution(string rootFull)
     {

--- a/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
@@ -52,7 +52,11 @@ public static class Frontend
         var projects = await LoadProjectsAsync(workspace, projectOrSolution, rootFull, extraProjects);
         Console.Error.WriteLine($"[projects] {projects.Count} loaded, {failures} workspace failure(s)");
 
-        var collector = new FactCollector(rootFull, IgnoredDirs());
+        var firstPartyAssemblies = projects
+            .Select(p => p.AssemblyName)
+            .Where(n => !string.IsNullOrEmpty(n))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var collector = new FactCollector(rootFull, IgnoredDirs(), firstPartyAssemblies);
         foreach (var project in projects)
         {
             // GetCompilationAsync runs source generators, so symbols that resolve
@@ -96,10 +100,13 @@ public static class Frontend
         private readonly HashSet<(string, int, int, string)> _seenExternals = new();
         private readonly HashSet<(string, int, int, string, int, string)> _seenQueries = new();
 
-        public FactCollector(string rootFull, HashSet<string> ignoredDirs)
+        private readonly HashSet<string> _firstPartyAssemblies;
+
+        public FactCollector(string rootFull, HashSet<string> ignoredDirs, HashSet<string> firstPartyAssemblies)
         {
             _rootFull = rootFull;
             _ignoredDirs = ignoredDirs;
+            _firstPartyAssemblies = firstPartyAssemblies;
         }
 
         public bool IsFirstParty(string path)
@@ -215,7 +222,8 @@ public static class Frontend
             var pos = location.GetLineSpan().StartLinePosition;
             var col = ByteCol(location, pos);
             var name = nameToken.ValueText;
-            if (FirstPartyDecl(DeclaredMethod(symbol)) is not { } target)
+            var declared = DeclaredMethod(symbol);
+            if (FirstPartyDecl(declared) is not { } target)
             {
                 // A successfully resolved symbol with no first-party declaration
                 // lives in metadata: the call provably leaves the repo, and the
@@ -224,6 +232,15 @@ public static class Frontend
                 // A site that is first-party under another target framework's
                 // compilation still wins: the Python lookup consults the
                 // positive call facts before the external set.
+                // EXCEPT metadata from an assembly this repo builds: projects
+                // consuming the repo's own published package (Polly's samples)
+                // resolve first-party code to metadata, and marking those
+                // sites external would suppress the fallback edges that
+                // correctly bind them to the first-party source.
+                if (_firstPartyAssemblies.Contains(declared.ContainingAssembly?.Name ?? ""))
+                {
+                    return;
+                }
                 if (_seenExternals.Add((rel, pos.Line + 1, col, name)))
                 {
                     _externals.Add(new ExternalFact(rel, pos.Line + 1, col, name));

--- a/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
@@ -24,6 +24,10 @@ public static class Frontend
 
         var rootFull = Path.GetFullPath(args[0]);
         var projectOrSolution = args.Length > 1 ? Path.GetFullPath(args[1]) : null;
+        // Projects the solution does not cover (bench/samples outside the .sln);
+        // the Python side discovers and restores them, this side loads them
+        // additively so their files get facts too.
+        var extraProjects = args.Skip(2).Select(Path.GetFullPath).ToList();
 
         var debug = Environment.GetEnvironmentVariable("CGR_FE_DEBUG") == "1";
         using var workspace = MSBuildWorkspace.Create();
@@ -45,7 +49,7 @@ public static class Frontend
             }
         });
 
-        var projects = await LoadProjectsAsync(workspace, projectOrSolution, rootFull);
+        var projects = await LoadProjectsAsync(workspace, projectOrSolution, rootFull, extraProjects);
         Console.Error.WriteLine($"[projects] {projects.Count} loaded, {failures} workspace failure(s)");
 
         var collector = new FactCollector(rootFull, IgnoredDirs());
@@ -416,31 +420,59 @@ public static class Frontend
     }
 
     private static async Task<List<Project>> LoadProjectsAsync(
-        MSBuildWorkspace workspace, string? projectOrSolution, string rootFull)
+        MSBuildWorkspace workspace, string? projectOrSolution, string rootFull,
+        IReadOnlyList<string> extraProjects)
     {
         var input = projectOrSolution ?? FindProjectOrSolution(rootFull);
-        if (input is null)
+        if (input is not null)
         {
-            return new List<Project>();
-        }
-        try
-        {
-            if (input.EndsWith(".sln", StringComparison.OrdinalIgnoreCase)
-                || input.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase))
+            try
             {
-                var solution = await workspace.OpenSolutionAsync(input);
-                return solution.Projects.ToList();
+                if (input.EndsWith(".sln", StringComparison.OrdinalIgnoreCase)
+                    || input.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase))
+                {
+                    await workspace.OpenSolutionAsync(input);
+                }
+                else
+                {
+                    await workspace.OpenProjectAsync(input);
+                }
             }
-            var project = await workspace.OpenProjectAsync(input);
-            return new List<Project> { project };
+            catch (Exception ex)
+            {
+                // Always on stderr: a load failure otherwise degrades the whole run
+                // to zero facts with no visible cause.
+                Console.Error.WriteLine($"[LoadProjects] {input}: {ex.Message}");
+            }
         }
-        catch (Exception ex)
+        foreach (var extra in extraProjects)
         {
-            // Always on stderr: a load failure otherwise degrades the whole run
-            // to zero facts with no visible cause.
-            Console.Error.WriteLine($"[LoadProjects] {input}: {ex.Message}");
-            return new List<Project>();
+            // A supplemental project may already sit in the workspace as a
+            // project-reference of an earlier load; re-opening it would throw.
+            var loaded = workspace.CurrentSolution.Projects
+                .Select(p => p.FilePath)
+                .OfType<string>()
+                .Select(Path.GetFullPath)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            if (loaded.Contains(extra))
+            {
+                continue;
+            }
+            try
+            {
+                await workspace.OpenProjectAsync(extra);
+            }
+            catch (Exception ex)
+            {
+                // Per-project degradation: one broken sample must not cost the
+                // facts of the solution or the other supplemental projects.
+                Console.Error.WriteLine($"[LoadProjects] {extra}: {ex.Message}");
+            }
         }
+        // CurrentSolution accumulates every load (solution members, supplemental
+        // projects, and their project-references); non-first-party trees are
+        // filtered per file by IsFirstParty.
+        return workspace.CurrentSolution.Projects.ToList();
     }
 
     private static string? FindProjectOrSolution(string rootFull)

--- a/codebase_rag/tests/test_csharp_out_of_solution_facts.py
+++ b/codebase_rag/tests/test_csharp_out_of_solution_facts.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_SLN = """Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Main", "Main\\Main.csproj", "{11111111-1111-1111-1111-111111111111}"
+EndProject
+Global
+EndGlobal
+"""
+
+_SLNX = """<Solution>
+  <Project Path="Main/Main.csproj" />
+</Solution>
+"""
+
+_CSPROJ = """<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+</Project>
+"""
+
+_MAIN_SRC = """namespace Main;
+public class Lib
+{
+    public void Go() { Step(); }
+    public void Step() { }
+}
+"""
+
+_SAMPLE_SRC = """namespace Samples;
+public class Demo
+{
+    public void Run() { Helper("x"); }
+    public void Helper(string s) { }
+    public void Helper(int i) { }
+}
+"""
+
+
+def _solution_repo(root: Path, solution_name: str, solution_body: str) -> None:
+    (root / "Main").mkdir(parents=True)
+    (root / "Samples").mkdir()
+    (root / solution_name).write_text(solution_body, encoding="utf-8")
+    (root / "Main" / "Main.csproj").write_text(_CSPROJ, encoding="utf-8")
+    (root / "Main" / "Lib.cs").write_text(_MAIN_SRC, encoding="utf-8")
+    (root / "Samples" / "Samples.csproj").write_text(_CSPROJ, encoding="utf-8")
+    (root / "Samples" / "Sample.cs").write_text(_SAMPLE_SRC, encoding="utf-8")
+
+
+def test_sln_member_projects_parsed(temp_repo: Path) -> None:
+    from codebase_rag.parsers.csharp_frontend.frontend import _solution_member_projects
+
+    _solution_repo(temp_repo, "Repo.sln", _SLN)
+    members = _solution_member_projects(temp_repo / "Repo.sln")
+
+    assert members == {(temp_repo / "Main" / "Main.csproj").resolve()}
+
+
+def test_slnx_member_projects_parsed(temp_repo: Path) -> None:
+    from codebase_rag.parsers.csharp_frontend.frontend import _solution_member_projects
+
+    _solution_repo(temp_repo, "Repo.slnx", _SLNX)
+    members = _solution_member_projects(temp_repo / "Repo.slnx")
+
+    assert members == {(temp_repo / "Main" / "Main.csproj").resolve()}
+
+
+def test_uncovered_projects_found_for_solution(temp_repo: Path) -> None:
+    from codebase_rag.parsers.csharp_frontend.frontend import uncovered_csharp_projects
+
+    _solution_repo(temp_repo, "Repo.sln", _SLN)
+    uncovered = uncovered_csharp_projects(temp_repo, temp_repo / "Repo.sln")
+
+    assert uncovered == [temp_repo / "Samples" / "Samples.csproj"]
+
+
+def test_uncovered_projects_found_for_single_csproj(temp_repo: Path) -> None:
+    from codebase_rag.parsers.csharp_frontend.frontend import uncovered_csharp_projects
+
+    _solution_repo(temp_repo, "Repo.sln", _SLN)
+    (temp_repo / "Repo.sln").unlink()
+    uncovered = uncovered_csharp_projects(temp_repo, temp_repo / "Main" / "Main.csproj")
+
+    assert uncovered == [temp_repo / "Samples" / "Samples.csproj"]
+
+
+def test_uncovered_projects_skips_ignored_dirs(temp_repo: Path) -> None:
+    from codebase_rag.parsers.csharp_frontend.frontend import uncovered_csharp_projects
+
+    _solution_repo(temp_repo, "Repo.sln", _SLN)
+    (temp_repo / "Samples" / "obj").mkdir()
+    (temp_repo / "Samples" / "obj" / "Generated.csproj").write_text(
+        _CSPROJ, encoding="utf-8"
+    )
+    uncovered = uncovered_csharp_projects(temp_repo, temp_repo / "Repo.sln")
+
+    assert uncovered == [temp_repo / "Samples" / "Samples.csproj"]
+
+
+def test_roslyn_facts_cover_projects_outside_the_solution(temp_repo: Path) -> None:
+    # (H) Polly-shaped layout: the solution lists only Main, while Samples sits
+    # (H) beside it un-referenced (bench/samples projects). Facts must still
+    # (H) cover Samples' files or every call in them degrades to tree-sitter
+    # (H) heuristics (the #794 recall tail).
+    from codebase_rag.parsers.csharp_frontend import (
+        csharp_frontend_available,
+        run_csharp_frontend,
+    )
+
+    if not csharp_frontend_available():
+        pytest.skip("dotnet not available")
+
+    _solution_repo(temp_repo, "Repo.sln", _SLN)
+    facts = run_csharp_frontend(temp_repo)
+    if not facts.call_sites:
+        pytest.skip("Roslyn frontend could not build/restore in this environment")
+
+    main_calls = [k for k in facts.call_sites if k[0] == "Main/Lib.cs"]
+    sample_calls = [k for k in facts.call_sites if k[0] == "Samples/Sample.cs"]
+    assert main_calls, facts.call_sites
+    assert any(k[3] == "Helper" for k in sample_calls), facts.call_sites

--- a/codebase_rag/tests/test_csharp_out_of_solution_facts.py
+++ b/codebase_rag/tests/test_csharp_out_of_solution_facts.py
@@ -102,6 +102,75 @@ def test_uncovered_projects_skips_ignored_dirs(temp_repo: Path) -> None:
     assert uncovered == [temp_repo / "Samples" / "Samples.csproj"]
 
 
+_CONSUMER_CSPROJ = """<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Main">
+      <HintPath>../Main/bin/Debug/net8.0/Main.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+</Project>
+"""
+
+_CONSUMER_SRC = """namespace Samples;
+public class Consumer
+{
+    public void Use()
+    {
+        new Main.Lib().Go();
+        System.Console.WriteLine("done");
+    }
+}
+"""
+
+
+def test_first_party_assembly_reference_is_not_marked_external(
+    temp_repo: Path,
+) -> None:
+    # (H) Polly-shaped backfire: samples consume the repo's own published
+    # (H) package, so their calls into first-party code resolve to METADATA.
+    # (H) The assembly is still built from this repo, so marking those sites
+    # (H) external would suppress the tree-sitter fallback edges that
+    # (H) correctly bind them to the first-party source (the 3272->3238
+    # (H) regression). Metadata from a first-party-named assembly must emit
+    # (H) neither a positive fact nor an external fact.
+    import subprocess
+
+    from codebase_rag.parsers.csharp_frontend import (
+        csharp_frontend_available,
+        run_csharp_frontend,
+    )
+
+    if not csharp_frontend_available():
+        pytest.skip("dotnet not available")
+
+    _solution_repo(temp_repo, "Repo.sln", _SLN)
+    (temp_repo / "Samples" / "Samples.csproj").write_text(
+        _CONSUMER_CSPROJ, encoding="utf-8"
+    )
+    (temp_repo / "Samples" / "Sample.cs").write_text(_CONSUMER_SRC, encoding="utf-8")
+    build = subprocess.run(
+        ["dotnet", "build", str(temp_repo / "Main" / "Main.csproj")],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=300,
+    )
+    if build.returncode != 0:
+        pytest.skip(f"dotnet build unavailable in this environment: {build.stderr}")
+
+    facts = run_csharp_frontend(temp_repo)
+    if not facts.call_sites:
+        pytest.skip("Roslyn frontend could not build/restore in this environment")
+
+    sample_externals = [k for k in facts.external_sites if k[0] == "Samples/Sample.cs"]
+    assert not any(k[3] == "Go" for k in sample_externals), facts.external_sites
+    # (H) A genuinely external call in the same file stays an external fact.
+    assert any(k[3] == "WriteLine" for k in sample_externals), facts.external_sites
+
+
 def test_roslyn_facts_cover_projects_outside_the_solution(temp_repo: Path) -> None:
     # (H) Polly-shaped layout: the solution lists only Main, while Samples sits
     # (H) beside it un-referenced (bench/samples projects). Facts must still

--- a/uv.lock
+++ b/uv.lock
@@ -540,7 +540,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.385"
+version = "0.0.388"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes the deferred observation from #794: bench/sample projects that sit outside the repo's .sln/.slnx got no Roslyn facts, so every call in their files degraded to tree-sitter heuristics.

## What changed

- The Python runner parses the solution's member list (classic .sln via regex, .slnx via defusedxml), discovers `.csproj` files the solution does not cover (ignore-dirs excluded), restores each, and passes them to the tool as extra arguments (`_solution_member_projects`, `uncovered_csharp_projects`).
- The Roslyn tool opens the supplemental projects additively into the same MSBuildWorkspace, skipping paths already present (a supplemental project can arrive earlier as a project-reference), degrading per project on load failure, and returning `CurrentSolution.Projects` so every loaded compilation contributes facts. Existing cross-compilation dedup applies unchanged.
- Backfire fix found by measurement: sample projects consume the repo's own published package (Polly's samples `PackageReference Polly.Core`), so their calls into first-party code resolve to metadata, and marking those sites external suppressed 35 previously-correct fallback edges. The tool now skips external facts when the metadata assembly's name matches an assembly the loaded projects build; the tree-sitter fallback keeps binding those sites, while genuinely external calls (ASP.NET, BCL) stay suppressed.

## Measurement (same Polly snapshot, before/after on this machine)

| run | tp | fp | fn | precision | recall |
|-----|----|----|----|-----------|--------|
| main | 3272 | 0 | 167 | 1.0000 | 0.9514 |
| this PR | 3271 | 0 | 168 | 1.0000 | 0.9511 |

The headline is neutral by design of the name-based oracle: sample-to-Polly calls were already credited via the name trie. The composition improved: +1 genuine edge (a sample calling its own first-party `AddTiming` extension now binds via facts), and the 2 newly-missing edges are oracle artifacts where the graph is now semantically right (`Query.TryGetValue` is ASP.NET Core's and `builder.Build()` is `WebApplicationBuilder.Build`; both are correctly external now, but the oracle name-matches them to Polly's own `TryGetValue`/`Build`). Sample files additionally gain exact-overload positive facts for their internal calls.

## Tests

Strict RED then GREEN, two rounds in commit history: 4d954e7e adds failing specs for membership parsing (.sln and .slnx), uncovered discovery (solution, single-csproj, ignored dirs), and an e2e where a project outside the .sln must produce call facts; 25ec254b adds the failing e2e reproducing the metadata backfire (a supplemental project referencing a first-party-built DLL must produce neither a positive nor an external fact for that call, while `Console.WriteLine` in the same file stays external). Full suite: 5210 passed.