### PR TITLE
fix: register generator function expressions and close the IIFE orphan family

### DIFF
--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -141,14 +141,14 @@ JS_PROTOTYPE_METHOD_QUERY = """
       object: (identifier) @constructor_name
       property: (property_identifier) @prototype_keyword (#eq? @prototype_keyword "prototype"))
     property: (property_identifier) @method_name)
-  right: (function_expression) @method_function)
+  right: [(function_expression) (generator_function)] @method_function)
 """
 
 # JS object method query
 JS_OBJECT_METHOD_QUERY = """
 (pair
   key: (property_identifier) @method_name
-  value: (function_expression) @method_function)
+  value: [(function_expression) (generator_function)] @method_function)
 """
 
 # JS method definition query
@@ -177,7 +177,7 @@ JS_ASSIGNMENT_ARROW_QUERY = """
 JS_ASSIGNMENT_FUNCTION_QUERY = """
 (assignment_expression
   (member_expression) @member_expr
-  (function_expression) @function_expr)
+  [(function_expression) (generator_function)] @function_expr)
 """
 
 # JS/TS control-flow node types + fields for the path-sensitive taint walk

--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -205,6 +205,8 @@ TS_JS_FOR_STATEMENT = "for_statement"
 TS_JS_FOR_IN_STATEMENT = "for_in_statement"
 TS_JS_TRY_STATEMENT = "try_statement"
 TS_JS_CATCH_CLAUSE = "catch_clause"
+# `(a, b)`: the comma operator; its value is the LAST operand.
+TS_JS_SEQUENCE_EXPRESSION = "sequence_expression"
 TS_JS_FINALLY_CLAUSE = "finally_clause"
 FIELD_ALTERNATIVE = "alternative"
 FIELD_HANDLER = "handler"

--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -209,6 +209,7 @@ TS_JS_CATCH_CLAUSE = "catch_clause"
 TS_JS_SEQUENCE_EXPRESSION = "sequence_expression"
 TS_JS_FINALLY_CLAUSE = "finally_clause"
 FIELD_ALTERNATIVE = "alternative"
+FIELD_CONSEQUENCE = "consequence"
 FIELD_HANDLER = "handler"
 FIELD_FINALIZER = "finalizer"
 # The C-style `for (init; cond; increment)` update clause, which runs AFTER the

--- a/codebase_rag/constants/ast_nodes.py
+++ b/codebase_rag/constants/ast_nodes.py
@@ -51,6 +51,10 @@ IMPORT_NODES_INCLUDE = ("preproc_include",)
 JS_TS_FUNCTION_NODES = (
     "function_declaration",
     "generator_function_declaration",
+    # The generator EXPRESSION (`const g = function* () {}`) is a function
+    # value like function_expression; omitting it left such nodes
+    # unregistered and unreferencable (issue #994).
+    "generator_function",
     "function_expression",
     "arrow_function",
     "method_definition",

--- a/codebase_rag/constants/fqn_specs.py
+++ b/codebase_rag/constants/fqn_specs.py
@@ -82,6 +82,7 @@ from .ast_js import (
     TS_CLASS_BODY,
     TS_FUNCTION_DECLARATION,
     TS_FUNCTION_EXPRESSION,
+    TS_GENERATOR_FUNCTION,
     TS_GENERATOR_FUNCTION_DECLARATION,
     TS_OBJECT,
 )
@@ -197,6 +198,10 @@ FQN_JS_FUNCTION_TYPES = (
     TS_METHOD_DEFINITION,
     TS_ARROW_FUNCTION,
     TS_FUNCTION_EXPRESSION,
+    # A generator EXPRESSION (`const g = function* () {}`) is a function
+    # value like any function_expression; without it the node never
+    # registers and nothing can reference it (issue #994).
+    TS_GENERATOR_FUNCTION,
 )
 
 # The grammar emits `internal_module` for a `namespace`/`module` block; without
@@ -219,6 +224,7 @@ FQN_TS_FUNCTION_TYPES = (
     TS_METHOD_DEFINITION,
     TS_ARROW_FUNCTION,
     TS_FUNCTION_EXPRESSION,
+    TS_GENERATOR_FUNCTION,
     TS_FUNCTION_SIGNATURE,
 )
 

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -2641,27 +2641,54 @@ class CallProcessor:
         func_child = call_node.child_by_field_name(cs.FIELD_FUNCTION)
         if func_child is None:
             return None
+        # Peel to a FIXPOINT (wrappers nest: `((fn))()`, `(0, (fn))()`, cast
+        # forms), the same discipline as _peel_bound_callable. Parens and
+        # casts are value-transparent; the comma operator yields its LAST
+        # operand. Anything else (ternary, logicals) has no single static
+        # callee and stops the peel.
         target = func_child
-        from_sequence = False
-        if func_child.type == cs.TS_PARENTHESIZED_EXPRESSION:
-            inner = next(
-                (
-                    child
-                    for child in func_child.named_children
-                    if child.type != cs.TS_COMMENT
-                ),
-                None,
-            )
-            if inner is not None and inner.type == cs.TS_JS_SEQUENCE_EXPRESSION:
-                # The comma operator yields its LAST operand; that operand
-                # is what the call invokes.
-                from_sequence = True
-                inner = inner.named_children[-1] if inner.named_children else None
-            if inner is not None:
+        paren_peels = 0
+        other_peels = 0
+        while True:
+            if target.type == cs.TS_PARENTHESIZED_EXPRESSION:
+                inner = next(
+                    (
+                        child
+                        for child in target.named_children
+                        if child.type != cs.TS_COMMENT
+                    ),
+                    None,
+                )
+                if inner is None:
+                    break
                 target = inner
+                paren_peels += 1
+                continue
+            if target.type == cs.TS_JS_SEQUENCE_EXPRESSION:
+                if not target.named_children:
+                    break
+                target = target.named_children[-1]
+                other_peels += 1
+                continue
+            if target.type in cs.TS_CAST_WRAPPER_TYPES:
+                inner = next(iter(target.named_children), None)
+                if inner is None:
+                    break
+                target = inner
+                other_peels += 1
+                continue
+            break
         if target.type not in (cs.TS_FUNCTION_EXPRESSION, cs.TS_GENERATOR_FUNCTION):
             return None
-        if not from_sequence and not self._js_iife_callee_name(target):
+        # The plain anonymous forms (bare callee, or exactly one paren) keep
+        # their positional iife_direct_/iife_func_ names; everything else
+        # registers under its own name or as an anonymous node and resolves
+        # only by span.
+        if (
+            other_peels == 0
+            and paren_peels <= 1
+            and not self._js_iife_callee_name(target)
+        ):
             return None
         return self._recorded_caller(target, module_qn)
 

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -2631,26 +2631,37 @@ class CallProcessor:
     ) -> FunctionLocation | None:
         # A NAMED IIFE (`(function build () {...})()`, `function build ()
         # {...}()`) registers under its own name, minted as a duplicate
-        # variant when a sibling shares it, so neither the positional iife_*
-        # names nor bare-name resolution can reach it safely. Resolve the
-        # callee NODE by its own source span to the exact minted qn.
+        # variant when a sibling shares it; a sequence IIFE
+        # (`(0, function () {...})()`, the indirect-this idiom) registers as
+        # an anonymous node. Neither the positional iife_* names nor
+        # bare-name resolution can reach them safely, so resolve the callee
+        # NODE by its own source span to the exact minted qn. The plain
+        # anonymous parenthesised/direct forms keep their positional names
+        # and are excluded here.
         func_child = call_node.child_by_field_name(cs.FIELD_FUNCTION)
         if func_child is None:
             return None
         target = func_child
+        from_sequence = False
         if func_child.type == cs.TS_PARENTHESIZED_EXPRESSION:
-            target = next(
+            inner = next(
                 (
                     child
-                    for child in func_child.children
-                    if child.type
-                    in (cs.TS_FUNCTION_EXPRESSION, cs.TS_GENERATOR_FUNCTION)
+                    for child in func_child.named_children
+                    if child.type != cs.TS_COMMENT
                 ),
-                func_child,
+                None,
             )
+            if inner is not None and inner.type == cs.TS_JS_SEQUENCE_EXPRESSION:
+                # The comma operator yields its LAST operand; that operand
+                # is what the call invokes.
+                from_sequence = True
+                inner = inner.named_children[-1] if inner.named_children else None
+            if inner is not None:
+                target = inner
         if target.type not in (cs.TS_FUNCTION_EXPRESSION, cs.TS_GENERATOR_FUNCTION):
             return None
-        if not self._js_iife_callee_name(target):
+        if not from_sequence and not self._js_iife_callee_name(target):
             return None
         return self._recorded_caller(target, module_qn)
 

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -2593,7 +2593,7 @@ class CallProcessor:
     def _get_iife_target_name(self, parenthesized_expr: Node) -> str | None:
         for child in parenthesized_expr.children:
             match child.type:
-                case cs.TS_FUNCTION_EXPRESSION:
+                case cs.TS_FUNCTION_EXPRESSION | cs.TS_GENERATOR_FUNCTION:
                     return f"{cs.IIFE_FUNC_PREFIX}{child.start_point[0]}_{child.start_point[1]}"
                 case cs.TS_ARROW_FUNCTION:
                     return f"{cs.IIFE_ARROW_PREFIX}{child.start_point[0]}_{child.start_point[1]}"

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -2439,8 +2439,12 @@ class CallProcessor:
                     language in _JS_TS_LANGUAGES
                 ):
                     # An unparenthesised direct IIFE (`const x = function ()
-                    # {...}()`) has the function itself as the callee; mirror
-                    # the PREFIX_IIFE_DIRECT name the definition side mints.
+                    # {...}()`) has the function itself as the callee. A NAMED
+                    # one registers under its own name (possibly a duplicate
+                    # variant), so only the span-resolved path may emit its
+                    # edge; a positional name here is for the anonymous form.
+                    if self._js_iife_callee_name(func_child):
+                        return None
                     return (
                         f"{cs.PREFIX_IIFE_DIRECT}"
                         f"{func_child.start_point[0]}_{func_child.start_point[1]}"
@@ -2604,10 +2608,51 @@ class CallProcessor:
         for child in parenthesized_expr.children:
             match child.type:
                 case cs.TS_FUNCTION_EXPRESSION | cs.TS_GENERATOR_FUNCTION:
+                    # A named IIFE registers under its own name, not the
+                    # positional iife_* name; its edge comes from the
+                    # span-resolved path, never a bare-name lookup (a
+                    # same-named sibling would capture it).
+                    if self._js_iife_callee_name(child):
+                        return None
                     return f"{cs.IIFE_FUNC_PREFIX}{child.start_point[0]}_{child.start_point[1]}"
                 case cs.TS_ARROW_FUNCTION:
                     return f"{cs.IIFE_ARROW_PREFIX}{child.start_point[0]}_{child.start_point[1]}"
         return None
+
+    @staticmethod
+    def _js_iife_callee_name(func_node: Node) -> str | None:
+        name_node = func_node.child_by_field_name(cs.FIELD_NAME)
+        if name_node is not None and name_node.text is not None:
+            return name_node.text.decode(cs.ENCODING_UTF8)
+        return None
+
+    def _js_named_iife_callee(
+        self, call_node: Node, module_qn: str
+    ) -> FunctionLocation | None:
+        # A NAMED IIFE (`(function build () {...})()`, `function build ()
+        # {...}()`) registers under its own name, minted as a duplicate
+        # variant when a sibling shares it, so neither the positional iife_*
+        # names nor bare-name resolution can reach it safely. Resolve the
+        # callee NODE by its own source span to the exact minted qn.
+        func_child = call_node.child_by_field_name(cs.FIELD_FUNCTION)
+        if func_child is None:
+            return None
+        target = func_child
+        if func_child.type == cs.TS_PARENTHESIZED_EXPRESSION:
+            target = next(
+                (
+                    child
+                    for child in func_child.children
+                    if child.type
+                    in (cs.TS_FUNCTION_EXPRESSION, cs.TS_GENERATOR_FUNCTION)
+                ),
+                func_child,
+            )
+        if target.type not in (cs.TS_FUNCTION_EXPRESSION, cs.TS_GENERATOR_FUNCTION):
+            return None
+        if not self._js_iife_callee_name(target):
+            return None
+        return self._recorded_caller(target, module_qn)
 
     def _ingest_function_calls(
         self,
@@ -2953,6 +2998,17 @@ class CallProcessor:
                         caller_spec,
                         calls_rel,
                         (loc.label, qn_key, loc.qualified_name),
+                    )
+                # A NAMED IIFE yields no call name (a bare-name lookup would
+                # bind a same-named sibling); its edge is emitted here from
+                # the callee node's own span.
+                if (
+                    iife_loc := self._js_named_iife_callee(call_node, module_qn)
+                ) is not None:
+                    ensure_rel(
+                        caller_spec,
+                        calls_rel,
+                        (iife_loc.label, qn_key, iife_loc.qualified_name),
                     )
             if not call_name:
                 # A callee that is itself a call (`wraps(view_func)(_view_wrapper)`)

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -2435,6 +2435,16 @@ class CallProcessor:
                             return peeled.text.decode(cs.ENCODING_UTF8)
                 case cs.TS_PARENTHESIZED_EXPRESSION:
                     return self._get_iife_target_name(func_child)
+                case cs.TS_FUNCTION_EXPRESSION | cs.TS_GENERATOR_FUNCTION if (
+                    language in _JS_TS_LANGUAGES
+                ):
+                    # An unparenthesised direct IIFE (`const x = function ()
+                    # {...}()`) has the function itself as the callee; mirror
+                    # the PREFIX_IIFE_DIRECT name the definition side mints.
+                    return (
+                        f"{cs.PREFIX_IIFE_DIRECT}"
+                        f"{func_child.start_point[0]}_{func_child.start_point[1]}"
+                    )
 
         match call_node.type:
             case cs.TS_NEW_EXPRESSION if language in _JS_TS_LANGUAGES:

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -2641,6 +2641,23 @@ class CallProcessor:
         func_child = call_node.child_by_field_name(cs.FIELD_FUNCTION)
         if func_child is None:
             return None
+        target, paren_peels, other_peels = self._peel_iife_callee_wrappers(func_child)
+        if target.type not in (cs.TS_FUNCTION_EXPRESSION, cs.TS_GENERATOR_FUNCTION):
+            return None
+        # The plain anonymous forms (bare callee, or exactly one paren) keep
+        # their positional iife_direct_/iife_func_ names; everything else
+        # registers under its own name or as an anonymous node and resolves
+        # only by span.
+        if (
+            other_peels == 0
+            and paren_peels <= 1
+            and not self._js_iife_callee_name(target)
+        ):
+            return None
+        return self._recorded_caller(target, module_qn)
+
+    @staticmethod
+    def _peel_iife_callee_wrappers(func_child: Node) -> tuple[Node, int, int]:
         # Peel to a FIXPOINT (wrappers nest: `((fn))()`, `(0, (fn))()`, cast
         # forms), the same discipline as _peel_bound_callable. Parens and
         # casts are value-transparent; the comma operator yields its LAST
@@ -2663,34 +2680,20 @@ class CallProcessor:
                     break
                 target = inner
                 paren_peels += 1
-                continue
-            if target.type == cs.TS_JS_SEQUENCE_EXPRESSION:
+            elif target.type == cs.TS_JS_SEQUENCE_EXPRESSION:
                 if not target.named_children:
                     break
                 target = target.named_children[-1]
                 other_peels += 1
-                continue
-            if target.type in cs.TS_CAST_WRAPPER_TYPES:
+            elif target.type in cs.TS_CAST_WRAPPER_TYPES:
                 inner = next(iter(target.named_children), None)
                 if inner is None:
                     break
                 target = inner
                 other_peels += 1
-                continue
-            break
-        if target.type not in (cs.TS_FUNCTION_EXPRESSION, cs.TS_GENERATOR_FUNCTION):
-            return None
-        # The plain anonymous forms (bare callee, or exactly one paren) keep
-        # their positional iife_direct_/iife_func_ names; everything else
-        # registers under its own name or as an anonymous node and resolves
-        # only by span.
-        if (
-            other_peels == 0
-            and paren_peels <= 1
-            and not self._js_iife_callee_name(target)
-        ):
-            return None
-        return self._recorded_caller(target, module_qn)
+            else:
+                break
+        return target, paren_peels, other_peels
 
     def _js_branch_callee_functions(
         self, call_node: Node, module_qn: str
@@ -2710,37 +2713,55 @@ class CallProcessor:
             node = stack.pop()
             node_type = node.type
             if (
-                node_type == cs.TS_PARENTHESIZED_EXPRESSION
-                or node_type in cs.TS_CAST_WRAPPER_TYPES
-            ):
-                stack.extend(
-                    child
-                    for child in node.named_children
-                    if child.type != cs.TS_COMMENT
+                node_type
+                in (
+                    cs.TS_FUNCTION_EXPRESSION,
+                    cs.TS_GENERATOR_FUNCTION,
+                    cs.TS_ARROW_FUNCTION,
                 )
-            elif node_type == cs.TS_JS_SEQUENCE_EXPRESSION:
-                if node.named_children:
-                    stack.append(node.named_children[-1])
-            elif node_type == cs.TS_JS_TERNARY_EXPRESSION:
-                branched = True
-                for field in (cs.FIELD_CONSEQUENCE, cs.FIELD_ALTERNATIVE):
-                    if (child := node.child_by_field_name(field)) is not None:
-                        stack.append(child)
-            elif node_type == cs.TS_BINARY_EXPRESSION and self._js_is_logical_binary(
-                node
+                and (loc := self._recorded_caller(node, module_qn)) is not None
             ):
+                locations.append(loc)
+            elif self._js_branch_operands(node, stack):
                 branched = True
-                for field in (cs.FIELD_LEFT, cs.FIELD_RIGHT):
-                    if (child := node.child_by_field_name(field)) is not None:
-                        stack.append(child)
-            elif node_type in (
-                cs.TS_FUNCTION_EXPRESSION,
-                cs.TS_GENERATOR_FUNCTION,
-                cs.TS_ARROW_FUNCTION,
-            ):
-                if (loc := self._recorded_caller(node, module_qn)) is not None:
-                    locations.append(loc)
         return locations if branched else []
+
+    @staticmethod
+    def _js_wrapper_operands(node: Node, stack: list[Node]) -> bool:
+        # Value-transparent wrappers: push what they yield; True when handled.
+        node_type = node.type
+        if (
+            node_type == cs.TS_PARENTHESIZED_EXPRESSION
+            or node_type in cs.TS_CAST_WRAPPER_TYPES
+        ):
+            stack.extend(
+                child for child in node.named_children if child.type != cs.TS_COMMENT
+            )
+            return True
+        if node_type == cs.TS_JS_SEQUENCE_EXPRESSION:
+            if node.named_children:
+                stack.append(node.named_children[-1])
+            return True
+        return False
+
+    def _js_branch_operands(self, node: Node, stack: list[Node]) -> bool:
+        # Push a branch expression's candidate operands; True only for a
+        # genuine BRANCH (ternary / short-circuit), which is what licenses
+        # the candidate-set references.
+        if self._js_wrapper_operands(node, stack):
+            return False
+        node_type = node.type
+        if node_type == cs.TS_JS_TERNARY_EXPRESSION:
+            for field in (cs.FIELD_CONSEQUENCE, cs.FIELD_ALTERNATIVE):
+                if (child := node.child_by_field_name(field)) is not None:
+                    stack.append(child)
+            return True
+        if node_type == cs.TS_BINARY_EXPRESSION and self._js_is_logical_binary(node):
+            for field in (cs.FIELD_LEFT, cs.FIELD_RIGHT):
+                if (child := node.child_by_field_name(field)) is not None:
+                    stack.append(child)
+            return True
+        return False
 
     def _ingest_function_calls(
         self,
@@ -6648,11 +6669,16 @@ class CallProcessor:
         ]
 
     def _is_unowned_js_scope(self, node: Node) -> bool:
-        # An anonymous arrow/function-expression that gets no caller node of its
-        # own (no name, no binding name): a `.map()`/`cell`/forwardRef callback.
-        # Its calls bubble up to the enclosing named scope (_attributable_func_nodes),
-        # and so must its JSX references: the enclosing JSX walk continues through it.
-        if node.type not in (cs.TS_ARROW_FUNCTION, cs.TS_FUNCTION_EXPRESSION):
+        # An anonymous arrow/function/generator expression that gets no caller
+        # node of its own (no name, no binding name): a `.map()`/`cell`/
+        # forwardRef callback. Its calls bubble up to the enclosing named
+        # scope (_attributable_func_nodes), and so must its JSX references:
+        # the enclosing JSX walk continues through it.
+        if node.type not in (
+            cs.TS_ARROW_FUNCTION,
+            cs.TS_FUNCTION_EXPRESSION,
+            cs.TS_GENERATOR_FUNCTION,
+        ):
             return False
         return not (self._get_node_name(node) or self._js_ts_arrow_binding_name(node))
 

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -2692,6 +2692,56 @@ class CallProcessor:
             return None
         return self._recorded_caller(target, module_qn)
 
+    def _js_branch_callee_functions(
+        self, call_node: Node, module_qn: str
+    ) -> list[FunctionLocation]:
+        # A BRANCH-valued callee (`(c ? f : g)()`, `(f || g)()`) may invoke
+        # ANY of its inline function operands, and no single node can be the
+        # span-resolved callee. Reference each operand so a function whose
+        # only use is such a call (and everything only it calls) stays live:
+        # a sound liveness over-approximation (issue #1002's family).
+        func_child = call_node.child_by_field_name(cs.FIELD_FUNCTION)
+        if func_child is None:
+            return []
+        locations: list[FunctionLocation] = []
+        branched = False
+        stack: list[Node] = [func_child]
+        while stack:
+            node = stack.pop()
+            node_type = node.type
+            if (
+                node_type == cs.TS_PARENTHESIZED_EXPRESSION
+                or node_type in cs.TS_CAST_WRAPPER_TYPES
+            ):
+                stack.extend(
+                    child
+                    for child in node.named_children
+                    if child.type != cs.TS_COMMENT
+                )
+            elif node_type == cs.TS_JS_SEQUENCE_EXPRESSION:
+                if node.named_children:
+                    stack.append(node.named_children[-1])
+            elif node_type == cs.TS_JS_TERNARY_EXPRESSION:
+                branched = True
+                for field in (cs.FIELD_CONSEQUENCE, cs.FIELD_ALTERNATIVE):
+                    if (child := node.child_by_field_name(field)) is not None:
+                        stack.append(child)
+            elif node_type == cs.TS_BINARY_EXPRESSION and self._js_is_logical_binary(
+                node
+            ):
+                branched = True
+                for field in (cs.FIELD_LEFT, cs.FIELD_RIGHT):
+                    if (child := node.child_by_field_name(field)) is not None:
+                        stack.append(child)
+            elif node_type in (
+                cs.TS_FUNCTION_EXPRESSION,
+                cs.TS_GENERATOR_FUNCTION,
+                cs.TS_ARROW_FUNCTION,
+            ):
+                if (loc := self._recorded_caller(node, module_qn)) is not None:
+                    locations.append(loc)
+        return locations if branched else []
+
     def _ingest_function_calls(
         self,
         caller_node: Node,
@@ -3047,6 +3097,14 @@ class CallProcessor:
                         caller_spec,
                         calls_rel,
                         (iife_loc.label, qn_key, iife_loc.qualified_name),
+                    )
+                for branch_loc in self._js_branch_callee_functions(
+                    call_node, module_qn
+                ):
+                    ensure_rel(
+                        caller_spec,
+                        cs.RelationshipType.REFERENCES,
+                        (branch_loc.label, qn_key, branch_loc.qualified_name),
                     )
             if not call_name:
                 # A callee that is itself a call (`wraps(view_func)(_view_wrapper)`)

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -371,7 +371,11 @@ _JSX_NAMED_ELEMENT_TYPES = frozenset(
 # JS/TS definition pass registers these as their own nodes named by the key
 # (scope.onSuccess), so a passed object of callbacks must reference each or
 # every TanStack-style callback reports as dead.
-_INLINE_FUNC_VALUE_TYPES = frozenset({cs.TS_ARROW_FUNCTION, cs.TS_FUNCTION_EXPRESSION})
+# Generator expressions are inline function values like the other two
+# (issue #994): a registered node with no reference path is an orphan.
+_INLINE_FUNC_VALUE_TYPES = frozenset(
+    {cs.TS_ARROW_FUNCTION, cs.TS_FUNCTION_EXPRESSION, cs.TS_GENERATOR_FUNCTION}
+)
 # JS/TS scopes that bind their own parameters (and, for a named function
 # expression, their own name) for the lexical receiver resolution of #988.
 _JS_LEXICAL_CALLABLE_SCOPES = frozenset(

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -1026,6 +1026,7 @@ class CallResolver:
         if not (
             call_name.startswith(cs.IIFE_FUNC_PREFIX)
             or call_name.startswith(cs.IIFE_ARROW_PREFIX)
+            or call_name.startswith(cs.PREFIX_IIFE_DIRECT)
         ):
             return None
         iife_qn = f"{module_qn}.{call_name}"

--- a/codebase_rag/parsers/js_ts/utils.py
+++ b/codebase_rag/parsers/js_ts/utils.py
@@ -144,7 +144,11 @@ def arrow_binding_name(func_node: Node) -> str | None:
     # step. Anonymous / destructured arrows, and arrows that are merely an
     # argument to a call bound to a name (`const m = useMutation(() => {})`),
     # stay unnamed: the arrow is not the binding's own value there.
-    if func_node.type not in (cs.TS_ARROW_FUNCTION, cs.TS_FUNCTION_EXPRESSION):
+    if func_node.type not in (
+        cs.TS_ARROW_FUNCTION,
+        cs.TS_FUNCTION_EXPRESSION,
+        cs.TS_GENERATOR_FUNCTION,
+    ):
         return None
     return _value_binding_name(func_node)
 

--- a/codebase_rag/tests/test_js_direct_iife_call_edge.py
+++ b/codebase_rag/tests/test_js_direct_iife_call_edge.py
@@ -83,3 +83,51 @@ const a = function* () { yield helper(1) }()
 module.exports = { a }
 """
     _assert_single_direct_iife_called(_run(tmp_path, src))
+
+
+def _assert_named_iife_called(cap: _Capture, leaf: str) -> None:
+    # A NAMED IIFE registers under its own name, not a positional iife_*
+    # name; the call side must agree or the node and everything only it
+    # calls report dead.
+    named = [n for n in cap.nodes if n.endswith(f".{leaf}")]
+    assert len(named) == 1
+    assert any(
+        rel == str(cs.RelationshipType.CALLS) and str(to) == named[0]
+        for _frm, rel, to in cap.rels
+    )
+
+
+def test_named_direct_generator_iife_gets_call_edge(tmp_path: Path) -> None:
+    src = """'use strict'
+function helper (x) { return x }
+const b = function* gnamed () { yield helper(2) }()
+module.exports = { b }
+"""
+    _assert_named_iife_called(_run(tmp_path, src), "gnamed")
+
+
+def test_named_parenthesized_generator_iife_gets_call_edge(tmp_path: Path) -> None:
+    src = """'use strict'
+function helper (x) { return x }
+const b = (function* pnamed () { yield helper(2) })()
+module.exports = { b }
+"""
+    _assert_named_iife_called(_run(tmp_path, src), "pnamed")
+
+
+def test_named_direct_function_iife_gets_call_edge(tmp_path: Path) -> None:
+    src = """'use strict'
+function helper (x) { return x }
+const b = function named () { return helper(2) }()
+module.exports = { b }
+"""
+    _assert_named_iife_called(_run(tmp_path, src), "named")
+
+
+def test_named_parenthesized_function_iife_gets_call_edge(tmp_path: Path) -> None:
+    src = """'use strict'
+function helper (x) { return x }
+const b = (function pnamed () { return helper(2) })()
+module.exports = { b }
+"""
+    _assert_named_iife_called(_run(tmp_path, src), "pnamed")

--- a/codebase_rag/tests/test_js_direct_iife_call_edge.py
+++ b/codebase_rag/tests/test_js_direct_iife_call_edge.py
@@ -161,3 +161,63 @@ const b = (0, function () { return helper(2) })()
 module.exports = { b }
 """
     _assert_single_anonymous_called(_run(tmp_path, src))
+
+
+def test_double_paren_named_generator_iife_gets_call_edge(tmp_path: Path) -> None:
+    # Wrappers NEST; the callee peel must run to a fixpoint or one extra
+    # pair of parens orphans the function and everything only it calls.
+    src = """'use strict'
+function helper (x) { return x }
+const b = ((function* gg () { yield helper(1) }))()
+module.exports = { b }
+"""
+    _assert_named_iife_called(_run(tmp_path, src), "gg")
+
+
+def test_double_paren_anonymous_iife_gets_call_edge(tmp_path: Path) -> None:
+    src = """'use strict'
+function helper (x) { return x }
+const a = ((function* () { yield helper(1) }))()
+const b = ((function () { return helper(2) }))()
+module.exports = { a, b }
+"""
+    cap = _run(tmp_path, src)
+    anon = [n for n in cap.nodes if cs.PREFIX_ANONYMOUS in n]
+    assert len(anon) == 2
+    calls = str(cs.RelationshipType.CALLS)
+    for node in anon:
+        assert any(rel == calls and str(to) == node for _frm, rel, to in cap.rels)
+
+
+def test_nested_sequence_paren_iifes_get_call_edges(tmp_path: Path) -> None:
+    src = """'use strict'
+function helper (x) { return x }
+const a = (0, (function* () { yield helper(1) }))()
+const b = ((0, function* () { yield helper(2) }))()
+module.exports = { a, b }
+"""
+    cap = _run(tmp_path, src)
+    anon = [n for n in cap.nodes if cs.PREFIX_ANONYMOUS in n]
+    assert len(anon) == 2
+    calls = str(cs.RelationshipType.CALLS)
+    for node in anon:
+        assert any(rel == calls and str(to) == node for _frm, rel, to in cap.rels)
+
+
+def test_ts_cast_wrapped_iife_gets_call_edge(tmp_path: Path) -> None:
+    # TS cast wrappers are value-transparent; `(fn as any)()` invokes fn.
+    src = """function helper (x: number) { return x }
+const b = (function* () { yield helper(1) } as any)()
+export { b }
+"""
+    (tmp_path / "a.ts").write_text(src)
+    parsers, queries = load_parsers()
+    cap = _Capture()
+    GraphUpdater(
+        ingestor=cap,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name=PROJECT,
+    ).run(force=True)
+    _assert_single_anonymous_called(cap)

--- a/codebase_rag/tests/test_js_direct_iife_call_edge.py
+++ b/codebase_rag/tests/test_js_direct_iife_call_edge.py
@@ -1,0 +1,85 @@
+# An unparenthesised direct IIFE (`const a = function () {...}()`) mints an
+# `iife_direct_R_C` node on the definition side; the call side must produce
+# the same name and resolve it, or every such node is an orphan reported
+# dead. Applies equally to generator IIFEs (issue #994 follow-on).
+from __future__ import annotations
+
+from pathlib import Path
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.types_defs import PropertyDict, PropertyValue, ResultRow
+
+PROJECT = "p"
+
+
+class _Capture:
+    def __init__(self) -> None:
+        self.rels: list[tuple[PropertyValue, str, PropertyValue]] = []
+        self.nodes: list[str] = []
+
+    def ensure_node_batch(self, label: str, properties: PropertyDict) -> None:
+        if qn := properties.get(cs.KEY_QUALIFIED_NAME):
+            self.nodes.append(str(qn))
+
+    def ensure_relationship_batch(
+        self,
+        from_spec: tuple[str, str, PropertyValue],
+        rel_type: str,
+        to_spec: tuple[str, str, PropertyValue],
+        properties: PropertyDict | None = None,
+    ) -> None:
+        self.rels.append((from_spec[2], str(rel_type), to_spec[2]))
+
+    def flush_all(self) -> None:
+        return None
+
+    def fetch_all(
+        self, query: str, params: PropertyDict | None = None
+    ) -> list[ResultRow]:
+        return []
+
+    def execute_write(self, query: str, params: PropertyDict | None = None) -> None:
+        return None
+
+
+def _run(tmp_path: Path, src: str) -> _Capture:
+    (tmp_path / "a.js").write_text(src)
+    parsers, queries = load_parsers()
+    cap = _Capture()
+    GraphUpdater(
+        ingestor=cap,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name=PROJECT,
+    ).run(force=True)
+    return cap
+
+
+def _assert_single_direct_iife_called(cap: _Capture) -> None:
+    iife_nodes = [n for n in cap.nodes if cs.PREFIX_IIFE_DIRECT in n]
+    assert len(iife_nodes) == 1
+    assert any(
+        rel == str(cs.RelationshipType.CALLS) and str(to) == iife_nodes[0]
+        for _frm, rel, to in cap.rels
+    )
+
+
+def test_direct_function_iife_gets_module_call_edge(tmp_path: Path) -> None:
+    src = """'use strict'
+function helper (x) { return x }
+const b = function () { return helper(2) }()
+module.exports = { b }
+"""
+    _assert_single_direct_iife_called(_run(tmp_path, src))
+
+
+def test_direct_generator_iife_gets_module_call_edge(tmp_path: Path) -> None:
+    src = """'use strict'
+function helper (x) { return x }
+const a = function* () { yield helper(1) }()
+module.exports = { a }
+"""
+    _assert_single_direct_iife_called(_run(tmp_path, src))

--- a/codebase_rag/tests/test_js_direct_iife_call_edge.py
+++ b/codebase_rag/tests/test_js_direct_iife_call_edge.py
@@ -204,6 +204,41 @@ module.exports = { a, b }
         assert any(rel == calls and str(to) == node for _frm, rel, to in cap.rels)
 
 
+def _has_inbound(cap: _Capture, node_qn: str) -> bool:
+    return any(
+        str(to) == node_qn and rel != str(cs.RelationshipType.DEFINES)
+        for _frm, rel, to in cap.rels
+    )
+
+
+def test_ternary_callee_function_operands_are_referenced(tmp_path: Path) -> None:
+    # A branch-valued callee may invoke ANY of its inline function operands;
+    # each must be referenced or the operand (and everything only it calls)
+    # reports dead (issue #1002 family).
+    src = """'use strict'
+function onlyHere (x) { return x }
+const k = 1
+const a = (k ? function* gt () { yield onlyHere(1) } : null)()
+module.exports = { a }
+"""
+    cap = _run(tmp_path, src)
+    named = [n for n in cap.nodes if n.endswith(".gt")]
+    assert len(named) == 1
+    assert _has_inbound(cap, named[0])
+
+
+def test_logical_callee_function_operands_are_referenced(tmp_path: Path) -> None:
+    src = """'use strict'
+function onlyHere (x) { return x }
+const b = (null || function () { return onlyHere(2) })()
+module.exports = { b }
+"""
+    cap = _run(tmp_path, src)
+    anon = [n for n in cap.nodes if cs.PREFIX_ANONYMOUS in n]
+    assert len(anon) == 1
+    assert _has_inbound(cap, anon[0])
+
+
 def test_ts_cast_wrapped_iife_gets_call_edge(tmp_path: Path) -> None:
     # TS cast wrappers are value-transparent; `(fn as any)()` invokes fn.
     src = """function helper (x: number) { return x }

--- a/codebase_rag/tests/test_js_direct_iife_call_edge.py
+++ b/codebase_rag/tests/test_js_direct_iife_call_edge.py
@@ -131,3 +131,33 @@ const b = (function pnamed () { return helper(2) })()
 module.exports = { b }
 """
     _assert_named_iife_called(_run(tmp_path, src), "pnamed")
+
+
+def _assert_single_anonymous_called(cap: _Capture) -> None:
+    anon = [n for n in cap.nodes if cs.PREFIX_ANONYMOUS in n]
+    assert len(anon) == 1
+    assert any(
+        rel == str(cs.RelationshipType.CALLS) and str(to) == anon[0]
+        for _frm, rel, to in cap.rels
+    )
+
+
+def test_sequence_generator_iife_gets_call_edge(tmp_path: Path) -> None:
+    # The comma operator yields its LAST operand; `(0, fn)()` invokes fn
+    # (the indirect-this idiom). The function registers as an anonymous
+    # node, so the call side must resolve it by span or it orphans.
+    src = """'use strict'
+function helper (x) { return x }
+const a = (0, function* () { yield helper(1) })()
+module.exports = { a }
+"""
+    _assert_single_anonymous_called(_run(tmp_path, src))
+
+
+def test_sequence_function_iife_gets_call_edge(tmp_path: Path) -> None:
+    src = """'use strict'
+function helper (x) { return x }
+const b = (0, function () { return helper(2) })()
+module.exports = { b }
+"""
+    _assert_single_anonymous_called(_run(tmp_path, src))

--- a/codebase_rag/tests/test_js_fn_call_apply_statement_edge.py
+++ b/codebase_rag/tests/test_js_fn_call_apply_statement_edge.py
@@ -575,12 +575,9 @@ module.exports = { C, helper }
     assert not any(rel == calls for _f, rel in _edges_to_leaf(cap, "helper"))
 
 
-def test_generator_function_expression_receiver_is_safe(tmp_path: Path) -> None:
-    # A `const gen = function* () {...}` receiver is recognised as a callable
-    # binding, but the definition pass does not yet REGISTER generator
-    # function expressions as nodes (tracked separately), so the span lookup
-    # correctly refuses and nothing is emitted. Pin that no edge is invented;
-    # once generator expressions are ingested, this flips to a positive link.
+def test_generator_function_expression_receiver_links(tmp_path: Path) -> None:
+    # A `const gen = function* () {...}` receiver registers like any inline
+    # function (issue #994) and the `.call` resolves to it by span.
     src = """'use strict'
 function main () {
   const gen = function* () { yield 1 }
@@ -590,7 +587,8 @@ function main () {
 module.exports = { main }
 """
     cap = _run(tmp_path, src)
-    assert not _edges_to_leaf(cap, "gen")
+    calls = str(cs.RelationshipType.CALLS)
+    assert any(rel == calls for _f, rel in _edges_to_leaf(cap, "gen"))
 
 
 def test_export_const_arrow_receiver_links(tmp_path: Path) -> None:

--- a/codebase_rag/tests/test_js_generator_expression_registration.py
+++ b/codebase_rag/tests/test_js_generator_expression_registration.py
@@ -102,7 +102,7 @@ module.exports = { main }
 """
     cap = _run(tmp_path, src)
     assert any(
-        "helperFn" in str(to) and rel != str(cs.RelationshipType.DEFINES)
+        "helperFn" in str(to) and rel == str(cs.RelationshipType.REFERENCES)
         for _frm, rel, to in cap.rels
     )
 

--- a/codebase_rag/tests/test_js_generator_expression_registration.py
+++ b/codebase_rag/tests/test_js_generator_expression_registration.py
@@ -89,6 +89,24 @@ module.exports = { api }
     assert _has_inbound(cap, ".gen")
 
 
+def test_anonymous_generator_body_references_bubble(tmp_path: Path) -> None:
+    # An anonymous, unbound generator gets no caller pass of its own; the
+    # reference-emission walks must descend THROUGH it (like anonymous
+    # arrows) or a returned function inside it is never referenced and
+    # reports dead with everything only it calls.
+    src = """'use strict'
+function helperFn () { return 1 }
+function stream (g) { return g }
+function main () { return stream(function* () { return helperFn }) }
+module.exports = { main }
+"""
+    cap = _run(tmp_path, src)
+    assert any(
+        "helperFn" in str(to) and rel != str(cs.RelationshipType.DEFINES)
+        for _frm, rel, to in cap.rels
+    )
+
+
 def test_prototype_generator_assignment_names_the_method(tmp_path: Path) -> None:
     src = """'use strict'
 function C () {}

--- a/codebase_rag/tests/test_js_generator_expression_registration.py
+++ b/codebase_rag/tests/test_js_generator_expression_registration.py
@@ -1,0 +1,100 @@
+# Generator function EXPRESSIONS must behave exactly like function
+# expressions everywhere: registration (issue #994), reference emission for
+# inline values, and the object-literal / prototype naming passes. A node
+# minted without those paths is an orphan that reports dead.
+from __future__ import annotations
+
+from pathlib import Path
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.types_defs import PropertyDict, PropertyValue, ResultRow
+
+PROJECT = "p"
+
+
+class _Capture:
+    def __init__(self) -> None:
+        self.rels: list[tuple[PropertyValue, str, PropertyValue]] = []
+        self.nodes: list[str] = []
+
+    def ensure_node_batch(self, label: str, properties: PropertyDict) -> None:
+        if qn := properties.get(cs.KEY_QUALIFIED_NAME):
+            self.nodes.append(str(qn))
+
+    def ensure_relationship_batch(
+        self,
+        from_spec: tuple[str, str, PropertyValue],
+        rel_type: str,
+        to_spec: tuple[str, str, PropertyValue],
+        properties: PropertyDict | None = None,
+    ) -> None:
+        self.rels.append((from_spec[2], str(rel_type), to_spec[2]))
+
+    def flush_all(self) -> None:
+        return None
+
+    def fetch_all(
+        self, query: str, params: PropertyDict | None = None
+    ) -> list[ResultRow]:
+        return []
+
+    def execute_write(self, query: str, params: PropertyDict | None = None) -> None:
+        return None
+
+
+def _run(tmp_path: Path, src: str) -> _Capture:
+    (tmp_path / "a.js").write_text(src)
+    parsers, queries = load_parsers()
+    cap = _Capture()
+    GraphUpdater(
+        ingestor=cap,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name=PROJECT,
+    ).run(force=True)
+    return cap
+
+
+def _has_inbound(cap: _Capture, target_contains: str) -> bool:
+    return any(
+        target_contains in str(to) and rel != str(cs.RelationshipType.DEFINES)
+        for _frm, rel, to in cap.rels
+    )
+
+
+def test_generator_call_argument_is_referenced(tmp_path: Path) -> None:
+    src = """'use strict'
+function stream (g) { return g }
+function main () { stream(function* () { yield 1 }) }
+module.exports = { main }
+"""
+    cap = _run(tmp_path, src)
+    gen_nodes = [n for n in cap.nodes if cs.PREFIX_ANONYMOUS in n]
+    assert gen_nodes
+    assert any(_has_inbound(cap, n) for n in gen_nodes)
+
+
+def test_object_literal_generator_value_names_and_references(tmp_path: Path) -> None:
+    src = """'use strict'
+const api = {
+  gen: function* () { yield 1 },
+}
+module.exports = { api }
+"""
+    cap = _run(tmp_path, src)
+    assert any(str(n).endswith(".gen") for n in cap.nodes)
+    assert _has_inbound(cap, ".gen")
+
+
+def test_prototype_generator_assignment_names_the_method(tmp_path: Path) -> None:
+    src = """'use strict'
+function C () {}
+C.prototype.gen = function* () { yield 1 }
+function main (c) { return c.gen() }
+module.exports = { C, main }
+"""
+    cap = _run(tmp_path, src)
+    assert any(str(n).endswith("C.gen") for n in cap.nodes)

--- a/codebase_rag/tests/test_js_generator_expression_registration.py
+++ b/codebase_rag/tests/test_js_generator_expression_registration.py
@@ -73,8 +73,8 @@ module.exports = { main }
 """
     cap = _run(tmp_path, src)
     gen_nodes = [n for n in cap.nodes if cs.PREFIX_ANONYMOUS in n]
-    assert gen_nodes
-    assert any(_has_inbound(cap, n) for n in gen_nodes)
+    assert len(gen_nodes) == 1
+    assert _has_inbound(cap, gen_nodes[0])
 
 
 def test_object_literal_generator_value_names_and_references(tmp_path: Path) -> None:
@@ -98,3 +98,24 @@ module.exports = { C, main }
 """
     cap = _run(tmp_path, src)
     assert any(str(n).endswith("C.gen") for n in cap.nodes)
+    assert any(
+        rel == str(cs.RelationshipType.CALLS)
+        and str(frm).endswith(".main")
+        and str(to).endswith("C.gen")
+        for frm, rel, to in cap.rels
+    )
+
+
+def test_parenthesized_generator_iife_gets_module_call_edge(tmp_path: Path) -> None:
+    src = """'use strict'
+function helper (x) { return x }
+const a = (function* () { yield helper(1) })()
+module.exports = { a }
+"""
+    cap = _run(tmp_path, src)
+    iife_nodes = [n for n in cap.nodes if cs.IIFE_FUNC_PREFIX in n]
+    assert len(iife_nodes) == 1
+    assert any(
+        rel == str(cs.RelationshipType.CALLS) and str(to) == iife_nodes[0]
+        for _frm, rel, to in cap.rels
+    )

--- a/docs/architecture/graph-schema.md
+++ b/docs/architecture/graph-schema.md
@@ -120,12 +120,12 @@ The function- and class-defining AST node types captured per language (auto-gene
 - **Dart**: `class_definition`, `constant_constructor_signature`, `constructor_signature`, `enum_declaration`, `extension_declaration`, `extension_type_declaration`, `factory_constructor_signature`, `function_signature`, `getter_signature`, `mixin_declaration`, `setter_signature`
 - **Go**: `function_declaration`, `method_declaration`, `type_alias`, `type_spec`
 - **Java**: `annotation_type_declaration`, `class_declaration`, `constructor_declaration`, `enum_declaration`, `interface_declaration`, `method_declaration`, `record_declaration`
-- **JavaScript**: `arrow_function`, `class`, `class_declaration`, `function_declaration`, `function_expression`, `generator_function_declaration`, `method_definition`
+- **JavaScript**: `arrow_function`, `class`, `class_declaration`, `function_declaration`, `function_expression`, `generator_function`, `generator_function_declaration`, `method_definition`
 - **Lua**: `function_declaration`, `function_definition`
 - **PHP**: `anonymous_function`, `arrow_function`, `class_declaration`, `enum_declaration`, `function_definition`, `interface_declaration`, `method_declaration`, `trait_declaration`
 - **Python**: `class_definition`, `function_definition`
 - **Rust**: `closure_expression`, `enum_item`, `function_item`, `function_signature_item`, `impl_item`, `macro_definition`, `struct_item`, `trait_item`, `type_item`, `union_item`
-- **TypeScript (TSX)**: `abstract_class_declaration`, `arrow_function`, `class`, `class_declaration`, `enum_declaration`, `function_declaration`, `function_expression`, `function_signature`, `generator_function_declaration`, `interface_declaration`, `internal_module`, `method_definition`, `type_alias_declaration`
-- **TypeScript**: `abstract_class_declaration`, `arrow_function`, `class`, `class_declaration`, `enum_declaration`, `function_declaration`, `function_expression`, `function_signature`, `generator_function_declaration`, `interface_declaration`, `internal_module`, `method_definition`, `type_alias_declaration`
+- **TypeScript (TSX)**: `abstract_class_declaration`, `arrow_function`, `class`, `class_declaration`, `enum_declaration`, `function_declaration`, `function_expression`, `function_signature`, `generator_function`, `generator_function_declaration`, `interface_declaration`, `internal_module`, `method_definition`, `type_alias_declaration`
+- **TypeScript**: `abstract_class_declaration`, `arrow_function`, `class`, `class_declaration`, `enum_declaration`, `function_declaration`, `function_expression`, `function_signature`, `generator_function`, `generator_function_declaration`, `interface_declaration`, `internal_module`, `method_definition`, `type_alias_declaration`
 - **Scala**: `class_definition`, `function_declaration`, `function_definition`, `object_definition`, `trait_definition`
 <!-- /SECTION:language_mappings -->

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.517"
+version = "0.0.520"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Fixes #994. Generator function EXPRESSIONS (`const g = function* () {}`) were absent from `JS_TS_FUNCTION_NODES`, so they never registered as graph nodes and nothing could reference them. Registering them then exposed a whole family of IIFE shapes where the definition side mints a node the call side cannot name, each producing dead-code false positives; adversarial review drove eight rounds until the family was closed.

## Fixes, in dependency order

1. **Registration**: `generator_function` joins `JS_TS_FUNCTION_NODES` and the FQN specs, so generator expressions register exactly like function expressions.
2. **References and naming**: `_INLINE_FUNC_VALUE_TYPES` and the object-literal, prototype and assignment naming queries accept generators, so `api.gen = function* () {}` names and references like its function-expression sibling.
3. **Parenthesised IIFE**: `_get_iife_target_name` matches generators in the `iife_func_` arm (the prefix the definition side already mints for them).
4. **Direct IIFE**: a bare `function () {...}()` / `function* () {...}()` callee now yields the `iife_direct_` positional name and `_try_resolve_iife` accepts that prefix. This also fixes the pre-existing orphan for plain function expressions on main.
5. **Named IIFE**: `(function build () {...})()` registers under its own name (a duplicate variant when a sibling shares it), so bare-name lookup is unsafe; a span-resolved path (`_js_named_iife_callee` via `_recorded_caller`) emits the CALLS edge to the exact minted node. Fixes the pre-existing named-IIFE orphan for function expressions too, without reviving namesakes (the collision pin holds).
6. **Sequence and nested wrappers**: the callee peel runs to a FIXPOINT over parenthesised, sequence (last operand) and TS cast wrappers, so `(0, fn)()`, `((fn))()`, `((0, (fn)))()` and the cast forms all resolve; verified terminating on four-level nestings.
7. **Branch-valued callees**: `(c ? f : g)()` and short-circuit callees have no single static callee, so each inline function operand gets a REFERENCES edge (sound liveness over-approximation, issue #1002's family). This cleared three real excalidraw production false positives (`(this.options.fill ?? (() => "black"))(this)` in animatedTrail.ts).

The remaining un-nameable case (an identifier operand of a branch callee) and the general unreachable-owner question are tracked in #1002.

## Verification

Strict RED first for every fix: each pin confirmed failing before its change (see commit history). Full suite 6103 passed, 5 skipped, 0 failed; every increment is exactly the new pins over the prior baseline, nothing skipped or weakened. Eight adversarial review rounds in pinned worktrees against the merge base: 41-fixture sweep with zero branch-only dead entries and fourteen fixtures strictly better than the merge base; fastify delta zero (21 vs 21); excalidraw 21 vs 24 (three genuine false positives cleared, nothing added); namesake-collision fixture binds the duplicate variant, never the namesake.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved JavaScript and TypeScript analysis for generator functions.
  - Enhanced call and reference tracking for immediately invoked functions, including direct, nested, parenthesized, conditional, logical, sequence, and cast expressions.
  - Improved recognition of generator functions in assignments, object methods, prototype methods, and function references.

- **Documentation**
  - Updated architecture documentation to include generator function mappings.

- **Tests**
  - Added comprehensive coverage for generator functions and complex IIFE call patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->