### PR TITLE
ci: push version bumps with a deploy key instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2
-          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh-key: ${{ secrets.VERSION_BUMP_SSH_KEY }}
 
       - name: Check if version was manually changed
         id: check_manual

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.482"
+version = "0.0.483"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Switches the Version Bump workflow checkout from `GITHUB_TOKEN` to the `VERSION_BUMP_SSH_KEY` deploy key so bump commits and tags are pushed via SSH.
- Prerequisite for tightening the main branch ruleset (PR required, required status checks) with the deploy key as the sole bypass actor, raising the Scorecard Branch-Protection score.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [x] CI/CD or tooling
- [ ] Dependencies

## Related Issues

None.

## Test Plan

- [x] Manual testing (describe below)

The deploy key (write access) and the `VERSION_BUMP_SSH_KEY` secret are already configured on the repository. The workflow will be verified by the auto-bump run triggered when this PR merges; the ruleset tightening happens only after that run succeeds.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [x] No new comments or docstrings (code should be self-documenting)
