### PR TITLE
ci: only cancel superseded runs on PRs, never on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,10 @@ permissions: read-all
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Cancel superseded PR runs to save minutes, but never cancel a main push:
+  # each main commit (incl. the auto version-bump) must finish so the CI badge
+  # never latches onto a cancelled run and flashes "failing".
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,11 @@ on:
 permissions: read-all
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  # Cancel superseded PR runs to save minutes, but never cancel a main push:
-  # each main commit (incl. the auto version-bump) must finish so the CI badge
-  # never latches onto a cancelled run and flashes "failing".
+  # PRs group by ref so rapid pushes cancel superseded runs (saves minutes).
+  # Non-PR events (main push, version-bump push, dispatch) group by SHA so each
+  # commit gets its own group and can neither cancel nor be cancelled, even in a
+  # burst. A cancelled run is what makes the branch CI badge flash "failing".
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:


### PR DESCRIPTION
## Summary

- The CI badge intermittently showed **failing** on `main` even though CI passed.
- Root cause: every merge to `main` fires a `ci.yml` run, then `version-bump.yml` pushes a `chore: bump version` commit that fires a second run; with `cancel-in-progress: true` keyed on `github.ref` (identical for both), the second run **cancels** the first, and the branch badge latches onto the cancelled run and renders red.
- Fix: PRs keep ref-grouping so superseded runs still cancel (saves minutes); non-PR events (main push, version-bump push, dispatch) group by `github.sha`, so each commit gets its own group and can neither cancel nor be cancelled, even in a burst.

## Type of Change

- [x] CI/CD or tooling

## Related Issues

None.

## Test Plan

- [x] Greptile verified the concurrency expressions with actionlint and per-context evaluation (PR, main-push, dispatch), exit code 0.
- No application code changed; unit/integration suites unaffected.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
