### PR TITLE
feat(dart): recorded return types for class-qualified call locals plus inherited-lookup coverage

### DIFF
--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -27,6 +27,7 @@ from ...utils.path_utils import cached_relative_path, cached_resolve_posix
 from ..cpp import CppTypeInferenceEngine
 from ..cpp import utils as cpp_utils
 from ..csharp import utils as csharp_utils
+from ..dart import utils as dart_utils
 from ..dart.type_inference import DartTypeInferenceEngine
 from ..go import GoTypeInferenceEngine
 from ..java import utils as java_utils
@@ -1163,6 +1164,16 @@ class ClassIngestMixin:
                 is not None
             ):
                 self.csharp_generic_methods.add(ingested_qn)
+            # (H) Record Dart return types (a constructor "returns" its class)
+            # (H) so a local bound from a static factory or named constructor
+            # (H) (`var s = Greeter.create()`) types from the RECORDED return
+            # (H) instead of guessing the class from the call's base name.
+            if (
+                ingested_qn is not None
+                and language == cs.SupportedLanguage.DART
+                and (dart_return := dart_utils.dart_return_type_name(method_node))
+            ):
+                self.method_return_types[ingested_qn] = dart_return
             if ingested_qn is not None:
                 record_cpp_definition_span(
                     self.cpp_definition_spans,

--- a/codebase_rag/parsers/dart/__init__.py
+++ b/codebase_rag/parsers/dart/__init__.py
@@ -7,6 +7,7 @@ from .utils import (
     dart_get_name,
     dart_local_name,
     dart_resolve_import,
+    dart_return_type_name,
 )
 
 __all__ = [
@@ -18,4 +19,5 @@ __all__ = [
     "dart_get_name",
     "dart_local_name",
     "dart_resolve_import",
+    "dart_return_type_name",
 ]

--- a/codebase_rag/parsers/dart/type_inference.py
+++ b/codebase_rag/parsers/dart/type_inference.py
@@ -218,8 +218,7 @@ def _record_static_call(
                 base = part.text.decode(cs.ENCODING_UTF8)
         elif part.type == cs.TS_DART_SELECTOR:
             if any(
-                inner.type == cs.TS_DART_ARGUMENT_PART
-                for inner in part.named_children
+                inner.type == cs.TS_DART_ARGUMENT_PART for inner in part.named_children
             ):
                 has_argument_selector = True
             elif member is None:

--- a/codebase_rag/parsers/dart/type_inference.py
+++ b/codebase_rag/parsers/dart/type_inference.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from tree_sitter import Node
 
 from ... import constants as cs
-from .utils import dart_body_node
+from .utils import _selector_member_name, dart_body_node
 
 
 class DartTypeInferenceEngine:
@@ -25,6 +25,30 @@ class DartTypeInferenceEngine:
         if body is not None:
             self._collect_locals(body, types, conflicts)
         return types
+
+    def collect_static_call_bindings(
+        self, caller_node: Node
+    ) -> dict[str, tuple[str, str]]:
+        # (H) Locals bound from a class-qualified call (`var s =
+        # (H) Base.member(args)`, an UpperCamelCase base): the construction
+        # (H) heuristic types them as Base, but a registered member's RECORDED
+        # (H) return type should win (a `static String describe()` local is a
+        # (H) String, not the class). The hub enrichment consumes this map.
+        bindings: dict[str, tuple[str, str]] = {}
+        body = dart_body_node(caller_node)
+        if body is None:
+            return bindings
+        stack = list(body.named_children)
+        while stack:
+            node = stack.pop()
+            if node.type == cs.TS_DART_INITIALIZED_VARIABLE_DEFINITION:
+                _record_static_call(node.named_children, bindings)
+                for part in node.named_children:
+                    if part.type == cs.TS_DART_INITIALIZED_IDENTIFIER:
+                        _record_static_call(part.named_children, bindings)
+                continue
+            stack.extend(node.named_children)
+        return bindings
 
     def build_field_type_map(self, class_node: Node) -> dict[str, str]:
         # (H) `String name;` in a class_body is declaration(type_identifier,
@@ -175,6 +199,39 @@ def _record_binding(
         return
     if init_base is not None and has_argument_selector and init_base[:1].isupper():
         _record(var_name, init_base, types, conflicts)
+
+
+def _record_static_call(
+    parts: list[Node], bindings: dict[str, tuple[str, str]]
+) -> None:
+    # (H) shape: identifier var, identifier Base, selector(.member),
+    # (H) selector(argument_part); anything else is not a class-qualified call
+    var_name: str | None = None
+    base: str | None = None
+    member: str | None = None
+    has_argument_selector = False
+    for part in parts:
+        if part.type == cs.TS_DART_IDENTIFIER and part.text:
+            if var_name is None:
+                var_name = part.text.decode(cs.ENCODING_UTF8)
+            elif base is None:
+                base = part.text.decode(cs.ENCODING_UTF8)
+        elif part.type == cs.TS_DART_SELECTOR:
+            if any(
+                inner.type == cs.TS_DART_ARGUMENT_PART
+                for inner in part.named_children
+            ):
+                has_argument_selector = True
+            elif member is None:
+                member = _selector_member_name(part)
+    if (
+        var_name is not None
+        and base is not None
+        and member is not None
+        and has_argument_selector
+        and base[:1].isupper()
+    ):
+        bindings[var_name] = (base, member)
 
 
 def _record(

--- a/codebase_rag/parsers/dart/type_inference.py
+++ b/codebase_rag/parsers/dart/type_inference.py
@@ -34,6 +34,14 @@ class DartTypeInferenceEngine:
         # (H) heuristic types them as Base, but a registered member's RECORDED
         # (H) return type should win (a `static String describe()` local is a
         # (H) String, not the class). The hub enrichment consumes this map.
+        # (H) OWN-scope only (PR #807 review): a nested function's same-named
+        # (H) binding must never retype the outer local, and since the
+        # (H) enrichment cannot tell which scope produced a var_types entry, a
+        # (H) nested binding is never collected at all -- nested locals simply
+        # (H) keep the construction heuristic. A definition with an EXPLICIT
+        # (H) declared type is skipped entirely: the declaration statically
+        # (H) fixes the type and the initializer's return must not override
+        # (H) or untype it.
         bindings: dict[str, tuple[str, str]] = {}
         body = dart_body_node(caller_node)
         if body is None:
@@ -41,14 +49,24 @@ class DartTypeInferenceEngine:
         stack = list(body.named_children)
         while stack:
             node = stack.pop()
+            if node.type in cs.DART_NESTED_SCOPE_NODE_TYPES:
+                continue
             if node.type == cs.TS_DART_INITIALIZED_VARIABLE_DEFINITION:
-                _record_static_call(node.named_children, bindings)
-                for part in node.named_children:
-                    if part.type == cs.TS_DART_INITIALIZED_IDENTIFIER:
-                        _record_static_call(part.named_children, bindings)
+                self._record_definition_calls(node, bindings)
                 continue
             stack.extend(node.named_children)
         return bindings
+
+    @staticmethod
+    def _record_definition_calls(
+        node: Node, bindings: dict[str, tuple[str, str]]
+    ) -> None:
+        if _declared_type_name(node) is not None:
+            return
+        _record_static_call(node.named_children, bindings)
+        for part in node.named_children:
+            if part.type == cs.TS_DART_INITIALIZED_IDENTIFIER:
+                _record_static_call(part.named_children, bindings)
 
     def build_field_type_map(self, class_node: Node) -> dict[str, str]:
         # (H) `String name;` in a class_body is declaration(type_identifier,

--- a/codebase_rag/parsers/dart/utils.py
+++ b/codebase_rag/parsers/dart/utils.py
@@ -178,6 +178,26 @@ def dart_call_name(call_node: Node) -> str | None:
     return cs.SEPARATOR_DOT.join(parts)
 
 
+def dart_return_type_name(node: Node) -> str | None:
+    """The declared return type of a Dart signature, or None.
+
+    A constructor "returns" its class (its FIRST identifier); a method or
+    function signature's leading type_identifier before the name is its
+    return type; void, inferred, and getter-less shapes record nothing.
+    """
+    if node.type in cs.DART_CONSTRUCTOR_SIGNATURE_TYPES:
+        for child in node.named_children:
+            if child.type == cs.TS_DART_IDENTIFIER and child.text:
+                return child.text.decode(cs.ENCODING_UTF8)
+        return None
+    for child in node.named_children:
+        if child.type == cs.TS_DART_TYPE_IDENTIFIER and child.text:
+            return child.text.decode(cs.ENCODING_UTF8)
+        if child.type == cs.TS_DART_IDENTIFIER:
+            return None
+    return None
+
+
 def dart_extract_uri(node: Node) -> str | None:
     """The unquoted URI of an import/export/part directive, or None."""
     stack = [node]

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -26,7 +26,7 @@ from ..types_defs import (
 from ..utils.path_utils import cached_relative_path, cached_resolve_posix
 from . import export_detection
 from .cpp import utils as cpp_utils
-from .dart import dart_definition_end_point
+from .dart import dart_definition_end_point, dart_return_type_name
 from .go import utils as go_utils
 from .lua import utils as lua_utils
 from .rs import utils as rs_utils
@@ -362,6 +362,14 @@ class FunctionIngestMixin:
             # (H) this map. No impl target here, so a `Self` return stays None.
             if language == cs.SupportedLanguage.RUST and (
                 return_type := rs_utils.extract_return_type_name(func_node, None)
+            ):
+                self.method_return_types[resolution.qualified_name] = return_type
+
+            # (H) Same for a Dart free function: a call-bound local
+            # (H) (`var g = makeIt()` via the enrichment pass) types from
+            # (H) this map.
+            if language == cs.SupportedLanguage.DART and (
+                return_type := dart_return_type_name(func_node)
             ):
                 self.method_return_types[resolution.qualified_name] = return_type
 

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -301,7 +301,44 @@ class TypeInferenceEngine:
                         f"{cs.KEYWORD_SELF}{cs.SEPARATOR_DOT}{field}", ftype
                     )
             self._enrich_rust_call_locals(caller_node, module_qn, local)
+        elif language == cs.SupportedLanguage.DART:
+            self._enrich_dart_call_locals(caller_node, local)
         return local
+
+    def _enrich_dart_call_locals(
+        self, caller_node: ASTNode, var_types: dict[str, str]
+    ) -> None:
+        # (H) A local bound from a class-qualified call (`var s =
+        # (H) Base.member(args)`) was heuristically typed as Base; when the
+        # (H) member is a REGISTERED method with a recorded return type, that
+        # (H) type wins (a named constructor or same-class factory keeps Base,
+        # (H) a `static String describe()` local becomes a String whose member
+        # (H) calls then drop as external). A registered member WITHOUT a
+        # (H) recorded return (void) untypes the local; an unregistered member
+        # (H) (external library factory) keeps the heuristic.
+        bindings = self.dart_type_inference.collect_static_call_bindings(caller_node)
+        for name, (base, member) in bindings.items():
+            if var_types.get(name) != base:
+                continue
+            method_qn = self._dart_unique_class_member(base, member)
+            if method_qn is None:
+                continue
+            recorded = self.method_return_types.get(method_qn)
+            if recorded is None:
+                var_types.pop(name, None)
+            else:
+                var_types[name] = recorded
+
+    def _dart_unique_class_member(self, base: str, member: str) -> str | None:
+        suffix = f"{cs.SEPARATOR_DOT}{base}{cs.SEPARATOR_DOT}{member}"
+        matches = [
+            qn
+            for qn in self.function_registry.find_ending_with(member)
+            if qn.endswith(suffix)
+        ]
+        if len(matches) == 1:
+            return matches[0]
+        return None
 
     def _enrich_go_call_locals(
         self, caller_node: ASTNode, module_qn: str, var_types: dict[str, str]

--- a/codebase_rag/tests/test_dart_type_inference.py
+++ b/codebase_rag/tests/test_dart_type_inference.py
@@ -79,6 +79,28 @@ class Registry {
   }
 }
 
+class Widgetry {
+  Widgetry();
+
+  static void configure() {
+    return;
+  }
+
+  String render() {
+    return 'w';
+  }
+}
+
+class OtherRenderer {
+  String render() {
+    return 'o';
+  }
+
+  String evict() {
+    return 'o';
+  }
+}
+
 class Holder {
   Greeter buddy;
   Holder(this.buddy);
@@ -131,6 +153,21 @@ String useInherited(Dog d) {
 
 String misuseFactory() {
   var r = Registry.describe();
+  return r.evict();
+}
+
+String useDeclaredWins() {
+  Widgetry w = Widgetry.configure();
+  return w.render();
+}
+
+String outerEnrich() {
+  var r = Registry();
+  void innerBind() {
+    var r = Registry.describe();
+    r.evict();
+  }
+  innerBind();
   return r.evict();
 }
 
@@ -264,6 +301,31 @@ def test_non_class_static_return_does_not_type_the_local(
     assert not _has(calls, ".app.misuseFactory", ".Registry.evict"), sorted(calls)
     # (H) the static call itself still resolves
     assert _has(calls, ".app.misuseFactory", ".Registry.describe"), sorted(calls)
+
+
+def test_declared_type_wins_over_initializer_return(
+    dart_typed_project: Path, mock_ingestor: MagicMock
+):
+    run_updater(dart_typed_project, mock_ingestor, skip_if_missing=SKIP)
+    calls = _calls(mock_ingestor)
+    # (H) an EXPLICIT declared type statically fixes the variable's type; the
+    # (H) initializer's recorded (void) return must not untype it
+    # (H) (PR #807 review). OtherRenderer.render is the decoy.
+    assert _has(calls, ".app.useDeclaredWins", ".Widgetry.render"), sorted(calls)
+    assert not _has(calls, ".app.useDeclaredWins", ".OtherRenderer.render"), sorted(
+        calls
+    )
+
+
+def test_nested_binding_does_not_retype_outer_local(
+    dart_typed_project: Path, mock_ingestor: MagicMock
+):
+    run_updater(dart_typed_project, mock_ingestor, skip_if_missing=SKIP)
+    calls = _calls(mock_ingestor)
+    # (H) an inner function's same-named `var r = Registry.describe()` must
+    # (H) not retype the OUTER r (a constructed Registry) to String
+    # (H) (PR #807 review). OtherRenderer.evict is the decoy.
+    assert _has(calls, ".app.outerEnrich", ".Registry.evict"), sorted(calls)
 
 
 def test_inherited_method_on_typed_receiver(

--- a/codebase_rag/tests/test_dart_type_inference.py
+++ b/codebase_rag/tests/test_dart_type_inference.py
@@ -29,6 +29,10 @@ class Greeter {
   String hail() {
     return name;
   }
+
+  static Greeter create() {
+    return Greeter('s');
+  }
 }
 
 class Shouter {
@@ -40,6 +44,38 @@ class Shouter {
 
   String hail() {
     return 'LOUD';
+  }
+}
+
+class Animal {
+  String speak() {
+    return 'a';
+  }
+}
+
+class Dog extends Animal {
+  Dog();
+
+  String bark() {
+    return 'b';
+  }
+}
+
+class OtherSpeaker {
+  String speak() {
+    return 'o';
+  }
+}
+
+class Registry {
+  Registry();
+
+  static String describe() {
+    return 'r';
+  }
+
+  String evict() {
+    return 'e';
   }
 }
 
@@ -82,6 +118,20 @@ String useNamedCtor() {
 String useUntypedHelper() {
   var h = lowercaseFactory();
   return h.greet();
+}
+
+String useStaticFactory() {
+  var s = Greeter.create();
+  return s.greet();
+}
+
+String useInherited(Dog d) {
+  return d.speak();
+}
+
+String misuseFactory() {
+  var r = Registry.describe();
+  return r.evict();
 }
 
 String outerScoped() {
@@ -189,6 +239,42 @@ def test_multi_variable_declarations_type_every_binding(
     assert _has(calls, ".app.useMultiDeclaration", ".Shouter.greet"), sorted(calls)
     assert not _has(calls, ".app.useMultiDeclaration", ".Greeter.greet"), sorted(calls)
     assert _has(calls, ".app.useMultiDeclaration", ".Greeter.hail"), sorted(calls)
+
+
+def test_static_factory_return_types_the_local(
+    dart_typed_project: Path, mock_ingestor: MagicMock
+):
+    run_updater(dart_typed_project, mock_ingestor, skip_if_missing=SKIP)
+    calls = _calls(mock_ingestor)
+    # (H) `var s = Greeter.create()` types s from create's recorded return
+    # (H) type; the Shouter.greet decoy defeats both the suffix trie and the
+    # (H) unique-member gate, so only return typing can bind this
+    assert _has(calls, ".app.useStaticFactory", ".Greeter.greet"), sorted(calls)
+    assert not _has(calls, ".app.useStaticFactory", ".Shouter.greet"), sorted(calls)
+
+
+def test_non_class_static_return_does_not_type_the_local(
+    dart_typed_project: Path, mock_ingestor: MagicMock
+):
+    run_updater(dart_typed_project, mock_ingestor, skip_if_missing=SKIP)
+    calls = _calls(mock_ingestor)
+    # (H) Registry.describe() returns a String, not a Registry: the recorded
+    # (H) return type must override the construction heuristic, so `r` is a
+    # (H) String and `r.evict()` must NOT bind Registry.evict
+    assert not _has(calls, ".app.misuseFactory", ".Registry.evict"), sorted(calls)
+    # (H) the static call itself still resolves
+    assert _has(calls, ".app.misuseFactory", ".Registry.describe"), sorted(calls)
+
+
+def test_inherited_method_on_typed_receiver(
+    dart_typed_project: Path, mock_ingestor: MagicMock
+):
+    run_updater(dart_typed_project, mock_ingestor, skip_if_missing=SKIP)
+    calls = _calls(mock_ingestor)
+    # (H) speak() is defined on Animal, the receiver is typed Dog: lookup must
+    # (H) walk the inheritance chain; OtherSpeaker.speak is the decoy
+    assert _has(calls, ".app.useInherited", ".Animal.speak"), sorted(calls)
+    assert not _has(calls, ".app.useInherited", ".OtherSpeaker.speak"), sorted(calls)
 
 
 def test_lowercase_initializer_does_not_type(


### PR DESCRIPTION
## Problem

Follow-up to PR #806, closing its two recorded ceilings. One turned out to already work; the other hid a real precision bug.

- **Inherited lookup**: typed-receiver method resolution already walks `class_inheritance` (the generic `_try_method_on_class` path); Dart's inheritance entries resolve fine. This PR pins that with a decoy-guarded regression test rather than changing code.
- **Static factories**: `var s = Greeter.create()` was typed by the construction heuristic (base identifier = class), which is correct exactly when a factory returns its own class. When it does not (`static String describe()`), the local was typed as the class anyway, and `r.evict()` on what is actually a String fabricated a CALLS edge to `Registry.evict`.

## Fix

- Dart return types are now RECORDED at ingestion: methods and static members via the class-ingest loop, module functions via function ingest, and constructors record their own class (a constructor "returns" its type), all through a new `dart_return_type_name` (leading `type_identifier` before the name; void and inferred shapes record nothing).
- A hub enrichment pass (`_enrich_dart_call_locals`, mirroring the Go/Rust enrichments) revisits locals the heuristic typed from a class-qualified call `Base.member(args)`: a registered member's recorded return type wins (named constructors and same-class factories keep Base; a `static String describe()` local becomes a String whose member calls then drop as external), a registered member WITHOUT a recorded return (void) untypes the local, and an unregistered member (external library factory) keeps the heuristic.

## Validation

- Dogfood on dart-lang/args: 1444 -> **1449 CALLS, still zero dangling project-internal targets** (the five new edges are statics and factories whose locals now carry the recorded return type).
- Full suite: 5494 passed, only the documented memgraph-integration environmental flake.

## Tests

RED -> GREEN: `test_non_class_static_return_does_not_type_the_local` (the fabricated `Registry.evict` edge disappears while `Registry.describe` itself still resolves), plus passing-by-construction regression pins for the two ceilings: `test_inherited_method_on_typed_receiver` (method on a base class, decoy sibling) and `test_static_factory_return_types_the_local` (decoy defeats the trie and the unique-member gate, so only return typing can bind).