### PR TITLE
feat: React class-component lifecycle methods are dead-code roots

### DIFF
--- a/codebase_rag/constants/deadcode_roots.py
+++ b/codebase_rag/constants/deadcode_roots.py
@@ -260,6 +260,45 @@ NEST_FRAMEWORK_METHOD_NAMES: frozenset[str] = frozenset(
     }
 )
 
+# React component base classes: a class that `extends` one of these is a class
+# component whose lifecycle methods React drives at runtime. Matched on the base
+# interface/class leaf name (`React.Component`, `PureComponent`, and the rarely
+# spelled-out `React.PureComponent`), so the INHERITS target's last segment
+# identifies it regardless of the import alias.
+REACT_COMPONENT_BASE_NAMES: frozenset[str] = frozenset({"Component", "PureComponent"})
+
+# The module-namespace token that distinguishes React's `Component`/`PureComponent`
+# base (`react.Component`, `React.Component`) from an unrelated base sharing that
+# simple name (Ember/Glimmer's `@glimmer/component.Component`). Lowercased match.
+REACT_NAMESPACE_TOKEN = "react"
+
+# React class-component lifecycle methods the runtime invokes (mount/update/
+# unmount/render/error), plus the constructor React calls when it instantiates
+# the component. Never called by a first-party call the graph can see, so they
+# are reachability roots on a React component class (gated by INHERITS to a
+# REACT_COMPONENT_BASE_NAMES base and a JS/TS extension); the methods and
+# callbacks they reach via `this.` then expand from them.
+REACT_LIFECYCLE_METHOD_NAMES: frozenset[str] = frozenset(
+    {
+        "render",
+        "constructor",
+        "componentDidMount",
+        "componentDidUpdate",
+        "componentWillUnmount",
+        "shouldComponentUpdate",
+        "getSnapshotBeforeUpdate",
+        "componentDidCatch",
+        "getDerivedStateFromProps",
+        "getDerivedStateFromError",
+        "componentWillMount",
+        "componentWillReceiveProps",
+        "componentWillUpdate",
+        "UNSAFE_componentWillMount",
+        "UNSAFE_componentWillReceiveProps",
+        "UNSAFE_componentWillUpdate",
+    }
+)
+
 # Python Enum protocol hooks: the enum machinery invokes these sunder
 # METHODS by NAME (_generate_next_value_ on auto(), _missing_ on a failed
 # value lookup), never through a call the graph can see -- runtime roots

--- a/codebase_rag/constants/deadcode_roots.py
+++ b/codebase_rag/constants/deadcode_roots.py
@@ -267,9 +267,10 @@ NEST_FRAMEWORK_METHOD_NAMES: frozenset[str] = frozenset(
 # identifies it regardless of the import alias.
 REACT_COMPONENT_BASE_NAMES: frozenset[str] = frozenset({"Component", "PureComponent"})
 
-# The module-namespace token that distinguishes React's `Component`/`PureComponent`
-# base (`react.Component`, `React.Component`) from an unrelated base sharing that
-# simple name (Ember/Glimmer's `@glimmer/component.Component`). Lowercased match.
+# The module namespace React's `Component`/`PureComponent` base lives in
+# (`react.Component`, `React.Component`). The base's namespace must equal this
+# EXACTLY (lowercased), so a look-alike (`preact.Component`, `notreact.Component`,
+# Ember/Glimmer's `@glimmer/component.Component`) is not mistaken for React.
 REACT_NAMESPACE_TOKEN = "react"
 
 # React class-component lifecycle methods the runtime invokes (mount/update/

--- a/codebase_rag/dead_code.py
+++ b/codebase_rag/dead_code.py
@@ -221,6 +221,43 @@ def _is_nest_root(
     return False
 
 
+def _is_react_base_qn(base_qn: str) -> bool:
+    # A React component base: the simple name is `Component`/`PureComponent` AND
+    # it lives in a react-namespaced module (`react.Component`, `React.Component`,
+    # `react.PureComponent`). The namespace check keeps an unrelated base that
+    # merely SHARES the `Component` simple name (Ember/Glimmer's
+    # `@glimmer/component.Component`, a bespoke `ui.Component`) from being taken
+    # for React.
+    namespace, sep, leaf = base_qn.rpartition(cs.SEPARATOR_DOT)
+    return (
+        bool(sep)
+        and leaf in cs.REACT_COMPONENT_BASE_NAMES
+        and cs.REACT_NAMESPACE_TOKEN in namespace.lower()
+    )
+
+
+def _is_react_root(
+    qn: str,
+    member: str,
+    is_method: bool,
+    path: str,
+    method_to_class: dict[str, str],
+    react_component_classes: set[str],
+) -> bool:
+    # A React class-component lifecycle method (render/componentDidMount/... and
+    # the constructor React calls on instantiation) is invoked by React, never by
+    # a first-party call the graph sees, so it is a reachability root on a class
+    # that INHERITS a React component base. The methods/callbacks it reaches via
+    # `this.` then expand from it. Gated to JS/TS methods; a same-named method on
+    # a plain (non-React) class is untouched.
+    if not is_method or not path.endswith(_JS_TS_EXTS):
+        return False
+    if member not in cs.REACT_LIFECYCLE_METHOD_NAMES:
+        return False
+    cls = method_to_class.get(qn)
+    return cls is not None and cls in react_component_classes
+
+
 def _walk(
     frontier: set[str],
     adjacency: dict[str, set[str]],
@@ -295,13 +332,23 @@ def dead_code_from_graph(
     # methods are roots (issue #973). Restricted to that naming convention so an
     # unrelated third-party interface implementer is not force-rooted.
     nest_factory_classes: set[str] = set()
+    # A class that `extends` a React component base (directly or through a
+    # first-party intermediate base) is a class component whose lifecycle methods
+    # React drives at runtime (issue #978). Seeds are direct extenders; the
+    # transitive closure over INHERITS is computed after the scan.
+    react_component_classes: set[str] = set()
+    inherits_subclasses: dict[str, set[str]] = defaultdict(set)
     for from_label, from_val, rel_type, to_label, to_val in rels:
         if rel_type == _DEFINES and from_label in (_FUNCTION, _METHOD):
             defines_pairs.append((str(from_val), str(to_val)))
             if to_label == _CLASS:
                 nested_class_pairs.append((str(from_val), str(to_val)))
-        elif rel_type == _INHERITS and str(to_val) in cs.PROTOCOL_BASE_QNS:
-            protocol_classes.add(str(from_val))
+        elif rel_type == _INHERITS:
+            inherits_subclasses[str(to_val)].add(str(from_val))
+            if str(to_val) in cs.PROTOCOL_BASE_QNS:
+                protocol_classes.add(str(from_val))
+            elif _is_react_base_qn(str(to_val)):
+                react_component_classes.add(str(from_val))
         elif rel_type == _DEFINES_METHOD:
             class_methods.append((str(from_val), str(to_val)))
         elif (
@@ -323,6 +370,10 @@ def dead_code_from_graph(
             roots.add(target_qn)
     protocol_stubs = {m for c, m in class_methods if c in protocol_classes}
     method_to_class = {m: c for c, m in class_methods}
+    # Expand React components down the inheritance tree: a class extending a
+    # first-party base that (transitively) extends react.Component is itself a
+    # React component (a shared `BaseComponent extends React.Component` is common).
+    _walk(set(react_component_classes), inherits_subclasses, react_component_classes)
 
     for qn in candidates:
         if qn in roots:
@@ -388,6 +439,15 @@ def dead_code_from_graph(
             method_to_class,
             class_decorators_norm,
             nest_factory_classes,
+        ):
+            roots.add(qn)
+        elif _is_react_root(
+            qn,
+            leaf.split(cs.CHAR_PAREN_OPEN, 1)[0],
+            qn in method_qns,
+            path,
+            method_to_class,
+            react_component_classes,
         ):
             roots.add(qn)
         elif any(qn.endswith(entry) for entry in config.entry_points):

--- a/codebase_rag/dead_code.py
+++ b/codebase_rag/dead_code.py
@@ -232,7 +232,7 @@ def _is_react_base_qn(base_qn: str) -> bool:
     return (
         bool(sep)
         and leaf in cs.REACT_COMPONENT_BASE_NAMES
-        and cs.REACT_NAMESPACE_TOKEN in namespace.lower()
+        and namespace.lower() == cs.REACT_NAMESPACE_TOKEN
     )
 
 

--- a/codebase_rag/tests/test_react_dead_code_roots.py
+++ b/codebase_rag/tests/test_react_dead_code_roots.py
@@ -1,0 +1,161 @@
+# React class-component lifecycle methods (issue #978): render / componentDidMount
+# / componentWillUnmount / constructor / ... are invoked by React at runtime,
+# never by an explicit call the graph can see, so they are reachability roots on
+# a class that INHERITS a React component base. A same-named method on a plain
+# class must NOT be rooted.
+from __future__ import annotations
+
+from codebase_rag import constants as cs
+from codebase_rag import cypher_queries as cq
+from codebase_rag.dead_code import collect_dead_code, default_dead_code_config
+from codebase_rag.types_defs import ResultRow
+
+_MODULE = cs.NodeLabel.MODULE.value
+_CLASS = cs.NodeLabel.CLASS.value
+_METHOD = cs.NodeLabel.METHOD.value
+_DEFINES_METHOD = cs.RelationshipType.DEFINES_METHOD.value
+_INHERITS = cs.RelationshipType.INHERITS.value
+_CALLS = cs.RelationshipType.CALLS.value
+
+_PATH = "app/App.tsx"
+
+
+class FakeIngestor:
+    def __init__(self, nodes: list[ResultRow], rels: list[ResultRow]) -> None:
+        self._nodes = nodes
+        self._rels = rels
+
+    def fetch_all(
+        self, query: str, params: dict[str, str] | None = None
+    ) -> list[ResultRow]:
+        if query == cq.CYPHER_DEAD_CODE_NODES:
+            return self._nodes
+        return self._rels
+
+
+def _node(label: str, qn: str, name: str) -> ResultRow:
+    return {
+        "label": label,
+        "qualified_name": qn,
+        "name": name,
+        "path": _PATH,
+        "start_line": 1,
+        "end_line": 2,
+        "decorators": [],
+        "is_exported": False,
+        "overrides_external": False,
+    }
+
+
+def _rel(
+    from_label: str, from_qn: str, rel_type: str, to_label: str, to_qn: str
+) -> ResultRow:
+    return {
+        "from_label": from_label,
+        "from_qn": from_qn,
+        "rel_type": rel_type,
+        "to_label": to_label,
+        "to_qn": to_qn,
+    }
+
+
+def _dead(nodes: list[ResultRow], rels: list[ResultRow]) -> set[str]:
+    config = default_dead_code_config(include_tests=True, include_classes=False)
+    return {
+        row["qualified_name"]
+        for row in collect_dead_code(FakeIngestor(nodes, rels), "app", config)
+    }
+
+
+def test_react_lifecycle_methods_and_reachable_helpers_are_rooted() -> None:
+    # App extends React.Component: componentDidMount is React-invoked (root), and
+    # the helper it calls via this.helper() is reachable through it. Only the
+    # unreferenced private helper is genuinely dead.
+    nodes = [
+        _node(_MODULE, "app.App", "App"),
+        _node(_CLASS, "app.App.App", "App"),
+        _node(_METHOD, "app.App.App.componentDidMount", "componentDidMount"),
+        _node(_METHOD, "app.App.App.render", "render"),
+        _node(_METHOD, "app.App.App.wire", "wire"),
+        _node(_METHOD, "app.App.App.orphan", "orphan"),
+    ]
+    rels = [
+        _rel(_CLASS, "app.App.App", _INHERITS, _CLASS, "react.Component"),
+        *[
+            _rel(_CLASS, "app.App.App", _DEFINES_METHOD, _METHOD, m)
+            for m in (
+                "app.App.App.componentDidMount",
+                "app.App.App.render",
+                "app.App.App.wire",
+                "app.App.App.orphan",
+            )
+        ],
+        # componentDidMount calls this.wire() -> wire is reachable.
+        _rel(
+            _METHOD,
+            "app.App.App.componentDidMount",
+            _CALLS,
+            _METHOD,
+            "app.App.App.wire",
+        ),
+    ]
+    dead = _dead(nodes, rels)
+    assert "app.App.App.componentDidMount" not in dead
+    assert "app.App.App.render" not in dead
+    assert "app.App.App.wire" not in dead  # reached through the rooted lifecycle
+    assert "app.App.App.orphan" in dead  # never referenced -> genuinely dead
+
+
+def test_lifecycle_named_method_on_plain_class_stays_dead() -> None:
+    # A plain (non-React) class with a `render` method must stay dead.
+    nodes = [
+        _node(_MODULE, "app.App", "App"),
+        _node(_CLASS, "app.App.Plain", "Plain"),
+        _node(_METHOD, "app.App.Plain.render", "render"),
+    ]
+    rels = [
+        _rel(_CLASS, "app.App.Plain", _DEFINES_METHOD, _METHOD, "app.App.Plain.render")
+    ]
+    dead = _dead(nodes, rels)
+    assert "app.App.Plain.render" in dead
+
+
+def test_non_react_component_base_is_not_rooted() -> None:
+    # A base whose simple name is `Component` but is NOT React (Ember/Glimmer's
+    # `@glimmer/component.Component`) must not make its subclass a React
+    # component; a `render` method there stays dead.
+    nodes = [
+        _node(_MODULE, "app.App", "App"),
+        _node(_CLASS, "app.App.Card", "Card"),
+        _node(_METHOD, "app.App.Card.render", "render"),
+    ]
+    rels = [
+        _rel(_CLASS, "app.App.Card", _INHERITS, _CLASS, "@glimmer/component.Component"),
+        _rel(_CLASS, "app.App.Card", _DEFINES_METHOD, _METHOD, "app.App.Card.render"),
+    ]
+    dead = _dead(nodes, rels)
+    assert "app.App.Card.render" in dead
+
+
+def test_transitive_react_base_lifecycle_is_rooted() -> None:
+    # App extends a first-party BaseWidget that extends react.Component: App's
+    # lifecycle methods are still React-invoked, so they must be rooted.
+    nodes = [
+        _node(_MODULE, "app.App", "App"),
+        _node(_CLASS, "app.App.BaseWidget", "BaseWidget"),
+        _node(_CLASS, "app.App.App", "App"),
+        _node(_METHOD, "app.App.App.componentDidMount", "componentDidMount"),
+    ]
+    rels = [
+        _rel(_CLASS, "app.App.BaseWidget", _INHERITS, _CLASS, "react.Component"),
+        _rel(_CLASS, "app.App.App", _INHERITS, _CLASS, "app.App.BaseWidget"),
+        _rel(
+            _CLASS,
+            "app.App.App",
+            _DEFINES_METHOD,
+            _METHOD,
+            "app.App.App.componentDidMount",
+        ),
+    ]
+    dead = _dead(nodes, rels)
+    assert "app.App.App.componentDidMount" not in dead

--- a/codebase_rag/tests/test_react_dead_code_roots.py
+++ b/codebase_rag/tests/test_react_dead_code_roots.py
@@ -137,6 +137,22 @@ def test_non_react_component_base_is_not_rooted() -> None:
     assert "app.App.Card.render" in dead
 
 
+def test_react_lookalike_namespace_is_not_rooted() -> None:
+    # A base in a namespace that merely CONTAINS "react" (preact, notreact) is
+    # not React: the namespace must match exactly, so a `render` there stays dead.
+    for base in ("preact.Component", "notreact.Component"):
+        nodes = [
+            _node(_MODULE, "app.App", "App"),
+            _node(_CLASS, "app.App.C", "C"),
+            _node(_METHOD, "app.App.C.render", "render"),
+        ]
+        rels = [
+            _rel(_CLASS, "app.App.C", _INHERITS, _CLASS, base),
+            _rel(_CLASS, "app.App.C", _DEFINES_METHOD, _METHOD, "app.App.C.render"),
+        ]
+        assert "app.App.C.render" in _dead(nodes, rels), base
+
+
 def test_transitive_react_base_lifecycle_is_rooted() -> None:
     # App extends a first-party BaseWidget that extends react.Component: App's
     # lifecycle methods are still React-invoked, so they must be rooted.

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.510"
+version = "0.0.511"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
A React class component's lifecycle methods (`render`, `componentDidMount`,
`componentDidUpdate`, `componentWillUnmount`, the constructor, ...) are invoked by
React at runtime, never by an explicit call the graph can see, so `cgr dead-code`
reported them dead. Since the reachability walk starts from these (unreached)
methods, everything they call via `this.` and every nested callback collapsed
into the dead list too, so an entire live component was reported dead.

This adds a React-aware reachability root, mirroring the NestJS (#973), Python
dunder, and Java serialization roots: a method whose name is a React lifecycle
method AND whose class (transitively) extends a React component base is a root.

Validated by dogfooding excalidraw/excalidraw: dead-code candidates **161 → 78**.
Collab 34 → 1, App (the main editor component) 89 → 41.

## Type of Change
- [x] Feature (dead-code precision; eliminates the React class-component false-positive class)

## Related Issues
Closes #978.

## Test Plan
- [x] `test_react_dead_code_roots.py` (RED→GREEN): lifecycle methods + the helpers
  they reach via `this.` are rooted while an unreferenced private helper stays
  dead; a lifecycle-named method on a plain class stays dead; a non-React
  `Component`-named base (Glimmer) does NOT root; a transitive React base
  (`App extends BaseWidget extends react.Component`) does root.
- [x] Full unit suite: 5971 passed, 5 pre-existing env skips, 0 failed.
- [x] Real excalidraw index: 161 → 78, no wins lost after the precision/transitivity fixes.
- [x] ruff / ty / pre-commit clean; adversarial diff review (which surfaced the
  namespace-precision and transitive-inheritance points, both fixed) re-verified.

## Checklist
- [x] PR title follows Conventional Commits
- [x] RED demonstrated before the change
- [x] React base match gated to the `react` namespace (not just the simple name)
- [x] Transitive inheritance to a React base covered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dead-code detection for React class components.
  * React lifecycle methods, constructors, and reachable helper methods are now correctly recognized as active.
  * Added support for components inheriting from `React.Component` or `React.PureComponent`, including indirect inheritance.
  * Prevented similarly named components from unrelated frameworks from being incorrectly treated as React components.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->