### PR TITLE
fix: isolate unit tests from live vector stores

### DIFF
--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -113,13 +113,21 @@ def _pin_csharp_frontend_treesitter(monkeypatch: pytest.MonkeyPatch) -> None:
 def _isolate_vector_store(
     tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # Tests must never touch the developer's real local vector store: a
-    # clean-path test would purge it for real, and parallel xdist workers
-    # would collide on its file lock.
+    # Tests must never touch the developer's real vector store: a clean-path
+    # test would purge it for real, and parallel xdist workers would collide
+    # on its file lock. A developer .env sets QDRANT_URL to the live daemon
+    # stack, and URL mode never reads QDRANT_DB_PATH, so the URL must be
+    # cleared too or the purge lands on the live server.
     from codebase_rag.config import settings
 
+    monkeypatch.setattr(settings, "QDRANT_URL", None)
     monkeypatch.setattr(
         settings, "QDRANT_DB_PATH", str(tmp_path_factory.mktemp("qdrant-iso"))
+    )
+    monkeypatch.setattr(
+        settings,
+        "MILVUS_URI",
+        str(tmp_path_factory.mktemp("milvus-iso") / "milvus.db"),
     )
 
 

--- a/codebase_rag/tests/test_vector_store_isolation.py
+++ b/codebase_rag/tests/test_vector_store_isolation.py
@@ -12,15 +12,23 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from codebase_rag.config import settings
 
 
-def test_qdrant_url_is_neutralised_for_unit_tests() -> None:
+def test_qdrant_url_is_neutralised_for_unit_tests(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
     # URL mode bypasses QDRANT_DB_PATH entirely, so isolation must force the
     # embedded per-test store even when the environment points at a live
     # server. On a box with no .env this holds by default; the subprocess
     # guard below is what gives it teeth.
     assert settings.QDRANT_URL is None
+    # Config-value checks alone would still pass if the fixture pointed the
+    # embedded store at a developer path; the effective location must live
+    # under pytest's own temp area.
+    assert Path(settings.QDRANT_DB_PATH).is_relative_to(tmp_path_factory.getbasetemp())
 
 
 def test_isolation_fixture_neutralises_env_qdrant_url() -> None:
@@ -50,8 +58,10 @@ def test_isolation_fixture_neutralises_env_qdrant_url() -> None:
     assert result.returncode == 0, result.stdout + result.stderr
 
 
-def test_milvus_uri_is_isolated_for_unit_tests() -> None:
+def test_milvus_uri_is_isolated_for_unit_tests(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
     # The shipped default is a CWD-relative file, which in a checkout is the
-    # developer's real embeddings database.
-    assert settings.MILVUS_URI != "./.milvus_code_embeddings.db"
-    assert Path(settings.MILVUS_URI).is_absolute()
+    # developer's real embeddings database; the isolated file must live under
+    # pytest's own temp area, not merely be absolute.
+    assert Path(settings.MILVUS_URI).is_relative_to(tmp_path_factory.getbasetemp())

--- a/codebase_rag/tests/test_vector_store_isolation.py
+++ b/codebase_rag/tests/test_vector_store_isolation.py
@@ -1,0 +1,57 @@
+"""Guards that unit tests can never reach a developer's live vector store.
+
+A developer .env typically sets QDRANT_URL to the local daemon stack; if that
+leaks into the unit suite, every --clean code path purges the real collections
+and concurrent xdist workers race on the live server (issue #905).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from codebase_rag.config import settings
+
+
+def test_qdrant_url_is_neutralised_for_unit_tests() -> None:
+    # URL mode bypasses QDRANT_DB_PATH entirely, so isolation must force the
+    # embedded per-test store even when the environment points at a live
+    # server. On a box with no .env this holds by default; the subprocess
+    # guard below is what gives it teeth.
+    assert settings.QDRANT_URL is None
+
+
+def test_isolation_fixture_neutralises_env_qdrant_url() -> None:
+    # In CI the shipped QDRANT_URL default is already None, so the assertion
+    # above cannot catch the isolation fixture being deleted. Re-run it in a
+    # subprocess with the environment a developer .env would produce; only
+    # the conftest fixture can make it pass there.
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-q",
+            "-p",
+            "no:cacheprovider",
+            "-o",
+            "addopts=",
+            f"{__file__}::test_qdrant_url_is_neutralised_for_unit_tests",
+        ],
+        env=os.environ | {"QDRANT_URL": "http://127.0.0.1:9"},
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=Path(__file__).resolve().parents[2],
+        timeout=120,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_milvus_uri_is_isolated_for_unit_tests() -> None:
+    # The shipped default is a CWD-relative file, which in a checkout is the
+    # developer's real embeddings database.
+    assert settings.MILVUS_URI != "./.milvus_code_embeddings.db"
+    assert Path(settings.MILVUS_URI).is_absolute()

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.488"
+version = "0.0.490"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Closes #905.

Unit tests mocked Memgraph but not the vector store, and the conftest isolation fixture only patched `QDRANT_DB_PATH`. A developer `.env` sets `QDRANT_URL`, and URL mode never reads the DB path, so every unmocked `--clean` code path connected to the live Qdrant at `localhost:6333`, purged real collections, and raced under `pytest -n auto` (9 failures locally; invisible in CI where no server listens).

* `_isolate_vector_store` now clears `QDRANT_URL` and points `MILVUS_URI` at a per-test temp path, alongside the existing `QDRANT_DB_PATH` isolation, so unit tests always land on embedded per-test stores.
* New `test_vector_store_isolation.py` guards the invariant. Because the shipped `QDRANT_URL` default is already `None` in CI, a plain assertion would be vacuous there; the guard therefore re-runs itself in a subprocess with `QDRANT_URL` injected into the environment, exactly as a developer `.env` would produce, and only the conftest fixture can make that pass. Deleting the protective line makes the guard fail everywhere, including CI.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Related Issues

Closes #905.

## Test Plan

RED: the guard asserting `settings.QDRANT_URL is None` failed on a developer box (`'http://localhost:6333' is None`) before the fixture change. GREEN: fixture updated, guard passes. The guard's own teeth were verified by temporarily deleting the protective line and watching the subprocess test fail, then restoring it. The two previously racing files (`test_cli_clean.py`, `test_cli_repo_path_validation.py`) pass 18/18 under `-n auto` with the live Qdrant collection confirmed untouched before and after. Full unit suite: 5765 passed, 5 pre-existing dependency-conditional skips.

## Checklist

- [x] RED demonstrated before GREEN
- [x] Full unit suite green under `-n auto`
- [x] pre-commit green
- [x] Live services confirmed untouched by the test run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation so automated tests use temporary, local vector-store configurations.
  * Added safeguards preventing tests from connecting to developer or CI Qdrant and Milvus backends.
  * Added coverage verifying external vector-store settings are neutralized during test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->