### PR TITLE
fix: extract generated Go routes (const-concat paths, attribute handlers)

### DIFF
--- a/codebase_rag/constants/ast_go.py
+++ b/codebase_rag/constants/ast_go.py
@@ -33,6 +33,7 @@ TS_GO_ASSIGNMENT_STATEMENT = "assignment_statement"
 # the selector/subscript node shapes (only used by member-access reads, which Go
 # has none of, so they are inert placeholders here).
 TS_GO_IDENTIFIER = "identifier"
+TS_GO_TYPE_IDENTIFIER = "type_identifier"
 TS_GO_CONST_SPEC = "const_spec"
 TS_GO_RANGE_CLAUSE = "range_clause"
 # The init;cond;post header of a C-style Go for; its post statement lives in

--- a/codebase_rag/parsers/endpoint_routes.py
+++ b/codebase_rag/parsers/endpoint_routes.py
@@ -9,11 +9,14 @@ registrations so they become ENDPOINT resources like Python decorators do.
 
 The evidence gate is twofold. The path must be a literal opening with ``/``
 (or a ``VERB /path`` pattern); backtick literals count when they carry no
-substitution. And the call must look like a SERVER registration, not an
-outbound client request: either its receiver is bound in-module to a known
-framework factory (``express()``, ``echo.New()``, ``chi.NewRouter()``, ...),
-or ``http.Handle*`` with ``net/http`` imported, or one of its handler
-arguments is an inline function or a function declared in the module. A bare
+substitution, and Go paths may concatenate module-level string consts
+(``BaseURL+"/x"``, the oapi-codegen shape, issue #909). And the call must
+look like a SERVER registration, not an outbound client request: either its
+receiver is bound in-module to a known framework factory (``express()``,
+``echo.New()``, ``chi.NewRouter()``, ...), or ``http.Handle*`` with
+``net/http`` imported, or one of its handler arguments is an inline
+function, a function declared in the module, or (Go verb methods) an
+attribute expression like ``wrapper.GetMe``. A bare
 ``apiClient.get('/users')`` has none of these and is ignored.
 
 EXPOSES attribution is a ladder: a bare-identifier handler defined in the
@@ -23,8 +26,8 @@ wiring site.
 
 Ceilings (each simply yields nothing, never a wrong template): sub-router
 mounting (``app.use('/prefix', router)``), gorilla mux ``.Methods()``
-chains, handlers referenced through imports or attributes, factories bound
-in a different module.
+chains, JS handlers referenced through imports or attributes, factories and
+consts bound in a different module.
 """
 
 from __future__ import annotations
@@ -36,6 +39,8 @@ from typing import TYPE_CHECKING
 from .. import constants as cs
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from tree_sitter import Node
 
 METHOD_ANY = "ANY"
@@ -98,6 +103,7 @@ _GO_FRAMEWORK_FACTORIES = frozenset(
 )
 _GO_HTTP_PACKAGE = "http"
 _GO_NET_HTTP_IMPORT = "net/http"
+_GO_CONCAT_OPERATOR = "+"
 # Go 1.22 ServeMux patterns: "GET /products/{id}".
 _GO_PATTERN_RE = re.compile(r"^(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS) (/\S*)$")
 
@@ -124,11 +130,15 @@ class RouteRegistration:
 @dataclass(frozen=True)
 class _ModuleEvidence:
     # Server-side evidence collected in a pre-pass: functions declared in the
-    # module, receivers bound to a framework factory, and whether net/http is
-    # imported (which legitimises `http.Handle*`).
+    # module, receivers bound to a framework factory, whether net/http is
+    # imported (which legitimises `http.Handle*`), and module-level string
+    # consts (which resolve generated `BaseURL+"/x"` paths, issue #909).
+    # Module scope only: a flat map of function locals could leak one
+    # function's binding into another and mint a WRONG template.
     declared_functions: frozenset[str]
     framework_receivers: frozenset[str]
     net_http_imported: bool
+    module_consts: Mapping[str, str]
 
 
 def _decode(node: Node | None) -> str | None:
@@ -303,9 +313,43 @@ def _go_server_evidence(
         and _decode(fn.child_by_field_name(cs.FIELD_OPERAND)) == _GO_HTTP_PACKAGE
     ):
         return True
+    # A generated `router.Get(BaseURL+"/x", wrapper.GetMe)` hands an
+    # attribute-expression handler to a verb method; with a rooted path this
+    # is registration shape, not a client call (issue #909).
+    if field in _GO_VERB_METHODS and any(
+        arg.type == cs.TS_GO_SELECTOR_EXPRESSION for arg in args[1:]
+    ):
+        return True
     return _handler_evidence(
         args[1:], evidence, frozenset({cs.TS_GO_FUNC_LITERAL}), cs.TS_GO_IDENTIFIER
     )
+
+
+def _go_path_value(
+    node: Node | None, evidence: _ModuleEvidence, depth: int = 0
+) -> str | None:
+    # A literal, a module-level string const, or a `+` concatenation of
+    # those (oapi-codegen keeps BaseURL adjacent to its routes, issue #909).
+    if node is None or depth > _CHAIN_DEPTH_LIMIT:
+        return None
+    literal = _literal_path(node, _GO_PATH_LITERALS)
+    if literal is not None:
+        return literal
+    if node.type == cs.TS_GO_IDENTIFIER:
+        return evidence.module_consts.get(_decode(node) or "")
+    if (
+        node.type == cs.TS_BINARY_EXPRESSION
+        and _decode(node.child_by_field_name(cs.FIELD_OPERATOR)) == _GO_CONCAT_OPERATOR
+    ):
+        left = _go_path_value(
+            node.child_by_field_name(cs.TS_FIELD_LEFT), evidence, depth + 1
+        )
+        right = _go_path_value(
+            node.child_by_field_name(cs.TS_FIELD_RIGHT), evidence, depth + 1
+        )
+        if left is not None and right is not None:
+            return left + right
+    return None
 
 
 def _go_registration(
@@ -316,7 +360,7 @@ def _go_registration(
         return None
     field = _decode(fn.child_by_field_name(cs.FIELD_FIELD))
     args = _call_args(call)
-    path = _literal_path(args[0] if args else None, _GO_PATH_LITERALS)
+    path = _go_path_value(args[0] if args else None, evidence)
     if path is None or field is None:
         return None
     if not _go_server_evidence(fn, field, args, evidence):
@@ -385,12 +429,44 @@ def _go_bound_names_and_value(node: Node) -> tuple[list[str], Node | None]:
     return names, value
 
 
-def _go_evidence(node: Node, declared: set[str], receivers: set[str]) -> bool:
+def _go_module_const(node: Node) -> tuple[str, str] | None:
+    # `const BaseURL = "/api/v1"` at FILE scope (also inside a const block):
+    # (name, literal). Anything scoped, multi-named, or non-literal is None.
+    if node.type != cs.TS_GO_CONST_SPEC:
+        return None
+    declaration = node.parent
+    if (
+        declaration is None
+        or declaration.parent is None
+        or declaration.parent.type != cs.TS_GO_SOURCE_FILE
+    ):
+        return None
+    names = [c for c in node.named_children if c.type == cs.TS_GO_IDENTIFIER]
+    value = node.child_by_field_name(cs.FIELD_VALUE)
+    if value is not None and value.type == cs.TS_GO_EXPRESSION_LIST:
+        values = value.named_children
+        value = values[0] if len(values) == 1 else None
+    if len(names) != 1 or value is None:
+        return None
+    name = _decode(names[0])
+    literal = _literal_path(value, _GO_PATH_LITERALS)
+    if name is None or literal is None:
+        return None
+    return name, literal
+
+
+def _go_evidence(
+    node: Node, declared: set[str], receivers: set[str], consts: dict[str, str]
+) -> bool:
     # Returns True when the node imports net/http.
     if node.type == cs.TS_GO_FUNCTION_DECLARATION:
         name = _decode(node.child_by_field_name(cs.TS_FIELD_NAME))
         if name:
             declared.add(name)
+        return False
+    const = _go_module_const(node)
+    if const is not None:
+        consts[const[0]] = const[1]
         return False
     names, value = _go_bound_names_and_value(node)
     if names and value is not None:
@@ -405,17 +481,18 @@ def _go_evidence(node: Node, declared: set[str], receivers: set[str]) -> bool:
 def _collect_evidence(root: Node, language: cs.SupportedLanguage) -> _ModuleEvidence:
     declared: set[str] = set()
     receivers: set[str] = set()
+    consts: dict[str, str] = {}
     net_http = False
     stack = [root]
     is_go = language is cs.SupportedLanguage.GO
     while stack:
         node = stack.pop()
         if is_go:
-            net_http = _go_evidence(node, declared, receivers) or net_http
+            net_http = _go_evidence(node, declared, receivers, consts) or net_http
         else:
             _js_evidence(node, declared, receivers)
         stack.extend(node.named_children)
-    return _ModuleEvidence(frozenset(declared), frozenset(receivers), net_http)
+    return _ModuleEvidence(frozenset(declared), frozenset(receivers), net_http, consts)
 
 
 def _child_scope(scope: str, node: Node) -> str:

--- a/codebase_rag/parsers/endpoint_routes.py
+++ b/codebase_rag/parsers/endpoint_routes.py
@@ -16,7 +16,7 @@ receiver is bound in-module to a known framework factory (``express()``,
 ``echo.New()``, ``chi.NewRouter()``, ...), or ``http.Handle*`` with
 ``net/http`` imported, or one of its handler arguments is an inline
 function, a function declared in the module, or (Go verb methods on a
-const-derived path, the generated shape) an attribute expression like
+concatenated path, the generated shape) an attribute expression like
 ``wrapper.GetMe``. A bare ``apiClient.get('/users')`` has none of these
 and is ignored.
 
@@ -308,7 +308,7 @@ def _go_server_evidence(
     field: str,
     args: list[Node],
     evidence: _ModuleEvidence,
-    const_derived_path: bool,
+    concat_path: bool,
 ) -> bool:
     if _receiver_is_framework(fn, evidence):
         return True
@@ -320,10 +320,11 @@ def _go_server_evidence(
         return True
     # A generated `router.Get(BaseURL+"/x", wrapper.GetMe)` hands an
     # attribute-expression handler to a verb method (issue #909). The
-    # const-derived path narrows this to the generated shape: a client's
-    # `c.Get("/users", opts.Header)` passes a plain literal and stays out.
+    # concatenated path narrows this to the generated shape: a client's
+    # `c.Get("/users", opts.Header)` or `c.Get(baseURL, opts.Header)`
+    # passes a plain literal or bare const and stays out.
     if (
-        const_derived_path
+        concat_path
         and field in _GO_VERB_METHODS
         and any(arg.type == cs.TS_GO_SELECTOR_EXPRESSION for arg in args[1:])
     ):
@@ -372,10 +373,10 @@ def _go_registration(
     path = _go_path_value(path_node, evidence)
     if path is None or field is None:
         return None
-    const_derived = (
-        path_node is not None and _literal_path(path_node, _GO_PATH_LITERALS) is None
-    )
-    if not _go_server_evidence(fn, field, args, evidence, const_derived):
+    # Only a CONCATENATION is the generated registration shape; a bare
+    # const identifier can just as well hold a client's URL.
+    concat_path = path_node is not None and path_node.type == cs.TS_BINARY_EXPRESSION
+    if not _go_server_evidence(fn, field, args, evidence, concat_path):
         return None
     handler = _handler_identifier(
         args[1] if len(args) > 1 else None, cs.TS_PY_IDENTIFIER

--- a/codebase_rag/parsers/endpoint_routes.py
+++ b/codebase_rag/parsers/endpoint_routes.py
@@ -140,6 +140,10 @@ class _ModuleEvidence:
     framework_receivers: frozenset[str]
     net_http_imported: bool
     module_consts: Mapping[str, str]
+    # Names bound to a composite literal of a module-declared type
+    # (`wrapper := ServerInterfaceWrapper{...}`): the generated wiring
+    # shape that legitimises selector handlers (issue #909).
+    wrapper_receivers: frozenset[str]
 
 
 def _decode(node: Node | None) -> str | None:
@@ -320,13 +324,19 @@ def _go_server_evidence(
         return True
     # A generated `router.Get(BaseURL+"/x", wrapper.GetMe)` hands an
     # attribute-expression handler to a verb method (issue #909). The
-    # concatenated path narrows this to the generated shape: a client's
-    # `c.Get("/users", opts.Header)` or `c.Get(baseURL, opts.Header)`
-    # passes a plain literal or bare const and stays out.
+    # generated shape is narrow: a concatenated path AND a selector whose
+    # receiver is bound to a composite literal of a module-declared type
+    # (`wrapper := ServerInterfaceWrapper{...}`). A client passing
+    # `opts.Header` after a concat path has no such binding and stays out.
     if (
         concat_path
         and field in _GO_VERB_METHODS
-        and any(arg.type == cs.TS_GO_SELECTOR_EXPRESSION for arg in args[1:])
+        and any(
+            arg.type == cs.TS_GO_SELECTOR_EXPRESSION
+            and (_decode(arg.child_by_field_name(cs.FIELD_OPERAND)) or "")
+            in evidence.wrapper_receivers
+            for arg in args[1:]
+        )
     ):
         return True
     return _handler_evidence(
@@ -469,13 +479,23 @@ def _go_module_const(node: Node) -> tuple[str, str] | None:
 
 
 def _go_evidence(
-    node: Node, declared: set[str], receivers: set[str], consts: dict[str, str]
+    node: Node,
+    declared: set[str],
+    receivers: set[str],
+    consts: dict[str, str],
+    types: set[str],
+    composites: list[tuple[str, str]],
 ) -> bool:
     # Returns True when the node imports net/http.
     if node.type == cs.TS_GO_FUNCTION_DECLARATION:
         name = _decode(node.child_by_field_name(cs.TS_FIELD_NAME))
         if name:
             declared.add(name)
+        return False
+    if node.type == cs.TS_GO_TYPE_SPEC:
+        type_name = _decode(node.child_by_field_name(cs.TS_FIELD_NAME))
+        if type_name:
+            types.add(type_name)
         return False
     const = _go_module_const(node)
     if const is not None:
@@ -485,6 +505,16 @@ def _go_evidence(
     if names and value is not None:
         if _factory_callee(value) in _GO_FRAMEWORK_FACTORIES:
             receivers.update(n for n in names if n)
+        elif value.type == cs.TS_GO_COMPOSITE_LITERAL and len(names) == 1:
+            literal_type = value.child_by_field_name(cs.FIELD_TYPE)
+            type_name = (
+                _decode(literal_type)
+                if literal_type is not None
+                and literal_type.type == cs.TS_GO_TYPE_IDENTIFIER
+                else None
+            )
+            if names[0] and type_name:
+                composites.append((names[0], type_name))
         return False
     return node.type == cs.TS_GO_IMPORT_DECLARATION and f'"{_GO_NET_HTTP_IMPORT}"' in (
         _decode(node) or ""
@@ -495,17 +525,27 @@ def _collect_evidence(root: Node, language: cs.SupportedLanguage) -> _ModuleEvid
     declared: set[str] = set()
     receivers: set[str] = set()
     consts: dict[str, str] = {}
+    types: set[str] = set()
+    composites: list[tuple[str, str]] = []
     net_http = False
     stack = [root]
     is_go = language is cs.SupportedLanguage.GO
     while stack:
         node = stack.pop()
         if is_go:
-            net_http = _go_evidence(node, declared, receivers, consts) or net_http
+            net_http = (
+                _go_evidence(node, declared, receivers, consts, types, composites)
+                or net_http
+            )
         else:
             _js_evidence(node, declared, receivers)
         stack.extend(node.named_children)
-    return _ModuleEvidence(frozenset(declared), frozenset(receivers), net_http, consts)
+    # The type set only completes after the walk, so wrapper bindings are
+    # judged here rather than in-flight.
+    wrappers = frozenset(name for name, type_name in composites if type_name in types)
+    return _ModuleEvidence(
+        frozenset(declared), frozenset(receivers), net_http, consts, wrappers
+    )
 
 
 def _child_scope(scope: str, node: Node) -> str:

--- a/codebase_rag/parsers/endpoint_routes.py
+++ b/codebase_rag/parsers/endpoint_routes.py
@@ -15,9 +15,10 @@ look like a SERVER registration, not an outbound client request: either its
 receiver is bound in-module to a known framework factory (``express()``,
 ``echo.New()``, ``chi.NewRouter()``, ...), or ``http.Handle*`` with
 ``net/http`` imported, or one of its handler arguments is an inline
-function, a function declared in the module, or (Go verb methods) an
-attribute expression like ``wrapper.GetMe``. A bare
-``apiClient.get('/users')`` has none of these and is ignored.
+function, a function declared in the module, or (Go verb methods on a
+const-derived path, the generated shape) an attribute expression like
+``wrapper.GetMe``. A bare ``apiClient.get('/users')`` has none of these
+and is ignored.
 
 EXPOSES attribution is a ladder: a bare-identifier handler defined in the
 module, else the registering call's enclosing function, else the module
@@ -303,7 +304,11 @@ def _js_chained_registration(
 
 
 def _go_server_evidence(
-    fn: Node, field: str, args: list[Node], evidence: _ModuleEvidence
+    fn: Node,
+    field: str,
+    args: list[Node],
+    evidence: _ModuleEvidence,
+    const_derived_path: bool,
 ) -> bool:
     if _receiver_is_framework(fn, evidence):
         return True
@@ -314,10 +319,13 @@ def _go_server_evidence(
     ):
         return True
     # A generated `router.Get(BaseURL+"/x", wrapper.GetMe)` hands an
-    # attribute-expression handler to a verb method; with a rooted path this
-    # is registration shape, not a client call (issue #909).
-    if field in _GO_VERB_METHODS and any(
-        arg.type == cs.TS_GO_SELECTOR_EXPRESSION for arg in args[1:]
+    # attribute-expression handler to a verb method (issue #909). The
+    # const-derived path narrows this to the generated shape: a client's
+    # `c.Get("/users", opts.Header)` passes a plain literal and stays out.
+    if (
+        const_derived_path
+        and field in _GO_VERB_METHODS
+        and any(arg.type == cs.TS_GO_SELECTOR_EXPRESSION for arg in args[1:])
     ):
         return True
     return _handler_evidence(
@@ -360,10 +368,14 @@ def _go_registration(
         return None
     field = _decode(fn.child_by_field_name(cs.FIELD_FIELD))
     args = _call_args(call)
-    path = _go_path_value(args[0] if args else None, evidence)
+    path_node = args[0] if args else None
+    path = _go_path_value(path_node, evidence)
     if path is None or field is None:
         return None
-    if not _go_server_evidence(fn, field, args, evidence):
+    const_derived = (
+        path_node is not None and _literal_path(path_node, _GO_PATH_LITERALS) is None
+    )
+    if not _go_server_evidence(fn, field, args, evidence, const_derived):
         return None
     handler = _handler_identifier(
         args[1] if len(args) > 1 else None, cs.TS_PY_IDENTIFIER

--- a/codebase_rag/parsers/endpoint_routes.py
+++ b/codebase_rag/parsers/endpoint_routes.py
@@ -155,9 +155,11 @@ class _ModuleEvidence:
     net_http_imported: bool
     module_consts: Mapping[str, str]
     # Names bound to a composite literal of a module-declared type
-    # (`wrapper := ServerInterfaceWrapper{...}`): the generated wiring
-    # shape that legitimises selector handlers (issue #909).
-    wrapper_receivers: frozenset[str]
+    # (`wrapper := ServerInterfaceWrapper{...}`), each with the byte span of
+    # its enclosing function (None at file scope): the generated wiring shape
+    # that legitimises selector handlers, but only for calls inside the same
+    # function as the binding (issue #909).
+    wrapper_bindings: frozenset[tuple[str, tuple[int, int] | None]]
 
 
 def _decode(node: Node | None) -> str | None:
@@ -419,6 +421,15 @@ def _go_registrations(
     return [] if single is None else [single]
 
 
+def _wrapper_in_scope(name: str, position: int, evidence: _ModuleEvidence) -> bool:
+    # A file-scope binding (span None) is visible everywhere; a function-local
+    # one only legitimises calls inside that function's byte span.
+    return any(
+        bound == name and (span is None or span[0] <= position < span[1])
+        for bound, span in evidence.wrapper_bindings
+    )
+
+
 def _go_server_evidence(
     fn: Node,
     field: str,
@@ -438,15 +449,19 @@ def _go_server_evidence(
     # attribute-expression handler to a verb method (issue #909). The
     # generated shape is narrow: a concatenated path AND a selector whose
     # receiver is bound to a composite literal of a module-declared type
-    # (`wrapper := ServerInterfaceWrapper{...}`). A client passing
-    # `opts.Header` after a concat path has no such binding and stays out.
+    # (`wrapper := ServerInterfaceWrapper{...}`) in the SAME function (or at
+    # file scope). A client passing `opts.Header` after a concat path has no
+    # in-scope binding and stays out.
     if (
         concat_path
         and field in _GO_VERB_METHODS
         and any(
             arg.type == cs.TS_GO_SELECTOR_EXPRESSION
-            and (_decode(arg.child_by_field_name(cs.FIELD_OPERAND)) or "")
-            in evidence.wrapper_receivers
+            and _wrapper_in_scope(
+                _decode(arg.child_by_field_name(cs.FIELD_OPERAND)) or "",
+                fn.start_byte,
+                evidence,
+            )
             for arg in args[1:]
         )
     ):
@@ -594,13 +609,57 @@ def _go_module_const(node: Node) -> tuple[str, str] | None:
     return name, literal
 
 
+_GO_FUNCTION_SCOPES = frozenset(
+    {cs.TS_GO_FUNCTION_DECLARATION, cs.TS_GO_METHOD_DECLARATION, cs.TS_GO_FUNC_LITERAL}
+)
+
+
+def _go_scope_span(node: Node) -> tuple[int, int] | None:
+    # Byte span of the enclosing function; None at file scope.
+    current = node.parent
+    while current is not None:
+        if current.type in _GO_FUNCTION_SCOPES:
+            return current.start_byte, current.end_byte
+        current = current.parent
+    return None
+
+
+def _go_composite_binding(names: list[str], value: Node) -> tuple[str, str] | None:
+    # `wrapper := SomeType{...}` with a single bound name: (name, type name).
+    if value.type != cs.TS_GO_COMPOSITE_LITERAL or len(names) != 1 or not names[0]:
+        return None
+    literal_type = value.child_by_field_name(cs.FIELD_TYPE)
+    if literal_type is None or literal_type.type != cs.TS_GO_TYPE_IDENTIFIER:
+        return None
+    type_name = _decode(literal_type)
+    if not type_name:
+        return None
+    return names[0], type_name
+
+
+def _go_binding_evidence(
+    node: Node,
+    receivers: set[str],
+    composites: list[tuple[str, str, tuple[int, int] | None]],
+) -> None:
+    names, value = _go_bound_names_and_value(node)
+    if not names or value is None:
+        return
+    if _factory_callee(value) in _GO_FRAMEWORK_FACTORIES:
+        receivers.update(n for n in names if n)
+        return
+    binding = _go_composite_binding(names, value)
+    if binding is not None:
+        composites.append((binding[0], binding[1], _go_scope_span(node)))
+
+
 def _go_evidence(
     node: Node,
     declared: set[str],
     receivers: set[str],
     consts: dict[str, str],
     types: set[str],
-    composites: list[tuple[str, str]],
+    composites: list[tuple[str, str, tuple[int, int] | None]],
 ) -> bool:
     # Returns True when the node imports net/http.
     if node.type == cs.TS_GO_FUNCTION_DECLARATION:
@@ -617,21 +676,7 @@ def _go_evidence(
     if const is not None:
         consts[const[0]] = const[1]
         return False
-    names, value = _go_bound_names_and_value(node)
-    if names and value is not None:
-        if _factory_callee(value) in _GO_FRAMEWORK_FACTORIES:
-            receivers.update(n for n in names if n)
-        elif value.type == cs.TS_GO_COMPOSITE_LITERAL and len(names) == 1:
-            literal_type = value.child_by_field_name(cs.FIELD_TYPE)
-            type_name = (
-                _decode(literal_type)
-                if literal_type is not None
-                and literal_type.type == cs.TS_GO_TYPE_IDENTIFIER
-                else None
-            )
-            if names[0] and type_name:
-                composites.append((names[0], type_name))
-        return False
+    _go_binding_evidence(node, receivers, composites)
     return node.type == cs.TS_GO_IMPORT_DECLARATION and f'"{_GO_NET_HTTP_IMPORT}"' in (
         _decode(node) or ""
     )
@@ -642,7 +687,7 @@ def _collect_evidence(root: Node, language: cs.SupportedLanguage) -> _ModuleEvid
     receivers: set[str] = set()
     consts: dict[str, str] = {}
     types: set[str] = set()
-    composites: list[tuple[str, str]] = []
+    composites: list[tuple[str, str, tuple[int, int] | None]] = []
     net_http = False
     stack = [root]
     is_go = language is cs.SupportedLanguage.GO
@@ -658,7 +703,9 @@ def _collect_evidence(root: Node, language: cs.SupportedLanguage) -> _ModuleEvid
         stack.extend(node.named_children)
     # The type set only completes after the walk, so wrapper bindings are
     # judged here rather than in-flight.
-    wrappers = frozenset(name for name, type_name in composites if type_name in types)
+    wrappers = frozenset(
+        (name, span) for name, type_name, span in composites if type_name in types
+    )
     return _ModuleEvidence(
         frozenset(declared), frozenset(receivers), net_http, consts, wrappers
     )

--- a/codebase_rag/parsers/endpoint_routes.py
+++ b/codebase_rag/parsers/endpoint_routes.py
@@ -647,14 +647,33 @@ def _go_composite_binding(names: list[str], value: Node) -> tuple[str, str] | No
     return names[0], type_name
 
 
+_GO_HANDLER_PARAM_SUFFIXES = frozenset({"ResponseWriter", "Request", "Context", "Ctx"})
+
+
+def _go_handler_signature(node: Node) -> bool:
+    # Generated wrapper methods take http handler parameters
+    # (`w http.ResponseWriter, r *http.Request`) or a framework context
+    # (`ctx echo.Context`); an option method like `Header(timeout int)`
+    # does not (issue #909 review).
+    parameters = node.child_by_field_name(cs.FIELD_PARAMETERS)
+    if parameters is None or not parameters.named_children:
+        return False
+    for parameter in parameters.named_children:
+        type_node = parameter.child_by_field_name(cs.FIELD_TYPE)
+        type_text = (_decode(type_node) or "").lstrip("*")
+        if type_text.rsplit(cs.SEPARATOR_DOT, 1)[-1] not in _GO_HANDLER_PARAM_SUFFIXES:
+            return False
+    return True
+
+
 def _go_method_pair(node: Node) -> tuple[str, str] | None:
-    # `func (siw *ServerInterfaceWrapper) GetMe(...)`: (receiver type, name),
-    # unwrapping a pointer receiver.
+    # `func (siw *ServerInterfaceWrapper) GetMe(...)` with a handler-shaped
+    # parameter list: (receiver type, name), unwrapping a pointer receiver.
     if node.type != cs.TS_GO_METHOD_DECLARATION:
         return None
     name = _decode(node.child_by_field_name(cs.TS_FIELD_NAME))
     receiver = node.child_by_field_name(cs.FIELD_RECEIVER)
-    if not name or receiver is None:
+    if not name or receiver is None or not _go_handler_signature(node):
         return None
     for parameter in receiver.named_children:
         type_node = parameter.child_by_field_name(cs.FIELD_TYPE)

--- a/codebase_rag/parsers/endpoint_routes.py
+++ b/codebase_rag/parsers/endpoint_routes.py
@@ -155,11 +155,15 @@ class _ModuleEvidence:
     net_http_imported: bool
     module_consts: Mapping[str, str]
     # Names bound to a composite literal of a module-declared type
-    # (`wrapper := ServerInterfaceWrapper{...}`), each with the byte span of
-    # its enclosing function (None at file scope): the generated wiring shape
+    # (`wrapper := ServerInterfaceWrapper{...}`) as (name, type, enclosing
+    # function byte span; span None at file scope): the generated wiring shape
     # that legitimises selector handlers, but only for calls inside the same
-    # function as the binding (issue #909).
-    wrapper_bindings: frozenset[tuple[str, tuple[int, int] | None]]
+    # function as the binding AND selector fields that name a method declared
+    # on the bound type in this module (issue #909) — `opts.Header` on an
+    # options struct is a field access, not a wrapper method, and stays out.
+    wrapper_bindings: frozenset[tuple[str, str, tuple[int, int] | None]]
+    # (receiver type name, method name) for every module method declaration.
+    module_methods: frozenset[tuple[str, str]]
 
 
 def _decode(node: Node | None) -> str | None:
@@ -421,12 +425,17 @@ def _go_registrations(
     return [] if single is None else [single]
 
 
-def _wrapper_in_scope(name: str, position: int, evidence: _ModuleEvidence) -> bool:
+def _wrapper_in_scope(
+    name: str, field: str, position: int, evidence: _ModuleEvidence
+) -> bool:
     # A file-scope binding (span None) is visible everywhere; a function-local
-    # one only legitimises calls inside that function's byte span.
+    # one only legitimises calls inside that function's byte span. The field
+    # must be a method declared on the bound type in this module.
     return any(
-        bound == name and (span is None or span[0] <= position < span[1])
-        for bound, span in evidence.wrapper_bindings
+        bound == name
+        and (span is None or span[0] <= position < span[1])
+        and (type_name, field) in evidence.module_methods
+        for bound, type_name, span in evidence.wrapper_bindings
     )
 
 
@@ -459,6 +468,7 @@ def _go_server_evidence(
             arg.type == cs.TS_GO_SELECTOR_EXPRESSION
             and _wrapper_in_scope(
                 _decode(arg.child_by_field_name(cs.FIELD_OPERAND)) or "",
+                _decode(arg.child_by_field_name(cs.FIELD_FIELD)) or "",
                 fn.start_byte,
                 evidence,
             )
@@ -637,6 +647,26 @@ def _go_composite_binding(names: list[str], value: Node) -> tuple[str, str] | No
     return names[0], type_name
 
 
+def _go_method_pair(node: Node) -> tuple[str, str] | None:
+    # `func (siw *ServerInterfaceWrapper) GetMe(...)`: (receiver type, name),
+    # unwrapping a pointer receiver.
+    if node.type != cs.TS_GO_METHOD_DECLARATION:
+        return None
+    name = _decode(node.child_by_field_name(cs.TS_FIELD_NAME))
+    receiver = node.child_by_field_name(cs.FIELD_RECEIVER)
+    if not name or receiver is None:
+        return None
+    for parameter in receiver.named_children:
+        type_node = parameter.child_by_field_name(cs.FIELD_TYPE)
+        if type_node is not None and type_node.type == cs.TS_GO_POINTER_TYPE:
+            type_node = next(iter(type_node.named_children), None)
+        if type_node is not None and type_node.type == cs.TS_GO_TYPE_IDENTIFIER:
+            type_name = _decode(type_node)
+            if type_name:
+                return type_name, name
+    return None
+
+
 def _go_binding_evidence(
     node: Node,
     receivers: set[str],
@@ -660,12 +690,17 @@ def _go_evidence(
     consts: dict[str, str],
     types: set[str],
     composites: list[tuple[str, str, tuple[int, int] | None]],
+    methods: set[tuple[str, str]],
 ) -> bool:
     # Returns True when the node imports net/http.
     if node.type == cs.TS_GO_FUNCTION_DECLARATION:
         name = _decode(node.child_by_field_name(cs.TS_FIELD_NAME))
         if name:
             declared.add(name)
+        return False
+    method = _go_method_pair(node)
+    if method is not None:
+        methods.add(method)
         return False
     if node.type == cs.TS_GO_TYPE_SPEC:
         type_name = _decode(node.child_by_field_name(cs.TS_FIELD_NAME))
@@ -688,6 +723,7 @@ def _collect_evidence(root: Node, language: cs.SupportedLanguage) -> _ModuleEvid
     consts: dict[str, str] = {}
     types: set[str] = set()
     composites: list[tuple[str, str, tuple[int, int] | None]] = []
+    methods: set[tuple[str, str]] = set()
     net_http = False
     stack = [root]
     is_go = language is cs.SupportedLanguage.GO
@@ -695,7 +731,9 @@ def _collect_evidence(root: Node, language: cs.SupportedLanguage) -> _ModuleEvid
         node = stack.pop()
         if is_go:
             net_http = (
-                _go_evidence(node, declared, receivers, consts, types, composites)
+                _go_evidence(
+                    node, declared, receivers, consts, types, composites, methods
+                )
                 or net_http
             )
         else:
@@ -704,10 +742,17 @@ def _collect_evidence(root: Node, language: cs.SupportedLanguage) -> _ModuleEvid
     # The type set only completes after the walk, so wrapper bindings are
     # judged here rather than in-flight.
     wrappers = frozenset(
-        (name, span) for name, type_name, span in composites if type_name in types
+        (name, type_name, span)
+        for name, type_name, span in composites
+        if type_name in types
     )
     return _ModuleEvidence(
-        frozenset(declared), frozenset(receivers), net_http, consts, wrappers
+        frozenset(declared),
+        frozenset(receivers),
+        net_http,
+        consts,
+        wrappers,
+        frozenset(methods),
     )
 
 

--- a/codebase_rag/tests/test_route_call_endpoints.py
+++ b/codebase_rag/tests/test_route_call_endpoints.py
@@ -364,7 +364,11 @@ class TestGoGeneratedRoutes:
         "package main\n\n"
         'import "github.com/go-chi/chi/v5"\n\n'
         'const BaseURL = "/api/v1"\n\n'
-        "func HandlerFromMux(wrapper ServerInterfaceWrapper, router chi.Router) {\n"
+        "type ServerInterfaceWrapper struct {\n"
+        "\tHandler ServerInterface\n"
+        "}\n\n"
+        "func HandlerFromMux(si ServerInterface, router chi.Router) {\n"
+        "\twrapper := ServerInterfaceWrapper{Handler: si}\n"
         '\trouter.Get(BaseURL+"/me", wrapper.GetMe)\n'
         '\trouter.Post(BaseURL+"/logout", wrapper.PostLogout)\n'
         "}\n"
@@ -384,7 +388,9 @@ class TestGoGeneratedRoutes:
                 "const (\n"
                 '\tprefix = "/internal"\n'
                 ")\n\n"
+                "type healthWrapper struct{}\n\n"
                 "func mount(router Router) {\n"
+                "\twrapper := healthWrapper{}\n"
                 '\trouter.Get(prefix+"/health", wrapper.Health)\n'
                 "}\n"
             ),
@@ -434,6 +440,24 @@ class TestGoGeneratedRoutes:
                 "package main\n\n"
                 "func fetchUsers(client HTTPClient, opts Options) {\n"
                 '\tclient.Get("/users", opts.Header)\n'
+                "}\n"
+            ),
+        }
+        edges = _run(tmp_path, files, "go")
+        assert not edges, edges
+
+    def test_concat_path_with_option_selector_is_ignored(
+        self, tmp_path: Path
+    ) -> None:
+        # `client.Get(baseURL + "/me", opts.Header)` concatenates a const
+        # AND passes a selector, but `opts` is a parameter, not a wrapper
+        # bound to a module-declared type: no registration.
+        files = {
+            "client.go": (
+                "package main\n\n"
+                'const baseURL = "/api/v1"\n\n'
+                "func fetchMe(client HTTPClient, opts Options) {\n"
+                '\tclient.Get(baseURL + "/me", opts.Header)\n'
                 "}\n"
             ),
         }

--- a/codebase_rag/tests/test_route_call_endpoints.py
+++ b/codebase_rag/tests/test_route_call_endpoints.py
@@ -367,6 +367,8 @@ class TestGoGeneratedRoutes:
         "type ServerInterfaceWrapper struct {\n"
         "\tHandler ServerInterface\n"
         "}\n\n"
+        "func (siw *ServerInterfaceWrapper) GetMe(w ResponseWriter, r *Request) {}\n\n"
+        "func (siw *ServerInterfaceWrapper) PostLogout(w ResponseWriter, r *Request) {}\n\n"
         "func HandlerFromMux(si ServerInterface, router chi.Router) {\n"
         "\twrapper := ServerInterfaceWrapper{Handler: si}\n"
         '\trouter.Get(BaseURL+"/me", wrapper.GetMe)\n'
@@ -389,6 +391,7 @@ class TestGoGeneratedRoutes:
                 '\tprefix = "/internal"\n'
                 ")\n\n"
                 "type healthWrapper struct{}\n\n"
+                "func (h healthWrapper) Health(w ResponseWriter, r *Request) {}\n\n"
                 "func mount(router Router) {\n"
                 "\twrapper := healthWrapper{}\n"
                 '\trouter.Get(prefix+"/health", wrapper.Health)\n'
@@ -477,6 +480,24 @@ class TestGoGeneratedRoutes:
         edges = _run(tmp_path, files, "go")
         assert not edges, edges
 
+    def test_same_function_options_struct_is_ignored(self, tmp_path: Path) -> None:
+        # `opts := Options{}` right next to the call still is not wrapper
+        # evidence: `Header` is a field access, not a method declared on
+        # `Options` in this module.
+        files = {
+            "client.go": (
+                "package main\n\n"
+                'const baseURL = "/api/v1"\n\n'
+                "type Options struct{}\n\n"
+                "func fetchMe(client HTTPClient) {\n"
+                "\topts := Options{}\n"
+                '\tclient.Get(baseURL + "/me", opts.Header)\n'
+                "}\n"
+            ),
+        }
+        edges = _run(tmp_path, files, "go")
+        assert not edges, edges
+
     def test_wrapper_binding_in_another_function_is_ignored(
         self, tmp_path: Path
     ) -> None:
@@ -507,6 +528,7 @@ class TestGoGeneratedRoutes:
                 "package main\n\n"
                 'const prefix = "/internal"\n\n'
                 "type healthWrapper struct{}\n\n"
+                "func (h healthWrapper) Health(w ResponseWriter, r *Request) {}\n\n"
                 "var wrapper = healthWrapper{}\n\n"
                 "func mount(router Router) {\n"
                 '\trouter.Get(prefix+"/health", wrapper.Health)\n'

--- a/codebase_rag/tests/test_route_call_endpoints.py
+++ b/codebase_rag/tests/test_route_call_endpoints.py
@@ -509,7 +509,7 @@ class TestGoGeneratedRoutes:
                 "package main\n\n"
                 'const baseURL = "/api/v1"\n\n'
                 "type Options struct{}\n\n"
-                "func (o Options) Header(timeout int) string { return \"\" }\n\n"
+                'func (o Options) Header(timeout int) string { return "" }\n\n'
                 "func fetchMe(client HTTPClient) {\n"
                 "\topts := Options{}\n"
                 '\tclient.Get(baseURL + "/me", opts.Header)\n'

--- a/codebase_rag/tests/test_route_call_endpoints.py
+++ b/codebase_rag/tests/test_route_call_endpoints.py
@@ -354,3 +354,73 @@ class TestStaleRouteCleanup:
         assert any(
             module_qn in (c.args[1].get("module_qns") or []) for c in cleanups
         ), cleanups
+
+
+class TestGoGeneratedRoutes:
+    # Issue #909: oapi-codegen emits `router.Get(BaseURL+"/x", wrapper.H)`;
+    # the path is a module-const concatenation and the handler an attribute.
+
+    _GEN_SOURCE = (
+        "package main\n\n"
+        'import "github.com/go-chi/chi/v5"\n\n'
+        'const BaseURL = "/api/v1"\n\n'
+        "func HandlerFromMux(wrapper ServerInterfaceWrapper, router chi.Router) {\n"
+        '\trouter.Get(BaseURL+"/me", wrapper.GetMe)\n'
+        '\trouter.Post(BaseURL+"/logout", wrapper.PostLogout)\n'
+        "}\n"
+    )
+
+    def test_const_concat_with_attribute_handler_registers(
+        self, tmp_path: Path
+    ) -> None:
+        edges = _run(tmp_path, {"gen.go": self._GEN_SOURCE}, "go")
+        assert _endpoint(edges, "gen.HandlerFromMux", "GET /api/v1/me"), edges
+        assert _endpoint(edges, "gen.HandlerFromMux", "POST /api/v1/logout"), edges
+
+    def test_const_block_resolves_too(self, tmp_path: Path) -> None:
+        files = {
+            "routes.go": (
+                "package main\n\n"
+                "const (\n"
+                '\tprefix = "/internal"\n'
+                ")\n\n"
+                "func mount(router Router) {\n"
+                '\trouter.Get(prefix+"/health", wrapper.Health)\n'
+                "}\n"
+            ),
+        }
+        edges = _run(tmp_path, files, "go")
+        assert _endpoint(edges, "routes.mount", "GET /internal/health"), edges
+
+    def test_client_const_concat_without_handler_is_ignored(
+        self, tmp_path: Path
+    ) -> None:
+        files = {
+            "client.go": (
+                "package main\n\n"
+                'const baseURL = "/api/v1"\n\n'
+                "func fetchMe(c HTTPClient) {\n"
+                '\tc.Get(baseURL + "/me")\n'
+                "}\n"
+            ),
+        }
+        edges = _run(tmp_path, files, "go")
+        assert not edges, edges
+
+    def test_function_local_strings_do_not_resolve(self, tmp_path: Path) -> None:
+        # A flat name map would let one function's local leak into another
+        # and mint a WRONG template; only module-level consts resolve.
+        files = {
+            "routes.go": (
+                "package main\n\n"
+                "func other() {\n"
+                '\tprefix := "/wrong"\n'
+                "\t_ = prefix\n"
+                "}\n\n"
+                "func mount(router Router) {\n"
+                '\trouter.Get(prefix+"/health", wrapper.Health)\n'
+                "}\n"
+            ),
+        }
+        edges = _run(tmp_path, files, "go")
+        assert not edges, edges

--- a/codebase_rag/tests/test_route_call_endpoints.py
+++ b/codebase_rag/tests/test_route_call_endpoints.py
@@ -440,9 +440,7 @@ class TestGoGeneratedRoutes:
         edges = _run(tmp_path, files, "go")
         assert not edges, edges
 
-    def test_bare_const_path_with_selector_arg_is_ignored(
-        self, tmp_path: Path
-    ) -> None:
+    def test_bare_const_path_with_selector_arg_is_ignored(self, tmp_path: Path) -> None:
         # A client can hold its URL in a module const too; only a
         # concatenation is the generated registration shape.
         files = {

--- a/codebase_rag/tests/test_route_call_endpoints.py
+++ b/codebase_rag/tests/test_route_call_endpoints.py
@@ -477,6 +477,45 @@ class TestGoGeneratedRoutes:
         edges = _run(tmp_path, files, "go")
         assert not edges, edges
 
+    def test_wrapper_binding_in_another_function_is_ignored(
+        self, tmp_path: Path
+    ) -> None:
+        # A composite-literal binding legitimises selector handlers only
+        # inside its own function; one in `setup` must not turn a client
+        # call in `fetchMe` into a registration.
+        files = {
+            "client.go": (
+                "package main\n\n"
+                'const baseURL = "/api/v1"\n\n'
+                "type Options struct{}\n\n"
+                "func setup() {\n"
+                "\topts := Options{}\n"
+                "\t_ = opts\n"
+                "}\n\n"
+                "func fetchMe(client HTTPClient, opts Options) {\n"
+                '\tclient.Get(baseURL + "/me", opts.Header)\n'
+                "}\n"
+            ),
+        }
+        edges = _run(tmp_path, files, "go")
+        assert not edges, edges
+
+    def test_module_level_wrapper_binding_registers(self, tmp_path: Path) -> None:
+        # A wrapper bound at FILE scope is visible in every function.
+        files = {
+            "routes.go": (
+                "package main\n\n"
+                'const prefix = "/internal"\n\n'
+                "type healthWrapper struct{}\n\n"
+                "var wrapper = healthWrapper{}\n\n"
+                "func mount(router Router) {\n"
+                '\trouter.Get(prefix+"/health", wrapper.Health)\n'
+                "}\n"
+            ),
+        }
+        edges = _run(tmp_path, files, "go")
+        assert _endpoint(edges, "routes.mount", "GET /internal/health"), edges
+
 
 class TestOptionsObjectRoutes:
     # Issue #907: one call, one object literal carrying method/path/handler.

--- a/codebase_rag/tests/test_route_call_endpoints.py
+++ b/codebase_rag/tests/test_route_call_endpoints.py
@@ -425,9 +425,7 @@ class TestGoGeneratedRoutes:
         edges = _run(tmp_path, files, "go")
         assert not edges, edges
 
-    def test_plain_literal_with_selector_arg_is_ignored(
-        self, tmp_path: Path
-    ) -> None:
+    def test_plain_literal_with_selector_arg_is_ignored(self, tmp_path: Path) -> None:
         # An outbound client call can pass a selector too
         # (`client.Get("/users", opts.Header)`); selector-handler evidence
         # only counts on a const-derived path, the generated shape.

--- a/codebase_rag/tests/test_route_call_endpoints.py
+++ b/codebase_rag/tests/test_route_call_endpoints.py
@@ -446,9 +446,7 @@ class TestGoGeneratedRoutes:
         edges = _run(tmp_path, files, "go")
         assert not edges, edges
 
-    def test_concat_path_with_option_selector_is_ignored(
-        self, tmp_path: Path
-    ) -> None:
+    def test_concat_path_with_option_selector_is_ignored(self, tmp_path: Path) -> None:
         # `client.Get(baseURL + "/me", opts.Header)` concatenates a const
         # AND passes a selector, but `opts` is a parameter, not a wrapper
         # bound to a module-declared type: no registration.

--- a/codebase_rag/tests/test_route_call_endpoints.py
+++ b/codebase_rag/tests/test_route_call_endpoints.py
@@ -424,3 +424,20 @@ class TestGoGeneratedRoutes:
         }
         edges = _run(tmp_path, files, "go")
         assert not edges, edges
+
+    def test_plain_literal_with_selector_arg_is_ignored(
+        self, tmp_path: Path
+    ) -> None:
+        # An outbound client call can pass a selector too
+        # (`client.Get("/users", opts.Header)`); selector-handler evidence
+        # only counts on a const-derived path, the generated shape.
+        files = {
+            "client.go": (
+                "package main\n\n"
+                "func fetchUsers(client HTTPClient, opts Options) {\n"
+                '\tclient.Get("/users", opts.Header)\n'
+                "}\n"
+            ),
+        }
+        edges = _run(tmp_path, files, "go")
+        assert not edges, edges

--- a/codebase_rag/tests/test_route_call_endpoints.py
+++ b/codebase_rag/tests/test_route_call_endpoints.py
@@ -440,6 +440,23 @@ class TestGoGeneratedRoutes:
         edges = _run(tmp_path, files, "go")
         assert not edges, edges
 
+    def test_bare_const_path_with_selector_arg_is_ignored(
+        self, tmp_path: Path
+    ) -> None:
+        # A client can hold its URL in a module const too; only a
+        # concatenation is the generated registration shape.
+        files = {
+            "client.go": (
+                "package main\n\n"
+                'const baseURL = "/users"\n\n'
+                "func fetchUsers(client HTTPClient, opts Options) {\n"
+                "\tclient.Get(baseURL, opts.Header)\n"
+                "}\n"
+            ),
+        }
+        edges = _run(tmp_path, files, "go")
+        assert not edges, edges
+
 
 class TestTestModulesEmitNoEndpoints:
     # Issue #910: routes registered inside test files must not become

--- a/codebase_rag/tests/test_route_call_endpoints.py
+++ b/codebase_rag/tests/test_route_call_endpoints.py
@@ -498,6 +498,45 @@ class TestGoGeneratedRoutes:
         edges = _run(tmp_path, files, "go")
         assert not edges, edges
 
+    def test_non_handler_method_on_options_struct_is_ignored(
+        self, tmp_path: Path
+    ) -> None:
+        # Even a genuine method on the bound type is not wrapper evidence
+        # unless its signature is a handler's; `Header(timeout int)` is an
+        # outbound request option, not generated wiring.
+        files = {
+            "client.go": (
+                "package main\n\n"
+                'const baseURL = "/api/v1"\n\n'
+                "type Options struct{}\n\n"
+                "func (o Options) Header(timeout int) string { return \"\" }\n\n"
+                "func fetchMe(client HTTPClient) {\n"
+                "\topts := Options{}\n"
+                '\tclient.Get(baseURL + "/me", opts.Header)\n'
+                "}\n"
+            ),
+        }
+        edges = _run(tmp_path, files, "go")
+        assert not edges, edges
+
+    def test_context_style_wrapper_method_registers(self, tmp_path: Path) -> None:
+        # Echo-style codegen hands the wrapper a single Context parameter.
+        files = {
+            "routes.go": (
+                "package main\n\n"
+                'const base = "/api"\n\n'
+                "type ServerInterfaceWrapper struct{}\n\n"
+                "func (w *ServerInterfaceWrapper) GetMe(ctx echo.Context) error"
+                " { return nil }\n\n"
+                "func register(router Router) {\n"
+                "\twrapper := ServerInterfaceWrapper{}\n"
+                '\trouter.Get(base+"/me", wrapper.GetMe)\n'
+                "}\n"
+            ),
+        }
+        edges = _run(tmp_path, files, "go")
+        assert _endpoint(edges, "routes.register", "GET /api/me"), edges
+
     def test_wrapper_binding_in_another_function_is_ignored(
         self, tmp_path: Path
     ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.468"
+version = "0.0.469"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Problem

oapi-codegen and similar generators emit Go registrations of the shape `router.Get(BaseURL+"/api/v1/me", wrapper.GetMe)`. Two gates rejected this: the path argument is a binary concatenation rather than a plain literal, and the handler is an attribute expression while the receiver is a parameter rather than a module-bound factory. Dogfooding a monorepo whose public REST surface is entirely generated: not one generated route produced an ENDPOINT resource.

## Fix

Two additions to `endpoint_routes.py`, both Go-scoped:

- **Path resolution**: `_go_path_value` resolves a literal, a module-level string const, or a `+` concatenation of those (depth-capped). Const collection is FILE scope only, including `const (...)` blocks; a flat map of function locals could leak one function's binding into another and mint a wrong template, so locals deliberately do not resolve (covered by a regression test).
- **Handler evidence**: on a Go verb method, an attribute-expression handler (`wrapper.GetMe`) now counts as registration evidence. Attribution keeps the existing ladder, so these endpoints anchor to the registering function.

A client-style `c.Get(baseURL + "/me")` with no handler argument stays ignored.

## Tests

RED first (commit d6c0a766): the generated shape yields `GET /api/v1/me` and `POST /api/v1/logout` anchored to the registering function; a const-block prefix resolves; the no-handler client call and the function-local-string case stay silent. Full unit (5977) and integration (307) suites pass.

Fixes #909


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Go route detection to resolve endpoint paths built from module-level `const` strings using concatenation.
  * Recognizes generated-style route registrations that use wrapper-type attribute handlers as server registrations.

* **Bug Fixes**
  * Prevents incorrect endpoint linking for outbound/client-style HTTP calls, including cases combining `const` concatenation with handler/selector arguments.
  * Avoids resolving route paths derived from function-local variables and unrelated selector/handler evidence.

* **Tests**
  * Added a dedicated Go route suite covering positive endpoint extraction and multiple negative client/non-resolvable scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->