### PR TITLE
fix: keep dispatch resolutions alive through the endpoint relink sweep

### DIFF
--- a/codebase_rag/parsers/endpoints.py
+++ b/codebase_rag/parsers/endpoints.py
@@ -42,7 +42,11 @@ CYPHER_LIVE_ENDPOINT_RESOURCES = (
     "RETURN DISTINCT r.qualified_name AS qualified_name, "
     "r.name AS name, r.kind AS kind, r.project AS project"
 )
-CYPHER_DELETE_RESOLVES_TO = "MATCH ()-[r:RESOLVES_TO]->() DELETE r"
+# Scoped to URL resolutions: RESOLVES_TO has other owners (a DISPATCH
+# deployment-suffix link, issue #913) whose edges must survive the relink.
+CYPHER_DELETE_RESOLVES_TO = (
+    "MATCH (:Resource {kind: 'NETWORK'})-[r:RESOLVES_TO]->() DELETE r"
+)
 
 KEY_PROJECT = "project"
 _PROJECT_HASH_SEPARATOR = "__"

--- a/codebase_rag/tests/integration/test_route_exposes_cleanup.py
+++ b/codebase_rag/tests/integration/test_route_exposes_cleanup.py
@@ -88,3 +88,37 @@ class TestModuleExposesCleanupOwnership:
         )
 
         assert _exposing_qns(memgraph_ingestor) == []
+
+
+class TestResolvesToCleanupOwnership:
+    def test_dispatch_resolution_survives_endpoint_relink(
+        self, memgraph_ingestor: MemgraphIngestor
+    ) -> None:
+        # The endpoint relink sweeps its own stale URL resolutions before
+        # recomputing; RESOLVES_TO edges owned by OTHER kinds (a DISPATCH
+        # deployment-suffix link, issue #913) must survive the sweep.
+        from codebase_rag.parsers.endpoints import CYPHER_DELETE_RESOLVES_TO
+
+        memgraph_ingestor.execute_write(
+            "CREATE (u:Resource {qualified_name: 'resource::NETWORK::/x', "
+            "kind: 'NETWORK', name: '/x'}), "
+            "(ep:Resource {qualified_name: 'resource::ENDPOINT::p::GET /x', "
+            "kind: 'ENDPOINT', name: 'GET /x'}), "
+            "(u)-[:RESOLVES_TO]->(ep), "
+            "(d:Resource {qualified_name: 'resource::DISPATCH::k/dev', "
+            "kind: 'DISPATCH', name: 'k/dev'}), "
+            "(h:Resource {qualified_name: 'resource::DISPATCH::k', "
+            "kind: 'DISPATCH', name: 'k'}), "
+            "(d)-[:RESOLVES_TO]->(h)"
+        )
+        memgraph_ingestor.execute_write(CYPHER_DELETE_RESOLVES_TO)
+        survivors = memgraph_ingestor.fetch_all(
+            "MATCH (a)-[:RESOLVES_TO]->(b) "
+            "RETURN a.qualified_name AS a, b.qualified_name AS b"
+        )
+        pairs = {(str(r["a"]), str(r["b"])) for r in survivors}
+        assert ("resource::DISPATCH::k/dev", "resource::DISPATCH::k") in pairs, pairs
+        assert (
+            "resource::NETWORK::/x",
+            "resource::ENDPOINT::p::GET /x",
+        ) not in pairs, pairs

--- a/codebase_rag/tests/integration/test_route_exposes_cleanup.py
+++ b/codebase_rag/tests/integration/test_route_exposes_cleanup.py
@@ -94,24 +94,30 @@ class TestResolvesToCleanupOwnership:
     def test_dispatch_resolution_survives_endpoint_relink(
         self, memgraph_ingestor: MemgraphIngestor
     ) -> None:
-        # The endpoint relink sweeps its own stale URL resolutions before
-        # recomputing; RESOLVES_TO edges owned by OTHER kinds (a DISPATCH
-        # deployment-suffix link, issue #913) must survive the sweep.
-        from codebase_rag.parsers.endpoints import CYPHER_DELETE_RESOLVES_TO
+        # The PRODUCTION relink (link_endpoints) sweeps its own stale URL
+        # resolutions before recomputing; RESOLVES_TO edges owned by OTHER
+        # kinds (a DISPATCH deployment-suffix link, issue #913) must survive
+        # the sweep, while the URL edge is recomputed from live sinks.
+        from codebase_rag.parsers.endpoints import link_endpoints
 
         memgraph_ingestor.execute_write(
-            "CREATE (u:Resource {qualified_name: 'resource::NETWORK::/x', "
-            "kind: 'NETWORK', name: '/x'}), "
-            "(ep:Resource {qualified_name: 'resource::ENDPOINT::p::GET /x', "
-            "kind: 'ENDPOINT', name: 'GET /x'}), "
-            "(u)-[:RESOLVES_TO]->(ep), "
+            "CREATE (f:Function {qualified_name: 'project.app.fetch'}), "
+            "(u:Resource {qualified_name: 'resource::NETWORK::/items/detail', "
+            "kind: 'NETWORK', name: '/items/detail'}), "
+            "(f)-[:READS_FROM]->(u), "
+            "(h:Function {qualified_name: 'project.api.get_detail'}), "
+            "(ep:Resource "
+            "{qualified_name: 'resource::ENDPOINT::project::GET /items/detail', "
+            "kind: 'ENDPOINT', name: 'GET /items/detail'}), "
+            "(h)-[:EXPOSES]->(ep), "
             "(d:Resource {qualified_name: 'resource::DISPATCH::k/dev', "
             "kind: 'DISPATCH', name: 'k/dev'}), "
-            "(h:Resource {qualified_name: 'resource::DISPATCH::k', "
+            "(dh:Resource {qualified_name: 'resource::DISPATCH::k', "
             "kind: 'DISPATCH', name: 'k'}), "
-            "(d)-[:RESOLVES_TO]->(h)"
+            "(d)-[:RESOLVES_TO]->(dh)"
         )
-        memgraph_ingestor.execute_write(CYPHER_DELETE_RESOLVES_TO)
+        link_endpoints(memgraph_ingestor)
+        memgraph_ingestor.flush_all()
         survivors = memgraph_ingestor.fetch_all(
             "MATCH (a)-[:RESOLVES_TO]->(b) "
             "RETURN a.qualified_name AS a, b.qualified_name AS b"
@@ -119,6 +125,6 @@ class TestResolvesToCleanupOwnership:
         pairs = {(str(r["a"]), str(r["b"])) for r in survivors}
         assert ("resource::DISPATCH::k/dev", "resource::DISPATCH::k") in pairs, pairs
         assert (
-            "resource::NETWORK::/x",
-            "resource::ENDPOINT::p::GET /x",
-        ) not in pairs, pairs
+            "resource::NETWORK::/items/detail",
+            "resource::ENDPOINT::project::GET /items/detail",
+        ) in pairs, pairs

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.494"
+version = "0.0.495"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Follow-up to #946, found by probing the live graph after its merge: the dispatch deployment-suffix `RESOLVES_TO` edge was created during finalization and then silently deleted moments later, because the endpoint linker's stale-URL sweep ran `MATCH ()-[r:RESOLVES_TO]->() DELETE r` over the whole graph. That query predates `RESOLVES_TO` having a second owner.

## Fix

The sweep is scoped to the resolutions the endpoint linker owns: `MATCH (:Resource {kind: 'NETWORK'})-[r:RESOLVES_TO]->() DELETE r`. URL relinking still clears and recomputes its own edges; resolutions owned by other kinds (the DISPATCH deployment-suffix link) survive.

## Testing

RED first: an integration test creating both a NETWORK-to-ENDPOINT and a DISPATCH-to-DISPATCH resolution, running the sweep, and asserting the dispatch link survives while the URL link is cleared. Failed against the unscoped query, passes with the scoped one. Full suite: 6115 passed, 10 skipped. Verified end to end against a live graph: after a full re-index the producer, suffix resolution, and registered handler chain persists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Refined endpoint relinking cleanup to delete only `RESOLVES_TO` relationships originating from `NETWORK` resources, avoiding broader removal of unrelated edges.
  - Ensures `RESOLVES_TO` relationships owned by other resource types remain intact during relinking.

- **Tests**
  - Added an integration test covering the endpoint relink cleanup workflow and verifying correct ownership scoping for `RESOLVES_TO` relationships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->