### PR TITLE
ci: build the Docker image on published releases

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,6 +1,8 @@
 name: Docker Publish
 
 on:
+  release:
+    types: [published]
   push:
     tags:
       - 'v*'

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.495"
+version = "0.0.496"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

`docker-publish.yml` triggered only on `push: tags`, so manually created GitHub Releases never built an image. The tag already exists by then (the version-bump workflow pushed it with `GITHUB_TOKEN`, which GitHub suppresses), so no tag-push event fires and the release event was not listened for. PyPI does not have this gap because `publish.yml` already carries `release: published` alongside the tag trigger; this restores parity.

Context: the GHCR image is currently five months stale at `0.0.100`. Two causes stacked up. Auto-bumped tags stopped firing the workflow once bumps moved to `GITHUB_TOKEN`, and the one build that did fire (`v0.0.484`) failed on `Git executable not found` because that tag predates the builder-stage `git` fix in #935 by about half an hour. Current main builds fine; `v0.0.496` has been published by manual dispatch to close the gap.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] CI/infrastructure

## Related Issues

Follows the release-automation work in #936 and the builder fix in #935.

## Test Plan

YAML parsed and the trigger set verified as `release`, `push`, `workflow_dispatch` with `types: [published]`. The build path itself is unchanged and was verified end to end by dispatching the current workflow against `v0.0.496`, which built and pushed `linux/amd64` and `linux/arm64` images to GHCR.

On duplicate builds: a cadence release pushes its tag with the deploy key and then creates the release with `GITHUB_TOKEN`, and GitHub suppresses events from the latter, so only one build runs. A maintainer who both pushes a tag by hand and publishes a release for it would get two runs; that is harmless, since pushing identical tags to GHCR is idempotent.

## Checklist

- [x] Workflow YAML validated
- [x] Trigger-only change, no shell interpolation introduced
- [x] pre-commit green
- [x] Publish path verified by real dispatch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Docker image publishing now runs automatically when a GitHub Release is published.
  * Existing tag-based and manual publishing triggers remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->