### PR TITLE
fix(findings): widen xss, sqli and factory rules to catch missed sinks

### DIFF
--- a/codebase_rag/analyzers/ast_grep_rules/patterns/javascript.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/patterns/javascript.yaml
@@ -25,3 +25,4 @@ rules:
                 any:
                   - kind: arrow_function
                   - kind: function_expression
+                  - kind: generator_function

--- a/codebase_rag/analyzers/ast_grep_rules/patterns/javascript.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/patterns/javascript.yaml
@@ -14,5 +14,14 @@ rules:
   - id: factory_function
     message: "Factory function: name starts with create/make/build"
     rule:
-      kind: function_declaration
-      has: { field: name, regex: '^(create|make|build)' }
+      any:
+        - kind: function_declaration
+          has: { field: name, regex: '^(create|make|build)' }
+        - kind: variable_declarator
+          all:
+            - has: { field: name, regex: '^(create|make|build)' }
+            - has:
+                field: value
+                any:
+                  - kind: arrow_function
+                  - kind: function_expression

--- a/codebase_rag/analyzers/ast_grep_rules/patterns/tsx.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/patterns/tsx.yaml
@@ -25,3 +25,4 @@ rules:
                 any:
                   - kind: arrow_function
                   - kind: function_expression
+                  - kind: generator_function

--- a/codebase_rag/analyzers/ast_grep_rules/patterns/tsx.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/patterns/tsx.yaml
@@ -14,5 +14,14 @@ rules:
   - id: factory_function
     message: "Factory function: name starts with create/make/build"
     rule:
-      kind: function_declaration
-      has: { field: name, regex: '^(create|make|build)' }
+      any:
+        - kind: function_declaration
+          has: { field: name, regex: '^(create|make|build)' }
+        - kind: variable_declarator
+          all:
+            - has: { field: name, regex: '^(create|make|build)' }
+            - has:
+                field: value
+                any:
+                  - kind: arrow_function
+                  - kind: function_expression

--- a/codebase_rag/analyzers/ast_grep_rules/patterns/typescript.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/patterns/typescript.yaml
@@ -25,3 +25,4 @@ rules:
                 any:
                   - kind: arrow_function
                   - kind: function_expression
+                  - kind: generator_function

--- a/codebase_rag/analyzers/ast_grep_rules/patterns/typescript.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/patterns/typescript.yaml
@@ -14,5 +14,14 @@ rules:
   - id: factory_function
     message: "Factory function: name starts with create/make/build"
     rule:
-      kind: function_declaration
-      has: { field: name, regex: '^(create|make|build)' }
+      any:
+        - kind: function_declaration
+          has: { field: name, regex: '^(create|make|build)' }
+        - kind: variable_declarator
+          all:
+            - has: { field: name, regex: '^(create|make|build)' }
+            - has:
+                field: value
+                any:
+                  - kind: arrow_function
+                  - kind: function_expression

--- a/codebase_rag/analyzers/ast_grep_rules/security/javascript.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/javascript.yaml
@@ -3,9 +3,13 @@ ast_grep_id: javascript
 extensions: [.js, .jsx, .mjs, .cjs]
 rules:
   - id: innerhtml_xss
-    message: "Possible XSS: assignment to innerHTML"
+    message: "Possible XSS: assignment to innerHTML/outerHTML"
     rule:
-      pattern: "$EL.innerHTML = $X"
+      any:
+        - pattern: "$EL.innerHTML = $X"
+        - pattern: "$EL.innerHTML += $X"
+        - pattern: "$EL.outerHTML = $X"
+        - pattern: "$EL.outerHTML += $X"
   - id: eval_use
     message: "eval() executes arbitrary code"
     rule:

--- a/codebase_rag/analyzers/ast_grep_rules/security/python.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/python.yaml
@@ -5,9 +5,11 @@ ast_grep_id: python
 extensions: [.py]
 rules:
   - id: sqli_concat
-    message: "Possible SQL injection: query built with string concatenation"
+    message: "Possible SQL injection: query built with string concatenation or % formatting"
     rule:
-      pattern: "$OBJ.execute($A + $B)"
+      any:
+        - pattern: "$OBJ.execute($A + $B)"
+        - pattern: "$OBJ.execute($A % $B)"
   - id: sqli_fstring
     message: "Possible SQL injection: execute() called with an f-string"
     rule:

--- a/codebase_rag/analyzers/ast_grep_rules/security/python.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/python.yaml
@@ -9,7 +9,11 @@ rules:
     rule:
       any:
         - pattern: "$OBJ.execute($A + $B)"
-        - pattern: "$OBJ.execute($A % $B)"
+        # (%) matches only when a string literal is present, so a numeric modulo
+        # like execute(index % shard_count) is not mistaken for query formatting.
+        - all:
+            - pattern: "$OBJ.execute($A % $B)"
+            - has: { kind: string, stopBy: end }
   - id: sqli_fstring
     message: "Possible SQL injection: execute() called with an f-string"
     rule:

--- a/codebase_rag/analyzers/ast_grep_rules/security/tsx.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/tsx.yaml
@@ -3,9 +3,13 @@ ast_grep_id: tsx
 extensions: [.tsx]
 rules:
   - id: innerhtml_xss
-    message: "Possible XSS: assignment to innerHTML"
+    message: "Possible XSS: assignment to innerHTML/outerHTML"
     rule:
-      pattern: "$EL.innerHTML = $X"
+      any:
+        - pattern: "$EL.innerHTML = $X"
+        - pattern: "$EL.innerHTML += $X"
+        - pattern: "$EL.outerHTML = $X"
+        - pattern: "$EL.outerHTML += $X"
   - id: eval_use
     message: "eval() executes arbitrary code"
     rule:

--- a/codebase_rag/analyzers/ast_grep_rules/security/typescript.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/typescript.yaml
@@ -3,9 +3,13 @@ ast_grep_id: typescript
 extensions: [.ts, .mts, .cts]
 rules:
   - id: innerhtml_xss
-    message: "Possible XSS: assignment to innerHTML"
+    message: "Possible XSS: assignment to innerHTML/outerHTML"
     rule:
-      pattern: "$EL.innerHTML = $X"
+      any:
+        - pattern: "$EL.innerHTML = $X"
+        - pattern: "$EL.innerHTML += $X"
+        - pattern: "$EL.outerHTML = $X"
+        - pattern: "$EL.outerHTML += $X"
   - id: eval_use
     message: "eval() executes arbitrary code"
     rule:

--- a/codebase_rag/tests/test_ast_grep_analyzer.py
+++ b/codebase_rag/tests/test_ast_grep_analyzer.py
@@ -279,11 +279,13 @@ def test_innerhtml_xss_catches_augmented_and_outerhtml(tmp_path: Path) -> None:
 
 def test_sqli_concat_catches_percent_format(tmp_path: Path) -> None:
     # (H) `execute("... %s" % params)` is the classic printf-style injection, as
-    # (H) dangerous as `+` concatenation; a parametrized query stays clean.
+    # (H) dangerous as `+` concatenation; a parametrized query stays clean, and a
+    # (H) numeric modulo (line 4) must NOT be mistaken for string formatting.
     src = (
         'db.execute("SELECT " + u)\n'
         'db.execute("SELECT %s" % u)\n'
         'db.execute("SELECT ?", (u,))\n'
+        "db.execute(index % shard_count)\n"
     )
     lines = sorted(
         p[cs.KEY_START_LINE]
@@ -294,12 +296,14 @@ def test_sqli_concat_catches_percent_format(tmp_path: Path) -> None:
 
 
 def test_factory_function_catches_arrow_and_expression(tmp_path: Path) -> None:
-    # (H) Modern factories are usually `const createX = () => {}` (arrow) or a
-    # (H) function expression, not a `function` declaration; catch all three.
+    # (H) Modern factories are usually `const createX = () => {}` (arrow), a
+    # (H) function expression, or a generator function expression, not a `function`
+    # (H) declaration; catch all four. A non-factory name stays clean.
     src = (
         "function createA() { return {}; }\n"
         "const createB = () => ({});\n"
         "const makeC = function () { return {}; };\n"
+        "const makeGen = function* () { yield {}; };\n"
         "const other = () => ({});\n"
     )
     names = sorted(
@@ -307,7 +311,7 @@ def test_factory_function_catches_arrow_and_expression(tmp_path: Path) -> None:
         for p in _fire(tmp_path, "f.js", src)
         if p[cs.KEY_NAME] == "factory_function"
     )
-    assert names == [1, 2, 3], names
+    assert names == [1, 2, 3, 4], names
 
 
 def test_same_line_findings_get_distinct_ids(tmp_path: Path) -> None:

--- a/codebase_rag/tests/test_ast_grep_analyzer.py
+++ b/codebase_rag/tests/test_ast_grep_analyzer.py
@@ -248,6 +248,68 @@ def test_every_rule_fires_on_positive_fixture(tmp_path: Path) -> None:
         assert set(ids) <= fired, f"{ext} dead rules: {sorted(set(ids) - fired)}"
 
 
+def _fire(tmp_path: Path, name: str, src: str) -> list:
+    from codebase_rag.analyzers import FindingAnalyzer
+
+    f = tmp_path / name
+    f.write_text(src, encoding="utf-8")
+    ing = _FakeIngestor()
+    FindingAnalyzer(ing, tmp_path, resolve_capture(["+findings"])).analyze(
+        {name.split(".", maxsplit=1)[0]: f}
+    )
+    return [p for _label, p in ing.nodes]
+
+
+def test_innerhtml_xss_catches_augmented_and_outerhtml(tmp_path: Path) -> None:
+    # (H) `+=` and outerHTML are the same DOM-injection sink as `innerHTML =`.
+    src = (
+        "a.innerHTML = x;\n"
+        "b.innerHTML += y;\n"
+        "c.outerHTML = z;\n"
+        "d.outerHTML += w;\n"
+        "e.textContent = safe;\n"
+    )
+    lines = sorted(
+        p[cs.KEY_START_LINE]
+        for p in _fire(tmp_path, "x.js", src)
+        if p[cs.KEY_NAME] == "innerhtml_xss"
+    )
+    assert lines == [1, 2, 3, 4], lines
+
+
+def test_sqli_concat_catches_percent_format(tmp_path: Path) -> None:
+    # (H) `execute("... %s" % params)` is the classic printf-style injection, as
+    # (H) dangerous as `+` concatenation; a parametrized query stays clean.
+    src = (
+        'db.execute("SELECT " + u)\n'
+        'db.execute("SELECT %s" % u)\n'
+        'db.execute("SELECT ?", (u,))\n'
+    )
+    lines = sorted(
+        p[cs.KEY_START_LINE]
+        for p in _fire(tmp_path, "dao.py", src)
+        if p[cs.KEY_NAME] == "sqli_concat"
+    )
+    assert lines == [1, 2], lines
+
+
+def test_factory_function_catches_arrow_and_expression(tmp_path: Path) -> None:
+    # (H) Modern factories are usually `const createX = () => {}` (arrow) or a
+    # (H) function expression, not a `function` declaration; catch all three.
+    src = (
+        "function createA() { return {}; }\n"
+        "const createB = () => ({});\n"
+        "const makeC = function () { return {}; };\n"
+        "const other = () => ({});\n"
+    )
+    names = sorted(
+        p[cs.KEY_START_LINE]
+        for p in _fire(tmp_path, "f.js", src)
+        if p[cs.KEY_NAME] == "factory_function"
+    )
+    assert names == [1, 2, 3], names
+
+
 def test_same_line_findings_get_distinct_ids(tmp_path: Path) -> None:
     # (H) two matches of one rule on a single line must not collapse into one
     # (H) node; the qualified_name has to distinguish them by column.

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.418"
+version = "0.0.419"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

Three recall gaps in the opt-in `FINDINGS` rules (#413), each surfaced by dogfooding and each a real missed sink:

- **`innerhtml_xss`** matched only `el.innerHTML = x`. Now also catches `+=` and `outerHTML` (`el.innerHTML += x`, `el.outerHTML = x`, `el.outerHTML += x`) which are the same DOM-injection sink. `textContent` stays clean.
- **`sqli_concat`** matched only `execute(a + b)`. Now also catches printf-style `execute("... %s" % params)`, the classic format-string injection. Parametrized queries stay clean.
- **`factory_function`** (js/ts/tsx) matched only `function createX()` declarations. Now also catches the modern forms `const createX = () => {}` (arrow) and `const makeX = function () {}` (function expression). Plain `const other = () => {}` stays clean.

## Testing

RED→GREEN for each: `test_innerhtml_xss_catches_augmented_and_outerhtml`, `test_sqli_concat_catches_percent_format`, `test_factory_function_catches_arrow_and_expression`. Each asserts the new sinks fire and the safe form does not.

Full non-integration suite: 5411 passed, 5 skipped.
