### PR TITLE
fix(index): ignore android .cxx and dart .dart_tool build caches

### DIFF
--- a/codebase_rag/constants/languages.py
+++ b/codebase_rag/constants/languages.py
@@ -310,6 +310,11 @@ IGNORE_PATTERNS = frozenset(
     {
         ".cache",
         ".claude",
+        # Android NDK per-ABI CMake build cache; ships compiler-probe
+        # sources (CMakeCCompilerId.c) that index as project code.
+        ".cxx",
+        # Dart/Flutter tool cache (package_config, generated plugin code).
+        ".dart_tool",
         ".eclipse",
         ".eggs",
         ".env",

--- a/codebase_rag/tests/test_build_cache_dirs_ignored.py
+++ b/codebase_rag/tests/test_build_cache_dirs_ignored.py
@@ -1,0 +1,33 @@
+# Android's NDK build cache (.cxx) and Dart's tool cache (.dart_tool) are
+# generated build output, but neither was in IGNORE_PATTERNS: a Flutter app
+# that committed its .cxx directory got 12 CMake compiler-probe `main`
+# functions indexed as project code and reported by dead-code.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.conftest import create_and_run_updater, get_node_names
+
+
+def test_native_build_cache_dirs_are_not_indexed(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    root = temp_repo / "app"
+    (root / ".cxx" / "CMakeFiles").mkdir(parents=True)
+    (root / ".cxx" / "CMakeFiles" / "CMakeCCompilerId.c").write_text(
+        "int main(void) { return 0; }\n", encoding="utf-8"
+    )
+    (root / ".dart_tool").mkdir()
+    (root / ".dart_tool" / "generated.dart").write_text(
+        "void tick() {}\n", encoding="utf-8"
+    )
+    (root / "lib").mkdir()
+    (root / "lib" / "main.dart").write_text("void main() {}\n", encoding="utf-8")
+
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="dart")
+
+    modules = get_node_names(mock_ingestor, "Module")
+    assert any(".lib.main" in m for m in modules), modules
+    assert not any(".cxx" in m for m in modules), modules
+    assert not any("dart_tool" in m for m in modules), modules

--- a/codebase_rag/tests/test_build_cache_dirs_ignored.py
+++ b/codebase_rag/tests/test_build_cache_dirs_ignored.py
@@ -2,6 +2,9 @@
 # generated build output, but neither was in IGNORE_PATTERNS: a Flutter app
 # that committed its .cxx directory got 12 CMake compiler-probe `main`
 # functions indexed as project code and reported by dead-code.
+# The two caches are asserted in separate tests so each one depends only on
+# its own parser: a .cxx regression must still fail where the optional Dart
+# parser is absent.
 from __future__ import annotations
 
 from pathlib import Path
@@ -10,7 +13,7 @@ from unittest.mock import MagicMock
 from codebase_rag.tests.conftest import create_and_run_updater, get_node_names
 
 
-def test_native_build_cache_dirs_are_not_indexed(
+def test_android_ndk_build_cache_is_not_indexed(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:
     root = temp_repo / "app"
@@ -18,7 +21,23 @@ def test_native_build_cache_dirs_are_not_indexed(
     (root / ".cxx" / "CMakeFiles" / "CMakeCCompilerId.c").write_text(
         "int main(void) { return 0; }\n", encoding="utf-8"
     )
-    (root / ".dart_tool").mkdir()
+    (root / "src").mkdir()
+    (root / "src" / "native.c").write_text(
+        "int add(int a, int b) { return a + b; }\n", encoding="utf-8"
+    )
+
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="c")
+
+    modules = get_node_names(mock_ingestor, "Module")
+    assert any(".src.native" in m for m in modules), modules
+    assert not any(".cxx" in m for m in modules), modules
+
+
+def test_dart_tool_cache_is_not_indexed(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    root = temp_repo / "app"
+    (root / ".dart_tool").mkdir(parents=True)
     (root / ".dart_tool" / "generated.dart").write_text(
         "void tick() {}\n", encoding="utf-8"
     )
@@ -29,5 +48,4 @@ def test_native_build_cache_dirs_are_not_indexed(
 
     modules = get_node_names(mock_ingestor, "Module")
     assert any(".lib.main" in m for m in modules), modules
-    assert not any(".cxx" in m for m in modules), modules
     assert not any("dart_tool" in m for m in modules), modules

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.438"
+version = "0.0.441"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
Found dogfooding on real Flutter apps: the wonderous app commits its Android NDK build cache, so 12 CMake compiler-probe `main` functions (`.cxx/**/CMakeCCompilerId.c` across four ABIs and two build variants) were indexed as project code and reported by dead-code. Neither `.cxx` (Android NDK per-ABI CMake cache) nor `.dart_tool` (Dart/Flutter tool cache with generated plugin code) was in `IGNORE_PATTERNS`, while their peers (`.gradle`, `build`, `node_modules`) already were.

## Changes
- Add `.cxx` and `.dart_tool` to `IGNORE_PATTERNS`.

## Testing
- RED: new test indexes a repo carrying both directories plus real `lib/` code and asserts only `lib/` produces Modules; it failed before the fix.
- GREEN after; full unit suite passes (5477 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Excluded Android NDK CMake build caches from source indexing.
  * Excluded Dart and Flutter tool-generated cache files from source indexing.
  * Confirmed that valid project source files continue to be indexed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->