### PR TITLE
feat(dart): track getter reads as REFERENCES so read-only getters stop reporting dead

### DIFF
--- a/codebase_rag/constants/ast_dart.py
+++ b/codebase_rag/constants/ast_dart.py
@@ -49,6 +49,17 @@ DART_CALL_QUERY = """
 # formal_parameter(type_identifier, identifier).
 TS_DART_CLASS_BODY = "class_body"
 TS_DART_BLOCK = "block"
+# Local binders beyond plain declarations: a for-in loop variable is the
+# FIRST identifier of for_loop_parts (the second is the iterable), catch
+# parameters bind every identifier, and a pattern declaration binds the
+# identifiers inside its *_pattern subtree. Their enclosing statements bound
+# the shadow scope.
+TS_DART_FOR_STATEMENT = "for_statement"
+TS_DART_FOR_LOOP_PARTS = "for_loop_parts"
+TS_DART_TRY_STATEMENT = "try_statement"
+TS_DART_CATCH_PARAMETERS = "catch_parameters"
+TS_DART_PATTERN_VARIABLE_DECLARATION = "pattern_variable_declaration"
+DART_PATTERN_NODE_SUFFIX = "_pattern"
 TS_DART_FUNCTION_EXPRESSION = "function_expression"
 TS_DART_LOCAL_FUNCTION_DECLARATION = "local_function_declaration"
 

--- a/codebase_rag/constants/ast_dart.py
+++ b/codebase_rag/constants/ast_dart.py
@@ -48,6 +48,7 @@ DART_CALL_QUERY = """
 # inferred_type plus construction initializer); a parameter is
 # formal_parameter(type_identifier, identifier).
 TS_DART_CLASS_BODY = "class_body"
+TS_DART_BLOCK = "block"
 TS_DART_FUNCTION_EXPRESSION = "function_expression"
 TS_DART_LOCAL_FUNCTION_DECLARATION = "local_function_declaration"
 

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1976,6 +1976,24 @@ class CallProcessor:
                 csharp_prop_names,
             )
 
+        # Same need again, Dart shape (issue #869): a getter access is a bare
+        # identifier or a member selector, never an invocation, so callers
+        # that only READ a getter emit nothing and dead-code flags it
+        # (wonderous' _enableVideo/startYr family).
+        if language == cs.SupportedLanguage.DART and (
+            dart_prop_names := self._resolver.function_registry.property_names()
+        ):
+            self._ingest_dart_getter_reads(
+                caller_node,
+                caller_spec,
+                caller_qn,
+                module_qn,
+                local_var_types,
+                class_context,
+                queries[language][cs.QUERY_CONFIG],
+                dart_prop_names,
+            )
+
         # Operator syntax (k in r, r[k], r[k]=v, len(r)) dispatches to dunder
         # methods; emit those edges when the operand is a first-party type.
         if language == cs.SupportedLanguage.PYTHON:
@@ -4047,6 +4065,12 @@ class CallProcessor:
         # produces schema-invalid edges.
         if res_type not in (cs.NodeLabel.FUNCTION, cs.NodeLabel.METHOD):
             return
+        # A Dart getter in argument position is a VALUE READ, not a tear-off:
+        # the getter-read pass owns those edges (with shadow handling), so
+        # emitting here would fabricate liveness for a local that hides the
+        # getter (issue #869).
+        if language == cs.SupportedLanguage.DART and registry.is_property(res_qn):
+            return
         for target_qn in registry.variants(res_qn):
             ensure_rel(
                 source_spec,
@@ -4533,6 +4557,140 @@ class CallProcessor:
                                     (method_label, qn_key, target_qn),
                                 )
             stack.extend(node.children)
+
+    def _ingest_dart_getter_reads(
+        self,
+        caller_node: Node,
+        caller_spec: tuple[str, str, str],
+        caller_qn: str,
+        module_qn: str,
+        local_var_types: dict[str, str] | None,
+        class_context: str | None,
+        lang_config: LanguageSpec,
+        prop_names: set[str],
+    ) -> None:
+        # Emit a REFERENCES edge (a read is not an invocation; the call graph
+        # stays invocation-only) from the caller to each getter it reads:
+        # bare identifiers resolve against the enclosing class (implicit
+        # this), member selectors reassemble their receiver chain and resolve
+        # through receiver typing. Registry-guarded: only resolutions landing
+        # on a MARKED property emit, so unrelated same-name locals or
+        # functions never fabricate an edge. Nested closures are walked (a
+        # Dart lambda's reads attribute to the enclosing method, matching the
+        # flat-attribute call pass), so their parameters join the shadow set.
+        resolver = self._resolver
+        resolve_func = resolver.resolve_function_call
+        registry = resolver.function_registry
+        ensure_rel = self.ingestor.ensure_relationship_batch
+        refs_rel = cs.RelationshipType.REFERENCES
+        class_types = lang_config.class_node_types
+        shadowed: set[str] | None = None
+        seen: set[str] = set()
+
+        def emit(read_name: str) -> None:
+            if read_name in seen:
+                return
+            resolved = resolve_func(
+                read_name, module_qn, local_var_types, class_context, caller_qn
+            )
+            if not resolved:
+                return
+            _res_type, res_qn = resolved
+            if not registry.is_property(res_qn) or res_qn == caller_qn:
+                return
+            seen.add(read_name)
+            ensure_rel(
+                caller_spec,
+                refs_rel,
+                (cs.NodeLabel.METHOD, cs.KEY_QUALIFIED_NAME, res_qn),
+            )
+
+        # The grammar splits a definition into a signature node and a SIBLING
+        # function_body: the signature holds no reads, so walk the body.
+        body = dart_utils.dart_body_node(caller_node)
+        walk_root = body if body is not None else caller_node
+        stack = list(walk_root.children)
+        while stack:
+            node = stack.pop()
+            node_type = node.type
+            if node_type in class_types:
+                continue
+            if node_type == cs.TS_DART_SELECTOR:
+                read_name = dart_utils.dart_member_read_name(node)
+                if (
+                    read_name
+                    and read_name.rsplit(cs.SEPARATOR_DOT, 1)[-1] in prop_names
+                ):
+                    emit(read_name)
+            elif node_type == cs.TS_DART_IDENTIFIER:
+                name = safe_decode_text(node)
+                following = node.next_named_sibling
+                parent = node.parent
+                # A bare read only: a chain head (following selector) is the
+                # member pass's job, an argument_part head is a call target,
+                # a label's identifier names a parameter, and a selector's
+                # own identifier is the member already handled above.
+                if (
+                    name
+                    and name in prop_names
+                    and (
+                        following is None
+                        or following.type
+                        not in (cs.TS_DART_SELECTOR, cs.TS_DART_ARGUMENT_PART)
+                    )
+                    and parent is not None
+                    and parent.type
+                    not in (
+                        cs.TS_DART_LABEL,
+                        cs.TS_DART_UNCONDITIONAL_ASSIGNABLE_SELECTOR,
+                        cs.TS_DART_CONDITIONAL_ASSIGNABLE_SELECTOR,
+                        cs.TS_DART_CASCADE_SELECTOR,
+                    )
+                ):
+                    if shadowed is None:
+                        shadowed = self._dart_shadow_names(caller_node, walk_root)
+                    if name not in shadowed:
+                        emit(name)
+            stack.extend(node.children)
+
+    def _dart_shadow_names(self, caller_node: Node, walk_root: Node) -> set[str]:
+        # Names declared as parameters or locals anywhere in the walked
+        # scopes: a same-name declaration hides the getter for bare reads.
+        # Parameters live in the SIGNATURE node, locals in the sibling body,
+        # so both roots are walked. Whole-body, not span-scoped (cf.
+        # _csharp_shadow_spans): a read BEFORE a later same-name local is
+        # suppressed too, which under-references (safe direction) and only
+        # for a shadow pattern Dart analyzers already discourage.
+        names: set[str] = set()
+        stack = list(caller_node.children)
+        if walk_root is not caller_node:
+            stack.extend(walk_root.children)
+        while stack:
+            node = stack.pop()
+            node_type = node.type
+            if node_type == cs.TS_DART_FORMAL_PARAMETER:
+                for child in node.named_children:
+                    if child.type == cs.TS_DART_IDENTIFIER and (
+                        name := safe_decode_text(child)
+                    ):
+                        names.add(name)
+                continue
+            if node_type in (
+                cs.TS_DART_INITIALIZED_VARIABLE_DEFINITION,
+                cs.TS_DART_INITIALIZED_IDENTIFIER,
+            ):
+                declared = next(
+                    (
+                        child
+                        for child in node.named_children
+                        if child.type == cs.TS_DART_IDENTIFIER
+                    ),
+                    None,
+                )
+                if declared is not None and (name := safe_decode_text(declared)):
+                    names.add(name)
+            stack.extend(node.children)
+        return names
 
     def _csharp_read_identifier(self, receiver: Node | None) -> str | None:
         # The identifier actually being READ in receiver position: unwrap

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -103,6 +103,42 @@ _ARG_REF_ONLY_LANGUAGES = frozenset(
 _DART_VALUE_WRAPPER_TYPES = frozenset(
     {cs.TS_DART_LIST_LITERAL, cs.TS_DART_SET_OR_MAP_LITERAL, cs.TS_DART_ARGUMENT}
 )
+# Scopes that bound a Dart local/parameter declaration for getter-read
+# shadowing; a declaration hides a same-name getter only inside them.
+_DART_SHADOW_SCOPE_TYPES = frozenset(
+    {
+        cs.TS_DART_BLOCK,
+        cs.TS_DART_FUNCTION_EXPRESSION,
+        cs.TS_DART_LOCAL_FUNCTION_DECLARATION,
+    }
+)
+_DART_LOCAL_DECLARATION_TYPES = frozenset(
+    {
+        cs.TS_DART_INITIALIZED_VARIABLE_DEFINITION,
+        cs.TS_DART_INITIALIZED_IDENTIFIER,
+    }
+)
+
+
+def _dart_is_bare_read(node: Node) -> bool:
+    # A bare-identifier getter read only: a chain head (following selector or
+    # cascade) belongs to the member/cascade passes, an argument_part head is
+    # a call target, a label's identifier names a parameter, and a selector's
+    # own identifier is the member the chain pass already handled.
+    following = node.next_named_sibling
+    if following is not None and following.type in (
+        cs.TS_DART_SELECTOR,
+        cs.TS_DART_ARGUMENT_PART,
+        cs.TS_DART_CASCADE_SECTION,
+    ):
+        return False
+    parent = node.parent
+    return parent is not None and parent.type not in (
+        cs.TS_DART_LABEL,
+        cs.TS_DART_UNCONDITIONAL_ASSIGNABLE_SELECTOR,
+        cs.TS_DART_CONDITIONAL_ASSIGNABLE_SELECTOR,
+        cs.TS_DART_CASCADE_SELECTOR,
+    )
 
 # Python nested-scope boundaries and sequence-literal node types used when
 # scanning a scope for dispatch tables of function references.
@@ -4578,32 +4614,9 @@ class CallProcessor:
         # functions never fabricate an edge. Nested closures are walked (a
         # Dart lambda's reads attribute to the enclosing method, matching the
         # flat-attribute call pass), so their parameters join the shadow set.
-        resolver = self._resolver
-        resolve_func = resolver.resolve_function_call
-        registry = resolver.function_registry
-        ensure_rel = self.ingestor.ensure_relationship_batch
-        refs_rel = cs.RelationshipType.REFERENCES
         class_types = lang_config.class_node_types
-        shadowed: set[str] | None = None
+        shadow_spans: dict[str, list[tuple[int, int]]] | None = None
         seen: set[str] = set()
-
-        def emit(read_name: str) -> None:
-            if read_name in seen:
-                return
-            resolved = resolve_func(
-                read_name, module_qn, local_var_types, class_context, caller_qn
-            )
-            if not resolved:
-                return
-            _res_type, res_qn = resolved
-            if not registry.is_property(res_qn) or res_qn == caller_qn:
-                return
-            seen.add(read_name)
-            ensure_rel(
-                caller_spec,
-                refs_rel,
-                (cs.NodeLabel.METHOD, cs.KEY_QUALIFIED_NAME, res_qn),
-            )
 
         # The grammar splits a definition into a signature node and a SIBLING
         # function_body: the signature holds no reads, so walk the body.
@@ -4615,53 +4628,81 @@ class CallProcessor:
             node_type = node.type
             if node_type in class_types:
                 continue
+            read_name: str | None = None
             if node_type == cs.TS_DART_SELECTOR:
                 read_name = dart_utils.dart_member_read_name(node)
-                if (
-                    read_name
-                    and read_name.rsplit(cs.SEPARATOR_DOT, 1)[-1] in prop_names
-                ):
-                    emit(read_name)
-            elif node_type == cs.TS_DART_IDENTIFIER:
+            elif node_type == cs.TS_DART_CASCADE_SECTION:
+                read_name = dart_utils.dart_cascade_read_name(node)
+            elif node_type == cs.TS_DART_IDENTIFIER and _dart_is_bare_read(node):
                 name = safe_decode_text(node)
-                following = node.next_named_sibling
-                parent = node.parent
-                # A bare read only: a chain head (following selector) is the
-                # member pass's job, an argument_part head is a call target,
-                # a label's identifier names a parameter, and a selector's
-                # own identifier is the member already handled above.
-                if (
-                    name
-                    and name in prop_names
-                    and (
-                        following is None
-                        or following.type
-                        not in (cs.TS_DART_SELECTOR, cs.TS_DART_ARGUMENT_PART)
-                    )
-                    and parent is not None
-                    and parent.type
-                    not in (
-                        cs.TS_DART_LABEL,
-                        cs.TS_DART_UNCONDITIONAL_ASSIGNABLE_SELECTOR,
-                        cs.TS_DART_CONDITIONAL_ASSIGNABLE_SELECTOR,
-                        cs.TS_DART_CASCADE_SELECTOR,
-                    )
-                ):
-                    if shadowed is None:
-                        shadowed = self._dart_shadow_names(caller_node, walk_root)
-                    if name not in shadowed:
-                        emit(name)
+                if name and name in prop_names:
+                    if shadow_spans is None:
+                        shadow_spans = self._dart_shadow_spans(caller_node, walk_root)
+                    pos = node.start_byte
+                    if not any(
+                        lo <= pos < hi for lo, hi in shadow_spans.get(name, ())
+                    ):
+                        read_name = name
+            if read_name and read_name.rsplit(cs.SEPARATOR_DOT, 1)[-1] in prop_names:
+                self._emit_dart_property_read(
+                    read_name,
+                    caller_spec,
+                    caller_qn,
+                    module_qn,
+                    local_var_types,
+                    class_context,
+                    seen,
+                )
             stack.extend(node.children)
 
-    def _dart_shadow_names(self, caller_node: Node, walk_root: Node) -> set[str]:
-        # Names declared as parameters or locals anywhere in the walked
-        # scopes: a same-name declaration hides the getter for bare reads.
-        # Parameters live in the SIGNATURE node, locals in the sibling body,
-        # so both roots are walked. Whole-body, not span-scoped (cf.
-        # _csharp_shadow_spans): a read BEFORE a later same-name local is
-        # suppressed too, which under-references (safe direction) and only
-        # for a shadow pattern Dart analyzers already discourage.
-        names: set[str] = set()
+    def _emit_dart_property_read(
+        self,
+        read_name: str,
+        caller_spec: tuple[str, str, str],
+        caller_qn: str,
+        module_qn: str,
+        local_var_types: dict[str, str] | None,
+        class_context: str | None,
+        seen: set[str],
+    ) -> None:
+        if read_name in seen:
+            return
+        resolved = self._resolver.resolve_function_call(
+            read_name, module_qn, local_var_types, class_context, caller_qn
+        )
+        if not resolved:
+            return
+        _res_type, res_qn = resolved
+        registry = self._resolver.function_registry
+        if not registry.is_property(res_qn) or res_qn == caller_qn:
+            return
+        seen.add(read_name)
+        self.ingestor.ensure_relationship_batch(
+            caller_spec,
+            cs.RelationshipType.REFERENCES,
+            (cs.NodeLabel.METHOD, cs.KEY_QUALIFIED_NAME, res_qn),
+        )
+
+    def _dart_shadow_spans(
+        self, caller_node: Node, walk_root: Node
+    ) -> dict[str, list[tuple[int, int]]]:
+        # {declared name: [byte span of each declaring SCOPE]} for parameters
+        # and locals. A declaration shadows a same-name getter only for bare
+        # reads INSIDE its declaring scope: a closure's parameter must not
+        # suppress the enclosing method's read (cf. _csharp_shadow_spans).
+        # Method parameters live in the SIGNATURE, outside the walked body,
+        # so their scope walk falls through to the whole body.
+        whole_body = (walk_root.start_byte, walk_root.end_byte)
+
+        def scope_span(decl: Node) -> tuple[int, int]:
+            anc = decl.parent
+            while anc is not None and anc is not walk_root:
+                if anc.type in _DART_SHADOW_SCOPE_TYPES:
+                    return (anc.start_byte, anc.end_byte)
+                anc = anc.parent
+            return whole_body
+
+        spans: dict[str, list[tuple[int, int]]] = {}
         stack = list(caller_node.children)
         if walk_root is not caller_node:
             stack.extend(walk_root.children)
@@ -4673,12 +4714,9 @@ class CallProcessor:
                     if child.type == cs.TS_DART_IDENTIFIER and (
                         name := safe_decode_text(child)
                     ):
-                        names.add(name)
+                        spans.setdefault(name, []).append(scope_span(node))
                 continue
-            if node_type in (
-                cs.TS_DART_INITIALIZED_VARIABLE_DEFINITION,
-                cs.TS_DART_INITIALIZED_IDENTIFIER,
-            ):
+            if node_type in _DART_LOCAL_DECLARATION_TYPES:
                 declared = next(
                     (
                         child
@@ -4688,9 +4726,9 @@ class CallProcessor:
                     None,
                 )
                 if declared is not None and (name := safe_decode_text(declared)):
-                    names.add(name)
+                    spans.setdefault(name, []).append(scope_span(node))
             stack.extend(node.children)
-        return names
+        return spans
 
     def _csharp_read_identifier(self, receiver: Node | None) -> str | None:
         # The identifier actually being READ in receiver position: unwrap

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -121,6 +121,13 @@ _DART_LOCAL_DECLARATION_TYPES = frozenset(
         cs.TS_DART_INITIALIZED_IDENTIFIER,
     }
 )
+# Statement scopes whose binder is live only AFTER its declaration: the
+# for-in iterable and the try body precede theirs and read the getter. A
+# block-scoped local needs no such split: Dart scopes it to the whole block
+# and rejects reads before the declaration at compile time.
+_DART_STATEMENT_SCOPE_TYPES = frozenset(
+    {cs.TS_DART_FOR_STATEMENT, cs.TS_DART_TRY_STATEMENT}
+)
 
 
 def _dart_declared_names(node: Node) -> list[str]:
@@ -194,12 +201,29 @@ def _dart_is_bare_read(node: Node) -> bool:
     ):
         return False
     parent = node.parent
-    return parent is not None and parent.type not in (
+    if parent is None or parent.type in (
         cs.TS_DART_LABEL,
         cs.TS_DART_UNCONDITIONAL_ASSIGNABLE_SELECTOR,
         cs.TS_DART_CONDITIONAL_ASSIGNABLE_SELECTOR,
         cs.TS_DART_CASCADE_SELECTOR,
-    )
+        # Catch parameters only BIND names; they never read.
+        cs.TS_DART_CATCH_PARAMETERS,
+    ):
+        return False
+    if parent.type == cs.TS_DART_FOR_LOOP_PARTS:
+        # The FIRST identifier of a for-in is the loop BINDER, not a read;
+        # the iterable position after it reads normally.
+        first = next(
+            (
+                child
+                for child in parent.named_children
+                if child.type == cs.TS_DART_IDENTIFIER
+            ),
+            None,
+        )
+        if first is not None and first.start_byte == node.start_byte:
+            return False
+    return True
 
 
 # Python nested-scope boundaries and sequence-literal node types used when
@@ -4788,6 +4812,8 @@ class CallProcessor:
             anc = decl.parent
             while anc is not None and anc is not walk_root:
                 if anc.type in _DART_SHADOW_SCOPE_TYPES:
+                    if anc.type in _DART_STATEMENT_SCOPE_TYPES:
+                        return (decl.end_byte, anc.end_byte)
                     return (anc.start_byte, anc.end_byte)
                 anc = anc.parent
             return whole_body

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from bisect import bisect_left, bisect_right
 from collections import defaultdict
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import NamedTuple
 
@@ -118,6 +118,29 @@ _DART_LOCAL_DECLARATION_TYPES = frozenset(
         cs.TS_DART_INITIALIZED_IDENTIFIER,
     }
 )
+
+
+def _dart_declared_names(node: Node) -> list[str]:
+    # The name(s) a parameter or local declaration binds; anything else
+    # declares nothing.
+    if node.type == cs.TS_DART_FORMAL_PARAMETER:
+        return [
+            name
+            for child in node.named_children
+            if child.type == cs.TS_DART_IDENTIFIER and (name := safe_decode_text(child))
+        ]
+    if node.type in _DART_LOCAL_DECLARATION_TYPES:
+        declared = next(
+            (
+                child
+                for child in node.named_children
+                if child.type == cs.TS_DART_IDENTIFIER
+            ),
+            None,
+        )
+        if declared is not None and (name := safe_decode_text(declared)):
+            return [name]
+    return []
 
 
 def _dart_is_bare_read(node: Node) -> bool:
@@ -4616,33 +4639,27 @@ class CallProcessor:
         # Dart lambda's reads attribute to the enclosing method, matching the
         # flat-attribute call pass), so their parameters join the shadow set.
         class_types = lang_config.class_node_types
-        shadow_spans: dict[str, list[tuple[int, int]]] | None = None
         seen: set[str] = set()
 
         # The grammar splits a definition into a signature node and a SIBLING
         # function_body: the signature holds no reads, so walk the body.
         body = dart_utils.dart_body_node(caller_node)
         walk_root = body if body is not None else caller_node
+        shadow_cell: list[dict[str, list[tuple[int, int]]]] = []
+
+        def shadow_spans() -> dict[str, list[tuple[int, int]]]:
+            # Built lazily on the first bare read; most callers have none.
+            if not shadow_cell:
+                shadow_cell.append(self._dart_shadow_spans(caller_node, walk_root))
+            return shadow_cell[0]
+
         stack = list(walk_root.children)
         while stack:
             node = stack.pop()
-            node_type = node.type
-            if node_type in class_types:
+            if node.type in class_types:
                 continue
-            read_name: str | None = None
-            if node_type == cs.TS_DART_SELECTOR:
-                read_name = dart_utils.dart_member_read_name(node)
-            elif node_type == cs.TS_DART_CASCADE_SECTION:
-                read_name = dart_utils.dart_cascade_read_name(node)
-            elif node_type == cs.TS_DART_IDENTIFIER and _dart_is_bare_read(node):
-                name = safe_decode_text(node)
-                if name and name in prop_names:
-                    if shadow_spans is None:
-                        shadow_spans = self._dart_shadow_spans(caller_node, walk_root)
-                    pos = node.start_byte
-                    if not any(lo <= pos < hi for lo, hi in shadow_spans.get(name, ())):
-                        read_name = name
-            if read_name and read_name.rsplit(cs.SEPARATOR_DOT, 1)[-1] in prop_names:
+            read_name = self._dart_read_name(node, prop_names, shadow_spans)
+            if read_name:
                 self._emit_dart_property_read(
                     read_name,
                     caller_spec,
@@ -4653,6 +4670,42 @@ class CallProcessor:
                     seen,
                 )
             stack.extend(node.children)
+
+    def _dart_read_name(
+        self,
+        node: Node,
+        prop_names: set[str],
+        shadow_spans: Callable[[], dict[str, list[tuple[int, int]]]],
+    ) -> str | None:
+        # The dotted name this node READS, or None: member selectors and
+        # cascades reassemble their receiver chain; a bare identifier counts
+        # only when no in-scope local/parameter shadows it.
+        node_type = node.type
+        if node_type == cs.TS_DART_SELECTOR:
+            read_name = dart_utils.dart_member_read_name(node)
+        elif node_type == cs.TS_DART_CASCADE_SECTION:
+            read_name = dart_utils.dart_cascade_read_name(node)
+        elif node_type == cs.TS_DART_IDENTIFIER and _dart_is_bare_read(node):
+            read_name = self._dart_unshadowed_name(node, prop_names, shadow_spans)
+        else:
+            return None
+        if read_name and read_name.rsplit(cs.SEPARATOR_DOT, 1)[-1] in prop_names:
+            return read_name
+        return None
+
+    def _dart_unshadowed_name(
+        self,
+        node: Node,
+        prop_names: set[str],
+        shadow_spans: Callable[[], dict[str, list[tuple[int, int]]]],
+    ) -> str | None:
+        name = safe_decode_text(node)
+        if not name or name not in prop_names:
+            return None
+        pos = node.start_byte
+        if any(lo <= pos < hi for lo, hi in shadow_spans().get(name, ())):
+            return None
+        return name
 
     def _emit_dart_property_read(
         self,
@@ -4707,25 +4760,8 @@ class CallProcessor:
             stack.extend(walk_root.children)
         while stack:
             node = stack.pop()
-            node_type = node.type
-            if node_type == cs.TS_DART_FORMAL_PARAMETER:
-                for child in node.named_children:
-                    if child.type == cs.TS_DART_IDENTIFIER and (
-                        name := safe_decode_text(child)
-                    ):
-                        spans.setdefault(name, []).append(scope_span(node))
-                continue
-            if node_type in _DART_LOCAL_DECLARATION_TYPES:
-                declared = next(
-                    (
-                        child
-                        for child in node.named_children
-                        if child.type == cs.TS_DART_IDENTIFIER
-                    ),
-                    None,
-                )
-                if declared is not None and (name := safe_decode_text(declared)):
-                    spans.setdefault(name, []).append(scope_span(node))
+            for name in _dart_declared_names(node):
+                spans.setdefault(name, []).append(scope_span(node))
             stack.extend(node.children)
         return spans
 

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -140,6 +140,7 @@ def _dart_is_bare_read(node: Node) -> bool:
         cs.TS_DART_CASCADE_SELECTOR,
     )
 
+
 # Python nested-scope boundaries and sequence-literal node types used when
 # scanning a scope for dispatch tables of function references.
 _PY_SCOPE_BOUNDARY_TYPES = frozenset(
@@ -4639,9 +4640,7 @@ class CallProcessor:
                     if shadow_spans is None:
                         shadow_spans = self._dart_shadow_spans(caller_node, walk_root)
                     pos = node.start_byte
-                    if not any(
-                        lo <= pos < hi for lo, hi in shadow_spans.get(name, ())
-                    ):
+                    if not any(lo <= pos < hi for lo, hi in shadow_spans.get(name, ())):
                         read_name = name
             if read_name and read_name.rsplit(cs.SEPARATOR_DOT, 1)[-1] in prop_names:
                 self._emit_dart_property_read(

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -104,12 +104,15 @@ _DART_VALUE_WRAPPER_TYPES = frozenset(
     {cs.TS_DART_LIST_LITERAL, cs.TS_DART_SET_OR_MAP_LITERAL, cs.TS_DART_ARGUMENT}
 )
 # Scopes that bound a Dart local/parameter declaration for getter-read
-# shadowing; a declaration hides a same-name getter only inside them.
+# shadowing; a declaration hides a same-name getter only inside them. A loop
+# variable scopes its for_statement, a catch parameter its try_statement.
 _DART_SHADOW_SCOPE_TYPES = frozenset(
     {
         cs.TS_DART_BLOCK,
         cs.TS_DART_FUNCTION_EXPRESSION,
         cs.TS_DART_LOCAL_FUNCTION_DECLARATION,
+        cs.TS_DART_FOR_STATEMENT,
+        cs.TS_DART_TRY_STATEMENT,
     }
 )
 _DART_LOCAL_DECLARATION_TYPES = frozenset(
@@ -121,15 +124,16 @@ _DART_LOCAL_DECLARATION_TYPES = frozenset(
 
 
 def _dart_declared_names(node: Node) -> list[str]:
-    # The name(s) a parameter or local declaration binds; anything else
-    # declares nothing.
-    if node.type == cs.TS_DART_FORMAL_PARAMETER:
+    # The name(s) a parameter, local declaration, loop variable, catch
+    # parameter, or pattern binding binds; anything else declares nothing.
+    node_type = node.type
+    if node_type in (cs.TS_DART_FORMAL_PARAMETER, cs.TS_DART_CATCH_PARAMETERS):
         return [
             name
             for child in node.named_children
             if child.type == cs.TS_DART_IDENTIFIER and (name := safe_decode_text(child))
         ]
-    if node.type in _DART_LOCAL_DECLARATION_TYPES:
+    if node_type in _DART_LOCAL_DECLARATION_TYPES:
         declared = next(
             (
                 child
@@ -140,7 +144,41 @@ def _dart_declared_names(node: Node) -> list[str]:
         )
         if declared is not None and (name := safe_decode_text(declared)):
             return [name]
+    if node_type == cs.TS_DART_FOR_LOOP_PARTS:
+        # `for (final total in xs)`: the FIRST identifier is the loop
+        # variable, the second the iterable expression.
+        first = next(
+            (
+                child
+                for child in node.named_children
+                if child.type == cs.TS_DART_IDENTIFIER
+            ),
+            None,
+        )
+        if first is not None and (name := safe_decode_text(first)):
+            return [name]
+    if node_type == cs.TS_DART_PATTERN_VARIABLE_DECLARATION:
+        return _dart_pattern_bound_names(node)
     return []
+
+
+def _dart_pattern_bound_names(node: Node) -> list[str]:
+    # `var (alpha, beta) = rhs` binds every identifier inside the *_pattern
+    # subtree; the RHS expression binds nothing.
+    names: list[str] = []
+    stack = [
+        child
+        for child in node.named_children
+        if child.type.endswith(cs.DART_PATTERN_NODE_SUFFIX)
+    ]
+    while stack:
+        current = stack.pop()
+        if current.type == cs.TS_DART_IDENTIFIER and (
+            name := safe_decode_text(current)
+        ):
+            names.append(name)
+        stack.extend(current.named_children)
+    return names
 
 
 def _dart_is_bare_read(node: Node) -> bool:

--- a/codebase_rag/parsers/dart/utils.py
+++ b/codebase_rag/parsers/dart/utils.py
@@ -210,6 +210,27 @@ def dart_call_name(call_node: Node) -> str | None:
     return _assemble_chain(tokens)
 
 
+def dart_member_read_name(selector_node: Node) -> str | None:
+    """The dotted name a member-selector READ targets, or None.
+
+    `marker.startYr` is `identifier` + `selector(.startYr)`: reassemble the
+    receiver chain plus the member. A selector followed by an argument_part
+    selector is an invocation the call pass owns; a chain broken by an index
+    or arbitrary expression has no static name. A `this` base is dropped so
+    the bare member resolves against the caller's class.
+    """
+    following = selector_node.next_named_sibling
+    if following is not None and _selector_has_argument_part(following):
+        return None
+    member = _selector_member_name(selector_node)
+    if member is None:
+        return None
+    receiver = _walk_chain(selector_node.prev_named_sibling, allow_calls=True)
+    if receiver is None:
+        return None
+    return _assemble_chain([*receiver, member])
+
+
 def dart_return_type_name(node: Node) -> str | None:
     """The declared return type of a Dart signature, or None.
 

--- a/codebase_rag/parsers/dart/utils.py
+++ b/codebase_rag/parsers/dart/utils.py
@@ -231,6 +231,34 @@ def dart_member_read_name(selector_node: Node) -> str | None:
     return _assemble_chain([*receiver, member])
 
 
+def dart_cascade_read_name(section: Node) -> str | None:
+    """The dotted name a cascade member READ targets (`m..startYr`), or None.
+
+    A pure read section holds ONLY cascade_selector children: an
+    argument_part marks an invocation the call pass owns, and any other
+    child (an assignment's RHS) marks a WRITE targeting the setter. The
+    shared base receiver is reassembled exactly like a cascade call's.
+    """
+    if any(
+        child.type != cs.TS_DART_CASCADE_SELECTOR for child in section.named_children
+    ):
+        return None
+    parts = [
+        name
+        for child in section.named_children
+        if (name := _first_identifier_text(child)) is not None
+    ]
+    if not parts:
+        return None
+    base = section.prev_named_sibling
+    while base is not None and base.type == cs.TS_DART_CASCADE_SECTION:
+        base = base.prev_named_sibling
+    receiver = _walk_chain(base)
+    if receiver is None:
+        return None
+    return cs.SEPARATOR_DOT.join(receiver + parts)
+
+
 def dart_return_type_name(node: Node) -> str | None:
     """The declared return type of a Dart signature, or None.
 

--- a/codebase_rag/parsers/dart/utils.py
+++ b/codebase_rag/parsers/dart/utils.py
@@ -253,10 +253,13 @@ def dart_cascade_read_name(section: Node) -> str | None:
     base = section.prev_named_sibling
     while base is not None and base.type == cs.TS_DART_CASCADE_SECTION:
         base = base.prev_named_sibling
-    receiver = _walk_chain(base)
+    # allow_calls: a call-result cascade (`getMarker()..startYr`) keeps its
+    # `()` hop so the resolver types the receiver from the callee's declared
+    # return type, exactly like a plain chained read.
+    receiver = _walk_chain(base, allow_calls=True)
     if receiver is None:
         return None
-    return cs.SEPARATOR_DOT.join(receiver + parts)
+    return _assemble_chain([*receiver, *parts])
 
 
 def dart_return_type_name(node: Node) -> str | None:

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -808,9 +808,12 @@ def ingest_method(
     # depends on it, so without persistence those edges drop (issue #532 parity).
     # A C# property_declaration IS a property by grammar (no decorator to
     # inspect); marking it lets the C# member-read pass find it, exactly as
-    # Python's @property marking feeds its attribute-access pass.
-    is_property = _is_property_decorator(decorators) or (
-        method_node.type == cs.TS_CSHARP_PROPERTY_DECLARATION
+    # Python's @property marking feeds its attribute-access pass. A Dart
+    # getter_signature is the same shape (issue #869): its accesses are
+    # attribute reads the Dart getter-read pass resolves through this flag.
+    is_property = _is_property_decorator(decorators) or method_node.type in (
+        cs.TS_CSHARP_PROPERTY_DECLARATION,
+        cs.TS_DART_GETTER_SIGNATURE,
     )
     if is_property:
         method_props[cs.KEY_IS_PROPERTY] = True

--- a/codebase_rag/tests/test_dart_getter_reads.py
+++ b/codebase_rag/tests/test_dart_getter_reads.py
@@ -1,0 +1,150 @@
+# A Dart getter access is an attribute read, not an invocation: no CALLS
+# edge can ever land on one, so dead-code flagged every read-only getter
+# (roughly 15 of the wonderous app's ~20 residual candidates: _enableVideo,
+# _artifactRoute, startYr/endYr and kin). Mirror the C# property-read
+# design: mark getter_signature methods is_property and emit REFERENCES
+# edges for bare and receiver-position reads (issue #869).
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+REFERENCES = cs.RelationshipType.REFERENCES.value
+
+
+def _run(tmp_path: Path, files: dict[str, str]) -> MagicMock:
+    parsers, queries = load_parsers()
+    if "dart" not in parsers:
+        pytest.skip("dart parser not available")
+    for rel, content in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock, repo_path=tmp_path, parsers=parsers, queries=queries
+    ).run()
+    return mock
+
+
+def _rels(mock: MagicMock) -> set[tuple[str, str, str]]:
+    return {
+        (c.args[0][2], str(c.args[1]), c.args[2][2])
+        for c in mock.ensure_relationship_batch.call_args_list
+    }
+
+
+def _has(
+    rels: set[tuple[str, str, str]], caller_suffix: str, rel: str, callee_suffix: str
+) -> bool:
+    return any(
+        a.endswith(caller_suffix) and r == rel and b.endswith(callee_suffix)
+        for a, r, b in rels
+    )
+
+
+def test_getter_is_marked_is_property(tmp_path: Path) -> None:
+    mock = _run(
+        tmp_path,
+        {"m.dart": "class Money {\n  bool get enabled => true;\n}\n"},
+    )
+    props: dict[str, dict] = {}
+    for c in mock.ensure_node_batch.call_args_list:
+        if c.args[0] == cs.NodeLabel.METHOD:
+            props.setdefault(c.args[1][cs.KEY_QUALIFIED_NAME], {}).update(c.args[1])
+    enabled = next(v for k, v in props.items() if k.endswith("Money.enabled"))
+    assert enabled.get(cs.KEY_IS_PROPERTY) is True, enabled
+
+
+def test_bare_getter_read_is_referenced(tmp_path: Path) -> None:
+    files = {
+        "app.dart": (
+            "class Player {\n"
+            "  bool get enableVideo => true;\n"
+            "  bool get unusedFlag => false;\n"
+            "  void start() {\n"
+            "    if (enableVideo) {\n"
+            "      run();\n"
+            "    }\n"
+            "  }\n"
+            "  void run() {}\n"
+            "}\n"
+        ),
+    }
+    rels = _rels(_run(tmp_path, files))
+    assert _has(rels, ".Player.start", REFERENCES, ".Player.enableVideo"), rels
+    assert not _has(rels, ".Player.start", REFERENCES, ".Player.unusedFlag")
+
+
+def test_receiver_getter_read_is_referenced(tmp_path: Path) -> None:
+    files = {
+        "app.dart": (
+            "class Marker {\n"
+            "  int get startYr => 1900;\n"
+            "}\n"
+            "\n"
+            "class Timeline {\n"
+            "  void draw(Marker marker) {\n"
+            "    print(marker.startYr);\n"
+            "  }\n"
+            "}\n"
+        ),
+    }
+    rels = _rels(_run(tmp_path, files))
+    assert _has(rels, ".Timeline.draw", REFERENCES, ".Marker.startYr"), rels
+
+
+def test_this_qualified_getter_read_is_referenced(tmp_path: Path) -> None:
+    files = {
+        "app.dart": (
+            "class Gauge {\n"
+            "  int get level => 1;\n"
+            "  void show() {\n"
+            "    print(this.level);\n"
+            "  }\n"
+            "}\n"
+        ),
+    }
+    rels = _rels(_run(tmp_path, files))
+    assert _has(rels, ".Gauge.show", REFERENCES, ".Gauge.level"), rels
+
+
+def test_local_shadow_suppresses_bare_read(tmp_path: Path) -> None:
+    # A local (or parameter) named like the getter hides it for bare reads;
+    # emitting an edge here would fabricate liveness for a dead getter.
+    files = {
+        "app.dart": (
+            "class Cart {\n"
+            "  int get total => 3;\n"
+            "  void tally(int total) {\n"
+            "    print(total);\n"
+            "  }\n"
+            "}\n"
+        ),
+    }
+    rels = _rels(_run(tmp_path, files))
+    assert not _has(rels, ".Cart.tally", REFERENCES, ".Cart.total"), rels
+
+
+def test_getter_call_chain_is_not_double_counted(tmp_path: Path) -> None:
+    # `other.total()` is an invocation the call pass already resolves; the
+    # read pass must not add a REFERENCES edge for the same chain, or every
+    # method call would double as a phantom property read.
+    files = {
+        "app.dart": (
+            "class Engine {\n"
+            "  void ignite() {}\n"
+            "  void fire(Engine other) {\n"
+            "    other.ignite();\n"
+            "  }\n"
+            "}\n"
+        ),
+    }
+    rels = _rels(_run(tmp_path, files))
+    assert not _has(rels, ".Engine.fire", REFERENCES, ".Engine.ignite"), rels

--- a/codebase_rag/tests/test_dart_getter_reads.py
+++ b/codebase_rag/tests/test_dart_getter_reads.py
@@ -183,6 +183,62 @@ def test_closure_shadow_does_not_suppress_outer_read(tmp_path: Path) -> None:
     assert _has(rels, ".Cart.tally", REFERENCES, ".Cart.untouched"), rels
 
 
+def test_loop_catch_and_pattern_binders_shadow_bare_reads(tmp_path: Path) -> None:
+    # A loop variable, catch parameter, or pattern binding reusing a getter
+    # name declares a local like any other: reads of it must not fabricate
+    # liveness for the (otherwise unused) getter.
+    files = {
+        "app.dart": (
+            "class Bag {\n"
+            "  int get total => 1;\n"
+            "  int get errorCode => 2;\n"
+            "  int get alpha => 3;\n"
+            "  void churn(List<int> xs) {\n"
+            "    for (final total in xs) {\n"
+            "      print(total);\n"
+            "    }\n"
+            "    try {\n"
+            "      print(xs);\n"
+            "    } catch (errorCode) {\n"
+            "      print(errorCode);\n"
+            "    }\n"
+            "    var (alpha, beta) = (1, 2);\n"
+            "    print(alpha);\n"
+            "    print(beta);\n"
+            "  }\n"
+            "}\n"
+        ),
+    }
+    rels = _rels(_run(tmp_path, files))
+    assert not _has(rels, ".Bag.churn", REFERENCES, ".Bag.total"), rels
+    assert not _has(rels, ".Bag.churn", REFERENCES, ".Bag.errorCode"), rels
+    assert not _has(rels, ".Bag.churn", REFERENCES, ".Bag.alpha"), rels
+
+
+def test_call_result_cascade_read_is_referenced(tmp_path: Path) -> None:
+    # `getMarker()..startYr` reads the getter through a call-result cascade:
+    # the receiver chain carries a call hop the resolver types from the
+    # callee's declared return type.
+    files = {
+        "app.dart": (
+            "class Marker {\n"
+            "  int get startYr => 1900;\n"
+            "}\n"
+            "\n"
+            "class Board {\n"
+            "  Marker getMarker() {\n"
+            "    return Marker();\n"
+            "  }\n"
+            "  void ping() {\n"
+            "    getMarker()..startYr;\n"
+            "  }\n"
+            "}\n"
+        ),
+    }
+    rels = _rels(_run(tmp_path, files))
+    assert _has(rels, ".Board.ping", REFERENCES, ".Marker.startYr"), rels
+
+
 def test_getter_call_chain_is_not_double_counted(tmp_path: Path) -> None:
     # `other.total()` is an invocation the call pass already resolves; the
     # read pass must not add a REFERENCES edge for the same chain, or every

--- a/codebase_rag/tests/test_dart_getter_reads.py
+++ b/codebase_rag/tests/test_dart_getter_reads.py
@@ -132,6 +132,57 @@ def test_local_shadow_suppresses_bare_read(tmp_path: Path) -> None:
     assert not _has(rels, ".Cart.tally", REFERENCES, ".Cart.total"), rels
 
 
+def test_cascade_getter_read_is_referenced(tmp_path: Path) -> None:
+    # `marker..startYr` reads through a cascade_section, not the ordinary
+    # selector chain; a cascade holding an argument_part is an invocation
+    # the call pass owns, and a cascade WRITE (`..endYr = 5`) targets the
+    # setter, so neither may fabricate a getter read.
+    files = {
+        "app.dart": (
+            "class Marker {\n"
+            "  int get startYr => 1900;\n"
+            "  int get endYr => 2000;\n"
+            "  void refresh() {}\n"
+            "}\n"
+            "\n"
+            "class Board {\n"
+            "  void ping(Marker marker) {\n"
+            "    marker..startYr;\n"
+            "    marker..refresh();\n"
+            "  }\n"
+            "}\n"
+        ),
+    }
+    rels = _rels(_run(tmp_path, files))
+    assert _has(rels, ".Board.ping", REFERENCES, ".Marker.startYr"), rels
+    assert not _has(rels, ".Board.ping", REFERENCES, ".Marker.refresh"), rels
+
+
+def test_closure_shadow_does_not_suppress_outer_read(tmp_path: Path) -> None:
+    # A closure's parameter named like the getter shadows it only INSIDE the
+    # closure: the enclosing method's own bare read still resolves to the
+    # getter and must be referenced, while the closure-internal read of the
+    # parameter must not be.
+    files = {
+        "app.dart": (
+            "class Cart {\n"
+            "  int get total => 3;\n"
+            "  int get untouched => 4;\n"
+            "  void tally() {\n"
+            "    run((int total) {\n"
+            "      print(total);\n"
+            "      print(untouched);\n"
+            "    });\n"
+            "    print(total);\n"
+            "  }\n"
+            "}\n"
+        ),
+    }
+    rels = _rels(_run(tmp_path, files))
+    assert _has(rels, ".Cart.tally", REFERENCES, ".Cart.total"), rels
+    assert _has(rels, ".Cart.tally", REFERENCES, ".Cart.untouched"), rels
+
+
 def test_getter_call_chain_is_not_double_counted(tmp_path: Path) -> None:
     # `other.total()` is an invocation the call pass already resolves; the
     # read pass must not add a REFERENCES edge for the same chain, or every

--- a/codebase_rag/tests/test_dart_getter_reads.py
+++ b/codebase_rag/tests/test_dart_getter_reads.py
@@ -215,6 +215,33 @@ def test_loop_catch_and_pattern_binders_shadow_bare_reads(tmp_path: Path) -> Non
     assert not _has(rels, ".Bag.churn", REFERENCES, ".Bag.alpha"), rels
 
 
+def test_reads_before_the_binder_still_reference_the_getter(tmp_path: Path) -> None:
+    # A binder is live only AFTER its declaration: the for-in ITERABLE and
+    # the try BODY precede theirs, so a getter read there is genuine and
+    # must not be suppressed by the statement-wide shadow.
+    files = {
+        "app.dart": (
+            "class Scanner {\n"
+            "  int get total => 1;\n"
+            "  int get errorCode => 2;\n"
+            "  void scan() {\n"
+            "    for (final total in [total]) {\n"
+            "      print(total);\n"
+            "    }\n"
+            "    try {\n"
+            "      print(errorCode);\n"
+            "    } catch (errorCode) {\n"
+            "      print(errorCode);\n"
+            "    }\n"
+            "  }\n"
+            "}\n"
+        ),
+    }
+    rels = _rels(_run(tmp_path, files))
+    assert _has(rels, ".Scanner.scan", REFERENCES, ".Scanner.total"), rels
+    assert _has(rels, ".Scanner.scan", REFERENCES, ".Scanner.errorCode"), rels
+
+
 def test_call_result_cascade_read_is_referenced(tmp_path: Path) -> None:
     # `getMarker()..startYr` reads the getter through a call-result cascade:
     # the receiver chain carries a call hop the resolver types from the

--- a/codebase_rag/tests/test_dart_tearoff_references.py
+++ b/codebase_rag/tests/test_dart_tearoff_references.py
@@ -119,9 +119,11 @@ def test_conditional_tearoff_references_both_branches(tmp_path: Path) -> None:
     rels = _run_rels(tmp_path, files)
     assert _has(rels, ".Selector.build", REFERENCES, ".Selector.goRight"), rels
     assert _has(rels, ".Selector.build", REFERENCES, ".Selector.goLeft"), rels
-    # The condition is only truthiness-tested, never handed over; expanding
-    # it would resurface the Python operand order on Dart's ternary.
-    assert not _has(rels, ".Selector.build", REFERENCES, ".Selector.isRight")
+    # The condition is never handed over as a value, but truthiness-testing
+    # a GETTER invokes it: the getter-read pass (issue #869) records that
+    # read. An operand-order regression is caught by the positive
+    # assertions above (the consequence would go missing).
+    assert _has(rels, ".Selector.build", REFERENCES, ".Selector.isRight"), rels
 
 
 def test_list_literal_tearoffs_are_referenced(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.445"
+version = "0.0.447"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.441"
+version = "0.0.445"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Closes #869.

A Dart getter access is an attribute read, not an invocation, so no CALLS edge could ever land on one and dead-code flagged every read-only getter (roughly 15 of the wonderous app's ~20 residual candidates after #864/#865/#867/#868). This mirrors the C# property-read design:

- `getter_signature` methods are marked `is_property` at ingestion, feeding the same registry flag the Python and C# read passes use.
- A new Dart read pass emits REFERENCES edges for bare-identifier reads (implicit `this`, resolved against the enclosing class) and receiver-position member reads (`marker.startYr`, `this.level`), reassembled through the existing selector-chain walker and resolved through receiver typing. Only resolutions landing on a marked property emit, so unrelated same-name symbols never fabricate an edge.
- Parameters and locals shadow same-name getters for bare reads (whole-body shadow set; the safe, under-referencing direction).
- The argument-reference (tear-off) path now excludes Dart properties: a getter in argument position is a value read owned by the read pass, so a shadowing local no longer fabricates liveness.
- A member selector followed by an argument_part stays with the call pass, so method calls are not double-counted as reads.

The dead-code walk already traverses REFERENCES, so no changes on that side.

## Testing

- New `test_dart_getter_reads.py`: is_property marking, bare read, receiver read, this-qualified read, local-shadow suppression, and no double-counting of call chains (RED first, commit history shows the failing state).
- `test_dart_tearoff_references.py` conditional test updated: truthiness-testing a getter is now a recorded read, and operand-order regressions stay caught by the branch assertions.
- Full suite: 5804 passed, 10 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dart getter reads are now represented as `REFERENCES` relationships (bare, receiver-qualified, `this`-qualified, and cascade member reads).
  * Dart getter signatures are now correctly identified as properties.

* **Bug Fixes**
  * Prevents duplicate or incorrect edge types by ensuring Dart getter reads don’t emit invocation-style call edges.
  * Suppresses bare getter references when shadowed by in-scope locals/parameters, including loop variables, catch parameters, and pattern binders.

* **Tests**
  * Expanded Dart regression coverage for getter reads and cascade cases, and updated conditional tear-off reference expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->