### PR TITLE
fix(dart): seed dead-code reachability roots from lexical visibility

### DIFF
--- a/codebase_rag/constants/ast_dart.py
+++ b/codebase_rag/constants/ast_dart.py
@@ -57,6 +57,20 @@ TS_DART_ENUM_DECLARATION = "enum_declaration"
 TS_DART_EXTENSION_DECLARATION = "extension_declaration"
 TS_DART_EXTENSION_TYPE_DECLARATION = "extension_type_declaration"
 
+# (H) Dart privacy is lexical: a leading underscore marks a library-private
+# (H) symbol; every other name is public. Export detection walks the enclosing
+# (H) type chain, so a public member of a private type is still unreachable.
+DART_PRIVATE_PREFIX = "_"
+DART_TYPE_DECLARATION_NODE_TYPES = frozenset(
+    {
+        TS_DART_CLASS_DEFINITION,
+        TS_DART_MIXIN_DECLARATION,
+        TS_DART_ENUM_DECLARATION,
+        TS_DART_EXTENSION_DECLARATION,
+        TS_DART_EXTENSION_TYPE_DECLARATION,
+    }
+)
+
 # (H) Function/method signature nodes (all captured as @function)
 TS_DART_FUNCTION_SIGNATURE = "function_signature"
 TS_DART_GETTER_SIGNATURE = "getter_signature"

--- a/codebase_rag/parsers/export_detection.py
+++ b/codebase_rag/parsers/export_detection.py
@@ -61,6 +61,8 @@ def is_exported(node: Node, name: str, language: cs.SupportedLanguage) -> bool:
             return _rust_exported(node)
         case cs.SupportedLanguage.CPP:
             return cpp_utils.is_exported(node)
+        case cs.SupportedLanguage.DART:
+            return _dart_exported(node, name)
         case _:
             return False
 
@@ -88,6 +90,32 @@ def _python_nested_in_function(node: Node) -> bool:
 
 def _go_exported(name: str) -> bool:
     return bool(name) and name[0].isupper()
+
+
+def _dart_exported(node: Node, name: str) -> bool:
+    # (H) Dart visibility is purely lexical: a leading underscore means
+    # (H) library-private, everything else is public. A public member is only
+    # (H) externally reachable when EVERY enclosing type is also public, since
+    # (H) a private class/mixin/extension cannot be named outside its library
+    # (H) (`_Internal.doThing` is unreachable from other libraries even though
+    # (H) `doThing` has no underscore). Walk the ancestor type chain and treat
+    # (H) any private link as private.
+    if name.startswith(cs.DART_PRIVATE_PREFIX):
+        return False
+    ancestor = node.parent
+    while ancestor is not None:
+        if ancestor.type in cs.DART_TYPE_DECLARATION_NODE_TYPES:
+            type_name = ancestor.child_by_field_name(cs.FIELD_NAME)
+            if (
+                type_name is not None
+                and type_name.text is not None
+                and type_name.text.decode(cs.ENCODING_UTF8).startswith(
+                    cs.DART_PRIVATE_PREFIX
+                )
+            ):
+                return False
+        ancestor = ancestor.parent
+    return True
 
 
 def _js_ts_exported(node: Node, name: str) -> bool:

--- a/codebase_rag/parsers/export_detection.py
+++ b/codebase_rag/parsers/export_detection.py
@@ -92,27 +92,31 @@ def _go_exported(name: str) -> bool:
     return bool(name) and name[0].isupper()
 
 
+_DART_PRIVATE_BYTE = cs.DART_PRIVATE_PREFIX.encode(cs.ENCODING_UTF8)
+
+
 def _dart_exported(node: Node, name: str) -> bool:
     # (H) Dart visibility is purely lexical: a leading underscore means
     # (H) library-private, everything else is public. A public member is only
     # (H) externally reachable when EVERY enclosing type is also public, since
     # (H) a private class/mixin/extension cannot be named outside its library
     # (H) (`_Internal.doThing` is unreachable from other libraries even though
-    # (H) `doThing` has no underscore). Walk the ancestor type chain and treat
-    # (H) any private link as private.
+    # (H) `doThing` has no underscore). An UNNAMED extension (`extension on
+    # (H) String {...}`, no name field) is likewise usable only in its
+    # (H) declaring library, so its members are private too. Walk the ancestor
+    # (H) type chain and treat any private link as private.
     if name.startswith(cs.DART_PRIVATE_PREFIX):
         return False
     ancestor = node.parent
     while ancestor is not None:
         if ancestor.type in cs.DART_TYPE_DECLARATION_NODE_TYPES:
             type_name = ancestor.child_by_field_name(cs.FIELD_NAME)
-            if (
-                type_name is not None
-                and type_name.text is not None
-                and type_name.text.decode(cs.ENCODING_UTF8).startswith(
-                    cs.DART_PRIVATE_PREFIX
-                )
-            ):
+            if type_name is None or type_name.text is None:
+                # (H) only an extension_declaration legitimately lacks a name,
+                # (H) and an unnamed one is library-private
+                if ancestor.type == cs.TS_DART_EXTENSION_DECLARATION:
+                    return False
+            elif type_name.text.startswith(_DART_PRIVATE_BYTE):
                 return False
         ancestor = ancestor.parent
     return True

--- a/codebase_rag/tests/test_is_exported_roots.py
+++ b/codebase_rag/tests/test_is_exported_roots.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+from tree_sitter import Node
 
 from codebase_rag import constants as cs
 from codebase_rag.graph_updater import GraphUpdater
@@ -426,8 +427,8 @@ def test_dart_unnamed_extension_member_is_private() -> None:
         pytest.skip("dart parser not available")
     tree = parsers["dart"].parse(b"extension on String {\n  void shout() {}\n}\n")
 
-    def _find(node: object, wanted: str):
-        for child in node.children:  # type: ignore[attr-defined]
+    def _find(node: Node, wanted: str) -> Node | None:
+        for child in node.children:
             if child.type == wanted:
                 return child
             found = _find(child, wanted)

--- a/codebase_rag/tests/test_is_exported_roots.py
+++ b/codebase_rag/tests/test_is_exported_roots.py
@@ -374,3 +374,36 @@ def test_script_module_scan_runs_once_per_file(
         for declaration in declarations:
             assert export_detection._is_script_global(declaration) is True
     assert spy.call_count <= len(declarations)
+
+
+DART_SRC = """\
+void publicFn() {}
+void _privateFn() {}
+
+class Command {
+  void run() {}
+  void _wrap() {}
+  Command.named() {}
+}
+
+class _Internal {
+  void doThing() {}
+}
+"""
+
+
+def test_dart_visibility_seeds_exported_roots(tmp_path: Path) -> None:
+    # (H) Dart privacy is purely lexical: a leading underscore on the symbol OR
+    # (H) any enclosing type means library-private (not externally reachable),
+    # (H) everything else is public API and must seed a dead-code root. Without
+    # (H) this every public Dart symbol read as private and a library's whole
+    # (H) public surface flagged dead (dart-lang/args: 89 false positives).
+    exported = _run(tmp_path, {"lib.dart": DART_SRC})
+
+    assert _one(exported, ".lib.publicFn") is True
+    assert _one(exported, ".lib._privateFn") is False
+    assert _one(exported, ".Command.run") is True
+    assert _one(exported, ".Command._wrap") is False
+    # (H) a public method of a PRIVATE class is not reachable from outside the
+    # (H) library, so it is not an export root on its own
+    assert _one(exported, "._Internal.doThing") is False

--- a/codebase_rag/tests/test_is_exported_roots.py
+++ b/codebase_rag/tests/test_is_exported_roots.py
@@ -390,10 +390,6 @@ class _Internal {
   void doThing() {}
 }
 
-extension on String {
-  void shout() {}
-}
-
 extension PublicExt on String {
   void boom() {}
 }
@@ -415,7 +411,30 @@ def test_dart_visibility_seeds_exported_roots(tmp_path: Path) -> None:
     # (H) a public method of a PRIVATE class is not reachable from outside the
     # (H) library, so it is not an export root on its own
     assert _one(exported, "._Internal.doThing") is False
-    # (H) an unnamed extension is visible only in its declaring library, so its
-    # (H) members are not export roots; a public NAMED extension is importable
-    assert _one(exported, ".shout") is False
+    # (H) a public NAMED extension is importable, so its members are roots
     assert _one(exported, ".PublicExt.boom") is True
+
+
+def test_dart_unnamed_extension_member_is_private() -> None:
+    # (H) An unnamed extension (`extension on String {...}`) is usable only in
+    # (H) its declaring library; export detection must treat its members as
+    # (H) private even though the leaf name looks public (PR #819 review).
+    from codebase_rag.parsers.export_detection import _dart_exported
+
+    parsers, _ = load_parsers()
+    if "dart" not in parsers:
+        pytest.skip("dart parser not available")
+    tree = parsers["dart"].parse(b"extension on String {\n  void shout() {}\n}\n")
+
+    def _find(node: object, wanted: str):
+        for child in node.children:  # type: ignore[attr-defined]
+            if child.type == wanted:
+                return child
+            found = _find(child, wanted)
+            if found is not None:
+                return found
+        return None
+
+    sig = _find(tree.root_node, "function_signature")
+    assert sig is not None
+    assert _dart_exported(sig, "shout") is False

--- a/codebase_rag/tests/test_is_exported_roots.py
+++ b/codebase_rag/tests/test_is_exported_roots.py
@@ -389,6 +389,14 @@ class Command {
 class _Internal {
   void doThing() {}
 }
+
+extension on String {
+  void shout() {}
+}
+
+extension PublicExt on String {
+  void boom() {}
+}
 """
 
 
@@ -407,3 +415,7 @@ def test_dart_visibility_seeds_exported_roots(tmp_path: Path) -> None:
     # (H) a public method of a PRIVATE class is not reachable from outside the
     # (H) library, so it is not an export root on its own
     assert _one(exported, "._Internal.doThing") is False
+    # (H) an unnamed extension is visible only in its declaring library, so its
+    # (H) members are not export roots; a public NAMED extension is importable
+    assert _one(exported, ".shout") is False
+    assert _one(exported, ".PublicExt.boom") is True


### PR DESCRIPTION
## Problem

Dart got CALLS edges (PR #804) and receiver typing (#806/#807), which turned dead-code detection ON for Dart, but Dart was never added to `is_exported` (export_detection.py). It fell through the `match` to `case _: return False`, so **every public Dart symbol was treated as library-private**. A public API with no in-project caller then flagged as dead. Measured on the dart-lang/args library: **122 symbols reported dead, 89 of them public API false positives** (`Command.run`, `CommandRunner.parse`, `ArgParser.addCommand`, ...).

## Fix

`_dart_exported(node, name)` implements Dart's actual visibility rule, which is purely lexical:
- a leading underscore on the symbol means library-private (not a root),
- and a public member is only externally reachable when EVERY enclosing type is also public, because a private class/mixin/extension cannot be named outside its library. The check walks the ancestor type chain and treats any private link as private (`_Internal.doThing` is not exported even though `doThing` has no underscore).

Wired into the `is_exported` dispatch as `case cs.SupportedLanguage.DART`. Unmodelled languages keep the conservative `False` default; every other language's branch is untouched, so this is DART-gated by construction.

## Validation

- dart-lang/args dead-code: **122 -> 12**, and the public-API false positives collapse from **89 -> 0**. The remaining 12 are underscore-private symbols (genuine internal-reachability candidates, the same semantics C++ uses).
- Cross-language scoreboard byte-identical (Java gson 37, Python django 12, and the Go/Rust/JS/C++ corpora unchanged), confirming zero collateral.
- Full suite green (documented memgraph-integration environmental flake only).

## Known follow-up (not this PR)

One of the 12 remaining, `_Usage.generate`, is still a false positive but from a DIFFERENT gap: it is invoked as `_Usage(...).generate()`, a construction-temporary chained call (`f().g()` where `f()` is a constructor) that Dart type inference does not yet resolve. That is a call-resolution ceiling, separate from export detection, and the natural next Dart improvement.

## Tests

RED -> GREEN: `test_dart_visibility_seeds_exported_roots` in test_is_exported_roots.py — public top-level function and public method exported; underscore members not; and a public method of a private class not exported.
