### PR TITLE
fix: keep the brace-list base path on scoped identifiers in Rust use trees

### DIFF
--- a/codebase_rag/parsers/rs/utils.py
+++ b/codebase_rag/parsers/rs/utils.py
@@ -46,11 +46,16 @@ def _process_use_tree(node: Node, base_path: str, imports: dict[str, str]) -> No
                 imports[name] = full_path
 
         case cs.TS_SCOPED_IDENTIFIER | cs.TS_RS_SCOPED_TYPE_IDENTIFIER:
-            if (full_path := _extract_path_from_node(node)) and (
-                parts := full_path.split(cs.SEPARATOR_DOUBLE_COLON)
-            ):
-                imported_name = parts[-1]
-                imports[imported_name] = full_path
+            # Inside a brace list the scoped path is RELATIVE to the
+            # list's base (`use crate::flags::{hiargs::HiArgs}` names
+            # crate::flags::hiargs::HiArgs); stored bare it can never be
+            # followed, and every consumer of the re-export silently
+            # loses resolution (ripgrep's HiArgs surface, issue #1039).
+            if full_path := _extract_path_from_node(node):
+                if base_path:
+                    full_path = f"{base_path}{cs.SEPARATOR_DOUBLE_COLON}{full_path}"
+                parts = full_path.split(cs.SEPARATOR_DOUBLE_COLON)
+                imports[parts[-1]] = full_path
 
         case cs.TS_RS_USE_AS_CLAUSE:
             _process_use_as_clause(node, base_path, imports)

--- a/codebase_rag/parsers/rs/utils.py
+++ b/codebase_rag/parsers/rs/utils.py
@@ -111,6 +111,11 @@ def _process_use_wildcard(node: Node, base_path: str, imports: dict[str, str]) -
         ),
         "",
     ):
+        # Same base-path rule as scoped identifiers: inside a brace list
+        # the glob's path is relative (`use crate::flags::{hiargs::*}`
+        # globs crate::flags::hiargs), so the list's base joins it.
+        if base_path:
+            wildcard_base = f"{base_path}{cs.SEPARATOR_DOUBLE_COLON}{wildcard_base}"
         wildcard_key = f"{cs.RS_WILDCARD_PREFIX}{wildcard_base}"
         imports[wildcard_key] = wildcard_base
     elif base_path:

--- a/codebase_rag/tests/test_rust_param_receiver_typing.py
+++ b/codebase_rag/tests/test_rust_param_receiver_typing.py
@@ -1,0 +1,362 @@
+"""Rust method receivers typed by parameter annotations (issue #1039).
+
+A parameter `s: &S` binds `s` to `S` inside the function exactly as a
+`let` annotation does, so `s.go()` must emit a CALLS edge to `S.go`.
+ripgrep's whole `HiArgs` surface (`fn search(args: &HiArgs)` calling
+`args.matcher()`) reported dead because these edges were missing.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.test_rust_crate_path_trait_linking import (
+    _calls,
+    _write,
+    create_and_run_updater,
+)
+
+
+def test_method_call_on_reference_param_receiver(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    project = temp_repo / "rs_param_ref"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "rs_param_ref"\nversion = "0.1.0"\n',
+            "src/main.rs": (
+                "pub struct S;\n\n"
+                "impl S {\n"
+                "    pub fn go(&self) -> u32 {\n        1\n    }\n"
+                "}\n\n"
+                "fn run(s: &S) -> u32 {\n    s.go()\n}\n\n"
+                "fn main() {\n    let _ = run(&S);\n}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    base = "rs_param_ref.src.main"
+    calls = _calls(mock_ingestor)
+    assert (f"{base}.run", f"{base}.S.go") in calls, calls
+
+
+def test_method_call_on_owned_and_mut_param_receivers(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    project = temp_repo / "rs_param_owned"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "rs_param_owned"\nversion = "0.1.0"\n',
+            "src/main.rs": (
+                "pub struct S;\n\n"
+                "impl S {\n"
+                "    pub fn go(&self) -> u32 {\n        1\n    }\n"
+                "    pub fn bump(&mut self) -> u32 {\n        2\n    }\n"
+                "}\n\n"
+                "fn consume(s: S) -> u32 {\n    s.go()\n}\n\n"
+                "fn mutate(s: &mut S) -> u32 {\n    s.bump()\n}\n\n"
+                "fn main() {\n"
+                "    let _ = consume(S);\n"
+                "    let mut s = S;\n"
+                "    let _ = mutate(&mut s);\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    base = "rs_param_owned.src.main"
+    calls = _calls(mock_ingestor)
+    assert (f"{base}.consume", f"{base}.S.go") in calls, calls
+    assert (f"{base}.mutate", f"{base}.S.bump") in calls, calls
+
+
+def test_method_call_on_cross_module_param_receiver(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # ripgrep's exact shape: the receiver type lives in another module's
+    # submodule and reaches the caller through a mod.rs re-export
+    # (`use crate::flags::HiArgs;` where flags/mod.rs re-exports
+    # hiargs::HiArgs); the parameter annotation must still type the
+    # receiver.
+    project = temp_repo / "rs_param_xmod"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "rs_param_xmod"\nversion = "0.1.0"\n',
+            "src/main.rs": (
+                "mod flags;\nmod search;\n\n"
+                "fn main() {\n"
+                "    let args = crate::flags::HiArgs::new();\n"
+                "    let _ = crate::search::search(&args);\n"
+                "}\n"
+            ),
+            "src/flags/mod.rs": (
+                "mod hiargs;\n\npub(crate) use crate::flags::hiargs::HiArgs;\n"
+            ),
+            "src/flags/hiargs.rs": (
+                "pub(crate) struct HiArgs;\n\n"
+                "impl HiArgs {\n"
+                "    pub(crate) fn new() -> HiArgs {\n        HiArgs\n    }\n"
+                "    pub(crate) fn matcher(&self) -> u32 {\n        1\n    }\n"
+                "}\n"
+            ),
+            "src/search.rs": (
+                "use crate::flags::HiArgs;\n\n"
+                "pub(crate) fn search(args: &HiArgs) -> u32 {\n"
+                "    args.matcher()\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    base = "rs_param_xmod.src"
+    calls = _calls(mock_ingestor)
+    assert (
+        f"{base}.search.search",
+        f"{base}.flags.hiargs.HiArgs.matcher",
+    ) in calls, calls
+
+
+def test_param_receiver_in_entry_file_with_brace_list_use(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # ripgrep's exact shape: the caller fn lives in the crate ROOT file
+    # itself, importing the type through a brace-list use of the mod.rs
+    # re-export, and a same-named method exists on another type.
+    project = temp_repo / "rs_param_entry"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "rs_param_entry"\nversion = "0.1.0"\n',
+            "src/main.rs": (
+                "mod flags;\nmod worker;\n\n"
+                "use crate::flags::{HiArgs, SearchMode};\n\n"
+                "fn search(args: &HiArgs, _mode: SearchMode) -> u32 {\n"
+                "    args.matcher()\n"
+                "}\n\n"
+                "fn main() {\n"
+                "    let args = crate::flags::HiArgs::new();\n"
+                "    let _ = search(&args, SearchMode::Standard);\n"
+                "    let w = crate::worker::Worker;\n"
+                "    let _ = w.matcher();\n"
+                "}\n"
+            ),
+            "src/flags/mod.rs": (
+                "mod hiargs;\n\n"
+                "pub(crate) use crate::flags::hiargs::HiArgs;\n\n"
+                "pub(crate) enum SearchMode {\n    Standard,\n}\n"
+            ),
+            "src/flags/hiargs.rs": (
+                "pub(crate) struct HiArgs;\n\n"
+                "impl HiArgs {\n"
+                "    pub(crate) fn new() -> HiArgs {\n        HiArgs\n    }\n"
+                "    pub(crate) fn matcher(&self) -> u32 {\n        1\n    }\n"
+                "}\n"
+            ),
+            "src/worker.rs": (
+                "pub(crate) struct Worker;\n\n"
+                "impl Worker {\n"
+                "    pub(crate) fn matcher(&self) -> u32 {\n        2\n    }\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    base = "rs_param_entry.src"
+    calls = _calls(mock_ingestor)
+    assert (
+        f"{base}.main.search",
+        f"{base}.flags.hiargs.HiArgs.matcher",
+    ) in calls, calls
+    assert (f"{base}.main.search", f"{base}.worker.Worker.matcher") not in calls, calls
+
+
+def test_param_receiver_in_deep_manifest_target(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # ripgrep's real layout: the workspace ROOT manifest declares
+    # `[[bin]] path = "crates/core/main.rs"`, so the crate root sits deep
+    # in the tree with no local Cargo.toml or src/ directory.
+    project = temp_repo / "rs_param_deep"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_param_deep"\nversion = "0.1.0"\n\n'
+                '[[bin]]\nname = "rg"\npath = "crates/core/main.rs"\n'
+            ),
+            "crates/core/main.rs": (
+                "mod flags;\n\n"
+                "use crate::flags::HiArgs;\n\n"
+                "fn search(args: &HiArgs) -> u32 {\n"
+                "    args.matcher()\n"
+                "}\n\n"
+                "fn main() {\n"
+                "    let args = crate::flags::HiArgs::new();\n"
+                "    let _ = search(&args);\n"
+                "}\n"
+            ),
+            "crates/core/flags/mod.rs": (
+                "mod hiargs;\n\npub(crate) use crate::flags::hiargs::HiArgs;\n"
+            ),
+            "crates/core/flags/hiargs.rs": (
+                "pub(crate) struct HiArgs;\n\n"
+                "impl HiArgs {\n"
+                "    pub(crate) fn new() -> HiArgs {\n        HiArgs\n    }\n"
+                "    pub(crate) fn matcher(&self) -> u32 {\n        1\n    }\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    base = "rs_param_deep.crates.core"
+    calls = _calls(mock_ingestor)
+    assert (
+        f"{base}.main.search",
+        f"{base}.flags.hiargs.HiArgs.matcher",
+    ) in calls, calls
+
+
+def test_method_call_beats_same_named_free_fn_in_type_module(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # ripgrep's `args.stats()`: HiArgs::stats(&self) AND a free
+    # `fn stats(low: &LowArgs)` live in the same file, and the caller
+    # binds `let mut stats = args.stats();`. The receiver call must bind
+    # the METHOD, never the free fn.
+    project = temp_repo / "rs_param_freefn"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "rs_param_freefn"\nversion = "0.1.0"\n',
+            "src/main.rs": (
+                "mod flags;\n\n"
+                "use crate::flags::HiArgs;\n\n"
+                "fn search(args: &HiArgs) -> u32 {\n"
+                "    let mut stats = args.stats();\n"
+                "    stats += 1;\n"
+                "    stats\n"
+                "}\n\n"
+                "fn main() {\n"
+                "    let args = crate::flags::HiArgs::new();\n"
+                "    let _ = search(&args);\n"
+                "}\n"
+            ),
+            "src/flags/mod.rs": (
+                "mod hiargs;\n\npub(crate) use crate::flags::hiargs::HiArgs;\n"
+            ),
+            "src/flags/hiargs.rs": (
+                "pub(crate) struct HiArgs;\n"
+                "pub(crate) struct LowArgs;\n\n"
+                "impl HiArgs {\n"
+                "    pub(crate) fn new() -> HiArgs {\n        HiArgs\n    }\n"
+                "    pub(crate) fn stats(&self) -> u32 {\n        stats(&LowArgs)\n    }\n"
+                "}\n\n"
+                "fn stats(_low: &LowArgs) -> u32 {\n    1\n}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    base = "rs_param_freefn.src"
+    calls = _calls(mock_ingestor)
+    assert (
+        f"{base}.main.search",
+        f"{base}.flags.hiargs.HiArgs.stats",
+    ) in calls, calls
+    assert (f"{base}.main.search", f"{base}.flags.hiargs.stats") not in calls, calls
+
+
+def test_scoped_identifier_in_use_list_keeps_its_base_path(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # ripgrep's flags/mod.rs: `pub(crate) use crate::flags::{ ...,
+    # hiargs::HiArgs, ... };`. A scoped identifier INSIDE a brace list
+    # must keep the list's base path; stored relative it can never be
+    # followed, and every receiver typed through the re-export loses its
+    # method edges (the real cause behind issue #1039's HiArgs surface).
+    project = temp_repo / "rs_param_nested_use"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_param_nested_use"\nversion = "0.1.0"\n'
+            ),
+            "src/main.rs": (
+                "mod flags;\n\n"
+                "use crate::flags::{HiArgs, SearchMode};\n\n"
+                "fn search(args: &HiArgs, _mode: SearchMode) -> u32 {\n"
+                "    args.matcher()\n"
+                "}\n\n"
+                "fn main() {\n"
+                "    let args = crate::flags::HiArgs::new();\n"
+                "    let _ = search(&args, SearchMode::Standard);\n"
+                "}\n"
+            ),
+            "src/flags/mod.rs": (
+                "mod hiargs;\nmod lowargs;\n\n"
+                "pub(crate) use crate::flags::{\n"
+                "    hiargs::HiArgs,\n"
+                "    lowargs::SearchMode,\n"
+                "};\n"
+            ),
+            "src/flags/hiargs.rs": (
+                "pub(crate) struct HiArgs;\n\n"
+                "impl HiArgs {\n"
+                "    pub(crate) fn new() -> HiArgs {\n        HiArgs\n    }\n"
+                "    pub(crate) fn matcher(&self) -> u32 {\n        1\n    }\n"
+                "}\n"
+            ),
+            "src/flags/lowargs.rs": (
+                "pub(crate) enum SearchMode {\n    Standard,\n}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    base = "rs_param_nested_use.src"
+    calls = _calls(mock_ingestor)
+    assert (
+        f"{base}.main.search",
+        f"{base}.flags.hiargs.HiArgs.matcher",
+    ) in calls, calls
+
+
+def test_param_type_disambiguates_same_named_methods(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # Two types define `go`; the parameter annotation picks the right one.
+    project = temp_repo / "rs_param_disambig"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "rs_param_disambig"\nversion = "0.1.0"\n',
+            "src/main.rs": (
+                "pub struct A;\n"
+                "pub struct B;\n\n"
+                "impl A {\n"
+                "    pub fn go(&self) -> u32 {\n        1\n    }\n"
+                "}\n\n"
+                "impl B {\n"
+                "    pub fn go(&self) -> u32 {\n        2\n    }\n"
+                "}\n\n"
+                "fn run(b: &B) -> u32 {\n    b.go()\n}\n\n"
+                "fn main() {\n"
+                "    let a = A;\n"
+                "    let _ = a.go() + run(&B);\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    base = "rs_param_disambig.src.main"
+    calls = _calls(mock_ingestor)
+    assert (f"{base}.run", f"{base}.B.go") in calls, calls
+    assert (f"{base}.run", f"{base}.A.go") not in calls, calls

--- a/codebase_rag/tests/test_rust_param_receiver_typing.py
+++ b/codebase_rag/tests/test_rust_param_receiver_typing.py
@@ -1,9 +1,13 @@
-"""Rust method receivers typed by parameter annotations (issue #1039).
+"""Rust brace-list use paths keep their base; receivers stay typed.
 
-A parameter `s: &S` binds `s` to `S` inside the function exactly as a
-`let` annotation does, so `s.go()` must emit a CALLS edge to `S.go`.
-ripgrep's whole `HiArgs` surface (`fn search(args: &HiArgs)` calling
-`args.matcher()`) reported dead because these edges were missing.
+Issue #1039 presented as missing parameter-receiver typing (ripgrep's
+`fn search(args: &HiArgs)` calling `args.matcher()` emitted no edges),
+but the root cause was a scoped identifier inside a brace-list use
+(`use crate::flags::{hiargs::HiArgs}`) dropping the list's base path,
+which severed every consumer of the re-export. The use-list test here
+pins the fix; the receiver-shaped tests pin the already-working
+parameter typing the issue was filed against, so a regression in either
+half now fails loudly.
 """
 
 from pathlib import Path

--- a/codebase_rag/tests/test_rust_utils.py
+++ b/codebase_rag/tests/test_rust_utils.py
@@ -601,3 +601,16 @@ class TestExtractUseImportsEdgeCases:
         assert result["self"] == "std::fs"
         assert result["File"] == "std::fs::File"
         assert result["read_to_string"] == "std::fs::read_to_string"
+
+
+class TestBraceListGlobBase:
+    def test_glob_inside_brace_list_keeps_base_path(self) -> None:
+        # `use crate::flags::{hiargs::*};` globs crate::flags::hiargs;
+        # dropped bases left an unfollowable relative glob (issue #1039).
+        code = "use crate::flags::{hiargs::*};"
+        root = parse_rust_code(code)
+        use_node = find_node_by_type(root, "use_declaration")
+        assert use_node is not None
+
+        result = extract_use_imports(use_node)
+        assert result["*crate::flags::hiargs"] == "crate::flags::hiargs"

--- a/codebase_rag/tests/test_rust_utils.py
+++ b/codebase_rag/tests/test_rust_utils.py
@@ -195,7 +195,10 @@ class TestExtractUseImports:
         assert "File" in result
         assert result["Read"] == "std::io::Read"
         assert result["Write"] == "std::io::Write"
-        assert result["File"] == "fs::File"
+        # A scoped identifier inside the brace list keeps the list's
+        # base: `fs::File` here names std::fs::File (issue #1039; the
+        # old expectation pinned the dropped base path).
+        assert result["File"] == "std::fs::File"
 
     def test_self_alias_in_group(self) -> None:
         code = "use std::io::{self as Sio, Read};"

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.532"
+version = "0.0.534"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #1039.

## What

A scoped identifier inside a Rust brace-list use dropped the list's base path: `use crate::flags::{hiargs::HiArgs, ...}` stored `HiArgs -> hiargs::HiArgs` instead of `crate::flags::hiargs::HiArgs`, so the mapping could never be followed and every consumer of the re-export silently lost resolution. The issue was filed as missing parameter-receiver typing because ripgrep's whole `HiArgs` surface (`fn search(args: &HiArgs)` calling `args.matcher()`, `args.printer(...)`) had zero incoming CALLS edges; replicating the function statement by statement showed the shapes all resolve, and the trigger is flags/mod.rs re-exporting `HiArgs` through exactly this nested list. Parameter typing itself was already correct, and the new tests pin it.

The fix prepends the base path in `_process_use_tree`'s scoped-identifier branch, mirroring what the plain-identifier and alias branches already did, and the adversarial round's sweep surfaced the same drop in the braced-glob sibling (`use crate::flags::{hiargs::*}`), fixed alike. One existing expectation in `test_rust_utils.py` had pinned the dropped base (`File == "fs::File"` for `use std::{io::{Read, Write}, fs::File}`) and now asserts the rustc-correct `std::fs::File`.

## Adversarial review

The single pre-push round could not break the production change: it compiled the corrected `std::fs::File` expectation against rustc, proved absolute paths inside brace lists are E0433 so the prepend cannot double-qualify compiling code, and ran a seventeen-case parse battery with every changed value rustc-correct. Its two observations are acted on here: the test file's framing is rewritten to name the real root cause, and the braced-glob base drop it spotted (no failing edge demonstrable, same defect class) is fixed with a pinned mapping test.

## TDD

RED first: `test_rust_param_receiver_typing.py` holds the nested-use repro (observed binding nothing before the fix) plus pinning coverage for the misdiagnosed surface: reference, owned, and `&mut` parameter receivers, cross-module re-exported types, the entry-file brace-list shape with a same-named decoy method, ripgrep's deep `[[bin]] path` manifest layout, and a same-named free function in the type's own module. A statement-for-statement replica of ripgrep's `search()` (nested receiver arguments, `?`, shadowing locals, closures) resolves all twelve `HiArgs` method edges after the fix. Full suite: 6741 passed, 10 skipped, against a freshly measured main baseline of 6732 with the same skips.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Rust import resolution for nested scoped and wildcard imports, preserving complete qualified paths.
  * Improved method-call resolution for typed receivers, including references, owned and mutable values, cross-module calls, and crate-root targets.
  * Better distinguishes methods from free functions and resolves same-named methods by parameter type.

* **Tests**
  * Added comprehensive coverage for Rust receiver typing and import path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->