### PR TITLE
docs: align all documentation with current code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,7 @@ All checks run in parallel and must pass before a PR can be merged. A summary jo
 
 ```bash
 make lint          # Lint check
-make format        # Format check
+make format        # Apply formatting (ruff format writes files; CI uses ruff format --check)
 make typecheck     # Type check
 make test-parallel # Unit tests in parallel
 make test-integration  # Integration tests (requires Docker)

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -8,7 +8,7 @@ A graph-based RAG system that parses multi-language codebases with Tree-sitter, 
 pip install code-graph-rag
 ```
 
-With all Tree-sitter grammars (Python, JS, TS, Rust, Go, Java, Scala, C++, Lua):
+With all Tree-sitter grammars (Python, JS, TS, Rust, Go, Java, Scala, C, C++, C#, PHP, Lua, Dart):
 
 ```bash
 pip install 'code-graph-rag[treesitter-full]'
@@ -161,7 +161,7 @@ Configure via `.env` or environment variables:
 |----------|---------|-------------|
 | `MEMGRAPH_HOST` | `localhost` | Memgraph hostname |
 | `MEMGRAPH_PORT` | `7687` | Memgraph port |
-| `ORCHESTRATOR_PROVIDER` | | Provider: `google`, `openai`, `ollama` |
+| `ORCHESTRATOR_PROVIDER` | | Provider: `google`, `openai`, `anthropic`, `azure`, `ollama`, `minimax`, `litellm_proxy` |
 | `ORCHESTRATOR_MODEL` | | Model ID (e.g. `gpt-4o`, `gemini-2.5-pro`) |
 | `ORCHESTRATOR_API_KEY` | | API key for the provider (not needed for `ollama`) |
 | `CYPHER_PROVIDER` | | Provider for Cypher generation |

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ See the [Architecture Overview](docs/architecture/overview.md) and [Graph Schema
 
 ## Supported Languages
 
-Python, TypeScript, TSX, JavaScript, Rust, Go, Java, C, C++, C#, PHP, Lua, and Dart are fully supported. Scala is in development. See the [Language Support](docs/architecture/language-support.md) matrix for per-language capabilities.
+Python, TypeScript, TSX, JavaScript, Rust, Go, Java, C, C++, C#, PHP, Lua, and Dart are fully supported. Scala is in development, and Ruby has structural support (modules, functions, classes, and imports) through the pluggable ast-grep tier. See the [Language Support](docs/architecture/language-support.md) matrix for per-language capabilities.
 
 ## Installation
 

--- a/codebase_rag/parsers/io_access/registry.py
+++ b/codebase_rag/parsers/io_access/registry.py
@@ -140,8 +140,9 @@ _PYTHON_SINKS: tuple[IOSink, ...] = (
 _JS_TS_SINKS: tuple[IOSink, ...] = (
     IOSink("console.log", ResourceKind.STDOUT, IODirection.WRITE),
     IOSink("console.info", ResourceKind.STDOUT, IODirection.WRITE),
-    IOSink("console.warn", ResourceKind.STDOUT, IODirection.WRITE),
-    IOSink("console.error", ResourceKind.STDOUT, IODirection.WRITE),
+    # Node writes warn/error to stderr (console.warn is an alias of console.error).
+    IOSink("console.warn", ResourceKind.STDERR, IODirection.WRITE),
+    IOSink("console.error", ResourceKind.STDERR, IODirection.WRITE),
     IOSink("fetch", ResourceKind.NETWORK, IODirection.READ, target_arg=0),
     IOSink("axios.get", ResourceKind.NETWORK, IODirection.READ, target_arg=0),
     IOSink("axios.head", ResourceKind.NETWORK, IODirection.READ, target_arg=0),
@@ -202,11 +203,11 @@ _JAVA_SYSTEM_SINKS: tuple[IOSink, ...] = (
     IOSink("System.out.printf", ResourceKind.STDOUT, IODirection.WRITE),
     IOSink("System.out.format", ResourceKind.STDOUT, IODirection.WRITE),
     IOSink("System.out.write", ResourceKind.STDOUT, IODirection.WRITE),
-    IOSink("System.err.println", ResourceKind.STDOUT, IODirection.WRITE),
-    IOSink("System.err.print", ResourceKind.STDOUT, IODirection.WRITE),
-    IOSink("System.err.printf", ResourceKind.STDOUT, IODirection.WRITE),
-    IOSink("System.err.format", ResourceKind.STDOUT, IODirection.WRITE),
-    IOSink("System.err.write", ResourceKind.STDOUT, IODirection.WRITE),
+    IOSink("System.err.println", ResourceKind.STDERR, IODirection.WRITE),
+    IOSink("System.err.print", ResourceKind.STDERR, IODirection.WRITE),
+    IOSink("System.err.printf", ResourceKind.STDERR, IODirection.WRITE),
+    IOSink("System.err.format", ResourceKind.STDERR, IODirection.WRITE),
+    IOSink("System.err.write", ResourceKind.STDERR, IODirection.WRITE),
 )
 
 # java.nio.file.Files static sinks. Registered under BOTH the simple `Files.X`
@@ -471,9 +472,13 @@ IO_ARG_HANDLE_SINKS: dict[cs.SupportedLanguage, dict[str, ArgHandleSink]] = {
 
 # Macro-call I/O sinks keyed by macro name (issue #714). Rust's stdout/stderr write
 # path is the `println!`/`print!`/`eprintln!`/`eprint!` macros, not calls; the target
-# is a format template, so the resource identity is always <dynamic> (STDOUT).
+# is a format template, so the resource identity is always <dynamic>.
 _RUST_MACRO_SINKS: dict[str, IOSink] = {
-    name: IOSink(name, ResourceKind.STDOUT, IODirection.WRITE)
+    name: IOSink(
+        name,
+        ResourceKind.STDERR if name.startswith("e") else ResourceKind.STDOUT,
+        IODirection.WRITE,
+    )
     for name in ("println", "print", "eprintln", "eprint")
 }
 
@@ -484,7 +489,11 @@ IO_MACRO_SINKS: dict[cs.SupportedLanguage, dict[str, IOSink]] = {
 # Stream-insertion I/O sinks keyed by the left-spine base of a `<<` chain
 # (`std::cout << x` writes STDOUT). Both the bare and std:: forms are keyed.
 _CPP_STREAM_SINKS: dict[str, IOSink] = {
-    f"{prefix}{name}": IOSink(name, ResourceKind.STDOUT, IODirection.WRITE)
+    f"{prefix}{name}": IOSink(
+        name,
+        ResourceKind.STDOUT if name in ("cout", "wcout") else ResourceKind.STDERR,
+        IODirection.WRITE,
+    )
     for name in ("cout", "cerr", "clog", "wcout", "wcerr", "wclog")
     for prefix in _CPP_SINK_PREFIXES
 }

--- a/codebase_rag/tests/integration/test_cpp_io_e2e.py
+++ b/codebase_rag/tests/integration/test_cpp_io_e2e.py
@@ -57,13 +57,15 @@ void leak(const char* name) {
 def test_cpp_direct_io_sinks(
     memgraph_ingestor: MemgraphIngestor, tmp_path: Path
 ) -> None:
-    # std::getenv reads ENV::SECRET; printf writes STDOUT; std::cout / std::cerr `<<`
-    # insertion writes STDOUT. First C++ increment of issue #714 -- direct calls +
-    # stream insertion, no fstream/FILE* handles (deferred).
+    # std::getenv reads ENV::SECRET; printf / std::cout `<<` insertion writes
+    # STDOUT; std::cerr `<<` insertion writes STDERR. First C++ increment of
+    # issue #714 -- direct calls + stream insertion, no fstream/FILE* handles
+    # (deferred).
     _build(memgraph_ingestor, tmp_path, _CPP_CODE)
     edges = _io_edges(memgraph_ingestor)
     assert (_READS, "resource::ENV::SECRET") in edges
     assert (_WRITES, "resource::STDOUT::<dynamic>") in edges
+    assert (_WRITES, "resource::STDERR::<dynamic>") in edges
 
 
 def test_cpp_unqualified_getenv(
@@ -79,24 +81,24 @@ def test_cpp_unqualified_getenv(
 
 
 @pytest.mark.parametrize(
-    "body",
+    ("body", "resource"),
     [
-        "putchar('x');",
-        'std::wcout << L"hi";',
-        'std::wcerr << L"e";',
+        ("putchar('x');", "resource::STDOUT::<dynamic>"),
+        ('std::wcout << L"hi";', "resource::STDOUT::<dynamic>"),
+        ('std::wcerr << L"e";', "resource::STDERR::<dynamic>"),
     ],
 )
 def test_cpp_putchar_and_wide_streams(
-    memgraph_ingestor: MemgraphIngestor, tmp_path: Path, body: str
+    memgraph_ingestor: MemgraphIngestor, tmp_path: Path, body: str, resource: str
 ) -> None:
-    # putchar and the wide streams wcout/wcerr (`<<`) each write STDOUT, like
-    # puts / cout. Isolated so the STDOUT edge can only come from the sink.
+    # putchar and wcout (`<<`) write STDOUT like puts / cout; wcerr writes
+    # STDERR like cerr. Isolated so the edge can only come from the sink.
     _build(
         memgraph_ingestor,
         tmp_path,
         f"#include <cstdio>\n#include <iostream>\nvoid f() {{\n    {body}\n}}\n",
     )
-    assert (_WRITES, "resource::STDOUT::<dynamic>") in _io_edges(memgraph_ingestor)
+    assert (_WRITES, resource) in _io_edges(memgraph_ingestor)
 
 
 def test_cpp_nested_lambda_not_credited(

--- a/codebase_rag/tests/integration/test_java_io_e2e.py
+++ b/codebase_rag/tests/integration/test_java_io_e2e.py
@@ -56,14 +56,16 @@ class App {
 def test_java_direct_io_sinks(
     memgraph_ingestor: MemgraphIngestor, tmp_path: Path
 ) -> None:
-    # System.getenv reads ENV::SECRET (literal arg); System.out/err.print* write
-    # STDOUT (arg is an identifier -> <dynamic>); Files.writeString writes a FILE
-    # (its arg is a Path, so the path identity is <dynamic>). First Java increment
-    # of issue #714 -- direct, non-handle sinks only.
+    # System.getenv reads ENV::SECRET (literal arg); System.out.print* writes
+    # STDOUT and System.err.print* writes STDERR (arg is an identifier ->
+    # <dynamic>); Files.writeString writes a FILE (its arg is a Path, so the
+    # path identity is <dynamic>). First Java increment of issue #714 --
+    # direct, non-handle sinks only.
     _build(memgraph_ingestor, tmp_path, _JAVA_CODE)
     edges = _io_edges(memgraph_ingestor)
     assert (_READS, "resource::ENV::SECRET") in edges
     assert (_WRITES, "resource::STDOUT::<dynamic>") in edges
+    assert (_WRITES, "resource::STDERR::<dynamic>") in edges
     assert (_WRITES, "resource::FILE::<dynamic>") in edges
 
 

--- a/codebase_rag/tests/integration/test_rust_io_e2e.py
+++ b/codebase_rag/tests/integration/test_rust_io_e2e.py
@@ -58,14 +58,15 @@ fn leak(name: String) {
 def test_rust_direct_io_sinks(
     memgraph_ingestor: MemgraphIngestor, tmp_path: Path
 ) -> None:
-    # std::env::var reads ENV::SECRET; println!/print!/eprintln!/eprint! macros
-    # write STDOUT; std::fs::write / create_dir / read_to_string are direct FILE
-    # write/read. First Rust increment of issue #714: direct calls plus print
-    # macros, no handles.
+    # std::env::var reads ENV::SECRET; println!/print! macros write STDOUT and
+    # eprintln!/eprint! write STDERR; std::fs::write / create_dir /
+    # read_to_string are direct FILE write/read. First Rust increment of issue
+    # #714: direct calls plus print macros, no handles.
     _build(memgraph_ingestor, tmp_path, _RUST_CODE)
     edges = _io_edges(memgraph_ingestor)
     assert (_READS, "resource::ENV::SECRET") in edges
     assert (_WRITES, "resource::STDOUT::<dynamic>") in edges
+    assert (_WRITES, "resource::STDERR::<dynamic>") in edges
     assert (_WRITES, "resource::FILE::out.txt") in edges
     assert (_WRITES, "resource::FILE::d") in edges
     assert (_READS, "resource::FILE::in.txt") in edges

--- a/codebase_rag/tests/test_io_stderr_streams.py
+++ b/codebase_rag/tests/test_io_stderr_streams.py
@@ -101,37 +101,20 @@ def test_cpp_cerr_and_clog_write_stderr(tmp_path: Path) -> None:
 
 def test_cpp_cout_still_writes_stdout(tmp_path: Path) -> None:
     files = {
-        "main.cpp": (
-            "#include <iostream>\n"
-            "void say(int x) {\n"
-            "    std::cout << x;\n"
-            "}\n"
-        )
+        "main.cpp": ("#include <iostream>\nvoid say(int x) {\n    std::cout << x;\n}\n")
     }
     writes = _writes(tmp_path, files)
     assert _has(writes, "main.say", STDOUT_DYNAMIC), writes
 
 
 def test_rust_eprintln_writes_stderr(tmp_path: Path) -> None:
-    files = {
-        "main.rs": (
-            "fn report(x: i32) {\n"
-            '    eprintln!("{}", x);\n'
-            "}\n"
-        )
-    }
+    files = {"main.rs": ('fn report(x: i32) {\n    eprintln!("{}", x);\n}\n')}
     writes = _writes(tmp_path, files)
     assert _has(writes, "main.report", STDERR_DYNAMIC), writes
     assert not _has(writes, "main.report", STDOUT_DYNAMIC), writes
 
 
 def test_rust_println_still_writes_stdout(tmp_path: Path) -> None:
-    files = {
-        "main.rs": (
-            "fn say(x: i32) {\n"
-            '    println!("{}", x);\n'
-            "}\n"
-        )
-    }
+    files = {"main.rs": ('fn say(x: i32) {\n    println!("{}", x);\n}\n')}
     writes = _writes(tmp_path, files)
     assert _has(writes, "main.say", STDOUT_DYNAMIC), writes

--- a/codebase_rag/tests/test_io_stderr_streams.py
+++ b/codebase_rag/tests/test_io_stderr_streams.py
@@ -1,0 +1,137 @@
+# Error-stream writes must classify as STDERR, not STDOUT: Java System.err.*,
+# JS/TS console.error/console.warn (Node aliases warn to error, both write
+# stderr), C++ cerr/clog stream inserts, and Rust eprintln!/eprint! macros.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.capture import resolve_capture
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+WRITES_TO = cs.RelationshipType.WRITES_TO.value
+_CAPTURE_IO = resolve_capture([cs.CaptureGroup.IO.value])
+
+STDERR_DYNAMIC = "resource::STDERR::<dynamic>"
+STDOUT_DYNAMIC = "resource::STDOUT::<dynamic>"
+
+
+def _writes(tmp_path: Path, files: dict[str, str]) -> set[tuple[str, str]]:
+    parsers, queries = load_parsers()
+    for rel, content in files.items():
+        (tmp_path / rel).write_text(content, encoding="utf-8")
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        capture=_CAPTURE_IO,
+    ).run()
+    return {
+        (c.args[0][2], c.args[2][2])
+        for c in mock.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) == WRITES_TO
+    }
+
+
+def _has(writes: set[tuple[str, str]], caller: str, resource: str) -> bool:
+    return any(a.endswith(caller) and b == resource for a, b in writes)
+
+
+def test_java_system_err_writes_stderr(tmp_path: Path) -> None:
+    files = {
+        "Main.java": (
+            "public class Main {\n"
+            "    void log(String msg) {\n"
+            "        System.err.println(msg);\n"
+            "    }\n"
+            "}\n"
+        )
+    }
+    writes = _writes(tmp_path, files)
+    assert _has(writes, "Main.log(String)", STDERR_DYNAMIC), writes
+    assert not _has(writes, "Main.log(String)", STDOUT_DYNAMIC), writes
+
+
+def test_java_system_out_still_writes_stdout(tmp_path: Path) -> None:
+    files = {
+        "Main.java": (
+            "public class Main {\n"
+            "    void say(String msg) {\n"
+            "        System.out.println(msg);\n"
+            "    }\n"
+            "}\n"
+        )
+    }
+    writes = _writes(tmp_path, files)
+    assert _has(writes, "Main.say(String)", STDOUT_DYNAMIC), writes
+
+
+def test_js_console_error_and_warn_write_stderr(tmp_path: Path) -> None:
+    files = {
+        "app.js": (
+            "function report(msg) {\n"
+            "    console.error(msg);\n"
+            "    console.warn(msg);\n"
+            "}\n"
+        )
+    }
+    writes = _writes(tmp_path, files)
+    assert _has(writes, "app.report", STDERR_DYNAMIC), writes
+    assert not _has(writes, "app.report", STDOUT_DYNAMIC), writes
+
+
+def test_cpp_cerr_and_clog_write_stderr(tmp_path: Path) -> None:
+    files = {
+        "main.cpp": (
+            "#include <iostream>\n"
+            "void report(int x) {\n"
+            "    std::cerr << x;\n"
+            "    std::clog << x;\n"
+            "}\n"
+        )
+    }
+    writes = _writes(tmp_path, files)
+    assert _has(writes, "main.report", STDERR_DYNAMIC), writes
+    assert not _has(writes, "main.report", STDOUT_DYNAMIC), writes
+
+
+def test_cpp_cout_still_writes_stdout(tmp_path: Path) -> None:
+    files = {
+        "main.cpp": (
+            "#include <iostream>\n"
+            "void say(int x) {\n"
+            "    std::cout << x;\n"
+            "}\n"
+        )
+    }
+    writes = _writes(tmp_path, files)
+    assert _has(writes, "main.say", STDOUT_DYNAMIC), writes
+
+
+def test_rust_eprintln_writes_stderr(tmp_path: Path) -> None:
+    files = {
+        "main.rs": (
+            "fn report(x: i32) {\n"
+            '    eprintln!("{}", x);\n'
+            "}\n"
+        )
+    }
+    writes = _writes(tmp_path, files)
+    assert _has(writes, "main.report", STDERR_DYNAMIC), writes
+    assert not _has(writes, "main.report", STDOUT_DYNAMIC), writes
+
+
+def test_rust_println_still_writes_stdout(tmp_path: Path) -> None:
+    files = {
+        "main.rs": (
+            "fn say(x: i32) {\n"
+            '    println!("{}", x);\n'
+            "}\n"
+        )
+    }
+    writes = _writes(tmp_path, files)
+    assert _has(writes, "main.say", STDOUT_DYNAMIC), writes

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,9 +1,11 @@
 # Type Inference Gaps
 
 Type-extraction engines now exist for Python, TypeScript/JavaScript, Java, C++, Rust, and Go
-(`codebase_rag/parsers/*/type_inference.py`), covering explicit declarations, `var`/`auto`/short
-declarations, generics element types, and return-type inference. The items below are the gaps
-that remain.
+(`codebase_rag/parsers/*/type_inference.py`). Coverage varies by language: all handle explicit
+local declarations; `var`/`auto`/short-declaration inference, generics element types, and
+return-type inference are each implemented where that language's engine supports them (for
+example C++ resolves `auto` from constructor-shaped initializers but does not generally infer
+a variable's type from an arbitrary call's return type). The items below are the known gaps.
 
 ## Python
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,40 +1,43 @@
 # Type Inference Gaps
 
+Type-extraction engines now exist for Python, TypeScript/JavaScript, Java, C++, Rust, and Go
+(`codebase_rag/parsers/*/type_inference.py`), covering explicit declarations, `var`/`auto`/short
+declarations, generics element types, and return-type inference. The items below are the gaps
+that remain.
+
 ## Python
 
-### 1. Parse Return Type Annotations
+### Parse Return Type Annotations
 
 ```python
-def get_all_users() -> list[User]:  # Not parsed
+def get_all_users() -> list[User]:  # Annotation itself not parsed
     ...
 ```
 
-Tree-sitter: `function_definition` → `return_type` field.
-
-### 2. Extract Element Type from Generics
-
-```python
-users = get_all_users()  # type: list[User]
-for user in users:       # user should be: User
-    user.save()          # resolves to: User.save()
-```
-
-Regex: `list[X]` → `X`, `dict[K, V]` → `V`, `Optional[X]` → `X`
+Return types are currently inferred from `return` statements rather than parsed from the
+annotation. Tree-sitter: `function_definition` → `return_type` field.
 
 ---
 
 ## TypeScript
 
-### 1. Parse Type Annotations
+### Parse Type Annotations
 
 ```typescript
 const users: User[] = getUsers();  // Not parsed
-function getUsers(): User[] { ... }  // Not parsed
 ```
 
-Tree-sitter: `variable_declarator` → `type` field, `function_declaration` → `return_type` field.
+Variable types are inferred from the assigned value (`new` expressions, call return types),
+not from explicit annotations. Tree-sitter: `variable_declarator` → `type` field.
 
-### 2. Handle For-Of Loops
+### Extract Element Type from Array/Generic Types
+
+```typescript
+User[]      → User
+Array<User> → User
+```
+
+### Handle For-Of Loops
 
 ```typescript
 for (const user of users) {  // Not handled
@@ -42,20 +45,13 @@ for (const user of users) {  // Not handled
 }
 ```
 
-Tree-sitter: `for_in_statement` with `of` variant.
-
-### 3. Extract Element Type from Array/Generic Types
-
-```typescript
-User[]      → User
-Array<User> → User
-```
+Tree-sitter: `for_in_statement` with `of` variant. No loop-variable element-type inference yet.
 
 ---
 
 ## JavaScript
 
-### 1. Handle For-Of Loops
+### Handle For-Of Loops
 
 ```javascript
 for (const user of users) {  // Not handled
@@ -64,79 +60,6 @@ for (const user of users) {  // Not handled
 ```
 
 Same as TypeScript - no loop variable inference.
-
----
-
-## Java
-
-### 1. Extract Element Type from Generics
-
-```java
-List<User> users = getUsers();
-users.get(0).save();  // Doesn't know get(0) returns User
-```
-
-Parse `List<User>` → extract `User` for collection method return types.
-
-### 2. Handle `var` Type Inference
-
-```java
-var users = getUsers();  // type is List<User>, needs inference
-var user = users.get(0); // type is User, needs inference
-```
-
-When `var` is used, infer from right-hand side expression.
-
----
-
-## C++
-
-### No Type Extraction Engine
-
-Currently returns empty `local_var_types`. Need to extract explicit types from declarations.
-
-```cpp
-User user = getUser();  // Extract "User" from declaration
-user.save();            // Resolve to User::save()
-
-auto user = getUser();  // Needs return type inference (like Java var)
-```
-
-Tree-sitter: `declaration` → `type` field, `init_declarator` → `declarator` field.
-
----
-
-## Rust
-
-### No Type Extraction Engine
-
-Currently returns empty `local_var_types`. Need to extract explicit types from declarations.
-
-```rust
-let user: User = get_user();  // Extract "User" from type annotation
-user.save();                   // Resolve to User::save()
-
-let user = get_user();  // Needs return type inference
-```
-
-Tree-sitter: `let_declaration` → `type` field.
-
----
-
-## Go
-
-### No Type Extraction Engine
-
-Currently returns empty `local_var_types`. Need to extract explicit types from declarations.
-
-```go
-var user User = getUser()  // Extract "User" from declaration
-user.Save()                // Resolve to User.Save()
-
-user := getUser()  // Short declaration - needs return type inference
-```
-
-Tree-sitter: `var_declaration` → type identifier, `short_var_declaration` needs inference.
 
 ---
 

--- a/docs/advanced/adding-languages.md
+++ b/docs/advanced/adding-languages.md
@@ -40,28 +40,23 @@ When you add a language, the tool automatically:
 
 1. **Downloads the Grammar**: Clones the tree-sitter grammar repository as a git submodule
 2. **Detects Configuration**: Auto-extracts language metadata from `tree-sitter.json`
-3. **Analyses Node Types**: Automatically identifies AST node types for functions/methods, classes/structs, modules/files, and function calls
-4. **Compiles Bindings**: Builds Python bindings from the grammar source
-5. **Updates Configuration**: Adds the language to `codebase_rag/language_config.py`
-6. **Enables Parsing**: Makes the language immediately available for codebase analysis
+3. **Analyses Node Types**: Automatically identifies AST node types for functions/methods, classes/structs, modules/files, and function calls from `node-types.json`
+4. **Updates Configuration**: Adds the language to `codebase_rag/language_spec.py`
+5. **Enables Parsing**: Makes the language available for codebase analysis (the grammar itself is compiled on first use by the parser loader)
 
 ## Example: Adding C# Support
 
 ```bash
 $ cgr language add-grammar c-sharp
-Using default tree-sitter URL: https://github.com/tree-sitter/tree-sitter-c-sharp
-Adding submodule from https://github.com/tree-sitter/tree-sitter-c-sharp...
-Successfully added submodule at grammars/tree-sitter-c-sharp
-Auto-detected language: c-sharp
-Auto-detected file extensions: ['cs']
-Auto-detected node types:
+Search: Using default tree-sitter URL: https://github.com/tree-sitter/tree-sitter-c-sharp
+OK Submodule added at: grammars/tree-sitter-c-sharp
+Auto-detected extensions: ['.cs']
 Functions: ['destructor_declaration', 'method_declaration', 'constructor_declaration']
 Classes: ['struct_declaration', 'enum_declaration', 'interface_declaration', 'class_declaration']
 Modules: ['compilation_unit', 'file_scoped_namespace_declaration', 'namespace_declaration']
 Calls: ['invocation_expression']
-
-Language 'c-sharp' has been added to the configuration!
-Updated codebase_rag/language_config.py
+OK Language 'c-sharp' added
+Note: Updated codebase_rag/language_spec.py
 ```
 
 ## Managing Languages
@@ -74,11 +69,11 @@ cgr language remove-language <language-name>
 
 ## Language Configuration
 
-Each language is defined in `codebase_rag/language_config.py`:
+Each language is defined in the `LANGUAGE_SPECS` dict in `codebase_rag/language_spec.py`:
 
 ```python
-"language-name": LanguageConfig(
-    name="language-name",
+"language-name": LanguageSpec(
+    language="language-name",
     file_extensions=[".ext1", ".ext2"],
     function_node_types=["function_declaration", "method_declaration"],
     class_node_types=["class_declaration", "struct_declaration"],
@@ -101,4 +96,4 @@ cgr language add-grammar --grammar-url https://github.com/custom/tree-sitter-myl
 uv add tree-sitter@latest
 ```
 
-**Missing node types**: The tool automatically detects common node patterns, but you can manually adjust the configuration in `language_config.py` if needed.
+**Missing node types**: The tool automatically detects common node patterns, but you can manually adjust the configuration in `language_spec.py` if needed.

--- a/docs/advanced/troubleshooting.md
+++ b/docs/advanced/troubleshooting.md
@@ -43,4 +43,4 @@ cgr language add-grammar --grammar-url https://github.com/custom/tree-sitter-myl
 uv add tree-sitter@latest
 ```
 
-**Missing node types**: Manually adjust the configuration in `codebase_rag/language_config.py`.
+**Missing node types**: Manually adjust the configuration in `codebase_rag/language_spec.py`.

--- a/docs/architecture/data-flow-edges.md
+++ b/docs/architecture/data-flow-edges.md
@@ -50,7 +50,7 @@ qualified name has the form `resource::<KIND>::<identity>`:
 |--------|------------|------------------------|-----------|
 | `FILE` | A file on disk | `open(...)` and its handle methods (`.read`, `.write`, …); `json.load` / `json.dump` | read + write |
 | `ENV` | An environment variable | `os.getenv(...)`, `os.environ.get(...)` | read |
-| `NETWORK` | A network endpoint / URL | `requests.get` / `.head`, `urllib.request.urlopen` (read); `requests.post` / `.put` / `.patch` / `.delete` (write) | read + write |
+| `NETWORK` | A network endpoint / URL | `requests.get` / `.head`, `urllib.request.urlopen`, `httpx.get` (read); `requests.post` / `.put` / `.patch` / `.delete`, `httpx.post` (write); `httpx.Client` / `AsyncClient` and `aiohttp.ClientSession` handle methods | read + write |
 | `DATABASE` | A database connection | `sqlite3.connect(...)` handle methods (`.execute`, `.fetchone`, `.commit`, …) | read + write |
 | `SOCKET` | A network socket | `socket.socket(...)` handle methods (`.recv`, `.send`, …) | read + write |
 | `STDOUT` | Standard output | `print(...)` | write |
@@ -59,8 +59,9 @@ qualified name has the form `resource::<KIND>::<identity>`:
 
 Example: `os.getenv("K")` refers to `resource::ENV::K`; `print(x)` refers to
 `resource::STDOUT::<dynamic>`. The registry is extended in
-`codebase_rag/parsers/io_access/registry.py`; `STDIN` and `STDERR` exist as
-resource kinds but are not emitted until a source or sink for them is added.
+`codebase_rag/parsers/io_access/registry.py`. The Python registry does not yet
+register `STDIN` or `STDERR` sources/sinks, but other languages emit them
+(for example C `scanf`, C++ `std::cerr`, Java `System.err`, C# `Console.Error`).
 
 ## READS_FROM and WRITES_TO
 
@@ -361,8 +362,9 @@ module is re-exported under its own name. A project that does
   tainted value at the caller's site.
 - Sources and sinks are direct I/O calls from the registry; there are no
   `Parameter` nodes and no SSA-level precision.
-- The source/sink registry is Python-only in this phase; other languages need
-  their own tables before they emit these edges.
+- The source/sink registry covers Python, JavaScript, TypeScript (including TSX),
+  Go, Java, Rust, C, C++, and C#; a language not in the registry emits no I/O or
+  flow edges until its table is added.
 
 These are deliberate ceilings, chosen so the feature is correct and cheap where
 it applies rather than broad and noisy.

--- a/docs/architecture/graph-schema.md
+++ b/docs/architecture/graph-schema.md
@@ -11,23 +11,31 @@ The knowledge graph uses a unified schema across all supported languages.
 | Label | Properties |
 |-------|------------|
 | Project | `{name: string}` |
-| Package | `{qualified_name: string, name: string, path: string}` |
-| Folder | `{path: string, name: string}` |
-| File | `{path: string, name: string, extension: string}` |
-| Module | `{qualified_name: string, name: string, path: string}` |
-| Class | `{qualified_name: string, name: string, decorators: list[string]}` |
-| Function | `{qualified_name: string, name: string, decorators: list[string]}` |
-| Method | `{qualified_name: string, name: string, decorators: list[string]}` |
-| Interface | `{qualified_name: string, name: string}` |
-| Enum | `{qualified_name: string, name: string}` |
-| Type | `{qualified_name: string, name: string}` |
-| Union | `{qualified_name: string, name: string}` |
-| ModuleInterface | `{qualified_name: string, name: string, path: string}` |
-| ModuleImplementation | `{qualified_name: string, name: string, path: string, implements_module: string}` |
-| ExternalPackage | `{name: string, version_spec: string}` |
+| Package | `{qualified_name: string, name: string, path: string, absolute_path: string}` |
+| Folder | `{path: string, name: string, absolute_path: string}` |
+| File | `{path: string, name: string, extension: string?, absolute_path: string}` |
+| Module | `{qualified_name: string, name: string, path: string, absolute_path: string, start_line: int?, end_line: int?}` |
+| Class | `{qualified_name: string, name: string, modifiers: list[string], decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
+| Function | same as Class, plus `is_macro: boolean?` |
+| Method | same as Class, plus `is_property: boolean?, overrides_external: boolean?` |
+| Interface | `{qualified_name: string, name: string, path: string, absolute_path: string, modifiers: list[string]?, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
+| Enum | same as Interface |
+| Type | same as Interface, but `path` and `absolute_path` are optional |
+| Union | same as Type |
+| ModuleInterface | `{qualified_name: string, name: string, path: string, absolute_path: string, module_type: string}` |
+| ModuleImplementation | `{qualified_name: string, name: string, path: string, absolute_path: string, implements_module: string, module_type: string}` |
+| ExternalPackage | `{name: string}` |
+| ExternalModule | `{qualified_name: string, name: string, path: string}` |
 | Resource | `{qualified_name: string, name: string, kind: string}` |
+| Pattern | `{qualified_name: string, name: string, message: string, start_line: int, end_line: int, path: string, snippet: string?}` |
+| CodeSmell | same as Pattern |
+| SecurityIssue | same as Pattern |
+
+`ExternalModule` stands for an imported module that lives outside the repository (a third-party or stdlib target of `IMPORTS`, or a positively-external base class target of `INHERITS`/`IMPLEMENTS`).
 
 `Resource` is a synthetic node standing for an external I/O target (a file, environment variable, network endpoint, database, standard stream, socket). Its `qualified_name` has the form `resource::<KIND>::<identity>`, where `identity` is a static string literal when one is available and `<dynamic>` otherwise, and `kind` is one of `FILE`, `NETWORK`, `DATABASE`, `STDIN`, `STDOUT`, `STDERR`, `ENV`, `SOCKET`. Resource nodes are captured only when the `io` capture group is enabled (see below).
+
+`Pattern`, `CodeSmell`, and `SecurityIssue` are ast-grep finding nodes, captured only when the `findings` capture group is enabled.
 
 ## Relationships
 
@@ -37,21 +45,28 @@ The knowledge graph uses a unified schema across all supported languages.
 | Project, Package, Folder | CONTAINS_FOLDER | Folder |
 | Project, Package, Folder | CONTAINS_FILE | File |
 | Project, Package, Folder | CONTAINS_MODULE | Module |
-| Module, Function, Method | DEFINES | Class, Function |
-| Class | DEFINES_METHOD | Method |
-| Module | IMPORTS | Module |
+| Module, Function, Method, Class | DEFINES | Class, Function, Method, Enum, Interface, Type, Union, Module |
+| Class, Interface, Enum, Type, Union | DEFINES_METHOD | Method |
+| Module | IMPORTS | Module, ExternalModule |
 | Module | EXPORTS | Class, Function |
 | Module | EXPORTS_MODULE | ModuleInterface |
 | Module | IMPLEMENTS_MODULE | ModuleImplementation |
-| Class | INHERITS | Class |
-| Class | IMPLEMENTS | Interface |
-| Method | OVERRIDES | Method |
+| Class, Interface, Function | INHERITS | Class, Interface, Function, ExternalModule |
+| Class, Enum | IMPLEMENTS | Interface, Class, Enum, ExternalModule |
+| Method, Function | OVERRIDES | Method |
 | ModuleImplementation | IMPLEMENTS | ModuleInterface |
 | Project | DEPENDS_ON_EXTERNAL | ExternalPackage |
-| Function, Method | CALLS | Function, Method |
+| Module, Function, Method | CALLS | Function, Method, Enum, Type |
+| Module, Function, Method | REFERENCES | Function, Method, Class |
+| Module, Function, Method | INSTANTIATES | Class |
 | Module, Function, Method | READS_FROM | Resource |
 | Module, Function, Method | WRITES_TO | Resource |
 | Module, Function, Method, Resource | FLOWS_TO | Module, Function, Method, Resource |
+| Module | IMPLEMENTS_PATTERN | Pattern |
+| Module | HAS_SMELL | CodeSmell |
+| Module | HAS_VULNERABILITY | SecurityIssue |
+
+`REFERENCES` records a non-call mention of a callable or class (a function passed as a value, a callback stored in a dict). `INSTANTIATES` records a class being constructed. Both belong to the default `calls` capture group. The findings relationships (`IMPLEMENTS_PATTERN`, `HAS_SMELL`, `HAS_VULNERABILITY`) are opt-in with the `findings` capture group.
 
 ## I/O and Data-Flow Edges
 
@@ -73,7 +88,7 @@ See [I/O and Data-Flow Edges](data-flow-edges.md) for the detailed reference: th
 
 A function or class defined inside another function or method (a closure or a function-local class) is attached by `DEFINES` to its **enclosing scope**, not flattened onto the Module. So `DEFINES` can originate from a `Function` or `Method` as well as a `Module`. A top-level function or class is still defined by its `Module`.
 
-Methods and classes defined inside function bodies are captured only when `CGR_CAPTURE_LOCAL_DEFINITIONS` is enabled (see [Configuration](../getting-started/configuration.md)); function-local *classes* are captured by default, but their methods require the flag.
+Methods of classes defined inside function bodies are captured only when `CGR_CAPTURE_LOCAL_DEFINITIONS` is enabled, which is the default (see [Configuration](../getting-started/configuration.md)); function-local *classes* are always captured, and setting the flag to `false` skips their methods.
 
 ## Qualified Name Uniqueness
 
@@ -90,118 +105,27 @@ Macro definitions map onto the existing `Function` label rather than a dedicated
 Language notes:
 
 - **Rust**: macros and functions live in separate namespaces, so a macro invocation (`write!`) never binds a same-named `fn` and a function call never binds a same-named macro. `#[macro_export]` sets `is_exported` (macros take no `pub`).
-- **C/C++** (libclang frontend): compiler builtins, system-header macros, and empty-bodied object-like macros (include guards, feature flags) are not nodes. A macro use inside a function body emits `CALLS` from that function; a use outside any function attributes to the `Module`. A macro whose definition body references another macro emits a macro-to-macro `CALLS` edge, since nested expansions are never reported as individual uses.
-- **C/C++ hybrid mode** (`CPP_FRONTEND=hybrid`): tree-sitter remains the backbone (every file gets its tree-sitter definitions and calls; nothing is skipped) and libclang layers on only macro `Function` nodes and `#include` `IMPORTS` edges, whose qualified names are identical between the two schemes. Macro uses are attributed to the tightest enclosing tree-sitter definition span after the definition pass, so macro `CALLS` edges join the qualified-name scheme the rest of the graph uses.
+- **C/C++** (macro semantics, shared by the libclang-backed modes): compiler builtins, system-header macros, and empty-bodied object-like macros (include guards, feature flags) are not nodes. A macro use inside a function body emits `CALLS` from that function; a use outside any function attributes to the `Module`. A macro whose definition body references another macro emits a macro-to-macro `CALLS` edge, since nested expansions are never reported as individual uses.
+- **C/C++ hybrid mode** (the default: `CPP_FRONTEND=hybrid`; `libclang` forces the pure libclang frontend and `treesitter` disables libclang entirely): tree-sitter remains the backbone (every file gets its tree-sitter definitions and calls; nothing is skipped) and libclang layers on only macro `Function` nodes and `#include` `IMPORTS` edges, whose qualified names are identical between the two schemes. Macro uses are attributed to the tightest enclosing tree-sitter definition span after the definition pass, so macro `CALLS` edges join the qualified-name scheme the rest of the graph uses.
 - **C# hybrid mode** (the default: `CSHARP_FRONTEND=auto` runs it wherever `dotnet` is on PATH, falling back to pure tree-sitter otherwise; `hybrid`/`roslyn` force it, `treesitter` disables it): tree-sitter remains the backbone and a bundled Roslyn tool (requires `dotnet`) layers on location-keyed semantic facts. Base lists get exact `INHERITS`-vs-`IMPLEMENTS` classification; each invocation site gets the compiler's own overload resolution (argument types, not arity) and extension-method binding, overriding the syntactic heuristics per call; `partial` types merge by symbol identity instead of the directory heuristic; and LINQ query-syntax operators that resolve to first-party methods emit `CALLS` edges tree-sitter cannot see (query syntax has no invocation nodes). Source generators run inside the workspace compilation, so resolution through generated members works, but generated code has no repo file and gets no nodes. Any missing fact degrades to the tree-sitter heuristic for that site.
 
 ## Language-Specific AST Mappings
 
-### C++
+The function- and class-defining AST node types captured per language (auto-generated from the language specs):
 
-- `class_specifier`
-- `declaration`
-- `enum_specifier`
-- `field_declaration`
-- `function_definition`
-- `lambda_expression`
-- `struct_specifier`
-- `template_declaration`
-- `union_specifier`
-
-### Java
-
-- `annotation_type_declaration`
-- `class_declaration`
-- `constructor_declaration`
-- `enum_declaration`
-- `interface_declaration`
-- `method_declaration`
-- `record_declaration`
-
-### JavaScript
-
-- `arrow_function`
-- `class`
-- `class_declaration`
-- `function_declaration`
-- `function_expression`
-- `generator_function_declaration`
-- `method_definition`
-
-### Lua
-
-- `function_declaration`
-- `function_definition`
-
-### Python
-
-- `class_definition`
-- `function_definition`
-
-### Rust
-
-- `closure_expression`
-- `enum_item`
-- `function_item`
-- `function_signature_item`
-- `impl_item`
-- `macro_definition`
-- `struct_item`
-- `trait_item`
-- `type_item`
-- `union_item`
-
-### TypeScript
-
-- `abstract_class_declaration`
-- `arrow_function`
-- `class`
-- `class_declaration`
-- `enum_declaration`
-- `function_declaration`
-- `function_expression`
-- `function_signature`
-- `generator_function_declaration`
-- `interface_declaration`
-- `internal_module`
-- `method_definition`
-- `type_alias_declaration`
-
-### C#
-
-- `anonymous_method_expression`
-- `class_declaration`
-- `constructor_declaration`
-- `destructor_declaration`
-- `enum_declaration`
-- `function_pointer_type`
-- `interface_declaration`
-- `lambda_expression`
-- `local_function_statement`
-- `method_declaration`
-- `struct_declaration`
-
-### Go
-
-- `function_declaration`
-- `method_declaration`
-- `type_declaration`
-
-### PHP
-
-- `anonymous_function`
-- `arrow_function`
-- `class_declaration`
-- `enum_declaration`
-- `function_definition`
-- `function_static_declaration`
-- `interface_declaration`
-- `trait_declaration`
-
-### Scala
-
-- `class_definition`
-- `function_declaration`
-- `function_definition`
-- `object_definition`
-- `trait_definition`
+<!-- SECTION:language_mappings -->
+- **C**: `enum_specifier`, `function_definition`, `struct_specifier`, `union_specifier`
+- **C#**: `class_declaration`, `constructor_declaration`, `conversion_operator_declaration`, `destructor_declaration`, `enum_declaration`, `interface_declaration`, `local_function_statement`, `method_declaration`, `operator_declaration`, `property_declaration`, `record_declaration`, `struct_declaration`
+- **C++**: `class_specifier`, `declaration`, `enum_specifier`, `field_declaration`, `function_definition`, `lambda_expression`, `struct_specifier`, `template_declaration`, `union_specifier`
+- **Dart**: `class_definition`, `constant_constructor_signature`, `constructor_signature`, `enum_declaration`, `extension_declaration`, `extension_type_declaration`, `factory_constructor_signature`, `function_signature`, `getter_signature`, `mixin_declaration`, `setter_signature`
+- **Go**: `function_declaration`, `method_declaration`, `type_alias`, `type_spec`
+- **Java**: `annotation_type_declaration`, `class_declaration`, `constructor_declaration`, `enum_declaration`, `interface_declaration`, `method_declaration`, `record_declaration`
+- **JavaScript**: `arrow_function`, `class`, `class_declaration`, `function_declaration`, `function_expression`, `generator_function_declaration`, `method_definition`
+- **Lua**: `function_declaration`, `function_definition`
+- **PHP**: `anonymous_function`, `arrow_function`, `class_declaration`, `enum_declaration`, `function_definition`, `interface_declaration`, `method_declaration`, `trait_declaration`
+- **Python**: `class_definition`, `function_definition`
+- **Rust**: `closure_expression`, `enum_item`, `function_item`, `function_signature_item`, `impl_item`, `macro_definition`, `struct_item`, `trait_item`, `type_item`, `union_item`
+- **TypeScript (TSX)**: `abstract_class_declaration`, `arrow_function`, `class`, `class_declaration`, `enum_declaration`, `function_declaration`, `function_expression`, `function_signature`, `generator_function_declaration`, `interface_declaration`, `internal_module`, `method_definition`, `type_alias_declaration`
+- **TypeScript**: `abstract_class_declaration`, `arrow_function`, `class`, `class_declaration`, `enum_declaration`, `function_declaration`, `function_expression`, `function_signature`, `generator_function_declaration`, `interface_declaration`, `internal_module`, `method_definition`, `type_alias_declaration`
+- **Scala**: `class_definition`, `function_declaration`, `function_definition`, `object_definition`, `trait_definition`
+<!-- /SECTION:language_mappings -->

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -14,7 +14,7 @@ A Tree-sitter based parsing system that analyses codebases and ingests data into
 
 - Uses Tree-sitter for robust, language-agnostic AST parsing
 - Extracts functions, classes, methods, modules, and their relationships
-- Supports 11 programming languages with a unified graph schema
+- Supports 13 programming languages with a unified graph schema (plus Scala in development)
 - Handles complex patterns like nested functions, class hierarchies, and cross-module calls
 
 ### 2. RAG System (`codebase_rag/`)

--- a/docs/claude-code-setup.md
+++ b/docs/claude-code-setup.md
@@ -69,9 +69,14 @@ docker run -p 7687:7687 -p 7444:7444 memgraph/memgraph-platform
 ## Available Tools
 
 - **index_repository** - Build knowledge graph (clears previous repository data)
+- **update_repository** - Incrementally refresh the graph for changed files
+- **list_projects / delete_project / wipe_database** - Manage indexed projects
 - **query_code_graph** - Natural language queries
 - **get_code_snippet** - Retrieve code by name
 - **surgical_replace_code** - Precise code edits
+- **structural_search / structural_replace** - AST-pattern search and rewrite (registered when ast-grep support is available)
+- **semantic_search** - Embedding-based search (registered when the `semantic` extra and a vector store are available)
+- **ask_agent** - Delegate a question to the full agentic CLI loop
 - **read_file / write_file** - File operations
 - **list_directory** - Browse directories
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -40,7 +40,7 @@ pre-commit autoupdate
 
 ```bash
 make lint          # Lint check
-make format        # Format check
+make format        # Apply formatting (ruff format writes files; CI uses ruff format --check)
 make typecheck     # Type check
 make test-parallel # Unit tests in parallel
 make test-integration  # Integration tests (requires Docker)

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -81,7 +81,7 @@ Get your MiniMax API key from the [MiniMax Platform](https://platform.minimax.io
 
 | Variable | Description |
 |----------|-------------|
-| `ORCHESTRATOR_PROVIDER` | Provider name (`google`, `openai`, `ollama`, `minimax`) |
+| `ORCHESTRATOR_PROVIDER` | Provider name (`google`, `openai`, `anthropic`, `azure`, `ollama`, `minimax`, `litellm_proxy`) |
 | `ORCHESTRATOR_MODEL` | Model ID (e.g., `gemini-2.5-pro`, `gpt-4o`, `llama3.2`) |
 | `ORCHESTRATOR_API_KEY` | API key for the provider (if required) |
 | `ORCHESTRATOR_ENDPOINT` | Custom endpoint URL (if required) |
@@ -95,7 +95,7 @@ Get your MiniMax API key from the [MiniMax Platform](https://platform.minimax.io
 
 | Variable | Description |
 |----------|-------------|
-| `CYPHER_PROVIDER` | Provider name (`google`, `openai`, `ollama`, `minimax`) |
+| `CYPHER_PROVIDER` | Provider name (`google`, `openai`, `anthropic`, `azure`, `ollama`, `minimax`, `litellm_proxy`) |
 | `CYPHER_MODEL` | Model ID (e.g., `gemini-2.5-flash`, `gpt-4o-mini`, `codellama`) |
 | `CYPHER_API_KEY` | API key for the provider (if required) |
 | `CYPHER_ENDPOINT` | Custom endpoint URL (if required) |
@@ -115,8 +115,8 @@ Get your MiniMax API key from the [MiniMax Platform](https://platform.minimax.io
 | `LAB_PORT` | `3000` | Memgraph Lab port |
 | `MEMGRAPH_BATCH_SIZE` | `1000` | Batch size for Memgraph operations |
 | `TARGET_REPO_PATH` | `.` | Default repository path |
-| `CGR_CAPTURE_LOCAL_DEFINITIONS` | `false` | Capture classes/methods defined inside function bodies (function-local definitions). Off by default to keep the graph free of throwaway helpers and test mocks; enable for exhaustive structure capture. |
-| `LOCAL_MODEL_ENDPOINT` | `http://localhost:11434/v1` | Fallback endpoint for Ollama |
+| `CGR_CAPTURE_LOCAL_DEFINITIONS` | `true` | Capture methods of classes defined inside function bodies (function-local definitions). On by default for exhaustive structure capture; set to `false` to keep the graph free of throwaway helpers and test mocks. |
+| `OLLAMA_BASE_URL` | `http://localhost:11434` | Base URL for the local Ollama server (`/v1` is appended for the OpenAI-compatible endpoint) |
 
 ## Setting Up Ollama
 

--- a/docs/guide/mcp-server.md
+++ b/docs/guide/mcp-server.md
@@ -50,7 +50,7 @@ git clone https://github.com/vitali87/code-graph-rag.git
 cd code-graph-rag
 uv sync
 
-docker run -p 7687:7687 -p 7444:7444 memgraph/memgraph-platform
+cgr daemon up
 ```
 
 ## Available Tools

--- a/docs/guide/realtime-updates.md
+++ b/docs/guide/realtime-updates.md
@@ -59,4 +59,4 @@ cgr start --repo-path ~/my-project
 
 ## Performance Note
 
-The updater currently recalculates all CALLS relationships on every file change to ensure consistency. This prevents "island" problems where changes in one file aren't reflected in relationships from other files, but may impact performance on very large codebases with frequent changes. Optimisation of this behaviour is a work in progress.
+The updater batches rapid saves with a debounce window and recalculates all CALLS relationships on every processed change to ensure consistency. This prevents "island" problems where changes in one file aren't reflected in relationships from other files, but may impact performance on very large codebases with frequent changes. Optimisation of this behaviour is a work in progress.

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ Code-Graph-RAG is an accurate Retrieval-Augmented Generation (RAG) system that a
 
 ```bash
 pip install code-graph-rag
-docker compose up -d
+cgr daemon up
 cgr start --repo-path ./my-project --update-graph --clean
 ```
 

--- a/scripts/generate_readme.py
+++ b/scripts/generate_readme.py
@@ -11,6 +11,7 @@ PROJECT_ROOT = Path(__file__).parent.parent
 TARGET_FILES = (
     "README.md",
     "docs/architecture/language-support.md",
+    "docs/architecture/graph-schema.md",
     "docs/guide/mcp-server.md",
     "docs/guide/interactive-querying.md",
     "docs/getting-started/installation.md",

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.422"
+version = "0.0.423"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Full docs-vs-code audit: every markdown page under docs/ plus README, PYPI_README, and CONTRIBUTING was read and each verifiable claim checked against the current code. This PR fixes all confirmed drift.

### Wrong facts fixed
- configuration.md: `CGR_CAPTURE_LOCAL_DEFINITIONS` documented as default `false` with inverted semantics; the code default is `true` (config.py). The nonexistent `LOCAL_MODEL_ENDPOINT` variable is replaced with the real `OLLAMA_BASE_URL`.
- graph-schema.md: `ExternalPackage` had a phantom `version_spec` property; `ExternalModule`, findings nodes (`Pattern`, `CodeSmell`, `SecurityIssue`), `REFERENCES`, `INSTANTIATES`, and the findings relationships were missing; node property lists and relationship source/target sets now match `NODE_SCHEMAS`/`RELATIONSHIP_SCHEMAS` in types_defs.py exactly; the C/C++ hybrid frontend is now correctly described as the default.
- data-flow-edges.md: the "registry is Python-only" limitation is stale; it now lists the real per-language coverage (Python, JS/TS/TSX, Go, Java, Rust, C, C++, C#) and corrects the STDIN/STDERR emission claim.
- adding-languages.md and troubleshooting.md: `language_config.py` does not exist; all references now point to `language_spec.py`, the config example uses the real `LanguageSpec(language=...)` shape, and the invented "compiles bindings" step is gone.

### Stale content refreshed
- overview.md language count (11 → 13), PYPI_README grammar list (missing C, PHP, C#, Dart) and provider list, configuration.md provider lists (missing `anthropic`, `azure`, `litellm_proxy`).
- index.md and mcp-server.md prerequisites now use `cgr daemon up` instead of a `docker compose`/`docker run` invocation that fails for pip-installed users.
- claude-code-setup.md tool list now covers all registered MCP tools.
- README supported-languages paragraph now mentions Ruby's structural support via the ast-grep tier, matching the Latest News entry.
- docs/TODO.md: removed type-inference items that are already implemented (C++/Rust/Go engines, Java generics and `var`, Python generics); kept the genuinely open TS/JS gaps.
- contributing docs: `make format` is labeled as applying formatting, not checking it.

### Root-cause fix
- The hand-maintained "Language-Specific AST Mappings" section in graph-schema.md (stale for Go/C#/PHP, missing C and Dart) is replaced with the auto-generated `language_mappings` SECTION block, and graph-schema.md is added to the generate-readme hook targets so it can never drift again.

## Test plan
- `uv run pre-commit run` passes (including the generate-readme hook)
- `pytest -n auto -m "not integration"`: 5377 passed, 5 skipped