### PR TITLE
feat(findings): add pattern, smell and security rules for 11 more languages

### DIFF
--- a/codebase_rag/analyzers/ast_grep_rules/patterns/c.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/patterns/c.yaml
@@ -1,0 +1,31 @@
+# ast-grep design-pattern rules for C (issue #413).
+# Each match becomes a Pattern node linked to the file's Module via
+# IMPLEMENTS_PATTERN. C has no classic OO patterns, so these are heuristic
+# function-name idioms recognised via the declarator identifier.
+ast_grep_id: c
+extensions: [.c, .h]
+rules:
+  - id: constructor_like
+    message: "Constructor idiom: function name starts with create/make/new/alloc"
+    rule:
+      kind: function_definition
+      has:
+        kind: function_declarator
+        stopBy: end
+        has: { field: declarator, kind: identifier, regex: '^(create|make|new|alloc)' }
+  - id: initializer_like
+    message: "Initializer idiom: function name starts with init"
+    rule:
+      kind: function_definition
+      has:
+        kind: function_declarator
+        stopBy: end
+        has: { field: declarator, kind: identifier, regex: '^init' }
+  - id: destructor_like
+    message: "Destructor idiom: function name starts with free/destroy/release"
+    rule:
+      kind: function_definition
+      has:
+        kind: function_declarator
+        stopBy: end
+        has: { field: declarator, kind: identifier, regex: '^(free|destroy|release)' }

--- a/codebase_rag/analyzers/ast_grep_rules/patterns/cpp.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/patterns/cpp.yaml
@@ -1,0 +1,34 @@
+# ast-grep design-pattern rules for C++ (issue #413).
+# Each match becomes a Pattern node linked to the file's Module via
+# IMPLEMENTS_PATTERN. Rules are heuristic and syntactic.
+ast_grep_id: cpp
+extensions: [.cpp, .cc, .cxx, .hpp, .hh]
+rules:
+  - id: singleton
+    message: "Singleton: class exposes a static getInstance accessor"
+    rule:
+      kind: function_definition
+      all:
+        - has: { kind: storage_class_specifier, regex: '^static$', stopBy: end }
+        - has:
+            kind: function_declarator
+            has: { field: declarator, regex: '^getInstance$' }
+            stopBy: end
+  - id: factory_function
+    message: "Factory function: name starts with create/make/build"
+    rule:
+      kind: function_definition
+      has:
+        kind: function_declarator
+        has: { field: declarator, regex: '^(create|make|build)' }
+        stopBy: end
+  - id: abstract_class
+    message: "Abstract class: declares a pure virtual method (= 0)"
+    rule:
+      kind: class_specifier
+      has:
+        kind: field_declaration
+        all:
+          - has: { regex: '^virtual$', stopBy: end }
+          - regex: '=\s*0\s*;'
+        stopBy: end

--- a/codebase_rag/analyzers/ast_grep_rules/patterns/csharp.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/patterns/csharp.yaml
@@ -1,0 +1,46 @@
+# ast-grep design-pattern rules for C# (issue #413).
+# Each match becomes a Pattern node linked to the file's Module via
+# IMPLEMENTS_PATTERN. Rules are heuristic and syntactic.
+ast_grep_id: csharp
+extensions: [.cs]
+rules:
+  - id: singleton
+    message: "Singleton: class exposes a static Instance member"
+    rule:
+      kind: class_declaration
+      has:
+        stopBy: end
+        any:
+          # static property named Instance / _instance
+          - kind: property_declaration
+            all:
+              - has: { kind: modifier, regex: '^static$', stopBy: end }
+              - has: { kind: identifier, regex: '^_?[Ii]nstance$', stopBy: end }
+          # static backing field named Instance / _instance
+          - kind: field_declaration
+            all:
+              - has: { kind: modifier, regex: '^static$', stopBy: end }
+              - has: { kind: identifier, regex: '^_?[Ii]nstance$', stopBy: end }
+  - id: factory_method
+    message: "Factory method: name starts with Create/Make/Build"
+    rule:
+      kind: method_declaration
+      has: { field: name, regex: '^(Create|Make|Build)' }
+  - id: builder
+    message: "Builder: class name ends with Builder"
+    rule:
+      kind: class_declaration
+      has: { field: name, regex: 'Builder$' }
+  - id: abstract_class
+    message: "Abstract base class: declared with the abstract modifier"
+    rule:
+      kind: class_declaration
+      has: { kind: modifier, regex: '^abstract$' }
+  - id: disposable
+    message: "Disposable: class defines a Dispose method"
+    rule:
+      kind: class_declaration
+      has:
+        stopBy: end
+        kind: method_declaration
+        has: { field: name, regex: '^Dispose$' }

--- a/codebase_rag/analyzers/ast_grep_rules/patterns/dart.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/patterns/dart.yaml
@@ -1,0 +1,28 @@
+# ast-grep design-pattern rules for Dart (issue #413).
+# Each match becomes a Pattern node linked to the file's Module via
+# IMPLEMENTS_PATTERN. Rules are heuristic and syntactic.
+ast_grep_id: dart
+extensions: [.dart]
+rules:
+  - id: factory_constructor
+    message: "Factory: class exposes a factory constructor"
+    rule:
+      kind: factory_constructor_signature
+  - id: singleton
+    message: "Singleton: class holds a static instance field"
+    rule:
+      kind: class_declaration
+      has:
+        kind: static_final_declaration
+        stopBy: end
+        has: { kind: identifier, regex: '(?i)instance' }
+  - id: builder
+    message: "Builder: class name ends in Builder"
+    rule:
+      kind: class_declaration
+      has: { field: name, regex: 'Builder$' }
+  - id: abstract_class
+    message: "Abstract class declares an interface for subclasses"
+    rule:
+      kind: class_declaration
+      regex: '^abstract\s'

--- a/codebase_rag/analyzers/ast_grep_rules/patterns/go.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/patterns/go.yaml
@@ -1,0 +1,25 @@
+# ast-grep design-pattern rules for Go (issue #413).
+# Each match becomes a Pattern node linked to the file's Module via
+# IMPLEMENTS_PATTERN. Rules are heuristic and syntactic.
+ast_grep_id: go
+extensions: [.go]
+rules:
+  - id: constructor
+    message: "Constructor: function name starts with New"
+    rule:
+      kind: function_declaration
+      has: { field: name, regex: '^New' }
+  - id: factory_function
+    message: "Factory function: name starts with New/Make/Build/Create"
+    rule:
+      kind: function_declaration
+      has: { field: name, regex: '^(New|Make|Build|Create)' }
+  - id: singleton
+    message: "Singleton: struct embeds sync.Once to guard one-time init"
+    rule:
+      kind: struct_type
+      has: { kind: qualified_type, regex: 'sync\.Once', stopBy: end }
+  - id: interface_declaration
+    message: "Interface: a behavioural contract declared for satisfaction"
+    rule:
+      kind: interface_type

--- a/codebase_rag/analyzers/ast_grep_rules/patterns/java.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/patterns/java.yaml
@@ -1,0 +1,37 @@
+# ast-grep design-pattern rules for Java (issue #413).
+# Each match becomes a Pattern node linked to the file's Module via
+# IMPLEMENTS_PATTERN. Rules are heuristic and syntactic.
+ast_grep_id: java
+extensions: [.java]
+rules:
+  - id: singleton
+    message: "Singleton: class exposes a static getInstance accessor"
+    rule:
+      kind: class_declaration
+      has:
+        kind: method_declaration
+        stopBy: end
+        all:
+          - has: { kind: modifiers, has: { regex: '^static$' } }
+          - has: { field: name, regex: '^getInstance$' }
+  - id: factory_method
+    message: "Factory method: name starts with create/make/build/newInstance"
+    rule:
+      kind: method_declaration
+      has: { field: name, regex: '^(create|make|build|newInstance)' }
+  - id: builder
+    message: "Builder: class name ends with Builder"
+    rule:
+      kind: class_declaration
+      has: { field: name, regex: 'Builder$' }
+  - id: fluent_builder
+    message: "Fluent builder: instance method returns this"
+    rule:
+      kind: method_declaration
+      has:
+        kind: block
+        has:
+          kind: return_statement
+          has: { kind: this }
+          stopBy: end
+        stopBy: end

--- a/codebase_rag/analyzers/ast_grep_rules/patterns/lua.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/patterns/lua.yaml
@@ -1,0 +1,31 @@
+# ast-grep design-pattern rules for Lua (issue #413).
+# Each match becomes a Pattern node linked to the file's Module via
+# IMPLEMENTS_PATTERN. Rules are heuristic and syntactic.
+ast_grep_id: lua
+extensions: [.lua]
+rules:
+  - id: metatable_oop
+    message: "Metatable OOP: setmetatable() wires a table to its class table"
+    rule:
+      kind: function_call
+      has: { kind: identifier, regex: '^setmetatable$' }
+  - id: index_metatable
+    message: "Class table: __index assigned for prototype-style inheritance"
+    rule:
+      kind: assignment_statement
+      has:
+        kind: dot_index_expression
+        has: { field: field, regex: '^__index$' }
+        stopBy: end
+  - id: factory_function
+    message: "Factory function: name starts with new/create/make"
+    rule:
+      kind: function_declaration
+      has: { kind: identifier, regex: '^(new|create|make)', stopBy: end }
+  - id: module_return
+    message: "Module pattern: chunk returns a single table variable"
+    rule:
+      kind: return_statement
+      has:
+        kind: expression_list
+        has: { kind: identifier, nthChild: 1 }

--- a/codebase_rag/analyzers/ast_grep_rules/patterns/php.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/patterns/php.yaml
@@ -1,0 +1,31 @@
+# ast-grep design-pattern rules for PHP (issue #413).
+# Each match becomes a Pattern node linked to the file's Module via
+# IMPLEMENTS_PATTERN. Rules are heuristic and syntactic.
+ast_grep_id: php
+extensions: [.php]
+rules:
+  - id: singleton
+    message: "Singleton: class exposes a static getInstance accessor"
+    rule:
+      kind: class_declaration
+      has:
+        kind: method_declaration
+        stopBy: end
+        all:
+          - has: { kind: static_modifier }
+          - has: { field: name, regex: '^getInstance$' }
+  - id: factory_function
+    message: "Factory function: name starts with create/make/build"
+    rule:
+      kind: function_definition
+      has: { field: name, regex: '^(create|make|build)' }
+  - id: factory_method
+    message: "Factory method: name starts with create/make/build"
+    rule:
+      kind: method_declaration
+      has: { field: name, regex: '^(create|make|build)' }
+  - id: abstract_class
+    message: "Abstract class: declared with the abstract modifier"
+    rule:
+      kind: class_declaration
+      has: { kind: abstract_modifier }

--- a/codebase_rag/analyzers/ast_grep_rules/patterns/ruby.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/patterns/ruby.yaml
@@ -11,10 +11,15 @@ rules:
   - id: factory_method
     message: "Factory: class method named create/build/make"
     rule:
-      kind: singleton_method
-      has:
-        field: name
-        regex: '^(create|build|make)'
+      any:
+        # def self.create ...
+        - kind: singleton_method
+          has: { field: name, regex: '^(create|build|make)' }
+        # class << self; def create ...
+        - kind: method
+          all:
+            - has: { field: name, regex: '^(create|build|make)' }
+            - inside: { kind: singleton_class, stopBy: end }
   - id: module_mixin
     message: "Module mixin: behavior shared via include/extend"
     rule:

--- a/codebase_rag/analyzers/ast_grep_rules/patterns/ruby.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/patterns/ruby.yaml
@@ -1,0 +1,24 @@
+# ast-grep design-pattern rules for Ruby (issue #413).
+# Each match becomes a Pattern node linked to the file's Module via
+# IMPLEMENTS_PATTERN. Rules are heuristic and syntactic.
+ast_grep_id: ruby
+extensions: [.rb]
+rules:
+  - id: singleton
+    message: "Singleton: class mixes in the Singleton module"
+    rule:
+      pattern: "include Singleton"
+  - id: factory_method
+    message: "Factory: class method named create/build/make"
+    rule:
+      kind: singleton_method
+      has:
+        field: name
+        regex: '^(create|build|make)'
+  - id: module_mixin
+    message: "Module mixin: behavior shared via include/extend"
+    rule:
+      kind: call
+      has:
+        field: method
+        regex: '^(include|extend|prepend)$'

--- a/codebase_rag/analyzers/ast_grep_rules/patterns/rust.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/patterns/rust.yaml
@@ -1,0 +1,27 @@
+# ast-grep design-pattern rules for Rust (issue #413).
+# Each match becomes a Pattern node linked to the file's Module via
+# IMPLEMENTS_PATTERN. Rules are heuristic and syntactic.
+ast_grep_id: rust
+extensions: [.rs]
+rules:
+  - id: constructor_new
+    message: "Constructor: associated fn new returning Self"
+    rule:
+      kind: function_item
+      all:
+        - has: { field: name, regex: '^new$' }
+        - has: { field: return_type, regex: '^Self$' }
+  - id: factory_function
+    message: "Factory function: name starts with new/build/create/make"
+    rule:
+      kind: function_item
+      has: { field: name, regex: '^(new|build|create|make)' }
+  - id: trait_impl
+    message: "Trait implementation: impl Trait for Type"
+    rule:
+      kind: impl_item
+      has: { field: trait, regex: '.' }
+  - id: trait_definition
+    message: "Trait definition declares an interface"
+    rule:
+      kind: trait_item

--- a/codebase_rag/analyzers/ast_grep_rules/patterns/scala.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/patterns/scala.yaml
@@ -1,0 +1,25 @@
+# ast-grep design-pattern rules for Scala (issue #413).
+# Each match becomes a Pattern node linked to the file's Module via
+# IMPLEMENTS_PATTERN. Rules are heuristic and syntactic.
+ast_grep_id: scala
+extensions: [.scala, .sc]
+rules:
+  - id: singleton_object
+    message: "Singleton: object declares a single shared instance"
+    rule:
+      kind: object_definition
+  - id: case_class
+    message: "Case class: immutable value type with generated equality"
+    rule:
+      kind: class_definition
+      regex: '^case\s+class'
+  - id: companion_factory
+    message: "Factory: apply method builds instances of the type"
+    rule:
+      kind: function_definition
+      has: { field: name, regex: '^apply$' }
+  - id: factory_method
+    message: "Factory method: name starts with make/create/build"
+    rule:
+      kind: function_definition
+      has: { field: name, regex: '^(make|create|build)' }

--- a/codebase_rag/analyzers/ast_grep_rules/security/c.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/c.yaml
@@ -1,0 +1,35 @@
+# ast-grep security rules for C (issue #413).
+# Each match becomes a SecurityIssue node linked to the file's Module via
+# HAS_VULNERABILITY. Rules favour recall; treat findings as review prompts.
+ast_grep_id: c
+extensions: [.c, .h]
+rules:
+  - id: dangerous_string_fn
+    message: "Unbounded string function (gets/strcpy/strcat/sprintf) risks buffer overflow"
+    rule:
+      kind: call_expression
+      has: { field: function, regex: '^(gets|strcpy|strcat|sprintf|vsprintf|scanf)$' }
+  - id: command_execution
+    message: "Possible command injection via system/popen/exec* call"
+    rule:
+      kind: call_expression
+      has: { field: function, regex: '^(system|popen|execl|execlp|execle|execv|execvp|execvpe)$' }
+  - id: hardcoded_secret
+    # Security rule: favour recall. Target name matches a credential word and the
+    # value is a non-trivial string literal (>=10 chars) that is not a printf-style
+    # format template. Handles both `char *password = "..."` (pointer_declarator)
+    # and `T token = "..."` (plain identifier) via a stopBy-end identifier probe.
+    message: "Hardcoded secret assigned to a credential-named variable"
+    rule:
+      kind: init_declarator
+      all:
+        - has: { stopBy: end, kind: identifier, regex: '(?i)(password|secret|api_key|token)' }
+        - has:
+            field: value
+            all:
+              - kind: string_literal
+              - regex: '^.{10,}$'
+              - not:
+                  any:
+                    - regex: '\{[^{}]*\}'
+                    - regex: '%[sdrifeEgGxXoc(]'

--- a/codebase_rag/analyzers/ast_grep_rules/security/cpp.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/cpp.yaml
@@ -1,0 +1,53 @@
+# ast-grep security rules for C++ (issue #413).
+# Each match becomes a SecurityIssue node linked to the file's Module via
+# HAS_VULNERABILITY. Rules are heuristic; treat findings as review prompts.
+ast_grep_id: cpp
+extensions: [.cpp, .cc, .cxx, .hpp, .hh]
+rules:
+  - id: system_call
+    message: "Possible command injection: system() executes a shell command"
+    rule:
+      kind: call_expression
+      has: { field: function, regex: '^system$' }
+  - id: unsafe_string_function
+    message: "Unsafe C string function; can overflow the destination buffer"
+    rule:
+      kind: call_expression
+      has:
+        field: function
+        regex: '^(strcpy|strcat|sprintf|gets|scanf|strncpy)$'
+  - id: hardcoded_secret
+    # Security rule: favour recall. Value must be a non-trivial string literal
+    # (>=10 chars incl. quotes) that is not a format/message template (a
+    # printf %s/%d specifier or a {..} placeholder). Braces and % conversions
+    # are the only exclusions so real secrets that contain %, spaces, URLs with
+    # embedded credentials, or SCREAMING_SNAKE shapes are still caught. Without
+    # entropy scoring, identifier/word literals still surface as review prompts;
+    # that residual is the known limit of regex-only secret detection.
+    message: "Hardcoded secret assigned to a credential-named variable"
+    rule:
+      any:
+        - kind: init_declarator
+          all:
+            - has: { field: declarator, regex: '(?i)(password|secret|api_key|token)' }
+            - has:
+                field: value
+                all:
+                  - kind: string_literal
+                  - regex: '^.{10,}$'
+                  - not:
+                      any:
+                        - regex: '\{[^{}]*\}'
+                        - regex: '%[sdrifeEgGxXoc(]'
+        - kind: assignment_expression
+          all:
+            - has: { field: left, regex: '(?i)(password|secret|api_key|token)' }
+            - has:
+                field: right
+                all:
+                  - kind: string_literal
+                  - regex: '^.{10,}$'
+                  - not:
+                      any:
+                        - regex: '\{[^{}]*\}'
+                        - regex: '%[sdrifeEgGxXoc(]'

--- a/codebase_rag/analyzers/ast_grep_rules/security/csharp.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/csharp.yaml
@@ -21,7 +21,8 @@ rules:
                 any:
                   - kind: binary_expression
                   - kind: interpolated_string_expression
-        # cmd.CommandText = "SELECT " + x;
+        # cmd.CommandText = "SELECT * FROM ..." + x;  (require a real SQL shape so
+        # an unrelated obj.CommandText = "Choose " + x is not misflagged)
         - kind: assignment_expression
           all:
             - has: { regex: 'CommandText', stopBy: end }
@@ -30,6 +31,9 @@ rules:
                 any:
                   - kind: binary_expression
                   - kind: interpolated_string_expression
+            - has:
+                stopBy: end
+                regex: '(?i)(select\b.*\bfrom\b|insert\b.*\binto\b|update\b.*\bset\b|delete\b.*\bfrom\b)'
   - id: hardcoded_secret
     # Security rule: favour recall. A credential-named field, property, or
     # assignment target bound to a non-trivial (>=8 char) plain string literal.

--- a/codebase_rag/analyzers/ast_grep_rules/security/csharp.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/csharp.yaml
@@ -1,0 +1,68 @@
+# ast-grep security rules for C# (issue #413).
+# Each match becomes a SecurityIssue node linked to the file's Module via
+# HAS_VULNERABILITY. Rules are heuristic; treat findings as review prompts.
+ast_grep_id: csharp
+extensions: [.cs]
+rules:
+  - id: process_start
+    message: "Process.Start can execute external commands; validate inputs"
+    rule:
+      pattern: "Process.Start($$$)"
+  - id: sql_injection
+    message: "Possible SQL injection: SqlCommand text built with concatenation or interpolation"
+    rule:
+      kind: object_creation_expression
+      all:
+        - has: { kind: identifier, regex: 'SqlCommand', stopBy: end }
+        - has:
+            stopBy: end
+            any:
+              - kind: binary_expression
+              - kind: interpolated_string_expression
+  - id: hardcoded_secret
+    # Security rule: favour recall. A credential-named field, property, or
+    # assignment target bound to a non-trivial (>=8 char) plain string literal.
+    # Name regex intentionally broadened beyond the literal api_key spelling to
+    # the idiomatic C# ApiKey/apiKey forms; still contains password|secret|
+    # api_key|token. Format templates ({..} placeholders, printf %s/%d) are the
+    # only value exclusions so URLs-with-credentials and SCREAMING_SNAKE shapes
+    # still surface. Identifier/word literals remain the known regex-only limit.
+    message: "Hardcoded secret assigned to a credential-named member"
+    rule:
+      any:
+        # field: private string password = "....";
+        - kind: variable_declarator
+          all:
+            - has: { kind: identifier, regex: '(?i)(password|passwd|secret|api_?key|token)' }
+            - has:
+                kind: string_literal
+                all:
+                  - regex: '^.{10,}$'
+                  - not:
+                      any:
+                        - regex: '\{[^{}]*\}'
+                        - regex: '%[sdrifeEgGxXoc(]'
+        # property: public string ApiKey { get; set; } = "....";
+        - kind: property_declaration
+          all:
+            - has: { field: name, regex: '(?i)(password|passwd|secret|api_?key|token)' }
+            - has:
+                kind: string_literal
+                all:
+                  - regex: '^.{10,}$'
+                  - not:
+                      any:
+                        - regex: '\{[^{}]*\}'
+                        - regex: '%[sdrifeEgGxXoc(]'
+        # assignment: token = "....";
+        - kind: assignment_expression
+          all:
+            - has: { kind: identifier, regex: '(?i)(password|passwd|secret|api_?key|token)' }
+            - has:
+                kind: string_literal
+                all:
+                  - regex: '^.{10,}$'
+                  - not:
+                      any:
+                        - regex: '\{[^{}]*\}'
+                        - regex: '%[sdrifeEgGxXoc(]'

--- a/codebase_rag/analyzers/ast_grep_rules/security/csharp.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/csharp.yaml
@@ -11,14 +11,25 @@ rules:
   - id: sql_injection
     message: "Possible SQL injection: SqlCommand text built with concatenation or interpolation"
     rule:
-      kind: object_creation_expression
-      all:
-        - has: { kind: identifier, regex: 'SqlCommand', stopBy: end }
-        - has:
-            stopBy: end
-            any:
-              - kind: binary_expression
-              - kind: interpolated_string_expression
+      any:
+        # new SqlCommand("SELECT " + x)
+        - kind: object_creation_expression
+          all:
+            - has: { kind: identifier, regex: 'SqlCommand', stopBy: end }
+            - has:
+                stopBy: end
+                any:
+                  - kind: binary_expression
+                  - kind: interpolated_string_expression
+        # cmd.CommandText = "SELECT " + x;
+        - kind: assignment_expression
+          all:
+            - has: { regex: 'CommandText', stopBy: end }
+            - has:
+                stopBy: end
+                any:
+                  - kind: binary_expression
+                  - kind: interpolated_string_expression
   - id: hardcoded_secret
     # Security rule: favour recall. A credential-named field, property, or
     # assignment target bound to a non-trivial (>=8 char) plain string literal.

--- a/codebase_rag/analyzers/ast_grep_rules/security/dart.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/dart.yaml
@@ -1,0 +1,41 @@
+# ast-grep security rules for Dart (issue #413).
+# Each match becomes a SecurityIssue node linked to the file's Module via
+# HAS_VULNERABILITY. Rules are heuristic; treat findings as review prompts.
+ast_grep_id: dart
+extensions: [.dart]
+rules:
+  - id: process_exec
+    # Dart's ast-grep pattern parser does not resolve receiver.method() call
+    # patterns, so match the call_expression by its source text instead.
+    message: "Process.run/start may enable command injection"
+    rule:
+      kind: call_expression
+      regex: '^Process\.(run|start|runSync|startSync)\s*\('
+  - id: sqli_concat
+    # Possible SQL injection: a query string literal joined with another
+    # expression through the + operator.
+    message: "Possible SQL injection: query built with string concatenation"
+    rule:
+      kind: additive_expression
+      has:
+        kind: string_literal
+        regex: '(?i)(select|insert|update|delete)\s'
+        stopBy: end
+  - id: hardcoded_secret
+    # Security rule: favour recall. A field or local variable whose name matches
+    # a credential shape bound to a non-trivial (>=8 char incl. quotes) string
+    # literal. Both the class-field form (initialized_identifier) and the local
+    # form (initialized_variable_definition) are covered. Without entropy
+    # scoring, config-name-shaped literals still surface as review prompts; that
+    # residual is the known limit of regex-only secret detection, not a defect.
+    message: "Hardcoded secret assigned to a credential-named variable"
+    rule:
+      any:
+        - kind: initialized_identifier
+          all:
+            - has: { kind: identifier, regex: '(?i)(password|secret|api_key|token)' }
+            - has: { kind: string_literal, regex: '^.{10,}$' }
+        - kind: initialized_variable_definition
+          all:
+            - has: { kind: identifier, regex: '(?i)(password|secret|api_key|token)' }
+            - has: { kind: string_literal, regex: '^.{10,}$' }

--- a/codebase_rag/analyzers/ast_grep_rules/security/dart.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/dart.yaml
@@ -19,7 +19,9 @@ rules:
       kind: additive_expression
       has:
         kind: string_literal
-        regex: '(?i)(select|insert|update|delete)\s'
+        # Anchor the SQL verb to the start of the literal so ordinary prose that
+        # merely contains a word like "select" is not misflagged.
+        regex: '(?i)^["'']?\s*(select|insert|update|delete|drop)\b'
         stopBy: end
   - id: hardcoded_secret
     # Security rule: favour recall. A field or local variable whose name matches

--- a/codebase_rag/analyzers/ast_grep_rules/security/dart.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/dart.yaml
@@ -19,9 +19,9 @@ rules:
       kind: additive_expression
       has:
         kind: string_literal
-        # Anchor the SQL verb to the start of the literal so ordinary prose that
-        # merely contains a word like "select" is not misflagged.
-        regex: '(?i)^["'']?\s*(select|insert|update|delete|drop)\b'
+        # Require a full SQL-statement shape (verb + companion keyword) so UI text
+        # like "Select " + option is not misflagged as a query.
+        regex: '(?i)(select\b.*\bfrom\b|insert\b.*\binto\b|update\b.*\bset\b|delete\b.*\bfrom\b)'
         stopBy: end
   - id: hardcoded_secret
     # Security rule: favour recall. A field or local variable whose name matches

--- a/codebase_rag/analyzers/ast_grep_rules/security/dart.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/dart.yaml
@@ -12,17 +12,19 @@ rules:
       kind: call_expression
       regex: '^Process\.(run|start|runSync|startSync)\s*\('
   - id: sqli_concat
-    # Possible SQL injection: a query string literal joined with another
-    # expression through the + operator.
+    # Anchored to an actual database call (rawQuery/execute/query/...) whose
+    # argument is built by string concatenation. Tying the rule to a sink, rather
+    # than to SQL-looking string content, keeps ordinary prose that merely
+    # contains words like "select ... from" from being misflagged.
     message: "Possible SQL injection: query built with string concatenation"
     rule:
-      kind: additive_expression
-      has:
-        kind: string_literal
-        # Require a full SQL-statement shape (verb + companion keyword) so UI text
-        # like "Select " + option is not misflagged as a query.
-        regex: '(?i)(select\b.*\bfrom\b|insert\b.*\binto\b|update\b.*\bset\b|delete\b.*\bfrom\b)'
-        stopBy: end
+      kind: call_expression
+      all:
+        - regex: '(?i)\b(rawQuery|rawInsert|rawUpdate|rawDelete|execute|query)\s*\('
+        - has:
+            kind: additive_expression
+            has: { kind: string_literal, stopBy: end }
+            stopBy: end
   - id: hardcoded_secret
     # Security rule: favour recall. A field or local variable whose name matches
     # a credential shape bound to a non-trivial (>=8 char incl. quotes) string

--- a/codebase_rag/analyzers/ast_grep_rules/security/go.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/go.yaml
@@ -1,0 +1,94 @@
+# ast-grep security rules for Go (issue #413).
+# Each match becomes a SecurityIssue node linked to the file's Module via
+# HAS_VULNERABILITY. Rules are heuristic and favour recall; treat findings as
+# review prompts.
+ast_grep_id: go
+extensions: [.go]
+rules:
+  - id: exec_command
+    message: "External command execution via os/exec.Command"
+    rule:
+      kind: call_expression
+      has:
+        field: function
+        kind: selector_expression
+        all:
+          - has: { field: operand, regex: '^exec$' }
+          - has: { field: field, regex: '^Command' }
+  - id: sqli_concat
+    message: "Possible SQL injection: Query/Exec argument built with string concatenation"
+    rule:
+      kind: call_expression
+      all:
+        - has:
+            kind: selector_expression
+            has: { field: field, regex: '^(Query|Exec)' }
+            stopBy: end
+        - has:
+            kind: binary_expression
+            has: { field: operator, regex: '\+' }
+            stopBy: end
+  - id: hardcoded_secret
+    # Security rule: favour recall. Value must be a non-trivial literal (>=8
+    # content chars) that is not a format/message template (a Sprintf {..}
+    # placeholder or a printf %s/%d specifier). Braces and % conversions are the
+    # only exclusions so real secrets that legitimately contain %, spaces, or
+    # URLs with embedded credentials are still caught. Covers :=, =, and
+    # var/const declarations. Ceiling: without entropy scoring, plain word/URL
+    # literals still surface as review prompts; that residual is the known limit
+    # of regex-only secret detection, not a defect.
+    message: "Hardcoded secret assigned to a credential-named variable"
+    rule:
+      any:
+        - kind: short_var_declaration
+          all:
+            - has: { field: left, regex: '(?i)(password|passwd|secret|api_?key|apikey|token|access_?key)' }
+            - has:
+                field: right
+                has:
+                  kind: interpreted_string_literal
+                  all:
+                    - regex: '^.{10,}$'
+                    - not:
+                        any:
+                          - regex: '\{[^{}]*\}'
+                          - regex: '%[sdrifeEgGxXoqvtbc]'
+                  stopBy: end
+        - kind: assignment_statement
+          all:
+            - has: { field: left, regex: '(?i)(password|passwd|secret|api_?key|apikey|token|access_?key)' }
+            - has:
+                field: right
+                has:
+                  kind: interpreted_string_literal
+                  all:
+                    - regex: '^.{10,}$'
+                    - not:
+                        any:
+                          - regex: '\{[^{}]*\}'
+                          - regex: '%[sdrifeEgGxXoqvtbc]'
+                  stopBy: end
+        - kind: var_spec
+          all:
+            - has: { field: name, regex: '(?i)(password|passwd|secret|api_?key|apikey|token|access_?key)' }
+            - has:
+                kind: interpreted_string_literal
+                all:
+                  - regex: '^.{10,}$'
+                  - not:
+                      any:
+                        - regex: '\{[^{}]*\}'
+                        - regex: '%[sdrifeEgGxXoqvtbc]'
+                stopBy: end
+        - kind: const_spec
+          all:
+            - has: { field: name, regex: '(?i)(password|passwd|secret|api_?key|apikey|token|access_?key)' }
+            - has:
+                kind: interpreted_string_literal
+                all:
+                  - regex: '^.{10,}$'
+                  - not:
+                      any:
+                        - regex: '\{[^{}]*\}'
+                        - regex: '%[sdrifeEgGxXoqvtbc]'
+                stopBy: end

--- a/codebase_rag/analyzers/ast_grep_rules/security/go.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/go.yaml
@@ -46,8 +46,10 @@ rules:
             - has:
                 field: right
                 has:
-                  kind: interpreted_string_literal
                   all:
+                    - any:
+                        - kind: interpreted_string_literal
+                        - kind: raw_string_literal
                     - regex: '^.{10,}$'
                     - not:
                         any:
@@ -60,8 +62,10 @@ rules:
             - has:
                 field: right
                 has:
-                  kind: interpreted_string_literal
                   all:
+                    - any:
+                        - kind: interpreted_string_literal
+                        - kind: raw_string_literal
                     - regex: '^.{10,}$'
                     - not:
                         any:
@@ -72,8 +76,10 @@ rules:
           all:
             - has: { field: name, regex: '(?i)(password|passwd|secret|api_?key|apikey|token|access_?key)' }
             - has:
-                kind: interpreted_string_literal
                 all:
+                  - any:
+                      - kind: interpreted_string_literal
+                      - kind: raw_string_literal
                   - regex: '^.{10,}$'
                   - not:
                       any:
@@ -84,8 +90,10 @@ rules:
           all:
             - has: { field: name, regex: '(?i)(password|passwd|secret|api_?key|apikey|token|access_?key)' }
             - has:
-                kind: interpreted_string_literal
                 all:
+                  - any:
+                      - kind: interpreted_string_literal
+                      - kind: raw_string_literal
                   - regex: '^.{10,}$'
                   - not:
                       any:

--- a/codebase_rag/analyzers/ast_grep_rules/security/java.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/java.yaml
@@ -1,0 +1,49 @@
+# ast-grep security rules for Java (issue #413).
+# Each match becomes a SecurityIssue node linked to the file's Module via
+# HAS_VULNERABILITY. Rules are heuristic; treat findings as review prompts.
+ast_grep_id: java
+extensions: [.java]
+rules:
+  - id: runtime_exec
+    message: "Runtime.exec() can enable command injection"
+    rule:
+      kind: method_invocation
+      has: { field: name, regex: '^exec$' }
+  - id: process_builder
+    message: "ProcessBuilder spawns an external process; validate its input"
+    rule:
+      pattern: "new ProcessBuilder($$$)"
+  - id: sqli_concat
+    message: "Possible SQL injection: query built with string concatenation"
+    rule:
+      kind: method_invocation
+      all:
+        - has: { field: name, regex: '^(executeQuery|executeUpdate|execute)$' }
+        - has:
+            kind: binary_expression
+            has: { kind: string_literal, stopBy: end }
+            stopBy: end
+  - id: hardcoded_secret
+    # Security rule: favour recall. Any variable/field whose name matches a
+    # credential word and is bound to a non-trivial string literal (>=8 inner
+    # chars, i.e. >=10 including the surrounding quotes) surfaces as a review
+    # prompt. Format/message templates (a "{..}" placeholder or a printf
+    # %s/%d specifier) are excluded so only literal-looking secrets remain.
+    message: "Hardcoded secret assigned to a credential-named variable"
+    rule:
+      kind: variable_declarator
+      all:
+        - has: { field: name, regex: '(?i)(password|secret|api_key|token)' }
+        - has:
+            field: value
+            all:
+              - kind: string_literal
+              - regex: '^.{10,}$'
+              - not:
+                  any:
+                    - regex: '\{[^{}]*\}'
+                    - regex: '%[sdrifeEgGxXoc(]'
+  - id: md5_digest
+    message: "Weak hash algorithm (MD5) requested"
+    rule:
+      pattern: 'MessageDigest.getInstance("MD5")'

--- a/codebase_rag/analyzers/ast_grep_rules/security/java.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/java.yaml
@@ -5,10 +5,13 @@ ast_grep_id: java
 extensions: [.java]
 rules:
   - id: runtime_exec
+    # Require a Runtime receiver so an unrelated obj.exec() is not misflagged.
     message: "Runtime.exec() can enable command injection"
     rule:
       kind: method_invocation
-      has: { field: name, regex: '^exec$' }
+      all:
+        - has: { field: name, regex: '^exec$' }
+        - has: { regex: '(?i)runtime', stopBy: end }
   - id: process_builder
     message: "ProcessBuilder spawns an external process; validate its input"
     rule:
@@ -18,7 +21,7 @@ rules:
     rule:
       kind: method_invocation
       all:
-        - has: { field: name, regex: '^(executeQuery|executeUpdate|execute)$' }
+        - has: { field: name, regex: '^(executeQuery|executeUpdate|execute|prepareStatement)$' }
         - has:
             kind: binary_expression
             has: { kind: string_literal, stopBy: end }
@@ -44,6 +47,9 @@ rules:
                     - regex: '\{[^{}]*\}'
                     - regex: '%[sdrifeEgGxXoc(]'
   - id: md5_digest
+    # Both the uppercase and lowercase spellings are common in the wild.
     message: "Weak hash algorithm (MD5) requested"
     rule:
-      pattern: 'MessageDigest.getInstance("MD5")'
+      any:
+        - pattern: 'MessageDigest.getInstance("MD5")'
+        - pattern: 'MessageDigest.getInstance("md5")'

--- a/codebase_rag/analyzers/ast_grep_rules/security/java.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/java.yaml
@@ -11,7 +11,9 @@ rules:
       kind: method_invocation
       all:
         - has: { field: name, regex: '^exec$' }
-        - has: { regex: '(?i)runtime', stopBy: end }
+        # Constrain to the receiver so a string arg mentioning "runtime" or an
+        # unrelated obj.exec() is not misflagged.
+        - has: { field: object, regex: '(?i)runtime', stopBy: end }
   - id: process_builder
     message: "ProcessBuilder spawns an external process; validate its input"
     rule:

--- a/codebase_rag/analyzers/ast_grep_rules/security/lua.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/lua.yaml
@@ -1,0 +1,38 @@
+# ast-grep security rules for Lua (issue #413).
+# Each match becomes a SecurityIssue node linked to the file's Module via
+# HAS_VULNERABILITY. Rules are heuristic; treat findings as review prompts.
+ast_grep_id: lua
+extensions: [.lua]
+rules:
+  - id: dynamic_code
+    message: "load()/loadstring() executes arbitrary code at runtime"
+    rule:
+      kind: function_call
+      has: { kind: identifier, regex: '^(load|loadstring)$' }
+  - id: os_command
+    message: "Possible command injection: os.execute()/io.popen() runs a shell command"
+    rule:
+      kind: function_call
+      has:
+        kind: dot_index_expression
+        regex: '^(os\.execute|io\.popen)$'
+  - id: dofile_use
+    message: "dofile()/loadfile() loads and runs an external file"
+    rule:
+      kind: function_call
+      has: { kind: identifier, regex: '^(dofile|loadfile)$' }
+  - id: hardcoded_secret
+    # Security rule: favour recall. Target name matches a credential keyword and
+    # the value is a non-trivial string literal. Covers both `local secret = ...`
+    # (assignment wrapped in variable_declaration) and bare `secret = ...` globals
+    # because both share the assignment_statement node.
+    message: "Hardcoded secret assigned to a credential-named variable"
+    rule:
+      kind: assignment_statement
+      all:
+        - has:
+            kind: variable_list
+            has: { kind: identifier, regex: '(?i)(password|secret|api_key|token)', stopBy: end }
+        - has:
+            kind: expression_list
+            has: { kind: string, regex: '^.{8,}$', stopBy: end }

--- a/codebase_rag/analyzers/ast_grep_rules/security/php.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/php.yaml
@@ -27,11 +27,11 @@ rules:
       any:
         - kind: function_call_expression
           all:
-            - has: { field: function, regex: '(?i)query' }
+            - has: { field: function, regex: '(?i)^(mysqli_query|pg_query|sqlsrv_query|db_query)$' }
             - has: { kind: binary_expression, stopBy: end }
         - kind: member_call_expression
           all:
-            - has: { field: name, regex: '(?i)query' }
+            - has: { field: name, regex: '(?i)^query$' }
             - has: { kind: binary_expression, stopBy: end }
   - id: hardcoded_secret
     # Security rule: favour recall. Value must be a non-trivial literal (>=10

--- a/codebase_rag/analyzers/ast_grep_rules/security/php.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/php.yaml
@@ -1,0 +1,59 @@
+# ast-grep security rules for PHP (issue #413).
+# Each match becomes a SecurityIssue node linked to the file's Module via
+# HAS_VULNERABILITY. Rules are heuristic and favour recall; treat findings as
+# review prompts.
+ast_grep_id: php
+extensions: [.php]
+rules:
+  - id: eval_use
+    message: "eval() executes arbitrary code"
+    rule:
+      kind: function_call_expression
+      has: { field: function, regex: '^eval$' }
+  - id: command_exec
+    # Shell/process execution sinks: user-controlled args risk command injection.
+    message: "Command execution sink (system/exec/shell_exec/passthru/proc_open/popen)"
+    rule:
+      kind: function_call_expression
+      has:
+        field: function
+        regex: '^(system|exec|shell_exec|passthru|proc_open|popen)$'
+  - id: sqli_concat
+    # SQL built by string concatenation (binary '.') passed to a query sink.
+    # Favour recall: match either a bare mysqli_query call or any ->query() method
+    # whose argument list contains a concatenation.
+    message: "Possible SQL injection: query built with string concatenation"
+    rule:
+      any:
+        - kind: function_call_expression
+          all:
+            - has: { field: function, regex: '(?i)query' }
+            - has: { kind: binary_expression, stopBy: end }
+        - kind: member_call_expression
+          all:
+            - has: { field: name, regex: '(?i)query' }
+            - has: { kind: binary_expression, stopBy: end }
+  - id: hardcoded_secret
+    # Security rule: favour recall. Value must be a non-trivial literal (>=10
+    # chars) that is not a format/message template (a {..} placeholder or a
+    # printf-style %s/%d specifier). Those two exclusions are the only ones, so
+    # real secrets containing %, spaces, or URLs with embedded credentials still
+    # surface. Ceiling: without entropy scoring, ordinary word/URL literals bound
+    # to a credential-named variable still surface as review prompts; that
+    # residual is the known limit of regex-only secret detection, not a defect.
+    message: "Hardcoded secret assigned to a credential-named variable"
+    rule:
+      kind: assignment_expression
+      all:
+        - has: { field: left, regex: '(?i)(password|secret|api_key|token)' }
+        - has:
+            field: right
+            all:
+              - any:
+                  - kind: encapsed_string  # double-quoted
+                  - kind: string           # single-quoted
+              - regex: '^.{10,}$'
+              - not:
+                  any:
+                    - regex: '\{[^{}]*\}'
+                    - regex: '%[sdrifeEgGxXoc(]'

--- a/codebase_rag/analyzers/ast_grep_rules/security/ruby.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/ruby.yaml
@@ -29,7 +29,7 @@ rules:
       all:
         - has:
             field: method
-            regex: '^(execute|exec_query|select_all|find_by_sql|query)$'
+            regex: '^(execute|exec_query|select_all|find_by_sql|query|where|find_by)$'
         - has:
             stopBy: end
             any:

--- a/codebase_rag/analyzers/ast_grep_rules/security/ruby.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/ruby.yaml
@@ -1,0 +1,65 @@
+# ast-grep security rules for Ruby (issue #413).
+# Each match becomes a SecurityIssue node linked to the file's Module via
+# HAS_VULNERABILITY. Rules are heuristic and favour recall; treat findings as
+# review prompts.
+ast_grep_id: ruby
+extensions: [.rb]
+rules:
+  - id: eval_use
+    message: "eval/instance_eval/class_eval executes arbitrary code"
+    rule:
+      kind: call
+      has:
+        field: method
+        regex: '^(eval|instance_eval|class_eval|module_eval)$'
+  - id: os_command
+    message: "Possible command injection: shell command via system/exec/backticks/%x"
+    rule:
+      any:
+        # backticks `...` and %x{...} both parse as subshell
+        - kind: subshell
+        - kind: call
+          has:
+            field: method
+            regex: '^(system|exec|spawn)$'
+  - id: sql_injection
+    message: "Possible SQL injection: query built with interpolation or concatenation"
+    rule:
+      kind: call
+      all:
+        - has:
+            field: method
+            regex: '^(execute|exec_query|select_all|find_by_sql|query)$'
+        - has:
+            stopBy: end
+            any:
+              # string with #{...} interpolation
+              - kind: interpolation
+              # "..." + var concatenation
+              - kind: binary
+                has:
+                  kind: string
+                  stopBy: end
+  - id: hardcoded_secret
+    # Security rule: favour recall. Target name matches a credential keyword and
+    # the value is a non-trivial (>=8 char) string literal that is not a
+    # format/message template (an #{..} interpolation placeholder or a printf
+    # %s/%d specifier). Those two exclusions keep real secrets that contain %,
+    # spaces, URLs with embedded credentials, or SCREAMING_SNAKE shapes.
+    # Ceiling: without entropy scoring, identifier/word-shaped literals still
+    # surface as review prompts; that residual is the known limit of regex-only
+    # secret detection, not a defect.
+    message: "Hardcoded secret assigned to a credential-named variable"
+    rule:
+      kind: assignment
+      all:
+        - has: { field: left, regex: '(?i)(password|secret|api_key|token)' }
+        - has:
+            field: right
+            all:
+              - kind: string
+              - regex: '^.{10,}$'
+              - not:
+                  any:
+                    - has: { kind: interpolation, stopBy: end }
+                    - regex: '%[sdrifeEgGxXoc]'

--- a/codebase_rag/analyzers/ast_grep_rules/security/rust.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/rust.yaml
@@ -1,0 +1,64 @@
+# ast-grep security rules for Rust (issue #413).
+# Each match becomes a SecurityIssue node linked to the file's Module via
+# HAS_VULNERABILITY. Rules are heuristic; treat findings as review prompts.
+ast_grep_id: rust
+extensions: [.rs]
+rules:
+  - id: command_new
+    message: "Spawning an external process (Command::new) can enable command injection"
+    rule:
+      kind: call_expression
+      has:
+        kind: scoped_identifier
+        regex: 'Command\s*::\s*new'
+        stopBy: end
+  - id: unsafe_block
+    message: "unsafe block bypasses Rust memory-safety guarantees"
+    rule:
+      kind: unsafe_block
+  - id: hardcoded_secret
+    # Security rule: favour recall. Target name matches a credential keyword and
+    # the value is a non-trivial string literal (>=10 chars incl. quotes) that is
+    # not a format template (a {..} placeholder or a printf-style specifier).
+    # Covers both `let` bindings and reassignments. Identifier/word/URL-name
+    # literals still surface as review prompts; that residual is the known limit
+    # of regex-only secret detection, not a defect.
+    message: "Hardcoded secret assigned to a credential-named variable"
+    rule:
+      any:
+        - kind: let_declaration
+          all:
+            - has: { field: pattern, regex: '(?i)(password|secret|api_key|token)' }
+            - has:
+                field: value
+                all:
+                  - kind: string_literal
+                  - regex: '^.{10,}$'
+                  - not:
+                      any:
+                        - regex: '\{[^{}]*\}'
+                        - regex: '%[sdrifeEgGxXoc(]'
+        - kind: assignment_expression
+          all:
+            - has: { field: left, regex: '(?i)(password|secret|api_key|token)' }
+            - has:
+                field: right
+                all:
+                  - kind: string_literal
+                  - regex: '^.{10,}$'
+                  - not:
+                      any:
+                        - regex: '\{[^{}]*\}'
+                        - regex: '%[sdrifeEgGxXoc(]'
+  - id: sql_format
+    message: "Possible SQL injection: query built with format! passed to execute"
+    rule:
+      kind: call_expression
+      all:
+        - has:
+            kind: field_expression
+            has: { field: field, regex: '^execute$' }
+        - has:
+            kind: macro_invocation
+            has: { field: macro, regex: '^format$' }
+            stopBy: end

--- a/codebase_rag/analyzers/ast_grep_rules/security/rust.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/rust.yaml
@@ -57,7 +57,7 @@ rules:
       all:
         - has:
             kind: field_expression
-            has: { field: field, regex: '^execute$' }
+            has: { field: field, regex: '^(execute|query|fetch)' }
         - has:
             kind: macro_invocation
             has: { field: macro, regex: '^format$' }

--- a/codebase_rag/analyzers/ast_grep_rules/security/scala.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/scala.yaml
@@ -1,0 +1,33 @@
+# ast-grep security rules for Scala (issue #413).
+# Each match becomes a SecurityIssue node linked to the file's Module via
+# HAS_VULNERABILITY. Rules are heuristic; treat findings as review prompts.
+ast_grep_id: scala
+extensions: [.scala, .sc]
+rules:
+  - id: os_command_exec
+    message: "Possible command injection: external process launched from code"
+    rule:
+      any:
+        - pattern: "$X.exec($$$)"
+        - pattern: "Process($$$)"
+        - pattern: "Runtime.getRuntime.exec($$$)"
+  - id: sql_string_concat
+    # Security rule: favour recall. A SQL keyword string literal joined with +
+    # is a classic injection shape.
+    message: "Possible SQL injection: query built by string concatenation"
+    rule:
+      kind: infix_expression
+      all:
+        - has: { kind: string, regex: '(?i)\b(select|insert|update|delete)\b' }
+        - has: { kind: operator_identifier, regex: '^\+$' }
+  - id: hardcoded_secret
+    # Security rule: favour recall. A val/var whose name matches a credential
+    # keyword bound to a non-trivial (>=10 char) string literal.
+    message: "Hardcoded secret assigned to a credential-named variable"
+    rule:
+      all:
+        - any:
+            - kind: val_definition
+            - kind: var_definition
+        - has: { kind: identifier, regex: '(?i)(password|secret|api_key|token)' }
+        - has: { kind: string, regex: '^.{12,}$' }

--- a/codebase_rag/analyzers/ast_grep_rules/security/scala.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/scala.yaml
@@ -8,9 +8,10 @@ rules:
     message: "Possible command injection: external process launched from code"
     rule:
       any:
-        - pattern: "$X.exec($$$)"
-        - pattern: "Process($$$)"
+        # A bare $X.exec matched any method named exec; require a Runtime receiver.
         - pattern: "Runtime.getRuntime.exec($$$)"
+        - pattern: "Process($$$)"
+        - pattern: "scala.sys.process.Process($$$)"
   - id: sql_string_concat
     # Security rule: favour recall. A SQL keyword string literal joined with +
     # is a classic injection shape.

--- a/codebase_rag/analyzers/ast_grep_rules/smells/c.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/smells/c.yaml
@@ -1,0 +1,20 @@
+# ast-grep code-smell rules for C (issue #413).
+# Each match becomes a CodeSmell node linked to the file's Module via HAS_SMELL.
+ast_grep_id: c
+extensions: [.c, .h]
+rules:
+  - id: goto_statement
+    message: "goto complicates control flow"
+    rule:
+      kind: goto_statement
+  - id: debug_print
+    message: "Leftover debug printf/fprintf output"
+    rule:
+      kind: call_expression
+      has: { field: function, regex: '^(printf|fprintf)$' }
+  - id: infinite_loop
+    message: "Infinite loop while(1)/for(;;) has no visible exit condition"
+    rule:
+      any:
+        - pattern: "while (1) $$$"
+        - pattern: "for (;;) $$$"

--- a/codebase_rag/analyzers/ast_grep_rules/smells/cpp.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/smells/cpp.yaml
@@ -6,13 +6,14 @@ rules:
   - id: using_namespace_std
     message: "using namespace std pollutes the global namespace"
     rule:
-      kind: using_declaration
-      regex: 'using\s+namespace\s+std'
+      pattern: "using namespace std;"
   - id: cout_debug_output
+    # Match both std::cout and the bare cout common under `using namespace std`.
     message: "Debug output via std::cout left in source"
     rule:
-      kind: qualified_identifier
-      regex: '^std::cout$'
+      any:
+        - pattern: "std::cout"
+        - pattern: "cout"
   - id: raw_new
     message: "Raw new expression; prefer smart pointers"
     rule:

--- a/codebase_rag/analyzers/ast_grep_rules/smells/cpp.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/smells/cpp.yaml
@@ -1,0 +1,23 @@
+# ast-grep code-smell rules for C++ (issue #413).
+# Each match becomes a CodeSmell node linked to the file's Module via HAS_SMELL.
+ast_grep_id: cpp
+extensions: [.cpp, .cc, .cxx, .hpp, .hh]
+rules:
+  - id: using_namespace_std
+    message: "using namespace std pollutes the global namespace"
+    rule:
+      kind: using_declaration
+      regex: 'using\s+namespace\s+std'
+  - id: cout_debug_output
+    message: "Debug output via std::cout left in source"
+    rule:
+      kind: qualified_identifier
+      regex: '^std::cout$'
+  - id: raw_new
+    message: "Raw new expression; prefer smart pointers"
+    rule:
+      kind: new_expression
+  - id: c_array_buffer
+    message: "Fixed-size C array; prefer std::array or std::vector"
+    rule:
+      kind: array_declarator

--- a/codebase_rag/analyzers/ast_grep_rules/smells/csharp.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/smells/csharp.yaml
@@ -1,0 +1,27 @@
+# ast-grep code-smell rules for C# (issue #413).
+# Each match becomes a CodeSmell node linked to the file's Module via HAS_SMELL.
+ast_grep_id: csharp
+extensions: [.cs]
+rules:
+  - id: console_writeline
+    message: "Console.WriteLine left in code reads like debug output"
+    rule:
+      any:
+        - pattern: "Console.WriteLine($$$)"
+        - pattern: "Console.Write($$$)"
+  - id: empty_catch
+    message: "Empty catch block swallows the exception silently"
+    rule:
+      kind: catch_clause
+      has: { kind: block, regex: '^\{\s*\}$' }
+  - id: broad_catch
+    message: "catch (Exception ...) catches too much"
+    rule:
+      kind: catch_clause
+      has:
+        kind: catch_declaration
+        has: { kind: identifier, regex: '^Exception$' }
+  - id: thread_sleep
+    message: "Thread.Sleep blocks the thread; prefer async waiting"
+    rule:
+      pattern: "Thread.Sleep($$$)"

--- a/codebase_rag/analyzers/ast_grep_rules/smells/dart.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/smells/dart.yaml
@@ -25,4 +25,5 @@ rules:
     message: "Prefer null-aware operators over explicit == null checks scattered in code"
     rule:
       kind: equality_expression
-      regex: '(?:==\s*null|null\s*==)'
+      # Word boundaries so `null` matches only the literal, not `nullValue` etc.
+      regex: '(?:==\s*\bnull\b|\bnull\b\s*==)'

--- a/codebase_rag/analyzers/ast_grep_rules/smells/dart.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/smells/dart.yaml
@@ -21,7 +21,8 @@ rules:
       kind: type_identifier
       regex: '^dynamic$'
   - id: double_equals_null
+    # Catch both orders: `x == null` and the Yoda form `null == x`.
     message: "Prefer null-aware operators over explicit == null checks scattered in code"
     rule:
       kind: equality_expression
-      regex: '==\s*null$'
+      regex: '(?:==\s*null|null\s*==)'

--- a/codebase_rag/analyzers/ast_grep_rules/smells/dart.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/smells/dart.yaml
@@ -1,0 +1,27 @@
+# ast-grep code-smell rules for Dart (issue #413).
+# Each match becomes a CodeSmell node linked to the file's Module via HAS_SMELL.
+ast_grep_id: dart
+extensions: [.dart]
+rules:
+  - id: debug_print
+    message: "Leftover print() debug statement"
+    rule:
+      kind: call_expression
+      regex: '^print\s*\('
+  - id: empty_catch
+    message: "Empty catch block swallows the exception"
+    rule:
+      kind: block
+      regex: '^\{\s*\}$'
+      inside: { kind: try_statement, stopBy: end }
+      follows: { kind: catch_clause }
+  - id: dynamic_type
+    message: "dynamic type defeats static type checking"
+    rule:
+      kind: type_identifier
+      regex: '^dynamic$'
+  - id: double_equals_null
+    message: "Prefer null-aware operators over explicit == null checks scattered in code"
+    rule:
+      kind: equality_expression
+      regex: '==\s*null$'

--- a/codebase_rag/analyzers/ast_grep_rules/smells/go.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/smells/go.yaml
@@ -22,9 +22,9 @@ rules:
     message: "Return value discarded with blank identifier in := declaration"
     rule:
       kind: short_var_declaration
-      has: { field: left, regex: '\b_\b' }
+      has: { field: left, regex: '_\s*$' }
   - id: ignored_error_assign
     message: "Return value discarded with blank identifier in = assignment"
     rule:
       kind: assignment_statement
-      has: { field: left, regex: '\b_\b' }
+      has: { field: left, regex: '_\s*$' }

--- a/codebase_rag/analyzers/ast_grep_rules/smells/go.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/smells/go.yaml
@@ -1,0 +1,30 @@
+# ast-grep code-smell rules for Go (issue #413).
+# Each match becomes a CodeSmell node linked to the file's Module via HAS_SMELL.
+ast_grep_id: go
+extensions: [.go]
+rules:
+  - id: debug_print
+    message: "Leftover debug output: fmt.Print/Printf/Println call"
+    rule:
+      kind: call_expression
+      has:
+        field: function
+        kind: selector_expression
+        all:
+          - has: { field: operand, regex: '^fmt$' }
+          - has: { field: field, regex: '^Print' }
+  - id: panic_call
+    message: "panic() aborts the program; prefer returning an error"
+    rule:
+      kind: call_expression
+      has: { field: function, kind: identifier, regex: '^panic$' }
+  - id: ignored_error_shortvar
+    message: "Return value discarded with blank identifier in := declaration"
+    rule:
+      kind: short_var_declaration
+      has: { field: left, regex: '\b_\b' }
+  - id: ignored_error_assign
+    message: "Return value discarded with blank identifier in = assignment"
+    rule:
+      kind: assignment_statement
+      has: { field: left, regex: '\b_\b' }

--- a/codebase_rag/analyzers/ast_grep_rules/smells/java.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/smells/java.yaml
@@ -1,0 +1,32 @@
+# ast-grep code-smell rules for Java (issue #413).
+# Each match becomes a CodeSmell node linked to the file's Module via HAS_SMELL.
+ast_grep_id: java
+extensions: [.java]
+rules:
+  - id: system_out_println
+    message: "Debug print left in code: System.out.println"
+    rule:
+      pattern: "System.out.println($$$)"
+  - id: empty_catch
+    message: "Empty catch block swallows the exception"
+    rule:
+      kind: catch_clause
+      has:
+        field: body
+        kind: block
+        regex: '^\{\s*\}$'
+  - id: broad_catch
+    message: "Broad catch of Exception/Throwable catches too much"
+    rule:
+      kind: catch_clause
+      has:
+        kind: catch_formal_parameter
+        has:
+          kind: type_identifier
+          regex: '^(Exception|Throwable)$'
+          stopBy: end
+  - id: print_stack_trace
+    message: "printStackTrace used instead of a logger"
+    rule:
+      kind: method_invocation
+      has: { field: name, regex: '^printStackTrace$' }

--- a/codebase_rag/analyzers/ast_grep_rules/smells/lua.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/smells/lua.yaml
@@ -1,0 +1,24 @@
+# ast-grep code-smell rules for Lua (issue #413).
+# Each match becomes a CodeSmell node linked to the file's Module via HAS_SMELL.
+ast_grep_id: lua
+extensions: [.lua]
+rules:
+  - id: debug_print
+    message: "Leftover print() call looks like debug output"
+    rule:
+      kind: function_call
+      has: { kind: identifier, regex: '^print$' }
+  - id: global_assignment
+    message: "Assignment without local leaks a global"
+    rule:
+      kind: assignment_statement
+      not: { inside: { kind: variable_declaration } }
+  - id: long_param_list
+    message: "Very long parameter list is hard to call correctly"
+    rule:
+      kind: parameters
+      has: { kind: identifier, nthChild: 8 }
+  - id: goto_statement
+    message: "goto makes control flow hard to follow"
+    rule:
+      kind: goto_statement

--- a/codebase_rag/analyzers/ast_grep_rules/smells/php.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/smells/php.yaml
@@ -1,0 +1,24 @@
+# ast-grep code-smell rules for PHP (issue #413).
+# Each match becomes a CodeSmell node linked to the file's Module via HAS_SMELL.
+ast_grep_id: php
+extensions: [.php]
+rules:
+  - id: debug_output
+    message: "Debug output call (var_dump/print_r/var_export) left in code"
+    rule:
+      kind: function_call_expression
+      has: { field: function, regex: '^(var_dump|print_r|var_export)$' }
+  - id: error_suppression
+    message: "Error suppression operator @ hides failures"
+    rule:
+      kind: error_suppression_expression
+  - id: loose_equality
+    # Loose == / != coerce operand types; anchored regex skips strict === / !==.
+    message: "Loose equality (== or !=) performs type coercion"
+    rule:
+      kind: binary_expression
+      has: { field: operator, regex: '^(==|!=)$' }
+  - id: global_declaration
+    message: "global declaration couples the function to global state"
+    rule:
+      kind: global_declaration

--- a/codebase_rag/analyzers/ast_grep_rules/smells/ruby.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/smells/ruby.yaml
@@ -1,0 +1,31 @@
+# ast-grep code-smell rules for Ruby (issue #413).
+# Each match becomes a CodeSmell node linked to the file's Module via HAS_SMELL.
+ast_grep_id: ruby
+extensions: [.rb]
+rules:
+  - id: debug_print
+    message: "Leftover debug output (puts/p/pp/print)"
+    rule:
+      kind: call
+      has:
+        field: method
+        regex: '^(puts|pp|print|p)$'
+  - id: swallowed_rescue
+    message: "rescue that is empty or only returns nil hides errors"
+    rule:
+      kind: rescue
+      any:
+        # rescue with no handler body at all
+        - not:
+            has:
+              kind: then
+        # rescue whose body is just nil
+        - has:
+            kind: then
+            has:
+              kind: nil
+              stopBy: end
+  - id: global_variable
+    message: "Global variable ($var) couples code to shared mutable state"
+    rule:
+      kind: global_variable

--- a/codebase_rag/analyzers/ast_grep_rules/smells/rust.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/smells/rust.yaml
@@ -1,0 +1,23 @@
+# ast-grep code-smell rules for Rust (issue #413).
+# Each match becomes a CodeSmell node linked to the file's Module via HAS_SMELL.
+ast_grep_id: rust
+extensions: [.rs]
+rules:
+  - id: unwrap_call
+    message: "unwrap() panics instead of handling the error case"
+    rule:
+      pattern: "$X.unwrap()"
+  - id: expect_call
+    message: "expect() panics instead of handling the error case"
+    rule:
+      pattern: "$X.expect($$$)"
+  - id: dbg_macro
+    message: "dbg! macro left in code"
+    rule:
+      kind: macro_invocation
+      has: { field: macro, regex: '^dbg$' }
+  - id: panic_macro
+    message: "panic!/unimplemented!/todo!/unreachable! macro aborts at runtime"
+    rule:
+      kind: macro_invocation
+      has: { field: macro, regex: '^(panic|unimplemented|todo|unreachable)$' }

--- a/codebase_rag/analyzers/ast_grep_rules/smells/scala.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/smells/scala.yaml
@@ -1,0 +1,22 @@
+# ast-grep code-smell rules for Scala (issue #413).
+# Each match becomes a CodeSmell node linked to the file's Module via HAS_SMELL.
+ast_grep_id: scala
+extensions: [.scala, .sc]
+rules:
+  - id: debug_println
+    message: "println left in code; use a logger instead"
+    rule:
+      pattern: "println($$$)"
+  - id: mutable_var
+    message: "Mutable var declaration; prefer val where possible"
+    rule:
+      kind: var_definition
+  - id: null_usage
+    message: "null literal; prefer Option to represent absence"
+    rule:
+      kind: null_literal
+  - id: instanceof_cast
+    message: "asInstanceOf cast bypasses the type system"
+    rule:
+      kind: generic_function
+      regex: 'asInstanceOf'

--- a/codebase_rag/tests/test_ast_grep_analyzer.py
+++ b/codebase_rag/tests/test_ast_grep_analyzer.py
@@ -265,8 +265,9 @@ _POSITIVE_FIXTURES = {
         "func run(db DB) {\n"
         '    fmt.Println("hi")\n'
         '    panic("x")\n'
-        "    _, err := doThing()\n"
+        "    result, _ := doThing()\n"
         "    _ = other()\n"
+        "    _ = result\n"
         '    exec.Command("ls")\n'
         '    db.Query("SELECT " + err)\n'
         '    password := "supersecretvalue"\n'
@@ -529,6 +530,47 @@ def test_factory_function_catches_arrow_and_expression(tmp_path: Path) -> None:
         if p[cs.KEY_NAME] == "factory_function"
     )
     assert names == [1, 2, 3, 4], names
+
+
+def test_go_ignored_error_only_flags_discarded_last_value(tmp_path: Path) -> None:
+    # (H) In Go, `_, err := f()` keeps the error and is idiomatic; only a trailing
+    # (H) `_` (discarding the conventionally-last error) is the smell. The rule
+    # (H) must flag line 4 (result, _) and leave line 3 (_, err) clean.
+    src = (
+        "package main\n"
+        "func f() {\n"
+        "    _, err := doThing()\n"
+        "    result, _ := doThing()\n"
+        "    _ = err\n"
+        "    _ = result\n"
+        "}\n"
+    )
+    lines = sorted(
+        p[cs.KEY_START_LINE]
+        for p in _fire(tmp_path, "x.go", src)
+        if p[cs.KEY_NAME] == "ignored_error_shortvar"
+    )
+    assert lines == [4], lines
+
+
+def test_multilang_security_rules_avoid_common_false_positives(
+    tmp_path: Path,
+) -> None:
+    # (H) Precision guards for the widened multi-language rules: each benign
+    # (H) construct must NOT emit its neighbouring finding.
+    cases = [
+        (
+            "q.php",
+            '<?php build_query("a" . $x); $o->query_posts("z" . $w);\n',
+            "sqli_concat",
+        ),
+        ("e.java", 'class A { void f(){ myExecutor.exec("job"); } }\n', "runtime_exec"),
+        ("e.scala", "object O { def f() { list.exec() } }\n", "os_command_exec"),
+        ("d.dart", 'void f(x){ var b = "Please select one " + x; }\n', "sqli_concat"),
+    ]
+    for name, src, rule_id in cases:
+        names = [p[cs.KEY_NAME] for p in _fire(tmp_path, name, src)]
+        assert rule_id not in names, (name, rule_id, names)
 
 
 def test_same_line_findings_get_distinct_ids(tmp_path: Path) -> None:

--- a/codebase_rag/tests/test_ast_grep_analyzer.py
+++ b/codebase_rag/tests/test_ast_grep_analyzer.py
@@ -405,7 +405,7 @@ _POSITIVE_FIXTURES = {
         "    dynamic x = 5;\n"
         "    if (y == null) {}\n"
         '    Process.run("ls", []);\n'
-        '    var q = "SELECT " + name;\n'
+        '    var q = "SELECT * FROM t WHERE id=" + name;\n'
         '    var password = "supersecretvalue";\n'
         "  }\n"
         "}\n"
@@ -567,6 +567,18 @@ def test_multilang_security_rules_avoid_common_false_positives(
         ("e.java", 'class A { void f(){ myExecutor.exec("job"); } }\n', "runtime_exec"),
         ("e.scala", "object O { def f() { list.exec() } }\n", "os_command_exec"),
         ("d.dart", 'void f(x){ var b = "Please select one " + x; }\n', "sqli_concat"),
+        # keyword-in-text must not read as a SQL sink without a real query shape
+        ("u.dart", 'void f(x){ var label = "Select " + option; }\n', "sqli_concat"),
+        (
+            "r.java",
+            'class A { void f(){ executor.exec("Runtime configuration"); } }\n',
+            "runtime_exec",
+        ),
+        (
+            "c.cs",
+            'class A { void f(){ request.CommandText = "Choose " + option; } }\n',
+            "sql_injection",
+        ),
     ]
     for name, src, rule_id in cases:
         names = [p[cs.KEY_NAME] for p in _fire(tmp_path, name, src)]

--- a/codebase_rag/tests/test_ast_grep_analyzer.py
+++ b/codebase_rag/tests/test_ast_grep_analyzer.py
@@ -129,6 +129,25 @@ def test_rules_load_and_meet_acceptance_counts() -> None:
         assert len(_labelled(js, cs.NodeLabel.SECURITY_ISSUE)) >= 3
 
 
+def test_every_language_has_all_three_categories() -> None:
+    # (H) Each supported grammar must ship patterns + smells + security with at
+    # (H) least 3 rules apiece, so a language never regresses to partial coverage.
+    from codebase_rag.analyzers.ast_grep_analyzer import load_finding_rules
+
+    by_grammar: dict[str, dict] = {}
+    for lang in load_finding_rules().values():
+        counts = by_grammar.setdefault(lang.ast_grep_id, {})
+        for r in lang.rules:
+            counts[r.node_label] = counts.get(r.node_label, 0) + 1
+    for gid, counts in sorted(by_grammar.items()):
+        for label in (
+            cs.NodeLabel.PATTERN,
+            cs.NodeLabel.CODE_SMELL,
+            cs.NodeLabel.SECURITY_ISSUE,
+        ):
+            assert counts.get(label, 0) >= 3, f"{gid} has <3 {label}: {counts}"
+
+
 def test_analyzer_emits_node_and_edge_directly(tmp_path: Path) -> None:
     from codebase_rag.analyzers import FindingAnalyzer
 
@@ -179,15 +198,10 @@ def test_loose_equality_flags_inequality_not_strict(tmp_path: Path) -> None:
     assert lines == [3, 4], lines
 
 
-def test_every_rule_fires_on_positive_fixture(tmp_path: Path) -> None:
-    # (H) Exhaustive functionality lock: a rule whose `kind`/`pattern` is wrong for
-    # (H) ast-grep's bundled grammar silently matches nothing (the f_string class of
-    # (H) bug). Every shipped rule must fire on a hand-crafted positive fixture, so a
-    # (H) future typo that zeroes a rule fails here instead of shipping dead.
-    from codebase_rag.analyzers import FindingAnalyzer
-    from codebase_rag.analyzers.ast_grep_analyzer import load_finding_rules
-
-    py = (
+# Positive fixtures keyed by ast-grep grammar id. Each string is crafted to
+# trigger every rule shipped for that grammar; test_every_rule_fires asserts so.
+_POSITIVE_FIXTURES = {
+    "python": (
         "from mod import *\n"
         "class Config:\n    _instance = None\n"
         "class Ctx:\n    def __enter__(self): return self\n"
@@ -210,8 +224,8 @@ def test_every_rule_fires_on_positive_fixture(tmp_path: Path) -> None:
         '    os.system("rm " + u)\n'
         "    subprocess.run(u, shell=True)\n"
         "    yaml.load(u); pickle.loads(u)\n"
-    )
-    js = (
+    ),
+    "javascript": (
         "class A { getInstance() { return 1; } }\n"
         "const p = new Promise((res) => res(1));\n"
         "function createThing() { return {}; }\n"
@@ -223,10 +237,213 @@ def test_every_rule_fires_on_positive_fixture(tmp_path: Path) -> None:
         "eval(userInput);\n"
         "document.write(userInput);\n"
         'const password = "supersecretvalue123";\n'
-    )
+    ),
+    "rust": (
+        "struct S;\n"
+        "impl S { fn new() -> Self { S } }\n"
+        "trait Greet { fn hi(&self); }\n"
+        "impl Greet for S { fn hi(&self) {} }\n"
+        "fn build_it(conn: &Conn) -> i32 {\n"
+        "    let x: Option<i32> = None;\n"
+        "    let a = x.unwrap();\n"
+        '    let b = x.expect("no");\n'
+        "    dbg!(a);\n"
+        '    panic!("boom");\n'
+        "    unsafe { }\n"
+        '    let password = "supersecretvalue";\n'
+        '    std::process::Command::new("ls");\n'
+        '    conn.execute(format!("SELECT {}", a));\n'
+        "    b\n"
+        "}\n"
+    ),
+    "go": (
+        "package main\n"
+        'import ("fmt"; "os/exec"; "sync")\n'
+        "type Server struct { once sync.Once }\n"
+        "type Greeter interface { Hi() }\n"
+        "func NewServer() *Server { return nil }\n"
+        "func run(db DB) {\n"
+        '    fmt.Println("hi")\n'
+        '    panic("x")\n'
+        "    _, err := doThing()\n"
+        "    _ = other()\n"
+        '    exec.Command("ls")\n'
+        '    db.Query("SELECT " + err)\n'
+        '    password := "supersecretvalue"\n'
+        "    _ = password\n"
+        "}\n"
+    ),
+    "java": (
+        "class FooBuilder {\n"
+        "    static Foo getInstance() { return null; }\n"
+        "    Foo createFoo() { return null; }\n"
+        "    FooBuilder self() { return this; }\n"
+        "    void go() {\n"
+        '        System.out.println("x");\n'
+        "        try { risky(); } catch (Exception e) {}\n"
+        "        try { risky(); } catch (IOException e) { e.printStackTrace(); }\n"
+        '        Runtime.getRuntime().exec("ls");\n'
+        '        new ProcessBuilder("ls");\n'
+        '        stmt.executeQuery("SELECT " + x);\n'
+        '        String password = "supersecretval";\n'
+        '        MessageDigest.getInstance("MD5");\n'
+        "    }\n"
+        "}\n"
+    ),
+    "c": (
+        "#include <stdio.h>\n"
+        "void* create_obj() { return 0; }\n"
+        "void init_sys() {}\n"
+        "void free_obj(void* p) {}\n"
+        "void run(char* src) {\n"
+        "    goto done;\n"
+        '    printf("dbg");\n'
+        "    while (1) { break; }\n"
+        "    char buf[10];\n"
+        "    strcpy(buf, src);\n"
+        '    system("ls");\n'
+        '    char *password = "supersecretvalue";\n'
+        "done: ;\n"
+        "}\n"
+    ),
+    "cpp": (
+        "#include <iostream>\n"
+        "using namespace std;\n"
+        "class Base { public: virtual void f() = 0; };\n"
+        "class Mgr {\n"
+        "  public:\n"
+        "    static Mgr& getInstance() { static Mgr m; return m; }\n"
+        "    static Mgr* create() { return nullptr; }\n"
+        "};\n"
+        "void run(char* src) {\n"
+        '    std::cout << "dbg";\n'
+        "    int* p = new int(5);\n"
+        "    char buf[10];\n"
+        '    system("ls");\n'
+        "    strcpy(buf, src);\n"
+        '    const char* password = "supersecretval";\n'
+        "}\n"
+    ),
+    "csharp": (
+        "abstract class FooBuilder {\n"
+        "    static Foo Instance;\n"
+        "    public Foo CreateFoo() { return null; }\n"
+        "    public void Dispose() {}\n"
+        "    public void Go() {\n"
+        '        Console.WriteLine("x");\n'
+        "        try { Risky(); } catch (Exception e) {}\n"
+        "        Thread.Sleep(100);\n"
+        '        Process.Start("ls");\n'
+        '        var cmd = new SqlCommand("SELECT " + x);\n'
+        '        string password = "supersecretvalue";\n'
+        "    }\n"
+        "}\n"
+    ),
+    "php": (
+        "<?php\n"
+        "abstract class Widget {\n"
+        "    public static function getInstance() { return null; }\n"
+        "    public function createThing() { return null; }\n"
+        "}\n"
+        "function build_widget() { return null; }\n"
+        "function run($db) {\n"
+        "    var_dump($x);\n"
+        '    @file_get_contents("x");\n'
+        "    if ($a == $b) {}\n"
+        "    global $conf;\n"
+        "    eval($code);\n"
+        '    system("ls");\n'
+        '    $db->query("SELECT " . $x);\n'
+        '    $password = "supersecretvalue";\n'
+        "}\n"
+    ),
+    "lua": (
+        "local M = {}\n"
+        "function new_obj()\n"
+        "    local self = setmetatable({}, M)\n"
+        "    return self\n"
+        "end\n"
+        "M.__index = M\n"
+        "function big(a, b, c, d, e, f, g, h) end\n"
+        "function run()\n"
+        '    print("dbg")\n'
+        "    counter = 5\n"
+        "    goto done\n"
+        '    load("code")\n'
+        '    os.execute("ls")\n'
+        '    dofile("x.lua")\n'
+        '    local password = "supersecretvalue"\n'
+        "    ::done::\n"
+        "end\n"
+        "return M\n"
+    ),
+    "scala": (
+        "object Registry {\n"
+        "  def apply(): Registry = new Registry()\n"
+        "  def create(): Registry = new Registry()\n"
+        "  var count = 0\n"
+        "  val x: String = null\n"
+        "  def run(): Unit = {\n"
+        '    println("dbg")\n'
+        "    val s = obj.asInstanceOf[String]\n"
+        '    Runtime.getRuntime.exec("ls")\n'
+        '    val q = "SELECT x" + name\n'
+        '    val password = "supersecretvalue1"\n'
+        "  }\n"
+        "}\n"
+        "case class Point(x: Int, y: Int)\n"
+        "class Registry\n"
+    ),
+    "dart": (
+        "abstract class ShapeBuilder {\n"
+        "  static final ShapeBuilder instance = ShapeBuilder._();\n"
+        "  factory ShapeBuilder.of() => instance;\n"
+        "  void run() {\n"
+        '    print("dbg");\n'
+        "    try { risky(); } catch (e) {}\n"
+        "    dynamic x = 5;\n"
+        "    if (y == null) {}\n"
+        '    Process.run("ls", []);\n'
+        '    var q = "SELECT " + name;\n'
+        '    var password = "supersecretvalue";\n'
+        "  }\n"
+        "}\n"
+    ),
+    "ruby": (
+        "class Registry\n"
+        "  include Singleton\n"
+        "  def self.create\n"
+        "  end\n"
+        "  def run\n"
+        '    puts "dbg"\n'
+        "    begin\n"
+        "      risky\n"
+        "    rescue\n"
+        "    end\n"
+        "    $global = 5\n"
+        "    eval(code)\n"
+        '    system("ls")\n'
+        '    execute("SELECT #{x}")\n'
+        '    password = "supersecretvalue"\n'
+        "  end\n"
+        "end\n"
+    ),
+}
+_POSITIVE_FIXTURES["typescript"] = _POSITIVE_FIXTURES["javascript"]
+_POSITIVE_FIXTURES["tsx"] = _POSITIVE_FIXTURES["javascript"]
+
+
+def test_every_rule_fires_on_positive_fixture(tmp_path: Path) -> None:
+    # (H) Exhaustive functionality lock: a rule whose `kind`/`pattern` is wrong for
+    # (H) ast-grep's bundled grammar silently matches nothing (the f_string class of
+    # (H) bug). Every shipped rule must fire on a hand-crafted positive fixture, so a
+    # (H) future typo that zeroes a rule fails here instead of shipping dead.
+    from codebase_rag.analyzers import FindingAnalyzer
+    from codebase_rag.analyzers.ast_grep_analyzer import load_finding_rules
+
     # (H) Keyed by ast-grep grammar id, not extension: .js/.jsx/.mjs/.cjs all
     # (H) share the javascript grammar and rule set, so one fixture covers them.
-    by_grammar = {"python": py, "javascript": js, "typescript": js, "tsx": js}
+    by_grammar = _POSITIVE_FIXTURES
     for ext, lang in load_finding_rules().items():
         # (H) A new language with rules but no fixture would silently skip firing
         # (H) coverage; force a fixture mapping to exist for every loaded grammar.

--- a/codebase_rag/tests/test_ast_grep_analyzer.py
+++ b/codebase_rag/tests/test_ast_grep_analyzer.py
@@ -405,7 +405,7 @@ _POSITIVE_FIXTURES = {
         "    dynamic x = 5;\n"
         "    if (y == null) {}\n"
         '    Process.run("ls", []);\n'
-        '    var q = "SELECT * FROM t WHERE id=" + name;\n'
+        '    db.rawQuery("SELECT * FROM t WHERE id=" + name);\n'
         '    var password = "supersecretvalue";\n'
         "  }\n"
         "}\n"
@@ -566,8 +566,13 @@ def test_multilang_security_rules_avoid_common_false_positives(
         ),
         ("e.java", 'class A { void f(){ myExecutor.exec("job"); } }\n', "runtime_exec"),
         ("e.scala", "object O { def f() { list.exec() } }\n", "os_command_exec"),
-        ("d.dart", 'void f(x){ var b = "Please select one " + x; }\n', "sqli_concat"),
-        # keyword-in-text must not read as a SQL sink without a real query shape
+        # prose containing SQL keyword pairs must not read as a query without a
+        # real database sink around the concatenation
+        (
+            "d.dart",
+            'void f(x){ var b = "Please select a file from the list: " + x; }\n',
+            "sqli_concat",
+        ),
         ("u.dart", 'void f(x){ var label = "Select " + option; }\n', "sqli_concat"),
         (
             "r.java",

--- a/codebase_rag/tests/test_ast_grep_analyzer.py
+++ b/codebase_rag/tests/test_ast_grep_analyzer.py
@@ -574,6 +574,12 @@ def test_multilang_security_rules_avoid_common_false_positives(
             "sqli_concat",
         ),
         ("u.dart", 'void f(x){ var label = "Select " + option; }\n', "sqli_concat"),
+        # `== nullValue` is a normal comparison, not an explicit null check
+        (
+            "n.dart",
+            "void f(x, nullValue){ if (x == nullValue) {} }\n",
+            "double_equals_null",
+        ),
         (
             "r.java",
             'class A { void f(){ executor.exec("Runtime configuration"); } }\n',

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.419"
+version = "0.0.420"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

Extends the opt-in `FINDINGS` analyzer (#413) from 4 languages to 15: adds pattern, code-smell and security rule sets for **Rust, Go, Java, C, C++, C#, PHP, Lua, Scala, Dart, and Ruby**. No analyzer code changes were needed — the loader auto-discovers rule files by `analyzers/ast_grep_rules/<category>/<lang>.yaml`, so each language is just three new YAML files. Off by default (not in `DEFAULT_CAPTURE_GROUPS`); enable with `--capture +findings`.

Each language ships at least 3 rules per category (123 new rules total), e.g.:
- **Rust**: `unwrap()`/`expect()`/`dbg!`/`panic!`; `Command::new`, `unsafe` block, `format!`-built SQL, hardcoded secret.
- **Go**: `New*` constructors, `sync.Once` singleton; `fmt.Print*` debug, discarded `_` errors; `exec.Command`, `Query`+concat SQL, hardcoded secret.
- **Java/C#**: singleton/factory/builder; empty & broad catch, debug print; `Runtime.exec`/`Process.Start`, `SqlCommand` concat, weak MD5, hardcoded secret.
- **C/C++**: constructor/init/destructor idioms, singleton, pure-virtual abstract; `goto`, raw `new`, `using namespace std`; `system()`, `strcpy`/`sprintf`/`gets`, hardcoded secret.
- **PHP/Ruby/Lua/Scala/Dart**: language-idiomatic patterns, debug output / swallowed rescue / loose equality smells; `eval`/command-exec/SQL-injection sinks, hardcoded secret.

All security rules favour recall (a missed secret is worse than a false positive) and exclude only format-template shapes, matching the existing Python/JS convention.

## Testing

- `test_every_rule_fires_on_positive_fixture` now iterates **every** loaded grammar (15) and asserts each shipped rule fires on a crafted positive fixture — a rule whose `kind` is wrong for ast-grep's bundled grammar would ship dead and fail here. All 123 new rules validated live against the real loader.
- `test_every_language_has_all_three_categories` guards that every grammar ships patterns + smells + security with ≥3 rules each.
- Full non-integration suite: 5378 passed, 5 skipped.

Rule kinds were validated against ast-grep's own bundled grammar (not tree-sitter), which differs in field/kind names (e.g. C# id is `csharp` not `c_sharp`; JS variable_declarator field is `name` not `id`; generator is `generator_function`).
