### PR TITLE
fix: resolve SonarCloud new-code quality gate failures

### DIFF
--- a/codebase_rag/main.py
+++ b/codebase_rag/main.py
@@ -542,10 +542,7 @@ async def run_with_cancellation[T](
         return await asyncio.wait_for(task, timeout=timeout) if timeout else await task
     except TimeoutError:
         task.cancel()
-        try:
-            await task
-        except asyncio.CancelledError:
-            pass
+        await asyncio.gather(task, return_exceptions=True)
         app_context.console.print(
             f"\n{style(cs.MSG_TIMEOUT_FORMAT.format(timeout=timeout), cs.Color.YELLOW)}"
         )
@@ -553,10 +550,7 @@ async def run_with_cancellation[T](
     except (asyncio.CancelledError, KeyboardInterrupt):
         if not task.done():
             task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
+            await asyncio.gather(task, return_exceptions=True)
         app_context.console.print(
             f"\n{style(cs.MSG_THINKING_CANCELLED, cs.Color.YELLOW)}"
         )
@@ -676,7 +670,7 @@ async def _run_agent_response_loop(
             )
             continue
 
-        asyncio.create_task(_refresh_context_tokens(list(message_history)))
+        _spawn_background(_refresh_context_tokens(list(message_history)))
 
         output_text = response.output
         if not isinstance(output_text, str):
@@ -834,6 +828,15 @@ def _token_usage() -> tuple[int, int, float]:
     return used, max_ctx, pct
 
 
+_background_tasks: set[asyncio.Task[None]] = set()
+
+
+def _spawn_background(coro: Coroutine[None, None, None]) -> None:
+    task = asyncio.create_task(coro)
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+
+
 async def _refresh_context_tokens(messages: list[ModelMessage]) -> None:
     try:
         config = settings.active_orchestrator_config
@@ -858,7 +861,7 @@ def _prime_context_token_counter(system_prompt: str) -> None:
     baseline_messages: list[ModelMessage] = [
         ModelRequest(parts=[SystemPromptPart(content=system_prompt)])
     ]
-    asyncio.create_task(_refresh_context_tokens(baseline_messages))
+    _spawn_background(_refresh_context_tokens(baseline_messages))
 
 
 def _short_model_id() -> tuple[str, str]:
@@ -1127,11 +1130,8 @@ def _thinking_with_status_bar(message: str):
 
         async def _refresh_bar() -> None:
             while True:
-                try:
-                    live.update(render())
-                    await asyncio.sleep(0.25)
-                except asyncio.CancelledError:
-                    return
+                live.update(render())
+                await asyncio.sleep(0.25)
 
         refresh_task = asyncio.get_running_loop().create_task(_refresh_bar())
         try:

--- a/codebase_rag/main.py
+++ b/codebase_rag/main.py
@@ -548,9 +548,8 @@ async def run_with_cancellation[T](
         )
         return CancelledResult(cancelled=True)
     except (asyncio.CancelledError, KeyboardInterrupt):
-        if not task.done():
-            task.cancel()
-            await asyncio.gather(task, return_exceptions=True)
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
         app_context.console.print(
             f"\n{style(cs.MSG_THINKING_CANCELLED, cs.Color.YELLOW)}"
         )

--- a/codebase_rag/mcp/tools.py
+++ b/codebase_rag/mcp/tools.py
@@ -51,6 +51,27 @@ from codebase_rag.utils.path_utils import derive_project_name
 from codebase_rag.vector_store import clear_all_embeddings, delete_project_embeddings
 
 
+def _read_file_slice(full_path: Path, start: int, limit: int | None) -> str:
+    with open(full_path, encoding=cs.ENCODING_UTF8) as f:
+        skipped_count = sum(1 for _ in itertools.islice(f, start))
+
+        if limit is not None:
+            sliced_lines = [line for _, line in zip(range(limit), f)]
+        else:
+            sliced_lines = list(f)
+
+        paginated_content = "".join(sliced_lines)
+        remaining_lines_count = sum(1 for _ in f)
+
+    total_lines = skipped_count + len(sliced_lines) + remaining_lines_count
+    header = cs.MCP_PAGINATION_HEADER.format(
+        start=start + 1,
+        end=start + len(sliced_lines),
+        total=total_lines,
+    )
+    return header + paginated_content
+
+
 class MCPToolsRegistry:
     def __init__(
         self,
@@ -655,28 +676,9 @@ class MCPToolsRegistry:
                         message=lg.FILE_OUTSIDE_ROOT.format(action="access")
                     )
                 start = offset if offset is not None else 0
-
-                with open(full_path, encoding=cs.ENCODING_UTF8) as f:
-                    skipped_count = sum(1 for _ in itertools.islice(f, start))
-
-                    if limit is not None:
-                        sliced_lines = [line for _, line in zip(range(limit), f)]
-                    else:
-                        sliced_lines = list(f)
-
-                    paginated_content = "".join(sliced_lines)
-
-                    remaining_lines_count = sum(1 for _ in f)
-                    total_lines = (
-                        skipped_count + len(sliced_lines) + remaining_lines_count
-                    )
-
-                    header = cs.MCP_PAGINATION_HEADER.format(
-                        start=start + 1,
-                        end=start + len(sliced_lines),
-                        total=total_lines,
-                    )
-                    return header + paginated_content
+                return await asyncio.to_thread(
+                    _read_file_slice, full_path, start, limit
+                )
             else:
                 result = await self._file_reader_tool.function(file_path=file_path)
                 return str(result)

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -140,7 +140,8 @@ class _DeferredForwardDecl(NamedTuple):
 
 
 class ClassIngestMixin:
-    __slots__ = ()
+    # No __slots__: this mixin lazily creates _deferred_* registries on the
+    # host instance, which requires the host to provide a __dict__.
     ingestor: IngestorProtocol
     repo_path: Path
     project_name: str

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -214,7 +214,8 @@ _GO_TYPE_NODE_TYPES = frozenset({NodeType.CLASS, NodeType.TYPE, NodeType.INTERFA
 
 
 class FunctionIngestMixin:
-    __slots__ = ()
+    # No __slots__: this mixin lazily creates _deferred_* registries on the
+    # host instance, which requires the host to provide a __dict__.
     ingestor: IngestorProtocol
     repo_path: Path
     project_name: str

--- a/codebase_rag/parsers/py/expression_analyzer.py
+++ b/codebase_rag/parsers/py/expression_analyzer.py
@@ -363,7 +363,7 @@ class PythonExpressionAnalyzerMixin(_ExprBase):
 
             return self._resolve_class_method(class_name, method_name, module_qn)
 
-        if parts[0] == cs.PY_KEYWORD_SELF and len(parts) >= 3:
+        if parts[0] == cs.PY_KEYWORD_SELF:
             attribute_name = parts[1]
             method_name = parts[-1]
 
@@ -372,12 +372,9 @@ class PythonExpressionAnalyzerMixin(_ExprBase):
                     attribute_type, method_name, module_qn
                 )
 
-        if len(parts) >= 3:
-            potential_class = parts[-2]
-            method_name = parts[-1]
-            return self._resolve_class_method(potential_class, method_name, module_qn)
-
-        return None
+        potential_class = parts[-2]
+        method_name = parts[-1]
+        return self._resolve_class_method(potential_class, method_name, module_qn)
 
     def _resolve_class_method(
         self, class_name: str, method_name: str, module_qn: str

--- a/codebase_rag/stack/constants.py
+++ b/codebase_rag/stack/constants.py
@@ -16,6 +16,8 @@ SERVICE_MEMGRAPH = "memgraph"
 SERVICE_QDRANT = "qdrant"
 SERVICE_LAB = "lab"
 
+LOOPBACK_HOST = "127.0.0.1"
+
 
 class StackState(StrEnum):
     RUNNING = "running"

--- a/codebase_rag/stack/health.py
+++ b/codebase_rag/stack/health.py
@@ -46,12 +46,13 @@ def wait_for_memgraph(
 
 
 def wait_for_qdrant(
-    host: str,
     port: int,
     timeout: float = cs.DEFAULT_HEALTH_TIMEOUT_S,
     interval: float = cs.DEFAULT_HEALTH_INTERVAL_S,
 ) -> bool:
-    url = f"http://{host}:{port}/readyz"
+    # Plain HTTP is deliberate: the stack manager only launches containers on
+    # this machine, so the probe is pinned to loopback.
+    url = f"http://127.0.0.1:{port}/readyz"
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         if _http_reachable(url):

--- a/codebase_rag/stack/manager.py
+++ b/codebase_rag/stack/manager.py
@@ -33,7 +33,6 @@ class StackManager:
         package_compose: Path | None = None,
         memgraph_host: str | None = None,
         memgraph_port: int | None = None,
-        qdrant_host: str = "localhost",
         qdrant_port: int = 6333,
         project_name: str = cs.COMPOSE_PROJECT_NAME,
     ) -> None:
@@ -44,7 +43,6 @@ class StackManager:
         )
         self.memgraph_host = memgraph_host or settings.MEMGRAPH_HOST
         self.memgraph_port = memgraph_port or settings.MEMGRAPH_PORT
-        self.qdrant_host = qdrant_host
         self.qdrant_port = qdrant_port
         self.project_name = project_name
 
@@ -181,11 +179,11 @@ class StackManager:
         logger.info(
             cs.MSG_WAITING_FOR_HEALTH.format(
                 service=cs.SERVICE_QDRANT,
-                host=self.qdrant_host,
+                host=cs.LOOPBACK_HOST,
                 port=self.qdrant_port,
             )
         )
-        if not wait_for_qdrant(self.qdrant_host, self.qdrant_port, timeout):
+        if not wait_for_qdrant(self.qdrant_port, timeout):
             raise StackError(
                 cs.ERR_STACK_NOT_HEALTHY.format(
                     service=cs.SERVICE_QDRANT, timeout=timeout
@@ -196,9 +194,7 @@ class StackManager:
         memgraph_ok = wait_for_memgraph(
             self.memgraph_host, self.memgraph_port, timeout=0.1, interval=0.0
         )
-        qdrant_ok = wait_for_qdrant(
-            self.qdrant_host, self.qdrant_port, timeout=0.1, interval=0.0
-        )
+        qdrant_ok = wait_for_qdrant(self.qdrant_port, timeout=0.1, interval=0.0)
         match (memgraph_ok, qdrant_ok):
             case (True, True):
                 state = cs.StackState.RUNNING
@@ -212,7 +208,7 @@ class StackManager:
             qdrant_reachable=qdrant_ok,
             compose_file=self.compose_file,
             memgraph_endpoint=f"{self.memgraph_host}:{self.memgraph_port}",
-            qdrant_endpoint=f"{self.qdrant_host}:{self.qdrant_port}",
+            qdrant_endpoint=f"{cs.LOOPBACK_HOST}:{self.qdrant_port}",
         )
 
     def ensure_running(self) -> StackStatus:

--- a/codebase_rag/tests/test_background_task_retention.py
+++ b/codebase_rag/tests/test_background_task_retention.py
@@ -1,0 +1,29 @@
+"""Background helper tasks must stay referenced until they finish.
+
+A bare ``asyncio.create_task`` result that nobody stores can be garbage
+collected mid-flight, silently killing the task (python:S7502).
+"""
+
+import asyncio
+
+from codebase_rag.main import _background_tasks, _spawn_background
+
+
+def test_spawned_task_is_retained_until_done() -> None:
+    async def scenario() -> None:
+        release = asyncio.Event()
+
+        async def work() -> None:
+            await release.wait()
+
+        before = set(_background_tasks)
+        _spawn_background(work())
+        pending = _background_tasks - before
+        assert len(pending) == 1
+
+        task = next(iter(pending))
+        release.set()
+        await task
+        assert task not in _background_tasks
+
+    asyncio.run(scenario())

--- a/codebase_rag/tests/test_file_editor_write_serialisation.py
+++ b/codebase_rag/tests/test_file_editor_write_serialisation.py
@@ -5,6 +5,7 @@ old synchronous write provided, so overlapping writes could interleave.
 """
 
 import asyncio
+import threading
 import time
 from pathlib import Path
 from unittest.mock import patch
@@ -19,16 +20,20 @@ def test_concurrent_edits_do_not_overlap(tmp_path: Path) -> None:
 
     in_flight = 0
     max_in_flight = 0
+    counter_lock = threading.Lock()
     real_write_text = Path.write_text
 
     def slow_write_text(self: Path, data: str, encoding: str | None = None) -> int:
         nonlocal in_flight, max_in_flight
-        in_flight += 1
-        max_in_flight = max(max_in_flight, in_flight)
-        time.sleep(0.05)
-        result = real_write_text(self, data, encoding=encoding)
-        in_flight -= 1
-        return result
+        with counter_lock:
+            in_flight += 1
+            max_in_flight = max(max_in_flight, in_flight)
+        try:
+            time.sleep(0.05)
+            return real_write_text(self, data, encoding=encoding)
+        finally:
+            with counter_lock:
+                in_flight -= 1
 
     async def scenario() -> None:
         with patch.object(Path, "write_text", slow_write_text):

--- a/codebase_rag/tests/test_file_editor_write_serialisation.py
+++ b/codebase_rag/tests/test_file_editor_write_serialisation.py
@@ -1,0 +1,42 @@
+"""Concurrent edit_file calls must not write the same tree concurrently.
+
+Offloading the write to a thread removed the event-loop serialisation the
+old synchronous write provided, so overlapping writes could interleave.
+"""
+
+import asyncio
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+from codebase_rag.tools.file_editor import FileEditor
+
+
+def test_concurrent_edits_do_not_overlap(tmp_path: Path) -> None:
+    editor = FileEditor(project_root=str(tmp_path))
+    target = tmp_path / "target.txt"
+    target.write_text("initial")
+
+    in_flight = 0
+    max_in_flight = 0
+    real_write_text = Path.write_text
+
+    def slow_write_text(self: Path, data: str, encoding: str | None = None) -> int:
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        time.sleep(0.05)
+        result = real_write_text(self, data, encoding=encoding)
+        in_flight -= 1
+        return result
+
+    async def scenario() -> None:
+        with patch.object(Path, "write_text", slow_write_text):
+            await asyncio.gather(
+                editor.edit_file(str(target), "a" * 32),
+                editor.edit_file(str(target), "b" * 32),
+            )
+
+    asyncio.run(scenario())
+    assert max_in_flight == 1
+    assert target.read_text() in ("a" * 32, "b" * 32)

--- a/codebase_rag/tests/test_import_parsing.py
+++ b/codebase_rag/tests/test_import_parsing.py
@@ -43,30 +43,15 @@ class TestImportParsing:
     def test_python_import_parsing(self, graph_updater: GraphUpdater) -> None:
         """Test Python import statement parsing."""
 
-        import_patterns = [
-            "import os",
-            "import sys, json",
-            "from pathlib import Path",
-            "from collections import defaultdict, Counter",
-            "from . import local_module",
-            "from ..parent import something",
-        ]
-
-        for pattern in import_patterns:
-            try:
-                assert hasattr(
-                    graph_updater.factory.import_processor, "_parse_python_imports"
-                )
-                assert hasattr(
-                    graph_updater.factory.import_processor,
-                    "_handle_python_import_statement",
-                )
-                assert hasattr(
-                    graph_updater.factory.import_processor,
-                    "_handle_python_import_from_statement",
-                )
-            except Exception as e:
-                pytest.fail(f"Python import parsing failed for '{pattern}': {e}")
+        assert hasattr(graph_updater.factory.import_processor, "_parse_python_imports")
+        assert hasattr(
+            graph_updater.factory.import_processor,
+            "_handle_python_import_statement",
+        )
+        assert hasattr(
+            graph_updater.factory.import_processor,
+            "_handle_python_import_from_statement",
+        )
 
     def test_import_mapping_functionality(self, graph_updater: GraphUpdater) -> None:
         """Test that import mapping works correctly."""
@@ -107,13 +92,10 @@ class TestImportParsing:
             graph_updater.factory.import_processor, "_resolve_relative_import"
         )
 
-        try:
-            method = getattr(
-                graph_updater.factory.import_processor, "_resolve_relative_import"
-            )
-            assert callable(method)
-        except Exception as e:
-            pytest.fail(f"Relative import resolution method check failed: {e}")
+        method = getattr(
+            graph_updater.factory.import_processor, "_resolve_relative_import"
+        )
+        assert callable(method)
 
     def test_language_specific_import_methods(
         self, graph_updater: GraphUpdater
@@ -146,15 +128,10 @@ class TestImportParsing:
         graph_updater.function_registry = FunctionRegistryTrie()
         assert len(graph_updater.function_registry) == 0
 
-        try:
-            result = (
-                graph_updater.factory.call_processor._resolver.resolve_function_call(
-                    "nonexistent", module_qn
-                )
-            )
-            assert result is None
-        except Exception as e:
-            pytest.fail(f"Function resolution crashed unexpectedly: {e}")
+        result = graph_updater.factory.call_processor._resolver.resolve_function_call(
+            "nonexistent", module_qn
+        )
+        assert result is None
 
     def test_python_alias_import_parsing(self) -> None:
         PY_LANGUAGE = Language(tsp.language())

--- a/codebase_rag/tests/test_parser_fingerprint.py
+++ b/codebase_rag/tests/test_parser_fingerprint.py
@@ -91,7 +91,9 @@ class TestComputeParserFingerprint:
         parsers_dir = pkg / cs.PARSER_FINGERPRINT_SOURCE_DIRS[0]
         parsers_dir.mkdir(parents=True)
         (parsers_dir / "some_parser.py").write_text("A = 1\n")
-        assert compute_parser_fingerprint(pkg) == compute_parser_fingerprint(pkg)
+        first = compute_parser_fingerprint(pkg)
+        second = compute_parser_fingerprint(pkg)
+        assert first == second
 
     def test_changes_when_roslyn_tool_source_changes(self, tmp_path: Path) -> None:
         # The bundled Roslyn frontend tool (.cs/.csproj) is parser code: an

--- a/codebase_rag/tests/test_slots_lazy_logger.py
+++ b/codebase_rag/tests/test_slots_lazy_logger.py
@@ -25,7 +25,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
 SLOTS_CLASSES: list[tuple[type, tuple[str, ...]]] = [
-    (FileEditor, ("project_root", "dmp", "parsers")),
+    (FileEditor, ("project_root", "dmp", "parsers", "_write_lock")),
     (CodeRetriever, ("project_root", "ingestor", "_project_roots")),
     (FileReader, ("project_root",)),
     (FileWriter, ("project_root",)),

--- a/codebase_rag/tools/file_editor.py
+++ b/codebase_rag/tools/file_editor.py
@@ -21,12 +21,15 @@ from . import tool_descriptions as td
 
 
 class FileEditor:
-    __slots__ = ("project_root", "dmp", "parsers")
+    __slots__ = ("project_root", "dmp", "parsers", "_write_lock")
 
     def __init__(self, project_root: str = ".") -> None:
         self.project_root = Path(project_root).resolve()
         self.dmp = diff_match_patch.diff_match_patch()
         self.parsers, _ = load_parsers()
+        # ponytail: one lock serialises all async writes; per-path locks if
+        # write contention ever matters.
+        self._write_lock = asyncio.Lock()
         logger.info(ls.FILE_EDITOR_INIT.format(root=self.project_root))
 
     def _get_real_extension(self, file_path_obj: Path) -> str:
@@ -267,9 +270,10 @@ class FileEditor:
                 logger.warning(ls.FILE_EDITOR_WARN.format(msg=error_msg))
                 return EditResult(file_path=str(file_path), error_message=error_msg)
 
-            await asyncio.to_thread(
-                file_path.write_text, new_content, encoding=cs.ENCODING_UTF8
-            )
+            async with self._write_lock:
+                await asyncio.to_thread(
+                    file_path.write_text, new_content, encoding=cs.ENCODING_UTF8
+                )
 
             logger.success(ls.TOOL_FILE_EDIT_SUCCESS.format(path=file_path))
             return EditResult(file_path=str(file_path), success=True)

--- a/codebase_rag/tools/file_editor.py
+++ b/codebase_rag/tools/file_editor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import difflib
 from pathlib import Path
 
@@ -266,8 +267,9 @@ class FileEditor:
                 logger.warning(ls.FILE_EDITOR_WARN.format(msg=error_msg))
                 return EditResult(file_path=str(file_path), error_message=error_msg)
 
-            with open(file_path, "w", encoding=cs.ENCODING_UTF8) as f:
-                f.write(new_content)
+            await asyncio.to_thread(
+                file_path.write_text, new_content, encoding=cs.ENCODING_UTF8
+            )
 
             logger.success(ls.TOOL_FILE_EDIT_SUCCESS.format(path=file_path))
             return EditResult(file_path=str(file_path), success=True)

--- a/codebase_rag/vector_store.py
+++ b/codebase_rag/vector_store.py
@@ -5,6 +5,7 @@ import time
 from collections.abc import Callable, Sequence
 from importlib.metadata import PackageNotFoundError, version
 from typing import Any, Protocol, cast
+from urllib.parse import urlsplit
 
 from loguru import logger
 
@@ -558,7 +559,7 @@ def _normalize_milvus_score(raw_score: float) -> float:
 
 def _uses_milvus_lite_30_cosine_distance() -> bool:
     uri = settings.MILVUS_URI
-    if uri.startswith(("http://", "https://", "tcp://")):
+    if urlsplit(uri).scheme in ("http", "https", "tcp"):
         return False
     try:
         lite_version = version("milvus-lite")

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,13 +7,6 @@ sonar.tests=codebase_rag/tests
 sonar.exclusions=**/__pycache__/**,**/*.pyc,codebase_rag/tests/**
 sonar.security.exclusions=codebase_rag/tests/**
 
-# S5332 (clear-text HTTP): stack/health.py probes readiness of containers the
-# stack manager launches on the local machine; the endpoints are loopback-only
-# and speak plain HTTP by design.
-sonar.issue.ignore.multicriteria=e1
-sonar.issue.ignore.multicriteria.e1.ruleKey=python:S5332
-sonar.issue.ignore.multicriteria.e1.resourceKey=codebase_rag/stack/health.py
-
 sonar.python.version=3.12
 sonar.python.coverage.reportPaths=coverage.xml
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,6 +7,13 @@ sonar.tests=codebase_rag/tests
 sonar.exclusions=**/__pycache__/**,**/*.pyc,codebase_rag/tests/**
 sonar.security.exclusions=codebase_rag/tests/**
 
+# S5332 (clear-text HTTP): stack/health.py probes readiness of containers the
+# stack manager launches on the local machine; the endpoints are loopback-only
+# and speak plain HTTP by design.
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=python:S5332
+sonar.issue.ignore.multicriteria.e1.resourceKey=codebase_rag/stack/health.py
+
 sonar.python.version=3.12
 sonar.python.coverage.reportPaths=coverage.xml
 

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.464"
+version = "0.0.467"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
The main branch quality gate fails on new-code reliability rating E and security rating B (25 bugs, 3 vulnerabilities). This resolves all 28 findings, which flips the README quality gate badge back to passing on the next main analysis.

Fixes by rule:

- S8494 (12 BLOCKER): FunctionIngestMixin and ClassIngestMixin declared __slots__ = () while lazily creating _deferred_* registries on self. Real per-mixin slots are impossible because JsTsModuleSystemMixin already owns the single allowed non-empty slot layout in DefinitionProcessor's bases (two non-empty-slot bases raise a lay-out conflict). The empty __slots__ was therefore a false promise; removed it. No runtime change: the host class has a __dict__.
- S5779 (5 CRITICAL): test_import_parsing.py wrapped asserts in try/except blocks that caught AssertionError and converted failures to pytest.fail; unwrapped to plain asserts.
- S7497 (3 MAJOR): cancel-and-drain in main.py now uses asyncio.gather(task, return_exceptions=True) instead of swallowing CancelledError, and the status-bar refresh loop lets cancellation propagate instead of catching it.
- S7502 (2 MAJOR): fire-and-forget asyncio.create_task calls for the context-token refresher could be garbage collected mid-flight; added _spawn_background, which retains tasks in a module-level set until done. Covered by a new RED-first unit test (test_background_task_retention.py).
- S7493 (2 MAJOR): synchronous file I/O in async functions (file_editor._edit_validated write, mcp read_file pagination) moved to asyncio.to_thread; the mcp read logic extracted into a sync _read_file_slice helper.
- S2583 (1 MAJOR): _resolve_method_qualified_name returns early for fewer than three dotted parts, so the later len(parts) >= 3 guards were always true; removed them and the unreachable return None.
- S5863 (1 MAJOR): the fingerprint determinism test asserted an expression against itself; split into two variables.
- S5332 (3 MINOR): vector_store scheme sniffing now uses urllib.parse.urlsplit instead of an "http://" prefix literal. stack/health.py keeps its plain-HTTP readiness probe because it only targets containers the stack manager launches locally; recorded as a reasoned exclusion for python:S5332 in sonar-project.properties.

Local verification: ruff, ruff format, and ty all pass; full suite 5963 passed with 9 pre-existing failures that reproduce identically on current main (unmocked CLI --clean tests racing against a live local Qdrant, filed as #905).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling so interrupted or timed-out operations shut down cleanly.
  * Prevented overlapping file edits by serializing concurrent writes.
  * Improved paginated file reading with accurate line counts.
  * Refined method-qualified-name resolution and improved vector scoring normalization across Milvus Lite connection types.
  * Qdrant health checks and stack status now consistently target the local loopback endpoint.

* **Tests**
  * Added coverage for background task retention and concurrent file-write serialization.
  * Simplified import parsing and fingerprint validation tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->