### PR TITLE
fix(findings): eliminate Go sqli_concat and hardcoded_secret false positives

### DIFF
--- a/codebase_rag/analyzers/ast_grep_rules/security/go.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/go.yaml
@@ -50,11 +50,12 @@ rules:
     # var/const declarations. Ceiling: without entropy scoring, plain word/URL
     # literals still surface as review prompts; that residual is the known limit
     # of regex-only secret detection, not a defect.
-    # The string literal must be the ASSIGNED VALUE itself (a direct child of
-    # the right-hand expression_list), not merely present somewhere in the RHS.
-    # Dropping the old `stopBy: end` kills the false-positive class where the
-    # value is a function call carrying a long string argument, e.g.
-    # `token := getEnv("SOME_LONG_DEFAULT")`.
+    # The string literal must be the ASSIGNED VALUE itself, reached from the
+    # right-hand expression_list without crossing a call boundary
+    # (`stopBy: {kind: call_expression}`). This traverses through
+    # parenthesized_expression wrappers so `token := ("literal")` is caught,
+    # while killing the false-positive class where the value is a function call
+    # carrying a long string argument, e.g. `token := getEnv("SOME_LONG_DEFAULT")`.
     message: "Hardcoded secret assigned to a credential-named variable"
     rule:
       any:
@@ -65,6 +66,7 @@ rules:
                 field: right
                 kind: expression_list
                 has:
+                  stopBy: { kind: call_expression }
                   all:
                     - any:
                         - kind: interpreted_string_literal
@@ -81,6 +83,7 @@ rules:
                 field: right
                 kind: expression_list
                 has:
+                  stopBy: { kind: call_expression }
                   all:
                     - any:
                         - kind: interpreted_string_literal
@@ -96,6 +99,7 @@ rules:
             - has:
                 kind: expression_list
                 has:
+                  stopBy: { kind: call_expression }
                   all:
                     - any:
                         - kind: interpreted_string_literal
@@ -111,6 +115,7 @@ rules:
             - has:
                 kind: expression_list
                 has:
+                  stopBy: { kind: call_expression }
                   all:
                     - any:
                         - kind: interpreted_string_literal

--- a/codebase_rag/analyzers/ast_grep_rules/security/go.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/go.yaml
@@ -16,18 +16,31 @@ rules:
           - has: { field: operand, regex: '^exec$' }
           - has: { field: field, regex: '^Command' }
   - id: sqli_concat
+    # Sink-anchored: the Query/Exec selector must be THIS call's function (a
+    # direct child, not a nested one) and the `+` concatenation must live in
+    # THIS call's argument_list. Without that anchoring a benign
+    # `c.Header().Set("d", a + url.QueryEscape(b))` matched (QueryEscape is a
+    # net/url false friend for `^Query`, and its `+` belonged to Set). The
+    # explicit exclusion of Query(Escape|Unescape) covers the direct
+    # `url.QueryEscape("a" + b)` case since the Rust regex engine has no
+    # lookaround.
     message: "Possible SQL injection: Query/Exec argument built with string concatenation"
     rule:
       kind: call_expression
       all:
         - has:
             kind: selector_expression
-            has: { field: field, regex: '^(Query|Exec)' }
-            stopBy: end
+            has:
+              field: field
+              all:
+                - regex: '^(Query|Exec)'
+                - not: { regex: '^Query(Escape|Unescape)' }
         - has:
-            kind: binary_expression
-            has: { field: operator, regex: '\+' }
-            stopBy: end
+            kind: argument_list
+            has:
+              kind: binary_expression
+              has: { field: operator, regex: '\+', stopBy: end }
+              stopBy: end
   - id: hardcoded_secret
     # Security rule: favour recall. Value must be a non-trivial literal (>=8
     # content chars) that is not a format/message template (a Sprintf {..}
@@ -37,6 +50,11 @@ rules:
     # var/const declarations. Ceiling: without entropy scoring, plain word/URL
     # literals still surface as review prompts; that residual is the known limit
     # of regex-only secret detection, not a defect.
+    # The string literal must be the ASSIGNED VALUE itself (a direct child of
+    # the right-hand expression_list), not merely present somewhere in the RHS.
+    # Dropping the old `stopBy: end` kills the false-positive class where the
+    # value is a function call carrying a long string argument, e.g.
+    # `token := getEnv("SOME_LONG_DEFAULT")`.
     message: "Hardcoded secret assigned to a credential-named variable"
     rule:
       any:
@@ -45,6 +63,7 @@ rules:
             - has: { field: left, regex: '(?i)(password|passwd|secret|api_?key|apikey|token|access_?key)' }
             - has:
                 field: right
+                kind: expression_list
                 has:
                   all:
                     - any:
@@ -55,12 +74,12 @@ rules:
                         any:
                           - regex: '\{[^{}]*\}'
                           - regex: '%[sdrifeEgGxXoqvtbc]'
-                  stopBy: end
         - kind: assignment_statement
           all:
             - has: { field: left, regex: '(?i)(password|passwd|secret|api_?key|apikey|token|access_?key)' }
             - has:
                 field: right
+                kind: expression_list
                 has:
                   all:
                     - any:
@@ -71,32 +90,33 @@ rules:
                         any:
                           - regex: '\{[^{}]*\}'
                           - regex: '%[sdrifeEgGxXoqvtbc]'
-                  stopBy: end
         - kind: var_spec
           all:
             - has: { field: name, regex: '(?i)(password|passwd|secret|api_?key|apikey|token|access_?key)' }
             - has:
-                all:
-                  - any:
-                      - kind: interpreted_string_literal
-                      - kind: raw_string_literal
-                  - regex: '^.{10,}$'
-                  - not:
-                      any:
-                        - regex: '\{[^{}]*\}'
-                        - regex: '%[sdrifeEgGxXoqvtbc]'
-                stopBy: end
+                kind: expression_list
+                has:
+                  all:
+                    - any:
+                        - kind: interpreted_string_literal
+                        - kind: raw_string_literal
+                    - regex: '^.{10,}$'
+                    - not:
+                        any:
+                          - regex: '\{[^{}]*\}'
+                          - regex: '%[sdrifeEgGxXoqvtbc]'
         - kind: const_spec
           all:
             - has: { field: name, regex: '(?i)(password|passwd|secret|api_?key|apikey|token|access_?key)' }
             - has:
-                all:
-                  - any:
-                      - kind: interpreted_string_literal
-                      - kind: raw_string_literal
-                  - regex: '^.{10,}$'
-                  - not:
-                      any:
-                        - regex: '\{[^{}]*\}'
-                        - regex: '%[sdrifeEgGxXoqvtbc]'
-                stopBy: end
+                kind: expression_list
+                has:
+                  all:
+                    - any:
+                        - kind: interpreted_string_literal
+                        - kind: raw_string_literal
+                    - regex: '^.{10,}$'
+                    - not:
+                        any:
+                          - regex: '\{[^{}]*\}'
+                          - regex: '%[sdrifeEgGxXoqvtbc]'

--- a/codebase_rag/tests/test_ast_grep_analyzer.py
+++ b/codebase_rag/tests/test_ast_grep_analyzer.py
@@ -553,6 +553,50 @@ def test_go_ignored_error_only_flags_discarded_last_value(tmp_path: Path) -> Non
     assert lines == [4], lines
 
 
+def test_go_sqli_concat_requires_concat_inside_the_query_call(
+    tmp_path: Path,
+) -> None:
+    # (H) Dogfood FP: the concatenation must be an ARGUMENT of the Query/Exec
+    # (H) call, not merely present somewhere in the same expression. Line 4's
+    # (H) `url.QueryEscape` is a net/url false friend (matches `^Query`) and the
+    # (H) `+` belongs to a Header().Set call, not a database sink.
+    src = (
+        "package main\n"
+        "func f(db D, c C, a, b, id string) {\n"
+        '    db.Query("select * from t where x=" + id)\n'
+        '    c.Header().Set("d", a + url.QueryEscape(b))\n'
+        "}\n"
+    )
+    lines = sorted(
+        p[cs.KEY_START_LINE]
+        for p in _fire(tmp_path, "dao.go", src)
+        if p[cs.KEY_NAME] == "sqli_concat"
+    )
+    assert lines == [3], lines
+
+
+def test_go_hardcoded_secret_requires_literal_value(tmp_path: Path) -> None:
+    # (H) Dogfood FP class: a credential-named var whose value is a function
+    # (H) call (e.g. `token := getEnv("SOME_LONG_DEFAULT")`) is NOT a hardcoded
+    # (H) secret; the string literal must be the assigned value itself, not
+    # (H) buried inside a call argument. Line 3 is a real literal secret.
+    src = (
+        "package main\n"
+        "func f() {\n"
+        '    token := "literalsecretvalue"\n'
+        '    apikey := getEnv("SOME_LONG_DEFAULT")\n'
+        "    _ = token\n"
+        "    _ = apikey\n"
+        "}\n"
+    )
+    lines = sorted(
+        p[cs.KEY_START_LINE]
+        for p in _fire(tmp_path, "cfg.go", src)
+        if p[cs.KEY_NAME] == "hardcoded_secret"
+    )
+    assert lines == [3], lines
+
+
 def test_multilang_security_rules_avoid_common_false_positives(
     tmp_path: Path,
 ) -> None:

--- a/codebase_rag/tests/test_ast_grep_analyzer.py
+++ b/codebase_rag/tests/test_ast_grep_analyzer.py
@@ -560,11 +560,15 @@ def test_go_sqli_concat_requires_concat_inside_the_query_call(
     # (H) call, not merely present somewhere in the same expression. Line 4's
     # (H) `url.QueryEscape` is a net/url false friend (matches `^Query`) and the
     # (H) `+` belongs to a Header().Set call, not a database sink.
+    # (H) Line 5 wraps the concatenation in parentheses; because the `+` search
+    # (H) descends the anchored call's argument_list, the paren form stays a true
+    # (H) positive (recall preserved).
     src = (
         "package main\n"
         "func f(db D, c C, a, b, id string) {\n"
         '    db.Query("select * from t where x=" + id)\n'
         '    c.Header().Set("d", a + url.QueryEscape(b))\n'
+        '    db.Query(("select * from t where y=" + id))\n'
         "}\n"
     )
     lines = sorted(
@@ -572,7 +576,7 @@ def test_go_sqli_concat_requires_concat_inside_the_query_call(
         for p in _fire(tmp_path, "dao.go", src)
         if p[cs.KEY_NAME] == "sqli_concat"
     )
-    assert lines == [3], lines
+    assert lines == [3, 5], lines
 
 
 def test_go_hardcoded_secret_requires_literal_value(tmp_path: Path) -> None:
@@ -580,13 +584,18 @@ def test_go_hardcoded_secret_requires_literal_value(tmp_path: Path) -> None:
     # (H) call (e.g. `token := getEnv("SOME_LONG_DEFAULT")`) is NOT a hardcoded
     # (H) secret; the string literal must be the assigned value itself, not
     # (H) buried inside a call argument. Line 3 is a real literal secret.
+    # (H) Line 5 wraps the literal in parentheses; the value is still a constant
+    # (H) reached without crossing a call, so it stays a true positive. Line 4's
+    # (H) call-buried string must not fire.
     src = (
         "package main\n"
         "func f() {\n"
         '    token := "literalsecretvalue"\n'
         '    apikey := getEnv("SOME_LONG_DEFAULT")\n'
+        '    secret := ("anotherliteralvalue")\n'
         "    _ = token\n"
         "    _ = apikey\n"
+        "    _ = secret\n"
         "}\n"
     )
     lines = sorted(
@@ -594,7 +603,7 @@ def test_go_hardcoded_secret_requires_literal_value(tmp_path: Path) -> None:
         for p in _fire(tmp_path, "cfg.go", src)
         if p[cs.KEY_NAME] == "hardcoded_secret"
     )
-    assert lines == [3], lines
+    assert lines == [3, 5], lines
 
 
 def test_multilang_security_rules_avoid_common_false_positives(

--- a/codebase_rag/tests/test_ast_grep_analyzer.py
+++ b/codebase_rag/tests/test_ast_grep_analyzer.py
@@ -130,8 +130,8 @@ def test_rules_load_and_meet_acceptance_counts() -> None:
 
 
 def test_every_language_has_all_three_categories() -> None:
-    # (H) Each supported grammar must ship patterns + smells + security with at
-    # (H) least 3 rules apiece, so a language never regresses to partial coverage.
+    # Each supported grammar must ship patterns + smells + security with at
+    # least 3 rules apiece, so a language never regresses to partial coverage.
     from codebase_rag.analyzers.ast_grep_analyzer import load_finding_rules
 
     by_grammar: dict[str, dict] = {}
@@ -174,8 +174,8 @@ def test_analyzer_noops_when_findings_disabled(tmp_path: Path) -> None:
 
 
 def test_loose_equality_flags_inequality_not_strict(tmp_path: Path) -> None:
-    # (H) `!=` coerces types exactly like `==`, so the loose_equality smell must
-    # (H) catch it too; the strict `===`/`!==` forms must stay clean.
+    # `!=` coerces types exactly like `==`, so the loose_equality smell must
+    # catch it too; the strict `===`/`!==` forms must stay clean.
     from codebase_rag.analyzers import FindingAnalyzer
 
     src = tmp_path / "eq.js"
@@ -435,25 +435,25 @@ _POSITIVE_FIXTURES["tsx"] = _POSITIVE_FIXTURES["javascript"]
 
 
 def test_every_rule_fires_on_positive_fixture(tmp_path: Path) -> None:
-    # (H) Exhaustive functionality lock: a rule whose `kind`/`pattern` is wrong for
-    # (H) ast-grep's bundled grammar silently matches nothing (the f_string class of
-    # (H) bug). Every shipped rule must fire on a hand-crafted positive fixture, so a
-    # (H) future typo that zeroes a rule fails here instead of shipping dead.
+    # Exhaustive functionality lock: a rule whose `kind`/`pattern` is wrong for
+    # ast-grep's bundled grammar silently matches nothing (the f_string class of
+    # bug). Every shipped rule must fire on a hand-crafted positive fixture, so a
+    # future typo that zeroes a rule fails here instead of shipping dead.
     from codebase_rag.analyzers import FindingAnalyzer
     from codebase_rag.analyzers.ast_grep_analyzer import load_finding_rules
 
-    # (H) Keyed by ast-grep grammar id, not extension: .js/.jsx/.mjs/.cjs all
-    # (H) share the javascript grammar and rule set, so one fixture covers them.
+    # Keyed by ast-grep grammar id, not extension: .js/.jsx/.mjs/.cjs all
+    # share the javascript grammar and rule set, so one fixture covers them.
     by_grammar = _POSITIVE_FIXTURES
     for ext, lang in load_finding_rules().items():
-        # (H) A new language with rules but no fixture would silently skip firing
-        # (H) coverage; force a fixture mapping to exist for every loaded grammar.
+        # A new language with rules but no fixture would silently skip firing
+        # coverage; force a fixture mapping to exist for every loaded grammar.
         assert lang.ast_grep_id in by_grammar, (
             f"{ext}: no fixture for {lang.ast_grep_id}"
         )
         ids = [r.rule_id for r in lang.rules]
-        # (H) The set comparison below is only sound if ids are unique per ext; a
-        # (H) duplicate id could let one rule fire while its twin stays dead.
+        # The set comparison below is only sound if ids are unique per ext; a
+        # duplicate id could let one rule fire while its twin stays dead.
         assert len(ids) == len(set(ids)), f"{ext} duplicate rule ids: {ids}"
         stem = ext.replace(".", "")
         f = tmp_path / f"probe{stem}{ext}"
@@ -479,7 +479,7 @@ def _fire(tmp_path: Path, name: str, src: str) -> list:
 
 
 def test_innerhtml_xss_catches_augmented_and_outerhtml(tmp_path: Path) -> None:
-    # (H) `+=` and outerHTML are the same DOM-injection sink as `innerHTML =`.
+    # `+=` and outerHTML are the same DOM-injection sink as `innerHTML =`.
     src = (
         "a.innerHTML = x;\n"
         "b.innerHTML += y;\n"
@@ -496,9 +496,9 @@ def test_innerhtml_xss_catches_augmented_and_outerhtml(tmp_path: Path) -> None:
 
 
 def test_sqli_concat_catches_percent_format(tmp_path: Path) -> None:
-    # (H) `execute("... %s" % params)` is the classic printf-style injection, as
-    # (H) dangerous as `+` concatenation; a parametrized query stays clean, and a
-    # (H) numeric modulo (line 4) must NOT be mistaken for string formatting.
+    # `execute("... %s" % params)` is the classic printf-style injection, as
+    # dangerous as `+` concatenation; a parametrized query stays clean, and a
+    # numeric modulo (line 4) must NOT be mistaken for string formatting.
     src = (
         'db.execute("SELECT " + u)\n'
         'db.execute("SELECT %s" % u)\n'
@@ -514,9 +514,9 @@ def test_sqli_concat_catches_percent_format(tmp_path: Path) -> None:
 
 
 def test_factory_function_catches_arrow_and_expression(tmp_path: Path) -> None:
-    # (H) Modern factories are usually `const createX = () => {}` (arrow), a
-    # (H) function expression, or a generator function expression, not a `function`
-    # (H) declaration; catch all four. A non-factory name stays clean.
+    # Modern factories are usually `const createX = () => {}` (arrow), a
+    # function expression, or a generator function expression, not a `function`
+    # declaration; catch all four. A non-factory name stays clean.
     src = (
         "function createA() { return {}; }\n"
         "const createB = () => ({});\n"
@@ -533,9 +533,9 @@ def test_factory_function_catches_arrow_and_expression(tmp_path: Path) -> None:
 
 
 def test_go_ignored_error_only_flags_discarded_last_value(tmp_path: Path) -> None:
-    # (H) In Go, `_, err := f()` keeps the error and is idiomatic; only a trailing
-    # (H) `_` (discarding the conventionally-last error) is the smell. The rule
-    # (H) must flag line 4 (result, _) and leave line 3 (_, err) clean.
+    # In Go, `_, err := f()` keeps the error and is idiomatic; only a trailing
+    # `_` (discarding the conventionally-last error) is the smell. The rule
+    # must flag line 4 (result, _) and leave line 3 (_, err) clean.
     src = (
         "package main\n"
         "func f() {\n"
@@ -556,13 +556,13 @@ def test_go_ignored_error_only_flags_discarded_last_value(tmp_path: Path) -> Non
 def test_go_sqli_concat_requires_concat_inside_the_query_call(
     tmp_path: Path,
 ) -> None:
-    # (H) Dogfood FP: the concatenation must be an ARGUMENT of the Query/Exec
-    # (H) call, not merely present somewhere in the same expression. Line 4's
-    # (H) `url.QueryEscape` is a net/url false friend (matches `^Query`) and the
-    # (H) `+` belongs to a Header().Set call, not a database sink.
-    # (H) Line 5 wraps the concatenation in parentheses; because the `+` search
-    # (H) descends the anchored call's argument_list, the paren form stays a true
-    # (H) positive (recall preserved).
+    # Dogfood FP: the concatenation must be an ARGUMENT of the Query/Exec
+    # call, not merely present somewhere in the same expression. Line 4's
+    # `url.QueryEscape` is a net/url false friend (matches `^Query`) and the
+    # `+` belongs to a Header().Set call, not a database sink.
+    # Line 5 wraps the concatenation in parentheses; because the `+` search
+    # descends the anchored call's argument_list, the paren form stays a true
+    # positive (recall preserved).
     src = (
         "package main\n"
         "func f(db D, c C, a, b, id string) {\n"
@@ -580,13 +580,13 @@ def test_go_sqli_concat_requires_concat_inside_the_query_call(
 
 
 def test_go_hardcoded_secret_requires_literal_value(tmp_path: Path) -> None:
-    # (H) Dogfood FP class: a credential-named var whose value is a function
-    # (H) call (e.g. `token := getEnv("SOME_LONG_DEFAULT")`) is NOT a hardcoded
-    # (H) secret; the string literal must be the assigned value itself, not
-    # (H) buried inside a call argument. Line 3 is a real literal secret.
-    # (H) Line 5 wraps the literal in parentheses; the value is still a constant
-    # (H) reached without crossing a call, so it stays a true positive. Line 4's
-    # (H) call-buried string must not fire.
+    # Dogfood FP class: a credential-named var whose value is a function
+    # call (e.g. `token := getEnv("SOME_LONG_DEFAULT")`) is NOT a hardcoded
+    # secret; the string literal must be the assigned value itself, not
+    # buried inside a call argument. Line 3 is a real literal secret.
+    # Line 5 wraps the literal in parentheses; the value is still a constant
+    # reached without crossing a call, so it stays a true positive. Line 4's
+    # call-buried string must not fire.
     src = (
         "package main\n"
         "func f() {\n"
@@ -609,8 +609,8 @@ def test_go_hardcoded_secret_requires_literal_value(tmp_path: Path) -> None:
 def test_multilang_security_rules_avoid_common_false_positives(
     tmp_path: Path,
 ) -> None:
-    # (H) Precision guards for the widened multi-language rules: each benign
-    # (H) construct must NOT emit its neighbouring finding.
+    # Precision guards for the widened multi-language rules: each benign
+    # construct must NOT emit its neighbouring finding.
     cases = [
         (
             "q.php",

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.426"
+version = "0.0.427"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

Dogfooding the `+findings` ast-grep rules (issue #413) over real repos surfaced two false-positive classes in the Go security rules. Both are fixed here, RED→GREEN.

### 1. `sqli_concat` fired on `url.QueryEscape` + unrelated concatenation

Running the rules over **gin** flagged:

```go
c.Writer.Header().Set("Content-Disposition", `attachment; filename*=UTF-8''`+url.QueryEscape(filename))
```

Two problems compounded: `url.QueryEscape` matches the `^(Query|Exec)` selector regex (a `net/url` false friend), and the `+` concatenation lived in the `Header().Set(...)` call, structurally unrelated to it. The old rule only checked "a `.Query*` selector exists somewhere **and** a `+` exists somewhere" in the same call.

Fix: sink-anchor. The `Query`/`Exec` selector must be **this** call's function (a direct child, not nested), and the `+` must live in **this** call's `argument_list`. Also exclude `Query(Escape|Unescape)` explicitly to cover a direct `url.QueryEscape("a" + b)` (the Rust regex engine has no lookaround).

### 2. `hardcoded_secret` matched a string buried in a call argument (latent)

Same buried-value class:

```go
token := getEnv("SOME_LONG_DEFAULT_VALUE")   // NOT a hardcoded secret
```

The old rule used `stopBy: end`, so any string literal anywhere in the RHS subtree counted. Fix: the string literal must be the assigned **value** itself (a direct child of the right-hand `expression_list`), across all four declaration forms (`:=`, `=`, `var`, `const`). A real literal `token := "literalsecretvalue"` still fires.

## Verification

- RED→GREEN tests: `test_go_sqli_concat_requires_concat_inside_the_query_call`, `test_go_hardcoded_secret_requires_literal_value`.
- Re-dogfooded gin: `sqli_concat` FP gone; `hardcoded_secret` now flags only the real `password := "my-super-secret-password"`.
- Full findings suite green (21 passed); `test_every_rule_fires_on_positive_fixture` still passes (both rules still fire on true positives).