### PR TITLE
feat: NestJS-aware dead-code roots for DI classes and external OptionsFactory implementers

### DIFF
--- a/codebase_rag/constants/deadcode_roots.py
+++ b/codebase_rag/constants/deadcode_roots.py
@@ -210,6 +210,48 @@ TEST_PATH_PATTERNS: tuple[str, ...] = (
     "__tests__",
 )
 
+# NestJS component decorators that mark a CLASS as instantiated and driven by
+# the DI container / framework, never by a first-party `new` the graph can see:
+# `@Injectable` (providers/services), `@Controller`, `@Module`, `@Catch`
+# (exception filters), `@Resolver` (GraphQL), `@WebSocketGateway`. Such a class's
+# constructor is invoked by the container and its framework-contract methods by
+# Nest, so both are reachability roots (gated by a JS/TS extension). Names are the
+# lowercased, argument-stripped form _norm_decorator produces.
+NEST_ROOT_CLASS_DECORATORS: frozenset[str] = frozenset(
+    {
+        "injectable",
+        "controller",
+        "module",
+        "catch",
+        "resolver",
+        "websocketgateway",
+    }
+)
+
+# NestJS methods invoked by the framework through a lifecycle or interface
+# contract, never by a named call the graph can see: lifecycle hooks
+# (`onModuleInit`, `onApplicationBootstrap`, ...) and the single-method
+# interface contracts (`NestMiddleware.use`, `NestInterceptor.intercept`,
+# `NestModule.configure`, `CanActivate.canActivate`, `ExceptionFilter.catch`,
+# `PipeTransform.transform`). Rooted only on a method of a NestJS component
+# class (a NEST_ROOT_CLASS_DECORATORS decorator), so a same-named ordinary
+# method (`use`, `transform`) on a plain class is NOT force-rooted.
+NEST_FRAMEWORK_METHOD_NAMES: frozenset[str] = frozenset(
+    {
+        "onModuleInit",
+        "onModuleDestroy",
+        "onApplicationBootstrap",
+        "onApplicationShutdown",
+        "beforeApplicationShutdown",
+        "configure",
+        "use",
+        "intercept",
+        "canActivate",
+        "catch",
+        "transform",
+    }
+)
+
 # Python Enum protocol hooks: the enum machinery invokes these sunder
 # METHODS by NAME (_generate_next_value_ on auto(), _missing_ on a failed
 # value lookup), never through a call the graph can see -- runtime roots

--- a/codebase_rag/constants/deadcode_roots.py
+++ b/codebase_rag/constants/deadcode_roots.py
@@ -228,6 +228,14 @@ NEST_ROOT_CLASS_DECORATORS: frozenset[str] = frozenset(
     }
 )
 
+# NestJS async-options factory interfaces follow the `XxxOptionsFactory` naming
+# convention (`TypeOrmOptionsFactory`, `MongooseOptionsFactory`,
+# `GqlOptionsFactory`, ...). A class that `implements` one has its factory method
+# invoked by Nest, so its methods are roots. Matched on the interface leaf name
+# so only these framework contracts root (an unrelated third-party interface
+# does not), gated to an EXTERNAL interface (outside the project prefix).
+NEST_OPTIONS_FACTORY_SUFFIX = "OptionsFactory"
+
 # NestJS methods invoked by the framework through a lifecycle or interface
 # contract, never by a named call the graph can see: lifecycle hooks
 # (`onModuleInit`, `onApplicationBootstrap`, ...) and the single-method

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -187,7 +187,8 @@ ORDER BY count DESC
 # query timeout on big projects (django: 31k roots, 101k CALLS edges). These
 # two linear scans fetch the project's nodes and edges instead; the target
 # of a relationship is deliberately unfiltered so INHERITS to an external
-# base (typing.Protocol) and OVERRIDES of external methods stay visible.
+# base (typing.Protocol), OVERRIDES of external methods, and IMPLEMENTS of an
+# external interface (NestJS `...OptionsFactory`) stay visible.
 _DEAD_CODE_NODE_LABELS = "|".join(
     (
         NodeLabel.FUNCTION.value,
@@ -205,6 +206,7 @@ _DEAD_CODE_REL_TYPES = "|".join(
         RelationshipType.DEFINES.value,
         RelationshipType.DEFINES_METHOD.value,
         RelationshipType.OVERRIDES.value,
+        RelationshipType.IMPLEMENTS.value,
     )
 )
 

--- a/codebase_rag/dead_code.py
+++ b/codebase_rag/dead_code.py
@@ -31,6 +31,8 @@ _INHERITS = cs.RelationshipType.INHERITS.value
 _DEFINES = cs.RelationshipType.DEFINES.value
 _DEFINES_METHOD = cs.RelationshipType.DEFINES_METHOD.value
 _OVERRIDES = cs.RelationshipType.OVERRIDES.value
+_IMPLEMENTS = cs.RelationshipType.IMPLEMENTS.value
+_JS_TS_EXTS = cs.TS_EXTENSIONS + cs.TSX_EXTENSIONS + cs.JS_EXTENSIONS
 _NodeId = tuple[str, PropertyValue]
 _RelTuple = tuple[str, PropertyValue, str, str, PropertyValue]
 
@@ -170,6 +172,37 @@ def _has_root_decorator(props: PropertyDict, root_decorators: frozenset[str]) ->
     return any(_norm_decorator(str(d)) in root_decorators for d in decorators)
 
 
+def _is_nest_root(
+    qn: str,
+    member: str,
+    is_method: bool,
+    path: str,
+    method_to_class: dict[str, str],
+    class_decorators_norm: dict[str, frozenset[str]],
+    external_impl_classes: set[str],
+) -> bool:
+    # NestJS runs code the static graph sees no call to. A class decorated
+    # @Injectable/@Controller/@Module/... is instantiated by the DI container
+    # (root its constructor) and driven by the framework through lifecycle and
+    # single-method interface contracts (root those methods by name). A class
+    # implementing an EXTERNAL `...OptionsFactory` interface has its methods
+    # invoked by Nest, so root them all (mirrors overrides_external). Gated to
+    # JS/TS methods; a same-named ordinary method on a plain class is untouched.
+    if not is_method or not path.endswith(_JS_TS_EXTS):
+        return False
+    cls = method_to_class.get(qn)
+    if cls is None:
+        return False
+    if cls in external_impl_classes:
+        return True
+    decorators = class_decorators_norm.get(cls)
+    if decorators and decorators & cs.NEST_ROOT_CLASS_DECORATORS:
+        return (
+            member == cs.KEYWORD_CONSTRUCTOR or member in cs.NEST_FRAMEWORK_METHOD_NAMES
+        )
+    return False
+
+
 def _walk(
     frontier: set[str],
     adjacency: dict[str, set[str]],
@@ -205,10 +238,20 @@ def dead_code_from_graph(
     props_by_qn: dict[str, PropertyDict] = {}
     method_qns: set[str] = set()
     module_path: dict[str, str] = {}
+    # Normalized decorators per CLASS qn (collected for every class, not just
+    # class candidates), so a method root rule can consult its class's
+    # @Injectable/@Controller/@Module marker (NestJS DI roots, issue #973).
+    class_decorators_norm: dict[str, frozenset[str]] = {}
     for (label, uid), props in nodes.items():
         if label == _MODULE:
             module_path[str(uid)] = str(props.get(cs.KEY_PATH, ""))
-        elif label in labels and str(uid).startswith(project_prefix):
+        if label == _CLASS:
+            decorators = props.get(cs.KEY_DECORATORS)
+            if isinstance(decorators, list):
+                class_decorators_norm[str(uid)] = frozenset(
+                    _norm_decorator(str(d)) for d in decorators
+                )
+        if label in labels and str(uid).startswith(project_prefix):
             # With tests excluded, a test-file symbol's only callers are
             # excluded as roots, so reporting it is noise (test helpers and
             # mocks are infrastructure, not dead production code).
@@ -229,6 +272,10 @@ def dead_code_from_graph(
     protocol_classes: set[str] = set()
     class_methods: list[tuple[str, str]] = []
     nested_class_pairs: list[tuple[str, str]] = []
+    # A class implementing an interface NOT defined in this project (an external
+    # framework interface such as NestJS `...OptionsFactory`) has its methods
+    # invoked by that framework (issue #973).
+    external_impl_classes: set[str] = set()
     for from_label, from_val, rel_type, to_label, to_val in rels:
         if rel_type == _DEFINES and from_label in (_FUNCTION, _METHOD):
             defines_pairs.append((str(from_val), str(to_val)))
@@ -238,6 +285,8 @@ def dead_code_from_graph(
             protocol_classes.add(str(from_val))
         elif rel_type == _DEFINES_METHOD:
             class_methods.append((str(from_val), str(to_val)))
+        elif rel_type == _IMPLEMENTS and not str(to_val).startswith(project_prefix):
+            external_impl_classes.add(str(from_val))
         if from_label != _MODULE or rel_type not in module_rels:
             continue
         target_qn = str(to_val)
@@ -248,6 +297,7 @@ def dead_code_from_graph(
         if config.include_tests or not is_test:
             roots.add(target_qn)
     protocol_stubs = {m for c, m in class_methods if c in protocol_classes}
+    method_to_class = {m: c for c, m in class_methods}
 
     for qn in candidates:
         if qn in roots:
@@ -304,6 +354,16 @@ def dead_code_from_graph(
         ):
             roots.add(qn)
         elif _is_csharp_operator_or_finalizer_root(leaf, path):
+            roots.add(qn)
+        elif _is_nest_root(
+            qn,
+            leaf.split(cs.CHAR_PAREN_OPEN, 1)[0],
+            qn in method_qns,
+            path,
+            method_to_class,
+            class_decorators_norm,
+            external_impl_classes,
+        ):
             roots.add(qn)
         elif any(qn.endswith(entry) for entry in config.entry_points):
             roots.add(qn)

--- a/codebase_rag/dead_code.py
+++ b/codebase_rag/dead_code.py
@@ -172,6 +172,17 @@ def _has_root_decorator(props: PropertyDict, root_decorators: frozenset[str]) ->
     return any(_norm_decorator(str(d)) in root_decorators for d in decorators)
 
 
+def _is_nest_component_class(
+    class_qn: str,
+    class_decorators_norm: dict[str, frozenset[str]],
+    nest_factory_classes: set[str],
+) -> bool:
+    if class_qn in nest_factory_classes:
+        return True
+    decorators = class_decorators_norm.get(class_qn)
+    return bool(decorators and decorators & cs.NEST_ROOT_CLASS_DECORATORS)
+
+
 def _is_nest_root(
     qn: str,
     member: str,
@@ -179,21 +190,28 @@ def _is_nest_root(
     path: str,
     method_to_class: dict[str, str],
     class_decorators_norm: dict[str, frozenset[str]],
-    external_impl_classes: set[str],
+    nest_factory_classes: set[str],
 ) -> bool:
     # NestJS runs code the static graph sees no call to. A class decorated
     # @Injectable/@Controller/@Module/... is instantiated by the DI container
     # (root its constructor) and driven by the framework through lifecycle and
     # single-method interface contracts (root those methods by name). A class
-    # implementing an EXTERNAL `...OptionsFactory` interface has its methods
-    # invoked by Nest, so root them all (mirrors overrides_external). Gated to
-    # JS/TS methods; a same-named ordinary method on a plain class is untouched.
-    if not is_method or not path.endswith(_JS_TS_EXTS):
+    # implementing an EXTERNAL `...OptionsFactory` interface has its factory
+    # method invoked by Nest, so root all its methods (mirrors overrides_external).
+    # Gated to JS/TS; a same-named ordinary method on a plain class is untouched.
+    if not path.endswith(_JS_TS_EXTS):
         return False
+    if not is_method:
+        # A CLASS-node candidate (only present with --classes): the component
+        # class is instantiated by the container, so it roots itself -- a rooted
+        # constructor cannot revive it because DEFINES_METHOD is not a
+        # reachability edge. (A non-class, non-method candidate -- a bare
+        # function -- is not in either map, so this returns False.)
+        return _is_nest_component_class(qn, class_decorators_norm, nest_factory_classes)
     cls = method_to_class.get(qn)
     if cls is None:
         return False
-    if cls in external_impl_classes:
+    if cls in nest_factory_classes:
         return True
     decorators = class_decorators_norm.get(cls)
     if decorators and decorators & cs.NEST_ROOT_CLASS_DECORATORS:
@@ -272,10 +290,11 @@ def dead_code_from_graph(
     protocol_classes: set[str] = set()
     class_methods: list[tuple[str, str]] = []
     nested_class_pairs: list[tuple[str, str]] = []
-    # A class implementing an interface NOT defined in this project (an external
-    # framework interface such as NestJS `...OptionsFactory`) has its methods
-    # invoked by that framework (issue #973).
-    external_impl_classes: set[str] = set()
+    # A class implementing an EXTERNAL NestJS `...OptionsFactory` interface (one
+    # not defined in this project) has its factory method invoked by Nest, so its
+    # methods are roots (issue #973). Restricted to that naming convention so an
+    # unrelated third-party interface implementer is not force-rooted.
+    nest_factory_classes: set[str] = set()
     for from_label, from_val, rel_type, to_label, to_val in rels:
         if rel_type == _DEFINES and from_label in (_FUNCTION, _METHOD):
             defines_pairs.append((str(from_val), str(to_val)))
@@ -285,8 +304,14 @@ def dead_code_from_graph(
             protocol_classes.add(str(from_val))
         elif rel_type == _DEFINES_METHOD:
             class_methods.append((str(from_val), str(to_val)))
-        elif rel_type == _IMPLEMENTS and not str(to_val).startswith(project_prefix):
-            external_impl_classes.add(str(from_val))
+        elif (
+            rel_type == _IMPLEMENTS
+            and not str(to_val).startswith(project_prefix)
+            and str(to_val)
+            .rsplit(cs.SEPARATOR_DOT, 1)[-1]
+            .endswith(cs.NEST_OPTIONS_FACTORY_SUFFIX)
+        ):
+            nest_factory_classes.add(str(from_val))
         if from_label != _MODULE or rel_type not in module_rels:
             continue
         target_qn = str(to_val)
@@ -362,7 +387,7 @@ def dead_code_from_graph(
             path,
             method_to_class,
             class_decorators_norm,
-            external_impl_classes,
+            nest_factory_classes,
         ):
             roots.add(qn)
         elif any(qn.endswith(entry) for entry in config.entry_points):

--- a/codebase_rag/tests/test_nest_dead_code_roots.py
+++ b/codebase_rag/tests/test_nest_dead_code_roots.py
@@ -1,0 +1,158 @@
+# NestJS-aware dead-code reachability roots (issue #973): a class decorated
+# @Injectable/@Controller/@Module is instantiated by the DI container and driven
+# by the framework, so its constructor and lifecycle/interface-contract methods
+# are roots; a class implementing an external `...OptionsFactory` interface has
+# its methods invoked by Nest. Same-named ordinary methods on a plain class must
+# NOT be force-rooted.
+from __future__ import annotations
+
+from codebase_rag import constants as cs
+from codebase_rag import cypher_queries as cq
+from codebase_rag.dead_code import collect_dead_code, default_dead_code_config
+from codebase_rag.types_defs import ResultRow
+
+_MODULE = cs.NodeLabel.MODULE.value
+_CLASS = cs.NodeLabel.CLASS.value
+_METHOD = cs.NodeLabel.METHOD.value
+_FUNCTION = cs.NodeLabel.FUNCTION.value
+_DEFINES_METHOD = cs.RelationshipType.DEFINES_METHOD.value
+_IMPLEMENTS = cs.RelationshipType.IMPLEMENTS.value
+
+_PATH = "proj/app.module.ts"
+
+
+class FakeIngestor:
+    def __init__(self, nodes: list[ResultRow], rels: list[ResultRow]) -> None:
+        self._nodes = nodes
+        self._rels = rels
+
+    def fetch_all(
+        self, query: str, params: dict[str, str] | None = None
+    ) -> list[ResultRow]:
+        if query == cq.CYPHER_DEAD_CODE_NODES:
+            return self._nodes
+        return self._rels
+
+
+def _node(
+    label: str, qn: str, name: str, decorators: list[str] | None = None
+) -> ResultRow:
+    return {
+        "label": label,
+        "qualified_name": qn,
+        "name": name,
+        "path": _PATH,
+        "start_line": 1,
+        "end_line": 2,
+        "decorators": decorators or [],
+        "is_exported": False,
+        "overrides_external": False,
+    }
+
+
+def _rel(
+    from_label: str, from_qn: str, rel_type: str, to_label: str, to_qn: str
+) -> ResultRow:
+    return {
+        "from_label": from_label,
+        "from_qn": from_qn,
+        "rel_type": rel_type,
+        "to_label": to_label,
+        "to_qn": to_qn,
+    }
+
+
+def _dead(nodes: list[ResultRow], rels: list[ResultRow]) -> set[str]:
+    # include_classes False: we only assert about function/method candidates.
+    config = default_dead_code_config(include_tests=True, include_classes=False)
+    return {
+        row["qualified_name"]
+        for row in collect_dead_code(FakeIngestor(nodes, rels), "proj", config)
+    }
+
+
+def test_injectable_constructor_and_framework_methods_are_roots() -> None:
+    # A DI class: its constructor is container-invoked; `use`/`onModuleInit` are
+    # framework-invoked. Only the plain private helper is genuinely dead.
+    nodes = [
+        _node(_MODULE, "proj.app.module", "app.module"),
+        _node(_CLASS, "proj.app.module.Svc", "Svc", ["@Injectable()"]),
+        _node(_METHOD, "proj.app.module.Svc.constructor", "constructor"),
+        _node(_METHOD, "proj.app.module.Svc.use", "use"),
+        _node(_METHOD, "proj.app.module.Svc.onModuleInit", "onModuleInit"),
+        _node(_METHOD, "proj.app.module.Svc.helper", "helper"),
+    ]
+    rels = [
+        _rel(_CLASS, "proj.app.module.Svc", _DEFINES_METHOD, _METHOD, m)
+        for m in (
+            "proj.app.module.Svc.constructor",
+            "proj.app.module.Svc.use",
+            "proj.app.module.Svc.onModuleInit",
+            "proj.app.module.Svc.helper",
+        )
+    ]
+    dead = _dead(nodes, rels)
+    assert "proj.app.module.Svc.constructor" not in dead
+    assert "proj.app.module.Svc.use" not in dead
+    assert "proj.app.module.Svc.onModuleInit" not in dead
+    # A non-framework private helper on a DI class is still genuinely dead.
+    assert "proj.app.module.Svc.helper" in dead
+
+
+def test_external_options_factory_methods_are_roots() -> None:
+    # A class implementing an EXTERNAL `...OptionsFactory` interface has its
+    # methods invoked by Nest.
+    nodes = [
+        _node(_MODULE, "proj.app.module", "app.module"),
+        _node(_CLASS, "proj.app.module.ConfigService", "ConfigService"),
+        _node(
+            _METHOD,
+            "proj.app.module.ConfigService.createTypeOrmOptions",
+            "createTypeOrmOptions",
+        ),
+    ]
+    rels = [
+        _rel(
+            _CLASS,
+            "proj.app.module.ConfigService",
+            _DEFINES_METHOD,
+            _METHOD,
+            "proj.app.module.ConfigService.createTypeOrmOptions",
+        ),
+        _rel(
+            _CLASS,
+            "proj.app.module.ConfigService",
+            _IMPLEMENTS,
+            _CLASS,
+            "@nestjs.typeorm.TypeOrmOptionsFactory",
+        ),
+    ]
+    dead = _dead(nodes, rels)
+    assert "proj.app.module.ConfigService.createTypeOrmOptions" not in dead
+
+
+def test_dead_code_rels_query_fetches_implements_edges() -> None:
+    # The external-interface (`...OptionsFactory`) root rule is fed by IMPLEMENTS
+    # edges, so the rel-fetch query must include that relationship type.
+    assert cs.RelationshipType.IMPLEMENTS.value in cq.CYPHER_DEAD_CODE_RELS
+
+
+def test_plain_class_framework_named_method_is_not_rooted() -> None:
+    # `use` on a plain (undecorated, non-implementing) class must stay dead:
+    # the NestJS name set only roots on a NestJS component class.
+    nodes = [
+        _node(_MODULE, "proj.app.module", "app.module"),
+        _node(_CLASS, "proj.app.module.Plain", "Plain"),
+        _node(_METHOD, "proj.app.module.Plain.use", "use"),
+    ]
+    rels = [
+        _rel(
+            _CLASS,
+            "proj.app.module.Plain",
+            _DEFINES_METHOD,
+            _METHOD,
+            "proj.app.module.Plain.use",
+        )
+    ]
+    dead = _dead(nodes, rels)
+    assert "proj.app.module.Plain.use" in dead

--- a/codebase_rag/tests/test_nest_dead_code_roots.py
+++ b/codebase_rag/tests/test_nest_dead_code_roots.py
@@ -62,9 +62,12 @@ def _rel(
     }
 
 
-def _dead(nodes: list[ResultRow], rels: list[ResultRow]) -> set[str]:
-    # include_classes False: we only assert about function/method candidates.
-    config = default_dead_code_config(include_tests=True, include_classes=False)
+def _dead(
+    nodes: list[ResultRow], rels: list[ResultRow], include_classes: bool = False
+) -> set[str]:
+    config = default_dead_code_config(
+        include_tests=True, include_classes=include_classes
+    )
     return {
         row["qualified_name"]
         for row in collect_dead_code(FakeIngestor(nodes, rels), "proj", config)
@@ -135,6 +138,57 @@ def test_dead_code_rels_query_fetches_implements_edges() -> None:
     # The external-interface (`...OptionsFactory`) root rule is fed by IMPLEMENTS
     # edges, so the rel-fetch query must include that relationship type.
     assert cs.RelationshipType.IMPLEMENTS.value in cq.CYPHER_DEAD_CODE_RELS
+
+
+def test_component_class_node_is_rooted_with_include_classes() -> None:
+    # With --classes, the CLASS node is a candidate. A non-exported @Injectable
+    # component class is instantiated by the container, so the class node itself
+    # must be a root (a rooted constructor cannot revive it: DEFINES_METHOD is
+    # not a reachability edge).
+    nodes = [
+        _node(_MODULE, "proj.app.module", "app.module"),
+        _node(_CLASS, "proj.app.module.Svc", "Svc", ["@Injectable()"]),
+        _node(_METHOD, "proj.app.module.Svc.constructor", "constructor"),
+    ]
+    rels = [
+        _rel(
+            _CLASS,
+            "proj.app.module.Svc",
+            _DEFINES_METHOD,
+            _METHOD,
+            "proj.app.module.Svc.constructor",
+        )
+    ]
+    dead = _dead(nodes, rels, include_classes=True)
+    assert "proj.app.module.Svc" not in dead
+
+
+def test_non_nest_external_interface_helper_stays_dead() -> None:
+    # Implementing an unrelated third-party interface (NOT a NestJS
+    # `...OptionsFactory`) must NOT root the class's private helpers.
+    nodes = [
+        _node(_MODULE, "proj.app.module", "app.module"),
+        _node(_CLASS, "proj.app.module.Widget", "Widget"),
+        _node(_METHOD, "proj.app.module.Widget.helper", "helper"),
+    ]
+    rels = [
+        _rel(
+            _CLASS,
+            "proj.app.module.Widget",
+            _DEFINES_METHOD,
+            _METHOD,
+            "proj.app.module.Widget.helper",
+        ),
+        _rel(
+            _CLASS,
+            "proj.app.module.Widget",
+            _IMPLEMENTS,
+            _CLASS,
+            "some.thirdparty.Comparable",
+        ),
+    ]
+    dead = _dead(nodes, rels)
+    assert "proj.app.module.Widget.helper" in dead
 
 
 def test_plain_class_framework_named_method_is_not_rooted() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.509"
+version = "0.0.510"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
NestJS runs a lot of code the static graph sees no call to (the DI/framework
idiom), producing dead-code false positives. This adds NestJS-aware reachability
roots, mirroring cgr's existing Flask/FastAPI (`@route`) and C# (`[HttpGet]`)
framework roots:

- **DI-decorated classes** (`@Injectable`/`@Controller`/`@Module`/`@Catch`/
  `@Resolver`/`@WebSocketGateway`) are instantiated by the container and driven
  by Nest, so their **constructor** and **lifecycle/interface-contract methods**
  (`onModuleInit`, `onApplicationBootstrap`, `use`, `intercept`, `configure`,
  `canActivate`, `catch`, `transform`, ...) are roots. The framework method names
  root only on a NestJS component class, so a same-named ordinary method on a
  plain class is not force-rooted.
- **External-interface implementers**: a class with an `IMPLEMENTS` edge to an
  interface outside the project (e.g. `@nestjs.typeorm.TypeOrmOptionsFactory`)
  has its methods invoked by Nest, so they are roots (mirrors the existing
  `overrides_external` rule). This required adding `IMPLEMENTS` to the dead-code
  rel-fetch query, which previously omitted it.

Validated by re-running dead-code on a full NestJS index: **24 -> 9 findings**.
The remaining 9 carry no NestJS DI signal (a provider without `@Injectable`, a
factory without an `implements` clause, genuinely-dead example helpers), so they
are correctly out of scope for this decorator/interface-driven approach.

## Type of Change
- [x] Feature (dead-code precision; eliminates the NestJS DI false-positive class)

## Related Issues
Closes #973.

## Test Plan
- [x] `test_nest_dead_code_roots.py`: RED->GREEN for (a) `@Injectable` constructor
  + framework methods rooted while a plain private helper stays dead, (b) external
  `OptionsFactory` methods rooted, (c) a same-named `use` on a plain class stays
  dead (no over-rooting), (d) the rel query fetches `IMPLEMENTS`.
- [x] Existing dead-code root suites (C#, C/C++, collect) still pass.
- [x] Full unit suite: 5965 passed, 5 pre-existing env skips, 0 failed.
- [x] Real NestJS repo: 24 -> 9 dead-code findings, no over-rooting.
- [x] ruff / ty / pre-commit clean; adversarial diff review found no defect.

## Checklist
- [x] PR title follows Conventional Commits
- [x] RED demonstrated before the change
- [x] Framework roots gated to JS/TS extensions
- [x] Known, intended tradeoff documented below

## Note (intended tradeoff)
The external-interface rule roots every method of a class implementing an
external interface (not only `create*Options`), consistent with how NestJS
contract interfaces work and with `overrides_external`. A private helper on such
a class is therefore treated as reachable; in practice these classes are small
factories/guards and their helpers are reached through normal CALLS edges anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced dead-code analysis for NestJS apps by treating DI-instantiated classes, constructors, and framework-invoked lifecycle methods as reachable.
  - Expanded rooting to include external `...OptionsFactory` implementations detected via interface implementation relationships.

- **Tests**
  - Added/updated coverage to verify Nest-specific roots are retained (including when class rooting is enabled).
  - Added negative coverage to ensure unrelated third-party interface helpers remain flagged as dead.
  - Confirmed reachability logic now includes `IMPLEMENTS` relationships for external interface rooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->