### PR TITLE
fix: bind Rust module-qualified calls inside the named module via its re-exports

### DIFF
--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -850,6 +850,26 @@ class CallResolver:
                 self._simple_resolution_cache[cache_key] = result
             return result
 
+        # A Rust `module::item` call names its function through the module
+        # path, so it binds inside that module: a direct item, or the
+        # module's own `use` re-export (ripgrep's flags::parse() through
+        # flags/mod.rs). Runs after the import probes, so an aliased or
+        # imported first segment keeps its precise resolution, and DECIDES
+        # whenever the path names a real first-party module: an item the
+        # module does not hold is a drop, never a bare-name trie guess at
+        # an unrelated same-named function (issue #1009).
+        if (
+            language == cs.SupportedLanguage.RUST
+            and cs.SEPARATOR_DOUBLE_COLON in call_name
+        ):
+            result, decided = self._try_resolve_rust_module_qualified(
+                call_name, module_qn
+            )
+            if decided:
+                if use_cache:
+                    self._simple_resolution_cache[cache_key] = result
+                return result
+
         if class_context and (
             result := self._resolve_self_sibling_method(call_name, class_context)
         ):
@@ -1329,6 +1349,51 @@ class CallResolver:
         if target is None:
             return None
         return (self._follow_rust_scope_target(target),)
+
+    def _try_resolve_rust_module_qualified(
+        self, call_name: str, module_qn: str
+    ) -> tuple[tuple[str, str] | None, bool]:
+        """Bind `module::item` inside the named module, or drop.
+
+        Returns (result, decided). Undecided (False) means the path names
+        no first-party module here and the ordinary fallbacks apply: a
+        registered type's associated call, or an external path such as
+        std::mem::replace. Decided with None means the module is real but
+        holds no such item, so the edge is dropped rather than rebound by
+        bare name.
+        """
+        parts = call_name.split(cs.SEPARATOR_DOUBLE_COLON)
+        object_path, item = parts[:-1], parts[-1]
+        if not item or not all(object_path):
+            return None, False
+        # A registered type as the first segment is an associated-function
+        # call, owned by the class-resolution paths.
+        if self._resolve_class_name(object_path[0], module_qn):
+            return None, False
+        modules = self.type_inference.module_qn_to_file_path
+        import_mapping = self.import_processor.import_mapping
+        # At most one of these legally binds the first segment in the
+        # caller's scope (a use alias colliding with a mod declaration is
+        # E0255, two mod declarations E0428): a module-mapped import, the
+        # caller file's own child module (inline mods key as qn children
+        # everywhere; file submodules of non-entry files too), then the
+        # qn-sibling spelling entry-file submodules get (src/flags.rs
+        # beside src/main.rs keys src.flags).
+        bases = []
+        if mapped := import_mapping.get(module_qn, {}).get(object_path[0]):
+            bases.append(cs.SEPARATOR_DOT.join([mapped, *object_path[1:]]))
+        parent = module_qn.rpartition(cs.SEPARATOR_DOT)[0]
+        for anchor in (module_qn, parent):
+            if anchor:
+                bases.append(cs.SEPARATOR_DOT.join([anchor, *object_path]))
+        for base in bases:
+            if base not in modules and base not in import_mapping:
+                continue
+            return (
+                self._follow_rust_scope_target(f"{base}{cs.SEPARATOR_DOT}{item}"),
+                True,
+            )
+        return None, False
 
     def _follow_rust_scope_target(self, target: str) -> tuple[str, str] | None:
         # An entry-file `pub use` re-export maps the name to the

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -863,7 +863,7 @@ class CallResolver:
             and cs.SEPARATOR_DOUBLE_COLON in call_name
         ):
             result, decided = self._try_resolve_rust_module_qualified(
-                call_name, module_qn
+                call_name, module_qn, caller_qn
             )
             if decided:
                 if use_cache:
@@ -1351,7 +1351,7 @@ class CallResolver:
         return (self._follow_rust_scope_target(target),)
 
     def _try_resolve_rust_module_qualified(
-        self, call_name: str, module_qn: str
+        self, call_name: str, module_qn: str, caller_qn: str | None
     ) -> tuple[tuple[str, str] | None, bool]:
         """Bind `module::item` inside the named module, or drop.
 
@@ -1361,58 +1361,186 @@ class CallResolver:
         std::mem::replace. Decided with None means the module is real but
         holds no such item, so the edge is dropped rather than rebound by
         bare name.
+
+        The first segment binds where Rust binds it: the caller's inner
+        scopes first (an inline mod's own child module or use shadows the
+        file's), then the file module's use (at most one binding per
+        scope is legal, E0255/E0428), then the file's own submodule tree
+        via the same relative-path machinery its use declarations resolve
+        through (entry files attach submodules beside themselves via the
+        declaring scan; other files nest them). A use binding the segment
+        to a path outside the indexed project stops the probe undecided:
+        the name is spoken for, so the module tree must not claim it.
         """
         parts = call_name.split(cs.SEPARATOR_DOUBLE_COLON)
         object_path, item = parts[:-1], parts[-1]
         if not item or not all(object_path):
             return None, False
+        head = object_path[0]
+        if head in (cs.RUST_CRATE_KEYWORD, cs.KEYWORD_SELF, cs.KEYWORD_SUPER):
+            return self._resolve_rust_prefixed_path(
+                object_path, item, module_qn, caller_qn
+            )
         # A registered type as the first segment is an associated-function
         # call, owned by the class-resolution paths.
-        if self._resolve_class_name(object_path[0], module_qn):
+        if self._resolve_class_name(head, module_qn):
             return None, False
-        modules = self.type_inference.module_qn_to_file_path
         import_mapping = self.import_processor.import_mapping
-        # At most one of these legally binds the first segment in the
-        # caller's scope (a use alias colliding with a mod declaration is
-        # E0255, two mod declarations E0428): a module-mapped import, the
-        # caller file's own child module (inline mods key as qn children
-        # everywhere; file submodules of non-entry files too), then the
-        # qn-sibling spelling entry-file submodules get (src/flags.rs
-        # beside src/main.rs keys src.flags).
-        bases = []
-        if mapped := import_mapping.get(module_qn, {}).get(object_path[0]):
-            bases.append(cs.SEPARATOR_DOT.join([mapped, *object_path[1:]]))
-        parent = module_qn.rpartition(cs.SEPARATOR_DOT)[0]
-        for anchor in (module_qn, parent):
-            if anchor:
-                bases.append(cs.SEPARATOR_DOT.join([anchor, *object_path]))
-        for base in bases:
-            if base not in modules and base not in import_mapping:
-                continue
-            return (
-                self._follow_rust_scope_target(f"{base}{cs.SEPARATOR_DOT}{item}"),
-                True,
+        for scope in self._rust_enclosing_scopes(module_qn, caller_qn):
+            base = cs.SEPARATOR_DOT.join([scope, *object_path])
+            target = f"{base}{cs.SEPARATOR_DOT}{item}"
+            if (hit := self.function_registry.get(target)) is not None:
+                return (hit, target), True
+            if mapped := import_mapping.get(scope, {}).get(head):
+                return self._decide_rust_module_item(
+                    mapped, object_path[1:], item, scope
+                )
+        if mapped := import_mapping.get(module_qn, {}).get(head):
+            return self._decide_rust_module_item(
+                mapped, object_path[1:], item, module_qn
             )
+        base = self.import_processor._rust_resolve_relative(
+            module_qn, list(object_path), module_qn
+        )
+        return self._decide_rust_base(base, item)
+
+    def _resolve_rust_prefixed_path(
+        self,
+        object_path: list[str],
+        item: str,
+        module_qn: str,
+        caller_qn: str | None,
+    ) -> tuple[tuple[str, str] | None, bool]:
+        # crate:: is chain-independent; self::/super:: resolve against the
+        # caller's innermost enclosing MOD chain, which a caller nested
+        # below the file module (an inline mod or an impl block,
+        # indistinguishable in qn space) does not expose, so those stay
+        # with the ordinary fallbacks.
+        if object_path[0] != cs.RUST_CRATE_KEYWORD and self._rust_enclosing_scopes(
+            module_qn, caller_qn
+        ):
+            return None, False
+        base = self.import_processor._rewrite_rust_local_use_path(
+            cs.SEPARATOR_DOUBLE_COLON.join(object_path), module_qn
+        )
+        if cs.SEPARATOR_DOUBLE_COLON in base:
+            return None, False
+        return self._decide_rust_base(base, item)
+
+    def _rust_enclosing_scopes(
+        self, module_qn: str, caller_qn: str | None
+    ) -> list[str]:
+        # The caller's qn scopes strictly between it and the file module,
+        # innermost first (inline mod chains; impl targets appear too,
+        # harmlessly, since mod-level use storage keys mirror them).
+        if not caller_qn or not caller_qn.startswith(f"{module_qn}{cs.SEPARATOR_DOT}"):
+            return []
+        scopes = []
+        scope = caller_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
+        while len(scope) > len(module_qn):
+            scopes.append(scope)
+            scope = scope.rsplit(cs.SEPARATOR_DOT, 1)[0]
+        return scopes
+
+    def _decide_rust_module_item(
+        self, mapped: str, rest: list[str], item: str, owner: str
+    ) -> tuple[tuple[str, str] | None, bool]:
+        resolved = self._rust_local_qn(mapped, owner)
+        if resolved is None:
+            # The use binds the head outside the indexed project (std, or
+            # a workspace crate by name, unresolved today): the head is
+            # spoken for, but no first-party module backs it here.
+            return None, False
+        return self._decide_rust_base(cs.SEPARATOR_DOT.join([resolved, *rest]), item)
+
+    def _decide_rust_base(
+        self, base: str, item: str
+    ) -> tuple[tuple[str, str] | None, bool]:
+        target = f"{base}{cs.SEPARATOR_DOT}{item}"
+        result, unknown = self._follow_rust_scope_item(target, {target})
+        if result is not None:
+            return result, True
+        if unknown:
+            # A glob re-export whose base we cannot index may supply the
+            # item; never a decided drop.
+            return None, False
+        if (
+            base in self.type_inference.module_qn_to_file_path
+            or base in self.import_processor.import_mapping
+        ):
+            return None, True
         return None, False
 
-    def _follow_rust_scope_target(self, target: str) -> tuple[str, str] | None:
-        # An entry-file `pub use` re-export maps the name to the
-        # re-exporting module's qn, not the defining one; hop through
-        # that module's own import map before concluding the target
-        # is outside the graph (None: a deliberate drop, never a
-        # fall-through to name-trie guessing).
-        import_mapping = self.import_processor.import_mapping
-        seen = {target}
-        while (target_type := self.function_registry.get(target)) is None:
-            owner, _, item = target.rpartition(cs.SEPARATOR_DOT)
-            hop = import_mapping.get(owner, {}).get(item)
-            if hop is None or hop in seen:
-                break
-            seen.add(hop)
-            target = hop
-        if target_type is not None:
-            return target_type, target
+    def _rust_local_qn(self, value: str, owner: str) -> str | None:
+        """A use-mapping value as a project qn, or None when external.
+
+        crate::/super::/self:: values were rewritten to dotted qns at
+        parse time, so a value still holding :: (or a single bare name)
+        is a Rust 2018 uniform path: it binds locally when its head
+        names a module in the owning scope (`use pool::connect;` beside
+        `mod pool;`), else it names an external crate.
+        """
+        if cs.SEPARATOR_DOUBLE_COLON not in value and cs.SEPARATOR_DOT in value:
+            return value
+        segments = value.split(cs.SEPARATOR_DOUBLE_COLON)
+        head_qn = self.import_processor._rust_resolve_relative(
+            owner, segments[:1], owner
+        )
+        if (
+            head_qn in self.type_inference.module_qn_to_file_path
+            or head_qn in self.import_processor.import_mapping
+        ):
+            return self.import_processor._rust_resolve_relative(owner, segments, owner)
         return None
+
+    def _follow_rust_scope_target(self, target: str) -> tuple[str, str] | None:
+        return self._follow_rust_scope_item(target, {target})[0]
+
+    def _follow_rust_scope_item(
+        self, target: str, seen: set[str]
+    ) -> tuple[tuple[str, str] | None, bool]:
+        """Chase a candidate qn through re-export hops to a registered fn.
+
+        A module's `pub use` maps the name to the re-exporting module's
+        qn, not the defining one; hop through that module's own import
+        map before concluding the target is outside the graph. Named
+        hops win; failing those, each glob re-export (`pub use m::*;`)
+        is expanded when its base is indexable. The second element is
+        True when an unindexable glob base was met: the item may live
+        behind it, so the caller must not turn the miss into a decided
+        drop.
+        """
+        while True:
+            if (target_type := self.function_registry.get(target)) is not None:
+                return (target_type, target), False
+            owner, _, item = target.rpartition(cs.SEPARATOR_DOT)
+            owner_map = self.import_processor.import_mapping.get(owner)
+            if not owner_map:
+                return None, False
+            if (hop := owner_map.get(item)) is not None:
+                resolved = self._rust_local_qn(hop, owner)
+                if resolved is None or resolved in seen:
+                    return None, False
+                seen.add(resolved)
+                target = resolved
+                continue
+            unknown = False
+            for key, value in owner_map.items():
+                if not key.startswith(cs.RS_WILDCARD_PREFIX):
+                    continue
+                resolved = self._rust_local_qn(value, owner)
+                if resolved is None:
+                    unknown = True
+                    continue
+                candidate = f"{resolved}{cs.SEPARATOR_DOT}{item}"
+                if candidate in seen:
+                    continue
+                seen.add(candidate)
+                result, sub_unknown = self._follow_rust_scope_item(candidate, seen)
+                if result is not None:
+                    return result, False
+                unknown = unknown or sub_unknown
+            return None, unknown
 
     def _rust_block_import_at(
         self, module_qn: str, name: str, call_point: int | None

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -1391,6 +1391,11 @@ class CallResolver:
             target = f"{base}{cs.SEPARATOR_DOT}{item}"
             if (hit := self.function_registry.get(target)) is not None:
                 return (hit, target), True
+            if base in import_mapping:
+                # The scope's own child module holds the item only via
+                # re-exports; it still shadows every outer same-named
+                # module, so the decision is made HERE.
+                return self._decide_rust_base(base, item)
             if mapped := import_mapping.get(scope, {}).get(head):
                 return self._decide_rust_module_item(
                     mapped, object_path[1:], item, scope
@@ -1524,23 +1529,32 @@ class CallResolver:
                 seen.add(resolved)
                 target = resolved
                 continue
-            unknown = False
-            for key, value in owner_map.items():
-                if not key.startswith(cs.RS_WILDCARD_PREFIX):
-                    continue
-                resolved = self._rust_local_qn(value, owner)
-                if resolved is None:
-                    unknown = True
-                    continue
-                candidate = f"{resolved}{cs.SEPARATOR_DOT}{item}"
-                if candidate in seen:
-                    continue
-                seen.add(candidate)
-                result, sub_unknown = self._follow_rust_scope_item(candidate, seen)
-                if result is not None:
-                    return result, False
-                unknown = unknown or sub_unknown
-            return None, unknown
+            return self._expand_rust_glob_hops(owner_map, owner, item, seen)
+
+    def _expand_rust_glob_hops(
+        self,
+        owner_map: dict[str, str],
+        owner: str,
+        item: str,
+        seen: set[str],
+    ) -> tuple[tuple[str, str] | None, bool]:
+        unknown = False
+        for key, value in owner_map.items():
+            if not key.startswith(cs.RS_WILDCARD_PREFIX):
+                continue
+            resolved = self._rust_local_qn(value, owner)
+            if resolved is None:
+                unknown = True
+                continue
+            candidate = f"{resolved}{cs.SEPARATOR_DOT}{item}"
+            if candidate in seen:
+                continue
+            seen.add(candidate)
+            result, sub_unknown = self._follow_rust_scope_item(candidate, seen)
+            if result is not None:
+                return result, False
+            unknown = unknown or sub_unknown
+        return None, unknown
 
     def _rust_block_import_at(
         self, module_qn: str, name: str, call_point: int | None

--- a/codebase_rag/tests/test_rust_module_qualified_calls.py
+++ b/codebase_rag/tests/test_rust_module_qualified_calls.py
@@ -101,6 +101,166 @@ def test_module_qualified_call_with_deep_path(
     assert (f"{base}.main.main", f"{base}.flags.defs.build") in calls, calls
 
 
+def test_module_qualified_call_follows_glob_reexport(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # flags/mod.rs re-exports parse's items with a glob; flags::parse()
+    # still binds through the module's namespace, deterministically, not
+    # by bare-name luck.
+    project = temp_repo / "rs_modqual_glob"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "rs_modqual_glob"\nversion = "0.1.0"\n',
+            "src/main.rs": (
+                "mod flags;\n\nfn main() {\n    let _ = flags::parse();\n}\n"
+            ),
+            "src/flags/mod.rs": (
+                "pub(crate) mod parse;\n\npub(crate) use crate::flags::parse::*;\n"
+            ),
+            "src/flags/parse.rs": "pub(crate) fn parse() -> i32 {\n    1\n}\n",
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    base = "rs_modqual_glob.src"
+    calls = _calls(mock_ingestor)
+    assert (f"{base}.main.main", f"{base}.flags.parse.parse") in calls, calls
+
+
+def test_module_qualified_call_follows_uniform_path_reexport(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # Rust 2018 uniform path: `pub use pool::connect;` names the sibling
+    # submodule without a self:: prefix and re-exports its function.
+    project = temp_repo / "rs_modqual_uniform"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "rs_modqual_uniform"\nversion = "0.1.0"\n',
+            "src/main.rs": "mod db;\n\nfn main() {\n    let _ = db::connect();\n}\n",
+            "src/db/mod.rs": "pub mod pool;\n\npub use pool::connect;\n",
+            "src/db/pool.rs": "pub fn connect() -> i32 {\n    1\n}\n",
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    base = "rs_modqual_uniform.src"
+    calls = _calls(mock_ingestor)
+    assert (f"{base}.main.main", f"{base}.db.pool.connect") in calls, calls
+
+
+def test_module_qualified_call_follows_self_glob_reexport(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The self::-prefixed glob spelling of the same re-export.
+    project = temp_repo / "rs_modqual_selfglob"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "rs_modqual_selfglob"\nversion = "0.1.0"\n',
+            "src/main.rs": "mod db;\n\nfn main() {\n    let _ = db::connect();\n}\n",
+            "src/db/mod.rs": "pub mod pool;\n\npub use self::pool::*;\n",
+            "src/db/pool.rs": "pub fn connect() -> i32 {\n    1\n}\n",
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    base = "rs_modqual_selfglob.src"
+    calls = _calls(mock_ingestor)
+    assert (f"{base}.main.main", f"{base}.db.pool.connect") in calls, calls
+
+
+def test_inline_mod_qualified_call_binds_inner_module(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # A caller inside an inline mod sees THAT mod's child module first;
+    # the file-level module of the same name must not steal the edge.
+    project = temp_repo / "rs_modqual_inline"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "rs_modqual_inline"\nversion = "0.1.0"\n',
+            "src/main.rs": (
+                "mod util;\n\n"
+                "mod inner {\n"
+                "    pub mod util {\n"
+                "        pub fn go() -> i32 {\n            1\n        }\n"
+                "    }\n"
+                "    pub fn call() -> i32 {\n        util::go()\n    }\n"
+                "}\n\n"
+                "fn main() {\n    let _ = inner::call();\n}\n"
+            ),
+            "src/util.rs": "pub fn go() -> i32 {\n    2\n}\n",
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    base = "rs_modqual_inline.src"
+    calls = _calls(mock_ingestor)
+    assert (f"{base}.main.inner.call", f"{base}.main.inner.util.go") in calls, calls
+    assert (f"{base}.main.inner.call", f"{base}.util.go") not in calls, calls
+
+
+def test_crate_prefixed_qualified_call_follows_reexport(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The crate::-prefixed spelling of issue #1009's exact failure mode.
+    project = temp_repo / "rs_modqual_crateprefix"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_modqual_crateprefix"\nversion = "0.1.0"\n'
+            ),
+            "src/main.rs": (
+                "mod flags;\n\nfn main() {\n    let _ = crate::flags::parse();\n}\n"
+            ),
+            "src/flags/mod.rs": (
+                "pub(crate) mod config;\n"
+                "pub(crate) mod parse;\n\n"
+                "pub(crate) use crate::flags::parse::parse;\n"
+            ),
+            "src/flags/parse.rs": "pub(crate) fn parse() -> i32 {\n    1\n}\n",
+            "src/flags/config.rs": "pub(crate) fn parse() -> i32 {\n    2\n}\n",
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    base = "rs_modqual_crateprefix.src"
+    calls = _calls(mock_ingestor)
+    assert (f"{base}.main.main", f"{base}.flags.parse.parse") in calls, calls
+    assert (f"{base}.main.main", f"{base}.flags.config.parse") not in calls, calls
+
+
+def test_self_prefixed_qualified_call_binds_submodule(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # self::util::go() from the file module binds the declared submodule,
+    # never the same-named decoy.
+    project = temp_repo / "rs_modqual_selfprefix"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_modqual_selfprefix"\nversion = "0.1.0"\n'
+            ),
+            "src/main.rs": (
+                "mod util;\nmod decoy;\n\n"
+                "fn main() {\n    let _ = self::util::go();\n}\n"
+            ),
+            "src/util.rs": "pub fn go() -> i32 {\n    1\n}\n",
+            "src/decoy.rs": "pub fn go() -> i32 {\n    2\n}\n",
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    base = "rs_modqual_selfprefix.src"
+    calls = _calls(mock_ingestor)
+    assert (f"{base}.main.main", f"{base}.util.go") in calls, calls
+    assert (f"{base}.main.main", f"{base}.decoy.go") not in calls, calls
+
+
 def test_associated_function_call_still_binds_the_type(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:

--- a/codebase_rag/tests/test_rust_module_qualified_calls.py
+++ b/codebase_rag/tests/test_rust_module_qualified_calls.py
@@ -202,6 +202,53 @@ def test_inline_mod_qualified_call_binds_inner_module(
     assert (f"{base}.main.inner.call", f"{base}.util.go") not in calls, calls
 
 
+def test_inline_mod_child_reexports_shadow_enclosing_module(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # An inline mod's child holding the item only via re-exports (named
+    # AND glob) still shadows the enclosing same-named module: the edges
+    # bind through inner.api's namespace, never to main's own api.
+    project = temp_repo / "rs_modqual_shadow"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "rs_modqual_shadow"\nversion = "0.1.0"\n',
+            "src/main.rs": (
+                "mod api {\n"
+                "    pub fn named() -> i32 {\n        10\n    }\n"
+                "    pub fn globbed() -> i32 {\n        20\n    }\n"
+                "}\n\n"
+                "mod backing {\n"
+                "    pub fn named() -> i32 {\n        1\n    }\n"
+                "}\n\n"
+                "mod globsrc {\n"
+                "    pub fn globbed() -> i32 {\n        2\n    }\n"
+                "}\n\n"
+                "mod inner {\n"
+                "    pub mod api {\n"
+                "        pub use crate::backing::named;\n"
+                "        pub use crate::globsrc::*;\n"
+                "    }\n"
+                "    pub fn call() -> i32 {\n        api::named() + api::globbed()\n    }\n"
+                "}\n\n"
+                "fn main() {\n"
+                "    let _ = inner::call() + api::named() + api::globbed();\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    base = "rs_modqual_shadow.src.main"
+    calls = _calls(mock_ingestor)
+    assert (f"{base}.inner.call", f"{base}.backing.named") in calls, calls
+    assert (f"{base}.inner.call", f"{base}.globsrc.globbed") in calls, calls
+    assert (f"{base}.inner.call", f"{base}.api.named") not in calls, calls
+    assert (f"{base}.inner.call", f"{base}.api.globbed") not in calls, calls
+    assert (f"{base}.main", f"{base}.api.named") in calls, calls
+    assert (f"{base}.main", f"{base}.api.globbed") in calls, calls
+
+
 def test_crate_prefixed_qualified_call_follows_reexport(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:

--- a/codebase_rag/tests/test_rust_module_qualified_calls.py
+++ b/codebase_rag/tests/test_rust_module_qualified_calls.py
@@ -1,0 +1,129 @@
+"""Rust `module::item` calls resolve through the module's own namespace.
+
+A module-qualified call names its function through the module path, so it
+must bind inside that module: a direct item, or the module's re-export
+(`pub use`), and NEVER an unrelated same-named function found by bare-name
+search (issue #1009: ripgrep's `flags::parse()` bound `config.parse`).
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.test_rust_crate_path_trait_linking import (
+    _calls,
+    _write,
+    create_and_run_updater,
+)
+
+
+def test_module_qualified_call_follows_mod_rs_reexport(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # main calls flags::parse(); flags/mod.rs re-exports parse::parse.
+    # The re-export is the module's namespace entry for `parse`, so the
+    # edge lands on flags.parse.parse; config.rs's unrelated parse must
+    # not be bound by the simple-name fallback.
+    project = temp_repo / "rs_modqual_reexport"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "rs_modqual_reexport"\nversion = "0.1.0"\n',
+            "src/main.rs": (
+                "mod flags;\n\nfn main() {\n    let _ = flags::parse();\n}\n"
+            ),
+            "src/flags/mod.rs": (
+                "pub(crate) mod config;\n"
+                "pub(crate) mod parse;\n\n"
+                "pub(crate) use crate::flags::parse::{ParseResult, parse};\n"
+            ),
+            "src/flags/parse.rs": (
+                "pub(crate) struct ParseResult;\n\n"
+                "pub(crate) fn parse() -> i32 {\n    parse_low()\n}\n\n"
+                "fn parse_low() -> i32 {\n    1\n}\n"
+            ),
+            "src/flags/config.rs": "pub(crate) fn parse() -> i32 {\n    2\n}\n",
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    base = "rs_modqual_reexport.src"
+    calls = _calls(mock_ingestor)
+    assert (f"{base}.main.main", f"{base}.flags.parse.parse") in calls, calls
+    assert (f"{base}.main.main", f"{base}.flags.config.parse") not in calls, calls
+
+
+def test_module_qualified_call_binds_direct_submodule_function(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # util::go() from main binds util.rs's own go; the same-named decoy in
+    # another module must not be reachable through the bare-name fallback.
+    project = temp_repo / "rs_modqual_direct"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "rs_modqual_direct"\nversion = "0.1.0"\n',
+            "src/main.rs": (
+                "mod util;\nmod decoy;\n\nfn main() {\n    let _ = util::go();\n}\n"
+            ),
+            "src/util.rs": "pub fn go() -> i32 {\n    1\n}\n",
+            "src/decoy.rs": "pub fn go() -> i32 {\n    2\n}\n",
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    base = "rs_modqual_direct.src"
+    calls = _calls(mock_ingestor)
+    assert (f"{base}.main.main", f"{base}.util.go") in calls, calls
+    assert (f"{base}.main.main", f"{base}.decoy.go") not in calls, calls
+
+
+def test_module_qualified_call_with_deep_path(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # flags::defs::build() names the function through two module segments.
+    project = temp_repo / "rs_modqual_deep"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "rs_modqual_deep"\nversion = "0.1.0"\n',
+            "src/main.rs": (
+                "mod flags;\n\nfn main() {\n    let _ = flags::defs::build();\n}\n"
+            ),
+            "src/flags/mod.rs": "pub mod defs;\n",
+            "src/flags/defs.rs": "pub fn build() -> i32 {\n    3\n}\n",
+            "src/other.rs": "",
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    base = "rs_modqual_deep.src"
+    calls = _calls(mock_ingestor)
+    assert (f"{base}.main.main", f"{base}.flags.defs.build") in calls, calls
+
+
+def test_associated_function_call_still_binds_the_type(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # Type::assoc() shares the :: syntax; a registered type's associated
+    # function keeps its class binding untouched by the module probe.
+    project = temp_repo / "rs_modqual_assoc"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "rs_modqual_assoc"\nversion = "0.1.0"\n',
+            "src/main.rs": (
+                "struct Ping;\n\n"
+                "impl Ping {\n"
+                "    fn new() -> Self {\n        Ping\n    }\n"
+                "}\n\n"
+                "fn main() {\n"
+                "    let _ = Ping::new();\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    base = "rs_modqual_assoc.src"
+    calls = _calls(mock_ingestor)
+    assert (f"{base}.main.main", f"{base}.main.Ping.new") in calls, calls

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.528"
+version = "0.0.531"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #1009.

## What

A Rust `module::item` call whose import probes found nothing fell through to the simple-name trie, which binds an arbitrary same-named function anywhere in the project. ripgrep's `main` calls `flags::parse()`, where `flags/mod.rs` re-exports `pub(crate) use crate::flags::parse::{ParseResult, parse};`: the re-export sits in the flags module's import mapping (correct since #1007), but resolution never consulted it and emitted `main.main CALLS flags.config.parse`, the unrelated config-file parser. That one fabricated edge both marks `config.parse` falsely live and severs `main` from the whole flag pipeline, keeping `flags.parse.parse`, `Parser.parse`, `HiArgs.from_low_args` and transitively the ~926 `Flag` impl methods dead in the dead-code report even with OVERRIDES present.

The fix adds `_try_resolve_rust_module_qualified`, consulted after the import probes and before every name-based fallback. The first segment binds where Rust binds it: the caller's inner scopes first (an inline mod's own child module or `use` shadows the file's), then the file module's `use` (at most one binding per scope is legal, E0255/E0428), then the file's own submodule tree through the same relative-path machinery its `use` declarations resolve with, so entry files attach submodules beside themselves via the declaring scan and other files nest them. `crate::`/`self::`/`super::` prefixed call paths resolve through the #1007 rewrite machinery too, so the prefixed spellings of the same call bind identically. A `use` that binds the segment to a path outside the indexed project (std, or a workspace crate by name) stops the probe undecided rather than letting the module tree claim a shadowed name.

Once a module is decided, the item resolves directly or through the module's own re-exports: named `pub use` hops chain as before, Rust 2018 uniform paths (`pub use pool::connect;`) resolve relative to the owning module, and glob re-exports (`pub use m::*;`) expand when their base is indexable. An item the module verifiably does not hold is a drop, never a trie guess; a glob whose base cannot be indexed keeps the probe undecided so no edge is dropped on incomplete knowledge. Registered types (`Ping::new()`) are untouched.

## Adversarial review

The single pre-push adversarial round found five defects in the first cut, four fixed here with RED tests: glob re-exports and uniform-path re-exports became decided drops (both regressions), inline-mod callers bound the file's same-named module, and the `crate::`-prefixed spelling of the issue's own failure mode was untouched. The fifth (a `use std::fmt;` shadowing a first-party sibling `fmt` module still yields the trie's fabricated edge downstream) is narrowed but not eliminated: the probe now correctly stops undecided instead of authoritatively binding the sibling, and a decided drop there would need workspace crate-name resolution first, since cross-crate calls (`use grep_searcher::sinks; sinks::UTF8(...)`) are served only by the trie today. Follow-up: #1033.

## TDD

RED first: `test_rust_module_qualified_calls.py` holds the issue's exact repro (the re-export shape bound `config.parse`, observed failing), a direct submodule call with a same-named decoy (bound `decoy.go`, observed failing), the deep `flags::defs::build()` path, the `Type::assoc()` pinning case, and six review-round repros (crate-glob, uniform-path, and self-glob re-exports, inline-mod shadowing, `crate::` and `self::` prefixed spellings), each observed failing before its fix. Full suite: 6707 passed, 10 skipped, against a main baseline of 6697 with the same skips.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resolution of Rust module-qualified calls, including nested modules, re-exports, glob imports, relative paths, and `crate::`/`self::` prefixes.
  * Prevented calls to missing module items from incorrectly binding to unrelated functions with the same name.
  * Preserved correct handling of external paths and associated functions.

* **Tests**
  * Added comprehensive coverage for module paths, re-exports, inline modules, and associated function calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->