### PR TITLE
fix(endpoints): skip all-parameter templates when linking client URLs

### DIFF
--- a/codebase_rag/parsers/endpoints.py
+++ b/codebase_rag/parsers/endpoints.py
@@ -92,6 +92,20 @@ def url_matches_template(url: str, template: str) -> bool:
     )
 
 
+def _has_literal_segment(template: str) -> bool:
+    """True when at least one path segment is not a template parameter.
+
+    An all-parameter template (``/{id}/``, ``/<path:path>``, or the bare
+    root ``/``) matches any URL of the right shape, so linking it to a
+    literal URL carries no evidence and only fabricates traces.
+    """
+    return any(
+        not _TEMPLATE_PARAM_RE.match(segment)
+        for segment in template.split("/")
+        if segment
+    )
+
+
 def emit_endpoints(
     ingestor: IngestorProtocol,
     label: cs.NodeLabel,
@@ -160,7 +174,9 @@ def link_endpoints(ingestor: QueryProtocol) -> int:
     Endpoint identities are ``METHOD /path/template``; a NETWORK resource
     links to every endpoint whose template matches its URL path. Matching
     is method-agnostic: the request method lives on the sink edge, not in
-    the Resource identity. Returns the number of edges emitted.
+    the Resource identity. Templates without a literal segment are skipped
+    entirely; they would match any same-length URL path. Returns the number
+    of edges emitted.
     """
     ingestor.execute_write(CYPHER_DELETE_RESOLVES_TO)
     networks, endpoints = _collect_live_resources(ingestor)
@@ -172,7 +188,11 @@ def link_endpoints(ingestor: QueryProtocol) -> int:
     for network_qn, url in networks.items():
         for endpoint_qn, identity in endpoints.items():
             _, _, template = identity.partition(" ")
-            if template and url_matches_template(url, template):
+            if (
+                template
+                and _has_literal_segment(template)
+                and url_matches_template(url, template)
+            ):
                 writer.ensure_relationship_batch(
                     (cs.NodeLabel.RESOURCE, cs.KEY_QUALIFIED_NAME, network_qn),
                     cs.RelationshipType.RESOLVES_TO,

--- a/codebase_rag/tests/test_endpoint_extraction.py
+++ b/codebase_rag/tests/test_endpoint_extraction.py
@@ -190,6 +190,82 @@ class TestLinkEndpoints:
         ingestor.ensure_relationship_batch.assert_not_called()
 
 
+class TestAllParameterTemplatesDoNotLink:
+    """Dogfood finding: a one-segment URL like ``http://host/docs`` matched
+    every one-segment wildcard template (``/{id}/``, ``/<path:path>``, ...)
+    across every indexed project, fabricating cross-service traces. A
+    template with no literal segment carries no evidence and must not link.
+    """
+
+    @staticmethod
+    def _rows(url: str, *endpoints: str) -> list[dict[str, str]]:
+        rows = [
+            {
+                "qualified_name": f"resource::NETWORK::{url}",
+                "name": url,
+                "kind": "NETWORK",
+            }
+        ]
+        rows += [
+            {
+                "qualified_name": f"resource::ENDPOINT::{identity}",
+                "name": identity,
+                "kind": "ENDPOINT",
+            }
+            for identity in endpoints
+        ]
+        return rows
+
+    def test_all_parameter_templates_do_not_link(self) -> None:
+        from unittest.mock import MagicMock
+
+        from codebase_rag import constants as cs
+        from codebase_rag.parsers.endpoints import link_endpoints
+
+        ingestor = MagicMock()
+        ingestor.fetch_all.return_value = self._rows(
+            "http://localhost:8000/docs",
+            "GET /{id}/",
+            "GET /<path:path>",
+            "GET /docs",
+        )
+
+        assert link_endpoints(ingestor) == 1
+        ingestor.ensure_relationship_batch.assert_called_once_with(
+            (
+                cs.NodeLabel.RESOURCE,
+                "qualified_name",
+                "resource::NETWORK::http://localhost:8000/docs",
+            ),
+            cs.RelationshipType.RESOLVES_TO,
+            (cs.NodeLabel.RESOURCE, "qualified_name", "resource::ENDPOINT::GET /docs"),
+        )
+
+    def test_root_template_does_not_link(self) -> None:
+        from unittest.mock import MagicMock
+
+        from codebase_rag.parsers.endpoints import link_endpoints
+
+        ingestor = MagicMock()
+        ingestor.fetch_all.return_value = self._rows("http://svc/", "GET /")
+
+        assert link_endpoints(ingestor) == 0
+        ingestor.ensure_relationship_batch.assert_not_called()
+
+    def test_mixed_template_with_literal_segment_still_links(self) -> None:
+        from unittest.mock import MagicMock
+
+        from codebase_rag.parsers.endpoints import link_endpoints
+
+        ingestor = MagicMock()
+        ingestor.fetch_all.return_value = self._rows(
+            "http://user-service:8000/users/42",
+            "GET /users/{id}",
+        )
+
+        assert link_endpoints(ingestor) == 1
+
+
 class TestReviewHardening:
     @pytest.mark.parametrize(
         ("decorator", "expected"),


### PR DESCRIPTION
## Summary

Dogfooding the endpoint linking from #425 on four real repos (fastapi, flask, and two FastAPI microservice projects) exposed a precision hole: the single literal URL in the corpus, `http://localhost:8000/docs`, produced 23 `RESOLVES_TO` edges. Every one-segment wildcard template in the graph (`/{id}/`, `/{user_id}`, `/<path:path>`, `/<page>`, ...) matched it, fabricating cross-service traces such as a fastapi playwright script resolving to a handler in an unrelated microservice project.

A template with no literal path segment matches any URL of the right shape, so linking it carries no evidence. `link_endpoints` now skips templates whose segments are all parameters (this also covers the bare root `/`, which previously matched any host-root URL and would have fanned out to every `GET /` handler across all indexed projects, 236 of them in the dogfood graph).

After the fix, the same dogfood graph produces exactly one edge: `http://localhost:8000/docs -> GET /docs`.

## Changes

- `_has_literal_segment` helper in `codebase_rag/parsers/endpoints.py`; the link loop requires it before matching
- RED test first (`TestAllParameterTemplatesDoNotLink`): all-parameter and root templates must not link, mixed templates with a literal segment still link

## Testing

- `codebase_rag/tests/test_endpoint_extraction.py` RED then GREEN
- Full non-integration suite: 5470 passed; integration suite: 284 passed
- Live Memgraph validation on the dogfood graph: 23 edges before, 1 correct edge after