### PR TITLE
docs: expand PyPI readme with feature overview, workspaces, and MCP tool surface

### DIFF
--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -18,7 +18,7 @@ Point it at a repository and it reads every source file, extracts functions, cla
 
 ## Supported Languages
 
-Python, TypeScript, TSX, JavaScript, Rust, Go, Java, C, C++, C#, PHP, Lua, and Dart are fully supported. Scala is in development, and Ruby has structural support (modules, functions, classes, and imports) through the pluggable ast-grep tier.
+Python, TypeScript, TSX, JavaScript, Rust, Go, Java, C, C++, C#, PHP, Lua, and Dart are fully supported. Scala is in development, and Ruby has structural support (modules, functions, classes, and imports) through the pluggable ast-grep tier, which requires the `ast-grep` extra (`pip install 'code-graph-rag[ast-grep]'`).
 
 ## Install
 
@@ -115,11 +115,11 @@ cgr doctor                                 # check dependencies and configuratio
 
 ## MCP Server
 
-Run `cgr mcp-server` to serve the tools over stdio or HTTP for Claude Code and other MCP clients. The server exposes the full toolbox:
+Run `cgr mcp-server` to serve the tools over stdio or HTTP for Claude Code and other MCP clients. The MCP surface registers:
 
-- **Ask and retrieve:** `ask_agent`, `query_code_graph`, `semantic_search`, `get_code_snippet`
-- **Structural editing:** `structural_search`, `structural_replace`, `surgical_replace_code`
-- **Files and projects:** `read_file`, `write_file`, `list_directory`, `list_projects`, `index_repository`, `update_repository`, `delete_project`
+- **Ask and retrieve:** `ask_agent`, `query_code_graph`, `get_code_snippet`, and `semantic_search` (needs the `semantic` extra)
+- **Structural editing:** `surgical_replace_code`, plus `structural_search` and `structural_replace` (need the `ast-grep` extra)
+- **Files and projects:** `read_file`, `write_file`, `list_directory`, `list_projects`, `index_repository`, `update_repository`, `delete_project`, `wipe_database`
 
 ## Python SDK
 

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -1,6 +1,23 @@
 # Code-Graph-RAG
 
-A graph-based RAG system that parses multi-language codebases with Tree-sitter, builds knowledge graphs in Memgraph, and enables natural language querying, editing, and optimisation.
+Code-Graph-RAG parses a multi-language codebase with Tree-sitter, builds a knowledge graph of its structure in Memgraph, and lets you query, edit, and optimise that code in plain English. It works across a monorepo of mixed languages under one unified graph schema.
+
+## What It Does
+
+Point it at a repository and it reads every source file, extracts functions, classes, methods, and modules along with the relationships between them, and stores the result as an interconnected graph. Once the graph exists you can:
+
+- Ask questions about the codebase in natural language and get answers grounded in the real structure.
+- Retrieve the actual source of any function, class, or method by name or by intent.
+- Edit code through the agent with AST-based surgical patching and a diff preview before anything changes.
+- Search and rewrite code structurally by AST pattern with ast-grep, instead of text or regex.
+- Trace data flow through assignments, calls, and I/O sinks via `FLOWS_TO` taint edges.
+- Optimise code against language best practices or your own coding standards.
+- Find dead code by walking call and reference edges from entry points.
+- Group several repositories into a named workspace and query them as one graph.
+
+## Supported Languages
+
+Python, TypeScript, TSX, JavaScript, Rust, Go, Java, C, C++, C#, PHP, Lua, and Dart are fully supported. Scala is in development, and Ruby has structural support (modules, functions, classes, and imports) through the pluggable ast-grep tier.
 
 ## Install
 
@@ -78,17 +95,30 @@ cgr dead-code --format json --fail-on-found     # CI-friendly report
 Results are candidates for review, not a guaranteed delete list. See the
 [Dead Code Detection guide](https://docs.code-graph-rag.com/guide/dead-code/).
 
-**Run as an MCP server (for Claude Code):**
+**Group repositories into a workspace and query them together:**
 
 ```bash
-cgr mcp-server
+cgr workspace create my-platform
+cgr workspace add-repo my-platform ./service-a
+cgr workspace add-repo my-platform ./service-b
+cgr start --workspace my-platform
 ```
 
-**Check your setup:**
+**Inspect the graph and the stack:**
 
 ```bash
-cgr doctor
+cgr stats                                  # node and relationship counts
+cgr status                                 # stack state and last sync per project
+cgr doctor                                 # check dependencies and configuration
 ```
+
+## MCP Server
+
+Run `cgr mcp-server` to serve the tools over stdio or HTTP for Claude Code and other MCP clients. The server exposes the full toolbox:
+
+- **Ask and retrieve:** `ask_agent`, `query_code_graph`, `semantic_search`, `get_code_snippet`
+- **Structural editing:** `structural_search`, `structural_replace`, `surgical_replace_code`
+- **Files and projects:** `read_file`, `write_file`, `list_directory`, `list_projects`, `index_repository`, `update_repository`, `delete_project`
 
 ## Python SDK
 

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -14,6 +14,7 @@ Point it at a repository and it reads every source file, extracts functions, cla
 - Optimise code against language best practices or your own coding standards.
 - Find dead code by walking call and reference edges from entry points.
 - Group several repositories into a named workspace and query them as one graph.
+- Trace calls between microservices: route decorators become endpoint templates, and HTTP client URLs resolve to the handlers that serve them, linking services across project boundaries.
 
 ## Supported Languages
 

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.484"
+version = "0.0.485"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

The PyPI project page rendered a thin description that undersold the actual surface of the package. This expands `PYPI_README.md` with:

* A proper opening paragraph matching the repository README.
* A **What It Does** capability list: natural language querying, AST-based surgical editing with diff preview, structural search and replace via ast-grep, data-flow tracing with `FLOWS_TO` edges, optimisation, dead-code detection, and multi-repo workspaces.
* A **Supported Languages** section including TSX, Scala status, and the Ruby ast-grep tier (with its `ast-grep` extra requirement).
* CLI examples for `cgr workspace` (create, add-repo, query as one graph), `cgr stats`, and `cgr status`.
* An expanded **MCP Server** section listing the registered tools grouped by purpose, with optional-extra gating noted for `semantic_search`, `structural_search`, and `structural_replace`.

All command names and flags verified against `codebase_rag/cli_help.py`, `codebase_rag/workspaces/cli.py`, and `codebase_rag/cli.py`; tool names verified against `codebase_rag/mcp/tools.py` and `codebase_rag/constants/mcp.py`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring

## Related Issues

None; follows up the PyPI publishing work in #936 so the refreshed page ships with the next published version.

## Test Plan

Documentation only, no code changes. Every command, flag, and MCP tool name in the new sections was checked against the source files listed above, and Greptile's T-Rex run independently confirmed the documented MCP surface matches the live registry (no missing base tools, no undocumented live tools).

## Checklist

- [x] Prose matches the codebase (commands, flags, tool names verified against source)
- [x] `uv.lock` version sync picked up by the readme hook (0.0.485)
- [x] Optional-extra gating documented for dependency-gated features
- [x] CI green
