### PR TITLE
fix(docker): install git in builder stage for git-pinned grammar forks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY --from=uv /uv /uvx /bin/
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        cmake build-essential libssl-dev zlib1g-dev libzstd-dev && \
+        cmake build-essential git libssl-dev zlib1g-dev libzstd-dev && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.483"
+version = "0.0.484"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Installs `git` in the Docker builder stage so `uv sync` can fetch `tree-sitter-c` and `tree-sitter-cpp`, which are pinned to patched git forks in `pyproject.toml`.
- Fixes the Docker Publish failure ("Failed to download and build tree-sitter-c: Git operation failed") first surfaced by the v0.0.484 tag push; the workflow had not run since the grammar pins moved to git sources, so the breakage went unnoticed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD or tooling
- [ ] Dependencies

## Related Issues

None.

## Test Plan

- [x] Manual testing (describe below)

Reproduced the failure locally (builder stage fails at the first `uv sync` without `git`), then built the `builder` stage with this change and verified the fix by importing both git-pinned grammars from the resulting image: `docker run --rm <image> /app/.venv/bin/python -c "import tree_sitter_c, tree_sitter_cpp"` succeeds.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [x] No new comments or docstrings (code should be self-documenting)
