### PR TITLE
docs(readme): remove Fork History section

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,3 @@ For issues or questions, check the [Troubleshooting](docs/advanced/troubleshooti
 ## License
 
 MIT. See [LICENSE](LICENSE).
-
-## Fork History
-
-[![Fork History Chart](https://fork-history.site/svg?repos=vitali87/code-graph-rag)](https://fork-history.site/#vitali87/code-graph-rag)

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.411"
+version = "0.0.413"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Removes the Fork History chart block from the README, matching the earlier removal of the Star History section.