### PR TITLE
fix(mcp): patch CVE-2026-52869 exposure with mcp>=1.28.1 and a loopback default bind

### DIFF
--- a/codebase_rag/config.py
+++ b/codebase_rag/config.py
@@ -325,7 +325,10 @@ class AppConfig(BaseSettings):
 
     CGR_CAPTURE: str = Field("", validation_alias="CGR_CAPTURE")
 
-    MCP_HTTP_HOST: str = "0.0.0.0"
+    # (H) Loopback by default: the StreamableHTTP endpoint has no built-in
+    # (H) auth, so exposing it beyond the host must be an explicit operator
+    # (H) choice via MCP_HTTP_HOST (issue #808).
+    MCP_HTTP_HOST: str = "127.0.0.1"
     MCP_HTTP_PORT: int = 8080
     MCP_HTTP_ENDPOINT_PATH: str = "/mcp"
 

--- a/codebase_rag/tests/test_mcp_http_defaults.py
+++ b/codebase_rag/tests/test_mcp_http_defaults.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from importlib.metadata import version
 
+from packaging.version import Version
+
 from codebase_rag.config import AppConfig
 
 
@@ -18,5 +20,4 @@ def test_mcp_http_default_bind_is_loopback() -> None:
 
 def test_mcp_dependency_is_patched() -> None:
     # (H) 1.27.2 fixed CVE-2026-52869/52870; 1.28.1 fixed CVE-2026-59950
-    major, minor, patch = (int(p) for p in version("mcp").split(".")[:3])
-    assert (major, minor, patch) >= (1, 28, 1), version("mcp")
+    assert Version(version("mcp")) >= Version("1.28.1"), version("mcp")

--- a/codebase_rag/tests/test_mcp_http_defaults.py
+++ b/codebase_rag/tests/test_mcp_http_defaults.py
@@ -1,0 +1,22 @@
+# (H) Issue #808: the HTTP MCP endpoint mounts the StreamableHTTP session
+# (H) manager with no auth middleware, so the DEFAULT bind must be loopback --
+# (H) a 0.0.0.0 default exposed the unauthenticated transport to the network
+# (H) and made CVE-2026-52869 (session requests served without verifying the
+# (H) authenticated principal) reachable from outside the host. Reaching a
+# (H) non-local bind must be an explicit operator decision (MCP_HTTP_HOST).
+from __future__ import annotations
+
+from importlib.metadata import version
+
+from codebase_rag.config import AppConfig
+
+
+def test_mcp_http_default_bind_is_loopback() -> None:
+    config = AppConfig(_env_file=None)  # ty: ignore[unknown-argument]
+    assert config.MCP_HTTP_HOST == "127.0.0.1"
+
+
+def test_mcp_dependency_is_patched() -> None:
+    # (H) 1.27.2 fixed CVE-2026-52869/52870; 1.28.1 fixed CVE-2026-59950
+    major, minor, patch = (int(p) for p in version("mcp").split(".")[:3])
+    assert (major, minor, patch) >= (1, 28, 1), version("mcp")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ keywords = [
 ]
 dependencies = [
     "loguru>=0.7.3",
-    "mcp>=1.25.0",
+    "mcp>=1.28.1",
     "pydantic-ai>=1.102.0",
     "pydantic-settings>=2.12.0",
     "pymgclient>=1.5.1",

--- a/uv.lock
+++ b/uv.lock
@@ -540,7 +540,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.388"
+version = "0.0.391"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -636,7 +636,7 @@ requires-dist = [
     { name = "huggingface-hub", extras = ["hf-xet"], specifier = ">=1.7.2" },
     { name = "libclang", marker = "extra == 'test'", specifier = ">=18.1.1" },
     { name = "loguru", specifier = ">=0.7.3" },
-    { name = "mcp", specifier = ">=1.25.0" },
+    { name = "mcp", specifier = ">=1.28.1" },
     { name = "pathspec", specifier = ">=1.0.4" },
     { name = "prompt-toolkit", specifier = ">=3.0.52" },
     { name = "protobuf", specifier = ">=6.33.5" },
@@ -2088,7 +2088,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.25.0"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2106,9 +2106,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/2d/649d80a0ecf6a1f82632ca44bec21c0461a9d9fc8934d38cb5b319f2db5e/mcp-1.25.0.tar.gz", hash = "sha256:56310361ebf0364e2d438e5b45f7668cbb124e158bb358333cd06e49e83a6802", size = 605387, upload-time = "2025-12-19T10:19:56.985Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/fc/6dc7659c2ae5ddf280477011f4213a74f806862856b796ef08f028e664bf/mcp-1.25.0-py3-none-any.whl", hash = "sha256:b37c38144a666add0862614cc79ec276e97d72aa8ca26d622818d4e278b9721a", size = 233076, upload-time = "2025-12-19T10:19:55.416Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

Issue #808 (reported by @elfrost, verified line by line): `mcp` was pinned at 1.25.0, which carries three published advisories, and one of them was live here. `serve_http()` mounts the StreamableHTTP session manager behind a bare Starlette route with no authentication middleware, and the default bind was `0.0.0.0:8080`, so CVE-2026-52869 (StreamableHTTP serves session requests without verifying the authenticated principal) was reachable from the network on a default deployment. CVE-2026-52870 (experimental task handlers) was conditional and CVE-2026-59950 (WebSocket Host/Origin validation) inert for this codebase, exactly as the report triaged.

## Fix

- `mcp>=1.28.1` (1.27.2 fixed 52869 and 52870, 1.28.1 fixed 59950; one bump covers all three), lockfile regenerated. The 1.28 session-manager API is compatible: our `app`/`json_response`/`stateless` construction verified against the new signature, and the full MCP test surface passes unchanged.
- `MCP_HTTP_HOST` now defaults to `127.0.0.1`: the endpoint has no built-in auth, so exposing it beyond the host becomes an explicit operator choice via the existing setting. Deployments that intentionally bind externally must now set `MCP_HTTP_HOST=0.0.0.0` (called out here since it is a behavior change, deliberate and secure-by-default).

## Validation

Full suite: 5498 passed, only the documented memgraph-integration environmental flake.

## Tests

RED -> GREEN: `test_mcp_http_defaults.py` — the default bind is loopback, and the installed `mcp` meets the patched floor.

Closes #808.