### PR TITLE
fix: resolve this.method() self-dispatch through nested arrows to the enclosing class

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -372,6 +372,16 @@ _JSX_NAMED_ELEMENT_TYPES = frozenset(
 # (scope.onSuccess), so a passed object of callbacks must reference each or
 # every TanStack-style callback reports as dead.
 _INLINE_FUNC_VALUE_TYPES = frozenset({cs.TS_ARROW_FUNCTION, cs.TS_FUNCTION_EXPRESSION})
+# JS/TS function scopes that REBIND `this` per call (a plain function /
+# generator / function expression), as opposed to an arrow_function (inherits
+# `this` lexically) or a method_definition / class-field arrow (binds `this` to
+# the instance). Used to tell whether a `this.M()` call site lexically refers to
+# the enclosing class instance.
+_JS_THIS_REBINDING_FUNC_TYPES: frozenset[str] = frozenset(
+    t
+    for t in cs.JS_TS_FUNCTION_NODES
+    if t not in (cs.TS_ARROW_FUNCTION, cs.TS_METHOD_DEFINITION)
+)
 
 
 def _scope_qn_candidates(scope_qn: str) -> list[str]:
@@ -1744,6 +1754,29 @@ class CallProcessor:
         return f"{name}{param_sig}"
 
     @staticmethod
+    def _js_this_is_class_instance(call_node: Node) -> bool:
+        # True when `this` at this JS/TS call site lexically refers to the
+        # enclosing class instance: walk up treating an arrow_function as
+        # transparent (it inherits `this`), stopping at the first scope that
+        # BINDS `this` -- a method_definition or the class itself (a class-field
+        # arrow) means the instance (True); a plain function / generator /
+        # function expression rebinds `this` per call, so `this` is NOT the
+        # instance (False). Prevents a false self-dispatch edge for `this.M()`
+        # inside a plain nested `function(){}` (adversarial review of issue #971).
+        current = call_node.parent
+        while current is not None:
+            node_type = current.type
+            if (
+                node_type == cs.TS_METHOD_DEFINITION
+                or node_type in cs.JS_TS_CLASS_NODES
+            ):
+                return True
+            if node_type in _JS_THIS_REBINDING_FUNC_TYPES:
+                return False
+            current = current.parent
+        return False
+
+    @staticmethod
     def _method_in_class_body(
         method_node: Node, class_body: Node, lang_config: LanguageSpec
     ) -> bool:
@@ -2794,6 +2827,36 @@ class CallProcessor:
                 )
 
             if not callee_info:
+                if (
+                    is_js_ts
+                    and class_context
+                    and call_name.startswith(cs.JS_THIS_CALL_PREFIX)
+                    and self._js_this_is_class_instance(call_node)
+                ):
+                    # `this.M()` binds `this` lexically to the enclosing class
+                    # instance ONLY in a method body or a nested arrow that inherits
+                    # its `this`; a plain nested `function(){}` rebinds `this` per
+                    # call, so `_js_this_is_class_instance` gates those out (JS
+                    # same-syntax/different-semantics). Ordinary name resolution
+                    # climbs one scope from the caller qn -- which lands on the class
+                    # for a direct method but on the METHOD for a nested arrow --
+                    # then falls back to a bare `M` lookup that, under cross-class
+                    # same-name ambiguity, is dropped, so M reports dead (issue
+                    # #971). Anchor on the enclosing class instead and emit the
+                    # self-dispatch edge(s).
+                    _, _, self_method = call_name.partition(cs.SEPARATOR_DOT)
+                    if self_method and cs.SEPARATOR_DOT not in self_method:
+                        for target_type, target_qn in resolver.self_dispatch_targets(
+                            class_context, self_method
+                        ):
+                            for variant in resolver.function_registry.variants(
+                                target_qn
+                            ):
+                                ensure_rel(
+                                    caller_spec,
+                                    calls_rel,
+                                    (target_type, qn_key, variant),
+                                )
                 if is_arg_ref_lang:
                     # The callee is not first-party (a framework/stdlib call such as
                     # grpclib Handler(self.__rpc_x), JS setTimeout(target), or a

--- a/codebase_rag/tests/test_ts_this_dispatch_nested_arrow.py
+++ b/codebase_rag/tests/test_ts_this_dispatch_nested_arrow.py
@@ -1,0 +1,123 @@
+# A `this.method()` self-dispatch inside a NESTED arrow must anchor `this` to the
+# enclosing class, so a method called only from such a position is not dead. The
+# JS/TS `this.M` resolver climbed only one scope level (landing on the class for
+# a direct method but on the method for a nested arrow), then fell back to a
+# bare-name lookup that, under cross-class same-name ambiguity, drops the edge.
+# Found dogfooding NestJS `ListenersController.getContextId` (issue #971): it has
+# 5 same-named siblings across classes, and the real self-call sits inside a
+# nested arrow, so it was reported dead.
+from __future__ import annotations
+
+from pathlib import Path
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.types_defs import PropertyDict, PropertyValue, ResultRow
+
+PROJECT = "p"
+
+# Two classes each declare `getContextId` (the cross-class ambiguity), and A's
+# self-call sits inside a nested arrow bound to a local const.
+AMBIGUOUS_NESTED_ARROW_SRC = """export class Other {
+  getContextId(x: unknown): number { return 2; }
+}
+
+export class A {
+  private getContextId(x: unknown): number { return 1; }
+
+  public make(): (...args: unknown[]) => Promise<number> {
+    const handler = async (...args: unknown[]) => {
+      return this.getContextId(args);
+    };
+    return handler;
+  }
+}
+"""
+
+# A `this.M()` inside a PLAIN nested function (not an arrow) must NOT anchor to
+# the enclosing class: JS rebinds `this` per plain-function call, so it does not
+# refer to the instance. Anchoring here would fabricate a false CALLS edge.
+PLAIN_NESTED_FUNCTION_SRC = """export class Other {
+  getContextId(x: unknown): number { return 2; }
+}
+
+export class A {
+  getContextId(x: unknown): number { return 1; }
+
+  public make(): number {
+    function inner() {
+      return this.getContextId(1);
+    }
+    return inner();
+  }
+}
+"""
+
+
+class _Capture:
+    def __init__(self) -> None:
+        self.rels: list[tuple[PropertyValue, str, PropertyValue]] = []
+
+    def ensure_node_batch(self, label: str, properties: PropertyDict) -> None:
+        return None
+
+    def ensure_relationship_batch(
+        self,
+        from_spec: tuple[str, str, PropertyValue],
+        rel_type: str,
+        to_spec: tuple[str, str, PropertyValue],
+        properties: PropertyDict | None = None,
+    ) -> None:
+        self.rels.append((from_spec[2], str(rel_type), to_spec[2]))
+
+    def flush_all(self) -> None:
+        return None
+
+    def fetch_all(
+        self, query: str, params: PropertyDict | None = None
+    ) -> list[ResultRow]:
+        return []
+
+    def execute_write(self, query: str, params: PropertyDict | None = None) -> None:
+        return None
+
+
+def _run(tmp_path: Path, src: str) -> _Capture:
+    (tmp_path / "m.ts").write_text(src)
+    parsers, queries = load_parsers()
+    cap = _Capture()
+    GraphUpdater(
+        ingestor=cap,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name=PROJECT,
+    ).run(force=True)
+    return cap
+
+
+def _calls_to(cap: _Capture, target_qn: str) -> bool:
+    calls = str(cs.RelationshipType.CALLS)
+    return any(rel == calls and str(to) == target_qn for _f, rel, to in cap.rels)
+
+
+def test_this_call_in_nested_arrow_resolves_to_enclosing_class(
+    tmp_path: Path,
+) -> None:
+    cap = _run(tmp_path, AMBIGUOUS_NESTED_ARROW_SRC)
+    # The self-dispatch must land on A.getContextId (the enclosing class), not be
+    # dropped as ambiguous with Other.getContextId.
+    assert _calls_to(cap, f"{PROJECT}.m.A.getContextId")
+    # And must NOT wrongly resolve to the sibling class's method.
+    assert not _calls_to(cap, f"{PROJECT}.m.Other.getContextId")
+
+
+def test_this_call_in_plain_nested_function_is_not_anchored(
+    tmp_path: Path,
+) -> None:
+    # A plain nested `function(){}` rebinds `this` dynamically, so `this.M()`
+    # inside it does NOT refer to the enclosing class instance; anchoring it to
+    # the class would fabricate a false CALLS edge.
+    cap = _run(tmp_path, PLAIN_NESTED_FUNCTION_SRC)
+    assert not _calls_to(cap, f"{PROJECT}.m.A.getContextId")


### PR DESCRIPTION
## Summary
Closes #971.

A JS/TS `this.method()` call whose `this` is bound lexically to the enclosing
class instance (a method body, or a nested arrow that inherits `this`) was not
resolved when the call sat inside a nested arrow AND several classes declared a
same-named method. Ordinary name resolution climbs one scope from the caller qn
(landing on the class for a direct method, but on the METHOD for a nested
arrow), then falls back to a bare-name lookup that, under cross-class ambiguity,
is dropped. The method then reports dead.

Found dogfooding NestJS `ListenersController.getContextId`: 5 same-named
`getContextId` methods across classes, and the real self-call sits inside the
`requestScopedHandler` nested arrow, so it was reported dead. Full-repo re-index
confirms the fix drops it from the dead list (25 -> 24 findings).

## Fix
In the unresolved-call branch, for JS/TS `this.M()` with an enclosing class,
anchor on the class via `self_dispatch_targets` (the same class-anchored resolver
Python uses for `self.M()`) and emit the self-dispatch edge(s).

Crucially, this is gated by `_js_this_is_class_instance`: arrows inherit `this`
lexically, but a plain nested `function(){}` / generator / function expression
REBINDS `this` per call, so `this.M()` there does NOT refer to the instance. The
gate walks up from the call, treating arrows as transparent and stopping at the
first `this`-binding scope (method/class = instance; plain function = dynamic),
so no false edge is minted for the plain-function case (caught in adversarial
review; the JS same-syntax/different-semantics trap).

## Tests
`test_ts_this_dispatch_nested_arrow.py` (RED->GREEN):
- `this.M()` in a nested arrow under cross-class ambiguity resolves to the
  enclosing class (and NOT the sibling class).
- `this.M()` in a plain nested `function(){}` is NOT anchored (no false edge).

Verified matrix: direct method body, nested arrow, arrow-in-arrow, class-field
arrow -> anchored; plain nested function, arrow-inside-plain-function -> not
anchored. Full unit suite: 5961 passed, 5 pre-existing env skips, 0 failed.
ruff + ty + pre-commit clean; adversarial diff review (which caught the plain-
function defect) re-verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JavaScript and TypeScript call resolution for `this.method()` inside class methods and nested arrow functions.
  * Prevented incorrect method links when `this` is rebound inside nested regular functions.

* **Tests**
  * Added coverage for `this`-based calls in nested arrow functions and regular nested functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->