### PR TITLE
feat: bind RPC clients declared as struct fields and parameters

### DIFF
--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -112,6 +112,36 @@ def _rpc_qualifier_resolves(qualifier: str, import_map: dict[str, str]) -> bool:
     )
 
 
+def _collect_go_param_bindings(
+    parameter: Node, import_map: dict[str, str], bindings: dict[str, HandleBinding]
+) -> None:
+    # One parameter declaration: every name of a connect-client type binds
+    # like a constructor result would (issue #912).
+    stem = _go_client_type_stem(
+        parameter.child_by_field_name(cs.FIELD_TYPE), import_map
+    )
+    if stem is None:
+        return
+    for child in parameter.named_children:
+        if child.type == cs.TS_GO_IDENTIFIER and child.text is not None:
+            bindings[child.text.decode(cs.ENCODING_UTF8)] = HandleBinding(
+                kind=ResourceKind.RPC, identity=stem
+            )
+
+
+def _collect_go_field_stems(
+    node: Node, import_map: dict[str, str], fields: dict[str, str]
+) -> None:
+    # One struct field declaration: every named field of a connect-client
+    # type maps to the service stem (several names may share one type).
+    stem = _go_client_type_stem(node.child_by_field_name(cs.FIELD_TYPE), import_map)
+    if stem is None:
+        return
+    for child in node.named_children:
+        if child.type == cs.TS_GO_FIELD_IDENTIFIER and child.text is not None:
+            fields[child.text.decode(cs.ENCODING_UTF8)] = stem
+
+
 def _go_client_type_stem(
     type_node: Node | None, import_map: dict[str, str]
 ) -> str | None:
@@ -191,9 +221,11 @@ class IOAccessProcessor:
         # When neither I/O edge is enabled, skip the body walk entirely.
         self._selection = selection
         self._enabled = selection.io_enabled
-        # module_qn -> {field name: service stem} for connect-client-typed
-        # struct fields (issue #912); the module walk runs once per module.
-        self._rpc_field_cache: dict[str, dict[str, str]] = {}
+        # (module_qn, parse-tree root id) -> {field name: service stem} for
+        # connect-client-typed struct fields (issue #912). The root id keys
+        # out stale entries when a long-lived processor (realtime updater)
+        # re-parses a file: a new tree gets a new root id.
+        self._rpc_field_cache: dict[tuple[str, int], dict[str, str]] = {}
 
     def process_io_for_caller(
         self,
@@ -221,24 +253,16 @@ class IOAccessProcessor:
         # call sinks and emit, without Python's handle/scope machinery (streams
         # and data-flow are a follow-up). Python keeps the full handle-aware walk.
         if language != cs.SupportedLanguage.PYTHON:
-            descriptor = LANGUAGE_DESCRIPTORS.get(language)
-            if descriptor is not None:
-                lean_handles = _lean_handles_for(language)
-                if lean_handles is not None and lean_handles.rpc_clients:
-                    self._seed_go_rpc_evidence(
-                        caller_node, module_qn, import_map, lean_handles
-                    )
-                self._emit_direct_sinks(
-                    caller_node,
-                    caller_spec,
-                    import_map,
-                    sink_by_name,
-                    macro_sinks,
-                    stream_sinks,
-                    IO_MEMBER_READS.get(language, ()),
-                    descriptor,
-                    lean_handles,
-                )
+            self._process_lean_caller(
+                caller_node,
+                caller_spec,
+                module_qn,
+                language,
+                import_map,
+                sink_by_name,
+                macro_sinks,
+                stream_sinks,
+            )
             return
         ctor_by_name = {c.callee: c for c in constructors}
 
@@ -1252,6 +1276,37 @@ class IOAccessProcessor:
         self._emit(caller_spec, sink.direction, ResourceKind.FILE, DYNAMIC_TARGET)
         return True
 
+    def _process_lean_caller(
+        self,
+        caller_node: Node,
+        caller_spec: tuple[str, str, str],
+        module_qn: str,
+        language: cs.SupportedLanguage,
+        import_map: dict[str, str],
+        sink_by_name: dict[str, IOSink],
+        macro_sinks: dict[str, IOSink],
+        stream_sinks: dict[str, IOSink],
+    ) -> None:
+        # Non-Python languages take a lean direct-sink walk (issue #714),
+        # seeded with connect-client evidence for Go (issue #912).
+        descriptor = LANGUAGE_DESCRIPTORS.get(language)
+        if descriptor is None:
+            return
+        lean_handles = _lean_handles_for(language)
+        if lean_handles is not None and lean_handles.rpc_clients:
+            self._seed_go_rpc_evidence(caller_node, module_qn, import_map, lean_handles)
+        self._emit_direct_sinks(
+            caller_node,
+            caller_spec,
+            import_map,
+            sink_by_name,
+            macro_sinks,
+            stream_sinks,
+            IO_MEMBER_READS.get(language, ()),
+            descriptor,
+            lean_handles,
+        )
+
     def _seed_go_rpc_evidence(
         self,
         caller_node: Node,
@@ -1264,16 +1319,7 @@ class IOAccessProcessor:
         # consulted by the dotted-receiver fallback.
         parameters = caller_node.child_by_field_name(cs.FIELD_PARAMETERS)
         for parameter in parameters.named_children if parameters is not None else []:
-            stem = _go_client_type_stem(
-                parameter.child_by_field_name(cs.FIELD_TYPE), import_map
-            )
-            if stem is None:
-                continue
-            for child in parameter.named_children:
-                if child.type == cs.TS_GO_IDENTIFIER and child.text is not None:
-                    lean_handles.bindings[child.text.decode(cs.ENCODING_UTF8)] = (
-                        HandleBinding(kind=ResourceKind.RPC, identity=stem)
-                    )
+            _collect_go_param_bindings(parameter, import_map, lean_handles.bindings)
         lean_handles.rpc_fields.update(
             self._go_rpc_fields(caller_node, module_qn, import_map)
         )
@@ -1281,29 +1327,21 @@ class IOAccessProcessor:
     def _go_rpc_fields(
         self, caller_node: Node, module_qn: str, import_map: dict[str, str]
     ) -> dict[str, str]:
-        cached = self._rpc_field_cache.get(module_qn)
-        if cached is not None:
-            return cached
         root = caller_node
         while root.parent is not None:
             root = root.parent
+        key = (module_qn, root.id)
+        cached = self._rpc_field_cache.get(key)
+        if cached is not None:
+            return cached
         fields: dict[str, str] = {}
         stack = [root]
         while stack:
             node = stack.pop()
             if node.type == cs.TS_GO_FIELD_DECLARATION:
-                stem = _go_client_type_stem(
-                    node.child_by_field_name(cs.FIELD_TYPE), import_map
-                )
-                if stem is not None:
-                    for child in node.named_children:
-                        if (
-                            child.type == cs.TS_GO_FIELD_IDENTIFIER
-                            and child.text is not None
-                        ):
-                            fields[child.text.decode(cs.ENCODING_UTF8)] = stem
+                _collect_go_field_stems(node, import_map, fields)
             stack.extend(node.named_children)
-        self._rpc_field_cache[module_qn] = fields
+        self._rpc_field_cache[key] = fields
         return fields
 
     def _emit_rpc_field_method(

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -130,16 +130,23 @@ def _collect_go_param_bindings(
 
 
 def _collect_go_field_stems(
-    node: Node, import_map: dict[str, str], fields: dict[str, str]
+    node: Node,
+    import_map: dict[str, str],
+    fields: dict[str, str],
+    conflicted: set[str],
 ) -> None:
     # One struct field declaration: every named field of a connect-client
-    # type maps to the service stem (several names may share one type).
+    # type maps to the service stem (several names may share one type). A
+    # name already mapped to a DIFFERENT stem is marked conflicted.
     stem = _go_client_type_stem(node.child_by_field_name(cs.FIELD_TYPE), import_map)
     if stem is None:
         return
     for child in node.named_children:
         if child.type == cs.TS_GO_FIELD_IDENTIFIER and child.text is not None:
-            fields[child.text.decode(cs.ENCODING_UTF8)] = stem
+            name = child.text.decode(cs.ENCODING_UTF8)
+            if fields.get(name, stem) != stem:
+                conflicted.add(name)
+            fields[name] = stem
 
 
 def _go_client_type_stem(
@@ -1335,12 +1342,17 @@ class IOAccessProcessor:
         if cached is not None:
             return cached
         fields: dict[str, str] = {}
+        conflicted: set[str] = set()
         stack = [root]
         while stack:
             node = stack.pop()
             if node.type == cs.TS_GO_FIELD_DECLARATION:
-                _collect_go_field_stems(node, import_map, fields)
+                _collect_go_field_stems(node, import_map, fields, conflicted)
             stack.extend(node.named_children)
+        # A name typed to DIFFERENT services in this module cannot be told
+        # apart by the flat receiver-tail lookup: drop it rather than guess.
+        for name in conflicted:
+            fields.pop(name, None)
         self._rpc_field_cache[key] = fields
         return fields
 

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -125,8 +125,8 @@ def _go_client_type_stem(
         or type_node.text is None
     ):
         return None
-    qualifier, sep, name = (
-        type_node.text.decode(cs.ENCODING_UTF8).rpartition(cs.SEPARATOR_DOT)
+    qualifier, sep, name = type_node.text.decode(cs.ENCODING_UTF8).rpartition(
+        cs.SEPARATOR_DOT
     )
     if not sep or not _rpc_qualifier_resolves(qualifier, import_map):
         return None
@@ -1317,9 +1317,7 @@ class IOAccessProcessor:
         # struct field declared with a generated client type in this module.
         if cs.SEPARATOR_DOT not in receiver or not method[:1].isupper():
             return False
-        stem = lean_handles.rpc_fields.get(
-            receiver.rsplit(cs.SEPARATOR_DOT, 1)[-1]
-        )
+        stem = lean_handles.rpc_fields.get(receiver.rsplit(cs.SEPARATOR_DOT, 1)[-1])
         if stem is None:
             return False
         self._emit(

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -92,12 +92,46 @@ class _LeanHandles(NamedTuple):
     # are recognised by shape, not by a registry entry (issue #912). Go only:
     # the `<pkg>connect.New<Stem>Client` convention is connect-go codegen.
     rpc_clients: bool
+    # Struct fields DECLARED with a generated client type in this module
+    # (`userClient userv1connect.UserServiceClient`): field name -> stem.
+    # Injected clients are called through these, not through a local binding.
+    rpc_fields: dict[str, str]
 
 
 # The connect-go constructor: `New<Stem>Client`, qualified by a generated
 # package whose name ends in `connect`.
 _RPC_CLIENT_RE = re.compile(r"^New([A-Z]\w*)Client$")
+_RPC_CLIENT_TYPE_RE = re.compile(r"^([A-Z]\w*)Client$")
 _RPC_PACKAGE_SUFFIX = "connect"
+
+
+def _rpc_qualifier_resolves(qualifier: str, import_map: dict[str, str]) -> bool:
+    resolved = import_map.get(qualifier)
+    return resolved is not None and resolved.rsplit("/", 1)[-1].endswith(
+        _RPC_PACKAGE_SUFFIX
+    )
+
+
+def _go_client_type_stem(
+    type_node: Node | None, import_map: dict[str, str]
+) -> str | None:
+    # `userv1connect.UserServiceClient` (pointer unwrapped): the declared
+    # generated client type; its stem is the service (issue #912).
+    if type_node is not None and type_node.type == cs.TS_GO_POINTER_TYPE:
+        type_node = next(iter(type_node.named_children), None)
+    if (
+        type_node is None
+        or type_node.type != cs.TS_GO_QUALIFIED_TYPE
+        or type_node.text is None
+    ):
+        return None
+    qualifier, sep, name = (
+        type_node.text.decode(cs.ENCODING_UTF8).rpartition(cs.SEPARATOR_DOT)
+    )
+    if not sep or not _rpc_qualifier_resolves(qualifier, import_map):
+        return None
+    match = _RPC_CLIENT_TYPE_RE.match(name)
+    return match.group(1) if match else None
 
 
 def _rpc_client_binding(
@@ -110,10 +144,7 @@ def _rpc_client_binding(
     qualifier, sep, func = raw.rpartition(cs.SEPARATOR_DOT)
     if not sep or qualifier in in_scope:
         return None
-    resolved = import_map.get(qualifier)
-    if resolved is None or not resolved.rsplit("/", 1)[-1].endswith(
-        _RPC_PACKAGE_SUFFIX
-    ):
+    if not _rpc_qualifier_resolves(qualifier, import_map):
         return None
     match = _RPC_CLIENT_RE.match(func)
     if match is None:
@@ -139,6 +170,7 @@ def _lean_handles_for(language: cs.SupportedLanguage) -> _LeanHandles | None:
         arg_sinks=IO_ARG_HANDLE_SINKS.get(language, {}),
         bindings={},
         rpc_clients=language is cs.SupportedLanguage.GO,
+        rpc_fields={},
     )
 
 
@@ -159,6 +191,9 @@ class IOAccessProcessor:
         # When neither I/O edge is enabled, skip the body walk entirely.
         self._selection = selection
         self._enabled = selection.io_enabled
+        # module_qn -> {field name: service stem} for connect-client-typed
+        # struct fields (issue #912); the module walk runs once per module.
+        self._rpc_field_cache: dict[str, dict[str, str]] = {}
 
     def process_io_for_caller(
         self,
@@ -188,6 +223,11 @@ class IOAccessProcessor:
         if language != cs.SupportedLanguage.PYTHON:
             descriptor = LANGUAGE_DESCRIPTORS.get(language)
             if descriptor is not None:
+                lean_handles = _lean_handles_for(language)
+                if lean_handles is not None and lean_handles.rpc_clients:
+                    self._seed_go_rpc_evidence(
+                        caller_node, module_qn, import_map, lean_handles
+                    )
                 self._emit_direct_sinks(
                     caller_node,
                     caller_spec,
@@ -197,7 +237,7 @@ class IOAccessProcessor:
                     stream_sinks,
                     IO_MEMBER_READS.get(language, ()),
                     descriptor,
-                    _lean_handles_for(language),
+                    lean_handles,
                 )
             return
         ctor_by_name = {c.callee: c for c in constructors}
@@ -1212,6 +1252,84 @@ class IOAccessProcessor:
         self._emit(caller_spec, sink.direction, ResourceKind.FILE, DYNAMIC_TARGET)
         return True
 
+    def _seed_go_rpc_evidence(
+        self,
+        caller_node: Node,
+        module_qn: str,
+        import_map: dict[str, str],
+        lean_handles: _LeanHandles,
+    ) -> None:
+        # Parameters declared with a generated client type bind like a
+        # constructor would; struct fields go into the module-level field map
+        # consulted by the dotted-receiver fallback.
+        parameters = caller_node.child_by_field_name(cs.FIELD_PARAMETERS)
+        for parameter in parameters.named_children if parameters is not None else []:
+            stem = _go_client_type_stem(
+                parameter.child_by_field_name(cs.FIELD_TYPE), import_map
+            )
+            if stem is None:
+                continue
+            for child in parameter.named_children:
+                if child.type == cs.TS_GO_IDENTIFIER and child.text is not None:
+                    lean_handles.bindings[child.text.decode(cs.ENCODING_UTF8)] = (
+                        HandleBinding(kind=ResourceKind.RPC, identity=stem)
+                    )
+        lean_handles.rpc_fields.update(
+            self._go_rpc_fields(caller_node, module_qn, import_map)
+        )
+
+    def _go_rpc_fields(
+        self, caller_node: Node, module_qn: str, import_map: dict[str, str]
+    ) -> dict[str, str]:
+        cached = self._rpc_field_cache.get(module_qn)
+        if cached is not None:
+            return cached
+        root = caller_node
+        while root.parent is not None:
+            root = root.parent
+        fields: dict[str, str] = {}
+        stack = [root]
+        while stack:
+            node = stack.pop()
+            if node.type == cs.TS_GO_FIELD_DECLARATION:
+                stem = _go_client_type_stem(
+                    node.child_by_field_name(cs.FIELD_TYPE), import_map
+                )
+                if stem is not None:
+                    for child in node.named_children:
+                        if (
+                            child.type == cs.TS_GO_FIELD_IDENTIFIER
+                            and child.text is not None
+                        ):
+                            fields[child.text.decode(cs.ENCODING_UTF8)] = stem
+            stack.extend(node.named_children)
+        self._rpc_field_cache[module_qn] = fields
+        return fields
+
+    def _emit_rpc_field_method(
+        self,
+        receiver: str,
+        method: str,
+        caller_spec: tuple[str, str, str],
+        lean_handles: _LeanHandles,
+    ) -> bool:
+        # `a.userClient.GetUser(...)`: the receiver's LAST segment names a
+        # struct field declared with a generated client type in this module.
+        if cs.SEPARATOR_DOT not in receiver or not method[:1].isupper():
+            return False
+        stem = lean_handles.rpc_fields.get(
+            receiver.rsplit(cs.SEPARATOR_DOT, 1)[-1]
+        )
+        if stem is None:
+            return False
+        self._emit(
+            caller_spec,
+            IODirection.READ_WRITE,
+            ResourceKind.RPC,
+            f"{stem}{cs.SEPARATOR_DOT}{method}",
+        )
+        return True
+
     def _emit_lean_handle_method(
         self,
         call_node: Node,
@@ -1229,7 +1347,9 @@ class IOAccessProcessor:
             return False
         binding = lean_handles.bindings.get(receiver)
         if binding is None:
-            return False
+            return self._emit_rpc_field_method(
+                receiver, method, caller_spec, lean_handles
+            )
         if binding.kind == ResourceKind.RPC:
             # A generated client exposes exactly its RPC methods, all
             # exported; the operation is request AND response (issue #912).

--- a/codebase_rag/tests/test_io_handle_edges.py
+++ b/codebase_rag/tests/test_io_handle_edges.py
@@ -905,9 +905,7 @@ class TestGoRpcTypedClientEvidence:
 
     _RPC = "resource::RPC::UserService.GetUser"
 
-    def test_struct_field_typed_client_call_emits_sink(
-        self, tmp_path: Path
-    ) -> None:
+    def test_struct_field_typed_client_call_emits_sink(self, tmp_path: Path) -> None:
         files = {
             "auth.go": (
                 "package auth\n\n"

--- a/codebase_rag/tests/test_io_handle_edges.py
+++ b/codebase_rag/tests/test_io_handle_edges.py
@@ -894,3 +894,77 @@ class TestGoRpcClientSinks:
         }
         rels = _run_io(tmp_path, files)
         assert not any("resource::RPC::" in b for _a, _r, b in rels), rels
+
+
+class TestGoRpcTypedClientEvidence:
+    """Issue #912 slice 1b: production code constructs the client once and
+    injects it; calls happen on struct fields or parameters DECLARED with the
+    generated client type (`userv1connect.UserServiceClient`). The declared
+    type carries the same evidence as the constructor.
+    """
+
+    _RPC = "resource::RPC::UserService.GetUser"
+
+    def test_struct_field_typed_client_call_emits_sink(
+        self, tmp_path: Path
+    ) -> None:
+        files = {
+            "auth.go": (
+                "package auth\n\n"
+                'import "example.com/gen/user/v1/userv1connect"\n\n'
+                "type Auth struct {\n"
+                "\tuserClient userv1connect.UserServiceClient\n"
+                "}\n\n"
+                "func (a *Auth) Lookup() {\n"
+                "\ta.userClient.GetUser(nil, nil)\n"
+                "}\n"
+            ),
+        }
+        rels = _run_io(tmp_path, files)
+        assert _has(rels, "auth.Auth.Lookup", READS_FROM, self._RPC), rels
+        assert _has(rels, "auth.Auth.Lookup", WRITES_TO, self._RPC), rels
+
+    def test_parameter_typed_client_call_emits_sink(self, tmp_path: Path) -> None:
+        files = {
+            "main.go": (
+                "package main\n\n"
+                'import "example.com/gen/user/v1/userv1connect"\n\n'
+                "func fetch(cl userv1connect.UserServiceClient) {\n"
+                "\tcl.GetUser(nil, nil)\n"
+                "}\n"
+            ),
+        }
+        rels = _run_io(tmp_path, files)
+        assert _has(rels, "main.fetch", READS_FROM, self._RPC), rels
+
+    def test_non_connect_field_type_is_not_rpc(self, tmp_path: Path) -> None:
+        files = {
+            "auth.go": (
+                "package auth\n\n"
+                'import "example.com/api"\n\n'
+                "type Auth struct {\n"
+                "\tuserClient api.HTTPClient\n"
+                "}\n\n"
+                "func (a *Auth) Lookup() {\n"
+                "\ta.userClient.GetUser(nil)\n"
+                "}\n"
+            ),
+        }
+        rels = _run_io(tmp_path, files)
+        assert not any("resource::RPC::" in b for _a, _r, b in rels), rels
+
+    def test_pointer_typed_field_binds_too(self, tmp_path: Path) -> None:
+        files = {
+            "auth.go": (
+                "package auth\n\n"
+                'import "example.com/gen/user/v1/userv1connect"\n\n'
+                "type Auth struct {\n"
+                "\tuserClient *userv1connect.UserServiceClient\n"
+                "}\n\n"
+                "func (a *Auth) Lookup() {\n"
+                "\ta.userClient.GetUser(nil, nil)\n"
+                "}\n"
+            ),
+        }
+        rels = _run_io(tmp_path, files)
+        assert _has(rels, "auth.Auth.Lookup", READS_FROM, self._RPC), rels

--- a/codebase_rag/tests/test_io_handle_edges.py
+++ b/codebase_rag/tests/test_io_handle_edges.py
@@ -966,3 +966,46 @@ class TestGoRpcTypedClientEvidence:
         }
         rels = _run_io(tmp_path, files)
         assert _has(rels, "auth.Auth.Lookup", READS_FROM, self._RPC), rels
+
+    def test_colliding_field_names_yield_nothing(self, tmp_path: Path) -> None:
+        # Two structs share a field name with DIFFERENT client types; the
+        # flat name lookup cannot tell the receivers apart, so the field
+        # drops out entirely rather than guess (never a wrong edge).
+        files = {
+            "auth.go": (
+                "package auth\n\n"
+                'import "example.com/gen/user/v1/userv1connect"\n'
+                'import "example.com/gen/billing/v1/billingv1connect"\n\n'
+                "type Auth struct {\n"
+                "\tuserClient userv1connect.UserServiceClient\n"
+                "}\n\n"
+                "type Billing struct {\n"
+                "\tuserClient billingv1connect.BillingServiceClient\n"
+                "}\n\n"
+                "func (a *Auth) Lookup() {\n"
+                "\ta.userClient.GetUser(nil, nil)\n"
+                "}\n"
+            ),
+        }
+        rels = _run_io(tmp_path, files)
+        assert not any("resource::RPC::" in b for _a, _r, b in rels), rels
+
+    def test_same_stem_duplicate_fields_still_bind(self, tmp_path: Path) -> None:
+        # The same field name with the SAME client type is no conflict.
+        files = {
+            "auth.go": (
+                "package auth\n\n"
+                'import "example.com/gen/user/v1/userv1connect"\n\n'
+                "type Auth struct {\n"
+                "\tuserClient userv1connect.UserServiceClient\n"
+                "}\n\n"
+                "type Admin struct {\n"
+                "\tuserClient userv1connect.UserServiceClient\n"
+                "}\n\n"
+                "func (a *Auth) Lookup() {\n"
+                "\ta.userClient.GetUser(nil, nil)\n"
+                "}\n"
+            ),
+        }
+        rels = _run_io(tmp_path, files)
+        assert _has(rels, "auth.Auth.Lookup", READS_FROM, self._RPC), rels

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.479"
+version = "0.0.480"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Second slice-1 instalment for #912 (follows PR #927).

Re-dogfooding after #927 showed zero RPC sinks in the reference monorepo: production code constructs the generated client once in `main()` and injects it, so the calls happen on struct fields or parameters DECLARED with the generated client type (`userClient userv1connect.UserServiceClient`, then `a.userClient.GetUser(...)`), never on a local constructor binding.

- Parameters declared with a connect-client type (qualifier import-resolves to a `…connect` package, type name `<Stem>Client`, pointer unwrapped) seed the same per-function RPC binding a constructor would.
- Struct fields so declared go into a per-module field map (computed once per module, cached); a dotted receiver whose last segment names such a field (`a.userClient.GetUser`) emits the RPC sink for `<Stem>.<Method>`.
- Non-connect field types and undeclared names stay out.

Four tests: field-typed call, parameter-typed call, pointer-typed field, non-connect field negative.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of connect-go generated RPC clients used as struct fields or function parameters.
  * Added support for pointer-typed generated clients.
  * Avoided incorrectly treating non-connect HTTP clients as RPC services.
  * Corrected RPC edge emission, including proper method-based READ/WRITE relationships and safer behavior for field-name collisions.
* **Tests**
  * Added a Go RPC evidence test suite covering typed fields, typed parameters, pointer clients, non-RPC client types, and collision scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->