### PR TITLE
fix: type Rust iterator-adaptor closure params from the collection's element

### DIFF
--- a/codebase_rag/constants/ast_rust.py
+++ b/codebase_rag/constants/ast_rust.py
@@ -200,3 +200,33 @@ RS_MANIFEST_TARGET_TABLE_KEY = "target"
 # Crates shipped with the toolchain: external by construction, no
 # manifest needed to know a use head naming one is outside the project.
 RS_STDLIB_CRATES = frozenset({"std", "core", "alloc", "proc_macro"})
+
+# Iterator-adaptor closure typing (issue #1045): a closure argument of one
+# of these adaptors receives the sequence's element (by value or
+# reference, indistinguishable for method binding), so its parameter can
+# type from the iterated collection's element type.
+RS_ITER_ADAPTORS = frozenset(
+    {
+        "map",
+        "filter",
+        "for_each",
+        "inspect",
+        "take_while",
+        "skip_while",
+        "filter_map",
+        "find",
+        "position",
+        "any",
+        "all",
+    }
+)
+# Chain hops between the collection and the adaptor that preserve the
+# element type. Element-changing adaptors (enumerate, zip, flat_map) are
+# deliberately absent: crossing one loses the element.
+RS_ITER_NEUTRAL_HOPS = frozenset(
+    {"iter", "into_iter", "iter_mut", "by_ref", "rev", "cloned", "copied"}
+)
+# Sequence containers whose FIRST generic argument is the element type.
+RS_ELEMENT_CONTAINERS = frozenset({"Vec", "VecDeque"})
+TS_RS_ARRAY_TYPE = "array_type"
+RS_FIELD_ELEMENT = "element"

--- a/codebase_rag/constants/ast_rust.py
+++ b/codebase_rag/constants/ast_rust.py
@@ -224,7 +224,7 @@ RS_ITER_ADAPTORS = frozenset(
 # element type. Element-changing adaptors (enumerate, zip, flat_map) are
 # deliberately absent: crossing one loses the element.
 RS_ITER_NEUTRAL_HOPS = frozenset(
-    {"iter", "into_iter", "iter_mut", "by_ref", "rev", "cloned", "copied"}
+    {"iter", "into_iter", "iter_mut", "by_ref", "rev", "cloned", "copied", "filter"}
 )
 # Sequence containers whose FIRST generic argument is the element type.
 RS_ELEMENT_CONTAINERS = frozenset({"Vec", "VecDeque"})

--- a/codebase_rag/constants/ast_rust.py
+++ b/codebase_rag/constants/ast_rust.py
@@ -228,5 +228,7 @@ RS_ITER_NEUTRAL_HOPS = frozenset(
 )
 # Sequence containers whose FIRST generic argument is the element type.
 RS_ELEMENT_CONTAINERS = frozenset({"Vec", "VecDeque"})
+RS_ITER_MAP = "map"
+RS_ITER_COLLECT = "collect"
 TS_RS_ARRAY_TYPE = "array_type"
 RS_FIELD_ELEMENT = "element"

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -2239,27 +2239,27 @@ class CallProcessor:
                     func_node_starts=func_node_starts,
                 )
 
-    def _overlay_match_arm_binding(
+    def _overlay_span_binding(
         self,
         call_name: str,
         call_node: Node,
         local_var_types: dict[str, str] | None,
-        match_arm_bindings: list[tuple[int, int, str, str]],
+        span_bindings: list[tuple[int, int, str, str]],
     ) -> dict[str, str] | None:
-        # If the call's receiver base is a match-arm binding whose arm range
-        # contains this call, overlay that arm's variant type (shadowing the flat
-        # map's last-arm value) so `cmd.apply()` dispatches to the arm's variant.
-        # The innermost (smallest) containing arm wins for nested matches.
+        # If the call's receiver base is a span-scoped binding (match-arm
+        # variant, adaptor-closure parameter) whose range contains this call,
+        # overlay that binding's type, shadowing the flat map's value. The
+        # innermost (smallest) containing span wins for nested scopes.
         if local_var_types is None or cs.SEPARATOR_DOT not in call_name:
             return local_var_types
         base = call_name.split(cs.SEPARATOR_DOT, 1)[0]
         pos = call_node.start_byte
         best: tuple[int, str] | None = None
-        for start, end, name, variant_type in match_arm_bindings:
+        for start, end, name, bound_type in span_bindings:
             if name == base and start <= pos < end:
                 span = end - start
                 if best is None or span < best[0]:
-                    best = (span, variant_type)
+                    best = (span, bound_type)
         if best is None or local_var_types.get(base) == best[1]:
             return local_var_types
         return {**local_var_types, base: best[1]}
@@ -2821,13 +2821,14 @@ class CallProcessor:
         else:
             local_var_types = None
 
-        # Rust match arms often reuse one binding name (`cmd`) for different variant
-        # types; the flat map keeps only the last arm's type. These per-arm scoped
-        # bindings let each call inside an arm resolve against ITS arm's type.
-        match_arm_bindings: list[tuple[int, int, str, str]] = []
+        # Rust match arms and iterator-adaptor closures both reuse one binding
+        # name for different types at different byte ranges (`cmd` per arm;
+        # `|x|` per collection); the flat map keeps only one. These span-scoped
+        # bindings let each call resolve against the binding containing it.
+        span_bindings: list[tuple[int, int, str, str]] = []
         if language == cs.SupportedLanguage.RUST and local_var_types is not None:
-            match_arm_bindings = self._resolver.type_inference.rust_type_inference.collect_match_arm_bindings(
-                caller_node
+            span_bindings = self._resolver.type_inference.collect_rust_span_bindings(
+                caller_node, class_context
             )
 
         caller_spec = (caller_type, cs.KEY_QUALIFIED_NAME, caller_qn)
@@ -3207,9 +3208,9 @@ class CallProcessor:
                 continue
 
             call_var_types = local_var_types
-            if match_arm_bindings:
-                call_var_types = self._overlay_match_arm_binding(
-                    call_name, call_node, local_var_types, match_arm_bindings
+            if span_bindings:
+                call_var_types = self._overlay_span_binding(
+                    call_name, call_node, local_var_types, span_bindings
                 )
 
             if is_cpp:

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -2828,7 +2828,7 @@ class CallProcessor:
         span_bindings: list[tuple[int, int, str, str]] = []
         if language == cs.SupportedLanguage.RUST and local_var_types is not None:
             span_bindings = self._resolver.type_inference.collect_rust_span_bindings(
-                caller_node, class_context
+                caller_node, module_qn, class_context
             )
 
         caller_spec = (caller_type, cs.KEY_QUALIFIED_NAME, caller_qn)

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -165,6 +165,7 @@ class ClassIngestMixin:
     csharp_base_kinds: dict[tuple[str, int], dict[str, str]]
     csharp_type_locations: dict[tuple[str, int], str]
     class_field_guard_inner: dict[str, dict[str, str]]
+    class_field_element_types: dict[str, dict[str, str]]
     method_return_types: dict[str, str]
     interface_implementers: dict[str, set[str]]
     function_locations: dict[FunctionSpanKey, FunctionLocation]
@@ -958,6 +959,8 @@ class ClassIngestMixin:
                 self.class_field_types[class_qn] = field_types
             if guard_inner := rust_engine.build_field_guard_inner_map(class_node):
                 self.class_field_guard_inner[class_qn] = guard_inner
+            if elements := rust_engine.build_field_element_map(class_node):
+                self.class_field_element_types[class_qn] = elements
         elif language == cs.SupportedLanguage.DART:
             # Record Dart field types (`Greeter buddy;`) so a field-typed
             # receiver (`buddy.greet()`, `this.buddy.hail()`) resolves

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -161,6 +161,10 @@ class DefinitionProcessor(
         # the WRAPPER; this inner is applied only when a receiver chain reaches a
         # lock/read/borrow guard accessor (guards do not deref-coerce).
         self.class_field_guard_inner: dict[str, dict[str, str]] = {}
+        # {class_qn: {field_name: element_type}} for Rust sequence fields
+        # (`workers: Vec<Worker>` -> {"workers": "Worker"}), applied only when
+        # an iterator adaptor's closure parameter binds the element (#1045).
+        self.class_field_element_types: dict[str, dict[str, str]] = {}
         # {alias_name: underlying_bare_type} for C++ typedef/using aliases, so a
         # receiver declared with an alias resolves to the aliased class. Collected
         # across all files (an alias in a header is used in a .cc), read by the

--- a/codebase_rag/parsers/factory.py
+++ b/codebase_rag/parsers/factory.py
@@ -125,6 +125,7 @@ class ProcessorFactory:
                 simple_name_lookup=self.simple_name_lookup,
                 class_field_types=self.definition_processor.class_field_types,
                 class_field_guard_inner=self.definition_processor.class_field_guard_inner,
+                class_field_element_types=self.definition_processor.class_field_element_types,
                 method_return_types=self.definition_processor.method_return_types,
                 go_function_return_types=self.definition_processor.go_function_return_types,
                 csharp_partial_groups=self.definition_processor.csharp_partial_groups,

--- a/codebase_rag/parsers/rs/type_inference.py
+++ b/codebase_rag/parsers/rs/type_inference.py
@@ -90,13 +90,21 @@ class RustTypeInferenceEngine:
                 elements[name] = elem
         return elements
 
-    def collect_element_types(self, caller_node: Node) -> dict[str, str]:
+    def collect_element_entries(
+        self, caller_node: Node
+    ) -> list[tuple[str, str, int, int, int]]:
         # Collection-typed parameters and annotated lets -> element type
         # (`workers: Vec<Worker>` / `&[Worker]` -> Worker), feeding the
-        # iterator-adaptor closure-parameter bindings.
-        elements: dict[str, str] = {}
+        # iterator-adaptor closure-parameter bindings. Entries are
+        # (name, element, scope_start, scope_end, decl_end): a let is in
+        # scope only within its enclosing block and only AFTER its own
+        # declaration (Rust shadowing is positional), while parameters
+        # span the whole body from position zero.
+        entries: list[tuple[str, str, int, int, int]] = []
+        body = caller_node.child_by_field_name(cs.FIELD_BODY)
+        body_span = (body.start_byte, body.end_byte) if body is not None else (0, 0)
         params = caller_node.child_by_field_name(cs.FIELD_PARAMETERS)
-        if params is not None:
+        if params is not None and body is not None:
             for param in params.children:
                 if param.type != cs.TS_RS_PARAMETER:
                     continue
@@ -111,12 +119,22 @@ class RustTypeInferenceEngine:
                 if (name := safe_decode_text(pattern)) and (
                     elem := _rust_element_type_name(type_node)
                 ):
-                    elements[name] = elem
-        if body := caller_node.child_by_field_name(cs.FIELD_BODY):
-            self._collect_element_lets(body, elements)
-        return elements
+                    entries.append((name, elem, *body_span, 0))
+        if body is not None:
+            self._collect_element_lets(body, body_span, entries)
+        return entries
 
-    def _collect_element_lets(self, node: Node, elements: dict[str, str]) -> None:
+    def _collect_element_lets(
+        self,
+        node: Node,
+        scope: tuple[int, int],
+        entries: list[tuple[str, str, int, int, int]],
+    ) -> None:
+        if node.type == cs.TS_RS_FUNCTION_ITEM:
+            # A nested fn item shares no scope with the enclosing body:
+            # its lets must not leak out (closures DO share attribution
+            # scope and keep descending, span-gated by their block).
+            return
         if node.type == cs.TS_RS_LET_DECLARATION:
             pattern = node.child_by_field_name(cs.TS_FIELD_PATTERN)
             if (
@@ -130,21 +148,42 @@ class RustTypeInferenceEngine:
                     if annotation is not None
                     else None
                 )
-                if elem is None:
+                if elem is None and (
+                    annotation is None or self._inferred_container(annotation)
+                ):
                     # `let workers: Vec<_> = ...map(|s| Worker { .. })
-                    # .collect();` leaves the annotation inferred: the
-                    # element is the collect chain's mapped struct literal.
+                    # .collect();` leaves the element inferred: the
+                    # collect chain's mapped struct literal supplies it.
+                    # A NON-sequence annotation (`Result<Vec<T>, E>`)
+                    # stands: the bound value is not a sequence of the
+                    # mapped type.
                     elem = self._collected_element_type(
                         node.child_by_field_name(cs.FIELD_VALUE)
                     )
                 if elem:
-                    elements[name] = elem
+                    entries.append((name, elem, *scope, node.end_byte))
+        child_scope = (
+            (node.start_byte, node.end_byte) if node.type == cs.TS_RS_BLOCK else scope
+        )
         for child in node.children:
-            self._collect_element_lets(child, elements)
+            self._collect_element_lets(child, child_scope, entries)
+
+    def _inferred_container(self, annotation: Node) -> bool:
+        # `Vec<_>` / `VecDeque<_>`: a sequence annotation whose element is
+        # left for inference.
+        if annotation.type != cs.TS_GENERIC_TYPE:
+            return False
+        outer = annotation.child_by_field_name(cs.FIELD_TYPE)
+        outer_name = safe_decode_text(outer) if outer else None
+        return (
+            outer_name in cs.RS_ELEMENT_CONTAINERS
+            and _rust_element_type_name(annotation) is None
+        )
 
     def _collected_element_type(self, value: Node | None) -> str | None:
         # Element type of a `<chain>.map(|..| Type { .. })....collect()`
-        # value: descend receiver hops from `collect` through
+        # value: descend receiver hops from `collect` (plain or turbofish;
+        # a typed `collect::<Vec<Worker>>()` answers directly) through
         # element-preserving adaptors to the nearest `map` whose closure
         # returns a struct literal. Any other hop changes or hides the
         # element, so the walk stops undecided.
@@ -154,12 +193,20 @@ class RustTypeInferenceEngine:
         seen_collect = False
         while node is not None and node.type in cs.RS_CALL_OR_GENERIC_FN:
             func = node.child_by_field_name(cs.FIELD_FUNCTION)
+            turbofish = None
+            if func is not None and func.type == cs.TS_GENERIC_FUNCTION:
+                turbofish = func.child_by_field_name(cs.TS_RS_TYPE_ARGUMENTS)
+                func = func.child_by_field_name(cs.FIELD_FUNCTION)
             if func is None or func.type != cs.TS_RS_FIELD_EXPRESSION:
                 return None
             field = func.child_by_field_name(cs.FIELD_FIELD)
             field_name = safe_decode_text(field) if field else None
             if field_name == cs.RS_ITER_COLLECT and not seen_collect:
                 seen_collect = True
+                if turbofish is not None and (
+                    elem := self._turbofish_element_type(turbofish)
+                ):
+                    return elem
             elif seen_collect and field_name == cs.RS_ITER_MAP:
                 args = node.child_by_field_name(cs.FIELD_ARGUMENTS)
                 return self._closure_struct_literal_type(args)
@@ -167,6 +214,17 @@ class RustTypeInferenceEngine:
                 return None
             node = func.child_by_field_name(cs.FIELD_VALUE)
         return None
+
+    def _turbofish_element_type(self, type_arguments: Node) -> str | None:
+        target = next(
+            (
+                c
+                for c in type_arguments.children
+                if c.type in cs.RS_RETURN_TYPE_NODE_TYPES
+            ),
+            None,
+        )
+        return _rust_element_type_name(target) if target is not None else None
 
     def _closure_struct_literal_type(self, args: Node | None) -> str | None:
         closure = (
@@ -181,7 +239,11 @@ class RustTypeInferenceEngine:
             closure.child_by_field_name(cs.FIELD_BODY) if closure is not None else None
         )
         if body is not None and body.type == cs.TS_RS_BLOCK:
-            named = [c for c in body.named_children]
+            # The block's VALUE is its last expression; trailing comments
+            # are named nodes and must not hide it.
+            named = [
+                c for c in body.named_children if c.type not in cs.RS_COMMENT_TYPES
+            ]
             body = named[-1] if named else None
         if body is not None and body.type == cs.TS_RS_STRUCT_EXPRESSION:
             struct_name = body.child_by_field_name(cs.FIELD_NAME)
@@ -190,7 +252,7 @@ class RustTypeInferenceEngine:
         return None
 
     def collect_closure_param_bindings(
-        self, caller_node: Node, element_types: dict[str, str]
+        self, caller_node: Node, element_entries: list[tuple[str, str, int, int, int]]
     ) -> list[tuple[int, int, str, str]]:
         # Span-scoped closure-parameter types: (closure_start_byte,
         # closure_end_byte, name, type), overlaid at call sites like match
@@ -224,13 +286,13 @@ class RustTypeInferenceEngine:
                         (closure.start_byte, closure.end_byte, name, type_name)
                     )
             if len(bare) == 1 and not annotated:
-                elem = self._adaptor_element_type(closure, element_types)
+                elem = self._adaptor_element_type(closure, element_entries)
                 if elem and (name := safe_decode_text(bare[0])):
                     bindings.append((closure.start_byte, closure.end_byte, name, elem))
         return bindings
 
     def _adaptor_element_type(
-        self, closure: Node, element_types: dict[str, str]
+        self, closure: Node, element_entries: list[tuple[str, str, int, int, int]]
     ) -> str | None:
         parent = closure.parent
         if parent is None or parent.type != cs.TS_ARGUMENTS:
@@ -253,14 +315,34 @@ class RustTypeInferenceEngine:
         # Longest known prefix names the collection (locals are one
         # segment, `self.field` two); everything after it must preserve
         # the element or the closure sees a different type.
+        pos = call.start_byte
         for k in range(len(segments), 0, -1):
             key = cs.SEPARATOR_DOT.join(segments[:k])
-            if (elem := element_types.get(key)) is not None:
+            if (elem := self._element_at(key, pos, element_entries)) is not None:
                 hops = segments[k:]
                 if all(hop in cs.RS_ITER_NEUTRAL_HOPS for hop in hops):
                     return elem
                 return None
         return None
+
+    def _element_at(
+        self,
+        key: str,
+        pos: int,
+        element_entries: list[tuple[str, str, int, int, int]],
+    ) -> str | None:
+        # The binding visible for `key` at byte position `pos`: entries
+        # whose scope contains the position and whose declaration precedes
+        # it; the innermost scope wins, later declarations shadow earlier
+        # ones within it.
+        best: tuple[int, int, str] | None = None
+        for name, elem, start, end, decl_end in element_entries:
+            if name != key or not (start <= pos < end) or pos < decl_end:
+                continue
+            rank = (end - start, -decl_end)
+            if best is None or rank < (best[0], best[1]):
+                best = (end - start, -decl_end, elem)
+        return best[2] if best is not None else None
 
     def _guard_inner_type(self, type_node: Node) -> str | None:
         # `Mutex<State>` / `Arc<Mutex<State>>` -> State; None for a non-guard type.

--- a/codebase_rag/parsers/rs/type_inference.py
+++ b/codebase_rag/parsers/rs/type_inference.py
@@ -69,6 +69,141 @@ class RustTypeInferenceEngine:
                 inners[name] = inner
         return inners
 
+    def build_field_element_map(self, class_node: Node) -> dict[str, str]:
+        # For struct fields holding a sequence (`workers: Vec<Worker>`),
+        # record field -> element type (`workers` -> Worker). The field map
+        # keeps the container (`Vec`); the element applies only when an
+        # iterator adaptor's closure parameter binds it (issue #1045).
+        elements: dict[str, str] = {}
+        field_list = class_node.child_by_field_name(cs.FIELD_BODY)
+        if field_list is None or field_list.type != cs.TS_RS_FIELD_DECLARATION_LIST:
+            return elements
+        for decl in field_list.children:
+            if decl.type != cs.TS_RS_FIELD_DECLARATION:
+                continue
+            name_node = decl.child_by_field_name(cs.FIELD_NAME)
+            type_node = decl.child_by_field_name(cs.FIELD_TYPE)
+            if name_node is None or type_node is None:
+                continue
+            name = safe_decode_text(name_node)
+            if name and (elem := _rust_element_type_name(type_node)):
+                elements[name] = elem
+        return elements
+
+    def collect_element_types(self, caller_node: Node) -> dict[str, str]:
+        # Collection-typed parameters and annotated lets -> element type
+        # (`workers: Vec<Worker>` / `&[Worker]` -> Worker), feeding the
+        # iterator-adaptor closure-parameter bindings.
+        elements: dict[str, str] = {}
+        params = caller_node.child_by_field_name(cs.FIELD_PARAMETERS)
+        if params is not None:
+            for param in params.children:
+                if param.type != cs.TS_RS_PARAMETER:
+                    continue
+                pattern = param.child_by_field_name(cs.TS_FIELD_PATTERN)
+                type_node = param.child_by_field_name(cs.FIELD_TYPE)
+                if (
+                    pattern is None
+                    or pattern.type != cs.TS_IDENTIFIER
+                    or type_node is None
+                ):
+                    continue
+                if (name := safe_decode_text(pattern)) and (
+                    elem := _rust_element_type_name(type_node)
+                ):
+                    elements[name] = elem
+        if body := caller_node.child_by_field_name(cs.FIELD_BODY):
+            self._collect_element_lets(body, elements)
+        return elements
+
+    def _collect_element_lets(self, node: Node, elements: dict[str, str]) -> None:
+        if node.type == cs.TS_RS_LET_DECLARATION:
+            pattern = node.child_by_field_name(cs.TS_FIELD_PATTERN)
+            annotation = node.child_by_field_name(cs.FIELD_TYPE)
+            if (
+                pattern is not None
+                and pattern.type == cs.TS_IDENTIFIER
+                and annotation is not None
+                and (name := safe_decode_text(pattern))
+                and (elem := _rust_element_type_name(annotation))
+            ):
+                elements[name] = elem
+        for child in node.children:
+            self._collect_element_lets(child, elements)
+
+    def collect_closure_param_bindings(
+        self, caller_node: Node, element_types: dict[str, str]
+    ) -> list[tuple[int, int, str, str]]:
+        # Span-scoped closure-parameter types: (closure_start_byte,
+        # closure_end_byte, name, type), overlaid at call sites like match
+        # arms. An explicit `|w: Worker|` annotation binds directly; a bare
+        # parameter binds when the closure is the argument of an iterator
+        # adaptor whose receiver chain reaches a collection of known
+        # element type through element-preserving hops (issue #1045).
+        # Calls inside closures attribute to the enclosing fn, so the
+        # enclosing map is exactly where these bindings belong.
+        bindings: list[tuple[int, int, str, str]] = []
+        body = caller_node.child_by_field_name(cs.FIELD_BODY)
+        if body is None:
+            return bindings
+        for closure in self._descendants_of_type(body, cs.TS_RS_CLOSURE_EXPRESSION):
+            params = closure.child_by_field_name(cs.FIELD_PARAMETERS)
+            if params is None:
+                continue
+            annotated = [c for c in params.children if c.type == cs.TS_RS_PARAMETER]
+            bare = [c for c in params.children if c.type == cs.TS_IDENTIFIER]
+            for param in annotated:
+                pattern = param.child_by_field_name(cs.TS_FIELD_PATTERN)
+                type_node = param.child_by_field_name(cs.FIELD_TYPE)
+                if (
+                    pattern is not None
+                    and pattern.type == cs.TS_IDENTIFIER
+                    and type_node is not None
+                    and (name := safe_decode_text(pattern))
+                    and (type_name := self._bare_type_name(type_node))
+                ):
+                    bindings.append(
+                        (closure.start_byte, closure.end_byte, name, type_name)
+                    )
+            if len(bare) == 1 and not annotated:
+                elem = self._adaptor_element_type(closure, element_types)
+                if elem and (name := safe_decode_text(bare[0])):
+                    bindings.append((closure.start_byte, closure.end_byte, name, elem))
+        return bindings
+
+    def _adaptor_element_type(
+        self, closure: Node, element_types: dict[str, str]
+    ) -> str | None:
+        parent = closure.parent
+        if parent is None or parent.type != cs.TS_ARGUMENTS:
+            return None
+        call = parent.parent
+        if call is None or call.type != cs.TS_RS_CALL_EXPRESSION:
+            return None
+        func = call.child_by_field_name(cs.FIELD_FUNCTION)
+        if func is None or func.type != cs.TS_RS_FIELD_EXPRESSION:
+            return None
+        field = func.child_by_field_name(cs.FIELD_FIELD)
+        if not field or safe_decode_text(field) not in cs.RS_ITER_ADAPTORS:
+            return None
+        receiver = func.child_by_field_name(cs.FIELD_VALUE)
+        if receiver is None:
+            return None
+        segments = self._callee_chain_segments(receiver)
+        if not segments:
+            return None
+        # Longest known prefix names the collection (locals are one
+        # segment, `self.field` two); everything after it must preserve
+        # the element or the closure sees a different type.
+        for k in range(len(segments), 0, -1):
+            key = cs.SEPARATOR_DOT.join(segments[:k])
+            if (elem := element_types.get(key)) is not None:
+                hops = segments[k:]
+                if all(hop in cs.RS_ITER_NEUTRAL_HOPS for hop in hops):
+                    return elem
+                return None
+        return None
+
     def _guard_inner_type(self, type_node: Node) -> str | None:
         # `Mutex<State>` / `Arc<Mutex<State>>` -> State; None for a non-guard type.
         # A guard wrapped in a deref pointer (`Arc<Mutex<T>>`) still unwraps to its
@@ -303,6 +438,52 @@ def _rust_bare_generic_name(type_node: Node) -> str | None:
         None,
     )
     return _rust_bare_type_name(inner) if inner else outer_name
+
+
+def _rust_element_type_name(type_node: Node) -> str | None:
+    # Element type of a sequence-shaped type, or None: `Vec<Worker>` /
+    # `&[Worker]` / `[Worker; 4]` -> Worker, recursing through references
+    # and transparent deref pointers (`Arc<Vec<Worker>>`, `Box<[Worker]>`).
+    match type_node.type:
+        case cs.TS_RS_REFERENCE_TYPE:
+            for child in type_node.children:
+                if (
+                    child.type in cs.RS_RETURN_TYPE_NODE_TYPES
+                    or child.type == cs.TS_RS_ARRAY_TYPE
+                ):
+                    return _rust_element_type_name(child)
+            return None
+        case cs.TS_RS_ARRAY_TYPE:
+            element = type_node.child_by_field_name(cs.RS_FIELD_ELEMENT)
+            return _rust_bare_type_name(element) if element else None
+        case cs.TS_GENERIC_TYPE:
+            outer = type_node.child_by_field_name(cs.FIELD_TYPE)
+            outer_name = safe_decode_text(outer) if outer else None
+            args = type_node.child_by_field_name(cs.TS_RS_TYPE_ARGUMENTS)
+            inner = (
+                next(
+                    (
+                        c
+                        for c in args.children
+                        if c.type in cs.RS_RETURN_TYPE_NODE_TYPES
+                        or c.type == cs.TS_RS_ARRAY_TYPE
+                    ),
+                    None,
+                )
+                if args is not None
+                else None
+            )
+            if inner is None:
+                return None
+            if outer_name in cs.RS_ELEMENT_CONTAINERS:
+                if inner.type == cs.TS_RS_ARRAY_TYPE:
+                    return _rust_element_type_name(inner)
+                return _rust_bare_type_name(inner)
+            if outer_name in cs.RS_DEREF_WRAPPERS:
+                return _rust_element_type_name(inner)
+            return None
+        case _:
+            return None
 
 
 def _rust_bare_type_name(type_node: Node) -> str | None:

--- a/codebase_rag/parsers/rs/type_inference.py
+++ b/codebase_rag/parsers/rs/type_inference.py
@@ -102,27 +102,33 @@ class RustTypeInferenceEngine:
         # span the whole body from position zero.
         entries: list[tuple[str, str, int, int, int]] = []
         body = caller_node.child_by_field_name(cs.FIELD_BODY)
-        body_span = (body.start_byte, body.end_byte) if body is not None else (0, 0)
-        params = caller_node.child_by_field_name(cs.FIELD_PARAMETERS)
-        if params is not None and body is not None:
-            for param in params.children:
-                if param.type != cs.TS_RS_PARAMETER:
-                    continue
-                pattern = param.child_by_field_name(cs.TS_FIELD_PATTERN)
-                type_node = param.child_by_field_name(cs.FIELD_TYPE)
-                if (
-                    pattern is None
-                    or pattern.type != cs.TS_IDENTIFIER
-                    or type_node is None
-                ):
-                    continue
-                if (name := safe_decode_text(pattern)) and (
-                    elem := _rust_element_type_name(type_node)
-                ):
-                    entries.append((name, elem, *body_span, 0))
-        if body is not None:
-            self._collect_element_lets(body, body_span, entries)
+        if body is None:
+            return entries
+        body_span = (body.start_byte, body.end_byte)
+        self._collect_element_params(caller_node, body_span, entries)
+        self._collect_element_lets(body, body_span, entries)
         return entries
+
+    def _collect_element_params(
+        self,
+        caller_node: Node,
+        span: tuple[int, int],
+        entries: list[tuple[str, str, int, int, int]],
+    ) -> None:
+        params = caller_node.child_by_field_name(cs.FIELD_PARAMETERS)
+        if params is None:
+            return
+        for param in params.children:
+            if param.type != cs.TS_RS_PARAMETER:
+                continue
+            pattern = param.child_by_field_name(cs.TS_FIELD_PATTERN)
+            type_node = param.child_by_field_name(cs.FIELD_TYPE)
+            if pattern is None or pattern.type != cs.TS_IDENTIFIER or type_node is None:
+                continue
+            if (name := safe_decode_text(pattern)) and (
+                elem := _rust_element_type_name(type_node)
+            ):
+                entries.append((name, elem, *span, 0))
 
     def _collect_element_lets(
         self,
@@ -136,37 +142,40 @@ class RustTypeInferenceEngine:
             # scope and keep descending, span-gated by their block).
             return
         if node.type == cs.TS_RS_LET_DECLARATION:
-            pattern = node.child_by_field_name(cs.TS_FIELD_PATTERN)
-            if (
-                pattern is not None
-                and pattern.type == cs.TS_IDENTIFIER
-                and (name := safe_decode_text(pattern))
-            ):
-                annotation = node.child_by_field_name(cs.FIELD_TYPE)
-                elem = (
-                    _rust_element_type_name(annotation)
-                    if annotation is not None
-                    else None
-                )
-                if elem is None and (
-                    annotation is None or self._inferred_container(annotation)
-                ):
-                    # `let workers: Vec<_> = ...map(|s| Worker { .. })
-                    # .collect();` leaves the element inferred: the
-                    # collect chain's mapped struct literal supplies it.
-                    # A NON-sequence annotation (`Result<Vec<T>, E>`)
-                    # stands: the bound value is not a sequence of the
-                    # mapped type.
-                    elem = self._collected_element_type(
-                        node.child_by_field_name(cs.FIELD_VALUE)
-                    )
-                if elem:
-                    entries.append((name, elem, *scope, node.end_byte))
+            self._element_let_entry(node, scope, entries)
         child_scope = (
             (node.start_byte, node.end_byte) if node.type == cs.TS_RS_BLOCK else scope
         )
         for child in node.children:
             self._collect_element_lets(child, child_scope, entries)
+
+    def _element_let_entry(
+        self,
+        node: Node,
+        scope: tuple[int, int],
+        entries: list[tuple[str, str, int, int, int]],
+    ) -> None:
+        pattern = node.child_by_field_name(cs.TS_FIELD_PATTERN)
+        if pattern is None or pattern.type != cs.TS_IDENTIFIER:
+            return
+        name = safe_decode_text(pattern)
+        if not name:
+            return
+        annotation = node.child_by_field_name(cs.FIELD_TYPE)
+        elem = _rust_element_type_name(annotation) if annotation is not None else None
+        if elem is None and (
+            annotation is None or self._inferred_container(annotation)
+        ):
+            # `let workers: Vec<_> = ...map(|s| Worker { .. }).collect();`
+            # leaves the element inferred: the collect chain's mapped
+            # struct literal supplies it. A NON-sequence annotation
+            # (`Result<Vec<T>, E>`) stands: the bound value is not a
+            # sequence of the mapped type.
+            elem = self._collected_element_type(
+                node.child_by_field_name(cs.FIELD_VALUE)
+            )
+        if elem:
+            entries.append((name, elem, *scope, node.end_byte))
 
     def _inferred_container(self, annotation: Node) -> bool:
         # `Vec<_>` / `VecDeque<_>`: a sequence annotation whose element is
@@ -192,27 +201,42 @@ class RustTypeInferenceEngine:
         node = self._unwrap_try(value)
         seen_collect = False
         while node is not None and node.type in cs.RS_CALL_OR_GENERIC_FN:
-            func = node.child_by_field_name(cs.FIELD_FUNCTION)
-            turbofish = None
-            if func is not None and func.type == cs.TS_GENERIC_FUNCTION:
-                turbofish = func.child_by_field_name(cs.TS_RS_TYPE_ARGUMENTS)
-                func = func.child_by_field_name(cs.FIELD_FUNCTION)
-            if func is None or func.type != cs.TS_RS_FIELD_EXPRESSION:
+            step = self._collect_chain_step(node, seen_collect)
+            if step is None:
                 return None
-            field = func.child_by_field_name(cs.FIELD_FIELD)
-            field_name = safe_decode_text(field) if field else None
-            if field_name == cs.RS_ITER_COLLECT and not seen_collect:
-                seen_collect = True
-                if turbofish is not None and (
-                    elem := self._turbofish_element_type(turbofish)
-                ):
-                    return elem
-            elif seen_collect and field_name == cs.RS_ITER_MAP:
-                args = node.child_by_field_name(cs.FIELD_ARGUMENTS)
-                return self._closure_struct_literal_type(args)
-            elif not (seen_collect and field_name in cs.RS_ITER_NEUTRAL_HOPS):
-                return None
-            node = func.child_by_field_name(cs.FIELD_VALUE)
+            elem, seen_collect, node = step
+            if elem is not None:
+                return elem
+        return None
+
+    def _collect_chain_step(
+        self, node: Node, seen_collect: bool
+    ) -> tuple[str | None, bool, Node | None] | None:
+        # One hop of the collect chain: (found element or None, updated
+        # collect flag, next receiver). None means the chain left the
+        # supported shape entirely.
+        func = node.child_by_field_name(cs.FIELD_FUNCTION)
+        turbofish = None
+        if func is not None and func.type == cs.TS_GENERIC_FUNCTION:
+            turbofish = func.child_by_field_name(cs.TS_RS_TYPE_ARGUMENTS)
+            func = func.child_by_field_name(cs.FIELD_FUNCTION)
+        if func is None or func.type != cs.TS_RS_FIELD_EXPRESSION:
+            return None
+        field = func.child_by_field_name(cs.FIELD_FIELD)
+        field_name = safe_decode_text(field) if field else None
+        receiver = func.child_by_field_name(cs.FIELD_VALUE)
+        if field_name == cs.RS_ITER_COLLECT and not seen_collect:
+            elem = (
+                self._turbofish_element_type(turbofish)
+                if turbofish is not None
+                else None
+            )
+            return elem, True, receiver
+        if seen_collect and field_name == cs.RS_ITER_MAP:
+            args = node.child_by_field_name(cs.FIELD_ARGUMENTS)
+            return self._closure_struct_literal_type(args), True, None
+        if seen_collect and field_name in cs.RS_ITER_NEUTRAL_HOPS:
+            return None, True, receiver
         return None
 
     def _turbofish_element_type(self, type_arguments: Node) -> str | None:
@@ -266,34 +290,99 @@ class RustTypeInferenceEngine:
         body = caller_node.child_by_field_name(cs.FIELD_BODY)
         if body is None:
             return bindings
-        for closure in self._descendants_of_type(body, cs.TS_RS_CLOSURE_EXPRESSION):
+        closures = self._descendants_of_type(body, cs.TS_RS_CLOSURE_EXPRESSION)
+        shadows = self._closure_shadow_spans(closures)
+        for closure in closures:
             params = closure.child_by_field_name(cs.FIELD_PARAMETERS)
             if params is None:
                 continue
             annotated = [c for c in params.children if c.type == cs.TS_RS_PARAMETER]
             bare = [c for c in params.children if c.type == cs.TS_IDENTIFIER]
-            for param in annotated:
-                pattern = param.child_by_field_name(cs.TS_FIELD_PATTERN)
-                type_node = param.child_by_field_name(cs.FIELD_TYPE)
-                if (
-                    pattern is not None
-                    and pattern.type == cs.TS_IDENTIFIER
-                    and type_node is not None
-                    and (name := safe_decode_text(pattern))
-                    and (type_name := self._bare_type_name(type_node))
-                ):
-                    bindings.append(
-                        (closure.start_byte, closure.end_byte, name, type_name)
-                    )
+            self._annotated_param_bindings(closure, annotated, bindings)
             if len(bare) == 1 and not annotated:
-                elem = self._adaptor_element_type(closure, element_entries)
+                elem = self._adaptor_element_type(closure, element_entries, shadows)
                 if elem and (name := safe_decode_text(bare[0])):
                     bindings.append((closure.start_byte, closure.end_byte, name, elem))
         return bindings
 
+    def _annotated_param_bindings(
+        self,
+        closure: Node,
+        annotated: list[Node],
+        bindings: list[tuple[int, int, str, str]],
+    ) -> None:
+        for param in annotated:
+            pattern = param.child_by_field_name(cs.TS_FIELD_PATTERN)
+            type_node = param.child_by_field_name(cs.FIELD_TYPE)
+            if (
+                pattern is not None
+                and pattern.type == cs.TS_IDENTIFIER
+                and type_node is not None
+                and (name := safe_decode_text(pattern))
+                and (type_name := self._bare_type_name(type_node))
+            ):
+                bindings.append((closure.start_byte, closure.end_byte, name, type_name))
+
+    def _closure_shadow_spans(self, closures: list[Node]) -> list[tuple[str, int, int]]:
+        # Every name a closure's parameter list binds shadows same-named
+        # outer collections within the closure's span: `|items|` over one
+        # collection hides a fn param `items`, so the inner adaptor's
+        # receiver is the closure's binding, not the outer entry.
+        shadows: list[tuple[str, int, int]] = []
+        for closure in closures:
+            params = closure.child_by_field_name(cs.FIELD_PARAMETERS)
+            if params is None:
+                continue
+            for name in self._closure_bound_names(params):
+                shadows.append((name, closure.start_byte, closure.end_byte))
+        return shadows
+
+    def _closure_bound_names(self, params: Node) -> set[str]:
+        # All identifiers a closure parameter list binds: bare params,
+        # annotated params' pattern side, and pattern contents (`|(i, w)|`).
+        names: set[str] = set()
+        for child in params.children:
+            target: Node | None = child
+            if child.type == cs.TS_RS_PARAMETER:
+                target = child.child_by_field_name(cs.TS_FIELD_PATTERN)
+            if target is None:
+                continue
+            if target.type == cs.TS_IDENTIFIER:
+                if text := safe_decode_text(target):
+                    names.add(text)
+                continue
+            for ident in self._descendants_of_type(target, cs.TS_IDENTIFIER):
+                if text := safe_decode_text(ident):
+                    names.add(text)
+        return names
+
     def _adaptor_element_type(
-        self, closure: Node, element_entries: list[tuple[str, str, int, int, int]]
+        self,
+        closure: Node,
+        element_entries: list[tuple[str, str, int, int, int]],
+        shadows: list[tuple[str, int, int]],
     ) -> str | None:
+        receiver = self._adaptor_receiver(closure)
+        if receiver is None:
+            return None
+        segments, pos = receiver
+        # Longest known prefix names the collection (locals are one
+        # segment, `self.field` two); everything after it must preserve
+        # the element or the closure sees a different type.
+        for k in range(len(segments), 0, -1):
+            key = cs.SEPARATOR_DOT.join(segments[:k])
+            elem = self._element_at(key, pos, element_entries, shadows)
+            if elem is not None:
+                hops = segments[k:]
+                if all(hop in cs.RS_ITER_NEUTRAL_HOPS for hop in hops):
+                    return elem
+                return None
+        return None
+
+    def _adaptor_receiver(self, closure: Node) -> tuple[list[str], int] | None:
+        # The receiver chain of the iterator adaptor this closure is an
+        # argument of, with the adaptor call's position: None when the
+        # closure sits anywhere else.
         parent = closure.parent
         if parent is None or parent.type != cs.TS_ARGUMENTS:
             return None
@@ -306,38 +395,32 @@ class RustTypeInferenceEngine:
         field = func.child_by_field_name(cs.FIELD_FIELD)
         if not field or safe_decode_text(field) not in cs.RS_ITER_ADAPTORS:
             return None
-        receiver = func.child_by_field_name(cs.FIELD_VALUE)
-        if receiver is None:
-            return None
-        segments = self._callee_chain_segments(receiver)
+        value = func.child_by_field_name(cs.FIELD_VALUE)
+        segments = self._callee_chain_segments(value) if value is not None else None
         if not segments:
             return None
-        # Longest known prefix names the collection (locals are one
-        # segment, `self.field` two); everything after it must preserve
-        # the element or the closure sees a different type.
-        pos = call.start_byte
-        for k in range(len(segments), 0, -1):
-            key = cs.SEPARATOR_DOT.join(segments[:k])
-            if (elem := self._element_at(key, pos, element_entries)) is not None:
-                hops = segments[k:]
-                if all(hop in cs.RS_ITER_NEUTRAL_HOPS for hop in hops):
-                    return elem
-                return None
-        return None
+        return segments, call.start_byte
 
     def _element_at(
         self,
         key: str,
         pos: int,
         element_entries: list[tuple[str, str, int, int, int]],
+        shadows: list[tuple[str, int, int]],
     ) -> str | None:
         # The binding visible for `key` at byte position `pos`: entries
         # whose scope contains the position and whose declaration precedes
         # it; the innermost scope wins, later declarations shadow earlier
-        # ones within it.
+        # ones within it. An enclosing closure PARAMETER of the same name
+        # hides every entry declared outside that closure.
         best: tuple[int, int, str] | None = None
         for name, elem, start, end, decl_end in element_entries:
             if name != key or not (start <= pos < end) or pos < decl_end:
+                continue
+            if any(
+                sname == key and s0 <= pos < s1 and start < s0
+                for sname, s0, s1 in shadows
+            ):
                 continue
             rank = (end - start, -decl_end)
             if best is None or rank < (best[0], best[1]):
@@ -597,36 +680,40 @@ def _rust_element_type_name(type_node: Node) -> str | None:
             element = type_node.child_by_field_name(cs.RS_FIELD_ELEMENT)
             return _rust_bare_type_name(element) if element else None
         case cs.TS_GENERIC_TYPE:
-            outer = type_node.child_by_field_name(cs.FIELD_TYPE)
-            outer_name = safe_decode_text(outer) if outer else None
-            args = type_node.child_by_field_name(cs.TS_RS_TYPE_ARGUMENTS)
-            inner = (
-                next(
-                    (
-                        c
-                        for c in args.children
-                        if c.type in cs.RS_RETURN_TYPE_NODE_TYPES
-                        or c.type == cs.TS_RS_ARRAY_TYPE
-                    ),
-                    None,
-                )
-                if args is not None
-                else None
-            )
-            if inner is None:
-                return None
-            if outer_name in cs.RS_ELEMENT_CONTAINERS:
-                if inner.type == cs.TS_RS_ARRAY_TYPE:
-                    return _rust_element_type_name(inner)
-                name = _rust_bare_type_name(inner)
-                # `Vec<_>` leaves the element inferred: no type, so the
-                # caller may derive it from the value expression instead.
-                return None if name == cs.CHAR_UNDERSCORE else name
-            if outer_name in cs.RS_DEREF_WRAPPERS:
-                return _rust_element_type_name(inner)
-            return None
+            return _rust_generic_element_name(type_node)
         case _:
             return None
+
+
+def _rust_generic_element_name(type_node: Node) -> str | None:
+    outer = type_node.child_by_field_name(cs.FIELD_TYPE)
+    outer_name = safe_decode_text(outer) if outer else None
+    args = type_node.child_by_field_name(cs.TS_RS_TYPE_ARGUMENTS)
+    inner = (
+        next(
+            (
+                c
+                for c in args.children
+                if c.type in cs.RS_RETURN_TYPE_NODE_TYPES
+                or c.type == cs.TS_RS_ARRAY_TYPE
+            ),
+            None,
+        )
+        if args is not None
+        else None
+    )
+    if inner is None:
+        return None
+    if outer_name in cs.RS_ELEMENT_CONTAINERS:
+        if inner.type == cs.TS_RS_ARRAY_TYPE:
+            return _rust_element_type_name(inner)
+        name = _rust_bare_type_name(inner)
+        # `Vec<_>` leaves the element inferred: no type, so the caller
+        # may derive it from the value expression instead.
+        return None if name == cs.CHAR_UNDERSCORE else name
+    if outer_name in cs.RS_DEREF_WRAPPERS:
+        return _rust_element_type_name(inner)
+    return None
 
 
 def _rust_bare_type_name(type_node: Node) -> str | None:

--- a/codebase_rag/parsers/rs/type_inference.py
+++ b/codebase_rag/parsers/rs/type_inference.py
@@ -119,17 +119,75 @@ class RustTypeInferenceEngine:
     def _collect_element_lets(self, node: Node, elements: dict[str, str]) -> None:
         if node.type == cs.TS_RS_LET_DECLARATION:
             pattern = node.child_by_field_name(cs.TS_FIELD_PATTERN)
-            annotation = node.child_by_field_name(cs.FIELD_TYPE)
             if (
                 pattern is not None
                 and pattern.type == cs.TS_IDENTIFIER
-                and annotation is not None
                 and (name := safe_decode_text(pattern))
-                and (elem := _rust_element_type_name(annotation))
             ):
-                elements[name] = elem
+                annotation = node.child_by_field_name(cs.FIELD_TYPE)
+                elem = (
+                    _rust_element_type_name(annotation)
+                    if annotation is not None
+                    else None
+                )
+                if elem is None:
+                    # `let workers: Vec<_> = ...map(|s| Worker { .. })
+                    # .collect();` leaves the annotation inferred: the
+                    # element is the collect chain's mapped struct literal.
+                    elem = self._collected_element_type(
+                        node.child_by_field_name(cs.FIELD_VALUE)
+                    )
+                if elem:
+                    elements[name] = elem
         for child in node.children:
             self._collect_element_lets(child, elements)
+
+    def _collected_element_type(self, value: Node | None) -> str | None:
+        # Element type of a `<chain>.map(|..| Type { .. })....collect()`
+        # value: descend receiver hops from `collect` through
+        # element-preserving adaptors to the nearest `map` whose closure
+        # returns a struct literal. Any other hop changes or hides the
+        # element, so the walk stops undecided.
+        if value is None:
+            return None
+        node = self._unwrap_try(value)
+        seen_collect = False
+        while node is not None and node.type in cs.RS_CALL_OR_GENERIC_FN:
+            func = node.child_by_field_name(cs.FIELD_FUNCTION)
+            if func is None or func.type != cs.TS_RS_FIELD_EXPRESSION:
+                return None
+            field = func.child_by_field_name(cs.FIELD_FIELD)
+            field_name = safe_decode_text(field) if field else None
+            if field_name == cs.RS_ITER_COLLECT and not seen_collect:
+                seen_collect = True
+            elif seen_collect and field_name == cs.RS_ITER_MAP:
+                args = node.child_by_field_name(cs.FIELD_ARGUMENTS)
+                return self._closure_struct_literal_type(args)
+            elif not (seen_collect and field_name in cs.RS_ITER_NEUTRAL_HOPS):
+                return None
+            node = func.child_by_field_name(cs.FIELD_VALUE)
+        return None
+
+    def _closure_struct_literal_type(self, args: Node | None) -> str | None:
+        closure = (
+            next(
+                (c for c in args.children if c.type == cs.TS_RS_CLOSURE_EXPRESSION),
+                None,
+            )
+            if args is not None
+            else None
+        )
+        body = (
+            closure.child_by_field_name(cs.FIELD_BODY) if closure is not None else None
+        )
+        if body is not None and body.type == cs.TS_RS_BLOCK:
+            named = [c for c in body.named_children]
+            body = named[-1] if named else None
+        if body is not None and body.type == cs.TS_RS_STRUCT_EXPRESSION:
+            struct_name = body.child_by_field_name(cs.FIELD_NAME)
+            if struct_name is not None:
+                return self._bare_type_name(struct_name)
+        return None
 
     def collect_closure_param_bindings(
         self, caller_node: Node, element_types: dict[str, str]
@@ -478,7 +536,10 @@ def _rust_element_type_name(type_node: Node) -> str | None:
             if outer_name in cs.RS_ELEMENT_CONTAINERS:
                 if inner.type == cs.TS_RS_ARRAY_TYPE:
                     return _rust_element_type_name(inner)
-                return _rust_bare_type_name(inner)
+                name = _rust_bare_type_name(inner)
+                # `Vec<_>` leaves the element inferred: no type, so the
+                # caller may derive it from the value expression instead.
+                return None if name == cs.CHAR_UNDERSCORE else name
             if outer_name in cs.RS_DEREF_WRAPPERS:
                 return _rust_element_type_name(inner)
             return None

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -334,7 +334,7 @@ class TypeInferenceEngine:
         return local
 
     def collect_rust_span_bindings(
-        self, caller_node: ASTNode, class_context: str | None
+        self, caller_node: ASTNode, module_qn: str, class_context: str | None
     ) -> list[tuple[int, int, str, str]]:
         """Span-scoped Rust bindings overlaid at each call's position.
 
@@ -343,22 +343,35 @@ class TypeInferenceEngine:
         different byte ranges, which the flat map cannot express. Element
         types come from the caller's own collection-typed params/lets plus
         its class's sequence fields, keyed `self.<field>` exactly as the
-        flat map spells field receivers.
+        flat map spells field receivers. Closure bindings whose type does
+        NOT resolve to a registered class from this module are dropped: a
+        type parameter (`Vec<T>`) or a name invisible here would let the
+        external-receiver guard delete the edge the trie fallback still
+        finds, so an unresolvable binding is strictly worse than none.
         """
         engine = self.rust_type_inference
         bindings = engine.collect_match_arm_bindings(caller_node)
-        element_types = engine.collect_element_types(caller_node)
+        element_entries = engine.collect_element_entries(caller_node)
         if class_context:
+            span = (caller_node.start_byte, caller_node.end_byte)
             for field, elem in self.class_field_element_types.get(
                 class_context, {}
             ).items():
-                element_types.setdefault(
-                    f"{cs.KEYWORD_SELF}{cs.SEPARATOR_DOT}{field}", elem
+                element_entries.append(
+                    (f"{cs.KEYWORD_SELF}{cs.SEPARATOR_DOT}{field}", elem, *span, 0)
                 )
         bindings.extend(
-            engine.collect_closure_param_bindings(caller_node, element_types)
+            binding
+            for binding in engine.collect_closure_param_bindings(
+                caller_node, element_entries
+            )
+            if self._rust_binding_type_resolves(binding[3], module_qn)
         )
         return bindings
+
+    def _rust_binding_type_resolves(self, type_name: str, module_qn: str) -> bool:
+        qn = self._resolve_rust_type_qn(type_name, module_qn)
+        return self.function_registry.get(qn) is not None
 
     def _enrich_dart_call_locals(
         self, caller_node: ASTNode, var_types: dict[str, str]

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -41,6 +41,7 @@ class TypeInferenceEngine:
         "simple_name_lookup",
         "class_field_types",
         "class_field_guard_inner",
+        "class_field_element_types",
         "method_return_types",
         "go_function_return_types",
         "csharp_partial_groups",
@@ -79,6 +80,7 @@ class TypeInferenceEngine:
         simple_name_lookup: SimpleNameLookup,
         class_field_types: dict[str, dict[str, str]] | None = None,
         class_field_guard_inner: dict[str, dict[str, str]] | None = None,
+        class_field_element_types: dict[str, dict[str, str]] | None = None,
         method_return_types: dict[str, str] | None = None,
         go_function_return_types: dict[str, str] | None = None,
         csharp_partial_groups: dict[str, list[str]] | None = None,
@@ -114,6 +116,13 @@ class TypeInferenceEngine:
         # guard-accessor hop so a direct wrapper call isn't mis-resolved to it.
         self.class_field_guard_inner = (
             class_field_guard_inner if class_field_guard_inner is not None else {}
+        )
+        # Shared reference (as with class_field_types): Rust sequence-field
+        # element types (`Pool.workers` -> Worker for a `Vec<Worker>` field),
+        # applied only when an iterator adaptor's closure parameter binds the
+        # element (issue #1045).
+        self.class_field_element_types = (
+            class_field_element_types if class_field_element_types is not None else {}
         )
         # Shared reference (as with class_field_types): DefinitionProcessor's
         # func_qn -> return-type map, populated during ingestion and read by the
@@ -323,6 +332,33 @@ class TypeInferenceEngine:
         elif language == cs.SupportedLanguage.DART:
             self._enrich_dart_call_locals(caller_node, local)
         return local
+
+    def collect_rust_span_bindings(
+        self, caller_node: ASTNode, class_context: str | None
+    ) -> list[tuple[int, int, str, str]]:
+        """Span-scoped Rust bindings overlaid at each call's position.
+
+        Match-arm variant bindings plus iterator-adaptor closure-parameter
+        bindings (issue #1045): both rebind one name to different types at
+        different byte ranges, which the flat map cannot express. Element
+        types come from the caller's own collection-typed params/lets plus
+        its class's sequence fields, keyed `self.<field>` exactly as the
+        flat map spells field receivers.
+        """
+        engine = self.rust_type_inference
+        bindings = engine.collect_match_arm_bindings(caller_node)
+        element_types = engine.collect_element_types(caller_node)
+        if class_context:
+            for field, elem in self.class_field_element_types.get(
+                class_context, {}
+            ).items():
+                element_types.setdefault(
+                    f"{cs.KEYWORD_SELF}{cs.SEPARATOR_DOT}{field}", elem
+                )
+        bindings.extend(
+            engine.collect_closure_param_bindings(caller_node, element_types)
+        )
+        return bindings
 
     def _enrich_dart_call_locals(
         self, caller_node: ASTNode, var_types: dict[str, str]

--- a/codebase_rag/tests/test_rust_iter_closure_param_typing.py
+++ b/codebase_rag/tests/test_rust_iter_closure_param_typing.py
@@ -497,3 +497,24 @@ def test_turbofish_collect_types_element(rust_fn_parser) -> None:
     entries = RustTypeInferenceEngine().collect_element_entries(fn)
     assert [e for e in entries if e[0] == "a" and e[1] == "Worker"], entries
     assert [e for e in entries if e[0] == "b" and e[1] == "Worker"], entries
+
+
+def test_enclosing_closure_param_shadows_collection(rust_fn_parser) -> None:
+    # An enclosing closure parameter shadowing a collection name hides
+    # the function-level entry: the inner adaptor's receiver is the
+    # closure's binding, whose element the engine does not know, so the
+    # inner parameter must stay unbound rather than type from the
+    # shadowed outer collection.
+    fn = rust_fn_parser(
+        "pub fn drive(items: Vec<Worker>, groups: Vec<Group>) {\n"
+        "    groups.into_iter().for_each(|items| {\n"
+        "        items.iter().for_each(|x| {\n"
+        "            x.run();\n"
+        "        });\n"
+        "    });\n"
+        "}\n"
+    )
+    engine = RustTypeInferenceEngine()
+    entries = engine.collect_element_entries(fn)
+    bindings = engine.collect_closure_param_bindings(fn, entries)
+    assert not [b for b in bindings if b[2] == "x"], bindings

--- a/codebase_rag/tests/test_rust_iter_closure_param_typing.py
+++ b/codebase_rag/tests/test_rust_iter_closure_param_typing.py
@@ -1,0 +1,200 @@
+"""Iterator-adaptor closure parameters type from the collection's element.
+
+A closure bound by an iterator adaptor over a collection of known element
+type (`workers.into_iter().map(|worker| ...)`) never typed its parameter,
+so method calls on it resolved to nothing: ripgrep's `Worker::run` had
+zero incoming CALLS and the whole parallel-walk machinery reported dead
+(issue #1045). Calls inside closures attribute to the enclosing function,
+so bindings overlay the caller's map span-gated, like match arms.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.test_rust_crate_path_trait_linking import (
+    _calls,
+    _write,
+    create_and_run_updater,
+)
+
+_CARGO = '[package]\nname = "rs_iterclosure"\nversion = "0.1.0"\n'
+
+_WORKER = (
+    "pub struct Worker {\n    pub id: i32,\n}\n\n"
+    "impl Worker {\n    pub fn run(&self) -> i32 {\n        self.id\n    }\n}\n\n"
+    "pub struct Decoy;\n\n"
+    "impl Decoy {\n    pub fn run(&self) -> i32 {\n        0\n    }\n}\n"
+)
+
+
+def test_map_closure_param_types_from_vec_local(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The ripgrep shape, including the nested capture: the adaptor closure
+    # spawns an inner closure that calls the captured element.
+    project = temp_repo / "rs_ic_local"
+    _write(
+        project,
+        {
+            "Cargo.toml": _CARGO,
+            "src/lib.rs": "pub mod types;\npub mod visit;\n",
+            "src/types.rs": _WORKER,
+            "src/visit.rs": (
+                "use crate::types::Worker;\n\n"
+                "fn run_later<F: Fn() -> i32>(f: F) -> i32 {\n    f()\n}\n\n"
+                "pub fn visit(workers: Vec<Worker>) -> Vec<i32> {\n"
+                "    workers.into_iter().map(|worker| "
+                "run_later(|| worker.run())).collect()\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    base = "rs_ic_local.src"
+    assert (f"{base}.visit.visit", f"{base}.types.Worker.run") in calls, calls
+    assert (f"{base}.visit.visit", f"{base}.types.Decoy.run") not in calls, calls
+
+
+def test_filter_closure_param_types_from_iter(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `iter()` + `filter` hand the closure a reference; method binding is
+    # unaffected by the reference level.
+    project = temp_repo / "rs_ic_filter"
+    _write(
+        project,
+        {
+            "Cargo.toml": _CARGO,
+            "src/lib.rs": "pub mod types;\npub mod scan;\n",
+            "src/types.rs": _WORKER,
+            "src/scan.rs": (
+                "use crate::types::Worker;\n\n"
+                "pub fn scan(workers: Vec<Worker>) -> usize {\n"
+                "    workers.iter().filter(|worker| worker.run() > 0).count()\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    base = "rs_ic_filter.src"
+    assert (f"{base}.scan.scan", f"{base}.types.Worker.run") in calls, calls
+
+
+def test_same_name_closures_bind_their_own_collections(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # Two closures reusing one parameter name over different collections:
+    # each binds ITS collection's element (a flat map would keep only the
+    # last), exactly the match-arm span-overlay contract.
+    project = temp_repo / "rs_ic_spans"
+    _write(
+        project,
+        {
+            "Cargo.toml": _CARGO,
+            "src/lib.rs": "pub mod both;\n",
+            "src/both.rs": (
+                "pub struct Alpha;\n\n"
+                "impl Alpha {\n    pub fn go(&self) -> i32 {\n        1\n    }\n}\n\n"
+                "pub struct Beta;\n\n"
+                "impl Beta {\n    pub fn go(&self) -> i32 {\n        2\n    }\n}\n\n"
+                "pub fn both(aa: Vec<Alpha>, bb: Vec<Beta>) {\n"
+                "    aa.iter().for_each(|x| {\n        x.go();\n    });\n"
+                "    bb.iter().for_each(|x| {\n        x.go();\n    });\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    base = "rs_ic_spans.src.both"
+    assert (f"{base}.both", f"{base}.Alpha.go") in calls, calls
+    assert (f"{base}.both", f"{base}.Beta.go") in calls, calls
+
+
+def test_field_collection_types_closure_param(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The collection is a struct FIELD: `self.workers.iter().for_each(...)`
+    # reads the field's declared element type.
+    project = temp_repo / "rs_ic_field"
+    _write(
+        project,
+        {
+            "Cargo.toml": _CARGO,
+            "src/lib.rs": "pub mod types;\npub mod pool;\n",
+            "src/types.rs": _WORKER,
+            "src/pool.rs": (
+                "use crate::types::Worker;\n\n"
+                "pub struct Pool {\n    pub workers: Vec<Worker>,\n}\n\n"
+                "impl Pool {\n"
+                "    pub fn drive(&self) {\n"
+                "        self.workers.iter().for_each(|worker| {\n"
+                "            worker.run();\n        });\n"
+                "    }\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    base = "rs_ic_field.src"
+    assert (f"{base}.pool.Pool.drive", f"{base}.types.Worker.run") in calls, calls
+
+
+def test_slice_param_types_closure_param(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The collection is a borrowed slice parameter: `&[Worker]`.
+    project = temp_repo / "rs_ic_slice"
+    _write(
+        project,
+        {
+            "Cargo.toml": _CARGO,
+            "src/lib.rs": "pub mod types;\npub mod sum;\n",
+            "src/types.rs": _WORKER,
+            "src/sum.rs": (
+                "use crate::types::Worker;\n\n"
+                "pub fn sum(workers: &[Worker]) -> i32 {\n"
+                "    workers.iter().map(|worker| worker.run()).sum()\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    base = "rs_ic_slice.src"
+    assert (f"{base}.sum.sum", f"{base}.types.Worker.run") in calls, calls
+
+
+def test_annotated_closure_param_uses_its_annotation(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # An explicit `|worker: Worker|` annotation types the parameter even
+    # when the receiver chain offers no element type (a generic iterator).
+    project = temp_repo / "rs_ic_annot"
+    _write(
+        project,
+        {
+            "Cargo.toml": _CARGO,
+            "src/lib.rs": "pub mod types;\npub mod gen;\n",
+            "src/types.rs": _WORKER,
+            "src/gen.rs": (
+                "use crate::types::Worker;\n\n"
+                "pub fn consume<I: Iterator<Item = Worker>>(it: I) -> i32 {\n"
+                "    it.map(|worker: Worker| worker.run()).sum()\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    base = "rs_ic_annot.src"
+    assert (f"{base}.gen.consume", f"{base}.types.Worker.run") in calls, calls

--- a/codebase_rag/tests/test_rust_iter_closure_param_typing.py
+++ b/codebase_rag/tests/test_rust_iter_closure_param_typing.py
@@ -173,6 +173,44 @@ def test_slice_param_types_closure_param(
     assert (f"{base}.sum.sum", f"{base}.types.Worker.run") in calls, calls
 
 
+def test_collected_struct_literals_type_the_collection(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # ripgrep's actual shape: `let workers: Vec<_> = ...map(|s| Worker
+    # { .. }).collect();` — the annotation is inferred, so the element
+    # comes from the collect chain's map closure returning a struct
+    # literal. The later adaptor over `workers` then types its parameter.
+    project = temp_repo / "rs_ic_collect"
+    _write(
+        project,
+        {
+            "Cargo.toml": _CARGO,
+            "src/lib.rs": "pub mod types;\npub mod pool;\n",
+            "src/types.rs": _WORKER,
+            "src/pool.rs": (
+                "use crate::types::Worker;\n\n"
+                "fn run_later<F: Fn() -> i32>(f: F) -> i32 {\n    f()\n}\n\n"
+                "pub fn drive(ids: Vec<i32>) -> Vec<i32> {\n"
+                "    let workers: Vec<_> = ids\n"
+                "        .into_iter()\n"
+                "        .map(|id| Worker { id })\n"
+                "        .collect();\n"
+                "    workers\n"
+                "        .into_iter()\n"
+                "        .map(|worker| run_later(|| worker.run()))\n"
+                "        .collect()\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    base = "rs_ic_collect.src"
+    assert (f"{base}.pool.drive", f"{base}.types.Worker.run") in calls, calls
+    assert (f"{base}.pool.drive", f"{base}.types.Decoy.run") not in calls, calls
+
+
 def test_annotated_closure_param_uses_its_annotation(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:

--- a/codebase_rag/tests/test_rust_iter_closure_param_typing.py
+++ b/codebase_rag/tests/test_rust_iter_closure_param_typing.py
@@ -11,11 +11,29 @@ so bindings overlay the caller's map span-gated, like match arms.
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
+import tree_sitter
+import tree_sitter_rust
+
+from codebase_rag.parsers.rs.type_inference import RustTypeInferenceEngine
 from codebase_rag.tests.test_rust_crate_path_trait_linking import (
     _calls,
     _write,
     create_and_run_updater,
 )
+
+
+@pytest.fixture
+def rust_fn_parser():
+    lang = tree_sitter.Language(tree_sitter_rust.language())
+    parser = tree_sitter.Parser(lang)
+
+    def parse_fn(source: str):
+        tree = parser.parse(source.encode("utf8"))
+        return tree.root_node.children[0]
+
+    return parse_fn
+
 
 _CARGO = '[package]\nname = "rs_iterclosure"\nversion = "0.1.0"\n'
 
@@ -236,3 +254,246 @@ def test_annotated_closure_param_uses_its_annotation(
     calls = _calls(mock_ingestor)
     base = "rs_ic_annot.src"
     assert (f"{base}.gen.consume", f"{base}.types.Worker.run") in calls, calls
+
+
+def test_generic_param_collection_keeps_trie_edge(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `Vec<T>` with T a type parameter: "T" resolves to no registered
+    # class, and a binding to it would let the external-receiver guard
+    # DELETE the edge the trie fallback produces today. Unresolvable
+    # element types must leave the parameter untyped.
+    project = temp_repo / "rs_ic_generic"
+    _write(
+        project,
+        {
+            "Cargo.toml": _CARGO,
+            "src/lib.rs": "pub mod task;\npub mod runner;\n",
+            "src/task.rs": (
+                "pub trait Task {\n    fn execute(&self);\n}\n\n"
+                "pub struct Job;\n\n"
+                "impl Task for Job {\n    fn execute(&self) {}\n}\n"
+            ),
+            "src/runner.rs": (
+                "use crate::task::Task;\n\n"
+                "pub fn run_all<T: Task>(items: Vec<T>) {\n"
+                "    items.iter().for_each(|t| {\n        t.execute();\n    });\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    base = "rs_ic_generic.src"
+    assert (f"{base}.runner.run_all", f"{base}.task.Job.execute") in calls, calls
+
+
+def test_generic_field_collection_keeps_trie_edge(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The generic-element shape on a struct FIELD: `Pool<T> { items:
+    # Vec<T> }` must not bind `T` either.
+    project = temp_repo / "rs_ic_genfield"
+    _write(
+        project,
+        {
+            "Cargo.toml": _CARGO,
+            "src/lib.rs": "pub mod task;\npub mod pool;\n",
+            "src/task.rs": (
+                "pub trait Task {\n    fn execute(&self);\n}\n\n"
+                "pub struct Job;\n\n"
+                "impl Task for Job {\n    fn execute(&self) {}\n}\n"
+            ),
+            "src/pool.rs": (
+                "use crate::task::Task;\n\n"
+                "pub struct Pool<T: Task> {\n    pub items: Vec<T>,\n}\n\n"
+                "impl<T: Task> Pool<T> {\n"
+                "    pub fn drive(&self) {\n"
+                "        self.items.iter().for_each(|t| {\n"
+                "            t.execute();\n        });\n"
+                "    }\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    base = "rs_ic_genfield.src"
+    assert (f"{base}.pool.Pool.drive", f"{base}.task.Job.execute") in calls, calls
+
+
+def test_unresolvable_element_keeps_trie_edges(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `Vec<String>` with a first-party `impl Shout for String` in ANOTHER
+    # module: "String" is a real type but resolves to nothing from the
+    # calling module, so binding it would delete the trie's edges.
+    project = temp_repo / "rs_ic_stdtype"
+    _write(
+        project,
+        {
+            "Cargo.toml": _CARGO,
+            "src/lib.rs": "pub mod ext;\npub mod use_it;\n",
+            "src/ext.rs": (
+                "pub trait Shout {\n    fn shout(&self) -> String;\n}\n\n"
+                "impl Shout for String {\n"
+                "    fn shout(&self) -> String {\n        self.clone()\n    }\n"
+                "}\n"
+            ),
+            "src/use_it.rs": (
+                "use crate::ext::Shout;\n\n"
+                "pub fn all(names: Vec<String>) {\n"
+                "    names.iter().for_each(|n| {\n        n.shout();\n    });\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    base = "rs_ic_stdtype.src"
+    assert (f"{base}.use_it.all", f"{base}.ext.String.shout") in calls, calls
+
+
+def test_nested_fn_let_does_not_leak(temp_repo: Path, mock_ingestor: MagicMock) -> None:
+    # A `let` inside a nested `fn` item shares no scope with the outer
+    # body: its element must not rebind the outer closure's parameter.
+    project = temp_repo / "rs_ic_nestedfn"
+    _write(
+        project,
+        {
+            "Cargo.toml": _CARGO,
+            "src/lib.rs": "pub mod types;\npub mod f;\n",
+            "src/types.rs": _WORKER,
+            "src/f.rs": (
+                "use crate::types::{Decoy, Worker};\n\n"
+                "pub fn go(items: Vec<Decoy>) {\n"
+                "    fn helper() {\n"
+                "        let items: Vec<Worker> = Vec::new();\n"
+                "        let _ = items;\n    }\n"
+                "    helper();\n"
+                "    items.iter().for_each(|x| {\n        x.run();\n    });\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    base = "rs_ic_nestedfn.src"
+    assert (f"{base}.f.go", f"{base}.types.Decoy.run") in calls, calls
+    assert (f"{base}.f.go", f"{base}.types.Worker.run") not in calls, calls
+
+
+def test_later_block_let_does_not_rebind(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # A block-scoped `let` written AFTER the adaptor call is not in scope
+    # for it (position and block span both exclude it).
+    project = temp_repo / "rs_ic_laterlet"
+    _write(
+        project,
+        {
+            "Cargo.toml": _CARGO,
+            "src/lib.rs": "pub mod types;\npub mod f;\n",
+            "src/types.rs": _WORKER,
+            "src/f.rs": (
+                "use crate::types::{Decoy, Worker};\n\n"
+                "pub fn go(items: Vec<Decoy>) {\n"
+                "    items.iter().for_each(|x| {\n        x.run();\n    });\n"
+                "    {\n"
+                "        let items: Vec<_> =\n"
+                "            (0..3).map(|n| Worker { id: n }).collect();\n"
+                "        let _ = items;\n    }\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    base = "rs_ic_laterlet.src"
+    assert (f"{base}.f.go", f"{base}.types.Decoy.run") in calls, calls
+    assert (f"{base}.f.go", f"{base}.types.Worker.run") not in calls, calls
+
+
+def test_filter_hop_preserves_element(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `filter` between the collection and the binding adaptor preserves
+    # the element.
+    project = temp_repo / "rs_ic_filterhop"
+    _write(
+        project,
+        {
+            "Cargo.toml": _CARGO,
+            "src/lib.rs": "pub mod types;\npub mod f;\n",
+            "src/types.rs": _WORKER,
+            "src/f.rs": (
+                "use crate::types::Worker;\n\n"
+                "pub fn go(items: Vec<Worker>) -> Vec<i32> {\n"
+                "    items\n"
+                "        .iter()\n"
+                "        .filter(|w| true)\n"
+                "        .map(|worker| worker.run())\n"
+                "        .collect()\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    base = "rs_ic_filterhop.src"
+    assert (f"{base}.f.go", f"{base}.types.Worker.run") in calls, calls
+
+
+def test_result_annotation_blocks_collect_inference(rust_fn_parser) -> None:
+    # `let v: Result<Vec<Worker>, ()> = ...collect();` names a NON
+    # sequence: the value a later `v.map(|list| ...)` closure receives is
+    # the whole Vec, so the collect chain must not type v's element.
+    fn = rust_fn_parser(
+        "pub fn go(xs: Vec<i32>) {\n"
+        "    let v: Result<Vec<Worker>, ()> ="
+        " xs.iter().map(|x| Worker { id: 1 }).collect();\n"
+        "    let _ = v;\n"
+        "}\n"
+    )
+    entries = RustTypeInferenceEngine().collect_element_entries(fn)
+    assert not [e for e in entries if e[0] == "v"], entries
+
+
+def test_trailing_comment_keeps_struct_literal(rust_fn_parser) -> None:
+    # A trailing comment in the map closure's block must not hide the
+    # struct literal from the collect-chain inference.
+    fn = rust_fn_parser(
+        "pub fn go(xs: Vec<i32>) {\n"
+        "    let v: Vec<_> = xs\n"
+        "        .iter()\n"
+        "        .map(|x| {\n"
+        "            Worker { id: 1 } // build it\n"
+        "        })\n"
+        "        .collect();\n"
+        "    let _ = v;\n"
+        "}\n"
+    )
+    entries = RustTypeInferenceEngine().collect_element_entries(fn)
+    assert [e for e in entries if e[0] == "v" and e[1] == "Worker"], entries
+
+
+def test_turbofish_collect_types_element(rust_fn_parser) -> None:
+    # The turbofish spelling `collect::<Vec<_>>()` types the element from
+    # the mapped struct literal; a typed `collect::<Vec<Worker>>()` reads
+    # it straight from the turbofish.
+    fn = rust_fn_parser(
+        "pub fn go(xs: Vec<i32>) {\n"
+        "    let a = xs.iter().map(|x| Worker { id: 1 }).collect::<Vec<_>>();\n"
+        "    let b = xs.iter().map(make).collect::<Vec<Worker>>();\n"
+        "    let _ = (a, b);\n"
+        "}\n"
+    )
+    entries = RustTypeInferenceEngine().collect_element_entries(fn)
+    assert [e for e in entries if e[0] == "a" and e[1] == "Worker"], entries
+    assert [e for e in entries if e[0] == "b" and e[1] == "Worker"], entries

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.535"
+version = "0.0.536"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #1045.

## What

A Rust closure parameter bound by an iterator adaptor over a collection of known element type never got typed, so method calls on it resolved to nothing. ripgrep's parallel walk is the canonical casualty: `WalkParallel::visit` is live and its closures are rooted, but `worker.run()` inside `.map(|worker| s.spawn(|| worker.run()))` bound nothing, `Worker::run` had zero incoming CALLS, and the entire machinery underneath (worker loop, work items, helpers, their closures) reported dead.

Calls inside closures already attribute to the enclosing function and share its local type map, so the fix adds span-scoped bindings overlaid at each call's byte position, exactly the mechanism match arms already use (the overlay is renamed from match-arm-specific to span bindings, since both rebind one name to different types at different ranges). Three sources feed it:

- An explicit `|worker: Worker|` annotation binds directly.
- A bare parameter binds when the closure is the argument of an element-receiving adaptor (`map`, `filter`, `for_each`, `find`, and friends) whose receiver chain reaches a collection of known element type through element-preserving hops (`iter`, `into_iter`, `iter_mut`, `rev`, `cloned`, `copied`, `by_ref`); element-changing hops such as `enumerate` stop the walk. Element types come from `Vec<T>`/`VecDeque<T>`/slice/array parameters and annotated lets, from struct fields (a `class_field_element_types` map mirroring the guard-inner one, keyed `self.<field>`), and from `let workers: Vec<_> = <chain>.map(|s| Worker { .. }).collect();`, where the element is the collect chain's mapped struct literal (`Vec<_>` counts as no annotation).

Out of scope, per the issue: element types produced by method returns, adaptors that change the element between collection and closure, and `std` combinators on non-collection receivers.

## Adversarial review

The single pre-push round ran both trees over shared fixtures and produced five findings, all acted on here:

1. and 2. (one root cause) A binding whose type resolves to no registered class from the calling module is strictly worse than no binding: the external-receiver guard then deletes the edge the trie fallback still finds. Confirmed for `Vec<T>` with a type parameter (both fn and struct generics) and for a real type invisible in the calling module (`Vec<String>` with a first-party `impl Shout for String` elsewhere). Fixed with a resolution gate on every closure binding, annotated ones included; unresolvable types leave the parameter untyped.
3. Element lets were scope-blind: a `let` inside a nested `fn` item or a later block rebound the outer closure and fabricated an edge. Element sources are now positional entries (enclosing block span plus declaration position; parameters span the whole body), the innermost scope wins and later declarations shadow earlier ones, and nested `fn` items are skipped entirely.
4. The collect-chain fallback discarded a non-sequence annotation (`Result<Vec<T>, E>`): it now runs only when the annotation is absent or an inferred-element container (`Vec<_>`).
5. Three silent misses fixed: trailing comments no longer hide the mapped struct literal, the turbofish `collect::<Vec<_>>()` spelling walks the chain (and a typed `collect::<Vec<Worker>>()` answers directly), and `filter` joined the element-preserving hops.

## TDD

RED first: sixteen tests in `test_rust_iter_closure_param_typing.py`, every one failing before its fix. Seven end-to-end for the feature (the nested-capture ripgrep shape with a decoy method, `filter` over `iter()`, two same-named closures binding their own collections, a struct-field collection, a slice parameter, the collect-chain inferred `Vec<_>`, an explicit annotation on an untypeable generic receiver), six end-to-end plus three engine-level for the review findings. A live ripgrep re-measure moved 255 to 221 and holds there with the hardened code: all 34 resolved candidates are the ignore crate's parallel-walk machinery, none newly exposed. Full suite: 6768 passed, 10 skipped, against a main baseline of 6752 with the same skips.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved Rust code analysis for iterator chains, closures, collections, arrays, slices, and sequence fields.
  * Enhanced type inference across nested scopes, variable shadowing, chained adaptors, explicit annotations, and collected values.
  * Improved call-graph accuracy by resolving calls inside iterator closures and match arms more reliably.

* **Bug Fixes**
  * Preserved fallback call relationships when Rust types cannot be fully resolved.
  * Improved handling of `Result` collections, turbofish syntax, trailing comments, and nested code blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->