### PR TITLE
fix: accept object method shorthand as options-object handler evidence

### DIFF
--- a/codebase_rag/parsers/endpoint_routes.py
+++ b/codebase_rag/parsers/endpoint_routes.py
@@ -337,6 +337,13 @@ def _object_entries(obj: Node) -> dict[str, Node]:
             if name:
                 entries[name] = child
             continue
+        if child.type == cs.TS_METHOD_DEFINITION:
+            # `async handler(ctx) {...}`: an object method maps to itself
+            # (issue #920).
+            name = _decode(child.child_by_field_name(cs.TS_FIELD_NAME))
+            if name:
+                entries[name] = child
+            continue
         if child.type != cs.TS_PAIR:
             continue
         key = child.child_by_field_name(cs.FIELD_KEY)
@@ -401,8 +408,9 @@ def _js_options_registrations(
         and handler.type in (cs.TS_PY_IDENTIFIER, cs.TS_SHORTHAND_PROPERTY_IDENTIFIER)
         else None
     )
+    inline_types = _JS_INLINE_HANDLER_TYPES | {cs.TS_METHOD_DEFINITION}
     if not (
-        (handler is not None and handler.type in _JS_INLINE_HANDLER_TYPES)
+        (handler is not None and handler.type in inline_types)
         or (handler_name is not None and handler_name in evidence.declared_functions)
     ):
         return []

--- a/codebase_rag/parsers/endpoint_routes.py
+++ b/codebase_rag/parsers/endpoint_routes.py
@@ -353,9 +353,11 @@ def _object_entry(child: Node) -> tuple[str, Node] | None:
 
 def _object_entries(obj: Node) -> dict[str, Node]:
     # Key -> value node for an object literal.
-    return dict(
-        entry for child in obj.named_children if (entry := _object_entry(child))
-    )
+    return {
+        entry[0]: entry[1]
+        for child in obj.named_children
+        if (entry := _object_entry(child))
+    }
 
 
 def _options_methods(node: Node | None) -> list[str]:

--- a/codebase_rag/parsers/endpoint_routes.py
+++ b/codebase_rag/parsers/endpoint_routes.py
@@ -327,37 +327,35 @@ def _js_chained_registration(
     return RouteRegistration(method, path, handler, scope)
 
 
+def _object_entry(child: Node) -> tuple[str, Node] | None:
+    # A shorthand property maps the name to its own identifier node; an
+    # object method (`async handler(ctx) {...}`, issue #920) maps its name
+    # to the method_definition itself.
+    if child.type == cs.TS_SHORTHAND_PROPERTY_IDENTIFIER:
+        name = _decode(child)
+        return (name, child) if name else None
+    if child.type == cs.TS_METHOD_DEFINITION:
+        name = _decode(child.child_by_field_name(cs.TS_FIELD_NAME))
+        return (name, child) if name else None
+    if child.type != cs.TS_PAIR:
+        return None
+    key = child.child_by_field_name(cs.FIELD_KEY)
+    value = child.child_by_field_name(cs.FIELD_VALUE)
+    if key is None or value is None:
+        return None
+    name = (
+        _decode(key)
+        if key.type == cs.TS_PROPERTY_IDENTIFIER
+        else _literal_path(key, _JS_PATH_LITERALS)
+    )
+    return (name, value) if name else None
+
+
 def _object_entries(obj: Node) -> dict[str, Node]:
-    # Key -> value node for an object literal; a shorthand property maps the
-    # name to its own identifier node.
-    entries: dict[str, Node] = {}
-    for child in obj.named_children:
-        if child.type == cs.TS_SHORTHAND_PROPERTY_IDENTIFIER:
-            name = _decode(child)
-            if name:
-                entries[name] = child
-            continue
-        if child.type == cs.TS_METHOD_DEFINITION:
-            # `async handler(ctx) {...}`: an object method maps to itself
-            # (issue #920).
-            name = _decode(child.child_by_field_name(cs.TS_FIELD_NAME))
-            if name:
-                entries[name] = child
-            continue
-        if child.type != cs.TS_PAIR:
-            continue
-        key = child.child_by_field_name(cs.FIELD_KEY)
-        value = child.child_by_field_name(cs.FIELD_VALUE)
-        if key is None or value is None:
-            continue
-        name = (
-            _decode(key)
-            if key.type == cs.TS_PROPERTY_IDENTIFIER
-            else _literal_path(key, _JS_PATH_LITERALS)
-        )
-        if name:
-            entries[name] = value
-    return entries
+    # Key -> value node for an object literal.
+    return dict(
+        entry for child in obj.named_children if (entry := _object_entry(child))
+    )
 
 
 def _options_methods(node: Node | None) -> list[str]:

--- a/codebase_rag/tests/test_route_call_endpoints.py
+++ b/codebase_rag/tests/test_route_call_endpoints.py
@@ -595,6 +595,46 @@ class TestOptionsObjectRoutes:
         edges = _run(tmp_path, files, "typescript")
         assert _endpoint(edges, "gateway", "GET /stems/:stemId/artifacts"), edges
 
+    def test_endpoint_options_object_with_method_shorthand_handler(
+        self, tmp_path: Path
+    ) -> None:
+        # Issue #920: `async handler(ctx) {}` is a method_definition child of
+        # the object literal, not a pair, and is inline handler evidence.
+        files = {
+            "gateway.ts": (
+                "const app = createApp()\n\n"
+                "app.endpoint({\n"
+                '  method: "GET",\n'
+                '  route: "/users",\n'
+                "  async handler(ctx) {\n"
+                "    return ctx.json([])\n"
+                "  },\n"
+                "})\n"
+            ),
+        }
+        edges = _run(tmp_path, files, "typescript")
+        assert _endpoint(edges, "gateway", "GET /users"), edges
+
+    def test_client_method_shorthand_without_route_member_is_ignored(
+        self, tmp_path: Path
+    ) -> None:
+        # The member-name gate still applies: `request({...})` with a method
+        # shorthand is not a registration.
+        files = {
+            "client.ts": (
+                "const client = getClient()\n\n"
+                "client.request({\n"
+                '  method: "GET",\n'
+                '  url: "/users",\n'
+                "  async transform(res) {\n"
+                "    return res\n"
+                "  },\n"
+                "})\n"
+            ),
+        }
+        edges = _run(tmp_path, files, "typescript")
+        assert not edges, edges
+
     def test_fastify_route_with_shorthand_handler(self, tmp_path: Path) -> None:
         files = {
             "server.js": (

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.474"
+version = "0.0.476"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Fixes #920.

Options-object route registrations written with the object method shorthand (`async handler(ctx) {...}`) produced no ENDPOINT resources: the handler is a `method_definition` child of the object literal, not a `pair`, so `_object_entries` skipped it and the registration failed the handler-evidence gate. Found while re-dogfooding a large private polyglot monorepo, where roughly 130 of 330 options-object registrations across six packages use this shape.

- `_object_entries` now maps a method definition to itself under its declared name.
- The options handler evidence accepts a method definition as an inline handler, exactly like an arrow or function expression.
- RED test first (method-shorthand registration extracts), plus a negative guarding the member-name gate (`client.request({...})` with a method shorthand stays out).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved endpoint detection for JavaScript/TypeScript options objects that define handlers as object-literal methods.
  * Async method-style handlers (e.g., `async handler(ctx) { ... }`) are now correctly recognized for endpoint registrations.
  * Avoids mistakenly treating unrelated client request objects as exposed endpoints.
* **Tests**
  * Added new test coverage for parsing method-definition handlers inside endpoint option objects.
  * Added a negative test to ensure non-route client requests do not produce endpoint/expose relationships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->