### PR TITLE
fix: render JS template-literal substitutions as URL placeholders

### DIFF
--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -67,6 +67,8 @@ TS_CAST_WRAPPER_TYPES = frozenset(
 # JS/TS ingest node types
 TS_PAIR = "pair"
 TS_OBJECT = "object"
+TS_TEMPLATE_STRING = "template_string"
+TS_TEMPLATE_SUBSTITUTION = "template_substitution"
 TS_ARRAY = "array"
 
 # When a variable_declarator's value is one of these, the variable binds the

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -1126,6 +1126,8 @@ class FlowProcessor:
                 content_type=jc.descriptor.string_content_type,
                 keyword_arg_type=jc.descriptor.keyword_arg_type,
                 wrapper_type=jc.descriptor.argument_wrapper_type,
+                template_type=jc.descriptor.template_string_type,
+                substitution_type=jc.descriptor.template_substitution_type,
             )
             for _via, taint in args:
                 if taint is None:
@@ -1440,6 +1442,8 @@ class FlowProcessor:
             content_type=jc.descriptor.string_content_type,
             keyword_arg_type=jc.descriptor.keyword_arg_type,
             wrapper_type=jc.descriptor.argument_wrapper_type,
+            template_type=jc.descriptor.template_string_type,
+            substitution_type=jc.descriptor.template_substitution_type,
         )
         return HandleBinding(kind=sink.kind, identity=identity)
 

--- a/codebase_rag/parsers/io_access/descriptor.py
+++ b/codebase_rag/parsers/io_access/descriptor.py
@@ -114,12 +114,18 @@ class LanguageDescriptor:
     # with the expression unfielded). Lets the handle-binding walk read the RHS.
     # False for every language whose value is field-labelled.
     declarator_value_is_last_child: bool = False
+    # Interpolated-string node types (JS/TS template literals); substitutions
+    # render as placeholders in captured resource identities (issue #884).
+    template_string_type: str | None = None
+    template_substitution_type: str | None = None
 
 
 _JS_TS_DESCRIPTOR = LanguageDescriptor(
     call_type=cs.TS_CALL_EXPRESSION,
     string_type=cs.TS_STRING,
     string_content_type=cs.TS_STRING_FRAGMENT,
+    template_string_type=cs.TS_TEMPLATE_STRING,
+    template_substitution_type=cs.TS_TEMPLATE_SUBSTITUTION,
     keyword_arg_type=None,
     nested_scope_types=frozenset(
         {

--- a/codebase_rag/parsers/io_access/extract.py
+++ b/codebase_rag/parsers/io_access/extract.py
@@ -179,12 +179,45 @@ _URL_STRUCTURE_DELIMITERS = "/?#"
 OPAQUE_PLACEHOLDER = "{*}"
 
 
+def _template_literal(arg: Node, content_type: str, substitution_type: str) -> str:
+    # A JS/TS template literal: fragments stay verbatim and each
+    # `${expr}` substitution renders as a `{expr}` placeholder, mirroring
+    # the Python f-string treatment (issue #884). All-substitution
+    # templates carry no identity and stay dynamic.
+    parts: list[str] = []
+    has_content = False
+    for child in arg.named_children:
+        if child.text is None:
+            continue
+        if child.type == content_type:
+            has_content = True
+            parts.append(child.text.decode(cs.ENCODING_UTF8))
+        elif child.type == substitution_type:
+            inner = child.text.decode(cs.ENCODING_UTF8)[2:-1]
+            safe = not any(delim in inner for delim in _URL_STRUCTURE_DELIMITERS)
+            parts.append(f"{{{inner}}}" if safe else OPAQUE_PLACEHOLDER)
+    if not has_content:
+        return DYNAMIC_TARGET
+    return "".join(parts)
+
+
 def string_literal(
     arg: Node | None,
     string_type: str = cs.TS_PY_STRING,
     content_type: str = cs.TS_PY_STRING_CONTENT,
+    *,
+    template_type: str | None = None,
+    substitution_type: str | None = None,
 ) -> str:
-    if arg is None or arg.type != string_type:
+    if arg is None:
+        return DYNAMIC_TARGET
+    if (
+        template_type is not None
+        and substitution_type is not None
+        and arg.type == template_type
+    ):
+        return _template_literal(arg, content_type, substitution_type)
+    if arg.type != string_type:
         return DYNAMIC_TARGET
     # An f-string is a `string` node whose content is split around
     # `interpolation` children; keep every fragment and render each
@@ -414,6 +447,8 @@ def literal_target(
     content_type: str = cs.TS_PY_STRING_CONTENT,
     keyword_arg_type: str | None = cs.TS_PY_KEYWORD_ARGUMENT,
     wrapper_type: str | None = None,
+    template_type: str | None = None,
+    substitution_type: str | None = None,
 ) -> str:
     if arg_index is None and arg_keyword is None:
         return DYNAMIC_TARGET
@@ -425,7 +460,13 @@ def literal_target(
     if arg_keyword is not None and wrapper_type is not None:
         named = _wrapper_keyword_value(args, arg_keyword, wrapper_type)
         if named is not None:
-            return string_literal(named, string_type, content_type)
+            return string_literal(
+                named,
+                string_type,
+                content_type,
+                template_type=template_type,
+                substitution_type=substitution_type,
+            )
     # Exclude keyword args, comment nodes (tree-sitter keeps comments as named
     # children), and C# named-argument wrappers so the positional index maps to the
     # real positional argument.
@@ -440,9 +481,15 @@ def literal_target(
             unwrap_argument(positional[arg_index], wrapper_type),
             string_type,
             content_type,
+            template_type=template_type,
+            substitution_type=substitution_type,
         )
     if arg_keyword is not None:
         return string_literal(
-            keyword_value(args, arg_keyword), string_type, content_type
+            keyword_value(args, arg_keyword),
+            string_type,
+            content_type,
+            template_type=template_type,
+            substitution_type=substitution_type,
         )
     return DYNAMIC_TARGET

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -1082,6 +1082,8 @@ class IOAccessProcessor:
             content_type=descriptor.string_content_type,
             keyword_arg_type=descriptor.keyword_arg_type,
             wrapper_type=descriptor.argument_wrapper_type,
+            template_type=descriptor.template_string_type,
+            substitution_type=descriptor.template_substitution_type,
         )
         direction = sink.direction
         if sink.method_options_arg is not None:

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -1500,6 +1500,8 @@ class IOAccessProcessor:
             content_type=descriptor.string_content_type,
             keyword_arg_type=descriptor.keyword_arg_type,
             wrapper_type=descriptor.argument_wrapper_type,
+            template_type=descriptor.template_string_type,
+            substitution_type=descriptor.template_substitution_type,
         )
         if identity != DYNAMIC_TARGET or ctor.target_arg != 0:
             return identity
@@ -1538,6 +1540,8 @@ class IOAccessProcessor:
             content_type=descriptor.string_content_type,
             keyword_arg_type=descriptor.keyword_arg_type,
             wrapper_type=descriptor.argument_wrapper_type,
+            template_type=descriptor.template_string_type,
+            substitution_type=descriptor.template_substitution_type,
         )
 
     @staticmethod

--- a/codebase_rag/tests/test_io_access_js_imports.py
+++ b/codebase_rag/tests/test_io_access_js_imports.py
@@ -330,3 +330,24 @@ class TestTemplateLiteralUrls:
             READS_FROM,
             "resource::NETWORK::http://svc:8000/products/{*}",
         ), rels
+
+    def test_handle_constructor_template_keeps_placeholder(
+        self, tmp_path: Path
+    ) -> None:
+        # Identity must not depend on the analysis path: the handle
+        # constructor reads templates exactly like direct sinks.
+        rels = _run_io_directed(
+            tmp_path,
+            {
+                "m.js": (
+                    "import fs from 'fs'\n\n"
+                    "export function log(date, line) {\n"
+                    "  const s = fs.createWriteStream(`logs/${date}.txt`)\n"
+                    "  s.write(line)\n"
+                    "}\n"
+                )
+            },
+        )
+        assert _edge(
+            rels, "m.log", WRITES_TO, "resource::FILE::logs/{date}.txt"
+        ), rels

--- a/codebase_rag/tests/test_io_access_js_imports.py
+++ b/codebase_rag/tests/test_io_access_js_imports.py
@@ -348,6 +348,4 @@ class TestTemplateLiteralUrls:
                 )
             },
         )
-        assert _edge(
-            rels, "m.log", WRITES_TO, "resource::FILE::logs/{date}.txt"
-        ), rels
+        assert _edge(rels, "m.log", WRITES_TO, "resource::FILE::logs/{date}.txt"), rels

--- a/codebase_rag/tests/test_io_access_js_imports.py
+++ b/codebase_rag/tests/test_io_access_js_imports.py
@@ -255,3 +255,78 @@ class TestFetchMethodOption:
         )
         assert _edge(rels, "m.send", READS_FROM, self.RESOURCE), rels
         assert _edge(rels, "m.send", WRITES_TO, self.RESOURCE), rels
+
+
+class TestTemplateLiteralUrls:
+    """A template literal is the dominant way JS clients build URLs; its
+    interpolations must become placeholders, not discard the whole URL
+    (issue #884, the JS analogue of the Python f-string fix).
+    """
+
+    def test_fetch_template_literal_keeps_placeholder(self, tmp_path: Path) -> None:
+        rels = _run_io_directed(
+            tmp_path,
+            {
+                "m.js": (
+                    "export function load(productId) {\n"
+                    "  return fetch(`http://svc:8000/products/${productId}`)\n"
+                    "}\n"
+                )
+            },
+        )
+        assert _edge(
+            rels,
+            "m.load",
+            READS_FROM,
+            "resource::NETWORK::http://svc:8000/products/{productId}",
+        ), rels
+
+    def test_axios_template_literal_keeps_placeholder(self, tmp_path: Path) -> None:
+        rels = _run_io_directed(
+            tmp_path,
+            {
+                "m.js": (
+                    "import axios from 'axios'\n\n"
+                    "export function stock(id) {\n"
+                    "  return axios.get(`http://svc:8000/products/${id}/stock`)\n"
+                    "}\n"
+                )
+            },
+        )
+        assert _edge(
+            rels,
+            "m.stock",
+            READS_FROM,
+            "resource::NETWORK::http://svc:8000/products/{id}/stock",
+        ), rels
+
+    def test_all_interpolation_template_stays_dynamic(self, tmp_path: Path) -> None:
+        rels = _run_io_directed(
+            tmp_path,
+            {
+                "m.js": (
+                    "export function go(base, path) {\n"
+                    "  return fetch(`${base}${path}`)\n"
+                    "}\n"
+                )
+            },
+        )
+        assert _edge(rels, "m.go", READS_FROM, "resource::NETWORK::<dynamic>"), rels
+
+    def test_delimiter_bearing_substitution_collapses(self, tmp_path: Path) -> None:
+        rels = _run_io_directed(
+            tmp_path,
+            {
+                "m.js": (
+                    "export function page(offset, limit) {\n"
+                    "  return fetch(`http://svc:8000/products/${offset / limit}`)\n"
+                    "}\n"
+                )
+            },
+        )
+        assert _edge(
+            rels,
+            "m.page",
+            READS_FROM,
+            "resource::NETWORK::http://svc:8000/products/{*}",
+        ), rels

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.454"
+version = "0.0.456"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Fixes #884.

A JS template literal is a `template_string` node, not the plain `string` the literal reader accepts, so `` fetch(`http://catalog-service:8000/products/${productId}`) `` was captured as `<dynamic>` and the dominant way JS clients build URLs could never resolve to an endpoint.

The reader now recognises template literals through two new descriptor fields (JS and TS share the descriptor): fragments stay verbatim and each `${expr}` substitution renders as a `{expr}` placeholder, mirroring the Python f-string treatment from #876. A substitution whose expression contains `/`, `?` or `#` collapses to the opaque `{*}` placeholder so it cannot fabricate segment structure, and an all-substitution template stays `<dynamic>` because placeholders alone carry no identity. Every other language path is untouched (the template fields default to absent).

Verified live on a polyglot graph: the fetch and axios template-literal URLs now RESOLVES_TO the correct FastAPI endpoints across languages (`.../products/{productId}` to `GET /products/{product_id}`), joining the literal-URL and `{method: 'POST'}` cases that already worked.

RED then GREEN in commit history.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved JavaScript and TypeScript IO/flow analysis for template-literal URLs.
  * Preserves interpolation placeholders in derived resource paths (e.g., `{id}`) and uses wildcard placeholders for complex substitutions.
  * Treats fully interpolated template URLs as dynamic.
* **Bug Fixes**
  * Improved consistency when matching resources passed through `fetch`, Axios, and related calls, including constructor-style sinks like file writes.
  * Ensures template literals are handled consistently across read-source and write-sink identity detection.
* **Tests**
  * Added coverage for template-literal URL placeholder preservation and dynamic template behavior in JS/TS import IO analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->