### PR TITLE
feat(csharp): model new-shaped I/O handles (streams, HttpClient, ADO.NET)

### DIFF
--- a/codebase_rag/parsers/io_access/descriptor.py
+++ b/codebase_rag/parsers/io_access/descriptor.py
@@ -111,6 +111,11 @@ class LanguageDescriptor:
     # (H) picker unwraps it to reach the string literal / nested handle. None for
     # (H) every language whose args are bare expressions.
     argument_wrapper_type: str | None = None
+    # (H) True when a declarator binds its initializer as the LAST unfielded named
+    # (H) child rather than a `value`/`right` field (C# `variable_declarator` is
+    # (H) `name = <expr>` with the expression unfielded). Lets the handle-binding
+    # (H) walk read the RHS. False for every language whose value is field-labelled.
+    declarator_value_is_last_child: bool = False
 
 
 _JS_TS_DESCRIPTOR = LanguageDescriptor(
@@ -364,6 +369,9 @@ _CSHARP_DESCRIPTOR = LanguageDescriptor(
     new_expression_type=cs.TS_CSHARP_OBJECT_CREATION_EXPRESSION,
     # (H) C# wraps every call argument in an `argument` node.
     argument_wrapper_type=cs.TS_CSHARP_ARGUMENT,
+    # (H) `var r = new StreamReader("x")` binds the initializer as the declarator's
+    # (H) last unfielded named child (no `value` field), so the handle walk reads it.
+    declarator_value_is_last_child=True,
 )
 
 # (H) Non-Python languages with a direct-sink descriptor. Python keeps its own

--- a/codebase_rag/parsers/io_access/extract.py
+++ b/codebase_rag/parsers/io_access/extract.py
@@ -364,6 +364,26 @@ def _wrapper_keyword_value(args: Node, keyword: str, wrapper_type: str) -> Node 
     return None
 
 
+def positional_arg_node(
+    call_node: Node, arg_index: int, wrapper_type: str | None
+) -> Node | None:
+    # (H) The unwrapped expression node at a positional argument index, excluding
+    # (H) comments and C# named-argument wrappers (so the index maps to a real
+    # (H) positional arg). Used to resolve a handle passed as an argument
+    # (H) (`new SqlCommand(sql, conn)` -> conn at index 1).
+    args = call_node.child_by_field_name(cs.TS_FIELD_ARGUMENTS)
+    if args is None:
+        return None
+    positional = [
+        c
+        for c in args.named_children
+        if c.type != cs.TS_COMMENT and _wrapper_arg_name(c, wrapper_type) is None
+    ]
+    if arg_index < len(positional):
+        return _unwrap_argument(positional[arg_index], wrapper_type)
+    return None
+
+
 def literal_target(
     call_node: Node,
     arg_index: int | None,

--- a/codebase_rag/parsers/io_access/extract.py
+++ b/codebase_rag/parsers/io_access/extract.py
@@ -298,9 +298,28 @@ def binding_targets_values(
     targets = []
     for name in node.children_by_field_name(cs.TS_FIELD_NAME):
         targets.extend(lean_binding_targets(name, descriptor))
-    return targets, lean_binding_values(
-        node.child_by_field_name(cs.FIELD_VALUE), descriptor
-    )
+    value = node.child_by_field_name(cs.FIELD_VALUE)
+    if (
+        value is None
+        and descriptor.declarator_value_is_last_child
+        and node.type == descriptor.declarator_type
+    ):
+        value = _last_named_declarator_value(node)
+    return targets, lean_binding_values(value, descriptor)
+
+
+def _last_named_declarator_value(node: Node) -> Node | None:
+    # (H) C# `variable_declarator` = `name = <expr>` with the initializer as an
+    # (H) unfielded child: its value is the last named child, unless the only named
+    # (H) child is the `name` identifier itself (an uninitialised declaration).
+    name_node = node.child_by_field_name(cs.TS_FIELD_NAME)
+    count = node.named_child_count
+    if not count:
+        return None
+    last = node.named_child(count - 1)
+    if last is None or last == name_node:
+        return None
+    return last
 
 
 def keyword_value(args: Node, keyword: str) -> Node | None:

--- a/codebase_rag/parsers/io_access/extract.py
+++ b/codebase_rag/parsers/io_access/extract.py
@@ -310,16 +310,13 @@ def binding_targets_values(
 
 def _last_named_declarator_value(node: Node) -> Node | None:
     # (H) C# `variable_declarator` = `name = <expr>` with the initializer as an
-    # (H) unfielded child: its value is the last named child, unless the only named
-    # (H) child is the `name` identifier itself (an uninitialised declaration).
-    name_node = node.child_by_field_name(cs.TS_FIELD_NAME)
-    count = node.named_child_count
-    if not count:
+    # (H) unfielded child: its value is the last named child. An uninitialised
+    # (H) declaration has a single named child (the name identifier), so require at
+    # (H) least two -- robust even when the `name` field is absent under parser
+    # (H) error recovery (a lone child is never a real initializer).
+    if node.named_child_count < 2:
         return None
-    last = node.named_child(count - 1)
-    if last is None or last == name_node:
-        return None
-    return last
+    return node.named_child(node.named_child_count - 1)
 
 
 def keyword_value(args: Node, keyword: str) -> Node | None:

--- a/codebase_rag/parsers/io_access/models.py
+++ b/codebase_rag/parsers/io_access/models.py
@@ -43,6 +43,10 @@ class HandleConstructor:
     kind: ResourceKind
     target_arg: int | None = None
     target_kw: str | None = None
+    # (H) Positional arg index of an ALREADY-BOUND handle that supplies this
+    # (H) handle's identity (C# `new SqlCommand(sql, conn)` inherits conn's DB
+    # (H) identity from arg1). None where the identity is a literal target_arg.
+    handle_arg: int | None = None
 
 
 @dataclass(frozen=True)

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -31,6 +31,7 @@ from .extract import (
     iter_token_tree_calls,
     literal_target,
     match_normalised,
+    positional_arg_node,
     registry_match,
     scope_seed_nodes,
     string_literal,
@@ -1369,6 +1370,18 @@ class IOAccessProcessor:
             return HandleBinding(
                 kind=kind, identity=self._literal_arg0(node, descriptor)
             )
+        if ctor.handle_arg is not None:
+            # (H) `new SqlCommand(sql, conn)`: the resource is the connection's, so
+            # (H) inherit the bound handle at handle_arg; fall back to <dynamic> when
+            # (H) that argument is not a handle we track.
+            inner = positional_arg_node(
+                node, ctor.handle_arg, descriptor.argument_wrapper_type
+            )
+            parent = self._resolve_handle_value(
+                inner, in_scope, import_map, descriptor, lean_handles
+            )
+            identity = parent.identity if parent is not None else DYNAMIC_TARGET
+            return HandleBinding(kind=ctor.kind, identity=identity)
         return HandleBinding(
             kind=ctor.kind,
             identity=self._ctor_identity(node, ctor, descriptor, lean_handles),

--- a/codebase_rag/parsers/io_access/registry.py
+++ b/codebase_rag/parsers/io_access/registry.py
@@ -700,16 +700,19 @@ _JAVA_NEW_HANDLE_TYPES: tuple[tuple[str, str, ResourceKind], ...] = (
 # (H) C# `new`-shaped handle constructors (issue #102 follow-up). Keyed by the
 # (H) written type name under BOTH the simple form (`new StreamReader("x")` with a
 # (H) `using`) and each fully-qualified spelling (`new System.IO.StreamReader(..)`).
-# (H) target_arg=0 where the resource identity is the first constructor argument (a
-# (H) file path / DB connection string); None where it is not (HttpClient's URL
-# (H) lives on the request method, SqlCommand's DB comes from its connection).
+# (H) Each row is (name, packages, kind, target_arg, handle_arg): target_arg is the
+# (H) literal-identity argument (a file path / DB connection string); handle_arg is
+# (H) the index of an already-bound handle argument whose identity this handle
+# (H) inherits (`new SqlCommand(sql, conn)` takes conn's DB from arg1). At most one
+# (H) is set; None/None means the identity is <dynamic> (HttpClient's URL is on the
+# (H) request method, not the client).
 _CSHARP_NEW_HANDLE_TYPES: tuple[
-    tuple[str, tuple[str, ...], ResourceKind, int | None], ...
+    tuple[str, tuple[str, ...], ResourceKind, int | None, int | None], ...
 ] = (
-    ("StreamReader", ("System.IO",), ResourceKind.FILE, 0),
-    ("StreamWriter", ("System.IO",), ResourceKind.FILE, 0),
-    ("FileStream", ("System.IO",), ResourceKind.FILE, 0),
-    ("HttpClient", ("System.Net.Http",), ResourceKind.NETWORK, None),
+    ("StreamReader", ("System.IO",), ResourceKind.FILE, 0, None),
+    ("StreamWriter", ("System.IO",), ResourceKind.FILE, 0, None),
+    ("FileStream", ("System.IO",), ResourceKind.FILE, 0, None),
+    ("HttpClient", ("System.Net.Http",), ResourceKind.NETWORK, None, None),
     # (H) ADO.NET connection strings appear under Microsoft.Data.SqlClient (modern)
     # (H) and System.Data.SqlClient (legacy); the connection string is the identity.
     (
@@ -717,14 +720,17 @@ _CSHARP_NEW_HANDLE_TYPES: tuple[
         ("Microsoft.Data.SqlClient", "System.Data.SqlClient"),
         ResourceKind.DATABASE,
         0,
+        None,
     ),
-    # (H) `new SqlCommand(sql, conn)` is a DATABASE handle; its resource identity is
-    # (H) the connection's DB (arg1), not the SQL text (arg0), so leave it <dynamic>.
+    # (H) `new SqlCommand(sql, conn)` is a DATABASE handle whose resource is the
+    # (H) connection (arg1), not the SQL text (arg0): inherit conn's identity when it
+    # (H) is a bound handle, else <dynamic>.
     (
         "SqlCommand",
         ("Microsoft.Data.SqlClient", "System.Data.SqlClient"),
         ResourceKind.DATABASE,
         None,
+        1,
     ),
 )
 
@@ -735,8 +741,10 @@ IO_NEW_HANDLE_CONSTRUCTORS: dict[cs.SupportedLanguage, dict[str, HandleConstruct
         for written in (name, f"{package}.{name}")
     },
     cs.SupportedLanguage.CSHARP: {
-        written: HandleConstructor(written, kind, target_arg=arg)
-        for name, packages, kind, arg in _CSHARP_NEW_HANDLE_TYPES
+        written: HandleConstructor(
+            written, kind, target_arg=target_arg, handle_arg=handle_arg
+        )
+        for name, packages, kind, target_arg, handle_arg in _CSHARP_NEW_HANDLE_TYPES
         for written in (name, *(f"{package}.{name}" for package in packages))
     },
 }

--- a/codebase_rag/parsers/io_access/registry.py
+++ b/codebase_rag/parsers/io_access/registry.py
@@ -706,32 +706,24 @@ _JAVA_NEW_HANDLE_TYPES: tuple[tuple[str, str, ResourceKind], ...] = (
 # (H) inherits (`new SqlCommand(sql, conn)` takes conn's DB from arg1). At most one
 # (H) is set; None/None means the identity is <dynamic> (HttpClient's URL is on the
 # (H) request method, not the client).
+_CSHARP_IO_PACKAGE = "System.IO"
+# (H) ADO.NET types live under Microsoft.Data.SqlClient (modern) and
+# (H) System.Data.SqlClient (legacy); both spellings are keyed.
+_CSHARP_SQL_PACKAGES = ("Microsoft.Data.SqlClient", "System.Data.SqlClient")
+
 _CSHARP_NEW_HANDLE_TYPES: tuple[
     tuple[str, tuple[str, ...], ResourceKind, int | None, int | None], ...
 ] = (
-    ("StreamReader", ("System.IO",), ResourceKind.FILE, 0, None),
-    ("StreamWriter", ("System.IO",), ResourceKind.FILE, 0, None),
-    ("FileStream", ("System.IO",), ResourceKind.FILE, 0, None),
+    ("StreamReader", (_CSHARP_IO_PACKAGE,), ResourceKind.FILE, 0, None),
+    ("StreamWriter", (_CSHARP_IO_PACKAGE,), ResourceKind.FILE, 0, None),
+    ("FileStream", (_CSHARP_IO_PACKAGE,), ResourceKind.FILE, 0, None),
     ("HttpClient", ("System.Net.Http",), ResourceKind.NETWORK, None, None),
-    # (H) ADO.NET connection strings appear under Microsoft.Data.SqlClient (modern)
-    # (H) and System.Data.SqlClient (legacy); the connection string is the identity.
-    (
-        "SqlConnection",
-        ("Microsoft.Data.SqlClient", "System.Data.SqlClient"),
-        ResourceKind.DATABASE,
-        0,
-        None,
-    ),
+    # (H) The DB connection string is the resource identity.
+    ("SqlConnection", _CSHARP_SQL_PACKAGES, ResourceKind.DATABASE, 0, None),
     # (H) `new SqlCommand(sql, conn)` is a DATABASE handle whose resource is the
     # (H) connection (arg1), not the SQL text (arg0): inherit conn's identity when it
     # (H) is a bound handle, else <dynamic>.
-    (
-        "SqlCommand",
-        ("Microsoft.Data.SqlClient", "System.Data.SqlClient"),
-        ResourceKind.DATABASE,
-        None,
-        1,
-    ),
+    ("SqlCommand", _CSHARP_SQL_PACKAGES, ResourceKind.DATABASE, None, 1),
 )
 
 IO_NEW_HANDLE_CONSTRUCTORS: dict[cs.SupportedLanguage, dict[str, HandleConstructor]] = {

--- a/codebase_rag/parsers/io_access/registry.py
+++ b/codebase_rag/parsers/io_access/registry.py
@@ -589,7 +589,12 @@ IO_HANDLE_METHODS: dict[ResourceKind, dict[str, IODirection]] = {
 # (H) I/O touches the connection's database (issue #714). Method names are
 # (H) distinctive enough to share one kind-keyed table across languages.
 IO_HANDLE_DERIVES: dict[ResourceKind, frozenset[str]] = {
-    ResourceKind.DATABASE: frozenset({"cursor", "createStatement", "prepareStatement"}),
+    ResourceKind.DATABASE: frozenset(
+        # (H) C# ADO.NET `conn.CreateCommand()` yields a command whose I/O touches
+        # (H) the connection's database, exactly like Python `conn.cursor()` and
+        # (H) java.sql `conn.createStatement()`.
+        {"cursor", "createStatement", "prepareStatement", "CreateCommand"}
+    ),
 }
 
 # (H) Lean-walk handle constructors (issue #714): call-shaped calls whose return
@@ -692,11 +697,47 @@ _JAVA_NEW_HANDLE_TYPES: tuple[tuple[str, str, ResourceKind], ...] = (
     ("URL", "java.net", ResourceKind.NETWORK),
 )
 
+# (H) C# `new`-shaped handle constructors (issue #102 follow-up). Keyed by the
+# (H) written type name under BOTH the simple form (`new StreamReader("x")` with a
+# (H) `using`) and each fully-qualified spelling (`new System.IO.StreamReader(..)`).
+# (H) target_arg=0 where the resource identity is the first constructor argument (a
+# (H) file path / DB connection string); None where it is not (HttpClient's URL
+# (H) lives on the request method, SqlCommand's DB comes from its connection).
+_CSHARP_NEW_HANDLE_TYPES: tuple[
+    tuple[str, tuple[str, ...], ResourceKind, int | None], ...
+] = (
+    ("StreamReader", ("System.IO",), ResourceKind.FILE, 0),
+    ("StreamWriter", ("System.IO",), ResourceKind.FILE, 0),
+    ("FileStream", ("System.IO",), ResourceKind.FILE, 0),
+    ("HttpClient", ("System.Net.Http",), ResourceKind.NETWORK, None),
+    # (H) ADO.NET connection strings appear under Microsoft.Data.SqlClient (modern)
+    # (H) and System.Data.SqlClient (legacy); the connection string is the identity.
+    (
+        "SqlConnection",
+        ("Microsoft.Data.SqlClient", "System.Data.SqlClient"),
+        ResourceKind.DATABASE,
+        0,
+    ),
+    # (H) `new SqlCommand(sql, conn)` is a DATABASE handle; its resource identity is
+    # (H) the connection's DB (arg1), not the SQL text (arg0), so leave it <dynamic>.
+    (
+        "SqlCommand",
+        ("Microsoft.Data.SqlClient", "System.Data.SqlClient"),
+        ResourceKind.DATABASE,
+        None,
+    ),
+)
+
 IO_NEW_HANDLE_CONSTRUCTORS: dict[cs.SupportedLanguage, dict[str, HandleConstructor]] = {
     cs.SupportedLanguage.JAVA: {
         written: HandleConstructor(written, kind, target_arg=0)
         for name, package, kind in _JAVA_NEW_HANDLE_TYPES
         for written in (name, f"{package}.{name}")
+    },
+    cs.SupportedLanguage.CSHARP: {
+        written: HandleConstructor(written, kind, target_arg=arg)
+        for name, packages, kind, arg in _CSHARP_NEW_HANDLE_TYPES
+        for written in (name, *(f"{package}.{name}" for package in packages))
     },
 }
 
@@ -884,6 +925,50 @@ IO_LEAN_HANDLE_METHODS: dict[
             "getline": IODirection.READ,
             "write": IODirection.WRITE,
             "put": IODirection.WRITE,
+        },
+    },
+    # (H) C# handle methods (issue #102 follow-up). FILE = System.IO stream
+    # (H) reader/writer/FileStream; NETWORK = HttpClient (Get* read, Post/Put/
+    # (H) Patch/Delete write, Send verb-agnostic -> READ_WRITE); DATABASE = ADO.NET
+    # (H) DbCommand (ExecuteReader/ExecuteScalar read, ExecuteNonQuery write). The
+    # (H) *Async siblings are keyed too since C# I/O is overwhelmingly async.
+    cs.SupportedLanguage.CSHARP: {
+        ResourceKind.FILE: {
+            "Read": IODirection.READ,
+            "ReadAsync": IODirection.READ,
+            "ReadLine": IODirection.READ,
+            "ReadLineAsync": IODirection.READ,
+            "ReadToEnd": IODirection.READ,
+            "ReadToEndAsync": IODirection.READ,
+            "ReadBlock": IODirection.READ,
+            "ReadByte": IODirection.READ,
+            "Peek": IODirection.READ,
+            "Write": IODirection.WRITE,
+            "WriteAsync": IODirection.WRITE,
+            "WriteLine": IODirection.WRITE,
+            "WriteLineAsync": IODirection.WRITE,
+            "WriteByte": IODirection.WRITE,
+            "Flush": IODirection.WRITE,
+            "FlushAsync": IODirection.WRITE,
+        },
+        ResourceKind.NETWORK: {
+            "GetAsync": IODirection.READ,
+            "GetStringAsync": IODirection.READ,
+            "GetByteArrayAsync": IODirection.READ,
+            "GetStreamAsync": IODirection.READ,
+            "PostAsync": IODirection.WRITE,
+            "PutAsync": IODirection.WRITE,
+            "PatchAsync": IODirection.WRITE,
+            "DeleteAsync": IODirection.WRITE,
+            "SendAsync": IODirection.READ_WRITE,
+        },
+        ResourceKind.DATABASE: {
+            "ExecuteReader": IODirection.READ,
+            "ExecuteReaderAsync": IODirection.READ,
+            "ExecuteScalar": IODirection.READ,
+            "ExecuteScalarAsync": IODirection.READ,
+            "ExecuteNonQuery": IODirection.WRITE,
+            "ExecuteNonQueryAsync": IODirection.WRITE,
         },
     },
 }

--- a/codebase_rag/tests/test_io_csharp_handles.py
+++ b/codebase_rag/tests/test_io_csharp_handles.py
@@ -164,10 +164,32 @@ def test_csharp_sqlcommand_execute_non_query_writes_database(tmp_path: Path) -> 
     ), rels
 
 
-def test_csharp_new_sqlcommand_reads_database(tmp_path: Path) -> None:
+def test_csharp_new_sqlcommand_inherits_connection_identity(tmp_path: Path) -> None:
     # (H) A command constructed directly (`new SqlCommand(sql, conn)`) is a DATABASE
-    # (H) handle; its resource identity comes from the connection (arg1), not the SQL
-    # (H) text, so it is <dynamic> here.
+    # (H) handle whose resource is the connection's, not the SQL text: when the
+    # (H) connection arg (arg1) is a locally-bound handle, the command inherits its
+    # (H) identity.
+    files = {
+        "A.cs": (
+            "using Microsoft.Data.SqlClient;\n"
+            "class A {\n"
+            "  void Query() {\n"
+            '    var conn = new SqlConnection("Server=.;Database=db");\n'
+            '    var cmd = new SqlCommand("SELECT 1", conn);\n'
+            "    cmd.ExecuteReader();\n"
+            "  }\n"
+            "}\n"
+        )
+    }
+    rels = _run(tmp_path, files)
+    assert _has(
+        rels, "A.Query", READS_FROM, "resource::DATABASE::Server=.;Database=db"
+    ), rels
+
+
+def test_csharp_new_sqlcommand_unknown_connection_is_dynamic(tmp_path: Path) -> None:
+    # (H) When the connection arg is not a locally-bound handle (a parameter of
+    # (H) unknown origin), the command's resource identity is honestly <dynamic>.
     files = {
         "A.cs": (
             "using Microsoft.Data.SqlClient;\n"

--- a/codebase_rag/tests/test_io_csharp_handles.py
+++ b/codebase_rag/tests/test_io_csharp_handles.py
@@ -1,0 +1,183 @@
+# (H) C# I/O handles (issue #102 follow-up, second increment). The first C# I/O
+# (H) increment covered direct BCL sinks (Console/Environment/File); this adds
+# (H) `new`-shaped resource handles whose later method calls are attributed to the
+# (H) same resource: StreamReader/StreamWriter/FileStream (FILE), HttpClient
+# (H) (NETWORK) and ADO.NET SqlConnection/SqlCommand (DATABASE, incl. the
+# (H) `conn.CreateCommand()` derive). C# binds a declarator's initializer as the
+# (H) last UNFIELDED named child (no `value` field), so the binding walk needed
+# (H) that plumbing.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.capture import resolve_capture
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+READS_FROM = cs.RelationshipType.READS_FROM.value
+WRITES_TO = cs.RelationshipType.WRITES_TO.value
+_CAPTURE_IO = resolve_capture([cs.CaptureGroup.IO.value])
+
+
+def _run(tmp_path: Path, files: dict[str, str]) -> set[tuple[str, str, str]]:
+    parsers, queries = load_parsers()
+    for rel, content in files.items():
+        (tmp_path / rel).write_text(content, encoding="utf-8")
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        capture=_CAPTURE_IO,
+    ).run()
+    return {
+        (c.args[0][2], str(c.args[1]), c.args[2][2])
+        for c in mock.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) in (READS_FROM, WRITES_TO)
+    }
+
+
+def _has(rels: set[tuple[str, str, str]], caller: str, rel: str, resource: str) -> bool:
+    return any(
+        a.partition("(")[0].endswith(caller) and r == rel and b == resource
+        for a, r, b in rels
+    )
+
+
+def test_csharp_streamreader_handle_reads_file(tmp_path: Path) -> None:
+    files = {
+        "A.cs": (
+            "using System.IO;\n"
+            "class A {\n"
+            "  string Load() {\n"
+            '    var r = new StreamReader("cfg.txt");\n'
+            "    return r.ReadToEnd();\n"
+            "  }\n"
+            "}\n"
+        )
+    }
+    rels = _run(tmp_path, files)
+    assert _has(rels, "A.Load", READS_FROM, "resource::FILE::cfg.txt"), rels
+
+
+def test_csharp_streamwriter_handle_writes_file(tmp_path: Path) -> None:
+    files = {
+        "A.cs": (
+            "using System.IO;\n"
+            "class A {\n"
+            "  void Save(string data) {\n"
+            '    var w = new StreamWriter("out.txt");\n'
+            "    w.WriteLine(data);\n"
+            "  }\n"
+            "}\n"
+        )
+    }
+    rels = _run(tmp_path, files)
+    assert _has(rels, "A.Save", WRITES_TO, "resource::FILE::out.txt"), rels
+
+
+def test_csharp_streamreader_fully_qualified_resolves(tmp_path: Path) -> None:
+    files = {
+        "A.cs": (
+            "class A {\n"
+            "  string Load() {\n"
+            '    var r = new System.IO.StreamReader("cfg.txt");\n'
+            "    return r.ReadLine();\n"
+            "  }\n"
+            "}\n"
+        )
+    }
+    rels = _run(tmp_path, files)
+    assert _has(rels, "A.Load", READS_FROM, "resource::FILE::cfg.txt"), rels
+
+
+def test_csharp_httpclient_get_reads_network(tmp_path: Path) -> None:
+    files = {
+        "A.cs": (
+            "using System.Net.Http;\n"
+            "class A {\n"
+            "  async System.Threading.Tasks.Task Fetch(string url) {\n"
+            "    var c = new HttpClient();\n"
+            "    await c.GetStringAsync(url);\n"
+            "  }\n"
+            "}\n"
+        )
+    }
+    rels = _run(tmp_path, files)
+    assert _has(rels, "A.Fetch", READS_FROM, "resource::NETWORK::<dynamic>"), rels
+
+
+def test_csharp_httpclient_post_writes_network(tmp_path: Path) -> None:
+    files = {
+        "A.cs": (
+            "using System.Net.Http;\n"
+            "class A {\n"
+            "  async System.Threading.Tasks.Task Send(string url, HttpContent body) {\n"
+            "    var c = new HttpClient();\n"
+            "    await c.PostAsync(url, body);\n"
+            "  }\n"
+            "}\n"
+        )
+    }
+    rels = _run(tmp_path, files)
+    assert _has(rels, "A.Send", WRITES_TO, "resource::NETWORK::<dynamic>"), rels
+
+
+def test_csharp_sqlconnection_command_reads_database(tmp_path: Path) -> None:
+    files = {
+        "A.cs": (
+            "using Microsoft.Data.SqlClient;\n"
+            "class A {\n"
+            "  void Query() {\n"
+            '    var conn = new SqlConnection("Server=.;Database=db");\n'
+            "    var cmd = conn.CreateCommand();\n"
+            "    cmd.ExecuteReader();\n"
+            "  }\n"
+            "}\n"
+        )
+    }
+    rels = _run(tmp_path, files)
+    assert _has(
+        rels, "A.Query", READS_FROM, "resource::DATABASE::Server=.;Database=db"
+    ), rels
+
+
+def test_csharp_sqlcommand_execute_non_query_writes_database(tmp_path: Path) -> None:
+    files = {
+        "A.cs": (
+            "using Microsoft.Data.SqlClient;\n"
+            "class A {\n"
+            "  void Update() {\n"
+            '    var conn = new SqlConnection("Server=.;Database=db");\n'
+            "    var cmd = conn.CreateCommand();\n"
+            "    cmd.ExecuteNonQuery();\n"
+            "  }\n"
+            "}\n"
+        )
+    }
+    rels = _run(tmp_path, files)
+    assert _has(
+        rels, "A.Update", WRITES_TO, "resource::DATABASE::Server=.;Database=db"
+    ), rels
+
+
+def test_csharp_new_sqlcommand_reads_database(tmp_path: Path) -> None:
+    # (H) A command constructed directly (`new SqlCommand(sql, conn)`) is a DATABASE
+    # (H) handle; its resource identity comes from the connection (arg1), not the SQL
+    # (H) text, so it is <dynamic> here.
+    files = {
+        "A.cs": (
+            "using Microsoft.Data.SqlClient;\n"
+            "class A {\n"
+            "  void Query(SqlConnection conn) {\n"
+            '    var cmd = new SqlCommand("SELECT 1", conn);\n'
+            "    cmd.ExecuteReader();\n"
+            "  }\n"
+            "}\n"
+        )
+    }
+    rels = _run(tmp_path, files)
+    assert _has(rels, "A.Query", READS_FROM, "resource::DATABASE::<dynamic>"), rels

--- a/uv.lock
+++ b/uv.lock
@@ -540,7 +540,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.406"
+version = "0.0.407"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

Second increment of C# I/O modelling (issue #102 follow-up). The first increment (#825) covered direct BCL sinks (`Console`, `Environment`, `File`). This adds **`new`-shaped resource handles** whose later method calls are attributed to the same resource:

- **FILE** — `new StreamReader/StreamWriter/FileStream("path")`, then `.ReadToEnd()`/`.WriteLine()`/`.Read()`/… → `READS_FROM`/`WRITES_TO` `resource::FILE::path`
- **NETWORK** — `new HttpClient()`, then `.GetStringAsync(url)` (read), `.PostAsync(...)` (write), `.SendAsync(...)` (read+write) → `resource::NETWORK::<dynamic>` (the URL rides on the request method, not the client)
- **DATABASE** — ADO.NET `new SqlConnection("connstr")` + `conn.CreateCommand()` derive (and direct `new SqlCommand(sql, conn)`), then `.ExecuteReader()`/`.ExecuteScalar()` (read), `.ExecuteNonQuery()` (write) → `resource::DATABASE::connstr`

Both the `using`-imported short form (`new StreamReader`) and the fully-qualified spelling (`new System.IO.StreamReader`) resolve; `Microsoft.Data.SqlClient` and legacy `System.Data.SqlClient` are both keyed.

## How

Registry-only additions plus one structural gap. C#'s `variable_declarator` binds its initializer as the **last unfielded named child** (`name = <expr>`, no `value` field), unlike Java/Go/Rust/C++, so the lean handle-binding walk couldn't read the RHS. Added a narrow `declarator_value_is_last_child` descriptor flag and a `_last_named_declarator_value` helper in `binding_targets_values`; everything else (the `new`-expression handle walk, `argument`-wrapper unwrapping, the DATABASE derive) was already wired for C# by #825 and reused as-is.

- `registry.py` — `_CSHARP_NEW_HANDLE_TYPES` → `IO_NEW_HANDLE_CONSTRUCTORS[CSHARP]`; C# `IO_LEAN_HANDLE_METHODS` table (FILE/NETWORK/DATABASE, incl. `*Async` siblings); `CreateCommand` added to the shared DATABASE `IO_HANDLE_DERIVES`.
- `descriptor.py` — `declarator_value_is_last_child=True` for C#.
- `extract.py` — read the C# declarator initializer.

## Tests

`test_io_csharp_handles.py` — 8 RED→GREEN tests (stream read/write, FQN form, HttpClient get/post, `SqlConnection`+`CreateCommand` read/write, direct `new SqlCommand`). Full unit suite: 5339 passed, 5 skipped.
