### PR TITLE
fix(cpp): singleton accessor chain loses both onward edges

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1957,16 +1957,14 @@ class CallProcessor:
                 # construction emitted nothing (issue #896, the singleton
                 # `new WindowClassRegistrar()`). Returning the type name routes
                 # it through the normal resolve loop: the class gets
-                # INSTANTIATES and its constructor CALLS. Strip template args
-                # (`new Foo<int>()` -> Foo); a `ns::Foo` path is left for the
-                # resolver; a primitive type resolves to nothing and stays
-                # silent.
+                # INSTANTIATES and its constructor CALLS. The type reduces
+                # STRUCTURALLY to its dotted class path (`new Foo<int>()` ->
+                # Foo, `new Outer<int>::Inner()` -> Outer.Inner; a textual cut
+                # at `<` would drop the nested suffix); a primitive type
+                # reduces to nothing and stays silent.
                 type_node = call_node.child_by_field_name(cs.FIELD_TYPE)
-                if type_node is not None and type_node.text is not None:
-                    name = type_node.text.decode(cs.ENCODING_UTF8).split(
-                        cs.CHAR_ANGLE_OPEN, 1
-                    )[0]
-                    return name.replace(cs.SEPARATOR_DOUBLE_COLON, cs.SEPARATOR_DOT)
+                if type_node is not None:
+                    return cpp_utils.new_expression_class_path(type_node)
             case cs.TS_CSHARP_IMPLICIT_OBJECT_CREATION_EXPRESSION if (
                 language == cs.SupportedLanguage.CSHARP
             ):

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1951,6 +1951,22 @@ class CallProcessor:
                     return type_node.text.decode(cs.ENCODING_UTF8).split(
                         cs.CHAR_ANGLE_OPEN, 1
                     )[0]
+            case cs.TS_NEW_EXPRESSION if language == cs.SupportedLanguage.CPP:
+                # C++ `new Foo(...)` names the class via the `type` field (no
+                # `function` field), so it fell through nameless and heap
+                # construction emitted nothing (issue #896, the singleton
+                # `new WindowClassRegistrar()`). Returning the type name routes
+                # it through the normal resolve loop: the class gets
+                # INSTANTIATES and its constructor CALLS. Strip template args
+                # (`new Foo<int>()` -> Foo); a `ns::Foo` path is left for the
+                # resolver; a primitive type resolves to nothing and stays
+                # silent.
+                type_node = call_node.child_by_field_name(cs.FIELD_TYPE)
+                if type_node is not None and type_node.text is not None:
+                    name = type_node.text.decode(cs.ENCODING_UTF8).split(
+                        cs.CHAR_ANGLE_OPEN, 1
+                    )[0]
+                    return name.replace(cs.SEPARATOR_DOUBLE_COLON, cs.SEPARATOR_DOT)
             case cs.TS_CSHARP_IMPLICIT_OBJECT_CREATION_EXPRESSION if (
                 language == cs.SupportedLanguage.CSHARP
             ):
@@ -2644,6 +2660,25 @@ class CallProcessor:
                 continue
 
             callee_type, callee_qn = callee_info
+
+            if (
+                language == cs.SupportedLanguage.CPP
+                and call_node.type == cs.TS_NEW_EXPRESSION
+                and callee_type != class_label
+            ):
+                # Inside X's own methods the bare name `X` prefers the class
+                # MEMBER (the ctor), so `new X()` resolves past the class
+                # branch and INSTANTIATES is lost (issue #896, the singleton's
+                # `new WindowClassRegistrar()` in GetInstance). Construction
+                # always targets the CLASS: rebind so the class branch below
+                # emits INSTANTIATES plus the full ctor/dtor redirect.
+                leaf = call_name.rsplit(cs.SEPARATOR_DOT, 1)[-1]
+                class_qn = resolver._resolve_class_name(leaf, module_qn)
+                if class_qn is not None and (
+                    class_qn == call_name
+                    or class_qn.endswith(f"{cs.SEPARATOR_DOT}{call_name}")
+                ):
+                    callee_type, callee_qn = class_label, class_qn
 
             # A callee that resolved to a builtin (e.g. JS setTimeout(target))
             # has no first-party body to follow into, so pass-through flow is

--- a/codebase_rag/parsers/cpp/utils.py
+++ b/codebase_rag/parsers/cpp/utils.py
@@ -458,6 +458,29 @@ def _find_qualified_identifier_in_declarator(func_node: Node) -> Node | None:
     inner_node = _get_inner_function_node(func_node)
 
     declarator = inner_node.child_by_field_name(cs.FIELD_DECLARATOR)
+    # A pointer/reference-returning definition (`const wchar_t*
+    # C::GetWindowClass()`) wraps the function_declarator in
+    # pointer/reference_declarator layers; reference_declarator exposes no
+    # `declarator` field, so fall back to scanning children (issue #896).
+    while declarator is not None and declarator.type in (
+        cs.CppNodeType.POINTER_DECLARATOR,
+        cs.CppNodeType.REFERENCE_DECLARATOR,
+        cs.CppNodeType.PARENTHESIZED_DECLARATOR,
+    ):
+        declarator = declarator.child_by_field_name(cs.FIELD_DECLARATOR) or next(
+            (
+                child
+                for child in declarator.children
+                if child.type
+                in (
+                    cs.CppNodeType.POINTER_DECLARATOR,
+                    cs.CppNodeType.REFERENCE_DECLARATOR,
+                    cs.CppNodeType.PARENTHESIZED_DECLARATOR,
+                    cs.CppNodeType.FUNCTION_DECLARATOR,
+                )
+            ),
+            None,
+        )
     if not declarator:
         return None
 

--- a/codebase_rag/parsers/cpp/utils.py
+++ b/codebase_rag/parsers/cpp/utils.py
@@ -443,6 +443,15 @@ def _return_type_path(type_node: Node) -> str | None:
     return cs.SEPARATOR_DOT.join(parts) if parts else None
 
 
+def new_expression_class_path(type_node: Node) -> str | None:
+    # The dotted class path a `new_expression`'s `type` field constructs.
+    # Shares the return-type reducer so template arguments reduce
+    # structurally: `Outer<int>::Inner` -> "Outer.Inner" (a textual cut at
+    # the first `<` would drop the `::Inner` suffix, issue #896 review), a
+    # primitive type yields None and the allocation stays silent.
+    return _return_type_path(type_node)
+
+
 def extract_return_type_name(func_node: Node) -> str | None:
     # The qualified class path a C++ function/method returns, for chained-call
     # typing (`parser(...).parse(...)`). Unwraps a template_declaration to the

--- a/codebase_rag/tests/test_cpp_singleton_chain.py
+++ b/codebase_rag/tests/test_cpp_singleton_chain.py
@@ -102,6 +102,6 @@ def test_new_in_inline_method_emits_instantiates(
 ):
     run_updater(cpp_singleton_project, mock_ingestor)
     inst = _rels(mock_ingestor, cs.RelationshipType.INSTANTIATES.value)
-    assert _has(
-        inst, ".WindowClassRegistrar.GetInstance", ".WindowClassRegistrar"
-    ), sorted(inst)
+    assert _has(inst, ".WindowClassRegistrar.GetInstance", ".WindowClassRegistrar"), (
+        sorted(inst)
+    )

--- a/codebase_rag/tests/test_cpp_singleton_chain.py
+++ b/codebase_rag/tests/test_cpp_singleton_chain.py
@@ -1,0 +1,107 @@
+# Singleton accessor chains (issue #896). The registrar pattern loses both
+# onward edges: the chained hop off a pointer-returning static
+# (`GetInstance()->GetWindowClass()`) and the `new Registrar()` construction
+# inside the INLINE in-class method body, so the class's ctor/dtor and the
+# chained member all report dead despite live callers.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import run_updater
+
+MAIN_CPP = """
+class WindowClassRegistrar {
+ public:
+  ~WindowClassRegistrar() = default;
+  static WindowClassRegistrar* GetInstance() {
+    if (!instance_) {
+      instance_ = new WindowClassRegistrar();
+    }
+    return instance_;
+  }
+  const wchar_t* GetWindowClass();
+
+ private:
+  WindowClassRegistrar() = default;
+  static WindowClassRegistrar* instance_;
+};
+
+WindowClassRegistrar* WindowClassRegistrar::instance_ = nullptr;
+
+const wchar_t* WindowClassRegistrar::GetWindowClass() {
+  return L"CLASS";
+}
+
+int use() {
+  const wchar_t* wc = WindowClassRegistrar::GetInstance()->GetWindowClass();
+  return wc != nullptr;
+}
+"""
+
+
+@pytest.fixture
+def cpp_singleton_project(temp_repo: Path) -> Path:
+    root = temp_repo / "singleton"
+    root.mkdir()
+    (root / "main.cpp").write_text(MAIN_CPP, encoding="utf-8")
+    return root
+
+
+def _rels(mock_ingestor: MagicMock, rel_type: str) -> set[tuple[str, str]]:
+    return {
+        (str(c.args[0][2]), str(c.args[2][2]))
+        for c in mock_ingestor.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) == rel_type
+    }
+
+
+def _has(edges: set[tuple[str, str]], src: str, dst: str) -> bool:
+    return any(s.endswith(src) and d.endswith(dst) for s, d in edges)
+
+
+def test_static_accessor_call_resolves(
+    cpp_singleton_project: Path, mock_ingestor: MagicMock
+):
+    # The already-working half: `use` calls the static accessor.
+    run_updater(cpp_singleton_project, mock_ingestor)
+    calls = _rels(mock_ingestor, cs.RelationshipType.CALLS.value)
+    assert _has(calls, ".use", ".WindowClassRegistrar.GetInstance"), sorted(calls)
+
+
+def test_chained_hop_off_pointer_returning_static(
+    cpp_singleton_project: Path, mock_ingestor: MagicMock
+):
+    # `GetInstance()` returns `WindowClassRegistrar*`; the chained
+    # `->GetWindowClass()` must map through the POINTER return type to the
+    # class and land on the member.
+    run_updater(cpp_singleton_project, mock_ingestor)
+    calls = _rels(mock_ingestor, cs.RelationshipType.CALLS.value)
+    assert _has(calls, ".use", ".WindowClassRegistrar.GetWindowClass"), sorted(calls)
+
+
+def test_new_in_inline_method_emits_ctor_call(
+    cpp_singleton_project: Path, mock_ingestor: MagicMock
+):
+    # `new WindowClassRegistrar()` inside the INLINE in-class body of
+    # GetInstance must call the (private, defaulted) constructor.
+    run_updater(cpp_singleton_project, mock_ingestor)
+    calls = _rels(mock_ingestor, cs.RelationshipType.CALLS.value)
+    assert _has(
+        calls,
+        ".WindowClassRegistrar.GetInstance",
+        ".WindowClassRegistrar.WindowClassRegistrar",
+    ), sorted(calls)
+
+
+def test_new_in_inline_method_emits_instantiates(
+    cpp_singleton_project: Path, mock_ingestor: MagicMock
+):
+    run_updater(cpp_singleton_project, mock_ingestor)
+    inst = _rels(mock_ingestor, cs.RelationshipType.INSTANTIATES.value)
+    assert _has(
+        inst, ".WindowClassRegistrar.GetInstance", ".WindowClassRegistrar"
+    ), sorted(inst)

--- a/codebase_rag/tests/test_cpp_singleton_chain.py
+++ b/codebase_rag/tests/test_cpp_singleton_chain.py
@@ -87,13 +87,20 @@ def test_new_in_inline_method_emits_ctor_call(
     cpp_singleton_project: Path, mock_ingestor: MagicMock
 ):
     # `new WindowClassRegistrar()` inside the INLINE in-class body of
-    # GetInstance must call the (private, defaulted) constructor.
+    # GetInstance must call the (private, defaulted) constructor, and the
+    # class-branch redirect must also revive the dtor (`~X` runs at end of
+    # lifetime with no call node of its own; Greptile round 1).
     run_updater(cpp_singleton_project, mock_ingestor)
     calls = _rels(mock_ingestor, cs.RelationshipType.CALLS.value)
     assert _has(
         calls,
         ".WindowClassRegistrar.GetInstance",
         ".WindowClassRegistrar.WindowClassRegistrar",
+    ), sorted(calls)
+    assert _has(
+        calls,
+        ".WindowClassRegistrar.GetInstance",
+        ".WindowClassRegistrar.~WindowClassRegistrar",
     ), sorted(calls)
 
 
@@ -105,3 +112,43 @@ def test_new_in_inline_method_emits_instantiates(
     assert _has(inst, ".WindowClassRegistrar.GetInstance", ".WindowClassRegistrar"), (
         sorted(inst)
     )
+
+
+NESTED_CPP = """
+template <typename T>
+class Outer {
+ public:
+  Outer() {}
+  class Inner {
+   public:
+    Inner() {}
+  };
+};
+
+void make() {
+  auto* p = new Outer<int>::Inner();
+}
+"""
+
+
+@pytest.fixture
+def cpp_nested_new_project(temp_repo: Path) -> Path:
+    root = temp_repo / "nested"
+    root.mkdir()
+    (root / "main.cpp").write_text(NESTED_CPP, encoding="utf-8")
+    return root
+
+
+def test_nested_templated_new_targets_inner_class(
+    cpp_nested_new_project: Path, mock_ingestor: MagicMock
+):
+    # `new Outer<int>::Inner()` names the NESTED class: cutting the type
+    # text at the first `<` would drop the `::Inner` suffix and bind the
+    # construction to Outer instead (Greptile round 1, T-Rex repro).
+    run_updater(cpp_nested_new_project, mock_ingestor)
+    calls = _rels(mock_ingestor, cs.RelationshipType.CALLS.value)
+    inst = _rels(mock_ingestor, cs.RelationshipType.INSTANTIATES.value)
+    assert _has(calls, ".make", ".Outer.Inner.Inner"), sorted(calls)
+    assert _has(inst, ".make", ".Outer.Inner"), sorted(inst)
+    assert not _has(calls, ".make", ".Outer.Outer"), sorted(calls)
+    assert not _has(inst, ".make", ".Outer"), sorted(inst)

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.460"
+version = "0.0.464"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Fixes #896.

The singleton registrar pattern (wonderous `window_manager`) lost both onward edges, so `WindowClassRegistrar.WindowClassRegistrar`, `~WindowClassRegistrar` and `GetWindowClass` reported dead despite live callers. Two independent root causes:

## 1. Pointer-returning out-of-class definitions registered flat

`const wchar_t* WindowClassRegistrar::GetWindowClass()` wraps its `function_declarator` in a `pointer_declarator` (a reference return wraps it in a `reference_declarator`, which exposes no `declarator` field at all). `_find_qualified_identifier_in_declarator` only accepted a direct `function_declarator`, so the definition was not recognised as an out-of-class method and registered as the flat function `module.GetWindowClass` instead of `module.WindowClassRegistrar.GetWindowClass`.

The chained hop off the accessor (`GetInstance()->GetWindowClass()`) already typed the receiver correctly (the recorded return type is the class; the `*` lives in the declarator, not the type field), but the member lookup then missed because the method was never registered under the class. Unwrapping pointer/reference/parenthesized declarator layers fixes registration, and with it the chained hop, for every pointer or reference returning out-of-class member definition. The same helper drives caller attribution (`_cpp_out_of_class_method_caller`), so both sides stay consistent by construction.

## 2. `new X(...)` emitted nothing

C++ `new_expression` is in `SPEC_CPP_CALL_TYPES` but `_get_call_target_name` had no branch for it: the class is named by the `type` field (there is no `function` field), so the call fell through nameless and heap construction emitted no edges anywhere. Added the branch mirroring the Java/C# `object_creation_expression` handling (template args stripped, `::` normalised to dots), routing construction through the normal resolve loop.

One follow-on inside that loop: within X's own methods the bare name `X` resolves to the class MEMBER (the constructor), so `new X()` in `GetInstance` skipped the class branch and lost INSTANTIATES. A `new_expression` that resolved to a non-class is rebound to the registered class (boundary-safe suffix check), so the class branch emits INSTANTIATES plus the full ctor/dtor redirect, consistent with stack constructions.

## Tests

`test_cpp_singleton_chain.py` covers the issue's repro end to end: the static accessor call (guard), the chained hop through the pointer return, and ctor CALLS + INSTANTIATES from the inline `new`. RED demonstrated in commit history before the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved C++ `new` expression handling to correctly resolve the constructed class and restore constructor/instantiation relationship extraction.
  - Enhanced detection for pointer/reference and parenthesized return-type declarators, improving qualified identifier resolution.
  - Fixed nested templated `new` cases (e.g., `Outer<int>::Inner`) to target the correct inner class without mis-linking to outer forms.

- **Tests**
  - Expanded C++ coverage for singleton accessor chains and constructor/instantiation edges.
  - Added fixtures and assertions for nested templated `new` relationship correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->