### PR TITLE
docs: tighten release verification guidance from PR #1013 review

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -96,8 +96,12 @@ Each [GitHub release](https://github.com/vitali87/code-graph-rag/releases) ships
 To verify provenance with the [GitHub CLI](https://cli.github.com/):
 
 ```bash
-gh attestation verify code-graph-rag-linux-amd64 --repo vitali87/code-graph-rag
+gh attestation verify code-graph-rag-linux-amd64 \
+  --repo vitali87/code-graph-rag \
+  --signer-workflow vitali87/code-graph-rag/.github/workflows/build-binaries.yml
 ```
+
+The `--signer-workflow` flag pins the attestation to the release workflow itself; `--repo` alone accepts an attestation signed by any workflow in the repository.
 
 To verify a signature with [cosign](https://docs.sigstore.dev/cosign/system_config/installation/):
 
@@ -109,7 +113,7 @@ cosign verify-blob \
   code-graph-rag-linux-amd64
 ```
 
-Substitute the binary name for your platform. Packages installed from PyPI are protected separately by PyPI's own integrity checks through `pip` and `uv`.
+Substitute the binary name for your platform. Packages installed from PyPI are protected differently: `pip` and `uv` verify package hashes, which proves integrity in transit, and releases after v0.0.187 additionally carry a [PEP 740](https://peps.python.org/pep-0740/) attestation. That is a publish attestation — proof that the file was uploaded by this project's trusted publisher — rather than build provenance, and it can be queried through PyPI's [Integrity API](https://docs.pypi.org/api/integrity/).
 
 ## Start Memgraph
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,7 +4,7 @@ description: "What Code-Graph-RAG intends to do, and not do, over the next year.
 
 # Roadmap
 
-This page describes what the project intends to do, and deliberately not do, over roughly the next year (from mid 2026). It is a statement of direction rather than a schedule; items ship when they are ready. Day-to-day priorities live in the [issue tracker](https://github.com/vitali87/code-graph-rag/issues), and known analysis gaps are catalogued in [TODO.md](https://github.com/vitali87/code-graph-rag/blob/main/docs/TODO.md).
+This page describes what the project intends to do, and deliberately not do, over roughly the next year (from mid-2026). It is a statement of direction rather than a schedule; items ship when they are ready. Day-to-day priorities live in the [issue tracker](https://github.com/vitali87/code-graph-rag/issues), and known analysis gaps are catalogued in [TODO.md](https://github.com/vitali87/code-graph-rag/blob/main/docs/TODO.md).
 
 ## What we intend to do
 


### PR DESCRIPTION
## Summary

- Pins the documented `gh attestation verify` command to the release workflow with `--signer-workflow`, since `--repo` alone does not restrict which workflow signed the artifact (verified against the real v0.0.525 and v0.0.484 assets, exit 0)
- Corrects the PyPI trust-path paragraph: hashes prove integrity in transit, the PEP 740 attestation is a publish attestation (present on releases after v0.0.187) rather than build provenance, and the Integrity API link now points at the actual API reference
- Hyphenates "mid-2026" in the roadmap

Follow-up to the CodeRabbit review on #1013, which landed after that PR merged.

## Type of Change

- [x] Documentation

## Related Issues

Related to #1013

## Test Plan

- [x] Manual testing (describe below)

`uv run mkdocs build --strict` passes; pre-commit passes on the touched files; the exact documented `gh attestation verify` command was run verbatim against a downloaded release binary and succeeded, and substituting a different signer workflow fails, confirming the flag tightens verification.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [x] No new comments or docstrings (code should be self-documenting)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified release verification guidance for GitHub build attestations.
  * Distinguished PyPI hash checks from PEP 740 publish attestations and linked to the PyPI Integrity API.
  * Updated roadmap wording to specify the timeframe as “from mid-2026.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->