### PR TITLE
fix: link whole-module commonjs function exports and load-time export wrappers

### DIFF
--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -262,6 +262,17 @@ JS_COMMONJS_EXPORTS_FUNCTION_QUERY = """
 """
 
 # JS/TS CommonJS module.exports query
+# The DIRECT form `module.exports = function (...) {...}` / arrow: the whole
+# module IS one function (fastify's generated error-serializer). Two-level
+# member on the left, unlike the three-level named-property form below.
+JS_COMMONJS_DIRECT_EXPORT_QUERY = """
+(assignment_expression
+  left: (member_expression
+    object: (identifier) @module_obj
+    property: (property_identifier) @exports_prop)
+  right: [(function_expression) (arrow_function)] @export_function)
+"""
+
 JS_COMMONJS_MODULE_EXPORTS_QUERY = """
 (assignment_expression
   left: (member_expression

--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -270,7 +270,7 @@ JS_COMMONJS_DIRECT_EXPORT_QUERY = """
   left: (member_expression
     object: (identifier) @module_obj
     property: (property_identifier) @exports_prop)
-  right: [(function_expression) (arrow_function)] @export_function)
+  right: [(function_expression) (arrow_function) (call_expression)] @export_function)
 """
 
 JS_COMMONJS_MODULE_EXPORTS_QUERY = """

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1300,6 +1300,9 @@ class GraphUpdater:
             else relative_path.with_suffix("").parts
         )
         module_qn_prefix = cs.SEPARATOR_DOT.join([self.project_name, *path_parts])
+        self.factory.import_processor.commonjs_direct_exports.pop(
+            module_qn_prefix, None
+        )
 
         qns_to_remove = set()
 

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -1078,6 +1078,14 @@ class CallResolver:
         if imported_qn in self.function_registry:
             logger.debug(ls.CALL_DIRECT_IMPORT, call_name=call_name, qn=imported_qn)
             return self.function_registry[imported_qn], imported_qn
+        # A whole-module require alias (`const f = require('./m'); f(x)`)
+        # maps to the MODULE qn; when that module's entire export is one
+        # function (`module.exports = function ... `), the call is a call to
+        # that function (issue #991, fastify's error-serializer).
+        direct = self.import_processor.commonjs_direct_exports.get(imported_qn)
+        if direct is not None and direct in self.function_registry:
+            logger.debug(ls.CALL_DIRECT_IMPORT, call_name=call_name, qn=direct)
+            return self.function_registry[direct], direct
         return None
 
     def _try_resolve_qualified_call(

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -397,6 +397,12 @@ class DefinitionProcessor(
                 # only genuinely anonymous spans (callbacks, IIFEs) still
                 # need their held-back registration.
                 self._flush_deferred_js_anonymous()
+                # Direct module.exports functions finalise by SPAN now that
+                # every node's minted qn is recorded.
+                self._finalise_direct_module_exports(
+                    module_qn, self._pending_direct_module_exports
+                )
+                self._pending_direct_module_exports = []
 
             return (root_node, language)
 

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -402,6 +402,9 @@ class ImportProcessor:
         lang_config = queries[language]["config"]
 
         self.import_mapping[module_qn] = {}
+        # A re-parsed module that no longer directly exports one function
+        # must not leave the stale whole-module alias mapping behind.
+        self.commonjs_direct_exports.pop(module_qn, None)
         # Reset per-module PHP use-function state too, so a re-index that drops a
         # `use function` import does not leave a stale exemption behind.
         self.php_function_imports.pop(module_qn, None)

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -215,6 +215,7 @@ class ImportProcessor:
         "ingestor",
         "function_registry",
         "import_mapping",
+        "commonjs_direct_exports",
         "conditional_imports",
         "php_function_imports",
         "js_ts_bare_imports",
@@ -244,6 +245,11 @@ class ImportProcessor:
         self.ingestor = ingestor
         self.function_registry = function_registry
         self.import_mapping: dict[str, dict[str, str]] = {}
+        # CommonJS modules whose ENTIRE export is one function
+        # (`module.exports = function (...) {...}`): module qn -> the
+        # exported function's qn, so a whole-module require alias called
+        # directly (`const f = require('./m'); f(x)`) resolves to it.
+        self.commonjs_direct_exports: dict[str, str] = {}
         # Names bound by a CONDITIONAL Python import (nested under if/try --
         # click's `if WIN: from ._winconsole import X`): the dead-code fan-out
         # treats a same-named local def as the mutually-exclusive fallback

--- a/codebase_rag/parsers/js_ts/module_system.py
+++ b/codebase_rag/parsers/js_ts/module_system.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from loguru import logger
-from tree_sitter import QueryCursor
+from tree_sitter import Language, QueryCursor
 
 from ... import constants as cs
 from ... import logs as ls
@@ -296,6 +296,51 @@ class JsTsModuleSystemMixin:
                     cs.JS_EXPORT_TYPE_COMMONJS_MODULE,
                 )
 
+    def _ingest_direct_module_export(
+        self,
+        root_node: ASTNode,
+        module_qn: str,
+        language_obj: Language,
+    ) -> None:
+        # `module.exports = function (...) {...}` makes the WHOLE module one
+        # function (fastify's generated error-serializer). Register it as an
+        # exported function under its own name (or its position when
+        # anonymous) and record the module-to-function mapping, so a
+        # whole-module require alias called directly resolves to it.
+        try:
+            cursor = QueryCursor(
+                get_cached_query(language_obj, cs.JS_COMMONJS_DIRECT_EXPORT_QUERY)
+            )
+            captures = sorted_captures(cursor, root_node)
+        except Exception as e:
+            logger.debug(ls.JS_COMMONJS_EXPORTS_QUERY_FAILED, error=e)
+            return
+        for module_obj, exports_prop, export_function in zip(
+            captures.get(cs.CAPTURE_MODULE_OBJ, []),
+            captures.get(cs.CAPTURE_EXPORTS_PROP, []),
+            captures.get(cs.CAPTURE_EXPORT_FUNCTION, []),
+        ):
+            if safe_decode_text(module_obj) != cs.JS_MODULE_KEYWORD:
+                continue
+            if safe_decode_text(exports_prop) != cs.JS_EXPORTS_KEYWORD:
+                continue
+            name_node = export_function.child_by_field_name(cs.FIELD_NAME)
+            function_name = (
+                safe_decode_text(name_node) if name_node is not None else None
+            )
+            if not function_name:
+                row, col = export_function.start_point
+                function_name = f"{cs.PREFIX_ANONYMOUS}{row}_{col}"
+            self._ingest_export_function(
+                export_function,
+                function_name,
+                module_qn,
+                cs.JS_EXPORT_TYPE_COMMONJS_MODULE,
+            )
+            self.import_processor.commonjs_direct_exports[module_qn] = (
+                f"{module_qn}{cs.SEPARATOR_DOT}{function_name}"
+            )
+
     def _ingest_commonjs_exports(
         self,
         root_node: ASTNode,
@@ -314,6 +359,7 @@ class JsTsModuleSystemMixin:
             cs.JS_COMMONJS_EXPORTS_FUNCTION_QUERY,
             cs.JS_COMMONJS_MODULE_EXPORTS_QUERY,
         ]
+        self._ingest_direct_module_export(root_node, module_qn, language_obj)
 
         for query_text in query_texts:
             try:

--- a/codebase_rag/parsers/js_ts/module_system.py
+++ b/codebase_rag/parsers/js_ts/module_system.py
@@ -324,6 +324,23 @@ class JsTsModuleSystemMixin:
                 continue
             if safe_decode_text(exports_prop) != cs.JS_EXPORTS_KEYWORD:
                 continue
+            immediately_invoked = False
+            if export_function.type == cs.TS_CALL_EXPRESSION:
+                # `module.exports = function (...) {...}(args)` (generated
+                # fast-json-stringify, fastify's error-serializer): the
+                # export is the IIFE's RETURN value, and the wrapped
+                # function runs at module load, so the module CALLS it; its
+                # returned callables stay alive through their internal
+                # references. Any other call expression is not a function
+                # export.
+                callee = export_function.child_by_field_name(cs.FIELD_FUNCTION)
+                if callee is None or callee.type not in (
+                    cs.TS_FUNCTION_EXPRESSION,
+                    cs.TS_ARROW_FUNCTION,
+                ):
+                    continue
+                export_function = callee
+                immediately_invoked = True
             name_node = export_function.child_by_field_name(cs.FIELD_NAME)
             function_name = (
                 safe_decode_text(name_node) if name_node is not None else None
@@ -337,9 +354,17 @@ class JsTsModuleSystemMixin:
                 module_qn,
                 cs.JS_EXPORT_TYPE_COMMONJS_MODULE,
             )
-            self.import_processor.commonjs_direct_exports[module_qn] = (
-                f"{module_qn}{cs.SEPARATOR_DOT}{function_name}"
-            )
+            function_qn = f"{module_qn}{cs.SEPARATOR_DOT}{function_name}"
+            if immediately_invoked:
+                self.ingestor.ensure_relationship_batch(
+                    (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, module_qn),
+                    cs.RelationshipType.CALLS,
+                    (cs.NodeLabel.FUNCTION, cs.KEY_QUALIFIED_NAME, function_qn),
+                )
+            else:
+                # The alias map is only sound for the plain form: an IIFE's
+                # export is its return value, not the wrapped function.
+                self.import_processor.commonjs_direct_exports[module_qn] = function_qn
 
     def _ingest_commonjs_exports(
         self,

--- a/codebase_rag/parsers/js_ts/module_system.py
+++ b/codebase_rag/parsers/js_ts/module_system.py
@@ -13,6 +13,7 @@ from ... import constants as cs
 from ... import logs as ls
 from ...types_defs import ASTNode
 from ..utils import (
+    function_span_key,
     get_cached_query,
     ingest_exported_function,
     safe_decode_text,
@@ -24,7 +25,9 @@ from .utils import get_js_ts_language_obj
 if TYPE_CHECKING:
     from ...services import IngestorProtocol
     from ...types_defs import (
+        FunctionLocation,
         FunctionRegistryTrieProtocol,
+        FunctionSpanKey,
         LanguageQueries,
         SimpleNameLookup,
     )
@@ -32,7 +35,7 @@ if TYPE_CHECKING:
 
 
 class JsTsModuleSystemMixin:
-    __slots__ = ("_processed_imports",)
+    __slots__ = ("_processed_imports", "_pending_direct_module_exports")
     ingestor: IngestorProtocol
     repo_path: Path
     project_name: str
@@ -40,6 +43,7 @@ class JsTsModuleSystemMixin:
     simple_name_lookup: SimpleNameLookup
     module_qn_to_file_path: dict[str, Path]
     import_processor: ImportProcessor
+    function_locations: dict[FunctionSpanKey, FunctionLocation]
     _processed_imports: set[str]
 
     @abstractmethod
@@ -64,6 +68,7 @@ class JsTsModuleSystemMixin:
 
     def __init__(self) -> None:
         self._processed_imports = set()
+        self._pending_direct_module_exports: list[tuple[ASTNode, bool]] = []
 
     def _ingest_missing_import_patterns(
         self,
@@ -301,12 +306,16 @@ class JsTsModuleSystemMixin:
         root_node: ASTNode,
         module_qn: str,
         language_obj: Language,
-    ) -> None:
+    ) -> list[tuple[ASTNode, bool]]:
         # `module.exports = function (...) {...}` makes the WHOLE module one
-        # function (fastify's generated error-serializer). Register it as an
-        # exported function under its own name (or its position when
-        # anonymous) and record the module-to-function mapping, so a
-        # whole-module require alias called directly resolves to it.
+        # function; `module.exports = function (...) {...}(args)` (with or
+        # without parens, fastify's generated error-serializer) exports the
+        # IIFE's RETURN value and runs the wrapper at module load. Collect
+        # the function nodes now; the caller finalises AFTER the deferred
+        # anonymous flush, resolving each node's qn by its own SOURCE SPAN so
+        # a name collision or refused registration can never point the edge
+        # or the alias map at an unrelated namesake.
+        pending: list[tuple[ASTNode, bool]] = []
         try:
             cursor = QueryCursor(
                 get_cached_query(language_obj, cs.JS_COMMONJS_DIRECT_EXPORT_QUERY)
@@ -314,7 +323,7 @@ class JsTsModuleSystemMixin:
             captures = sorted_captures(cursor, root_node)
         except Exception as e:
             logger.debug(ls.JS_COMMONJS_EXPORTS_QUERY_FAILED, error=e)
-            return
+            return pending
         for module_obj, exports_prop, export_function in zip(
             captures.get(cs.CAPTURE_MODULE_OBJ, []),
             captures.get(cs.CAPTURE_EXPORTS_PROP, []),
@@ -324,47 +333,79 @@ class JsTsModuleSystemMixin:
                 continue
             if safe_decode_text(exports_prop) != cs.JS_EXPORTS_KEYWORD:
                 continue
+            if self._is_export_inside_function(export_function):
+                # Assigned when the enclosing function runs, not at module
+                # load: neither a load-time call nor the module's export.
+                continue
             immediately_invoked = False
             if export_function.type == cs.TS_CALL_EXPRESSION:
-                # `module.exports = function (...) {...}(args)` (generated
-                # fast-json-stringify, fastify's error-serializer): the
-                # export is the IIFE's RETURN value, and the wrapped
-                # function runs at module load, so the module CALLS it; its
-                # returned callables stay alive through their internal
-                # references. Any other call expression is not a function
-                # export.
-                callee = export_function.child_by_field_name(cs.FIELD_FUNCTION)
+                callee: ASTNode | None = export_function.child_by_field_name(
+                    cs.FIELD_FUNCTION
+                )
+                while (
+                    callee is not None and callee.type == cs.TS_PARENTHESIZED_EXPRESSION
+                ):
+                    callee = callee.named_children[0] if callee.named_children else None
                 if callee is None or callee.type not in (
                     cs.TS_FUNCTION_EXPRESSION,
                     cs.TS_ARROW_FUNCTION,
                 ):
+                    # Any other call expression is not a function export.
                     continue
                 export_function = callee
                 immediately_invoked = True
-            name_node = export_function.child_by_field_name(cs.FIELD_NAME)
-            function_name = (
-                safe_decode_text(name_node) if name_node is not None else None
-            )
-            if not function_name:
-                row, col = export_function.start_point
-                function_name = f"{cs.PREFIX_ANONYMOUS}{row}_{col}"
-            self._ingest_export_function(
-                export_function,
-                function_name,
-                module_qn,
-                cs.JS_EXPORT_TYPE_COMMONJS_MODULE,
-            )
-            function_qn = f"{module_qn}{cs.SEPARATOR_DOT}{function_name}"
-            if immediately_invoked:
+            else:
+                # The function IS the export: register it (own name, or its
+                # position when anonymous) marked exported. A refusal (span
+                # already claimed by the node's earlier registration) is
+                # fine: finalisation reads the claimed span either way.
+                name_node = export_function.child_by_field_name(cs.FIELD_NAME)
+                function_name = (
+                    safe_decode_text(name_node) if name_node is not None else None
+                )
+                if not function_name:
+                    row, col = export_function.start_point
+                    function_name = f"{cs.PREFIX_ANONYMOUS}{row}_{col}"
+                self._ingest_export_function(
+                    export_function,
+                    function_name,
+                    module_qn,
+                    cs.JS_EXPORT_TYPE_COMMONJS_MODULE,
+                )
+            pending.append((export_function, immediately_invoked))
+        return pending
+
+    def _finalise_direct_module_exports(
+        self, module_qn: str, pending: list[tuple[ASTNode, bool]]
+    ) -> None:
+        # Runs AFTER the deferred anonymous flush: every function node's
+        # minted qn is now in the span registry. An unregistered span means
+        # the node was refused everywhere; emit nothing rather than guess.
+        for node, invoked in pending:
+            loc = self.function_locations.get(function_span_key(module_qn, node))
+            if loc is None:
+                continue
+            if invoked:
                 self.ingestor.ensure_relationship_batch(
                     (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, module_qn),
                     cs.RelationshipType.CALLS,
-                    (cs.NodeLabel.FUNCTION, cs.KEY_QUALIFIED_NAME, function_qn),
+                    (loc.label, cs.KEY_QUALIFIED_NAME, loc.qualified_name),
                 )
             else:
-                # The alias map is only sound for the plain form: an IIFE's
-                # export is its return value, not the wrapped function.
-                self.import_processor.commonjs_direct_exports[module_qn] = function_qn
+                # The module's one export: aliases calling the whole-module
+                # require resolve to it, and it is exported by definition
+                # (the named form's earlier registration may have recorded
+                # is_exported False; the merge fixes it up).
+                self.ingestor.ensure_node_batch(
+                    loc.label,
+                    {
+                        cs.KEY_QUALIFIED_NAME: loc.qualified_name,
+                        cs.KEY_IS_EXPORTED: True,
+                    },
+                )
+                self.import_processor.commonjs_direct_exports[module_qn] = (
+                    loc.qualified_name
+                )
 
     def _ingest_commonjs_exports(
         self,
@@ -384,7 +425,9 @@ class JsTsModuleSystemMixin:
             cs.JS_COMMONJS_EXPORTS_FUNCTION_QUERY,
             cs.JS_COMMONJS_MODULE_EXPORTS_QUERY,
         ]
-        self._ingest_direct_module_export(root_node, module_qn, language_obj)
+        self._pending_direct_module_exports = self._ingest_direct_module_export(
+            root_node, module_qn, language_obj
+        )
 
         for query_text in query_texts:
             try:

--- a/codebase_rag/parsers/js_ts/module_system.py
+++ b/codebase_rag/parsers/js_ts/module_system.py
@@ -383,7 +383,10 @@ class JsTsModuleSystemMixin:
         # the node was refused everywhere; emit nothing rather than guess.
         for node, invoked in pending:
             loc = self.function_locations.get(function_span_key(module_qn, node))
-            if loc is None:
+            if loc is None or loc.qualified_name not in self.function_registry:
+                # No claim, or a STALE claim from before a watch-mode removal
+                # purged the registry: writing anything would resurrect a
+                # sparse node for a function that no longer exists.
                 continue
             if invoked:
                 self.ingestor.ensure_relationship_batch(
@@ -421,6 +424,9 @@ class JsTsModuleSystemMixin:
         if not language_obj:
             return
 
+        # Reset first: an exception in a later pass must not leak a stale
+        # pending list into the next file's finalisation.
+        self._pending_direct_module_exports = []
         query_texts = [
             cs.JS_COMMONJS_EXPORTS_FUNCTION_QUERY,
             cs.JS_COMMONJS_MODULE_EXPORTS_QUERY,

--- a/codebase_rag/parsers/js_ts/module_system.py
+++ b/codebase_rag/parsers/js_ts/module_system.py
@@ -337,43 +337,43 @@ class JsTsModuleSystemMixin:
                 # Assigned when the enclosing function runs, not at module
                 # load: neither a load-time call nor the module's export.
                 continue
-            immediately_invoked = False
-            if export_function.type == cs.TS_CALL_EXPRESSION:
-                callee: ASTNode | None = export_function.child_by_field_name(
-                    cs.FIELD_FUNCTION
-                )
-                while (
-                    callee is not None and callee.type == cs.TS_PARENTHESIZED_EXPRESSION
-                ):
-                    callee = callee.named_children[0] if callee.named_children else None
-                if callee is None or callee.type not in (
-                    cs.TS_FUNCTION_EXPRESSION,
-                    cs.TS_ARROW_FUNCTION,
-                ):
-                    # Any other call expression is not a function export.
-                    continue
-                export_function = callee
-                immediately_invoked = True
-            else:
-                # The function IS the export: register it (own name, or its
-                # position when anonymous) marked exported. A refusal (span
-                # already claimed by the node's earlier registration) is
-                # fine: finalisation reads the claimed span either way.
-                name_node = export_function.child_by_field_name(cs.FIELD_NAME)
-                function_name = (
-                    safe_decode_text(name_node) if name_node is not None else None
-                )
-                if not function_name:
-                    row, col = export_function.start_point
-                    function_name = f"{cs.PREFIX_ANONYMOUS}{row}_{col}"
-                self._ingest_export_function(
-                    export_function,
-                    function_name,
-                    module_qn,
-                    cs.JS_EXPORT_TYPE_COMMONJS_MODULE,
-                )
-            pending.append((export_function, immediately_invoked))
+            entry = self._pending_direct_export_entry(export_function, module_qn)
+            if entry is not None:
+                pending.append(entry)
         return pending
+
+    def _pending_direct_export_entry(
+        self, export_function: ASTNode, module_qn: str
+    ) -> tuple[ASTNode, bool] | None:
+        if export_function.type == cs.TS_CALL_EXPRESSION:
+            callee: ASTNode | None = export_function.child_by_field_name(
+                cs.FIELD_FUNCTION
+            )
+            while callee is not None and callee.type == cs.TS_PARENTHESIZED_EXPRESSION:
+                callee = callee.named_children[0] if callee.named_children else None
+            if callee is None or callee.type not in (
+                cs.TS_FUNCTION_EXPRESSION,
+                cs.TS_ARROW_FUNCTION,
+            ):
+                # Any other call expression is not a function export.
+                return None
+            return callee, True
+        # The function IS the export: register it (own name, or its position
+        # when anonymous) marked exported. A refusal (span already claimed by
+        # the node's earlier registration) is fine: finalisation reads the
+        # claimed span either way.
+        name_node = export_function.child_by_field_name(cs.FIELD_NAME)
+        function_name = safe_decode_text(name_node) if name_node is not None else None
+        if not function_name:
+            row, col = export_function.start_point
+            function_name = f"{cs.PREFIX_ANONYMOUS}{row}_{col}"
+        self._ingest_export_function(
+            export_function,
+            function_name,
+            module_qn,
+            cs.JS_EXPORT_TYPE_COMMONJS_MODULE,
+        )
+        return export_function, False
 
     def _finalise_direct_module_exports(
         self, module_qn: str, pending: list[tuple[ASTNode, bool]]

--- a/codebase_rag/tests/test_js_commonjs_direct_function_export_call.py
+++ b/codebase_rag/tests/test_js_commonjs_direct_function_export_call.py
@@ -1,0 +1,129 @@
+# A module exporting a function expression directly (`module.exports =
+# function name () {...}`) is consumed as `const f = require('./mod'); f(x)`;
+# the call must link to the exported function or it (and everything nested in
+# it) reports dead. Found dogfooding fastify: lib/error-serializer.js is
+# exactly `module.exports = function anonymous (...) {...}`, consumed by
+# lib/error-handler.js as `serializeError({...})`. Issue #991.
+from __future__ import annotations
+
+from pathlib import Path
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.types_defs import PropertyDict, PropertyValue, ResultRow
+
+PROJECT = "p"
+
+
+class _Capture:
+    def __init__(self) -> None:
+        self.rels: list[tuple[PropertyValue, str, PropertyValue]] = []
+
+    def ensure_node_batch(self, label: str, properties: PropertyDict) -> None:
+        return None
+
+    def ensure_relationship_batch(
+        self,
+        from_spec: tuple[str, str, PropertyValue],
+        rel_type: str,
+        to_spec: tuple[str, str, PropertyValue],
+        properties: PropertyDict | None = None,
+    ) -> None:
+        self.rels.append((from_spec[2], str(rel_type), to_spec[2]))
+
+    def flush_all(self) -> None:
+        return None
+
+    def fetch_all(
+        self, query: str, params: PropertyDict | None = None
+    ) -> list[ResultRow]:
+        return []
+
+    def execute_write(self, query: str, params: PropertyDict | None = None) -> None:
+        return None
+
+
+def _run(tmp_path: Path, files: dict[str, str]) -> _Capture:
+    for name, src in files.items():
+        (tmp_path / name).write_text(src)
+    parsers, queries = load_parsers()
+    cap = _Capture()
+    GraphUpdater(
+        ingestor=cap,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name=PROJECT,
+    ).run(force=True)
+    return cap
+
+
+def _linked(cap: _Capture, caller_leaf: str, target_qn: str) -> bool:
+    return any(
+        str(frm).rsplit(cs.SEPARATOR_DOT, 1)[-1] == caller_leaf
+        and str(to) == target_qn
+        and rel != str(cs.RelationshipType.DEFINES)
+        for frm, rel, to in cap.rels
+    )
+
+
+def test_direct_function_export_called_via_required_alias(tmp_path: Path) -> None:
+    cap = _run(
+        tmp_path,
+        {
+            "ser.js": """'use strict'
+module.exports = function anonymous (v) { return String(v) }
+""",
+            "b.js": """'use strict'
+const serialize = require('./ser')
+function main () { return serialize(1) }
+module.exports = { main }
+""",
+        },
+    )
+    assert _linked(cap, "main", "p.ser.anonymous")
+
+
+def test_direct_arrow_export_called_via_required_alias(tmp_path: Path) -> None:
+    cap = _run(
+        tmp_path,
+        {
+            "ser.js": """'use strict'
+module.exports = (v) => String(v)
+""",
+            "b.js": """'use strict'
+const serialize = require('./ser')
+function main () { return serialize(1) }
+module.exports = { main }
+""",
+        },
+    )
+    # The anonymous arrow registers positionally under the module; any
+    # non-DEFINES edge from main into a ser-module function keeps it alive.
+    assert any(
+        str(frm).rsplit(cs.SEPARATOR_DOT, 1)[-1] == "main"
+        and str(to).startswith("p.ser.")
+        and rel != str(cs.RelationshipType.DEFINES)
+        for frm, rel, to in cap.rels
+    )
+
+
+def test_object_export_call_still_links(tmp_path: Path) -> None:
+    # The already-working shape: `module.exports = { fn }` consumed via
+    # destructuring keeps its edge.
+    cap = _run(
+        tmp_path,
+        {
+            "lib.js": """'use strict'
+function fn (v) { return v }
+module.exports = { fn }
+""",
+            "b.js": """'use strict'
+const { fn } = require('./lib')
+function main () { return fn(1) }
+module.exports = { main }
+""",
+        },
+    )
+    assert _linked(cap, "main", "p.lib.fn")

--- a/codebase_rag/tests/test_js_commonjs_direct_function_export_call.py
+++ b/codebase_rag/tests/test_js_commonjs_direct_function_export_call.py
@@ -127,3 +127,28 @@ module.exports = { main }
         },
     )
     assert _linked(cap, "main", "p.lib.fn")
+
+
+def test_iife_module_export_calls_the_wrapped_function(tmp_path: Path) -> None:
+    # The generated fast-json-stringify shape (fastify's error-serializer):
+    # the export is the RESULT of immediately invoking the function, so the
+    # module must gain a CALLS edge onto the wrapped function; its returned
+    # inner callable stays alive transitively through the internal reference.
+    cap = _run(
+        tmp_path,
+        {
+            "ser.js": """'use strict'
+const validator = null
+const serializer = null
+module.exports = function anonymous(validator, serializer) {
+  function anonymous0 (input) { return String(input) }
+  const main = anonymous0
+  return main
+}(validator, serializer)
+""",
+        },
+    )
+    assert any(
+        str(to) == "p.ser.anonymous" and rel == str(cs.RelationshipType.CALLS)
+        for _frm, rel, to in cap.rels
+    )

--- a/codebase_rag/tests/test_js_commonjs_direct_function_export_call.py
+++ b/codebase_rag/tests/test_js_commonjs_direct_function_export_call.py
@@ -152,3 +152,140 @@ module.exports = function anonymous(validator, serializer) {
         str(to) == "p.ser.anonymous" and rel == str(cs.RelationshipType.CALLS)
         for _frm, rel, to in cap.rels
     )
+
+
+def test_iife_wrapper_collision_targets_the_wrapper_variant(tmp_path: Path) -> None:
+    # The wrapper's own name collides with an unrelated top-level function;
+    # the module CALLS edge must target the qn actually minted for the
+    # WRAPPER (a duplicate variant), never the namesake.
+    cap = _run(
+        tmp_path,
+        {
+            "ser.js": """'use strict'
+function build (v) { return v }
+module.exports = function build (validator) {
+  function inner (x) { return x }
+  return inner
+}(1)
+""",
+        },
+    )
+    calls = str(cs.RelationshipType.CALLS)
+    module_calls = {
+        str(to) for frm, rel, to in cap.rels if rel == calls and str(frm) == "p.ser"
+    }
+    assert "p.ser.build" not in module_calls
+    assert any(t.startswith("p.ser.build") for t in module_calls)
+
+
+def test_export_inside_function_emits_nothing(tmp_path: Path) -> None:
+    # `module.exports = ...` INSIDE a function is not a module-load export;
+    # no module CALLS edge and no phantom qn may be emitted.
+    cap = _run(
+        tmp_path,
+        {
+            "ser.js": """'use strict'
+function setup () {
+  module.exports = function wrapped (v) { return v }(1)
+}
+setup()
+""",
+        },
+    )
+    calls = str(cs.RelationshipType.CALLS)
+    assert not any(
+        rel == calls and str(frm) == "p.ser" and "wrapped" in str(to)
+        for frm, rel, to in cap.rels
+    )
+
+
+def test_inside_function_export_does_not_map_alias(tmp_path: Path) -> None:
+    # The refused registration must not leave a guessed alias mapping behind
+    # that points a consumer call at an unrelated top-level namesake.
+    cap = _run(
+        tmp_path,
+        {
+            "m.js": """'use strict'
+function handler (v) { return 'top' }
+function setup () {
+  module.exports = function handler (v) { return 'inner' }
+}
+setup()
+""",
+            "b.js": """'use strict'
+const h = require('./m')
+function main () { return h(1) }
+module.exports = { main }
+""",
+        },
+    )
+    assert not any(
+        str(frm).endswith(".main") and str(to) == "p.m.handler"
+        for frm, _rel, to in cap.rels
+    )
+
+
+def test_reindex_clears_direct_export_map(tmp_path: Path) -> None:
+    # A re-parsed module that no longer directly exports a function must not
+    # leave the stale alias mapping behind (watch mode).
+    (tmp_path / "ser.js").write_text("""'use strict'
+module.exports = function serialize (v) { return String(v) }
+""")
+    (tmp_path / "b.js").write_text("""'use strict'
+const s = require('./ser')
+function main () { return s(1) }
+module.exports = { main }
+""")
+    parsers, queries = load_parsers()
+    cap = _Capture()
+    updater = GraphUpdater(
+        ingestor=cap,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name=PROJECT,
+    )
+    updater.run(force=True)
+    (tmp_path / "ser.js").write_text("""'use strict'
+function serialize (v) { return String(v) }
+module.exports = { other: (v) => v }
+""")
+    cap.rels.clear()
+    updater.run(force=True)
+    assert not any(
+        str(frm).endswith(".main") and str(to) == "p.ser.serialize"
+        for frm, _rel, to in cap.rels
+    )
+
+
+def test_parenthesised_iife_export_links(tmp_path: Path) -> None:
+    # The canonical hand-written IIFE: `(function wrapped () {...})(1)`.
+    cap = _run(
+        tmp_path,
+        {
+            "ser.js": """'use strict'
+module.exports = (function wrapped (v) { return v })(1)
+""",
+        },
+    )
+    calls = str(cs.RelationshipType.CALLS)
+    assert any(
+        rel == calls and str(frm) == "p.ser" and str(to).endswith(".wrapped")
+        for frm, rel, to in cap.rels
+    )
+
+
+def test_parenthesised_arrow_iife_export_links(tmp_path: Path) -> None:
+    cap = _run(
+        tmp_path,
+        {
+            "ser.js": """'use strict'
+module.exports = ((v) => v)(1)
+""",
+        },
+    )
+    calls = str(cs.RelationshipType.CALLS)
+    assert any(
+        rel == calls and str(frm) == "p.ser" and str(to).startswith("p.ser.")
+        for frm, rel, to in cap.rels
+    )

--- a/codebase_rag/tests/test_js_commonjs_direct_function_export_call.py
+++ b/codebase_rag/tests/test_js_commonjs_direct_function_export_call.py
@@ -19,9 +19,13 @@ PROJECT = "p"
 class _Capture:
     def __init__(self) -> None:
         self.rels: list[tuple[PropertyValue, str, PropertyValue]] = []
+        self.exported_nodes: list[str] = []
 
     def ensure_node_batch(self, label: str, properties: PropertyDict) -> None:
-        return None
+        if properties.get(cs.KEY_IS_EXPORTED) and (
+            qn := properties.get(cs.KEY_QUALIFIED_NAME)
+        ):
+            self.exported_nodes.append(str(qn))
 
     def ensure_relationship_batch(
         self,
@@ -289,3 +293,32 @@ module.exports = ((v) => v)(1)
         rel == calls and str(frm) == "p.ser" and str(to).startswith("p.ser.")
         for frm, rel, to in cap.rels
     )
+
+
+def test_reindex_does_not_resurrect_sparse_export_node(tmp_path: Path) -> None:
+    # A reused updater re-parses the file; the stale span claim refuses
+    # re-registration, so finalisation must NOT write an exported node (or
+    # repopulate the alias map) for a qn absent from the registry.
+    (tmp_path / "ser.js").write_text("module.exports = (v) => String(v)\n")
+    (tmp_path / "b.js").write_text("""'use strict'
+const s = require('./ser')
+function main () { return s(1) }
+module.exports = { main }
+""")
+    parsers, queries = load_parsers()
+    cap = _Capture()
+    updater = GraphUpdater(
+        ingestor=cap,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name=PROJECT,
+    )
+    updater.run(force=True)
+    (tmp_path / "ser.js").write_text("module.exports = (v) => String(v) + ''\n")
+    updater.remove_file_from_state(tmp_path / "ser.js")
+    cap.exported_nodes.clear()
+    updater.run(force=True)
+    registry = updater.factory.call_processor._resolver.function_registry
+    for qn in cap.exported_nodes:
+        assert qn in registry

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.516"
+version = "0.0.517"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Fixes #991.

## Problem

A CommonJS module whose entire export is one function was invisible to callers. Two shapes, both from fastify's generated `lib/error-serializer.js` family:

- `module.exports = function name (...) {...}`: a consumer's `const f = require('./mod'); f(x)` produced no edge into the exported function.
- `module.exports = function anonymous (...) {...}(args)` (the fast-json-stringify standalone output, with or without parentheses around the callee): the wrapper runs at module load and the export is its RETURN value; neither the wrapper nor its returned inner callable had any inbound edge, so both reported dead.

## Fix

A new tree-sitter query recognises `module.exports = <function|arrow|call>`. The definition pass COLLECTS the function nodes (skipping exports inside functions entirely, and peeling parenthesised IIFE callees), then finalises AFTER the deferred anonymous flush, resolving each node by its own SOURCE SPAN against the span registry:

- a direct export registers as an exported function (own name, or positional when anonymous), gains an `is_exported` merge, and records `module qn to function qn` in the new `ImportProcessor.commonjs_direct_exports` map; `_try_resolve_direct_import` falls back to that map when a whole-module require alias resolves to a module qn absent from the function registry, so the consumer call links;
- an immediately invoked wrapper gets a `Module CALLS wrapper` edge with the span-recorded label and qn (its returned callables stay alive through their internal references); the alias map is deliberately not populated for this shape, since the export is the return value, not the wrapper.

Span-first resolution means a name collision targets the wrapper's actual minted variant, a refused registration emits nothing, and a STALE span claim after a watch-mode removal is guarded by a registry membership check so nothing sparse is ever resurrected. The map is invalidated in `parse_imports` (beside the other per-module resets) and in `remove_file_from_state`.

## Review history

One adversarial review round over the live pipeline found six defects in the first design (all rooted in deriving qns from names: collision mistargeting, phantom edges for in-function exports, a wrong cross-module alias, an uninvalidated map, the parenthesised IIFE gap, and inconsistent export marking); the span-finalised redesign fixed all six, and the follow-up round confirmed them fixed while catching the stale-claim resurrection, closed by the registry guard. Every finding is pinned as a test.

## Validation

- 11 tests in `codebase_rag/tests/test_js_commonjs_direct_function_export_call.py`: the direct, anonymous-arrow and object-export forms, both IIFE spellings, the collision variant, in-function silence and no-alias, re-index map clearing, and the sparse-resurrection guard (RED against the watch-mode removal sequence).
- Full non-integration suite green, `pytest -n auto`.
- Real-repo verification on fastify: dead-code candidates 36 to 34 relative to main; both `error-serializer` candidates (`anonymous`, `anonymous0`) revived through the module-load CALLS edge and the internal reference.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved JavaScript/CommonJS support for modules that export a function directly.
  - Added more accurate linking when importing and calling these exported functions, including wrapped and immediately invoked functions.

- **Bug Fixes**
  - Prevented stale export references after files are reprocessed or removed.
  - Preserved correct behavior for object exports and avoided incorrect matches for nested functions or naming collisions.

- **Tests**
  - Added comprehensive coverage for direct exports, aliases, wrappers, reindexing, and related edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->