### PR TITLE
feat(readme): auto-generate Latest News from a curated NEWS.md

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,9 @@
+# Latest News
+
+Newest first. The top three entries are rendered into the README's "Latest News"
+section automatically by `scripts/generate_readme.py`, so edit them here rather
+than in the README.
+
+- **Structural Search & Replace**: Find and rewrite code by AST pattern with ast-grep, exposed as agent tools so you can match and transform structure across the whole codebase instead of relying on text or regex.
+- **Data-Flow Tracing**: New `FLOWS_TO` taint edges follow values through assignments, function calls, and I/O sinks, with coverage across C#, Java, C, and Go.
+- **C# and Dart Support**: Full C# (with Roslyn semantic analysis) and Dart/Flutter now join the graph, bringing the total to 14 supported languages.

--- a/README.md
+++ b/README.md
@@ -62,9 +62,13 @@ Code-Graph-RAG parses a multi-language codebase with Tree-sitter, builds a knowl
 
 ## Latest News 🔥
 
-- **PHP Language Support**: Full PHP support added, covering classes, interfaces, traits, enums, namespaces, PHP 8 attributes, and call graph analysis. Contributed by [@rs-ipps](https://github.com/rs-ipps).
-- **C Language Support**: Full C support added, covering functions, structs, unions, enums, preprocessor includes, and call graph analysis. Contributed by [@dj0nes](https://github.com/dj0nes).
-- **Visualise any GitHub repo instantly!** Just change `github.com` to `gitcgr.com` in any repo URL, that's it, only 3 letters. Get an interactive graph of the entire codebase structure. Try it now: [gitcgr.com](https://gitcgr.com)
+<!-- SECTION:latest_news -->
+- **Structural Search & Replace**: Find and rewrite code by AST pattern with ast-grep, exposed as agent tools so you can match and transform structure across the whole codebase instead of relying on text or regex.
+- **Data-Flow Tracing**: New `FLOWS_TO` taint edges follow values through assignments, function calls, and I/O sinks, with coverage across C#, Java, C, and Go.
+- **C# and Dart Support**: Full C# (with Roslyn semantic analysis) and Dart/Flutter now join the graph, bringing the total to 14 supported languages.
+<!-- /SECTION:latest_news -->
+
+See [NEWS.md](NEWS.md) for the full history.
 
 ## What It Does
 
@@ -183,10 +187,6 @@ For issues or questions, check the [Troubleshooting](docs/advanced/troubleshooti
 ## License
 
 MIT. See [LICENSE](LICENSE).
-
-## Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=vitali87/code-graph-rag&type=Date)](https://www.star-history.com/#vitali87/code-graph-rag&Date)
 
 ## Fork History
 

--- a/codebase_rag/readme_sections.py
+++ b/codebase_rag/readme_sections.py
@@ -229,6 +229,18 @@ def format_dependencies(deps: list[str]) -> str:
         _save_pypi_cache(cache)
 
 
+def format_latest_news(news_path: Path, limit: int = 3) -> str:
+    # (H) Render the top `limit` bullet entries from NEWS.md into the README's
+    # (H) "Latest News" section. NEWS.md is the single hand-curated source of
+    # (H) truth (newest first); the generator only syncs it into the README.
+    try:
+        content = news_path.read_text(encoding=ENCODING_UTF8)
+    except OSError:
+        return ""
+    bullets = [line for line in content.splitlines() if line.startswith("- ")]
+    return "\n".join(bullets[:limit])
+
+
 def generate_all_sections(project_root: Path) -> dict[str, str]:
     makefile_commands = extract_makefile_commands(project_root / "Makefile")
     node_schemas = extract_node_schemas()
@@ -245,4 +257,5 @@ def generate_all_sections(project_root: Path) -> dict[str, str]:
         "mcp_tools": format_mcp_tools_table(),
         "agentic_tools": format_agentic_tools_table(),
         "dependencies": format_dependencies(deps),
+        "latest_news": format_latest_news(project_root / "NEWS.md"),
     }

--- a/codebase_rag/readme_sections.py
+++ b/codebase_rag/readme_sections.py
@@ -237,7 +237,23 @@ def format_latest_news(news_path: Path, limit: int = 3) -> str:
         content = news_path.read_text(encoding=ENCODING_UTF8)
     except OSError:
         return ""
-    bullets = [line for line in content.splitlines() if line.startswith("- ")]
+    # (H) Group each "- " entry with its wrapped continuation lines; a blank line
+    # (H) closes the entry (Markdown list-item semantics), so trailing prose or a
+    # (H) header list elsewhere in the file is not swept into the news bullets.
+    bullets: list[str] = []
+    current: list[str] = []
+    for line in content.splitlines():
+        if line.startswith("- "):
+            if current:
+                bullets.append("\n".join(current))
+            current = [line]
+        elif current and line.strip():
+            current.append(line)
+        elif current:
+            bullets.append("\n".join(current))
+            current = []
+    if current:
+        bullets.append("\n".join(current))
     return "\n".join(bullets[:limit])
 
 

--- a/codebase_rag/tests/test_generate_readme.py
+++ b/codebase_rag/tests/test_generate_readme.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from codebase_rag import cli_help as ch
-from codebase_rag.readme_sections import format_cli_commands_table
+from codebase_rag.readme_sections import format_cli_commands_table, format_latest_news
 from scripts.generate_readme import TARGET_FILES, replace_sections, update_file
 
 
@@ -48,6 +48,29 @@ class TestDocsTargets:
             assert update_file(page, {"mcp_tools": "fresh"}) is False
         finally:
             page.chmod(0o644)
+
+
+class TestLatestNews:
+    def test_renders_top_n_bullets(self, tmp_path: Path) -> None:
+        news = tmp_path / "NEWS.md"
+        news.write_text(
+            "# News\n\n"
+            "- **A**: first.\n"
+            "- **B**: second.\n"
+            "- **C**: third.\n"
+            "- **D**: fourth.\n",
+            encoding="utf-8",
+        )
+        result = format_latest_news(news, limit=3)
+        assert result == "- **A**: first.\n- **B**: second.\n- **C**: third."
+
+    def test_takes_all_when_fewer_than_limit(self, tmp_path: Path) -> None:
+        news = tmp_path / "NEWS.md"
+        news.write_text("- **A**: only one.\n", encoding="utf-8")
+        assert format_latest_news(news, limit=3) == "- **A**: only one."
+
+    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        assert format_latest_news(tmp_path / "nope.md") == ""
 
 
 def test_cli_command_table_has_one_markdown_row_per_command() -> None:

--- a/codebase_rag/tests/test_generate_readme.py
+++ b/codebase_rag/tests/test_generate_readme.py
@@ -69,6 +69,27 @@ class TestLatestNews:
         news.write_text("- **A**: only one.\n", encoding="utf-8")
         assert format_latest_news(news, limit=3) == "- **A**: only one."
 
+    def test_joins_wrapped_continuation_lines(self, tmp_path: Path) -> None:
+        news = tmp_path / "NEWS.md"
+        news.write_text(
+            "- **A**: line one\n  wrapped line two.\n- **B**: second.\n",
+            encoding="utf-8",
+        )
+        assert (
+            format_latest_news(news, limit=1)
+            == "- **A**: line one\n  wrapped line two."
+        )
+
+    def test_blank_line_ends_bullet_and_drops_trailing_prose(
+        self, tmp_path: Path
+    ) -> None:
+        news = tmp_path / "NEWS.md"
+        news.write_text(
+            "# News\n\n- **A**: only entry.\n\nSee CHANGELOG for more.\n",
+            encoding="utf-8",
+        )
+        assert format_latest_news(news, limit=3) == "- **A**: only entry."
+
     def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
         assert format_latest_news(tmp_path / "nope.md") == ""
 

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.410"
+version = "0.0.411"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

The README "Latest News" bullets were stale (PHP, C, the gitcgr trick). This makes that section auto-generated and refreshes the highlights to the genuinely recent features.

## Changes

- **`NEWS.md`** (new): a hand-curated, newest-first changelog. The top three entries are the single source of truth for the README highlights.
- **`format_latest_news()`** in `readme_sections.py`: renders the top N bullets from `NEWS.md`, registered as the `latest_news` generated section.
- **README**: "Latest News" bullets wrapped in `<!-- SECTION:latest_news -->` markers so the existing `generate-readme` pre-commit hook keeps them in sync; added a link to `NEWS.md` for the full history. Also removed the Star History chart.
- Refreshed highlights: structural search & replace (ast-grep), data-flow taint edges (`FLOWS_TO`), and C#/Dart support (14 languages).

## Why this shape

News is editorial, so deriving bullets from commit subjects would produce awkward copy and churn the README on every merge. Instead the generator syncs a human-written `NEWS.md`, reusing the same infrastructure as every other generated section. No new hook, no new dependency.

## Tests

`format_latest_news` added RED first, then implemented (top-N, fewer-than-limit, and missing-file cases). Full `test_generate_readme.py` suite passes; pre-commit clean.