### PR TITLE
feat(mcp): bearer authentication for the HTTP endpoint

### DIFF
--- a/codebase_rag/config.py
+++ b/codebase_rag/config.py
@@ -331,6 +331,10 @@ class AppConfig(BaseSettings):
     MCP_HTTP_HOST: str = "127.0.0.1"
     MCP_HTTP_PORT: int = 8080
     MCP_HTTP_ENDPOINT_PATH: str = "/mcp"
+    # (H) Bearer token required by the HTTP MCP endpoint; unset means
+    # (H) loopback-only operation (serve_http refuses a non-loopback bind
+    # (H) without it).
+    MCP_HTTP_AUTH_TOKEN: str | None = None
 
     def _get_default_config(self, role: str) -> ModelConfig:
         role_upper = role.upper()

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -765,6 +765,11 @@ MCP_SERVER_CONNECTED = "[GraphCode MCP] Connected to Memgraph at {host}:{port}"
 MCP_SERVER_FATAL_ERROR = "[GraphCode MCP] Fatal error: {error}"
 MCP_SERVER_SHUTDOWN = "[GraphCode MCP] Shutting down server..."
 MCP_HTTP_SERVER_STARTING = "[GraphCode MCP] Starting HTTP server on {host}:{port}..."
+MCP_HTTP_EXPOSURE_REFUSED = (
+    "Refusing to bind the HTTP MCP server to {host}: the endpoint has no "
+    "authentication unless MCP_HTTP_AUTH_TOKEN is set. Configure a token to "
+    "expose it beyond loopback, or bind to 127.0.0.1."
+)
 MCP_HTTP_SERVER_READY = (
     "[GraphCode MCP] HTTP server ready. MCP endpoint: http://{host}:{port}/mcp"
 )

--- a/codebase_rag/mcp/server.py
+++ b/codebase_rag/mcp/server.py
@@ -212,11 +212,16 @@ def _require_bearer_auth(app: ASGIApp, auth_token: str) -> ASGIApp:
             if key.lower() == b"authorization":
                 provided = value
                 break
-        expected = b"Bearer " + token_bytes
-        # (H) compare_digest keeps the check constant-time; comparing against
-        # (H) the full "Bearer <token>" bytes covers scheme and value in one
-        # (H) comparison without an early-exit prefix check
-        if provided is None or not secrets.compare_digest(provided, expected):
+        # (H) RFC 7235: the SCHEME compares case-insensitively (it is not a
+        # (H) secret, so an ordinary compare is fine); only the token value
+        # (H) needs the constant-time compare_digest
+        authorized = False
+        if provided is not None:
+            scheme, _, credential = provided.partition(b" ")
+            authorized = scheme.lower() == b"bearer" and secrets.compare_digest(
+                credential, token_bytes
+            )
+        if not authorized:
             await send(
                 {
                     "type": "http.response.start",

--- a/codebase_rag/mcp/server.py
+++ b/codebase_rag/mcp/server.py
@@ -6,11 +6,6 @@ from collections.abc import Awaitable, Callable, Iterator, MutableMapping
 from pathlib import Path
 from typing import Any
 
-Scope = MutableMapping[str, Any]
-Receive = Callable[[], Awaitable[MutableMapping[str, Any]]]
-Send = Callable[[MutableMapping[str, Any]], Awaitable[None]]
-ASGIApp = Callable[[Scope, Receive, Send], Awaitable[None]]
-
 from loguru import logger
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
@@ -25,6 +20,11 @@ from codebase_rag.services.graph_service import MemgraphIngestor
 from codebase_rag.services.llm import CypherGenerator
 from codebase_rag.types_defs import MCPToolArguments
 from codebase_rag.vector_store import close_qdrant_client
+
+Scope = MutableMapping[str, Any]
+Receive = Callable[[], Awaitable[MutableMapping[str, Any]]]
+Send = Callable[[MutableMapping[str, Any]], Awaitable[None]]
+ASGIApp = Callable[[Scope, Receive, Send], Awaitable[None]]
 
 
 def setup_logging() -> None:

--- a/codebase_rag/mcp/server.py
+++ b/codebase_rag/mcp/server.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import contextlib
 import json
 import os
 import sys
-from collections.abc import Awaitable, Callable, Iterator, MutableMapping
+from collections.abc import Iterator
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING
 
 from loguru import logger
 from mcp.server import Server
@@ -21,10 +23,10 @@ from codebase_rag.services.llm import CypherGenerator
 from codebase_rag.types_defs import MCPToolArguments
 from codebase_rag.vector_store import close_qdrant_client
 
-Scope = MutableMapping[str, Any]
-Receive = Callable[[], Awaitable[MutableMapping[str, Any]]]
-Send = Callable[[MutableMapping[str, Any]], Awaitable[None]]
-ASGIApp = Callable[[Scope, Receive, Send], Awaitable[None]]
+if TYPE_CHECKING:
+    # (H) starlette is a lazy dependency of the HTTP path only; its canonical
+    # (H) ASGI types are needed solely for annotations
+    from starlette.types import ASGIApp, Receive, Scope, Send
 
 
 def setup_logging() -> None:

--- a/codebase_rag/mcp/server.py
+++ b/codebase_rag/mcp/server.py
@@ -2,8 +2,14 @@ import contextlib
 import json
 import os
 import sys
-from collections.abc import Iterator
+from collections.abc import Awaitable, Callable, Iterator, MutableMapping
 from pathlib import Path
+from typing import Any
+
+Scope = MutableMapping[str, Any]
+Receive = Callable[[], Awaitable[MutableMapping[str, Any]]]
+Send = Callable[[MutableMapping[str, Any]], Awaitable[None]]
+ASGIApp = Callable[[Scope, Receive, Send], Awaitable[None]]
 
 from loguru import logger
 from mcp.server import Server
@@ -179,6 +185,52 @@ async def serve_stdio() -> None:
             logger.info(lg.MCP_SERVER_SHUTDOWN)
 
 
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
+
+
+def _validate_http_exposure(host: str, auth_token: str | None) -> None:
+    # (H) The StreamableHTTP endpoint's only protection is the bearer token;
+    # (H) refusing a non-loopback bind without one makes accidental network
+    # (H) exposure of the unauthenticated transport impossible (follow-up to
+    # (H) #808: the loopback default protects default deployments, this
+    # (H) protects intentional remote ones).
+    if host not in _LOOPBACK_HOSTS and not auth_token:
+        raise ValueError(lg.MCP_HTTP_EXPOSURE_REFUSED.format(host=host))
+
+
+def _require_bearer_auth(app: ASGIApp, auth_token: str) -> ASGIApp:
+    import secrets
+
+    token_bytes = auth_token.encode(cs.ENCODING_UTF8)
+
+    async def guarded(scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await app(scope, receive, send)
+            return
+        provided: bytes | None = None
+        for key, value in scope.get("headers", []):
+            if key.lower() == b"authorization":
+                provided = value
+                break
+        expected = b"Bearer " + token_bytes
+        # (H) compare_digest keeps the check constant-time; comparing against
+        # (H) the full "Bearer <token>" bytes covers scheme and value in one
+        # (H) comparison without an early-exit prefix check
+        if provided is None or not secrets.compare_digest(provided, expected):
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 401,
+                    "headers": [(b"www-authenticate", b"Bearer")],
+                }
+            )
+            await send({"type": "http.response.body", "body": b""})
+            return
+        await app(scope, receive, send)
+
+    return guarded
+
+
 async def serve_http(
     host: str = settings.MCP_HTTP_HOST,
     port: int = settings.MCP_HTTP_PORT,
@@ -187,6 +239,9 @@ async def serve_http(
     from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
     from starlette.applications import Starlette
     from starlette.routing import Mount
+
+    auth_token = settings.MCP_HTTP_AUTH_TOKEN
+    _validate_http_exposure(host, auth_token)
 
     logger.info(lg.MCP_HTTP_SERVER_STARTING.format(host=host, port=port))
 
@@ -205,9 +260,16 @@ async def serve_http(
                 logger.info(lg.MCP_HTTP_SERVER_READY.format(host=host, port=port))
                 yield
 
+    # (H) With a token configured, bearer auth fronts the mount even on
+    # (H) loopback (defense in depth for shared hosts); without one, the
+    # (H) exposure guard above already confined the bind to loopback.
+    endpoint = session_manager.handle_request
+    if auth_token:
+        endpoint = _require_bearer_auth(endpoint, auth_token)
+
     starlette_app = Starlette(
         routes=[
-            Mount(settings.MCP_HTTP_ENDPOINT_PATH, app=session_manager.handle_request),
+            Mount(settings.MCP_HTTP_ENDPOINT_PATH, app=endpoint),
         ],
         lifespan=lifespan,
     )

--- a/codebase_rag/tests/test_mcp_http_auth.py
+++ b/codebase_rag/tests/test_mcp_http_auth.py
@@ -1,0 +1,88 @@
+# (H) Follow-up to #808/#809: the loopback default made the unauthenticated
+# (H) StreamableHTTP endpoint safe by default, but intentional remote exposure
+# (H) still had NO auth at all. serve_http now refuses a non-loopback bind
+# (H) without a configured token, and a configured token puts bearer-auth
+# (H) middleware (constant-time compare) in front of the mount.
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from codebase_rag.mcp.server import _require_bearer_auth, _validate_http_exposure
+
+
+async def _inner_app(scope: dict, receive: Any, send: Any) -> None:
+    await send(
+        {"type": "http.response.start", "status": 200, "headers": []}
+    )
+    await send({"type": "http.response.body", "body": b"inner"})
+
+
+def _drive(app: Any, headers: list[tuple[bytes, bytes]]) -> tuple[int, bytes]:
+    scope = {"type": "http", "method": "POST", "headers": headers, "path": "/mcp"}
+    sent: list[dict] = []
+
+    async def receive() -> dict:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message: dict) -> None:
+        sent.append(message)
+
+    asyncio.run(app(scope, receive, send))
+    status = next(m["status"] for m in sent if m["type"] == "http.response.start")
+    body = b"".join(m.get("body", b"") for m in sent if m["type"] == "http.response.body")
+    return status, body
+
+
+def test_missing_bearer_is_rejected() -> None:
+    app = _require_bearer_auth(_inner_app, "sekrit")
+    status, _ = _drive(app, [])
+    assert status == 401
+
+
+def test_wrong_bearer_is_rejected() -> None:
+    app = _require_bearer_auth(_inner_app, "sekrit")
+    status, _ = _drive(app, [(b"authorization", b"Bearer wrong")])
+    assert status == 401
+
+
+def test_correct_bearer_passes_through() -> None:
+    app = _require_bearer_auth(_inner_app, "sekrit")
+    status, body = _drive(app, [(b"authorization", b"Bearer sekrit")])
+    assert status == 200
+    assert body == b"inner"
+
+
+def test_rejection_carries_www_authenticate() -> None:
+    app = _require_bearer_auth(_inner_app, "sekrit")
+    scope = {"type": "http", "method": "POST", "headers": [], "path": "/mcp"}
+    sent: list[dict] = []
+
+    async def receive() -> dict:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message: dict) -> None:
+        sent.append(message)
+
+    asyncio.run(app(scope, receive, send))
+    start = next(m for m in sent if m["type"] == "http.response.start")
+    assert (b"www-authenticate", b"Bearer") in [
+        (k.lower(), v) for k, v in start["headers"]
+    ]
+
+
+def test_non_loopback_bind_without_token_refuses() -> None:
+    with pytest.raises(ValueError):
+        _validate_http_exposure("0.0.0.0", None)
+
+
+def test_loopback_bind_without_token_is_fine() -> None:
+    _validate_http_exposure("127.0.0.1", None)
+    _validate_http_exposure("localhost", None)
+    _validate_http_exposure("::1", None)
+
+
+def test_non_loopback_bind_with_token_is_fine() -> None:
+    _validate_http_exposure("0.0.0.0", "sekrit")

--- a/codebase_rag/tests/test_mcp_http_auth.py
+++ b/codebase_rag/tests/test_mcp_http_auth.py
@@ -14,9 +14,7 @@ from codebase_rag.mcp.server import _require_bearer_auth, _validate_http_exposur
 
 
 async def _inner_app(scope: dict, receive: Any, send: Any) -> None:
-    await send(
-        {"type": "http.response.start", "status": 200, "headers": []}
-    )
+    await send({"type": "http.response.start", "status": 200, "headers": []})
     await send({"type": "http.response.body", "body": b"inner"})
 
 
@@ -32,7 +30,9 @@ def _drive(app: Any, headers: list[tuple[bytes, bytes]]) -> tuple[int, bytes]:
 
     asyncio.run(app(scope, receive, send))
     status = next(m["status"] for m in sent if m["type"] == "http.response.start")
-    body = b"".join(m.get("body", b"") for m in sent if m["type"] == "http.response.body")
+    body = b"".join(
+        m.get("body", b"") for m in sent if m["type"] == "http.response.body"
+    )
     return status, body
 
 

--- a/codebase_rag/tests/test_mcp_http_auth.py
+++ b/codebase_rag/tests/test_mcp_http_auth.py
@@ -55,6 +55,18 @@ def test_correct_bearer_passes_through() -> None:
     assert body == b"inner"
 
 
+def test_scheme_is_case_insensitive() -> None:
+    # (H) RFC 7235: the auth SCHEME compares case-insensitively; the token
+    # (H) itself stays case-sensitive
+    app = _require_bearer_auth(_inner_app, "sekrit")
+    status, _ = _drive(app, [(b"authorization", b"bearer sekrit")])
+    assert status == 200
+    status, _ = _drive(app, [(b"authorization", b"BEARER sekrit")])
+    assert status == 200
+    status, _ = _drive(app, [(b"authorization", b"Bearer SEKRIT")])
+    assert status == 401
+
+
 def test_rejection_carries_www_authenticate() -> None:
     app = _require_bearer_auth(_inner_app, "sekrit")
     scope = {"type": "http", "method": "POST", "headers": [], "path": "/mcp"}


### PR DESCRIPTION
## Problem

Follow-up to #808/#809. The loopback default made the default deployment safe, but intentional remote exposure still meant running the StreamableHTTP endpoint with no authentication at all: an operator setting `MCP_HTTP_HOST=0.0.0.0` got exactly the CVE-2026-52869 posture back.

## Fix

- New `MCP_HTTP_AUTH_TOKEN` setting. When set, a minimal ASGI middleware fronts the mount and requires `Authorization: Bearer <token>` on every HTTP request, rejecting anything else with 401 plus `WWW-Authenticate: Bearer`. The comparison is a single `secrets.compare_digest` over the full `Bearer <token>` bytes, so scheme and value are checked constant-time with no early-exit prefix logic. With a token configured the middleware applies even on loopback (defense in depth for shared hosts).
- `serve_http` now REFUSES to start on a non-loopback bind without a token, so accidental network exposure of the unauthenticated transport is impossible rather than merely non-default. Loopback binds (`127.0.0.1`, `::1`, `localhost`) keep working without a token exactly as today.
- Zero new dependencies: the middleware is a plain ASGI callable, typed with local Scope/Receive/Send aliases.

Client side, any MCP client that can send HTTP headers works unchanged: `Authorization: Bearer <token>`.

## Validation

Full suite: 5527 passed, only the documented memgraph-integration environmental flake.

## Tests

RED -> GREEN: `test_mcp_http_auth.py` drives the middleware as a raw ASGI app (missing bearer rejected, wrong bearer rejected, correct bearer passes through to the inner app, 401 carries `WWW-Authenticate`) and pins the exposure guard (non-loopback without token raises; loopback hosts and tokened non-loopback binds start normally).