### PR TITLE
fix: link same-path multi-method groups from inferred matches

### DIFF
--- a/codebase_rag/parsers/endpoints.py
+++ b/codebase_rag/parsers/endpoints.py
@@ -463,9 +463,9 @@ def link_endpoints(ingestor: QueryProtocol) -> int:
             _exact, suffix, mounts = _match_candidates(
                 url, directions, set(endpoints), endpoints
             )
-        match = _resolve_inferred_match(suffix, mounts, endpoints)
-        if match is not None:
-            endpoint_qn, key, lead = match
+        for endpoint_qn, key, lead in _resolve_inferred_matches(
+            suffix, mounts, endpoints
+        ):
             writer.ensure_relationship_batch(
                 (cs.NodeLabel.RESOURCE, cs.KEY_QUALIFIED_NAME, network_qn),
                 cs.RelationshipType.RESOLVES_TO,
@@ -539,38 +539,62 @@ def _match_candidates(
     return exact, suffix, mounts
 
 
-def _resolve_inferred_match(
+def _resolve_inferred_matches(
     suffix: dict[str, str],
     mounts: dict[str, str],
     endpoints: dict[str, tuple[str, str | None]],
-) -> tuple[str, str, str] | None:
+) -> list[tuple[str, str, str]]:
     # URL-side suffix inference outranks template-side mount inference: a
     # client-visible lead is stronger evidence than a mount the client
-    # never speaks. Mounts link only when unique; no tie-breaking.
-    match = _resolve_suffix_match(suffix, endpoints)
-    if match is not None:
-        return match[0], KEY_LEAD_PREFIX, match[1]
-    if len(mounts) == 1:
-        endpoint_qn, mount = next(iter(mounts.items()))
-        return endpoint_qn, KEY_MOUNT_PREFIX, mount
-    return None
+    # never speaks.
+    matches = _resolve_suffix_matches(suffix, endpoints)
+    if matches:
+        return [(qn, KEY_LEAD_PREFIX, lead) for qn, lead in matches]
+    return [
+        (qn, KEY_MOUNT_PREFIX, mount)
+        for qn, mount in _resolve_mount_matches(mounts, endpoints)
+    ]
 
 
-def _resolve_suffix_match(
+def _same_path_group(
+    matches: dict[str, str], endpoints: dict[str, tuple[str, str | None]]
+) -> list[tuple[str, str]]:
+    # Several methods on ONE template path in ONE project are the same
+    # resource, not an ambiguity; the group links exactly like an exact
+    # match would (#925). The same path exposed by two projects stays a
+    # genuine tie.
+    paths = {endpoints[qn][0].partition(" ")[2] for qn in matches}
+    projects = {endpoints[qn][1] for qn in matches}
+    if len(paths) == 1 and len(projects) == 1:
+        return list(matches.items())
+    return []
+
+
+def _resolve_suffix_matches(
     suffix: dict[str, str], endpoints: dict[str, tuple[str, str | None]]
-) -> tuple[str, str] | None:
-    # Suffix matches are an inference: a unique match links, and a tie is
-    # dropped instead of guessed unless the stripped lead itself names
-    # exactly one candidate's project (`/y/some-service/review`).
-    if len(suffix) == 1:
-        return next(iter(suffix.items()))
+) -> list[tuple[str, str]]:
+    # Suffix matches are an inference: a unique match or a same-path method
+    # group links; any other tie is dropped instead of guessed unless the
+    # stripped lead itself names exactly one candidate's project
+    # (`/y/some-service/review`).
+    group = _same_path_group(suffix, endpoints)
+    if group:
+        return group
     named = [
         (qn, lead)
         for qn, lead in suffix.items()
         if (project := endpoints[qn][1]) is not None
         and _project_stem(project) in _lead_stems(lead)
     ]
-    return named[0] if len(named) == 1 else None
+    return named if len(named) == 1 else []
+
+
+def _resolve_mount_matches(
+    mounts: dict[str, str], endpoints: dict[str, tuple[str, str | None]]
+) -> list[tuple[str, str]]:
+    # Mounts link only when unique or a same-path method group; no
+    # tie-breaking beyond that.
+    return _same_path_group(mounts, endpoints)
 
 
 def _lead_stems(lead: str) -> set[str]:

--- a/codebase_rag/tests/test_endpoint_extraction.py
+++ b/codebase_rag/tests/test_endpoint_extraction.py
@@ -798,6 +798,78 @@ class TestMountPrefixLinking:
         assert kwargs.get("properties") == {"lead_prefix": "/api"}
 
 
+class TestSamePathInferredGroups:
+    """Issue #925: several methods on ONE template path are the same
+    resource, not an ambiguity; an inferred match links the whole group
+    exactly like an exact match would.
+    """
+
+    _ingestor = staticmethod(TestPrefixTolerantLinking._ingestor)
+    _endpoint = staticmethod(TestPrefixTolerantLinking._endpoint)
+
+    @staticmethod
+    def _network(url: str, directions: list[str]) -> dict[str, object]:
+        return {
+            "qualified_name": f"resource::NETWORK::{url}",
+            "name": url,
+            "kind": "NETWORK",
+            "directions": directions,
+        }
+
+    def test_mount_group_on_one_path_links_every_method(self) -> None:
+        from codebase_rag.parsers.endpoints import link_endpoints
+
+        ingestor = self._ingestor(
+            [
+                self._network("/enterprises", ["READS_FROM", "WRITES_TO"]),
+                self._endpoint("GET /admin/enterprises", "gateway"),
+                self._endpoint("POST /admin/enterprises", "gateway"),
+            ]
+        )
+        assert link_endpoints(ingestor) == 2
+        for call in ingestor.ensure_relationship_batch.call_args_list:
+            assert call.kwargs.get("properties") == {"mount_prefix": "/admin"}
+
+    def test_suffix_group_on_one_path_links_every_method(self) -> None:
+        from codebase_rag.parsers.endpoints import link_endpoints
+
+        ingestor = self._ingestor(
+            [
+                self._network("/api/cases", ["READS_FROM", "WRITES_TO"]),
+                self._endpoint("GET /cases", "backend"),
+                self._endpoint("POST /cases", "backend"),
+            ]
+        )
+        assert link_endpoints(ingestor) == 2
+
+    def test_different_paths_still_drop(self) -> None:
+        from codebase_rag.parsers.endpoints import link_endpoints
+
+        ingestor = self._ingestor(
+            [
+                self._network("/otp/verify", ["WRITES_TO"]),
+                self._endpoint("POST /admin/otp/verify", "service-a"),
+                self._endpoint("POST /auth/otp/verify", "service-b"),
+            ]
+        )
+        assert link_endpoints(ingestor) == 0
+
+    def test_direction_filter_still_prunes_the_group(self) -> None:
+        # A read-only URL links only the GET half of the group.
+        from codebase_rag.parsers.endpoints import link_endpoints
+
+        ingestor = self._ingestor(
+            [
+                self._network("/enterprises", ["READS_FROM"]),
+                self._endpoint("GET /admin/enterprises", "gateway"),
+                self._endpoint("POST /admin/enterprises", "gateway"),
+            ]
+        )
+        assert link_endpoints(ingestor) == 1
+        args = ingestor.ensure_relationship_batch.call_args.args
+        assert "GET /admin/enterprises" in args[2][2]
+
+
 class TestRootfulRelativeUrlMatch:
     """Issue #908: same-origin clients fetch rootful relative paths.
 

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.477"
+version = "0.0.478"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Fixes #925.

Inferred matches (URL-side suffix leads from #911 and template-side mount prefixes from #923) linked only a unique candidate, so a client URL matching several methods on ONE template path was dropped as a tie. Example from re-dogfooding a large private polyglot monorepo: `/enterprises` against `GET /admin/enterprises` and `POST /admin/enterprises`.

- `_same_path_group`: when every inferred candidate shares one template path AND one project, the group links exactly like an exact match would; the same path exposed by two projects stays a genuine tie.
- Applies to both tiers; the #911 lead-names-project tiebreak is unchanged as the fallback.
- The direction filter still prunes the group first, so a read-only URL links only the GET half.
- Four tests: mount group, suffix group, cross-project same-path still drops, direction pruning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved endpoint relationship detection for inferred URL matches.
  * Multiple HTTP methods sharing the same path are now linked correctly.
  * Same-path matches are handled consistently for mount and suffix-based routing.
  * Unrelated paths are no longer grouped together.
  * Read-only network connections now link only the applicable method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->