### PR TITLE
feat(parsers): ast-grep pattern-driven language tier with Ruby support

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -21,6 +21,7 @@ from .language_spec import (
 )
 from .parser_fingerprint import compute_parser_fingerprint
 from .parser_loader import COMBINED_FUNC_CLASS_IMPORT_QUERIES
+from .parsers.ast_grep_tier import AstGrepTier
 from .parsers.cpp.preproc_recovery import parse_with_preproc_recovery
 from .parsers.cpp_frontend import (
     cpp_frontend_available,
@@ -568,6 +569,9 @@ class GraphUpdater:
             exclude_paths=self.exclude_paths,
             capture=self.capture,
         )
+        # (H) Fallback structural tier for languages with no tree-sitter
+        # (H) LanguageSpec (e.g. Ruby), driven by ast-grep pattern configs.
+        self.ast_grep_tier = AstGrepTier(self._sink, self.repo_path, self.project_name)
 
     def _run_cpp_frontend(self) -> None:
         # (H) Optional libclang C++ pre-pass when a compile_commands.json is
@@ -1684,6 +1688,10 @@ class GraphUpdater:
                 self._parsed_files.append((filepath, language))
         elif self._is_dependency_file(filepath.name, filepath):
             self.factory.definition_processor.process_dependencies(filepath)
+        elif self.ast_grep_tier.handles(filepath.suffix):
+            self.ast_grep_tier.process_file(
+                filepath, self.factory.structure_processor.structural_elements
+            )
 
         self.factory.structure_processor.process_generic_file(filepath, filepath.name)
 

--- a/codebase_rag/parsers/ast_grep_patterns/README.md
+++ b/codebase_rag/parsers/ast_grep_patterns/README.md
@@ -1,0 +1,59 @@
+# ast-grep language patterns
+
+Basic structural support for a language that has **no tree-sitter `LanguageSpec`**
+in cgr can be added with a single YAML file here, instead of a hand-written
+tree-sitter traversal. The `AstGrepTier` (`../ast_grep_tier.py`) loads every
+`*.yaml` in this directory and, for files whose extension matches, emits
+`Module`, `Function`, and `Class` nodes plus `DEFINES` and `IMPORTS`
+relationships, using [ast-grep](https://ast-grep.github.io/) patterns.
+
+This is a **basic** tier: names are flat (no nested-namespace qualification) and
+there is no call-graph (`CALLS`) resolution. Languages that need that get a full
+tree-sitter `LanguageSpec`. The tier is active only when the `ast-grep` extra is
+installed (`pip install code-graph-rag[ast-grep]`); otherwise it is a no-op.
+
+## Config format
+
+```yaml
+language: ruby          # human-readable name (documentation only)
+ast_grep_id: ruby       # ast-grep language id (see AST_GREP_LANGUAGES)
+extensions:             # file extensions routed to this config
+  - ".rb"
+functions:              # patterns whose match becomes a Function node
+  - "def self.$NAME"
+  - "def $NAME"
+classes:                # patterns whose match becomes a Class node
+  - "class $NAME"
+  - "module $NAME"
+imports:                # patterns whose match becomes an IMPORTS edge
+  - "require $PATH"
+  - "require_relative $PATH"
+```
+
+`extensions` and `ast_grep_id` are required; the pattern lists are optional.
+
+## Metavariable conventions
+
+- Definition patterns (`functions`, `classes`) must capture the name as **`$NAME`**.
+- Import patterns must capture the imported path as **`$PATH`** (surrounding
+  quotes are stripped automatically).
+
+## Ordering
+
+Patterns are tried in order and **the first pattern to match a source line
+claims it**. Put specific patterns before general ones so, for example,
+`def self.$NAME` (captures `build`) wins over `def $NAME` (would capture `self`)
+for `def self.build`.
+
+## Testing a new language
+
+Write patterns against a snippet first:
+
+```python
+from ast_grep_py import SgRoot
+root = SgRoot(source, "ruby").root()
+for node in root.find_all(pattern="def $NAME"):
+    print(node.get_match("NAME").text(), node.range().start.line + 1)
+```
+
+Then add an end-to-end test mirroring `tests/test_ast_grep_tier.py`.

--- a/codebase_rag/parsers/ast_grep_patterns/ruby.yaml
+++ b/codebase_rag/parsers/ast_grep_patterns/ruby.yaml
@@ -1,0 +1,21 @@
+# ast-grep pattern config for Ruby (issue #414).
+# Ruby has no tree-sitter LanguageSpec in cgr, so the ast-grep tier extracts
+# structural nodes from these patterns. See README.md for the format.
+#
+# Convention: definition patterns capture the name as $NAME; import patterns
+# capture the imported path as $PATH. Patterns are tried in order; the first
+# pattern to match a given source line claims it (so put specific patterns,
+# like `def self.$NAME`, before general ones, like `def $NAME`).
+language: ruby
+ast_grep_id: ruby
+extensions:
+  - ".rb"
+functions:
+  - "def self.$NAME"
+  - "def $NAME"
+classes:
+  - "class $NAME"
+  - "module $NAME"
+imports:
+  - "require $PATH"
+  - "require_relative $PATH"

--- a/codebase_rag/parsers/ast_grep_tier.py
+++ b/codebase_rag/parsers/ast_grep_tier.py
@@ -125,26 +125,54 @@ class AstGrepTier:
             (cs.NodeLabel.FUNCTION, config.functions),
             (cs.NodeLabel.CLASS, config.classes),
         ):
-            claimed: set[int] = set()
-            for pattern in patterns:
-                for node in self._find_all(root, pattern, file_path):
-                    name_node = node.get_match(_NAME_METAVAR)
-                    if name_node is None:
-                        continue
-                    line = node.range().start.line
-                    if line in claimed:
-                        continue
-                    claimed.add(line)
-                    self._emit_definition(
-                        label,
-                        name_node.text(),
-                        node,
-                        module_qn,
-                        relative_path,
-                        absolute_path,
-                    )
+            self._extract_definitions(
+                root,
+                label,
+                patterns,
+                file_path,
+                module_qn,
+                relative_path,
+                absolute_path,
+            )
+        self._extract_imports(root, config.imports, file_path, module_qn)
 
-        for pattern in config.imports:
+    def _extract_definitions(
+        self,
+        root: SgNode,
+        label: cs.NodeLabel,
+        patterns: tuple[str, ...],
+        file_path: Path,
+        module_qn: str,
+        relative_path: str,
+        absolute_path: str,
+    ) -> None:
+        claimed: set[int] = set()
+        for pattern in patterns:
+            for node in self._find_all(root, pattern, file_path):
+                name_node = node.get_match(_NAME_METAVAR)
+                if name_node is None:
+                    continue
+                line = node.range().start.line
+                if line in claimed:
+                    continue
+                claimed.add(line)
+                self._emit_definition(
+                    label,
+                    name_node.text(),
+                    node,
+                    module_qn,
+                    relative_path,
+                    absolute_path,
+                )
+
+    def _extract_imports(
+        self,
+        root: SgNode,
+        patterns: tuple[str, ...],
+        file_path: Path,
+        module_qn: str,
+    ) -> None:
+        for pattern in patterns:
             for node in self._find_all(root, pattern, file_path):
                 target_node = node.get_match(_PATH_METAVAR)
                 if target_node is not None:
@@ -180,13 +208,12 @@ class AstGrepTier:
         )
         parent_rel_path = relative_path.parent
         parent_container_qn = structural_elements.get(parent_rel_path)
-        parent = (
-            (cs.NodeLabel.PACKAGE, cs.KEY_QUALIFIED_NAME, parent_container_qn)
-            if parent_container_qn
-            else (cs.NodeLabel.FOLDER, cs.KEY_PATH, parent_rel_path.as_posix())
-            if parent_rel_path != Path(".")
-            else (cs.NodeLabel.PROJECT, cs.KEY_NAME, self._project_name)
-        )
+        if parent_container_qn:
+            parent = (cs.NodeLabel.PACKAGE, cs.KEY_QUALIFIED_NAME, parent_container_qn)
+        elif parent_rel_path != Path("."):
+            parent = (cs.NodeLabel.FOLDER, cs.KEY_PATH, parent_rel_path.as_posix())
+        else:
+            parent = (cs.NodeLabel.PROJECT, cs.KEY_NAME, self._project_name)
         self._ingestor.ensure_relationship_batch(
             parent,
             cs.RelationshipType.CONTAINS_MODULE,

--- a/codebase_rag/parsers/ast_grep_tier.py
+++ b/codebase_rag/parsers/ast_grep_tier.py
@@ -48,6 +48,8 @@ def load_pattern_configs() -> dict[str, _LangConfig]:
             raise ValueError(
                 f"{path.name}: 'extensions' and 'ast_grep_id' are required"
             )
+        if isinstance(extensions, str):
+            extensions = [ext.strip() for ext in extensions.split(",") if ext.strip()]
         config = _LangConfig(
             ast_grep_id=str(ast_grep_id),
             functions=tuple(data.get("functions") or ()),
@@ -84,6 +86,11 @@ class AstGrepTier:
             # (H) ast-grep/pyyaml are the [ast-grep] extra; no-op if absent.
             logger.warning("ast-grep-py unavailable; ast-grep language tier disabled")
             self._configs = {}
+        except Exception as exc:  # noqa: BLE001
+            # (H) a malformed shipped config must not crash GraphUpdater
+            # (H) construction; disable the tier and surface the reason.
+            logger.warning("ast-grep language tier disabled: %s", exc)
+            self._configs = {}
 
     def handles(self, suffix: str) -> bool:
         return suffix in self._configs
@@ -110,13 +117,15 @@ class AstGrepTier:
         relative_path = cached_relative_path(file_path, self._repo_path).as_posix()
         absolute_path = cached_resolve_posix(file_path)
 
-        # (H) Functions then classes, deduped by start line so a specific pattern
-        # (H) (def self.$NAME) wins over a general one (def $NAME) on the same line.
-        claimed: set[int] = set()
+        # (H) Functions then classes; dedupe by start line PER label so a specific
+        # (H) pattern (def self.$NAME) wins over a general one (def $NAME) on the
+        # (H) same line, while a class and a function sharing a line (one-liners)
+        # (H) both still land.
         for label, patterns in (
             (cs.NodeLabel.FUNCTION, config.functions),
             (cs.NodeLabel.CLASS, config.classes),
         ):
+            claimed: set[int] = set()
             for pattern in patterns:
                 for node in self._find_all(root, pattern, file_path):
                     name_node = node.get_match(_NAME_METAVAR)

--- a/codebase_rag/parsers/ast_grep_tier.py
+++ b/codebase_rag/parsers/ast_grep_tier.py
@@ -1,0 +1,239 @@
+# (H) ast-grep pattern-driven language tier (issue #414). For languages with no
+# (H) tree-sitter LanguageSpec, this extracts Module/Function/Class nodes and
+# (H) DEFINES/IMPORTS edges from per-language YAML pattern configs, so adding a
+# (H) new language is a config file rather than a hand-written tree-sitter
+# (H) traversal. It is a BASIC structural tier: names are flat (no nested
+# (H) namespace qualification) and there is no call-graph resolution.
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .. import constants as cs
+from ..utils.path_utils import cached_relative_path, cached_resolve_posix
+
+if TYPE_CHECKING:
+    from ast_grep_py import SgNode
+
+    from ..services import IngestorProtocol
+
+logger = logging.getLogger(__name__)
+
+_PATTERNS_DIR = Path(__file__).parent / "ast_grep_patterns"
+# (H) Metavar conventions contributors must follow in the YAML patterns.
+_NAME_METAVAR = "NAME"
+_PATH_METAVAR = "PATH"
+
+
+@dataclass(frozen=True)
+class _LangConfig:
+    ast_grep_id: str
+    functions: tuple[str, ...]
+    classes: tuple[str, ...]
+    imports: tuple[str, ...]
+
+
+def load_pattern_configs() -> dict[str, _LangConfig]:
+    """Load every ast_grep_patterns/*.yaml, keyed by file extension."""
+    import yaml
+
+    configs: dict[str, _LangConfig] = {}
+    for path in sorted(_PATTERNS_DIR.glob("*.yaml")):
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        extensions = data.get("extensions")
+        ast_grep_id = data.get("ast_grep_id")
+        if not extensions or not ast_grep_id:
+            raise ValueError(
+                f"{path.name}: 'extensions' and 'ast_grep_id' are required"
+            )
+        config = _LangConfig(
+            ast_grep_id=str(ast_grep_id),
+            functions=tuple(data.get("functions") or ()),
+            classes=tuple(data.get("classes") or ()),
+            imports=tuple(data.get("imports") or ()),
+        )
+        for extension in extensions:
+            configs[extension] = config
+    return configs
+
+
+def _strip_quotes(text: str) -> str:
+    if len(text) >= 2 and text[0] in "\"'" and text[-1] == text[0]:
+        return text[1:-1]
+    return text
+
+
+class AstGrepTier:
+    """Structural extractor for languages without a tree-sitter LanguageSpec."""
+
+    __slots__ = ("_ingestor", "_repo_path", "_project_name", "_configs")
+
+    def __init__(
+        self, ingestor: IngestorProtocol, repo_path: Path, project_name: str
+    ) -> None:
+        self._ingestor = ingestor
+        self._repo_path = repo_path
+        self._project_name = project_name
+        try:
+            import ast_grep_py  # noqa: F401
+
+            self._configs = load_pattern_configs()
+        except ImportError:
+            # (H) ast-grep/pyyaml are the [ast-grep] extra; no-op if absent.
+            logger.warning("ast-grep-py unavailable; ast-grep language tier disabled")
+            self._configs = {}
+
+    def handles(self, suffix: str) -> bool:
+        return suffix in self._configs
+
+    def process_file(
+        self, file_path: Path, structural_elements: dict[Path, str | None]
+    ) -> None:
+        config = self._configs.get(file_path.suffix)
+        if config is None:
+            return
+        try:
+            source = file_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            return
+        from ast_grep_py import SgRoot
+
+        try:
+            root = SgRoot(source, config.ast_grep_id).root()
+        except (RuntimeError, ValueError) as exc:
+            logger.warning("ast-grep failed to parse %s: %s", file_path, exc)
+            return
+
+        module_qn = self._emit_module(file_path, structural_elements)
+        relative_path = cached_relative_path(file_path, self._repo_path).as_posix()
+        absolute_path = cached_resolve_posix(file_path)
+
+        # (H) Functions then classes, deduped by start line so a specific pattern
+        # (H) (def self.$NAME) wins over a general one (def $NAME) on the same line.
+        claimed: set[int] = set()
+        for label, patterns in (
+            (cs.NodeLabel.FUNCTION, config.functions),
+            (cs.NodeLabel.CLASS, config.classes),
+        ):
+            for pattern in patterns:
+                for node in self._find_all(root, pattern, file_path):
+                    name_node = node.get_match(_NAME_METAVAR)
+                    if name_node is None:
+                        continue
+                    line = node.range().start.line
+                    if line in claimed:
+                        continue
+                    claimed.add(line)
+                    self._emit_definition(
+                        label,
+                        name_node.text(),
+                        node,
+                        module_qn,
+                        relative_path,
+                        absolute_path,
+                    )
+
+        for pattern in config.imports:
+            for node in self._find_all(root, pattern, file_path):
+                target_node = node.get_match(_PATH_METAVAR)
+                if target_node is not None:
+                    self._emit_import(_strip_quotes(target_node.text()), module_qn)
+
+    def _find_all(self, root: SgNode, pattern: str, file_path: Path) -> list[SgNode]:
+        try:
+            return root.find_all(pattern=pattern)
+        except RuntimeError as exc:
+            logger.warning(
+                "bad ast-grep pattern %r for %s: %s", pattern, file_path, exc
+            )
+            return []
+
+    def _emit_module(
+        self, file_path: Path, structural_elements: dict[Path, str | None]
+    ) -> str:
+        relative_path = cached_relative_path(file_path, self._repo_path)
+        # (H) flat module qn, no init/mod special-case or stem
+        # (H) disambiguation; add if a config language collides with another
+        # (H) file's stem in the same directory.
+        module_qn = cs.SEPARATOR_DOT.join(
+            [self._project_name, *relative_path.with_suffix("").parts]
+        )
+        self._ingestor.ensure_node_batch(
+            cs.NodeLabel.MODULE,
+            {
+                cs.KEY_QUALIFIED_NAME: module_qn,
+                cs.KEY_NAME: file_path.name,
+                cs.KEY_PATH: relative_path.as_posix(),
+                cs.KEY_ABSOLUTE_PATH: cached_resolve_posix(file_path),
+            },
+        )
+        parent_rel_path = relative_path.parent
+        parent_container_qn = structural_elements.get(parent_rel_path)
+        parent = (
+            (cs.NodeLabel.PACKAGE, cs.KEY_QUALIFIED_NAME, parent_container_qn)
+            if parent_container_qn
+            else (cs.NodeLabel.FOLDER, cs.KEY_PATH, parent_rel_path.as_posix())
+            if parent_rel_path != Path(".")
+            else (cs.NodeLabel.PROJECT, cs.KEY_NAME, self._project_name)
+        )
+        self._ingestor.ensure_relationship_batch(
+            parent,
+            cs.RelationshipType.CONTAINS_MODULE,
+            (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, module_qn),
+        )
+        return module_qn
+
+    def _emit_definition(
+        self,
+        label: cs.NodeLabel,
+        name: str,
+        node: SgNode,
+        module_qn: str,
+        relative_path: str,
+        absolute_path: str,
+    ) -> None:
+        qualified_name = f"{module_qn}{cs.SEPARATOR_DOT}{name}"
+        node_range = node.range()
+        self._ingestor.ensure_node_batch(
+            label,
+            {
+                cs.KEY_QUALIFIED_NAME: qualified_name,
+                cs.KEY_NAME: name,
+                cs.KEY_MODIFIERS: [],
+                cs.KEY_DECORATORS: [],
+                cs.KEY_START_LINE: node_range.start.line + 1,
+                cs.KEY_END_LINE: node_range.end.line + 1,
+                cs.KEY_DOCSTRING: None,
+                # (H) no visibility analysis for these languages; mark
+                # (H) exported so dead-code does not false-flag everything.
+                cs.KEY_IS_EXPORTED: True,
+                cs.KEY_PATH: relative_path,
+                cs.KEY_ABSOLUTE_PATH: absolute_path,
+            },
+        )
+        self._ingestor.ensure_relationship_batch(
+            (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, module_qn),
+            cs.RelationshipType.DEFINES,
+            (label, cs.KEY_QUALIFIED_NAME, qualified_name),
+        )
+
+    def _emit_import(self, target: str, module_qn: str) -> None:
+        if not target:
+            return
+        # (H) every require target is treated as an external module; local
+        # (H) require_relative resolution needs path handling this tier skips.
+        self._ingestor.ensure_node_batch(
+            cs.NodeLabel.EXTERNAL_MODULE,
+            {
+                cs.KEY_NAME: target,
+                cs.KEY_QUALIFIED_NAME: target,
+                cs.KEY_PATH: target,
+            },
+        )
+        self._ingestor.ensure_relationship_batch(
+            (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, module_qn),
+            cs.RelationshipType.IMPORTS,
+            (cs.NodeLabel.EXTERNAL_MODULE, cs.KEY_QUALIFIED_NAME, target),
+        )

--- a/codebase_rag/tests/test_ast_grep_tier.py
+++ b/codebase_rag/tests/test_ast_grep_tier.py
@@ -1,0 +1,126 @@
+# (H) ast-grep pattern-driven language tier (issue #414). Languages without a
+# (H) tree-sitter LanguageSpec (here: Ruby) are extracted structurally from
+# (H) per-language YAML pattern configs, emitting the same Module/Function/Class
+# (H) nodes and DEFINES/IMPORTS relationships the tree-sitter path emits. These
+# (H) tests index a real .rb file end to end and assert those nodes/edges land.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+FUNCTION = cs.NodeLabel.FUNCTION.value
+CLASS = cs.NodeLabel.CLASS.value
+MODULE = cs.NodeLabel.MODULE.value
+DEFINES = cs.RelationshipType.DEFINES.value
+IMPORTS = cs.RelationshipType.IMPORTS.value
+
+RUBY = (
+    'require "json"\n'
+    'require_relative "helper"\n'
+    "\n"
+    "module Greeter\n"
+    "  class Formal\n"
+    "    def self.build\n"
+    "      new\n"
+    "    end\n"
+    "    def greet(name)\n"
+    '      "Hello, #{name}"\n'
+    "    end\n"
+    "  end\n"
+    "end\n"
+    "\n"
+    "def bare_method\n"
+    "  42\n"
+    "end\n"
+)
+
+
+def _run(tmp_path: Path, files: dict[str, str]) -> MagicMock:
+    parsers, queries = load_parsers()
+    for rel, content in files.items():
+        (tmp_path / rel).write_text(content, encoding="utf-8")
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock, repo_path=tmp_path, parsers=parsers, queries=queries
+    ).run()
+    return mock
+
+
+def _node_names(mock: MagicMock, label: str) -> set[str]:
+    return {
+        c.args[1].get(cs.KEY_NAME)
+        for c in mock.ensure_node_batch.call_args_list
+        if str(c.args[0]) == label
+    }
+
+
+def _rels(mock: MagicMock, rel_type: str) -> set[tuple[str, str]]:
+    return {
+        (c.args[0][2], c.args[2][2])
+        for c in mock.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) == rel_type
+    }
+
+
+def test_ruby_functions_extracted(tmp_path: Path) -> None:
+    mock = _run(tmp_path, {"greeter.rb": RUBY})
+    names = _node_names(mock, FUNCTION)
+    assert {"greet", "build", "bare_method"} <= names, names
+
+
+def test_ruby_classes_and_modules_extracted(tmp_path: Path) -> None:
+    mock = _run(tmp_path, {"greeter.rb": RUBY})
+    names = _node_names(mock, CLASS)
+    assert {"Formal", "Greeter"} <= names, names
+
+
+def test_ruby_module_node_emitted(tmp_path: Path) -> None:
+    mock = _run(tmp_path, {"greeter.rb": RUBY})
+    assert "greeter.rb" in _node_names(mock, MODULE)
+
+
+def test_ruby_defines_edges(tmp_path: Path) -> None:
+    mock = _run(tmp_path, {"greeter.rb": RUBY})
+    defined = {to for _from, to in _rels(mock, DEFINES)}
+    assert any(qn.endswith(".bare_method") for qn in defined), defined
+    assert any(qn.endswith(".Formal") for qn in defined), defined
+
+
+def test_ruby_imports_edges(tmp_path: Path) -> None:
+    mock = _run(tmp_path, {"greeter.rb": RUBY})
+    targets = {to for _from, to in _rels(mock, IMPORTS)}
+    assert any(t.endswith("json") for t in targets), targets
+    assert any(t.endswith("helper") for t in targets), targets
+
+
+def test_shipped_ruby_config_loads() -> None:
+    from codebase_rag.parsers.ast_grep_tier import load_pattern_configs
+
+    configs = load_pattern_configs()
+    assert ".rb" in configs
+    assert configs[".rb"].ast_grep_id == "ruby"
+
+
+def test_config_missing_required_keys_raises(tmp_path: Path, monkeypatch) -> None:
+    from codebase_rag.parsers import ast_grep_tier
+
+    (tmp_path / "broken.yaml").write_text("functions: ['def $NAME']\n")
+    monkeypatch.setattr(ast_grep_tier, "_PATTERNS_DIR", tmp_path)
+    try:
+        ast_grep_tier.load_pattern_configs()
+    except ValueError as exc:
+        assert "required" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for missing extensions/ast_grep_id")
+
+
+def test_strip_quotes() -> None:
+    from codebase_rag.parsers.ast_grep_tier import _strip_quotes
+
+    assert _strip_quotes('"json"') == "json"
+    assert _strip_quotes("'json'") == "json"
+    assert _strip_quotes("json") == "json"

--- a/codebase_rag/tests/test_ast_grep_tier.py
+++ b/codebase_rag/tests/test_ast_grep_tier.py
@@ -97,6 +97,14 @@ def test_ruby_imports_edges(tmp_path: Path) -> None:
     assert any(t.endswith("helper") for t in targets), targets
 
 
+def test_class_and_method_on_same_line_both_land(tmp_path: Path) -> None:
+    # (H) one-liner: class and def share a start line; per-label dedup must
+    # (H) keep both instead of the function claiming the line for the class too.
+    mock = _run(tmp_path, {"oneliner.rb": "class Boxed; def unwrap; end; end\n"})
+    assert "unwrap" in _node_names(mock, FUNCTION)
+    assert "Boxed" in _node_names(mock, CLASS)
+
+
 def test_shipped_ruby_config_loads() -> None:
     from codebase_rag.parsers.ast_grep_tier import load_pattern_configs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ codebase_rag = [
     "docker-compose.yaml",
     "parsers/csharp_frontend/roslyn/*.cs",
     "parsers/csharp_frontend/roslyn/*.csproj",
+    "parsers/ast_grep_patterns/*.yaml",
 ]
 
 [project.optional-dependencies]
@@ -128,6 +129,7 @@ milvus = [
 
 ast-grep = [
     "ast-grep-py>=0.44.0",
+    "pyyaml>=6.0",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ test = [
     "libclang>=18.1.1",
     "filelock>=3.12",
     "ast-grep-py>=0.44.0",
+    "pyyaml>=6.0",
 ]
 
 treesitter-full = [

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.409"
+version = "0.0.410"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -595,6 +595,7 @@ dependencies = [
 [package.optional-dependencies]
 ast-grep = [
     { name = "ast-grep-py" },
+    { name = "pyyaml" },
 ]
 milvus = [
     { name = "pymilvus", extra = ["milvus-lite"] },
@@ -681,6 +682,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.0.0" },
     { name = "pytest-xdist", marker = "extra == 'test'", specifier = ">=3.8.0" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
+    { name = "pyyaml", marker = "extra == 'ast-grep'", specifier = ">=6.0" },
     { name = "qdrant-client", marker = "extra == 'semantic'", specifier = ">=1.9.0" },
     { name = "rich", specifier = ">=14.2.0" },
     { name = "testcontainers", marker = "extra == 'test'", specifier = ">=4.9.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -613,6 +613,7 @@ test = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
+    { name = "pyyaml" },
     { name = "testcontainers" },
 ]
 treesitter-full = [
@@ -683,6 +684,7 @@ requires-dist = [
     { name = "pytest-xdist", marker = "extra == 'test'", specifier = ">=3.8.0" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "pyyaml", marker = "extra == 'ast-grep'", specifier = ">=6.0" },
+    { name = "pyyaml", marker = "extra == 'test'", specifier = ">=6.0" },
     { name = "qdrant-client", marker = "extra == 'semantic'", specifier = ">=1.9.0" },
     { name = "rich", specifier = ">=14.2.0" },
     { name = "testcontainers", marker = "extra == 'test'", specifier = ">=4.9.0" },


### PR DESCRIPTION
## Summary

Adds a generic **ast-grep pattern-driven language tier** (`AstGrepTier`) that gives basic structural support to languages with no tree-sitter `LanguageSpec`, driven by per-language YAML pattern configs instead of hand-written traversal. Proven end to end on **Ruby**.

Closes #414.

## Why this shape

The issue originally proposed an `AstGrepHandler` implementing the `LanguageHandler` protocol. That protocol is only a name/FQN-extraction helper (the Python handler is ~25 lines); languages like Go, C#, Scala already ride the `BaseLanguageHandler` fallback and are fully supported via tree-sitter **queries**, not the handler. So a handler-shaped `AstGrepHandler` would accelerate nothing.

The real per-language cost is the tree-sitter query authoring that produces `Function`/`Class`/`Import` nodes. This PR targets exactly that: a tier that emits those nodes from ast-grep patterns, registered as a fallback for files the tree-sitter path skips.

## What it does

- `codebase_rag/parsers/ast_grep_tier.py` — loads `ast_grep_patterns/*.yaml`; for a matching file extension emits `Module` + `Function`/`Class` nodes and `DEFINES`/`IMPORTS` edges, matching the tree-sitter path's node/relationship contract. Wired into `graph_updater._process_single_file` as a fallback below the tree-sitter and dependency-file paths.
- `ast_grep_patterns/ruby.yaml` — Ruby patterns (methods incl. `def self.x`, `class`, `module`, `require`/`require_relative`).
- `ast_grep_patterns/README.md` — contributor template: YAML format, `$NAME`/`$PATH` metavar conventions, first-match-per-line ordering rule.
- `pyyaml` added to the existing `ast-grep` optional extra. The tier degrades to a no-op when the extra is absent, so base installs and all existing languages are unaffected.

## Scope

This is the **basic structural tier** the issue describes: flat qualified names (no nested-namespace qualification) and no `CALLS` resolution. Languages needing full analysis still get a tree-sitter `LanguageSpec`.

Ruby is a partial step toward #118 (Support Ruby fully); it is **not** full Ruby support.

## Testing

- TDD RED→GREEN (RED commit verified failing at its own tree state).
- 9 tests in `tests/test_ast_grep_tier.py`: end-to-end Ruby extraction (functions, classes/modules, module node, DEFINES, IMPORTS) plus unit tests for config validation and quote-stripping.
- Full suite: 5645 passed, 10 skipped.

## Acceptance criteria (#414)

- [x] Generic tier over the ingest node-writing layer
- [x] YAML pattern config format, documented and validated
- [x] One language (Ruby) supported end to end
- [x] Registered as a fallback in the parse dispatch
- [x] Emits Module/Function/Class nodes + DEFINES/IMPORTS edges
- [x] Template/guide for adding a language
- [x] Unit + end-to-end tests
