### PR TITLE
fix: resolve Rust workspace crate names in use paths so cross-crate calls bind precisely

### DIFF
--- a/codebase_rag/constants/ast_rust.py
+++ b/codebase_rag/constants/ast_rust.py
@@ -195,6 +195,8 @@ RS_MANIFEST_WORKSPACE_KEY = "workspace"
 RS_MANIFEST_MEMBERS_KEY = "members"
 RS_MANIFEST_NAME_KEY = "name"
 RS_MANIFEST_LIB_SECTION = "lib"
+RS_MANIFEST_DEP_SECTIONS = ("dependencies", "dev-dependencies", "build-dependencies")
+RS_MANIFEST_TARGET_TABLE_KEY = "target"
 # Crates shipped with the toolchain: external by construction, no
 # manifest needed to know a use head naming one is outside the project.
 RS_STDLIB_CRATES = frozenset({"std", "core", "alloc", "proc_macro"})

--- a/codebase_rag/constants/ast_rust.py
+++ b/codebase_rag/constants/ast_rust.py
@@ -195,3 +195,6 @@ RS_MANIFEST_WORKSPACE_KEY = "workspace"
 RS_MANIFEST_MEMBERS_KEY = "members"
 RS_MANIFEST_NAME_KEY = "name"
 RS_MANIFEST_LIB_SECTION = "lib"
+# Crates shipped with the toolchain: external by construction, no
+# manifest needed to know a use head naming one is outside the project.
+RS_STDLIB_CRATES = frozenset({"std", "core", "alloc", "proc_macro"})

--- a/codebase_rag/constants/ast_rust.py
+++ b/codebase_rag/constants/ast_rust.py
@@ -191,3 +191,7 @@ RS_MANIFEST_TARGET_SECTIONS = ("bin", "lib", "example", "test", "bench")
 RS_MANIFEST_PATH_KEY = "path"
 RS_MANIFEST_PACKAGE_KEY = "package"
 RS_MANIFEST_BUILD_KEY = "build"
+RS_MANIFEST_WORKSPACE_KEY = "workspace"
+RS_MANIFEST_MEMBERS_KEY = "members"
+RS_MANIFEST_NAME_KEY = "name"
+RS_MANIFEST_LIB_SECTION = "lib"

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -1486,11 +1486,15 @@ class CallResolver:
     ) -> tuple[tuple[str, str] | None, bool]:
         resolved = self._rust_local_qn(mapped, owner)
         if resolved is None:
-            if mapped.split(cs.SEPARATOR_DOUBLE_COLON, 1)[0] in cs.RS_STDLIB_CRATES:
-                # A standard-library head is external by construction:
-                # the name is spoken for, so neither the module tree nor
-                # the trie may claim it for a same-named first-party
-                # sibling (issue #1033).
+            head = mapped.split(cs.SEPARATOR_DOUBLE_COLON, 1)[0]
+            if head in cs.RS_STDLIB_CRATES or (
+                self.import_processor.rust_head_is_external_dep(head, owner)
+            ):
+                # A standard-library head, or one the importer's own
+                # manifest binds outside the repo (a registry version),
+                # is external by construction: the name is spoken for,
+                # so neither the module tree nor the trie may claim it
+                # for a same-named first-party sibling (issue #1033).
                 return None, True
             # Any other unresolved head may still be first-party in a
             # layout the import half does not cover (a nested workspace

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -1484,10 +1484,12 @@ class CallResolver:
     ) -> tuple[tuple[str, str] | None, bool]:
         resolved = self._rust_local_qn(mapped, owner)
         if resolved is None:
-            # The use binds the head outside the indexed project (std, or
-            # a workspace crate by name, unresolved today): the head is
-            # spoken for, but no first-party module backs it here.
-            return None, False
+            # The use binds the head outside the indexed project: with
+            # workspace crate names rewritten to project qns at parse
+            # time (issue #1033), a still-unresolved head is genuinely
+            # external, so the name is spoken for and neither the module
+            # tree nor the trie may claim it.
+            return None, True
         return self._decide_rust_base(cs.SEPARATOR_DOT.join([resolved, *rest]), item)
 
     def _decide_rust_base(

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -1401,8 +1401,10 @@ class CallResolver:
         via the same relative-path machinery its use declarations resolve
         through (entry files attach submodules beside themselves via the
         declaring scan; other files nest them). A use binding the segment
-        to a path outside the indexed project stops the probe undecided:
-        the name is spoken for, so the module tree must not claim it.
+        to a path outside the indexed project decides a drop when the
+        path's head is a standard-library crate (external by
+        construction) and stops the probe undecided otherwise: the name
+        is spoken for either way, so the module tree must not claim it.
         """
         parts = call_name.split(cs.SEPARATOR_DOUBLE_COLON)
         object_path, item = parts[:-1], parts[-1]
@@ -1484,12 +1486,18 @@ class CallResolver:
     ) -> tuple[tuple[str, str] | None, bool]:
         resolved = self._rust_local_qn(mapped, owner)
         if resolved is None:
-            # The use binds the head outside the indexed project: with
-            # workspace crate names rewritten to project qns at parse
-            # time (issue #1033), a still-unresolved head is genuinely
-            # external, so the name is spoken for and neither the module
-            # tree nor the trie may claim it.
-            return None, True
+            if mapped.split(cs.SEPARATOR_DOUBLE_COLON, 1)[0] in cs.RS_STDLIB_CRATES:
+                # A standard-library head is external by construction:
+                # the name is spoken for, so neither the module tree nor
+                # the trie may claim it for a same-named first-party
+                # sibling (issue #1033).
+                return None, True
+            # Any other unresolved head may still be first-party in a
+            # layout the import half does not cover (a nested workspace
+            # root, a path dependency without a workspace, a #[path]
+            # module): stay undecided so the ordinary fallbacks keep
+            # their edges.
+            return None, False
         return self._decide_rust_base(cs.SEPARATOR_DOT.join([resolved, *rest]), item)
 
     def _decide_rust_base(

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -402,6 +402,7 @@ class ImportProcessor:
         "_rust_explicit_targets",
         "_rust_auto_build_flags",
         "_rust_workspace_crates",
+        "_rust_pkg_deps",
         "_rust_inline_scope_keys",
         "_rust_pending_fn_scope_uses",
         "rust_fn_scope_imports",
@@ -459,14 +460,21 @@ class ImportProcessor:
         # explicitly, false disables it entirely). Filled alongside the
         # explicit-target parse, cleared with it.
         self._rust_auto_build_flags: dict[tuple[str, ...], bool] = {}
-        # Workspace member crate names (underscore-spelled) -> lib-root
-        # (dir parts, entry stem), so `use grep_searcher::sinks;` rewrites
+        # Workspace crate names (underscore-spelled) -> (package dir, lib
+        # root dir, entry stem), so `use grep_searcher::sinks;` rewrites
         # to a project qn at parse time like crate:: paths do (issue
         # #1033). Built lazily from the root manifest's members plus the
         # root package; None until first use, re-None'd on manifest edits.
-        self._rust_workspace_crates: dict[str, tuple[tuple[str, ...], str]] | None = (
-            None
-        )
+        self._rust_workspace_crates: (
+            dict[str, tuple[tuple[str, ...], tuple[str, ...], str]] | None
+        ) = None
+        # Per-package dependency targets: dep name (underscore-spelled) ->
+        # repo-relative dir of the path/workspace dependency it resolves
+        # to, or None for registry and renamed entries. Gates the member
+        # rewrite to dependencies cargo actually binds to the member.
+        self._rust_pkg_deps: dict[
+            tuple[str, ...], dict[str, tuple[str, ...] | None]
+        ] = {}
         # Inline-mod import scopes minted per file (file qn -> effective qns),
         # so a watch-mode re-parse of the file drops its stale sub-scopes.
         self._rust_inline_scope_keys: dict[str, set[str]] = {}
@@ -1192,19 +1200,23 @@ class ImportProcessor:
         except (OSError, tomllib.TOMLDecodeError):
             return {}
 
-    def _rust_workspace_crate_roots(self) -> dict[str, tuple[tuple[str, ...], str]]:
-        """Workspace member crate names -> (lib-root dir parts, entry stem).
+    def _rust_workspace_crate_roots(
+        self,
+    ) -> dict[str, tuple[tuple[str, ...], tuple[str, ...], str]]:
+        """Workspace crate names -> (package dir, lib-root dir, entry stem).
 
         Cargo resolves a `use` head naming another crate through the
         [dependencies] graph; indexing has no lockfile, so the root
         manifest's workspace members (plus the root package itself, an
         implicit member that integration tests import by name) stand in:
-        every member with a lib target is importable by its [package]
-        name, hyphens spelled as underscores in code (issue #1033).
+        every member with a lib target is importable by its lib name
+        ([package] name unless [lib] name overrides), hyphens spelled as
+        underscores in code (issue #1033). The package dir feeds the
+        per-importer dependency gate.
         """
         if self._rust_workspace_crates is not None:
             return self._rust_workspace_crates
-        mapping: dict[str, tuple[tuple[str, ...], str]] = {}
+        mapping: dict[str, tuple[tuple[str, ...], tuple[str, ...], str]] = {}
         for member in self._rust_workspace_member_dirs():
             manifest = self._rust_read_manifest(member)
             package = manifest.get(cs.RS_MANIFEST_PACKAGE_KEY)
@@ -1220,8 +1232,13 @@ class ImportProcessor:
                 name = lib_name
             if not isinstance(name, str) or not name:
                 continue
+            try:
+                pkg = member.relative_to(self.repo_path).parts
+            except ValueError:
+                continue
             if (root := self._rust_member_lib_root(member, manifest)) is not None:
-                mapping[name.replace(cs.CHAR_HYPHEN, cs.CHAR_UNDERSCORE)] = root
+                key = name.replace(cs.CHAR_HYPHEN, cs.CHAR_UNDERSCORE)
+                mapping[key] = (pkg, *root)
         self._rust_workspace_crates = mapping
         return mapping
 
@@ -1266,6 +1283,108 @@ class ImportProcessor:
         if cs.LIB_RS in self._rust_dir_entries(member / cs.LANG_SRC_DIR):
             return (*rel, cs.LANG_SRC_DIR), "lib"
         return None
+
+    def _rust_enclosing_package(self, module_qn: str) -> tuple[str, ...] | None:
+        # The nearest ancestor directory holding a Cargo.toml, from the
+        # module's own directory upward (inline-mod qn segments probe
+        # nonexistent dirs harmlessly on the way).
+        parts = module_qn.split(cs.SEPARATOR_DOT)[1:]
+        for i in range(len(parts), -1, -1):
+            if cs.PKG_CARGO_TOML in self._rust_dir_entries(
+                self.repo_path.joinpath(*parts[:i])
+            ):
+                return tuple(parts[:i])
+        return None
+
+    def _rust_package_deps(
+        self, pkg_parts: tuple[str, ...]
+    ) -> dict[str, tuple[str, ...] | None]:
+        if (cached := self._rust_pkg_deps.get(pkg_parts)) is not None:
+            return cached
+        manifest = self._rust_read_manifest(self.repo_path.joinpath(*pkg_parts))
+        tables = [manifest]
+        target = manifest.get(cs.RS_MANIFEST_TARGET_TABLE_KEY)
+        if isinstance(target, dict):
+            tables.extend(t for t in target.values() if isinstance(t, dict))
+        deps: dict[str, tuple[str, ...] | None] = {}
+        for table in tables:
+            for section in cs.RS_MANIFEST_DEP_SECTIONS:
+                entries = table.get(section)
+                if not isinstance(entries, dict):
+                    continue
+                for key, value in entries.items():
+                    name = key.replace(cs.CHAR_HYPHEN, cs.CHAR_UNDERSCORE)
+                    resolved = self._rust_dep_target_dir(pkg_parts, key, value)
+                    # A path target from any section wins over a
+                    # registry spelling elsewhere (version + path in one
+                    # entry is the common published-workspace shape).
+                    if resolved is not None or name not in deps:
+                        deps[name] = resolved
+        self._rust_pkg_deps[pkg_parts] = deps
+        return deps
+
+    def _rust_dep_target_dir(
+        self, pkg_parts: tuple[str, ...], key: str, value: str | dict[str, object]
+    ) -> tuple[str, ...] | None:
+        # Repo-relative dir of the package this dependency entry binds
+        # to, or None when it resolves outside the repo (registry
+        # version, git, renamed `package =` entries stay out of scope).
+        if not isinstance(value, dict):
+            return None
+        if cs.RS_MANIFEST_PACKAGE_KEY in value:
+            return None
+        base = self.repo_path.joinpath(*pkg_parts)
+        if value.get(cs.RS_MANIFEST_WORKSPACE_KEY) is True:
+            workspace = self._rust_read_manifest(self.repo_path).get(
+                cs.RS_MANIFEST_WORKSPACE_KEY
+            )
+            entry = (
+                workspace.get(cs.RS_MANIFEST_DEP_SECTIONS[0], {}).get(key)
+                if isinstance(workspace, dict)
+                else None
+            )
+            if not isinstance(entry, dict):
+                return None
+            value = entry
+            base = self.repo_path
+        path = value.get(cs.RS_MANIFEST_PATH_KEY)
+        if not isinstance(path, str):
+            return None
+        try:
+            return (
+                (base / _rust_norm_manifest_path(path))
+                .resolve()
+                .relative_to(self.repo_path.resolve())
+                .parts
+            )
+        except (OSError, ValueError):
+            return None
+
+    def _rust_member_rewrite_allowed(
+        self, member_pkg: tuple[str, ...], module_qn: str
+    ) -> bool:
+        # Cargo binds a crate-name head only to a dependency the
+        # importing package declares, or to the package's OWN lib (its
+        # integration tests, benches, and bins import it by name): a
+        # same-named registry dependency keeps the head external.
+        importer_pkg = self._rust_enclosing_package(module_qn)
+        if importer_pkg is None or importer_pkg == member_pkg:
+            return True
+        return member_pkg in self._rust_package_deps(importer_pkg).values()
+
+    def rust_head_is_external_dep(self, head: str, module_qn: str) -> bool:
+        """Whether the importer's manifest proves this head external.
+
+        A dependency entry that resolves to no repo directory (registry
+        version, git, renamed package) speaks for the name, so the call
+        resolver can decide a drop instead of leaving the trie to guess
+        (issue #1033).
+        """
+        pkg = self._rust_enclosing_package(module_qn)
+        if pkg is None:
+            return False
+        deps = self._rust_package_deps(pkg)
+        return head in deps and deps[head] is None
 
     def _rust_crate_root(self, module_qn: str) -> tuple[str, list[str]] | None:
         """The file's crate root: ("classic", dir parts) or ("file", qn parts).
@@ -1599,10 +1718,12 @@ class ImportProcessor:
             keep = max(len(base_parts) - depth, 1)
             base = cs.SEPARATOR_DOT.join(base_parts[:keep])
             return self._rust_resolve_relative(base, parts[depth:], module_qn)
-        if head not in local_mods and (
-            (root := self._rust_workspace_crate_roots().get(head)) is not None
+        if (
+            head not in local_mods
+            and (root := self._rust_workspace_crate_roots().get(head)) is not None
+            and self._rust_member_rewrite_allowed(root[0], module_qn)
         ):
-            dir_parts, stem = root
+            _pkg, dir_parts, stem = root
             return self._rust_attach(list(dir_parts), stem, parts[1:], definitive=True)
         return full_path
 
@@ -2144,6 +2265,7 @@ class ImportProcessor:
         self._rust_explicit_targets.clear()
         self._rust_auto_build_flags.clear()
         self._rust_workspace_crates = None
+        self._rust_pkg_deps.clear()
 
     def refresh_rust_path_caches_for(self, file_path: Path, created: bool) -> None:
         # The realtime watcher re-parses through process_file without
@@ -2217,6 +2339,7 @@ class ImportProcessor:
             self._rust_explicit_targets.clear()
             self._rust_auto_build_flags.clear()
             self._rust_workspace_crates = None
+            self._rust_pkg_deps.clear()
             for key, stems in self._rust_entry_mod_decls.items():
                 allowed = {
                     name[: -len(cs.EXT_RS)]

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -1308,20 +1308,28 @@ class ImportProcessor:
             tables.extend(t for t in target.values() if isinstance(t, dict))
         deps: dict[str, tuple[str, ...] | None] = {}
         for table in tables:
-            for section in cs.RS_MANIFEST_DEP_SECTIONS:
-                entries = table.get(section)
-                if not isinstance(entries, dict):
-                    continue
-                for key, value in entries.items():
-                    name = key.replace(cs.CHAR_HYPHEN, cs.CHAR_UNDERSCORE)
-                    resolved = self._rust_dep_target_dir(pkg_parts, key, value)
-                    # A path target from any section wins over a
-                    # registry spelling elsewhere (version + path in one
-                    # entry is the common published-workspace shape).
-                    if resolved is not None or name not in deps:
-                        deps[name] = resolved
+            self._rust_collect_dep_table(pkg_parts, table, deps)
         self._rust_pkg_deps[pkg_parts] = deps
         return deps
+
+    def _rust_collect_dep_table(
+        self,
+        pkg_parts: tuple[str, ...],
+        table: dict,
+        deps: dict[str, tuple[str, ...] | None],
+    ) -> None:
+        for section in cs.RS_MANIFEST_DEP_SECTIONS:
+            entries = table.get(section)
+            if not isinstance(entries, dict):
+                continue
+            for key, value in entries.items():
+                name = key.replace(cs.CHAR_HYPHEN, cs.CHAR_UNDERSCORE)
+                resolved = self._rust_dep_target_dir(pkg_parts, key, value)
+                # A path target from any section wins over a registry
+                # spelling elsewhere (version + path in one entry is the
+                # common published-workspace shape).
+                if resolved is not None or name not in deps:
+                    deps[name] = resolved
 
     def _rust_dep_target_dir(
         self, pkg_parts: tuple[str, ...], key: str, value: str | dict[str, object]
@@ -1687,27 +1695,7 @@ class ImportProcessor:
         parts = full_path.split(cs.SEPARATOR_DOUBLE_COLON)
         head = parts[0]
         if head == cs.RUST_CRATE_KEYWORD:
-            root = self._rust_crate_root(module_qn)
-            rest = parts[1:]
-            if root is None:
-                return (
-                    cs.SEPARATOR_DOT.join([self.project_name, *rest])
-                    if rest
-                    else self.project_name
-                )
-            kind, root_parts = root
-            if kind == "file":
-                # An auto-target crate (src/bin/tool.rs): items and
-                # submodules both nest under the entry file's qn.
-                return cs.SEPARATOR_DOT.join([self.project_name, *root_parts, *rest])
-            if kind == "entry":
-                # An explicit manifest target: the root file IS the entry,
-                # so submodule files sit beside it and items nest in it.
-                return self._rust_attach(
-                    root_parts[:-1], root_parts[-1], rest, definitive=True
-                )
-            stem, definitive = self._rust_entry_stem(root_parts, module_qn)
-            return self._rust_attach(root_parts, stem, rest, definitive)
+            return self._rust_rewrite_crate_path(parts[1:], module_qn)
         if head == cs.KEYWORD_SELF:
             return self._rust_resolve_relative(module_qn, parts[1:], module_qn)
         if head == cs.KEYWORD_SUPER:
@@ -1726,6 +1714,28 @@ class ImportProcessor:
             _pkg, dir_parts, stem = root
             return self._rust_attach(list(dir_parts), stem, parts[1:], definitive=True)
         return full_path
+
+    def _rust_rewrite_crate_path(self, rest: list[str], module_qn: str) -> str:
+        root = self._rust_crate_root(module_qn)
+        if root is None:
+            return (
+                cs.SEPARATOR_DOT.join([self.project_name, *rest])
+                if rest
+                else self.project_name
+            )
+        kind, root_parts = root
+        if kind == "file":
+            # An auto-target crate (src/bin/tool.rs): items and
+            # submodules both nest under the entry file's qn.
+            return cs.SEPARATOR_DOT.join([self.project_name, *root_parts, *rest])
+        if kind == "entry":
+            # An explicit manifest target: the root file IS the entry,
+            # so submodule files sit beside it and items nest in it.
+            return self._rust_attach(
+                root_parts[:-1], root_parts[-1], rest, definitive=True
+            )
+        stem, definitive = self._rust_entry_stem(root_parts, module_qn)
+        return self._rust_attach(root_parts, stem, rest, definitive)
 
     def _module_label(self, module_path: str) -> cs.NodeLabel:
         # #498: import targets outside the project prefix live under the

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -1211,6 +1211,13 @@ class ImportProcessor:
             if not isinstance(package, dict):
                 continue
             name = package.get(cs.RS_MANIFEST_NAME_KEY)
+            # `[lib] name` overrides the import spelling: dependents must
+            # write the lib target's name, not the package's.
+            lib = manifest.get(cs.RS_MANIFEST_LIB_SECTION)
+            if isinstance(lib, dict) and isinstance(
+                lib_name := lib.get(cs.RS_MANIFEST_NAME_KEY), str
+            ):
+                name = lib_name
             if not isinstance(name, str) or not name:
                 continue
             if (root := self._rust_member_lib_root(member, manifest)) is not None:
@@ -1259,20 +1266,6 @@ class ImportProcessor:
         if cs.LIB_RS in self._rust_dir_entries(member / cs.LANG_SRC_DIR):
             return (*rel, cs.LANG_SRC_DIR), "lib"
         return None
-
-    def _rust_uniform_head_is_local(self, head: str, module_qn: str) -> bool:
-        # A uniform-path head binds a sibling module before an extern
-        # crate (`use pool::connect;` beside `mod pool;`, mirroring the
-        # resolver's _rust_local_qn), so a workspace crate name only
-        # claims heads no file-backed local module answers for.
-        head_qn = self._rust_resolve_relative(module_qn, [head], module_qn)
-        parts = head_qn.split(cs.SEPARATOR_DOT)[1:]
-        if not parts:
-            return False
-        directory = self.repo_path.joinpath(*parts[:-1])
-        if f"{parts[-1]}{cs.EXT_RS}" in self._rust_dir_entries(directory):
-            return True
-        return cs.MOD_RS in self._rust_dir_entries(directory / parts[-1])
 
     def _rust_crate_root(self, module_qn: str) -> tuple[str, list[str]] | None:
         """The file's crate root: ("classic", dir parts) or ("file", qn parts).
@@ -1554,7 +1547,12 @@ class ImportProcessor:
             return self._rust_attach(parts[:-1], parts[-1], rest, definitive=True)
         return cs.SEPARATOR_DOT.join([base_qn, *rest]) if rest else base_qn
 
-    def _rewrite_rust_local_use_path(self, full_path: str, module_qn: str) -> str:
+    def _rewrite_rust_local_use_path(
+        self,
+        full_path: str,
+        module_qn: str,
+        local_mods: frozenset[str] = frozenset(),
+    ) -> str:
         """Rewrite a crate::/super::/self:: use path to a project qn.
 
         Stored raw, these paths resolve nowhere: class resolution hands them
@@ -1562,7 +1560,10 @@ class ImportProcessor:
         ExternalModule nodes (crate.flags.Flag) and the override pass never
         links impl methods to their trait (issue #1007). module_qn must be
         the EFFECTIVE module of the use declaration, including inline `mod`
-        blocks. External paths (std::fmt) pass through unchanged.
+        blocks. A head naming a workspace member crate rewrites the same
+        way, unless a `mod` in the declaring scope (local_mods) claims it:
+        rustc binds the local module first (issue #1033). External paths
+        (std::fmt) pass through unchanged.
         """
         parts = full_path.split(cs.SEPARATOR_DOUBLE_COLON)
         head = parts[0]
@@ -1598,8 +1599,8 @@ class ImportProcessor:
             keep = max(len(base_parts) - depth, 1)
             base = cs.SEPARATOR_DOT.join(base_parts[:keep])
             return self._rust_resolve_relative(base, parts[depth:], module_qn)
-        if (root := self._rust_workspace_crate_roots().get(head)) is not None and (
-            not self._rust_uniform_head_is_local(head, module_qn)
+        if head not in local_mods and (
+            (root := self._rust_workspace_crate_roots().get(head)) is not None
         ):
             dir_parts, stem = root
             return self._rust_attach(list(dir_parts), stem, parts[1:], definitive=True)
@@ -2275,9 +2276,12 @@ class ImportProcessor:
             else module_qn
         )
         sub_scope = scope_node is not None or scope_parts != []
+        local_mods = rs_utils.enclosing_mod_names(use_node)
         resolved_imports: dict[str, str] = {}
         for imported_name, full_path in imports.items():
-            resolved = self._rewrite_rust_local_use_path(full_path, resolve_qn)
+            resolved = self._rewrite_rust_local_use_path(
+                full_path, resolve_qn, local_mods
+            )
             resolved_imports[imported_name] = resolved
             if sub_scope:
                 # The generic deferral loop only reads the file-level map;

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -401,6 +401,7 @@ class ImportProcessor:
         "_rust_entry_mod_decls",
         "_rust_explicit_targets",
         "_rust_auto_build_flags",
+        "_rust_workspace_crates",
         "_rust_inline_scope_keys",
         "_rust_pending_fn_scope_uses",
         "rust_fn_scope_imports",
@@ -458,6 +459,14 @@ class ImportProcessor:
         # explicitly, false disables it entirely). Filled alongside the
         # explicit-target parse, cleared with it.
         self._rust_auto_build_flags: dict[tuple[str, ...], bool] = {}
+        # Workspace member crate names (underscore-spelled) -> lib-root
+        # (dir parts, entry stem), so `use grep_searcher::sinks;` rewrites
+        # to a project qn at parse time like crate:: paths do (issue
+        # #1033). Built lazily from the root manifest's members plus the
+        # root package; None until first use, re-None'd on manifest edits.
+        self._rust_workspace_crates: dict[str, tuple[tuple[str, ...], str]] | None = (
+            None
+        )
         # Inline-mod import scopes minted per file (file qn -> effective qns),
         # so a watch-mode re-parse of the file drops its stale sub-scopes.
         self._rust_inline_scope_keys: dict[str, set[str]] = {}
@@ -1141,14 +1150,7 @@ class ImportProcessor:
         if cached is not None:
             return cached
         paths: set[str] = set()
-        try:
-            manifest = tomllib.loads(
-                self.repo_path.joinpath(*pkg_parts, cs.PKG_CARGO_TOML).read_text(
-                    encoding=cs.RS_ENCODING_UTF8, errors="ignore"
-                )
-            )
-        except (OSError, tomllib.TOMLDecodeError):
-            manifest = {}
+        manifest = self._rust_read_manifest(self.repo_path.joinpath(*pkg_parts))
         for section in cs.RS_MANIFEST_TARGET_SECTIONS:
             entries = manifest.get(section)
             if isinstance(entries, dict):
@@ -1179,6 +1181,98 @@ class ImportProcessor:
         result = frozenset(paths)
         self._rust_explicit_targets[pkg_parts] = result
         return result
+
+    def _rust_read_manifest(self, directory: Path) -> dict:
+        try:
+            return tomllib.loads(
+                (directory / cs.PKG_CARGO_TOML).read_text(
+                    encoding=cs.RS_ENCODING_UTF8, errors="ignore"
+                )
+            )
+        except (OSError, tomllib.TOMLDecodeError):
+            return {}
+
+    def _rust_workspace_crate_roots(self) -> dict[str, tuple[tuple[str, ...], str]]:
+        """Workspace member crate names -> (lib-root dir parts, entry stem).
+
+        Cargo resolves a `use` head naming another crate through the
+        [dependencies] graph; indexing has no lockfile, so the root
+        manifest's workspace members (plus the root package itself, an
+        implicit member that integration tests import by name) stand in:
+        every member with a lib target is importable by its [package]
+        name, hyphens spelled as underscores in code (issue #1033).
+        """
+        if self._rust_workspace_crates is not None:
+            return self._rust_workspace_crates
+        mapping: dict[str, tuple[tuple[str, ...], str]] = {}
+        for member in self._rust_workspace_member_dirs():
+            manifest = self._rust_read_manifest(member)
+            package = manifest.get(cs.RS_MANIFEST_PACKAGE_KEY)
+            if not isinstance(package, dict):
+                continue
+            name = package.get(cs.RS_MANIFEST_NAME_KEY)
+            if not isinstance(name, str) or not name:
+                continue
+            if (root := self._rust_member_lib_root(member, manifest)) is not None:
+                mapping[name.replace(cs.CHAR_HYPHEN, cs.CHAR_UNDERSCORE)] = root
+        self._rust_workspace_crates = mapping
+        return mapping
+
+    def _rust_workspace_member_dirs(self) -> list[Path]:
+        dirs = [self.repo_path]
+        workspace = self._rust_read_manifest(self.repo_path).get(
+            cs.RS_MANIFEST_WORKSPACE_KEY
+        )
+        members = (
+            workspace.get(cs.RS_MANIFEST_MEMBERS_KEY)
+            if isinstance(workspace, dict)
+            else None
+        )
+        if not isinstance(members, list):
+            return dirs
+        for pattern in members:
+            if not isinstance(pattern, str):
+                continue
+            try:
+                matches = sorted(self.repo_path.glob(pattern))
+            except (ValueError, NotImplementedError):
+                continue
+            dirs.extend(match for match in matches if match.is_dir())
+        return dirs
+
+    def _rust_member_lib_root(
+        self, member: Path, manifest: dict
+    ) -> tuple[tuple[str, ...], str] | None:
+        # Only a lib target is importable by crate name; a bin-only member
+        # cannot appear as a use head in compiling code.
+        try:
+            rel = member.relative_to(self.repo_path).parts
+        except ValueError:
+            return None
+        lib = manifest.get(cs.RS_MANIFEST_LIB_SECTION)
+        if isinstance(lib, dict) and isinstance(
+            path := lib.get(cs.RS_MANIFEST_PATH_KEY), str
+        ):
+            parts = _rust_norm_manifest_path(path).split(cs.SEPARATOR_SLASH)
+            if parts[-1].endswith(cs.EXT_RS):
+                return (*rel, *parts[:-1]), parts[-1][: -len(cs.EXT_RS)]
+        if cs.LIB_RS in self._rust_dir_entries(member / cs.LANG_SRC_DIR):
+            return (*rel, cs.LANG_SRC_DIR), "lib"
+        return None
+
+    def _rust_uniform_head_is_local(self, head: str, module_qn: str) -> bool:
+        # A uniform-path head binds a sibling module before an extern
+        # crate (`use pool::connect;` beside `mod pool;`, mirroring the
+        # resolver's _rust_local_qn), so a workspace crate name only
+        # claims heads no file-backed local module answers for.
+        head_qn = self._rust_resolve_relative(module_qn, [head], module_qn)
+        parts = head_qn.split(cs.SEPARATOR_DOT)[1:]
+        if not parts:
+            return False
+        directory = self.repo_path.joinpath(*parts[:-1])
+        if f"{parts[-1]}{cs.EXT_RS}" in self._rust_dir_entries(directory):
+            return True
+        return cs.MOD_RS in self._rust_dir_entries(directory / parts[-1])
 
     def _rust_crate_root(self, module_qn: str) -> tuple[str, list[str]] | None:
         """The file's crate root: ("classic", dir parts) or ("file", qn parts).
@@ -1504,6 +1598,11 @@ class ImportProcessor:
             keep = max(len(base_parts) - depth, 1)
             base = cs.SEPARATOR_DOT.join(base_parts[:keep])
             return self._rust_resolve_relative(base, parts[depth:], module_qn)
+        if (root := self._rust_workspace_crate_roots().get(head)) is not None and (
+            not self._rust_uniform_head_is_local(head, module_qn)
+        ):
+            dir_parts, stem = root
+            return self._rust_attach(list(dir_parts), stem, parts[1:], definitive=True)
         return full_path
 
     def _module_label(self, module_path: str) -> cs.NodeLabel:
@@ -2043,6 +2142,7 @@ class ImportProcessor:
         self._rust_entry_mod_decls.clear()
         self._rust_explicit_targets.clear()
         self._rust_auto_build_flags.clear()
+        self._rust_workspace_crates = None
 
     def refresh_rust_path_caches_for(self, file_path: Path, created: bool) -> None:
         # The realtime watcher re-parses through process_file without
@@ -2115,6 +2215,7 @@ class ImportProcessor:
             # their storm protection) untouched.
             self._rust_explicit_targets.clear()
             self._rust_auto_build_flags.clear()
+            self._rust_workspace_crates = None
             for key, stems in self._rust_entry_mod_decls.items():
                 allowed = {
                     name[: -len(cs.EXT_RS)]

--- a/codebase_rag/parsers/rs/utils.py
+++ b/codebase_rag/parsers/rs/utils.py
@@ -332,11 +332,14 @@ def rust_use_scope(node: Node) -> tuple[Node | None, list[str] | None, bool]:
 
 
 def enclosing_mod_names(node: Node) -> frozenset[str]:
-    """Names of `mod` items declared in the node's enclosing scopes.
+    """Names of `mod` items in scope at the node's own module level.
 
     A uniform-path use head binds any `mod` in scope before an extern
     crate, whether file-backed (`mod pool;`) or inline (`mod pool { }`),
-    so callers gate crate-name rewriting on this set (issue #1033).
+    so callers gate crate-name rewriting on this set (issue #1033). The
+    walk stops at the first module boundary: a parent module's items,
+    including the enclosing mod's OWN name, are not in scope inside it
+    (rustc binds `use util::x;` within `mod util { }` to the crate).
     """
     names: set[str] = set()
     current = node.parent
@@ -349,6 +352,10 @@ def enclosing_mod_names(node: Node) -> frozenset[str]:
                 and (text := name_node.text) is not None
             ):
                 names.add(text.decode(cs.RS_ENCODING_UTF8))
+        if current.type == cs.TS_RS_SOURCE_FILE or (
+            current.parent is not None and current.parent.type == cs.TS_RS_MOD_ITEM
+        ):
+            break
         current = current.parent
     return frozenset(names)
 

--- a/codebase_rag/parsers/rs/utils.py
+++ b/codebase_rag/parsers/rs/utils.py
@@ -331,6 +331,28 @@ def rust_use_scope(node: Node) -> tuple[Node | None, list[str] | None, bool]:
     return None, parts, pure
 
 
+def enclosing_mod_names(node: Node) -> frozenset[str]:
+    """Names of `mod` items declared in the node's enclosing scopes.
+
+    A uniform-path use head binds any `mod` in scope before an extern
+    crate, whether file-backed (`mod pool;`) or inline (`mod pool { }`),
+    so callers gate crate-name rewriting on this set (issue #1033).
+    """
+    names: set[str] = set()
+    current = node.parent
+    while current is not None:
+        for sibling in current.named_children:
+            if (
+                sibling.type == cs.TS_RS_MOD_ITEM
+                and (name_node := sibling.child_by_field_name(cs.FIELD_NAME))
+                is not None
+                and (text := name_node.text) is not None
+            ):
+                names.add(text.decode(cs.RS_ENCODING_UTF8))
+        current = current.parent
+    return frozenset(names)
+
+
 def rust_block_scope_holes(
     block: Node,
 ) -> tuple[

--- a/codebase_rag/tests/test_rust_workspace_crate_names.py
+++ b/codebase_rag/tests/test_rust_workspace_crate_names.py
@@ -1,0 +1,207 @@
+"""Workspace member crate names resolve to project qns in Rust use paths.
+
+A `use` whose head names another workspace crate kept its raw `::` path in
+the import mapping: only crate::/super::/self:: paths were rewritten at
+parse time, so a cross-crate call reached its target only by trie luck and
+an external import shadowing a first-party sibling still yielded a
+fabricated edge (issue #1033: ripgrep's `use grep_searcher::sinks;` then
+`sinks::UTF8(...)`).
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.test_rust_crate_path_trait_linking import (
+    _calls,
+    _write,
+    create_and_run_updater,
+)
+
+
+def test_glob_member_module_qualified_call_binds_cross_crate(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # Members declared by glob; the crate name is hyphenated, spoken with
+    # underscores in code. sinks::utf8() must bind the searcher crate's
+    # function, never the caller crate's same-named decoy.
+    project = temp_repo / "rs_ws_glob"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[workspace]\nmembers = ["crates/*"]\n',
+            "crates/searcher/Cargo.toml": (
+                '[package]\nname = "grep-searcher"\nversion = "0.1.0"\n'
+            ),
+            "crates/searcher/src/lib.rs": "pub mod sinks;\n",
+            "crates/searcher/src/sinks.rs": "pub fn utf8() -> i32 {\n    1\n}\n",
+            "crates/core/Cargo.toml": '[package]\nname = "core"\nversion = "0.1.0"\n',
+            "crates/core/src/main.rs": (
+                "mod decoy;\n\n"
+                "use grep_searcher::sinks;\n\n"
+                "fn main() {\n    let _ = sinks::utf8();\n}\n"
+            ),
+            "crates/core/src/decoy.rs": "pub fn utf8() -> i32 {\n    2\n}\n",
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    caller = "rs_ws_glob.crates.core.src.main.main"
+    assert (caller, "rs_ws_glob.crates.searcher.src.sinks.utf8") in calls, calls
+    assert (caller, "rs_ws_glob.crates.core.src.decoy.utf8") not in calls, calls
+
+
+def test_listed_member_direct_item_import_binds(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # Members listed literally; `use util::helper;` imports an item
+    # declared in the member's lib.rs itself.
+    project = temp_repo / "rs_ws_listed"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[workspace]\nmembers = ["app", "util"]\n',
+            "util/Cargo.toml": '[package]\nname = "util"\nversion = "0.1.0"\n',
+            "util/src/lib.rs": "pub fn helper() -> i32 {\n    1\n}\n",
+            "app/Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\n',
+            "app/src/main.rs": (
+                "mod decoy;\n\n"
+                "use util::helper;\n\n"
+                "fn main() {\n    let _ = helper();\n}\n"
+            ),
+            "app/src/decoy.rs": "pub fn helper() -> i32 {\n    2\n}\n",
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    caller = "rs_ws_listed.app.src.main.main"
+    assert (caller, "rs_ws_listed.util.src.lib.helper") in calls, calls
+    assert (caller, "rs_ws_listed.app.src.decoy.helper") not in calls, calls
+
+
+def test_root_package_name_binds_integration_test_import(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # No [workspace] at all: an integration test (tests/*.rs is its own
+    # crate) imports the root package's lib BY NAME, the only way Rust
+    # allows it to.
+    project = temp_repo / "rs_ws_root"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "my-lib"\nversion = "0.1.0"\n',
+            "src/lib.rs": "pub fn engine_run() -> i32 {\n    1\n}\n",
+            "tests/integration.rs": (
+                "use my_lib::engine_run;\n\n"
+                "#[test]\nfn t() {\n    let _ = engine_run();\n}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    assert (
+        "rs_ws_root.tests.integration.t",
+        "rs_ws_root.src.lib.engine_run",
+    ) in calls, calls
+
+
+def test_lib_path_override_roots_member_crate(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # A member whose lib target is repointed by `[lib] path`: the crate
+    # name maps to the named file, not to a src/lib.rs that is absent.
+    project = temp_repo / "rs_ws_libpath"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[workspace]\nmembers = ["engine", "app"]\n',
+            "engine/Cargo.toml": (
+                '[package]\nname = "engine"\nversion = "0.1.0"\n\n'
+                '[lib]\npath = "src/custom.rs"\n'
+            ),
+            "engine/src/custom.rs": "pub fn spin() -> i32 {\n    1\n}\n",
+            "app/Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\n',
+            "app/src/main.rs": (
+                "use engine::spin;\n\nfn main() {\n    let _ = spin();\n}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    assert (
+        "rs_ws_libpath.app.src.main.main",
+        "rs_ws_libpath.engine.src.custom.spin",
+    ) in calls, calls
+
+
+def test_external_import_shadowing_sibling_is_dropped(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `use std::fmt;` binds `fmt` to std in worker.rs; the sibling
+    # src/fmt.rs must not receive the call by bare-name fallback. With
+    # workspace crates resolved at parse time, an import-bound head that
+    # still resolves to no project qn is genuinely external: a decided
+    # drop, not a trie guess.
+    project = temp_repo / "rs_ws_shadow"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "shadow"\nversion = "0.1.0"\n',
+            "src/main.rs": (
+                "mod fmt;\nmod worker;\n\nfn main() {\n"
+                "    let _ = worker::run();\n    let _ = fmt::format();\n}\n"
+            ),
+            "src/worker.rs": (
+                "use std::fmt;\n\n"
+                "pub fn run() -> String {\n"
+                '    fmt::format(format_args!("hi"))\n'
+                "}\n"
+            ),
+            "src/fmt.rs": "pub fn format() -> i32 {\n    2\n}\n",
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    assert (
+        "rs_ws_shadow.src.worker.run",
+        "rs_ws_shadow.src.fmt.format",
+    ) not in calls, calls
+    # main's own unshadowed module-qualified call keeps its edge.
+    assert (
+        "rs_ws_shadow.src.main.main",
+        "rs_ws_shadow.src.fmt.format",
+    ) in calls, calls
+
+
+def test_local_module_head_beats_member_crate_name(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # app has its own `mod util;` and does not depend on the member crate
+    # of the same name: rustc binds the uniform-path head to the local
+    # module, so the member's name must not hijack it.
+    project = temp_repo / "rs_ws_localwins"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[workspace]\nmembers = ["app", "util"]\n',
+            "util/Cargo.toml": '[package]\nname = "util"\nversion = "0.1.0"\n',
+            "util/src/lib.rs": "pub fn helper() -> i32 {\n    1\n}\n",
+            "app/Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\n',
+            "app/src/main.rs": (
+                "mod util;\n\n"
+                "use util::helper;\n\n"
+                "fn main() {\n    let _ = helper();\n}\n"
+            ),
+            "app/src/util.rs": "pub fn helper() -> i32 {\n    2\n}\n",
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    caller = "rs_ws_localwins.app.src.main.main"
+    assert (caller, "rs_ws_localwins.app.src.util.helper") in calls, calls
+    assert (caller, "rs_ws_localwins.util.src.lib.helper") not in calls, calls

--- a/codebase_rag/tests/test_rust_workspace_crate_names.py
+++ b/codebase_rag/tests/test_rust_workspace_crate_names.py
@@ -34,7 +34,10 @@ def test_glob_member_module_qualified_call_binds_cross_crate(
             ),
             "crates/searcher/src/lib.rs": "pub mod sinks;\n",
             "crates/searcher/src/sinks.rs": "pub fn utf8() -> i32 {\n    1\n}\n",
-            "crates/core/Cargo.toml": '[package]\nname = "core"\nversion = "0.1.0"\n',
+            "crates/core/Cargo.toml": (
+                '[package]\nname = "core"\nversion = "0.1.0"\n\n'
+                '[dependencies]\ngrep-searcher = { path = "../searcher" }\n'
+            ),
             "crates/core/src/main.rs": (
                 "mod decoy;\n\n"
                 "use grep_searcher::sinks;\n\n"
@@ -63,7 +66,10 @@ def test_listed_member_direct_item_import_binds(
             "Cargo.toml": '[workspace]\nmembers = ["app", "util"]\n',
             "util/Cargo.toml": '[package]\nname = "util"\nversion = "0.1.0"\n',
             "util/src/lib.rs": "pub fn helper() -> i32 {\n    1\n}\n",
-            "app/Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\n',
+            "app/Cargo.toml": (
+                '[package]\nname = "app"\nversion = "0.1.0"\n\n'
+                '[dependencies]\nutil = { path = "../util" }\n'
+            ),
             "app/src/main.rs": (
                 "mod decoy;\n\n"
                 "use util::helper;\n\n"
@@ -127,7 +133,10 @@ def test_lib_path_override_roots_member_crate(
             ),
             "engine/src/custom.rs": "pub mod gear;\n",
             "engine/src/gear.rs": "pub fn spin() -> i32 {\n    1\n}\n",
-            "app/Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\n',
+            "app/Cargo.toml": (
+                '[package]\nname = "app"\nversion = "0.1.0"\n\n'
+                '[dependencies]\nengine = { path = "../engine" }\n'
+            ),
             "app/src/main.rs": (
                 "mod decoy;\n\n"
                 "use engine::gear;\n\n"
@@ -160,7 +169,10 @@ def test_lib_name_override_binds_by_target_name(
             ),
             "searcher/src/lib.rs": "pub mod sinks;\n",
             "searcher/src/sinks.rs": "pub fn utf8() -> i32 {\n    1\n}\n",
-            "app/Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\n',
+            "app/Cargo.toml": (
+                '[package]\nname = "app"\nversion = "0.1.0"\n\n'
+                '[dependencies]\ngrep-searcher = { path = "../searcher" }\n'
+            ),
             "app/src/main.rs": (
                 "mod decoy;\n\n"
                 "use searcher::sinks;\n\n"
@@ -273,6 +285,76 @@ def test_inline_module_head_beats_member_crate_name(
     caller = "rs_ws_inlinewins.app.src.main.main"
     assert (caller, "rs_ws_inlinewins.app.src.main.util.helper") in calls, calls
     assert (caller, "rs_ws_inlinewins.util.src.lib.helper") not in calls, calls
+
+
+def test_use_inside_same_named_mod_binds_the_crate(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # Inside `mod util { use util::sinks; }` the mod's own name is NOT in
+    # scope, so rustc binds the head to the dependency crate: the scan of
+    # local modules must stop at the module boundary and never collect
+    # the enclosing mod itself.
+    project = temp_repo / "rs_ws_selfmod"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[workspace]\nmembers = ["app", "util"]\n',
+            "util/Cargo.toml": '[package]\nname = "util"\nversion = "0.1.0"\n',
+            "util/src/lib.rs": "pub mod sinks;\n",
+            "util/src/sinks.rs": "pub fn utf8() -> i32 {\n    1\n}\n",
+            "app/Cargo.toml": (
+                '[package]\nname = "app"\nversion = "0.1.0"\n\n'
+                '[dependencies]\nutil = { path = "../util" }\n'
+            ),
+            "app/src/main.rs": (
+                "mod decoy;\n\n"
+                "mod util {\n"
+                "    use util::sinks;\n\n"
+                "    pub fn run() -> i32 {\n        sinks::utf8()\n    }\n"
+                "}\n\n"
+                "fn main() {\n    let _ = util::run();\n}\n"
+            ),
+            "app/src/decoy.rs": "pub fn utf8() -> i32 {\n    2\n}\n",
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    caller = "rs_ws_selfmod.app.src.main.util.run"
+    assert (caller, "rs_ws_selfmod.util.src.sinks.utf8") in calls, calls
+    assert (caller, "rs_ws_selfmod.app.src.decoy.utf8") not in calls, calls
+
+
+def test_registry_dependency_shadows_same_named_member(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The importing package depends on a REGISTRY crate named foo
+    # (version only, no path); an unrelated workspace member of the same
+    # name must not capture the import, and the manifest-proven external
+    # head is a decided drop.
+    project = temp_repo / "rs_ws_registry"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[workspace]\nmembers = ["app", "foo"]\n',
+            "foo/Cargo.toml": '[package]\nname = "foo"\nversion = "0.1.0"\n',
+            "foo/src/lib.rs": "pub fn answer() -> i32 {\n    1\n}\n",
+            "app/Cargo.toml": (
+                '[package]\nname = "app"\nversion = "0.1.0"\n\n'
+                '[dependencies]\nfoo = "1.0"\n'
+            ),
+            "app/src/main.rs": (
+                "use foo;\n\nfn main() {\n    let _ = foo::answer();\n}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    assert (
+        "rs_ws_registry.app.src.main.main",
+        "rs_ws_registry.foo.src.lib.answer",
+    ) not in calls, calls
 
 
 def test_path_dependency_without_workspace_keeps_trie_edge(

--- a/codebase_rag/tests/test_rust_workspace_crate_names.py
+++ b/codebase_rag/tests/test_rust_workspace_crate_names.py
@@ -85,33 +85,37 @@ def test_root_package_name_binds_integration_test_import(
 ) -> None:
     # No [workspace] at all: an integration test (tests/*.rs is its own
     # crate) imports the root package's lib BY NAME, the only way Rust
-    # allows it to.
+    # allows it to. Module-qualified with a same-named decoy, so trie
+    # luck cannot make this pass.
     project = temp_repo / "rs_ws_root"
     _write(
         project,
         {
             "Cargo.toml": '[package]\nname = "my-lib"\nversion = "0.1.0"\n',
-            "src/lib.rs": "pub fn engine_run() -> i32 {\n    1\n}\n",
+            "src/lib.rs": "pub mod api;\npub mod decoy;\n",
+            "src/api.rs": "pub fn engine_run() -> i32 {\n    1\n}\n",
+            "src/decoy.rs": "pub fn engine_run() -> i32 {\n    2\n}\n",
             "tests/integration.rs": (
-                "use my_lib::engine_run;\n\n"
-                "#[test]\nfn t() {\n    let _ = engine_run();\n}\n"
+                "use my_lib::api;\n\n"
+                "#[test]\nfn t() {\n    let _ = api::engine_run();\n}\n"
             ),
         },
     )
     create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
 
     calls = _calls(mock_ingestor)
-    assert (
-        "rs_ws_root.tests.integration.t",
-        "rs_ws_root.src.lib.engine_run",
-    ) in calls, calls
+    caller = "rs_ws_root.tests.integration.t"
+    assert (caller, "rs_ws_root.src.api.engine_run") in calls, calls
+    assert (caller, "rs_ws_root.src.decoy.engine_run") not in calls, calls
 
 
 def test_lib_path_override_roots_member_crate(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:
     # A member whose lib target is repointed by `[lib] path`: the crate
-    # name maps to the named file, not to a src/lib.rs that is absent.
+    # name maps to the named file's crate, whose submodules sit beside
+    # it. Module-qualified with a decoy, so a wrong root cannot pass by
+    # trie luck.
     project = temp_repo / "rs_ws_libpath"
     _write(
         project,
@@ -121,20 +125,56 @@ def test_lib_path_override_roots_member_crate(
                 '[package]\nname = "engine"\nversion = "0.1.0"\n\n'
                 '[lib]\npath = "src/custom.rs"\n'
             ),
-            "engine/src/custom.rs": "pub fn spin() -> i32 {\n    1\n}\n",
+            "engine/src/custom.rs": "pub mod gear;\n",
+            "engine/src/gear.rs": "pub fn spin() -> i32 {\n    1\n}\n",
             "app/Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\n',
             "app/src/main.rs": (
-                "use engine::spin;\n\nfn main() {\n    let _ = spin();\n}\n"
+                "mod decoy;\n\n"
+                "use engine::gear;\n\n"
+                "fn main() {\n    let _ = gear::spin();\n}\n"
             ),
+            "app/src/decoy.rs": "pub fn spin() -> i32 {\n    2\n}\n",
         },
     )
     create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
 
     calls = _calls(mock_ingestor)
-    assert (
-        "rs_ws_libpath.app.src.main.main",
-        "rs_ws_libpath.engine.src.custom.spin",
-    ) in calls, calls
+    caller = "rs_ws_libpath.app.src.main.main"
+    assert (caller, "rs_ws_libpath.engine.src.gear.spin") in calls, calls
+    assert (caller, "rs_ws_libpath.app.src.decoy.spin") not in calls, calls
+
+
+def test_lib_name_override_binds_by_target_name(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `[lib] name` overrides the import spelling: dependents must write
+    # the lib target's name, not the package name, so the map keys on it.
+    project = temp_repo / "rs_ws_libname"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[workspace]\nmembers = ["searcher", "app"]\n',
+            "searcher/Cargo.toml": (
+                '[package]\nname = "grep-searcher"\nversion = "0.1.0"\n\n'
+                '[lib]\nname = "searcher"\n'
+            ),
+            "searcher/src/lib.rs": "pub mod sinks;\n",
+            "searcher/src/sinks.rs": "pub fn utf8() -> i32 {\n    1\n}\n",
+            "app/Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\n',
+            "app/src/main.rs": (
+                "mod decoy;\n\n"
+                "use searcher::sinks;\n\n"
+                "fn main() {\n    let _ = sinks::utf8();\n}\n"
+            ),
+            "app/src/decoy.rs": "pub fn utf8() -> i32 {\n    2\n}\n",
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    caller = "rs_ws_libname.app.src.main.main"
+    assert (caller, "rs_ws_libname.searcher.src.sinks.utf8") in calls, calls
+    assert (caller, "rs_ws_libname.app.src.decoy.utf8") not in calls, calls
 
 
 def test_external_import_shadowing_sibling_is_dropped(
@@ -205,3 +245,65 @@ def test_local_module_head_beats_member_crate_name(
     caller = "rs_ws_localwins.app.src.main.main"
     assert (caller, "rs_ws_localwins.app.src.util.helper") in calls, calls
     assert (caller, "rs_ws_localwins.util.src.lib.helper") not in calls, calls
+
+
+def test_inline_module_head_beats_member_crate_name(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The local module rustc binds may be INLINE, with no backing file:
+    # the member crate name must not hijack the head.
+    project = temp_repo / "rs_ws_inlinewins"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[workspace]\nmembers = ["app", "util"]\n',
+            "util/Cargo.toml": '[package]\nname = "util"\nversion = "0.1.0"\n',
+            "util/src/lib.rs": "pub fn helper() -> i32 {\n    1\n}\n",
+            "app/Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\n',
+            "app/src/main.rs": (
+                "mod util {\n    pub fn helper() -> i32 {\n        2\n    }\n}\n\n"
+                "use util::helper;\n\n"
+                "fn main() {\n    let _ = helper();\n}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    caller = "rs_ws_inlinewins.app.src.main.main"
+    assert (caller, "rs_ws_inlinewins.app.src.main.util.helper") in calls, calls
+    assert (caller, "rs_ws_inlinewins.util.src.lib.helper") not in calls, calls
+
+
+def test_path_dependency_without_workspace_keeps_trie_edge(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # A path dependency with no [workspace] table is invisible to the
+    # member map, so its head stays unresolved: the probe must stay
+    # UNDECIDED there (the ordinary fallbacks keep the edge), deciding a
+    # drop only for standard-library heads.
+    project = temp_repo / "rs_ws_pathdep"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "consumer"\nversion = "0.1.0"\n\n'
+                '[dependencies]\nhelperlib = { path = "helperlib" }\n'
+            ),
+            "src/main.rs": (
+                "use helperlib::util;\n\nfn main() {\n    let _ = util::work();\n}\n"
+            ),
+            "helperlib/Cargo.toml": (
+                '[package]\nname = "helperlib"\nversion = "0.1.0"\n'
+            ),
+            "helperlib/src/lib.rs": "pub mod util;\n",
+            "helperlib/src/util.rs": "pub fn work() -> i32 {\n    1\n}\n",
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    assert (
+        "rs_ws_pathdep.src.main.main",
+        "rs_ws_pathdep.helperlib.src.util.work",
+    ) in calls, calls

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.534"
+version = "0.0.535"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #1033.

## What

A Rust `use` whose head names another workspace crate kept its raw `::` path in the import mapping: only `crate::`/`super::`/`self::` paths were rewritten to project qns at parse time. Cross-crate calls (`use grep_searcher::sinks;` then `sinks::utf8()`) therefore reached their target only by trie luck, and could bind a same-named decoy in the caller's own crate instead. The same gap forced the module-qualified probe (#1009) to stay undecided whenever a head was import-bound to an unindexed path, so an external import shadowing a first-party sibling (`use std::fmt;` beside `src/fmt.rs`) still let the trie fabricate a first-party edge.

The fix maps workspace member crate names to their lib-crate roots and rewrites member-named use heads to project qns at parse time, exactly as `crate::` paths are. The map is built from the root manifest's `[workspace] members` (globs expanded) plus the root package itself, which is an implicit member that integration test crates (`tests/*.rs`) import by name; each member contributes its `[package] name` with hyphens spelled as underscores, rooted at `src/lib.rs` or the `[lib] path` override, and bin-only members are skipped since compiling code cannot import them by name. A uniform-path head that a file-backed local module answers for stays local, mirroring rustc's binding (`use pool::connect;` beside `mod pool;`). With workspace names resolved, an import-bound head that still resolves to no project qn is genuinely external, so the module-qualified probe now decides a drop there instead of leaving the trie to guess.

Out of scope, per the issue: renamed dependencies (`alias = { package = ... }`) and path dependencies outside the workspace.

## Adversarial review

The single pre-push round produced four findings, all acted on here:

1. The blanket decided-drop for unresolved import-bound heads silently deleted true first-party edges in layouts the member map cannot cover (nested workspace roots, path dependencies without a workspace table, `#[path]` modules). Narrowed: the drop is decided only when the mapped path's head is a standard-library crate (`std`/`core`/`alloc`/`proc_macro`), which is external by construction; every other unresolved head stays undecided so the ordinary fallbacks keep their edges, pinned by a path-dependency test.
2. The local-module guard probed only for file-backed modules, so an inline `mod util { }` lost its head to a same-named member crate. Replaced with a declaration scan of the use node's enclosing scopes (`enclosing_mod_names`), which covers both spellings; pinned by an inline-mod test.
3. The map keyed on `[package] name` where Rust imports by the lib target's name; `[lib] name` now overrides, pinned by its own test.
4. Two tests passed pre-fix by bare-name trie luck; both now assert module-qualified edges against a same-named decoy.

## Greptile findings

Greptile's run verified two further P1s with live cargo harnesses, both fixed here with RED tests:

1. Inside `mod util { use util::sinks; }` the mod's own name is not in scope, so rustc binds the crate; the local-module scan was collecting the enclosing mod's name from the ancestor chain and blocking the rewrite. `enclosing_mod_names` now stops at the first module boundary, matching Rust scoping (a parent module's items are not in scope inside a child).
2. A workspace member could capture a same-named registry dependency. The rewrite is now gated on the importing package's manifest: allowed only when the importer is the member's own package (integration tests, benches, bins importing their lib by name) or declares a path or workspace-inherited dependency resolving to the member's directory. A dependency entry that resolves to no repo directory (registry version, git, renamed `package =`) proves the head external, so the module-qualified probe decides a drop there exactly as for std heads.

## TDD

RED first: eleven fixtures in `test_rust_workspace_crate_names.py`. Three failed before the fix (glob-expanded members with a hyphenated crate name and a same-named decoy, a listed member's direct item import, the std-shadowed sibling now dropped), three more before the adversarial corrections (`[lib] name` override, inline-mod local beating a member name, path dependency keeping its edge), and two before the Greptile fixes (use inside a same-named mod binding the crate, registry dependency shadowing a member). Member fixtures declare their path dependencies, as compiling cargo code must. A live ripgrep re-measure moved 265 to 255: twelve trait impl methods in the regex and pcre2 crates revived through `use grep_matcher::Matcher`, and two candidates newly listed because their only incoming edges were trie fabrications from external calls (`Seq::from_iter` on the registry crate regex-syntax's type had been bound to first-party `TSeq::from_iter`), which the manifest-proven drop now severs. Full suite: 6750 passed, 10 skipped, against a main baseline of 6741 with the same skips.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved Rust workspace and Cargo crate-name resolution, including custom library names and paths.
  * Better distinguishes local modules, workspace crates, path dependencies, and external dependencies.
  * Reduced incorrect links from unresolved standard-library and external imports.
  * Improved handling of nested, inline, and same-named modules.

* **Tests**
  * Added comprehensive coverage for workspace imports, dependency shadowing, custom library configuration, and cross-crate call relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->