### PR TITLE
fix(dart): root dead-code at @override methods of external bases

### DIFF
--- a/codebase_rag/constants/ast_dart.py
+++ b/codebase_rag/constants/ast_dart.py
@@ -86,6 +86,10 @@ TS_DART_FUNCTION_BODY = "function_body"
 # `@override`-style metadata: a preceding SIBLING of the (wrapped)
 # signature, not a child, so the highlights walk collects it explicitly.
 TS_DART_ANNOTATION = "annotation"
+# The decorator string as captured on Method nodes; when the enclosing class
+# has an external base, a method carrying it is framework-invoked and roots
+# the dead-code walk.
+DART_OVERRIDE_ANNOTATION = "@override"
 
 # Module and import/directive nodes
 TS_DART_PROGRAM = "program"

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -1107,6 +1107,7 @@ class ClassIngestMixin:
         # the dead-code root property. Only unregistered (external) parents
         # contribute; first-party bases resolve via OVERRIDES edges.
         external_override_names: frozenset[str] = frozenset()
+        root_annotated_overrides = False
         if language == cs.SupportedLanguage.PYTHON:
             external_parents = [
                 p
@@ -1117,6 +1118,15 @@ class ClassIngestMixin:
                 external_override_names = external_stdlib_base_method_names(
                     external_parents
                 )
+        elif language == cs.SupportedLanguage.DART:
+            # An external base (a Flutter widget class) is not introspectable
+            # the way Python stdlib bases are, but Dart marks every override
+            # explicitly with @override: trust the annotation whenever any
+            # parent is unregistered.
+            root_annotated_overrides = any(
+                self.function_registry.get(p) is None
+                for p in self.class_inheritance.get(class_qn, [])
+            )
 
         for method_node in method_nodes:
             if _skip_method(method_node, class_node, body_node, lang_config):
@@ -1156,6 +1166,7 @@ class ClassIngestMixin:
                 file_path=file_path,
                 repo_path=self.repo_path,
                 external_override_names=external_override_names,
+                root_annotated_overrides=root_annotated_overrides,
             )
             if (
                 ingested_qn is not None

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -148,6 +148,7 @@ class ClassIngestMixin:
     module_qn_to_file_path: dict[str, Path]
     import_processor: ImportProcessor
     class_inheritance: dict[str, list[str]]
+    dart_annotated_overrides: dict[str, list[tuple[str, str]]]
     class_field_types: dict[str, dict[str, str]]
     java_anon_overrides: list[tuple[str, str, str, str]]
     csharp_methods: set[str]
@@ -430,14 +431,22 @@ class ClassIngestMixin:
             return 0
         self._deferred_inherits = []
         emitted = 0
+        dart_external_children: set[str] = set()
         for entry in deferred:
             child_type = self.function_registry.get(entry.child_qn)
             if child_type is None:
                 continue
             resolved = self._resolve_deferred_parent_qn(entry)
+            is_dart = entry.language == cs.SupportedLanguage.DART
             if resolved is None:
+                # Resolves nowhere = not first-party: for Dart that is still
+                # external-ancestry evidence for override rooting.
+                if is_dart:
+                    dart_external_children.add(entry.child_qn)
                 continue
             parent_qn, is_external = resolved
+            if is_dart and is_external:
+                dart_external_children.add(entry.child_qn)
             external_label: str | None = None
             if is_external:
                 # The import pass mints the same node for IMPORTS edges, so
@@ -477,7 +486,47 @@ class ClassIngestMixin:
                     parent_label=external_label,
                 )
             emitted += 1
+        self._flag_dart_external_overrides(dart_external_children)
         return emitted
+
+    def _flag_dart_external_overrides(self, external_children: set[str]) -> None:
+        # A Dart @override on a class with external ancestry roots the
+        # dead-code walk (the framework invokes it), UNLESS a registered
+        # ancestor defines the name, in which case the override resolves via
+        # OVERRIDES edges and must stay an ordinary candidate. Runs here
+        # because externality is only known after every class is registered;
+        # the partial row MERGEs into the node ingested during Pass 2.
+        for child_qn in external_children:
+            for method_qn, method_name in self.dart_annotated_overrides.get(
+                child_qn, ()
+            ):
+                if self._registered_ancestor_defines(child_qn, method_name):
+                    continue
+                self.ingestor.ensure_node_batch(
+                    cs.NodeLabel.METHOD,
+                    {
+                        cs.KEY_QUALIFIED_NAME: method_qn,
+                        cs.KEY_OVERRIDES_EXTERNAL: True,
+                    },
+                )
+
+    def _registered_ancestor_defines(self, class_qn: str, name: str) -> bool:
+        seen: set[str] = set()
+        stack = list(self.class_inheritance.get(class_qn, []))
+        while stack:
+            ancestor = stack.pop()
+            if ancestor in seen:
+                continue
+            seen.add(ancestor)
+            if self.function_registry.get(ancestor) is None:
+                continue
+            if (
+                self.function_registry.get(f"{ancestor}{cs.SEPARATOR_DOT}{name}")
+                is not None
+            ):
+                return True
+            stack.extend(self.class_inheritance.get(ancestor, []))
+        return False
 
     def _resolve_deferred_parent_qn(
         self, entry: DeferredInherit
@@ -1107,7 +1156,7 @@ class ClassIngestMixin:
         # the dead-code root property. Only unregistered (external) parents
         # contribute; first-party bases resolve via OVERRIDES edges.
         external_override_names: frozenset[str] = frozenset()
-        root_annotated_overrides = False
+        annotated_override_sink: dict[str, list[tuple[str, str]]] | None = None
         if language == cs.SupportedLanguage.PYTHON:
             external_parents = [
                 p
@@ -1121,12 +1170,11 @@ class ClassIngestMixin:
         elif language == cs.SupportedLanguage.DART:
             # An external base (a Flutter widget class) is not introspectable
             # the way Python stdlib bases are, but Dart marks every override
-            # explicitly with @override: trust the annotation whenever any
-            # parent is unregistered.
-            root_annotated_overrides = any(
-                self.function_registry.get(p) is None
-                for p in self.class_inheritance.get(class_qn, [])
-            )
+            # explicitly with @override. Whether a parent is truly external is
+            # unknowable here (it may live in a file parsed later), so only
+            # RECORD the annotated methods; resolve_deferred_inherits decides
+            # once every class is registered.
+            annotated_override_sink = self.dart_annotated_overrides
 
         for method_node in method_nodes:
             if _skip_method(method_node, class_node, body_node, lang_config):
@@ -1166,7 +1214,7 @@ class ClassIngestMixin:
                 file_path=file_path,
                 repo_path=self.repo_path,
                 external_override_names=external_override_names,
-                root_annotated_overrides=root_annotated_overrides,
+                annotated_override_sink=annotated_override_sink,
             )
             if (
                 ingested_qn is not None

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -432,6 +432,10 @@ class ClassIngestMixin:
         self._deferred_inherits = []
         emitted = 0
         dart_external_children: set[str] = set()
+        # `implements` targets never enter class_inheritance, so the override
+        # ancestry walk needs the resolved first-party IMPLEMENTS parents
+        # collected here or a registered interface's method is wrongly rooted.
+        dart_implements: dict[str, list[str]] = {}
         for entry in deferred:
             child_type = self.function_registry.get(entry.child_qn)
             if child_type is None:
@@ -472,6 +476,8 @@ class ClassIngestMixin:
                 self.interface_implementers.setdefault(parent_qn, set()).add(
                     entry.child_qn
                 )
+                if is_dart and not is_external:
+                    dart_implements.setdefault(entry.child_qn, []).append(parent_qn)
             else:
                 bases = self.class_inheritance.get(entry.child_qn)
                 if bases is not None and entry.base_index < len(bases):
@@ -486,10 +492,14 @@ class ClassIngestMixin:
                     parent_label=external_label,
                 )
             emitted += 1
-        self._flag_dart_external_overrides(dart_external_children)
+        self._flag_dart_external_overrides(dart_external_children, dart_implements)
         return emitted
 
-    def _flag_dart_external_overrides(self, external_children: set[str]) -> None:
+    def _flag_dart_external_overrides(
+        self,
+        external_children: set[str],
+        implements_map: dict[str, list[str]],
+    ) -> None:
         # A Dart @override on a class with external ancestry roots the
         # dead-code walk (the framework invokes it), UNLESS a registered
         # ancestor defines the name, in which case the override resolves via
@@ -500,7 +510,9 @@ class ClassIngestMixin:
             for method_qn, method_name in self.dart_annotated_overrides.get(
                 child_qn, ()
             ):
-                if self._registered_ancestor_defines(child_qn, method_name):
+                if self._registered_ancestor_defines(
+                    child_qn, method_name, implements_map
+                ):
                     continue
                 self.ingestor.ensure_node_batch(
                     cs.NodeLabel.METHOD,
@@ -510,9 +522,15 @@ class ClassIngestMixin:
                     },
                 )
 
-    def _registered_ancestor_defines(self, class_qn: str, name: str) -> bool:
+    def _registered_ancestor_defines(
+        self,
+        class_qn: str,
+        name: str,
+        implements_map: dict[str, list[str]],
+    ) -> bool:
         seen: set[str] = set()
         stack = list(self.class_inheritance.get(class_qn, []))
+        stack.extend(implements_map.get(class_qn, []))
         while stack:
             ancestor = stack.pop()
             if ancestor in seen:
@@ -526,6 +544,7 @@ class ClassIngestMixin:
             ):
                 return True
             stack.extend(self.class_inheritance.get(ancestor, []))
+            stack.extend(implements_map.get(ancestor, []))
         return False
 
     def _resolve_deferred_parent_qn(

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -427,11 +427,8 @@ class ClassIngestMixin:
         override detection walk the real hierarchy.
         """
         deferred = self._deferred_inherits
-        if not deferred:
-            return 0
         self._deferred_inherits = []
         emitted = 0
-        dart_external_children: set[str] = set()
         # `implements` targets never enter class_inheritance, so the override
         # ancestry walk needs the resolved first-party IMPLEMENTS parents
         # collected here or a registered interface's method is wrongly rooted.
@@ -443,14 +440,8 @@ class ClassIngestMixin:
             resolved = self._resolve_deferred_parent_qn(entry)
             is_dart = entry.language == cs.SupportedLanguage.DART
             if resolved is None:
-                # Resolves nowhere = not first-party: for Dart that is still
-                # external-ancestry evidence for override rooting.
-                if is_dart:
-                    dart_external_children.add(entry.child_qn)
                 continue
             parent_qn, is_external = resolved
-            if is_dart and is_external:
-                dart_external_children.add(entry.child_qn)
             external_label: str | None = None
             if is_external:
                 # The import pass mints the same node for IMPORTS edges, so
@@ -492,24 +483,25 @@ class ClassIngestMixin:
                     parent_label=external_label,
                 )
             emitted += 1
-        self._flag_dart_external_overrides(dart_external_children, dart_implements)
+        self._flag_dart_external_overrides(dart_implements)
         return emitted
 
     def _flag_dart_external_overrides(
         self,
-        external_children: set[str],
         implements_map: dict[str, list[str]],
     ) -> None:
-        # A Dart @override on a class with external ancestry roots the
-        # dead-code walk (the framework invokes it), UNLESS a registered
-        # ancestor defines the name, in which case the override resolves via
-        # OVERRIDES edges and must stay an ordinary candidate. Runs here
-        # because externality is only known after every class is registered;
-        # the partial row MERGEs into the node ingested during Pass 2.
-        for child_qn in external_children:
-            for method_qn, method_name in self.dart_annotated_overrides.get(
-                child_qn, ()
-            ):
+        # Every Dart class ultimately extends Object, so an @override whose
+        # name NO registered ancestor defines can only target external code:
+        # a framework base (direct or through any chain of first-party
+        # classes), an implemented external interface, or Object itself
+        # (toString/hashCode/operator==, invoked by interpolation and
+        # collections). Those methods root the dead-code walk; a name a
+        # registered ancestor defines resolves via OVERRIDES edges and must
+        # stay an ordinary candidate. Runs here because ancestry is only
+        # known after every class is registered; the partial row MERGEs into
+        # the node ingested during Pass 2.
+        for child_qn, methods in self.dart_annotated_overrides.items():
+            for method_qn, method_name in methods:
                 if self._registered_ancestor_defines(
                     child_qn, method_name, implements_map
                 ):

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -65,6 +65,10 @@ class DefinitionProcessor(
         self.import_processor = import_processor
         self.module_qn_to_file_path = module_qn_to_file_path
         self.class_inheritance: dict[str, list[str]] = {}
+        # {class_qn: [(method_qn, method_name)]} for Dart @override methods;
+        # whether they override an EXTERNAL base is only decidable once every
+        # class is registered, so resolve_deferred_inherits consumes this.
+        self.dart_annotated_overrides: dict[str, list[tuple[str, str]]] = {}
         # {interface_qn: [implementer_class_qns]} from IMPLEMENTS edges, so the
         # resolver can redirect an interface-typed call `I.m` to the concrete
         # `Impl.m` when I has exactly one first-party implementer (unambiguous).

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -708,6 +708,7 @@ def ingest_method(
     defer_containment: list[DeferredParentLink] | None = None,
     module_qn: str | None = None,
     external_override_names: frozenset[str] = frozenset(),
+    root_annotated_overrides: bool = False,
     skip_cpp_artifact_check: bool = False,
 ) -> str | None:
     # Returns the registered method qn (post register_unique_qn, so with any
@@ -817,7 +818,9 @@ def ingest_method(
     # Overriding a method of an EXTERNAL stdlib base (click's TextWrapper
     # subclass overriding textwrap's _wrap_chunks): the base's machinery invokes
     # it, so the dead-code surfaces root this property.
-    if method_name in external_override_names:
+    if method_name in external_override_names or (
+        root_annotated_overrides and cs.DART_OVERRIDE_ANNOTATION in decorators
+    ):
         method_props[cs.KEY_OVERRIDES_EXTERNAL] = True
 
     logger.info(logs.METHOD_FOUND.format(name=method_name, qn=method_qn))

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -708,7 +708,7 @@ def ingest_method(
     defer_containment: list[DeferredParentLink] | None = None,
     module_qn: str | None = None,
     external_override_names: frozenset[str] = frozenset(),
-    root_annotated_overrides: bool = False,
+    annotated_override_sink: dict[str, list[tuple[str, str]]] | None = None,
     skip_cpp_artifact_check: bool = False,
 ) -> str | None:
     # Returns the registered method qn (post register_unique_qn, so with any
@@ -818,10 +818,18 @@ def ingest_method(
     # Overriding a method of an EXTERNAL stdlib base (click's TextWrapper
     # subclass overriding textwrap's _wrap_chunks): the base's machinery invokes
     # it, so the dead-code surfaces root this property.
-    if method_name in external_override_names or (
-        root_annotated_overrides and cs.DART_OVERRIDE_ANNOTATION in decorators
-    ):
+    if method_name in external_override_names:
         method_props[cs.KEY_OVERRIDES_EXTERNAL] = True
+    # A Dart @override is only an EXTERNAL override if the resolved ancestry
+    # says so, which is unknowable until every class is registered: record it
+    # for resolve_deferred_inherits to judge.
+    if (
+        annotated_override_sink is not None
+        and cs.DART_OVERRIDE_ANNOTATION in decorators
+    ):
+        annotated_override_sink.setdefault(container_qn, []).append(
+            (method_qn, method_name)
+        )
 
     logger.info(logs.METHOD_FOUND.format(name=method_name, qn=method_qn))
     ingestor.ensure_node_batch(cs.NodeLabel.METHOD, method_props)

--- a/codebase_rag/tests/test_dart_external_override_flag.py
+++ b/codebase_rag/tests/test_dart_external_override_flag.py
@@ -73,7 +73,5 @@ def test_internal_base_override_is_not_flagged(
     )
     create_and_run_updater(root, mock_ingestor, skip_if_missing="dart")
     props = _method_props(mock_ingestor)
-    override = next(
-        v for k, v in props.items() if k.endswith("Circle.area")
-    )
+    override = next(v for k, v in props.items() if k.endswith("Circle.area"))
     assert not override.get(cs.KEY_OVERRIDES_EXTERNAL), override

--- a/codebase_rag/tests/test_dart_external_override_flag.py
+++ b/codebase_rag/tests/test_dart_external_override_flag.py
@@ -1,0 +1,79 @@
+# A Dart method overriding an EXTERNAL base class method (a Flutter widget's
+# `build`/`initState`/`createState`) is invoked by the framework, never by
+# first-party code, so it reported dead: 440 of 538 wonderous-app candidates
+# were framework overrides. Unlike Python, the external base's method set is
+# not introspectable, but Dart marks every override explicitly with
+# `@override`; trust the annotation whenever the class has an external parent.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import create_and_run_updater
+
+
+def _method_props(mock_ingestor: MagicMock) -> dict[str, dict]:
+    return {
+        c.args[1][cs.KEY_QUALIFIED_NAME]: c.args[1]
+        for c in mock_ingestor.ensure_node_batch.call_args_list
+        if c.args[0] == cs.NodeLabel.METHOD
+    }
+
+
+def test_external_base_override_is_flagged(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    root = temp_repo / "dartext"
+    root.mkdir(parents=True)
+    (root / "widget.dart").write_text(
+        "import 'package:flutter/material.dart';\n"
+        "\n"
+        "class MyLabel extends StatelessWidget {\n"
+        "  @override\n"
+        "  Widget build(BuildContext context) {\n"
+        "    return helper();\n"
+        "  }\n"
+        "\n"
+        "  Widget helper() {\n"
+        "    return Container();\n"
+        "  }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="dart")
+    props = _method_props(mock_ingestor)
+    build = next(v for k, v in props.items() if k.endswith(".build"))
+    helper = next(v for k, v in props.items() if k.endswith(".helper"))
+    assert build.get(cs.KEY_OVERRIDES_EXTERNAL) is True, build
+    assert not helper.get(cs.KEY_OVERRIDES_EXTERNAL), helper
+
+
+def test_internal_base_override_is_not_flagged(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # A first-party base resolves via OVERRIDES edges; the external-root
+    # property must stay off so virtual dispatch keeps doing the work.
+    root = temp_repo / "dartint"
+    root.mkdir(parents=True)
+    (root / "shapes.dart").write_text(
+        "class Shape {\n"
+        "  double area() {\n"
+        "    return 0;\n"
+        "  }\n"
+        "}\n"
+        "\n"
+        "class Circle extends Shape {\n"
+        "  @override\n"
+        "  double area() {\n"
+        "    return 3.14;\n"
+        "  }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="dart")
+    props = _method_props(mock_ingestor)
+    override = next(
+        v for k, v in props.items() if k.endswith("Circle.area")
+    )
+    assert not override.get(cs.KEY_OVERRIDES_EXTERNAL), override

--- a/codebase_rag/tests/test_dart_external_override_flag.py
+++ b/codebase_rag/tests/test_dart_external_override_flag.py
@@ -162,3 +162,38 @@ def test_mixed_ancestry_flags_only_names_missing_on_registered_base(
     on_frame = next(v for k, v in props.items() if k.endswith("C.onFrame"))
     assert not tick.get(cs.KEY_OVERRIDES_EXTERNAL), tick
     assert on_frame.get(cs.KEY_OVERRIDES_EXTERNAL) is True, on_frame
+
+
+def test_registered_implemented_interface_method_is_not_flagged(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # A class implementing BOTH a registered interface and an external one:
+    # `implements` targets never enter class_inheritance, so the ancestry
+    # walk must consult the resolved IMPLEMENTS parents too or the registered
+    # interface's method is wrongly rooted, hiding it and its call tree from
+    # dead-code results. A name only the external interface can declare still
+    # roots.
+    root = temp_repo / "dartimplmixed"
+    root.mkdir(parents=True)
+    (root / "app.dart").write_text(
+        "import 'package:events/events.dart';\n"
+        "\n"
+        "abstract class Registered {\n"
+        "  void run();\n"
+        "}\n"
+        "\n"
+        "class Worker implements Registered, ExternalListener {\n"
+        "  @override\n"
+        "  void run() {}\n"
+        "\n"
+        "  @override\n"
+        "  void onEvent() {}\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="dart")
+    props = _method_props(mock_ingestor)
+    run = next(v for k, v in props.items() if k.endswith("Worker.run"))
+    on_event = next(v for k, v in props.items() if k.endswith("Worker.onEvent"))
+    assert not run.get(cs.KEY_OVERRIDES_EXTERNAL), run
+    assert on_event.get(cs.KEY_OVERRIDES_EXTERNAL) is True, on_event

--- a/codebase_rag/tests/test_dart_external_override_flag.py
+++ b/codebase_rag/tests/test_dart_external_override_flag.py
@@ -14,11 +14,14 @@ from codebase_rag.tests.conftest import create_and_run_updater
 
 
 def _method_props(mock_ingestor: MagicMock) -> dict[str, dict]:
-    return {
-        c.args[1][cs.KEY_QUALIFIED_NAME]: c.args[1]
-        for c in mock_ingestor.ensure_node_batch.call_args_list
-        if c.args[0] == cs.NodeLabel.METHOD
-    }
+    # Mirror the ingestor's MERGE ... SET n += props semantics: a later
+    # partial row (the deferred overrides_external update) merges into the
+    # full row ingested during Pass 2.
+    props: dict[str, dict] = {}
+    for c in mock_ingestor.ensure_node_batch.call_args_list:
+        if c.args[0] == cs.NodeLabel.METHOD:
+            props.setdefault(c.args[1][cs.KEY_QUALIFIED_NAME], {}).update(c.args[1])
+    return props
 
 
 def test_external_base_override_is_flagged(
@@ -75,3 +78,87 @@ def test_internal_base_override_is_not_flagged(
     props = _method_props(mock_ingestor)
     override = next(v for k, v in props.items() if k.endswith("Circle.area"))
     assert not override.get(cs.KEY_OVERRIDES_EXTERNAL), override
+
+
+def test_cross_file_internal_base_is_not_flagged(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The base lives in a file parsed AFTER the subclass, so it is not yet
+    # registered at class-ingest time; the external-or-not decision must wait
+    # for deferred inheritance resolution or a first-party override is
+    # permanently rooted and its dead call tree hidden.
+    root = temp_repo / "dartxfile"
+    root.mkdir(parents=True)
+    (root / "a_child.dart").write_text(
+        "import 'z_base.dart';\n"
+        "\n"
+        "class Child extends Base {\n"
+        "  @override\n"
+        "  void tick() {}\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    (root / "z_base.dart").write_text(
+        "class Base {\n  void tick() {}\n}\n",
+        encoding="utf-8",
+    )
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="dart")
+    props = _method_props(mock_ingestor)
+    child_tick = next(v for k, v in props.items() if k.endswith("Child.tick"))
+    assert not child_tick.get(cs.KEY_OVERRIDES_EXTERNAL), child_tick
+
+
+def test_implements_external_interface_is_flagged(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `implements` targets are IMPLEMENTS, not INHERITS; a class whose only
+    # external ancestry is an implemented framework interface still has its
+    # annotated callbacks invoked by that framework.
+    root = temp_repo / "dartimpl"
+    root.mkdir(parents=True)
+    (root / "handler.dart").write_text(
+        "import 'package:events/events.dart';\n"
+        "\n"
+        "class Handler implements Listener {\n"
+        "  @override\n"
+        "  void onEvent() {}\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="dart")
+    props = _method_props(mock_ingestor)
+    on_event = next(v for k, v in props.items() if k.endswith("Handler.onEvent"))
+    assert on_event.get(cs.KEY_OVERRIDES_EXTERNAL) is True, on_event
+
+
+def test_mixed_ancestry_flags_only_names_missing_on_registered_base(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # A class with a first-party base AND an external mixin: an @override of
+    # the registered base's method resolves via OVERRIDES edges and must not
+    # be rooted, while a name the registered ancestry does not define can
+    # only override the external mixin.
+    root = temp_repo / "dartmixed"
+    root.mkdir(parents=True)
+    (root / "app.dart").write_text(
+        "import 'package:anim/anim.dart';\n"
+        "\n"
+        "class Base {\n"
+        "  void tick() {}\n"
+        "}\n"
+        "\n"
+        "class C extends Base with FrameMixin {\n"
+        "  @override\n"
+        "  void tick() {}\n"
+        "\n"
+        "  @override\n"
+        "  void onFrame() {}\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="dart")
+    props = _method_props(mock_ingestor)
+    tick = next(v for k, v in props.items() if k.endswith("C.tick"))
+    on_frame = next(v for k, v in props.items() if k.endswith("C.onFrame"))
+    assert not tick.get(cs.KEY_OVERRIDES_EXTERNAL), tick
+    assert on_frame.get(cs.KEY_OVERRIDES_EXTERNAL) is True, on_frame

--- a/codebase_rag/tests/test_dart_external_override_flag.py
+++ b/codebase_rag/tests/test_dart_external_override_flag.py
@@ -197,3 +197,70 @@ def test_registered_implemented_interface_method_is_not_flagged(
     on_event = next(v for k, v in props.items() if k.endswith("Worker.onEvent"))
     assert not run.get(cs.KEY_OVERRIDES_EXTERNAL), run
     assert on_event.get(cs.KEY_OVERRIDES_EXTERNAL) is True, on_event
+
+
+def test_grandchild_of_external_base_is_flagged(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # External ancestry is transitive: `Mid extends ExternalWidget` and
+    # `Leaf extends Mid`. Leaf's @override of a name Mid does not define can
+    # only target the external grandparent, so it roots; its @override of
+    # Mid's own method resolves via OVERRIDES edges and must not.
+    root = temp_repo / "dartgrand"
+    root.mkdir(parents=True)
+    (root / "app.dart").write_text(
+        "import 'package:flutter/material.dart';\n"
+        "\n"
+        "class Mid extends StatelessWidget {\n"
+        "  void tick() {}\n"
+        "}\n"
+        "\n"
+        "class Leaf extends Mid {\n"
+        "  @override\n"
+        "  void tick() {}\n"
+        "\n"
+        "  @override\n"
+        "  Widget build(BuildContext context) {\n"
+        "    return Container();\n"
+        "  }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="dart")
+    props = _method_props(mock_ingestor)
+    leaf_tick = next(v for k, v in props.items() if k.endswith("Leaf.tick"))
+    leaf_build = next(v for k, v in props.items() if k.endswith("Leaf.build"))
+    assert not leaf_tick.get(cs.KEY_OVERRIDES_EXTERNAL), leaf_tick
+    assert leaf_build.get(cs.KEY_OVERRIDES_EXTERNAL) is True, leaf_build
+
+
+def test_bare_class_object_override_is_flagged(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # A class with no ancestry clause still extends Object implicitly:
+    # `@override toString` is invoked by string interpolation, never by a
+    # call the graph sees, so it roots; an unannotated sibling stays a
+    # candidate.
+    root = temp_repo / "dartbare"
+    root.mkdir(parents=True)
+    (root / "model.dart").write_text(
+        "class Money {\n"
+        "  int cents = 0;\n"
+        "\n"
+        "  @override\n"
+        "  String toString() {\n"
+        "    return 'cents';\n"
+        "  }\n"
+        "\n"
+        "  int helper() {\n"
+        "    return cents;\n"
+        "  }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="dart")
+    props = _method_props(mock_ingestor)
+    to_string = next(v for k, v in props.items() if k.endswith("Money.toString"))
+    helper = next(v for k, v in props.items() if k.endswith("Money.helper"))
+    assert to_string.get(cs.KEY_OVERRIDES_EXTERNAL) is True, to_string
+    assert not helper.get(cs.KEY_OVERRIDES_EXTERNAL), helper

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.438"
+version = "0.0.441"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
Found dogfooding dead-code on real Flutter apps: 440 of 538 candidates on the wonderous app were framework-invoked overrides (`build`, `initState`, `createState`, `didUpdateWidget`), including `_WondersAppState.build` in `lib/main.dart`. The `overrides_external` dead-code root existed only for Python, where the stdlib base's method set is introspectable. A Flutter base is not, so Dart overrides of external classes were never rooted; internal bases were already covered by OVERRIDES edges.

## Changes
- Dart marks every override explicitly with `@override`, and the annotation is already captured into the method's decorators. When the enclosing class has at least one unregistered (external) parent, an annotated method now gets `overrides_external: true`, feeding the existing dead-code root.
- New `DART_OVERRIDE_ANNOTATION` constant; `ingest_method` grows a `root_annotated_overrides` flag computed in the class-ingest mixin.

## Testing
- RED: `test_external_base_override_is_flagged` (a `StatelessWidget` subclass's `build` must carry the flag, its plain helper must not) failed before the fix; a control asserts internal-base overrides stay unflagged so OVERRIDES-edge dispatch keeps doing that work.
- GREEN after; full unit suite passes (5478 passed).
- Live: wonderous app dead-code candidates drop from 538 to 199 with `lib/main.dart` fully cleared.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of Dart `@override` methods that override external framework methods, ensuring correct override-flagging.
  - Reduced false positives by correctly resolving override targets across both inheritance and `implements`, including mixed ancestry and implicit `Object` cases.
- **Tests**
  - Expanded Dart external override test coverage with new scenarios for transitive external-base overrides and implicit `Object` `toString` overrides, plus additional mixed-ancestry and callback cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->