### PR TITLE
fix: override QDRANT_URL explicitly so .env cannot force a remote client

### DIFF
--- a/codebase_rag/tests/test_vector_store.py
+++ b/codebase_rag/tests/test_vector_store.py
@@ -512,9 +512,13 @@ def test_process_exit_closes_local_client_cleanly(temp_qdrant_path: Path) -> Non
         capture_output=True,
         text=True,
         env={
-            # An inherited QDRANT_URL would open a remote client and skip
-            # the local-path shutdown this test exists to exercise.
-            **{k: v for k, v in os.environ.items() if k != "QDRANT_URL"},
+            **os.environ,
+            # A QDRANT_URL would open a remote client and skip the local-path
+            # shutdown this test exists to exercise. Dropping the key is not
+            # enough: settings load with env_file=".env", so a checkout whose
+            # .env sets QDRANT_URL still resolves it. Only an explicit empty
+            # value overrides the file, and it is falsy, so the local path wins.
+            "QDRANT_URL": "",
             "QDRANT_DB_PATH": str(temp_qdrant_path),
         },
         timeout=120,

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.536"
+version = "0.0.537"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #1051.

## What

`test_process_exit_closes_local_client_cleanly` exists to exercise the **local-path** client shutdown, and dropped `QDRANT_URL` from the subprocess environment to stop a remote client being opened instead.

Removing a key from `env` cannot override an `env_file` value. Settings load with `env_file=".env"` (`codebase_rag/config.py:153`), so on any checkout whose `.env` sets `QDRANT_URL` (the documented local setup) the value came back regardless and `vector_store.py:157` took the remote branch. With no server listening the test failed with `ResponseHandlingException: [Errno 61] Connection refused`, and the dead client then stalled the whole run in gRPC teardown (`GOAWAY ... ENHANCE_YOUR_CALM`), so the suite never printed a summary.

Passing an explicit empty `QDRANT_URL` overrides the file, and `settings.QDRANT_URL` is truthiness-checked, so the local path is selected exactly as the test intends.

## Verification

Confirmed the mechanism directly before changing anything:

```
# key absent -> .env leaks in -> remote client
env -u QDRANT_URL QDRANT_DB_PATH=/tmp/a python -c '...get_qdrant_client()'
ResponseHandlingException: [Errno 61] Connection refused

# explicit empty -> overrides .env -> local path
QDRANT_URL= QDRANT_DB_PATH=/tmp/b python -c '...get_qdrant_client()'
OK
```

The failure reproduced on `main` as well as on a feature branch, confirming it is pre-existing and environment-driven rather than caused by any code change.

`codebase_rag/tests/test_vector_store.py`: 26 passed (was 25 passed, 1 failed). ruff clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of local vector-store configuration when a remote URL is present in environment settings.
  * Ensured local-path behavior is tested consistently across process environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->