### PR TITLE
fix: dispatch Rust generic-bound receivers through their trait bounds

### DIFF
--- a/codebase_rag/constants/ast_rust.py
+++ b/codebase_rag/constants/ast_rust.py
@@ -26,6 +26,13 @@ TS_RS_IMPL_ITEM = "impl_item"
 TS_RS_FUNCTION_SIGNATURE_ITEM = "function_signature_item"
 TS_RS_CLOSURE_EXPRESSION = "closure_expression"
 TS_RS_UNION_ITEM = "union_item"
+TS_RS_TYPE_PARAMETERS = "type_parameters"
+TS_RS_TYPE_PARAMETER = "type_parameter"
+TS_RS_WHERE_CLAUSE = "where_clause"
+TS_RS_WHERE_PREDICATE = "where_predicate"
+# Items whose generic parameter lists and where clauses put trait bounds in
+# scope for the calls beneath them.
+RS_GENERIC_SCOPE_ITEMS = (TS_RS_FUNCTION_ITEM, TS_RS_IMPL_ITEM, TS_RS_TRAIT_ITEM)
 TS_RS_USE_DECLARATION = "use_declaration"
 TS_RS_EXTERN_CRATE_DECLARATION = "extern_crate_declaration"
 TS_RS_CALL_EXPRESSION = "call_expression"

--- a/codebase_rag/parsers/rs/type_inference.py
+++ b/codebase_rag/parsers/rs/type_inference.py
@@ -465,6 +465,90 @@ class RustTypeInferenceEngine:
             self._collect_call_bindings(body, bindings)
         return bindings
 
+    def collect_generic_bounds(self, caller_node: Node) -> dict[str, list[str]]:
+        # Trait bounds for every generic type parameter in scope at this
+        # caller: the fn's own generics and where clause, then each
+        # enclosing impl/trait block's (a method's field receiver takes its
+        # bound from the impl header). Innermost declaration wins outright:
+        # a fn-level `M` shadows an impl-level `M` entirely, so the outer
+        # list is not merged in. Scoped bound spellings keep their path
+        # (`crate::x::Matcher`); bare names stay bare.
+        bounds: dict[str, list[str]] = {}
+        node: Node | None = caller_node
+        while node is not None:
+            if node.type in cs.RS_GENERIC_SCOPE_ITEMS:
+                for name, spellings in self._item_generic_bounds(node).items():
+                    bounds.setdefault(name, spellings)
+            node = node.parent
+        return bounds
+
+    def _item_generic_bounds(self, item: Node) -> dict[str, list[str]]:
+        # One item's parameter-list bounds (`<M: Matcher + Clone>`) merged
+        # with its where-clause bounds (`where M: Matcher`); a parameter
+        # bounded in both places gets both lists.
+        merged: dict[str, list[str]] = {}
+        if params := item.child_by_field_name(cs.TS_RS_TYPE_PARAMETERS):
+            for param in params.children:
+                if param.type != cs.TS_RS_TYPE_PARAMETER:
+                    continue
+                self._merge_bound_entry(
+                    merged,
+                    param.child_by_field_name(cs.FIELD_NAME),
+                    param.child_by_field_name(cs.FIELD_BOUNDS),
+                )
+        for child in item.children:
+            if child.type != cs.TS_RS_WHERE_CLAUSE:
+                continue
+            for pred in child.children:
+                if pred.type != cs.TS_RS_WHERE_PREDICATE:
+                    continue
+                self._merge_bound_entry(
+                    merged,
+                    pred.child_by_field_name(cs.FIELD_LEFT),
+                    pred.child_by_field_name(cs.FIELD_BOUNDS),
+                )
+        return merged
+
+    def _merge_bound_entry(
+        self,
+        merged: dict[str, list[str]],
+        name_node: Node | None,
+        bounds_node: Node | None,
+    ) -> None:
+        # Only a plain identifier binds a substitutable parameter name: a
+        # where-clause left side like `Self::Item` or `Vec<M>` constrains a
+        # projection, not a bare parameter.
+        if (
+            name_node is None
+            or name_node.type != cs.TS_TYPE_IDENTIFIER
+            or bounds_node is None
+        ):
+            return
+        name = safe_decode_text(name_node)
+        if not name:
+            return
+        spellings = [
+            spelling
+            for child in bounds_node.children
+            if (spelling := self._bound_spelling(child))
+        ]
+        if spellings:
+            merged.setdefault(name, []).extend(spellings)
+
+    def _bound_spelling(self, node: Node) -> str | None:
+        # A bound's usable spelling: a bare trait name as-is, a scoped path
+        # whole (the consumer gates on its head), a generic bound
+        # (`From<NoError>`) by its base path. Lifetimes, `?Sized` markers,
+        # and fn-trait bounds yield nothing.
+        if node.type == cs.TS_TYPE_IDENTIFIER:
+            return safe_decode_text(node)
+        if node.type == cs.TS_RS_SCOPED_TYPE_IDENTIFIER:
+            return safe_decode_text(node)
+        if node.type == cs.TS_GENERIC_TYPE:
+            inner = node.child_by_field_name(cs.FIELD_TYPE)
+            return self._bound_spelling(inner) if inner is not None else None
+        return None
+
     def _collect_parameters(self, caller_node: Node, var_types: dict[str, str]) -> None:
         params = caller_node.child_by_field_name(cs.FIELD_PARAMETERS)
         if params is None:

--- a/codebase_rag/parsers/rs/type_inference.py
+++ b/codebase_rag/parsers/rs/type_inference.py
@@ -537,9 +537,9 @@ class RustTypeInferenceEngine:
 
     def _bound_spelling(self, node: Node) -> str | None:
         # A bound's usable spelling: a bare trait name as-is, a scoped path
-        # whole (the consumer gates on its head), a generic bound
-        # (`From<NoError>`) by its base path. Lifetimes, `?Sized` markers,
-        # and fn-trait bounds yield nothing.
+        # whole (the consumer resolves it strictly by module path), a generic
+        # bound (`From<NoError>`) by its base path. Lifetimes, `?Sized`
+        # markers, and fn-trait bounds yield nothing.
         if node.type == cs.TS_TYPE_IDENTIFIER:
             return safe_decode_text(node)
         if node.type == cs.TS_RS_SCOPED_TYPE_IDENTIFIER:

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -328,11 +328,13 @@ class TypeInferenceEngine:
                     local.setdefault(
                         f"{cs.KEYWORD_SELF}{cs.SEPARATOR_DOT}{field}", ftype
                     )
-            # Substitute BEFORE enrichment only: params, lets, and fields
-            # spell generic names from the caller's own scope chain, but an
+            # Substitute BEFORE enrichment: params, lets, and fields spell
+            # generic names from the caller's own scope chain, but an
             # enriched call-return type (`let x = Maker::make()` with
             # `fn make() -> M`) spells the CALLEE's generic parameter, which
-            # the caller's bounds must not capture.
+            # the caller's bounds must not capture. Sole exception: a
+            # `self.<method>()` return spells the caller's own impl-header
+            # generics, handled inside enrichment.
             self._substitute_rust_generic_bounds(caller_node, module_qn, local)
             self._enrich_rust_call_locals(caller_node, module_qn, local)
         elif language == cs.SupportedLanguage.DART:
@@ -380,30 +382,65 @@ class TypeInferenceEngine:
     ) -> None:
         # A receiver typed as a bare generic parameter (`m: M`, a field `M` of
         # an `impl<M: Matcher>` block) dispatches through the parameter's trait
-        # bound, so rewrite the recorded type to the first bound that resolves
-        # to a registered first-party trait (issue #1047). A parameter whose
-        # bounds resolve to nothing keeps the generic name: the known-external
+        # bound, so rewrite the recorded type to the qn of the first bound that
+        # resolves strictly first-party (issue #1047). A parameter whose bounds
+        # resolve to nothing keeps the generic name: the known-external
         # receiver guard then suppresses the name-based fallback instead of
         # letting it fabricate an edge onto an unrelated same-named method.
         bounds = self.rust_type_inference.collect_generic_bounds(caller_node)
         if not bounds:
             return
-        for name, type_name in var_types.items():
-            for spelling in bounds.get(type_name, ()):
-                if trait := self._rust_bound_trait(spelling, module_qn):
-                    var_types[name] = trait
-                    break
+        for name in var_types:
+            self._apply_rust_generic_bound(bounds, module_qn, var_types, name)
 
-    def _rust_bound_trait(self, spelling: str, module_qn: str) -> str | None:
-        # Only a bare bound spelling substitutes: a scoped path with an
-        # external head (`std::io::Write`) must never reach the simple-name
-        # fallback in _resolve_rust_import_path, which would bind it to an
-        # arbitrary first-party type sharing the leaf name.
+    def _apply_rust_generic_bound(
+        self,
+        bounds: dict[str, list[str]],
+        module_qn: str,
+        var_types: dict[str, str],
+        name: str,
+    ) -> None:
+        for spelling in bounds.get(var_types[name], ()):
+            if trait_qn := self._rust_bound_trait_qn(spelling, module_qn):
+                var_types[name] = trait_qn
+                break
+
+    def _rust_bound_trait_qn(self, spelling: str, module_qn: str) -> str | None:
+        # Resolve a bound spelling STRICTLY to a registered first-party qn;
+        # anything looser fabricates edges: the simple-name fallbacks would
+        # bind `use std::io::Write` + `W: Write` (or a bare prelude `Clone`)
+        # to an arbitrary first-party type sharing the leaf name. The qn goes
+        # into the map directly, so the consumer cannot re-resolve it fuzzily.
         if cs.SEPARATOR_DOUBLE_COLON in spelling:
+            # A scoped bound substitutes only on an exact module-path match.
+            parts = [
+                p
+                for p in spelling.split(cs.SEPARATOR_DOUBLE_COLON)
+                if p not in cs.RS_PATH_KEYWORDS
+            ]
+            qn = self._resolve_rust_import_path(
+                spelling, node_types=(NodeType.INTERFACE,)
+            )
+            suffix = cs.SEPARATOR_DOT + cs.SEPARATOR_DOT.join(parts)
+            if qn.endswith(suffix) and self._rust_registered_trait(qn):
+                return qn
             return None
-        if self._rust_binding_type_resolves(spelling, module_qn):
-            return spelling
-        return None
+        import_map = self.import_processor.import_mapping.get(module_qn, {})
+        if (target := import_map.get(spelling)) is not None:
+            # An external `use` target is a raw `::` path; a first-party one
+            # arrives as an already-resolved project qn.
+            if cs.SEPARATOR_DOUBLE_COLON in target:
+                return None
+            return target if self._rust_registered_trait(target) else None
+        # No import in scope: a bare name is only visible when defined in
+        # this module (a prelude trait lands here and resolves to None).
+        local_qn = f"{module_qn}{cs.SEPARATOR_DOT}{spelling}"
+        return local_qn if self._rust_registered_trait(local_qn) else None
+
+    def _rust_registered_trait(self, qn: str) -> bool:
+        # A Rust bound always names a trait, which registers as INTERFACE;
+        # a same-named struct/enum must never satisfy it.
+        return self.function_registry.get(qn) == NodeType.INTERFACE
 
     def _rust_binding_type_resolves(self, type_name: str, module_qn: str) -> bool:
         qn = self._resolve_rust_type_qn(type_name, module_qn)
@@ -516,6 +553,7 @@ class TypeInferenceEngine:
         # (`let cmd = Command::from_frame(f)?`) with the call's return type, so a
         # later `cmd.apply()` resolves to the real type, not the ambiguous name-only
         # trie fallback. Only fills names not already typed.
+        bounds: dict[str, list[str]] | None = None
         for name, segments in self.rust_type_inference.collect_call_var_bindings(
             caller_node
         ):
@@ -525,6 +563,17 @@ class TypeInferenceEngine:
                 segments, module_qn, var_types
             ):
                 var_types[name] = return_type
+                if len(segments) == 2 and segments[0] == cs.KEYWORD_SELF:
+                    # A `let m = self.get()` callee lives in the caller's own
+                    # impl, whose header generics a method cannot shadow
+                    # (E0403): a generic return spells the CALLER's own
+                    # parameter, so its bound applies. Any other callee's
+                    # generic return stays uncaptured (issue #1047).
+                    if bounds is None:
+                        bounds = self.rust_type_inference.collect_generic_bounds(
+                            caller_node
+                        )
+                    self._apply_rust_generic_bound(bounds, module_qn, var_types, name)
 
     def _infer_rust_call_return_type(
         self, segments: list[str], module_qn: str, var_types: dict[str, str]

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -328,6 +328,12 @@ class TypeInferenceEngine:
                     local.setdefault(
                         f"{cs.KEYWORD_SELF}{cs.SEPARATOR_DOT}{field}", ftype
                     )
+            # Substitute BEFORE enrichment only: params, lets, and fields
+            # spell generic names from the caller's own scope chain, but an
+            # enriched call-return type (`let x = Maker::make()` with
+            # `fn make() -> M`) spells the CALLEE's generic parameter, which
+            # the caller's bounds must not capture.
+            self._substitute_rust_generic_bounds(caller_node, module_qn, local)
             self._enrich_rust_call_locals(caller_node, module_qn, local)
         elif language == cs.SupportedLanguage.DART:
             self._enrich_dart_call_locals(caller_node, local)
@@ -368,6 +374,36 @@ class TypeInferenceEngine:
             if self._rust_binding_type_resolves(binding[3], module_qn)
         )
         return bindings
+
+    def _substitute_rust_generic_bounds(
+        self, caller_node: ASTNode, module_qn: str, var_types: dict[str, str]
+    ) -> None:
+        # A receiver typed as a bare generic parameter (`m: M`, a field `M` of
+        # an `impl<M: Matcher>` block) dispatches through the parameter's trait
+        # bound, so rewrite the recorded type to the first bound that resolves
+        # to a registered first-party trait (issue #1047). A parameter whose
+        # bounds resolve to nothing keeps the generic name: the known-external
+        # receiver guard then suppresses the name-based fallback instead of
+        # letting it fabricate an edge onto an unrelated same-named method.
+        bounds = self.rust_type_inference.collect_generic_bounds(caller_node)
+        if not bounds:
+            return
+        for name, type_name in var_types.items():
+            for spelling in bounds.get(type_name, ()):
+                if trait := self._rust_bound_trait(spelling, module_qn):
+                    var_types[name] = trait
+                    break
+
+    def _rust_bound_trait(self, spelling: str, module_qn: str) -> str | None:
+        # Only a bare bound spelling substitutes: a scoped path with an
+        # external head (`std::io::Write`) must never reach the simple-name
+        # fallback in _resolve_rust_import_path, which would bind it to an
+        # arbitrary first-party type sharing the leaf name.
+        if cs.SEPARATOR_DOUBLE_COLON in spelling:
+            return None
+        if self._rust_binding_type_resolves(spelling, module_qn):
+            return spelling
+        return None
 
     def _rust_binding_type_resolves(self, type_name: str, module_qn: str) -> bool:
         qn = self._resolve_rust_type_qn(type_name, module_qn)

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -387,6 +387,10 @@ class TypeInferenceEngine:
         # resolve to nothing keeps the generic name: the known-external
         # receiver guard then suppresses the name-based fallback instead of
         # letting it fabricate an edge onto an unrelated same-named method.
+        if not var_types:
+            # Nothing recorded to rewrite, so the ancestor walk that collects
+            # the bounds is pure waste.
+            return
         bounds = self.rust_type_inference.collect_generic_bounds(caller_node)
         if not bounds:
             return

--- a/codebase_rag/tests/test_rust_generic_bound_dispatch.py
+++ b/codebase_rag/tests/test_rust_generic_bound_dispatch.py
@@ -66,6 +66,24 @@ pub fn use_decoy(d: Decoy) -> bool {
 pub fn drain<W: std::io::Write>(w: W) -> bool {
     w.poll()
 }
+
+pub struct Maker;
+
+impl Maker {
+    pub fn make<M>() -> M {
+        unimplemented!()
+    }
+}
+
+pub fn capture_guard<M: Matcher>(_m: M) -> bool {
+    let x: M = Maker::make();
+    x.find("k")
+}
+
+pub fn no_capture<M: Matcher>(_m: M) -> bool {
+    let x = Maker::make();
+    x.find("k")
+}
 """
 
 
@@ -133,6 +151,27 @@ def test_direct_inherent_call_still_resolves(
     base = _build(temp_repo, mock_ingestor, "rs_bound_decoy")
     calls = _calls(mock_ingestor)
     assert (f"{base}.use_decoy", f"{base}.Decoy.is_match") in calls, calls
+
+
+def test_annotated_local_substitutes_caller_scope_bound(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `let x: M = ...` spells the CALLER's generic parameter, so the bound
+    # substitution applies to the local exactly as to a parameter.
+    base = _build(temp_repo, mock_ingestor, "rs_bound_let")
+    calls = _calls(mock_ingestor)
+    assert (f"{base}.capture_guard", f"{base}.Matcher.find") in calls, calls
+
+
+def test_callee_return_generic_is_not_captured_by_caller_bounds(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `let x = Maker::make()` types x from the callee's declared return `M`,
+    # which is MAKER's generic parameter; the caller's own `M: Matcher` bound
+    # must not capture it and fabricate a Matcher edge.
+    base = _build(temp_repo, mock_ingestor, "rs_bound_capture")
+    calls = _calls(mock_ingestor)
+    assert (f"{base}.no_capture", f"{base}.Matcher.find") not in calls, calls
 
 
 def test_external_bound_does_not_fabricate_inherent_edge(

--- a/codebase_rag/tests/test_rust_generic_bound_dispatch.py
+++ b/codebase_rag/tests/test_rust_generic_bound_dispatch.py
@@ -1,0 +1,146 @@
+# A method call on a receiver whose type is a generic type parameter never
+# resolved through the parameter's trait bound: the call either vanished
+# (fn params, where clauses) or fell through to the name-based fallback and
+# fabricated an edge onto an unrelated type's inherent method (impl-generic
+# struct fields). Rust dispatches such calls to the bound trait's method, so
+# the edge must target the trait (ripgrep: all seventeen Matcher default
+# methods reported dead; issue #1047).
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.constants import RelationshipType
+from codebase_rag.tests.conftest import create_and_run_updater, get_relationships
+
+_LIB_RS = """\
+pub trait Matcher {
+    fn find(&self, hay: &str) -> bool;
+
+    fn is_match(&self, hay: &str) -> bool {
+        self.find(hay)
+    }
+}
+
+pub fn search<M: Matcher>(m: M) -> bool {
+    m.is_match("x")
+}
+
+pub struct Core<M> {
+    matcher: M,
+}
+
+impl<M: Matcher> Core<M> {
+    pub fn run(&self) -> bool {
+        self.matcher.is_match("y")
+    }
+}
+
+pub fn search_where<M>(m: M) -> bool
+where
+    M: Matcher,
+{
+    m.is_match("z")
+}
+
+pub fn search_multi<M: Matcher + Clone>(m: M) -> bool {
+    m.is_match("v")
+}
+
+pub struct Decoy;
+
+impl Decoy {
+    pub fn is_match(&self, _hay: &str) -> bool {
+        false
+    }
+
+    pub fn poll(&self) -> bool {
+        true
+    }
+}
+
+pub fn use_decoy(d: Decoy) -> bool {
+    d.is_match("w")
+}
+
+pub fn drain<W: std::io::Write>(w: W) -> bool {
+    w.poll()
+}
+"""
+
+
+def _write(project: Path, files: dict[str, str]) -> None:
+    for rel_path, source in files.items():
+        target = project / rel_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(encoding="utf-8", data=source)
+
+
+def _calls(mock_ingestor: MagicMock) -> set[tuple[str, str]]:
+    return {
+        (call[0][0][2], call[0][2][2])
+        for call in get_relationships(mock_ingestor, RelationshipType.CALLS.value)
+    }
+
+
+def _build(temp_repo: Path, mock_ingestor: MagicMock, name: str) -> str:
+    project = temp_repo / name
+    _write(
+        project,
+        {
+            "Cargo.toml": f'[package]\nname = "{name}"\nversion = "0.1.0"\n',
+            "src/lib.rs": _LIB_RS,
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    return f"{name}.src.lib"
+
+
+def test_fn_generic_param_bound_dispatch(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    base = _build(temp_repo, mock_ingestor, "rs_bound_fn")
+    calls = _calls(mock_ingestor)
+    assert (f"{base}.search", f"{base}.Matcher.is_match") in calls, calls
+
+
+def test_where_clause_bound_dispatch(temp_repo: Path, mock_ingestor: MagicMock) -> None:
+    base = _build(temp_repo, mock_ingestor, "rs_bound_where")
+    calls = _calls(mock_ingestor)
+    assert (f"{base}.search_where", f"{base}.Matcher.is_match") in calls, calls
+
+
+def test_multi_bound_resolves_through_first_party_trait(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    base = _build(temp_repo, mock_ingestor, "rs_bound_multi")
+    calls = _calls(mock_ingestor)
+    assert (f"{base}.search_multi", f"{base}.Matcher.is_match") in calls, calls
+
+
+def test_impl_generic_field_bound_dispatch_beats_decoy(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    base = _build(temp_repo, mock_ingestor, "rs_bound_field")
+    calls = _calls(mock_ingestor)
+    assert (f"{base}.Core.run", f"{base}.Matcher.is_match") in calls, calls
+    assert (f"{base}.Core.run", f"{base}.Decoy.is_match") not in calls, calls
+
+
+def test_direct_inherent_call_still_resolves(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    base = _build(temp_repo, mock_ingestor, "rs_bound_decoy")
+    calls = _calls(mock_ingestor)
+    assert (f"{base}.use_decoy", f"{base}.Decoy.is_match") in calls, calls
+
+
+def test_external_bound_does_not_fabricate_inherent_edge(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `W: std::io::Write` names no first-party trait, so `w.poll()` cannot be
+    # a first-party call; the name-based fallback must not bind it to the
+    # unrelated inherent Decoy.poll.
+    base = _build(temp_repo, mock_ingestor, "rs_bound_external")
+    calls = _calls(mock_ingestor)
+    assert (f"{base}.drain", f"{base}.Decoy.poll") not in calls, calls

--- a/codebase_rag/tests/test_rust_generic_bound_dispatch.py
+++ b/codebase_rag/tests/test_rust_generic_bound_dispatch.py
@@ -34,6 +34,15 @@ impl<M: Matcher> Core<M> {
     pub fn run(&self) -> bool {
         self.matcher.is_match("y")
     }
+
+    pub fn get(self) -> M {
+        self.matcher
+    }
+
+    pub fn run_via_get(self) -> bool {
+        let m = self.get();
+        m.is_match("g")
+    }
 }
 
 pub fn search_where<M>(m: M) -> bool
@@ -85,6 +94,67 @@ pub fn no_capture<M: Matcher>(_m: M) -> bool {
     x.find("k")
 }
 """
+
+
+# Multi-module crate: a bound's spelling must resolve STRICTLY (import map,
+# exact module path, or same-module definition); a bare spelling naming an
+# external trait (`use std::io::Write` then `W: Write`, prelude `Clone`) must
+# not fuzzy-bind to an unrelated first-party type sharing the leaf name.
+_MOD_FILES = {
+    "src/lib.rs": "pub mod dom;\npub mod fmtx;\npub mod m;\npub mod sink;\n"
+    "pub mod u;\npub mod u2;\npub mod util;\n",
+    "src/fmtx.rs": """\
+pub struct Write;
+
+impl Write {
+    pub fn flush(&self) -> bool {
+        true
+    }
+}
+""",
+    "src/sink.rs": """\
+use std::io::Write;
+
+pub fn drain<W: Write>(w: W) -> bool {
+    w.flush()
+}
+""",
+    "src/dom.rs": """\
+pub struct Clone;
+
+impl Clone {
+    pub fn poll(&self) -> bool {
+        true
+    }
+}
+""",
+    "src/util.rs": """\
+pub fn dup<T: Clone>(t: T) -> bool {
+    t.poll()
+}
+""",
+    "src/m.rs": """\
+pub trait Matcher {
+    fn find(&self, hay: &str) -> bool;
+
+    fn is_match(&self, hay: &str) -> bool {
+        self.find(hay)
+    }
+}
+""",
+    "src/u.rs": """\
+pub fn go<M: crate::m::Matcher>(m: M) -> bool {
+    m.is_match("q")
+}
+""",
+    "src/u2.rs": """\
+use crate::m::Matcher;
+
+pub fn go2<M: Matcher>(m: M) -> bool {
+    m.is_match("r")
+}
+""",
+}
 
 
 def _write(project: Path, files: dict[str, str]) -> None:
@@ -172,6 +242,65 @@ def test_callee_return_generic_is_not_captured_by_caller_bounds(
     base = _build(temp_repo, mock_ingestor, "rs_bound_capture")
     calls = _calls(mock_ingestor)
     assert (f"{base}.no_capture", f"{base}.Matcher.find") not in calls, calls
+
+
+def _build_modules(temp_repo: Path, mock_ingestor: MagicMock, name: str) -> str:
+    project = temp_repo / name
+    files = {"Cargo.toml": f'[package]\nname = "{name}"\nversion = "0.1.0"\n'}
+    files.update(_MOD_FILES)
+    _write(project, files)
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    return f"{name}.src"
+
+
+def test_bare_imported_external_bound_does_not_substitute(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `use std::io::Write` then `W: Write`: the bound names the EXTERNAL
+    # trait, so the unrelated first-party fmtx::Write must not gain an edge.
+    base = _build_modules(temp_repo, mock_ingestor, "rs_bound_use_ext")
+    calls = _calls(mock_ingestor)
+    assert (f"{base}.sink.drain", f"{base}.fmtx.Write.flush") not in calls, calls
+
+
+def test_prelude_bound_does_not_substitute(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `T: Clone` with no import names the prelude trait; the first-party
+    # dom::Clone struct sharing the leaf name must not gain an edge.
+    base = _build_modules(temp_repo, mock_ingestor, "rs_bound_prelude")
+    calls = _calls(mock_ingestor)
+    assert (f"{base}.util.dup", f"{base}.dom.Clone.poll") not in calls, calls
+
+
+def test_scoped_first_party_bound_dispatches(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `M: crate::m::Matcher` resolves by exact module path, so the scoped
+    # spelling dispatches exactly as the bare one.
+    base = _build_modules(temp_repo, mock_ingestor, "rs_bound_scoped")
+    calls = _calls(mock_ingestor)
+    assert (f"{base}.u.go", f"{base}.m.Matcher.is_match") in calls, calls
+
+
+def test_cross_module_imported_bound_dispatches(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `use crate::m::Matcher` then `M: Matcher`: the import map carries the
+    # already-resolved project qn, which substitutes directly.
+    base = _build_modules(temp_repo, mock_ingestor, "rs_bound_use_fp")
+    calls = _calls(mock_ingestor)
+    assert (f"{base}.u2.go2", f"{base}.m.Matcher.is_match") in calls, calls
+
+
+def test_same_impl_accessor_generic_return_substitutes(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `let m = self.get()` returns the caller's OWN impl-header generic
+    # (a method cannot shadow it, E0403), so the bound applies to the local.
+    base = _build(temp_repo, mock_ingestor, "rs_bound_self_get")
+    calls = _calls(mock_ingestor)
+    assert (f"{base}.Core.run_via_get", f"{base}.Matcher.is_match") in calls, calls
 
 
 def test_external_bound_does_not_fabricate_inherent_edge(


### PR DESCRIPTION
Closes #1047.

## What

A method call on a receiver whose type is a generic type parameter never resolved through the parameter's trait bound. The call either vanished (fn params, `where` clauses: the unresolvable type name tripped the known-external receiver guard) or fell through to the name based fallback and fabricated an edge onto an unrelated type's inherent method (impl generic struct fields, three part `self.field.method` receivers the two part guard never sees). ripgrep's core dispatch surface was the casualty: `SearcherCore` calls `self.matcher.is_match(line)` through `M: Matcher`, the printer calls `matcher.new_captures()` the same way, and all seventeen `Matcher` default methods sat in the dead code report.

The fix rewrites the recorded type at map build time: `_substitute_rust_generic_bounds` runs over the assembled Rust local map (params, annotated lets, fields, `self.<field>` entries) and replaces a type that names an in scope generic parameter with the registry qn of the first trait bound that resolves strictly first party. Bounds come from `collect_generic_bounds`, which walks the caller's ancestors and reads each `function_item`/`impl_item`/`trait_item`'s parameter list (`<M: Matcher + Clone>`) and `where` clause; the innermost declaration of a name wins outright, and a parameter bounded in both places gets both lists.

Strict resolution is the load bearing part. `_rust_bound_trait_qn` accepts a spelling only when it names a registered first party trait (traits register as INTERFACE; a same named struct or enum never satisfies a bound) through one of three exact routes, and it writes the resolved qn into the map directly so no downstream consumer can re resolve the name fuzzily:

- a bare name mapped by the module's `use` imports to an already resolved project qn;
- a bare name defined in the same module;
- a scoped path (`crate::m::Matcher`) whose module path matches a registered trait exactly.

Everything else is a deliberate non substitution:

- A bare spelling whose `use` target is a raw `::` path (`use std::io::Write;` then `W: Write`) names an external trait; substituting it through the simple name fallback would fabricate an edge onto an arbitrary first party type sharing the leaf name.
- A bare prelude bound (`T: Clone`, no import) resolves to no same module definition and stays put, even when the project defines its own `Clone` somewhere else.
- A scoped path with no exact module path match (external heads, workspace crate spellings whose qn interposes `src.lib`) is a recall miss, never a wrong edge.
- A parameter whose bounds all fail resolution keeps the generic name, so the known-external receiver guard suppresses the name based fallback instead of letting it fabricate an edge.
- Lifetimes, `?Sized` markers, and fn trait bounds yield no spelling; a generic bound (`From<NoError>`) contributes its base path. A `where` left side that is not a plain identifier (`Self::Item: ...`) constrains a projection, not a parameter, and is skipped.

Substitution runs BEFORE call return enrichment: an enriched binding's declared return type (`fn make() -> M`) spells the CALLEE's generic parameter, which the caller's bounds must not capture. The sole exception is a `let m = self.get()` binding: a `self.<method>()` callee lives in the caller's own impl, whose header generics a method cannot shadow (E0403), so a generic return there spells the caller's own parameter and its bound applies.

## TDD

RED first, in two rounds. Round one: six of eight tests in `test_rust_generic_bound_dispatch.py` failing before the fix (fn generic param, `where` clause, multi bound, impl generic field with a decoy inherent method proving the fabricated edge, annotated local), plus guards for a direct inherent call, the scoped external bound shape, and a callee's generic return staying uncaptured. Round two (from adversarial review): four more failing tests pinning the bare spelled external import decoy, the prelude decoy, scoped first party dispatch, and the same impl accessor, plus a cross module import guard. Thirteen tests total.

Full suite: 6782 passed, 10 skipped. The baseline on `main` is 6769 passed / 10 skipped, so the delta is exactly the 13 tests this branch adds, with no new skips, xfails or deselections. Live ripgrep re measure: 221 to 189, 32 resolved and 0 newly listed, and the resolved set is exactly the predicted surface (eight `Matcher` default methods, their pcre2/regex `RegexMatcher`/`RegexCaptures` implementations through OVERRIDES liveness, the whole `Sink` dispatch chain, and two closures inside revived methods). Re measured again after the adversarial hardening: the 189 row set is byte for byte identical, so the strict resolution loses none of the recall.

## Adversarial review

One round, three findings, all fixed RED first:

1. Confirmed regression: the original guard checked the bound's SPELLING for `::`, not what it resolves to, so a bare spelled external bound (`use std::io::Write;` + `W: Write`, or prelude `Clone`) reached the simple name fallback and fabricated a CALLS edge onto an unrelated first party type sharing the leaf name. Fixed by the strict three route resolution above, which also gates on the trait node kind and stores the resolved qn instead of the spelling.
2. Scoped first party bounds (`M: crate::m::Matcher`) never substituted, and the code disagreed with its own comment. Fixed: exact module path matches now dispatch; only inexact scoped spellings stay out.
3. A same impl accessor (`let m = self.get(); m.is_match()`) lost its edge because blanket pre enrichment ordering treated the caller's own impl generic as a foreign callee generic. Fixed with the E0403 backed `self.<method>()` exception inside enrichment.

## Infinite loop caught by the suite

The bound collector walks `node.parent` until it reaches `None`, which terminates on any real tree sitter tree but not on the bare `MagicMock` that `test_returns_empty_dict_for_unsupported_language[rust]` passes in: a mock auto creates `.parent` forever. One xdist worker wedged there at 99% while the rest finished, so the run never printed a summary. Confirmed by timeout (exit 124, no output).

Fixed at the semantic level rather than by special casing the test: substitution exists to rewrite entries in the variable map, so an empty map has nothing to rewrite and the ancestor walk is pure waste. The early return removes the traversal for every Rust call with no recorded locals. The previously hanging class now runs 9 passed in 2.3s.

Note the adversarial round inspected this traversal and cleared it, reasoning about what is reachable in Rust that compiles, which does not cover a mock caller. The suite caught what the review did not.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved Rust code analysis for generic type bounds across functions, implementations, and traits.
  * More accurately resolves trait-based method calls, including imported and cross-module types.
  * Preserves correct scoping when generic declarations overlap and avoids unsupported or external trait matches.

* **Bug Fixes**
  * Prevented incorrect call relationships caused by confusing caller and callee generic parameters.
  * Improved handling of `where` clauses, multiple bounds, and generic receiver types.

* **Tests**
  * Added comprehensive coverage for Rust generic-bound dispatch and related edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->