### PR TITLE
fix: link JS/TS fn.bind(this)() immediately-invoked calls

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -2111,6 +2111,19 @@ class CallProcessor:
                             receiver = receiver_node.text.decode(cs.ENCODING_UTF8)
                             return f"{receiver}{cs.SEPARATOR_DOT}{method}"
                         return method
+                case cs.TS_CALL_EXPRESSION if language in _JS_TS_LANGUAGES:
+                    # A bound function that is itself invoked (`fn.bind(ctx)()`)
+                    # has a nested `fn.bind(ctx)` call_expression as its callee, so
+                    # no earlier case names it. Resolve to fn so the invocation
+                    # links to fn, not the Function.prototype builtin (issue:
+                    # JoinAttribute.relation's local getValue called as
+                    # getValue.bind(this)()). Guard on _unwrap_bound_function so a
+                    # plain call-of-a-call (`getFactory()()`) stays unnamed, then
+                    # peel to a fixpoint for chained binds / interleaved casts.
+                    if self._unwrap_bound_function(func_child) is not None:
+                        peeled = self._peel_bound_callable(func_child)
+                        if peeled.text is not None:
+                            return peeled.text.decode(cs.ENCODING_UTF8)
                 case cs.TS_PARENTHESIZED_EXPRESSION:
                     return self._get_iife_target_name(func_child)
 

--- a/codebase_rag/tests/test_ts_bound_immediate_call_edge.py
+++ b/codebase_rag/tests/test_ts_bound_immediate_call_edge.py
@@ -1,0 +1,126 @@
+# A locally-defined function invoked immediately through `fn.bind(this)()`
+# must record a CALLS edge to `fn`, exactly like the plain `fn()` form; without
+# it the function reports as dead code. Found dogfooding TypeORM
+# JoinAttribute.relation, whose local `getValue` is called as
+# `getValue.bind(this)()` (issue: TS bound-then-invoked call loses its edge).
+from __future__ import annotations
+
+from pathlib import Path
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.types_defs import PropertyDict, PropertyValue, ResultRow
+
+PROJECT = "p"
+
+SRC = """export class C {
+  get direct() {
+    const getValue = () => { return 1; };
+    return getValue();
+  }
+  get bound() {
+    const getValue = () => { return 2; };
+    return getValue.bind(this)();
+  }
+  get chained() {
+    const getValue = () => { return 3; };
+    return getValue.bind(this).bind(this)();
+  }
+}
+"""
+
+
+class _Capture:
+    def __init__(self) -> None:
+        self.rels: list[tuple[PropertyValue, str, PropertyValue]] = []
+
+    def ensure_node_batch(self, label: str, properties: PropertyDict) -> None:
+        return None
+
+    def ensure_relationship_batch(
+        self,
+        from_spec: tuple[str, str, PropertyValue],
+        rel_type: str,
+        to_spec: tuple[str, str, PropertyValue],
+        properties: PropertyDict | None = None,
+    ) -> None:
+        self.rels.append((from_spec[2], str(rel_type), to_spec[2]))
+
+    def flush_all(self) -> None:
+        return None
+
+    def fetch_all(
+        self, query: str, params: PropertyDict | None = None
+    ) -> list[ResultRow]:
+        return []
+
+    def execute_write(self, query: str, params: PropertyDict | None = None) -> None:
+        return None
+
+
+def _calls_leaf_under(cap: _Capture, scope: str, leaf: str) -> bool:
+    calls = str(cs.RelationshipType.CALLS)
+    return any(
+        rel == calls
+        and str(frm).rsplit(".", 1)[-1] == scope
+        and str(to).rsplit(".", 1)[-1] == leaf
+        for frm, rel, to in cap.rels
+    )
+
+
+def _run(tmp_path: Path) -> _Capture:
+    (tmp_path / "c.ts").write_text(SRC)
+    parsers, queries = load_parsers()
+    cap = _Capture()
+    GraphUpdater(
+        ingestor=cap,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name=PROJECT,
+    ).run(force=True)
+    return cap
+
+
+def test_direct_local_call_has_edge(tmp_path: Path) -> None:
+    # Guards the already-working plain `getValue()` form against regression.
+    assert _calls_leaf_under(_run(tmp_path), "direct", "getValue")
+
+
+def test_bound_immediate_local_call_has_edge(tmp_path: Path) -> None:
+    # `getValue.bind(this)()` invokes getValue and must record the CALLS edge.
+    assert _calls_leaf_under(_run(tmp_path), "bound", "getValue")
+
+
+def test_chained_bound_local_call_has_edge(tmp_path: Path) -> None:
+    # `getValue.bind(this).bind(this)()` still invokes getValue; the bound
+    # callee must be peeled to a fixpoint, not a single pass.
+    assert _calls_leaf_under(_run(tmp_path), "chained", "getValue")
+
+
+# A plain call-of-a-call `getFactory()()` invokes getFactory (inner call) and
+# then its RETURN value; the outer callee is not nameable, so it must NOT be
+# treated as a bound call. getFactory still links from the inner call node.
+CALL_OF_CALL_SRC = """export class D {
+  run() {
+    const getFactory = () => () => 1;
+    return getFactory()();
+  }
+}
+"""
+
+
+def test_call_of_call_still_links_inner_only(tmp_path: Path) -> None:
+    (tmp_path / "c.ts").write_text(CALL_OF_CALL_SRC)
+    parsers, queries = load_parsers()
+    cap = _Capture()
+    GraphUpdater(
+        ingestor=cap,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name=PROJECT,
+    ).run(force=True)
+    # The inner `getFactory()` records the call; the outer `()` names nothing.
+    assert _calls_leaf_under(cap, "run", "getFactory")

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.513"
+version = "0.0.514"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Resolve JS/TS calls of an immediately invoked bound function (`fn.bind(this)()`) to the underlying callable `fn`, so the CALLS edge is recorded instead of dropped.
- Peel to a fixpoint so chained binds and interleaved casts (`fn.bind(a).bind(b)()`) also resolve; a plain call-of-a-call (`getFactory()()`) stays unnamed.
- Fixes a dead-code false positive found dogfooding TypeORM's `JoinAttribute.relation` (`getValue.bind(this)()`).

## Type of Change

- [x] Bug fix

## Related Issues

Closes #982

## Test Plan

- [x] Unit tests pass (`uv run pytest -n auto -m "not integration"`)
- [x] New tests added

New tests in `test_ts_bound_immediate_call_edge.py`: `bound` (`fn.bind(this)()` links), `chained` (fixpoint peel), `direct` (plain `fn()` regression guard), `call_of_call` (`getFactory()()` links only the inner call, no fabricated outer edge).

## Checklist

- [x] PR title follows Conventional Commits format
- [x] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints

Scope note: idiomatic single `fn.call(x)` / `fn.apply(x)` are intentionally left unchanged; their member-expression callee is ambiguous with a real method named `call`/`apply`, so this PR does not touch them.