### PR TITLE
fix(io): collapse JS default-export segment when matching sink registries

### DIFF
--- a/codebase_rag/parsers/io_access/extract.py
+++ b/codebase_rag/parsers/io_access/extract.py
@@ -105,6 +105,20 @@ def normalise(name: str | None, import_map: dict[str, str]) -> str | None:
     return f"{base}{cs.SEPARATOR_DOT}{rest}" if rest else base
 
 
+def default_export_collapsed(name: str) -> str | None:
+    # (H) A JS default import maps the local name to `<module>.default` (and a
+    # (H) node: builtin to `node:<module>.default`), but sink registries are
+    # (H) keyed by the module's own dotted API (`fs.readFileSync`). Collapse
+    # (H) the default-export segment and scheme for a lookup candidate; a
+    # (H) local-module base keeps its project-qualified prefix, so its
+    # (H) collapsed form can never collide with a sink key. Returns None when
+    # (H) nothing collapsed.
+    collapsed = name.removeprefix(cs.NODE_BUILTIN_PREFIX).replace(
+        ".default.", cs.SEPARATOR_DOT, 1
+    )
+    return collapsed if collapsed != name else None
+
+
 def registry_match[T](
     mapping: dict[str, T], raw_name: str | None, import_map: dict[str, str]
 ) -> T | None:
@@ -120,6 +134,12 @@ def registry_match[T](
         return None
     name = normalise(raw_name, import_map)
     if name is not None and (hit := mapping.get(name)) is not None:
+        return hit
+    if (
+        name is not None
+        and (collapsed := default_export_collapsed(name)) is not None
+        and (hit := mapping.get(collapsed)) is not None
+    ):
         return hit
     if cs.SEPARATOR_DOT in raw_name:
         return mapping.get(raw_name)
@@ -150,6 +170,8 @@ def match_normalised[T](
     hit = mapping.get(normalised)
     if hit is None and normalised.startswith(cs.NODE_BUILTIN_PREFIX):
         hit = mapping.get(normalised.removeprefix(cs.NODE_BUILTIN_PREFIX))
+    if hit is None and (collapsed := default_export_collapsed(normalised)) is not None:
+        hit = mapping.get(collapsed)
     return hit
 
 

--- a/codebase_rag/tests/test_io_access_js_imports.py
+++ b/codebase_rag/tests/test_io_access_js_imports.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.capture import resolve_capture
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+READS_FROM = cs.RelationshipType.READS_FROM.value
+_CAPTURE_IO = resolve_capture([cs.CaptureGroup.IO.value])
+
+
+def _run_io(tmp_path: Path, files: dict[str, str]) -> set[tuple[str, str, str]]:
+    parsers, queries = load_parsers()
+    if "javascript" not in parsers:
+        pytest.skip("javascript parser not available")
+    for rel, content in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        capture=_CAPTURE_IO,
+    ).run()
+    return {
+        (c.args[0][2], str(c.args[1]), c.args[2][2])
+        for c in mock.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) == READS_FROM
+    }
+
+
+def _reads_file(rels: set[tuple[str, str, str]], caller_suffix: str) -> bool:
+    return any(
+        caller.endswith(caller_suffix) and resource.startswith("resource::FILE::")
+        for caller, _rel, resource in rels
+    )
+
+
+def test_default_import_matches_file_sink(tmp_path: Path) -> None:
+    # (H) `import fs from 'fs'` maps fs -> fs.default; the sink lookup must
+    # (H) collapse the default-export segment to hit `fs.readFileSync`.
+    rels = _run_io(
+        tmp_path,
+        {
+            "m.js": (
+                "import fs from 'fs'\n"
+                "export function load(p) { return fs.readFileSync(p, 'utf8') }\n"
+            )
+        },
+    )
+    assert _reads_file(rels, "m.load"), rels
+
+
+def test_aliased_default_import_matches_file_sink(tmp_path: Path) -> None:
+    # (H) `import myFs from 'fs'` leaves no raw-text `fs.` prefix, so only the
+    # (H) normalised form (myFs -> fs.default) can match the sink.
+    rels = _run_io(
+        tmp_path,
+        {
+            "m.js": (
+                "import myFs from 'fs'\n"
+                "export function load(p) { return myFs.readFileSync(p, 'utf8') }\n"
+            )
+        },
+    )
+    assert _reads_file(rels, "m.load"), rels
+
+
+def test_node_prefixed_default_import_matches_file_sink(tmp_path: Path) -> None:
+    # (H) `import fs from 'node:fs'` (the officially recommended builtin form)
+    # (H) maps fs -> node:fs.default: both the scheme and the default-export
+    # (H) segment must be stripped for the sink key to match.
+    rels = _run_io(
+        tmp_path,
+        {
+            "m.js": (
+                "import fs from 'node:fs'\n"
+                "export function load(p) { return fs.readFileSync(p, 'utf8') }\n"
+            )
+        },
+    )
+    assert _reads_file(rels, "m.load"), rels
+
+
+def test_aliased_node_prefixed_default_import_matches_file_sink(
+    tmp_path: Path,
+) -> None:
+    rels = _run_io(
+        tmp_path,
+        {
+            "m.js": (
+                "import fsNode from 'node:fs'\n"
+                "export function load(p) { return fsNode.readFileSync(p, 'utf8') }\n"
+            )
+        },
+    )
+    assert _reads_file(rels, "m.load"), rels
+
+
+def test_node_prefixed_namespace_import_matches_file_sink(tmp_path: Path) -> None:
+    rels = _run_io(
+        tmp_path,
+        {
+            "m.js": (
+                "import * as fs from 'node:fs'\n"
+                "export function load(p) { return fs.readFileSync(p, 'utf8') }\n"
+            )
+        },
+    )
+    assert _reads_file(rels, "m.load"), rels
+
+
+def test_node_prefixed_named_import_matches_file_sink(tmp_path: Path) -> None:
+    rels = _run_io(
+        tmp_path,
+        {
+            "m.js": (
+                "import { readFileSync } from 'node:fs'\n"
+                "export function load(p) { return readFileSync(p, 'utf8') }\n"
+            )
+        },
+    )
+    assert _reads_file(rels, "m.load"), rels
+
+
+def test_local_default_import_does_not_hit_builtin_sink(tmp_path: Path) -> None:
+    # (H) A default import of FIRST-PARTY code named like a builtin must stay
+    # (H) unmatched: ./fs resolves to a local module, not the node builtin.
+    rels = _run_io(
+        tmp_path,
+        {
+            "fs.js": "export default { readFileSync(p) { return p } }\n",
+            "m.js": (
+                "import fs from './fs'\n"
+                "export function load(p) { return fs.readFileSync(p, 'utf8') }\n"
+            ),
+        },
+    )
+    assert not _reads_file(rels, "m.load"), rels

--- a/uv.lock
+++ b/uv.lock
@@ -540,7 +540,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.388"
+version = "0.0.391"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Second find from the flow-edges dogfood. A JS default import maps the local name to `<module>.default` (`import fs from 'fs'` records `fs -> fs.default`; the `node:` builtin form records `node:fs.default`), but IO sink registries are keyed by the module's own dotted API (`fs.readFileSync`). The normalised lookup therefore missed, and only the raw-text fallback saved the cases where the local name happens to equal the module name. Aliased default imports (`import myFs from 'fs'`, `import fsNode from 'node:fs'`) produced no READS_FROM/WRITES_TO/FLOWS_TO at all.

## What changed

`default_export_collapsed` in `io_access/extract.py` strips the `node:` scheme and collapses the `.default.` segment to produce a lookup candidate; `registry_match` and `match_normalised` try it after their exact lookups miss. A local-module default import keeps its project-qualified prefix after collapsing, so it can never collide with a sink key (pinned by test).

## Tests

RED first (c194edb9): the two aliased default-import forms fail on main; five sibling specs (same-name default, node: named/namespace forms, local-module guard) pass and pin the surrounding behavior. GREEN in 295bad1d. Full suite: 5229 passed.