### PR TITLE
docs: add governance, roadmap, security model, and release verification for OpenSSF silver

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Code Graph RAG
 
-Thank you for your interest in contributing to Code Graph RAG! We welcome contributions from the community.
+Thank you for your interest in contributing to Code Graph RAG! We welcome contributions from the community. How the project is run, who decides what, and how to become a maintainer are described in [GOVERNANCE.md](GOVERNANCE.md).
 
 ## Getting Started
 
@@ -55,7 +55,7 @@ Labels are automatically synced from [`.github/labels.yml`](.github/labels.yml).
 
 3. **Make Your Changes**:
    - Follow the existing code style and patterns
-   - Add tests for new functionality
+   - Add tests: this is project policy, not a suggestion. New functionality must come with tests that exercise it, and bug fixes must include a regression test that fails without the fix
    - Update documentation if needed
    - Do not add inline comments (see Comment Policy below)
 
@@ -74,7 +74,7 @@ Labels are automatically synced from [`.github/labels.yml`](.github/labels.yml).
 
 - Keep PRs focused on a single issue or feature
 - Write clear, descriptive commit messages
-- Include tests for new functionality
+- Tests are required for new functionality and for bug fixes; PRs adding major functionality without tests will not be merged
 - Update documentation when necessary
 - Be responsive to feedback during code review
 
@@ -806,6 +806,10 @@ The scope (in parentheses) is optional and can contain alphanumeric characters, 
 ### Comment Policy
 
 Write comments that explain **why** and **how**, not **what**. A comment that only restates the adjacent code adds no value; one that captures a non-obvious reason, a tricky invariant, or a concrete edge case earns its place.
+
+## Licensing of Contributions
+
+This project is licensed under the [MIT licence](LICENSE). By submitting a contribution, you agree that it is your own work (or that you have the right to submit it) and that it is licensed to the project and its users under the same MIT licence. You retain copyright in your contribution; no copyright assignment is required.
 
 ## Questions?
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,42 @@
+# Governance
+
+This document describes how the code-graph-rag project is governed: how decisions are made, who holds which roles, and how the project continues if a key person becomes unavailable.
+
+## Governance Model
+
+code-graph-rag uses a maintainer-led governance model. A single lead maintainer holds final decision-making authority over the project's direction, code, and releases. All decisions are made in the open through GitHub issues and pull requests, and anyone is welcome to participate in those discussions.
+
+## Roles and Responsibilities
+
+### Lead Maintainer
+
+The lead maintainer is [Vitali Avagyan (@vitali87)](https://github.com/vitali87). The lead maintainer is responsible for:
+
+- Setting the project direction and maintaining the [roadmap](https://docs.code-graph-rag.com/roadmap/)
+- Triaging issues and reviewing pull requests
+- Merging changes and publishing releases to PyPI and GitHub
+- Responding to security reports as described in the [security policy](.github/SECURITY.md)
+- Enforcing the [code of conduct](.github/CODE_OF_CONDUCT.md)
+
+### Contributors
+
+Anyone may contribute through pull requests, following the [contributing guide](CONTRIBUTING.md). Contributors are credited in release notes and retain copyright in their contributions, which are accepted under the project's MIT licence.
+
+### Becoming a Maintainer
+
+Contributors who make sustained, high-quality contributions and demonstrate good judgement in reviews and issue discussions may be invited by the lead maintainer to become co-maintainers with commit access.
+
+## Decision Making
+
+Routine decisions (bug fixes, small features, dependency updates) are made through the normal pull request process. Significant decisions (new language support, architectural changes, breaking changes) are proposed and discussed in GitHub issues before implementation, so the reasoning is public and searchable. The lead maintainer makes the final call when consensus is not reached.
+
+## Continuity
+
+The project is designed so that no local machine or personal key is required to keep it running:
+
+- The repository, the PyPI package, and release automation are all driven from GitHub; releases are built and signed by GitHub Actions using keyless Sigstore signing, and PyPI publishing uses trusted publishing rather than a maintainer-held token.
+- The automated version-bump pipeline uses repository-scoped secrets (a deploy key and a release-notes endpoint token); a repository admin can regenerate these, and releases can also be dispatched manually without them.
+
+An emergency contact with standby access to the repository and the PyPI project is being designated so that issues, merges, and releases can continue within a week if the lead maintainer becomes unavailable.
+
+If the project becomes unmaintained, the MIT licence permits anyone to fork and continue it.

--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -1,0 +1,46 @@
+---
+description: "Security model and assurance case: threat model, trust boundaries, and how the project's security requirements are met."
+---
+
+# Security Model
+
+This page documents what users can and cannot expect from code-graph-rag in terms of security: the security requirements, the trust boundaries, the threat model, and the argument for why the requirements are met. Vulnerability reporting is covered by the [security policy](https://github.com/vitali87/code-graph-rag/blob/main/.github/SECURITY.md), and project decision-making by the [governance document](https://github.com/vitali87/code-graph-rag/blob/main/GOVERNANCE.md).
+
+## What the software does
+
+code-graph-rag parses codebases into a knowledge graph stored in a local Memgraph database, optionally embeds code for semantic search in a local Qdrant instance, and answers natural-language questions about the code, either through the interactive CLI agent or through the MCP server.
+
+## Security requirements
+
+1. Tree-sitter parsing of analysed repository content must never execute that content. Frontends that invoke a language toolchain on the analysed project must be documented, along with how to disable them.
+2. Credentials (LLM API keys, MCP tokens) must never appear in source code or in the graph.
+3. The MCP server must not expose the graph or the tools to other hosts unauthenticated.
+4. The paths by which code can leave the machine must be documented and controlled by explicit configuration.
+5. Agent tool use (shell commands, file edits) must be constrained to the project being analysed, with any escape hatch requiring an explicit user choice.
+
+## Trust boundaries and threat model
+
+**The analysed repository is untrusted input, with one important exception.** Most language frontends are pure Tree-sitter parsers: they read bytes and produce syntax trees, so a hostile repository can at worst produce a wrong graph, not code execution. Two frontends go further. The C++ frontend defaults to `CPP_FRONTEND=hybrid`, which additionally parses translation units with libclang; this is still parsing only. The C# frontend defaults to `CSHARP_FRONTEND=auto`, which resolves to the Roslyn-based hybrid frontend whenever a `dotnet` toolchain is on `PATH`; that path runs `dotnet restore` and evaluates the project's MSBuild files, and source generators from the analysed repository execute inside the compilation. In other words, with the .NET SDK installed, indexing a C# repository runs parts of that repository's build with your privileges, and this is the default. Set `CSHARP_FRONTEND=treesitter` before indexing C# repositories whose build you do not trust. See the [graph schema documentation](graph-schema.md) for the frontend matrix.
+
+**The graph and vector stores are local processes, but their ports are currently network-reachable.** Memgraph and Qdrant run in local Docker containers managed by `cgr daemon`. The compose file presently publishes their ports (7687, 7444, 3000, 6333, 6334) without a host-address restriction, which Docker binds to all interfaces, so on an untrusted network other hosts can reach the unauthenticated Memgraph and Qdrant endpoints. Treat the graph with the same confidentiality as the code itself and run the stack only on trusted networks; issue [#1012](https://github.com/vitali87/code-graph-rag/issues/1012) tracks changing the default to a loopback bind.
+
+**The LLM and embedding provider boundary.** Code can leave the machine on two paths, both chosen by configuration: interactive querying sends snippets and questions to the configured model provider, and semantic indexing sends code to the embedding provider when `CGR_EMBEDDING_PROVIDER=openai` is set. Both use TLS with standard certificate verification (httpx defaults). The defaults keep everything local: a local UniXcoder model computes embeddings, and with a local model provider (Ollama) queries never leave the machine either. API keys are supplied via environment variables or `.env`, are excluded from version control, and are never written to the graph.
+
+**The MCP server boundary.** The HTTP MCP server binds `127.0.0.1` by default. It refuses to bind a non-loopback address unless `MCP_HTTP_AUTH_TOKEN` is set, in which case every request must carry the bearer token. This closes the drive-by exposure reported in issue [#808](https://github.com/vitali87/code-graph-rag/issues/808).
+
+**The agent's tools.** The CLI agent can run shell commands and edit files at the user's request. In the default permission mode, shell commands are checked against an allowlist and screened for destructive patterns (for example `rm` against paths outside the project) before execution, and file operations are scoped to the target project root. The interactive session offers a YOLO mode that disables the allowlist check (destructive-path screening still applies); it exists for users who accept the risk, is off by default, and requires an explicit toggle.
+
+**XML and other parsers.** XML from analysed projects is parsed with `defusedxml`, which disables entity-expansion attacks.
+
+## How the requirements are assured
+
+- **Secure development process.** Every change goes through a pull request with CI, strict ruff linting, and a red/green test discipline; statement coverage is above 90% and is tracked on [SonarCloud](https://sonarcloud.io/project/overview?id=vitali87_code-graph-rag), which also performs static security analysis.
+- **Dependency hygiene.** Dependencies are pinned in `uv.lock`, monitored by Dependabot, and scanned by OSV-Scanner in CI.
+- **Supply-chain integrity.** Release binaries are signed with Sigstore and, from v0.0.484 onwards, carry SLSA build provenance generated by GitHub Actions; see [verifying release artifacts](../getting-started/installation.md#verify-release-artifacts). The project's [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/vitali87/code-graph-rag) is published, and the project holds the [OpenSSF Best Practices badge](https://www.bestpractices.dev/projects/13757).
+- **No bespoke cryptography.** The project implements no cryptographic algorithms of its own; TLS and signature verification are delegated to httpx, Sigstore, and the platform.
+
+## What users should not expect
+
+- Toolchain-invoking analysis of a hostile repository is not sandboxed; the toolchain runs with your privileges (see the C# frontend caveat above).
+- The local Memgraph and Qdrant containers are unauthenticated services intended for a single user on a trusted machine and network (see issue [#1012](https://github.com/vitali87/code-graph-rag/issues/1012)).
+- Pre-1.0, the project releases continuously and security-relevant defaults may be tightened in any release; release notes call such changes out.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -89,6 +89,28 @@ make dev
 
 This installs all dependencies and sets up pre-commit hooks automatically.
 
+## Verify Release Artifacts
+
+Each [GitHub release](https://github.com/vitali87/code-graph-rag/releases) ships prebuilt binaries together with Sigstore signatures (`*.sigstore.json`); releases from v0.0.484 onwards also carry a SLSA build provenance attestation (`multiple.intoto.jsonl`). Both are produced by the `build-binaries.yml` GitHub Actions workflow using keyless signing, so there is no maintainer-held key to obtain: verification checks that the artifact was built by this repository's release workflow.
+
+To verify provenance with the [GitHub CLI](https://cli.github.com/):
+
+```bash
+gh attestation verify code-graph-rag-linux-amd64 --repo vitali87/code-graph-rag
+```
+
+To verify a signature with [cosign](https://docs.sigstore.dev/cosign/system_config/installation/):
+
+```bash
+cosign verify-blob \
+  --bundle code-graph-rag-linux-amd64.sigstore.json \
+  --certificate-identity-regexp 'https://github\.com/vitali87/code-graph-rag/\.github/workflows/build-binaries\.yml@.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  code-graph-rag-linux-amd64
+```
+
+Substitute the binary name for your platform. Packages installed from PyPI are protected separately by PyPI's own integrity checks through `pip` and `uv`.
+
 ## Start Memgraph
 
 ```bash

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,31 @@
+---
+description: "What Code-Graph-RAG intends to do, and not do, over the next year."
+---
+
+# Roadmap
+
+This page describes what the project intends to do, and deliberately not do, over roughly the next year (from mid 2026). It is a statement of direction rather than a schedule; items ship when they are ready. Day-to-day priorities live in the [issue tracker](https://github.com/vitali87/code-graph-rag/issues), and known analysis gaps are catalogued in [TODO.md](https://github.com/vitali87/code-graph-rag/blob/main/docs/TODO.md).
+
+## What we intend to do
+
+**Deepen analysis quality for the languages we already support.** The fully supported languages (see the [language support matrix](architecture/language-support.md) for the current list and per-language status) should converge on the same level of fidelity: call resolution, type inference, and data-flow edges. The known per-language type-inference gaps are tracked in TODO.md and are worked down continuously.
+
+**Keep improving dead-code detection precision.** False-positive reduction against real-world codebases is an ongoing campaign, driven by dogfooding the tool against large open-source projects and fixing every class of misreport at the root.
+
+**Maintain and extend the evaluation harness.** Structure evals with native per-language AST oracles keep the extractors honest. New analysis features land with eval coverage.
+
+**Grow the configuration-driven language tier.** The ast-grep YAML tier lets a new language be added as a configuration file rather than a full extractor. This is the intended path for broadening language coverage cheaply.
+
+**Stability of the SDK and MCP server.** The Python SDK and the MCP server are the supported integration surfaces and their interfaces are kept stable within the pre-1.0 versioning policy below.
+
+**Performance and incremental updates.** Large-repository ingestion time and the real-time updater are active areas of improvement.
+
+**Security posture.** The project holds the OpenSSF Best Practices passing badge and is working towards the silver badge, alongside improving its OpenSSF Scorecard results.
+
+## What we do not intend to do
+
+**New first-class language frontends without demonstrated demand.** A new hand-written extractor is a large permanent maintenance cost. Requests for new languages start as issues; a language graduates to a first-class frontend only when multiple users ask for it. Until then, the ast-grep YAML tier is the supported route.
+
+**A hosted service.** code-graph-rag stays a local-first CLI and SDK. Your code and your graph remain on your machine unless you configure a cloud LLM provider yourself.
+
+**API stability guarantees before 1.0.** The project releases continuously (a patch release on every merge), so while it is pre-1.0, interfaces may change in any release. Breaking changes are called out in release notes.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,11 +100,13 @@ nav:
     - Graph Schema: architecture/graph-schema.md
     - I/O and Data-Flow Edges: architecture/data-flow-edges.md
     - Language Support: architecture/language-support.md
+    - Security Model: architecture/security.md
   - Advanced:
     - Adding Languages: advanced/adding-languages.md
     - Ignore Patterns: advanced/ignore-patterns.md
     - Building Binaries: advanced/building-binaries.md
     - Troubleshooting: advanced/troubleshooting.md
+  - Roadmap: roadmap.md
   - Contributing: contributing.md
 
 # Internal analysis artifacts kept in the repo but not published to the doc site nav.

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.522"
+version = "0.0.524"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Adds the four documents required by the OpenSSF Best Practices silver criteria: `GOVERNANCE.md` (governance, roles_responsibilities, access_continuity), `docs/roadmap.md` (documentation_roadmap), `docs/architecture/security.md` (assurance_case, documentation_security), and a release verification section in the installation guide (signed_releases)
- Strengthens CONTRIBUTING.md: tests are stated as required policy (test_policy_mandated, tests_documented_added) and an inbound=outbound MIT licensing section is added (dco)
- The security model documents two real findings surfaced while writing it: the C# hybrid frontend executes analysed-project build logic by default, and the daemon stack publishes Memgraph/Qdrant ports on all interfaces (tracked in #1012)

## Type of Change

- [x] Documentation

## Related Issues

Related to #1012

## Test Plan

- [x] Manual testing (describe below)

`uv run mkdocs build --strict` passes with the two new nav entries; pre-commit passes on all changed files. An adversarial review verified the cosign/gh verification commands against the v0.0.484 release bundle certificate and the documented claims against the code and workflows.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [x] No new comments or docstrings (code should be self-documenting)

## Note for the maintainer

GOVERNANCE.md says an emergency contact "is being designated": before claiming the access_continuity silver criterion, choose the person and grant them standby access to the repo and PyPI, then update that sentence to name the arrangement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added governance guidance covering maintainership, contributions, decision-making, and continuity.
  * Added a security model describing trust boundaries, threat considerations, authentication, and tool restrictions.
  * Documented release artifact and signature verification steps.
  * Added a project roadmap outlining upcoming priorities and out-of-scope areas.
  * Updated contribution guidance with testing and licensing information.
  * Added the new security and roadmap pages to the documentation navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->