### PR TITLE
feat(io): model Java java.net/http NETWORK sinks and Socket streams

### DIFF
--- a/codebase_rag/parsers/io_access/registry.py
+++ b/codebase_rag/parsers/io_access/registry.py
@@ -748,6 +748,8 @@ IO_LEAN_HANDLE_METHODS: dict[
         # (H) and Python client.request() stance.
         ResourceKind.NETWORK: {
             "openStream": IODirection.READ,
+            # (H) URL.getContent() opens a connection and retrieves the resource.
+            "getContent": IODirection.READ,
             "send": IODirection.READ_WRITE,
             "sendAsync": IODirection.READ_WRITE,
         },

--- a/codebase_rag/parsers/io_access/registry.py
+++ b/codebase_rag/parsers/io_access/registry.py
@@ -528,6 +528,17 @@ _JAVA_LEAN_HANDLE_CONSTRUCTORS: tuple[HandleConstructor, ...] = tuple(
             0,
             ("DriverManager", "java.sql.DriverManager"),
         ),
+        # (H) `HttpClient.newHttpClient()` (java.net.http, Java 11+) yields a
+        # (H) NETWORK client; the URL lives on the HttpRequest passed to send(),
+        # (H) not the client, so the client's resource identity is <dynamic>
+        # (H) (target_arg=None). The builder form `HttpClient.newBuilder().build()`
+        # (H) is a follow-up (the chained build() does not bind here).
+        (
+            "newHttpClient",
+            ResourceKind.NETWORK,
+            None,
+            ("HttpClient", "java.net.http.HttpClient"),
+        ),
     )
     for prefix in prefixes
 )
@@ -578,6 +589,11 @@ _JAVA_NEW_HANDLE_TYPES: tuple[tuple[str, str, ResourceKind], ...] = (
     ("PrintWriter", _JAVA_IO_PACKAGE, ResourceKind.FILE),
     ("RandomAccessFile", _JAVA_IO_PACKAGE, ResourceKind.FILE),
     ("Socket", "java.net", ResourceKind.SOCKET),
+    # (H) `new URL("http://..")` is a NETWORK handle: the URL literal is the
+    # (H) resource identity, and a later `.openStream()` reads it. URL parsing
+    # (H) itself does no I/O, but construction emits no edge (only the handle
+    # (H) methods do), so keying it as a NETWORK handle is behaviourally exact.
+    ("URL", "java.net", ResourceKind.NETWORK),
 )
 
 IO_NEW_HANDLE_CONSTRUCTORS: dict[cs.SupportedLanguage, dict[str, HandleConstructor]] = {
@@ -725,6 +741,22 @@ IO_LEAN_HANDLE_METHODS: dict[
             "executeUpdate": IODirection.WRITE,
             "executeBatch": IODirection.WRITE,
             "execute": IODirection.READ_WRITE,
+        },
+        # (H) URL.openStream() reads the resource; HttpClient.send/sendAsync
+        # (H) are verb-agnostic (the method rides on the HttpRequest), so
+        # (H) READ_WRITE is the honest "either" label, matching the DB execute()
+        # (H) and Python client.request() stance.
+        ResourceKind.NETWORK: {
+            "openStream": IODirection.READ,
+            "send": IODirection.READ_WRITE,
+            "sendAsync": IODirection.READ_WRITE,
+        },
+        # (H) `new Socket(host, port)` was already a registered SOCKET handle but
+        # (H) had no method table, so its reads/writes emitted nothing: a
+        # (H) java.net.Socket is used via get{Input,Output}Stream().
+        ResourceKind.SOCKET: {
+            "getInputStream": IODirection.READ,
+            "getOutputStream": IODirection.WRITE,
         },
     },
     cs.SupportedLanguage.RUST: {

--- a/codebase_rag/tests/test_io_java_network.py
+++ b/codebase_rag/tests/test_io_java_network.py
@@ -1,0 +1,97 @@
+# (H) Java networking I/O: the java.net / java.net.http surface (URL.openStream,
+# (H) URLConnection, HttpClient.send) is NETWORK, previously invisible to the
+# (H) catalog which only modelled java.net.Socket as a SOCKET.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.capture import resolve_capture
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+READS_FROM = cs.RelationshipType.READS_FROM.value
+WRITES_TO = cs.RelationshipType.WRITES_TO.value
+_CAPTURE_IO = resolve_capture([cs.CaptureGroup.IO.value])
+
+
+def _run(tmp_path: Path, files: dict[str, str]) -> set[tuple[str, str, str]]:
+    parsers, queries = load_parsers()
+    for rel, content in files.items():
+        (tmp_path / rel).write_text(content, encoding="utf-8")
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        capture=_CAPTURE_IO,
+    ).run()
+    return {
+        (c.args[0][2], str(c.args[1]), c.args[2][2])
+        for c in mock.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) in (READS_FROM, WRITES_TO)
+    }
+
+
+def _has(rels: set[tuple[str, str, str]], caller: str, rel: str, resource: str) -> bool:
+    return any(
+        a.partition("(")[0].endswith(caller) and r == rel and b == resource
+        for a, r, b in rels
+    )
+
+
+def test_java_url_open_stream_reads_network(tmp_path: Path) -> None:
+    files = {
+        "A.java": (
+            "import java.net.URL;\n"
+            "import java.io.InputStream;\n"
+            "class A {\n"
+            "  void fetch() throws Exception {\n"
+            '    URL u = new URL("http://example.com/data");\n'
+            "    InputStream in = u.openStream();\n"
+            "  }\n"
+            "}\n"
+        )
+    }
+    rels = _run(tmp_path, files)
+    assert _has(
+        rels, "A.fetch", READS_FROM, "resource::NETWORK::http://example.com/data"
+    ), rels
+
+
+def test_java_http_client_send_touches_network(tmp_path: Path) -> None:
+    files = {
+        "A.java": (
+            "import java.net.http.HttpClient;\n"
+            "class A {\n"
+            "  void call(Object req, Object handler) throws Exception {\n"
+            "    HttpClient client = HttpClient.newHttpClient();\n"
+            "    client.send(req, handler);\n"
+            "  }\n"
+            "}\n"
+        )
+    }
+    rels = _run(tmp_path, files)
+    assert _has(rels, "A.call", READS_FROM, "resource::NETWORK::<dynamic>") or _has(
+        rels, "A.call", WRITES_TO, "resource::NETWORK::<dynamic>"
+    ), rels
+
+
+def test_java_socket_streams_touch_socket(tmp_path: Path) -> None:
+    files = {
+        "A.java": (
+            "import java.net.Socket;\n"
+            "class A {\n"
+            "  void talk() throws Exception {\n"
+            '    Socket s = new Socket("host", 80);\n'
+            "    var in = s.getInputStream();\n"
+            "    var out = s.getOutputStream();\n"
+            "  }\n"
+            "}\n"
+        )
+    }
+    rels = _run(tmp_path, files)
+    assert _has(rels, "A.talk", READS_FROM, "resource::SOCKET::host"), rels
+    assert _has(rels, "A.talk", WRITES_TO, "resource::SOCKET::host"), rels

--- a/codebase_rag/tests/test_io_java_network.py
+++ b/codebase_rag/tests/test_io_java_network.py
@@ -74,8 +74,26 @@ def test_java_http_client_send_touches_network(tmp_path: Path) -> None:
         )
     }
     rels = _run(tmp_path, files)
-    assert _has(rels, "A.call", READS_FROM, "resource::NETWORK::<dynamic>") or _has(
-        rels, "A.call", WRITES_TO, "resource::NETWORK::<dynamic>"
+    # (H) send() is READ_WRITE, so both directions must be emitted.
+    assert _has(rels, "A.call", READS_FROM, "resource::NETWORK::<dynamic>"), rels
+    assert _has(rels, "A.call", WRITES_TO, "resource::NETWORK::<dynamic>"), rels
+
+
+def test_java_url_get_content_reads_network(tmp_path: Path) -> None:
+    files = {
+        "A.java": (
+            "import java.net.URL;\n"
+            "class A {\n"
+            "  Object grab() throws Exception {\n"
+            '    URL u = new URL("http://example.com/x");\n'
+            "    return u.getContent();\n"
+            "  }\n"
+            "}\n"
+        )
+    }
+    rels = _run(tmp_path, files)
+    assert _has(
+        rels, "A.grab", READS_FROM, "resource::NETWORK::http://example.com/x"
     ), rels
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -540,7 +540,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.400"
+version = "0.0.403"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

Expands the Java I/O sink catalog to cover the **NETWORK** resource surface, which was previously invisible (only `java.net.Socket` was modelled, as a SOCKET handle with no method table).

Concretely, flow/IO edges now emit for:

- **`new URL("http://..").openStream()`** → `READS_FROM NETWORK::<url>` — the URL literal is the resource identity.
- **`HttpClient.newHttpClient().send(..)` / `.sendAsync(..)`** (java.net.http, Java 11+) → `NETWORK::<dynamic>` `READ_WRITE` (the verb rides on the `HttpRequest`, not the client, so direction is the honest "either" label, matching the DB `execute()` and Python `client.request()` stance).
- **`new Socket(host, port).getInputStream()/getOutputStream()`** → `READS_FROM`/`WRITES_TO SOCKET::<host>` — `new Socket` was already a registered handle but had **no method table**, so its reads/writes emitted nothing; that dangling capability is now closed.

## Why

Java's HTTP surface is a core I/O modality that the catalog didn't touch, so any Java taint/flow analysis silently dropped network reads and writes. This continues the sink-catalog line from #820 (C/libc) into Java networking.

## Tests

`codebase_rag/tests/test_io_java_network.py` — RED→GREEN for URL stream reads, HttpClient send, and Socket streams. Full suite: 3074 passed.

Builder form `HttpClient.newBuilder().build()` and `URLConnection` derive-chains are noted as follow-ups (the chained `build()` / `openConnection()` do not bind here).