### PR TITLE
feat(io): add C# to the I/O subsystem with BCL direct sinks

### DIFF
--- a/codebase_rag/constants/ast_csharp.py
+++ b/codebase_rag/constants/ast_csharp.py
@@ -180,6 +180,14 @@ TS_CSHARP_ARGUMENT = "argument"
 # (H) a typed fallback where the `arguments` field lookup returns nothing.
 TS_CSHARP_ARGUMENT_LIST = "argument_list"
 
+# (H) String literals: `"x"` is a string_literal wrapping a string_literal_content
+# (H) token. Used by the I/O walk to read a sink's static path/key argument.
+TS_CSHARP_STRING_LITERAL = "string_literal"
+TS_CSHARP_STRING_LITERAL_CONTENT = "string_literal_content"
+# (H) `map[k]` subscript; inert in the I/O walk (C# env access is a call, not a
+# (H) member read) but wired into the descriptor for shape correctness.
+TS_CSHARP_ELEMENT_ACCESS_EXPRESSION = "element_access_expression"
+
 # (H) Nested scopes that own their own locals; the variable-type walk stops at
 # (H) these so a lambda/local-function local cannot leak into (or shadow) the
 # (H) enclosing method's type map.

--- a/codebase_rag/parsers/io_access/descriptor.py
+++ b/codebase_rag/parsers/io_access/descriptor.py
@@ -105,6 +105,12 @@ class LanguageDescriptor:
     assignment_type: str | None = None
     augmented_assignment_type: str | None = None
     update_expression_type: str | None = None
+    # (H) Node type that WRAPS each call argument (C# `argument_list` holds
+    # (H) `argument` nodes, each wrapping the real expression), unlike Java/Go
+    # (H) where the argument IS the expression. When set, the positional-arg
+    # (H) picker unwraps it to reach the string literal / nested handle. None for
+    # (H) every language whose args are bare expressions.
+    argument_wrapper_type: str | None = None
 
 
 _JS_TS_DESCRIPTOR = LanguageDescriptor(
@@ -312,6 +318,54 @@ _CPP_DESCRIPTOR = LanguageDescriptor(
     declarator_name_field=cs.FIELD_DECLARATOR,
 )
 
+_CSHARP_DESCRIPTOR = LanguageDescriptor(
+    call_type=cs.TS_CSHARP_INVOCATION_EXPRESSION,
+    string_type=cs.TS_CSHARP_STRING_LITERAL,
+    string_content_type=cs.TS_CSHARP_STRING_LITERAL_CONTENT,
+    keyword_arg_type=None,
+    nested_scope_types=frozenset(
+        {
+            cs.TS_CSHARP_METHOD_DECLARATION,
+            cs.TS_CSHARP_CONSTRUCTOR_DECLARATION,
+            cs.TS_CSHARP_LOCAL_FUNCTION_STATEMENT,
+            cs.TS_CSHARP_LAMBDA_EXPRESSION,
+            cs.TS_CSHARP_CLASS_DECLARATION,
+            cs.TS_CSHARP_STRUCT_DECLARATION,
+        }
+    ),
+    # (H) C# sink heads (System.Console/Environment, System.IO.File) are BCL
+    # (H) effective globals never in import_map, so the catalog is not
+    # (H) import-gated. Shadowing an `argument`-wrapped sink head with a local
+    # (H) named `System` is pathological, so the shadow machinery is left inert
+    # (H) like C++/Rust: the fields below are wired to real C# nodes for
+    # (H) correctness but never actually suppress a real sink.
+    identifier_type=cs.TS_CSHARP_IDENTIFIER,
+    declarator_type=cs.TS_CSHARP_VARIABLE_DECLARATOR,
+    params_field=cs.TS_FIELD_PARAMETERS,
+    block_scope_type=cs.TS_CSHARP_BLOCK,
+    extra_declarator_types=frozenset(),
+    loop_declarator_types=frozenset(),
+    statement_container_type=None,
+    sinks_require_import=False,
+    # (H) C# locals are declare-at-point (in scope from their statement on), like
+    # (H) Java: source-order shadow collection, local visible in its own initializer.
+    hoisted_declarations=False,
+    decl_in_own_initializer=True,
+    declaration_statement_type=None,
+    macro_type=None,
+    # (H) Inert (no IO_MEMBER_READS for C#): env access is a call
+    # (H) (Environment.GetEnvironmentVariable). Wired with C#'s member_access /
+    # (H) element_access shapes for correctness.
+    member_expression_type=cs.TS_CSHARP_MEMBER_ACCESS_EXPRESSION,
+    subscript_type=cs.TS_CSHARP_ELEMENT_ACCESS_EXPRESSION,
+    object_field=cs.TS_CSHARP_FIELD_EXPRESSION,
+    property_field=cs.TS_CSHARP_FIELD_NAME,
+    subscript_index_field=cs.TS_FIELD_ARGUMENTS,
+    new_expression_type=cs.TS_CSHARP_OBJECT_CREATION_EXPRESSION,
+    # (H) C# wraps every call argument in an `argument` node.
+    argument_wrapper_type=cs.TS_CSHARP_ARGUMENT,
+)
+
 # (H) Non-Python languages with a direct-sink descriptor. Python keeps its own
 # (H) handle-aware walk; each new language lands one entry (plus registry rows).
 LANGUAGE_DESCRIPTORS: dict[cs.SupportedLanguage, LanguageDescriptor] = {
@@ -326,4 +380,5 @@ LANGUAGE_DESCRIPTORS: dict[cs.SupportedLanguage, LanguageDescriptor] = {
     # (H) (call_expression, string_literal, init_declarator, compound_statement),
     # (H) so C reuses it verbatim.
     cs.SupportedLanguage.C: _CPP_DESCRIPTOR,
+    cs.SupportedLanguage.CSHARP: _CSHARP_DESCRIPTOR,
 }

--- a/codebase_rag/parsers/io_access/extract.py
+++ b/codebase_rag/parsers/io_access/extract.py
@@ -314,17 +314,38 @@ def keyword_value(args: Node, keyword: str) -> Node | None:
     return None
 
 
+def _wrapper_arg_name(node: Node, wrapper_type: str | None) -> str | None:
+    # (H) The parameter name of a C# named argument (`path: "x"` -> "path"), read
+    # (H) from the `argument` wrapper's `name` field; None for a positional arg.
+    if wrapper_type is None or node.type != wrapper_type:
+        return None
+    name = node.child_by_field_name(cs.TS_FIELD_NAME)
+    if name is not None and name.text is not None:
+        return name.text.decode(cs.ENCODING_UTF8)
+    return None
+
+
 def _unwrap_argument(node: Node, wrapper_type: str | None) -> Node:
     # (H) C# wraps each call arg in an `argument` node; the real expression is its
-    # (H) sole named child (a `name_colon` for a named arg is unnamed). Unwrap so
-    # (H) the string reader sees the literal, not the wrapper. No-op elsewhere.
+    # (H) last named child (a named arg's `name` identifier is an earlier named
+    # (H) child). Unwrap so the string reader sees the literal. No-op elsewhere.
     if (
         wrapper_type is not None
         and node.type == wrapper_type
         and node.named_child_count
     ):
-        return node.named_children[-1]
+        return node.named_child(node.named_child_count - 1) or node
     return node
+
+
+def _wrapper_keyword_value(args: Node, keyword: str, wrapper_type: str) -> Node | None:
+    # (H) Find a C# named argument (`variable: "X"`) by its parameter name and
+    # (H) return its value expression, so a reordered named arg resolves to the
+    # (H) right resource identity regardless of position.
+    for child in args.named_children:
+        if _wrapper_arg_name(child, wrapper_type) == keyword:
+            return _unwrap_argument(child, wrapper_type)
+    return None
 
 
 def literal_target(
@@ -342,12 +363,20 @@ def literal_target(
     args = call_node.child_by_field_name(cs.TS_FIELD_ARGUMENTS)
     if args is None:
         return DYNAMIC_TARGET
-    # (H) Exclude keyword args and comment nodes (tree-sitter keeps comments as
-    # (H) named children) so the positional index maps to the real argument.
+    # (H) A C# named argument (`path: "x"`) is matched by name FIRST: named args
+    # (H) can be reordered, so they must not count toward the positional index.
+    if arg_keyword is not None and wrapper_type is not None:
+        named = _wrapper_keyword_value(args, arg_keyword, wrapper_type)
+        if named is not None:
+            return string_literal(named, string_type, content_type)
+    # (H) Exclude keyword args, comment nodes (tree-sitter keeps comments as named
+    # (H) children), and C# named-argument wrappers so the positional index maps
+    # (H) to the real positional argument.
     positional = [
         c
         for c in args.named_children
         if c.type not in (keyword_arg_type, cs.TS_COMMENT)
+        and _wrapper_arg_name(c, wrapper_type) is None
     ]
     if arg_index is not None and arg_index < len(positional):
         return string_literal(

--- a/codebase_rag/parsers/io_access/extract.py
+++ b/codebase_rag/parsers/io_access/extract.py
@@ -314,6 +314,19 @@ def keyword_value(args: Node, keyword: str) -> Node | None:
     return None
 
 
+def _unwrap_argument(node: Node, wrapper_type: str | None) -> Node:
+    # (H) C# wraps each call arg in an `argument` node; the real expression is its
+    # (H) sole named child (a `name_colon` for a named arg is unnamed). Unwrap so
+    # (H) the string reader sees the literal, not the wrapper. No-op elsewhere.
+    if (
+        wrapper_type is not None
+        and node.type == wrapper_type
+        and node.named_child_count
+    ):
+        return node.named_children[-1]
+    return node
+
+
 def literal_target(
     call_node: Node,
     arg_index: int | None,
@@ -322,6 +335,7 @@ def literal_target(
     string_type: str = cs.TS_PY_STRING,
     content_type: str = cs.TS_PY_STRING_CONTENT,
     keyword_arg_type: str | None = cs.TS_PY_KEYWORD_ARGUMENT,
+    wrapper_type: str | None = None,
 ) -> str:
     if arg_index is None and arg_keyword is None:
         return DYNAMIC_TARGET
@@ -336,7 +350,11 @@ def literal_target(
         if c.type not in (keyword_arg_type, cs.TS_COMMENT)
     ]
     if arg_index is not None and arg_index < len(positional):
-        return string_literal(positional[arg_index], string_type, content_type)
+        return string_literal(
+            _unwrap_argument(positional[arg_index], wrapper_type),
+            string_type,
+            content_type,
+        )
     if arg_keyword is not None:
         return string_literal(
             keyword_value(args, arg_keyword), string_type, content_type

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -1079,6 +1079,7 @@ class IOAccessProcessor:
             string_type=descriptor.string_type,
             content_type=descriptor.string_content_type,
             keyword_arg_type=descriptor.keyword_arg_type,
+            wrapper_type=descriptor.argument_wrapper_type,
         )
         self._emit(caller_spec, sink.direction, sink.kind, identity)
 
@@ -1445,6 +1446,7 @@ class IOAccessProcessor:
             string_type=descriptor.string_type,
             content_type=descriptor.string_content_type,
             keyword_arg_type=descriptor.keyword_arg_type,
+            wrapper_type=descriptor.argument_wrapper_type,
         )
         if identity != DYNAMIC_TARGET or ctor.target_arg != 0:
             return identity
@@ -1482,6 +1484,7 @@ class IOAccessProcessor:
             string_type=descriptor.string_type,
             content_type=descriptor.string_content_type,
             keyword_arg_type=descriptor.keyword_arg_type,
+            wrapper_type=descriptor.argument_wrapper_type,
         )
 
     @staticmethod

--- a/codebase_rag/parsers/io_access/registry.py
+++ b/codebase_rag/parsers/io_access/registry.py
@@ -257,6 +257,85 @@ _JAVA_SINKS: tuple[IOSink, ...] = (
     ),
 )
 
+# (H) C# BCL direct-call I/O sinks (issue #102 follow-up: C# had full structural
+# (H) support but zero I/O modelling). call_name returns the dotted callee text from
+# (H) invocation_expression's `function` field, so each sink is keyed under BOTH the
+# (H) fully-qualified spelling (`System.Console.WriteLine`) and the using-imported
+# (H) short form (`Console.WriteLine`). System.* is a BCL effective global, never in
+# (H) import_map, so the catalog is not import-gated (sinks_require_import=False).
+_CSHARP_CONSOLE_PREFIXES: tuple[str, ...] = ("Console", "System.Console")
+_CSHARP_ENV_PREFIXES: tuple[str, ...] = ("Environment", "System.Environment")
+_CSHARP_FILE_PREFIXES: tuple[str, ...] = ("File", "System.IO.File", "IO.File")
+
+_CSHARP_STDOUT_METHODS: tuple[str, ...] = ("WriteLine", "Write")
+_CSHARP_STDIN_METHODS: tuple[str, ...] = ("ReadLine", "Read", "ReadKey")
+_CSHARP_FILE_READ_METHODS: tuple[str, ...] = (
+    "ReadAllText",
+    "ReadAllLines",
+    "ReadAllBytes",
+    "ReadLines",
+    "OpenText",
+)
+_CSHARP_FILE_WRITE_METHODS: tuple[str, ...] = (
+    "WriteAllText",
+    "WriteAllLines",
+    "WriteAllBytes",
+    "AppendAllText",
+    "AppendAllLines",
+)
+
+_CSHARP_SINKS: tuple[IOSink, ...] = (
+    *(
+        IOSink(f"{prefix}.{method}", ResourceKind.STDOUT, IODirection.WRITE)
+        for prefix in _CSHARP_CONSOLE_PREFIXES
+        for method in _CSHARP_STDOUT_METHODS
+    ),
+    # (H) Console.Error.* / Console.Out.* target the standard streams explicitly.
+    *(
+        IOSink(f"{prefix}.Error.{method}", ResourceKind.STDERR, IODirection.WRITE)
+        for prefix in _CSHARP_CONSOLE_PREFIXES
+        for method in ("WriteLine", "Write")
+    ),
+    *(
+        IOSink(f"{prefix}.Out.{method}", ResourceKind.STDOUT, IODirection.WRITE)
+        for prefix in _CSHARP_CONSOLE_PREFIXES
+        for method in ("WriteLine", "Write")
+    ),
+    *(
+        IOSink(f"{prefix}.{method}", ResourceKind.STDIN, IODirection.READ)
+        for prefix in _CSHARP_CONSOLE_PREFIXES
+        for method in _CSHARP_STDIN_METHODS
+    ),
+    *(
+        IOSink(
+            f"{prefix}.GetEnvironmentVariable",
+            ResourceKind.ENV,
+            IODirection.READ,
+            target_arg=0,
+        )
+        for prefix in _CSHARP_ENV_PREFIXES
+    ),
+    *(
+        IOSink(
+            f"{prefix}.SetEnvironmentVariable",
+            ResourceKind.ENV,
+            IODirection.WRITE,
+            target_arg=0,
+        )
+        for prefix in _CSHARP_ENV_PREFIXES
+    ),
+    *(
+        IOSink(f"{prefix}.{method}", ResourceKind.FILE, IODirection.READ, target_arg=0)
+        for prefix in _CSHARP_FILE_PREFIXES
+        for method in _CSHARP_FILE_READ_METHODS
+    ),
+    *(
+        IOSink(f"{prefix}.{method}", ResourceKind.FILE, IODirection.WRITE, target_arg=0)
+        for prefix in _CSHARP_FILE_PREFIXES
+        for method in _CSHARP_FILE_WRITE_METHODS
+    ),
+)
+
 # (H) Rust direct-call I/O sinks (issue #714). call_name yields the callee's path text
 # (H) with `::` separators (`std::env::var`, `std::fs::write`); Rust code reaches these
 # (H) either fully-qualified or via `use std::fs;` + `fs::write(..)`, so each sink is
@@ -352,6 +431,7 @@ IO_SINKS: dict[cs.SupportedLanguage, tuple[IOSink, ...]] = {
     cs.SupportedLanguage.JAVA: _JAVA_SINKS,
     cs.SupportedLanguage.RUST: _RUST_SINKS,
     cs.SupportedLanguage.CPP: _CPP_SINKS,
+    cs.SupportedLanguage.CSHARP: _CSHARP_SINKS,
     # (H) C shares the libc catalog, bare names only (no std:: forms).
     cs.SupportedLanguage.C: tuple(
         IOSink(fn, kind, direction, target_arg=arg)

--- a/codebase_rag/parsers/io_access/registry.py
+++ b/codebase_rag/parsers/io_access/registry.py
@@ -306,12 +306,15 @@ _CSHARP_SINKS: tuple[IOSink, ...] = (
         for prefix in _CSHARP_CONSOLE_PREFIXES
         for method in _CSHARP_STDIN_METHODS
     ),
+    # (H) target_kw is the real BCL parameter name so a reordered named argument
+    # (H) (`GetEnvironmentVariable(variable: "X")`) resolves by name, not position.
     *(
         IOSink(
             f"{prefix}.GetEnvironmentVariable",
             ResourceKind.ENV,
             IODirection.READ,
             target_arg=0,
+            target_kw="variable",
         )
         for prefix in _CSHARP_ENV_PREFIXES
     ),
@@ -321,16 +324,29 @@ _CSHARP_SINKS: tuple[IOSink, ...] = (
             ResourceKind.ENV,
             IODirection.WRITE,
             target_arg=0,
+            target_kw="variable",
         )
         for prefix in _CSHARP_ENV_PREFIXES
     ),
     *(
-        IOSink(f"{prefix}.{method}", ResourceKind.FILE, IODirection.READ, target_arg=0)
+        IOSink(
+            f"{prefix}.{method}",
+            ResourceKind.FILE,
+            IODirection.READ,
+            target_arg=0,
+            target_kw="path",
+        )
         for prefix in _CSHARP_FILE_PREFIXES
         for method in _CSHARP_FILE_READ_METHODS
     ),
     *(
-        IOSink(f"{prefix}.{method}", ResourceKind.FILE, IODirection.WRITE, target_arg=0)
+        IOSink(
+            f"{prefix}.{method}",
+            ResourceKind.FILE,
+            IODirection.WRITE,
+            target_arg=0,
+            target_kw="path",
+        )
         for prefix in _CSHARP_FILE_PREFIXES
         for method in _CSHARP_FILE_WRITE_METHODS
     ),

--- a/codebase_rag/tests/test_io_csharp_edges.py
+++ b/codebase_rag/tests/test_io_csharp_edges.py
@@ -1,0 +1,144 @@
+# (H) C# I/O: the language had full structural support (issue #102) but ZERO
+# (H) flow/IO modelling. First increment: direct sinks for the effective-global
+# (H) BCL surface (System.Console, System.Environment, System.IO.File), which are
+# (H) never in import_map, so the catalog is not import-gated.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.capture import resolve_capture
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+READS_FROM = cs.RelationshipType.READS_FROM.value
+WRITES_TO = cs.RelationshipType.WRITES_TO.value
+_CAPTURE_IO = resolve_capture([cs.CaptureGroup.IO.value])
+
+
+def _run(tmp_path: Path, files: dict[str, str]) -> set[tuple[str, str, str]]:
+    parsers, queries = load_parsers()
+    for rel, content in files.items():
+        (tmp_path / rel).write_text(content, encoding="utf-8")
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        capture=_CAPTURE_IO,
+    ).run()
+    return {
+        (c.args[0][2], str(c.args[1]), c.args[2][2])
+        for c in mock.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) in (READS_FROM, WRITES_TO)
+    }
+
+
+def _has(rels: set[tuple[str, str, str]], caller: str, rel: str, resource: str) -> bool:
+    return any(
+        a.partition("(")[0].endswith(caller) and r == rel and b == resource
+        for a, r, b in rels
+    )
+
+
+def test_csharp_console_writeline_writes_stdout(tmp_path: Path) -> None:
+    files = {
+        "A.cs": (
+            'class A {\n  void Log() {\n    System.Console.WriteLine("hi");\n  }\n}\n'
+        )
+    }
+    rels = _run(tmp_path, files)
+    assert _has(rels, "A.Log", WRITES_TO, "resource::STDOUT::<dynamic>"), rels
+
+
+def test_csharp_get_environment_variable_reads_env(tmp_path: Path) -> None:
+    files = {
+        "A.cs": (
+            "class A {\n"
+            "  string Tmp() {\n"
+            '    return System.Environment.GetEnvironmentVariable("SECRET");\n'
+            "  }\n"
+            "}\n"
+        )
+    }
+    rels = _run(tmp_path, files)
+    assert _has(rels, "A.Tmp", READS_FROM, "resource::ENV::SECRET"), rels
+
+
+def test_csharp_file_read_all_text_reads_file(tmp_path: Path) -> None:
+    files = {
+        "A.cs": (
+            "class A {\n"
+            "  string Load() {\n"
+            '    return System.IO.File.ReadAllText("cfg.txt");\n'
+            "  }\n"
+            "}\n"
+        )
+    }
+    rels = _run(tmp_path, files)
+    assert _has(rels, "A.Load", READS_FROM, "resource::FILE::cfg.txt"), rels
+
+
+def test_csharp_file_write_all_text_writes_file(tmp_path: Path) -> None:
+    files = {
+        "A.cs": (
+            "class A {\n"
+            "  void Save(string data) {\n"
+            '    System.IO.File.WriteAllText("out.txt", data);\n'
+            "  }\n"
+            "}\n"
+        )
+    }
+    rels = _run(tmp_path, files)
+    assert _has(rels, "A.Save", WRITES_TO, "resource::FILE::out.txt"), rels
+
+
+def test_csharp_console_error_writes_stderr(tmp_path: Path) -> None:
+    files = {
+        "A.cs": (
+            "class A {\n"
+            "  void Warn() {\n"
+            '    System.Console.Error.WriteLine("boom");\n'
+            "  }\n"
+            "}\n"
+        )
+    }
+    rels = _run(tmp_path, files)
+    assert _has(rels, "A.Warn", WRITES_TO, "resource::STDERR::<dynamic>"), rels
+
+
+def test_csharp_using_imported_short_names_resolve(tmp_path: Path) -> None:
+    # (H) With `using System;` / `using System.IO;` the calls are written in their
+    # (H) short form (Console.X, File.X); both spellings are keyed.
+    files = {
+        "A.cs": (
+            "using System;\n"
+            "using System.IO;\n"
+            "class A {\n"
+            "  void M() {\n"
+            '    string s = Environment.GetEnvironmentVariable("K");\n'
+            '    File.WriteAllText("o.txt", s);\n'
+            "  }\n"
+            "}\n"
+        )
+    }
+    rels = _run(tmp_path, files)
+    assert _has(rels, "A.M", READS_FROM, "resource::ENV::K"), rels
+    assert _has(rels, "A.M", WRITES_TO, "resource::FILE::o.txt"), rels
+
+
+def test_csharp_console_readline_reads_stdin(tmp_path: Path) -> None:
+    files = {
+        "A.cs": (
+            "using System;\n"
+            "class A {\n"
+            "  string Ask() {\n"
+            "    return Console.ReadLine();\n"
+            "  }\n"
+            "}\n"
+        )
+    }
+    rels = _run(tmp_path, files)
+    assert _has(rels, "A.Ask", READS_FROM, "resource::STDIN::<dynamic>"), rels

--- a/codebase_rag/tests/test_io_csharp_edges.py
+++ b/codebase_rag/tests/test_io_csharp_edges.py
@@ -129,6 +129,38 @@ def test_csharp_using_imported_short_names_resolve(tmp_path: Path) -> None:
     assert _has(rels, "A.M", WRITES_TO, "resource::FILE::o.txt"), rels
 
 
+def test_csharp_reordered_named_args_resolve_correct_path(tmp_path: Path) -> None:
+    # (H) C# named args can be reordered, so the target must be matched by name,
+    # (H) not by positional index: here `path` is the 2nd argument.
+    files = {
+        "A.cs": (
+            "using System.IO;\n"
+            "class A {\n"
+            "  void Save(string data) {\n"
+            '    File.WriteAllText(contents: data, path: "out.txt");\n'
+            "  }\n"
+            "}\n"
+        )
+    }
+    rels = _run(tmp_path, files)
+    assert _has(rels, "A.Save", WRITES_TO, "resource::FILE::out.txt"), rels
+
+
+def test_csharp_named_target_arg_resolves(tmp_path: Path) -> None:
+    files = {
+        "A.cs": (
+            "using System;\n"
+            "class A {\n"
+            "  string Get() {\n"
+            '    return Environment.GetEnvironmentVariable(variable: "SECRET");\n'
+            "  }\n"
+            "}\n"
+        )
+    }
+    rels = _run(tmp_path, files)
+    assert _has(rels, "A.Get", READS_FROM, "resource::ENV::SECRET"), rels
+
+
 def test_csharp_console_readline_reads_stdin(tmp_path: Path) -> None:
     files = {
         "A.cs": (

--- a/uv.lock
+++ b/uv.lock
@@ -540,7 +540,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.403"
+version = "0.0.404"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

C# had full **structural** support (issue #102) but **zero** flow/IO modelling — no `READS_FROM`/`WRITES_TO` edges at all. This lands the first increment: **direct sinks** for the effective-global BCL surface.

Edges now emit for:

- **`System.Console.WriteLine` / `.Write` / `.Out.*`** → `WRITES_TO STDOUT`; **`.Error.*`** → `WRITES_TO STDERR`; **`.ReadLine` / `.Read` / `.ReadKey`** → `READS_FROM STDIN`.
- **`System.Environment.GetEnvironmentVariable("K")`** → `READS_FROM ENV::K`; **`SetEnvironmentVariable`** → `WRITES_TO ENV::K`.
- **`System.IO.File.ReadAllText/ReadAllLines/ReadAllBytes/ReadLines/OpenText`** → `READS_FROM FILE::<path>`; **`WriteAllText/WriteAllLines/WriteAllBytes/AppendAllText/AppendAllLines`** → `WRITES_TO FILE::<path>`.

Each sink is keyed under **both** the fully-qualified (`System.Console.WriteLine`) and `using`-imported short (`Console.WriteLine`) spelling, since `System.*` is a BCL effective global never in the import map (so the catalog is not import-gated, matching Java's `System`/`Files` stance).

## How

C#'s `invocation_expression` exposes `function` + `arguments` fields, so `call_name` already yields the full dotted callee — no reconstruction needed. The one structural difference from Java/Go is that C# wraps each call argument in an `argument` node, so:

- New descriptor field `argument_wrapper_type` (None for every existing language; `argument` for C#); `literal_target` unwraps it before reading the string literal. Fully backward-compatible.
- New `_CSHARP_DESCRIPTOR` (declare-at-point like Java; shadow machinery wired but inert, since shadowing a `System` head is pathological — same stance as C++/Rust).
- New C# constants: `string_literal`, `string_literal_content`, `element_access_expression`.

## Tests

`codebase_rag/tests/test_io_csharp_edges.py` — 7 RED→GREEN tests (Console stdout/stderr/stdin, Environment read/write, File read/write, fully-qualified + `using`-imported forms). Interpolated-string args degrade cleanly to `<dynamic>`. Full suite: 5593 passed (one unrelated realtime-debounce timing flake, passes in isolation).

## Follow-ups (out of scope, next increments)

- **Handles**: `new StreamReader/StreamWriter(path)` (FILE), `new HttpClient()` (NETWORK), ADO.NET `new SqlConnection` + `SqlCommand.ExecuteReader/ExecuteNonQuery` (DATABASE) — needs the C# handle walk (declarator value binds via an unfielded child, not a `value` field).
- **Flow taint** (`FLOWS_TO`) for C#, which builds on the handle/declarator value plumbing.