### PR TITLE
fix(incremental): disambiguate cross-language module qn on incremental add

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1087,6 +1087,28 @@ class GraphUpdater:
                 self._rehydrated_module_qns.add(qn)
         self._rehydrate_class_inheritance_from_graph()
 
+    def _seed_module_qns_from_graph(self) -> None:
+        # (H) Cross-language module-qn disambiguation (definition_processor.
+        # (H) _disambiguate_module_qn) only sees files processed in the current
+        # (H) run. On an incremental ADD of a file whose basename collides with an
+        # (H) already-indexed sibling of another language (shapes.rs already owns
+        # (H) proj.shapes, then shapes.cpp is added), the added file would re-claim
+        # (H) the bare qn and silently overwrite the existing module under the
+        # (H) qualified_name constraint. Seed the qn->file map from the graph
+        # (H) BEFORE processing so the disambiguator sees taken qns; a re-parsed
+        # (H) (changed) file still matches its own path and keeps its bare qn.
+        if not isinstance(self.ingestor, QueryProtocol):
+            return
+        module_map = self.factory.definition_processor.module_qn_to_file_path
+        for row in self.ingestor.fetch_all(cs.CYPHER_ALL_MODULE_PATHS_INTERNAL):
+            qn = row.get(cs.KEY_QUALIFIED_NAME)
+            path = row.get(cs.KEY_PATH)
+            if not isinstance(qn, str) or not isinstance(path, str) or not path:
+                continue
+            if path.startswith(cs.INLINE_MODULE_PATH_PREFIX):
+                continue
+            module_map.setdefault(qn, self.repo_path / path)
+
     def _rehydrate_class_inheritance_from_graph(self) -> None:
         # (H) Incremental runs rebuild class_inheritance only from re-parsed files.
         # (H) Restore the child->bases map for classes defined in files that were
@@ -1457,6 +1479,9 @@ class GraphUpdater:
 
         _touch_empty_json(cache_path)
         _touch_empty_json(dir_mtimes_path)
+
+        if not is_full_build:
+            self._seed_module_qns_from_graph()
 
         eligible_files = self._collect_eligible_files()
         new_hashes: FileHashCache = {}

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1087,7 +1087,7 @@ class GraphUpdater:
                 self._rehydrated_module_qns.add(qn)
         self._rehydrate_class_inheritance_from_graph()
 
-    def _seed_module_qns_from_graph(self) -> None:
+    def _seed_module_qns_from_graph(self, eligible_paths: set[str]) -> None:
         # (H) Cross-language module-qn disambiguation (definition_processor.
         # (H) _disambiguate_module_qn) only sees files processed in the current
         # (H) run. On an incremental ADD of a file whose basename collides with an
@@ -1107,14 +1107,14 @@ class GraphUpdater:
                 continue
             if path.startswith(cs.INLINE_MODULE_PATH_PREFIX):
                 continue
-            # (H) Skip modules whose file was deleted this cycle: seeding a
-            # (H) deleted file's qn would make a same-basename ADD (delete
-            # (H) shapes.rs + add shapes.cpp) take the suffixed form, diverging
-            # (H) from a clean index that gives the survivor the bare qn.
-            abs_path = self.repo_path / path
-            if not abs_path.exists():
+            # (H) Only seed modules whose file survives this run (still eligible).
+            # (H) A file deleted OR newly excluded this cycle is gone from
+            # (H) eligible_paths, so a same-basename ADD (delete shapes.rs + add
+            # (H) shapes.cpp) takes the bare qn a clean index would give it,
+            # (H) instead of the suffixed form.
+            if path not in eligible_paths:
                 continue
-            module_map.setdefault(qn, abs_path)
+            module_map.setdefault(qn, self.repo_path / path)
 
     def _rehydrate_class_inheritance_from_graph(self) -> None:
         # (H) Incremental runs rebuild class_inheritance only from re-parsed files.
@@ -1487,10 +1487,10 @@ class GraphUpdater:
         _touch_empty_json(cache_path)
         _touch_empty_json(dir_mtimes_path)
 
-        if not is_full_build:
-            self._seed_module_qns_from_graph()
-
         eligible_files = self._collect_eligible_files()
+
+        if not is_full_build:
+            self._seed_module_qns_from_graph({key for _fp, key in eligible_files})
         new_hashes: FileHashCache = {}
         skipped_count = 0
         changed_count = 0

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1107,7 +1107,14 @@ class GraphUpdater:
                 continue
             if path.startswith(cs.INLINE_MODULE_PATH_PREFIX):
                 continue
-            module_map.setdefault(qn, self.repo_path / path)
+            # (H) Skip modules whose file was deleted this cycle: seeding a
+            # (H) deleted file's qn would make a same-basename ADD (delete
+            # (H) shapes.rs + add shapes.cpp) take the suffixed form, diverging
+            # (H) from a clean index that gives the survivor the bare qn.
+            abs_path = self.repo_path / path
+            if not abs_path.exists():
+                continue
+            module_map.setdefault(qn, abs_path)
 
     def _rehydrate_class_inheritance_from_graph(self) -> None:
         # (H) Incremental runs rebuild class_inheritance only from re-parsed files.

--- a/codebase_rag/tests/test_incremental_cross_language_collision.py
+++ b/codebase_rag/tests/test_incremental_cross_language_collision.py
@@ -92,3 +92,35 @@ def test_incremental_add_of_cross_language_sibling_does_not_collide(
         f"cross-language module qn collision on incremental add: {modules}"
     )
     assert modules["shapes.rs"] == "proj.shapes", modules
+
+
+@pytest.mark.usefixtures("_needs_rust_cpp")
+def test_incremental_delete_then_add_sibling_matches_clean_index(
+    temp_repo: Path,
+) -> None:
+    # (H) Deleting shapes.rs while adding shapes.cpp in the same cycle must give
+    # (H) shapes.cpp the bare qn a clean index would (proj.shapes), not the
+    # (H) suffixed form. The seed must not hand the disambiguator a qn owned by a
+    # (H) file that no longer exists on disk (Greptile #823 P1).
+    (temp_repo / "shapes.rs").write_text(_RS, encoding="utf-8")
+
+    store = _StatefulIngestor()
+    _index(store, temp_repo, force=False)
+    assert _shapes_modules(store) == {"shapes.rs": "proj.shapes"}
+
+    cache = temp_repo / cs.HASH_CACHE_FILENAME
+    future = cache.stat().st_mtime + 10
+    (temp_repo / "shapes.rs").unlink()
+    cpp = temp_repo / "shapes.cpp"
+    cpp.write_text(_CPP, encoding="utf-8")
+    os.utime(cpp, (future, future))
+
+    _index(store, temp_repo, force=False)
+
+    modules = _shapes_modules(store)
+    assert modules == {"shapes.cpp": "proj.shapes"}, modules
+
+    # (H) equivalence check: a clean index of the final tree agrees.
+    clean = _StatefulIngestor()
+    _index(clean, temp_repo, force=True)
+    assert _shapes_modules(clean) == modules

--- a/codebase_rag/tests/test_incremental_cross_language_collision.py
+++ b/codebase_rag/tests/test_incremental_cross_language_collision.py
@@ -1,0 +1,94 @@
+# (H) Incremental cross-language module-qn collision (found via the polyglot
+# (H) eval). On a full build, two files that strip to the same module qn
+# (H) (shapes.rs / shapes.cpp) are disambiguated -- the second gets its extension
+# (H) appended -- because both pass through _disambiguate_module_qn in one run.
+# (H) On an INCREMENTAL run that ADDS one of them next to an already-indexed
+# (H) sibling, the disambiguator only sees files processed this run, so the added
+# (H) file re-claims the bare qn and silently overwrites the existing module
+# (H) under the qualified_name uniqueness constraint (issue #652 class). This
+# (H) needs the query-capable _StatefulIngestor: the mock harness never
+# (H) rehydrates, so the bug is invisible to every other test.
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from evals.cgr_graph import _StatefulIngestor
+
+_MODULE = cs.NodeLabel.MODULE.value
+
+_RS = "pub struct Square;\n\npub fn describe() -> i32 {\n    1\n}\n"
+_CPP = "class Square {};\n\nint describe() { return 1; }\n"
+
+
+def _index(store: _StatefulIngestor, repo: Path, force: bool) -> None:
+    parsers, queries = load_parsers()
+    GraphUpdater(
+        ingestor=store,
+        repo_path=repo,
+        parsers=parsers,
+        queries=queries,
+        project_name="proj",
+    ).run(force=force)
+
+
+def _shapes_modules(store: _StatefulIngestor) -> dict[str, str]:
+    # (H) path -> module qn, for every Module node whose file is a shapes.* file.
+    out: dict[str, str] = {}
+    for (label, _uid), props in store.nodes.items():
+        if label != _MODULE:
+            continue
+        path = props.get(cs.KEY_PATH)
+        qn = props.get(cs.KEY_QUALIFIED_NAME)
+        if (
+            isinstance(path, str)
+            and isinstance(qn, str)
+            and Path(path).stem == "shapes"
+        ):
+            out[path] = qn
+    return out
+
+
+@pytest.fixture
+def _needs_rust_cpp() -> None:
+    parsers, _ = load_parsers()
+    for lang in (cs.SupportedLanguage.RUST, cs.SupportedLanguage.CPP):
+        if lang not in parsers:
+            pytest.skip(f"{lang.value} parser not available")
+
+
+@pytest.mark.usefixtures("_needs_rust_cpp")
+def test_incremental_add_of_cross_language_sibling_does_not_collide(
+    temp_repo: Path,
+) -> None:
+    (temp_repo / "shapes.rs").write_text(_RS, encoding="utf-8")
+
+    store = _StatefulIngestor()
+    _index(store, temp_repo, force=False)
+
+    # (H) rust owns the bare module qn after the first (full) index.
+    assert _shapes_modules(store) == {"shapes.rs": "proj.shapes"}
+
+    # (H) Add the C++ sibling and mark it changed past the hash cache so the
+    # (H) incremental run re-parses it.
+    cache = temp_repo / cs.HASH_CACHE_FILENAME
+    future = cache.stat().st_mtime + 10
+    cpp = temp_repo / "shapes.cpp"
+    cpp.write_text(_CPP, encoding="utf-8")
+    os.utime(cpp, (future, future))
+
+    _index(store, temp_repo, force=False)
+
+    modules = _shapes_modules(store)
+    # (H) Both files must survive with DISTINCT module qns; pre-fix, shapes.cpp
+    # (H) re-claims proj.shapes and overwrites the rust module node.
+    assert set(modules) == {"shapes.rs", "shapes.cpp"}, modules
+    assert len(set(modules.values())) == 2, (
+        f"cross-language module qn collision on incremental add: {modules}"
+    )
+    assert modules["shapes.rs"] == "proj.shapes", modules

--- a/uv.lock
+++ b/uv.lock
@@ -540,7 +540,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.403"
+version = "0.0.404"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Problem

On a full build, two files that strip to the same module qn (`shapes.rs` / `shapes.cpp`) are disambiguated: the second gets its extension appended, because both pass through `_disambiguate_module_qn` in one run.

On an **incremental** run that ADDS one of them next to an already-indexed sibling of another language, the disambiguator only sees files processed in the current run (`_process_files` runs before `_rehydrate_registry_from_graph`). The added file re-claims the bare qn and **silently overwrites the existing module** under the `qualified_name` uniqueness constraint (issue #652 class). Index `shapes.rs` -> `proj.shapes`; later add `shapes.cpp` -> the rust module is erased.

This was invisible to the mock test harness, which never rehydrates. It surfaced via the new polyglot cross-language eval.

## Fix

`_seed_module_qns_from_graph()` seeds `module_qn_to_file_path` from `CYPHER_ALL_MODULE_PATHS_INTERNAL` before the incremental file loop, so disambiguation sees already-taken qns. A re-parsed (changed) file still matches its own path and keeps its bare qn.

## Tests

RED -> GREEN with the query-capable `_StatefulIngestor` (the mock harness can't reproduce it). Full non-integration suite: 5313 passed / 5 skipped; incremental set incl. the real-Memgraph integration test green.