### PR TITLE
fix: reference nested inline JS/TS functions by their own source span

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -4276,6 +4276,7 @@ class CallProcessor:
                 ensure_rel,
                 caller_spec[2],
                 cs.RelationshipType.REFERENCES,
+                module_qn,
             )
             return
         # Only a bare name / attribute / member-expression in value position names
@@ -4535,6 +4536,28 @@ class CallProcessor:
         # the candidate from caller_qn (source_spec[2] is the callee for the
         # callable-param path). Registry guard skips unregistered names.
         registry = self._resolver.function_registry
+        # The node's OWN source span records the qn the definition pass minted,
+        # so resolve by span first when the module is known: it is authoritative
+        # across the two ways caller_qn can mislead a name/position guess. An
+        # object-literal method nested in a bound arrow is named FLAT (`mod.
+        # update`, dropping the nameless `make`) while the function it contains
+        # nests a level deeper (`mod.make.update.anonymous_R_C`), so no
+        # `{caller_qn}.anonymous_R_C` candidate matches (issue #985); and a NESTED
+        # named function-expression (`mod.make.update.handler`) whose name
+        # collides with a module-level function would otherwise match the
+        # module-flat name candidate and reference the WRONG top-level node. The
+        # candidate loop below is kept as the fallback for an incremental run
+        # where an unchanged file's span was not re-recorded this pass.
+        if (
+            module_qn is not None
+            and (loc := self._recorded_caller(arg_node, module_qn)) is not None
+        ):
+            ensure_rel(
+                source_spec,
+                rel_type,
+                (cs.NodeLabel.FUNCTION, cs.KEY_QUALIFIED_NAME, loc.qualified_name),
+            )
+            return
         scope_qn = caller_qn or source_spec[2]
         suffixes = [
             f"{cs.SEPARATOR_DOT}{cs.PREFIX_ANONYMOUS}"
@@ -4816,7 +4839,7 @@ class CallProcessor:
         # reference it by position the same way inline object-literal values are.
         if arg_node.type in _INLINE_FUNC_VALUE_TYPES:
             self._emit_inline_arg_function_ref(
-                arg_node, source_spec, ensure_rel, caller_qn, rel_type
+                arg_node, source_spec, ensure_rel, caller_qn, rel_type, module_qn
             )
             return
         if not (arg_text := safe_decode_text(arg_node)):

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -4530,12 +4530,6 @@ class CallProcessor:
         rel_type: cs.RelationshipType = cs.RelationshipType.REFERENCES,
         module_qn: str | None = None,
     ) -> None:
-        # An inline arrow/function-expression call argument is registered by the
-        # definition pass as {enclosing_scope}.anonymous_<row>_<col> from its own
-        # start position. The anonymous node lives in the CALLER's scope, so build
-        # the candidate from caller_qn (source_spec[2] is the callee for the
-        # callable-param path). Registry guard skips unregistered names.
-        registry = self._resolver.function_registry
         # The node's OWN source span records the qn the definition pass minted,
         # so resolve by span first when the module is known: it is authoritative
         # across the two ways caller_qn can mislead a name/position guess. An
@@ -4546,8 +4540,8 @@ class CallProcessor:
         # named function-expression (`mod.make.update.handler`) whose name
         # collides with a module-level function would otherwise match the
         # module-flat name candidate and reference the WRONG top-level node. The
-        # candidate loop below is kept as the fallback for an incremental run
-        # where an unchanged file's span was not re-recorded this pass.
+        # candidate fallback is kept for an incremental run where an unchanged
+        # file's span was not re-recorded this pass.
         if (
             module_qn is not None
             and (loc := self._recorded_caller(arg_node, module_qn)) is not None
@@ -4558,6 +4552,25 @@ class CallProcessor:
                 (cs.NodeLabel.FUNCTION, cs.KEY_QUALIFIED_NAME, loc.qualified_name),
             )
             return
+        self._emit_inline_ref_candidates(
+            arg_node, source_spec, ensure_rel, caller_qn, rel_type, module_qn
+        )
+
+    def _emit_inline_ref_candidates(
+        self,
+        arg_node: Node,
+        source_spec: tuple[str, str, str],
+        ensure_rel,
+        caller_qn: str | None,
+        rel_type: cs.RelationshipType,
+        module_qn: str | None,
+    ) -> None:
+        # An inline arrow/function-expression call argument is registered by the
+        # definition pass as {enclosing_scope}.anonymous_<row>_<col> from its own
+        # start position. The anonymous node lives in the CALLER's scope, so build
+        # the candidate from caller_qn (source_spec[2] is the callee for the
+        # callable-param path). Registry guard skips unregistered names.
+        registry = self._resolver.function_registry
         scope_qn = caller_qn or source_spec[2]
         suffixes = [
             f"{cs.SEPARATOR_DOT}{cs.PREFIX_ANONYMOUS}"

--- a/codebase_rag/tests/test_ts_reassigned_closure_arrow.py
+++ b/codebase_rag/tests/test_ts_reassigned_closure_arrow.py
@@ -1,0 +1,155 @@
+# An arrow assigned to an outer closure variable inside a nested object-literal
+# method is invoked indirectly through that variable elsewhere (a `render` that
+# calls `getText()`), so it is live. The reassignment references the arrow, but
+# the arrow's registered qn nests one level deeper than the object method's flat
+# qn (`p.c.make.update.anonymous_R_C` vs caller `p.c.update`), so the
+# caller-scope-prefixed position lookup missed it and the arrow reported dead.
+# Found dogfooding TypeORM (`packages/codemod/src/lib/spinner.ts`). Issue #985.
+from __future__ import annotations
+
+from pathlib import Path
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.types_defs import PropertyDict, PropertyValue, ResultRow
+
+PROJECT = "p"
+_REFERENCES = str(cs.RelationshipType.REFERENCES)
+
+
+class _Capture:
+    def __init__(self) -> None:
+        self.rels: list[tuple[PropertyValue, str, PropertyValue]] = []
+        self.nodes: list[str] = []
+
+    def ensure_node_batch(self, label: str, properties: PropertyDict) -> None:
+        if qn := properties.get(cs.KEY_QUALIFIED_NAME):
+            self.nodes.append(str(qn))
+
+    def ensure_relationship_batch(
+        self,
+        from_spec: tuple[str, str, PropertyValue],
+        rel_type: str,
+        to_spec: tuple[str, str, PropertyValue],
+        properties: PropertyDict | None = None,
+    ) -> None:
+        self.rels.append((from_spec[2], str(rel_type), to_spec[2]))
+
+    def flush_all(self) -> None:
+        return None
+
+    def fetch_all(
+        self, query: str, params: PropertyDict | None = None
+    ) -> list[ResultRow]:
+        return []
+
+    def execute_write(self, query: str, params: PropertyDict | None = None) -> None:
+        return None
+
+
+def _run(tmp_path: Path, src: str) -> _Capture:
+    (tmp_path / "c.ts").write_text(src)
+    parsers, queries = load_parsers()
+    cap = _Capture()
+    GraphUpdater(
+        ingestor=cap,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name=PROJECT,
+    ).run(force=True)
+    return cap
+
+
+def _reassigned_arrow_referenced(cap: _Capture, method: str) -> bool:
+    # The reassigned arrow is anonymous and registered under the object method's
+    # scope; a REFERENCES edge into `...<method>...anonymous_R_C` keeps it live.
+    return any(
+        rel == _REFERENCES
+        and f"{cs.SEPARATOR_DOT}{method}{cs.SEPARATOR_DOT}" in str(to)
+        and cs.PREFIX_ANONYMOUS in str(to)
+        for _frm, rel, to in cap.rels
+    )
+
+
+def test_reassigned_closure_arrow_in_object_method_is_referenced(
+    tmp_path: Path,
+) -> None:
+    src = """export const createSpinner = (text: string | (() => string)) => {
+  let getText = typeof text === "function" ? text : () => text
+  const render = () => { process.stderr.write(`${getText()}`) }
+  render()
+  return {
+    update(newText: string | (() => string)) {
+      getText = typeof newText === "function" ? newText : () => newText
+    },
+  }
+}
+"""
+    assert _reassigned_arrow_referenced(_run(tmp_path, src), "update")
+
+
+def test_plain_reassigned_arrow_in_object_method_is_referenced(
+    tmp_path: Path,
+) -> None:
+    # The same defect without the ternary: a bare arrow reassigned to the outer
+    # closure variable inside the nested method must still be referenced.
+    src = """export const make = () => {
+  let g = () => 1
+  const run = () => g()
+  run()
+  return { update() { g = () => 2 } }
+}
+"""
+    assert _reassigned_arrow_referenced(_run(tmp_path, src), "update")
+
+
+def _edges_to_leaf(cap: _Capture, leaf: str) -> set[tuple[str, str, str]]:
+    return {
+        (str(frm), rel, str(to))
+        for frm, rel, to in cap.rels
+        if str(to).rsplit(cs.SEPARATOR_DOT, 1)[-1] == leaf
+    }
+
+
+def test_nested_named_function_expression_in_array_links_to_itself(
+    tmp_path: Path,
+) -> None:
+    # A NESTED named function-expression whose name collides with a module-level
+    # function must reference ITSELF (its lexical scope), never the unrelated
+    # top-level function. Resolving by name alone would emit `p.c.update
+    # REFERENCES p.c.handler` (the wrong, top-level node) and falsely revive it.
+    src = """export function handler() { return 1 }
+export const make = () => {
+  return { update() { const arr = [function handler() { return 2 }]; return arr } }
+}
+"""
+    edges = _edges_to_leaf(_run(tmp_path, src), "handler")
+    refs = {(f, t) for f, rel, t in edges if rel == _REFERENCES}
+    # The correct nested node is referenced; the top-level namesake is not.
+    assert any(t.endswith(".update.handler") for _f, t in refs)
+    assert not any(t == "p.c.handler" for _f, t in refs)
+
+
+def test_nested_named_function_expression_call_arg_links_to_itself(
+    tmp_path: Path,
+) -> None:
+    # Same collision on the direct call-argument path, which also emits a CALLS
+    # edge: neither the CALLS nor REFERENCES edge may target the top-level
+    # `handler`.
+    src = """export function handler() { return 1 }
+export const make = () => {
+  return {
+    update() { window.addEventListener("click", function handler() { return 2 }) }
+  }
+}
+"""
+    edges = _edges_to_leaf(_run(tmp_path, src), "handler")
+    # DEFINES `p.c handler -> p.c.handler` is legitimate module containment; only
+    # a CALLS/REFERENCES edge onto the top-level namesake would falsely revive it.
+    call_ref = {
+        (f, rel, t) for f, rel, t in edges if rel != str(cs.RelationshipType.DEFINES)
+    }
+    assert not any(t == "p.c.handler" for _f, _rel, t in call_ref)
+    assert any(t.endswith(".update.handler") for _f, _rel, t in call_ref)

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.515"
+version = "0.0.516"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Fixes #985.

## Problem

An arrow function assigned to an outer closure `let` variable inside a nested object-literal method was reported dead even though it is invoked indirectly through that variable. Witness: TypeORM `packages/codemod/src/lib/spinner.ts`, where `update(newText)` reassigns `getText` and `render()` calls `getText()`.

## Root cause

Two qualified-name builders disagree about nameless scopes. The unified FQN resolver names the object-literal method FLAT (`mod.update`, dropping the nameless bound arrow between module and method), while the nested-qn builder that registers anonymous arrows recovers the binding name and nests one level deeper (`mod.make.update.anonymous_R_C`). The inline-function reference emitter built its candidate qns from the caller's qn prefix, so no candidate ever matched the registered arrow and no REFERENCES edge was emitted.

## Fix

Resolve the inline function node by its OWN source span first. The definition pass records the exact minted qn for every function span in `function_locations`; `_recorded_caller(arg_node, module_qn)` looks that up under a registry guard. When the module is known and the span is recorded, that resolution is authoritative and we emit directly to it. The existing candidate loop remains as the fallback for incremental runs where an unchanged file's span was not re-recorded this pass.

Span-first also fixes a latent collision: a NESTED named function-expression whose name matches a module-level function would otherwise resolve by name to the WRONG top-level node and falsely revive it. Two of the new tests pin this on both the array-element and call-argument paths.

## Validation

- 4 new tests in `codebase_rag/tests/test_ts_reassigned_closure_arrow.py` (RED before the fix).
- Full non-integration suite green: 6008 passed, 5 skipped (pre-existing), `pytest -n auto`.
- Real-repo verification on TypeORM: dead-code candidates 5 to 4; the spinner arrow now carries `spinner.update REFERENCES ...update.anonymous_34_64`; the 4 residuals are genuine ambient `declare class` entries in `bson.typings`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inline callable-reference resolution by preferring recorded source-span locations when module context is available.
  * Fixed reference edge emission for inline call arguments and arrow/function expressions.
  * Corrected reassigned closure arrow linking and prevented incorrect targets when nested function-expression names overlap module-level symbols.
* **Tests**
  * Added new coverage for reassigned closure arrows in object methods and for nested named function expressions in both array elements and call arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->