### PR TITLE
feat(io): C language flow support with a shared libc catalog and Java system properties

### DIFF
--- a/codebase_rag/parsers/io_access/descriptor.py
+++ b/codebase_rag/parsers/io_access/descriptor.py
@@ -322,4 +322,8 @@ LANGUAGE_DESCRIPTORS: dict[cs.SupportedLanguage, LanguageDescriptor] = {
     cs.SupportedLanguage.JAVA: _JAVA_DESCRIPTOR,
     cs.SupportedLanguage.RUST: _RUST_DESCRIPTOR,
     cs.SupportedLanguage.CPP: _CPP_DESCRIPTOR,
+    # (H) The C grammar shares every node type the C++ descriptor references
+    # (H) (call_expression, string_literal, init_declarator, compound_statement),
+    # (H) so C reuses it verbatim.
+    cs.SupportedLanguage.C: _CPP_DESCRIPTOR,
 }

--- a/codebase_rag/parsers/io_access/models.py
+++ b/codebase_rag/parsers/io_access/models.py
@@ -46,6 +46,16 @@ class HandleConstructor:
 
 
 @dataclass(frozen=True)
+class ArgHandleSink:
+    """A call-shaped handle sink: the resource handle arrives as an ARGUMENT
+    (libc's `fprintf(f, ...)` / `fgets(buf, n, f)`), not as a receiver."""
+
+    callee: str
+    handle_arg: int
+    direction: IODirection
+
+
+@dataclass(frozen=True)
 class HandleBinding:
     """A local variable bound to a resource handle within one function body."""
 

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -1105,7 +1105,9 @@ class IOAccessProcessor:
             if arguments is not None
             else []
         )
-        handle = args[sink.handle_arg] if sink.handle_arg < len(args) else None
+        handle = next(
+            (arg for index, arg in enumerate(args) if index == sink.handle_arg), None
+        )
         text = safe_decode_text(handle)
         if text is not None:
             if (binding := lean_handles.bindings.get(text)) is not None:

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -35,8 +35,9 @@ from .extract import (
     scope_seed_nodes,
     string_literal,
 )
-from .models import HandleBinding, HandleConstructor, IOSink
+from .models import ArgHandleSink, HandleBinding, HandleConstructor, IOSink
 from .registry import (
+    IO_ARG_HANDLE_SINKS,
     IO_CALL_HANDLE_WRAPPERS,
     IO_HANDLE_CONSTRUCTORS,
     IO_HANDLE_DERIVES,
@@ -52,6 +53,7 @@ from .registry import (
     IO_SINKS,
     IO_STREAM_SINKS,
     IO_TYPE_HANDLE_CONSTRUCTORS,
+    LIBC_STD_STREAMS,
 )
 
 _DIRECTION_REL = {
@@ -78,6 +80,7 @@ class _LeanHandles(NamedTuple):
     methods: dict[ResourceKind, dict[str, IODirection]]
     identity_calls: frozenset[str]
     identity_new_types: dict[str, ResourceKind]
+    arg_sinks: dict[str, ArgHandleSink]
     bindings: dict[str, HandleBinding]
 
 
@@ -96,6 +99,7 @@ def _lean_handles_for(language: cs.SupportedLanguage) -> _LeanHandles | None:
         methods=IO_LEAN_HANDLE_METHODS.get(language, {}),
         identity_calls=IO_IDENTITY_UNWRAP_CALLS.get(language, frozenset()),
         identity_new_types=IO_IDENTITY_UNWRAP_NEW_TYPES.get(language, {}),
+        arg_sinks=IO_ARG_HANDLE_SINKS.get(language, {}),
         bindings={},
     )
 
@@ -1054,6 +1058,10 @@ class IOAccessProcessor:
             node, caller_spec, raw, descriptor, lean_handles
         ):
             return
+        if lean_handles is not None and self._emit_arg_handle_sink(
+            node, caller_spec, raw, lean_handles
+        ):
+            return
         sink = self._resolve_sink(
             raw,
             import_map,
@@ -1073,6 +1081,41 @@ class IOAccessProcessor:
             keyword_arg_type=descriptor.keyword_arg_type,
         )
         self._emit(caller_spec, sink.direction, sink.kind, identity)
+
+    def _emit_arg_handle_sink(
+        self,
+        call_node: Node,
+        caller_spec: tuple[str, str, str],
+        raw_name: str,
+        lean_handles: _LeanHandles,
+    ) -> bool:
+        # (H) libc FILE* access: the handle is an ARGUMENT (`fprintf(f, ..)`,
+        # (H) `fgets(buf, n, f)`). A bound handle resolves to its resource; the
+        # (H) pre-bound stdin/stdout/stderr globals resolve to their streams;
+        # (H) any other handle expression is a FILE by signature (<dynamic>).
+        sink = lean_handles.arg_sinks.get(raw_name)
+        if sink is None:
+            return False
+        arguments = call_node.child_by_field_name(cs.TS_FIELD_ARGUMENTS)
+        handle = (
+            arguments.named_children[sink.handle_arg]
+            if arguments is not None and sink.handle_arg < len(arguments.named_children)
+            else None
+        )
+        text = (
+            handle.text.decode(cs.ENCODING_UTF8)
+            if handle is not None and handle.text is not None
+            else None
+        )
+        if text is not None:
+            if (binding := lean_handles.bindings.get(text)) is not None:
+                self._emit(caller_spec, sink.direction, binding.kind, binding.identity)
+                return True
+            if (stream_kind := LIBC_STD_STREAMS.get(text)) is not None:
+                self._emit(caller_spec, sink.direction, stream_kind, DYNAMIC_TARGET)
+                return True
+        self._emit(caller_spec, sink.direction, ResourceKind.FILE, DYNAMIC_TARGET)
+        return True
 
     def _emit_lean_handle_method(
         self,

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -9,7 +9,7 @@ from ... import constants as cs
 from ...capture import CaptureSelection
 from ...services import IngestorProtocol
 from ..import_processor import ImportProcessor
-from ..utils import cpp_declarator_name
+from ..utils import cpp_declarator_name, safe_decode_text
 from .constants import (
     DYNAMIC_TARGET,
     KEY_KIND,
@@ -1097,16 +1097,16 @@ class IOAccessProcessor:
         if sink is None:
             return False
         arguments = call_node.child_by_field_name(cs.TS_FIELD_ARGUMENTS)
-        handle = (
-            arguments.named_children[sink.handle_arg]
-            if arguments is not None and sink.handle_arg < len(arguments.named_children)
-            else None
+        # (H) Comments are named nodes inside the argument list and must not
+        # (H) shift the handle-argument index; safe_decode_text keeps malformed
+        # (H) bytes from raising.
+        args = (
+            [child for child in arguments.named_children if child.type != cs.TS_COMMENT]
+            if arguments is not None
+            else []
         )
-        text = (
-            handle.text.decode(cs.ENCODING_UTF8)
-            if handle is not None and handle.text is not None
-            else None
-        )
+        handle = args[sink.handle_arg] if sink.handle_arg < len(args) else None
+        text = safe_decode_text(handle)
         if text is not None:
             if (binding := lean_handles.bindings.get(text)) is not None:
                 self._emit(caller_spec, sink.direction, binding.kind, binding.identity)

--- a/codebase_rag/parsers/io_access/registry.py
+++ b/codebase_rag/parsers/io_access/registry.py
@@ -227,6 +227,23 @@ _JAVA_FILES_METHODS: tuple[tuple[str, IODirection], ...] = (
 
 _JAVA_SINKS: tuple[IOSink, ...] = (
     *_JAVA_SYSTEM_SINKS,
+    # (H) System properties are process-level configuration like env vars
+    # (H) (java.io.tmpdir/user.home reads are ubiquitous): modelled as ENV.
+    IOSink("System.getProperty", ResourceKind.ENV, IODirection.READ, target_arg=0),
+    IOSink(
+        "java.lang.System.getProperty",
+        ResourceKind.ENV,
+        IODirection.READ,
+        target_arg=0,
+    ),
+    IOSink("System.setProperty", ResourceKind.ENV, IODirection.WRITE, target_arg=0),
+    IOSink(
+        "java.lang.System.setProperty",
+        ResourceKind.ENV,
+        IODirection.WRITE,
+        target_arg=0,
+    ),
+    IOSink("System.clearProperty", ResourceKind.ENV, IODirection.WRITE, target_arg=0),
     *(
         IOSink(f"{prefix}.{method}", ResourceKind.FILE, direction, target_arg=0)
         for method, direction in _JAVA_FILES_METHODS

--- a/codebase_rag/parsers/io_access/registry.py
+++ b/codebase_rag/parsers/io_access/registry.py
@@ -244,6 +244,12 @@ _JAVA_SINKS: tuple[IOSink, ...] = (
         target_arg=0,
     ),
     IOSink("System.clearProperty", ResourceKind.ENV, IODirection.WRITE, target_arg=0),
+    IOSink(
+        "java.lang.System.clearProperty",
+        ResourceKind.ENV,
+        IODirection.WRITE,
+        target_arg=0,
+    ),
     *(
         IOSink(f"{prefix}.{method}", ResourceKind.FILE, direction, target_arg=0)
         for method, direction in _JAVA_FILES_METHODS
@@ -309,6 +315,7 @@ _CPP_CALL_METHODS: tuple[tuple[str, ResourceKind, IODirection, int | None], ...]
 _LIBC_ARG_HANDLE_METHODS: tuple[tuple[str, int, IODirection], ...] = (
     ("fprintf", 0, IODirection.WRITE),
     ("vfprintf", 0, IODirection.WRITE),
+    ("vfscanf", 0, IODirection.READ),
     ("fputs", 1, IODirection.WRITE),
     ("fputc", 1, IODirection.WRITE),
     ("putc", 1, IODirection.WRITE),

--- a/codebase_rag/parsers/io_access/registry.py
+++ b/codebase_rag/parsers/io_access/registry.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from ... import constants as cs
 from .constants import IODirection, ResourceKind
-from .models import HandleConstructor, IOSink
+from .models import ArgHandleSink, HandleConstructor, IOSink
 
 # (H) Direct I/O sink calls, keyed by normalised (import-expanded) callee name.
 _PYTHON_SINKS: tuple[IOSink, ...] = (
@@ -281,7 +281,35 @@ _CPP_CALL_METHODS: tuple[tuple[str, ResourceKind, IODirection, int | None], ...]
     ("printf", ResourceKind.STDOUT, IODirection.WRITE, None),
     ("puts", ResourceKind.STDOUT, IODirection.WRITE, None),
     ("putchar", ResourceKind.STDOUT, IODirection.WRITE, None),
+    ("perror", ResourceKind.STDERR, IODirection.WRITE, None),
+    ("scanf", ResourceKind.STDIN, IODirection.READ, None),
+    ("gets", ResourceKind.STDIN, IODirection.READ, None),
 )
+
+# (H) The libc FILE* API passes the handle as an ARGUMENT (fprintf's stream is
+# (H) arg 0, fgets's arg 2, fread/fwrite's arg 3), unlike every method-shaped
+# (H) handle API. snprintf/sprintf write to a BUFFER, not a resource: excluded.
+_LIBC_ARG_HANDLE_METHODS: tuple[tuple[str, int, IODirection], ...] = (
+    ("fprintf", 0, IODirection.WRITE),
+    ("vfprintf", 0, IODirection.WRITE),
+    ("fputs", 1, IODirection.WRITE),
+    ("fputc", 1, IODirection.WRITE),
+    ("putc", 1, IODirection.WRITE),
+    ("fwrite", 3, IODirection.WRITE),
+    ("fgets", 2, IODirection.READ),
+    ("fgetc", 0, IODirection.READ),
+    ("getc", 0, IODirection.READ),
+    ("fread", 3, IODirection.READ),
+    ("fscanf", 0, IODirection.READ),
+    ("getline", 2, IODirection.READ),
+)
+
+# (H) Pre-bound libc stream globals: `fprintf(stderr, ...)` needs no fopen.
+LIBC_STD_STREAMS: dict[str, ResourceKind] = {
+    "stdin": ResourceKind.STDIN,
+    "stdout": ResourceKind.STDOUT,
+    "stderr": ResourceKind.STDERR,
+}
 
 # (H) Keyed under both the bare (C linkage / `using namespace std`) and `std::`-
 # (H) qualified forms; C++ has no use-alias import map to expand a short path.
@@ -300,6 +328,25 @@ IO_SINKS: dict[cs.SupportedLanguage, tuple[IOSink, ...]] = {
     cs.SupportedLanguage.JAVA: _JAVA_SINKS,
     cs.SupportedLanguage.RUST: _RUST_SINKS,
     cs.SupportedLanguage.CPP: _CPP_SINKS,
+    # (H) C shares the libc catalog, bare names only (no std:: forms).
+    cs.SupportedLanguage.C: tuple(
+        IOSink(fn, kind, direction, target_arg=arg)
+        for fn, kind, direction, arg in _CPP_CALL_METHODS
+    ),
+}
+
+# (H) Call-shaped handle sinks per language (libc FILE* family); C++ gets both
+# (H) the bare and std:: spellings.
+IO_ARG_HANDLE_SINKS: dict[cs.SupportedLanguage, dict[str, ArgHandleSink]] = {
+    cs.SupportedLanguage.C: {
+        fn: ArgHandleSink(fn, arg, direction)
+        for fn, arg, direction in _LIBC_ARG_HANDLE_METHODS
+    },
+    cs.SupportedLanguage.CPP: {
+        f"{prefix}{fn}": ArgHandleSink(f"{prefix}{fn}", arg, direction)
+        for fn, arg, direction in _LIBC_ARG_HANDLE_METHODS
+        for prefix in _CPP_SINK_PREFIXES
+    },
 }
 
 # (H) Macro-call I/O sinks keyed by macro name (issue #714). Rust's stdout/stderr write
@@ -478,6 +525,18 @@ IO_LEAN_HANDLE_CONSTRUCTORS: dict[
     cs.SupportedLanguage.GO: _GO_LEAN_HANDLE_CONSTRUCTORS,
     cs.SupportedLanguage.JAVA: _JAVA_LEAN_HANDLE_CONSTRUCTORS,
     cs.SupportedLanguage.RUST: _RUST_LEAN_HANDLE_CONSTRUCTORS,
+    # (H) libc FILE* binding: `FILE *f = fopen("x", "w")`; mode_arg 1 flips the
+    # (H) direction when methods do not (fopen "r" vs "w" is informational only;
+    # (H) the arg-handle sink's own direction decides each access).
+    cs.SupportedLanguage.C: (
+        HandleConstructor("fopen", ResourceKind.FILE, target_arg=0),
+        HandleConstructor("freopen", ResourceKind.FILE, target_arg=0),
+    ),
+    cs.SupportedLanguage.CPP: tuple(
+        HandleConstructor(f"{prefix}{fn}", ResourceKind.FILE, target_arg=0)
+        for fn in ("fopen", "freopen")
+        for prefix in _CPP_SINK_PREFIXES
+    ),
 }
 
 # (H) `new`-shaped handle constructors keyed by the written type name (Java

--- a/codebase_rag/tests/test_io_java_properties.py
+++ b/codebase_rag/tests/test_io_java_properties.py
@@ -56,6 +56,20 @@ def test_java_get_property_reads_env(tmp_path: Path) -> None:
     assert _has(rels, "A.tmp", READS_FROM, "resource::ENV::java.io.tmpdir"), rels
 
 
+def test_java_qualified_clear_property_writes_env(tmp_path: Path) -> None:
+    files = {
+        "A.java": (
+            "class A {\n"
+            "  void drop() {\n"
+            '    java.lang.System.clearProperty("flag");\n'
+            "  }\n"
+            "}\n"
+        )
+    }
+    rels = _run(tmp_path, files)
+    assert _has(rels, "A.drop", WRITES_TO, "resource::ENV::flag"), rels
+
+
 def test_java_set_property_writes_env(tmp_path: Path) -> None:
     files = {
         "A.java": (

--- a/codebase_rag/tests/test_io_java_properties.py
+++ b/codebase_rag/tests/test_io_java_properties.py
@@ -1,0 +1,70 @@
+# (H) Java system properties are process-level configuration exactly like
+# (H) environment variables (commons-io reads java.io.tmpdir/user.home
+# (H) constantly): model them as ENV resources.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.capture import resolve_capture
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+READS_FROM = cs.RelationshipType.READS_FROM.value
+WRITES_TO = cs.RelationshipType.WRITES_TO.value
+_CAPTURE_IO = resolve_capture([cs.CaptureGroup.IO.value])
+
+
+def _run(tmp_path: Path, files: dict[str, str]) -> set[tuple[str, str, str]]:
+    parsers, queries = load_parsers()
+    for rel, content in files.items():
+        (tmp_path / rel).write_text(content, encoding="utf-8")
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        capture=_CAPTURE_IO,
+    ).run()
+    return {
+        (c.args[0][2], str(c.args[1]), c.args[2][2])
+        for c in mock.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) in (READS_FROM, WRITES_TO)
+    }
+
+
+def _has(rels: set[tuple[str, str, str]], caller: str, rel: str, resource: str) -> bool:
+    return any(
+        a.partition("(")[0].endswith(caller) and r == rel and b == resource
+        for a, r, b in rels
+    )
+
+
+def test_java_get_property_reads_env(tmp_path: Path) -> None:
+    files = {
+        "A.java": (
+            "class A {\n"
+            "  String tmp() {\n"
+            '    return System.getProperty("java.io.tmpdir");\n'
+            "  }\n"
+            "}\n"
+        )
+    }
+    rels = _run(tmp_path, files)
+    assert _has(rels, "A.tmp", READS_FROM, "resource::ENV::java.io.tmpdir"), rels
+
+
+def test_java_set_property_writes_env(tmp_path: Path) -> None:
+    files = {
+        "A.java": (
+            "class A {\n"
+            "  void mark() {\n"
+            '    System.setProperty("flag", "on");\n'
+            "  }\n"
+            "}\n"
+        )
+    }
+    rels = _run(tmp_path, files)
+    assert _has(rels, "A.mark", WRITES_TO, "resource::ENV::flag"), rels

--- a/codebase_rag/tests/test_io_libc_edges.py
+++ b/codebase_rag/tests/test_io_libc_edges.py
@@ -1,0 +1,159 @@
+# (H) libc I/O for C (previously ZERO flow support) and C++: direct sinks
+# (H) (getenv/printf/perror/scanf), fopen-bound FILE* handles, and the
+# (H) call-shaped handle sinks (`fprintf(f, ...)` carries the handle as an
+# (H) ARGUMENT), including the pre-bound stdout/stderr/stdin globals.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.capture import resolve_capture
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+READS_FROM = cs.RelationshipType.READS_FROM.value
+WRITES_TO = cs.RelationshipType.WRITES_TO.value
+FLOWS_TO = cs.RelationshipType.FLOWS_TO.value
+_CAPTURE_IO = resolve_capture([cs.CaptureGroup.IO.value])
+
+
+def _run(tmp_path: Path, files: dict[str, str]) -> set[tuple[str, str, str]]:
+    parsers, queries = load_parsers()
+    for rel, content in files.items():
+        (tmp_path / rel).write_text(content, encoding="utf-8")
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        capture=_CAPTURE_IO,
+    ).run()
+    return {
+        (c.args[0][2], str(c.args[1]), c.args[2][2])
+        for c in mock.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) in (READS_FROM, WRITES_TO, FLOWS_TO)
+    }
+
+
+def _has(rels: set[tuple[str, str, str]], caller: str, rel: str, resource: str) -> bool:
+    return any(a.endswith(caller) and r == rel and b == resource for a, r, b in rels)
+
+
+def test_c_getenv_reads_env(tmp_path: Path) -> None:
+    files = {
+        "main.c": (
+            "#include <stdlib.h>\n"
+            "void work(void) {\n"
+            '    const char *s = getenv("SECRET");\n'
+            "    (void)s;\n"
+            "}\n"
+        )
+    }
+    rels = _run(tmp_path, files)
+    assert _has(rels, "main.work", READS_FROM, "resource::ENV::SECRET"), rels
+
+
+def test_c_printf_writes_stdout_and_env_flows(tmp_path: Path) -> None:
+    files = {
+        "main.c": (
+            "#include <stdio.h>\n"
+            "#include <stdlib.h>\n"
+            "void work(void) {\n"
+            '    const char *s = getenv("SECRET");\n'
+            '    printf("%s", s);\n'
+            "}\n"
+        )
+    }
+    rels = _run(tmp_path, files)
+    assert _has(rels, "main.work", WRITES_TO, "resource::STDOUT::<dynamic>"), rels
+    assert (
+        "resource::ENV::SECRET",
+        FLOWS_TO,
+        "resource::STDOUT::<dynamic>",
+    ) in rels, rels
+
+
+def test_c_fopen_bound_fprintf_writes_file(tmp_path: Path) -> None:
+    files = {
+        "main.c": (
+            "#include <stdio.h>\n"
+            "void work(void) {\n"
+            '    FILE *f = fopen("out.txt", "w");\n'
+            '    fprintf(f, "%d", 1);\n'
+            "    fclose(f);\n"
+            "}\n"
+        )
+    }
+    rels = _run(tmp_path, files)
+    assert _has(rels, "main.work", WRITES_TO, "resource::FILE::out.txt"), rels
+
+
+def test_c_fopen_bound_fgets_reads_file(tmp_path: Path) -> None:
+    files = {
+        "main.c": (
+            "#include <stdio.h>\n"
+            "void work(char *buf) {\n"
+            '    FILE *f = fopen("in.txt", "r");\n'
+            "    fgets(buf, 100, f);\n"
+            "    fclose(f);\n"
+            "}\n"
+        )
+    }
+    rels = _run(tmp_path, files)
+    assert _has(rels, "main.work", READS_FROM, "resource::FILE::in.txt"), rels
+
+
+def test_c_fprintf_stderr_writes_stderr(tmp_path: Path) -> None:
+    files = {
+        "main.c": (
+            '#include <stdio.h>\nvoid work(void) {\n    fprintf(stderr, "boom");\n}\n'
+        )
+    }
+    rels = _run(tmp_path, files)
+    assert _has(rels, "main.work", WRITES_TO, "resource::STDERR::<dynamic>"), rels
+
+
+def test_c_perror_writes_stderr(tmp_path: Path) -> None:
+    files = {
+        "main.c": ('#include <stdio.h>\nvoid work(void) {\n    perror("open");\n}\n')
+    }
+    rels = _run(tmp_path, files)
+    assert _has(rels, "main.work", WRITES_TO, "resource::STDERR::<dynamic>"), rels
+
+
+def test_c_scanf_reads_stdin(tmp_path: Path) -> None:
+    files = {
+        "main.c": ('#include <stdio.h>\nvoid work(int *x) {\n    scanf("%d", x);\n}\n')
+    }
+    rels = _run(tmp_path, files)
+    assert _has(rels, "main.work", READS_FROM, "resource::STDIN::<dynamic>"), rels
+
+
+def test_cpp_fopen_bound_fwrite_writes_file(tmp_path: Path) -> None:
+    # (H) Real C++ uses the libc FILE* API too (spdlog's file sinks).
+    files = {
+        "main.cpp": (
+            "#include <cstdio>\n"
+            "void work(const char *data) {\n"
+            '    FILE *f = std::fopen("log.txt", "w");\n'
+            "    std::fwrite(data, 1, 8, f);\n"
+            "    std::fclose(f);\n"
+            "}\n"
+        )
+    }
+    rels = _run(tmp_path, files)
+    assert _has(rels, "main.work", WRITES_TO, "resource::FILE::log.txt"), rels
+
+
+def test_c_unknown_handle_fprintf_is_dynamic_file(tmp_path: Path) -> None:
+    # (H) A FILE* parameter is a file by signature even when its origin is
+    # (H) unknown in this function.
+    files = {
+        "main.c": (
+            '#include <stdio.h>\nvoid work(FILE *f) {\n    fprintf(f, "x");\n}\n'
+        )
+    }
+    rels = _run(tmp_path, files)
+    assert _has(rels, "main.work", WRITES_TO, "resource::FILE::<dynamic>"), rels

--- a/codebase_rag/tests/test_io_libc_edges.py
+++ b/codebase_rag/tests/test_io_libc_edges.py
@@ -115,6 +115,21 @@ def test_c_fprintf_stderr_writes_stderr(tmp_path: Path) -> None:
     assert _has(rels, "main.work", WRITES_TO, "resource::STDERR::<dynamic>"), rels
 
 
+def test_c_comment_before_handle_arg_still_resolves(tmp_path: Path) -> None:
+    # (H) A comment inside the argument list is a named node in some grammars;
+    # (H) it must not shift the handle-argument index.
+    files = {
+        "main.c": (
+            "#include <stdio.h>\n"
+            "void work(void) {\n"
+            '    fprintf(/* stream */ stderr, "boom");\n'
+            "}\n"
+        )
+    }
+    rels = _run(tmp_path, files)
+    assert _has(rels, "main.work", WRITES_TO, "resource::STDERR::<dynamic>"), rels
+
+
 def test_c_perror_writes_stderr(tmp_path: Path) -> None:
     files = {
         "main.c": ('#include <stdio.h>\nvoid work(void) {\n    perror("open");\n}\n')

--- a/uv.lock
+++ b/uv.lock
@@ -540,7 +540,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.399"
+version = "0.0.400"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Sweep-driven sink-catalog expansion (commons-io for Java, spdlog for C++, kilo for C). The headline finding: C had ZERO flow support — no sink catalog and no lean-walk descriptor, so a whole supported language produced no READS_FROM/WRITES_TO/FLOWS_TO at all. C++ lacked the entire libc FILE* family, leaving spdlog (a logging library) nearly invisible. Java lacked system properties.

## What changed

- **C wired end to end**: `LANGUAGE_DESCRIPTORS[C]` reuses the C++ descriptor verbatim (the grammars share every referenced node type), and `IO_SINKS[C]` shares the libc method table (bare names only; C++ keys both bare and `std::` forms). getenv/secure_getenv read ENV; printf/puts/putchar write STDOUT; new: perror writes STDERR, scanf/gets read STDIN.
- **libc FILE* family via a new call-shaped handle mechanism**: unlike every method-shaped handle API so far, libc passes the handle as an ARGUMENT (`fprintf(f, ...)` at 0, `fgets(buf, n, f)` at 2, `fread/fwrite` at 3). A new `ArgHandleSink` model plus `IO_ARG_HANDLE_SINKS` and one emission hook resolve the handle argument: an fopen/freopen-bound variable hits its resource identity, the pre-bound `stdin`/`stdout`/`stderr` globals hit their streams, and any other handle expression is FILE `<dynamic>` by signature. `snprintf`/`sprintf` are deliberately excluded (they write buffers, not resources).
- **Java system properties as ENV**: `System.getProperty`/`setProperty`/`clearProperty` (plus fully qualified forms) — process-level configuration exactly like env vars, and commons-io reads `java.io.tmpdir`/`user.home` constantly.

## Validation (organic, before -> after)

| repo | edges before | after |
|------|--------------|-------|
| kilo (C) | 0 | 5, each verified against source (`fopen(filename,"r")` read, `perror` STDERR writes) |
| spdlog (C++) | 8 | 22 (`fwrite_bytes`, `fwrite_all`, `count_lines`, bundled `fprintf` now visible) |
| commons-io (Java) | 0 ENV edges | 5 ENV edges at the `getProperty` sites |

## Tests

RED first, two rounds in history (ec7c8d8d, 5d0d53e4): nine libc specs (C getenv/printf plus the getenv-to-stdout FLOWS_TO, fopen-bound fprintf/fgets with literal identities, `fprintf(stderr, ...)`, perror, scanf, C++ `std::fopen`/`std::fwrite`, unknown-handle fallback) and two Java property specs; all failed on main. GREEN in a5d88b9f and eb41b3cb. Full suite: 5303 passed.