### PR TITLE
feat: show per-turn and session token usage and cost (#80)

### DIFF
--- a/codebase_rag/constants/cli.py
+++ b/codebase_rag/constants/cli.py
@@ -161,6 +161,9 @@ UI_MODEL_USAGE = "[bold yellow]Usage: /model <provider:model> (e.g., /model goog
 # appended only for proprietary models with a known price.
 UI_TURN_USAGE_TOKENS = "tokens · turn {ti:,}→{to:,} · session {si:,}→{so:,}"
 UI_TURN_USAGE_COST = " · ${tc:.4f} turn · ${sc:.4f} session"
+# When an earlier turn had no known price (e.g. a local model), the running
+# session total understates the true spend, so it is shown as a partial floor.
+UI_TURN_USAGE_COST_PARTIAL = " · ${tc:.4f} turn · ${sc:.4f}+ session (partial)"
 UI_HELP_COMMANDS = """[bold cyan]Available commands:[/bold cyan]
   /model <provider:model> - Switch to a different model
   /model                  - Show current model

--- a/codebase_rag/constants/cli.py
+++ b/codebase_rag/constants/cli.py
@@ -157,6 +157,10 @@ UI_MODEL_SWITCHED = "[bold green]Model switched to: {model}[/bold green]"
 UI_MODEL_CURRENT = "[bold cyan]Current model: {model}[/bold cyan]"
 UI_MODEL_SWITCH_ERROR = "[bold red]Failed to switch model: {error}[/bold red]"
 UI_MODEL_USAGE = "[bold yellow]Usage: /model <provider:model> (e.g., /model google:gemini-3.1-pro-preview)[/bold yellow]"
+# Per-turn token consumption and USD cost line (issue #80). The cost segment is
+# appended only for proprietary models with a known price.
+UI_TURN_USAGE_TOKENS = "tokens · turn {ti:,}→{to:,} · session {si:,}→{so:,}"
+UI_TURN_USAGE_COST = " · ${tc:.4f} turn · ${sc:.4f} session"
 UI_HELP_COMMANDS = """[bold cyan]Available commands:[/bold cyan]
   /model <provider:model> - Switch to a different model
   /model                  - Show current model

--- a/codebase_rag/main.py
+++ b/codebase_rag/main.py
@@ -606,6 +606,8 @@ def _record_and_print_turn_usage(
     session.total_input_tokens += turn_input
     session.total_output_tokens += turn_output
     session.total_cost_usd += turn_cost
+    if not turn_priced:
+        session.cost_incomplete = True
     line = cs.UI_TURN_USAGE_TOKENS.format(
         ti=turn_input,
         to=turn_output,
@@ -613,7 +615,12 @@ def _record_and_print_turn_usage(
         so=session.total_output_tokens,
     )
     if turn_priced:
-        line += cs.UI_TURN_USAGE_COST.format(tc=turn_cost, sc=session.total_cost_usd)
+        template = (
+            cs.UI_TURN_USAGE_COST_PARTIAL
+            if session.cost_incomplete
+            else cs.UI_TURN_USAGE_COST
+        )
+        line += template.format(tc=turn_cost, sc=session.total_cost_usd)
     app_context.console.print(dim(line))
 
 

--- a/codebase_rag/main.py
+++ b/codebase_rag/main.py
@@ -586,11 +586,14 @@ def _cancel_orphaned_tool_calls(message_history: list[ModelMessage]) -> None:
     )
 
 
-def _price_current_run(usage: RunUsage) -> Decimal | None:
-    try:
-        model_config = settings.active_orchestrator_config
-    except Exception:  # noqa: BLE001 - pricing is display-only, never fatal
-        return None
+def _price_current_run(
+    usage: RunUsage, model_config: ModelConfig | None
+) -> Decimal | None:
+    if model_config is None:
+        try:
+            model_config = settings.active_orchestrator_config
+        except Exception:  # noqa: BLE001 - pricing is display-only, never fatal
+            return None
     from .services.usage_cost import price_run
 
     return price_run(usage, model_config.provider, model_config.model_id)
@@ -603,15 +606,13 @@ def _record_and_print_turn_usage(
     session.total_input_tokens += turn_input
     session.total_output_tokens += turn_output
     session.total_cost_usd += turn_cost
-    if turn_priced:
-        session.cost_known = True
     line = cs.UI_TURN_USAGE_TOKENS.format(
         ti=turn_input,
         to=turn_output,
         si=session.total_input_tokens,
         so=session.total_output_tokens,
     )
-    if session.cost_known:
+    if turn_priced:
         line += cs.UI_TURN_USAGE_COST.format(tc=turn_cost, sc=session.total_cost_usd)
     app_context.console.print(dim(line))
 
@@ -623,6 +624,7 @@ async def _run_agent_response_loop(
     config: AgentLoopUI,
     tool_names: ConfirmationToolNames,
     model_override: Model | None = None,
+    model_override_config: ModelConfig | None = None,
 ) -> None:
     deferred_results: DeferredToolResults | None = None
     pending_prompt: str | list[UserContent] | None = question_with_context
@@ -653,7 +655,7 @@ async def _run_agent_response_loop(
         run_usage = response.usage()
         turn_input += run_usage.input_tokens
         turn_output += run_usage.output_tokens
-        run_cost = _price_current_run(run_usage)
+        run_cost = _price_current_run(run_usage, model_override_config)
         if run_cost is not None:
             turn_cost += run_cost
             turn_priced = True
@@ -1313,6 +1315,7 @@ async def _run_interactive_loop(
                 config,
                 tool_names,
                 model_override,
+                model_override_config,
             )
 
             initial_question = None

--- a/codebase_rag/main.py
+++ b/codebase_rag/main.py
@@ -16,6 +16,7 @@ from collections import deque
 from collections.abc import Callable, Coroutine
 from contextlib import contextmanager
 from dataclasses import replace
+from decimal import Decimal
 from html import escape as html_escape
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -93,6 +94,7 @@ if TYPE_CHECKING:
     from pydantic_ai import Agent
     from pydantic_ai.messages import ModelMessage
     from pydantic_ai.models import Model
+    from pydantic_ai.usage import RunUsage
 
 
 def style(
@@ -584,6 +586,36 @@ def _cancel_orphaned_tool_calls(message_history: list[ModelMessage]) -> None:
     )
 
 
+def _price_current_run(usage: RunUsage) -> Decimal | None:
+    try:
+        model_config = settings.active_orchestrator_config
+    except Exception:  # noqa: BLE001 - pricing is display-only, never fatal
+        return None
+    from .services.usage_cost import price_run
+
+    return price_run(usage, model_config.provider, model_config.model_id)
+
+
+def _record_and_print_turn_usage(
+    turn_input: int, turn_output: int, turn_cost: Decimal, turn_priced: bool
+) -> None:
+    session = app_context.session
+    session.total_input_tokens += turn_input
+    session.total_output_tokens += turn_output
+    session.total_cost_usd += turn_cost
+    if turn_priced:
+        session.cost_known = True
+    line = cs.UI_TURN_USAGE_TOKENS.format(
+        ti=turn_input,
+        to=turn_output,
+        si=session.total_input_tokens,
+        so=session.total_output_tokens,
+    )
+    if session.cost_known:
+        line += cs.UI_TURN_USAGE_COST.format(tc=turn_cost, sc=session.total_cost_usd)
+    app_context.console.print(dim(line))
+
+
 async def _run_agent_response_loop(
     rag_agent: Agent[None, str | DeferredToolRequests],
     message_history: list[ModelMessage],
@@ -594,6 +626,9 @@ async def _run_agent_response_loop(
 ) -> None:
     deferred_results: DeferredToolResults | None = None
     pending_prompt: str | list[UserContent] | None = question_with_context
+    turn_input = turn_output = 0
+    turn_cost = Decimal(0)
+    turn_priced = False
 
     while True:
         with _thinking_with_status_bar(config.status_message):
@@ -614,6 +649,14 @@ async def _run_agent_response_loop(
             break
 
         message_history.extend(response.new_messages())
+
+        run_usage = response.usage()
+        turn_input += run_usage.input_tokens
+        turn_output += run_usage.output_tokens
+        run_cost = _price_current_run(run_usage)
+        if run_cost is not None:
+            turn_cost += run_cost
+            turn_priced = True
 
         if isinstance(response.output, DeferredToolRequests):
             deferred_results = await _process_tool_approvals(
@@ -639,6 +682,7 @@ async def _run_agent_response_loop(
         )
 
         log_session_event(f"{cs.SESSION_PREFIX_ASSISTANT}{output_text}")
+        _record_and_print_turn_usage(turn_input, turn_output, turn_cost, turn_priced)
         break
 
 

--- a/codebase_rag/models.py
+++ b/codebase_rag/models.py
@@ -26,6 +26,8 @@ class SessionState:
     total_input_tokens: int = 0
     total_output_tokens: int = 0
     total_cost_usd: Decimal = field(default_factory=lambda: Decimal(0))
+    # Set once any turn cannot be priced, so the session total is a floor.
+    cost_incomplete: bool = False
 
     def reset_cancelled(self) -> None:
         self.cancelled = False

--- a/codebase_rag/models.py
+++ b/codebase_rag/models.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from decimal import Decimal
 from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple
 
@@ -21,6 +22,11 @@ class SessionState:
     permission_mode: PermissionMode = PermissionMode.NORMAL
     context_tokens: int = 0
     target_repo: Path | None = None
+    # Cumulative token consumption and USD cost across the session (issue #80).
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    total_cost_usd: Decimal = field(default_factory=lambda: Decimal(0))
+    cost_known: bool = False
 
     def reset_cancelled(self) -> None:
         self.cancelled = False

--- a/codebase_rag/models.py
+++ b/codebase_rag/models.py
@@ -26,7 +26,6 @@ class SessionState:
     total_input_tokens: int = 0
     total_output_tokens: int = 0
     total_cost_usd: Decimal = field(default_factory=lambda: Decimal(0))
-    cost_known: bool = False
 
     def reset_cancelled(self) -> None:
         self.cancelled = False

--- a/codebase_rag/services/usage_cost.py
+++ b/codebase_rag/services/usage_cost.py
@@ -1,0 +1,32 @@
+# Per-run USD cost from token usage (issue #80). Prices a run's RunUsage with
+# the genai-prices data bundled via pydantic-ai, so no price table is hand
+# maintained here. Local or unknown models have no public price, so pricing
+# returns None and callers show token counts without a cost, which keeps cost
+# reporting to proprietary models only.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from decimal import Decimal
+
+    from pydantic_ai.usage import RunUsage
+
+
+def price_run(usage: RunUsage, provider: str, model_id: str) -> Decimal | None:
+    """USD cost for one run, or None when the model has no known public price.
+
+    ``model_id`` may carry a ``provider:model`` prefix; only the model part is
+    priced. The given provider is tried first, then genai-prices auto-detection
+    from the model id, so a proxy provider name (e.g. litellm) still prices a
+    recognizable model.
+    """
+    model_ref = model_id.split(":", 1)[-1]
+    for provider_id in (provider or None, None):
+        try:
+            from genai_prices import calc_price
+
+            return calc_price(usage, model_ref, provider_id=provider_id).total_price
+        except Exception:  # noqa: BLE001 - pricing is display-only, never fatal
+            continue
+    return None

--- a/codebase_rag/tests/test_model_switching.py
+++ b/codebase_rag/tests/test_model_switching.py
@@ -5,11 +5,13 @@ from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pydantic_ai.usage import RunUsage
 
 from codebase_rag import constants as cs
 from codebase_rag import exceptions as ex
 from codebase_rag.config import ModelConfig
 from codebase_rag.main import _create_model_from_string, _handle_model_command
+from codebase_rag.models import SessionState
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -171,6 +173,7 @@ class TestModelOverrideInAgentLoop:
         mock_response = MagicMock()
         mock_response.output = "Test response"
         mock_response.new_messages.return_value = []
+        mock_response.usage.return_value = RunUsage(input_tokens=0, output_tokens=0)
         mock_agent.run = AsyncMock(return_value=mock_response)
 
         mock_model = MagicMock()
@@ -188,6 +191,7 @@ class TestModelOverrideInAgentLoop:
             mock_ctx.console.status.return_value.__enter__ = MagicMock()
             mock_ctx.console.status.return_value.__exit__ = MagicMock()
             mock_ctx.console.print = MagicMock()
+            mock_ctx.session = SessionState()
 
             await _run_agent_response_loop(
                 mock_agent,
@@ -211,6 +215,7 @@ class TestModelOverrideInAgentLoop:
         mock_response = MagicMock()
         mock_response.output = "Test response"
         mock_response.new_messages.return_value = []
+        mock_response.usage.return_value = RunUsage(input_tokens=0, output_tokens=0)
         mock_agent.run = AsyncMock(return_value=mock_response)
 
         tool_names = ConfirmationToolNames(
@@ -227,6 +232,7 @@ class TestModelOverrideInAgentLoop:
             mock_ctx.console.status.return_value.__enter__ = MagicMock()
             mock_ctx.console.status.return_value.__exit__ = MagicMock()
             mock_ctx.console.print = MagicMock()
+            mock_ctx.session = SessionState()
 
             await _run_agent_response_loop(
                 mock_agent,
@@ -247,6 +253,7 @@ class TestAgentLoopUserPromptOnResume:
         response = MagicMock()
         response.output = output
         response.new_messages.return_value = []
+        response.usage.return_value = RunUsage(input_tokens=0, output_tokens=0)
         return response
 
     @staticmethod
@@ -288,7 +295,7 @@ class TestAgentLoopUserPromptOnResume:
 
         with ctx as mock_ctx, log_evt, approvals, refresh, status:
             mock_ctx.console.print = MagicMock()
-            mock_ctx.session.cancelled = False
+            mock_ctx.session = SessionState()
 
             await _run_agent_response_loop(
                 mock_agent,
@@ -330,7 +337,7 @@ class TestAgentLoopUserPromptOnResume:
 
         with ctx as mock_ctx, log_evt, approvals, refresh, status:
             mock_ctx.console.print = MagicMock()
-            mock_ctx.session.cancelled = False
+            mock_ctx.session = SessionState()
 
             await _run_agent_response_loop(
                 mock_agent, [], "multi-step task", CHAT_LOOP_UI, tool_names
@@ -358,7 +365,7 @@ class TestAgentLoopUserPromptOnResume:
 
         with ctx as mock_ctx, log_evt, approvals, refresh, status:
             mock_ctx.console.print = MagicMock()
-            mock_ctx.session.cancelled = False
+            mock_ctx.session = SessionState()
 
             await _run_agent_response_loop(
                 mock_agent, [], "just a question", CHAT_LOOP_UI, tool_names
@@ -396,7 +403,7 @@ class TestAgentLoopUserPromptOnResume:
 
         with ctx as mock_ctx, log_evt, approvals, refresh, status:
             mock_ctx.console.print = MagicMock()
-            mock_ctx.session.cancelled = False
+            mock_ctx.session = SessionState()
 
             await _run_agent_response_loop(
                 mock_agent, [], multimodal_prompt, CHAT_LOOP_UI, tool_names
@@ -439,7 +446,7 @@ class TestAgentLoopUserPromptOnResume:
             patch("codebase_rag.main._thinking_with_status_bar"),
         ):
             mock_ctx.console.print = MagicMock()
-            mock_ctx.session.cancelled = False
+            mock_ctx.session = SessionState()
 
             await _run_agent_response_loop(
                 mock_agent, [], "edit file", CHAT_LOOP_UI, tool_names

--- a/codebase_rag/tests/test_turn_usage_display.py
+++ b/codebase_rag/tests/test_turn_usage_display.py
@@ -55,6 +55,20 @@ def test_priced_turn_shows_cost_segment() -> None:
     assert "$0.0105" in buffer.getvalue()
 
 
+def test_session_total_marked_partial_after_an_unpriced_turn() -> None:
+    # priced -> unpriced -> priced: the final session total omits the unpriced
+    # turn, so it must be shown as a partial floor, not a definitive total.
+    _, buffer = _fresh_session()
+    main._record_and_print_turn_usage(1000, 500, Decimal("0.01"), turn_priced=True)
+    main._record_and_print_turn_usage(200, 100, Decimal(0), turn_priced=False)
+    buffer.truncate(0)
+    buffer.seek(0)
+    main._record_and_print_turn_usage(300, 150, Decimal("0.003"), turn_priced=True)
+    out = buffer.getvalue()
+    assert "partial" in out
+    assert "$0.0130+" in out
+
+
 def test_price_current_run_none_when_no_config(monkeypatch) -> None:
     class _Boom:
         @property

--- a/codebase_rag/tests/test_turn_usage_display.py
+++ b/codebase_rag/tests/test_turn_usage_display.py
@@ -26,12 +26,24 @@ def test_accumulates_tokens_and_cost_across_turns() -> None:
     assert session.total_input_tokens == 1200
     assert session.total_output_tokens == 600
     assert session.total_cost_usd == Decimal("0.012")
-    assert session.cost_known is True
 
 
 def test_cost_stays_hidden_until_a_turn_is_priced() -> None:
     _, buffer = _fresh_session()
     main._record_and_print_turn_usage(10, 5, Decimal(0), turn_priced=False)
+    out = buffer.getvalue()
+    assert "tokens" in out
+    assert "$" not in out
+
+
+def test_unpriced_turn_after_priced_turn_hides_cost() -> None:
+    # Switching to a local/unknown model mid-session must not render its
+    # unpriced turn as a known $0 cost just because an earlier turn was priced.
+    _, buffer = _fresh_session()
+    main._record_and_print_turn_usage(1000, 500, Decimal("0.01"), turn_priced=True)
+    buffer.truncate(0)
+    buffer.seek(0)
+    main._record_and_print_turn_usage(200, 100, Decimal(0), turn_priced=False)
     out = buffer.getvalue()
     assert "tokens" in out
     assert "$" not in out
@@ -50,4 +62,24 @@ def test_price_current_run_none_when_no_config(monkeypatch) -> None:
             raise RuntimeError("no config")
 
     monkeypatch.setattr(main, "settings", _Boom())
-    assert main._price_current_run(object()) is None
+    assert main._price_current_run(object(), None) is None
+
+
+def test_price_current_run_uses_override_config(monkeypatch) -> None:
+    # After a /model switch, pricing must follow the override config, not the
+    # default orchestrator config. Boom settings prove settings is not consulted.
+    from pydantic_ai.usage import RunUsage
+
+    from codebase_rag.config import ModelConfig
+
+    class _Boom:
+        @property
+        def active_orchestrator_config(self):  # noqa: ANN202
+            raise RuntimeError("settings must not be read when an override exists")
+
+    monkeypatch.setattr(main, "settings", _Boom())
+    override = ModelConfig(provider="anthropic", model_id="claude-sonnet-4-5")
+    usage = RunUsage(input_tokens=1000, output_tokens=500)
+    cost = main._price_current_run(usage, override)
+    assert cost is not None
+    assert cost > 0

--- a/codebase_rag/tests/test_turn_usage_display.py
+++ b/codebase_rag/tests/test_turn_usage_display.py
@@ -1,0 +1,53 @@
+# Unit tests for the per-turn token/cost display helpers (issue #80). No DB or
+# LLM call: they drive the accumulator and formatting directly.
+from __future__ import annotations
+
+import io
+from decimal import Decimal
+
+from rich.console import Console
+
+from codebase_rag import main
+from codebase_rag.models import SessionState
+
+
+def _fresh_session() -> tuple[SessionState, io.StringIO]:
+    session = SessionState()
+    main.app_context.session = session
+    buffer = io.StringIO()
+    main.app_context.console = Console(file=buffer, force_terminal=False, no_color=True)
+    return session, buffer
+
+
+def test_accumulates_tokens_and_cost_across_turns() -> None:
+    session, _ = _fresh_session()
+    main._record_and_print_turn_usage(1000, 500, Decimal("0.01"), turn_priced=True)
+    main._record_and_print_turn_usage(200, 100, Decimal("0.002"), turn_priced=True)
+    assert session.total_input_tokens == 1200
+    assert session.total_output_tokens == 600
+    assert session.total_cost_usd == Decimal("0.012")
+    assert session.cost_known is True
+
+
+def test_cost_stays_hidden_until_a_turn_is_priced() -> None:
+    _, buffer = _fresh_session()
+    main._record_and_print_turn_usage(10, 5, Decimal(0), turn_priced=False)
+    out = buffer.getvalue()
+    assert "tokens" in out
+    assert "$" not in out
+
+
+def test_priced_turn_shows_cost_segment() -> None:
+    _, buffer = _fresh_session()
+    main._record_and_print_turn_usage(1000, 500, Decimal("0.0105"), turn_priced=True)
+    assert "$0.0105" in buffer.getvalue()
+
+
+def test_price_current_run_none_when_no_config(monkeypatch) -> None:
+    class _Boom:
+        @property
+        def active_orchestrator_config(self):  # noqa: ANN202
+            raise RuntimeError("no config")
+
+    monkeypatch.setattr(main, "settings", _Boom())
+    assert main._price_current_run(object()) is None

--- a/codebase_rag/tests/test_usage_cost.py
+++ b/codebase_rag/tests/test_usage_cost.py
@@ -1,0 +1,46 @@
+# Per-run USD cost pricing (issue #80). These are pure unit tests: they price a
+# RunUsage against the bundled genai-prices data with no DB or LLM call.
+from __future__ import annotations
+
+from pydantic_ai.usage import RunUsage
+
+from codebase_rag.services.usage_cost import price_run
+
+
+def test_prices_known_proprietary_model() -> None:
+    cost = price_run(
+        RunUsage(input_tokens=1000, output_tokens=500),
+        "anthropic",
+        "anthropic:claude-sonnet-4-5",
+    )
+    assert cost is not None
+    assert cost > 0
+
+
+def test_strips_provider_prefix_from_model_id() -> None:
+    usage = RunUsage(input_tokens=1000, output_tokens=0)
+    with_prefix = price_run(usage, "openai", "openai:gpt-4o")
+    without_prefix = price_run(usage, "openai", "gpt-4o")
+    assert with_prefix is not None
+    assert with_prefix == without_prefix
+
+
+def test_unknown_local_model_returns_none() -> None:
+    cost = price_run(
+        RunUsage(input_tokens=1000, output_tokens=500),
+        "ollama",
+        "ollama:llama3",
+    )
+    assert cost is None
+
+
+def test_mismatched_provider_falls_back_to_autodetect() -> None:
+    # A provider string genai-prices does not know (e.g. a proxy) still prices
+    # when the model id alone is recognizable.
+    cost = price_run(
+        RunUsage(input_tokens=1000, output_tokens=500),
+        "litellm",
+        "claude-sonnet-4-5",
+    )
+    assert cost is not None
+    assert cost > 0

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.438"
+version = "0.0.441"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #80.

Shows how many tokens each turn consumed and what it cost, plus running session totals, in the interactive chat.

## What it does
- After every assistant turn the REPL prints a compact dim line:
  `tokens · turn 1,523→488 · session 12,045→3,902 · $0.0105 turn · $0.1837 session`
- Token counts come from the model's own reported usage (`response.usage()`), so they are exact, not estimated.
- Cost is computed from the bundled `genai-prices` data, so there is no hand-maintained price table to go stale.
- The cost segment appears only for models with a known public price. Local or unknown models (Ollama and similar) show token counts with no cost, which keeps cost reporting to proprietary models, exactly what the issue asked for.

## How
- `services/usage_cost.py`: a small pure `price_run(usage, provider, model_id)` that returns the USD cost for one run, or `None` when the model has no known price. It tries the configured provider first, then falls back to price data auto-detection from the model id, so a proxy provider name still prices a recognizable model.
- `SessionState` gains cumulative token and cost accumulators.
- `_run_agent_response_loop` accumulates each run's usage across a turn (including tool-approval rounds) and prints the line once the turn completes.

Pricing is display only and is fully guarded, so a missing price or a pricing error never interrupts a turn.

## Tests
- `test_usage_cost.py`: prices a known proprietary model, strips a `provider:model` prefix, returns `None` for a local model, and falls back to auto-detection on an unknown provider.
- `test_turn_usage_display.py`: accumulation across turns, cost hidden until a turn is priced, cost shown once priced.
- All unit tests here run with no database or model call. Full suite: 5775 passed, 10 skipped.

Note: the one-shot `--ask-agent` path is left untouched so its stdout stays machine-parseable; a usage figure there would fit better as a JSON payload field and can be a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added per-turn token usage reporting (input/output) with session-wide cumulative totals.
  - Added per-turn USD cost display when pricing can be computed, plus accumulated session cost.
  - Supports pricing across recognized providers and honors model overrides.
- **Improvements**
  - Cost details remain hidden for turns that can’t be priced, preventing cost “leakage” across turns.
  - Usage/cost reporting stays consistent during interactive runs, including model switching.
- **Tests**
  - Added/extended unit coverage for pricing logic and per-turn/session display behavior, including partial-session totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->