### PR TITLE
fix: AgentRunResult.usage API compatibility

### DIFF
--- a/codebase_rag/main.py
+++ b/codebase_rag/main.py
@@ -652,7 +652,7 @@ async def _run_agent_response_loop(
 
         message_history.extend(response.new_messages())
 
-        run_usage = response.usage()
+        run_usage = response.usage
         turn_input += run_usage.input_tokens
         turn_output += run_usage.output_tokens
         run_cost = _price_current_run(run_usage, model_override_config)


### PR DESCRIPTION
## Summary

Fix compatibility with newer versions of `pydantic-ai` where
`AgentRunResult.usage` is exposed as a property instead of a method.

## Changes

- Replace `response.usage()` with `response.usage`
- Prevent `TypeError: 'RunUsage' object is not callable`

## Reproduction

Running:

```bash
cgr start --repo-path /path/to/project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected token usage tracking for interactive agent responses.
  * Improved per-turn input/output token accounting and run pricing calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->