### PR TITLE
fix(flow): branch-and-merge Python match arms

### DIFF
--- a/codebase_rag/constants/ast_python.py
+++ b/codebase_rag/constants/ast_python.py
@@ -56,6 +56,10 @@ FIELD_SUBJECT = "subject"
 # (H) and is a CAPTURE (irrefutable); multi-part dotted names are value
 # (H) patterns that compare.
 TS_PY_DOTTED_NAME = "dotted_name"
+# (H) `a | b` case alternatives; the bare `_` alternative is an ANONYMOUS
+# (H) node, invisible to named_children.
+TS_PY_UNION_PATTERN = "union_pattern"
+TS_PY_WILDCARD_NODE = "_"
 TS_PY_WHILE_STATEMENT = "while_statement"
 TS_PY_ELIF_CLAUSE = "elif_clause"
 TS_PY_ELSE_CLAUSE = "else_clause"

--- a/codebase_rag/constants/ast_python.py
+++ b/codebase_rag/constants/ast_python.py
@@ -52,6 +52,10 @@ TS_PY_CASE_CLAUSE = "case_clause"
 TS_PY_CASE_PATTERN = "case_pattern"
 TS_PY_FIELD_GUARD = "guard"
 FIELD_SUBJECT = "subject"
+# (H) A bare name in a case pattern parses as dotted_name with ONE identifier
+# (H) and is a CAPTURE (irrefutable); multi-part dotted names are value
+# (H) patterns that compare.
+TS_PY_DOTTED_NAME = "dotted_name"
 TS_PY_WHILE_STATEMENT = "while_statement"
 TS_PY_ELIF_CLAUSE = "elif_clause"
 TS_PY_ELSE_CLAUSE = "else_clause"

--- a/codebase_rag/constants/ast_python.py
+++ b/codebase_rag/constants/ast_python.py
@@ -45,6 +45,13 @@ TS_PY_COMPARISON_OPERATOR = "comparison_operator"
 TS_FIELD_OPERATORS = "operators"
 TS_PY_IF_STATEMENT = "if_statement"
 TS_PY_TRY_STATEMENT = "try_statement"
+# (H) Match statement: arms are exclusive; an UNGUARDED `case _` (empty
+# (H) case_pattern) always matches, removing the implicit no-match path.
+TS_PY_MATCH_STATEMENT = "match_statement"
+TS_PY_CASE_CLAUSE = "case_clause"
+TS_PY_CASE_PATTERN = "case_pattern"
+TS_PY_FIELD_GUARD = "guard"
+FIELD_SUBJECT = "subject"
 TS_PY_WHILE_STATEMENT = "while_statement"
 TS_PY_ELIF_CLAUSE = "elif_clause"
 TS_PY_ELSE_CLAUSE = "else_clause"

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -248,6 +248,23 @@ def _py_pattern_irrefutable(pattern: Node) -> bool:
             None,
         )
         return inner is not None and _py_pattern_irrefutable(inner)
+    if child.type == cs.TS_PY_UNION_PATTERN:
+        # (H) `1 | _` / `1 | other`: only the LAST alternative may legally be
+        # (H) irrefutable, and a bare `_` alternative is an ANONYMOUS node, so
+        # (H) inspect ALL children for the final non-separator one.
+        last = next(
+            (
+                c
+                for c in reversed(child.children)
+                if c.is_named or c.type == cs.TS_PY_WILDCARD_NODE
+            ),
+            None,
+        )
+        if last is None:
+            return False
+        if last.type == cs.TS_PY_WILDCARD_NODE:
+            return True
+        return last.type == cs.TS_PY_DOTTED_NAME and last.named_child_count == 1
     return False
 
 

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -218,6 +218,20 @@ def _arm_falls_into_next(arm: Node) -> bool:
     return last is not None and last.type == cs.TS_GO_FALLTHROUGH_STATEMENT
 
 
+def _py_case_always_matches(arm: Node) -> bool:
+    # (H) An UNGUARDED wildcard (`case _:`) always matches: its case_pattern
+    # (H) has no named children (the `_` is anonymous) and no guard clause. A
+    # (H) guarded wildcard can fail its guard, so it never removes the
+    # (H) no-match path.
+    if arm.child_by_field_name(cs.TS_PY_FIELD_GUARD) is not None:
+        return False
+    pattern = next(
+        (child for child in arm.named_children if child.type == cs.TS_PY_CASE_PATTERN),
+        None,
+    )
+    return pattern is not None and pattern.named_child_count == 0
+
+
 def _switch_arm_is_default(arm: Node) -> bool:
     # (H) C++ default is a case_statement without a `value` field; a Java
     # (H) default arm's switch_label has no named children (a case label
@@ -1475,6 +1489,8 @@ class FlowProcessor:
             return self._walk_loop(node, state, ctx)
         if node_type == cs.TS_PY_TRY_STATEMENT:
             return self._walk_try(node, state, ctx)
+        if node_type == cs.TS_PY_MATCH_STATEMENT:
+            return self._walk_py_match(node, state, ctx)
         if node_type == cs.TS_PY_ASSIGNMENT:
             self._apply_assignment(node, state, ctx)
         elif node_type == cs.TS_PY_CALL:
@@ -1493,6 +1509,31 @@ class FlowProcessor:
         for child in node.children:
             state = self._walk_stmt(child, state, ctx)
         return state
+
+    def _walk_py_match(self, node: Node, state: _TaintMap, ctx: _FlowCtx) -> _TaintMap:
+        # (H) match arms are EXCLUSIVE: each case_clause walks against a copy
+        # (H) of the post-subject state and the exits union (MAY join), same
+        # (H) semantics as the lean walk's switch family. The implicit
+        # (H) no-match path joins unless an UNGUARDED `case _` (empty
+        # (H) case_pattern, no guard) always matches.
+        subject = node.child_by_field_name(cs.FIELD_SUBJECT)
+        if subject is not None:
+            state = self._walk_stmt(subject, state, ctx)
+        body = node.child_by_field_name(cs.FIELD_BODY)
+        if body is None:
+            return state
+        arm_exits: list[_TaintMap] = []
+        has_wildcard = False
+        for arm in body.named_children:
+            if arm.type != cs.TS_PY_CASE_CLAUSE:
+                continue
+            has_wildcard = has_wildcard or _py_case_always_matches(arm)
+            arm_exits.append(self._walk_stmt(arm, dict(state), ctx))
+        if not arm_exits:
+            return state
+        if not has_wildcard:
+            arm_exits.append(dict(state))
+        return self._merge(arm_exits)
 
     def _walk_if(self, node: Node, state: _TaintMap, ctx: _FlowCtx) -> _TaintMap:
         # (H) The if-condition runs on all paths; process it in the incoming state.

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -219,17 +219,36 @@ def _arm_falls_into_next(arm: Node) -> bool:
 
 
 def _py_case_always_matches(arm: Node) -> bool:
-    # (H) An UNGUARDED wildcard (`case _:`) always matches: its case_pattern
-    # (H) has no named children (the `_` is anonymous) and no guard clause. A
-    # (H) guarded wildcard can fail its guard, so it never removes the
-    # (H) no-match path.
+    # (H) An UNGUARDED irrefutable pattern always matches; a guarded one can
+    # (H) fail its guard, so it never removes the no-match path.
     if arm.child_by_field_name(cs.TS_PY_FIELD_GUARD) is not None:
         return False
     pattern = next(
         (child for child in arm.named_children if child.type == cs.TS_PY_CASE_PATTERN),
         None,
     )
-    return pattern is not None and pattern.named_child_count == 0
+    return pattern is not None and _py_pattern_irrefutable(pattern)
+
+
+def _py_pattern_irrefutable(pattern: Node) -> bool:
+    # (H) Irrefutable case patterns: `_` (empty case_pattern), a bare CAPTURE
+    # (H) name (dotted_name with exactly one identifier; multi-part dotted
+    # (H) names are value patterns that compare), and `<irrefutable> as x`.
+    children = pattern.named_children
+    if not children:
+        return True
+    if len(children) != 1:
+        return False
+    child = children[0]
+    if child.type == cs.TS_PY_DOTTED_NAME:
+        return child.named_child_count == 1
+    if child.type == cs.TS_PY_AS_PATTERN:
+        inner = next(
+            (c for c in child.named_children if c.type == cs.TS_PY_CASE_PATTERN),
+            None,
+        )
+        return inner is not None and _py_pattern_irrefutable(inner)
+    return False
 
 
 def _switch_arm_is_default(arm: Node) -> bool:

--- a/codebase_rag/tests/test_flow_switch_branches.py
+++ b/codebase_rag/tests/test_flow_switch_branches.py
@@ -80,6 +80,62 @@ def test_python_match_kill_on_every_arm_with_wildcard_kills(tmp_path: Path) -> N
     assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") not in flows
 
 
+def test_python_match_bare_capture_is_irrefutable(tmp_path: Path) -> None:
+    # (H) `case other:` is a CAPTURE pattern (a bare name binds, it never
+    # (H) compares), so it always matches like `case _`: a kill on every arm
+    # (H) including it kills on every path.
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "def work(x):\n"
+            "    s = os.getenv('SECRET')\n"
+            "    match x:\n"
+            "        case 1:\n"
+            "            s = 'clean'\n"
+            "        case other:\n"
+            "            s = 'clean'\n"
+            "    print(s)\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") not in flows
+
+
+def test_python_match_as_wildcard_is_irrefutable(tmp_path: Path) -> None:
+    # (H) `case _ as y:` wraps an irrefutable pattern: still always matches.
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "def work(x):\n"
+            "    s = os.getenv('SECRET')\n"
+            "    match x:\n"
+            "        case _ as y:\n"
+            "            s = 'clean'\n"
+            "    print(s)\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") not in flows
+
+
+def test_python_match_refutable_patterns_keep_skip_path(tmp_path: Path) -> None:
+    # (H) A dotted value pattern (`case Color.RED`) and a sequence pattern
+    # (H) compare rather than bind: the no-match path survives their kills.
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "def work(x):\n"
+            "    s = os.getenv('SECRET')\n"
+            "    match x:\n"
+            "        case [a, b]:\n"
+            "            s = 'clean'\n"
+            "    print(s)\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") in flows
+
+
 def test_python_match_guarded_wildcard_keeps_skip_path(tmp_path: Path) -> None:
     # (H) `case _ if cond` can fail its guard, so the no-match path survives
     # (H) even when every listed arm kills.

--- a/codebase_rag/tests/test_flow_switch_branches.py
+++ b/codebase_rag/tests/test_flow_switch_branches.py
@@ -39,6 +39,83 @@ def _run_flow(tmp_path: Path, files: dict[str, str]) -> set[tuple[str, str]]:
     }
 
 
+def test_python_match_arm_kill_does_not_erase_other_arms(tmp_path: Path) -> None:
+    # (H) Python's own match statement needs the same arm isolation the other
+    # (H) languages' switches got: a kill in one case must not erase the
+    # (H) other arms' (or the no-match path's) taint.
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "def work(x):\n"
+            "    s = os.getenv('SECRET')\n"
+            "    match x:\n"
+            "        case 1:\n"
+            "            s = 'clean'\n"
+            "        case 2:\n"
+            "            pass\n"
+            "    print(s)\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") in flows
+
+
+def test_python_match_kill_on_every_arm_with_wildcard_kills(tmp_path: Path) -> None:
+    # (H) An unguarded `case _` always matches, so a kill on every arm
+    # (H) including it kills on every path: no edge.
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "def work(x):\n"
+            "    s = os.getenv('SECRET')\n"
+            "    match x:\n"
+            "        case 1:\n"
+            "            s = 'clean'\n"
+            "        case _:\n"
+            "            s = 'clean'\n"
+            "    print(s)\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") not in flows
+
+
+def test_python_match_guarded_wildcard_keeps_skip_path(tmp_path: Path) -> None:
+    # (H) `case _ if cond` can fail its guard, so the no-match path survives
+    # (H) even when every listed arm kills.
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "def work(x, cond):\n"
+            "    s = os.getenv('SECRET')\n"
+            "    match x:\n"
+            "        case _ if cond:\n"
+            "            s = 'clean'\n"
+            "    print(s)\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") in flows
+
+
+def test_python_match_arms_are_exclusive(tmp_path: Path) -> None:
+    # (H) Taint bound in one arm must not reach a sink in another arm.
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "def work(x):\n"
+            "    s = 'clean'\n"
+            "    match x:\n"
+            "        case 1:\n"
+            "            s = os.getenv('SECRET')\n"
+            "        case 2:\n"
+            "            print(s)\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") not in flows
+
+
 def test_go_switch_case_kill_does_not_erase_other_arms(tmp_path: Path) -> None:
     files = {
         "main.go": (

--- a/codebase_rag/tests/test_flow_switch_branches.py
+++ b/codebase_rag/tests/test_flow_switch_branches.py
@@ -118,6 +118,60 @@ def test_python_match_as_wildcard_is_irrefutable(tmp_path: Path) -> None:
     assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") not in flows
 
 
+def test_python_match_or_pattern_with_wildcard_is_irrefutable(
+    tmp_path: Path,
+) -> None:
+    # (H) `case 1 | _:` covers everything through its wildcard alternative
+    # (H) (only the LAST alternative may legally be irrefutable).
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "def work(x):\n"
+            "    s = os.getenv('SECRET')\n"
+            "    match x:\n"
+            "        case 1 | _:\n"
+            "            s = 'clean'\n"
+            "    print(s)\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") not in flows
+
+
+def test_python_match_or_pattern_with_capture_is_irrefutable(
+    tmp_path: Path,
+) -> None:
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "def work(x):\n"
+            "    s = os.getenv('SECRET')\n"
+            "    match x:\n"
+            "        case 1 | other:\n"
+            "            s = 'clean'\n"
+            "    print(s)\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") not in flows
+
+
+def test_python_match_refutable_or_pattern_keeps_skip_path(tmp_path: Path) -> None:
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "def work(x):\n"
+            "    s = os.getenv('SECRET')\n"
+            "    match x:\n"
+            "        case 1 | 2:\n"
+            "            s = 'clean'\n"
+            "    print(s)\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") in flows
+
+
 def test_python_match_refutable_patterns_keep_skip_path(tmp_path: Path) -> None:
     # (H) A dotted value pattern (`case Color.RED`) and a sequence pattern
     # (H) compare rather than bind: the no-match path survives their kills.

--- a/uv.lock
+++ b/uv.lock
@@ -540,7 +540,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.396"
+version = "0.0.398"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Follow-up to #815 caught by probing: Python's OWN `match` statement had the exact defect the switch family just fixed for the other languages — case clauses threaded sequentially, so a kill in one arm erased every arm's taint and per-arm binds leaked forward.

## What changed

`_walk_py_match` in the Python walk: the subject runs on all paths; each `case_clause` walks against a copy of the post-subject state and the exits union (MAY join). Arms are exclusive. The implicit no-match path joins the merge unless an UNGUARDED `case _` exists (its `case_pattern` has no named children — the `_` is anonymous — and no `guard` clause); a guarded wildcard can fail its guard, so it never removes the no-match path.

## Tests

RED first (8a998b85): four specs in test_flow_switch_branches.py — arm kill must not erase other arms, kill on every arm including an unguarded wildcard kills, a guarded wildcard keeps the skip path, and arms are exclusive (three failed on main; the wildcard-kill pin passed). GREEN in 62009021. Full suite: 5275 passed.