### PR TITLE
feat: prefix-tolerant endpoint matching for gateway and proxy rewrites

### DIFF
--- a/codebase_rag/parsers/endpoints.py
+++ b/codebase_rag/parsers/endpoints.py
@@ -144,6 +144,41 @@ def url_matches_template(url: str, template: str) -> bool:
     )
 
 
+# Bounded suffix mode (issue #911): ingress mounts (`/y/<service>/review` to
+# `POST /review`) and proxy rewrites (`/api/cases` to `GET /cases`) put
+# infrastructure lead segments on the client path. At most this many are
+# stripped, and only when exactly one candidate endpoint matches.
+_MAX_SUFFIX_LEAD_SEGMENTS = 2
+KEY_LEAD_PREFIX = "lead_prefix"
+
+
+def url_suffix_match_lead(url: str, template: str) -> str | None:
+    """The stripped lead when ``template`` matches a proper tail of ``url``.
+
+    ``/y/some-service/review`` against ``/review`` yields
+    ``/y/some-service``. Gated: one or two stripped lead segments only, and
+    a template carrying the unknown-lead marker already tail-matches in
+    :func:`url_matches_template`, so it stays out of this mode.
+    """
+    parsed = urlparse(url)
+    is_absolute = bool(parsed.scheme and parsed.netloc)
+    is_rooted = not parsed.netloc and url.startswith("/")
+    if not (is_absolute or is_rooted):
+        return None
+    url_segments = [s for s in parsed.path.split("/") if s]
+    template_segments = [s for s in template.split("/") if s]
+    if not template_segments or template_segments[0] == UNKNOWN_LEAD_SEGMENT:
+        return None
+    lead = len(url_segments) - len(template_segments)
+    if not 1 <= lead <= _MAX_SUFFIX_LEAD_SEGMENTS:
+        return None
+    matches = all(
+        _TEMPLATE_PARAM_RE.match(expected) or expected == actual
+        for actual, expected in zip(url_segments[lead:], template_segments, strict=True)
+    )
+    return "/" + "/".join(url_segments[:lead]) if matches else None
+
+
 def _has_literal_segment(template: str) -> bool:
     """True when at least one path segment is not a template parameter.
 
@@ -331,8 +366,10 @@ def link_endpoints(ingestor: QueryProtocol) -> int:
     cannot hit a write-only route). Templates without a literal segment are
     skipped entirely; they would match any same-length URL path. When the
     URL's hostname names an indexed project, only that project's endpoints
-    are candidates; an unmatched host keeps the full fan-out. Returns the
-    number of edges emitted.
+    are candidates; an unmatched host keeps the full fan-out. A URL with no
+    exact match may still resolve through the bounded suffix mode (#911),
+    recording the stripped lead on the edge. Returns the number of edges
+    emitted.
     """
     ingestor.execute_write(CYPHER_DELETE_RESOLVES_TO)
     networks, endpoints = _collect_live_resources(ingestor)
@@ -357,19 +394,39 @@ def link_endpoints(ingestor: QueryProtocol) -> int:
             candidates = owned | legacy
         else:
             candidates = set(endpoints)
+        exact: list[str] = []
+        suffix: dict[str, str] = {}
         for endpoint_qn in candidates:
             identity, _project = endpoints[endpoint_qn]
             method, _, template = identity.partition(" ")
-            if (
+            if not (
                 template
                 and _direction_compatible(directions, method)
                 and _has_literal_segment(template)
-                and url_matches_template(url, template)
             ):
-                writer.ensure_relationship_batch(
-                    (cs.NodeLabel.RESOURCE, cs.KEY_QUALIFIED_NAME, network_qn),
-                    cs.RelationshipType.RESOLVES_TO,
-                    (cs.NodeLabel.RESOURCE, cs.KEY_QUALIFIED_NAME, endpoint_qn),
-                )
-                created += 1
+                continue
+            if url_matches_template(url, template):
+                exact.append(endpoint_qn)
+                continue
+            lead = url_suffix_match_lead(url, template)
+            if lead is not None:
+                suffix[endpoint_qn] = lead
+        for endpoint_qn in exact:
+            writer.ensure_relationship_batch(
+                (cs.NodeLabel.RESOURCE, cs.KEY_QUALIFIED_NAME, network_qn),
+                cs.RelationshipType.RESOLVES_TO,
+                (cs.NodeLabel.RESOURCE, cs.KEY_QUALIFIED_NAME, endpoint_qn),
+            )
+            created += 1
+        # Suffix matches are an inference: exact matches suppress them, and
+        # a tie between distinct endpoints is dropped instead of guessed.
+        if not exact and len(suffix) == 1:
+            endpoint_qn, lead = next(iter(suffix.items()))
+            writer.ensure_relationship_batch(
+                (cs.NodeLabel.RESOURCE, cs.KEY_QUALIFIED_NAME, network_qn),
+                cs.RelationshipType.RESOLVES_TO,
+                (cs.NodeLabel.RESOURCE, cs.KEY_QUALIFIED_NAME, endpoint_qn),
+                properties={KEY_LEAD_PREFIX: lead},
+            )
+            created += 1
     return created

--- a/codebase_rag/tests/test_endpoint_extraction.py
+++ b/codebase_rag/tests/test_endpoint_extraction.py
@@ -562,3 +562,110 @@ class TestHostAwareLinkingHardening:
         assert created == 1
         target = ingestor.ensure_relationship_batch.call_args.args[2][2]
         assert "order__worker__2adc9027" in target
+
+
+class TestPrefixTolerantLinking:
+    """Issue #911: infrastructure prefixes (ingress mounts, proxy rewrites)
+    put extra lead segments on the client path, so the exposed template
+    matches a tail of the URL. The suffix mode is bounded and only fires
+    when it is unambiguous.
+    """
+
+    @staticmethod
+    def _ingestor(rows: list[dict[str, object]]) -> object:
+        from unittest.mock import MagicMock
+
+        ingestor = MagicMock()
+        ingestor.fetch_all.return_value = rows
+        return ingestor
+
+    @staticmethod
+    def _network(url: str, direction: str) -> dict[str, object]:
+        return {
+            "qualified_name": f"resource::NETWORK::{url}",
+            "name": url,
+            "kind": "NETWORK",
+            "directions": [direction],
+        }
+
+    @staticmethod
+    def _endpoint(identity: str, project: str) -> dict[str, object]:
+        return {
+            "qualified_name": f"resource::ENDPOINT::{project}::{identity}",
+            "name": identity,
+            "kind": "ENDPOINT",
+            "project": project,
+        }
+
+    def test_ingress_prefix_links_with_lead_recorded(self) -> None:
+        from codebase_rag.parsers.endpoints import link_endpoints
+
+        ingestor = self._ingestor(
+            [
+                self._network("/y/some-service/review", "WRITES_TO"),
+                self._endpoint("POST /review", "some-service"),
+            ]
+        )
+        assert link_endpoints(ingestor) == 1
+        _args, kwargs = ingestor.ensure_relationship_batch.call_args
+        assert kwargs.get("properties") == {"lead_prefix": "/y/some-service"}
+
+    def test_proxy_strip_links(self) -> None:
+        from codebase_rag.parsers.endpoints import link_endpoints
+
+        ingestor = self._ingestor(
+            [
+                self._network("/api/cases", "READS_FROM"),
+                self._endpoint("GET /cases", "backend"),
+            ]
+        )
+        assert link_endpoints(ingestor) == 1
+
+    def test_absolute_url_with_gateway_prefix_links(self) -> None:
+        from codebase_rag.parsers.endpoints import link_endpoints
+
+        ingestor = self._ingestor(
+            [
+                self._network("http://gateway/y/svc/review", "WRITES_TO"),
+                self._endpoint("POST /review", "svc"),
+            ]
+        )
+        assert link_endpoints(ingestor) == 1
+
+    def test_ambiguous_suffix_ties_are_dropped(self) -> None:
+        from codebase_rag.parsers.endpoints import link_endpoints
+
+        ingestor = self._ingestor(
+            [
+                self._network("/api/cases", "READS_FROM"),
+                self._endpoint("GET /cases", "service-a"),
+                self._endpoint("GET /cases", "service-b"),
+            ]
+        )
+        assert link_endpoints(ingestor) == 0
+
+    def test_exact_match_suppresses_suffix_candidates(self) -> None:
+        from codebase_rag.parsers.endpoints import link_endpoints
+
+        ingestor = self._ingestor(
+            [
+                self._network("http://svc/api/cases", "READS_FROM"),
+                self._endpoint("GET /api/cases", "svc"),
+                self._endpoint("GET /cases", "svc"),
+            ]
+        )
+        assert link_endpoints(ingestor) == 1
+        _args, kwargs = ingestor.ensure_relationship_batch.call_args
+        assert "resource::ENDPOINT::svc::GET /api/cases" in _args[2]
+        assert not kwargs
+
+    def test_lead_is_bounded_at_two_segments(self) -> None:
+        from codebase_rag.parsers.endpoints import link_endpoints
+
+        ingestor = self._ingestor(
+            [
+                self._network("/a/b/c/users", "READS_FROM"),
+                self._endpoint("GET /users", "svc"),
+            ]
+        )
+        assert link_endpoints(ingestor) == 0

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.468"
+version = "0.0.469"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Problem

In real deployments the path a client writes and the path a service exposes differ by an infrastructure prefix: ingress mounts (client calls `/y/some-service/review`, the service exposes `POST /review`) and dev proxies with rewrites (`/api/cases` forwarded as `/cases`). `url_matches_template` requires exact segment-count agreement, so all of these produce zero RESOLVES_TO edges even when both sides are in the graph. Dogfooding a monorepo where every frontend-to-backend call crossed such a prefix: zero edges across roughly 260 client sinks.

## Fix

A bounded suffix mode in `link_endpoints`:

- `url_suffix_match_lead(url, template)` returns the stripped lead when the full template matches a proper tail of the URL path, stripping at most two lead segments; templates carrying the unknown-lead marker stay out (they already tail-match in the exact mode).
- Exact matches always win: the suffix mode only runs when a URL produced no exact link.
- The inference must be unambiguous: a tie between distinct candidate endpoints is dropped instead of guessed.
- The matched variant is recorded on the edge as `lead_prefix` (for example `/y/some-service`) so consumers can audit the inference.

All existing gates stay: at least one literal template segment, direction and method compatibility, and host-aware candidate scoping.

## Tests

RED first (commit 3d7e60d4): ingress-prefix write linking with the lead recorded, proxy-strip read linking, an absolute gateway URL, ambiguity dropping, exact-match suppression, and the two-segment bound. Full unit (5979) and integration (307) suites pass.

Fixes #911

## Update after merging main

Main now carries #915 (rootful same-origin candidate scoping), which deliberately blocks cross-project links for rootful URLs, while an ingress-prefixed rootful call crosses projects by design. Reconciliation: exact matching keeps the caller-project scope; when a rootful URL has no exact match and no in-scope suffix match, the suffix search widens to all endpoints, still gated by unambiguity. A tie now resolves only when the stripped lead itself names exactly one candidate's project (`/y/service-b/cases` picks service-b), otherwise it is dropped.

This restructuring also extracts `_candidate_endpoints`, `_match_candidates` and `_resolve_suffix_match` from `link_endpoints`, clearing the python:S3776 cognitive-complexity finding SonarCloud raised on #915.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved endpoint linking to handle client URLs with extra leading infrastructure/gateway path segments (supports exact then bounded-suffix matching).
  * Records a `lead_prefix` relationship property when the inferred match is unambiguous.
  * Avoids incorrect or ambiguous inferred links, preserving exact matches as highest priority.
  * Refuses linking when the matched leading prefix exceeds the supported limit.

* **Tests**
  * Added coverage for proxy rewrites, absolute gateway-prefixed URLs, ambiguous suffix candidates, exact-match precedence, and unsupported long prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->