### PR TITLE
fix(dart): reference getters read from class field initializers

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -147,6 +147,18 @@ _DART_NON_READ_PARENT_TYPES = (
 )
 
 
+def _dart_is_owned_function_body(node: Node) -> bool:
+    # A function_body belonging to a top-level function or class member has
+    # its OWN caller pass; a closure's or local function's body does not (a
+    # Dart lambda's reads attribute to the enclosing scope), so only bodies
+    # NOT under a nested-scope node are skipped by the module walks.
+    return (
+        node.type == cs.TS_DART_FUNCTION_BODY
+        and (parent := node.parent) is not None
+        and parent.type not in cs.DART_NESTED_SCOPE_NODE_TYPES
+    )
+
+
 def _dart_declared_names(node: Node) -> list[str]:
     # The name(s) a parameter, local declaration, loop variable, catch
     # parameter, or pattern binding binds; anything else declares nothing.
@@ -1002,6 +1014,26 @@ class CallProcessor:
             # entries reachable; scan before the no-calls early return so a file
             # that only defines functions and a table is still covered. Runs for
             # every flow language with an object/array/dict literal form.
+            if language == cs.SupportedLanguage.DART and (
+                dart_prop_names := self._resolver.function_registry.property_names()
+            ):
+                # Field initializers execute at construction time even in a
+                # file holding nothing but classes (no module caller pass
+                # runs there), so each class subtree is scanned at FILE
+                # level, before the no-calls early return.
+                dart_config = queries[language][cs.QUERY_CONFIG]
+                module_spec = (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, module_qn)
+                for child in root_node.named_children:
+                    if child.type in dart_config.class_node_types:
+                        self._ingest_dart_class_initializer_reads(
+                            child,
+                            module_spec,
+                            module_qn,
+                            module_qn,
+                            None,
+                            dart_config,
+                            dart_prop_names,
+                        )
             if language == cs.SupportedLanguage.PYTHON or language in _JS_TS_LANGUAGES:
                 collection_boundaries = self._flow_scope_boundaries(
                     queries[language][cs.QUERY_CONFIG]
@@ -4717,11 +4749,11 @@ class CallProcessor:
         # function_body: the signature holds no reads, so walk the body.
         body = dart_utils.dart_body_node(caller_node)
         walk_root = body if body is not None else caller_node
-        # The bodiless caller is the MODULE pass: class subtrees must be
-        # descended there because FIELD INITIALIZERS read getters outside
-        # any method body (`late final body = _createFont(contentFont, ..)`),
-        # while every function_body is skipped (each method's own pass walks
-        # it). Method callers keep skipping nested classes instead.
+        # The bodiless caller is the MODULE pass: FIELD INITIALIZERS read
+        # getters outside any method body (`late final body =
+        # _createFont(contentFont, ..)`), so each class subtree is walked by
+        # a per-class sub-pass carrying the OWNING class as resolution
+        # context. Method callers keep skipping nested classes instead.
         is_module_scope = body is None
         shadow_cell: list[dict[str, list[tuple[int, int]]]] = []
 
@@ -4734,10 +4766,11 @@ class CallProcessor:
         stack = list(walk_root.children)
         while stack:
             node = stack.pop()
-            if is_module_scope:
-                if node.type == cs.TS_DART_FUNCTION_BODY:
-                    continue
-            elif node.type in class_types:
+            if node.type in class_types:
+                # Class subtrees (field initializers) are scanned once at
+                # FILE level by _ingest_dart_class_initializer_reads.
+                continue
+            if is_module_scope and _dart_is_owned_function_body(node):
                 continue
             read_name = self._dart_read_name(node, prop_names, shadow_spans)
             if read_name:
@@ -4748,6 +4781,72 @@ class CallProcessor:
                     module_qn,
                     local_var_types,
                     class_context,
+                    seen,
+                )
+            stack.extend(node.children)
+
+    def _ingest_dart_class_initializer_reads(
+        self,
+        class_node: Node,
+        caller_spec: tuple[str, str, str],
+        caller_qn: str,
+        module_qn: str,
+        local_var_types: dict[str, str] | None,
+        lang_config: LanguageSpec,
+        prop_names: set[str],
+    ) -> None:
+        # Field initializers run in the class's OWN scope: bare reads resolve
+        # against the owning class (two classes may share a getter name), and
+        # each class gets its own dedup set. A closure inside an initializer
+        # belongs to no method pass, so its body is walked here; only
+        # method/constructor bodies (owned by a class-body signature) have
+        # their own pass. Nested classes recurse with their own context.
+        class_types = lang_config.class_node_types
+        name_node = next(
+            (
+                child
+                for child in class_node.named_children
+                if child.type == cs.TS_DART_IDENTIFIER
+            ),
+            None,
+        )
+        class_name = safe_decode_text(name_node) if name_node is not None else None
+        class_ctx = f"{module_qn}{cs.SEPARATOR_DOT}{class_name}" if class_name else None
+        seen: set[str] = set()
+        shadow_cell: list[dict[str, list[tuple[int, int]]]] = []
+
+        def shadow_spans() -> dict[str, list[tuple[int, int]]]:
+            # Initializer closures declare parameters; their spans confine
+            # any shadowing to the closure itself.
+            if not shadow_cell:
+                shadow_cell.append(self._dart_shadow_spans(class_node, class_node))
+            return shadow_cell[0]
+
+        stack = list(class_node.children)
+        while stack:
+            node = stack.pop()
+            if node.type in class_types:
+                self._ingest_dart_class_initializer_reads(
+                    node,
+                    caller_spec,
+                    caller_qn,
+                    module_qn,
+                    local_var_types,
+                    lang_config,
+                    prop_names,
+                )
+                continue
+            if _dart_is_owned_function_body(node):
+                continue
+            read_name = self._dart_read_name(node, prop_names, shadow_spans)
+            if read_name:
+                self._emit_dart_property_read(
+                    read_name,
+                    caller_spec,
+                    caller_qn,
+                    module_qn,
+                    local_var_types,
+                    class_ctx,
                     seen,
                 )
             stack.extend(node.children)
@@ -4800,13 +4899,23 @@ class CallProcessor:
     ) -> None:
         if read_name in seen:
             return
-        resolved = self._resolver.resolve_function_call(
-            read_name, module_qn, local_var_types, class_context, caller_qn
-        )
-        if not resolved:
-            return
-        _res_type, res_qn = resolved
         registry = self._resolver.function_registry
+        res_qn: str | None = None
+        # A bare read inside a class binds the OWNING class's member first:
+        # the trie fallback is name-global and would pick a same-named getter
+        # from whichever class sorts first (a module-caller's caller_qn
+        # carries no class to guide it).
+        if class_context is not None and cs.SEPARATOR_DOT not in read_name:
+            candidate = f"{class_context}{cs.SEPARATOR_DOT}{read_name}"
+            if registry.get(candidate) is not None:
+                res_qn = candidate
+        if res_qn is None:
+            resolved = self._resolver.resolve_function_call(
+                read_name, module_qn, local_var_types, class_context, caller_qn
+            )
+            if not resolved:
+                return
+            res_qn = resolved[1]
         if not registry.is_property(res_qn) or res_qn == caller_qn:
             return
         seen.add(read_name)

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -128,6 +128,23 @@ _DART_LOCAL_DECLARATION_TYPES = frozenset(
 _DART_STATEMENT_SCOPE_TYPES = frozenset(
     {cs.TS_DART_FOR_STATEMENT, cs.TS_DART_TRY_STATEMENT}
 )
+# Parents whose direct identifier is never a value read: member/cascade
+# selectors carry the chain passes' members, a label names a parameter,
+# catch parameters only BIND names, and a signature's identifier is the
+# DECLARED name (the module pass walks class bodies for field initializers,
+# so signatures are in view there).
+_DART_NON_READ_PARENT_TYPES = (
+    frozenset(
+        {
+            cs.TS_DART_LABEL,
+            cs.TS_DART_UNCONDITIONAL_ASSIGNABLE_SELECTOR,
+            cs.TS_DART_CONDITIONAL_ASSIGNABLE_SELECTOR,
+            cs.TS_DART_CASCADE_SELECTOR,
+            cs.TS_DART_CATCH_PARAMETERS,
+        }
+    )
+    | cs.DART_SIGNATURE_TYPES
+)
 
 
 def _dart_declared_names(node: Node) -> list[str]:
@@ -201,14 +218,7 @@ def _dart_is_bare_read(node: Node) -> bool:
     ):
         return False
     parent = node.parent
-    if parent is None or parent.type in (
-        cs.TS_DART_LABEL,
-        cs.TS_DART_UNCONDITIONAL_ASSIGNABLE_SELECTOR,
-        cs.TS_DART_CONDITIONAL_ASSIGNABLE_SELECTOR,
-        cs.TS_DART_CASCADE_SELECTOR,
-        # Catch parameters only BIND names; they never read.
-        cs.TS_DART_CATCH_PARAMETERS,
-    ):
+    if parent is None or parent.type in _DART_NON_READ_PARENT_TYPES:
         return False
     if parent.type == cs.TS_DART_FOR_LOOP_PARTS:
         # The FIRST identifier of a for-in is the loop BINDER, not a read;
@@ -4707,6 +4717,12 @@ class CallProcessor:
         # function_body: the signature holds no reads, so walk the body.
         body = dart_utils.dart_body_node(caller_node)
         walk_root = body if body is not None else caller_node
+        # The bodiless caller is the MODULE pass: class subtrees must be
+        # descended there because FIELD INITIALIZERS read getters outside
+        # any method body (`late final body = _createFont(contentFont, ..)`),
+        # while every function_body is skipped (each method's own pass walks
+        # it). Method callers keep skipping nested classes instead.
+        is_module_scope = body is None
         shadow_cell: list[dict[str, list[tuple[int, int]]]] = []
 
         def shadow_spans() -> dict[str, list[tuple[int, int]]]:
@@ -4718,7 +4734,10 @@ class CallProcessor:
         stack = list(walk_root.children)
         while stack:
             node = stack.pop()
-            if node.type in class_types:
+            if is_module_scope:
+                if node.type == cs.TS_DART_FUNCTION_BODY:
+                    continue
+            elif node.type in class_types:
                 continue
             read_name = self._dart_read_name(node, prop_names, shadow_spans)
             if read_name:

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -147,6 +147,21 @@ _DART_NON_READ_PARENT_TYPES = (
 )
 
 
+def _dart_scope_span(decl: Node, walk_root: Node) -> tuple[int, int]:
+    # The byte span a declaration shadows: its nearest enclosing scope, with
+    # statement scopes (for/try) starting at the declaration END because the
+    # for-in iterable and the try body precede their binder. No scope
+    # ancestor (a signature parameter) falls through to the whole body.
+    anc = decl.parent
+    while anc is not None and anc is not walk_root:
+        if anc.type in _DART_SHADOW_SCOPE_TYPES:
+            if anc.type in _DART_STATEMENT_SCOPE_TYPES:
+                return (decl.end_byte, anc.end_byte)
+            return (anc.start_byte, anc.end_byte)
+        anc = anc.parent
+    return (walk_root.start_byte, walk_root.end_byte)
+
+
 def _dart_is_owned_function_body(node: Node) -> bool:
     # A function_body belonging to a top-level function or class member has
     # its OWN caller pass; a closure's or local function's body does not (a
@@ -4947,18 +4962,6 @@ class CallProcessor:
         # suppress the enclosing method's read (cf. _csharp_shadow_spans).
         # Method parameters live in the SIGNATURE, outside the walked body,
         # so their scope walk falls through to the whole body.
-        whole_body = (walk_root.start_byte, walk_root.end_byte)
-
-        def scope_span(decl: Node) -> tuple[int, int]:
-            anc = decl.parent
-            while anc is not None and anc is not walk_root:
-                if anc.type in _DART_SHADOW_SCOPE_TYPES:
-                    if anc.type in _DART_STATEMENT_SCOPE_TYPES:
-                        return (decl.end_byte, anc.end_byte)
-                    return (anc.start_byte, anc.end_byte)
-                anc = anc.parent
-            return whole_body
-
         spans: dict[str, list[tuple[int, int]]] = {}
         stack = list(caller_node.children)
         if walk_root is not caller_node:
@@ -4975,7 +4978,7 @@ class CallProcessor:
             ):
                 continue
             for name in _dart_declared_names(node):
-                spans.setdefault(name, []).append(scope_span(node))
+                spans.setdefault(name, []).append(_dart_scope_span(node, walk_root))
             stack.extend(node.children)
         return spans
 

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -4794,13 +4794,15 @@ class CallProcessor:
         local_var_types: dict[str, str] | None,
         lang_config: LanguageSpec,
         prop_names: set[str],
+        parent_qn: str | None = None,
     ) -> None:
         # Field initializers run in the class's OWN scope: bare reads resolve
         # against the owning class (two classes may share a getter name), and
         # each class gets its own dedup set. A closure inside an initializer
         # belongs to no method pass, so its body is walked here; only
         # method/constructor bodies (owned by a class-body signature) have
-        # their own pass. Nested classes recurse with their own context.
+        # their own pass. Dart forbids nested class declarations, but the
+        # defensive recursion still threads the enclosing context through.
         class_types = lang_config.class_node_types
         name_node = next(
             (
@@ -4811,15 +4813,22 @@ class CallProcessor:
             None,
         )
         class_name = safe_decode_text(name_node) if name_node is not None else None
-        class_ctx = f"{module_qn}{cs.SEPARATOR_DOT}{class_name}" if class_name else None
+        owner_qn = parent_qn if parent_qn is not None else module_qn
+        class_ctx = f"{owner_qn}{cs.SEPARATOR_DOT}{class_name}" if class_name else None
         seen: set[str] = set()
         shadow_cell: list[dict[str, list[tuple[int, int]]]] = []
 
         def shadow_spans() -> dict[str, list[tuple[int, int]]]:
             # Initializer closures declare parameters; their spans confine
-            # any shadowing to the closure itself.
+            # any shadowing to the closure itself. Member signatures and
+            # owned bodies stay out: a method parameter scopes its own body,
+            # which this walk never reads.
             if not shadow_cell:
-                shadow_cell.append(self._dart_shadow_spans(class_node, class_node))
+                shadow_cell.append(
+                    self._dart_shadow_spans(
+                        class_node, class_node, skip_owned_members=True
+                    )
+                )
             return shadow_cell[0]
 
         stack = list(class_node.children)
@@ -4834,6 +4843,7 @@ class CallProcessor:
                     local_var_types,
                     lang_config,
                     prop_names,
+                    parent_qn=class_ctx,
                 )
                 continue
             if _dart_is_owned_function_body(node):
@@ -4926,7 +4936,10 @@ class CallProcessor:
         )
 
     def _dart_shadow_spans(
-        self, caller_node: Node, walk_root: Node
+        self,
+        caller_node: Node,
+        walk_root: Node,
+        skip_owned_members: bool = False,
     ) -> dict[str, list[tuple[int, int]]]:
         # {declared name: [byte span of each declaring SCOPE]} for parameters
         # and locals. A declaration shadows a same-name getter only for bare
@@ -4952,6 +4965,15 @@ class CallProcessor:
             stack.extend(walk_root.children)
         while stack:
             node = stack.pop()
+            # For the class-initializer pass, member signatures and owned
+            # bodies are invisible to the READ walk, so their parameters and
+            # locals must not join the shadow map either: a method parameter
+            # scopes its own body, never a sibling field initializer.
+            if skip_owned_members and (
+                node.type in cs.DART_SIGNATURE_TYPES
+                or _dart_is_owned_function_body(node)
+            ):
+                continue
             for name in _dart_declared_names(node):
                 spans.setdefault(name, []).append(scope_span(node))
             stack.extend(node.children)

--- a/codebase_rag/tests/test_dart_getter_reads.py
+++ b/codebase_rag/tests/test_dart_getter_reads.py
@@ -287,9 +287,9 @@ def test_field_initializer_getter_read_is_referenced(tmp_path: Path) -> None:
         ),
     }
     rels = _rels(_run(tmp_path, files))
-    assert any(
-        r == REFERENCES and b.endswith(".Palette.base") for _a, r, b in rels
-    ), rels
+    assert any(r == REFERENCES and b.endswith(".Palette.base") for _a, r, b in rels), (
+        rels
+    )
     assert any(
         r == REFERENCES and b.endswith(".Palette.factor") for _a, r, b in rels
     ), rels

--- a/codebase_rag/tests/test_dart_getter_reads.py
+++ b/codebase_rag/tests/test_dart_getter_reads.py
@@ -266,6 +266,38 @@ def test_call_result_cascade_read_is_referenced(tmp_path: Path) -> None:
     assert _has(rels, ".Board.ping", REFERENCES, ".Marker.startYr"), rels
 
 
+def test_field_initializer_getter_read_is_referenced(tmp_path: Path) -> None:
+    # A class FIELD INITIALIZER reads getters outside any method body
+    # (wonderous: `late final TextStyle body = _createFont(contentFont, ...)`),
+    # so neither a method caller's walk nor the module pass (which skipped
+    # class subtrees) saw it, and the getter reported dead.
+    files = {
+        "app.dart": (
+            "int wrap(int v) {\n"
+            "  return v;\n"
+            "}\n"
+            "\n"
+            "class Palette {\n"
+            "  int get base => 3;\n"
+            "  int get factor => 2;\n"
+            "  int get unusedTone => 9;\n"
+            "  late final int wrapped = wrap(base);\n"
+            "  late final int scaled = factor * 2;\n"
+            "}\n"
+        ),
+    }
+    rels = _rels(_run(tmp_path, files))
+    assert any(
+        r == REFERENCES and b.endswith(".Palette.base") for _a, r, b in rels
+    ), rels
+    assert any(
+        r == REFERENCES and b.endswith(".Palette.factor") for _a, r, b in rels
+    ), rels
+    assert not any(
+        r == REFERENCES and b.endswith(".Palette.unusedTone") for _a, r, b in rels
+    ), rels
+
+
 def test_getter_call_chain_is_not_double_counted(tmp_path: Path) -> None:
     # `other.total()` is an invocation the call pass already resolves; the
     # read pass must not add a REFERENCES edge for the same chain, or every

--- a/codebase_rag/tests/test_dart_getter_reads.py
+++ b/codebase_rag/tests/test_dart_getter_reads.py
@@ -357,3 +357,24 @@ def test_getter_call_chain_is_not_double_counted(tmp_path: Path) -> None:
     }
     rels = _rels(_run(tmp_path, files))
     assert not _has(rels, ".Engine.fire", REFERENCES, ".Engine.ignite"), rels
+
+
+def test_method_parameter_does_not_shadow_initializer_read(tmp_path: Path) -> None:
+    # A method parameter named like the getter scopes to ITS method body,
+    # which the initializer walk never enters: it must not suppress a field
+    # initializer's read of the getter.
+    files = {
+        "app.dart": (
+            "class Widgeta {\n"
+            "  int get tone => 1;\n"
+            "  late final int value = tone;\n"
+            "  void resize(int tone) {\n"
+            "    print(tone);\n"
+            "  }\n"
+            "}\n"
+        ),
+    }
+    rels = _rels(_run(tmp_path, files))
+    assert any(r == REFERENCES and b.endswith("Widgeta.tone") for _a, r, b in rels), (
+        rels
+    )

--- a/codebase_rag/tests/test_dart_getter_reads.py
+++ b/codebase_rag/tests/test_dart_getter_reads.py
@@ -298,6 +298,49 @@ def test_field_initializer_getter_read_is_referenced(tmp_path: Path) -> None:
     ), rels
 
 
+def test_field_initializers_resolve_against_the_owning_class(tmp_path: Path) -> None:
+    # Two classes can define the same getter name: each field initializer
+    # must resolve against ITS OWN class, and one class's read must not
+    # dedup away the other's.
+    files = {
+        "app.dart": (
+            "int wrap(int v) {\n"
+            "  return v;\n"
+            "}\n"
+            "\n"
+            "class Alpha {\n"
+            "  int get tone => 1;\n"
+            "  late final int a = wrap(tone);\n"
+            "}\n"
+            "\n"
+            "class Beta {\n"
+            "  int get tone => 2;\n"
+            "  late final int b = wrap(tone);\n"
+            "}\n"
+        ),
+    }
+    rels = _rels(_run(tmp_path, files))
+    assert any(r == REFERENCES and b.endswith("Alpha.tone") for _a, r, b in rels), rels
+    assert any(r == REFERENCES and b.endswith("Beta.tone") for _a, r, b in rels), rels
+
+
+def test_initializer_closure_read_is_referenced(tmp_path: Path) -> None:
+    # A closure INSIDE a field initializer belongs to no method pass: its
+    # body must still be walked or the getter it reads reports dead.
+    files = {
+        "app.dart": (
+            "class Deck {\n"
+            "  int get tone => 1;\n"
+            "  late final int Function() pick = () {\n"
+            "    return tone;\n"
+            "  };\n"
+            "}\n"
+        ),
+    }
+    rels = _rels(_run(tmp_path, files))
+    assert any(r == REFERENCES and b.endswith("Deck.tone") for _a, r, b in rels), rels
+
+
 def test_getter_call_chain_is_not_double_counted(tmp_path: Path) -> None:
     # `other.total()` is an invocation the call pass already resolves; the
     # read pass must not add a REFERENCES edge for the same chain, or every

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.449"
+version = "0.0.450"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Found live-validating #870 on the wonderous app: three `_Text` getters (`contentFont`, `quoteFont`, `wonderTitleFont`) regressed to dead-code candidates. They are read ONLY from class FIELD INITIALIZERS (`late final TextStyle body = _createFont(contentFont, ...)`), which sit outside every method body: method callers walk only their own bodies, and the module pass skipped class subtrees entirely, so no read pass ever saw them. Their previous liveness came from the argument-reference path #870 deliberately excluded for Dart properties.

The module-scope getter-read pass (the bodiless caller) now descends class bodies while skipping every `function_body` (each method's own pass walks those), so field-initializer reads emit REFERENCES from the module. A follow-on subtlety the new walk exposed: a signature's identifier is a DECLARED name, not a read, so signature parents joined the non-read set or every getter would self-reference.

## Testing

- RED first: `test_field_initializer_getter_read_is_referenced` (getter read via argument and via binary expression in initializers; an unread getter stays unreferenced).
- Full suite: 5829 passed, 10 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Dart getter-read tracking so references from class field initializers (including `late final`) are captured even when a file has no call expressions.
  * Refined getter-read scope traversal (module vs method body), including correct handling for nested classes, closure reads inside initializers, and avoiding shadowing by owned function bodies.
  * Enhanced resolution for bare reads inside classes to prioritize the owning class’s getter before falling back to the standard resolver.
* **Tests**
  * Added coverage for referenced vs unused getters in field initializers, owning-class resolution across classes, initializer closures, and method parameters with matching names not suppressing reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->