### PR TITLE
docs(flow): correct the stale return-taint ordering ceiling

### DIFF
--- a/docs/architecture/data-flow-edges.md
+++ b/docs/architecture/data-flow-edges.md
@@ -351,17 +351,20 @@ module is re-exported under its own name. A project that does
 
 ## Scope of the current phase
 
-`FLOWS_TO` is intentionally conservative and intra-procedural in this phase:
+`FLOWS_TO` is intentionally conservative in this phase:
 
-- Value flow is tracked within a function body plus one level of argument/return
-  hand-off. A callee returning **different** sources on different branches carries
-  every origin to its callers. It is not path-sensitive: a kill on one branch of an
-  `if`/`else` drops taint conservatively.
-- Return-taint propagation is a single source-order pass, so a callee whose body is
-  processed **after** its caller (typically cross-file) is not yet known to return a
-  tainted value at the caller's site.
-- Sources and sinks are direct I/O calls from the registry; there are no
-  `Parameter` nodes and no SSA-level precision.
+- Value flow inside a function body is tracked by an intra-procedural walk. A callee
+  returning **different** sources on different branches carries every origin to its
+  callers. It is not path-sensitive: a kill on one branch of an `if`/`else` drops
+  taint conservatively.
+- Return taint composes **transitively across functions and files**. Per-function
+  summaries are resolved by a worklist fixpoint once every file has been walked, so
+  a callee defined after (or in a different file from) its caller is still known to
+  return a tainted value at the caller's site.
+- Argument hand-off is one level: an `ARG` edge records that a tainted value reached
+  a call, but the taint does not enter the callee's body. There are no `Parameter`
+  nodes and no SSA-level precision, and sources and sinks are direct I/O calls from
+  the registry.
 - The source/sink registry covers Python, JavaScript, TypeScript (including TSX),
   Go, Java, Rust, C, C++, and C#; a language not in the registry emits no I/O or
   flow edges until its table is added.

--- a/docs/architecture/data-flow-edges.md
+++ b/docs/architecture/data-flow-edges.md
@@ -361,10 +361,10 @@ module is re-exported under its own name. A project that does
   summaries are resolved by a worklist fixpoint once every file has been walked, so
   a callee defined after (or in a different file from) its caller is still known to
   return a tainted value at the caller's site.
-- Argument hand-off is one level: an `ARG` edge records that a tainted value reached
-  a call, but the taint does not enter the callee's body. There are no `Parameter`
-  nodes and no SSA-level precision, and sources and sinks are direct I/O calls from
-  the registry.
+- Argument hand-off is one level: a `FLOWS_TO` edge with `kind = arg` records that a
+  tainted value reached a call, but the taint does not enter the callee's body. There
+  are no `Parameter` nodes and no SSA-level precision, and sources and sinks are
+  direct I/O calls from the registry.
 - The source/sink registry covers Python, JavaScript, TypeScript (including TSX),
   Go, Java, Rust, C, C++, and C#; a language not in the registry emits no I/O or
   flow edges until its table is added.

--- a/docs/architecture/graph-schema.md
+++ b/docs/architecture/graph-schema.md
@@ -78,7 +78,7 @@ The `io` capture group (opt-in; excluded from the default capture set) adds thre
 
 - **resource → resource** (`kind = resource`): a value read from one resource reaches a write to another within a function body, e.g. `x = os.getenv("K"); print(x)` yields `Resource(ENV::K) -FLOWS_TO-> Resource(STDOUT)`.
 - **caller → callee** (`kind = arg`): a tainted local value is passed as an argument to a first-party callee. A `via` edge property names the conduit as `arg:<index>` or `kw:<name>`.
-- **callee → caller** (`kind = return`, `via = return`): a callee whose return value is tainted flows that value back to the assignment in its caller.
+- **callee → caller** (`kind = return`, `via = return`): a callee whose return value is tainted flows that value back to its caller. The edge terminates at the calling function, not at the assignment that received the value.
 
 Taint is propagated through plain `x = y` assignments. `FLOWS_TO` is intentionally conservative in this phase: flow inside a body is tracked by an intra-procedural walk, return taint composes transitively across functions and files, and argument hand-off is one level.
 

--- a/docs/architecture/graph-schema.md
+++ b/docs/architecture/graph-schema.md
@@ -74,13 +74,13 @@ The `io` capture group (opt-in; excluded from the default capture set) adds thre
 
 `READS_FROM` and `WRITES_TO` connect a callable to a `Resource` it reads from or writes to (for example `os.getenv("K")` reads the `ENV` resource, `print(x)` writes the `STDOUT` resource).
 
-`FLOWS_TO` records intra-procedural value flow, turning provenance questions into graph reachability. It is emitted in three shapes, distinguished by a `kind` edge property:
+`FLOWS_TO` records value flow, turning provenance questions into graph reachability. It is emitted in three shapes, distinguished by a `kind` edge property:
 
 - **resource → resource** (`kind = resource`): a value read from one resource reaches a write to another within a function body, e.g. `x = os.getenv("K"); print(x)` yields `Resource(ENV::K) -FLOWS_TO-> Resource(STDOUT)`.
 - **caller → callee** (`kind = arg`): a tainted local value is passed as an argument to a first-party callee. A `via` edge property names the conduit as `arg:<index>` or `kw:<name>`.
 - **callee → caller** (`kind = return`, `via = return`): a callee whose return value is tainted flows that value back to the assignment in its caller.
 
-Taint is propagated through plain `x = y` assignments. `FLOWS_TO` is intentionally conservative and intra-procedural in this phase; a tainted value is only tracked within a single function body plus one level of argument/return hand-off.
+Taint is propagated through plain `x = y` assignments. `FLOWS_TO` is intentionally conservative in this phase: flow inside a body is tracked by an intra-procedural walk, return taint composes transitively across functions and files, and argument hand-off is one level.
 
 See [I/O and Data-Flow Edges](data-flow-edges.md) for the detailed reference: the taint model, propagation and kill rules, the `kind`/`via` edge properties, scope attribution, and example queries.
 

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.539"
+version = "0.0.540"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
The "Scope of the current phase" section still described return-taint propagation as a single source-order pass in which a callee walked after its caller is unknown at the call site. That ceiling was removed by #712: `FlowProcessor.finalize()` resolves per-function summaries with a worklist fixpoint once every file has been walked, so forward and cross-file return taint is emitted, transitively.

Verified against current main with the exact scenario the docs claimed would fail: `reader.py` returns `os.getenv("API_KEY")`, `app.py` prints the result. Both the cross-file `RETURN` edge and the `ENV::API_KEY` to `STDOUT` resource flow are emitted. The three existing tests in `test_forward_return_taint_e2e.py` cover this and pass.

The rewritten section separates the three distinct ceilings that were previously conflated under "intra-procedural": the body walk (intra-procedural, not path-sensitive), return taint (transitive across functions and files), and argument hand-off (one level, no taint into the callee body since parameters seed only the shadow set). `graph-schema.md` carried the same conflation and is corrected to match.

Docs only, no behaviour change. Related: #1050, which covers making an empty flow result distinguish "no flow" from "outside coverage".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that return-taint propagation works transitively across functions and files.
  * Documented that argument hand-off remains limited to one level.
  * Updated data-flow and graph-schema guidance while preserving existing resource-flow and assignment rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->