### PR TITLE
chore: remove retired (H) comment marker from non-Python files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,9 +77,9 @@ jobs:
   test-unit:
     name: Unit Tests (${{ matrix.os }}, py${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
-    # (H) Slow runners (ubuntu/windows py3.13) can exceed 20 min on the full -n auto
-    # (H) suite and hit the cap as a spurious CANCELLED; 30 min absorbs the variance
-    # (H) while still bounding a genuine hang.
+    # Slow runners (ubuntu/windows py3.13) can exceed 20 min on the full -n auto
+    # suite and hit the cap as a spurious CANCELLED; 30 min absorbs the variance
+    # while still bounding a genuine hang.
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -109,10 +109,10 @@ jobs:
         run: |
           uv sync --python ${{ matrix.python-version }} --extra treesitter-full --extra test --extra semantic --extra milvus --group dev
 
-      # (H) --no-sync is required: a bare `uv run` re-syncs to .python-version
-      # (H) (3.12) with default deps only, so on a 3.13 matrix (and on Windows,
-      # (H) where interpreter discovery mismatches the venv) it silently rebuilds
-      # (H) the venv without the test extra and pytest loses the xdist -n flag.
+      # --no-sync is required: a bare `uv run` re-syncs to .python-version
+      # (3.12) with default deps only, so on a 3.13 matrix (and on Windows,
+      # where interpreter discovery mismatches the venv) it silently rebuilds
+      # the venv without the test extra and pytest loses the xdist -n flag.
       - name: Run unit tests (parallel, with coverage)
         if: matrix.os == 'macos-latest' && matrix.python-version == '3.12'
         run: |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -64,7 +64,7 @@ jobs:
 
             **Style:**
             - Ruff compliant (linting and formatting)
-            - No inline comments unless prefixed with (H)
+            - Comments explain why/how, not what
             - Conventional commit message format
 
             Be constructive and reference specific lines. For first-time contributors, be extra welcoming.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,7 @@ on:
     paths:
       - "docs/**"
       - "mkdocs.yml"
-  # (H) Rebuilds periodically so the GitHub repo widget (version, stars, forks)
+  # Rebuilds periodically so the GitHub repo widget (version, stars, forks)
   # stays current; MkDocs Material fetches these stats at build time.
   schedule:
     - cron: "0 */6 * * *"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -688,10 +688,6 @@ def save_item(item):
     _save(SQL_ITEM, item.dict())
 ```
 
-#### No Comments or Docstrings
-
-Code should be self-documenting. Exception: comments prefixed with `(H)` are allowed.
-
 #### No Type Ignores, Casts, Any, or object
 
 Never use `# type: ignore` comments, `cast()`, `Any` type, or `object` as a type hint. These provide no useful type information. Fix the underlying type issue using proper typing, type narrowing, specific union types (e.g., `str | int | bool | None`), or TypedDict for dict values.
@@ -809,21 +805,7 @@ The scope (in parentheses) is optional and can contain alphanumeric characters, 
 
 ### Comment Policy
 
-**No inline comments are allowed** unless they meet one of these criteria:
-
-1. **Top-of-file comments**: Comments that appear before any code (including imports) are allowed
-2. **`(H)` marker**: Comments containing `(H)` are allowed - this stands for "Human" and indicates an intentional, human-written comment
-3. **Type annotations**: Comments containing `type:`, `noqa`, `pyright`, or `ty:` are allowed
-
-**Why this rule exists**: AI tools (like code assistants and LLMs) tend to generate redundant, obvious comments that clutter the codebase. Comments like `# Loop through items` or `# Return the result` add no value. This policy prevents AI-generated comment slop from polluting the code.
-
-If you need to add a comment, prefix it with `(H)`:
-
-```python
-# (H) This algorithm uses memoization because the recursive solution times out on large inputs
-```
-
-The pre-commit hook `no-inline-comments` enforces this rule automatically.
+Write comments that explain **why** and **how**, not **what**. A comment that only restates the adjacent code adds no value; one that captures a non-obvious reason, a tricky invariant, or a concrete edge case earns its place.
 
 ## Questions?
 

--- a/Makefile
+++ b/Makefile
@@ -88,12 +88,10 @@ pre-commit: ## Run all pre-commit checks locally (comprehensive test before comm
 	$(PYTHON) ruff check --fix .
 	@echo "3. Type checking..."
 	$(PYTHON) ty check --exclude codebase_rag/tests/
-	@echo "4. Checking for missing docstrings..."
-	$(PYTHON) python scripts/check_no_docs.py
-	@echo "5. Generating README sections..."
+	@echo "4. Generating README sections..."
 	$(PYTHON) python scripts/hooks/generate_readme.py
-	@echo "6. Running security checks..."
+	@echo "5. Running security checks..."
 	$(PYTHON) bandit -c pyproject.toml --severity-level high -r codebase_rag/ --exclude codebase_rag/tests/,scripts/
-	@echo "7. Running unit tests (integration tests skipped - run 'make test-integration' separately)..."
+	@echo "6. Running unit tests (integration tests skipped - run 'make test-integration' separately)..."
 	$(PYTHON) pytest -n auto -m "not integration"
 	@echo "All pre-commit checks passed!"

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -95,11 +95,7 @@ This project uses automated code review bots (**Greptile** and **Gemini Code Ass
 
 ## Comment Policy
 
-No inline comments are allowed unless they:
-
-1. Appear before any code at the top of the file
-2. Contain the `(H)` marker (intentional, human-written comment)
-3. Are type annotations (`type:`, `noqa`, `pyright`, `ty:`)
+Write comments that explain why and how, not what. A comment that only restates the adjacent code adds no value.
 
 ## Questions?
 

--- a/evals/oracles/java_oracle/Oracle.java
+++ b/evals/oracles/java_oracle/Oracle.java
@@ -70,8 +70,8 @@ public class Oracle {
         return s.replace("\\", "\\\\").replace("\"", "\\\"");
     }
 
-    // (H) Simple name of an extends/implements type: drop generics and any
-    // (H) package/outer qualifier, matching how cgr resolves bases by simple name.
+    // Simple name of an extends/implements type: drop generics and any
+    // package/outer qualifier, matching how cgr resolves bases by simple name.
     static String simpleName(Object typeTree) {
         String s = typeTree.toString();
         int lt = s.indexOf('<');
@@ -92,9 +92,9 @@ public class Oracle {
             + "},\"target_name\":\"" + esc(targetName) + "\"}");
     }
 
-    // (H) A file-level call site: caller file + callee simple name (the method
-    // (H) identifier). The Python side keeps only callees whose name is a declared
-    // (H) first-party Method/Function, mirroring the Go/Rust call oracles.
+    // A file-level call site: caller file + callee simple name (the method
+    // identifier). The Python side keeps only callees whose name is a declared
+    // first-party Method/Function, mirroring the Go/Rust call oracles.
     static void emitCall(String file, String name) {
         calls.add("{\"file\":\"" + esc(file) + "\",\"name\":\"" + esc(name) + "\"}");
     }
@@ -119,7 +119,7 @@ public class Oracle {
                 return "Interface";
             case ENUM:
                 return "Enum";
-            // (H) cgr models an annotation type (@interface) as a Class.
+            // cgr models an annotation type (@interface) as a Class.
             default:
                 return "Class";
         }
@@ -162,23 +162,23 @@ public class Oracle {
             new TreePathScanner<Void, Void>() {
                 public Void visitClass(ClassTree node, Void p) {
                     long pos = sp.getStartPosition(unit, node);
-                    // (H) Anonymous classes have an empty name and no cgr node.
+                    // Anonymous classes have an empty name and no cgr node.
                     if (pos >= 0 && node.getSimpleName().length() > 0) {
                         long line = lm.getLineNumber(pos);
                         long endLine = lm.getLineNumber(sp.getEndPosition(unit, node));
                         String kind = classKind(node);
                         emit(kind, rel, line, endLine, node.getSimpleName().toString());
-                        // (H) Every named type is DEFINEd by the file module,
-                        // (H) including nested types (cgr keeps this flat).
+                        // Every named type is DEFINEd by the file module,
+                        // including nested types (cgr keeps this flat).
                         emitEdge("DEFINES", rel, "Module", MODULE_LINE, kind, line);
-                        // (H) extends superclass -> INHERITS (a class only).
+                        // extends superclass -> INHERITS (a class only).
                         if (node.getExtendsClause() != null) {
                             emitNameEdge("INHERITS", rel, kind, line,
                                 simpleName(node.getExtendsClause()));
                         }
-                        // (H) The implements clause holds a class/enum's interfaces
-                        // (H) (-> IMPLEMENTS) but an interface's superinterfaces
-                        // (H) (-> INHERITS, like cgr).
+                        // The implements clause holds a class/enum's interfaces
+                        // (-> IMPLEMENTS) but an interface's superinterfaces
+                        // (-> INHERITS, like cgr).
                         String hrel = node.getKind() == Tree.Kind.INTERFACE
                             ? "INHERITS" : "IMPLEMENTS";
                         for (Tree it : node.getImplementsClause()) {
@@ -191,10 +191,10 @@ public class Oracle {
                 public Void visitMethod(MethodTree node, Void p) {
                     long pos = sp.getStartPosition(unit, node);
                     if (pos >= 0) {
-                        // (H) cgr labels a member a Method only when its nearest
-                        // (H) enclosing named class precedes any enclosing method or
-                        // (H) lambda body; members of an anonymous class (declared in
-                        // (H) a method body) are modelled as standalone Functions.
+                        // cgr labels a member a Method only when its nearest
+                        // enclosing named class precedes any enclosing method or
+                        // lambda body; members of an anonymous class (declared in
+                        // a method body) are modelled as standalone Functions.
                         String kind = "Function";
                         ClassTree owner = null;
                         for (TreePath up = getCurrentPath().getParentPath();
@@ -213,11 +213,11 @@ public class Oracle {
                         long line = lm.getLineNumber(pos);
                         long endLine = lm.getLineNumber(sp.getEndPosition(unit, node));
                         emit(kind, rel, line, endLine, node.getName().toString());
-                        // (H) A Method binds to its enclosing named type; an
-                        // (H) anonymous-class member (Function) has no owner node,
-                        // (H) so cgr anchors it to the module with DEFINES (the
-                        // (H) orphan-prevention fallback) and the oracle models
-                        // (H) the same containment.
+                        // A Method binds to its enclosing named type; an
+                        // anonymous-class member (Function) has no owner node,
+                        // so cgr anchors it to the module with DEFINES (the
+                        // orphan-prevention fallback) and the oracle models
+                        // the same containment.
                         if (owner != null) {
                             long opos = sp.getStartPosition(unit, owner);
                             if (opos >= 0) {
@@ -233,11 +233,11 @@ public class Oracle {
                 }
 
                 public Void visitMethodInvocation(MethodInvocationTree node, Void p) {
-                    // (H) The callee simple name: the trailing identifier of a
-                    // (H) member-select (`obj.foo()`, `Type.bar()`) or a bare
-                    // (H) identifier (`foo()`, same-class or static-imported). A
-                    // (H) `super()`/`this()` constructor call yields "super"/"this"
-                    // (H) and is dropped downstream (never a declared method name).
+                    // The callee simple name: the trailing identifier of a
+                    // member-select (`obj.foo()`, `Type.bar()`) or a bare
+                    // identifier (`foo()`, same-class or static-imported). A
+                    // `super()`/`this()` constructor call yields "super"/"this"
+                    // and is dropped downstream (never a declared method name).
                     ExpressionTree sel = node.getMethodSelect();
                     String name = null;
                     if (sel instanceof MemberSelectTree) {

--- a/evals/oracles/lua_oracle/lua_ast.js
+++ b/evals/oracles/lua_oracle/lua_ast.js
@@ -29,9 +29,9 @@ const nodes = [];
 const edges = [];
 const calls = [];
 
-// (H) The simple name of a luaparse name reference: a bare Identifier's name, or
-// (H) the trailing member of a MemberExpression (`t.f` / `t:m` -> f / m). A
-// (H) dynamic index (`t["k"]`) or any other base has no static name.
+// The simple name of a luaparse name reference: a bare Identifier's name, or
+// the trailing member of a MemberExpression (`t.f` / `t:m` -> f / m). A
+// dynamic index (`t["k"]`) or any other base has no static name.
 function refName(ref) {
   if (!ref) return null;
   if (ref.type === "Identifier") return ref.name;
@@ -41,7 +41,7 @@ function refName(ref) {
   return null;
 }
 
-// (H) A function declaration is named by its own identifier when present
+// A function declaration is named by its own identifier when present
 // (`function foo`, `function t.f`, `function t:m`), else by the variable it is
 // assigned to (`local foo = function`, `t.f = function`), else anonymous.
 function declName(node, assignedNames) {
@@ -54,9 +54,9 @@ function walk(node, file, parentRef, assignedNames) {
     for (const c of node) walk(c, file, parentRef, assignedNames);
     return;
   }
-  // (H) Record the binding name of any function expression assigned in this
-  // (H) statement before recursing, so the FunctionDeclaration handler can name
-  // (H) it the way cgr does (lua_utils.extract_assigned_name).
+  // Record the binding name of any function expression assigned in this
+  // statement before recursing, so the FunctionDeclaration handler can name
+  // it the way cgr does (lua_utils.extract_assigned_name).
   if (
     (node.type === "LocalStatement" || node.type === "AssignmentStatement") &&
     Array.isArray(node.variables) &&
@@ -84,7 +84,7 @@ function walk(node, file, parentRef, assignedNames) {
       parent: { kind: parentRef.kind, file, line: parentRef.line },
       child: { kind: "Function", file, line },
     });
-    // (H) Functions nested in this one bind to it (its lexical parent).
+    // Functions nested in this one bind to it (its lexical parent).
     const sub = { kind: "Function", line };
     for (const k of Object.keys(node)) {
       if (k === "loc" || k === "range") continue;

--- a/evals/oracles/php_oracle/php_ast.js
+++ b/evals/oracles/php_oracle/php_ast.js
@@ -43,8 +43,8 @@ const edges = [];
 const nameEdges = [];
 const calls = [];
 
-// (H) A php-parser declaration name is an identifier object ({name:"foo"}) or a
-// (H) bare string depending on node/version; normalise to the string.
+// A php-parser declaration name is an identifier object ({name:"foo"}) or a
+// bare string depending on node/version; normalise to the string.
 function nameOf(n) {
   if (!n) return "anonymous";
   if (typeof n === "string") return n;
@@ -55,9 +55,9 @@ function emit(kind, file, line, endLine, name) {
   nodes.push({ kind, file, line, end_line: endLine, name: name || "decl" });
 }
 
-// (H) The callee simple name of a php-parser `call`: a bare function name
-// (H) (`foo()`), or the trailing member of a method (`$this->h()`) or static
-// (H) (`Bar::s()`) lookup. Dynamic callees (`$f()`, `$obj->$m()`) yield null.
+// The callee simple name of a php-parser `call`: a bare function name
+// (`foo()`), or the trailing member of a method (`$this->h()`) or static
+// (`Bar::s()`) lookup. Dynamic callees (`$f()`, `$obj->$m()`) yield null.
 function callName(what) {
   if (!what) return null;
   if (what.kind === "name") return what.name ? what.name.split("\\").pop() : null;
@@ -66,9 +66,9 @@ function callName(what) {
     what.kind === "nullsafepropertylookup" ||
     what.kind === "staticlookup"
   ) {
-    // (H) Only a static identifier offset is a real callee name; a dynamic
-    // (H) offset (`$obj->$m()`) is kind "variable" whose `name` is the variable
-    // (H) identifier, which must not be emitted as a call edge.
+    // Only a static identifier offset is a real callee name; a dynamic
+    // offset (`$obj->$m()`) is kind "variable" whose `name` is the variable
+    // identifier, which must not be emitted as a call edge.
     const off = what.offset;
     if (off && off.kind === "identifier" && typeof off.name === "string") {
       return off.name;
@@ -93,8 +93,8 @@ function emitNameEdge(rel, file, skind, sline, targetName) {
   });
 }
 
-// (H) Simple name of a php-parser Name ref: its last namespace segment, matching
-// (H) how cgr resolves bases by simple name (e.g. \App\Base -> Base).
+// Simple name of a php-parser Name ref: its last namespace segment, matching
+// how cgr resolves bases by simple name (e.g. \App\Base -> Base).
 function phpSimpleName(ref) {
   const n = ref && ref.name ? ref.name : "";
   return n.split("\\").pop();
@@ -105,8 +105,8 @@ function asList(refs) {
   return Array.isArray(refs) ? refs : [refs];
 }
 
-// (H) class extends -> INHERITS, implements -> IMPLEMENTS; interface extends
-// (H) (an array) -> INHERITS (cgr models superinterfaces as inheritance).
+// class extends -> INHERITS, implements -> IMPLEMENTS; interface extends
+// (an array) -> INHERITS (cgr models superinterfaces as inheritance).
 function emitInheritance(node, file, kind, line) {
   const extendsRel = "INHERITS";
   for (const ref of asList(node.extends)) {
@@ -162,8 +162,8 @@ function walk(node, file, ctx) {
   switch (node.kind) {
     case "class": {
       if (isAnonymous(node)) {
-        // (H) Anonymous class: no node; its methods are Functions bound to the
-        // (H) enclosing function/module, so keep funcRef and mark the container.
+        // Anonymous class: no node; its methods are Functions bound to the
+        // enclosing function/module, so keep funcRef and mark the container.
         walkChildren(node, file, { container: "anon", typeRef: null, funcRef: ctx.funcRef });
       } else {
         const line = declLine(node);
@@ -221,9 +221,9 @@ function walk(node, file, ctx) {
       return;
     }
     case "call": {
-      // (H) Emit the callee simple name; the Python side keeps only callees whose
-      // (H) name is a declared first-party Function/Method. Recurse for nested
-      // (H) calls in the arguments / receiver.
+      // Emit the callee simple name; the Python side keeps only callees whose
+      // name is a declared first-party Function/Method. Recurse for nested
+      // calls in the arguments / receiver.
       const name = callName(node.what);
       if (name) calls.push({ file, name });
       walkChildren(node, file, ctx);

--- a/evals/oracles/rs_oracle/src/main.rs
+++ b/evals/oracles/rs_oracle/src/main.rs
@@ -110,17 +110,17 @@ fn call_json(file: &str, name: &str) -> String {
     format!("{{\"file\":\"{}\",\"name\":\"{}\"}}", esc(file), esc(name))
 }
 
-// (H) Last path segment of a trait reference (`a::b::Trait` / `Trait<T>` -> Trait).
+// Last path segment of a trait reference (`a::b::Trait` / `Trait<T>` -> Trait).
 fn trait_path_name(path: &syn::Path) -> Option<String> {
     path.segments.last().map(|s| s.ident.to_string())
 }
 
 // ---- call-site collection ----
 //
-// (H) Every call expression's (file, callee simple name): a path call's last
-// (H) segment (`foo()`, `a::b::foo()`, `Type::assoc()` -> foo / assoc) and a
-// (H) method call's method ident (`x.method()` -> method). Mirrors go_ast.go's
-// (H) call oracle so cgr's Rust CALLS edges grade against an independent parser.
+// Every call expression's (file, callee simple name): a path call's last
+// segment (`foo()`, `a::b::foo()`, `Type::assoc()` -> foo / assoc) and a
+// method call's method ident (`x.method()` -> method). Mirrors go_ast.go's
+// call oracle so cgr's Rust CALLS edges grade against an independent parser.
 
 struct CallCollector<'a> {
     file: &'a str,
@@ -204,12 +204,12 @@ impl<'ast, 'a> Visit<'ast> for NodeCollector<'a> {
 
 // ---- closure containment ----
 //
-// (H) A closure is DEFINEd by the nearest enclosing function-like scope: a free
-// (H) fn or another closure (Function), or an impl/trait method (Method); at item
-// (H) scope it falls back to the enclosing module. This mirrors cgr, which routes
-// (H) every closure through its free-function path and binds it to its lexical
-// (H) parent. The walk keeps a stack of enclosing function-likes so nested
-// (H) closures bind to the closure that contains them, not the outer method.
+// A closure is DEFINEd by the nearest enclosing function-like scope: a free
+// fn or another closure (Function), or an impl/trait method (Method); at item
+// scope it falls back to the enclosing module. This mirrors cgr, which routes
+// every closure through its free-function path and binds it to its lexical
+// parent. The walk keeps a stack of enclosing function-likes so nested
+// closures bind to the closure that contains them, not the outer method.
 
 struct ClosureEdges<'a> {
     file: &'a str,
@@ -383,7 +383,7 @@ fn process_edges(
                 edges.push(edge_json(
                     REL_DEFINES, file, KIND_MODULE, module_line, KIND_INTERFACE, tline,
                 ));
-                // (H) Supertrait bounds (`trait Sub: Super`) -> Sub INHERITS Super.
+                // Supertrait bounds (`trait Sub: Super`) -> Sub INHERITS Super.
                 for bound in &tr.supertraits {
                     if let syn::TypeParamBound::Trait(tb) = bound {
                         if let Some(name) = trait_path_name(&tb.path) {
@@ -399,8 +399,8 @@ fn process_edges(
                             REL_DEFINES_METHOD, file, KIND_INTERFACE, tline, KIND_METHOD,
                             m.sig.ident.span().start().line,
                         )),
-                        // (H) An associated type is a module-scoped Type declaration
-                        // (H) in cgr's model (DEFINEd by the enclosing module).
+                        // An associated type is a module-scoped Type declaration
+                        // in cgr's model (DEFINEd by the enclosing module).
                         syn::TraitItem::Type(t) => edges.push(edge_json(
                             REL_DEFINES, file, KIND_MODULE, module_line, KIND_TYPE,
                             t.ident.span().start().line,
@@ -412,7 +412,7 @@ fn process_edges(
             syn::Item::Impl(im) => {
                 let owner = impl_target_name(&im.self_ty)
                     .and_then(|name| resolve_type(modpath, &name, table));
-                // (H) `impl Trait for Type` -> Type IMPLEMENTS Trait.
+                // `impl Trait for Type` -> Type IMPLEMENTS Trait.
                 if let (Some((kind, tline)), Some((_, path, _))) = (&owner, &im.trait_) {
                     if let Some(name) = trait_path_name(path) {
                         name_edges.push(name_edge_json(
@@ -429,11 +429,11 @@ fn process_edges(
                                     m.sig.ident.span().start().line,
                                 ));
                             } else {
-                                // (H) An impl on a type declared elsewhere (Box<P>,
-                                // (H) primitives, external types) has no owner node;
-                                // (H) cgr anchors such methods to the module with
-                                // (H) DEFINES (orphan-prevention fallback), so the
-                                // (H) oracle models the same containment.
+                                // An impl on a type declared elsewhere (Box<P>,
+                                // primitives, external types) has no owner node;
+                                // cgr anchors such methods to the module with
+                                // DEFINES (orphan-prevention fallback), so the
+                                // oracle models the same containment.
                                 edges.push(edge_json(
                                     REL_DEFINES, file, KIND_MODULE, module_line, KIND_METHOD,
                                     m.sig.ident.span().start().line,

--- a/evals/oracles/ts_oracle/ts_ast.js
+++ b/evals/oracles/ts_oracle/ts_ast.js
@@ -60,18 +60,18 @@ function emitNameEdge(rel, file, skind, sline, targetName) {
   });
 }
 
-// (H) Simple name of an extends/implements entry: the base expression's last
-// (H) identifier (type arguments live separately, so they're already excluded).
+// Simple name of an extends/implements entry: the base expression's last
+// identifier (type arguments live separately, so they're already excluded).
 function heritageSimpleName(typeNode) {
   let expr = typeNode.expression || typeNode;
   while (expr && expr.name && expr.expression) {
-    expr = expr.name; // (H) a.b.Base -> Base
+    expr = expr.name; // a.b.Base -> Base
   }
   return expr && expr.text ? expr.text : expr.getText();
 }
 
-// (H) A class's extends -> INHERITS, implements -> IMPLEMENTS; an interface's
-// (H) extends -> INHERITS (cgr models superinterfaces as inheritance).
+// A class's extends -> INHERITS, implements -> IMPLEMENTS; an interface's
+// extends -> INHERITS (cgr models superinterfaces as inheritance).
 function emitHeritage(node, sf, file, kind, line) {
   if (!node.heritageClauses) return;
   for (const clause of node.heritageClauses) {
@@ -87,8 +87,8 @@ function lineOf(sf, node) {
   return sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1;
 }
 
-// (H) Last line of a node's full span (its end position), for span/end_line
-// (H) grading against cgr's end_line.
+// Last line of a node's full span (its end position), for span/end_line
+// grading against cgr's end_line.
 function endLineOf(sf, node) {
   return sf.getLineAndCharacterOfPosition(node.getEnd()).line + 1;
 }
@@ -97,10 +97,10 @@ function methodKind(container) {
   return container === "namespace" || container === "class" ? "Method" : "Function";
 }
 
-// (H) The binding name of an arrow/function expression (`const foo = () => ...`,
-// (H) `foo = () => ...` class property, `{ foo: () => ... }`), matching how cgr
-// (H) names such a Function. Used so the call oracle's declared-name universe
-// (H) includes these (cgr resolves `foo()` to them); falls back to "anonymous".
+// The binding name of an arrow/function expression (`const foo = () => ...`,
+// `foo = () => ...` class property, `{ foo: () => ... }`), matching how cgr
+// names such a Function. Used so the call oracle's declared-name universe
+// includes these (cgr resolves `foo()` to them); falls back to "anonymous".
 function bindingName(node) {
   const p = node.parent;
   if (
@@ -116,16 +116,16 @@ function bindingName(node) {
   return "anonymous";
 }
 
-// (H) cgr models `X.prototype.m = function` as the CONSTRUCTOR node DEFINES the
-// (H) method (the prototype pass registers `module.X.m` under the constructor,
-// (H) resolved by module-flat name), so the oracle mirrors it: the file's
-// (H) declared functions (declarations and var-assigned expressions) are the
-// (H) constructor candidates. First declaration wins, matching cgr's registry.
+// cgr models `X.prototype.m = function` as the CONSTRUCTOR node DEFINES the
+// method (the prototype pass registers `module.X.m` under the constructor,
+// resolved by module-flat name), so the oracle mirrors it: the file's
+// declared functions (declarations and var-assigned expressions) are the
+// constructor candidates. First declaration wins, matching cgr's registry.
 let declaredFns = new Map();
 
-// (H) Unwrap `( ... )` and `lhs = ...` chains so `var X = (exports.X =
-// (H) function ...)` resolves to the function expression, matching cgr's
-// (H) nameless-binding registration of X at the function node.
+// Unwrap `( ... )` and `lhs = ...` chains so `var X = (exports.X =
+// function ...)` resolves to the function expression, matching cgr's
+// nameless-binding registration of X at the function node.
 function unwrapInitializer(node) {
   while (node) {
     if (ts.isParenthesizedExpression(node)) {
@@ -145,10 +145,10 @@ function unwrapInitializer(node) {
 function collectDeclaredFunctions(sf) {
   const decls = new Map();
   function scan(node) {
-    // (H) cgr resolves prototype constructors MODULE-FLAT (module.X); a
-    // (H) function declared inside another function registers nested and
-    // (H) never matches, so the scan must not descend past function or
-    // (H) class boundaries.
+    // cgr resolves prototype constructors MODULE-FLAT (module.X); a
+    // function declared inside another function registers nested and
+    // never matches, so the scan must not descend past function or
+    // class boundaries.
     if (
       ts.isFunctionDeclaration(node) ||
       ts.isFunctionExpression(node) ||
@@ -180,7 +180,7 @@ function collectDeclaredFunctions(sf) {
   return decls;
 }
 
-// (H) `X.prototype.m = <fn expr>`: the shape cgr's prototype-method pass owns.
+// `X.prototype.m = <fn expr>`: the shape cgr's prototype-method pass owns.
 function prototypeAssignment(node) {
   if (!ts.isBinaryExpression(node)) return null;
   if (node.operatorToken.kind !== ts.SyntaxKind.EqualsToken) return null;
@@ -260,8 +260,8 @@ function walk(node, sf, file, container, ctx) {
       : node.name && ts.isIdentifier(node.name)
         ? node.name.text
         : node.name && node.name.text;
-    // (H) Class members are Methods; object-literal shorthand methods are modelled
-    // (H) by cgr as standalone Functions.
+    // Class members are Methods; object-literal shorthand methods are modelled
+    // by cgr as standalone Functions.
     const kind = container === "class" ? "Method" : "Function";
     const line = lineOf(sf, node);
     if (nm) {
@@ -280,8 +280,8 @@ function walk(node, sf, file, container, ctx) {
     if (ctorLine !== undefined) {
       emitEdge("DEFINES", file, "Function", ctorLine, "Function", line);
     } else {
-      // (H) Unregistered constructor: cgr's deferred parent falls back to the
-      // (H) lexical enclosing function, then the module.
+      // Unregistered constructor: cgr's deferred parent falls back to the
+      // lexical enclosing function, then the module.
       const parent = ctx.funcRef || { kind: "Module", line: MODULE_LINE };
       emitEdge("DEFINES", file, parent.kind, parent.line, "Function", line);
     }
@@ -290,7 +290,7 @@ function walk(node, sf, file, container, ctx) {
     return;
   }
   if (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) {
-    // (H) cgr captures every arrow/function expression as a Function node (named
+    // cgr captures every arrow/function expression as a Function node (named
     // by its variable when assigned, else anonymous), at the expression's own
     // line. The name is irrelevant to the (kind, file, line) join.
     const kind = methodKind(container);
@@ -301,11 +301,11 @@ function walk(node, sf, file, container, ctx) {
     node.forEachChild((c) => walk(c, sf, file, "function", sub));
     return;
   }
-  // (H) A call site: the callee simple name is a bare identifier (`foo()`,
-  // (H) same-scope or imported) or the trailing identifier of a property access
-  // (H) (`obj.foo()`, `Type.bar()`). The Python side keeps only callees whose
-  // (H) name is a declared first-party Function/Method, mirroring the Go/Rust/Java
-  // (H) call oracles. Do not return -- recurse so nested calls (`f(g())`) emit too.
+  // A call site: the callee simple name is a bare identifier (`foo()`,
+  // same-scope or imported) or the trailing identifier of a property access
+  // (`obj.foo()`, `Type.bar()`). The Python side keeps only callees whose
+  // name is a declared first-party Function/Method, mirroring the Go/Rust/Java
+  // call oracles. Do not return -- recurse so nested calls (`f(g())`) emit too.
   if (ts.isCallExpression(node)) {
     const callee = node.expression;
     if (ts.isIdentifier(callee)) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,9 +70,9 @@ cgr = "codebase_rag.cli:app"
 [tool.uv]
 package = true
 
-# (H) Patched grammars: upstream tree-sitter-c drops declarations after a
-# (H) #define whose value embeds a block comment (issue #555). Our forks carry
-# (H) the repeat(preproc_arg) fix; drop these overrides once upstream releases it.
+# Patched grammars: upstream tree-sitter-c drops declarations after a
+# #define whose value embeds a block comment (issue #555). Our forks carry
+# the repeat(preproc_arg) fix; drop these overrides once upstream releases it.
 [tool.uv.sources]
 tree-sitter-c = { git = "https://github.com/vitali87/tree-sitter-c", rev = "fa327ad98f847f8173fc46926be4165c7971f960" }
 tree-sitter-cpp = { git = "https://github.com/vitali87/tree-sitter-cpp", rev = "b4a7be2f62f36dd460a14b2d1728d42d81d2c486" }
@@ -168,12 +168,12 @@ exclude = ["codebase_rag/tests/test_cypher_queries.py", "codebase_rag/tests/test
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-# (H) loadgroup honors the xdist_group marker that pins the integration dir to
-# (H) one worker; for unmarked tests it schedules identically to the default.
-# (H) xdist workers decide their grouping flag from the parsed args/ini before
-# (H) any conftest hook fires (xdist remote.py setup_config), so this must be
-# (H) an ini-level option; every dependency set that carries pytest also
-# (H) carries pytest-xdist, so the flag always parses.
+# loadgroup honors the xdist_group marker that pins the integration dir to
+# one worker; for unmarked tests it schedules identically to the default.
+# xdist workers decide their grouping flag from the parsed args/ini before
+# any conftest hook fires (xdist remote.py setup_config), so this must be
+# an ini-level option; every dependency set that carries pytest also
+# carries pytest-xdist, so the flag always parses.
 addopts = "--dist=loadgroup"
 testpaths = ["codebase_rag/tests"]
 norecursedirs = ["grammars", ".git", "__pycache__", "*.egg-info", ".venv", "venv"]

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.423"
+version = "0.0.424"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

Completes the `(H)` author-marker cleanup by removing the marker and its documentation from the non-Python files the earlier waves (#838, #841, #842, #843) did not touch. After this PR no literal `(H)` remains in any tracked text file (the two `demo.gif` binaries carry the byte sequence incidentally; it is not a comment).

## Changes

- **Marker strip** (comment leader kept, only the `(H)` token removed, substantive why/how text preserved):
  - `evals/oracles/` Java, Lua, PHP, Rust, TypeScript oracle sources (`// (H)` -> `//`)
  - `.github/workflows/ci.yml`, `.github/workflows/docs.yml`, `pyproject.toml` (`# (H)` -> `#`)
- **Retired-rule documentation removed / reworded to the new why/how norm:**
  - `CONTRIBUTING.md`: dropped the "No Comments or Docstrings" exception and rewrote the "Comment Policy" section.
  - `docs/contributing.md`: rewrote the "Comment Policy" section.
  - `.github/workflows/claude-code-review.yml`: the review prompt now asks for why/how comments instead of enforcing the marker.
- **`Makefile`**: removed the `pre-commit` step that invoked the already-deleted `scripts/check_no_docs.py` (a leftover from #838 that broke `make pre-commit`).

## Verification

- `git grep -F '(H)'` over tracked text files returns zero.
- Every changed line in the oracle and workflow/toml sources is a comment line; no code, string, or identifier token changed.
- `pre-commit run --all-files` green (yaml/toml valid, ruff, ty, bandit, README generation).
