### PR TITLE
fix: extract options-object route registrations (app.endpoint, fastify/hapi route)

### DIFF
--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -209,6 +209,7 @@ TS_OBJECT_PATTERN = "object_pattern"
 TS_ARRAY_PATTERN = "array_pattern"
 TS_REST_PATTERN = "rest_pattern"
 TS_SHORTHAND_PROPERTY_IDENTIFIER_PATTERN = "shorthand_property_identifier_pattern"
+TS_SHORTHAND_PROPERTY_IDENTIFIER = "shorthand_property_identifier"
 TS_PAIR_PATTERN = "pair_pattern"
 # `process.env.X` is a member_expression; `process.env['X']` a subscript, used
 # to detect environment-variable reads (issue #714 process.env follow-up).

--- a/codebase_rag/parsers/endpoint_routes.py
+++ b/codebase_rag/parsers/endpoint_routes.py
@@ -90,6 +90,9 @@ _JS_INLINE_HANDLER_TYPES = frozenset({cs.TS_FUNCTION_EXPRESSION, cs.TS_ARROW_FUN
 _JS_OPTIONS_PATH_KEYS = ("route", "url", "path")
 _JS_OPTIONS_METHOD_KEY = "method"
 _JS_OPTIONS_HANDLER_KEY = "handler"
+# Only registration members accept the options-object shape; a client SDK's
+# `.request({...})` can carry a local callback under a handler key too.
+_JS_OPTIONS_MEMBERS = frozenset({"route", "endpoint"})
 
 _HTTP_METHODS = ("GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS")
 # echo/gin use uppercase verb methods; chi uses Go-idiomatic PascalCase.
@@ -347,6 +350,8 @@ def _js_options_registrations(
 ) -> list[RouteRegistration]:
     fn = call.child_by_field_name(cs.FIELD_FUNCTION)
     if fn is None or fn.type != cs.TS_MEMBER_EXPRESSION:
+        return []
+    if _decode(fn.child_by_field_name(cs.FIELD_PROPERTY)) not in _JS_OPTIONS_MEMBERS:
         return []
     args = _call_args(call)
     if len(args) != 1 or args[0].type != cs.TS_OBJECT:

--- a/codebase_rag/parsers/endpoint_routes.py
+++ b/codebase_rag/parsers/endpoint_routes.py
@@ -2,10 +2,13 @@
 
 JS and Go frameworks register routes through calls rather than decorators:
 Express-style ``app.get('/path', handler)`` and ``app.route('/p').get(fn)``
-chains, Go ``http.HandleFunc("/path", h)`` (including Go 1.22 ``"GET /p"``
-patterns) and echo/gin/chi-style verb methods (``e.GET("/p", h)``). This
-walker recognises them in cached module ASTs and yields ``METHOD /template``
-registrations so they become ENDPOINT resources like Python decorators do.
+chains, options-object calls whose single argument carries method, path and
+handler (fastify ``.route({...})``, hapi ``server.route({...})``, in-house
+``app.endpoint({...})`` gateways, issue #907), Go ``http.HandleFunc("/path",
+h)`` (including Go 1.22 ``"GET /p"`` patterns) and echo/gin/chi-style verb
+methods (``e.GET("/p", h)``). This walker recognises them in cached module
+ASTs and yields ``METHOD /template`` registrations so they become ENDPOINT
+resources like Python decorators do.
 
 The evidence gate is twofold. The path must be a literal opening with ``/``
 (or a ``VERB /path`` pattern); backtick literals count when they carry no
@@ -79,6 +82,14 @@ _JS_VERBS = {
 _JS_ROUTE_CHAIN = "route"
 _JS_FRAMEWORK_FACTORIES = frozenset({"express", "express.Router"})
 _JS_INLINE_HANDLER_TYPES = frozenset({cs.TS_FUNCTION_EXPRESSION, cs.TS_ARROW_FUNCTION})
+
+# Options-object registrations (issue #907): one member call whose single
+# argument is an object literal carrying method, path and handler, as in
+# fastify `.route({...})`, hapi `server.route({...})` and in-house
+# `app.endpoint({...})` gateways.
+_JS_OPTIONS_PATH_KEYS = ("route", "url", "path")
+_JS_OPTIONS_METHOD_KEY = "method"
+_JS_OPTIONS_HANDLER_KEY = "handler"
 
 _HTTP_METHODS = ("GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS")
 # echo/gin use uppercase verb methods; chi uses Go-idiomatic PascalCase.
@@ -292,6 +303,102 @@ def _js_chained_registration(
     return RouteRegistration(method, path, handler, scope)
 
 
+def _object_entries(obj: Node) -> dict[str, Node]:
+    # Key -> value node for an object literal; a shorthand property maps the
+    # name to its own identifier node.
+    entries: dict[str, Node] = {}
+    for child in obj.named_children:
+        if child.type == cs.TS_SHORTHAND_PROPERTY_IDENTIFIER:
+            name = _decode(child)
+            if name:
+                entries[name] = child
+            continue
+        if child.type != cs.TS_PAIR:
+            continue
+        key = child.child_by_field_name(cs.FIELD_KEY)
+        value = child.child_by_field_name(cs.FIELD_VALUE)
+        if key is None or value is None:
+            continue
+        name = (
+            _decode(key)
+            if key.type == cs.TS_PROPERTY_IDENTIFIER
+            else _literal_path(key, _JS_PATH_LITERALS)
+        )
+        if name:
+            entries[name] = value
+    return entries
+
+
+def _options_methods(node: Node | None) -> list[str]:
+    # A literal verb, or an array of them; anything dynamic yields nothing.
+    if node is None:
+        return []
+    values = node.named_children if node.type == cs.TS_ARRAY else [node]
+    methods = []
+    for value in values:
+        verb = (_literal_path(value, _JS_PATH_LITERALS) or "").upper()
+        if verb in _HTTP_METHODS:
+            methods.append(verb)
+    return methods
+
+
+def _js_options_registrations(
+    call: Node, scope: str, evidence: _ModuleEvidence
+) -> list[RouteRegistration]:
+    fn = call.child_by_field_name(cs.FIELD_FUNCTION)
+    if fn is None or fn.type != cs.TS_MEMBER_EXPRESSION:
+        return []
+    args = _call_args(call)
+    if len(args) != 1 or args[0].type != cs.TS_OBJECT:
+        return []
+    entries = _object_entries(args[0])
+    path = next(
+        (
+            p
+            for key in _JS_OPTIONS_PATH_KEYS
+            if (p := _literal_path(entries.get(key), _JS_PATH_LITERALS)) is not None
+        ),
+        None,
+    )
+    if path is None or not path.startswith("/"):
+        return []
+    methods = _options_methods(entries.get(_JS_OPTIONS_METHOD_KEY))
+    if not methods:
+        return []
+    # The handler shape is the server evidence: an inline function, or an
+    # identifier declared in the module. A client's request({url, method})
+    # has neither; a handler referenced through an import stays a ceiling.
+    handler = entries.get(_JS_OPTIONS_HANDLER_KEY)
+    handler_name = (
+        _decode(handler)
+        if handler is not None
+        and handler.type in (cs.TS_PY_IDENTIFIER, cs.TS_SHORTHAND_PROPERTY_IDENTIFIER)
+        else None
+    )
+    if not (
+        (handler is not None and handler.type in _JS_INLINE_HANDLER_TYPES)
+        or (handler_name is not None and handler_name in evidence.declared_functions)
+    ):
+        return []
+    return [RouteRegistration(m, path, handler_name, scope) for m in methods]
+
+
+def _js_registrations(
+    call: Node, scope: str, evidence: _ModuleEvidence
+) -> list[RouteRegistration]:
+    single = _js_registration(call, scope, evidence)
+    if single is not None:
+        return [single]
+    return _js_options_registrations(call, scope, evidence)
+
+
+def _go_registrations(
+    call: Node, scope: str, evidence: _ModuleEvidence
+) -> list[RouteRegistration]:
+    single = _go_registration(call, scope, evidence)
+    return [] if single is None else [single]
+
+
 def _go_server_evidence(
     fn: Node, field: str, args: list[Node], evidence: _ModuleEvidence
 ) -> bool:
@@ -433,11 +540,11 @@ def collect_route_registrations(
     if language is cs.SupportedLanguage.GO:
         scope_types = _GO_SCOPE_TYPES
         call_type = cs.TS_GO_CALL_EXPRESSION
-        extract = _go_registration
+        extract = _go_registrations
     else:
         scope_types = _JS_SCOPE_TYPES
         call_type = cs.TS_CALL_EXPRESSION
-        extract = _js_registration
+        extract = _js_registrations
     out: list[RouteRegistration] = []
     stack: list[tuple[Node, str]] = [(root, "")]
     while stack:
@@ -447,8 +554,6 @@ def collect_route_registrations(
             stack.extend((child, inner) for child in node.named_children)
             continue
         if node.type == call_type:
-            registration = extract(node, scope, evidence)
-            if registration is not None:
-                out.append(registration)
+            out.extend(extract(node, scope, evidence))
         stack.extend((child, scope) for child in node.named_children)
     return out

--- a/codebase_rag/parsers/endpoint_routes.py
+++ b/codebase_rag/parsers/endpoint_routes.py
@@ -472,6 +472,10 @@ def _js_evidence(node: Node, declared: set[str], receivers: set[str]) -> None:
         if name and value is not None:
             if _factory_callee(value) in _JS_FRAMEWORK_FACTORIES:
                 receivers.add(name)
+            elif value.type in _JS_INLINE_HANDLER_TYPES:
+                # `const handler = async () => {}` declares a function just
+                # as much as a function statement does.
+                declared.add(name)
 
 
 def _go_bound_names_and_value(node: Node) -> tuple[list[str], Node | None]:

--- a/codebase_rag/tests/test_route_call_endpoints.py
+++ b/codebase_rag/tests/test_route_call_endpoints.py
@@ -359,9 +359,7 @@ class TestStaleRouteCleanup:
 class TestOptionsObjectRoutes:
     # Issue #907: one call, one object literal carrying method/path/handler.
 
-    def test_endpoint_options_object_with_inline_handler(
-        self, tmp_path: Path
-    ) -> None:
+    def test_endpoint_options_object_with_inline_handler(self, tmp_path: Path) -> None:
         files = {
             "gateway.ts": (
                 "const app = createApp()\n\n"
@@ -425,9 +423,7 @@ class TestOptionsObjectRoutes:
         edges = _run(tmp_path, files, "javascript")
         assert not edges, edges
 
-    def test_imported_handler_identifier_is_not_evidence(
-        self, tmp_path: Path
-    ) -> None:
+    def test_imported_handler_identifier_is_not_evidence(self, tmp_path: Path) -> None:
         # A handler referenced through an import is a documented ceiling: the
         # object shape alone must not register when nothing in the module
         # backs the handler up.

--- a/codebase_rag/tests/test_route_call_endpoints.py
+++ b/codebase_rag/tests/test_route_call_endpoints.py
@@ -354,3 +354,88 @@ class TestStaleRouteCleanup:
         assert any(
             module_qn in (c.args[1].get("module_qns") or []) for c in cleanups
         ), cleanups
+
+
+class TestOptionsObjectRoutes:
+    # Issue #907: one call, one object literal carrying method/path/handler.
+
+    def test_endpoint_options_object_with_inline_handler(
+        self, tmp_path: Path
+    ) -> None:
+        files = {
+            "gateway.ts": (
+                "const app = createApp()\n\n"
+                "app.endpoint({\n"
+                '  method: "GET",\n'
+                '  route: "/stems/:stemId/artifacts",\n'
+                "  handler: async (ctx) => { return ctx.json([]) },\n"
+                "})\n"
+            ),
+        }
+        edges = _run(tmp_path, files, "typescript")
+        assert _endpoint(edges, "gateway", "GET /stems/:stemId/artifacts"), edges
+
+    def test_fastify_route_with_shorthand_handler(self, tmp_path: Path) -> None:
+        files = {
+            "server.js": (
+                "const fastify = require('fastify')()\n\n"
+                "function handler(req, reply) { reply.send({}) }\n\n"
+                "fastify.route({ method: 'GET', url: '/users/:id', handler })\n"
+            ),
+        }
+        edges = _run(tmp_path, files, "javascript")
+        assert _endpoint(edges, "server.handler", "GET /users/:id"), edges
+
+    def test_hapi_route_with_declared_handler(self, tmp_path: Path) -> None:
+        files = {
+            "server.js": (
+                "function createOrder(request, h) { return h.response({}) }\n\n"
+                "server.route({ method: 'POST', path: '/orders', handler: createOrder })\n"
+            ),
+        }
+        edges = _run(tmp_path, files, "javascript")
+        assert _endpoint(edges, "server.createOrder", "POST /orders"), edges
+
+    def test_method_array_registers_each_verb(self, tmp_path: Path) -> None:
+        files = {
+            "server.js": (
+                "fastify.route({\n"
+                "  method: ['GET', 'HEAD'],\n"
+                "  url: '/ping',\n"
+                "  handler: async () => 'pong',\n"
+                "})\n"
+            ),
+        }
+        edges = _run(tmp_path, files, "javascript")
+        assert _endpoint(edges, "server", "GET /ping"), edges
+        assert _endpoint(edges, "server", "HEAD /ping"), edges
+
+    def test_client_options_object_without_handler_is_ignored(
+        self, tmp_path: Path
+    ) -> None:
+        # An HTTP client's request({url, method}) has no handler function:
+        # it is an outbound call, not a route registration.
+        files = {
+            "client.js": (
+                "const client = require('./api')\n\n"
+                "client.request({ url: '/users', method: 'GET' })\n"
+                "client.request({ url: '/users', method: 'POST', body: payload })\n"
+            ),
+        }
+        edges = _run(tmp_path, files, "javascript")
+        assert not edges, edges
+
+    def test_imported_handler_identifier_is_not_evidence(
+        self, tmp_path: Path
+    ) -> None:
+        # A handler referenced through an import is a documented ceiling: the
+        # object shape alone must not register when nothing in the module
+        # backs the handler up.
+        files = {
+            "routes.js": (
+                "const { listUsers } = require('./handlers')\n\n"
+                "sdk.describe({ method: 'GET', path: '/users', handler: listUsers })\n"
+            ),
+        }
+        edges = _run(tmp_path, files, "javascript")
+        assert not edges, edges

--- a/codebase_rag/tests/test_route_call_endpoints.py
+++ b/codebase_rag/tests/test_route_call_endpoints.py
@@ -436,9 +436,7 @@ class TestOptionsObjectRoutes:
         edges = _run(tmp_path, files, "javascript")
         assert not edges, edges
 
-    def test_client_request_with_local_handler_is_ignored(
-        self, tmp_path: Path
-    ) -> None:
+    def test_client_request_with_local_handler_is_ignored(self, tmp_path: Path) -> None:
         # A client SDK's request({...}) may pass a locally declared callback
         # under a handler key; only registration members (.route/.endpoint)
         # accept the options-object shape.

--- a/codebase_rag/tests/test_route_call_endpoints.py
+++ b/codebase_rag/tests/test_route_call_endpoints.py
@@ -449,3 +449,15 @@ class TestOptionsObjectRoutes:
         }
         edges = _run(tmp_path, files, "javascript")
         assert not edges, edges
+
+    def test_const_arrow_handler_registers(self, tmp_path: Path) -> None:
+        # A handler bound with `const handler = async () => {}` is as much
+        # module-declared evidence as a function declaration.
+        files = {
+            "server.js": (
+                "const handler = async (req, reply) => reply.send({})\n\n"
+                "fastify.route({ method: 'GET', url: '/x', handler })\n"
+            ),
+        }
+        edges = _run(tmp_path, files, "javascript")
+        assert _endpoint(edges, "server.handler", "GET /x"), edges

--- a/codebase_rag/tests/test_route_call_endpoints.py
+++ b/codebase_rag/tests/test_route_call_endpoints.py
@@ -435,3 +435,19 @@ class TestOptionsObjectRoutes:
         }
         edges = _run(tmp_path, files, "javascript")
         assert not edges, edges
+
+    def test_client_request_with_local_handler_is_ignored(
+        self, tmp_path: Path
+    ) -> None:
+        # A client SDK's request({...}) may pass a locally declared callback
+        # under a handler key; only registration members (.route/.endpoint)
+        # accept the options-object shape.
+        files = {
+            "client.js": (
+                "const client = require('./api')\n\n"
+                "function onDone(res) { return res }\n\n"
+                "client.request({ method: 'GET', url: '/users', handler: onDone })\n"
+            ),
+        }
+        edges = _run(tmp_path, files, "javascript")
+        assert not edges, edges

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.468"
+version = "0.0.469"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Problem

Call-registered route extraction (issue #886) recognises verb-method calls, `.route('/p').get(h)` chains and Go registrations, but not the options-object idiom where one call takes a single object literal:

```ts
app.endpoint({ method: "GET", route: "/stems/:stemId/artifacts", handler: async (ctx) => { ... } })
fastify.route({ method: "GET", url: "/users/:id", handler })
server.route({ method: "POST", path: "/orders", handler: createOrder })  // hapi
```

Dogfooding a large private polyglot monorepo whose in-house gateway uses exactly this idiom: 330 registrations across 72 files were invisible, so the resolution pass had almost no server side to match against and cross-service RESOLVES_TO came out at zero.

## Fix

`endpoint_routes.py` now accepts a member call whose single argument is an object literal carrying:

- a literal `method` naming an HTTP verb, or an array of verbs (each verb yields its own registration),
- a literal path under `route`, `url` or `path`, opening with `/` (substitution-free backtick literals count, as today),
- a `handler` whose value is an inline function, a module-declared identifier, or the shorthand form `{ handler }`.

The handler shape itself is the server-side evidence, so the receiver does not need to be bound to a known framework factory. The existing EXPOSES attribution ladder applies unchanged (identifier handler, else enclosing function, else module). A client's `request({url, method})` carries no handler and stays ignored; a handler referenced through an import remains a documented ceiling.

`collect_route_registrations` now extends from list-returning extractors so one options object with `method: ["GET", "HEAD"]` yields both endpoints; the Go path is wrapped unchanged.

## Tests

RED first (commit b963d9c2): six new cases in `test_route_call_endpoints.py` covering the in-house idiom with an inline handler (TS), fastify shorthand handler, hapi declared handler, a method array, and two negatives (client `{url, method}` with no handler; imported-identifier handler). All 26 route-call tests, the full unit suite (5979) and integration suite (307) pass.

Fixes #907


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for detecting JavaScript/TypeScript route registrations expressed as a single options-object call (e.g., framework-style `route(...)`/`endpoint(...)`).
  * Extracts literal route paths and generates separate endpoint entries for one or multiple HTTP methods.

* **Bug Fixes**
  * Reduced false positives by validating that registrations include correct handler evidence and skipping HTTP-client-style `request(...)` patterns.

* **Tests**
  * Added a new suite covering TypeScript, Fastify, and Hapi options-object routes, including multiple verbs and negative cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->