### PR TITLE
ci: skip SonarCloud analysis on Dependabot pull requests

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   sonarcloud:
     name: SonarCloud Analysis
-    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
+    if: github.actor != 'dependabot[bot]' && (github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push')
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.484"
+version = "0.0.485"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Dependabot-triggered `pull_request` workflows only receive Dependabot secrets, so `secrets.SONAR_TOKEN` resolves empty and the scan fails with HTTP 403 in about one second (seen on #859: `Failed to query JRE metadata ... Please check the property sonar.token`).

Dependency bumps change no first-party code, so scanning them adds nothing. This extends the job guard to skip the analysis when the actor is `dependabot[bot]`, alongside the existing fork guard.

`uv.lock` refresh comes from the readme pre-commit hook picking up the auto-bumped 0.0.485.