### PR TITLE
feat: emit RPC sinks for connect-go generated client calls

### DIFF
--- a/codebase_rag/parsers/io_access/constants.py
+++ b/codebase_rag/parsers/io_access/constants.py
@@ -25,6 +25,10 @@ class ResourceKind(StrEnum):
     ENV = "ENV"
     SOCKET = "SOCKET"
     ENDPOINT = "ENDPOINT"
+    # A codegen contract operation (issue #912): client stubs and server
+    # implementations of the same contract meet at one shared node keyed
+    # `<ServiceStem>.<Method>`, no URL literal involved.
+    RPC = "RPC"
 
 
 class IODirection(StrEnum):

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from collections.abc import Iterator
 from typing import NamedTuple
 
@@ -87,6 +88,28 @@ class _LeanHandles(NamedTuple):
     identity_new_types: dict[str, ResourceKind]
     arg_sinks: dict[str, ArgHandleSink]
     bindings: dict[str, HandleBinding]
+    # connect-go generated client bindings (`userv1connect.NewUserServiceClient`)
+    # are recognised by shape, not by a registry entry (issue #912). Go only:
+    # the `<pkg>connect.New<Stem>Client` convention is connect-go codegen.
+    rpc_clients: bool
+
+
+# The connect-go constructor: `New<Stem>Client`, qualified by a generated
+# package whose name ends in `connect`.
+_RPC_CLIENT_RE = re.compile(r"^New([A-Z]\w*)Client$")
+_RPC_PACKAGE_SUFFIX = "connect"
+
+
+def _rpc_client_binding(raw: str) -> HandleBinding | None:
+    qualifier, sep, func = raw.rpartition(cs.SEPARATOR_DOT)
+    if not sep or not qualifier.rsplit(cs.SEPARATOR_DOT, 1)[-1].endswith(
+        _RPC_PACKAGE_SUFFIX
+    ):
+        return None
+    match = _RPC_CLIENT_RE.match(func)
+    if match is None:
+        return None
+    return HandleBinding(kind=ResourceKind.RPC, identity=match.group(1))
 
 
 def _lean_handles_for(language: cs.SupportedLanguage) -> _LeanHandles | None:
@@ -106,6 +129,7 @@ def _lean_handles_for(language: cs.SupportedLanguage) -> _LeanHandles | None:
         identity_new_types=IO_IDENTITY_UNWRAP_NEW_TYPES.get(language, {}),
         arg_sinks=IO_ARG_HANDLE_SINKS.get(language, {}),
         bindings={},
+        rpc_clients=language is cs.SupportedLanguage.GO,
     )
 
 
@@ -1197,6 +1221,18 @@ class IOAccessProcessor:
         binding = lean_handles.bindings.get(receiver)
         if binding is None:
             return False
+        if binding.kind == ResourceKind.RPC:
+            # A generated client exposes exactly its RPC methods, all
+            # exported; the operation is request AND response (issue #912).
+            if not method[:1].isupper():
+                return False
+            self._emit(
+                caller_spec,
+                IODirection.READ_WRITE,
+                ResourceKind.RPC,
+                f"{binding.identity}{cs.SEPARATOR_DOT}{method}",
+            )
+            return True
         direction = lean_handles.methods.get(binding.kind, {}).get(method)
         if direction is None:
             return False
@@ -1375,6 +1411,10 @@ class IOAccessProcessor:
                 parent.kind, frozenset()
             ):
                 return parent
+        if lean_handles.rpc_clients:
+            rpc = _rpc_client_binding(raw)
+            if rpc is not None:
+                return rpc
         ctor = self._resolve_sink(
             raw,
             import_map,

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -100,9 +100,18 @@ _RPC_CLIENT_RE = re.compile(r"^New([A-Z]\w*)Client$")
 _RPC_PACKAGE_SUFFIX = "connect"
 
 
-def _rpc_client_binding(raw: str) -> HandleBinding | None:
+def _rpc_client_binding(
+    raw: str, import_map: dict[str, str], in_scope: frozenset[str]
+) -> HandleBinding | None:
+    # The qualifier must be an IMPORTED package (aliases resolve through the
+    # import map) that is not shadowed by an in-scope local, and the resolved
+    # import path's last segment must carry the connect-go marker. A bare or
+    # locally-shadowed name is a value, not the generated package.
     qualifier, sep, func = raw.rpartition(cs.SEPARATOR_DOT)
-    if not sep or not qualifier.rsplit(cs.SEPARATOR_DOT, 1)[-1].endswith(
+    if not sep or qualifier in in_scope:
+        return None
+    resolved = import_map.get(qualifier)
+    if resolved is None or not resolved.rsplit("/", 1)[-1].endswith(
         _RPC_PACKAGE_SUFFIX
     ):
         return None
@@ -1412,7 +1421,7 @@ class IOAccessProcessor:
             ):
                 return parent
         if lean_handles.rpc_clients:
-            rpc = _rpc_client_binding(raw)
+            rpc = _rpc_client_binding(raw, import_map, in_scope)
             if rpc is not None:
                 return rpc
         ctor = self._resolve_sink(

--- a/codebase_rag/tests/test_io_handle_edges.py
+++ b/codebase_rag/tests/test_io_handle_edges.py
@@ -881,11 +881,12 @@ class TestGoRpcClientSinks:
         assert not any("resource::RPC::" in b for _a, _r, b in rels), rels
 
     def test_unimported_qualifier_is_not_rpc(self, tmp_path: Path) -> None:
-        # No import maps `fooconnect`, so the name alone is no evidence.
+        # No import maps `fooconnect`, so the name alone is no evidence
+        # (no parameter here: the missing-import guard must fail alone).
         files = {
             "main.go": (
                 "package main\n\n"
-                "func fetch(fooconnect Factory) {\n"
+                "func fetch() {\n"
                 "\tclient := fooconnect.NewBarClient()\n"
                 "\tclient.Do(nil)\n"
                 "}\n"

--- a/codebase_rag/tests/test_io_handle_edges.py
+++ b/codebase_rag/tests/test_io_handle_edges.py
@@ -872,7 +872,7 @@ class TestGoRpcClientSinks:
                 "package main\n\n"
                 'import "example.com/gen/user/v1/userv1connect"\n\n'
                 "func fetch(userv1connect FakeFactory) {\n"
-                "\tclient := userv1connect.NewUserServiceClient(nil, \"\")\n"
+                '\tclient := userv1connect.NewUserServiceClient(nil, "")\n'
                 "\tclient.GetUser(nil, nil)\n"
                 "}\n"
             ),

--- a/codebase_rag/tests/test_io_handle_edges.py
+++ b/codebase_rag/tests/test_io_handle_edges.py
@@ -764,3 +764,88 @@ class TestGoSprintfUrls:
             READS_FROM,
             "resource::NETWORK::http://svc:8000/products/{*}",
         ), rels
+
+
+class TestGoRpcClientSinks:
+    """Issue #912 slice 1: a connect-go generated client binding
+    (`c := userv1connect.NewUserServiceClient(...)`) makes every exported
+    method call on it an RPC sink on `resource::RPC::<Stem>.<Method>`, so
+    interior service-mesh traffic becomes visible without URL literals.
+    """
+
+    _RPC = "resource::RPC::UserService.GetUser"
+
+    def test_connect_client_call_emits_rpc_sink(self, tmp_path: Path) -> None:
+        files = {
+            "main.go": (
+                "package main\n\n"
+                'import "example.com/gen/user/v1/userv1connect"\n\n'
+                "func fetch(base string) {\n"
+                "\tclient := userv1connect.NewUserServiceClient(nil, base)\n"
+                "\tclient.GetUser(nil, nil)\n"
+                "}\n"
+            ),
+        }
+        rels = _run_io(tmp_path, files)
+        assert _has(rels, "main.fetch", READS_FROM, self._RPC), rels
+        assert _has(rels, "main.fetch", WRITES_TO, self._RPC), rels
+
+    def test_alias_tracks_the_rpc_binding(self, tmp_path: Path) -> None:
+        files = {
+            "main.go": (
+                "package main\n\n"
+                'import "example.com/gen/user/v1/userv1connect"\n\n'
+                "func fetch(base string) {\n"
+                "\tc := userv1connect.NewUserServiceClient(nil, base)\n"
+                "\tg := c\n"
+                "\tg.GetUser(nil, nil)\n"
+                "}\n"
+            ),
+        }
+        rels = _run_io(tmp_path, files)
+        assert _has(rels, "main.fetch", READS_FROM, self._RPC), rels
+
+    def test_non_connect_package_is_not_rpc(self, tmp_path: Path) -> None:
+        # `api.NewHTTPClient` lacks the connect-go package marker.
+        files = {
+            "main.go": (
+                "package main\n\n"
+                'import "example.com/api"\n\n'
+                "func fetch(base string) {\n"
+                "\tclient := api.NewHTTPClient(base)\n"
+                "\tclient.Get(nil)\n"
+                "}\n"
+            ),
+        }
+        rels = _run_io(tmp_path, files)
+        assert not any("resource::RPC::" in b for _a, _r, b in rels), rels
+
+    def test_unexported_method_is_ignored(self, tmp_path: Path) -> None:
+        files = {
+            "main.go": (
+                "package main\n\n"
+                'import "example.com/gen/user/v1/userv1connect"\n\n'
+                "func fetch(base string) {\n"
+                "\tclient := userv1connect.NewUserServiceClient(nil, base)\n"
+                "\tclient.close()\n"
+                "}\n"
+            ),
+        }
+        rels = _run_io(tmp_path, files)
+        assert not any("resource::RPC::" in b for _a, _r, b in rels), rels
+
+    def test_bare_new_client_without_package_is_not_rpc(
+        self, tmp_path: Path
+    ) -> None:
+        # A local helper `NewFooClient()` has no connect package qualifier.
+        files = {
+            "main.go": (
+                "package main\n\n"
+                "func fetch() {\n"
+                "\tclient := NewFooClient()\n"
+                "\tclient.Call(nil)\n"
+                "}\n"
+            ),
+        }
+        rels = _run_io(tmp_path, files)
+        assert not any("resource::RPC::" in b for _a, _r, b in rels), rels

--- a/codebase_rag/tests/test_io_handle_edges.py
+++ b/codebase_rag/tests/test_io_handle_edges.py
@@ -834,9 +834,7 @@ class TestGoRpcClientSinks:
         rels = _run_io(tmp_path, files)
         assert not any("resource::RPC::" in b for _a, _r, b in rels), rels
 
-    def test_bare_new_client_without_package_is_not_rpc(
-        self, tmp_path: Path
-    ) -> None:
+    def test_bare_new_client_without_package_is_not_rpc(self, tmp_path: Path) -> None:
         # A local helper `NewFooClient()` has no connect package qualifier.
         files = {
             "main.go": (

--- a/codebase_rag/tests/test_io_handle_edges.py
+++ b/codebase_rag/tests/test_io_handle_edges.py
@@ -847,3 +847,49 @@ class TestGoRpcClientSinks:
         }
         rels = _run_io(tmp_path, files)
         assert not any("resource::RPC::" in b for _a, _r, b in rels), rels
+
+    def test_aliased_connect_import_binds(self, tmp_path: Path) -> None:
+        # A Go import alias hides the package name; the import map still
+        # records the real path, and that is what carries the evidence.
+        files = {
+            "main.go": (
+                "package main\n\n"
+                'import userv1 "example.com/gen/user/v1/userv1connect"\n\n'
+                "func fetch(base string) {\n"
+                "\tclient := userv1.NewUserServiceClient(nil, base)\n"
+                "\tclient.GetUser(nil, nil)\n"
+                "}\n"
+            ),
+        }
+        rels = _run_io(tmp_path, files)
+        assert _has(rels, "main.fetch", READS_FROM, self._RPC), rels
+
+    def test_shadowed_qualifier_is_not_rpc(self, tmp_path: Path) -> None:
+        # A parameter shadowing the imported package name is a value, not
+        # the generated package.
+        files = {
+            "main.go": (
+                "package main\n\n"
+                'import "example.com/gen/user/v1/userv1connect"\n\n'
+                "func fetch(userv1connect FakeFactory) {\n"
+                "\tclient := userv1connect.NewUserServiceClient(nil, \"\")\n"
+                "\tclient.GetUser(nil, nil)\n"
+                "}\n"
+            ),
+        }
+        rels = _run_io(tmp_path, files)
+        assert not any("resource::RPC::" in b for _a, _r, b in rels), rels
+
+    def test_unimported_qualifier_is_not_rpc(self, tmp_path: Path) -> None:
+        # No import maps `fooconnect`, so the name alone is no evidence.
+        files = {
+            "main.go": (
+                "package main\n\n"
+                "func fetch(fooconnect Factory) {\n"
+                "\tclient := fooconnect.NewBarClient()\n"
+                "\tclient.Do(nil)\n"
+                "}\n"
+            ),
+        }
+        rels = _run_io(tmp_path, files)
+        assert not any("resource::RPC::" in b for _a, _r, b in rels), rels

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.478"
+version = "0.0.479"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
First slice of #912 (design posted on the issue).

In contract-first architectures no HTTP path literal ever appears in application code, so URL matching cannot see interior service-to-service traffic at all. connect-go codegen gives a recognisable client shape: `client := userv1connect.NewUserServiceClient(httpClient, baseURL)` followed by `client.GetUser(ctx, req)`.

- The lean handle walk now recognises `<pkg>connect.New<Stem>Client(...)` (the generated package always ends in `connect`) as an RPC handle binding carrying the service stem; no registry entry, the shape IS the evidence, and it is gated to Go where the convention comes from.
- Every exported method call on the binding emits READS_FROM and WRITES_TO edges (an RPC is request and response) to a shared contract resource `resource::RPC::<Stem>.<Method>`; unexported calls and non-connect constructors (`api.NewHTTPClient`) stay out.
- Aliasing (`g := c`) tracks through the existing binding machinery.
- Server-side exposure (slice 2: `New<Stem>Handler` wiring plus structural interface match at link time) and TS/Python client stubs (slice 3) follow; both meet the client at the same resource node.

Five tests: sink emission, alias tracking, non-connect package negative, unexported method negative, unqualified constructor negative.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detection of Go connect-go RPC client calls and recognition of RPC resources.
  * RPC exported client method calls now emit read/write resource connections.
  * RPC bindings remain recognized when client variables are aliased.

* **Bug Fixes**
  * Prevented non-connect packages, shadowed qualifiers, unimported qualifiers, and unexported methods from being misclassified as RPC resources.

* **Tests**
  * Added Go RPC sink test coverage for detection, alias tracking, and rejection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->