### PR TITLE
feat(dart): resolve method calls on construction-temporary and factory receivers

### DIFF
--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -1716,10 +1716,11 @@ class CallResolver:
             return_type = self.type_inference.method_return_types.get(resolved[1])
             if return_type:
                 return self._resolve_type_to_class_qn(return_type, module_qn)
-        if language == cs.SupportedLanguage.CPP:
+        if language in (cs.SupportedLanguage.CPP, cs.SupportedLanguage.DART):
             # (H) Constructor temporary: `X(...)` resolved to a ctor (never a
             # (H) recorded return) or to nothing at all; if X names a registered
-            # (H) class, that class IS the receiver type.
+            # (H) class, that class IS the receiver type (C++ `Reader<T>(...)`,
+            # (H) Dart `_Usage(...).generate()`).
             return self._resolve_type_to_class_qn(callee, module_qn)
         return None
 

--- a/codebase_rag/parsers/dart/utils.py
+++ b/codebase_rag/parsers/dart/utils.py
@@ -90,13 +90,30 @@ def _first_identifier_text(node: Node) -> str | None:
     return None
 
 
-def _walk_chain(node: Node | None) -> list[str] | None:
+_CALL_HOP = "()"
+
+
+def _selector_has_argument_part(node: Node) -> bool:
+    return node.type == cs.TS_DART_SELECTOR and any(
+        child.type == cs.TS_DART_ARGUMENT_PART for child in node.named_children
+    )
+
+
+def _walk_chain(node: Node | None, allow_calls: bool = False) -> list[str] | None:
     # (H) Backward walk over a selector chain, shared by plain and cascade
-    # (H) calls: None means the chain is broken (index selector, call result,
-    # (H) arbitrary expression) and has no static name; an empty list means
-    # (H) the chain bottomed out at `this`/`super`.
+    # (H) calls: None means the chain is broken (index selector, arbitrary
+    # (H) expression) and has no static name; an empty list means the chain
+    # (H) bottomed out at `this`/`super`. With allow_calls, a call hop in the
+    # (H) receiver (`Base(args).m()`, `factory().m()`) contributes a `()`
+    # (H) marker so the resolver's chained path can type the receiver from the
+    # (H) callee's return type or constructor class; without it (cascade path)
+    # (H) a call-result receiver stays unresolvable.
     parts_rev: list[str] = []
     while node is not None:
+        if allow_calls and _selector_has_argument_part(node):
+            parts_rev.append(_CALL_HOP)
+            node = node.prev_named_sibling
+            continue
         part = _chain_part(node)
         if part is None:
             return None
@@ -107,6 +124,20 @@ def _walk_chain(node: Node | None) -> list[str] | None:
             break
         node = node.prev_named_sibling
     return list(reversed(parts_rev))
+
+
+def _assemble_chain(tokens: list[str]) -> str:
+    # (H) A `()` marker attaches to the preceding hop with no separator
+    # (H) (`Base` + `()` -> `Base()`); every other hop is dot-joined.
+    out = ""
+    for token in tokens:
+        if token == _CALL_HOP:
+            out += _CALL_HOP
+        elif out:
+            out += cs.SEPARATOR_DOT + token
+        else:
+            out = token
+    return out
 
 
 def _cascade_call_name(call_node: Node) -> str | None:
@@ -165,17 +196,18 @@ def dart_call_name(call_node: Node) -> str | None:
     `selector(argument_part)`, `a.b(x)` is `identifier` + `selector(.b)` +
     `selector(argument_part)`, and `obj..m()` holds the `argument_part`
     inside its `cascade_section`. Walk the preceding sibling chain and
-    rebuild the dotted target; a chain broken by an index (`xs[0].f()`) or a
-    call result (`f().g()`) has no static name and returns None. A `this`/
-    `super` base is dropped so the bare member name resolves against the
-    caller's class.
+    rebuild the target; a call hop in the receiver (`Base(args).m()`,
+    `factory().m()`) is preserved as `()` so the resolver's chained path can
+    type it, while a chain broken by an index (`xs[0].f()`) still has no
+    static name and returns None. A `this`/`super` base is dropped so the
+    bare member name resolves against the caller's class.
     """
     if call_node.type == cs.TS_DART_CASCADE_SECTION:
         return _cascade_call_name(call_node)
-    parts = _walk_chain(call_node.prev_named_sibling)
-    if not parts:
+    tokens = _walk_chain(call_node.prev_named_sibling, allow_calls=True)
+    if not tokens or all(token == _CALL_HOP for token in tokens):
         return None
-    return cs.SEPARATOR_DOT.join(parts)
+    return _assemble_chain(tokens)
 
 
 def dart_return_type_name(node: Node) -> str | None:

--- a/codebase_rag/tests/test_dart_calls.py
+++ b/codebase_rag/tests/test_dart_calls.py
@@ -187,9 +187,11 @@ class A extends B {
     assert "obj.field.chainCascade" in calls
     assert "brokenCascade" not in calls
     assert "Widget.of" in calls
-    # (H) index and call-result receivers have no static name, and neither
-    # (H) does a cascade on a call result
-    assert calls.count(None) >= 3
+    # (H) a call-result receiver is now preserved as a `()` chain form so the
+    # (H) resolver can type it (`f().chained` -> f's return type); an index
+    # (H) receiver and a cascade on a call result still have no static name
+    assert "f().chained" in calls
+    assert calls.count(None) >= 2
 
     # (H) span helpers pass non-signature nodes through unchanged
     root = tree.root_node

--- a/codebase_rag/tests/test_dart_type_inference.py
+++ b/codebase_rag/tests/test_dart_type_inference.py
@@ -190,6 +190,18 @@ String useMultiDeclaration() {
 Greeter lowercaseFactory() {
   return Greeter('z');
 }
+
+String useConstructionChain() {
+  return Greeter('x').greet();
+}
+
+String useFactoryChain() {
+  return lowercaseFactory().hail();
+}
+
+String useInheritedConstructionChain() {
+  return Dog().speak();
+}
 """
 
 
@@ -337,6 +349,46 @@ def test_inherited_method_on_typed_receiver(
     # (H) walk the inheritance chain; OtherSpeaker.speak is the decoy
     assert _has(calls, ".app.useInherited", ".Animal.speak"), sorted(calls)
     assert not _has(calls, ".app.useInherited", ".OtherSpeaker.speak"), sorted(calls)
+
+
+def test_construction_temporary_chain_resolves(
+    dart_typed_project: Path, mock_ingestor: MagicMock
+):
+    run_updater(dart_typed_project, mock_ingestor, skip_if_missing=SKIP)
+    calls = _calls(mock_ingestor)
+    # (H) `Greeter('x').greet()` invokes a method on a construction temporary;
+    # (H) the receiver is a call result, so only chained typing off the ctor
+    # (H) can bind it. Shouter.greet is the decoy.
+    assert _has(calls, ".app.useConstructionChain", ".Greeter.greet"), sorted(calls)
+    assert not _has(calls, ".app.useConstructionChain", ".Shouter.greet"), sorted(
+        calls
+    )
+
+
+def test_factory_return_chain_resolves(
+    dart_typed_project: Path, mock_ingestor: MagicMock
+):
+    run_updater(dart_typed_project, mock_ingestor, skip_if_missing=SKIP)
+    calls = _calls(mock_ingestor)
+    # (H) `lowercaseFactory().hail()` types the receiver from the factory's
+    # (H) recorded return type (Greeter), then binds hail on it
+    assert _has(calls, ".app.useFactoryChain", ".Greeter.hail"), sorted(calls)
+    assert not _has(calls, ".app.useFactoryChain", ".Shouter.hail"), sorted(calls)
+
+
+def test_inherited_method_on_construction_chain(
+    dart_typed_project: Path, mock_ingestor: MagicMock
+):
+    run_updater(dart_typed_project, mock_ingestor, skip_if_missing=SKIP)
+    calls = _calls(mock_ingestor)
+    # (H) `Dog().speak()` where speak is defined on Animal: chained typing must
+    # (H) walk the inheritance chain. OtherSpeaker.speak is the decoy.
+    assert _has(calls, ".app.useInheritedConstructionChain", ".Animal.speak"), sorted(
+        calls
+    )
+    assert not _has(
+        calls, ".app.useInheritedConstructionChain", ".OtherSpeaker.speak"
+    ), sorted(calls)
 
 
 def test_lowercase_initializer_does_not_type(

--- a/codebase_rag/tests/test_dart_type_inference.py
+++ b/codebase_rag/tests/test_dart_type_inference.py
@@ -360,9 +360,7 @@ def test_construction_temporary_chain_resolves(
     # (H) the receiver is a call result, so only chained typing off the ctor
     # (H) can bind it. Shouter.greet is the decoy.
     assert _has(calls, ".app.useConstructionChain", ".Greeter.greet"), sorted(calls)
-    assert not _has(calls, ".app.useConstructionChain", ".Shouter.greet"), sorted(
-        calls
-    )
+    assert not _has(calls, ".app.useConstructionChain", ".Shouter.greet"), sorted(calls)
 
 
 def test_factory_return_chain_resolves(


### PR DESCRIPTION
## Problem

The remaining Dart dead-code false positive after PR #819: `_Usage(...).generate()` (dart-lang/args) reported `_Usage.generate` dead even though it is called, because a method invoked on a construction temporary was dropped. `dart_call_name` returned `None` for any chain whose receiver is a call result (`Base(args).m()`, `factory().m()`), so it never reached the resolver's chained-call path — which is already general and inheritance-aware.

## Fix

Two small changes that let the existing chained-call machinery do the work:

- `dart_call_name` now preserves a call hop in the receiver as a `()` marker instead of bailing: `_walk_chain(..., allow_calls=True)` emits `()` for an `argument_part` selector, and `_assemble_chain` renders `Base` + `()` + `.method` as `Base().method`. An index-selector receiver (`xs[0].f()`) still has no static name and drops, and the cascade path keeps its call-free behavior. A name that is only `()` markers (no method) drops.
- The constructor-temporary fallback in `_infer_call_base_type` (previously C++-only) now also applies to Dart: when `Base(...)` names a registered class and has no recorded return type, that class IS the receiver type. Factory receivers (`lowercaseFactory().m()`) were already covered by the recorded-return-type path from PR #807.

Everything downstream is reused unchanged: `_infer_chained_object_type` types the base, `_resolve_chained_call` binds the final method and walks `class_inheritance` for inherited methods.

## Validation

- dart-lang/args dead-code: **12 -> 5**, `_Usage.generate` resolved and gone. All 5 remaining are underscore-private symbols (the legitimate internal-reachability residual). Public-API false positives stay at 0. Across the two Dart dead-code fixes the count fell 122 -> 12 -> 5.
- C++ chained-call corpora byte-identical (nlohmann json 225, fmt 631): the shared `_infer_call_base_type` change only ADDED Dart to the existing C++ branch, so C++ is untouched.
- Full suite: 5572 passed, 0 failures.

## Known remaining ceiling

A NAMED constructor temporary (`Greeter.named('y').hail()`) still drops: the base `Greeter.named()` is a two-hop receiver the chain typer does not treat as a construction. Rare; noted for a later pass.

## Tests

RED -> GREEN in test_dart_type_inference.py: construction-temporary chain (`Greeter('x').greet()`, decoy `Shouter.greet`), factory-return chain (`lowercaseFactory().hail()`), and inherited method on a construction chain (`Dog().speak()` -> `Animal.speak`, decoy `OtherSpeaker.speak`). test_dart_calls.py shape test updated: `f().chained` is now a produced chain name, not `None`.
