### PR TITLE
fix: scope endpoint identity by project and honour the URL host when linking

### DIFF
--- a/codebase_rag/parsers/endpoints.py
+++ b/codebase_rag/parsers/endpoints.py
@@ -349,9 +349,7 @@ def link_endpoints(ingestor: QueryProtocol) -> int:
             # Legacy rows carry no project and stay linkable even when the
             # host pins a scoped project (partially migrated graphs).
             legacy = {
-                qn
-                for qn, (_identity, project) in endpoints.items()
-                if project is None
+                qn for qn, (_identity, project) in endpoints.items() if project is None
             }
             candidates = owned | legacy
         else:

--- a/codebase_rag/parsers/endpoints.py
+++ b/codebase_rag/parsers/endpoints.py
@@ -35,9 +35,12 @@ CYPHER_LIVE_NETWORK_RESOURCES = (
 CYPHER_LIVE_ENDPOINT_RESOURCES = (
     "MATCH ()-[:EXPOSES]->(r:Resource {kind: 'ENDPOINT'}) "
     "RETURN DISTINCT r.qualified_name AS qualified_name, "
-    "r.name AS name, r.kind AS kind"
+    "r.name AS name, r.kind AS kind, r.project AS project"
 )
 CYPHER_DELETE_RESOLVES_TO = "MATCH ()-[r:RESOLVES_TO]->() DELETE r"
+
+KEY_PROJECT = "project"
+_PROJECT_HASH_SEPARATOR = "__"
 
 _HTTP_METHOD_NAMES = frozenset(
     {"get", "post", "put", "patch", "delete", "head", "options", "websocket"}
@@ -190,11 +193,16 @@ def emit_endpoints(
                 resolved = prefix_resolver(module_qn, receiver)
                 if resolved:
                     prefixes = resolved
+        # The qn is scoped by owning project (EXPOSES always comes from
+        # within one), so same-template endpoints in different services stay
+        # distinct nodes and host-aware linking can tell them apart (#879).
+        project = qualified_name.split(cs.SEPARATOR_DOT, 1)[0]
         for method, path in pairs:
             for prefix in prefixes:
                 identity = f"{method} {prefix}{path}"
                 resource_qn = RESOURCE_QN_FORMAT.format(
-                    kind=ResourceKind.ENDPOINT.value, identity=identity
+                    kind=ResourceKind.ENDPOINT.value,
+                    identity=f"{project}::{identity}",
                 )
                 ingestor.ensure_node_batch(
                     cs.NodeLabel.RESOURCE,
@@ -202,6 +210,7 @@ def emit_endpoints(
                         cs.KEY_QUALIFIED_NAME: resource_qn,
                         cs.KEY_NAME: identity,
                         KEY_KIND: ResourceKind.ENDPOINT.value,
+                        KEY_PROJECT: project,
                     },
                 )
                 ingestor.ensure_relationship_batch(
@@ -213,11 +222,11 @@ def emit_endpoints(
 
 def _collect_live_resources(
     ingestor: QueryProtocol,
-) -> tuple[dict[str, str], dict[str, str]]:
+) -> tuple[dict[str, str], dict[str, tuple[str, str | None]]]:
     from .io_access.constants import DYNAMIC_TARGET, KEY_KIND, ResourceKind
 
     networks: dict[str, str] = {}
-    endpoints: dict[str, str] = {}
+    endpoints: dict[str, tuple[str, str | None]] = {}
     for query in (CYPHER_LIVE_NETWORK_RESOURCES, CYPHER_LIVE_ENDPOINT_RESOURCES):
         for row in ingestor.fetch_all(query):
             qn = row.get(cs.KEY_QUALIFIED_NAME)
@@ -228,8 +237,21 @@ def _collect_live_resources(
             if kind == ResourceKind.NETWORK.value and name != DYNAMIC_TARGET:
                 networks[qn] = name
             elif kind == ResourceKind.ENDPOINT.value:
-                endpoints[qn] = name
+                project = row.get(KEY_PROJECT)
+                endpoints[qn] = (name, project if isinstance(project, str) else None)
     return networks, endpoints
+
+
+def _host_stem(url: str) -> str | None:
+    host = urlparse(url).hostname
+    return host.lower().replace("_", "-") if host else None
+
+
+def _project_stem(project: str) -> str:
+    # `user-service__2adc9027` deploys as host `user-service` (compose and
+    # cluster DNS use the service name); underscores and dashes are
+    # interchangeable across compose file and directory conventions.
+    return project.split(_PROJECT_HASH_SEPARATOR, 1)[0].lower().replace("_", "-")
 
 
 def link_endpoints(ingestor: QueryProtocol) -> int:
@@ -239,8 +261,10 @@ def link_endpoints(ingestor: QueryProtocol) -> int:
     links to every endpoint whose template matches its URL path. Matching
     is method-agnostic: the request method lives on the sink edge, not in
     the Resource identity. Templates without a literal segment are skipped
-    entirely; they would match any same-length URL path. Returns the number
-    of edges emitted.
+    entirely; they would match any same-length URL path. When the URL's
+    hostname names an indexed project, only that project's endpoints are
+    candidates; an unmatched host keeps the full fan-out. Returns the
+    number of edges emitted.
     """
     ingestor.execute_write(CYPHER_DELETE_RESOLVES_TO)
     networks, endpoints = _collect_live_resources(ingestor)
@@ -250,7 +274,15 @@ def link_endpoints(ingestor: QueryProtocol) -> int:
     writer = cast("IngestorProtocol", ingestor)
     created = 0
     for network_qn, url in networks.items():
-        for endpoint_qn, identity in endpoints.items():
+        host = _host_stem(url)
+        owned = {
+            qn
+            for qn, (_identity, project) in endpoints.items()
+            if project is not None and _project_stem(project) == host
+        }
+        candidates = owned if owned else set(endpoints)
+        for endpoint_qn in candidates:
+            identity, _project = endpoints[endpoint_qn]
             _, _, template = identity.partition(" ")
             if (
                 template

--- a/codebase_rag/parsers/endpoints.py
+++ b/codebase_rag/parsers/endpoints.py
@@ -314,8 +314,9 @@ def _host_stem(url: str) -> str | None:
 def _project_stem(project: str) -> str:
     # `user-service__2adc9027` deploys as host `user-service` (compose and
     # cluster DNS use the service name); underscores and dashes are
-    # interchangeable across compose file and directory conventions.
-    return project.split(_PROJECT_HASH_SEPARATOR, 1)[0].lower().replace("_", "-")
+    # interchangeable across compose file and directory conventions. Only
+    # the LAST separator is the hash suffix; a base name may contain `__`.
+    return project.rsplit(_PROJECT_HASH_SEPARATOR, 1)[0].lower().replace("_", "-")
 
 
 def link_endpoints(ingestor: QueryProtocol) -> int:
@@ -344,7 +345,17 @@ def link_endpoints(ingestor: QueryProtocol) -> int:
             for qn, (_identity, project) in endpoints.items()
             if project is not None and _project_stem(project) == host
         }
-        candidates = owned if owned else set(endpoints)
+        if owned:
+            # Legacy rows carry no project and stay linkable even when the
+            # host pins a scoped project (partially migrated graphs).
+            legacy = {
+                qn
+                for qn, (_identity, project) in endpoints.items()
+                if project is None
+            }
+            candidates = owned | legacy
+        else:
+            candidates = set(endpoints)
         for endpoint_qn in candidates:
             identity, _project = endpoints[endpoint_qn]
             method, _, template = identity.partition(" ")

--- a/codebase_rag/tests/test_endpoint_extraction.py
+++ b/codebase_rag/tests/test_endpoint_extraction.py
@@ -101,9 +101,10 @@ class TestEmitEndpoints:
         ingestor.ensure_node_batch.assert_called_once_with(
             cs.NodeLabel.RESOURCE,
             {
-                "qualified_name": "resource::ENDPOINT::GET /users/{id}",
+                "qualified_name": "resource::ENDPOINT::user-service::GET /users/{id}",
                 "name": "GET /users/{id}",
                 "kind": "ENDPOINT",
+                "project": "user-service",
             },
         )
         ingestor.ensure_relationship_batch.assert_called_once_with(
@@ -112,7 +113,7 @@ class TestEmitEndpoints:
             (
                 cs.NodeLabel.RESOURCE,
                 "qualified_name",
-                "resource::ENDPOINT::GET /users/{id}",
+                "resource::ENDPOINT::user-service::GET /users/{id}",
             ),
         )
 

--- a/codebase_rag/tests/test_endpoint_extraction.py
+++ b/codebase_rag/tests/test_endpoint_extraction.py
@@ -531,34 +531,32 @@ class TestHostAwareLinking:
 
 
 class TestHostAwareLinkingHardening:
-    _network = TestHostAwareLinking._network
-    _endpoint = TestHostAwareLinking._endpoint
-    _link = TestHostAwareLinking._link
-
     def test_legacy_rows_stay_linkable_when_host_matches_a_project(self) -> None:
         # A partially migrated graph: the host matches a scoped project, but
         # a matching legacy (project-less) endpoint must not be dropped.
-        created, _ = self._link(
-            self,
+        helper = TestHostAwareLinking()
+        created, _ = helper._link(
             [
-                self._network("http://user-service:8000/users/42"),
-                self._endpoint("user-service__2ad", "GET /users/{id}"),
+                TestHostAwareLinking._network("http://user-service:8000/users/42"),
+                TestHostAwareLinking._endpoint("user-service__2ad", "GET /users/{id}"),
                 {
                     "qualified_name": "resource::ENDPOINT::GET /users/{id}",
                     "name": "GET /users/{id}",
                     "kind": "ENDPOINT",
                 },
-            ],
+            ]
         )
         assert created == 2
 
     def test_project_stem_keeps_double_underscore_base_names(self) -> None:
-        created, _ = self._link(
-            self,
+        helper = TestHostAwareLinking()
+        created, _ = helper._link(
             [
-                self._network("http://order--worker:8000/jobs/5"),
-                self._endpoint("order__worker__2adc9027", "GET /jobs/{id}"),
-                self._endpoint("other__9f9f9f9f", "GET /jobs/{id}"),
-            ],
+                TestHostAwareLinking._network("http://order--worker:8000/jobs/5"),
+                TestHostAwareLinking._endpoint(
+                    "order__worker__2adc9027", "GET /jobs/{id}"
+                ),
+                TestHostAwareLinking._endpoint("other__9f9f9f9f", "GET /jobs/{id}"),
+            ]
         )
         assert created == 1

--- a/codebase_rag/tests/test_endpoint_extraction.py
+++ b/codebase_rag/tests/test_endpoint_extraction.py
@@ -8,9 +8,9 @@ can resolve to.
 
 from __future__ import annotations
 
-import pytest
-
 from unittest.mock import MagicMock
+
+import pytest
 
 from codebase_rag import constants as cs
 from codebase_rag.parsers.endpoints import parse_route_decorator

--- a/codebase_rag/tests/test_endpoint_extraction.py
+++ b/codebase_rag/tests/test_endpoint_extraction.py
@@ -550,7 +550,7 @@ class TestHostAwareLinkingHardening:
 
     def test_project_stem_keeps_double_underscore_base_names(self) -> None:
         helper = TestHostAwareLinking()
-        created, _ = helper._link(
+        created, ingestor = helper._link(
             [
                 TestHostAwareLinking._network("http://order--worker:8000/jobs/5"),
                 TestHostAwareLinking._endpoint(
@@ -560,3 +560,5 @@ class TestHostAwareLinkingHardening:
             ]
         )
         assert created == 1
+        target = ingestor.ensure_relationship_batch.call_args.args[2][2]
+        assert "order__worker__2adc9027" in target

--- a/codebase_rag/tests/test_endpoint_extraction.py
+++ b/codebase_rag/tests/test_endpoint_extraction.py
@@ -528,3 +528,37 @@ class TestHostAwareLinking:
             ]
         )
         assert created == 1
+
+
+class TestHostAwareLinkingHardening:
+    _network = TestHostAwareLinking._network
+    _endpoint = TestHostAwareLinking._endpoint
+    _link = TestHostAwareLinking._link
+
+    def test_legacy_rows_stay_linkable_when_host_matches_a_project(self) -> None:
+        # A partially migrated graph: the host matches a scoped project, but
+        # a matching legacy (project-less) endpoint must not be dropped.
+        created, _ = self._link(
+            self,
+            [
+                self._network("http://user-service:8000/users/42"),
+                self._endpoint("user-service__2ad", "GET /users/{id}"),
+                {
+                    "qualified_name": "resource::ENDPOINT::GET /users/{id}",
+                    "name": "GET /users/{id}",
+                    "kind": "ENDPOINT",
+                },
+            ],
+        )
+        assert created == 2
+
+    def test_project_stem_keeps_double_underscore_base_names(self) -> None:
+        created, _ = self._link(
+            self,
+            [
+                self._network("http://order--worker:8000/jobs/5"),
+                self._endpoint("order__worker__2adc9027", "GET /jobs/{id}"),
+                self._endpoint("other__9f9f9f9f", "GET /jobs/{id}"),
+            ],
+        )
+        assert created == 1

--- a/codebase_rag/tests/test_endpoint_extraction.py
+++ b/codebase_rag/tests/test_endpoint_extraction.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 
 import pytest
 
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
 from codebase_rag.parsers.endpoints import parse_route_decorator
 
 
@@ -324,3 +327,105 @@ class TestReviewHardening:
 
         assert "READS_FROM|WRITES_TO" in CYPHER_LIVE_NETWORK_RESOURCES
         assert "EXPOSES" in CYPHER_LIVE_ENDPOINT_RESOURCES
+
+
+class TestPerProjectEndpointIdentity:
+    def test_emit_scopes_endpoint_qn_by_project(self) -> None:
+        from codebase_rag.parsers.endpoints import emit_endpoints
+
+        ingestor = MagicMock()
+        emit_endpoints(
+            ingestor,
+            cs.NodeLabel.FUNCTION,
+            "user-service__abc.app.main.health",
+            ['@app.get("/health")'],
+        )
+        node = ingestor.ensure_node_batch.call_args.args[1]
+        assert node["qualified_name"] == (
+            "resource::ENDPOINT::user-service__abc::GET /health"
+        )
+        assert node["name"] == "GET /health"
+        assert node["project"] == "user-service__abc"
+
+
+class TestHostAwareLinking:
+    @staticmethod
+    def _network(url: str) -> dict[str, object]:
+        return {
+            "qualified_name": f"resource::NETWORK::{url}",
+            "name": url,
+            "kind": "NETWORK",
+            "directions": ["READS_FROM"],
+        }
+
+    @staticmethod
+    def _endpoint(project: str, identity: str) -> dict[str, str]:
+        return {
+            "qualified_name": f"resource::ENDPOINT::{project}::{identity}",
+            "name": identity,
+            "kind": "ENDPOINT",
+            "project": project,
+        }
+
+    def _link(self, rows: list[dict[str, object]]) -> tuple[int, object]:
+        from codebase_rag.parsers.endpoints import link_endpoints
+
+        ingestor = MagicMock()
+        ingestor.fetch_all.return_value = rows
+        return link_endpoints(ingestor), ingestor
+
+    def test_host_matching_a_project_links_only_that_project(self) -> None:
+        created, ingestor = self._link(
+            [
+                self._network("http://payment-service:8000/health"),
+                self._endpoint("payment-service__99e", "GET /health"),
+                self._endpoint("user-service__2ad", "GET /health"),
+            ]
+        )
+        assert created == 1
+        target = ingestor.ensure_relationship_batch.call_args.args[2][2]
+        assert "payment-service__99e" in target
+
+    def test_underscore_host_matches_dash_project(self) -> None:
+        created, _ = self._link(
+            [
+                self._network("http://cast_service:8000/api/v1/casts/5/"),
+                self._endpoint("cast-service__1a2", "GET /api/v1/casts/{id}/"),
+            ]
+        )
+        assert created == 1
+
+    def test_unmatched_host_keeps_fanout(self) -> None:
+        created, _ = self._link(
+            [
+                self._network("http://localhost:8000/health"),
+                self._endpoint("payment-service__99e", "GET /health"),
+                self._endpoint("user-service__2ad", "GET /health"),
+            ]
+        )
+        assert created == 2
+
+    def test_host_match_excludes_other_projects_tail_templates(self) -> None:
+        created, ingestor = self._link(
+            [
+                self._network("http://user-service:8000/users/42"),
+                self._endpoint("user-service__2ad", "GET /users/{user_id}"),
+                self._endpoint("fst__be7", "GET /**/users/{user_id}"),
+            ]
+        )
+        assert created == 1
+        target = ingestor.ensure_relationship_batch.call_args.args[2][2]
+        assert "user-service__2ad" in target
+
+    def test_legacy_rows_without_project_stay_permissive(self) -> None:
+        created, _ = self._link(
+            [
+                self._network("http://user-service:8000/health"),
+                {
+                    "qualified_name": "resource::ENDPOINT::GET /health",
+                    "name": "GET /health",
+                    "kind": "ENDPOINT",
+                },
+            ]
+        )
+        assert created == 1

--- a/codebase_rag/tests/test_endpoint_prefix_resolution.py
+++ b/codebase_rag/tests/test_endpoint_prefix_resolution.py
@@ -41,8 +41,10 @@ def _run(tmp_path: Path, files: dict[str, str]) -> set[tuple[str, str]]:
         queries=queries,
         capture=_CAPTURE_IO,
     ).run()
+    # The endpoint qn is project-scoped (resource::ENDPOINT::<project>::
+    # <identity>); the identity is the last ::-part.
     return {
-        (c.args[0][2], c.args[2][2].removeprefix("resource::ENDPOINT::"))
+        (c.args[0][2], c.args[2][2].split("::")[-1])
         for c in mock.ensure_relationship_batch.call_args_list
         if str(c.args[1]) == EXPOSES
     }


### PR DESCRIPTION
Fixes #879.

ENDPOINT resources were keyed by `METHOD /template` alone, so two services exposing `GET /health` collapsed into one shared node with EXPOSES edges from both handlers, and any matching URL's trace fanned out to every service, including ones the call can never reach. The URL names its target service in the host (compose and cluster DNS use the service name) and that evidence was discarded.

Endpoint qns are now scoped by owning project (`resource::ENDPOINT::<project>::METHOD /template`, with a `project` property; EXPOSES always comes from within one project, so the owner is known at emission). The linker became host-aware: when the URL's hostname stem matches an indexed project's name stem (hash suffix stripped, underscores and dashes interchangeable), only that project's endpoints are candidates; a host matching no project keeps the full permissive fan-out, and legacy endpoint rows without a project stay linkable. This also stops unknown-lead (`/**`) templates in one project from tail-matching another service's URLs.

Verified live on a five-project graph (three fixture services plus fastapi/full-stack-fastapi-template and paurakhsharma/python-microservice-fastapi): the health-check trace now reaches only the addressed service, and every one of the seven caller-to-handler traces is exact, with zero cross-project fabrication.

RED then GREEN in commit history; combined with the direction gate from #881 in one linker pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Endpoint resources now include project ownership metadata and use project-scoped qualified names.
  * Host-aware endpoint linking now matches endpoints using a normalized project “stem,” while preserving legacy/unscoped fallback behavior.
* **Bug Fixes**
  * Improved endpoint resolution and linking across differing host/project naming formats (including underscore vs. dash) and partially migrated graphs.
* **Tests**
  * Updated and expanded endpoint extraction, endpoint identity/prefix resolution, and host-aware linking tests, including exclusion of other-project template tail matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->