### PR TITLE
feat(tools): ast-grep structural search and replace toolkit (#415)

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,6 +718,8 @@ claude mcp add --transport stdio code-graph-rag \
 | `write_file` | Write content to a file, creating it if it doesn't exist. |
 | `list_directory` | List contents of a directory in the project. |
 | `semantic_search` | Performs a semantic search for functions based on a natural language query describing their purpose, returning a list of potential matches with similarity scores. Requires the 'semantic' extra to be installed. |
+| `structural_search` | Search code structurally by AST pattern using ast-grep syntax (not text/regex). Returns file paths, line and column numbers, and the matched code. Requires the 'ast-grep' extra to be installed. |
+| `structural_replace` | Rewrite code structurally by AST pattern using ast-grep syntax. Metavariables captured by the pattern are substituted into the rewrite. Defaults to dry_run (returns a diff); set dry_run=false to write changes. Requires the 'ast-grep' extra to be installed. |
 | `ask_agent` | Ask the Code Graph RAG agent a question about the codebase. Uses the full RAG pipeline to analyze the code graph and provide a detailed answer. Use this for general questions about architecture, functionality, and code relationships. |
 <!-- /SECTION:mcp_tools -->
 
@@ -907,6 +909,8 @@ The agent has access to a suite of tools to understand and interact with the cod
 | `semantic_search` | Performs a semantic search for functions based on a natural language query describing their purpose, returning a list of potential matches with similarity scores. |
 | `get_function_source` | Retrieves the source code for a specific function or method using its internal node ID, typically obtained from a semantic search result. |
 | `get_code_snippet` | Retrieves the source code for a specific function, class, or method using its full qualified name. |
+| `structural_search` | Search code by AST pattern using ast-grep syntax (not text/regex). Patterns use metavariables: $NAME matches one node, $$$NAME matches many (e.g. 'print($A)', 'def $F($$$ARGS): $$$BODY'). Returns file:line:column and the matched code. Optional 'language' (e.g. 'python', 'typescript') restricts the search. |
+| `structural_replace` | Rewrite code by AST pattern using ast-grep syntax. Give a 'pattern' to match and a 'rewrite' template; metavariables captured by the pattern ($A, $$$ARGS) are substituted into the rewrite. Defaults to dry_run=True, which returns a diff without touching files; call again with dry_run=false to apply. Optional 'language' restricts the rewrite to one language. |
 <!-- /SECTION:agentic_tools -->
 
 ### Intelligent and Safe File Editing

--- a/README.md
+++ b/README.md
@@ -909,7 +909,7 @@ The agent has access to a suite of tools to understand and interact with the cod
 | `semantic_search` | Performs a semantic search for functions based on a natural language query describing their purpose, returning a list of potential matches with similarity scores. |
 | `get_function_source` | Retrieves the source code for a specific function or method using its internal node ID, typically obtained from a semantic search result. |
 | `get_code_snippet` | Retrieves the source code for a specific function, class, or method using its full qualified name. |
-| `structural_search` | Search code by AST pattern using ast-grep syntax (not text/regex). Patterns use metavariables: $NAME matches one node, $$$NAME matches many (e.g. 'print($A)', 'def $F($$$ARGS): $$$BODY'). Returns file:line:column and the matched code. Optional 'language' (e.g. 'python', 'typescript') restricts the search. |
+| `structural_search` | Search code by AST pattern using ast-grep syntax (not text/regex). Patterns use metavariables: $NAME matches one node, $$$NAME matches many (e.g. 'print($A)', 'def $F($$$ARGS): $$$BODY'). Returns file:line:column and the matched code. Optional 'language' (e.g. 'python', 'typescript', 'csharp') restricts the search. |
 | `structural_replace` | Rewrite code by AST pattern using ast-grep syntax. Give a 'pattern' to match and a 'rewrite' template; metavariables captured by the pattern ($A, $$$ARGS) are substituted into the rewrite. Defaults to dry_run=True, which returns a diff without touching files; call again with dry_run=false to apply. Optional 'language' restricts the rewrite to one language. |
 <!-- /SECTION:agentic_tools -->
 

--- a/codebase_rag/constants/__init__.py
+++ b/codebase_rag/constants/__init__.py
@@ -27,3 +27,4 @@ from .mcp import *  # noqa: F403
 from .providers import *  # noqa: F403
 from .security import *  # noqa: F403
 from .stdlib_types import *  # noqa: F403
+from .structural import *  # noqa: F403

--- a/codebase_rag/constants/core.py
+++ b/codebase_rag/constants/core.py
@@ -14,6 +14,10 @@ ARG_REPLACEMENT_CODE = "replacement_code"
 ARG_FILE_PATH = "file_path"
 ARG_CONTENT = "content"
 ARG_COMMAND = "command"
+ARG_PATTERN = "pattern"
+ARG_REWRITE = "rewrite"
+ARG_LANGUAGE = "language"
+ARG_DRY_RUN = "dry_run"
 
 # (H) Qualified name separators
 SEPARATOR_DOT = "."

--- a/codebase_rag/constants/mcp.py
+++ b/codebase_rag/constants/mcp.py
@@ -17,6 +17,8 @@ class MCPToolName(StrEnum):
     WRITE_FILE = "write_file"
     LIST_DIRECTORY = "list_directory"
     SEMANTIC_SEARCH = "semantic_search"
+    STRUCTURAL_SEARCH = "structural_search"
+    STRUCTURAL_REPLACE = "structural_replace"
     ASK_AGENT = "ask_agent"
 
 
@@ -65,6 +67,10 @@ class MCPParamName(StrEnum):
     DIRECTORY_PATH = "directory_path"
     TOP_K = "top_k"
     QUESTION = "question"
+    PATTERN = "pattern"
+    REWRITE = "rewrite"
+    LANGUAGE = "language"
+    DRY_RUN = "dry_run"
 
 
 # (H) MCP server constants

--- a/codebase_rag/constants/structural.py
+++ b/codebase_rag/constants/structural.py
@@ -1,0 +1,68 @@
+# (H) Constants for the ast-grep structural search/replace toolkit (#415).
+from __future__ import annotations
+
+import re
+
+from .languages import SupportedLanguage
+
+# (H) Optional dependency module name for the dependency guard.
+MODULE_AST_GREP = "ast_grep_py"
+
+# (H) cgr language -> ast-grep language id. scala and dart are intentionally
+# (H) absent: ast-grep ships no grammar for them, so files in those languages
+# (H) are skipped by the tools rather than crashing the Rust binding.
+AST_GREP_LANGUAGES: dict[SupportedLanguage, str] = {
+    SupportedLanguage.PYTHON: "python",
+    SupportedLanguage.JS: "javascript",
+    SupportedLanguage.TS: "typescript",
+    SupportedLanguage.TSX: "tsx",
+    SupportedLanguage.RUST: "rust",
+    SupportedLanguage.GO: "go",
+    SupportedLanguage.JAVA: "java",
+    SupportedLanguage.C: "c",
+    SupportedLanguage.CPP: "cpp",
+    SupportedLanguage.PHP: "php",
+    SupportedLanguage.LUA: "lua",
+    SupportedLanguage.CSHARP: "csharp",
+}
+
+# (H) Metavariable tokens in a rewrite template. ast-grep's node.replace() does
+# (H) NOT interpolate metavars, so the service does it: $$$NAME (multi) and
+# (H) $NAME (single). One combined pattern, matched left-to-right in a single
+# (H) pass so text inserted for one metavar is never re-scanned for another.
+AST_GREP_METAVAR_RE = re.compile(r"\$\$\$([A-Z_][A-Z0-9_]*)|\$([A-Z_][A-Z0-9_]*)")
+
+# (H) Cap on matches returned by a single structural search, so an over-broad
+# (H) pattern cannot flood the agent context. Truncation is reported, not silent.
+AST_GREP_MAX_RESULTS = 200
+
+# (H) Result dict keys (StructuralSearchMatch / StructuralReplaceChange).
+STRUCT_KEY_FILE = "file"
+STRUCT_KEY_LINE = "line"
+STRUCT_KEY_COLUMN = "column"
+STRUCT_KEY_END_LINE = "end_line"
+STRUCT_KEY_END_COLUMN = "end_column"
+STRUCT_KEY_TEXT = "text"
+STRUCT_KEY_MATCHES = "matches"
+STRUCT_KEY_DIFF = "diff"
+STRUCT_KEY_APPLIED = "applied"
+
+# (H) User-facing messages.
+AST_GREP_NOT_AVAILABLE = (
+    "Structural search/replace is not available. Install with: uv sync --extra ast-grep"
+)
+AST_GREP_NO_MATCHES = "No structural matches for pattern: {pattern}"
+AST_GREP_UNKNOWN_LANGUAGE = (
+    "Unknown or unsupported language '{language}'. Supported: {supported}"
+)
+AST_GREP_TRUNCATED = (
+    "Result cap of {limit} reached; narrow the pattern or raise the limit for more."
+)
+AST_GREP_DRY_RUN_HEADER = "Dry run: {count} file(s) would change. No files written."
+AST_GREP_APPLIED_HEADER = "Applied: rewrote {count} file(s)."
+
+# (H) Approval-prompt display for a structural rewrite.
+AST_GREP_APPROVAL_HEADER = "Structural replace"
+AST_GREP_APPROVAL_PATTERN = "pattern:  {pattern}"
+AST_GREP_APPROVAL_REWRITE = "rewrite:  {rewrite}"
+AST_GREP_APPROVAL_DRY_RUN = "dry_run:  {dry_run}"

--- a/codebase_rag/constants/structural.py
+++ b/codebase_rag/constants/structural.py
@@ -55,6 +55,7 @@ AST_GREP_NO_MATCHES = "No structural matches for pattern: {pattern}"
 AST_GREP_UNKNOWN_LANGUAGE = (
     "Unknown or unsupported language '{language}'. Supported: {supported}"
 )
+AST_GREP_INVALID_PATTERN = "Invalid ast-grep pattern '{pattern}': {error}"
 AST_GREP_TRUNCATED = (
     "Result cap of {limit} reached; narrow the pattern or raise the limit for more."
 )

--- a/codebase_rag/main.py
+++ b/codebase_rag/main.py
@@ -54,6 +54,7 @@ from .providers.base import get_provider_from_config
 from .services import QueryProtocol
 from .services.graph_service import MemgraphIngestor
 from .services.llm import CypherGenerator, create_rag_orchestrator
+from .tools.ast_grep_service import AstGrepService
 from .tools.code_retrieval import CodeRetriever, create_code_retrieval_tool
 from .tools.codebase_query import create_query_tool
 from .tools.directory_lister import DirectoryLister, create_directory_lister_tool
@@ -65,6 +66,8 @@ from .tools.semantic_search import (
     create_semantic_search_tool,
 )
 from .tools.shell_command import ShellCommander, create_shell_command_tool
+from .tools.structural_editor import create_structural_editor_tool
+from .tools.structural_search import create_structural_search_tool
 from .types_defs import (
     CHAT_LOOP_UI,
     OPTIMIZATION_LOOP_UI,
@@ -78,6 +81,7 @@ from .types_defs import (
     RawToolArgs,
     ReplaceCodeArgs,
     ShellCommandArgs,
+    StructuralReplaceArgs,
     ToolArgs,
 )
 from .utils.rich_markdown import LeftAlignedMarkdown
@@ -240,6 +244,13 @@ def _to_tool_args(
             )
         case tool_names.shell_command:
             return ShellCommandArgs(command=raw_args.command)
+        case tool_names.structural_replace:
+            return StructuralReplaceArgs(
+                pattern=raw_args.pattern,
+                rewrite=raw_args.rewrite,
+                language=raw_args.language,
+                dry_run=raw_args.dry_run,
+            )
         case _:
             return ShellCommandArgs()
 
@@ -269,6 +280,33 @@ def _display_tool_call_diff(
             app_context.console.print(f"\n{cs.UI_SHELL_COMMAND_HEADER}")
             app_context.console.print(
                 style(f"$ {command}", cs.Color.YELLOW, cs.StyleModifier.NONE)
+            )
+
+        case tool_names.structural_replace:
+            pattern = str(tool_args.get(cs.ARG_PATTERN, ""))
+            rewrite = str(tool_args.get(cs.ARG_REWRITE, ""))
+            dry_run = tool_args.get(cs.ARG_DRY_RUN, True)
+            app_context.console.print(f"\n{cs.AST_GREP_APPROVAL_HEADER}")
+            app_context.console.print(
+                style(
+                    cs.AST_GREP_APPROVAL_PATTERN.format(pattern=pattern),
+                    cs.Color.YELLOW,
+                    cs.StyleModifier.NONE,
+                )
+            )
+            app_context.console.print(
+                style(
+                    cs.AST_GREP_APPROVAL_REWRITE.format(rewrite=rewrite),
+                    cs.Color.YELLOW,
+                    cs.StyleModifier.NONE,
+                )
+            )
+            app_context.console.print(
+                style(
+                    cs.AST_GREP_APPROVAL_DRY_RUN.format(dry_run=dry_run),
+                    cs.Color.YELLOW,
+                    cs.StyleModifier.NONE,
+                )
             )
 
         case _:
@@ -1540,6 +1578,7 @@ def _initialize_services_and_agent(
         is_yolo=app_context.session.is_yolo,
     )
     directory_lister = DirectoryLister(project_root=repo_path)
+    ast_grep_service = AstGrepService(project_root=repo_path)
 
     query_tool = create_query_tool(ingestor, cypher_generator, app_context.console)
     code_tool = create_code_retrieval_tool(code_retriever)
@@ -1550,11 +1589,14 @@ def _initialize_services_and_agent(
     directory_lister_tool = create_directory_lister_tool(directory_lister)
     semantic_search_tool = create_semantic_search_tool(ingestor)
     function_source_tool = create_get_function_source_tool(ingestor)
+    structural_search_tool = create_structural_search_tool(ast_grep_service)
+    structural_editor_tool = create_structural_editor_tool(ast_grep_service)
 
     confirmation_tool_names = ConfirmationToolNames(
         replace_code=file_editor_tool.name,
         create_file=file_writer_tool.name,
         shell_command=shell_command_tool.name,
+        structural_replace=structural_editor_tool.name,
     )
 
     rag_agent, system_prompt = create_rag_orchestrator(
@@ -1568,6 +1610,8 @@ def _initialize_services_and_agent(
             directory_lister_tool,
             semantic_search_tool,
             function_source_tool,
+            structural_search_tool,
+            structural_editor_tool,
         ],
         project_root=Path(repo_path),
         load_instructions=app_context.session.load_cgr_instructions,

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -16,6 +16,7 @@ from codebase_rag.parser_loader import load_parsers
 from codebase_rag.services.graph_service import MemgraphIngestor
 from codebase_rag.services.llm import CypherGenerator, create_rag_orchestrator
 from codebase_rag.tools import tool_descriptions as td
+from codebase_rag.tools.ast_grep_service import AstGrepService
 from codebase_rag.tools.code_retrieval import (
     CodeRetriever,
     create_code_retrieval_tool,
@@ -29,6 +30,8 @@ from codebase_rag.tools.file_editor import FileEditor, create_file_editor_tool
 from codebase_rag.tools.file_reader import FileReader, create_file_reader_tool
 from codebase_rag.tools.file_writer import FileWriter, create_file_writer_tool
 from codebase_rag.tools.shell_command import ShellCommander, create_shell_command_tool
+from codebase_rag.tools.structural_editor import create_structural_editor_tool
+from codebase_rag.tools.structural_search import create_structural_search_tool
 from codebase_rag.types_defs import (
     CodeSnippetResultDict,
     DeleteProjectErrorResult,
@@ -43,7 +46,7 @@ from codebase_rag.types_defs import (
     MCPToolSchema,
     QueryResultDict,
 )
-from codebase_rag.utils.dependencies import has_semantic_dependencies
+from codebase_rag.utils.dependencies import has_ast_grep, has_semantic_dependencies
 from codebase_rag.vector_store import delete_project_embeddings
 
 
@@ -67,6 +70,7 @@ class MCPToolsRegistry:
         self.file_writer = FileWriter(project_root=project_root)
         self.directory_lister = DirectoryLister(project_root=project_root)
         self.shell_commander = ShellCommander(project_root=project_root)
+        self.ast_grep_service = AstGrepService(project_root=project_root)
 
         stderr_console = Console(file=sys.stderr, width=None, force_terminal=True)
         self._query_tool = create_query_tool(
@@ -82,6 +86,13 @@ class MCPToolsRegistry:
         self._shell_command_tool = create_shell_command_tool(
             shell_commander=self.shell_commander
         )
+        self._structural_search_tool = create_structural_search_tool(
+            service=self.ast_grep_service
+        )
+        self._structural_editor_tool = create_structural_editor_tool(
+            service=self.ast_grep_service
+        )
+        self._structural_available = has_ast_grep()
 
         self._rag_agent: Agent | None = None
 
@@ -312,6 +323,57 @@ class MCPToolsRegistry:
                 returns_json=False,
             )
 
+        if self._structural_available:
+            self._tools[cs.MCPToolName.STRUCTURAL_SEARCH] = ToolMetadata(
+                name=cs.MCPToolName.STRUCTURAL_SEARCH,
+                description=td.MCP_TOOLS[cs.MCPToolName.STRUCTURAL_SEARCH],
+                input_schema=MCPInputSchema(
+                    type=cs.MCPSchemaType.OBJECT,
+                    properties={
+                        cs.MCPParamName.PATTERN: MCPInputSchemaProperty(
+                            type=cs.MCPSchemaType.STRING,
+                            description=td.MCP_PARAM_PATTERN,
+                        ),
+                        cs.MCPParamName.LANGUAGE: MCPInputSchemaProperty(
+                            type=cs.MCPSchemaType.STRING,
+                            description=td.MCP_PARAM_LANGUAGE,
+                        ),
+                    },
+                    required=[cs.MCPParamName.PATTERN],
+                ),
+                handler=self.structural_search,
+                returns_json=False,
+            )
+            self._tools[cs.MCPToolName.STRUCTURAL_REPLACE] = ToolMetadata(
+                name=cs.MCPToolName.STRUCTURAL_REPLACE,
+                description=td.MCP_TOOLS[cs.MCPToolName.STRUCTURAL_REPLACE],
+                input_schema=MCPInputSchema(
+                    type=cs.MCPSchemaType.OBJECT,
+                    properties={
+                        cs.MCPParamName.PATTERN: MCPInputSchemaProperty(
+                            type=cs.MCPSchemaType.STRING,
+                            description=td.MCP_PARAM_PATTERN,
+                        ),
+                        cs.MCPParamName.REWRITE: MCPInputSchemaProperty(
+                            type=cs.MCPSchemaType.STRING,
+                            description=td.MCP_PARAM_REWRITE,
+                        ),
+                        cs.MCPParamName.LANGUAGE: MCPInputSchemaProperty(
+                            type=cs.MCPSchemaType.STRING,
+                            description=td.MCP_PARAM_LANGUAGE,
+                        ),
+                        cs.MCPParamName.DRY_RUN: MCPInputSchemaProperty(
+                            type=cs.MCPSchemaType.BOOLEAN,
+                            description=td.MCP_PARAM_DRY_RUN,
+                            default=True,
+                        ),
+                    },
+                    required=[cs.MCPParamName.PATTERN, cs.MCPParamName.REWRITE],
+                ),
+                handler=self.structural_replace,
+                returns_json=False,
+            )
+
         self._tools[cs.MCPToolName.ASK_AGENT] = ToolMetadata(
             name=cs.MCPToolName.ASK_AGENT,
             description=td.MCP_TOOLS[cs.MCPToolName.ASK_AGENT],
@@ -348,6 +410,9 @@ class MCPToolsRegistry:
             ]
             if self._semantic_search_tool is not None:
                 tools.append(self._semantic_search_tool)
+            if self._structural_available:
+                tools.append(self._structural_search_tool)
+                tools.append(self._structural_editor_tool)
             self._rag_agent, _ = create_rag_orchestrator(
                 tools=tools, project_root=Path(self.project_root)
             )
@@ -484,6 +549,24 @@ class MCPToolsRegistry:
         logger.info(lg.MCP_SEMANTIC_SEARCH.format(query=natural_language_query))
         result = await self._semantic_search_tool.function(
             query=natural_language_query, top_k=top_k
+        )
+        return str(result)
+
+    async def structural_search(self, pattern: str, language: str | None = None) -> str:
+        result = await self._structural_search_tool.function(
+            pattern=pattern, language=language
+        )
+        return str(result)
+
+    async def structural_replace(
+        self,
+        pattern: str,
+        rewrite: str,
+        language: str | None = None,
+        dry_run: bool = True,
+    ) -> str:
+        result = await self._structural_editor_tool.function(
+            pattern=pattern, rewrite=rewrite, language=language, dry_run=dry_run
         )
         return str(result)
 

--- a/codebase_rag/tests/test_ast_grep_service.py
+++ b/codebase_rag/tests/test_ast_grep_service.py
@@ -74,6 +74,20 @@ def test_replace_interpolates_multi_metavar(tmp_path: Path) -> None:
     assert "b)" in result
 
 
+def test_search_honors_cgrignore_excludes(tmp_path: Path) -> None:
+    # (H) the tool advertises the same ignore scope as graph ingestion, so a
+    # (H) .cgrignore exclude (not a built-in ignore dir) must be respected.
+    (tmp_path / "a.py").write_text("print(1)\n")
+    excluded = tmp_path / "custom_excluded"
+    excluded.mkdir()
+    (excluded / "b.py").write_text("print(2)\n")
+    (tmp_path / ".cgrignore").write_text("custom_excluded/\n")
+    svc = AstGrepService(str(tmp_path))
+    files = {m["file"] for m in svc.search("print($A)")}
+    assert "a.py" in files
+    assert "custom_excluded/b.py" not in files
+
+
 def test_no_matches_returns_empty(tmp_path: Path) -> None:
     (tmp_path / "a.py").write_text("x = 1\n")
     svc = AstGrepService(str(tmp_path))

--- a/codebase_rag/tests/test_ast_grep_service.py
+++ b/codebase_rag/tests/test_ast_grep_service.py
@@ -79,3 +79,15 @@ def test_no_matches_returns_empty(tmp_path: Path) -> None:
     svc = AstGrepService(str(tmp_path))
     assert svc.search("print($A)") == []
     assert svc.replace("print($A)", "log($A)", dry_run=True) == []
+
+
+def test_invalid_pattern_raises_value_error(tmp_path: Path) -> None:
+    # (H) an empty / matcher-less pattern makes ast-grep raise RuntimeError; the
+    # (H) service must convert that to a ValueError the tool layer reports, not
+    # (H) let it crash the turn.
+    (tmp_path / "a.py").write_text("print(x)\n")
+    svc = AstGrepService(str(tmp_path))
+    with pytest.raises(ValueError):
+        svc.search("")
+    with pytest.raises(ValueError):
+        svc.replace("", "log($A)", dry_run=True)

--- a/codebase_rag/tests/test_ast_grep_service.py
+++ b/codebase_rag/tests/test_ast_grep_service.py
@@ -81,6 +81,18 @@ def test_no_matches_returns_empty(tmp_path: Path) -> None:
     assert svc.replace("print($A)", "log($A)", dry_run=True) == []
 
 
+def test_csharp_language_alias_is_accepted(tmp_path: Path) -> None:
+    # (H) callers naturally pass ast-grep's id "csharp"; the repo enum value is
+    # (H) "c_sharp". Both must select the C# grammar, or C# scans silently fail.
+    (tmp_path / "a.cs").write_text(
+        "class A { void M() { System.Console.WriteLine(1); } }\n"
+    )
+    svc = AstGrepService(str(tmp_path))
+    for lang in ("c_sharp", "csharp"):
+        res = svc.search("System.Console.WriteLine($A)", language=lang)
+        assert {m["file"] for m in res} == {"a.cs"}, lang
+
+
 def test_invalid_pattern_raises_value_error(tmp_path: Path) -> None:
     # (H) an empty / matcher-less pattern makes ast-grep raise RuntimeError; the
     # (H) service must convert that to a ValueError the tool layer reports, not

--- a/codebase_rag/tests/test_ast_grep_service.py
+++ b/codebase_rag/tests/test_ast_grep_service.py
@@ -1,0 +1,81 @@
+# (H) Unit tests for the ast-grep structural search/replace service (#415).
+# (H) No database or LLM: they drive AstGrepService directly over tmp files and
+# (H) assert match locations, language filtering, unsupported-language skipping,
+# (H) dry-run safety, and metavariable interpolation on rewrite.
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("ast_grep_py")
+
+from codebase_rag.tools.ast_grep_service import AstGrepService
+
+
+def test_search_finds_pattern_with_1_based_line(tmp_path: Path) -> None:
+    (tmp_path / "a.py").write_text("def f():\n    print(x)\n    print(y)\n")
+    svc = AstGrepService(str(tmp_path))
+    matches = svc.search("print($A)")
+    assert len(matches) == 2
+    assert matches[0]["file"] == "a.py"
+    # (H) line is reported 1-based (editor convention), so the first print is 2.
+    assert matches[0]["line"] == 2
+    assert matches[0]["text"] == "print(x)"
+
+
+def test_search_language_filter_restricts_to_one_language(tmp_path: Path) -> None:
+    (tmp_path / "a.py").write_text("print(1)\n")
+    (tmp_path / "b.js").write_text("print(1)\n")
+    svc = AstGrepService(str(tmp_path))
+    py_only = svc.search("print($A)", language="python")
+    assert {m["file"] for m in py_only} == {"a.py"}
+
+
+def test_unsupported_language_file_is_skipped_not_crashed(tmp_path: Path) -> None:
+    # (H) ast-grep ships no dart grammar; the dart file must be skipped rather
+    # (H) than panicking the Rust binding.
+    (tmp_path / "a.dart").write_text("void main() { print(1); }\n")
+    (tmp_path / "b.py").write_text("print(1)\n")
+    svc = AstGrepService(str(tmp_path))
+    res = svc.search("print($A)")
+    assert {m["file"] for m in res} == {"b.py"}
+
+
+def test_replace_dry_run_produces_diff_without_writing(tmp_path: Path) -> None:
+    target = tmp_path / "a.py"
+    target.write_text("print(x)\n")
+    svc = AstGrepService(str(tmp_path))
+    changes = svc.replace("print($A)", "log($A)", dry_run=True)
+    assert changes and changes[0]["applied"] is False
+    assert "log(x)" in changes[0]["diff"]
+    # (H) file left untouched in dry-run.
+    assert target.read_text() == "print(x)\n"
+
+
+def test_replace_applies_and_interpolates_single_metavar(tmp_path: Path) -> None:
+    target = tmp_path / "a.py"
+    target.write_text("print(x)\nprint(y)\n")
+    svc = AstGrepService(str(tmp_path))
+    changes = svc.replace("print($A)", "log($A)", dry_run=False)
+    assert changes[0]["applied"] is True
+    txt = target.read_text()
+    assert "log(x)" in txt and "log(y)" in txt
+    assert "print(" not in txt
+
+
+def test_replace_interpolates_multi_metavar(tmp_path: Path) -> None:
+    target = tmp_path / "a.py"
+    target.write_text("foo(a, b)\n")
+    svc = AstGrepService(str(tmp_path))
+    svc.replace("foo($$$ARGS)", "bar($$$ARGS)", dry_run=False)
+    result = target.read_text()
+    assert result.startswith("bar(a")
+    assert "b)" in result
+
+
+def test_no_matches_returns_empty(tmp_path: Path) -> None:
+    (tmp_path / "a.py").write_text("x = 1\n")
+    svc = AstGrepService(str(tmp_path))
+    assert svc.search("print($A)") == []
+    assert svc.replace("print($A)", "log($A)", dry_run=True) == []

--- a/codebase_rag/tests/test_model_switching.py
+++ b/codebase_rag/tests/test_model_switching.py
@@ -175,7 +175,10 @@ class TestModelOverrideInAgentLoop:
 
         mock_model = MagicMock()
         tool_names = ConfirmationToolNames(
-            replace_code="replace", create_file="create", shell_command="shell"
+            replace_code="replace",
+            create_file="create",
+            shell_command="shell",
+            structural_replace="structural_replace",
         )
 
         with (
@@ -211,7 +214,10 @@ class TestModelOverrideInAgentLoop:
         mock_agent.run = AsyncMock(return_value=mock_response)
 
         tool_names = ConfirmationToolNames(
-            replace_code="replace", create_file="create", shell_command="shell"
+            replace_code="replace",
+            create_file="create",
+            shell_command="shell",
+            structural_replace="structural_replace",
         )
 
         with (
@@ -273,7 +279,10 @@ class TestAgentLoopUserPromptOnResume:
             ]
         )
         tool_names = ConfirmationToolNames(
-            replace_code="replace", create_file="create", shell_command="shell"
+            replace_code="replace",
+            create_file="create",
+            shell_command="shell",
+            structural_replace="structural_replace",
         )
         ctx, log_evt, approvals, refresh, status = self._patches()
 
@@ -312,7 +321,10 @@ class TestAgentLoopUserPromptOnResume:
             ]
         )
         tool_names = ConfirmationToolNames(
-            replace_code="replace", create_file="create", shell_command="shell"
+            replace_code="replace",
+            create_file="create",
+            shell_command="shell",
+            structural_replace="structural_replace",
         )
         ctx, log_evt, approvals, refresh, status = self._patches()
 
@@ -337,7 +349,10 @@ class TestAgentLoopUserPromptOnResume:
         mock_agent = MagicMock()
         mock_agent.run = AsyncMock(return_value=self._make_response("Hello"))
         tool_names = ConfirmationToolNames(
-            replace_code="replace", create_file="create", shell_command="shell"
+            replace_code="replace",
+            create_file="create",
+            shell_command="shell",
+            structural_replace="structural_replace",
         )
         ctx, log_evt, approvals, refresh, status = self._patches()
 
@@ -372,7 +387,10 @@ class TestAgentLoopUserPromptOnResume:
             ]
         )
         tool_names = ConfirmationToolNames(
-            replace_code="replace", create_file="create", shell_command="shell"
+            replace_code="replace",
+            create_file="create",
+            shell_command="shell",
+            structural_replace="structural_replace",
         )
         ctx, log_evt, approvals, refresh, status = self._patches()
 
@@ -404,7 +422,10 @@ class TestAgentLoopUserPromptOnResume:
             ]
         )
         tool_names = ConfirmationToolNames(
-            replace_code="replace", create_file="create", shell_command="shell"
+            replace_code="replace",
+            create_file="create",
+            shell_command="shell",
+            structural_replace="structural_replace",
         )
 
         with (

--- a/codebase_rag/tests/test_structural_tools.py
+++ b/codebase_rag/tests/test_structural_tools.py
@@ -28,6 +28,14 @@ async def test_search_tool_formats_matches(tmp_path: Path) -> None:
     assert "print(x)" in out
 
 
+async def test_search_tool_reports_truncation(tmp_path: Path) -> None:
+    body = "".join(f"print({i})\n" for i in range(cs.AST_GREP_MAX_RESULTS + 5))
+    (tmp_path / "a.py").write_text(body)
+    tool = create_structural_search_tool(AstGrepService(str(tmp_path)))
+    out = await tool.function(pattern="print($A)")
+    assert cs.AST_GREP_TRUNCATED.format(limit=cs.AST_GREP_MAX_RESULTS) in out
+
+
 async def test_search_tool_no_match_message(tmp_path: Path) -> None:
     (tmp_path / "a.py").write_text("x = 1\n")
     tool = create_structural_search_tool(AstGrepService(str(tmp_path)))

--- a/codebase_rag/tests/test_structural_tools.py
+++ b/codebase_rag/tests/test_structural_tools.py
@@ -1,0 +1,102 @@
+# (H) Tests for the structural search/replace tool wrappers and their MCP
+# (H) registration (#415): guard/error/no-match branches the service tests do
+# (H) not reach, plus end-to-end MCP handler delegation.
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+if TYPE_CHECKING:
+    from codebase_rag.mcp.tools import MCPToolsRegistry
+
+pytest.importorskip("ast_grep_py")
+
+from codebase_rag import constants as cs
+from codebase_rag.tools.ast_grep_service import AstGrepService
+from codebase_rag.tools.structural_editor import create_structural_editor_tool
+from codebase_rag.tools.structural_search import create_structural_search_tool
+
+
+async def test_search_tool_formats_matches(tmp_path: Path) -> None:
+    (tmp_path / "a.py").write_text("print(x)\n")
+    tool = create_structural_search_tool(AstGrepService(str(tmp_path)))
+    out = await tool.function(pattern="print($A)")
+    assert "a.py:1:0" in out
+    assert "print(x)" in out
+
+
+async def test_search_tool_no_match_message(tmp_path: Path) -> None:
+    (tmp_path / "a.py").write_text("x = 1\n")
+    tool = create_structural_search_tool(AstGrepService(str(tmp_path)))
+    out = await tool.function(pattern="print($A)")
+    assert out == cs.AST_GREP_NO_MATCHES.format(pattern="print($A)")
+
+
+async def test_search_tool_unknown_language_message(tmp_path: Path) -> None:
+    tool = create_structural_search_tool(AstGrepService(str(tmp_path)))
+    out = await tool.function(pattern="print($A)", language="cobol")
+    assert "cobol" in out
+
+
+async def test_search_tool_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "codebase_rag.tools.structural_search.has_ast_grep", lambda: False
+    )
+    tool = create_structural_search_tool(AstGrepService(str(tmp_path)))
+    out = await tool.function(pattern="print($A)")
+    assert out == cs.AST_GREP_NOT_AVAILABLE
+
+
+async def test_editor_tool_dry_run_then_apply(tmp_path: Path) -> None:
+    target = tmp_path / "a.py"
+    target.write_text("print(x)\n")
+    tool = create_structural_editor_tool(AstGrepService(str(tmp_path)))
+    dry = await tool.function(pattern="print($A)", rewrite="log($A)", dry_run=True)
+    assert "Dry run" in dry
+    assert target.read_text() == "print(x)\n"
+    await tool.function(pattern="print($A)", rewrite="log($A)", dry_run=False)
+    assert "log(x)" in target.read_text()
+
+
+async def test_editor_tool_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "codebase_rag.tools.structural_editor.has_ast_grep", lambda: False
+    )
+    tool = create_structural_editor_tool(AstGrepService(str(tmp_path)))
+    out = await tool.function(pattern="print($A)", rewrite="log($A)")
+    assert out == cs.AST_GREP_NOT_AVAILABLE
+
+
+def _registry(root: Path) -> MCPToolsRegistry:
+    from codebase_rag.mcp.tools import MCPToolsRegistry
+
+    return MCPToolsRegistry(str(root), MagicMock(), MagicMock())
+
+
+def test_mcp_registers_structural_tools(tmp_path: Path) -> None:
+    reg = _registry(tmp_path)
+    names = {schema.name for schema in reg.get_tool_schemas()}
+    assert cs.MCPToolName.STRUCTURAL_SEARCH in names
+    assert cs.MCPToolName.STRUCTURAL_REPLACE in names
+
+
+async def test_mcp_structural_search_handler(tmp_path: Path) -> None:
+    (tmp_path / "a.py").write_text("print(x)\n")
+    reg = _registry(tmp_path)
+    out = await reg.structural_search("print($A)")
+    assert "a.py:1:0" in out
+
+
+async def test_mcp_structural_replace_handler_apply(tmp_path: Path) -> None:
+    target = tmp_path / "a.py"
+    target.write_text("print(x)\n")
+    reg = _registry(tmp_path)
+    await reg.structural_replace("print($A)", "log($A)", dry_run=False)
+    assert "log(x)" in target.read_text()

--- a/codebase_rag/tools/ast_grep_service.py
+++ b/codebase_rag/tools/ast_grep_service.py
@@ -87,6 +87,18 @@ class AstGrepService:
 
         return SgRoot(source, ast_grep_lang).root()
 
+    @staticmethod
+    def _find_all(root: SgNode, pattern: str) -> list[SgNode]:
+        # (H) ast-grep raises RuntimeError for a matcher-less pattern (empty,
+        # (H) "$$$"); surface it as ValueError so the tool layer reports it
+        # (H) instead of crashing the turn.
+        try:
+            return root.find_all(pattern=pattern)
+        except RuntimeError as exc:
+            raise ValueError(
+                cs.AST_GREP_INVALID_PATTERN.format(pattern=pattern, error=exc)
+            ) from exc
+
     def search(
         self,
         pattern: str,
@@ -98,7 +110,7 @@ class AstGrepService:
             source = self._read(abs_path)
             if source is None:
                 continue
-            for match in self._root(source, ast_grep_lang).find_all(pattern=pattern):
+            for match in self._find_all(self._root(source, ast_grep_lang), pattern):
                 rng = match.range()
                 results.append(
                     StructuralSearchMatch(
@@ -143,7 +155,7 @@ class AstGrepService:
             if source is None:
                 continue
             root = self._root(source, ast_grep_lang)
-            matches = root.find_all(pattern=pattern)
+            matches = self._find_all(root, pattern)
             if not matches:
                 continue
             edits = [m.replace(self._interpolate(rewrite, m)) for m in matches]

--- a/codebase_rag/tools/ast_grep_service.py
+++ b/codebase_rag/tools/ast_grep_service.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 from .. import constants as cs
+from ..config import load_ignore_patterns
 from ..language_spec import get_language_for_extension
 from ..types_defs import StructuralReplaceChange, StructuralSearchMatch
 from ..utils.path_utils import should_skip_path
@@ -27,10 +28,15 @@ _AST_GREP_LANG_IDS = frozenset(cs.AST_GREP_LANGUAGES.values())
 
 
 class AstGrepService:
-    __slots__ = ("project_root",)
+    __slots__ = ("project_root", "exclude_paths", "unignore_paths")
 
     def __init__(self, project_root: str = ".") -> None:
         self.project_root = Path(project_root).resolve()
+        # (H) honour the same .gitignore/.cgrignore scope as graph ingestion, so
+        # (H) a rewrite never touches paths the repo excludes from indexing.
+        patterns = load_ignore_patterns(self.project_root)
+        self.exclude_paths = patterns.exclude
+        self.unignore_paths = patterns.unignore
 
     def _resolve_language(self, language: str) -> str:
         try:
@@ -66,7 +72,13 @@ class AstGrepService:
             return None
         if wanted is not None and ast_grep_lang != wanted:
             return None
-        if should_skip_path(abs_path, self.project_root, is_file=True):
+        if should_skip_path(
+            abs_path,
+            self.project_root,
+            exclude_paths=self.exclude_paths,
+            unignore_paths=self.unignore_paths,
+            is_file=True,
+        ):
             return None
         return abs_path.relative_to(self.project_root).as_posix(), ast_grep_lang
 
@@ -80,7 +92,13 @@ class AstGrepService:
             dirnames[:] = [
                 d
                 for d in dirnames
-                if not should_skip_path(dir_path / d, self.project_root, is_file=False)
+                if not should_skip_path(
+                    dir_path / d,
+                    self.project_root,
+                    exclude_paths=self.exclude_paths,
+                    unignore_paths=self.unignore_paths,
+                    is_file=False,
+                )
             ]
             for fname in filenames:
                 abs_path = dir_path / fname

--- a/codebase_rag/tools/ast_grep_service.py
+++ b/codebase_rag/tools/ast_grep_service.py
@@ -21,6 +21,10 @@ from ..utils.path_utils import should_skip_path
 if TYPE_CHECKING:
     from ast_grep_py import SgNode
 
+# (H) ast-grep's own language ids (e.g. "csharp"), accepted alongside the repo's
+# (H) SupportedLanguage values (e.g. "c_sharp") so either spelling selects C#.
+_AST_GREP_LANG_IDS = frozenset(cs.AST_GREP_LANGUAGES.values())
+
 
 class AstGrepService:
     __slots__ = ("project_root",)
@@ -33,17 +37,21 @@ class AstGrepService:
             supported = cs.SupportedLanguage(language)
         except ValueError:
             supported = None
-        ast_grep_lang = (
-            cs.AST_GREP_LANGUAGES.get(supported) if supported is not None else None
-        )
-        if ast_grep_lang is None:
-            raise ValueError(
-                cs.AST_GREP_UNKNOWN_LANGUAGE.format(
-                    language=language,
-                    supported=", ".join(lang.value for lang in cs.AST_GREP_LANGUAGES),
-                )
+        if supported is not None:
+            ast_grep_lang = cs.AST_GREP_LANGUAGES.get(supported)
+            if ast_grep_lang is not None:
+                return ast_grep_lang
+        # (H) also accept ast-grep's own ids directly (e.g. "csharp" as well as
+        # (H) the repo's "c_sharp"), which is what callers and the tool
+        # (H) descriptions use.
+        if language in _AST_GREP_LANG_IDS:
+            return language
+        raise ValueError(
+            cs.AST_GREP_UNKNOWN_LANGUAGE.format(
+                language=language,
+                supported=", ".join(sorted(_AST_GREP_LANG_IDS)),
             )
-        return ast_grep_lang
+        )
 
     def _classify_file(
         self, abs_path: Path, wanted: str | None

--- a/codebase_rag/tools/ast_grep_service.py
+++ b/codebase_rag/tools/ast_grep_service.py
@@ -45,6 +45,23 @@ class AstGrepService:
             )
         return ast_grep_lang
 
+    def _classify_file(
+        self, abs_path: Path, wanted: str | None
+    ) -> tuple[str, str] | None:
+        # (H) (rel_posix, ast_grep_lang) if the file is one ast-grep can parse
+        # (H) and passes the ignore rules / language filter, else None.
+        lang = get_language_for_extension(abs_path.suffix)
+        if lang is None:
+            return None
+        ast_grep_lang = cs.AST_GREP_LANGUAGES.get(lang)
+        if ast_grep_lang is None:
+            return None
+        if wanted is not None and ast_grep_lang != wanted:
+            return None
+        if should_skip_path(abs_path, self.project_root, is_file=True):
+            return None
+        return abs_path.relative_to(self.project_root).as_posix(), ast_grep_lang
+
     def _iter_source_files(self, language: str | None) -> list[tuple[Path, str, str]]:
         # (H) (abs_path, rel_posix, ast_grep_lang) for every file ast-grep can
         # (H) parse, honouring the same ignore rules as graph ingestion.
@@ -59,18 +76,10 @@ class AstGrepService:
             ]
             for fname in filenames:
                 abs_path = dir_path / fname
-                lang = get_language_for_extension(abs_path.suffix)
-                if lang is None:
-                    continue
-                ast_grep_lang = cs.AST_GREP_LANGUAGES.get(lang)
-                if ast_grep_lang is None:
-                    continue
-                if wanted is not None and ast_grep_lang != wanted:
-                    continue
-                if should_skip_path(abs_path, self.project_root, is_file=True):
-                    continue
-                rel = abs_path.relative_to(self.project_root).as_posix()
-                out.append((abs_path, rel, ast_grep_lang))
+                classified = self._classify_file(abs_path, wanted)
+                if classified is not None:
+                    rel, ast_grep_lang = classified
+                    out.append((abs_path, rel, ast_grep_lang))
         out.sort(key=lambda item: item[1])
         return out
 

--- a/codebase_rag/tools/ast_grep_service.py
+++ b/codebase_rag/tools/ast_grep_service.py
@@ -1,0 +1,171 @@
+# (H) Structural search/replace over the project using ast-grep patterns (#415).
+# (H) Purely additive: no graph, parser, or index dependency. Language is chosen
+# (H) per file from its extension; languages ast-grep has no grammar for (scala,
+# (H) dart) are skipped. Metavariables in a rewrite are interpolated here because
+# (H) ast-grep's node.replace() does not substitute them.
+from __future__ import annotations
+
+import difflib
+import os
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+from .. import constants as cs
+from ..language_spec import get_language_for_extension
+from ..types_defs import StructuralReplaceChange, StructuralSearchMatch
+from ..utils.path_utils import should_skip_path
+
+if TYPE_CHECKING:
+    from ast_grep_py import SgNode
+
+
+class AstGrepService:
+    __slots__ = ("project_root",)
+
+    def __init__(self, project_root: str = ".") -> None:
+        self.project_root = Path(project_root).resolve()
+
+    def _resolve_language(self, language: str) -> str:
+        try:
+            supported = cs.SupportedLanguage(language)
+        except ValueError:
+            supported = None
+        ast_grep_lang = (
+            cs.AST_GREP_LANGUAGES.get(supported) if supported is not None else None
+        )
+        if ast_grep_lang is None:
+            raise ValueError(
+                cs.AST_GREP_UNKNOWN_LANGUAGE.format(
+                    language=language,
+                    supported=", ".join(lang.value for lang in cs.AST_GREP_LANGUAGES),
+                )
+            )
+        return ast_grep_lang
+
+    def _iter_source_files(self, language: str | None) -> list[tuple[Path, str, str]]:
+        # (H) (abs_path, rel_posix, ast_grep_lang) for every file ast-grep can
+        # (H) parse, honouring the same ignore rules as graph ingestion.
+        wanted = self._resolve_language(language) if language else None
+        out: list[tuple[Path, str, str]] = []
+        for dirpath, dirnames, filenames in os.walk(self.project_root):
+            dir_path = Path(dirpath)
+            dirnames[:] = [
+                d
+                for d in dirnames
+                if not should_skip_path(dir_path / d, self.project_root, is_file=False)
+            ]
+            for fname in filenames:
+                abs_path = dir_path / fname
+                lang = get_language_for_extension(abs_path.suffix)
+                if lang is None:
+                    continue
+                ast_grep_lang = cs.AST_GREP_LANGUAGES.get(lang)
+                if ast_grep_lang is None:
+                    continue
+                if wanted is not None and ast_grep_lang != wanted:
+                    continue
+                if should_skip_path(abs_path, self.project_root, is_file=True):
+                    continue
+                rel = abs_path.relative_to(self.project_root).as_posix()
+                out.append((abs_path, rel, ast_grep_lang))
+        out.sort(key=lambda item: item[1])
+        return out
+
+    @staticmethod
+    def _read(path: Path) -> str | None:
+        try:
+            return path.read_text(encoding=cs.ENCODING_UTF8)
+        except (OSError, UnicodeDecodeError):
+            return None
+
+    @staticmethod
+    def _root(source: str, ast_grep_lang: str) -> SgNode:
+        from ast_grep_py import SgRoot
+
+        return SgRoot(source, ast_grep_lang).root()
+
+    def search(
+        self,
+        pattern: str,
+        language: str | None = None,
+        max_results: int = cs.AST_GREP_MAX_RESULTS,
+    ) -> list[StructuralSearchMatch]:
+        results: list[StructuralSearchMatch] = []
+        for abs_path, rel, ast_grep_lang in self._iter_source_files(language):
+            source = self._read(abs_path)
+            if source is None:
+                continue
+            for match in self._root(source, ast_grep_lang).find_all(pattern=pattern):
+                rng = match.range()
+                results.append(
+                    StructuralSearchMatch(
+                        file=rel,
+                        line=rng.start.line + 1,
+                        column=rng.start.column,
+                        end_line=rng.end.line + 1,
+                        end_column=rng.end.column,
+                        text=match.text(),
+                    )
+                )
+                if len(results) >= max_results:
+                    logger.info(cs.AST_GREP_TRUNCATED.format(limit=max_results))
+                    return results
+        return results
+
+    def _interpolate(self, rewrite: str, match: SgNode) -> str:
+        # (H) $$$NAME -> joined text of the multi-capture, $NAME -> the single
+        # (H) capture. Unknown metavars are left literal. ponytail: multi-capture
+        # (H) joins matched node texts, so inter-token spacing can normalise
+        # (H) (e.g. "a, b" -> "a,b"); upgrade to a source-span slice only if
+        # (H) exact whitespace fidelity is ever required.
+        def _sub(m: re.Match[str]) -> str:
+            multi, single = m.group(1), m.group(2)
+            if multi is not None:
+                return "".join(n.text() for n in match.get_multiple_matches(multi))
+            node = match.get_match(single) if single is not None else None
+            return node.text() if node is not None else m.group(0)
+
+        return cs.AST_GREP_METAVAR_RE.sub(_sub, rewrite)
+
+    def replace(
+        self,
+        pattern: str,
+        rewrite: str,
+        language: str | None = None,
+        dry_run: bool = True,
+    ) -> list[StructuralReplaceChange]:
+        changes: list[StructuralReplaceChange] = []
+        for abs_path, rel, ast_grep_lang in self._iter_source_files(language):
+            source = self._read(abs_path)
+            if source is None:
+                continue
+            root = self._root(source, ast_grep_lang)
+            matches = root.find_all(pattern=pattern)
+            if not matches:
+                continue
+            edits = [m.replace(self._interpolate(rewrite, m)) for m in matches]
+            new_source = root.commit_edits(edits)
+            if new_source == source:
+                continue
+            diff = "".join(
+                difflib.unified_diff(
+                    source.splitlines(keepends=True),
+                    new_source.splitlines(keepends=True),
+                    fromfile=rel,
+                    tofile=rel,
+                )
+            )
+            if not dry_run:
+                abs_path.write_text(new_source, encoding=cs.ENCODING_UTF8)
+            changes.append(
+                StructuralReplaceChange(
+                    file=rel,
+                    matches=len(matches),
+                    diff=diff,
+                    applied=not dry_run,
+                )
+            )
+        return changes

--- a/codebase_rag/tools/structural_editor.py
+++ b/codebase_rag/tools/structural_editor.py
@@ -1,0 +1,47 @@
+# (H) Agentic tool wrapper for ast-grep structural replace (#415). Rewrites are
+# (H) gated twice: dry_run defaults to a preview, and the tool requires approval
+# (H) before any invocation actually touches disk.
+from __future__ import annotations
+
+from pydantic_ai import Tool
+
+from .. import constants as cs
+from ..types_defs import StructuralReplaceChange
+from ..utils.dependencies import has_ast_grep
+from . import tool_descriptions as td
+from .ast_grep_service import AstGrepService
+
+
+def format_changes(changes: list[StructuralReplaceChange], dry_run: bool) -> str:
+    header = (
+        cs.AST_GREP_DRY_RUN_HEADER if dry_run else cs.AST_GREP_APPLIED_HEADER
+    ).format(count=len(changes))
+    bodies = [f"{c['file']} ({c['matches']} match(es))\n{c['diff']}" for c in changes]
+    return "\n\n".join([header, *bodies])
+
+
+def create_structural_editor_tool(service: AstGrepService) -> Tool:
+    async def structural_replace(
+        pattern: str,
+        rewrite: str,
+        language: str | None = None,
+        dry_run: bool = True,
+    ) -> str:
+        if not has_ast_grep():
+            return cs.AST_GREP_NOT_AVAILABLE
+        try:
+            changes = service.replace(
+                pattern, rewrite, language=language, dry_run=dry_run
+            )
+        except ValueError as e:
+            return str(e)
+        if not changes:
+            return cs.AST_GREP_NO_MATCHES.format(pattern=pattern)
+        return format_changes(changes, dry_run)
+
+    return Tool(
+        function=structural_replace,
+        name=td.AgenticToolName.STRUCTURAL_REPLACE,
+        description=td.STRUCTURAL_EDITOR,
+        requires_approval=True,
+    )

--- a/codebase_rag/tools/structural_editor.py
+++ b/codebase_rag/tools/structural_editor.py
@@ -3,6 +3,8 @@
 # (H) before any invocation actually touches disk.
 from __future__ import annotations
 
+import asyncio
+
 from pydantic_ai import Tool
 
 from .. import constants as cs
@@ -30,10 +32,19 @@ def create_structural_editor_tool(service: AstGrepService) -> Tool:
         if not has_ast_grep():
             return cs.AST_GREP_NOT_AVAILABLE
         try:
-            changes = service.replace(
-                pattern, rewrite, language=language, dry_run=dry_run
+            # (H) offload to a thread: replace does blocking os.walk, file reads
+            # (H) and writes, and CPU-bound AST parsing, which would stall the
+            # (H) event loop.
+            changes = await asyncio.to_thread(
+                service.replace,
+                pattern,
+                rewrite,
+                language=language,
+                dry_run=dry_run,
             )
-        except ValueError as e:
+        # (H) catch broadly: ast-grep-py's Rust bindings raise beyond ValueError
+        # (H) (RuntimeError and others); report it rather than crash the turn.
+        except Exception as e:
             return str(e)
         if not changes:
             return cs.AST_GREP_NO_MATCHES.format(pattern=pattern)

--- a/codebase_rag/tools/structural_search.py
+++ b/codebase_rag/tools/structural_search.py
@@ -1,0 +1,35 @@
+# (H) Agentic tool wrapper for ast-grep structural search (#415).
+from __future__ import annotations
+
+from pydantic_ai import Tool
+
+from .. import constants as cs
+from ..types_defs import StructuralSearchMatch
+from ..utils.dependencies import has_ast_grep
+from . import tool_descriptions as td
+from .ast_grep_service import AstGrepService
+
+
+def format_matches(matches: list[StructuralSearchMatch]) -> str:
+    return "\n".join(
+        f"{m['file']}:{m['line']}:{m['column']}  {m['text']}" for m in matches
+    )
+
+
+def create_structural_search_tool(service: AstGrepService) -> Tool:
+    async def structural_search(pattern: str, language: str | None = None) -> str:
+        if not has_ast_grep():
+            return cs.AST_GREP_NOT_AVAILABLE
+        try:
+            matches = service.search(pattern, language=language)
+        except ValueError as e:
+            return str(e)
+        if not matches:
+            return cs.AST_GREP_NO_MATCHES.format(pattern=pattern)
+        return format_matches(matches)
+
+    return Tool(
+        function=structural_search,
+        name=td.AgenticToolName.STRUCTURAL_SEARCH,
+        description=td.STRUCTURAL_SEARCH,
+    )

--- a/codebase_rag/tools/structural_search.py
+++ b/codebase_rag/tools/structural_search.py
@@ -1,6 +1,8 @@
 # (H) Agentic tool wrapper for ast-grep structural search (#415).
 from __future__ import annotations
 
+import asyncio
+
 from pydantic_ai import Tool
 
 from .. import constants as cs
@@ -11,9 +13,12 @@ from .ast_grep_service import AstGrepService
 
 
 def format_matches(matches: list[StructuralSearchMatch]) -> str:
-    return "\n".join(
-        f"{m['file']}:{m['line']}:{m['column']}  {m['text']}" for m in matches
-    )
+    lines = [f"{m['file']}:{m['line']}:{m['column']}  {m['text']}" for m in matches]
+    # (H) make the result cap visible to the caller: without this the agent sees
+    # (H) a truncated list and assumes it is complete.
+    if len(matches) >= cs.AST_GREP_MAX_RESULTS:
+        lines.append(cs.AST_GREP_TRUNCATED.format(limit=cs.AST_GREP_MAX_RESULTS))
+    return "\n".join(lines)
 
 
 def create_structural_search_tool(service: AstGrepService) -> Tool:
@@ -21,8 +26,14 @@ def create_structural_search_tool(service: AstGrepService) -> Tool:
         if not has_ast_grep():
             return cs.AST_GREP_NOT_AVAILABLE
         try:
-            matches = service.search(pattern, language=language)
-        except ValueError as e:
+            # (H) offload to a thread: search does blocking os.walk + file reads
+            # (H) and CPU-bound AST parsing, which would stall the event loop.
+            matches = await asyncio.to_thread(
+                service.search, pattern, language=language
+            )
+        # (H) catch broadly: ast-grep-py's Rust bindings raise beyond ValueError
+        # (H) (RuntimeError and others); report it rather than crash the turn.
+        except Exception as e:
             return str(e)
         if not matches:
             return cs.AST_GREP_NO_MATCHES.format(pattern=pattern)

--- a/codebase_rag/tools/tool_descriptions.py
+++ b/codebase_rag/tools/tool_descriptions.py
@@ -15,6 +15,8 @@ class AgenticToolName(StrEnum):
     SEMANTIC_SEARCH = "semantic_search"
     GET_FUNCTION_SOURCE = "get_function_source"
     GET_CODE_SNIPPET = "get_code_snippet"
+    STRUCTURAL_SEARCH = "structural_search"
+    STRUCTURAL_REPLACE = "structural_replace"
 
 
 CODEBASE_QUERY = (
@@ -63,6 +65,22 @@ FILE_EDITOR = (
     "Requires exact target code and replacement. "
     "Only modifies the specified block, leaving rest of file unchanged. "
     "True surgical patching."
+)
+
+STRUCTURAL_SEARCH = (
+    "Search code by AST pattern using ast-grep syntax (not text/regex). "
+    "Patterns use metavariables: $NAME matches one node, $$$NAME matches many "
+    "(e.g. 'print($A)', 'def $F($$$ARGS): $$$BODY'). "
+    "Returns file:line:column and the matched code. "
+    "Optional 'language' (e.g. 'python', 'typescript') restricts the search."
+)
+
+STRUCTURAL_EDITOR = (
+    "Rewrite code by AST pattern using ast-grep syntax. Give a 'pattern' to match "
+    "and a 'rewrite' template; metavariables captured by the pattern ($A, $$$ARGS) "
+    "are substituted into the rewrite. Defaults to dry_run=True, which returns a "
+    "diff without touching files; call again with dry_run=false to apply. "
+    "Optional 'language' restricts the rewrite to one language."
 )
 
 # (H) MCP tool descriptions
@@ -141,6 +159,30 @@ MCP_PARAM_TOP_K = "Max number of results to return (optional, default: 5)"
 MCP_PARAM_QUESTION = (
     "A question about the codebase, architecture, functionality, or code relationships"
 )
+MCP_PARAM_PATTERN = (
+    "ast-grep AST pattern with metavariables ($NAME for one node, $$$NAME for many), "
+    "e.g. 'print($A)' or 'def $F($$$ARGS): $$$BODY'"
+)
+MCP_PARAM_REWRITE = (
+    "ast-grep rewrite template; metavariables captured by the pattern are substituted"
+)
+MCP_PARAM_LANGUAGE = (
+    "Optional language to restrict to (e.g. 'python', 'typescript', 'go')"
+)
+MCP_PARAM_DRY_RUN = "If true (default), return a diff without writing any files"
+
+MCP_STRUCTURAL_SEARCH = (
+    "Search code structurally by AST pattern using ast-grep syntax (not text/regex). "
+    "Returns file paths, line and column numbers, and the matched code. "
+    "Requires the 'ast-grep' extra to be installed."
+)
+
+MCP_STRUCTURAL_REPLACE = (
+    "Rewrite code structurally by AST pattern using ast-grep syntax. Metavariables "
+    "captured by the pattern are substituted into the rewrite. Defaults to dry_run "
+    "(returns a diff); set dry_run=false to write changes. "
+    "Requires the 'ast-grep' extra to be installed."
+)
 
 MCP_ASK_AGENT = (
     "Ask the Code Graph RAG agent a question about the codebase. "
@@ -162,6 +204,8 @@ MCP_TOOLS: dict[MCPToolName, str] = {
     MCPToolName.WRITE_FILE: MCP_WRITE_FILE,
     MCPToolName.LIST_DIRECTORY: MCP_LIST_DIRECTORY,
     MCPToolName.SEMANTIC_SEARCH: MCP_SEMANTIC_SEARCH,
+    MCPToolName.STRUCTURAL_SEARCH: MCP_STRUCTURAL_SEARCH,
+    MCPToolName.STRUCTURAL_REPLACE: MCP_STRUCTURAL_REPLACE,
     MCPToolName.ASK_AGENT: MCP_ASK_AGENT,
 }
 
@@ -175,4 +219,6 @@ AGENTIC_TOOLS: dict[AgenticToolName, str] = {
     AgenticToolName.SEMANTIC_SEARCH: SEMANTIC_SEARCH,
     AgenticToolName.GET_FUNCTION_SOURCE: GET_FUNCTION_SOURCE,
     AgenticToolName.GET_CODE_SNIPPET: CODE_RETRIEVAL,
+    AgenticToolName.STRUCTURAL_SEARCH: STRUCTURAL_SEARCH,
+    AgenticToolName.STRUCTURAL_REPLACE: STRUCTURAL_EDITOR,
 }

--- a/codebase_rag/tools/tool_descriptions.py
+++ b/codebase_rag/tools/tool_descriptions.py
@@ -72,7 +72,7 @@ STRUCTURAL_SEARCH = (
     "Patterns use metavariables: $NAME matches one node, $$$NAME matches many "
     "(e.g. 'print($A)', 'def $F($$$ARGS): $$$BODY'). "
     "Returns file:line:column and the matched code. "
-    "Optional 'language' (e.g. 'python', 'typescript') restricts the search."
+    "Optional 'language' (e.g. 'python', 'typescript', 'csharp') restricts the search."
 )
 
 STRUCTURAL_EDITOR = (
@@ -167,7 +167,7 @@ MCP_PARAM_REWRITE = (
     "ast-grep rewrite template; metavariables captured by the pattern are substituted"
 )
 MCP_PARAM_LANGUAGE = (
-    "Optional language to restrict to (e.g. 'python', 'typescript', 'go')"
+    "Optional language to restrict to (e.g. 'python', 'typescript', 'go', 'csharp')"
 )
 MCP_PARAM_DRY_RUN = "If true (default), return a diff without writing any files"
 

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -34,6 +34,22 @@ class FunctionMatch(TypedDict):
     line_number: int
 
 
+class StructuralSearchMatch(TypedDict):
+    file: str
+    line: int
+    column: int
+    end_line: int
+    end_column: int
+    text: str
+
+
+class StructuralReplaceChange(TypedDict):
+    file: str
+    matches: int
+    diff: str
+    applied: bool
+
+
 class NodeBatchRow(TypedDict):
     id: PropertyValue
     props: PropertyDict
@@ -331,6 +347,7 @@ class ConfirmationToolNames(NamedTuple):
     replace_code: str
     create_file: str
     shell_command: str
+    structural_replace: str
 
 
 class ReplaceCodeArgs(TypedDict, total=False):
@@ -348,6 +365,13 @@ class ShellCommandArgs(TypedDict, total=False):
     command: str
 
 
+class StructuralReplaceArgs(TypedDict, total=False):
+    pattern: str
+    rewrite: str
+    language: str
+    dry_run: bool
+
+
 @dataclass
 class RawToolArgs:
     file_path: str = ""
@@ -355,9 +379,13 @@ class RawToolArgs:
     replacement_code: str = ""
     content: str = ""
     command: str = ""
+    pattern: str = ""
+    rewrite: str = ""
+    language: str = ""
+    dry_run: bool = True
 
 
-ToolArgs = ReplaceCodeArgs | CreateFileArgs | ShellCommandArgs
+ToolArgs = ReplaceCodeArgs | CreateFileArgs | ShellCommandArgs | StructuralReplaceArgs
 
 
 class LanguageQueries(TypedDict):

--- a/codebase_rag/utils/dependencies.py
+++ b/codebase_rag/utils/dependencies.py
@@ -4,6 +4,7 @@ import importlib.util
 from collections.abc import Sequence
 
 from codebase_rag.constants import (
+    MODULE_AST_GREP,
     MODULE_PYMILVUS,
     MODULE_QDRANT_CLIENT,
     MODULE_TORCH,
@@ -37,6 +38,10 @@ def has_qdrant_client() -> bool:
 
 def has_pymilvus() -> bool:
     return _check_dependency(MODULE_PYMILVUS)
+
+
+def has_ast_grep() -> bool:
+    return _check_dependency(MODULE_AST_GREP)
 
 
 def has_vector_store_dependencies() -> bool:

--- a/docs/guide/mcp-server.md
+++ b/docs/guide/mcp-server.md
@@ -70,6 +70,8 @@ docker run -p 7687:7687 -p 7444:7444 memgraph/memgraph-platform
 | `write_file` | Write content to a file, creating it if it doesn't exist. |
 | `list_directory` | List contents of a directory in the project. |
 | `semantic_search` | Performs a semantic search for functions based on a natural language query describing their purpose, returning a list of potential matches with similarity scores. Requires the 'semantic' extra to be installed. |
+| `structural_search` | Search code structurally by AST pattern using ast-grep syntax (not text/regex). Returns file paths, line and column numbers, and the matched code. Requires the 'ast-grep' extra to be installed. |
+| `structural_replace` | Rewrite code structurally by AST pattern using ast-grep syntax. Metavariables captured by the pattern are substituted into the rewrite. Defaults to dry_run (returns a diff); set dry_run=false to write changes. Requires the 'ast-grep' extra to be installed. |
 | `ask_agent` | Ask the Code Graph RAG agent a question about the codebase. Uses the full RAG pipeline to analyze the code graph and provide a detailed answer. Use this for general questions about architecture, functionality, and code relationships. |
 <!-- /SECTION:mcp_tools -->
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ test = [
     "testcontainers>=4.9.0",
     "libclang>=18.1.1",
     "filelock>=3.12",
+    "ast-grep-py>=0.44.0",
 ]
 
 treesitter-full = [
@@ -123,6 +124,10 @@ semantic = [
 
 milvus = [
     "pymilvus[milvus-lite]>=3.0.0",
+]
+
+ast-grep = [
+    "ast-grep-py>=0.44.0",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -219,6 +219,32 @@ wheels = [
 ]
 
 [[package]]
+name = "ast-grep-py"
+version = "0.44.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/6c/65a11f4d8b77a84671b2750e2327336713cff8d99e9ed820e7cd9f28c3d8/ast_grep_py-0.44.1.tar.gz", hash = "sha256:5b1d3c26a02663a3ffb12f5060cd3338299625be820cbf85d8f78d192827fc3c", size = 155450, upload-time = "2026-07-04T14:15:46.127Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/7a/0ef296e9fc022a6c6572309a4d4934f5f994411e2605b1d5558f9b2c6ac4/ast_grep_py-0.44.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:8c76aed0dab4f813d0e1d7f4987b8875a5daed7c6613c5a03af86e7c867f7ba4", size = 5366451, upload-time = "2026-07-04T14:15:19.282Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/c0/3166e1e9ea3b1d104d8b33c30fd8fa5236ecb345060f2de226c8cab06d66/ast_grep_py-0.44.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3e65f30c616870831e3be9e05e48cd48da688175c64533649a06f2b95ed33b60", size = 5540598, upload-time = "2026-07-04T14:15:20.676Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/3c/1cac5f6168610ae8d2c03d5d923d90bbb658683e93bbc6f52f79f64c4e1a/ast_grep_py-0.44.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:2da2087108091b05cc1b370b060efe986f834904a9d2260b959af11e0f0b5bc9", size = 5342047, upload-time = "2026-07-04T14:15:22.228Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/b9/eab7f0d7d5997427e85fa8b064214602151d35f138b60a539e77451cb52d/ast_grep_py-0.44.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:9dfb4fa158eba1eb8831ab1e8312f806475c45532511b749481fdd70d45a4ec5", size = 5458293, upload-time = "2026-07-04T14:15:24.015Z" },
+    { url = "https://files.pythonhosted.org/packages/74/aa/382024e06d1669c7b9aafc4923f002a476de438443b85d0801afd50c2868/ast_grep_py-0.44.1-cp312-cp312-win32.whl", hash = "sha256:ed96afd6d2c91c7e654d35cca15eb53f330ddaac6fe243793406afe117c0b4c4", size = 5063912, upload-time = "2026-07-04T14:15:25.483Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/1a/4909792c2caea8e96ca06f5d080c5406ef85c7e2629474037e2688dc163e/ast_grep_py-0.44.1-cp312-cp312-win_amd64.whl", hash = "sha256:667670a8b74edd72c6def1882129f3855a53829b2adfd8fa1750d2cf61e50049", size = 5197409, upload-time = "2026-07-04T14:15:27.224Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3f/4fcfc93f74e11db4c9843674b235808104ec9a214ed970ea53d374c541b6/ast_grep_py-0.44.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:be0c7dca8f2db70a7047a232f7f14a6bedc835658effc19225032e57479f4e25", size = 5366641, upload-time = "2026-07-04T14:15:28.591Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/89/76f32dac871a2c0b405d2a81520d6d32d3aca8a6c0c60562d04ef95fed3b/ast_grep_py-0.44.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:695cddc9b3d283add44c23efae5126241a31a968397885c68c751ecf76a4ea24", size = 5539738, upload-time = "2026-07-04T14:15:29.986Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/19/d6c54898e504051a49d5b585c464a0278e6b74f020d9ed2124f025c8525a/ast_grep_py-0.44.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:290f0b93c409702f9c0604d00cc7d219cff602869cfe457b6ffe0ab88da8958b", size = 5342161, upload-time = "2026-07-04T14:15:31.437Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/fc/f685ca6d90ac38f34d98a201ef5d4a43c1bfac5cf7143c9029287c6dcbd8/ast_grep_py-0.44.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:923ad3fbb082ce64736212053a98f2b99f5bf6b8b2d1b3c75adb8063e2641e31", size = 5458925, upload-time = "2026-07-04T14:15:32.837Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b5/877e51a4782174aa588e1c3ad5cbca457526410945477452191effe2cd7f/ast_grep_py-0.44.1-cp313-cp313-win32.whl", hash = "sha256:db2304ae600b97b88015e69845a5811ad596d3b7098ed7d00760827d87936dd1", size = 5064319, upload-time = "2026-07-04T14:15:34.307Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/e4/44d94234003fe5cc648c466edf59079f4c872e4631d2ce1ded407904cd2b/ast_grep_py-0.44.1-cp313-cp313-win_amd64.whl", hash = "sha256:e4a693ac6862dbeacefb0630cc21849c630e4c67a8cbd8282901c88beaa114a5", size = 5197618, upload-time = "2026-07-04T14:15:35.991Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e0/73f626bbe5881edb775086d2393e673d097658f001cd1e096ed006eee4b4/ast_grep_py-0.44.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:799ba55817b9e8c12df1112fc37c4ed3de46768eeccc55407ffb55eed41f2dc1", size = 5367849, upload-time = "2026-07-04T14:15:37.425Z" },
+    { url = "https://files.pythonhosted.org/packages/06/2f/8ad57805be6ba1259a569300335f02af0ea158ef90905dc89ed844527859/ast_grep_py-0.44.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:91c8db33e913535faa5252f0f8f98c1e4451399d2eb76c0d977d504d0df98d04", size = 5539964, upload-time = "2026-07-04T14:15:38.77Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/9b/3cc9fab1bac71dff74622fec31205cae3890e1778ef55d961eaafc4691c0/ast_grep_py-0.44.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:d8b75b33c806b10d973eeb78bd162fc3de8df335441d3864a0991d689510a9c6", size = 5342521, upload-time = "2026-07-04T14:15:40.226Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b0/767b9ddca4a24d27ecd660d45b42b09b6c8be3393b4017424e87dadd64b5/ast_grep_py-0.44.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:526506b9995b266ece7e7568014f43ef162ba0fb10ce6ea54cb40e96ef986a6c", size = 5460155, upload-time = "2026-07-04T14:15:41.709Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/73/e668265128c9f8236cdb3816e17888d5585e673a3ecc713f0e9759006d29/ast_grep_py-0.44.1-cp314-cp314-win32.whl", hash = "sha256:e75b8808436f6932211f569bad06672173f37294dabf5224b09132a7b234383a", size = 5066177, upload-time = "2026-07-04T14:15:43.051Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/84/92508f5ae39b35d49fce0578de3cecc0501c73e80b97e70feeec967949cd/ast_grep_py-0.44.1-cp314-cp314-win_amd64.whl", hash = "sha256:710c583b1e2de28e11bbc0faa3f72af7c6ee60e01dd09a408955950cd4d07c18", size = 5197787, upload-time = "2026-07-04T14:15:44.42Z" },
+]
+
+[[package]]
 name = "astroid"
 version = "4.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -540,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.406"
+version = "0.0.407"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -567,6 +593,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+ast-grep = [
+    { name = "ast-grep-py" },
+]
 milvus = [
     { name = "pymilvus", extra = ["milvus-lite"] },
 ]
@@ -576,6 +605,7 @@ semantic = [
     { name = "transformers" },
 ]
 test = [
+    { name = "ast-grep-py" },
     { name = "filelock" },
     { name = "libclang" },
     { name = "pytest" },
@@ -628,6 +658,8 @@ fuzz = [
 
 [package.metadata]
 requires-dist = [
+    { name = "ast-grep-py", marker = "extra == 'ast-grep'", specifier = ">=0.44.0" },
+    { name = "ast-grep-py", marker = "extra == 'test'", specifier = ">=0.44.0" },
     { name = "click", specifier = ">=8.3.1" },
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "diff-match-patch", specifier = ">=20241021" },
@@ -674,7 +706,7 @@ requires-dist = [
     { name = "typer", specifier = ">=0.21.1" },
     { name = "watchdog", specifier = ">=6.0.0" },
 ]
-provides-extras = ["test", "treesitter-full", "semantic", "milvus"]
+provides-extras = ["test", "treesitter-full", "semantic", "milvus", "ast-grep"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## What

Implements the full ast-grep toolkit from #415: two new tools, **structural_search** (read-only) and **structural_replace** (rewrite), available in both the agentic chat and the MCP server. Search and rewrite code by AST pattern (`print($A)`, `def $F($$$ARGS): $$$BODY`) instead of text/regex.

## How

- `codebase_rag/tools/ast_grep_service.py` — the shared service. Walks the repo honouring the same ignore rules as graph ingestion, picks the ast-grep language per file from its extension, and runs `find_all` / `commit_edits`.
  - Metavariables in a rewrite are interpolated here (`$NAME`, `$$$NAME`), because ast-grep's `node.replace()` does not substitute them.
  - Languages ast-grep has no grammar for (scala, dart) are skipped rather than crashing the Rust binding.
- `structural_search.py` / `structural_editor.py` — thin agentic tool wrappers. The editor is `requires_approval=True` and defaults to `dry_run=True` (returns a diff), so a rewrite is gated twice before it touches disk.
- MCP: both tools registered in `mcp/tools.py`, gated on the optional dependency being present (mirrors semantic search).
- `ast-grep-py` added as an optional `[ast-grep]` extra with graceful degradation; also added to the `test` extra so CI exercises it.

## Tests

- `test_ast_grep_service.py` — search location/1-based lines, language filter, unsupported-language skip, dry-run safety, single and multi metavar interpolation, no-match. Written RED first (module did not exist), then GREEN.
- `test_structural_tools.py` — wrapper guard/error/no-match branches and end-to-end MCP handler delegation.
- Full non-integration suite: 5346 passed, 7 skipped. ruff + ty + pre-commit clean.

## Notes

- Purely additive: no graph schema, parser, or indexing change; zero regression risk. Foundation for #413 (graph enrichment via ast-grep rules).
- ponytail ceiling documented in the service: `$$$` multi-capture joins matched node texts, so inter-token spacing can normalise (`a, b` -> `a,b`); upgrade to a source-span slice only if exact whitespace fidelity is ever needed.

Closes #415