### PR TITLE
fix: reference a ternary-selected handler in a JSX attribute value

### DIFF
--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -193,9 +193,6 @@ TS_JS_TERNARY_EXPRESSION = "ternary_expression"
 # Short-circuit operators whose result IS one of the operands, so a
 # bind through them unions both operands' taints.
 JS_SHORT_CIRCUIT_OPERATORS: frozenset[str] = frozenset({"||", "??", "&&"})
-# `a && b` binds ONLY its right operand as the resulting value (the left is
-# truthiness-tested and never the value); `||` / `??` can bind either operand.
-JS_LOGICAL_AND_OPERATOR = "&&"
 TS_JS_ELSE_CLAUSE = "else_clause"
 TS_JS_WHILE_STATEMENT = "while_statement"
 TS_JS_FOR_STATEMENT = "for_statement"

--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -193,6 +193,9 @@ TS_JS_TERNARY_EXPRESSION = "ternary_expression"
 # Short-circuit operators whose result IS one of the operands, so a
 # bind through them unions both operands' taints.
 JS_SHORT_CIRCUIT_OPERATORS: frozenset[str] = frozenset({"||", "??", "&&"})
+# `a && b` binds ONLY its right operand as the resulting value (the left is
+# truthiness-tested and never the value); `||` / `??` can bind either operand.
+JS_LOGICAL_AND_OPERATOR = "&&"
 TS_JS_ELSE_CLAUSE = "else_clause"
 TS_JS_WHILE_STATEMENT = "while_statement"
 TS_JS_FOR_STATEMENT = "for_statement"

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -422,14 +422,8 @@ def _first_class_value_children(
         is_js_ts
         and node.type == cs.TS_BINARY_EXPRESSION
         and (operator := node.child_by_field_name(cs.FIELD_OPERATOR)) is not None
-        and (op_text := safe_decode_text(operator)) in cs.JS_SHORT_CIRCUIT_OPERATORS
+        and safe_decode_text(operator) in cs.JS_SHORT_CIRCUIT_OPERATORS
     ):
-        # `a && b` binds ONLY its right operand as the value (the left is
-        # truthiness-tested, never the value), so returning both would falsely
-        # reference the left operand; `||` / `??` can bind either operand.
-        if op_text == cs.JS_LOGICAL_AND_OPERATOR:
-            right = node.child_by_field_name(cs.TS_FIELD_RIGHT)
-            return [right] if right is not None else []
         return list(node.named_children)
     if (
         is_dart
@@ -1241,7 +1235,6 @@ class CallProcessor:
                     None,
                     None,
                     self._flow_scope_boundaries(queries[language][cs.QUERY_CONFIG]),
-                    language=language,
                 )
             if language == cs.SupportedLanguage.PYTHON:
                 decorator_targets = list(sorted_func_nodes or [])
@@ -2437,7 +2430,6 @@ class CallProcessor:
                 class_context,
                 self._flow_scope_boundaries(queries[language][cs.QUERY_CONFIG]),
                 caller_qn,
-                language=language,
             )
             # A DEFAULT PARAMETER value naming a function (`useStore(api,
             # selector = identity as any)`, zustand) references it: the default
@@ -3529,7 +3521,6 @@ class CallProcessor:
         class_context: str | None,
         boundary_types: frozenset[str],
         caller_qn: str | None = None,
-        language: cs.SupportedLanguage | None = None,
     ) -> None:
         # `<Card />` renders the Card component: the framework invokes it
         # through the element, never by a call the graph can see, so the JSX
@@ -3577,11 +3568,14 @@ class CallProcessor:
                 # or inline arrow (onClick={() => x()}) is a function the
                 # framework invokes on the event, so reference it; other
                 # expressions resolve to nothing and are skipped by the helper.
-                # Peel a conditional / cast wrapper first, so a handler chosen by
-                # a ternary (onDrop={cond ? this.handleDrop : undefined}) is
-                # referenced through each result operand (issue #980).
+                # Peel ONLY a ternary / cast wrapper, whose operands are candidate
+                # handler values (onDrop={cond ? this.handleDrop : undefined},
+                # issue #980). A short-circuit (`x || y`, `x && y`) is NOT peeled:
+                # in a JSX data prop (`alt={name || fallback}`) its operands are
+                # data, and expanding them would false-revive a same-named module
+                # function.
                 for value in node.named_children:
-                    for operand in self._expand_py_first_class_values(value, language):
+                    for operand in self._jsx_value_operands(value):
                         self._emit_callback_edge(
                             caller_spec,
                             operand,
@@ -3594,6 +3588,21 @@ class CallProcessor:
                             rel_type=cs.RelationshipType.REFERENCES,
                         )
             stack.extend(node.children)
+
+    @staticmethod
+    def _jsx_value_operands(value: Node) -> list[Node]:
+        # The candidate handler operands of a JSX `{...}` value: a ternary's two
+        # result branches (`cond ? a : b`), peeled through any transparent TS
+        # cast wrapper (`(cond ? a : b) as any`). A short-circuit or any other
+        # expression is returned as-is (a single operand) so it is resolved
+        # directly, never peeled -- expanding `||`/`&&`/`??` in a JSX data prop
+        # would false-revive a same-named module function (issue #980).
+        node = value
+        while node.type in cs.TS_CAST_WRAPPER_TYPES and node.named_children:
+            node = node.named_children[0]
+        if node.type in (cs.TS_PY_CONDITIONAL_EXPRESSION, cs.TS_JS_TERNARY_EXPRESSION):
+            return _conditional_result_operands(node, is_dart=False)
+        return [node]
 
     def _ingest_returned_function_references(
         self,

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -422,8 +422,14 @@ def _first_class_value_children(
         is_js_ts
         and node.type == cs.TS_BINARY_EXPRESSION
         and (operator := node.child_by_field_name(cs.FIELD_OPERATOR)) is not None
-        and safe_decode_text(operator) in cs.JS_SHORT_CIRCUIT_OPERATORS
+        and (op_text := safe_decode_text(operator)) in cs.JS_SHORT_CIRCUIT_OPERATORS
     ):
+        # `a && b` binds ONLY its right operand as the value (the left is
+        # truthiness-tested, never the value), so returning both would falsely
+        # reference the left operand; `||` / `??` can bind either operand.
+        if op_text == cs.JS_LOGICAL_AND_OPERATOR:
+            right = node.child_by_field_name(cs.TS_FIELD_RIGHT)
+            return [right] if right is not None else []
         return list(node.named_children)
     if (
         is_dart

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1235,6 +1235,7 @@ class CallProcessor:
                     None,
                     None,
                     self._flow_scope_boundaries(queries[language][cs.QUERY_CONFIG]),
+                    language=language,
                 )
             if language == cs.SupportedLanguage.PYTHON:
                 decorator_targets = list(sorted_func_nodes or [])
@@ -2430,6 +2431,7 @@ class CallProcessor:
                 class_context,
                 self._flow_scope_boundaries(queries[language][cs.QUERY_CONFIG]),
                 caller_qn,
+                language=language,
             )
             # A DEFAULT PARAMETER value naming a function (`useStore(api,
             # selector = identity as any)`, zustand) references it: the default
@@ -3521,6 +3523,7 @@ class CallProcessor:
         class_context: str | None,
         boundary_types: frozenset[str],
         caller_qn: str | None = None,
+        language: cs.SupportedLanguage | None = None,
     ) -> None:
         # `<Card />` renders the Card component: the framework invokes it
         # through the element, never by a call the graph can see, so the JSX
@@ -3568,18 +3571,22 @@ class CallProcessor:
                 # or inline arrow (onClick={() => x()}) is a function the
                 # framework invokes on the event, so reference it; other
                 # expressions resolve to nothing and are skipped by the helper.
+                # Peel a conditional / cast wrapper first, so a handler chosen by
+                # a ternary (onDrop={cond ? this.handleDrop : undefined}) is
+                # referenced through each result operand (issue #980).
                 for value in node.named_children:
-                    self._emit_callback_edge(
-                        caller_spec,
-                        value,
-                        module_qn,
-                        local_var_types,
-                        class_context,
-                        resolve_func,
-                        ensure_rel,
-                        caller_qn=caller_qn,
-                        rel_type=cs.RelationshipType.REFERENCES,
-                    )
+                    for operand in self._expand_py_first_class_values(value, language):
+                        self._emit_callback_edge(
+                            caller_spec,
+                            operand,
+                            module_qn,
+                            local_var_types,
+                            class_context,
+                            resolve_func,
+                            ensure_rel,
+                            caller_qn=caller_qn,
+                            rel_type=cs.RelationshipType.REFERENCES,
+                        )
             stack.extend(node.children)
 
     def _ingest_returned_function_references(

--- a/codebase_rag/tests/test_ts_jsx_ternary_handler_ref.py
+++ b/codebase_rag/tests/test_ts_jsx_ternary_handler_ref.py
@@ -1,0 +1,90 @@
+# A `this.method` reference in a JSX attribute value is referenced when written
+# directly, and must ALSO be referenced when it sits inside a ternary
+# (`onDrop={cond ? this.handleDrop : undefined}`), or the handler reports dead.
+# Found dogfooding excalidraw App.handleAppOnDrop (issue #980).
+from __future__ import annotations
+
+from pathlib import Path
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.types_defs import PropertyDict, PropertyValue, ResultRow
+
+PROJECT = "p"
+
+SRC = """import React from "react";
+export class Widget extends React.Component {
+  handleClick = () => {};
+  handleDrop = () => {};
+  render() {
+    return (
+      <div
+        onClick={this.handleClick}
+        onDrop={cond ? this.handleDrop : undefined}
+      />
+    );
+  }
+}
+"""
+
+
+class _Capture:
+    def __init__(self) -> None:
+        self.rels: list[tuple[PropertyValue, str, PropertyValue]] = []
+
+    def ensure_node_batch(self, label: str, properties: PropertyDict) -> None:
+        return None
+
+    def ensure_relationship_batch(
+        self,
+        from_spec: tuple[str, str, PropertyValue],
+        rel_type: str,
+        to_spec: tuple[str, str, PropertyValue],
+        properties: PropertyDict | None = None,
+    ) -> None:
+        self.rels.append((from_spec[2], str(rel_type), to_spec[2]))
+
+    def flush_all(self) -> None:
+        return None
+
+    def fetch_all(
+        self, query: str, params: PropertyDict | None = None
+    ) -> list[ResultRow]:
+        return []
+
+    def execute_write(self, query: str, params: PropertyDict | None = None) -> None:
+        return None
+
+
+def _refs_leaf(cap: _Capture, leaf: str) -> bool:
+    ref = str(cs.RelationshipType.REFERENCES)
+    calls = str(cs.RelationshipType.CALLS)
+    return any(
+        rel in (ref, calls) and str(to).rsplit(".", 1)[-1] == leaf
+        for _frm, rel, to in cap.rels
+    )
+
+
+def _run(tmp_path: Path) -> _Capture:
+    (tmp_path / "w.tsx").write_text(SRC)
+    parsers, queries = load_parsers()
+    cap = _Capture()
+    GraphUpdater(
+        ingestor=cap,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name=PROJECT,
+    ).run(force=True)
+    return cap
+
+
+def test_direct_jsx_handler_is_referenced(tmp_path: Path) -> None:
+    # The already-working direct case (guards against regression).
+    assert _refs_leaf(_run(tmp_path), "handleClick")
+
+
+def test_ternary_jsx_handler_is_referenced(tmp_path: Path) -> None:
+    # `cond ? this.handleDrop : undefined` must reference handleDrop.
+    assert _refs_leaf(_run(tmp_path), "handleDrop")

--- a/codebase_rag/tests/test_ts_jsx_ternary_handler_ref.py
+++ b/codebase_rag/tests/test_ts_jsx_ternary_handler_ref.py
@@ -90,23 +90,25 @@ def test_ternary_jsx_handler_is_referenced(tmp_path: Path) -> None:
     assert _refs_leaf(_run(tmp_path), "handleDrop")
 
 
-SHORT_CIRCUIT_SRC = """import React from "react";
-function guard() { return true; }
+# A short-circuit in a JSX DATA prop selects data, not a handler; its operands
+# must not be peeled, or a same-named module function is false-revived.
+DATA_PROP_SHORT_CIRCUIT_SRC = """import React from "react";
+function profile() { return 1; }
 export class W extends React.Component {
-  handleClick = () => {};
   render() {
-    return <div onClick={guard && this.handleClick}>x</div>;
+    return <img alt={displayName || profile} title={ready && profile} />;
   }
 }
 """
 
 
-def test_short_circuit_and_left_operand_is_not_referenced(tmp_path: Path) -> None:
-    # In `guard && this.handleClick` the LEFT operand `guard` is only
-    # truthiness-tested, never the bound value, so it must NOT be referenced
-    # (a same-named module function would otherwise be falsely revived); the
-    # RIGHT operand `this.handleClick` IS the value and must be referenced.
-    (tmp_path / "w.tsx").write_text(SHORT_CIRCUIT_SRC)
+def test_short_circuit_data_prop_does_not_reference_module_function(
+    tmp_path: Path,
+) -> None:
+    # `alt={displayName || profile}` / `title={ready && profile}` select DATA;
+    # a JSX short-circuit must NOT be peeled, or `profile` (a same-named module
+    # function) is falsely revived (adversarial review of #980).
+    (tmp_path / "w.tsx").write_text(DATA_PROP_SHORT_CIRCUIT_SRC)
     parsers, queries = load_parsers()
     cap = _Capture()
     GraphUpdater(
@@ -116,5 +118,4 @@ def test_short_circuit_and_left_operand_is_not_referenced(tmp_path: Path) -> Non
         queries=queries,
         project_name=PROJECT,
     ).run(force=True)
-    assert _refs_leaf(cap, "handleClick")  # right operand = the value
-    assert not _refs_leaf(cap, "guard")  # left operand = truthiness only
+    assert not _refs_leaf(cap, "profile")

--- a/codebase_rag/tests/test_ts_jsx_ternary_handler_ref.py
+++ b/codebase_rag/tests/test_ts_jsx_ternary_handler_ref.py
@@ -88,3 +88,33 @@ def test_direct_jsx_handler_is_referenced(tmp_path: Path) -> None:
 def test_ternary_jsx_handler_is_referenced(tmp_path: Path) -> None:
     # `cond ? this.handleDrop : undefined` must reference handleDrop.
     assert _refs_leaf(_run(tmp_path), "handleDrop")
+
+
+SHORT_CIRCUIT_SRC = """import React from "react";
+function guard() { return true; }
+export class W extends React.Component {
+  handleClick = () => {};
+  render() {
+    return <div onClick={guard && this.handleClick}>x</div>;
+  }
+}
+"""
+
+
+def test_short_circuit_and_left_operand_is_not_referenced(tmp_path: Path) -> None:
+    # In `guard && this.handleClick` the LEFT operand `guard` is only
+    # truthiness-tested, never the bound value, so it must NOT be referenced
+    # (a same-named module function would otherwise be falsely revived); the
+    # RIGHT operand `this.handleClick` IS the value and must be referenced.
+    (tmp_path / "w.tsx").write_text(SHORT_CIRCUIT_SRC)
+    parsers, queries = load_parsers()
+    cap = _Capture()
+    GraphUpdater(
+        ingestor=cap,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name=PROJECT,
+    ).run(force=True)
+    assert _refs_leaf(cap, "handleClick")  # right operand = the value
+    assert not _refs_leaf(cap, "guard")  # left operand = truthiness only


### PR DESCRIPTION
## Summary
A `this.method` handler used as a JSX attribute value is referenced when written
directly (`onClick={this.handleClick}`), but NOT when it sits inside a ternary
(`onDrop={cond ? this.handleDrop : undefined}`), so a handler wired only as a
conditional prop reports dead. This peels a ternary (and any transparent TS cast
wrapper) in a JSX `{...}` value and references each result operand.

Deliberately narrow: a short-circuit (`x || y`, `x && y`, `x ?? y`) is NOT
peeled. In a JSX DATA prop (`alt={name || fallback}`) the operands are data, and
expanding them would false-revive a same-named module function (caught in
adversarial review). A ternary's branches, by contrast, are genuinely candidate
handler values.

Found dogfooding excalidraw/excalidraw (`App.handleAppOnDrop` is
`onDrop={this.isInteractionEnabled() ? this.handleAppOnDrop : undefined}`).
Dead-code candidates 78 -> 69, with no data-prop false positives.

## Type of Change
- [x] Bug fix (dead-code false positive)

## Related Issues
Closes #980.

## Test Plan
- [x] `test_ts_jsx_ternary_handler_ref.py` (RED->GREEN): direct handler (kept
  working), ternary handler referenced, and a short-circuit DATA prop
  (`alt={displayName || profile}` / `title={ready && profile}`) does NOT
  reference the same-named module function.
- [x] Existing cast/short-circuit value tests still pass (no regression).
- [x] Full unit suite: 5977 passed, 5 pre-existing env skips, 0 failed.
- [x] Real excalidraw index: 78 -> 69, handleAppOnDrop resolved, no false revives.
- [x] ruff / ty / pre-commit clean; adversarial diff review (which caught the
  short-circuit over-reach) re-verified.

## Checklist
- [x] PR title follows Conventional Commits
- [x] RED demonstrated before the change
- [x] Short-circuit operands deliberately left unexpanded in JSX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved JSX reference detection for conditional prop values.
  - Correctly identifies event handlers used within ternary expressions.
  - Prevents unrelated functions from being incorrectly linked when short-circuit expressions are used in data props.

- **Tests**
  - Added coverage for direct handlers, conditional handlers, and short-circuit prop expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->