### PR TITLE
fix: resolve Go receiver methods through package siblings first

### DIFF
--- a/codebase_rag/constants/ast_go.py
+++ b/codebase_rag/constants/ast_go.py
@@ -1,5 +1,7 @@
 # Go tree-sitter node types.
 
+TS_GO_PACKAGE_CLAUSE = "package_clause"
+TS_GO_PACKAGE_IDENTIFIER = "package_identifier"
 TS_GO_TYPE_DECLARATION = "type_declaration"
 TS_GO_TYPE_SPEC = "type_spec"
 TS_GO_TYPE_ALIAS = "type_alias"

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -562,7 +562,7 @@ class CallProcessor:
         self._path_to_module_qn: dict[Path, str] | None = None
         # Package-prefix index over module_qn_to_file_path (issue #930),
         # rebuilt lazily whenever the underlying map grows.
-        self._package_index: dict[str, list[str]] = {}
+        self._package_index: dict[Path, list[str]] = {}
         self._package_index_size = -1
         self.cpp_out_of_class_methods = cpp_out_of_class_methods or {}
         self.function_locations = function_locations or {}
@@ -1432,26 +1432,30 @@ class CallProcessor:
     ) -> tuple[str, str] | None:
         # A unique registered `<package sibling>.<ReceiverType>.<method>` is
         # the definition pass's own binding; ambiguity falls back.
-        package_prefix = module_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
         hits: list[tuple[str, str]] = []
-        for sibling_qn in self._package_modules(package_prefix):
+        for sibling_qn in self._package_modules(module_qn):
             container_qn = f"{sibling_qn}{cs.SEPARATOR_DOT}{receiver_type}"
             caller_qn = f"{container_qn}{cs.SEPARATOR_DOT}{method_name}"
             if caller_qn in self._resolver.function_registry:
                 hits.append((caller_qn, container_qn))
         return hits[0] if len(hits) == 1 else None
 
-    def _package_modules(self, package_prefix: str) -> list[str]:
-        # Lazily indexed from module_qn_to_file_path; rebuilt when the map
-        # grew (incremental runs register modules as they parse).
+    def _package_modules(self, module_qn: str) -> list[str]:
+        # Lazily indexed from module_qn_to_file_path by the file's PARENT
+        # DIRECTORY (extension disambiguation makes qn-prefix grouping split
+        # `pkg.service.go` from its package); rebuilt when the map grew
+        # (incremental runs register modules as they parse).
+        requester = self.module_qn_to_file_path.get(module_qn)
+        if requester is None:
+            return []
         size = len(self.module_qn_to_file_path)
         if self._package_index_size != size:
-            index: dict[str, list[str]] = {}
-            for qn in self.module_qn_to_file_path:
-                index.setdefault(qn.rsplit(cs.SEPARATOR_DOT, 1)[0], []).append(qn)
+            index: dict[Path, list[str]] = {}
+            for qn, path in self.module_qn_to_file_path.items():
+                index.setdefault(path.parent, []).append(qn)
             self._package_index = index
             self._package_index_size = size
-        return self._package_index.get(package_prefix, [])
+        return self._package_index.get(requester.parent, [])
 
     def _recorded_caller(
         self, func_node: Node, module_qn: str

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -525,6 +525,7 @@ class CallProcessor:
         "_path_to_module_qn",
         "_package_index",
         "_package_index_size",
+        "_go_package_names",
         "cpp_out_of_class_methods",
         "function_locations",
         "macro_qns",
@@ -554,6 +555,7 @@ class CallProcessor:
         function_locations: dict[FunctionSpanKey, FunctionLocation] | None = None,
         macro_qns: set[str] | None = None,
         ast_cache: ASTCacheProtocol | None = None,
+        go_package_names: Mapping[str, str] | None = None,
     ) -> None:
         self.ingestor = ingestor
         self.repo_path = repo_path
@@ -564,6 +566,7 @@ class CallProcessor:
         # rebuilt lazily whenever the underlying map grows.
         self._package_index: dict[Path, list[str]] = {}
         self._package_index_size = -1
+        self._go_package_names: Mapping[str, str] = go_package_names or {}
         self.cpp_out_of_class_methods = cpp_out_of_class_methods or {}
         self.function_locations = function_locations or {}
         self.macro_qns = macro_qns if macro_qns is not None else set()
@@ -1431,18 +1434,25 @@ class CallProcessor:
         self, receiver_type: str, method_name: str, module_qn: str
     ) -> tuple[str, str] | None:
         # A unique registered `<package sibling>.<ReceiverType>.<method>` is
-        # the definition pass's own binding; ambiguity falls back. A `_test.go`
-        # sibling may belong to an external `package foo_test`; production
-        # files can never see its types, so it only counts for test requesters.
+        # the definition pass's own binding; ambiguity falls back. Go package
+        # membership is (directory, `package` clause), and a `_test.go`
+        # sibling is additionally compiled only under `go test`, so it only
+        # counts for test requesters.
         requester = self.module_qn_to_file_path.get(module_qn)
         requester_is_test = requester is not None and requester.stem.endswith(
             cs.GO_TEST_FILE_SUFFIX
         )
+        requester_package = self._go_package_names.get(module_qn)
         hits: list[tuple[str, str]] = []
         for sibling_qn in self._package_modules(module_qn):
             sibling_path = self.module_qn_to_file_path[sibling_qn]
             if not requester_is_test and sibling_path.stem.endswith(
                 cs.GO_TEST_FILE_SUFFIX
+            ):
+                continue
+            if (
+                requester_package is not None
+                and self._go_package_names.get(sibling_qn) != requester_package
             ):
                 continue
             container_qn = f"{sibling_qn}{cs.SEPARATOR_DOT}{receiver_type}"

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -596,6 +596,7 @@ class CallProcessor:
             selection=selection,
             module_paths=self.module_qn_to_file_path,
             ast_cache=ast_cache,
+            go_package_names=self._go_package_names,
         )
         self._flow_processor = FlowProcessor(
             ingestor,

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1431,9 +1431,20 @@ class CallProcessor:
         self, receiver_type: str, method_name: str, module_qn: str
     ) -> tuple[str, str] | None:
         # A unique registered `<package sibling>.<ReceiverType>.<method>` is
-        # the definition pass's own binding; ambiguity falls back.
+        # the definition pass's own binding; ambiguity falls back. A `_test.go`
+        # sibling may belong to an external `package foo_test`; production
+        # files can never see its types, so it only counts for test requesters.
+        requester = self.module_qn_to_file_path.get(module_qn)
+        requester_is_test = requester is not None and requester.stem.endswith(
+            cs.GO_TEST_FILE_SUFFIX
+        )
         hits: list[tuple[str, str]] = []
         for sibling_qn in self._package_modules(module_qn):
+            sibling_path = self.module_qn_to_file_path[sibling_qn]
+            if not requester_is_test and sibling_path.stem.endswith(
+                cs.GO_TEST_FILE_SUFFIX
+            ):
+                continue
             container_qn = f"{sibling_qn}{cs.SEPARATOR_DOT}{receiver_type}"
             caller_qn = f"{container_qn}{cs.SEPARATOR_DOT}{method_name}"
             if caller_qn in self._resolver.function_registry:

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -523,6 +523,8 @@ class CallProcessor:
         "project_name",
         "module_qn_to_file_path",
         "_path_to_module_qn",
+        "_package_index",
+        "_package_index_size",
         "cpp_out_of_class_methods",
         "function_locations",
         "macro_qns",
@@ -558,6 +560,10 @@ class CallProcessor:
         self.project_name = project_name
         self.module_qn_to_file_path = module_qn_to_file_path or {}
         self._path_to_module_qn: dict[Path, str] | None = None
+        # Package-prefix index over module_qn_to_file_path (issue #930),
+        # rebuilt lazily whenever the underlying map grows.
+        self._package_index: dict[str, list[str]] = {}
+        self._package_index_size = -1
         self.cpp_out_of_class_methods = cpp_out_of_class_methods or {}
         self.function_locations = function_locations or {}
         self.macro_qns = macro_qns if macro_qns is not None else set()
@@ -1404,6 +1410,15 @@ class CallProcessor:
         receiver_type = go_utils.extract_receiver_type_name(func_node)
         if not receiver_type:
             return None
+        # The receiver struct is by Go definition in the METHOD'S OWN
+        # package; same-package siblings outrank the global class-name
+        # resolver, whose leaf lookup collides across packages on common
+        # names like `Server` and dangles every edge (issue #930).
+        package_hit = self._go_package_receiver_qn(
+            receiver_type, method_name, module_qn
+        )
+        if package_hit is not None:
+            return package_hit
         container_qn = self._resolver._resolve_class_name(receiver_type, module_qn) or (
             f"{module_qn}{cs.SEPARATOR_DOT}{receiver_type}"
         )
@@ -1411,6 +1426,32 @@ class CallProcessor:
         if caller_qn in self._resolver.function_registry:
             return caller_qn, container_qn
         return None
+
+    def _go_package_receiver_qn(
+        self, receiver_type: str, method_name: str, module_qn: str
+    ) -> tuple[str, str] | None:
+        # A unique registered `<package sibling>.<ReceiverType>.<method>` is
+        # the definition pass's own binding; ambiguity falls back.
+        package_prefix = module_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
+        hits: list[tuple[str, str]] = []
+        for sibling_qn in self._package_modules(package_prefix):
+            container_qn = f"{sibling_qn}{cs.SEPARATOR_DOT}{receiver_type}"
+            caller_qn = f"{container_qn}{cs.SEPARATOR_DOT}{method_name}"
+            if caller_qn in self._resolver.function_registry:
+                hits.append((caller_qn, container_qn))
+        return hits[0] if len(hits) == 1 else None
+
+    def _package_modules(self, package_prefix: str) -> list[str]:
+        # Lazily indexed from module_qn_to_file_path; rebuilt when the map
+        # grew (incremental runs register modules as they parse).
+        size = len(self.module_qn_to_file_path)
+        if self._package_index_size != size:
+            index: dict[str, list[str]] = {}
+            for qn in self.module_qn_to_file_path:
+                index.setdefault(qn.rsplit(cs.SEPARATOR_DOT, 1)[0], []).append(qn)
+            self._package_index = index
+            self._package_index_size = size
+        return self._package_index.get(package_prefix, [])
 
     def _recorded_caller(
         self, func_node: Node, module_qn: str

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -27,6 +27,7 @@ from .cpp.preproc_recovery import parse_with_preproc_recovery
 from .csharp_frontend import CallSiteKey, CSharpCallSite
 from .dependency_parser import parse_dependencies
 from .function_ingest import FunctionIngestMixin
+from .go import utils as go_utils
 from .handlers import get_handler
 from .js_ts.ingest import JsTsIngestMixin
 from .utils import safe_decode_with_fallback, sorted_captures
@@ -64,6 +65,9 @@ class DefinitionProcessor(
         self.simple_name_lookup = simple_name_lookup
         self.import_processor = import_processor
         self.module_qn_to_file_path = module_qn_to_file_path
+        # {go module qn: its `package` clause name}; Go package membership is
+        # (directory, clause), so receiver binding needs both.
+        self.go_package_names: dict[str, str] = {}
         self.class_inheritance: dict[str, list[str]] = {}
         # {class_qn: [(method_qn, method_name)]} for Dart @override methods;
         # whether they override an EXTERNAL base is only decidable once every
@@ -295,6 +299,10 @@ class DefinitionProcessor(
                 )
             module_qn = self._disambiguate_module_qn(module_qn, file_path)
             self.module_qn_to_file_path[module_qn] = file_path
+            if language == cs.SupportedLanguage.GO and (
+                package_name := go_utils.extract_package_name(root_node)
+            ):
+                self.go_package_names[module_qn] = package_name
 
             self.ingestor.ensure_node_batch(
                 cs.NodeLabel.MODULE,

--- a/codebase_rag/parsers/factory.py
+++ b/codebase_rag/parsers/factory.py
@@ -159,5 +159,6 @@ class ProcessorFactory:
                 function_locations=self.definition_processor.function_locations,
                 macro_qns=self.definition_processor.macro_qns,
                 ast_cache=self.ast_cache,
+                go_package_names=self.definition_processor.go_package_names,
             )
         return self._call_processor

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -1004,10 +1004,23 @@ class FunctionIngestMixin:
         if self.function_registry.get(same_file) is not None:
             return same_file
         package = module_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
+        method_file = self.module_qn_to_file_path.get(module_qn)
+        method_is_test = method_file is not None and method_file.stem.endswith(
+            cs.GO_TEST_FILE_SUFFIX
+        )
         for qn in self.simple_name_lookup.get(receiver_type, set()):
             if self.function_registry.get(qn) not in _GO_TYPE_NODE_TYPES:
                 continue
             type_module = qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
+            if not method_is_test:
+                # A `_test.go` sibling may declare a same-named type in an
+                # external `package foo_test`; production files can never see
+                # it, so it must not steal the binding.
+                type_file = self.module_qn_to_file_path.get(type_module)
+                if type_file is not None and type_file.stem.endswith(
+                    cs.GO_TEST_FILE_SUFFIX
+                ):
+                    continue
             if type_module.rsplit(cs.SEPARATOR_DOT, 1)[0] == package:
                 return qn
         return same_file

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -222,6 +222,7 @@ class FunctionIngestMixin:
     function_registry: FunctionRegistryTrieProtocol
     simple_name_lookup: SimpleNameLookup
     module_qn_to_file_path: dict[str, Path]
+    go_package_names: dict[str, str]
     java_anon_overrides: list[tuple[str, str, str, str]]
     pending_endpoints: list[tuple[cs.NodeLabel, str, list[str], str | None]]
     _handler: LanguageHandler
@@ -1003,27 +1004,47 @@ class FunctionIngestMixin:
         same_file = f"{module_qn}{cs.SEPARATOR_DOT}{receiver_type}"
         if self.function_registry.get(same_file) is not None:
             return same_file
-        package = module_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
         method_file = self.module_qn_to_file_path.get(module_qn)
-        method_is_test = method_file is not None and method_file.stem.endswith(
-            cs.GO_TEST_FILE_SUFFIX
-        )
         for qn in self.simple_name_lookup.get(receiver_type, set()):
             if self.function_registry.get(qn) not in _GO_TYPE_NODE_TYPES:
                 continue
             type_module = qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
-            if not method_is_test:
-                # A `_test.go` sibling may declare a same-named type in an
-                # external `package foo_test`; production files can never see
-                # it, so it must not steal the binding.
-                type_file = self.module_qn_to_file_path.get(type_module)
-                if type_file is not None and type_file.stem.endswith(
-                    cs.GO_TEST_FILE_SUFFIX
-                ):
-                    continue
-            if type_module.rsplit(cs.SEPARATOR_DOT, 1)[0] == package:
+            if self._go_type_visible_from(type_module, module_qn, method_file):
                 return qn
         return same_file
+
+    def _go_type_visible_from(
+        self, type_module: str, method_module: str, method_file: Path | None
+    ) -> bool:
+        # Go package membership is (directory, `package` clause). A `_test.go`
+        # declaration is additionally compiled only under `go test`, so it is
+        # invisible to non-test files even inside the same package.
+        type_file = self.module_qn_to_file_path.get(type_module)
+        method_is_test = method_file is not None and method_file.stem.endswith(
+            cs.GO_TEST_FILE_SUFFIX
+        )
+        if (
+            not method_is_test
+            and type_file is not None
+            and type_file.stem.endswith(cs.GO_TEST_FILE_SUFFIX)
+        ):
+            return False
+        method_package = self.go_package_names.get(method_module)
+        type_package = self.go_package_names.get(type_module)
+        if (
+            method_package is not None
+            and type_package is not None
+            and method_package != type_package
+        ):
+            return False
+        if type_file is not None and method_file is not None:
+            return type_file.parent == method_file.parent
+        # Path-less registrations (mock harnesses) fall back to qn-prefix
+        # grouping.
+        return (
+            type_module.rsplit(cs.SEPARATOR_DOT, 1)[0]
+            == method_module.rsplit(cs.SEPARATOR_DOT, 1)[0]
+        )
 
     def resolve_deferred_go_methods(self) -> int:
         """Ingest Go receiver methods now that every receiver type is registered.
@@ -1059,6 +1080,11 @@ class FunctionIngestMixin:
                 language=cs.SupportedLanguage.GO,
                 file_path=entry.file_path,
                 repo_path=self.repo_path,
+                # An undeclared receiver keeps the same-file fallback qn; the
+                # deferred link verifies the container and anchors to the
+                # module instead of a phantom the database would drop.
+                defer_containment=self._deferred_parent_links,
+                module_qn=entry.module_qn,
             )
             # Record the method's return type so a chained call `c.Root().Run()`
             # resolves `Run` on the type `Root()` returns.

--- a/codebase_rag/parsers/go/utils.py
+++ b/codebase_rag/parsers/go/utils.py
@@ -6,6 +6,18 @@ from ... import constants as cs
 from ..utils import safe_decode_text
 
 
+def extract_package_name(root: Node) -> str | None:
+    # The `package foo` clause names the Go package a file belongs to;
+    # membership is (directory, package name), not directory alone.
+    for child in root.named_children:
+        if child.type != cs.TS_GO_PACKAGE_CLAUSE:
+            continue
+        for ident in child.named_children:
+            if ident.type == cs.TS_GO_PACKAGE_IDENTIFIER:
+                return safe_decode_text(ident)
+    return None
+
+
 def is_receiver_method(node: Node) -> bool:
     return (
         node.type == cs.TS_GO_METHOD_DECLARATION

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -131,6 +131,14 @@ def _collect_go_param_bindings(
             )
 
 
+def _same_go_package(
+    sibling_qn: str, path: Path, requester_dir: Path | None, package_qn: str
+) -> bool:
+    if requester_dir is not None:
+        return path.parent == requester_dir
+    return sibling_qn.rsplit(cs.SEPARATOR_DOT, 1)[0] == package_qn
+
+
 def _collect_go_file_fields(
     root: Node,
     import_map: dict[str, str],
@@ -1364,32 +1372,8 @@ class IOAccessProcessor:
             root = root.parent
         package_qn = module_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
         # Go splits a package across files: the struct (and its typed field)
-        # may live in a sibling of the calling file. `_test.go` files,
-        # including the REQUESTING one, compile only under `go test` and
-        # contribute no fields.
-        requester = self._module_paths.get(module_qn)
-        # Package membership groups by the file's PARENT DIRECTORY when the
-        # requester's path is known: extension disambiguation (`service.go`
-        # next to `service.ts` -> qn `pkg.service.go`) would split a file
-        # from its Go package under qn-prefix grouping (issue #930 review).
-        requester_dir = requester.parent if requester is not None else None
-        sources: list[tuple[Node, dict[str, str]]] = []
-        if requester is None or not requester.stem.endswith(cs.GO_TEST_FILE_SUFFIX):
-            sources.append((root, import_map))
-        for sibling_qn, path in self._module_paths.items():
-            if sibling_qn == module_qn or path.stem.endswith(cs.GO_TEST_FILE_SUFFIX):
-                continue
-            if requester_dir is not None:
-                if path.parent != requester_dir:
-                    continue
-            elif sibling_qn.rsplit(cs.SEPARATOR_DOT, 1)[0] != package_qn:
-                continue
-            entry = self._ast_cache.load(path) if self._ast_cache else None
-            if entry is None or entry[1] is not cs.SupportedLanguage.GO:
-                continue
-            sources.append(
-                (entry[0], self._import_processor.import_mapping.get(sibling_qn, {}))
-            )
+        # may live in a sibling of the calling file.
+        sources = self._go_rpc_field_sources(root, module_qn, import_map)
         key = (package_qn, tuple(sorted(node.id for node, _imports in sources)))
         cached = self._rpc_field_cache.get(key)
         if cached is not None:
@@ -1404,6 +1388,33 @@ class IOAccessProcessor:
             fields.pop(name, None)
         self._rpc_field_cache[key] = fields
         return fields
+
+    def _go_rpc_field_sources(
+        self, root: Node, module_qn: str, import_map: dict[str, str]
+    ) -> list[tuple[Node, dict[str, str]]]:
+        # Package membership groups by the file's PARENT DIRECTORY when the
+        # requester's path is known: extension disambiguation (`service.go`
+        # next to `service.ts` -> qn `pkg.service.go`) would split a file
+        # from its Go package under qn-prefix grouping (issue #930 review).
+        # `_test.go` files, including the requesting one, contribute nothing.
+        requester = self._module_paths.get(module_qn)
+        requester_dir = requester.parent if requester is not None else None
+        package_qn = module_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
+        sources: list[tuple[Node, dict[str, str]]] = []
+        if requester is None or not requester.stem.endswith(cs.GO_TEST_FILE_SUFFIX):
+            sources.append((root, import_map))
+        for sibling_qn, path in self._module_paths.items():
+            if sibling_qn == module_qn or path.stem.endswith(cs.GO_TEST_FILE_SUFFIX):
+                continue
+            if not _same_go_package(sibling_qn, path, requester_dir, package_qn):
+                continue
+            entry = self._ast_cache.load(path) if self._ast_cache else None
+            if entry is None or entry[1] is not cs.SupportedLanguage.GO:
+                continue
+            sources.append(
+                (entry[0], self._import_processor.import_mapping.get(sibling_qn, {}))
+            )
+        return sources
 
     def _emit_rpc_field_method(
         self,

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -1410,15 +1410,8 @@ class IOAccessProcessor:
         if requester is None or not requester.stem.endswith(cs.GO_TEST_FILE_SUFFIX):
             sources.append((root, import_map))
         for sibling_qn, path in self._module_paths.items():
-            if sibling_qn == module_qn or path.stem.endswith(cs.GO_TEST_FILE_SUFFIX):
-                continue
-            if not _same_go_package(sibling_qn, path, requester_dir, package_qn):
-                continue
-            sibling_package = self._go_package_names.get(sibling_qn)
-            if (
-                requester_package is not None
-                and sibling_package is not None
-                and sibling_package != requester_package
+            if sibling_qn == module_qn or not self._go_sibling_contributes(
+                sibling_qn, path, requester_dir, package_qn, requester_package
             ):
                 continue
             entry = self._ast_cache.load(path) if self._ast_cache else None
@@ -1428,6 +1421,28 @@ class IOAccessProcessor:
                 (entry[0], self._import_processor.import_mapping.get(sibling_qn, {}))
             )
         return sources
+
+    def _go_sibling_contributes(
+        self,
+        sibling_qn: str,
+        path: Path,
+        requester_dir: Path | None,
+        package_qn: str,
+        requester_package: str | None,
+    ) -> bool:
+        # Membership is (directory, `package` clause): an external
+        # `package svc_test` requester shares a directory with `package svc`
+        # production files without sharing their fields.
+        if path.stem.endswith(cs.GO_TEST_FILE_SUFFIX):
+            return False
+        if not _same_go_package(sibling_qn, path, requester_dir, package_qn):
+            return False
+        sibling_package = self._go_package_names.get(sibling_qn)
+        return (
+            requester_package is None
+            or sibling_package is None
+            or sibling_package == requester_package
+        )
 
     def _emit_rpc_field_method(
         self,

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -1368,15 +1368,21 @@ class IOAccessProcessor:
         # including the REQUESTING one, compile only under `go test` and
         # contribute no fields.
         requester = self._module_paths.get(module_qn)
+        # Package membership groups by the file's PARENT DIRECTORY when the
+        # requester's path is known: extension disambiguation (`service.go`
+        # next to `service.ts` -> qn `pkg.service.go`) would split a file
+        # from its Go package under qn-prefix grouping (issue #930 review).
+        requester_dir = requester.parent if requester is not None else None
         sources: list[tuple[Node, dict[str, str]]] = []
         if requester is None or not requester.stem.endswith(cs.GO_TEST_FILE_SUFFIX):
             sources.append((root, import_map))
         for sibling_qn, path in self._module_paths.items():
-            if (
-                sibling_qn == module_qn
-                or sibling_qn.rsplit(cs.SEPARATOR_DOT, 1)[0] != package_qn
-                or path.stem.endswith(cs.GO_TEST_FILE_SUFFIX)
-            ):
+            if sibling_qn == module_qn or path.stem.endswith(cs.GO_TEST_FILE_SUFFIX):
+                continue
+            if requester_dir is not None:
+                if path.parent != requester_dir:
+                    continue
+            elif sibling_qn.rsplit(cs.SEPARATOR_DOT, 1)[0] != package_qn:
                 continue
             entry = self._ast_cache.load(path) if self._ast_cache else None
             if entry is None or entry[1] is not cs.SupportedLanguage.GO:

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -248,6 +248,7 @@ class IOAccessProcessor:
         selection: CaptureSelection,
         module_paths: Mapping[str, Path] | None = None,
         ast_cache: ASTCacheProtocol | None = None,
+        go_package_names: Mapping[str, str] | None = None,
     ) -> None:
         self.ingestor = ingestor
         # import_processor owns import_mapping[module_qn][local] = full_name, used to
@@ -260,6 +261,10 @@ class IOAccessProcessor:
         # struct declaration and its method files across one directory.
         self._module_paths = module_paths or {}
         self._ast_cache = ast_cache
+        # Go module qn -> `package` clause; membership is (directory, clause),
+        # so an external `package svc_test` file shares a directory with
+        # `package svc` production files without sharing their fields.
+        self._go_package_names: Mapping[str, str] = go_package_names or {}
         # (package_qn, sorted root ids of every participating file) ->
         # {field name: service stem} for connect-client-typed struct fields
         # (issue #912). Fingerprinting EVERY root id keys out stale entries
@@ -1400,6 +1405,7 @@ class IOAccessProcessor:
         requester = self._module_paths.get(module_qn)
         requester_dir = requester.parent if requester is not None else None
         package_qn = module_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
+        requester_package = self._go_package_names.get(module_qn)
         sources: list[tuple[Node, dict[str, str]]] = []
         if requester is None or not requester.stem.endswith(cs.GO_TEST_FILE_SUFFIX):
             sources.append((root, import_map))
@@ -1407,6 +1413,13 @@ class IOAccessProcessor:
             if sibling_qn == module_qn or path.stem.endswith(cs.GO_TEST_FILE_SUFFIX):
                 continue
             if not _same_go_package(sibling_qn, path, requester_dir, package_qn):
+                continue
+            sibling_package = self._go_package_names.get(sibling_qn)
+            if (
+                requester_package is not None
+                and sibling_package is not None
+                and sibling_package != requester_package
+            ):
                 continue
             entry = self._ast_cache.load(path) if self._ast_cache else None
             if entry is None or entry[1] is not cs.SupportedLanguage.GO:

--- a/codebase_rag/tests/test_go_receiver_methods.py
+++ b/codebase_rag/tests/test_go_receiver_methods.py
@@ -151,3 +151,100 @@ def test_go_crossfile_method_binds_to_declaring_type(
     )
     pairs = {(call[0][0][2], call[0][2][2]) for call in defines_method}
     assert (f"{project}.types.Point", f"{project}.types.Point.Scale") in pairs
+
+
+@pytest.fixture
+def go_external_test_type_project(temp_repo: Path) -> Path:
+    # The only same-named type in the directory lives in an external
+    # `package shapes_test` file. An internal test file (`package shapes`)
+    # cannot see it, so its method must not bind there.
+    project_path = temp_repo / "go_extpkg_test"
+    project_path.mkdir()
+    (project_path / "go.mod").write_text(
+        encoding="utf-8", data="module go_extpkg_test\n\ngo 1.22\n"
+    )
+    (project_path / "types_test.go").write_text(
+        encoding="utf-8",
+        data="package shapes_test\n\ntype Point struct {\n\tX int\n}\n",
+    )
+    (project_path / "ops_test.go").write_text(
+        encoding="utf-8",
+        data="package shapes\n\nfunc (p Point) Scale(k int) int {\n\treturn k\n}\n",
+    )
+    return project_path
+
+
+def test_internal_test_method_does_not_bind_to_external_test_type(
+    go_external_test_type_project: Path, mock_ingestor: MagicMock
+) -> None:
+    create_and_run_updater(
+        go_external_test_type_project, mock_ingestor, skip_if_missing="go"
+    )
+    project = go_external_test_type_project.name
+    qns = _method_qns(mock_ingestor)
+    assert f"{project}.types_test.Point.Scale" not in qns, qns
+    # With no visible declaration the binding stays on the method's own
+    # module, mirroring the same-file fallback.
+    assert f"{project}.ops_test.Point.Scale" in qns, qns
+
+
+@pytest.fixture
+def go_test_decoy_project(temp_repo: Path) -> Path:
+    # Production declares Point; an external `package shapes_test` decoy
+    # declares another Point. The internal test method sees only the
+    # production one.
+    project_path = temp_repo / "go_decoy_test"
+    project_path.mkdir()
+    (project_path / "go.mod").write_text(
+        encoding="utf-8", data="module go_decoy_test\n\ngo 1.22\n"
+    )
+    (project_path / "types.go").write_text(
+        encoding="utf-8",
+        data="package shapes\n\ntype Point struct {\n\tX int\n}\n",
+    )
+    (project_path / "decoy_test.go").write_text(
+        encoding="utf-8",
+        data="package shapes_test\n\ntype Point struct{}\n",
+    )
+    (project_path / "ops_test.go").write_text(
+        encoding="utf-8",
+        data="package shapes\n\nfunc (p Point) Scale(k int) int {\n\treturn p.X * k\n}\n",
+    )
+    return project_path
+
+
+def test_internal_test_method_binds_to_production_type_past_decoy(
+    go_test_decoy_project: Path, mock_ingestor: MagicMock
+) -> None:
+    create_and_run_updater(go_test_decoy_project, mock_ingestor, skip_if_missing="go")
+    project = go_test_decoy_project.name
+    qns = _method_qns(mock_ingestor)
+    assert f"{project}.types.Point.Scale" in qns, qns
+    assert f"{project}.decoy_test.Point.Scale" not in qns, qns
+
+
+def test_container_resolution_uses_directory_for_disambiguated_modules() -> None:
+    # The declaring module's qn carries an appended extension
+    # (`proj.svc.types.go` beside a same-stem file of another language), so
+    # qn-prefix package comparison places it in a phantom package. Directory
+    # grouping must still bind the method to the real type node.
+    from codebase_rag.parsers.function_ingest import FunctionIngestMixin
+    from codebase_rag.types_defs import NodeType
+
+    class _Stub(FunctionIngestMixin):
+        function_registry = {"proj.svc.types.go.Point": NodeType.CLASS}  # type: ignore[assignment]
+        simple_name_lookup = {"Point": {"proj.svc.types.go.Point"}}
+        module_qn_to_file_path = {
+            "proj.svc.ops": Path("/repo/svc/ops.go"),
+            "proj.svc.types.go": Path("/repo/svc/types.go"),
+        }
+        go_package_names = {
+            "proj.svc.ops": "shapes",
+            "proj.svc.types.go": "shapes",
+        }
+
+        def _get_docstring(self, node: object) -> str | None:
+            return None
+
+    resolved = _Stub()._resolve_go_container_qn("proj.svc.ops", "Point")
+    assert resolved == "proj.svc.types.go.Point", resolved

--- a/codebase_rag/tests/test_io_handle_edges.py
+++ b/codebase_rag/tests/test_io_handle_edges.py
@@ -1154,3 +1154,39 @@ class TestGoRpcTypedClientEvidence:
         )
         after = processor._go_rpc_fields(caller_fn, "proj.svc.create", {})
         assert after == {"userClient": "UserService"}, after
+
+    def test_receiver_collision_across_packages_attributes_correctly(
+        self, tmp_path: Path
+    ) -> None:
+        # Issue #930: `Server` recurs across packages. The receiver struct is
+        # by Go definition in the METHOD'S OWN package; a same-named struct
+        # elsewhere must not steal the attribution and dangle the edge.
+        files = {
+            "aaa/server.go": (
+                "package aaa\n\n"
+                "type Server struct{}\n\n"
+                "func (s *Server) Unrelated() {}\n"
+            ),
+            "svc/service.go": (
+                "package svc\n\n"
+                'import "example.com/gen/user/v1/userv1connect"\n\n'
+                "type Server struct {\n"
+                "\tuserClient userv1connect.UserServiceClient\n"
+                "}\n"
+            ),
+            "svc/create.go": (
+                "package svc\n\n"
+                "func (s *Server) Create() {\n"
+                "\ts.userClient.GetUser(nil, nil)\n"
+                "}\n"
+            ),
+        }
+        rels = _run_io(tmp_path, files)
+        matches = [
+            a for a, r, b in rels
+            if b == self._RPC and r == READS_FROM
+        ]
+        assert matches, rels
+        # The caller qn must be the REGISTERED method node
+        # (svc.service.Server.Create), never a receiver-dropping fallback.
+        assert all(".svc.service.Server.Create" in a for a in matches), matches

--- a/codebase_rag/tests/test_io_handle_edges.py
+++ b/codebase_rag/tests/test_io_handle_edges.py
@@ -1188,6 +1188,38 @@ class TestGoRpcTypedClientEvidence:
         # (svc.service.Server.Create), never a receiver-dropping fallback.
         assert all(".svc.service.Server.Create" in a for a in matches), matches
 
+    def test_external_test_package_sibling_does_not_block_resolution(
+        self, tmp_path: Path
+    ) -> None:
+        # An external `package svc_test` sibling can declare its own `Server`
+        # with the same method name, but production files can never see a
+        # type from a `_test.go` file, so it must not force the ambiguity
+        # fallback that dangles the production method's edges.
+        files = {
+            "svc/service.go": (
+                "package svc\n\n"
+                'import "example.com/gen/user/v1/userv1connect"\n\n'
+                "type Server struct {\n"
+                "\tuserClient userv1connect.UserServiceClient\n"
+                "}\n"
+            ),
+            "svc/create.go": (
+                "package svc\n\n"
+                "func (s *Server) Create() {\n"
+                "\ts.userClient.GetUser(nil, nil)\n"
+                "}\n"
+            ),
+            "svc/helpers_test.go": (
+                "package svc_test\n\n"
+                "type Server struct{}\n\n"
+                "func (s *Server) Create() {}\n"
+            ),
+        }
+        rels = _run_io(tmp_path, files)
+        matches = [a for a, r, b in rels if b == self._RPC and r == READS_FROM]
+        assert matches, rels
+        assert all(".svc.service.Server.Create" in a for a in matches), matches
+
     def test_extension_disambiguated_module_keeps_its_package(
         self, tmp_path: Path
     ) -> None:

--- a/codebase_rag/tests/test_io_handle_edges.py
+++ b/codebase_rag/tests/test_io_handle_edges.py
@@ -1184,66 +1184,6 @@ class TestGoRpcTypedClientEvidence:
         rels = _run_io(tmp_path, files)
         matches = [a for a, r, b in rels if b == self._RPC and r == READS_FROM]
         assert matches, rels
-
-    def test_disambiguated_declaring_module_still_contributes_fields(
-        self, tmp_path: Path
-    ) -> None:
-        # Deterministic variant: the DECLARING module's qn carries the
-        # appended extension (`proj.svc.service.go`); grouping by qn prefix
-        # would place it in a phantom package. Directory grouping keeps it.
-        from codebase_rag.capture import resolve_capture
-        from codebase_rag.parser_loader import load_parsers
-        from codebase_rag.parsers.io_access.processor import IOAccessProcessor
-
-        parsers, _ = load_parsers()
-        decl_src = (
-            "package svc\n\n"
-            'import "example.com/gen/user/v1/userv1connect"\n\n'
-            "type Server struct {\n"
-            "\tuserClient userv1connect.UserServiceClient\n"
-            "}\n"
-        )
-        caller_src = (
-            "package svc\n\nfunc (s *Server) Create() {\n"
-            "\ts.userClient.GetUser(nil, nil)\n}\n"
-        )
-        caller_tree = parsers["go"].parse(caller_src.encode())
-        decl_path = tmp_path / "svc" / "service.go"
-
-        class _FakeCache:
-            def __init__(self) -> None:
-                self.entry = (
-                    parsers["go"].parse(decl_src.encode()).root_node,
-                    cs.SupportedLanguage.GO,
-                )
-
-            def load(self, key: Path) -> tuple[object, cs.SupportedLanguage]:
-                return self.entry
-
-        import_processor = MagicMock()
-        import_processor.import_mapping = {
-            "proj.svc.service.go": {
-                "userv1connect": "example.com/gen/user/v1/userv1connect"
-            },
-            "proj.svc.create": {},
-        }
-        processor = IOAccessProcessor(
-            MagicMock(),
-            import_processor,
-            selection=resolve_capture([cs.CaptureGroup.IO.value]),
-            module_paths={
-                "proj.svc.service.go": decl_path,
-                "proj.svc.create": tmp_path / "svc" / "create.go",
-            },
-            ast_cache=_FakeCache(),  # type: ignore[arg-type]
-        )
-        caller_fn = next(
-            c
-            for c in caller_tree.root_node.named_children
-            if c.type == "method_declaration"
-        )
-        fields = processor._go_rpc_fields(caller_fn, "proj.svc.create", {})
-        assert fields == {"userClient": "UserService"}, fields
         # The caller qn must be the REGISTERED method node
         # (svc.service.Server.Create), never a receiver-dropping fallback.
         assert all(".svc.service.Server.Create" in a for a in matches), matches

--- a/codebase_rag/tests/test_io_handle_edges.py
+++ b/codebase_rag/tests/test_io_handle_edges.py
@@ -1182,10 +1182,7 @@ class TestGoRpcTypedClientEvidence:
             ),
         }
         rels = _run_io(tmp_path, files)
-        matches = [
-            a for a, r, b in rels
-            if b == self._RPC and r == READS_FROM
-        ]
+        matches = [a for a, r, b in rels if b == self._RPC and r == READS_FROM]
         assert matches, rels
         # The caller qn must be the REGISTERED method node
         # (svc.service.Server.Create), never a receiver-dropping fallback.

--- a/codebase_rag/tests/test_io_handle_edges.py
+++ b/codebase_rag/tests/test_io_handle_edges.py
@@ -1184,6 +1184,153 @@ class TestGoRpcTypedClientEvidence:
         rels = _run_io(tmp_path, files)
         matches = [a for a, r, b in rels if b == self._RPC and r == READS_FROM]
         assert matches, rels
+
+    def test_disambiguated_declaring_module_still_contributes_fields(
+        self, tmp_path: Path
+    ) -> None:
+        # Deterministic variant: the DECLARING module's qn carries the
+        # appended extension (`proj.svc.service.go`); grouping by qn prefix
+        # would place it in a phantom package. Directory grouping keeps it.
+        from codebase_rag.capture import resolve_capture
+        from codebase_rag.parser_loader import load_parsers
+        from codebase_rag.parsers.io_access.processor import IOAccessProcessor
+
+        parsers, _ = load_parsers()
+        decl_src = (
+            "package svc\n\n"
+            'import "example.com/gen/user/v1/userv1connect"\n\n'
+            "type Server struct {\n"
+            "\tuserClient userv1connect.UserServiceClient\n"
+            "}\n"
+        )
+        caller_src = (
+            "package svc\n\nfunc (s *Server) Create() {\n"
+            "\ts.userClient.GetUser(nil, nil)\n}\n"
+        )
+        caller_tree = parsers["go"].parse(caller_src.encode())
+        decl_path = tmp_path / "svc" / "service.go"
+
+        class _FakeCache:
+            def __init__(self) -> None:
+                self.entry = (
+                    parsers["go"].parse(decl_src.encode()).root_node,
+                    cs.SupportedLanguage.GO,
+                )
+
+            def load(self, key: Path) -> tuple[object, cs.SupportedLanguage]:
+                return self.entry
+
+        import_processor = MagicMock()
+        import_processor.import_mapping = {
+            "proj.svc.service.go": {
+                "userv1connect": "example.com/gen/user/v1/userv1connect"
+            },
+            "proj.svc.create": {},
+        }
+        processor = IOAccessProcessor(
+            MagicMock(),
+            import_processor,
+            selection=resolve_capture([cs.CaptureGroup.IO.value]),
+            module_paths={
+                "proj.svc.service.go": decl_path,
+                "proj.svc.create": tmp_path / "svc" / "create.go",
+            },
+            ast_cache=_FakeCache(),  # type: ignore[arg-type]
+        )
+        caller_fn = next(
+            c
+            for c in caller_tree.root_node.named_children
+            if c.type == "method_declaration"
+        )
+        fields = processor._go_rpc_fields(caller_fn, "proj.svc.create", {})
+        assert fields == {"userClient": "UserService"}, fields
         # The caller qn must be the REGISTERED method node
         # (svc.service.Server.Create), never a receiver-dropping fallback.
         assert all(".svc.service.Server.Create" in a for a in matches), matches
+
+    def test_extension_disambiguated_module_keeps_its_package(
+        self, tmp_path: Path
+    ) -> None:
+        # `service.ts` shares the stem with `service.go`, so the Go module
+        # qn gets the extension appended (`svc.service.go`). Package
+        # membership must group by DIRECTORY, not qn prefix, or the struct
+        # file splits away from its siblings and attribution dangles.
+        files = {
+            "svc/service.ts": "export const unrelated = 1\n",
+            "svc/service.go": (
+                "package svc\n\n"
+                'import "example.com/gen/user/v1/userv1connect"\n\n'
+                "type Server struct {\n"
+                "\tuserClient userv1connect.UserServiceClient\n"
+                "}\n"
+            ),
+            "svc/create.go": (
+                "package svc\n\n"
+                "func (s *Server) Create() {\n"
+                "\ts.userClient.GetUser(nil, nil)\n"
+                "}\n"
+            ),
+        }
+        rels = _run_io(tmp_path, files)
+        matches = [a for a, r, b in rels if b == self._RPC and r == READS_FROM]
+        assert matches, rels
+
+    def test_disambiguated_declaring_module_still_contributes_fields(
+        self, tmp_path: Path
+    ) -> None:
+        # Deterministic variant: the DECLARING module's qn carries the
+        # appended extension (`proj.svc.service.go`); grouping by qn prefix
+        # would place it in a phantom package. Directory grouping keeps it.
+        from codebase_rag.capture import resolve_capture
+        from codebase_rag.parser_loader import load_parsers
+        from codebase_rag.parsers.io_access.processor import IOAccessProcessor
+
+        parsers, _ = load_parsers()
+        decl_src = (
+            "package svc\n\n"
+            'import "example.com/gen/user/v1/userv1connect"\n\n'
+            "type Server struct {\n"
+            "\tuserClient userv1connect.UserServiceClient\n"
+            "}\n"
+        )
+        caller_src = (
+            "package svc\n\nfunc (s *Server) Create() {\n"
+            "\ts.userClient.GetUser(nil, nil)\n}\n"
+        )
+        caller_tree = parsers["go"].parse(caller_src.encode())
+        decl_path = tmp_path / "svc" / "service.go"
+
+        class _FakeCache:
+            def __init__(self) -> None:
+                self.entry = (
+                    parsers["go"].parse(decl_src.encode()).root_node,
+                    cs.SupportedLanguage.GO,
+                )
+
+            def load(self, key: Path) -> tuple[object, cs.SupportedLanguage]:
+                return self.entry
+
+        import_processor = MagicMock()
+        import_processor.import_mapping = {
+            "proj.svc.service.go": {
+                "userv1connect": "example.com/gen/user/v1/userv1connect"
+            },
+            "proj.svc.create": {},
+        }
+        processor = IOAccessProcessor(
+            MagicMock(),
+            import_processor,
+            selection=resolve_capture([cs.CaptureGroup.IO.value]),
+            module_paths={
+                "proj.svc.service.go": decl_path,
+                "proj.svc.create": tmp_path / "svc" / "create.go",
+            },
+            ast_cache=_FakeCache(),  # type: ignore[arg-type]
+        )
+        caller_fn = next(
+            c
+            for c in caller_tree.root_node.named_children
+            if c.type == "method_declaration"
+        )
+        fields = processor._go_rpc_fields(caller_fn, "proj.svc.create", {})
+        assert fields == {"userClient": "UserService"}, fields

--- a/codebase_rag/tests/test_io_handle_edges.py
+++ b/codebase_rag/tests/test_io_handle_edges.py
@@ -1220,6 +1220,34 @@ class TestGoRpcTypedClientEvidence:
         assert matches, rels
         assert all(".svc.service.Server.Create" in a for a in matches), matches
 
+    def test_external_test_method_does_not_consume_production_fields(
+        self, tmp_path: Path
+    ) -> None:
+        # The reverse direction: an external `package svc_test` file cannot
+        # reference unexported members of `package svc`, so a same-named
+        # field on its own harness type must not pick up the production
+        # file's typed-client evidence.
+        files = {
+            "svc/service.go": (
+                "package svc\n\n"
+                'import "example.com/gen/user/v1/userv1connect"\n\n'
+                "type Server struct {\n"
+                "\tuserClient userv1connect.UserServiceClient\n"
+                "}\n"
+            ),
+            "svc/harness_test.go": (
+                "package svc_test\n\n"
+                "type harness struct {\n"
+                "\tuserClient fakeClient\n"
+                "}\n\n"
+                "func (h *harness) run() {\n"
+                "\th.userClient.GetUser(nil, nil)\n"
+                "}\n"
+            ),
+        }
+        rels = _run_io(tmp_path, files)
+        assert not any("resource::RPC::" in b for _a, _r, b in rels), rels
+
     def test_extension_disambiguated_module_keeps_its_package(
         self, tmp_path: Path
     ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.481"
+version = "0.0.482"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Fixes #930.

Traced from the reference monorepo: interior RPC sinks emitted correctly (verified by tracing `_emit` inside the real CLI flow) but never landed in the graph, because every edge from a Go method defined in a different file than its receiver struct carried a wrong caller qn and was dropped as dangling at flush. `_go_receiver_method_caller` resolved the receiver type through the global class-name resolver, which collides across packages on ubiquitous names like `Server`; the failed registry check then fell through to the receiver-dropping `module.method` attribution. This silently dropped CALLS, READS_FROM, and WRITES_TO edges from all such methods at monorepo scale.

- The receiver struct is by Go definition in the METHOD'S OWN package, so resolution now tries `<package sibling>.<ReceiverType>.<method>` against the function registry first, accepting a unique hit; ambiguity falls back to the previous behaviour.
- Package siblings come from a lazily built index over `module_qn_to_file_path`, rebuilt when the map grows.
- RED test: a same-named struct in another package must not steal the attribution; the sink edge must carry the registered method qn.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Go receiver-method and container binding using sibling-aware, uniqueness-filtered lookup.
  * Ensured methods and typed-client RPC attribution ignore inappropriate `_test.go`-only types.
  * Refined Go typed-client evidence to resolve “same package” more accurately using directory and package-clause details.
* **New Features**
  * Added faster sibling indexing for cross-file package resolution with lazy rebuild.
* **Tests**
  * Expanded regression coverage for typed-client collisions, external test-package siblings, directory/extension module disambiguation, and deterministic field attribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->