### PR TITLE
docs: add SkillsLLM security check badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@
   <a href="https://pepy.tech/projects/code-graph-rag">
     <img src="https://static.pepy.tech/personalized-badge/code-graph-rag?period=total&units=INTERNATIONAL_SYSTEM&left_color=BLACK&right_color=GREEN&left_text=downloads" alt="PyPI Downloads" />
   </a>
+  <a href="https://skillsllm.com/security-check/DHsMGRb1Ysys">
+    <img src="https://skillsllm.com/security-check/badge.svg?owner=vitali87&repo=code-graph-rag" alt="SkillsLLM Security Check" />
+  </a>
   <!-- OpenSSF Scorecard only tracks GitHub-hosted repos. Uncomment once the Scorecard workflow is confirmed running on the authoritative GitHub repo.
   <a href="https://scorecard.dev/viewer/?uri=github.com/vitali87/code-graph-rag">
     <img src="https://api.scorecard.dev/projects/github.com/vitali87/code-graph-rag/badge" alt="OpenSSF Scorecard" />


### PR DESCRIPTION
Adds the SkillsLLM security check badge to the README badge row, linking to the repository's security assessment at https://skillsllm.com/security-check/DHsMGRb1Ysys. The badge SVG endpoint was verified to return 200 with image/svg+xml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a SkillsLLM Security Check badge and link to the README header alongside the existing badges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->