### PR TITLE
fix: attribute class arrow-property body callbacks to the property scope

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -36,6 +36,7 @@ from .go import utils as go_utils
 from .import_processor import ImportProcessor
 from .io_access import IOAccessProcessor
 from .java import utils as java_utils
+from .js_ts import utils as js_ts_utils
 from .lua import utils as lua_utils
 from .rpc_exposure import GoRpcExposureProcessor
 from .rs import utils as rs_utils
@@ -5579,40 +5580,10 @@ class CallProcessor:
         return f"{module_qn}{cs.SEPARATOR_DOT}{func_name}"
 
     def _js_ts_arrow_binding_name(self, func_node: Node) -> str | None:
-        # An arrow / function expression has no `name` field, so the call pass
-        # skipped it and never processed its body's calls. Recover the binding
-        # name for the two named forms whose value IS the arrow: a module/local
-        # `const f = () => ...` (variable_declarator) and a class field
-        # `helper = () => ...` (public_field_definition). The body's calls then
-        # attribute to the qn the definition pass registered. Anonymous /
-        # destructured arrows stay unnamed (skipped).
-        if func_node.type not in (cs.TS_ARROW_FUNCTION, cs.TS_FUNCTION_EXPRESSION):
-            return None
-        # The arrow may be bound THROUGH transparent wrappers: parens and TS
-        # casts (`export const createStore = ((s) => ...) as CreateStore`,
-        # zustand's public-API shape). The def pass unwraps these when naming the
-        # function, so the call pass must climb them too or the arrow looks
-        # anonymous and its body's calls drop at module scope.
-        node = func_node
-        parent = node.parent
-        while parent is not None and parent.type in _TS_BINDING_WRAPPER_TYPES:
-            node = parent
-            parent = node.parent
-        if parent is None:
-            return None
-        # node must be the parent's value/initializer for both forms
-        # (variable_declarator and public_field_definition), so one value check
-        # covers both. `==` not `is`: py-tree-sitter returns a fresh Node wrapper
-        # per access, so identity comparison always fails (Node `==` compares id).
-        if parent.child_by_field_name(cs.FIELD_VALUE) != node:
-            return None
-        name_node = parent.child_by_field_name(cs.FIELD_NAME)
-        if name_node is None or name_node.type not in (
-            cs.TS_IDENTIFIER,
-            cs.TS_PROPERTY_IDENTIFIER,
-        ):
-            return None
-        return safe_decode_text(name_node)
+        # Shared with the definition pass (function_ingest) so both derive the
+        # SAME name for a name-bound arrow; divergence makes the caller qn a
+        # phantom and the arrow's body callbacks report dead.
+        return js_ts_utils.arrow_binding_name(func_node)
 
     def _attributable_func_nodes(
         self, func_nodes: list[Node], language: cs.SupportedLanguage

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -29,6 +29,7 @@ from .cpp import utils as cpp_utils
 from .dart import dart_definition_end_point, dart_return_type_name
 from .endpoints import emit_endpoints, queue_endpoints
 from .go import utils as go_utils
+from .js_ts import utils as js_ts_utils
 from .lua import utils as lua_utils
 from .rs import utils as rs_utils
 from .utils import (
@@ -1378,37 +1379,13 @@ class FunctionIngestMixin:
         if name_node and name_node.text:
             return safe_decode_text(name_node)
 
-        # Anonymous function EXPRESSIONS bound to a declarator (`export const
-        # api = (function (x) {...}) as unknown as Api`) take the binding name like
-        # arrows: the call pass's binding-name climb accepts both, and the two
-        # passes must agree or the caller qn is a phantom.
-        if func_node.type in (cs.TS_ARROW_FUNCTION, cs.TS_FUNCTION_EXPRESSION):
-            current = func_node.parent
-            while current:
-                if current.type == cs.TS_VARIABLE_DECLARATOR:
-                    # `const m = useMutation({fn: () => {}})` binds the CALL result
-                    # to `m`, not the inner arrow; naming the arrow `m` invents a
-                    # phantom function (dead-code false positive). Only claim the
-                    # declarator name when its value is not a call.
-                    value = current.child_by_field_name(cs.FIELD_VALUE)
-                    if (
-                        value is not None
-                        and value.type in cs.JS_CALL_RESULT_VALUE_TYPES
-                    ):
-                        return None
-                    for child in current.children:
-                        if child.type == cs.TS_IDENTIFIER and child.text:
-                            return safe_decode_text(child)
-                    return None
-                # Crossing another function's body means this arrow is nested
-                # inside it (a JSX handler, a `.map()` callback), not bound to the
-                # outer const: stop so it stays anonymous instead of inheriting the
-                # component's name as a `Component.Component` phantom.
-                if current.type in cs.JS_ARROW_NAME_CLIMB_BOUNDARY:
-                    return None
-                current = current.parent
-
-        return None
+        # An anonymous arrow / function expression bound to a name (a
+        # `const f = () => ...` declarator OR a `helper = () => ...` class field)
+        # takes that binding name, in lock-step with the call pass's
+        # binding-name climb (they must agree or the caller qn is a phantom and
+        # the arrow's body callbacks report dead). One shared helper keeps both
+        # passes' naming identical.
+        return js_ts_utils.arrow_binding_name(func_node)
 
     def _generate_anonymous_function_name(self, func_node: Node, module_qn: str) -> str:
         parent = func_node.parent

--- a/codebase_rag/parsers/js_ts/ingest.py
+++ b/codebase_rag/parsers/js_ts/ingest.py
@@ -24,7 +24,7 @@ from ..utils import (
     sorted_captures,
 )
 from .module_system import JsTsModuleSystemMixin
-from .utils import get_js_ts_language_obj
+from .utils import arrow_binding_name, get_js_ts_language_obj
 
 if TYPE_CHECKING:
     from ...language_spec import LanguageSpec
@@ -799,12 +799,18 @@ class JsTsIngestMixin(JsTsModuleSystemMixin):
         # a value of, or the lhs of an assignment. Recovering it keeps a callback
         # under its arrow-const component (module.Cmp.onSuccess), consistent with the
         # call pass, instead of collapsing to module.onSuccess and dangling.
+        # The value-bound forms (`const f = () => ...` declarator and a class
+        # field `create = (s) => ...`), including through paren/cast wrappers
+        # (`create = ((s) => ...) as Create`), share the call pass's helper so a
+        # callback in the arrow body attributes to `scope.create.cb` in lock-step
+        # with the caller qn; without this a class arrow-property factory drops
+        # the property scope and its callbacks report dead.
+        if name := arrow_binding_name(node):
+            return name
         parent = node.parent
         if parent is None:
             return None
-        if parent.type == cs.TS_VARIABLE_DECLARATOR:
-            binding = parent.child_by_field_name(cs.FIELD_NAME)
-        elif parent.type == cs.TS_PAIR:
+        if parent.type == cs.TS_PAIR:
             binding = parent.child_by_field_name(cs.FIELD_KEY)
         elif parent.type == cs.TS_ASSIGNMENT_EXPRESSION:
             binding = parent.child_by_field_name(cs.FIELD_LEFT)

--- a/codebase_rag/parsers/js_ts/utils.py
+++ b/codebase_rag/parsers/js_ts/utils.py
@@ -130,6 +130,45 @@ def extract_constructor_name(new_expr_node: Node) -> str | None:
     return None
 
 
+_BINDING_WRAPPER_TYPES = cs.TS_CAST_WRAPPER_TYPES | {cs.TS_PARENTHESIZED_EXPRESSION}
+
+
+def arrow_binding_name(func_node: Node) -> str | None:
+    # An arrow / function expression has no `name` field. Recover the binding
+    # name for the two named forms whose VALUE is the arrow: a module/local
+    # `const f = () => ...` (variable_declarator) and a class field
+    # `helper = () => ...` (public_field_definition). Both the definition pass
+    # (registering the arrow's qn) and the call pass (attributing the body's
+    # calls) must derive the SAME name, or the caller qn is a phantom and the
+    # arrow's body callbacks report dead; sharing this one helper keeps them in
+    # step. Anonymous / destructured arrows, and arrows that are merely an
+    # argument to a call bound to a name (`const m = useMutation(() => {})`),
+    # stay unnamed: the arrow is not the binding's own value there.
+    if func_node.type not in (cs.TS_ARROW_FUNCTION, cs.TS_FUNCTION_EXPRESSION):
+        return None
+    # The arrow may sit behind transparent wrappers (parens, TS casts:
+    # `export const create = ((s) => ...) as Create`); climb them so the arrow
+    # is recognised as the binding's value.
+    node = func_node
+    parent = node.parent
+    while parent is not None and parent.type in _BINDING_WRAPPER_TYPES:
+        node = parent
+        parent = node.parent
+    if parent is None:
+        return None
+    # `==` not `is`: py-tree-sitter returns a fresh Node wrapper per access, so
+    # identity comparison always fails.
+    if parent.child_by_field_name(cs.FIELD_VALUE) != node:
+        return None
+    name_node = parent.child_by_field_name(cs.FIELD_NAME)
+    if name_node is None or name_node.type not in (
+        cs.TS_IDENTIFIER,
+        cs.TS_PROPERTY_IDENTIFIER,
+    ):
+        return None
+    return safe_decode_text(name_node)
+
+
 def analyze_return_expression(expr_node: Node, method_qn: str) -> str | None:
     match expr_node.type:
         case cs.TS_NEW_EXPRESSION:

--- a/codebase_rag/tests/test_ts_arrow_property_scope_callbacks.py
+++ b/codebase_rag/tests/test_ts_arrow_property_scope_callbacks.py
@@ -15,9 +15,6 @@ from codebase_rag.types_defs import PropertyDict, PropertyValue, ResultRow
 
 PROJECT = "p"
 
-# The `used` callback sits at row 3 in each source, inside the factory body.
-CALLBACK_ROW = 3
-
 # Case A: static arrow property (the zod pattern).  Case B: regular method
 # (already works) — a control that must also pass.
 ARROW_PROPERTY_SRC = """class Box {
@@ -80,7 +77,20 @@ class _Capture:
         return None
 
 
-def _callback_is_referenced(tmp_path: Path, src: str) -> bool:
+# The factory owns a callback that escapes (`shape`) AND one that is constructed
+# then dropped (`unused`); the escaping one must be referenced FROM the property
+# scope and the dropped one must stay dead, proving precise attribution.
+PRECISION_SRC = """class Box {
+  constructor(cfg: any) {}
+  static make = (s: any) => {
+    (() => { neverEscapes(); });
+    return new Box({ shape: () => { used(); } });
+  };
+}
+"""
+
+
+def _run(tmp_path: Path, src: str) -> _Capture:
     (tmp_path / "m.ts").write_text(src)
     parsers, queries = load_parsers()
     cap = _Capture()
@@ -91,32 +101,63 @@ def _callback_is_referenced(tmp_path: Path, src: str) -> bool:
         queries=queries,
         project_name=PROJECT,
     ).run(force=True)
-    ref_rels = {
-        str(cs.RelationshipType.REFERENCES),
-        str(cs.RelationshipType.CALLS),
-    }
-    # Any Function/Method node whose body starts on the callback row.
-    referenced = {str(to) for frm, rel, to in cap.rels if rel in ref_rels}
-    # The `shape` callback registers either by key (`...shape`) or by position
-    # (`...anonymous_<row>_<col>`); accept both, but it must be referenced.
-    for qn in referenced:
-        leaf = qn.rsplit(".", 1)[-1]
-        if leaf.startswith("shape") or leaf.startswith(
-            f"{cs.PREFIX_ANONYMOUS}{CALLBACK_ROW}_"
-        ):
-            return True
-    return False
+    return cap
+
+
+_REF_RELS = {
+    str(cs.RelationshipType.REFERENCES),
+    str(cs.RelationshipType.CALLS),
+}
+
+
+def _is_shape_callback(qn: str) -> bool:
+    # The `shape` callback registers either by its object key (`...shape`) or by
+    # position (`...anonymous_<row>_<col>`) behind a cast wrapper.
+    leaf = qn.rsplit(".", 1)[-1]
+    return leaf.startswith("shape") or leaf.startswith(cs.PREFIX_ANONYMOUS)
+
+
+def _shape_referenced_from(cap: _Capture, expected_scope_suffix: str) -> bool:
+    # The escaping `shape` callback must be referenced FROM the recovered
+    # property scope (e.g. `...Box.make`), not merely reachable from anywhere.
+    return any(
+        rel in _REF_RELS
+        and _is_shape_callback(str(to))
+        and str(frm).endswith(expected_scope_suffix)
+        for frm, rel, to in cap.rels
+    )
 
 
 class TestArrowPropertyScopeCallbacks:
     def test_method_body_callback_referenced(self, tmp_path: Path) -> None:
         # Control: a regular method already references its body callbacks.
-        assert _callback_is_referenced(tmp_path, METHOD_SRC)
+        assert _shape_referenced_from(_run(tmp_path, METHOD_SRC), ".Box.make")
 
     def test_arrow_property_body_callback_referenced(self, tmp_path: Path) -> None:
-        assert _callback_is_referenced(tmp_path, ARROW_PROPERTY_SRC)
+        assert _shape_referenced_from(_run(tmp_path, ARROW_PROPERTY_SRC), ".Box.make")
 
     def test_cast_wrapped_arrow_property_body_callback_referenced(
         self, tmp_path: Path
     ) -> None:
-        assert _callback_is_referenced(tmp_path, CAST_WRAPPED_ARROW_PROPERTY_SRC)
+        cap = _run(tmp_path, CAST_WRAPPED_ARROW_PROPERTY_SRC)
+        assert _shape_referenced_from(cap, ".Box.make")
+
+    def test_dropped_sibling_callback_stays_dead(self, tmp_path: Path) -> None:
+        # Precision: `shape` escapes and is referenced from `Box.make`; the
+        # bare `(() => {...})` expression is constructed and dropped, so no ref
+        # edge may target a Box.make callback that only calls `neverEscapes`.
+        cap = _run(tmp_path, PRECISION_SRC)
+        assert _shape_referenced_from(cap, ".Box.make")
+        dropped = {
+            str(to)
+            for frm, rel, to in cap.rels
+            if rel == str(cs.RelationshipType.DEFINES)
+            and str(frm).endswith(".Box.make")
+            and cs.PREFIX_ANONYMOUS in str(to).rsplit(".", 1)[-1]
+        }
+        referenced = {to for _f, rel, to in cap.rels if rel in _REF_RELS}
+        assert dropped, "expected a dropped anonymous callback under Box.make"
+        assert not (dropped & {str(t) for t in referenced}), (
+            f"a constructed-then-dropped callback was referenced: "
+            f"{dropped & {str(t) for t in referenced}}"
+        )

--- a/codebase_rag/tests/test_ts_arrow_property_scope_callbacks.py
+++ b/codebase_rag/tests/test_ts_arrow_property_scope_callbacks.py
@@ -118,10 +118,12 @@ def _is_shape_callback(qn: str) -> bool:
 
 
 def _shape_referenced_from(cap: _Capture, expected_scope_suffix: str) -> bool:
-    # The escaping `shape` callback must be referenced FROM the recovered
-    # property scope (e.g. `...Box.make`), not merely reachable from anywhere.
+    # The escaping `shape` callback must get a REFERENCES edge (the exact edge
+    # the fix emits) FROM the recovered property scope (e.g. `...Box.make`), not
+    # merely a CALLS edge or reachability from anywhere.
+    references = str(cs.RelationshipType.REFERENCES)
     return any(
-        rel in _REF_RELS
+        rel == references
         and _is_shape_callback(str(to))
         and str(frm).endswith(expected_scope_suffix)
         for frm, rel, to in cap.rels

--- a/codebase_rag/tests/test_ts_arrow_property_scope_callbacks.py
+++ b/codebase_rag/tests/test_ts_arrow_property_scope_callbacks.py
@@ -1,0 +1,122 @@
+# A class factory written as an ARROW PROPERTY (`static create = (s) => {...}`)
+# must reference the inline callbacks in its body exactly as a regular method
+# does. cgr attributed those callbacks to the enclosing CLASS scope and gave the
+# arrow property no caller pass, so they got no reference edge and `cgr
+# dead-code` false-flagged them. Found dogfooding zod, whose factories are all
+# arrow properties (`create = (...) => {...}`).
+from __future__ import annotations
+
+from pathlib import Path
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.types_defs import PropertyDict, PropertyValue, ResultRow
+
+PROJECT = "p"
+
+# The `used` callback sits at row 3 in each source, inside the factory body.
+CALLBACK_ROW = 3
+
+# Case A: static arrow property (the zod pattern).  Case B: regular method
+# (already works) — a control that must also pass.
+ARROW_PROPERTY_SRC = """class Box {
+  constructor(cfg: any) {}
+  static make = (s: any) => {
+    return new Box({ shape: () => { used(); } });
+  };
+}
+"""
+
+METHOD_SRC = """class Box {
+  constructor(cfg: any) {}
+  static make(s: any) {
+    return new Box({ shape: () => { used(); } });
+  }
+}
+"""
+
+# The arrow property is bound THROUGH a cast wrapper (zustand's public-API
+# shape). The binding name must still be recovered so the callback attributes to
+# the property scope.
+CAST_WRAPPED_ARROW_PROPERTY_SRC = """class Box {
+  constructor(cfg: any) {}
+  static make = ((s: any) => {
+    return new Box({ shape: () => { used(); } });
+  }) as any;
+}
+"""
+
+
+class _Capture:
+    def __init__(self) -> None:
+        self.rels: list[tuple[PropertyValue, str, PropertyValue]] = []
+        self.func_qns: set[str] = set()
+
+    def ensure_node_batch(self, label: str, properties: PropertyDict) -> None:
+        if label in (cs.NodeLabel.FUNCTION, cs.NodeLabel.METHOD):
+            qn = properties.get(cs.KEY_QUALIFIED_NAME)
+            if qn is not None:
+                self.func_qns.add(str(qn))
+
+    def ensure_relationship_batch(
+        self,
+        from_spec: tuple[str, str, PropertyValue],
+        rel_type: str,
+        to_spec: tuple[str, str, PropertyValue],
+        properties: PropertyDict | None = None,
+    ) -> None:
+        self.rels.append((from_spec[2], str(rel_type), to_spec[2]))
+
+    def flush_all(self) -> None:
+        return None
+
+    def fetch_all(
+        self, query: str, params: PropertyDict | None = None
+    ) -> list[ResultRow]:
+        return []
+
+    def execute_write(self, query: str, params: PropertyDict | None = None) -> None:
+        return None
+
+
+def _callback_is_referenced(tmp_path: Path, src: str) -> bool:
+    (tmp_path / "m.ts").write_text(src)
+    parsers, queries = load_parsers()
+    cap = _Capture()
+    GraphUpdater(
+        ingestor=cap,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name=PROJECT,
+    ).run(force=True)
+    ref_rels = {
+        str(cs.RelationshipType.REFERENCES),
+        str(cs.RelationshipType.CALLS),
+    }
+    # Any Function/Method node whose body starts on the callback row.
+    referenced = {str(to) for frm, rel, to in cap.rels if rel in ref_rels}
+    # The `shape` callback registers either by key (`...shape`) or by position
+    # (`...anonymous_<row>_<col>`); accept both, but it must be referenced.
+    for qn in referenced:
+        leaf = qn.rsplit(".", 1)[-1]
+        if leaf.startswith("shape") or leaf.startswith(
+            f"{cs.PREFIX_ANONYMOUS}{CALLBACK_ROW}_"
+        ):
+            return True
+    return False
+
+
+class TestArrowPropertyScopeCallbacks:
+    def test_method_body_callback_referenced(self, tmp_path: Path) -> None:
+        # Control: a regular method already references its body callbacks.
+        assert _callback_is_referenced(tmp_path, METHOD_SRC)
+
+    def test_arrow_property_body_callback_referenced(self, tmp_path: Path) -> None:
+        assert _callback_is_referenced(tmp_path, ARROW_PROPERTY_SRC)
+
+    def test_cast_wrapped_arrow_property_body_callback_referenced(
+        self, tmp_path: Path
+    ) -> None:
+        assert _callback_is_referenced(tmp_path, CAST_WRAPPED_ARROW_PROPERTY_SRC)

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.503"
+version = "0.0.504"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Fixes #960.

## Problem

Inline callbacks in the body of a class **arrow-property factory** (`static create = (s) => {...}`) were attributed to the enclosing **class** scope (`Class.shape`) instead of the property (`Class.create.shape`). The per-caller reference scan for `create` looks for callbacks under `Class.create.*`, so the mismatched registration meant no `REFERENCES` edge was emitted and `cgr dead-code` false-flagged them. The same code as a regular method already worked. Found dogfooding zod, whose factories are all arrow properties.

## Root cause

Three passes recover an arrow's binding name, and each handled a different subset of binding forms:

- `function_ingest._extract_function_name` (def pass) — only `variable_declarator`.
- `call_processor._js_ts_arrow_binding_name` (call pass) — `variable_declarator` + `public_field_definition`.
- `js_ts/ingest._js_nameless_binding_name` (object-value naming) — `variable_declarator`, `pair`, `assignment_expression`, but **not** `public_field_definition`.

So a class arrow-property's nested callbacks lost the property name in their qualified name, and the def and call passes disagreed.

## Fix

- Extract the call pass's binding-name logic into one shared helper `js_ts/utils.arrow_binding_name` and route both the def pass (`_extract_function_name`) and call pass (`_js_ts_arrow_binding_name`) through it, so they can never diverge.
- Add `public_field_definition` to `_js_nameless_binding_name` so an object-value callback inside an arrow-property body attributes to `Class.create.<key>`.

## Tests

RED→GREEN `test_ts_arrow_property_scope_callbacks.py`: a callback inside a `static make = (s) => {...}` arrow property is referenced, matching the regular-method control. Full unit suite green.

## Dogfood

zod `shape@` factory callbacks are now referenced and the remaining arrow-property callbacks are correctly attributed under `.create.`. A separate follow-up (ternary-branch object-property arrow values, e.g. `catchValue: cond ? x : () => x`) covers the last cluster.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of names bound to JavaScript and TypeScript arrow functions and function expressions.
  * Fixed callback reference detection for TypeScript static arrow-property factories, including cast-wrapped variants.
  * Enhanced handling of arrow/function expressions wrapped in parentheses or type casts.
  * Added broader coverage via new ingestion attribution tests for escaping callback scope and a “precision” case where sibling callbacks remain unreferenced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->