### PR TITLE
feat: link client request URLs to server route handlers across projects

### DIFF
--- a/codebase_rag/constants/graph.py
+++ b/codebase_rag/constants/graph.py
@@ -158,6 +158,8 @@ class RelationshipType(StrEnum):
     READS_FROM = "READS_FROM"
     WRITES_TO = "WRITES_TO"
     FLOWS_TO = "FLOWS_TO"
+    EXPOSES = "EXPOSES"
+    RESOLVES_TO = "RESOLVES_TO"
     IMPLEMENTS_PATTERN = "IMPLEMENTS_PATTERN"
     HAS_SMELL = "HAS_SMELL"
     HAS_VULNERABILITY = "HAS_VULNERABILITY"
@@ -214,6 +216,8 @@ CAPTURE_GROUP_RELS: dict[CaptureGroup, frozenset[RelationshipType]] = {
             RelationshipType.READS_FROM,
             RelationshipType.WRITES_TO,
             RelationshipType.FLOWS_TO,
+            RelationshipType.EXPOSES,
+            RelationshipType.RESOLVES_TO,
         }
     ),
     CaptureGroup.FINDINGS: frozenset(

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -38,6 +38,7 @@ from .parsers.csharp_frontend import (
     find_csharp_project,
     run_csharp_frontend,
 )
+from .parsers.endpoints import link_endpoints
 from .parsers.factory import ProcessorFactory
 from .parsers.utils import sorted_captures
 from .services import FilteringIngestor, IngestorProtocol, QueryProtocol
@@ -1042,9 +1043,25 @@ class GraphUpdater:
         logger.info(ls.ANALYSIS_COMPLETE)
         self.ingestor.flush_all()
 
+        self._link_endpoint_resources()
+
         self._prune_orphan_nodes()
 
         self._generate_semantic_embeddings()
+
+    def _link_endpoint_resources(self) -> None:
+        # After flush_all so this run's Resource nodes are queryable; NETWORK
+        # resources of previously indexed projects join here too, which is
+        # what makes client-URL-to-endpoint edges cross-project (issue #425).
+        # The raw ingestor bypasses the capture filter, so gate explicitly.
+        if not self.capture.rel_enabled(cs.RelationshipType.RESOLVES_TO):
+            return
+        if not isinstance(self.ingestor, QueryProtocol):
+            return
+        created = link_endpoints(self.ingestor)
+        if created:
+            logger.info("Resolved {} client request URLs to endpoints", created)
+            self.ingestor.flush_all()
 
     def _rehydrate_registry_from_graph(self) -> None:
         # Incremental runs populate the function registry only from re-parsed

--- a/codebase_rag/parsers/endpoints.py
+++ b/codebase_rag/parsers/endpoints.py
@@ -1,0 +1,70 @@
+"""Route-decorator parsing and URL/template matching (issue #425 phase 3).
+
+Handler decorators are stored verbatim on Function/Method nodes (e.g.
+``@app.get("/users/{id}")``); this module turns them into
+``(METHOD, /path/template)`` pairs and matches literal client URLs against
+those templates so cross-project request edges can resolve to handlers.
+"""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import urlparse
+
+_HTTP_METHOD_NAMES = frozenset(
+    {"get", "post", "put", "patch", "delete", "head", "options", "websocket"}
+)
+_ROUTE_NAME = "route"
+_DEFAULT_ROUTE_METHOD = "GET"
+
+# ponytail: decorators arrive as raw text, so this is a text parse, not an
+# AST walk. The literal must open the argument list (a leading quote), which
+# rejects computed paths like (prefix + "/users").
+_DECORATOR_CALL_RE = re.compile(
+    r"^@[\w.]*?(?P<name>\w+)\(\s*(?P<quote>['\"])(?P<path>/[^'\"]*)(?P=quote)",
+)
+_METHODS_KWARG_RE = re.compile(r"methods\s*=\s*\[(?P<items>[^\]]*)\]")
+_METHOD_ITEM_RE = re.compile(r"['\"](\w+)['\"]")
+
+
+def parse_route_decorator(decorator_text: str) -> list[tuple[str, str]]:
+    """Return ``(METHOD, path_template)`` pairs for a route decorator.
+
+    Non-route decorators, computed paths, and pathless calls yield ``[]``.
+    """
+    match = _DECORATOR_CALL_RE.match(decorator_text.strip())
+    if match is None:
+        return []
+    name = match.group("name").lower()
+    path = match.group("path")
+    if name in _HTTP_METHOD_NAMES:
+        return [(name.upper(), path)]
+    if name != _ROUTE_NAME:
+        return []
+    methods_match = _METHODS_KWARG_RE.search(decorator_text)
+    if methods_match is None:
+        return [(_DEFAULT_ROUTE_METHOD, path)]
+    methods = _METHOD_ITEM_RE.findall(methods_match.group("items"))
+    return [(m.upper(), path) for m in methods]
+
+
+_TEMPLATE_PARAM_RE = re.compile(r"^\{[^/]+\}$")
+
+
+def url_matches_template(url: str, template: str) -> bool:
+    """Match a literal request URL's path against a route template.
+
+    Template segments like ``{id}`` match exactly one path segment; the
+    comparison ignores scheme, host, port, query, and a trailing slash.
+    """
+    parsed = urlparse(url)
+    if not parsed.scheme or not parsed.netloc:
+        return False
+    url_segments = [s for s in parsed.path.split("/") if s]
+    template_segments = [s for s in template.split("/") if s]
+    if len(url_segments) != len(template_segments):
+        return False
+    return all(
+        _TEMPLATE_PARAM_RE.match(expected) or expected == actual
+        for actual, expected in zip(url_segments, template_segments, strict=True)
+    )

--- a/codebase_rag/parsers/endpoints.py
+++ b/codebase_rag/parsers/endpoints.py
@@ -9,7 +9,7 @@ those templates so cross-project request edges can resolve to handlers.
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 from urllib.parse import urlparse
 
 from .. import constants as cs
@@ -146,12 +146,15 @@ def link_endpoints(ingestor: QueryProtocol) -> int:
         elif kind == ResourceKind.ENDPOINT.value:
             endpoints.append((qn, name))
 
+    # The live ingestor both queries and writes; QueryProtocol alone types
+    # the read side, so the single write goes through an ingestor view.
+    writer = cast("IngestorProtocol", ingestor)
     created = 0
     for network_qn, url in networks:
         for endpoint_qn, identity in endpoints:
             _, _, template = identity.partition(" ")
             if template and url_matches_template(url, template):
-                ingestor.ensure_relationship_batch(
+                writer.ensure_relationship_batch(
                     (cs.NodeLabel.RESOURCE, cs.KEY_QUALIFIED_NAME, network_qn),
                     cs.RelationshipType.RESOLVES_TO,
                     (cs.NodeLabel.RESOURCE, cs.KEY_QUALIFIED_NAME, endpoint_qn),

--- a/codebase_rag/parsers/endpoints.py
+++ b/codebase_rag/parsers/endpoints.py
@@ -17,10 +17,20 @@ from .. import constants as cs
 if TYPE_CHECKING:
     from ..services import IngestorProtocol, QueryProtocol
 
-CYPHER_ALL_RESOURCES = (
-    "MATCH (r:Resource) RETURN r.qualified_name AS qualified_name, "
+# Anchoring on live sink/EXPOSES edges keeps resources whose caller or
+# handler was deleted from relinking; delete-then-relink makes the pass
+# idempotent so changed URLs or routes drop their stale RESOLVES_TO edges.
+CYPHER_LIVE_NETWORK_RESOURCES = (
+    "MATCH ()-[:READS_FROM|WRITES_TO]->(r:Resource {kind: 'NETWORK'}) "
+    "RETURN DISTINCT r.qualified_name AS qualified_name, "
     "r.name AS name, r.kind AS kind"
 )
+CYPHER_LIVE_ENDPOINT_RESOURCES = (
+    "MATCH ()-[:EXPOSES]->(r:Resource {kind: 'ENDPOINT'}) "
+    "RETURN DISTINCT r.qualified_name AS qualified_name, "
+    "r.name AS name, r.kind AS kind"
+)
+CYPHER_DELETE_RESOLVES_TO = "MATCH ()-[r:RESOLVES_TO]->() DELETE r"
 
 _HTTP_METHOD_NAMES = frozenset(
     {"get", "post", "put", "patch", "delete", "head", "options", "websocket"}
@@ -34,7 +44,7 @@ _DEFAULT_ROUTE_METHOD = "GET"
 _DECORATOR_CALL_RE = re.compile(
     r"^@[\w.]*?(?P<name>\w+)\(\s*(?P<quote>['\"])(?P<path>/[^'\"]*)(?P=quote)",
 )
-_METHODS_KWARG_RE = re.compile(r"methods\s*=\s*\[(?P<items>[^\]]*)\]")
+_METHODS_KWARG_RE = re.compile(r"methods\s*=\s*[\[({](?P<items>[^\])}]*)[\])}]")
 _METHOD_ITEM_RE = re.compile(r"['\"](\w+)['\"]")
 
 
@@ -59,7 +69,8 @@ def parse_route_decorator(decorator_text: str) -> list[tuple[str, str]]:
     return [(m.upper(), path) for m in methods]
 
 
-_TEMPLATE_PARAM_RE = re.compile(r"^\{[^/]+\}$")
+# FastAPI-style {id} and Flask-style <user_id> / <int:user_id> variables.
+_TEMPLATE_PARAM_RE = re.compile(r"^(\{[^/]+\}|<[^/]+>)$")
 
 
 def url_matches_template(url: str, template: str) -> bool:
@@ -132,26 +143,27 @@ def link_endpoints(ingestor: QueryProtocol) -> int:
     """
     from .io_access.constants import DYNAMIC_TARGET, KEY_KIND, ResourceKind
 
-    rows = ingestor.fetch_all(CYPHER_ALL_RESOURCES)
-    networks: list[tuple[str, str]] = []
-    endpoints: list[tuple[str, str]] = []
-    for row in rows:
-        qn = row.get(cs.KEY_QUALIFIED_NAME)
-        name = row.get(cs.KEY_NAME)
-        if not isinstance(qn, str) or not isinstance(name, str):
-            continue
-        kind = row.get(KEY_KIND)
-        if kind == ResourceKind.NETWORK.value and name != DYNAMIC_TARGET:
-            networks.append((qn, name))
-        elif kind == ResourceKind.ENDPOINT.value:
-            endpoints.append((qn, name))
+    ingestor.execute_write(CYPHER_DELETE_RESOLVES_TO)
+    networks: dict[str, str] = {}
+    endpoints: dict[str, str] = {}
+    for query in (CYPHER_LIVE_NETWORK_RESOURCES, CYPHER_LIVE_ENDPOINT_RESOURCES):
+        for row in ingestor.fetch_all(query):
+            qn = row.get(cs.KEY_QUALIFIED_NAME)
+            name = row.get(cs.KEY_NAME)
+            if not isinstance(qn, str) or not isinstance(name, str):
+                continue
+            kind = row.get(KEY_KIND)
+            if kind == ResourceKind.NETWORK.value and name != DYNAMIC_TARGET:
+                networks[qn] = name
+            elif kind == ResourceKind.ENDPOINT.value:
+                endpoints[qn] = name
 
     # The live ingestor both queries and writes; QueryProtocol alone types
     # the read side, so the single write goes through an ingestor view.
     writer = cast("IngestorProtocol", ingestor)
     created = 0
-    for network_qn, url in networks:
-        for endpoint_qn, identity in endpoints:
+    for network_qn, url in networks.items():
+        for endpoint_qn, identity in endpoints.items():
             _, _, template = identity.partition(" ")
             if template and url_matches_template(url, template):
                 writer.ensure_relationship_batch(

--- a/codebase_rag/parsers/endpoints.py
+++ b/codebase_rag/parsers/endpoints.py
@@ -9,7 +9,18 @@ those templates so cross-project request edges can resolve to handlers.
 from __future__ import annotations
 
 import re
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
+
+from .. import constants as cs
+
+if TYPE_CHECKING:
+    from ..services import IngestorProtocol, QueryProtocol
+
+CYPHER_ALL_RESOURCES = (
+    "MATCH (r:Resource) RETURN r.qualified_name AS qualified_name, "
+    "r.name AS name, r.kind AS kind"
+)
 
 _HTTP_METHOD_NAMES = frozenset(
     {"get", "post", "put", "patch", "delete", "head", "options", "websocket"}
@@ -68,3 +79,82 @@ def url_matches_template(url: str, template: str) -> bool:
         _TEMPLATE_PARAM_RE.match(expected) or expected == actual
         for actual, expected in zip(url_segments, template_segments, strict=True)
     )
+
+
+def emit_endpoints(
+    ingestor: IngestorProtocol,
+    label: cs.NodeLabel,
+    qualified_name: str,
+    decorators: object,
+) -> None:
+    """Emit an ENDPOINT Resource plus an EXPOSES edge per route decorator."""
+    # Imported lazily: parsers.utils imports this module, and the io_access
+    # package init pulls extract, which imports parsers.utils back.
+    from .io_access.constants import KEY_KIND, RESOURCE_QN_FORMAT, ResourceKind
+
+    # A filtering sink that would drop the EXPOSES edge must not receive the
+    # Resource node either, or selective capture leaves an orphaned endpoint.
+    rel_gate = getattr(ingestor, "rel_enabled", None)
+    if callable(rel_gate) and not rel_gate(cs.RelationshipType.EXPOSES):
+        return
+    if not isinstance(decorators, list):
+        return
+    for decorator in decorators:
+        if not isinstance(decorator, str):
+            continue
+        for method, path in parse_route_decorator(decorator):
+            identity = f"{method} {path}"
+            resource_qn = RESOURCE_QN_FORMAT.format(
+                kind=ResourceKind.ENDPOINT.value, identity=identity
+            )
+            ingestor.ensure_node_batch(
+                cs.NodeLabel.RESOURCE,
+                {
+                    cs.KEY_QUALIFIED_NAME: resource_qn,
+                    cs.KEY_NAME: identity,
+                    KEY_KIND: ResourceKind.ENDPOINT.value,
+                },
+            )
+            ingestor.ensure_relationship_batch(
+                (label, cs.KEY_QUALIFIED_NAME, qualified_name),
+                cs.RelationshipType.EXPOSES,
+                (cs.NodeLabel.RESOURCE, cs.KEY_QUALIFIED_NAME, resource_qn),
+            )
+
+
+def link_endpoints(ingestor: QueryProtocol) -> int:
+    """Resolve literal client request URLs to matching ENDPOINT resources.
+
+    Endpoint identities are ``METHOD /path/template``; a NETWORK resource
+    links to every endpoint whose template matches its URL path. Matching
+    is method-agnostic: the request method lives on the sink edge, not in
+    the Resource identity. Returns the number of edges emitted.
+    """
+    from .io_access.constants import DYNAMIC_TARGET, KEY_KIND, ResourceKind
+
+    rows = ingestor.fetch_all(CYPHER_ALL_RESOURCES)
+    networks: list[tuple[str, str]] = []
+    endpoints: list[tuple[str, str]] = []
+    for row in rows:
+        qn = row.get(cs.KEY_QUALIFIED_NAME)
+        name = row.get(cs.KEY_NAME)
+        if not isinstance(qn, str) or not isinstance(name, str):
+            continue
+        kind = row.get(KEY_KIND)
+        if kind == ResourceKind.NETWORK.value and name != DYNAMIC_TARGET:
+            networks.append((qn, name))
+        elif kind == ResourceKind.ENDPOINT.value:
+            endpoints.append((qn, name))
+
+    created = 0
+    for network_qn, url in networks:
+        for endpoint_qn, identity in endpoints:
+            _, _, template = identity.partition(" ")
+            if template and url_matches_template(url, template):
+                ingestor.ensure_relationship_batch(
+                    (cs.NodeLabel.RESOURCE, cs.KEY_QUALIFIED_NAME, network_qn),
+                    cs.RelationshipType.RESOLVES_TO,
+                    (cs.NodeLabel.RESOURCE, cs.KEY_QUALIFIED_NAME, endpoint_qn),
+                )
+                created += 1
+    return created

--- a/codebase_rag/parsers/endpoints.py
+++ b/codebase_rag/parsers/endpoints.py
@@ -42,7 +42,7 @@ _DEFAULT_ROUTE_METHOD = "GET"
 # AST walk. The literal must open the argument list (a leading quote), which
 # rejects computed paths like (prefix + "/users").
 _DECORATOR_CALL_RE = re.compile(
-    r"^@[\w.]*?(?P<name>\w+)\(\s*(?P<quote>['\"])(?P<path>/[^'\"]*)(?P=quote)",
+    r"^@(?:\w+\.)*(?P<name>\w+)\(\s*(?P<quote>['\"])(?P<path>/[^'\"]*)(?P=quote)",
 )
 _METHODS_KWARG_RE = re.compile(r"methods\s*=\s*[\[({](?P<items>[^\])}]*)[\])}]")
 _METHOD_ITEM_RE = re.compile(r"['\"](\w+)['\"]")
@@ -133,17 +133,11 @@ def emit_endpoints(
             )
 
 
-def link_endpoints(ingestor: QueryProtocol) -> int:
-    """Resolve literal client request URLs to matching ENDPOINT resources.
-
-    Endpoint identities are ``METHOD /path/template``; a NETWORK resource
-    links to every endpoint whose template matches its URL path. Matching
-    is method-agnostic: the request method lives on the sink edge, not in
-    the Resource identity. Returns the number of edges emitted.
-    """
+def _collect_live_resources(
+    ingestor: QueryProtocol,
+) -> tuple[dict[str, str], dict[str, str]]:
     from .io_access.constants import DYNAMIC_TARGET, KEY_KIND, ResourceKind
 
-    ingestor.execute_write(CYPHER_DELETE_RESOLVES_TO)
     networks: dict[str, str] = {}
     endpoints: dict[str, str] = {}
     for query in (CYPHER_LIVE_NETWORK_RESOURCES, CYPHER_LIVE_ENDPOINT_RESOURCES):
@@ -157,6 +151,19 @@ def link_endpoints(ingestor: QueryProtocol) -> int:
                 networks[qn] = name
             elif kind == ResourceKind.ENDPOINT.value:
                 endpoints[qn] = name
+    return networks, endpoints
+
+
+def link_endpoints(ingestor: QueryProtocol) -> int:
+    """Resolve literal client request URLs to matching ENDPOINT resources.
+
+    Endpoint identities are ``METHOD /path/template``; a NETWORK resource
+    links to every endpoint whose template matches its URL path. Matching
+    is method-agnostic: the request method lives on the sink edge, not in
+    the Resource identity. Returns the number of edges emitted.
+    """
+    ingestor.execute_write(CYPHER_DELETE_RESOLVES_TO)
+    networks, endpoints = _collect_live_resources(ingestor)
 
     # The live ingestor both queries and writes; QueryProtocol alone types
     # the read side, so the single write goes through an ingestor view.

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -26,8 +26,8 @@ from ..types_defs import (
 from ..utils.path_utils import cached_relative_path, cached_resolve_posix
 from . import export_detection
 from .cpp import utils as cpp_utils
-from .endpoints import emit_endpoints
 from .dart import dart_definition_end_point, dart_return_type_name
+from .endpoints import emit_endpoints
 from .go import utils as go_utils
 from .lua import utils as lua_utils
 from .rs import utils as rs_utils

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -26,6 +26,7 @@ from ..types_defs import (
 from ..utils.path_utils import cached_relative_path, cached_resolve_posix
 from . import export_detection
 from .cpp import utils as cpp_utils
+from .endpoints import emit_endpoints
 from .dart import dart_definition_end_point, dart_return_type_name
 from .go import utils as go_utils
 from .lua import utils as lua_utils
@@ -731,6 +732,12 @@ class FunctionIngestMixin:
 
             logger.info(ls.METHOD_FOUND.format(name=entry.method_name, qn=method_qn))
             self.ingestor.ensure_node_batch(cs.NodeLabel.METHOD, props)
+            emit_endpoints(
+                self.ingestor,
+                cs.NodeLabel.METHOD,
+                method_qn,
+                props.get(cs.KEY_DECORATORS),
+            )
             self.function_registry[method_qn] = NodeType.METHOD
             self.simple_name_lookup[entry.method_name].add(method_qn)
             if entry.return_type:
@@ -1040,6 +1047,12 @@ class FunctionIngestMixin:
             ls.FUNC_FOUND.format(name=resolution.name, qn=resolution.qualified_name)
         )
         self.ingestor.ensure_node_batch(cs.NodeLabel.FUNCTION, func_props)
+        emit_endpoints(
+            self.ingestor,
+            cs.NodeLabel.FUNCTION,
+            resolution.qualified_name,
+            func_props.get(cs.KEY_DECORATORS),
+        )
 
         self.function_registry[resolution.qualified_name] = NodeType.FUNCTION
         if is_macro:

--- a/codebase_rag/parsers/io_access/constants.py
+++ b/codebase_rag/parsers/io_access/constants.py
@@ -24,6 +24,7 @@ class ResourceKind(StrEnum):
     STDERR = "STDERR"
     ENV = "ENV"
     SOCKET = "SOCKET"
+    ENDPOINT = "ENDPOINT"
 
 
 class IODirection(StrEnum):

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -23,6 +23,7 @@ from ..types_defs import (
     TreeSitterNodeProtocol,
 )
 from ..utils.path_utils import cached_relative_path, cached_resolve_posix
+from .endpoints import emit_endpoints
 
 if TYPE_CHECKING:
     from ..language_spec import LanguageSpec
@@ -821,6 +822,9 @@ def ingest_method(
 
     logger.info(logs.METHOD_FOUND.format(name=method_name, qn=method_qn))
     ingestor.ensure_node_batch(cs.NodeLabel.METHOD, method_props)
+    emit_endpoints(
+        ingestor, cs.NodeLabel.METHOD, method_qn, method_props.get(cs.KEY_DECORATORS)
+    )
     function_registry[method_qn] = NodeType.METHOD
     if is_property:
         function_registry.mark_property(method_qn)
@@ -952,6 +956,12 @@ def ingest_exported_function(
         )
     )
     ingestor.ensure_node_batch(cs.NodeLabel.FUNCTION, function_props)
+    emit_endpoints(
+        ingestor,
+        cs.NodeLabel.FUNCTION,
+        function_qn,
+        function_props.get(cs.KEY_DECORATORS),
+    )
     function_registry[function_qn] = NodeType.FUNCTION
     simple_name_lookup[function_name].add(function_qn)
     ingestor.ensure_relationship_batch(

--- a/codebase_rag/services/filtering.py
+++ b/codebase_rag/services/filtering.py
@@ -38,6 +38,9 @@ class FilteringIngestor:
     def flush_all(self) -> None:
         self._inner.flush_all()
 
+    def rel_enabled(self, rel_type: RelationshipType) -> bool:
+        return self._selection.rel_enabled(rel_type)
+
     def fetch_all(
         self, query: str, params: PropertyDict | None = None
     ) -> list[ResultRow]:

--- a/codebase_rag/tests/integration/test_endpoint_linking_e2e.py
+++ b/codebase_rag/tests/integration/test_endpoint_linking_e2e.py
@@ -23,21 +23,21 @@ if TYPE_CHECKING:
 
 pytestmark = [pytest.mark.integration]
 
-_CLIENT_SOURCE = '''import requests
+_CLIENT_SOURCE = """import requests
 
 
 def create_order(user_id):
     user = requests.get("http://user-service:8000/users/42")
     return {"user": user}
-'''
+"""
 
-_SERVER_SOURCE = '''app = object()
+_SERVER_SOURCE = """app = object()
 
 
 @app.get("/users/{id}")
 def get_user(id):
     return {"id": id}
-'''
+"""
 
 
 def _index(ingestor: MemgraphIngestor, repo: Path) -> None:

--- a/codebase_rag/tests/integration/test_endpoint_linking_e2e.py
+++ b/codebase_rag/tests/integration/test_endpoint_linking_e2e.py
@@ -1,0 +1,82 @@
+"""Cross-project endpoint linking end to end (issue #425 phase 3).
+
+A client service calling ``requests.get("http://user-service:8000/users/42")``
+and a server service exposing ``@app.get("/users/{id}")`` are indexed as two
+separate projects into one graph; the client's NETWORK resource must resolve
+to the server's ENDPOINT resource, tracing caller to handler across projects.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.capture import resolve_capture
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+if TYPE_CHECKING:
+    from codebase_rag.services.graph_service import MemgraphIngestor
+
+pytestmark = [pytest.mark.integration]
+
+_CLIENT_SOURCE = '''import requests
+
+
+def create_order(user_id):
+    user = requests.get("http://user-service:8000/users/42")
+    return {"user": user}
+'''
+
+_SERVER_SOURCE = '''app = object()
+
+
+@app.get("/users/{id}")
+def get_user(id):
+    return {"id": id}
+'''
+
+
+def _index(ingestor: MemgraphIngestor, repo: Path) -> None:
+    parsers, queries = load_parsers()
+    GraphUpdater(
+        ingestor=ingestor,
+        repo_path=repo,
+        parsers=parsers,
+        queries=queries,
+        capture=resolve_capture([cs.CaptureGroup.IO.value]),
+    ).run()
+    ingestor.flush_all()
+
+
+class TestEndpointLinkingE2E:
+    def test_client_url_resolves_to_server_endpoint(
+        self, memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+    ) -> None:
+        client_repo = tmp_path / "order-service"
+        client_repo.mkdir()
+        (client_repo / "orders.py").write_text(_CLIENT_SOURCE, encoding="utf-8")
+        server_repo = tmp_path / "user-service"
+        server_repo.mkdir()
+        (server_repo / "handlers.py").write_text(_SERVER_SOURCE, encoding="utf-8")
+
+        _index(memgraph_ingestor, server_repo)
+        _index(memgraph_ingestor, client_repo)
+
+        rows = memgraph_ingestor.fetch_all(
+            "MATCH (caller)-[:READS_FROM]->(url:Resource {kind: 'NETWORK'})"
+            "-[:RESOLVES_TO]->(ep:Resource {kind: 'ENDPOINT'})"
+            "<-[:EXPOSES]-(handler) "
+            "RETURN caller.qualified_name AS caller, url.name AS url, "
+            "ep.name AS endpoint, handler.qualified_name AS handler"
+        )
+
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["caller"] == "order-service.orders.create_order"
+        assert row["url"] == "http://user-service:8000/users/42"
+        assert row["endpoint"] == "GET /users/{id}"
+        assert row["handler"] == "user-service.handlers.get_user"

--- a/codebase_rag/tests/test_endpoint_extraction.py
+++ b/codebase_rag/tests/test_endpoint_extraction.py
@@ -55,9 +55,7 @@ class TestParseRouteDecorator:
         assert parse_route_decorator(decorator) == []
 
     def test_websocket_route(self) -> None:
-        assert parse_route_decorator('@app.websocket("/ws")') == [
-            ("WEBSOCKET", "/ws")
-        ]
+        assert parse_route_decorator('@app.websocket("/ws")') == [("WEBSOCKET", "/ws")]
 
 
 class TestUrlTemplateMatch:
@@ -76,9 +74,7 @@ class TestUrlTemplateMatch:
             ("http://svc/", "/", True),
         ],
     )
-    def test_url_matches_template(
-        self, url: str, template: str, matches: bool
-    ) -> None:
+    def test_url_matches_template(self, url: str, template: str, matches: bool) -> None:
         from codebase_rag.parsers.endpoints import url_matches_template
 
         assert url_matches_template(url, template) is matches
@@ -145,9 +141,21 @@ class TestLinkEndpoints:
 
         ingestor = MagicMock()
         ingestor.fetch_all.return_value = [
-            {"qualified_name": network_qn, "name": "http://user-service:8000/users/42", "kind": "NETWORK"},
-            {"qualified_name": endpoint_qn, "name": "GET /users/{id}", "kind": "ENDPOINT"},
-            {"qualified_name": other_endpoint_qn, "name": "POST /orders", "kind": "ENDPOINT"},
+            {
+                "qualified_name": network_qn,
+                "name": "http://user-service:8000/users/42",
+                "kind": "NETWORK",
+            },
+            {
+                "qualified_name": endpoint_qn,
+                "name": "GET /users/{id}",
+                "kind": "ENDPOINT",
+            },
+            {
+                "qualified_name": other_endpoint_qn,
+                "name": "POST /orders",
+                "kind": "ENDPOINT",
+            },
         ]
 
         created = link_endpoints(ingestor)
@@ -166,8 +174,16 @@ class TestLinkEndpoints:
 
         ingestor = MagicMock()
         ingestor.fetch_all.return_value = [
-            {"qualified_name": "resource::NETWORK::<dynamic>", "name": "<dynamic>", "kind": "NETWORK"},
-            {"qualified_name": "resource::ENDPOINT::GET /users/{id}", "name": "GET /users/{id}", "kind": "ENDPOINT"},
+            {
+                "qualified_name": "resource::NETWORK::<dynamic>",
+                "name": "<dynamic>",
+                "kind": "NETWORK",
+            },
+            {
+                "qualified_name": "resource::ENDPOINT::GET /users/{id}",
+                "name": "GET /users/{id}",
+                "kind": "ENDPOINT",
+            },
         ]
 
         assert link_endpoints(ingestor) == 0

--- a/codebase_rag/tests/test_endpoint_extraction.py
+++ b/codebase_rag/tests/test_endpoint_extraction.py
@@ -188,3 +188,63 @@ class TestLinkEndpoints:
 
         assert link_endpoints(ingestor) == 0
         ingestor.ensure_relationship_batch.assert_not_called()
+
+
+class TestReviewHardening:
+    @pytest.mark.parametrize(
+        ("decorator", "expected"),
+        [
+            ('@bp.route("/login", methods=("POST",))', [("POST", "/login")]),
+            ('@bp.route("/login", methods={"POST"})', [("POST", "/login")]),
+            (
+                '@bp.route("/x", methods=("PUT", "DELETE"))',
+                [("PUT", "/x"), ("DELETE", "/x")],
+            ),
+        ],
+    )
+    def test_flask_methods_accept_any_iterable_literal(
+        self, decorator: str, expected: list[tuple[str, str]]
+    ) -> None:
+        assert parse_route_decorator(decorator) == expected
+
+    @pytest.mark.parametrize(
+        ("url", "template", "matches"),
+        [
+            ("http://svc/users/42", "/users/<int:user_id>", True),
+            ("http://svc/users/42", "/users/<user_id>", True),
+            ("http://svc/files/report", "/files/<path:name>", True),
+            ("http://svc/users/42/x", "/users/<int:user_id>", False),
+        ],
+    )
+    def test_flask_angle_bracket_variables_match(
+        self, url: str, template: str, matches: bool
+    ) -> None:
+        from codebase_rag.parsers.endpoints import url_matches_template
+
+        assert url_matches_template(url, template) is matches
+
+    def test_relink_deletes_existing_resolves_to_first(self) -> None:
+        from unittest.mock import MagicMock
+
+        from codebase_rag.parsers.endpoints import (
+            CYPHER_DELETE_RESOLVES_TO,
+            link_endpoints,
+        )
+
+        ingestor = MagicMock()
+        ingestor.fetch_all.return_value = []
+
+        link_endpoints(ingestor)
+
+        ingestor.execute_write.assert_called_once_with(CYPHER_DELETE_RESOLVES_TO)
+
+    def test_link_only_considers_actively_referenced_resources(self) -> None:
+        # Resources whose caller or handler was deleted must not relink:
+        # the fetch queries anchor on live sink and EXPOSES edges.
+        from codebase_rag.parsers.endpoints import (
+            CYPHER_LIVE_ENDPOINT_RESOURCES,
+            CYPHER_LIVE_NETWORK_RESOURCES,
+        )
+
+        assert "READS_FROM|WRITES_TO" in CYPHER_LIVE_NETWORK_RESOURCES
+        assert "EXPOSES" in CYPHER_LIVE_ENDPOINT_RESOURCES

--- a/codebase_rag/tests/test_endpoint_extraction.py
+++ b/codebase_rag/tests/test_endpoint_extraction.py
@@ -82,3 +82,93 @@ class TestUrlTemplateMatch:
         from codebase_rag.parsers.endpoints import url_matches_template
 
         assert url_matches_template(url, template) is matches
+
+
+class TestEmitEndpoints:
+    def test_route_decorator_emits_endpoint_resource_and_exposes_edge(self) -> None:
+        from unittest.mock import MagicMock
+
+        from codebase_rag import constants as cs
+        from codebase_rag.parsers.endpoints import emit_endpoints
+
+        ingestor = MagicMock()
+        emit_endpoints(
+            ingestor,
+            cs.NodeLabel.FUNCTION,
+            "user-service.api.get_user",
+            ['@app.get("/users/{id}")'],
+        )
+
+        ingestor.ensure_node_batch.assert_called_once_with(
+            cs.NodeLabel.RESOURCE,
+            {
+                "qualified_name": "resource::ENDPOINT::GET /users/{id}",
+                "name": "GET /users/{id}",
+                "kind": "ENDPOINT",
+            },
+        )
+        ingestor.ensure_relationship_batch.assert_called_once_with(
+            (cs.NodeLabel.FUNCTION, "qualified_name", "user-service.api.get_user"),
+            cs.RelationshipType.EXPOSES,
+            (
+                cs.NodeLabel.RESOURCE,
+                "qualified_name",
+                "resource::ENDPOINT::GET /users/{id}",
+            ),
+        )
+
+    def test_plain_decorators_emit_nothing(self) -> None:
+        from unittest.mock import MagicMock
+
+        from codebase_rag import constants as cs
+        from codebase_rag.parsers.endpoints import emit_endpoints
+
+        ingestor = MagicMock()
+        emit_endpoints(
+            ingestor, cs.NodeLabel.FUNCTION, "proj.mod.fn", ["@staticmethod"]
+        )
+
+        ingestor.ensure_node_batch.assert_not_called()
+        ingestor.ensure_relationship_batch.assert_not_called()
+
+
+class TestLinkEndpoints:
+    def test_network_urls_resolve_to_matching_endpoints(self) -> None:
+        from unittest.mock import MagicMock
+
+        from codebase_rag import constants as cs
+        from codebase_rag.parsers.endpoints import link_endpoints
+
+        network_qn = "resource::NETWORK::http://user-service:8000/users/42"
+        endpoint_qn = "resource::ENDPOINT::GET /users/{id}"
+        other_endpoint_qn = "resource::ENDPOINT::POST /orders"
+
+        ingestor = MagicMock()
+        ingestor.fetch_all.return_value = [
+            {"qualified_name": network_qn, "name": "http://user-service:8000/users/42", "kind": "NETWORK"},
+            {"qualified_name": endpoint_qn, "name": "GET /users/{id}", "kind": "ENDPOINT"},
+            {"qualified_name": other_endpoint_qn, "name": "POST /orders", "kind": "ENDPOINT"},
+        ]
+
+        created = link_endpoints(ingestor)
+
+        assert created == 1
+        ingestor.ensure_relationship_batch.assert_called_once_with(
+            (cs.NodeLabel.RESOURCE, "qualified_name", network_qn),
+            cs.RelationshipType.RESOLVES_TO,
+            (cs.NodeLabel.RESOURCE, "qualified_name", endpoint_qn),
+        )
+
+    def test_dynamic_urls_do_not_link(self) -> None:
+        from unittest.mock import MagicMock
+
+        from codebase_rag.parsers.endpoints import link_endpoints
+
+        ingestor = MagicMock()
+        ingestor.fetch_all.return_value = [
+            {"qualified_name": "resource::NETWORK::<dynamic>", "name": "<dynamic>", "kind": "NETWORK"},
+            {"qualified_name": "resource::ENDPOINT::GET /users/{id}", "name": "GET /users/{id}", "kind": "ENDPOINT"},
+        ]
+
+        assert link_endpoints(ingestor) == 0
+        ingestor.ensure_relationship_batch.assert_not_called()

--- a/codebase_rag/tests/test_endpoint_extraction.py
+++ b/codebase_rag/tests/test_endpoint_extraction.py
@@ -1,0 +1,84 @@
+"""Server route decorators must become endpoint Resource nodes (issue #425).
+
+Handlers decorated with FastAPI/Flask-style route decorators expose an HTTP
+endpoint; parsing the retained decorator text into ``METHOD /path/template``
+gives cross-project linking a server-side anchor that client request URLs
+can resolve to.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from codebase_rag.parsers.endpoints import parse_route_decorator
+
+
+class TestParseRouteDecorator:
+    @pytest.mark.parametrize(
+        ("decorator", "expected"),
+        [
+            ('@app.get("/users/{id}")', [("GET", "/users/{id}")]),
+            ("@router.post('/orders')", [("POST", "/orders")]),
+            ('@api.put("/items/{item_id}/name")', [("PUT", "/items/{item_id}/name")]),
+            ('@app.delete("/users/{id}")', [("DELETE", "/users/{id}")]),
+            ('@app.patch("/users/{id}")', [("PATCH", "/users/{id}")]),
+            ('@app.route("/health")', [("GET", "/health")]),
+            (
+                '@app.route("/users", methods=["GET", "POST"])',
+                [("GET", "/users"), ("POST", "/users")],
+            ),
+            (
+                "@bp.route('/login', methods=['POST'])",
+                [("POST", "/login")],
+            ),
+        ],
+    )
+    def test_parses_route_decorators(
+        self, decorator: str, expected: list[tuple[str, str]]
+    ) -> None:
+        assert parse_route_decorator(decorator) == expected
+
+    @pytest.mark.parametrize(
+        "decorator",
+        [
+            "@staticmethod",
+            "@property",
+            '@pytest.mark.parametrize("x", [1])',
+            "@app.get",
+            "@app.get()",
+            '@task("/not/a/route")',
+            '@app.get(prefix + "/users")',
+            "@lru_cache(maxsize=128)",
+        ],
+    )
+    def test_non_routes_return_empty(self, decorator: str) -> None:
+        assert parse_route_decorator(decorator) == []
+
+    def test_websocket_route(self) -> None:
+        assert parse_route_decorator('@app.websocket("/ws")') == [
+            ("WEBSOCKET", "/ws")
+        ]
+
+
+class TestUrlTemplateMatch:
+    @pytest.mark.parametrize(
+        ("url", "template", "matches"),
+        [
+            ("http://user-service:8000/users/42", "/users/{id}", True),
+            ("https://api.internal/users/42", "/users/{id}", True),
+            ("http://svc/users", "/users", True),
+            ("http://svc/users/", "/users", True),
+            ("http://svc/users/42/name", "/users/{id}", False),
+            ("http://svc/orders/42", "/users/{id}", False),
+            ("http://svc/users/42?verbose=1", "/users/{id}", True),
+            ("http://svc/items/7/name", "/items/{item_id}/name", True),
+            ("not a url", "/users/{id}", False),
+            ("http://svc/", "/", True),
+        ],
+    )
+    def test_url_matches_template(
+        self, url: str, template: str, matches: bool
+    ) -> None:
+        from codebase_rag.parsers.endpoints import url_matches_template
+
+        assert url_matches_template(url, template) is matches

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -900,6 +900,16 @@ RELATIONSHIP_SCHEMAS: tuple[RelationshipSchema, ...] = (
         (NodeLabel.MODULE, NodeLabel.FUNCTION, NodeLabel.METHOD, NodeLabel.RESOURCE),
     ),
     RelationshipSchema(
+        (NodeLabel.FUNCTION, NodeLabel.METHOD),
+        RelationshipType.EXPOSES,
+        (NodeLabel.RESOURCE,),
+    ),
+    RelationshipSchema(
+        (NodeLabel.RESOURCE,),
+        RelationshipType.RESOLVES_TO,
+        (NodeLabel.RESOURCE,),
+    ),
+    RelationshipSchema(
         (NodeLabel.MODULE,),
         RelationshipType.IMPLEMENTS_PATTERN,
         (NodeLabel.PATTERN,),

--- a/docs/guide/multi-project.md
+++ b/docs/guide/multi-project.md
@@ -57,6 +57,34 @@ single project: the agent's `semantic_search` tool accepts an optional
 project name and then only returns matches whose qualified names belong to
 that project. Without it, results are ranked across every indexed project.
 
+## Tracing calls between services
+
+With the `io` capture group enabled, a route handler such as
+`@app.get("/users/{id}")` becomes an endpoint resource
+(`resource::ENDPOINT::GET /users/{id}`) connected to its handler by an
+`EXPOSES` edge, and a client call like
+`requests.get("http://user-service:8000/users/42")` becomes a network
+resource connected to its caller by `READS_FROM`/`WRITES_TO`. After each
+indexing run, literal client URLs are matched against the endpoint path
+templates in the graph (`{id}` matches one path segment) and linked with
+`RESOLVES_TO`, so a request in one service traces to the handler in
+another:
+
+```bash
+cgr start --repo-path ~/services/user-service --update-graph --capture io
+cgr start --repo-path ~/services/order-service --update-graph --capture io
+```
+
+```cypher
+MATCH (caller)-[:READS_FROM|WRITES_TO]->(:Resource {kind: 'NETWORK'})
+      -[:RESOLVES_TO]->(:Resource {kind: 'ENDPOINT'})<-[:EXPOSES]-(handler)
+RETURN caller.qualified_name, handler.qualified_name
+```
+
+Matching uses the URL path only: dynamic (non-literal) URLs and requests
+whose paths match no known template stay unlinked. FastAPI and Flask style
+route decorators are recognized.
+
 ## Housekeeping
 
 ```bash

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.432"
+version = "0.0.434"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Phase 3 of #425 (cross-project indexing and retrieval): microservice call tracing.

## What changed

- **Route decorators become endpoint resources.** Handler decorators are already stored verbatim on Function/Method nodes; `parsers/endpoints.py` parses FastAPI/Flask-style forms (`@app.get("/users/{id}")`, `@bp.route("/login", methods=["POST"])`) into `METHOD /template` pairs. Every handler emission site now emits a shared `resource::ENDPOINT::GET /users/{id}` Resource node plus a new `EXPOSES` edge from the handler. Computed paths, pathless calls, and non-route decorators are ignored.
- **Client URLs resolve to endpoints.** After each indexing run, a linking pass matches literal client request URLs (the existing NETWORK Resource nodes from the io_access registry) against endpoint path templates (`{id}` matches exactly one segment; scheme/host/port/query ignored) and emits `RESOLVES_TO` between the two Resource nodes. Resource identities carry no project prefix, so services indexed as separate projects converge on the same nodes, which is what makes the link cross-project:

```
order-service.orders.create_order
  -[READS_FROM]-> resource::NETWORK::http://user-service:8000/users/42
  -[RESOLVES_TO]-> resource::ENDPOINT::GET /users/{id}
  <-[EXPOSES]- user-service.handlers.get_user
```

- **Capture discipline.** Both new relationship types live in the `io` capture group; endpoint emission checks the filter first so selective capture never leaves an orphaned endpoint node, and the linking pass gates on `RESOLVES_TO` being enabled since it writes through the raw ingestor.
- **Registration.** `EXPOSES` and `RESOLVES_TO` added to `RelationshipType`, `RELATIONSHIP_SCHEMAS`, and the IO capture group; `ResourceKind.ENDPOINT` added; the graph audit validates all of it on every fixture test.
- **Docs.** The multi-project guide gained a "Tracing calls between services" section with the capture flags and the Cypher trace query.

## Limitations (by design, documented)

- Matching is URL-path-only and method-agnostic; request method lives on the sink edge (`READS_FROM` vs `WRITES_TO`), not in the Resource identity.
- Dynamic (non-literal) URLs collapse to `<dynamic>` upstream and are never linked.
- Decorator parsing covers FastAPI/Flask-style Python routes first; other frameworks/languages can extend the same parser.

## Testing

- RED commits precede each behavior (decorator parsing, URL/template matching, emission, linking).
- New e2e `integration/test_endpoint_linking_e2e.py` indexes two services into one Memgraph and asserts the full caller-to-handler trace above.
- Full suite green locally: 5732 passed.

Advances #425.