### PR TITLE
fix: resolve symbol-keyed member dispatch through a project-wide symbol index

### DIFF
--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -104,6 +104,9 @@ TS_PROPERTY_IDENTIFIER = "property_identifier"
 TS_JS_COMPUTED_PROPERTY_NAME = "computed_property_name"
 # The `(a, b = 1, ...rest)` parameter list of a function.
 TS_JS_FORMAL_PARAMETERS = "formal_parameters"
+# A class field in the JS grammar (`[k] = v` in a class body); TS spells it
+# public_field_definition. Its key sits in the `property` field.
+TS_JS_FIELD_DEFINITION = "field_definition"
 # The Symbol global: `Symbol('x')` / `Symbol.for('x')` mint the unique keys
 # that symbol-keyed member dispatch (issue #989) indexes.
 JS_SYMBOL_GLOBAL = "Symbol"

--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -100,6 +100,11 @@ TS_MODULE = "module"
 TS_CLASS_BODY = "class_body"
 
 TS_PROPERTY_IDENTIFIER = "property_identifier"
+# `[expr]` as an object-literal / class-member key.
+TS_JS_COMPUTED_PROPERTY_NAME = "computed_property_name"
+# The Symbol global: `Symbol('x')` / `Symbol.for('x')` mint the unique keys
+# that symbol-keyed member dispatch (issue #989) indexes.
+JS_SYMBOL_GLOBAL = "Symbol"
 
 # JS prototype property keywords
 JS_PROTOTYPE_KEYWORD = "prototype"

--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -102,6 +102,8 @@ TS_CLASS_BODY = "class_body"
 TS_PROPERTY_IDENTIFIER = "property_identifier"
 # `[expr]` as an object-literal / class-member key.
 TS_JS_COMPUTED_PROPERTY_NAME = "computed_property_name"
+# The `(a, b = 1, ...rest)` parameter list of a function.
+TS_JS_FORMAL_PARAMETERS = "formal_parameters"
 # The Symbol global: `Symbol('x')` / `Symbol.for('x')` mint the unique keys
 # that symbol-keyed member dispatch (issue #989) indexes.
 JS_SYMBOL_GLOBAL = "Symbol"

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1917,10 +1917,16 @@ class GraphUpdater:
                 self.queries,
                 func_class_captures_cache=captures_cache,
             )
+            self.factory.call_processor.collect_js_symbol_bindings(
+                file_path, root_node, language
+            )
         # Bindings are pending until every file's ctor metadata (param order,
         # param->attribute renames) is in: a construction site may be scanned
-        # before the file defining its class.
+        # before the file defining its class. Symbol-keyed installations wait
+        # the same way: a `[kX]: value` site may be swept before the file
+        # defining kX.
         self.factory.call_processor.finalize_callable_field_bindings()
+        self.factory.call_processor.finalize_js_symbol_bindings()
         for file_path, language in self._parsed_files:
             root_node = self._ast_for(file_path)
             if root_node is None:

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -119,14 +119,6 @@ _JS_SCOPE_CONTAINER_TYPES = frozenset(
 )
 
 
-def _walk_named(node: Node):  # noqa: ANN201 - simple generator over Node
-    stack = list(node.named_children)
-    while stack:
-        current = stack.pop()
-        yield current
-        stack.extend(current.named_children)
-
-
 # Languages with argument-REFERENCE edges but no interprocedural
 # callable-param flow: passing a function keeps it reachable (REFERENCES),
 # while invocation edges stay with the flow languages.
@@ -905,6 +897,7 @@ class CallProcessor:
         "js_symbol_constants",
         "_js_symbol_assignments",
         "js_symbol_member_types",
+        "_js_proto_evidence_cache",
     )
 
     def __init__(
@@ -954,6 +947,7 @@ class CallProcessor:
         self.js_symbol_constants: set[str] = set()
         self._js_symbol_assignments: list[tuple[str, str, str]] = []
         self.js_symbol_member_types: dict[str, set[str]] = {}
+        self._js_proto_evidence_cache: dict[tuple[str, str | None], bool] = {}
 
         self._resolver = CallResolver(
             function_registry=function_registry,
@@ -3177,11 +3171,14 @@ class CallProcessor:
                     targets, unique = sym_targets
                     sym_rel = calls_rel if unique else cs.RelationshipType.REFERENCES
                     for sym_label, sym_qn_target in targets:
-                        ensure_rel(
-                            caller_spec,
-                            sym_rel,
-                            (sym_label, qn_key, sym_qn_target),
-                        )
+                        for variant in resolver.function_registry.variants(
+                            sym_qn_target
+                        ):
+                            ensure_rel(
+                                caller_spec,
+                                sym_rel,
+                                (sym_label, qn_key, variant),
+                            )
                     call_name = None
             if not call_name:
                 # A callee that is itself a call (`wraps(view_func)(_view_wrapper)`)
@@ -6739,12 +6736,15 @@ class CallProcessor:
         return not (self._get_node_name(node) or self._js_ts_arrow_binding_name(node))
 
     def reset_js_receiver_bindings(self) -> None:
-        # Drop the per-file receiver-binding index; a reused updater's next
-        # pass re-parses files and must rebuild it from the fresh trees.
+        # Despite the historical name this clears ALL per-run JS call-pass
+        # state: the receiver-binding index, the symbol index, and the
+        # prototype-evidence memo. A reused updater's next pass re-parses
+        # files and must rebuild each from the fresh trees.
         self._js_file_receiver_bindings.clear()
         self.js_symbol_constants.clear()
         self._js_symbol_assignments.clear()
         self.js_symbol_member_types.clear()
+        self._js_proto_evidence_cache.clear()
 
     def collect_js_symbol_bindings(
         self,
@@ -6767,20 +6767,23 @@ class CallProcessor:
             )
         except ValueError:
             return
-        stack: list[Node] = [root_node]
-        while stack:
-            node = stack.pop()
-            if node.type == cs.TS_VARIABLE_DECLARATOR:
-                self._collect_symbol_declarator(node, module_qn)
-            elif node.type in (
-                cs.TS_PAIR,
-                cs.TS_PUBLIC_FIELD_DEFINITION,
-                cs.TS_JS_FIELD_DEFINITION,
-            ):
-                self._collect_symbol_pair(node, module_qn)
-            elif node.type == cs.TS_JS_ASSIGNMENT_EXPRESSION:
-                self._collect_symbol_subscript_assignment(node, module_qn)
-            stack.extend(node.children)
+        try:
+            stack: list[Node] = [root_node]
+            while stack:
+                node = stack.pop()
+                if node.type == cs.TS_VARIABLE_DECLARATOR:
+                    self._collect_symbol_declarator(node, module_qn)
+                elif node.type in (
+                    cs.TS_PAIR,
+                    cs.TS_PUBLIC_FIELD_DEFINITION,
+                    cs.TS_JS_FIELD_DEFINITION,
+                ):
+                    self._collect_symbol_pair(node, module_qn)
+                elif node.type == cs.TS_JS_ASSIGNMENT_EXPRESSION:
+                    self._collect_symbol_subscript_assignment(node, module_qn)
+                stack.extend(node.children)
+        except Exception as e:
+            logger.error(ls.CALL_PROCESSING_FAILED, path=file_path, error=e)
 
     @staticmethod
     def _js_is_symbol_mint(value: Node | None) -> bool:
@@ -6801,12 +6804,25 @@ class CallProcessor:
             )
         return False
 
+    @staticmethod
+    def _js_inside_callable(node: Node) -> bool:
+        current = node.parent
+        while current is not None:
+            if current.type in cs.JS_TS_FUNCTION_NODES:
+                return True
+            current = current.parent
+        return False
+
     def _collect_symbol_declarator(self, node: Node, module_qn: str) -> None:
+        # Only a MODULE-scoped binding mints a shared symbol constant; a
+        # function-local `k = Symbol(...)` is a local value whose name must
+        # not hijack same-spelled reads elsewhere in the module.
         target = node.child_by_field_name(cs.FIELD_NAME)
         if (
             target is not None
             and target.type == cs.TS_IDENTIFIER
             and self._js_is_symbol_mint(node.child_by_field_name(cs.FIELD_VALUE))
+            and not self._js_inside_callable(node)
             and (name := safe_decode_text(target))
         ):
             self.js_symbol_constants.add(f"{module_qn}{cs.SEPARATOR_DOT}{name}")
@@ -6823,8 +6839,9 @@ class CallProcessor:
         if key is None or value is None:
             return
         if key.type == cs.TS_PROPERTY_IDENTIFIER and self._js_is_symbol_mint(value):
-            if name := safe_decode_text(key):
-                self.js_symbol_constants.add(f"{module_qn}{cs.SEPARATOR_DOT}{name}")
+            if not self._js_inside_callable(node):
+                if name := safe_decode_text(key):
+                    self.js_symbol_constants.add(f"{module_qn}{cs.SEPARATOR_DOT}{name}")
             return
         if key.type == cs.TS_JS_COMPUTED_PROPERTY_NAME:
             index = next(
@@ -6925,6 +6942,14 @@ class CallProcessor:
         return self._js_has_prototype_members(class_qn, member=method)
 
     def _js_has_prototype_members(self, fn_qn: str, member: str | None = None) -> bool:
+        cache_key = (fn_qn, member)
+        if cache_key in self._js_proto_evidence_cache:
+            return self._js_proto_evidence_cache[cache_key]
+        result = self._js_scan_prototype_members(fn_qn, member)
+        self._js_proto_evidence_cache[cache_key] = result
+        return result
+
+    def _js_scan_prototype_members(self, fn_qn: str, member: str | None = None) -> bool:
         # Constructor EVIDENCE: at least one `Fn.prototype.x = ...` in the
         # function's module (any member), or, when `member` is given, an
         # assignment for that SPECIFIC member. Without it, `module.fn.name`
@@ -7429,7 +7454,7 @@ class CallProcessor:
         fan = [
             (registry[qn], qn)
             for qn in sorted(name_matches)
-            if qn in registry and registry[qn] != NodeType.CLASS
+            if qn in registry and registry[qn] in (NodeType.FUNCTION, NodeType.METHOD)
         ]
         return fan, False
 

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -869,6 +869,9 @@ class CallProcessor:
         "_rpc_exposure",
         "_dispatch_registry",
         "_js_file_receiver_bindings",
+        "js_symbol_constants",
+        "_js_symbol_assignments",
+        "js_symbol_member_types",
     )
 
     def __init__(
@@ -910,6 +913,14 @@ class CallProcessor:
         self._js_file_receiver_bindings: dict[
             str, dict[str, list[tuple[Node | None, Node | None]]]
         ] = {}
+        # Symbol-keyed member dispatch (issue #989): qns of symbol CONSTANTS
+        # (`kX = Symbol(...)`, `kX: Symbol(...)`), raw `[kX]: value` /
+        # `obj[kX] = value` records as (module_qn, symbol_name, class_qn),
+        # and the finalised symbol qn -> assigned class qns map. Strings
+        # only: holding Node values would pin whole trees.
+        self.js_symbol_constants: set[str] = set()
+        self._js_symbol_assignments: list[tuple[str, str, str]] = []
+        self.js_symbol_member_types: dict[str, set[str]] = {}
 
         self._resolver = CallResolver(
             function_registry=function_registry,
@@ -2940,6 +2951,22 @@ class CallProcessor:
                         calls_rel,
                         (loc.label, qn_key, loc.qualified_name),
                     )
+                # `recv[kSym].method(...)`: the callee text contains brackets
+                # and resolves nowhere useful; the symbol index carries the
+                # edges, and the generic path (with its phantom-prone
+                # bare-name fallback) is suppressed for the recognised shape.
+                if (
+                    sym_targets := self._js_symbol_member_targets(call_node, module_qn)
+                ) is not None:
+                    targets, unique = sym_targets
+                    sym_rel = calls_rel if unique else cs.RelationshipType.REFERENCES
+                    for sym_label, sym_qn_target in targets:
+                        ensure_rel(
+                            caller_spec,
+                            sym_rel,
+                            (sym_label, qn_key, sym_qn_target),
+                        )
+                    call_name = None
             if not call_name:
                 # A callee that is itself a call (`wraps(view_func)(_view_wrapper)`)
                 # or otherwise yields no name still consumes its arguments through
@@ -6494,6 +6521,280 @@ class CallProcessor:
         # Drop the per-file receiver-binding index; a reused updater's next
         # pass re-parses files and must rebuild it from the fresh trees.
         self._js_file_receiver_bindings.clear()
+        self.js_symbol_constants.clear()
+        self._js_symbol_assignments.clear()
+        self.js_symbol_member_types.clear()
+
+    def collect_js_symbol_bindings(
+        self,
+        file_path: Path,
+        root_node: Node,
+        language: cs.SupportedLanguage,
+    ) -> None:
+        # Pre-pass for symbol-keyed member dispatch (issue #989): one walk
+        # per JS/TS file collecting (a) symbol CONSTANT definitions
+        # (`kX = Symbol('...')` declarators, `kX: Symbol('...')` pairs) and
+        # (b) raw symbol-keyed installations (`{ [kX]: value }` pairs,
+        # `obj[kX] = value` assignments) with the value's class resolved
+        # immediately (strings only). Whether a key actually names a symbol
+        # constant is judged in finalize, once every file's constants are in.
+        if language not in _JS_TS_LANGUAGES:
+            return
+        try:
+            module_qn = self._module_qn(
+                file_path, cached_relative_path(file_path, self.repo_path)
+            )
+        except ValueError:
+            return
+        stack: list[Node] = [root_node]
+        while stack:
+            node = stack.pop()
+            if node.type == cs.TS_VARIABLE_DECLARATOR:
+                self._collect_symbol_declarator(node, module_qn)
+            elif node.type == cs.TS_PAIR:
+                self._collect_symbol_pair(node, module_qn)
+            elif node.type == cs.TS_JS_ASSIGNMENT_EXPRESSION:
+                self._collect_symbol_subscript_assignment(node, module_qn)
+            stack.extend(node.children)
+
+    @staticmethod
+    def _js_is_symbol_mint(value: Node | None) -> bool:
+        # `Symbol('x')` or `Symbol.for('x')`.
+        if value is None or value.type != cs.TS_CALL_EXPRESSION:
+            return False
+        func = value.child_by_field_name(cs.FIELD_FUNCTION)
+        if func is None:
+            return False
+        if func.type == cs.TS_IDENTIFIER:
+            return safe_decode_text(func) == cs.JS_SYMBOL_GLOBAL
+        if func.type == cs.TS_MEMBER_EXPRESSION:
+            obj = func.child_by_field_name(cs.FIELD_OBJECT)
+            return (
+                obj is not None
+                and obj.type == cs.TS_IDENTIFIER
+                and safe_decode_text(obj) == cs.JS_SYMBOL_GLOBAL
+            )
+        return False
+
+    def _collect_symbol_declarator(self, node: Node, module_qn: str) -> None:
+        target = node.child_by_field_name(cs.FIELD_NAME)
+        if (
+            target is not None
+            and target.type == cs.TS_IDENTIFIER
+            and self._js_is_symbol_mint(node.child_by_field_name(cs.FIELD_VALUE))
+            and (name := safe_decode_text(target))
+        ):
+            self.js_symbol_constants.add(f"{module_qn}{cs.SEPARATOR_DOT}{name}")
+
+    def _collect_symbol_pair(self, node: Node, module_qn: str) -> None:
+        key = node.child_by_field_name(cs.FIELD_KEY)
+        value = node.child_by_field_name(cs.FIELD_VALUE)
+        if key is None or value is None:
+            return
+        if key.type == cs.TS_PROPERTY_IDENTIFIER and self._js_is_symbol_mint(value):
+            if name := safe_decode_text(key):
+                self.js_symbol_constants.add(f"{module_qn}{cs.SEPARATOR_DOT}{name}")
+            return
+        if key.type == cs.TS_JS_COMPUTED_PROPERTY_NAME:
+            index = next(
+                (c for c in key.named_children if c.type != cs.TS_COMMENT), None
+            )
+            if (
+                index is not None
+                and index.type == cs.TS_IDENTIFIER
+                and (sym_name := safe_decode_text(index))
+                and (class_qn := self._js_symbol_value_class_qn(value, module_qn))
+            ):
+                self._js_symbol_assignments.append((module_qn, sym_name, class_qn))
+
+    def _collect_symbol_subscript_assignment(self, node: Node, module_qn: str) -> None:
+        left = node.child_by_field_name(cs.FIELD_LEFT)
+        value = node.child_by_field_name(cs.TS_FIELD_RIGHT)
+        if left is None or value is None or left.type != cs.TS_SUBSCRIPT_EXPRESSION:
+            return
+        index = left.child_by_field_name(cs.TS_FIELD_INDEX)
+        if (
+            index is not None
+            and index.type == cs.TS_IDENTIFIER
+            and (sym_name := safe_decode_text(index))
+            and (class_qn := self._js_symbol_value_class_qn(value, module_qn))
+        ):
+            self._js_symbol_assignments.append((module_qn, sym_name, class_qn))
+
+    def _js_symbol_value_class_qn(self, value: Node, module_qn: str) -> str | None:
+        # Resolve the INSTALLED value to a class qn, entirely at sweep time
+        # so only strings are kept: a direct construction, a factory call, or
+        # an identifier typed by the enclosing callable's locals.
+        js = self._resolver.type_inference.js_type_inference
+        if value.type == cs.TS_IDENTIFIER:
+            enclosing = value.parent
+            while (
+                enclosing is not None and enclosing.type not in cs.JS_TS_FUNCTION_NODES
+            ):
+                enclosing = enclosing.parent
+            if enclosing is None:
+                return None
+            hint = js.build_local_variable_type_map(enclosing, module_qn).get(
+                safe_decode_text(value) or ""
+            )
+        else:
+            hint = js._infer_js_variable_type_from_value(value, module_qn)
+        if not hint:
+            return None
+        return self._js_class_qn_from_hint(hint, module_qn)
+
+    def _js_class_qn_from_hint(self, hint: str, module_qn: str) -> str | None:
+        js = self._resolver.type_inference.js_type_inference
+        registry = self._resolver.function_registry
+        if hint in registry and registry[hint] == NodeType.CLASS:
+            return hint
+        # _resolve_js_class_name falls back to the imported qn even when it
+        # is not a class; only a REGISTERED class ends the search here.
+        resolved = js._resolve_js_class_name(hint, module_qn)
+        if (
+            resolved is not None
+            and resolved in registry
+            and registry[resolved] == NodeType.CLASS
+        ):
+            return resolved
+        # A bare FACTORY name: resolve the function and type its return.
+        fn_qn = self._js_symbol_name_qn(hint, module_qn)
+        if fn_qn is None or fn_qn not in registry:
+            return None
+        fn_node = self._js_function_node_by_qn(fn_qn)
+        if fn_node is None:
+            return None
+        factory_module = fn_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
+        # A direct `return new X(...)` names the class outright (the general
+        # return analysis resolves a NEW to the factory's OWN scope, which
+        # for a top-level function is the module).
+        if ctor := self._js_direct_return_ctor(fn_node):
+            resolved = js._resolve_js_class_name(ctor, factory_module)
+            if (
+                resolved is not None
+                and resolved in registry
+                and registry[resolved] == NodeType.CLASS
+            ):
+                return resolved
+            return None
+        returned = js._analyze_return_statements(fn_node, fn_qn)
+        if returned is None:
+            return None
+        if returned in registry and registry[returned] == NodeType.CLASS:
+            return returned
+        resolved = js._resolve_js_class_name(returned, factory_module)
+        if (
+            resolved is not None
+            and resolved in registry
+            and registry[resolved] == NodeType.CLASS
+        ):
+            return resolved
+        return None
+
+    @staticmethod
+    def _js_direct_return_ctor(fn_node: Node) -> str | None:
+        stack: list[Node] = list(fn_node.children)
+        while stack:
+            node = stack.pop()
+            if node.type in cs.JS_TS_FUNCTION_NODES:
+                # A nested callable's returns are its own.
+                continue
+            if node.type == cs.TS_RETURN_STATEMENT:
+                for child in node.named_children:
+                    if child.type == cs.TS_NEW_EXPRESSION:
+                        return js_ts_utils.extract_constructor_name(child)
+            stack.extend(node.children)
+        return None
+
+    def _js_function_node_by_qn(self, fn_qn: str) -> Node | None:
+        # Locate a top-level FUNCTION's definition node from its qn (the
+        # class.method finder cannot: it splits qns as module.Class.method).
+        module_qn, _, fn_name = fn_qn.rpartition(cs.SEPARATOR_DOT)
+        type_inference = self._resolver.type_inference
+        file_path = type_inference.module_qn_to_file_path.get(module_qn)
+        if file_path is None or not (entry := type_inference.ast_cache.load(file_path)):
+            return None
+        root_node, _language = entry
+        stack: list[Node] = [root_node]
+        while stack:
+            node = stack.pop()
+            if node.type == cs.TS_FUNCTION_DECLARATION:
+                name = node.child_by_field_name(cs.FIELD_NAME)
+                if name is not None and safe_decode_text(name) == fn_name:
+                    return node
+            elif node.type == cs.TS_VARIABLE_DECLARATOR:
+                name = node.child_by_field_name(cs.FIELD_NAME)
+                value = node.child_by_field_name(cs.FIELD_VALUE)
+                if (
+                    name is not None
+                    and value is not None
+                    and value.type in cs.JS_TS_FUNCTION_NODES
+                    and safe_decode_text(name) == fn_name
+                ):
+                    return value
+            stack.extend(node.children)
+        return None
+
+    def _js_symbol_name_qn(self, name: str, module_qn: str) -> str | None:
+        # The qn a bare name denotes in this module: the imported member's qn
+        # when the name is imported, else the module-local qn.
+        import_map = self._resolver.import_processor.import_mapping.get(module_qn)
+        if import_map is not None and name in import_map:
+            imported = import_map[name]
+            if imported.endswith(f"{cs.SEPARATOR_DOT}{name}"):
+                return imported
+            return f"{imported}{cs.SEPARATOR_DOT}{name}"
+        return f"{module_qn}{cs.SEPARATOR_DOT}{name}"
+
+    def finalize_js_symbol_bindings(self) -> None:
+        # Keep only installations whose key resolves to a REGISTERED symbol
+        # constant: an arbitrary computed key (`obj[i]`) must never join the
+        # index, or unrelated subscript reads would type by it.
+        for module_qn, sym_name, class_qn in self._js_symbol_assignments:
+            sym_qn = self._js_symbol_name_qn(sym_name, module_qn)
+            if sym_qn is not None and sym_qn in self.js_symbol_constants:
+                self.js_symbol_member_types.setdefault(sym_qn, set()).add(class_qn)
+        self._js_symbol_assignments.clear()
+
+    def _js_symbol_member_targets(
+        self, call_node: Node, module_qn: str
+    ) -> tuple[list[tuple[str, str]], bool] | None:
+        # `recv[kSym].method(...)` where kSym resolves to a symbol constant
+        # with recorded installations: exactly ONE installed class binds the
+        # call (unique=True, CALLS); several installed classes are a sound
+        # candidate set (unique=False, the caller references each class's
+        # matching method so liveness holds without guessing). Returns None
+        # for every other shape, leaving the generic path untouched. The
+        # bare-name trie fallback is SUPPRESSED for the recognised shapes:
+        # the issue #989 receiver is statically unknowable by name and the
+        # trie falsely revives same-named methods on unrelated classes.
+        func = call_node.child_by_field_name(cs.FIELD_FUNCTION)
+        if func is None or func.type != cs.TS_MEMBER_EXPRESSION:
+            return None
+        obj = func.child_by_field_name(cs.FIELD_OBJECT)
+        prop = func.child_by_field_name(cs.FIELD_PROPERTY)
+        if obj is None or prop is None or obj.type != cs.TS_SUBSCRIPT_EXPRESSION:
+            return None
+        index = obj.child_by_field_name(cs.TS_FIELD_INDEX)
+        if index is None or index.type != cs.TS_IDENTIFIER:
+            return None
+        sym_name = safe_decode_text(index)
+        method = safe_decode_text(prop)
+        if not sym_name or not method:
+            return None
+        sym_qn = self._js_symbol_name_qn(sym_name, module_qn)
+        if sym_qn is None or sym_qn not in self.js_symbol_constants:
+            return None
+        classes = self.js_symbol_member_types.get(sym_qn)
+        if not classes:
+            return None
+        registry = self._resolver.function_registry
+        targets = [
+            (registry[method_qn], method_qn)
+            for class_qn in sorted(classes)
+            if (method_qn := f"{class_qn}{cs.SEPARATOR_DOT}{method}") in registry
+        ]
+        return targets, len(classes) == 1
 
     def _js_fn_call_receiver_binding(
         self, call_node: Node, module_qn: str

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -6580,7 +6580,11 @@ class CallProcessor:
             node = stack.pop()
             if node.type == cs.TS_VARIABLE_DECLARATOR:
                 self._collect_symbol_declarator(node, module_qn)
-            elif node.type == cs.TS_PAIR:
+            elif node.type in (
+                cs.TS_PAIR,
+                cs.TS_PUBLIC_FIELD_DEFINITION,
+                cs.TS_JS_FIELD_DEFINITION,
+            ):
                 self._collect_symbol_pair(node, module_qn)
             elif node.type == cs.TS_JS_ASSIGNMENT_EXPRESSION:
                 self._collect_symbol_subscript_assignment(node, module_qn)
@@ -6616,7 +6620,13 @@ class CallProcessor:
             self.js_symbol_constants.add(f"{module_qn}{cs.SEPARATOR_DOT}{name}")
 
     def _collect_symbol_pair(self, node: Node, module_qn: str) -> None:
-        key = node.child_by_field_name(cs.FIELD_KEY)
+        # An object-literal pair OR a class field: the key sits in `key`,
+        # `name` (TS field) or `property` (JS field), the value in `value`.
+        key = (
+            node.child_by_field_name(cs.FIELD_KEY)
+            or node.child_by_field_name(cs.FIELD_NAME)
+            or node.child_by_field_name(cs.FIELD_PROPERTY)
+        )
         value = node.child_by_field_name(cs.FIELD_VALUE)
         if key is None or value is None:
             return
@@ -6676,26 +6686,51 @@ class CallProcessor:
             return self._js_value_type_class_qn(inner, module_qn, depth)
         if node_type == cs.TS_NEW_EXPRESSION:
             ctor = js_ts_utils.extract_constructor_name(value)
-            return self._js_registered_class(ctor, module_qn) if ctor else None
+            if not ctor:
+                return None
+            return self._js_registered_class(
+                ctor, module_qn, allow_constructor_function=True
+            )
         if node_type == cs.TS_IDENTIFIER:
             return self._js_identifier_class_qn(value, module_qn, depth)
         if node_type == cs.TS_CALL_EXPRESSION:
-            return self._js_call_result_class_qn(value, module_qn, depth)
+            return self._js_call_result_class_qn(value, module_qn)
         return None
 
-    def _js_registered_class(self, name: str, module_qn: str) -> str | None:
-        js = self._resolver.type_inference.js_type_inference
+    def _js_registered_class(
+        self, name: str, module_qn: str, allow_constructor_function: bool = False
+    ) -> str | None:
+        # allow_constructor_function: a `new X(...)` target may be an
+        # old-style CONSTRUCTOR FUNCTION with prototype methods (fastify's
+        # ContentTypeParser), registered as Function; accepting it lets its
+        # prototype methods resolve. Never allowed for name hints, where a
+        # function qn is a factory, not a type.
         registry = self._resolver.function_registry
-        if name in registry and registry[name] == NodeType.CLASS:
+        accepted = (
+            (NodeType.CLASS, NodeType.FUNCTION)
+            if allow_constructor_function
+            else (NodeType.CLASS,)
+        )
+        if name in registry and registry[name] in accepted:
             return name
-        resolved = js._resolve_js_class_name(name, module_qn)
-        if (
-            resolved is not None
-            and resolved in registry
-            and registry[resolved] == NodeType.CLASS
-        ):
-            return resolved
+        for candidate in self._js_name_candidates(name, module_qn):
+            if candidate in registry and registry[candidate] in accepted:
+                return candidate
         return None
+
+    def _js_name_candidates(self, name: str, module_qn: str) -> list[str]:
+        # The qns a bare name may denote: the imported member, the imported
+        # MODULE's same-named export (`const P = require('./p.js')` where
+        # p.js exports its constructor), or the module-local binding.
+        candidates: list[str] = []
+        import_map = self._resolver.import_processor.import_mapping.get(module_qn)
+        if import_map is not None and name in import_map:
+            imported = import_map[name]
+            candidates.append(imported)
+            if not imported.endswith(f"{cs.SEPARATOR_DOT}{name}"):
+                candidates.append(f"{imported}{cs.SEPARATOR_DOT}{name}")
+        candidates.append(f"{module_qn}{cs.SEPARATOR_DOT}{name}")
+        return candidates
 
     def _js_identifier_class_qn(
         self, ident: Node, module_qn: str, depth: int
@@ -6757,8 +6792,16 @@ class CallProcessor:
                     and kind_node is not None
                     and self._js_pattern_binds(left, name)
                 ):
+                    # `for (var x of xs)` hoists x to the FUNCTION; a read
+                    # after the loop still reads the loop variable.
+                    span_node = scope if kind_node.type == cs.TS_JS_VAR_KIND else node
                     intros.append(
-                        (node.start_byte, node.end_byte, _JS_DECL_OPAQUE, None)
+                        (
+                            span_node.start_byte,
+                            span_node.end_byte,
+                            _JS_DECL_OPAQUE,
+                            None,
+                        )
                     )
             elif node.type == cs.TS_JS_CATCH_CLAUSE:
                 param = node.child_by_field_name(cs.FIELD_PARAMETER)
@@ -6843,9 +6886,7 @@ class CallProcessor:
                 stack.extend(node.named_children)
         return False
 
-    def _js_call_result_class_qn(
-        self, call: Node, module_qn: str, depth: int
-    ) -> str | None:
+    def _js_call_result_class_qn(self, call: Node, module_qn: str) -> str | None:
         func = call.child_by_field_name(cs.FIELD_FUNCTION)
         if func is None:
             return None
@@ -6857,48 +6898,51 @@ class CallProcessor:
                 self._js_symbol_name_qn(fn_name, module_qn)
             )
         if func.type == cs.TS_MEMBER_EXPRESSION:
-            obj = func.child_by_field_name(cs.FIELD_OBJECT)
-            prop = func.child_by_field_name(cs.FIELD_PROPERTY)
-            if (
-                obj is None
-                or prop is None
-                or obj.type != cs.TS_IDENTIFIER
-                or not (owner := safe_decode_text(obj))
-                or not (method := safe_decode_text(prop))
-            ):
-                return None
-            js = self._resolver.type_inference.js_type_inference
-            hint = js._infer_js_method_return_type(
-                f"{owner}{cs.SEPARATOR_DOT}{method}", module_qn
-            )
-            if hint and (resolved := self._js_registered_class(hint, module_qn)):
-                return resolved
-            # A static assigned OUTSIDE the class body (`C.build = build`;
-            # fastify's SchemaController.buildSchemaController) is invisible
-            # to the class-body method finder. Only a VERIFIED assignment in
-            # the class's module may redirect; a same-named free function
-            # alone must not (it can be unrelated).
-            class_qn = js._resolve_js_class_name(owner, module_qn)
-            if class_qn is None:
-                return None
-            assigned = self._js_static_assigned_factory(class_qn, method)
-            if assigned is None:
-                return None
-            class_module = class_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
-            if assigned.type == cs.TS_IDENTIFIER:
-                fn_name = safe_decode_text(assigned)
-                if not fn_name:
-                    return None
-                return self._js_factory_return_class(
-                    f"{class_module}{cs.SEPARATOR_DOT}{fn_name}"
-                )
-            if assigned.type in cs.JS_TS_FUNCTION_NODES:
-                return self._js_function_return_class(
-                    assigned,
-                    f"{class_module}{cs.SEPARATOR_DOT}{method}",
-                    class_module,
-                )
+            return self._js_member_call_result_class(func, module_qn)
+        return None
+
+    def _js_member_call_result_class(self, func: Node, module_qn: str) -> str | None:
+        obj = func.child_by_field_name(cs.FIELD_OBJECT)
+        prop = func.child_by_field_name(cs.FIELD_PROPERTY)
+        if (
+            obj is None
+            or prop is None
+            or obj.type != cs.TS_IDENTIFIER
+            or not (owner := safe_decode_text(obj))
+            or not (method := safe_decode_text(prop))
+        ):
             return None
+        js = self._resolver.type_inference.js_type_inference
+        hint = js._infer_js_method_return_type(
+            f"{owner}{cs.SEPARATOR_DOT}{method}", module_qn
+        )
+        if hint and (resolved := self._js_registered_class(hint, module_qn)):
+            return resolved
+        # A static assigned OUTSIDE the class body (`C.build = build`;
+        # fastify's SchemaController.buildSchemaController) is invisible
+        # to the class-body method finder. Only a VERIFIED assignment in
+        # the class's module may redirect; a same-named free function
+        # alone must not (it can be unrelated).
+        class_qn = js._resolve_js_class_name(owner, module_qn)
+        if class_qn is None:
+            return None
+        assigned = self._js_static_assigned_factory(class_qn, method)
+        if assigned is None:
+            return None
+        class_module = class_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
+        if assigned.type == cs.TS_IDENTIFIER:
+            fn_name = safe_decode_text(assigned)
+            if not fn_name:
+                return None
+            return self._js_factory_return_class(
+                f"{class_module}{cs.SEPARATOR_DOT}{fn_name}"
+            )
+        if assigned.type in cs.JS_TS_FUNCTION_NODES:
+            return self._js_function_return_class(
+                assigned,
+                f"{class_module}{cs.SEPARATOR_DOT}{method}",
+                class_module,
+            )
         return None
 
     def _js_static_assigned_factory(self, class_qn: str, method: str) -> Node | None:
@@ -7118,17 +7162,29 @@ class CallProcessor:
         if sym_qn is None or sym_qn not in self.js_symbol_constants:
             return None
         # The shape is recognised from here on: a symbol-keyed receiver is
-        # NEVER resolvable by name, so the generic path is suppressed even
-        # when no installation typed (an empty target list), rather than
-        # letting the trie guess a same-named method on an unrelated class.
-        classes = self.js_symbol_member_types.get(sym_qn) or set()
+        # never resolvable by NAME, so the generic path (whose trie fallback
+        # guesses one same-named method) is suppressed. With typed
+        # installations the index provides the targets; without any, the
+        # site degrades to REFERENCES over EVERY method of that name, so
+        # liveness survives while no wrong-class CALLS is fabricated.
         registry = self._resolver.function_registry
-        targets = [
-            (registry[method_qn], method_qn)
-            for class_qn in sorted(classes)
-            if (method_qn := f"{class_qn}{cs.SEPARATOR_DOT}{method}") in registry
+        classes = self.js_symbol_member_types.get(sym_qn)
+        if classes:
+            targets = [
+                (registry[method_qn], method_qn)
+                for class_qn in sorted(classes)
+                if (method_qn := f"{class_qn}{cs.SEPARATOR_DOT}{method}") in registry
+            ]
+            return targets, len(classes) == 1
+        name_matches = self._resolver.type_inference.simple_name_lookup.get(
+            method, set()
+        )
+        fan = [
+            (registry[qn], qn)
+            for qn in sorted(name_matches)
+            if qn in registry and registry[qn] != NodeType.CLASS
         ]
-        return targets, len(classes) == 1
+        return fan, False
 
     def _js_fn_call_receiver_binding(
         self, call_node: Node, module_qn: str

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -6706,17 +6706,52 @@ class CallProcessor:
         # prototype methods resolve. Never allowed for name hints, where a
         # function qn is a factory, not a type.
         registry = self._resolver.function_registry
-        accepted = (
-            (NodeType.CLASS, NodeType.FUNCTION)
-            if allow_constructor_function
-            else (NodeType.CLASS,)
-        )
-        if name in registry and registry[name] in accepted:
-            return name
-        for candidate in self._js_name_candidates(name, module_qn):
-            if candidate in registry and registry[candidate] in accepted:
+        candidates = [name, *self._js_name_candidates(name, module_qn)]
+        for candidate in candidates:
+            if candidate not in registry:
+                continue
+            node_type = registry[candidate]
+            if node_type == NodeType.CLASS:
+                return candidate
+            if (
+                allow_constructor_function
+                and node_type == NodeType.FUNCTION
+                and self._js_has_prototype_members(candidate)
+            ):
                 return candidate
         return None
+
+    def _js_has_prototype_members(self, fn_qn: str) -> bool:
+        # Constructor EVIDENCE: at least one `Fn.prototype.x = ...` in the
+        # function's module. Without it, `module.fn.name` registry entries
+        # under the function are its NESTED helpers, not methods, and
+        # accepting the function as a type would manufacture edges to them.
+        fn_module, _, fn_leaf = fn_qn.rpartition(cs.SEPARATOR_DOT)
+        type_inference = self._resolver.type_inference
+        file_path = type_inference.module_qn_to_file_path.get(fn_module)
+        if file_path is None or not (entry := type_inference.ast_cache.load(file_path)):
+            return False
+        root_node, _language = entry
+        stack: list[Node] = [root_node]
+        while stack:
+            node = stack.pop()
+            if node.type == cs.TS_JS_ASSIGNMENT_EXPRESSION:
+                left = node.child_by_field_name(cs.FIELD_LEFT)
+                if (
+                    left is not None
+                    and left.type == cs.TS_MEMBER_EXPRESSION
+                    and (inner := left.child_by_field_name(cs.FIELD_OBJECT)) is not None
+                    and inner.type == cs.TS_MEMBER_EXPRESSION
+                    and (obj := inner.child_by_field_name(cs.FIELD_OBJECT)) is not None
+                    and obj.type == cs.TS_IDENTIFIER
+                    and safe_decode_text(obj) == fn_leaf
+                    and (prop := inner.child_by_field_name(cs.FIELD_PROPERTY))
+                    is not None
+                    and safe_decode_text(prop) == cs.JS_PROTOTYPE_KEYWORD
+                ):
+                    return True
+            stack.extend(node.children)
+        return False
 
     def _js_name_candidates(self, name: str, module_qn: str) -> list[str]:
         # The qns a bare name may denote: the imported member, the imported

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -6721,11 +6721,23 @@ class CallProcessor:
                 return candidate
         return None
 
-    def _js_has_prototype_members(self, fn_qn: str) -> bool:
+    def _js_member_is_exposed(self, class_qn: str, method: str) -> bool:
+        # A CLASS's registry members are its real methods. A CONSTRUCTOR
+        # FUNCTION shares its `module.fn.name` namespace with its NESTED
+        # private helpers, so each member needs its own
+        # `Fn.prototype.<method> = ...` evidence before the qn may be
+        # treated as callable from outside.
+        registry = self._resolver.function_registry
+        if class_qn in registry and registry[class_qn] == NodeType.CLASS:
+            return True
+        return self._js_has_prototype_members(class_qn, member=method)
+
+    def _js_has_prototype_members(self, fn_qn: str, member: str | None = None) -> bool:
         # Constructor EVIDENCE: at least one `Fn.prototype.x = ...` in the
-        # function's module. Without it, `module.fn.name` registry entries
-        # under the function are its NESTED helpers, not methods, and
-        # accepting the function as a type would manufacture edges to them.
+        # function's module (any member), or, when `member` is given, an
+        # assignment for that SPECIFIC member. Without it, `module.fn.name`
+        # registry entries under the function are its NESTED helpers, not
+        # methods, and accepting them would manufacture edges.
         fn_module, _, fn_leaf = fn_qn.rpartition(cs.SEPARATOR_DOT)
         type_inference = self._resolver.type_inference
         file_path = type_inference.module_qn_to_file_path.get(fn_module)
@@ -6749,7 +6761,14 @@ class CallProcessor:
                     is not None
                     and safe_decode_text(prop) == cs.JS_PROTOTYPE_KEYWORD
                 ):
-                    return True
+                    if member is None:
+                        return True
+                    outer_prop = left.child_by_field_name(cs.FIELD_PROPERTY)
+                    if (
+                        outer_prop is not None
+                        and safe_decode_text(outer_prop) == member
+                    ):
+                        return True
             stack.extend(node.children)
         return False
 
@@ -7209,6 +7228,7 @@ class CallProcessor:
                 (registry[method_qn], method_qn)
                 for class_qn in sorted(classes)
                 if (method_qn := f"{class_qn}{cs.SEPARATOR_DOT}{method}") in registry
+                and self._js_member_is_exposed(class_qn, method)
             ]
             return targets, len(classes) == 1
         name_matches = self._resolver.type_inference.simple_name_lookup.get(

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -98,6 +98,20 @@ _TYPED_LANGUAGES = frozenset(
 # declarator-aware extractor rather than a plain child_by_field_name("name").
 _C_FAMILY_LANGUAGES = frozenset({cs.SupportedLanguage.C, cs.SupportedLanguage.CPP})
 _JS_TS_LANGUAGES = cs.JS_TS_LANGUAGES
+
+# Declarator kinds for the symbol-index value chase (issue #989).
+_JS_DECL_PLAIN = "plain"
+_JS_DECL_DESTRUCTURED = "destructured"
+
+
+def _walk_named(node: Node):  # noqa: ANN201 - simple generator over Node
+    stack = list(node.named_children)
+    while stack:
+        current = stack.pop()
+        yield current
+        stack.extend(current.named_children)
+
+
 # Languages with argument-REFERENCE edges but no interprocedural
 # callable-param flow: passing a function keeps it reachable (REFERENCES),
 # while invocation edges stay with the flow languages.
@@ -6623,66 +6637,43 @@ class CallProcessor:
 
     def _js_symbol_value_class_qn(self, value: Node, module_qn: str) -> str | None:
         # Resolve the INSTALLED value to a class qn, entirely at sweep time
-        # so only strings are kept: a direct construction, a factory call, or
-        # an identifier typed by the enclosing callable's locals.
-        js = self._resolver.type_inference.js_type_inference
-        if value.type == cs.TS_IDENTIFIER:
-            enclosing = value.parent
-            while (
-                enclosing is not None and enclosing.type not in cs.JS_TS_FUNCTION_NODES
-            ):
-                enclosing = enclosing.parent
-            if enclosing is None:
-                return None
-            hint = js.build_local_variable_type_map(enclosing, module_qn).get(
-                safe_decode_text(value) or ""
-            )
-        else:
-            hint = js._infer_js_variable_type_from_value(value, module_qn)
-        if not hint:
-            return None
-        return self._js_class_qn_from_hint(hint, module_qn)
+        # so only strings are kept.
+        return self._js_value_type_class_qn(value, module_qn, depth=0)
 
-    def _js_class_qn_from_hint(self, hint: str, module_qn: str) -> str | None:
+    def _js_value_type_class_qn(
+        self, value: Node | None, module_qn: str, depth: int
+    ) -> str | None:
+        # Type a VALUE expression to a registered class qn: a direct
+        # construction, a factory call (bare, member/static, or one whose
+        # returned OBJECT the caller destructures), or an identifier chased
+        # to its declarator. Depth-capped: each hop crosses at most one
+        # binding or one function return.
+        if value is None or depth > 3:
+            return None
+        node_type = value.type
+        if (
+            node_type == cs.TS_PARENTHESIZED_EXPRESSION
+            or node_type in cs.TS_CAST_WRAPPER_TYPES
+        ):
+            inner = next(
+                (c for c in value.named_children if c.type != cs.TS_COMMENT), None
+            )
+            return self._js_value_type_class_qn(inner, module_qn, depth)
+        if node_type == cs.TS_NEW_EXPRESSION:
+            ctor = js_ts_utils.extract_constructor_name(value)
+            return self._js_registered_class(ctor, module_qn) if ctor else None
+        if node_type == cs.TS_IDENTIFIER:
+            return self._js_identifier_class_qn(value, module_qn, depth)
+        if node_type == cs.TS_CALL_EXPRESSION:
+            return self._js_call_result_class_qn(value, module_qn, depth)
+        return None
+
+    def _js_registered_class(self, name: str, module_qn: str) -> str | None:
         js = self._resolver.type_inference.js_type_inference
         registry = self._resolver.function_registry
-        if hint in registry and registry[hint] == NodeType.CLASS:
-            return hint
-        # _resolve_js_class_name falls back to the imported qn even when it
-        # is not a class; only a REGISTERED class ends the search here.
-        resolved = js._resolve_js_class_name(hint, module_qn)
-        if (
-            resolved is not None
-            and resolved in registry
-            and registry[resolved] == NodeType.CLASS
-        ):
-            return resolved
-        # A bare FACTORY name: resolve the function and type its return.
-        fn_qn = self._js_symbol_name_qn(hint, module_qn)
-        if fn_qn is None or fn_qn not in registry:
-            return None
-        fn_node = self._js_function_node_by_qn(fn_qn)
-        if fn_node is None:
-            return None
-        factory_module = fn_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
-        # A direct `return new X(...)` names the class outright (the general
-        # return analysis resolves a NEW to the factory's OWN scope, which
-        # for a top-level function is the module).
-        if ctor := self._js_direct_return_ctor(fn_node):
-            resolved = js._resolve_js_class_name(ctor, factory_module)
-            if (
-                resolved is not None
-                and resolved in registry
-                and registry[resolved] == NodeType.CLASS
-            ):
-                return resolved
-            return None
-        returned = js._analyze_return_statements(fn_node, fn_qn)
-        if returned is None:
-            return None
-        if returned in registry and registry[returned] == NodeType.CLASS:
-            return returned
-        resolved = js._resolve_js_class_name(returned, factory_module)
+        if name in registry and registry[name] == NodeType.CLASS:
+            return name
+        resolved = js._resolve_js_class_name(name, module_qn)
         if (
             resolved is not None
             and resolved in registry
@@ -6690,6 +6681,180 @@ class CallProcessor:
         ):
             return resolved
         return None
+
+    def _js_identifier_class_qn(
+        self, ident: Node, module_qn: str, depth: int
+    ) -> str | None:
+        # Chase the identifier to the declarator that binds it, searching
+        # each enclosing callable from the innermost outward (a closure
+        # reads outer scopes), then module scope.
+        name = safe_decode_text(ident)
+        if not name:
+            return None
+        scope = ident.parent
+        while scope is not None:
+            if scope.type in cs.JS_TS_FUNCTION_NODES or scope.parent is None:
+                found = self._js_declarator_for(scope, name)
+                if found is not None:
+                    kind, value = found
+                    if kind == _JS_DECL_PLAIN:
+                        return self._js_value_type_class_qn(value, module_qn, depth + 1)
+                    return self._js_destructured_return_class(
+                        value, name, module_qn, depth + 1
+                    )
+            scope = scope.parent
+        return None
+
+    @staticmethod
+    def _js_declarator_for(scope: Node, name: str) -> tuple[str, Node] | None:
+        # The declarator binding `name` directly under this scope (nested
+        # callables own their locals and are skipped).
+        stack: list[Node] = list(scope.children)
+        while stack:
+            node = stack.pop()
+            if node.type in cs.JS_TS_FUNCTION_NODES:
+                continue
+            if node.type == cs.TS_VARIABLE_DECLARATOR:
+                target = node.child_by_field_name(cs.FIELD_NAME)
+                value = node.child_by_field_name(cs.FIELD_VALUE)
+                if target is not None and value is not None:
+                    if (
+                        target.type == cs.TS_IDENTIFIER
+                        and safe_decode_text(target) == name
+                    ):
+                        return _JS_DECL_PLAIN, value
+                    if target.type != cs.TS_IDENTIFIER and any(
+                        n.type
+                        in (
+                            cs.TS_IDENTIFIER,
+                            cs.TS_SHORTHAND_PROPERTY_IDENTIFIER_PATTERN,
+                        )
+                        and safe_decode_text(n) == name
+                        for n in _walk_named(target)
+                    ):
+                        return _JS_DECL_DESTRUCTURED, value
+            stack.extend(node.children)
+        return None
+
+    def _js_call_result_class_qn(
+        self, call: Node, module_qn: str, depth: int
+    ) -> str | None:
+        func = call.child_by_field_name(cs.FIELD_FUNCTION)
+        if func is None:
+            return None
+        if func.type == cs.TS_IDENTIFIER:
+            fn_name = safe_decode_text(func)
+            if not fn_name:
+                return None
+            return self._js_factory_return_class(
+                self._js_symbol_name_qn(fn_name, module_qn), module_qn, depth
+            )
+        if func.type == cs.TS_MEMBER_EXPRESSION:
+            obj = func.child_by_field_name(cs.FIELD_OBJECT)
+            prop = func.child_by_field_name(cs.FIELD_PROPERTY)
+            if (
+                obj is None
+                or prop is None
+                or obj.type != cs.TS_IDENTIFIER
+                or not (owner := safe_decode_text(obj))
+                or not (method := safe_decode_text(prop))
+            ):
+                return None
+            js = self._resolver.type_inference.js_type_inference
+            hint = js._infer_js_method_return_type(
+                f"{owner}{cs.SEPARATOR_DOT}{method}", module_qn
+            )
+            if hint and (resolved := self._js_registered_class(hint, module_qn)):
+                return resolved
+            # A static assigned OUTSIDE the class body (`C.build = build`;
+            # fastify's SchemaController.buildSchemaController) is a free
+            # function in the class's module, invisible to the class-body
+            # method finder.
+            class_qn = js._resolve_js_class_name(owner, module_qn)
+            if class_qn is None:
+                return None
+            class_module = class_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
+            return self._js_factory_return_class(
+                f"{class_module}{cs.SEPARATOR_DOT}{method}", class_module, depth
+            )
+        return None
+
+    def _js_factory_return_class(
+        self, fn_qn: str | None, module_qn: str, depth: int
+    ) -> str | None:
+        registry = self._resolver.function_registry
+        if fn_qn is None or fn_qn not in registry:
+            return None
+        fn_node = self._js_function_node_by_qn(fn_qn)
+        if fn_node is None:
+            return None
+        factory_module = fn_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
+        if ctor := self._js_direct_return_ctor(fn_node):
+            return self._js_registered_class(ctor, factory_module)
+        js = self._resolver.type_inference.js_type_inference
+        returned = js._analyze_return_statements(fn_node, fn_qn)
+        if returned is None:
+            return None
+        return self._js_registered_class(returned, factory_module)
+
+    def _js_destructured_return_class(
+        self, call_value: Node, prop_name: str, module_qn: str, depth: int
+    ) -> str | None:
+        # `const { name } = f(...)`: the binding's type is the type of the
+        # `name` property in f's returned object literal.
+        if depth > 3 or call_value.type != cs.TS_CALL_EXPRESSION:
+            return None
+        func = call_value.child_by_field_name(cs.FIELD_FUNCTION)
+        if func is None or func.type != cs.TS_IDENTIFIER:
+            return None
+        fn_name = safe_decode_text(func)
+        if not fn_name:
+            return None
+        fn_qn = self._js_symbol_name_qn(fn_name, module_qn)
+        registry = self._resolver.function_registry
+        if fn_qn is None or fn_qn not in registry:
+            return None
+        fn_node = self._js_function_node_by_qn(fn_qn)
+        if fn_node is None:
+            return None
+        factory_module = fn_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
+        for obj in self._js_own_returned_objects(fn_node):
+            for child in obj.named_children:
+                if child.type == cs.TS_PAIR:
+                    key = child.child_by_field_name(cs.FIELD_KEY)
+                    if (
+                        key is not None
+                        and key.type == cs.TS_PROPERTY_IDENTIFIER
+                        and safe_decode_text(key) == prop_name
+                    ):
+                        return self._js_value_type_class_qn(
+                            child.child_by_field_name(cs.FIELD_VALUE),
+                            factory_module,
+                            depth + 1,
+                        )
+                elif (
+                    child.type == cs.TS_SHORTHAND_PROPERTY_IDENTIFIER
+                    and safe_decode_text(child) == prop_name
+                ):
+                    return self._js_identifier_class_qn(
+                        child, factory_module, depth + 1
+                    )
+        return None
+
+    @staticmethod
+    def _js_own_returned_objects(fn_node: Node) -> list[Node]:
+        objects: list[Node] = []
+        stack: list[Node] = list(fn_node.children)
+        while stack:
+            node = stack.pop()
+            if node.type in cs.JS_TS_FUNCTION_NODES:
+                continue
+            if node.type == cs.TS_RETURN_STATEMENT:
+                for child in node.named_children:
+                    if child.type == cs.TS_OBJECT:
+                        objects.append(child)
+            stack.extend(node.children)
+        return objects
 
     @staticmethod
     def _js_direct_return_ctor(fn_node: Node) -> str | None:

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -6964,30 +6964,34 @@ class CallProcessor:
         stack: list[Node] = [root_node]
         while stack:
             node = stack.pop()
-            if node.type == cs.TS_JS_ASSIGNMENT_EXPRESSION:
-                left = node.child_by_field_name(cs.FIELD_LEFT)
-                if (
-                    left is not None
-                    and left.type == cs.TS_MEMBER_EXPRESSION
-                    and (inner := left.child_by_field_name(cs.FIELD_OBJECT)) is not None
-                    and inner.type == cs.TS_MEMBER_EXPRESSION
-                    and (obj := inner.child_by_field_name(cs.FIELD_OBJECT)) is not None
-                    and obj.type == cs.TS_IDENTIFIER
-                    and safe_decode_text(obj) == fn_leaf
-                    and (prop := inner.child_by_field_name(cs.FIELD_PROPERTY))
-                    is not None
-                    and safe_decode_text(prop) == cs.JS_PROTOTYPE_KEYWORD
-                ):
-                    if member is None:
-                        return True
-                    outer_prop = left.child_by_field_name(cs.FIELD_PROPERTY)
-                    if (
-                        outer_prop is not None
-                        and safe_decode_text(outer_prop) == member
-                    ):
-                        return True
+            if node.type == cs.TS_JS_ASSIGNMENT_EXPRESSION and (
+                self._js_prototype_assignment_matches(node, fn_leaf, member)
+            ):
+                return True
             stack.extend(node.children)
         return False
+
+    @staticmethod
+    def _js_prototype_assignment_matches(
+        node: Node, fn_leaf: str, member: str | None
+    ) -> bool:
+        left = node.child_by_field_name(cs.FIELD_LEFT)
+        if (
+            left is None
+            or left.type != cs.TS_MEMBER_EXPRESSION
+            or (inner := left.child_by_field_name(cs.FIELD_OBJECT)) is None
+            or inner.type != cs.TS_MEMBER_EXPRESSION
+            or (obj := inner.child_by_field_name(cs.FIELD_OBJECT)) is None
+            or obj.type != cs.TS_IDENTIFIER
+            or safe_decode_text(obj) != fn_leaf
+            or (prop := inner.child_by_field_name(cs.FIELD_PROPERTY)) is None
+            or safe_decode_text(prop) != cs.JS_PROTOTYPE_KEYWORD
+        ):
+            return False
+        if member is None:
+            return True
+        outer_prop = left.child_by_field_name(cs.FIELD_PROPERTY)
+        return outer_prop is not None and safe_decode_text(outer_prop) == member
 
     def _js_name_candidates(self, name: str, module_qn: str) -> list[str]:
         # The qns a bare name may denote: the imported member, the imported
@@ -7056,31 +7060,41 @@ class CallProcessor:
             if node.type == cs.TS_VARIABLE_DECLARATOR:
                 self._js_declarator_introduction(node, scope, name, intros)
             elif node.type == cs.TS_JS_FOR_IN_STATEMENT:
-                left = node.child_by_field_name(cs.FIELD_LEFT)
-                kind_node = node.child_by_field_name(cs.FIELD_KIND)
-                if (
-                    left is not None
-                    and kind_node is not None
-                    and self._js_pattern_binds(left, name)
-                ):
-                    # `for (var x of xs)` hoists x to the FUNCTION; a read
-                    # after the loop still reads the loop variable.
-                    span_node = scope if kind_node.type == cs.TS_JS_VAR_KIND else node
-                    intros.append(
-                        (
-                            span_node.start_byte,
-                            span_node.end_byte,
-                            _JS_DECL_OPAQUE,
-                            None,
-                        )
-                    )
+                self._js_loop_introduction(node, scope, name, intros)
             elif node.type == cs.TS_JS_CATCH_CLAUSE:
-                param = node.child_by_field_name(cs.FIELD_PARAMETER)
-                if param is not None and self._js_pattern_binds(param, name):
-                    intros.append(
-                        (node.start_byte, node.end_byte, _JS_DECL_OPAQUE, None)
-                    )
+                self._js_catch_introduction(node, name, intros)
             stack.extend(node.children)
+
+    def _js_loop_introduction(
+        self,
+        node: Node,
+        scope: Node,
+        name: str,
+        intros: list[tuple[int, int, str, Node | None]],
+    ) -> None:
+        left = node.child_by_field_name(cs.FIELD_LEFT)
+        kind_node = node.child_by_field_name(cs.FIELD_KIND)
+        if (
+            left is not None
+            and kind_node is not None
+            and self._js_pattern_binds(left, name)
+        ):
+            # `for (var x of xs)` hoists x to the FUNCTION; a read after
+            # the loop still reads the loop variable.
+            span_node = scope if kind_node.type == cs.TS_JS_VAR_KIND else node
+            intros.append(
+                (span_node.start_byte, span_node.end_byte, _JS_DECL_OPAQUE, None)
+            )
+
+    def _js_catch_introduction(
+        self,
+        node: Node,
+        name: str,
+        intros: list[tuple[int, int, str, Node | None]],
+    ) -> None:
+        param = node.child_by_field_name(cs.FIELD_PARAMETER)
+        if param is not None and self._js_pattern_binds(param, name):
+            intros.append((node.start_byte, node.end_byte, _JS_DECL_OPAQUE, None))
 
     def _js_declarator_introduction(
         self,

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -99,9 +99,24 @@ _TYPED_LANGUAGES = frozenset(
 _C_FAMILY_LANGUAGES = frozenset({cs.SupportedLanguage.C, cs.SupportedLanguage.CPP})
 _JS_TS_LANGUAGES = cs.JS_TS_LANGUAGES
 
-# Declarator kinds for the symbol-index value chase (issue #989).
+# Declarator kinds for the symbol-index value chase (issue #989). OPAQUE
+# marks an introduction whose value cannot be known statically (a parameter,
+# a loop or catch binding, an uninitialised declarator): it wins scoping and
+# refuses typing.
 _JS_DECL_PLAIN = "plain"
 _JS_DECL_DESTRUCTURED = "destructured"
+_JS_DECL_OPAQUE = "opaque"
+
+# Ancestors bounding a `let`/`const` declaration's scope (mirrors the
+# type-inference engine's set).
+_JS_SCOPE_CONTAINER_TYPES = frozenset(
+    {
+        "statement_block",
+        "switch_body",
+        "for_statement",
+        "for_in_statement",
+    }
+)
 
 
 def _walk_named(node: Node):  # noqa: ANN201 - simple generator over Node
@@ -6685,56 +6700,148 @@ class CallProcessor:
     def _js_identifier_class_qn(
         self, ident: Node, module_qn: str, depth: int
     ) -> str | None:
-        # Chase the identifier to the declarator that binds it, searching
-        # each enclosing callable from the innermost outward (a closure
-        # reads outer scopes), then module scope.
+        # Chase the identifier to the INTRODUCTION it actually reads: every
+        # binding of the name visible from this position (parameters, catch
+        # and loop bindings, lexical and var declarators) is collected with
+        # the byte span of the scope it governs, and the innermost enclosing
+        # one wins. A parameter or other opaque introduction is statically
+        # unknowable and refuses; name-match-anywhere resolution leaks (the
+        # #988 lesson) and is never used.
         name = safe_decode_text(ident)
         if not name:
             return None
+        intros: list[tuple[int, int, str, Node | None]] = []
         scope = ident.parent
         while scope is not None:
             if scope.type in cs.JS_TS_FUNCTION_NODES or scope.parent is None:
-                found = self._js_declarator_for(scope, name)
-                if found is not None:
-                    kind, value = found
-                    if kind == _JS_DECL_PLAIN:
-                        return self._js_value_type_class_qn(value, module_qn, depth + 1)
-                    return self._js_destructured_return_class(
-                        value, name, module_qn, depth + 1
-                    )
+                self._js_scope_introductions(scope, name, intros)
             scope = scope.parent
+        pos = ident.start_byte
+        enclosing = [e for e in intros if e[0] <= pos < e[1]]
+        if not enclosing:
+            return None
+        best_start = max(e[0] for e in enclosing)
+        best = [e for e in enclosing if e[0] == best_start]
+        if len(best) != 1:
+            return None
+        _s, _e, kind, value = best[0]
+        if kind == _JS_DECL_PLAIN:
+            return self._js_value_type_class_qn(value, module_qn, depth + 1)
+        if kind == _JS_DECL_DESTRUCTURED and value is not None:
+            return self._js_destructured_return_class(value, name, module_qn, depth + 1)
         return None
 
-    @staticmethod
-    def _js_declarator_for(scope: Node, name: str) -> tuple[str, Node] | None:
-        # The declarator binding `name` directly under this scope (nested
-        # callables own their locals and are skipped).
+    def _js_scope_introductions(
+        self,
+        scope: Node,
+        name: str,
+        intros: list[tuple[int, int, str, Node | None]],
+    ) -> None:
+        # All introductions of `name` owned by this callable (or module
+        # root), each with the byte span of the scope it governs. Nested
+        # callables own their locals and are skipped.
+        if scope.type in cs.JS_TS_FUNCTION_NODES and self._js_params_bind(scope, name):
+            intros.append((scope.start_byte, scope.end_byte, _JS_DECL_OPAQUE, None))
         stack: list[Node] = list(scope.children)
         while stack:
             node = stack.pop()
             if node.type in cs.JS_TS_FUNCTION_NODES:
                 continue
             if node.type == cs.TS_VARIABLE_DECLARATOR:
-                target = node.child_by_field_name(cs.FIELD_NAME)
-                value = node.child_by_field_name(cs.FIELD_VALUE)
-                if target is not None and value is not None:
-                    if (
-                        target.type == cs.TS_IDENTIFIER
-                        and safe_decode_text(target) == name
-                    ):
-                        return _JS_DECL_PLAIN, value
-                    if target.type != cs.TS_IDENTIFIER and any(
-                        n.type
-                        in (
-                            cs.TS_IDENTIFIER,
-                            cs.TS_SHORTHAND_PROPERTY_IDENTIFIER_PATTERN,
-                        )
-                        and safe_decode_text(n) == name
-                        for n in _walk_named(target)
-                    ):
-                        return _JS_DECL_DESTRUCTURED, value
+                self._js_declarator_introduction(node, scope, name, intros)
+            elif node.type == cs.TS_JS_FOR_IN_STATEMENT:
+                left = node.child_by_field_name(cs.FIELD_LEFT)
+                kind_node = node.child_by_field_name(cs.FIELD_KIND)
+                if (
+                    left is not None
+                    and kind_node is not None
+                    and self._js_pattern_binds(left, name)
+                ):
+                    intros.append(
+                        (node.start_byte, node.end_byte, _JS_DECL_OPAQUE, None)
+                    )
+            elif node.type == cs.TS_JS_CATCH_CLAUSE:
+                param = node.child_by_field_name(cs.FIELD_PARAMETER)
+                if param is not None and self._js_pattern_binds(param, name):
+                    intros.append(
+                        (node.start_byte, node.end_byte, _JS_DECL_OPAQUE, None)
+                    )
             stack.extend(node.children)
-        return None
+
+    def _js_declarator_introduction(
+        self,
+        node: Node,
+        scope: Node,
+        name: str,
+        intros: list[tuple[int, int, str, Node | None]],
+    ) -> None:
+        target = node.child_by_field_name(cs.FIELD_NAME)
+        if target is None:
+            return
+        if target.type == cs.TS_IDENTIFIER:
+            if safe_decode_text(target) != name:
+                return
+            kind = _JS_DECL_PLAIN
+        elif self._js_pattern_binds(target, name):
+            kind = _JS_DECL_DESTRUCTURED
+        else:
+            return
+        value = node.child_by_field_name(cs.FIELD_VALUE)
+        if value is None:
+            kind = _JS_DECL_OPAQUE
+        is_lexical = (
+            node.parent is not None and node.parent.type == cs.TS_LEXICAL_DECLARATION
+        )
+        span_node = scope
+        if is_lexical:
+            current = node.parent
+            while current is not None and current.id != scope.id:
+                if current.type in _JS_SCOPE_CONTAINER_TYPES:
+                    span_node = current
+                    break
+                current = current.parent
+        intros.append((span_node.start_byte, span_node.end_byte, kind, value))
+
+    def _js_params_bind(self, scope: Node, name: str) -> bool:
+        for field in (cs.FIELD_PARAMETERS, cs.FIELD_PARAMETER):
+            params = scope.child_by_field_name(field)
+            if params is not None and self._js_pattern_binds(params, name):
+                return True
+        return False
+
+    @staticmethod
+    def _js_pattern_binds(target: Node, name: str) -> bool:
+        # BINDING positions only: pattern defaults' right sides, computed
+        # keys and pair keys are reads of the enclosing scope.
+        stack: list[Node] = [target]
+        while stack:
+            node = stack.pop()
+            node_type = node.type
+            if node_type in (
+                cs.TS_IDENTIFIER,
+                cs.TS_SHORTHAND_PROPERTY_IDENTIFIER_PATTERN,
+            ):
+                if safe_decode_text(node) == name:
+                    return True
+            elif node_type in (
+                cs.TS_ASSIGNMENT_PATTERN,
+                cs.TS_OBJECT_ASSIGNMENT_PATTERN,
+            ):
+                if (left := node.child_by_field_name(cs.FIELD_LEFT)) is not None:
+                    stack.append(left)
+            elif node_type == cs.TS_PAIR_PATTERN:
+                if (value := node.child_by_field_name(cs.FIELD_VALUE)) is not None:
+                    stack.append(value)
+            elif node_type in (
+                cs.TS_OBJECT_PATTERN,
+                cs.TS_ARRAY_PATTERN,
+                cs.TS_REST_PATTERN,
+                cs.TS_JS_FORMAL_PARAMETERS,
+                cs.TS_REQUIRED_PARAMETER,
+                cs.TS_OPTIONAL_PARAMETER,
+            ):
+                stack.extend(node.named_children)
+        return False
 
     def _js_call_result_class_qn(
         self, call: Node, module_qn: str, depth: int
@@ -6747,7 +6854,7 @@ class CallProcessor:
             if not fn_name:
                 return None
             return self._js_factory_return_class(
-                self._js_symbol_name_qn(fn_name, module_qn), module_qn, depth
+                self._js_symbol_name_qn(fn_name, module_qn)
             )
         if func.type == cs.TS_MEMBER_EXPRESSION:
             obj = func.child_by_field_name(cs.FIELD_OBJECT)
@@ -6767,21 +6874,62 @@ class CallProcessor:
             if hint and (resolved := self._js_registered_class(hint, module_qn)):
                 return resolved
             # A static assigned OUTSIDE the class body (`C.build = build`;
-            # fastify's SchemaController.buildSchemaController) is a free
-            # function in the class's module, invisible to the class-body
-            # method finder.
+            # fastify's SchemaController.buildSchemaController) is invisible
+            # to the class-body method finder. Only a VERIFIED assignment in
+            # the class's module may redirect; a same-named free function
+            # alone must not (it can be unrelated).
             class_qn = js._resolve_js_class_name(owner, module_qn)
             if class_qn is None:
                 return None
+            assigned = self._js_static_assigned_factory(class_qn, method)
+            if assigned is None:
+                return None
             class_module = class_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
-            return self._js_factory_return_class(
-                f"{class_module}{cs.SEPARATOR_DOT}{method}", class_module, depth
-            )
+            if assigned.type == cs.TS_IDENTIFIER:
+                fn_name = safe_decode_text(assigned)
+                if not fn_name:
+                    return None
+                return self._js_factory_return_class(
+                    f"{class_module}{cs.SEPARATOR_DOT}{fn_name}"
+                )
+            if assigned.type in cs.JS_TS_FUNCTION_NODES:
+                return self._js_function_return_class(
+                    assigned,
+                    f"{class_module}{cs.SEPARATOR_DOT}{method}",
+                    class_module,
+                )
+            return None
         return None
 
-    def _js_factory_return_class(
-        self, fn_qn: str | None, module_qn: str, depth: int
-    ) -> str | None:
+    def _js_static_assigned_factory(self, class_qn: str, method: str) -> Node | None:
+        # The right-hand side of `ClassLeaf.method = ...` in the class's
+        # module, or None when no such assignment exists.
+        class_module, _, class_leaf = class_qn.rpartition(cs.SEPARATOR_DOT)
+        type_inference = self._resolver.type_inference
+        file_path = type_inference.module_qn_to_file_path.get(class_module)
+        if file_path is None or not (entry := type_inference.ast_cache.load(file_path)):
+            return None
+        root_node, _language = entry
+        stack: list[Node] = [root_node]
+        while stack:
+            node = stack.pop()
+            if node.type == cs.TS_JS_ASSIGNMENT_EXPRESSION:
+                left = node.child_by_field_name(cs.FIELD_LEFT)
+                if (
+                    left is not None
+                    and left.type == cs.TS_MEMBER_EXPRESSION
+                    and (obj := left.child_by_field_name(cs.FIELD_OBJECT)) is not None
+                    and obj.type == cs.TS_IDENTIFIER
+                    and safe_decode_text(obj) == class_leaf
+                    and (prop := left.child_by_field_name(cs.FIELD_PROPERTY))
+                    is not None
+                    and safe_decode_text(prop) == method
+                ):
+                    return node.child_by_field_name(cs.TS_FIELD_RIGHT)
+            stack.extend(node.children)
+        return None
+
+    def _js_factory_return_class(self, fn_qn: str | None) -> str | None:
         registry = self._resolver.function_registry
         if fn_qn is None or fn_qn not in registry:
             return None
@@ -6789,6 +6937,11 @@ class CallProcessor:
         if fn_node is None:
             return None
         factory_module = fn_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
+        return self._js_function_return_class(fn_node, fn_qn, factory_module)
+
+    def _js_function_return_class(
+        self, fn_node: Node, fn_qn: str, factory_module: str
+    ) -> str | None:
         if ctor := self._js_direct_return_ctor(fn_node):
             return self._js_registered_class(ctor, factory_module)
         js = self._resolver.type_inference.js_type_inference
@@ -6818,27 +6971,41 @@ class CallProcessor:
         if fn_node is None:
             return None
         factory_module = fn_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
+        # Every returned object contributes its `name` property's class;
+        # divergent returns are ambiguous and refuse (never guess one path).
+        candidates: set[str | None] = set()
         for obj in self._js_own_returned_objects(fn_node):
-            for child in obj.named_children:
-                if child.type == cs.TS_PAIR:
-                    key = child.child_by_field_name(cs.FIELD_KEY)
-                    if (
-                        key is not None
-                        and key.type == cs.TS_PROPERTY_IDENTIFIER
-                        and safe_decode_text(key) == prop_name
-                    ):
-                        return self._js_value_type_class_qn(
-                            child.child_by_field_name(cs.FIELD_VALUE),
-                            factory_module,
-                            depth + 1,
-                        )
-                elif (
-                    child.type == cs.TS_SHORTHAND_PROPERTY_IDENTIFIER
-                    and safe_decode_text(child) == prop_name
+            candidates.add(
+                self._js_returned_object_property_class(
+                    obj, prop_name, factory_module, depth
+                )
+            )
+        candidates.discard(None)
+        if len(candidates) == 1:
+            return candidates.pop()
+        return None
+
+    def _js_returned_object_property_class(
+        self, obj: Node, prop_name: str, factory_module: str, depth: int
+    ) -> str | None:
+        for child in obj.named_children:
+            if child.type == cs.TS_PAIR:
+                key = child.child_by_field_name(cs.FIELD_KEY)
+                if (
+                    key is not None
+                    and key.type == cs.TS_PROPERTY_IDENTIFIER
+                    and safe_decode_text(key) == prop_name
                 ):
-                    return self._js_identifier_class_qn(
-                        child, factory_module, depth + 1
+                    return self._js_value_type_class_qn(
+                        child.child_by_field_name(cs.FIELD_VALUE),
+                        factory_module,
+                        depth + 1,
                     )
+            elif (
+                child.type == cs.TS_SHORTHAND_PROPERTY_IDENTIFIER
+                and safe_decode_text(child) == prop_name
+            ):
+                return self._js_identifier_class_qn(child, factory_module, depth + 1)
         return None
 
     @staticmethod
@@ -6950,9 +7117,11 @@ class CallProcessor:
         sym_qn = self._js_symbol_name_qn(sym_name, module_qn)
         if sym_qn is None or sym_qn not in self.js_symbol_constants:
             return None
-        classes = self.js_symbol_member_types.get(sym_qn)
-        if not classes:
-            return None
+        # The shape is recognised from here on: a symbol-keyed receiver is
+        # NEVER resolvable by name, so the generic path is suppressed even
+        # when no installation typed (an empty target list), rather than
+        # letting the trie guess a same-named method on an unrelated class.
+        classes = self.js_symbol_member_types.get(sym_qn) or set()
         registry = self._resolver.function_registry
         targets = [
             (registry[method_qn], method_qn)

--- a/codebase_rag/tests/test_js_symbol_keyed_member_dispatch.py
+++ b/codebase_rag/tests/test_js_symbol_keyed_member_dispatch.py
@@ -199,9 +199,109 @@ def test_symbol_for_registry_constant_links(tmp_path: Path) -> None:
     )
 
 
+def test_module_binding_constructor_install_links(tmp_path: Path) -> None:
+    # `const CTP = require('./mod.js')` binding a whole-module CONSTRUCTOR
+    # FUNCTION (prototype methods, no class syntax): `[kSym]: new CTP()`
+    # must type the install (fastify's kContentTypeParser).
+    files = {
+        "symbols.js": SYMBOLS,
+        "parser.js": """'use strict'
+function Parser (opts) {
+  this.opts = opts
+}
+Parser.prototype.ping = function () { return 'pong' }
+module.exports = Parser
+""",
+        "main.js": """'use strict'
+const { kCtrl } = require('./symbols.js')
+const Parser = require('./parser.js')
+function build (options) {
+  return { [kCtrl]: new Parser(options) }
+}
+function use (server) {
+  return server[kCtrl].ping()
+}
+module.exports = { build, use }
+""",
+    }
+    cap = _run(tmp_path, files)
+    assert any(
+        rel == str(cs.RelationshipType.CALLS)
+        and str(frm).endswith(".use")
+        and str(to) == "p.parser.Parser.ping"
+        for frm, rel, to in cap.rels
+    )
+
+
+def test_class_field_symbol_install_links(tmp_path: Path) -> None:
+    # `class Server { [kCtrl] = new Ctrl() }`: the class-field installation
+    # feeds the index like an object-literal key.
+    files = {
+        "symbols.js": SYMBOLS,
+        "ctrl.js": CTRL,
+        "main.js": """'use strict'
+const { kCtrl } = require('./symbols.js')
+const { Ctrl } = require('./ctrl.js')
+class Server {
+  [kCtrl] = new Ctrl()
+}
+function use (server) {
+  return server[kCtrl].ping()
+}
+module.exports = { Server, use }
+""",
+    }
+    cap = _run(tmp_path, files)
+    assert any(
+        rel == str(cs.RelationshipType.CALLS)
+        and str(frm).endswith(".use")
+        and str(to) == "p.ctrl.Ctrl.ping"
+        for frm, rel, to in cap.rels
+    )
+
+
+def test_for_of_var_binding_is_function_scoped(tmp_path: Path) -> None:
+    # `for (var ctrl of list)` hoists ctrl to the function; a read AFTER the
+    # loop still reads the loop variable, never an outer same-named binding.
+    ctrl = CTRL.replace(
+        "module.exports = { Ctrl, createCtrl }",
+        """class Other {
+  ping () { return 'nope' }
+}
+module.exports = { Ctrl, Other, createCtrl }
+""",
+    )
+    main = """'use strict'
+const { kCtrl } = require('./symbols.js')
+const { Other } = require('./ctrl.js')
+const ctrl = new Other()
+function sink (v) { return v }
+function build (list) {
+  for (var ctrl of list) { sink(ctrl) }
+  return { [kCtrl]: ctrl }
+}
+function use (server) {
+  return server[kCtrl].ping()
+}
+module.exports = { build, use, ctrl }
+"""
+    cap = _run(
+        tmp_path,
+        {"symbols.js": SYMBOLS, "ctrl.js": ctrl, "main.js": main},
+    )
+    assert not any(
+        rel == str(cs.RelationshipType.CALLS)
+        and str(frm).endswith(".use")
+        and str(to).endswith(".ping")
+        for frm, rel, to in cap.rels
+    )
+
+
 def test_parameter_installation_is_unknowable(tmp_path: Path) -> None:
     # The installed value is a PARAMETER; a same-named module-level binding
-    # must not type it (the decorator pattern this feature targets).
+    # must not type it (the decorator pattern this feature targets). The
+    # call site degrades to REFERENCES over name-matching methods so
+    # liveness survives without a wrong-class CALLS.
     main = """'use strict'
 const { kCtrl } = require('./symbols.js')
 const { Other } = require('./ctrl.js')
@@ -232,6 +332,12 @@ module.exports = { Ctrl, Other, createCtrl }
         and str(to).endswith(".ping")
         for frm, rel, to in cap.rels
     )
+    refs = str(cs.RelationshipType.REFERENCES)
+    for target in ("p.ctrl.Ctrl.ping", "p.ctrl.Other.ping"):
+        assert any(
+            rel == refs and str(frm).endswith(".use") and str(to) == target
+            for frm, rel, to in cap.rels
+        )
 
 
 def test_parameter_subscript_installation_is_unknowable(tmp_path: Path) -> None:
@@ -265,6 +371,12 @@ module.exports = { Ctrl, Other, createCtrl }
         and str(to).endswith(".ping")
         for frm, rel, to in cap.rels
     )
+    refs = str(cs.RelationshipType.REFERENCES)
+    for target in ("p.ctrl.Ctrl.ping", "p.ctrl.Other.ping"):
+        assert any(
+            rel == refs and str(frm).endswith(".use") and str(to) == target
+            for frm, rel, to in cap.rels
+        )
 
 
 def test_block_shadow_does_not_type_the_installation(tmp_path: Path) -> None:

--- a/codebase_rag/tests/test_js_symbol_keyed_member_dispatch.py
+++ b/codebase_rag/tests/test_js_symbol_keyed_member_dispatch.py
@@ -233,6 +233,45 @@ module.exports = { build, use }
     )
 
 
+def test_plain_function_nested_helper_never_types_the_install(
+    tmp_path: Path,
+) -> None:
+    # `new makeThing()` where makeThing is a PLAIN function (no prototype
+    # members): its nested private helpers share the `module.fn.name`
+    # registry namespace with prototype methods, so accepting the function
+    # as a constructor would manufacture a confident CALLS to an
+    # unreachable helper.
+    files = {
+        "symbols.js": SYMBOLS,
+        "factory.js": """'use strict'
+function makeThing (o) {
+  function ping () { return 'private helper' }
+  ping()
+  return {}
+}
+module.exports = makeThing
+""",
+        "main.js": """'use strict'
+const { kCtrl } = require('./symbols.js')
+const makeThing = require('./factory.js')
+function build () {
+  return { [kCtrl]: new makeThing() }
+}
+function use (s) {
+  return s[kCtrl].ping()
+}
+module.exports = { build, use }
+""",
+    }
+    cap = _run(tmp_path, files)
+    assert not any(
+        rel == str(cs.RelationshipType.CALLS)
+        and str(frm).endswith(".use")
+        and str(to) == "p.factory.makeThing.ping"
+        for frm, rel, to in cap.rels
+    )
+
+
 def test_class_field_symbol_install_links(tmp_path: Path) -> None:
     # `class Server { [kCtrl] = new Ctrl() }`: the class-field installation
     # feeds the index like an object-literal key.

--- a/codebase_rag/tests/test_js_symbol_keyed_member_dispatch.py
+++ b/codebase_rag/tests/test_js_symbol_keyed_member_dispatch.py
@@ -1,0 +1,210 @@
+# A method call through a symbol-keyed computed member,
+# `obj[kSymbol].method(...)`, emits no CALLS edge when the symbol and the
+# class live in different modules from the call site; every method of a
+# class installed this way reports dead. Found dogfooding fastify
+# (LogController via kLogController, SchemaController via
+# kSchemaController: seventeen candidates). Issue #989.
+from __future__ import annotations
+
+from pathlib import Path
+
+from codebase_rag import constants as cs
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.types_defs import PropertyDict, PropertyValue, ResultRow
+
+PROJECT = "p"
+
+SYMBOLS = """'use strict'
+module.exports = { kCtrl: Symbol('ctrl') }
+"""
+
+CTRL = """'use strict'
+class Ctrl {
+  ping () { return 'pong' }
+}
+function createCtrl (options) { return new Ctrl() }
+module.exports = { Ctrl, createCtrl }
+"""
+
+MAIN = """'use strict'
+const { kCtrl } = require('./symbols.js')
+const { createCtrl } = require('./ctrl.js')
+function build (options) {
+  const ctrl = createCtrl(options)
+  return { [kCtrl]: ctrl }
+}
+function use (server) {
+  return server[kCtrl].ping()
+}
+module.exports = { build, use }
+"""
+
+
+class _Capture:
+    def __init__(self) -> None:
+        self.rels: list[tuple[PropertyValue, str, PropertyValue]] = []
+
+    def ensure_node_batch(self, label: str, properties: PropertyDict) -> None:
+        return None
+
+    def ensure_relationship_batch(
+        self,
+        from_spec: tuple[str, str, PropertyValue],
+        rel_type: str,
+        to_spec: tuple[str, str, PropertyValue],
+        properties: PropertyDict | None = None,
+    ) -> None:
+        self.rels.append((from_spec[2], str(rel_type), to_spec[2]))
+
+    def flush_all(self) -> None:
+        return None
+
+    def fetch_all(
+        self, query: str, params: PropertyDict | None = None
+    ) -> list[ResultRow]:
+        return []
+
+    def execute_write(self, query: str, params: PropertyDict | None = None) -> None:
+        return None
+
+
+def _run(tmp_path: Path, files: dict[str, str]) -> _Capture:
+    for name, src in files.items():
+        (tmp_path / name).write_text(src)
+    parsers, queries = load_parsers()
+    cap = _Capture()
+    GraphUpdater(
+        ingestor=cap,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name=PROJECT,
+    ).run(force=True)
+    return cap
+
+
+def test_cross_module_symbol_keyed_method_call_links(tmp_path: Path) -> None:
+    cap = _run(
+        tmp_path,
+        {"symbols.js": SYMBOLS, "ctrl.js": CTRL, "main.js": MAIN},
+    )
+    assert any(
+        rel == str(cs.RelationshipType.CALLS)
+        and str(frm).endswith(".use")
+        and str(to) == "p.ctrl.Ctrl.ping"
+        for frm, rel, to in cap.rels
+    )
+
+
+def test_subscript_assignment_installation_links(tmp_path: Path) -> None:
+    # The `obj[kSym] = value` installation form (fastify installs onto
+    # `this`-like receivers) feeds the same index.
+    main = MAIN.replace(
+        "  return { [kCtrl]: ctrl }",
+        "  const server = {}\n  server[kCtrl] = ctrl\n  return server",
+    )
+    cap = _run(
+        tmp_path,
+        {"symbols.js": SYMBOLS, "ctrl.js": CTRL, "main.js": main},
+    )
+    assert any(
+        rel == str(cs.RelationshipType.CALLS)
+        and str(frm).endswith(".use")
+        and str(to) == "p.ctrl.Ctrl.ping"
+        for frm, rel, to in cap.rels
+    )
+
+
+def test_two_installed_classes_reference_without_guessing(tmp_path: Path) -> None:
+    # Two DIFFERENT classes installed under one symbol project-wide: no
+    # single CALLS edge may be guessed (the bare-name fallback used to pick
+    # one arbitrarily); instead each candidate's matching method is
+    # REFERENCED so liveness holds.
+    ctrl = CTRL.replace(
+        "module.exports = { Ctrl, createCtrl }",
+        """class Other {
+  ping () { return 'nope' }
+}
+module.exports = { Ctrl, Other, createCtrl }
+""",
+    )
+    main = MAIN.replace(
+        "const { createCtrl } = require('./ctrl.js')",
+        "const { createCtrl, Other } = require('./ctrl.js')",
+    ).replace(
+        "module.exports = { build, use }",
+        """function shadow (o) {
+  return { [kCtrl]: new Other() }
+}
+module.exports = { build, use, shadow }
+""",
+    )
+    cap = _run(
+        tmp_path,
+        {"symbols.js": SYMBOLS, "ctrl.js": ctrl, "main.js": main},
+    )
+    calls = str(cs.RelationshipType.CALLS)
+    refs = str(cs.RelationshipType.REFERENCES)
+    assert not any(
+        rel == calls and str(frm).endswith(".use") and str(to).endswith(".ping")
+        for frm, rel, to in cap.rels
+    )
+    for target in ("p.ctrl.Ctrl.ping", "p.ctrl.Other.ping"):
+        assert any(
+            rel == refs and str(frm).endswith(".use") and str(to) == target
+            for frm, rel, to in cap.rels
+        )
+
+
+def test_non_symbol_computed_key_never_joins_the_index(tmp_path: Path) -> None:
+    # `rows[i] = new Row()` with a plain loop variable must not let the
+    # SYMBOL index type an unrelated `cells[i].render()`. Two render-bearing
+    # classes keep the pre-existing name-trie fallback out of the picture,
+    # so any Row.render edge here could only come from the index.
+    files = {
+        "rows.js": """'use strict'
+class Row {
+  render () { return 1 }
+}
+class Panel {
+  render () { return 2 }
+}
+function fill (rows, cells, i) {
+  rows[i] = new Row()
+  return cells[i].render()
+}
+function decorate (p) { return new Panel().render() }
+module.exports = { Row, Panel, fill, decorate }
+""",
+    }
+    cap = _run(tmp_path, files)
+    assert not any(
+        str(frm).endswith(".fill") and str(to) == "p.rows.Row.render"
+        for frm, _rel, to in cap.rels
+    )
+
+
+def test_symbol_for_registry_constant_links(tmp_path: Path) -> None:
+    symbols = SYMBOLS.replace("Symbol('ctrl')", "Symbol.for('app.ctrl')")
+    cap = _run(
+        tmp_path,
+        {"symbols.js": symbols, "ctrl.js": CTRL, "main.js": MAIN},
+    )
+    assert any(
+        rel == str(cs.RelationshipType.CALLS)
+        and str(frm).endswith(".use")
+        and str(to) == "p.ctrl.Ctrl.ping"
+        for frm, rel, to in cap.rels
+    )
+
+
+def test_unknown_method_on_installed_class_emits_nothing(tmp_path: Path) -> None:
+    main = MAIN.replace("server[kCtrl].ping()", "server[kCtrl].vanish()")
+    cap = _run(
+        tmp_path,
+        {"symbols.js": SYMBOLS, "ctrl.js": CTRL, "main.js": main},
+    )
+    assert not any(
+        str(frm).endswith(".use") and "vanish" in str(to) for frm, _rel, to in cap.rels
+    )

--- a/codebase_rag/tests/test_js_symbol_keyed_member_dispatch.py
+++ b/codebase_rag/tests/test_js_symbol_keyed_member_dispatch.py
@@ -272,6 +272,43 @@ module.exports = { build, use }
     )
 
 
+def test_prototype_evidence_is_per_member_not_per_function(
+    tmp_path: Path,
+) -> None:
+    # A constructor WITH prototype methods still must not expose its nested
+    # private helpers: the evidence has to name the SPECIFIC member.
+    files = {
+        "symbols.js": SYMBOLS,
+        "parser.js": """'use strict'
+function Parser (x) {
+  function ping () { return 'private helper' }
+  ping()
+  this.x = x
+}
+Parser.prototype.other = function () { return 'proto' }
+module.exports = Parser
+""",
+        "main.js": """'use strict'
+const { kCtrl } = require('./symbols.js')
+const Parser = require('./parser.js')
+function build () {
+  return { [kCtrl]: new Parser(1) }
+}
+function use (s) {
+  return s[kCtrl].ping()
+}
+module.exports = { build, use }
+""",
+    }
+    cap = _run(tmp_path, files)
+    assert not any(
+        rel == str(cs.RelationshipType.CALLS)
+        and str(frm).endswith(".use")
+        and str(to) == "p.parser.Parser.ping"
+        for frm, rel, to in cap.rels
+    )
+
+
 def test_class_field_symbol_install_links(tmp_path: Path) -> None:
     # `class Server { [kCtrl] = new Ctrl() }`: the class-field installation
     # feeds the index like an object-literal key.

--- a/codebase_rag/tests/test_js_symbol_keyed_member_dispatch.py
+++ b/codebase_rag/tests/test_js_symbol_keyed_member_dispatch.py
@@ -185,6 +185,33 @@ module.exports = { Row, Panel, fill, decorate }
     )
 
 
+def test_function_local_symbol_pair_is_not_a_constant(tmp_path: Path) -> None:
+    # A `k: Symbol(...)` pair INSIDE a function is a local value, not a
+    # module symbol constant; an unrelated module-level name spelled the
+    # same must keep its generic resolution (here: the unique-class trie
+    # CALLS), not get suppressed into a fan.
+    files = {
+        "ctrl.js": CTRL,
+        "main.js": """'use strict'
+const { Ctrl } = require('./ctrl.js')
+function make () {
+  return { kCtrl: Symbol('local') }
+}
+function use (server, kCtrl) {
+  return server[kCtrl].ping()
+}
+module.exports = { make, use }
+""",
+    }
+    cap = _run(tmp_path, files)
+    assert any(
+        rel == str(cs.RelationshipType.CALLS)
+        and str(frm).endswith(".use")
+        and str(to) == "p.ctrl.Ctrl.ping"
+        for frm, rel, to in cap.rels
+    )
+
+
 def test_symbol_for_registry_constant_links(tmp_path: Path) -> None:
     symbols = SYMBOLS.replace("Symbol('ctrl')", "Symbol.for('app.ctrl')")
     cap = _run(

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.520"
+version = "0.0.521"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Fixes #989. A method call through a symbol-keyed computed member, `obj[kSymbol].method(...)`, emitted no CALLS edge when the symbol and the class lived in different modules from the call site, so every method of a class installed this way reported dead (seventeen fastify candidates across LogController and SchemaController).

## Design

A project-wide symbol index built in a pre-pass before call resolution:

1. **Symbol constants**: `kX = Symbol(...)` declarators and `kX: Symbol(...)` object pairs register the constant's qn (`Symbol(...)` and `Symbol.for(...)`).
2. **Installations**: `{ [kX]: value }` object keys, class fields (both grammars), and `obj[kX] = value` subscript assignments record the installed value's class, typed at sweep time by a depth-capped value chase: direct constructions, factory calls (bare, member, verified `Class.method = fn` static assignments), destructured-return object properties, and identifiers resolved to the INNERMOST introduction whose scope span encloses the read (parameters, catch and loop bindings and uninitialised declarators are opaque and refuse; the name-match-anywhere resolution that leaks was never used). A `new X(...)` target may be an old-style constructor FUNCTION only with per-member `X.prototype.<method> = ...` evidence, so nested private helpers sharing the `module.fn.name` namespace never masquerade as methods.
3. **Resolution**: `recv[kSym].method()` with exactly ONE installed class emits a precise CALLS; several installed classes emit REFERENCES to each candidate's matching method; a recognised symbol shape with NO typed installation degrades to REFERENCES over every registry function or method of that name, replacing the bare-name trie fallback that guessed one same-named method on an arbitrary class (a known method on the installed class set that fails the evidence gate emits nothing, matching the unknown-method rule). Divergent factory returns and ambiguous introductions always refuse rather than guess.

## Verification

Strict RED first for all sixteen pins (each confirmed failing before its fix; see commit history). Five adversarial review rounds in pinned worktrees against upstream main: nine findings (unscoped declarator chase in three forms, unrelated free-function fallback, divergent destructured returns, for-of `var` hoisting, edge-deleting suppression, and the Function-acceptance phantom in per-function and per-member forms), every one fixed and re-verified with its original repro.

Corpus results versus main: **fastify dead-code 18 to 0** with nothing added (this branch clears the seventeen symbol-dispatch candidates and their nested functions; the merged #1001 covers the rest), the four ContentTypeParser cross-checks land as precise CALLS, and excalidraw, zod and typeorm are delta-zero at both dead-code and (for excalidraw) full edge level. Full suite 6125 passed, 5 skipped, 0 failed.

With this PR merged, the fastify dogfood round that opened at 36 dead-code candidates closes at zero.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved JavaScript and TypeScript analysis for methods accessed through computed or symbol-based properties.
  * More accurately identifies class targets across constructors, factories, object properties, scopes, and modules.
  * Produces more precise call and reference relationships, including conservative handling of ambiguous cases.

* **Bug Fixes**
  * Prevents incorrect inferred calls when symbol bindings are unknown, shadowed, or associated with multiple classes.

* **Tests**
  * Added comprehensive coverage for symbol-based member dispatch scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->