### PR TITLE
fix(traversal): keep Cargo src bin binaries while ignoring build-output bin dirs

### DIFF
--- a/codebase_rag/constants/languages.py
+++ b/codebase_rag/constants/languages.py
@@ -283,6 +283,11 @@ class TreeSitterModule(StrEnum):
     DART = "tree_sitter_dart"
 
 
+# (H) Directory names with a context-dependent ignore: `bin` is build output
+# (H) everywhere EXCEPT Cargo's first-party src/bin/ binary layout.
+DIR_BIN = "bin"
+DIR_SRC = "src"
+
 # (H) Patterns to detect at repo root and offer as exclude candidates (user selects which to exclude)
 IGNORE_PATTERNS = frozenset(
     {

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1323,6 +1323,14 @@ class GraphUpdater:
             return False
         if dirname not in cs.IGNORE_PATTERNS:
             return True
+        # (H) Cargo's src/bin/ holds first-party binaries, not build output;
+        # (H) mirrors has_ignored_dir_part.
+        if (
+            dirname == cs.DIR_BIN
+            and dir_prefix.rstrip(cs.SEPARATOR_SLASH).rsplit(cs.SEPARATOR_SLASH, 1)[-1]
+            == cs.DIR_SRC
+        ):
+            return True
         return bool(
             self.unignore_paths
             and any(

--- a/codebase_rag/tests/test_rust_src_bin_ingestion.py
+++ b/codebase_rag/tests/test_rust_src_bin_ingestion.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.conftest import get_nodes, run_updater
+
+
+def _function_qns(ingestor: MagicMock) -> set[str]:
+    return {c.args[1]["qualified_name"] for c in get_nodes(ingestor, "Function")}
+
+
+def test_rust_src_bin_binaries_are_ingested(temp_repo: Path) -> None:
+    # (H) Cargo's standard multi-binary layout puts additional binaries under
+    # (H) src/bin/; the generic build-output ignore for `bin` directories must
+    # (H) not swallow it (mini-redis's entire cli.rs/server.rs were invisible).
+    root = temp_repo / "crate"
+    (root / "src" / "bin").mkdir(parents=True)
+    (root / "Cargo.toml").write_text(
+        '[package]\nname = "crate"\nversion = "0.1.0"\n', encoding="utf-8"
+    )
+    (root / "src" / "lib.rs").write_text(
+        "pub fn shared() -> u32 { 1 }\n", encoding="utf-8"
+    )
+    (root / "src" / "bin" / "cli.rs").write_text(
+        "fn main() { crate_lib_helper(); }\nfn crate_lib_helper() {}\n",
+        encoding="utf-8",
+    )
+
+    ingestor = MagicMock()
+    run_updater(root, ingestor, skip_if_missing="rust")
+
+    qns = _function_qns(ingestor)
+    assert any(qn.endswith("src.bin.cli.main") for qn in qns), qns
+    assert any(qn.endswith("src.bin.cli.crate_lib_helper") for qn in qns), qns
+
+
+def test_non_src_bin_directories_stay_ignored(temp_repo: Path) -> None:
+    # (H) Build-output bin/ trees (dotnet's <proj>/bin/Debug, a repo-root bin/)
+    # (H) keep the existing ignore.
+    root = temp_repo / "app"
+    (root / "bin").mkdir(parents=True)
+    (root / "proj" / "bin" / "Debug").mkdir(parents=True)
+    (root / "bin" / "tool.rs").write_text("fn ignored_root() {}\n", encoding="utf-8")
+    (root / "proj" / "bin" / "Debug" / "gen.rs").write_text(
+        "fn ignored_output() {}\n", encoding="utf-8"
+    )
+    (root / "lib.rs").write_text("pub fn kept() {}\n", encoding="utf-8")
+
+    ingestor = MagicMock()
+    run_updater(root, ingestor, skip_if_missing="rust")
+
+    qns = _function_qns(ingestor)
+    assert any(qn.endswith("lib.kept") for qn in qns), qns
+    assert not any("ignored_root" in qn for qn in qns), qns
+    assert not any("ignored_output" in qn for qn in qns), qns

--- a/codebase_rag/utils/path_utils.py
+++ b/codebase_rag/utils/path_utils.py
@@ -105,7 +105,20 @@ def should_skip_path(
         # (H) or rescued files get no Folder/Package ancestry in the graph.
         return False
     dir_parts = rel_path.parent.parts if _is_file else rel_path.parts
-    return not cs.IGNORE_PATTERNS.isdisjoint(dir_parts)
+    return has_ignored_dir_part(dir_parts)
+
+
+def has_ignored_dir_part(dir_parts: tuple[str, ...]) -> bool:
+    # (H) `bin` is a build-output ignore (dotnet's <proj>/bin, repo-root bin/)
+    # (H) EXCEPT directly under src/: Cargo's standard multi-binary layout puts
+    # (H) first-party binaries in src/bin/, and build systems never emit there.
+    for index, part in enumerate(dir_parts):
+        if part not in cs.IGNORE_PATTERNS:
+            continue
+        if part == cs.DIR_BIN and index > 0 and dir_parts[index - 1] == cs.DIR_SRC:
+            continue
+        return True
+    return False
 
 
 def should_skip_rel_file(
@@ -122,4 +135,4 @@ def should_skip_rel_file(
     # (H) unignore rescues only built-in ignores, never explicit user excludes.
     if unignore_paths and matches_ignore_patterns(rel_path_str, unignore_paths):
         return False
-    return not cs.IGNORE_PATTERNS.isdisjoint(dir_parts)
+    return has_ignored_dir_part(dir_parts)

--- a/uv.lock
+++ b/uv.lock
@@ -540,7 +540,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.388"
+version = "0.0.391"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Third find from the flow-edges dogfood: the built-in ignore list prunes ANY directory named `bin`, which swallows Cargo's standard `src/bin/` multi-binary layout. mini-redis's entire `src/bin/cli.rs` and `src/bin/server.rs` were invisible to the graph: no Function nodes, no CALLS, no IO or flow edges (9 of its 11 real `println!` write sites were missing), and dead-code loses the binary entry-point roots.

## What changed

`bin` stays a build-output ignore (dotnet's `<proj>/bin/Debug`, a repo-root `bin/`) EXCEPT when its parent directory is `src`, which is Cargo's first-party binary location and never a build-output target. Implemented once as `has_ignored_dir_part` in `path_utils` (replacing the two `isdisjoint` checks) and mirrored in the walk's `_should_keep_dir` prefix check.

## Validation

mini-redis re-dump: `src.bin.cli.main` now emits all 9 previously-missing WRITES_TO edges (11 total repo-wide, matching a manual count of every real non-doc-comment println site).

## Tests

RED first (e6bacb08): `src/bin/cli.rs` functions must be ingested, while a repo-root `bin/` and a `proj/bin/Debug/` stay ignored. GREEN in 4f3cfe17. Full suite: 5224 passed.