### PR TITLE
ci: auto-release every 50 tags with model-written highlights

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,3 +46,5 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
+        with:
+          skip-existing: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,14 @@ name: Publish to PyPI
 on:
   release:
     types: [published]
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish (e.g. v0.0.484)"
+        required: true
 
 permissions: read-all
 
@@ -19,6 +27,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,14 @@ jobs:
       contents: read
 
     steps:
+      - name: Validate dispatched tag
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          printf '%s' "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            || { echo "tag must match vMAJOR.MINOR.PATCH, got: $TAG"; exit 1; }
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ inputs.tag || github.ref }}
+          ref: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || github.ref }}
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -116,12 +116,16 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           LATEST=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name 2>/dev/null || echo "")
-          NEW_PATCH="${{ steps.bump_version.outputs.new }}"
-          NEW_PATCH="${NEW_PATCH##*.}"
-          LATEST_PATCH="${LATEST##*.}"
           RELEASE=false
-          if [ -n "$LATEST" ] && [ $((NEW_PATCH - LATEST_PATCH)) -ge "$RELEASE_EVERY" ]; then
-            RELEASE=true
+          if [ -n "$LATEST" ]; then
+            TAGS_SINCE=$(git ls-remote --tags origin "refs/tags/v*" \
+              | awk -F'refs/tags/' '{print $2}' \
+              | grep -v '\^{}' \
+              | sort -V \
+              | awk -v latest="$LATEST" 'seen {count++} $0 == latest {seen=1} END {print count + 0}')
+            if [ $((TAGS_SINCE + 1)) -ge "$RELEASE_EVERY" ]; then
+              RELEASE=true
+            fi
           fi
           echo "release=$RELEASE" >> $GITHUB_OUTPUT
           echo "latest=$LATEST" >> $GITHUB_OUTPUT

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -166,7 +166,7 @@ jobs:
           sed -E 's| by @[^ ]+ in https://[^ ]+||' /tmp/notes.md > /tmp/titles.md
           jq -n --rawfile notes /tmp/titles.md \
             '{model: "default", temperature: 0.3, max_tokens: 900, messages: [
-              {role: "user", content: ("Write a \"## Highlights\" section for a software release: 3 to 7 bullets, each starting with a short bold theme followed by a colon, grouping the most important changes. Use British English. Never use em-dashes or en-dashes. Ground every claim strictly in the pull request titles below; do not invent anything. Output only the markdown section, starting with the line \"## Highlights\".\n\n" + $notes)}
+              {role: "user", content: ("Write a \"## Highlights\" section for a software release: a markdown bullet list of 3 to 7 items, each line starting with \"* \" then a short bold theme followed by a colon, grouping the most important changes. Use British English. Never use em-dashes or en-dashes. Ground every claim strictly in the pull request titles below; do not invent anything. Output only the markdown section, starting with the line \"## Highlights\".\n\n" + $notes)}
             ]}' > /tmp/req.json
           curl -sf --max-time 1500 "${RESOLVE_ARGS[@]}" \
             -H "Authorization: Bearer ${HIGHLIGHTS_API_TOKEN}" \

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -26,7 +26,7 @@ jobs:
     name: Auto Version Bump
     if: "!contains(github.event.head_commit.message, 'chore: bump version')"
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 40
     permissions:
       contents: write
     steps:
@@ -173,7 +173,7 @@ jobs:
             -H "Content-Type: application/json" \
             -d @/tmp/req.json \
             "${HIGHLIGHTS_API_URL}/v1/chat/completions" \
-          | jq -r '.choices[0].message.content' \
+          | jq -er '.choices[0].message.content // empty' \
           | sed -e '/<think>/,/<\/think>/d' > /tmp/highlights.md
 
       - name: Create release

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -158,13 +158,17 @@ jobs:
         env:
           HIGHLIGHTS_API_URL: ${{ secrets.HIGHLIGHTS_API_URL }}
           HIGHLIGHTS_API_TOKEN: ${{ secrets.HIGHLIGHTS_API_TOKEN }}
+          HIGHLIGHTS_RESOLVE: ${{ secrets.HIGHLIGHTS_RESOLVE }}
         run: |
           [ -n "$HIGHLIGHTS_API_URL" ] || exit 0
-          jq -n --rawfile notes /tmp/notes.md \
+          RESOLVE_ARGS=()
+          [ -n "$HIGHLIGHTS_RESOLVE" ] && RESOLVE_ARGS=(--resolve "$HIGHLIGHTS_RESOLVE")
+          sed -E 's| by @[^ ]+ in https://[^ ]+||' /tmp/notes.md > /tmp/titles.md
+          jq -n --rawfile notes /tmp/titles.md \
             '{model: "default", temperature: 0.3, max_tokens: 900, messages: [
               {role: "user", content: ("Write a \"## Highlights\" section for a software release: 3 to 7 bullets, each starting with a short bold theme followed by a colon, grouping the most important changes. Use British English. Never use em-dashes or en-dashes. Ground every claim strictly in the pull request titles below; do not invent anything. Output only the markdown section, starting with the line \"## Highlights\".\n\n" + $notes)}
             ]}' > /tmp/req.json
-          curl -sf --max-time 600 \
+          curl -sf --max-time 1500 "${RESOLVE_ARGS[@]}" \
             -H "Authorization: Bearer ${HIGHLIGHTS_API_TOKEN}" \
             -H "Content-Type: application/json" \
             -d @/tmp/req.json \

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -18,6 +18,9 @@ on:
 
 permissions: read-all
 
+env:
+  RELEASE_EVERY: 50
+
 jobs:
   bump-version:
     name: Auto Version Bump
@@ -106,10 +109,75 @@ jobs:
           git commit -m "chore: bump version to ${{ steps.bump_version.outputs.new }}"
           git push
 
+      - name: Decide whether this tag ships a release
+        if: steps.check_manual.outputs.skip == 'false'
+        id: decide
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LATEST=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name 2>/dev/null || echo "")
+          NEW_PATCH="${{ steps.bump_version.outputs.new }}"
+          NEW_PATCH="${NEW_PATCH##*.}"
+          LATEST_PATCH="${LATEST##*.}"
+          RELEASE=false
+          if [ -n "$LATEST" ] && [ $((NEW_PATCH - LATEST_PATCH)) -ge "$RELEASE_EVERY" ]; then
+            RELEASE=true
+          fi
+          echo "release=$RELEASE" >> $GITHUB_OUTPUT
+          echo "latest=$LATEST" >> $GITHUB_OUTPUT
+
       - name: Create git tag
         if: steps.check_manual.outputs.skip == 'false'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git tag "v${{ steps.bump_version.outputs.new }}"
-          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "v${{ steps.bump_version.outputs.new }}"
+          if [ "${{ steps.decide.outputs.release }}" = "true" ]; then
+            git push origin "v${{ steps.bump_version.outputs.new }}"
+          else
+            git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "v${{ steps.bump_version.outputs.new }}"
+          fi
+
+      - name: Generate release notes
+        if: steps.decide.outputs.release == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+            -f tag_name="v${{ steps.bump_version.outputs.new }}" \
+            -f previous_tag_name="${{ steps.decide.outputs.latest }}" \
+            --jq .body > /tmp/notes.md
+
+      - name: Generate highlights
+        if: steps.decide.outputs.release == 'true'
+        continue-on-error: true
+        env:
+          HIGHLIGHTS_API_URL: ${{ secrets.HIGHLIGHTS_API_URL }}
+          HIGHLIGHTS_API_TOKEN: ${{ secrets.HIGHLIGHTS_API_TOKEN }}
+        run: |
+          [ -n "$HIGHLIGHTS_API_URL" ] || exit 0
+          jq -n --rawfile notes /tmp/notes.md \
+            '{model: "default", temperature: 0.3, max_tokens: 900, messages: [
+              {role: "user", content: ("Write a \"## Highlights\" section for a software release: 3 to 7 bullets, each starting with a short bold theme followed by a colon, grouping the most important changes. Use British English. Never use em-dashes or en-dashes. Ground every claim strictly in the pull request titles below; do not invent anything. Output only the markdown section, starting with the line \"## Highlights\".\n\n" + $notes)}
+            ]}' > /tmp/req.json
+          curl -sf --max-time 600 \
+            -H "Authorization: Bearer ${HIGHLIGHTS_API_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d @/tmp/req.json \
+            "${HIGHLIGHTS_API_URL}/v1/chat/completions" \
+          | jq -r '.choices[0].message.content' \
+          | sed -e '/<think>/,/<\/think>/d' > /tmp/highlights.md
+
+      - name: Create release
+        if: steps.decide.outputs.release == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="v${{ steps.bump_version.outputs.new }}"
+          if [ -s /tmp/highlights.md ]; then
+            cat /tmp/highlights.md /tmp/notes.md > /tmp/body.md
+          else
+            cp /tmp/notes.md /tmp/body.md
+          fi
+          gh release create "$TAG" --title "$TAG" --notes-file /tmp/body.md --verify-tag \
+            || gh release edit "$TAG" --notes-file /tmp/body.md

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.484"
+version = "0.0.485"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Automatically cuts a GitHub release once 50 tags have accumulated since the latest release; a manual release resets the counter by definition since the count is measured from whatever release is latest.
- The release-cadence tag is pushed via the SSH deploy key so the existing tag-triggered pipelines fire (Build Binaries with signing and provenance, Docker Publish); all other tags keep the silent `GITHUB_TOKEN` push.
- The release body is a model-written `## Highlights` section (OpenAI-compatible endpoint held in `HIGHLIGHTS_API_URL`/`HIGHLIGHTS_API_TOKEN` secrets, `continue-on-error` with fallback to plain notes) followed by GitHub's generated What's Changed notes.
- publish.yml gains a tag-push trigger for PyPI parity on auto releases (only deploy-key tag pushes fire it; `GITHUB_TOKEN` pushes are event-suppressed) plus a `workflow_dispatch` tag input for backfills, and `skip-existing: true` makes reruns idempotent.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [x] CI/CD or tooling
- [ ] Dependencies

## Related Issues

None.

## Test Plan

- [x] Manual testing (describe below)

The tag-counting pipeline was validated against the live tag list (1 tag since v0.0.484, 64 since v0.0.421, both exact), and it is robust across minor and major bumps because it counts tags rather than subtracting patch numbers. The event-suppression premise (releases and tags created with `GITHUB_TOKEN` fire no workflows) was observed in production on v0.0.484 and v0.0.485. An adversarial review's findings were fixed (tag counting replaces patch arithmetic) or hardened against (`skip-existing`).

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [x] No new comments or docstrings (code should be self-documenting)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for publishing releases manually or automatically when version tags are pushed.
  * Added configurable release frequency for version bumps.
  * Added automatic GitHub release creation with generated release notes and optional highlights.

* **Bug Fixes**
  * Prevented publishing failures when a package or release already exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->