### PR TITLE
feat: tolerate bounded mount prefixes on the template side

### DIFF
--- a/codebase_rag/parsers/endpoints.py
+++ b/codebase_rag/parsers/endpoints.py
@@ -190,6 +190,47 @@ def url_suffix_match_lead(url: str, template: str) -> str | None:
     return "/" + "/".join(url_segments[:lead]) if matches else None
 
 
+KEY_MOUNT_PREFIX = "mount_prefix"
+
+
+def template_mount_lead(url: str, template: str) -> str | None:
+    """The template's mount prefix when the URL matches its proper tail.
+
+    ``/api/v1/otp/verify`` against ``/admin/api/v1/otp/verify`` yields
+    ``/admin`` (issue #923): routers mounted under an infrastructure prefix
+    register a template the client never speaks. The mirror of
+    :func:`url_suffix_match_lead`, gated the same way: one or two stripped
+    template segments, every one of them literal (a parameter mount would
+    match anything), and a matched tail that keeps at least one literal
+    segment as evidence.
+    """
+    parsed = urlparse(url)
+    is_absolute = bool(parsed.scheme and parsed.netloc)
+    is_rooted = not parsed.netloc and url.startswith("/")
+    if not (is_absolute or is_rooted):
+        return None
+    url_segments = [s for s in parsed.path.split("/") if s]
+    template_segments = [s for s in template.split("/") if s]
+    if not url_segments or (
+        template_segments and template_segments[0] == UNKNOWN_LEAD_SEGMENT
+    ):
+        return None
+    lead = len(template_segments) - len(url_segments)
+    if not 1 <= lead <= _MAX_SUFFIX_LEAD_SEGMENTS:
+        return None
+    mount = template_segments[:lead]
+    tail = template_segments[lead:]
+    if any(_TEMPLATE_PARAM_RE.match(segment) for segment in mount):
+        return None
+    if all(_TEMPLATE_PARAM_RE.match(segment) for segment in tail):
+        return None
+    matches = all(
+        _TEMPLATE_PARAM_RE.match(expected) or expected == actual
+        for actual, expected in zip(url_segments, tail, strict=True)
+    )
+    return "/" + "/".join(mount) if matches else None
+
+
 def _has_literal_segment(template: str) -> bool:
     """True when at least one path segment is not a template parameter.
 
@@ -403,7 +444,7 @@ def link_endpoints(ingestor: QueryProtocol) -> int:
     for network_qn, (url, directions, caller_projects) in networks.items():
         rootful = not urlparse(url).netloc and url.startswith("/")
         candidates = _candidate_endpoints(url, rootful, caller_projects, endpoints)
-        exact, suffix = _match_candidates(url, directions, candidates, endpoints)
+        exact, suffix, mounts = _match_candidates(url, directions, candidates, endpoints)
         for endpoint_qn in exact:
             writer.ensure_relationship_batch(
                 (cs.NodeLabel.RESOURCE, cs.KEY_QUALIFIED_NAME, network_qn),
@@ -413,21 +454,21 @@ def link_endpoints(ingestor: QueryProtocol) -> int:
             created += 1
         if exact:
             continue
-        if rootful and not suffix:
+        if rootful and not (suffix or mounts):
             # An ingress-prefixed rootful call (`/y/<service>/review`)
             # crosses projects by design, so the suffix search widens
             # beyond the same-origin scope; the tie gate still applies.
-            _exact, suffix = _match_candidates(
+            _exact, suffix, mounts = _match_candidates(
                 url, directions, set(endpoints), endpoints
             )
-        match = _resolve_suffix_match(suffix, endpoints)
+        match = _resolve_inferred_match(suffix, mounts, endpoints)
         if match is not None:
-            endpoint_qn, lead = match
+            endpoint_qn, key, lead = match
             writer.ensure_relationship_batch(
                 (cs.NodeLabel.RESOURCE, cs.KEY_QUALIFIED_NAME, network_qn),
                 cs.RelationshipType.RESOLVES_TO,
                 (cs.NodeLabel.RESOURCE, cs.KEY_QUALIFIED_NAME, endpoint_qn),
-                properties={KEY_LEAD_PREFIX: lead},
+                properties={key: lead},
             )
             created += 1
     return created
@@ -468,10 +509,12 @@ def _match_candidates(
     directions: frozenset[str],
     candidates: set[str],
     endpoints: dict[str, tuple[str, str | None]],
-) -> tuple[list[str], dict[str, str]]:
-    # Exact template matches, plus suffix matches keyed by stripped lead.
+) -> tuple[list[str], dict[str, str], dict[str, str]]:
+    # Exact template matches, suffix matches keyed by stripped URL lead,
+    # and mount matches keyed by stripped template lead (#923).
     exact: list[str] = []
     suffix: dict[str, str] = {}
+    mounts: dict[str, str] = {}
     for endpoint_qn in candidates:
         identity, _project = endpoints[endpoint_qn]
         method, _, template = identity.partition(" ")
@@ -487,7 +530,28 @@ def _match_candidates(
         lead = url_suffix_match_lead(url, template)
         if lead is not None:
             suffix[endpoint_qn] = lead
-    return exact, suffix
+            continue
+        mount = template_mount_lead(url, template)
+        if mount is not None:
+            mounts[endpoint_qn] = mount
+    return exact, suffix, mounts
+
+
+def _resolve_inferred_match(
+    suffix: dict[str, str],
+    mounts: dict[str, str],
+    endpoints: dict[str, tuple[str, str | None]],
+) -> tuple[str, str, str] | None:
+    # URL-side suffix inference outranks template-side mount inference: a
+    # client-visible lead is stronger evidence than a mount the client
+    # never speaks. Mounts link only when unique; no tie-breaking.
+    match = _resolve_suffix_match(suffix, endpoints)
+    if match is not None:
+        return match[0], KEY_LEAD_PREFIX, match[1]
+    if len(mounts) == 1:
+        endpoint_qn, mount = next(iter(mounts.items()))
+        return endpoint_qn, KEY_MOUNT_PREFIX, mount
+    return None
 
 
 def _resolve_suffix_match(

--- a/codebase_rag/parsers/endpoints.py
+++ b/codebase_rag/parsers/endpoints.py
@@ -444,7 +444,9 @@ def link_endpoints(ingestor: QueryProtocol) -> int:
     for network_qn, (url, directions, caller_projects) in networks.items():
         rootful = not urlparse(url).netloc and url.startswith("/")
         candidates = _candidate_endpoints(url, rootful, caller_projects, endpoints)
-        exact, suffix, mounts = _match_candidates(url, directions, candidates, endpoints)
+        exact, suffix, mounts = _match_candidates(
+            url, directions, candidates, endpoints
+        )
         for endpoint_qn in exact:
             writer.ensure_relationship_batch(
                 (cs.NodeLabel.RESOURCE, cs.KEY_QUALIFIED_NAME, network_qn),

--- a/codebase_rag/tests/test_endpoint_extraction.py
+++ b/codebase_rag/tests/test_endpoint_extraction.py
@@ -685,6 +685,119 @@ class TestPrefixTolerantLinking:
         assert link_endpoints(ingestor) == 0
 
 
+class TestMountPrefixLinking:
+    """Issue #923: routers mounted under an infrastructure prefix register
+    templates like ``/admin/api/v1/cases/:caseUid`` while clients speak
+    ``/api/v1/cases/{caseUid}``. The mirror of the #911 suffix mode: a
+    bounded, all-literal template-side lead, unique matches only.
+    """
+
+    _ingestor = staticmethod(TestPrefixTolerantLinking._ingestor)
+    _network = staticmethod(TestPrefixTolerantLinking._network)
+    _endpoint = staticmethod(TestPrefixTolerantLinking._endpoint)
+
+    def test_template_mount_prefix_links_with_mount_recorded(self) -> None:
+        from codebase_rag.parsers.endpoints import link_endpoints
+
+        ingestor = self._ingestor(
+            [
+                self._network("/api/v1/otp/verify", "WRITES_TO"),
+                self._endpoint("POST /admin/api/v1/otp/verify", "gateway"),
+            ]
+        )
+        assert link_endpoints(ingestor) == 1
+        _args, kwargs = ingestor.ensure_relationship_batch.call_args
+        assert kwargs.get("properties") == {"mount_prefix": "/admin"}
+
+    def test_absolute_url_with_mounted_template_links(self) -> None:
+        from codebase_rag.parsers.endpoints import link_endpoints
+
+        ingestor = self._ingestor(
+            [
+                self._network("http://gateway/api/v1/cases", "READS_FROM"),
+                self._endpoint("GET /admin/api/v1/cases", "gateway"),
+            ]
+        )
+        assert link_endpoints(ingestor) == 1
+
+    def test_param_mount_prefix_is_not_evidence(self) -> None:
+        from codebase_rag.parsers.endpoints import link_endpoints
+
+        ingestor = self._ingestor(
+            [
+                self._network("/users", "READS_FROM"),
+                self._endpoint("GET /:tenant/users", "gateway"),
+            ]
+        )
+        assert link_endpoints(ingestor) == 0
+
+    def test_all_param_tail_is_not_evidence(self) -> None:
+        from codebase_rag.parsers.endpoints import link_endpoints
+
+        ingestor = self._ingestor(
+            [
+                self._network("/42", "READS_FROM"),
+                self._endpoint("GET /admin/:id", "gateway"),
+            ]
+        )
+        assert link_endpoints(ingestor) == 0
+
+    def test_mount_ambiguity_is_dropped(self) -> None:
+        from codebase_rag.parsers.endpoints import link_endpoints
+
+        ingestor = self._ingestor(
+            [
+                self._network("/otp/verify", "WRITES_TO"),
+                self._endpoint("POST /admin/otp/verify", "service-a"),
+                self._endpoint("POST /auth/otp/verify", "service-b"),
+            ]
+        )
+        assert link_endpoints(ingestor) == 0
+
+    def test_mount_is_bounded_at_two_segments(self) -> None:
+        from codebase_rag.parsers.endpoints import link_endpoints
+
+        ingestor = self._ingestor(
+            [
+                self._network("/users", "READS_FROM"),
+                self._endpoint("GET /a/b/c/users", "gateway"),
+            ]
+        )
+        assert link_endpoints(ingestor) == 0
+
+    def test_exact_match_suppresses_mount_candidates(self) -> None:
+        from codebase_rag.parsers.endpoints import link_endpoints
+
+        ingestor = self._ingestor(
+            [
+                self._network("http://svc/api/users", "READS_FROM"),
+                self._endpoint("GET /api/users", "svc"),
+                self._endpoint("GET /admin/api/users", "svc"),
+            ]
+        )
+        assert link_endpoints(ingestor) == 1
+        _args, kwargs = ingestor.ensure_relationship_batch.call_args
+        assert "resource::ENDPOINT::svc::GET /api/users" in _args[2]
+        assert not kwargs
+
+    def test_url_suffix_wins_over_template_mount(self) -> None:
+        # `/api/cases` strips its own lead to `GET /cases` before any
+        # template-side mount is considered.
+        from codebase_rag.parsers.endpoints import link_endpoints
+
+        ingestor = self._ingestor(
+            [
+                self._network("/api/cases", "READS_FROM"),
+                self._endpoint("GET /cases", "svc"),
+                self._endpoint("GET /admin/api/cases", "svc"),
+            ]
+        )
+        assert link_endpoints(ingestor) == 1
+        args, kwargs = ingestor.ensure_relationship_batch.call_args
+        assert "resource::ENDPOINT::svc::GET /cases" in args[2]
+        assert kwargs.get("properties") == {"lead_prefix": "/api"}
+
+
 class TestRootfulRelativeUrlMatch:
     """Issue #908: same-origin clients fetch rootful relative paths.
 

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.476"
+version = "0.0.477"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Fixes #923.

Re-dogfooding a large private polyglot monorepo showed several services mounting routers under an infrastructure prefix: the registered template is `/admin/api/v1/cases/:caseUid` while every client speaks `/api/v1/cases/{caseUid}`. #911 strips extra lead segments from the URL side; this adds the mirror, a bounded template-side mount tolerance.

- `template_mount_lead(url, template)` returns the stripped template lead when the URL matches a proper tail of the template. Gates: one or two stripped segments, every one literal (a parameter mount would match anything), and the matched tail keeps at least one literal segment as evidence.
- `_match_candidates` collects mount matches as a third tier below exact and URL-side suffix; `_resolve_inferred_match` links a mount only when it is unique, with no tie-breaking, and records the stripped prefix on the edge as `mount_prefix`.
- Eight tests: positive rootful and absolute cases, parameter-mount refusal, all-parameter-tail refusal, ambiguity drop, the two-segment bound, exact-match suppression, and URL-side suffix outranking template-side mount.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved endpoint URL resolution for services hosted under infrastructure mount prefixes.
  * Added support for recording whether a match was inferred from a URL suffix or mount prefix.
  * Added safeguards to avoid ambiguous or parameterized mount-prefix matches.

* **Bug Fixes**
  * URL suffix matches now take precedence over mount-prefix inference.
  * Exact endpoint matches suppress unnecessary inferred links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->