### PR TITLE
fix(deadcode): root c and c++ os entry points

### DIFF
--- a/codebase_rag/constants/deadcode_roots.py
+++ b/codebase_rag/constants/deadcode_roots.py
@@ -7,6 +7,13 @@
 # C++ file uniquely identifies them (member or free function).
 CPP_OPERATOR_PREFIX = "operator"
 
+# C/C++ program entries the OS runtime invokes with no visible call site:
+# hosted `main`/Windows `wmain`, GUI `WinMain`/`wWinMain`, and a DLL's
+# `DllMain`. Free functions on C/C++ files only.
+C_CPP_ENTRY_FUNCTION_NAMES: frozenset[str] = frozenset(
+    {"main", "wmain", "WinMain", "wWinMain", "DllMain"}
+)
+
 # Decorators whose presence marks a function/method as an implicit entry point
 # (web routes, task/flow handlers, fixtures, CLI commands, event listeners, and
 # Pydantic validators/serializers the framework invokes by registration).

--- a/codebase_rag/constants/languages.py
+++ b/codebase_rag/constants/languages.py
@@ -81,6 +81,9 @@ CPP_EXTENSIONS = (
     EXT_CPPM,
     EXT_CCM,
 )
+# Translation-unit sources: only these can define a linkable OS entry point;
+# headers and C++ module interface files never are the entry unit.
+C_CPP_SOURCE_EXTENSIONS = (EXT_C, EXT_CPP, EXT_CC, EXT_CXX)
 PHP_EXTENSIONS = (EXT_PHP,)
 LUA_EXTENSIONS = (EXT_LUA,)
 CS_EXTENSIONS = (EXT_CS,)

--- a/codebase_rag/dead_code.py
+++ b/codebase_rag/dead_code.py
@@ -83,6 +83,19 @@ def _is_rust_runtime_root(name: str, is_method: bool, path: str) -> bool:
     return is_method and name in cs.RUST_TRAIT_METHOD_NAMES
 
 
+def _is_c_cpp_entry_root(name: str, is_method: bool, path: str) -> bool:
+    # A C/C++ program entry (`main`, Windows' `wWinMain`/`WinMain`/`wmain`, a
+    # DLL's `DllMain`) is invoked by the OS runtime, never by a call the graph
+    # sees, so it roots its whole call tree (an unrooted wWinMain reported all
+    # 34 windows/runner symbols of a Flutter desktop shim dead). Free
+    # functions only; a method named main is not an entry.
+    return (
+        not is_method
+        and name in cs.C_CPP_ENTRY_FUNCTION_NAMES
+        and (path.endswith(cs.CPP_EXTENSIONS) or path.endswith(cs.EXT_C))
+    )
+
+
 def _is_cpp_operator_root(name: str, path: str) -> bool:
     # A C++ operator overload / user-defined literal (`operator==`, `operator[]`,
     # `operator""_json`) is invoked by operator/literal SYNTAX, not a named call
@@ -274,6 +287,8 @@ def dead_code_from_graph(
         elif _is_rust_runtime_root(leaf, qn in method_qns, path):
             roots.add(qn)
         elif _is_cpp_operator_root(leaf, path):
+            roots.add(qn)
+        elif _is_c_cpp_entry_root(leaf, qn in method_qns, path):
             roots.add(qn)
         elif _is_java_serialization_root(
             leaf.split(cs.CHAR_PAREN_OPEN, 1)[0], qn in method_qns, path

--- a/codebase_rag/dead_code.py
+++ b/codebase_rag/dead_code.py
@@ -83,17 +83,25 @@ def _is_rust_runtime_root(name: str, is_method: bool, path: str) -> bool:
     return is_method and name in cs.RUST_TRAIT_METHOD_NAMES
 
 
-def _is_c_cpp_entry_root(name: str, is_method: bool, path: str) -> bool:
+def _is_c_cpp_entry_root(name: str, is_method: bool, path: str, qn: str) -> bool:
     # A C/C++ program entry (`main`, Windows' `wWinMain`/`WinMain`/`wmain`, a
     # DLL's `DllMain`) is invoked by the OS runtime, never by a call the graph
     # sees, so it roots its whole call tree (an unrooted wWinMain reported all
-    # 34 windows/runner symbols of a Flutter desktop shim dead). Free
-    # functions only; a method named main is not an entry.
-    return (
-        not is_method
-        and name in cs.C_CPP_ENTRY_FUNCTION_NAMES
-        and (path.endswith(cs.CPP_EXTENSIONS) or path.endswith(cs.EXT_C))
-    )
+    # 34 windows/runner symbols of a Flutter desktop shim dead). Only a free
+    # function at FILE scope in a translation-unit source counts: a method, a
+    # namespace-scoped `main`, or a header-defined `WinMain` is ordinary code
+    # the OS cannot invoke. (Linkage is not captured in the graph, so a
+    # file-scope `static DllMain` in a source file still roots.)
+    if is_method or name not in cs.C_CPP_ENTRY_FUNCTION_NAMES:
+        return False
+    if not path.endswith(cs.C_CPP_SOURCE_EXTENSIONS):
+        return False
+    # File scope: the qn segment before the leaf is the module itself, whose
+    # segment is the file stem (`proj.runner.main.wWinMain` for
+    # runner/main.cpp); a namespace inserts its own segment there.
+    parts = qn.split(cs.SEPARATOR_DOT)
+    stem = path.rsplit("/", 1)[-1].rsplit(".", 1)[0]
+    return len(parts) >= 2 and parts[-2] == stem
 
 
 def _is_cpp_operator_root(name: str, path: str) -> bool:
@@ -286,9 +294,9 @@ def dead_code_from_graph(
             roots.add(qn)
         elif _is_rust_runtime_root(leaf, qn in method_qns, path):
             roots.add(qn)
-        elif _is_cpp_operator_root(leaf, path):
-            roots.add(qn)
-        elif _is_c_cpp_entry_root(leaf, qn in method_qns, path):
+        elif _is_cpp_operator_root(leaf, path) or _is_c_cpp_entry_root(
+            leaf, qn in method_qns, path, qn
+        ):
             roots.add(qn)
         elif _is_java_serialization_root(
             leaf.split(cs.CHAR_PAREN_OPEN, 1)[0], qn in method_qns, path

--- a/codebase_rag/dead_code.py
+++ b/codebase_rag/dead_code.py
@@ -83,7 +83,9 @@ def _is_rust_runtime_root(name: str, is_method: bool, path: str) -> bool:
     return is_method and name in cs.RUST_TRAIT_METHOD_NAMES
 
 
-def _is_c_cpp_entry_root(name: str, is_method: bool, path: str, qn: str) -> bool:
+def _is_c_cpp_entry_root(
+    name: str, is_method: bool, path: str, qn: str, project_prefix: str
+) -> bool:
     # A C/C++ program entry (`main`, Windows' `wWinMain`/`WinMain`/`wmain`, a
     # DLL's `DllMain`) is invoked by the OS runtime, never by a call the graph
     # sees, so it roots its whole call tree (an unrooted wWinMain reported all
@@ -96,12 +98,15 @@ def _is_c_cpp_entry_root(name: str, is_method: bool, path: str, qn: str) -> bool
         return False
     if not path.endswith(cs.C_CPP_SOURCE_EXTENSIONS):
         return False
-    # File scope: the qn segment before the leaf is the module itself, whose
-    # segment is the file stem (`proj.runner.main.wWinMain` for
-    # runner/main.cpp); a namespace inserts its own segment there.
-    parts = qn.split(cs.SEPARATOR_DOT)
-    stem = path.rsplit("/", 1)[-1].rsplit(".", 1)[0]
-    return len(parts) >= 2 and parts[-2] == stem
+    # File scope, exactly: a file-scope definition's qn is the project prefix
+    # plus the path's dotted form (extension dropped) plus the name
+    # (`proj.runner.main.wWinMain` for runner/main.cpp). A namespace inserts
+    # its own segment, even one named like the file stem (`namespace main`
+    # in main.cpp), so nothing short of the exact qn earns the root.
+    dotted_module = path.rsplit(cs.SEPARATOR_DOT, 1)[0].replace(
+        cs.SEPARATOR_SLASH, cs.SEPARATOR_DOT
+    )
+    return qn == f"{project_prefix}{dotted_module}{cs.SEPARATOR_DOT}{name}"
 
 
 def _is_cpp_operator_root(name: str, path: str) -> bool:
@@ -295,7 +300,7 @@ def dead_code_from_graph(
         elif _is_rust_runtime_root(leaf, qn in method_qns, path):
             roots.add(qn)
         elif _is_cpp_operator_root(leaf, path) or _is_c_cpp_entry_root(
-            leaf, qn in method_qns, path, qn
+            leaf, qn in method_qns, path, qn, project_prefix
         ):
             roots.add(qn)
         elif _is_java_serialization_root(

--- a/codebase_rag/tests/test_dead_code_cpp_entry_roots.py
+++ b/codebase_rag/tests/test_dead_code_cpp_entry_roots.py
@@ -82,6 +82,17 @@ def test_header_defined_entry_name_is_not_rooted() -> None:
     assert len(reported) == 1, reported
 
 
+def test_namespace_named_like_file_stem_is_not_rooted() -> None:
+    # `namespace main { int main(); }` in main.cpp: the segment before the
+    # leaf equals the file stem, but it is the NAMESPACE, not the module.
+    # Only the exact file-scope qn (project prefix + dotted path + name)
+    # earns the root.
+    nodes = [_node("proj.app.main.main.main", "main", "app/main.cpp")]
+    config = default_dead_code_config(include_tests=True, include_classes=False)
+    reported = collect_dead_code(FakeIngestor(nodes, []), "proj", config)
+    assert len(reported) == 1, reported
+
+
 def test_namespace_scoped_main_is_not_rooted() -> None:
     # `namespace detail { int main(); }` is an ordinary function the OS
     # cannot invoke; only a file-scope entry (qn directly under the module,

--- a/codebase_rag/tests/test_dead_code_cpp_entry_roots.py
+++ b/codebase_rag/tests/test_dead_code_cpp_entry_roots.py
@@ -67,10 +67,29 @@ def test_windows_entry_points_root_their_call_tree() -> None:
 
 
 def test_c_main_is_rooted() -> None:
-    nodes = [_node("proj.tool.main", "main", "tool/entry.c")]
+    nodes = [_node("proj.tool.entry.main", "main", "tool/entry.c")]
     config = default_dead_code_config(include_tests=True, include_classes=False)
     reported = collect_dead_code(FakeIngestor(nodes, []), "proj", config)
     assert reported == [], reported
+
+
+def test_header_defined_entry_name_is_not_rooted() -> None:
+    # A header is not an OS entry translation unit: a function named WinMain
+    # defined in a .h/.hpp is ordinary code and must stay a candidate.
+    nodes = [_node("proj.lib.api.WinMain", "WinMain", "lib/api.h")]
+    config = default_dead_code_config(include_tests=True, include_classes=False)
+    reported = collect_dead_code(FakeIngestor(nodes, []), "proj", config)
+    assert len(reported) == 1, reported
+
+
+def test_namespace_scoped_main_is_not_rooted() -> None:
+    # `namespace detail { int main(); }` is an ordinary function the OS
+    # cannot invoke; only a file-scope entry (qn directly under the module,
+    # whose segment matches the file stem) earns the root.
+    nodes = [_node("proj.app.util.detail.main", "main", "app/util.cpp")]
+    config = default_dead_code_config(include_tests=True, include_classes=False)
+    reported = collect_dead_code(FakeIngestor(nodes, []), "proj", config)
+    assert len(reported) == 1, reported
 
 
 def test_entry_name_on_other_language_is_not_rooted() -> None:

--- a/codebase_rag/tests/test_dead_code_cpp_entry_roots.py
+++ b/codebase_rag/tests/test_dead_code_cpp_entry_roots.py
@@ -1,0 +1,82 @@
+# A C/C++ program entry the OS runtime invokes (`main`, Windows'
+# `wWinMain`/`WinMain`/`wmain`, a DLL's `DllMain`) has no call site the graph
+# can see, so it reported dead and took its whole call tree with it: all 34
+# windows/runner candidates on the wonderous Flutter app cascaded from one
+# unrooted `wWinMain`.
+from __future__ import annotations
+
+from codebase_rag import constants as cs
+from codebase_rag import cypher_queries as cq
+from codebase_rag.dead_code import collect_dead_code, default_dead_code_config
+from codebase_rag.types_defs import ResultRow
+
+_FUNCTION = cs.NodeLabel.FUNCTION.value
+_CALLS = cs.RelationshipType.CALLS.value
+
+
+class FakeIngestor:
+    def __init__(self, nodes: list[ResultRow], rels: list[ResultRow]) -> None:
+        self._nodes = nodes
+        self._rels = rels
+
+    def fetch_all(
+        self, query: str, params: dict[str, str] | None = None
+    ) -> list[ResultRow]:
+        if query == cq.CYPHER_DEAD_CODE_NODES:
+            return self._nodes
+        return self._rels
+
+
+def _node(qn: str, name: str, path: str) -> ResultRow:
+    return {
+        "label": _FUNCTION,
+        "qualified_name": qn,
+        "name": name,
+        "path": path,
+        "start_line": 1,
+        "end_line": 2,
+        "decorators": [],
+        "is_exported": False,
+        "overrides_external": False,
+    }
+
+
+def test_windows_entry_points_root_their_call_tree() -> None:
+    nodes = [
+        _node("proj.runner.main.wWinMain", "wWinMain", "runner/main.cpp"),
+        _node("proj.runner.window.Create", "Create", "runner/window.cpp"),
+        _node("proj.runner.window.orphan", "orphan", "runner/window.cpp"),
+    ]
+    rels = [
+        {
+            "from_label": _FUNCTION,
+            "from_qn": "proj.runner.main.wWinMain",
+            "rel_type": _CALLS,
+            "to_label": _FUNCTION,
+            "to_qn": "proj.runner.window.Create",
+        },
+    ]
+    config = default_dead_code_config(include_tests=True, include_classes=False)
+    reported = {
+        row["qualified_name"]
+        for row in collect_dead_code(FakeIngestor(nodes, rels), "proj", config)
+    }
+    assert "proj.runner.main.wWinMain" not in reported, reported
+    assert "proj.runner.window.Create" not in reported, reported
+    assert "proj.runner.window.orphan" in reported, reported
+
+
+def test_c_main_is_rooted() -> None:
+    nodes = [_node("proj.tool.main", "main", "tool/entry.c")]
+    config = default_dead_code_config(include_tests=True, include_classes=False)
+    reported = collect_dead_code(FakeIngestor(nodes, []), "proj", config)
+    assert reported == [], reported
+
+
+def test_entry_name_on_other_language_is_not_rooted() -> None:
+    # The names are OS-runtime contracts of C/C++ translation units only; a
+    # same-named Python function earns no root.
+    nodes = [_node("proj.tool.wWinMain", "wWinMain", "tool/entry.py")]
+    config = default_dead_code_config(include_tests=True, include_classes=False)
+    reported = collect_dead_code(FakeIngestor(nodes, []), "proj", config)
+    assert len(reported) == 1, reported

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.438"
+version = "0.0.441"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
Found dogfooding dead-code on real Flutter apps: all 34 windows/runner candidates on the wonderous app cascaded from a single unrooted `wWinMain`. Dead-code had per-language runtime roots for Go (`main`/`init`), Rust (`fn main`), Python dunders, Java serialization hooks, and C# attributes, but no C/C++ entry rule at all: the OS invokes `main`, `wmain`, `WinMain`, `wWinMain`, and `DllMain` with no call site the graph can see.

## Changes
- New `C_CPP_ENTRY_FUNCTION_NAMES` constant and `_is_c_cpp_entry_root` rule: free functions with those names on C/C++ files root the reachability walk, mirroring `_is_rust_runtime_root` (methods named `main` earn nothing).

## Testing
- RED: three tests (a `wWinMain` call tree stays live while a true orphan still reports, a `.c` `main` is rooted, the same name on a Python file is not) failed before the fix.
- GREEN after; full unit suite passes (5479 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dead-code detection for C/C++ by recognizing OS-invoked entry points (for example, `main` and Windows `WinMain` variants) as reachability roots.
  * Preserved call trees from valid entry points while continuing to report unrelated unused functions.
  * Avoided treating similarly named symbols in headers, namespaces, or other-language files as entry points.

* **Tests**
  * Added deterministic coverage for C/C++ entry-point rooting, including positive Windows and C `main` cases and multiple non-root edge scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->