### PR TITLE
feat(dart): receiver type inference for member calls

### DIFF
--- a/codebase_rag/constants/ast_dart.py
+++ b/codebase_rag/constants/ast_dart.py
@@ -33,6 +33,18 @@ DART_CALL_QUERY = """
 # (H) (declared) or an inferred_type plus a construction initializer; a
 # (H) parameter is formal_parameter(type_identifier, identifier).
 TS_DART_CLASS_BODY = "class_body"
+TS_DART_FUNCTION_EXPRESSION = "function_expression"
+TS_DART_LOCAL_FUNCTION_DECLARATION = "local_function_declaration"
+
+# (H) Nodes opening their OWN variable scope: the local-type walk must not
+# (H) descend into them, or a nested function's same-named local would
+# (H) conflict-drop the outer binding from the outer caller's map.
+DART_NESTED_SCOPE_NODE_TYPES = frozenset(
+    {
+        TS_DART_FUNCTION_EXPRESSION,
+        TS_DART_LOCAL_FUNCTION_DECLARATION,
+    }
+)
 TS_DART_INITIALIZED_IDENTIFIER_LIST = "initialized_identifier_list"
 TS_DART_INITIALIZED_IDENTIFIER = "initialized_identifier"
 TS_DART_INITIALIZED_VARIABLE_DEFINITION = "initialized_variable_definition"

--- a/codebase_rag/constants/ast_dart.py
+++ b/codebase_rag/constants/ast_dart.py
@@ -27,6 +27,17 @@ DART_CALL_QUERY = """
 (cascade_section (argument_part)) @call
 """
 
+# (H) Declaration shapes for receiver typing: a class field is
+# (H) declaration(type_identifier, initialized_identifier_list); a body local
+# (H) is initialized_variable_definition with either a leading type_identifier
+# (H) (declared) or an inferred_type plus a construction initializer; a
+# (H) parameter is formal_parameter(type_identifier, identifier).
+TS_DART_CLASS_BODY = "class_body"
+TS_DART_INITIALIZED_IDENTIFIER_LIST = "initialized_identifier_list"
+TS_DART_INITIALIZED_IDENTIFIER = "initialized_identifier"
+TS_DART_INITIALIZED_VARIABLE_DEFINITION = "initialized_variable_definition"
+TS_DART_FORMAL_PARAMETER = "formal_parameter"
+
 # (H) Type/class-like declarations (all captured as @class)
 TS_DART_CLASS_DEFINITION = "class_definition"
 TS_DART_MIXIN_DECLARATION = "mixin_declaration"

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -85,6 +85,7 @@ _TYPED_LANGUAGES = frozenset(
         cs.SupportedLanguage.GO,
         cs.SupportedLanguage.CPP,
         cs.SupportedLanguage.RUST,
+        cs.SupportedLanguage.DART,
     }
 )
 

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -734,13 +734,18 @@ class CallResolver:
                 self._simple_resolution_cache[cache_key] = None
             return None
 
-        # (H) A JS/TS member call on an UNTYPED receiver (`view.render(...)` where
-        # (H) `view` is a param constructed in the caller) targets a MEMBER: the
-        # (H) bare-name trie would rebind it to a free function of the same name
-        # (H) (express's application.render), a false edge that also kills the real
-        # (H) prototype method. Bind the UNIQUE member-like candidate (parent qn
-        # (H) itself registered) or drop.
-        if language in cs.JS_TS_LANGUAGES and cs.SEPARATOR_DOT in call_name:
+        # (H) A JS/TS/Dart member call on an UNTYPED receiver (`view.render(...)`
+        # (H) where `view` is a param constructed in the caller) targets a
+        # (H) MEMBER: the bare-name trie would rebind it to an arbitrary
+        # (H) same-named candidate (express's application.render; a Dart
+        # (H) `h.greet()` picking whichever class's greet is closest), a false
+        # (H) edge that also hides the real method from dead-code. Bind the
+        # (H) UNIQUE member-like candidate (parent qn itself registered) or
+        # (H) drop. Typed Dart receivers never reach this: the local-type path
+        # (H) above already bound them.
+        if (
+            language in cs.JS_TS_LANGUAGES or language == cs.SupportedLanguage.DART
+        ) and cs.SEPARATOR_DOT in call_name:
             result = self._resolve_js_member_call_unique(call_name, module_qn)
             if use_cache:
                 self._simple_resolution_cache[cache_key] = result

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -25,6 +25,7 @@ from ...types_defs import (
 )
 from ...utils.path_utils import cached_relative_path, cached_resolve_posix
 from ..cpp import CppTypeInferenceEngine
+from ..dart.type_inference import DartTypeInferenceEngine
 from ..cpp import utils as cpp_utils
 from ..csharp import utils as csharp_utils
 from ..go import GoTypeInferenceEngine
@@ -886,6 +887,14 @@ class ClassIngestMixin:
                 self.class_field_types[class_qn] = field_types
             if guard_inner := rust_engine.build_field_guard_inner_map(class_node):
                 self.class_field_guard_inner[class_qn] = guard_inner
+        elif language == cs.SupportedLanguage.DART:
+            # (H) Record Dart field types (`Greeter buddy;`) so a field-typed
+            # (H) receiver (`buddy.greet()`, `this.buddy.hail()`) resolves
+            # (H) through the field's declared type.
+            if field_types := DartTypeInferenceEngine().build_field_type_map(
+                class_node
+            ):
+                self.class_field_types[class_qn] = field_types
         elif language == cs.SupportedLanguage.CSHARP:
             # (H) Record C# field/property types so a field-typed receiver
             # (H) (`_w.M()`, `this._w.M()`) resolves, including a field inherited

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -25,9 +25,9 @@ from ...types_defs import (
 )
 from ...utils.path_utils import cached_relative_path, cached_resolve_posix
 from ..cpp import CppTypeInferenceEngine
-from ..dart.type_inference import DartTypeInferenceEngine
 from ..cpp import utils as cpp_utils
 from ..csharp import utils as csharp_utils
+from ..dart.type_inference import DartTypeInferenceEngine
 from ..go import GoTypeInferenceEngine
 from ..java import utils as java_utils
 from ..py import external_stdlib_base_method_names, resolve_class_name

--- a/codebase_rag/parsers/dart/type_inference.py
+++ b/codebase_rag/parsers/dart/type_inference.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from tree_sitter import Node
+
+from ... import constants as cs
+from .utils import dart_body_node
+
+
+class DartTypeInferenceEngine:
+    # (H) Dart receiver typing (analog of the C#/Java engines): type function
+    # (H) parameters and body locals so the generic local-type resolution can
+    # (H) bind `g.greet()` to the receiver's class method instead of leaving
+    # (H) it to the suffix trie's arbitrary pick among same-named candidates.
+
+    def build_local_variable_type_map(self, caller_node: Node) -> dict[str, str]:
+        # (H) caller_node is the SIGNATURE (the grammar splits the body off as
+        # (H) a sibling): parameters come from the signature's parameter list,
+        # (H) locals from the sibling body. Conflicting redefinitions of one
+        # (H) name (sibling blocks reusing a binding) drop, mirroring the C#
+        # (H) engine's conservative rule.
+        types: dict[str, str] = {}
+        conflicts: set[str] = set()
+        self._collect_parameters(caller_node, types, conflicts)
+        body = dart_body_node(caller_node)
+        if body is not None:
+            self._collect_locals(body, types, conflicts)
+        return types
+
+    def build_field_type_map(self, class_node: Node) -> dict[str, str]:
+        # (H) `String name;` in a class_body is declaration(type_identifier,
+        # (H) initialized_identifier_list); record {name: String} so a
+        # (H) field-typed receiver (`buddy.greet()`, `this.buddy.hail()`)
+        # (H) resolves through the field's declared type.
+        fields: dict[str, str] = {}
+        for child in class_node.named_children:
+            if child.type != cs.TS_DART_CLASS_BODY:
+                continue
+            for member in child.named_children:
+                if member.type != cs.TS_DART_DECLARATION:
+                    continue
+                self._record_field(member, fields)
+        return fields
+
+    @staticmethod
+    def _record_field(member: Node, fields: dict[str, str]) -> None:
+        type_name: str | None = None
+        for part in member.named_children:
+            if part.type == cs.TS_DART_TYPE_IDENTIFIER and part.text:
+                type_name = part.text.decode(cs.ENCODING_UTF8)
+            elif part.type == cs.TS_DART_INITIALIZED_IDENTIFIER_LIST and type_name:
+                for entry in part.named_children:
+                    if entry.type != cs.TS_DART_INITIALIZED_IDENTIFIER:
+                        continue
+                    for ident in entry.named_children:
+                        if ident.type == cs.TS_DART_IDENTIFIER and ident.text:
+                            fields[ident.text.decode(cs.ENCODING_UTF8)] = type_name
+                        break
+
+    def _collect_parameters(
+        self, caller_node: Node, types: dict[str, str], conflicts: set[str]
+    ) -> None:
+        stack = [caller_node]
+        while stack:
+            node = stack.pop()
+            if node.type == cs.TS_DART_FORMAL_PARAMETER:
+                self._record_parameter(node, types, conflicts)
+                continue
+            stack.extend(node.named_children)
+
+    @staticmethod
+    def _record_parameter(
+        node: Node, types: dict[str, str], conflicts: set[str]
+    ) -> None:
+        type_name: str | None = None
+        for part in node.named_children:
+            if part.type == cs.TS_DART_TYPE_IDENTIFIER and part.text:
+                type_name = part.text.decode(cs.ENCODING_UTF8)
+            elif (
+                part.type == cs.TS_DART_IDENTIFIER and part.text and type_name
+            ):
+                _record(
+                    part.text.decode(cs.ENCODING_UTF8), type_name, types, conflicts
+                )
+
+    def _collect_locals(
+        self, body: Node, types: dict[str, str], conflicts: set[str]
+    ) -> None:
+        stack = list(body.named_children)
+        while stack:
+            node = stack.pop()
+            if node.type == cs.TS_DART_INITIALIZED_VARIABLE_DEFINITION:
+                self._record_local(node, types, conflicts)
+                continue
+            stack.extend(node.named_children)
+
+    @staticmethod
+    def _record_local(
+        node: Node, types: dict[str, str], conflicts: set[str]
+    ) -> None:
+        # (H) Two typable shapes: a DECLARED type (`Greeter t = ...` puts a
+        # (H) type_identifier before the name) and a CONSTRUCTION initializer
+        # (H) (`var b = Greeter('x')` / `final n = Greeter.named('y')`: the
+        # (H) initializer's base identifier, UpperCamelCase by Dart
+        # (H) convention, names the constructed class; a lowercase base is an
+        # (H) ordinary call whose return type is unknown, so the local stays
+        # (H) untyped).
+        declared_type: str | None = None
+        var_name: str | None = None
+        init_base: str | None = None
+        has_argument_selector = False
+        for part in node.named_children:
+            if part.type == cs.TS_DART_TYPE_IDENTIFIER and part.text:
+                declared_type = part.text.decode(cs.ENCODING_UTF8)
+            elif part.type == cs.TS_DART_IDENTIFIER and part.text:
+                if var_name is None:
+                    var_name = part.text.decode(cs.ENCODING_UTF8)
+                elif init_base is None:
+                    init_base = part.text.decode(cs.ENCODING_UTF8)
+            elif part.type == cs.TS_DART_SELECTOR and any(
+                inner.type == cs.TS_DART_ARGUMENT_PART
+                for inner in part.named_children
+            ):
+                has_argument_selector = True
+        if var_name is None:
+            return
+        if declared_type is not None:
+            _record(var_name, declared_type, types, conflicts)
+            return
+        if (
+            init_base is not None
+            and has_argument_selector
+            and init_base[:1].isupper()
+        ):
+            _record(var_name, init_base, types, conflicts)
+
+
+def _record(
+    name: str, type_name: str, types: dict[str, str], conflicts: set[str]
+) -> None:
+    if name in conflicts:
+        return
+    if name in types and types[name] != type_name:
+        conflicts.add(name)
+        del types[name]
+        return
+    types[name] = type_name

--- a/codebase_rag/parsers/dart/type_inference.py
+++ b/codebase_rag/parsers/dart/type_inference.py
@@ -43,18 +43,12 @@ class DartTypeInferenceEngine:
 
     @staticmethod
     def _record_field(member: Node, fields: dict[str, str]) -> None:
-        type_name: str | None = None
+        type_name = _declared_type_name(member)
+        if type_name is None:
+            return
         for part in member.named_children:
-            if part.type == cs.TS_DART_TYPE_IDENTIFIER and part.text:
-                type_name = part.text.decode(cs.ENCODING_UTF8)
-            elif part.type == cs.TS_DART_INITIALIZED_IDENTIFIER_LIST and type_name:
-                for entry in part.named_children:
-                    if entry.type != cs.TS_DART_INITIALIZED_IDENTIFIER:
-                        continue
-                    for ident in entry.named_children:
-                        if ident.type == cs.TS_DART_IDENTIFIER and ident.text:
-                            fields[ident.text.decode(cs.ENCODING_UTF8)] = type_name
-                        break
+            if part.type == cs.TS_DART_INITIALIZED_IDENTIFIER_LIST:
+                _record_field_names(part, type_name, fields)
 
     def _collect_parameters(
         self, caller_node: Node, types: dict[str, str], conflicts: set[str]
@@ -102,15 +96,32 @@ class DartTypeInferenceEngine:
         # (H) (`var a = X(), b = Y();`) nests as an initialized_identifier
         # (H) carrying the same name-plus-initializer shape, with a declared
         # (H) type (if any) shared by every binding.
-        declared_type: str | None = None
-        for part in node.named_children:
-            if part.type == cs.TS_DART_TYPE_IDENTIFIER and part.text:
-                declared_type = part.text.decode(cs.ENCODING_UTF8)
-                break
+        declared_type = _declared_type_name(node)
         _record_binding(node.named_children, declared_type, types, conflicts)
         for part in node.named_children:
             if part.type == cs.TS_DART_INITIALIZED_IDENTIFIER:
                 _record_binding(part.named_children, declared_type, types, conflicts)
+
+
+def _declared_type_name(node: Node) -> str | None:
+    for part in node.named_children:
+        if part.type == cs.TS_DART_TYPE_IDENTIFIER and part.text:
+            return part.text.decode(cs.ENCODING_UTF8)
+    return None
+
+
+def _record_field_names(
+    id_list: Node, type_name: str, fields: dict[str, str]
+) -> None:
+    # (H) only an entry's FIRST identifier is the field name; later
+    # (H) identifiers belong to its initializer
+    for entry in id_list.named_children:
+        if entry.type != cs.TS_DART_INITIALIZED_IDENTIFIER:
+            continue
+        for ident in entry.named_children:
+            if ident.type == cs.TS_DART_IDENTIFIER and ident.text:
+                fields[ident.text.decode(cs.ENCODING_UTF8)] = type_name
+            break
 
 
 def _record_binding(

--- a/codebase_rag/parsers/dart/type_inference.py
+++ b/codebase_rag/parsers/dart/type_inference.py
@@ -75,12 +75,8 @@ class DartTypeInferenceEngine:
         for part in node.named_children:
             if part.type == cs.TS_DART_TYPE_IDENTIFIER and part.text:
                 type_name = part.text.decode(cs.ENCODING_UTF8)
-            elif (
-                part.type == cs.TS_DART_IDENTIFIER and part.text and type_name
-            ):
-                _record(
-                    part.text.decode(cs.ENCODING_UTF8), type_name, types, conflicts
-                )
+            elif part.type == cs.TS_DART_IDENTIFIER and part.text and type_name:
+                _record(part.text.decode(cs.ENCODING_UTF8), type_name, types, conflicts)
 
     def _collect_locals(
         self, body: Node, types: dict[str, str], conflicts: set[str]
@@ -94,9 +90,7 @@ class DartTypeInferenceEngine:
             stack.extend(node.named_children)
 
     @staticmethod
-    def _record_local(
-        node: Node, types: dict[str, str], conflicts: set[str]
-    ) -> None:
+    def _record_local(node: Node, types: dict[str, str], conflicts: set[str]) -> None:
         # (H) Two typable shapes: a DECLARED type (`Greeter t = ...` puts a
         # (H) type_identifier before the name) and a CONSTRUCTION initializer
         # (H) (`var b = Greeter('x')` / `final n = Greeter.named('y')`: the
@@ -117,8 +111,7 @@ class DartTypeInferenceEngine:
                 elif init_base is None:
                     init_base = part.text.decode(cs.ENCODING_UTF8)
             elif part.type == cs.TS_DART_SELECTOR and any(
-                inner.type == cs.TS_DART_ARGUMENT_PART
-                for inner in part.named_children
+                inner.type == cs.TS_DART_ARGUMENT_PART for inner in part.named_children
             ):
                 has_argument_selector = True
         if var_name is None:
@@ -126,11 +119,7 @@ class DartTypeInferenceEngine:
         if declared_type is not None:
             _record(var_name, declared_type, types, conflicts)
             return
-        if (
-            init_base is not None
-            and has_argument_selector
-            and init_base[:1].isupper()
-        ):
+        if init_base is not None and has_argument_selector and init_base[:1].isupper():
             _record(var_name, init_base, types, conflicts)
 
 

--- a/codebase_rag/parsers/dart/type_inference.py
+++ b/codebase_rag/parsers/dart/type_inference.py
@@ -75,13 +75,37 @@ class DartTypeInferenceEngine:
     def _collect_locals(
         self, body: Node, types: dict[str, str], conflicts: set[str]
     ) -> None:
+        # (H) Two passes with precedence (PR #806 review): the caller's OWN
+        # (H) scope first, with full conflict semantics; then nested
+        # (H) function/lambda scopes, fill-in only. Nested locals must still
+        # (H) be collected -- a Dart test body is a lambda argument
+        # (H) (`test('x', () { var p = ArgParser(); p.addFlag(...); })`) whose
+        # (H) calls flat-attribute to the enclosing caller -- but an inner
+        # (H) same-named local must never conflict-drop or overwrite the
+        # (H) outer binding.
+        nested: list[Node] = []
         stack = list(body.named_children)
         while stack:
             node = stack.pop()
+            if node.type in cs.DART_NESTED_SCOPE_NODE_TYPES:
+                nested.append(node)
+                continue
             if node.type == cs.TS_DART_INITIALIZED_VARIABLE_DEFINITION:
                 self._record_local(node, types, conflicts)
                 continue
             stack.extend(node.named_children)
+        fill_in: dict[str, str] = {}
+        fill_conflicts: set[str] = set(conflicts)
+        stack = nested
+        while stack:
+            node = stack.pop()
+            if node.type == cs.TS_DART_INITIALIZED_VARIABLE_DEFINITION:
+                self._record_local(node, fill_in, fill_conflicts)
+                continue
+            stack.extend(node.named_children)
+        for name, type_name in fill_in.items():
+            if name not in types and name not in conflicts:
+                types[name] = type_name
 
     @staticmethod
     def _record_local(node: Node, types: dict[str, str], conflicts: set[str]) -> None:

--- a/codebase_rag/parsers/dart/type_inference.py
+++ b/codebase_rag/parsers/dart/type_inference.py
@@ -110,9 +110,7 @@ def _declared_type_name(node: Node) -> str | None:
     return None
 
 
-def _record_field_names(
-    id_list: Node, type_name: str, fields: dict[str, str]
-) -> None:
+def _record_field_names(id_list: Node, type_name: str, fields: dict[str, str]) -> None:
     # (H) only an entry's FIRST identifier is the field name; later
     # (H) identifiers belong to its initializer
     for entry in id_list.named_children:

--- a/codebase_rag/parsers/dart/type_inference.py
+++ b/codebase_rag/parsers/dart/type_inference.py
@@ -110,9 +110,7 @@ class DartTypeInferenceEngine:
         _record_binding(node.named_children, declared_type, types, conflicts)
         for part in node.named_children:
             if part.type == cs.TS_DART_INITIALIZED_IDENTIFIER:
-                _record_binding(
-                    part.named_children, declared_type, types, conflicts
-                )
+                _record_binding(part.named_children, declared_type, types, conflicts)
 
 
 def _record_binding(

--- a/codebase_rag/parsers/dart/type_inference.py
+++ b/codebase_rag/parsers/dart/type_inference.py
@@ -97,30 +97,53 @@ class DartTypeInferenceEngine:
         # (H) initializer's base identifier, UpperCamelCase by Dart
         # (H) convention, names the constructed class; a lowercase base is an
         # (H) ordinary call whose return type is unknown, so the local stays
-        # (H) untyped).
+        # (H) untyped). The FIRST variable's name and initializer are direct
+        # (H) children; each ADDITIONAL variable of a multi-declaration
+        # (H) (`var a = X(), b = Y();`) nests as an initialized_identifier
+        # (H) carrying the same name-plus-initializer shape, with a declared
+        # (H) type (if any) shared by every binding.
         declared_type: str | None = None
-        var_name: str | None = None
-        init_base: str | None = None
-        has_argument_selector = False
         for part in node.named_children:
             if part.type == cs.TS_DART_TYPE_IDENTIFIER and part.text:
                 declared_type = part.text.decode(cs.ENCODING_UTF8)
-            elif part.type == cs.TS_DART_IDENTIFIER and part.text:
-                if var_name is None:
-                    var_name = part.text.decode(cs.ENCODING_UTF8)
-                elif init_base is None:
-                    init_base = part.text.decode(cs.ENCODING_UTF8)
-            elif part.type == cs.TS_DART_SELECTOR and any(
-                inner.type == cs.TS_DART_ARGUMENT_PART for inner in part.named_children
-            ):
-                has_argument_selector = True
-        if var_name is None:
-            return
-        if declared_type is not None:
-            _record(var_name, declared_type, types, conflicts)
-            return
-        if init_base is not None and has_argument_selector and init_base[:1].isupper():
-            _record(var_name, init_base, types, conflicts)
+                break
+        _record_binding(node.named_children, declared_type, types, conflicts)
+        for part in node.named_children:
+            if part.type == cs.TS_DART_INITIALIZED_IDENTIFIER:
+                _record_binding(
+                    part.named_children, declared_type, types, conflicts
+                )
+
+
+def _record_binding(
+    parts: list[Node],
+    declared_type: str | None,
+    types: dict[str, str],
+    conflicts: set[str],
+) -> None:
+    # (H) One name-plus-initializer run: the first identifier is the variable,
+    # (H) a second identifier followed by an argument selector is a
+    # (H) construction base typing the variable when no declared type applies.
+    var_name: str | None = None
+    init_base: str | None = None
+    has_argument_selector = False
+    for part in parts:
+        if part.type == cs.TS_DART_IDENTIFIER and part.text:
+            if var_name is None:
+                var_name = part.text.decode(cs.ENCODING_UTF8)
+            elif init_base is None:
+                init_base = part.text.decode(cs.ENCODING_UTF8)
+        elif part.type == cs.TS_DART_SELECTOR and any(
+            inner.type == cs.TS_DART_ARGUMENT_PART for inner in part.named_children
+        ):
+            has_argument_selector = True
+    if var_name is None:
+        return
+    if declared_type is not None:
+        _record(var_name, declared_type, types, conflicts)
+        return
+    if init_base is not None and has_argument_selector and init_base[:1].isupper():
+        _record(var_name, init_base, types, conflicts)
 
 
 def _record(

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -14,6 +14,7 @@ from ..types_defs import (
 )
 from .cpp import CppTypeInferenceEngine
 from .csharp.type_inference import CSharpTypeInferenceEngine
+from .dart.type_inference import DartTypeInferenceEngine
 from .csharp_frontend import CallSiteKey, CSharpCallSite
 from .go import GoTypeInferenceEngine
 from .import_processor import ImportProcessor
@@ -58,6 +59,7 @@ class TypeInferenceEngine:
         "_go_type_inference",
         "_rust_type_inference",
         "_cpp_type_inference",
+        "_dart_type_inference",
     )
 
     def __init__(
@@ -157,6 +159,7 @@ class TypeInferenceEngine:
 
         self._java_type_inference: JavaTypeInferenceEngine | None = None
         self._csharp_type_inference: CSharpTypeInferenceEngine | None = None
+        self._dart_type_inference: DartTypeInferenceEngine | None = None
         self._lua_type_inference: LuaTypeInferenceEngine | None = None
         self._js_type_inference: JsTypeInferenceEngine | None = None
         self._python_type_inference: PythonTypeInferenceEngine | None = None
@@ -224,6 +227,12 @@ class TypeInferenceEngine:
                 function_locations=self.function_locations,
             )
         return self._csharp_type_inference
+
+    @property
+    def dart_type_inference(self) -> DartTypeInferenceEngine:
+        if self._dart_type_inference is None:
+            self._dart_type_inference = DartTypeInferenceEngine()
+        return self._dart_type_inference
 
     @property
     def lua_type_inference(self) -> LuaTypeInferenceEngine:
@@ -516,6 +525,10 @@ class TypeInferenceEngine:
                 )
             case cs.SupportedLanguage.CSHARP:
                 return self.csharp_type_inference.build_variable_type_map(caller_node)
+            case cs.SupportedLanguage.DART:
+                return self.dart_type_inference.build_local_variable_type_map(
+                    caller_node
+                )
             case cs.SupportedLanguage.LUA:
                 return self.lua_type_inference.build_local_variable_type_map(
                     caller_node, module_qn

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -14,8 +14,8 @@ from ..types_defs import (
 )
 from .cpp import CppTypeInferenceEngine
 from .csharp.type_inference import CSharpTypeInferenceEngine
-from .dart.type_inference import DartTypeInferenceEngine
 from .csharp_frontend import CallSiteKey, CSharpCallSite
+from .dart.type_inference import DartTypeInferenceEngine
 from .go import GoTypeInferenceEngine
 from .import_processor import ImportProcessor
 from .java import JavaTypeInferenceEngine

--- a/codebase_rag/tests/test_dart_type_inference.py
+++ b/codebase_rag/tests/test_dart_type_inference.py
@@ -1,0 +1,161 @@
+# (H) Dart receiver typing (follow-up to PR #804): a member call on a typed
+# (H) receiver (`g.greet()` where g is a declared local, a construction-bound
+# (H) local, a parameter, or a class field) resolves through the generic
+# (H) local-type machinery once Dart supplies a variable-type map, exactly
+# (H) like Java/C#/C++/Go. Construction typing keys off the UpperCamelCase
+# (H) base identifier of `Base(...)` / `Base.named(...)` initializers.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import run_updater
+
+SKIP = "dart"
+
+APP_DART = """
+class Greeter {
+  String name;
+  Greeter(this.name);
+  Greeter.named(String n) : name = n;
+
+  String greet() {
+    return name;
+  }
+
+  String hail() {
+    return name;
+  }
+}
+
+class Shouter {
+  Shouter();
+
+  String greet() {
+    return 'LOUD';
+  }
+
+  String hail() {
+    return 'LOUD';
+  }
+}
+
+class Holder {
+  Greeter buddy;
+  Holder(this.buddy);
+
+  String viaField() {
+    return buddy.greet();
+  }
+
+  String viaThisField() {
+    return this.buddy.hail();
+  }
+}
+
+Greeter makeIt() {
+  return Greeter('m');
+}
+
+String useParam(Greeter g) {
+  return g.greet();
+}
+
+String useDeclared() {
+  Greeter t = makeIt();
+  return t.greet();
+}
+
+String useConstructed() {
+  var b = Greeter('x');
+  return b.greet();
+}
+
+String useNamedCtor() {
+  final n = Greeter.named('y');
+  return n.hail();
+}
+
+String useUntypedHelper() {
+  var h = lowercaseFactory();
+  return h.greet();
+}
+
+Greeter lowercaseFactory() {
+  return Greeter('z');
+}
+"""
+
+
+@pytest.fixture
+def dart_typed_project(temp_repo: Path) -> Path:
+    root = temp_repo / "dtyped"
+    root.mkdir()
+    (root / "app.dart").write_text(APP_DART, encoding="utf-8")
+    return root
+
+
+def _calls(mock_ingestor: MagicMock) -> set[tuple[str, str]]:
+    return {
+        (str(c.args[0][2]), str(c.args[2][2]))
+        for c in mock_ingestor.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) == cs.RelationshipType.CALLS.value
+    }
+
+
+def _has(edges: set[tuple[str, str]], src: str, dst: str) -> bool:
+    return any(s.endswith(src) and d.endswith(dst) for s, d in edges)
+
+
+def test_param_typed_receiver(dart_typed_project: Path, mock_ingestor: MagicMock):
+    # (H) Shouter.greet is a same-named decoy in every test here: bare
+    # (H) suffix-trie binding cannot disambiguate, only receiver typing can.
+    run_updater(dart_typed_project, mock_ingestor, skip_if_missing=SKIP)
+    calls = _calls(mock_ingestor)
+    assert _has(calls, ".app.useParam", ".Greeter.greet"), sorted(calls)
+    assert not _has(calls, ".app.useParam", ".Shouter.greet"), sorted(calls)
+
+
+def test_declared_local_receiver(dart_typed_project: Path, mock_ingestor: MagicMock):
+    run_updater(dart_typed_project, mock_ingestor, skip_if_missing=SKIP)
+    calls = _calls(mock_ingestor)
+    assert _has(calls, ".app.useDeclared", ".Greeter.greet"), sorted(calls)
+    assert not _has(calls, ".app.useDeclared", ".Shouter.greet"), sorted(calls)
+
+
+def test_construction_bound_receiver(
+    dart_typed_project: Path, mock_ingestor: MagicMock
+):
+    run_updater(dart_typed_project, mock_ingestor, skip_if_missing=SKIP)
+    calls = _calls(mock_ingestor)
+    assert _has(calls, ".app.useConstructed", ".Greeter.greet"), sorted(calls)
+    assert not _has(calls, ".app.useConstructed", ".Shouter.greet"), sorted(calls)
+    assert _has(calls, ".app.useNamedCtor", ".Greeter.hail"), sorted(calls)
+    assert not _has(calls, ".app.useNamedCtor", ".Shouter.hail"), sorted(calls)
+
+
+def test_field_typed_receiver(dart_typed_project: Path, mock_ingestor: MagicMock):
+    run_updater(dart_typed_project, mock_ingestor, skip_if_missing=SKIP)
+    calls = _calls(mock_ingestor)
+    # (H) bare field receiver and explicit this.field receiver both hop
+    # (H) through the field's declared type
+    assert _has(calls, ".Holder.viaField", ".Greeter.greet"), sorted(calls)
+    assert not _has(calls, ".Holder.viaField", ".Shouter.greet"), sorted(calls)
+    assert _has(calls, ".Holder.viaThisField", ".Greeter.hail"), sorted(calls)
+
+
+def test_lowercase_initializer_does_not_type(
+    dart_typed_project: Path, mock_ingestor: MagicMock
+):
+    run_updater(dart_typed_project, mock_ingestor, skip_if_missing=SKIP)
+    calls = _calls(mock_ingestor)
+    # (H) `var h = lowercaseFactory()` is a call, not a construction: the base
+    # (H) identifier is not UpperCamelCase, so h stays untyped and the
+    # (H) ambiguous `h.greet()` binds NEITHER candidate
+    assert not _has(calls, ".app.useUntypedHelper", ".Greeter.greet"), sorted(calls)
+    assert not _has(calls, ".app.useUntypedHelper", ".Shouter.greet"), sorted(calls)
+    # (H) the construction inside lowercaseFactory itself still resolves
+    assert _has(calls, ".app.lowercaseFactory", ".Greeter.Greeter"), sorted(calls)

--- a/codebase_rag/tests/test_dart_type_inference.py
+++ b/codebase_rag/tests/test_dart_type_inference.py
@@ -172,7 +172,9 @@ def test_nested_local_function_does_not_poison_outer_scope(
     # (H) outer `s` (a Greeter) from the outer caller's type map
     # (H) (PR #806 review round 3)
     assert _has(calls, ".app.outerScoped", ".Greeter.greet"), sorted(calls)
-    assert _has(calls, ".outerScoped.inner", ".Shouter.greet"), sorted(calls)
+    # (H) a local function registers flat (app.inner) per the Dart FQN spec
+    # (H) and its own map types ITS s as Shouter
+    assert _has(calls, ".app.inner", ".Shouter.greet"), sorted(calls)
 
 
 def test_multi_variable_declarations_type_every_binding(

--- a/codebase_rag/tests/test_dart_type_inference.py
+++ b/codebase_rag/tests/test_dart_type_inference.py
@@ -84,6 +84,16 @@ String useUntypedHelper() {
   return h.greet();
 }
 
+String outerScoped() {
+  var s = Greeter('o');
+  void inner() {
+    var s = Shouter();
+    return s.greet();
+  }
+  inner();
+  return s.greet();
+}
+
 String useMultiDeclaration() {
   var first = Greeter('a'), second = Shouter();
   Greeter third = makeIt(), fourth = makeIt();
@@ -151,6 +161,18 @@ def test_field_typed_receiver(dart_typed_project: Path, mock_ingestor: MagicMock
     assert _has(calls, ".Holder.viaField", ".Greeter.greet"), sorted(calls)
     assert not _has(calls, ".Holder.viaField", ".Shouter.greet"), sorted(calls)
     assert _has(calls, ".Holder.viaThisField", ".Greeter.hail"), sorted(calls)
+
+
+def test_nested_local_function_does_not_poison_outer_scope(
+    dart_typed_project: Path, mock_ingestor: MagicMock
+):
+    run_updater(dart_typed_project, mock_ingestor, skip_if_missing=SKIP)
+    calls = _calls(mock_ingestor)
+    # (H) inner()'s same-named `s` (a Shouter) must not conflict-drop the
+    # (H) outer `s` (a Greeter) from the outer caller's type map
+    # (H) (PR #806 review round 3)
+    assert _has(calls, ".app.outerScoped", ".Greeter.greet"), sorted(calls)
+    assert _has(calls, ".outerScoped.inner", ".Shouter.greet"), sorted(calls)
 
 
 def test_multi_variable_declarations_type_every_binding(

--- a/codebase_rag/tests/test_dart_type_inference.py
+++ b/codebase_rag/tests/test_dart_type_inference.py
@@ -84,6 +84,12 @@ String useUntypedHelper() {
   return h.greet();
 }
 
+String useMultiDeclaration() {
+  var first = Greeter('a'), second = Shouter();
+  Greeter third = makeIt(), fourth = makeIt();
+  return second.greet() + fourth.hail();
+}
+
 Greeter lowercaseFactory() {
   return Greeter('z');
 }
@@ -145,6 +151,20 @@ def test_field_typed_receiver(dart_typed_project: Path, mock_ingestor: MagicMock
     assert _has(calls, ".Holder.viaField", ".Greeter.greet"), sorted(calls)
     assert not _has(calls, ".Holder.viaField", ".Shouter.greet"), sorted(calls)
     assert _has(calls, ".Holder.viaThisField", ".Greeter.hail"), sorted(calls)
+
+
+def test_multi_variable_declarations_type_every_binding(
+    dart_typed_project: Path, mock_ingestor: MagicMock
+):
+    run_updater(dart_typed_project, mock_ingestor, skip_if_missing=SKIP)
+    calls = _calls(mock_ingestor)
+    # (H) additional variables of a multi-declaration nest as
+    # (H) initialized_identifier children; `second` takes its OWN
+    # (H) construction's type, `fourth` the shared declared type
+    # (H) (PR #806 review).
+    assert _has(calls, ".app.useMultiDeclaration", ".Shouter.greet"), sorted(calls)
+    assert not _has(calls, ".app.useMultiDeclaration", ".Greeter.greet"), sorted(calls)
+    assert _has(calls, ".app.useMultiDeclaration", ".Greeter.hail"), sorted(calls)
 
 
 def test_lowercase_initializer_does_not_type(


### PR DESCRIPTION
## Problem

PR #804 left receiver-typed instance calls unresolved by typing, but in practice they were WORSE than unresolved: a dotted Dart call on an untyped receiver fell to the suffix trie, which always binds the closest same-named candidate. On a fixture with two classes both defining `greet()`, `h.greet()` on an unknown receiver bound one of them arbitrarily, a fabricated edge that also hides the other method from dead-code analysis.

## Fix

- New `DartTypeInferenceEngine` (parsers/dart/type_inference.py) building the local variable-type map the generic local-type resolution consumes: typed parameters (`useParam(Greeter g)`), declared locals (`Greeter t = ...`), and construction-bound locals (`var b = Greeter('x')`, `final n = Greeter.named('y')` — the initializer's base identifier types the local, gated on Dart's UpperCamelCase class convention so a lowercase call base leaves the local untyped). Parameters come from the signature and locals from the sibling `function_body`, honoring the grammar's signature/body split. Conflicting same-name redefinitions drop, mirroring the C# engine's conservative rule.
- Dart field types (`Greeter buddy;`) recorded into `class_field_types` at class ingestion, so field receivers (`buddy.greet()`, `this.buddy.hail()`) hop through the field's declared type via the existing overlay.
- DART joins `_TYPED_LANGUAGES` and the type-inference hub dispatch.
- The untyped-dotted fallback moves from the arbitrary-pick trie to the same unique-member gate JS/TS use: bind the unique visible member-like candidate or drop. Typed receivers never reach it.

## Validation

- Dogfood on dart-lang/args: **1084 -> 1444 CALLS (+360), still zero dangling project-internal targets.** The gains are exactly the receiver-typed surface: `addFlag` 154 -> 260, `parse` 124 -> 230, `addOption` 128 -> 224, all on `ArgParser` locals typed from their constructions.
- Full-breadth run: 5481 passed, only the two documented memgraph-integration environmental flakes.

## Tests

RED -> GREEN: `test_dart_type_inference.py` — every case carries a same-named decoy class so suffix binding cannot pass the test, only receiver typing can: param-typed, declared-local, construction-bound (default and named constructor), field and `this.field` receivers, and the untyped-ambiguous case dropping BOTH candidates.