### PR TITLE
fix: stop Rust bare calls binding same-named inherent methods

### DIFF
--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -383,7 +383,11 @@ class CallResolver:
                     scope[: len(scope) - len(last)] + last.split(cs.DUP_QN_MARKER, 1)[0]
                 )
                 natural_candidate = f"{natural_scope}{cs.SEPARATOR_DOT}{call_name}"
-                if natural_candidate in self.function_registry:
+                if natural_candidate in self.function_registry and (
+                    language != cs.SupportedLanguage.RUST
+                    or self.function_registry[natural_candidate]
+                    != cs.NodeLabel.METHOD.value
+                ):
                     return (
                         self.function_registry[natural_candidate],
                         natural_candidate,
@@ -946,7 +950,7 @@ class CallResolver:
                 self._simple_resolution_cache[cache_key] = result
             return result
 
-        result = self._try_resolve_via_trie(call_name, module_qn)
+        result = self._try_resolve_via_trie(call_name, module_qn, language)
         if use_cache:
             self._simple_resolution_cache[cache_key] = result
         return result
@@ -1696,7 +1700,10 @@ class CallResolver:
         return language
 
     def _try_resolve_via_trie(
-        self, call_name: str, module_qn: str
+        self,
+        call_name: str,
+        module_qn: str,
+        language: cs.SupportedLanguage | None = None,
     ) -> tuple[str, str] | None:
         search_name = _SEARCH_NAME_CACHE.get(call_name)
         if search_name is None:
@@ -1705,6 +1712,16 @@ class CallResolver:
         possible_matches = self._nameable_candidates(
             self.function_registry.find_ending_with(search_name), module_qn
         )
+        if language == cs.SupportedLanguage.RUST and search_name == call_name:
+            # A bare Rust path NEVER names a method (inherent methods need
+            # self./Self::/Type::), so a same-named method must not soak
+            # up the edge when the real target is external, prelude, or a
+            # shadowing closure the graph cannot see (issue #1011).
+            possible_matches = [
+                qn
+                for qn in possible_matches
+                if self.function_registry[qn] != cs.NodeLabel.METHOD.value
+            ]
         if not possible_matches:
             logger.debug(ls.CALL_UNRESOLVED, call_name=call_name)
             return None

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -344,7 +344,11 @@ class CallResolver:
         return None
 
     def _resolve_enclosing_scope(
-        self, call_name: str, caller_qn: str | None, module_qn: str
+        self,
+        call_name: str,
+        caller_qn: str | None,
+        module_qn: str,
+        language: cs.SupportedLanguage | None = None,
     ) -> tuple[str, str] | None:
         # Python LEGB: a bare name defined in the caller's own body or an enclosing
         # FUNCTION scope (a nested def) shadows module-level and same-named nested
@@ -359,7 +363,15 @@ class CallResolver:
         while True:
             candidate = f"{scope}{cs.SEPARATOR_DOT}{call_name}"
             if candidate in self.function_registry:
-                return self.function_registry[candidate], candidate
+                # A scope segment may be a Rust impl target, and a bare
+                # Rust path NEVER names a method: inherent methods are
+                # reachable only via self./Self::/Type:: (rustc-verified;
+                # the bare spelling calls the module item, issue #1011).
+                if (
+                    language != cs.SupportedLanguage.RUST
+                    or self.function_registry[candidate] != cs.NodeLabel.METHOD.value
+                ):
+                    return self.function_registry[candidate], candidate
             # A duplicate-variant caller (click's real `command` registers as
             # `command@168` behind its @t.overload stubs) owns nested defs the
             # def pass registers under the NATURAL qn (`command.decorator`);
@@ -742,7 +754,9 @@ class CallResolver:
         # Enclosing-scope (nested def) lookup is caller-specific, so it must run
         # before the module-keyed cache/trie, which would otherwise return a sibling
         # scope's same-named nested function.
-        if result := self._resolve_enclosing_scope(call_name, caller_qn, module_qn):
+        if result := self._resolve_enclosing_scope(
+            call_name, caller_qn, module_qn, language
+        ):
             return result
 
         # `this.m()` inside a prototype-assigned function dispatches to a sibling
@@ -1336,7 +1350,13 @@ class CallResolver:
             scope = caller_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
             while len(scope) > len(module_qn):
                 local_qn = f"{scope}{cs.SEPARATOR_DOT}{call_name}"
-                if (local_type := self.function_registry.get(local_qn)) is not None:
+                # A scope segment may be an impl target, and a bare Rust
+                # path NEVER names a method: inherent methods are reachable
+                # only via self./Self::/Type:: (rustc-verified; the bare
+                # spelling calls the module item instead, issue #1011).
+                if (
+                    local_type := self.function_registry.get(local_qn)
+                ) is not None and local_type != cs.NodeLabel.METHOD.value:
                     return ((local_type, local_qn),)
                 target = (
                     weak

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -362,16 +362,10 @@ class CallResolver:
         scope = caller_qn
         while True:
             candidate = f"{scope}{cs.SEPARATOR_DOT}{call_name}"
-            if candidate in self.function_registry:
-                # A scope segment may be a Rust impl target, and a bare
-                # Rust path NEVER names a method: inherent methods are
-                # reachable only via self./Self::/Type:: (rustc-verified;
-                # the bare spelling calls the module item, issue #1011).
-                if (
-                    language != cs.SupportedLanguage.RUST
-                    or self.function_registry[candidate] != cs.NodeLabel.METHOD.value
-                ):
-                    return self.function_registry[candidate], candidate
+            if candidate in self.function_registry and self._bare_call_allowed(
+                language, candidate
+            ):
+                return self.function_registry[candidate], candidate
             # A duplicate-variant caller (click's real `command` registers as
             # `command@168` behind its @t.overload stubs) owns nested defs the
             # def pass registers under the NATURAL qn (`command.decorator`);
@@ -384,9 +378,7 @@ class CallResolver:
                 )
                 natural_candidate = f"{natural_scope}{cs.SEPARATOR_DOT}{call_name}"
                 if natural_candidate in self.function_registry and (
-                    language != cs.SupportedLanguage.RUST
-                    or self.function_registry[natural_candidate]
-                    != cs.NodeLabel.METHOD.value
+                    self._bare_call_allowed(language, natural_candidate)
                 ):
                     return (
                         self.function_registry[natural_candidate],
@@ -398,6 +390,18 @@ class CallResolver:
             if parent == module_qn or parent not in self.function_registry:
                 return None
             scope = parent
+
+    def _bare_call_allowed(
+        self, language: cs.SupportedLanguage | None, qn: str
+    ) -> bool:
+        # A bare Rust path NEVER names a method: inherent methods are
+        # reachable only via self./Self::/Type:: (rustc-verified; the bare
+        # spelling calls the module item, issue #1011). Other languages
+        # keep their scope-chain semantics.
+        return (
+            language != cs.SupportedLanguage.RUST
+            or self.function_registry[qn] != cs.NodeLabel.METHOD.value
+        )
 
     def _protocol_impl_map(self) -> dict[str, str]:
         # A Protocol stub never runs; the concrete implementer does. Map each
@@ -1354,14 +1358,12 @@ class CallResolver:
             scope = caller_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
             while len(scope) > len(module_qn):
                 local_qn = f"{scope}{cs.SEPARATOR_DOT}{call_name}"
-                # A scope segment may be an impl target, and a bare Rust
-                # path NEVER names a method: inherent methods are reachable
-                # only via self./Self::/Type:: (rustc-verified; the bare
-                # spelling calls the module item instead, issue #1011).
-                if (
-                    local_type := self.function_registry.get(local_qn)
-                ) is not None and local_type != cs.NodeLabel.METHOD.value:
-                    return ((local_type, local_qn),)
+                # The scope segment may be an impl target whose method a
+                # bare path can never name (issue #1011).
+                if local_qn in self.function_registry and self._bare_call_allowed(
+                    cs.SupportedLanguage.RUST, local_qn
+                ):
+                    return ((self.function_registry[local_qn], local_qn),)
                 target = (
                     weak
                     if weak is not None

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -361,35 +361,42 @@ class CallResolver:
             return None
         scope = caller_qn
         while True:
-            candidate = f"{scope}{cs.SEPARATOR_DOT}{call_name}"
-            if candidate in self.function_registry and self._bare_call_allowed(
-                language, candidate
-            ):
-                return self.function_registry[candidate], candidate
-            # A duplicate-variant caller (click's real `command` registers as
-            # `command@168` behind its @t.overload stubs) owns nested defs the
-            # def pass registers under the NATURAL qn (`command.decorator`);
-            # probe the variant-stripped scope too, or the call falls to the
-            # module trie and mis-binds to a sibling's same-named nested.
-            last = scope.rsplit(cs.SEPARATOR_DOT, 1)[-1]
-            if cs.DUP_QN_MARKER in last:
-                natural_scope = (
-                    scope[: len(scope) - len(last)] + last.split(cs.DUP_QN_MARKER, 1)[0]
-                )
-                natural_candidate = f"{natural_scope}{cs.SEPARATOR_DOT}{call_name}"
-                if natural_candidate in self.function_registry and (
-                    self._bare_call_allowed(language, natural_candidate)
-                ):
-                    return (
-                        self.function_registry[natural_candidate],
-                        natural_candidate,
-                    )
+            if hit := self._scope_candidate(scope, call_name, language):
+                return hit
+            if hit := self._dup_variant_scope_candidate(scope, call_name, language):
+                return hit
             if cs.SEPARATOR_DOT not in scope:
                 return None
             parent = scope.rsplit(cs.SEPARATOR_DOT, 1)[0]
             if parent == module_qn or parent not in self.function_registry:
                 return None
             scope = parent
+
+    def _scope_candidate(
+        self, scope: str, call_name: str, language: cs.SupportedLanguage | None
+    ) -> tuple[str, str] | None:
+        candidate = f"{scope}{cs.SEPARATOR_DOT}{call_name}"
+        if candidate in self.function_registry and self._bare_call_allowed(
+            language, candidate
+        ):
+            return self.function_registry[candidate], candidate
+        return None
+
+    def _dup_variant_scope_candidate(
+        self, scope: str, call_name: str, language: cs.SupportedLanguage | None
+    ) -> tuple[str, str] | None:
+        # A duplicate-variant caller (click's real `command` registers as
+        # `command@168` behind its @t.overload stubs) owns nested defs the
+        # def pass registers under the NATURAL qn (`command.decorator`);
+        # probe the variant-stripped scope too, or the call falls to the
+        # module trie and mis-binds to a sibling's same-named nested.
+        last = scope.rsplit(cs.SEPARATOR_DOT, 1)[-1]
+        if cs.DUP_QN_MARKER not in last:
+            return None
+        natural_scope = (
+            scope[: len(scope) - len(last)] + last.split(cs.DUP_QN_MARKER, 1)[0]
+        )
+        return self._scope_candidate(natural_scope, call_name, language)
 
     def _bare_call_allowed(
         self, language: cs.SupportedLanguage | None, qn: str
@@ -1357,13 +1364,12 @@ class CallResolver:
             ).get(call_name)
             scope = caller_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
             while len(scope) > len(module_qn):
-                local_qn = f"{scope}{cs.SEPARATOR_DOT}{call_name}"
                 # The scope segment may be an impl target whose method a
                 # bare path can never name (issue #1011).
-                if local_qn in self.function_registry and self._bare_call_allowed(
-                    cs.SupportedLanguage.RUST, local_qn
+                if local := self._scope_candidate(
+                    scope, call_name, cs.SupportedLanguage.RUST
                 ):
-                    return ((self.function_registry[local_qn], local_qn),)
+                    return (local,)
                 target = (
                     weak
                     if weak is not None

--- a/codebase_rag/tests/test_rust_bare_call_inherent_method.py
+++ b/codebase_rag/tests/test_rust_bare_call_inherent_method.py
@@ -43,6 +43,92 @@ def test_bare_call_in_impl_method_binds_free_function(
     assert (f"{base}.foo.S.run", f"{base}.foo.S.helper") not in calls, calls
 
 
+def test_bare_call_with_external_import_never_falls_to_the_method(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `use std::cmp::max` binds the bare name to std; with no first-party
+    # target the edge is dropped, never trie-guessed onto the inherent
+    # method (rustc: "method `max` is never used").
+    project = temp_repo / "rs_bare_ext"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "rs_bare_ext"\nversion = "0.1.0"\n',
+            "src/main.rs": "mod foo;\n\nfn main() {\n    let _ = foo::S.run();\n}\n",
+            "src/foo.rs": (
+                "use std::cmp::max;\n\n"
+                "pub struct S;\n\n"
+                "impl S {\n"
+                "    fn max(&self) -> u32 {\n        2\n    }\n"
+                "    pub fn run(&self) -> u32 {\n        max(1u32, 2u32)\n    }\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    base = "rs_bare_ext.src"
+    calls = _calls(mock_ingestor)
+    assert (f"{base}.foo.S.run", f"{base}.foo.S.max") not in calls, calls
+
+
+def test_bare_prelude_call_never_falls_to_the_method(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `drop(x)` is the prelude function; the same-named inherent method
+    # stays unbound (rustc: "method `drop` is never used").
+    project = temp_repo / "rs_bare_prelude"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "rs_bare_prelude"\nversion = "0.1.0"\n',
+            "src/main.rs": "mod foo;\n\nfn main() {\n    let _ = foo::S.run();\n}\n",
+            "src/foo.rs": (
+                "pub struct S;\n\n"
+                "impl S {\n"
+                "    fn drop(&self) -> u32 {\n        2\n    }\n"
+                "    pub fn run(&self) -> u32 {\n        drop(1u32);\n        5\n    }\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    base = "rs_bare_prelude.src"
+    calls = _calls(mock_ingestor)
+    assert (f"{base}.foo.S.run", f"{base}.foo.S.drop") not in calls, calls
+
+
+def test_bare_closure_call_never_falls_to_the_method(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # A local closure shadows everything; the inherent method must not
+    # receive the edge.
+    project = temp_repo / "rs_bare_closure"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "rs_bare_closure"\nversion = "0.1.0"\n',
+            "src/main.rs": "mod foo;\n\nfn main() {\n    let _ = foo::S.run();\n}\n",
+            "src/foo.rs": (
+                "pub struct S;\n\n"
+                "impl S {\n"
+                "    fn helper(&self) -> u32 {\n        2\n    }\n"
+                "    pub fn run(&self) -> u32 {\n"
+                "        let helper = || 3u32;\n"
+                "        helper()\n"
+                "    }\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    base = "rs_bare_closure.src"
+    calls = _calls(mock_ingestor)
+    assert (f"{base}.foo.S.run", f"{base}.foo.S.helper") not in calls, calls
+
+
 def test_self_method_call_still_binds_the_inherent_method(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:

--- a/codebase_rag/tests/test_rust_bare_call_inherent_method.py
+++ b/codebase_rag/tests/test_rust_bare_call_inherent_method.py
@@ -1,0 +1,72 @@
+"""A bare Rust call never binds an inherent method (issue #1011).
+
+Inside an impl method, a bare path resolves through module items and
+imports only: inherent methods are reachable solely via `self.helper()`,
+`Self::helper()` or `S::helper()` (rustc-verified; the bare spelling calls
+the free function and `S::helper` stays unused).
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.test_rust_crate_path_trait_linking import (
+    _calls,
+    _write,
+    create_and_run_updater,
+)
+
+
+def test_bare_call_in_impl_method_binds_free_function(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    project = temp_repo / "rs_bare_inherent"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "rs_bare_inherent"\nversion = "0.1.0"\n',
+            "src/main.rs": "mod foo;\n\nfn main() {\n    let _ = foo::S.run();\n}\n",
+            "src/foo.rs": (
+                "pub fn helper() -> u32 {\n    1\n}\n\n"
+                "pub struct S;\n\n"
+                "impl S {\n"
+                "    fn helper(&self) -> u32 {\n        2\n    }\n"
+                "    pub fn run(&self) -> u32 {\n        helper()\n    }\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    base = "rs_bare_inherent.src"
+    calls = _calls(mock_ingestor)
+    assert (f"{base}.foo.S.run", f"{base}.foo.helper") in calls, calls
+    assert (f"{base}.foo.S.run", f"{base}.foo.S.helper") not in calls, calls
+
+
+def test_self_method_call_still_binds_the_inherent_method(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The receiver spelling keeps its method edge: only the BARE path is
+    # barred from inherent methods.
+    project = temp_repo / "rs_bare_inherent_self"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_bare_inherent_self"\nversion = "0.1.0"\n'
+            ),
+            "src/main.rs": "mod foo;\n\nfn main() {\n    let _ = 1;\n}\n",
+            "src/foo.rs": (
+                "pub struct S;\n\n"
+                "impl S {\n"
+                "    fn helper(&self) -> u32 {\n        2\n    }\n"
+                "    pub fn run(&self) -> u32 {\n        self.helper()\n    }\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    base = "rs_bare_inherent_self.src"
+    calls = _calls(mock_ingestor)
+    assert (f"{base}.foo.S.run", f"{base}.foo.S.helper") in calls, calls

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.531"
+version = "0.0.532"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #1011.

## What

A bare function call inside a Rust impl method bound to a same-named inherent method of the surrounding type, fabricating a CALLS edge Rust forbids: in the issue's repro, `run(&self)` calling `helper()` emitted `S.run CALLS S.helper`, while rustc resolves the bare path to the free function `helper` and warns that `S::helper` is never used. The fabricated edge both misses the real target and revives a dead inherent method in dead-code analysis.

Two resolution paths reached the wrong answer. The Rust inline-scope walk probes each enclosing qn segment for a local item, and an impl target's segment surfaces the inherent method; it now skips Method-labelled hits, since a bare Rust path can only name a method through `self.`, `Self::` or `Type::`, all of which resolve elsewhere. The generic enclosing-scope walk (Python LEGB) reaches the same method through the class segment; it now takes the language and applies the identical gate for Rust callers only, leaving every other language's behaviour untouched. With both gates in place the bare call falls through to same-module resolution and lands on the free function.

## Adversarial review

The single pre-push adversarial round confirmed the two gated walks regression-free across sixteen rustc-valid fixtures, and found the invariant still broken where no first-party binding exists: with `use std::cmp::max`, a prelude call, or a shadowing closure, the trie fallback still soaked the edge onto the inherent method. Fixed here: the trie excludes Method-labelled candidates for bare Rust names, and the duplicate-variant branch of the enclosing-scope walk carries the same gate. A related pre-existing defect it surfaced (a nested fn inside an impl method registering with a label its CALLS edge does not match) is filed as #1037.

## TDD

RED first: the issue's exact fixture, observed emitting `S.run -> S.helper` with the free-function edge missing, plus the review round's three trie-hole repros (external import, prelude, closure shadowing), each observed failing, and a `self.helper()` control pinning that receiver spellings keep their method edge. All green after the fix. Full suite: 6713 passed, 10 skipped, against a main baseline of 6708 with the same skips.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved call resolution across nested scopes while preserving the caller’s programming language context.
  - Corrected Rust bare-name lookups so they resolve to free functions, imports, prelude functions, or local closures instead of inherent methods.
  - Ensured receiver-qualified calls such as `self.method()` continue to resolve to the appropriate inherent method.

- **Tests**
  - Added coverage for Rust call resolution inside inherent implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->