### PR TITLE
fix(vector): purge the vector store when the graph database is cleaned

### DIFF
--- a/codebase_rag/cli.py
+++ b/codebase_rag/cli.py
@@ -46,7 +46,7 @@ from .tools.health_checker import HealthChecker
 from .tools.language import cli as language_cli
 from .types_defs import DeadCodeConfig, DeadCodeRow, ResultRow
 from .utils.path_utils import derive_project_name, resolve_repo_path
-from .vector_store import delete_project_embeddings
+from .vector_store import clear_all_embeddings, delete_project_embeddings
 from .workspaces import WorkspaceConfig, WorkspaceError, load_workspace
 from .workspaces.cli import cli as workspace_cli
 
@@ -225,6 +225,9 @@ def _run_graph_sync(
             _info(style(cs.CLI_MSG_CLEANING_DB, cs.Color.YELLOW))
             ingestor.clean_database()
             _delete_hash_cache(repo)
+            # Stale vectors keyed by recycled node ids would crowd out live
+            # hits and can map onto unrelated nodes in the rebuilt graph.
+            clear_all_embeddings()
 
         ingestor.ensure_constraints()
 
@@ -452,6 +455,7 @@ def start(
             _info(style(cs.CLI_MSG_CLEANING_DB, cs.Color.YELLOW))
             ingestor.clean_database()
 
+        clear_all_embeddings()
         _delete_hash_cache(repo_to_clean)
         _info(style(cs.CLI_MSG_CLEAN_DONE, cs.Color.GREEN))
         return

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -136,7 +136,6 @@ VECTOR_STORE_DELETE_PROJECT_FAILED = (
     "Failed to delete {backend} vectors for project '{project}': {error}"
 )
 VECTOR_STORE_CLEARED = "Cleared all {backend} vectors"
-VECTOR_STORE_CLEAR_FAILED = "Failed to clear {backend} vectors: {error}"
 QDRANT_DELETE_PROJECT = "Deleting {count} Qdrant vectors for project '{project}'"
 QDRANT_DELETE_PROJECT_DONE = "Deleted Qdrant vectors for project '{project}'"
 QDRANT_DELETE_PROJECT_FAILED = (

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -135,6 +135,8 @@ VECTOR_STORE_DELETE_PROJECT_DONE = "Deleted {backend} vectors for project '{proj
 VECTOR_STORE_DELETE_PROJECT_FAILED = (
     "Failed to delete {backend} vectors for project '{project}': {error}"
 )
+VECTOR_STORE_CLEARED = "Cleared all {backend} vectors"
+VECTOR_STORE_CLEAR_FAILED = "Failed to clear {backend} vectors: {error}"
 QDRANT_DELETE_PROJECT = "Deleting {count} Qdrant vectors for project '{project}'"
 QDRANT_DELETE_PROJECT_DONE = "Deleted Qdrant vectors for project '{project}'"
 QDRANT_DELETE_PROJECT_FAILED = (

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -48,7 +48,7 @@ from codebase_rag.types_defs import (
 )
 from codebase_rag.utils.dependencies import has_ast_grep, has_semantic_dependencies
 from codebase_rag.utils.path_utils import derive_project_name
-from codebase_rag.vector_store import delete_project_embeddings
+from codebase_rag.vector_store import clear_all_embeddings, delete_project_embeddings
 
 
 class MCPToolsRegistry:
@@ -482,6 +482,7 @@ class MCPToolsRegistry:
         try:
             async with self._ingestor_lock:
                 await asyncio.to_thread(self.ingestor.clean_database)
+                await asyncio.to_thread(clear_all_embeddings)
             return cs.MCP_WIPE_SUCCESS
         except Exception as e:
             logger.error(lg.MCP_ERROR_WIPE.format(error=e))

--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -110,6 +110,20 @@ def _pin_csharp_frontend_treesitter(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture(autouse=True)
+def _isolate_vector_store(
+    tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Tests must never touch the developer's real local vector store: a
+    # clean-path test would purge it for real, and parallel xdist workers
+    # would collide on its file lock.
+    from codebase_rag.config import settings
+
+    monkeypatch.setattr(
+        settings, "QDRANT_DB_PATH", str(tmp_path_factory.mktemp("qdrant-iso"))
+    )
+
+
+@pytest.fixture(autouse=True)
 def _isolate_cgr_home(
     tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch
 ) -> Generator[Path, None, None]:

--- a/codebase_rag/tests/test_cli_clean.py
+++ b/codebase_rag/tests/test_cli_clean.py
@@ -59,6 +59,24 @@ class TestCleanWithoutUpdateGraph:
         assert result.exit_code == 0, result.output
         clear.assert_called_once()
 
+    def test_clean_alone_surfaces_vector_purge_failure(
+        self,
+        mock_memgraph_connect: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        # A silently failed purge would report a clean database while stale
+        # vectors keep resolving to unrelated nodes after the rebuild.
+        with patch(
+            "codebase_rag.cli.clear_all_embeddings",
+            side_effect=RuntimeError("purge failed"),
+        ):
+            result = runner.invoke(
+                app,
+                ["start", "--clean", "--repo-path", str(tmp_path)],
+            )
+
+        assert result.exit_code != 0
+
     def test_clean_alone_deletes_hash_cache(
         self,
         mock_memgraph_connect: MagicMock,

--- a/codebase_rag/tests/test_cli_clean.py
+++ b/codebase_rag/tests/test_cli_clean.py
@@ -43,6 +43,22 @@ class TestCleanWithoutUpdateGraph:
         ingestor = _get_ingestor(mock_memgraph_connect)
         ingestor.clean_database.assert_called_once()
 
+    def test_clean_alone_purges_vector_store(
+        self,
+        mock_memgraph_connect: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        # Stale vectors keyed by recycled Memgraph node ids crowd out live
+        # hits and can map onto unrelated nodes after a clean rebuild.
+        with patch("codebase_rag.cli.clear_all_embeddings") as clear:
+            result = runner.invoke(
+                app,
+                ["start", "--clean", "--repo-path", str(tmp_path)],
+            )
+
+        assert result.exit_code == 0, result.output
+        clear.assert_called_once()
+
     def test_clean_alone_deletes_hash_cache(
         self,
         mock_memgraph_connect: MagicMock,
@@ -166,6 +182,30 @@ class TestCleanWithUpdateGraph:
         assert result.exit_code == 0, result.output
         ingestor = _get_ingestor(mock_memgraph_connect)
         ingestor.clean_database.assert_called_once()
+
+    @patch("codebase_rag.cli.GraphUpdater")
+    @patch("codebase_rag.cli.load_parsers", return_value=({}, {}))
+    @patch("codebase_rag.cli.load_ignore_patterns")
+    def test_clean_with_update_purges_vector_store(
+        self,
+        mock_cgrignore: MagicMock,
+        mock_load_parsers: MagicMock,
+        mock_graph_updater: MagicMock,
+        mock_memgraph_connect: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        mock_cgrignore.return_value = CgrignorePatterns(
+            exclude=frozenset(), unignore=frozenset()
+        )
+
+        with patch("codebase_rag.cli.clear_all_embeddings") as clear:
+            result = runner.invoke(
+                app,
+                ["start", "--clean", "--update-graph", "--repo-path", str(tmp_path)],
+            )
+
+        assert result.exit_code == 0, result.output
+        clear.assert_called_once()
 
     @patch("codebase_rag.cli.GraphUpdater")
     @patch("codebase_rag.cli.load_parsers", return_value=({}, {}))

--- a/codebase_rag/tests/test_mcp_query_and_index.py
+++ b/codebase_rag/tests/test_mcp_query_and_index.py
@@ -568,6 +568,14 @@ class TestWipeDatabase:
         assert "wiped" in result.lower()
         mcp_registry.ingestor.clean_database.assert_called_once()  # type: ignore[attr-defined]
 
+    async def test_wipe_database_purges_vector_store(
+        self, mcp_registry: MCPToolsRegistry
+    ) -> None:
+        with patch("codebase_rag.mcp.tools.clear_all_embeddings") as clear:
+            await mcp_registry.wipe_database(confirm=True)
+
+        clear.assert_called_once()
+
     async def test_wipe_database_not_confirmed(
         self, mcp_registry: MCPToolsRegistry
     ) -> None:

--- a/codebase_rag/tests/test_mcp_query_and_index.py
+++ b/codebase_rag/tests/test_mcp_query_and_index.py
@@ -576,6 +576,17 @@ class TestWipeDatabase:
 
         clear.assert_called_once()
 
+    async def test_wipe_database_reports_vector_purge_failure(
+        self, mcp_registry: MCPToolsRegistry
+    ) -> None:
+        with patch(
+            "codebase_rag.mcp.tools.clear_all_embeddings",
+            side_effect=RuntimeError("purge failed"),
+        ):
+            result = await mcp_registry.wipe_database(confirm=True)
+
+        assert "purge failed" in result
+
     async def test_wipe_database_not_confirmed(
         self, mcp_registry: MCPToolsRegistry
     ) -> None:

--- a/codebase_rag/tests/test_vector_store.py
+++ b/codebase_rag/tests/test_vector_store.py
@@ -461,3 +461,37 @@ def test_module_clear_all_embeddings_noop_without_backend() -> None:
 
     with patch("codebase_rag.vector_store._get_vector_store", return_value=None):
         vs.clear_all_embeddings()
+
+
+def test_clear_all_embeddings_qdrant_propagates_failure(
+    reset_global_client: None,
+) -> None:
+    # A swallowed purge failure would let clean report success while stale
+    # vectors keep resolving to unrelated nodes in the rebuilt graph.
+    import codebase_rag.vector_store as vs
+
+    mock_client = MagicMock()
+    mock_client.delete_collection.side_effect = RuntimeError("qdrant down")
+    with (
+        patch(
+            "codebase_rag.vector_store.get_qdrant_client", return_value=mock_client
+        ),
+        pytest.raises(RuntimeError, match="qdrant down"),
+    ):
+        vs.QdrantVectorStore().clear_all_embeddings()
+
+
+def test_clear_all_embeddings_milvus_propagates_failure(
+    reset_global_client: None,
+) -> None:
+    import codebase_rag.vector_store as vs
+
+    mock_client = MagicMock()
+    mock_client.drop_collection.side_effect = RuntimeError("milvus down")
+    with (
+        patch(
+            "codebase_rag.vector_store.get_milvus_client", return_value=mock_client
+        ),
+        pytest.raises(RuntimeError, match="milvus down"),
+    ):
+        vs.MilvusVectorStore().clear_all_embeddings()

--- a/codebase_rag/tests/test_vector_store.py
+++ b/codebase_rag/tests/test_vector_store.py
@@ -472,11 +472,10 @@ def test_clear_all_embeddings_qdrant_propagates_failure(
 
     mock_client = MagicMock()
     mock_client.delete_collection.side_effect = RuntimeError("qdrant down")
-    with (
-        patch("codebase_rag.vector_store.get_qdrant_client", return_value=mock_client),
-        pytest.raises(RuntimeError, match="qdrant down"),
-    ):
-        vs.QdrantVectorStore().clear_all_embeddings()
+    with patch("codebase_rag.vector_store.get_qdrant_client", return_value=mock_client):
+        store = vs.QdrantVectorStore()
+        with pytest.raises(RuntimeError, match="qdrant down"):
+            store.clear_all_embeddings()
 
 
 def test_clear_all_embeddings_milvus_propagates_failure(
@@ -486,8 +485,7 @@ def test_clear_all_embeddings_milvus_propagates_failure(
 
     mock_client = MagicMock()
     mock_client.drop_collection.side_effect = RuntimeError("milvus down")
-    with (
-        patch("codebase_rag.vector_store.get_milvus_client", return_value=mock_client),
-        pytest.raises(RuntimeError, match="milvus down"),
-    ):
-        vs.MilvusVectorStore().clear_all_embeddings()
+    with patch("codebase_rag.vector_store.get_milvus_client", return_value=mock_client):
+        store = vs.MilvusVectorStore()
+        with pytest.raises(RuntimeError, match="milvus down"):
+            store.clear_all_embeddings()

--- a/codebase_rag/tests/test_vector_store.py
+++ b/codebase_rag/tests/test_vector_store.py
@@ -473,9 +473,7 @@ def test_clear_all_embeddings_qdrant_propagates_failure(
     mock_client = MagicMock()
     mock_client.delete_collection.side_effect = RuntimeError("qdrant down")
     with (
-        patch(
-            "codebase_rag.vector_store.get_qdrant_client", return_value=mock_client
-        ),
+        patch("codebase_rag.vector_store.get_qdrant_client", return_value=mock_client),
         pytest.raises(RuntimeError, match="qdrant down"),
     ):
         vs.QdrantVectorStore().clear_all_embeddings()
@@ -489,9 +487,7 @@ def test_clear_all_embeddings_milvus_propagates_failure(
     mock_client = MagicMock()
     mock_client.drop_collection.side_effect = RuntimeError("milvus down")
     with (
-        patch(
-            "codebase_rag.vector_store.get_milvus_client", return_value=mock_client
-        ),
+        patch("codebase_rag.vector_store.get_milvus_client", return_value=mock_client),
         pytest.raises(RuntimeError, match="milvus down"),
     ):
         vs.MilvusVectorStore().clear_all_embeddings()

--- a/codebase_rag/tests/test_vector_store.py
+++ b/codebase_rag/tests/test_vector_store.py
@@ -411,3 +411,59 @@ def test_milvus_store_search_verify_delete_roundtrip(
     assert [node_id for node_id, _score in results] == [101, 103]
     assert found_ids == {101, 102}
     assert remaining_ids == {103}
+
+
+def test_clear_all_embeddings_qdrant_drops_and_recreates_collection(
+    reset_global_client: None,
+) -> None:
+    import codebase_rag.vector_store as vs
+
+    mock_client = MagicMock()
+    with patch(
+        "codebase_rag.vector_store.get_qdrant_client", return_value=mock_client
+    ):
+        vs.QdrantVectorStore().clear_all_embeddings()
+
+    mock_client.delete_collection.assert_called_once_with(
+        collection_name=vs.settings.QDRANT_COLLECTION_NAME
+    )
+    mock_client.create_collection.assert_called_once()
+
+
+def test_clear_all_embeddings_milvus_drops_and_recreates_collection(
+    reset_global_client: None,
+) -> None:
+    import codebase_rag.vector_store as vs
+
+    mock_client = MagicMock()
+    with (
+        patch(
+            "codebase_rag.vector_store.get_milvus_client", return_value=mock_client
+        ),
+        patch(
+            "codebase_rag.vector_store._ensure_milvus_collection"
+        ) as mock_ensure,
+    ):
+        vs.MilvusVectorStore().clear_all_embeddings()
+
+    mock_client.drop_collection.assert_called_once_with(
+        vs.settings.MILVUS_COLLECTION_NAME
+    )
+    mock_ensure.assert_called_once_with(mock_client)
+
+
+def test_module_clear_all_embeddings_dispatches_to_backend() -> None:
+    import codebase_rag.vector_store as vs
+
+    store = MagicMock()
+    with patch("codebase_rag.vector_store._get_vector_store", return_value=store):
+        vs.clear_all_embeddings()
+
+    store.clear_all_embeddings.assert_called_once_with()
+
+
+def test_module_clear_all_embeddings_noop_without_backend() -> None:
+    import codebase_rag.vector_store as vs
+
+    with patch("codebase_rag.vector_store._get_vector_store", return_value=None):
+        vs.clear_all_embeddings()

--- a/codebase_rag/tests/test_vector_store.py
+++ b/codebase_rag/tests/test_vector_store.py
@@ -419,9 +419,7 @@ def test_clear_all_embeddings_qdrant_drops_and_recreates_collection(
     import codebase_rag.vector_store as vs
 
     mock_client = MagicMock()
-    with patch(
-        "codebase_rag.vector_store.get_qdrant_client", return_value=mock_client
-    ):
+    with patch("codebase_rag.vector_store.get_qdrant_client", return_value=mock_client):
         vs.QdrantVectorStore().clear_all_embeddings()
 
     mock_client.delete_collection.assert_called_once_with(
@@ -437,12 +435,8 @@ def test_clear_all_embeddings_milvus_drops_and_recreates_collection(
 
     mock_client = MagicMock()
     with (
-        patch(
-            "codebase_rag.vector_store.get_milvus_client", return_value=mock_client
-        ),
-        patch(
-            "codebase_rag.vector_store._ensure_milvus_collection"
-        ) as mock_ensure,
+        patch("codebase_rag.vector_store.get_milvus_client", return_value=mock_client),
+        patch("codebase_rag.vector_store._ensure_milvus_collection") as mock_ensure,
     ):
         vs.MilvusVectorStore().clear_all_embeddings()
 

--- a/codebase_rag/vector_store.py
+++ b/codebase_rag/vector_store.py
@@ -336,21 +336,18 @@ class QdrantVectorStore:
     def clear_all_embeddings(self) -> None:
         # Vectors are keyed by Memgraph-internal node ids, which a clean
         # rebuild reassigns; stale points crowd out live hits and can map
-        # onto unrelated nodes, so the whole collection must go.
-        try:
-            client = get_qdrant_client()
-            client.delete_collection(collection_name=settings.QDRANT_COLLECTION_NAME)
-            client.create_collection(
-                collection_name=settings.QDRANT_COLLECTION_NAME,
-                vectors_config=VectorParams(
-                    size=settings.QDRANT_VECTOR_DIM, distance=Distance.COSINE
-                ),
-            )
-            logger.info(ls.VECTOR_STORE_CLEARED.format(backend=self.backend))
-        except Exception as e:
-            logger.warning(
-                ls.VECTOR_STORE_CLEAR_FAILED.format(backend=self.backend, error=e)
-            )
+        # onto unrelated nodes, so the whole collection must go. Failures
+        # propagate: a swallowed error would let clean report success while
+        # the stale points survive.
+        client = get_qdrant_client()
+        client.delete_collection(collection_name=settings.QDRANT_COLLECTION_NAME)
+        client.create_collection(
+            collection_name=settings.QDRANT_COLLECTION_NAME,
+            vectors_config=VectorParams(
+                size=settings.QDRANT_VECTOR_DIM, distance=Distance.COSINE
+            ),
+        )
+        logger.info(ls.VECTOR_STORE_CLEARED.format(backend=self.backend))
 
     def verify_stored_ids(self, expected_ids: set[int]) -> set[int]:
         if not expected_ids:
@@ -461,15 +458,11 @@ class MilvusVectorStore:
             )
 
     def clear_all_embeddings(self) -> None:
-        try:
-            client = get_milvus_client()
-            client.drop_collection(settings.MILVUS_COLLECTION_NAME)
-            _ensure_milvus_collection(client)
-            logger.info(ls.VECTOR_STORE_CLEARED.format(backend=self.backend))
-        except Exception as e:
-            logger.warning(
-                ls.VECTOR_STORE_CLEAR_FAILED.format(backend=self.backend, error=e)
-            )
+        # Failures propagate; see QdrantVectorStore.clear_all_embeddings.
+        client = get_milvus_client()
+        client.drop_collection(settings.MILVUS_COLLECTION_NAME)
+        _ensure_milvus_collection(client)
+        logger.info(ls.VECTOR_STORE_CLEARED.format(backend=self.backend))
 
     def verify_stored_ids(self, expected_ids: set[int]) -> set[int]:
         if not expected_ids:

--- a/codebase_rag/vector_store.py
+++ b/codebase_rag/vector_store.py
@@ -81,6 +81,8 @@ class VectorStore(Protocol):
         self, project_name: str, node_ids: Sequence[int]
     ) -> None: ...
 
+    def clear_all_embeddings(self) -> None: ...
+
     def verify_stored_ids(self, expected_ids: set[int]) -> set[int]: ...
 
     def search_embeddings(
@@ -331,6 +333,27 @@ class QdrantVectorStore:
                 )
             )
 
+    def clear_all_embeddings(self) -> None:
+        # Vectors are keyed by Memgraph-internal node ids, which a clean
+        # rebuild reassigns; stale points crowd out live hits and can map
+        # onto unrelated nodes, so the whole collection must go.
+        try:
+            client = get_qdrant_client()
+            client.delete_collection(
+                collection_name=settings.QDRANT_COLLECTION_NAME
+            )
+            client.create_collection(
+                collection_name=settings.QDRANT_COLLECTION_NAME,
+                vectors_config=VectorParams(
+                    size=settings.QDRANT_VECTOR_DIM, distance=Distance.COSINE
+                ),
+            )
+            logger.info(ls.VECTOR_STORE_CLEARED.format(backend=self.backend))
+        except Exception as e:
+            logger.warning(
+                ls.VECTOR_STORE_CLEAR_FAILED.format(backend=self.backend, error=e)
+            )
+
     def verify_stored_ids(self, expected_ids: set[int]) -> set[int]:
         if not expected_ids:
             return set()
@@ -437,6 +460,17 @@ class MilvusVectorStore:
                 ls.VECTOR_STORE_DELETE_PROJECT_FAILED.format(
                     backend=self.backend, project=project_name, error=e
                 )
+            )
+
+    def clear_all_embeddings(self) -> None:
+        try:
+            client = get_milvus_client()
+            client.drop_collection(settings.MILVUS_COLLECTION_NAME)
+            _ensure_milvus_collection(client)
+            logger.info(ls.VECTOR_STORE_CLEARED.format(backend=self.backend))
+        except Exception as e:
+            logger.warning(
+                ls.VECTOR_STORE_CLEAR_FAILED.format(backend=self.backend, error=e)
             )
 
     def verify_stored_ids(self, expected_ids: set[int]) -> set[int]:
@@ -553,6 +587,13 @@ def delete_project_embeddings(project_name: str, node_ids: Sequence[int]) -> Non
     if vector_store is None:
         return
     vector_store.delete_project_embeddings(project_name, node_ids)
+
+
+def clear_all_embeddings() -> None:
+    vector_store = _get_vector_store()
+    if vector_store is None:
+        return
+    vector_store.clear_all_embeddings()
 
 
 def verify_stored_ids(expected_ids: set[int]) -> set[int]:

--- a/codebase_rag/vector_store.py
+++ b/codebase_rag/vector_store.py
@@ -339,9 +339,7 @@ class QdrantVectorStore:
         # onto unrelated nodes, so the whole collection must go.
         try:
             client = get_qdrant_client()
-            client.delete_collection(
-                collection_name=settings.QDRANT_COLLECTION_NAME
-            )
+            client.delete_collection(collection_name=settings.QDRANT_COLLECTION_NAME)
             client.create_collection(
                 collection_name=settings.QDRANT_COLLECTION_NAME,
                 vectors_config=VectorParams(

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.434"
+version = "0.0.436"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Dogfooding semantic search on a multi-project graph returned degraded results: a `top_k=4` query yielded only 2 hits, and after a few clean rebuilds it returned nothing at all. Root cause: embeddings are keyed by Memgraph-internal node ids, and `--clean` (and the MCP `wipe_database` tool) wipes the graph plus the hash cache but never touches the vector store. Stale points accumulate forever, crowd live hits out of the search window, and because Memgraph reassigns internal ids from scratch on a clean database, a stale vector can silently resolve to an unrelated node in the rebuilt graph.

## Changes

- `clear_all_embeddings()` on the `VectorStore` protocol, both backends, and the module-level dispatcher: Qdrant drops and recreates the collection; Milvus drops the collection and recreates it through the existing `_ensure_milvus_collection`
- Both CLI clean paths (`--clean` alone and `--clean --update-graph`) and the MCP `wipe_database` tool purge the store right after `clean_database()`
- The content-hash-keyed embedding cache is deliberately untouched: it is id-free, so re-embedding after a clean rebuild stays cheap

## Testing

- RED first: 7 failing tests across the CLI clean paths, MCP wipe, and both backend implementations
- Live validation: after `--clean` plus re-index, the collection holds exactly the fresh repo's 19 points and the same query fills all 4 slots with correct hits
- Full suite: 5751 passed; pre-commit green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to fully clear stored vector and embedding data across supported backends.
  * Database wipe and CLI cleanup operations now also remove stale vector data.
  * Vector stores are automatically recreated and ready for continued use after clearing.

* **Bug Fixes**
  * Prevented stale search results caused by outdated vector-store entries.

* **Tests**
  * Added coverage for vector clearing, cleanup workflows, error handling, and isolated test data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->