### PR TITLE
ci: pin split-score actions by hash and attach SLSA provenance to releases

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -92,6 +92,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      attestations: write
     steps:
       - name: Install cosign
         uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
@@ -114,4 +115,22 @@ jobs:
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
           files: artifacts/*.sigstore.json
+          fail_on_unmatched_files: false
+
+      - name: Generate build provenance
+        id: attest
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: |
+            artifacts/*
+            !artifacts/*.sigstore.json
+
+      - name: Stage provenance bundle
+        shell: bash
+        run: cp "${{ steps.attest.outputs.bundle-path }}" artifacts/multiple.intoto.jsonl
+
+      - name: Upload provenance to release
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
+        with:
+          files: artifacts/multiple.intoto.jsonl
           fail_on_unmatched_files: false

--- a/.github/workflows/split-score.yml
+++ b/.github/workflows/split-score.yml
@@ -12,11 +12,11 @@ jobs:
   score:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: pr-split score
-        uses: vitali87/pr-split@v1.0.0
+        uses: vitali87/pr-split@adad0c2b3db0a9cff42a54c5d988f1600f072124 # v1.0.0
         with:
           max-loc: "400"

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.469"
+version = "0.0.470"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Two OpenSSF Scorecard remediations:

1. Pinned-Dependencies (9/10): split-score.yml was the only workflow with unpinned actions. actions/checkout is now pinned to the same v6.0.2 hash the other workflows use, and vitali87/pr-split is pinned to the commit behind its v1.0.0 tag.

2. Signed-Releases (8/10): releases carry cosign signatures but no provenance. The sign-release job now generates GitHub build provenance for all binaries (excluding the signature bundles) via actions/attest-build-provenance and uploads it to the release as multiple.intoto.jsonl, the asset name Scorecard recognises. Takes effect from the next release.