### PR TITLE
docs: use British English across documentation and user-facing strings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,8 @@ Thank you for your interest in contributing to Code Graph RAG! We welcome contri
 ## Getting Started
 
 1. **Browse Issues**: Check out our [issue tracker](https://github.com/vitali87/code-graph-rag/issues) to find tasks that need work
-   - Look for issues labeled `good first issue` for beginner-friendly tasks
-   - Issues labeled `help wanted` are open for community contributions
+   - Look for issues labelled `good first issue` for beginner-friendly tasks
+   - Issues labelled `help wanted` are open for community contributions
 2. **Pick an Issue**: Choose an issue that interests you and matches your skill level
 3. **Comment on the Issue**: Let us know you're working on it to avoid duplicate effort
 4. **Fork the Repository**: Create your own fork to work on
@@ -14,7 +14,7 @@ Thank you for your interest in contributing to Code Graph RAG! We welcome contri
 
 ### Issue Labels
 
-Our repository uses standardized labels to categorize issues and PRs:
+Our repository uses standardised labels to categorise issues and PRs:
 
 | Label              | Purpose                                                           |
 | ------------------ | ----------------------------------------------------------------- |
@@ -151,7 +151,7 @@ This process ensures that human reviewers focus on high-level design and logic r
 
 ### Code Standards
 
-- **Heavy Pydantic Usage**: Use Pydantic models extensively for data validation, serialization, and configuration
+- **Heavy Pydantic Usage**: Use Pydantic models extensively for data validation, serialisation, and configuration
 - **Package Management**: Use `uv` for all dependency management and virtual environments
 - **Code Quality**: Use `ruff` for linting and formatting - run `ruff check` and `ruff format` before submitting
 - **Type Safety**: Use type hints everywhere and run `uv run ty check` for type checking
@@ -220,8 +220,8 @@ uv run ruff format .
 | **StrEnum**            | Constrained string constants used in comparisons, defaults, assignments |
 | **NamedTuple**         | Immutable records with named fields (lightweight, hashable)             |
 | **TypedDict**          | Dict shapes for function return types or JSON-like data                 |
-| **dataclass**          | Mutable class instances with behavior/methods                           |
-| **Pydantic BaseModel** | Configs needing validation, serialization, or schema generation         |
+| **dataclass**          | Mutable class instances with behaviour/methods                           |
+| **Pydantic BaseModel** | Configs needing validation, serialisation, or schema generation         |
 
 ```python
 from dataclasses import dataclass
@@ -330,14 +330,14 @@ class MyProtocol(Protocol):
 
 Only use `Callable` attributes when reusing complex callable types is necessary.
 
-### Code Organization
+### Code Organisation
 
 #### File Structure
 
 Standard files in each module:
 
 - `types_defs.py` - Type aliases, TypedDicts, NamedTuples (immutable structural types)
-- `models.py` - Dataclasses only (runtime data structures with behavior)
+- `models.py` - Dataclasses only (runtime data structures with behaviour)
 - `constants.py` - StrEnums, string literals, and application constants
 - `config.py` - Pydantic settings, environment config, and runtime configuration instances
 - `schemas.py` - All Pydantic BaseModel classes (data transfer objects, results, responses)
@@ -345,7 +345,7 @@ Standard files in each module:
 - `tool_errors.py` - Error messages returned by tools to the LLM/user
 - `exceptions.py` - Exception classes and their error message templates (for raise statements)
 
-#### Modularization
+#### Modularisation
 
 - Soft rule: keep files under 700 lines (after linting); split larger files into submodules
 - Group related functionality into submodules (e.g., `stem_ops/`, `tools/`, `srg_parser/`)
@@ -416,9 +416,9 @@ def process(mode: Mode = Mode.FAST): ...
 if status == Status.PENDING: ...
 ```
 
-#### Centralized Error Messages
+#### Centralised Error Messages
 
-Use an Enum with `__call__` for parameterized error messages:
+Use an Enum with `__call__` for parameterised error messages:
 
 ```python
 from enum import Enum
@@ -627,7 +627,7 @@ If a helper function is trivial and used once, inline it.
 
 #### Move Assignments Close to Usage
 
-Declare variables as close to their usage as possible to minimize cognitive load and prevent stranded variables:
+Declare variables as close to their usage as possible to minimise cognitive load and prevent stranded variables:
 
 ```python
 # Bad - assignment far from usage

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -1,6 +1,6 @@
 # Code-Graph-RAG
 
-A graph-based RAG system that parses multi-language codebases with Tree-sitter, builds knowledge graphs in Memgraph, and enables natural language querying, editing, and optimization.
+A graph-based RAG system that parses multi-language codebases with Tree-sitter, builds knowledge graphs in Memgraph, and enables natural language querying, editing, and optimisation.
 
 ## Install
 
@@ -61,7 +61,7 @@ cgr index -o ./index-output --repo-path ./my-project
 cgr export -o graph.json
 ```
 
-**AI-guided optimization:**
+**AI-guided optimisation:**
 
 ```bash
 cgr optimize python --repo-path ./my-project

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@
 
 # Code-Graph-RAG
 
-Code-Graph-RAG parses a multi-language codebase with Tree-sitter, builds a knowledge graph of its structure in Memgraph, and lets you query, edit, and optimize that code in plain English. It works across a monorepo of mixed languages under one unified graph schema.
+Code-Graph-RAG parses a multi-language codebase with Tree-sitter, builds a knowledge graph of its structure in Memgraph, and lets you query, edit, and optimise that code in plain English. It works across a monorepo of mixed languages under one unified graph schema.
 
 <p align="center">
   <img src="./assets/demo.gif" alt="demo">
@@ -77,7 +77,7 @@ Point Code-Graph-RAG at a repository and it reads every source file, extracts fu
 - Ask questions about the codebase in natural language and get answers grounded in the real structure.
 - Retrieve the actual source of any function, class, or method by name or by intent.
 - Edit code through the agent with AST-based surgical patching and a diff preview before anything changes.
-- Optimize code against language best practices or your own coding standards.
+- Optimise code against language best practices or your own coding standards.
 - Find dead code by walking call and reference edges from entry points.
 - Search and rewrite structurally by AST pattern with ast-grep.
 
@@ -86,7 +86,7 @@ Point Code-Graph-RAG at a repository and it reads every source file, extracts fu
 The system has two components:
 
 1. **Multi-language parser.** A Tree-sitter based parser reads the codebase and ingests functions, classes, methods, modules, and their relationships into Memgraph under a single language-agnostic schema.
-2. **RAG system** (`codebase_rag/`). An interactive CLI that turns natural language into Cypher queries, retrieves matching code, and drives AI-powered editing and optimization.
+2. **RAG system** (`codebase_rag/`). An interactive CLI that turns natural language into Cypher queries, retrieves matching code, and drives AI-powered editing and optimisation.
 
 ```
 Source Code -> Tree-sitter Parser -> AST Analysis -> Memgraph Knowledge Graph
@@ -141,7 +141,7 @@ Code-Graph-RAG runs as an [MCP](https://modelcontextprotocol.io) server so Claud
 **User Guide**
 - [CLI Reference](docs/guide/cli-reference.md)
 - [Interactive Querying](docs/guide/interactive-querying.md)
-- [Code Optimization](docs/guide/code-optimization.md)
+- [Code Optimisation](docs/guide/code-optimization.md)
 - [Dead Code Detection](docs/guide/dead-code.md)
 - [Graph Export](docs/guide/graph-export.md)
 - [Real-Time Updates](docs/guide/realtime-updates.md)
@@ -167,10 +167,10 @@ Code-Graph-RAG runs as an [MCP](https://modelcontextprotocol.io) server so Claud
 
 ## Enterprise Services
 
-Code-Graph-RAG is open source and free to use. For organizations that need more, we offer **fully managed cloud-hosted solutions** and **on-premise deployments**:
+Code-Graph-RAG is open source and free to use. For organisations that need more, we offer **fully managed cloud-hosted solutions** and **on-premise deployments**:
 
 - **Cloud-Hosted Deployment**: Managed cloud infrastructure for both the graph database and the AI agent connection. Zero infrastructure overhead, so we handle scaling, updates, and availability while your team focuses on building.
-- **On-Premise & Air-Gapped Deployment**: Deploy Code-Graph-RAG entirely within your own environment, including air-gapped networks. Full data sovereignty for regulated industries and security-sensitive organizations.
+- **On-Premise & Air-Gapped Deployment**: Deploy Code-Graph-RAG entirely within your own environment, including air-gapped networks. Full data sovereignty for regulated industries and security-sensitive organisations.
 
 We also offer custom development, integration consulting, technical support contracts, and team training.
 

--- a/codebase_rag/cli_help.py
+++ b/codebase_rag/cli_help.py
@@ -21,7 +21,7 @@ class CLICommandName(StrEnum):
 
 
 APP_DESCRIPTION = (
-    "Analyze source code with Tree-sitter, store its structure in a shared "
+    "Analyse source code with Tree-sitter, store its structure in a shared "
     "knowledge graph, and query it in natural language."
 )
 APP_EPILOG = "Run 'cgr help COMMAND' for details about a command."
@@ -34,7 +34,7 @@ PANEL_HELP = "Help"
 CMD_START = "Open the code assistant for a repository or workspace"
 CMD_INDEX = "Write an offline protobuf index for a repository"
 CMD_EXPORT = "Export the shared graph database to JSON"
-CMD_OPTIMIZE = "Run a language-focused code optimization session"
+CMD_OPTIMIZE = "Run a language-focused code optimisation session"
 CMD_MCP_SERVER = "Serve cgr tools over stdio or HTTP"
 CMD_GRAPH_LOADER = "Summarize an exported graph JSON file"
 CMD_LANGUAGE = "Manage language grammars and parser metadata"
@@ -108,7 +108,7 @@ HELP_DAEMON_LOGS_SERVICE = (
     "Show only SERVICE logs (memgraph, qdrant, or lab). By default, show all services."
 )
 HELP_NO_START_STACK = "Do not start the shared stack automatically."
-HELP_NO_SYNC = "Do not synchronize the graph before starting the assistant."
+HELP_NO_SYNC = "Do not synchronise the graph before starting the assistant."
 HELP_NO_EMBEDDINGS = (
     "Do not generate semantic embeddings during sync. Graph nodes and relationships "
     "are still updated. Equivalent env: CGR_SKIP_EMBEDDINGS=1."
@@ -134,7 +134,7 @@ HELP_NO_INSTRUCTIONS = (
 
 HELP_REPO_PATH_RETRIEVAL = "Repository to open. Defaults to the current directory."
 HELP_REPO_PATH_INDEX = "Repository to index. Defaults to the current directory."
-HELP_REPO_PATH_OPTIMIZE = "Repository to optimize. Defaults to the current directory."
+HELP_REPO_PATH_OPTIMIZE = "Repository to optimise. Defaults to the current directory."
 HELP_REPO_PATH_WATCH = "Repository to watch."
 HELP_VERSION = "Show the version and exit."
 HELP_QUIET = "Suppress progress, banners, and informational logs."
@@ -154,8 +154,8 @@ HELP_OUTPUT_PATH = "Write the exported graph to PATH."
 HELP_OUTPUT_PROTO_DIR = "Write protobuf index files under DIRECTORY."
 HELP_SPLIT_INDEX = "Write separate nodes.bin and relationships.bin files."
 HELP_FORMAT_JSON = "Use JSON output. Other export formats are not supported."
-HELP_LANGUAGE_ARG = "Language to optimize, such as python, java, javascript, or cpp."
-HELP_REFERENCE_DOC = "Reference document to use during optimization."
+HELP_LANGUAGE_ARG = "Language to optimise, such as python, java, javascript, or cpp."
+HELP_REFERENCE_DOC = "Reference document to use during optimisation."
 HELP_GRAPH_FILE = "Exported graph JSON file to load."
 HELP_EXPORTED_GRAPH_FILE = "Path to the exported_graph.json file."
 

--- a/codebase_rag/tools/tool_descriptions.py
+++ b/codebase_rag/tools/tool_descriptions.py
@@ -186,7 +186,7 @@ MCP_STRUCTURAL_REPLACE = (
 
 MCP_ASK_AGENT = (
     "Ask the Code Graph RAG agent a question about the codebase. "
-    "Uses the full RAG pipeline to analyze the code graph and provide a detailed answer. "
+    "Uses the full RAG pipeline to analyse the code graph and provide a detailed answer. "
     "Use this for general questions about architecture, functionality, and code relationships."
 )
 

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -311,11 +311,11 @@ ORANGE_STYLE = Style.from_dict(
 )
 
 OPTIMIZATION_LOOP_UI = AgentLoopUI(
-    status_message="[bold green]Agent is analyzing codebase... (Press Ctrl+C to cancel)[/bold green]",
+    status_message="[bold green]Agent is analysing codebase... (Press Ctrl+C to cancel)[/bold green]",
     cancelled_log="ASSISTANT: [Analysis was cancelled]",
-    approval_prompt="Do you approve this optimization?",
-    denial_default="User rejected this optimization without feedback",
-    panel_title="[bold green]Optimization Agent[/bold green]",
+    approval_prompt="Do you approve this optimisation?",
+    denial_default="User rejected this optimisation without feedback",
+    panel_title="[bold green]Optimisation Agent[/bold green]",
 )
 
 CHAT_LOOP_UI = AgentLoopUI(

--- a/docs/advanced/adding-languages.md
+++ b/docs/advanced/adding-languages.md
@@ -28,7 +28,7 @@ cgr language add-grammar kotlin
 
 ## Custom Grammar Repositories
 
-For languages hosted outside the standard tree-sitter organization:
+For languages hosted outside the standard tree-sitter organisation:
 
 ```bash
 cgr language add-grammar --grammar-url https://github.com/custom/tree-sitter-mylang
@@ -40,7 +40,7 @@ When you add a language, the tool automatically:
 
 1. **Downloads the Grammar**: Clones the tree-sitter grammar repository as a git submodule
 2. **Detects Configuration**: Auto-extracts language metadata from `tree-sitter.json`
-3. **Analyzes Node Types**: Automatically identifies AST node types for functions/methods, classes/structs, modules/files, and function calls
+3. **Analyses Node Types**: Automatically identifies AST node types for functions/methods, classes/structs, modules/files, and function calls
 4. **Compiles Bindings**: Builds Python bindings from the grammar source
 5. **Updates Configuration**: Adds the language to `codebase_rag/language_config.py`
 6. **Enables Parsing**: Makes the language immediately available for codebase analysis

--- a/docs/architecture/data-flow-edges.md
+++ b/docs/architecture/data-flow-edges.md
@@ -268,7 +268,7 @@ Within a function body, taint moves and disappears by these rules:
 
 A multi-hop chain like `a = getenv(...); b = a; c = b; print(c)` might look as if
 it needs a backward search from the sink (`print`) down through `c → b → a` to
-the source. It does not. The analyzer makes a **single forward pass**, top to
+the source. It does not. The analyser makes a **single forward pass**, top to
 bottom, carrying one live table:
 
 > `tainted` = { variable name → the **origin resource** it currently carries }

--- a/docs/architecture/language-support.md
+++ b/docs/architecture/language-support.md
@@ -29,7 +29,7 @@ Code-Graph-RAG uses Tree-sitter for language-agnostic AST parsing with a unified
 
 ## Language-Agnostic Design
 
-All languages share a unified graph schema, meaning queries work the same way regardless of language. You can query across languages in the same knowledge graph when analyzing polyglot repositories.
+All languages share a unified graph schema, meaning queries work the same way regardless of language. You can query across languages in the same knowledge graph when analysing polyglot repositories.
 
 ## Adding New Languages
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -4,13 +4,13 @@ description: "Architecture overview of Code-Graph-RAG's two-component system for
 
 # Architecture Overview
 
-Code-Graph-RAG consists of two main components that work together to analyze and query codebases.
+Code-Graph-RAG consists of two main components that work together to analyse and query codebases.
 
 ## Components
 
 ### 1. Multi-Language Parser
 
-A Tree-sitter based parsing system that analyzes codebases and ingests data into Memgraph.
+A Tree-sitter based parsing system that analyses codebases and ingests data into Memgraph.
 
 - Uses Tree-sitter for robust, language-agnostic AST parsing
 - Extracts functions, classes, methods, modules, and their relationships
@@ -24,7 +24,7 @@ An interactive CLI for querying the stored knowledge graph.
 - Translates natural language questions into Cypher queries
 - Retrieves source code snippets for found elements
 - Supports AI-powered code editing with AST-based targeting
-- Provides code optimization with interactive approval workflow
+- Provides code optimisation with interactive approval workflow
 
 ## Data Flow
 

--- a/docs/claude-code-setup.md
+++ b/docs/claude-code-setup.md
@@ -39,7 +39,7 @@ claude mcp add --transport stdio code-graph-rag \
 ```
 
 **Replace**:
-- `/absolute/path/to/your/project` - Your codebase to analyze
+- `/absolute/path/to/your/project` - Your codebase to analyse
 - `/absolute/path/to/code-graph-rag` - Where you cloned this repo
 - `your-google-api-key` - Your Google AI API key
 
@@ -121,7 +121,7 @@ claude mcp add --transport stdio code-graph-rag-frontend \
 
 **Can't find uv/code-graph-rag**: Use absolute paths from `which uv`
 
-**Wrong repository analyzed**:
+**Wrong repository analysed**:
 - Without `TARGET_REPO_PATH`: MCP uses the directory where Claude Code is opened
 - With `TARGET_REPO_PATH`: MCP always uses that specific path (must be absolute)
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -78,7 +78,7 @@ This project uses automated code review bots (**Greptile** and **Gemini Code Ass
 ## Technical Requirements
 
 - **PydanticAI Only**: Do not introduce other agentic frameworks (LangChain, CrewAI, AutoGen, etc.)
-- **Heavy Pydantic Usage**: Use Pydantic models for data validation, serialization, and configuration
+- **Heavy Pydantic Usage**: Use Pydantic models for data validation, serialisation, and configuration
 - **Package Management**: Use `uv` for all dependency management
 - **Code Quality**: Use `ruff` for linting and formatting
 - **Type Safety**: Use type hints everywhere and run `uv run ty check`

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -98,6 +98,6 @@ for func in functions[:5]:
 
 - [CLI Reference](../guide/cli-reference.md) for all available commands
 - [Interactive Querying](../guide/interactive-querying.md) for query examples
-- [Code Optimization](../guide/code-optimization.md) for AI-powered improvements
+- [Code Optimisation](../guide/code-optimization.md) for AI-powered improvements
 - [MCP Server](../guide/mcp-server.md) for Claude Code integration
 - [Python SDK](../sdk/overview.md) for programmatic access

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -48,7 +48,7 @@ cgr export -o my_graph.json
 
 ### `cgr optimize`
 
-AI-powered codebase optimization.
+AI-powered codebase optimisation.
 
 ```bash
 cgr optimize <language> --repo-path /path/to/repo [OPTIONS]
@@ -59,7 +59,7 @@ cgr optimize <language> --repo-path /path/to/repo [OPTIONS]
 | `--repo-path` | Path to repository |
 | `--orchestrator` | Specify provider:model for operations |
 | `--batch-size` | Override Memgraph flush batch size |
-| `--reference-document` | Path to reference documentation for guided optimization |
+| `--reference-document` | Path to reference documentation for guided optimisation |
 
 Supported languages: `python`, `javascript`, `typescript`, `rust`, `go`, `java`, `scala`, `c`, `cpp`
 

--- a/docs/guide/code-optimization.md
+++ b/docs/guide/code-optimization.md
@@ -1,10 +1,10 @@
 ---
-description: "AI-powered codebase optimization with language-specific best practices and interactive approval."
+description: "AI-powered codebase optimisation with language-specific best practices and interactive approval."
 ---
 
-# Code Optimization
+# Code Optimisation
 
-Code-Graph-RAG provides AI-powered codebase optimization with best practices guidance and an interactive approval workflow.
+Code-Graph-RAG provides AI-powered codebase optimisation with best practices guidance and an interactive approval workflow.
 
 ## Basic Usage
 
@@ -14,7 +14,7 @@ cgr optimize python --repo-path /path/to/your/repo
 
 ## With Reference Documentation
 
-Guide the optimization process using your own coding standards:
+Guide the optimisation process using your own coding standards:
 
 ```bash
 cgr optimize python \
@@ -32,7 +32,7 @@ cgr optimize rust \
   --reference-document ./docs/performance_guide.md
 ```
 
-The agent incorporates guidance from your reference documents when suggesting optimizations, ensuring they align with your project's standards and architectural decisions.
+The agent incorporates guidance from your reference documents when suggesting optimisations, ensuring they align with your project's standards and architectural decisions.
 
 ## Using Specific Models
 
@@ -53,10 +53,10 @@ All supported languages: `python`, `javascript`, `typescript`, `rust`, `go`, `ja
 
 ## How It Works
 
-1. **Analysis Phase**: The agent analyzes your codebase structure using the knowledge graph
+1. **Analysis Phase**: The agent analyses your codebase structure using the knowledge graph
 2. **Pattern Recognition**: Identifies common anti-patterns, performance issues, and improvement opportunities
 3. **Best Practices Application**: Applies language-specific best practices and patterns
-4. **Interactive Approval**: Presents each optimization suggestion for your approval before implementation
+4. **Interactive Approval**: Presents each optimisation suggestion for your approval before implementation
 5. **Guided Implementation**: Implements approved changes with detailed explanations
 
 ## Example Session

--- a/docs/guide/interactive-querying.md
+++ b/docs/guide/interactive-querying.md
@@ -24,7 +24,7 @@ cgr start --repo-path /path/to/your/repo
 - "Find Rust structs and their methods"
 - "Show me Go interfaces and implementations"
 
-### Analyzing Relationships
+### Analysing Relationships
 
 - "Find all functions that call each other"
 - "What classes are in the user module"
@@ -35,7 +35,7 @@ cgr start --repo-path /path/to/your/repo
 ### C++ Specific Queries
 
 - "Find all C++ operator overloads in the Matrix class"
-- "Show me C++ template functions with their specializations"
+- "Show me C++ template functions with their specialisations"
 - "List all C++ namespaces and their contained classes"
 - "Find C++ lambda expressions used in algorithms"
 
@@ -45,7 +45,7 @@ cgr start --repo-path /path/to/your/repo
 - "Refactor the User class to use dependency injection"
 - "Convert these Python functions to async/await pattern"
 - "Add error handling to authentication methods"
-- "Optimize this function for better performance"
+- "Optimise this function for better performance"
 
 ## Semantic Code Search
 

--- a/docs/guide/mcp-server.md
+++ b/docs/guide/mcp-server.md
@@ -72,7 +72,7 @@ docker run -p 7687:7687 -p 7444:7444 memgraph/memgraph-platform
 | `semantic_search` | Performs a semantic search for functions based on a natural language query describing their purpose, returning a list of potential matches with similarity scores. Requires the 'semantic' extra to be installed. |
 | `structural_search` | Search code structurally by AST pattern using ast-grep syntax (not text/regex). Returns file paths, line and column numbers, and the matched code. Requires the 'ast-grep' extra to be installed. |
 | `structural_replace` | Rewrite code structurally by AST pattern using ast-grep syntax. Metavariables captured by the pattern are substituted into the rewrite. Defaults to dry_run (returns a diff); set dry_run=false to write changes. Requires the 'ast-grep' extra to be installed. |
-| `ask_agent` | Ask the Code Graph RAG agent a question about the codebase. Uses the full RAG pipeline to analyze the code graph and provide a detailed answer. Use this for general questions about architecture, functionality, and code relationships. |
+| `ask_agent` | Ask the Code Graph RAG agent a question about the codebase. Uses the full RAG pipeline to analyse the code graph and provide a detailed answer. Use this for general questions about architecture, functionality, and code relationships. |
 <!-- /SECTION:mcp_tools -->
 
 ## Example Usage
@@ -136,7 +136,7 @@ claude mcp add --transport stdio code-graph-rag-frontend \
 | Issue | Solution |
 |-------|----------|
 | Can't find uv/code-graph-rag | Use absolute paths from `which uv` |
-| Wrong repository analyzed | Set `TARGET_REPO_PATH` to an absolute path |
+| Wrong repository analysed | Set `TARGET_REPO_PATH` to an absolute path |
 | Memgraph connection failed | Ensure `docker ps` shows Memgraph running |
 | Tools not showing | Run `claude mcp list` to verify installation |
 

--- a/docs/guide/realtime-updates.md
+++ b/docs/guide/realtime-updates.md
@@ -1,10 +1,10 @@
 ---
-description: "Keep your Code-Graph-RAG knowledge graph synchronized with code changes using the real-time file watcher."
+description: "Keep your Code-Graph-RAG knowledge graph synchronised with code changes using the real-time file watcher."
 ---
 
 # Real-Time Graph Updates
 
-For active development, keep your knowledge graph automatically synchronized with code changes using the real-time updater.
+For active development, keep your knowledge graph automatically synchronised with code changes using the real-time updater.
 
 ## What It Does
 
@@ -59,4 +59,4 @@ cgr start --repo-path ~/my-project
 
 ## Performance Note
 
-The updater currently recalculates all CALLS relationships on every file change to ensure consistency. This prevents "island" problems where changes in one file aren't reflected in relationships from other files, but may impact performance on very large codebases with frequent changes. Optimization of this behavior is a work in progress.
+The updater currently recalculates all CALLS relationships on every file change to ensure consistency. This prevents "island" problems where changes in one file aren't reflected in relationships from other files, but may impact performance on very large codebases with frequent changes. Optimisation of this behaviour is a work in progress.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 ---
-description: "Graph-based RAG system that parses multi-language codebases with Tree-sitter, builds knowledge graphs, and enables natural language querying, editing, and optimization."
+description: "Graph-based RAG system that parses multi-language codebases with Tree-sitter, builds knowledge graphs, and enables natural language querying, editing, and optimisation."
 ---
 
 # Code-Graph-RAG
@@ -12,7 +12,7 @@ description: "Graph-based RAG system that parses multi-language codebases with T
 
 ## What is Code-Graph-RAG?
 
-Code-Graph-RAG is an accurate Retrieval-Augmented Generation (RAG) system that analyzes multi-language codebases using Tree-sitter, builds comprehensive knowledge graphs in Memgraph, and enables natural language querying of codebase structure and relationships as well as editing capabilities.
+Code-Graph-RAG is an accurate Retrieval-Augmented Generation (RAG) system that analyses multi-language codebases using Tree-sitter, builds comprehensive knowledge graphs in Memgraph, and enables natural language querying of codebase structure and relationships as well as editing capabilities.
 
 ## Key Features
 
@@ -24,8 +24,8 @@ Code-Graph-RAG is an accurate Retrieval-Augmented Generation (RAG) system that a
 - **Code Snippet Retrieval** with actual source code for found functions and methods
 - **Advanced File Editing** with AST-based function targeting and visual diff previews
 - **Shell Command Execution** for running tests and CLI tools
-- **Interactive Code Optimization** with language-specific best practices
-- **Reference-Guided Optimization** using your own coding standards
+- **Interactive Code Optimisation** with language-specific best practices
+- **Reference-Guided Optimisation** using your own coding standards
 - **Dead Code Detection** to find functions unreachable from any entry point
 - **Dependency Analysis** from `pyproject.toml`
 - **Semantic Code Search** using UniXcoder embeddings to find functions by intent
@@ -44,6 +44,6 @@ See the [Installation](getting-started/installation.md) guide for full setup ins
 
 ## Enterprise Services
 
-Code-Graph-RAG is open source and free to use. For organizations that need more, we offer **fully managed cloud-hosted solutions** and **on-premise deployments**.
+Code-Graph-RAG is open source and free to use. For organisations that need more, we offer **fully managed cloud-hosted solutions** and **on-premise deployments**.
 
 [View plans & pricing at code-graph-rag.com](https://code-graph-rag.com/enterprise){ .md-button }

--- a/docs/reports/BENCHMARK_REPORT.md
+++ b/docs/reports/BENCHMARK_REPORT.md
@@ -62,9 +62,9 @@ Convert paths to strings at the boundary of `should_skip_path` and use `str.remo
 
 ---
 
-## FINDING 3: orjson vs stdlib json (JSON Serialization)
+## FINDING 3: orjson vs stdlib json (JSON Serialisation)
 
-**orjson provides massive speedups on serialization with zero integration overhead.**
+**orjson provides massive speedups on serialisation with zero integration overhead.**
 
 ### Measured Results
 
@@ -83,11 +83,11 @@ Convert paths to strings at the boundary of `should_skip_path` and use `str.remo
 ### Projected vs Measured
 
 The language recommendations projected 5x to 15x. Our measured results show:
-- **Compact serialization: 5.4x to 5.7x** (within projected range)
-- **Indented serialization: 24x to 25x** (exceeds projected range significantly)
-- **Deserialization: 1.8x to 2.0x** (below projected range)
+- **Compact serialisation: 5.4x to 5.7x** (within projected range)
+- **Indented serialisation: 24x to 25x** (exceeds projected range significantly)
+- **Deserialisation: 1.8x to 2.0x** (below projected range)
 
-The indented serialization speedup is particularly relevant because `_write_graph_json` uses `json.dump(data, f, indent=2)` (the slowest path). For a 20K node graph, this drops from 217ms to 8.6ms.
+The indented serialisation speedup is particularly relevant because `_write_graph_json` uses `json.dump(data, f, indent=2)` (the slowest path). For a 20K node graph, this drops from 217ms to 8.6ms.
 
 ---
 
@@ -166,7 +166,7 @@ GraphLoader.load() is 2x to 2.7x slower than raw JSON parsing due to index const
 
 ### Analysis
 
-SHA256 with 8KB buffer is already the fastest option. Larger buffers and mmap add overhead for these file sizes. MD5 is slower (no hardware acceleration on this platform). File hashing consumes <0.5% of total runtime. No optimization needed.
+SHA256 with 8KB buffer is already the fastest option. Larger buffers and mmap add overhead for these file sizes. MD5 is slower (no hardware acceleration on this platform). File hashing consumes <0.5% of total runtime. No optimisation needed.
 
 ---
 
@@ -179,7 +179,7 @@ SHA256 with 8KB buffer is already the fastest option. Larger buffers and mmap ad
 | orjson for JSON | 5x to 15x on JSON ops | **1.8x to 25x** depending on operation | **VALIDATED** |
 | BLAKE3 for hashing | 4x to 10x speedup | **0.5x (slower)** | **INVALIDATED** |
 | neo4j-rust-ext | 3x to 10x on DB ops | N/A (wrong driver) | **INVALIDATED** (uses Memgraph/pymgclient) |
-| Rust AST extension | 10x to 16x on parsing | Not benchmarked (3.1% of CPU) | **DEPRIORITIZED** (targets 3.1% of runtime) |
+| Rust AST extension | 10x to 16x on parsing | Not benchmarked (3.1% of CPU) | **DEPRIORITISED** (targets 3.1% of runtime) |
 | Rust trie | 3x to 8x on lookups | 1.5x to 3x net (per feasibility) | **SUPERSEDED** by Python index fix |
 
 ## Revised Priority Order (Measured)
@@ -188,7 +188,7 @@ SHA256 with 8KB buffer is already the fastest option. Larger buffers and mmap ad
 |---|---|---|---|---|
 | **1** | Fix `find_ending_with` suffix index | Python bugfix | 261x to 382x on operation (~1.9x total) | Low |
 | **2** | Replace pathlib with string ops | Python refactor | 45x to 643x on path ops (~1.15x total) | Low |
-| **3** | Cache type inference results | Python memoization | Not benchmarked (projected ~1.07x total) | Low |
+| **3** | Cache type inference results | Python memoisation | Not benchmarked (projected ~1.07x total) | Low |
 | **4** | Suppress debug logging | Config change | Not benchmarked (projected ~1.06x total) | Trivial |
 | **5** | Deduplicate FS traversal | Python refactor | Not benchmarked (projected ~1.05x total) | Low |
 | **6** | orjson for JSON | Dependency swap | 5.4x to 25x on JSON ops | Trivial |

--- a/docs/reports/INTEGRATION_FEASIBILITY.md
+++ b/docs/reports/INTEGRATION_FEASIBILITY.md
@@ -17,7 +17,7 @@
 Drop-in dependency swap. Replace `import json` with `import orjson` in graph_loader.py, graph_updater.py, services/graph_service.py, embedder.py, stdlib_extractor.py.
 
 ### Integration Overhead
-- **Serialization boundary:** Zero. orjson is a direct Python C extension. No FFI marshalling.
+- **Serialisation boundary:** Zero. orjson is a direct Python C extension. No FFI marshalling.
 - **API difference:** `orjson.dumps()` returns `bytes` not `str`. Every `json.dumps()` call site that feeds the result to something expecting `str` needs `.decode()`. In this codebase, the `_write_graph_json` function in `main.py` uses `json.dump(graph_data, f, indent=2, ensure_ascii=False)` which would need adjustment since orjson's `OPT_INDENT_2` flag replaces the `indent` parameter.
 - **Protobuf service:** `services/protobuf_service.py` does not use JSON. No impact.
 - **Hash cache I/O:** `_save_hash_cache` and `_load_hash_cache` use `json.dump/load` with file objects. orjson does not support file-object streaming; need to call `orjson.dumps()` then `f.write()`.
@@ -46,9 +46,9 @@ NOT APPLICABLE. This codebase uses **Memgraph** via `pymgclient` (mgclient C lib
 
 ### Alternative for Memgraph Driver
 - pymgclient is already a C extension wrapping Memgraph's C client library. It is already compiled code.
-- The actual overhead is in Python-side batch construction (building `list[RelBatchRow]` and `list[NodeBatchRow]` dicts), Cypher query string formatting, and result deserialization in `_cursor_to_results`.
+- The actual overhead is in Python-side batch construction (building `list[RelBatchRow]` and `list[NodeBatchRow]` dicts), Cypher query string formatting, and result deserialisation in `_cursor_to_results`.
 - The `_cursor_to_results` method iterates cursor results and builds `list[ResultRow]` via `dict(zip(column_names, row))`. This is pure Python overhead.
-- Potential optimization: Use cursor iteration in C rather than Python, but this requires pymgclient changes, not neo4j-rust-ext.
+- Potential optimisation: Use cursor iteration in C rather than Python, but this requires pymgclient changes, not neo4j-rust-ext.
 
 ### Net Projected Gain
 - **Net gain:** 0x. This recommendation is inapplicable.
@@ -61,7 +61,7 @@ NOT APPLICABLE. This codebase uses **Memgraph** via `pymgclient` (mgclient C lib
 Drop-in hash function replacement in `EmbeddingCache._content_hash()` and `_hash_file()` in `graph_updater.py`.
 
 ### Integration Overhead
-- **Serialization boundary:** Zero. blake3 Python package is a C extension.
+- **Serialisation boundary:** Zero. blake3 Python package is a C extension.
 - **API change:** `hashlib.sha256(content.encode()).hexdigest()` becomes `blake3.blake3(content.encode()).hexdigest()`. One-line change per call site.
 - **Cache invalidation:** Existing embedding caches (`.qdrant_code_embeddings/embedding_cache.json`) and file hash caches (`.file_hashes.json`) will be invalidated because hash values change. This forces a full re-index on first run after the change.
 - **Build system change:** Add `blake3>=1.0.0` to dependencies. blake3 publishes pre-built wheels.
@@ -184,17 +184,17 @@ Expose a Rust-backed trie as a Python class via PyO3, bundled in the same crate 
 ## Candidate 6: File Processing Parallelism (Python)
 
 ### Integration Strategy
-Use `concurrent.futures.ProcessPoolExecutor` to parallelize per-file processing in `GraphUpdater._process_files()`.
+Use `concurrent.futures.ProcessPoolExecutor` to parallelise per-file processing in `GraphUpdater._process_files()`.
 
 ### Integration Overhead Assessment
 
-**Serialization at boundary:**
-- Each worker process needs: file path (Path, serializable), language queries (NOT serializable: contains tree-sitter Parser, Query, Language objects which are C pointers).
-- **Critical problem:** `LanguageQueries` contains `Parser`, `Query`, and `Language` objects from tree-sitter, which are C-level objects that cannot be serialized across process boundaries.
+**Serialisation at boundary:**
+- Each worker process needs: file path (Path, serialisable), language queries (NOT serialisable: contains tree-sitter Parser, Query, Language objects which are C pointers).
+- **Critical problem:** `LanguageQueries` contains `Parser`, `Query`, and `Language` objects from tree-sitter, which are C-level objects that cannot be serialised across process boundaries.
 - Each worker would need to call `load_parsers()` independently, loading all language grammars (~50ms startup cost per worker).
-- Results (function definitions, call relationships) are Python dicts/tuples that serialize easily.
+- Results (function definitions, call relationships) are Python dicts/tuples that serialise easily.
 
-**State synchronization:**
+**State synchronisation:**
 - `FunctionRegistryTrie` is shared mutable state. Workers write to it during function registration, and readers need it during call resolution.
 - With multiprocessing, each worker would have its own trie. Merging tries after parallel processing adds complexity.
 - `import_mapping` in `ImportProcessor` is similarly shared mutable state.
@@ -202,14 +202,14 @@ Use `concurrent.futures.ProcessPoolExecutor` to parallelize per-file processing 
 
 **GIL considerations:**
 - `threading.Thread` would not help because call resolution is CPU-bound Python code held by the GIL.
-- `ProcessPoolExecutor` bypasses GIL but introduces serialization overhead.
-- Estimated per-file serialization overhead for results: ~0.1ms per file.
-- For 1000 files on 4 cores: ~25ms total serialization overhead vs ~5000ms saved.
+- `ProcessPoolExecutor` bypasses GIL but introduces serialisation overhead.
+- Estimated per-file serialisation overhead for results: ~0.1ms per file.
+- For 1000 files on 4 cores: ~25ms total serialisation overhead vs ~5000ms saved.
 
 ### Net Projected Gain
 - **Raw gain:** 2x to 4x (limited by sequential passes and Amdahl's law)
-- **Serialization overhead:** ~5ms for 1000 files (minimal)
-- **Worker initialization overhead:** ~50ms per worker (grammar loading), amortized across files
+- **Serialisation overhead:** ~5ms for 1000 files (minimal)
+- **Worker initialisation overhead:** ~50ms per worker (grammar loading), amortised across files
 - **Architecture complexity:** High. Requires restructuring the three-pass processing pipeline, managing shared state (trie, import maps), and handling errors across processes.
 - **Net gain:** 1.5x to 3x after accounting for sequential bottlenecks (pass dependencies)
 - **Recommendation:** Medium priority. Worth doing after Candidate 4 (Rust extension) is evaluated. If Candidate 4 makes per-file processing fast enough, parallelism becomes less critical.
@@ -252,7 +252,7 @@ This validates the principle: **a function 10x faster but with 8x overhead at th
 
 **Candidate 2 is completely inapplicable** due to incorrect driver assumption.
 
-**Candidate 3 optimizes a non-bottleneck** (microsecond-level operations).
+**Candidate 3 optimises a non-bottleneck** (microsecond-level operations).
 
 The only candidates with clear positive ROI accounting for integration overhead are:
 1. **orjson** (zero overhead, significant JSON gains)
@@ -291,7 +291,7 @@ The CPU profiling report (cProfile, 31.2s total, 179M function calls on 352 Pyth
 2. **Build a suffix index:** Create a `dict[str, set[QualifiedName]]` mapping the last dot-separated segment of every qualified name to its full name. This converts O(n) scans to O(1) lookups.
 3. **Cache negative results:** If a suffix has been scanned and yielded no results, cache that fact to avoid re-scanning.
 
-**Integration overhead:** Zero. This is a bugfix/optimization within existing Python code.
+**Integration overhead:** Zero. This is a bugfix/optimisation within existing Python code.
 **Projected gain:** Eliminating 15.07s (48.3% of total) would reduce total runtime from 31.2s to ~16.1s. Even a 90% reduction (fixing most misses) saves ~13.5s.
 **Net gain:** ~1.9x total speedup from a pure Python fix.
 **Risk:** Very low.
@@ -311,7 +311,7 @@ The CPU profiling report (cProfile, 31.2s total, 179M function calls on 352 Pyth
 
 #### NEW CANDIDATE C: Cache `build_local_variable_type_map` Results
 
-**Integration strategy:** Memoize results keyed by (file_path, function_start_line, function_end_line).
+**Integration strategy:** Memoise results keyed by (file_path, function_start_line, function_end_line).
 
 **Root cause:** Called 5,228 times, re-traversing AST nodes that have already been parsed. Multiple functions in the same file trigger independent traversals.
 
@@ -378,7 +378,7 @@ The Rust AST extension only becomes worthwhile AFTER all pure Python fixes are a
 |----------|-----------|------|---------------------------|--------|---------------------|
 | **1** | **A: Fix find_ending_with** | **Python bugfix** | **~1.9x (13.5s saved)** | **Low** | **Zero** |
 | **2** | **B: String path ops** | **Python refactor** | **~1.15x (4.0s saved)** | **Low** | **Zero** |
-| **3** | **C: Cache type inference** | **Python memoization** | **~1.07x (2.0s saved)** | **Low** | **Zero** |
+| **3** | **C: Cache type inference** | **Python memoisation** | **~1.07x (2.0s saved)** | **Low** | **Zero** |
 | **4** | **D: Suppress debug logging** | **Config change** | **~1.06x (1.7s saved)** | **Trivial** | **Zero** |
 | **5** | **E: Deduplicate FS traversal** | **Python refactor** | **~1.05x (1.5s saved)** | **Low** | **Zero** |
 | 6 | 1: orjson | Dependency swap | Marginal on indexing | Trivial | Zero |
@@ -387,6 +387,6 @@ The Rust AST extension only becomes worthwhile AFTER all pure Python fixes are a
 
 ### Conclusion
 
-**The top 5 optimizations require zero language rewrites and zero integration overhead.** They fix algorithmic inefficiencies (linear scan), unnecessary object creation (pathlib), redundant computation (uncached type inference, duplicate traversal), and avoidable overhead (debug logging). Together they provide ~3.7x speedup.
+**The top 5 optimisations require zero language rewrites and zero integration overhead.** They fix algorithmic inefficiencies (linear scan), unnecessary object creation (pathlib), redundant computation (uncached type inference, duplicate traversal), and avoidable overhead (debug logging). Together they provide ~3.7x speedup.
 
 The Rust AST extension (previously the headline recommendation) addresses only 3.1% of actual CPU time and is demoted to priority 7. It should only be reconsidered after Python-level fixes are applied and the workload scales to repositories an order of magnitude larger than the current test case.

--- a/docs/reports/LANGUAGE_RECOMMENDATIONS.md
+++ b/docs/reports/LANGUAGE_RECOMMENDATIONS.md
@@ -4,7 +4,7 @@
 
 **CPU profiling reveals that 48.3% of total runtime is spent in a single Python function** (`FunctionRegistryTrie.find_ending_with()`) performing a linear scan fallback with 123.7M `str.endswith()` calls. This is a pure algorithmic bottleneck, not a language limitation, and fixing the simple name lookup index (80.7% miss rate) would nearly halve total runtime with zero language rewrite.
 
-After addressing algorithmic issues (Phase 0: ~3.7x total improvement from pure Python fixes), **Rust via PyO3** is the recommended target language for the remaining CPU-bound hotspots (AST wrapper overhead, trie operations, call resolution). For serialization, **orjson** (Rust-backed) is a drop-in replacement for stdlib json. ~~neo4j-rust-ext~~ was retracted (codebase uses Memgraph/pymgclient, not Neo4j).
+After addressing algorithmic issues (Phase 0: ~3.7x total improvement from pure Python fixes), **Rust via PyO3** is the recommended target language for the remaining CPU-bound hotspots (AST wrapper overhead, trie operations, call resolution). For serialisation, **orjson** (Rust-backed) is a drop-in replacement for stdlib json. ~~neo4j-rust-ext~~ was retracted (codebase uses Memgraph/pymgclient, not Neo4j).
 
 **Critical distinction:** This report contains both theoretical per-instruction overhead multipliers (20x-50x from structural analysis) and empirical runtime impact (from CPU profiling). The structural multipliers explain WHY Python is slow at specific operations, but the IMPACT must be measured against the actual profiled runtime distribution via Amdahl's law. After Phase 0 Python fixes reduce the baseline from 31.2s to ~8-10s, the Rust extension (Phase 2) addresses ~20% of the reduced baseline, yielding diminishing but still meaningful returns.
 
@@ -69,15 +69,15 @@ After addressing algorithmic issues (Phase 0: ~3.7x total improvement from pure 
 - `find_ending_with()` at `graph_updater.py:156`: **7.91s self time (25.3%), 15.07s cumulative (48.3%)** across 27,376 calls
 - Root cause: The `_simple_name_lookup` index has an **80.7% miss rate** (22,096 of 27,376 calls miss). On each miss, the code falls back to a linear scan: `[qn for qn in self._entries.keys() if qn.endswith(f".{suffix}")]`, triggering **123.7M `str.endswith()` calls** (7.21s self time)
 - Called 26,950 times from `CallResolver._try_resolve_via_trie()`, the last-resort call resolution strategy
-- **This single function accounts for nearly half of all CPU time. The trie data structure exists but is bypassed in favor of the linear fallback in most cases.**
-- **CRITICAL: Fix the simple name lookup index first (Python algorithmic fix).** A proper reverse index mapping simple names to qualified names would eliminate the linear scan entirely, reducing this from 15.07s to sub-second. This is the highest-ROI optimization in the entire codebase. Note: even after the algorithmic fix, Python's per-call `str.endswith()` overhead is 5x to 10x what Rust byte-slice comparisons would cost (structural analysis cross-reference), so the Rust trie rewrite remains valuable for the remaining lookup operations.
+- **This single function accounts for nearly half of all CPU time. The trie data structure exists but is bypassed in favour of the linear fallback in most cases.**
+- **CRITICAL: Fix the simple name lookup index first (Python algorithmic fix).** A proper reverse index mapping simple names to qualified names would eliminate the linear scan entirely, reducing this from 15.07s to sub-second. This is the highest-ROI optimisation in the entire codebase. Note: even after the algorithmic fix, Python's per-call `str.endswith()` overhead is 5x to 10x what Rust byte-slice comparisons would cost (structural analysis cross-reference), so the Rust trie rewrite remains valuable for the remaining lookup operations.
 
 **Evidence for language rewrite (after algorithmic fix):**
 - **Concurrency analysis confirms this is GIL-bound:** Pure Python trie/dict operations in `FunctionRegistryTrie` and `CallResolver` hold the GIL throughout, preventing any thread-level parallelism. The concurrency analyst estimates 10x to 50x speedup from moving this to native code. This is the strongest case for a Rust rewrite since it eliminates both per-operation overhead AND the GIL bottleneck.
 - The current implementation uses nested Python dicts as trie nodes, which means every level of trie traversal creates Python string objects and performs dict hash lookups with full Python object overhead.
-- **Structural analysis (HIGH severity):** Python dicts carry 50 to 80 bytes overhead per entry plus hash computation. Each `in` or `[]` lookup involves: hash the key string (O(n) for string length), probe the hash table, compare keys. In Rust, a `HashMap` has similar algorithmic complexity but with inline storage, no reference counting, and cache-friendly memory layout. Specialized data structures (arena-allocated tries, interned string IDs) are practical in systems languages but impractical in Python due to the object model.
+- **Structural analysis (HIGH severity):** Python dicts carry 50 to 80 bytes overhead per entry plus hash computation. Each `in` or `[]` lookup involves: hash the key string (O(n) for string length), probe the hash table, compare keys. In Rust, a `HashMap` has similar algorithmic complexity but with inline storage, no reference counting, and cache-friendly memory layout. Specialised data structures (arena-allocated tries, interned string IDs) are practical in systems languages but impractical in Python due to the object model.
 - **String overhead (HIGH severity, 5x to 15x):** Qualified names are constructed, split, compared, and looked up thousands of times per file. Each `.split(".")` allocates a new list of new string objects. Each f-string creates a new heap allocation. `_calculate_import_distance()` at `call_resolver.py:651-671` splits both strings and compares elementwise. In Rust, these would be zero-copy string views or stack-allocated slices.
-- Rust trie implementations (radix_trie crate) store data contiguously in memory with no per-node heap allocation, eliminating GC pressure. For high-miss-rate lookups (common in call resolution with fallback chains), optimized Rust tries outperform Python dicts. [Source: dev.to/timclicks/two-trie-implementations-in-rust]
+- Rust trie implementations (radix_trie crate) store data contiguously in memory with no per-node heap allocation, eliminating GC pressure. For high-miss-rate lookups (common in call resolution with fallback chains), optimised Rust tries outperform Python dicts. [Source: dev.to/timclicks/two-trie-implementations-in-rust]
 - The Gauge.sh case study showed that moving data structures out of Python and into compact Rust structs reduced malloc calls by 8.5x, directly relevant to this trie-heavy workload.
 - PyO3 achieves 92% of pure Rust performance for data structure operations while maintaining full Python interoperability. [Source: pyo3.rs/main/performance]
 
@@ -89,11 +89,11 @@ After addressing algorithmic issues (Phase 0: ~3.7x total improvement from pure 
 
 ---
 
-### HOTSPOT 3: JSON Serialization/Deserialization for Graph Data
+### HOTSPOT 3: JSON Serialisation/Deserialisation for Graph Data
 
 **Files:** `graph_loader.py`, `graph_updater.py`, `services/graph_service.py`
 
-**Workload:** Loading and saving large graph JSON files (nodes, relationships, properties). The `GraphLoader.load()` method reads potentially multi-megabyte JSON files. The `GraphUpdater` serializes graph data for Neo4j ingestion.
+**Workload:** Loading and saving large graph JSON files (nodes, relationships, properties). The `GraphLoader.load()` method reads potentially multi-megabyte JSON files. The `GraphUpdater` serialises graph data for Neo4j ingestion.
 
 **Recommended Language:** Drop-in replacement with orjson (Rust-backed)
 
@@ -103,9 +103,9 @@ After addressing algorithmic issues (Phase 0: ~3.7x total improvement from pure 
 - orjson (written in Rust) is 2x to 15.8x faster than Python's stdlib json, depending on payload size. For large payloads (>1MB), gains are 10x or more. [Source: medium.com/codeelevation/want-500-faster-json-in-python-try-orjson]
 - orjson uses SIMD (AVX2) for parallel UTF-8 validation and string escaping, scanning 32 bytes at once vs byte-by-byte. [Source: github.com/ijl/orjson]
 - Memory usage is 75% lower peak RSS, which matters for large graph files.
-- For a 10K-record benchmark, orjson achieved 820 MB/s serialization vs json's 52 MB/s (15.8x).
+- For a 10K-record benchmark, orjson achieved 820 MB/s serialisation vs json's 52 MB/s (15.8x).
 
-**Architecture:** Replace `import json` with `import orjson` throughout the codebase. This is the lowest-effort, highest-ROI optimization. orjson is a drop-in replacement for most use cases. The only API difference is that `orjson.dumps()` returns bytes instead of str.
+**Architecture:** Replace `import json` with `import orjson` throughout the codebase. This is the lowest-effort, highest-ROI optimisation. orjson is a drop-in replacement for most use cases. The only API difference is that `orjson.dumps()` returns bytes instead of str.
 
 **Why this over a full rewrite:** The JSON parsing itself is the bottleneck, not the surrounding Python code. orjson already provides native Rust performance for this specific operation. Writing a custom Rust extension for JSON handling would duplicate orjson's work.
 
@@ -115,7 +115,7 @@ After addressing algorithmic issues (Phase 0: ~3.7x total improvement from pure 
 
 **CORRECTION (from integration-architect):** This codebase uses **Memgraph via `pymgclient`** (a C extension), NOT the Neo4j Python driver. There is no `neo4j` dependency in `pyproject.toml`. The `neo4j-rust-ext` package patches the Neo4j driver's PackStream implementation and has **zero effect** on `pymgclient`. This recommendation is retracted.
 
-`pymgclient` is already a C extension with low overhead. CPU profiling confirms database serialization (protobuf) is negligible at 0.17s total. No language rewrite is needed for the database communication layer.
+`pymgclient` is already a C extension with low overhead. CPU profiling confirms database serialisation (protobuf) is negligible at 0.17s total. No language rewrite is needed for the database communication layer.
 
 ---
 
@@ -136,7 +136,7 @@ After addressing algorithmic issues (Phase 0: ~3.7x total improvement from pure 
 
 **Architecture:** Replace `hashlib.sha256` with `blake3.blake3` in the `EmbeddingCache._content_hash()` method. This is a one-line change. Note: existing caches would need to be regenerated since hash values will differ.
 
-**CPU PROFILING RESULT: Hashing is NOT a bottleneck.** `_hash_file()` costs only 0.04s total (0.1%) across 453 calls. SHA-256 hashing is fast and not worth optimizing. BLAKE3 swap is deprioritized.
+**CPU PROFILING RESULT: Hashing is NOT a bottleneck.** `_hash_file()` costs only 0.04s total (0.1%) across 453 calls. SHA-256 hashing is fast and not worth optimising. BLAKE3 swap is deprioritised.
 
 **Additional structural insight (MEDIUM severity):** The embedding pipeline at `embedder.py:109-126` and `unixcoder.py:97-107` crosses the Python/C boundary 3+ times per embedding: Python `list[list[int]]` to `torch.tensor` (copy), through PyTorch C++ backend (efficient), `.cpu().numpy()` (copy), `.tolist()` (N allocations for N-dim vector). Each crossing involves full memory copies and new container allocations. In Rust with `tch-rs`, tensor references can be held throughout without conversion overhead, providing 2x to 3x improvement on the embedding data path itself (separate from model inference time).
 
@@ -159,7 +159,7 @@ After addressing algorithmic issues (Phase 0: ~3.7x total improvement from pure 
 - **Key insight from profiling:** File traversal is NOT I/O-bound as originally assumed. The bottleneck is Python pathlib object overhead (creating intermediate Path objects for every `relative_to()` call), not filesystem I/O (`posix.scandir` costs only 0.42s). Using string-based path operations instead of pathlib would eliminate most of this overhead. Additionally, merging the duplicate traversal passes would cut FS stat calls in half.
 
 **I/O PROFILING DATA (confirms NOT I/O-bound):**
-- Actual disk I/O for the entire workload totals only **0.85s (6.1% of 14.0s)**. File reads: 0.02s, hashing: 0.02s, protobuf serialization: 0.01s, JSON cache: 0.001s.
+- Actual disk I/O for the entire workload totals only **0.85s (6.1% of 14.0s)**. File reads: 0.02s, hashing: 0.02s, protobuf serialisation: 0.01s, JSON cache: 0.001s.
 - `pathlib.relative_to()` performs **zero disk I/O**. It constructs intermediate `PurePosixPath` objects via `__init__`, `is_relative_to`, `with_segments`, `_from_parsed_parts`. Measured at **10.6 us/call**.
 - **String slice equivalent: 0.065 us/call (163x faster).** This is the measured speedup from the I/O profiler for replacing `pathlib.relative_to()` with string slicing.
 - Duplicate `rglob("*")` traversals cost ~0.80s combined (two passes of ~0.40s each scanning 59,283 entries).
@@ -168,7 +168,7 @@ After addressing algorithmic issues (Phase 0: ~3.7x total improvement from pure 
 - The `rglob` filesystem traversal itself is fast (0.42s). The 4.29s in `should_skip_path` is pure Python object creation overhead from pathlib.
 - The real opportunity is (a) replacing `pathlib.relative_to()` with string slicing (163x faster per call), and (b) merging the two separate `rglob` passes into one.
 
-**Architecture:** Keep file traversal in Python. Fix pathlib overhead first (Priority 0b). Thread-based parallelism for file processing is less impactful than originally estimated: CPU profiling shows tree-sitter parsing is only 0.6% of total CPU, so parallelizing parsing yields minimal gains. The dominant bottleneck (48.3%) is in the post-parsing call resolution phase, which is sequential and GIL-bound.
+**Architecture:** Keep file traversal in Python. Fix pathlib overhead first (Priority 0b). Thread-based parallelism for file processing is less impactful than originally estimated: CPU profiling shows tree-sitter parsing is only 0.6% of total CPU, so parallelising parsing yields minimal gains. The dominant bottleneck (48.3%) is in the post-parsing call resolution phase, which is sequential and GIL-bound.
 
 **Why not Rust for traversal:** The per-file processing calls into tree-sitter (C library) and constructs Python objects. The overhead is in path manipulation (pathlib), not traversal I/O. A string-based path fix in Python is sufficient.
 
@@ -216,14 +216,14 @@ After addressing algorithmic issues (Phase 0: ~3.7x total improvement from pure 
 **Key observations:**
 1. 48.3% of CPU is in a single function with an algorithmic fix available (index miss rate)
 2. Tree-sitter C operations (parse + captures) total only 1.0s (3.1%), confirming the bottleneck is Python wrapper code
-3. Protobuf serialization is negligible (0.17s total)
+3. Protobuf serialisation is negligible (0.17s total)
 4. File hashing is negligible (0.04s total)
 
 ---
 
 ## Structural Performance Ceilings (from Static Analysis)
 
-The static-pattern-analyst identified 9 categories of Python runtime overhead that create inherent performance ceilings. These are organized by severity:
+The static-pattern-analyst identified 9 categories of Python runtime overhead that create inherent performance ceilings. These are organised by severity:
 
 | Severity | Pattern | Overhead Multiplier | Rewrite Benefit |
 |---|---|---|---|
@@ -261,9 +261,9 @@ Memory profiling confirms that Python's object model creates significant memory 
 
 ---
 
-## Non-Language Optimizations (Algorithmic / Python-Level)
+## Non-Language Optimisations (Algorithmic / Python-Level)
 
-CPU profiling and concurrency analysis identified multiple high-impact optimizations that do NOT require a language rewrite. **These should be implemented first** as they collectively address over 70% of CPU time.
+CPU profiling and concurrency analysis identified multiple high-impact optimisations that do NOT require a language rewrite. **These should be implemented first** as they collectively address over 70% of CPU time.
 
 ### ALGORITHMIC 0: Fix `find_ending_with()` Simple Name Index (THE #1 PRIORITY)
 
@@ -287,7 +287,7 @@ CPU profiling and concurrency analysis identified multiple high-impact optimizat
 
 **Projected Speedup:** ~2x to 5x on the type inference phase
 
-**Action:** Memoize type inference results per function AST node. Since the AST is immutable after parsing, results are safe to cache.
+**Action:** Memoise type inference results per function AST node. Since the AST is immutable after parsing, results are safe to cache.
 
 ### ALGORITHMIC 0d: Reduce Debug Logging Overhead
 
@@ -307,7 +307,7 @@ CPU profiling and concurrency analysis identified multiple high-impact optimizat
 
 ### ALGORITHMIC 0f: Binary Format for Embedding Cache
 
-**Issue:** 500 embeddings (768-dim float vectors) stored as JSON = 6.3MB, save = 149ms, load = 38ms. Each embedding is serialized as a JSON array of 768 float values with full decimal precision.
+**Issue:** 500 embeddings (768-dim float vectors) stored as JSON = 6.3MB, save = 149ms, load = 38ms. Each embedding is serialised as a JSON array of 768 float values with full decimal precision.
 
 **Projected Speedup:** 10x+ on embedding cache I/O (both size and speed)
 
@@ -357,7 +357,7 @@ CPU profiling and concurrency analysis identified multiple high-impact optimizat
 
 ---
 
-## Prioritized Implementation Order
+## Prioritised Implementation Order
 
 ### Phase 0: Python Algorithmic Fixes (addresses ~72% of CPU time)
 
@@ -376,11 +376,11 @@ CPU profiling and concurrency analysis identified multiple high-impact optimizat
 
 | Priority | Library | Effort | Expected Speedup |
 |---|---|---|---|
-| 1a | JSON serialization (orjson) | Very low (dependency swap) | 5x-15x on JSON ops |
+| 1a | JSON serialisation (orjson) | Very low (dependency swap) | 5x-15x on JSON ops |
 | ~~1b~~ | ~~Neo4j driver (neo4j-rust-ext)~~ | ~~RETRACTED~~ | ~~Inapplicable: codebase uses Memgraph/pymgclient, not Neo4j~~ |
 | 1b | Embedding hash (BLAKE3) | Very low (one-line change) | 4x-10x on hashing (confirmed negligible: 0.04s) |
 
-**Note from profiling:** File hashing (`_hash_file`) is only 0.04s total (0.1%), and protobuf serialization is 0.17s total. These are negligible. BLAKE3 (Priority 1b) can be deprioritized. orjson remains worthwhile for larger codebases. The neo4j-rust-ext recommendation was retracted because this codebase uses Memgraph via `pymgclient` (C extension), not the Neo4j Python driver.
+**Note from profiling:** File hashing (`_hash_file`) is only 0.04s total (0.1%), and protobuf serialisation is 0.17s total. These are negligible. BLAKE3 (Priority 1b) can be deprioritised. orjson remains worthwhile for larger codebases. The neo4j-rust-ext recommendation was retracted because this codebase uses Memgraph via `pymgclient` (C extension), not the Neo4j Python driver.
 
 ### Phase 2: Rust Extension (addresses remaining CPU-bound overhead)
 
@@ -399,7 +399,7 @@ CPU profiling and concurrency analysis identified multiple high-impact optimizat
 |---|---|---|---|
 | 3a | File processing parallelism (ThreadPoolExecutor) | Medium | Downgraded: marginal gains |
 
-**Phase 3 is downgraded based on revised analysis.** CPU profiling shows tree-sitter parsing is only 0.6% of CPU, and the file processing bottleneck (`pathlib.relative_to` at 13.7%) is GIL-bound pure Python that ThreadPoolExecutor cannot parallelize. The pathlib fix (Phase 0b, string slicing, 163x faster) is the correct solution, not parallelism. ProcessPoolExecutor for call resolution is also impractical: memory profiling shows 170 MiB peak memory, making serialization cost too high. The Rust PyO3 native extension (Phase 2) is the only viable path for parallelizing call resolution, as it can release the GIL via `Python::allow_threads`.
+**Phase 3 is downgraded based on revised analysis.** CPU profiling shows tree-sitter parsing is only 0.6% of CPU, and the file processing bottleneck (`pathlib.relative_to` at 13.7%) is GIL-bound pure Python that ThreadPoolExecutor cannot parallelise. The pathlib fix (Phase 0b, string slicing, 163x faster) is the correct solution, not parallelism. ProcessPoolExecutor for call resolution is also impractical: memory profiling shows 170 MiB peak memory, making serialisation cost too high. The Rust PyO3 native extension (Phase 2) is the only viable path for parallelising call resolution, as it can release the GIL via `Python::allow_threads`.
 
 ---
 
@@ -408,7 +408,7 @@ CPU profiling and concurrency analysis identified multiple high-impact optimizat
 - [Gauge.sh: Python extensions should be lazy](https://www.gauge.sh/blog/python-extensions-should-be-lazy) - 16x speedup moving AST processing to Rust
 - [Neo4j Python Driver 10x Faster With Rust](https://neo4j.com/blog/developer/python-driver-10x-faster-with-rust/) - neo4j-rust-ext benchmarks
 - [Baseten: 12x higher embedding throughput with Python and Rust](https://www.baseten.co/blog/your-client-code-matters-10x-higher-embedding-throughput-with-python-and-rust/) - PyO3 GIL release pattern
-- [orjson: 500% Faster JSON in Python](https://medium.com/codeelevation/want-500-faster-json-in-python-try-orjson-powered-by-rust-22995c25c312) - JSON serialization benchmarks
+- [orjson: 500% Faster JSON in Python](https://medium.com/codeelevation/want-500-faster-json-in-python-try-orjson-powered-by-rust-22995c25c312) - JSON serialisation benchmarks
 - [PyO3 Performance Guide](https://pyo3.rs/main/performance) - FFI overhead characteristics
 - [Rust: Python's New Performance Engine](https://thenewstack.io/rust-pythons-new-performance-engine/) - Industry adoption trends
 - [Comparing Cython to Rust for Python Extensions](https://willayd.com/comparing-cython-to-rust-evaluating-python-extensions.html) - Graph algorithm benchmarks
@@ -420,4 +420,4 @@ CPU profiling and concurrency analysis identified multiple high-impact optimizat
 - [ast-grep](https://github.com/ast-grep/ast-grep) - Rust tree-sitter code analysis tool
 - [Rust trie implementations](https://dev.to/timclicks/two-trie-implementations-in-rust-ones-super-fast) - Trie performance
 - [Corrode: Migrating from Python to Rust](https://corrode.dev/learn/migration-guides/python-to-rust/) - Migration guide
-- [Datadog: Migrating static analyzer from Java to Rust](https://www.datadoghq.com/blog/engineering/how-we-migrated-our-static-analyzer-from-java-to-rust/) - Code analysis tool migration
+- [Datadog: Migrating static analyser from Java to Rust](https://www.datadoghq.com/blog/engineering/how-we-migrated-our-static-analyzer-from-java-to-rust/) - Code analysis tool migration

--- a/docs/reports/PRIORITIZED_SCORECARD.md
+++ b/docs/reports/PRIORITIZED_SCORECARD.md
@@ -1,10 +1,10 @@
-# Prioritized Scorecard: Rewrite Candidates
+# Prioritised Scorecard: Rewrite Candidates
 
 **Baseline:** 31.2s total, 179M function calls, indexing 352 Python files (cProfile)
 
 ## Scoring Methodology
 
-Each candidate is scored 1 to 5 on six dimensions. The final rank is determined by **Net Score**, which weights measured/projected performance gain and scope of impact highest, while penalizing integration overhead, risk, and maintenance burden.
+Each candidate is scored 1 to 5 on six dimensions. The final rank is determined by **Net Score**, which weights measured/projected performance gain and scope of impact highest, while penalising integration overhead, risk, and maintenance burden.
 
 **Weights:** Performance Gain (25%) | Memory Improvement (10%) | Integration Feasibility (20%) | Risk & Complexity (20%) | Scope of Impact (15%) | Maintenance Burden (10%)
 
@@ -46,19 +46,19 @@ Each candidate is scored 1 to 5 on six dimensions. The final rank is determined 
 
 ---
 
-### Rank 3: Cache `build_local_variable_type_map` Results (Python Memoization)
+### Rank 3: Cache `build_local_variable_type_map` Results (Python Memoisation)
 
 | Dimension | Score | Rationale |
 |---|---|---|
 | Performance Gain | 3 | 8.3% of CPU (2.59s across 5,228 calls). Saves ~2s. |
 | Memory Improvement | 2 | Adds ~2MB cache. Slight memory increase. |
-| Integration Feasibility | 5 | Add `@lru_cache` or dict-based memoization. No dependencies. |
+| Integration Feasibility | 5 | Add `@lru_cache` or dict-based memoisation. No dependencies. |
 | Risk & Complexity | 5 | Keyed by (file_path, function_start_line, function_end_line). Cache invalidation handled by existing incremental update system. |
 | Scope of Impact | 3 | Affects call resolution for files with multiple functions. |
-| Maintenance Burden | 5 | Standard memoization pattern. |
+| Maintenance Burden | 5 | Standard memoisation pattern. |
 | **Net Score** | **3.90** | |
 
-**Verdict: PROCEED.** Standard memoization with minimal memory cost.
+**Verdict: PROCEED.** Standard memoisation with minimal memory cost.
 
 ---
 
@@ -136,8 +136,8 @@ Each candidate is scored 1 to 5 on six dimensions. The final rank is determined 
 |---|---|---|
 | Performance Gain | 3 | 1.5x to 3x after Tier 1 fixes. Limited by sequential pass dependencies (Amdahl's law). |
 | Memory Improvement | 1 | Increases memory (per-worker grammar loading, duplicate tries). |
-| Integration Feasibility | 3 | Requires restructuring three-pass pipeline. Shared mutable state (trie, import maps) needs synchronization. |
-| Risk & Complexity | 3 | Tree-sitter objects not serializable across process boundaries. Worker initialization overhead (~50ms per worker). |
+| Integration Feasibility | 3 | Requires restructuring three-pass pipeline. Shared mutable state (trie, import maps) needs synchronisation. |
+| Risk & Complexity | 3 | Tree-sitter objects not serialisable across process boundaries. Worker initialisation overhead (~50ms per worker). |
 | Scope of Impact | 3 | Affects per-file processing throughput. |
 | Maintenance Burden | 3 | Adds concurrency complexity. Harder to debug. |
 | **Net Score** | **2.70** | |
@@ -192,7 +192,7 @@ Each candidate is scored 1 to 5 on six dimensions. The final rank is determined 
 | Maintenance Burden | 4 | Minimal. |
 | **Net Score** | **1.85** | |
 
-**Verdict: REJECT.** Optimizing an operation that takes microseconds per call provides no meaningful improvement. The cache invalidation cost (forced full re-index) creates a one-time penalty that exceeds months of per-operation savings. The integration architect's analysis is correct: "Skip unless profiling proves hashing is >5% of total wall clock time." It is far below 5%.
+**Verdict: REJECT.** Optimising an operation that takes microseconds per call provides no meaningful improvement. The cache invalidation cost (forced full re-index) creates a one-time penalty that exceeds months of per-operation savings. The integration architect's analysis is correct: "Skip unless profiling proves hashing is >5% of total wall clock time." It is far below 5%.
 
 ---
 
@@ -254,11 +254,11 @@ The Rust AST extension (Rank 7) would save ~0.94s from tree-sitter, reducing to 
 
 3. **neo4j-rust-ext is completely inapplicable** (wrong database driver). This was a factual error in the language recommendations.
 
-4. **BLAKE3 hashing optimizes a non-bottleneck** (microsecond-level operations that total <0.1% of runtime).
+4. **BLAKE3 hashing optimises a non-bottleneck** (microsecond-level operations that total <0.1% of runtime).
 
 5. **Standalone Rust trie and string processing have negative net gains** due to per-lookup FFI boundary crossing costs that exceed the per-operation savings.
 
-6. **The single largest optimization (Rank 1) is a Python bugfix**, not a language rewrite. Fixing the `_simple_name_lookup` index miss rate from 80.7% to near 0% eliminates 48.3% of total CPU time.
+6. **The single largest optimisation (Rank 1) is a Python bugfix**, not a language rewrite. Fixing the `_simple_name_lookup` index miss rate from 80.7% to near 0% eliminates 48.3% of total CPU time.
 
 ---
 
@@ -268,7 +268,7 @@ The Rust AST extension (Rank 7) would save ~0.94s from tree-sitter, reducing to 
 |------|-----------|------|-----------|------------|---------|
 | 1 | Fix `find_ending_with` | Python bugfix | 4.80 | ~13.5s (43.3%) | **PROCEED** |
 | 2 | String path ops | Python refactor | 4.50 | ~4.0s (12.8%) | **PROCEED** |
-| 3 | Cache type inference | Python memoization | 3.90 | ~2.0s (6.4%) | **PROCEED** |
+| 3 | Cache type inference | Python memoisation | 3.90 | ~2.0s (6.4%) | **PROCEED** |
 | 4 | Suppress debug logging | Config change | 3.75 | ~1.7s (5.5%) | **PROCEED** |
 | 5 | Deduplicate FS traversal | Python refactor | 3.55 | ~1.5s (4.8%) | **PROCEED** |
 | 6 | orjson | Dependency swap | 3.50 | Variable | **PROCEED** |

--- a/docs/reports/REWRITE_RECOMMENDATIONS.md
+++ b/docs/reports/REWRITE_RECOMMENDATIONS.md
@@ -1,4 +1,4 @@
-# Rewrite Recommendations: code-graph-rag Performance Optimization
+# Rewrite Recommendations: code-graph-rag Performance Optimisation
 
 ## Executive Summary
 
@@ -10,7 +10,7 @@ A comprehensive performance analysis of the code-graph-rag codebase (31.2s total
 
 2. **Replace pathlib with string operations in `should_skip_path`** (Python refactor): Eliminates 13.7% of total CPU time. `pathlib.relative_to()` creates intermediate objects on every call (59,012 calls, 3.39s total). Benchmarked fix: **45x to 634x speedup** on path operations. Projected total speedup: ~1.15x.
 
-3. **Cache `build_local_variable_type_map` results** (Python memoization): Eliminates 8.3% of total CPU time. 5,228 uncached AST traversals. Projected total speedup: ~1.07x.
+3. **Cache `build_local_variable_type_map` results** (Python memoisation): Eliminates 8.3% of total CPU time. 5,228 uncached AST traversals. Projected total speedup: ~1.07x.
 
 **Combined Tier 1 impact:** ~3.7x total speedup (31.2s to ~8.5s) from pure Python fixes with zero integration overhead.
 
@@ -105,7 +105,7 @@ The security auditor approved all recommended candidates with zero disputes. The
 ### Candidate 3: Cache Type Inference Results
 
 **Priority:** 3
-**Type:** Python memoization
+**Type:** Python memoisation
 **Effort:** Low
 **Files:** `codebase_rag/parsers/type_inference.py:119`
 
@@ -114,7 +114,7 @@ The security auditor approved all recommended candidates with zero disputes. The
 - Call count: 5,228 calls
 - Root cause: Re-traverses AST nodes per function for type inference without caching
 
-**Fix:** Memoize results keyed by `(file_path, function_start_line, function_end_line)`. Cache invalidation handled by existing incremental update system.
+**Fix:** Memoise results keyed by `(file_path, function_start_line, function_end_line)`. Cache invalidation handled by existing incremental update system.
 
 **Projected Net Gain:** ~1.07x total speedup (2.0s saved)
 **Integration Overhead:** ~2MB memory for cache
@@ -162,7 +162,7 @@ The security auditor approved all recommended candidates with zero disputes. The
 
 ---
 
-### Candidate 6: orjson for JSON Serialization
+### Candidate 6: orjson for JSON Serialisation
 
 **Priority:** 6
 **Type:** Dependency swap
@@ -263,7 +263,7 @@ The security auditor approved all recommended candidates with zero disputes. The
 
 ---
 
-## Optimize-First Recommendations (Non-Rewrite)
+## Optimise-First Recommendations (Non-Rewrite)
 
 These Python-level improvements should be implemented before any language rewrite consideration:
 
@@ -323,7 +323,7 @@ Run all benchmarks: `uv run python benchmarks/run_all.py`
 | Language research | #7 | language-researcher | Target language recommendations (Rust via PyO3) |
 | Integration feasibility | #8 | integration-architect | FFI overhead analysis, build system impact, net gain calculations |
 | Benchmarks | #9 | benchmark-designer | Measured performance for all candidates |
-| Scorecard | #10 | evaluator | Prioritized ranking with scores |
+| Scorecard | #10 | evaluator | Prioritised ranking with scores |
 | Adversarial review | #11 | adversarial-reviewer | No rewrite justified at current scale |
 | Security audit | #12 | security-auditor | All candidates approved, zero disputes |
 
@@ -331,10 +331,10 @@ Run all benchmarks: `uv run python benchmarks/run_all.py`
 
 ## Conclusion
 
-The performance analysis produced a clear, data-driven result: **optimize Python first, rewrite later (if ever).**
+The performance analysis produced a clear, data-driven result: **optimise Python first, rewrite later (if ever).**
 
 The top 5 bottlenecks consuming 72.8% of runtime are all pure Python algorithmic issues (linear scan fallback, pathlib object overhead, uncached traversals, debug logging, duplicate traversals). Fixing them provides ~3.7x total speedup with zero integration overhead, zero build system changes, and zero maintenance burden.
 
-The Rust AST extension, while technically sound as a future optimization for large-scale workloads, targets only 3.1% of current CPU time and provides ~1.03x total improvement after Python fixes. It should be reconsidered only when the codebase routinely processes 5,000+ file repositories and the Python fixes have been applied.
+The Rust AST extension, while technically sound as a future optimisation for large-scale workloads, targets only 3.1% of current CPU time and provides ~1.03x total improvement after Python fixes. It should be reconsidered only when the codebase routinely processes 5,000+ file repositories and the Python fixes have been applied.
 
 No language rewrite recommendation survived the adversarial review at current scale.

--- a/docs/sdk/graph-loader.md
+++ b/docs/sdk/graph-loader.md
@@ -44,7 +44,7 @@ classes = graph.find_nodes_by_label("Class")
 modules = graph.find_nodes_by_label("Module")
 ```
 
-### Analyze Relationships
+### Analyse Relationships
 
 ```python
 for func in functions[:5]:


### PR DESCRIPTION
Converts American spellings to British English (-ise convention) across all documentation, markdown, and user-facing strings (CLI help, status/approval prompts, MCP tool descriptions).

Scope is **prose only**. A context-aware pass protected and left untouched:
- Code identifiers, function/class/variable names, and enum values
- CLI command tokens (`cgr optimize` stays) and command examples
- Markdown link URLs and file paths (e.g. `code-optimization.md`)
- Fenced code blocks, inline-code spans, HTML tag attributes (`align="center"`), and CSS
- `cythonize` (Cython build API), `artifact`, `license` (accepted British computing/proper-noun usage)

Generated doc sections were updated at their source (`tool_descriptions.py`, `cli_help.py`, `types_defs.py`) so the README generator stays consistent rather than reverting the change.

Full test suite passes (5677 passed); the single integration failure is a pre-existing live-model flake (`test_parallel_tool_calls_all_execute`, model called 3 of 4 tools) reproduced on clean main without this diff.