### PR TITLE
docs: add OpenSSF Best Practices badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@
   <a href="https://scorecard.dev/viewer/?uri=github.com/vitali87/code-graph-rag">
     <img src="https://api.scorecard.dev/projects/github.com/vitali87/code-graph-rag/badge" alt="OpenSSF Scorecard" />
   </a>
+  <a href="https://www.bestpractices.dev/projects/13757">
+    <img src="https://www.bestpractices.dev/projects/13757/badge" alt="OpenSSF Best Practices" />
+  </a>
   <!--
   <a href="https://gitcgr.com/vitali87/code-graph-rag">
     <img src="https://gitcgr.com/badge/vitali87/code-graph-rag.svg" alt="gitcgr" />

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.481"
+version = "0.0.482"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Adds the OpenSSF Best Practices passing badge (project [13757](https://www.bestpractices.dev/projects/13757), earned today) to the README badge row, next to the OpenSSF Scorecard badge.
- `uv.lock` editable package metadata synchronised to the current project version by the generate-readme pre-commit hook.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [x] Documentation
- [ ] CI/CD or tooling
- [ ] Dependencies

## Related Issues

None.

## Test Plan

- [x] Manual testing (describe below)

Verified the badge URL renders the passing badge and links to https://www.bestpractices.dev/projects/13757. README-only change; no code paths affected.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [x] No new comments or docstrings (code should be self-documenting)
