### PR TITLE
fix: type factory returns that flow through reassigned locals

### DIFF
--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -228,6 +228,8 @@ TS_REST_PATTERN = "rest_pattern"
 TS_SHORTHAND_PROPERTY_IDENTIFIER_PATTERN = "shorthand_property_identifier_pattern"
 TS_SHORTHAND_PROPERTY_IDENTIFIER = "shorthand_property_identifier"
 TS_PAIR_PATTERN = "pair_pattern"
+# `{ a = dflt }` in a destructuring pattern: `left` binds, `right` is a READ.
+TS_OBJECT_ASSIGNMENT_PATTERN = "object_assignment_pattern"
 # `process.env.X` is a member_expression; `process.env['X']` a subscript, used
 # to detect environment-variable reads (issue #714 process.env follow-up).
 TS_SUBSCRIPT_EXPRESSION = "subscript_expression"

--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -194,6 +194,10 @@ TS_JS_SWITCH_DEFAULT = "switch_default"
 # `c ? a : b` (shared name with the Java grammar); C++ spells it
 # conditional_expression.
 TS_JS_TERNARY_EXPRESSION = "ternary_expression"
+# tree-sitter-javascript parses `await (X)()` as a CALL to an identifier
+# spelled `await` with X as its argument (the TS grammar does not); climbs
+# treat that call as the transparent await it denotes.
+JS_AWAIT_IDENTIFIER = "await"
 # Short-circuit operators whose result IS one of the operands, so a
 # bind through them unions both operands' taints.
 JS_SHORT_CIRCUIT_OPERATORS: frozenset[str] = frozenset({"||", "??", "&&"})

--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -205,6 +205,10 @@ TS_JS_FOR_STATEMENT = "for_statement"
 TS_JS_FOR_IN_STATEMENT = "for_in_statement"
 TS_JS_TRY_STATEMENT = "try_statement"
 TS_JS_CATCH_CLAUSE = "catch_clause"
+TS_JS_SWITCH_BODY = "switch_body"
+# `for (var x of xs)` hoists x to the function; only this `kind` widens the
+# loop binding's scope past the for statement itself.
+TS_JS_VAR_KIND = "var"
 TS_JS_FINALLY_CLAUSE = "finally_clause"
 FIELD_ALTERNATIVE = "alternative"
 FIELD_HANDLER = "handler"

--- a/codebase_rag/constants/ast_nodes.py
+++ b/codebase_rag/constants/ast_nodes.py
@@ -89,6 +89,7 @@ FIELD_PARAMETERS = "parameters"
 # A JS/TS arrow with a single bare-identifier parameter (`x => ...`) carries it
 # in the singular `parameter` field, with no formal_parameters wrapper.
 FIELD_PARAMETER = "parameter"
+FIELD_KIND = "kind"
 FIELD_RECEIVER = "receiver"
 FIELD_TYPE = "type"
 # The wrapped function/class inside a Python decorated_definition node.

--- a/codebase_rag/parsers/js_ts/type_inference.py
+++ b/codebase_rag/parsers/js_ts/type_inference.py
@@ -12,6 +12,12 @@ from ...types_defs import ASTNode, FunctionRegistryTrieProtocol, NodeType
 from ..utils import get_cached_query, safe_decode_text
 from . import utils as ut
 
+# Callable node types whose bodies own their locals and returns; the shared
+# JS_TS_FUNCTION_NODES tuple lacks the generator EXPRESSION form.
+_JS_NESTED_CALLABLE_TYPES = frozenset(cs.JS_TS_FUNCTION_NODES) | {
+    cs.TS_GENERATOR_FUNCTION
+}
+
 if TYPE_CHECKING:
     from ...types_defs import LanguageQueries
     from ..import_processor import ImportProcessor
@@ -26,7 +32,6 @@ class JsTypeInferenceEngine:
         "project_name",
         "_find_method_ast_node",
         "_queries",
-        "_ctor_binding_maps",
     )
 
     def __init__(
@@ -42,10 +47,6 @@ class JsTypeInferenceEngine:
         self.project_name = project_name
         self._find_method_ast_node = find_method_ast_node_func
         self._queries = queries
-        # Per-method map of local name -> the single `new C(...)` bound to it
-        # (None marks a conflict), built once per method for the identifier
-        # return inference; keyed by the method node's stable id.
-        self._ctor_binding_maps: dict[int, dict[str, ASTNode | None]] = {}
 
     def _get_declarators_via_query(
         self, caller_node: ASTNode, language: cs.SupportedLanguage | None = None
@@ -255,6 +256,12 @@ class JsTypeInferenceEngine:
         return_nodes: list[ASTNode] = []
         ut.find_return_statements(method_node, return_nodes, self._get_language_obj())
 
+        # One O(body) scan shared by every `return <identifier>` in this
+        # method; deliberately NOT stored on the engine: a tree-sitter node id
+        # is a recycled heap address across parses, and holding Node values
+        # would pin whole trees against the bounded AST cache.
+        ctor_bindings: dict[str, ASTNode | None] | None = None
+
         for return_node in return_nodes:
             for child in return_node.children:
                 if child.type == cs.TS_RETURN:
@@ -274,9 +281,12 @@ class JsTypeInferenceEngine:
                     child.type == cs.TS_IDENTIFIER
                     and self._return_belongs_to(return_node, method_node)
                     and (name := safe_decode_text(child))
-                    and (constructed := self._js_ctor_bindings(method_node).get(name))
-                    is not None
                 ):
+                    if ctor_bindings is None:
+                        ctor_bindings = self._js_ctor_bindings(method_node)
+                    constructed = ctor_bindings.get(name)
+                    if constructed is None:
+                        continue
                     ctor = ut.extract_constructor_name(constructed)
                     if ctor:
                         own_qn = ut.analyze_return_expression(constructed, method_qn)
@@ -305,20 +315,18 @@ class JsTypeInferenceEngine:
     def _return_belongs_to(return_node: ASTNode, method_node: ASTNode) -> bool:
         current = return_node.parent
         while current is not None:
-            if current.type in cs.JS_TS_FUNCTION_NODES:
+            if current.type in _JS_NESTED_CALLABLE_TYPES:
                 return current.id == method_node.id
             current = current.parent
         return False
 
     def _js_ctor_bindings(self, method_node: ASTNode) -> dict[str, ASTNode | None]:
-        cached = self._ctor_binding_maps.get(method_node.id)
-        if cached is not None:
-            return cached
+        body = method_node.child_by_field_name(cs.FIELD_BODY)
         bindings: dict[str, ASTNode | None] = {}
         stack: list[ASTNode] = list(method_node.children)
         while stack:
             node = stack.pop()
-            if node.type in cs.JS_TS_FUNCTION_NODES:
+            if node.type in _JS_NESTED_CALLABLE_TYPES:
                 # A nested callable's locals are its own.
                 continue
             target_value: tuple[ASTNode | None, ASTNode | None] | None = None
@@ -341,13 +349,27 @@ class JsTypeInferenceEngine:
                     and value.type == cs.TS_NEW_EXPRESSION
                     and (bound_name := safe_decode_text(target))
                 ):
-                    ctor = ut.extract_constructor_name(value)
-                    if bound_name not in bindings:
+                    if (
+                        node.type == cs.TS_VARIABLE_DECLARATOR
+                        and node.parent is not None
+                        and node.parent.type == cs.TS_LEXICAL_DECLARATION
+                        and (
+                            body is None
+                            or node.parent.parent is None
+                            or node.parent.parent.id != body.id
+                        )
+                    ):
+                        # A `let`/`const` in a NESTED block is a DIFFERENT
+                        # variable; it can never type the method's return,
+                        # and its existence makes the name unknowable here.
+                        bindings[bound_name] = None
+                    elif bound_name not in bindings:
                         bindings[bound_name] = value
                     else:
                         prior = bindings[bound_name]
-                        if prior is None or ut.extract_constructor_name(prior) != ctor:
+                        if prior is None or ut.extract_constructor_name(
+                            prior
+                        ) != ut.extract_constructor_name(value):
                             bindings[bound_name] = None
             stack.extend(node.children)
-        self._ctor_binding_maps[method_node.id] = bindings
         return bindings

--- a/codebase_rag/parsers/js_ts/type_inference.py
+++ b/codebase_rag/parsers/js_ts/type_inference.py
@@ -381,6 +381,9 @@ class JsTypeInferenceEngine:
     def _js_enclosing_invocation(owner: ASTNode) -> ASTNode | None:
         # Climb value-transparent wrappers; at a call, require the wrapped
         # owner to BE the callee (not an argument, not one operand of many).
+        # The one argument-position exception: the JS grammar parses
+        # `await (X)()` as a call to an identifier spelled `await` with X as
+        # its sole argument, so that call IS a transparent await of X.
         node = owner
         current = owner.parent
         while current is not None:
@@ -391,6 +394,23 @@ class JsTypeInferenceEngine:
                 node = current
                 current = current.parent
                 continue
+            if current.type == cs.TS_ARGUMENTS:
+                call = current.parent
+                func = (
+                    call.child_by_field_name(cs.FIELD_FUNCTION)
+                    if call is not None and call.type == cs.TS_CALL_EXPRESSION
+                    else None
+                )
+                if (
+                    call is not None
+                    and func is not None
+                    and func.type == cs.TS_IDENTIFIER
+                    and safe_decode_text(func) == cs.JS_AWAIT_IDENTIFIER
+                ):
+                    node = call
+                    current = call.parent
+                    continue
+                return None
             if current.type == cs.TS_CALL_EXPRESSION:
                 func = current.child_by_field_name(cs.FIELD_FUNCTION)
                 if func is not None and func.id == node.id:

--- a/codebase_rag/parsers/js_ts/type_inference.py
+++ b/codebase_rag/parsers/js_ts/type_inference.py
@@ -284,8 +284,13 @@ class JsTypeInferenceEngine:
         for return_node in return_nodes:
             # Nested callables own their returns: a callback's `return new
             # Foo()` (or `return x`) is the callback's value, never the
-            # method's, so BOTH branches below are gated here.
-            if not self._return_belongs_to(return_node, method_node):
+            # method's. The ONE exception is an IIFE whose call value the
+            # method itself returns (`return (function () { return new C()
+            # })()`): its direct-expression returns ARE the method's value.
+            owner_is_method = self._return_belongs_to(return_node, method_node)
+            if not owner_is_method and not self._iife_return_of(
+                return_node, method_node
+            ):
                 continue
             for child in return_node.children:
                 if child.type == cs.TS_RETURN:
@@ -293,6 +298,11 @@ class JsTypeInferenceEngine:
 
                 if inferred_type := ut.analyze_return_expression(child, method_qn):
                     return inferred_type
+
+                if not owner_is_method:
+                    # An IIFE's `return x` reads the IIFE's OWN locals; the
+                    # method-body binding index says nothing about them.
+                    continue
 
                 # `return x` where the METHOD'S OWN body binds `x = new
                 # C(...)` (the cache-then-construct factory, fastify's
@@ -343,6 +353,67 @@ class JsTypeInferenceEngine:
                 return current.id == method_node.id
             current = current.parent
         return False
+
+    def _iife_return_of(self, return_node: ASTNode, method_node: ASTNode) -> bool:
+        # True when the return's owning callable is immediately invoked and
+        # the call's value is returned by the method itself, so the inner
+        # return IS the method's return value. A callback ARGUMENT never
+        # qualifies: its owner is not the callee of any enclosing call.
+        owner = self._js_owning_callable(return_node)
+        if owner is None or owner.id == method_node.id:
+            return False
+        call = self._js_enclosing_invocation(owner)
+        if call is None:
+            return False
+        consumer = self._js_value_consumer_return(call)
+        return consumer is not None and self._return_belongs_to(consumer, method_node)
+
+    @staticmethod
+    def _js_owning_callable(return_node: ASTNode) -> ASTNode | None:
+        current = return_node.parent
+        while current is not None:
+            if current.type in _JS_NESTED_CALLABLE_TYPES:
+                return current
+            current = current.parent
+        return None
+
+    @staticmethod
+    def _js_enclosing_invocation(owner: ASTNode) -> ASTNode | None:
+        # Climb value-transparent wrappers; at a call, require the wrapped
+        # owner to BE the callee (not an argument, not one operand of many).
+        node = owner
+        current = owner.parent
+        while current is not None:
+            if (
+                current.type == cs.TS_PARENTHESIZED_EXPRESSION
+                or current.type in cs.TS_CAST_WRAPPER_TYPES
+            ):
+                node = current
+                current = current.parent
+                continue
+            if current.type == cs.TS_CALL_EXPRESSION:
+                func = current.child_by_field_name(cs.FIELD_FUNCTION)
+                if func is not None and func.id == node.id:
+                    return current
+                return None
+            return None
+        return None
+
+    @staticmethod
+    def _js_value_consumer_return(call: ASTNode) -> ASTNode | None:
+        current = call.parent
+        while current is not None:
+            if (
+                current.type == cs.TS_PARENTHESIZED_EXPRESSION
+                or current.type in cs.TS_CAST_WRAPPER_TYPES
+                or current.type == cs.TS_AWAIT_EXPRESSION
+            ):
+                current = current.parent
+                continue
+            if current.type == cs.TS_RETURN_STATEMENT:
+                return current
+            return None
+        return None
 
     def _js_ctor_binding_index(self, method_node: ASTNode) -> _CtorBindingIndex:
         # One scan of the method body (nested callables excluded: their
@@ -438,21 +509,35 @@ class JsTypeInferenceEngine:
 
     @staticmethod
     def _js_binding_names(target: ASTNode) -> list[str]:
-        if target.type == cs.TS_IDENTIFIER:
-            name = safe_decode_text(target)
-            return [name] if name else []
+        # Only BINDING positions introduce names: a pattern default's right
+        # side, a computed key's expression, and a pair's key are READS of
+        # the enclosing scope and must not shadow it.
         names: list[str] = []
-        stack: list[ASTNode] = list(target.children)
+        stack: list[ASTNode] = [target]
         while stack:
             node = stack.pop()
-            if node.type in (
+            node_type = node.type
+            if node_type in (
                 cs.TS_IDENTIFIER,
                 cs.TS_SHORTHAND_PROPERTY_IDENTIFIER_PATTERN,
             ):
                 if name := safe_decode_text(node):
                     names.append(name)
-                continue
-            stack.extend(node.children)
+            elif node_type in (
+                cs.TS_ASSIGNMENT_PATTERN,
+                cs.TS_OBJECT_ASSIGNMENT_PATTERN,
+            ):
+                if (left := node.child_by_field_name(cs.FIELD_LEFT)) is not None:
+                    stack.append(left)
+            elif node_type == cs.TS_PAIR_PATTERN:
+                if (value := node.child_by_field_name(cs.FIELD_VALUE)) is not None:
+                    stack.append(value)
+            elif node_type in (
+                cs.TS_OBJECT_PATTERN,
+                cs.TS_ARRAY_PATTERN,
+                cs.TS_REST_PATTERN,
+            ):
+                stack.extend(node.named_children)
         return names
 
     @staticmethod
@@ -498,11 +583,15 @@ class JsTypeInferenceEngine:
         for site, value in assigns.get(name, []):
             if self._js_innermost_scope(entries, site) == scope:
                 constructions.append(value)
+        # A construction whose class name cannot be extracted (`new
+        # registry.Cached(v)`) is an UNKNOWN class: it vetoes exactly like a
+        # different named class, never silently loses to one.
         ctor_names = {ut.extract_constructor_name(value) for value in constructions}
-        ctor_names.discard(None)
         if len(ctor_names) != 1:
             return None
         chosen = ctor_names.pop()
+        if chosen is None:
+            return None
         return next(
             value
             for value in constructions

--- a/codebase_rag/parsers/js_ts/type_inference.py
+++ b/codebase_rag/parsers/js_ts/type_inference.py
@@ -26,6 +26,7 @@ class JsTypeInferenceEngine:
         "project_name",
         "_find_method_ast_node",
         "_queries",
+        "_ctor_binding_maps",
     )
 
     def __init__(
@@ -41,6 +42,10 @@ class JsTypeInferenceEngine:
         self.project_name = project_name
         self._find_method_ast_node = find_method_ast_node_func
         self._queries = queries
+        # Per-method map of local name -> the single `new C(...)` bound to it
+        # (None marks a conflict), built once per method for the identifier
+        # return inference; keyed by the method node's stable id.
+        self._ctor_binding_maps: dict[int, dict[str, ASTNode | None]] = {}
 
     def _get_declarators_via_query(
         self, caller_node: ASTNode, language: cs.SupportedLanguage | None = None
@@ -258,39 +263,64 @@ class JsTypeInferenceEngine:
                 if inferred_type := ut.analyze_return_expression(child, method_qn):
                     return inferred_type
 
-                # `return x` where the body assigns `x = new C(...)` (the
-                # cache-then-construct factory, fastify's ContentType.from,
-                # issue #992): the constructed class types the return when
-                # every construction bound to x agrees. Assignments of
-                # UNKNOWN values (the cache hit) do not veto: the cached
-                # instance is the same constructed type in practice, and a
-                # conflicting second class does veto below.
-                if child.type == cs.TS_IDENTIFIER and (
-                    constructed := self._sole_constructed_binding(
-                        method_node, safe_decode_text(child)
-                    )
+                # `return x` where the METHOD'S OWN body binds `x = new
+                # C(...)` (the cache-then-construct factory, fastify's
+                # ContentType.from, issue #992): the CONSTRUCTED class types
+                # the return when every construction bound to x agrees.
+                # Unknown-value assignments (the cache hit) do not veto; a
+                # second DIFFERENT class does. Nested callables own their
+                # locals and their returns, so both are excluded.
+                if (
+                    child.type == cs.TS_IDENTIFIER
+                    and self._return_belongs_to(return_node, method_node)
+                    and (name := safe_decode_text(child))
+                    and (constructed := self._js_ctor_bindings(method_node).get(name))
+                    is not None
                 ):
-                    if inferred_type := ut.analyze_return_expression(
-                        constructed, method_qn
-                    ):
-                        return inferred_type
+                    ctor = ut.extract_constructor_name(constructed)
+                    if ctor:
+                        own_qn = ut.analyze_return_expression(constructed, method_qn)
+                        own_leaf = (
+                            own_qn.rsplit(cs.SEPARATOR_DOT, 1)[-1] if own_qn else None
+                        )
+                        # analyze_return_expression resolves a NEW to the
+                        # method's OWN class; keep that qn precision only
+                        # when the constructed class IS the own class.
+                        # Otherwise resolve the constructed class in the
+                        # FACTORY'S module (where the construction names it),
+                        # falling back to the bare name.
+                        if ctor == own_leaf:
+                            return own_qn
+                        if own_qn and cs.SEPARATOR_DOT in own_qn:
+                            factory_module = own_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
+                            if resolved := self._resolve_js_class_name(
+                                ctor, factory_module
+                            ):
+                                return resolved
+                        return ctor
 
         return None
 
     @staticmethod
-    def _sole_constructed_binding(
-        method_node: ASTNode, name: str | None
-    ) -> ASTNode | None:
-        # The single `new C(...)` bound to local `name` anywhere in this
-        # method (declarator value or assignment right), or None when there
-        # is no construction or two constructions of DIFFERENT classes.
-        if not name:
-            return None
-        found: ASTNode | None = None
-        found_ctor: str | None = None
+    def _return_belongs_to(return_node: ASTNode, method_node: ASTNode) -> bool:
+        current = return_node.parent
+        while current is not None:
+            if current.type in cs.JS_TS_FUNCTION_NODES:
+                return current.id == method_node.id
+            current = current.parent
+        return False
+
+    def _js_ctor_bindings(self, method_node: ASTNode) -> dict[str, ASTNode | None]:
+        cached = self._ctor_binding_maps.get(method_node.id)
+        if cached is not None:
+            return cached
+        bindings: dict[str, ASTNode | None] = {}
         stack: list[ASTNode] = list(method_node.children)
         while stack:
             node = stack.pop()
+            if node.type in cs.JS_TS_FUNCTION_NODES:
+                # A nested callable's locals are its own.
+                continue
             target_value: tuple[ASTNode | None, ASTNode | None] | None = None
             if node.type == cs.TS_VARIABLE_DECLARATOR:
                 target_value = (
@@ -308,14 +338,16 @@ class JsTypeInferenceEngine:
                     target is not None
                     and value is not None
                     and target.type == cs.TS_IDENTIFIER
-                    and safe_decode_text(target) == name
                     and value.type == cs.TS_NEW_EXPRESSION
+                    and (bound_name := safe_decode_text(target))
                 ):
                     ctor = ut.extract_constructor_name(value)
-                    if found is None:
-                        found = value
-                        found_ctor = ctor
-                    elif ctor != found_ctor:
-                        return None
+                    if bound_name not in bindings:
+                        bindings[bound_name] = value
+                    else:
+                        prior = bindings[bound_name]
+                        if prior is None or ut.extract_constructor_name(prior) != ctor:
+                            bindings[bound_name] = None
             stack.extend(node.children)
-        return found
+        self._ctor_binding_maps[method_node.id] = bindings
+        return bindings

--- a/codebase_rag/parsers/js_ts/type_inference.py
+++ b/codebase_rag/parsers/js_ts/type_inference.py
@@ -258,4 +258,64 @@ class JsTypeInferenceEngine:
                 if inferred_type := ut.analyze_return_expression(child, method_qn):
                     return inferred_type
 
+                # `return x` where the body assigns `x = new C(...)` (the
+                # cache-then-construct factory, fastify's ContentType.from,
+                # issue #992): the constructed class types the return when
+                # every construction bound to x agrees. Assignments of
+                # UNKNOWN values (the cache hit) do not veto: the cached
+                # instance is the same constructed type in practice, and a
+                # conflicting second class does veto below.
+                if child.type == cs.TS_IDENTIFIER and (
+                    constructed := self._sole_constructed_binding(
+                        method_node, safe_decode_text(child)
+                    )
+                ):
+                    if inferred_type := ut.analyze_return_expression(
+                        constructed, method_qn
+                    ):
+                        return inferred_type
+
         return None
+
+    @staticmethod
+    def _sole_constructed_binding(
+        method_node: ASTNode, name: str | None
+    ) -> ASTNode | None:
+        # The single `new C(...)` bound to local `name` anywhere in this
+        # method (declarator value or assignment right), or None when there
+        # is no construction or two constructions of DIFFERENT classes.
+        if not name:
+            return None
+        found: ASTNode | None = None
+        found_ctor: str | None = None
+        stack: list[ASTNode] = list(method_node.children)
+        while stack:
+            node = stack.pop()
+            target_value: tuple[ASTNode | None, ASTNode | None] | None = None
+            if node.type == cs.TS_VARIABLE_DECLARATOR:
+                target_value = (
+                    node.child_by_field_name(cs.FIELD_NAME),
+                    node.child_by_field_name(cs.FIELD_VALUE),
+                )
+            elif node.type == cs.TS_JS_ASSIGNMENT_EXPRESSION:
+                target_value = (
+                    node.child_by_field_name(cs.FIELD_LEFT),
+                    node.child_by_field_name(cs.TS_FIELD_RIGHT),
+                )
+            if target_value is not None:
+                target, value = target_value
+                if (
+                    target is not None
+                    and value is not None
+                    and target.type == cs.TS_IDENTIFIER
+                    and safe_decode_text(target) == name
+                    and value.type == cs.TS_NEW_EXPRESSION
+                ):
+                    ctor = ut.extract_constructor_name(value)
+                    if found is None:
+                        found = value
+                        found_ctor = ctor
+                    elif ctor != found_ctor:
+                        return None
+            stack.extend(node.children)
+        return found

--- a/codebase_rag/parsers/js_ts/type_inference.py
+++ b/codebase_rag/parsers/js_ts/type_inference.py
@@ -18,6 +18,25 @@ _JS_NESTED_CALLABLE_TYPES = frozenset(cs.JS_TS_FUNCTION_NODES) | {
     cs.TS_GENERATOR_FUNCTION
 }
 
+# Ancestor node types that bound a `let`/`const` declaration's scope: the
+# nearest one governs the binding (a for-header declaration scopes to the for
+# statement, a case-level one to the whole switch body).
+_JS_SCOPE_CONTAINER_TYPES = frozenset(
+    {
+        cs.TS_STATEMENT_BLOCK,
+        cs.TS_JS_SWITCH_BODY,
+        cs.TS_JS_FOR_STATEMENT,
+        cs.TS_JS_FOR_IN_STATEMENT,
+    }
+)
+
+# Declarations of a name: (scope start_byte, scope end_byte, `new` value node
+# when the declarator's own initialiser constructs, else None). Assignments:
+# (site byte, `new` value node).
+_CtorDecls = dict[str, list[tuple[int, int, "ASTNode | None"]]]
+_CtorAssigns = dict[str, list[tuple[int, "ASTNode"]]]
+_CtorBindingIndex = tuple[_CtorDecls, _CtorAssigns]
+
 if TYPE_CHECKING:
     from ...types_defs import LanguageQueries
     from ..import_processor import ImportProcessor
@@ -260,9 +279,14 @@ class JsTypeInferenceEngine:
         # method; deliberately NOT stored on the engine: a tree-sitter node id
         # is a recycled heap address across parses, and holding Node values
         # would pin whole trees against the bounded AST cache.
-        ctor_bindings: dict[str, ASTNode | None] | None = None
+        ctor_index: _CtorBindingIndex | None = None
 
         for return_node in return_nodes:
+            # Nested callables own their returns: a callback's `return new
+            # Foo()` (or `return x`) is the callback's value, never the
+            # method's, so BOTH branches below are gated here.
+            if not self._return_belongs_to(return_node, method_node):
+                continue
             for child in return_node.children:
                 if child.type == cs.TS_RETURN:
                     continue
@@ -273,18 +297,18 @@ class JsTypeInferenceEngine:
                 # `return x` where the METHOD'S OWN body binds `x = new
                 # C(...)` (the cache-then-construct factory, fastify's
                 # ContentType.from, issue #992): the CONSTRUCTED class types
-                # the return when every construction bound to x agrees.
-                # Unknown-value assignments (the cache hit) do not veto; a
-                # second DIFFERENT class does. Nested callables own their
-                # locals and their returns, so both are excluded.
-                if (
-                    child.type == cs.TS_IDENTIFIER
-                    and self._return_belongs_to(return_node, method_node)
-                    and (name := safe_decode_text(child))
-                ):
-                    if ctor_bindings is None:
-                        ctor_bindings = self._js_ctor_bindings(method_node)
-                    constructed = ctor_bindings.get(name)
+                # the return when every construction reaching THIS return's
+                # variable agrees. Bindings resolve by SCOPE SPAN: the
+                # innermost declarator whose scope encloses the return is the
+                # variable, so a nested-block shadow neither erases an outer
+                # construction nor inherits it. Unknown-value assignments
+                # (the cache hit) do not veto; a second DIFFERENT class does.
+                if child.type == cs.TS_IDENTIFIER and (name := safe_decode_text(child)):
+                    if ctor_index is None:
+                        ctor_index = self._js_ctor_binding_index(method_node)
+                    constructed = self._js_constructed_for(
+                        name, child.start_byte, ctor_index
+                    )
                     if constructed is None:
                         continue
                     ctor = ut.extract_constructor_name(constructed)
@@ -320,56 +344,167 @@ class JsTypeInferenceEngine:
             current = current.parent
         return False
 
-    def _js_ctor_bindings(self, method_node: ASTNode) -> dict[str, ASTNode | None]:
-        body = method_node.child_by_field_name(cs.FIELD_BODY)
-        bindings: dict[str, ASTNode | None] = {}
+    def _js_ctor_binding_index(self, method_node: ASTNode) -> _CtorBindingIndex:
+        # One scan of the method body (nested callables excluded: their
+        # locals are their own) collecting every DECLARATION of every name
+        # with the byte span of the scope it governs, plus every
+        # `x = new C(...)` assignment site. Scope spans, not name equality,
+        # decide which construction reaches which return.
+        decls: _CtorDecls = {}
+        assigns: _CtorAssigns = {}
         stack: list[ASTNode] = list(method_node.children)
         while stack:
             node = stack.pop()
             if node.type in _JS_NESTED_CALLABLE_TYPES:
-                # A nested callable's locals are its own.
                 continue
-            target_value: tuple[ASTNode | None, ASTNode | None] | None = None
             if node.type == cs.TS_VARIABLE_DECLARATOR:
-                target_value = (
-                    node.child_by_field_name(cs.FIELD_NAME),
-                    node.child_by_field_name(cs.FIELD_VALUE),
-                )
+                self._index_ctor_declarator(node, method_node, decls)
             elif node.type == cs.TS_JS_ASSIGNMENT_EXPRESSION:
-                target_value = (
-                    node.child_by_field_name(cs.FIELD_LEFT),
-                    node.child_by_field_name(cs.TS_FIELD_RIGHT),
-                )
-            if target_value is not None:
-                target, value = target_value
-                if (
-                    target is not None
-                    and value is not None
-                    and target.type == cs.TS_IDENTIFIER
-                    and value.type == cs.TS_NEW_EXPRESSION
-                    and (bound_name := safe_decode_text(target))
-                ):
-                    if (
-                        node.type == cs.TS_VARIABLE_DECLARATOR
-                        and node.parent is not None
-                        and node.parent.type == cs.TS_LEXICAL_DECLARATION
-                        and (
-                            body is None
-                            or node.parent.parent is None
-                            or node.parent.parent.id != body.id
-                        )
-                    ):
-                        # A `let`/`const` in a NESTED block is a DIFFERENT
-                        # variable; it can never type the method's return,
-                        # and its existence makes the name unknowable here.
-                        bindings[bound_name] = None
-                    elif bound_name not in bindings:
-                        bindings[bound_name] = value
-                    else:
-                        prior = bindings[bound_name]
-                        if prior is None or ut.extract_constructor_name(
-                            prior
-                        ) != ut.extract_constructor_name(value):
-                            bindings[bound_name] = None
+                self._index_ctor_assignment(node, assigns)
+            elif node.type == cs.TS_JS_FOR_IN_STATEMENT:
+                self._index_ctor_loop_binding(node, method_node, decls)
+            elif node.type == cs.TS_JS_CATCH_CLAUSE:
+                self._index_ctor_catch_binding(node, decls)
             stack.extend(node.children)
-        return bindings
+        return decls, assigns
+
+    def _index_ctor_declarator(
+        self, node: ASTNode, method_node: ASTNode, decls: _CtorDecls
+    ) -> None:
+        target = node.child_by_field_name(cs.FIELD_NAME)
+        if target is None:
+            return
+        value = node.child_by_field_name(cs.FIELD_VALUE)
+        ctor_value = (
+            value if value is not None and value.type == cs.TS_NEW_EXPRESSION else None
+        )
+        is_lexical = (
+            node.parent is not None and node.parent.type == cs.TS_LEXICAL_DECLARATION
+        )
+        span = (
+            self._js_scope_span(node, method_node)
+            if is_lexical
+            else (method_node.start_byte, method_node.end_byte)
+        )
+        # A destructuring pattern introduces its names with an unknowable
+        # value (the construction cannot be attributed to one of them).
+        single = target.type == cs.TS_IDENTIFIER
+        for bound_name in self._js_binding_names(target):
+            decls.setdefault(bound_name, []).append(
+                (span[0], span[1], ctor_value if single else None)
+            )
+
+    @staticmethod
+    def _index_ctor_assignment(node: ASTNode, assigns: _CtorAssigns) -> None:
+        target = node.child_by_field_name(cs.FIELD_LEFT)
+        value = node.child_by_field_name(cs.TS_FIELD_RIGHT)
+        if (
+            target is not None
+            and value is not None
+            and target.type == cs.TS_IDENTIFIER
+            and value.type == cs.TS_NEW_EXPRESSION
+            and (bound_name := safe_decode_text(target))
+        ):
+            assigns.setdefault(bound_name, []).append((node.start_byte, value))
+
+    def _index_ctor_loop_binding(
+        self, node: ASTNode, method_node: ASTNode, decls: _CtorDecls
+    ) -> None:
+        # `for (const x of xs)` binds x over the loop; `for (var x of xs)`
+        # hoists it; `for (x of xs)` (no kind) assigns an existing binding
+        # and introduces nothing.
+        kind = node.child_by_field_name(cs.FIELD_KIND)
+        if kind is None:
+            return
+        left = node.child_by_field_name(cs.FIELD_LEFT)
+        if left is None:
+            return
+        span = (
+            (method_node.start_byte, method_node.end_byte)
+            if kind.type == cs.TS_JS_VAR_KIND
+            else (node.start_byte, node.end_byte)
+        )
+        for bound_name in self._js_binding_names(left):
+            decls.setdefault(bound_name, []).append((span[0], span[1], None))
+
+    def _index_ctor_catch_binding(self, node: ASTNode, decls: _CtorDecls) -> None:
+        param = node.child_by_field_name(cs.FIELD_PARAMETER)
+        if param is None:
+            return
+        for bound_name in self._js_binding_names(param):
+            decls.setdefault(bound_name, []).append(
+                (node.start_byte, node.end_byte, None)
+            )
+
+    @staticmethod
+    def _js_binding_names(target: ASTNode) -> list[str]:
+        if target.type == cs.TS_IDENTIFIER:
+            name = safe_decode_text(target)
+            return [name] if name else []
+        names: list[str] = []
+        stack: list[ASTNode] = list(target.children)
+        while stack:
+            node = stack.pop()
+            if node.type in (
+                cs.TS_IDENTIFIER,
+                cs.TS_SHORTHAND_PROPERTY_IDENTIFIER_PATTERN,
+            ):
+                if name := safe_decode_text(node):
+                    names.append(name)
+                continue
+            stack.extend(node.children)
+        return names
+
+    @staticmethod
+    def _js_scope_span(node: ASTNode, method_node: ASTNode) -> tuple[int, int]:
+        # The scope a `let`/`const` governs: the nearest enclosing block-like
+        # ancestor (a for-header declaration governs the for statement, a
+        # case-level one the switch body), or the whole method.
+        current = node.parent
+        while current is not None and current.id != method_node.id:
+            if current.type in _JS_SCOPE_CONTAINER_TYPES:
+                return (current.start_byte, current.end_byte)
+            current = current.parent
+        return (method_node.start_byte, method_node.end_byte)
+
+    @staticmethod
+    def _js_innermost_scope(
+        entries: list[tuple[int, int, ASTNode | None]], pos: int
+    ) -> tuple[int, int] | None:
+        enclosing = [(s, e) for s, e, _v in entries if s <= pos < e]
+        if not enclosing:
+            return None
+        # Nested spans: the innermost starts latest; ties are the same span.
+        return max(enclosing, key=lambda span: (span[0], -span[1]))
+
+    def _js_constructed_for(
+        self, name: str, pos: int, index: _CtorBindingIndex
+    ) -> ASTNode | None:
+        # The variable `return x` reads is the innermost declaration of x
+        # whose scope encloses the return (no declaration: the name is a
+        # parameter, function-scoped). The constructions reaching it are its
+        # own initialiser plus every assignment site resolving to the SAME
+        # declaration; they must all agree on one class.
+        decls, assigns = index
+        entries = decls.get(name, [])
+        scope = self._js_innermost_scope(entries, pos)
+        constructions: list[ASTNode] = []
+        if scope is not None:
+            constructions.extend(
+                value
+                for s, e, value in entries
+                if (s, e) == scope and value is not None
+            )
+        for site, value in assigns.get(name, []):
+            if self._js_innermost_scope(entries, site) == scope:
+                constructions.append(value)
+        ctor_names = {ut.extract_constructor_name(value) for value in constructions}
+        ctor_names.discard(None)
+        if len(ctor_names) != 1:
+            return None
+        chosen = ctor_names.pop()
+        return next(
+            value
+            for value in constructions
+            if ut.extract_constructor_name(value) == chosen
+        )

--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import builtins
 import os
 import shutil
 import sys
@@ -47,6 +48,12 @@ class MockNode:
     @property
     def type(self) -> str:
         return self.node_type
+
+    @property
+    def id(self) -> int:
+        # Real tree-sitter nodes expose a per-parse identity; object identity
+        # is the mock's equivalent.
+        return builtins.id(self)
 
     @property
     def children(self) -> list[MockNode]:

--- a/codebase_rag/tests/test_js_factory_return_local_typing.py
+++ b/codebase_rag/tests/test_js_factory_return_local_typing.py
@@ -113,7 +113,115 @@ module.exports = ContentType
         "reply.js": REPLY,
     }
     cap = _run(tmp_path, files)
+    # The veto means NO type at all: neither class's getter may be
+    # referenced (a no-veto implementation would emit ContentType's).
     assert not any(
-        str(frm).endswith(".send") and str(to).endswith("Other.parameters")
+        str(frm).endswith(".send") and str(to).endswith(".parameters")
+        for frm, _rel, to in cap.rels
+    )
+
+
+def test_factory_building_a_different_class_types_that_class(tmp_path: Path) -> None:
+    # The constructed class types the return, never the factory's own class.
+    files = {
+        "w.js": """'use strict'
+class Widget {
+  get parameters () { return new Map() }
+}
+class Factory {
+  static build (h) { const w = new Widget(h); return w }
+  get parameters () { return new Map() }
+}
+module.exports = { Factory, Widget }
+""",
+        "reply.js": """'use strict'
+const { Factory } = require('./w.js')
+function send (header) {
+  const o = Factory.build(header)
+  return o.parameters.has('charset')
+}
+module.exports = { send }
+""",
+    }
+    cap = _run(tmp_path, files)
+    assert any(
+        str(frm).endswith(".send") and str(to).endswith("Widget.parameters")
+        for frm, _rel, to in cap.rels
+    )
+    assert not any(
+        str(frm).endswith(".send") and str(to).endswith("Factory.parameters")
+        for frm, _rel, to in cap.rels
+    )
+
+
+def test_nested_closure_local_does_not_veto(tmp_path: Path) -> None:
+    # An unrelated same-named local inside a callback is a different
+    # variable; it must not veto the outer inference.
+    files = {
+        "content-type.js": CT.replace(
+            "cache.set(headerValue, contentType)",
+            "cache.set(headerValue, contentType)\n"
+            "    setTimeout(function () { let contentType = new Map(); "
+            "return contentType }, 0)",
+        ),
+        "reply.js": REPLY,
+    }
+    cap = _run(tmp_path, files)
+    assert any(
+        str(frm).endswith(".send")
+        and str(to) == "p.content-type.ContentType.parameters"
+        for frm, _rel, to in cap.rels
+    )
+
+
+def test_nested_closure_construction_does_not_type_outer_return(
+    tmp_path: Path,
+) -> None:
+    # A construction bound to a CALLBACK's local, with the method returning
+    # its parameter, must not type the return.
+    files = {
+        "content-type.js": """'use strict'
+function run (cb) { return cb() }
+class ContentType {
+  static from (x) {
+    run(function () { let x = new ContentType('a'); return x.toString() })
+    return x
+  }
+  get parameters () { return new Map() }
+}
+module.exports = ContentType
+""",
+        "reply.js": REPLY,
+    }
+    cap = _run(tmp_path, files)
+    assert not any(
+        str(frm).endswith(".send")
+        and str(to) == "p.content-type.ContentType.parameters"
+        for frm, _rel, to in cap.rels
+    )
+
+
+def test_nested_callback_return_does_not_type_the_method(tmp_path: Path) -> None:
+    # `return list` where list is an ARRAY built by a mapped callback that
+    # returns constructions: the callback's return is not the method's.
+    files = {
+        "content-type.js": """'use strict'
+class Other {
+  get parameters () { return new Map() }
+}
+class ContentType {
+  static from (v) {
+    const list = v.split(',').map(function (p) { const y = new Other(p); return y })
+    return list
+  }
+  get parameters () { return new Map() }
+}
+module.exports = ContentType
+""",
+        "reply.js": REPLY,
+    }
+    cap = _run(tmp_path, files)
+    assert not any(
+        str(frm).endswith(".send") and "parameters" in str(to)
         for frm, _rel, to in cap.rels
     )

--- a/codebase_rag/tests/test_js_factory_return_local_typing.py
+++ b/codebase_rag/tests/test_js_factory_return_local_typing.py
@@ -395,6 +395,32 @@ module.exports = ContentType
     )
 
 
+def test_awaited_async_iife_return_types_the_construction(tmp_path: Path) -> None:
+    # tree-sitter-javascript parses `await (X)()` as a CALL to an identifier
+    # named `await` with X as its argument, invoked; the climb must treat
+    # that call as the transparent await it spells, or the .js spelling of
+    # an awaited async IIFE factory loses its type (the TS grammar has no
+    # such ambiguity).
+    files = {
+        "content-type.js": """'use strict'
+class ContentType {
+  static async from (v) {
+    return await (async function () { return new ContentType(v) })()
+  }
+  get parameters () { return new Map() }
+}
+module.exports = ContentType
+""",
+        "reply.js": REPLY,
+    }
+    cap = _run(tmp_path, files)
+    assert any(
+        str(frm).endswith(".send")
+        and str(to) == "p.content-type.ContentType.parameters"
+        for frm, _rel, to in cap.rels
+    )
+
+
 def test_destructuring_reads_do_not_shadow(tmp_path: Path) -> None:
     # Destructuring DEFAULTS, computed keys and array defaults READ outer
     # names; treating those reads as block-scoped declarations would shadow

--- a/codebase_rag/tests/test_js_factory_return_local_typing.py
+++ b/codebase_rag/tests/test_js_factory_return_local_typing.py
@@ -225,3 +225,55 @@ module.exports = ContentType
         str(frm).endswith(".send") and "parameters" in str(to)
         for frm, _rel, to in cap.rels
     )
+
+
+def test_block_scoped_shadow_does_not_type_the_parameter(tmp_path: Path) -> None:
+    # `let x` inside a nested block is a DIFFERENT variable from the
+    # returned parameter x.
+    files = {
+        "content-type.js": """'use strict'
+class Other {
+  get parameters () { return new Map() }
+  warm () { return 1 }
+}
+class ContentType {
+  static from (x) {
+    if (x) { let x = new Other('a'); x.warm() }
+    return x
+  }
+  get parameters () { return new Map() }
+}
+module.exports = ContentType
+""",
+        "reply.js": REPLY,
+    }
+    cap = _run(tmp_path, files)
+    assert not any(
+        str(frm).endswith(".send") and "parameters" in str(to)
+        for frm, _rel, to in cap.rels
+    )
+
+
+def test_generator_expression_locals_do_not_leak(tmp_path: Path) -> None:
+    files = {
+        "content-type.js": """'use strict'
+class Other {
+  get parameters () { return new Map() }
+}
+class ContentType {
+  static from (v) {
+    const g = function* () { const y = new Other(v); return y }
+    const list = [...g()]
+    return list
+  }
+  get parameters () { return new Map() }
+}
+module.exports = ContentType
+""",
+        "reply.js": REPLY,
+    }
+    cap = _run(tmp_path, files)
+    assert not any(
+        str(frm).endswith(".send") and "parameters" in str(to)
+        for frm, _rel, to in cap.rels
+    )

--- a/codebase_rag/tests/test_js_factory_return_local_typing.py
+++ b/codebase_rag/tests/test_js_factory_return_local_typing.py
@@ -1,0 +1,119 @@
+# A static factory whose return value flows through a reassigned local
+# (`let x = cache.get(...); if (x) return x; x = new C(...); return x`)
+# defeated return-type inference, so locals typed from the factory stayed
+# untyped and downstream getter reads emitted nothing. Found dogfooding
+# fastify: `ContentType.from` (lib/content-type.js) with the `parameters`
+# getter read in lib/reply.js. Issue #992.
+from __future__ import annotations
+
+from pathlib import Path
+
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.types_defs import PropertyDict, PropertyValue, ResultRow
+
+PROJECT = "p"
+
+CT = """'use strict'
+const cache = new Map()
+class ContentType {
+  #parameters = new Map()
+  static from (headerValue) {
+    let contentType = cache.get(headerValue)
+    if (contentType !== undefined) return contentType
+    contentType = new ContentType(headerValue)
+    cache.set(headerValue, contentType)
+    return contentType
+  }
+  get parameters () { return this.#parameters }
+}
+module.exports = ContentType
+"""
+
+REPLY = """'use strict'
+const ContentType = require('./content-type.js')
+function send (header) {
+  const contentType = ContentType.from(header)
+  return contentType.parameters.has('charset')
+}
+module.exports = { send }
+"""
+
+
+class _Capture:
+    def __init__(self) -> None:
+        self.rels: list[tuple[PropertyValue, str, PropertyValue]] = []
+
+    def ensure_node_batch(self, label: str, properties: PropertyDict) -> None:
+        return None
+
+    def ensure_relationship_batch(
+        self,
+        from_spec: tuple[str, str, PropertyValue],
+        rel_type: str,
+        to_spec: tuple[str, str, PropertyValue],
+        properties: PropertyDict | None = None,
+    ) -> None:
+        self.rels.append((from_spec[2], str(rel_type), to_spec[2]))
+
+    def flush_all(self) -> None:
+        return None
+
+    def fetch_all(
+        self, query: str, params: PropertyDict | None = None
+    ) -> list[ResultRow]:
+        return []
+
+    def execute_write(self, query: str, params: PropertyDict | None = None) -> None:
+        return None
+
+
+def _run(tmp_path: Path, files: dict[str, str]) -> _Capture:
+    for name, src in files.items():
+        (tmp_path / name).write_text(src)
+    parsers, queries = load_parsers()
+    cap = _Capture()
+    GraphUpdater(
+        ingestor=cap,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name=PROJECT,
+    ).run(force=True)
+    return cap
+
+
+def test_reassigned_local_factory_return_types_the_receiver(tmp_path: Path) -> None:
+    cap = _run(tmp_path, {"content-type.js": CT, "reply.js": REPLY})
+    assert any(
+        str(frm).endswith(".send")
+        and str(to) == "p.content-type.ContentType.parameters"
+        for frm, _rel, to in cap.rels
+    )
+
+
+def test_conflicting_constructions_stay_untyped(tmp_path: Path) -> None:
+    # Two different classes assigned to the returned local: the return type
+    # is unknowable and no getter edge may be guessed.
+    files = {
+        "content-type.js": """'use strict'
+class Other {
+  get parameters () { return new Map() }
+}
+class ContentType {
+  static from (v) {
+    let x = new Other(v)
+    x = new ContentType(v)
+    return x
+  }
+  get parameters () { return new Map() }
+}
+module.exports = ContentType
+""",
+        "reply.js": REPLY,
+    }
+    cap = _run(tmp_path, files)
+    assert not any(
+        str(frm).endswith(".send") and str(to).endswith("Other.parameters")
+        for frm, _rel, to in cap.rels
+    )

--- a/codebase_rag/tests/test_js_factory_return_local_typing.py
+++ b/codebase_rag/tests/test_js_factory_return_local_typing.py
@@ -255,15 +255,17 @@ module.exports = ContentType
 
 
 def test_generator_expression_locals_do_not_leak(tmp_path: Path) -> None:
+    # `var` inside the generator discriminates: the lexical-block rule lets
+    # var through, so only the generator exclusion blocks this leak.
     files = {
         "content-type.js": """'use strict'
 class Other {
   get parameters () { return new Map() }
 }
 class ContentType {
-  static from (v) {
-    const g = function* () { const y = new Other(v); return y }
-    const list = [...g()]
+  static from (list) {
+    const g = function* () { var list = new Other(1); yield list }
+    g().next()
     return list
   }
   get parameters () { return new Map() }

--- a/codebase_rag/tests/test_js_factory_return_local_typing.py
+++ b/codebase_rag/tests/test_js_factory_return_local_typing.py
@@ -371,6 +371,111 @@ module.exports = ContentType
     )
 
 
+def test_iife_returning_factory_types_the_construction(tmp_path: Path) -> None:
+    # `return (function () { return new C(v) })()`: the IIFE's value IS the
+    # method's return, so the inner construction types it (a blanket
+    # nested-callable exclusion regresses this).
+    files = {
+        "content-type.js": """'use strict'
+class ContentType {
+  static from (v) {
+    return (function () { return new ContentType(v) })()
+  }
+  get parameters () { return new Map() }
+}
+module.exports = ContentType
+""",
+        "reply.js": REPLY,
+    }
+    cap = _run(tmp_path, files)
+    assert any(
+        str(frm).endswith(".send")
+        and str(to) == "p.content-type.ContentType.parameters"
+        for frm, _rel, to in cap.rels
+    )
+
+
+def test_destructuring_reads_do_not_shadow(tmp_path: Path) -> None:
+    # Destructuring DEFAULTS, computed keys and array defaults READ outer
+    # names; treating those reads as block-scoped declarations would shadow
+    # the real outer binding and drop its type.
+    files = {
+        "content-type.js": """'use strict'
+function use (v) { return v }
+class ContentType {
+  static from (v) {
+    let x = new ContentType(v)
+    if (v === 1) { const { a = x } = v; use(a); return x }
+    if (v === 2) { const { [x]: b } = v; use(b); return x }
+    if (v === 3) { const [ c = x ] = v; use(c); return x }
+    return null
+  }
+  get parameters () { return new Map() }
+}
+module.exports = ContentType
+""",
+        "reply.js": REPLY,
+    }
+    cap = _run(tmp_path, files)
+    assert any(
+        str(frm).endswith(".send")
+        and str(to) == "p.content-type.ContentType.parameters"
+        for frm, _rel, to in cap.rels
+    )
+
+
+def test_destructuring_read_keeps_conflict_veto(tmp_path: Path) -> None:
+    # The spurious block declaration also mis-scoped a genuine conflicting
+    # reassignment into the block, silently disabling the veto.
+    files = {
+        "content-type.js": """'use strict'
+class Other {
+  get parameters () { return new Map() }
+  touch () { return 1 }
+}
+class ContentType {
+  static from (v) {
+    let x = new ContentType(v)
+    if (v) { const { a = x } = v; x = new Other(v) }
+    return x
+  }
+  get parameters () { return new Map() }
+}
+module.exports = ContentType
+""",
+        "reply.js": REPLY,
+    }
+    cap = _run(tmp_path, files)
+    assert not any(
+        str(frm).endswith(".send") and "parameters" in str(to)
+        for frm, _rel, to in cap.rels
+    )
+
+
+def test_unextractable_constructor_keeps_veto(tmp_path: Path) -> None:
+    # `new registry.Cached(v)` has no extractable class name; a later
+    # DIFFERENT construction must veto, never silently win.
+    files = {
+        "content-type.js": """'use strict'
+class ContentType {
+  static from (v) {
+    let x = new v.registry.Cached(v)
+    if (!v) x = new ContentType(v)
+    return x
+  }
+  get parameters () { return new Map() }
+}
+module.exports = ContentType
+""",
+        "reply.js": REPLY,
+    }
+    cap = _run(tmp_path, files)
+    assert not any(
+        str(frm).endswith(".send") and "parameters" in str(to)
+        for frm, _rel, to in cap.rels
+    )
+
+
 def test_generator_expression_locals_do_not_leak(tmp_path: Path) -> None:
     # `var` inside the generator discriminates: the lexical-block rule lets
     # var through, so only the generator exclusion blocks this leak.

--- a/codebase_rag/tests/test_js_factory_return_local_typing.py
+++ b/codebase_rag/tests/test_js_factory_return_local_typing.py
@@ -254,6 +254,123 @@ module.exports = ContentType
     )
 
 
+def test_outer_construction_survives_nested_shadow(tmp_path: Path) -> None:
+    # A nested-block shadow is a DIFFERENT variable; it must not erase the
+    # unambiguous outer construction that the outer return actually returns.
+    files = {
+        "content-type.js": """'use strict'
+class Other {
+  get parameters () { return new Map() }
+  warm () { return 1 }
+}
+class ContentType {
+  static from (v) {
+    let x = new ContentType(v)
+    if (v) { let x = new Other(v); x.warm() }
+    return x
+  }
+  get parameters () { return new Map() }
+}
+module.exports = ContentType
+""",
+        "reply.js": REPLY,
+    }
+    cap = _run(tmp_path, files)
+    assert any(
+        str(frm).endswith(".send")
+        and str(to) == "p.content-type.ContentType.parameters"
+        for frm, _rel, to in cap.rels
+    )
+    assert not any(
+        str(frm).endswith(".send") and str(to).endswith("Other.parameters")
+        for frm, _rel, to in cap.rels
+    )
+
+
+def test_return_inside_shadow_block_types_the_shadow(tmp_path: Path) -> None:
+    # A return INSIDE the shadowing block returns the SHADOW's construction,
+    # never the outer one (an unscoped outer-wins rule would fabricate a
+    # wrong-class edge here).
+    files = {
+        "content-type.js": """'use strict'
+class Other {
+  get parameters () { return new Map() }
+}
+class ContentType {
+  static from (v) {
+    let x = new ContentType(v)
+    x.toString()
+    if (v) { let x = new Other(v); return x }
+    return null
+  }
+  get parameters () { return new Map() }
+}
+module.exports = ContentType
+""",
+        "reply.js": REPLY,
+    }
+    cap = _run(tmp_path, files)
+    assert any(
+        str(frm).endswith(".send") and str(to).endswith("Other.parameters")
+        for frm, _rel, to in cap.rels
+    )
+    assert not any(
+        str(frm).endswith(".send")
+        and str(to) == "p.content-type.ContentType.parameters"
+        for frm, _rel, to in cap.rels
+    )
+
+
+def test_non_new_shadow_does_not_inherit_outer_type(tmp_path: Path) -> None:
+    # A shadow initialised from a CALL is unknowable; the return inside its
+    # block must not be typed by the outer same-named construction.
+    files = {
+        "content-type.js": """'use strict'
+class ContentType {
+  static from (v) {
+    let x = new ContentType(v)
+    x.toString()
+    if (v) { let x = v.parse(); return x }
+    return null
+  }
+  get parameters () { return new Map() }
+}
+module.exports = ContentType
+""",
+        "reply.js": REPLY,
+    }
+    cap = _run(tmp_path, files)
+    assert not any(
+        str(frm).endswith(".send") and "parameters" in str(to)
+        for frm, _rel, to in cap.rels
+    )
+
+
+def test_callback_direct_construction_return_not_attributed(tmp_path: Path) -> None:
+    # A callback ARGUMENT directly returning a construction is the
+    # callback's return, not the method's; attributing it types the factory
+    # with a class it never returns.
+    files = {
+        "content-type.js": """'use strict'
+function run (cb) { return cb() }
+class ContentType {
+  static from (v) {
+    run(function () { return new ContentType('a') })
+    return v
+  }
+  get parameters () { return new Map() }
+}
+module.exports = ContentType
+""",
+        "reply.js": REPLY,
+    }
+    cap = _run(tmp_path, files)
+    assert not any(
+        str(frm).endswith(".send") and "parameters" in str(to)
+        for frm, _rel, to in cap.rels
+    )
+
+
 def test_generator_expression_locals_do_not_leak(tmp_path: Path) -> None:
     # `var` inside the generator discriminates: the lexical-block rule lets
     # var through, so only the generator exclusion blocks this leak.

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.519"
+version = "0.0.520"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.517"
+version = "0.0.518"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.518"
+version = "0.0.519"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Fixes #992.

## Problem

A static factory whose return value flows through a reassigned local, `let x = cache.get(v); if (x) return x; x = new C(v); return x`, defeated JS/TS return-type inference. Locals typed from such factories stayed untyped, so downstream getter reads emitted nothing and the members reported dead. Fastify witness: `ContentType.from` with the `parameters` getter read in `lib/reply.js`.

## Fix

`_analyze_return_statements` now handles `return <identifier>`: one O(body) scan per inference call collects the `new C(...)` bound to each local (declarator values and assignment rights), and the CONSTRUCTED class types the return when every construction bound to the name agrees. Precision rules, each pinned by a test:

- the constructed class wins, never the factory's own class; a different class resolves via `_resolve_js_class_name` in the factory's module;
- a second DIFFERENT construction vetoes; unknown-value assignments (the cache hit) do not;
- nested callables own their locals AND their returns (a widened local set including the generator EXPRESSION form gates both the binding scan and return attribution);
- a `let`/`const` declarator in a nested block is a different variable and marks the name unknowable;
- nothing is memoised across calls: a tree-sitter node id is a recycled heap address across parses, and holding node values would pin whole trees against the bounded AST cache, so the binding map lives only for the single inference call.

## Review history

Two adversarial rounds over the live pipeline. Round one killed the first design's five defects (own-class mistyping, closure veto and shadow leaks, a vacuous conflict test, and a quadratic per-return rescan). Round two killed the memoised successor (recycled-address collisions producing nondeterministic misses, tree pinning against the documented AST cache bound, the remaining block-scope shadow, and the generator-expression leak) and then verified the final design clean, including a mutation check that every pin fails under its targeted revert.

## Validation

- 8 tests in `codebase_rag/tests/test_js_factory_return_local_typing.py`.
- Full non-integration suite green on the branch merged with current main, `pytest -n auto`.
- Real-repo verification on fastify: the two genuine candidates this typing unlocks (`ContentType.parameters`, `ContentType.isEmpty`) leave the dead list; nothing else changes; runtime and memory flat (reviewer-measured 8.1s vs 8.2s, 669 MB both).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JavaScript and TypeScript analysis of factory methods and callable functions.
  * Return types are inferred more accurately for local variables, reassigned factories, constructors, destructuring, loops, and catch bindings.
  * Improved handling of nested callbacks, block-scoped variables, conflicting or ambiguous constructions, and generated functions.
  * Added support for identifying returned values from directly invoked and awaited functions.
  * Prevented unrelated nested code from affecting return-type results, improving receiver and class identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->