### PR TITLE
docs(readme): slim README to a product overview that links to docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ You also need Docker (for Memgraph), `cmake`, and `ripgrep`. Full prerequisites,
 ## Quick Start
 
 ```bash
-# Start Memgraph
-docker compose up -d
+# Start the packaged Memgraph + Qdrant stack (no compose file needed)
+cgr daemon up
 
 # Parse a repository into the graph, then query it
 cgr start --repo-path /path/to/repo --update-graph --clean

--- a/README.md
+++ b/README.md
@@ -52,10 +52,9 @@
 </p>
 </div>
 
-# Code-Graph-RAG: A Graph-Based RAG System for Any Codebases
+# Code-Graph-RAG
 
-An accurate Retrieval-Augmented Generation (RAG) system that analyzes multi-language codebases using Tree-sitter, builds comprehensive knowledge graphs, and enables natural language querying of codebase structure and relationships as well as editing capabilities.
-
+Code-Graph-RAG parses a multi-language codebase with Tree-sitter, builds a knowledge graph of its structure in Memgraph, and lets you query, edit, and optimize that code in plain English. It works across a monorepo of mixed languages under one unified graph schema.
 
 <p align="center">
   <img src="./assets/demo.gif" alt="demo">
@@ -63,92 +62,43 @@ An accurate Retrieval-Augmented Generation (RAG) system that analyzes multi-lang
 
 ## Latest News 🔥
 
-- **PHP Language Support**: Full PHP language support added — classes, interfaces, traits, enums, namespaces, PHP 8 attributes, and call graph analysis. Contributed by [@rs-ipps](https://github.com/rs-ipps).
-- **C Language Support**: Full C language support added — functions, structs, unions, enums, preprocessor includes, and call graph analysis. Contributed by [@dj0nes](https://github.com/dj0nes).
-- **Visualise any GitHub repo instantly!** Just change `github.com` to `gitcgr.com` in any repo URL — that's it, only 3 letters! Get an interactive graph of the entire codebase structure. Try it now: [gitcgr.com](https://gitcgr.com)
+- **PHP Language Support**: Full PHP support added, covering classes, interfaces, traits, enums, namespaces, PHP 8 attributes, and call graph analysis. Contributed by [@rs-ipps](https://github.com/rs-ipps).
+- **C Language Support**: Full C support added, covering functions, structs, unions, enums, preprocessor includes, and call graph analysis. Contributed by [@dj0nes](https://github.com/dj0nes).
+- **Visualise any GitHub repo instantly!** Just change `github.com` to `gitcgr.com` in any repo URL, that's it, only 3 letters. Get an interactive graph of the entire codebase structure. Try it now: [gitcgr.com](https://gitcgr.com)
 
-## 🚀 Features
+## What It Does
 
-- **Multi-Language Support**:
+Point Code-Graph-RAG at a repository and it reads every source file, extracts functions, classes, methods, modules, and the relationships between them, and stores the result as an interconnected graph. Once the graph exists you can:
 
-<!-- SECTION:supported_languages -->
-| Language | Status | Extensions | Functions | Classes/Structs | Modules | Package Detection | Additional Features |
-|--------|------|----------|---------|---------------|-------|-----------------|-------------------|
-| C | Fully Supported | .c | ✓ | ✓ | ✓ | ✓ | Functions, structs, unions, enums, preprocessor includes |
-| C# | Fully Supported | .cs | ✓ | ✓ | ✓ | - | Namespaces (block and file-scoped), classes/structs/records/interfaces/enums, generics, inheritance/interfaces/overrides, typed call resolution with overloads, using directives |
-| C++ | Fully Supported | .cpp, .h, .hpp, .cc, .cxx, .hxx, .hh, .ixx, .cppm, .ccm | ✓ | ✓ | ✓ | ✓ | Constructors, destructors, operator overloading, templates, lambdas, C++20 modules, namespaces, preprocessor macros |
-| Dart | Fully Supported | .dart | ✓ | ✓ | ✓ | - | Classes, mixins, extensions, enhanced enums, factory/named constructors, Flutter widgets, package/relative/dart: imports, part directives, pubspec dependencies |
-| Go | Fully Supported | .go | ✓ | ✓ | ✓ | - | Receiver methods with cross-file binding, structs, interfaces, type declarations, function-local types |
-| Java | Fully Supported | .java | ✓ | ✓ | ✓ | - | Generics, annotations, modern features (records/sealed classes), concurrency, reflection |
-| JavaScript | Fully Supported | .js, .jsx, .mjs, .cjs | ✓ | ✓ | ✓ | - | ES6 modules, CommonJS, prototype methods, object methods, arrow functions |
-| Lua | Fully Supported | .lua | ✓ | - | ✓ | - | Local/global functions, metatables, closures, coroutines |
-| PHP | Fully Supported | .php | ✓ | ✓ | ✓ | - | Classes, interfaces, traits, enums, namespaces, PHP 8 attributes |
-| Python | Fully Supported | .py | ✓ | ✓ | ✓ | ✓ | Type inference, decorators, nested functions |
-| Rust | Fully Supported | .rs | ✓ | ✓ | ✓ | ✓ | impl blocks, associated functions, macro_rules! macros |
-| TypeScript (TSX) | Fully Supported | .tsx | ✓ | ✓ | ✓ | - | All TypeScript features plus JSX elements and components |
-| TypeScript | Fully Supported | .ts, .mts, .cts | ✓ | ✓ | ✓ | - | Interfaces, type aliases, enums, namespaces, ES6/CommonJS modules |
-| Scala | In Development | .scala, .sc | ✓ | ✓ | ✓ | - | Case classes, objects |
-<!-- /SECTION:supported_languages -->
-- **🌳 Tree-sitter Parsing**: Uses Tree-sitter for robust, language-agnostic AST parsing
-- **📊 Knowledge Graph Storage**: Uses Memgraph to store codebase structure as an interconnected graph
-- **🗣️ Natural Language Querying**: Ask questions about your codebase in plain English
-- **🤖 AI-Powered Cypher Generation**: Supports both cloud models (Google Gemini), local models (Ollama), and OpenAI models for natural language to Cypher translation
-- **🤖 OpenAI Integration**: Leverage OpenAI models to enhance AI functionalities.
-- **📝 Code Snippet Retrieval**: Retrieves actual source code snippets for found functions/methods
-- **✍️ Advanced File Editing**: Surgical code replacement with AST-based function targeting, visual diff previews, and exact code block modifications
-- **⚡️ Shell Command Execution**: Can execute terminal commands for tasks like running tests or using CLI tools.
-- **🚀 Interactive Code Optimization**: AI-powered codebase optimization with language-specific best practices and interactive approval workflow
-- **📚 Reference-Guided Optimization**: Use your own coding standards and architectural documents to guide optimization suggestions
-- **🧹 Dead Code Detection**: Report functions and methods unreachable from any entry point by walking `CALLS`/`REFERENCES` edges from roots (with a CI-friendly `--fail-on-found`)
-- **🔗 Dependency Analysis**: Parses `pyproject.toml` to understand external dependencies
-- **🎯 Nested Function Support**: Handles complex nested functions and class hierarchies
-- **🔄 Language-Agnostic Design**: Unified graph schema across all supported languages
+- Ask questions about the codebase in natural language and get answers grounded in the real structure.
+- Retrieve the actual source of any function, class, or method by name or by intent.
+- Edit code through the agent with AST-based surgical patching and a diff preview before anything changes.
+- Optimize code against language best practices or your own coding standards.
+- Find dead code by walking call and reference edges from entry points.
+- Search and rewrite structurally by AST pattern with ast-grep.
 
-## 🏗️ Architecture
+## How It Works
 
-The system consists of two main components:
+The system has two components:
 
-1. **Multi-language Parser**: Tree-sitter based parsing system that analyzes codebases and ingests data into Memgraph
-2. **RAG System** (`codebase_rag/`): Interactive CLI for querying the stored knowledge graph
+1. **Multi-language parser.** A Tree-sitter based parser reads the codebase and ingests functions, classes, methods, modules, and their relationships into Memgraph under a single language-agnostic schema.
+2. **RAG system** (`codebase_rag/`). An interactive CLI that turns natural language into Cypher queries, retrieves matching code, and drives AI-powered editing and optimization.
 
-
-## 📋 Prerequisites
-
-- Python 3.12+
-- Docker & Docker Compose (for Memgraph)
-- **cmake** (required for building pymgclient dependency)
-- **ripgrep** (`rg`) (required for shell command text searching)
-- **For cloud models**: Google Gemini API key
-- **For local models**: Ollama installed and running
-- `uv` package manager
-
-### Installing cmake and ripgrep
-
-On macOS:
-```bash
-brew install cmake ripgrep
+```
+Source Code -> Tree-sitter Parser -> AST Analysis -> Memgraph Knowledge Graph
+                                                             |
+User Query -> AI Model (Cypher Gen) -> Cypher Query -> Graph Results -> Response
 ```
 
-On Linux (Ubuntu/Debian):
-```bash
-sudo apt-get update
-sudo apt-get install cmake ripgrep
-```
+See the [Architecture Overview](docs/architecture/overview.md) and [Graph Schema](docs/architecture/graph-schema.md) for the full picture.
 
-On Linux (CentOS/RHEL):
-```bash
-sudo yum install cmake
-sudo dnf install ripgrep
-# Note: ripgrep may need to be installed from EPEL or via cargo
-```
+## Supported Languages
 
-## 🛠️ Installation
+Python, TypeScript, TSX, JavaScript, Rust, Go, Java, C, C++, C#, PHP, Lua, and Dart are fully supported. Scala is in development. See the [Language Support](docs/architecture/language-support.md) matrix for per-language capabilities.
 
-### System-wide install (recommended for end users)
+## Installation
 
-`cgr` is published to PyPI and can be installed system-wide so it works from any
-target repo without activating a project virtualenv. Install with the
-`treesitter-full` (all languages) and `semantic` (vector search) extras:
+`cgr` is published to PyPI. Install it system-wide with the `treesitter-full` (all languages) and `semantic` (vector search) extras:
 
 ```bash
 # with uv (recommended)
@@ -158,928 +108,81 @@ uv tool install "code-graph-rag[treesitter-full,semantic]"
 pipx install "code-graph-rag[treesitter-full,semantic]"
 ```
 
-For a Python-only install, omit the extras. For local development from a clone,
-use `uv tool install --editable "/path/to/code-graph-rag[treesitter-full,semantic]"`.
+You also need Docker (for Memgraph), `cmake`, and `ripgrep`. Full prerequisites, source installs, and environment setup are in the [Installation](docs/getting-started/installation.md) guide.
 
-After install, `cgr` is on PATH. From any repository, run:
-
-```bash
-cd ~/path/to/some-target-repo
-cgr daemon up        # one-time: start the shared memgraph + qdrant stack
-cgr start            # auto-sync the current repo and drop into the agent
-```
-
-`cgr start` defaults `--repo-path` to the current directory and auto-syncs the
-graph incrementally on entry. Pass `--no-sync` to skip the sync, or
-`--no-start-stack` if memgraph/qdrant already run elsewhere.
-
-Useful subcommands:
-
-| Command | Purpose |
-|---|---|
-| `cgr daemon up/down/status/restart/logs` | Manage the shared docker stack |
-| `cgr stop` | Alias for `cgr daemon down` |
-| `cgr status` | Show stack state + per-project last-sync timestamp |
-| `cgr workspace create/list/show/delete` | Manage named bundles of repos |
-| `cgr workspace add-repo / remove-repo` | Edit a workspace's repo set |
-| `cgr start --workspace mono` | Open the agent over every project in the workspace |
-| `cgr start --projects a,b,c` | Scope agent queries to the listed projects |
-
-Indexed data persists across `cgr daemon down` thanks to named memgraph + qdrant
-volumes (`memgraph_data`, `memgraph_log`, `qdrant_storage`).
-
-Semantic search uses Qdrant by default. To store semantic vectors in Milvus
-Lite instead, install the `milvus` extra alongside `semantic` and set the
-vector store backend before indexing:
+## Quick Start
 
 ```bash
-uv tool install 'code-graph-rag[semantic,milvus]'
-export CGR_VECTOR_STORE_BACKEND=milvus
-export MILVUS_URI="./.milvus_code_embeddings.db"
-cgr start
+# Start Memgraph
+docker compose up -d
+
+# Parse a repository into the graph, then query it
+cgr start --repo-path /path/to/repo --update-graph --clean
+cgr start --repo-path /path/to/repo
 ```
 
-For a self-hosted open-source Milvus endpoint, set `MILVUS_URI` to the endpoint,
-for example `http://localhost:19530`.
-
-Embeddings are computed locally with UniXcoder by default. To use an
-OpenAI-compatible embeddings endpoint instead (OpenAI, Ollama, vLLM, LM
-Studio), which drops the local torch/transformers requirement:
-
-```bash
-export CGR_EMBEDDING_PROVIDER=openai
-export OPENAI_EMBEDDING_BASE_URL="http://localhost:11434/v1"
-export OPENAI_EMBEDDING_MODEL="nomic-embed-text"
-export QDRANT_VECTOR_DIM=768  # must match the model's output dimension
-```
-
-`OPENAI_EMBEDDING_API_KEY` (falling back to `OPENAI_API_KEY`) is sent as a
-bearer token when set; local servers that need no key work without one.
-
-### Local development install
-
-```bash
-git clone https://github.com/vitali87/code-graph-rag.git
-cd code-graph-rag
-```
-
-2. **Install dependencies**:
-
-For basic Python support:
-```bash
-uv sync
-```
-
-For full multi-language support:
-```bash
-uv sync --extra treesitter-full
-```
-
-For development (including tests and pre-commit hooks):
-```bash
-make dev
-```
-
-This installs all dependencies and sets up pre-commit hooks automatically.
-
-This installs Tree-sitter grammars for all supported languages (see Multi-Language Support section).
-
-3. **Set up environment variables**:
-```bash
-cp .env.example .env
-# Edit .env with your configuration (see options below)
-```
-
-### Configuration Options
-
-The new provider-explicit configuration supports mixing different providers for orchestrator and cypher models.
-
-#### Option 1: All Ollama (Local Models)
-
-```bash
-# .env file
-ORCHESTRATOR_PROVIDER=ollama
-ORCHESTRATOR_MODEL=llama3.2
-ORCHESTRATOR_ENDPOINT=http://localhost:11434/v1
-
-CYPHER_PROVIDER=ollama
-CYPHER_MODEL=codellama
-CYPHER_ENDPOINT=http://localhost:11434/v1
-```
-
-#### Option 2: All OpenAI Models
-```bash
-# .env file
-ORCHESTRATOR_PROVIDER=openai
-ORCHESTRATOR_MODEL=gpt-4o
-ORCHESTRATOR_API_KEY=sk-your-openai-key
-
-CYPHER_PROVIDER=openai
-CYPHER_MODEL=gpt-4o-mini
-CYPHER_API_KEY=sk-your-openai-key
-```
-
-#### Option 3: All Google Models
-```bash
-# .env file
-ORCHESTRATOR_PROVIDER=google
-ORCHESTRATOR_MODEL=gemini-2.5-pro
-ORCHESTRATOR_API_KEY=your-google-api-key
-
-CYPHER_PROVIDER=google
-CYPHER_MODEL=gemini-2.5-flash
-CYPHER_API_KEY=your-google-api-key
-```
-
-#### Option 4: Mixed Providers
-```bash
-# .env file - Google orchestrator + Ollama cypher
-ORCHESTRATOR_PROVIDER=google
-ORCHESTRATOR_MODEL=gemini-2.5-pro
-ORCHESTRATOR_API_KEY=your-google-api-key
-
-CYPHER_PROVIDER=ollama
-CYPHER_MODEL=codellama
-CYPHER_ENDPOINT=http://localhost:11434/v1
-```
-
-Get your Google API key from [Google AI Studio](https://aistudio.google.com/app/apikey).
-
-**Install and run Ollama**:
-```bash
-# Install Ollama (macOS/Linux)
-curl -fsSL https://ollama.ai/install.sh | sh
-
-# Pull required models
-ollama pull llama3.2
-# Or try other models like:
-# ollama pull llama3
-# ollama pull mistral
-# ollama pull codellama
-
-# Ollama will automatically start serving on localhost:11434
-```
-
-> **Note**: Local models provide privacy and no API costs, but may have lower accuracy compared to cloud models like Gemini.
-
-4. **Start Memgraph database**:
-```bash
-cgr daemon up
-```
-
-5. **Verify installation**:
-```bash
-# If installed from PyPI:
-cgr --help
-
-# If running from source:
-uv run cgr --help
-```
-
-> **Note**: When running from source (cloned repo), prefix all `cgr` commands below with `uv run`, e.g., `uv run cgr start ...`
-
-## 🛠️ Makefile Commands
-
-Use the Makefile for common development tasks:
-
-<!-- SECTION:makefile_commands -->
-| Command | Description |
-|-------|-----------|
-| `make help` | Show this help message |
-| `make all` | Install everything for full development environment (deps, grammars, hooks, tests) |
-| `make install` | Install project dependencies with full language support |
-| `make python` | Install project dependencies for Python only |
-| `make dev` | Setup development environment (install deps + pre-commit hooks) |
-| `make test` | Run unit tests only (fast, no Docker) |
-| `make test-parallel` | Run unit tests in parallel (fast, no Docker) |
-| `make test-integration` | Run integration tests (requires Docker) |
-| `make test-all` | Run all tests including integration and e2e (requires Docker) |
-| `make test-parallel-all` | Run all tests in parallel including integration and e2e (requires Docker) |
-| `make clean` | Clean up build artifacts and cache |
-| `make build-grammars` | Build grammar submodules |
-| `make watch` | Watch repository for changes and update graph in real-time |
-| `make readme` | Regenerate README.md from codebase |
-| `make lint` | Run ruff check |
-| `make format` | Run ruff format |
-| `make typecheck` | Run type checking with ty |
-| `make check` | Run all checks: lint, typecheck, test |
-| `make release` | Build, verify, and publish the current pyproject version to PyPI, then tag and create a GitHub Release |
-| `make pre-commit` | Run all pre-commit checks locally (comprehensive test before commit) |
-<!-- /SECTION:makefile_commands -->
-
-## 🎯 Usage
-
-The Code-Graph-RAG system offers four main modes of operation:
-1. **Parse & Ingest**: Build knowledge graph from your codebase
-2. **Interactive Query**: Ask questions about your code in natural language
-3. **Export & Analyze**: Export graph data for programmatic analysis
-4. **AI Optimization**: Get AI-powered optimization suggestions for your code.
-5. **Editing**: Perform surgical code replacements and modifications with precise targeting.
-
-### Step 1: Parse a Repository
-
-Parse and ingest a multi-language repository into the knowledge graph:
-
-**For the first repository (clean start):**
-```bash
-cgr start --repo-path /path/to/repo1 --update-graph --clean
-```
-
-**For additional repositories (preserve existing data):**
-```bash
-cgr start --repo-path /path/to/repo2 --update-graph
-cgr start --repo-path /path/to/repo3 --update-graph
-```
-
-**Control Memgraph batch flushing:**
-```bash
-# Flush every 5,000 records instead of the default from settings
-cgr start --repo-path /path/to/repo --update-graph \
-  --batch-size 5000
-```
-
-The system automatically detects and processes files for all supported languages (see Multi-Language Support section).
-
-### Step 2: Query the Codebase
-
-**Interactive mode:**
-
-Start the interactive RAG CLI:
-
-```bash
-cgr start --repo-path /path/to/your/repo
-```
-
-**Non-interactive mode (single query):**
-
-Run a single query and exit, with output sent to stdout (useful for scripting):
-
-```bash
-python -m codebase_rag.main start --repo-path /path/to/your/repo \
-  --ask-agent "What functions call UserService.create_user?"
-```
-
-### Step 2.5: Real-Time Graph Updates (Optional)
-
-For active development, you can keep your knowledge graph automatically synchronized with code changes using the realtime updater. This is particularly useful when you're actively modifying code and want the AI assistant to always work with the latest codebase structure.
-
-**What it does:**
-- Watches your repository for file changes (create, modify, delete)
-- Automatically updates the knowledge graph in real-time
-- Maintains consistency by recalculating all function call relationships
-- Filters out irrelevant files (`.git`, `node_modules`, etc.)
-
-**How to use:**
-
-Run the realtime updater in a separate terminal:
-
-```bash
-# Using Python directly
-python realtime_updater.py /path/to/your/repo
-
-# Or using the Makefile
-make watch REPO_PATH=/path/to/your/repo
-```
-
-**With custom Memgraph settings:**
-```bash
-# Python
-python realtime_updater.py /path/to/your/repo --host localhost --port 7687 --batch-size 1000
-
-# Makefile
-make watch REPO_PATH=/path/to/your/repo HOST=localhost PORT=7687 BATCH_SIZE=1000
-```
-
-**Multi-terminal workflow:**
-```bash
-# Terminal 1: Start the realtime updater
-python realtime_updater.py ~/my-project
-
-# Terminal 2: Run the AI assistant
-cgr start --repo-path ~/my-project
-```
-
-**Performance note:** The updater currently recalculates all CALLS relationships on every file change to ensure consistency. This prevents "island" problems where changes in one file aren't reflected in relationships from other files, but may impact performance on very large codebases with frequent changes. **Note:** Optimization of this behavior is a work in progress.
-
-**CLI Arguments:**
-- `repo_path` (required): Path to repository to watch
-- `--host`: Memgraph host (default: `localhost`)
-- `--port`: Memgraph port (default: `7687`)
-- `--batch-size`: Number of buffered nodes/relationships before flushing to Memgraph
-
-**Specify Custom Models:**
-```bash
-# Use specific local models
-cgr start --repo-path /path/to/your/repo \
-  --orchestrator ollama:llama3.2 \
-  --cypher ollama:codellama
-
-# Use specific Gemini models
-cgr start --repo-path /path/to/your/repo \
-  --orchestrator google:gemini-2.0-flash-thinking-exp-01-21 \
-  --cypher google:gemini-2.5-flash-lite-preview-06-17
-
-# Use mixed providers
-cgr start --repo-path /path/to/your/repo \
-  --orchestrator google:gemini-2.0-flash-thinking-exp-01-21 \
-  --cypher ollama:codellama
-```
-
-Example queries (works across all supported languages):
-- "Show me all classes that contain 'user' in their name"
-- "Find functions related to database operations"
-- "What methods does the User class have?"
-- "Show me functions that handle authentication"
-- "List all TypeScript components"
-- "Find Rust structs and their methods"
-- "Show me Go interfaces and implementations"
-- "Find all C++ operator overloads in the Matrix class"
-- "Show me C++ template functions with their specializations"
-- "List all C++ namespaces and their contained classes"
-- "Find C++ lambda expressions used in algorithms"
-- "Add logging to all database connection functions"
-- "Refactor the User class to use dependency injection"
-- "Convert these Python functions to async/await pattern"
-- "Add error handling to authentication methods"
-- "Optimize this function for better performance"
-
-### Step 3: Export Graph Data
-
-For programmatic access and integration with other tools, you can export the entire knowledge graph to JSON:
-
-**Export during graph update:**
-```bash
-cgr start --repo-path /path/to/repo --update-graph --clean -o my_graph.json
-```
-
-**Export existing graph without updating:**
-```bash
-cgr export -o my_graph.json
-```
-
-**Optional: adjust Memgraph batching during export:**
-```bash
-cgr export -o my_graph.json --batch-size 5000
-```
-
-**Working with exported data:**
-```python
-from codebase_rag.graph_loader import load_graph
-
-# Load the exported graph
-graph = load_graph("my_graph.json")
-
-# Get summary statistics
-summary = graph.summary()
-print(f"Total nodes: {summary['total_nodes']}")
-print(f"Total relationships: {summary['total_relationships']}")
-
-# Find specific node types
-functions = graph.find_nodes_by_label("Function")
-classes = graph.find_nodes_by_label("Class")
-
-# Analyze relationships
-for func in functions[:5]:
-    relationships = graph.get_relationships_for_node(func.node_id)
-    print(f"Function {func.properties['name']} has {len(relationships)} relationships")
-```
-
-**Example analysis script:**
-```bash
-python examples/graph_export_example.py my_graph.json
-```
-
-This provides a reliable, programmatic way to access your codebase structure without LLM restrictions, perfect for:
-- Integration with other tools
-- Custom analysis scripts
-- Building documentation generators
-- Creating code metrics dashboards
-
-### Step 4: Code Optimization
-
-For AI-powered codebase optimization with best practices guidance:
-
-**Basic optimization for a specific language:**
-```bash
-cgr optimize python --repo-path /path/to/your/repo
-```
-
-**Optimization with reference documentation:**
-```bash
-cgr optimize python \
-  --repo-path /path/to/your/repo \
-  --reference-document /path/to/best_practices.md
-```
-
-**Using specific models for optimization:**
-```bash
-cgr optimize javascript \
-  --repo-path /path/to/frontend \
-  --orchestrator google:gemini-2.0-flash-thinking-exp-01-21
-
-# Optional: override Memgraph batch flushing during optimization
-cgr optimize javascript --repo-path /path/to/frontend \
-  --batch-size 5000
-```
-
-**Supported Languages for Optimization:**
-All supported languages: `python`, `javascript`, `typescript`, `rust`, `go`, `java`, `scala`, `c`, `cpp`
-
-**How It Works:**
-1. **Analysis Phase**: The agent analyzes your codebase structure using the knowledge graph
-2. **Pattern Recognition**: Identifies common anti-patterns, performance issues, and improvement opportunities
-3. **Best Practices Application**: Applies language-specific best practices and patterns
-4. **Interactive Approval**: Presents each optimization suggestion for your approval before implementation
-5. **Guided Implementation**: Implements approved changes with detailed explanations
-
-**Example Optimization Session:**
-```
-Starting python optimization session...
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ The agent will analyze your python codebase and propose specific          ┃
-┃ optimizations. You'll be asked to approve each suggestion before          ┃
-┃ implementation. Type 'exit' or 'quit' to end the session.                 ┃
-┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-
-🔍 Analyzing codebase structure...
-📊 Found 23 Python modules with potential optimizations
-
-💡 Optimization Suggestion #1:
-   File: src/data_processor.py
-   Issue: Using list comprehension in a loop can be optimized
-   Suggestion: Replace with generator expression for memory efficiency
-
-   [y/n] Do you approve this optimization?
-```
-
-**Reference Document Support:**
-You can provide reference documentation (like coding standards, architectural guidelines, or best practices documents) to guide the optimization process:
-
-```bash
-# Use company coding standards
-cgr optimize python \
-  --reference-document ./docs/coding_standards.md
-
-# Use architectural guidelines
-cgr optimize java \
-  --reference-document ./ARCHITECTURE.md
-
-# Use performance best practices
-cgr optimize rust \
-  --reference-document ./docs/performance_guide.md
-```
-
-The agent will incorporate the guidance from your reference documents when suggesting optimizations, ensuring they align with your project's standards and architectural decisions.
-
-**Common CLI Arguments:**
-- `--orchestrator`: Specify provider:model for main operations (e.g., `google:gemini-2.0-flash-thinking-exp-01-21`, `ollama:llama3.2`)
-- `--cypher`: Specify provider:model for graph queries (e.g., `google:gemini-2.5-flash-lite-preview-06-17`, `ollama:codellama`)
-- `--repo-path`: Path to repository (defaults to current directory)
-- `--batch-size`: Override Memgraph flush batch size (defaults to `MEMGRAPH_BATCH_SIZE` in settings)
-- `--reference-document`: Path to reference documentation (optimization only)
-
-### Step 5: Dead Code Detection
-
-Once a repository is indexed, report functions and methods that are unreachable
-from any entry point. The walk starts from roots (exported/public symbols,
-tests, decorated handlers like routes/tasks/commands, dunder/lifecycle methods)
-and follows `CALLS` and `REFERENCES` edges; anything it never reaches is listed.
-
-```bash
-# Scan the indexed project (auto-selected when only one exists)
-cgr dead-code
-
-# Pick a project when several are indexed
-cgr dead-code --project-name my-project
-```
-
-**Declare framework/external entry points** so the code they reach is not flagged:
-
-```bash
-cgr dead-code -e main -e cli.run --decorator-root celery_app.task
-```
-
-**Exclude generated or vendored code** (noisy with library-invoked callbacks):
-
-```bash
-cgr dead-code --exclude '*client/core*' --exclude '*.gen.*'
-```
-
-**Fail CI when new unreachable code appears**, writing a JSON report:
-
-```bash
-cgr dead-code --format json --output dead-code.json --fail-on-found
-```
-
-> Results are candidates for review, not a guaranteed delete list: code reached
-> only via dynamic dispatch, reflection, or an external framework may still be
-> reported. See the [Dead Code Detection guide](https://docs.code-graph-rag.com/guide/dead-code/) for details.
-
-**Dead Code CLI Arguments:**
-- `--project-name`, `-n`: Project to scan (defaults to the sole indexed project)
-- `--entry-point`, `-e`: Treat symbols ending with this qualified name as reachable roots (repeatable)
-- `--decorator-root`: Treat symbols carrying this decorator as roots (repeatable)
-- `--exclude`: Glob matched against a symbol's file path to exclude (repeatable)
-- `--include-tests` / `--no-include-tests`: Treat test code as roots (on by default)
-- `--classes` / `--no-classes`: Also report unreachable classes (off by default)
-- `--format`: `table` (default) or `json`
-- `--output`, `-o`: Write the report to a file instead of stdout
-- `--fail-on-found`: Exit with code 1 when any candidate is found
-
-## 🔌 MCP Server (Claude Code Integration)
-
-Code-Graph-RAG can run as an MCP (Model Context Protocol) server, enabling seamless integration with Claude Code and other MCP clients.
-
-### Quick Setup
-
-```bash
-claude mcp add --transport stdio code-graph-rag \
-  --env TARGET_REPO_PATH=/absolute/path/to/your/project \
-  --env CYPHER_PROVIDER=openai \
-  --env CYPHER_MODEL=gpt-4 \
-  --env CYPHER_API_KEY=your-api-key \
-  -- uv run --directory /path/to/code-graph-rag code-graph-rag mcp-server
-```
-
-### Available Tools
-
-<!-- SECTION:mcp_tools -->
-| Tool | Description |
-|----|-----------|
-| `list_projects` | List all indexed projects in the knowledge graph database. Returns a list of project names that have been indexed. |
-| `delete_project` | Delete a specific project from the knowledge graph database. This removes all nodes associated with the project while preserving other projects. Use list_projects first to see available projects. |
-| `wipe_database` | WARNING: Completely wipe the entire database, removing ALL indexed projects. This cannot be undone. Use delete_project for removing individual projects. |
-| `index_repository` | WARNING: Clears all data for the current project including its embeddings. Parse and ingest the repository into the Memgraph knowledge graph. Use update_repository for incremental updates. Only use when explicitly requested. |
-| `update_repository` | Update the repository in the Memgraph knowledge graph without clearing existing data. Use this for incremental updates. |
-| `query_code_graph` | Query the codebase knowledge graph using natural language. Use semantic_search unless you know the exact names of classes/functions you are searching for. Ask questions like 'What functions call UserService.create_user?' or 'Show me all classes that implement the Repository interface'. |
-| `get_code_snippet` | Retrieve source code for a function, class, or method by its qualified name. Returns the source code, file path, line numbers, and docstring. |
-| `surgical_replace_code` | Surgically replace an exact code block in a file using diff-match-patch. Only modifies the exact target block, leaving the rest unchanged. |
-| `read_file` | Read the contents of a file from the project. Supports pagination for large files. |
-| `write_file` | Write content to a file, creating it if it doesn't exist. |
-| `list_directory` | List contents of a directory in the project. |
-| `semantic_search` | Performs a semantic search for functions based on a natural language query describing their purpose, returning a list of potential matches with similarity scores. Requires the 'semantic' extra to be installed. |
-| `structural_search` | Search code structurally by AST pattern using ast-grep syntax (not text/regex). Returns file paths, line and column numbers, and the matched code. Requires the 'ast-grep' extra to be installed. |
-| `structural_replace` | Rewrite code structurally by AST pattern using ast-grep syntax. Metavariables captured by the pattern are substituted into the rewrite. Defaults to dry_run (returns a diff); set dry_run=false to write changes. Requires the 'ast-grep' extra to be installed. |
-| `ask_agent` | Ask the Code Graph RAG agent a question about the codebase. Uses the full RAG pipeline to analyze the code graph and provide a detailed answer. Use this for general questions about architecture, functionality, and code relationships. |
-<!-- /SECTION:mcp_tools -->
-
-### Example Usage
-
-```
-> Index this repository
-> What functions call UserService.create_user?
-> Update the login function to add rate limiting
-```
-
-For detailed setup, see [Claude Code Setup Guide](docs/claude-code-setup.md).
-
-## 📊 Graph Schema
-
-The knowledge graph uses the following node types and relationships:
-
-### Node Types
-
-<!-- SECTION:node_schemas -->
-| Label | Properties |
-|-----|----------|
-| Project | `{name: string}` |
-| Package | `{qualified_name: string, name: string, path: string, absolute_path: string}` |
-| Folder | `{path: string, name: string, absolute_path: string}` |
-| File | `{path: string, name: string, extension: string?, absolute_path: string}` |
-| Module | `{qualified_name: string, name: string, path: string, absolute_path: string, start_line: int?, end_line: int?}` |
-| Class | `{qualified_name: string, name: string, modifiers: list[string], decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
-| Function | `{qualified_name: string, name: string, modifiers: list[string], decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?, is_macro: boolean?}` |
-| Method | `{qualified_name: string, name: string, modifiers: list[string], decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?, is_property: boolean?, overrides_external: boolean?}` |
-| Interface | `{qualified_name: string, name: string, path: string, absolute_path: string, modifiers: list[string]?, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
-| Enum | `{qualified_name: string, name: string, path: string, absolute_path: string, modifiers: list[string]?, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
-| Type | `{qualified_name: string, name: string, path: string?, absolute_path: string?, modifiers: list[string]?, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
-| Union | `{qualified_name: string, name: string, path: string?, absolute_path: string?, modifiers: list[string]?, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
-| ModuleInterface | `{qualified_name: string, name: string, path: string, absolute_path: string, module_type: string}` |
-| ModuleImplementation | `{qualified_name: string, name: string, path: string, absolute_path: string, implements_module: string, module_type: string}` |
-| ExternalPackage | `{name: string}` |
-| ExternalModule | `{qualified_name: string, name: string, path: string}` |
-| Resource | `{qualified_name: string, name: string, kind: string}` |
-<!-- /SECTION:node_schemas -->
-
-### Language-Specific Mappings
-
-<!-- SECTION:language_mappings -->
-- **C**: `enum_specifier`, `function_definition`, `struct_specifier`, `union_specifier`
-- **C#**: `class_declaration`, `constructor_declaration`, `conversion_operator_declaration`, `destructor_declaration`, `enum_declaration`, `interface_declaration`, `local_function_statement`, `method_declaration`, `operator_declaration`, `property_declaration`, `record_declaration`, `struct_declaration`
-- **C++**: `class_specifier`, `declaration`, `enum_specifier`, `field_declaration`, `function_definition`, `lambda_expression`, `struct_specifier`, `template_declaration`, `union_specifier`
-- **Dart**: `class_definition`, `constant_constructor_signature`, `constructor_signature`, `enum_declaration`, `extension_declaration`, `extension_type_declaration`, `factory_constructor_signature`, `function_signature`, `getter_signature`, `mixin_declaration`, `setter_signature`
-- **Go**: `function_declaration`, `method_declaration`, `type_alias`, `type_spec`
-- **Java**: `annotation_type_declaration`, `class_declaration`, `constructor_declaration`, `enum_declaration`, `interface_declaration`, `method_declaration`, `record_declaration`
-- **JavaScript**: `arrow_function`, `class`, `class_declaration`, `function_declaration`, `function_expression`, `generator_function_declaration`, `method_definition`
-- **Lua**: `function_declaration`, `function_definition`
-- **PHP**: `anonymous_function`, `arrow_function`, `class_declaration`, `enum_declaration`, `function_definition`, `interface_declaration`, `method_declaration`, `trait_declaration`
-- **Python**: `class_definition`, `function_definition`
-- **Rust**: `closure_expression`, `enum_item`, `function_item`, `function_signature_item`, `impl_item`, `macro_definition`, `struct_item`, `trait_item`, `type_item`, `union_item`
-- **TypeScript (TSX)**: `abstract_class_declaration`, `arrow_function`, `class`, `class_declaration`, `enum_declaration`, `function_declaration`, `function_expression`, `function_signature`, `generator_function_declaration`, `interface_declaration`, `internal_module`, `method_definition`, `type_alias_declaration`
-- **TypeScript**: `abstract_class_declaration`, `arrow_function`, `class`, `class_declaration`, `enum_declaration`, `function_declaration`, `function_expression`, `function_signature`, `generator_function_declaration`, `interface_declaration`, `internal_module`, `method_definition`, `type_alias_declaration`
-- **Scala**: `class_definition`, `function_declaration`, `function_definition`, `object_definition`, `trait_definition`
-<!-- /SECTION:language_mappings -->
-
-### Relationships
-
-<!-- SECTION:relationship_schemas -->
-| Source | Relationship | Target |
-|------|------------|------|
-| Project, Package, Folder | CONTAINS_PACKAGE | Package |
-| Project, Package, Folder | CONTAINS_FOLDER | Folder |
-| Project, Package, Folder | CONTAINS_FILE | File |
-| Project, Package, Folder | CONTAINS_MODULE | Module |
-| Module, Function, Method, Class | DEFINES | Class, Function, Method, Enum, Interface, Type, Union, Module |
-| Class, Interface, Enum, Type, Union | DEFINES_METHOD | Method |
-| Module | IMPORTS | Module, ExternalModule |
-| Module | EXPORTS | Class, Function |
-| Module | EXPORTS_MODULE | ModuleInterface |
-| Module | IMPLEMENTS_MODULE | ModuleImplementation |
-| Class, Interface, Function | INHERITS | Class, Interface, Function, ExternalModule |
-| Class, Enum | IMPLEMENTS | Interface, Class, Enum, ExternalModule |
-| Method, Function | OVERRIDES | Method |
-| ModuleImplementation | IMPLEMENTS | ModuleInterface |
-| Project | DEPENDS_ON_EXTERNAL | ExternalPackage |
-| Module, Function, Method | CALLS | Function, Method, Enum, Type |
-| Module, Function, Method | REFERENCES | Function, Method, Class |
-| Module, Function, Method | INSTANTIATES | Class |
-| Module, Function, Method | READS_FROM | Resource |
-| Module, Function, Method | WRITES_TO | Resource |
-| Module, Function, Method, Resource | FLOWS_TO | Module, Function, Method, Resource |
-<!-- /SECTION:relationship_schemas -->
-
-## 🔧 Configuration
-
-Configuration is managed through environment variables in `.env` file:
-
-### Provider-Specific Settings
-
-#### Orchestrator Model Configuration
-- `ORCHESTRATOR_PROVIDER`: Provider name (`google`, `openai`, `ollama`)
-- `ORCHESTRATOR_MODEL`: Model ID (e.g., `gemini-2.5-pro`, `gpt-4o`, `llama3.2`)
-- `ORCHESTRATOR_API_KEY`: API key for the provider (if required)
-- `ORCHESTRATOR_ENDPOINT`: Custom endpoint URL (if required)
-- `ORCHESTRATOR_PROJECT_ID`: Google Cloud project ID (for Vertex AI)
-- `ORCHESTRATOR_REGION`: Google Cloud region (default: `us-central1`)
-- `ORCHESTRATOR_PROVIDER_TYPE`: Google provider type (`gla` or `vertex`)
-- `ORCHESTRATOR_THINKING_BUDGET`: Thinking budget for reasoning models
-- `ORCHESTRATOR_SERVICE_ACCOUNT_FILE`: Path to service account file (for Vertex AI)
-
-#### Cypher Model Configuration
-- `CYPHER_PROVIDER`: Provider name (`google`, `openai`, `ollama`)
-- `CYPHER_MODEL`: Model ID (e.g., `gemini-2.5-flash`, `gpt-4o-mini`, `codellama`)
-- `CYPHER_API_KEY`: API key for the provider (if required)
-- `CYPHER_ENDPOINT`: Custom endpoint URL (if required)
-- `CYPHER_PROJECT_ID`: Google Cloud project ID (for Vertex AI)
-- `CYPHER_REGION`: Google Cloud region (default: `us-central1`)
-- `CYPHER_PROVIDER_TYPE`: Google provider type (`gla` or `vertex`)
-- `CYPHER_THINKING_BUDGET`: Thinking budget for reasoning models
-- `CYPHER_SERVICE_ACCOUNT_FILE`: Path to service account file (for Vertex AI)
-
-### System Settings
-- `MEMGRAPH_HOST`: Memgraph hostname (default: `localhost`)
-- `MEMGRAPH_PORT`: Memgraph port (default: `7687`)
-- `MEMGRAPH_HTTP_PORT`: Memgraph HTTP port (default: `7444`)
-- `LAB_PORT`: Memgraph Lab port (default: `3000`)
-- `MEMGRAPH_BATCH_SIZE`: Batch size for Memgraph operations (default: `1000`)
-- `TARGET_REPO_PATH`: Default repository path (default: `.`)
-- `LOCAL_MODEL_ENDPOINT`: Fallback endpoint for Ollama (default: `http://localhost:11434/v1`)
-
-### Custom Ignore Patterns
-
-You can specify additional files and directories to exclude by creating a `.cgrignore` file in your repository root. Patterns follow `.gitignore` conventions:
-
-```
-# Comments start with #
-vendor
-*.gen.ts
-docs/*.md
-/generated
-!bin/keep.py
-```
-
-- Gitignore syntax: `*` matches within a segment, `**` crosses segments, bare names match at any depth, slash-containing patterns are anchored to the root, trailing slash matches directories only
-- Lines starting with `!` un-ignore paths that a default exclusion would skip (explicit excludes always win)
-- Lines starting with `#` are comments; blank lines are ignored
-- Patterns from `.cgrignore` are merged with `--exclude` flags (same syntax) and auto-detected directories
-
-### Key Dependencies
-
-<!-- SECTION:dependencies -->
-- **loguru**: Python logging made (stupidly) simple
-- **mcp**: Model Context Protocol SDK
-- **pydantic-ai**: AI Agent Framework, the Pydantic way
-- **pydantic-settings**: Settings management using Pydantic
-- **pymgclient**: Memgraph database adapter for Python language
-- **python-dotenv**: Read key-value pairs from a .env file and set them as environment variables
-- **tiktoken**: tiktoken is a fast BPE tokeniser for use with OpenAI's models
-- **toml**: Python Library for Tom's Obvious, Minimal Language
-- **tree-sitter-python**: Python grammar for tree-sitter
-- **tree-sitter**: Python bindings to the Tree-sitter parsing library
-- **watchdog**: Filesystem events monitoring
-- **typer**: Typer, build great CLIs. Easy to code. Based on Python type hints.
-- **rich**: Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal
-- **prompt-toolkit**: Library for building powerful interactive command lines in Python
-- **diff-match-patch**: Repackaging of Google's Diff Match and Patch libraries.
-- **click**: Composable command line interface toolkit
-- **protobuf**
-- **defusedxml**: XML bomb protection for Python stdlib modules
-- **huggingface-hub**: Client library to download and publish models, datasets and other repos on the huggingface.co hub
-- **griffe**: Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API.
-- **pathspec**: Utility library for gitignore style pattern matching of file paths.
-<!-- /SECTION:dependencies -->
-
-## 🤖 Agentic Workflow & Tools
-
-The agent is designed with a deliberate workflow to ensure it acts with context and precision, especially when modifying the file system.
-
-### Core Tools
-
-The agent has access to a suite of tools to understand and interact with the codebase:
-
-<!-- SECTION:agentic_tools -->
-| Tool | Description |
-|----|-----------|
-| `query_graph` | Query the codebase knowledge graph using natural language questions. Ask in plain English about classes, functions, methods, dependencies, or code structure. Examples: 'Find all functions that call each other', 'What classes are in the user module', 'Show me functions with the longest call chains'. |
-| `read_file` | Reads the content of text-based files. Images and PDFs the user references are attached inline; read them directly. |
-| `create_file` | Creates a new file with content. IMPORTANT: Check file existence first! Overwrites completely WITHOUT showing diff. Use only for new files, not existing file modifications. |
-| `replace_code` | Surgically replaces specific code blocks in files. Requires exact target code and replacement. Only modifies the specified block, leaving rest of file unchanged. True surgical patching. |
-| `list_directory` | Lists the contents of a directory to explore the codebase. |
-| `execute_shell` | Executes shell commands from allowlist. Read-only commands run without approval; write operations require user confirmation. |
-| `semantic_search` | Performs a semantic search for functions based on a natural language query describing their purpose, returning a list of potential matches with similarity scores. |
-| `get_function_source` | Retrieves the source code for a specific function or method using its internal node ID, typically obtained from a semantic search result. |
-| `get_code_snippet` | Retrieves the source code for a specific function, class, or method using its full qualified name. |
-| `structural_search` | Search code by AST pattern using ast-grep syntax (not text/regex). Patterns use metavariables: $NAME matches one node, $$$NAME matches many (e.g. 'print($A)', 'def $F($$$ARGS): $$$BODY'). Returns file:line:column and the matched code. Optional 'language' (e.g. 'python', 'typescript', 'csharp') restricts the search. |
-| `structural_replace` | Rewrite code by AST pattern using ast-grep syntax. Give a 'pattern' to match and a 'rewrite' template; metavariables captured by the pattern ($A, $$$ARGS) are substituted into the rewrite. Defaults to dry_run=True, which returns a diff without touching files; call again with dry_run=false to apply. Optional 'language' restricts the rewrite to one language. |
-<!-- /SECTION:agentic_tools -->
-
-### Intelligent and Safe File Editing
-
-The agent uses AST-based function targeting with Tree-sitter for precise code modifications. Features include:
-- **Visual diff preview** before changes
-- **Surgical patching** that only modifies target code blocks
-- **Multi-language support** across all supported languages
-- **Security sandbox** preventing edits outside project directory
-- **Smart function matching** with qualified names and line numbers
-
-
-
-## 🌍 Multi-Language Support
-
-### Adding New Languages
-
-Code-Graph-RAG makes it easy to add support for any language that has a Tree-sitter grammar. The system automatically handles grammar compilation and integration.
-
-> **⚠️ Recommendation**: While you can add languages yourself, we recommend waiting for official full support to ensure optimal parsing quality, comprehensive feature coverage, and robust integration. The languages marked as "In Development" above will receive dedicated optimization and testing.
-
-> **💡 Request Support**: If you want a specific language to be officially supported, please [submit an issue](https://github.com/vitali87/code-graph-rag/issues) with your language request.
-
-#### Quick Start: Add a Language
-
-Use the built-in language management tool to add any Tree-sitter supported language:
-
-```bash
-# Add a language using the standard tree-sitter repository
-cgr language add-grammar <language-name>
-
-# Examples:
-cgr language add-grammar c-sharp
-cgr language add-grammar php
-cgr language add-grammar ruby
-cgr language add-grammar kotlin
-```
-
-#### Custom Grammar Repositories
-
-For languages hosted outside the standard tree-sitter organization:
-
-```bash
-# Add a language from a custom repository
-cgr language add-grammar --grammar-url https://github.com/custom/tree-sitter-mylang
-```
-
-#### What Happens Automatically
-
-When you add a language, the tool automatically:
-
-1. **Downloads the Grammar**: Clones the tree-sitter grammar repository as a git submodule
-2. **Detects Configuration**: Auto-extracts language metadata from `tree-sitter.json`
-3. **Analyzes Node Types**: Automatically identifies AST node types for:
-   - Functions/methods (`method_declaration`, `function_definition`, etc.)
-   - Classes/structs (`class_declaration`, `struct_declaration`, etc.)
-   - Modules/files (`compilation_unit`, `source_file`, etc.)
-   - Function calls (`call_expression`, `method_invocation`, etc.)
-4. **Compiles Bindings**: Builds Python bindings from the grammar source
-5. **Updates Configuration**: Adds the language to `codebase_rag/language_config.py`
-6. **Enables Parsing**: Makes the language immediately available for codebase analysis
-
-#### Example: Adding C# Support
-
-```bash
-$ cgr language add-grammar c-sharp
-🔍 Using default tree-sitter URL: https://github.com/tree-sitter/tree-sitter-c-sharp
-🔄 Adding submodule from https://github.com/tree-sitter/tree-sitter-c-sharp...
-✅ Successfully added submodule at grammars/tree-sitter-c-sharp
-Auto-detected language: c-sharp
-Auto-detected file extensions: ['cs']
-Auto-detected node types:
-Functions: ['destructor_declaration', 'method_declaration', 'constructor_declaration']
-Classes: ['struct_declaration', 'enum_declaration', 'interface_declaration', 'class_declaration']
-Modules: ['compilation_unit', 'file_scoped_namespace_declaration', 'namespace_declaration']
-Calls: ['invocation_expression']
-
-✅ Language 'c-sharp' has been added to the configuration!
-📝 Updated codebase_rag/language_config.py
-```
-
-#### Managing Languages
-
-```bash
-# List all configured languages
-cgr language list-languages
-
-# Remove a language (this also removes the git submodule unless --keep-submodule is specified)
-cgr language remove-language <language-name>
-```
-
-#### Language Configuration
-
-The system uses a configuration-driven approach for language support. Each language is defined in `codebase_rag/language_config.py` with the following structure:
-
-```python
-"language-name": LanguageConfig(
-    name="language-name",
-    file_extensions=[".ext1", ".ext2"],
-    function_node_types=["function_declaration", "method_declaration"],
-    class_node_types=["class_declaration", "struct_declaration"],
-    module_node_types=["compilation_unit", "source_file"],
-    call_node_types=["call_expression", "method_invocation"],
-),
-```
-
-#### Troubleshooting
-
-**Grammar not found**: If the automatic URL doesn't work, use a custom URL:
-```bash
-cgr language add-grammar --grammar-url https://github.com/custom/tree-sitter-mylang
-```
-
-**Version incompatibility**: If you get "Incompatible Language version" errors, update your tree-sitter package:
-```bash
-uv add tree-sitter@latest
-```
-
-**Missing node types**: The tool automatically detects common node patterns, but you can manually adjust the configuration in `language_config.py` if needed.
-
-## 📦 Building a binary
-
-You can build a binary of the application using the `build_binary.py` script. This script uses PyInstaller to package the application and its dependencies into a single executable.
-
-```bash
-python build_binary.py
-```
-The resulting binary will be located in the `dist` directory.
-
-## 🐛 Debugging
-
-1. **Check Memgraph connection**:
-   - Ensure Docker containers are running: `docker-compose ps`
-   - Verify Memgraph is accessible on port 7687
-
-2. **View database in Memgraph Lab**:
-   - Open http://localhost:3000
-   - Connect to memgraph:7687
-
-3. **For local models**:
-   - Verify Ollama is running: `ollama list`
-   - Check if models are downloaded: `ollama pull llama3`
-   - Test Ollama API: `curl http://localhost:11434/v1/models`
-   - Check Ollama logs: `ollama logs`
-
-## 🤝 Contributing
-
-Please see [CONTRIBUTING.md](CONTRIBUTING.md) for detailed contribution guidelines.
-
-Good first PRs are from TODO issues.
-
-## 🙋‍♂️ Support
-
-For issues or questions:
-1. Check the logs for error details
-2. Verify Memgraph connection
-3. Ensure all environment variables are set
-4. Review the graph schema matches your expectations
-
-## 💼 Enterprise Services
+The [Quick Start](docs/getting-started/quickstart.md) guide walks through parsing, querying, and exporting in five minutes.
+
+## MCP Server
+
+Code-Graph-RAG runs as an [MCP](https://modelcontextprotocol.io) server so Claude Code and other MCP clients can query and edit your codebase directly. See the [MCP Server](docs/guide/mcp-server.md) guide for setup.
+
+## Documentation
+
+**Getting Started**
+- [Installation](docs/getting-started/installation.md)
+- [Quick Start](docs/getting-started/quickstart.md)
+- [Configuration](docs/getting-started/configuration.md)
+
+**User Guide**
+- [CLI Reference](docs/guide/cli-reference.md)
+- [Interactive Querying](docs/guide/interactive-querying.md)
+- [Code Optimization](docs/guide/code-optimization.md)
+- [Dead Code Detection](docs/guide/dead-code.md)
+- [Graph Export](docs/guide/graph-export.md)
+- [Real-Time Updates](docs/guide/realtime-updates.md)
+- [MCP Server](docs/guide/mcp-server.md)
+
+**Architecture**
+- [Overview](docs/architecture/overview.md)
+- [Graph Schema](docs/architecture/graph-schema.md)
+- [Language Support](docs/architecture/language-support.md)
+- [Data-Flow Edges](docs/architecture/data-flow-edges.md)
+
+**Python SDK**
+- [Overview](docs/sdk/overview.md)
+- [Graph Loader](docs/sdk/graph-loader.md)
+- [Cypher Generator](docs/sdk/cypher-generator.md)
+- [Semantic Search](docs/sdk/semantic-search.md)
+
+**Advanced**
+- [Adding Languages](docs/advanced/adding-languages.md)
+- [Ignore Patterns](docs/advanced/ignore-patterns.md)
+- [Building Binaries](docs/advanced/building-binaries.md)
+- [Troubleshooting](docs/advanced/troubleshooting.md)
+
+## Enterprise Services
 
 Code-Graph-RAG is open source and free to use. For organizations that need more, we offer **fully managed cloud-hosted solutions** and **on-premise deployments**:
 
-- **Cloud-Hosted Deployment** — Managed cloud infrastructure for both the graph database and AI agent connection. Zero infrastructure overhead — we handle scaling, updates, and availability so your team can focus on building.
-- **On-Premise & Air-Gapped Deployment** — Deploy Code-Graph-RAG entirely within your own environment, including air-gapped networks. Full data sovereignty for regulated industries and security-sensitive organizations.
+- **Cloud-Hosted Deployment**: Managed cloud infrastructure for both the graph database and the AI agent connection. Zero infrastructure overhead, so we handle scaling, updates, and availability while your team focuses on building.
+- **On-Premise & Air-Gapped Deployment**: Deploy Code-Graph-RAG entirely within your own environment, including air-gapped networks. Full data sovereignty for regulated industries and security-sensitive organizations.
 
 We also offer custom development, integration consulting, technical support contracts, and team training.
 
-**[View plans & pricing at code-graph-rag.com →](https://code-graph-rag.com/enterprise)**
+**[View plans & pricing at code-graph-rag.com](https://code-graph-rag.com/enterprise)**
+
+## Contributing
+
+Please see [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines. Good first PRs come from the TODO issues.
+
+## Support
+
+For issues or questions, check the [Troubleshooting](docs/advanced/troubleshooting.md) guide first, then open an issue.
+
+## License
+
+MIT. See [LICENSE](LICENSE).
 
 ## Star History
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -113,3 +113,29 @@ cgr doctor
 ```
 
 This checks that all required dependencies and services are available.
+
+## Key Dependencies
+
+<!-- SECTION:dependencies -->
+- **loguru**: Python logging made (stupidly) simple
+- **mcp**: Model Context Protocol SDK
+- **pydantic-ai**: AI Agent Framework, the Pydantic way
+- **pydantic-settings**: Settings management using Pydantic
+- **pymgclient**: Memgraph database adapter for Python language
+- **python-dotenv**: Read key-value pairs from a .env file and set them as environment variables
+- **tiktoken**: tiktoken is a fast BPE tokeniser for use with OpenAI's models
+- **toml**: Python Library for Tom's Obvious, Minimal Language
+- **tree-sitter-python**: Python grammar for tree-sitter
+- **tree-sitter**: Python bindings to the Tree-sitter parsing library
+- **watchdog**: Filesystem events monitoring
+- **typer**: Typer, build great CLIs. Easy to code. Based on Python type hints.
+- **rich**: Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal
+- **prompt-toolkit**: Library for building powerful interactive command lines in Python
+- **diff-match-patch**: Repackaging of Google's Diff Match and Patch libraries.
+- **click**: Composable command line interface toolkit
+- **protobuf**
+- **defusedxml**: XML bomb protection for Python stdlib modules
+- **huggingface-hub**: Client library to download and publish models, datasets and other repos on the huggingface.co hub
+- **griffe**: Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API.
+- **pathspec**: Utility library for gitignore style pattern matching of file paths.
+<!-- /SECTION:dependencies -->

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -92,10 +92,10 @@ This installs all dependencies and sets up pre-commit hooks automatically.
 ## Start Memgraph
 
 ```bash
-docker compose up -d
+cgr daemon up
 ```
 
-This starts the Memgraph database on port 7687 and Memgraph Lab on port 3000.
+This starts the packaged Memgraph + Qdrant stack and waits until it is healthy. It works the same whether you installed from PyPI or from source, since the compose file ships inside the package. Memgraph listens on port 7687 and Memgraph Lab on port 3000.
 
 ## Set Up Environment Variables
 

--- a/docs/guide/interactive-querying.md
+++ b/docs/guide/interactive-querying.md
@@ -74,18 +74,21 @@ instead of locally, set `CGR_EMBEDDING_PROVIDER=openai`; see
 
 The interactive agent has access to these tools:
 
+<!-- SECTION:agentic_tools -->
 | Tool | Description |
-|------|-------------|
-| `query_graph` | Query the knowledge graph using natural language |
-| `read_file` | Read the content of text-based files |
-| `create_file` | Create a new file with content |
-| `replace_code` | Surgically replace specific code blocks |
-| `list_directory` | List directory contents |
-| `analyze_document` | Analyze documents (PDFs, images) |
-| `execute_shell` | Execute shell commands from allowlist |
-| `semantic_search` | Semantic function search by description |
-| `get_function_source` | Retrieve source code by node ID |
-| `get_code_snippet` | Retrieve source code by qualified name |
+|----|-----------|
+| `query_graph` | Query the codebase knowledge graph using natural language questions. Ask in plain English about classes, functions, methods, dependencies, or code structure. Examples: 'Find all functions that call each other', 'What classes are in the user module', 'Show me functions with the longest call chains'. |
+| `read_file` | Reads the content of text-based files. Images and PDFs the user references are attached inline; read them directly. |
+| `create_file` | Creates a new file with content. IMPORTANT: Check file existence first! Overwrites completely WITHOUT showing diff. Use only for new files, not existing file modifications. |
+| `replace_code` | Surgically replaces specific code blocks in files. Requires exact target code and replacement. Only modifies the specified block, leaving rest of file unchanged. True surgical patching. |
+| `list_directory` | Lists the contents of a directory to explore the codebase. |
+| `execute_shell` | Executes shell commands from allowlist. Read-only commands run without approval; write operations require user confirmation. |
+| `semantic_search` | Performs a semantic search for functions based on a natural language query describing their purpose, returning a list of potential matches with similarity scores. |
+| `get_function_source` | Retrieves the source code for a specific function or method using its internal node ID, typically obtained from a semantic search result. |
+| `get_code_snippet` | Retrieves the source code for a specific function, class, or method using its full qualified name. |
+| `structural_search` | Search code by AST pattern using ast-grep syntax (not text/regex). Patterns use metavariables: $NAME matches one node, $$$NAME matches many (e.g. 'print($A)', 'def $F($$$ARGS): $$$BODY'). Returns file:line:column and the matched code. Optional 'language' (e.g. 'python', 'typescript', 'csharp') restricts the search. |
+| `structural_replace` | Rewrite code by AST pattern using ast-grep syntax. Give a 'pattern' to match and a 'rewrite' template; metavariables captured by the pattern ($A, $$$ARGS) are substituted into the rewrite. Defaults to dry_run=True, which returns a diff without touching files; call again with dry_run=false to apply. Optional 'language' restricts the rewrite to one language. |
+<!-- /SECTION:agentic_tools -->
 
 ## Intelligent File Editing
 

--- a/scripts/generate_readme.py
+++ b/scripts/generate_readme.py
@@ -12,6 +12,8 @@ TARGET_FILES = (
     "README.md",
     "docs/architecture/language-support.md",
     "docs/guide/mcp-server.md",
+    "docs/guide/interactive-querying.md",
+    "docs/getting-started/installation.md",
 )
 
 SECTION_PATTERN = re.compile(

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.409"
+version = "0.0.410"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

Restructures `README.md` from a 1090-line technical dump into a concise product overview, deferring detail to the existing `docs/` tree (reference style).

## Why

The README read like a spec sheet pasted into a landing page. This makes it a product description first: what it does, how it works, install, run, then links out.

## Changes

- **README 1090 -> 193 lines.** Sections: pitch + demo, Latest News, What It Does, How It Works (two components + data-flow diagram), Supported Languages, Installation, Quick Start, MCP Server, a grouped **Documentation** index, Enterprise, Contributing, Support, License, star/fork history.
- **No content lost.** Every trimmed section already had a home under `docs/`; the README now links to it instead of inlining it.
- **Auto-generation preserved.** The two generated tables that lived only in README (`agentic_tools`, `dependencies`) moved into `docs/guide/interactive-querying.md` and `docs/getting-started/installation.md`, and those files were registered with the generator. The previously hand-written agentic-tools table was stale (missing `structural_search`/`structural_replace`, listing a nonexistent `analyze_document`); it is now auto-generated and correct.

## Verification

- All 31 README doc links resolve.
- Pre-commit green; the README generator is idempotent on the new layout.
- `docs/index.md` and `mkdocs.yml` untouched.