### PR TITLE
fix: resolve inline arrows through TS casts, short-circuit operators, and ternary RHS

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -382,7 +382,9 @@ def _scope_qn_candidates(scope_qn: str) -> list[str]:
     return [scope_qn, natural]
 
 
-def _first_class_value_children(node: Node, is_dart: bool) -> list[Node] | None:
+def _first_class_value_children(
+    node: Node, is_dart: bool, is_js_ts: bool = False
+) -> list[Node] | None:
     # The wrapped value nodes a container/branch node hands onward, or None
     # for a leaf that IS the first-class value.
     if node.type in _PY_VALUE_WRAPPER_TYPES:
@@ -393,6 +395,22 @@ def _first_class_value_children(node: Node, is_dart: bool) -> list[Node] | None:
         return _py_dict_values(node)
     if node.type in (cs.TS_PY_CONDITIONAL_EXPRESSION, cs.TS_JS_TERNARY_EXPRESSION):
         return _conditional_result_operands(node, is_dart)
+    # A TS cast (`(() => {}) as any`, `fn satisfies T`, `cb!`) is transparent for
+    # first-class-value resolution: the wrapped value is the first named child.
+    if node.type in cs.TS_CAST_WRAPPER_TYPES and node.named_children:
+        return [node.named_children[0]]
+    # A JS/TS short-circuit operator (`fn ?? (() => {})`, `a || cb`) binds one of
+    # its OPERANDS as the value, exactly like Python's boolean_operator; JS/TS
+    # spells it `binary_expression`. Gated to JS/TS: Go and C also use
+    # `binary_expression` with `||`/`&&`, where a bare-name operand resolves to a
+    # boolean, not a callable, and expanding it would fabricate a phantom edge.
+    if (
+        is_js_ts
+        and node.type == cs.TS_BINARY_EXPRESSION
+        and (operator := node.child_by_field_name(cs.FIELD_OPERATOR)) is not None
+        and safe_decode_text(operator) in cs.JS_SHORT_CIRCUIT_OPERATORS
+    ):
+        return list(node.named_children)
     if (
         is_dart
         and node.type.endswith(cs.DART_EXPRESSION_NODE_SUFFIX)
@@ -1140,6 +1158,7 @@ class CallProcessor:
                     None,
                     None,
                     collection_boundaries,
+                    language,
                 )
                 # A module-scope first-class assignment (registry_handler =
                 # handle_event, module.exports.run = run) references its target
@@ -2378,6 +2397,7 @@ class CallProcessor:
                 class_context,
                 self._flow_scope_boundaries(queries[language][cs.QUERY_CONFIG]),
                 caller_qn,
+                language,
             )
         # Dispatch-table handler references, for every flow language. Module-scope
         # literals are scanned explicitly in process_calls_in_file (before the
@@ -2392,6 +2412,7 @@ class CallProcessor:
                 local_var_types,
                 class_context,
                 self._flow_scope_boundaries(queries[language][cs.QUERY_CONFIG]),
+                language,
             )
         if language == cs.SupportedLanguage.GO and caller_type != cs.NodeLabel.MODULE:
             self._ingest_go_composite_function_references(
@@ -3300,14 +3321,18 @@ class CallProcessor:
                     # boolean operands are possible results.
                     if value.type in (
                         cs.TS_PY_CONDITIONAL_EXPRESSION,
+                        cs.TS_JS_TERNARY_EXPRESSION,
                         cs.TS_PY_BOOLEAN_OPERATOR,
                     ):
-                        operands = list(value.named_children)
-                        if (
-                            value.type == cs.TS_PY_CONDITIONAL_EXPRESSION
-                            and len(operands) == 3
-                        ):
-                            operands = [operands[0], operands[2]]
+                        # A boolean-default RHS binds either operand; a ternary
+                        # binds a RESULT operand, never the truthiness-tested
+                        # condition (whose index differs between Python's
+                        # conditional_expression and TS's ternary_expression).
+                        operands = (
+                            list(value.named_children)
+                            if value.type == cs.TS_PY_BOOLEAN_OPERATOR
+                            else _conditional_result_operands(value, False)
+                        )
                         for operand in operands:
                             operand = self._unwrap_ts_value(operand)
                             if (
@@ -3471,6 +3496,7 @@ class CallProcessor:
         class_context: str | None,
         boundary_types: frozenset[str],
         caller_qn: str | None = None,
+        language: cs.SupportedLanguage | None = None,
     ) -> None:
         # A function handed back via `return` (a useEffect cleanup
         # `return () => unsubscribe()`, a factory `return handler`) is invoked by
@@ -3504,7 +3530,7 @@ class CallProcessor:
                     # __reduce__: pickle later calls the first element);
                     # expand containers so each function handed back inside
                     # one is referenced like a bare return.
-                    for expanded in self._expand_py_first_class_values(value):
+                    for expanded in self._expand_py_first_class_values(value, language):
                         self._emit_callback_edge(
                             caller_spec,
                             expanded,
@@ -3529,11 +3555,12 @@ class CallProcessor:
         # bound, so it stays excluded. Any other node comes back unchanged, so
         # non-Python shapes are unaffected.
         is_dart = language == cs.SupportedLanguage.DART
+        is_js_ts = language in cs.JS_TS_LANGUAGES
         out: list[Node] = []
         stack = [value]
         while stack:
             node = stack.pop()
-            children = _first_class_value_children(node, is_dart)
+            children = _first_class_value_children(node, is_dart, is_js_ts)
             if children is None:
                 out.append(node)
             else:
@@ -3565,6 +3592,7 @@ class CallProcessor:
         local_var_types: dict[str, str] | None,
         class_context: str | None,
         boundary_types: frozenset[str],
+        language: cs.SupportedLanguage | None = None,
     ) -> None:
         # A function/method placed as a value in a dict/object or list/array literal
         # is a dispatch table wired to be invoked later (handlers[key](...)),
@@ -3611,7 +3639,9 @@ class CallProcessor:
                         # (django SQLCompiler's `"local_setter": (partial(...)
                         # if ... else local_setter_noop)`) hides the handler
                         # candidates one level down; expand before emitting.
-                        for expanded in self._expand_py_first_class_values(value):
+                        for expanded in self._expand_py_first_class_values(
+                            value, language
+                        ):
                             self._emit_value_function_ref(
                                 expanded,
                                 caller_spec,
@@ -3623,7 +3653,9 @@ class CallProcessor:
                             )
             elif node.type in _SEQUENCE_LIKE_COLLECTION_TYPES:
                 for element in node.named_children:
-                    for expanded in self._expand_py_first_class_values(element):
+                    for expanded in self._expand_py_first_class_values(
+                        element, language
+                    ):
                         self._emit_value_function_ref(
                             expanded,
                             caller_spec,

--- a/codebase_rag/tests/test_ts_cast_logical_value_wrappers.py
+++ b/codebase_rag/tests/test_ts_cast_logical_value_wrappers.py
@@ -1,0 +1,145 @@
+# TypeScript wraps first-class function values in node types Python has no
+# equivalent for, and the first-class-value machinery only recognised the Python
+# shapes. So an inline arrow reached through a TS cast (`(() => {}) as any`), a
+# nullish/logical operator (`fn ?? (() => {})`), or a ternary on a
+# variable-declaration RHS was never referenced and `cgr dead-code` false-flagged
+# it. Found dogfooding zod (`catchValue: (... ? ... : () => ...) as any`,
+# `fn ?? (() => true)`, `const f = typeof d === "function" ? d : () => d`).
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.types_defs import PropertyDict, PropertyValue, ResultRow
+
+PROJECT = "p"
+
+CASES = {
+    # arrow reached through a nullish-coalescing operator, as a call argument
+    "nullish_arg": """export function reachable(fn: any) {
+  return callFoo(fn ?? (() => { used(); }));
+}
+""",
+    # arrow reached through `??`, as an object-property value
+    "nullish_obj_value": """class C { constructor(cfg: any) {} }
+export function reachable(o: any) {
+  return new C({ cb: (o as any) ?? (() => { used(); }) });
+}
+""",
+    # a cast-wrapped inline arrow object value
+    "cast_arrow_obj_value": """class C { constructor(cfg: any) {} }
+export function reachable() {
+  return new C({ cb: ((i: any) => { used(); }) as any });
+}
+""",
+    # a cast-wrapped ternary object value
+    "cast_ternary_obj_value": """class C { constructor(cfg: any) {} }
+export function reachable(x: any) {
+  return new C({ cb: (typeof x === "function" ? x : () => { used(); }) as any });
+}
+""",
+    # a ternary on a variable-declaration RHS
+    "var_decl_ternary": """class C { constructor(cfg: any) {} }
+export function reachable(x: any) {
+  const cb = typeof x === "function" ? x : () => { used(); };
+  return new C({ cb });
+}
+""",
+}
+
+
+class _Capture:
+    def __init__(self) -> None:
+        self.rels: list[tuple[PropertyValue, str, PropertyValue]] = []
+
+    def ensure_node_batch(self, label: str, properties: PropertyDict) -> None:
+        return None
+
+    def ensure_relationship_batch(
+        self,
+        from_spec: tuple[str, str, PropertyValue],
+        rel_type: str,
+        to_spec: tuple[str, str, PropertyValue],
+        properties: PropertyDict | None = None,
+    ) -> None:
+        self.rels.append((from_spec[2], str(rel_type), to_spec[2]))
+
+    def flush_all(self) -> None:
+        return None
+
+    def fetch_all(
+        self, query: str, params: PropertyDict | None = None
+    ) -> list[ResultRow]:
+        return []
+
+    def execute_write(self, query: str, params: PropertyDict | None = None) -> None:
+        return None
+
+
+def _anonymous_arrow_referenced(tmp_path: Path, src: str) -> bool:
+    (tmp_path / "m.ts").write_text(src)
+    parsers, queries = load_parsers()
+    cap = _Capture()
+    GraphUpdater(
+        ingestor=cap,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name=PROJECT,
+    ).run(force=True)
+    ref_rels = {
+        str(cs.RelationshipType.REFERENCES),
+        str(cs.RelationshipType.CALLS),
+    }
+    return any(
+        rel in ref_rels and cs.PREFIX_ANONYMOUS in str(to).rsplit(".", 1)[-1]
+        for _frm, rel, to in cap.rels
+    )
+
+
+class TestTsCastLogicalValueWrappers:
+    @pytest.mark.parametrize("case", sorted(CASES))
+    def test_wrapped_arrow_referenced(self, tmp_path: Path, case: str) -> None:
+        assert _anonymous_arrow_referenced(tmp_path, CASES[case])
+
+
+# Go also spells `a || b` as `binary_expression`, but its operands are booleans,
+# not callables. Expanding them would fabricate a phantom REFERENCES edge to any
+# function whose name collides with a bool local/param. The short-circuit
+# expansion must be gated to JS/TS.
+GO_SRC = """package main
+
+func ready() {}
+
+func check(ready bool) bool { return ready || ready }
+
+func flag() {}
+
+func use(b bool) {}
+
+func run(flag bool) { use(flag || flag) }
+"""
+
+
+def test_go_short_circuit_operands_not_referenced(tmp_path: Path) -> None:
+    (tmp_path / "m.go").write_text(GO_SRC)
+    parsers, queries = load_parsers()
+    cap = _Capture()
+    GraphUpdater(
+        ingestor=cap,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name=PROJECT,
+    ).run(force=True)
+    phantom = [
+        (frm, to)
+        for frm, rel, to in cap.rels
+        if rel == str(cs.RelationshipType.REFERENCES)
+        and (str(to).endswith(".ready") or str(to).endswith(".flag"))
+    ]
+    assert not phantom, f"Go `||` operand fabricated a phantom reference: {phantom}"

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.504"
+version = "0.0.505"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Fixes #966.

## Summary

Inline arrow functions reached through a TypeScript **cast** (`(() => {}) as any`), a **short-circuit operator** (`fn ?? (() => {})`, `x || cb`), or a **ternary on a variable-declaration RHS** are not referenced, so `cgr dead-code` false-flags them. These are the same "TS uses a different tree-sitter node type than Python" class as #962: the first-class-value machinery recognised only the Python shapes.

## Repro

Found dogfooding `cgr dead-code` on [zod](https://github.com/colinhacks/zod). Examples:

```ts
// cast-wrapped arrow object value (v4/core/api.ts _stringbool)
new _Codec({ transform: ((input, payload) => { ... }) as any });

// cast-wrapped ternary object value (v4/core/api.ts _catch)
new Class({ catchValue: (typeof c === "function" ? c : () => c) as any });

// nullish-coalescing argument (v4/classic/schemas.ts custom)
core._custom(ZodCustom, fn ?? (() => true), _params);

// ternary on a variable-declaration RHS (v3/types.ts ZodType.catch)
const catchValueFunc = typeof def === "function" ? def : () => def;
```

## Root cause

`_first_class_value_children` (the first-class-value expander used by object-value, array-element, argument and return references) did not peel TS cast wrappers (`as_expression` / `satisfies_expression` / `non_null_expression`) and did not recognise a TS short-circuit `binary_expression` (`??` / `||` / `&&`); Python's `boolean_operator` is a different node type. Separately, the assignment-RHS handler recognised only Python's `conditional_expression`, not TS's `ternary_expression`, and used the Python operand order.

## Fix

- `_first_class_value_children`: peel TS cast wrappers to the wrapped value, and expand a short-circuit `binary_expression` to its operands.
- Assignment-RHS handler: recognise `ternary_expression` and select result operands via the shared `_conditional_result_operands` (which already knows the TS/Dart vs Python operand order).

## Dogfood

Completes the zod clean-up: dead-code candidates 26 → 2, and the remaining 2 are genuine true positives (`abstract class Class` used only as a type bound, never instantiated).
