### PR TITLE
ci: push bump tags with GITHUB_TOKEN so they trigger no workflows

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -108,6 +108,8 @@ jobs:
 
       - name: Create git tag
         if: steps.check_manual.outputs.skip == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git tag "v${{ steps.bump_version.outputs.new }}"
-          git push origin "v${{ steps.bump_version.outputs.new }}"
+          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "v${{ steps.bump_version.outputs.new }}"

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.483"
+version = "0.0.484"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Pushes the auto-bump `v*` tag over HTTPS with `GITHUB_TOKEN` instead of the SSH deploy key, so the tag push triggers no workflows (GitHub suppresses triggers for `GITHUB_TOKEN` pushes).
- The bump commit itself still pushes via the deploy key, which is required to bypass the main branch ruleset.
- Restores the pre-#933 behaviour where auto-bumped tags never fire Build Binaries or Docker Publish, so releases are created manually when ready instead of automatically on every merge.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [x] CI/CD or tooling
- [ ] Dependencies

## Related Issues

None.

## Test Plan

- [x] Manual testing (describe below)

Adversarially reviewed for credential routing: the explicit HTTPS URL is not rewritten by checkout's SSH configuration, `contents: write` suffices for the tag push, and the token is masked in logs. Verified in production by the next merge to main: the bump commit must land via the deploy key and the tag must appear with no Build Binaries or Docker Publish run triggered.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [x] No new comments or docstrings (code should be self-documenting)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated version tagging to authenticate reliably when publishing release tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->