### PR TITLE
fix(updater): discard the hash cache when the graph no longer holds the project

### DIFF
--- a/codebase_rag/constants/graph.py
+++ b/codebase_rag/constants/graph.py
@@ -348,6 +348,10 @@ CYPHER_DELETE_CALLS = "MATCH ()-[r:CALLS]->() DELETE r"
 CYPHER_DELETE_ORPHAN_EXTERNAL_MODULES = (
     "MATCH (m:ExternalModule) WHERE NOT (m)<--() DETACH DELETE m"
 )
+CYPHER_COUNT_PROJECT_MODULES = (
+    "MATCH (m:Module) WHERE m.qualified_name STARTS WITH $project_prefix "
+    "RETURN count(m) AS count"
+)
 
 # Queries for orphan pruning: return all paths stored in the graph
 CYPHER_ALL_FILE_PATHS = (

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -566,6 +566,7 @@ class GraphUpdater:
         logger.info(ls.ENSURING_PROJECT, name=self.project_name)
 
         if not force and self._single_file is None:
+            self._drop_cache_if_graph_lost()
             self._warn_if_parser_changed()
 
         if not force and self._is_already_in_sync():
@@ -1081,6 +1082,37 @@ class GraphUpdater:
                 unignore_could_match_within(u, rel_dir) for u in self.unignore_paths
             )
         )
+
+    def _drop_cache_if_graph_lost(self) -> None:
+        """Discard the hash cache when the graph no longer holds this project.
+
+        The cache lives inside the repo, but the database is shared: cleaning
+        the database while indexing another repo, an MCP wipe_database, or a
+        fresh Memgraph instance voids the cache without touching it, and an
+        incremental sync that trusts it would skip every file and leave the
+        project silently empty.
+        """
+        cache_path = self.repo_path / cs.HASH_CACHE_FILENAME
+        if not cache_path.is_file():
+            return
+        fetch_all = getattr(self.ingestor, "fetch_all", None)
+        if fetch_all is None:
+            return
+        rows = fetch_all(
+            cs.CYPHER_COUNT_PROJECT_MODULES,
+            {cs.KEY_PROJECT_PREFIX: self.project_name + "."},
+        )
+        try:
+            # count() always yields exactly one row; anything else means the
+            # sink did not really answer and cannot invalidate the cache.
+            count = int(rows[0]["count"])
+        except (KeyError, IndexError, TypeError, ValueError):
+            return
+        if count:
+            return
+        logger.warning(ls.HASH_CACHE_ORPHANED.format(project=self.project_name))
+        cache_path.unlink(missing_ok=True)
+        (self.repo_path / cs.DIR_MTIMES_FILENAME).unlink(missing_ok=True)
 
     def _warn_if_parser_changed(self) -> None:
         # No hash cache means a full build is coming: nothing to compare.

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1098,10 +1098,15 @@ class GraphUpdater:
         fetch_all = getattr(self.ingestor, "fetch_all", None)
         if fetch_all is None:
             return
-        rows = fetch_all(
-            cs.CYPHER_COUNT_PROJECT_MODULES,
-            {cs.KEY_PROJECT_PREFIX: self.project_name + "."},
-        )
+        try:
+            rows = fetch_all(
+                cs.CYPHER_COUNT_PROJECT_MODULES,
+                {cs.KEY_PROJECT_PREFIX: self.project_name + "."},
+            )
+        except Exception:
+            # A graph that cannot answer (connection refused, a sink that
+            # rejects reads) cannot invalidate the cache: fail open.
+            return
         try:
             # count() always yields exactly one row; anything else means the
             # sink did not really answer and cannot invalidate the cache.

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -779,6 +779,11 @@ INCREMENTAL_SKIPPED = "Skipped {count} unchanged files"
 INCREMENTAL_CHANGED = "Re-indexing {count} changed files"
 INCREMENTAL_DELETED = "Removed state for {count} deleted files"
 INCREMENTAL_FORCE = "Force mode enabled, bypassing hash cache"
+HASH_CACHE_ORPHANED = (
+    "Hash cache exists but project '{project}' has no modules in the graph; "
+    "the database was likely wiped since the last sync. Discarding the cache "
+    "and rebuilding fully."
+)
 PARSER_FINGERPRINT_SAVE_FAILED = "Failed to save parser fingerprint to {path}: {error}"
 PARSER_FINGERPRINT_MISMATCH = (
     "Parser code changed since this graph was built. Incremental sync keeps "

--- a/codebase_rag/tests/integration/test_stale_hash_cache_e2e.py
+++ b/codebase_rag/tests/integration/test_stale_hash_cache_e2e.py
@@ -1,0 +1,84 @@
+"""A hash cache must not survive the graph it describes.
+
+The cache lives inside the repo, but the database is shared: cleaning the
+database while indexing another repo (or MCP wipe_database, or pointing cgr
+at a fresh instance) voids every other repo's cache without touching it.
+An incremental sync that trusts the orphaned cache skips every file and
+leaves the project silently empty.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+if TYPE_CHECKING:
+    from codebase_rag.services.graph_service import MemgraphIngestor
+
+pytestmark = [pytest.mark.integration]
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    project = tmp_path / "cachedrepo"
+    project.mkdir()
+    (project / "main.py").write_text(
+        """def hello():
+    return "hi"
+""",
+        encoding="utf-8",
+    )
+    return project
+
+
+def _index(ingestor: MemgraphIngestor, repo_path: Path) -> None:
+    parsers, queries = load_parsers()
+    GraphUpdater(
+        ingestor=ingestor, repo_path=repo_path, parsers=parsers, queries=queries
+    ).run()
+
+
+def _module_count(ingestor: MemgraphIngestor) -> int:
+    rows = ingestor.fetch_all(
+        "MATCH (m:Module) WHERE m.qualified_name STARTS WITH 'cachedrepo.' "
+        "RETURN count(m) AS count"
+    )
+    return int(rows[0]["count"])
+
+
+class TestStaleHashCache:
+    def test_reindex_after_external_wipe_rebuilds_fully(
+        self, memgraph_ingestor: MemgraphIngestor, repo: Path
+    ) -> None:
+        _index(memgraph_ingestor, repo)
+        assert _module_count(memgraph_ingestor) > 0
+        assert (repo / cs.HASH_CACHE_FILENAME).is_file()
+
+        # Anything outside this repo's own clean path can wipe the shared
+        # database: --clean while indexing another repo, MCP wipe_database,
+        # a fresh Memgraph container.
+        memgraph_ingestor._execute_query("MATCH (n) DETACH DELETE n")
+
+        _index(memgraph_ingestor, repo)
+        assert _module_count(memgraph_ingestor) > 0
+
+    def test_intact_graph_keeps_incremental_sync(
+        self, memgraph_ingestor: MemgraphIngestor, repo: Path
+    ) -> None:
+        _index(memgraph_ingestor, repo)
+
+        parsers, queries = load_parsers()
+        updater = GraphUpdater(
+            ingestor=memgraph_ingestor,
+            repo_path=repo,
+            parsers=parsers,
+            queries=queries,
+        )
+        updater.run()
+        assert updater.skipped_because_in_sync

--- a/codebase_rag/tests/test_hash_cache_guard.py
+++ b/codebase_rag/tests/test_hash_cache_guard.py
@@ -1,0 +1,31 @@
+# The cache-invalidation preflight asks the graph whether the project still
+# exists; a graph that cannot answer (connection refused, a sink that rejects
+# reads) must fail OPEN: keep the cache, keep syncing. A raised query error
+# aborted the whole non-forced sync instead.
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import create_and_run_updater
+
+
+def test_query_failure_keeps_cache_and_sync(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    cache_path = temp_repo / cs.HASH_CACHE_FILENAME
+    cache_path.write_text(json.dumps({"m.py": "stale"}), encoding="utf-8")
+
+    def unavailable(query: str, params: dict | None = None) -> list:
+        if query == cs.CYPHER_COUNT_PROJECT_MODULES:
+            raise RuntimeError("graph down")
+        return []
+
+    mock_ingestor.fetch_all.side_effect = unavailable
+
+    create_and_run_updater(temp_repo, mock_ingestor, skip_if_missing=None)
+
+    assert cache_path.is_file()

--- a/codebase_rag/tests/test_hash_cache_guard.py
+++ b/codebase_rag/tests/test_hash_cache_guard.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -18,6 +19,10 @@ def test_query_failure_keeps_cache_and_sync(
     (temp_repo / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
     cache_path = temp_repo / cs.HASH_CACHE_FILENAME
     cache_path.write_text(json.dumps({"m.py": "stale"}), encoding="utf-8")
+    # Backdate the cache so the mtime fast path cannot skip the source file
+    # before the hash comparison sees the stale entry.
+    stale_time = cache_path.stat().st_mtime - 60
+    os.utime(cache_path, (stale_time, stale_time))
 
     count_queries: list[str] = []
 

--- a/codebase_rag/tests/test_hash_cache_guard.py
+++ b/codebase_rag/tests/test_hash_cache_guard.py
@@ -19,8 +19,11 @@ def test_query_failure_keeps_cache_and_sync(
     cache_path = temp_repo / cs.HASH_CACHE_FILENAME
     cache_path.write_text(json.dumps({"m.py": "stale"}), encoding="utf-8")
 
+    count_queries: list[str] = []
+
     def unavailable(query: str, params: dict | None = None) -> list:
         if query == cs.CYPHER_COUNT_PROJECT_MODULES:
+            count_queries.append(query)
             raise RuntimeError("graph down")
         return []
 
@@ -28,4 +31,13 @@ def test_query_failure_keeps_cache_and_sync(
 
     create_and_run_updater(temp_repo, mock_ingestor, skip_if_missing=None)
 
+    # The guard must actually have asked (and been refused), the cache must
+    # survive, and the sync must still ingest the repo's module.
+    assert count_queries
     assert cache_path.is_file()
+    module_qns = {
+        c.args[1].get(cs.KEY_QUALIFIED_NAME)
+        for c in mock_ingestor.ensure_node_batch.call_args_list
+        if c.args[0] == cs.NodeLabel.MODULE
+    }
+    assert any(str(qn).endswith(".m") for qn in module_qns), module_qns

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.438"
+version = "0.0.441"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
Found while dogfooding on real Dart repositories: `--clean` wipes the whole shared database but deletes only the current repo's `.cgr-hash-cache.json`, which lives inside that repo's working tree. Re-indexing any other repo afterwards trusts its now-orphaned cache, logs "no changes detected", and leaves that project silently empty; two of three indexed projects ended up with zero Module nodes after a successful-looking sync. MCP `wipe_database` and pointing cgr at a fresh Memgraph instance void caches the same way, so deleting other repos' cache files at clean time cannot fix this: the caches are unreachable from the cleaning process.

## Changes
- Before trusting a hash cache, `GraphUpdater.run` asks the graph whether the project still has Module nodes (`CYPHER_COUNT_PROJECT_MODULES`). An explicit zero means the cache describes a graph that no longer exists, so the cache and dir-mtimes files are deleted and a full rebuild runs.
- The guard fails open: sinks that cannot answer the query (offline writers, unit-test fakes returning no rows) keep the cache, since Cypher's `count()` always yields exactly one row when it really ran.

## Testing
- RED: new integration test `test_reindex_after_external_wipe_rebuilds_fully` (index, external `DETACH DELETE`, re-index must rebuild) failed before the fix; a control test asserts an intact graph still short-circuits to an incremental skip.
- GREEN after the fix; full unit suite (5476 passed) and full integration suite (293 passed) both green.
- Live re-run of the original three-repo scenario rebuilds the wiped projects instead of skipping them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically detects when the current project has no indexed modules and discards stale local cache files to trigger a full rebuild.
  * Improves cache-validation behavior in multi-file incremental runs by checking graph state before treating data as “in sync.”
  * Fails safely: if the project-graph check can’t be completed, it preserves the existing cache and continues syncing.
* **Tests**
  * Added end-to-end integration coverage for recovery after an external graph wipe and for continued incremental syncing when the graph is intact.
  * Added a guard test to ensure cache files remain when the graph check fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->