### PR TITLE
fix(dart): receiver-position getter reads and ternary arguments swallowed by low-precedence operators

### DIFF
--- a/codebase_rag/constants/ast_dart.py
+++ b/codebase_rag/constants/ast_dart.py
@@ -60,6 +60,10 @@ TS_DART_TRY_STATEMENT = "try_statement"
 TS_DART_CATCH_PARAMETERS = "catch_parameters"
 TS_DART_PATTERN_VARIABLE_DECLARATION = "pattern_variable_declaration"
 DART_PATTERN_NODE_SUFFIX = "_pattern"
+# The grammar's flat operator nodes (additive_expression, if_null_expression,
+# logical_and_expression, ...) share this suffix; a low-precedence operator
+# swallows a trailing ternary as its LAST named child.
+DART_EXPRESSION_NODE_SUFFIX = "_expression"
 TS_DART_FUNCTION_EXPRESSION = "function_expression"
 TS_DART_LOCAL_FUNCTION_DECLARATION = "local_function_declaration"
 

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -233,15 +233,22 @@ def _dart_pattern_bound_names(node: Node) -> list[str]:
 
 
 def _dart_is_bare_read(node: Node) -> bool:
-    # A bare-identifier getter read only: a chain head (following selector or
-    # cascade) belongs to the member/cascade passes, an argument_part head is
-    # a call target, a label's identifier names a parameter, and a selector's
+    # A bare-identifier getter read, INCLUDING a receiver-position chain head:
+    # `_wonders.length` reads the `_wonders` getter even though the member
+    # pass only emits for the final member (issue #873). Only a head invoked
+    # directly (`f(x)` = identifier + selector(argument_part)) belongs to the
+    # call pass; a label's identifier names a parameter, and a selector's
     # own identifier is the member the chain pass already handled.
     following = node.next_named_sibling
-    if following is not None and following.type in (
-        cs.TS_DART_SELECTOR,
-        cs.TS_DART_ARGUMENT_PART,
-        cs.TS_DART_CASCADE_SECTION,
+    if following is not None and (
+        following.type == cs.TS_DART_ARGUMENT_PART
+        or (
+            following.type == cs.TS_DART_SELECTOR
+            and any(
+                child.type == cs.TS_DART_ARGUMENT_PART
+                for child in following.named_children
+            )
+        )
     ):
         return False
     parent = node.parent
@@ -376,6 +383,18 @@ def _first_class_value_children(node: Node, is_dart: bool) -> list[Node] | None:
         return _py_dict_values(node)
     if node.type == cs.TS_PY_CONDITIONAL_EXPRESSION:
         return _conditional_result_operands(node, is_dart)
+    if (
+        is_dart
+        and node.type.endswith(cs.DART_EXPRESSION_NODE_SUFFIX)
+        and (kids := node.named_children)
+        and kids[-1].type == cs.TS_PY_CONDITIONAL_EXPRESSION
+    ):
+        # tree-sitter-dart parses low-precedence operators OVER the ternary
+        # (`a + b > 0 ? f : null` -> additive_expression(a, +,
+        # conditional_expression(...))), swallowing the conditional as the
+        # LAST child of the operator node; its result operands are still the
+        # handed-over values (issue #873).
+        return [kids[-1]]
     if node.type == cs.TS_PY_BOOLEAN_OPERATOR:
         return [
             operand
@@ -1135,13 +1154,16 @@ class CallProcessor:
             if not all_call_nodes and language not in (
                 cs.SupportedLanguage.CSHARP,
                 cs.SupportedLanguage.CPP,
+                cs.SupportedLanguage.DART,
             ):
                 # A file with no call expressions has nothing further to
                 # process, except in C#, where a class can still READ
-                # properties (`return Size;`), and C++, where a ctor's
+                # properties (`return Size;`), C++, where a ctor's
                 # member initializer list (`: buffer(g, 0)`) runs base
-                # ctors without any call_expression node; both passes run
-                # per caller inside class processing, so they proceed.
+                # ctors without any call_expression node, and Dart, where
+                # a getter body can read another getter (`=> _wonders.length`,
+                # issue #873); these passes run per caller inside class
+                # processing, so they proceed.
                 return
             self._process_calls_in_classes(
                 root_node,

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -386,6 +386,9 @@ def _first_class_value_children(node: Node, is_dart: bool) -> list[Node] | None:
     if (
         is_dart
         and node.type.endswith(cs.DART_EXPRESSION_NODE_SUFFIX)
+        # A scope-opening node (function_expression) IS the first-class
+        # value; only flat operator nodes hand a swallowed ternary onward.
+        and node.type not in cs.DART_NESTED_SCOPE_NODE_TYPES
         and (kids := node.named_children)
         and kids[-1].type == cs.TS_PY_CONDITIONAL_EXPRESSION
     ):

--- a/codebase_rag/tests/test_dart_getter_reads.py
+++ b/codebase_rag/tests/test_dart_getter_reads.py
@@ -378,3 +378,72 @@ def test_method_parameter_does_not_shadow_initializer_read(tmp_path: Path) -> No
     assert any(r == REFERENCES and b.endswith("Widgeta.tone") for _a, r, b in rels), (
         rels
     )
+
+
+def test_receiver_position_getter_read_is_referenced(tmp_path: Path) -> None:
+    # `_wonders.length` reads the `_wonders` getter even though the FINAL
+    # member (`length`) is external: the chain head in receiver position is
+    # a read (issue #873, wonderous `_HomeScreenState._wonders`).
+    files = {
+        "app.dart": (
+            "class Screen {\n"
+            "  List<int> get _wonders => [1, 2];\n"
+            "  int get _numWonders => _wonders.length;\n"
+            "}\n"
+        ),
+    }
+    rels = _rels(_run(tmp_path, files))
+    assert _has(rels, ".Screen._numWonders", REFERENCES, ".Screen._wonders"), rels
+
+
+def test_receiver_position_read_shadowed_by_local(tmp_path: Path) -> None:
+    # A local named like the getter owns the receiver position inside its
+    # scope: no read of the getter may be fabricated.
+    files = {
+        "app.dart": (
+            "class Screen {\n"
+            "  List<int> get _wonders => [1, 2];\n"
+            "  int count() {\n"
+            "    final _wonders = <int>[3];\n"
+            "    return _wonders.length;\n"
+            "  }\n"
+            "}\n"
+        ),
+    }
+    rels = _rels(_run(tmp_path, files))
+    assert not _has(rels, ".Screen.count", REFERENCES, ".Screen._wonders"), rels
+
+
+def test_cascade_receiver_getter_read_is_referenced(tmp_path: Path) -> None:
+    # `_wonders..add(3)` reads the `_wonders` getter to obtain the cascade
+    # receiver; the cascaded call itself belongs to the call pass.
+    files = {
+        "app.dart": (
+            "class Screen {\n"
+            "  List<int> get _wonders => [1, 2];\n"
+            "  void fill() {\n"
+            "    _wonders..add(3);\n"
+            "  }\n"
+            "}\n"
+        ),
+    }
+    rels = _rels(_run(tmp_path, files))
+    assert _has(rels, ".Screen.fill", REFERENCES, ".Screen._wonders"), rels
+
+
+def test_invoked_chain_head_is_not_a_property_read(tmp_path: Path) -> None:
+    # `_wonders(3)` is an invocation the call pass owns: a head followed
+    # directly by an argument_part must stay out of the read pass.
+    files = {
+        "app.dart": (
+            "class Screen {\n"
+            "  int _wonders(int n) => n;\n"
+            "  int get _tone => 1;\n"
+            "  void fill() {\n"
+            "    _wonders(3);\n"
+            "  }\n"
+            "}\n"
+        ),
+    }
+    rels = _rels(_run(tmp_path, files))
+    assert not _has(rels, ".Screen.fill", REFERENCES, ".Screen._wonders"), rels

--- a/codebase_rag/tests/test_dart_getter_reads.py
+++ b/codebase_rag/tests/test_dart_getter_reads.py
@@ -432,13 +432,14 @@ def test_cascade_receiver_getter_read_is_referenced(tmp_path: Path) -> None:
 
 
 def test_invoked_chain_head_is_not_a_property_read(tmp_path: Path) -> None:
-    # `_wonders(3)` is an invocation the call pass owns: a head followed
-    # directly by an argument_part must stay out of the read pass.
+    # `_wonders(3)` on a getter returning a callable is an invocation the
+    # call pass owns (it emits the CALLS edge that keeps the getter alive):
+    # a head followed directly by an argument_part must stay out of the
+    # read pass or every such site would double as a phantom read.
     files = {
         "app.dart": (
             "class Screen {\n"
-            "  int _wonders(int n) => n;\n"
-            "  int get _tone => 1;\n"
+            "  int Function(int) get _wonders => (n) => n;\n"
             "  void fill() {\n"
             "    _wonders(3);\n"
             "  }\n"
@@ -447,3 +448,4 @@ def test_invoked_chain_head_is_not_a_property_read(tmp_path: Path) -> None:
     }
     rels = _rels(_run(tmp_path, files))
     assert not _has(rels, ".Screen.fill", REFERENCES, ".Screen._wonders"), rels
+    assert _has(rels, ".Screen.fill", "CALLS", ".Screen._wonders"), rels

--- a/codebase_rag/tests/test_dart_tearoff_references.py
+++ b/codebase_rag/tests/test_dart_tearoff_references.py
@@ -211,3 +211,28 @@ def test_constructor_argument_direct_tearoff_is_referenced(tmp_path: Path) -> No
     }
     rels = _run_rels(tmp_path, files)
     assert _has(rels, ".Screen.build", REFERENCES, ".Screen._handleReset"), rels
+
+
+def test_closure_argument_is_not_unwrapped_as_ternary(tmp_path: Path) -> None:
+    # A closure argument (`on: () => flag ? f : g`) IS the first-class value:
+    # the swallowed-ternary expansion must never tear a scope-opening node
+    # apart, even though `function_expression` shares the `_expression`
+    # suffix with the grammar's flat operator nodes. The grammar wraps the
+    # body in `function_expression_body`, and the expansion additionally
+    # excludes nested-scope nodes outright.
+    from codebase_rag.parsers.call_processor import _first_class_value_children
+
+    parsers, _ = load_parsers()
+    if "dart" not in parsers:
+        pytest.skip("dart parser not available")
+    tree = parsers["dart"].parse(b"void t() { render(on: () => flag ? f : g); }")
+    stack = [tree.root_node]
+    closure = None
+    while stack:
+        node = stack.pop()
+        if node.type == cs.TS_DART_FUNCTION_EXPRESSION:
+            closure = node
+            break
+        stack.extend(node.named_children)
+    assert closure is not None
+    assert _first_class_value_children(closure, is_dart=True) is None

--- a/codebase_rag/tests/test_dart_tearoff_references.py
+++ b/codebase_rag/tests/test_dart_tearoff_references.py
@@ -168,3 +168,46 @@ def test_map_and_set_literal_tearoffs_are_referenced(tmp_path: Path) -> None:
     assert _has(rels, ".Table.register", REFERENCES, ".Table.onDrag"), rels
     assert _has(rels, ".Table.register", REFERENCES, ".Table.onSetA"), rels
     assert _has(rels, ".Table.register", REFERENCES, ".Table.onTyped"), rels
+
+
+def test_constructor_argument_ternary_tearoff_is_referenced(tmp_path: Path) -> None:
+    # A tear-off inside a ternary handed to a RESOLVABLE constructor
+    # (`Footer(onReset: cond ? _handleReset : null)`) is stored by the
+    # constructed object and invoked later; issue #873's second repro
+    # (wonderous `_CollectionScreenState._handleReset`).
+    files = {
+        "app.dart": (
+            "class Footer {\n"
+            "  final void Function()? onReset;\n"
+            "  Footer({this.onReset});\n"
+            "}\n"
+            "class Screen {\n"
+            "  void _handleReset() {}\n"
+            "  Footer build(int discovered, int explored) {\n"
+            "    return Footer(onReset: discovered + explored > 0"
+            " ? _handleReset : null);\n"
+            "  }\n"
+            "}\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files)
+    assert _has(rels, ".Screen.build", REFERENCES, ".Screen._handleReset"), rels
+
+
+def test_constructor_argument_direct_tearoff_is_referenced(tmp_path: Path) -> None:
+    files = {
+        "app.dart": (
+            "class Footer {\n"
+            "  final void Function()? onReset;\n"
+            "  Footer({this.onReset});\n"
+            "}\n"
+            "class Screen {\n"
+            "  void _handleReset() {}\n"
+            "  Footer build() {\n"
+            "    return Footer(onReset: _handleReset);\n"
+            "  }\n"
+            "}\n"
+        ),
+    }
+    rels = _run_rels(tmp_path, files)
+    assert _has(rels, ".Screen.build", REFERENCES, ".Screen._handleReset"), rels

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.450"
+version = "0.0.451"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Emit Dart getter REFERENCES for receiver-position chain heads (`_wonders.length` reads the `_wonders` getter); the head exclusion now only covers direct invocations, and Dart joins C#/C++ in the no-calls early-return exemption so getters-only files still run the per-method read pass.
- Expand ternary constructor arguments swallowed by tree-sitter-dart's low-precedence operator parse (`Footer(onReset: a + b > 0 ? _handleReset : null)` parses the conditional INSIDE `additive_expression`), with scope-opening nodes excluded so closures stay intact first-class values.
- Wonderous dead-code goes 23 to 21: `_wonders` and `_handleReset` clear; `_runSuggestions` (genuine), `_GridBtn._btnSize` (#875) and the 19 C++ items (#871) correctly remain.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD or tooling
- [ ] Dependencies

## Related Issues

Fixes #873. The `_btnSize` residual triaged there is filed separately as #875.

## Test Plan

- [x] Unit tests pass (`uv run pytest -n auto codebase_rag/tests/`, 5839 passed)
- [x] New tests added (RED demonstrated: 4e60e8c0 fails before 95acebca; the round-2 guard is defence-in-depth whose failing shape the grammar cannot produce, so its test pins the invariant directly)
- [ ] Integration tests pass (`make test-integration`, requires Docker)
- [x] Manual testing (full wonderous re-index and dead-code report on this branch, 23 to 21 with exactly the two issue repros clearing)

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [x] Comments follow the repo's constraint-only convention
