### PR TITLE
fix(rust): bind a brace-list self import under the module name

### DIFF
--- a/codebase_rag/constants/ast_rust.py
+++ b/codebase_rag/constants/ast_rust.py
@@ -183,6 +183,12 @@ RS_USE_LIST_DELIMITERS = frozenset({"{", "}", ","})
 RS_ENCODING_UTF8 = "utf8"
 
 RS_WILDCARD_PREFIX = "*"
+# Marks a `use path::{self}` entry, whose name the base path supplies rather
+# than the source. Rust keeps types and values in separate namespaces while
+# the import map holds one slot per name, so such a binding is WEAK: it never
+# displaces a name another `use` in the same scope already claimed (#1054).
+# No Rust identifier can contain the marker character.
+RS_SELF_MODULE_PREFIX = "@"
 
 RS_FIELD_ARGUMENT = "argument"
 

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -1415,6 +1415,13 @@ class CallResolver:
             return self._resolve_rust_prefixed_path(
                 object_path, item, module_qn, caller_qn
             )
+        # A module the caller bound with `use path::{self}` is a module, full
+        # stop: decide through it before the type probe below, whose
+        # name-based resolution would otherwise answer with a same-named
+        # value and abandon the path (issue #1054).
+        if binding := self._rust_self_module_head(head, module_qn, caller_qn):
+            mapped, scope = binding
+            return self._decide_rust_module_item(mapped, object_path[1:], item, scope)
         # A registered type as the first segment is an associated-function
         # call, owned by the class-resolution paths.
         if self._resolve_class_name(head, module_qn):
@@ -1442,6 +1449,20 @@ class CallResolver:
             module_qn, list(object_path), module_qn
         )
         return self._decide_rust_base(base, item)
+
+    def _rust_self_module_head(
+        self, head: str, module_qn: str, caller_qn: str | None
+    ) -> tuple[str, str] | None:
+        # A `use path::{self}` binding names a MODULE outright, so it answers
+        # a qualified `head::item` even when the shared import map's one slot
+        # went to a value of the same name, which Rust's separate namespaces
+        # allow (issue #1054). Innermost scope first, like every other Rust
+        # name lookup here.
+        self_modules = self.import_processor.rust_self_module_imports
+        for scope in (*self._rust_enclosing_scopes(module_qn, caller_qn), module_qn):
+            if mapped := self_modules.get(scope, {}).get(head):
+                return mapped, scope
+        return None
 
     def _resolve_rust_prefixed_path(
         self,

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -408,6 +408,7 @@ class ImportProcessor:
         "rust_fn_scope_imports",
         "rust_fn_scope_mod_imports",
         "rust_block_scope_imports",
+        "rust_self_module_imports",
         "_rust_fn_scope_keys",
         "_rust_pending_mod_scope_uses",
         "_rust_mod_scope_registry",
@@ -523,6 +524,11 @@ class ImportProcessor:
             ],
         ] = {}
         self._rust_fn_scope_keys: dict[str, set[str]] = {}
+        # Modules bound by a `use path::{self}` brace item, per scope qn.
+        # A module name lives in Rust's TYPE namespace while import_mapping
+        # holds one slot for both namespaces, so a qualified `name::item`
+        # reads here and a bare call reads there (issue #1054).
+        self.rust_self_module_imports: dict[str, dict[str, str]] = {}
         # Sub-scope (inline mod) maps held back until every file is
         # parsed: whether the key collides with an indexer-registered
         # module is only knowable then (finalise_rust_mod_scope_uses).
@@ -2381,6 +2387,7 @@ class ImportProcessor:
         self._rust_pending_mod_scope_uses.pop(module_qn, None)
         self._rust_mod_scope_registry.pop(module_qn, None)
         self.rust_block_scope_imports.pop(module_qn, None)
+        self.rust_self_module_imports.pop(module_qn, None)
         for key in self._rust_fn_scope_keys.pop(module_qn, ()):
             self.rust_fn_scope_imports.pop(key, None)
             self.rust_fn_scope_mod_imports.pop(key, None)
@@ -2428,10 +2435,16 @@ class ImportProcessor:
             )
             if imported_name.startswith(cs.RS_SELF_MODULE_PREFIX):
                 imported_name = imported_name[len(cs.RS_SELF_MODULE_PREFIX) :]
+                # A `{self}` item binds a MODULE, which lives in Rust's type
+                # namespace, so it is recorded where qualified `name::item`
+                # resolution can find it whatever else claims the name.
+                self.rust_self_module_imports.setdefault(effective_qn, {})[
+                    imported_name
+                ] = resolved
                 if imported_name in self.import_mapping.get(effective_qn, {}):
-                    # A `{self}` module binding is weak: types and values are
-                    # separate namespaces in Rust but one slot here, so it
-                    # yields to whatever a previous `use` bound (issue #1054).
+                    # The one slot the shared map has is already taken by a
+                    # binding from the other namespace, and evicting it would
+                    # send that name's bare calls to the trie (issue #1054).
                     continue
             resolved_imports[imported_name] = resolved
             if sub_scope:

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -2415,6 +2415,13 @@ class ImportProcessor:
             resolved = self._rewrite_rust_local_use_path(
                 full_path, resolve_qn, local_mods
             )
+            if imported_name.startswith(cs.RS_SELF_MODULE_PREFIX):
+                imported_name = imported_name[len(cs.RS_SELF_MODULE_PREFIX) :]
+                if imported_name in self.import_mapping.get(effective_qn, {}):
+                    # A `{self}` module binding is weak: types and values are
+                    # separate namespaces in Rust but one slot here, so it
+                    # yields to whatever a previous `use` bound (issue #1054).
+                    continue
             resolved_imports[imported_name] = resolved
             if sub_scope:
                 # The generic deferral loop only reads the file-level map;

--- a/codebase_rag/parsers/rs/utils.py
+++ b/codebase_rag/parsers/rs/utils.py
@@ -79,12 +79,15 @@ def _process_use_tree(node: Node, base_path: str, imports: dict[str, str]) -> No
             # and those spellings resolve by trie luck instead (issue #1054).
             if base_path:
                 name = base_path.rsplit(cs.SEPARATOR_DOUBLE_COLON, maxsplit=1)[-1]
-                # A relative base (`use super::{self, x}`) ends in a keyword,
-                # which is no name at all: the module is in scope under a name
-                # only the resolved path knows, so bind nothing rather than
-                # something wrong.
+                # A relative base (`use super::{self, x}`) leaves a keyword
+                # where the name would be, and rustc rejects that spelling
+                # outright ("imports need to be explicitly named"), so there is
+                # no binding to record.
                 if name not in cs.RS_PATH_KEYWORDS:
-                    imports[name] = base_path
+                    # Marked weak: the name comes from the path rather than the
+                    # source, and it must not evict a name another `use` bound
+                    # in the other namespace (see the constant).
+                    imports[f"{cs.RS_SELF_MODULE_PREFIX}{name}"] = base_path
 
         case _:
             for child in node.children:

--- a/codebase_rag/parsers/rs/utils.py
+++ b/codebase_rag/parsers/rs/utils.py
@@ -72,7 +72,19 @@ def _process_use_tree(node: Node, base_path: str, imports: dict[str, str]) -> No
             _process_scoped_use_list(node, base_path, imports)
 
         case cs.KEYWORD_SELF:
-            imports[cs.KEYWORD_SELF] = base_path or cs.KEYWORD_SELF
+            # `use std::io::{self, Write}` imports the base path ITSELF, in
+            # scope under its own last segment (`io`), which is the name every
+            # later `io::...` spelling in the file is written against. Keyed on
+            # the keyword the binding is unreachable, the real name is absent,
+            # and those spellings resolve by trie luck instead (issue #1054).
+            if base_path:
+                name = base_path.rsplit(cs.SEPARATOR_DOUBLE_COLON, maxsplit=1)[-1]
+                # A relative base (`use super::{self, x}`) ends in a keyword,
+                # which is no name at all: the module is in scope under a name
+                # only the resolved path knows, so bind nothing rather than
+                # something wrong.
+                if name not in cs.RS_PATH_KEYWORDS:
+                    imports[name] = base_path
 
         case _:
             for child in node.children:

--- a/codebase_rag/tests/test_multilang_import_parsing.py
+++ b/codebase_rag/tests/test_multilang_import_parsing.py
@@ -242,8 +242,11 @@ fn main() {
             "submod2": f"{project_name}.module2.submod2",
             "local_module": f"{project_name}.test.local_module",
             "parent_module": f"{project_name}.parent_module",
-            "self": project_name,
         }
+        # `use super::{self, parent_module}` binds the parent module under a
+        # name only its resolved path knows, so the `self` part contributes no
+        # entry; keyed on the keyword it was unreachable anyway (issue #1054).
+        assert "self" not in actual_imports
 
         for name, path in expected.items():
             assert name in actual_imports, f"Missing import: {name}"

--- a/codebase_rag/tests/test_rust_self_import_binding.py
+++ b/codebase_rag/tests/test_rust_self_import_binding.py
@@ -100,7 +100,9 @@ def test_self_import_does_not_displace_a_same_named_value_import(
             ),
             "src/io.rs": "pub fn open() -> i32 {\n    1\n}\n",
             "src/helpers.rs": "pub fn io() -> i32 {\n    5\n}\n",
-            "src/aaa.rs": "pub fn io() -> i32 {\n    9\n}\n",
+            "src/aaa.rs": (
+                "pub fn io() -> i32 {\n    9\n}\n\npub fn open() -> i32 {\n    7\n}\n"
+            ),
             "src/app.rs": (
                 "use crate::helpers::io;\n"
                 "use crate::io::{self};\n"
@@ -116,6 +118,10 @@ def test_self_import_does_not_displace_a_same_named_value_import(
     caller = "rs_self_collide.src.app.run"
     assert (caller, "rs_self_collide.src.helpers.io") in calls, calls
     assert (caller, "rs_self_collide.src.aaa.io") not in calls, calls
+    # The module-qualified call still belongs to the module namespace, so it
+    # must reach io.rs and not the decoy the suffix trie would otherwise find.
+    assert (caller, "rs_self_collide.src.io.open") in calls, calls
+    assert (caller, "rs_self_collide.src.aaa.open") not in calls, calls
 
 
 def test_self_alias_import_still_binds_under_the_alias(

--- a/codebase_rag/tests/test_rust_self_import_binding.py
+++ b/codebase_rag/tests/test_rust_self_import_binding.py
@@ -1,0 +1,112 @@
+"""A brace-list `self` import binds the module under its own name.
+
+`use crate::io::{self, Reader};` puts the module in scope as `io`, but the
+import mapping keyed the entry on the `self` keyword, a name nothing ever
+looks up, so every later `io::...` spelling in the file resolved to nothing
+(issue #1054).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.test_rust_crate_path_trait_linking import (
+    _calls,
+    _write,
+    create_and_run_updater,
+)
+
+
+def test_brace_self_import_binds_module_qualified_call(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `use crate::io::{self, Reader};` puts the MODULE in scope as `io`, so a
+    # later `io::open()` resolves through it. Keyed on the `self` keyword the
+    # binding is unreachable and the call falls to the trie, which happily
+    # picks the caller's own same-named decoy.
+    project = temp_repo / "rs_self_import"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\n',
+            "src/lib.rs": "pub mod io;\npub mod app;\npub mod decoy;\n",
+            "src/io.rs": ("pub struct Reader;\n\npub fn open() -> i32 {\n    1\n}\n"),
+            "src/decoy.rs": "pub fn open() -> i32 {\n    2\n}\n",
+            "src/app.rs": (
+                "use crate::io::{self, Reader};\n"
+                "\n"
+                "pub fn run() -> i32 {\n"
+                "    let _r = Reader;\n"
+                "    io::open()\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    caller = "rs_self_import.src.app.run"
+    assert (caller, "rs_self_import.src.io.open") in calls, calls
+    assert (caller, "rs_self_import.src.decoy.open") not in calls, calls
+
+
+def test_nested_brace_self_import_binds_module_qualified_call(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The same `self` nested one level deeper (`use crate::{io::{self}, util}`),
+    # where the base path is assembled from two enclosing lists rather than a
+    # single scoped prefix.
+    project = temp_repo / "rs_self_nested"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\n',
+            "src/lib.rs": "pub mod io;\npub mod util;\npub mod app;\npub mod decoy;\n",
+            "src/io.rs": "pub fn open() -> i32 {\n    1\n}\n",
+            "src/util.rs": "pub fn helper() -> i32 {\n    3\n}\n",
+            "src/decoy.rs": "pub fn open() -> i32 {\n    2\n}\n",
+            "src/app.rs": (
+                "use crate::{io::{self}, util};\n"
+                "\n"
+                "pub fn run() -> i32 {\n"
+                "    let _ = util::helper();\n"
+                "    io::open()\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    caller = "rs_self_nested.src.app.run"
+    assert (caller, "rs_self_nested.src.io.open") in calls, calls
+    assert (caller, "rs_self_nested.src.decoy.open") not in calls, calls
+
+
+def test_self_alias_import_still_binds_under_the_alias(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `use crate::io::{self as sys};` renames the module. The alias form takes
+    # a different code path, so binding the plain form must not disturb it: the
+    # module answers to `sys`, and to nothing else.
+    project = temp_repo / "rs_self_alias"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\n',
+            "src/lib.rs": "pub mod io;\npub mod app;\npub mod decoy;\n",
+            "src/io.rs": "pub fn open() -> i32 {\n    1\n}\n",
+            "src/decoy.rs": "pub fn open() -> i32 {\n    2\n}\n",
+            "src/app.rs": (
+                "use crate::io::{self as sys};\n"
+                "\n"
+                "pub fn run() -> i32 {\n"
+                "    sys::open()\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    caller = "rs_self_alias.src.app.run"
+    assert (caller, "rs_self_alias.src.io.open") in calls, calls
+    assert (caller, "rs_self_alias.src.decoy.open") not in calls, calls

--- a/codebase_rag/tests/test_rust_self_import_binding.py
+++ b/codebase_rag/tests/test_rust_self_import_binding.py
@@ -82,6 +82,42 @@ def test_nested_brace_self_import_binds_module_qualified_call(
     assert (caller, "rs_self_nested.src.decoy.open") not in calls, calls
 
 
+def test_self_import_does_not_displace_a_same_named_value_import(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # Rust keeps types and values in separate namespaces, so a module `io`
+    # and a function `io` are both in scope in one file, legally. The import
+    # map has one slot per name, so the module binding must not evict the
+    # function another `use` already bound: the bare `io()` call would fall
+    # to the trie and pick a same-named decoy in an unrelated module.
+    project = temp_repo / "rs_self_collide"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\n',
+            "src/lib.rs": (
+                "pub mod io;\npub mod helpers;\npub mod aaa;\npub mod app;\n"
+            ),
+            "src/io.rs": "pub fn open() -> i32 {\n    1\n}\n",
+            "src/helpers.rs": "pub fn io() -> i32 {\n    5\n}\n",
+            "src/aaa.rs": "pub fn io() -> i32 {\n    9\n}\n",
+            "src/app.rs": (
+                "use crate::helpers::io;\n"
+                "use crate::io::{self};\n"
+                "\n"
+                "pub fn run() -> i32 {\n"
+                "    io() + io::open()\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    caller = "rs_self_collide.src.app.run"
+    assert (caller, "rs_self_collide.src.helpers.io") in calls, calls
+    assert (caller, "rs_self_collide.src.aaa.io") not in calls, calls
+
+
 def test_self_alias_import_still_binds_under_the_alias(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:

--- a/codebase_rag/tests/test_rust_utils.py
+++ b/codebase_rag/tests/test_rust_utils.py
@@ -595,10 +595,14 @@ class TestExtractUseImportsEdgeCases:
         assert use_node is not None
 
         result = extract_use_imports(use_node)
-        assert "self" in result
+        # `{self}` binds the base path under the name it is in scope as, `fs`.
+        # Keyed on the keyword instead, the entry was unreachable and every
+        # `fs::...` spelling in the file resolved to nothing (issue #1054).
+        assert "fs" in result
+        assert "self" not in result
         assert "File" in result
         assert "read_to_string" in result
-        assert result["self"] == "std::fs"
+        assert result["fs"] == "std::fs"
         assert result["File"] == "std::fs::File"
         assert result["read_to_string"] == "std::fs::read_to_string"
 

--- a/codebase_rag/tests/test_rust_utils.py
+++ b/codebase_rag/tests/test_rust_utils.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from codebase_rag import constants as cs
 from codebase_rag.parser_loader import load_parsers
 from codebase_rag.parsers.rs.utils import (
     build_module_path,
@@ -595,14 +596,16 @@ class TestExtractUseImportsEdgeCases:
         assert use_node is not None
 
         result = extract_use_imports(use_node)
-        # `{self}` binds the base path under the name it is in scope as, `fs`.
-        # Keyed on the keyword instead, the entry was unreachable and every
-        # `fs::...` spelling in the file resolved to nothing (issue #1054).
-        assert "fs" in result
+        # `{self}` binds the base path under the name it is in scope as, `fs`,
+        # marked weak because the name comes from the path rather than the
+        # source. Keyed on the keyword instead, the entry was unreachable and
+        # every `fs::...` spelling in the file resolved to nothing (#1054).
+        weak_fs = f"{cs.RS_SELF_MODULE_PREFIX}fs"
+        assert weak_fs in result
         assert "self" not in result
         assert "File" in result
         assert "read_to_string" in result
-        assert result["fs"] == "std::fs"
+        assert result[weak_fs] == "std::fs"
         assert result["File"] == "std::fs::File"
         assert result["read_to_string"] == "std::fs::read_to_string"
 

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.538"
+version = "0.0.539"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #1054.

## What

`use std::io::{self, IsTerminal};` records the imported module under the literal key `self` instead of the name it actually binds, `io`. A `self` entry in a brace list imports the base path itself, in scope under its last segment, and every later `io::...` spelling in that file is written against that name. Nothing ever looks up `self`, so the binding was unreachable while the real name was absent from the map.

The damage is not a silent miss. With no entry for the head, a qualified call falls through to the trie, which picks any same-named function it can find:

```rust
// src/app.rs
use crate::io::{self, Reader};
pub fn run() -> i32 { io::open() }   // bound to src/decoy.rs::open, not src/io.rs::open
```

## Where the name comes from

The bound name is the base path's last segment, so `use std::io::{self, Write}` records `io -> std::io`, and the nested form `use crate::{io::{self}, util}` behaves the same once the enclosing lists have assembled the base.

A relative base is the exception: `use super::{self, parent_module}` ends in a keyword, which is no name at all, and the name the parent module is in scope under is knowable only from the resolved path, which this layer does not have. That shape binds nothing rather than something wrong. The alias form (`use crate::io::{self as sys}`) already resolved through a separate path and is untouched, with a regression guard added.

## Two changed expectations

Two existing tests asserted that `self` is a key in the import map, one on `use std::fs::{self, File, read_to_string}` and one on `use super::{self, parent_module}`. Both pinned the defect rather than a behaviour: no consumer reads that key (path HEADS spelled `self::x` are handled elsewhere, on the value side), so the entry was unreachable data. They now assert the reachable binding and its absence respectively.

## The binding is weak

Rust keeps types and values in separate namespaces, so a module `io` and a function `io` are both in scope in one file, legally, while the import map holds one slot per name. A `{self}` entry therefore never displaces a name another `use` in the same scope already bound: it is recorded under a marked key that the import processor drops when the slot is taken. Without that, adding the binding would have evicted the function and sent a bare `io()` call to the trie, which picks any same-named function it can find.

The reverse order, a later `use` overwriting the module binding, is the flat map's existing limit and is unchanged by this PR.

## TDD

RED first: 3 of the 4 tests in `test_rust_self_import_binding.py` fail before the fix, the direct and nested brace-list forms and the namespace collision, each showing the call bound to a decoy in an unrelated module. The fourth is the alias regression guard, green throughout by design.

Full suite: 6797 passed, 10 skipped, against a 6793 / 10 baseline on `main`, so the delta is exactly the 4 tests this branch adds, with no new skips, xfails or deselections.

## Adversarial review

One round, two findings, both acted on.

1. Confirmed regression: the new binding was written unconditionally, so a file importing both a module and a function of the same name lost the function, and its bare call bound to a decoy. Fixed by the weak binding above, pinned RED first.
2. The keyword branch's comment was factually wrong. `use super::{self, x}` is not a construct whose name is merely unknowable here; rustc rejects it outright ("imports need to be explicitly named"). The guard stays, since this parses whatever is on disk, but the comment now says why. One pre-existing fixture in `test_multilang_import_parsing.py` contains that uncompilable spelling, and its assertion now records that nothing is bound.

## Measurements

Live ripgrep: 189 to 187, 0 newly listed, on this change alone, since it mostly repairs call edges rather than roots.

On top of #1048, now merged, it takes ripgrep from 189 to 161, 28 resolved and 0 newly listed. The extra 6 over #1048's own 22 are exactly the candidates that needed this head to resolve: both `io::Write` methods on `StandardStream`, `CommandReader.read`, `DecompressionReader.read`, and a closure inside a revived method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Rust import handling for `{self}` module bindings.
  * Correctly resolves module-qualified calls and nested imports.
  * Prevents conflicting imports from overriding existing bindings.
  * Supports aliased `self` imports more reliably.

* **Tests**
  * Added regression coverage for Rust self-import resolution and collision scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->