### PR TITLE
docs: state an external service policy and soften the framework rule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,7 +147,7 @@ This process ensures that human reviewers focus on high-level design and logic r
 
 ### Agentic Framework
 
-- **PydanticAI Only**: This project uses PydanticAI as the official agentic framework. Do not introduce other frameworks like LangChain, CrewAI, or AutoGen.
+- **PydanticAI for now**: PydanticAI is the agentic framework the project runs on today. That is a current choice, not a permanent commitment, and a well-argued case for moving is welcome. What it does rule out is arriving at a second framework by accident, so do not introduce one (LangChain, CrewAI, AutoGen) as part of a feature pull request. Open an issue first, as `GOVERNANCE.md` asks for architectural decisions.
 
 ### External Service Integrations
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,6 +149,15 @@ This process ensures that human reviewers focus on high-level design and logic r
 
 - **PydanticAI Only**: This project uses PydanticAI as the official agentic framework. Do not introduce other frameworks like LangChain, CrewAI, or AutoGen.
 
+### External Service Integrations
+
+Integrations with external services (search APIs, model hosts, data providers) are welcome, on these terms:
+
+- **Free tier only**: The open-source tree carries capability that works without payment. Do not add configuration that selects a vendor's paid plan, and do not document a route to one. Paid capability belongs in [Enterprise Services](https://code-graph-rag.com/enterprise), not in an environment variable here.
+- **No single-vendor lock**: A generic capability resolves its backend from configuration, the way model and embedding providers already do in `codebase_rag/config.py`. A capability that works only for holders of one vendor's key is not a capability this project has.
+- **Keyless default**: Where a provider needs no account, it is the default, so the feature works on a fresh checkout.
+- **Disclose affiliation**: If you work for, or are compensated by, the service you are integrating, say so in the pull request description.
+
 ### Code Standards
 
 - **Heavy Pydantic Usage**: Use Pydantic models extensively for data validation, serialisation, and configuration

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -77,7 +77,8 @@ This project uses automated code review bots (**Greptile** and **Gemini Code Ass
 
 ## Technical Requirements
 
-- **PydanticAI Only**: Do not introduce other agentic frameworks (LangChain, CrewAI, AutoGen, etc.)
+- **PydanticAI for now**: The current framework choice, open to a well-argued change. Do not add a second one (LangChain, CrewAI, AutoGen) in a feature PR; open an issue first
+- **External services**: Integrations use free tiers only, resolve their backend from configuration rather than hard-coding one vendor, and default to a keyless provider where one exists. Paid capability belongs in [Enterprise Services](https://code-graph-rag.com/enterprise)
 - **Heavy Pydantic Usage**: Use Pydantic models for data validation, serialisation, and configuration
 - **Package Management**: Use `uv` for all dependency management
 - **Code Quality**: Use `ruff` for linting and formatting

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -78,7 +78,7 @@ This project uses automated code review bots (**Greptile** and **Gemini Code Ass
 ## Technical Requirements
 
 - **PydanticAI for now**: The current framework choice, open to a well-argued change. Do not add a second one (LangChain, CrewAI, AutoGen) in a feature PR; open an issue first
-- **External services**: Integrations use free tiers only, resolve their backend from configuration rather than hard-coding one vendor, and default to a keyless provider where one exists. Paid capability belongs in [Enterprise Services](https://code-graph-rag.com/enterprise)
+- **External services**: Integrations use free tiers only, resolve their backend from configuration rather than hard-coding one vendor, and default to a keyless provider where one exists. Paid capability belongs in [Enterprise Services](https://code-graph-rag.com/enterprise). Contributors integrating a service they are compensated by disclose that in the PR description. See [`CONTRIBUTING.md`](https://github.com/vitali87/code-graph-rag/blob/main/CONTRIBUTING.md) for the full terms
 - **Heavy Pydantic Usage**: Use Pydantic models for data validation, serialisation, and configuration
 - **Package Management**: Use `uv` for all dependency management
 - **Code Quality**: Use `ruff` for linting and formatting

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.540"
+version = "0.0.542"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Two changes to the Technical Requirements section of `CONTRIBUTING.md`, with `docs/contributing.md` kept in step.

**1. Adds an External Service Integrations section.**

The project already advertises Enterprise Services in the README, and `GOVERNANCE.md` gives the lead maintainer the final call on significant decisions, but nothing stated what the open tree may carry when a contribution wires in a third-party commercial service. PR #955 surfaced the gap: it shipped a paid-tier selector behind an environment variable, and a contributor had no written rule to check against. Four terms:

- **Free tier only.** Paid capability belongs in [Enterprise Services](https://code-graph-rag.com/enterprise), not in an environment variable in the open tree.
- **No single-vendor lock.** A generic capability resolves its backend from configuration, as model and embedding providers already do in `codebase_rag/config.py`.
- **Keyless default.** Where a provider needs no account, it is the default, so the feature works on a fresh checkout.
- **Disclose affiliation.** Contributors integrating a service they are compensated by say so in the PR description.

**2. Softens "PydanticAI Only" to "PydanticAI for now".**

The old wording read as a permanent prohibition. PydanticAI is the current choice and a well-argued case for moving is welcome. What the rule actually needs to prevent is arriving at a second framework by accident inside a feature PR, so the requirement is now to open an issue first, which is what `GOVERNANCE.md` already asks for architectural decisions.

## Type of Change

Documentation.

## Related Issues

Context for the changes requested on #955.

## Test Plan

Documentation only, no code paths touched. `uv run pre-commit run --files CONTRIBUTING.md docs/contributing.md` passes.

The `uv.lock` line syncs the recorded version to the 0.0.542 already on `main`.

## Checklist

- [x] Follows the existing document structure
- [x] Root guide and its `docs/` summary agree
- [x] Pre-commit passes
- [x] No code changes, so no tests required


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contribution guidelines for external service integrations.
  * Clarified requirements for free-tier functionality, vendor-neutral configuration, keyless defaults, and disclosure of service affiliations.
  * Documented architectural review requirements for introducing alternative agentic frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->