### PR TITLE
test(evals): add polyglot cross-language ingestion eval and regression guard

### DIFF
--- a/codebase_rag/tests/test_polyglot_eval.py
+++ b/codebase_rag/tests/test_polyglot_eval.py
@@ -48,7 +48,13 @@ def test_every_available_language_is_represented(polyglot_corpus: Path) -> None:
     )
     # (H) each present language must also contribute at least one definition,
     # (H) not just an empty module node.
-    empty = [lang.value for lang in available if not report.defs_by_language.get(lang)]
+    # (H) sorted() so iteration order is deterministic across runs (StrEnum
+    # (H) members hash by string, whose order varies with hash randomization).
+    empty = [
+        lang.value
+        for lang in sorted(available)
+        if not report.defs_by_language.get(lang)
+    ]
     assert not empty, f"languages with no definitions: {sorted(empty)}"
 
 

--- a/codebase_rag/tests/test_polyglot_eval.py
+++ b/codebase_rag/tests/test_polyglot_eval.py
@@ -62,12 +62,23 @@ def test_cross_language_basename_collision_is_disambiguated(
     polyglot_corpus: Path,
 ) -> None:
     available = _available_languages()
-    if not {cs.SupportedLanguage.RUST, cs.SupportedLanguage.CPP} <= available:
-        pytest.skip("collision trio needs the rust and cpp parsers")
+    trio = {
+        cs.SupportedLanguage.RUST,
+        cs.SupportedLanguage.CPP,
+        cs.SupportedLanguage.TS,
+    }
+    if not trio <= available:
+        pytest.skip("collision trio needs the rust, cpp and typescript parsers")
     report = cgr_polyglot(polyglot_corpus, polyglot_corpus.name)
     # (H) shapes.rs / shapes.cpp / shapes.ts strip to the same module qn; each
     # (H) must end up with its OWN qn or one silently overwrites the others
     # (H) under the qualified_name uniqueness constraint (issue #652 class).
+    # (H) Assert all three files produced a module FIRST: cgr_polyglot keys its
+    # (H) path map by qn, so a real collapse would drop a path and a bare
+    # (H) uniqueness check could still pass on the survivors (Greptile #824 P1).
+    assert set(report.collision_qns) == {"shapes.rs", "shapes.cpp", "shapes.ts"}, (
+        f"a colliding-basename file lost its module: {report.collision_qns}"
+    )
     qns = list(report.collision_qns.values())
     assert len(qns) == len(set(qns)), (
         f"colliding basenames share a module qn: {report.collision_qns}"

--- a/codebase_rag/tests/test_polyglot_eval.py
+++ b/codebase_rag/tests/test_polyglot_eval.py
@@ -1,0 +1,104 @@
+# (H) Cross-language / polyglot ingestion regression guard. Drives the
+# (H) evals.polyglot corpus (one file per SupportedLanguage, plus a three-way
+# (H) same-basename collision) through a single cgr graph build and asserts the
+# (H) cross-language integrity invariants: every available language is
+# (H) represented, basename collisions are disambiguated rather than
+# (H) overwritten, no semantic edge crosses a language boundary, the recorded
+# (H) graph is dangling/orphan free, and the whole thing is deterministic. No
+# (H) eval before this one indexed more than one language at a time.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.tests.conftest import create_and_run_updater
+from evals.polyglot import (
+    EXPECTED_LANGUAGES,
+    build_polyglot_corpus,
+    cgr_polyglot,
+)
+
+
+def _available_languages() -> frozenset[cs.SupportedLanguage]:
+    # (H) Only grade languages whose parser actually loaded, so a missing
+    # (H) optional grammar skips that language instead of failing the suite --
+    # (H) but any loaded language that drops out of the graph is a real bug.
+    parsers, _ = load_parsers()
+    return EXPECTED_LANGUAGES & frozenset(parsers)
+
+
+@pytest.fixture
+def polyglot_corpus(temp_repo: Path) -> Path:
+    root = temp_repo / "poly"
+    build_polyglot_corpus(root)
+    return root
+
+
+def test_every_available_language_is_represented(polyglot_corpus: Path) -> None:
+    available = _available_languages()
+    report = cgr_polyglot(polyglot_corpus, polyglot_corpus.name)
+    dropped = available & report.missing_languages
+    assert not dropped, (
+        "languages dropped from the polyglot graph: "
+        f"{sorted(lang.value for lang in dropped)}"
+    )
+    # (H) each present language must also contribute at least one definition,
+    # (H) not just an empty module node.
+    empty = [lang.value for lang in available if not report.defs_by_language.get(lang)]
+    assert not empty, f"languages with no definitions: {sorted(empty)}"
+
+
+def test_cross_language_basename_collision_is_disambiguated(
+    polyglot_corpus: Path,
+) -> None:
+    available = _available_languages()
+    if not {cs.SupportedLanguage.RUST, cs.SupportedLanguage.CPP} <= available:
+        pytest.skip("collision trio needs the rust and cpp parsers")
+    report = cgr_polyglot(polyglot_corpus, polyglot_corpus.name)
+    # (H) shapes.rs / shapes.cpp / shapes.ts strip to the same module qn; each
+    # (H) must end up with its OWN qn or one silently overwrites the others
+    # (H) under the qualified_name uniqueness constraint (issue #652 class).
+    qns = list(report.collision_qns.values())
+    assert len(qns) == len(set(qns)), (
+        f"colliding basenames share a module qn: {report.collision_qns}"
+    )
+
+
+def test_no_edge_crosses_a_language_boundary(polyglot_corpus: Path) -> None:
+    report = cgr_polyglot(polyglot_corpus, polyglot_corpus.name)
+    # (H) cgr does not resolve references across languages; a CALLS/INHERITS/etc.
+    # (H) edge whose endpoints live in different-language modules means a qn from
+    # (H) one language bled into another's resolution.
+    assert not report.cross_language_edges, (
+        f"edges crossing a language boundary: {sorted(report.cross_language_edges)}"
+    )
+
+
+def test_polyglot_graph_is_dangling_and_orphan_free(polyglot_corpus: Path) -> None:
+    # (H) create_and_run_updater runs the structural integrity audit (schema,
+    # (H) orphans, dangling relationships) over the recorded batches; a
+    # (H) violation raises. This proves mixing every language in one build does
+    # (H) not produce an edge with a phantom endpoint.
+    mock_ingestor = MagicMock()
+    mock_ingestor.ensure_node_batch = MagicMock()
+    mock_ingestor.ensure_relationship_batch = MagicMock()
+    create_and_run_updater(polyglot_corpus, mock_ingestor)
+
+
+def test_polyglot_report_is_deterministic(
+    temp_repo: Path, polyglot_corpus: Path
+) -> None:
+    # (H) The collision winner is decided by file-processing order; two builds of
+    # (H) the same corpus must produce identical qns, or incremental re-index and
+    # (H) cross-project references key on a moving target.
+    second = temp_repo / "poly_again"
+    build_polyglot_corpus(second)
+    a = cgr_polyglot(polyglot_corpus, "poly")
+    b = cgr_polyglot(second, "poly")
+    assert a.modules_by_language == b.modules_by_language
+    assert a.collision_qns == b.collision_qns
+    assert a.cross_language_edges == b.cross_language_edges

--- a/evals/README.md
+++ b/evals/README.md
@@ -340,6 +340,32 @@ multi-package fixtures whose cross-package edges are known by construction
 are correctly excluded. cgr resolves all of these; the eval stands as a
 regression guard for monorepo cross-package resolution.
 
+## Polyglot — cross-language ingestion integrity
+
+Every other eval indexes a single language (or a Python-dominant tree), so none
+checks what happens when cgr builds **one** graph over files from all 14
+supported languages at once — the mixed-language repo it is actually pointed at
+in the wild. This eval ingests a corpus spanning every `SupportedLanguage`, with
+a deliberate three-way basename collision (`shapes.rs` / `shapes.cpp` /
+`shapes.ts`), and grades cross-language integrity invariants that need no
+external oracle (`codebase_rag/tests/test_polyglot_eval.py`):
+
+1. every available language contributes at least one module and one definition
+   (no language silently dropped when mixed in),
+2. files that strip to the same module qn get **distinct** qns — the collision is
+   disambiguated, not overwritten under the `qualified_name` constraint (issue
+   #652 class),
+3. no `CALLS` / `INHERITS` / `OVERRIDES` / `IMPLEMENTS` / `INSTANTIATES` edge
+   crosses a language boundary (a Rust call resolving onto a Python node would be
+   cross-language qn bleed),
+4. the recorded graph is dangling/orphan free (the `create_and_run_updater`
+   audit), and the report is deterministic so the collision winner never churns.
+
+cgr satisfies all of these on a clean (full) build; the eval stands as a
+regression guard for polyglot ingestion. The collision winner on a full build is
+decided by sorted file order (`shapes.cpp` keeps the bare `…shapes`, `shapes.rs`
+and `shapes.ts` take the suffixed form).
+
 ## Static calls — function-level direct-call recall
 
 Grades cgr's `CALLS` graph at function granularity against an `ast` oracle that

--- a/evals/polyglot.py
+++ b/evals/polyglot.py
@@ -1,0 +1,324 @@
+# (H) Polyglot (cross-language) ingestion eval. Every other eval indexes a
+# (H) single-language (or Python-dominant) corpus, so none checks what happens
+# (H) when cgr builds ONE graph over files from every supported language at
+# (H) once -- the mixed-language repo it is actually pointed at in the wild.
+# (H) This ingests a corpus spanning all 14 SupportedLanguages (including a
+# (H) deliberate same-basename collision across three languages) and grades
+# (H) cross-language integrity invariants that need no external oracle:
+#   1. every language contributes at least one module and one definition
+#      (no language silently dropped when mixed in),
+#   2. two files that strip to the same module qn get DISTINCT qns
+#      (cross-language basename collisions are disambiguated, not overwritten),
+#   3. no CALLS/INHERITS/OVERRIDES/IMPLEMENTS/INSTANTIATES edge crosses a
+#      language boundary (a Rust call must not resolve onto a Python node --
+#      cross-language qn bleed),
+#   4. the report is deterministic (same corpus -> same qns), so the collision
+#      winner never churns run to run.
+from __future__ import annotations
+
+from pathlib import Path
+from typing import NamedTuple
+
+from codebase_rag import constants as cs
+from codebase_rag.language_spec import get_language_for_extension
+
+from .cgr_graph import _capture
+
+_MODULE = cs.NodeLabel.MODULE.value
+_DEFINITION_LABELS = frozenset(
+    {
+        cs.NodeLabel.FUNCTION.value,
+        cs.NodeLabel.METHOD.value,
+        cs.NodeLabel.CLASS.value,
+        cs.NodeLabel.INTERFACE.value,
+        cs.NodeLabel.ENUM.value,
+        cs.NodeLabel.TYPE.value,
+        cs.NodeLabel.UNION.value,
+    }
+)
+# (H) Semantic def-to-def edges that must never cross a language boundary.
+# (H) IMPORTS/CONTAINS/DEFINES are excluded: an import can legitimately point at
+# (H) an external stub, and CONTAINS/DEFINES are module-internal by construction.
+_CODE_EDGES = frozenset(
+    {
+        cs.RelationshipType.CALLS.value,
+        cs.RelationshipType.INHERITS.value,
+        cs.RelationshipType.OVERRIDES.value,
+        cs.RelationshipType.IMPLEMENTS.value,
+        cs.RelationshipType.INSTANTIATES.value,
+    }
+)
+
+# (H) A tiny, self-contained module per language: each declares a module plus at
+# (H) least one definition and one intra-file call, so "language present" and the
+# (H) cross-language-edge check both have material. shapes.{rs,cpp,ts} share a
+# (H) basename on purpose -- they are THE collision the disambiguation must split.
+_RS_SHAPES = """pub trait Shape {
+    fn area(&self) -> f64;
+}
+
+pub struct Square {
+    pub side: f64,
+}
+
+impl Square {
+    pub fn new(side: f64) -> Square {
+        Square { side }
+    }
+}
+
+impl Shape for Square {
+    fn area(&self) -> f64 {
+        self.side * self.side
+    }
+}
+
+pub fn describe(s: &dyn Shape) -> f64 {
+    s.area()
+}
+"""
+
+_CPP_SHAPES = """class Shape {
+public:
+    virtual double area() const = 0;
+    double describe() const { return area(); }
+};
+
+class Square : public Shape {
+    double side;
+
+public:
+    Square(double s) : side(s) {}
+    double area() const override { return side * side; }
+};
+
+double run() {
+    Square sq(3.0);
+    return sq.describe() + sq.area();
+}
+"""
+
+_TS_SHAPES = """export interface Shape {
+  area(): number;
+}
+
+
+export abstract class Base implements Shape {
+  abstract area(): number;
+
+  describe(): string {
+    return `area=${this.area()}`;
+  }
+}
+"""
+
+POLYGLOT_SOURCES: dict[str, str] = {
+    "analytics.py": (
+        "def helper(x):\n    return x + 1\n\n\ndef run():\n    return helper(1)\n"
+    ),
+    "client.js": (
+        "export function greet(name) {\n"
+        "  return 'hi ' + name;\n"
+        "}\n\n"
+        "export function run() {\n"
+        "  return greet('x');\n"
+        "}\n"
+    ),
+    "orders.ts": (
+        "export function total(xs: number[]): number {\n"
+        "  return xs.length;\n"
+        "}\n\n"
+        "export function run(): number {\n"
+        "  return total([1]);\n"
+        "}\n"
+    ),
+    "widget.tsx": (
+        "export function Label() {\n"
+        "  return <span>hi</span>;\n"
+        "}\n\n"
+        "export function App() {\n"
+        "  return Label();\n"
+        "}\n"
+    ),
+    "gateway.go": (
+        "package gateway\n\n"
+        "func Helper() int {\n"
+        "    return 1\n"
+        "}\n\n"
+        "func Run() int {\n"
+        "    return Helper()\n"
+        "}\n"
+    ),
+    "pricing.scala": (
+        "package fixture\n\n"
+        "object Pricing {\n"
+        "  def helper(): Int = 1\n"
+        "  def run(): Int = helper()\n"
+        "}\n"
+    ),
+    "Billing.java": (
+        "package fixture;\n\n"
+        "class Billing {\n"
+        "    int helper() { return 1; }\n"
+        "    int run() { return helper(); }\n"
+        "}\n"
+    ),
+    "hashing.c": (
+        "int square(int x) {\n"
+        "    return x * x;\n"
+        "}\n\n"
+        "int run() {\n"
+        "    return square(2);\n"
+        "}\n"
+    ),
+    "router.php": (
+        "<?php\n"
+        "function helper() {\n"
+        "    return 1;\n"
+        "}\n\n"
+        "function run() {\n"
+        "    return helper();\n"
+        "}\n"
+    ),
+    "config.lua": (
+        "local function helper()\n"
+        "    return 1\n"
+        "end\n\n"
+        "local function run()\n"
+        "    return helper()\n"
+        "end\n\n"
+        "return { run = run }\n"
+    ),
+    "Inventory.cs": (
+        "namespace Fixture;\n\n"
+        "class Inventory {\n"
+        "    int Helper() { return 1; }\n"
+        "    int Run() { return Helper(); }\n"
+        "}\n"
+    ),
+    "catalog.dart": (
+        "int helper(int x) {\n"
+        "  return x + 1;\n"
+        "}\n\n"
+        "int run() {\n"
+        "  return helper(1);\n"
+        "}\n"
+    ),
+    # (H) the cross-language collision trio -- same basename, three languages.
+    "shapes.rs": _RS_SHAPES,
+    "shapes.cpp": _CPP_SHAPES,
+    "shapes.ts": _TS_SHAPES,
+}
+
+# (H) The languages the corpus is meant to exercise -- one per SupportedLanguage.
+EXPECTED_LANGUAGES: frozenset[cs.SupportedLanguage] = frozenset(cs.SupportedLanguage)
+
+# (H) Basenames that appear under more than one file in the corpus: the
+# (H) disambiguation must give each colliding file its own module qn.
+COLLIDING_BASENAMES: frozenset[str] = frozenset({"shapes"})
+
+
+class PolyglotReport(NamedTuple):
+    # (H) language -> set of that language's module qns.
+    modules_by_language: dict[cs.SupportedLanguage, frozenset[str]]
+    # (H) language -> set of that language's definition qns.
+    defs_by_language: dict[cs.SupportedLanguage, frozenset[str]]
+    # (H) SupportedLanguages with zero modules in the graph.
+    missing_languages: frozenset[cs.SupportedLanguage]
+    # (H) rel_type, src_qn, dst_qn for every code edge whose endpoints resolve
+    # (H) to modules of DIFFERENT languages (should always be empty).
+    cross_language_edges: frozenset[tuple[str, str, str]]
+    # (H) source relative path -> the module qn cgr assigned it, for files whose
+    # (H) basename collides (should be all-distinct across a collision group).
+    collision_qns: dict[str, str]
+
+
+def build_polyglot_corpus(root: Path) -> None:
+    """Write the all-language corpus into ``root`` (created if missing)."""
+    root.mkdir(parents=True, exist_ok=True)
+    for name, content in POLYGLOT_SOURCES.items():
+        (root / name).write_text(content, encoding="utf-8")
+
+
+def _language_of_path(path: str) -> cs.SupportedLanguage | None:
+    suffix = Path(path).suffix
+    if not suffix:
+        return None
+    try:
+        return get_language_for_extension(suffix)
+    except Exception:
+        return None
+
+
+def cgr_polyglot(target: Path, project: str) -> PolyglotReport:
+    ingestor = _capture(target, project)
+
+    # (H) module qn -> language, from each Module node's recorded path.
+    module_language: dict[str, cs.SupportedLanguage] = {}
+    module_qns_by_lang: dict[cs.SupportedLanguage, set[str]] = {}
+    path_of_module: dict[str, str] = {}
+    for (label, _uid), props in ingestor.nodes.items():
+        if label != _MODULE:
+            continue
+        qn = props.get(cs.KEY_QUALIFIED_NAME)
+        path = props.get(cs.KEY_PATH)
+        if not isinstance(qn, str) or not isinstance(path, str):
+            continue
+        lang = _language_of_path(path)
+        if lang is None:
+            continue
+        module_language[qn] = lang
+        module_qns_by_lang.setdefault(lang, set()).add(qn)
+        path_of_module[qn] = path
+
+    # (H) The longest module-qn that prefixes a given qn is the module it lives
+    # (H) in. ponytail: linear scan per qn; the corpus is ~15 modules, not worth
+    # (H) a trie.
+    def owning_module(qn: str) -> str | None:
+        best: str | None = None
+        for m in module_language:
+            if (qn == m or qn.startswith(m + cs.SEPARATOR_DOT)) and (
+                best is None or len(m) > len(best)
+            ):
+                best = m
+        return best
+
+    defs_by_lang: dict[cs.SupportedLanguage, set[str]] = {}
+    for (label, _uid), props in ingestor.nodes.items():
+        if label not in _DEFINITION_LABELS:
+            continue
+        qn = props.get(cs.KEY_QUALIFIED_NAME)
+        if not isinstance(qn, str):
+            continue
+        m = owning_module(qn)
+        if m is None:
+            continue
+        defs_by_lang.setdefault(module_language[m], set()).add(qn)
+
+    cross_edges: set[tuple[str, str, str]] = set()
+    for from_label, from_val, rel_type, to_label, to_val in ingestor.rels:
+        if rel_type not in _CODE_EDGES:
+            continue
+        src, dst = str(from_val), str(to_val)
+        src_mod, dst_mod = owning_module(src), owning_module(dst)
+        if src_mod is None or dst_mod is None:
+            continue
+        if module_language[src_mod] != module_language[dst_mod]:
+            cross_edges.add((rel_type, src, dst))
+
+    collision_qns: dict[str, str] = {
+        path: qn
+        for qn, path in path_of_module.items()
+        if Path(path).stem in COLLIDING_BASENAMES
+    }
+
+    present = frozenset(module_qns_by_lang)
+    return PolyglotReport(
+        modules_by_language={
+            lang: frozenset(qns) for lang, qns in module_qns_by_lang.items()
+        },
+        defs_by_language={lang: frozenset(qns) for lang, qns in defs_by_lang.items()},
+        missing_languages=EXPECTED_LANGUAGES - present,
+        cross_language_edges=frozenset(cross_edges),
+        collision_qns=collision_qns,
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -540,7 +540,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.403"
+version = "0.0.404"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

Every other eval indexes a single language (or a Python-dominant tree). None checks what happens when cgr builds **one** graph over files from all 14 supported languages at once — the mixed-language repo it is actually pointed at in the wild.

`evals/polyglot.py` ingests a corpus spanning every `SupportedLanguage`, with a deliberate three-way basename collision (`shapes.rs` / `shapes.cpp` / `shapes.ts`), and grades cross-language integrity invariants that need no external oracle (`codebase_rag/tests/test_polyglot_eval.py`):

1. every available language contributes at least one module and one definition (no language silently dropped when mixed in),
2. files that strip to the same module qn get **distinct** qns (collision disambiguated, not overwritten — issue #652 class),
3. no `CALLS` / `INHERITS` / `OVERRIDES` / `IMPLEMENTS` / `INSTANTIATES` edge crosses a language boundary (cross-language qn bleed),
4. the recorded graph is dangling/orphan free, and the report is deterministic.

cgr satisfies all of these on a clean build; the eval stands as a regression guard for polyglot ingestion.

## Note

Building this surfaced a real incremental-path bug (cross-language module-qn collision on incremental add), fixed separately in #823.

## Tests

5 new tests pass; full non-integration suite green (5313 passed / 5 skipped).