### PR TITLE
fix(js): ingest mjs cjs mts cts module extension variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,13 @@ An accurate Retrieval-Augmented Generation (RAG) system that analyzes multi-lang
 | Dart | Fully Supported | .dart | ✓ | ✓ | ✓ | - | Classes, mixins, extensions, enhanced enums, factory/named constructors, Flutter widgets, package/relative/dart: imports, part directives, pubspec dependencies |
 | Go | Fully Supported | .go | ✓ | ✓ | ✓ | - | Receiver methods with cross-file binding, structs, interfaces, type declarations, function-local types |
 | Java | Fully Supported | .java | ✓ | ✓ | ✓ | - | Generics, annotations, modern features (records/sealed classes), concurrency, reflection |
-| JavaScript | Fully Supported | .js, .jsx | ✓ | ✓ | ✓ | - | ES6 modules, CommonJS, prototype methods, object methods, arrow functions |
+| JavaScript | Fully Supported | .js, .jsx, .mjs, .cjs | ✓ | ✓ | ✓ | - | ES6 modules, CommonJS, prototype methods, object methods, arrow functions |
 | Lua | Fully Supported | .lua | ✓ | - | ✓ | - | Local/global functions, metatables, closures, coroutines |
 | PHP | Fully Supported | .php | ✓ | ✓ | ✓ | - | Classes, interfaces, traits, enums, namespaces, PHP 8 attributes |
 | Python | Fully Supported | .py | ✓ | ✓ | ✓ | ✓ | Type inference, decorators, nested functions |
 | Rust | Fully Supported | .rs | ✓ | ✓ | ✓ | ✓ | impl blocks, associated functions, macro_rules! macros |
 | TypeScript (TSX) | Fully Supported | .tsx | ✓ | ✓ | ✓ | - | All TypeScript features plus JSX elements and components |
-| TypeScript | Fully Supported | .ts | ✓ | ✓ | ✓ | - | Interfaces, type aliases, enums, namespaces, ES6/CommonJS modules |
+| TypeScript | Fully Supported | .ts, .mts, .cts | ✓ | ✓ | ✓ | - | Interfaces, type aliases, enums, namespaces, ES6/CommonJS modules |
 | Scala | In Development | .scala, .sc | ✓ | ✓ | ✓ | - | Case classes, objects |
 <!-- /SECTION:supported_languages -->
 - **🌳 Tree-sitter Parsing**: Uses Tree-sitter for robust, language-agnostic AST parsing

--- a/codebase_rag/constants/languages.py
+++ b/codebase_rag/constants/languages.py
@@ -124,6 +124,8 @@ JS_EXTERNAL_IMPORT_SCHEMES: frozenset[str] = frozenset(
 # (H) module qn (`src/util.ts` -> `src/util`), longest first so `.d.ts`-like
 # (H) compound suffixes are handled before the bare `.ts`.
 JS_TS_MODULE_EXTENSIONS: tuple[str, ...] = (
+    ".d.mts",
+    ".d.cts",
     ".d.ts",
     ".tsx",
     ".mts",

--- a/codebase_rag/constants/languages.py
+++ b/codebase_rag/constants/languages.py
@@ -21,7 +21,11 @@ BINARY_EXTENSIONS: frozenset[str] = frozenset(
 EXT_PY = ".py"
 EXT_JS = ".js"
 EXT_JSX = ".jsx"
+EXT_MJS = ".mjs"
+EXT_CJS = ".cjs"
 EXT_TS = ".ts"
+EXT_MTS = ".mts"
+EXT_CTS = ".cts"
 EXT_TSX = ".tsx"
 EXT_RS = ".rs"
 EXT_GO = ".go"
@@ -47,10 +51,19 @@ EXT_DART = ".dart"
 
 # (H) File extension tuples by language
 PY_EXTENSIONS = (EXT_PY,)
-JS_EXTENSIONS = (EXT_JS, EXT_JSX)
-TS_EXTENSIONS = (EXT_TS,)
+JS_EXTENSIONS = (EXT_JS, EXT_JSX, EXT_MJS, EXT_CJS)
+TS_EXTENSIONS = (EXT_TS, EXT_MTS, EXT_CTS)
 TSX_EXTENSIONS = (EXT_TSX,)
-JS_TS_ALL_EXTENSIONS = (EXT_JS, EXT_JSX, EXT_TS, EXT_TSX)
+JS_TS_ALL_EXTENSIONS = (
+    EXT_JS,
+    EXT_JSX,
+    EXT_MJS,
+    EXT_CJS,
+    EXT_TS,
+    EXT_MTS,
+    EXT_CTS,
+    EXT_TSX,
+)
 RS_EXTENSIONS = (EXT_RS,)
 GO_EXTENSIONS = (EXT_GO,)
 SCALA_EXTENSIONS = (EXT_SCALA, EXT_SC)
@@ -113,6 +126,8 @@ JS_EXTERNAL_IMPORT_SCHEMES: frozenset[str] = frozenset(
 JS_TS_MODULE_EXTENSIONS: tuple[str, ...] = (
     ".d.ts",
     ".tsx",
+    ".mts",
+    ".cts",
     ".ts",
     ".jsx",
     ".mjs",

--- a/codebase_rag/tests/test_js_module_extension_variants.py
+++ b/codebase_rag/tests/test_js_module_extension_variants.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.conftest import get_nodes, get_relationships, run_updater
+
+
+def _function_qns(ingestor: MagicMock) -> set[str]:
+    return {c.args[1]["qualified_name"] for c in get_nodes(ingestor, "Function")}
+
+
+def _call_pairs(ingestor: MagicMock) -> set[tuple[str, str]]:
+    return {(c.args[0][2], c.args[2][2]) for c in get_relationships(ingestor, "CALLS")}
+
+
+def test_mjs_module_functions_and_calls_ingested(temp_repo: Path) -> None:
+    # (H) ESM packages ship .mjs files (config files, dual-package libs); they
+    # (H) parse with the same grammar as .js and must produce the same graph.
+    root = temp_repo / "mjsproj"
+    root.mkdir()
+    (root / "util.mjs").write_text(
+        "export function helper() { return 1 }\n", encoding="utf-8"
+    )
+    (root / "main.mjs").write_text(
+        "import { helper } from './util.mjs'\n"
+        "export function run() { return helper() }\n",
+        encoding="utf-8",
+    )
+
+    ingestor = MagicMock()
+    run_updater(root, ingestor, skip_if_missing="javascript")
+
+    qns = _function_qns(ingestor)
+    assert any(qn.endswith("util.helper") for qn in qns), qns
+    assert any(qn.endswith("main.run") for qn in qns), qns
+    assert any(
+        caller.endswith("main.run") and callee.endswith("util.helper")
+        for caller, callee in _call_pairs(ingestor)
+    ), _call_pairs(ingestor)
+
+
+def test_cjs_module_functions_and_calls_ingested(temp_repo: Path) -> None:
+    root = temp_repo / "cjsproj"
+    root.mkdir()
+    (root / "util.cjs").write_text(
+        "function helper() { return 1 }\nmodule.exports = { helper }\n",
+        encoding="utf-8",
+    )
+    (root / "main.cjs").write_text(
+        "const { helper } = require('./util.cjs')\n"
+        "function run() { return helper() }\n"
+        "module.exports = { run }\n",
+        encoding="utf-8",
+    )
+
+    ingestor = MagicMock()
+    run_updater(root, ingestor, skip_if_missing="javascript")
+
+    qns = _function_qns(ingestor)
+    assert any(qn.endswith("util.helper") for qn in qns), qns
+    assert any(qn.endswith("main.run") for qn in qns), qns
+    assert any(
+        caller.endswith("main.run") and callee.endswith("util.helper")
+        for caller, callee in _call_pairs(ingestor)
+    ), _call_pairs(ingestor)
+
+
+def test_mts_and_cts_typescript_variants_ingested(temp_repo: Path) -> None:
+    # (H) TypeScript's ESM/CJS variants of .ts: same grammar, same graph.
+    root = temp_repo / "mtsproj"
+    root.mkdir()
+    (root / "util.mts").write_text(
+        "export function helper(): number { return 1 }\n", encoding="utf-8"
+    )
+    (root / "legacy.cts").write_text(
+        "export function older(): number { return 2 }\n", encoding="utf-8"
+    )
+
+    ingestor = MagicMock()
+    run_updater(root, ingestor, skip_if_missing="typescript")
+
+    qns = _function_qns(ingestor)
+    assert any(qn.endswith("util.helper") for qn in qns), qns
+    assert any(qn.endswith("legacy.older") for qn in qns), qns
+
+
+def test_extensionless_relative_import_resolves_to_mjs(temp_repo: Path) -> None:
+    # (H) `import './util'` must probe the .mjs/.cjs candidates like .js/.ts.
+    root = temp_repo / "resolveproj"
+    root.mkdir()
+    (root / "util.mjs").write_text(
+        "export function helper() { return 1 }\n", encoding="utf-8"
+    )
+    (root / "main.js").write_text(
+        "import { helper } from './util'\nexport function run() { return helper() }\n",
+        encoding="utf-8",
+    )
+
+    ingestor = MagicMock()
+    run_updater(root, ingestor, skip_if_missing="javascript")
+
+    assert any(
+        caller.endswith("main.run") and callee.endswith("util.helper")
+        for caller, callee in _call_pairs(ingestor)
+    ), _call_pairs(ingestor)

--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -17,13 +17,13 @@ Code-Graph-RAG uses Tree-sitter for language-agnostic AST parsing with a unified
 | Dart | Fully Supported | .dart | ✓ | ✓ | ✓ | - | Classes, mixins, extensions, enhanced enums, factory/named constructors, Flutter widgets, package/relative/dart: imports, part directives, pubspec dependencies |
 | Go | Fully Supported | .go | ✓ | ✓ | ✓ | - | Receiver methods with cross-file binding, structs, interfaces, type declarations, function-local types |
 | Java | Fully Supported | .java | ✓ | ✓ | ✓ | - | Generics, annotations, modern features (records/sealed classes), concurrency, reflection |
-| JavaScript | Fully Supported | .js, .jsx | ✓ | ✓ | ✓ | - | ES6 modules, CommonJS, prototype methods, object methods, arrow functions |
+| JavaScript | Fully Supported | .js, .jsx, .mjs, .cjs | ✓ | ✓ | ✓ | - | ES6 modules, CommonJS, prototype methods, object methods, arrow functions |
 | Lua | Fully Supported | .lua | ✓ | - | ✓ | - | Local/global functions, metatables, closures, coroutines |
 | PHP | Fully Supported | .php | ✓ | ✓ | ✓ | - | Classes, interfaces, traits, enums, namespaces, PHP 8 attributes |
 | Python | Fully Supported | .py | ✓ | ✓ | ✓ | ✓ | Type inference, decorators, nested functions |
 | Rust | Fully Supported | .rs | ✓ | ✓ | ✓ | ✓ | impl blocks, associated functions, macro_rules! macros |
 | TypeScript (TSX) | Fully Supported | .tsx | ✓ | ✓ | ✓ | - | All TypeScript features plus JSX elements and components |
-| TypeScript | Fully Supported | .ts | ✓ | ✓ | ✓ | - | Interfaces, type aliases, enums, namespaces, ES6/CommonJS modules |
+| TypeScript | Fully Supported | .ts, .mts, .cts | ✓ | ✓ | ✓ | - | Interfaces, type aliases, enums, namespaces, ES6/CommonJS modules |
 | Scala | In Development | .scala, .sc | ✓ | ✓ | ✓ | - | Case classes, objects |
 <!-- /SECTION:supported_languages -->
 


### PR DESCRIPTION
Found dogfooding the flow edges: files with the .mjs, .cjs, .mts, and .cts extensions were not parsed at all. JS_EXTENSIONS stopped at .js/.jsx and TS_EXTENSIONS at .ts, so whole ESM packages, dual-package libraries, and modern config files (eslint.config.mjs and friends) were invisible to the graph: no Module or Function nodes, no CALLS, no IMPORTS, no IO or flow edges. The extensions were already listed in JS_TS_MODULE_EXTENSIONS for tsconfig path stripping, which made the gap easy to miss.

## What changed

- `JS_EXTENSIONS` gains `.mjs`/`.cjs`, `TS_EXTENSIONS` gains `.mts`/`.cts`, and `JS_TS_ALL_EXTENSIONS` covers all eight, so extensionless relative imports (`import './util'`) also probe the new candidates during module resolution.
- `JS_TS_MODULE_EXTENSIONS` gains `.mts`/`.cts` so tsconfig path targets strip them like the rest.

## Tests

RED first (46f7c7a5): four failing specs covering .mjs and .cjs function/call ingestion, .mts/.cts TypeScript variants, and extensionless import resolution to a .mjs file. GREEN in 80891734. Full suite: 5214 passed.