### PR TITLE
fix(go): type free-fn call bindings and honor receiver types in flow taint resolution

### DIFF
--- a/codebase_rag/constants/ast_go.py
+++ b/codebase_rag/constants/ast_go.py
@@ -60,6 +60,9 @@ TS_GO_UNARY_EXPRESSION = "unary_expression"
 # (H) lean flow walk so the operand's taint carries through (issue #714).
 TS_GO_TYPE_CONVERSION_EXPRESSION = "type_conversion_expression"
 TS_GO_POINTER_TYPE = "pointer_type"
+# (H) `pkg.Type` in a signature; kept as dotted text so a binding typed to an
+# (H) external package's type stays TYPED (and drops) instead of trie-guessed.
+TS_GO_QUALIFIED_TYPE = "qualified_type"
 # (H) Go composite types a method may return; a chained call lands on the CONTAINER,
 # (H) not its element, so return-type inference must not unwrap these to an element
 # (H) name (a `[]Command` return must not resolve `.Run()` to `Command.Run`).

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1776,7 +1776,13 @@ class CallProcessor:
             caller_node, caller_spec, module_qn, language
         )
         self._flow_processor.process_flow_for_caller(
-            caller_node, caller_spec, caller_qn, module_qn, language, class_context
+            caller_node,
+            caller_spec,
+            caller_qn,
+            module_qn,
+            language,
+            class_context,
+            local_var_types,
         )
 
         caller_params: frozenset[str] = frozenset()

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -158,6 +158,11 @@ class DefinitionProcessor(
         # (H) ingestion, so a chained call `x.foo().bar()` can resolve `bar` on the
         # (H) type `foo()` returns. Read by the resolver's chained-call path.
         self.method_return_types: dict[str, str] = {}
+        # (H) {go_free_fn_qn: first_return_type} for typing `v, err := f()`
+        # (H) bindings. Kept OFF method_return_types deliberately: that map
+        # (H) feeds chained-call resolution, where a multi-return callee is
+        # (H) uncallable and first-type recording would shift edge behavior.
+        self.go_function_return_types: dict[str, str] = {}
         # (H) Alias names seen with conflicting underlying types across scopes/files;
         # (H) dropped from type_aliases so their receivers fall back to name-only.
         self._type_alias_conflicts: set[str] = set()

--- a/codebase_rag/parsers/factory.py
+++ b/codebase_rag/parsers/factory.py
@@ -126,6 +126,7 @@ class ProcessorFactory:
                 class_field_types=self.definition_processor.class_field_types,
                 class_field_guard_inner=self.definition_processor.class_field_guard_inner,
                 method_return_types=self.definition_processor.method_return_types,
+                go_function_return_types=self.definition_processor.go_function_return_types,
                 csharp_partial_groups=self.definition_processor.csharp_partial_groups,
                 csharp_extension_methods=self.definition_processor.csharp_extension_methods,
                 csharp_call_sites=self.definition_processor.csharp_call_sites,

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -109,6 +109,11 @@ class _FlowCtx(NamedTuple):
     # (H) `std::cout << x` (stream insertion). Empty for languages without them.
     macro_sinks: dict[str, IOSink]
     stream_sinks: dict[str, IOSink]
+    # (H) The caller's local receiver types (same map the CALLS pipeline used):
+    # (H) callee resolution for taint edges must honor typed receivers, or an
+    # (H) external-typed `cl.Get` unique-binds back to the enclosing method and
+    # (H) fabricates a FLOWS_TO self edge (viper's Get -> Get).
+    local_var_types: dict[str, str] | None
 
 
 # (H) Languages whose local declarations hoist to the whole function scope (JS/TS
@@ -210,6 +215,7 @@ class FlowProcessor:
         module_qn: str,
         language: cs.SupportedLanguage,
         class_context: str | None,
+        local_var_types: dict[str, str] | None = None,
     ) -> None:
         if not self._enabled:
             return
@@ -229,6 +235,7 @@ class FlowProcessor:
             },
             macro_sinks=IO_MACRO_SINKS.get(language, {}),
             stream_sinks=IO_STREAM_SINKS.get(language, {}),
+            local_var_types=local_var_types,
         )
         # (H) Non-Python languages take a lean STRAIGHT-LINE flow walk (issue #714):
         # (H) taint from a read source (process.env, fetch, fs.readFile) reaching a
@@ -737,6 +744,7 @@ class FlowProcessor:
                 jc.flow.class_context,
                 jc.flow.caller_qn,
                 jc.flow.language,
+                jc.flow.local_var_types,
             )
             if callee is not None:
                 self._return_edge_candidates.append(
@@ -786,6 +794,7 @@ class FlowProcessor:
             jc.flow.class_context,
             jc.flow.caller_qn,
             jc.flow.language,
+            jc.flow.local_var_types,
         )
         if callee is None:
             return
@@ -1350,7 +1359,12 @@ class FlowProcessor:
                 tainted[lhs] = Taint(frozenset({seed}), frozenset())
                 return
             callee = self._resolve(
-                raw, ctx.module_qn, ctx.class_context, ctx.caller_qn, ctx.language
+                raw,
+                ctx.module_qn,
+                ctx.class_context,
+                ctx.caller_qn,
+                ctx.language,
+                ctx.local_var_types,
             )
             if callee is not None:
                 # (H) Defer: mark lhs pending on the callee's return and record a
@@ -1388,7 +1402,12 @@ class FlowProcessor:
                     )
             return
         callee = self._resolve(
-            raw, ctx.module_qn, ctx.class_context, ctx.caller_qn, ctx.language
+            raw,
+            ctx.module_qn,
+            ctx.class_context,
+            ctx.caller_qn,
+            ctx.language,
+            ctx.local_var_types,
         )
         if callee is None:
             return
@@ -1435,7 +1454,12 @@ class FlowProcessor:
                     result = _merge_taint(result, Taint(frozenset({seed}), frozenset()))
                     continue
                 callee = self._resolve(
-                    raw, ctx.module_qn, ctx.class_context, ctx.caller_qn, ctx.language
+                    raw,
+                    ctx.module_qn,
+                    ctx.class_context,
+                    ctx.caller_qn,
+                    ctx.language,
+                    ctx.local_var_types,
                 )
                 if callee is not None:
                     self._return_edge_candidates.append(
@@ -1578,9 +1602,10 @@ class FlowProcessor:
         class_context: str | None,
         caller_qn: str,
         language: cs.SupportedLanguage,
+        local_var_types: dict[str, str] | None = None,
     ) -> tuple[str, str] | None:
         info = self._resolver.resolve_function_call(
-            raw_name, module_qn, None, class_context, caller_qn, language
+            raw_name, module_qn, local_var_types, class_context, caller_qn, language
         )
         if info is None or info[1].startswith(_BUILTIN_QN_PREFIX):
             return None

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -209,6 +209,7 @@ class FunctionIngestMixin:
     _deferred_cpp_containment: list[_DeferredCppContainment]
     _deferred_parent_links: list[DeferredParentLink]
     method_return_types: dict[str, str]
+    go_function_return_types: dict[str, str]
     cpp_out_of_class_methods: dict[tuple[str, int], tuple[str, str]]
     function_locations: dict[FunctionSpanKey, FunctionLocation]
     cpp_definition_spans: dict[str, list[CppDefinitionSpan]]
@@ -372,6 +373,16 @@ class FunctionIngestMixin:
                 return_type := dart_return_type_name(func_node)
             ):
                 self.method_return_types[resolution.qualified_name] = return_type
+
+            # (H) Go free functions record their FIRST return type in a
+            # (H) dedicated map so `cm, err := getManager()` types cm under the
+            # (H) (T, error) idiom (viper's false Get->Get self edge). Not
+            # (H) method_return_types: chaining must keep skipping uncallable
+            # (H) multi-return callees.
+            if language == cs.SupportedLanguage.GO and (
+                return_type := go_utils.extract_first_return_type_name(func_node)
+            ):
+                self.go_function_return_types[resolution.qualified_name] = return_type
 
     def _function_span_claimed(self, module_qn: str, func_node: Node) -> bool:
         # (H) A span is claimed when a pass recorded THIS function node's

--- a/codebase_rag/parsers/go/__init__.py
+++ b/codebase_rag/parsers/go/__init__.py
@@ -1,6 +1,7 @@
 from .module_paths import discover_go_module_paths, resolve_go_import_path
 from .type_inference import GoTypeInferenceEngine
 from .utils import (
+    extract_first_return_type_name,
     extract_receiver_type_name,
     extract_return_type_name,
     is_receiver_method,
@@ -9,6 +10,7 @@ from .utils import (
 __all__ = [
     "GoTypeInferenceEngine",
     "discover_go_module_paths",
+    "extract_first_return_type_name",
     "extract_receiver_type_name",
     "extract_return_type_name",
     "is_receiver_method",

--- a/codebase_rag/parsers/go/utils.py
+++ b/codebase_rag/parsers/go/utils.py
@@ -36,6 +36,36 @@ def extract_return_type_name(node: Node) -> str | None:
     return _return_type_identifier(result)
 
 
+def extract_first_return_type_name(node: Node) -> str | None:
+    # (H) FIRST return type of a Go function, for typing `v, err := f()`
+    # (H) bindings under the (T, error) idiom. Unlike extract_return_type_name
+    # (H) (chaining, where a multi-return callee is uncallable so the skip is
+    # (H) correct), a parameter_list result contributes its first declared
+    # (H) type, and a qualified `pkg.T` keeps its dotted text so a local bound
+    # (H) to an external package's type stays typed rather than trie-guessed.
+    result = node.child_by_field_name(cs.FIELD_RESULT)
+    if result is None:
+        return None
+    if result.type == cs.TS_GO_PARAMETER_LIST:
+        for param in result.children:
+            if param.type != cs.TS_GO_PARAMETER_DECLARATION:
+                continue
+            type_node = param.child_by_field_name(cs.FIELD_TYPE)
+            return _first_return_identifier(type_node) if type_node else None
+        return None
+    return _first_return_identifier(result)
+
+
+def _first_return_identifier(type_node: Node) -> str | None:
+    if type_node.type == cs.TS_GO_QUALIFIED_TYPE:
+        return safe_decode_text(type_node)
+    if type_node.type == cs.TS_GO_POINTER_TYPE:
+        for child in type_node.named_children:
+            return _first_return_identifier(child)
+        return None
+    return _return_type_identifier(type_node)
+
+
 def _return_type_identifier(type_node: Node) -> str | None:
     # (H) Like type_identifier_text but does NOT unwrap composite types: a
     # (H) `[]Command`/`map[k]Command`/`chan Command` return is a container, and a

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -58,6 +58,8 @@ class TypeInferenceEngine:
         "_js_type_inference",
         "_python_type_inference",
         "_go_type_inference",
+        "_go_free_fn_index",
+        "_go_free_fn_index_size",
         "_rust_type_inference",
         "_cpp_type_inference",
         "_dart_type_inference",
@@ -122,6 +124,8 @@ class TypeInferenceEngine:
         self.go_function_return_types = (
             go_function_return_types if go_function_return_types is not None else {}
         )
+        self._go_free_fn_index: dict[tuple[str, str], str] = {}
+        self._go_free_fn_index_size = -1
         # (H) Shared reference (as with class_field_types): C# partial-class part
         # (H) groups, populated during ingestion and read by the C# resolver to
         # (H) span all parts of a split type.
@@ -392,25 +396,27 @@ class TypeInferenceEngine:
 
     def _go_free_fn_return_type(self, name: str, module_qn: str) -> str | None:
         # (H) Same module (file) first; then the enclosing package's sibling
-        # (H) files (same parent dir, exactly one file segment between), since
-        # (H) Go free functions are package-scoped, not file-scoped.
+        # (H) files (same parent dir), since Go free functions are
+        # (H) package-scoped, not file-scoped. The sibling lookup goes through
+        # (H) a lazily rebuilt (package, name) index: the shared map fills
+        # (H) DURING ingestion, so an init-time index would be empty, and the
+        # (H) size check rebuilds only when entries were added since.
         if hit := self.go_function_return_types.get(
             f"{module_qn}{cs.SEPARATOR_DOT}{name}"
         ):
             return hit
         if cs.SEPARATOR_DOT not in module_qn:
             return None
+        if len(self.go_function_return_types) != self._go_free_fn_index_size:
+            self._go_free_fn_index = {}
+            for qn, return_type in self.go_function_return_types.items():
+                head, _, fn_name = qn.rpartition(cs.SEPARATOR_DOT)
+                package, _, _file = head.rpartition(cs.SEPARATOR_DOT)
+                if package:
+                    self._go_free_fn_index.setdefault((package, fn_name), return_type)
+            self._go_free_fn_index_size = len(self.go_function_return_types)
         package_prefix = module_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
-        prefix_dots = package_prefix.count(cs.SEPARATOR_DOT)
-        suffix = f"{cs.SEPARATOR_DOT}{name}"
-        for qn, return_type in self.go_function_return_types.items():
-            if (
-                qn.endswith(suffix)
-                and qn.startswith(f"{package_prefix}{cs.SEPARATOR_DOT}")
-                and qn.count(cs.SEPARATOR_DOT) == prefix_dots + 2
-            ):
-                return return_type
-        return None
+        return self._go_free_fn_index.get((package_prefix, name))
 
     def _enrich_rust_call_locals(
         self, caller_node: ASTNode, module_qn: str, var_types: dict[str, str]

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -42,6 +42,7 @@ class TypeInferenceEngine:
         "class_field_types",
         "class_field_guard_inner",
         "method_return_types",
+        "go_function_return_types",
         "csharp_partial_groups",
         "csharp_extension_methods",
         "csharp_call_sites",
@@ -76,6 +77,7 @@ class TypeInferenceEngine:
         class_field_types: dict[str, dict[str, str]] | None = None,
         class_field_guard_inner: dict[str, dict[str, str]] | None = None,
         method_return_types: dict[str, str] | None = None,
+        go_function_return_types: dict[str, str] | None = None,
         csharp_partial_groups: dict[str, list[str]] | None = None,
         csharp_extension_methods: dict[str, list[tuple[str, str, str, int]]]
         | None = None,
@@ -114,6 +116,11 @@ class TypeInferenceEngine:
         # (H) resolver's chained-call path.
         self.method_return_types = (
             method_return_types if method_return_types is not None else {}
+        )
+        # (H) Shared reference (as with class_field_types): Go free-fn qn ->
+        # (H) FIRST return type, read only by the single-segment binding path.
+        self.go_function_return_types = (
+            go_function_return_types if go_function_return_types is not None else {}
         )
         # (H) Shared reference (as with class_field_types): C# partial-class part
         # (H) groups, populated during ingestion and read by the C# resolver to
@@ -364,8 +371,11 @@ class TypeInferenceEngine:
     ) -> str | None:
         # (H) `['e','trees','get']`: base `e` -> Engine (a typed local), field `trees`
         # (H) -> its struct-field type, then method `get` -> its recorded return type.
-        # (H) A plain function (`['f']`) has no receiver, so its return type is not in
-        # (H) the method map and stays unresolved (rare in the receiver-dispatch gap).
+        # (H) A plain function (`['f']`) types from the free-fn return map:
+        # (H) same-module first, then a same-package sibling file (Go package
+        # (H) scope spans the directory, viper's remote.go shape).
+        if len(segments) == 1:
+            return self._go_free_fn_return_type(segments[0], module_qn)
         if len(segments) < 2:
             return None
         base_type = var_types.get(segments[0])
@@ -379,6 +389,28 @@ class TypeInferenceEngine:
             class_qn = self._resolve_class_name(field_type, module_qn) or field_type
         method_qn = f"{class_qn}{cs.SEPARATOR_DOT}{segments[-1]}"
         return self.method_return_types.get(method_qn)
+
+    def _go_free_fn_return_type(self, name: str, module_qn: str) -> str | None:
+        # (H) Same module (file) first; then the enclosing package's sibling
+        # (H) files (same parent dir, exactly one file segment between), since
+        # (H) Go free functions are package-scoped, not file-scoped.
+        if hit := self.go_function_return_types.get(
+            f"{module_qn}{cs.SEPARATOR_DOT}{name}"
+        ):
+            return hit
+        if cs.SEPARATOR_DOT not in module_qn:
+            return None
+        package_prefix = module_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
+        prefix_dots = package_prefix.count(cs.SEPARATOR_DOT)
+        suffix = f"{cs.SEPARATOR_DOT}{name}"
+        for qn, return_type in self.go_function_return_types.items():
+            if (
+                qn.endswith(suffix)
+                and qn.startswith(f"{package_prefix}{cs.SEPARATOR_DOT}")
+                and qn.count(cs.SEPARATOR_DOT) == prefix_dots + 2
+            ):
+                return return_type
+        return None
 
     def _enrich_rust_call_locals(
         self, caller_node: ASTNode, module_qn: str, var_types: dict[str, str]

--- a/codebase_rag/tests/test_go_multi_return_receiver_typing.py
+++ b/codebase_rag/tests/test_go_multi_return_receiver_typing.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.conftest import get_relationships, run_updater
+
+_GO_MOD = "module example.com/multiret\n\ngo 1.22\n"
+
+_MULTI_RETURN_SRC = """package main
+
+type zmanager struct{}
+
+func (m zmanager) Get(key string) ([]byte, error) { return nil, nil }
+
+type provider struct{}
+
+func (p provider) Get(path string) ([]byte, error) {
+	cm, err := getManager()
+	if err != nil {
+		return nil, err
+	}
+	return cm.Get(path)
+}
+
+func getManager() (zmanager, error) { return zmanager{}, nil }
+"""
+
+_SINGLE_RETURN_SRC = """package main
+
+type worker struct{}
+
+func (w worker) Run() int { return 1 }
+
+type owner struct{}
+
+func (o owner) Run() int { return 2 }
+
+func (o owner) Drive() int {
+	h := makeWorker()
+	return h.Run()
+}
+
+func makeWorker() worker { return worker{} }
+"""
+
+_EXTERNAL_RETURN_SRC = """package main
+
+import "example.com/vendorpkg/thirdparty"
+
+type provider struct{}
+
+func (p provider) Do() {}
+
+func (p provider) Fetch() {
+	cl, err := connect()
+	if err != nil {
+		return
+	}
+	cl.Do()
+}
+
+func connect() (thirdparty.Client, error) {
+	var c thirdparty.Client
+	return c, nil
+}
+"""
+
+
+def _calls(ingestor: MagicMock) -> set[tuple[str, str]]:
+    return {(c.args[0][2], c.args[2][2]) for c in get_relationships(ingestor, "CALLS")}
+
+
+def _build(temp_repo: Path, name: str, source: str) -> set[tuple[str, str]]:
+    root = temp_repo / name
+    root.mkdir()
+    (root / "go.mod").write_text(_GO_MOD, encoding="utf-8")
+    (root / "main.go").write_text(source, encoding="utf-8")
+    ingestor = MagicMock()
+    run_updater(root, ingestor, skip_if_missing="go")
+    return _calls(ingestor)
+
+
+def test_multi_return_free_fn_binding_dispatches_real_receiver(
+    temp_repo: Path,
+) -> None:
+    # (H) `cm, err := getManager()` must type cm from getManager's FIRST return
+    # (H) (Go's (T, error) idiom), so `cm.Get` binds zmanager.Get instead of
+    # (H) trie-falling back to the enclosing provider.Get (a false SELF edge:
+    # (H) viper's remoteConfigProvider.Get -> Get). zmanager sorts AFTER
+    # (H) provider so an alphabetical trie coincidence cannot fake a pass.
+    calls = _build(temp_repo, "multi", _MULTI_RETURN_SRC)
+
+    assert any(
+        caller.endswith("provider.Get") and callee.endswith("zmanager.Get")
+        for caller, callee in calls
+    ), calls
+    assert not any(
+        caller.endswith("provider.Get") and callee.endswith("provider.Get")
+        for caller, callee in calls
+    ), calls
+
+
+def test_single_return_free_fn_binding_dispatches_real_receiver(
+    temp_repo: Path,
+) -> None:
+    calls = _build(temp_repo, "single", _SINGLE_RETURN_SRC)
+
+    assert any(
+        caller.endswith("owner.Drive") and callee.endswith("worker.Run")
+        for caller, callee in calls
+    ), calls
+    assert not any(
+        caller.endswith("owner.Drive") and callee.endswith("owner.Run")
+        for caller, callee in calls
+    ), calls
+
+
+def test_external_qualified_return_does_not_bind_local_decoy(
+    temp_repo: Path,
+) -> None:
+    # (H) connect() returns an EXTERNAL package's type: `cl` is typed but the
+    # (H) type resolves outside the repo, so `cl.Do()` must not bind the
+    # (H) same-module provider.Do decoy.
+    calls = _build(temp_repo, "external", _EXTERNAL_RETURN_SRC)
+
+    assert not any(
+        caller.endswith("provider.Fetch") and callee.endswith("provider.Do")
+        for caller, callee in calls
+    ), calls

--- a/codebase_rag/tests/test_go_multi_return_receiver_typing.py
+++ b/codebase_rag/tests/test_go_multi_return_receiver_typing.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock
 
+from codebase_rag import constants as cs
+from codebase_rag.capture import resolve_capture
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
 from codebase_rag.tests.conftest import get_relationships, run_updater
+
+_CAPTURE_IO = resolve_capture([cs.CaptureGroup.IO.value])
 
 _GO_MOD = "module example.com/multiret\n\ngo 1.22\n"
 
@@ -114,6 +120,68 @@ def test_single_return_free_fn_binding_dispatches_real_receiver(
         caller.endswith("owner.Drive") and callee.endswith("owner.Run")
         for caller, callee in calls
     ), calls
+
+
+_FLOW_SELF_EDGE_SRC = """package main
+
+import (
+	"os"
+
+	"example.com/vendorpkg/thirdparty"
+)
+
+type provider struct{}
+
+func (p provider) Get(path string) ([]byte, error) {
+	cl, err := connect()
+	if err != nil {
+		return nil, err
+	}
+	b, err := cl.Get(path)
+	if err != nil {
+		return nil, err
+	}
+	if b == nil {
+		raw, _ := os.ReadFile(path)
+		return raw, nil
+	}
+	return b, nil
+}
+
+func connect() (thirdparty.Client, error) {
+	var c thirdparty.Client
+	return c, nil
+}
+"""
+
+
+def test_flow_return_taint_honors_receiver_typing(temp_repo: Path) -> None:
+    # (H) The flow walk resolves callees for return-taint edges itself; without
+    # (H) the caller's local type map, `cl.Get` on an external-typed receiver
+    # (H) unique-binds back to the enclosing provider.Get and finalize emits
+    # (H) the FLOWS_TO self edge the CALLS pipeline had already correctly
+    # (H) dropped (viper's remoteConfigProvider Get -> Get).
+    root = temp_repo / "flowmulti"
+    root.mkdir()
+    (root / "go.mod").write_text(_GO_MOD, encoding="utf-8")
+    (root / "main.go").write_text(_FLOW_SELF_EDGE_SRC, encoding="utf-8")
+    parsers, queries = load_parsers()
+    ingestor = MagicMock()
+    GraphUpdater(
+        ingestor=ingestor,
+        repo_path=root,
+        parsers=parsers,
+        queries=queries,
+        capture=_CAPTURE_IO,
+    ).run()
+
+    flows = {
+        (c.args[0][2], c.args[2][2]) for c in get_relationships(ingestor, "FLOWS_TO")
+    }
+    assert not any(
+        source.endswith("provider.Get") and target.endswith("provider.Get")
+        for source, target in flows
+    ), flows
 
 
 def test_external_qualified_return_does_not_bind_local_decoy(

--- a/uv.lock
+++ b/uv.lock
@@ -540,7 +540,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.388"
+version = "0.0.391"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Fourth find from the flow-edges dogfood: viper's `remoteConfigProvider.Get` carried a false SELF edge (`Get -> Get`, both CALLS-side historically and FLOWS_TO). Two composing defects, each fixed RED to GREEN:

## 1. Go free-function call bindings never typed their local

`cm, err := getConfigManager(rp)` collected a binding for `cm`, but `_infer_go_call_return_type` bailed on single-segment callees (free functions), so `cm` stayed untyped and `cm.Get` trie-bound to the enclosing method. Same gap the Rust side closed in #681.

- `extract_first_return_type_name` (go/utils.py) reads a Go function's FIRST return type: single returns as before, a `parameter_list` result contributes its first declared type (the `(T, error)` idiom), and a qualified `pkg.T` keeps its dotted text so a local bound to an external package's type stays typed (and drops) instead of trie-guessed.
- Recorded in a dedicated `go_function_return_types` map, deliberately NOT `method_return_types`: that map feeds chained-call resolution, where multi-return callees are uncallable and first-type recording would shift edge behavior.
- `_infer_go_call_return_type` resolves single-segment callees through the new map: same module first, then same-package sibling files (Go free functions are package-scoped).

## 2. The flow walk resolved taint callees without the caller's local types

The FLOWS_TO return-taint pipeline resolves callees itself, and `_resolve` passed `None` for `local_var_types`. With `cl` untyped, an external-typed `cl.Get` unique-bound back to the enclosing `provider.Get` and finalize emitted the FLOWS_TO self edge the CALLS pipeline had already correctly dropped (confirmed by instrumenting the resolver on viper). `_FlowCtx` now carries the same local type map the CALLS pipeline used, and all five resolution sites pass it through.

## Validation

viper full-repo re-dump: `remoteConfigProvider.Get` self edges 0 (was present on main); its legit edges (`getConfigManager`, `defaultRemoteProvider.Path`) remain. gin/cobra Go suites pass unchanged.

## Tests

RED first, two rounds in history (f4d00a85, 2e17d7cb): multi-return binding with an after-sorting decoy (alphabetical trie coincidence cannot fake a pass), single-return binding, external-qualified return not binding a local decoy, and the viper-shaped FLOWS_TO self-edge repro (unique same-name method + tainted return). GREEN in 84ba9c3b and 8e06d63e. Full suite post-merge with main: 5241 passed.