### PR TITLE
fix: test modules must not emit ENDPOINT resources

### DIFF
--- a/codebase_rag/dead_code.py
+++ b/codebase_rag/dead_code.py
@@ -10,6 +10,7 @@ from fnmatch import fnmatch
 
 from . import constants as cs
 from . import cypher_queries as cq
+from .path_filters import matches_test_path
 from .types_defs import (
     DeadCodeConfig,
     GraphQueryClient,
@@ -162,17 +163,6 @@ def _is_csharp_operator_or_finalizer_root(name: str, path: str) -> bool:
     )
 
 
-def _matches_test_path(path: str, patterns: tuple[str, ...]) -> bool:
-    # Match test-path patterns against a leading-slash-normalized path so a dir
-    # pattern like `/tests/` also matches a ROOT `tests/` dir (Rust integration
-    # tests, a top-level tests/ folder), not just a nested `src/tests/`. The
-    # leading slash keeps `contests/` from matching `/tests/`.
-    normalized = (
-        path if path.startswith(cs.SEPARATOR_SLASH) else cs.SEPARATOR_SLASH + path
-    )
-    return any(pattern in normalized for pattern in patterns)
-
-
 def _has_root_decorator(props: PropertyDict, root_decorators: frozenset[str]) -> bool:
     decorators = props.get(cs.KEY_DECORATORS)
     if not isinstance(decorators, list):
@@ -222,7 +212,7 @@ def dead_code_from_graph(
             # With tests excluded, a test-file symbol's only callers are
             # excluded as roots, so reporting it is noise (test helpers and
             # mocks are infrastructure, not dead production code).
-            if not config.include_tests and _matches_test_path(
+            if not config.include_tests and matches_test_path(
                 str(props.get(cs.KEY_PATH) or ""), config.test_patterns
             ):
                 continue
@@ -254,7 +244,7 @@ def dead_code_from_graph(
         if target_qn not in candidates:
             continue
         path = module_path.get(str(from_val), "")
-        is_test = _matches_test_path(path, config.test_patterns)
+        is_test = matches_test_path(path, config.test_patterns)
         if config.include_tests or not is_test:
             roots.add(target_qn)
     protocol_stubs = {m for c, m in class_methods if c in protocol_classes}
@@ -317,7 +307,7 @@ def dead_code_from_graph(
             roots.add(qn)
         elif any(qn.endswith(entry) for entry in config.entry_points):
             roots.add(qn)
-        elif config.include_tests and _matches_test_path(path, config.test_patterns):
+        elif config.include_tests and matches_test_path(path, config.test_patterns):
             roots.add(qn)
 
     adjacency: dict[str, set[str]] = defaultdict(set)

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -62,6 +62,7 @@ from .parsers.endpoints import (
 )
 from .parsers.factory import ProcessorFactory
 from .parsers.utils import sorted_captures
+from .path_filters import matches_test_path
 from .services import FilteringIngestor, IngestorProtocol, QueryProtocol
 from .services.resource_cleanup import prune_unanchored_resources
 from .types_defs import (
@@ -819,6 +820,15 @@ class GraphUpdater:
         )
         registry = build_router_registry(module_asts)
         for label, qn, decorators, module_qn in entries:
+            # Test modules stay in the stale-EXPOSES drop above (so a
+            # legacy graph sheds their endpoints) but emit nothing: a route
+            # spun up inside a test is not a production endpoint (#910).
+            if self._is_test_module(
+                self.factory.definition_processor.module_qn_to_file_path.get(
+                    module_qn or ""
+                )
+            ):
+                continue
             emit_endpoints(
                 self._sink,
                 label,
@@ -853,7 +863,10 @@ class GraphUpdater:
         # still sheds its old EXPOSES edges even though it contributes no new
         # registrations.
         self._drop_stale_module_exposes(sorted(modules))
-        for module_qn, (root, language) in modules.items():
+        for module_qn, (root, language, path) in modules.items():
+            # Kept in the cleanup above, skipped for emission (#910).
+            if self._is_test_module(path):
+                continue
             for registration in collect_route_registrations(root, language):
                 label, source_qn = self._route_source(module_qn, registration)
                 identity = f"{registration.method} {registration.path}"
@@ -898,17 +911,29 @@ class GraphUpdater:
 
     def _route_module_asts(
         self,
-    ) -> dict[str, tuple[Node, cs.SupportedLanguage]]:
+    ) -> dict[str, tuple[Node, cs.SupportedLanguage, Path]]:
         dp = self.factory.definition_processor
         files: dict[str, Path] = dict(dp.module_qn_to_file_path)
         for qn, path in self._graph_route_module_paths():
             files.setdefault(qn, path)
-        out: dict[str, tuple[Node, cs.SupportedLanguage]] = {}
+        out: dict[str, tuple[Node, cs.SupportedLanguage, Path]] = {}
         for qn, path in files.items():
             entry = self.ast_cache.load(path)
             if entry is not None and entry[1] in ROUTE_CALL_LANGUAGES:
-                out[qn] = entry
+                out[qn] = (entry[0], entry[1], path)
         return out
+
+    def _is_test_module(self, path: Path | None) -> bool:
+        # Judged on the repo-relative POSIX path; an unknown path (a
+        # rehydrated legacy handler) stays permissive. The repo-relative cut
+        # keeps a `/tmp/pytest-*/` parent from classifying the whole run.
+        if path is None:
+            return False
+        try:
+            relative = path.relative_to(self.repo_path)
+        except ValueError:
+            relative = path
+        return matches_test_path(relative.as_posix())
 
     def _graph_route_module_paths(self) -> list[tuple[str, Path]]:
         # Unchanged modules come back from the graph on an incremental run,

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -801,7 +801,8 @@ class GraphUpdater:
         if not self.capture.rel_enabled(cs.RelationshipType.EXPOSES):
             return
         dp = self.factory.definition_processor
-        module_asts = self._python_module_asts()
+        module_files = self._python_module_files()
+        module_asts = self._python_module_asts(module_files)
         entries = list(dp.pending_endpoints)
         # A mount-only incremental change re-parses just the mounting module;
         # the unchanged handlers must still re-emit under the new prefix, so
@@ -823,11 +824,14 @@ class GraphUpdater:
             # Test modules stay in the stale-EXPOSES drop above (so a
             # legacy graph sheds their endpoints) but emit nothing: a route
             # spun up inside a test is not a production endpoint (#910).
-            if self._is_test_module(
-                self.factory.definition_processor.module_qn_to_file_path.get(
-                    module_qn or ""
-                )
-            ):
+            # Rehydrated handlers live in graph-backed modules absent from
+            # the re-parse map, so the merged python-files map goes first.
+            path = module_files.get(
+                module_qn or ""
+            ) or self.factory.definition_processor.module_qn_to_file_path.get(
+                module_qn or ""
+            )
+            if self._is_test_module(path):
                 continue
             emit_endpoints(
                 self._sink,
@@ -932,7 +936,10 @@ class GraphUpdater:
         try:
             relative = path.relative_to(self.repo_path)
         except ValueError:
-            relative = path
+            # Outside the repo means the repo-relative judgement is
+            # impossible; stay permissive rather than matching absolute
+            # segments like a `/tmp/tests/` parent.
+            return False
         return matches_test_path(relative.as_posix())
 
     def _graph_route_module_paths(self) -> list[tuple[str, Path]]:
@@ -976,10 +983,9 @@ class GraphUpdater:
                 out.append(entry)
         return out
 
-    def _python_module_asts(self) -> dict[str, Node]:
+    def _python_module_files(self) -> dict[str, Path]:
         # Re-parsed files first; on an incremental run the unchanged modules
-        # holding the mounts come back from the graph's Module nodes, loaded
-        # through the disk-backed AST cache.
+        # come back from the graph's Module nodes.
         dp = self.factory.definition_processor
         files: dict[str, Path] = {
             qn: path
@@ -988,6 +994,10 @@ class GraphUpdater:
         }
         for qn, path in self._graph_python_modules():
             files.setdefault(qn, path)
+        return files
+
+    def _python_module_asts(self, files: Mapping[str, Path]) -> dict[str, Node]:
+        # Loaded through the disk-backed AST cache.
         asts: dict[str, Node] = {}
         for qn, path in files.items():
             entry = self.ast_cache.load(path)

--- a/codebase_rag/path_filters.py
+++ b/codebase_rag/path_filters.py
@@ -1,0 +1,23 @@
+# Path-based source classification shared by the dead-code engine and the
+# endpoint emission passes (issue #910), so both judge "is this a test file"
+# with one heuristic.
+
+from . import constants as cs
+
+
+def matches_test_path(
+    path: str, patterns: tuple[str, ...] = cs.TEST_PATH_PATTERNS
+) -> bool:
+    """True when a repo-relative path names test code.
+
+    Patterns match against a leading-slash-normalized path so a dir pattern
+    like ``/tests/`` also matches a ROOT ``tests/`` dir (Rust integration
+    tests, a top-level tests/ folder), not just a nested ``src/tests/``. The
+    leading slash keeps ``contests/`` from matching ``/tests/``. Callers
+    pass POSIX-style relative paths; an absolute path would let directories
+    outside the repo (a ``/tmp/pytest-*/`` parent) misclassify everything.
+    """
+    normalized = (
+        path if path.startswith(cs.SEPARATOR_SLASH) else cs.SEPARATOR_SLASH + path
+    )
+    return any(pattern in normalized for pattern in patterns)

--- a/codebase_rag/tests/test_route_call_endpoints.py
+++ b/codebase_rag/tests/test_route_call_endpoints.py
@@ -403,3 +403,66 @@ class TestTestModulesEmitNoEndpoints:
     ) -> None:
         edges = _run(tmp_path, {"api.py": self._PY_SOURCE}, "python")
         assert _endpoint(edges, "api.list_cases", "GET /cases"), edges
+
+    def test_rehydrated_test_module_handler_stays_excluded(
+        self, tmp_path: Path
+    ) -> None:
+        # An incremental run rehydrates unchanged handlers from the graph;
+        # dp.module_qn_to_file_path only covers re-parsed files, so the gate
+        # must also see graph-backed module paths or a test handler fails
+        # open and re-emits after stale cleanup.
+        from codebase_rag.parsers.endpoint_prefixes import (
+            CYPHER_PROJECT_PY_MODULES,
+            CYPHER_PROJECT_ROUTE_HANDLERS,
+        )
+
+        parsers, queries = load_parsers()
+        source = tmp_path / "tests" / "test_api.py"
+        source.parent.mkdir(parents=True)
+        source.write_text(self._PY_SOURCE, encoding="utf-8")
+        project = tmp_path.name
+        module_qn = f"{project}.tests.test_api"
+
+        class _Ingestor:
+            # Concrete (not MagicMock) so isinstance(_, QueryProtocol) holds.
+            def __init__(self) -> None:
+                self.ensure_node_batch = MagicMock()
+                self.ensure_relationship_batch = MagicMock()
+                self.flush_all = MagicMock()
+                self.execute_write = MagicMock()
+
+            def fetch_all(
+                self, query: str, params: dict[str, object] | None = None
+            ) -> list[dict[str, object]]:
+                if query == CYPHER_PROJECT_PY_MODULES:
+                    return [
+                        {
+                            "qualified_name": module_qn,
+                            "path": "tests/test_api.py",
+                        }
+                    ]
+                if query == CYPHER_PROJECT_ROUTE_HANDLERS:
+                    return [
+                        {
+                            "qualified_name": f"{module_qn}.list_cases",
+                            "decorators": ['@app.get("/cases")'],
+                            "labels": ["Function"],
+                        }
+                    ]
+                return []
+
+        ingestor = _Ingestor()
+        updater = GraphUpdater(
+            ingestor=ingestor,
+            repo_path=tmp_path,
+            parsers=parsers,
+            queries=queries,
+            capture=_CAPTURE_IO,
+        )
+        updater._emit_pending_endpoints()
+        exposes = [
+            c
+            for c in ingestor.ensure_relationship_batch.call_args_list
+            if str(c.args[1]) == EXPOSES
+        ]
+        assert not exposes, exposes

--- a/codebase_rag/tests/test_route_call_endpoints.py
+++ b/codebase_rag/tests/test_route_call_endpoints.py
@@ -354,3 +354,57 @@ class TestStaleRouteCleanup:
         assert any(
             module_qn in (c.args[1].get("module_qns") or []) for c in cleanups
         ), cleanups
+
+
+class TestTestModulesEmitNoEndpoints:
+    # Issue #910: routes registered inside test files must not become
+    # production ENDPOINT resources.
+
+    _GO_SOURCE = (
+        "package main\n\n"
+        'import "github.com/gofiber/fiber/v2"\n\n'
+        "func serveCases() {\n"
+        "\tapp := fiber.New()\n"
+        '\tapp.Get("/cases", func(c *fiber.Ctx) error { return nil })\n'
+        "}\n"
+    )
+
+    def test_go_test_module_registers_nothing(self, tmp_path: Path) -> None:
+        edges = _run(tmp_path, {"main_test.go": self._GO_SOURCE}, "go")
+        assert not edges, edges
+
+    def test_same_go_registration_outside_tests_registers(
+        self, tmp_path: Path
+    ) -> None:
+        edges = _run(tmp_path, {"routes.go": self._GO_SOURCE}, "go")
+        assert _endpoint(edges, "routes.serveCases", "GET /cases"), edges
+
+    _JS_SOURCE = (
+        "const express = require('express')\n"
+        "const app = express()\n\n"
+        "function getCases(req, res) { res.json([]) }\n\n"
+        "app.get('/cases', getCases)\n"
+    )
+
+    def test_js_test_module_registers_nothing(self, tmp_path: Path) -> None:
+        edges = _run(tmp_path, {"api.test.js": self._JS_SOURCE}, "javascript")
+        assert not edges, edges
+
+    _PY_SOURCE = (
+        "app = object()\n\n\n"
+        '@app.get("/cases")\n'
+        "def list_cases():\n"
+        "    return []\n"
+    )
+
+    def test_python_decorator_in_tests_dir_registers_nothing(
+        self, tmp_path: Path
+    ) -> None:
+        edges = _run(tmp_path, {"tests/test_api.py": self._PY_SOURCE}, "python")
+        assert not edges, edges
+
+    def test_same_python_decorator_outside_tests_registers(
+        self, tmp_path: Path
+    ) -> None:
+        edges = _run(tmp_path, {"api.py": self._PY_SOURCE}, "python")
+        assert _endpoint(edges, "api.list_cases", "GET /cases"), edges

--- a/codebase_rag/tests/test_route_call_endpoints.py
+++ b/codebase_rag/tests/test_route_call_endpoints.py
@@ -373,9 +373,7 @@ class TestTestModulesEmitNoEndpoints:
         edges = _run(tmp_path, {"main_test.go": self._GO_SOURCE}, "go")
         assert not edges, edges
 
-    def test_same_go_registration_outside_tests_registers(
-        self, tmp_path: Path
-    ) -> None:
+    def test_same_go_registration_outside_tests_registers(self, tmp_path: Path) -> None:
         edges = _run(tmp_path, {"routes.go": self._GO_SOURCE}, "go")
         assert _endpoint(edges, "routes.serveCases", "GET /cases"), edges
 
@@ -391,10 +389,7 @@ class TestTestModulesEmitNoEndpoints:
         assert not edges, edges
 
     _PY_SOURCE = (
-        "app = object()\n\n\n"
-        '@app.get("/cases")\n'
-        "def list_cases():\n"
-        "    return []\n"
+        'app = object()\n\n\n@app.get("/cases")\ndef list_cases():\n    return []\n'
     )
 
     def test_python_decorator_in_tests_dir_registers_nothing(

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.468"
+version = "0.0.469"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Problem

Route registrations inside test files became production ENDPOINT resources. A dogfood run showed a Go `_test.go` file spinning up an in-memory server (`app.Get("/cases", func(c *fiber.Ctx) error {...})`) producing an EXPOSES edge attributed to the test function, polluting the endpoint inventory and creating a false cross-service link target for a path that also exists on a real service.

## Fix

The existing test-path heuristic from the dead-code engine is hoisted into a shared `path_filters.matches_test_path` (one heuristic, per the issue), and both emission passes now consult it through a repo-relative POSIX path:

- the decorator pass skips pending handlers whose module path names test code,
- the call-registration pass skips test modules before collecting registrations.

Both passes keep test modules in their stale-EXPOSES cleanup, so a legacy graph sheds previously emitted test endpoints on the next index. The repo-relative cut matters: matching on absolute paths would let a `/tmp/pytest-*/` parent directory classify every module as test code. An unknown path (a rehydrated legacy handler) stays permissive.

## Tests

RED first (commit 30aeb5ae): a Go fiber registration in `main_test.go`, an express registration in `api.test.js`, and a decorated Python handler under `tests/` each emitted an endpoint before the fix and now emit none, while identical registrations in non-test modules still register. Full unit (5978) and integration (307) suites pass.

Fixes #910


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test-file detection with shared path-matching logic.
  * HTTP routes registered in test modules are no longer emitted as production endpoints (including during pending/re-hydration flows).
  * Production routes outside test modules continue to be detected correctly.

* **Tests**
  * Added regression coverage ensuring test-module route registrations (Go/JavaScript/Python) emit no endpoint resources.
  * Added an incremental-run test to confirm the exclusion behavior persists after rehydration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->