### PR TITLE
feat(graph): detect patterns/smells/security issues via opt-in ast-grep findings (#413)

### DIFF
--- a/codebase_rag/analyzers/__init__.py
+++ b/codebase_rag/analyzers/__init__.py
@@ -1,0 +1,4 @@
+# (H) ast-grep finding analyzers (issue #413).
+from .ast_grep_analyzer import FindingAnalyzer, load_finding_rules
+
+__all__ = ["FindingAnalyzer", "load_finding_rules"]

--- a/codebase_rag/analyzers/ast_grep_analyzer.py
+++ b/codebase_rag/analyzers/ast_grep_analyzer.py
@@ -134,9 +134,12 @@ class FindingAnalyzer:
             if lang_rules is None:
                 continue
             try:
-                source = file_path.read_text(encoding="utf-8")
-            except (OSError, UnicodeDecodeError):
+                raw = file_path.read_bytes()
+            except OSError:
                 continue
+            # (H) decode with replacement so a few malformed bytes don't skip the
+            # (H) whole file; ast-grep tolerates U+FFFD in the source.
+            source = raw.decode("utf-8", errors="replace")
             try:
                 root = SgRoot(source, lang_rules.ast_grep_id).root()
             except (RuntimeError, ValueError) as exc:

--- a/codebase_rag/analyzers/ast_grep_analyzer.py
+++ b/codebase_rag/analyzers/ast_grep_analyzer.py
@@ -1,0 +1,197 @@
+# (H) ast-grep finding analyzer (issue #413). A post-pass over indexed source
+# (H) files that runs categorized ast-grep YAML rules and emits
+# (H) Pattern/CodeSmell/SecurityIssue nodes linked to each file's Module. Rules
+# (H) live in ast_grep_rules/{patterns,smells,security}/<lang>.yaml; a new rule is
+# (H) a YAML entry, no code. The FINDINGS capture group is opt-in, so the analyzer
+# (H) no-ops entirely unless a finding relationship is enabled. Findings link to
+# (H) the Module (not the enclosing Class/Function); the finding node carries the
+# (H) line so the site is still locatable. Symbol-level linkage is a follow-up.
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from .. import constants as cs
+from ..utils.path_utils import cached_relative_path
+
+if TYPE_CHECKING:
+    from ..capture import CaptureSelection
+    from ..services import IngestorProtocol
+
+logger = logging.getLogger(__name__)
+
+_RULES_DIR = Path(__file__).parent / "ast_grep_rules"
+_SNIPPET_MAX = 200
+
+# (H) rule-category directory name -> (finding node label, relationship type).
+_CATEGORY_MAP: dict[str, tuple[cs.NodeLabel, cs.RelationshipType]] = {
+    "patterns": (cs.NodeLabel.PATTERN, cs.RelationshipType.IMPLEMENTS_PATTERN),
+    "smells": (cs.NodeLabel.CODE_SMELL, cs.RelationshipType.HAS_SMELL),
+    "security": (cs.NodeLabel.SECURITY_ISSUE, cs.RelationshipType.HAS_VULNERABILITY),
+}
+
+
+@dataclass(frozen=True)
+class _Rule:
+    rule_id: str
+    message: str
+    body: dict[str, Any]  # (H) ast-grep rule body, splatted into find_all(**body)
+    node_label: cs.NodeLabel
+    rel_type: cs.RelationshipType
+
+
+@dataclass(frozen=True)
+class _LangRules:
+    ast_grep_id: str
+    rules: tuple[_Rule, ...]
+
+
+def load_finding_rules() -> dict[str, _LangRules]:
+    """Load ast_grep_rules/<category>/*.yaml, merged per file extension."""
+    lang_id_by_ext: dict[str, str] = {}
+    rules_by_ext: dict[str, list[_Rule]] = {}
+    for category_dir in sorted(_RULES_DIR.iterdir()):
+        mapping = _CATEGORY_MAP.get(category_dir.name)
+        if not category_dir.is_dir() or mapping is None:
+            continue
+        node_label, rel_type = mapping
+        for path in sorted(category_dir.glob("*.yaml")):
+            ast_grep_id, extensions, rules = _parse_rule_file(
+                path, node_label, rel_type
+            )
+            for ext in extensions:
+                lang_id_by_ext[ext] = ast_grep_id
+                rules_by_ext.setdefault(ext, []).extend(rules)
+    return {
+        ext: _LangRules(lang_id_by_ext[ext], tuple(rules))
+        for ext, rules in rules_by_ext.items()
+    }
+
+
+def _parse_rule_file(
+    path: Path, node_label: cs.NodeLabel, rel_type: cs.RelationshipType
+) -> tuple[str, list[str], list[_Rule]]:
+    import yaml
+
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    ast_grep_id = data.get("ast_grep_id")
+    extensions = data.get("extensions")
+    if isinstance(extensions, str):
+        extensions = [ext.strip() for ext in extensions.split(",") if ext.strip()]
+    if not ast_grep_id or not extensions:
+        raise ValueError(f"{path.name}: 'ast_grep_id' and 'extensions' are required")
+    rules = [
+        _Rule(
+            rule_id=str(entry["id"]),
+            message=str(entry.get("message", entry["id"])),
+            body=entry["rule"],
+            node_label=node_label,
+            rel_type=rel_type,
+        )
+        for entry in (data.get("rules") or [])
+    ]
+    return str(ast_grep_id), list(extensions), rules
+
+
+class FindingAnalyzer:
+    """Runs ast-grep finding rules over indexed files and emits finding nodes."""
+
+    __slots__ = ("_ingestor", "_repo_path", "_enabled", "_rules")
+
+    def __init__(
+        self,
+        ingestor: IngestorProtocol,
+        repo_path: Path,
+        selection: CaptureSelection,
+    ) -> None:
+        self._ingestor = ingestor
+        self._repo_path = repo_path
+        finding_rels = cs.CAPTURE_GROUP_RELS[cs.CaptureGroup.FINDINGS]
+        self._enabled = any(selection.rel_enabled(rel) for rel in finding_rels)
+        self._rules: dict[str, _LangRules] = {}
+        if not self._enabled:
+            return
+        try:
+            import ast_grep_py  # noqa: F401
+
+            self._rules = load_finding_rules()
+        except ImportError:
+            # (H) ast-grep/pyyaml are the [ast-grep] extra; no-op if absent.
+            logger.warning("ast-grep-py unavailable; finding analyzer disabled")
+        except Exception as exc:  # noqa: BLE001
+            # (H) a malformed shipped rule file must not crash indexing.
+            logger.warning("ast-grep finding analyzer disabled: %s", exc)
+
+    def analyze(self, module_qn_to_file_path: dict[str, Path]) -> None:
+        if not self._enabled or not self._rules:
+            return
+        from ast_grep_py import SgRoot
+
+        for module_qn, file_path in module_qn_to_file_path.items():
+            lang_rules = self._rules.get(file_path.suffix)
+            if lang_rules is None:
+                continue
+            try:
+                source = file_path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+            try:
+                root = SgRoot(source, lang_rules.ast_grep_id).root()
+            except (RuntimeError, ValueError) as exc:
+                logger.warning("ast-grep failed to parse %s: %s", file_path, exc)
+                continue
+            relative_path = cached_relative_path(file_path, self._repo_path).as_posix()
+            for rule in lang_rules.rules:
+                self._emit_rule(root, rule, module_qn, relative_path, file_path)
+
+    def _emit_rule(
+        self,
+        root: Any,
+        rule: _Rule,
+        module_qn: str,
+        relative_path: str,
+        file_path: Path,
+    ) -> None:
+        try:
+            matches = root.find_all(**rule.body)
+        except (RuntimeError, TypeError, ValueError) as exc:
+            logger.warning(
+                "bad ast-grep rule %r for %s: %s", rule.rule_id, file_path, exc
+            )
+            return
+        for node in matches:
+            self._emit_finding(rule, node, module_qn, relative_path)
+
+    def _emit_finding(
+        self, rule: _Rule, node: Any, module_qn: str, relative_path: str
+    ) -> None:
+        node_range = node.range()
+        start_line = node_range.start.line + 1
+        end_line = node_range.end.line + 1
+        # (H) qn scopes the finding to file+line+rule so repeat hits stay
+        # (H) distinct while re-indexing merges idempotently.
+        qualified_name = cs.SEPARATOR_DOT.join(
+            [module_qn, str(start_line), rule.rule_id]
+        )
+        snippet = node.text()
+        if len(snippet) > _SNIPPET_MAX:
+            snippet = snippet[:_SNIPPET_MAX]
+        self._ingestor.ensure_node_batch(
+            rule.node_label,
+            {
+                cs.KEY_QUALIFIED_NAME: qualified_name,
+                cs.KEY_NAME: rule.rule_id,
+                cs.KEY_MESSAGE: rule.message,
+                cs.KEY_START_LINE: start_line,
+                cs.KEY_END_LINE: end_line,
+                cs.KEY_PATH: relative_path,
+                cs.KEY_SNIPPET: snippet,
+            },
+        )
+        self._ingestor.ensure_relationship_batch(
+            (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, module_qn),
+            rule.rel_type,
+            (rule.node_label, cs.KEY_QUALIFIED_NAME, qualified_name),
+        )

--- a/codebase_rag/analyzers/ast_grep_analyzer.py
+++ b/codebase_rag/analyzers/ast_grep_analyzer.py
@@ -170,10 +170,11 @@ class FindingAnalyzer:
         node_range = node.range()
         start_line = node_range.start.line + 1
         end_line = node_range.end.line + 1
-        # (H) qn scopes the finding to file+line+rule so repeat hits stay
-        # (H) distinct while re-indexing merges idempotently.
+        # (H) qn scopes the finding to file+line+column+rule so two matches of one
+        # (H) rule on the same line stay distinct, while re-indexing merges the
+        # (H) same site idempotently.
         qualified_name = cs.SEPARATOR_DOT.join(
-            [module_qn, str(start_line), rule.rule_id]
+            [module_qn, str(start_line), str(node_range.start.column), rule.rule_id]
         )
         snippet = node.text()
         if len(snippet) > _SNIPPET_MAX:

--- a/codebase_rag/analyzers/ast_grep_rules/patterns/javascript.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/patterns/javascript.yaml
@@ -1,0 +1,18 @@
+# ast-grep design-pattern rules for JavaScript (issue #413).
+ast_grep_id: javascript
+extensions: [.js, .jsx, .mjs, .cjs]
+rules:
+  - id: singleton
+    message: "Singleton: class exposes a static getInstance()"
+    rule:
+      kind: method_definition
+      has: { field: name, regex: '^getInstance$' }
+  - id: promise_constructor
+    message: "Promise constructor: manual new Promise usage"
+    rule:
+      pattern: "new Promise($$$)"
+  - id: factory_function
+    message: "Factory function: name starts with create/make/build"
+    rule:
+      kind: function_declaration
+      has: { field: name, regex: '^(create|make|build)' }

--- a/codebase_rag/analyzers/ast_grep_rules/patterns/python.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/patterns/python.yaml
@@ -1,0 +1,49 @@
+# ast-grep design-pattern rules for Python (issue #413).
+# Each match becomes a Pattern node linked to the file's Module via
+# IMPLEMENTS_PATTERN. Rules are heuristic and syntactic.
+ast_grep_id: python
+extensions: [.py]
+rules:
+  - id: singleton
+    message: "Singleton: class holds a private _instance"
+    rule:
+      kind: class_definition
+      has:
+        pattern: "_instance = None"
+        stopBy: end
+  - id: context_manager
+    message: "Context manager: class defines __enter__ and __exit__"
+    rule:
+      kind: class_definition
+      all:
+        - has:
+            kind: function_definition
+            has: { field: name, regex: '^__enter__$' }
+            stopBy: end
+        - has:
+            kind: function_definition
+            has: { field: name, regex: '^__exit__$' }
+            stopBy: end
+  - id: iterator
+    message: "Iterator: class defines __iter__ and __next__"
+    rule:
+      kind: class_definition
+      all:
+        - has:
+            kind: function_definition
+            has: { field: name, regex: '^__iter__$' }
+            stopBy: end
+        - has:
+            kind: function_definition
+            has: { field: name, regex: '^__next__$' }
+            stopBy: end
+  - id: abstract_base
+    message: "Abstract base class: inherits ABC"
+    rule:
+      kind: class_definition
+      has: { field: superclasses, regex: 'ABC' }
+  - id: factory_function
+    message: "Factory function: name starts with make_/create_/build_"
+    rule:
+      kind: function_definition
+      has: { field: name, regex: '^(make|create|build)_' }

--- a/codebase_rag/analyzers/ast_grep_rules/patterns/tsx.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/patterns/tsx.yaml
@@ -1,0 +1,18 @@
+# ast-grep design-pattern rules for TSX (issue #413).
+ast_grep_id: tsx
+extensions: [.tsx]
+rules:
+  - id: singleton
+    message: "Singleton: class exposes a static getInstance()"
+    rule:
+      kind: method_definition
+      has: { field: name, regex: '^getInstance$' }
+  - id: promise_constructor
+    message: "Promise constructor: manual new Promise usage"
+    rule:
+      pattern: "new Promise($$$)"
+  - id: factory_function
+    message: "Factory function: name starts with create/make/build"
+    rule:
+      kind: function_declaration
+      has: { field: name, regex: '^(create|make|build)' }

--- a/codebase_rag/analyzers/ast_grep_rules/patterns/typescript.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/patterns/typescript.yaml
@@ -1,0 +1,18 @@
+# ast-grep design-pattern rules for TypeScript (issue #413).
+ast_grep_id: typescript
+extensions: [.ts, .mts, .cts]
+rules:
+  - id: singleton
+    message: "Singleton: class exposes a static getInstance()"
+    rule:
+      kind: method_definition
+      has: { field: name, regex: '^getInstance$' }
+  - id: promise_constructor
+    message: "Promise constructor: manual new Promise usage"
+    rule:
+      pattern: "new Promise($$$)"
+  - id: factory_function
+    message: "Factory function: name starts with create/make/build"
+    rule:
+      kind: function_declaration
+      has: { field: name, regex: '^(create|make|build)' }

--- a/codebase_rag/analyzers/ast_grep_rules/security/javascript.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/javascript.yaml
@@ -1,0 +1,23 @@
+# ast-grep security rules for JavaScript (issue #413).
+ast_grep_id: javascript
+extensions: [.js, .jsx, .mjs, .cjs]
+rules:
+  - id: innerhtml_xss
+    message: "Possible XSS: assignment to innerHTML"
+    rule:
+      pattern: "$EL.innerHTML = $X"
+  - id: eval_use
+    message: "eval() executes arbitrary code"
+    rule:
+      pattern: "eval($$$)"
+  - id: document_write
+    message: "document.write() can enable XSS"
+    rule:
+      pattern: "document.write($$$)"
+  - id: hardcoded_secret
+    message: "Hardcoded secret assigned to a credential-named variable"
+    rule:
+      kind: variable_declarator
+      all:
+        - has: { field: name, regex: '(?i)(password|secret|api_key|token)' }
+        - has: { field: value, kind: string }

--- a/codebase_rag/analyzers/ast_grep_rules/security/python.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/python.yaml
@@ -1,0 +1,49 @@
+# ast-grep security rules for Python (issue #413).
+# Each match becomes a SecurityIssue node linked to the file's Module via
+# HAS_VULNERABILITY. Rules are heuristic; treat findings as review prompts.
+ast_grep_id: python
+extensions: [.py]
+rules:
+  - id: sqli_concat
+    message: "Possible SQL injection: query built with string concatenation"
+    rule:
+      pattern: "$OBJ.execute($A + $B)"
+  - id: sqli_fstring
+    message: "Possible SQL injection: execute() called with an f-string"
+    rule:
+      kind: call
+      all:
+        - has: { pattern: "execute", stopBy: end }
+        - has: { kind: string, regex: '^f', stopBy: end }
+  - id: hardcoded_secret
+    message: "Hardcoded secret assigned to a credential-named variable"
+    rule:
+      kind: assignment
+      all:
+        - has: { field: left, regex: '(?i)(password|secret|api_key|token)' }
+        - has: { field: right, kind: string }
+  - id: eval_use
+    message: "eval() executes arbitrary code"
+    rule:
+      pattern: "eval($$$)"
+  - id: exec_use
+    message: "exec() executes arbitrary code"
+    rule:
+      pattern: "exec($$$)"
+  - id: os_system_concat
+    message: "Possible command injection: os.system() with concatenation"
+    rule:
+      pattern: "os.system($A + $B)"
+  - id: subprocess_shell
+    message: "subprocess called with shell=True enables command injection"
+    rule:
+      pattern: "subprocess.$M($$$)"
+      has: { regex: 'shell\s*=\s*True', stopBy: end }
+  - id: yaml_load
+    message: "yaml.load() without SafeLoader can execute arbitrary code"
+    rule:
+      pattern: "yaml.load($$$)"
+  - id: pickle_loads
+    message: "pickle.loads() on untrusted data executes arbitrary code"
+    rule:
+      pattern: "pickle.loads($$$)"

--- a/codebase_rag/analyzers/ast_grep_rules/security/tsx.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/tsx.yaml
@@ -1,0 +1,23 @@
+# ast-grep security rules for TSX (issue #413).
+ast_grep_id: tsx
+extensions: [.tsx]
+rules:
+  - id: innerhtml_xss
+    message: "Possible XSS: assignment to innerHTML"
+    rule:
+      pattern: "$EL.innerHTML = $X"
+  - id: eval_use
+    message: "eval() executes arbitrary code"
+    rule:
+      pattern: "eval($$$)"
+  - id: document_write
+    message: "document.write() can enable XSS"
+    rule:
+      pattern: "document.write($$$)"
+  - id: hardcoded_secret
+    message: "Hardcoded secret assigned to a credential-named variable"
+    rule:
+      kind: variable_declarator
+      all:
+        - has: { field: name, regex: '(?i)(password|secret|api_key|token)' }
+        - has: { field: value, kind: string }

--- a/codebase_rag/analyzers/ast_grep_rules/security/typescript.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/typescript.yaml
@@ -1,0 +1,23 @@
+# ast-grep security rules for TypeScript (issue #413).
+ast_grep_id: typescript
+extensions: [.ts, .mts, .cts]
+rules:
+  - id: innerhtml_xss
+    message: "Possible XSS: assignment to innerHTML"
+    rule:
+      pattern: "$EL.innerHTML = $X"
+  - id: eval_use
+    message: "eval() executes arbitrary code"
+    rule:
+      pattern: "eval($$$)"
+  - id: document_write
+    message: "document.write() can enable XSS"
+    rule:
+      pattern: "document.write($$$)"
+  - id: hardcoded_secret
+    message: "Hardcoded secret assigned to a credential-named variable"
+    rule:
+      kind: variable_declarator
+      all:
+        - has: { field: name, regex: '(?i)(password|secret|api_key|token)' }
+        - has: { field: value, kind: string }

--- a/codebase_rag/analyzers/ast_grep_rules/smells/javascript.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/smells/javascript.yaml
@@ -1,0 +1,20 @@
+# ast-grep code-smell rules for JavaScript (issue #413).
+ast_grep_id: javascript
+extensions: [.js, .jsx, .mjs, .cjs]
+rules:
+  - id: var_usage
+    message: "var declaration; prefer let/const"
+    rule:
+      kind: variable_declaration
+  - id: loose_equality
+    message: "Loose equality (==); prefer strict ==="
+    rule:
+      pattern: "$A == $B"
+  - id: console_log
+    message: "Leftover console.log"
+    rule:
+      pattern: "console.log($$$)"
+  - id: debugger_statement
+    message: "Leftover debugger statement"
+    rule:
+      kind: debugger_statement

--- a/codebase_rag/analyzers/ast_grep_rules/smells/python.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/smells/python.yaml
@@ -1,0 +1,33 @@
+# ast-grep code-smell rules for Python (issue #413).
+# Each match becomes a CodeSmell node linked to the file's Module via HAS_SMELL.
+ast_grep_id: python
+extensions: [.py]
+rules:
+  - id: bare_except
+    message: "Bare except swallows every exception"
+    rule:
+      kind: except_clause
+      regex: '^except\s*:'
+  - id: broad_except
+    message: "Broad except Exception catches too much"
+    rule:
+      kind: except_clause
+      regex: 'except\s+Exception'
+  - id: mutable_default_list
+    message: "Mutable default argument (list) is shared across calls"
+    rule:
+      kind: default_parameter
+      has: { field: value, kind: list }
+  - id: mutable_default_dict
+    message: "Mutable default argument (dict) is shared across calls"
+    rule:
+      kind: default_parameter
+      has: { field: value, kind: dictionary }
+  - id: wildcard_import
+    message: "Wildcard import pollutes the namespace"
+    rule:
+      pattern: "from $M import *"
+  - id: global_statement
+    message: "global statement couples the function to module state"
+    rule:
+      kind: global_statement

--- a/codebase_rag/analyzers/ast_grep_rules/smells/tsx.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/smells/tsx.yaml
@@ -1,0 +1,20 @@
+# ast-grep code-smell rules for TSX (issue #413).
+ast_grep_id: tsx
+extensions: [.tsx]
+rules:
+  - id: var_usage
+    message: "var declaration; prefer let/const"
+    rule:
+      kind: variable_declaration
+  - id: loose_equality
+    message: "Loose equality (==); prefer strict ==="
+    rule:
+      pattern: "$A == $B"
+  - id: console_log
+    message: "Leftover console.log"
+    rule:
+      pattern: "console.log($$$)"
+  - id: debugger_statement
+    message: "Leftover debugger statement"
+    rule:
+      kind: debugger_statement

--- a/codebase_rag/analyzers/ast_grep_rules/smells/typescript.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/smells/typescript.yaml
@@ -1,0 +1,20 @@
+# ast-grep code-smell rules for TypeScript (issue #413).
+ast_grep_id: typescript
+extensions: [.ts, .mts, .cts]
+rules:
+  - id: var_usage
+    message: "var declaration; prefer let/const"
+    rule:
+      kind: variable_declaration
+  - id: loose_equality
+    message: "Loose equality (==); prefer strict ==="
+    rule:
+      pattern: "$A == $B"
+  - id: console_log
+    message: "Leftover console.log"
+    rule:
+      pattern: "console.log($$$)"
+  - id: debugger_statement
+    message: "Leftover debugger statement"
+    rule:
+      kind: debugger_statement

--- a/codebase_rag/constants/graph.py
+++ b/codebase_rag/constants/graph.py
@@ -44,6 +44,9 @@ KEY_PROJECT_PREFIX = "project_prefix"
 KEY_VERSION_SPEC = "version_spec"
 KEY_PREFIX = "prefix"
 KEY_PROJECT_NAME = "project_name"
+# (H) ast-grep finding node properties (issue #413)
+KEY_MESSAGE = "message"
+KEY_SNIPPET = "snippet"
 
 ERR_SUBSTR_ALREADY_EXISTS = "already exists"
 ERR_SUBSTR_CONSTRAINT = "constraint"
@@ -97,6 +100,11 @@ class NodeLabel(StrEnum):
     EXTERNAL_PACKAGE = "ExternalPackage"
     EXTERNAL_MODULE = "ExternalModule"
     RESOURCE = "Resource"
+    # (H) ast-grep findings (issue #413): quality/security signals attached to a
+    # (H) Module. Opt-in via CaptureGroup.FINDINGS.
+    PATTERN = "Pattern"
+    CODE_SMELL = "CodeSmell"
+    SECURITY_ISSUE = "SecurityIssue"
 
 
 _NODE_LABEL_UNIQUE_KEYS: dict[NodeLabel, UniqueKeyType] = {
@@ -117,6 +125,9 @@ _NODE_LABEL_UNIQUE_KEYS: dict[NodeLabel, UniqueKeyType] = {
     NodeLabel.EXTERNAL_PACKAGE: UniqueKeyType.NAME,
     NodeLabel.EXTERNAL_MODULE: UniqueKeyType.QUALIFIED_NAME,
     NodeLabel.RESOURCE: UniqueKeyType.QUALIFIED_NAME,
+    NodeLabel.PATTERN: UniqueKeyType.QUALIFIED_NAME,
+    NodeLabel.CODE_SMELL: UniqueKeyType.QUALIFIED_NAME,
+    NodeLabel.SECURITY_ISSUE: UniqueKeyType.QUALIFIED_NAME,
 }
 
 _missing_keys = set(NodeLabel) - set(_NODE_LABEL_UNIQUE_KEYS.keys())
@@ -148,6 +159,9 @@ class RelationshipType(StrEnum):
     READS_FROM = "READS_FROM"
     WRITES_TO = "WRITES_TO"
     FLOWS_TO = "FLOWS_TO"
+    IMPLEMENTS_PATTERN = "IMPLEMENTS_PATTERN"
+    HAS_SMELL = "HAS_SMELL"
+    HAS_VULNERABILITY = "HAS_VULNERABILITY"
 
 
 class CaptureGroup(StrEnum):
@@ -156,6 +170,7 @@ class CaptureGroup(StrEnum):
     TYPES = "types"
     IMPORTS = "imports"
     IO = "io"
+    FINDINGS = "findings"
 
 
 # (H) Each relationship type belongs to exactly one capture group. The guard
@@ -202,6 +217,13 @@ CAPTURE_GROUP_RELS: dict[CaptureGroup, frozenset[RelationshipType]] = {
             RelationshipType.FLOWS_TO,
         }
     ),
+    CaptureGroup.FINDINGS: frozenset(
+        {
+            RelationshipType.IMPLEMENTS_PATTERN,
+            RelationshipType.HAS_SMELL,
+            RelationshipType.HAS_VULNERABILITY,
+        }
+    ),
 }
 
 # (H) Node labels a group exclusively owns; the label is captured only while the
@@ -209,6 +231,9 @@ CAPTURE_GROUP_RELS: dict[CaptureGroup, frozenset[RelationshipType]] = {
 # (H) group are always captured.
 CAPTURE_GROUP_NODE_LABELS: dict[CaptureGroup, frozenset[NodeLabel]] = {
     CaptureGroup.IO: frozenset({NodeLabel.RESOURCE}),
+    CaptureGroup.FINDINGS: frozenset(
+        {NodeLabel.PATTERN, NodeLabel.CODE_SMELL, NodeLabel.SECURITY_ISSUE}
+    ),
 }
 
 # (H) Groups enabled when the user configures nothing. Add-ons (io) are opt-in.

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -82,6 +82,22 @@ WHERE c.name = 'UserService'
 RETURN c.name AS className, m.name AS methodName, m.qualified_name AS qualified_name, labels(m) AS type
 LIMIT {CYPHER_DEFAULT_LIMIT}"""
 
+# (H) ast-grep findings (issue #413): Pattern/CodeSmell/SecurityIssue nodes hang
+# (H) off a Module via IMPLEMENTS_PATTERN/HAS_SMELL/HAS_VULNERABILITY. The finding
+# (H) node's name is the rule id; start_line locates the site.
+CYPHER_EXAMPLE_FIND_PATTERN = f"""MATCH (m:Module)-[:IMPLEMENTS_PATTERN]->(p:Pattern)
+WHERE p.name = 'singleton'
+RETURN m.path AS path, p.name AS pattern, p.start_line AS line, p.message AS message
+LIMIT {CYPHER_DEFAULT_LIMIT}"""
+
+CYPHER_EXAMPLE_SECURITY_ISSUES = f"""MATCH (m:Module)-[:HAS_VULNERABILITY]->(s:SecurityIssue)
+RETURN m.path AS path, s.name AS rule, s.start_line AS line, s.message AS message
+LIMIT {CYPHER_DEFAULT_LIMIT}"""
+
+CYPHER_EXAMPLE_CODE_SMELLS = f"""MATCH (m:Module)-[:HAS_SMELL]->(c:CodeSmell)
+RETURN m.path AS path, c.name AS smell, c.start_line AS line, c.message AS message
+LIMIT {CYPHER_DEFAULT_LIMIT}"""
+
 CYPHER_EXPORT_NODES = """
 MATCH (n)
 RETURN id(n) as node_id, labels(n) as labels, properties(n) as properties

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -12,6 +12,7 @@ from tree_sitter import Node, Parser, QueryCursor
 
 from . import constants as cs
 from . import logs as ls
+from .analyzers import FindingAnalyzer
 from .capture import CaptureSelection, default_capture
 from .config import settings
 from .language_spec import (
@@ -572,6 +573,11 @@ class GraphUpdater:
         # (H) Fallback structural tier for languages with no tree-sitter
         # (H) LanguageSpec (e.g. Ruby), driven by ast-grep pattern configs.
         self.ast_grep_tier = AstGrepTier(self._sink, self.repo_path, self.project_name)
+        # (H) Opt-in ast-grep finding analyzer (issue #413): Pattern/CodeSmell/
+        # (H) SecurityIssue nodes from categorized YAML rules, run as a post-pass.
+        self.finding_analyzer = FindingAnalyzer(
+            self._sink, self.repo_path, self.capture
+        )
 
     def _run_cpp_frontend(self) -> None:
         # (H) Optional libclang C++ pre-pass when a compile_commands.json is
@@ -1013,6 +1019,12 @@ class GraphUpdater:
         self._emit_csharp_query_calls()
 
         self.factory.definition_processor.process_all_method_overrides()
+
+        # (H) ast-grep findings post-pass (opt-in FINDINGS group). Links to the
+        # (H) Modules the definition pass already emitted, so no dangling edges.
+        self.finding_analyzer.analyze(
+            self.factory.definition_processor.module_qn_to_file_path
+        )
 
         logger.info(ls.ANALYSIS_COMPLETE)
         self.ingestor.flush_all()

--- a/codebase_rag/prompts.py
+++ b/codebase_rag/prompts.py
@@ -2,15 +2,18 @@ from typing import TYPE_CHECKING
 
 from .cypher_queries import (
     CYPHER_EXAMPLE_CLASS_METHODS,
+    CYPHER_EXAMPLE_CODE_SMELLS,
     CYPHER_EXAMPLE_CONTENT_BY_PATH,
     CYPHER_EXAMPLE_DECORATED_FUNCTIONS,
     CYPHER_EXAMPLE_FILES_IN_FOLDER,
     CYPHER_EXAMPLE_FIND_FILE,
+    CYPHER_EXAMPLE_FIND_PATTERN,
     CYPHER_EXAMPLE_KEYWORD_SEARCH,
     CYPHER_EXAMPLE_LIMIT_ONE,
     CYPHER_EXAMPLE_PROJECT_SCOPED,
     CYPHER_EXAMPLE_PYTHON_FILES,
     CYPHER_EXAMPLE_README,
+    CYPHER_EXAMPLE_SECURITY_ISSUES,
     CYPHER_EXAMPLE_TASKS,
 )
 from .schema_builder import GRAPH_SCHEMA_DEFINITION
@@ -286,6 +289,15 @@ cypher// "What methods does UserService have?" or "Show me methods in UserServic
 cypher// "show all classes in myproject" (multi-project database)
 // Filter on the qualified_name prefix to keep results within one project.
 {CYPHER_EXAMPLE_PROJECT_SCOPED}
+
+**Pattern: Design Patterns, Code Smells & Security Issues (ast-grep findings)**
+cypher// "find all Singleton classes" / "which patterns are used"
+// Finding nodes (Pattern/CodeSmell/SecurityIssue) hang off a Module; name is the rule id.
+{CYPHER_EXAMPLE_FIND_PATTERN}
+cypher// "show functions with SQL injection risk" / "list security issues"
+{CYPHER_EXAMPLE_SECURITY_ISSUES}
+cypher// "find code smells" / "show bare excepts"
+{CYPHER_EXAMPLE_CODE_SMELLS}
 
 **4. Output Format**
 Provide only the Cypher query.

--- a/codebase_rag/tests/test_ast_grep_analyzer.py
+++ b/codebase_rag/tests/test_ast_grep_analyzer.py
@@ -152,3 +152,40 @@ def test_analyzer_noops_when_findings_disabled(tmp_path: Path) -> None:
     FindingAnalyzer(ing, tmp_path, resolve_capture([])).analyze({"proj.m": src})
     assert ing.nodes == []
     assert ing.rels == []
+
+
+def test_same_line_findings_get_distinct_ids(tmp_path: Path) -> None:
+    # (H) two matches of one rule on a single line must not collapse into one
+    # (H) node; the qualified_name has to distinguish them by column.
+    from codebase_rag.analyzers import FindingAnalyzer
+
+    src = tmp_path / "a.js"
+    src.write_text("console.log(1); console.log(2);\n", encoding="utf-8")
+    ing = _FakeIngestor()
+    FindingAnalyzer(ing, tmp_path, resolve_capture(["+findings"])).analyze(
+        {"proj.a": src}
+    )
+    qns = [
+        p[cs.KEY_QUALIFIED_NAME]
+        for label, p in ing.nodes
+        if label == CODE_SMELL and p[cs.KEY_NAME] == "console_log"
+    ]
+    assert len(qns) == 2, qns
+    assert len(set(qns)) == 2, qns
+
+
+def test_tsx_files_get_findings(tmp_path: Path) -> None:
+    from codebase_rag.analyzers import FindingAnalyzer
+    from codebase_rag.analyzers.ast_grep_analyzer import load_finding_rules
+
+    assert ".tsx" in load_finding_rules()
+    src = tmp_path / "c.tsx"
+    src.write_text(
+        "const C = () => { console.log('x'); return null; };\n", encoding="utf-8"
+    )
+    ing = _FakeIngestor()
+    FindingAnalyzer(ing, tmp_path, resolve_capture(["+findings"])).analyze(
+        {"proj.c": src}
+    )
+    names = [p[cs.KEY_NAME] for label, p in ing.nodes if label == CODE_SMELL]
+    assert "console_log" in names, names

--- a/codebase_rag/tests/test_ast_grep_analyzer.py
+++ b/codebase_rag/tests/test_ast_grep_analyzer.py
@@ -1,0 +1,154 @@
+# (H) ast-grep finding analyzer (issue #413). Runs categorized YAML rules over
+# (H) indexed source files and emits Pattern/CodeSmell/SecurityIssue nodes linked
+# (H) to each file's Module. The FINDINGS capture group is opt-in, so these tests
+# (H) build a selection with it enabled and assert the finding nodes/edges land.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.capture import resolve_capture
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+PATTERN = cs.NodeLabel.PATTERN.value
+CODE_SMELL = cs.NodeLabel.CODE_SMELL.value
+SECURITY_ISSUE = cs.NodeLabel.SECURITY_ISSUE.value
+IMPLEMENTS_PATTERN = cs.RelationshipType.IMPLEMENTS_PATTERN.value
+HAS_SMELL = cs.RelationshipType.HAS_SMELL.value
+HAS_VULNERABILITY = cs.RelationshipType.HAS_VULNERABILITY.value
+
+SINGLETON_PY = (
+    "class Config:\n"
+    "    _instance = None\n"
+    "\n"
+    "    def get(self):\n"
+    "        return self._instance\n"
+)
+
+SQLI_PY = (
+    "def lookup(db, user_id):\n"
+    "    return db.execute('SELECT * FROM t WHERE id = ' + user_id)\n"
+)
+
+SAFE_PY = (
+    "def lookup(db, user_id):\n"
+    "    return db.execute('SELECT * FROM t WHERE id = ?', (user_id,))\n"
+)
+
+
+def _run(tmp_path: Path, files: dict[str, str], tokens: list[str]) -> MagicMock:
+    parsers, queries = load_parsers()
+    for rel, content in files.items():
+        (tmp_path / rel).write_text(content, encoding="utf-8")
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        capture=resolve_capture(tokens),
+    ).run()
+    return mock
+
+
+def _node_names(mock: MagicMock, label: str) -> set[str]:
+    return {
+        c.args[1].get(cs.KEY_NAME)
+        for c in mock.ensure_node_batch.call_args_list
+        if str(c.args[0]) == label
+    }
+
+
+def _rel_targets(mock: MagicMock, rel_type: str) -> set[str]:
+    return {
+        c.args[2][2]
+        for c in mock.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) == rel_type
+    }
+
+
+def test_singleton_pattern_detected(tmp_path: Path) -> None:
+    mock = _run(tmp_path, {"config.py": SINGLETON_PY}, ["+findings"])
+    assert "singleton" in _node_names(mock, PATTERN)
+
+
+def test_sql_injection_detected(tmp_path: Path) -> None:
+    mock = _run(tmp_path, {"dao.py": SQLI_PY}, ["+findings"])
+    assert "sqli_concat" in _node_names(mock, SECURITY_ISSUE)
+
+
+def test_finding_linked_to_module(tmp_path: Path) -> None:
+    mock = _run(tmp_path, {"dao.py": SQLI_PY}, ["+findings"])
+    targets = _rel_targets(mock, HAS_VULNERABILITY)
+    assert any(qn.endswith("sqli_concat") for qn in targets), targets
+
+
+def test_safe_query_not_flagged(tmp_path: Path) -> None:
+    mock = _run(tmp_path, {"dao.py": SAFE_PY}, ["+findings"])
+    assert "sqli_concat" not in _node_names(mock, SECURITY_ISSUE)
+
+
+def test_findings_opt_in_disabled_by_default(tmp_path: Path) -> None:
+    # (H) FINDINGS is not in DEFAULT_CAPTURE_GROUPS; a default index emits none.
+    mock = _run(tmp_path, {"config.py": SINGLETON_PY, "dao.py": SQLI_PY}, [])
+    assert _node_names(mock, PATTERN) == set()
+    assert _node_names(mock, SECURITY_ISSUE) == set()
+
+
+class _FakeIngestor:
+    def __init__(self) -> None:
+        self.nodes: list[tuple[str, dict]] = []
+        self.rels: list[tuple[tuple, str, tuple]] = []
+
+    def ensure_node_batch(self, label, props) -> None:
+        self.nodes.append((str(label), props))
+
+    def ensure_relationship_batch(self, src, rel, dst) -> None:
+        self.rels.append((src, str(rel), dst))
+
+
+def _labelled(rules, label) -> list:
+    return [r for r in rules if r.node_label == label]
+
+
+def test_rules_load_and_meet_acceptance_counts() -> None:
+    from codebase_rag.analyzers.ast_grep_analyzer import load_finding_rules
+
+    rules = load_finding_rules()
+    assert {".py", ".js", ".ts"} <= set(rules)
+    py = rules[".py"].rules
+    assert len(_labelled(py, cs.NodeLabel.PATTERN)) >= 5
+    assert len(_labelled(py, cs.NodeLabel.CODE_SMELL)) >= 5
+    assert len(_labelled(py, cs.NodeLabel.SECURITY_ISSUE)) >= 5
+    for ext in (".js", ".ts"):
+        js = rules[ext].rules
+        assert len(_labelled(js, cs.NodeLabel.PATTERN)) >= 3
+        assert len(_labelled(js, cs.NodeLabel.CODE_SMELL)) >= 3
+        assert len(_labelled(js, cs.NodeLabel.SECURITY_ISSUE)) >= 3
+
+
+def test_analyzer_emits_node_and_edge_directly(tmp_path: Path) -> None:
+    from codebase_rag.analyzers import FindingAnalyzer
+
+    src = tmp_path / "m.py"
+    src.write_text(SINGLETON_PY, encoding="utf-8")
+    ing = _FakeIngestor()
+    FindingAnalyzer(ing, tmp_path, resolve_capture(["+findings"])).analyze(
+        {"proj.m": src}
+    )
+    pattern_nodes = [p for label, p in ing.nodes if label == PATTERN]
+    assert any(p[cs.KEY_NAME] == "singleton" for p in pattern_nodes)
+    assert any(rel == IMPLEMENTS_PATTERN for _s, rel, _d in ing.rels)
+
+
+def test_analyzer_noops_when_findings_disabled(tmp_path: Path) -> None:
+    from codebase_rag.analyzers import FindingAnalyzer
+
+    src = tmp_path / "m.py"
+    src.write_text(SINGLETON_PY, encoding="utf-8")
+    ing = _FakeIngestor()
+    FindingAnalyzer(ing, tmp_path, resolve_capture([])).analyze({"proj.m": src})
+    assert ing.nodes == []
+    assert ing.rels == []

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -689,6 +689,12 @@ class RelationshipSchema(NamedTuple):
     targets: tuple[NodeLabel, ...]
 
 
+# (H) shared property string for the ast-grep finding node labels (issue #413)
+_FINDING_NODE_PROPS = (
+    "{qualified_name: string, name: string, message: string, "
+    "start_line: int, end_line: int, path: string, snippet: string?}"
+)
+
 NODE_SCHEMAS: tuple[NodeSchema, ...] = (
     NodeSchema(NodeLabel.PROJECT, "{name: string}"),
     NodeSchema(
@@ -749,18 +755,9 @@ NODE_SCHEMAS: tuple[NodeSchema, ...] = (
         NodeLabel.RESOURCE,
         "{qualified_name: string, name: string, kind: string}",
     ),
-    NodeSchema(
-        NodeLabel.PATTERN,
-        "{qualified_name: string, name: string, message: string, start_line: int, end_line: int, path: string, snippet: string?}",
-    ),
-    NodeSchema(
-        NodeLabel.CODE_SMELL,
-        "{qualified_name: string, name: string, message: string, start_line: int, end_line: int, path: string, snippet: string?}",
-    ),
-    NodeSchema(
-        NodeLabel.SECURITY_ISSUE,
-        "{qualified_name: string, name: string, message: string, start_line: int, end_line: int, path: string, snippet: string?}",
-    ),
+    NodeSchema(NodeLabel.PATTERN, _FINDING_NODE_PROPS),
+    NodeSchema(NodeLabel.CODE_SMELL, _FINDING_NODE_PROPS),
+    NodeSchema(NodeLabel.SECURITY_ISSUE, _FINDING_NODE_PROPS),
 )
 
 

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -749,6 +749,18 @@ NODE_SCHEMAS: tuple[NodeSchema, ...] = (
         NodeLabel.RESOURCE,
         "{qualified_name: string, name: string, kind: string}",
     ),
+    NodeSchema(
+        NodeLabel.PATTERN,
+        "{qualified_name: string, name: string, message: string, start_line: int, end_line: int, path: string, snippet: string?}",
+    ),
+    NodeSchema(
+        NodeLabel.CODE_SMELL,
+        "{qualified_name: string, name: string, message: string, start_line: int, end_line: int, path: string, snippet: string?}",
+    ),
+    NodeSchema(
+        NodeLabel.SECURITY_ISSUE,
+        "{qualified_name: string, name: string, message: string, start_line: int, end_line: int, path: string, snippet: string?}",
+    ),
 )
 
 
@@ -889,5 +901,20 @@ RELATIONSHIP_SCHEMAS: tuple[RelationshipSchema, ...] = (
         (NodeLabel.MODULE, NodeLabel.FUNCTION, NodeLabel.METHOD, NodeLabel.RESOURCE),
         RelationshipType.FLOWS_TO,
         (NodeLabel.MODULE, NodeLabel.FUNCTION, NodeLabel.METHOD, NodeLabel.RESOURCE),
+    ),
+    RelationshipSchema(
+        (NodeLabel.MODULE,),
+        RelationshipType.IMPLEMENTS_PATTERN,
+        (NodeLabel.PATTERN,),
+    ),
+    RelationshipSchema(
+        (NodeLabel.MODULE,),
+        RelationshipType.HAS_SMELL,
+        (NodeLabel.CODE_SMELL,),
+    ),
+    RelationshipSchema(
+        (NodeLabel.MODULE,),
+        RelationshipType.HAS_VULNERABILITY,
+        (NodeLabel.SECURITY_ISSUE,),
     ),
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ codebase_rag = [
     "parsers/csharp_frontend/roslyn/*.cs",
     "parsers/csharp_frontend/roslyn/*.csproj",
     "parsers/ast_grep_patterns/*.yaml",
+    "analyzers/ast_grep_rules/*/*.yaml",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.413"
+version = "0.0.414"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #413.

Enriches the knowledge graph with pattern / smell / vulnerability detection driven by ast-grep YAML rules, so the graph can answer questions like "find all Singleton classes" or "show functions with SQL-injection risk".

## Graph schema (opt-in)
- New node labels: `Pattern`, `CodeSmell`, `SecurityIssue`.
- New relationships: `IMPLEMENTS_PATTERN`, `HAS_SMELL`, `HAS_VULNERABILITY`.
- New capture group `FINDINGS`, **excluded from `DEFAULT_CAPTURE_GROUPS`** (mirrors the `IO` add-on). Findings are emitted only when the user opts in with `--capture +findings` (or `CGR_CAPTURE`), so existing graphs are unaffected.
- Unique-key and capture-coverage guards, plus `NODE_SCHEMAS` / `RELATIONSHIP_SCHEMAS` audit docs, all updated.

## Analyzer
- `codebase_rag/analyzers/ast_grep_analyzer.py` runs as a post-pass (after Pass 3, before flush) over the modules the definition pass already emitted, so finding nodes always attach to an existing `Module` (no dangling edges). It no-ops entirely unless a `FINDINGS` relationship is enabled.
- Rules live in `analyzers/ast_grep_rules/{patterns,smells,security}/<language>.yaml`. A new rule is a YAML entry, no code. Rule bodies are passed straight to `ast-grep-py`'s `find_all(**rule)`.

## Rules
- Python: 5 patterns, 6 smells, 9 security.
- JavaScript and TypeScript: 3 patterns, 4 smells, 4 security each.
- Meets the issue's >=5 (Python) / >=3 (JS/TS) per-category bar.

## Queryability
- Three cypher example templates (`CYPHER_EXAMPLE_FIND_PATTERN` / `_SECURITY_ISSUES` / `_CODE_SMELLS`) wired into the Cypher-generation prompt.

## Deliberate scoping
- Findings link to the file's `Module`, not the enclosing `Class`/`Function`; the finding node carries `start_line`/`end_line` so the site stays locatable. Symbol-level linkage is a clean follow-up.
- Protobuf export gracefully skips finding nodes (warn + skip), matching the existing `FLOWS_TO` behaviour whose relationship type is likewise absent from the proto enum. The primary Memgraph backend has full support.

## Tests
- `codebase_rag/tests/test_ast_grep_analyzer.py`: 8 tests (RED confirmed before implementation) covering detection, Module linkage, safe-code negatives, opt-in gating, rule-count acceptance, and a fast direct-analyzer unit path.
- Full non-integration suite: 5403 passed, 5 skipped.
