### PR TITLE
fix: reference functions bound to class fields and object shorthand properties

### DIFF
--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -82,12 +82,9 @@ TS_REQUIRED_PARAMETER = "required_parameter"
 TS_OPTIONAL_PARAMETER = "optional_parameter"
 TS_ASSIGNMENT_PATTERN = "assignment_pattern"
 TS_JS_ASSIGNMENT_EXPRESSION = "assignment_expression"
-# A class field holding a value: `log = noop` / `helper = () => {}`; `name` is
-# the property, `value` is the initializer.
+# A class field holding a value (`log = noop`); `name` is the property, `value`
+# is the initializer. Used to reference a NAMED function a field binds.
 TS_PUBLIC_FIELD_DEFINITION = "public_field_definition"
-# An object-literal shorthand property `{ retryStrategy }`: the identifier is
-# BOTH the key and the value, so it can name a first-class function value.
-TS_SHORTHAND_PROPERTY_IDENTIFIER = "shorthand_property_identifier"
 # `x += v` and friends: reads the old value AND writes the new one.
 TS_JS_AUGMENTED_ASSIGNMENT_EXPRESSION = "augmented_assignment_expression"
 # `x++` / `--x`: also a read-then-write; the operand is the `argument` field.

--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -82,6 +82,12 @@ TS_REQUIRED_PARAMETER = "required_parameter"
 TS_OPTIONAL_PARAMETER = "optional_parameter"
 TS_ASSIGNMENT_PATTERN = "assignment_pattern"
 TS_JS_ASSIGNMENT_EXPRESSION = "assignment_expression"
+# A class field holding a value: `log = noop` / `helper = () => {}`; `name` is
+# the property, `value` is the initializer.
+TS_PUBLIC_FIELD_DEFINITION = "public_field_definition"
+# An object-literal shorthand property `{ retryStrategy }`: the identifier is
+# BOTH the key and the value, so it can name a first-class function value.
+TS_SHORTHAND_PROPERTY_IDENTIFIER = "shorthand_property_identifier"
 # `x += v` and friends: reads the old value AND writes the new one.
 TS_JS_AUGMENTED_ASSIGNMENT_EXPRESSION = "augmented_assignment_expression"
 # `x++` / `--x`: also a read-then-write; the operand is the `argument` field.

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1144,12 +1144,16 @@ class CallProcessor:
                 collection_boundaries = self._flow_scope_boundaries(
                     queries[language][cs.QUERY_CONFIG]
                 )
-                if language == cs.SupportedLanguage.PYTHON:
-                    # A Python class body executes at import time, so a
-                    # dispatch table stored as a class ATTRIBUTE (django's
-                    # backend `data_types = {"CharField": _get_varchar_...}`)
-                    # is module-load wiring like a module-level table; the scan
-                    # descends through classes but still stops at function
+                if (
+                    language == cs.SupportedLanguage.PYTHON
+                    or language in _JS_TS_LANGUAGES
+                ):
+                    # A Python class body (import time) or a JS/TS class-field
+                    # initializer (construction time) can store a dispatch table
+                    # as a class ATTRIBUTE (django's `data_types = {"CharField":
+                    # _get_varchar_...}`; a JS `opts = { retryStrategy }`), which
+                    # is construction-load wiring like a module-level table; the
+                    # scan descends through classes but still stops at function
                     # scopes. ponytail: decorated classes stay boundaries
                     # (decorated_definition also wraps functions).
                     collection_boundaries = collection_boundaries - frozenset(

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -342,8 +342,9 @@ _ASSIGNMENT_RHS_FIELDS = {
     # callable RHS (an inline arrow or a name resolving to a function) yields an
     # edge; a data RHS (`count += 1`) resolves to nothing and adds none.
     cs.TS_JS_AUGMENTED_ASSIGNMENT_EXPRESSION: cs.TS_FIELD_RIGHT,
-    # A class field bound to a first-class function value (`log = noop`,
-    # `handler = () => {}`) references it exactly like a `const` declarator.
+    # A class field bound to a NAMED first-class function value (`log = noop`)
+    # references it like a `const` declarator. (An inline-arrow field value is a
+    # method definition, referenced elsewhere, not a name to resolve here.)
     cs.TS_PUBLIC_FIELD_DEFINITION: cs.FIELD_VALUE,
     cs.TS_VARIABLE_DECLARATOR: cs.FIELD_VALUE,
     cs.TS_GO_VAR_SPEC: cs.FIELD_VALUE,
@@ -3641,7 +3642,11 @@ class CallProcessor:
                         continue
                     # A SHORTHAND property (`{ retryStrategy }` == `retryStrategy:
                     # retryStrategy`): the identifier is both key and value, so it
-                    # can name a first-class function value to reference.
+                    # can name a first-class function value to reference. ponytail:
+                    # a local data var shadowing a same-named module function is
+                    # over-referenced (the resolver is name-based), matching the
+                    # existing explicit-pair path; a per-scope shadow check is the
+                    # upgrade path if it ever matters.
                     if pair.type == cs.TS_SHORTHAND_PROPERTY_IDENTIFIER:
                         self._emit_callback_edge(
                             caller_spec,

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -342,6 +342,9 @@ _ASSIGNMENT_RHS_FIELDS = {
     # callable RHS (an inline arrow or a name resolving to a function) yields an
     # edge; a data RHS (`count += 1`) resolves to nothing and adds none.
     cs.TS_JS_AUGMENTED_ASSIGNMENT_EXPRESSION: cs.TS_FIELD_RIGHT,
+    # A class field bound to a first-class function value (`log = noop`,
+    # `handler = () => {}`) references it exactly like a `const` declarator.
+    cs.TS_PUBLIC_FIELD_DEFINITION: cs.FIELD_VALUE,
     cs.TS_VARIABLE_DECLARATOR: cs.FIELD_VALUE,
     cs.TS_GO_VAR_SPEC: cs.FIELD_VALUE,
     cs.TS_GO_SHORT_VAR_DECLARATION: cs.TS_FIELD_RIGHT,
@@ -1164,13 +1167,24 @@ class CallProcessor:
                 # handle_event, module.exports.run = run) references its target
                 # even in a file with no calls, so scan before the no-calls
                 # early return.
+                assignment_boundaries = self._flow_scope_boundaries(
+                    queries[language][cs.QUERY_CONFIG]
+                )
+                if language in _JS_TS_LANGUAGES:
+                    # A JS/TS class-field initializer (`log = noop`) runs at
+                    # construction, so descend into class bodies to reference the
+                    # function it binds; the scan still stops at method/function
+                    # scopes, so a local assignment inside a method stays theirs.
+                    assignment_boundaries = assignment_boundaries - frozenset(
+                        queries[language][cs.QUERY_CONFIG].class_node_types
+                    )
                 self._ingest_assignment_function_references(
                     root_node,
                     (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, module_qn),
                     module_qn,
                     None,
                     None,
-                    self._flow_scope_boundaries(queries[language][cs.QUERY_CONFIG]),
+                    assignment_boundaries,
                 )
             if language == cs.SupportedLanguage.GO:
                 # A module-scope Go func map/slice (var funcMap = map[...]{...})
@@ -3623,6 +3637,22 @@ class CallProcessor:
                     if pair.type == cs.TS_METHOD_DEFINITION:
                         self._emit_shorthand_method_ref(
                             pair, caller_spec, module_qn, ensure_rel
+                        )
+                        continue
+                    # A SHORTHAND property (`{ retryStrategy }` == `retryStrategy:
+                    # retryStrategy`): the identifier is both key and value, so it
+                    # can name a first-class function value to reference.
+                    if pair.type == cs.TS_SHORTHAND_PROPERTY_IDENTIFIER:
+                        self._emit_callback_edge(
+                            caller_spec,
+                            pair,
+                            module_qn,
+                            local_var_types,
+                            class_context,
+                            resolve_func,
+                            ensure_rel,
+                            caller_spec[2],
+                            cs.RelationshipType.REFERENCES,
                         )
                         continue
                     if (

--- a/codebase_rag/tests/test_ts_field_and_shorthand_refs.py
+++ b/codebase_rag/tests/test_ts_field_and_shorthand_refs.py
@@ -28,6 +28,15 @@ SHORTHAND_SRC = """export function getOpts() {
 }
 """
 
+# A class field holding an object literal with a shorthand (the collection scan
+# must also descend into class bodies).
+CLASS_FIELD_OBJECT_SRC = """function retryStrategy() {}
+
+export class Client {
+  opts = { retryStrategy };
+}
+"""
+
 
 class _Capture:
     def __init__(self) -> None:
@@ -68,12 +77,9 @@ def _referenced(tmp_path: Path, src: str, leaf: str) -> bool:
         queries=queries,
         project_name=PROJECT,
     ).run(force=True)
-    ref_rels = {
-        str(cs.RelationshipType.REFERENCES),
-        str(cs.RelationshipType.CALLS),
-    }
+    references = str(cs.RelationshipType.REFERENCES)
     return any(
-        rel in ref_rels and str(to).rsplit(".", 1)[-1] == leaf
+        rel == references and str(to).rsplit(".", 1)[-1] == leaf
         for _frm, rel, to in cap.rels
     )
 
@@ -84,3 +90,8 @@ class TestFieldAndShorthandRefs:
 
     def test_object_shorthand_references_function(self, tmp_path: Path) -> None:
         assert _referenced(tmp_path, SHORTHAND_SRC, "retryStrategy")
+
+    def test_class_field_object_shorthand_references_function(
+        self, tmp_path: Path
+    ) -> None:
+        assert _referenced(tmp_path, CLASS_FIELD_OBJECT_SRC, "retryStrategy")

--- a/codebase_rag/tests/test_ts_field_and_shorthand_refs.py
+++ b/codebase_rag/tests/test_ts_field_and_shorthand_refs.py
@@ -1,0 +1,86 @@
+# A function referenced from a CLASS-FIELD initializer (`log = noop`) or an
+# OBJECT SHORTHAND property (`return { retryStrategy }`) must get a REFERENCES
+# edge, or `cgr dead-code` false-flags it. Found dogfooding NestJS
+# (`SilentLogger` assigns a module `noop` to seven fields; `getClientOptions`
+# returns `{ retryStrategy }`).
+from __future__ import annotations
+
+from pathlib import Path
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.types_defs import PropertyDict, PropertyValue, ResultRow
+
+PROJECT = "p"
+
+CLASS_FIELD_SRC = """const noop = () => {};
+
+export class Logger {
+  log = noop;
+  error = noop;
+}
+"""
+
+SHORTHAND_SRC = """export function getOpts() {
+  const retryStrategy = (t: number) => t * 2;
+  return { a: 1, retryStrategy };
+}
+"""
+
+
+class _Capture:
+    def __init__(self) -> None:
+        self.rels: list[tuple[PropertyValue, str, PropertyValue]] = []
+
+    def ensure_node_batch(self, label: str, properties: PropertyDict) -> None:
+        return None
+
+    def ensure_relationship_batch(
+        self,
+        from_spec: tuple[str, str, PropertyValue],
+        rel_type: str,
+        to_spec: tuple[str, str, PropertyValue],
+        properties: PropertyDict | None = None,
+    ) -> None:
+        self.rels.append((from_spec[2], str(rel_type), to_spec[2]))
+
+    def flush_all(self) -> None:
+        return None
+
+    def fetch_all(
+        self, query: str, params: PropertyDict | None = None
+    ) -> list[ResultRow]:
+        return []
+
+    def execute_write(self, query: str, params: PropertyDict | None = None) -> None:
+        return None
+
+
+def _referenced(tmp_path: Path, src: str, leaf: str) -> bool:
+    (tmp_path / "m.ts").write_text(src)
+    parsers, queries = load_parsers()
+    cap = _Capture()
+    GraphUpdater(
+        ingestor=cap,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name=PROJECT,
+    ).run(force=True)
+    ref_rels = {
+        str(cs.RelationshipType.REFERENCES),
+        str(cs.RelationshipType.CALLS),
+    }
+    return any(
+        rel in ref_rels and str(to).rsplit(".", 1)[-1] == leaf
+        for _frm, rel, to in cap.rels
+    )
+
+
+class TestFieldAndShorthandRefs:
+    def test_class_field_initializer_references_function(self, tmp_path: Path) -> None:
+        assert _referenced(tmp_path, CLASS_FIELD_SRC, "noop")
+
+    def test_object_shorthand_references_function(self, tmp_path: Path) -> None:
+        assert _referenced(tmp_path, SHORTHAND_SRC, "retryStrategy")

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.505"
+version = "0.0.507"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Fixes #968.

## Problem
`cgr dead-code` false-flags a function referenced only from a class-field initializer (`log = noop`) or an object shorthand property (`return { retryStrategy }`). Found dogfooding NestJS (`SilentLogger` binds a module `noop` to seven fields; `getClientOptions` returns `{ retryStrategy }`).

## Fix
- The module-level assignment-reference scan now descends into JS/TS class bodies (still stopping at method/function scopes) and maps `public_field_definition` to its `value`, so a class-field initializer references the function it binds.
- Object shorthand properties (`shorthand_property_identifier`) reference the named function.

## Tests
RED→GREEN `test_ts_field_and_shorthand_refs.py`; full unit suite green (5691). NestJS dead-code 38 → 34.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JavaScript and TypeScript code analysis for functions assigned in class fields.
  * Improved reference and call-graph tracking for shorthand properties in object literals.
  * Call and reference relationships are now more accurately captured in these common patterns.

* **Tests**
  * Added coverage for class-field function initializers and object shorthand references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->