### PR TITLE
fix: harden shell tests against slow Windows spawns and surface timeout cause

### DIFF
--- a/codebase_rag/tests/test_shell_command.py
+++ b/codebase_rag/tests/test_shell_command.py
@@ -40,7 +40,10 @@ def temp_project_root(tmp_path: Path) -> Path:
 
 @pytest.fixture
 def shell_commander(temp_project_root: Path) -> ShellCommander:
-    return ShellCommander(str(temp_project_root), timeout=5)
+    # Real-spawn tests share this budget; cold Windows CI runners can take
+    # seconds per process spawn, so keep it at the production default
+    # rather than a tight test-only value (issue #902).
+    return ShellCommander(str(temp_project_root), timeout=30)
 
 
 class TestShellCommanderInit:
@@ -134,14 +137,14 @@ class TestShellCommanderExecute:
         test_file = temp_project_root / "test.txt"
         test_file.write_text("content", encoding="utf-8")
         result = await shell_commander.execute("ls")
-        assert result.return_code == 0
+        assert result.return_code == 0, result.stderr
         assert "test.txt" in result.stdout
 
     async def test_execute_pwd_command(
         self, shell_commander: ShellCommander, temp_project_root: Path
     ) -> None:
         result = await shell_commander.execute("pwd")
-        assert result.return_code == 0
+        assert result.return_code == 0, result.stderr
         bash_out = result.stdout.strip().replace("/c/", "C:/").replace("/d/", "D:/")
         if bash_out.startswith("/tmp/"):
             import tempfile
@@ -154,7 +157,7 @@ class TestShellCommanderExecute:
 
     async def test_execute_echo_command(self, shell_commander: ShellCommander) -> None:
         result = await shell_commander.execute("echo 'Hello World'")
-        assert result.return_code == 0
+        assert result.return_code == 0, result.stderr
         assert "Hello World" in result.stdout
 
     async def test_execute_command_not_in_allowlist(
@@ -195,8 +198,18 @@ class TestShellCommanderExecute:
         test_file = temp_project_root / "cat_test.txt"
         test_file.write_text("File content here", encoding="utf-8")
         result = await shell_commander.execute("cat cat_test.txt")
-        assert result.return_code == 0
+        assert result.return_code == 0, result.stderr
         assert "File content here" in result.stdout
+
+    async def test_timeout_reports_reason_in_stderr(
+        self, temp_project_root: Path
+    ) -> None:
+        # An exhausted budget must surface the timeout message, not a bare
+        # -1: that silence is what made issue #902 undiagnosable in CI.
+        commander = ShellCommander(str(temp_project_root), timeout=0)
+        result = await commander.execute("pwd")
+        assert result.return_code == -1
+        assert "timed out" in result.stderr
 
 
 class TestCreateShellCommandTool:
@@ -224,7 +237,7 @@ class TestToolApprovalBehavior:
         mock_ctx = MagicMock()
         mock_ctx.tool_call_approved = False
         result = await tool.function(mock_ctx, "ls")
-        assert result.return_code == 0
+        assert result.return_code == 0, result.stderr
 
     async def test_write_command_requires_approval(
         self, shell_commander: ShellCommander
@@ -244,7 +257,7 @@ class TestToolApprovalBehavior:
         mock_ctx = MagicMock()
         mock_ctx.tool_call_approved = True
         result = await tool.function(mock_ctx, "rm to_delete.txt")
-        assert result.return_code == 0
+        assert result.return_code == 0, result.stderr
         assert not test_file.exists()
 
 
@@ -304,7 +317,7 @@ class TestYoloMode:
         mock_ctx = MagicMock()
         mock_ctx.tool_call_approved = False
         result = await tool.function(mock_ctx, "rm yolo_target.txt")
-        assert result.return_code == 0
+        assert result.return_code == 0, result.stderr
         assert not test_file.exists()
 
     async def test_yolo_runs_non_allowlist_command(
@@ -442,7 +455,7 @@ class TestPipedCommandExecution:
         for i in range(5):
             (temp_project_root / f"file{i}.txt").write_text("content", encoding="utf-8")
         result = await shell_commander.execute("ls | wc -l")
-        assert result.return_code == 0
+        assert result.return_code == 0, result.stderr
         assert "5" in result.stdout
 
     @pytest.mark.skipif(
@@ -454,7 +467,7 @@ class TestPipedCommandExecution:
         (temp_project_root / "test.py").write_text("print(1)", encoding="utf-8")
         (temp_project_root / "test.txt").write_text("text", encoding="utf-8")
         result = await shell_commander.execute("find . -name '*.py' | wc -l")
-        assert result.return_code == 0
+        assert result.return_code == 0, result.stderr
         assert "1" in result.stdout
 
     async def test_rg_in_pipeline(
@@ -466,7 +479,7 @@ class TestPipedCommandExecution:
             pytest.skip("rg (ripgrep) not installed")
         (temp_project_root / "data.txt").write_text("foo\nbar\nbaz\n", encoding="utf-8")
         result = await shell_commander.execute("cat data.txt | rg bar")
-        assert result.return_code == 0
+        assert result.return_code == 0, result.stderr
         assert "bar" in result.stdout
 
     async def test_pipe_with_disallowed_command(
@@ -518,7 +531,7 @@ class TestQuoteAwareSubshellDetection:
         self, shell_commander: ShellCommander
     ) -> None:
         result = await shell_commander.execute("echo 'a subshell is $(...)'")
-        assert result.return_code == 0
+        assert result.return_code == 0, result.stderr
         assert "a subshell is $(...)" in result.stdout
 
     async def test_double_quoted_subshell_rejected(
@@ -535,7 +548,7 @@ class TestShellOperators:
     ) -> None:
         (temp_project_root / "test.txt").write_text("content", encoding="utf-8")
         result = await shell_commander.execute("ls && pwd")
-        assert result.return_code == 0
+        assert result.return_code == 0, result.stderr
         assert "test.txt" in result.stdout
 
         def path_match(line, target):
@@ -574,7 +587,7 @@ class TestShellOperators:
     ) -> None:
         (temp_project_root / "test.txt").write_text("content", encoding="utf-8")
         result = await shell_commander.execute("ls || echo 'should not run'")
-        assert result.return_code == 0
+        assert result.return_code == 0, result.stderr
         assert "should not run" not in result.stdout
 
     async def test_semicolon_operator(
@@ -900,7 +913,7 @@ class TestAwkSedXargsIntegration:
         test_file = temp_project_root / "data.txt"
         test_file.write_text("hello world\n", encoding="utf-8")
         result = await shell_commander.execute("cat data.txt | awk '{print $1}'")
-        assert result.return_code == 0
+        assert result.return_code == 0, result.stderr
         assert "hello" in result.stdout
 
     async def test_safe_sed_allowed(
@@ -909,7 +922,7 @@ class TestAwkSedXargsIntegration:
         test_file = temp_project_root / "data.txt"
         test_file.write_text("foo bar\n", encoding="utf-8")
         result = await shell_commander.execute("cat data.txt | sed 's/foo/baz/'")
-        assert result.return_code == 0
+        assert result.return_code == 0, result.stderr
         assert "baz" in result.stdout
 
     async def test_safe_xargs_allowed(
@@ -918,5 +931,5 @@ class TestAwkSedXargsIntegration:
         test_file = temp_project_root / "file.txt"
         test_file.write_text("content\n", encoding="utf-8")
         result = await shell_commander.execute("echo file.txt | xargs cat")
-        assert result.return_code == 0
+        assert result.return_code == 0, result.stderr
         assert "content" in result.stdout

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.464"
+version = "0.0.467"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Fixes #902.

## What happened

On CI run 29945276330 (PR #898), `test_safe_awk_allowed` failed on windows-latest with a bare `assert -1 == 0`. Return code -1 is `SHELL_RETURN_CODE_ERROR`, which ShellCommander returns for every rejection, timeout and spawn failure alike, and the assertion discarded `result.stderr`, so the actual cause never reached the CI log. A plain rerun went green with zero code changes.

## Root cause

The shared test fixture gave ShellCommander a 5 second budget for the whole pipeline. On a cold, loaded Windows runner, spawning two Git Bash executables (`cat`, then `awk`) under antivirus scanning can occasionally exceed that, and the TimeoutError path returns exactly -1. The tight budget was a test-only value with no test depending on it.

## Fix

- The fixture now uses the production default of 30 seconds, so process spawn latency can no longer masquerade as a command failure. Rejection-path tests never spawn anything and are unaffected.
- Every success assertion (`return_code == 0`) in the file now carries `result.stderr` as its message, so any future failure shows the real reason directly in the CI log instead of a bare -1.
- New test `test_timeout_reports_reason_in_stderr` pins the previously uncovered timeout path: an exhausted budget must return -1 with the timeout message in stderr. The RED evidence for this change is the observed CI failure itself, which was undiagnosable precisely because nothing surfaced the reason.

## Verification

Full unit suite (5675 passed), integration suite (297 passed) and pre-commit all green locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved command execution test coverage and diagnostics.
  * Added explicit success-status validation across shell command, pipeline, filtering, and approval scenarios.
  * Enhanced timeout checks to verify a clear “timed out” error message.
  * Increased the test timeout threshold to reduce false failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->