### PR TITLE
fix: root Rust inline #[test] functions and test-module symbols in dead-code analysis

### DIFF
--- a/codebase_rag/constants/deadcode_roots.py
+++ b/codebase_rag/constants/deadcode_roots.py
@@ -73,9 +73,13 @@ RUST_ROOT_FUNCTION_NAMES: frozenset[str] = frozenset({"main"})
 RUST_TEST_ATTRIBUTE_NAMES: frozenset[str] = frozenset({"test", "bench"})
 RUST_TEST_ATTRIBUTE_SUFFIX = "::test"
 
-# The `#[cfg(test)] mod tests` convention: any qn segment `tests` in a .rs
-# file marks inline test code (issue #1008).
-RUST_TESTS_MODULE_SEGMENT = "tests"
+# The `#[cfg(test)] mod tests` convention: a MODULE segment named `tests`
+# or `test` in a .rs file marks inline test code (issue #1008). Both
+# spellings, mirroring TEST_PATH_PATTERNS' /tests/ and /test/ directories.
+# Module segments only: the project prefix and the symbol's own name are
+# not modules, so a project directory or a method named `tests` stays
+# production code.
+RUST_TEST_MODULE_SEGMENTS: frozenset[str] = frozenset({"tests", "test"})
 
 # Rust trait-impl methods the language/std dispatches implicitly (Display::fmt
 # via format!, PartialEq::eq via ==, Iterator::next via for, operator traits,

--- a/codebase_rag/constants/deadcode_roots.py
+++ b/codebase_rag/constants/deadcode_roots.py
@@ -67,6 +67,16 @@ GO_ROOT_FUNCTION_NAMES: frozenset[str] = frozenset({"init", "main"})
 # call site -- a reachability root (gated by .rs).
 RUST_ROOT_FUNCTION_NAMES: frozenset[str] = frozenset({"main"})
 
+# Rust test attributes: the harness invokes these functions with no call site.
+# Bare names match exactly; scoped runner variants (#[tokio::test],
+# #[async_std::test]) match by the ::test suffix. Gated by .rs (issue #1008).
+RUST_TEST_ATTRIBUTE_NAMES: frozenset[str] = frozenset({"test", "bench"})
+RUST_TEST_ATTRIBUTE_SUFFIX = "::test"
+
+# The `#[cfg(test)] mod tests` convention: any qn segment `tests` in a .rs
+# file marks inline test code (issue #1008).
+RUST_TESTS_MODULE_SEGMENT = "tests"
+
 # Rust trait-impl methods the language/std dispatches implicitly (Display::fmt
 # via format!, PartialEq::eq via ==, Iterator::next via for, operator traits,
 # Drop::drop, serde, ...), never through an explicit call the graph can see.

--- a/codebase_rag/constants/deadcode_roots.py
+++ b/codebase_rag/constants/deadcode_roots.py
@@ -73,12 +73,16 @@ RUST_ROOT_FUNCTION_NAMES: frozenset[str] = frozenset({"main"})
 RUST_TEST_ATTRIBUTE_NAMES: frozenset[str] = frozenset({"test", "bench"})
 RUST_TEST_ATTRIBUTE_SUFFIX = "::test"
 
-# The `#[cfg(test)] mod tests` convention: a MODULE segment named `tests`
-# or `test` in a .rs file marks inline test code (issue #1008). Both
-# spellings, mirroring TEST_PATH_PATTERNS' /tests/ and /test/ directories.
-# Module segments only: the project prefix and the symbol's own name are
-# not modules, so a project directory or a method named `tests` stays
-# production code.
+# The `#[cfg(test)] mod tests` convention: a real MODULE node named
+# `tests` or `test` in a .rs file marks inline test code (issue #1008).
+# This is deliberately WIDER than TEST_PATH_PATTERNS (whose /tests/ and
+# /test/ entries match directory segments only, never a src/test.rs file
+# or an inline mod): the name is a proxy for the `#[cfg(test)]` gate the
+# graph does not yet record. Measured across a 972-crate corpus, 4155
+# such modules are cfg-gated test code and 41 are ungated, of which two
+# ship as production API (aws-lc-rs `pub mod test`, alacritty's terminal
+# test helpers), both test-support by nature; that residual silencing is
+# accepted until issue #1010 replaces the name proxy with cfg awareness.
 RUST_TEST_MODULE_SEGMENTS: frozenset[str] = frozenset({"tests", "test"})
 
 # Rust trait-impl methods the language/std dispatches implicitly (Display::fmt

--- a/codebase_rag/dead_code.py
+++ b/codebase_rag/dead_code.py
@@ -91,7 +91,11 @@ def _has_rust_test_attribute(props: PropertyDict) -> bool:
     if not isinstance(decorators, list):
         return False
     for decorator in decorators:
-        name = str(decorator).strip("#[] ").split(cs.CHAR_PAREN_OPEN)[0]
+        head = str(decorator).strip("#[] ").split(cs.CHAR_PAREN_OPEN)[0]
+        # Attribute paths are token streams: `#[tokio :: test]` names the
+        # same attribute as `#[tokio::test]`, so drop internal whitespace
+        # before matching.
+        name = "".join(head.split())
         if name in cs.RUST_TEST_ATTRIBUTE_NAMES or name.endswith(
             cs.RUST_TEST_ATTRIBUTE_SUFFIX
         ):

--- a/codebase_rag/dead_code.py
+++ b/codebase_rag/dead_code.py
@@ -86,23 +86,7 @@ def _is_rust_runtime_root(name: str, is_method: bool, path: str) -> bool:
     return is_method and name in cs.RUST_TRAIT_METHOD_NAMES
 
 
-def _is_rust_test_symbol(props: PropertyDict, qn: str, path: str) -> bool:
-    # Rust unit tests live INSIDE source files (`#[cfg(test)] mod tests`), so
-    # path-based test detection never sees them (issue #1008). Test code is a
-    # function carrying a `#[test]` family attribute (#[test], #[tokio::test],
-    # #[bench]) or any symbol inside a `tests` module (the #[cfg(test)]
-    # convention), including the plain helpers such modules define.
-    if not path.endswith(cs.EXT_RS):
-        return False
-    # Module segments only: qn[0] is the project prefix and qn[-1] the
-    # symbol's own name; neither is a module, so a project directory or a
-    # method named `tests` must not mark test code (and root away its
-    # whole callee closure).
-    if any(
-        segment in cs.RUST_TEST_MODULE_SEGMENTS
-        for segment in qn.split(cs.SEPARATOR_DOT)[1:-1]
-    ):
-        return True
+def _has_rust_test_attribute(props: PropertyDict) -> bool:
     decorators = props.get(cs.KEY_DECORATORS)
     if not isinstance(decorators, list):
         return False
@@ -113,6 +97,80 @@ def _is_rust_test_symbol(props: PropertyDict, qn: str, path: str) -> bool:
         ):
             return True
     return False
+
+
+def _is_rust_test_symbol(
+    props: PropertyDict, qn: str, path: str, rust_test_modules: set[str]
+) -> bool:
+    # Rust unit tests live INSIDE source files (`#[cfg(test)] mod tests`), so
+    # path-based test detection never sees them (issue #1008). Test code is a
+    # function carrying a `#[test]` family attribute (#[test], #[tokio::test],
+    # #[bench]) or any symbol inside a `tests`/`test` MODULE (the #[cfg(test)]
+    # convention), including the plain helpers such modules define. The
+    # module check walks the qn's PREFIXES against real Module qns: a type
+    # or method named `tests`, or a dotted project name, shares the string
+    # shape but has no Module node and must stay reportable.
+    if not path.endswith(cs.EXT_RS):
+        return False
+    if rust_test_modules:
+        prefix = ""
+        for segment in qn.split(cs.SEPARATOR_DOT)[:-1]:
+            prefix = f"{prefix}{cs.SEPARATOR_DOT}{segment}" if prefix else segment
+            if prefix in rust_test_modules:
+                return True
+    return _has_rust_test_attribute(props)
+
+
+def _rust_test_modules_from_nodes(
+    nodes: dict[_NodeId, PropertyDict],
+) -> set[str]:
+    # Module qns whose own name is a test-module spelling, gated to Rust
+    # files (inline `mod tests` blocks carry synthesised inline paths).
+    modules: set[str] = set()
+    for (label, uid), props in nodes.items():
+        if label != _MODULE:
+            continue
+        qn = str(uid)
+        if qn.rsplit(cs.SEPARATOR_DOT, 1)[-1] not in cs.RUST_TEST_MODULE_SEGMENTS:
+            continue
+        path = str(props.get(cs.KEY_PATH, ""))
+        if path.endswith(cs.EXT_RS) or path.startswith(cs.INLINE_MODULE_PATH_PREFIX):
+            modules.add(qn)
+    return modules
+
+
+def _rust_test_fn_spans(
+    nodes: dict[_NodeId, PropertyDict],
+) -> dict[str, list[tuple[int, int]]]:
+    # Spans of `#[test]` family functions per Rust file: a nested fn
+    # registers FLAT under the module qn and a closure as
+    # anonymous_<line>_<col>, so with tests excluded, symbols lexically
+    # inside a suppressed test fn are recognised by span containment.
+    spans: dict[str, list[tuple[int, int]]] = {}
+    for (label, uid), props in nodes.items():
+        if label not in (_FUNCTION, _METHOD):
+            continue
+        path = str(props.get(cs.KEY_PATH, ""))
+        if not path.endswith(cs.EXT_RS) or not _has_rust_test_attribute(props):
+            continue
+        start = props.get(cs.KEY_START_LINE)
+        end = props.get(cs.KEY_END_LINE)
+        if isinstance(start, int) and isinstance(end, int) and start > 0:
+            spans.setdefault(path, []).append((start, end))
+    return spans
+
+
+def _within_rust_test_span(
+    props: PropertyDict, spans: dict[str, list[tuple[int, int]]]
+) -> bool:
+    path_spans = spans.get(str(props.get(cs.KEY_PATH, "")))
+    if not path_spans:
+        return False
+    start = props.get(cs.KEY_START_LINE)
+    end = props.get(cs.KEY_END_LINE)
+    if not isinstance(start, int) or not isinstance(end, int) or start <= 0:
+        return False
+    return any(s <= start and end <= e for s, e in path_spans)
 
 
 def _is_c_cpp_entry_root(
@@ -348,6 +406,8 @@ def dead_code_from_graph(
     props_by_qn: dict[str, PropertyDict] = {}
     method_qns: set[str] = set()
     module_path: dict[str, str] = {}
+    rust_test_modules = _rust_test_modules_from_nodes(nodes)
+    rust_test_spans = _rust_test_fn_spans(nodes) if not config.include_tests else {}
     # Normalized decorators per CLASS qn (collected for every class, not just
     # class candidates), so a method root rule can consult its class's
     # @Injectable/@Controller/@Module marker (NestJS DI roots, issue #973).
@@ -372,8 +432,12 @@ def dead_code_from_graph(
                     str(props.get(cs.KEY_PATH) or ""), config.test_patterns
                 )
                 or _is_rust_test_symbol(
-                    props, str(uid), str(props.get(cs.KEY_PATH) or "")
+                    props,
+                    str(uid),
+                    str(props.get(cs.KEY_PATH) or ""),
+                    rust_test_modules,
                 )
+                or _within_rust_test_span(props, rust_test_spans)
             ):
                 continue
             candidates.add(str(uid))
@@ -523,7 +587,7 @@ def dead_code_from_graph(
             roots.add(qn)
         elif config.include_tests and (
             matches_test_path(path, config.test_patterns)
-            or _is_rust_test_symbol(props, qn, path)
+            or _is_rust_test_symbol(props, qn, path, rust_test_modules)
         ):
             roots.add(qn)
 
@@ -647,7 +711,15 @@ def _node_props(row: ResultRow) -> PropertyDict:
         cs.KEY_DECORATORS: _as_str_list(row.get(cs.KEY_DECORATORS)),
         cs.KEY_IS_EXPORTED: row.get(cs.KEY_IS_EXPORTED) is True,
         cs.KEY_OVERRIDES_EXTERNAL: row.get(cs.KEY_OVERRIDES_EXTERNAL) is True,
+        # Spans feed the Rust nested-test-symbol exclusion (issue #1008);
+        # non-int values coalesce to 0 so the containment checks skip them.
+        cs.KEY_START_LINE: _as_line(row.get(cs.KEY_START_LINE)),
+        cs.KEY_END_LINE: _as_line(row.get(cs.KEY_END_LINE)),
     }
+
+
+def _as_line(value: object) -> int:
+    return value if isinstance(value, int) else 0
 
 
 def _row_qn(row: ResultRow) -> str:

--- a/codebase_rag/dead_code.py
+++ b/codebase_rag/dead_code.py
@@ -86,6 +86,28 @@ def _is_rust_runtime_root(name: str, is_method: bool, path: str) -> bool:
     return is_method and name in cs.RUST_TRAIT_METHOD_NAMES
 
 
+def _is_rust_test_symbol(props: PropertyDict, qn: str, path: str) -> bool:
+    # Rust unit tests live INSIDE source files (`#[cfg(test)] mod tests`), so
+    # path-based test detection never sees them (issue #1008). Test code is a
+    # function carrying a `#[test]` family attribute (#[test], #[tokio::test],
+    # #[bench]) or any symbol inside a `tests` module (the #[cfg(test)]
+    # convention), including the plain helpers such modules define.
+    if not path.endswith(cs.EXT_RS):
+        return False
+    if cs.RUST_TESTS_MODULE_SEGMENT in qn.split(cs.SEPARATOR_DOT):
+        return True
+    decorators = props.get(cs.KEY_DECORATORS)
+    if not isinstance(decorators, list):
+        return False
+    for decorator in decorators:
+        name = str(decorator).strip("#[] ").split(cs.CHAR_PAREN_OPEN)[0]
+        if name in cs.RUST_TEST_ATTRIBUTE_NAMES or name.endswith(
+            cs.RUST_TEST_ATTRIBUTE_SUFFIX
+        ):
+            return True
+    return False
+
+
 def _is_c_cpp_entry_root(
     name: str, is_method: bool, path: str, qn: str, project_prefix: str
 ) -> bool:
@@ -333,11 +355,18 @@ def dead_code_from_graph(
                     _norm_decorator(str(d)) for d in decorators
                 )
         if label in labels and str(uid).startswith(project_prefix):
-            # With tests excluded, a test-file symbol's only callers are
-            # excluded as roots, so reporting it is noise (test helpers and
-            # mocks are infrastructure, not dead production code).
-            if not config.include_tests and matches_test_path(
-                str(props.get(cs.KEY_PATH) or ""), config.test_patterns
+            # With tests excluded, a test symbol's only callers are excluded
+            # as roots, so reporting it is noise (test helpers and mocks are
+            # infrastructure, not dead production code). Rust test code lives
+            # INSIDE source files, so it is matched by attribute/module, not
+            # path (issue #1008).
+            if not config.include_tests and (
+                matches_test_path(
+                    str(props.get(cs.KEY_PATH) or ""), config.test_patterns
+                )
+                or _is_rust_test_symbol(
+                    props, str(uid), str(props.get(cs.KEY_PATH) or "")
+                )
             ):
                 continue
             candidates.add(str(uid))
@@ -485,7 +514,10 @@ def dead_code_from_graph(
             roots.add(qn)
         elif any(qn.endswith(entry) for entry in config.entry_points):
             roots.add(qn)
-        elif config.include_tests and matches_test_path(path, config.test_patterns):
+        elif config.include_tests and (
+            matches_test_path(path, config.test_patterns)
+            or _is_rust_test_symbol(props, qn, path)
+        ):
             roots.add(qn)
 
     adjacency: dict[str, set[str]] = defaultdict(set)

--- a/codebase_rag/dead_code.py
+++ b/codebase_rag/dead_code.py
@@ -94,7 +94,14 @@ def _is_rust_test_symbol(props: PropertyDict, qn: str, path: str) -> bool:
     # convention), including the plain helpers such modules define.
     if not path.endswith(cs.EXT_RS):
         return False
-    if cs.RUST_TESTS_MODULE_SEGMENT in qn.split(cs.SEPARATOR_DOT):
+    # Module segments only: qn[0] is the project prefix and qn[-1] the
+    # symbol's own name; neither is a module, so a project directory or a
+    # method named `tests` must not mark test code (and root away its
+    # whole callee closure).
+    if any(
+        segment in cs.RUST_TEST_MODULE_SEGMENTS
+        for segment in qn.split(cs.SEPARATOR_DOT)[1:-1]
+    ):
         return True
     decorators = props.get(cs.KEY_DECORATORS)
     if not isinstance(decorators, list):

--- a/codebase_rag/dead_code.py
+++ b/codebase_rag/dead_code.py
@@ -164,6 +164,24 @@ def _rust_test_fn_spans(
     return spans
 
 
+def _is_test_symbol(
+    props: PropertyDict,
+    qn: str,
+    path: str,
+    test_patterns: tuple[str, ...],
+    rust_test_modules: set[str],
+    rust_test_spans: dict[str, list[tuple[int, int]]],
+) -> bool:
+    # One definition for BOTH polarities: a symbol excluded as test code
+    # when tests are off must be the same symbol rooted when they are on,
+    # or the two modes silently diverge.
+    return (
+        matches_test_path(path, test_patterns)
+        or _is_rust_test_symbol(props, qn, path, rust_test_modules)
+        or _within_rust_test_span(props, rust_test_spans)
+    )
+
+
 def _within_rust_test_span(
     props: PropertyDict, spans: dict[str, list[tuple[int, int]]]
 ) -> bool:
@@ -438,17 +456,13 @@ def dead_code_from_graph(
             # infrastructure, not dead production code). Rust test code lives
             # INSIDE source files, so it is matched by attribute/module, not
             # path (issue #1008).
-            if not config.include_tests and (
-                matches_test_path(
-                    str(props.get(cs.KEY_PATH) or ""), config.test_patterns
-                )
-                or _is_rust_test_symbol(
-                    props,
-                    str(uid),
-                    str(props.get(cs.KEY_PATH) or ""),
-                    rust_test_modules,
-                )
-                or _within_rust_test_span(props, rust_test_spans)
+            if not config.include_tests and _is_test_symbol(
+                props,
+                str(uid),
+                str(props.get(cs.KEY_PATH) or ""),
+                config.test_patterns,
+                rust_test_modules,
+                rust_test_spans,
             ):
                 continue
             candidates.add(str(uid))
@@ -596,10 +610,13 @@ def dead_code_from_graph(
             roots.add(qn)
         elif any(qn.endswith(entry) for entry in config.entry_points):
             roots.add(qn)
-        elif config.include_tests and (
-            matches_test_path(path, config.test_patterns)
-            or _is_rust_test_symbol(props, qn, path, rust_test_modules)
-            or _within_rust_test_span(props, rust_test_spans)
+        elif config.include_tests and _is_test_symbol(
+            props,
+            qn,
+            path,
+            config.test_patterns,
+            rust_test_modules,
+            rust_test_spans,
         ):
             roots.add(qn)
 

--- a/codebase_rag/dead_code.py
+++ b/codebase_rag/dead_code.py
@@ -170,7 +170,10 @@ def _within_rust_test_span(
     end = props.get(cs.KEY_END_LINE)
     if not isinstance(start, int) or not isinstance(end, int) or start <= 0:
         return False
-    return any(s <= start and end <= e for s, e in path_spans)
+    # Strict on both ends: spans carry no columns, so a production fn
+    # packed onto the test fn's first or last physical line must not be
+    # swallowed; every rustfmt-shaped nested symbol sits strictly inside.
+    return any(s < start and end < e for s, e in path_spans)
 
 
 def _is_c_cpp_entry_root(
@@ -407,7 +410,11 @@ def dead_code_from_graph(
     method_qns: set[str] = set()
     module_path: dict[str, str] = {}
     rust_test_modules = _rust_test_modules_from_nodes(nodes)
-    rust_test_spans = _rust_test_fn_spans(nodes) if not config.include_tests else {}
+    # Both polarities need the spans: excluded test fns take their nested
+    # symbols with them, and INCLUDED ones must root those same symbols (a
+    # fn passed as a value, `filter(is_even)`, has no CALLS edge to revive
+    # it).
+    rust_test_spans = _rust_test_fn_spans(nodes)
     # Normalized decorators per CLASS qn (collected for every class, not just
     # class candidates), so a method root rule can consult its class's
     # @Injectable/@Controller/@Module marker (NestJS DI roots, issue #973).
@@ -588,6 +595,7 @@ def dead_code_from_graph(
         elif config.include_tests and (
             matches_test_path(path, config.test_patterns)
             or _is_rust_test_symbol(props, qn, path, rust_test_modules)
+            or _within_rust_test_span(props, rust_test_spans)
         ):
             roots.add(qn)
 

--- a/codebase_rag/tests/test_rust_test_attribute_roots.py
+++ b/codebase_rag/tests/test_rust_test_attribute_roots.py
@@ -180,11 +180,15 @@ def test_exclude_tests_suppresses_inline_test_symbols() -> None:
                 "test_add",
                 "src/lib.rs",
                 decorators=["#[test]"],
+                start_line=10,
+                end_line=12,
             ),
             _function(
                 "proj.src.lib.tests.mk_input",
                 "mk_input",
                 "src/lib.rs",
+                start_line=20,
+                end_line=22,
             ),
         ],
         include_tests=False,
@@ -240,7 +244,9 @@ def test_project_named_tests_still_reports() -> None:
 def test_singular_test_module_matches_plural() -> None:
     # cs.TEST_PATH_PATTERNS covers both /tests/ and /test/ directories;
     # the inline-module rule mirrors it, so `mod test` behaves exactly
-    # like `mod tests` on both flag polarities.
+    # like `mod tests` on both flag polarities. Distinct spans and NO
+    # call edge: only the module rule itself can suppress mk_input, so
+    # this test genuinely pins the singular spelling.
     nodes = [
         _module("proj.src.lib.test", "src/lib.rs"),
         _function(
@@ -248,12 +254,71 @@ def test_singular_test_module_matches_plural() -> None:
             "t_basic",
             "src/lib.rs",
             decorators=["#[test]"],
+            start_line=10,
+            end_line=12,
         ),
-        _function("proj.src.lib.test.mk_input", "mk_input", "src/lib.rs"),
+        _function(
+            "proj.src.lib.test.mk_input",
+            "mk_input",
+            "src/lib.rs",
+            start_line=20,
+            end_line=22,
+        ),
     ]
-    rels = [_calls("proj.src.lib.test.t_basic", "proj.src.lib.test.mk_input")]
-    assert _collect(nodes, rels) == set()
-    assert _collect(nodes, rels, include_tests=False) == set()
+    assert _collect(nodes) == set()
+    assert _collect(nodes, include_tests=False) == set()
+
+
+def test_symbols_nested_in_test_fns_are_rooted_when_tests_included() -> None:
+    # A fn defined inside a `#[test]` fn and consumed as a value
+    # (`filter(is_even)`) has no CALLS edge; the span rule must root it
+    # on the include side too, or the default report flags it dead.
+    dead = _collect(
+        [
+            _function(
+                "proj.src.lib.t",
+                "t",
+                "src/lib.rs",
+                decorators=["#[test]"],
+                start_line=10,
+                end_line=20,
+            ),
+            _function(
+                "proj.src.lib.is_even",
+                "is_even",
+                "src/lib.rs",
+                start_line=12,
+                end_line=13,
+            ),
+        ]
+    )
+    assert dead == set()
+
+
+def test_symbols_sharing_a_test_fns_line_stay_reportable() -> None:
+    # Line spans have no columns: a production fn packed onto the test
+    # fn's first or last physical line is NOT lexically inside it, so
+    # containment is strict on both ends and such symbols stay in the
+    # report on both polarities.
+    nodes = [
+        _function(
+            "proj.src.lib.t",
+            "t",
+            "src/lib.rs",
+            decorators=["#[test]"],
+            start_line=3,
+            end_line=5,
+        ),
+        _function(
+            "proj.src.lib.produce",
+            "produce",
+            "src/lib.rs",
+            start_line=5,
+            end_line=5,
+        ),
+    ]
+    assert "proj.src.lib.produce" in _collect(nodes)
+    assert "proj.src.lib.produce" in _collect(nodes, include_tests=False)
 
 
 def test_symbols_nested_in_excluded_test_fns_are_excluded() -> None:

--- a/codebase_rag/tests/test_rust_test_attribute_roots.py
+++ b/codebase_rag/tests/test_rust_test_attribute_roots.py
@@ -116,6 +116,8 @@ def test_test_attribute_roots_function_and_its_callees() -> None:
 
 
 def test_scoped_test_attributes_root() -> None:
+    # Attribute paths are token streams: `#[tokio :: test]` is the same
+    # attribute as `#[tokio::test]`, so matching normalises whitespace.
     dead = _collect(
         [
             _function(
@@ -123,6 +125,12 @@ def test_scoped_test_attributes_root() -> None:
                 "test_async",
                 "src/lib.rs",
                 decorators=['#[tokio::test(flavor = "multi_thread")]'],
+            ),
+            _function(
+                "proj.src.lib.test_spaced",
+                "test_spaced",
+                "src/lib.rs",
+                decorators=["#[tokio :: test]"],
             ),
             _function(
                 "proj.src.lib.bench_add",

--- a/codebase_rag/tests/test_rust_test_attribute_roots.py
+++ b/codebase_rag/tests/test_rust_test_attribute_roots.py
@@ -1,0 +1,168 @@
+# Rust unit tests live INSIDE source files (`#[cfg(test)] mod tests` with
+# `#[test]` functions), so path-based test detection never sees them: the
+# tests and the production helpers only they exercise were reported dead
+# despite --include-tests (ripgrep: 459 of 1811 candidates). A `#[test]`
+# family attribute must root its function when tests are included, and mark
+# it as test code to exclude when they are not. Issue #1008.
+from __future__ import annotations
+
+from codebase_rag import constants as cs
+from codebase_rag import cypher_queries as cq
+from codebase_rag.dead_code import collect_dead_code, default_dead_code_config
+from codebase_rag.types_defs import ResultRow
+
+_FUNCTION = cs.NodeLabel.FUNCTION.value
+
+
+class FakeIngestor:
+    def __init__(self, nodes: list[ResultRow], rels: list[ResultRow]) -> None:
+        self._nodes = nodes
+        self._rels = rels
+
+    def fetch_all(
+        self, query: str, params: dict[str, str] | None = None
+    ) -> list[ResultRow]:
+        if query == cq.CYPHER_DEAD_CODE_NODES:
+            return self._nodes
+        return self._rels
+
+
+def _function(
+    qn: str, name: str, path: str, decorators: list[str] | None = None
+) -> ResultRow:
+    return {
+        "label": _FUNCTION,
+        "qualified_name": qn,
+        "name": name,
+        "path": path,
+        "start_line": 1,
+        "end_line": 2,
+        "decorators": decorators or [],
+        "is_exported": False,
+        "overrides_external": False,
+    }
+
+
+def _calls(from_qn: str, to_qn: str) -> ResultRow:
+    return {
+        "from_label": _FUNCTION,
+        "from_qn": from_qn,
+        "rel_type": cs.RelationshipType.CALLS.value,
+        "to_label": _FUNCTION,
+        "to_qn": to_qn,
+    }
+
+
+def _collect(
+    nodes: list[ResultRow],
+    rels: list[ResultRow] | None = None,
+    include_tests: bool = True,
+) -> set[str]:
+    rows = collect_dead_code(
+        FakeIngestor(nodes, rels or []),
+        "proj",
+        default_dead_code_config(include_tests=include_tests, include_classes=False),
+    )
+    return {row["qualified_name"] for row in rows}
+
+
+def test_test_attribute_roots_function_and_its_callees() -> None:
+    dead = _collect(
+        [
+            _function(
+                "proj.src.lib.tests.test_add",
+                "test_add",
+                "src/lib.rs",
+                decorators=["#[test]"],
+            ),
+            _function(
+                "proj.src.lib.helper_only_used_by_tests",
+                "helper_only_used_by_tests",
+                "src/lib.rs",
+            ),
+        ],
+        rels=[
+            _calls(
+                "proj.src.lib.tests.test_add",
+                "proj.src.lib.helper_only_used_by_tests",
+            )
+        ],
+    )
+    assert "proj.src.lib.tests.test_add" not in dead
+    assert "proj.src.lib.helper_only_used_by_tests" not in dead
+
+
+def test_scoped_test_attributes_root() -> None:
+    dead = _collect(
+        [
+            _function(
+                "proj.src.lib.tests.test_async",
+                "test_async",
+                "src/lib.rs",
+                decorators=["#[tokio::test]"],
+            ),
+            _function(
+                "proj.src.lib.tests.bench_add",
+                "bench_add",
+                "src/lib.rs",
+                decorators=["#[bench]"],
+            ),
+        ]
+    )
+    assert dead == set()
+
+
+def test_plain_function_still_reports() -> None:
+    dead = _collect([_function("proj.src.lib.orphan", "orphan", "src/lib.rs")])
+    assert "proj.src.lib.orphan" in dead
+
+
+def test_non_test_attribute_does_not_root() -> None:
+    dead = _collect(
+        [
+            _function(
+                "proj.src.lib.orphan",
+                "orphan",
+                "src/lib.rs",
+                decorators=["#[inline]"],
+            )
+        ]
+    )
+    assert "proj.src.lib.orphan" in dead
+
+
+def test_exclude_tests_suppresses_inline_test_symbols() -> None:
+    # With tests excluded, an inline #[test] function (and anything in a
+    # `mod tests`) is infrastructure, not dead production code: not a root,
+    # not a candidate.
+    dead = _collect(
+        [
+            _function(
+                "proj.src.lib.tests.test_add",
+                "test_add",
+                "src/lib.rs",
+                decorators=["#[test]"],
+            ),
+            _function(
+                "proj.src.lib.tests.mk_input",
+                "mk_input",
+                "src/lib.rs",
+            ),
+        ],
+        include_tests=False,
+    )
+    assert dead == set()
+
+
+def test_test_attribute_on_non_rust_path_does_not_root() -> None:
+    dead = _collect(
+        [
+            _function(
+                "proj.app.orphan",
+                "orphan",
+                "app.py",
+                decorators=["#[test]"],
+            )
+        ]
+    )
+    assert "proj.app.orphan" in dead

--- a/codebase_rag/tests/test_rust_test_attribute_roots.py
+++ b/codebase_rag/tests/test_rust_test_attribute_roots.py
@@ -12,6 +12,7 @@ from codebase_rag.dead_code import collect_dead_code, default_dead_code_config
 from codebase_rag.types_defs import ResultRow
 
 _FUNCTION = cs.NodeLabel.FUNCTION.value
+_MODULE = cs.NodeLabel.MODULE.value
 
 
 class FakeIngestor:
@@ -28,16 +29,35 @@ class FakeIngestor:
 
 
 def _function(
-    qn: str, name: str, path: str, decorators: list[str] | None = None
+    qn: str,
+    name: str,
+    path: str,
+    decorators: list[str] | None = None,
+    start_line: int = 1,
+    end_line: int = 2,
 ) -> ResultRow:
     return {
         "label": _FUNCTION,
         "qualified_name": qn,
         "name": name,
         "path": path,
-        "start_line": 1,
-        "end_line": 2,
+        "start_line": start_line,
+        "end_line": end_line,
         "decorators": decorators or [],
+        "is_exported": False,
+        "overrides_external": False,
+    }
+
+
+def _module(qn: str, path: str) -> ResultRow:
+    return {
+        "label": _MODULE,
+        "qualified_name": qn,
+        "name": qn.rsplit(".", 1)[-1],
+        "path": path,
+        "start_line": 1,
+        "end_line": 1,
+        "decorators": [],
         "is_exported": False,
         "overrides_external": False,
     }
@@ -117,9 +137,13 @@ def test_scoped_test_attributes_root() -> None:
 
 def test_tests_module_symbols_root_without_attributes() -> None:
     # The module rule on its own: a plain helper inside a `tests` module
-    # is test code even with no attribute anywhere.
+    # is test code even with no attribute anywhere. The Module node is
+    # what makes `tests` a MODULE segment rather than a type or leaf.
     dead = _collect(
-        [_function("proj.src.lib.tests.mk_input", "mk_input", "src/lib.rs")]
+        [
+            _module("proj.src.lib.tests", "src/lib.rs"),
+            _function("proj.src.lib.tests.mk_input", "mk_input", "src/lib.rs"),
+        ]
     )
     assert dead == set()
 
@@ -150,6 +174,7 @@ def test_exclude_tests_suppresses_inline_test_symbols() -> None:
     # candidates.
     dead = _collect(
         [
+            _module("proj.src.lib.tests", "src/lib.rs"),
             _function(
                 "proj.src.lib.test_add",
                 "test_add",
@@ -217,6 +242,7 @@ def test_singular_test_module_matches_plural() -> None:
     # the inline-module rule mirrors it, so `mod test` behaves exactly
     # like `mod tests` on both flag polarities.
     nodes = [
+        _module("proj.src.lib.test", "src/lib.rs"),
         _function(
             "proj.src.lib.test.t_basic",
             "t_basic",
@@ -228,3 +254,71 @@ def test_singular_test_module_matches_plural() -> None:
     rels = [_calls("proj.src.lib.test.t_basic", "proj.src.lib.test.mk_input")]
     assert _collect(nodes, rels) == set()
     assert _collect(nodes, rels, include_tests=False) == set()
+
+
+def test_symbols_nested_in_excluded_test_fns_are_excluded() -> None:
+    # Nested fns register FLAT under the module qn and closures as
+    # anonymous_<line>_<col>; neither carries the attribute or a tests
+    # segment, so the exclusion must also cover symbols whose span lies
+    # inside an excluded test fn's span in the same file.
+    dead = _collect(
+        [
+            _function(
+                "proj.src.lib.test_ctx",
+                "test_ctx",
+                "src/lib.rs",
+                decorators=["#[test]"],
+                start_line=10,
+                end_line=30,
+            ),
+            _function(
+                "proj.src.lib.nested_helper",
+                "nested_helper",
+                "src/lib.rs",
+                start_line=12,
+                end_line=14,
+            ),
+            _function(
+                "proj.src.lib.anonymous_16_8",
+                "anonymous_16_8",
+                "src/lib.rs",
+                start_line=16,
+                end_line=18,
+            ),
+        ],
+        include_tests=False,
+    )
+    assert dead == set()
+
+
+def test_type_named_tests_does_not_mark_test_code() -> None:
+    # A lowercase TYPE named `tests` shares the qn shape of a module but
+    # has no Module node: its methods stay reportable.
+    dead = _collect(
+        [
+            _module("proj.src.lib", "src/lib.rs"),
+            _function("proj.src.lib.tests.dead_method", "dead_method", "src/lib.rs"),
+            _function("proj.src.lib.helper", "helper", "src/lib.rs"),
+        ],
+        rels=[_calls("proj.src.lib.tests.dead_method", "proj.src.lib.helper")],
+    )
+    assert "proj.src.lib.tests.dead_method" in dead
+    assert "proj.src.lib.helper" in dead
+
+
+def test_dotted_project_prefix_does_not_mask_reporting() -> None:
+    # A project name may itself contain dots ending in `tests`; the
+    # module match keys on real Module qns, so the prefix segments never
+    # silence reporting.
+    rows = collect_dead_code(
+        FakeIngestor(
+            [
+                _module("my.tests.src.lib", "src/lib.rs"),
+                _function("my.tests.src.lib.orphan", "orphan", "src/lib.rs"),
+            ],
+            [],
+        ),
+        "my.tests",
+        default_dead_code_config(include_tests=True, include_classes=False),
+    )
+    assert {row["qualified_name"] for row in rows} == {"my.tests.src.lib.orphan"}

--- a/codebase_rag/tests/test_rust_test_attribute_roots.py
+++ b/codebase_rag/tests/test_rust_test_attribute_roots.py
@@ -67,10 +67,13 @@ def _collect(
 
 
 def test_test_attribute_roots_function_and_its_callees() -> None:
+    # The qns carry NO `tests` module segment, so the ATTRIBUTE alone must
+    # decide (a `tests` segment in the fixtures would satisfy the module
+    # rule first and leave the decorator branch untested).
     dead = _collect(
         [
             _function(
-                "proj.src.lib.tests.test_add",
+                "proj.src.lib.test_add",
                 "test_add",
                 "src/lib.rs",
                 decorators=["#[test]"],
@@ -83,12 +86,12 @@ def test_test_attribute_roots_function_and_its_callees() -> None:
         ],
         rels=[
             _calls(
-                "proj.src.lib.tests.test_add",
+                "proj.src.lib.test_add",
                 "proj.src.lib.helper_only_used_by_tests",
             )
         ],
     )
-    assert "proj.src.lib.tests.test_add" not in dead
+    assert "proj.src.lib.test_add" not in dead
     assert "proj.src.lib.helper_only_used_by_tests" not in dead
 
 
@@ -96,18 +99,27 @@ def test_scoped_test_attributes_root() -> None:
     dead = _collect(
         [
             _function(
-                "proj.src.lib.tests.test_async",
+                "proj.src.lib.test_async",
                 "test_async",
                 "src/lib.rs",
-                decorators=["#[tokio::test]"],
+                decorators=['#[tokio::test(flavor = "multi_thread")]'],
             ),
             _function(
-                "proj.src.lib.tests.bench_add",
+                "proj.src.lib.bench_add",
                 "bench_add",
                 "src/lib.rs",
                 decorators=["#[bench]"],
             ),
         ]
+    )
+    assert dead == set()
+
+
+def test_tests_module_symbols_root_without_attributes() -> None:
+    # The module rule on its own: a plain helper inside a `tests` module
+    # is test code even with no attribute anywhere.
+    dead = _collect(
+        [_function("proj.src.lib.tests.mk_input", "mk_input", "src/lib.rs")]
     )
     assert dead == set()
 
@@ -132,13 +144,14 @@ def test_non_test_attribute_does_not_root() -> None:
 
 
 def test_exclude_tests_suppresses_inline_test_symbols() -> None:
-    # With tests excluded, an inline #[test] function (and anything in a
-    # `mod tests`) is infrastructure, not dead production code: not a root,
-    # not a candidate.
+    # With tests excluded, an inline #[test] function (decorator-decided,
+    # no `tests` segment) and a helper in a `mod tests` (module-decided)
+    # are infrastructure, not dead production code: not roots, not
+    # candidates.
     dead = _collect(
         [
             _function(
-                "proj.src.lib.tests.test_add",
+                "proj.src.lib.test_add",
                 "test_add",
                 "src/lib.rs",
                 decorators=["#[test]"],
@@ -166,3 +179,52 @@ def test_test_attribute_on_non_rust_path_does_not_root() -> None:
         ]
     )
     assert "proj.app.orphan" in dead
+
+
+def test_symbol_named_tests_is_not_test_code() -> None:
+    # `tests` must match MODULE segments only: a production method named
+    # `tests` is ordinary Rust, and rooting it would hide its whole
+    # callee closure from the report.
+    dead = _collect(
+        [
+            _function("proj.src.lib.Suite.tests", "tests", "src/lib.rs"),
+            _function("proj.src.lib.Suite.normalise", "normalise", "src/lib.rs"),
+            _function("proj.src.lib.Suite.tally", "tally", "src/lib.rs"),
+        ],
+        rels=[
+            _calls("proj.src.lib.Suite.tests", "proj.src.lib.Suite.normalise"),
+            _calls("proj.src.lib.Suite.tests", "proj.src.lib.Suite.tally"),
+        ],
+    )
+    assert "proj.src.lib.Suite.tests" in dead
+    assert "proj.src.lib.Suite.normalise" in dead
+    assert "proj.src.lib.Suite.tally" in dead
+
+
+def test_project_named_tests_still_reports() -> None:
+    # The project prefix is not a module segment: a project directory
+    # named `tests` must not silence Rust dead-code reporting wholesale.
+    rows = collect_dead_code(
+        FakeIngestor([_function("tests.src.lib.orphan", "orphan", "src/lib.rs")], []),
+        "tests",
+        default_dead_code_config(include_tests=True, include_classes=False),
+    )
+    assert {row["qualified_name"] for row in rows} == {"tests.src.lib.orphan"}
+
+
+def test_singular_test_module_matches_plural() -> None:
+    # cs.TEST_PATH_PATTERNS covers both /tests/ and /test/ directories;
+    # the inline-module rule mirrors it, so `mod test` behaves exactly
+    # like `mod tests` on both flag polarities.
+    nodes = [
+        _function(
+            "proj.src.lib.test.t_basic",
+            "t_basic",
+            "src/lib.rs",
+            decorators=["#[test]"],
+        ),
+        _function("proj.src.lib.test.mk_input", "mk_input", "src/lib.rs"),
+    ]
+    rels = [_calls("proj.src.lib.test.t_basic", "proj.src.lib.test.mk_input")]
+    assert _collect(nodes, rels) == set()
+    assert _collect(nodes, rels, include_tests=False) == set()

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.526"
+version = "0.0.528"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #1008.

## What

Rust unit tests live inside source files (`#[cfg(test)] mod tests` with `#[test]` functions), so path-based test detection never sees them: `matches_test_path("crates/globset/src/glob.rs")` is false, and `_norm_decorator("#[test]")` mangles the attribute to `#[test` (with `test` absent from the root-decorator set anyway). The tests and every production helper only they exercise were reported dead despite `--include-tests` defaulting to on: 459 of ripgrep's 1811 candidates.

The fix adds `_is_rust_test_symbol`, gated to `.rs` paths: a function carrying a `#[test]` family attribute (`#[test]`, `#[bench]`, or a scoped runner variant ending in `::test` such as `#[tokio::test]`), or any symbol inside a `tests` or `test` MODULE (the `#[cfg(test)] mod tests` convention in both spellings). The module check walks the qn's prefixes against real Module nodes rather than raw string segments, so a type or method named `tests`, a project directory named `tests`, and a dotted project name all stay ordinary reportable code instead of silently rooting their callee closures. Symbols lexically nested inside a test function (nested fns register flat under the module qn, closures as `anonymous_<line>_<col>`) are recognised by span containment and follow it on BOTH polarities: excluded with it when tests are off, rooted with it when they are on (a fn passed by value to `filter()` has no CALLS edge to revive it). Containment is strict on both ends because spans carry no columns, so a production fn packed onto a test fn's first or last physical line stays reportable. The module-name rule is deliberately wider than the path patterns (those match directory segments only, never a `src/test.rs` file or an inline mod): the name is a proxy for the `#[cfg(test)]` gate the graph does not yet record. A 972-crate corpus scan during review measured 4155 cfg-gated `mod test(s)` declarations against 41 ungated ones, of which exactly two ship as production API (aws-lc-rs `pub mod test`, alacritty's terminal test helpers), both test-support by nature; that residual silencing is accepted and documented until #1010 replaces the name proxy with cfg awareness. Wired into both sides of the existing test handling:

- with `--include-tests` (default), matching symbols are liveness roots, exactly as test-path files are today;
- with `--no-include-tests`, they are excluded from the candidate set, exactly as test-path symbols are (test infrastructure, not dead production code).

## Effect on ripgrep

Client side only (no re-index needed). On a fresh index of ripgrep at master, the pre-fix collector reports 1811 candidates (matching the issue's opening scan exactly, re-measured on the same graph) and the fixed collector reports 1157: the rooted `#[test]` functions revive their entire callee closures across every crate. With `--no-include-tests` the count is 1257, the span containment having removed the seventeen closures nested inside `#[test]`/`#[bench]` functions that a first review round showed leaking into the report. The residue includes ten `crates.searcher.src.testutil.*` methods gated by `#[cfg(test)]` on a cross-file `mod testutil;` declaration; that subclass is filed separately as #1010.

## Tests

TDD RED first: `test_rust_test_attribute_roots.py` holds fifteen repros (attribute roots plus callee revival with qns carrying NO `tests` segment so the decorator branch is load-bearing on its own, scoped `#[tokio::test(flavor = "multi_thread")]`/`#[bench]`, the module rule alone rooting an attribute-less helper, plain and non-test-attribute functions still reporting, `--no-include-tests` excluding both the decorator-decided and module-decided shapes, the non-Rust path guard, a production method named `tests` and a project directory named `tests` both staying reportable, the singular `mod test` matching the plural on both polarities with distinct real-shaped spans and no rescuing edge, the module rule keyed on real Module nodes with a lowercase type named `tests` staying reportable alongside its closure, a dotted project prefix not masking reporting, span-nested symbols excluded with their suppressed test fn AND rooted with an included one, and same-line-packed production fns staying reportable on both polarities), every behavioural case observed failing before its fix. Four adversarial review rounds drove the hardening: they confirmed the attribute matcher against real parses (raw `#[...]` decorator text, argument stripping, the `#[cfg(test)]` and `#[testing::...]` traps rejected), verified closure-revival transitivity, both polarities, class handling, and hostile span shapes on real parses, ran a fifteen-mutation vacuity matrix over the tests, measured the rule's width across a 972-crate corpus, and held the ripgrep candidate sets byte-stable at 1157/1257 across every refinement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Rust dead-code analysis for test and benchmark functions, scoped test attributes, and symbols inside `test`/`tests` modules.
  * Test-related code is now correctly included or excluded according to analysis settings.
  * Reduced false positives and negatives involving symbol names, project paths, and source-code boundaries.

* **Tests**
  * Added comprehensive coverage for Rust test detection and dead-code reporting scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->