### PR TITLE
fix(vector): close the vector store client at exit instead of interpreter shutdown

### DIFF
--- a/codebase_rag/tests/test_vector_store.py
+++ b/codebase_rag/tests/test_vector_store.py
@@ -511,7 +511,12 @@ def test_process_exit_closes_local_client_cleanly(temp_qdrant_path: Path) -> Non
         check=False,
         capture_output=True,
         text=True,
-        env={**os.environ, "QDRANT_DB_PATH": str(temp_qdrant_path)},
+        env={
+            # An inherited QDRANT_URL would open a remote client and skip
+            # the local-path shutdown this test exists to exercise.
+            **{k: v for k, v in os.environ.items() if k != "QDRANT_URL"},
+            "QDRANT_DB_PATH": str(temp_qdrant_path),
+        },
         timeout=120,
     )
     assert result.returncode == 0

--- a/codebase_rag/tests/test_vector_store.py
+++ b/codebase_rag/tests/test_vector_store.py
@@ -503,7 +503,9 @@ def test_process_exit_closes_local_client_cleanly(temp_qdrant_path: Path) -> Non
     if not has_qdrant_client():
         pytest.skip("qdrant-client not installed")
 
-    script = "from codebase_rag.vector_store import get_qdrant_client; get_qdrant_client()"
+    script = (
+        "from codebase_rag.vector_store import get_qdrant_client; get_qdrant_client()"
+    )
     result = subprocess.run(
         [sys.executable, "-c", script],
         capture_output=True,

--- a/codebase_rag/tests/test_vector_store.py
+++ b/codebase_rag/tests/test_vector_store.py
@@ -508,6 +508,7 @@ def test_process_exit_closes_local_client_cleanly(temp_qdrant_path: Path) -> Non
     )
     result = subprocess.run(
         [sys.executable, "-c", script],
+        check=False,
         capture_output=True,
         text=True,
         env={**os.environ, "QDRANT_DB_PATH": str(temp_qdrant_path)},

--- a/codebase_rag/tests/test_vector_store.py
+++ b/codebase_rag/tests/test_vector_store.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import os
 import shutil
+import subprocess
+import sys
 import tempfile
 from collections.abc import Generator
 from pathlib import Path
@@ -489,3 +492,24 @@ def test_clear_all_embeddings_milvus_propagates_failure(
         store = vs.MilvusVectorStore()
         with pytest.raises(RuntimeError, match="milvus down"):
             store.clear_all_embeddings()
+
+
+def test_process_exit_closes_local_client_cleanly(temp_qdrant_path: Path) -> None:
+    # Nothing closes the module-global client on process exit, so teardown
+    # falls to QdrantClient.__del__ during interpreter shutdown, where
+    # qdrant's close() imports portalocker and dies with ImportError. Every
+    # CLI run that touches the store then ends with an "Exception ignored"
+    # traceback on stderr.
+    if not has_qdrant_client():
+        pytest.skip("qdrant-client not installed")
+
+    script = "from codebase_rag.vector_store import get_qdrant_client; get_qdrant_client()"
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "QDRANT_DB_PATH": str(temp_qdrant_path)},
+        timeout=120,
+    )
+    assert result.returncode == 0
+    assert "Exception ignored" not in result.stderr

--- a/codebase_rag/vector_store.py
+++ b/codebase_rag/vector_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import atexit
 import time
 from collections.abc import Callable, Sequence
 from importlib.metadata import PackageNotFoundError, version
@@ -105,6 +106,12 @@ def close_vector_store_client() -> None:
 
 def close_qdrant_client() -> None:
     close_vector_store_client()
+
+
+# Left to garbage collection, the client's __del__ runs during interpreter
+# shutdown, where qdrant's close() imports portalocker and dies with
+# ImportError; atexit runs while imports still work.
+atexit.register(close_vector_store_client)
 
 
 def _selected_backend() -> VectorStoreBackend | None:

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.438"
+version = "0.0.441"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
Every CLI run that touches the local vector store ended with an `Exception ignored in: QdrantClient.__del__` traceback on stderr. Nothing closes the module-global client on process exit, so teardown falls to the garbage collector during interpreter shutdown, where qdrant's `close()` imports portalocker and dies with `ImportError: sys.meta_path is None`. Found while dogfooding `cgr start --clean --no-embeddings` on real Dart repositories: #858 routes the clean path through the vector store, so the traceback now also fires on runs that never generate embeddings.

## Changes
- Register `close_vector_store_client` with `atexit` in `codebase_rag/vector_store.py`, so the client closes while imports still work. The function is idempotent and a noop when no client was ever created.

## Testing
- RED: new `test_process_exit_closes_local_client_cleanly` spawns a subprocess that opens the local client and exits, asserting no "Exception ignored" on stderr; it failed before the fix.
- GREEN after the fix; full unit suite passes (5477 passed) and a live `cgr start --clean --no-embeddings` run now exits with empty stderr.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown behavior by proactively closing the local vector store client during interpreter termination.
  * Prevented cleanup-related “Exception ignored” traceback output on exit.
* **Tests**
  * Added a regression test to verify the subprocess exits successfully without stderr cleanup tracebacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->