### PR TITLE
fix: root well-known symbol members in dead-code analysis

### DIFF
--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -197,6 +197,11 @@ TS_JS_TERNARY_EXPRESSION = "ternary_expression"
 # Short-circuit operators whose result IS one of the operands, so a
 # bind through them unions both operands' taints.
 JS_SHORT_CIRCUIT_OPERATORS: frozenset[str] = frozenset({"||", "??", "&&"})
+# The computed-name leaf prefix of a well-known-symbol class member
+# (`[Symbol.iterator]`, `[Symbol.toStringTag]`) as the definition pass
+# registers it; user symbol keys register without the `Symbol.` path.
+JS_WELL_KNOWN_SYMBOL_NAME_PREFIX = "[Symbol."
+JS_COMPUTED_NAME_SUFFIX = "]"
 # `&&` alone among them cannot yield its LEFT operand as a function value.
 JS_OPERATOR_LOGICAL_AND = "&&"
 TS_JS_ELSE_CLAUSE = "else_clause"

--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -202,6 +202,7 @@ JS_SHORT_CIRCUIT_OPERATORS: frozenset[str] = frozenset({"||", "??", "&&"})
 # registers it; user symbol keys register without the `Symbol.` path.
 JS_WELL_KNOWN_SYMBOL_NAME_PREFIX = "[Symbol."
 JS_COMPUTED_NAME_SUFFIX = "]"
+JS_WELL_KNOWN_SYMBOL_BRACKET_PREFIX = "[Symbol["
 # `&&` alone among them cannot yield its LEFT operand as a function value.
 JS_OPERATOR_LOGICAL_AND = "&&"
 TS_JS_ELSE_CLAUSE = "else_clause"

--- a/codebase_rag/dead_code.py
+++ b/codebase_rag/dead_code.py
@@ -132,12 +132,15 @@ def _is_js_well_known_symbol_root(name: str, is_method: bool, path: str) -> bool
     # the `Symbol.` path and stays ordinary code.
     if not is_method or not path.endswith(_JS_TS_EXTS):
         return False
-    # Formatting must not decide (`[ Symbol.iterator ]`, `[Symbol["iterator"]]`
-    # spell the same protocol member): compare whitespace-free, accepting the
-    # dotted and the bracket-notation access off the Symbol global. A string
-    # key (`['Symbol.fake']`) or user symbol variable (`[mySym]`) keeps its
-    # own spelling and never matches.
-    compact = name.replace(" ", "")
+    # Formatting must not decide (`[ Symbol.iterator ]`, `[\tSymbol.iterator\t]`,
+    # `[Symbol["iterator"]]` spell the same protocol member): compare free of
+    # ALL whitespace, accepting the dotted and the bracket-notation access off
+    # the Symbol global. Deliberately any Symbol access, not an allowlist of
+    # the well-known set: `Symbol.for(...)` registry members (Node invokes
+    # `Symbol.for('nodejs.util.inspect.custom')`) are runtime-reached too. A
+    # string key (`['Symbol.fake']`) or user symbol variable (`[mySym]`) keeps
+    # its own spelling and never matches.
+    compact = "".join(name.split())
     return compact.endswith(cs.JS_COMPUTED_NAME_SUFFIX) and (
         compact.startswith(cs.JS_WELL_KNOWN_SYMBOL_NAME_PREFIX)
         or compact.startswith(cs.JS_WELL_KNOWN_SYMBOL_BRACKET_PREFIX)

--- a/codebase_rag/dead_code.py
+++ b/codebase_rag/dead_code.py
@@ -130,11 +130,17 @@ def _is_js_well_known_symbol_root(name: str, is_method: bool, path: str) -> bool
     # computed-name brackets, so the `[Symbol.` prefix on a JS/TS file
     # identifies exactly these members; a user symbol key registers without
     # the `Symbol.` path and stays ordinary code.
-    return (
-        is_method
-        and path.endswith(cs.JS_TS_ALL_EXTENSIONS)
-        and name.startswith(cs.JS_WELL_KNOWN_SYMBOL_NAME_PREFIX)
-        and name.endswith(cs.JS_COMPUTED_NAME_SUFFIX)
+    if not is_method or not path.endswith(_JS_TS_EXTS):
+        return False
+    # Formatting must not decide (`[ Symbol.iterator ]`, `[Symbol["iterator"]]`
+    # spell the same protocol member): compare whitespace-free, accepting the
+    # dotted and the bracket-notation access off the Symbol global. A string
+    # key (`['Symbol.fake']`) or user symbol variable (`[mySym]`) keeps its
+    # own spelling and never matches.
+    compact = name.replace(" ", "")
+    return compact.endswith(cs.JS_COMPUTED_NAME_SUFFIX) and (
+        compact.startswith(cs.JS_WELL_KNOWN_SYMBOL_NAME_PREFIX)
+        or compact.startswith(cs.JS_WELL_KNOWN_SYMBOL_BRACKET_PREFIX)
     )
 
 

--- a/codebase_rag/dead_code.py
+++ b/codebase_rag/dead_code.py
@@ -121,6 +121,23 @@ def _is_cpp_operator_root(name: str, path: str) -> bool:
     return name.startswith(cs.CPP_OPERATOR_PREFIX) and path.endswith(cs.CPP_EXTENSIONS)
 
 
+def _is_js_well_known_symbol_root(name: str, is_method: bool, path: str) -> bool:
+    # A JS/TS class member keyed by a well-known symbol (`[Symbol.iterator]`,
+    # `get [Symbol.toStringTag]`) is invoked implicitly by the language
+    # runtime (iteration protocol, Object.prototype.toString, using/dispose),
+    # never by a name the graph can see, so it is a reachability root (like
+    # Python dunders / Rust trait methods). The registered leaf keeps the
+    # computed-name brackets, so the `[Symbol.` prefix on a JS/TS file
+    # identifies exactly these members; a user symbol key registers without
+    # the `Symbol.` path and stays ordinary code.
+    return (
+        is_method
+        and path.endswith(cs.JS_TS_ALL_EXTENSIONS)
+        and name.startswith(cs.JS_WELL_KNOWN_SYMBOL_NAME_PREFIX)
+        and name.endswith(cs.JS_COMPUTED_NAME_SUFFIX)
+    )
+
+
 def _is_java_serialization_root(name: str, is_method: bool, path: str) -> bool:
     # A Java serialization hook (`readObject`/`writeObject`/`writeReplace`/
     # `readResolve`/`readObjectNoData`) is invoked reflectively by the java.io
@@ -415,6 +432,13 @@ def dead_code_from_graph(
             roots.add(qn)
         elif _is_rust_runtime_root(leaf, qn in method_qns, path):
             roots.add(qn)
+        # NOT leaf-based: the computed name contains a dot, so the qn's
+        # last dotted segment is `toStringTag]`; match on the bracketed
+        # member name as registered.
+        elif _is_js_well_known_symbol_root(
+            str(props.get(cs.KEY_NAME) or ""), qn in method_qns, path
+        ):
+            roots.add(qn)
         elif _is_cpp_operator_root(leaf, path) or _is_c_cpp_entry_root(
             leaf, qn in method_qns, path, qn, project_prefix
         ):
@@ -568,6 +592,10 @@ def _node_props(row: ResultRow) -> PropertyDict:
     # reads are kept; the report is built from the raw rows.
     return {
         cs.KEY_PATH: str(row.get(cs.KEY_PATH) or ""),
+        # The registered member NAME survives here because a computed
+        # well-known-symbol name (`[Symbol.toStringTag]`) contains a dot and
+        # cannot be recovered from the qn's last dotted segment.
+        cs.KEY_NAME: str(row.get(cs.KEY_NAME) or ""),
         cs.KEY_DECORATORS: _as_str_list(row.get(cs.KEY_DECORATORS)),
         cs.KEY_IS_EXPORTED: row.get(cs.KEY_IS_EXPORTED) is True,
         cs.KEY_OVERRIDES_EXTERNAL: row.get(cs.KEY_OVERRIDES_EXTERNAL) is True,

--- a/codebase_rag/tests/test_dead_code_js_symbol_roots.py
+++ b/codebase_rag/tests/test_dead_code_js_symbol_roots.py
@@ -1,0 +1,84 @@
+# Class members keyed by well-known symbols (`get [Symbol.toStringTag] ()`,
+# `[Symbol.iterator] ()`) are invoked implicitly by the JavaScript runtime;
+# no source-level call site can exist, so they are reachability roots, not
+# dead code. Found dogfooding fastify (`ContentType.[Symbol.toStringTag]`).
+# Issue #993.
+from __future__ import annotations
+
+from codebase_rag import constants as cs
+from codebase_rag import cypher_queries as cq
+from codebase_rag.dead_code import collect_dead_code, default_dead_code_config
+from codebase_rag.types_defs import ResultRow
+
+_METHOD = cs.NodeLabel.METHOD.value
+
+
+class FakeIngestor:
+    def __init__(self, nodes: list[ResultRow], rels: list[ResultRow]) -> None:
+        self._nodes = nodes
+        self._rels = rels
+
+    def fetch_all(
+        self, query: str, params: dict[str, str] | None = None
+    ) -> list[ResultRow]:
+        if query == cq.CYPHER_DEAD_CODE_NODES:
+            return self._nodes
+        return self._rels
+
+
+def _method(qn: str, name: str, path: str) -> ResultRow:
+    return {
+        "label": _METHOD,
+        "qualified_name": qn,
+        "name": name,
+        "path": path,
+        "start_line": 1,
+        "end_line": 2,
+        "decorators": [],
+        "is_exported": False,
+        "overrides_external": False,
+    }
+
+
+def _collect(nodes: list[ResultRow]) -> set[str]:
+    rows = collect_dead_code(
+        FakeIngestor(nodes, []),
+        "proj",
+        default_dead_code_config(include_tests=True, include_classes=False),
+    )
+    return {row["qualified_name"] for row in rows}
+
+
+def test_well_known_symbol_members_are_roots() -> None:
+    dead = _collect(
+        [
+            _method(
+                "proj.ct.ContentType.[Symbol.toStringTag]",
+                "[Symbol.toStringTag]",
+                "lib/content-type.js",
+            ),
+            _method(
+                "proj.ct.Box.[Symbol.iterator]",
+                "[Symbol.iterator]",
+                "lib/box.ts",
+            ),
+        ]
+    )
+    assert "proj.ct.ContentType.[Symbol.toStringTag]" not in dead
+    assert "proj.ct.Box.[Symbol.iterator]" not in dead
+
+
+def test_ordinary_uncalled_method_still_reports() -> None:
+    dead = _collect(
+        [_method("proj.ct.ContentType.parse", "parse", "lib/content-type.js")]
+    )
+    assert "proj.ct.ContentType.parse" in dead
+
+
+def test_symbol_name_on_non_js_path_still_reports() -> None:
+    # The bracket pattern is JS/TS syntax; a same-named symbol elsewhere is
+    # ordinary code.
+    dead = _collect(
+        [_method("proj.x.C.[Symbol.toStringTag]", "[Symbol.toStringTag]", "x/c.py")]
+    )
+    assert "proj.x.C.[Symbol.toStringTag]" in dead

--- a/codebase_rag/tests/test_dead_code_js_symbol_roots.py
+++ b/codebase_rag/tests/test_dead_code_js_symbol_roots.py
@@ -82,3 +82,36 @@ def test_symbol_name_on_non_js_path_still_reports() -> None:
         [_method("proj.x.C.[Symbol.toStringTag]", "[Symbol.toStringTag]", "x/c.py")]
     )
     assert "proj.x.C.[Symbol.toStringTag]" in dead
+
+
+def test_spaced_and_bracket_notation_variants_are_roots() -> None:
+    # `[ Symbol.iterator ]` and `[Symbol["iterator"]]` are the same runtime
+    # protocol member spelled differently; formatting must not decide.
+    dead = _collect(
+        [
+            _method(
+                "proj.a.Spaced.[ Symbol.iterator ]",
+                "[ Symbol.iterator ]",
+                "a/s.ts",
+            ),
+            _method(
+                'proj.a.Bracketed.[Symbol["iterator"]]',
+                '[Symbol["iterator"]]',
+                "a/b.ts",
+            ),
+        ]
+    )
+    assert not dead
+
+
+def test_near_miss_names_still_report() -> None:
+    # A STRING key spelling `'Symbol.fake'` and a user symbol variable are
+    # ordinary members: no runtime protocol invokes them.
+    dead = _collect(
+        [
+            _method("proj.a.C.['Symbol.fake']", "['Symbol.fake']", "a/c.ts"),
+            _method("proj.a.C.[mySym]", "[mySym]", "a/c.ts"),
+        ]
+    )
+    assert "proj.a.C.['Symbol.fake']" in dead
+    assert "proj.a.C.[mySym]" in dead

--- a/codebase_rag/tests/test_dead_code_js_symbol_roots.py
+++ b/codebase_rag/tests/test_dead_code_js_symbol_roots.py
@@ -104,6 +104,43 @@ def test_spaced_and_bracket_notation_variants_are_roots() -> None:
     assert not dead
 
 
+def test_tab_and_newline_formatting_variants_are_roots() -> None:
+    # Formatters can put any whitespace inside the computed brackets; tabs and
+    # line terminators must normalise away exactly like spaces.
+    dead = _collect(
+        [
+            _method(
+                "proj.a.Tabbed.[\tSymbol.iterator\t]",
+                "[\tSymbol.iterator\t]",
+                "a/t.ts",
+            ),
+            _method(
+                "proj.a.Wrapped.[\n  Symbol.asyncIterator\n]",
+                "[\n  Symbol.asyncIterator\n]",
+                "a/w.js",
+            ),
+        ]
+    )
+    assert not dead
+
+
+def test_symbol_registry_members_are_roots() -> None:
+    # `Symbol.for(...)` registry symbols are invoked by runtime consumers the
+    # graph cannot see (Node's util.inspect invokes
+    # `Symbol.for('nodejs.util.inspect.custom')` members). The predicate is
+    # deliberately any-Symbol-access, not an allowlist of the well-known set.
+    dead = _collect(
+        [
+            _method(
+                "proj.a.C.[Symbol.for('nodejs.util.inspect.custom')]",
+                "[Symbol.for('nodejs.util.inspect.custom')]",
+                "a/c.js",
+            )
+        ]
+    )
+    assert not dead
+
+
 def test_near_miss_names_still_report() -> None:
     # A STRING key spelling `'Symbol.fake'` and a user symbol variable are
     # ordinary members: no runtime protocol invokes them.

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.518"
+version = "0.0.520"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.517"
+version = "0.0.518"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Fixes #993.

## Problem

Class members keyed by well-known symbols, `get [Symbol.toStringTag] ()`, `[Symbol.iterator] ()`, `[Symbol.asyncDispose] ()`, are invoked implicitly by the JavaScript runtime; no source-level call site can exist, so dead-code analysis flagged them. Witness: fastify's `ContentType.[Symbol.toStringTag]`.

## Fix

A new liveness-root predicate in the dead-code engine, following the existing per-language pattern (Python dunders, Rust trait methods, C++ operators, Java serialisation hooks): a METHOD on a JS/TS file whose registered NAME is a computed `Symbol` member is a reachability root. Matching is whitespace-free and accepts both the dotted (`[Symbol.iterator]`) and bracket-notation (`[Symbol["iterator"]]`) spellings; string keys (`['Symbol.fake']`) and user symbol variables (`[mySym]`) keep their own spellings and never match. The member NAME is now threaded through `_node_props`, because the computed name contains a dot and cannot be recovered from the qn's last dotted segment.

## Validation

- 5 tests in `codebase_rag/tests/test_dead_code_js_symbol_roots.py`: the root rule, formatting variants, near-miss negatives, an ordinary-method guard, and a non-JS-path guard.
- Adversarial review verified the registered-name shapes against the live pipeline for eleven member spellings (generators, static, getters/setters, `Symbol.for`, dispose family) and confirmed the fastify effect is exactly the one intended node leaving the dead list, with typeorm, NestJS and zod dead sets byte-identical.
- Full non-integration suite green, `pytest -n auto`.
- Discovered and filed separately: #998 (object-literal computed symbol members register with a mangled name).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dead-code detection for JavaScript and TypeScript methods used through well-known symbols, such as iterators and type tags.
  * Recognizes common formatting and bracket-notation variants while continuing to report ordinary or unrelated uncalled methods.

* **Tests**
  * Added coverage for well-known symbol methods, formatting variations, near-matches, and non-JavaScript files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->