### PR TITLE
fix: reference JS/TS getters read as properties in compound expressions

### DIFF
--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -77,6 +77,10 @@ TS_ARRAY = "array"
 # name; arrows nested under a const-bound object still take the object's name.
 JS_CALL_RESULT_VALUE_TYPES = frozenset({TS_CALL_EXPRESSION, TS_NEW_EXPRESSION})
 TS_FUNCTION_EXPRESSION = "function_expression"
+# The `get` accessor keyword prefixing a getter `method_definition`
+# (`get thing() {...}`); its presence marks the method as a property whose
+# reads are member accesses, not invocations.
+TS_GET_ACCESSOR_KEYWORD = "get"
 TS_ARROW_FUNCTION = "arrow_function"
 TS_REQUIRED_PARAMETER = "required_parameter"
 TS_OPTIONAL_PARAMETER = "optional_parameter"

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -5870,6 +5870,10 @@ class CallProcessor:
         recv = member_node.child_by_field_name(cs.FIELD_OBJECT)
         if recv is None:
             return None
+        # Peel transparent TS casts/parens/non-null off the receiver so
+        # `(box as Base).thing` and `this!.thing` resolve like `box.thing` /
+        # `this.thing`.
+        recv = self._unwrap_ts_value(recv)
         if recv.type == cs.TS_THIS:
             # `this` binds to the class instance only when the read is lexically
             # inside a CLASS method or class-field (arrows are transparent);
@@ -5919,7 +5923,6 @@ class CallProcessor:
         ensure_rel = self.ingestor.ensure_relationship_batch
         registry = self._resolver.function_registry
         refs_rel = cs.RelationshipType.REFERENCES
-        method_label = cs.NodeLabel.METHOD
         qn_key = cs.KEY_QUALIFIED_NAME
         function_types = lang_config.function_node_types
         class_types = lang_config.class_node_types
@@ -5949,15 +5952,20 @@ class CallProcessor:
                         )
                     )
                 ):
-                    candidate = f"{class_qn}{cs.SEPARATOR_DOT}{name}"
-                    if registry.is_property(candidate):
-                        for target_qn in registry.variants(candidate):
+                    # Resolve the getter on the receiver's class OR an ancestor
+                    # (an inherited getter still invokes real code); emit only
+                    # when the resolved target is a registered property, so a
+                    # same-named data field or regular method never links.
+                    resolved = self._resolver._try_resolve_method(class_qn, name)
+                    if resolved is not None and registry.is_property(resolved[1]):
+                        res_label, res_qn = resolved
+                        for target_qn in registry.variants(res_qn):
                             if target_qn != caller_qn and target_qn not in seen:
                                 seen.add(target_qn)
                                 ensure_rel(
                                     caller_spec,
                                     refs_rel,
-                                    (method_label, qn_key, target_qn),
+                                    (res_label, qn_key, target_qn),
                                 )
             stack.extend(node.children)
 

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -2414,6 +2414,26 @@ class CallProcessor:
                 dart_prop_names,
             )
 
+        # Same need again, JS/TS shape (issue #984): a getter read is a
+        # member_expression (`this.relation`, `loadMap.mainLoadMapItem`), never
+        # an invocation. The return/assignment reference passes only inspect the
+        # direct value, so a getter read nested in a ternary, member chain, `if`
+        # condition, or binary expression emitted nothing and dead-code flagged
+        # it (TypeORM's JoinAttribute.relation, LoadMap.mainLoadMapItem).
+        if language in _JS_TS_LANGUAGES and (
+            js_ts_prop_names := self._resolver.function_registry.property_names()
+        ):
+            self._ingest_js_ts_getter_reads(
+                caller_node,
+                caller_spec,
+                module_qn,
+                local_var_types,
+                class_context,
+                queries[language][cs.QUERY_CONFIG],
+                js_ts_prop_names,
+                caller_qn=caller_qn,
+            )
+
         # Operator syntax (k in r, r[k], r[k]=v, len(r)) dispatches to dunder
         # methods; emit those edges when the operand is a first-party type.
         if language == cs.SupportedLanguage.PYTHON:
@@ -5776,6 +5796,169 @@ class CallProcessor:
                     and parent.child_by_field_name(cs.FIELD_TYPE) != node
                 ):
                     try_emit(safe_decode_text(node), node, False)
+            stack.extend(node.children)
+
+    @staticmethod
+    def _js_ts_member_is_write_target(node: Node) -> bool:
+        # True when a member read is the WRITE target of a plain assignment
+        # (`this.thing = v`, and destructuring forms `[this.thing] = a`,
+        # `({x: this.thing} = o)` where the member is nested in the left pattern
+        # but is not its direct `left` child); those invoke the SETTER, not the
+        # getter. An augmented assignment (`this.thing += 1`) reads first, so it
+        # is NOT a write target. The walk stops at the nearest assignment or at a
+        # function/class boundary so an outer assignment cannot misjudge a member
+        # that actually sits in a nested scope or on the right-hand side.
+        current = node.parent
+        while current is not None:
+            node_type = current.type
+            if node_type == cs.TS_JS_ASSIGNMENT_EXPRESSION:
+                left = current.child_by_field_name(cs.FIELD_LEFT)
+                return (
+                    left is not None
+                    and left.start_byte <= node.start_byte
+                    and node.end_byte <= left.end_byte
+                )
+            if (
+                node_type
+                in (
+                    cs.TS_JS_AUGMENTED_ASSIGNMENT_EXPRESSION,
+                    cs.TS_METHOD_DEFINITION,
+                    cs.TS_ARROW_FUNCTION,
+                )
+                or node_type in _JS_THIS_REBINDING_FUNC_TYPES
+                or node_type in cs.JS_TS_CLASS_NODES
+            ):
+                return False
+            current = current.parent
+        return False
+
+    @staticmethod
+    def _js_this_binds_to_enclosing_class(read_node: Node) -> bool:
+        # True when `this`/`super` at read_node lexically refers to the enclosing
+        # class instance: walk up, arrows are transparent (they inherit `this`),
+        # a method_definition binds `this` to the class ONLY when it is a class
+        # member (parent is a class_body) -- an object-literal shorthand method
+        # binds `this` to the object; a class node itself is a class-field arrow
+        # context; a plain function / function-expression / generator rebinds.
+        current = read_node.parent
+        while current is not None:
+            node_type = current.type
+            if node_type == cs.TS_METHOD_DEFINITION:
+                parent = current.parent
+                return parent is not None and parent.type == cs.TS_CLASS_BODY
+            if node_type in cs.JS_TS_CLASS_NODES:
+                return True
+            if node_type in _JS_THIS_REBINDING_FUNC_TYPES:
+                return False
+            current = current.parent
+        return False
+
+    def _js_ts_getter_read_class_qn(
+        self,
+        member_node: Node,
+        class_context: str | None,
+        local_var_types: dict[str, str] | None,
+        module_qn: str,
+    ) -> str | None:
+        # The class that owns a getter read `recv.getter`, resolved from the
+        # RECEIVER's type only: `this`/`super` is the enclosing class, and a
+        # plain identifier is typed via local_var_types then resolved to its
+        # class qn. Any other receiver (an unknown local, a chained expression)
+        # yields None so no edge is fabricated. Resolving by receiver type (not
+        # the name-global trie) is what keeps a same-named getter on an
+        # unrelated class from being falsely revived.
+        recv = member_node.child_by_field_name(cs.FIELD_OBJECT)
+        if recv is None:
+            return None
+        if recv.type == cs.TS_THIS:
+            # `this` binds to the class instance only when the read is lexically
+            # inside a CLASS method or class-field (arrows are transparent);
+            # inside a nested plain `function`/function-expression, or an
+            # object-literal method, `this` rebinds, so it is NOT the class and
+            # must not link (issue #971's rebinding rule, extended to reject an
+            # object-literal method whose method_definition binds `this` to the
+            # object, not the class). `super.getter` is deliberately NOT handled:
+            # it reads the BASE class's getter, and class_context is the current
+            # class, so mapping it here would target the wrong (or a missing)
+            # method; a conservative miss is preferred to a wrong edge.
+            if self._js_this_binds_to_enclosing_class(member_node):
+                return class_context
+            return None
+        if recv.type == cs.TS_IDENTIFIER and (recv_name := safe_decode_text(recv)):
+            # A typed local already stores its resolved class qn; a bare
+            # class-name receiver (a static getter read, `Box.thing`) resolves
+            # through the class registry. An unknown receiver (an untyped
+            # parameter) matches neither and yields None, so the name-global
+            # trie never fires and an unrelated same-named getter is not revived.
+            if (recv_type := (local_var_types or {}).get(recv_name)) is not None:
+                return recv_type
+            return self._resolver._resolve_class_name(recv_name, module_qn)
+        return None
+
+    def _ingest_js_ts_getter_reads(
+        self,
+        caller_node: Node,
+        caller_spec: tuple[str, str, str],
+        module_qn: str,
+        local_var_types: dict[str, str] | None,
+        class_context: str | None,
+        lang_config: LanguageSpec,
+        prop_names: set[str],
+        caller_qn: str | None = None,
+    ) -> None:
+        # Emit a REFERENCES edge (a read invokes the getter but is not a call, so
+        # the call graph stays invocation-only) for every member_expression whose
+        # property resolves to a getter ON THE RECEIVER'S OWN CLASS, wherever it
+        # appears in the body. The walk is position-agnostic, so a getter read
+        # inside a ternary, member chain (`loadMap.mainLoadMapItem.entity` visits
+        # the inner `loadMap.mainLoadMapItem`), or `if` condition links the same
+        # as a bare read. The candidate qn is built from the receiver's class and
+        # emitted only when it is a registered property, so a same-named data
+        # field, a same-named regular method, or a same-named getter on an
+        # unrelated class never fabricates an edge.
+        ensure_rel = self.ingestor.ensure_relationship_batch
+        registry = self._resolver.function_registry
+        refs_rel = cs.RelationshipType.REFERENCES
+        method_label = cs.NodeLabel.METHOD
+        qn_key = cs.KEY_QUALIFIED_NAME
+        function_types = lang_config.function_node_types
+        class_types = lang_config.class_node_types
+        seen: set[str] = set()
+        stack = list(caller_node.children)
+        while stack:
+            node = stack.pop()
+            node_type = node.type
+            # A nested class or NON-arrow function owns its own reads (and
+            # rebinds `this`), so it is processed as its own caller; do not
+            # descend. An arrow is transparent (it captures the enclosing `this`
+            # and shares the outer locals), so descend into it or getter reads in
+            # `.map`/`.find`/`.forEach` callbacks are missed.
+            if (
+                node_type in function_types and node_type != cs.TS_ARROW_FUNCTION
+            ) or node_type in class_types:
+                continue
+            if node_type == cs.TS_MEMBER_EXPRESSION:
+                prop = node.child_by_field_name(cs.FIELD_PROPERTY)
+                if (
+                    not self._js_ts_member_is_write_target(node)
+                    and prop is not None
+                    and (name := safe_decode_text(prop)) in prop_names
+                    and (
+                        class_qn := self._js_ts_getter_read_class_qn(
+                            node, class_context, local_var_types, module_qn
+                        )
+                    )
+                ):
+                    candidate = f"{class_qn}{cs.SEPARATOR_DOT}{name}"
+                    if registry.is_property(candidate):
+                        for target_qn in registry.variants(candidate):
+                            if target_qn != caller_qn and target_qn not in seen:
+                                seen.add(target_qn)
+                                ensure_rel(
+                                    caller_spec,
+                                    refs_rel,
+                                    (method_label, qn_key, target_qn),
+                                )
             stack.extend(node.children)
 
     def _build_nested_qualified_name(

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -5868,12 +5868,26 @@ class CallProcessor:
         # the name-global trie) is what keeps a same-named getter on an
         # unrelated class from being falsely revived.
         recv = member_node.child_by_field_name(cs.FIELD_OBJECT)
+        # Parens, `x!`, and `x satisfies T` keep the operand's type, so peel them;
+        # an `as` cast ASSERTS a type, so resolve the receiver from that target
+        # type directly (`(box as Base).thing` links even when box is untyped).
+        while recv is not None:
+            recv_type = recv.type
+            if recv_type in (
+                cs.TS_PARENTHESIZED_EXPRESSION,
+                cs.TS_NON_NULL_EXPRESSION,
+                cs.TS_SATISFIES_EXPRESSION,
+            ):
+                recv = recv.named_child(0)
+            elif recv_type == cs.TS_AS_EXPRESSION:
+                type_node = recv.named_children[-1] if recv.named_children else None
+                if type_node is None or not (tname := safe_decode_text(type_node)):
+                    return None
+                return self._resolver._resolve_class_name(tname, module_qn)
+            else:
+                break
         if recv is None:
             return None
-        # Peel transparent TS casts/parens/non-null off the receiver so
-        # `(box as Base).thing` and `this!.thing` resolve like `box.thing` /
-        # `this.thing`.
-        recv = self._unwrap_ts_value(recv)
         if recv.type == cs.TS_THIS:
             # `this` binds to the class instance only when the read is lexically
             # inside a CLASS method or class-field (arrows are transparent);

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -812,9 +812,27 @@ def ingest_method(
     # Python's @property marking feeds its attribute-access pass. A Dart
     # getter_signature is the same shape (issue #869): its accesses are
     # attribute reads the Dart getter-read pass resolves through this flag.
-    is_property = _is_property_decorator(decorators) or method_node.type in (
-        cs.TS_CSHARP_PROPERTY_DECLARATION,
-        cs.TS_DART_GETTER_SIGNATURE,
+    # A JS/TS getter is a `method_definition` carrying the `get` keyword; its
+    # reads are member accesses (`obj.thing`), so mark it like the other
+    # languages' properties to feed the JS/TS getter-read pass. The keyword is a
+    # direct child but not always the first (`static get x()` leads with
+    # `static`); a method named `get` carries a property_identifier, not a `get`
+    # keyword node, so scanning direct children stays exact.
+    is_js_ts_getter = (
+        language in cs.JS_TS_LANGUAGES
+        and method_node.type == cs.TS_METHOD_DEFINITION
+        and any(
+            child.type == cs.TS_GET_ACCESSOR_KEYWORD for child in method_node.children
+        )
+    )
+    is_property = (
+        _is_property_decorator(decorators)
+        or is_js_ts_getter
+        or method_node.type
+        in (
+            cs.TS_CSHARP_PROPERTY_DECLARATION,
+            cs.TS_DART_GETTER_SIGNATURE,
+        )
     )
     if is_property:
         method_props[cs.KEY_IS_PROPERTY] = True

--- a/codebase_rag/tests/test_ts_getter_property_read.py
+++ b/codebase_rag/tests/test_ts_getter_property_read.py
@@ -1,0 +1,258 @@
+# A JS/TS getter read as a property invokes the getter, so it must record an
+# edge to the getter method regardless of the expression position of the read.
+# Reads in direct return/assignment position already linked; reads nested in a
+# ternary condition, a member chain, an `if` condition, or a binary expression
+# did not, so the getter reported as dead. Found dogfooding TypeORM
+# (PlainObjectToDatabaseEntityTransformer's `loadMap.mainLoadMapItem` in a
+# ternary+chain, and JoinAttribute's `relation` getter read via `this.relation`
+# in `if`/chain positions). Issue #984. The edge is emitted only when the read's
+# property is a getter ON THE RECEIVER'S OWN CLASS, so unrelated same-named
+# symbols are never revived.
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.types_defs import PropertyDict, PropertyValue, ResultRow
+
+PROJECT = "p"
+
+
+class _Capture:
+    def __init__(self) -> None:
+        self.rels: list[tuple[PropertyValue, str, PropertyValue]] = []
+
+    def ensure_node_batch(self, label: str, properties: PropertyDict) -> None:
+        return None
+
+    def ensure_relationship_batch(
+        self,
+        from_spec: tuple[str, str, PropertyValue],
+        rel_type: str,
+        to_spec: tuple[str, str, PropertyValue],
+        properties: PropertyDict | None = None,
+    ) -> None:
+        self.rels.append((from_spec[2], str(rel_type), to_spec[2]))
+
+    def flush_all(self) -> None:
+        return None
+
+    def fetch_all(
+        self, query: str, params: PropertyDict | None = None
+    ) -> list[ResultRow]:
+        return []
+
+    def execute_write(self, query: str, params: PropertyDict | None = None) -> None:
+        return None
+
+
+def _edge_to(cap: _Capture, leaf: str, rel: str) -> bool:
+    return any(
+        r == rel and str(to).rsplit(".", 1)[-1] == leaf for _frm, r, to in cap.rels
+    )
+
+
+_REFERENCES = str(cs.RelationshipType.REFERENCES)
+_CALLS = str(cs.RelationshipType.CALLS)
+
+
+def _run(tmp_path: Path, src: str) -> _Capture:
+    (tmp_path / "c.ts").write_text(src)
+    parsers, queries = load_parsers()
+    cap = _Capture()
+    GraphUpdater(
+        ingestor=cap,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name=PROJECT,
+    ).run(force=True)
+    return cap
+
+
+# `this` receiver: the getter is on the SAME class the read sits in.
+_THIS_TEMPLATE = """export class T {{
+  get thing() {{ return 1; }}
+  method() {{ {body} }}
+}}
+"""
+
+# typed-local receiver: the getter is on the local's class.
+_LOCAL_TEMPLATE = """class Box {{ get thing() {{ return 1; }} }}
+export class T {{
+  method() {{
+    const box = new Box();
+    {body}
+  }}
+}}
+"""
+
+_POSITIONS = [
+    "return {r}.thing + 1;",
+    "return {r}.thing ? 1 : 2;",
+    "return {r}.thing.entity;",
+    "if ({r}.thing) return 1; return 2;",
+]
+
+
+@pytest.mark.parametrize("body", _POSITIONS)
+def test_this_getter_read_in_compound_expression_is_referenced(
+    tmp_path: Path, body: str
+) -> None:
+    cap = _run(tmp_path, _THIS_TEMPLATE.format(body=body.format(r="this")))
+    assert _edge_to(cap, "thing", _REFERENCES)
+
+
+@pytest.mark.parametrize("body", _POSITIONS)
+def test_typed_local_getter_read_in_compound_expression_is_referenced(
+    tmp_path: Path, body: str
+) -> None:
+    cap = _run(tmp_path, _LOCAL_TEMPLATE.format(body=body.format(r="box")))
+    assert _edge_to(cap, "thing", _REFERENCES)
+
+
+def test_static_getter_read_is_referenced(tmp_path: Path) -> None:
+    # `static get thing()` carries `static` before `get`; it must still be
+    # detected as a getter and referenced through the class name.
+    src = """export class Box {
+  static get thing() { return 1; }
+  static run() { return Box.thing ? 1 : 2; }
+}
+"""
+    assert _edge_to(_run(tmp_path, src), "thing", _REFERENCES)
+
+
+def test_getter_read_in_inline_arrow_callback_is_referenced(tmp_path: Path) -> None:
+    # An arrow callback captures the enclosing `this`, so `this.thing` read
+    # inside `a.map(() => ...)` must link (TypeORM reads getters through
+    # .map/.find/.forEach constantly). Adversarial review of #984.
+    src = """export class T {
+  get thing() { return 1; }
+  method(a: number[]) { return a.map(() => this.thing + 1); }
+}
+"""
+    assert _edge_to(_run(tmp_path, src), "thing", _REFERENCES)
+
+
+def test_typed_local_getter_read_in_inline_arrow_is_referenced(tmp_path: Path) -> None:
+    src = """class Box { get thing() { return 1; } }
+export class T {
+  method(a: number[]) {
+    const box = new Box();
+    return a.map(() => box.thing + 1);
+  }
+}
+"""
+    assert _edge_to(_run(tmp_path, src), "thing", _REFERENCES)
+
+
+def test_augmented_assignment_reads_the_getter(tmp_path: Path) -> None:
+    # `this.thing += 1` reads the current value (invokes the getter) before it
+    # writes, so it is a genuine read and must link. Adversarial review of #984.
+    src = """export class T {
+  get thing(): number { return 1; }
+  set thing(v: number) {}
+  method() { this.thing += 1; }
+}
+"""
+    assert _edge_to(_run(tmp_path, src), "thing", _REFERENCES)
+
+
+def test_this_in_nested_plain_function_does_not_link(tmp_path: Path) -> None:
+    # A nested non-arrow `function` rebinds `this`, so `this.thing` there is NOT
+    # the class instance and must not fabricate an edge to the class getter.
+    # Adversarial review of #984.
+    src = """export class T {
+  get thing() { return 1; }
+  method() {
+    function inner() { return this.thing + 1; }
+    return inner;
+  }
+}
+"""
+    assert not _edge_to(_run(tmp_path, src), "thing", _REFERENCES)
+
+
+def test_this_in_object_literal_method_does_not_link(tmp_path: Path) -> None:
+    # An object-literal shorthand method rebinds `this` to the object, not the
+    # enclosing class, so `this.thing` there must not link. Review of #984.
+    src = """export class T {
+  get thing() { return 1; }
+  method() {
+    const o = { foo() { return this.thing + 1; } };
+    return o;
+  }
+}
+"""
+    assert not _edge_to(_run(tmp_path, src), "thing", _REFERENCES)
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "this.thing = 1;",
+        "[this.thing] = arr;",
+        "({ x: this.thing } = o);",
+    ],
+)
+def test_setter_write_target_does_not_link_getter(tmp_path: Path, body: str) -> None:
+    # A plain-assignment write target (direct or via destructuring) invokes the
+    # SETTER, not the getter, so it must not link. Adversarial review of #984.
+    src = f"""export class T {{
+  get thing(): number {{ return 1; }}
+  set thing(v: number) {{}}
+  method(arr: number[], o: any) {{ {body} }}
+}}
+"""
+    assert not _edge_to(_run(tmp_path, src), "thing", _REFERENCES)
+
+
+def test_plain_field_read_does_not_fabricate_edge(tmp_path: Path) -> None:
+    # `field` is a data field, not a getter; reading it must NOT create an edge.
+    src = """class Box { field = 1; }
+export class T {
+  method() {
+    const box = new Box();
+    return box.field ? box.field.x : 0;
+  }
+}
+"""
+    cap = _run(tmp_path, src)
+    assert not _edge_to(cap, "field", _REFERENCES)
+
+
+def test_unrelated_receiver_does_not_revive_getter(tmp_path: Path) -> None:
+    # `p.secret` on an untyped parameter must NOT link to a same-named getter on
+    # an unrelated class; the receiver type is unknown, so no class owns it
+    # (adversarial review of #984 -- the name-global trie must not fire here).
+    src = """export class Foo { get secret() { return 1; } }
+export function handle(p: any) { return p.secret ? 1 : 2; }
+"""
+    cap = _run(tmp_path, src)
+    assert not _edge_to(cap, "secret", _REFERENCES)
+    assert not _edge_to(cap, "secret", _CALLS)
+
+
+def test_same_named_method_on_other_class_gets_no_spurious_reference(
+    tmp_path: Path,
+) -> None:
+    # A regular method `Other.thing()` shares the name with a getter `Box.thing`;
+    # calling `other.thing()` must record only the CALLS edge to Other.thing, not
+    # a spurious REFERENCES edge (adversarial review of #984).
+    src = """class Box { get thing() { return 1; } }
+export class Other {
+  thing() { return 2; }
+  run() {
+    const other = new Other();
+    return other.thing();
+  }
+}
+"""
+    cap = _run(tmp_path, src)
+    # No REFERENCES edge should target a `thing`; only the CALLS edge is correct.
+    assert not _edge_to(cap, "thing", _REFERENCES)
+    assert _edge_to(cap, "thing", _CALLS)

--- a/codebase_rag/tests/test_ts_getter_property_read.py
+++ b/codebase_rag/tests/test_ts_getter_property_read.py
@@ -126,16 +126,22 @@ export class Sub extends Base {
     assert _edge_to(_run(tmp_path, src), "thing", _REFERENCES)
 
 
-def test_cast_and_non_null_receiver_reads_are_referenced(tmp_path: Path) -> None:
-    # A receiver wrapped in a TS cast or non-null assertion is transparent, so
-    # `(box as Base).thing` and `this!.thing` must link (CodeRabbit review).
+def test_cast_receiver_read_is_referenced(tmp_path: Path) -> None:
+    # An `as` cast asserts the receiver's type, so `(box as Base).thing` links to
+    # Base's getter through the cast target type (even for an untyped receiver).
+    src = """class Base { get thing() { return 1; } }
+export class T {
+  method(box: unknown) { return (box as Base).thing ? 1 : 0; }
+}
+"""
+    assert _edge_to(_run(tmp_path, src), "thing", _REFERENCES)
+
+
+def test_non_null_receiver_read_is_referenced(tmp_path: Path) -> None:
+    # A non-null-asserted receiver is transparent: `this!.thing` must link.
     src = """class Base { get thing() { return 1; } }
 export class T extends Base {
-  method(box: Base) {
-    const a = (box as Base).thing ? 1 : 0;
-    const b = this!.thing ? 1 : 0;
-    return a + b;
-  }
+  method() { return this!.thing ? 1 : 0; }
 }
 """
     assert _edge_to(_run(tmp_path, src), "thing", _REFERENCES)

--- a/codebase_rag/tests/test_ts_getter_property_read.py
+++ b/codebase_rag/tests/test_ts_getter_property_read.py
@@ -115,6 +115,32 @@ def test_typed_local_getter_read_in_compound_expression_is_referenced(
     assert _edge_to(cap, "thing", _REFERENCES)
 
 
+def test_inherited_getter_read_is_referenced(tmp_path: Path) -> None:
+    # A getter defined on a base class and read through a subclass instance must
+    # link to the base getter (CodeRabbit review of #984).
+    src = """class Base { get thing() { return 1; } }
+export class Sub extends Base {
+  method() { return this.thing ? 1 : 2; }
+}
+"""
+    assert _edge_to(_run(tmp_path, src), "thing", _REFERENCES)
+
+
+def test_cast_and_non_null_receiver_reads_are_referenced(tmp_path: Path) -> None:
+    # A receiver wrapped in a TS cast or non-null assertion is transparent, so
+    # `(box as Base).thing` and `this!.thing` must link (CodeRabbit review).
+    src = """class Base { get thing() { return 1; } }
+export class T extends Base {
+  method(box: Base) {
+    const a = (box as Base).thing ? 1 : 0;
+    const b = this!.thing ? 1 : 0;
+    return a + b;
+  }
+}
+"""
+    assert _edge_to(_run(tmp_path, src), "thing", _REFERENCES)
+
+
 def test_static_getter_read_is_referenced(tmp_path: Path) -> None:
     # `static get thing()` carries `static` before `get`; it must still be
     # detected as a getter and referenced through the class name.

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.514"
+version = "0.0.515"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Add a JS/TS getter-read pass so reading a getter as a property (`this.relation`, `loadMap.mainLoadMapItem`) links to the getter method wherever the read appears (ternary, member chain, `if` condition, binary op, inline arrow callback), not only in direct return/assignment position.
- Register JS/TS getters (including `static get`) as properties so the pass can find them.
- Fixes dead-code false positives found dogfooding TypeORM (`JoinAttribute.relation`, `PlainObjectToDatabaseEntityTransformer.LoadMap.mainLoadMapItem`); TypeORM candidates drop from 8 to 5 (combined with #982), and the 5 residuals are genuine.

## Type of Change

- [x] Bug fix

## Related Issues

Closes #984

## Test Plan

- [x] Unit tests pass (`uv run pytest -n auto -m "not integration"`)
- [x] New tests added

`test_ts_getter_property_read.py` covers: this- and typed-local reads across compound positions; static getters; inline arrow callbacks; augmented assignment (reads); and negatives that must NOT link (plain data field, unrelated/untyped receiver, same-named method on another class, nested plain function `this`, object-literal method `this`, plain and destructuring setter-write targets).

## Checklist

- [x] PR title follows Conventional Commits format
- [x] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints

## Correctness scope (from adversarial review)

The edge is emitted only when the property is a getter on the receiver's **own resolved class**, so unrelated same-named symbols are never revived. `this` is honoured only where it lexically binds to the class (arrows transparent; nested plain functions and object-literal methods rebind `this` and do not link). Deliberate limitations: `super.getter` (base-class member) and inherited getters are conservative misses rather than wrong edges; a getter read inside a named method-scoped arrow may be attributed to both the arrow and the enclosing method, which is harmless for reachability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JavaScript/TypeScript understanding of `get ...()` so property reads are captured as `REFERENCES` rather than treated like invocations.
  * Added more accurate handling across ternaries, chains, conditions, and inherited getter scenarios.
  * Reduced incorrect links for setter/write targets and tricky receiver binding cases (including casts and non-null assertions).

* **Tests**
  * Expanded and refined TypeScript getter property-read coverage by splitting the cast vs non-null receiver cases into separate assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->