### PR TITLE
feat: aggregate RPC client fields across a Go package

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -16,6 +16,7 @@ from ..language_spec import LanguageSpec
 from ..parser_loader import COMBINED_FUNC_CLASS_QUERIES
 from ..services import IngestorProtocol
 from ..types_defs import (
+    ASTCacheProtocol,
     FunctionLocation,
     FunctionRegistryTrieProtocol,
     FunctionSpanKey,
@@ -550,6 +551,7 @@ class CallProcessor:
         cpp_out_of_class_methods: dict[tuple[str, int], tuple[str, str]] | None = None,
         function_locations: dict[FunctionSpanKey, FunctionLocation] | None = None,
         macro_qns: set[str] | None = None,
+        ast_cache: ASTCacheProtocol | None = None,
     ) -> None:
         self.ingestor = ingestor
         self.repo_path = repo_path
@@ -583,6 +585,8 @@ class CallProcessor:
             ingestor,
             import_processor,
             selection=selection,
+            module_paths=self.module_qn_to_file_path,
+            ast_cache=ast_cache,
         )
         self._flow_processor = FlowProcessor(
             ingestor,

--- a/codebase_rag/parsers/factory.py
+++ b/codebase_rag/parsers/factory.py
@@ -158,5 +158,6 @@ class ProcessorFactory:
                 cpp_out_of_class_methods=self.definition_processor.cpp_out_of_class_methods,
                 function_locations=self.definition_processor.function_locations,
                 macro_qns=self.definition_processor.macro_qns,
+                ast_cache=self.ast_cache,
             )
         return self._call_processor

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
+from pathlib import Path
 from typing import NamedTuple
 
 from tree_sitter import Node
@@ -9,6 +10,7 @@ from tree_sitter import Node
 from ... import constants as cs
 from ...capture import CaptureSelection
 from ...services import IngestorProtocol
+from ...types_defs import ASTCacheProtocol
 from ..import_processor import ImportProcessor
 from ..utils import cpp_declarator_name, safe_decode_text
 from .constants import (
@@ -129,6 +131,22 @@ def _collect_go_param_bindings(
             )
 
 
+def _collect_go_file_fields(
+    root: Node,
+    import_map: dict[str, str],
+    fields: dict[str, str],
+    conflicted: set[str],
+) -> None:
+    # All connect-client-typed struct fields of one file, resolved with THAT
+    # file's imports (the declaring file names the generated package).
+    stack = [root]
+    while stack:
+        node = stack.pop()
+        if node.type == cs.TS_GO_FIELD_DECLARATION:
+            _collect_go_field_stems(node, import_map, fields, conflicted)
+        stack.extend(node.named_children)
+
+
 def _collect_go_field_stems(
     node: Node,
     import_map: dict[str, str],
@@ -220,6 +238,8 @@ class IOAccessProcessor:
         ingestor: IngestorProtocol,
         import_processor: ImportProcessor,
         selection: CaptureSelection,
+        module_paths: Mapping[str, Path] | None = None,
+        ast_cache: ASTCacheProtocol | None = None,
     ) -> None:
         self.ingestor = ingestor
         # import_processor owns import_mapping[module_qn][local] = full_name, used to
@@ -228,10 +248,14 @@ class IOAccessProcessor:
         # When neither I/O edge is enabled, skip the body walk entirely.
         self._selection = selection
         self._enabled = selection.io_enabled
-        # (module_qn, parse-tree root id) -> {field name: service stem} for
-        # connect-client-typed struct fields (issue #912). The root id keys
-        # out stale entries when a long-lived processor (realtime updater)
-        # re-parses a file: a new tree gets a new root id.
+        # Sibling-file lookups for the package-level field map: Go splits a
+        # struct declaration and its method files across one directory.
+        self._module_paths = module_paths or {}
+        self._ast_cache = ast_cache
+        # (package_qn, requesting file's parse-tree root id) -> {field name:
+        # service stem} for connect-client-typed struct fields (issue #912).
+        # The root id keys out stale entries when a long-lived processor
+        # (realtime updater) re-parses a file: a new tree gets a new root id.
         self._rpc_field_cache: dict[tuple[str, int], dict[str, str]] = {}
 
     def process_io_for_caller(
@@ -1337,19 +1361,32 @@ class IOAccessProcessor:
         root = caller_node
         while root.parent is not None:
             root = root.parent
-        key = (module_qn, root.id)
+        package_qn = module_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
+        key = (package_qn, root.id)
         cached = self._rpc_field_cache.get(key)
         if cached is not None:
             return cached
         fields: dict[str, str] = {}
         conflicted: set[str] = set()
-        stack = [root]
-        while stack:
-            node = stack.pop()
-            if node.type == cs.TS_GO_FIELD_DECLARATION:
-                _collect_go_field_stems(node, import_map, fields, conflicted)
-            stack.extend(node.named_children)
-        # A name typed to DIFFERENT services in this module cannot be told
+        _collect_go_file_fields(root, import_map, fields, conflicted)
+        # Go splits a package across files: the struct (and its typed field)
+        # may live in a sibling of the calling file. `_test.go` siblings
+        # compile only under `go test` and stay out.
+        for sibling_qn, path in self._module_paths.items():
+            if (
+                sibling_qn == module_qn
+                or sibling_qn.rsplit(cs.SEPARATOR_DOT, 1)[0] != package_qn
+                or path.stem.endswith(cs.GO_TEST_FILE_SUFFIX)
+            ):
+                continue
+            entry = self._ast_cache.load(path) if self._ast_cache else None
+            if entry is None or entry[1] is not cs.SupportedLanguage.GO:
+                continue
+            sibling_imports = self._import_processor.import_mapping.get(
+                sibling_qn, {}
+            )
+            _collect_go_file_fields(entry[0], sibling_imports, fields, conflicted)
+        # A name typed to DIFFERENT services in this package cannot be told
         # apart by the flat receiver-tail lookup: drop it rather than guess.
         for name in conflicted:
             fields.pop(name, None)

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -252,11 +252,12 @@ class IOAccessProcessor:
         # struct declaration and its method files across one directory.
         self._module_paths = module_paths or {}
         self._ast_cache = ast_cache
-        # (package_qn, requesting file's parse-tree root id) -> {field name:
-        # service stem} for connect-client-typed struct fields (issue #912).
-        # The root id keys out stale entries when a long-lived processor
-        # (realtime updater) re-parses a file: a new tree gets a new root id.
-        self._rpc_field_cache: dict[tuple[str, int], dict[str, str]] = {}
+        # (package_qn, sorted root ids of every participating file) ->
+        # {field name: service stem} for connect-client-typed struct fields
+        # (issue #912). Fingerprinting EVERY root id keys out stale entries
+        # when a long-lived processor (realtime updater) re-parses ANY file
+        # of the package: a re-parsed file gets a new root id.
+        self._rpc_field_cache: dict[tuple[str, tuple[int, ...]], dict[str, str]] = {}
 
     def process_io_for_caller(
         self,
@@ -1362,16 +1363,14 @@ class IOAccessProcessor:
         while root.parent is not None:
             root = root.parent
         package_qn = module_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
-        key = (package_qn, root.id)
-        cached = self._rpc_field_cache.get(key)
-        if cached is not None:
-            return cached
-        fields: dict[str, str] = {}
-        conflicted: set[str] = set()
-        _collect_go_file_fields(root, import_map, fields, conflicted)
         # Go splits a package across files: the struct (and its typed field)
-        # may live in a sibling of the calling file. `_test.go` siblings
-        # compile only under `go test` and stay out.
+        # may live in a sibling of the calling file. `_test.go` files,
+        # including the REQUESTING one, compile only under `go test` and
+        # contribute no fields.
+        requester = self._module_paths.get(module_qn)
+        sources: list[tuple[Node, dict[str, str]]] = []
+        if requester is None or not requester.stem.endswith(cs.GO_TEST_FILE_SUFFIX):
+            sources.append((root, import_map))
         for sibling_qn, path in self._module_paths.items():
             if (
                 sibling_qn == module_qn
@@ -1382,8 +1381,17 @@ class IOAccessProcessor:
             entry = self._ast_cache.load(path) if self._ast_cache else None
             if entry is None or entry[1] is not cs.SupportedLanguage.GO:
                 continue
-            sibling_imports = self._import_processor.import_mapping.get(sibling_qn, {})
-            _collect_go_file_fields(entry[0], sibling_imports, fields, conflicted)
+            sources.append(
+                (entry[0], self._import_processor.import_mapping.get(sibling_qn, {}))
+            )
+        key = (package_qn, tuple(sorted(node.id for node, _imports in sources)))
+        cached = self._rpc_field_cache.get(key)
+        if cached is not None:
+            return cached
+        fields: dict[str, str] = {}
+        conflicted: set[str] = set()
+        for source_root, source_imports in sources:
+            _collect_go_file_fields(source_root, source_imports, fields, conflicted)
         # A name typed to DIFFERENT services in this package cannot be told
         # apart by the flat receiver-tail lookup: drop it rather than guess.
         for name in conflicted:

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -1382,9 +1382,7 @@ class IOAccessProcessor:
             entry = self._ast_cache.load(path) if self._ast_cache else None
             if entry is None or entry[1] is not cs.SupportedLanguage.GO:
                 continue
-            sibling_imports = self._import_processor.import_mapping.get(
-                sibling_qn, {}
-            )
+            sibling_imports = self._import_processor.import_mapping.get(sibling_qn, {})
             _collect_go_file_fields(entry[0], sibling_imports, fields, conflicted)
         # A name typed to DIFFERENT services in this package cannot be told
         # apart by the flat receiver-tail lookup: drop it rather than guess.

--- a/codebase_rag/tests/test_io_handle_edges.py
+++ b/codebase_rag/tests/test_io_handle_edges.py
@@ -1072,3 +1072,85 @@ class TestGoRpcTypedClientEvidence:
         }
         rels = _run_io(tmp_path, files)
         assert not any("resource::RPC::" in b for _a, _r, b in rels), rels
+
+    def test_requesting_test_file_own_field_is_ignored(self, tmp_path: Path) -> None:
+        # A `_test.go` file declaring its own fake connect-typed struct must
+        # not bind its own calls either.
+        files = {
+            "svc/service_test.go": (
+                "package svc\n\n"
+                'import "example.com/gen/user/v1/userv1connect"\n\n'
+                "type fakeServer struct {\n"
+                "\tuserClient userv1connect.UserServiceClient\n"
+                "}\n\n"
+                "func (s *fakeServer) run() {\n"
+                "\ts.userClient.GetUser(nil, nil)\n"
+                "}\n"
+            ),
+        }
+        rels = _run_io(tmp_path, files)
+        assert not any("resource::RPC::" in b for _a, _r, b in rels), rels
+
+    def test_sibling_reparse_refreshes_the_field_map(self, tmp_path: Path) -> None:
+        # A long-lived processor (realtime updater) must not serve a stale
+        # package aggregate when a SIBLING re-parses while the requesting
+        # file's tree is unchanged: the cache key fingerprints every
+        # participating root id.
+        from codebase_rag.capture import resolve_capture
+        from codebase_rag.parser_loader import load_parsers
+        from codebase_rag.parsers.io_access.processor import IOAccessProcessor
+
+        parsers, _ = load_parsers()
+        caller_src = (
+            "package svc\n\nfunc (s *Server) Create() {\n"
+            "\ts.userClient.GetUser(nil, nil)\n}\n"
+        )
+        decl_v1 = "package svc\n\ntype Server struct{}\n"
+        decl_v2 = (
+            "package svc\n\n"
+            'import "example.com/gen/user/v1/userv1connect"\n\n'
+            "type Server struct {\n"
+            "\tuserClient userv1connect.UserServiceClient\n"
+            "}\n"
+        )
+        caller_tree = parsers["go"].parse(caller_src.encode())
+        decl_path = tmp_path / "svc" / "service.go"
+
+        class _FakeCache:
+            def __init__(self) -> None:
+                self.entry = (
+                    parsers["go"].parse(decl_v1.encode()).root_node,
+                    cs.SupportedLanguage.GO,
+                )
+
+            def load(self, key: Path) -> tuple[object, cs.SupportedLanguage]:
+                return self.entry
+
+        cache = _FakeCache()
+        import_processor = MagicMock()
+        import_processor.import_mapping = {
+            "proj.svc.service": {
+                "userv1connect": "example.com/gen/user/v1/userv1connect"
+            },
+            "proj.svc.create": {},
+        }
+        processor = IOAccessProcessor(
+            MagicMock(),
+            import_processor,
+            selection=resolve_capture([cs.CaptureGroup.IO.value]),
+            module_paths={"proj.svc.service": decl_path},
+            ast_cache=cache,  # type: ignore[arg-type]
+        )
+        caller_fn = next(
+            c
+            for c in caller_tree.root_node.named_children
+            if c.type == "method_declaration"
+        )
+        before = processor._go_rpc_fields(caller_fn, "proj.svc.create", {})
+        assert before == {}
+        cache.entry = (
+            parsers["go"].parse(decl_v2.encode()).root_node,
+            cs.SupportedLanguage.GO,
+        )
+        after = processor._go_rpc_fields(caller_fn, "proj.svc.create", {})
+        assert after == {"userClient": "UserService"}, after

--- a/codebase_rag/tests/test_io_handle_edges.py
+++ b/codebase_rag/tests/test_io_handle_edges.py
@@ -1009,3 +1009,66 @@ class TestGoRpcTypedClientEvidence:
         }
         rels = _run_io(tmp_path, files)
         assert _has(rels, "auth.Auth.Lookup", READS_FROM, self._RPC), rels
+
+    def test_field_declared_in_sibling_file_binds(self, tmp_path: Path) -> None:
+        # Go packages split declaration and use across files: the struct
+        # (and its connect-typed field) lives in service.go, the handler
+        # calling it in create.go. The field map is package-level.
+        files = {
+            "svc/service.go": (
+                "package svc\n\n"
+                'import "example.com/gen/user/v1/userv1connect"\n\n'
+                "type Server struct {\n"
+                "\tuserClient userv1connect.UserServiceClient\n"
+                "}\n"
+            ),
+            "svc/create.go": (
+                "package svc\n\n"
+                "func (s *Server) Create() {\n"
+                "\ts.userClient.GetUser(nil, nil)\n"
+                "}\n"
+            ),
+        }
+        rels = _run_io(tmp_path, files)
+        assert _has(rels, "Server.Create", READS_FROM, self._RPC), rels
+
+    def test_field_in_other_directory_does_not_leak(self, tmp_path: Path) -> None:
+        # A connect-typed field in a DIFFERENT package is not evidence here.
+        files = {
+            "other/service.go": (
+                "package other\n\n"
+                'import "example.com/gen/user/v1/userv1connect"\n\n'
+                "type Server struct {\n"
+                "\tuserClient userv1connect.UserServiceClient\n"
+                "}\n"
+            ),
+            "svc/create.go": (
+                "package svc\n\n"
+                "func (s *Server) Create() {\n"
+                "\ts.userClient.GetUser(nil, nil)\n"
+                "}\n"
+            ),
+        }
+        rels = _run_io(tmp_path, files)
+        assert not any("resource::RPC::" in b for _a, _r, b in rels), rels
+
+    def test_sibling_test_file_field_is_ignored(self, tmp_path: Path) -> None:
+        # A `_test.go` sibling compiles only under `go test`; its fake
+        # struct fields are not production evidence.
+        files = {
+            "svc/service_test.go": (
+                "package svc\n\n"
+                'import "example.com/gen/user/v1/userv1connect"\n\n'
+                "type fakeServer struct {\n"
+                "\tuserClient userv1connect.UserServiceClient\n"
+                "}\n"
+            ),
+            "svc/create.go": (
+                "package svc\n\n"
+                "func (s *Server) Create() {\n"
+                "\ts.userClient.GetUser(nil, nil)\n"
+                "}\n"
+            ),
+        }
+        rels = _run_io(tmp_path, files)
+        assert not any("resource::RPC::" in b for _a, _r, b in rels), rels

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.480"
+version = "0.0.481"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Third slice-1 instalment for #912 (follows PRs #927 and #928).

Re-dogfooding after #928 made the injected-client mesh visible for single-file packages (24 operations, 58 sink edges), but Go idiomatically splits a package across files: the struct with the connect-typed field lives in `service.go` while each handler file calls `s.client.Method(...)`. The per-file field map missed every such package.

- The field map is now aggregated across all Go files of the package (same directory qn), each file resolved with ITS OWN import map; sibling ASTs come from the shared bounded AST cache plumbed through `CallProcessor`.
- `_test.go` siblings stay out (they compile only under `go test`).
- Collision-drop still applies package-wide; the cache stays keyed by the requesting file's parse-tree root id, so the long-lived realtime updater never reads a stale entry.

Three tests: sibling-file field binds, other-directory field does not leak, test-file sibling ignored.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Go RPC analysis so typed client fields declared in sibling files are correctly recognized within the same Go package.
  - Ensured RPC evidence does not leak across package boundaries.
  - Excluded fields declared only in `_test.go` files from production RPC evidence.
  - Fixed stale-analysis behavior by refreshing the computed field mapping when sibling files are re-parsed.

- **Tests**
  - Added regression and scenario coverage for same-package, cross-package, and `_test.go`-only cases, including re-parse refresh verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->