### PR TITLE
fix(dead-code): root Rust methods implementing external traits

### DIFF
--- a/codebase_rag/constants/ast_rust.py
+++ b/codebase_rag/constants/ast_rust.py
@@ -208,6 +208,39 @@ RS_MANIFEST_TARGET_TABLE_KEY = "target"
 # manifest needed to know a use head naming one is outside the project.
 RS_STDLIB_CRATES = frozenset({"std", "core", "alloc", "proc_macro"})
 
+# Traits the Rust prelude puts in scope with no `use`: an impl naming one
+# without importing it and without a same-named first-party declaration
+# implements the standard trait, whose dispatch lives outside the graph
+# (issue #1048). Marker traits with no methods are omitted as pointless.
+RS_PRELUDE_TRAITS = frozenset(
+    {
+        "AsMut",
+        "AsRef",
+        "Clone",
+        "Default",
+        "DoubleEndedIterator",
+        "Drop",
+        "ExactSizeIterator",
+        "Extend",
+        "Fn",
+        "FnMut",
+        "FnOnce",
+        "From",
+        "FromIterator",
+        "Hash",
+        "Into",
+        "IntoIterator",
+        "Iterator",
+        "Ord",
+        "PartialEq",
+        "PartialOrd",
+        "ToOwned",
+        "ToString",
+        "TryFrom",
+        "TryInto",
+    }
+)
+
 # Iterator-adaptor closure typing (issue #1045): a closure argument of one
 # of these adaptors receives the sequence's element (by value or
 # reference, indistinguishable for method binding), so its parameter can

--- a/codebase_rag/constants/ast_rust.py
+++ b/codebase_rag/constants/ast_rust.py
@@ -227,7 +227,6 @@ RS_PRELUDE_TRAITS = frozenset(
         "FnOnce",
         "From",
         "FromIterator",
-        "Hash",
         "Into",
         "IntoIterator",
         "Iterator",

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -523,11 +523,22 @@ class ClassIngestMixin:
         # genuinely dead first-party trait impl for good.
         module_qn = impl.entry.module_qn
         resolved = self._resolve_deferred_parent_qn(impl.entry)
-        if resolved is not None and not resolved[1]:
-            # A registered first-party trait dispatches through OVERRIDES
-            # liveness, which already covers its impls.
+        if (
+            resolved is not None
+            and not resolved[1]
+            and self.function_registry.get(resolved[0]) == NodeType.INTERFACE
+        ):
+            # A registered first-party TRAIT dispatches through OVERRIDES
+            # liveness, which already covers its impls. The node kind has to
+            # be checked: parent resolution ends in a project-wide simple-name
+            # sweep, so a struct the project happens to call `Default` answers
+            # for the prelude trait and would silence every `impl Default`.
             return False
         head, scoped = self._rust_trait_head(impl.spelling, module_qn)
+        if self.import_processor.rust_head_is_repo_crate(head):
+            # The crate is indexed here whatever the manifest says about
+            # fetching it, so its traits are first-party.
+            return False
         if (
             head in cs.RS_STDLIB_CRATES
             or self.import_processor.rust_head_is_external_dep(head, module_qn)

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -22,6 +22,7 @@ from ...types_defs import (
     FunctionSpanKey,
     NodeType,
     PropertyDict,
+    RustTraitImpl,
 )
 from ...utils.path_utils import cached_relative_path, cached_resolve_posix
 from ..cpp import CppTypeInferenceEngine
@@ -174,6 +175,7 @@ class ClassIngestMixin:
     _deferred_parent_links: list[DeferredParentLink]
     _deferred_cpp_inherits: list[DeferredCppInherit]
     _deferred_inherits: list[DeferredInherit]
+    _rust_trait_impls: list[RustTraitImpl]
     cpp_module_interfaces: set[str]
     _deferred_cpp_module_impls: list[tuple[str, str]]
     declared_module_qns: set[str]
@@ -489,7 +491,66 @@ class ClassIngestMixin:
                 )
             emitted += 1
         self._flag_dart_external_overrides(dart_implements)
+        self._flag_rust_external_trait_overrides()
         return emitted
+
+    def _flag_rust_external_trait_overrides(self) -> None:
+        # A method in an `impl <ExternalTrait> for Type` block is only ever
+        # invoked through that trait's dispatch, by code the graph does not
+        # hold: the stdlib calls io::Read::read, serde calls its Visitor
+        # methods, the log facade calls Log::log. No first-party edge can
+        # prove it live, so it roots the dead-code walk (issue #1048).
+        impls = self._rust_trait_impls
+        self._rust_trait_impls = []
+        for impl in impls:
+            if not self._rust_trait_is_external(impl):
+                continue
+            for method_qn in impl.method_qns:
+                self.ingestor.ensure_node_batch(
+                    cs.NodeLabel.METHOD,
+                    {
+                        cs.KEY_QUALIFIED_NAME: method_qn,
+                        cs.KEY_OVERRIDES_EXTERNAL: True,
+                    },
+                )
+
+    def _rust_trait_is_external(self, impl: RustTraitImpl) -> bool:
+        # Only POSITIVE evidence roots: the crate the trait is written under
+        # must be the toolchain or a manifest-proven external dependency. An
+        # unresolved head alone means nothing (a workspace sibling reached by
+        # its crate name, `use grep_searcher::Sink`, resolves through a layout
+        # the import half may not cover), and rooting on it would hide a
+        # genuinely dead first-party trait impl for good.
+        module_qn = impl.entry.module_qn
+        resolved = self._resolve_deferred_parent_qn(impl.entry)
+        if resolved is not None and not resolved[1]:
+            # A registered first-party trait dispatches through OVERRIDES
+            # liveness, which already covers its impls.
+            return False
+        head, scoped = self._rust_trait_head(impl.spelling, module_qn)
+        if (
+            head in cs.RS_STDLIB_CRATES
+            or self.import_processor.rust_head_is_external_dep(head, module_qn)
+        ):
+            return True
+        # A bare name with no import and no first-party declaration is in
+        # scope only because the prelude put it there.
+        return not scoped and head in cs.RS_PRELUDE_TRAITS
+
+    def _rust_trait_head(self, spelling: str, module_qn: str) -> tuple[str, bool]:
+        """The crate the written trait path speaks for, and whether it is scoped.
+
+        The written head is itself an imported name whenever the module said
+        so: `use std::io;` then `impl io::Read` (Rust's usual spelling for a
+        stdlib trait) writes the head `io`, which speaks for `std`. Only a
+        head no `use` mentions stands for itself, and a bare one of those is
+        unscoped: nothing but the prelude can have put it in scope.
+        """
+        import_map = self.import_processor.import_mapping.get(module_qn, {})
+        head = spelling.split(cs.SEPARATOR_DOUBLE_COLON, 1)[0]
+        if (target := import_map.get(head)) is not None:
+            return target.split(cs.SEPARATOR_DOUBLE_COLON, 1)[0], True
+        return head, cs.SEPARATOR_DOUBLE_COLON in spelling
 
     def _flag_dart_external_overrides(
         self,
@@ -1062,20 +1123,33 @@ class ClassIngestMixin:
         # `impl Trait for Type` means Type IMPLEMENTS Trait. The target type's
         # node label may be Class/Enum/Type, so match the relationship source
         # to its registered label (else the IMPLEMENTS edge never resolves).
+        trait_impl_method_qns: list[str] | None = None
         if trait_name := rs_utils.extract_impl_trait(class_node):
             trait_qn = self._resolve_to_qn(trait_name, owner_module_qn)
             # The trait (or the impl target) may live in a file not yet
             # parsed; hold the IMPLEMENTS edge back for
             # resolve_deferred_inherits so an unresolvable trait
             # (std::fmt::Display) emits no phantom edge.
-            self._deferred_inherits.append(
-                DeferredInherit(
-                    rel_type=cs.RelationshipType.IMPLEMENTS,
-                    child_qn=class_qn,
-                    parent_qn=trait_qn,
-                    module_qn=owner_module_qn,
-                    base_index=0,
-                    language=cs.SupportedLanguage.RUST,
+            trait_entry = DeferredInherit(
+                rel_type=cs.RelationshipType.IMPLEMENTS,
+                child_qn=class_qn,
+                parent_qn=trait_qn,
+                module_qn=owner_module_qn,
+                base_index=0,
+                language=cs.SupportedLanguage.RUST,
+            )
+            self._deferred_inherits.append(trait_entry)
+            # Collect this block's methods against the trait AS WRITTEN: if the
+            # trait belongs to another crate, its dispatch is the only caller
+            # they can ever have (issue #1048). The decision waits for
+            # resolve_deferred_inherits, when every first-party trait is
+            # registered.
+            trait_impl_method_qns = []
+            self._rust_trait_impls.append(
+                RustTraitImpl(
+                    entry=trait_entry,
+                    spelling=rs_utils.extract_impl_trait_path(class_node) or trait_name,
+                    method_qns=trait_impl_method_qns,
                 )
             )
             # Record the implementer so a Rust trait call to the sole concrete
@@ -1136,6 +1210,8 @@ class ClassIngestMixin:
             # its own qn, and overwriting the record would re-attribute
             # its calls to this pass's twin.
             if ingested_qn is not None:
+                if trait_impl_method_qns is not None:
+                    trait_impl_method_qns.append(ingested_qn)
                 span = function_span_key(module_qn, method_node)
                 if span not in self.function_locations:
                     self.function_locations[span] = FunctionLocation(

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -18,6 +18,7 @@ from ..types_defs import (
     FunctionLocation,
     FunctionRegistryTrieProtocol,
     FunctionSpanKey,
+    RustTraitImpl,
     SimpleNameLookup,
 )
 from ..utils.path_utils import cached_relative_path, cached_resolve_posix
@@ -214,6 +215,11 @@ class DefinitionProcessor(
         # Non-C++ INHERITS/IMPLEMENTS held back until every class is
         # registered; resolve_deferred_inherits re-resolves the guesses.
         self._deferred_inherits: list[DeferredInherit] = []
+        # Rust `impl Trait for Type` blocks paired with the method qns they
+        # ingested. Whether the trait is external is only knowable once every
+        # trait is registered, so resolve_deferred_inherits judges it and
+        # flags the methods of the external ones (issue #1048).
+        self._rust_trait_impls: list[RustTraitImpl] = []
         # C++20 module interfaces declared this run (export module X), and
         # implementation units whose IMPLEMENTS edge waits for its
         # interface to be known.

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -1336,10 +1336,10 @@ class ImportProcessor:
     ) -> tuple[str, ...] | None:
         # Repo-relative dir of the package this dependency entry binds
         # to, or None when it resolves outside the repo (registry
-        # version, git, renamed `package =` entries stay out of scope).
+        # version, git). A `package =` rename changes the name the entry
+        # is spoken by, not where it lives: an entry carrying a path
+        # still binds that directory.
         if not isinstance(value, dict):
-            return None
-        if cs.RS_MANIFEST_PACKAGE_KEY in value:
             return None
         base = self.repo_path.joinpath(*pkg_parts)
         if value.get(cs.RS_MANIFEST_WORKSPACE_KEY) is True:
@@ -1393,6 +1393,17 @@ class ImportProcessor:
             return False
         deps = self._rust_package_deps(pkg)
         return head in deps and deps[head] is None
+
+    def rust_head_is_repo_crate(self, head: str) -> bool:
+        """Whether this use head names a lib crate the repo itself holds.
+
+        A manifest says how a crate is FETCHED, which is a different
+        question from whether the repo indexes it: a workspace sibling may
+        be declared by version alone (the published-workspace shape), and
+        the entry then resolves to no repo directory even though the
+        crate's own sources sit right here (issue #1048).
+        """
+        return head in self._rust_workspace_crate_roots()
 
     def _rust_crate_root(self, module_qn: str) -> tuple[str, list[str]] | None:
         """The file's crate root: ("classic", dir parts) or ("file", qn parts).

--- a/codebase_rag/parsers/rs/utils.py
+++ b/codebase_rag/parsers/rs/utils.py
@@ -243,6 +243,25 @@ def extract_impl_trait(impl_node: Node) -> str | None:
     return _impl_field_type_name(impl_node, cs.FIELD_TRAIT)
 
 
+def extract_impl_trait_path(impl_node: Node) -> str | None:
+    # The trait AS WRITTEN (`std::io::Read`, `serde::de::Visitor`), which the
+    # simple name discards. Only the written head says which crate speaks for
+    # the trait, and that decides whether its dispatch is external (#1048).
+    if impl_node.type != cs.TS_IMPL_ITEM:
+        return None
+    for i in range(impl_node.child_count):
+        if impl_node.field_name_for_child(i) != cs.FIELD_TRAIT:
+            continue
+        if (trait_node := impl_node.child(i)) is None:
+            continue
+        if (text := safe_decode_text(trait_node)) is None:
+            continue
+        # Type arguments (`FromIterator<u8>`) belong to the instantiation,
+        # not the path.
+        return text.split(cs.CHAR_ANGLE_OPEN, 1)[0].strip()
+    return None
+
+
 def extract_use_imports(use_node: Node) -> dict[str, str]:
     if use_node.type != cs.TS_USE_DECLARATION:
         return {}

--- a/codebase_rag/tests/test_rust_external_trait_impl_flag.py
+++ b/codebase_rag/tests/test_rust_external_trait_impl_flag.py
@@ -1,0 +1,288 @@
+# A Rust method in an `impl <ExternalTrait> for Type` block is invoked through
+# the external trait's dispatch by code outside the graph (the stdlib calls
+# `io::Read::read`, serde calls its `Visitor` methods, the `log` facade calls
+# `Log::log`), so no first-party call site can ever prove it live and it
+# reported dead: 26 of ripgrep's 221 remaining candidates were these. Flag the
+# whole impl block's methods so the dead-code surfaces root them (issue #1048).
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.conftest import create_and_run_updater
+
+
+def _method_props(mock_ingestor: MagicMock) -> dict[str, dict]:
+    # Mirror the ingestor's MERGE ... SET n += props semantics: the deferred
+    # overrides_external row merges into the full row ingested during Pass 2.
+    props: dict[str, dict] = {}
+    for c in mock_ingestor.ensure_node_batch.call_args_list:
+        if c.args[0] == cs.NodeLabel.METHOD:
+            props.setdefault(c.args[1][cs.KEY_QUALIFIED_NAME], {}).update(c.args[1])
+    return props
+
+
+def _build(root: Path, mock_ingestor: MagicMock, files: dict[str, str]) -> dict:
+    root.mkdir(parents=True)
+    (root / "Cargo.toml").write_text(
+        '[package]\nname = "fixture"\nversion = "0.1.0"\n', encoding="utf-8"
+    )
+    src = root / "src"
+    src.mkdir()
+    for name, text in files.items():
+        (src / name).write_text(text, encoding="utf-8")
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="rust")
+    return _method_props(mock_ingestor)
+
+
+def _prop(props: dict[str, dict], suffix: str) -> dict:
+    return next(v for k, v in props.items() if k.endswith(suffix))
+
+
+def test_scoped_stdlib_trait_impl_is_flagged(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `impl std::io::Read for Reader`: the trait is spelled as a scoped path
+    # whose head is the stdlib, and an inherent method on the same type stays
+    # an ordinary candidate.
+    props = _build(
+        temp_repo / "rsstd",
+        mock_ingestor,
+        {
+            "lib.rs": (
+                "pub struct Reader;\n"
+                "\n"
+                "impl std::io::Read for Reader {\n"
+                "    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {\n"
+                "        Ok(buf.len())\n"
+                "    }\n"
+                "}\n"
+                "\n"
+                "impl Reader {\n"
+                "    fn helper(&self) -> usize {\n"
+                "        0\n"
+                "    }\n"
+                "}\n"
+            )
+        },
+    )
+    read = _prop(props, "Reader.read")
+    helper = _prop(props, "Reader.helper")
+    assert read.get(cs.KEY_OVERRIDES_EXTERNAL) is True, read
+    assert not helper.get(cs.KEY_OVERRIDES_EXTERNAL), helper
+
+
+def test_bare_imported_external_trait_impl_is_flagged(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The common spelling: `use std::io::Write;` then a bare `impl Write`.
+    # Every method of the block is trait dispatch, so both flag.
+    props = _build(
+        temp_repo / "rsuse",
+        mock_ingestor,
+        {
+            "lib.rs": (
+                "use std::io::Write;\n"
+                "\n"
+                "pub struct Sink;\n"
+                "\n"
+                "impl Write for Sink {\n"
+                "    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {\n"
+                "        Ok(buf.len())\n"
+                "    }\n"
+                "\n"
+                "    fn flush(&mut self) -> std::io::Result<()> {\n"
+                "        Ok(())\n"
+                "    }\n"
+                "}\n"
+            )
+        },
+    )
+    assert _prop(props, "Sink.write").get(cs.KEY_OVERRIDES_EXTERNAL) is True
+    assert _prop(props, "Sink.flush").get(cs.KEY_OVERRIDES_EXTERNAL) is True
+
+
+def test_imported_module_head_trait_impl_is_flagged(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # Rust's usual spelling for a stdlib trait: `use std::io;` then a scoped
+    # `impl io::Read`. The written head is the imported MODULE, so taking it
+    # at face value misses every io::Read and io::Write impl there is.
+    props = _build(
+        temp_repo / "rsmodhead",
+        mock_ingestor,
+        {
+            "lib.rs": (
+                "use std::io;\n"
+                "\n"
+                "pub struct Reader;\n"
+                "\n"
+                "impl io::Read for Reader {\n"
+                "    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {\n"
+                "        Ok(buf.len())\n"
+                "    }\n"
+                "}\n"
+            )
+        },
+    )
+    read = _prop(props, "Reader.read")
+    assert read.get(cs.KEY_OVERRIDES_EXTERNAL) is True, read
+
+
+def test_generic_external_trait_impl_is_flagged(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # A generic trait head (`impl FromIterator<u8> for Seq`) names the same
+    # external contract; the type argument must not defeat the match.
+    props = _build(
+        temp_repo / "rsgeneric",
+        mock_ingestor,
+        {
+            "lib.rs": (
+                "pub struct Seq(Vec<u8>);\n"
+                "\n"
+                "impl FromIterator<u8> for Seq {\n"
+                "    fn from_iter<I: IntoIterator<Item = u8>>(it: I) -> Seq {\n"
+                "        Seq(it.into_iter().collect())\n"
+                "    }\n"
+                "}\n"
+            )
+        },
+    )
+    assert _prop(props, "Seq.from_iter").get(cs.KEY_OVERRIDES_EXTERNAL) is True
+
+
+def test_first_party_trait_impl_is_not_flagged(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # A trait declared in this project dispatches through OVERRIDES liveness,
+    # so flagging its impls would permanently root genuinely dead code.
+    props = _build(
+        temp_repo / "rsown",
+        mock_ingestor,
+        {
+            "lib.rs": (
+                "pub trait Greeter {\n"
+                "    fn hi(&self) -> u8;\n"
+                "}\n"
+                "\n"
+                "pub struct En;\n"
+                "\n"
+                "impl Greeter for En {\n"
+                "    fn hi(&self) -> u8 {\n"
+                "        1\n"
+                "    }\n"
+                "}\n"
+            )
+        },
+    )
+    hi = _prop(props, "En.hi")
+    assert not hi.get(cs.KEY_OVERRIDES_EXTERNAL), hi
+
+
+def test_workspace_sibling_crate_trait_impl_is_not_flagged(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The trait belongs to another WORKSPACE member, reached by its crate
+    # name (`use grep_searcher::Sink`). The name resolves to no registered
+    # trait here, but the manifest proves the head first-party, and rooting
+    # on unresolvedness alone would permanently hide the impls of every
+    # cross-crate trait in a workspace: ripgrep's whole Sink surface.
+    project = temp_repo / "rs_ws_trait"
+    project.mkdir(parents=True)
+    files = {
+        "Cargo.toml": '[workspace]\nmembers = ["searcher", "printer"]\n',
+        "searcher/Cargo.toml": (
+            '[package]\nname = "grep-searcher"\nversion = "0.1.0"\n'
+        ),
+        # The trait is declared in a submodule and re-exported from the crate
+        # root, so the importing crate's spelling reaches it through the
+        # re-export: exactly ripgrep's grep_searcher::Sink.
+        "searcher/src/lib.rs": "pub mod sink;\npub use crate::sink::Sink;\n",
+        "searcher/src/sink.rs": (
+            "pub trait Sink {\n    fn matched(&mut self) -> u8;\n}\n"
+        ),
+        "printer/Cargo.toml": (
+            '[package]\nname = "printer"\nversion = "0.1.0"\n\n'
+            '[dependencies]\ngrep-searcher = { path = "../searcher" }\n'
+        ),
+        "printer/src/lib.rs": (
+            "use grep_searcher::Sink;\n"
+            "\n"
+            "pub struct JSON;\n"
+            "\n"
+            "impl Sink for JSON {\n"
+            "    fn matched(&mut self) -> u8 {\n"
+            "        1\n"
+            "    }\n"
+            "}\n"
+        ),
+    }
+    for name, text in files.items():
+        target = project / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(text, encoding="utf-8")
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    matched = _prop(_method_props(mock_ingestor), "JSON.matched")
+    assert not matched.get(cs.KEY_OVERRIDES_EXTERNAL), matched
+
+
+def test_manifest_dependency_trait_impl_is_flagged(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # A registry dependency (no path, so no repo directory) speaks for its
+    # head: `termcolor::WriteColor` dispatch is outside the graph.
+    root = temp_repo / "rsdep"
+    root.mkdir(parents=True)
+    (root / "Cargo.toml").write_text(
+        '[package]\nname = "fixture"\nversion = "0.1.0"\n\n'
+        '[dependencies]\ntermcolor = "1.1"\n',
+        encoding="utf-8",
+    )
+    src = root / "src"
+    src.mkdir()
+    (src / "lib.rs").write_text(
+        "use termcolor::WriteColor;\n"
+        "\n"
+        "pub struct Out;\n"
+        "\n"
+        "impl WriteColor for Out {\n"
+        "    fn reset(&mut self) -> u8 {\n"
+        "        0\n"
+        "    }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    create_and_run_updater(root, mock_ingestor, skip_if_missing="rust")
+    reset = _prop(_method_props(mock_ingestor), "Out.reset")
+    assert reset.get(cs.KEY_OVERRIDES_EXTERNAL) is True, reset
+
+
+def test_cross_file_first_party_trait_impl_is_not_flagged(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The trait lives in a file parsed AFTER the impl, so it is unregistered
+    # at class-ingest time; the decision must wait for deferred inheritance
+    # resolution or a first-party impl is wrongly rooted.
+    props = _build(
+        temp_repo / "rsxfile",
+        mock_ingestor,
+        {
+            "lib.rs": "pub mod a_impl;\npub mod z_trait;\n",
+            "a_impl.rs": (
+                "use crate::z_trait::Greeter;\n"
+                "\n"
+                "pub struct En;\n"
+                "\n"
+                "impl Greeter for En {\n"
+                "    fn hi(&self) -> u8 {\n"
+                "        1\n"
+                "    }\n"
+                "}\n"
+            ),
+            "z_trait.rs": ("pub trait Greeter {\n    fn hi(&self) -> u8;\n}\n"),
+        },
+    )
+    hi = _prop(props, "En.hi")
+    assert not hi.get(cs.KEY_OVERRIDES_EXTERNAL), hi

--- a/codebase_rag/tests/test_rust_external_trait_impl_flag.py
+++ b/codebase_rag/tests/test_rust_external_trait_impl_flag.py
@@ -40,6 +40,41 @@ def _prop(props: dict[str, dict], suffix: str) -> dict:
     return next(v for k, v in props.items() if k.endswith(suffix))
 
 
+def _write_workspace(project: Path, files: dict[str, str]) -> None:
+    project.mkdir(parents=True)
+    for name, text in files.items():
+        target = project / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(text, encoding="utf-8")
+
+
+def _workspace_files(printer_dep: str, use_head: str) -> dict[str, str]:
+    return {
+        "Cargo.toml": '[workspace]\nmembers = ["searcher", "printer"]\n',
+        "searcher/Cargo.toml": '[package]\nname = "grep-searcher"\nversion = "0.1.0"\n',
+        # Declared in a submodule and re-exported from the crate root, so the
+        # importing crate's spelling reaches it through the re-export:
+        # exactly ripgrep's grep_searcher::Sink.
+        "searcher/src/lib.rs": "pub mod sink;\npub use crate::sink::Sink;\n",
+        "searcher/src/sink.rs": "pub trait Sink {\n    fn matched(&mut self) -> u8;\n}\n",
+        "printer/Cargo.toml": (
+            '[package]\nname = "printer"\nversion = "0.1.0"\n\n'
+            f"[dependencies]\n{printer_dep}\n"
+        ),
+        "printer/src/lib.rs": (
+            f"use {use_head}::Sink;\n"
+            "\n"
+            "pub struct JSON;\n"
+            "\n"
+            "impl Sink for JSON {\n"
+            "    fn matched(&mut self) -> u8 {\n"
+            "        1\n"
+            "    }\n"
+            "}\n"
+        ),
+    }
+
+
 def test_scoped_stdlib_trait_impl_is_flagged(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:
@@ -190,42 +225,77 @@ def test_workspace_sibling_crate_trait_impl_is_not_flagged(
     # on unresolvedness alone would permanently hide the impls of every
     # cross-crate trait in a workspace: ripgrep's whole Sink surface.
     project = temp_repo / "rs_ws_trait"
-    project.mkdir(parents=True)
-    files = {
-        "Cargo.toml": '[workspace]\nmembers = ["searcher", "printer"]\n',
-        "searcher/Cargo.toml": (
-            '[package]\nname = "grep-searcher"\nversion = "0.1.0"\n'
-        ),
-        # The trait is declared in a submodule and re-exported from the crate
-        # root, so the importing crate's spelling reaches it through the
-        # re-export: exactly ripgrep's grep_searcher::Sink.
-        "searcher/src/lib.rs": "pub mod sink;\npub use crate::sink::Sink;\n",
-        "searcher/src/sink.rs": (
-            "pub trait Sink {\n    fn matched(&mut self) -> u8;\n}\n"
-        ),
-        "printer/Cargo.toml": (
-            '[package]\nname = "printer"\nversion = "0.1.0"\n\n'
-            '[dependencies]\ngrep-searcher = { path = "../searcher" }\n'
-        ),
-        "printer/src/lib.rs": (
-            "use grep_searcher::Sink;\n"
-            "\n"
-            "pub struct JSON;\n"
-            "\n"
-            "impl Sink for JSON {\n"
-            "    fn matched(&mut self) -> u8 {\n"
-            "        1\n"
-            "    }\n"
-            "}\n"
-        ),
-    }
-    for name, text in files.items():
-        target = project / name
-        target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(text, encoding="utf-8")
+    _write_workspace(
+        project,
+        _workspace_files('grep-searcher = { path = "../searcher" }', "grep_searcher"),
+    )
     create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
     matched = _prop(_method_props(mock_ingestor), "JSON.matched")
     assert not matched.get(cs.KEY_OVERRIDES_EXTERNAL), matched
+
+
+def test_versioned_workspace_sibling_trait_impl_is_not_flagged(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # A published workspace declares its siblings by VERSION, with no path.
+    # The manifest then proves nothing about where the crate lives, but the
+    # repo holds it: a manifest says how a crate is fetched, not whether it
+    # is indexed here.
+    project = temp_repo / "rs_ws_versioned"
+    _write_workspace(
+        project, _workspace_files('grep-searcher = "0.1"', "grep_searcher")
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    matched = _prop(_method_props(mock_ingestor), "JSON.matched")
+    assert not matched.get(cs.KEY_OVERRIDES_EXTERNAL), matched
+
+
+def test_renamed_path_dependency_trait_impl_is_not_flagged(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `searcher = { path = "../searcher", package = "grep-searcher" }` speaks
+    # the sibling under another name. The rename changes what the crate is
+    # CALLED, not where it lives, so the path still binds a repo directory.
+    project = temp_repo / "rs_ws_renamed"
+    _write_workspace(
+        project,
+        _workspace_files(
+            'searcher = { path = "../searcher", package = "grep-searcher" }',
+            "searcher",
+        ),
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    matched = _prop(_method_props(mock_ingestor), "JSON.matched")
+    assert not matched.get(cs.KEY_OVERRIDES_EXTERNAL), matched
+
+
+def test_same_named_first_party_struct_does_not_silence_prelude_trait(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `impl Default for T` names the prelude trait; a struct the project
+    # happens to call `Default` in an unrelated, unimported module is not it.
+    # Parent resolution ends in a project-wide simple-name sweep, so without
+    # a node-kind check that struct answers for the trait and silences the
+    # flag (and the same sweep has T "implement" a struct).
+    props = _build(
+        temp_repo / "rsdecoytype",
+        mock_ingestor,
+        {
+            "lib.rs": "pub mod other;\npub mod thing;\n",
+            "other.rs": "pub struct Default {\n    pub x: u8,\n}\n",
+            "thing.rs": (
+                "pub struct T;\n"
+                "\n"
+                "impl Default for T {\n"
+                "    fn default() -> T {\n"
+                "        T\n"
+                "    }\n"
+                "}\n"
+            ),
+        },
+    )
+    default = _prop(props, "T.default")
+    assert default.get(cs.KEY_OVERRIDES_EXTERNAL) is True, default
 
 
 def test_manifest_dependency_trait_impl_is_flagged(

--- a/codebase_rag/tests/test_rust_external_trait_impl_flag.py
+++ b/codebase_rag/tests/test_rust_external_trait_impl_flag.py
@@ -37,7 +37,11 @@ def _build(root: Path, mock_ingestor: MagicMock, files: dict[str, str]) -> dict:
 
 
 def _prop(props: dict[str, dict], suffix: str) -> dict:
-    return next(v for k, v in props.items() if k.endswith(suffix))
+    # Exactly one match, or the assertion the caller makes is about a node it
+    # did not mean: the decoy fixtures turn on selecting the right one.
+    matches = [(k, v) for k, v in props.items() if k.endswith(suffix)]
+    assert len(matches) == 1, f"{suffix} matched {[k for k, _ in matches]}"
+    return matches[0][1]
 
 
 def _write_workspace(project: Path, files: dict[str, str]) -> None:

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -676,6 +676,20 @@ class DeferredInherit(NamedTuple):
     language: SupportedLanguage
 
 
+class RustTraitImpl(NamedTuple):
+    """A Rust `impl Trait for Type` block and the methods it ingested.
+
+    Whether the trait belongs to another crate decides whether those methods
+    are dead-code roots (nothing first-party can call them), and that is only
+    knowable once every first-party trait is registered, so the block is held
+    back for resolve_deferred_inherits to judge (issue #1048).
+    """
+
+    entry: DeferredInherit
+    spelling: str
+    method_qns: list[str]
+
+
 class DeferredImportEdge(NamedTuple):
     """IMPORTS edge held back until every file is parsed.
 

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.538"
+version = "0.0.539"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #1048.

## What

A method defined in an `impl <Trait> for Type` block whose trait belongs to another crate has no first-party caller and never can: the standard library calls `io::Read::read`, serde calls its `Visitor` methods from inside the deserialiser, the `log` facade calls `Log::log`, termcolor calls `WriteColor::set_color`. Internal reachability cannot prove such a method live, so all of them reported dead.

The fix flags the whole block's methods `overrides_external`, the property the dead-code surfaces already treat as a root (the same contract Python stdlib-base overrides and Dart framework overrides use). Each `impl Trait for Type` block records its ingested method qns alongside the deferred IMPLEMENTS entry, and `resolve_deferred_inherits` judges the trait once every first-party trait is registered.

## Only positive evidence roots

The decision is deliberately not "the trait resolves to no project node". A trait reached by a workspace sibling's crate name (`use grep_searcher::Sink`, re-exported from that crate's root) resolves nowhere here, and rooting on unresolvedness would have hidden ripgrep's entire `Sink` implementation surface, along with the genuinely dead code hanging off it, permanently. The first draft did exactly that: it rooted 66 candidates, of which 40 were first-party `Sink` impls and their call trees.

A trait counts as external only when the crate its written head speaks for is one of these:

- a toolchain crate (`std`, `core`, `alloc`, `proc_macro`);
- a head the importing package's own manifest binds outside the repo, a registry version or git dependency with no path (the `rust_head_is_external_dep` machinery from #1033, which reports `False` for a workspace path dependency);
- nothing at all, when the name is bare, unimported, and one of the prelude traits, the only way such a name can be in scope.

The written head is itself resolved through the module's imports first, because `use std::io;` then `impl io::Read` is Rust's usual spelling for a stdlib trait and the literal head `io` speaks for `std`. A trait that resolves to a registered first-party trait is skipped before any of this: OVERRIDES liveness already covers it.

## TDD

RED first: 5 of the 11 tests in `test_rust_external_trait_impl_flag.py` fail before the fix (scoped stdlib head, imported module head, bare imported external head, generic trait head, manifest registry dependency), with 3 guards passing throughout (same-file first-party trait, cross-file first-party trait, inherent impl on the same type). The 3 tests from adversarial review are RED against the reviewed commit and green after it.

The workspace-sibling guard was demonstrated RED against the loose first draft rather than against `main`: with the strictness stubbed out, `test_workspace_sibling_crate_trait_impl_is_not_flagged` fails, which is the ripgrep regression reproduced in a fixture. It only reproduces when the trait is declared in a submodule and re-exported from the crate root, exactly `grep_searcher::Sink`.

Full suite: 6793 passed, 10 skipped. The baseline on `main` is 6782 passed / 10 skipped, so the delta is exactly the 11 tests this branch adds, with no new skips, xfails or deselections.

Live ripgrep re-measure: 189 to 167, 22 resolved and 0 newly listed. The resolved set is the predicted surface: both `io::Read` and `io::Write` impls that spell their head as a scoped path, the whole termcolor `WriteColor` surface on `StandardStream` and `CounterWriter`, both `log::Log` methods, the serde `Visitor` methods, the `std::hash::Hasher` and `std::error::Error` impls, and `FromIterator::from_iter`.

## Adversarial review

One round, three findings, all fixed RED first, and re-measured afterwards: the 167 row set is byte for byte identical, so the extra strictness costs no recall.

1. The first-party guard accepted any registered node, not a trait. Parent resolution ends in a project-wide simple-name sweep, so a struct a project happens to call `Default` answered for the prelude trait and silenced the flag for every `impl Default` in the project (the same sweep also has the type "implement" a struct). Now gated on the resolved node being an INTERFACE, the same strictness #1047 needed for bound spellings.
2. `rust_head_is_external_dep` proves "this entry resolves to no repo directory", which is not the same as "this crate is outside the repo". A published workspace declaring a sibling by version alone, and a `package =` rename of a path dependency, both got their trait impls rooted, the exact direction the code's own comment calls unrecoverable. Fixed on both sides: a head naming a lib crate the repo holds is first-party whatever the manifest says about fetching it, and a dependency entry carrying a path binds that directory whether or not it also renames the package.
3. `Hash` is in no Rust prelude, so a bare `impl Hash` cannot compile without a `use`; the entry could only ever have fired on a first-party trait of that name. Removed.

Two conservative misses were reported and left alone, both recall gaps rather than wrong edges: a trait brought in by `use std::io::prelude::*;`, and an impl written inside a function body, whose scope-local `use` is not in the module import map.

## Residue

Three of the candidates listed in the issue survive: `StandardStream.write`, `StandardStream.flush` and `CommandReader.read`. Their modules spell the head through a brace-list `self` import (`use std::io::{self, IsTerminal};`), which the import processor records under the literal key `self` instead of `io`, so the head resolves to nothing and no positive evidence is available. That is a separate import-mapping defect affecting qualified calls in those modules too, filed as #1054 and fixed next; it is not worked around here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Rust trait analysis for external and first-party implementations.
  * Enhanced resolution of renamed Rust package dependencies and workspace crate imports.
  * Added support for fully qualified and generic trait paths.

* **Bug Fixes**
  * More accurately identifies methods associated with external traits while avoiding false positives for internal traits and similarly named structs.

* **Tests**
  * Added comprehensive coverage for scoped, imported, generic, registry-based, and workspace trait implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->