### PR TITLE
feat: anchor generated artefacts to the operations their contracts declare

### DIFF
--- a/codebase_rag/constants/languages.py
+++ b/codebase_rag/constants/languages.py
@@ -165,6 +165,11 @@ CONTRACT_OPERATION_METHODS: frozenset[str] = frozenset(
     {"get", "post", "put", "patch", "delete", "head", "options", "trace"}
 )
 CONTRACT_OPERATION_ID_KEY = "operationId"
+# The mount a spec states its paths are relative to: `basePath` in Swagger 2,
+# the path component of each server URL in OpenAPI 3.
+CONTRACT_BASE_PATH_KEY = "basePath"
+CONTRACT_SERVERS_KEY = "servers"
+CONTRACT_SERVER_URL_KEY = "url"
 # A spec is a document, not a data dump; anything larger is not one, and the
 # cap keeps the walk from parsing a huge generated file.
 CONTRACT_MAX_FILE_BYTES = 8 * 1024 * 1024

--- a/codebase_rag/constants/languages.py
+++ b/codebase_rag/constants/languages.py
@@ -150,6 +150,25 @@ TSCONFIG_FILENAMES: tuple[str, ...] = (
 TS_ALIAS_SKIP_DIRS: frozenset[str] = frozenset(
     {"node_modules", "dist", "build", "out", ".git"}
 )
+# Contract files that declare service operations (issue #912): OpenAPI specs
+# in JSON or YAML, and protobuf service definitions. The markers gate parsing
+# so the JSON and YAML a repo is otherwise full of is never read as a spec.
+CONTRACT_JSON_EXTENSION = ".json"
+CONTRACT_SPEC_EXTENSIONS: frozenset[str] = frozenset({".json", ".yaml", ".yml"})
+CONTRACT_PROTO_EXTENSION = ".proto"
+CONTRACT_SPEC_VERSION_KEYS: tuple[str, ...] = ("openapi", "swagger")
+CONTRACT_SPEC_MARKERS: tuple[str, ...] = ("openapi", "swagger")
+CONTRACT_PATHS_KEY = "paths"
+# The keys under an OpenAPI path item that name an operation; every other key
+# there (parameters, servers, summary) describes the path, not an operation.
+CONTRACT_OPERATION_METHODS: frozenset[str] = frozenset(
+    {"get", "post", "put", "patch", "delete", "head", "options", "trace"}
+)
+CONTRACT_OPERATION_ID_KEY = "operationId"
+# A spec is a document, not a data dump; anything larger is not one, and the
+# cap keeps the walk from parsing a huge generated file.
+CONTRACT_MAX_FILE_BYTES = 8 * 1024 * 1024
+
 JS_INDEX_STEM = "index"
 TS_COMPILER_OPTIONS_KEY = "compilerOptions"
 TS_PATHS_KEY = "paths"

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -27,6 +27,7 @@ from .language_spec import (
 from .parser_fingerprint import compute_parser_fingerprint
 from .parser_loader import COMBINED_FUNC_CLASS_IMPORT_QUERIES
 from .parsers.ast_grep_tier import AstGrepTier
+from .parsers.contract_linking import link_contracts
 from .parsers.cpp.preproc_recovery import parse_with_preproc_recovery
 from .parsers.cpp_frontend import (
     cpp_frontend_available,
@@ -1034,6 +1035,12 @@ class GraphUpdater:
         created = link_endpoints(self.ingestor)
         if created:
             logger.info("Resolved {} client request URLs to endpoints", created)
+            self.ingestor.flush_all()
+        # Contract files name the operations the generated artefacts on both
+        # sides implement, so they anchor after the artefacts exist.
+        anchored = link_contracts(self.ingestor, self.repo_path)
+        if anchored:
+            logger.info("Anchored {} artefacts to contract operations", anchored)
             self.ingestor.flush_all()
 
     def _rehydrate_registry_from_graph(self) -> None:

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1038,7 +1038,13 @@ class GraphUpdater:
             self.ingestor.flush_all()
         # Contract files name the operations the generated artefacts on both
         # sides implement, so they anchor after the artefacts exist.
-        anchored = link_contracts(self.ingestor, self.repo_path)
+        anchored = link_contracts(
+            self.ingestor,
+            self.repo_path,
+            self.project_name,
+            self.exclude_paths,
+            self.unignore_paths,
+        )
         if anchored:
             logger.info("Anchored {} artefacts to contract operations", anchored)
             self.ingestor.flush_all()

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -548,6 +548,10 @@ IMP_RUST = "Rust import: {name} -> {path}"
 IMP_CSHARP = "C# using: {name} -> {path}"
 IMP_GO = "Go import: {package} -> {path}"
 IMP_GO_MODULE_PATH = "Go module path: {module} -> {path}"
+CONTRACT_OPERATIONS = "Contract operations: {count} declared, {created} artefact links"
+CONTRACT_YAML_UNAVAILABLE = (
+    "PyYAML is not installed; skipping YAML contract spec {path}"
+)
 IMP_CPP_INCLUDE = "C++ include: {local} -> {full} (system: {system})"
 IMP_CPP_MODULE = "C++20 module import: {local} -> {full}"
 IMP_CPP_MODULE_IMPL = "C++20 module implementation: {name}"

--- a/codebase_rag/parsers/contract_linking.py
+++ b/codebase_rag/parsers/contract_linking.py
@@ -24,9 +24,14 @@ from .contracts import ContractOperation, discover_contract_operations
 from .endpoints import _has_literal_segment, url_matches_template
 from .io_access.constants import KEY_KIND, RESOURCE_QN_FORMAT, ResourceKind
 
+# RPC resources are deliberately unscoped, so a client in one project meets a
+# server in another on one node. A contract, though, is declared by THIS
+# repo, so only an operation this project's own code participates in is its
+# implementation; a same-named service elsewhere is a different contract.
 CYPHER_LIVE_RPC_RESOURCES = (
-    "MATCH (r:Resource {kind: 'RPC'}) "
-    "RETURN r.qualified_name AS qualified_name, r.name AS name"
+    "MATCH (f)-[:EXPOSES|READS_FROM|WRITES_TO]->(r:Resource {kind: 'RPC'}) "
+    "WHERE f.qualified_name STARTS WITH $project_prefix "
+    "RETURN DISTINCT r.qualified_name AS qualified_name, r.name AS name"
 )
 CYPHER_LIVE_ENDPOINT_RESOURCES = (
     "MATCH ()-[:EXPOSES]->(r:Resource {kind: 'ENDPOINT'}) "
@@ -50,9 +55,12 @@ CYPHER_DELETE_CONTRACT_RESOLVES_TO = (
 # A renamed operation leaves a node whose declaring file still anchors it,
 # so the file's own declarations are cleared before it re-declares them and
 # whatever it no longer declares is pruned as unanchored.
+# Every contract file in the repo, not only the ones that still declare
+# something: a spec edited to declare nothing would otherwise keep anchoring
+# the operations it no longer has.
 CYPHER_DELETE_FILE_CONTRACTS = (
     "MATCH (f:File)-[e:EXPOSES]->(:Resource {kind: 'CONTRACT'}) "
-    "WHERE f.absolute_path IN $paths DELETE e"
+    "WHERE f.absolute_path STARTS WITH $repo_prefix DELETE e"
 )
 
 _IDENTITY_SEPARATOR = "."
@@ -70,30 +78,35 @@ def link_contracts(
 
     Returns the number of RESOLVES_TO edges emitted.
     """
-    operations = discover_contract_operations(repo_path, exclude_paths, unignore_paths)
-    if not operations or not isinstance(ingestor, QueryProtocol):
+    if not isinstance(ingestor, QueryProtocol):
         return 0
     # A filtering sink that would drop the EXPOSES edge must not receive the
     # Resource node either, or selective capture leaves an orphaned contract.
     rel_gate = getattr(ingestor, "rel_enabled", None)
     if callable(rel_gate) and not rel_gate(cs.RelationshipType.EXPOSES):
         return 0
-    operations = _indexed_only(ingestor, operations)
+    # Cleared before anything is discovered, so a file that stopped
+    # declaring operations sheds them: its contract nodes lose their anchor
+    # and the unanchored-resource prune takes them and their edges.
+    ingestor.execute_write(
+        CYPHER_DELETE_FILE_CONTRACTS,
+        {"repo_prefix": cached_resolve_posix(repo_path)},
+    )
+    operations = _indexed_only(
+        ingestor,
+        discover_contract_operations(repo_path, exclude_paths, unignore_paths),
+    )
     if not operations:
         return 0
     ingestor.execute_write(
         CYPHER_DELETE_CONTRACT_RESOLVES_TO,
         {"contract_qns": sorted({_contract_qn(op) for op in operations})},
     )
-    ingestor.execute_write(
-        CYPHER_DELETE_FILE_CONTRACTS,
-        {"paths": sorted({cached_resolve_posix(op.source) for op in operations})},
-    )
     for operation in operations:
         _emit_contract(ingestor, operation)
-    created = _link_rpcs(ingestor, ingestor, operations) + _link_endpoints(
+    created = _link_rpcs(
         ingestor, ingestor, operations, project_name
-    )
+    ) + _link_endpoints(ingestor, ingestor, operations, project_name)
     logger.debug(ls.CONTRACT_OPERATIONS, count=len(operations), created=created)
     return created
 
@@ -157,6 +170,7 @@ def _link_rpcs(
     ingestor: IngestorProtocol,
     reader: QueryProtocol,
     operations: list[ContractOperation],
+    project_name: str,
 ) -> int:
     # An RPC resource is keyed `<Service>.<Method>`, which is exactly the
     # identity the proto declares, so this is a name match, not a heuristic.
@@ -166,7 +180,11 @@ def _link_rpcs(
         if operation.method is None
     }
     created = 0
-    for row in reader.fetch_all(CYPHER_LIVE_RPC_RESOURCES):
+    rows = reader.fetch_all(
+        CYPHER_LIVE_RPC_RESOURCES,
+        {"project_prefix": f"{project_name}{cs.SEPARATOR_DOT}"},
+    )
+    for row in rows:
         name = str(row.get(cs.KEY_NAME) or "")
         operation = by_identity.get(name)
         if operation is None:

--- a/codebase_rag/parsers/contract_linking.py
+++ b/codebase_rag/parsers/contract_linking.py
@@ -129,6 +129,11 @@ def _indexed_only(
     ]
 
 
+def _rpc_key(operation: ContractOperation) -> str:
+    service = operation.contract.rsplit(_IDENTITY_SEPARATOR, 1)[-1]
+    return f"{service}{_IDENTITY_SEPARATOR}{operation.operation}"
+
+
 def _identity(operation: ContractOperation) -> str:
     return f"{operation.contract}{_IDENTITY_SEPARATOR}{operation.operation}"
 
@@ -185,20 +190,22 @@ def _link_rpcs(
     operations: list[ContractOperation],
     project_name: str,
 ) -> int:
-    # An RPC resource is keyed `<Service>.<Method>`, which is exactly the
-    # identity the proto declares, so this is a name match, not a heuristic.
-    by_identity = {
-        _identity(operation): operation
-        for operation in operations
-        if operation.method is None
-    }
+    # An RPC resource is keyed by the BARE `<Service>.<Method>` the codegen
+    # produced, while a contract is identified by the protobuf
+    # `package.Service`, so the match drops the package. Two packages
+    # declaring one service name make the key ambiguous, and an ambiguous
+    # key claims nothing.
+    by_key: dict[str, list[ContractOperation]] = {}
+    for operation in operations:
+        if operation.method is None:
+            by_key.setdefault(_rpc_key(operation), []).append(operation)
     created = 0
     rows = reader.fetch_all(CYPHER_LIVE_RPC_RESOURCES, {"project_name": project_name})
     for row in rows:
-        name = str(row.get(cs.KEY_NAME) or "")
-        operation = by_identity.get(name)
-        if operation is None:
+        matches = by_key.get(str(row.get(cs.KEY_NAME) or ""), [])
+        if len(matches) != 1:
             continue
+        operation = matches[0]
         _resolve(
             ingestor,
             str(row.get(cs.KEY_QUALIFIED_NAME)),

--- a/codebase_rag/parsers/contract_linking.py
+++ b/codebase_rag/parsers/contract_linking.py
@@ -28,9 +28,11 @@ from .io_access.constants import KEY_KIND, RESOURCE_QN_FORMAT, ResourceKind
 # server in another on one node. A contract, though, is declared by THIS
 # repo, so only an operation this project's own code participates in is its
 # implementation; a same-named service elsewhere is a different contract.
+# Attribution is the qn's FIRST segment, as the endpoint linking does it: a
+# string prefix would let project `api` claim `api.worker`'s participation.
 CYPHER_LIVE_RPC_RESOURCES = (
     "MATCH (f)-[:EXPOSES|READS_FROM|WRITES_TO]->(r:Resource {kind: 'RPC'}) "
-    "WHERE f.qualified_name STARTS WITH $project_prefix "
+    "WHERE head(split(f.qualified_name, '.')) = $project_name "
     "RETURN DISTINCT r.qualified_name AS qualified_name, r.name AS name"
 )
 CYPHER_LIVE_ENDPOINT_RESOURCES = (
@@ -191,10 +193,7 @@ def _link_rpcs(
         if operation.method is None
     }
     created = 0
-    rows = reader.fetch_all(
-        CYPHER_LIVE_RPC_RESOURCES,
-        {"project_prefix": f"{project_name}{cs.SEPARATOR_DOT}"},
-    )
+    rows = reader.fetch_all(CYPHER_LIVE_RPC_RESOURCES, {"project_name": project_name})
     for row in rows:
         name = str(row.get(cs.KEY_NAME) or "")
         operation = by_identity.get(name)

--- a/codebase_rag/parsers/contract_linking.py
+++ b/codebase_rag/parsers/contract_linking.py
@@ -19,6 +19,7 @@ from .. import constants as cs
 from .. import logs as ls
 from ..services import IngestorProtocol, QueryProtocol
 from ..types_defs import PropertyDict
+from ..utils.path_utils import cached_resolve_posix
 from .contracts import ContractOperation, discover_contract_operations
 from .endpoints import url_matches_template
 from .io_access.constants import KEY_KIND, RESOURCE_QN_FORMAT, ResourceKind
@@ -34,6 +35,10 @@ CYPHER_LIVE_ENDPOINT_RESOURCES = (
 # Scoped to contract targets: RESOLVES_TO has other owners (client URL to
 # endpoint, a dispatch deployment suffix) whose edges must survive a relink
 # (issue #947).
+CYPHER_INDEXED_CONTRACT_FILES = (
+    "MATCH (f:File) WHERE f.absolute_path IN $paths "
+    "RETURN f.absolute_path AS absolute_path"
+)
 CYPHER_DELETE_CONTRACT_RESOLVES_TO = (
     "MATCH ()-[r:RESOLVES_TO]->(:Resource {kind: 'CONTRACT'}) DELETE r"
 )
@@ -48,17 +53,33 @@ def link_contracts(ingestor: IngestorProtocol, repo_path: Path) -> int:
     Returns the number of RESOLVES_TO edges emitted.
     """
     operations = discover_contract_operations(repo_path)
+    if not operations or not isinstance(ingestor, QueryProtocol):
+        return 0
+    operations = _indexed_only(ingestor, operations)
     if not operations:
         return 0
-    if isinstance(ingestor, QueryProtocol):
-        ingestor.execute_write(CYPHER_DELETE_CONTRACT_RESOLVES_TO)
+    ingestor.execute_write(CYPHER_DELETE_CONTRACT_RESOLVES_TO)
     for operation in operations:
         _emit_contract(ingestor, operation)
-    if not isinstance(ingestor, QueryProtocol):
-        return 0
     created = _link_rpcs(ingestor, operations) + _link_endpoints(ingestor, operations)
     logger.debug(ls.CONTRACT_OPERATIONS, count=len(operations), created=created)
     return created
+
+
+def _indexed_only(
+    ingestor: QueryProtocol, operations: list[ContractOperation]
+) -> list[ContractOperation]:
+    # Only a contract file the graph holds can anchor its operations; a file
+    # the walk skipped has no File node to hang them off, and a Resource that
+    # reaches nothing but Resources is pruned as unanchored anyway.
+    paths = sorted({cached_resolve_posix(op.source) for op in operations})
+    rows = ingestor.fetch_all(CYPHER_INDEXED_CONTRACT_FILES, {"paths": paths})
+    indexed = {str(row.get(cs.KEY_ABSOLUTE_PATH)) for row in rows}
+    return [
+        operation
+        for operation in operations
+        if cached_resolve_posix(operation.source) in indexed
+    ]
 
 
 def _identity(operation: ContractOperation) -> str:
@@ -78,6 +99,18 @@ def _emit_contract(ingestor: IngestorProtocol, operation: ContractOperation) -> 
         KEY_KIND: ResourceKind.CONTRACT.value,
     }
     ingestor.ensure_node_batch(cs.NodeLabel.RESOURCE, properties)
+    # The declaring file anchors the operation: a Resource whose only edges
+    # reach other Resources is pruned as unanchored (services/resource_cleanup),
+    # and a contract with no file is genuinely gone.
+    ingestor.ensure_relationship_batch(
+        (
+            cs.NodeLabel.FILE,
+            cs.KEY_ABSOLUTE_PATH,
+            cached_resolve_posix(operation.source),
+        ),
+        cs.RelationshipType.EXPOSES,
+        (cs.NodeLabel.RESOURCE, cs.KEY_QUALIFIED_NAME, _contract_qn(operation)),
+    )
 
 
 def _resolve(ingestor: IngestorProtocol, source_qn: str, target_qn: str) -> None:
@@ -88,9 +121,7 @@ def _resolve(ingestor: IngestorProtocol, source_qn: str, target_qn: str) -> None
     )
 
 
-def _link_rpcs(
-    ingestor: QueryProtocol, operations: list[ContractOperation]
-) -> int:
+def _link_rpcs(ingestor: QueryProtocol, operations: list[ContractOperation]) -> int:
     # An RPC resource is keyed `<Service>.<Method>`, which is exactly the
     # identity the proto declares, so this is a name match, not a heuristic.
     by_identity = {
@@ -104,9 +135,7 @@ def _link_rpcs(
         operation = by_identity.get(name)
         if operation is None:
             continue
-        _resolve(
-            ingestor, str(row.get(cs.KEY_QUALIFIED_NAME)), _contract_qn(operation)
-        )
+        _resolve(ingestor, str(row.get(cs.KEY_QUALIFIED_NAME)), _contract_qn(operation))
         created += 1
     return created
 

--- a/codebase_rag/parsers/contract_linking.py
+++ b/codebase_rag/parsers/contract_linking.py
@@ -1,0 +1,140 @@
+"""Anchor generated artefacts to the operation their contract declares.
+
+The artefacts already exist: an RPC resource where a generated client and
+server meet by service and method, an ENDPOINT resource where a generated
+server registers a route. This pass adds the contract's own name for each
+operation as one CONTRACT resource and resolves those artefacts into it, so
+one node answers "who implements this operation" across every language, and
+an operation whose client and server disagree on the path (or whose client
+carries no URL literal at all) is still joined.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from loguru import logger
+
+from .. import constants as cs
+from .. import logs as ls
+from ..services import IngestorProtocol, QueryProtocol
+from ..types_defs import PropertyDict
+from .contracts import ContractOperation, discover_contract_operations
+from .endpoints import url_matches_template
+from .io_access.constants import KEY_KIND, RESOURCE_QN_FORMAT, ResourceKind
+
+CYPHER_LIVE_RPC_RESOURCES = (
+    "MATCH (r:Resource {kind: 'RPC'}) "
+    "RETURN r.qualified_name AS qualified_name, r.name AS name"
+)
+CYPHER_LIVE_ENDPOINT_RESOURCES = (
+    "MATCH ()-[:EXPOSES]->(r:Resource {kind: 'ENDPOINT'}) "
+    "RETURN DISTINCT r.qualified_name AS qualified_name, r.name AS name"
+)
+# Scoped to contract targets: RESOLVES_TO has other owners (client URL to
+# endpoint, a dispatch deployment suffix) whose edges must survive a relink
+# (issue #947).
+CYPHER_DELETE_CONTRACT_RESOLVES_TO = (
+    "MATCH ()-[r:RESOLVES_TO]->(:Resource {kind: 'CONTRACT'}) DELETE r"
+)
+
+_IDENTITY_SEPARATOR = "."
+_METHOD_ANY = "ANY"
+
+
+def link_contracts(ingestor: IngestorProtocol, repo_path: Path) -> int:
+    """Emit CONTRACT resources and resolve live artefacts into them.
+
+    Returns the number of RESOLVES_TO edges emitted.
+    """
+    operations = discover_contract_operations(repo_path)
+    if not operations:
+        return 0
+    if isinstance(ingestor, QueryProtocol):
+        ingestor.execute_write(CYPHER_DELETE_CONTRACT_RESOLVES_TO)
+    for operation in operations:
+        _emit_contract(ingestor, operation)
+    if not isinstance(ingestor, QueryProtocol):
+        return 0
+    created = _link_rpcs(ingestor, operations) + _link_endpoints(ingestor, operations)
+    logger.debug(ls.CONTRACT_OPERATIONS, count=len(operations), created=created)
+    return created
+
+
+def _identity(operation: ContractOperation) -> str:
+    return f"{operation.contract}{_IDENTITY_SEPARATOR}{operation.operation}"
+
+
+def _contract_qn(operation: ContractOperation) -> str:
+    return RESOURCE_QN_FORMAT.format(
+        kind=ResourceKind.CONTRACT.value, identity=_identity(operation)
+    )
+
+
+def _emit_contract(ingestor: IngestorProtocol, operation: ContractOperation) -> None:
+    properties: PropertyDict = {
+        cs.KEY_QUALIFIED_NAME: _contract_qn(operation),
+        cs.KEY_NAME: _identity(operation),
+        KEY_KIND: ResourceKind.CONTRACT.value,
+    }
+    ingestor.ensure_node_batch(cs.NodeLabel.RESOURCE, properties)
+
+
+def _resolve(ingestor: IngestorProtocol, source_qn: str, target_qn: str) -> None:
+    ingestor.ensure_relationship_batch(
+        (cs.NodeLabel.RESOURCE, cs.KEY_QUALIFIED_NAME, source_qn),
+        cs.RelationshipType.RESOLVES_TO,
+        (cs.NodeLabel.RESOURCE, cs.KEY_QUALIFIED_NAME, target_qn),
+    )
+
+
+def _link_rpcs(
+    ingestor: QueryProtocol, operations: list[ContractOperation]
+) -> int:
+    # An RPC resource is keyed `<Service>.<Method>`, which is exactly the
+    # identity the proto declares, so this is a name match, not a heuristic.
+    by_identity = {
+        _identity(operation): operation
+        for operation in operations
+        if operation.method is None
+    }
+    created = 0
+    for row in ingestor.fetch_all(CYPHER_LIVE_RPC_RESOURCES):
+        name = str(row.get(cs.KEY_NAME) or "")
+        operation = by_identity.get(name)
+        if operation is None:
+            continue
+        _resolve(
+            ingestor, str(row.get(cs.KEY_QUALIFIED_NAME)), _contract_qn(operation)
+        )
+        created += 1
+    return created
+
+
+def _link_endpoints(
+    ingestor: QueryProtocol, operations: list[ContractOperation]
+) -> int:
+    http = [operation for operation in operations if operation.method is not None]
+    if not http:
+        return 0
+    created = 0
+    for row in ingestor.fetch_all(CYPHER_LIVE_ENDPOINT_RESOURCES):
+        method, _, path = str(row.get(cs.KEY_NAME) or "").partition(" ")
+        if not path:
+            continue
+        endpoint_qn = str(row.get(cs.KEY_QUALIFIED_NAME))
+        for operation in http:
+            if _serves(method, path, operation):
+                _resolve(ingestor, endpoint_qn, _contract_qn(operation))
+                created += 1
+    return created
+
+
+def _serves(method: str, path: str, operation: ContractOperation) -> bool:
+    # A registration with no verb (`http.HandleFunc("/x", h)`) serves every
+    # method the contract declares at that path. The path comparison is the
+    # template match the URL linking already uses, so `:id` and `{id}` are one
+    # segment and an unresolved mount lead still matches.
+    if method not in (_METHOD_ANY, operation.method):
+        return False
+    return operation.path is not None and url_matches_template(operation.path, path)

--- a/codebase_rag/parsers/contract_linking.py
+++ b/codebase_rag/parsers/contract_linking.py
@@ -90,7 +90,7 @@ def link_contracts(
     # and the unanchored-resource prune takes them and their edges.
     ingestor.execute_write(
         CYPHER_DELETE_FILE_CONTRACTS,
-        {"repo_prefix": cached_resolve_posix(repo_path)},
+        {"repo_prefix": f"{cached_resolve_posix(repo_path)}{cs.SEPARATOR_SLASH}"},
     )
     operations = _indexed_only(
         ingestor,
@@ -100,10 +100,10 @@ def link_contracts(
         return 0
     ingestor.execute_write(
         CYPHER_DELETE_CONTRACT_RESOLVES_TO,
-        {"contract_qns": sorted({_contract_qn(op) for op in operations})},
+        {"contract_qns": sorted({_contract_qn(op, project_name) for op in operations})},
     )
     for operation in operations:
-        _emit_contract(ingestor, operation)
+        _emit_contract(ingestor, operation, project_name)
     created = _link_rpcs(
         ingestor, ingestor, operations, project_name
     ) + _link_endpoints(ingestor, ingestor, operations, project_name)
@@ -131,15 +131,22 @@ def _identity(operation: ContractOperation) -> str:
     return f"{operation.contract}{_IDENTITY_SEPARATOR}{operation.operation}"
 
 
-def _contract_qn(operation: ContractOperation) -> str:
+def _contract_qn(operation: ContractOperation, project_name: str) -> str:
+    # Scoped by declaring project, exactly as an ENDPOINT resource is: two
+    # repositories can hold the same spec at the same relative path, and
+    # merging them would attribute each one's implementations to the other
+    # and let either one's relink delete the other's links.
     return RESOURCE_QN_FORMAT.format(
-        kind=ResourceKind.CONTRACT.value, identity=_identity(operation)
+        kind=ResourceKind.CONTRACT.value,
+        identity=f"{project_name}::{_identity(operation)}",
     )
 
 
-def _emit_contract(ingestor: IngestorProtocol, operation: ContractOperation) -> None:
+def _emit_contract(
+    ingestor: IngestorProtocol, operation: ContractOperation, project_name: str
+) -> None:
     properties: PropertyDict = {
-        cs.KEY_QUALIFIED_NAME: _contract_qn(operation),
+        cs.KEY_QUALIFIED_NAME: _contract_qn(operation, project_name),
         cs.KEY_NAME: _identity(operation),
         KEY_KIND: ResourceKind.CONTRACT.value,
     }
@@ -154,7 +161,11 @@ def _emit_contract(ingestor: IngestorProtocol, operation: ContractOperation) -> 
             cached_resolve_posix(operation.source),
         ),
         cs.RelationshipType.EXPOSES,
-        (cs.NodeLabel.RESOURCE, cs.KEY_QUALIFIED_NAME, _contract_qn(operation)),
+        (
+            cs.NodeLabel.RESOURCE,
+            cs.KEY_QUALIFIED_NAME,
+            _contract_qn(operation, project_name),
+        ),
     )
 
 
@@ -189,7 +200,11 @@ def _link_rpcs(
         operation = by_identity.get(name)
         if operation is None:
             continue
-        _resolve(ingestor, str(row.get(cs.KEY_QUALIFIED_NAME)), _contract_qn(operation))
+        _resolve(
+            ingestor,
+            str(row.get(cs.KEY_QUALIFIED_NAME)),
+            _contract_qn(operation, project_name),
+        )
         created += 1
     return created
 
@@ -217,7 +232,9 @@ def _link_endpoints(
         if len(matches) != 1:
             continue
         _resolve(
-            ingestor, str(row.get(cs.KEY_QUALIFIED_NAME)), _contract_qn(matches[0])
+            ingestor,
+            str(row.get(cs.KEY_QUALIFIED_NAME)),
+            _contract_qn(matches[0], project_name),
         )
         created += 1
     return created

--- a/codebase_rag/parsers/contract_linking.py
+++ b/codebase_rag/parsers/contract_linking.py
@@ -21,7 +21,7 @@ from ..services import IngestorProtocol, QueryProtocol
 from ..types_defs import PropertyDict
 from ..utils.path_utils import cached_resolve_posix
 from .contracts import ContractOperation, discover_contract_operations
-from .endpoints import url_matches_template
+from .endpoints import _has_literal_segment, url_matches_template
 from .io_access.constants import KEY_KIND, RESOURCE_QN_FORMAT, ResourceKind
 
 CYPHER_LIVE_RPC_RESOURCES = (
@@ -30,6 +30,7 @@ CYPHER_LIVE_RPC_RESOURCES = (
 )
 CYPHER_LIVE_ENDPOINT_RESOURCES = (
     "MATCH ()-[:EXPOSES]->(r:Resource {kind: 'ENDPOINT'}) "
+    "WHERE r.project = $project "
     "RETURN DISTINCT r.qualified_name AS qualified_name, r.name AS name"
 )
 # Scoped to contract targets: RESOLVES_TO has other owners (client URL to
@@ -39,29 +40,60 @@ CYPHER_INDEXED_CONTRACT_FILES = (
     "MATCH (f:File) WHERE f.absolute_path IN $paths "
     "RETURN f.absolute_path AS absolute_path"
 )
+# Scoped to the contracts THIS run declares: another project's contracts in
+# the shared graph keep their links (issue #897's lesson), and the artefacts
+# of other kinds keep theirs (issue #947's).
 CYPHER_DELETE_CONTRACT_RESOLVES_TO = (
-    "MATCH ()-[r:RESOLVES_TO]->(:Resource {kind: 'CONTRACT'}) DELETE r"
+    "MATCH ()-[r:RESOLVES_TO]->(c:Resource {kind: 'CONTRACT'}) "
+    "WHERE c.qualified_name IN $contract_qns DELETE r"
+)
+# A renamed operation leaves a node whose declaring file still anchors it,
+# so the file's own declarations are cleared before it re-declares them and
+# whatever it no longer declares is pruned as unanchored.
+CYPHER_DELETE_FILE_CONTRACTS = (
+    "MATCH (f:File)-[e:EXPOSES]->(:Resource {kind: 'CONTRACT'}) "
+    "WHERE f.absolute_path IN $paths DELETE e"
 )
 
 _IDENTITY_SEPARATOR = "."
 _METHOD_ANY = "ANY"
 
 
-def link_contracts(ingestor: IngestorProtocol, repo_path: Path) -> int:
+def link_contracts(
+    ingestor: IngestorProtocol,
+    repo_path: Path,
+    project_name: str,
+    exclude_paths: frozenset[str] | None = None,
+    unignore_paths: frozenset[str] | None = None,
+) -> int:
     """Emit CONTRACT resources and resolve live artefacts into them.
 
     Returns the number of RESOLVES_TO edges emitted.
     """
-    operations = discover_contract_operations(repo_path)
+    operations = discover_contract_operations(repo_path, exclude_paths, unignore_paths)
     if not operations or not isinstance(ingestor, QueryProtocol):
+        return 0
+    # A filtering sink that would drop the EXPOSES edge must not receive the
+    # Resource node either, or selective capture leaves an orphaned contract.
+    rel_gate = getattr(ingestor, "rel_enabled", None)
+    if callable(rel_gate) and not rel_gate(cs.RelationshipType.EXPOSES):
         return 0
     operations = _indexed_only(ingestor, operations)
     if not operations:
         return 0
-    ingestor.execute_write(CYPHER_DELETE_CONTRACT_RESOLVES_TO)
+    ingestor.execute_write(
+        CYPHER_DELETE_CONTRACT_RESOLVES_TO,
+        {"contract_qns": sorted({_contract_qn(op) for op in operations})},
+    )
+    ingestor.execute_write(
+        CYPHER_DELETE_FILE_CONTRACTS,
+        {"paths": sorted({cached_resolve_posix(op.source) for op in operations})},
+    )
     for operation in operations:
         _emit_contract(ingestor, operation)
-    created = _link_rpcs(ingestor, operations) + _link_endpoints(ingestor, operations)
+    created = _link_rpcs(ingestor, ingestor, operations) + _link_endpoints(
+        ingestor, ingestor, operations, project_name
+    )
     logger.debug(ls.CONTRACT_OPERATIONS, count=len(operations), created=created)
     return created
 
@@ -121,7 +153,11 @@ def _resolve(ingestor: IngestorProtocol, source_qn: str, target_qn: str) -> None
     )
 
 
-def _link_rpcs(ingestor: QueryProtocol, operations: list[ContractOperation]) -> int:
+def _link_rpcs(
+    ingestor: IngestorProtocol,
+    reader: QueryProtocol,
+    operations: list[ContractOperation],
+) -> int:
     # An RPC resource is keyed `<Service>.<Method>`, which is exactly the
     # identity the proto declares, so this is a name match, not a heuristic.
     by_identity = {
@@ -130,7 +166,7 @@ def _link_rpcs(ingestor: QueryProtocol, operations: list[ContractOperation]) -> 
         if operation.method is None
     }
     created = 0
-    for row in ingestor.fetch_all(CYPHER_LIVE_RPC_RESOURCES):
+    for row in reader.fetch_all(CYPHER_LIVE_RPC_RESOURCES):
         name = str(row.get(cs.KEY_NAME) or "")
         operation = by_identity.get(name)
         if operation is None:
@@ -141,21 +177,31 @@ def _link_rpcs(ingestor: QueryProtocol, operations: list[ContractOperation]) -> 
 
 
 def _link_endpoints(
-    ingestor: QueryProtocol, operations: list[ContractOperation]
+    ingestor: IngestorProtocol,
+    reader: QueryProtocol,
+    operations: list[ContractOperation],
+    project_name: str,
 ) -> int:
     http = [operation for operation in operations if operation.method is not None]
     if not http:
         return 0
     created = 0
-    for row in ingestor.fetch_all(CYPHER_LIVE_ENDPOINT_RESOURCES):
+    rows = reader.fetch_all(CYPHER_LIVE_ENDPOINT_RESOURCES, {"project": project_name})
+    for row in rows:
         method, _, path = str(row.get(cs.KEY_NAME) or "").partition(" ")
-        if not path:
+        # A template with no literal segment of its own (`/**`, `/:id`) says
+        # nothing about WHICH operation it serves, and a parameter segment
+        # swallows its literal siblings, so a template matching more than one
+        # operation names none of them.
+        if not path or not _has_literal_segment(path):
             continue
-        endpoint_qn = str(row.get(cs.KEY_QUALIFIED_NAME))
-        for operation in http:
-            if _serves(method, path, operation):
-                _resolve(ingestor, endpoint_qn, _contract_qn(operation))
-                created += 1
+        matches = [operation for operation in http if _serves(method, path, operation)]
+        if len(matches) != 1:
+            continue
+        _resolve(
+            ingestor, str(row.get(cs.KEY_QUALIFIED_NAME)), _contract_qn(matches[0])
+        )
+        created += 1
     return created
 
 

--- a/codebase_rag/parsers/contracts.py
+++ b/codebase_rag/parsers/contracts.py
@@ -1,0 +1,155 @@
+"""Contract files as the canonical name of a service operation (issue #912).
+
+In a contract-first repo neither side of a service call is written by hand:
+the client stub and the server handler are both generated, they share no
+symbol, and often no URL literal either. What they do share is the operation
+the contract declares, so an OpenAPI ``operationId`` and a protobuf ``rpc``
+each become one CONTRACT resource that the generated artefacts resolve into.
+
+Discovery is deliberately narrow. A JSON or YAML document counts as a spec
+only when it declares ``openapi``/``swagger`` and a ``paths`` mapping, so the
+manifests, lockfiles and fixtures every repo is full of contribute nothing,
+and a ``.proto`` yields operations only from inside a ``service`` block.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import NamedTuple
+
+from loguru import logger
+
+from .. import constants as cs
+from .. import logs as ls
+from ..types_defs import JsonValue
+
+
+class ContractOperation(NamedTuple):
+    # `contract` names the declaring unit (an OpenAPI spec stem, a protobuf
+    # service) and `operation` the operation within it. An HTTP operation
+    # also carries the method and path template it is served at; an rpc has
+    # neither, since it is addressed by name.
+    contract: str
+    operation: str
+    method: str | None
+    path: str | None
+
+
+def discover_contract_operations(repo_path: Path) -> list[ContractOperation]:
+    operations: list[ContractOperation] = []
+    for directory, subdirs, filenames in os.walk(repo_path):
+        subdirs[:] = [d for d in subdirs if d not in cs.IGNORE_PATTERNS]
+        for filename in filenames:
+            path = Path(directory) / filename
+            suffix = path.suffix.lower()
+            if suffix == cs.CONTRACT_PROTO_EXTENSION:
+                operations.extend(_proto_operations(path))
+            elif suffix in cs.CONTRACT_SPEC_EXTENSIONS:
+                operations.extend(_openapi_operations(path))
+    operations.sort()
+    return operations
+
+
+def _read_text(path: Path) -> str | None:
+    try:
+        if path.stat().st_size > cs.CONTRACT_MAX_FILE_BYTES:
+            return None
+        return path.read_text(encoding=cs.ENCODING_UTF8)
+    except (OSError, ValueError):
+        return None
+
+
+def _openapi_operations(path: Path) -> list[ContractOperation]:
+    text = _read_text(path)
+    # Cheap gate before parsing: a spec always names its version key, and
+    # most JSON/YAML in a repo is not a spec at all.
+    if text is None or not any(
+        marker in text for marker in cs.CONTRACT_SPEC_MARKERS
+    ):
+        return []
+    document = _parse_document(path, text)
+    if not isinstance(document, dict):
+        return []
+    if not any(key in document for key in cs.CONTRACT_SPEC_VERSION_KEYS):
+        return []
+    paths = document.get(cs.CONTRACT_PATHS_KEY)
+    if not isinstance(paths, dict):
+        return []
+    contract = path.stem
+    operations: list[ContractOperation] = []
+    for template, methods in paths.items():
+        if not isinstance(template, str) or not isinstance(methods, dict):
+            continue
+        for method, operation in methods.items():
+            if not isinstance(method, str) or method.lower() not in cs.CONTRACT_OPERATION_METHODS:
+                continue
+            if not isinstance(operation, dict):
+                continue
+            operation_id = operation.get(cs.CONTRACT_OPERATION_ID_KEY)
+            if isinstance(operation_id, str) and operation_id:
+                operations.append(
+                    ContractOperation(
+                        contract, operation_id, method.upper(), template
+                    )
+                )
+    return operations
+
+
+def _parse_document(path: Path, text: str) -> JsonValue:
+    if path.suffix.lower() == cs.CONTRACT_JSON_EXTENSION:
+        try:
+            return json.loads(text)
+        except ValueError:
+            return None
+    try:
+        import yaml
+    except ImportError:
+        logger.debug(ls.CONTRACT_YAML_UNAVAILABLE, path=str(path))
+        return None
+    try:
+        return yaml.safe_load(text)
+    except yaml.YAMLError:
+        return None
+
+
+# `service Name {` opens a block; `rpc Name(` is an operation inside one.
+_PROTO_SERVICE_RE = re.compile(r"\bservice\s+(\w+)\s*\{")
+_PROTO_RPC_RE = re.compile(r"\brpc\s+(\w+)\s*\(")
+_PROTO_LINE_COMMENT = "//"
+
+
+def _proto_operations(path: Path) -> list[ContractOperation]:
+    text = _read_text(path)
+    if text is None:
+        return []
+    operations: list[ContractOperation] = []
+    service: str | None = None
+    depth = 0
+    for raw_line in text.splitlines():
+        line = raw_line.split(_PROTO_LINE_COMMENT, 1)[0]
+        if service is None:
+            if match := _PROTO_SERVICE_RE.search(line):
+                service = match.group(1)
+                depth = line.count("{") - line.count("}")
+                if depth <= 0:
+                    operations.extend(
+                        ContractOperation(service, name, None, None)
+                        for name in _PROTO_RPC_RE.findall(line)
+                    )
+                    service = None
+                    continue
+                line = line.split("{", 1)[1]
+            else:
+                continue
+        else:
+            depth += line.count("{") - line.count("}")
+        operations.extend(
+            ContractOperation(service, name, None, None)
+            for name in _PROTO_RPC_RE.findall(line)
+        )
+        if depth <= 0:
+            service = None
+    return operations

--- a/codebase_rag/parsers/contracts.py
+++ b/codebase_rag/parsers/contracts.py
@@ -31,11 +31,13 @@ class ContractOperation(NamedTuple):
     # `contract` names the declaring unit (an OpenAPI spec stem, a protobuf
     # service) and `operation` the operation within it. An HTTP operation
     # also carries the method and path template it is served at; an rpc has
-    # neither, since it is addressed by name.
+    # neither, since it is addressed by name. `source` is the contract file
+    # that declares it, which is what anchors the operation to the repo.
     contract: str
     operation: str
     method: str | None
     path: str | None
+    source: Path
 
 
 def discover_contract_operations(repo_path: Path) -> list[ContractOperation]:
@@ -66,9 +68,7 @@ def _openapi_operations(path: Path) -> list[ContractOperation]:
     text = _read_text(path)
     # Cheap gate before parsing: a spec always names its version key, and
     # most JSON/YAML in a repo is not a spec at all.
-    if text is None or not any(
-        marker in text for marker in cs.CONTRACT_SPEC_MARKERS
-    ):
+    if text is None or not any(marker in text for marker in cs.CONTRACT_SPEC_MARKERS):
         return []
     document = _parse_document(path, text)
     if not isinstance(document, dict):
@@ -84,7 +84,10 @@ def _openapi_operations(path: Path) -> list[ContractOperation]:
         if not isinstance(template, str) or not isinstance(methods, dict):
             continue
         for method, operation in methods.items():
-            if not isinstance(method, str) or method.lower() not in cs.CONTRACT_OPERATION_METHODS:
+            if (
+                not isinstance(method, str)
+                or method.lower() not in cs.CONTRACT_OPERATION_METHODS
+            ):
                 continue
             if not isinstance(operation, dict):
                 continue
@@ -92,7 +95,7 @@ def _openapi_operations(path: Path) -> list[ContractOperation]:
             if isinstance(operation_id, str) and operation_id:
                 operations.append(
                     ContractOperation(
-                        contract, operation_id, method.upper(), template
+                        contract, operation_id, method.upper(), template, path
                     )
                 )
     return operations
@@ -136,7 +139,7 @@ def _proto_operations(path: Path) -> list[ContractOperation]:
                 depth = line.count("{") - line.count("}")
                 if depth <= 0:
                     operations.extend(
-                        ContractOperation(service, name, None, None)
+                        ContractOperation(service, name, None, None, path)
                         for name in _PROTO_RPC_RE.findall(line)
                     )
                     service = None
@@ -147,7 +150,7 @@ def _proto_operations(path: Path) -> list[ContractOperation]:
         else:
             depth += line.count("{") - line.count("}")
         operations.extend(
-            ContractOperation(service, name, None, None)
+            ContractOperation(service, name, None, None, path)
             for name in _PROTO_RPC_RE.findall(line)
         )
         if depth <= 0:

--- a/codebase_rag/parsers/contracts.py
+++ b/codebase_rag/parsers/contracts.py
@@ -100,15 +100,8 @@ def _read_text(path: Path) -> str | None:
 
 
 def _openapi_operations(path: Path, repo_path: Path) -> list[ContractOperation]:
-    text = _read_text(path)
-    # Cheap gate before parsing: a spec always names its version key, and
-    # most JSON/YAML in a repo is not a spec at all.
-    if text is None or not any(marker in text for marker in cs.CONTRACT_SPEC_MARKERS):
-        return []
-    document = _parse_document(path, text)
-    if not isinstance(document, dict):
-        return []
-    if not any(key in document for key in cs.CONTRACT_SPEC_VERSION_KEYS):
+    document = _spec_document(path)
+    if document is None:
         return []
     paths = document.get(cs.CONTRACT_PATHS_KEY)
     if not isinstance(paths, dict):
@@ -118,30 +111,58 @@ def _openapi_operations(path: Path, repo_path: Path) -> list[ContractOperation]:
     # API, or two unrelated services, into a single operation.
     contract = _contract_name(path, repo_path)
     prefix = _base_path(document)
+    return [
+        operation
+        for template, methods in paths.items()
+        if isinstance(template, str) and isinstance(methods, dict)
+        for operation in _path_operations(contract, prefix, template, methods, path)
+    ]
+
+
+def _spec_document(path: Path) -> dict[str, JsonValue] | None:
+    # A document is a spec only when it declares a version key and parses to
+    # a mapping; the text check is a cheap gate, since most JSON and YAML in
+    # a repo is not a spec at all.
+    text = _read_text(path)
+    if text is None or not any(marker in text for marker in cs.CONTRACT_SPEC_MARKERS):
+        return None
+    document = _parse_document(path, text)
+    if not isinstance(document, dict):
+        return None
+    if not any(key in document for key in cs.CONTRACT_SPEC_VERSION_KEYS):
+        return None
+    return document
+
+
+def _path_operations(
+    contract: str,
+    prefix: str,
+    template: str,
+    methods: dict[str, JsonValue],
+    source: Path,
+) -> list[ContractOperation]:
+    # Every key under a path item that names an operation; the rest
+    # (parameters, servers, summary) describes the path, not an operation.
     operations: list[ContractOperation] = []
-    for template, methods in paths.items():
-        if not isinstance(template, str) or not isinstance(methods, dict):
+    for method, operation in methods.items():
+        if not isinstance(operation, dict) or not _is_operation_method(method):
             continue
-        for method, operation in methods.items():
-            if (
-                not isinstance(method, str)
-                or method.lower() not in cs.CONTRACT_OPERATION_METHODS
-            ):
-                continue
-            if not isinstance(operation, dict):
-                continue
-            operation_id = operation.get(cs.CONTRACT_OPERATION_ID_KEY)
-            if isinstance(operation_id, str) and operation_id:
-                operations.append(
-                    ContractOperation(
-                        contract,
-                        operation_id,
-                        method.upper(),
-                        f"{prefix}{template}",
-                        path,
-                    )
+        operation_id = operation.get(cs.CONTRACT_OPERATION_ID_KEY)
+        if isinstance(operation_id, str) and operation_id:
+            operations.append(
+                ContractOperation(
+                    contract,
+                    operation_id,
+                    method.upper(),
+                    f"{prefix}{template}",
+                    source,
                 )
+            )
     return operations
+
+
+def _is_operation_method(method: str) -> bool:
+    return isinstance(method, str) and method.lower() in cs.CONTRACT_OPERATION_METHODS
 
 
 def _contract_name(path: Path, repo_path: Path) -> str:

--- a/codebase_rag/parsers/contracts.py
+++ b/codebase_rag/parsers/contracts.py
@@ -216,6 +216,9 @@ def _parse_document(path: Path, text: str) -> JsonValue:
 
 # `service Name {` opens a block; `rpc Name(` is an operation inside one.
 _PROTO_SERVICE_RE = re.compile(r"\bservice\s+(\w+)\s*\{")
+# protobuf identifies a service by `package.Service`, so two packages
+# declaring the same service name declare two different services.
+_PROTO_PACKAGE_RE = re.compile(r"\bpackage\s+([\w.]+)\s*;")
 _PROTO_RPC_RE = re.compile(r"\brpc\s+(\w+)\s*\(")
 
 
@@ -264,9 +267,11 @@ def _proto_operations(path: Path) -> list[ContractOperation]:
     if text is None:
         return []
     code = _proto_code(text)
+    package_match = _PROTO_PACKAGE_RE.search(code)
+    package = f"{package_match.group(1)}." if package_match else ""
     operations: list[ContractOperation] = []
     for match in _PROTO_SERVICE_RE.finditer(code):
-        service = match.group(1)
+        service = f"{package}{match.group(1)}"
         body = _block_body(code, match.end() - 1)
         operations.extend(
             ContractOperation(service, name, None, None, path)

--- a/codebase_rag/parsers/contracts.py
+++ b/codebase_rag/parsers/contracts.py
@@ -19,12 +19,14 @@ import os
 import re
 from pathlib import Path
 from typing import NamedTuple
+from urllib.parse import urlparse
 
 from loguru import logger
 
 from .. import constants as cs
 from .. import logs as ls
 from ..types_defs import JsonValue
+from ..utils.path_utils import should_skip_path
 
 
 class ContractOperation(NamedTuple):
@@ -40,19 +42,52 @@ class ContractOperation(NamedTuple):
     source: Path
 
 
-def discover_contract_operations(repo_path: Path) -> list[ContractOperation]:
+def discover_contract_operations(
+    repo_path: Path,
+    exclude_paths: frozenset[str] | None = None,
+    unignore_paths: frozenset[str] | None = None,
+) -> list[ContractOperation]:
+    # The same path filters the file walk applies, so a user exclusion is
+    # never read from disk and an un-ignored tree (a checked-in generated
+    # `dist/` the user rescued) is not skipped here while being indexed.
     operations: list[ContractOperation] = []
     for directory, subdirs, filenames in os.walk(repo_path):
-        subdirs[:] = [d for d in subdirs if d not in cs.IGNORE_PATTERNS]
+        subdirs[:] = [
+            d
+            for d in subdirs
+            if not should_skip_path(
+                Path(directory) / d,
+                repo_path,
+                exclude_paths,
+                unignore_paths,
+                is_file=False,
+            )
+        ]
         for filename in filenames:
             path = Path(directory) / filename
+            if should_skip_path(
+                path, repo_path, exclude_paths, unignore_paths, is_file=True
+            ):
+                continue
             suffix = path.suffix.lower()
             if suffix == cs.CONTRACT_PROTO_EXTENSION:
                 operations.extend(_proto_operations(path))
             elif suffix in cs.CONTRACT_SPEC_EXTENSIONS:
-                operations.extend(_openapi_operations(path))
-    operations.sort()
+                operations.extend(_openapi_operations(path, repo_path))
+    # Sorted by an explicit key: the tuple's own order would compare a
+    # method string against an rpc's None the moment two identities collide.
+    operations.sort(key=_sort_key)
     return operations
+
+
+def _sort_key(operation: ContractOperation) -> tuple[str, str, str, str, str]:
+    return (
+        operation.contract,
+        operation.operation,
+        operation.method or "",
+        operation.path or "",
+        operation.source.as_posix(),
+    )
 
 
 def _read_text(path: Path) -> str | None:
@@ -64,7 +99,7 @@ def _read_text(path: Path) -> str | None:
         return None
 
 
-def _openapi_operations(path: Path) -> list[ContractOperation]:
+def _openapi_operations(path: Path, repo_path: Path) -> list[ContractOperation]:
     text = _read_text(path)
     # Cheap gate before parsing: a spec always names its version key, and
     # most JSON/YAML in a repo is not a spec at all.
@@ -78,7 +113,11 @@ def _openapi_operations(path: Path) -> list[ContractOperation]:
     paths = document.get(cs.CONTRACT_PATHS_KEY)
     if not isinstance(paths, dict):
         return []
-    contract = path.stem
+    # The declaring FILE names the contract: `openapi.json` is the
+    # conventional filename, so a stem alone would fold two versions of one
+    # API, or two unrelated services, into a single operation.
+    contract = _contract_name(path, repo_path)
+    prefix = _base_path(document)
     operations: list[ContractOperation] = []
     for template, methods in paths.items():
         if not isinstance(template, str) or not isinstance(methods, dict):
@@ -95,10 +134,46 @@ def _openapi_operations(path: Path) -> list[ContractOperation]:
             if isinstance(operation_id, str) and operation_id:
                 operations.append(
                     ContractOperation(
-                        contract, operation_id, method.upper(), template, path
+                        contract,
+                        operation_id,
+                        method.upper(),
+                        f"{prefix}{template}",
+                        path,
                     )
                 )
     return operations
+
+
+def _contract_name(path: Path, repo_path: Path) -> str:
+    try:
+        relative = path.relative_to(repo_path)
+    except ValueError:
+        return path.stem
+    return relative.with_suffix("").as_posix()
+
+
+def _base_path(document: dict[str, JsonValue]) -> str:
+    # Swagger 2 states the mount as `basePath`; OpenAPI 3 states it in each
+    # server URL, and only a prefix EVERY server agrees on is part of the
+    # operation's path (one server rooted differently means there is none).
+    base = document.get(cs.CONTRACT_BASE_PATH_KEY)
+    if isinstance(base, str) and base.startswith(cs.SEPARATOR_SLASH):
+        return base.rstrip(cs.SEPARATOR_SLASH)
+    servers = document.get(cs.CONTRACT_SERVERS_KEY)
+    if not isinstance(servers, list) or not servers:
+        return ""
+    prefixes = set()
+    for server in servers:
+        if not isinstance(server, dict):
+            return ""
+        url = server.get(cs.CONTRACT_SERVER_URL_KEY)
+        if not isinstance(url, str):
+            return ""
+        prefixes.add(urlparse(url).path.rstrip(cs.SEPARATOR_SLASH))
+    if len(prefixes) != 1:
+        return ""
+    only = prefixes.pop()
+    return only if only.startswith(cs.SEPARATOR_SLASH) else ""
 
 
 def _parse_document(path: Path, text: str) -> JsonValue:
@@ -121,38 +196,73 @@ def _parse_document(path: Path, text: str) -> JsonValue:
 # `service Name {` opens a block; `rpc Name(` is an operation inside one.
 _PROTO_SERVICE_RE = re.compile(r"\bservice\s+(\w+)\s*\{")
 _PROTO_RPC_RE = re.compile(r"\brpc\s+(\w+)\s*\(")
-_PROTO_LINE_COMMENT = "//"
+
+
+def _proto_code(text: str) -> str:
+    # Comments and string literals are not code: a commented-out service
+    # declares nothing, an `option = "rpc Fake(X)"` is not an operation, and
+    # a brace inside a string must not open or close a block.
+    out: list[str] = []
+    index = 0
+    length = len(text)
+    while index < length:
+        char = text[index]
+        if char == "/" and text.startswith("//", index):
+            index = text.find("\n", index)
+            if index == -1:
+                break
+        elif char == "/" and text.startswith("/*", index):
+            end = text.find("*/", index + 2)
+            # An unterminated block comment runs to the end of the file.
+            index = length if end == -1 else end + 2
+            out.append(" ")
+        elif char in ("'", '"'):
+            index = _skip_string(text, index)
+            out.append(" ")
+        else:
+            out.append(char)
+            index += 1
+    return "".join(out)
+
+
+def _skip_string(text: str, index: int) -> int:
+    quote = text[index]
+    index += 1
+    while index < len(text):
+        if text[index] == "\\":
+            index += 2
+            continue
+        if text[index] == quote:
+            return index + 1
+        index += 1
+    return index
 
 
 def _proto_operations(path: Path) -> list[ContractOperation]:
     text = _read_text(path)
     if text is None:
         return []
+    code = _proto_code(text)
     operations: list[ContractOperation] = []
-    service: str | None = None
-    depth = 0
-    for raw_line in text.splitlines():
-        line = raw_line.split(_PROTO_LINE_COMMENT, 1)[0]
-        if service is None:
-            if match := _PROTO_SERVICE_RE.search(line):
-                service = match.group(1)
-                depth = line.count("{") - line.count("}")
-                if depth <= 0:
-                    operations.extend(
-                        ContractOperation(service, name, None, None, path)
-                        for name in _PROTO_RPC_RE.findall(line)
-                    )
-                    service = None
-                    continue
-                line = line.split("{", 1)[1]
-            else:
-                continue
-        else:
-            depth += line.count("{") - line.count("}")
+    for match in _PROTO_SERVICE_RE.finditer(code):
+        service = match.group(1)
+        body = _block_body(code, match.end() - 1)
         operations.extend(
             ContractOperation(service, name, None, None, path)
-            for name in _PROTO_RPC_RE.findall(line)
+            for name in _PROTO_RPC_RE.findall(body)
         )
-        if depth <= 0:
-            service = None
     return operations
+
+
+def _block_body(code: str, brace_index: int) -> str:
+    # The text between the service's braces, so an rpc declared after the
+    # block (or in a later one) is never attributed to this service.
+    depth = 0
+    for index in range(brace_index, len(code)):
+        if code[index] == "{":
+            depth += 1
+        elif code[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return code[brace_index + 1 : index]
+    return code[brace_index + 1 :]

--- a/codebase_rag/parsers/io_access/constants.py
+++ b/codebase_rag/parsers/io_access/constants.py
@@ -33,6 +33,10 @@ class ResourceKind(StrEnum):
     # workflow handlers registered under a string key meet their producers
     # at one shared node keyed by that string.
     DISPATCH = "DISPATCH"
+    # An operation a contract file declares (issue #912, phase 2): the
+    # canonical node every generated artefact of that operation resolves to,
+    # keyed `<contract>.<operation>`.
+    CONTRACT = "CONTRACT"
 
 
 # Dispatch registrar decorators (`@flow(name=...)`, `@task`) and the producer

--- a/codebase_rag/tests/test_contract_linking.py
+++ b/codebase_rag/tests/test_contract_linking.py
@@ -10,6 +10,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+from codebase_rag import constants as cs
 from codebase_rag.parsers.contract_linking import link_contracts
 from codebase_rag.types_defs import PropertyDict, PropertyValue, ResultRow
 
@@ -39,6 +40,7 @@ class _FakeIngestor:
         self.nodes: list[tuple[str, PropertyDict]] = []
         self.rels: list[tuple[PropertyValue, str, PropertyValue]] = []
         self.writes: list[str] = []
+        self.writes_with_params: list[tuple[str, PropertyDict | None]] = []
 
     def fetch_all(
         self, query: str, params: PropertyDict | None = None
@@ -58,6 +60,7 @@ class _FakeIngestor:
 
     def execute_write(self, query: str, params: PropertyDict | None = None) -> None:
         self.writes.append(query)
+        self.writes_with_params.append((query, params))
 
     def ensure_node_batch(self, label: str, properties: PropertyDict) -> None:
         self.nodes.append((str(label), properties))
@@ -147,7 +150,7 @@ class TestRpcAnchoring:
         link_contracts(ingestor, _repo(tmp_path), project_name="proj")
         assert (
             "resource::RPC::ThingService.CreateThing",
-            "resource::CONTRACT::ThingService.CreateThing",
+            "resource::CONTRACT::proj::ThingService.CreateThing",
         ) in _links(ingestor)
 
     def test_an_rpc_no_local_code_touches_stays_unlinked(self, tmp_path: Path) -> None:
@@ -173,7 +176,7 @@ class TestEndpointAnchoring:
         link_contracts(ingestor, _repo(tmp_path), project_name="proj")
         assert (
             "resource::ENDPOINT::proj::POST /v2/things",
-            "resource::CONTRACT::schemas/things.createThing",
+            "resource::CONTRACT::proj::schemas/things.createThing",
         ) in _links(ingestor)
 
     def test_path_parameter_spelling_does_not_matter(self, tmp_path: Path) -> None:
@@ -182,7 +185,7 @@ class TestEndpointAnchoring:
         link_contracts(ingestor, _repo(tmp_path), project_name="proj")
         assert (
             "resource::ENDPOINT::proj::GET /v2/things/:thingId",
-            "resource::CONTRACT::schemas/things.getThing",
+            "resource::CONTRACT::proj::schemas/things.getThing",
         ) in _links(ingestor)
 
     def test_unknown_mount_lead_still_anchors(self, tmp_path: Path) -> None:
@@ -192,7 +195,7 @@ class TestEndpointAnchoring:
         link_contracts(ingestor, _repo(tmp_path), project_name="proj")
         assert (
             "resource::ENDPOINT::proj::POST /**/v2/things",
-            "resource::CONTRACT::schemas/things.createThing",
+            "resource::CONTRACT::proj::schemas/things.createThing",
         ) in _links(ingestor)
 
     def test_method_must_match(self, tmp_path: Path) -> None:
@@ -214,7 +217,7 @@ class TestEndpointAnchoring:
         link_contracts(ingestor, _repo(tmp_path), project_name="proj")
         assert (
             "resource::ENDPOINT::proj::ANY /v2/things",
-            "resource::CONTRACT::schemas/things.createThing",
+            "resource::CONTRACT::proj::schemas/things.createThing",
         ) in _links(ingestor)
 
 
@@ -251,6 +254,30 @@ class TestLinkBounds:
         ingestor = _ingestor(endpoints=[_endpoint_row("GET /**")])
         link_contracts(ingestor, _repo(tmp_path), project_name="proj")
         assert not _links(ingestor)
+
+
+class TestProjectIsolation:
+    def test_contract_identities_are_project_scoped(self, tmp_path: Path) -> None:
+        # Two repositories can hold the same spec at the same relative path;
+        # merging their operations into one node would attribute each
+        # project's implementations to the other, and the relink sweep of
+        # either would delete the other's links.
+        ingestor = _ingestor()
+        link_contracts(ingestor, _repo(tmp_path), project_name="proj")
+        names = {str(props[cs.KEY_QUALIFIED_NAME]) for _label, props in ingestor.nodes}
+        assert all("::proj::" in name for name in names), names
+
+    def test_cleanup_stops_at_the_repository_root(self, tmp_path: Path) -> None:
+        # `/work/api` must not claim `/work/api-backup`: an unbounded prefix
+        # would delete the sibling repository's contract anchors.
+        ingestor = _ingestor()
+        link_contracts(ingestor, _repo(tmp_path), project_name="proj")
+        prefixes = [
+            params["repo_prefix"]
+            for query, params in ingestor.writes_with_params
+            if "repo_prefix" in (params or {})
+        ]
+        assert prefixes and all(p.endswith("/") for p in prefixes), prefixes
 
 
 class TestCaptureGate:

--- a/codebase_rag/tests/test_contract_linking.py
+++ b/codebase_rag/tests/test_contract_linking.py
@@ -45,6 +45,9 @@ class _FakeIngestor:
     ) -> list[ResultRow]:
         for marker, rows in self._rows.items():
             if marker in query:
+                if "$project_prefix" in query and params is not None:
+                    prefix = str(params["project_prefix"])
+                    return [r for r in rows if f"{r.get('project')}." == prefix]
                 if "$project" in query and params is not None:
                     return [r for r in rows if r.get("project") == params["project"]]
                 return rows
@@ -108,8 +111,12 @@ def _endpoint_row(name: str) -> dict[str, Any]:
     }
 
 
-def _rpc_row(name: str) -> dict[str, Any]:
-    return {"qualified_name": f"resource::RPC::{name}", "name": name}
+def _rpc_row(name: str, project: str = "proj") -> dict[str, Any]:
+    return {
+        "qualified_name": f"resource::RPC::{name}",
+        "name": name,
+        "project": project,
+    }
 
 
 def _links(ingestor: _FakeIngestor) -> set[tuple[PropertyValue, PropertyValue]]:
@@ -142,6 +149,17 @@ class TestRpcAnchoring:
             "resource::RPC::ThingService.CreateThing",
             "resource::CONTRACT::ThingService.CreateThing",
         ) in _links(ingestor)
+
+    def test_an_rpc_no_local_code_touches_stays_unlinked(self, tmp_path: Path) -> None:
+        # RPC resources are deliberately unscoped so a client in one project
+        # meets a server in another; a same-named service in an UNRELATED
+        # project must not be reported as this contract's implementation, so
+        # only an RPC this project's own code participates in anchors.
+        ingestor = _ingestor(
+            rpcs=[_rpc_row("ThingService.CreateThing", project="elsewhere")]
+        )
+        link_contracts(ingestor, _repo(tmp_path), project_name="proj")
+        assert not _links(ingestor)
 
     def test_undeclared_rpc_resource_stays_unlinked(self, tmp_path: Path) -> None:
         ingestor = _ingestor(rpcs=[_rpc_row("OtherService.Ping")])
@@ -263,6 +281,16 @@ class TestSweepOwnership:
         ingestor = _FakeIngestor({"'ENDPOINT'": [], "'RPC'": [], "(f:File)": []})
         assert link_contracts(ingestor, _repo(tmp_path), project_name="proj") == 0
         assert not ingestor.nodes
+
+    def test_a_file_that_stopped_declaring_operations_is_cleared(
+        self, tmp_path: Path
+    ) -> None:
+        # An indexed spec edited to declare nothing leaves its File node
+        # anchoring the operations it no longer has; the declarations of
+        # every contract file in the repo are cleared before re-emission.
+        ingestor = _ingestor()
+        link_contracts(ingestor, tmp_path, project_name="proj")
+        assert any("EXPOSES" in query for query in ingestor.writes), ingestor.writes
 
     def test_no_contract_files_writes_nothing(self, tmp_path: Path) -> None:
         ingestor = _ingestor(endpoints=[_endpoint_row("POST /v2/things")])

--- a/codebase_rag/tests/test_contract_linking.py
+++ b/codebase_rag/tests/test_contract_linking.py
@@ -45,6 +45,8 @@ class _FakeIngestor:
     ) -> list[ResultRow]:
         for marker, rows in self._rows.items():
             if marker in query:
+                if "$project" in query and params is not None:
+                    return [r for r in rows if r.get("project") == params["project"]]
                 return rows
         if "(f:File)" in query and params is not None:
             # Default: every contract file this repo declares is indexed.
@@ -70,9 +72,21 @@ class _FakeIngestor:
         return None
 
 
-def _repo(tmp_path: Path) -> Path:
+_SPEC_WITH_SIBLINGS = json.dumps(
+    {
+        "openapi": "3.0.0",
+        "paths": {
+            "/v2/things/{thingId}": {"get": {"operationId": "getThing"}},
+            "/v2/things/count": {"get": {"operationId": "countThings"}},
+        },
+    }
+)
+
+
+def _repo(tmp_path: Path, extra_paths: bool = False) -> Path:
     (tmp_path / "schemas").mkdir()
-    (tmp_path / "schemas/things.json").write_text(_SPEC, encoding="utf-8")
+    spec = _SPEC_WITH_SIBLINGS if extra_paths else _SPEC
+    (tmp_path / "schemas/things.json").write_text(spec, encoding="utf-8")
     (tmp_path / "schemas/things.proto").write_text(_PROTO, encoding="utf-8")
     return tmp_path
 
@@ -87,7 +101,11 @@ def _ingestor(**rows: list[dict[str, Any]]) -> _FakeIngestor:
 
 
 def _endpoint_row(name: str) -> dict[str, Any]:
-    return {"qualified_name": f"resource::ENDPOINT::proj::{name}", "name": name}
+    return {
+        "qualified_name": f"resource::ENDPOINT::proj::{name}",
+        "name": name,
+        "project": "proj",
+    }
 
 
 def _rpc_row(name: str) -> dict[str, Any]:
@@ -101,25 +119,25 @@ def _links(ingestor: _FakeIngestor) -> set[tuple[PropertyValue, PropertyValue]]:
 class TestContractNodes:
     def test_every_operation_becomes_a_resource(self, tmp_path: Path) -> None:
         ingestor = _ingestor()
-        link_contracts(ingestor, _repo(tmp_path))
+        link_contracts(ingestor, _repo(tmp_path), project_name="proj")
         names = {str(props["name"]) for _label, props in ingestor.nodes}
         assert names == {
-            "things.createThing",
-            "things.getThing",
-            "things.unservedThing",
+            "schemas/things.createThing",
+            "schemas/things.getThing",
+            "schemas/things.unservedThing",
             "ThingService.CreateThing",
         }
 
     def test_nodes_carry_the_contract_kind(self, tmp_path: Path) -> None:
         ingestor = _ingestor()
-        link_contracts(ingestor, _repo(tmp_path))
+        link_contracts(ingestor, _repo(tmp_path), project_name="proj")
         assert {str(props["kind"]) for _label, props in ingestor.nodes} == {"CONTRACT"}
 
 
 class TestRpcAnchoring:
     def test_rpc_resource_resolves_to_its_contract(self, tmp_path: Path) -> None:
         ingestor = _ingestor(rpcs=[_rpc_row("ThingService.CreateThing")])
-        link_contracts(ingestor, _repo(tmp_path))
+        link_contracts(ingestor, _repo(tmp_path), project_name="proj")
         assert (
             "resource::RPC::ThingService.CreateThing",
             "resource::CONTRACT::ThingService.CreateThing",
@@ -127,48 +145,46 @@ class TestRpcAnchoring:
 
     def test_undeclared_rpc_resource_stays_unlinked(self, tmp_path: Path) -> None:
         ingestor = _ingestor(rpcs=[_rpc_row("OtherService.Ping")])
-        link_contracts(ingestor, _repo(tmp_path))
+        link_contracts(ingestor, _repo(tmp_path), project_name="proj")
         assert not _links(ingestor)
 
 
 class TestEndpointAnchoring:
-    def test_endpoint_resolves_to_the_operation_it_serves(
-        self, tmp_path: Path
-    ) -> None:
+    def test_endpoint_resolves_to_the_operation_it_serves(self, tmp_path: Path) -> None:
         ingestor = _ingestor(endpoints=[_endpoint_row("POST /v2/things")])
-        link_contracts(ingestor, _repo(tmp_path))
+        link_contracts(ingestor, _repo(tmp_path), project_name="proj")
         assert (
             "resource::ENDPOINT::proj::POST /v2/things",
-            "resource::CONTRACT::things.createThing",
+            "resource::CONTRACT::schemas/things.createThing",
         ) in _links(ingestor)
 
     def test_path_parameter_spelling_does_not_matter(self, tmp_path: Path) -> None:
         # The server registers `:thingId`, the spec declares `{thingId}`.
         ingestor = _ingestor(endpoints=[_endpoint_row("GET /v2/things/:thingId")])
-        link_contracts(ingestor, _repo(tmp_path))
+        link_contracts(ingestor, _repo(tmp_path), project_name="proj")
         assert (
             "resource::ENDPOINT::proj::GET /v2/things/:thingId",
-            "resource::CONTRACT::things.getThing",
+            "resource::CONTRACT::schemas/things.getThing",
         ) in _links(ingestor)
 
     def test_unknown_mount_lead_still_anchors(self, tmp_path: Path) -> None:
         # A generated registration whose mount prefix could not be resolved
         # carries the unknown lead; the operation it serves is still known.
         ingestor = _ingestor(endpoints=[_endpoint_row("POST /**/v2/things")])
-        link_contracts(ingestor, _repo(tmp_path))
+        link_contracts(ingestor, _repo(tmp_path), project_name="proj")
         assert (
             "resource::ENDPOINT::proj::POST /**/v2/things",
-            "resource::CONTRACT::things.createThing",
+            "resource::CONTRACT::schemas/things.createThing",
         ) in _links(ingestor)
 
     def test_method_must_match(self, tmp_path: Path) -> None:
         ingestor = _ingestor(endpoints=[_endpoint_row("DELETE /v2/things")])
-        link_contracts(ingestor, _repo(tmp_path))
+        link_contracts(ingestor, _repo(tmp_path), project_name="proj")
         assert not _links(ingestor)
 
     def test_unrelated_path_does_not_anchor(self, tmp_path: Path) -> None:
         ingestor = _ingestor(endpoints=[_endpoint_row("POST /v2/other")])
-        link_contracts(ingestor, _repo(tmp_path))
+        link_contracts(ingestor, _repo(tmp_path), project_name="proj")
         assert not _links(ingestor)
 
     def test_method_agnostic_endpoint_anchors_every_method_of_its_path(
@@ -177,11 +193,58 @@ class TestEndpointAnchoring:
         # `http.HandleFunc("/v2/things", h)` registers ANY; it serves whatever
         # the contract declares at that path.
         ingestor = _ingestor(endpoints=[_endpoint_row("ANY /v2/things")])
-        link_contracts(ingestor, _repo(tmp_path))
+        link_contracts(ingestor, _repo(tmp_path), project_name="proj")
         assert (
             "resource::ENDPOINT::proj::ANY /v2/things",
-            "resource::CONTRACT::things.createThing",
+            "resource::CONTRACT::schemas/things.createThing",
         ) in _links(ingestor)
+
+
+class TestLinkBounds:
+    def test_only_this_projects_endpoints_anchor(self, tmp_path: Path) -> None:
+        # ENDPOINT nodes are project-scoped on purpose; another service in
+        # the shared graph registering the same verb and path is not an
+        # implementation of THIS repo's contract.
+        ingestor = _ingestor(
+            endpoints=[
+                {
+                    "qualified_name": "resource::ENDPOINT::other::POST /v2/things",
+                    "name": "POST /v2/things",
+                    "project": "other",
+                }
+            ]
+        )
+        link_contracts(ingestor, _repo(tmp_path), project_name="proj")
+        assert not _links(ingestor)
+
+    def test_an_endpoint_matching_several_operations_anchors_none(
+        self, tmp_path: Path
+    ) -> None:
+        # A parameter segment swallows its literal siblings, so `GET /v2/x/:id`
+        # matches every operation under that path; picking one would be a
+        # guess and linking all of them is noise.
+        ingestor = _ingestor(endpoints=[_endpoint_row("GET /v2/things/:id")])
+        link_contracts(ingestor, _repo(tmp_path, extra_paths=True), project_name="proj")
+        assert not _links(ingestor)
+
+    def test_a_lead_only_template_anchors_nothing(self, tmp_path: Path) -> None:
+        # `/**` alone is a route whose whole path is unknown; it would match
+        # every operation in the spec.
+        ingestor = _ingestor(endpoints=[_endpoint_row("GET /**")])
+        link_contracts(ingestor, _repo(tmp_path), project_name="proj")
+        assert not _links(ingestor)
+
+
+class TestCaptureGate:
+    def test_a_sink_that_drops_exposes_receives_no_contract_nodes(
+        self, tmp_path: Path
+    ) -> None:
+        # Selective capture must not leave a Resource whose anchoring edge
+        # was filtered out.
+        ingestor = _ingestor()
+        ingestor.rel_enabled = lambda rel: str(rel) != "EXPOSES"  # type: ignore[attr-defined]
+        assert link_contracts(ingestor, _repo(tmp_path), project_name="proj") == 0
+        assert not ingestor.nodes
 
 
 class TestSweepOwnership:
@@ -189,7 +252,7 @@ class TestSweepOwnership:
         # RESOLVES_TO has other owners (URL to endpoint, dispatch suffix);
         # relinking contracts must not touch them.
         ingestor = _ingestor()
-        link_contracts(ingestor, _repo(tmp_path))
+        link_contracts(ingestor, _repo(tmp_path), project_name="proj")
         assert ingestor.writes
         assert all("'CONTRACT'" in query for query in ingestor.writes), ingestor.writes
 
@@ -198,10 +261,10 @@ class TestSweepOwnership:
         # and claiming otherwise would hang them off a File node that does
         # not exist.
         ingestor = _FakeIngestor({"'ENDPOINT'": [], "'RPC'": [], "(f:File)": []})
-        assert link_contracts(ingestor, _repo(tmp_path)) == 0
+        assert link_contracts(ingestor, _repo(tmp_path), project_name="proj") == 0
         assert not ingestor.nodes
 
     def test_no_contract_files_writes_nothing(self, tmp_path: Path) -> None:
         ingestor = _ingestor(endpoints=[_endpoint_row("POST /v2/things")])
-        assert link_contracts(ingestor, tmp_path) == 0
+        assert link_contracts(ingestor, tmp_path, project_name="proj") == 0
         assert not ingestor.nodes

--- a/codebase_rag/tests/test_contract_linking.py
+++ b/codebase_rag/tests/test_contract_linking.py
@@ -26,6 +26,14 @@ _SPEC = json.dumps(
 )
 _PROTO = (
     'syntax = "proto3";\n\n'
+    "package things.v1;\n\n"
+    "service ThingService {\n"
+    "    rpc CreateThing(Req) returns (Res) {}\n"
+    "}\n"
+)
+_PROTO_TWIN = (
+    'syntax = "proto3";\n\n'
+    "package other.v1;\n\n"
     "service ThingService {\n"
     "    rpc CreateThing(Req) returns (Res) {}\n"
     "}\n"
@@ -142,7 +150,7 @@ class TestContractNodes:
             "schemas/things.createThing",
             "schemas/things.getThing",
             "schemas/things.unservedThing",
-            "ThingService.CreateThing",
+            "things.v1.ThingService.CreateThing",
         }
 
     def test_nodes_carry_the_contract_kind(self, tmp_path: Path) -> None:
@@ -157,7 +165,7 @@ class TestRpcAnchoring:
         link_contracts(ingestor, _repo(tmp_path), project_name="proj")
         assert (
             "resource::RPC::ThingService.CreateThing",
-            "resource::CONTRACT::proj::ThingService.CreateThing",
+            "resource::CONTRACT::proj::things.v1.ThingService.CreateThing",
         ) in _links(ingestor)
 
     def test_an_rpc_no_local_code_touches_stays_unlinked(self, tmp_path: Path) -> None:
@@ -182,6 +190,30 @@ class TestRpcAnchoring:
             rpcs=[_rpc_row("ThingService.CreateThing", project="projector")]
         )
         link_contracts(ingestor, _repo(tmp_path), project_name="proj")
+        assert not _links(ingestor)
+
+    def test_two_packages_declaring_one_service_stay_distinct(
+        self, tmp_path: Path
+    ) -> None:
+        # Same service name in two protobuf packages is two services; one
+        # node for both would report either package's implementation as the
+        # other's.
+        ingestor = _ingestor()
+        repo = _repo(tmp_path)
+        (repo / "schemas/twin.proto").write_text(_PROTO_TWIN, encoding="utf-8")
+        link_contracts(ingestor, repo, project_name="proj")
+        names = {str(props[cs.KEY_NAME]) for _label, props in ingestor.nodes}
+        assert "things.v1.ThingService.CreateThing" in names, names
+        assert "other.v1.ThingService.CreateThing" in names, names
+
+    def test_an_ambiguous_service_name_anchors_nothing(self, tmp_path: Path) -> None:
+        # The RPC resource is keyed by the bare `Service.Method` the codegen
+        # produced, so when two packages declare it, which contract it
+        # implements is unknowable and neither is claimed.
+        ingestor = _ingestor(rpcs=[_rpc_row("ThingService.CreateThing")])
+        repo = _repo(tmp_path)
+        (repo / "schemas/twin.proto").write_text(_PROTO_TWIN, encoding="utf-8")
+        link_contracts(ingestor, repo, project_name="proj")
         assert not _links(ingestor)
 
     def test_undeclared_rpc_resource_stays_unlinked(self, tmp_path: Path) -> None:

--- a/codebase_rag/tests/test_contract_linking.py
+++ b/codebase_rag/tests/test_contract_linking.py
@@ -312,11 +312,19 @@ class TestSweepOwnership:
     def test_a_file_that_stopped_declaring_operations_is_cleared(
         self, tmp_path: Path
     ) -> None:
-        # An indexed spec edited to declare nothing leaves its File node
-        # anchoring the operations it no longer has; the declarations of
-        # every contract file in the repo are cleared before re-emission.
+        # The real transition: a repo that declared operations has its specs
+        # emptied, and the relink must still clear what those files declared,
+        # or their File nodes keep anchoring operations that are gone.
         ingestor = _ingestor()
-        link_contracts(ingestor, tmp_path, project_name="proj")
+        repo = _repo(tmp_path)
+        link_contracts(ingestor, repo, project_name="proj")
+        assert ingestor.nodes
+        (repo / "schemas/things.json").write_text("{}", encoding="utf-8")
+        (repo / "schemas/things.proto").write_text("", encoding="utf-8")
+        ingestor.nodes.clear()
+        ingestor.writes.clear()
+        assert link_contracts(ingestor, repo, project_name="proj") == 0
+        assert not ingestor.nodes
         assert any("EXPOSES" in query for query in ingestor.writes), ingestor.writes
 
     def test_no_contract_files_writes_nothing(self, tmp_path: Path) -> None:

--- a/codebase_rag/tests/test_contract_linking.py
+++ b/codebase_rag/tests/test_contract_linking.py
@@ -46,6 +46,9 @@ class _FakeIngestor:
         for marker, rows in self._rows.items():
             if marker in query:
                 return rows
+        if "(f:File)" in query and params is not None:
+            # Default: every contract file this repo declares is indexed.
+            return [{"absolute_path": path} for path in params["paths"]]
         return []
 
     def execute_write(self, query: str, params: PropertyDict | None = None) -> None:
@@ -189,6 +192,14 @@ class TestSweepOwnership:
         link_contracts(ingestor, _repo(tmp_path))
         assert ingestor.writes
         assert all("'CONTRACT'" in query for query in ingestor.writes), ingestor.writes
+
+    def test_unindexed_contract_file_declares_nothing(self, tmp_path: Path) -> None:
+        # A contract the graph does not hold cannot anchor its operations,
+        # and claiming otherwise would hang them off a File node that does
+        # not exist.
+        ingestor = _FakeIngestor({"'ENDPOINT'": [], "'RPC'": [], "(f:File)": []})
+        assert link_contracts(ingestor, _repo(tmp_path)) == 0
+        assert not ingestor.nodes
 
     def test_no_contract_files_writes_nothing(self, tmp_path: Path) -> None:
         ingestor = _ingestor(endpoints=[_endpoint_row("POST /v2/things")])

--- a/codebase_rag/tests/test_contract_linking.py
+++ b/codebase_rag/tests/test_contract_linking.py
@@ -1,0 +1,196 @@
+# Every artefact of one contract operation meets at one CONTRACT resource
+# (issue #912, phase 2): the RPC node a generated client and server already
+# share, and the ENDPOINT the generated server registers. The join key is the
+# contract's own name for the operation, so it holds even where no URL
+# literal exists on the client side and where the two sides disagree on the
+# path they use.
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from codebase_rag.parsers.contract_linking import link_contracts
+from codebase_rag.types_defs import PropertyDict, PropertyValue, ResultRow
+
+_SPEC = json.dumps(
+    {
+        "openapi": "3.0.0",
+        "paths": {
+            "/v2/things": {"post": {"operationId": "createThing"}},
+            "/v2/things/{thingId}": {"get": {"operationId": "getThing"}},
+            "/v2/unserved": {"get": {"operationId": "unservedThing"}},
+        },
+    }
+)
+_PROTO = (
+    'syntax = "proto3";\n\n'
+    "service ThingService {\n"
+    "    rpc CreateThing(Req) returns (Res) {}\n"
+    "}\n"
+)
+
+
+class _FakeIngestor:
+    """Serves the live-resource queries and records what was written."""
+
+    def __init__(self, rows: dict[str, list[ResultRow]]) -> None:
+        self._rows = rows
+        self.nodes: list[tuple[str, PropertyDict]] = []
+        self.rels: list[tuple[PropertyValue, str, PropertyValue]] = []
+        self.writes: list[str] = []
+
+    def fetch_all(
+        self, query: str, params: PropertyDict | None = None
+    ) -> list[ResultRow]:
+        for marker, rows in self._rows.items():
+            if marker in query:
+                return rows
+        return []
+
+    def execute_write(self, query: str, params: PropertyDict | None = None) -> None:
+        self.writes.append(query)
+
+    def ensure_node_batch(self, label: str, properties: PropertyDict) -> None:
+        self.nodes.append((str(label), properties))
+
+    def ensure_relationship_batch(
+        self,
+        from_spec: tuple[str, str, PropertyValue],
+        rel_type: str,
+        to_spec: tuple[str, str, PropertyValue],
+        properties: PropertyDict | None = None,
+    ) -> None:
+        self.rels.append((from_spec[2], str(rel_type), to_spec[2]))
+
+    def flush_all(self) -> None:
+        return None
+
+
+def _repo(tmp_path: Path) -> Path:
+    (tmp_path / "schemas").mkdir()
+    (tmp_path / "schemas/things.json").write_text(_SPEC, encoding="utf-8")
+    (tmp_path / "schemas/things.proto").write_text(_PROTO, encoding="utf-8")
+    return tmp_path
+
+
+def _ingestor(**rows: list[dict[str, Any]]) -> _FakeIngestor:
+    return _FakeIngestor(
+        {
+            "'ENDPOINT'": rows.get("endpoints", []),
+            "'RPC'": rows.get("rpcs", []),
+        }
+    )
+
+
+def _endpoint_row(name: str) -> dict[str, Any]:
+    return {"qualified_name": f"resource::ENDPOINT::proj::{name}", "name": name}
+
+
+def _rpc_row(name: str) -> dict[str, Any]:
+    return {"qualified_name": f"resource::RPC::{name}", "name": name}
+
+
+def _links(ingestor: _FakeIngestor) -> set[tuple[PropertyValue, PropertyValue]]:
+    return {(src, dst) for src, rel, dst in ingestor.rels if rel == "RESOLVES_TO"}
+
+
+class TestContractNodes:
+    def test_every_operation_becomes_a_resource(self, tmp_path: Path) -> None:
+        ingestor = _ingestor()
+        link_contracts(ingestor, _repo(tmp_path))
+        names = {str(props["name"]) for _label, props in ingestor.nodes}
+        assert names == {
+            "things.createThing",
+            "things.getThing",
+            "things.unservedThing",
+            "ThingService.CreateThing",
+        }
+
+    def test_nodes_carry_the_contract_kind(self, tmp_path: Path) -> None:
+        ingestor = _ingestor()
+        link_contracts(ingestor, _repo(tmp_path))
+        assert {str(props["kind"]) for _label, props in ingestor.nodes} == {"CONTRACT"}
+
+
+class TestRpcAnchoring:
+    def test_rpc_resource_resolves_to_its_contract(self, tmp_path: Path) -> None:
+        ingestor = _ingestor(rpcs=[_rpc_row("ThingService.CreateThing")])
+        link_contracts(ingestor, _repo(tmp_path))
+        assert (
+            "resource::RPC::ThingService.CreateThing",
+            "resource::CONTRACT::ThingService.CreateThing",
+        ) in _links(ingestor)
+
+    def test_undeclared_rpc_resource_stays_unlinked(self, tmp_path: Path) -> None:
+        ingestor = _ingestor(rpcs=[_rpc_row("OtherService.Ping")])
+        link_contracts(ingestor, _repo(tmp_path))
+        assert not _links(ingestor)
+
+
+class TestEndpointAnchoring:
+    def test_endpoint_resolves_to_the_operation_it_serves(
+        self, tmp_path: Path
+    ) -> None:
+        ingestor = _ingestor(endpoints=[_endpoint_row("POST /v2/things")])
+        link_contracts(ingestor, _repo(tmp_path))
+        assert (
+            "resource::ENDPOINT::proj::POST /v2/things",
+            "resource::CONTRACT::things.createThing",
+        ) in _links(ingestor)
+
+    def test_path_parameter_spelling_does_not_matter(self, tmp_path: Path) -> None:
+        # The server registers `:thingId`, the spec declares `{thingId}`.
+        ingestor = _ingestor(endpoints=[_endpoint_row("GET /v2/things/:thingId")])
+        link_contracts(ingestor, _repo(tmp_path))
+        assert (
+            "resource::ENDPOINT::proj::GET /v2/things/:thingId",
+            "resource::CONTRACT::things.getThing",
+        ) in _links(ingestor)
+
+    def test_unknown_mount_lead_still_anchors(self, tmp_path: Path) -> None:
+        # A generated registration whose mount prefix could not be resolved
+        # carries the unknown lead; the operation it serves is still known.
+        ingestor = _ingestor(endpoints=[_endpoint_row("POST /**/v2/things")])
+        link_contracts(ingestor, _repo(tmp_path))
+        assert (
+            "resource::ENDPOINT::proj::POST /**/v2/things",
+            "resource::CONTRACT::things.createThing",
+        ) in _links(ingestor)
+
+    def test_method_must_match(self, tmp_path: Path) -> None:
+        ingestor = _ingestor(endpoints=[_endpoint_row("DELETE /v2/things")])
+        link_contracts(ingestor, _repo(tmp_path))
+        assert not _links(ingestor)
+
+    def test_unrelated_path_does_not_anchor(self, tmp_path: Path) -> None:
+        ingestor = _ingestor(endpoints=[_endpoint_row("POST /v2/other")])
+        link_contracts(ingestor, _repo(tmp_path))
+        assert not _links(ingestor)
+
+    def test_method_agnostic_endpoint_anchors_every_method_of_its_path(
+        self, tmp_path: Path
+    ) -> None:
+        # `http.HandleFunc("/v2/things", h)` registers ANY; it serves whatever
+        # the contract declares at that path.
+        ingestor = _ingestor(endpoints=[_endpoint_row("ANY /v2/things")])
+        link_contracts(ingestor, _repo(tmp_path))
+        assert (
+            "resource::ENDPOINT::proj::ANY /v2/things",
+            "resource::CONTRACT::things.createThing",
+        ) in _links(ingestor)
+
+
+class TestSweepOwnership:
+    def test_the_sweep_is_scoped_to_contract_targets(self, tmp_path: Path) -> None:
+        # RESOLVES_TO has other owners (URL to endpoint, dispatch suffix);
+        # relinking contracts must not touch them.
+        ingestor = _ingestor()
+        link_contracts(ingestor, _repo(tmp_path))
+        assert ingestor.writes
+        assert all("'CONTRACT'" in query for query in ingestor.writes), ingestor.writes
+
+    def test_no_contract_files_writes_nothing(self, tmp_path: Path) -> None:
+        ingestor = _ingestor(endpoints=[_endpoint_row("POST /v2/things")])
+        assert link_contracts(ingestor, tmp_path) == 0
+        assert not ingestor.nodes

--- a/codebase_rag/tests/test_contract_linking.py
+++ b/codebase_rag/tests/test_contract_linking.py
@@ -46,13 +46,20 @@ class _FakeIngestor:
         self, query: str, params: PropertyDict | None = None
     ) -> list[ResultRow]:
         for marker, rows in self._rows.items():
-            if marker in query:
-                if "$project_prefix" in query and params is not None:
-                    prefix = str(params["project_prefix"])
-                    return [r for r in rows if f"{r.get('project')}." == prefix]
-                if "$project" in query and params is not None:
-                    return [r for r in rows if r.get("project") == params["project"]]
+            if marker not in query:
+                continue
+            if params is None:
                 return rows
+            # Model the query's own scoping: first-segment attribution for
+            # RPC rows, exact project match for endpoint rows.
+            if "head(split(" in query:
+                name = str(params["project_name"])
+                return [
+                    r for r in rows if str(r.get("project", "")).split(".")[0] == name
+                ]
+            if "r.project = $project" in query:
+                return [r for r in rows if r.get("project") == params["project"]]
+            return rows
         if "(f:File)" in query and params is not None:
             # Default: every contract file this repo declares is indexed.
             return [{"absolute_path": path} for path in params["paths"]]
@@ -160,6 +167,19 @@ class TestRpcAnchoring:
         # only an RPC this project's own code participates in anchors.
         ingestor = _ingestor(
             rpcs=[_rpc_row("ThingService.CreateThing", project="elsewhere")]
+        )
+        link_contracts(ingestor, _repo(tmp_path), project_name="proj")
+        assert not _links(ingestor)
+
+    def test_a_name_sharing_project_does_not_claim_the_rpc(
+        self, tmp_path: Path
+    ) -> None:
+        # `proj` and `projector` are different projects that share a name
+        # prefix; attribution is the qualified name's first SEGMENT, so the
+        # first cannot claim the second's participation in a globally shared
+        # RPC resource.
+        ingestor = _ingestor(
+            rpcs=[_rpc_row("ThingService.CreateThing", project="projector")]
         )
         link_contracts(ingestor, _repo(tmp_path), project_name="proj")
         assert not _links(ingestor)

--- a/codebase_rag/tests/test_contract_operations.py
+++ b/codebase_rag/tests/test_contract_operations.py
@@ -6,8 +6,11 @@
 # graph resolve into it.
 from __future__ import annotations
 
+import importlib.util
 import json
 from pathlib import Path
+
+import pytest
 
 from codebase_rag.parsers.contracts import (
     ContractOperation,
@@ -30,7 +33,7 @@ _OPENAPI = {
 }
 
 _PROTO = (
-    "syntax = \"proto3\";\n\n"
+    'syntax = "proto3";\n\n'
     "package things.v1;\n\n"
     "// Interface exported by the server.\n"
     "service ThingService {\n"
@@ -54,17 +57,21 @@ class TestOpenApiDiscovery:
         _write(tmp_path, {"schemas/things.json": json.dumps(_OPENAPI)})
         spec = tmp_path / "schemas/things.json"
         assert set(discover_contract_operations(tmp_path)) == {
-            ContractOperation("things", "createThing", "POST", "/v2/things", spec),
-            ContractOperation("things", "listThings", "GET", "/v2/things", spec),
             ContractOperation(
-                "things", "getThing", "GET", "/v2/things/{thingId}", spec
+                "schemas/things", "createThing", "POST", "/v2/things", spec
+            ),
+            ContractOperation(
+                "schemas/things", "listThings", "GET", "/v2/things", spec
+            ),
+            ContractOperation(
+                "schemas/things", "getThing", "GET", "/v2/things/{thingId}", spec
             ),
         }
 
     def test_yaml_spec_is_read_when_yaml_is_available(self, tmp_path: Path) -> None:
-        yaml = __import__("importlib").util.find_spec("yaml")
-        if yaml is None:
-            return
+        # A silent `return` here would make a missing PyYAML look green.
+        if importlib.util.find_spec("yaml") is None:
+            pytest.skip("PyYAML is not installed")
         _write(
             tmp_path,
             {
@@ -79,7 +86,7 @@ class TestOpenApiDiscovery:
         )
         assert discover_contract_operations(tmp_path) == [
             ContractOperation(
-                "things",
+                "schemas/things",
                 "createThing",
                 "POST",
                 "/v2/things",
@@ -107,6 +114,145 @@ class TestOpenApiDiscovery:
     def test_ignored_directories_are_not_scanned(self, tmp_path: Path) -> None:
         _write(tmp_path, {"node_modules/pkg/openapi.json": json.dumps(_OPENAPI)})
         assert discover_contract_operations(tmp_path) == []
+
+
+class TestDiscoveryRobustness:
+    def test_an_rpc_and_an_operation_of_the_same_name_do_not_crash(
+        self, tmp_path: Path
+    ) -> None:
+        # Sorting tuples whose method/path are None for rpcs and strings for
+        # HTTP compares None with str the moment two identities collide, and
+        # this pass runs at the very end of an index run.
+        _write(
+            tmp_path,
+            {
+                "Foo.proto": "service Foo {\n    rpc Bar(A) returns (B);\n}\n",
+                "Foo.json": json.dumps(
+                    {
+                        "openapi": "3.0.0",
+                        "paths": {"/bar": {"get": {"operationId": "Bar"}}},
+                    }
+                ),
+            },
+        )
+        assert len(discover_contract_operations(tmp_path)) == 2
+
+    def test_same_spec_filename_in_two_directories_stays_distinct(
+        self, tmp_path: Path
+    ) -> None:
+        # `openapi.json` is the conventional name, so the stem is not a
+        # namespace: two versions of one API would become one operation.
+        spec = {
+            "openapi": "3.0.0",
+            "paths": {"/things": {"get": {"operationId": "listThings"}}},
+        }
+        _write(
+            tmp_path,
+            {
+                "v1/openapi.json": json.dumps(spec),
+                "v2/openapi.json": json.dumps(spec),
+            },
+        )
+        contracts = {op.contract for op in discover_contract_operations(tmp_path)}
+        assert len(contracts) == 2, contracts
+
+    def test_base_path_is_part_of_the_operation_path(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            {
+                "swagger.json": json.dumps(
+                    {
+                        "swagger": "2.0",
+                        "basePath": "/api/v2",
+                        "paths": {"/things": {"get": {"operationId": "listThings"}}},
+                    }
+                )
+            },
+        )
+        assert [op.path for op in discover_contract_operations(tmp_path)] == [
+            "/api/v2/things"
+        ]
+
+    def test_server_path_prefix_is_part_of_the_operation_path(
+        self, tmp_path: Path
+    ) -> None:
+        _write(
+            tmp_path,
+            {
+                "openapi.json": json.dumps(
+                    {
+                        "openapi": "3.0.0",
+                        "servers": [
+                            {"url": "https://a.example.com/api/v2"},
+                            {"url": "https://b.example.com/api/v2"},
+                        ],
+                        "paths": {"/things": {"get": {"operationId": "listThings"}}},
+                    }
+                )
+            },
+        )
+        assert [op.path for op in discover_contract_operations(tmp_path)] == [
+            "/api/v2/things"
+        ]
+
+    def test_servers_that_disagree_contribute_no_prefix(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            {
+                "openapi.json": json.dumps(
+                    {
+                        "openapi": "3.0.0",
+                        "servers": [
+                            {"url": "https://a.example.com/api/v2"},
+                            {"url": "https://b.example.com/"},
+                        ],
+                        "paths": {"/things": {"get": {"operationId": "listThings"}}},
+                    }
+                )
+            },
+        )
+        assert [op.path for op in discover_contract_operations(tmp_path)] == ["/things"]
+
+
+class TestProtoRobustness:
+    def test_commented_out_service_declares_nothing(self, tmp_path: Path) -> None:
+        source = (
+            'syntax = "proto3";\n\n'
+            "/* service GhostService {\n"
+            "    rpc Ghost(A) returns (B);\n"
+            "} */\n"
+        )
+        _write(tmp_path, {"a.proto": source})
+        assert discover_contract_operations(tmp_path) == []
+
+    def test_rpc_inside_a_string_literal_is_not_an_operation(
+        self, tmp_path: Path
+    ) -> None:
+        source = (
+            "service S {\n"
+            '    option (foo) = "rpc Fake(X) returns (Y)";\n'
+            "    rpc Real(A) returns (B);\n"
+            "}\n"
+        )
+        _write(tmp_path, {"a.proto": source})
+        assert [op.operation for op in discover_contract_operations(tmp_path)] == [
+            "Real"
+        ]
+
+    def test_a_brace_inside_a_string_does_not_skew_the_block(
+        self, tmp_path: Path
+    ) -> None:
+        source = (
+            "service S {\n"
+            '    option (x) = "{";\n'
+            "    rpc Inside(A) returns (B);\n"
+            "}\n"
+            "rpc Outside(A) returns (B);\n"
+        )
+        _write(tmp_path, {"a.proto": source})
+        assert [op.operation for op in discover_contract_operations(tmp_path)] == [
+            "Inside"
+        ]
 
 
 class TestProtoDiscovery:

--- a/codebase_rag/tests/test_contract_operations.py
+++ b/codebase_rag/tests/test_contract_operations.py
@@ -52,10 +52,13 @@ def _write(tmp_path: Path, files: dict[str, str]) -> Path:
 class TestOpenApiDiscovery:
     def test_json_spec_yields_one_operation_per_method(self, tmp_path: Path) -> None:
         _write(tmp_path, {"schemas/things.json": json.dumps(_OPENAPI)})
+        spec = tmp_path / "schemas/things.json"
         assert set(discover_contract_operations(tmp_path)) == {
-            ContractOperation("things", "createThing", "POST", "/v2/things"),
-            ContractOperation("things", "listThings", "GET", "/v2/things"),
-            ContractOperation("things", "getThing", "GET", "/v2/things/{thingId}"),
+            ContractOperation("things", "createThing", "POST", "/v2/things", spec),
+            ContractOperation("things", "listThings", "GET", "/v2/things", spec),
+            ContractOperation(
+                "things", "getThing", "GET", "/v2/things/{thingId}", spec
+            ),
         }
 
     def test_yaml_spec_is_read_when_yaml_is_available(self, tmp_path: Path) -> None:
@@ -75,7 +78,13 @@ class TestOpenApiDiscovery:
             },
         )
         assert discover_contract_operations(tmp_path) == [
-            ContractOperation("things", "createThing", "POST", "/v2/things")
+            ContractOperation(
+                "things",
+                "createThing",
+                "POST",
+                "/v2/things",
+                tmp_path / "schemas/things.yaml",
+            )
         ]
 
     def test_operation_without_an_id_is_skipped(self, tmp_path: Path) -> None:
@@ -103,9 +112,10 @@ class TestOpenApiDiscovery:
 class TestProtoDiscovery:
     def test_service_rpcs_become_operations(self, tmp_path: Path) -> None:
         _write(tmp_path, {"schemas/proto/things/v1/things.proto": _PROTO})
+        proto = tmp_path / "schemas/proto/things/v1/things.proto"
         assert set(discover_contract_operations(tmp_path)) == {
-            ContractOperation("ThingService", "CreateThing", None, None),
-            ContractOperation("ThingService", "GetThing", None, None),
+            ContractOperation("ThingService", "CreateThing", None, None, proto),
+            ContractOperation("ThingService", "GetThing", None, None, proto),
         }
 
     def test_rpcs_outside_a_service_are_not_operations(self, tmp_path: Path) -> None:
@@ -129,8 +139,8 @@ class TestProtoDiscovery:
         )
         _write(tmp_path, {"a.proto": source})
         assert set(discover_contract_operations(tmp_path)) == {
-            ContractOperation("A", "Ping", None, None),
-            ContractOperation("B", "Ping", None, None),
+            ContractOperation("A", "Ping", None, None, tmp_path / "a.proto"),
+            ContractOperation("B", "Ping", None, None, tmp_path / "a.proto"),
         }
 
     def test_single_line_service_is_read(self, tmp_path: Path) -> None:
@@ -139,5 +149,5 @@ class TestProtoDiscovery:
             {"a.proto": "service S { rpc Do(D) returns (D); }\n"},
         )
         assert discover_contract_operations(tmp_path) == [
-            ContractOperation("S", "Do", None, None)
+            ContractOperation("S", "Do", None, None, tmp_path / "a.proto")
         ]

--- a/codebase_rag/tests/test_contract_operations.py
+++ b/codebase_rag/tests/test_contract_operations.py
@@ -260,8 +260,10 @@ class TestProtoDiscovery:
         _write(tmp_path, {"schemas/proto/things/v1/things.proto": _PROTO})
         proto = tmp_path / "schemas/proto/things/v1/things.proto"
         assert set(discover_contract_operations(tmp_path)) == {
-            ContractOperation("ThingService", "CreateThing", None, None, proto),
-            ContractOperation("ThingService", "GetThing", None, None, proto),
+            ContractOperation(
+                "things.v1.ThingService", "CreateThing", None, None, proto
+            ),
+            ContractOperation("things.v1.ThingService", "GetThing", None, None, proto),
         }
 
     def test_rpcs_outside_a_service_are_not_operations(self, tmp_path: Path) -> None:
@@ -276,6 +278,29 @@ class TestProtoDiscovery:
         )
         _write(tmp_path, {"a.proto": source})
         assert discover_contract_operations(tmp_path) == []
+
+    def test_the_package_qualifies_the_service(self, tmp_path: Path) -> None:
+        # protobuf identifies a service by `package.Service`, so two packages
+        # declaring `Health` are two different services.
+        _write(
+            tmp_path,
+            {
+                "a.proto": (
+                    'syntax = "proto3";\n'
+                    "package things.v1;\n"
+                    "service Health {\n    rpc Check(P) returns (P);\n}\n"
+                ),
+                "b.proto": (
+                    'syntax = "proto3";\n'
+                    "package users.v1;\n"
+                    "service Health {\n    rpc Check(P) returns (P);\n}\n"
+                ),
+            },
+        )
+        assert {op.contract for op in discover_contract_operations(tmp_path)} == {
+            "things.v1.Health",
+            "users.v1.Health",
+        }
 
     def test_multiple_services_stay_separate(self, tmp_path: Path) -> None:
         source = (

--- a/codebase_rag/tests/test_contract_operations.py
+++ b/codebase_rag/tests/test_contract_operations.py
@@ -1,0 +1,143 @@
+# Contract-file anchoring (issue #912, phase 2). In a contract-first repo the
+# client stub and the server handler are both GENERATED, share no symbol, and
+# often no URL literal either, so the only thing that names the operation both
+# sides implement is the contract: an OpenAPI `operationId` or a protobuf
+# `rpc`. Each becomes one CONTRACT resource, and the artefacts already in the
+# graph resolve into it.
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codebase_rag.parsers.contracts import (
+    ContractOperation,
+    discover_contract_operations,
+)
+
+_OPENAPI = {
+    "openapi": "3.0.0",
+    "info": {"title": "Things API", "version": "1.0.0"},
+    "paths": {
+        "/v2/things": {
+            "post": {"operationId": "createThing", "responses": {}},
+            "get": {"operationId": "listThings", "responses": {}},
+        },
+        "/v2/things/{thingId}": {
+            "get": {"operationId": "getThing", "responses": {}},
+            "parameters": [{"name": "thingId", "in": "path"}],
+        },
+    },
+}
+
+_PROTO = (
+    "syntax = \"proto3\";\n\n"
+    "package things.v1;\n\n"
+    "// Interface exported by the server.\n"
+    "service ThingService {\n"
+    "    rpc CreateThing(CreateThingRequest) returns (CreateThingResponse) {}\n"
+    "    rpc GetThing(GetThingRequest) returns (GetThingResponse) {}\n"
+    "}\n\n"
+    "message CreateThingRequest {\n    string name = 1;\n}\n"
+)
+
+
+def _write(tmp_path: Path, files: dict[str, str]) -> Path:
+    for rel, content in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    return tmp_path
+
+
+class TestOpenApiDiscovery:
+    def test_json_spec_yields_one_operation_per_method(self, tmp_path: Path) -> None:
+        _write(tmp_path, {"schemas/things.json": json.dumps(_OPENAPI)})
+        assert set(discover_contract_operations(tmp_path)) == {
+            ContractOperation("things", "createThing", "POST", "/v2/things"),
+            ContractOperation("things", "listThings", "GET", "/v2/things"),
+            ContractOperation("things", "getThing", "GET", "/v2/things/{thingId}"),
+        }
+
+    def test_yaml_spec_is_read_when_yaml_is_available(self, tmp_path: Path) -> None:
+        yaml = __import__("importlib").util.find_spec("yaml")
+        if yaml is None:
+            return
+        _write(
+            tmp_path,
+            {
+                "schemas/things.yaml": (
+                    "openapi: 3.0.0\n"
+                    "paths:\n"
+                    "  /v2/things:\n"
+                    "    post:\n"
+                    "      operationId: createThing\n"
+                )
+            },
+        )
+        assert discover_contract_operations(tmp_path) == [
+            ContractOperation("things", "createThing", "POST", "/v2/things")
+        ]
+
+    def test_operation_without_an_id_is_skipped(self, tmp_path: Path) -> None:
+        spec = {"openapi": "3.0.0", "paths": {"/v2/things": {"get": {"tags": ["x"]}}}}
+        _write(tmp_path, {"schemas/things.json": json.dumps(spec)})
+        assert discover_contract_operations(tmp_path) == []
+
+    def test_non_spec_json_is_ignored(self, tmp_path: Path) -> None:
+        # A repo is full of JSON that is not a contract; reading every one of
+        # them as a spec would mint operations out of arbitrary data.
+        _write(
+            tmp_path,
+            {
+                "package.json": json.dumps({"name": "x", "paths": {"/a": {"get": {}}}}),
+                "tsconfig.json": json.dumps({"compilerOptions": {}}),
+            },
+        )
+        assert discover_contract_operations(tmp_path) == []
+
+    def test_ignored_directories_are_not_scanned(self, tmp_path: Path) -> None:
+        _write(tmp_path, {"node_modules/pkg/openapi.json": json.dumps(_OPENAPI)})
+        assert discover_contract_operations(tmp_path) == []
+
+
+class TestProtoDiscovery:
+    def test_service_rpcs_become_operations(self, tmp_path: Path) -> None:
+        _write(tmp_path, {"schemas/proto/things/v1/things.proto": _PROTO})
+        assert set(discover_contract_operations(tmp_path)) == {
+            ContractOperation("ThingService", "CreateThing", None, None),
+            ContractOperation("ThingService", "GetThing", None, None),
+        }
+
+    def test_rpcs_outside_a_service_are_not_operations(self, tmp_path: Path) -> None:
+        # `rpc` only means an operation inside a service block; a message
+        # field or a comment mentioning it does not.
+        source = (
+            'syntax = "proto3";\n\n'
+            "message Fake {\n"
+            "    string rpc = 1;\n"
+            "}\n"
+            "// rpc NotAnOperation(X) returns (Y);\n"
+        )
+        _write(tmp_path, {"a.proto": source})
+        assert discover_contract_operations(tmp_path) == []
+
+    def test_multiple_services_stay_separate(self, tmp_path: Path) -> None:
+        source = (
+            'syntax = "proto3";\n\n'
+            "service A {\n    rpc Ping(P) returns (P) {}\n}\n\n"
+            "service B {\n    rpc Ping(P) returns (P) {}\n}\n"
+        )
+        _write(tmp_path, {"a.proto": source})
+        assert set(discover_contract_operations(tmp_path)) == {
+            ContractOperation("A", "Ping", None, None),
+            ContractOperation("B", "Ping", None, None),
+        }
+
+    def test_single_line_service_is_read(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            {"a.proto": "service S { rpc Do(D) returns (D); }\n"},
+        )
+        assert discover_contract_operations(tmp_path) == [
+            ContractOperation("S", "Do", None, None)
+        ]

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -23,7 +23,9 @@ PropertyDict = dict[str, PropertyValue]
 
 # Any value a parsed JSON document can hold (a package.json manifest, a
 # tsconfig, an OpenAPI spec): recursive, so nested mappings stay typed.
-type JsonValue = str | int | float | bool | None | list[JsonValue] | dict[str, JsonValue]
+type JsonValue = (
+    str | int | float | bool | None | list[JsonValue] | dict[str, JsonValue]
+)
 
 type ResultScalar = str | int | float | bool | None
 type ResultValue = ResultScalar | list[ResultScalar] | dict[str, ResultScalar]

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -904,7 +904,7 @@ RELATIONSHIP_SCHEMAS: tuple[RelationshipSchema, ...] = (
         (NodeLabel.MODULE, NodeLabel.FUNCTION, NodeLabel.METHOD, NodeLabel.RESOURCE),
     ),
     RelationshipSchema(
-        (NodeLabel.FUNCTION, NodeLabel.METHOD),
+        (NodeLabel.FUNCTION, NodeLabel.METHOD, NodeLabel.FILE),
         RelationshipType.EXPOSES,
         (NodeLabel.RESOURCE,),
     ),

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -21,6 +21,10 @@ type LanguageLoader = Callable[[], Language] | None
 PropertyValue = str | int | float | bool | list[str] | None
 PropertyDict = dict[str, PropertyValue]
 
+# Any value a parsed JSON document can hold (a package.json manifest, a
+# tsconfig, an OpenAPI spec): recursive, so nested mappings stay typed.
+type JsonValue = str | int | float | bool | None | list[JsonValue] | dict[str, JsonValue]
+
 type ResultScalar = str | int | float | bool | None
 type ResultValue = ResultScalar | list[ResultScalar] | dict[str, ResultScalar]
 type ResultRow = dict[str, ResultValue]

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.498"
+version = "0.0.499"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- In a contract-first repo neither side of a service call is written by hand: the client stub and the server handler are both generated, they share no symbol, and often no URL literal either. What they do share is the operation their contract declares, so every OpenAPI `operationId` and every protobuf `rpc` now becomes one CONTRACT resource.
- The artefacts already in the graph resolve into it: an RPC resource by the `<Service>.<Method>` identity the proto declares, and an ENDPOINT resource by the method and path template it serves, reusing the same template matching the URL linking uses so `:id` and `{id}` are one segment and an unresolved mount lead still matches.
- Each operation is anchored by the file that declares it, so the node survives the unanchored-resource prune and answers "which contract declares this" as well as "who implements it"; the identity is the declaring file's path, because `openapi.json` is a filename, not a namespace.
- Bounded deliberately: only this project's endpoints are candidates (endpoint nodes are project-scoped), a template with no literal segment of its own anchors nothing, and a template matching more than one operation anchors none of them, since a parameter segment swallows its literal siblings.
- Discovery is deliberately narrow: a JSON or YAML document counts as a spec only when it declares `openapi`/`swagger` and a `paths` mapping, and a `.proto` yields operations only from inside a `service` block, so the manifests and fixtures a repo is full of contribute nothing. YAML is read when PyYAML is installed and skipped with a debug line otherwise, so no new required dependency.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD or tooling
- [ ] Dependencies

## Related Issues

Closes #912 (phase 2; phase 1 shipped in #939 and #943).

## Test Plan

- [x] Unit tests pass (`uv run pytest codebase_rag/tests -n auto`)
- [x] New tests added
- [x] Integration tests pass (run as part of the suite above)
- [x] Manual testing (describe below)

34 tests. Discovery: JSON and YAML specs, an operation with no id, non-spec JSON, ignored directories, protobuf services including a single-line one, `rpc` outside a service, two services declaring the same method, an rpc and an HTTP operation of the same name (which crashed the sort), the same spec filename in two directories, `basePath` and `servers` prefixes, disagreeing servers, and protobuf block comments, string literals and a brace inside a string. Linking: a node per operation, the contract kind, rpc and endpoint anchoring, parameter spelling, the unknown mount lead, method mismatch, unrelated path, the method-agnostic registration, another project's endpoints, an endpoint matching several operations, a lead-only template, the capture gate, sweep ownership, an unindexed contract file, and no contract files at all.

Manual validation on a large private polyglot monorepo: 122 declared operations (85 HTTP across 8 specs, 37 rpcs across 4 services), 83 artefact links (51 endpoints, 32 rpcs) reaching 82 distinct operations, no duplicate identities, and 40 operations with no implementation in the repo, which the graph could not previously distinguish from an implemented one. The full cross-language chain resolves: a generated TypeScript client method, its URL sink, the server route registered in a different language, and the operation the contract names.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] All pre-commit checks pass (`uv run pre-commit run --all-files`, plus `uv run ruff check`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [ ] No new comments or docstrings (code should be self-documenting)

The last item is not met: the two new modules document what makes a document a contract and why an operation is anchored by its file, neither of which can be read off the code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added contract discovery from OpenAPI/Swagger and protobuf specs, including operation extraction from `paths`/`operationId` and protobuf `service`/`rpc`.
  * Introduced a new contract resource type and automatic linking of live RPC/endpoint artifacts to discovered contract operations.
  * Enforced contract spec parsing limits (including max file size) and optional YAML support when available.
* **Bug Fixes**
  * Improved endpoint/RPC anchoring accuracy (method/path matching, ambiguity handling, and project isolation), plus cleanup of stale contract links.
* **Tests / Chores**
  * Added end-to-end contract operation discovery and linking tests; expanded relationship targeting to support file-to-flow and introduced recursive JSON typing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->