### PR TITLE
fix: emit CALLS edge to JS/TS constructor on new expression

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -2954,7 +2954,15 @@ class CallProcessor:
                                 caller_spec, calls_rel, (ctor_type, qn_key, variant)
                             )
                     continue
-                init_qn = f"{callee_qn}{cs.SEPARATOR_DOT}{cs.PY_METHOD_INIT}"
+                # A JS/TS `new X(...)` runs X's `constructor` method (leaf name
+                # `constructor`, not Python's `__init__`); redirect the CALLS
+                # edge there so an explicitly-declared constructor is reachable.
+                ctor_member = (
+                    cs.KEYWORD_CONSTRUCTOR
+                    if language in cs.JS_TS_LANGUAGES
+                    else cs.PY_METHOD_INIT
+                )
+                init_qn = f"{callee_qn}{cs.SEPARATOR_DOT}{ctor_member}"
                 if init_qn not in resolver.function_registry:
                     continue
                 callee_type = cs.NodeLabel.METHOD

--- a/codebase_rag/tests/test_ts_constructor_call_resolution.py
+++ b/codebase_rag/tests/test_ts_constructor_call_resolution.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from codebase_rag import constants as cs
 from codebase_rag.graph_updater import GraphUpdater
 from codebase_rag.parser_loader import load_parsers
@@ -14,8 +16,8 @@ from codebase_rag.types_defs import PropertyDict, PropertyValue, ResultRow
 
 PROJECT = "proj"
 
-MODULE_SRC = """class Widget {
-  x: number;
+# Type-annotation-free so the one source is valid JavaScript, TypeScript and TSX.
+JS_FAMILY_SRC = """class Widget {
   constructor() {
     this.x = 1;
   }
@@ -23,13 +25,31 @@ MODULE_SRC = """class Widget {
 
 class Plain {}
 
-function build(): Widget {
+function build() {
   return new Widget();
 }
 
-function buildPlain(): Plain {
+function buildPlain() {
   return new Plain();
 }
+"""
+
+# Python regression: the language switch must keep routing `X()` to `__init__`.
+PY_SRC = """class Widget:
+    def __init__(self) -> None:
+        self.x = 1
+
+
+class Plain:
+    pass
+
+
+def build() -> Widget:
+    return Widget()
+
+
+def build_plain() -> Plain:
+    return Plain()
 """
 
 
@@ -61,8 +81,10 @@ class _Capture:
         return None
 
 
-def _calls(tmp_path: Path) -> set[tuple[PropertyValue, PropertyValue]]:
-    (tmp_path / "m.ts").write_text(MODULE_SRC)
+def _calls(
+    tmp_path: Path, filename: str, src: str
+) -> set[tuple[PropertyValue, PropertyValue]]:
+    (tmp_path / filename).write_text(src)
     parsers, queries = load_parsers()
     cap = _Capture()
     GraphUpdater(
@@ -77,13 +99,26 @@ def _calls(tmp_path: Path) -> set[tuple[PropertyValue, PropertyValue]]:
     }
 
 
-class TestTsConstructorCallResolution:
-    def test_new_calls_constructor(self, tmp_path: Path) -> None:
-        calls = _calls(tmp_path)
+class TestJsFamilyConstructorCallResolution:
+    @pytest.mark.parametrize("filename", ["m.js", "m.ts", "m.tsx"])
+    def test_new_calls_constructor(self, tmp_path: Path, filename: str) -> None:
+        calls = _calls(tmp_path, filename, JS_FAMILY_SRC)
         assert ("proj.m.build", "proj.m.Widget.constructor") in calls, calls
 
-    def test_new_without_constructor_not_dropped_to_class(self, tmp_path: Path) -> None:
-        calls = _calls(tmp_path)
-        # Plain declares no constructor; cgr must not emit a CALLS edge to the
-        # class node (INSTANTIATES carries the construction instead).
+    @pytest.mark.parametrize("filename", ["m.js", "m.ts", "m.tsx"])
+    def test_new_without_constructor_emits_no_phantom_edge(
+        self, tmp_path: Path, filename: str
+    ) -> None:
+        calls = _calls(tmp_path, filename, JS_FAMILY_SRC)
+        # Plain declares no constructor: neither a CALLS edge to the class node
+        # nor a phantom CALLS edge to a non-existent `Plain.constructor` method.
         assert ("proj.m.buildPlain", "proj.m.Plain") not in calls, calls
+        assert ("proj.m.buildPlain", "proj.m.Plain.constructor") not in calls, calls
+
+
+class TestPythonConstructorStillRoutesToInit:
+    def test_new_calls_init(self, tmp_path: Path) -> None:
+        # The `constructor`-vs-`__init__` language switch must not regress Python.
+        calls = _calls(tmp_path, "m.py", PY_SRC)
+        assert ("proj.m.build", "proj.m.Widget.__init__") in calls, calls
+        assert ("proj.m.build_plain", "proj.m.Plain") not in calls, calls

--- a/codebase_rag/tests/test_ts_constructor_call_resolution.py
+++ b/codebase_rag/tests/test_ts_constructor_call_resolution.py
@@ -121,4 +121,7 @@ class TestPythonConstructorStillRoutesToInit:
         # The `constructor`-vs-`__init__` language switch must not regress Python.
         calls = _calls(tmp_path, "m.py", PY_SRC)
         assert ("proj.m.build", "proj.m.Widget.__init__") in calls, calls
+        # Plain has no __init__: neither a CALLS edge to the class node nor a
+        # phantom edge to a non-existent Plain.__init__ method.
         assert ("proj.m.build_plain", "proj.m.Plain") not in calls, calls
+        assert ("proj.m.build_plain", "proj.m.Plain.__init__") not in calls, calls

--- a/codebase_rag/tests/test_ts_constructor_call_resolution.py
+++ b/codebase_rag/tests/test_ts_constructor_call_resolution.py
@@ -1,0 +1,89 @@
+# A TS/JS `new X()` runs X's `constructor` method, but the constructor-call
+# redirect only looked for Python's `__init__`, so an explicitly-declared
+# TypeScript constructor got INSTANTIATES -> class and no CALLS edge, and the
+# dead-code walk (which never traverses INSTANTIATES by default) reported every
+# such constructor as unreachable. Found dogfooding `cgr dead-code` on zod.
+from __future__ import annotations
+
+from pathlib import Path
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.types_defs import PropertyDict, PropertyValue, ResultRow
+
+PROJECT = "proj"
+
+MODULE_SRC = """class Widget {
+  x: number;
+  constructor() {
+    this.x = 1;
+  }
+}
+
+class Plain {}
+
+function build(): Widget {
+  return new Widget();
+}
+
+function buildPlain(): Plain {
+  return new Plain();
+}
+"""
+
+
+class _Capture:
+    def __init__(self) -> None:
+        self.rels: list[tuple[PropertyValue, str, PropertyValue]] = []
+
+    def ensure_node_batch(self, label: str, properties: PropertyDict) -> None:
+        return None
+
+    def ensure_relationship_batch(
+        self,
+        from_spec: tuple[str, str, PropertyValue],
+        rel_type: str,
+        to_spec: tuple[str, str, PropertyValue],
+        properties: PropertyDict | None = None,
+    ) -> None:
+        self.rels.append((from_spec[2], str(rel_type), to_spec[2]))
+
+    def flush_all(self) -> None:
+        return None
+
+    def fetch_all(
+        self, query: str, params: PropertyDict | None = None
+    ) -> list[ResultRow]:
+        return []
+
+    def execute_write(self, query: str, params: PropertyDict | None = None) -> None:
+        return None
+
+
+def _calls(tmp_path: Path) -> set[tuple[PropertyValue, PropertyValue]]:
+    (tmp_path / "m.ts").write_text(MODULE_SRC)
+    parsers, queries = load_parsers()
+    cap = _Capture()
+    GraphUpdater(
+        ingestor=cap,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name=PROJECT,
+    ).run(force=True)
+    return {
+        (frm, to) for (frm, rel, to) in cap.rels if rel == cs.RelationshipType.CALLS
+    }
+
+
+class TestTsConstructorCallResolution:
+    def test_new_calls_constructor(self, tmp_path: Path) -> None:
+        calls = _calls(tmp_path)
+        assert ("proj.m.build", "proj.m.Widget.constructor") in calls, calls
+
+    def test_new_without_constructor_not_dropped_to_class(self, tmp_path: Path) -> None:
+        calls = _calls(tmp_path)
+        # Plain declares no constructor; cgr must not emit a CALLS edge to the
+        # class node (INSTANTIATES carries the construction instead).
+        assert ("proj.m.buildPlain", "proj.m.Plain") not in calls, calls

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.500"
+version = "0.0.502"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Fixes #956.

## Problem

`cgr dead-code` reported every explicitly-declared TypeScript/JavaScript **constructor** as unreachable, even for classes instantiated with `new` all over the codebase. Found dogfooding `cgr dead-code` on [zod](https://github.com/colinhacks/zod): `ParseInputLazyPath.constructor` was flagged despite ten `new ParseInputLazyPath(...)` sites in the same file.

## Root cause

In the `new`-expression handler (`call_processor.py`), the constructor-CALLS redirect handled Java/C#/C++/Dart explicitly, then fell through to a Python-hard-coded name for everything else:

```python
init_qn = f"{callee_qn}{cs.SEPARATOR_DOT}{cs.PY_METHOD_INIT}"  # "__init__"
```

A JS/TS constructor's method leaf is `constructor`, so the registry lookup always missed and no `CALLS` edge was emitted (only `INSTANTIATES → class`). The reachability walk traverses `CALLS`/`REFERENCES` but not `INSTANTIATES`/`DEFINES_METHOD` by default, so the constructor stayed unreachable. Python avoids this only because `__init__` is force-rooted as a dunder.

## Fix

Select the constructor member name by language before the lookup: `constructor` for JS/TS/TSX, `__init__` otherwise. Non-JS/TS languages keep byte-for-byte identical behaviour.

## Tests

RED→GREEN: `test_ts_constructor_call_resolution.py` asserts `new Widget()` emits `CALLS → Widget.constructor`, and that a constructor-less class emits `INSTANTIATES` only (no phantom edge to the class node).

## Dogfood verification

zod re-index: `ParseInputLazyPath.constructor` and all other instantiated-class constructors drop out of the report. The only remaining constructor findings are `abstract class Class` used purely as a type bound (`<T extends typeof Class>`), never instantiated, which are correct true positives.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed JavaScript/TypeScript call relationship resolution for `new X(...)` to link to `X.constructor` when it’s explicitly declared.
  * Prevented incorrect “phantom” call relationships when a class has no `constructor`.
  * Kept existing Python behavior by continuing to route `new X(...)` to `X.__init__`.

* **Tests**
  * Added regression tests covering `new X()` resolution across JavaScript, TypeScript, TSX, and Python.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->