### PR TITLE
fix: resolve duplicate Go module directives to the directory containing the package

### DIFF
--- a/codebase_rag/constants/deps.py
+++ b/codebase_rag/constants/deps.py
@@ -45,6 +45,8 @@ DEP_FILE_GOMOD = "go.mod"
 # the module's packages; a same-line comment (incl. `// Deprecated:`) may
 # trail it.
 GO_KEYWORD_MODULE = "module"
+GO_KEYWORD_PACKAGE = "package"
+GO_PACKAGE_MAIN = "main"
 GO_MOD_COMMENT_PREFIX = "//"
 DEP_FILE_GEMFILE = "gemfile"
 DEP_FILE_COMPOSER = "composer.json"

--- a/codebase_rag/parsers/go/module_paths.py
+++ b/codebase_rag/parsers/go/module_paths.py
@@ -63,13 +63,53 @@ def _has_importable_root_package(anchor: Path) -> bool:
             text = path.read_text(encoding=cs.ENCODING_UTF8)
         except (OSError, ValueError):
             continue
-        for line in text.splitlines():
-            parts = line.split(cs.GO_MOD_COMMENT_PREFIX, 1)[0].split()
-            if len(parts) >= 2 and parts[0] == cs.GO_KEYWORD_PACKAGE:
-                if parts[1] != cs.GO_PACKAGE_MAIN:
-                    return True
-                break
+        clause = _root_package_clause(text)
+        if clause is not None and clause != cs.GO_PACKAGE_MAIN:
+            return True
     return False
+
+
+def _root_package_clause(text: str) -> str | None:
+    # The package clause is the first code in a valid .go file, so only
+    # comments can precede it; strip line and block comments (which do not
+    # nest, and no string literal can appear before the clause) and read the
+    # first code line. Anything other than a package clause there means a
+    # malformed file: bail rather than guess.
+    in_block = False
+    for line in text.splitlines():
+        code, in_block = _strip_go_comments(line, in_block)
+        parts = code.split()
+        if not parts:
+            continue
+        if parts[0] == cs.GO_KEYWORD_PACKAGE and len(parts) >= 2:
+            return parts[1]
+        return None
+    return None
+
+
+def _strip_go_comments(line: str, in_block: bool) -> tuple[str, bool]:
+    code: list[str] = []
+    i = 0
+    while i < len(line):
+        if in_block:
+            end = line.find("*/", i)
+            if end == -1:
+                return "".join(code), True
+            in_block = False
+            i = end + 2
+            continue
+        block = line.find("/*", i)
+        line_comment = line.find(cs.GO_MOD_COMMENT_PREFIX, i)
+        if line_comment != -1 and (block == -1 or line_comment < block):
+            code.append(line[i:line_comment])
+            break
+        if block == -1:
+            code.append(line[i:])
+            break
+        code.append(line[i:block])
+        in_block = True
+        i = block + 2
+    return "".join(code), in_block
 
 
 def resolve_go_import_path(

--- a/codebase_rag/parsers/go/module_paths.py
+++ b/codebase_rag/parsers/go/module_paths.py
@@ -24,13 +24,15 @@ def _module_directive(gomod: Path) -> str | None:
     return None
 
 
-def discover_go_module_paths(repo_path: Path) -> list[tuple[str, str]]:
+def discover_go_module_paths(repo_path: Path) -> list[tuple[str, str, Path]]:
     # Go import paths are module-path-prefixed (github.com/acme/tool/pkg), so no
     # local import matches a repo-relative qn directly. Map every go.mod module
     # directive (root module plus nested workspace submodules) to the dotted
-    # directory that anchors it; longest module path first so a nested module
-    # shadows an enclosing one on shared prefixes.
-    mappings: list[tuple[str, str]] = []
+    # directory that anchors it, plus the anchoring directory itself (kept as a
+    # real Path so directory names containing dots stay unambiguous); longest
+    # module path first so a nested module shadows an enclosing one on shared
+    # prefixes.
+    mappings: list[tuple[str, str, Path]] = []
     for gomod in repo_path.rglob(cs.DEP_FILE_GOMOD):
         rel_dir = gomod.parent.relative_to(repo_path)
         if any(part in cs.IGNORE_PATTERNS for part in rel_dir.parts):
@@ -41,24 +43,42 @@ def discover_go_module_paths(repo_path: Path) -> list[tuple[str, str]]:
                 if rel_dir == Path()
                 else str(rel_dir).replace(os.sep, cs.SEPARATOR_DOT)
             )
-            mappings.append((module_path, dotted))
+            mappings.append((module_path, dotted, gomod.parent))
             logger.debug(ls.IMP_GO_MODULE_PATH, module=module_path, path=dotted)
-    mappings.sort(key=lambda m: len(m[0]), reverse=True)
+    # Deterministic order: longest module path first, then lexicographic, so
+    # duplicate module directives resolve the same way on every run and
+    # platform.
+    mappings.sort(key=lambda m: (-len(m[0]), m[0], m[1]))
     return mappings
 
 
 def resolve_go_import_path(
-    module_paths: list[tuple[str, str]], import_path: str
+    module_paths: list[tuple[str, str, Path]], import_path: str
 ) -> str | None:
     # Longest module-path prefix wins; the remainder of the import path is the
-    # package directory under that module. Returns the repo-relative dotted dir
-    # ('' when the import IS a module root), or None for external imports.
-    for module_path, dotted_dir in module_paths:
+    # package directory under that module. A dependency-pinning stub go.mod can
+    # declare the SAME module directive as the real code tree, so among the
+    # longest-prefix matches prefer one whose directory actually contains the
+    # imported package on disk (issue #941). Returns the repo-relative dotted
+    # dir ('' when the import IS a module root), or None for external imports.
+    matches: list[tuple[str, str, bool]] = []
+    for module_path, dotted_dir, anchor in module_paths:
         if import_path == module_path:
-            return dotted_dir
-        if import_path.startswith(f"{module_path}{cs.SEPARATOR_SLASH}"):
-            rel = import_path[len(module_path) + 1 :].replace(
-                cs.SEPARATOR_SLASH, cs.SEPARATOR_DOT
+            matches.append((module_path, dotted_dir, anchor.is_dir()))
+        elif import_path.startswith(f"{module_path}{cs.SEPARATOR_SLASH}"):
+            rel = import_path[len(module_path) + 1 :]
+            dotted_rel = rel.replace(cs.SEPARATOR_SLASH, cs.SEPARATOR_DOT)
+            candidate = (
+                f"{dotted_dir}{cs.SEPARATOR_DOT}{dotted_rel}"
+                if dotted_dir
+                else dotted_rel
             )
-            return f"{dotted_dir}{cs.SEPARATOR_DOT}{rel}" if dotted_dir else rel
-    return None
+            matches.append((module_path, candidate, (anchor / rel).is_dir()))
+    if not matches:
+        return None
+    longest = max(len(m[0]) for m in matches)
+    top = [m for m in matches if len(m[0]) == longest]
+    for _module_path, candidate, exists in top:
+        if exists:
+            return candidate
+    return top[0][1]

--- a/codebase_rag/parsers/go/module_paths.py
+++ b/codebase_rag/parsers/go/module_paths.py
@@ -52,6 +52,26 @@ def discover_go_module_paths(repo_path: Path) -> list[tuple[str, str, Path]]:
     return mappings
 
 
+def _has_importable_root_package(anchor: Path) -> bool:
+    # True when a .go file directly in `anchor` declares a non-main package.
+    try:
+        go_files = [p for p in anchor.iterdir() if p.suffix == cs.EXT_GO]
+    except OSError:
+        return False
+    for path in go_files:
+        try:
+            text = path.read_text(encoding=cs.ENCODING_UTF8)
+        except (OSError, ValueError):
+            continue
+        for line in text.splitlines():
+            parts = line.split(cs.GO_MOD_COMMENT_PREFIX, 1)[0].split()
+            if len(parts) >= 2 and parts[0] == cs.GO_KEYWORD_PACKAGE:
+                if parts[1] != cs.GO_PACKAGE_MAIN:
+                    return True
+                break
+    return False
+
+
 def resolve_go_import_path(
     module_paths: list[tuple[str, str, Path]], import_path: str
 ) -> str | None:
@@ -64,7 +84,12 @@ def resolve_go_import_path(
     matches: list[tuple[str, str, bool]] = []
     for module_path, dotted_dir, anchor in module_paths:
         if import_path == module_path:
-            matches.append((module_path, dotted_dir, anchor.is_dir()))
+            # Every discovered anchor exists, so for a module-ROOT import the
+            # discriminator is whether the root holds an importable package:
+            # a stub's `package main` cannot be imported.
+            matches.append(
+                (module_path, dotted_dir, _has_importable_root_package(anchor))
+            )
         elif import_path.startswith(f"{module_path}{cs.SEPARATOR_SLASH}"):
             rel = import_path[len(module_path) + 1 :]
             dotted_rel = rel.replace(cs.SEPARATOR_SLASH, cs.SEPARATOR_DOT)

--- a/codebase_rag/parsers/go/module_paths.py
+++ b/codebase_rag/parsers/go/module_paths.py
@@ -82,7 +82,8 @@ def _root_package_clause(text: str) -> str | None:
         if not parts:
             continue
         if parts[0] == cs.GO_KEYWORD_PACKAGE and len(parts) >= 2:
-            return parts[1]
+            # `package main;` is a valid explicit-semicolon clause form.
+            return parts[1].rstrip(";")
         return None
     return None
 
@@ -97,6 +98,9 @@ def _strip_go_comments(line: str, in_block: bool) -> tuple[str, bool]:
                 return "".join(code), True
             in_block = False
             i = end + 2
+            # A removed comment is a token separator, never a splice
+            # (`package/*doc*/gen` stays two tokens).
+            code.append(" ")
             continue
         block = line.find("/*", i)
         line_comment = line.find(cs.GO_MOD_COMMENT_PREFIX, i)

--- a/codebase_rag/tests/test_go_module_path_imports.py
+++ b/codebase_rag/tests/test_go_module_path_imports.py
@@ -296,3 +296,58 @@ def test_duplicate_module_paths_resolver_prefers_existing_package_dir(
     mappings = discover_go_module_paths(tmp_path)
     resolved = resolve_go_import_path(mappings, "github.com/acme/mytool/gen/util")
     assert resolved == "real.util", (mappings, resolved)
+
+
+def test_duplicate_module_root_import_resolver_unit(tmp_path: Path) -> None:
+    # The import names the module PATH itself. Both duplicate anchors exist
+    # on disk, so directory existence cannot discriminate; the stub holds
+    # only `package main`, which cannot be imported, and must lose to the
+    # anchor with an importable root package.
+    from codebase_rag.parsers.go import (
+        discover_go_module_paths,
+        resolve_go_import_path,
+    )
+
+    (tmp_path / "a_stub").mkdir()
+    (tmp_path / "a_stub" / "go.mod").write_text(
+        "module github.com/acme/mytool/gen\n", encoding="utf-8"
+    )
+    (tmp_path / "a_stub" / "main.go").write_text(
+        "package main\n\nfunc main() {}\n", encoding="utf-8"
+    )
+    (tmp_path / "gen").mkdir()
+    (tmp_path / "gen" / "go.mod").write_text(
+        "module github.com/acme/mytool/gen\n", encoding="utf-8"
+    )
+    (tmp_path / "gen" / "gen.go").write_text(
+        'package gen\n\nfunc Version() string {\n\treturn "1"\n}\n',
+        encoding="utf-8",
+    )
+    mappings = discover_go_module_paths(tmp_path)
+    resolved = resolve_go_import_path(mappings, "github.com/acme/mytool/gen")
+    assert resolved == "gen", (mappings, resolved)
+
+
+def test_duplicate_module_root_import_prefers_importable_package(
+    tmp_path: Path,
+) -> None:
+    # Pipeline-level regression of the same shape.
+    files = {
+        "go.mod": GO_MOD,
+        "a_stub/go.mod": "module github.com/acme/mytool/gen\n\ngo 1.22\n",
+        "a_stub/main.go": "package main\n\nfunc main() {}\n",
+        "gen/go.mod": "module github.com/acme/mytool/gen\n\ngo 1.22\n",
+        "gen/gen.go": 'package gen\n\nfunc Version() string {\n\treturn "1"\n}\n',
+        # Decoy for the name fallback if the import misresolves.
+        "meta/meta.go": 'package meta\n\nfunc Version() string {\n\treturn "x"\n}\n',
+        "main.go": (
+            "package main\n\n"
+            'import gen "github.com/acme/mytool/gen"\n\n'
+            "func main() {\n"
+            "    gen.Version()\n"
+            "}\n"
+        ),
+    }
+    calls = _calls(_run_rels(tmp_path, files), "main.main")
+    assert "mytool.gen.gen.Version" in calls, calls
+    assert "mytool.meta.meta.Version" not in calls, calls

--- a/codebase_rag/tests/test_go_module_path_imports.py
+++ b/codebase_rag/tests/test_go_module_path_imports.py
@@ -351,3 +351,33 @@ def test_duplicate_module_root_import_prefers_importable_package(
     calls = _calls(_run_rels(tmp_path, files), "main.main")
     assert "mytool.gen.gen.Version" in calls, calls
     assert "mytool.meta.meta.Version" not in calls, calls
+
+
+def test_block_comment_package_text_does_not_qualify_stub(tmp_path: Path) -> None:
+    # The stub's only file is `package main` preceded by a block comment
+    # containing the words `package docs`; comment text is not a clause.
+    from codebase_rag.parsers.go import (
+        discover_go_module_paths,
+        resolve_go_import_path,
+    )
+
+    (tmp_path / "a_stub").mkdir()
+    (tmp_path / "a_stub" / "go.mod").write_text(
+        "module github.com/acme/mytool/gen\n", encoding="utf-8"
+    )
+    (tmp_path / "a_stub" / "main.go").write_text(
+        "/*\npackage docs describes why this stub exists.\n*/\n"
+        "package main\n\nfunc main() {}\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "gen").mkdir()
+    (tmp_path / "gen" / "go.mod").write_text(
+        "module github.com/acme/mytool/gen\n", encoding="utf-8"
+    )
+    (tmp_path / "gen" / "gen.go").write_text(
+        'package gen\n\nfunc Version() string {\n\treturn "1"\n}\n',
+        encoding="utf-8",
+    )
+    mappings = discover_go_module_paths(tmp_path)
+    resolved = resolve_go_import_path(mappings, "github.com/acme/mytool/gen")
+    assert resolved == "gen", (mappings, resolved)

--- a/codebase_rag/tests/test_go_module_path_imports.py
+++ b/codebase_rag/tests/test_go_module_path_imports.py
@@ -381,3 +381,55 @@ def test_block_comment_package_text_does_not_qualify_stub(tmp_path: Path) -> Non
     mappings = discover_go_module_paths(tmp_path)
     resolved = resolve_go_import_path(mappings, "github.com/acme/mytool/gen")
     assert resolved == "gen", (mappings, resolved)
+
+
+def _write_duplicate_module_pair(
+    tmp_path: Path, stub_main_go: str, real_gen_go: str
+) -> None:
+    (tmp_path / "a_stub").mkdir()
+    (tmp_path / "a_stub" / "go.mod").write_text(
+        "module github.com/acme/mytool/gen\n", encoding="utf-8"
+    )
+    (tmp_path / "a_stub" / "main.go").write_text(stub_main_go, encoding="utf-8")
+    (tmp_path / "gen").mkdir()
+    (tmp_path / "gen" / "go.mod").write_text(
+        "module github.com/acme/mytool/gen\n", encoding="utf-8"
+    )
+    (tmp_path / "gen" / "gen.go").write_text(real_gen_go, encoding="utf-8")
+
+
+def test_semicolon_package_clause_still_counts_as_main(tmp_path: Path) -> None:
+    # `package main;` is a valid clause form; the trailing semicolon must not
+    # make the stub look importable.
+    from codebase_rag.parsers.go import (
+        discover_go_module_paths,
+        resolve_go_import_path,
+    )
+
+    _write_duplicate_module_pair(
+        tmp_path,
+        "package main;\n\nfunc main() {}\n",
+        'package gen\n\nfunc Version() string {\n\treturn "1"\n}\n',
+    )
+    mappings = discover_go_module_paths(tmp_path)
+    resolved = resolve_go_import_path(mappings, "github.com/acme/mytool/gen")
+    assert resolved == "gen", (mappings, resolved)
+
+
+def test_inline_block_comment_keeps_clause_tokens_apart(tmp_path: Path) -> None:
+    # `package/*doc*/gen` must still read as a `gen` clause: removing the
+    # comment may not glue the tokens together, or the real tree looks
+    # unimportable and the stub wins.
+    from codebase_rag.parsers.go import (
+        discover_go_module_paths,
+        resolve_go_import_path,
+    )
+
+    _write_duplicate_module_pair(
+        tmp_path,
+        "package main\n\nfunc main() {}\n",
+        'package/*doc*/gen\n\nfunc Version() string {\n\treturn "1"\n}\n',
+    )
+    mappings = discover_go_module_paths(tmp_path)
+    resolved = resolve_go_import_path(mappings, "github.com/acme/mytool/gen")
+    assert resolved == "gen", (mappings, resolved)

--- a/codebase_rag/tests/test_go_module_path_imports.py
+++ b/codebase_rag/tests/test_go_module_path_imports.py
@@ -243,3 +243,56 @@ def test_local_import_edge_targets_project_qn(tmp_path: Path) -> None:
     import_targets = {b for a, r, b in rels if r == "IMPORTS" and a.endswith("main")}
     assert "mytool.util.util" in import_targets
     assert not any(t.startswith("github.com/") for t in import_targets)
+
+
+def test_duplicate_module_directive_resolves_to_dir_with_package(
+    tmp_path: Path,
+) -> None:
+    # Two go.mod files declare the SAME module path: a dependency-pinning
+    # stub (holding only a placeholder main.go) and the real code tree. The
+    # import must resolve into the tree that contains the imported package,
+    # regardless of discovery order.
+    files = {
+        "go.mod": GO_MOD,
+        "a_stub/go.mod": "module github.com/acme/mytool/gen\n\ngo 1.22\n",
+        "a_stub/main.go": "package main\n\nfunc main() {}\n",
+        # An unrelated same-named package: if the import misresolves to the
+        # stub, the name fallback rebinds here instead of the imported one.
+        "alpha/util/util.go": GREET_ALPHA,
+        "gen/go.mod": "module github.com/acme/mytool/gen\n\ngo 1.22\n",
+        "gen/util/util.go": GREET_BETA,
+        "main.go": (
+            "package main\n\n"
+            'import "github.com/acme/mytool/gen/util"\n\n'
+            "func main() {\n"
+            "    util.Greet()\n"
+            "}\n"
+        ),
+    }
+    calls = _calls(_run_rels(tmp_path, files), "main.main")
+    assert "mytool.gen.util.util.Greet" in calls, calls
+    assert "mytool.alpha.util.util.Greet" not in calls, calls
+
+
+def test_duplicate_module_paths_resolver_prefers_existing_package_dir(
+    tmp_path: Path,
+) -> None:
+    # Unit-level determinism: the stub mapping sorts first, but only the real
+    # tree contains the imported package directory.
+    from codebase_rag.parsers.go import (
+        discover_go_module_paths,
+        resolve_go_import_path,
+    )
+
+    (tmp_path / "a_stub").mkdir()
+    (tmp_path / "a_stub" / "go.mod").write_text(
+        "module github.com/acme/mytool/gen\n", encoding="utf-8"
+    )
+    (tmp_path / "real" / "util").mkdir(parents=True)
+    (tmp_path / "real" / "go.mod").write_text(
+        "module github.com/acme/mytool/gen\n", encoding="utf-8"
+    )
+    (tmp_path / "real" / "util" / "util.go").write_text(GREET_BETA, encoding="utf-8")
+    mappings = discover_go_module_paths(tmp_path)
+    resolved = resolve_go_import_path(mappings, "github.com/acme/mytool/gen/util")
+    assert resolved == "real.util", (mappings, resolved)

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.490"
+version = "0.0.492"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Fixes #941. In a monorepo, a dependency-pinning stub `go.mod` can declare the SAME `module` directive as the real code tree. Discovery recorded both mappings and resolution returned the first longest-prefix match, so which directory an import resolved to depended on filesystem enumeration order; when the stub won, every import under that module path landed in a directory that does not contain the imported package, silently breaking cross-package IMPORTS, CALLS, and the #939 RPC exposure linking downstream.

## Fix

- Module mappings now carry the anchoring directory as a real `Path` (kept alongside the dotted form so directory names containing dots stay unambiguous), and discovery sorts deterministically (longest module path, then lexicographic) so resolution is reproducible across runs and platforms.
- `resolve_go_import_path` collects all longest-prefix matches and prefers one whose directory actually contains the imported package path on disk, falling back to the previous first-match behaviour when none do. Nested-module shadowing semantics are unchanged: shorter prefixes still lose to longer ones.

## Testing

RED first: a unit test where the stub mapping deterministically sorts before the real tree, and a pipeline test with a same-named decoy package proving the misresolution rebinds calls to the wrong package. Both failed before the fix and pass after. Full suite: 6083 passed, 10 skipped. Verified against the reference monorepo shape: server RPC exposure edges that were silently absent now emit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Go import resolution when multiple `module` directives share the same module path, including correct handling of subpackage imports.
  * For module-root imports, resolution now prefers anchors containing an importable package (non-`main`) rather than any existing directory.
  * Made module resolution ordering deterministic for consistent results across environments.

* **Tests**
  * Added regression coverage for duplicate module anchors, module-root preference rules, and avoiding false matches from `package ...` text in block comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->