### PR TITLE
feat(flow): switch-family path sensitivity for the lean flow walk

### DIFF
--- a/codebase_rag/constants/ast_cpp.py
+++ b/codebase_rag/constants/ast_cpp.py
@@ -193,6 +193,10 @@ CPP_OP_LEFT_SHIFT = "<<"
 # (H) READ of that handle's resource (issue #714).
 CPP_OP_RIGHT_SHIFT = ">>"
 TS_CPP_FOR_RANGE_LOOP = "for_range_loop"
+# (H) Switch family: cases may fall through; a default arm is a
+# (H) case_statement without a `value` field.
+TS_CPP_SWITCH_STATEMENT = "switch_statement"
+TS_CPP_CASE_STATEMENT = "case_statement"
 # (H) field_expression = `obj.field` (argument/field); subscript_expression =
 # (H) `arr[i]` (argument/indices). Inert for C++ I/O (env access is a call), wired for
 # (H) correctness / future value-level sinks.

--- a/codebase_rag/constants/ast_go.py
+++ b/codebase_rag/constants/ast_go.py
@@ -47,6 +47,9 @@ TS_GO_EXPRESSION_CASE = "expression_case"
 TS_GO_TYPE_CASE = "type_case"
 TS_GO_COMMUNICATION_CASE = "communication_case"
 TS_GO_DEFAULT_CASE = "default_case"
+# (H) Legal only as an arm's LAST statement; transfers into the next case.
+TS_GO_FALLTHROUGH_STATEMENT = "fallthrough_statement"
+TS_GO_STATEMENT_LIST = "statement_list"
 TS_GO_BLOCK = "block"
 # (H) Go wraps a block's statements in a single `statement_list` node (unlike JS/Java,
 # (H) whose block children are the statements directly); the source-order I/O walk

--- a/codebase_rag/constants/ast_go.py
+++ b/codebase_rag/constants/ast_go.py
@@ -39,6 +39,14 @@ TS_GO_RANGE_CLAUSE = "range_clause"
 # (H) The init;cond;post header of a C-style Go for; its post statement lives in
 # (H) an `update` field.
 TS_GO_FOR_CLAUSE = "for_clause"
+# (H) Switch family: arms are EXCLUSIVE (Go has no implicit fallthrough).
+TS_GO_EXPRESSION_SWITCH_STATEMENT = "expression_switch_statement"
+TS_GO_TYPE_SWITCH_STATEMENT = "type_switch_statement"
+TS_GO_SELECT_STATEMENT = "select_statement"
+TS_GO_EXPRESSION_CASE = "expression_case"
+TS_GO_TYPE_CASE = "type_case"
+TS_GO_COMMUNICATION_CASE = "communication_case"
+TS_GO_DEFAULT_CASE = "default_case"
 TS_GO_BLOCK = "block"
 # (H) Go wraps a block's statements in a single `statement_list` node (unlike JS/Java,
 # (H) whose block children are the statements directly); the source-order I/O walk

--- a/codebase_rag/constants/ast_java.py
+++ b/codebase_rag/constants/ast_java.py
@@ -31,6 +31,12 @@ TS_DECIMAL_FLOATING_POINT_LITERAL = "decimal_floating_point_literal"
 TS_ARRAY_CREATION_EXPRESSION = "array_creation_expression"
 TS_METHOD_DECLARATION = "method_declaration"
 TS_ENHANCED_FOR_STATEMENT = "enhanced_for_statement"
+# (H) Switch family: colon groups may fall through, arrow rules are exclusive;
+# (H) a default arm is a switch_label with no named children.
+TS_JAVA_SWITCH_EXPRESSION = "switch_expression"
+TS_JAVA_SWITCH_RULE = "switch_rule"
+TS_JAVA_SWITCH_BLOCK_STATEMENT_GROUP = "switch_block_statement_group"
+TS_JAVA_SWITCH_LABEL = "switch_label"
 TS_TRY_WITH_RESOURCES_STATEMENT = "try_with_resources_statement"
 # (H) One declaration inside a try-with-resources header; binds via `name`/`value`
 # (H) fields exactly like a variable_declarator.

--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -181,6 +181,10 @@ JS_ASSIGNMENT_FUNCTION_QUERY = """
 # (H) values coincide with the Python grammar's but stay JS-scoped per the per-language
 # (H) constants convention.
 TS_JS_IF_STATEMENT = "if_statement"
+# (H) Switch family: cases may fall through into the next case.
+TS_JS_SWITCH_STATEMENT = "switch_statement"
+TS_JS_SWITCH_CASE = "switch_case"
+TS_JS_SWITCH_DEFAULT = "switch_default"
 TS_JS_ELSE_CLAUSE = "else_clause"
 TS_JS_WHILE_STATEMENT = "while_statement"
 TS_JS_FOR_STATEMENT = "for_statement"

--- a/codebase_rag/constants/ast_nodes.py
+++ b/codebase_rag/constants/ast_nodes.py
@@ -229,6 +229,8 @@ TS_TEMPLATE_ARGUMENT_LIST = "template_argument_list"
 TS_ARGUMENT_LIST = "argument_list"
 # (H) `do { .. } while (cond)` -- same node type in the Java and C++ grammars.
 TS_DO_STATEMENT = "do_statement"
+# (H) Shared verbatim by the JS/TS, Java, and C++ grammars.
+TS_BREAK_STATEMENT = "break_statement"
 TS_TYPE_DESCRIPTOR = "type_descriptor"
 TS_TYPE_IDENTIFIER = "type_identifier"
 

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -191,6 +191,43 @@ _FALLTHROUGH_ARM_TYPES = frozenset(
 _EXPLICIT_DEFAULT_ARM_TYPES = frozenset(
     {cs.TS_GO_DEFAULT_CASE, cs.TS_JS_SWITCH_DEFAULT}
 )
+
+# (H) Constructs that capture a `break` of their own: a break nested inside one
+# (H) of these targets IT, not the enclosing switch, so the break search stops
+# (H) descending there.
+_BREAK_BOUNDARY_TYPES = frozenset(
+    {
+        cs.TS_JS_WHILE_STATEMENT,
+        cs.TS_JS_FOR_STATEMENT,
+        cs.TS_JS_FOR_IN_STATEMENT,
+        cs.TS_ENHANCED_FOR_STATEMENT,
+        cs.TS_CPP_FOR_RANGE_LOOP,
+        cs.TS_DO_STATEMENT,
+        cs.TS_GO_EXPRESSION_SWITCH_STATEMENT,
+        cs.TS_GO_TYPE_SWITCH_STATEMENT,
+        cs.TS_GO_SELECT_STATEMENT,
+        cs.TS_JAVA_SWITCH_EXPRESSION,
+        cs.TS_CPP_SWITCH_STATEMENT,
+        cs.TS_JS_SWITCH_STATEMENT,
+    }
+)
+
+
+def _arm_may_break(arm: Node) -> bool:
+    # (H) True when the arm holds a break at ITS OWN nesting level (a break in
+    # (H) a nested loop/switch targets that construct). Labeled breaks
+    # (H) over-approximate to True, the sound MAY direction.
+    stack = list(arm.named_children)
+    while stack:
+        node = stack.pop()
+        if node.type == cs.TS_BREAK_STATEMENT:
+            return True
+        if node.type in _BREAK_BOUNDARY_TYPES:
+            continue
+        stack.extend(node.named_children)
+    return False
+
+
 _JAVA_SWITCH_ARM_TYPES = frozenset(
     {cs.TS_JAVA_SWITCH_RULE, cs.TS_JAVA_SWITCH_BLOCK_STATEMENT_GROUP}
 )
@@ -205,15 +242,12 @@ def _switch_arm_is_default(arm: Node) -> bool:
     if arm.type == cs.TS_CPP_CASE_STATEMENT:
         return arm.child_by_field_name(cs.FIELD_VALUE) is None
     if arm.type in _JAVA_SWITCH_ARM_TYPES:
-        label = next(
-            (
-                child
-                for child in arm.named_children
-                if child.type == cs.TS_JAVA_SWITCH_LABEL
-            ),
-            None,
+        # (H) A group can stack labels (`case 1: default:`), so ANY empty
+        # (H) label marks the arm as the default target.
+        return any(
+            child.type == cs.TS_JAVA_SWITCH_LABEL and child.named_child_count == 0
+            for child in arm.named_children
         )
-        return label is not None and label.named_child_count == 0
     return False
 
 
@@ -590,14 +624,23 @@ class FlowProcessor:
         exits: list[_TaintMap] = []
         previous_exit: _TaintMap | None = None
         has_default = False
-        for arm in arms:
+        for index, arm in enumerate(arms):
             has_default = has_default or _switch_arm_is_default(arm)
             entry = dict(state)
             if previous_exit is not None and arm.type in _FALLTHROUGH_ARM_TYPES:
                 entry = self._merge([entry, previous_exit])
             arm_exit = walk(arm, entry, jc)
             self._restore_shadows(pre_arm_shadows, jc)
-            exits.append(arm_exit)
+            # (H) A non-final fallthrough arm without its own break never
+            # (H) terminates the switch (a stacked `case 1: default:` label's
+            # (H) empty group falls straight through), so its exit reaches the
+            # (H) merge only THROUGH the next arm's walk, not directly.
+            if (
+                index == len(arms) - 1
+                or arm.type not in _FALLTHROUGH_ARM_TYPES
+                or _arm_may_break(arm)
+            ):
+                exits.append(arm_exit)
             previous_exit = arm_exit
         if not has_default:
             exits.append(dict(state))

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -198,11 +198,24 @@ _JAVA_SWITCH_ARM_TYPES = frozenset(
 )
 
 
-def _ends_with_break(arm: Node) -> bool:
-    # (H) True when the arm's last top-level statement is a plain break, so
-    # (H) control can never reach the next arm by falling off this one's end.
+def _last_arm_statement(arm: Node) -> Node | None:
+    # (H) The arm's last top-level statement; Go nests arm statements inside a
+    # (H) statement_list, the C-family grammars keep them flat.
     last = arm.named_children[-1] if arm.named_children else None
-    return last is not None and last.type == cs.TS_BREAK_STATEMENT
+    if last is not None and last.type == cs.TS_GO_STATEMENT_LIST:
+        return last.named_children[-1] if last.named_children else None
+    return last
+
+
+def _arm_falls_into_next(arm: Node) -> bool:
+    # (H) Whether control can leave this arm by entering the NEXT one: a
+    # (H) C-family arm falls through unless its last statement is a plain
+    # (H) break (the break snapshot already carried that path out); a Go arm
+    # (H) falls only via the explicit trailing `fallthrough` keyword.
+    last = _last_arm_statement(arm)
+    if arm.type in _FALLTHROUGH_ARM_TYPES:
+        return last is None or last.type != cs.TS_BREAK_STATEMENT
+    return last is not None and last.type == cs.TS_GO_FALLTHROUGH_STATEMENT
 
 
 def _switch_arm_is_default(arm: Node) -> bool:
@@ -646,7 +659,10 @@ class FlowProcessor:
         for index, arm in enumerate(arms):
             has_default = has_default or _switch_arm_is_default(arm)
             entry = dict(state)
-            if fall_in is not None and arm.type in _FALLTHROUGH_ARM_TYPES:
+            # (H) fall_in is non-None exactly when the PREVIOUS arm can fall
+            # (H) into this one (C-family arm without a trailing break, or a Go
+            # (H) arm ending in the explicit `fallthrough` keyword).
+            if fall_in is not None:
                 entry = self._merge([entry, fall_in])
             # (H) Each break inside the arm exits the switch with the state it
             # (H) saw THEN (a conditional break before a later kill carries the
@@ -658,18 +674,15 @@ class FlowProcessor:
                 break_exits = self._break_exit_stack.pop() or []
             self._restore_shadows(pre_arm_shadows, jc)
             exits.extend(break_exits)
-            # (H) A non-final fallthrough arm's END state never exits the
-            # (H) switch directly (control continues into the next arm; a
-            # (H) stacked `case 1: default:` label's empty group falls straight
-            # (H) through), so it reaches the merge only THROUGH the next arm.
-            if index == len(arms) - 1 or arm.type not in _FALLTHROUGH_ARM_TYPES:
+            falls = index < len(arms) - 1 and _arm_falls_into_next(arm)
+            # (H) An arm's END state exits the switch directly only when it
+            # (H) does NOT continue into the next arm (a falling arm's state
+            # (H) reaches the merge THROUGH that arm instead; a stacked
+            # (H) `case 1: default:` label's empty group falls straight
+            # (H) through).
+            if not falls:
                 exits.append(arm_exit)
-            # (H) An arm whose LAST top-level statement is an unconditional
-            # (H) break has no fall-through path: its end state must not feed
-            # (H) the next arm's entry (the break snapshot already carried it
-            # (H) out). Conditional breaks keep the full end state, the sound
-            # (H) over-approximation.
-            fall_in = None if _ends_with_break(arm) else arm_exit
+            fall_in = arm_exit if falls else None
         return exits, has_default
 
     def _walk_flat_match(self, node: Node, state: _TaintMap, jc: _JsCtx) -> _TaintMap:

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict, deque
+from collections.abc import Callable
 from typing import NamedTuple
 
 from tree_sitter import Node
@@ -146,6 +147,74 @@ _FLAT_MANDATORY_LOOP_TYPES = frozenset({cs.TS_DO_STATEMENT, cs.TS_RS_LOOP_EXPRES
 _FLAT_TRY_TYPES = frozenset(
     {cs.TS_JS_TRY_STATEMENT, cs.TS_TRY_WITH_RESOURCES_STATEMENT}
 )
+# (H) Switch-family statements routed to the shared branch-and-merge walker.
+# (H) C++'s "switch_statement" string is shared with JS, but the flat walk only
+# (H) ever sees C++ trees (JS routes through its own walk).
+_FLAT_SWITCH_TYPES = frozenset(
+    {
+        cs.TS_GO_EXPRESSION_SWITCH_STATEMENT,
+        cs.TS_GO_TYPE_SWITCH_STATEMENT,
+        cs.TS_GO_SELECT_STATEMENT,
+        cs.TS_JAVA_SWITCH_EXPRESSION,
+        cs.TS_CPP_SWITCH_STATEMENT,
+    }
+)
+# (H) Every case-arm node type across the grammars; arms NOT in the
+# (H) fallthrough subset are exclusive (entered only from the switch header).
+_SWITCH_ARM_TYPES = frozenset(
+    {
+        cs.TS_GO_EXPRESSION_CASE,
+        cs.TS_GO_TYPE_CASE,
+        cs.TS_GO_COMMUNICATION_CASE,
+        cs.TS_GO_DEFAULT_CASE,
+        cs.TS_JAVA_SWITCH_RULE,
+        cs.TS_JAVA_SWITCH_BLOCK_STATEMENT_GROUP,
+        cs.TS_CPP_CASE_STATEMENT,
+        cs.TS_JS_SWITCH_CASE,
+        cs.TS_JS_SWITCH_DEFAULT,
+    }
+)
+# (H) Arms a previous case can fall INTO (no break modeling: the entry unions
+# (H) the previous arm's exit). Go cases and Java arrow rules never fall
+# (H) through, so they enter only from the header state.
+_FALLTHROUGH_ARM_TYPES = frozenset(
+    {
+        cs.TS_JAVA_SWITCH_BLOCK_STATEMENT_GROUP,
+        cs.TS_CPP_CASE_STATEMENT,
+        cs.TS_JS_SWITCH_CASE,
+        cs.TS_JS_SWITCH_DEFAULT,
+    }
+)
+
+# (H) Arm node types spelled `default` explicitly (Go default_case, JS
+# (H) switch_default); the other grammars mark default structurally.
+_EXPLICIT_DEFAULT_ARM_TYPES = frozenset(
+    {cs.TS_GO_DEFAULT_CASE, cs.TS_JS_SWITCH_DEFAULT}
+)
+_JAVA_SWITCH_ARM_TYPES = frozenset(
+    {cs.TS_JAVA_SWITCH_RULE, cs.TS_JAVA_SWITCH_BLOCK_STATEMENT_GROUP}
+)
+
+
+def _switch_arm_is_default(arm: Node) -> bool:
+    # (H) C++ default is a case_statement without a `value` field; a Java
+    # (H) default arm's switch_label has no named children (a case label
+    # (H) carries its pattern/expression there).
+    if arm.type in _EXPLICIT_DEFAULT_ARM_TYPES:
+        return True
+    if arm.type == cs.TS_CPP_CASE_STATEMENT:
+        return arm.child_by_field_name(cs.FIELD_VALUE) is None
+    if arm.type in _JAVA_SWITCH_ARM_TYPES:
+        label = next(
+            (
+                child
+                for child in arm.named_children
+                if child.type == cs.TS_JAVA_SWITCH_LABEL
+            ),
+            None,
+        )
+        return label is not None and label.named_child_count == 0
+    return False
 
 
 class _JsCtx(NamedTuple):
@@ -237,12 +306,14 @@ class FlowProcessor:
             stream_sinks=IO_STREAM_SINKS.get(language, {}),
             local_var_types=local_var_types,
         )
-        # (H) Non-Python languages take a lean STRAIGHT-LINE flow walk (issue #714):
-        # (H) taint from a read source (process.env, fetch, fs.readFile) reaching a
-        # (H) write sink emits a resource->resource flow, a tainted value passed to a
-        # (H) callee emits an arg edge, and a returned tainted value feeds the shared
-        # (H) return-taint fixpoint. No path-sensitivity yet (that is a follow-up),
-        # (H) and Python keeps its full path-sensitive walk below.
+        # (H) Non-Python languages take the lean flow walk (issue #714): taint
+        # (H) from a read source (process.env, fetch, fs.readFile) reaching a
+        # (H) write sink emits a resource->resource flow, a tainted value passed
+        # (H) to a callee emits an arg edge, and a returned tainted value feeds
+        # (H) the shared return-taint fixpoint. The walk is path-sensitive to
+        # (H) Python's level: if/loops/try branch-and-merge, plus each
+        # (H) language's own branching forms (Rust match, the switch family,
+        # (H) Go select, do-while). Python keeps its original walk below.
         if language != cs.SupportedLanguage.PYTHON:
             descriptor = LANGUAGE_DESCRIPTORS.get(language)
             if descriptor is not None:
@@ -331,6 +402,8 @@ class FlowProcessor:
             return self._walk_flat_mandatory_loop(node, state, jc)
         if node_type in _FLAT_TRY_TYPES:
             return self._walk_flat_try(node, state, jc)
+        if node_type in _FLAT_SWITCH_TYPES:
+            return self._walk_switch(node, state, jc, self._walk_flat_stmt)
         if node_type == cs.TS_RS_MATCH_EXPRESSION:
             return self._walk_flat_match(node, state, jc)
         self._apply_js_leaf(node, state, jc)
@@ -413,20 +486,29 @@ class FlowProcessor:
         # (H) exactly like _walk_flat_loop. `break` is not modelled: a kill
         # (H) below a conditional break still counts, the accepted flat-walk
         # (H) approximation.
+        return self._walk_mandatory_loop(node, state, jc, self._walk_flat_stmt)
+
+    def _walk_mandatory_loop(
+        self,
+        node: Node,
+        state: _TaintMap,
+        jc: _JsCtx,
+        walk: Callable[[Node, _TaintMap, _JsCtx], _TaintMap],
+    ) -> _TaintMap:
         body = node.child_by_field_name(cs.FIELD_BODY)
         condition = node.child_by_field_name(cs.TS_FIELD_CONDITION)
         pre_shadows = set(jc.local_names)
         once = dict(state)
         if body is not None:
-            once = self._walk_flat_stmt(body, once, jc)
+            once = walk(body, once, jc)
         if condition is not None:
-            once = self._walk_flat_stmt(condition, once, jc)
+            once = walk(condition, once, jc)
         self._restore_shadows(pre_shadows, jc)
         twice = dict(once)
         if body is not None:
-            twice = self._walk_flat_stmt(body, twice, jc)
+            twice = walk(body, twice, jc)
         if condition is not None:
-            twice = self._walk_flat_stmt(condition, twice, jc)
+            twice = walk(condition, twice, jc)
         self._restore_shadows(pre_shadows, jc)
         return self._merge([once, twice])
 
@@ -469,6 +551,58 @@ class FlowProcessor:
             merged = self._walk_flat_stmt(finally_clause, merged, jc)
             self._restore_shadows(pre_shadows, jc)
         return merged
+
+    def _walk_switch(
+        self,
+        node: Node,
+        state: _TaintMap,
+        jc: _JsCtx,
+        walk: Callable[[Node, _TaintMap, _JsCtx], _TaintMap],
+    ) -> _TaintMap:
+        # (H) Shared switch-family branch-and-merge (Go switch/type-switch/
+        # (H) select, Java switch, C++ switch, JS/TS switch). The header
+        # (H) (initializer, switched value, condition) runs on all paths; each
+        # (H) arm walks against a copy and the exits union (MAY join). An
+        # (H) exclusive arm (Go, Java arrow rule) enters from the header state
+        # (H) only; a fallthrough-capable arm also unions the previous arm's
+        # (H) exit (break is not modelled, so the fallthrough entry is the
+        # (H) sound over-approximation). Without a default arm the implicit
+        # (H) no-match path joins the exit merge; with one, some arm always
+        # (H) runs, so a kill on EVERY arm kills.
+        body = node.child_by_field_name(cs.FIELD_BODY)
+        arm_container = body if body is not None else node
+        arms = [
+            child
+            for child in arm_container.named_children
+            if child.type in _SWITCH_ARM_TYPES
+        ]
+        arm_ids = {arm.id for arm in arms}
+        if body is not None:
+            arm_ids.add(body.id)
+        pre_switch_shadows = set(jc.local_names)
+        for child in node.named_children:
+            if child.id not in arm_ids:
+                state = walk(child, state, jc)
+        if not arms:
+            self._restore_shadows(pre_switch_shadows, jc)
+            return state
+        pre_arm_shadows = set(jc.local_names)
+        exits: list[_TaintMap] = []
+        previous_exit: _TaintMap | None = None
+        has_default = False
+        for arm in arms:
+            has_default = has_default or _switch_arm_is_default(arm)
+            entry = dict(state)
+            if previous_exit is not None and arm.type in _FALLTHROUGH_ARM_TYPES:
+                entry = self._merge([entry, previous_exit])
+            arm_exit = walk(arm, entry, jc)
+            self._restore_shadows(pre_arm_shadows, jc)
+            exits.append(arm_exit)
+            previous_exit = arm_exit
+        if not has_default:
+            exits.append(dict(state))
+        self._restore_shadows(pre_switch_shadows, jc)
+        return self._merge(exits)
 
     def _walk_flat_match(self, node: Node, state: _TaintMap, jc: _JsCtx) -> _TaintMap:
         # (H) Rust match: the scrutinee runs on all paths; each arm is walked
@@ -544,6 +678,13 @@ class FlowProcessor:
             return self._walk_js_loop(node, state, jc)
         if node_type == cs.TS_JS_TRY_STATEMENT:
             return self._walk_js_try(node, state, jc)
+        if node_type == cs.TS_JS_SWITCH_STATEMENT:
+            return self._walk_switch(node, state, jc, self._walk_js_stmt)
+        if node_type == cs.TS_DO_STATEMENT:
+            # (H) do-while: the body always runs once and the condition runs
+            # (H) AFTER it, so this is the mandatory-loop shape, not the
+            # (H) zero-or-more loop walk.
+            return self._walk_mandatory_loop(node, state, jc, self._walk_js_stmt)
         self._apply_js_leaf(node, state, jc)
         for child in node.named_children:
             state = self._walk_js_stmt(child, state, jc)

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -192,41 +192,6 @@ _EXPLICIT_DEFAULT_ARM_TYPES = frozenset(
     {cs.TS_GO_DEFAULT_CASE, cs.TS_JS_SWITCH_DEFAULT}
 )
 
-# (H) Constructs that capture a `break` of their own: a break nested inside one
-# (H) of these targets IT, not the enclosing switch, so the break search stops
-# (H) descending there.
-_BREAK_BOUNDARY_TYPES = frozenset(
-    {
-        cs.TS_JS_WHILE_STATEMENT,
-        cs.TS_JS_FOR_STATEMENT,
-        cs.TS_JS_FOR_IN_STATEMENT,
-        cs.TS_ENHANCED_FOR_STATEMENT,
-        cs.TS_CPP_FOR_RANGE_LOOP,
-        cs.TS_DO_STATEMENT,
-        cs.TS_GO_EXPRESSION_SWITCH_STATEMENT,
-        cs.TS_GO_TYPE_SWITCH_STATEMENT,
-        cs.TS_GO_SELECT_STATEMENT,
-        cs.TS_JAVA_SWITCH_EXPRESSION,
-        cs.TS_CPP_SWITCH_STATEMENT,
-        cs.TS_JS_SWITCH_STATEMENT,
-    }
-)
-
-
-def _arm_may_break(arm: Node) -> bool:
-    # (H) True when the arm holds a break at ITS OWN nesting level (a break in
-    # (H) a nested loop/switch targets that construct). Labeled breaks
-    # (H) over-approximate to True, the sound MAY direction.
-    stack = list(arm.named_children)
-    while stack:
-        node = stack.pop()
-        if node.type == cs.TS_BREAK_STATEMENT:
-            return True
-        if node.type in _BREAK_BOUNDARY_TYPES:
-            continue
-        stack.extend(node.named_children)
-    return False
-
 
 _JAVA_SWITCH_ARM_TYPES = frozenset(
     {cs.TS_JAVA_SWITCH_RULE, cs.TS_JAVA_SWITCH_BLOCK_STATEMENT_GROUP}
@@ -297,6 +262,12 @@ class FlowProcessor:
         # (H) caller_spec, callee_type, callee_qn, via) emit iff a pending callee
         # (H) resolves to a tainted return.
         self._return_edge_candidates: list[tuple[str, str, tuple[str, str, str]]] = []
+        # (H) Break-exit collectors: the top list captures the taint state AT
+        # (H) each `break` inside the switch arm being walked (a break exits
+        # (H) the switch with the state it saw THEN, not the arm's end state).
+        # (H) Loop walkers push None to shield the collector: a break in a
+        # (H) nested loop targets that loop, not the enclosing switch.
+        self._break_exit_stack: list[list[_TaintMap] | None] = []
         self._deferred_resource_flows: list[
             tuple[frozenset[str], ResourceKind, str]
         ] = []
@@ -428,6 +399,9 @@ class FlowProcessor:
         node_type = node.type
         if node_type in jc.descriptor.nested_scope_types:
             return state
+        if node_type == cs.TS_BREAK_STATEMENT:
+            self._record_break_exit(state)
+            return state
         if node_type in _FLAT_IF_TYPES:
             return self._walk_flat_if(node, state, jc)
         if node_type in _FLAT_LOOP_TYPES:
@@ -446,6 +420,17 @@ class FlowProcessor:
         return state
 
     def _walk_flat_loop(self, node: Node, state: _TaintMap, jc: _JsCtx) -> _TaintMap:
+        # (H) Loop shield: a break inside the body targets THIS loop, never an
+        # (H) enclosing switch arm's collector.
+        self._shield_breaks()
+        try:
+            return self._walk_flat_loop_inner(node, state, jc)
+        finally:
+            self._unshield_breaks()
+
+    def _walk_flat_loop_inner(
+        self, node: Node, state: _TaintMap, jc: _JsCtx
+    ) -> _TaintMap:
         # (H) The body runs zero or more times: union the skip path with one pass,
         # (H) then re-walk once from that merge so taint carried from a later
         # (H) iteration into an earlier statement is caught (same two-pass
@@ -523,6 +508,21 @@ class FlowProcessor:
         return self._walk_mandatory_loop(node, state, jc, self._walk_flat_stmt)
 
     def _walk_mandatory_loop(
+        self,
+        node: Node,
+        state: _TaintMap,
+        jc: _JsCtx,
+        walk: Callable[[Node, _TaintMap, _JsCtx], _TaintMap],
+    ) -> _TaintMap:
+        # (H) Loop shield: a break inside the body targets THIS loop, never an
+        # (H) enclosing switch arm's collector.
+        self._shield_breaks()
+        try:
+            return self._walk_mandatory_loop_inner(node, state, jc, walk)
+        finally:
+            self._unshield_breaks()
+
+    def _walk_mandatory_loop_inner(
         self,
         node: Node,
         state: _TaintMap,
@@ -629,17 +629,21 @@ class FlowProcessor:
             entry = dict(state)
             if previous_exit is not None and arm.type in _FALLTHROUGH_ARM_TYPES:
                 entry = self._merge([entry, previous_exit])
-            arm_exit = walk(arm, entry, jc)
+            # (H) Each break inside the arm exits the switch with the state it
+            # (H) saw THEN (a conditional break before a later kill carries the
+            # (H) live taint out), captured by the arm's own collector.
+            self._break_exit_stack.append([])
+            try:
+                arm_exit = walk(arm, entry, jc)
+            finally:
+                break_exits = self._break_exit_stack.pop() or []
             self._restore_shadows(pre_arm_shadows, jc)
-            # (H) A non-final fallthrough arm without its own break never
-            # (H) terminates the switch (a stacked `case 1: default:` label's
-            # (H) empty group falls straight through), so its exit reaches the
-            # (H) merge only THROUGH the next arm's walk, not directly.
-            if (
-                index == len(arms) - 1
-                or arm.type not in _FALLTHROUGH_ARM_TYPES
-                or _arm_may_break(arm)
-            ):
+            exits.extend(break_exits)
+            # (H) A non-final fallthrough arm's END state never exits the
+            # (H) switch directly (control continues into the next arm; a
+            # (H) stacked `case 1: default:` label's empty group falls straight
+            # (H) through), so it reaches the merge only THROUGH the next arm.
+            if index == len(arms) - 1 or arm.type not in _FALLTHROUGH_ARM_TYPES:
                 exits.append(arm_exit)
             previous_exit = arm_exit
         if not has_default:
@@ -697,6 +701,21 @@ class FlowProcessor:
         self._restore_shadows(pre_if_shadows, jc)
         return self._merge(branch_exits)
 
+    def _record_break_exit(self, state: _TaintMap) -> None:
+        # (H) Snapshot the live state at a `break` for the enclosing switch
+        # (H) arm's collector. None on top = a loop shield (the break targets
+        # (H) that loop); empty stack = no enclosing switch at all. A labeled
+        # (H) break targeting a farther construct still records here: the
+        # (H) extra state only widens the MAY join, the sound direction.
+        if self._break_exit_stack and self._break_exit_stack[-1] is not None:
+            self._break_exit_stack[-1].append(dict(state))
+
+    def _shield_breaks(self) -> None:
+        self._break_exit_stack.append(None)
+
+    def _unshield_breaks(self) -> None:
+        self._break_exit_stack.pop()
+
     @staticmethod
     def _restore_shadows(pre_shadows: set[str], jc: _JsCtx) -> None:
         # (H) Reset the mutable live shadow set to a pre-branch snapshot in place (jc is
@@ -710,6 +729,9 @@ class FlowProcessor:
         # (H) in source order (so a nested call in an argument is still seen).
         node_type = node.type
         if node_type in jc.descriptor.nested_scope_types:
+            return state
+        if node_type == cs.TS_BREAK_STATEMENT:
+            self._record_break_exit(state)
             return state
         if node_type == cs.TS_JS_IF_STATEMENT:
             return self._walk_js_if(node, state, jc)
@@ -754,6 +776,17 @@ class FlowProcessor:
         return self._merge(branch_exits)
 
     def _walk_js_loop(self, node: Node, state: _TaintMap, jc: _JsCtx) -> _TaintMap:
+        # (H) Loop shield: a break inside the body targets THIS loop, never an
+        # (H) enclosing switch arm's collector.
+        self._shield_breaks()
+        try:
+            return self._walk_js_loop_inner(node, state, jc)
+        finally:
+            self._unshield_breaks()
+
+    def _walk_js_loop_inner(
+        self, node: Node, state: _TaintMap, jc: _JsCtx
+    ) -> _TaintMap:
         # (H) The initializer/condition/iterable runs before the body; the body runs
         # (H) zero or more times, so union the skip path with one pass, then re-walk
         # (H) once from that merge to catch taint carried from a later iteration into

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -198,6 +198,13 @@ _JAVA_SWITCH_ARM_TYPES = frozenset(
 )
 
 
+def _ends_with_break(arm: Node) -> bool:
+    # (H) True when the arm's last top-level statement is a plain break, so
+    # (H) control can never reach the next arm by falling off this one's end.
+    last = arm.named_children[-1] if arm.named_children else None
+    return last is not None and last.type == cs.TS_BREAK_STATEMENT
+
+
 def _switch_arm_is_default(arm: Node) -> bool:
     # (H) C++ default is a case_statement without a `value` field; a Java
     # (H) default arm's switch_label has no named children (a case label
@@ -599,10 +606,9 @@ class FlowProcessor:
         # (H) arm walks against a copy and the exits union (MAY join). An
         # (H) exclusive arm (Go, Java arrow rule) enters from the header state
         # (H) only; a fallthrough-capable arm also unions the previous arm's
-        # (H) exit (break is not modelled, so the fallthrough entry is the
-        # (H) sound over-approximation). Without a default arm the implicit
-        # (H) no-match path joins the exit merge; with one, some arm always
-        # (H) runs, so a kill on EVERY arm kills.
+        # (H) fall-through state. Without a default arm the implicit no-match
+        # (H) path joins the exit merge; with one, some arm always runs, so a
+        # (H) kill on EVERY arm kills.
         body = node.child_by_field_name(cs.FIELD_BODY)
         arm_container = body if body is not None else node
         arms = [
@@ -620,15 +626,28 @@ class FlowProcessor:
         if not arms:
             self._restore_shadows(pre_switch_shadows, jc)
             return state
+        exits, has_default = self._walk_switch_arms(arms, state, jc, walk)
+        if not has_default:
+            exits.append(dict(state))
+        self._restore_shadows(pre_switch_shadows, jc)
+        return self._merge(exits)
+
+    def _walk_switch_arms(
+        self,
+        arms: list[Node],
+        state: _TaintMap,
+        jc: _JsCtx,
+        walk: Callable[[Node, _TaintMap, _JsCtx], _TaintMap],
+    ) -> tuple[list[_TaintMap], bool]:
         pre_arm_shadows = set(jc.local_names)
         exits: list[_TaintMap] = []
-        previous_exit: _TaintMap | None = None
+        fall_in: _TaintMap | None = None
         has_default = False
         for index, arm in enumerate(arms):
             has_default = has_default or _switch_arm_is_default(arm)
             entry = dict(state)
-            if previous_exit is not None and arm.type in _FALLTHROUGH_ARM_TYPES:
-                entry = self._merge([entry, previous_exit])
+            if fall_in is not None and arm.type in _FALLTHROUGH_ARM_TYPES:
+                entry = self._merge([entry, fall_in])
             # (H) Each break inside the arm exits the switch with the state it
             # (H) saw THEN (a conditional break before a later kill carries the
             # (H) live taint out), captured by the arm's own collector.
@@ -645,11 +664,13 @@ class FlowProcessor:
             # (H) through), so it reaches the merge only THROUGH the next arm.
             if index == len(arms) - 1 or arm.type not in _FALLTHROUGH_ARM_TYPES:
                 exits.append(arm_exit)
-            previous_exit = arm_exit
-        if not has_default:
-            exits.append(dict(state))
-        self._restore_shadows(pre_switch_shadows, jc)
-        return self._merge(exits)
+            # (H) An arm whose LAST top-level statement is an unconditional
+            # (H) break has no fall-through path: its end state must not feed
+            # (H) the next arm's entry (the break snapshot already carried it
+            # (H) out). Conditional breaks keep the full end state, the sound
+            # (H) over-approximation.
+            fall_in = None if _ends_with_break(arm) else arm_exit
+        return exits, has_default
 
     def _walk_flat_match(self, node: Node, state: _TaintMap, jc: _JsCtx) -> _TaintMap:
         # (H) Rust match: the scrutinee runs on all paths; each arm is walked

--- a/codebase_rag/tests/test_flow_switch_branches.py
+++ b/codebase_rag/tests/test_flow_switch_branches.py
@@ -1,0 +1,294 @@
+# (H) Switch-family path-sensitivity for the lean non-Python flow walk: Go
+# (H) switch/type-switch/select and Rust match arms are EXCLUSIVE (no
+# (H) fallthrough), while C-family switches (JS/TS, Java colon groups, C++)
+# (H) may fall through, so each case entry unions the previous case's exit.
+# (H) MAY semantics throughout: a kill counts only when it happens on every
+# (H) path through the statement.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.capture import resolve_capture
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+FLOWS_TO = cs.RelationshipType.FLOWS_TO.value
+_CAPTURE_IO = resolve_capture([cs.CaptureGroup.IO.value])
+
+
+def _run_flow(tmp_path: Path, files: dict[str, str]) -> set[tuple[str, str]]:
+    parsers, queries = load_parsers()
+    for rel, content in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        capture=_CAPTURE_IO,
+    ).run()
+    return {
+        (c.args[0][2], c.args[2][2])
+        for c in mock.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) == FLOWS_TO
+    }
+
+
+def test_go_switch_case_kill_does_not_erase_other_arms(tmp_path: Path) -> None:
+    files = {
+        "main.go": (
+            "package main\n\n"
+            'import "os"\n\n'
+            "func work(x int) {\n"
+            '\ts := os.Getenv("SECRET")\n'
+            "\tswitch x {\n"
+            "\tcase 1:\n"
+            '\t\ts = "clean"\n'
+            "\tcase 2:\n"
+            "\t\t_ = x\n"
+            "\t}\n"
+            '\tos.WriteFile("out.txt", []byte(s), 0644)\n'
+            "}\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::SECRET", "resource::FILE::out.txt") in flows
+
+
+def test_go_switch_kill_on_every_arm_with_default_kills(tmp_path: Path) -> None:
+    # (H) With a default present some arm always runs, so a kill on EVERY arm
+    # (H) (including default) kills on every path: no edge.
+    files = {
+        "main.go": (
+            "package main\n\n"
+            'import "os"\n\n'
+            "func work(x int) {\n"
+            '\ts := os.Getenv("SECRET")\n'
+            "\tswitch x {\n"
+            "\tcase 1:\n"
+            '\t\ts = "clean"\n'
+            "\tdefault:\n"
+            '\t\ts = "clean"\n'
+            "\t}\n"
+            '\tos.WriteFile("out.txt", []byte(s), 0644)\n'
+            "}\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::SECRET", "resource::FILE::out.txt") not in flows
+
+
+def test_go_switch_arms_are_exclusive(tmp_path: Path) -> None:
+    # (H) Go has no implicit fallthrough: taint bound in case 1 must not reach
+    # (H) a sink in case 2.
+    files = {
+        "main.go": (
+            "package main\n\n"
+            'import "os"\n\n'
+            "func work(x int) {\n"
+            '\ts := "clean"\n'
+            "\tswitch x {\n"
+            "\tcase 1:\n"
+            '\t\ts = os.Getenv("SECRET")\n'
+            "\tcase 2:\n"
+            '\t\tos.WriteFile("out.txt", []byte(s), 0644)\n'
+            "\t}\n"
+            "}\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::SECRET", "resource::FILE::out.txt") not in flows
+
+
+def test_go_type_switch_arm_kill_does_not_leak(tmp_path: Path) -> None:
+    files = {
+        "main.go": (
+            "package main\n\n"
+            'import "os"\n\n'
+            "func work(x any) {\n"
+            '\ts := os.Getenv("SECRET")\n'
+            "\tswitch v := x.(type) {\n"
+            "\tcase int:\n"
+            '\t\ts = "clean"\n'
+            "\t\t_ = v\n"
+            "\tcase string:\n"
+            "\t\t_ = v\n"
+            "\t}\n"
+            '\tos.WriteFile("out.txt", []byte(s), 0644)\n'
+            "}\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::SECRET", "resource::FILE::out.txt") in flows
+
+
+def test_go_select_case_kill_does_not_erase_default_path(tmp_path: Path) -> None:
+    files = {
+        "main.go": (
+            "package main\n\n"
+            'import "os"\n\n'
+            "func work(ch chan int) {\n"
+            '\ts := os.Getenv("SECRET")\n'
+            "\tselect {\n"
+            "\tcase <-ch:\n"
+            '\t\ts = "clean"\n'
+            "\tdefault:\n"
+            "\t}\n"
+            '\tos.WriteFile("out.txt", []byte(s), 0644)\n'
+            "}\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::SECRET", "resource::FILE::out.txt") in flows
+
+
+def test_java_colon_switch_case_kill_does_not_erase_other_paths(
+    tmp_path: Path,
+) -> None:
+    files = {
+        "A.java": (
+            "class A {\n"
+            "  void work(int x) {\n"
+            '    String s = System.getenv("SECRET");\n'
+            "    switch (x) {\n"
+            "      case 1:\n"
+            '        s = "safe";\n'
+            "        break;\n"
+            "      case 2:\n"
+            "        break;\n"
+            "    }\n"
+            "    System.out.println(s);\n"
+            "  }\n"
+            "}\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") in flows
+
+
+def test_java_arrow_switch_rule_kill_does_not_erase_other_rules(
+    tmp_path: Path,
+) -> None:
+    files = {
+        "A.java": (
+            "class A {\n"
+            "  void work(int x) {\n"
+            '    String s = System.getenv("SECRET");\n'
+            "    switch (x) {\n"
+            '      case 1 -> { s = "safe"; }\n'
+            "      default -> { }\n"
+            "    }\n"
+            "    System.out.println(s);\n"
+            "  }\n"
+            "}\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") in flows
+
+
+def test_java_colon_switch_fallthrough_carries_case_taint(tmp_path: Path) -> None:
+    # (H) No break between the groups: taint bound in case 1 falls through to
+    # (H) the sink in case 2.
+    files = {
+        "A.java": (
+            "class A {\n"
+            "  void work(int x) {\n"
+            '    String s = "clean";\n'
+            "    switch (x) {\n"
+            "      case 1:\n"
+            '        s = System.getenv("SECRET");\n'
+            "      case 2:\n"
+            "        System.out.println(s);\n"
+            "        break;\n"
+            "    }\n"
+            "  }\n"
+            "}\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") in flows
+
+
+def test_cpp_switch_case_kill_does_not_erase_other_cases(tmp_path: Path) -> None:
+    files = {
+        "main.cpp": (
+            "#include <cstdlib>\n"
+            "#include <iostream>\n"
+            "void work(int x) {\n"
+            '    const char* s = getenv("SECRET");\n'
+            "    switch (x) {\n"
+            "        case 1:\n"
+            '            s = "safe";\n'
+            "            break;\n"
+            "        default:\n"
+            "            break;\n"
+            "    }\n"
+            "    std::cout << s;\n"
+            "}\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") in flows
+
+
+def test_js_switch_case_kill_does_not_erase_other_cases(tmp_path: Path) -> None:
+    files = {
+        "m.js": (
+            "export function work(x) {\n"
+            "  let s = process.env.SECRET\n"
+            "  switch (x) {\n"
+            "    case 1:\n"
+            "      s = 'safe'\n"
+            "      break\n"
+            "    default:\n"
+            "      break\n"
+            "  }\n"
+            "  console.log(s)\n"
+            "}\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") in flows
+
+
+def test_js_switch_fallthrough_carries_case_taint(tmp_path: Path) -> None:
+    files = {
+        "m.js": (
+            "export function work(x) {\n"
+            "  let s = 'clean'\n"
+            "  switch (x) {\n"
+            "    case 1:\n"
+            "      s = process.env.SECRET\n"
+            "    case 2:\n"
+            "      console.log(s)\n"
+            "      break\n"
+            "  }\n"
+            "}\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") in flows
+
+
+def test_js_do_while_loop_carried_taint(tmp_path: Path) -> None:
+    # (H) The sink precedes the bind in source order; a later iteration
+    # (H) carries the taint back: needs the mandatory-loop second pass.
+    files = {
+        "m.js": (
+            "export function work(x) {\n"
+            "  let s = ''\n"
+            "  do {\n"
+            "    console.log(s)\n"
+            "    s = process.env.SECRET\n"
+            "  } while (x)\n"
+            "}\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") in flows

--- a/codebase_rag/tests/test_flow_switch_branches.py
+++ b/codebase_rag/tests/test_flow_switch_branches.py
@@ -217,6 +217,59 @@ def test_java_stacked_default_label_kills_skip_path(tmp_path: Path) -> None:
     assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") not in flows
 
 
+def test_java_conditional_break_before_kill_keeps_taint(tmp_path: Path) -> None:
+    # (H) `if (c) break;` exits the switch BEFORE the kill, so the break path
+    # (H) carries the taint out even though every arm ends with a kill: the
+    # (H) exit state must be captured AT the break, not at the arm's end.
+    files = {
+        "A.java": (
+            "class A {\n"
+            "  void work(int x, boolean c) {\n"
+            '    String s = System.getenv("SECRET");\n'
+            "    switch (x) {\n"
+            "      case 1:\n"
+            "        if (c) break;\n"
+            '        s = "safe";\n'
+            "        break;\n"
+            "      default:\n"
+            '        s = "safe";\n'
+            "        break;\n"
+            "    }\n"
+            "    System.out.println(s);\n"
+            "  }\n"
+            "}\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") in flows
+
+
+def test_java_break_in_nested_loop_does_not_exit_switch(tmp_path: Path) -> None:
+    # (H) A break inside a loop nested in the arm targets the LOOP: the arm
+    # (H) still ends with the kill on every switch-exiting path, so no edge.
+    files = {
+        "A.java": (
+            "class A {\n"
+            "  void work(int x) {\n"
+            '    String s = System.getenv("SECRET");\n'
+            "    switch (x) {\n"
+            "      case 1:\n"
+            "        while (true) { break; }\n"
+            '        s = "safe";\n'
+            "        break;\n"
+            "      default:\n"
+            '        s = "safe";\n'
+            "        break;\n"
+            "    }\n"
+            "    System.out.println(s);\n"
+            "  }\n"
+            "}\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") not in flows
+
+
 def test_java_colon_switch_fallthrough_carries_case_taint(tmp_path: Path) -> None:
     # (H) No break between the groups: taint bound in case 1 falls through to
     # (H) the sink in case 2.

--- a/codebase_rag/tests/test_flow_switch_branches.py
+++ b/codebase_rag/tests/test_flow_switch_branches.py
@@ -192,6 +192,31 @@ def test_java_arrow_switch_rule_kill_does_not_erase_other_rules(
     assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") in flows
 
 
+def test_java_stacked_default_label_kills_skip_path(tmp_path: Path) -> None:
+    # (H) `case 1: default:` stacks both labels on ONE group: the arm is the
+    # (H) default target, so some arm always runs and the kill inside it kills
+    # (H) on every path. Only the first label being `case` must not hide the
+    # (H) default.
+    files = {
+        "A.java": (
+            "class A {\n"
+            "  void work(int x) {\n"
+            '    String s = System.getenv("SECRET");\n'
+            "    switch (x) {\n"
+            "      case 1:\n"
+            "      default:\n"
+            '        s = "safe";\n'
+            "        break;\n"
+            "    }\n"
+            "    System.out.println(s);\n"
+            "  }\n"
+            "}\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") not in flows
+
+
 def test_java_colon_switch_fallthrough_carries_case_taint(tmp_path: Path) -> None:
     # (H) No break between the groups: taint bound in case 1 falls through to
     # (H) the sink in case 2.

--- a/codebase_rag/tests/test_flow_switch_branches.py
+++ b/codebase_rag/tests/test_flow_switch_branches.py
@@ -270,6 +270,31 @@ def test_java_break_in_nested_loop_does_not_exit_switch(tmp_path: Path) -> None:
     assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") not in flows
 
 
+def test_java_trailing_break_does_not_fall_through(tmp_path: Path) -> None:
+    # (H) An arm ending in an UNCONDITIONAL break has no fall-through path:
+    # (H) its end state must not union into the next arm's entry, or taint
+    # (H) bound in case 1 fabricates a flow into case 2's sink.
+    files = {
+        "A.java": (
+            "class A {\n"
+            "  void work(int x) {\n"
+            '    String s = "clean";\n'
+            "    switch (x) {\n"
+            "      case 1:\n"
+            '        s = System.getenv("SECRET");\n'
+            "        break;\n"
+            "      case 2:\n"
+            "        System.out.println(s);\n"
+            "        break;\n"
+            "    }\n"
+            "  }\n"
+            "}\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") not in flows
+
+
 def test_java_colon_switch_fallthrough_carries_case_taint(tmp_path: Path) -> None:
     # (H) No break between the groups: taint bound in case 1 falls through to
     # (H) the sink in case 2.

--- a/codebase_rag/tests/test_flow_switch_branches.py
+++ b/codebase_rag/tests/test_flow_switch_branches.py
@@ -105,6 +105,30 @@ def test_go_switch_arms_are_exclusive(tmp_path: Path) -> None:
     assert ("resource::ENV::SECRET", "resource::FILE::out.txt") not in flows
 
 
+def test_go_explicit_fallthrough_carries_case_taint(tmp_path: Path) -> None:
+    # (H) Go's `fallthrough` keyword (legal only as an arm's last statement)
+    # (H) transfers control into the next case: the taint bound in case 1 must
+    # (H) reach the sink in case 2.
+    files = {
+        "main.go": (
+            "package main\n\n"
+            'import "os"\n\n'
+            "func work(x int) {\n"
+            '\ts := "clean"\n'
+            "\tswitch x {\n"
+            "\tcase 1:\n"
+            '\t\ts = os.Getenv("SECRET")\n'
+            "\t\tfallthrough\n"
+            "\tcase 2:\n"
+            '\t\tos.WriteFile("out.txt", []byte(s), 0644)\n'
+            "\t}\n"
+            "}\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::SECRET", "resource::FILE::out.txt") in flows
+
+
 def test_go_type_switch_arm_kill_does_not_leak(tmp_path: Path) -> None:
     files = {
         "main.go": (

--- a/uv.lock
+++ b/uv.lock
@@ -540,7 +540,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.394"
+version = "0.0.396"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Completes path-sensitivity for the non-Python flow walk to Python's level. The lean walk already branched-and-merged if/loops/try (and Rust match); the remaining gap was the switch family, which threaded cases SEQUENTIALLY: a kill in case 1 stayed applied entering case 2, and per-case taint leaked across exclusive arms, exactly the class issue #713 fixed for Python if/elif.

## Semantics

One shared `_walk_switch` (parameterized by the statement walker, so the flat and JS walks reuse it):

| construct | arms | entry state |
|-----------|------|-------------|
| Go `switch` / type switch / `select` | exclusive | header state |
| Java arrow rules (`case 1 -> {}`) | exclusive | header state |
| Java colon groups, C++ `case`, JS/TS `case`/`default` | may fall through | union(header state, previous arm's exit) |

The header (initializer, switched value, condition) runs on all paths. Arm exits union (MAY join); the implicit no-match path joins unless a default arm exists (Go/JS spell default explicitly; C++ default is a `case_statement` without a `value` field; a Java default label has no named children). `break` stays unmodeled, so the fallthrough entry is the sound over-approximation. Shadow scopes snapshot per arm and restore, mirroring the if/match walkers.

Also routed: JS/TS `do-while` through a shared mandatory-loop walker (body always runs, condition after body, second pass for loop-carried taint), extracted from the flat walker. JS `for-of` needed nothing (the grammar parses it as `for_in_statement`, already handled). The stale "straight-line, no path-sensitivity yet" comment now documents the actual behavior.

## Validation

viper (switch-heavy Go): FLOWS_TO 31 -> 152, verified as genuine propagation, not over-emission: `Viper.Get`'s type-switch previously let a sequential kill erase the env-derived taint on the returned value; with exclusive arms the taint correctly survives, so `Get`'s return is tainted and each consumer gains a true MAY-flow edge. mini-redis and dotenv edge sets are unchanged (no switches).

## Tests

RED first (afe6d82a): 12 specs, 9 failing on main: kill-isolation for Go switch/type-switch/select, Java colon and arrow forms, C++ and JS switch, plus JS do-while loop-carried taint; three pass as precision pins (kill-on-every-arm-with-default kills, Go arms are exclusive, fallthrough carries case taint). GREEN in 6b070483. Full suite: 5258 passed.