### PR TITLE
fix: resolve statement-position fn.call and fn.apply receivers by unique relevant binding

### DIFF
--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -189,7 +189,6 @@ JS_ASSIGNMENT_FUNCTION_QUERY = """
 TS_JS_IF_STATEMENT = "if_statement"
 # Switch family: cases may fall through into the next case.
 TS_JS_SWITCH_STATEMENT = "switch_statement"
-TS_JS_SWITCH_BODY = "switch_body"
 TS_JS_SWITCH_CASE = "switch_case"
 TS_JS_SWITCH_DEFAULT = "switch_default"
 # `c ? a : b` (shared name with the Java grammar); C++ spells it
@@ -230,8 +229,6 @@ TS_GENERATOR_FUNCTION = "generator_function"
 # Tree-sitter field names for module system
 FIELD_FUNCTION = "function"
 FIELD_KEY = "key"
-# An `export_statement` wraps the exported declaration in this field.
-FIELD_DECLARATION = "declaration"
 
 # JS/TS module system keywords
 JS_REQUIRE_KEYWORD = "require"

--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -189,6 +189,7 @@ JS_ASSIGNMENT_FUNCTION_QUERY = """
 TS_JS_IF_STATEMENT = "if_statement"
 # Switch family: cases may fall through into the next case.
 TS_JS_SWITCH_STATEMENT = "switch_statement"
+TS_JS_SWITCH_BODY = "switch_body"
 TS_JS_SWITCH_CASE = "switch_case"
 TS_JS_SWITCH_DEFAULT = "switch_default"
 # `c ? a : b` (shared name with the Java grammar); C++ spells it

--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -212,6 +212,9 @@ FIELD_FINALIZER = "finalizer"
 FIELD_INCREMENT = "increment"
 
 # JS/TS module system node types
+TS_TYPE_ANNOTATION = "type_annotation"
+TS_JS_WITH_STATEMENT = "with_statement"
+TS_CLASS_STATIC_BLOCK = "class_static_block"
 TS_OBJECT_PATTERN = "object_pattern"
 TS_ARRAY_PATTERN = "array_pattern"
 TS_REST_PATTERN = "rest_pattern"

--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -213,6 +213,7 @@ FIELD_INCREMENT = "increment"
 
 # JS/TS module system node types
 TS_TYPE_ANNOTATION = "type_annotation"
+TS_IMPORT_ALIAS = "import_alias"
 TS_JS_WITH_STATEMENT = "with_statement"
 TS_CLASS_STATIC_BLOCK = "class_static_block"
 TS_OBJECT_PATTERN = "object_pattern"

--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -224,10 +224,13 @@ TS_SUBSCRIPT_EXPRESSION = "subscript_expression"
 TS_FIELD_INDEX = "index"
 TS_FUNCTION_DECLARATION = "function_declaration"
 TS_GENERATOR_FUNCTION_DECLARATION = "generator_function_declaration"
+TS_GENERATOR_FUNCTION = "generator_function"
 
 # Tree-sitter field names for module system
 FIELD_FUNCTION = "function"
 FIELD_KEY = "key"
+# An `export_statement` wraps the exported declaration in this field.
+FIELD_DECLARATION = "declaration"
 
 # JS/TS module system keywords
 JS_REQUIRE_KEYWORD = "require"

--- a/codebase_rag/constants/ast_nodes.py
+++ b/codebase_rag/constants/ast_nodes.py
@@ -86,8 +86,6 @@ FIELD_RETURN_TYPE = "return_type"
 FIELD_CONSTRUCTOR = "constructor"
 FIELD_DECLARATOR = "declarator"
 FIELD_PARAMETERS = "parameters"
-# The declaration/expression clause of a C-style `for (init; cond; step)`.
-FIELD_INITIALIZER = "initializer"
 # A JS/TS arrow with a single bare-identifier parameter (`x => ...`) carries it
 # in the singular `parameter` field, with no formal_parameters wrapper.
 FIELD_PARAMETER = "parameter"

--- a/codebase_rag/constants/ast_nodes.py
+++ b/codebase_rag/constants/ast_nodes.py
@@ -86,6 +86,8 @@ FIELD_RETURN_TYPE = "return_type"
 FIELD_CONSTRUCTOR = "constructor"
 FIELD_DECLARATOR = "declarator"
 FIELD_PARAMETERS = "parameters"
+# The declaration/expression clause of a C-style `for (init; cond; step)`.
+FIELD_INITIALIZER = "initializer"
 # A JS/TS arrow with a single bare-identifier parameter (`x => ...`) carries it
 # in the singular `parameter` field, with no formal_parameters wrapper.
 FIELD_PARAMETER = "parameter"

--- a/codebase_rag/constants/ast_nodes.py
+++ b/codebase_rag/constants/ast_nodes.py
@@ -86,6 +86,9 @@ FIELD_RETURN_TYPE = "return_type"
 FIELD_CONSTRUCTOR = "constructor"
 FIELD_DECLARATOR = "declarator"
 FIELD_PARAMETERS = "parameters"
+# A JS/TS arrow with a single bare-identifier parameter (`x => ...`) carries it
+# in the singular `parameter` field, with no formal_parameters wrapper.
+FIELD_PARAMETER = "parameter"
 FIELD_RECEIVER = "receiver"
 FIELD_TYPE = "type"
 # The wrapped function/class inside a Python decorated_definition node.

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1894,6 +1894,11 @@ class GraphUpdater:
         return (root_node, language)
 
     def _process_function_calls(self) -> None:
+        # A reused updater (watch mode, a second run) re-parses files; the
+        # JS receiver-binding index holds nodes from the PREVIOUS parse,
+        # whose spans would resolve against the refreshed registry onto
+        # whatever now sits at the old line/column.
+        self.factory.call_processor.reset_js_receiver_bindings()
         captures_cache = self.factory._func_class_captures_cache
         # Iterate every file parsed this run, not the bounded AST cache: on a
         # large repo the cache evicts most files, and iterating it drops their

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -2755,6 +2755,39 @@ class CallProcessor:
                 is_macro_target = callee_info[1] in self.macro_qns
                 if is_macro_target != (call_node.type == cs.TS_RS_MACRO_INVOCATION):
                     callee_info = None
+            if not callee_info and is_js_ts:
+                # `fn.call(this, ...)` / `fn.apply(this, ...)` on a plain
+                # identifier that resolves to a first-party function is
+                # Function.prototype.call, an invocation of fn. Value positions
+                # already link via the bound-callable peel; a STATEMENT
+                # invocation reached here nameless-in-effect and its target
+                # reported dead (fastify's `multipleBindings.call(this, ...)`
+                # and the plugin-utils trio, issue #988). Runs only after the
+                # primary resolution failed, so a genuine method named
+                # call/apply on a typed receiver keeps its own edge, and only
+                # for an identifier receiver: a member-expression receiver
+                # (`checks[instance].call(...)`, `router.route.call(...)`)
+                # stays ambiguous exactly as PR #983 left it.
+                receiver, sep, invoke = call_name.rpartition(cs.SEPARATOR_DOT)
+                if (
+                    sep
+                    and invoke in (cs.JS_METHOD_CALL, cs.JS_METHOD_APPLY)
+                    and receiver
+                    and cs.SEPARATOR_DOT not in receiver
+                    and (
+                        receiver_info := resolve_func(
+                            receiver,
+                            module_qn,
+                            call_var_types,
+                            class_context,
+                            caller_qn,
+                            language,
+                        )
+                    )
+                    is not None
+                    and receiver_info[0] == cs.NodeLabel.FUNCTION
+                ):
+                    callee_info = receiver_info
             if not callee_info and resolve_builtin is not None:
                 callee_info = resolve_builtin(call_name)
             if not callee_info and resolve_cpp_op is not None:

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -2762,18 +2762,28 @@ class CallProcessor:
                 # already link via the bound-callable peel; a STATEMENT
                 # invocation reached here nameless-in-effect and its target
                 # reported dead (fastify's `multipleBindings.call(this, ...)`
-                # and the plugin-utils trio, issue #988). Runs only after the
-                # primary resolution failed, so a genuine method named
-                # call/apply on a typed receiver keeps its own edge, and only
-                # for an identifier receiver: a member-expression receiver
+                # and the plugin-utils trio, issue #988). Only an identifier
+                # receiver qualifies: a member-expression receiver
                 # (`checks[instance].call(...)`, `router.route.call(...)`)
-                # stays ambiguous exactly as PR #983 left it.
+                # stays ambiguous exactly as PR #983 left it. Bare-name
+                # resolution guesses, so the guess is confined to bindings the
+                # name can actually mean here: never a caller PARAMETER, never
+                # a name the caller REBINDS locally (unless it resolved to that
+                # local function itself), and never outside this module (the
+                # project-wide trie would revive same-named functions in
+                # unrelated files). The edge is emitted directly and the site
+                # is finished: routing through callee_info would map the
+                # callable-param flow onto the RAW argument list, whose
+                # position 0 is the `this` value, binding parameters one slot
+                # off. Real function-valued arguments keep their reachability
+                # through the argument-reference pass instead.
                 receiver, sep, invoke = call_name.rpartition(cs.SEPARATOR_DOT)
                 if (
                     sep
                     and invoke in (cs.JS_METHOD_CALL, cs.JS_METHOD_APPLY)
                     and receiver
                     and cs.SEPARATOR_DOT not in receiver
+                    and receiver not in caller_params
                     and (
                         receiver_info := resolve_func(
                             receiver,
@@ -2786,8 +2796,35 @@ class CallProcessor:
                     )
                     is not None
                     and receiver_info[0] == cs.NodeLabel.FUNCTION
+                    and receiver_info[1].startswith(f"{module_qn}{cs.SEPARATOR_DOT}")
+                    and (
+                        (
+                            caller_qn is not None
+                            and receiver_info[1].startswith(
+                                f"{caller_qn}{cs.SEPARATOR_DOT}"
+                            )
+                        )
+                        or not self._js_caller_rebinds_name(caller_node, receiver)
+                    )
                 ):
-                    callee_info = receiver_info
+                    ensure_rel(
+                        caller_spec,
+                        calls_rel,
+                        (receiver_info[0], qn_key, receiver_info[1]),
+                    )
+                    self._ingest_argument_function_references(
+                        call_node,
+                        caller_spec,
+                        module_qn,
+                        local_var_types,
+                        class_context,
+                        resolve_func,
+                        ensure_rel,
+                        caller_qn,
+                        cs.RelationshipType.REFERENCES,
+                        language,
+                    )
+                    continue
             if not callee_info and resolve_builtin is not None:
                 callee_info = resolve_builtin(call_name)
             if not callee_info and resolve_cpp_op is not None:
@@ -6135,6 +6172,35 @@ class CallProcessor:
         if node.type not in (cs.TS_ARROW_FUNCTION, cs.TS_FUNCTION_EXPRESSION):
             return False
         return not (self._get_node_name(node) or self._js_ts_arrow_binding_name(node))
+
+    @staticmethod
+    def _js_caller_rebinds_name(caller_node: Node, name: str) -> bool:
+        # True when any variable declarator anywhere in the caller's body binds
+        # `name`, meaning a bare `name` inside the caller may denote that local
+        # value rather than the same-named module-level function a scope-walk
+        # resolution would return (`const emitter = handlers.build();
+        # emitter.call(1)` must not bind a module function named emitter).
+        # Destructuring patterns count via the identifier scan of the whole
+        # `name` field. Over-approximate on purpose: a declarator in a nested
+        # inner scope also suppresses, trading a conservative miss for never
+        # emitting a cross-binding false edge.
+        stack = list(caller_node.children)
+        while stack:
+            node = stack.pop()
+            if node.type == cs.TS_VARIABLE_DECLARATOR:
+                target = node.child_by_field_name(cs.FIELD_NAME)
+                if target is not None:
+                    inner = [target]
+                    while inner:
+                        part = inner.pop()
+                        if (
+                            part.type == cs.TS_IDENTIFIER
+                            and safe_decode_text(part) == name
+                        ):
+                            return True
+                        inner.extend(part.named_children)
+            stack.extend(node.children)
+        return False
 
     def _is_method(self, func_node: Node, lang_config: LanguageSpec) -> bool:
         return is_method_node(func_node, lang_config)

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -391,6 +391,17 @@ _JS_LEXICAL_HOISTED_DECLARATIONS = frozenset(
 # Inline values that ARE callables when held by a declarator; generators
 # included (a `const gen = function* () {...}` receiver is invocable).
 _JS_INLINE_CALLABLE_VALUE_TYPES = _INLINE_FUNC_VALUE_TYPES | {cs.TS_GENERATOR_FUNCTION}
+# Declarations that bind a VALUE name for the receiver index: classes, TS
+# enums (compiled to vars) and namespaces/modules (compiled to objects).
+_JS_VALUE_TYPE_DECLARATIONS = frozenset(
+    {
+        cs.TS_CLASS_DECLARATION,
+        cs.TS_CLASS_EXPRESSION,
+        cs.TS_ENUM_DECLARATION,
+        cs.TS_INTERNAL_MODULE,
+        cs.TS_MODULE,
+    }
+)
 # JS/TS function scopes that REBIND `this` per call (a plain function /
 # generator / function expression), as opposed to an arrow_function (inherits
 # `this` lexically) or a method_definition / class-field arrow (binds `this` to
@@ -575,6 +586,264 @@ def _add_py_keyword_argument(child: Node, keyword: dict[str, Node]) -> None:
         and (name := safe_decode_text(name_node)) is not None
     ):
         keyword[name] = value_node
+
+
+class _JsFileBindingCollector:
+    """Whole-file binding index for the #988 receiver resolution.
+
+    One pass over a JS/TS file: name -> introductions as (function node or
+    None, container node or None for file-wide). Non-function introductions
+    are OVER-collected on purpose (destructuring, import aliases,
+    reassignment targets): each can only suppress. A `with` block makes every
+    name dynamic, so the whole file collapses to an empty index and nothing
+    ever resolves.
+
+    TS declaration merging: every block of one namespace shares one scope for
+    EXPORTED direct members, so those members gain one introduction per
+    SIBLING block afterwards; that is exactly where merging makes them
+    visible, and nowhere else. Merge groups key on (nearest NON-namespace
+    container id, dotted namespace path): `A { N }` in either A block and
+    `A.N` at top level all key to (program, "A.N") and merge, while a
+    top-level `N` keys to (program, "N") and stays distinct. Node identity
+    uses tree-sitter's stable `.id` (fresh Python wrappers over the same tree
+    node compare unequal with `is`).
+    """
+
+    __slots__ = (
+        "_bindings",
+        "_namespace_blocks",
+        "_namespace_group_of",
+        "_ns_exported",
+        "_poisoned",
+        "_unwrap_ts_value",
+    )
+
+    def __init__(self, unwrap_ts_value: Callable[[Node], Node]) -> None:
+        self._unwrap_ts_value = unwrap_ts_value
+        self._bindings: dict[str, list[tuple[Node | None, Node | None]]] = {}
+        self._namespace_blocks: dict[tuple[int, str], list[Node]] = {}
+        self._namespace_group_of: dict[int, tuple[int, str]] = {}
+        self._ns_exported: list[tuple[str, Node | None, Node]] = []
+        self._poisoned = False
+
+    def collect(self, root: Node) -> dict[str, list[tuple[Node | None, Node | None]]]:
+        stack: list[tuple[Node, Node, int, tuple[str, ...]]] = [
+            (root, root, root.id, ())
+        ]
+        while stack:
+            node, fn_container, ns_anchor, ns_path = stack.pop()
+            descend, frame = self._visit(node, fn_container, ns_anchor, ns_path)
+            if self._poisoned:
+                return {}
+            if descend:
+                for child in node.named_children:
+                    stack.append((child, *frame))
+        self._replicate_merged_members()
+        return self._bindings
+
+    def _visit(
+        self, node: Node, fn_container: Node, ns_anchor: int, ns_path: tuple[str, ...]
+    ) -> tuple[bool, tuple[Node, int, tuple[str, ...]]]:
+        node_type = node.type
+        frame = (fn_container, ns_anchor, ns_path)
+        if node_type in _JS_LEXICAL_CALLABLE_SCOPES:
+            return True, self._visit_callable(node, fn_container)
+        if node_type == cs.TS_CLASS_STATIC_BLOCK:
+            # A static block is its own `var` scope.
+            return True, (node, node.id, ())
+        if node_type == cs.TS_JS_WITH_STATEMENT:
+            # Dynamic scoping: no receiver in this file can be trusted.
+            self._poisoned = True
+            return False, frame
+        if node_type == cs.TS_VARIABLE_DECLARATOR:
+            self._visit_declarator(node, fn_container)
+        elif node_type == cs.TS_JS_FOR_IN_STATEMENT:
+            # Covers for-of and for-in, with or without var/let/const: the
+            # left side binds (or rebinds) its identifiers. The enclosing
+            # callable body over-approximates the lexical variants' scope,
+            # which can only suppress.
+            left = node.child_by_field_name(cs.FIELD_LEFT)
+            if left is not None:
+                self._add_pattern(left, fn_container)
+        elif node_type == cs.TS_JS_CATCH_CLAUSE:
+            param = node.child_by_field_name(cs.FIELD_PARAMETER)
+            if param is not None:
+                self._add_pattern(param, node)
+        elif node_type in _JS_VALUE_TYPE_DECLARATIONS:
+            return True, self._visit_type_binding(node, frame)
+        elif node_type in (cs.TS_IMPORT_ALIAS, cs.TS_IMPORT_STATEMENT):
+            # Either import form binds every identifier it contains: the
+            # default/named/namespace clauses, the TS `import x =
+            # require(...)` clause, and the namespace alias `import x =
+            # Other.thing` (whose aliased path identifiers over-collect,
+            # which can only suppress). The module path is a string.
+            self._add_pattern(node, None)
+            return False, frame
+        elif node_type in (
+            cs.TS_JS_ASSIGNMENT_EXPRESSION,
+            cs.TS_JS_AUGMENTED_ASSIGNMENT_EXPRESSION,
+        ):
+            self._visit_assignment(node)
+        return True, frame
+
+    def _visit_callable(
+        self, node: Node, fn_container: Node
+    ) -> tuple[Node, int, tuple[str, ...]]:
+        params = node.child_by_field_name(cs.FIELD_PARAMETERS)
+        if params is not None:
+            self._add_pattern(params, node)
+        elif (single := node.child_by_field_name(cs.FIELD_PARAMETER)) is not None:
+            self._add_pattern(single, node)
+        node_type = node.type
+        if node_type in (cs.TS_FUNCTION_EXPRESSION, cs.TS_GENERATOR_FUNCTION):
+            # A named function expression binds its own name in its body only.
+            name_node = node.child_by_field_name(cs.FIELD_NAME)
+            if name_node is not None:
+                self._add(safe_decode_text(name_node), node, node)
+        elif node_type in _JS_LEXICAL_HOISTED_DECLARATIONS:
+            self._visit_hoisted_declaration(node, fn_container)
+        # A method_definition name is a property, never a binding.
+        body = node.child_by_field_name(cs.FIELD_BODY) or node
+        return body, body.id, ()
+
+    def _visit_hoisted_declaration(self, node: Node, fn_container: Node) -> None:
+        # Function declarations hoist; Annex B makes even a block-level one
+        # function-scoped in sloppy mode, and one under a switch case is live
+        # across the whole switch body, so the enclosing callable body (or
+        # module) is the only container that never understates the binding's
+        # reach. In strict-mode block cases this over-widens, which can only
+        # suppress.
+        name_node = node.child_by_field_name(cs.FIELD_NAME)
+        if name_node is None:
+            return
+        decl_name = safe_decode_text(name_node)
+        self._add(decl_name, node, fn_container)
+        if (
+            decl_name
+            and fn_container.type in (cs.TS_INTERNAL_MODULE, cs.TS_MODULE)
+            and node.parent is not None
+            and node.parent.type == cs.TS_EXPORT_STATEMENT
+        ):
+            self._ns_exported.append((decl_name, node, fn_container))
+
+    def _visit_declarator(self, node: Node, fn_container: Node) -> None:
+        target = node.child_by_field_name(cs.FIELD_NAME)
+        declaration = node.parent
+        if target is None or declaration is None:
+            return
+        container = self._declarator_container(declaration, fn_container)
+        if target.type != cs.TS_IDENTIFIER:
+            self._add_pattern(target, container)
+            return
+        value = node.child_by_field_name(cs.FIELD_VALUE)
+        fn_value: Node | None = None
+        if value is not None:
+            value = self._unwrap_ts_value(value)
+            if value.type in _JS_INLINE_CALLABLE_VALUE_TYPES:
+                fn_value = value
+        target_name = safe_decode_text(target)
+        self._add(target_name, fn_value, container)
+        wrapper = declaration.parent
+        if (
+            target_name
+            and wrapper is not None
+            and wrapper.type == cs.TS_EXPORT_STATEMENT
+            and (body := wrapper.parent) is not None
+            and (ns := body.parent) is not None
+            and ns.type in (cs.TS_INTERNAL_MODULE, cs.TS_MODULE)
+        ):
+            self._ns_exported.append((target_name, fn_value, ns))
+
+    def _visit_type_binding(
+        self, node: Node, frame: tuple[Node, int, tuple[str, ...]]
+    ) -> tuple[Node, int, tuple[str, ...]]:
+        # Classes, TS enums and namespaces all bind VALUE names (an enum
+        # compiles to a var, a namespace to an object). A namespace/module
+        # body is additionally its own scope: its members are invisible
+        # outside it.
+        _fn_container, ns_anchor, ns_path = frame
+        name_node = node.child_by_field_name(cs.FIELD_NAME)
+        if name_node is not None:
+            self._add(safe_decode_text(name_node), None, None)
+        if node.type not in (cs.TS_INTERNAL_MODULE, cs.TS_MODULE):
+            return frame
+        if name_node is not None and (ns_name := safe_decode_text(name_node)):
+            ns_path = ns_path + tuple(ns_name.split(cs.SEPARATOR_DOT))
+            group = (ns_anchor, cs.SEPARATOR_DOT.join(ns_path))
+            self._namespace_blocks.setdefault(group, []).append(node)
+            self._namespace_group_of[node.id] = group
+        return node, ns_anchor, ns_path
+
+    def _visit_assignment(self, node: Node) -> None:
+        # A reassignment rebinds a name declared SOMEWHERE to an arbitrary
+        # value; file-wide relevance is the safe reading.
+        left = node.child_by_field_name(cs.FIELD_LEFT)
+        if left is None:
+            return
+        if left.type == cs.TS_IDENTIFIER:
+            self._add(safe_decode_text(left), None, None)
+        elif left.type in (cs.TS_OBJECT_PATTERN, cs.TS_ARRAY_PATTERN):
+            self._add_pattern(left, None)
+
+    def _add(
+        self, name: str | None, fn_node: Node | None, container: Node | None
+    ) -> None:
+        if name:
+            self._bindings.setdefault(name, []).append((fn_node, container))
+
+    def _add_pattern(self, pattern: Node, container: Node | None) -> None:
+        # Binding-side only: a default value (assignment_pattern right, or
+        # the TS grammar's wrapperless parameter default outside the pattern
+        # field) or a type annotation READS names, it does not introduce them.
+        stack = [pattern]
+        while stack:
+            part = stack.pop()
+            if part.type == cs.TS_ASSIGNMENT_PATTERN:
+                left = part.child_by_field_name(cs.FIELD_LEFT)
+                if left is not None:
+                    stack.append(left)
+                continue
+            if part.type in (cs.TS_REQUIRED_PARAMETER, cs.TS_OPTIONAL_PARAMETER):
+                ts_pattern = part.child_by_field_name(cs.TS_FIELD_PATTERN)
+                if ts_pattern is not None:
+                    stack.append(ts_pattern)
+                continue
+            if part.type == cs.TS_TYPE_ANNOTATION:
+                continue
+            if part.type in (
+                cs.TS_IDENTIFIER,
+                cs.TS_SHORTHAND_PROPERTY_IDENTIFIER_PATTERN,
+            ):
+                self._add(safe_decode_text(part), None, container)
+            stack.extend(part.named_children)
+
+    @staticmethod
+    def _declarator_container(declaration: Node, fn_container: Node) -> Node | None:
+        # `var` hoists to the enclosing callable body; `let`/`const` scope to
+        # the declaration's parent, peeling an export_statement wrapper and
+        # widening a switch-case slot to the shared switch body.
+        if declaration.type != cs.TS_LEXICAL_DECLARATION:
+            return fn_container
+        parent = declaration.parent
+        if parent is None:
+            return fn_container
+        if parent.type == cs.TS_EXPORT_STATEMENT:
+            return parent.parent
+        if parent.type in (cs.TS_JS_SWITCH_CASE, cs.TS_JS_SWITCH_DEFAULT):
+            return parent.parent
+        return parent
+
+    def _replicate_merged_members(self) -> None:
+        for member_name, fn_node, block in self._ns_exported:
+            group = self._namespace_group_of.get(block.id)
+            if group is None:
+                continue
+            blocks = self._namespace_blocks.get(group, [])
+            if len(blocks) < 2:
+                continue
+            for sibling in blocks:
+                if sibling.id != block.id:
+                    self._add(member_name, fn_node, sibling)
 
 
 class CallProcessor:
@@ -6222,230 +6491,7 @@ class CallProcessor:
     def _js_collect_file_bindings(
         self, root: Node
     ) -> dict[str, list[tuple[Node | None, Node | None]]]:
-        # One pass over the file: name -> introductions as (function node or
-        # None, container node or None for file-wide). Non-function
-        # introductions are OVER-collected on purpose (destructuring,
-        # import aliases, reassignment targets): each can only suppress. A
-        # `with` block makes every name dynamic, so the whole file returns
-        # empty and nothing ever resolves.
-        bindings: dict[str, list[tuple[Node | None, Node | None]]] = {}
-        # TS declaration merging: every `namespace N` block in the file
-        # shares one scope for EXPORTED direct members. Track blocks per
-        # namespace name and the exported members declared in each, so a
-        # repeated name's members gain one introduction per SIBLING block
-        # afterwards; that is exactly where merging makes them visible, and
-        # nowhere else.
-        # Merge groups key on (nearest NON-namespace container id, dotted
-        # namespace path): `A { N }` in either A block and `A.N` at top
-        # level all key to (program, "A.N") and merge, while a top-level `N`
-        # keys to (program, "N") and stays distinct. Node identity uses
-        # tree-sitter's stable `.id` (fresh Python wrappers over the same
-        # tree node compare unequal with `is`).
-        namespace_blocks: dict[tuple[int, str], list[Node]] = {}
-        namespace_group_of: dict[int, tuple[int, str]] = {}
-        ns_exported: list[tuple[str, Node | None, Node]] = []
-
-        def add(name: str | None, fn_node: Node | None, container: Node | None) -> None:
-            if name:
-                bindings.setdefault(name, []).append((fn_node, container))
-
-        def add_pattern(pattern: Node, container: Node | None) -> None:
-            # Binding-side only: a default value (assignment_pattern right)
-            # or a TS type annotation READS names, it does not introduce them.
-            stack = [pattern]
-            while stack:
-                part = stack.pop()
-                if part.type == cs.TS_ASSIGNMENT_PATTERN:
-                    left = part.child_by_field_name(cs.FIELD_LEFT)
-                    if left is not None:
-                        stack.append(left)
-                    continue
-                if part.type in (cs.TS_REQUIRED_PARAMETER, cs.TS_OPTIONAL_PARAMETER):
-                    # The TS grammar hangs a default straight off the
-                    # parameter (no assignment_pattern wrapper); only the
-                    # pattern field introduces names.
-                    ts_pattern = part.child_by_field_name(cs.TS_FIELD_PATTERN)
-                    if ts_pattern is not None:
-                        stack.append(ts_pattern)
-                    continue
-                if part.type == cs.TS_TYPE_ANNOTATION:
-                    continue
-                if part.type in (
-                    cs.TS_IDENTIFIER,
-                    cs.TS_SHORTHAND_PROPERTY_IDENTIFIER_PATTERN,
-                ):
-                    add(safe_decode_text(part), None, container)
-                stack.extend(part.named_children)
-
-        def declarator_container(declaration: Node, fn_container: Node) -> Node | None:
-            # `var` hoists to the enclosing callable body; `let`/`const`
-            # scope to the declaration's parent, peeling an export_statement
-            # wrapper and widening a switch-case slot to the shared switch
-            # body.
-            if declaration.type != cs.TS_LEXICAL_DECLARATION:
-                return fn_container
-            parent = declaration.parent
-            if parent is None:
-                return fn_container
-            if parent.type == cs.TS_EXPORT_STATEMENT:
-                return parent.parent
-            if parent.type in (cs.TS_JS_SWITCH_CASE, cs.TS_JS_SWITCH_DEFAULT):
-                return parent.parent
-            return parent
-
-        stack: list[tuple[Node, Node, int, tuple[str, ...]]] = [
-            (root, root, root.id, ())
-        ]
-        while stack:
-            node, fn_container, ns_anchor, ns_path = stack.pop()
-            node_type = node.type
-            next_container = fn_container
-            next_ns_anchor = ns_anchor
-            next_ns_path = ns_path
-            if node_type in _JS_LEXICAL_CALLABLE_SCOPES:
-                params = node.child_by_field_name(cs.FIELD_PARAMETERS)
-                if params is not None:
-                    add_pattern(params, node)
-                elif (
-                    single := node.child_by_field_name(cs.FIELD_PARAMETER)
-                ) is not None:
-                    add_pattern(single, node)
-                if node_type in (cs.TS_FUNCTION_EXPRESSION, cs.TS_GENERATOR_FUNCTION):
-                    # A named function expression binds its own name in its
-                    # body only.
-                    name_node = node.child_by_field_name(cs.FIELD_NAME)
-                    if name_node is not None:
-                        add(safe_decode_text(name_node), node, node)
-                elif node_type in _JS_LEXICAL_HOISTED_DECLARATIONS:
-                    # Function declarations hoist; Annex B makes even a
-                    # block-level one function-scoped in sloppy mode, and one
-                    # under a switch case is live across the whole switch
-                    # body, so the enclosing callable body (or module) is the
-                    # only container that never understates the binding's
-                    # reach. In strict-mode block cases this over-widens,
-                    # which can only suppress.
-                    name_node = node.child_by_field_name(cs.FIELD_NAME)
-                    if name_node is not None:
-                        decl_name = safe_decode_text(name_node)
-                        add(decl_name, node, fn_container)
-                        if (
-                            decl_name
-                            and fn_container.type
-                            in (cs.TS_INTERNAL_MODULE, cs.TS_MODULE)
-                            and node.parent is not None
-                            and node.parent.type == cs.TS_EXPORT_STATEMENT
-                        ):
-                            ns_exported.append((decl_name, node, fn_container))
-                # A method_definition name is a property, never a binding.
-                next_container = node.child_by_field_name(cs.FIELD_BODY) or node
-                next_ns_anchor = next_container.id
-                next_ns_path = ()
-            elif node_type == cs.TS_CLASS_STATIC_BLOCK:
-                # A static block is its own `var` scope.
-                next_container = node
-                next_ns_anchor = node.id
-                next_ns_path = ()
-            elif node_type == cs.TS_JS_WITH_STATEMENT:
-                # Dynamic scoping: no receiver in this file can be trusted.
-                return {}
-            elif node_type == cs.TS_VARIABLE_DECLARATOR:
-                target = node.child_by_field_name(cs.FIELD_NAME)
-                declaration = node.parent
-                if target is not None and declaration is not None:
-                    container = declarator_container(declaration, fn_container)
-                    if target.type == cs.TS_IDENTIFIER:
-                        value = node.child_by_field_name(cs.FIELD_VALUE)
-                        fn_value: Node | None = None
-                        if value is not None:
-                            value = self._unwrap_ts_value(value)
-                            if value.type in _JS_INLINE_CALLABLE_VALUE_TYPES:
-                                fn_value = value
-                        target_name = safe_decode_text(target)
-                        add(target_name, fn_value, container)
-                        wrapper = declaration.parent
-                        if (
-                            target_name
-                            and wrapper is not None
-                            and wrapper.type == cs.TS_EXPORT_STATEMENT
-                            and (body := wrapper.parent) is not None
-                            and (ns := body.parent) is not None
-                            and ns.type in (cs.TS_INTERNAL_MODULE, cs.TS_MODULE)
-                        ):
-                            ns_exported.append((target_name, fn_value, ns))
-                    else:
-                        add_pattern(target, container)
-            elif node_type == cs.TS_JS_FOR_IN_STATEMENT:
-                # Covers for-of and for-in, with or without var/let/const:
-                # the left side binds (or rebinds) its identifiers. The
-                # enclosing callable body over-approximates the lexical
-                # variants' scope, which can only suppress.
-                left = node.child_by_field_name(cs.FIELD_LEFT)
-                if left is not None:
-                    add_pattern(left, fn_container)
-            elif node_type == cs.TS_JS_CATCH_CLAUSE:
-                param = node.child_by_field_name(cs.FIELD_PARAMETER)
-                if param is not None:
-                    add_pattern(param, node)
-            elif node_type in (
-                cs.TS_CLASS_DECLARATION,
-                cs.TS_CLASS_EXPRESSION,
-                cs.TS_ENUM_DECLARATION,
-                cs.TS_INTERNAL_MODULE,
-                cs.TS_MODULE,
-            ):
-                # Classes, TS enums and namespaces all bind VALUE names (an
-                # enum compiles to a var, a namespace to an object). A
-                # namespace/module body is additionally its own scope: its
-                # members are invisible outside it.
-                name_node = node.child_by_field_name(cs.FIELD_NAME)
-                if name_node is not None:
-                    add(safe_decode_text(name_node), None, None)
-                if node_type in (cs.TS_INTERNAL_MODULE, cs.TS_MODULE):
-                    next_container = node
-                    if name_node is not None and (
-                        ns_name := safe_decode_text(name_node)
-                    ):
-                        next_ns_path = ns_path + tuple(ns_name.split(cs.SEPARATOR_DOT))
-                        group = (ns_anchor, cs.SEPARATOR_DOT.join(next_ns_path))
-                        namespace_blocks.setdefault(group, []).append(node)
-                        namespace_group_of[node.id] = group
-            elif node_type == cs.TS_IMPORT_ALIAS:
-                # `import x = Other.thing` (namespace alias form) binds x;
-                # the aliased path identifiers over-collect, which can only
-                # suppress.
-                add_pattern(node, None)
-                continue
-            elif node_type == cs.TS_IMPORT_STATEMENT:
-                # Covers default/named/namespace clauses AND the TS
-                # `import x = require(...)` form: every identifier in the
-                # statement is a bound name (the module path is a string).
-                add_pattern(node, None)
-                continue
-            elif node_type in (
-                cs.TS_JS_ASSIGNMENT_EXPRESSION,
-                cs.TS_JS_AUGMENTED_ASSIGNMENT_EXPRESSION,
-            ):
-                # A reassignment rebinds a name declared SOMEWHERE to an
-                # arbitrary value; file-wide relevance is the safe reading.
-                left = node.child_by_field_name(cs.FIELD_LEFT)
-                if left is not None:
-                    if left.type == cs.TS_IDENTIFIER:
-                        add(safe_decode_text(left), None, None)
-                    elif left.type in (cs.TS_OBJECT_PATTERN, cs.TS_ARRAY_PATTERN):
-                        add_pattern(left, None)
-            for child in node.named_children:
-                stack.append((child, next_container, next_ns_anchor, next_ns_path))
-        for member_name, fn_node, block in ns_exported:
-            group = namespace_group_of.get(block.id)
-            if group is None:
-                continue
-            blocks = namespace_blocks.get(group, [])
-            if len(blocks) < 2:
-                continue
-            for sibling in blocks:
-                if sibling.id != block.id:
-                    add(member_name, fn_node, sibling)
-        return bindings
+        return _JsFileBindingCollector(self._unwrap_ts_value).collect(root)
 
     def _is_method(self, func_node: Node, lang_config: LanguageSpec) -> bool:
         return is_method_node(func_node, lang_config)

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -6235,8 +6235,13 @@ class CallProcessor:
         # repeated name's members gain one introduction per SIBLING block
         # afterwards; that is exactly where merging makes them visible, and
         # nowhere else.
-        namespace_blocks: dict[str, list[Node]] = {}
-        namespace_name_of: dict[int, str] = {}
+        # Merge groups key on (enclosing container id, name): namespaces
+        # merge only when declared in the SAME parent scope, so `A.N` never
+        # merges with a top-level `N` that shares the leaf name. Node
+        # identity uses tree-sitter's stable `.id` (fresh Python wrappers
+        # over the same tree node compare unequal with `is`).
+        namespace_blocks: dict[tuple[int, str], list[Node]] = {}
+        namespace_group_of: dict[int, tuple[int, str]] = {}
         ns_exported: list[tuple[str, Node | None, Node]] = []
 
         def add(name: str | None, fn_node: Node | None, container: Node | None) -> None:
@@ -6391,8 +6396,9 @@ class CallProcessor:
                     if name_node is not None and (
                         ns_name := safe_decode_text(name_node)
                     ):
-                        namespace_blocks.setdefault(ns_name, []).append(node)
-                        namespace_name_of[id(node)] = ns_name
+                        group = (fn_container.id, ns_name)
+                        namespace_blocks.setdefault(group, []).append(node)
+                        namespace_group_of[node.id] = group
             elif node_type == cs.TS_IMPORT_ALIAS:
                 # `import x = Other.thing` (namespace alias form) binds x;
                 # the aliased path identifiers over-collect, which can only
@@ -6420,14 +6426,14 @@ class CallProcessor:
             for child in node.named_children:
                 stack.append((child, next_container))
         for member_name, fn_node, block in ns_exported:
-            ns_name = namespace_name_of.get(id(block))
-            if ns_name is None:
+            group = namespace_group_of.get(block.id)
+            if group is None:
                 continue
-            blocks = namespace_blocks.get(ns_name, [])
+            blocks = namespace_blocks.get(group, [])
             if len(blocks) < 2:
                 continue
             for sibling in blocks:
-                if sibling is not block:
+                if sibling.id != block.id:
                     add(member_name, fn_node, sibling)
         return bindings
 

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -372,6 +372,22 @@ _JSX_NAMED_ELEMENT_TYPES = frozenset(
 # (scope.onSuccess), so a passed object of callbacks must reference each or
 # every TanStack-style callback reports as dead.
 _INLINE_FUNC_VALUE_TYPES = frozenset({cs.TS_ARROW_FUNCTION, cs.TS_FUNCTION_EXPRESSION})
+# JS/TS scopes that bind their own parameters (and, for a named function
+# expression, their own name) for the lexical receiver resolution of #988.
+_JS_LEXICAL_CALLABLE_SCOPES = frozenset(
+    {
+        cs.TS_ARROW_FUNCTION,
+        cs.TS_FUNCTION_EXPRESSION,
+        cs.TS_FUNCTION_DECLARATION,
+        cs.TS_GENERATOR_FUNCTION,
+        cs.TS_GENERATOR_FUNCTION_DECLARATION,
+        cs.TS_METHOD_DEFINITION,
+    }
+)
+# Declarations hoisted to function/module scope: the LAST same-named one wins.
+_JS_LEXICAL_HOISTED_DECLARATIONS = frozenset(
+    {cs.TS_FUNCTION_DECLARATION, cs.TS_GENERATOR_FUNCTION_DECLARATION}
+)
 # JS/TS function scopes that REBIND `this` per call (a plain function /
 # generator / function expression), as opposed to an arrow_function (inherits
 # `this` lexically) or a method_definition / class-field arrow (binds `this` to
@@ -2615,6 +2631,25 @@ class CallProcessor:
                 self._ingest_inline_call_arg_references(
                     call_node, caller_spec, ensure_rel, caller_qn, module_qn
                 )
+                # `fn.call(this, ...)` / `fn.apply(this, ...)` invokes fn, but
+                # the callee names Function.prototype.call, so the resolve
+                # below fails (or, cast-wrapped, never even names the site)
+                # and a function invoked ONLY this way in statement position
+                # reports dead (issue #988; value positions link through the
+                # bound-callable peel). The receiver is resolved by LEXICAL
+                # BINDING, never by name lookup: only a binding that IS a
+                # function (a hoisted declaration or a declarator holding an
+                # inline function) emits, resolved by its own source span.
+                # Everything else about the site (name resolution, builtin
+                # handling, argument references) proceeds unchanged below.
+                if (
+                    loc := self._js_fn_call_receiver_binding(call_node, module_qn)
+                ) is not None:
+                    ensure_rel(
+                        caller_spec,
+                        calls_rel,
+                        (cs.NodeLabel.FUNCTION, qn_key, loc.qualified_name),
+                    )
             if not call_name:
                 # A callee that is itself a call (`wraps(view_func)(_view_wrapper)`)
                 # or otherwise yields no name still consumes its arguments through
@@ -2755,76 +2790,6 @@ class CallProcessor:
                 is_macro_target = callee_info[1] in self.macro_qns
                 if is_macro_target != (call_node.type == cs.TS_RS_MACRO_INVOCATION):
                     callee_info = None
-            if not callee_info and is_js_ts:
-                # `fn.call(this, ...)` / `fn.apply(this, ...)` on a plain
-                # identifier that resolves to a first-party function is
-                # Function.prototype.call, an invocation of fn. Value positions
-                # already link via the bound-callable peel; a STATEMENT
-                # invocation reached here nameless-in-effect and its target
-                # reported dead (fastify's `multipleBindings.call(this, ...)`
-                # and the plugin-utils trio, issue #988). Only an identifier
-                # receiver qualifies: a member-expression receiver
-                # (`checks[instance].call(...)`, `router.route.call(...)`)
-                # stays ambiguous exactly as PR #983 left it. Bare-name
-                # resolution guesses, so the guess is confined to bindings the
-                # name can actually mean here: never a caller PARAMETER, never
-                # a name the caller REBINDS locally (unless it resolved to that
-                # local function itself), and never outside this module (the
-                # project-wide trie would revive same-named functions in
-                # unrelated files). The edge is emitted directly and the site
-                # is finished: routing through callee_info would map the
-                # callable-param flow onto the RAW argument list, whose
-                # position 0 is the `this` value, binding parameters one slot
-                # off. Real function-valued arguments keep their reachability
-                # through the argument-reference pass instead.
-                receiver, sep, invoke = call_name.rpartition(cs.SEPARATOR_DOT)
-                if (
-                    sep
-                    and invoke in (cs.JS_METHOD_CALL, cs.JS_METHOD_APPLY)
-                    and receiver
-                    and cs.SEPARATOR_DOT not in receiver
-                    and receiver not in caller_params
-                    and (
-                        receiver_info := resolve_func(
-                            receiver,
-                            module_qn,
-                            call_var_types,
-                            class_context,
-                            caller_qn,
-                            language,
-                        )
-                    )
-                    is not None
-                    and receiver_info[0] == cs.NodeLabel.FUNCTION
-                    and receiver_info[1].startswith(f"{module_qn}{cs.SEPARATOR_DOT}")
-                    and (
-                        (
-                            caller_qn is not None
-                            and receiver_info[1].startswith(
-                                f"{caller_qn}{cs.SEPARATOR_DOT}"
-                            )
-                        )
-                        or not self._js_caller_rebinds_name(caller_node, receiver)
-                    )
-                ):
-                    ensure_rel(
-                        caller_spec,
-                        calls_rel,
-                        (receiver_info[0], qn_key, receiver_info[1]),
-                    )
-                    self._ingest_argument_function_references(
-                        call_node,
-                        caller_spec,
-                        module_qn,
-                        local_var_types,
-                        class_context,
-                        resolve_func,
-                        ensure_rel,
-                        caller_qn,
-                        cs.RelationshipType.REFERENCES,
-                        language,
-                    )
-                    continue
             if not callee_info and resolve_builtin is not None:
                 callee_info = resolve_builtin(call_name)
             if not callee_info and resolve_cpp_op is not None:
@@ -6173,33 +6138,144 @@ class CallProcessor:
             return False
         return not (self._get_node_name(node) or self._js_ts_arrow_binding_name(node))
 
+    def _js_fn_call_receiver_binding(
+        self, call_node: Node, module_qn: str
+    ) -> FunctionLocation | None:
+        # For `fn.call(...)` / `fn.apply(...)` (only: `.bind` produces a value
+        # without invoking), peel casts/parens off the receiver and, when it is
+        # a bare identifier, resolve what that identifier DENOTES at this site
+        # by lexical scoping. `.bind`-style member receivers and computed
+        # receivers never qualify.
+        fn_child = call_node.child_by_field_name(cs.TS_FIELD_FUNCTION)
+        if fn_child is None or fn_child.type != cs.TS_MEMBER_EXPRESSION:
+            return None
+        prop = fn_child.child_by_field_name(cs.FIELD_PROPERTY)
+        if prop is None or safe_decode_text(prop) not in (
+            cs.JS_METHOD_CALL,
+            cs.JS_METHOD_APPLY,
+        ):
+            return None
+        obj = fn_child.child_by_field_name(cs.FIELD_OBJECT)
+        if obj is None:
+            return None
+        obj = self._unwrap_ts_value(obj)
+        if obj.type != cs.TS_IDENTIFIER:
+            return None
+        name = safe_decode_text(obj)
+        if not name:
+            return None
+        return self._js_lexical_function_binding(call_node, name, module_qn)
+
+    def _js_lexical_function_binding(
+        self, site: Node, name: str, module_qn: str
+    ) -> FunctionLocation | None:
+        # Walk the enclosing scopes innermost-out; the FIRST scope that binds
+        # `name` decides. A binding that is a function (hoisted declaration,
+        # self-name of a function expression, or a declarator holding an
+        # inline function) resolves by its own source span; any other binding
+        # (parameter, loop/catch/class binding, non-function declarator) means
+        # the runtime value is unknowable and resolution stops with nothing.
+        # An unbound name (a true global or an import) also yields nothing.
+        scope = site.parent
+        while scope is not None:
+            bound, func_node = self._js_scope_binding_for(scope, name)
+            if bound:
+                if func_node is None:
+                    return None
+                return self._recorded_caller(func_node, module_qn)
+            scope = scope.parent
+        return None
+
+    def _js_scope_binding_for(self, scope: Node, name: str) -> tuple[bool, Node | None]:
+        # (bound, function_node): whether this scope introduces `name`, and
+        # the function node it binds when the binding IS a function.
+        if scope.type in _JS_LEXICAL_CALLABLE_SCOPES:
+            name_node = scope.child_by_field_name(cs.FIELD_NAME)
+            if name_node is not None and safe_decode_text(name_node) == name:
+                # A named function expression binds its own name in its body.
+                return True, scope
+            params = scope.child_by_field_name(cs.FIELD_PARAMETERS)
+            if params is not None and self._js_pattern_binds(params, name):
+                return True, None
+            # A single-identifier arrow param (`x => ...`) has no
+            # formal_parameters wrapper.
+            if (
+                scope.type == cs.TS_ARROW_FUNCTION
+                and params is None
+                and (single := scope.child_by_field_name(cs.FIELD_PARAMETER))
+                is not None
+                and safe_decode_text(single) == name
+            ):
+                return True, None
+            return False, None
+        if scope.type in (cs.TS_STATEMENT_BLOCK, cs.TS_PROGRAM):
+            hoisted: Node | None = None
+            for child in scope.named_children:
+                if child.type == cs.TS_EXPORT_STATEMENT:
+                    # `export function f ...` wraps the declaration; the
+                    # binding rules are those of the declaration itself.
+                    wrapped = child.child_by_field_name(cs.FIELD_DECLARATION)
+                    if wrapped is None:
+                        continue
+                    child = wrapped
+                if child.type in _JS_LEXICAL_HOISTED_DECLARATIONS:
+                    child_name = child.child_by_field_name(cs.FIELD_NAME)
+                    if child_name is not None and safe_decode_text(child_name) == name:
+                        # Later declaration wins under hoisting.
+                        hoisted = child
+                elif child.type in (
+                    cs.TS_LEXICAL_DECLARATION,
+                    cs.TS_VARIABLE_DECLARATION,
+                ):
+                    for declarator in child.named_children:
+                        if declarator.type != cs.TS_VARIABLE_DECLARATOR:
+                            continue
+                        target = declarator.child_by_field_name(cs.FIELD_NAME)
+                        if target is None or not self._js_pattern_binds(target, name):
+                            continue
+                        value = declarator.child_by_field_name(cs.FIELD_VALUE)
+                        if value is not None:
+                            value = self._unwrap_ts_value(value)
+                            if value.type in _INLINE_FUNC_VALUE_TYPES:
+                                return True, value
+                        return True, None
+                elif child.type == cs.TS_CLASS_DECLARATION:
+                    child_name = child.child_by_field_name(cs.FIELD_NAME)
+                    if child_name is not None and safe_decode_text(child_name) == name:
+                        return True, None
+            if hoisted is not None:
+                return True, hoisted
+            return False, None
+        if scope.type == cs.TS_JS_FOR_IN_STATEMENT:
+            left = scope.child_by_field_name(cs.FIELD_LEFT)
+            if left is not None and self._js_pattern_binds(left, name):
+                return True, None
+            return False, None
+        if scope.type == cs.TS_JS_CATCH_CLAUSE:
+            param = scope.child_by_field_name(cs.FIELD_PARAMETER)
+            if param is not None and self._js_pattern_binds(param, name):
+                return True, None
+            return False, None
+        return False, None
+
     @staticmethod
-    def _js_caller_rebinds_name(caller_node: Node, name: str) -> bool:
-        # True when any variable declarator anywhere in the caller's body binds
-        # `name`, meaning a bare `name` inside the caller may denote that local
-        # value rather than the same-named module-level function a scope-walk
-        # resolution would return (`const emitter = handlers.build();
-        # emitter.call(1)` must not bind a module function named emitter).
-        # Destructuring patterns count via the identifier scan of the whole
-        # `name` field. Over-approximate on purpose: a declarator in a nested
-        # inner scope also suppresses, trading a conservative miss for never
-        # emitting a cross-binding false edge.
-        stack = list(caller_node.children)
+    def _js_pattern_binds(pattern: Node, name: str) -> bool:
+        # Whether a binding pattern subtree (params, destructuring target,
+        # loop/catch binding) introduces `name`. Identifiers inside DEFAULT
+        # VALUES over-match; that only suppresses an edge, never invents one.
+        stack = [pattern]
         while stack:
-            node = stack.pop()
-            if node.type == cs.TS_VARIABLE_DECLARATOR:
-                target = node.child_by_field_name(cs.FIELD_NAME)
-                if target is not None:
-                    inner = [target]
-                    while inner:
-                        part = inner.pop()
-                        if (
-                            part.type == cs.TS_IDENTIFIER
-                            and safe_decode_text(part) == name
-                        ):
-                            return True
-                        inner.extend(part.named_children)
-            stack.extend(node.children)
+            part = stack.pop()
+            if (
+                part.type
+                in (
+                    cs.TS_IDENTIFIER,
+                    cs.TS_SHORTHAND_PROPERTY_IDENTIFIER_PATTERN,
+                )
+                and safe_decode_text(part) == name
+            ):
+                return True
+            stack.extend(part.named_children)
         return False
 
     def _is_method(self, func_node: Node, lang_config: LanguageSpec) -> bool:

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -384,10 +384,13 @@ _JS_LEXICAL_CALLABLE_SCOPES = frozenset(
         cs.TS_METHOD_DEFINITION,
     }
 )
-# Declarations hoisted to function/module scope: the LAST same-named one wins.
+# Declarations hoisted to function/module scope.
 _JS_LEXICAL_HOISTED_DECLARATIONS = frozenset(
     {cs.TS_FUNCTION_DECLARATION, cs.TS_GENERATOR_FUNCTION_DECLARATION}
 )
+# Inline values that ARE callables when held by a declarator; generators
+# included (a `const gen = function* () {...}` receiver is invocable).
+_JS_INLINE_CALLABLE_VALUE_TYPES = _INLINE_FUNC_VALUE_TYPES | {cs.TS_GENERATOR_FUNCTION}
 # JS/TS function scopes that REBIND `this` per call (a plain function /
 # generator / function expression), as opposed to an arrow_function (inherits
 # `this` lexically) or a method_definition / class-field arrow (binds `this` to
@@ -596,6 +599,7 @@ class CallProcessor:
         "_flow_processor",
         "_rpc_exposure",
         "_dispatch_registry",
+        "_js_file_receiver_bindings",
     )
 
     def __init__(
@@ -631,6 +635,12 @@ class CallProcessor:
         self.cpp_out_of_class_methods = cpp_out_of_class_methods or {}
         self.function_locations = function_locations or {}
         self.macro_qns = macro_qns if macro_qns is not None else set()
+        # Per-module map of identifier -> (binding count, function node,
+        # container) for the #988 lexical receiver resolution; built once per
+        # file on first use.
+        self._js_file_receiver_bindings: dict[
+            str, dict[str, tuple[int, Node | None, Node | None]]
+        ] = {}
 
         self._resolver = CallResolver(
             function_registry=function_registry,
@@ -6169,192 +6179,156 @@ class CallProcessor:
     def _js_lexical_function_binding(
         self, site: Node, name: str, module_qn: str
     ) -> FunctionLocation | None:
-        # Walk the enclosing scopes innermost-out; the FIRST scope that binds
-        # `name` decides. A binding that is a function (hoisted declaration,
-        # self-name of a function expression, or a declarator holding an
-        # inline function) resolves by its own source span; any other binding
-        # (parameter, loop/catch/class binding, non-function declarator) means
-        # the runtime value is unknowable and resolution stops with nothing.
-        # An unbound name (a true global or an import) also yields nothing.
-        scope = site.parent
-        while scope is not None:
-            bound, func_node = self._js_scope_binding_for(scope, name)
-            if bound:
-                if func_node is None:
-                    return None
-                return self._recorded_caller(func_node, module_qn)
-            scope = scope.parent
-        return None
+        # UNIQUE-BINDING resolution: the receiver name resolves only when the
+        # WHOLE FILE introduces it exactly once, that introduction IS a
+        # function (a hoisted declaration, a declarator holding an inline
+        # function, or a function expression's self-name), and the binding's
+        # container span encloses the site. Any second introduction anywhere
+        # (a parameter, another declarator, a loop/catch/class/import binding,
+        # even a plain reassignment) makes the runtime value unknowable and
+        # suppresses. This deliberately trades conservative misses for never
+        # inventing an edge: shadowing, `var` hoisting across sibling blocks,
+        # switch/for/catch scoping and duplicate declarations all collapse
+        # into "more than one introduction", with no scope simulation at all.
+        root = site
+        while root.parent is not None:
+            root = root.parent
+        bindings = self._js_file_receiver_bindings.get(module_qn)
+        if bindings is None:
+            bindings = self._js_collect_file_bindings(root)
+            self._js_file_receiver_bindings[module_qn] = bindings
+        entry = bindings.get(name)
+        if entry is None:
+            return None
+        count, fn_node, container = entry
+        if count != 1 or fn_node is None or container is None:
+            return None
+        if not (container.start_byte <= site.start_byte < container.end_byte):
+            return None
+        return self._recorded_caller(fn_node, module_qn)
 
-    def _js_scope_binding_for(self, scope: Node, name: str) -> tuple[bool, Node | None]:
-        # (bound, function_node): whether this scope introduces `name`, and
-        # the function node it binds when the binding IS a function.
-        if scope.type in _JS_LEXICAL_CALLABLE_SCOPES:
-            # Parameters shadow everything else in the body, including a
-            # function expression's own name.
-            params = scope.child_by_field_name(cs.FIELD_PARAMETERS)
-            if params is not None and self._js_pattern_binds(params, name):
-                return True, None
-            # A single-identifier arrow param (`x => ...`) has no
-            # formal_parameters wrapper.
-            if (
-                scope.type == cs.TS_ARROW_FUNCTION
-                and params is None
-                and (single := scope.child_by_field_name(cs.FIELD_PARAMETER))
-                is not None
-                and safe_decode_text(single) == name
-            ):
-                return True, None
-            # Only a named function/generator EXPRESSION binds its own name in
-            # its body; a declaration binds in the ENCLOSING scope (found by
-            # the hoisted scan there), and a METHOD name never binds at all.
-            if scope.type in (cs.TS_FUNCTION_EXPRESSION, cs.TS_GENERATOR_FUNCTION):
-                name_node = scope.child_by_field_name(cs.FIELD_NAME)
-                if name_node is not None and safe_decode_text(name_node) == name:
-                    return True, scope
-            # `var` hoists to function scope no matter which block wrote it.
-            return self._js_var_hoisted_binding(
-                scope.child_by_field_name(cs.FIELD_BODY), name
-            )
-        if scope.type in (cs.TS_STATEMENT_BLOCK, cs.TS_PROGRAM, cs.TS_JS_SWITCH_BODY):
-            decided = self._js_block_binding(scope, name)
-            if decided is not None:
-                return decided
-            if scope.type == cs.TS_PROGRAM:
-                # Module scope is also the top-level `var` hoist target.
-                return self._js_var_hoisted_binding(scope, name)
-            return False, None
-        if scope.type == cs.TS_JS_FOR_STATEMENT:
-            # The C-style loop's init clause scopes its bindings to the loop.
-            init = scope.child_by_field_name(cs.FIELD_INITIALIZER)
-            if init is not None and init.type in (
-                cs.TS_LEXICAL_DECLARATION,
-                cs.TS_VARIABLE_DECLARATION,
-            ):
-                decided = self._js_declaration_binding(init, name)
-                if decided is not None:
-                    return decided
-            return False, None
-        if scope.type == cs.TS_JS_FOR_IN_STATEMENT:
-            left = scope.child_by_field_name(cs.FIELD_LEFT)
-            if left is not None and self._js_pattern_binds(left, name):
-                return True, None
-            return False, None
-        if scope.type == cs.TS_JS_CATCH_CLAUSE:
-            param = scope.child_by_field_name(cs.FIELD_PARAMETER)
-            if param is not None and self._js_pattern_binds(param, name):
-                return True, None
-            return False, None
-        return False, None
+    def _js_collect_file_bindings(
+        self, root: Node
+    ) -> dict[str, tuple[int, Node | None, Node | None]]:
+        # One pass over the file: name -> (introduction count, function node
+        # when the single introduction is a function, container node whose
+        # span bounds where the binding is usable). Introductions are
+        # OVER-collected on purpose (destructuring defaults, import aliases,
+        # bare assignment targets): each extra count can only suppress.
+        bindings: dict[str, tuple[int, Node | None, Node | None]] = {}
 
-    def _js_block_binding(
-        self, scope: Node, name: str
-    ) -> tuple[bool, Node | None] | None:
-        # Scan a block-like scope's own declarations; None means the scope
-        # does not bind `name` and the walk continues outward. A switch body
-        # is one shared scope whose declarations sit inside its case clauses.
-        children: list[Node] = []
-        for child in scope.named_children:
-            if child.type in (cs.TS_JS_SWITCH_CASE, cs.TS_JS_SWITCH_DEFAULT):
-                children.extend(child.named_children)
+        def add(name: str | None, fn_node: Node | None, container: Node | None) -> None:
+            if not name:
+                return
+            prior = bindings.get(name)
+            if prior is None:
+                bindings[name] = (1, fn_node, container)
             else:
-                children.append(child)
-        hoisted: Node | None = None
-        for child in children:
-            if child.type == cs.TS_EXPORT_STATEMENT:
-                # `export function f ...` wraps the declaration; the binding
-                # rules are those of the declaration itself.
-                wrapped = child.child_by_field_name(cs.FIELD_DECLARATION)
-                if wrapped is None:
-                    continue
-                child = wrapped
-            if child.type in _JS_LEXICAL_HOISTED_DECLARATIONS:
-                child_name = child.child_by_field_name(cs.FIELD_NAME)
-                if child_name is not None and safe_decode_text(child_name) == name:
-                    # Later declaration wins under hoisting.
-                    hoisted = child
-            elif child.type in (
-                cs.TS_LEXICAL_DECLARATION,
-                cs.TS_VARIABLE_DECLARATION,
-            ):
-                decided = self._js_declaration_binding(child, name)
-                if decided is not None:
-                    return decided
-            elif child.type == cs.TS_CLASS_DECLARATION:
-                child_name = child.child_by_field_name(cs.FIELD_NAME)
-                if child_name is not None and safe_decode_text(child_name) == name:
-                    return True, None
-        if hoisted is not None:
-            return True, hoisted
-        return None
+                bindings[name] = (prior[0] + 1, None, None)
 
-    def _js_declaration_binding(
-        self, declaration: Node, name: str
-    ) -> tuple[bool, Node | None] | None:
-        for declarator in declaration.named_children:
-            if declarator.type != cs.TS_VARIABLE_DECLARATOR:
-                continue
-            target = declarator.child_by_field_name(cs.FIELD_NAME)
-            if target is None or not self._js_pattern_binds(target, name):
-                continue
-            value = declarator.child_by_field_name(cs.FIELD_VALUE)
-            if value is not None:
-                value = self._unwrap_ts_value(value)
-                if value.type in _INLINE_FUNC_VALUE_TYPES:
-                    return True, value
-            return True, None
-        return None
-
-    def _js_var_hoisted_binding(
-        self, body: Node | None, name: str
-    ) -> tuple[bool, Node | None]:
-        # `var` declarators anywhere in this function's body (nested callables
-        # and class bodies excluded: their vars are their own) bind `name` at
-        # function scope. A single var holding an inline function resolves to
-        # it; multiple same-named vars or a non-function value are unknowable.
-        if body is None:
-            return False, None
-        found: Node | None = None
-        count = 0
-        stack = list(body.named_children)
-        while stack:
-            node = stack.pop()
-            if (
-                node.type in _JS_LEXICAL_CALLABLE_SCOPES
-                or node.type == cs.TS_CLASS_BODY
-            ):
-                continue
-            if node.type == cs.TS_VARIABLE_DECLARATION:
-                decided = self._js_declaration_binding(node, name)
-                if decided is not None:
-                    count += 1
-                    found = decided[1]
-            stack.extend(node.named_children)
-        if count == 0:
-            return False, None
-        if count == 1:
-            return True, found
-        return True, None
-
-    @staticmethod
-    def _js_pattern_binds(pattern: Node, name: str) -> bool:
-        # Whether a binding pattern subtree (params, destructuring target,
-        # loop/catch binding) introduces `name`. Identifiers inside DEFAULT
-        # VALUES over-match; that only suppresses an edge, never invents one.
-        stack = [pattern]
-        while stack:
-            part = stack.pop()
-            if (
-                part.type
-                in (
+        def add_pattern(pattern: Node) -> None:
+            stack = [pattern]
+            while stack:
+                part = stack.pop()
+                if part.type in (
                     cs.TS_IDENTIFIER,
                     cs.TS_SHORTHAND_PROPERTY_IDENTIFIER_PATTERN,
+                ):
+                    add(safe_decode_text(part), None, None)
+                stack.extend(part.named_children)
+
+        stack: list[tuple[Node, Node]] = [(root, root)]
+        while stack:
+            node, fn_container = stack.pop()
+            node_type = node.type
+            next_container = fn_container
+            if node_type in _JS_LEXICAL_CALLABLE_SCOPES:
+                params = node.child_by_field_name(cs.FIELD_PARAMETERS)
+                if params is not None:
+                    add_pattern(params)
+                elif (
+                    single := node.child_by_field_name(cs.FIELD_PARAMETER)
+                ) is not None:
+                    add_pattern(single)
+                if node_type in (cs.TS_FUNCTION_EXPRESSION, cs.TS_GENERATOR_FUNCTION):
+                    # A named function expression binds its own name in its
+                    # body only.
+                    name_node = node.child_by_field_name(cs.FIELD_NAME)
+                    if name_node is not None:
+                        add(safe_decode_text(name_node), node, node)
+                elif node_type in _JS_LEXICAL_HOISTED_DECLARATIONS:
+                    name_node = node.child_by_field_name(cs.FIELD_NAME)
+                    container: Node | None = node.parent
+                    if (
+                        container is not None
+                        and container.type == cs.TS_EXPORT_STATEMENT
+                    ):
+                        container = container.parent
+                    if name_node is not None:
+                        add(safe_decode_text(name_node), node, container)
+                # A method_definition name is a property, never a binding.
+                next_container = node.child_by_field_name(cs.FIELD_BODY) or node
+            elif node_type == cs.TS_VARIABLE_DECLARATOR:
+                target = node.child_by_field_name(cs.FIELD_NAME)
+                if target is not None:
+                    if target.type == cs.TS_IDENTIFIER:
+                        value = node.child_by_field_name(cs.FIELD_VALUE)
+                        fn_value: Node | None = None
+                        if value is not None:
+                            value = self._unwrap_ts_value(value)
+                            if value.type in _JS_INLINE_CALLABLE_VALUE_TYPES:
+                                fn_value = value
+                        declaration = node.parent
+                        # `var` (variable_declaration) hoists to the enclosing
+                        # function; `let`/`const` scope to their declaration's
+                        # parent block.
+                        if (
+                            declaration is not None
+                            and declaration.type == cs.TS_LEXICAL_DECLARATION
+                            and declaration.parent is not None
+                        ):
+                            container = declaration.parent
+                        else:
+                            container = fn_container
+                        add(safe_decode_text(target), fn_value, container)
+                    else:
+                        add_pattern(target)
+            elif node_type == cs.TS_JS_FOR_IN_STATEMENT:
+                # Covers for-of and for-in, with or without var/let/const:
+                # the left side binds (or rebinds) its identifiers.
+                left = node.child_by_field_name(cs.FIELD_LEFT)
+                if left is not None:
+                    add_pattern(left)
+            elif node_type == cs.TS_JS_CATCH_CLAUSE:
+                param = node.child_by_field_name(cs.FIELD_PARAMETER)
+                if param is not None:
+                    add_pattern(param)
+            elif node_type in (cs.TS_CLASS_DECLARATION, cs.TS_CLASS_EXPRESSION):
+                name_node = node.child_by_field_name(cs.FIELD_NAME)
+                if name_node is not None:
+                    add(safe_decode_text(name_node), None, None)
+            elif node_type == cs.TS_IMPORT_STATEMENT:
+                clause = next(
+                    (
+                        child
+                        for child in node.named_children
+                        if child.type == cs.TS_IMPORT_CLAUSE
+                    ),
+                    None,
                 )
-                and safe_decode_text(part) == name
+                if clause is not None:
+                    add_pattern(clause)
+            elif node_type in (
+                cs.TS_JS_ASSIGNMENT_EXPRESSION,
+                cs.TS_JS_AUGMENTED_ASSIGNMENT_EXPRESSION,
             ):
-                return True
-            stack.extend(part.named_children)
-        return False
+                # A bare reassignment rebinds the name to an arbitrary value.
+                left = node.child_by_field_name(cs.FIELD_LEFT)
+                if left is not None and left.type == cs.TS_IDENTIFIER:
+                    add(safe_decode_text(left), None, None)
+            for child in node.named_children:
+                stack.append((child, next_container))
+        return bindings
 
     def _is_method(self, func_node: Node, lang_config: LanguageSpec) -> bool:
         return is_method_node(func_node, lang_config)

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1365,6 +1365,7 @@ class CallProcessor:
         relative_path = cached_relative_path(file_path, self.repo_path)
         logger.debug(ls.CALL_PROCESSING_FILE, path=relative_path)
 
+        module_qn: str | None = None
         try:
             module_qn = self._module_qn(file_path, relative_path)
 
@@ -1607,6 +1608,13 @@ class CallProcessor:
 
         except Exception as e:
             logger.error(ls.CALL_PROCESSING_FAILED, path=file_path, error=e)
+        finally:
+            # The receiver binding index is only ever consulted by sites in
+            # the SAME file; evicting here (errors and early returns
+            # included) keeps the map from retaining one parse tree per
+            # JS/TS module for the rest of the pass.
+            if module_qn is not None:
+                self._js_file_receiver_bindings.pop(module_qn, None)
 
     def _process_calls_in_functions(
         self,

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -6235,11 +6235,12 @@ class CallProcessor:
         # repeated name's members gain one introduction per SIBLING block
         # afterwards; that is exactly where merging makes them visible, and
         # nowhere else.
-        # Merge groups key on (enclosing container id, name): namespaces
-        # merge only when declared in the SAME parent scope, so `A.N` never
-        # merges with a top-level `N` that shares the leaf name. Node
-        # identity uses tree-sitter's stable `.id` (fresh Python wrappers
-        # over the same tree node compare unequal with `is`).
+        # Merge groups key on (nearest NON-namespace container id, dotted
+        # namespace path): `A { N }` in either A block and `A.N` at top
+        # level all key to (program, "A.N") and merge, while a top-level `N`
+        # keys to (program, "N") and stays distinct. Node identity uses
+        # tree-sitter's stable `.id` (fresh Python wrappers over the same
+        # tree node compare unequal with `is`).
         namespace_blocks: dict[tuple[int, str], list[Node]] = {}
         namespace_group_of: dict[int, tuple[int, str]] = {}
         ns_exported: list[tuple[str, Node | None, Node]] = []
@@ -6292,11 +6293,15 @@ class CallProcessor:
                 return parent.parent
             return parent
 
-        stack: list[tuple[Node, Node]] = [(root, root)]
+        stack: list[tuple[Node, Node, int, tuple[str, ...]]] = [
+            (root, root, root.id, ())
+        ]
         while stack:
-            node, fn_container = stack.pop()
+            node, fn_container, ns_anchor, ns_path = stack.pop()
             node_type = node.type
             next_container = fn_container
+            next_ns_anchor = ns_anchor
+            next_ns_path = ns_path
             if node_type in _JS_LEXICAL_CALLABLE_SCOPES:
                 params = node.child_by_field_name(cs.FIELD_PARAMETERS)
                 if params is not None:
@@ -6333,9 +6338,13 @@ class CallProcessor:
                             ns_exported.append((decl_name, node, fn_container))
                 # A method_definition name is a property, never a binding.
                 next_container = node.child_by_field_name(cs.FIELD_BODY) or node
+                next_ns_anchor = next_container.id
+                next_ns_path = ()
             elif node_type == cs.TS_CLASS_STATIC_BLOCK:
                 # A static block is its own `var` scope.
                 next_container = node
+                next_ns_anchor = node.id
+                next_ns_path = ()
             elif node_type == cs.TS_JS_WITH_STATEMENT:
                 # Dynamic scoping: no receiver in this file can be trusted.
                 return {}
@@ -6396,7 +6405,8 @@ class CallProcessor:
                     if name_node is not None and (
                         ns_name := safe_decode_text(name_node)
                     ):
-                        group = (fn_container.id, ns_name)
+                        next_ns_path = ns_path + tuple(ns_name.split(cs.SEPARATOR_DOT))
+                        group = (ns_anchor, cs.SEPARATOR_DOT.join(next_ns_path))
                         namespace_blocks.setdefault(group, []).append(node)
                         namespace_group_of[node.id] = group
             elif node_type == cs.TS_IMPORT_ALIAS:
@@ -6424,7 +6434,7 @@ class CallProcessor:
                     elif left.type in (cs.TS_OBJECT_PATTERN, cs.TS_ARRAY_PATTERN):
                         add_pattern(left, None)
             for child in node.named_children:
-                stack.append((child, next_container))
+                stack.append((child, next_container, next_ns_anchor, next_ns_path))
         for member_name, fn_node, block in ns_exported:
             group = namespace_group_of.get(block.id)
             if group is None:

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -6148,6 +6148,11 @@ class CallProcessor:
             return False
         return not (self._get_node_name(node) or self._js_ts_arrow_binding_name(node))
 
+    def reset_js_receiver_bindings(self) -> None:
+        # Drop the per-file receiver-binding index; a reused updater's next
+        # pass re-parses files and must rebuild it from the fresh trees.
+        self._js_file_receiver_bindings.clear()
+
     def _js_fn_call_receiver_binding(
         self, call_node: Node, module_qn: str
     ) -> FunctionLocation | None:
@@ -6239,6 +6244,14 @@ class CallProcessor:
                     left = part.child_by_field_name(cs.FIELD_LEFT)
                     if left is not None:
                         stack.append(left)
+                    continue
+                if part.type in (cs.TS_REQUIRED_PARAMETER, cs.TS_OPTIONAL_PARAMETER):
+                    # The TS grammar hangs a default straight off the
+                    # parameter (no assignment_pattern wrapper); only the
+                    # pattern field introduces names.
+                    ts_pattern = part.child_by_field_name(cs.TS_FIELD_PATTERN)
+                    if ts_pattern is not None:
+                        stack.append(ts_pattern)
                     continue
                 if part.type == cs.TS_TYPE_ANNOTATION:
                     continue
@@ -6338,10 +6351,20 @@ class CallProcessor:
                 cs.TS_MODULE,
             ):
                 # Classes, TS enums and namespaces all bind VALUE names (an
-                # enum compiles to a var, a namespace to an object).
+                # enum compiles to a var, a namespace to an object). A
+                # namespace/module body is additionally its own scope: its
+                # members are invisible outside it.
                 name_node = node.child_by_field_name(cs.FIELD_NAME)
                 if name_node is not None:
                     add(safe_decode_text(name_node), None, None)
+                if node_type in (cs.TS_INTERNAL_MODULE, cs.TS_MODULE):
+                    next_container = node
+            elif node_type == cs.TS_IMPORT_ALIAS:
+                # `import x = Other.thing` (namespace alias form) binds x;
+                # the aliased path identifiers over-collect, which can only
+                # suppress.
+                add_pattern(node, None)
+                continue
             elif node_type == cs.TS_IMPORT_STATEMENT:
                 # Covers default/named/namespace clauses AND the TS
                 # `import x = require(...)` form: every identifier in the

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -635,11 +635,11 @@ class CallProcessor:
         self.cpp_out_of_class_methods = cpp_out_of_class_methods or {}
         self.function_locations = function_locations or {}
         self.macro_qns = macro_qns if macro_qns is not None else set()
-        # Per-module map of identifier -> (binding count, function node,
+        # Per-module map of identifier -> introductions as (function node,
         # container) for the #988 lexical receiver resolution; built once per
         # file on first use.
         self._js_file_receiver_bindings: dict[
-            str, dict[str, tuple[int, Node | None, Node | None]]
+            str, dict[str, list[tuple[Node | None, Node | None]]]
         ] = {}
 
         self._resolver = CallResolver(
@@ -6179,17 +6179,18 @@ class CallProcessor:
     def _js_lexical_function_binding(
         self, site: Node, name: str, module_qn: str
     ) -> FunctionLocation | None:
-        # UNIQUE-BINDING resolution: the receiver name resolves only when the
-        # WHOLE FILE introduces it exactly once, that introduction IS a
-        # function (a hoisted declaration, a declarator holding an inline
-        # function, or a function expression's self-name), and the binding's
-        # container span encloses the site. Any second introduction anywhere
-        # (a parameter, another declarator, a loop/catch/class/import binding,
-        # even a plain reassignment) makes the runtime value unknowable and
-        # suppresses. This deliberately trades conservative misses for never
-        # inventing an edge: shadowing, `var` hoisting across sibling blocks,
-        # switch/for/catch scoping and duplicate declarations all collapse
-        # into "more than one introduction", with no scope simulation at all.
+        # UNIQUE-RELEVANT-BINDING resolution: collect every INTRODUCTION of
+        # every name in the file once (cached), each with the container whose
+        # span bounds where it is usable, then keep only the introductions
+        # whose container encloses THIS site (a file-wide container always
+        # qualifies). The receiver resolves only when exactly ONE relevant
+        # introduction remains and it IS a function registered by the
+        # definition pass; two or more relevant introductions, or a
+        # non-function one, mean the runtime value is unknowable and nothing
+        # is emitted. Shadowing, `var` hoisting, switch/for/catch scoping and
+        # duplicate declarations all collapse into "a second relevant
+        # introduction", with no scope simulation; an introduction confined
+        # to a SIBLING scope is irrelevant here and cannot suppress.
         root = site
         while root.parent is not None:
             root = root.parent
@@ -6197,45 +6198,72 @@ class CallProcessor:
         if bindings is None:
             bindings = self._js_collect_file_bindings(root)
             self._js_file_receiver_bindings[module_qn] = bindings
-        entry = bindings.get(name)
-        if entry is None:
+        entries = bindings.get(name)
+        if not entries:
             return None
-        count, fn_node, container = entry
-        if count != 1 or fn_node is None or container is None:
+        relevant = [
+            (fn_node, container)
+            for fn_node, container in entries
+            if container is None
+            or container.start_byte <= site.start_byte < container.end_byte
+        ]
+        if len(relevant) != 1:
             return None
-        if not (container.start_byte <= site.start_byte < container.end_byte):
+        fn_node, _container = relevant[0]
+        if fn_node is None:
             return None
         return self._recorded_caller(fn_node, module_qn)
 
     def _js_collect_file_bindings(
         self, root: Node
-    ) -> dict[str, tuple[int, Node | None, Node | None]]:
-        # One pass over the file: name -> (introduction count, function node
-        # when the single introduction is a function, container node whose
-        # span bounds where the binding is usable). Introductions are
-        # OVER-collected on purpose (destructuring defaults, import aliases,
-        # bare assignment targets): each extra count can only suppress.
-        bindings: dict[str, tuple[int, Node | None, Node | None]] = {}
+    ) -> dict[str, list[tuple[Node | None, Node | None]]]:
+        # One pass over the file: name -> introductions as (function node or
+        # None, container node or None for file-wide). Non-function
+        # introductions are OVER-collected on purpose (destructuring,
+        # import aliases, reassignment targets): each can only suppress. A
+        # `with` block makes every name dynamic, so the whole file returns
+        # empty and nothing ever resolves.
+        bindings: dict[str, list[tuple[Node | None, Node | None]]] = {}
 
         def add(name: str | None, fn_node: Node | None, container: Node | None) -> None:
-            if not name:
-                return
-            prior = bindings.get(name)
-            if prior is None:
-                bindings[name] = (1, fn_node, container)
-            else:
-                bindings[name] = (prior[0] + 1, None, None)
+            if name:
+                bindings.setdefault(name, []).append((fn_node, container))
 
-        def add_pattern(pattern: Node) -> None:
+        def add_pattern(pattern: Node, container: Node | None) -> None:
+            # Binding-side only: a default value (assignment_pattern right)
+            # or a TS type annotation READS names, it does not introduce them.
             stack = [pattern]
             while stack:
                 part = stack.pop()
+                if part.type == cs.TS_ASSIGNMENT_PATTERN:
+                    left = part.child_by_field_name(cs.FIELD_LEFT)
+                    if left is not None:
+                        stack.append(left)
+                    continue
+                if part.type == cs.TS_TYPE_ANNOTATION:
+                    continue
                 if part.type in (
                     cs.TS_IDENTIFIER,
                     cs.TS_SHORTHAND_PROPERTY_IDENTIFIER_PATTERN,
                 ):
-                    add(safe_decode_text(part), None, None)
+                    add(safe_decode_text(part), None, container)
                 stack.extend(part.named_children)
+
+        def declarator_container(declaration: Node, fn_container: Node) -> Node | None:
+            # `var` hoists to the enclosing callable body; `let`/`const`
+            # scope to the declaration's parent, peeling an export_statement
+            # wrapper and widening a switch-case slot to the shared switch
+            # body.
+            if declaration.type != cs.TS_LEXICAL_DECLARATION:
+                return fn_container
+            parent = declaration.parent
+            if parent is None:
+                return fn_container
+            if parent.type == cs.TS_EXPORT_STATEMENT:
+                return parent.parent
+            if parent.type in (cs.TS_JS_SWITCH_CASE, cs.TS_JS_SWITCH_DEFAULT):
+                return parent.parent
+            return parent
 
         stack: list[tuple[Node, Node]] = [(root, root)]
         while stack:
@@ -6245,11 +6273,11 @@ class CallProcessor:
             if node_type in _JS_LEXICAL_CALLABLE_SCOPES:
                 params = node.child_by_field_name(cs.FIELD_PARAMETERS)
                 if params is not None:
-                    add_pattern(params)
+                    add_pattern(params, node)
                 elif (
                     single := node.child_by_field_name(cs.FIELD_PARAMETER)
                 ) is not None:
-                    add_pattern(single)
+                    add_pattern(single, node)
                 if node_type in (cs.TS_FUNCTION_EXPRESSION, cs.TS_GENERATOR_FUNCTION):
                     # A named function expression binds its own name in its
                     # body only.
@@ -6268,9 +6296,17 @@ class CallProcessor:
                         add(safe_decode_text(name_node), node, container)
                 # A method_definition name is a property, never a binding.
                 next_container = node.child_by_field_name(cs.FIELD_BODY) or node
+            elif node_type == cs.TS_CLASS_STATIC_BLOCK:
+                # A static block is its own `var` scope.
+                next_container = node
+            elif node_type == cs.TS_JS_WITH_STATEMENT:
+                # Dynamic scoping: no receiver in this file can be trusted.
+                return {}
             elif node_type == cs.TS_VARIABLE_DECLARATOR:
                 target = node.child_by_field_name(cs.FIELD_NAME)
-                if target is not None:
+                declaration = node.parent
+                if target is not None and declaration is not None:
+                    container = declarator_container(declaration, fn_container)
                     if target.type == cs.TS_IDENTIFIER:
                         value = node.child_by_field_name(cs.FIELD_VALUE)
                         fn_value: Node | None = None
@@ -6278,31 +6314,21 @@ class CallProcessor:
                             value = self._unwrap_ts_value(value)
                             if value.type in _JS_INLINE_CALLABLE_VALUE_TYPES:
                                 fn_value = value
-                        declaration = node.parent
-                        # `var` (variable_declaration) hoists to the enclosing
-                        # function; `let`/`const` scope to their declaration's
-                        # parent block.
-                        if (
-                            declaration is not None
-                            and declaration.type == cs.TS_LEXICAL_DECLARATION
-                            and declaration.parent is not None
-                        ):
-                            container = declaration.parent
-                        else:
-                            container = fn_container
                         add(safe_decode_text(target), fn_value, container)
                     else:
-                        add_pattern(target)
+                        add_pattern(target, container)
             elif node_type == cs.TS_JS_FOR_IN_STATEMENT:
                 # Covers for-of and for-in, with or without var/let/const:
-                # the left side binds (or rebinds) its identifiers.
+                # the left side binds (or rebinds) its identifiers. The
+                # enclosing callable body over-approximates the lexical
+                # variants' scope, which can only suppress.
                 left = node.child_by_field_name(cs.FIELD_LEFT)
                 if left is not None:
-                    add_pattern(left)
+                    add_pattern(left, fn_container)
             elif node_type == cs.TS_JS_CATCH_CLAUSE:
                 param = node.child_by_field_name(cs.FIELD_PARAMETER)
                 if param is not None:
-                    add_pattern(param)
+                    add_pattern(param, node)
             elif node_type in (cs.TS_CLASS_DECLARATION, cs.TS_CLASS_EXPRESSION):
                 name_node = node.child_by_field_name(cs.FIELD_NAME)
                 if name_node is not None:
@@ -6317,15 +6343,19 @@ class CallProcessor:
                     None,
                 )
                 if clause is not None:
-                    add_pattern(clause)
+                    add_pattern(clause, None)
             elif node_type in (
                 cs.TS_JS_ASSIGNMENT_EXPRESSION,
                 cs.TS_JS_AUGMENTED_ASSIGNMENT_EXPRESSION,
             ):
-                # A bare reassignment rebinds the name to an arbitrary value.
+                # A reassignment rebinds a name declared SOMEWHERE to an
+                # arbitrary value; file-wide relevance is the safe reading.
                 left = node.child_by_field_name(cs.FIELD_LEFT)
-                if left is not None and left.type == cs.TS_IDENTIFIER:
-                    add(safe_decode_text(left), None, None)
+                if left is not None:
+                    if left.type == cs.TS_IDENTIFIER:
+                        add(safe_decode_text(left), None, None)
+                    elif left.type in (cs.TS_OBJECT_PATTERN, cs.TS_ARRAY_PATTERN):
+                        add_pattern(left, None)
             for child in node.named_children:
                 stack.append((child, next_container))
         return bindings

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -2648,7 +2648,7 @@ class CallProcessor:
                     ensure_rel(
                         caller_spec,
                         calls_rel,
-                        (cs.NodeLabel.FUNCTION, qn_key, loc.qualified_name),
+                        (loc.label, qn_key, loc.qualified_name),
                     )
             if not call_name:
                 # A callee that is itself a call (`wraps(view_func)(_view_wrapper)`)
@@ -6190,10 +6190,8 @@ class CallProcessor:
         # (bound, function_node): whether this scope introduces `name`, and
         # the function node it binds when the binding IS a function.
         if scope.type in _JS_LEXICAL_CALLABLE_SCOPES:
-            name_node = scope.child_by_field_name(cs.FIELD_NAME)
-            if name_node is not None and safe_decode_text(name_node) == name:
-                # A named function expression binds its own name in its body.
-                return True, scope
+            # Parameters shadow everything else in the body, including a
+            # function expression's own name.
             params = scope.child_by_field_name(cs.FIELD_PARAMETERS)
             if params is not None and self._js_pattern_binds(params, name):
                 return True, None
@@ -6207,44 +6205,35 @@ class CallProcessor:
                 and safe_decode_text(single) == name
             ):
                 return True, None
+            # Only a named function/generator EXPRESSION binds its own name in
+            # its body; a declaration binds in the ENCLOSING scope (found by
+            # the hoisted scan there), and a METHOD name never binds at all.
+            if scope.type in (cs.TS_FUNCTION_EXPRESSION, cs.TS_GENERATOR_FUNCTION):
+                name_node = scope.child_by_field_name(cs.FIELD_NAME)
+                if name_node is not None and safe_decode_text(name_node) == name:
+                    return True, scope
+            # `var` hoists to function scope no matter which block wrote it.
+            return self._js_var_hoisted_binding(
+                scope.child_by_field_name(cs.FIELD_BODY), name
+            )
+        if scope.type in (cs.TS_STATEMENT_BLOCK, cs.TS_PROGRAM, cs.TS_JS_SWITCH_BODY):
+            decided = self._js_block_binding(scope, name)
+            if decided is not None:
+                return decided
+            if scope.type == cs.TS_PROGRAM:
+                # Module scope is also the top-level `var` hoist target.
+                return self._js_var_hoisted_binding(scope, name)
             return False, None
-        if scope.type in (cs.TS_STATEMENT_BLOCK, cs.TS_PROGRAM):
-            hoisted: Node | None = None
-            for child in scope.named_children:
-                if child.type == cs.TS_EXPORT_STATEMENT:
-                    # `export function f ...` wraps the declaration; the
-                    # binding rules are those of the declaration itself.
-                    wrapped = child.child_by_field_name(cs.FIELD_DECLARATION)
-                    if wrapped is None:
-                        continue
-                    child = wrapped
-                if child.type in _JS_LEXICAL_HOISTED_DECLARATIONS:
-                    child_name = child.child_by_field_name(cs.FIELD_NAME)
-                    if child_name is not None and safe_decode_text(child_name) == name:
-                        # Later declaration wins under hoisting.
-                        hoisted = child
-                elif child.type in (
-                    cs.TS_LEXICAL_DECLARATION,
-                    cs.TS_VARIABLE_DECLARATION,
-                ):
-                    for declarator in child.named_children:
-                        if declarator.type != cs.TS_VARIABLE_DECLARATOR:
-                            continue
-                        target = declarator.child_by_field_name(cs.FIELD_NAME)
-                        if target is None or not self._js_pattern_binds(target, name):
-                            continue
-                        value = declarator.child_by_field_name(cs.FIELD_VALUE)
-                        if value is not None:
-                            value = self._unwrap_ts_value(value)
-                            if value.type in _INLINE_FUNC_VALUE_TYPES:
-                                return True, value
-                        return True, None
-                elif child.type == cs.TS_CLASS_DECLARATION:
-                    child_name = child.child_by_field_name(cs.FIELD_NAME)
-                    if child_name is not None and safe_decode_text(child_name) == name:
-                        return True, None
-            if hoisted is not None:
-                return True, hoisted
+        if scope.type == cs.TS_JS_FOR_STATEMENT:
+            # The C-style loop's init clause scopes its bindings to the loop.
+            init = scope.child_by_field_name(cs.FIELD_INITIALIZER)
+            if init is not None and init.type in (
+                cs.TS_LEXICAL_DECLARATION,
+                cs.TS_VARIABLE_DECLARATION,
+            ):
+                decided = self._js_declaration_binding(init, name)
+                if decided is not None:
+                    return decided
             return False, None
         if scope.type == cs.TS_JS_FOR_IN_STATEMENT:
             left = scope.child_by_field_name(cs.FIELD_LEFT)
@@ -6257,6 +6246,95 @@ class CallProcessor:
                 return True, None
             return False, None
         return False, None
+
+    def _js_block_binding(
+        self, scope: Node, name: str
+    ) -> tuple[bool, Node | None] | None:
+        # Scan a block-like scope's own declarations; None means the scope
+        # does not bind `name` and the walk continues outward. A switch body
+        # is one shared scope whose declarations sit inside its case clauses.
+        children: list[Node] = []
+        for child in scope.named_children:
+            if child.type in (cs.TS_JS_SWITCH_CASE, cs.TS_JS_SWITCH_DEFAULT):
+                children.extend(child.named_children)
+            else:
+                children.append(child)
+        hoisted: Node | None = None
+        for child in children:
+            if child.type == cs.TS_EXPORT_STATEMENT:
+                # `export function f ...` wraps the declaration; the binding
+                # rules are those of the declaration itself.
+                wrapped = child.child_by_field_name(cs.FIELD_DECLARATION)
+                if wrapped is None:
+                    continue
+                child = wrapped
+            if child.type in _JS_LEXICAL_HOISTED_DECLARATIONS:
+                child_name = child.child_by_field_name(cs.FIELD_NAME)
+                if child_name is not None and safe_decode_text(child_name) == name:
+                    # Later declaration wins under hoisting.
+                    hoisted = child
+            elif child.type in (
+                cs.TS_LEXICAL_DECLARATION,
+                cs.TS_VARIABLE_DECLARATION,
+            ):
+                decided = self._js_declaration_binding(child, name)
+                if decided is not None:
+                    return decided
+            elif child.type == cs.TS_CLASS_DECLARATION:
+                child_name = child.child_by_field_name(cs.FIELD_NAME)
+                if child_name is not None and safe_decode_text(child_name) == name:
+                    return True, None
+        if hoisted is not None:
+            return True, hoisted
+        return None
+
+    def _js_declaration_binding(
+        self, declaration: Node, name: str
+    ) -> tuple[bool, Node | None] | None:
+        for declarator in declaration.named_children:
+            if declarator.type != cs.TS_VARIABLE_DECLARATOR:
+                continue
+            target = declarator.child_by_field_name(cs.FIELD_NAME)
+            if target is None or not self._js_pattern_binds(target, name):
+                continue
+            value = declarator.child_by_field_name(cs.FIELD_VALUE)
+            if value is not None:
+                value = self._unwrap_ts_value(value)
+                if value.type in _INLINE_FUNC_VALUE_TYPES:
+                    return True, value
+            return True, None
+        return None
+
+    def _js_var_hoisted_binding(
+        self, body: Node | None, name: str
+    ) -> tuple[bool, Node | None]:
+        # `var` declarators anywhere in this function's body (nested callables
+        # and class bodies excluded: their vars are their own) bind `name` at
+        # function scope. A single var holding an inline function resolves to
+        # it; multiple same-named vars or a non-function value are unknowable.
+        if body is None:
+            return False, None
+        found: Node | None = None
+        count = 0
+        stack = list(body.named_children)
+        while stack:
+            node = stack.pop()
+            if (
+                node.type in _JS_LEXICAL_CALLABLE_SCOPES
+                or node.type == cs.TS_CLASS_BODY
+            ):
+                continue
+            if node.type == cs.TS_VARIABLE_DECLARATION:
+                decided = self._js_declaration_binding(node, name)
+                if decided is not None:
+                    count += 1
+                    found = decided[1]
+            stack.extend(node.named_children)
+        if count == 0:
+            return False, None
+        if count == 1:
+            return True, found
+        return True, None
 
     @staticmethod
     def _js_pattern_binds(pattern: Node, name: str) -> bool:

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -6285,15 +6285,16 @@ class CallProcessor:
                     if name_node is not None:
                         add(safe_decode_text(name_node), node, node)
                 elif node_type in _JS_LEXICAL_HOISTED_DECLARATIONS:
+                    # Function declarations hoist; Annex B makes even a
+                    # block-level one function-scoped in sloppy mode, and one
+                    # under a switch case is live across the whole switch
+                    # body, so the enclosing callable body (or module) is the
+                    # only container that never understates the binding's
+                    # reach. In strict-mode block cases this over-widens,
+                    # which can only suppress.
                     name_node = node.child_by_field_name(cs.FIELD_NAME)
-                    container: Node | None = node.parent
-                    if (
-                        container is not None
-                        and container.type == cs.TS_EXPORT_STATEMENT
-                    ):
-                        container = container.parent
                     if name_node is not None:
-                        add(safe_decode_text(name_node), node, container)
+                        add(safe_decode_text(name_node), node, fn_container)
                 # A method_definition name is a property, never a binding.
                 next_container = node.child_by_field_name(cs.FIELD_BODY) or node
             elif node_type == cs.TS_CLASS_STATIC_BLOCK:
@@ -6329,21 +6330,24 @@ class CallProcessor:
                 param = node.child_by_field_name(cs.FIELD_PARAMETER)
                 if param is not None:
                     add_pattern(param, node)
-            elif node_type in (cs.TS_CLASS_DECLARATION, cs.TS_CLASS_EXPRESSION):
+            elif node_type in (
+                cs.TS_CLASS_DECLARATION,
+                cs.TS_CLASS_EXPRESSION,
+                cs.TS_ENUM_DECLARATION,
+                cs.TS_INTERNAL_MODULE,
+                cs.TS_MODULE,
+            ):
+                # Classes, TS enums and namespaces all bind VALUE names (an
+                # enum compiles to a var, a namespace to an object).
                 name_node = node.child_by_field_name(cs.FIELD_NAME)
                 if name_node is not None:
                     add(safe_decode_text(name_node), None, None)
             elif node_type == cs.TS_IMPORT_STATEMENT:
-                clause = next(
-                    (
-                        child
-                        for child in node.named_children
-                        if child.type == cs.TS_IMPORT_CLAUSE
-                    ),
-                    None,
-                )
-                if clause is not None:
-                    add_pattern(clause, None)
+                # Covers default/named/namespace clauses AND the TS
+                # `import x = require(...)` form: every identifier in the
+                # statement is a bound name (the module path is a string).
+                add_pattern(node, None)
+                continue
             elif node_type in (
                 cs.TS_JS_ASSIGNMENT_EXPRESSION,
                 cs.TS_JS_AUGMENTED_ASSIGNMENT_EXPRESSION,

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -6229,6 +6229,11 @@ class CallProcessor:
         # `with` block makes every name dynamic, so the whole file returns
         # empty and nothing ever resolves.
         bindings: dict[str, list[tuple[Node | None, Node | None]]] = {}
+        # TS declaration merging: every `namespace N` block in the file
+        # shares one member scope. Track occurrences so a repeated name's
+        # blocks are widened afterwards.
+        namespace_blocks: dict[str, list[Node]] = {}
+        namespace_parent: dict[int, Node] = {}
 
         def add(name: str | None, fn_node: Node | None, container: Node | None) -> None:
             if name:
@@ -6359,6 +6364,11 @@ class CallProcessor:
                     add(safe_decode_text(name_node), None, None)
                 if node_type in (cs.TS_INTERNAL_MODULE, cs.TS_MODULE):
                     next_container = node
+                    if name_node is not None and (
+                        ns_name := safe_decode_text(name_node)
+                    ):
+                        namespace_blocks.setdefault(ns_name, []).append(node)
+                        namespace_parent[id(node)] = fn_container
             elif node_type == cs.TS_IMPORT_ALIAS:
                 # `import x = Other.thing` (namespace alias form) binds x;
                 # the aliased path identifiers over-collect, which can only
@@ -6385,7 +6395,37 @@ class CallProcessor:
                         add_pattern(left, None)
             for child in node.named_children:
                 stack.append((child, next_container))
+        merged = [
+            (block, namespace_parent[id(block)])
+            for blocks in namespace_blocks.values()
+            if len(blocks) > 1
+            for block in blocks
+        ]
+        if merged:
+            # Any binding scoped inside a merged namespace block is visible
+            # from that namespace's OTHER blocks; widening to the blocks'
+            # enclosing container never understates the reach (an over-wide
+            # container can only suppress).
+            for name, entries in bindings.items():
+                bindings[name] = [
+                    (fn_node, self._widen_merged_container(container, merged))
+                    for fn_node, container in entries
+                ]
         return bindings
+
+    @staticmethod
+    def _widen_merged_container(
+        container: Node | None, merged: list[tuple[Node, Node]]
+    ) -> Node | None:
+        if container is None:
+            return None
+        for block, parent in merged:
+            if (
+                block.start_byte <= container.start_byte
+                and container.end_byte <= block.end_byte
+            ):
+                return parent
+        return container
 
     def _is_method(self, func_node: Node, lang_config: LanguageSpec) -> bool:
         return is_method_node(func_node, lang_config)

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -6230,10 +6230,14 @@ class CallProcessor:
         # empty and nothing ever resolves.
         bindings: dict[str, list[tuple[Node | None, Node | None]]] = {}
         # TS declaration merging: every `namespace N` block in the file
-        # shares one member scope. Track occurrences so a repeated name's
-        # blocks are widened afterwards.
+        # shares one scope for EXPORTED direct members. Track blocks per
+        # namespace name and the exported members declared in each, so a
+        # repeated name's members gain one introduction per SIBLING block
+        # afterwards; that is exactly where merging makes them visible, and
+        # nowhere else.
         namespace_blocks: dict[str, list[Node]] = {}
-        namespace_parent: dict[int, Node] = {}
+        namespace_name_of: dict[int, str] = {}
+        ns_exported: list[tuple[str, Node | None, Node]] = []
 
         def add(name: str | None, fn_node: Node | None, container: Node | None) -> None:
             if name:
@@ -6312,7 +6316,16 @@ class CallProcessor:
                     # which can only suppress.
                     name_node = node.child_by_field_name(cs.FIELD_NAME)
                     if name_node is not None:
-                        add(safe_decode_text(name_node), node, fn_container)
+                        decl_name = safe_decode_text(name_node)
+                        add(decl_name, node, fn_container)
+                        if (
+                            decl_name
+                            and fn_container.type
+                            in (cs.TS_INTERNAL_MODULE, cs.TS_MODULE)
+                            and node.parent is not None
+                            and node.parent.type == cs.TS_EXPORT_STATEMENT
+                        ):
+                            ns_exported.append((decl_name, node, fn_container))
                 # A method_definition name is a property, never a binding.
                 next_container = node.child_by_field_name(cs.FIELD_BODY) or node
             elif node_type == cs.TS_CLASS_STATIC_BLOCK:
@@ -6333,7 +6346,18 @@ class CallProcessor:
                             value = self._unwrap_ts_value(value)
                             if value.type in _JS_INLINE_CALLABLE_VALUE_TYPES:
                                 fn_value = value
-                        add(safe_decode_text(target), fn_value, container)
+                        target_name = safe_decode_text(target)
+                        add(target_name, fn_value, container)
+                        wrapper = declaration.parent
+                        if (
+                            target_name
+                            and wrapper is not None
+                            and wrapper.type == cs.TS_EXPORT_STATEMENT
+                            and (body := wrapper.parent) is not None
+                            and (ns := body.parent) is not None
+                            and ns.type in (cs.TS_INTERNAL_MODULE, cs.TS_MODULE)
+                        ):
+                            ns_exported.append((target_name, fn_value, ns))
                     else:
                         add_pattern(target, container)
             elif node_type == cs.TS_JS_FOR_IN_STATEMENT:
@@ -6368,7 +6392,7 @@ class CallProcessor:
                         ns_name := safe_decode_text(name_node)
                     ):
                         namespace_blocks.setdefault(ns_name, []).append(node)
-                        namespace_parent[id(node)] = fn_container
+                        namespace_name_of[id(node)] = ns_name
             elif node_type == cs.TS_IMPORT_ALIAS:
                 # `import x = Other.thing` (namespace alias form) binds x;
                 # the aliased path identifiers over-collect, which can only
@@ -6395,37 +6419,17 @@ class CallProcessor:
                         add_pattern(left, None)
             for child in node.named_children:
                 stack.append((child, next_container))
-        merged = [
-            (block, namespace_parent[id(block)])
-            for blocks in namespace_blocks.values()
-            if len(blocks) > 1
-            for block in blocks
-        ]
-        if merged:
-            # Any binding scoped inside a merged namespace block is visible
-            # from that namespace's OTHER blocks; widening to the blocks'
-            # enclosing container never understates the reach (an over-wide
-            # container can only suppress).
-            for name, entries in bindings.items():
-                bindings[name] = [
-                    (fn_node, self._widen_merged_container(container, merged))
-                    for fn_node, container in entries
-                ]
+        for member_name, fn_node, block in ns_exported:
+            ns_name = namespace_name_of.get(id(block))
+            if ns_name is None:
+                continue
+            blocks = namespace_blocks.get(ns_name, [])
+            if len(blocks) < 2:
+                continue
+            for sibling in blocks:
+                if sibling is not block:
+                    add(member_name, fn_node, sibling)
         return bindings
-
-    @staticmethod
-    def _widen_merged_container(
-        container: Node | None, merged: list[tuple[Node, Node]]
-    ) -> Node | None:
-        if container is None:
-            return None
-        for block, parent in merged:
-            if (
-                block.start_byte <= container.start_byte
-                and container.end_byte <= block.end_byte
-            ):
-                return parent
-        return container
 
     def _is_method(self, func_node: Node, lang_config: LanguageSpec) -> bool:
         return is_method_node(func_node, lang_config)

--- a/codebase_rag/tests/test_js_fn_call_apply_statement_edge.py
+++ b/codebase_rag/tests/test_js_fn_call_apply_statement_edge.py
@@ -1,0 +1,151 @@
+# A locally-known function invoked as `fn.call(this, ...)` or `fn.apply(this,
+# ...)` in statement position must record a CALLS edge to `fn`; the receiver is
+# a plain identifier resolving to a function, so `.call` is unambiguously
+# Function.prototype.call. Value positions (`return fn.call(...)`, `x =
+# fn.call(...)`) already link via the bound-callable peel, which is why only
+# statement-position invocations report their targets dead. Found dogfooding
+# fastify (`multipleBindings.call(this, ...)` in lib/server.js, the
+# plugin-utils trio, `_addHook.call(this, ...)`). Issue #988.
+from __future__ import annotations
+
+from pathlib import Path
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.types_defs import PropertyDict, PropertyValue, ResultRow
+
+PROJECT = "p"
+
+
+class _Capture:
+    def __init__(self) -> None:
+        self.rels: list[tuple[PropertyValue, str, PropertyValue]] = []
+
+    def ensure_node_batch(self, label: str, properties: PropertyDict) -> None:
+        return None
+
+    def ensure_relationship_batch(
+        self,
+        from_spec: tuple[str, str, PropertyValue],
+        rel_type: str,
+        to_spec: tuple[str, str, PropertyValue],
+        properties: PropertyDict | None = None,
+    ) -> None:
+        self.rels.append((from_spec[2], str(rel_type), to_spec[2]))
+
+    def flush_all(self) -> None:
+        return None
+
+    def fetch_all(
+        self, query: str, params: PropertyDict | None = None
+    ) -> list[ResultRow]:
+        return []
+
+    def execute_write(self, query: str, params: PropertyDict | None = None) -> None:
+        return None
+
+
+def _run(tmp_path: Path, src: str, filename: str = "a.js") -> _Capture:
+    (tmp_path / filename).write_text(src)
+    parsers, queries = load_parsers()
+    cap = _Capture()
+    GraphUpdater(
+        ingestor=cap,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name=PROJECT,
+    ).run(force=True)
+    return cap
+
+
+def _edges_to_leaf(cap: _Capture, leaf: str) -> set[tuple[str, str]]:
+    return {
+        (str(frm), rel)
+        for frm, rel, to in cap.rels
+        if str(to).rsplit(cs.SEPARATOR_DOT, 1)[-1] == leaf
+        and rel != str(cs.RelationshipType.DEFINES)
+    }
+
+
+def test_statement_fn_call_links_to_function(tmp_path: Path) -> None:
+    src = """'use strict'
+function helper (x) { return x + 1 }
+function main () {
+  helper.call(this, 1)
+  return 2
+}
+module.exports = { main }
+"""
+    edges = _edges_to_leaf(_run(tmp_path, src), "helper")
+    assert any(f.endswith(".main") for f, _rel in edges)
+
+
+def test_statement_fn_apply_links_to_function(tmp_path: Path) -> None:
+    src = """'use strict'
+function helper (x) { return x + 1 }
+function main () {
+  helper.apply(this, [1])
+  return 2
+}
+module.exports = { main }
+"""
+    edges = _edges_to_leaf(_run(tmp_path, src), "helper")
+    assert any(f.endswith(".main") for f, _rel in edges)
+
+
+def test_fn_call_inside_nested_member_arrow_links(tmp_path: Path) -> None:
+    # The fastify lib/server.js shape: the `.call` sits inside an arrow
+    # assigned to an options member, itself inside another function.
+    src = """'use strict'
+function helper (x, cb) { cb(x) }
+function main (opts, cb) {
+  opts.cb = (err, address) => {
+    helper.call(this, err, () => { cb(null, address) })
+  }
+}
+module.exports = { main }
+"""
+    assert _edges_to_leaf(_run(tmp_path, src), "helper")
+
+
+def test_real_method_named_call_still_links_to_method(tmp_path: Path) -> None:
+    # A genuine method named `call` on a typed receiver must keep linking to
+    # the METHOD; the receiver is not a function, so the Function.prototype
+    # fallback must not fire, and no edge may target the decoy function
+    # sharing the receiver's name.
+    src = """'use strict'
+function inv () { return 'decoy' }
+class Invoker {
+  call (x) { return x }
+}
+function main () {
+  const invoker = new Invoker()
+  invoker.call(1)
+  return 2
+}
+module.exports = { main, Invoker, inv }
+"""
+    cap = _run(tmp_path, src)
+    call_edges = _edges_to_leaf(cap, "call")
+    assert any(f.endswith(".main") for f, _rel in call_edges)
+    # The decoy function `inv` gains no edge from main; the module export
+    # shorthand legitimately references it, so only the caller is asserted.
+    assert not any(f.endswith(".main") for f, _rel in _edges_to_leaf(cap, "inv"))
+
+
+def test_object_receiver_named_like_function_does_not_mislink(tmp_path: Path) -> None:
+    # `emitter.call(...)` where `emitter` is a plain object local must not
+    # link to an unrelated module-level function named `emitter`.
+    src = """'use strict'
+function emitter () { return 'decoy' }
+function main (handlers) {
+  const holder = { call: handlers.onCall }
+  holder.call(1)
+  return 2
+}
+module.exports = { main, emitter }
+"""
+    cap = _run(tmp_path, src)
+    assert not any(f.endswith(".main") for f, _rel in _edges_to_leaf(cap, "emitter"))

--- a/codebase_rag/tests/test_js_fn_call_apply_statement_edge.py
+++ b/codebase_rag/tests/test_js_fn_call_apply_statement_edge.py
@@ -1030,3 +1030,43 @@ namespace N { export function use (): number { return helper.call(this) } }
         for frm, rel, to in cap.rels
         if str(to).rsplit(cs.SEPARATOR_DOT, 1)[-1] == "helper"
     )
+
+
+def test_nested_namespace_merges_across_parent_blocks(tmp_path: Path) -> None:
+    # Two inner `N` blocks under two `A` blocks are the SAME namespace A.N;
+    # block 2's call must not fall through to the file-level namesake.
+    src = """function helper (): number { return 1 }
+namespace A { export namespace N { export function helper (): number { return 2 } } }
+namespace A { export namespace N { export function use (): number { return helper.call(this) } } }
+"""
+    cap = _run(tmp_path, src, filename="a.ts")
+    calls = str(cs.RelationshipType.CALLS)
+    assert not any(
+        rel == calls and str(to) == "p.a.helper" for _frm, rel, to in cap.rels
+    )
+
+
+def test_mixed_spelling_namespace_merges(tmp_path: Path) -> None:
+    # `namespace A { export namespace N }` and `namespace A.N` are the same
+    # namespace; the dotted spelling must join the group.
+    src = """function helper (): number { return 1 }
+namespace A { export namespace N { export function helper (): number { return 2 } } }
+namespace A.N { export function use (): number { return helper.call(this) } }
+"""
+    cap = _run(tmp_path, src, filename="a.ts")
+    calls = str(cs.RelationshipType.CALLS)
+    assert not any(
+        rel == calls and str(to) == "p.a.helper" for _frm, rel, to in cap.rels
+    )
+
+
+def test_depth_three_namespace_merges(tmp_path: Path) -> None:
+    src = """function helper (): number { return 1 }
+namespace A { export namespace B { export namespace N { export function helper (): number { return 2 } } } }
+namespace A { export namespace B { export namespace N { export function use (): number { return helper.call(this) } } } }
+"""
+    cap = _run(tmp_path, src, filename="a.ts")
+    calls = str(cs.RelationshipType.CALLS)
+    assert not any(
+        rel == calls and str(to) == "p.a.helper" for _frm, rel, to in cap.rels
+    )

--- a/codebase_rag/tests/test_js_fn_call_apply_statement_edge.py
+++ b/codebase_rag/tests/test_js_fn_call_apply_statement_edge.py
@@ -225,3 +225,136 @@ module.exports = { main }
     # Both function-valued arguments stay reachable from the call site.
     assert any(f.endswith(".main") for f, _rel in _edges_to_leaf(cap, "target"))
     assert any(f.endswith(".main") for f, _rel in _edges_to_leaf(cap, "decoy"))
+
+
+def test_sibling_nested_function_is_not_visible(tmp_path: Path) -> None:
+    # A function nested inside a SIBLING scope is not lexically visible at
+    # the call site; the same-file prefix must not stand in for scoping.
+    src = """'use strict'
+function other () { function helper (x) { return x }; return helper }
+function main () {
+  helper.call(this, 1)
+  return 2
+}
+module.exports = { main, other }
+"""
+    cap = _run(tmp_path, src)
+    assert not any(f.endswith(".main") for f, _rel in _edges_to_leaf(cap, "helper"))
+
+
+def test_for_of_binding_does_not_mislink(tmp_path: Path) -> None:
+    # A loop binding carries collection elements; `.call` through it must not
+    # bind the same-named module function (the tapable hook shape as a loop).
+    src = """'use strict'
+function hook (x) { return x }
+function main (compiler) {
+  for (const hook of compiler.hooks) {
+    hook.call(this, 1)
+  }
+  return 2
+}
+module.exports = { main, hook }
+"""
+    cap = _run(tmp_path, src)
+    assert not any(f.endswith(".main") for f, _rel in _edges_to_leaf(cap, "hook"))
+
+
+def test_catch_binding_does_not_mislink(tmp_path: Path) -> None:
+    src = """'use strict'
+function err () { return 'decoy' }
+function main (fn) {
+  try { fn() } catch (err) { err.call(this, 1) }
+  return 2
+}
+module.exports = { main, err }
+"""
+    cap = _run(tmp_path, src)
+    assert not any(f.endswith(".main") for f, _rel in _edges_to_leaf(cap, "err"))
+
+
+def test_nested_callback_param_does_not_mislink(tmp_path: Path) -> None:
+    # Calls inside an anonymous callback bubble to the enclosing named
+    # caller, but the callback's OWN parameter still shadows the module
+    # function at the call site.
+    src = """'use strict'
+function handler (x) { return x }
+function main (list) {
+  list.forEach(function (handler) { handler.call(this, 1) })
+  return 2
+}
+module.exports = { main, handler }
+"""
+    cap = _run(tmp_path, src)
+    assert not any(f.endswith(".main") for f, _rel in _edges_to_leaf(cap, "handler"))
+
+
+def test_module_level_callback_shadow_does_not_mislink(tmp_path: Path) -> None:
+    # A module-level anonymous callback whose local rebinds the name must not
+    # emit a module-scope edge to the same-named module function.
+    src = """'use strict'
+function hook (x) { return x }
+function setup (cb) { return cb }
+setup(() => {
+  const hook = { call: (n) => n }
+  hook.call(1)
+})
+module.exports = { hook, setup }
+"""
+    cap = _run(tmp_path, src)
+    calls = str(cs.RelationshipType.CALLS)
+    assert not any(rel == calls for _f, rel in _edges_to_leaf(cap, "hook"))
+
+
+def test_duplicate_declarations_last_one_wins(tmp_path: Path) -> None:
+    # Two same-named hoisted declarations: the later one is what the name
+    # denotes at runtime; SOME registered variant must gain the edge.
+    src = """'use strict'
+function helper (x) { return x + 1 }
+function helper (x) { return x + 2 }
+function main () {
+  helper.call(this, 1)
+  return 2
+}
+module.exports = { main }
+"""
+    cap = _run(tmp_path, src)
+    assert any(f.endswith(".main") for f, _rel in _edges_to_leaf(cap, "helper")) or any(
+        f.endswith(".main")
+        for f, rel in {
+            (str(frm), rel)
+            for frm, rel, to in cap.rels
+            if "helper@" in str(to) and rel != str(cs.RelationshipType.DEFINES)
+        }
+    )
+
+
+def test_variant_caller_local_arrow_still_links(tmp_path: Path) -> None:
+    # A DUPLICATE caller (registered as a @line variant) still resolves its
+    # own local arrow receiver by span; the feature must not switch off for
+    # variant callers.
+    src = """'use strict'
+function main () { return 3 }
+function main () {
+  const getValue = () => 1
+  getValue.call(this)
+  return 2
+}
+module.exports = { main }
+"""
+    cap = _run(tmp_path, src)
+    calls = str(cs.RelationshipType.CALLS)
+    assert any(rel == calls for _f, rel in _edges_to_leaf(cap, "getValue"))
+
+
+def test_ts_cast_receiver_links(tmp_path: Path) -> None:
+    # A cast-wrapped receiver (`(helper as any).call(...)`) peels to the
+    # identifier and resolves like the plain form.
+    src = """export function helper (x: number): number { return x + 1 }
+export function main (): number {
+  (helper as any).call(this, 1)
+  return 2
+}
+"""
+    cap = _run(tmp_path, src, filename="a.ts")
+    edges = _edges_to_leaf(cap, "helper")
+    assert any(f.endswith(".main") for f, _rel in edges)

--- a/codebase_rag/tests/test_js_fn_call_apply_statement_edge.py
+++ b/codebase_rag/tests/test_js_fn_call_apply_statement_edge.py
@@ -989,3 +989,44 @@ export function outerUse (): void { helper.call(this) }
     assert not any(
         rel == calls and str(frm).endswith(".outerUse") for frm, rel, _to in cap.rels
     )
+
+
+def test_distinct_namespaces_sharing_leaf_name_do_not_merge(tmp_path: Path) -> None:
+    # `A.N` and top-level `N` are different namespaces; sharing the leaf
+    # name must not replicate A.N's members into N.
+    src = """declare function helper (): number
+namespace A { export namespace N { export function helper (): number { return 2 } } }
+namespace N { export function use (): number { return helper.call(this) } }
+"""
+    cap = _run(tmp_path, src, filename="a.ts")
+    calls = str(cs.RelationshipType.CALLS)
+    assert not any(rel == calls for _f, rel in _edges_to_leaf(cap, "helper"))
+
+
+def test_sibling_inner_namespaces_do_not_merge(tmp_path: Path) -> None:
+    # `Foo.Utils` and `Bar.Utils` are distinct; a call in Bar.Utils to a
+    # file-level function must not bind Foo.Utils' member.
+    src = """function log (m: string): void { }
+namespace Foo { export namespace Utils { export function log (m: string): void { } } }
+namespace Bar { export namespace Utils { export function run (): void { log.call(this, 'x') } } }
+"""
+    cap = _run(tmp_path, src, filename="a.ts")
+    calls = str(cs.RelationshipType.CALLS)
+    assert not any(rel == calls and "Foo" in str(to) for _frm, rel, to in cap.rels)
+    # The file-level log is the unique relevant binding at the site.
+    assert any(rel == calls and str(to) == "p.a.log" for _frm, rel, to in cap.rels)
+
+
+def test_merged_namespace_exported_const_links(tmp_path: Path) -> None:
+    # The declarator replication path: an exported const arrow in block 1 is
+    # visible in block 2.
+    src = """namespace N { export const helper = (): number => 1 }
+namespace N { export function use (): number { return helper.call(this) } }
+"""
+    cap = _run(tmp_path, src, filename="a.ts")
+    calls = str(cs.RelationshipType.CALLS)
+    assert any(
+        rel == calls and str(frm).endswith(".use")
+        for frm, rel, to in cap.rels
+        if str(to).rsplit(cs.SEPARATOR_DOT, 1)[-1] == "helper"
+    )

--- a/codebase_rag/tests/test_js_fn_call_apply_statement_edge.py
+++ b/codebase_rag/tests/test_js_fn_call_apply_statement_edge.py
@@ -857,9 +857,9 @@ export function outerUse (): void {
     cap = _run(tmp_path, src, filename="a.ts")
     calls = str(cs.RelationshipType.CALLS)
     outer = {
-        (f, str(to))
-        for f, rel, to in [(str(a), b, c) for a, b, c in cap.rels]
-        if rel == calls and f.endswith(".outerUse")
+        (str(frm), str(to))
+        for frm, rel, to in cap.rels
+        if rel == calls and str(frm).endswith(".outerUse")
     }
     assert not outer
     assert any(

--- a/codebase_rag/tests/test_js_fn_call_apply_statement_edge.py
+++ b/codebase_rag/tests/test_js_fn_call_apply_statement_edge.py
@@ -305,9 +305,11 @@ module.exports = { hook, setup }
     assert not any(rel == calls for _f, rel in _edges_to_leaf(cap, "hook"))
 
 
-def test_duplicate_declarations_last_one_wins(tmp_path: Path) -> None:
-    # Two same-named hoisted declarations: the later one is what the name
-    # denotes at runtime; SOME registered variant must gain the edge.
+def test_duplicate_declarations_suppress(tmp_path: Path) -> None:
+    # Two same-named hoisted declarations: the name has two introductions, so
+    # which one the call hits is unknowable to the unique-binding rule; no
+    # edge may be invented (the shadowed first declaration IS dead code, and
+    # an edge onto either variant could falsely revive it).
     src = """'use strict'
 function helper (x) { return x + 1 }
 function helper (x) { return x + 2 }
@@ -318,13 +320,9 @@ function main () {
 module.exports = { main }
 """
     cap = _run(tmp_path, src)
-    assert any(f.endswith(".main") for f, _rel in _edges_to_leaf(cap, "helper")) or any(
-        f.endswith(".main")
-        for f, rel in {
-            (str(frm), rel)
-            for frm, rel, to in cap.rels
-            if "helper@" in str(to) and rel != str(cs.RelationshipType.DEFINES)
-        }
+    calls = str(cs.RelationshipType.CALLS)
+    assert not any(
+        rel == calls and f.endswith(".main") for f, rel in _edges_to_leaf(cap, "helper")
     )
 
 
@@ -384,18 +382,11 @@ module.exports = { main, hook }
 
 
 def test_switch_case_binding_does_not_mislink(tmp_path: Path) -> None:
-    # A lexical declaration inside a switch case scopes to the switch body.
+    # A lexical declaration inside a switch case shadows the module function;
+    # the call through it must emit nothing.
     src = """'use strict'
 function helper (x) { return x + 1 }
 function main (o, x) {
-  switch (x) {
-    case 1: {
-      helper.call(this, 1)
-      break
-    }
-    case 2:
-      break
-  }
   switch (x) {
     case 1:
       const helper = o.thing
@@ -407,16 +398,33 @@ function main (o, x) {
 module.exports = { main, helper }
 """
     cap = _run(tmp_path, src)
-    # The first switch's receiver is genuinely the module function (a block
-    # with no local binding); the second's is the case-scoped const. Exactly
-    # the first site may emit; the assertion pins that the const site does
-    # not, by demanding at most the single legitimate edge.
-    edges = {
-        (f, rel)
-        for f, rel in _edges_to_leaf(cap, "helper")
-        if rel == str(cs.RelationshipType.CALLS) and f.endswith(".main")
+    calls = str(cs.RelationshipType.CALLS)
+    assert not any(
+        rel == calls and f.endswith(".main") for f, rel in _edges_to_leaf(cap, "helper")
+    )
+
+
+def test_switch_case_unshadowed_call_links(tmp_path: Path) -> None:
+    # The positive twin: with no shadowing binding anywhere, a call inside a
+    # switch case links to the module function.
+    src = """'use strict'
+function helper (x) { return x + 1 }
+function main (x) {
+  switch (x) {
+    case 1: {
+      helper.call(this, 1)
+      break
     }
-    assert len(edges) <= 1
+  }
+  return 2
+}
+module.exports = { main, helper }
+"""
+    cap = _run(tmp_path, src)
+    calls = str(cs.RelationshipType.CALLS)
+    assert any(
+        rel == calls and f.endswith(".main") for f, rel in _edges_to_leaf(cap, "helper")
+    )
 
 
 def test_try_block_var_hoists_to_function_scope(tmp_path: Path) -> None:
@@ -501,3 +509,85 @@ module.exports = { f }
 """
     cap = _run(tmp_path, src)
     assert _self_loops(cap)
+
+
+def test_for_of_var_receiver_does_not_mislink(tmp_path: Path) -> None:
+    # `for (var hook of ...)` is function-scoped: after the loop the name is
+    # the loop binding, never the module function.
+    src = """'use strict'
+function hook (x) { return x + 1 }
+function main (list) {
+  for (var hook of list.hooks) { }
+  hook.call(this, 1)
+  return 2
+}
+module.exports = { main, hook }
+"""
+    cap = _run(tmp_path, src)
+    assert not any(f.endswith(".main") for f, _rel in _edges_to_leaf(cap, "hook"))
+
+
+def test_block_function_declaration_var_redeclared_suppresses(
+    tmp_path: Path,
+) -> None:
+    # A local function declaration plus a same-named `var` in a nested block:
+    # the runtime value after the try is the var's; no edge may bind the
+    # declaration.
+    src = """'use strict'
+function main (list) {
+  function hook (x) { return x + 1 }
+  try { var hook = list.resolve() } catch (e) { }
+  hook.call(this, 1)
+  return 2
+}
+module.exports = { main }
+"""
+    cap = _run(tmp_path, src)
+    calls = str(cs.RelationshipType.CALLS)
+    assert not any(rel == calls for _f, rel in _edges_to_leaf(cap, "hook"))
+
+
+def test_module_block_var_redeclaration_suppresses(tmp_path: Path) -> None:
+    src = """'use strict'
+function helper (x) { return x + 1 }
+{ var helper = globalThis.pick }
+helper.call(this, 1)
+module.exports = { helper }
+"""
+    cap = _run(tmp_path, src)
+    calls = str(cs.RelationshipType.CALLS)
+    assert not any(rel == calls for _f, rel in _edges_to_leaf(cap, "helper"))
+
+
+def test_class_static_block_var_shadow_suppresses(tmp_path: Path) -> None:
+    src = """'use strict'
+function helper (x) { return x + 1 }
+class C {
+  static {
+    if (globalThis.cond) { var helper = globalThis.pick }
+    helper.call(this, 1)
+  }
+}
+module.exports = { C, helper }
+"""
+    cap = _run(tmp_path, src)
+    calls = str(cs.RelationshipType.CALLS)
+    assert not any(rel == calls for _f, rel in _edges_to_leaf(cap, "helper"))
+
+
+def test_generator_function_expression_receiver_is_safe(tmp_path: Path) -> None:
+    # A `const gen = function* () {...}` receiver is recognised as a callable
+    # binding, but the definition pass does not yet REGISTER generator
+    # function expressions as nodes (tracked separately), so the span lookup
+    # correctly refuses and nothing is emitted. Pin that no edge is invented;
+    # once generator expressions are ingested, this flips to a positive link.
+    src = """'use strict'
+function main () {
+  const gen = function* () { yield 1 }
+  gen.call(this)
+  return 2
+}
+module.exports = { main }
+"""
+    cap = _run(tmp_path, src)
+    assert not _edges_to_leaf(cap, "gen")

--- a/codebase_rag/tests/test_js_fn_call_apply_statement_edge.py
+++ b/codebase_rag/tests/test_js_fn_call_apply_statement_edge.py
@@ -358,3 +358,146 @@ export function main (): number {
     cap = _run(tmp_path, src, filename="a.ts")
     edges = _edges_to_leaf(cap, "helper")
     assert any(f.endswith(".main") for f, _rel in edges)
+
+
+def _self_loops(cap: _Capture) -> set[str]:
+    return {
+        str(frm)
+        for frm, rel, to in cap.rels
+        if str(frm) == str(to) and rel == str(cs.RelationshipType.CALLS)
+    }
+
+
+def test_c_style_for_var_receiver_does_not_mislink(tmp_path: Path) -> None:
+    # The C-style loop variable is the binding at the call site, not the
+    # module function; `for_statement` introduces it outside any block.
+    src = """'use strict'
+function hook (x) { return x + 1 }
+function main (list) {
+  for (var hook = list.head; hook; hook = hook.next) { hook.call(this, 1) }
+  return 2
+}
+module.exports = { main, hook }
+"""
+    cap = _run(tmp_path, src)
+    assert not any(f.endswith(".main") for f, _rel in _edges_to_leaf(cap, "hook"))
+
+
+def test_switch_case_binding_does_not_mislink(tmp_path: Path) -> None:
+    # A lexical declaration inside a switch case scopes to the switch body.
+    src = """'use strict'
+function helper (x) { return x + 1 }
+function main (o, x) {
+  switch (x) {
+    case 1: {
+      helper.call(this, 1)
+      break
+    }
+    case 2:
+      break
+  }
+  switch (x) {
+    case 1:
+      const helper = o.thing
+      helper.call(this, 1)
+      break
+  }
+  return 2
+}
+module.exports = { main, helper }
+"""
+    cap = _run(tmp_path, src)
+    # The first switch's receiver is genuinely the module function (a block
+    # with no local binding); the second's is the case-scoped const. Exactly
+    # the first site may emit; the assertion pins that the const site does
+    # not, by demanding at most the single legitimate edge.
+    edges = {
+        (f, rel)
+        for f, rel in _edges_to_leaf(cap, "helper")
+        if rel == str(cs.RelationshipType.CALLS) and f.endswith(".main")
+    }
+    assert len(edges) <= 1
+
+
+def test_try_block_var_hoists_to_function_scope(tmp_path: Path) -> None:
+    # `try { var hook = ... } catch {}` binds `hook` for the WHOLE function;
+    # the call after the try must not bind the module function.
+    src = """'use strict'
+function hook (x) { return x + 1 }
+function main (list) {
+  try { var hook = list.resolve() } catch (e) { }
+  hook.call(this, 1)
+  return 2
+}
+module.exports = { main, hook }
+"""
+    cap = _run(tmp_path, src)
+    assert not any(f.endswith(".main") for f, _rel in _edges_to_leaf(cap, "hook"))
+
+
+def test_sibling_block_var_arrow_links(tmp_path: Path) -> None:
+    # The mirror case: a var-bound arrow in a nested block hoists to function
+    # scope, so the call after the block resolves to the arrow.
+    src = """'use strict'
+function main (cond) {
+  if (cond) { var doIt = () => 1 }
+  doIt.call(this)
+  return 2
+}
+module.exports = { main }
+"""
+    cap = _run(tmp_path, src)
+    calls = str(cs.RelationshipType.CALLS)
+    assert any(rel == calls for _f, rel in _edges_to_leaf(cap, "doIt"))
+
+
+def test_object_method_shadowing_name_calls_module_function(tmp_path: Path) -> None:
+    # An object method's NAME does not bind in its own body; the call inside
+    # it resolves to the module function, never to a phantom self-loop.
+    src = """'use strict'
+function helper (x) { return x + 1 }
+const o = { helper (x) { helper.call(this, 1); return x } }
+module.exports = { o, helper }
+"""
+    cap = _run(tmp_path, src)
+    assert not _self_loops(cap)
+    calls = str(cs.RelationshipType.CALLS)
+    assert any(rel == calls and str(to) == "p.a.helper" for _frm, rel, to in cap.rels)
+
+
+def test_class_method_named_like_function_calls_module_function(
+    tmp_path: Path,
+) -> None:
+    src = """'use strict'
+function helper (x) { return x + 1 }
+class C {
+  helper (x) { helper.call(this, 1); return x }
+}
+module.exports = { C, helper }
+"""
+    cap = _run(tmp_path, src)
+    assert not _self_loops(cap)
+    calls = str(cs.RelationshipType.CALLS)
+    assert any(rel == calls and str(to) == "p.a.helper" for _frm, rel, to in cap.rels)
+
+
+def test_named_function_expression_param_shadows_self_name(tmp_path: Path) -> None:
+    # A parameter sharing the function expression's own name wins inside the
+    # body, so the call must not bind the expression to itself.
+    src = """'use strict'
+const f = function helper (helper) { helper.call(this, 1); return 2 }
+module.exports = { f }
+"""
+    cap = _run(tmp_path, src)
+    assert not _self_loops(cap)
+
+
+def test_named_function_expression_self_recursion_links(tmp_path: Path) -> None:
+    # Without a shadowing param, the self-name IS the binding: genuine
+    # `.call` self-recursion keeps the function reachable.
+    src = """'use strict'
+const f = function helper () { helper.call(this) }
+module.exports = { f }
+"""
+    cap = _run(tmp_path, src)
+    assert _self_loops(cap)

--- a/codebase_rag/tests/test_js_fn_call_apply_statement_edge.py
+++ b/codebase_rag/tests/test_js_fn_call_apply_statement_edge.py
@@ -591,3 +591,143 @@ module.exports = { main }
 """
     cap = _run(tmp_path, src)
     assert not _edges_to_leaf(cap, "gen")
+
+
+def test_export_const_arrow_receiver_links(tmp_path: Path) -> None:
+    # The modern ESM idiom: an exported const arrow invoked only via `.call`
+    # must link; the export_statement wrapper must not shrink the binding's
+    # container to the single statement.
+    src = """export const helper = (x: number): number => x + 1
+export function main (): number {
+  helper.call(this, 1)
+  return 2
+}
+"""
+    cap = _run(tmp_path, src, filename="a.ts")
+    calls = str(cs.RelationshipType.CALLS)
+    assert any(
+        rel == calls and f.endswith(".main") for f, rel in _edges_to_leaf(cap, "helper")
+    )
+
+
+def test_default_param_value_reference_does_not_suppress(tmp_path: Path) -> None:
+    # `wrap (cb = helper)` READS helper as a default value; it introduces
+    # `cb`, not `helper`, so the genuine `.call` elsewhere keeps its edge.
+    src = """'use strict'
+function helper (x) { return x }
+function wrap (cb = helper) { return cb }
+function main () {
+  helper.call(this, 1)
+  return 2
+}
+module.exports = { main, wrap, helper }
+"""
+    cap = _run(tmp_path, src)
+    calls = str(cs.RelationshipType.CALLS)
+    assert any(
+        rel == calls and f.endswith(".main") for f, rel in _edges_to_leaf(cap, "helper")
+    )
+
+
+def test_ts_typeof_param_type_does_not_suppress(tmp_path: Path) -> None:
+    # A `typeof helper` TYPE QUERY in a parameter annotation is a use of the
+    # name, not an introduction.
+    src = """export function helper (x: number): number { return x }
+export function wrap (cb: typeof helper): void { void cb }
+export function main (): void {
+  helper.call(this, 1)
+}
+"""
+    cap = _run(tmp_path, src, filename="a.ts")
+    calls = str(cs.RelationshipType.CALLS)
+    assert any(
+        rel == calls and f.endswith(".main") for f, rel in _edges_to_leaf(cap, "helper")
+    )
+
+
+def test_sibling_function_local_does_not_suppress(tmp_path: Path) -> None:
+    # The fastify lib/route.js shape: a `const route = ...` inside a SIBLING
+    # function can never be in scope at the call site, so it must not
+    # suppress the edge onto the module-level `route`.
+    src = """'use strict'
+function prepareRoute (opts) {
+  route.call(this, { opts })
+}
+function findRoute (router) {
+  const route = router.find()
+  return route
+}
+function route (o) { return o }
+module.exports = { prepareRoute, findRoute }
+"""
+    cap = _run(tmp_path, src)
+    calls = str(cs.RelationshipType.CALLS)
+    assert any(
+        rel == calls and f.endswith(".prepareRoute")
+        for f, rel in _edges_to_leaf(cap, "route")
+    )
+
+
+def test_static_block_var_not_visible_outside(tmp_path: Path) -> None:
+    # A `var` inside a class static block scopes to the block; a site outside
+    # must not receive an edge onto it (the name is unbound there).
+    src = """'use strict'
+class C {
+  static { var doIt = () => 1 }
+}
+function main () {
+  doIt.call(this)
+  return 2
+}
+module.exports = { main, C }
+"""
+    cap = _run(tmp_path, src)
+    calls = str(cs.RelationshipType.CALLS)
+    assert not any(rel == calls for _f, rel in _edges_to_leaf(cap, "doIt"))
+
+
+def test_destructuring_reassignment_suppresses(tmp_path: Path) -> None:
+    # `({ helper } = ...)` and `[helper] = ...` rebind the name to arbitrary
+    # values; the declared function is no longer what the site invokes.
+    src = """'use strict'
+function helper (x) { return x + 1 }
+;({ helper } = require('./m'))
+function main () {
+  helper.call(this, 1)
+  return 2
+}
+module.exports = { main }
+"""
+    cap = _run(tmp_path, src)
+    calls = str(cs.RelationshipType.CALLS)
+    assert not any(rel == calls for _f, rel in _edges_to_leaf(cap, "helper"))
+
+
+def test_array_destructuring_reassignment_suppresses(tmp_path: Path) -> None:
+    src = """'use strict'
+function helper (x) { return x + 1 }
+function main (list) {
+  ;[helper] = list
+  helper.call(this, 1)
+  return 2
+}
+module.exports = { main }
+"""
+    cap = _run(tmp_path, src)
+    calls = str(cs.RelationshipType.CALLS)
+    assert not any(rel == calls for _f, rel in _edges_to_leaf(cap, "helper"))
+
+
+def test_with_statement_poisons_file(tmp_path: Path) -> None:
+    # `with (obj)` makes every name dynamically resolvable through obj; no
+    # receiver in the file can be trusted.
+    src = """function helper (x) { return x + 1 }
+function main (obj) {
+  with (obj) { helper.call(this, 1) }
+  return 2
+}
+module.exports = { main }
+"""
+    cap = _run(tmp_path, src)
+    calls = str(cs.RelationshipType.CALLS)
+    assert not any(rel == calls for _f, rel in _edges_to_leaf(cap, "helper"))

--- a/codebase_rag/tests/test_js_fn_call_apply_statement_edge.py
+++ b/codebase_rag/tests/test_js_fn_call_apply_statement_edge.py
@@ -904,3 +904,33 @@ export function main (cb: any = helper): void {
     assert any(
         rel == calls and f.endswith(".main") for f, rel in _edges_to_leaf(cap, "helper")
     )
+
+
+def test_ts_merged_namespace_member_shadow_suppresses(tmp_path: Path) -> None:
+    # Declaration merging: exported members of every `namespace N` block
+    # share one scope, so a site in block 2 sees block 1's helper, and the
+    # file-level namesake must not receive the edge.
+    src = """function helper (): number { return 1 }
+namespace N { export function helper (): number { return 2 } }
+namespace N { export function use (): number { return helper.call(this) } }
+"""
+    cap = _run(tmp_path, src, filename="a.ts")
+    calls = str(cs.RelationshipType.CALLS)
+    assert not any(
+        rel == calls and str(to) == "p.a.helper" for _frm, rel, to in cap.rels
+    )
+
+
+def test_ts_merged_namespace_member_links_without_namesake(tmp_path: Path) -> None:
+    # The same merging with no outer namesake: the block-1 member is the
+    # unique binding and the block-2 call links to it.
+    src = """namespace N { export function helper (): number { return 2 } }
+namespace N { export function use (): number { return helper.call(this) } }
+"""
+    cap = _run(tmp_path, src, filename="a.ts")
+    calls = str(cs.RelationshipType.CALLS)
+    assert any(
+        rel == calls and str(frm).endswith(".use")
+        for frm, rel, to in cap.rels
+        if str(to).rsplit(cs.SEPARATOR_DOT, 1)[-1] == "helper"
+    )

--- a/codebase_rag/tests/test_js_fn_call_apply_statement_edge.py
+++ b/codebase_rag/tests/test_js_fn_call_apply_statement_edge.py
@@ -136,16 +136,92 @@ module.exports = { main, Invoker, inv }
 
 
 def test_object_receiver_named_like_function_does_not_mislink(tmp_path: Path) -> None:
-    # `emitter.call(...)` where `emitter` is a plain object local must not
-    # link to an unrelated module-level function named `emitter`.
+    # `emitter.call(...)` where `emitter` is a LOCAL binding shadowing a
+    # module-level function of the same name must not link to that function:
+    # the local holds some other value and the name match is coincidence.
     src = """'use strict'
 function emitter () { return 'decoy' }
 function main (handlers) {
-  const holder = { call: handlers.onCall }
-  holder.call(1)
+  const emitter = { call: handlers.onCall }
+  emitter.call(1)
   return 2
 }
 module.exports = { main, emitter }
 """
     cap = _run(tmp_path, src)
     assert not any(f.endswith(".main") for f, _rel in _edges_to_leaf(cap, "emitter"))
+
+
+def test_param_shadowing_function_name_does_not_mislink(tmp_path: Path) -> None:
+    # A PARAMETER named like a module-level function carries whatever the
+    # caller passed; `.call` through it must not bind the module function.
+    src = """'use strict'
+function helper (x) { return x + 1 }
+function main (helper) {
+  helper.call(this, 1)
+  return 2
+}
+module.exports = { main, helper }
+"""
+    cap = _run(tmp_path, src)
+    assert not any(f.endswith(".main") for f, _rel in _edges_to_leaf(cap, "helper"))
+
+
+def test_cross_file_name_collision_does_not_mislink(tmp_path: Path) -> None:
+    # A local bound from an untyped expression and `.call`ed must never bind
+    # by bare name to a same-named function in an UNRELATED file (the
+    # tapable shape: `const hook = compiler.hooks.beforeRun; hook.call(...)`).
+    (tmp_path / "other.js").write_text("""'use strict'
+function hook (x) { return x }
+module.exports = { hook }
+""")
+    src = """'use strict'
+function main (compiler) {
+  const hook = compiler.hooks.beforeRun
+  hook.call(compiler)
+  return 2
+}
+module.exports = { main }
+"""
+    cap = _run(tmp_path, src, filename="user.js")
+    assert not any(f.endswith(".main") for f, _rel in _edges_to_leaf(cap, "hook"))
+
+
+def test_local_function_receiver_still_links(tmp_path: Path) -> None:
+    # A LOCAL arrow invoked via `.call` resolves to the local itself (it is
+    # the declared binding), so the shadow guard must not block it.
+    src = """'use strict'
+function main () {
+  const getValue = () => 1
+  getValue.call(this)
+  return 2
+}
+module.exports = { main }
+"""
+    edges = _edges_to_leaf(_run(tmp_path, src), "getValue")
+    assert any(f.endswith(".main") for f, _rel in edges)
+
+
+def test_this_arg_does_not_shift_callback_flow(tmp_path: Path) -> None:
+    # `runner.call(this, target, decoy)` passes target as parameter 0 and
+    # decoy as parameter 1; mapping the raw argument list positionally would
+    # bind `second` (the invoked parameter) to TARGET. No such wrong edge may
+    # be emitted, and the real arguments must stay referenced from the caller.
+    src = """'use strict'
+function runner (first, second) { second(); return first }
+function target () { return 1 }
+function decoy () { return 2 }
+function main () {
+  runner.call(this, target, decoy)
+  return 3
+}
+module.exports = { main }
+"""
+    cap = _run(tmp_path, src)
+    assert not any(
+        f.endswith(".runner") and rel == str(cs.RelationshipType.CALLS)
+        for f, rel in _edges_to_leaf(cap, "target")
+    )
+    # Both function-valued arguments stay reachable from the call site.
+    assert any(f.endswith(".main") for f, _rel in _edges_to_leaf(cap, "target"))
+    assert any(f.endswith(".main") for f, _rel in _edges_to_leaf(cap, "decoy"))

--- a/codebase_rag/tests/test_js_fn_call_apply_statement_edge.py
+++ b/codebase_rag/tests/test_js_fn_call_apply_statement_edge.py
@@ -808,3 +808,99 @@ namespace N {
     assert not any(
         rel == calls and str(to) == "p.a.helper" for _frm, rel, to in cap.rels
     )
+
+
+def test_reused_updater_does_not_use_stale_bindings(tmp_path: Path) -> None:
+    # A reused updater (watch mode, a second run) re-parses files; the
+    # binding index from the FIRST parse must not resolve spans against the
+    # new registry, or the edge lands on whatever now sits at the old
+    # line/column.
+    (tmp_path / "a.js").write_text("""'use strict'
+function helper () { return 1 }
+function main () { helper.call(this) }
+module.exports = { main }
+""")
+    parsers, queries = load_parsers()
+    cap = _Capture()
+    updater = GraphUpdater(
+        ingestor=cap,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name=PROJECT,
+    )
+    updater.run(force=True)
+    (tmp_path / "a.js").write_text("""'use strict'
+function decoy () { return 9 }
+function main () { const helper = require('./z'); helper.call(this) }
+module.exports = { main }
+""")
+    cap.rels.clear()
+    updater.run(force=True)
+    assert not any(
+        str(to).endswith(".decoy") and rel == str(cs.RelationshipType.CALLS)
+        for _frm, rel, to in cap.rels
+    )
+
+
+def test_ts_namespace_function_not_visible_outside(tmp_path: Path) -> None:
+    # A function declared inside a namespace is scoped to it; a site outside
+    # must not link to it, while a site inside must.
+    src = """namespace N {
+  function helper (): string { return 'inner' }
+  export function innerUse (): string { return '' + helper.call(this) }
+}
+export function outerUse (): void {
+  helper.call(this, 1)
+}
+"""
+    cap = _run(tmp_path, src, filename="a.ts")
+    calls = str(cs.RelationshipType.CALLS)
+    outer = {
+        (f, str(to))
+        for f, rel, to in [(str(a), b, c) for a, b, c in cap.rels]
+        if rel == calls and f.endswith(".outerUse")
+    }
+    assert not outer
+    assert any(
+        rel == calls and str(frm).endswith(".innerUse")
+        for frm, rel, to in cap.rels
+        if str(to).endswith(".helper")
+    )
+
+
+def test_ts_namespace_import_alias_shadow_suppresses(tmp_path: Path) -> None:
+    # `import helper = Other.thing` inside a namespace binds a value name.
+    src = """function helper (): string { return 'outer' }
+namespace Other {
+  export const thing = { call: (x: unknown) => x }
+}
+namespace N {
+  import helper = Other.thing
+  export function use (): void {
+    helper.call(this)
+  }
+}
+"""
+    cap = _run(tmp_path, src, filename="a.ts")
+    calls = str(cs.RelationshipType.CALLS)
+    assert not any(
+        rel == calls and str(to) == "p.a.helper" for _frm, rel, to in cap.rels
+    )
+
+
+def test_ts_default_param_value_does_not_suppress(tmp_path: Path) -> None:
+    # The TS twin of the JS default-value test, with the default in the SAME
+    # function as the site: `main (cb: any = helper)` reads helper; it
+    # introduces only cb, so the call inside main keeps its edge.
+    src = """export function helper (): number { return 1 }
+export function main (cb: any = helper): void {
+  helper.call(this)
+  void cb
+}
+"""
+    cap = _run(tmp_path, src, filename="a.ts")
+    calls = str(cs.RelationshipType.CALLS)
+    assert any(
+        rel == calls and f.endswith(".main") for f, rel in _edges_to_leaf(cap, "helper")
+    )

--- a/codebase_rag/tests/test_js_fn_call_apply_statement_edge.py
+++ b/codebase_rag/tests/test_js_fn_call_apply_statement_edge.py
@@ -934,3 +934,58 @@ namespace N { export function use (): number { return helper.call(this) } }
         for frm, rel, to in cap.rels
         if str(to).rsplit(cs.SEPARATOR_DOT, 1)[-1] == "helper"
     )
+
+
+def test_merged_namespace_ambient_namesake_no_edge_outside(tmp_path: Path) -> None:
+    # At file scope the name is the ambient declaration; the merged
+    # namespace's member is visible only inside N's blocks, so the outer
+    # site must emit nothing at all.
+    src = """declare function helper (): number
+namespace N { export function helper (): number { return 2 } }
+namespace N { export function other (): void {} }
+export function outerUse (): void { helper.call(this) }
+"""
+    cap = _run(tmp_path, src, filename="a.ts")
+    calls = str(cs.RelationshipType.CALLS)
+    assert not any(
+        rel == calls and str(frm).endswith(".outerUse") for frm, rel, _to in cap.rels
+    )
+
+
+def test_merged_namespace_nonexported_member_stays_private(tmp_path: Path) -> None:
+    # A NON-exported member is visible only in its own block, not in the
+    # namespace's other blocks and never outside.
+    src = """namespace N {
+  function helper (): number { return 1 }
+  export function inner (): void { helper.call(this) }
+}
+namespace N { export function other (): void {} }
+export function outerUse (): void { helper.call(this) }
+"""
+    cap = _run(tmp_path, src, filename="a.ts")
+    calls = str(cs.RelationshipType.CALLS)
+    assert not any(
+        rel == calls and str(frm).endswith(".outerUse") for frm, rel, _to in cap.rels
+    )
+    # Inside its own block the member still resolves.
+    assert any(
+        rel == calls and str(frm).endswith(".inner")
+        for frm, rel, to in cap.rels
+        if str(to).rsplit(cs.SEPARATOR_DOT, 1)[-1] == "helper"
+    )
+
+
+def test_merged_namespace_nested_namespace_stays_narrow(tmp_path: Path) -> None:
+    # A member of a NON-merged inner namespace M must not leak file-wide
+    # just because the outer N is merged.
+    src = """namespace N {
+  export namespace M { export function helper (): number { return 1 } }
+}
+namespace N { export function other (): void {} }
+export function outerUse (): void { helper.call(this) }
+"""
+    cap = _run(tmp_path, src, filename="a.ts")
+    calls = str(cs.RelationshipType.CALLS)
+    assert not any(
+        rel == calls and str(frm).endswith(".outerUse") for frm, rel, _to in cap.rels
+    )

--- a/codebase_rag/tests/test_js_fn_call_apply_statement_edge.py
+++ b/codebase_rag/tests/test_js_fn_call_apply_statement_edge.py
@@ -731,3 +731,80 @@ module.exports = { main }
     cap = _run(tmp_path, src)
     calls = str(cs.RelationshipType.CALLS)
     assert not any(rel == calls for _f, rel in _edges_to_leaf(cap, "helper"))
+
+
+def test_switch_case_function_declaration_shadow_suppresses(tmp_path: Path) -> None:
+    # A function declaration under one case is live across the WHOLE switch
+    # body; a call in another case hits the inner one, so no edge may bind
+    # the outer namesake.
+    src = """'use strict'
+function helper (x) { return 'outer' }
+function main (x) {
+  switch (x) {
+    case 1:
+      function helper (y) { return 'inner' }
+      break
+    case 2:
+      helper.call(this, 1)
+      break
+  }
+  return 2
+}
+module.exports = { main, helper }
+"""
+    cap = _run(tmp_path, src)
+    calls = str(cs.RelationshipType.CALLS)
+    assert not any(
+        rel == calls and str(to) == "p.a.helper" for _frm, rel, to in cap.rels
+    )
+
+
+def test_sloppy_block_function_declaration_shadow_suppresses(
+    tmp_path: Path,
+) -> None:
+    # Annex B: in a non-strict file a block-level function declaration is
+    # function-scoped; after the block the name is the inner function or
+    # undefined, never the outer one.
+    src = """function h2 (x) { return 'outer' }
+function main (cond) {
+  if (cond) { function h2 (y) { return 'inner' } }
+  return h2.call(this, 1)
+}
+module.exports = { main, h2 }
+"""
+    cap = _run(tmp_path, src)
+    calls = str(cs.RelationshipType.CALLS)
+    assert not any(rel == calls and str(to) == "p.a.h2" for _frm, rel, to in cap.rels)
+
+
+def test_ts_enum_shadow_suppresses(tmp_path: Path) -> None:
+    # A local TS enum is a VALUE binding (it compiles to a var); a call
+    # through the shadowed name must not bind the outer function.
+    src = """export function helper (x: number): number { return x + 1 }
+export function main (): void {
+  enum helper { A, B }
+  helper.call(this, 1)
+}
+"""
+    cap = _run(tmp_path, src, filename="a.ts")
+    calls = str(cs.RelationshipType.CALLS)
+    assert not any(rel == calls for _f, rel in _edges_to_leaf(cap, "helper"))
+
+
+def test_ts_import_require_shadow_suppresses(tmp_path: Path) -> None:
+    # `import helper = require('./other')` inside a namespace binds a value
+    # name that shadows the outer function for sites in that namespace.
+    (tmp_path / "other.ts").write_text("export function o (): number { return 1 }\n")
+    src = """export function helper (x: number): number { return x + 1 }
+namespace N {
+  import helper = require('./other')
+  export function main (): void {
+    helper.call(this, 1)
+  }
+}
+"""
+    cap = _run(tmp_path, src, filename="a.ts")
+    calls = str(cs.RelationshipType.CALLS)
+    assert not any(
+        rel == calls and str(to) == "p.a.helper" for _frm, rel, to in cap.rels
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.516"
+version = "0.0.517"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Fixes #988.

## Problem

A JS/TS invocation of the form `fn.call(this, ...)` or `fn.apply(this, ...)`, where `fn` names a first-party function, emitted no edge when the call was an expression statement. Functions whose only invocations use this idiom were falsely reported dead: twelve fastify candidates, including `multipleBindings` (with its four nested closures), the plugin-utils trio (`registerPluginName`, `checkPluginHealthiness`, `checkVersion`), `validateSchemaBodyOption`, `addNewRoute`, `_setNotFoundHandler` and `_addHook`.

## Root cause

PR #983 deliberately left `fn.call(...)`/`fn.apply(...)` unresolved because a member callee named `call` is ambiguous with a real method of that name. Value positions (`return fn.call(...)`, `x = fn.call(...)`) still linked via the bound-callable peel in the value-reference passes, which is why only statement-position invocations lost their targets.

## Fix: unique-relevant-binding resolution

For a call whose callee is `<receiver>.call` or `<receiver>.apply` (casts and parens peeled to a bare identifier), the receiver resolves through a whole-file binding index, never through name lookup in the resolver trie:

- `_js_collect_file_bindings` makes ONE cached pass per file collecting every INTRODUCTION of every identifier: callable parameters (binding side only, skipping default values and TS type annotations), hoisted function and generator declarations, function expression self-names, variable declarators (recording an inline arrow/function/generator value as the bound function; `var` containers widen to the enclosing callable body, `let`/`const` to the declaration's parent, peeling `export_statement` and widening switch-case slots to the switch body), for-in/for-of lefts, catch parameters, class names, import clause names, and reassignment targets including destructuring. A `with` block poisons the whole file.
- At a call site, introductions are filtered to those whose container span encloses the site (file-wide entries always qualify). The edge is emitted only when EXACTLY ONE relevant introduction remains and it is a function registered by the definition pass, resolved by its own source span via `_recorded_caller` with the recorded label.

Two or more relevant introductions, a non-function introduction, or an unbound name emit nothing. This makes every shadowing, `var` hoisting, switch/for/catch scoping and duplicate-declaration question collapse into "a second relevant introduction" with no scope simulation, while an introduction confined to a sibling scope cannot suppress a legitimate edge. Nothing else about the site changes: name resolution, builtin handling and argument references proceed exactly as before, so callable-parameter flow never sees the `this`-shifted argument list.

## Review history

Seven adversarial review rounds shaped this, each verified against the live pipeline; every finding is pinned as a test. Round 1 killed a `callee_info` route (positional flow shifted one slot by the `this` argument). Round 2 killed a resolver-name-lookup route (trie cross-file edges; parameter and declarator shadowing). Round 3 killed a hand-rolled scope walk (var hoisting, C-style for and switch scopes, method self-name phantom self-loops, hardcoded label). Round 4 killed its successor (for-of vars, block function declarations vs var redeclaration, static blocks, quadratic per-site scans). Round 5 refined the whole-file rule (export const containers, default values and `typeof` in parameter scans, sibling-scope suppression recovered via container relevance, static-block containment, destructuring reassignment, `with`). Round 6 widened hoisted declaration containers to the enclosing callable body (switch-case liveness and Annex B block declarations) and added TS enum, namespace and `import x = require(...)` bindings. Round 7 made the per-file index reset for reused updaters (watch mode re-parses; stale nodes resolved spans onto the wrong function), made namespace bodies their own containers, collected the namespace `import x = Other.thing` alias form, and taught the parameter scan the TS grammar's wrapperless defaults. The closing rounds hardened TS namespace declaration merging: exported direct members of a repeated namespace replicate one introduction per sibling block (never a container widening, which could grow relevance from zero and invent edges), merge groups key on the dotted namespace path from the nearest non-namespace container so `A { N }`, `A.N` and a top-level `N` group exactly as TS does, and all node bookkeeping uses tree-sitter's stable node ids so fresh Python wrappers cannot break identity checks.

## Validation

- 58 tests in `codebase_rag/tests/test_js_fn_call_apply_statement_edge.py`: positives (statement `.call`/`.apply`, nested arrows, casts, export const arrows, default-value and `typeof` non-suppression in both grammars, sibling-scope locals, switch case, namespace-internal calls, self-recursion, reused-updater freshness) and guards pinning every review finding.
- Full non-integration suite green, `pytest -n auto`.
- Real-repo verification on fastify after EVERY design iteration: dead-code candidates 36 to 24, exactly the twelve `.call`/`.apply` victims revived every time, no other candidate changed. The final reviewer sweep instrumented 28,897 candidate sites across fastify (27 resolved, all same-file, no false link, `route.call` in `lib/route.js` recovered) and confirmed zero resolutions and zero false edges across typeorm, zod, NestJS core and excalidraw sweeps.
- Discovered and filed separately: #994 (generator function expressions are not registered as function nodes).

## Known accepted approximations

- Flow-insensitive: `let f = () => 1; f = other; f.call()` counts two introductions and suppresses (conservative miss, never a wrong edge).
- The per-file binding cache stores tree-sitter nodes, keeping parsed trees alive for the duration of the call pass only; the pass already retains its AST cache, and the cache dies with the `CallProcessor`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved JavaScript and TypeScript call tracking for `.call()` and `.apply()`.
  * More accurately resolves function references across imports, aliases, destructuring, namespaces, scopes, hoisting, generators, classes, and inline functions.

* **Bug Fixes**
  * Prevented stale or ambiguous bindings from creating incorrect call relationships.
  * Improved handling of reassigned, shadowed, and dynamically scoped functions.

* **Tests**
  * Added comprehensive coverage for call resolution, statement-position calls, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->