### PR TITLE
fix: reference named operands of JS/TS logical default assignments

### DIFF
--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -212,6 +212,10 @@ FIELD_FINALIZER = "finalizer"
 FIELD_INCREMENT = "increment"
 
 # JS/TS module system node types
+# The operator field of a JS/TS binary_expression, and the short-circuit
+# operators that evaluate to one of their operands.
+JS_FIELD_OPERATOR = "operator"
+JS_LOGICAL_OPERATORS = frozenset({"||", "??", "&&"})
 TS_OBJECT_PATTERN = "object_pattern"
 TS_ARRAY_PATTERN = "array_pattern"
 TS_REST_PATTERN = "rest_pattern"

--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -212,10 +212,6 @@ FIELD_FINALIZER = "finalizer"
 FIELD_INCREMENT = "increment"
 
 # JS/TS module system node types
-# The operator field of a JS/TS binary_expression, and the short-circuit
-# operators that evaluate to one of their operands.
-JS_FIELD_OPERATOR = "operator"
-JS_LOGICAL_OPERATORS = frozenset({"||", "??", "&&"})
 TS_OBJECT_PATTERN = "object_pattern"
 TS_ARRAY_PATTERN = "array_pattern"
 TS_REST_PATTERN = "rest_pattern"

--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -197,6 +197,8 @@ TS_JS_TERNARY_EXPRESSION = "ternary_expression"
 # Short-circuit operators whose result IS one of the operands, so a
 # bind through them unions both operands' taints.
 JS_SHORT_CIRCUIT_OPERATORS: frozenset[str] = frozenset({"||", "??", "&&"})
+# `&&` alone among them cannot yield its LEFT operand as a function value.
+JS_OPERATOR_LOGICAL_AND = "&&"
 TS_JS_ELSE_CLAUSE = "else_clause"
 TS_JS_WHILE_STATEMENT = "while_statement"
 TS_JS_FOR_STATEMENT = "for_statement"

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -3364,6 +3364,13 @@ class CallProcessor:
                 )
         return True
 
+    @staticmethod
+    def _js_is_logical_binary(node: Node) -> bool:
+        # `||`, `??` and `&&` evaluate to ONE OF their operands; every other
+        # binary operator produces a fresh value.
+        operator = node.child_by_field_name(cs.JS_FIELD_OPERATOR)
+        return operator is not None and operator.type in cs.JS_LOGICAL_OPERATORS
+
     def _ingest_assignment_function_references(
         self,
         caller_node: Node,
@@ -3422,12 +3429,34 @@ class CallProcessor:
                     # arrow-const RHS is registered by its name, so the by-position
                     # lookup finds nothing.
                     # A LOGICAL DEFAULT RHS (`done = done || function (err,
-                    # str) {...}`, express's render) hides the stored function
-                    # one level down; scan the binary operands too.
+                    # str) {...}`, express's render; `options.handler =
+                    # options.handler || defaultHandler`, fastify, issue
+                    # #990) evaluates TO one of its operands, so a NAMED
+                    # function operand flows as the assigned value exactly
+                    # like an inline one; chains (`a || b || defaultFmt`)
+                    # nest further logical binaries on the left. Only the
+                    # short-circuit operators qualify: a comparison or
+                    # arithmetic operand (`x === fn`, `n + fn`) never IS the
+                    # assigned value, so named operands there stay silent
+                    # while inline functions keep the historical reference.
                     if value.type == cs.TS_BINARY_EXPRESSION:
-                        for operand in value.named_children:
-                            operand = self._unwrap_ts_value(operand)
-                            if operand.type in _INLINE_FUNC_VALUE_TYPES:
+                        is_logical = self._js_is_logical_binary(value)
+                        operands: list[Node] = []
+                        pending = list(value.named_children)
+                        while pending:
+                            operand = self._unwrap_ts_value(pending.pop())
+                            if (
+                                is_logical
+                                and operand.type == cs.TS_BINARY_EXPRESSION
+                                and self._js_is_logical_binary(operand)
+                            ):
+                                pending.extend(operand.named_children)
+                                continue
+                            operands.append(operand)
+                        for operand in operands:
+                            if operand.type in _INLINE_FUNC_VALUE_TYPES or (
+                                is_logical and operand.type in _ASSIGNMENT_RHS_REF_TYPES
+                            ):
                                 self._emit_callback_edge(
                                     caller_spec,
                                     operand,

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -3457,21 +3457,41 @@ class CallProcessor:
                             language in cs.JS_TS_LANGUAGES
                             and self._js_is_logical_binary(value)
                         )
-                        operands: list[Node] = []
-                        pending = list(value.named_children)
+                        # Position matters for `&&` only: a function value
+                        # is always truthy, so the LEFT operand of `&&` can
+                        # never be the expression's result; `||`/`??` flow
+                        # either operand.
+                        operands: list[tuple[Node, bool]] = []
+                        pending: list[tuple[Node, bool]] = [(value, True)]
                         while pending:
-                            operand = self._unwrap_ts_value(pending.pop())
+                            raw, value_position = pending.pop()
+                            operand = self._unwrap_ts_value(raw)
                             if (
                                 is_logical
                                 and operand.type == cs.TS_BINARY_EXPRESSION
                                 and self._js_is_logical_binary(operand)
                             ):
-                                pending.extend(operand.named_children)
+                                is_and = (
+                                    safe_decode_text(
+                                        operand.child_by_field_name(cs.FIELD_OPERATOR)
+                                    )
+                                    == cs.JS_OPERATOR_LOGICAL_AND
+                                )
+                                left = operand.child_by_field_name(cs.FIELD_LEFT)
+                                right = operand.child_by_field_name(cs.TS_FIELD_RIGHT)
+                                if left is not None:
+                                    pending.append(
+                                        (left, value_position and not is_and)
+                                    )
+                                if right is not None:
+                                    pending.append((right, value_position))
                                 continue
-                            operands.append(operand)
-                        for operand in operands:
+                            operands.append((operand, value_position))
+                        for operand, value_position in operands:
                             if operand.type in _INLINE_FUNC_VALUE_TYPES or (
-                                is_logical and operand.type in _ASSIGNMENT_RHS_REF_TYPES
+                                is_logical
+                                and value_position
+                                and operand.type in _ASSIGNMENT_RHS_REF_TYPES
                             ):
                                 self._emit_callback_edge(
                                     caller_spec,

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1200,6 +1200,7 @@ class CallProcessor:
                     None,
                     None,
                     assignment_boundaries,
+                    language=language,
                 )
             if language == cs.SupportedLanguage.GO:
                 # A module-scope Go func map/slice (var funcMap = map[...]{...})
@@ -1223,6 +1224,7 @@ class CallProcessor:
                     None,
                     None,
                     self._flow_scope_boundaries(queries[language][cs.QUERY_CONFIG]),
+                    language=language,
                 )
             if language in _JS_TS_LANGUAGES:
                 # A module-scope JSX element (export default <App />) can sit
@@ -2453,6 +2455,7 @@ class CallProcessor:
                 class_context,
                 self._flow_scope_boundaries(queries[language][cs.QUERY_CONFIG]),
                 caller_qn,
+                language=language,
             )
         if language in _JS_TS_LANGUAGES:
             self._ingest_jsx_component_references(
@@ -3367,9 +3370,14 @@ class CallProcessor:
     @staticmethod
     def _js_is_logical_binary(node: Node) -> bool:
         # `||`, `??` and `&&` evaluate to ONE OF their operands; every other
-        # binary operator produces a fresh value.
-        operator = node.child_by_field_name(cs.JS_FIELD_OPERATOR)
-        return operator is not None and operator.type in cs.JS_LOGICAL_OPERATORS
+        # binary operator produces a fresh value. Callers gate to JS/TS: Go
+        # spells boolean `||`/`&&` with the same node and field, where a
+        # named operand is a bool, never a callable.
+        operator = node.child_by_field_name(cs.FIELD_OPERATOR)
+        return (
+            operator is not None
+            and safe_decode_text(operator) in cs.JS_SHORT_CIRCUIT_OPERATORS
+        )
 
     def _ingest_assignment_function_references(
         self,
@@ -3380,6 +3388,7 @@ class CallProcessor:
         class_context: str | None,
         boundary_types: frozenset[str],
         caller_qn: str | None = None,
+        language: cs.SupportedLanguage | None = None,
     ) -> None:
         # `x = some_function` binds a first-class function value to a name; the
         # alias is then stored, passed onward, or returned for dynamic dispatch
@@ -3440,7 +3449,14 @@ class CallProcessor:
                     # assigned value, so named operands there stay silent
                     # while inline functions keep the historical reference.
                     if value.type == cs.TS_BINARY_EXPRESSION:
-                        is_logical = self._js_is_logical_binary(value)
+                        # Named-operand emission is JS/TS-only: Go reaches
+                        # this walk too, and its boolean `||`/`&&` operands
+                        # would fabricate phantom edges (a bool named like a
+                        # method falsely revives it).
+                        is_logical = (
+                            language in cs.JS_TS_LANGUAGES
+                            and self._js_is_logical_binary(value)
+                        )
                         operands: list[Node] = []
                         pending = list(value.named_children)
                         while pending:

--- a/codebase_rag/tests/test_js_logical_default_reference.py
+++ b/codebase_rag/tests/test_js_logical_default_reference.py
@@ -1,0 +1,148 @@
+# A function referenced as a fallback operand of a logical default in an
+# assignment (`x = a || fn`, chained `x = a || b || fn`, `x = a ?? fn`) flows
+# as the assigned VALUE, so it must be referenced or dead-code falsely flags
+# it. Found dogfooding fastify: `options.clientErrorHandler =
+# options.clientErrorHandler || defaultClientErrorHandler` (fastify.js) and
+# the chained `this.schemaErrorFormatter = a || b || defaultSchemaErrorFormatter`
+# (lib/context.js). Issue #990.
+from __future__ import annotations
+
+from pathlib import Path
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.types_defs import PropertyDict, PropertyValue, ResultRow
+
+PROJECT = "p"
+
+
+class _Capture:
+    def __init__(self) -> None:
+        self.rels: list[tuple[PropertyValue, str, PropertyValue]] = []
+
+    def ensure_node_batch(self, label: str, properties: PropertyDict) -> None:
+        return None
+
+    def ensure_relationship_batch(
+        self,
+        from_spec: tuple[str, str, PropertyValue],
+        rel_type: str,
+        to_spec: tuple[str, str, PropertyValue],
+        properties: PropertyDict | None = None,
+    ) -> None:
+        self.rels.append((from_spec[2], str(rel_type), to_spec[2]))
+
+    def flush_all(self) -> None:
+        return None
+
+    def fetch_all(
+        self, query: str, params: PropertyDict | None = None
+    ) -> list[ResultRow]:
+        return []
+
+    def execute_write(self, query: str, params: PropertyDict | None = None) -> None:
+        return None
+
+
+def _run(tmp_path: Path, src: str, filename: str = "a.js") -> _Capture:
+    (tmp_path / filename).write_text(src)
+    parsers, queries = load_parsers()
+    cap = _Capture()
+    GraphUpdater(
+        ingestor=cap,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name=PROJECT,
+    ).run(force=True)
+    return cap
+
+
+def _referenced_from(cap: _Capture, caller_leaf: str, target_leaf: str) -> bool:
+    return any(
+        str(frm).rsplit(cs.SEPARATOR_DOT, 1)[-1] == caller_leaf
+        and str(to).rsplit(cs.SEPARATOR_DOT, 1)[-1] == target_leaf
+        and rel != str(cs.RelationshipType.DEFINES)
+        for frm, rel, to in cap.rels
+    )
+
+
+def test_or_default_assignment_references_fallback(tmp_path: Path) -> None:
+    src = """'use strict'
+function fallback () { return 1 }
+function main (options) {
+  options.handler = options.handler || fallback
+  return options
+}
+module.exports = { main }
+"""
+    assert _referenced_from(_run(tmp_path, src), "main", "fallback")
+
+
+def test_chained_or_default_references_last_operand(tmp_path: Path) -> None:
+    # The fastify lib/context.js shape: a multi-line chain whose LAST operand
+    # is the module-level default.
+    src = """'use strict'
+function defaultFormatter (errors) { return String(errors) }
+function Context (opts, server) {
+  this.schemaErrorFormatter =
+    opts.schemaErrorFormatter ||
+    server.schemaErrorFormatter ||
+    defaultFormatter
+}
+module.exports = { Context }
+"""
+    assert _referenced_from(_run(tmp_path, src), "Context", "defaultFormatter")
+
+
+def test_nullish_default_references_fallback(tmp_path: Path) -> None:
+    src = """'use strict'
+function fallback () { return 1 }
+function main (options) {
+  const handler = options.handler ?? fallback
+  return handler
+}
+module.exports = { main }
+"""
+    assert _referenced_from(_run(tmp_path, src), "main", "fallback")
+
+
+def test_and_operand_references_fallback(tmp_path: Path) -> None:
+    # `a && fn` can evaluate TO fn; the assigned value may be the function.
+    src = """'use strict'
+function fallback () { return 1 }
+function main (options) {
+  const handler = options.enabled && fallback
+  return handler
+}
+module.exports = { main }
+"""
+    assert _referenced_from(_run(tmp_path, src), "main", "fallback")
+
+
+def test_comparison_operand_is_not_referenced(tmp_path: Path) -> None:
+    # `x === fn` only tests identity; the assigned boolean never IS the
+    # function, so no reference may be emitted for non-logical operators.
+    src = """'use strict'
+function fallback () { return 1 }
+function main (options) {
+  const isDefault = options.handler === fallback
+  return isDefault
+}
+module.exports = { main }
+"""
+    assert not _referenced_from(_run(tmp_path, src), "main", "fallback")
+
+
+def test_or_default_inline_function_still_references(tmp_path: Path) -> None:
+    # The already-working express shape (`done = done || function (err) {}`)
+    # must keep its reference.
+    src = """'use strict'
+function main (done) {
+  done = done || function fallbackDone (err) { return err }
+  return done
+}
+module.exports = { main }
+"""
+    assert _referenced_from(_run(tmp_path, src), "main", "fallbackDone")

--- a/codebase_rag/tests/test_js_logical_default_reference.py
+++ b/codebase_rag/tests/test_js_logical_default_reference.py
@@ -63,7 +63,7 @@ def _referenced_from(cap: _Capture, caller_leaf: str, target_leaf: str) -> bool:
     return any(
         str(frm).rsplit(cs.SEPARATOR_DOT, 1)[-1] == caller_leaf
         and str(to).rsplit(cs.SEPARATOR_DOT, 1)[-1] == target_leaf
-        and rel != str(cs.RelationshipType.DEFINES)
+        and rel == str(cs.RelationshipType.REFERENCES)
         for frm, rel, to in cap.rels
     )
 
@@ -168,3 +168,17 @@ func Run(valid bool, other bool) bool {
         and rel == str(cs.RelationshipType.REFERENCES)
         for _frm, rel, to in cap.rels
     )
+
+
+def test_and_left_operand_is_not_referenced(tmp_path: Path) -> None:
+    # A function value is always truthy, so the LEFT operand of `&&` can
+    # never be the expression's result; referencing it would falsely revive.
+    src = """'use strict'
+function fallback () { return 1 }
+function main (options) {
+  const handler = fallback && options.other
+  return handler
+}
+module.exports = { main }
+"""
+    assert not _referenced_from(_run(tmp_path, src), "main", "fallback")

--- a/codebase_rag/tests/test_js_logical_default_reference.py
+++ b/codebase_rag/tests/test_js_logical_default_reference.py
@@ -146,3 +146,25 @@ function main (done) {
 module.exports = { main }
 """
     assert _referenced_from(_run(tmp_path, src), "main", "fallbackDone")
+
+
+def test_go_boolean_operands_are_not_referenced(tmp_path: Path) -> None:
+    # Go spells boolean `||` with the same binary_expression node and
+    # operator field; a bool named like a method must not revive it.
+    src = """package m
+
+type T struct{}
+
+func (t T) valid() bool { return true }
+
+func Run(valid bool, other bool) bool {
+\tres := valid || other
+\treturn res
+}
+"""
+    cap = _run(tmp_path, src, filename="a.go")
+    assert not any(
+        str(to).rsplit(cs.SEPARATOR_DOT, 1)[-1] == "valid"
+        and rel == str(cs.RelationshipType.REFERENCES)
+        for _frm, rel, to in cap.rels
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.516"
+version = "0.0.517"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Fixes #990.

## Problem

A function referenced as a fallback operand of a logical default in an assignment, `x = a || fn`, a chained `x = a || b || fn`, or `x = a ?? fn`, emitted no REFERENCES edge and was falsely reported dead. Fastify witnesses: `options.clientErrorHandler = options.clientErrorHandler || defaultClientErrorHandler` (fastify.js) and the chained `this.schemaErrorFormatter = schemaErrorFormatter || server[kSchemaErrorFormatter] || defaultSchemaErrorFormatter` (lib/context.js).

## Root cause

The assignment-reference pass scanned binary RHS operands for INLINE functions only (the express `done = done || function () {}` shape); a bare identifier operand was skipped, and nested logical chains were not flattened.

## Fix

For a binary RHS whose operator is `||`, `??` or `&&` (the operators that evaluate TO one of their operands, tested via the existing `cs.JS_SHORT_CIRCUIT_OPERATORS`), named operands in `_ASSIGNMENT_RHS_REF_TYPES` now emit REFERENCES like inline functions always did, with nested logical chains flattened through casts and parens. Non-logical operators keep the old inline-only behaviour, so `x === fn` stays silent.

The emission is gated to JS/TS via a `language` parameter threaded from all three call sites: Go reaches the same walk and spells boolean `||`/`&&` with the same `binary_expression` node, where a bool named like a method would fabricate a phantom edge (the adversarial review demonstrated exactly that with a bool parameter reviving an unrelated method; the repro is pinned RED to GREEN).

## Validation

- 7 tests in `codebase_rag/tests/test_js_logical_default_reference.py`: the two fastify shapes, `??`, `&&`, the comparison guard, the pre-existing inline-function shape, and the Go phantom-edge guard.
- Full non-integration suite green, `pytest -n auto`.
- Real-repo verification on fastify: dead-code candidates 36 to 34 relative to main; both OR-default victims revived, nothing else changed. Reviewer verification covered `.js`, `.ts` and `.tsx` plus Go and Python behaviour, confirming Go and Python are byte-identical to pre-change.

## Noted, pre-existing, not addressed here

- The left operand of the idiom (`o.bar = o.bar || fn`) resolves through the loose trailing-name member resolution shared with the ternary path, which can reference a same-named member on an unrelated class.
- A ternary nested inside a logical chain (`a || (c ? f1 : f2)`) emits nothing on either side's pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code reference tracking for JavaScript and TypeScript assignments using `||`, `??`, and `&&`.
  * Nested logical expressions now correctly identify referenced callable functions.
  * Reduced incorrect references from comparisons and Go boolean expressions.
  * Preserved support for inline fallback functions and language-aware scanning.

* **Tests**
  * Added regression coverage for logical defaults, chained expressions, inline functions, comparisons, and Go expressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->