### PR TITLE
fix: reference inline arrow branches of a ternary object-property value

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -390,7 +390,7 @@ def _first_class_value_children(node: Node, is_dart: bool) -> list[Node] | None:
         return _dart_collection_values(node)
     if node.type == cs.TS_PY_DICTIONARY:
         return _py_dict_values(node)
-    if node.type == cs.TS_PY_CONDITIONAL_EXPRESSION:
+    if node.type in (cs.TS_PY_CONDITIONAL_EXPRESSION, cs.TS_JS_TERNARY_EXPRESSION):
         return _conditional_result_operands(node, is_dart)
     if (
         is_dart
@@ -453,10 +453,11 @@ def _conditional_result_operands(node: Node, is_dart: bool) -> list[Node]:
     operands = list(node.named_children)
     if len(operands) != 3:
         return operands
-    # Dart orders [condition, consequence, alternative]; Python orders
-    # [body, condition, alternative]. Pick the two result operands, never
-    # the truthiness-tested one.
-    return [operands[1], operands[2]] if is_dart else [operands[0], operands[2]]
+    # Dart and JS/TS (`ternary_expression`) order [condition, consequence,
+    # alternative]; Python (`conditional_expression`) orders [body, condition,
+    # alternative]. Pick the two result operands, never the truthiness-tested one.
+    condition_first = is_dart or node.type == cs.TS_JS_TERNARY_EXPRESSION
+    return [operands[1], operands[2]] if condition_first else [operands[0], operands[2]]
 
 
 def _find_call_arguments_node(call_node: Node) -> Node | None:

--- a/codebase_rag/tests/test_ts_ternary_object_value_arrows.py
+++ b/codebase_rag/tests/test_ts_ternary_object_value_arrows.py
@@ -1,0 +1,90 @@
+# An inline arrow that is a BRANCH of a ternary used as an object-property value
+# (`{ catchValue: cond ? x : () => fallback }`) is stored and invoked later, so
+# it must be referenced, not reported dead. cgr already handled a bare or
+# parenthesised arrow object value; only the ternary branch leaked. Found
+# dogfooding `cgr dead-code` on zod (`new ZodCatch({ catchValue: typeof c ===
+# "function" ? c : () => c })`).
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.types_defs import PropertyDict, PropertyValue, ResultRow
+
+PROJECT = "p"
+
+# Object literal passed to a `new` of a first-party class.
+NEW_EXPR_SRC = """class C { constructor(cfg: any) {} }
+export function reachable(x: any) {
+  return new C({ cb: (typeof x === "function" ? x : () => { fallback(); }) });
+}
+"""
+
+# Object literal passed as a plain call argument.
+CALL_ARG_SRC = """export function reachable(x: any) {
+  return callFoo({ cb: (typeof x === "function" ? x : () => { fallback(); }) });
+}
+"""
+
+
+class _Capture:
+    def __init__(self) -> None:
+        self.rels: list[tuple[PropertyValue, str, PropertyValue]] = []
+
+    def ensure_node_batch(self, label: str, properties: PropertyDict) -> None:
+        return None
+
+    def ensure_relationship_batch(
+        self,
+        from_spec: tuple[str, str, PropertyValue],
+        rel_type: str,
+        to_spec: tuple[str, str, PropertyValue],
+        properties: PropertyDict | None = None,
+    ) -> None:
+        self.rels.append((from_spec[2], str(rel_type), to_spec[2]))
+
+    def flush_all(self) -> None:
+        return None
+
+    def fetch_all(
+        self, query: str, params: PropertyDict | None = None
+    ) -> list[ResultRow]:
+        return []
+
+    def execute_write(self, query: str, params: PropertyDict | None = None) -> None:
+        return None
+
+
+def _anonymous_arrow_referenced(tmp_path: Path, src: str) -> bool:
+    # Each source declares exactly ONE inline arrow (the ternary's alternate
+    # branch); assert it receives a reference edge.
+    (tmp_path / "m.ts").write_text(src)
+    parsers, queries = load_parsers()
+    cap = _Capture()
+    GraphUpdater(
+        ingestor=cap,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name=PROJECT,
+    ).run(force=True)
+    ref_rels = {
+        str(cs.RelationshipType.REFERENCES),
+        str(cs.RelationshipType.CALLS),
+    }
+    return any(
+        rel in ref_rels and cs.PREFIX_ANONYMOUS in str(to).rsplit(".", 1)[-1]
+        for _frm, rel, to in cap.rels
+    )
+
+
+class TestTernaryObjectValueArrows:
+    @pytest.mark.parametrize(
+        "src", [NEW_EXPR_SRC, CALL_ARG_SRC], ids=["new_expr", "call_arg"]
+    )
+    def test_ternary_branch_arrow_referenced(self, tmp_path: Path, src: str) -> None:
+        assert _anonymous_arrow_referenced(tmp_path, src)

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.503"
+version = "0.0.504"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Fixes #962.

## Problem

A TypeScript ternary is the tree-sitter node type `ternary_expression`, but the first-class-value expander only recognised `conditional_expression` (Python's node type). So an inline arrow that is a branch of a ternary used as an object-property value / array element / call argument was never expanded, got no reference edge, and `cgr dead-code` false-flagged it. Found dogfooding zod:

```ts
new ZodCatch({ catchValue: typeof params.catch === "function" ? params.catch : () => params.catch });
```

## Root cause

`_first_class_value_children` gated ternary expansion on `TS_PY_CONDITIONAL_EXPRESSION` ("conditional_expression"), which a TS `ternary_expression` never matches, so the expander returned the ternary node whole and `_emit_value_function_ref` referenced only bare names, never the arrow branch.

The operand order also differs: Python `conditional_expression` is `[consequence, condition, alternative]` (results at 0, 2), while Dart and TS `ternary_expression` are `[condition, consequence, alternative]` (results at 1, 2).

## Fix

- Recognise `ternary_expression` alongside `conditional_expression` in `_first_class_value_children`.
- In `_conditional_result_operands`, select the result operands `[1, 2]` for a TS `ternary_expression` (same as Dart), never the truthiness-tested condition.

This flows through every value-position reference path (object values, array elements, arguments, returns). RED→GREEN test covers a ternary-branch arrow in both a `new`-expression and a plain call-argument object literal.

## Dogfood

Clears zod's ternary object-value factory callbacks (`catchValue` in `new ZodCatch/_Codec/...`). Combined with #963 (arrow-property scope attribution), zod's arrow-property factory dead-code false positives are resolved, leaving only genuine abstract type-anchor constructors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JavaScript and TypeScript conditional-expression handling.
  * Reference and call relationships now correctly follow both ternary branches, including inline arrow functions used as fallback values.
  * Prevented valid code paths from being incorrectly treated as unreachable.

* **Tests**
  * Added regression coverage for ternary branches used in object properties, constructor arguments, and function-call arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->