### PR TITLE
chore: contract comments in tests (part 2)

### DIFF
--- a/codebase_rag/tests/test_java_nested_type_receiver.py
+++ b/codebase_rag/tests/test_java_nested_type_receiver.py
@@ -45,7 +45,7 @@ def test_nested_class_typed_field_receiver_resolves(
     create_and_run_updater(temp_repo, mock_ingestor, skip_if_missing="java")
     calls = _calls(mock_ingestor)
     # HELPER is typed by the nested Helper, so HELPER.check must resolve to the
-    # nested Helper.check -- not drop.
+    # nested Helper.check, not drop.
     assert any(
         f.endswith(".M.ok(int)") and t.endswith(".M.Helper.check(int)")
         for f, t in calls

--- a/codebase_rag/tests/test_java_overload_resolution.py
+++ b/codebase_rag/tests/test_java_overload_resolution.py
@@ -24,7 +24,7 @@ def test_call_binds_to_arity_matching_overload(
     pkg = root / "com" / "example"
     pkg.mkdir(parents=True)
     # resolve(a,b,c) is public API; it calls the 4-arg overload resolve(a,b,c,m).
-    # Both must be reachable -- the 4-arg call must bind to the 4-arg overload, not
+    # Both must be reachable: the 4-arg call must bind to the 4-arg overload, not
     # the 3-arg one that merely shares the name.
     (pkg / "M.java").write_text(
         "package com.example;\n"

--- a/codebase_rag/tests/test_java_span_oracle.py
+++ b/codebase_rag/tests/test_java_span_oracle.py
@@ -1,8 +1,7 @@
-# Covers Java node SPAN (end_line) validation: cgr's end_line for each node is
-# graded against the JDK Compiler Tree API oracle (which emits each node's
-# source end position), joined on (kind, file, start). Exercises a class with a
-# multi-line method signature, an interface, an enum, and a nested class so
-# spans are not trivially single line.
+# Covers Java node SPAN (end_line) validation: cgr's end_line is graded against
+# the JDK Compiler Tree API oracle (each node's source end position), joined on
+# (kind, file, start). Exercises a multi-line method signature, an interface, an
+# enum, and a nested class so spans are not trivially single line.
 from __future__ import annotations
 
 from pathlib import Path

--- a/codebase_rag/tests/test_java_structure_oracle.py
+++ b/codebase_rag/tests/test_java_structure_oracle.py
@@ -1,8 +1,7 @@
 # Covers the Java structure oracle harness (evals/oracles/java_oracle +
-# evals/java_l1.py): the JDK Compiler Tree API oracle is authoritative ground
-# truth, and cgr's captured Java nodes are graded against it on
-# (kind, file, start_line). Includes an anonymous class, whose methods cgr
-# models as standalone Functions (like JS object-literal methods).
+# evals/java_l1.py): cgr's Java nodes are graded against the JDK Compiler Tree
+# API oracle on (kind, file, start_line). Includes an anonymous class, whose
+# methods cgr models as standalone Functions (like JS object-literal methods).
 from __future__ import annotations
 
 from pathlib import Path

--- a/codebase_rag/tests/test_javascript_containment_oracle.py
+++ b/codebase_rag/tests/test_javascript_containment_oracle.py
@@ -1,7 +1,6 @@
-# Covers JavaScript containment-edge validation: cgr's DEFINES (file module
-# -> class / top-level function) and DEFINES_METHOD (class -> method) edges
-# are graded against the TypeScript-compiler-API oracle run over .js, joined
-# on (kind, file, line).
+# Covers JavaScript containment edges: cgr's DEFINES (module to class or
+# top-level function) and DEFINES_METHOD (class to method), graded against
+# the TypeScript-compiler-API oracle over .js, joined on (kind, file, line).
 from __future__ import annotations
 
 from pathlib import Path

--- a/codebase_rag/tests/test_javascript_span_oracle.py
+++ b/codebase_rag/tests/test_javascript_span_oracle.py
@@ -1,8 +1,7 @@
-# Covers JavaScript node SPAN (end_line) validation: cgr's end_line for each
-# node is graded against the TS-compiler-API oracle run over .js (which emits
-# each node's full-span end line), joined on (kind, file, start). Exercises a
-# class with a multi-line method signature, a multi-line arrow assigned to a
-# const, and a nested arrow so spans are not trivially single line.
+# Covers JavaScript node SPAN (end_line) validation: cgr's end_line is graded
+# against the TS-compiler-API oracle over .js, joined on (kind, file, start).
+# Exercises a class with a multi-line method signature, a multi-line arrow
+# assigned to a const, and a nested arrow so spans are not trivially single line.
 from __future__ import annotations
 
 from pathlib import Path

--- a/codebase_rag/tests/test_javascript_structure_oracle.py
+++ b/codebase_rag/tests/test_javascript_structure_oracle.py
@@ -1,7 +1,7 @@
-# Covers the JavaScript structure oracle harness (evals/oracles/ts_oracle run
-# over .js/.jsx + evals/js_l1.py): the TS-compiler-API oracle is authoritative
-# ground truth, and cgr's captured JavaScript nodes are graded against it on
-# (kind, file, start_line).
+# Covers the JavaScript structure oracle harness (evals/oracles/ts_oracle over
+# .js/.jsx + evals/js_l1.py): the TS-compiler-API oracle is authoritative ground
+# truth; cgr's captured JavaScript nodes are graded against it on (kind, file,
+# start_line).
 from __future__ import annotations
 
 from pathlib import Path

--- a/codebase_rag/tests/test_js_named_function_expression_args.py
+++ b/codebase_rag/tests/test_js_named_function_expression_args.py
@@ -1,7 +1,7 @@
 # A NAMED function expression passed as a call argument (express's
 # `this.on('mount', function onmount(parent) {...})`, `defineGetter(req,
 # 'path', function path() {...})`) registers by its own NAME, but the inline
-# argument reference is built from the arg's POSITION only -- so the named
+# argument reference is built from the arg's POSITION only, so the named
 # node never matches and reports dead. Name candidates must be tried too.
 from __future__ import annotations
 

--- a/codebase_rag/tests/test_js_object_value_function_expression_naming.py
+++ b/codebase_rag/tests/test_js_object_value_function_expression_naming.py
@@ -1,9 +1,8 @@
-# An anonymous function expression used as an OBJECT VALUE (`var pets = {
-# list: function(req, res) {...}, delete: function(req, res) {...} }`,
-# express's route-map example) must NOT climb past the pair to the enclosing
-# declarator and steal its name -- that registers phantom `pets`/`pets@50`
-# Function nodes that nothing references (false dead). The pair-key naming
-# path owns object values.
+# An anonymous function expression used as an OBJECT VALUE (express's route-map
+# `var pets = { list: function(...){}, delete: function(...){} }`) must NOT
+# climb past the pair to the enclosing declarator and steal its name; that
+# registers phantom `pets`/`pets@50` Function nodes nothing references (false
+# dead). The pair-key naming path owns object values.
 from __future__ import annotations
 
 from pathlib import Path

--- a/codebase_rag/tests/test_js_prototype_assignment_single_registration.py
+++ b/codebase_rag/tests/test_js_prototype_assignment_single_registration.py
@@ -1,8 +1,8 @@
 # `View.prototype.lookup = function lookup(...) {...}` registers TWO nodes for
 # one method (the prototype path's `View.lookup` and the fn-expr's own-name
-# module-flat `view.lookup`). A call binds one twin and the other reports dead.
-# Per the duplicate-QN design (keep both nodes, CALLS-to-both), a dotted call
-# that binds either twin must also edge the same-module same-name member twin.
+# `view.lookup`); one twin binds, the other reports dead. Per the duplicate-QN
+# design (keep both nodes, CALLS-to-both), a dotted call binding either twin
+# must also edge the same-module same-name member twin.
 from __future__ import annotations
 
 from pathlib import Path

--- a/codebase_rag/tests/test_js_prototype_this_dispatch.py
+++ b/codebase_rag/tests/test_js_prototype_this_dispatch.py
@@ -1,8 +1,8 @@
-# `this.method()` inside a prototype-assigned function dispatches to a
-# sibling method of the same prototype target (Date.prototype.strftime
-# calling this.getTwoDigitMonth(), django admin's core.js). Binding `this`
-# only to module-level functions (the CommonJS pattern) leaves every such
-# sibling call unresolved and the methods falsely dead.
+# `this.method()` inside a prototype-assigned function dispatches to a sibling
+# method of the same prototype target (Date.prototype.strftime calling
+# this.getTwoDigitMonth(), django admin's core.js). Binding `this` only to
+# module-level functions (the CommonJS pattern) leaves such sibling calls
+# unresolved and the methods falsely dead.
 from __future__ import annotations
 
 from pathlib import Path

--- a/codebase_rag/tests/test_js_retrieval_eval.py
+++ b/codebase_rag/tests/test_js_retrieval_eval.py
@@ -13,10 +13,10 @@ from evals.oracles import typescript_available
 
 
 def _js_grammar_available() -> bool:
-    # cgr loads the JavaScript tree-sitter grammar only when the optional
-    # grammar extra is installed; without it cgr indexes zero .js functions, so
-    # the cgr-vs-oracle test must skip (like the Go/Rust/Java evals do on a
-    # missing toolchain) rather than hard-fail on an empty cgr graph.
+    # cgr loads the JavaScript tree-sitter grammar only with the optional
+    # grammar extra; without it cgr indexes zero .js functions, so the
+    # cgr-vs-oracle test must skip (like the Go/Rust/Java evals on a missing
+    # toolchain) rather than hard-fail on an empty cgr graph.
     from codebase_rag.parser_loader import load_parsers
 
     try:
@@ -69,7 +69,7 @@ def test_oracle_captures_first_party_js_calls(tmp_path: Path) -> None:
     assert ("use.js", "free") in edges
     assert ("use.js", "dbl") in edges
     assert ("use.js", "caller") in edges
-    # orphan is declared but never called -> never a call edge.
+    # orphan is declared but never called, so never a call edge.
     assert ("t.js", "orphan") not in edges
     assert {"helper", "caller", "orphan", "free", "dbl", "useIt"} <= declared
 

--- a/codebase_rag/tests/test_js_ts_aliased_import_calls.py
+++ b/codebase_rag/tests/test_js_ts_aliased_import_calls.py
@@ -26,9 +26,9 @@ def _make(root: Path) -> None:
         "export function notImplemented(m: string): never { throw new Error(m); }\n",
         encoding="utf-8",
     )
-    # A non-relative specifier (here a deno-style `ext:` alias; a tsconfig
-    # `paths` alias like `@/util` behaves identically) does not resolve to a
-    # file-path module qn, so the import target is unregistered.
+    # A non-relative specifier (deno-style `ext:` alias; a tsconfig `paths`
+    # alias like `@/util` behaves identically) does not resolve to a file-path
+    # module qn, so the import target is unregistered.
     (root / "a.ts").write_text(
         'import { notImplemented } from "ext:alias/util.ts";\n'
         "export function useAlias() { return notImplemented('x'); }\n",
@@ -56,8 +56,8 @@ def _make(root: Path) -> None:
 def test_call_via_non_relative_aliased_import_resolves(tmp_path: Path) -> None:
     # A call to a first-party function imported via a non-relative specifier was
     # dropped: the unresolvable target looked external and suppressed the
-    # simple-name trie fallback. It must resolve to the indexed first-party
-    # function, exactly as the relative-import call already does.
+    # simple-name trie fallback. It must resolve to the first-party function,
+    # like the relative-import call does.
     _make(tmp_path)
     ingestor = _capture(tmp_path, "proj")
     calls = {

--- a/codebase_rag/tests/test_js_ts_assignment_reference_edges.py
+++ b/codebase_rag/tests/test_js_ts_assignment_reference_edges.py
@@ -45,8 +45,8 @@ REFERENCES = cs.RelationshipType.REFERENCES.value
 
 def test_js_function_assigned_to_const_is_referenced(tmp_path: Path) -> None:
     # `const cb = handler` binds a first-class function to a local for later
-    # dynamic dispatch; the assignment must reference it exactly like the
-    # Python `http_callback = fn` shape or dead-code wrongly flags handler.
+    # dynamic dispatch; the assignment must reference it like the Python
+    # `http_callback = fn` shape or dead-code wrongly flags handler.
     files = {
         "m.js": (
             "function handler(evt) { return evt; }\n\n"
@@ -83,7 +83,7 @@ def test_js_module_exports_assignment_in_callless_module_is_referenced(
     tmp_path: Path,
 ) -> None:
     # `module.exports.run = run` in a file with NO call expressions must still
-    # emit the Module -> REFERENCES edge; the call-driven pass early-returns on
+    # emit the Module REFERENCES edge; the call-driven pass early-returns on
     # such modules, so the assignment scan has to run before it.
     files = {
         "m.js": ("function run() { return 1; }\n\nmodule.exports.run = run;\n"),
@@ -142,10 +142,10 @@ def test_js_plain_value_assignments_are_not_referenced(tmp_path: Path) -> None:
 
 def test_ts_as_cast_assignment_references_target(tmp_path: Path) -> None:
     # `export const persist = persistImpl as unknown as Persist` aliases the real
-    # implementation through TS `as` casts. The cast expression is transparent for
-    # reference resolution, so the module must reference persistImpl or it (and
-    # everything only it reaches) reports as dead -- the zustand middleware
-    # pattern where the public export is a cast of the internal impl.
+    # implementation through TS `as` casts. The cast is transparent for reference
+    # resolution, so the module must reference persistImpl or it (and everything
+    # only it reaches) reports as dead; the zustand middleware pattern where the
+    # public export is a cast of the internal impl.
     files = {
         "mw.ts": (
             "const persistImpl = (config) => build(config)\n"
@@ -172,7 +172,7 @@ def test_ts_non_null_cast_assignment_references_target(tmp_path: Path) -> None:
 
 def test_ts_cast_object_value_is_referenced(tmp_path: Path) -> None:
     # A cast function in a collection value (`{ onEvent: handler as any }`) must
-    # still be referenced -- the cast wrapper is unwrapped in the value-ref path.
+    # still be referenced; the cast wrapper is unwrapped in the value-ref path.
     files = {
         "m.ts": (
             "function handler() { return 1 }\n"

--- a/codebase_rag/tests/test_js_untyped_receiver_member_call.py
+++ b/codebase_rag/tests/test_js_untyped_receiver_member_call.py
@@ -1,10 +1,9 @@
 # A JS member call on an UNTYPED receiver (`view.render(opts, cb)` inside
-# `tryRender(view, cb)` -- the instance was constructed in the CALLER, so the
-# param has no inferred type) fell to the bare-name trie and mis-bound to the
-# same-module free function `render` (express's application.render): a false
-# edge AND the real prototype method View.render reported dead. A member call
-# targets a MEMBER: resolve to the unique member-like candidate (its parent qn
-# is itself registered) or drop; never rebind to a free function.
+# `tryRender(view, cb)`, the instance built in the CALLER) fell to the bare-name
+# trie and mis-bound to the same-module free function `render` (express's
+# application.render): a false edge, and the real View.render reported dead.
+# A member call targets a MEMBER: resolve to the unique member-like candidate
+# or drop; never rebind to a free function.
 from __future__ import annotations
 
 from pathlib import Path
@@ -56,9 +55,9 @@ def test_var_require_visibility_disambiguates_member_call(
 ) -> None:
     # With a same-named prototype method in an UNRELATED module (express's
     # examples GithubView.render), uniqueness needs the import-visibility
-    # filter -- and express binds View with `var View = require('./view')`,
-    # a variable_declaration the require-mapping walk did not visit (it only
-    # handled const/let lexical_declarations).
+    # filter, and express binds View with `var View = require('./view')`, a
+    # variable_declaration the require-mapping walk did not visit (it handled
+    # only const/let lexical_declarations).
     root = temp_repo / "exvis"
     root.mkdir(parents=True)
     (root / "view.js").write_text(
@@ -108,10 +107,10 @@ def test_invisible_singleton_member_is_not_bound(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:
     # An untyped member call in a file that neither defines nor imports the
-    # candidate's module (`client.render()` in an unrelated file) must NOT
-    # bind the repo's sole same-named member: visibility is required even
-    # for a singleton, else external-object calls grow false edges that hide
-    # real dead code.
+    # candidate's module (`client.render()` in an unrelated file) must NOT bind
+    # the repo's sole same-named member: visibility is required even for a
+    # singleton, else external-object calls grow false edges hiding real dead
+    # code.
     root = temp_repo / "exinv"
     root.mkdir(parents=True)
     (root / "view.js").write_text(

--- a/codebase_rag/tests/test_jsx_component_references.py
+++ b/codebase_rag/tests/test_jsx_component_references.py
@@ -44,9 +44,8 @@ def _has(
 
 def test_tsx_component_usage_is_referenced(tmp_path: Path) -> None:
     # `<Card />` renders the Card component: React invokes it through the
-    # element, so the JSX usage must reference it or every component used
-    # only in markup reports as dead (the shadcn/ui cluster on the FastAPI
-    # template).
+    # element, so the JSX usage must reference it or every component used only
+    # in markup reports as dead (the shadcn/ui cluster on the FastAPI template).
     files = {
         "card.tsx": (
             "export function Card({ title }: { title: string }) {\n"
@@ -69,9 +68,9 @@ def test_tsx_component_usage_is_referenced(tmp_path: Path) -> None:
 
 
 def test_tsx_paired_element_component_is_referenced(tmp_path: Path) -> None:
-    # A paired element (<Layout>...</Layout>) carries the component name on
-    # its opening element; only the opening side must emit (no duplicate
-    # from the closing tag).
+    # A paired element (<Layout>...</Layout>) carries the component name on its
+    # opening element; only the opening side emits (no duplicate from the
+    # closing tag).
     files = {
         "layout.tsx": (
             "export function Layout({ children }: { children: unknown }) {\n"
@@ -106,10 +105,10 @@ def test_jsx_component_usage_in_js_is_referenced(tmp_path: Path) -> None:
 
 
 def test_tsx_class_component_usage_is_referenced(tmp_path: Path) -> None:
-    # A React class component resolves to a CLASS node, not a function; the
-    # JSX usage must still reference the class. JS/TS classes have no
-    # __init__, so routing through the Python callback helper (which
-    # redirects CLASS -> Class.__init__) would silently drop the edge.
+    # A React class component resolves to a CLASS node, not a function; the JSX
+    # usage must still reference the class. JS/TS classes have no __init__, so
+    # routing through the Python callback helper (which redirects CLASS to
+    # Class.__init__) would silently drop the edge.
     files = {
         "card.tsx": (
             "import * as React from 'react'\n"
@@ -144,11 +143,10 @@ def test_html_tags_are_not_referenced(tmp_path: Path) -> None:
 
 
 def test_jsx_attribute_bare_handler_is_referenced(tmp_path: Path) -> None:
-    # `<button onClick={handleLogout}>` hands a local function to the element
-    # as a prop; the framework invokes it on the event, never by a call the
-    # graph can see, so the rendering scope must reference it or every event
-    # handler passed by name reports as dead (Sidebar/User handlers on the
-    # FastAPI template).
+    # `<button onClick={handleLogout}>` hands a local function to the element as
+    # a prop; the framework invokes it on the event, not by a call the graph can
+    # see, so the rendering scope must reference it or every event handler passed
+    # by name reports as dead (Sidebar/User handlers on the FastAPI template).
     files = {
         "panel.tsx": (
             "export function Panel() {\n"
@@ -166,8 +164,7 @@ def test_jsx_attribute_inline_arrow_is_referenced(tmp_path: Path) -> None:
     # An inline arrow in a JSX attribute (`onClick={() => toggle()}`) registers
     # as an anonymous node in the rendering scope with no incoming edge; the
     # element consumes it, so the scope must reference it by position or every
-    # inline JSX handler reports as dead (the routes/* form callbacks on the
-    # template).
+    # inline JSX handler reports as dead (routes/* form callbacks on the template).
     files = {
         "input.tsx": (
             "export function PasswordInput() {\n"
@@ -188,9 +185,9 @@ def test_jsx_attribute_inline_arrow_is_referenced(tmp_path: Path) -> None:
 def test_jsx_handler_in_nested_callback_is_referenced(tmp_path: Path) -> None:
     # A JSX handler inside a nested anonymous callback (`items.map(item => <a
     # onClick={handleMenuClick}/>)`) must still be referenced by the enclosing
-    # component. The map arrow is anonymous, so it never gets its own caller pass;
-    # the component's JSX walk must therefore continue THROUGH it instead of
-    # stopping at the arrow boundary, or the handler reports as dead.
+    # component. The map arrow is anonymous and never gets its own caller pass, so
+    # the component's JSX walk must continue THROUGH it, or the handler reports as
+    # dead.
     files = {
         "main.tsx": (
             "export function Main() {\n"

--- a/codebase_rag/tests/test_l3_decorator_normalization.py
+++ b/codebase_rag/tests/test_l3_decorator_normalization.py
@@ -1,7 +1,7 @@
 # Covers the L3 eval harness (evals/calls_trace.py): a call to a functools.wraps
-# decorated function dispatches through the decorator's generic wrapper at runtime,
-# but cgr's static graph resolves the call to the function itself. The trace must
-# attribute the wrapper frame to the wrapped function so the two agree.
+# decorated function dispatches through the decorator's generic wrapper at
+# runtime, but cgr's static graph resolves it to the function itself. The trace
+# must attribute the wrapper frame to the wrapped function so the two agree.
 from __future__ import annotations
 
 import importlib.util

--- a/codebase_rag/tests/test_local_alias_calls.py
+++ b/codebase_rag/tests/test_local_alias_calls.py
@@ -1,7 +1,7 @@
 # L3 finding from the evals/ harness: a function bound to a local variable and
-# then called through that alias (g = self._method; g()) runs the aliased
-# callable at runtime, but cgr saw a bare-name call that resolved to nothing.
-# A call through a local alias must produce a CALLS edge to the aliased target.
+# called through that alias (g = self._method; g()) runs the aliased callable at
+# runtime, but cgr saw a bare-name call that resolved to nothing. A call through
+# a local alias must produce a CALLS edge to the aliased target.
 from __future__ import annotations
 
 from pathlib import Path

--- a/codebase_rag/tests/test_local_alias_chain_resolution.py
+++ b/codebase_rag/tests/test_local_alias_chain_resolution.py
@@ -1,8 +1,8 @@
 # L3 finding from the evals/ harness: CallProcessor._ingest_function_calls does
 # `registry = resolver.function_registry` (resolver = self._resolver) then
 # `qn in registry`, dispatching to FunctionRegistryTrie.__contains__. Resolving it
-# needs local-variable aliasing (local = self.attr) plus cross-class attribute-chain
-# typing (local2 = local.attr) so the operand's concrete type is known.
+# needs local-variable aliasing (local = self.attr) plus cross-class chain typing
+# (local2 = local.attr) so the operand's concrete type is known.
 from __future__ import annotations
 
 from pathlib import Path

--- a/codebase_rag/tests/test_lua_containment_oracle.py
+++ b/codebase_rag/tests/test_lua_containment_oracle.py
@@ -1,7 +1,7 @@
 # Covers Lua containment-edge validation. Lua has no classes/methods, so the
-# only containment edge is DEFINES: the file module DEFINES top-level
-# functions, and a function DEFINES the functions nested in its body. Graded
-# against the independent luaparse oracle, joined on (kind, file, line).
+# only containment edge is DEFINES: the module DEFINES top-level functions,
+# and a function DEFINES those nested in its body. Graded against the
+# luaparse oracle, joined on (kind, file, line).
 from __future__ import annotations
 
 from pathlib import Path

--- a/codebase_rag/tests/test_lua_modern_features.py
+++ b/codebase_rag/tests/test_lua_modern_features.py
@@ -623,11 +623,10 @@ end
         calls_rels = get_relationships(mock_ingestor, "CALLS")
         call_edges = {(c.args[0][2], c.args[2][2]) for c in calls_rels}
 
-        # stdlib calls (math.*, string.*, table.*, io.*, os.*) are not
-        # first-party, so the only CALLS edges are between StdLib methods:
-        # run_all_tests fans out to the six test_* methods, and the
-        # top-level `StdLib.run_all_tests()` in main.lua is attributed to
-        # the main module (not duplicated onto every nested call site).
+        # stdlib calls (math.*, string.*, table.*, io.*, os.*) are not first-party,
+        # so the only CALLS edges are between StdLib methods: run_all_tests fans out
+        # to the six test_* methods, and the top-level `StdLib.run_all_tests()` in
+        # main.lua is attributed to the main module, not every nested call site.
         run_all = f"{stdlib_qn}.StdLib.run_all_tests"
         main_qn = f"{project.name}.main"
         for method in expected_functions:

--- a/codebase_rag/tests/test_lua_retrieval_eval.py
+++ b/codebase_rag/tests/test_lua_retrieval_eval.py
@@ -45,7 +45,7 @@ def test_oracle_captures_first_party_lua_calls(tmp_path: Path) -> None:
     assert ("mod.lua", "mul") in edges
     assert ("main.lua", "use") in edges
     assert ("main.lua", "compute") in edges
-    # orphan is declared but never called -> never a call edge.
+    # orphan is declared but never called, so never a call edge.
     assert ("mod.lua", "orphan") not in edges
     assert {"local_add", "mul", "use", "orphan", "compute"} <= declared
 

--- a/codebase_rag/tests/test_lua_span_oracle.py
+++ b/codebase_rag/tests/test_lua_span_oracle.py
@@ -1,7 +1,7 @@
 # Covers Lua node SPAN (end_line) validation: cgr's end_line for each Function
-# is graded against the luaparse oracle (which emits node.loc.end.line), joined
-# on (kind, file, start). Exercises a global function, a nested function, and a
-# multi-line anonymous function expression so spans are not single line.
+# is graded against the luaparse oracle (node.loc.end.line), joined on
+# (kind, file, start). Exercises a global, a nested, and a multi-line
+# anonymous function expression so spans are not single line.
 from __future__ import annotations
 
 from pathlib import Path

--- a/codebase_rag/tests/test_lua_structure_oracle.py
+++ b/codebase_rag/tests/test_lua_structure_oracle.py
@@ -1,7 +1,7 @@
 # Covers the Lua structure oracle harness (evals/oracles/lua_oracle +
-# evals/lua_l1.py): the luaparse oracle is authoritative ground truth, and
-# cgr's captured Lua nodes are graded against it on (kind, file, start_line).
-# Lua has no classes, so every function is a Function.
+# evals/lua_l1.py): luaparse is authoritative ground truth, and cgr's Lua
+# nodes are graded against it on (kind, file, start_line). Lua has no
+# classes, so every function is a Function.
 from __future__ import annotations
 
 from pathlib import Path

--- a/codebase_rag/tests/test_object_literal_callback_references.py
+++ b/codebase_rag/tests/test_object_literal_callback_references.py
@@ -66,9 +66,8 @@ def test_use_mutation_variable_not_registered_as_function(tmp_path: Path) -> Non
     # `const mutation = useMutation({...})` binds a call_expression, not a
     # function. The inner object-literal arrows (mutationFn/onSuccess) must NOT
     # climb past the pair/call up to the `mutation` declarator and register a
-    # bogus FUNCTION node named after the variable -- that phantom node has no
-    # incoming edge and reports as dead code (~27 of the template's remaining
-    # false positives).
+    # bogus FUNCTION node named after the variable: that phantom has no incoming
+    # edge and reports dead (~27 of the template's remaining false positives).
     files = {
         "AddUser.tsx": (
             "import { useMutation } from '@tanstack/react-query'\n\n\n"
@@ -324,9 +323,9 @@ def test_object_literal_string_key_inline_arrow_is_referenced(tmp_path: Path) ->
 def test_inline_arrow_call_argument_is_referenced(tmp_path: Path) -> None:
     # An arrow passed DIRECTLY as a call argument (useCallback(() => {}),
     # setTimeout(() => {}), arr.map(x => ...)) registers as an anonymous node in
-    # the enclosing scope but has no incoming edge -- the call consumes it, so
-    # the scope must REFERENCE it or every inline callback reports as dead (the
-    # dominant remaining false-positive class on the FastAPI template).
+    # the enclosing scope with no incoming edge, so the scope must REFERENCE it
+    # or every inline callback reports as dead (the dominant remaining
+    # false-positive class on the FastAPI template).
     files = {
         "hook.tsx": (
             "export function useCopyToClipboard() {\n"

--- a/codebase_rag/tests/test_package_reexport_inheritance.py
+++ b/codebase_rag/tests/test_package_reexport_inheritance.py
@@ -1,10 +1,9 @@
 # A base written as a PACKAGE attribute (`forms.ModelForm` via `from django
 # import forms`) names the re-exporting package, not the defining module
-# (django.forms.models.ModelForm re-exported by django/forms/__init__'s
-# star import). The deferred-INHERITS suffix match cannot bridge the missing
-# `.models` segment, so the edge was dropped -- and with it every OVERRIDES
-# relationship of the subclass (django BaseUserCreationForm._post_clean
-# reported dead).
+# (django.forms.models.ModelForm re-exported by django/forms/__init__'s star
+# import). The deferred-INHERITS suffix match cannot bridge the missing
+# `.models` segment, so the edge was dropped, and with it every OVERRIDES
+# relationship of the subclass (django BaseUserCreationForm._post_clean dead).
 from __future__ import annotations
 
 from pathlib import Path

--- a/codebase_rag/tests/test_php_containment_oracle.py
+++ b/codebase_rag/tests/test_php_containment_oracle.py
@@ -1,8 +1,7 @@
-# Covers PHP containment-edge validation: cgr's DEFINES (file module ->
-# every named type and top-level function) and DEFINES_METHOD (class/
-# interface/trait/enum -> method) edges are graded against the independent
-# php-parser oracle, joined on (kind, file, line). Exercises an interface,
-# a trait, an enum with a method, a class, and a free function.
+# Grades cgr's DEFINES (file module -> named types and top-level functions)
+# and DEFINES_METHOD (class/interface/trait/enum -> method) edges against the
+# independent php-parser oracle, joined on (kind, file, line). Exercises an
+# interface, a trait, an enum with a method, a class, and a free function.
 from __future__ import annotations
 
 from pathlib import Path

--- a/codebase_rag/tests/test_php_function_call.py
+++ b/codebase_rag/tests/test_php_function_call.py
@@ -16,8 +16,8 @@ def _make(root: Path) -> None:
 def test_php_plain_function_call_resolves(tmp_path: Path) -> None:
     # A bare PHP function call (`helper()`) is a function_call_expression whose
     # callee is a `name` node under the `function` field. _get_call_target_name
-    # did not handle the `name` type, so no callee name was extracted and the
-    # CALLS edge was dropped -- only method/static calls (which expose a `name`
+    # did not handle the `name` type, so the callee name was never extracted and
+    # the CALLS edge dropped; only method/static calls (which expose a `name`
     # field directly) resolved.
     _make(tmp_path)
     ingestor = _capture(tmp_path, "p")

--- a/codebase_rag/tests/test_php_inheritance_edges.py
+++ b/codebase_rag/tests/test_php_inheritance_edges.py
@@ -41,11 +41,8 @@ def test_php_inheritance_and_implements_edges(
     implements = _pairs(mock_ingestor, RelationshipType.IMPLEMENTS.value)
     base = "php_inh.lib"
 
-    # class extends -> INHERITS.
     assert (f"{base}.Circle", f"{base}.Base") in inherits, inherits
-    # class implements -> IMPLEMENTS to each interface.
     assert (f"{base}.Circle", f"{base}.Shape") in implements, implements
     assert (f"{base}.Circle", f"{base}.Drawable") in implements, implements
-    # interface extends -> INHERITS to each superinterface.
     assert (f"{base}.Big", f"{base}.Shape") in inherits, inherits
     assert (f"{base}.Big", f"{base}.Drawable") in inherits, inherits

--- a/codebase_rag/tests/test_php_inheritance_oracle.py
+++ b/codebase_rag/tests/test_php_inheritance_oracle.py
@@ -1,6 +1,6 @@
-# Covers PHP inheritance-edge validation: cgr's INHERITS (class/interface
-# extends) and IMPLEMENTS (class implements) edges are graded against the
-# php-parser oracle, by (source node, base SIMPLE NAME).
+# Grades cgr's INHERITS (class/interface extends) and IMPLEMENTS (class
+# implements) edges against the php-parser oracle, by (source node, base
+# SIMPLE NAME).
 from __future__ import annotations
 
 from pathlib import Path

--- a/codebase_rag/tests/test_php_retrieval_eval.py
+++ b/codebase_rag/tests/test_php_retrieval_eval.py
@@ -64,10 +64,10 @@ def test_cgr_matches_oracle_on_clean_php_project(tmp_path: Path) -> None:
 
 @needs_node
 def test_php_dynamic_member_call_not_emitted(tmp_path: Path) -> None:
-    # A dynamic member call (`$this->$method()`) has a `variable` offset whose
-    # name is the variable identifier ("method"), not a static method name. The
-    # oracle must not emit it as a call edge even when it collides with a
-    # declared first-party method name, or it becomes a false ground-truth edge.
+    # A dynamic member call (`$this->$method()`) exposes a `variable` offset
+    # named for the variable ("method"), not a static method name. The oracle
+    # must not emit it as a call edge even when it collides with a declared
+    # method name, or it becomes a false ground-truth edge.
     tmp_path.mkdir(parents=True, exist_ok=True)
     (tmp_path / "c.php").write_text(
         "<?php\nclass C {\n"

--- a/codebase_rag/tests/test_php_span_oracle.py
+++ b/codebase_rag/tests/test_php_span_oracle.py
@@ -1,7 +1,7 @@
-# Covers PHP node SPAN (end_line) validation: cgr's end_line for each node is
-# graded against the php-parser oracle (which emits node.loc.end.line), joined
-# on (kind, file, start). Exercises a class with a multi-line method, an
-# interface, an enum, and a multi-line function so spans are not single line.
+# Grades cgr's end_line for each node against the php-parser oracle (which
+# emits node.loc.end.line), joined on (kind, file, start). Exercises a class
+# with a multi-line method, an interface, an enum, and a multi-line function
+# so spans are not single line.
 from __future__ import annotations
 
 from pathlib import Path

--- a/codebase_rag/tests/test_php_structure_oracle.py
+++ b/codebase_rag/tests/test_php_structure_oracle.py
@@ -1,8 +1,8 @@
-# Covers the PHP structure oracle harness (evals/oracles/php_oracle +
-# evals/php_l1.py): the php-parser oracle is authoritative ground truth, and
-# cgr's captured PHP nodes are graded against it on (kind, file, start_line).
-# Includes an attributed class (whose span starts at the attribute) and an
-# anonymous class (whose methods cgr models as Functions).
+# Exercises the PHP structure oracle harness (evals/oracles/php_oracle +
+# evals/php_l1.py): the php-parser oracle is ground truth, cgr's PHP nodes are
+# graded against it on (kind, file, start_line). Includes an attributed class
+# (span starts at the attribute) and an anonymous class (methods modelled as
+# Functions).
 from __future__ import annotations
 
 from pathlib import Path

--- a/codebase_rag/tests/test_php_use_function_import.py
+++ b/codebase_rag/tests/test_php_use_function_import.py
@@ -62,10 +62,10 @@ def test_use_function_import_call_resolves_across_namespace_path_mismatch(
 
 
 def test_reparse_clears_stale_php_function_imports(tmp_path: Path) -> None:
-    # On an incremental re-index the same module_qn is parsed again;
-    # parse_imports resets import_mapping[module_qn] but must also drop the
-    # module's php_function_imports, or a `use function` removed from the file
-    # lingers and keeps (wrongly) exempting that name from external suppression.
+    # On incremental re-index the same module_qn is parsed again; parse_imports
+    # resets import_mapping[module_qn] but must also drop the module's
+    # php_function_imports, or a `use function` removed from the file lingers
+    # and keeps wrongly exempting that name from external suppression.
     parsers, queries = load_parsers()
     if cs.SupportedLanguage.PHP not in parsers:
         pytest.skip("php tree-sitter grammar not installed")

--- a/codebase_rag/tests/test_polyglot_eval.py
+++ b/codebase_rag/tests/test_polyglot_eval.py
@@ -1,11 +1,10 @@
-# Cross-language / polyglot ingestion regression guard. Drives the
-# evals.polyglot corpus (one file per SupportedLanguage, plus a three-way
-# same-basename collision) through a single cgr graph build and asserts the
-# cross-language integrity invariants: every available language is
-# represented, basename collisions are disambiguated rather than
-# overwritten, no semantic edge crosses a language boundary, the recorded
-# graph is dangling/orphan free, and the whole thing is deterministic. No
-# eval before this one indexed more than one language at a time.
+# Cross-language polyglot ingestion regression guard. Drives the evals.polyglot
+# corpus (one file per SupportedLanguage, plus a three-way same-basename
+# collision) through a single cgr build and asserts the cross-language
+# invariants: every available language is represented, basename collisions are
+# disambiguated not overwritten, no semantic edge crosses a language boundary,
+# the graph is dangling/orphan free, and the build is deterministic. No eval
+# before this one indexed more than one language at once.
 from __future__ import annotations
 
 from pathlib import Path
@@ -24,9 +23,9 @@ from evals.polyglot import (
 
 
 def _available_languages() -> frozenset[cs.SupportedLanguage]:
-    # Only grade languages whose parser actually loaded, so a missing
-    # optional grammar skips that language instead of failing the suite --
-    # but any loaded language that drops out of the graph is a real bug.
+    # Only grade languages whose parser actually loaded, so a missing optional
+    # grammar skips that language instead of failing the suite; any loaded
+    # language that drops out of the graph is a real bug.
     parsers, _ = load_parsers()
     return EXPECTED_LANGUAGES & frozenset(parsers)
 
@@ -46,10 +45,10 @@ def test_every_available_language_is_represented(polyglot_corpus: Path) -> None:
         "languages dropped from the polyglot graph: "
         f"{sorted(lang.value for lang in dropped)}"
     )
-    # each present language must also contribute at least one definition,
-    # not just an empty module node.
-    # sorted() so iteration order is deterministic across runs (StrEnum
-    # members hash by string, whose order varies with hash randomization).
+    # each present language must contribute at least one definition, not just
+    # an empty module node. sorted() so iteration order is deterministic across
+    # runs (StrEnum members hash by string, whose order varies with hash
+    # randomisation).
     empty = [
         lang.value
         for lang in sorted(available)
@@ -97,9 +96,9 @@ def test_no_edge_crosses_a_language_boundary(polyglot_corpus: Path) -> None:
 
 def test_polyglot_graph_is_dangling_and_orphan_free(polyglot_corpus: Path) -> None:
     # create_and_run_updater runs the structural integrity audit (schema,
-    # orphans, dangling relationships) over the recorded batches; a
-    # violation raises. This proves mixing every language in one build does
-    # not produce an edge with a phantom endpoint.
+    # orphans, dangling relationships) over the recorded batches; a violation
+    # raises. Proves mixing every language in one build produces no edge with
+    # a phantom endpoint.
     mock_ingestor = MagicMock()
     mock_ingestor.ensure_node_batch = MagicMock()
     mock_ingestor.ensure_relationship_batch = MagicMock()

--- a/codebase_rag/tests/test_property_getter_calls.py
+++ b/codebase_rag/tests/test_property_getter_calls.py
@@ -1,7 +1,7 @@
 # L3 finding from the evals/ harness: accessing an @property getter runs the
-# getter method at runtime, but cgr saw a plain attribute access and emitted no
-# CALLS edge. A property access must produce a CALLS edge to the getter method,
-# while a normal attribute / method reference must not.
+# getter at runtime, but cgr saw a plain attribute access and emitted no CALLS
+# edge. A property access must produce a CALLS edge to the getter; a normal
+# attribute or method reference must not.
 from __future__ import annotations
 
 from pathlib import Path

--- a/codebase_rag/tests/test_property_return_type_chain.py
+++ b/codebase_rag/tests/test_property_return_type_chain.py
@@ -1,8 +1,7 @@
-# L3 finding from the evals/ harness: a method calls self.prop.method(), where
+# L3 finding from the evals/ harness: a method calls self.prop.method() where
 # self.prop is an @property whose declared return type names the class owning
-# the real method. The property's return type must seed self.prop's type so the
-# chained call resolves to the correct class instead of an ambiguous same-class
-# method of the same name.
+# the real method. That return type must seed self.prop's type so the chained
+# call resolves to the right class, not a same-name method of the same class.
 from __future__ import annotations
 
 from pathlib import Path

--- a/codebase_rag/tests/test_protocol_dispatch_resolution.py
+++ b/codebase_rag/tests/test_protocol_dispatch_resolution.py
@@ -1,9 +1,8 @@
 # L3 finding from the evals/ harness: DefinitionProcessor._extract_decorators calls
 # self._handler.extract_decorators(node), where _handler is annotated as the Protocol
-# LanguageHandler (class-level annotation) and assigned dynamically via
-# get_handler(language). The runtime type is one of several conformers, so the sound
-# call graph emits an edge to extract_decorators on every conformer (capturing the
-# traced PythonHandler edge) and never to the Protocol stub, which never runs.
+# LanguageHandler but assigned dynamically via get_handler(language). The runtime type
+# is one of several conformers, so the call graph emits an edge to extract_decorators
+# on every conformer (capturing the traced PythonHandler edge), never the stub.
 from __future__ import annotations
 
 from pathlib import Path

--- a/codebase_rag/tests/test_protocol_impl_resolution.py
+++ b/codebase_rag/tests/test_protocol_impl_resolution.py
@@ -1,10 +1,8 @@
-# L3 finding from the evals/ harness: a call on a parameter typed as a
-# Protocol (function_registry.get() where function_registry is a
-# FunctionRegistryTrieProtocol) is traced to the concrete implementer
-# (FunctionRegistryTrie), not the Protocol stub. cgr infers the Protocol
-# type but stops at the stub; the XxxProtocol -> Xxx naming convention picks
-# the real implementer and disambiguates it from other structural conformers
-# such as a test mock.
+# L3 finding from the evals/ harness: a call on a parameter typed as a Protocol
+# (function_registry.get() where function_registry is a FunctionRegistryTrieProtocol)
+# is traced to the concrete implementer (FunctionRegistryTrie), not the stub. cgr
+# infers the Protocol type but stops there; the XxxProtocol -> Xxx naming convention
+# picks the real implementer, disambiguating it from other conformers like a test mock.
 from __future__ import annotations
 
 from pathlib import Path

--- a/codebase_rag/tests/test_protocol_operator_dispatch.py
+++ b/codebase_rag/tests/test_protocol_operator_dispatch.py
@@ -1,9 +1,8 @@
 # L3 finding from the evals/ harness: an operator on a Protocol-typed attribute
 # (self.ast_cache[k], k in self.ast_cache) must dispatch to the dunder on the
-# concrete implementer even when the implementer's name does not follow the
-# XxxProtocol convention, and even when the dunder (e.g. __len__) is defined only on
-# the implementer and not declared on the Protocol stub. Structural conformance
-# (a class defining the Protocol's named methods) identifies the implementer.
+# concrete implementer even when its name does not follow the XxxProtocol convention,
+# and even when the dunder (e.g. __len__) is defined only on the implementer, not on
+# the stub. Structural conformance (a class defining the Protocol's methods) identifies it.
 from __future__ import annotations
 
 from pathlib import Path
@@ -24,8 +23,8 @@ FILES = {
         "    def __getitem__(self, key):\n        ...\n\n"
         "    def __contains__(self, key):\n        ...\n"
     ),
-    # MemCache does not match the Cache name convention and adds __len__, which the
-    # Protocol does not declare. It conforms via the named method snapshot.
+    # MemCache does not match the Cache name convention and adds __len__ (not
+    # declared on the Protocol); it conforms via the named method snapshot.
     "pkg/impl.py": (
         "class MemCache:\n"
         "    def snapshot(self):\n        return {}\n\n"

--- a/codebase_rag/tests/test_provider_configuration.py
+++ b/codebase_rag/tests/test_provider_configuration.py
@@ -134,8 +134,8 @@ class TestProviderConfiguration:
     def test_default_fallback_behavior(self) -> None:
         """Test that defaults work when no explicit provider is configured."""
         # Clear provider vars but keep the home-dir vars: AppConfig's CGR_HOME
-        # default calls Path.home(), which hard-fails on Windows without
-        # USERPROFILE (POSIX falls back to pwd, so only CI on Windows caught it).
+        # default calls Path.home(), which fails on Windows without USERPROFILE
+        # (POSIX falls back to pwd, so only Windows CI caught it).
         home_env = {
             k: v
             for k, v in os.environ.items()

--- a/codebase_rag/tests/test_py_conditional_import_fallback.py
+++ b/codebase_rag/tests/test_py_conditional_import_fallback.py
@@ -1,9 +1,8 @@
 # A platform-conditional import with a local fallback definition (click's
-# `if WIN: from ._winconsole import _get_windows_console_stream ... else:
-# def _get_windows_console_stream(...)`) is statically undecidable: the call
-# resolves only to the imported target, so the mutually-exclusive local
-# fallback def looks dead. Like Go build variants, fan the call out to BOTH --
-# exactly one exists at runtime, and either may be it.
+# `if WIN: from ._winconsole import ... else: def ...`) is statically
+# undecidable: the call resolves only to the imported target, so the
+# mutually-exclusive local fallback def looks dead. Like Go build variants,
+# fan the call out to BOTH; exactly one exists at runtime.
 from __future__ import annotations
 
 from pathlib import Path
@@ -49,10 +48,9 @@ def test_conditional_import_local_fallback_gets_call_edge(
 def test_unconditional_import_shadowing_gets_no_fanout(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:
-    # An UNCONDITIONAL import that shadows an earlier local def is plain
+    # An UNCONDITIONAL import shadowing an earlier local def is plain
     # shadowing, not a platform variant: the local def is genuinely dead and
-    # must NOT receive a fan-out edge. The fan-out is gated to names bound by
-    # a CONDITIONAL (if/try-nested) import.
+    # must NOT get a fan-out edge (gated to CONDITIONAL if/try-nested imports).
     root = temp_repo / "pyshad"
     root.mkdir(parents=True)
     (root / "other.py").write_text(

--- a/codebase_rag/tests/test_py_external_override_flag.py
+++ b/codebase_rag/tests/test_py_external_override_flag.py
@@ -1,9 +1,8 @@
-# A Python method overriding a method of an EXTERNAL STDLIB base class
-# (click's `class TextWrapper(textwrap.TextWrapper)` overriding `_wrap_chunks`,
-# `_handle_long_word`) is invoked by the stdlib parent's machinery
-# (`wrap()` calls `self._wrap_chunks(...)`), never by first-party code, so it
-# reported dead. The base's method set IS knowable (stdlib import), so mark such
-# methods `overrides_external` -- the dead-code surfaces root the property.
+# A Python method overriding an EXTERNAL STDLIB base class method (click's
+# `TextWrapper(textwrap.TextWrapper)` overriding `_wrap_chunks`) is invoked by
+# the stdlib parent's machinery (`wrap()` calls self._wrap_chunks), never by
+# first-party code, so it reported dead. The base's method set IS knowable, so
+# mark such methods `overrides_external`; the dead-code surfaces root it.
 from __future__ import annotations
 
 from pathlib import Path

--- a/codebase_rag/tests/test_py_overload_variant_nested_scope.py
+++ b/codebase_rag/tests/test_py_overload_variant_nested_scope.py
@@ -1,11 +1,9 @@
 # A Python function whose qn carries a duplicate-variant suffix (click's
-# `command` -- @t.overload stubs claim the natural qn, the REAL def registers as
-# `command@168`) calls its own nested function (`return decorator(func)`). The
-# enclosing-scope walk probed `command@168.decorator`, which never exists (the
-# def pass registers the nested under the NATURAL qn `command.decorator`), so
-# resolution fell to the module trie and mis-bound to an alphabetically-earlier
-# sibling's nested (`argument.decorator`) -- a false edge AND a false-dead
-# `command.decorator`. The walk must also probe the variant-stripped scope.
+# `command`: @t.overload stubs claim the natural qn, the REAL def registers as
+# `command@168`) calls its own nested `decorator`. The enclosing-scope walk
+# probed `command@168.decorator`, which never exists (the nested registers
+# under the NATURAL qn `command.decorator`), so resolution mis-bound to a
+# sibling's `argument.decorator`. The walk must also probe the stripped scope.
 from __future__ import annotations
 
 from pathlib import Path

--- a/codebase_rag/tests/test_py_subscripted_generic_base.py
+++ b/codebase_rag/tests/test_py_subscripted_generic_base.py
@@ -1,9 +1,8 @@
-# A Python class inheriting a SUBSCRIPTED generic base (`class IntRange(
-# _NumberRangeBase[int, int], IntParamType)`, click's numeric types) got NO
-# INHERITS edge for that base: the superclass walk only accepted identifier and
-# attribute children, skipping `subscript` nodes entirely. Without the edge the
-# subclass has no OVERRIDES, so `self._clamp(...)` dispatch from the base never
-# reaches the override and it reports dead.
+# A Python class inheriting a SUBSCRIPTED generic base (click's numeric
+# `IntRange(_NumberRangeBase[int, int], IntParamType)`) got NO INHERITS edge:
+# the superclass walk only accepted identifier and attribute children, skipping
+# `subscript` nodes. Without the edge the subclass has no OVERRIDES, so
+# `self._clamp(...)` dispatch never reaches the override and it reports dead.
 from __future__ import annotations
 
 from pathlib import Path

--- a/codebase_rag/tests/test_python_factory_return_chain.py
+++ b/codebase_rag/tests/test_python_factory_return_chain.py
@@ -1,10 +1,9 @@
 # A Python chained call on a free-function factory receiver
-# (`get_resolver()._is_callback(name)`, django's urls/base.py) has the return of
-# a factory function as its receiver. Without inferring that return type the
-# final method binds to nothing and the returned class's methods report as dead
-# (django URLResolver._is_callback). cgr must infer the factory's return type
-# (annotation first, then return-statement analysis, transitively through
-# factory-calls-factory hops) and resolve the chained method on it.
+# (`get_resolver()._is_callback(name)`, django's urls/base.py) uses the factory's
+# return as its receiver. Without inferring that return type the final method
+# binds to nothing and the class's methods report dead (django
+# URLResolver._is_callback). cgr must infer the return type (annotation first,
+# then return-statement analysis, transitively through factory hops).
 from pathlib import Path
 
 from evals.cgr_graph import _capture
@@ -31,9 +30,9 @@ _DECOY = "class Aaa:\n    def run(self):\n        pass\n"
 
 
 def test_free_factory_return_chain_resolves(tmp_path: Path) -> None:
-    # `make_widget().run()` where make_widget returns Widget() must reach
-    # Widget.run. Aaa.run is an alphabetical decoy: a bare trie fallback would
-    # pick it, so a passing test proves real return typing.
+    # `make_widget().run()` (make_widget returns Widget()) must reach Widget.run.
+    # Aaa.run is an alphabetical decoy a bare trie fallback would pick, so passing
+    # proves real return typing.
     _make(
         tmp_path,
         {
@@ -59,9 +58,9 @@ def test_free_factory_return_chain_resolves(tmp_path: Path) -> None:
 
 
 def test_imported_factory_return_chain_resolves(tmp_path: Path) -> None:
-    # The factory and the returned class live in another module; the call site
-    # imports only the factory. The return type must resolve in the FACTORY's
-    # module scope, not the caller's.
+    # Factory and returned class live in another module; the call site imports
+    # only the factory, so the return type resolves in the FACTORY's module
+    # scope, not the caller's.
     _make(
         tmp_path,
         {
@@ -244,10 +243,9 @@ def test_local_var_factory_assignment_types_receiver(tmp_path: Path) -> None:
 
 
 def test_reexported_factory_return_chain_resolves(tmp_path: Path) -> None:
-    # django imports get_resolver through package re-exports (`from
-    # django.urls import get_resolver` -> __init__ -> .resolvers): the import
-    # target is the package qn, not the registered function qn, so the
-    # resolution must follow the re-export hops.
+    # django imports get_resolver through package re-exports (`from django.urls
+    # import get_resolver` -> __init__ -> .resolvers): the import target is the
+    # package qn, not the function qn, so resolution follows the re-export hops.
     _make(
         tmp_path,
         {

--- a/codebase_rag/tests/test_python_source_root_imports.py
+++ b/codebase_rag/tests/test_python_source_root_imports.py
@@ -61,8 +61,8 @@ def test_flat_layout_absolute_import(tmp_path: Path) -> None:
 
 def test_src_layout_absolute_import(tmp_path: Path) -> None:
     # src-layout: the package's import name (pkg) differs from its repo-relative
-    # path (packages/a/src/pkg). The absolute import must resolve to the
-    # path-based node, not be judged an external import and dropped.
+    # path (packages/a/src/pkg), so the absolute import must resolve to the
+    # path-based node, not be dropped as external.
     calls = _run_calls(
         tmp_path,
         {
@@ -230,8 +230,7 @@ def test_single_module_root_maps_to_module_path(tmp_path: Path) -> None:
 def test_package_dir_dotted_key_remap(tmp_path: Path) -> None:
     # package-dir keys can name a dotted subpackage ("acme.widgets" =
     # "lib/widgets"); the import's top-level segment (acme) has no entry of its
-    # own, so resolution must match the longest dotted prefix, not just the
-    # top-level name.
+    # own, so resolution must match the longest dotted prefix, not the top name.
     calls = _run_calls(
         tmp_path,
         {

--- a/codebase_rag/tests/test_python_span_oracle.py
+++ b/codebase_rag/tests/test_python_span_oracle.py
@@ -1,8 +1,7 @@
 # Covers Python L1 node SPAN (end_line) validation: cgr's end_line for each
 # Class/Function/Method is graded against the ast oracle (node.end_lineno) via
-# the L1 score(), joined on (kind, file, start). Exercises a decorated
-# multi-line def, a property, an async multi-line signature, and a nested
-# function so spans are not trivially single line.
+# score(), joined on (kind, file, start). Exercises a decorated def, a property,
+# an async signature, and a nested function so spans are not single line.
 from __future__ import annotations
 
 from pathlib import Path

--- a/codebase_rag/tests/test_realtime_debounce.py
+++ b/codebase_rag/tests/test_realtime_debounce.py
@@ -1,7 +1,5 @@
-# Tests for the realtime_updater debouncing functionality.
-#
-# These tests verify the hybrid debounce strategy that prevents redundant
-# graph updates during rapid file saves.
+# Tests for realtime_updater debouncing: the hybrid strategy that prevents
+# redundant graph updates during rapid file saves.
 
 from __future__ import annotations
 
@@ -133,8 +131,7 @@ class TestCodeChangeEventHandlerDebounce:
         )
 
         event = FileModifiedEvent(str(tmp_path / "some_dir"))
-        # The is_directory property is set by watchdog based on the event type
-        # For FileModifiedEvent, we need to check is_directory attribute
+        # watchdog derives is_directory from the event type; force it True here.
         object.__setattr__(event, "is_directory", True)
 
         handler.dispatch(event)

--- a/codebase_rag/tests/test_rust_containment_oracle.py
+++ b/codebase_rag/tests/test_rust_containment_oracle.py
@@ -1,8 +1,8 @@
-# Covers Rust containment-edge validation: cgr's DEFINES (module -> item /
-# nested module) and DEFINES_METHOD (struct/trait -> method) edges are graded
+# Covers Rust containment-edge validation: cgr's DEFINES (module to item or
+# nested module) and DEFINES_METHOD (struct/trait to method) edges are graded
 # against the independent syn oracle (evals/oracles/rs_oracle), joined on
 # (kind, file, line) endpoints. Exercises an inherent impl, a trait method,
-# and an impl inside a nested `mod` (cross-module type resolution).
+# and an impl inside a nested `mod`.
 from __future__ import annotations
 
 from pathlib import Path

--- a/codebase_rag/tests/test_rust_impl_method_call_qn.py
+++ b/codebase_rag/tests/test_rust_impl_method_call_qn.py
@@ -19,10 +19,10 @@ def _make_crate(root: Path) -> None:
 
 
 def test_rust_generic_impl_method_caller_qn_strips_generics(tmp_path: Path) -> None:
-    # A method in a generic impl block (`impl<'a> Thing for Chars<'a>`) is
-    # registered on the bare type node (crate.lib.Chars.go). The call inside it
-    # must be attributed to that bare-type caller qn, not a generic-bearing
-    # crate.lib.Chars<'a>.go that matches no node (which drops the CALLS edge).
+    # A method in a generic impl block (`impl<'a> Thing for Chars<'a>`) registers
+    # on the bare type node (crate.lib.Chars.go). The call inside must attribute
+    # to that bare-type caller qn, not a generic-bearing crate.lib.Chars<'a>.go
+    # that matches no node and drops the CALLS edge.
     _make_crate(tmp_path)
     ingestor = _capture(tmp_path, "crate")
     calls = {
@@ -48,11 +48,10 @@ def _make_super_import_crate(root: Path) -> None:
 
 
 def test_rust_super_imported_free_fn_call_resolves(tmp_path: Path) -> None:
-    # A free function imported by a Rust relative path (`use super::b::helper`)
-    # and called bare must resolve to the sibling-module function node
-    # (crate.b.helper). The import target is recorded as raw `super::b::helper`
-    # (`::`-separated, not project-prefixed), so the external-import guard must
-    # not mistake it for an external symbol and suppress the trie fallback.
+    # A free function imported by a relative path (`use super::b::helper`) and
+    # called bare must resolve to the sibling-module node (crate.b.helper). Its
+    # raw import target `super::b::helper` is `::`-separated and not project-prefixed,
+    # so the external-import guard must not suppress the trie fallback.
     _make_super_import_crate(tmp_path)
     ingestor = _capture(tmp_path, "crate")
     calls = {

--- a/codebase_rag/tests/test_rust_inheritance_edges.py
+++ b/codebase_rag/tests/test_rust_inheritance_edges.py
@@ -42,8 +42,8 @@ def test_rust_impl_and_supertrait_edges(
     implements = _pairs(mock_ingestor, RelationshipType.IMPLEMENTS.value)
     base = "rs_inh.src.lib"
 
-    # impl Trait for Type -> Type IMPLEMENTS Trait.
+    # impl Trait for Type means Type IMPLEMENTS Trait.
     assert (f"{base}.Circle", f"{base}.Shape") in implements, implements
     assert (f"{base}.Circle", f"{base}.Drawable") in implements, implements
-    # Supertrait bound -> Sub INHERITS Super.
+    # Supertrait bound means Sub INHERITS Super.
     assert (f"{base}.Drawable", f"{base}.Shape") in inherits, inherits

--- a/codebase_rag/tests/test_rust_inheritance_oracle.py
+++ b/codebase_rag/tests/test_rust_inheritance_oracle.py
@@ -1,6 +1,6 @@
 # Covers Rust inheritance-edge validation: cgr's INHERITS (supertrait bound)
-# and IMPLEMENTS (`impl Trait for Type`) edges are graded against the syn
-# oracle, by (source node, base SIMPLE NAME).
+# and IMPLEMENTS (`impl Trait for Type`) edges graded against the syn oracle
+# by (source node, base simple name).
 from __future__ import annotations
 
 from pathlib import Path

--- a/codebase_rag/tests/test_rust_receiver_resolution.py
+++ b/codebase_rag/tests/test_rust_receiver_resolution.py
@@ -116,10 +116,9 @@ def test_guard_deref_field_hop_binding_dispatch(tmp_path: Path) -> None:
 
 def test_guard_wrapper_local_not_erased_to_inner(tmp_path: Path) -> None:
     # A Mutex/RwLock does NOT deref-coerce: a bare `let m: Mutex<Inner>` receiver
-    # can only reach Inner via a lock/borrow hop, so `m` must stay typed as the
-    # wrapper -- NOT erased to Inner (which would mis-resolve a direct `m.work()`
-    # to Inner.work). `work` is defined on two types so the trie can't mask a
-    # precise mis-resolution.
+    # reaches Inner only via a lock/borrow hop, so `m` stays typed as the wrapper,
+    # not erased to Inner (which would mis-resolve a direct `m.work()` to
+    # Inner.work). `work` is on two types so the trie can't mask a mis-resolution.
     _make_crate(
         tmp_path,
         "use std::sync::Mutex;\n"
@@ -318,9 +317,9 @@ def test_enum_match_multiarm_binding_shadowing(tmp_path: Path) -> None:
 
 def test_nested_match_binding_not_leaked_to_outer_arm(tmp_path: Path) -> None:
     # A nested `match inner { Foo(x) => ... }` rebinds `x` only within its own arm.
-    # The outer arm's `x.tag()` (x = the Bar param) must stay Bar.tag -- the nested
-    # Foo binding must NOT be scoped to the whole outer arm (which would mis-overlay
-    # the outer call to Foo.tag).
+    # The outer arm's `x.tag()` (x = the Bar param) must stay Bar.tag; the nested
+    # Foo binding must NOT scope to the whole outer arm and mis-overlay the outer
+    # call to Foo.tag.
     _make_crate(
         tmp_path,
         "pub struct Bar {}\n"
@@ -377,11 +376,10 @@ def test_assoc_fn_chain_dispatch(tmp_path: Path) -> None:
 
 
 def test_imported_assoc_call_return_type_dispatch(tmp_path: Path) -> None:
-    # `use crate::cmd::Command; let cmd = Command::from_frame(f); cmd.apply()`:
-    # the type is IMPORTED, so its import target is a raw `::`-path, not a registry
-    # qn. The call-return binding must resolve it to the real class node
-    # (crate.cmd.Command) to look up from_frame's recorded return type -- else it
-    # falls back to the ambiguous trie path.
+    # `use crate::cmd::Command; let cmd = Command::from_frame(f); cmd.apply()`: the
+    # type is IMPORTED, so its import target is a raw `::`-path, not a registry qn.
+    # The call-return binding must resolve it to the real class node
+    # (crate.cmd.Command) for from_frame's return type, else it falls to the trie.
     tmp_path.mkdir(parents=True, exist_ok=True)
     (tmp_path / "lib.rs").write_text("pub mod cmd;\npub mod app;\n", encoding="utf-8")
     (tmp_path / "cmd.rs").write_text(
@@ -435,11 +433,10 @@ def test_reference_return_type_chained_dispatch(tmp_path: Path) -> None:
 
 
 def test_imported_type_disambiguated_by_path(tmp_path: Path) -> None:
-    # Two `Command` types in different modules whose `mk()` returns DIFFERENT
-    # types (cmd.Command -> Real, other.Command -> Fake). `use crate::cmd::Command`
+    # Two `Command` types in different modules whose `mk()` returns DIFFERENT types
+    # (cmd.Command gives Real, other.Command gives Fake). `use crate::cmd::Command`
     # must resolve the call-return base to crate.cmd.Command so `x.run()` lands on
-    # Real.run. A simple-name-only match would pick the alphabetically-first
-    # crate.aaa.Command, type x as Fake, and mis-resolve to Fake.run.
+    # Real.run, not the alphabetically-first crate.aaa.Command that types x as Fake.
     tmp_path.mkdir(parents=True, exist_ok=True)
     (tmp_path / "lib.rs").write_text(
         "pub mod aaa;\npub mod cmd;\npub mod types;\npub mod app;\n",

--- a/codebase_rag/tests/test_rust_span_oracle.py
+++ b/codebase_rag/tests/test_rust_span_oracle.py
@@ -1,8 +1,7 @@
-# Covers Rust node SPAN (end_line) validation: cgr's end_line for each node is
-# graded against the syn oracle (which emits the whole-node span end), joined
-# on (kind, file, start) endpoints. Exercises doc comments, multi-line
-# attributes, a multi-line signature, a where-clause, and a multi-line closure
-# so the span is not trivially the start line.
+# Covers Rust node SPAN (end_line) validation: cgr's end_line is graded against
+# the syn oracle (which emits the whole-node span end), joined on (kind, file,
+# start). Exercises doc comments, multi-line attributes, a signature, a
+# where-clause, and a closure so the span is not trivially the start line.
 from __future__ import annotations
 
 from pathlib import Path

--- a/codebase_rag/tests/test_rust_structure_oracle.py
+++ b/codebase_rag/tests/test_rust_structure_oracle.py
@@ -1,6 +1,6 @@
 # Covers the Rust structure oracle harness (evals/oracles/rs_oracle +
-# evals/rust_l1.py): the syn-based oracle is authoritative ground truth, and
-# cgr's captured Rust nodes are graded against it on (kind, file, start_line).
+# evals/rust_l1.py): the syn-based oracle is ground truth, and cgr's captured
+# Rust nodes are graded against it on (kind, file, start_line).
 from __future__ import annotations
 
 from pathlib import Path

--- a/codebase_rag/tests/test_scala_retrieval_eval.py
+++ b/codebase_rag/tests/test_scala_retrieval_eval.py
@@ -62,7 +62,7 @@ def test_oracle_captures_first_party_scala_calls(tmp_path: Path) -> None:
     # A bare paren-less select (u.done) is NOT graded: uniform access makes a
     # nullary call and a field read identical, so it is scoped out on both sides.
     assert ("Use.scala", "done") not in edges
-    # orphan is declared but never called -> never a call edge.
+    # orphan is declared but never called, so never a call edge.
     assert ("T.scala", "orphan") not in edges
     assert {
         "helper",

--- a/codebase_rag/tests/test_static_calls_eval.py
+++ b/codebase_rag/tests/test_static_calls_eval.py
@@ -52,8 +52,7 @@ def test_decorator_application_is_not_a_call_edge(tmp_path: Path) -> None:
 
 def test_oracle_attributes_method_nested_call_to_full_qn(tmp_path: Path) -> None:
     # A call inside a function nested in a method belongs to that nested
-    # function's full qn (Class.method.nested). The oracle records it there;
-    # the eval then checks cgr emits the same caller qn (see the recall test).
+    # function's full qn (Class.method.nested); cgr must emit the same caller qn.
     src = tmp_path / "proj"
     src.mkdir(parents=True, exist_ok=True)
     (src / "__init__.py").write_text("", encoding="utf-8")

--- a/codebase_rag/tests/test_status_bar_config.py
+++ b/codebase_rag/tests/test_status_bar_config.py
@@ -77,8 +77,7 @@ def test_abbreviated_repo_keeps_absolute_for_outside_paths() -> None:
 
 def test_abbreviated_repo_survives_unresolvable_home() -> None:
     # Path.home() raises RuntimeError when no home env vars are set (Windows
-    # without USERPROFILE, bare containers); the status bar must fall back to
-    # the absolute path instead of crashing.
+    # without USERPROFILE); the status bar must fall back to the absolute path.
     with patch.object(main_mod.Path, "home", side_effect=RuntimeError):
         assert main_mod._abbreviated_repo(Path("/etc/hosts")) == "/etc/hosts"
 

--- a/codebase_rag/tests/test_truthiness_dispatch_resolution.py
+++ b/codebase_rag/tests/test_truthiness_dispatch_resolution.py
@@ -1,7 +1,6 @@
 # L3 finding from the evals/ harness: `if self.function_registry:` tests an object
-# for truthiness, which at runtime calls __bool__ if defined else __len__. cgr only
-# extracted explicit calls, missing FunctionRegistryTrie.__len__. These edges are
-# emitted only when the tested operand is a first-party object defining the dunder.
+# for truthiness, which calls __bool__ if defined else __len__. cgr extracted only
+# explicit calls, missing these dunder edges when the operand is a first-party object.
 from __future__ import annotations
 
 from pathlib import Path

--- a/codebase_rag/tests/test_ts_arrow_caller_calls.py
+++ b/codebase_rag/tests/test_ts_arrow_caller_calls.py
@@ -18,9 +18,9 @@ def _make(root: Path) -> None:
 
 def test_ts_arrow_const_caller_body_calls_resolve(tmp_path: Path) -> None:
     # A call inside a named arrow / const-arrow function body must be attributed
-    # to that function (p.he.fmt). The call pass skipped arrows because they
-    # have no `name` field, so _get_node_name returned None and the whole arrow
-    # body -- and its calls -- went unprocessed.
+    # to that function (p.he.fmt). The call pass skipped arrows because they have
+    # no `name` field, so _get_node_name returned None and the arrow body went
+    # unprocessed.
     _make(tmp_path)
     ingestor = _capture(tmp_path, "p")
     calls = {

--- a/codebase_rag/tests/test_ts_class_field_arrow.py
+++ b/codebase_rag/tests/test_ts_class_field_arrow.py
@@ -20,10 +20,9 @@ def _make(root: Path) -> None:
 
 
 def test_ts_class_field_arrow_is_modeled_and_calls_resolve(tmp_path: Path) -> None:
-    # A class-property arrow (`helper = (x) => ...`) must be modeled as a
-    # member node (p.t.T.helper) just like a normal method, and the calls in
-    # its body must be attributed to it. Previously the definition pass created
-    # no node for it (no name field) and the call pass skipped its body.
+    # A class-property arrow (`helper = (x) => ...`) must be modeled as a member
+    # node (p.t.T.helper) like a normal method, with body calls attributed to it.
+    # Previously the def pass created no node (no name field) and skipped its body.
     _make(tmp_path)
     ingestor = _capture(tmp_path, "p")
     member_qns = {

--- a/codebase_rag/tests/test_ts_closure_containment.py
+++ b/codebase_rag/tests/test_ts_closure_containment.py
@@ -1,8 +1,7 @@
 # A function declared inside an anonymous callback must be DEFINEd by that
-# callback (its lexical parent), not hoisted to the nearest named ancestor.
-# The child's qn omits anonymous scopes, so deriving the DEFINES parent by
-# trimming the child qn skipped the callback; the parent is now recomputed
-# from the enclosing function node itself.
+# callback (its lexical parent), not the nearest named ancestor. The child's qn
+# omits anonymous scopes, so trimming it to derive the DEFINES parent skipped the
+# callback; the parent is now recomputed from the enclosing function node.
 from __future__ import annotations
 
 from pathlib import Path

--- a/codebase_rag/tests/test_ts_curried_arrow_references.py
+++ b/codebase_rag/tests/test_ts_curried_arrow_references.py
@@ -43,7 +43,7 @@ def test_double_curried_inner_arrows_are_referenced(
 ) -> None:
     # Three-deep currying `(a) => (b) => (c) => {...}`: the middle arrow is
     # anonymous (no caller pass of its own), so the innermost must be referenced
-    # too -- the walk bubbles both to the nearest named scope.
+    # too; the walk bubbles both to the nearest named scope.
     root = temp_repo / "zcurry2"
     root.mkdir(parents=True)
     (root / "mw.ts").write_text(

--- a/codebase_rag/tests/test_ts_export_no_duplicate.py
+++ b/codebase_rag/tests/test_ts_export_no_duplicate.py
@@ -20,8 +20,8 @@ def _make(root: Path) -> None:
 def test_ts_exported_function_not_duplicated(tmp_path: Path) -> None:
     # An exported function / const-arrow is already ingested by the definition
     # pass at its natural qn (p.util.parsedType). The ES6-export pass must not
-    # re-register it -- doing so makes a spurious `qn@line` duplicate node and
-    # splits CALLS edges onto that duplicate, mangling the callee qn.
+    # re-register it: doing so makes a spurious `qn@line` duplicate that splits
+    # CALLS edges onto it, mangling the callee qn.
     _make(tmp_path)
     ingestor = _capture(tmp_path, "p")
     fn_qns = {str(uid) for (label, uid) in ingestor.nodes if label == "Function"}

--- a/codebase_rag/tests/test_typescript_containment_oracle.py
+++ b/codebase_rag/tests/test_typescript_containment_oracle.py
@@ -1,8 +1,7 @@
-# Covers TypeScript containment-edge validation: cgr's DEFINES (file module
-# -> every named type, even nested) and DEFINES_METHOD (class/namespace ->
-# method) edges are graded against the independent TypeScript-compiler-API
-# oracle, joined on (kind, file, line). Exercises a class method, a top-level
-# function, and a namespace (class + function as methods of the namespace).
+# TypeScript containment-edge validation: cgr's DEFINES (file module ->
+# every named type) and DEFINES_METHOD (class/namespace -> method) edges are
+# graded against the TypeScript-compiler-API oracle, joined on (kind, file,
+# line). Exercises a class method, a top-level function, and a namespace.
 from __future__ import annotations
 
 from pathlib import Path

--- a/codebase_rag/tests/test_typescript_span_oracle.py
+++ b/codebase_rag/tests/test_typescript_span_oracle.py
@@ -1,9 +1,8 @@
-# Covers TypeScript node SPAN (end_line) validation: cgr's end_line for each
-# node is graded against the TS-compiler-API oracle (which emits each node's
-# full-span end line), joined on (kind, file, start). Exercises a class with a
-# multi-line method signature, an interface, an enum, a type alias, a
-# namespace, and a multi-line arrow function so spans are not trivially single
-# line.
+# TypeScript node SPAN (end_line) validation: cgr's end_line for each node is
+# graded against the TS-compiler-API oracle, joined on (kind, file, start).
+# Exercises a class with a multi-line method signature, an interface, an enum,
+# a type alias, a namespace, and a multi-line arrow so spans are not trivially
+# single line.
 from __future__ import annotations
 
 from pathlib import Path

--- a/codebase_rag/tests/test_vector_store.py
+++ b/codebase_rag/tests/test_vector_store.py
@@ -372,9 +372,9 @@ def test_milvus_lite_30_cosine_workaround_versions(
 
 
 def _has_milvus_lite() -> bool:
-    # A LOCAL Milvus uri needs the embedded milvus-lite server, which ships
-    # no Windows wheels: pymilvus alone installs there and the connect
-    # raises ConnectionConfigException (Windows CI).
+    # A LOCAL Milvus uri needs the embedded milvus-lite server, which ships no
+    # Windows wheels: pymilvus alone raises ConnectionConfigException there
+    # (Windows CI).
     import importlib.util
 
     return importlib.util.find_spec("milvus_lite") is not None

--- a/codebase_rag/tests/unit/test_flat_flow_path_sensitive_unit.py
+++ b/codebase_rag/tests/unit/test_flat_flow_path_sensitive_unit.py
@@ -19,8 +19,8 @@ _LANG_BY_FILE = {"main.go": "flow_go", "App.java": "flow_java"}
 
 
 class _RecordingIngestor:
-    # Structural IngestorProtocol stand-in that records FLOWS_TO relationships; the
-    # query-side methods are no-ops (a single fresh project needs no rehydration).
+    # Structural IngestorProtocol stand-in recording FLOWS_TO relationships;
+    # query-side methods are no-ops (a fresh project needs no rehydration).
     def __init__(self) -> None:
         self.rels: list[
             tuple[

--- a/codebase_rag/tests/unit/test_rust_cpp_flow_unit.py
+++ b/codebase_rag/tests/unit/test_rust_cpp_flow_unit.py
@@ -19,8 +19,8 @@ _LANG_BY_FILE = {"main.rs": "flow_rs", "main.cpp": "flow_cpp"}
 
 
 class _RecordingIngestor:
-    # Structural IngestorProtocol stand-in that records FLOWS_TO relationships; the
-    # query-side methods are no-ops (a single fresh project needs no rehydration).
+    # Structural IngestorProtocol stand-in recording FLOWS_TO relationships;
+    # query-side methods are no-ops (a fresh project needs no rehydration).
     def __init__(self) -> None:
         self.rels: list[
             tuple[

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.422"
+version = "0.0.423"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

Final wave of the comment cleanup (follows #838, #841, #842). Contracts inline comments in the second half of the test suite so they explain **why/how** rather than restate **what**. This completes the effort: no `# (H)` author markers remain anywhere in the repository, and the enforcement hook was removed in #838.

Scope: 70 test files (second half of `codebase_rag/tests/`, split alphabetically). Kept under Greptile's 500-file review limit.

## Rules applied

- Dropped pure "what" comments that only echo the adjacent code.
- Contracted multi-line why/how comments to their essence, keeping causal content and concrete examples.
- Kept verbatim: comments carrying issue/PR numbers or bug rationale, tool directives, and every `#` line living inside a triple-quoted fixture string (C/C++/Java/Go/JS/Rust/Lua/PHP source being parsed by the test, plus the Lua `#` length operator, never a Python comment).
- British spelling in touched prose; no dashes as punctuation.

## Verification

- Non-comment token streams (excluding `COMMENT` and `NL`) proven identical to base for all 70 files: no code, string, identifier, or docstring changed.
- Repo-wide `(H)` marker count is now zero.
- `ruff check` + `ruff format --check` clean; full pre-commit run green.
- `pytest -n auto -m "not integration"`: 5377 passed, 5 skipped. Since these are the edited test files themselves, a green run confirms no test logic was touched.