### PR TITLE
fix: register generated Go routes whose mount prefix cannot be resolved

### DIFF
--- a/codebase_rag/parsers/endpoint_routes.py
+++ b/codebase_rag/parsers/endpoint_routes.py
@@ -41,6 +41,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from .. import constants as cs
+from .endpoint_prefixes import UNKNOWN_LEAD
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -457,7 +458,14 @@ def _go_server_evidence(
     args: list[Node],
     evidence: _ModuleEvidence,
     concat_path: bool,
+    unknown_lead: bool = False,
 ) -> bool:
+    if unknown_lead:
+        # Nothing resolved the lead, so the generated wiring shape below is
+        # the ONLY evidence that this is a route rather than a client
+        # request: a callback argument alone would make an assertion helper
+        # passed to `client.Get(base+"/x", check)` look like a server.
+        return _go_wrapper_selector_evidence(fn, field, args, evidence, concat_path)
     if _receiver_is_framework(fn, evidence):
         return True
     if (
@@ -473,7 +481,21 @@ def _go_server_evidence(
     # (`wrapper := ServerInterfaceWrapper{...}`) in the SAME function (or at
     # file scope). A client passing `opts.Header` after a concat path has no
     # in-scope binding and stays out.
-    if (
+    if _go_wrapper_selector_evidence(fn, field, args, evidence, concat_path):
+        return True
+    return _handler_evidence(
+        args[1:], evidence, frozenset({cs.TS_GO_FUNC_LITERAL}), cs.TS_GO_IDENTIFIER
+    )
+
+
+def _go_wrapper_selector_evidence(
+    fn: Node,
+    field: str,
+    args: list[Node],
+    evidence: _ModuleEvidence,
+    concat_path: bool,
+) -> bool:
+    return (
         concat_path
         and field in _GO_VERB_METHODS
         and any(
@@ -486,10 +508,6 @@ def _go_server_evidence(
             )
             for arg in args[1:]
         )
-    ):
-        return True
-    return _handler_evidence(
-        args[1:], evidence, frozenset({cs.TS_GO_FUNC_LITERAL}), cs.TS_GO_IDENTIFIER
     )
 
 
@@ -517,13 +535,23 @@ def _go_path_value(
         )
         if left is not None and right is not None:
             return left + right
-        # The generated mount prefix is often a STRUCT FIELD
-        # (`options.BaseURL+"/v2/things"`), which no module-const lookup can
-        # resolve. The rooted literal suffix is still the route; an unknown
-        # mount prefix is what prefix-tolerant linking already handles, so
-        # keeping the suffix beats dropping the registration entirely.
-        if left is None and right is not None and right.startswith("/"):
-            return right
+        # The generated mount prefix is a STRUCT FIELD
+        # (`options.BaseURL+"/v2/things"`), which no const lookup can resolve.
+        # The suffix is a real route under an unknown lead, and `/**` is what
+        # the template vocabulary already spells for that, so the
+        # registration keeps its full meaning instead of claiming a lead it
+        # does not have. Restricted to a field access: any other unresolvable
+        # left operand may be knowable (a function-local literal) or
+        # truncated (the depth valve), and a wrong template is worse than none.
+        left_node = node.child_by_field_name(cs.TS_FIELD_LEFT)
+        if (
+            left is None
+            and right is not None
+            and right.startswith(cs.SEPARATOR_SLASH)
+            and left_node is not None
+            and left_node.type == cs.TS_GO_SELECTOR_EXPRESSION
+        ):
+            return f"{UNKNOWN_LEAD}{right}"
     return None
 
 
@@ -542,7 +570,8 @@ def _go_registration(
     # Only a CONCATENATION is the generated registration shape; a bare
     # const identifier can just as well hold a client's URL.
     concat_path = path_node is not None and path_node.type == cs.TS_BINARY_EXPRESSION
-    if not _go_server_evidence(fn, field, args, evidence, concat_path):
+    unknown_lead = path.startswith(UNKNOWN_LEAD)
+    if not _go_server_evidence(fn, field, args, evidence, concat_path, unknown_lead):
         return None
     handler = _handler_identifier(
         args[1] if len(args) > 1 else None, cs.TS_PY_IDENTIFIER

--- a/codebase_rag/parsers/endpoint_routes.py
+++ b/codebase_rag/parsers/endpoint_routes.py
@@ -517,6 +517,13 @@ def _go_path_value(
         )
         if left is not None and right is not None:
             return left + right
+        # The generated mount prefix is often a STRUCT FIELD
+        # (`options.BaseURL+"/v2/things"`), which no module-const lookup can
+        # resolve. The rooted literal suffix is still the route; an unknown
+        # mount prefix is what prefix-tolerant linking already handles, so
+        # keeping the suffix beats dropping the registration entirely.
+        if left is None and right is not None and right.startswith("/"):
+            return right
     return None
 
 

--- a/codebase_rag/tests/test_route_call_endpoints.py
+++ b/codebase_rag/tests/test_route_call_endpoints.py
@@ -418,33 +418,87 @@ class TestGoGeneratedRoutes:
         "}\n"
     )
 
-    def test_unresolvable_prefix_keeps_the_literal_suffix(self, tmp_path: Path) -> None:
-        # The codegen mount prefix is a STRUCT FIELD, not a module const, so
-        # nothing can resolve it; the literal suffix is still the route, and
-        # prefix-tolerant linking already handles an unknown mount (#911).
-        edges = _run(tmp_path, {"gen.go": self._FIBER_SOURCE}, "go")
-        assert _endpoint(edges, "gen.RegisterHandlersWithOptions", "POST /v2/things"), (
-            edges
-        )
-        assert _endpoint(
-            edges, "gen.RegisterHandlersWithOptions", "GET /v2/things/:id"
-        ), edges
-
-    def test_unresolvable_prefix_without_handler_is_ignored(
+    def test_unresolvable_prefix_keeps_the_suffix_under_an_unknown_lead(
         self, tmp_path: Path
     ) -> None:
-        # The same shape on the CLIENT side registers nothing: no handler
-        # argument, no wrapper binding, so no server evidence.
+        # The codegen mount prefix is a STRUCT FIELD, so nothing can resolve
+        # it. The suffix is a real route under an unknown lead, which is what
+        # `/**` means to the template matcher; asserting the bare suffix would
+        # claim a lead this registration does not have.
+        edges = _run(tmp_path, {"gen.go": self._FIBER_SOURCE}, "go")
+        assert _endpoint(
+            edges, "gen.RegisterHandlersWithOptions", "POST /**/v2/things"
+        ), edges
+        assert _endpoint(
+            edges, "gen.RegisterHandlersWithOptions", "GET /**/v2/things/:id"
+        ), edges
+
+    def test_unresolvable_prefix_with_a_callback_argument_is_ignored(
+        self, tmp_path: Path
+    ) -> None:
+        # A client request built the same way hands a DECLARED FUNCTION to the
+        # call as its response callback. With no resolved lead the generated
+        # wiring shape is the only thing that tells the two apart, so an
+        # assertion helper must not become the server for that route.
         files = {
-            "client.go": (
+            "clienthelper.go": (
                 "package main\n\n"
                 "type Options struct {\n\tBaseURL string\n}\n\n"
-                "func fetchThing(c HTTPClient, options Options) {\n"
-                '\tc.Get(options.BaseURL + "/v2/things")\n'
+                "func assertBody(resp *Response) {}\n\n"
+                "func checkThings(c HTTPClient, options Options) {\n"
+                '\tc.Get(options.BaseURL+"/v2/things", assertBody)\n'
                 "}\n"
             ),
         }
         assert not _run(tmp_path, files, "go")
+
+    def test_unresolvable_prefix_with_an_inline_callback_is_ignored(
+        self, tmp_path: Path
+    ) -> None:
+        files = {
+            "client2.go": (
+                "package main\n\n"
+                "type Options struct {\n\tBaseURL string\n}\n\n"
+                "func checkThings(c HTTPClient, options Options) {\n"
+                '\tc.Get(options.BaseURL+"/v2/things", func(b []byte) {})\n'
+                "}\n"
+            ),
+        }
+        assert not _run(tmp_path, files, "go")
+
+    def test_resolvable_local_prefix_is_never_truncated(self, tmp_path: Path) -> None:
+        # A function-scoped literal prefix is knowable, just not by the
+        # module-const map. Dropping it and keeping `/things` would assert a
+        # route that does not exist.
+        files = {
+            "routes.go": (
+                "package main\n\n"
+                "func getThings(c Ctx) error { return nil }\n\n"
+                "func mount(r Router) {\n"
+                '\tbase := "/api/v1"\n'
+                '\tr.Get(base+"/things", getThings)\n'
+                "}\n"
+            ),
+        }
+        edges = _run(tmp_path, files, "go")
+        assert not _endpoint(edges, "routes.getThings", "GET /things"), edges
+
+    def test_unknown_lead_needs_a_rooted_suffix(self, tmp_path: Path) -> None:
+        # `Handle`/`HandleFunc` read a `VERB /path` pattern, so an unrooted
+        # suffix would otherwise slip through as a pattern string.
+        files = {
+            "mux.go": (
+                "package main\n\n"
+                'import "net/http"\n\n'
+                "type Opts struct {\n\tPrefix string\n}\n\n"
+                "func h(w http.ResponseWriter, r *http.Request) {}\n\n"
+                "func mount(mux *http.ServeMux, o Opts) {\n"
+                '\tmux.Handle(o.Prefix+"GET /things", h)\n'
+                "}\n"
+            ),
+        }
+        edges = _run(tmp_path, files, "go")
+        assert not any("things" in identity for _l, _q, identity in edges), edges
 
     def test_unresolvable_prefix_with_relative_suffix_is_ignored(
         self, tmp_path: Path

--- a/codebase_rag/tests/test_route_call_endpoints.py
+++ b/codebase_rag/tests/test_route_call_endpoints.py
@@ -401,6 +401,69 @@ class TestGoGeneratedRoutes:
         edges = _run(tmp_path, files, "go")
         assert _endpoint(edges, "routes.mount", "GET /internal/health"), edges
 
+    _FIBER_SOURCE = (
+        "package main\n\n"
+        'import "github.com/gofiber/fiber/v2"\n\n'
+        "type FiberServerOptions struct {\n\tBaseURL string\n}\n\n"
+        "type ServerInterfaceWrapper struct {\n\tHandler ServerInterface\n}\n\n"
+        "func (siw *ServerInterfaceWrapper) CreateThing(c *fiber.Ctx) error "
+        "{ return nil }\n\n"
+        "func (siw *ServerInterfaceWrapper) GetThing(c *fiber.Ctx) error "
+        "{ return nil }\n\n"
+        "func RegisterHandlersWithOptions(router fiber.Router, si ServerInterface, "
+        "options FiberServerOptions) {\n"
+        "\twrapper := ServerInterfaceWrapper{Handler: si}\n"
+        '\trouter.Post(options.BaseURL+"/v2/things", wrapper.CreateThing)\n'
+        '\trouter.Get(options.BaseURL+"/v2/things/:id", wrapper.GetThing)\n'
+        "}\n"
+    )
+
+    def test_unresolvable_prefix_keeps_the_literal_suffix(self, tmp_path: Path) -> None:
+        # The codegen mount prefix is a STRUCT FIELD, not a module const, so
+        # nothing can resolve it; the literal suffix is still the route, and
+        # prefix-tolerant linking already handles an unknown mount (#911).
+        edges = _run(tmp_path, {"gen.go": self._FIBER_SOURCE}, "go")
+        assert _endpoint(edges, "gen.RegisterHandlersWithOptions", "POST /v2/things"), (
+            edges
+        )
+        assert _endpoint(
+            edges, "gen.RegisterHandlersWithOptions", "GET /v2/things/:id"
+        ), edges
+
+    def test_unresolvable_prefix_without_handler_is_ignored(
+        self, tmp_path: Path
+    ) -> None:
+        # The same shape on the CLIENT side registers nothing: no handler
+        # argument, no wrapper binding, so no server evidence.
+        files = {
+            "client.go": (
+                "package main\n\n"
+                "type Options struct {\n\tBaseURL string\n}\n\n"
+                "func fetchThing(c HTTPClient, options Options) {\n"
+                '\tc.Get(options.BaseURL + "/v2/things")\n'
+                "}\n"
+            ),
+        }
+        assert not _run(tmp_path, files, "go")
+
+    def test_unresolvable_prefix_with_relative_suffix_is_ignored(
+        self, tmp_path: Path
+    ) -> None:
+        # A suffix that is not rooted is not a route path on its own.
+        files = {
+            "gen2.go": (
+                "package main\n\n"
+                "type Opts struct {\n\tBaseURL string\n}\n\n"
+                "type wrap struct{}\n\n"
+                "func (w wrap) Thing(c Ctx) error { return nil }\n\n"
+                "func mount(router Router, options Opts) {\n"
+                "\twrapper := wrap{}\n"
+                '\trouter.Get(options.BaseURL+"things", wrapper.Thing)\n'
+                "}\n"
+            ),
+        }
+        assert not _run(tmp_path, files, "go")
+
     def test_client_const_concat_without_handler_is_ignored(
         self, tmp_path: Path
     ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.496"
+version = "0.0.498"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- The standard OpenAPI Go codegen registers every route through a mount prefix held in a struct field (`router.Post(options.BaseURL+"/v2/things", wrapper.CreateThing)`). Nothing could resolve that field, so the whole concatenation read as unresolvable and each registration was dropped: an entire generated server surface was missing from the graph while its clients had their URL sinks.
- A concatenation whose prefix is a field access now keeps its rooted suffix under the unknown-lead marker the template vocabulary already has (`/**`, from `endpoint_prefixes`), so the endpoint states exactly what is known and links across a mount prefix of any length instead of asserting a lead it does not have.
- Restricted deliberately to a field access. Any other unresolvable prefix may be knowable (a function-scoped literal) or truncated (the recursion depth valve), and a wrong template is worse than none.
- With no resolved lead, the generated wiring shape becomes the only admissible server evidence, so a client request handing a declared function or an inline closure to `client.Get(base+"/x", check)` still registers nothing.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD or tooling
- [ ] Dependencies

## Related Issues

Closes #950.

## Test Plan

- [x] Unit tests pass (`uv run pytest codebase_rag/tests -n auto`: 6133 passed, 10 skipped)
- [x] New tests added
- [x] Integration tests pass (run as part of the suite above)
- [x] Manual testing (describe below)

Five tests, four of them RED before the fix and each pinning a distinct rule: the codegen shape registers both routes under `/**`; a declared-function callback and an inline callback on the same path shape both register nothing; a function-scoped literal prefix is never truncated into a shorter route; and an unrooted suffix stays out of the `VERB /path` pattern reader.

Manual validation: the shape was first reproduced from a private monorepo whose generated Go handlers hold 50 such registrations, none of which reached the graph.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] All pre-commit checks pass (`uv run pre-commit run --all-files`, plus `uv run ruff check`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [ ] No new comments or docstrings (code should be self-documenting)

The last item is not met: this module documents every evidence rule it applies in comments, and the constraint here (why only a field access qualifies, and why the marker rather than a bare path) cannot be read off the code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved endpoint detection for Go Fiber route registrations with prefixes that cannot be resolved.
  - Preserved complete route templates instead of incorrectly dropping or truncating their prefixes.
  - Prevented callback-like code and relative paths from being incorrectly identified as endpoints.
  - Improved matching for `Handle` and `HandleFunc` routes, including validation of rooted URL suffixes.

- **Tests**
  - Added coverage for generated Go Fiber routes, unresolved prefixes, callback patterns, and route matching edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->