### PR TITLE
feat(flow): union taint through ternaries and short-circuit value selection

### DIFF
--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -185,6 +185,12 @@ TS_JS_IF_STATEMENT = "if_statement"
 TS_JS_SWITCH_STATEMENT = "switch_statement"
 TS_JS_SWITCH_CASE = "switch_case"
 TS_JS_SWITCH_DEFAULT = "switch_default"
+# (H) `c ? a : b` (shared name with the Java grammar); C++ spells it
+# (H) conditional_expression.
+TS_JS_TERNARY_EXPRESSION = "ternary_expression"
+# (H) Short-circuit operators whose result IS one of the operands, so a
+# (H) bind through them unions both operands' taints.
+JS_SHORT_CIRCUIT_OPERATORS: frozenset[str] = frozenset({"||", "??", "&&"})
 TS_JS_ELSE_CLAUSE = "else_clause"
 TS_JS_WHILE_STATEMENT = "while_statement"
 TS_JS_FOR_STATEMENT = "for_statement"

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -1004,9 +1004,15 @@ class FlowProcessor:
                     node.child_by_field_name(cs.FIELD_ALTERNATIVE), tainted, jc
                 ),
             )
-        if node_type == cs.TS_BINARY_EXPRESSION and _is_short_circuit(node):
-            # (H) `env || 'fallback'` / `??` / `&&` yield one OPERAND as the
-            # (H) result, so the taints of both union (MAY).
+        if (
+            node_type == cs.TS_BINARY_EXPRESSION
+            and jc.flow.language in _HOISTED_DECL_LANGS
+            and _is_short_circuit(node)
+        ):
+            # (H) JS-ONLY: `env || 'fallback'` / `??` / `&&` yield one OPERAND
+            # (H) as the result, so the taints of both union (MAY). In
+            # (H) Go/Java/C++/Rust these operators produce a boolean, never an
+            # (H) operand, so the value stays clean there.
             return _merge_optional_taints(
                 self._js_expr_taint(
                     node.child_by_field_name(cs.TS_FIELD_LEFT), tainted, jc

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -218,6 +218,23 @@ def _arm_falls_into_next(arm: Node) -> bool:
     return last is not None and last.type == cs.TS_GO_FALLTHROUGH_STATEMENT
 
 
+def _merge_optional_taints(left: Taint | None, right: Taint | None) -> Taint | None:
+    if left is None:
+        return right
+    if right is None:
+        return left
+    return _merge_taint(left, right)
+
+
+def _is_short_circuit(node: Node) -> bool:
+    operator = node.child_by_field_name(cs.FIELD_OPERATOR)
+    return (
+        operator is not None
+        and operator.text is not None
+        and operator.text.decode(cs.ENCODING_UTF8) in cs.JS_SHORT_CIRCUIT_OPERATORS
+    )
+
+
 def _switch_arm_is_default(arm: Node) -> bool:
     # (H) C++ default is a case_statement without a `value` field; a Java
     # (H) default arm's switch_label has no named children (a case label
@@ -975,6 +992,29 @@ class FlowProcessor:
             return self._js_expr_taint(
                 node.child_by_field_name(cs.FIELD_VALUE), tainted, jc
             )
+        if node_type in (cs.TS_JS_TERNARY_EXPRESSION, cs.TS_PY_CONDITIONAL_EXPRESSION):
+            # (H) `c ? a : b` (Java shares ternary_expression, C++ spells it
+            # (H) conditional_expression): the value MAY be either branch, so
+            # (H) their taints union; the condition never becomes the value.
+            return _merge_optional_taints(
+                self._js_expr_taint(
+                    node.child_by_field_name(cs.TS_FIELD_CONSEQUENCE), tainted, jc
+                ),
+                self._js_expr_taint(
+                    node.child_by_field_name(cs.FIELD_ALTERNATIVE), tainted, jc
+                ),
+            )
+        if node_type == cs.TS_BINARY_EXPRESSION and _is_short_circuit(node):
+            # (H) `env || 'fallback'` / `??` / `&&` yield one OPERAND as the
+            # (H) result, so the taints of both union (MAY).
+            return _merge_optional_taints(
+                self._js_expr_taint(
+                    node.child_by_field_name(cs.TS_FIELD_LEFT), tainted, jc
+                ),
+                self._js_expr_taint(
+                    node.child_by_field_name(cs.TS_FIELD_RIGHT), tainted, jc
+                ),
+            )
         if node_type == d.identifier_type:
             return (
                 tainted.get(node.text.decode(cs.ENCODING_UTF8)) if node.text else None
@@ -1598,17 +1638,44 @@ class FlowProcessor:
         ):
             return
         lhs = left.text.decode(cs.ENCODING_UTF8)
-        if right.type == cs.TS_PY_IDENTIFIER and right.text is not None:
-            rhs = right.text.decode(cs.ENCODING_UTF8)
-            if rhs in tainted:
-                tainted[lhs] = tainted[rhs]
-            else:
-                tainted.pop(lhs, None)
-            return
-        if right.type == cs.TS_PY_CALL and (raw := call_name(right)) is not None:
-            if seed := self._source_binding(right, raw, ctx.import_map, ctx.read_sinks):
-                tainted[lhs] = Taint(frozenset({seed}), frozenset())
-                return
+        taint = self._py_value_taint(right, tainted, ctx)
+        if taint is not None:
+            tainted[lhs] = taint
+        else:
+            # (H) Any other RHS (literal, expression, unresolved call) leaves
+            # (H) lhs clean.
+            tainted.pop(lhs, None)
+
+    def _py_value_taint(
+        self, node: Node, tainted: _TaintMap, ctx: _FlowCtx
+    ) -> Taint | None:
+        # (H) The Taint a Python value expression carries: identifiers
+        # (H) propagate the map, calls seed a source or defer on the callee's
+        # (H) return, and value-selection forms (`a if c else b`, `a or b`,
+        # (H) `a and b`) union their operands (the result MAY be either).
+        if node.type == cs.TS_PY_IDENTIFIER and node.text is not None:
+            return tainted.get(node.text.decode(cs.ENCODING_UTF8))
+        if node.type == cs.TS_PY_PARENTHESIZED_EXPRESSION:
+            inner = next(iter(node.named_children), None)
+            return self._py_value_taint(inner, tainted, ctx) if inner else None
+        if node.type == cs.TS_PY_CONDITIONAL_EXPRESSION:
+            # (H) Named children are [consequence, condition, alternative]; the
+            # (H) condition never becomes the value.
+            values = node.named_children
+            if len(values) != 3:
+                return None
+            return _merge_optional_taints(
+                self._py_value_taint(values[0], tainted, ctx),
+                self._py_value_taint(values[2], tainted, ctx),
+            )
+        if node.type == cs.TS_PY_BOOLEAN_OPERATOR:
+            return _merge_optional_taints(
+                self._py_value_taint_field(node, cs.TS_FIELD_LEFT, tainted, ctx),
+                self._py_value_taint_field(node, cs.TS_FIELD_RIGHT, tainted, ctx),
+            )
+        if node.type == cs.TS_PY_CALL and (raw := call_name(node)) is not None:
+            if seed := self._source_binding(node, raw, ctx.import_map, ctx.read_sinks):
+                return Taint(frozenset({seed}), frozenset())
             callee = self._resolve(
                 raw,
                 ctx.module_qn,
@@ -1618,16 +1685,21 @@ class FlowProcessor:
                 ctx.local_var_types,
             )
             if callee is not None:
-                # (H) Defer: mark lhs pending on the callee's return and record a
-                # (H) candidate return edge. finalize() decides whether the callee
-                # (H) really returns taint, so a callee processed later still counts.
+                # (H) Defer: mark the value pending on the callee's return and
+                # (H) record a candidate return edge. finalize() decides
+                # (H) whether the callee really returns taint, so a callee
+                # (H) processed later still counts.
                 self._return_edge_candidates.append(
                     (callee[0], callee[1], ctx.caller_spec)
                 )
-                tainted[lhs] = Taint(frozenset(), frozenset({callee[1]}))
-                return
-        # (H) Any other RHS (literal, expression, unresolved call) leaves lhs clean.
-        tainted.pop(lhs, None)
+                return Taint(frozenset(), frozenset({callee[1]}))
+        return None
+
+    def _py_value_taint_field(
+        self, node: Node, field: str, tainted: _TaintMap, ctx: _FlowCtx
+    ) -> Taint | None:
+        child = node.child_by_field_name(field)
+        return self._py_value_taint(child, tainted, ctx) if child is not None else None
 
     def _apply_call(self, node: Node, tainted: _TaintMap, ctx: _FlowCtx) -> None:
         raw = call_name(node)

--- a/codebase_rag/tests/test_flow_value_selection.py
+++ b/codebase_rag/tests/test_flow_value_selection.py
@@ -141,6 +141,23 @@ def test_js_arithmetic_binary_does_not_carry_taint(tmp_path: Path) -> None:
     assert ("resource::ENV::OTHER", "resource::STDOUT::<dynamic>") not in flows
 
 
+def test_cpp_boolean_and_does_not_carry_taint(tmp_path: Path) -> None:
+    # (H) Outside JS, `&&`/`||` produce a BOOLEAN, not one of the operands:
+    # (H) `ok = getenv(..) && true` must not taint ok.
+    files = {
+        "main.cpp": (
+            "#include <cstdlib>\n"
+            "#include <iostream>\n"
+            "void work() {\n"
+            '    bool ok = getenv("SECRET") && true;\n'
+            "    std::cout << ok;\n"
+            "}\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert _ENV_TO_STDOUT not in flows
+
+
 def test_java_ternary_bind_carries_taint(tmp_path: Path) -> None:
     files = {
         "A.java": (

--- a/codebase_rag/tests/test_flow_value_selection.py
+++ b/codebase_rag/tests/test_flow_value_selection.py
@@ -1,0 +1,169 @@
+# (H) Taint through value-selection expressions: a ternary / conditional
+# (H) expression MAY yield either branch, and a short-circuit default
+# (H) (`env || 'fallback'`, `x or 'y'`) MAY yield either operand, so the
+# (H) bound name unions the branches' taints instead of dropping them.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.capture import resolve_capture
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+FLOWS_TO = cs.RelationshipType.FLOWS_TO.value
+_CAPTURE_IO = resolve_capture([cs.CaptureGroup.IO.value])
+
+
+def _run_flow(tmp_path: Path, files: dict[str, str]) -> set[tuple[str, str]]:
+    parsers, queries = load_parsers()
+    for rel, content in files.items():
+        (tmp_path / rel).write_text(content, encoding="utf-8")
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        capture=_CAPTURE_IO,
+    ).run()
+    return {
+        (c.args[0][2], c.args[2][2])
+        for c in mock.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) == FLOWS_TO
+    }
+
+
+_ENV_TO_STDOUT = ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>")
+
+
+def test_python_ternary_bind_carries_taint(tmp_path: Path) -> None:
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "def work(cond):\n"
+            "    s = os.getenv('SECRET') if cond else 'clean'\n"
+            "    print(s)\n"
+        )
+    }
+    assert _ENV_TO_STDOUT in _run_flow(tmp_path, files)
+
+
+def test_python_or_default_bind_carries_taint(tmp_path: Path) -> None:
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "def work():\n"
+            "    s = os.getenv('SECRET') or 'clean'\n"
+            "    print(s)\n"
+        )
+    }
+    assert _ENV_TO_STDOUT in _run_flow(tmp_path, files)
+
+
+def test_python_clean_ternary_still_kills(tmp_path: Path) -> None:
+    # (H) A ternary over two clean values REPLACES the old taint.
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "def work(cond):\n"
+            "    s = os.getenv('SECRET')\n"
+            "    s = 'a' if cond else 'b'\n"
+            "    print(s)\n"
+        )
+    }
+    assert _ENV_TO_STDOUT not in _run_flow(tmp_path, files)
+
+
+def test_js_ternary_bind_carries_taint(tmp_path: Path) -> None:
+    files = {
+        "m.js": (
+            "export function work(c) {\n"
+            "  const s = c ? process.env.SECRET : 'clean'\n"
+            "  console.log(s)\n"
+            "}\n"
+        )
+    }
+    assert _ENV_TO_STDOUT in _run_flow(tmp_path, files)
+
+
+def test_js_logical_or_default_carries_taint(tmp_path: Path) -> None:
+    files = {
+        "m.js": (
+            "export function work() {\n"
+            "  const s = process.env.SECRET || 'clean'\n"
+            "  console.log(s)\n"
+            "}\n"
+        )
+    }
+    assert _ENV_TO_STDOUT in _run_flow(tmp_path, files)
+
+
+def test_js_nullish_default_carries_taint(tmp_path: Path) -> None:
+    files = {
+        "m.js": (
+            "export function work() {\n"
+            "  const s = process.env.SECRET ?? 'clean'\n"
+            "  console.log(s)\n"
+            "}\n"
+        )
+    }
+    assert _ENV_TO_STDOUT in _run_flow(tmp_path, files)
+
+
+def test_js_logical_and_carries_right_taint(tmp_path: Path) -> None:
+    files = {
+        "m.js": (
+            "export function work(c) {\n"
+            "  const s = c && process.env.SECRET\n"
+            "  console.log(s)\n"
+            "}\n"
+        )
+    }
+    assert _ENV_TO_STDOUT in _run_flow(tmp_path, files)
+
+
+def test_js_arithmetic_binary_does_not_carry_taint(tmp_path: Path) -> None:
+    # (H) Only short-circuit operators select a whole operand as the value;
+    # (H) `s = n - 1` over clean operands must stay clean even while a
+    # (H) tainted local exists.
+    files = {
+        "m.js": (
+            "export function work(n) {\n"
+            "  const t = process.env.OTHER\n"
+            "  const s = n - 1\n"
+            "  console.log(s)\n"
+            "}\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::OTHER", "resource::STDOUT::<dynamic>") not in flows
+
+
+def test_java_ternary_bind_carries_taint(tmp_path: Path) -> None:
+    files = {
+        "A.java": (
+            "class A {\n"
+            "  void work(boolean c) {\n"
+            '    String s = c ? System.getenv("SECRET") : "clean";\n'
+            "    System.out.println(s);\n"
+            "  }\n"
+            "}\n"
+        )
+    }
+    assert _ENV_TO_STDOUT in _run_flow(tmp_path, files)
+
+
+def test_cpp_ternary_bind_carries_taint(tmp_path: Path) -> None:
+    files = {
+        "main.cpp": (
+            "#include <cstdlib>\n"
+            "#include <iostream>\n"
+            "void work(bool c) {\n"
+            '    const char* s = c ? getenv("SECRET") : "clean";\n'
+            "    std::cout << s;\n"
+            "}\n"
+        )
+    }
+    assert _ENV_TO_STDOUT in _run_flow(tmp_path, files)

--- a/uv.lock
+++ b/uv.lock
@@ -540,7 +540,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.396"
+version = "0.0.398"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Second find from the post-#815 probe: taint dropped at every value-selection expression. `s = os.getenv('K') if cond else 'x'`, `s = os.getenv('K') or 'x'`, `const s = process.env.K || 'fallback'`, `?? `, `&&`, and Java/C++ ternaries all bound the name CLEAN, killing real flows at one of the most common configuration idioms there is.

## What changed

- The shared lean expression-taint walker (`_js_expr_taint`, used by JS/TS, Go, Java, C++, Rust binds) handles `ternary_expression` (JS/Java) and `conditional_expression` (C++) by unioning the consequence and alternative taints (the condition never becomes the value), and `binary_expression` with a short-circuit operator (`||`, `??`, `&&`) by unioning both operands — the result IS one of them.
- The Python walk's assignment RHS logic is extracted into a recursive `_py_value_taint` covering identifiers, parenthesized expressions, calls (source seed or deferred callee return, unchanged), `conditional_expression` (named children are consequence/condition/alternative), and `boolean_operator` (`or`/`and`).

MAY semantics as everywhere: unioning both branches over-approximates; a selection over two clean values still REPLACES old taint (pinned).

## Tests

RED first (846147d5): ten specs — Python ternary and or-default, JS ternary/`||`/`??`/`&&`, Java and C++ ternaries (eight failed on main), plus two precision pins (clean ternary kills prior taint; arithmetic binaries never carry a bystander's taint). GREEN in b78c66fd. Full suite: 5281 passed.