### PR TITLE
fix: poll for the debounced flush instead of racing the timer thread

### DIFF
--- a/codebase_rag/tests/test_realtime_debounce.py
+++ b/codebase_rag/tests/test_realtime_debounce.py
@@ -201,7 +201,13 @@ class TestCodeChangeEventHandlerDebounce:
         event2 = FileModifiedEvent(str(sample_file))
         handler.dispatch(event2)
 
-        time.sleep(0.15)
+        # The flush runs on a daemon timer thread; a fixed sleep races its
+        # scheduling on loaded CI runners, so poll with a generous deadline.
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if mock_ingestor.flush_all.call_count >= 1:
+                break
+            time.sleep(0.02)
 
         assert mock_ingestor.flush_all.call_count >= 1
 

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.430"
+version = "0.0.432"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
The SonarCloud coverage job on #852 hit a failure in test_max_wait_forces_update: the debounced flush runs on a daemon timer thread that fires at t=0.3s, and the test asserted at a fixed t=0.55s. On a loaded, coverage-instrumented runner the timer thread can start late and miss that 0.25s window, failing with call_count 0. The same test passes in the plain unit-test jobs and locally, which is the signature of a scheduling race, not a product defect.

The fix keeps the scenario identical and replaces the final fixed sleep with a bounded poll (5s deadline, 20ms interval) on the observable condition. No production code changes.