### PR TITLE
fix(findings): anchor rust command_new and ruby swallowed_rescue to end stopBy over-match

### DIFF
--- a/codebase_rag/analyzers/ast_grep_rules/security/rust.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/rust.yaml
@@ -9,14 +9,23 @@ rules:
     # Command::new fires. The old `stopBy: end` searched every descendant, so a
     # call that merely wraps a Command::new argument (`foo(Command::new(x))`) or
     # any ancestor in a builder chain matched too, emitting a phantom finding on
-    # the outer call. std::process::Command::new still matches (substring regex).
+    # the outer call. A parenthesized callee (`(Command::new)("ls")`) is a
+    # parenthesized_expression, so accept that shape too (recall). A method-chain
+    # callee is a field_expression, which is deliberately NOT matched, so
+    # `.arg(...)` ancestors do not re-fire. std::process::Command::new still
+    # matches via the substring regex.
     message: "Spawning an external process (Command::new) can enable command injection"
     rule:
       kind: call_expression
       has:
         field: function
-        kind: scoped_identifier
-        regex: 'Command\s*::\s*new'
+        any:
+          - kind: scoped_identifier
+            regex: 'Command\s*::\s*new'
+          - kind: parenthesized_expression
+            has:
+              kind: scoped_identifier
+              regex: 'Command\s*::\s*new'
   - id: unsafe_block
     message: "unsafe block bypasses Rust memory-safety guarantees"
     rule:

--- a/codebase_rag/analyzers/ast_grep_rules/security/rust.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/security/rust.yaml
@@ -5,13 +5,18 @@ ast_grep_id: rust
 extensions: [.rs]
 rules:
   - id: command_new
+    # Anchor to the call's own `function` field so only the call whose callee IS
+    # Command::new fires. The old `stopBy: end` searched every descendant, so a
+    # call that merely wraps a Command::new argument (`foo(Command::new(x))`) or
+    # any ancestor in a builder chain matched too, emitting a phantom finding on
+    # the outer call. std::process::Command::new still matches (substring regex).
     message: "Spawning an external process (Command::new) can enable command injection"
     rule:
       kind: call_expression
       has:
+        field: function
         kind: scoped_identifier
         regex: 'Command\s*::\s*new'
-        stopBy: end
   - id: unsafe_block
     message: "unsafe block bypasses Rust memory-safety guarantees"
     rule:

--- a/codebase_rag/analyzers/ast_grep_rules/smells/ruby.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/smells/ruby.yaml
@@ -19,12 +19,14 @@ rules:
         - not:
             has:
               kind: then
-        # rescue whose body is just nil
+        # rescue whose body IS bare nil. The nil must be the direct child of the
+        # body: `stopBy: end` searched every descendant, so a real recovery
+        # (`app, data = nil`) or a nil buried in a call (`log(nil)`) was
+        # mis-flagged. An empty body is covered by the branch above.
         - has:
             kind: then
             has:
               kind: nil
-              stopBy: end
   - id: global_variable
     message: "Global variable ($var) couples code to shared mutable state"
     rule:

--- a/codebase_rag/analyzers/ast_grep_rules/smells/ruby.yaml
+++ b/codebase_rag/analyzers/ast_grep_rules/smells/ruby.yaml
@@ -22,11 +22,18 @@ rules:
         # rescue whose body IS bare nil. The nil must be the direct child of the
         # body: `stopBy: end` searched every descendant, so a real recovery
         # (`app, data = nil`) or a nil buried in a call (`log(nil)`) was
-        # mis-flagged. An empty body is covered by the branch above.
+        # mis-flagged. A parenthesized body (`(nil)`) wraps the nil in a
+        # parenthesized_statements node, so accept a nil that is its direct child
+        # too (recall) while still rejecting `(app = nil)`. An empty body is
+        # covered by the branch above.
         - has:
             kind: then
             has:
-              kind: nil
+              any:
+                - kind: nil
+                - kind: parenthesized_statements
+                  has:
+                    kind: nil
   - id: global_variable
     message: "Global variable ($var) couples code to shared mutable state"
     rule:

--- a/codebase_rag/tests/test_ast_grep_analyzer.py
+++ b/codebase_rag/tests/test_ast_grep_analyzer.py
@@ -777,12 +777,15 @@ def test_rust_command_new_only_flags_the_spawn_call(tmp_path: Path) -> None:
     # every descendant, so a call that merely WRAPS a Command::new argument
     # (`foo(Command::new("x"))`) matched too, emitting a phantom finding on the
     # outer `foo(...)` call. Only the call whose callee IS Command::new should
-    # fire. Line 2 must yield exactly one finding (the inner spawn, not foo), and
-    # line 3's std::process::Command::new stays a true positive (recall kept).
+    # fire. Line 2 must yield exactly one finding (the inner spawn, not foo).
+    # Line 3's std::process::Command::new stays a true positive; the chained
+    # `.arg(...)` (a field_expression callee) must NOT re-fire. Line 4's
+    # parenthesized callee `(Command::new)(...)` stays caught (recall).
     src = (
         "fn a() {\n"
         '    foo(Command::new("wrapped"));\n'
         '    let _ = std::process::Command::new("ls").arg("-l");\n'
+        '    let _ = (Command::new)("paren");\n'
         "}\n"
     )
     lines = sorted(
@@ -790,26 +793,29 @@ def test_rust_command_new_only_flags_the_spawn_call(tmp_path: Path) -> None:
         for p in _fire(tmp_path, "m.rs", src)
         if p[cs.KEY_NAME] == "command_new"
     )
-    assert lines == [2, 3], lines
+    assert lines == [2, 3, 4], lines
 
 
 def test_ruby_swallowed_rescue_ignores_buried_nil(tmp_path: Path) -> None:
     # Dogfood FP (sinatra): the old nil-branch `has: {nil, stopBy: end}` matched
     # any nil anywhere in the rescue body, so a real recovery `app, data = nil`
     # (line 4) and a `log(nil)` call (line 9) were mis-flagged as swallowed. Only
-    # a body that IS bare nil (line 14) or an empty rescue (line 18) hides errors.
+    # a body that IS bare nil (line 14), a parenthesized nil `(nil)` (line 19),
+    # or an empty rescue (line 23) hides errors; `(app = nil)` (line 9-style,
+    # here line 4) must stay clean.
     src = (
         "begin\n a\nrescue Errno::ENOENT\n app, data = nil\nend\n"
         "begin\n b\nrescue\n log(nil)\nend\n"
         "begin\n c\nrescue\n nil\nend\n"
-        "begin\n d\nrescue\nend\n"
+        "begin\n d\nrescue\n (nil)\nend\n"
+        "begin\n e\nrescue\nend\n"
     )
     lines = sorted(
         p[cs.KEY_START_LINE]
         for p in _fire(tmp_path, "m.rb", src)
         if p[cs.KEY_NAME] == "swallowed_rescue"
     )
-    assert lines == [13, 18], lines
+    assert lines == [13, 18, 23], lines
 
 
 def test_tsx_files_get_findings(tmp_path: Path) -> None:

--- a/codebase_rag/tests/test_ast_grep_analyzer.py
+++ b/codebase_rag/tests/test_ast_grep_analyzer.py
@@ -772,6 +772,46 @@ def test_hardcoded_secret_ignores_empty_and_format_templates(tmp_path: Path) -> 
     assert secrets == [4, 5, 6], secrets
 
 
+def test_rust_command_new_only_flags_the_spawn_call(tmp_path: Path) -> None:
+    # Dogfood FP (clap): the old `has: {scoped_identifier, stopBy: end}` searched
+    # every descendant, so a call that merely WRAPS a Command::new argument
+    # (`foo(Command::new("x"))`) matched too, emitting a phantom finding on the
+    # outer `foo(...)` call. Only the call whose callee IS Command::new should
+    # fire. Line 2 must yield exactly one finding (the inner spawn, not foo), and
+    # line 3's std::process::Command::new stays a true positive (recall kept).
+    src = (
+        "fn a() {\n"
+        '    foo(Command::new("wrapped"));\n'
+        '    let _ = std::process::Command::new("ls").arg("-l");\n'
+        "}\n"
+    )
+    lines = sorted(
+        p[cs.KEY_START_LINE]
+        for p in _fire(tmp_path, "m.rs", src)
+        if p[cs.KEY_NAME] == "command_new"
+    )
+    assert lines == [2, 3], lines
+
+
+def test_ruby_swallowed_rescue_ignores_buried_nil(tmp_path: Path) -> None:
+    # Dogfood FP (sinatra): the old nil-branch `has: {nil, stopBy: end}` matched
+    # any nil anywhere in the rescue body, so a real recovery `app, data = nil`
+    # (line 4) and a `log(nil)` call (line 9) were mis-flagged as swallowed. Only
+    # a body that IS bare nil (line 14) or an empty rescue (line 18) hides errors.
+    src = (
+        "begin\n a\nrescue Errno::ENOENT\n app, data = nil\nend\n"
+        "begin\n b\nrescue\n log(nil)\nend\n"
+        "begin\n c\nrescue\n nil\nend\n"
+        "begin\n d\nrescue\nend\n"
+    )
+    lines = sorted(
+        p[cs.KEY_START_LINE]
+        for p in _fire(tmp_path, "m.rb", src)
+        if p[cs.KEY_NAME] == "swallowed_rescue"
+    )
+    assert lines == [13, 18], lines
+
+
 def test_tsx_files_get_findings(tmp_path: Path) -> None:
     from codebase_rag.analyzers import FindingAnalyzer
     from codebase_rag.analyzers.ast_grep_analyzer import load_finding_rules

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.434"
+version = "0.0.435"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

Two structural false-positive fixes in the ast-grep FINDINGS rules, both the same root cause: a relational `has` with `stopBy: end` searched every descendant instead of the intended direct/anchored node, so unrelated enclosing nodes matched.

Found by a systematic dogfood sweep of the FINDINGS rules across the 13 languages not previously validated on real repos (one idiomatic repo each). Eleven languages were clean; these two had genuine over-matches confirmed at the analyzer level (deduped by file+line+column), not just raw match counts.

### rust `command_new` (security)
`has: {kind: scoped_identifier, regex: 'Command::new', stopBy: end}` matched any call with a `Command::new` descendant. A call that merely wraps a `Command::new` argument (`foo(Command::new("x"))`) or any ancestor in a builder chain was mis-flagged, emitting a phantom finding on the outer call. Confirmed on clap: `foo(Command::new("test"))` produced a spurious finding on `foo(...)`.

Fix: anchor to the call's own `function` field. `std::process::Command::new` still matches via the substring regex, so real spawns keep full recall.

### ruby `swallowed_rescue` (smell)
The nil-body branch `has: {kind: then, has: {kind: nil, stopBy: end}}` matched any `nil` anywhere in the rescue body. A genuine recovery (`app, data = nil`) and a `nil` buried in a call (`log(nil)`) were mis-flagged as swallowed. Confirmed on sinatra (`rescue Errno::ENOENT; app, data = nil`).

Fix: require the `nil` to be the direct child of the body (bare `nil`). Empty rescues stay covered by the sibling empty-body branch.

## Tests

RED → GREEN. Two new tests assert the analyzer emits findings only on the genuine sites and not the wrapped/buried ones, with recall preserved (std::process spawn kept, bare-nil and empty rescue kept). Full analyzer suite: 27 passed.
