### PR TITLE
feat: emit network sinks for options-object generated client calls

### DIFF
--- a/codebase_rag/parsers/io_access/constants.py
+++ b/codebase_rag/parsers/io_access/constants.py
@@ -53,6 +53,7 @@ MODE_UPDATE_CHAR = "+"
 # fetch-style options objects carry the HTTP verb under this key; the verb
 # refines the sink's declared direction (an unlisted verb is unknown).
 HTTP_METHOD_OPTION_KEY = "method"
+HTTP_METHOD_OPTION_KEY_URL = "url"
 HTTP_READ_VERBS = frozenset({"GET", "HEAD", "OPTIONS"})
 HTTP_WRITE_VERBS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
 

--- a/codebase_rag/parsers/io_access/descriptor.py
+++ b/codebase_rag/parsers/io_access/descriptor.py
@@ -126,6 +126,13 @@ class LanguageDescriptor:
     # render as placeholders in captured resource identities (issue #884).
     template_string_type: str | None = None
     template_substitution_type: str | None = None
+    # Generated HTTP-client calls that carry the target in an options object
+    # (`client.get({ url: '/x' })`, the HeyApi SDK shape, issue #912): a verb
+    # method on a client-shaped receiver whose first argument is an object
+    # literal with a string `url` property. Off where the idiom does not exist.
+    object_url_client_calls: bool = False
+    object_literal_type: str | None = None
+    pair_type: str | None = None
 
 
 _JS_TS_DESCRIPTOR = LanguageDescriptor(
@@ -134,6 +141,9 @@ _JS_TS_DESCRIPTOR = LanguageDescriptor(
     string_content_type=cs.TS_STRING_FRAGMENT,
     template_string_type=cs.TS_TEMPLATE_STRING,
     template_substitution_type=cs.TS_TEMPLATE_SUBSTITUTION,
+    object_url_client_calls=True,
+    object_literal_type=cs.TS_OBJECT,
+    pair_type=cs.TS_PAIR,
     keyword_arg_type=None,
     nested_scope_types=frozenset(
         {

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -1317,20 +1317,21 @@ class IOAccessProcessor:
 
     @staticmethod
     def _object_pair_string(obj: Node, descriptor: LanguageDescriptor) -> str | None:
-        # The string value of the object's `url` property, if any.
+        # The identity of the object's `url` property, if any: plain and
+        # template-literal urls render exactly like every other sink target
+        # (issue #884); a quoted key (`{ "url": ... }`) counts too.
         for pair in obj.named_children:
             if pair.type != descriptor.pair_type:
                 continue
             key = safe_decode_text(pair.child_by_field_name(cs.FIELD_KEY))
-            if key != HTTP_METHOD_OPTION_KEY_URL:
+            if key is None or key.strip("'\"") != HTTP_METHOD_OPTION_KEY_URL:
                 continue
-            value = pair.child_by_field_name(cs.FIELD_VALUE)
-            if value is None or value.type != descriptor.string_type:
-                return None
-            return "".join(
-                safe_decode_text(c) or ""
-                for c in value.named_children
-                if c.type == descriptor.string_content_type
+            return string_literal(
+                pair.child_by_field_name(cs.FIELD_VALUE),
+                descriptor.string_type,
+                descriptor.string_content_type,
+                template_type=descriptor.template_string_type,
+                substitution_type=descriptor.template_substitution_type,
             )
         return None
 

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -1299,20 +1299,31 @@ class IOAccessProcessor:
         self._emit(caller_spec, direction, ResourceKind.NETWORK, url)
         return True
 
-    @staticmethod
-    def _names_client(receiver: Node, descriptor: LanguageDescriptor) -> bool:
-        # The receiver mentions a `client` binding somewhere (`this.client`,
-        # `options?.client ?? this.client`, bare `client`); a plain `map.get`
-        # does not.
-        stack = [receiver]
-        while stack:
-            node = stack.pop()
-            stack.extend(node.named_children)
-            if (
-                node.type in (descriptor.identifier_type, cs.TS_PROPERTY_IDENTIFIER)
-                and safe_decode_text(node) == _CLIENT_RECEIVER_NAME
-            ):
-                return True
+    @classmethod
+    def _names_client(cls, receiver: Node, descriptor: LanguageDescriptor) -> bool:
+        # The verb's IMMEDIATE receiver must itself be client-shaped: a bare
+        # `client`, a member whose TAIL property is `client` (`this.client`,
+        # `options?.client`), or wrappers/alternatives thereof
+        # (`(options?.client ?? this.client)`, `client!`). An ancestor
+        # mention is not enough: `this.client.cache.get(...)` calls the
+        # cache, not the client.
+        if receiver.type == descriptor.identifier_type:
+            return safe_decode_text(receiver) == _CLIENT_RECEIVER_NAME
+        if receiver.type == descriptor.member_expression_type:
+            prop = receiver.child_by_field_name(descriptor.property_field)
+            return safe_decode_text(prop) == _CLIENT_RECEIVER_NAME
+        if receiver.type in (cs.TS_PARENTHESIZED_EXPRESSION, cs.TS_BINARY_EXPRESSION):
+            return any(
+                cls._names_client(child, descriptor)
+                for child in receiver.named_children
+            )
+        if receiver.type == cs.TS_JS_TERNARY_EXPRESSION:
+            return any(
+                cls._names_client(child, descriptor)
+                for child in receiver.named_children[1:]
+            )
+        if receiver.type == cs.TS_NON_NULL_EXPRESSION and receiver.named_children:
+            return cls._names_client(receiver.named_children[0], descriptor)
         return False
 
     @staticmethod

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -16,6 +16,7 @@ from ..utils import cpp_declarator_name, safe_decode_text
 from .constants import (
     DYNAMIC_TARGET,
     HTTP_METHOD_OPTION_KEY,
+    HTTP_METHOD_OPTION_KEY_URL,
     HTTP_READ_VERBS,
     HTTP_WRITE_VERBS,
     KEY_KIND,
@@ -103,6 +104,18 @@ class _LeanHandles(NamedTuple):
 # The connect-go constructor: `New<Stem>Client`, qualified by a generated
 # package whose name ends in `connect`.
 _RPC_CLIENT_RE = re.compile(r"^New([A-Z]\w*)Client$")
+
+# HTTP verb methods of options-object clients (`client.get({url})`, the
+# HeyApi generated-SDK shape, issue #912): verb name -> edge direction.
+_HTTP_VERB_DIRECTIONS: dict[str, IODirection] = {
+    "get": IODirection.READ,
+    "head": IODirection.READ,
+    "post": IODirection.WRITE,
+    "put": IODirection.WRITE,
+    "patch": IODirection.WRITE,
+    "delete": IODirection.WRITE,
+}
+_CLIENT_RECEIVER_NAME = "client"
 _RPC_CLIENT_TYPE_RE = re.compile(r"^([A-Z]\w*)Client$")
 _RPC_PACKAGE_SUFFIX = "connect"
 
@@ -1196,6 +1209,10 @@ class IOAccessProcessor:
         local_names: frozenset[str],
         lean_handles: _LeanHandles | None,
     ) -> None:
+        if descriptor.object_url_client_calls and self._emit_object_url_client_call(
+            node, caller_spec, descriptor
+        ):
+            return
         raw = call_name(node)
         if raw is None:
             return
@@ -1246,6 +1263,76 @@ class IOAccessProcessor:
         if sink.method_options_arg is not None:
             direction = self._method_options_direction(node, sink, descriptor)
         self._emit(caller_spec, direction, sink.kind, identity)
+
+    def _emit_object_url_client_call(
+        self,
+        node: Node,
+        caller_spec: tuple[str, str, str],
+        descriptor: LanguageDescriptor,
+    ) -> bool:
+        # `(options?.client ?? this.client).get({ url: '/x', ...options })`:
+        # an HTTP verb on a client-shaped receiver with a literal `url` in the
+        # options object is a NETWORK sink attributed to the calling method.
+        func = node.child_by_field_name(cs.TS_FIELD_FUNCTION)
+        if func is None or func.type != descriptor.member_expression_type:
+            return False
+        verb = safe_decode_text(func.child_by_field_name(descriptor.property_field))
+        direction = _HTTP_VERB_DIRECTIONS.get(verb or "")
+        receiver = func.child_by_field_name(descriptor.object_field)
+        if (
+            direction is None
+            or receiver is None
+            or not self._names_client(receiver, descriptor)
+        ):
+            return False
+        arguments = node.child_by_field_name(cs.FIELD_ARGUMENTS)
+        first = (
+            arguments.named_children[0]
+            if arguments is not None and arguments.named_children
+            else None
+        )
+        if first is None or first.type != descriptor.object_literal_type:
+            return False
+        url = self._object_pair_string(first, descriptor)
+        if url is None:
+            return False
+        self._emit(caller_spec, direction, ResourceKind.NETWORK, url)
+        return True
+
+    @staticmethod
+    def _names_client(receiver: Node, descriptor: LanguageDescriptor) -> bool:
+        # The receiver mentions a `client` binding somewhere (`this.client`,
+        # `options?.client ?? this.client`, bare `client`); a plain `map.get`
+        # does not.
+        stack = [receiver]
+        while stack:
+            node = stack.pop()
+            stack.extend(node.named_children)
+            if (
+                node.type in (descriptor.identifier_type, cs.TS_PROPERTY_IDENTIFIER)
+                and safe_decode_text(node) == _CLIENT_RECEIVER_NAME
+            ):
+                return True
+        return False
+
+    @staticmethod
+    def _object_pair_string(obj: Node, descriptor: LanguageDescriptor) -> str | None:
+        # The string value of the object's `url` property, if any.
+        for pair in obj.named_children:
+            if pair.type != descriptor.pair_type:
+                continue
+            key = safe_decode_text(pair.child_by_field_name(cs.FIELD_KEY))
+            if key != HTTP_METHOD_OPTION_KEY_URL:
+                continue
+            value = pair.child_by_field_name(cs.FIELD_VALUE)
+            if value is None or value.type != descriptor.string_type:
+                return None
+            return "".join(
+                safe_decode_text(c) or ""
+                for c in value.named_children
+                if c.type == descriptor.string_content_type
+            )
+        return None
 
     def _method_options_direction(
         self, call_node: Node, sink: IOSink, descriptor: LanguageDescriptor

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -1312,15 +1312,20 @@ class IOAccessProcessor:
         if receiver.type == descriptor.member_expression_type:
             prop = receiver.child_by_field_name(descriptor.property_field)
             return safe_decode_text(prop) == _CLIENT_RECEIVER_NAME
-        if receiver.type in (cs.TS_PARENTHESIZED_EXPRESSION, cs.TS_BINARY_EXPRESSION):
-            return any(
-                cls._names_client(child, descriptor)
-                for child in receiver.named_children
+        if receiver.type == cs.TS_PARENTHESIZED_EXPRESSION and receiver.named_children:
+            return cls._names_client(receiver.named_children[0], descriptor)
+        if receiver.type == cs.TS_BINARY_EXPRESSION:
+            # `a ?? b` / `a || b` yields ONE operand at runtime, so EVERY
+            # operand must be client-shaped; a mixed pair may select the
+            # non-client.
+            children = receiver.named_children
+            return bool(children) and all(
+                cls._names_client(child, descriptor) for child in children
             )
         if receiver.type == cs.TS_JS_TERNARY_EXPRESSION:
-            return any(
-                cls._names_client(child, descriptor)
-                for child in receiver.named_children[1:]
+            branches = receiver.named_children[1:]
+            return bool(branches) and all(
+                cls._names_client(child, descriptor) for child in branches
             )
         if receiver.type == cs.TS_NON_NULL_EXPRESSION and receiver.named_children:
             return cls._names_client(receiver.named_children[0], descriptor)

--- a/codebase_rag/tests/test_io_handle_edges.py
+++ b/codebase_rag/tests/test_io_handle_edges.py
@@ -1334,3 +1334,95 @@ class TestGoRpcTypedClientEvidence:
         )
         fields = processor._go_rpc_fields(caller_fn, "proj.svc.create", {})
         assert fields == {"userClient": "UserService"}, fields
+
+
+class TestTsGeneratedClientSinks:
+    """Issue #912 slice 3: HeyApi-style generated TS SDK methods call
+    `(options?.client ?? this.client).get({ url: '/x', ...options })`. The
+    verb plus an object argument carrying a literal `url` on a client-shaped
+    receiver is a NETWORK sink attributed to the generated method."""
+
+    def test_generated_get_emits_network_read(self, tmp_path: Path) -> None:
+        files = {
+            "sdk.ts": (
+                "export class AuthClient {\n"
+                "  client: any;\n"
+                "  getRequestingUser(options?: any) {\n"
+                "    return (options?.client ?? this.client).get({ "
+                "url: '/auth/users/requesting', ...options });\n"
+                "  }\n"
+                "}\n"
+            ),
+        }
+        rels = _run_io(tmp_path, files)
+        assert _has(
+            rels,
+            "sdk.AuthClient.getRequestingUser",
+            READS_FROM,
+            "resource::NETWORK::/auth/users/requesting",
+        ), rels
+
+    def test_generated_post_emits_network_write(self, tmp_path: Path) -> None:
+        files = {
+            "sdk.ts": (
+                "export class AuthClient {\n"
+                "  client: any;\n"
+                "  createUser(options?: any) {\n"
+                "    return (options?.client ?? this.client).post({ "
+                "url: '/auth/users', ...options });\n"
+                "  }\n"
+                "}\n"
+            ),
+        }
+        rels = _run_io(tmp_path, files)
+        assert _has(
+            rels,
+            "sdk.AuthClient.createUser",
+            WRITES_TO,
+            "resource::NETWORK::/auth/users",
+        ), rels
+
+    def test_plain_this_client_receiver_binds(self, tmp_path: Path) -> None:
+        files = {
+            "sdk.ts": (
+                "export class AuthClient {\n"
+                "  client: any;\n"
+                "  del(options?: any) {\n"
+                "    return this.client.delete({ url: '/auth/users/1' });\n"
+                "  }\n"
+                "}\n"
+            ),
+        }
+        rels = _run_io(tmp_path, files)
+        assert _has(
+            rels,
+            "sdk.AuthClient.del",
+            WRITES_TO,
+            "resource::NETWORK::/auth/users/1",
+        ), rels
+
+    def test_non_client_receiver_is_not_a_sink(self, tmp_path: Path) -> None:
+        # `map.get({url})` is a lookup, not an HTTP request.
+        files = {
+            "app.ts": (
+                "export function lookup(map: Map<any, any>) {\n"
+                "  return map.get({ url: '/not-a-request' });\n"
+                "}\n"
+            ),
+        }
+        rels = _run_io(tmp_path, files)
+        assert not any("resource::NETWORK::" in b for _a, _r, b in rels), rels
+
+    def test_object_without_url_is_not_a_sink(self, tmp_path: Path) -> None:
+        files = {
+            "sdk.ts": (
+                "export class AuthClient {\n"
+                "  client: any;\n"
+                "  misc(options?: any) {\n"
+                "    return this.client.get({ path: '/auth/users' });\n"
+                "  }\n"
+                "}\n"
+            ),
+        }
+        rels = _run_io(tmp_path, files)
+        assert not any("resource::NETWORK::" in b for _a, _r, b in rels), rels

--- a/codebase_rag/tests/test_io_handle_edges.py
+++ b/codebase_rag/tests/test_io_handle_edges.py
@@ -1426,3 +1426,50 @@ class TestTsGeneratedClientSinks:
         }
         rels = _run_io(tmp_path, files)
         assert not any("resource::NETWORK::" in b for _a, _r, b in rels), rels
+
+    def test_quoted_url_key_binds(self, tmp_path: Path) -> None:
+        # Object keys may be string literals: `{ "url": '/q' }`.
+        files = {
+            "sdk.ts": (
+                "export class AuthClient {\n"
+                "  client: any;\n"
+                "  q(options?: any) {\n"
+                "    return this.client.get({ \"url\": '/q' });\n"
+                "  }\n"
+                "}\n"
+            ),
+        }
+        rels = _run_io(tmp_path, files)
+        assert _has(rels, "sdk.AuthClient.q", READS_FROM, "resource::NETWORK::/q"), rels
+
+    def test_template_literal_url_binds(self, tmp_path: Path) -> None:
+        # A template-literal url keeps fragments and renders substitutions as
+        # placeholders, like every other sink identity (issue #884).
+        files = {
+            "sdk.ts": (
+                "export class AuthClient {\n"
+                "  client: any;\n"
+                "  t(id: string, options?: any) {\n"
+                "    return this.client.get({ url: `/users/${id}` });\n"
+                "  }\n"
+                "}\n"
+            ),
+        }
+        rels = _run_io(tmp_path, files)
+        assert _has(
+            rels, "sdk.AuthClient.t", READS_FROM, "resource::NETWORK::/users/{id}"
+        ), rels
+
+    def test_empty_url_does_not_emit_degenerate_resource(self, tmp_path: Path) -> None:
+        files = {
+            "sdk.ts": (
+                "export class AuthClient {\n"
+                "  client: any;\n"
+                "  e(options?: any) {\n"
+                "    return this.client.get({ url: '' });\n"
+                "  }\n"
+                "}\n"
+            ),
+        }
+        rels = _run_io(tmp_path, files)
+        assert not any(b == "resource::NETWORK::" for _a, _r, b in rels), rels

--- a/codebase_rag/tests/test_io_handle_edges.py
+++ b/codebase_rag/tests/test_io_handle_edges.py
@@ -1473,3 +1473,19 @@ class TestTsGeneratedClientSinks:
         }
         rels = _run_io(tmp_path, files)
         assert not any(b == "resource::NETWORK::" for _a, _r, b in rels), rels
+
+    def test_nested_member_below_client_is_not_a_sink(self, tmp_path: Path) -> None:
+        # `this.client.cache.get({url})` calls the CACHE, not the client: the
+        # verb's immediate receiver must itself be client-shaped.
+        files = {
+            "sdk.ts": (
+                "export class AuthClient {\n"
+                "  client: any;\n"
+                "  c(options?: any) {\n"
+                "    return this.client.cache.get({ url: '/entry' });\n"
+                "  }\n"
+                "}\n"
+            ),
+        }
+        rels = _run_io(tmp_path, files)
+        assert not any("resource::NETWORK::" in b for _a, _r, b in rels), rels

--- a/codebase_rag/tests/test_io_handle_edges.py
+++ b/codebase_rag/tests/test_io_handle_edges.py
@@ -1489,3 +1489,20 @@ class TestTsGeneratedClientSinks:
         }
         rels = _run_io(tmp_path, files)
         assert not any("resource::NETWORK::" in b for _a, _r, b in rels), rels
+
+    def test_mixed_alternative_receiver_is_not_a_sink(self, tmp_path: Path) -> None:
+        # A wrapper that may select a NON-client at runtime is not client
+        # evidence: every alternative must be client-shaped.
+        files = {
+            "sdk.ts": (
+                "export class AuthClient {\n"
+                "  client: any;\n"
+                "  cache: any;\n"
+                "  m(flag: boolean, options?: any) {\n"
+                "    return (flag ? this.client : this.cache).get({ url: '/entry' });\n"
+                "  }\n"
+                "}\n"
+            ),
+        }
+        rels = _run_io(tmp_path, files)
+        assert not any("resource::NETWORK::" in b for _a, _r, b in rels), rels

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.492"
+version = "0.0.493"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Issue #912 slice 3 (first part): generated TS/JS SDK methods in the HeyApi style call `(options?.client ?? this.client).get({ url: '/x', ...options })`, a shape the sink table (keyed on dotted callee text with positional URL args) cannot see, so every generated client method contributed zero network evidence. An HTTP verb method on a client-shaped receiver whose first argument is an object literal carrying a `url` property now emits a NETWORK sink attributed to the generated method, with direction from the verb (get/head read, post/put/patch/delete write).

## How it works

- Gated by a new `object_url_client_calls` descriptor flag, on only for the shared JS/TS/TSX descriptor; the check runs before named-sink resolution and cannot shadow a registered sink (it requires a member callee whose receiver subtree names `client`, a verb, and a `url`-bearing object literal, none of which overlap the dotted-name table).
- URL identities render through the shared `string_literal` helper, so plain strings, quoted keys, and template literals with substitution placeholders all behave exactly like every other sink identity, and a non-literal url degrades to the dynamic marker instead of a wrong value.
- Emission funnels through the existing `_emit`, preserving capture-selection gating; relative rootful identities match what endpoint linking already consumes.

## Validation

Eight pipeline tests, all RED first, covering the generated shape, plain `this.client` receivers, quoted keys, template-literal urls, non-client receivers, url-less objects, and the empty-url degenerate. On a large private polyglot monorepo this recovers 439 sink edges over 393 distinct URLs from vendored generated SDK modules that previously contributed nothing. Full suite: 6096 passed, 10 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved detection of HTTP verb calls in JavaScript/TypeScript “client-shaped” patterns.
  - Network read/write relationships now include the request URL extracted from client options objects.

- **Bug Fixes**
  - Prevents network records when the receiver pattern doesn’t match, when the options object lacks a `url`, or when the extracted URL is empty.
  - Rejects sink attribution for nested or mixed conditional receivers that may not be a client at runtime.

- **Tests**
  - Added TypeScript SDK sink-attribution coverage with positive and negative cases, including quoted keys and template-literal URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->