### PR TITLE
fix(shell): surface spawn errors with failing segment and executable

### DIFF
--- a/codebase_rag/tests/test_shell_command.py
+++ b/codebase_rag/tests/test_shell_command.py
@@ -900,7 +900,7 @@ class TestAwkSedXargsIntegration:
         test_file = temp_project_root / "data.txt"
         test_file.write_text("hello world\n", encoding="utf-8")
         result = await shell_commander.execute("cat data.txt | awk '{print $1}'")
-        assert result.return_code == 0
+        assert result.return_code == 0, result.stderr
         assert "hello" in result.stdout
 
     async def test_safe_sed_allowed(
@@ -909,7 +909,7 @@ class TestAwkSedXargsIntegration:
         test_file = temp_project_root / "data.txt"
         test_file.write_text("foo bar\n", encoding="utf-8")
         result = await shell_commander.execute("cat data.txt | sed 's/foo/baz/'")
-        assert result.return_code == 0
+        assert result.return_code == 0, result.stderr
         assert "baz" in result.stdout
 
     async def test_safe_xargs_allowed(
@@ -918,7 +918,7 @@ class TestAwkSedXargsIntegration:
         test_file = temp_project_root / "file.txt"
         test_file.write_text("content\n", encoding="utf-8")
         result = await shell_commander.execute("echo file.txt | xargs cat")
-        assert result.return_code == 0
+        assert result.return_code == 0, result.stderr
         assert "content" in result.stdout
 
 

--- a/codebase_rag/tests/test_shell_command.py
+++ b/codebase_rag/tests/test_shell_command.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import shutil
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -924,19 +926,48 @@ class TestAwkSedXargsIntegration:
 
 class TestSpawnFailureDiagnostics:
     async def test_spawn_failure_names_failing_segment(
-        self, shell_commander: ShellCommander, monkeypatch: pytest.MonkeyPatch
+        self,
+        shell_commander: ShellCommander,
+        temp_project_root: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         # A failed spawn must say WHICH pipeline segment failed and why: a
         # bare str(OSError) leaves CI reading `assert -1 == 0` with no cause
         # (issue #902, the intermittent awk failure on the Windows runner).
-        async def fail_spawn(*args: object, **kwargs: object) -> None:
-            raise FileNotFoundError(2, "No such file or directory")
+        # The stub fails only the SECOND segment so the error must attribute
+        # the right one, and the resolved executable must appear too.
+        (temp_project_root / "data.txt").write_text("hello world\n", encoding="utf-8")
+        real_spawn = asyncio.create_subprocess_exec
+        awk_executable = shutil.which("awk") or "awk"
+
+        async def fail_awk_spawn(
+            program: str,
+            *args: str,
+            stdin: int | None = None,
+            stdout: int | None = None,
+            stderr: int | None = None,
+            cwd: Path | None = None,
+            env: dict[str, str] | None = None,
+        ) -> asyncio.subprocess.Process:
+            if Path(program).stem == "awk":
+                raise FileNotFoundError(2, "No such file or directory")
+            return await real_spawn(
+                program,
+                *args,
+                stdin=stdin,
+                stdout=stdout,
+                stderr=stderr,
+                cwd=cwd,
+                env=env,
+            )
 
         monkeypatch.setattr(
             "codebase_rag.tools.shell_command.asyncio.create_subprocess_exec",
-            fail_spawn,
+            fail_awk_spawn,
         )
         result = await shell_commander.execute("cat data.txt | awk '{print $1}'")
         assert result.return_code == -1
-        assert "cat data.txt" in result.stderr, result.stderr
+        assert "awk '{print $1}'" in result.stderr, result.stderr
+        assert "cat data.txt" not in result.stderr, result.stderr
+        assert awk_executable in result.stderr, result.stderr
         assert "No such file or directory" in result.stderr, result.stderr

--- a/codebase_rag/tests/test_shell_command.py
+++ b/codebase_rag/tests/test_shell_command.py
@@ -920,3 +920,23 @@ class TestAwkSedXargsIntegration:
         result = await shell_commander.execute("echo file.txt | xargs cat")
         assert result.return_code == 0
         assert "content" in result.stdout
+
+
+class TestSpawnFailureDiagnostics:
+    async def test_spawn_failure_names_failing_segment(
+        self, shell_commander: ShellCommander, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A failed spawn must say WHICH pipeline segment failed and why: a
+        # bare str(OSError) leaves CI reading `assert -1 == 0` with no cause
+        # (issue #902, the intermittent awk failure on the Windows runner).
+        async def fail_spawn(*args: object, **kwargs: object) -> None:
+            raise FileNotFoundError(2, "No such file or directory")
+
+        monkeypatch.setattr(
+            "codebase_rag.tools.shell_command.asyncio.create_subprocess_exec",
+            fail_spawn,
+        )
+        result = await shell_commander.execute("cat data.txt | awk '{print $1}'")
+        assert result.return_code == -1
+        assert "cat data.txt" in result.stderr, result.stderr
+        assert "No such file or directory" in result.stderr, result.stderr

--- a/codebase_rag/tool_errors.py
+++ b/codebase_rag/tool_errors.py
@@ -30,6 +30,7 @@ COMMAND_DANGEROUS_PATTERN = "Command matches dangerous pattern: {reason}"
 COMMAND_TIMEOUT = "Command '{cmd}' timed out after {timeout} seconds."
 COMMAND_SUBSHELL_NOT_ALLOWED = "Subshell execution not allowed: {pattern}"
 COMMAND_INVALID_SYNTAX = "Invalid command syntax: {segment}"
+COMMAND_SPAWN_FAILED = "Failed to spawn '{segment}' (executable: {executable}): {error}"
 
 # Code retrieval errors
 CODE_ENTITY_NOT_FOUND = "Entity not found in graph."

--- a/codebase_rag/tools/shell_command.py
+++ b/codebase_rag/tools/shell_command.py
@@ -304,15 +304,25 @@ class ShellCommander:
             if not executable:
                 executable = cmd_parts[0]
 
-            proc = await asyncio.create_subprocess_exec(
-                executable,
-                *cmd_parts[1:],
-                stdin=asyncio.subprocess.PIPE if input_data is not None else None,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                cwd=self.project_root,
-                env=env,
-            )
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    executable,
+                    *cmd_parts[1:],
+                    stdin=asyncio.subprocess.PIPE if input_data is not None else None,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    cwd=self.project_root,
+                    env=env,
+                )
+            except OSError as e:
+                # A bare str(OSError) hides WHICH segment failed to spawn, so
+                # an intermittent runner failure surfaces as an opaque -1
+                # (issue #902). Name the segment and the resolved executable.
+                raise RuntimeError(
+                    te.COMMAND_SPAWN_FAILED.format(
+                        segment=segment, executable=executable, error=e
+                    )
+                ) from e
             try:
                 stdout, stderr = await asyncio.wait_for(
                     proc.communicate(input=input_data), timeout=remaining_timeout

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.464"
+version = "0.0.467"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.467"
+version = "0.0.468"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- `ShellCommander._execute_pipeline` now catches `OSError` at the spawn site and re-raises with the failing pipeline segment and the resolved executable path, via a new `COMMAND_SPAWN_FAILED` template. Previously any spawn failure bubbled into the broad `except Exception` and returned `-1` with a bare `str(e)` (for example `[Errno 2] No such file or directory`) that named nothing.
- The safe pipeline tests (`awk`, `sed`, `xargs`) now pass `result.stderr` as the assertion message, so an intermittent runner failure reports its real cause instead of the bare `assert -1 == 0` seen in the #902 CI log.
- New test `TestSpawnFailureDiagnostics::test_spawn_failure_names_failing_segment` fails only the second pipeline segment and asserts the error names that segment, its resolved executable, and the underlying OS error.

## Type of Change

- [x] Bug fix

## Related Issues

Fixes #902

## Test Plan

- [x] Unit tests pass (`uv run pytest -n auto`, 5972 passed)
- [x] New tests added
- [ ] Integration tests pass (`make test-integration`, requires Docker)
- [ ] Manual testing (describe below)

RED first (`161c094d`): the new test monkeypatches `asyncio.create_subprocess_exec` to raise `FileNotFoundError` and failed with exactly the defect stderr (`[Errno 2] No such file or directory`, no segment named) before the fix.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [ ] No new comments or docstrings (two brief comments record the issue context at the spawn site and in the regression test)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell command pipeline failure diagnostics to identify the specific failing segment when a subprocess cannot be spawned.
  * Error messages now include the resolved executable name and the underlying operating system message to speed up troubleshooting.
  * Enhanced stderr reporting so only the relevant pipeline segment is attributed to the failure.
* **Tests**
  * Added coverage to verify spawn-failure diagnostics correctly attribute missing-executable errors to the failing pipeline segment and validate the included error details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->