### PR TITLE
fix(dart): bind undeclared receivers via the external base's type arguments

### DIFF
--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -652,7 +652,14 @@ class CallResolver:
         if result := self._resolve_js_prototype_sibling(call_name, caller_qn, language):
             return result
 
-        use_cache = not local_var_types
+        # The cache is keyed by (call_name, module_qn) only, so a caller whose
+        # class carries extends-clause type arguments must bypass it: its
+        # member resolution is class-context-dependent (#875) and a sibling
+        # class's cached answer for the same name would be wrong.
+        use_cache = not local_var_types and not (
+            language == cs.SupportedLanguage.DART
+            and class_context in self.type_inference.dart_extends_type_args
+        )
         if use_cache:
             cache_key = (call_name, module_qn)
             if cache_key in self._simple_resolution_cache:
@@ -745,6 +752,12 @@ class CallResolver:
         if (
             language in cs.JS_TS_LANGUAGES or language == cs.SupportedLanguage.DART
         ) and cs.SEPARATOR_DOT in call_name:
+            if language == cs.SupportedLanguage.DART and (
+                result := self._resolve_dart_external_base_arg_member(
+                    call_name, class_context, local_var_types
+                )
+            ):
+                return result
             result = self._resolve_js_member_call_unique(call_name, module_qn)
             if use_cache:
                 self._simple_resolution_cache[cache_key] = result
@@ -754,6 +767,45 @@ class CallResolver:
         if use_cache:
             self._simple_resolution_cache[cache_key] = result
         return result
+
+    def _resolve_dart_external_base_arg_member(
+        self,
+        call_name: str,
+        class_context: str | None,
+        local_var_types: dict[str, str] | None,
+    ) -> tuple[str, str] | None:
+        # `recv.member(...)` on a receiver undeclared in first-party scope,
+        # inside a class extending an EXTERNAL generic base: the only
+        # first-party types the base can hand back are its type arguments
+        # (`State<GridBtn>.widget` is a GridBtn), so bind when exactly one
+        # argument's class defines the member (issue #875). A first-party
+        # base, a declared receiver, or an own member named like the
+        # receiver all fall through to the unique-member gate instead.
+        if not class_context:
+            return None
+        type_args = self.type_inference.dart_extends_type_args.get(class_context)
+        if not type_args:
+            return None
+        receiver, sep, member = call_name.partition(cs.SEPARATOR_DOT)
+        if not sep or cs.SEPARATOR_DOT in member:
+            return None
+        if local_var_types and receiver in local_var_types:
+            return None
+        if f"{class_context}{cs.SEPARATOR_DOT}{receiver}" in self.function_registry:
+            return None
+        bases = self.class_inheritance.get(class_context)
+        # resolve_deferred_inherits rewrote bases in place, so a registered
+        # bases[0] means a first-party extends base owns its members.
+        if not bases or self.function_registry.get(bases[0]) is not None:
+            return None
+        matches = [
+            qn
+            for arg_qn in dict.fromkeys(type_args)
+            if (qn := f"{arg_qn}{cs.SEPARATOR_DOT}{member}") in self.function_registry
+        ]
+        if len(matches) == 1:
+            return self.function_registry[matches[0]], matches[0]
+        return None
 
     def _resolve_js_member_call_unique(
         self, call_name: str, module_qn: str

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -779,8 +779,10 @@ class CallResolver:
         # first-party types the base can hand back are its type arguments
         # (`State<GridBtn>.widget` is a GridBtn), so bind when exactly one
         # argument's class defines the member (issue #875). A first-party
-        # base, a declared receiver, or an own member named like the
-        # receiver all fall through to the unique-member gate instead.
+        # base, a declared receiver, or a member named like the receiver on
+        # the class or ANY registered ancestor (a first-party mixin's getter
+        # is inherited, not handed back by the external base) all fall
+        # through to the unique-member gate instead.
         if not class_context:
             return None
         type_args = self.type_inference.dart_extends_type_args.get(class_context)
@@ -791,7 +793,7 @@ class CallResolver:
             return None
         if local_var_types and receiver in local_var_types:
             return None
-        if f"{class_context}{cs.SEPARATOR_DOT}{receiver}" in self.function_registry:
+        if self._dart_registered_member_named(class_context, receiver):
             return None
         bases = self.class_inheritance.get(class_context)
         # resolve_deferred_inherits rewrote bases in place, so a registered
@@ -806,6 +808,23 @@ class CallResolver:
         if len(matches) == 1:
             return self.function_registry[matches[0]], matches[0]
         return None
+
+    def _dart_registered_member_named(self, class_qn: str, name: str) -> bool:
+        # True when the class or any registered first-party ancestor
+        # (extends base or `with` mixin, both in class_inheritance) defines
+        # a member with this name. Dart `implements` contributes interface
+        # only, never implementation, so it cannot supply a receiver.
+        seen: set[str] = set()
+        stack = [class_qn]
+        while stack:
+            current = stack.pop()
+            if current in seen:
+                continue
+            seen.add(current)
+            if f"{current}{cs.SEPARATOR_DOT}{name}" in self.function_registry:
+                return True
+            stack.extend(self.class_inheritance.get(current, ()))
+        return False
 
     def _resolve_js_member_call_unique(
         self, call_name: str, module_qn: str

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -46,6 +46,7 @@ from . import cpp_modules
 from . import identity as id_
 from . import method_override as mo
 from . import node_type as nt
+from . import parent_extraction as pe
 from . import relationships as rel
 from .utils import csharp_has_override_modifier
 
@@ -149,6 +150,7 @@ class ClassIngestMixin:
     import_processor: ImportProcessor
     class_inheritance: dict[str, list[str]]
     dart_annotated_overrides: dict[str, list[tuple[str, str]]]
+    dart_extends_type_args: dict[str, list[str]]
     class_field_types: dict[str, dict[str, str]]
     java_anon_overrides: list[tuple[str, str, str, str]]
     csharp_methods: set[str]
@@ -925,6 +927,12 @@ class ClassIngestMixin:
             defer_inherits=self._deferred_inherits,
             csharp_base_kinds=csharp_base_kinds,
         )
+        if language == cs.SupportedLanguage.DART and (
+            type_args := pe.extract_dart_extends_type_args(
+                member_node, module_qn, self._resolve_to_qn
+            )
+        ):
+            self.dart_extends_type_args[class_qn] = type_args
         if language == cs.SupportedLanguage.CPP:
             # Record this class's member-field types now (from the class body,
             # usually a header) so out-of-line method bodies in other files can
@@ -1476,8 +1484,6 @@ class ClassIngestMixin:
         )
 
     def _extract_cpp_base_class_name(self, parent_text: str) -> str:
-        from . import parent_extraction as pe
-
         return pe.extract_cpp_base_class_name(parent_text)
 
     def _get_node_type_for_inheritance(self, qualified_name: str) -> str:

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -48,7 +48,7 @@ from . import method_override as mo
 from . import node_type as nt
 from . import parent_extraction as pe
 from . import relationships as rel
-from .utils import csharp_has_override_modifier
+from .utils import csharp_has_override_modifier, find_child_by_type
 
 if TYPE_CHECKING:
     from ...services import IngestorProtocol
@@ -1150,6 +1150,11 @@ class ClassIngestMixin:
         module_qn: str | None = None,
     ) -> None:
         body_node = class_node.child_by_field_name("body")
+        if body_node is None and class_node.type == cs.TS_DART_MIXIN_DECLARATION:
+            # mixin_declaration is the one Dart type declaration whose
+            # class_body is a positional child, not a `body` field; without
+            # this fallback a mixin's members silently vanish.
+            body_node = find_child_by_type(class_node, cs.TS_DART_CLASS_BODY)
         if not body_node:
             return
 

--- a/codebase_rag/parsers/class_ingest/parent_extraction.py
+++ b/codebase_rag/parsers/class_ingest/parent_extraction.py
@@ -241,12 +241,28 @@ def extract_dart_extends_type_args(
     type_args = find_child_by_type(superclass, cs.TS_DART_TYPE_ARGUMENTS)
     if type_args is None:
         return []
-    return [
-        resolve_to_qn(name, module_qn)
-        for child in type_args.named_children
-        if child.type == cs.TS_DART_TYPE_IDENTIFIER
-        and (name := safe_decode_text(child))
-    ]
+    # An import-prefixed argument (`State<models.GridBtn>`) is two FLAT
+    # sibling type_identifiers, distinguishable from a two-argument list
+    # (`Pair<A, B>`) only by the joining `.` token, so walk ALL children
+    # and glue dot-joined runs into one dotted name. A nested generic's own
+    # arguments (`List<T>`) and nullable markers carry no bindable
+    # first-party identity and are skipped.
+    names: list[str] = []
+    parts: list[str] = []
+    pending_dot = False
+    for child in type_args.children:
+        if child.type == cs.TS_DART_TYPE_IDENTIFIER:
+            if parts and not pending_dot:
+                names.append(cs.SEPARATOR_DOT.join(parts))
+                parts = []
+            if name := safe_decode_text(child):
+                parts.append(name)
+            pending_dot = False
+        elif child.type == cs.SEPARATOR_DOT:
+            pending_dot = True
+    if parts:
+        names.append(cs.SEPARATOR_DOT.join(parts))
+    return [resolve_to_qn(name, module_qn) for name in names]
 
 
 def extract_cpp_parent_classes(class_node: Node, module_qn: str) -> list[str]:

--- a/codebase_rag/parsers/class_ingest/parent_extraction.py
+++ b/codebase_rag/parsers/class_ingest/parent_extraction.py
@@ -224,6 +224,31 @@ def extract_dart_parent_classes(
     return parents
 
 
+def extract_dart_extends_type_args(
+    class_node: Node,
+    module_qn: str,
+    resolve_to_qn: Callable[[str, str], str],
+) -> list[str]:
+    # `extends Base<T, U>`: the clause's type arguments resolved to qns, so
+    # a member call on an undeclared receiver inside the subclass can bind
+    # against the first-party types an EXTERNAL generic base hands back
+    # (`State<GridBtn>.widget` is a GridBtn, issue #875). The type_arguments
+    # child of `superclass` belongs to the extends base; a mixin's own
+    # arguments nest under `mixins` and are not collected.
+    superclass = find_child_by_type(class_node, cs.TS_DART_SUPERCLASS)
+    if superclass is None:
+        return []
+    type_args = find_child_by_type(superclass, cs.TS_DART_TYPE_ARGUMENTS)
+    if type_args is None:
+        return []
+    return [
+        resolve_to_qn(name, module_qn)
+        for child in type_args.named_children
+        if child.type == cs.TS_DART_TYPE_IDENTIFIER
+        and (name := safe_decode_text(child))
+    ]
+
+
 def extract_cpp_parent_classes(class_node: Node, module_qn: str) -> list[str]:
     return [guess for _, guess in extract_cpp_parent_bases(class_node, module_qn)]
 

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -69,6 +69,10 @@ class DefinitionProcessor(
         # whether they override an EXTERNAL base is only decidable once every
         # class is registered, so resolve_deferred_inherits consumes this.
         self.dart_annotated_overrides: dict[str, list[tuple[str, str]]] = {}
+        # {class_qn: [type_arg_qns]} for a Dart `extends Base<T, ...>` clause;
+        # read at call resolution to bind a member call on an undeclared
+        # receiver against the type arguments of an EXTERNAL base (#875).
+        self.dart_extends_type_args: dict[str, list[str]] = {}
         # {interface_qn: [implementer_class_qns]} from IMPLEMENTS edges, so the
         # resolver can redirect an interface-typed call `I.m` to the concrete
         # `Impl.m` when I has exactly one first-party implementer (unambiguous).

--- a/codebase_rag/parsers/factory.py
+++ b/codebase_rag/parsers/factory.py
@@ -136,6 +136,7 @@ class ProcessorFactory:
                 csharp_class_generic_arity=self.definition_processor.csharp_class_generic_arity,
                 csharp_method_return_types=self.definition_processor.csharp_method_return_types,
                 function_locations=self.definition_processor.function_locations,
+                dart_extends_type_args=self.definition_processor.dart_extends_type_args,
             )
         return self._type_inference
 

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -63,6 +63,7 @@ class TypeInferenceEngine:
         "_rust_type_inference",
         "_cpp_type_inference",
         "_dart_type_inference",
+        "dart_extends_type_args",
     )
 
     def __init__(
@@ -90,6 +91,7 @@ class TypeInferenceEngine:
         csharp_class_generic_arity: dict[str, int] | None = None,
         csharp_method_return_types: dict[str, tuple[str, int]] | None = None,
         function_locations: dict[FunctionSpanKey, FunctionLocation] | None = None,
+        dart_extends_type_args: dict[str, list[str]] | None = None,
     ):
         self.import_processor = import_processor
         self.function_registry = function_registry
@@ -166,6 +168,12 @@ class TypeInferenceEngine:
         )
         self.function_locations = (
             function_locations if function_locations is not None else {}
+        )
+        # Shared reference (as with class_field_types): Dart `extends Base<T>`
+        # type arguments per class qn, read by the resolver's undeclared
+        # receiver fallback (#875).
+        self.dart_extends_type_args = (
+            dart_extends_type_args if dart_extends_type_args is not None else {}
         )
 
         self._java_type_inference: JavaTypeInferenceEngine | None = None

--- a/codebase_rag/tests/test_dart_definitions.py
+++ b/codebase_rag/tests/test_dart_definitions.py
@@ -135,6 +135,10 @@ mixin Swimmer {
         s.endswith("mixed.Swimmer") and d.endswith("mixed.Swimmer.swim")
         for s, d in defines
     ), sorted(defines)
+    assert any(
+        s.endswith("mixed.Swimmer") and d.endswith("mixed.Swimmer.speed")
+        for s, d in defines
+    ), sorted(defines)
 
 
 def test_function_span_covers_body(

--- a/codebase_rag/tests/test_dart_definitions.py
+++ b/codebase_rag/tests/test_dart_definitions.py
@@ -103,6 +103,40 @@ class Repo {
         assert _endswith_any(funcs, name), f"missing {name}: {funcs}"
 
 
+def test_mixin_members_are_registered(
+    dart_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # mixin_declaration exposes NO `body` field (its class_body child is
+    # positional, unlike class_definition/enum_declaration), so method
+    # ingestion returned early and a mixin's methods and getters silently
+    # vanished from the graph (found via PR #889 review: the ancestry
+    # guard could not see a mixin's getter).
+    (dart_project / "mixed.dart").write_text(
+        """
+mixin Swimmer {
+  double get speed {
+    return 1.0;
+  }
+  void swim() {}
+}
+""",
+        encoding="utf-8",
+    )
+    run_updater(dart_project, mock_ingestor, skip_if_missing=SKIP)
+
+    methods = get_node_names(mock_ingestor, NodeType.METHOD)
+    assert _endswith_any(methods, "mixed.Swimmer.speed"), sorted(methods)
+    assert _endswith_any(methods, "mixed.Swimmer.swim"), sorted(methods)
+    defines = {
+        (str(r[0][0][2]), str(r[0][2][2]))
+        for r in get_relationships(mock_ingestor, "DEFINES_METHOD")
+    }
+    assert any(
+        s.endswith("mixed.Swimmer") and d.endswith("mixed.Swimmer.swim")
+        for s, d in defines
+    ), sorted(defines)
+
+
 def test_function_span_covers_body(
     dart_project: Path, mock_ingestor: MagicMock
 ) -> None:

--- a/codebase_rag/tests/test_dart_external_base_receiver.py
+++ b/codebase_rag/tests/test_dart_external_base_receiver.py
@@ -76,6 +76,49 @@ class ParamState extends State<GridBtn> {
     menu._btnSize(context);
   }
 }
+
+mixin Helpers {
+  OtherMenu get helper {
+    return OtherMenu();
+  }
+}
+
+class MixinState extends State<GridBtn> with Helpers {
+  void poke(BuildContext context) {
+    helper._btnSize(context);
+  }
+}
+"""
+
+MODELS_DART = """
+import 'package:flutter/material.dart';
+
+class PrefGridBtn {
+  PrefGridBtn();
+
+  double _prefSize(BuildContext context) {
+    return 1.0;
+  }
+}
+
+class PrefOtherMenu {
+  PrefOtherMenu();
+
+  double _prefSize(BuildContext context) {
+    return 2.0;
+  }
+}
+"""
+
+PREFIXED_DART = """
+import 'package:flutter/material.dart';
+import 'models.dart' as models;
+
+class PrefixedState extends State<models.PrefGridBtn> {
+  Widget build(BuildContext context) {
+    return SizedBox(width: widget._prefSize(context));
+  }
+}
 """
 
 
@@ -84,6 +127,8 @@ def dart_state_project(temp_repo: Path) -> Path:
     root = temp_repo / "dstate"
     root.mkdir()
     (root / "app.dart").write_text(APP_DART, encoding="utf-8")
+    (root / "models.dart").write_text(MODELS_DART, encoding="utf-8")
+    (root / "prefixed.dart").write_text(PREFIXED_DART, encoding="utf-8")
     return root
 
 
@@ -151,3 +196,30 @@ def test_declared_receiver_keeps_typed_resolution(
     calls = _calls(mock_ingestor)
     assert _has(calls, ".ParamState.poke", ".OtherMenu._btnSize"), sorted(calls)
     assert not _has(calls, ".ParamState.poke", ".GridBtn._btnSize"), sorted(calls)
+
+
+def test_first_party_ancestor_member_receiver_is_guarded(
+    dart_state_project: Path, mock_ingestor: MagicMock
+):
+    # `helper` is inherited from the FIRST-PARTY mixin Helpers (an
+    # OtherMenu getter), not handed back by the external base; the
+    # own-member guard must walk registered ancestry, or the fallback
+    # wrongly binds GridBtn._btnSize (Greptile round 1, T-Rex verified).
+    run_updater(dart_state_project, mock_ingestor, skip_if_missing=SKIP)
+    calls = _calls(mock_ingestor)
+    assert not _has(calls, ".MixinState.poke", ".GridBtn._btnSize"), sorted(calls)
+
+
+def test_import_prefixed_type_argument_binds(
+    dart_state_project: Path, mock_ingestor: MagicMock
+):
+    # `State<models.PrefGridBtn>` holds the prefix and the class as two
+    # FLAT sibling type_identifiers, told apart from a two-argument list
+    # only by the joining `.` token; the pair must resolve through the
+    # import alias as ONE argument, not two.
+    run_updater(dart_state_project, mock_ingestor, skip_if_missing=SKIP)
+    calls = _calls(mock_ingestor)
+    assert _has(calls, ".PrefixedState.build", ".PrefGridBtn._prefSize"), sorted(calls)
+    assert not _has(calls, ".PrefixedState.build", ".PrefOtherMenu._prefSize"), sorted(
+        calls
+    )

--- a/codebase_rag/tests/test_dart_external_base_receiver.py
+++ b/codebase_rag/tests/test_dart_external_base_receiver.py
@@ -1,0 +1,153 @@
+# Dart undeclared-receiver typing via the external superclass's type
+# arguments (issue #875): `widget._btnSize(context)` inside a class
+# extending Flutter's `State<GridBtn>` must reach `GridBtn._btnSize`.
+# The receiver `widget` is the inherited `State<T>.widget` property of an
+# EXTERNAL base, so it is undeclared in first-party scope and receiver
+# typing produces nothing; the only first-party types the external base
+# can hand back are its type arguments, so the member binds when exactly
+# one argument's class defines it. Registry guarded and conservative:
+# a first-party base, an ambiguous member, or an own member of the same
+# name all keep the edge dropped.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import run_updater
+
+SKIP = "dart"
+
+APP_DART = """
+import 'package:flutter/material.dart';
+
+class GridBtn {
+  GridBtn();
+
+  double _btnSize(BuildContext context) {
+    return 1.0;
+  }
+}
+
+class OtherMenu {
+  OtherMenu();
+
+  double _btnSize(BuildContext context) {
+    return 2.0;
+  }
+}
+
+class GridBtnState extends State<GridBtn> {
+  Widget build(BuildContext context) {
+    return SizedBox(width: widget._btnSize(context));
+  }
+}
+
+class PairState extends Pair<GridBtn, OtherMenu> {
+  void poke(BuildContext context) {
+    peer._btnSize(context);
+  }
+}
+
+class Box<T> {
+  Box();
+}
+
+class BoxSub extends Box<GridBtn> {
+  void poke(BuildContext context) {
+    mystery._btnSize(context);
+  }
+}
+
+class OwnState extends State<GridBtn> {
+  OtherMenu get helper {
+    return OtherMenu();
+  }
+
+  void poke(BuildContext context) {
+    helper._btnSize(context);
+  }
+}
+
+class ParamState extends State<GridBtn> {
+  void poke(OtherMenu menu, BuildContext context) {
+    menu._btnSize(context);
+  }
+}
+"""
+
+
+@pytest.fixture
+def dart_state_project(temp_repo: Path) -> Path:
+    root = temp_repo / "dstate"
+    root.mkdir()
+    (root / "app.dart").write_text(APP_DART, encoding="utf-8")
+    return root
+
+
+def _calls(mock_ingestor: MagicMock) -> set[tuple[str, str]]:
+    return {
+        (str(c.args[0][2]), str(c.args[2][2]))
+        for c in mock_ingestor.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) == cs.RelationshipType.CALLS.value
+    }
+
+
+def _has(edges: set[tuple[str, str]], src: str, dst: str) -> bool:
+    return any(s.endswith(src) and d.endswith(dst) for s, d in edges)
+
+
+def test_undeclared_receiver_binds_via_extends_type_argument(
+    dart_state_project: Path, mock_ingestor: MagicMock
+):
+    # The issue's repro: two first-party `_btnSize` methods defeat the
+    # unique-member gate, so only the `State<GridBtn>` type argument can
+    # bind the call.
+    run_updater(dart_state_project, mock_ingestor, skip_if_missing=SKIP)
+    calls = _calls(mock_ingestor)
+    assert _has(calls, ".GridBtnState.build", ".GridBtn._btnSize"), sorted(calls)
+    assert not _has(calls, ".GridBtnState.build", ".OtherMenu._btnSize"), sorted(calls)
+
+
+def test_ambiguous_type_arguments_drop_the_edge(
+    dart_state_project: Path, mock_ingestor: MagicMock
+):
+    # Both of Pair's type arguments define `_btnSize`: no unique owner, so
+    # the call must not bind either.
+    run_updater(dart_state_project, mock_ingestor, skip_if_missing=SKIP)
+    calls = _calls(mock_ingestor)
+    assert not _has(calls, ".PairState.poke", ".GridBtn._btnSize"), sorted(calls)
+    assert not _has(calls, ".PairState.poke", ".OtherMenu._btnSize"), sorted(calls)
+
+
+def test_first_party_base_keeps_the_fallback_conservative(
+    dart_state_project: Path, mock_ingestor: MagicMock
+):
+    # Box is first party: ordinary inheritance resolution owns its members,
+    # so the type-argument path must not fire for BoxSub's untyped receiver.
+    run_updater(dart_state_project, mock_ingestor, skip_if_missing=SKIP)
+    calls = _calls(mock_ingestor)
+    assert not _has(calls, ".BoxSub.poke", ".GridBtn._btnSize"), sorted(calls)
+
+
+def test_own_member_receiver_is_not_the_external_property(
+    dart_state_project: Path, mock_ingestor: MagicMock
+):
+    # `helper` is OwnState's OWN getter (an OtherMenu), not a member handed
+    # back by the external base; binding GridBtn._btnSize would be wrong.
+    run_updater(dart_state_project, mock_ingestor, skip_if_missing=SKIP)
+    calls = _calls(mock_ingestor)
+    assert not _has(calls, ".OwnState.poke", ".GridBtn._btnSize"), sorted(calls)
+
+
+def test_declared_receiver_keeps_typed_resolution(
+    dart_state_project: Path, mock_ingestor: MagicMock
+):
+    # A parameter-typed receiver already resolves through the local-type
+    # path; the type-argument fallback must not preempt it.
+    run_updater(dart_state_project, mock_ingestor, skip_if_missing=SKIP)
+    calls = _calls(mock_ingestor)
+    assert _has(calls, ".ParamState.poke", ".OtherMenu._btnSize"), sorted(calls)
+    assert not _has(calls, ".ParamState.poke", ".GridBtn._btnSize"), sorted(calls)

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.454"
+version = "0.0.456"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Fixes #875. A Dart member call on a bare receiver that is undeclared in first-party scope (`widget._btnSize(context)` inside a class extending Flutter's `State<GridBtn>`) never resolved: receiver typing produces nothing for the external base's inherited property, and two same-named first-party methods defeat the unique-member gate, so the invoked method reported dead.

The class's own inheritance clause already names the receiver's type. When the enclosing class extends an EXTERNAL generic base, the only first-party types that base can hand back are its type arguments, so the resolver now binds the member against the `extends` clause's type arguments when exactly one argument's class defines it. This is generic Dart semantics over the inheritance clause, not framework special-casing: any external `Base<T>` exposing a `T`-typed member produces the same shape.

## Changes

- `parent_extraction.extract_dart_extends_type_args`: resolves the `extends Base<T, ...>` clause's type arguments to qns (the `type_arguments` child of `superclass` belongs to the extends base; mixin arguments nest under `mixins` and are not collected).
- Class ingestion records them in a new shared `dart_extends_type_args` map, plumbed through `TypeInferenceEngine` like the other shared references.
- `CallResolver._resolve_dart_external_base_arg_member`: last-resort fallback ahead of the unique-member gate, guarded four ways. It fires only for a single-hop `recv.member` call where the receiver is not a typed local/parameter/field, not an own member of the enclosing class, the extends base is not a registered first-party class (checked after `resolve_deferred_inherits` rewrote `class_inheritance` in place), and exactly one type argument's class defines the member.
- The `(call_name, module_qn)` resolution cache is bypassed for callers whose class carries extends-clause type arguments, because their member resolution is class-context-dependent and a sibling class's cached answer for the same name would be wrong.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Closes #875.

## Test Plan

RED first (`d455bf48`): five tests in `test_dart_external_base_receiver.py`; the repro test fails on main, the four conservatism guards already hold and pin them:

- `test_undeclared_receiver_binds_via_extends_type_argument`: the issue's repro binds `GridBtn._btnSize`, not `OtherMenu._btnSize`.
- ambiguous type arguments (both define the member) drop the edge.
- a first-party generic base keeps the fallback out entirely.
- an own member named like the receiver is not treated as the external property.
- a declared (parameter-typed) receiver keeps ordinary typed resolution.

Full suite: 5891 passed. Live validation on flutter-wonderous-app: dead-code 21 -> 20; `_GridBtn._btnSize` cleared, `_runSuggestions` (genuinely dead) and the 19 C++ items of #871 correctly remain.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Dart member-call resolution when generic type arguments are inferred from `extends` external base classes.
  * Prevents incorrect or ambiguous bindings by adding guarded resolution behavior tied to class context.
  * Fixes handling of Dart `extends` type-argument extraction and ensures mixin members are ingested reliably.
* **Tests**
  * Added/expanded Dart test coverage for receiver binding via `extends` type arguments, ambiguity dropping, conservative fallback, own-member precedence, and import-prefixed type arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->