### PR TITLE
feat(csharp): emit FLOWS_TO taint edges through argument-wrapped sinks

### DIFF
--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -38,6 +38,7 @@ from ..io_access import (
     registry_match,
     scope_seed_nodes,
     string_literal,
+    unwrap_argument,
 )
 from .constants import (
     KEY_KIND,
@@ -1124,6 +1125,7 @@ class FlowProcessor:
                 string_type=jc.descriptor.string_type,
                 content_type=jc.descriptor.string_content_type,
                 keyword_arg_type=jc.descriptor.keyword_arg_type,
+                wrapper_type=jc.descriptor.argument_wrapper_type,
             )
             for _via, taint in args:
                 if taint is None:
@@ -1351,11 +1353,14 @@ class FlowProcessor:
             return []
         out: list[tuple[str, Taint | None]] = []
         # (H) Comments are named children; exclude them so arg positions stay correct.
+        # (H) C# wraps each arg in an `argument` node, so unwrap to the real
+        # (H) expression before reading its taint (no-op for the bare-arg grammars).
+        wrapper = jc.descriptor.argument_wrapper_type
         for index, child in enumerate(self._named_no_comments(args)):
             out.append(
                 (
                     VIA_ARG_FORMAT.format(index=index),
-                    self._js_expr_taint(child, tainted, jc),
+                    self._js_expr_taint(unwrap_argument(child, wrapper), tainted, jc),
                 )
             )
         return out
@@ -1434,6 +1439,7 @@ class FlowProcessor:
             string_type=jc.descriptor.string_type,
             content_type=jc.descriptor.string_content_type,
             keyword_arg_type=jc.descriptor.keyword_arg_type,
+            wrapper_type=jc.descriptor.argument_wrapper_type,
         )
         return HandleBinding(kind=sink.kind, identity=identity)
 

--- a/codebase_rag/parsers/io_access/__init__.py
+++ b/codebase_rag/parsers/io_access/__init__.py
@@ -23,6 +23,7 @@ from .extract import (
     registry_match,
     scope_seed_nodes,
     string_literal,
+    unwrap_argument,
 )
 from .models import HandleBinding, HandleConstructor, IOSink
 from .processor import IOAccessProcessor
@@ -67,4 +68,5 @@ __all__ = [
     "registry_match",
     "scope_seed_nodes",
     "string_literal",
+    "unwrap_argument",
 ]

--- a/codebase_rag/parsers/io_access/extract.py
+++ b/codebase_rag/parsers/io_access/extract.py
@@ -341,7 +341,7 @@ def _wrapper_arg_name(node: Node, wrapper_type: str | None) -> str | None:
     return None
 
 
-def _unwrap_argument(node: Node, wrapper_type: str | None) -> Node:
+def unwrap_argument(node: Node, wrapper_type: str | None) -> Node:
     # (H) C# wraps each call arg in an `argument` node; the real expression is its
     # (H) last named child (a named arg's `name` identifier is an earlier named
     # (H) child). Unwrap so the string reader sees the literal. No-op elsewhere.
@@ -360,7 +360,7 @@ def _wrapper_keyword_value(args: Node, keyword: str, wrapper_type: str) -> Node 
     # (H) right resource identity regardless of position.
     for child in args.named_children:
         if _wrapper_arg_name(child, wrapper_type) == keyword:
-            return _unwrap_argument(child, wrapper_type)
+            return unwrap_argument(child, wrapper_type)
     return None
 
 
@@ -380,7 +380,7 @@ def positional_arg_node(
         if c.type != cs.TS_COMMENT and _wrapper_arg_name(c, wrapper_type) is None
     ]
     if arg_index < len(positional):
-        return _unwrap_argument(positional[arg_index], wrapper_type)
+        return unwrap_argument(positional[arg_index], wrapper_type)
     return None
 
 
@@ -416,7 +416,7 @@ def literal_target(
     ]
     if arg_index is not None and arg_index < len(positional):
         return string_literal(
-            _unwrap_argument(positional[arg_index], wrapper_type),
+            unwrap_argument(positional[arg_index], wrapper_type),
             string_type,
             content_type,
         )

--- a/codebase_rag/tests/test_flow_csharp_edges.py
+++ b/codebase_rag/tests/test_flow_csharp_edges.py
@@ -1,0 +1,120 @@
+# (H) C# FLOWS_TO taint edges (issue #102 follow-up). C# had READS_FROM/WRITES_TO
+# (H) sinks (#825) and resource handles (#826) but no data-flow taint: a value read
+# (H) from one resource reaching a write sink emits a resource->resource FLOWS_TO.
+# (H) The lean flow walk is descriptor-driven and already ran for C#, but C# wraps
+# (H) every call argument in an `argument` node, so the sink-argument taint reader
+# (H) and the literal-identity resolver had to unwrap it.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.capture import resolve_capture
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+FLOWS_TO = cs.RelationshipType.FLOWS_TO.value
+_CAPTURE_IO = resolve_capture([cs.CaptureGroup.IO.value])
+
+
+def _run_flow(tmp_path: Path, files: dict[str, str]) -> set[tuple[str, str]]:
+    parsers, queries = load_parsers()
+    for rel, content in files.items():
+        (tmp_path / rel).write_text(content, encoding="utf-8")
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        capture=_CAPTURE_IO,
+    ).run()
+    return {
+        (c.args[0][2], c.args[2][2])
+        for c in mock.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) == FLOWS_TO
+    }
+
+
+def test_csharp_env_flows_to_file_via_variable(tmp_path: Path) -> None:
+    files = {
+        "A.cs": (
+            "using System;\n"
+            "using System.IO;\n"
+            "class A {\n"
+            "  void Leak() {\n"
+            '    string s = Environment.GetEnvironmentVariable("SECRET");\n'
+            '    File.WriteAllText("out.txt", s);\n'
+            "  }\n"
+            "}\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::SECRET", "resource::FILE::out.txt") in flows, flows
+
+
+def test_csharp_env_flows_to_file_inline(tmp_path: Path) -> None:
+    # (H) The read source is inlined as the write sink's argument (no variable).
+    files = {
+        "A.cs": (
+            "using System;\n"
+            "using System.IO;\n"
+            "class A {\n"
+            "  void Leak() {\n"
+            '    File.WriteAllText("out.txt", '
+            'Environment.GetEnvironmentVariable("SECRET"));\n'
+            "  }\n"
+            "}\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::SECRET", "resource::FILE::out.txt") in flows, flows
+
+
+def test_csharp_env_flows_to_stdout(tmp_path: Path) -> None:
+    files = {
+        "A.cs": (
+            "using System;\n"
+            "class A {\n"
+            "  void Log() {\n"
+            '    string k = Environment.GetEnvironmentVariable("KEY");\n'
+            "    Console.WriteLine(k);\n"
+            "  }\n"
+            "}\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::KEY", "resource::STDOUT::<dynamic>") in flows, flows
+
+
+def test_csharp_file_read_flows_to_file_write(tmp_path: Path) -> None:
+    files = {
+        "A.cs": (
+            "using System.IO;\n"
+            "class A {\n"
+            "  void Copy() {\n"
+            '    string data = File.ReadAllText("in.txt");\n'
+            '    File.WriteAllText("out.txt", data);\n'
+            "  }\n"
+            "}\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::FILE::in.txt", "resource::FILE::out.txt") in flows, flows
+
+
+def test_csharp_untainted_value_emits_no_flow(tmp_path: Path) -> None:
+    # (H) A literal argument carries no taint: no FLOWS_TO edge.
+    files = {
+        "A.cs": (
+            "using System.IO;\n"
+            "class A {\n"
+            "  void Save() {\n"
+            '    File.WriteAllText("out.txt", "constant");\n'
+            "  }\n"
+            "}\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert flows == set(), flows

--- a/uv.lock
+++ b/uv.lock
@@ -540,7 +540,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.407"
+version = "0.0.408"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

Completes C# I/O modelling (issue #102 follow-up) with **`FLOWS_TO` data-flow taint edges**. After #825 (sinks) and #826 (handles), C# emitted `READS_FROM`/`WRITES_TO` but no data flow: a value read from one resource that reaches a write sink now emits a resource→resource `FLOWS_TO` edge (an env secret written to a file, a file's contents echoed to stdout, etc.).

- `string s = Environment.GetEnvironmentVariable("SECRET"); File.WriteAllText("out.txt", s);` → `resource::ENV::SECRET` **FLOWS_TO** `resource::FILE::out.txt`
- Inline form (no variable), `File.ReadAllText → File.WriteAllText`, and env → `Console.WriteLine` all covered; a literal argument carries no taint (no edge).

## How

The lean flow walk is descriptor-driven and **already ran for C#** (C# had a descriptor since #825 and sinks in `IO_SINKS`), but produced nothing because C# wraps every call argument in an `argument` node. Two narrow gaps:

1. `_js_arg_taints` iterated `argument` wrappers directly, so a tainted identifier inside one was never seen → unwrap via the existing `argument_wrapper_type` before reading taint.
2. The two C#-reachable `literal_target` calls (write-sink identity in `_js_call`, read-source identity in `_js_read_source`) didn't pass `wrapper_type`, so a resolved source/sink got `<dynamic>` instead of the real path/key.

Both reuse machinery already built for the io walk in #825/#826. The arg-unwrap helper (`unwrap_argument`) was promoted from private to a public export of `io_access` so the flow walk can share it. The other `literal_target` sites are Python-only, Rust-macro, or C#-inert member-subscript — left untouched.

## Tests

`test_flow_csharp_edges.py` — 5 RED→GREEN tests (env→file via variable, env→file inline, env→stdout, file→file, untainted-no-edge). Full unit suite: 5346 passed, 5 skipped.
