### PR TITLE
fix(updater): delete prior module subtrees on a cacheless rebuild of an indexed project

### DIFF
--- a/codebase_rag/constants/graph.py
+++ b/codebase_rag/constants/graph.py
@@ -348,6 +348,10 @@ CYPHER_DELETE_CALLS = "MATCH ()-[r:CALLS]->() DELETE r"
 CYPHER_DELETE_ORPHAN_EXTERNAL_MODULES = (
     "MATCH (m:ExternalModule) WHERE NOT (m)<--() DETACH DELETE m"
 )
+CYPHER_PROJECT_MODULE_PATHS = (
+    "MATCH (m:Module) WHERE m.qualified_name STARTS WITH $project_prefix "
+    "RETURN m.path AS path"
+)
 
 # Queries for orphan pruning: return all paths stored in the graph
 CYPHER_ALL_FILE_PATHS = (

--- a/codebase_rag/constants/graph.py
+++ b/codebase_rag/constants/graph.py
@@ -338,9 +338,12 @@ PAYLOAD_QUALIFIED_NAME = "qualified_name"
 CYPHER_DELETE_MODULE = (
     # Scoped to the project: two projects in the shared graph can hold the
     # same relative path, and a path-only match would take the sibling's
-    # module subtree with it.
+    # module subtree with it. A repository-root __init__.py's module qn IS
+    # the bare project name (no trailing dot), so the prefix test alone
+    # would miss it.
     "MATCH (m:Module {path: $path}) "
-    "WHERE m.qualified_name STARTS WITH $project_prefix "
+    "WHERE m.qualified_name = $project_name "
+    "OR m.qualified_name STARTS WITH $project_prefix "
     "OPTIONAL MATCH (m)-[:DEFINES|DEFINES_METHOD*0..]->(c) "
     "DETACH DELETE m, c"
 )
@@ -353,7 +356,10 @@ CYPHER_DELETE_ORPHAN_EXTERNAL_MODULES = (
     "MATCH (m:ExternalModule) WHERE NOT (m)<--() DETACH DELETE m"
 )
 CYPHER_PROJECT_MODULE_PATHS = (
-    "MATCH (m:Module) WHERE m.qualified_name STARTS WITH $project_prefix "
+    # The bare-name alternative covers the repository-root __init__.py,
+    # whose module qn is the project name itself.
+    "MATCH (m:Module) WHERE m.qualified_name = $project_name "
+    "OR m.qualified_name STARTS WITH $project_prefix "
     "RETURN m.path AS path"
 )
 

--- a/codebase_rag/constants/graph.py
+++ b/codebase_rag/constants/graph.py
@@ -336,7 +336,11 @@ PAYLOAD_NODE_ID = "node_id"
 PAYLOAD_QUALIFIED_NAME = "qualified_name"
 
 CYPHER_DELETE_MODULE = (
+    # Scoped to the project: two projects in the shared graph can hold the
+    # same relative path, and a path-only match would take the sibling's
+    # module subtree with it.
     "MATCH (m:Module {path: $path}) "
+    "WHERE m.qualified_name STARTS WITH $project_prefix "
     "OPTIONAL MATCH (m)-[:DEFINES|DEFINES_METHOD*0..]->(c) "
     "DETACH DELETE m, c"
 )

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1453,9 +1453,7 @@ class GraphUpdater:
             preexisting_paths if preexisting_paths is not None else frozenset()
         )
         deleted_keys = (
-            (set(old_hashes.keys()) | graph_paths)
-            - current_file_keys
-            - unreadable_keys
+            (set(old_hashes.keys()) | graph_paths) - current_file_keys - unreadable_keys
         )
         if deleted_keys:
             logger.info(ls.INCREMENTAL_DELETED, count=len(deleted_keys))

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -189,6 +189,10 @@ class GraphUpdater:
         self.ingestor = ingestor
         self._sink: IngestorProtocol = FilteringIngestor(ingestor, self.capture)
         self._single_file: Path | None = None
+        # True while the current sync re-parses EVERY file (no cache/force):
+        # such a run re-resolves all edges itself, so graph reads may degrade
+        # on failure; an incremental run's correctness depends on them.
+        self._is_full_build = False
         if repo_path.is_file():
             resolved = repo_path.resolve()
             self._single_file = resolved
@@ -750,8 +754,11 @@ class GraphUpdater:
             rows = self.ingestor.fetch_all(cs.CYPHER_ALL_DEFINITION_QNS, project_params)
         except Exception:
             # Rehydration completes cross-file resolution for files this run
-            # did not re-parse; a graph that cannot answer degrades to the
-            # freshly parsed registry rather than aborting the sync.
+            # did not re-parse: a FULL build parsed them all, so it degrades
+            # to the freshly parsed registry; an incremental run would drop
+            # cross-file edges, so the outage aborts it.
+            if not self._is_full_build:
+                raise
             logger.warning(ls.REHYDRATE_QUERY_FAILED)
             return
         for row in rows:
@@ -800,7 +807,16 @@ class GraphUpdater:
         # Module qns from unchanged files: deferred import verification and
         # C++20 module-impl resolution must count them as real targets, or
         # an incremental run would drop edges a clean index emits.
-        for row in self.ingestor.fetch_all(cs.CYPHER_ALL_MODULE_QNS, project_params):
+        try:
+            module_rows = self.ingestor.fetch_all(
+                cs.CYPHER_ALL_MODULE_QNS, project_params
+            )
+        except Exception:
+            if not self._is_full_build:
+                raise
+            logger.warning(ls.REHYDRATE_QUERY_FAILED)
+            return
+        for row in module_rows:
             qn = row.get(cs.KEY_QUALIFIED_NAME)
             label = row.get(cs.KEY_LABEL)
             if not isinstance(qn, str) or not isinstance(label, str):
@@ -823,12 +839,10 @@ class GraphUpdater:
         if not isinstance(self.ingestor, QueryProtocol):
             return
         module_map = self.factory.definition_processor.module_qn_to_file_path
-        try:
-            rows = self.ingestor.fetch_all(cs.CYPHER_ALL_MODULE_PATHS_INTERNAL)
-        except Exception:
-            logger.warning(ls.REHYDRATE_QUERY_FAILED)
-            return
-        for row in rows:
+        # Only incremental runs seed (full builds process every file), so a
+        # failed read here always aborts: a missing seed can silently let an
+        # added file overwrite a sibling module's qn.
+        for row in self.ingestor.fetch_all(cs.CYPHER_ALL_MODULE_PATHS_INTERNAL):
             qn = row.get(cs.KEY_QUALIFIED_NAME)
             path = row.get(cs.KEY_PATH)
             if not isinstance(qn, str) or not isinstance(path, str) or not path:
@@ -862,6 +876,8 @@ class GraphUpdater:
                 {cs.KEY_PROJECT_PREFIX: self.project_name + "."},
             )
         except Exception:
+            if not self._is_full_build:
+                raise
             logger.warning(ls.REHYDRATE_QUERY_FAILED)
             return
         for child, bases in self._rehydrated_bases_by_child(
@@ -914,10 +930,12 @@ class GraphUpdater:
                 cs.CYPHER_INBOUND_EDGES, {cs.CYPHER_PARAM_PATHS: reindexed_keys}
             )
         except Exception:
-            # Restoration is an optimisation over re-resolving the callers; a
-            # graph that cannot answer (the same outage that failed the
-            # module-path probe) degrades to a clean re-resolution rather
-            # than aborting the whole sync.
+            # A FULL build re-parses every caller, so nothing is lost and the
+            # sync may continue; an incremental run cannot re-resolve edges
+            # from files it will not parse, so the outage must abort it
+            # rather than silently drop them.
+            if not self._is_full_build:
+                raise
             logger.warning(ls.INBOUND_CAPTURE_FAILED)
             return []
 
@@ -1006,7 +1024,10 @@ class GraphUpdater:
         try:
             rows = fetch_all(
                 cs.CYPHER_PROJECT_MODULE_PATHS,
-                {cs.KEY_PROJECT_PREFIX: self.project_name + "."},
+                {
+                    cs.KEY_PROJECT_NAME: self.project_name,
+                    cs.KEY_PROJECT_PREFIX: self.project_name + ".",
+                },
             )
         except Exception:
             return None
@@ -1034,6 +1055,7 @@ class GraphUpdater:
                 cs.CYPHER_DELETE_MODULE,
                 {
                     cs.KEY_PATH: file_key,
+                    cs.KEY_PROJECT_NAME: self.project_name,
                     cs.KEY_PROJECT_PREFIX: self.project_name + ".",
                 },
             )
@@ -1252,6 +1274,7 @@ class GraphUpdater:
         dir_mtimes_path = self.repo_path / cs.DIR_MTIMES_FILENAME
         old_hashes = _load_hash_cache(cache_path) if not force else {}
         is_full_build = (force or not old_hashes) and self._single_file is None
+        self._is_full_build = is_full_build
         cache_mtime = cache_path.stat().st_mtime if cache_path.is_file() else 0.0
         if force:
             logger.info(ls.INCREMENTAL_FORCE)
@@ -1580,6 +1603,7 @@ class GraphUpdater:
             (cs.CYPHER_ALL_FOLDER_PATHS, cs.CYPHER_DELETE_FOLDER, "Folder"),
         ]
 
+        read_failed = False
         for query_all, delete_query, label in prune_specs:
             try:
                 rows = self.ingestor.fetch_all(query_all)
@@ -1587,6 +1611,7 @@ class GraphUpdater:
                 # A graph that cannot be read cannot be pruned safely; the
                 # next healthy run sweeps whatever this one left behind.
                 logger.warning(ls.PRUNE_QUERY_FAILED, label=label)
+                read_failed = True
                 continue
             orphans = []
             for r in rows:
@@ -1617,6 +1642,12 @@ class GraphUpdater:
                             delete_query, {cs.KEY_PATH: orphan_path}
                         )
                 total_pruned += len(orphans)
+
+        if read_failed:
+            # The same outage that broke the path reads would break (or act
+            # on stale state through) the cleanup below; leave everything
+            # for the next healthy run.
+            return
 
         # Drop external import-target modules that no module imports anymore,
         # e.g. an imported name renamed/removed on an incremental rebuild.

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -746,9 +746,15 @@ class GraphUpdater:
             return
         added = 0
         project_params = {cs.KEY_PROJECT_PREFIX: self.project_name + "."}
-        for row in self.ingestor.fetch_all(
-            cs.CYPHER_ALL_DEFINITION_QNS, project_params
-        ):
+        try:
+            rows = self.ingestor.fetch_all(cs.CYPHER_ALL_DEFINITION_QNS, project_params)
+        except Exception:
+            # Rehydration completes cross-file resolution for files this run
+            # did not re-parse; a graph that cannot answer degrades to the
+            # freshly parsed registry rather than aborting the sync.
+            logger.warning(ls.REHYDRATE_QUERY_FAILED)
+            return
+        for row in rows:
             qn = row.get(cs.KEY_QUALIFIED_NAME)
             label = row.get(cs.KEY_LABEL)
             if not isinstance(qn, str) or not isinstance(label, str):
@@ -817,7 +823,12 @@ class GraphUpdater:
         if not isinstance(self.ingestor, QueryProtocol):
             return
         module_map = self.factory.definition_processor.module_qn_to_file_path
-        for row in self.ingestor.fetch_all(cs.CYPHER_ALL_MODULE_PATHS_INTERNAL):
+        try:
+            rows = self.ingestor.fetch_all(cs.CYPHER_ALL_MODULE_PATHS_INTERNAL)
+        except Exception:
+            logger.warning(ls.REHYDRATE_QUERY_FAILED)
+            return
+        for row in rows:
             qn = row.get(cs.KEY_QUALIFIED_NAME)
             path = row.get(cs.KEY_PATH)
             if not isinstance(qn, str) or not isinstance(path, str) or not path:
@@ -845,10 +856,14 @@ class GraphUpdater:
         if not isinstance(self.ingestor, QueryProtocol):
             return
         class_inheritance = self.factory.definition_processor.class_inheritance
-        rows = self.ingestor.fetch_all(
-            cs.CYPHER_ALL_INHERITS,
-            {cs.KEY_PROJECT_PREFIX: self.project_name + "."},
-        )
+        try:
+            rows = self.ingestor.fetch_all(
+                cs.CYPHER_ALL_INHERITS,
+                {cs.KEY_PROJECT_PREFIX: self.project_name + "."},
+            )
+        except Exception:
+            logger.warning(ls.REHYDRATE_QUERY_FAILED)
+            return
         for child, bases in self._rehydrated_bases_by_child(
             rows, class_inheritance
         ).items():
@@ -894,9 +909,17 @@ class GraphUpdater:
         # context-sensitive).
         if not reindexed_keys or not isinstance(self.ingestor, QueryProtocol):
             return []
-        return self.ingestor.fetch_all(
-            cs.CYPHER_INBOUND_EDGES, {cs.CYPHER_PARAM_PATHS: reindexed_keys}
-        )
+        try:
+            return self.ingestor.fetch_all(
+                cs.CYPHER_INBOUND_EDGES, {cs.CYPHER_PARAM_PATHS: reindexed_keys}
+            )
+        except Exception:
+            # Restoration is an optimisation over re-resolving the callers; a
+            # graph that cannot answer (the same outage that failed the
+            # module-path probe) degrades to a clean re-resolution rather
+            # than aborting the whole sync.
+            logger.warning(ls.INBOUND_CAPTURE_FAILED)
+            return []
 
     def _restore_inbound_edges(self, captured: list[ResultRow]) -> None:
         # Re-emit each captured inbound edge whose target still exists after the
@@ -1254,6 +1277,7 @@ class GraphUpdater:
         skipped_count = 0
         changed_count = 0
         unreadable_count = 0
+        unreadable_keys: set[str] = set()
 
         current_file_keys: set[str] = set()
 
@@ -1266,6 +1290,7 @@ class GraphUpdater:
                     file_mtime = filepath.stat().st_mtime
                 except OSError:
                     unreadable_count += 1
+                    unreadable_keys.add(file_key)
                     continue
                 if file_mtime <= cache_mtime:
                     new_hashes[file_key] = old_hashes[file_key]
@@ -1276,6 +1301,7 @@ class GraphUpdater:
             hashed = _hash_file_with_bytes(filepath)
             if hashed is None:
                 unreadable_count += 1
+                unreadable_keys.add(file_key)
                 continue
             current_hash, file_bytes = hashed
 
@@ -1357,11 +1383,17 @@ class GraphUpdater:
         # was deleted OR newly excluded since the previous index is absent
         # from current_file_keys and its subtree must go. (Disk-deleted files
         # are also swept by orphan pruning; excluded ones still exist on disk
-        # and only this reconciliation catches them.)
+        # and only this reconciliation catches them.) A file that merely
+        # could not be READ this run still exists: sweeping it would erase
+        # live state over a transient error, so unreadable keys are exempt.
         graph_paths = (
             preexisting_paths if preexisting_paths is not None else frozenset()
         )
-        deleted_keys = (set(old_hashes.keys()) | graph_paths) - current_file_keys
+        deleted_keys = (
+            (set(old_hashes.keys()) | graph_paths)
+            - current_file_keys
+            - unreadable_keys
+        )
         if deleted_keys:
             logger.info(ls.INCREMENTAL_DELETED, count=len(deleted_keys))
             for deleted_key in deleted_keys:
@@ -1549,7 +1581,13 @@ class GraphUpdater:
         ]
 
         for query_all, delete_query, label in prune_specs:
-            rows = self.ingestor.fetch_all(query_all)
+            try:
+                rows = self.ingestor.fetch_all(query_all)
+            except Exception:
+                # A graph that cannot be read cannot be pruned safely; the
+                # next healthy run sweeps whatever this one left behind.
+                logger.warning(ls.PRUNE_QUERY_FAILED, label=label)
+                continue
             orphans = []
             for r in rows:
                 path = r.get("path")

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -967,11 +967,15 @@ class GraphUpdater:
                 self.simple_name_lookup[simple_name] = new_qn_set
                 logger.debug(ls.CLEANED_SIMPLE_NAME, name=simple_name)
 
-    def _existing_module_paths(self) -> frozenset[str]:
+    def _existing_module_paths(self) -> frozenset[str] | None:
         """Paths of this project's Module nodes already in the graph.
 
-        Empty when the sink cannot answer (offline writers, unit fakes): a
-        graph that cannot be read cannot hold state worth deleting first.
+        Empty when the sink has no query surface (offline writers, unit
+        fakes) or answers with something that is not rows: such a sink holds
+        no readable state worth deleting first. None when the sink CLAIMS
+        readability but the query itself failed: the graph state is unknown,
+        and treating it as empty would skip every delete and recreate the
+        stale accumulation this probe exists to prevent.
         """
         fetch_all = getattr(self.ingestor, "fetch_all", None)
         if fetch_all is None:
@@ -981,10 +985,16 @@ class GraphUpdater:
                 cs.CYPHER_PROJECT_MODULE_PATHS,
                 {cs.KEY_PROJECT_PREFIX: self.project_name + "."},
             )
-            return frozenset(
-                path for row in rows if isinstance(path := row.get(cs.KEY_PATH), str)
-            )
         except Exception:
+            return None
+        try:
+            return frozenset(
+                path
+                for row in rows
+                if isinstance(path := row.get(cs.KEY_PATH), str)
+                and not path.startswith(cs.INLINE_MODULE_PATH_PREFIX)
+            )
+        except (TypeError, AttributeError):
             return frozenset()
 
     def _delete_module_entities(self, file_key: str) -> None:
@@ -998,7 +1008,11 @@ class GraphUpdater:
         """
         if isinstance(self.ingestor, QueryProtocol):
             self.ingestor.execute_write(
-                cs.CYPHER_DELETE_MODULE, {cs.KEY_PATH: file_key}
+                cs.CYPHER_DELETE_MODULE,
+                {
+                    cs.KEY_PATH: file_key,
+                    cs.KEY_PROJECT_PREFIX: self.project_name + ".",
+                },
             )
 
     def _diff_dir_against_cache(
@@ -1277,7 +1291,11 @@ class GraphUpdater:
                 skipped_count += 1
                 continue
 
-            is_new = file_key not in old_hashes and file_key not in preexisting_paths
+            is_new = (
+                file_key not in old_hashes
+                and preexisting_paths is not None
+                and file_key not in preexisting_paths
+            )
             if not is_new:
                 logger.debug(ls.FILE_HASH_CHANGED, path=file_key)
             else:
@@ -1334,7 +1352,16 @@ class GraphUpdater:
                     description=ls.PROGRESS_FILES_PROCESSED.format(count=changed_count),
                 )
 
-        deleted_keys = set(old_hashes.keys()) - current_file_keys
+        # On a cacheless rebuild old_hashes cannot name what disappeared, so
+        # the graph's own module paths join the reconciliation: a file that
+        # was deleted OR newly excluded since the previous index is absent
+        # from current_file_keys and its subtree must go. (Disk-deleted files
+        # are also swept by orphan pruning; excluded ones still exist on disk
+        # and only this reconciliation catches them.)
+        graph_paths = (
+            preexisting_paths if preexisting_paths is not None else frozenset()
+        )
+        deleted_keys = (set(old_hashes.keys()) | graph_paths) - current_file_keys
         if deleted_keys:
             logger.info(ls.INCREMENTAL_DELETED, count=len(deleted_keys))
             for deleted_key in deleted_keys:
@@ -1543,9 +1570,14 @@ class GraphUpdater:
                 logger.info(ls.PRUNE_FOUND, count=len(orphans), label=label)
                 for orphan_path in orphans:
                     logger.debug(ls.PRUNE_DELETING, label=label, path=orphan_path)
-                    self.ingestor.execute_write(
-                        delete_query, {cs.KEY_PATH: orphan_path}
-                    )
+                    if delete_query == cs.CYPHER_DELETE_MODULE:
+                        # Module deletes are project-scoped; a sibling
+                        # project's module can share the relative path.
+                        self._delete_module_entities(orphan_path)
+                    else:
+                        self.ingestor.execute_write(
+                            delete_query, {cs.KEY_PATH: orphan_path}
+                        )
                 total_pruned += len(orphans)
 
         # Drop external import-target modules that no module imports anymore,

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -982,9 +982,7 @@ class GraphUpdater:
                 {cs.KEY_PROJECT_PREFIX: self.project_name + "."},
             )
             return frozenset(
-                path
-                for row in rows
-                if isinstance(path := row.get(cs.KEY_PATH), str)
+                path for row in rows if isinstance(path := row.get(cs.KEY_PATH), str)
             )
         except Exception:
             return frozenset()

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -967,6 +967,28 @@ class GraphUpdater:
                 self.simple_name_lookup[simple_name] = new_qn_set
                 logger.debug(ls.CLEANED_SIMPLE_NAME, name=simple_name)
 
+    def _existing_module_paths(self) -> frozenset[str]:
+        """Paths of this project's Module nodes already in the graph.
+
+        Empty when the sink cannot answer (offline writers, unit fakes): a
+        graph that cannot be read cannot hold state worth deleting first.
+        """
+        fetch_all = getattr(self.ingestor, "fetch_all", None)
+        if fetch_all is None:
+            return frozenset()
+        try:
+            rows = fetch_all(
+                cs.CYPHER_PROJECT_MODULE_PATHS,
+                {cs.KEY_PROJECT_PREFIX: self.project_name + "."},
+            )
+            return frozenset(
+                path
+                for row in rows
+                if isinstance(path := row.get(cs.KEY_PATH), str)
+            )
+        except Exception:
+            return frozenset()
+
     def _delete_module_entities(self, file_key: str) -> None:
         """Remove a changed/deleted file's Module subtree from the graph.
 
@@ -1206,6 +1228,16 @@ class GraphUpdater:
 
         if not is_full_build:
             self._seed_module_qns_from_graph({key for _fp, key in eligible_files})
+        # A full build can still land on a graph that already holds this
+        # project: the cache lives in the repo working tree, the graph does
+        # not, so a fresh clone of an indexed repo (or a force run) parses
+        # every file as "new" while the previous parse's state is still
+        # there. A file whose Module already exists must take the
+        # delete-before-reingest path or renamed-away symbols and their
+        # CALLS/REFERENCES edges accumulate alongside the fresh parse.
+        preexisting_paths = (
+            self._existing_module_paths() if is_full_build else frozenset()
+        )
         new_hashes: FileHashCache = {}
         skipped_count = 0
         changed_count = 0
@@ -1247,7 +1279,7 @@ class GraphUpdater:
                 skipped_count += 1
                 continue
 
-            is_new = file_key not in old_hashes
+            is_new = file_key not in old_hashes and file_key not in preexisting_paths
             if not is_new:
                 logger.debug(ls.FILE_HASH_CHANGED, path=file_key)
             else:

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -791,8 +791,8 @@ REHYDRATE_QUERY_FAILED = (
     "only this run's freshly parsed registry."
 )
 INBOUND_CAPTURE_FAILED = (
-    "Could not read inbound edges from the graph; dependent-file edges will "
-    "be re-resolved instead of restored."
+    "Could not read inbound edges from the graph; this full rebuild "
+    "re-parses every caller, so the edges are re-resolved from source."
 )
 
 # Orphan pruning logs

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -786,8 +786,18 @@ PARSER_FINGERPRINT_MISMATCH = (
     "stale. Run 'cgr start --clean' to rebuild it from scratch."
 )
 
+REHYDRATE_QUERY_FAILED = (
+    "Could not read persisted definitions from the graph; continuing with "
+    "only this run's freshly parsed registry."
+)
+INBOUND_CAPTURE_FAILED = (
+    "Could not read inbound edges from the graph; dependent-file edges will "
+    "be re-resolved instead of restored."
+)
+
 # Orphan pruning logs
 PRUNE_START = "--- Pruning orphan nodes from graph ---"
+PRUNE_QUERY_FAILED = "Could not read {label} paths from the graph; skipping its prune."
 PRUNE_FOUND = "Found {count} orphan {label} nodes to remove"
 PRUNE_DELETING = "Pruning orphan {label}: {path}"
 PRUNE_COMPLETE = "Pruning complete. Removed {count} orphan nodes."

--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -271,6 +271,7 @@ def mock_updater(temp_repo: Path, mock_ingestor: MagicMock) -> MagicMock:
     mock.ingestor = mock_ingestor
     mock.parsers = parsers
     mock.queries = queries
+    mock.project_name = temp_repo.resolve().name
 
     mock.factory = MagicMock()
     mock.factory.definition_processor = MagicMock()

--- a/codebase_rag/tests/integration/test_cacheless_rebuild_e2e.py
+++ b/codebase_rag/tests/integration/test_cacheless_rebuild_e2e.py
@@ -122,6 +122,34 @@ class TestCachelessRebuild:
         assert any(qn.endswith(".kept") for qn in names), names
         assert not any(qn.endswith(".gen") for qn in names), names
 
+    def test_rebuild_without_cache_drops_root_init_symbols(
+        self, memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+    ) -> None:
+        # A repository-level __init__.py's module qn IS the project name,
+        # with no dot after it: a `STARTS WITH $project_prefix` scope misses
+        # it during lookup and deletion, so its renamed symbols linger.
+        repo = tmp_path / "rootinitrepo"
+        repo.mkdir()
+        (repo / "__init__.py").write_text(
+            "def old_root():\n    return 1\n", encoding="utf-8"
+        )
+        _index(memgraph_ingestor, repo)
+
+        (repo / "__init__.py").write_text(
+            "def new_root():\n    return 1\n", encoding="utf-8"
+        )
+        (repo / cs.HASH_CACHE_FILENAME).unlink()
+        (repo / cs.DIR_MTIMES_FILENAME).unlink()
+        _index(memgraph_ingestor, repo)
+
+        rows = memgraph_ingestor.fetch_all(
+            "MATCH (f:Function) WHERE f.qualified_name STARTS WITH 'rootinitrepo' "
+            "RETURN f.qualified_name AS qn"
+        )
+        names = {str(row["qn"]) for row in rows}
+        assert any(qn.endswith(".new_root") for qn in names), names
+        assert not any(qn.endswith(".old_root") for qn in names), names
+
     def test_cacheless_rebuild_spares_sibling_project_with_same_path(
         self, memgraph_ingestor: MemgraphIngestor, tmp_path: Path
     ) -> None:
@@ -159,12 +187,16 @@ class TestCachelessRebuild:
         assert any(qn.endswith(".beta_fn") for qn in names), names
 
     def test_unreadable_file_is_not_reconciled_away(
-        self, memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+        self,
+        memgraph_ingestor: MemgraphIngestor,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         # A file that cannot be read this run (permissions, transient IO) is
         # absent from the current key set, but it still EXISTS: sweeping its
         # subtree with the graph-path reconciliation would erase live state
-        # over a transient error.
+        # over a transient error. The read failure is injected at the hash
+        # helper (chmod is unreliable on Windows and as root).
         repo = tmp_path / "unreadrepo"
         repo.mkdir()
         (repo / "kept.py").write_text("def kept():\n    return 1\n", encoding="utf-8")
@@ -174,11 +206,17 @@ class TestCachelessRebuild:
 
         (repo / cs.HASH_CACHE_FILENAME).unlink()
         (repo / cs.DIR_MTIMES_FILENAME).unlink()
-        locked.chmod(0o000)
-        try:
-            _index(memgraph_ingestor, repo)
-        finally:
-            locked.chmod(0o644)
+        import codebase_rag.graph_updater as gu
+
+        real_hash = gu._hash_file_with_bytes
+
+        def failing_hash(path: Path) -> tuple[str, bytes] | None:
+            if path.name == "locked.py":
+                return None
+            return real_hash(path)
+
+        monkeypatch.setattr(gu, "_hash_file_with_bytes", failing_hash)
+        _index(memgraph_ingestor, repo)
 
         rows = memgraph_ingestor.fetch_all(
             "MATCH (f:Function) WHERE f.qualified_name STARTS WITH 'unreadrepo.' "

--- a/codebase_rag/tests/integration/test_cacheless_rebuild_e2e.py
+++ b/codebase_rag/tests/integration/test_cacheless_rebuild_e2e.py
@@ -138,13 +138,51 @@ class TestCachelessRebuild:
             )
             _index(memgraph_ingestor, repo)
 
+        # Rename alpha's function so the rebuild demonstrably DELETES the
+        # old subtree; beta's survival then proves the delete was
+        # project-scoped rather than simply absent.
+        (alpha / "lib" / "shared.py").write_text(
+            "def alpha_renamed():\n    return 1\n", encoding="utf-8"
+        )
         (alpha / cs.HASH_CACHE_FILENAME).unlink()
         (alpha / cs.DIR_MTIMES_FILENAME).unlink()
         _index(memgraph_ingestor, alpha)
 
         rows = memgraph_ingestor.fetch_all(
-            "MATCH (f:Function) WHERE f.qualified_name STARTS WITH 'betaproj.' "
+            "MATCH (f:Function) WHERE f.qualified_name STARTS WITH 'alphaproj.' "
+            "OR f.qualified_name STARTS WITH 'betaproj.' "
             "RETURN f.qualified_name AS qn"
         )
         names = {str(row["qn"]) for row in rows}
+        assert not any(qn.endswith(".alpha_fn") for qn in names), names
+        assert any(qn.endswith(".alpha_renamed") for qn in names), names
         assert any(qn.endswith(".beta_fn") for qn in names), names
+
+    def test_unreadable_file_is_not_reconciled_away(
+        self, memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+    ) -> None:
+        # A file that cannot be read this run (permissions, transient IO) is
+        # absent from the current key set, but it still EXISTS: sweeping its
+        # subtree with the graph-path reconciliation would erase live state
+        # over a transient error.
+        repo = tmp_path / "unreadrepo"
+        repo.mkdir()
+        (repo / "kept.py").write_text("def kept():\n    return 1\n", encoding="utf-8")
+        locked = repo / "locked.py"
+        locked.write_text("def locked_fn():\n    return 1\n", encoding="utf-8")
+        _index(memgraph_ingestor, repo)
+
+        (repo / cs.HASH_CACHE_FILENAME).unlink()
+        (repo / cs.DIR_MTIMES_FILENAME).unlink()
+        locked.chmod(0o000)
+        try:
+            _index(memgraph_ingestor, repo)
+        finally:
+            locked.chmod(0o644)
+
+        rows = memgraph_ingestor.fetch_all(
+            "MATCH (f:Function) WHERE f.qualified_name STARTS WITH 'unreadrepo.' "
+            "RETURN f.qualified_name AS qn"
+        )
+        names = {str(row["qn"]) for row in rows}
+        assert any(qn.endswith(".locked_fn") for qn in names), names

--- a/codebase_rag/tests/integration/test_cacheless_rebuild_e2e.py
+++ b/codebase_rag/tests/integration/test_cacheless_rebuild_e2e.py
@@ -24,10 +24,18 @@ if TYPE_CHECKING:
 pytestmark = [pytest.mark.integration]
 
 
-def _index(ingestor: MemgraphIngestor, repo_path: Path) -> None:
+def _index(
+    ingestor: MemgraphIngestor,
+    repo_path: Path,
+    exclude_paths: frozenset[str] | None = None,
+) -> None:
     parsers, queries = load_parsers()
     GraphUpdater(
-        ingestor=ingestor, repo_path=repo_path, parsers=parsers, queries=queries
+        ingestor=ingestor,
+        repo_path=repo_path,
+        parsers=parsers,
+        queries=queries,
+        exclude_paths=exclude_paths,
     ).run()
 
 
@@ -62,3 +70,81 @@ class TestCachelessRebuild:
         names = _function_names(memgraph_ingestor)
         assert any(qn.endswith(".new_name") for qn in names), names
         assert not any(qn.endswith(".old_name") for qn in names), names
+
+    def test_rebuild_without_cache_drops_removed_files(
+        self, memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+    ) -> None:
+        # A file deleted between the previous index and a cacheless rebuild
+        # appears nowhere: not in the (empty) old hashes and not on disk.
+        # Orphan pruning reconciles it from the graph's own path listing;
+        # this pins that cover.
+        repo = tmp_path / "removedrepo"
+        repo.mkdir()
+        (repo / "kept.py").write_text("def kept():\n    return 1\n", encoding="utf-8")
+        (repo / "gone.py").write_text("def gone():\n    return 1\n", encoding="utf-8")
+        _index(memgraph_ingestor, repo)
+
+        (repo / "gone.py").unlink()
+        (repo / cs.HASH_CACHE_FILENAME).unlink()
+        (repo / cs.DIR_MTIMES_FILENAME).unlink()
+
+        _index(memgraph_ingestor, repo)
+        rows = memgraph_ingestor.fetch_all(
+            "MATCH (f:Function) WHERE f.qualified_name STARTS WITH 'removedrepo.' "
+            "RETURN f.qualified_name AS qn"
+        )
+        names = {str(row["qn"]) for row in rows}
+        assert any(qn.endswith(".kept") for qn in names), names
+        assert not any(qn.endswith(".gone") for qn in names), names
+
+    def test_rebuild_without_cache_drops_newly_excluded_files(
+        self, memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+    ) -> None:
+        # A file EXCLUDED between the previous index and a cacheless rebuild
+        # still exists on disk, so orphan pruning keeps it, and the empty old
+        # hashes cannot mark it deleted. The rebuild must reconcile the
+        # graph's own module paths against the current eligible set.
+        repo = tmp_path / "exclrepo"
+        repo.mkdir()
+        (repo / "kept.py").write_text("def kept():\n    return 1\n", encoding="utf-8")
+        (repo / "gen.py").write_text("def gen():\n    return 1\n", encoding="utf-8")
+        _index(memgraph_ingestor, repo)
+
+        (repo / cs.HASH_CACHE_FILENAME).unlink()
+        (repo / cs.DIR_MTIMES_FILENAME).unlink()
+        _index(memgraph_ingestor, repo, exclude_paths=frozenset({"gen.py"}))
+
+        rows = memgraph_ingestor.fetch_all(
+            "MATCH (f:Function) WHERE f.qualified_name STARTS WITH 'exclrepo.' "
+            "RETURN f.qualified_name AS qn"
+        )
+        names = {str(row["qn"]) for row in rows}
+        assert any(qn.endswith(".kept") for qn in names), names
+        assert not any(qn.endswith(".gen") for qn in names), names
+
+    def test_cacheless_rebuild_spares_sibling_project_with_same_path(
+        self, memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+    ) -> None:
+        # Two projects in the shared graph both hold lib/shared.py. The
+        # delete-before-reingest of one project's cacheless rebuild must be
+        # scoped to that project's qualified names or it takes the sibling's
+        # module subtree with it.
+        alpha = tmp_path / "alphaproj"
+        beta = tmp_path / "betaproj"
+        for repo, fn in ((alpha, "alpha_fn"), (beta, "beta_fn")):
+            (repo / "lib").mkdir(parents=True)
+            (repo / "lib" / "shared.py").write_text(
+                f"def {fn}():\n    return 1\n", encoding="utf-8"
+            )
+            _index(memgraph_ingestor, repo)
+
+        (alpha / cs.HASH_CACHE_FILENAME).unlink()
+        (alpha / cs.DIR_MTIMES_FILENAME).unlink()
+        _index(memgraph_ingestor, alpha)
+
+        rows = memgraph_ingestor.fetch_all(
+            "MATCH (f:Function) WHERE f.qualified_name STARTS WITH 'betaproj.' "
+            "RETURN f.qualified_name AS qn"
+        )
+        names = {str(row["qn"]) for row in rows}
+        assert any(qn.endswith(".beta_fn") for qn in names), names

--- a/codebase_rag/tests/integration/test_cacheless_rebuild_e2e.py
+++ b/codebase_rag/tests/integration/test_cacheless_rebuild_e2e.py
@@ -48,7 +48,9 @@ class TestCachelessRebuild:
         source = repo / "main.py"
         source.write_text("def old_name():\n    return 1\n", encoding="utf-8")
         _index(memgraph_ingestor, repo)
-        assert any(qn.endswith(".old_name") for qn in _function_names(memgraph_ingestor))
+        assert any(
+            qn.endswith(".old_name") for qn in _function_names(memgraph_ingestor)
+        )
 
         # A fresh clone: same repo content evolves, but the cache files are
         # gone while the database still holds the previous parse.

--- a/codebase_rag/tests/integration/test_cacheless_rebuild_e2e.py
+++ b/codebase_rag/tests/integration/test_cacheless_rebuild_e2e.py
@@ -1,0 +1,62 @@
+"""A rebuild without a hash cache must not accumulate stale graph state.
+
+The cache lives in the repo working tree, so a fresh clone (or a deleted
+cache) has none while the shared database still holds the project. Every
+file then counts as "new", the per-file delete-before-reingest is skipped,
+and symbols renamed or removed since the previous index linger alongside
+the fresh parse, stale CALLS/REFERENCES edges included.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+if TYPE_CHECKING:
+    from codebase_rag.services.graph_service import MemgraphIngestor
+
+pytestmark = [pytest.mark.integration]
+
+
+def _index(ingestor: MemgraphIngestor, repo_path: Path) -> None:
+    parsers, queries = load_parsers()
+    GraphUpdater(
+        ingestor=ingestor, repo_path=repo_path, parsers=parsers, queries=queries
+    ).run()
+
+
+def _function_names(ingestor: MemgraphIngestor) -> set[str]:
+    rows = ingestor.fetch_all(
+        "MATCH (f:Function) WHERE f.qualified_name STARTS WITH 'renamerepo.' "
+        "RETURN f.qualified_name AS qn"
+    )
+    return {str(row["qn"]) for row in rows}
+
+
+class TestCachelessRebuild:
+    def test_rebuild_without_cache_drops_renamed_symbols(
+        self, memgraph_ingestor: MemgraphIngestor, tmp_path: Path
+    ) -> None:
+        repo = tmp_path / "renamerepo"
+        repo.mkdir()
+        source = repo / "main.py"
+        source.write_text("def old_name():\n    return 1\n", encoding="utf-8")
+        _index(memgraph_ingestor, repo)
+        assert any(qn.endswith(".old_name") for qn in _function_names(memgraph_ingestor))
+
+        # A fresh clone: same repo content evolves, but the cache files are
+        # gone while the database still holds the previous parse.
+        source.write_text("def new_name():\n    return 1\n", encoding="utf-8")
+        (repo / cs.HASH_CACHE_FILENAME).unlink()
+        (repo / cs.DIR_MTIMES_FILENAME).unlink()
+
+        _index(memgraph_ingestor, repo)
+        names = _function_names(memgraph_ingestor)
+        assert any(qn.endswith(".new_name") for qn in names), names
+        assert not any(qn.endswith(".old_name") for qn in names), names

--- a/codebase_rag/tests/test_cacheless_lookup_failure.py
+++ b/codebase_rag/tests/test_cacheless_lookup_failure.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
+
 from codebase_rag import constants as cs
 from codebase_rag.tests.conftest import create_and_run_updater
 
@@ -64,3 +66,28 @@ def test_fully_unreadable_graph_still_completes_the_rebuild(
         if c.args[0] == cs.NodeLabel.MODULE
     }
     assert any(str(qn).endswith(".m") for qn in module_qns), module_qns
+
+
+def test_incremental_run_aborts_when_inbound_capture_fails(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # A FULL build re-parses and re-resolves every edge, so it may degrade
+    # when the graph cannot be read; an INCREMENTAL run's correctness depends
+    # on those reads (inbound restore, rehydration): degrading would silently
+    # drop every edge from unchanged callers into the changed file, so the
+    # outage must abort the sync instead.
+    source = temp_repo / "m.py"
+    source.write_text("def f():\n    return 1\n", encoding="utf-8")
+    create_and_run_updater(temp_repo, mock_ingestor, skip_if_missing=None)
+
+    source.write_text("def f():\n    return 2\n", encoding="utf-8")
+
+    def unavailable(query: str, params: dict | None = None) -> list:
+        if query == cs.CYPHER_INBOUND_EDGES:
+            raise RuntimeError("graph down")
+        return []
+
+    mock_ingestor.fetch_all.side_effect = unavailable
+
+    with pytest.raises(RuntimeError, match="graph down"):
+        create_and_run_updater(temp_repo, mock_ingestor, skip_if_missing=None)

--- a/codebase_rag/tests/test_cacheless_lookup_failure.py
+++ b/codebase_rag/tests/test_cacheless_lookup_failure.py
@@ -68,6 +68,98 @@ def test_fully_unreadable_graph_still_completes_the_rebuild(
     assert any(str(qn).endswith(".m") for qn in module_qns), module_qns
 
 
+def test_incremental_rehydration_failure_aborts(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # Registry rehydration is what lets an incremental run resolve calls
+    # into files it did not re-parse; a sink that cannot answer must abort
+    # the sync, not silently drop those edges.
+    source = temp_repo / "m.py"
+    source.write_text("def f():\n    return 1\n", encoding="utf-8")
+    create_and_run_updater(temp_repo, mock_ingestor, skip_if_missing=None)
+
+    source.write_text("def f():\n    return 2\n", encoding="utf-8")
+
+    def unavailable(query: str, params: dict | None = None) -> list:
+        if query == cs.CYPHER_ALL_DEFINITION_QNS:
+            raise RuntimeError("graph down")
+        return []
+
+    mock_ingestor.fetch_all.side_effect = unavailable
+
+    with pytest.raises(RuntimeError, match="graph down"):
+        create_and_run_updater(temp_repo, mock_ingestor, skip_if_missing=None)
+
+
+def test_full_build_module_qn_rehydration_failure_degrades(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+
+    def unavailable(query: str, params: dict | None = None) -> list:
+        if query == cs.CYPHER_ALL_MODULE_QNS:
+            raise RuntimeError("graph down")
+        return []
+
+    mock_ingestor.fetch_all.side_effect = unavailable
+
+    create_and_run_updater(temp_repo, mock_ingestor, skip_if_missing=None)
+
+    module_qns = {
+        c.args[1].get(cs.KEY_QUALIFIED_NAME)
+        for c in mock_ingestor.ensure_node_batch.call_args_list
+        if c.args[0] == cs.NodeLabel.MODULE
+    }
+    assert any(str(qn).endswith(".m") for qn in module_qns), module_qns
+
+
+def test_full_build_inherits_rehydration_failure_degrades(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+
+    def unavailable(query: str, params: dict | None = None) -> list:
+        if query == cs.CYPHER_ALL_INHERITS:
+            raise RuntimeError("graph down")
+        return []
+
+    mock_ingestor.fetch_all.side_effect = unavailable
+
+    create_and_run_updater(temp_repo, mock_ingestor, skip_if_missing=None)
+
+    module_qns = {
+        c.args[1].get(cs.KEY_QUALIFIED_NAME)
+        for c in mock_ingestor.ensure_node_batch.call_args_list
+        if c.args[0] == cs.NodeLabel.MODULE
+    }
+    assert any(str(qn).endswith(".m") for qn in module_qns), module_qns
+
+
+def test_non_row_module_path_answer_reads_as_empty(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # A fake sink whose fetch_all answers with something that is not rows is
+    # NOT a readable graph: the probe reads it as empty (files stay "new",
+    # nothing is deleted first) rather than as a failure.
+    (temp_repo / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+
+    def non_rows(query: str, params: dict | None = None) -> object:
+        if query == cs.CYPHER_PROJECT_MODULE_PATHS:
+            return object()
+        return []
+
+    mock_ingestor.fetch_all.side_effect = non_rows
+
+    create_and_run_updater(temp_repo, mock_ingestor, skip_if_missing=None)
+
+    deleted_paths = {
+        c.args[1][cs.KEY_PATH]
+        for c in mock_ingestor.execute_write.call_args_list
+        if c.args[0] == cs.CYPHER_DELETE_MODULE
+    }
+    assert "m.py" not in deleted_paths, deleted_paths
+
+
 def test_incremental_run_aborts_when_inbound_capture_fails(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:

--- a/codebase_rag/tests/test_cacheless_lookup_failure.py
+++ b/codebase_rag/tests/test_cacheless_lookup_failure.py
@@ -96,8 +96,11 @@ def test_full_build_module_qn_rehydration_failure_degrades(
 ) -> None:
     (temp_repo / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
 
+    failed_queries: list[str] = []
+
     def unavailable(query: str, params: dict | None = None) -> list:
         if query == cs.CYPHER_ALL_MODULE_QNS:
+            failed_queries.append(query)
             raise RuntimeError("graph down")
         return []
 
@@ -105,6 +108,9 @@ def test_full_build_module_qn_rehydration_failure_degrades(
 
     create_and_run_updater(temp_repo, mock_ingestor, skip_if_missing=None)
 
+    # The guard must actually have been refused; module creation alone also
+    # happens when the rehydration query is never reached.
+    assert failed_queries
     module_qns = {
         c.args[1].get(cs.KEY_QUALIFIED_NAME)
         for c in mock_ingestor.ensure_node_batch.call_args_list
@@ -118,8 +124,11 @@ def test_full_build_inherits_rehydration_failure_degrades(
 ) -> None:
     (temp_repo / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
 
+    failed_queries: list[str] = []
+
     def unavailable(query: str, params: dict | None = None) -> list:
         if query == cs.CYPHER_ALL_INHERITS:
+            failed_queries.append(query)
             raise RuntimeError("graph down")
         return []
 
@@ -127,6 +136,7 @@ def test_full_build_inherits_rehydration_failure_degrades(
 
     create_and_run_updater(temp_repo, mock_ingestor, skip_if_missing=None)
 
+    assert failed_queries
     module_qns = {
         c.args[1].get(cs.KEY_QUALIFIED_NAME)
         for c in mock_ingestor.ensure_node_batch.call_args_list

--- a/codebase_rag/tests/test_cacheless_lookup_failure.py
+++ b/codebase_rag/tests/test_cacheless_lookup_failure.py
@@ -1,0 +1,35 @@
+# A full build asks the graph which of this project's modules already exist
+# so their subtrees are deleted before reingest. A sink that claims
+# readability but fails the query leaves the graph state UNKNOWN: treating it
+# as empty skips every delete and recreates the stale-accumulation corruption
+# the probe exists to prevent. The only safe answer is to delete-before-
+# reingest every current file (deleting an absent module is a no-op).
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import create_and_run_updater
+
+
+def test_module_path_lookup_failure_forces_delete_before_reingest(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+
+    def unavailable(query: str, params: dict | None = None) -> list:
+        if query == cs.CYPHER_PROJECT_MODULE_PATHS:
+            raise RuntimeError("graph down")
+        return []
+
+    mock_ingestor.fetch_all.side_effect = unavailable
+
+    create_and_run_updater(temp_repo, mock_ingestor, skip_if_missing=None)
+
+    deleted_paths = {
+        c.args[1][cs.KEY_PATH]
+        for c in mock_ingestor.execute_write.call_args_list
+        if c.args[0] == cs.CYPHER_DELETE_MODULE
+    }
+    assert "m.py" in deleted_paths, deleted_paths

--- a/codebase_rag/tests/test_cacheless_lookup_failure.py
+++ b/codebase_rag/tests/test_cacheless_lookup_failure.py
@@ -33,3 +33,34 @@ def test_module_path_lookup_failure_forces_delete_before_reingest(
         if c.args[0] == cs.CYPHER_DELETE_MODULE
     }
     assert "m.py" in deleted_paths, deleted_paths
+
+
+def test_fully_unreadable_graph_still_completes_the_rebuild(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # A sink whose EVERY read fails (graph briefly down while writes queue)
+    # must not abort the sync: the failed probe routes all files through
+    # delete-before-reingest, and the inbound-edge capture that path then
+    # attempts hits the same unreadable graph and must degrade to a clean
+    # re-resolution, not an unhandled exception.
+    (temp_repo / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+
+    def unavailable(query: str, params: dict | None = None) -> list:
+        raise RuntimeError("graph down")
+
+    mock_ingestor.fetch_all.side_effect = unavailable
+
+    create_and_run_updater(temp_repo, mock_ingestor, skip_if_missing=None)
+
+    deleted_paths = {
+        c.args[1][cs.KEY_PATH]
+        for c in mock_ingestor.execute_write.call_args_list
+        if c.args[0] == cs.CYPHER_DELETE_MODULE
+    }
+    assert "m.py" in deleted_paths, deleted_paths
+    module_qns = {
+        c.args[1].get(cs.KEY_QUALIFIED_NAME)
+        for c in mock_ingestor.ensure_node_batch.call_args_list
+        if c.args[0] == cs.NodeLabel.MODULE
+    }
+    assert any(str(qn).endswith(".m") for qn in module_qns), module_qns

--- a/codebase_rag/tests/test_graph_updater_pruning.py
+++ b/codebase_rag/tests/test_graph_updater_pruning.py
@@ -71,6 +71,7 @@ class TestPruneOrphanNodes:
         assert len(delete_calls) == 1
         assert delete_calls[0].args[1] == {
             cs.KEY_PATH: "old_project/main.py",
+            cs.KEY_PROJECT_NAME: project_name,
             cs.KEY_PROJECT_PREFIX: f"{project_name}.",
         }
 

--- a/codebase_rag/tests/test_graph_updater_pruning.py
+++ b/codebase_rag/tests/test_graph_updater_pruning.py
@@ -69,7 +69,10 @@ class TestPruneOrphanNodes:
             if c.args[0] == cs.CYPHER_DELETE_MODULE
         ]
         assert len(delete_calls) == 1
-        assert delete_calls[0].args[1] == {cs.KEY_PATH: "old_project/main.py"}
+        assert delete_calls[0].args[1] == {
+            cs.KEY_PATH: "old_project/main.py",
+            cs.KEY_PROJECT_PREFIX: f"{project_name}.",
+        }
 
     def test_prune_removes_orphan_external_module_nodes(
         self, py_project: Path, mock_ingestor: MagicMock

--- a/codebase_rag/tests/test_realtime_event_filtering.py
+++ b/codebase_rag/tests/test_realtime_event_filtering.py
@@ -207,4 +207,10 @@ class TestCypherDeleteFileQuery:
             if c.args[0] == cs.CYPHER_DELETE_MODULE
         ]
         assert len(delete_module_calls) == 1
-        assert delete_module_calls[0].args[1] == {cs.KEY_PATH: "remove.py"}
+        # The module delete is project-scoped: the query requires the scope
+        # parameters or a realtime change fails the delete outright.
+        assert delete_module_calls[0].args[1] == {
+            cs.KEY_PATH: "remove.py",
+            cs.KEY_PROJECT_NAME: mock_updater.project_name,
+            cs.KEY_PROJECT_PREFIX: f"{mock_updater.project_name}.",
+        }

--- a/realtime_updater.py
+++ b/realtime_updater.py
@@ -22,6 +22,8 @@ from codebase_rag.constants import (
     IGNORE_PATTERNS,
     IGNORE_SUFFIXES,
     KEY_PATH,
+    KEY_PROJECT_NAME,
+    KEY_PROJECT_PREFIX,
     LOG_LEVEL_INFO,
     REALTIME_LOGGER_FORMAT,
     WATCHER_SLEEP_INTERVAL,
@@ -215,8 +217,17 @@ class CodeChangeEventHandler(FileSystemEventHandler):
         )
 
         # Step 1: Delete existing nodes for this file path
-        # Delete Module node and its children (for code files)
-        ingestor.execute_write(CYPHER_DELETE_MODULE, {KEY_PATH: relative_path_str})
+        # Delete Module node and its children (for code files); the delete is
+        # project-scoped, so the sibling project sharing this relative path
+        # in the shared graph keeps its module.
+        ingestor.execute_write(
+            CYPHER_DELETE_MODULE,
+            {
+                KEY_PATH: relative_path_str,
+                KEY_PROJECT_NAME: self.updater.project_name,
+                KEY_PROJECT_PREFIX: f"{self.updater.project_name}.",
+            },
+        )
         # Delete File node (for all files including non-code like .md, .json)
         ingestor.execute_write(CYPHER_DELETE_FILE, {KEY_PATH: relative_path_str})
         logger.debug(logs.DELETION_QUERY.format(path=relative_path_str))

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.438"
+version = "0.0.441"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
Found dogfooding on real Dart repositories: the hash cache lives in the repo working tree, but the graph does not, so a fresh clone of an already-indexed repo (or a deliberately deleted cache, or a `force` run) treats every file as NEW. New files skip the delete-before-reingest step, so the previous parse's renamed-away symbols and their CALLS/REFERENCES edges accumulate alongside the fresh parse. Observed live: 552 stale REFERENCES edges survived a full re-index, silently suppressing dead-code candidates and fabricating call-graph state. This is the mirror image of #863 (wiped graph + surviving cache); here the graph survives and the cache is gone.

## Changes
- On a full build, `_process_files` first fetches the project's existing Module paths (`CYPHER_PROJECT_MODULE_PATHS`, one linear query); a file whose Module already exists is treated as changed, taking the existing delete-before-reingest path.
- The lookup fails open to an empty set for sinks that cannot answer (offline writers, unit fakes), preserving current behaviour everywhere a graph cannot be read.

## Testing
- RED: new integration test indexes a repo, renames a function while deleting only the cache files, re-indexes, and asserts the old symbol is gone; it failed before the fix.
- GREEN after; full unit suite (5476 passed) and full integration suite (292 passed) both green.
- Live: re-indexing the wonderous Flutter app after a cache wipe now purges all 552 stale REFERENCES edges (the one remaining edge is freshly and correctly re-emitted by the C++ argument-reference pass).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cacheless rebuild behavior for renamed, removed, newly excluded symbols/files, and root-level `__init__.py` changes.
  * Tightened project scoping so module counting, deletion, and pruning only affect the current project (including realtime file-content updates).
  * Increased robustness during graph read failures: safer warn/abort behavior, and unreadable subtrees are no longer reconciled away; pruning cleanup is skipped when reads fail.
* **Tests**
  * Expanded end-to-end and failure-mode regression coverage for cacheless rebuilds and incremental/inbound-edge error handling.
* **Chores**
  * Added clearer logs for incremental sync query failures and pruning read issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->