### PR TITLE
fix: reference inline arrows escaping via array literals and augmented assignment

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -337,8 +337,9 @@ _ASSIGNMENT_RHS_FIELDS = {
     cs.TS_ASSIGNMENT_EXPRESSION: cs.TS_FIELD_RIGHT,
     # A JS/TS logical-assign default (`obj.when ??= (p) => {...}`, `x ||= fn`)
     # stores the RHS function for later dynamic dispatch, exactly like a plain
-    # assignment; a numeric `+=` RHS is never an inline function, so it adds no
-    # edge. The RHS sits in the same `right` field.
+    # assignment, so its RHS is scanned the same way (same `right` field). Only a
+    # callable RHS (an inline arrow or a name resolving to a function) yields an
+    # edge; a data RHS (`count += 1`) resolves to nothing and adds none.
     cs.TS_JS_AUGMENTED_ASSIGNMENT_EXPRESSION: cs.TS_FIELD_RIGHT,
     cs.TS_VARIABLE_DECLARATOR: cs.FIELD_VALUE,
     cs.TS_GO_VAR_SPEC: cs.FIELD_VALUE,

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -335,6 +335,11 @@ _TS_BINDING_WRAPPER_TYPES = cs.TS_CAST_WRAPPER_TYPES | {cs.TS_PARENTHESIZED_EXPR
 _ASSIGNMENT_RHS_FIELDS = {
     cs.TS_PY_ASSIGNMENT: cs.TS_FIELD_RIGHT,
     cs.TS_ASSIGNMENT_EXPRESSION: cs.TS_FIELD_RIGHT,
+    # A JS/TS logical-assign default (`obj.when ??= (p) => {...}`, `x ||= fn`)
+    # stores the RHS function for later dynamic dispatch, exactly like a plain
+    # assignment; a numeric `+=` RHS is never an inline function, so it adds no
+    # edge. The RHS sits in the same `right` field.
+    cs.TS_JS_AUGMENTED_ASSIGNMENT_EXPRESSION: cs.TS_FIELD_RIGHT,
     cs.TS_VARIABLE_DECLARATOR: cs.FIELD_VALUE,
     cs.TS_GO_VAR_SPEC: cs.FIELD_VALUE,
     cs.TS_GO_SHORT_VAR_DECLARATION: cs.TS_FIELD_RIGHT,
@@ -3997,6 +4002,19 @@ class CallProcessor:
         # `fn.call(...)` / `fn.apply(...)` in value position (onError:
         # handleError.bind(toast)) hands off `fn`; peel both to a fixpoint.
         node = self._peel_bound_callable(node)
+        # An inline arrow/function-expression element (`handlers = [() => {}]`,
+        # zod's `onattach = [(inst) => {...}]`) is registered anonymously in the
+        # enclosing scope and named after no identifier, so resolve_func cannot
+        # find it; reference it by position exactly like an inline call argument.
+        if node.type in _INLINE_FUNC_VALUE_TYPES:
+            self._emit_inline_arg_function_ref(
+                node,
+                caller_spec,
+                ensure_rel,
+                caller_spec[2],
+                cs.RelationshipType.REFERENCES,
+            )
+            return
         # Only a bare name / attribute / member-expression in value position names
         # a function; a call, comprehension or literal is not a reference to a
         # callable. Reuses the flow-arg ref types (identifier, Python attribute,

--- a/codebase_rag/tests/test_ts_inline_arrow_escape_refs.py
+++ b/codebase_rag/tests/test_ts_inline_arrow_escape_refs.py
@@ -1,0 +1,129 @@
+# An inline arrow function that ESCAPES its definition site (passed, assigned,
+# returned, placed in a collection) is invoked later and must not be reported as
+# dead code. cgr already referenced arrows in most positions, but two leaked and
+# were false-flagged by `cgr dead-code` on zod:
+#   1. an arrow inside an ARRAY literal   (`x.onattach = [(i) => {...}]`)
+#   2. an arrow on the RHS of an AUGMENTED assignment (`x.when ??= (p) => {...}`)
+# Each escaping arrow must receive a REFERENCES (or CALLS) edge from its
+# enclosing scope so the reachability walk keeps it live. Arrows are identified
+# by their source ROW, which the definition pass encodes into the anonymous
+# qualified name (`...anonymous_<row>_<col>`).
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.types_defs import PropertyDict, PropertyValue, ResultRow
+
+PROJECT = "p"
+
+# One escaping arrow per line; the dict maps a label to that arrow's 0-indexed
+# source row. The trailing `discarded` arrow does NOT escape and must stay dead.
+SRC_LINES = [
+    "export function reachable() {",  # row 0
+    "  obj.list = [() => { arrLit(); }];",  # row 1  arrLit  (array assigned to member)
+    "  obj.when ??= (p) => { augWhen(); };",  # row 2  augWhen (augmented ??=)
+    "  obj.or ||= (p) => { augOr(); };",  # row 3  augOr   (augmented ||=)
+    "  callFoo([() => { arrArg(); }]);",  # row 4  arrArg  (array as call arg)
+    "  callFoo({ items: [() => { nested(); }] });",  # row 5  nested (array in object arg)
+    "  const local = { list: [() => { objArr(); }] };",  # row 6  objArr (array in object const)
+    "  (() => { discarded(); });",  # row 7  discarded (constructed, dropped)
+    "}",
+]
+SRC = "\n".join(SRC_LINES) + "\n"
+
+ESCAPING_ROWS = {
+    "arrLit": 1,
+    "augWhen": 2,
+    "augOr": 3,
+    "arrArg": 4,
+    "nested": 5,
+    "objArr": 6,
+}
+DISCARDED_ROW = 7
+
+
+class _Capture:
+    def __init__(self) -> None:
+        self.rels: list[tuple[PropertyValue, str, PropertyValue]] = []
+        self.func_qns: set[str] = set()
+
+    def ensure_node_batch(self, label: str, properties: PropertyDict) -> None:
+        if label in (cs.NodeLabel.FUNCTION, cs.NodeLabel.METHOD):
+            qn = properties.get(cs.KEY_QUALIFIED_NAME)
+            if qn is not None:
+                self.func_qns.add(str(qn))
+
+    def ensure_relationship_batch(
+        self,
+        from_spec: tuple[str, str, PropertyValue],
+        rel_type: str,
+        to_spec: tuple[str, str, PropertyValue],
+        properties: PropertyDict | None = None,
+    ) -> None:
+        self.rels.append((from_spec[2], str(rel_type), to_spec[2]))
+
+    def flush_all(self) -> None:
+        return None
+
+    def fetch_all(
+        self, query: str, params: PropertyDict | None = None
+    ) -> list[ResultRow]:
+        return []
+
+    def execute_write(self, query: str, params: PropertyDict | None = None) -> None:
+        return None
+
+
+def _referenced_rows(tmp_path: Path) -> set[int]:
+    """Source rows of the anonymous arrows that receive a REFERENCES/CALLS edge."""
+    (tmp_path / "m.ts").write_text(SRC)
+    parsers, queries = load_parsers()
+    cap = _Capture()
+    GraphUpdater(
+        ingestor=cap,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name=PROJECT,
+    ).run(force=True)
+    ref_rels = {
+        str(cs.RelationshipType.REFERENCES),
+        str(cs.RelationshipType.CALLS),
+    }
+    referenced_anon = {
+        str(to)
+        for frm, rel, to in cap.rels
+        if rel in ref_rels and cs.PREFIX_ANONYMOUS in str(to).rsplit(".", 1)[-1]
+    }
+    rows: set[int] = set()
+    for qn in referenced_anon:
+        leaf = qn.rsplit(".", 1)[-1]
+        # ...anonymous_<row>_<col>
+        row_col = leaf[len(cs.PREFIX_ANONYMOUS) :]
+        if "_" in row_col and row_col.split("_", 1)[0].isdigit():
+            rows.add(int(row_col.split("_", 1)[0]))
+    return rows
+
+
+class TestInlineArrowEscapeRefs:
+    @pytest.mark.parametrize("label", sorted(ESCAPING_ROWS))
+    def test_escaping_arrow_is_referenced(self, tmp_path: Path, label: str) -> None:
+        rows = _referenced_rows(tmp_path)
+        assert ESCAPING_ROWS[label] in rows, (
+            f"arrow {label!r} (row {ESCAPING_ROWS[label]}) escaped its definition "
+            f"site but got no REFERENCES edge; referenced rows={sorted(rows)}"
+        )
+
+    def test_discarded_arrow_stays_dead(self, tmp_path: Path) -> None:
+        rows = _referenced_rows(tmp_path)
+        # An arrow that is constructed and immediately dropped never escapes, so
+        # it correctly receives no reference and remains a dead-code candidate.
+        assert DISCARDED_ROW not in rows, (
+            f"discarded arrow (row {DISCARDED_ROW}) does not escape and must not "
+            f"be referenced; referenced rows={sorted(rows)}"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.502"
+version = "0.0.503"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Fixes #958.

## Problem

`cgr dead-code` false-flagged inline anonymous arrow functions that escape their definition site through an **array literal** or an **augmented (logical) assignment**. Found dogfooding on [zod](https://github.com/colinhacks/zod):

```ts
ch._zod.onattach = [(inst) => { ... }];         // arrow inside an array literal
inst._zod.def.when ??= (payload) => { ... };     // arrow on the RHS of `??=`
```

Both arrows are stored and invoked later, but received no reference edge, so the reachability walk (which never traverses `DEFINES`) reported them dead.

## Root cause

cgr already references arrows escaping as a direct call argument, a plain-assignment RHS, a return value, or an object-literal property. Two positions leaked:

1. **Array-literal elements** — `_emit_value_function_ref` bailed on anything that was not a bare name/attribute/member, so an inline arrow array element got no edge.
2. **Augmented assignment RHS** — `_ASSIGNMENT_RHS_FIELDS` had `assignment_expression` but not `augmented_assignment_expression`, so `x ??= () => {}` was never scanned.

## Fix

- `_emit_value_function_ref`: reference an inline arrow/function-expression element by position, exactly as inline call arguments are handled.
- Add `augmented_assignment_expression` to `_ASSIGNMENT_RHS_FIELDS`, routing its RHS through the existing inline-arrow reference path.

## Precision preserved

An arrow that is constructed and immediately discarded (never passed, assigned, or returned) still gets no reference and correctly stays a dead-code candidate. RED→GREEN test `test_ts_inline_arrow_escape_refs.py` parameterizes the six escaping positions and asserts the discarded arrow remains dead.

## Dogfood

zod dead-code candidates dropped from 26 to 17 (the array/`??=` arrows cleared). Remaining arrows escape through a distinct nested-arrow-scope attribution path (a separate follow-up); the constructor findings are fixed by #957.
