### PR TITLE
fix(dart): reference tear-off callback arguments so dead-code keeps them

### DIFF
--- a/codebase_rag/constants/ast_dart.py
+++ b/codebase_rag/constants/ast_dart.py
@@ -18,6 +18,12 @@ TS_DART_ARGUMENTS = "arguments"
 TS_DART_ARGUMENT = "argument"
 TS_DART_NAMED_ARGUMENT = "named_argument"
 TS_DART_LABEL = "label"
+# First-class value containers in argument position: `handlers: [a, b]` and
+# `{...}` literals hold tear-offs one level down. Dart's ternary shares
+# Python's `conditional_expression` node TYPE but orders operands
+# [condition, consequence, alternative], not [body, condition, alternative].
+TS_DART_LIST_LITERAL = "list_literal"
+TS_DART_SET_OR_MAP_LITERAL = "set_or_map_literal"
 TS_DART_CASCADE_SECTION = "cascade_section"
 TS_DART_CASCADE_SELECTOR = "cascade_selector"
 TS_DART_UNCONDITIONAL_ASSIGNABLE_SELECTOR = "unconditional_assignable_selector"

--- a/codebase_rag/constants/ast_dart.py
+++ b/codebase_rag/constants/ast_dart.py
@@ -12,6 +12,12 @@
 # argument_part directly inside the `cascade_section`.
 TS_DART_SELECTOR = "selector"
 TS_DART_ARGUMENT_PART = "argument_part"
+# Inside an argument_part: `arguments` holds `argument` wrappers for
+# positional values and `named_argument` (label + expression) for named ones.
+TS_DART_ARGUMENTS = "arguments"
+TS_DART_ARGUMENT = "argument"
+TS_DART_NAMED_ARGUMENT = "named_argument"
+TS_DART_LABEL = "label"
 TS_DART_CASCADE_SECTION = "cascade_section"
 TS_DART_CASCADE_SELECTOR = "cascade_selector"
 TS_DART_UNCONDITIONAL_ASSIGNABLE_SELECTOR = "unconditional_assignable_selector"

--- a/codebase_rag/constants/ast_dart.py
+++ b/codebase_rag/constants/ast_dart.py
@@ -24,6 +24,11 @@ TS_DART_LABEL = "label"
 # [condition, consequence, alternative], not [body, condition, alternative].
 TS_DART_LIST_LITERAL = "list_literal"
 TS_DART_SET_OR_MAP_LITERAL = "set_or_map_literal"
+# Inside a set_or_map_literal: a MAP entry is a `pair` whose `value` field
+# holds the stored expression; `type_arguments` (`<String, T>{...}`) carry
+# types, never values.
+TS_DART_PAIR = "pair"
+TS_DART_TYPE_ARGUMENTS = "type_arguments"
 TS_DART_CASCADE_SECTION = "cascade_section"
 TS_DART_CASCADE_SELECTOR = "cascade_selector"
 TS_DART_UNCONDITIONAL_ASSIGNABLE_SELECTOR = "unconditional_assignable_selector"

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -100,6 +100,9 @@ _JS_TS_LANGUAGES = cs.JS_TS_LANGUAGES
 _ARG_REF_ONLY_LANGUAGES = frozenset(
     {cs.SupportedLanguage.CSHARP, cs.SupportedLanguage.DART}
 )
+_DART_VALUE_WRAPPER_TYPES = frozenset(
+    {cs.TS_DART_LIST_LITERAL, cs.TS_DART_SET_OR_MAP_LITERAL, cs.TS_DART_ARGUMENT}
+)
 
 # Python nested-scope boundaries and sequence-literal node types used when
 # scanning a scope for dispatch tables of function references.
@@ -3015,7 +3018,9 @@ class CallProcessor:
                         )
             stack.extend(node.children)
 
-    def _expand_py_first_class_values(self, value: Node) -> list[Node]:
+    def _expand_py_first_class_values(
+        self, value: Node, language: cs.SupportedLanguage | None = None
+    ) -> list[Node]:
         # Peel Python container literals and result-position conditional
         # operands so a function stored in a tuple/list/set, a dict VALUE,
         # a bare return-tuple (expression_list), or a ternary/boolean-default
@@ -3023,11 +3028,14 @@ class CallProcessor:
         # recursively. A ternary's condition is only truthiness-tested, never
         # bound, so it stays excluded. Any other node comes back unchanged, so
         # non-Python shapes are unaffected.
+        is_dart = language == cs.SupportedLanguage.DART
         out: list[Node] = []
         stack = [value]
         while stack:
             node = stack.pop()
-            if node.type in _PY_VALUE_WRAPPER_TYPES:
+            if node.type in _PY_VALUE_WRAPPER_TYPES or (
+                is_dart and node.type in _DART_VALUE_WRAPPER_TYPES
+            ):
                 stack.extend(reversed(node.named_children))
             elif node.type == cs.TS_PY_DICTIONARY:
                 for pair in reversed(node.named_children):
@@ -3046,7 +3054,14 @@ class CallProcessor:
                 # over-referencing rather than dropping a branch.
                 operands = list(node.named_children)
                 if len(operands) == 3:
-                    operands = [operands[0], operands[2]]
+                    # Dart orders [condition, consequence, alternative];
+                    # Python orders [body, condition, alternative]. Pick the
+                    # two result operands, never the truthiness-tested one.
+                    operands = (
+                        [operands[1], operands[2]]
+                        if is_dart
+                        else [operands[0], operands[2]]
+                    )
                 stack.extend(reversed(operands))
             elif node.type == cs.TS_PY_BOOLEAN_OPERATOR:
                 right = node.child_by_field_name(cs.TS_FIELD_RIGHT)
@@ -4274,7 +4289,7 @@ class CallProcessor:
             # `... if single else local_setter_noop`, its SQLCompiler) hides
             # the passed functions one level down; each expanded value is a
             # first-class reference exactly like a bare-name argument.
-            for value_node in self._expand_py_first_class_values(arg_node):
+            for value_node in self._expand_py_first_class_values(arg_node, language):
                 self._emit_callback_edge(
                     caller_spec,
                     value_node,

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -206,6 +206,134 @@ def _scope_qn_candidates(scope_qn: str) -> list[str]:
     return [scope_qn, natural]
 
 
+def _first_class_value_children(node: Node, is_dart: bool) -> list[Node] | None:
+    # The wrapped value nodes a container/branch node hands onward, or None
+    # for a leaf that IS the first-class value.
+    if node.type in _PY_VALUE_WRAPPER_TYPES:
+        return list(node.named_children)
+    if is_dart and node.type in _DART_VALUE_WRAPPER_TYPES:
+        return _dart_collection_values(node)
+    if node.type == cs.TS_PY_DICTIONARY:
+        return _py_dict_values(node)
+    if node.type == cs.TS_PY_CONDITIONAL_EXPRESSION:
+        return _conditional_result_operands(node, is_dart)
+    if node.type == cs.TS_PY_BOOLEAN_OPERATOR:
+        return [
+            operand
+            for operand in (
+                node.child_by_field_name(cs.TS_FIELD_LEFT),
+                node.child_by_field_name(cs.TS_FIELD_RIGHT),
+            )
+            if operand is not None
+        ]
+    return None
+
+
+def _dart_collection_values(node: Node) -> list[Node]:
+    # A Dart MAP stores each value inside a `pair` node's value field
+    # (`{"tap": onTap}`); a set exposes its elements directly; a typed
+    # literal's `type_arguments` child carries types, never values.
+    children: list[Node] = []
+    for child in node.named_children:
+        if child.type == cs.TS_DART_TYPE_ARGUMENTS:
+            continue
+        if child.type == cs.TS_DART_PAIR:
+            if (pair_value := child.child_by_field_name(cs.FIELD_VALUE)) is not None:
+                children.append(pair_value)
+            continue
+        children.append(child)
+    return children
+
+
+def _py_dict_values(node: Node) -> list[Node]:
+    return [
+        pair_value
+        for pair in node.named_children
+        if pair.type == cs.TS_PY_PAIR
+        and (pair_value := pair.child_by_field_name(cs.FIELD_VALUE)) is not None
+    ]
+
+
+def _conditional_result_operands(node: Node, is_dart: bool) -> list[Node]:
+    # tree-sitter-python exposes NO field names on conditional_expression
+    # (child_by_field_name returns None for every operand), so the result
+    # operands are positional: [body, condition, alternative]. A shape that
+    # is not exactly three named operands falls back to all of them,
+    # over-referencing rather than dropping a branch.
+    operands = list(node.named_children)
+    if len(operands) != 3:
+        return operands
+    # Dart orders [condition, consequence, alternative]; Python orders
+    # [body, condition, alternative]. Pick the two result operands, never
+    # the truthiness-tested one.
+    return [operands[1], operands[2]] if is_dart else [operands[0], operands[2]]
+
+
+def _find_call_arguments_node(call_node: Node) -> Node | None:
+    args_node = call_node.child_by_field_name(cs.FIELD_ARGUMENTS)
+    if args_node is not None:
+        return args_node
+    # C# target-typed `new(...)` exposes NO fields at all; its argument_list
+    # is an unfielded named child (Serilog hands its CreateLogger local
+    # functions to `return new(...)`, which the fielded lookup silently
+    # dropped).
+    args_node = next(
+        (
+            child
+            for child in call_node.named_children
+            if child.type == cs.TS_CSHARP_ARGUMENT_LIST
+        ),
+        None,
+    )
+    if args_node is not None:
+        return args_node
+    # Dart has no call-expression node: a selector/cascade_section wraps its
+    # arguments in an argument_part holding the real `arguments` node one
+    # level down.
+    for part in call_node.named_children:
+        if part.type == cs.TS_DART_ARGUMENT_PART:
+            return next(
+                (
+                    grand
+                    for grand in part.named_children
+                    if grand.type == cs.TS_DART_ARGUMENTS
+                ),
+                None,
+            )
+    return None
+
+
+def _add_dart_named_argument(child: Node, keyword: dict[str, Node]) -> None:
+    # A named value is a `named_argument` whose label child names it and
+    # whose last named child is the expression.
+    label = next(
+        (grand for grand in child.named_children if grand.type == cs.TS_DART_LABEL),
+        None,
+    )
+    value_node = child.named_children[-1] if child.named_children else None
+    name_node = (
+        label.named_children[0] if label is not None and label.named_children else None
+    )
+    if (
+        name_node is not None
+        and value_node is not None
+        and value_node is not label
+        and (name := safe_decode_text(name_node)) is not None
+    ):
+        keyword[name] = value_node
+
+
+def _add_py_keyword_argument(child: Node, keyword: dict[str, Node]) -> None:
+    name_node = child.child_by_field_name(cs.FIELD_NAME)
+    value_node = child.child_by_field_name(cs.FIELD_VALUE)
+    if (
+        name_node is not None
+        and value_node is not None
+        and (name := safe_decode_text(name_node)) is not None
+    ):
+        keyword[name] = value_node
+
+
 class CallProcessor:
     __slots__ = (
         "ingestor",
@@ -3033,45 +3161,11 @@ class CallProcessor:
         stack = [value]
         while stack:
             node = stack.pop()
-            if node.type in _PY_VALUE_WRAPPER_TYPES or (
-                is_dart and node.type in _DART_VALUE_WRAPPER_TYPES
-            ):
-                stack.extend(reversed(node.named_children))
-            elif node.type == cs.TS_PY_DICTIONARY:
-                for pair in reversed(node.named_children):
-                    if (
-                        pair.type == cs.TS_PY_PAIR
-                        and (pair_value := pair.child_by_field_name(cs.FIELD_VALUE))
-                        is not None
-                    ):
-                        stack.append(pair_value)
-            elif node.type == cs.TS_PY_CONDITIONAL_EXPRESSION:
-                # tree-sitter-python exposes NO field names on
-                # conditional_expression (child_by_field_name returns None for
-                # every operand), so the result operands are positional:
-                # [body, condition, alternative]. A shape that is not exactly
-                # three named operands falls back to all of them,
-                # over-referencing rather than dropping a branch.
-                operands = list(node.named_children)
-                if len(operands) == 3:
-                    # Dart orders [condition, consequence, alternative];
-                    # Python orders [body, condition, alternative]. Pick the
-                    # two result operands, never the truthiness-tested one.
-                    operands = (
-                        [operands[1], operands[2]]
-                        if is_dart
-                        else [operands[0], operands[2]]
-                    )
-                stack.extend(reversed(operands))
-            elif node.type == cs.TS_PY_BOOLEAN_OPERATOR:
-                right = node.child_by_field_name(cs.TS_FIELD_RIGHT)
-                if right is not None:
-                    stack.append(right)
-                left = node.child_by_field_name(cs.TS_FIELD_LEFT)
-                if left is not None:
-                    stack.append(left)
-            else:
+            children = _first_class_value_children(node, is_dart)
+            if children is None:
                 out.append(node)
+            else:
+                stack.extend(reversed(children))
         return out
 
     def _emit_expression_body_return(
@@ -3842,81 +3936,24 @@ class CallProcessor:
     ) -> tuple[list[Node], dict[str, Node]]:
         positional: list[Node] = []
         keyword: dict[str, Node] = {}
-        args_node = call_node.child_by_field_name(cs.FIELD_ARGUMENTS)
-        if args_node is None:
-            # C# target-typed `new(...)` exposes NO fields at all; its
-            # argument_list is an unfielded named child (Serilog hands its
-            # CreateLogger local functions to `return new(...)`, which the
-            # fielded lookup silently dropped).
-            args_node = next(
-                (
-                    child
-                    for child in call_node.named_children
-                    if child.type == cs.TS_CSHARP_ARGUMENT_LIST
-                ),
-                None,
-            )
-        if args_node is None:
-            # Dart has no call-expression node: a selector/cascade_section
-            # wraps its arguments in an argument_part holding the real
-            # `arguments` node one level down.
-            for part in call_node.named_children:
-                if part.type == cs.TS_DART_ARGUMENT_PART:
-                    args_node = next(
-                        (
-                            grand
-                            for grand in part.named_children
-                            if grand.type == cs.TS_DART_ARGUMENTS
-                        ),
-                        None,
-                    )
-                    break
+        args_node = _find_call_arguments_node(call_node)
         if args_node is None:
             return positional, keyword
         for child in args_node.named_children:
             # C# wraps every argument expression in an `argument` node (which
-            # may carry a ref/out modifier or a name: colon); unwrap to the
-            # expression itself, its LAST named child, so downstream
-            # reference-type checks see the identifier, not the wrapper.
-            if child.type == cs.TS_CSHARP_ARGUMENT and child.named_children:
-                child = child.named_children[-1]
-            # Dart wraps positional values in `argument`; a named value is a
-            # `named_argument` whose label child names it and whose last named
-            # child is the expression.
-            if child.type == cs.TS_DART_ARGUMENT and child.named_children:
+            # may carry a ref/out modifier or a name: colon); Dart wraps
+            # positional values the same way. Unwrap to the expression itself,
+            # its LAST named child, so downstream reference-type checks see
+            # the identifier, not the wrapper.
+            if (
+                child.type in (cs.TS_CSHARP_ARGUMENT, cs.TS_DART_ARGUMENT)
+                and child.named_children
+            ):
                 child = child.named_children[-1]
             if child.type == cs.TS_DART_NAMED_ARGUMENT:
-                label = next(
-                    (
-                        grand
-                        for grand in child.named_children
-                        if grand.type == cs.TS_DART_LABEL
-                    ),
-                    None,
-                )
-                value_node = child.named_children[-1] if child.named_children else None
-                name_node = (
-                    label.named_children[0]
-                    if label is not None and label.named_children
-                    else None
-                )
-                if (
-                    name_node is not None
-                    and value_node is not None
-                    and value_node is not label
-                    and (name := safe_decode_text(name_node)) is not None
-                ):
-                    keyword[name] = value_node
-                continue
-            if child.type == cs.TS_PY_KEYWORD_ARGUMENT:
-                name_node = child.child_by_field_name(cs.FIELD_NAME)
-                value_node = child.child_by_field_name(cs.FIELD_VALUE)
-                if (
-                    name_node is not None
-                    and value_node is not None
-                    and (name := safe_decode_text(name_node)) is not None
-                ):
-                    keyword[name] = value_node
+                _add_dart_named_argument(child, keyword)
+            elif child.type == cs.TS_PY_KEYWORD_ARGUMENT:
+                _add_py_keyword_argument(child, keyword)
             else:
                 positional.append(child)
         return positional, keyword

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -94,6 +94,12 @@ _TYPED_LANGUAGES = frozenset(
 # declarator-aware extractor rather than a plain child_by_field_name("name").
 _C_FAMILY_LANGUAGES = frozenset({cs.SupportedLanguage.C, cs.SupportedLanguage.CPP})
 _JS_TS_LANGUAGES = cs.JS_TS_LANGUAGES
+# Languages with argument-REFERENCE edges but no interprocedural
+# callable-param flow: passing a function keeps it reachable (REFERENCES),
+# while invocation edges stay with the flow languages.
+_ARG_REF_ONLY_LANGUAGES = frozenset(
+    {cs.SupportedLanguage.CSHARP, cs.SupportedLanguage.DART}
+)
 
 # Python nested-scope boundaries and sequence-literal node types used when
 # scanning a scope for dispatch tables of function references.
@@ -1976,11 +1982,12 @@ class CallProcessor:
             or language in _JS_TS_LANGUAGES
             or is_cpp
         )
-        # C# gets the argument-REFERENCE half only (a method group passed as
-        # a delegate argument keeps its target reachable, Polly's EmptyHandler
-        # family, 16 dead-code false flags) without the interprocedural
-        # callable-param flow, which is untuned for C#.
-        is_arg_ref_lang = is_flow_lang or language == cs.SupportedLanguage.CSHARP
+        # C# and Dart get the argument-REFERENCE half only (a method group or
+        # tear-off passed as an argument keeps its target reachable, Polly's
+        # EmptyHandler family, Flutter's `onPressed: _handleTap` callbacks)
+        # without the interprocedural callable-param flow, which is untuned
+        # for them.
+        is_arg_ref_lang = is_flow_lang or language in _ARG_REF_ONLY_LANGUAGES
         # A method-group pass is not an invocation: C# records it as
         # REFERENCES everywhere (CALLS here put 282 phantom edges into the
         # Polly call graph, retrieval precision 1.0 -> 0.92); flow languages
@@ -3835,6 +3842,21 @@ class CallProcessor:
                 None,
             )
         if args_node is None:
+            # Dart has no call-expression node: a selector/cascade_section
+            # wraps its arguments in an argument_part holding the real
+            # `arguments` node one level down.
+            for part in call_node.named_children:
+                if part.type == cs.TS_DART_ARGUMENT_PART:
+                    args_node = next(
+                        (
+                            grand
+                            for grand in part.named_children
+                            if grand.type == cs.TS_DART_ARGUMENTS
+                        ),
+                        None,
+                    )
+                    break
+        if args_node is None:
             return positional, keyword
         for child in args_node.named_children:
             # C# wraps every argument expression in an `argument` node (which
@@ -3843,6 +3865,34 @@ class CallProcessor:
             # reference-type checks see the identifier, not the wrapper.
             if child.type == cs.TS_CSHARP_ARGUMENT and child.named_children:
                 child = child.named_children[-1]
+            # Dart wraps positional values in `argument`; a named value is a
+            # `named_argument` whose label child names it and whose last named
+            # child is the expression.
+            if child.type == cs.TS_DART_ARGUMENT and child.named_children:
+                child = child.named_children[-1]
+            if child.type == cs.TS_DART_NAMED_ARGUMENT:
+                label = next(
+                    (
+                        grand
+                        for grand in child.named_children
+                        if grand.type == cs.TS_DART_LABEL
+                    ),
+                    None,
+                )
+                value_node = child.named_children[-1] if child.named_children else None
+                name_node = (
+                    label.named_children[0]
+                    if label is not None and label.named_children
+                    else None
+                )
+                if (
+                    name_node is not None
+                    and value_node is not None
+                    and value_node is not label
+                    and (name := safe_decode_text(name_node)) is not None
+                ):
+                    keyword[name] = value_node
+                continue
             if child.type == cs.TS_PY_KEYWORD_ARGUMENT:
                 name_node = child.child_by_field_name(cs.FIELD_NAME)
                 value_node = child.child_by_field_name(cs.FIELD_VALUE)

--- a/codebase_rag/tests/test_dart_tearoff_references.py
+++ b/codebase_rag/tests/test_dart_tearoff_references.py
@@ -92,3 +92,43 @@ def test_receiver_call_tearoff_is_referenced(tmp_path: Path) -> None:
     }
     rels = _run_rels(tmp_path, files)
     assert _has(rels, ".Watcher.attach", REFERENCES, ".Watcher.update"), rels
+
+
+def test_conditional_tearoff_references_both_branches(tmp_path: Path) -> None:
+    # `onUpdate: isRight ? _handleRightDrag : _handleLeftDrag` hands one of
+    # two methods over; both are live. Dart's conditional_expression orders
+    # operands [condition, consequence, alternative], unlike Python's
+    # [body, condition, alternative], so index-based expansion must not
+    # reference the condition.
+    files = {
+        "app.dart": (
+            "class Selector {\n"
+            "  void goRight() {}\n"
+            "  void goLeft() {}\n"
+            "  bool isRight() => true;\n"
+            "  void build(bool flag) {\n"
+            "    render(onUpdate: flag ? goRight : goLeft);\n"
+            "  }\n"
+            "}\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files)
+    assert _has(rels, ".Selector.build", REFERENCES, ".Selector.goRight"), rels
+    assert _has(rels, ".Selector.build", REFERENCES, ".Selector.goLeft"), rels
+
+
+def test_list_literal_tearoffs_are_referenced(tmp_path: Path) -> None:
+    files = {
+        "app.dart": (
+            "class Registry {\n"
+            "  void first() {}\n"
+            "  void second() {}\n"
+            "  void register() {\n"
+            "    addAll(handlers: [first, second]);\n"
+            "  }\n"
+            "}\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files)
+    assert _has(rels, ".Registry.register", REFERENCES, ".Registry.first"), rels
+    assert _has(rels, ".Registry.register", REFERENCES, ".Registry.second"), rels

--- a/codebase_rag/tests/test_dart_tearoff_references.py
+++ b/codebase_rag/tests/test_dart_tearoff_references.py
@@ -16,6 +16,7 @@ from codebase_rag.graph_updater import GraphUpdater
 from codebase_rag.parser_loader import load_parsers
 
 REFERENCES = cs.RelationshipType.REFERENCES.value
+CALLS = cs.RelationshipType.CALLS.value
 
 
 def _run_rels(tmp_path: Path, files: dict[str, str]) -> set[tuple[str, str, str]]:
@@ -62,6 +63,9 @@ def test_positional_tearoff_to_external_callee_is_referenced(
     rels = _run_rels(tmp_path, files)
     assert _has(rels, ".Controller.start", REFERENCES, ".Controller.tick"), rels
     assert not _has(rels, ".Controller.start", REFERENCES, ".Controller.unused")
+    # A tear-off hands the method over without invoking it; it must never
+    # double as a CALLS edge.
+    assert not _has(rels, ".Controller.start", CALLS, ".Controller.tick")
 
 
 def test_named_argument_tearoff_is_referenced(tmp_path: Path) -> None:
@@ -105,9 +109,9 @@ def test_conditional_tearoff_references_both_branches(tmp_path: Path) -> None:
             "class Selector {\n"
             "  void goRight() {}\n"
             "  void goLeft() {}\n"
-            "  bool isRight() => true;\n"
-            "  void build(bool flag) {\n"
-            "    render(onUpdate: flag ? goRight : goLeft);\n"
+            "  bool get isRight => true;\n"
+            "  void build() {\n"
+            "    render(onUpdate: isRight ? goRight : goLeft);\n"
             "  }\n"
             "}\n"
         ),
@@ -115,6 +119,9 @@ def test_conditional_tearoff_references_both_branches(tmp_path: Path) -> None:
     rels = _run_rels(tmp_path, files)
     assert _has(rels, ".Selector.build", REFERENCES, ".Selector.goRight"), rels
     assert _has(rels, ".Selector.build", REFERENCES, ".Selector.goLeft"), rels
+    # The condition is only truthiness-tested, never handed over; expanding
+    # it would resurface the Python operand order on Dart's ternary.
+    assert not _has(rels, ".Selector.build", REFERENCES, ".Selector.isRight")
 
 
 def test_list_literal_tearoffs_are_referenced(tmp_path: Path) -> None:
@@ -132,3 +139,30 @@ def test_list_literal_tearoffs_are_referenced(tmp_path: Path) -> None:
     rels = _run_rels(tmp_path, files)
     assert _has(rels, ".Registry.register", REFERENCES, ".Registry.first"), rels
     assert _has(rels, ".Registry.register", REFERENCES, ".Registry.second"), rels
+
+
+def test_map_and_set_literal_tearoffs_are_referenced(tmp_path: Path) -> None:
+    # A dispatch table (`{"tap": onTap}`) stores its handlers in `pair`
+    # nodes whose value field holds the tear-off; a set literal exposes them
+    # directly. A typed map inserts a `type_arguments` child that carries no
+    # values at all.
+    files = {
+        "app.dart": (
+            "class Table {\n"
+            "  void onTap() {}\n"
+            "  void onDrag() {}\n"
+            "  void onSetA() {}\n"
+            "  void onTyped() {}\n"
+            "  void register() {\n"
+            '    addAll(handlers: {"tap": onTap, "drag": onDrag});\n'
+            "    addSet({onSetA});\n"
+            '    addTyped(<String, Function>{"t": onTyped});\n'
+            "  }\n"
+            "}\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files)
+    assert _has(rels, ".Table.register", REFERENCES, ".Table.onTap"), rels
+    assert _has(rels, ".Table.register", REFERENCES, ".Table.onDrag"), rels
+    assert _has(rels, ".Table.register", REFERENCES, ".Table.onSetA"), rels
+    assert _has(rels, ".Table.register", REFERENCES, ".Table.onTyped"), rels

--- a/codebase_rag/tests/test_dart_tearoff_references.py
+++ b/codebase_rag/tests/test_dart_tearoff_references.py
@@ -1,0 +1,94 @@
+# A Dart method passed as a tear-off (`Timer(d, _tick)`,
+# `onPressed: _handleTap`, `controller.addListener(_update)`) is invoked by
+# the receiving framework, never by first-party code, so dead-code flagged
+# every callback handler: 129 of the wonderous app's remaining candidates
+# were `_handleX` tear-offs. Mirror the C# method-group treatment: record the
+# pass as a REFERENCES edge from the passing scope.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+REFERENCES = cs.RelationshipType.REFERENCES.value
+
+
+def _run_rels(tmp_path: Path, files: dict[str, str]) -> set[tuple[str, str, str]]:
+    parsers, queries = load_parsers()
+    if "dart" not in parsers:
+        pytest.skip("dart parser not available")
+    for rel, content in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock, repo_path=tmp_path, parsers=parsers, queries=queries
+    ).run()
+    return {
+        (c.args[0][2], str(c.args[1]), c.args[2][2])
+        for c in mock.ensure_relationship_batch.call_args_list
+    }
+
+
+def _has(
+    rels: set[tuple[str, str, str]], caller_suffix: str, rel: str, callee_suffix: str
+) -> bool:
+    return any(
+        a.endswith(caller_suffix) and r == rel and b.endswith(callee_suffix)
+        for a, r, b in rels
+    )
+
+
+def test_positional_tearoff_to_external_callee_is_referenced(
+    tmp_path: Path,
+) -> None:
+    files = {
+        "app.dart": (
+            "class Controller {\n"
+            "  void tick() {}\n"
+            "  void unused() {}\n"
+            "  void start() {\n"
+            "    schedule(tick);\n"
+            "  }\n"
+            "}\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files)
+    assert _has(rels, ".Controller.start", REFERENCES, ".Controller.tick"), rels
+    assert not _has(rels, ".Controller.start", REFERENCES, ".Controller.unused")
+
+
+def test_named_argument_tearoff_is_referenced(tmp_path: Path) -> None:
+    files = {
+        "app.dart": (
+            "class Panel {\n"
+            "  void handleTap() {}\n"
+            "  void build() {\n"
+            "    render(onPressed: handleTap, count: 3);\n"
+            "  }\n"
+            "}\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files)
+    assert _has(rels, ".Panel.build", REFERENCES, ".Panel.handleTap"), rels
+
+
+def test_receiver_call_tearoff_is_referenced(tmp_path: Path) -> None:
+    files = {
+        "app.dart": (
+            "class Watcher {\n"
+            "  void update() {}\n"
+            "  void attach(dynamic controller) {\n"
+            "    controller.addListener(update);\n"
+            "  }\n"
+            "}\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files)
+    assert _has(rels, ".Watcher.attach", REFERENCES, ".Watcher.update"), rels

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.438"
+version = "0.0.441"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
Found dogfooding dead-code on real Flutter apps: after rooting framework overrides (#864), the largest remaining false-positive class on the wonderous app was callback handlers passed as tear-offs, `_pageController?.addListener(_handlePageChanged)`, `onPressed: _handleSearchTap`, `Timer(interval, _callAction)`. The receiving framework invokes them, first-party code never does, so they all reported dead. The argument-reference machinery already exists (REFERENCES edges, C# method groups took exactly this path) but Dart never joined it, and the shared argument parser could not see Dart arguments at all: the grammar has no call-expression node, so arguments hide inside a `selector`'s `argument_part`.

## Changes
- `_parse_call_arguments` learns the Dart shape: descend `selector`/`cascade_section` into `argument_part > arguments`, unwrap positional `argument` wrappers, and map `named_argument` labels to their expressions.
- Dart joins the argument-REFERENCE half via a new `_ARG_REF_ONLY_LANGUAGES` set alongside C#: tear-offs get REFERENCES edges (never CALLS, mirroring the C# phantom-edge lesson), and interprocedural callable-param flow stays off.

## Testing
- RED: three new tests (positional tear-off to an external callee, named-argument tear-off, tear-off on a receiver call) all failed before the fix.
- GREEN after; full unit suite passes (5479 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Dart call analysis to better recognize argument structures, including positional and named arguments.
  * Enhanced graph reference tracking for Dart method tear-offs passed through call arguments (including receiver/listener arguments, conditional branches, and list/map/set literals).

* **Bug Fixes**
  * Corrected call-graph relationship handling for Dart so argument-derived references are emitted accurately without incorrectly creating call edges where not intended.

* **Tests**
  * Added/extended Dart tear-off reference test coverage for positional, named, receiver, conditional, and literal-based scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->