### PR TITLE
fix: bind a Rust block-local item over the enclosing function body use

### DIFF
--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -848,7 +848,7 @@ class CallResolver:
         # cached under the file-scoped key.
         if language == cs.SupportedLanguage.RUST and caller_qn:
             scoped = self._try_resolve_rust_inline_scope(
-                call_name, module_qn, caller_qn
+                call_name, module_qn, caller_qn, call_point
             )
             if scoped is not None:
                 return scoped[0]
@@ -1331,7 +1331,7 @@ class CallResolver:
         return None
 
     def _try_resolve_rust_inline_scope(
-        self, call_name: str, module_qn: str, caller_qn: str
+        self, call_name: str, module_qn: str, caller_qn: str, call_point: int | None
     ) -> tuple[tuple[str, str] | None] | None:
         """Resolve a bare call through the caller's enclosing Rust scopes.
 
@@ -1342,7 +1342,11 @@ class CallResolver:
         the file module, checking each scope's own items, the caller's
         weak entries (its enclosing mod's use fanned out per function, in
         case the mod's shared key was arbitrated to a twin), and the
-        scope's import map. Initializer-block uses are served earlier, by
+        scope's import map. A body use loses to an item the call's own
+        enclosing block declares, whose flat-registered node the later
+        probes find (issue #1026); the walk below needs no such gate,
+        since it consults each scope's own items first already.
+        Initializer-block uses are served earlier, by
         the site-gated probe in _resolve_function_call. Returns a 1-tuple
         so a deliberate drop (the scope imports the name from OUTSIDE the
         indexed first-party graph) is distinguishable from "no scope
@@ -1358,6 +1362,10 @@ class CallResolver:
         target = self.import_processor.rust_fn_scope_imports.get(caller_qn, {}).get(
             call_name
         )
+        if target is not None and self._rust_block_item_shadows(
+            caller_qn, call_name, call_point
+        ):
+            target = None
         if target is None:
             weak = self.import_processor.rust_fn_scope_mod_imports.get(
                 caller_qn, {}
@@ -1381,6 +1389,19 @@ class CallResolver:
         if target is None:
             return None
         return (self._follow_rust_scope_target(target),)
+
+    def _rust_block_item_shadows(
+        self, caller_qn: str, name: str, call_point: int | None
+    ) -> bool:
+        """Does a block enclosing this site declare `name` as its own item?"""
+        if call_point is None:
+            return False
+        return any(
+            start <= call_point < end and name in names
+            for start, end, names in self.import_processor.rust_fn_scope_item_holes.get(
+                caller_qn, ()
+            )
+        )
 
     def _try_resolve_rust_module_qualified(
         self, call_name: str, module_qn: str, caller_qn: str | None

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -1342,10 +1342,11 @@ class CallResolver:
         the file module, checking each scope's own items, the caller's
         weak entries (its enclosing mod's use fanned out per function, in
         case the mod's shared key was arbitrated to a twin), and the
-        scope's import map. A body use loses to an item the call's own
-        enclosing block declares, whose flat-registered node the later
-        probes find (issue #1026); the walk below needs no such gate,
-        since it consults each scope's own items first already.
+        scope's import map. An item declared by a block the call sits
+        inside outranks the body use and every one of those scopes, and
+        binds by SPAN: the block item and a same-named item at module
+        level both register flat in one module, so a name lookup would
+        answer with whichever of them took the natural qn (issue #1026).
         Initializer-block uses are served earlier, by
         the site-gated probe in _resolve_function_call. Returns a 1-tuple
         so a deliberate drop (the scope imports the name from OUTSIDE the
@@ -1359,13 +1360,11 @@ class CallResolver:
         ):
             return None
         import_mapping = self.import_processor.import_mapping
+        if item_qn := self._rust_block_item_at(caller_qn, call_name, call_point):
+            return ((self.function_registry[item_qn], item_qn),)
         target = self.import_processor.rust_fn_scope_imports.get(caller_qn, {}).get(
             call_name
         )
-        if target is not None and self._rust_block_item_shadows(
-            caller_qn, call_name, call_point
-        ):
-            target = None
         if target is None:
             weak = self.import_processor.rust_fn_scope_mod_imports.get(
                 caller_qn, {}
@@ -1390,18 +1389,28 @@ class CallResolver:
             return None
         return (self._follow_rust_scope_target(target),)
 
-    def _rust_block_item_shadows(
+    def _rust_block_item_at(
         self, caller_qn: str, name: str, call_point: int | None
-    ) -> bool:
-        """Does a block enclosing this site declare `name` as its own item?"""
+    ) -> str | None:
+        """The item `name` binds to in the innermost block holding this site.
+
+        Innermost wins: nested blocks may each declare the name, and only
+        the tightest one is in scope where the call is written.
+        """
         if call_point is None:
-            return False
-        return any(
-            start <= call_point < end and name in names
-            for start, end, names in self.import_processor.rust_fn_scope_item_holes.get(
-                caller_qn, ()
-            )
-        )
+            return None
+        best: tuple[int, str] | None = None
+        for start, end, items in self.import_processor.rust_fn_scope_item_holes.get(
+            caller_qn, ()
+        ):
+            item_qn = items.get(name)
+            if item_qn is None or not (start <= call_point < end):
+                continue
+            if (best is None or end - start < best[0]) and (
+                item_qn in self.function_registry
+            ):
+                best = (end - start, item_qn)
+        return best[1] if best else None
 
     def _try_resolve_rust_module_qualified(
         self, call_name: str, module_qn: str, caller_qn: str | None
@@ -1673,7 +1682,7 @@ class CallResolver:
             if any(s <= call_point < e for s, e in mod_holes):
                 continue
             if any(
-                s <= call_point < e and name in names for s, e, names in item_scopes
+                s <= call_point < e and name in items for s, e, items in item_scopes
             ):
                 continue
             size = end - start

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -1359,35 +1359,51 @@ class CallResolver:
             or not caller_qn.startswith(f"{module_qn}{cs.SEPARATOR_DOT}")
         ):
             return None
-        import_mapping = self.import_processor.import_mapping
         if item_qn := self._rust_block_item_at(caller_qn, call_name, call_point):
             return ((self.function_registry[item_qn], item_qn),)
         target = self.import_processor.rust_fn_scope_imports.get(caller_qn, {}).get(
             call_name
         )
         if target is None:
-            weak = self.import_processor.rust_fn_scope_mod_imports.get(
-                caller_qn, {}
-            ).get(call_name)
-            scope = caller_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
-            while len(scope) > len(module_qn):
-                # The scope segment may be an impl target whose method a
-                # bare path can never name (issue #1011).
-                if local := self._scope_candidate(
-                    scope, call_name, cs.SupportedLanguage.RUST
-                ):
-                    return (local,)
-                target = (
-                    weak
-                    if weak is not None
-                    else import_mapping.get(scope, {}).get(call_name)
-                )
-                if target is not None:
-                    break
-                scope = scope.rsplit(cs.SEPARATOR_DOT, 1)[0]
+            local, target = self._rust_walk_enclosing_scopes(
+                call_name, module_qn, caller_qn
+            )
+            if local is not None:
+                return (local,)
         if target is None:
             return None
         return (self._follow_rust_scope_target(target),)
+
+    def _rust_walk_enclosing_scopes(
+        self, call_name: str, module_qn: str, caller_qn: str
+    ) -> tuple[tuple[str, str] | None, str | None]:
+        """Walk the caller's inline mods outwards for an item or an import.
+
+        Returns (resolved item, import target): the first scope owning the
+        name as its own item answers outright, otherwise the innermost
+        binding found on the way out is handed back for following.
+        """
+        import_mapping = self.import_processor.import_mapping
+        weak = self.import_processor.rust_fn_scope_mod_imports.get(caller_qn, {}).get(
+            call_name
+        )
+        scope = caller_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
+        while len(scope) > len(module_qn):
+            # The scope segment may be an impl target whose method a
+            # bare path can never name (issue #1011).
+            if local := self._scope_candidate(
+                scope, call_name, cs.SupportedLanguage.RUST
+            ):
+                return local, None
+            target = (
+                weak
+                if weak is not None
+                else import_mapping.get(scope, {}).get(call_name)
+            )
+            if target is not None:
+                return None, target
+            scope = scope.rsplit(cs.SEPARATOR_DOT, 1)[0]
+        return None, None
 
     def _rust_block_item_at(
         self, caller_qn: str, name: str, call_point: int | None

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -407,6 +407,7 @@ class ImportProcessor:
         "_rust_pending_fn_scope_uses",
         "rust_fn_scope_imports",
         "rust_fn_scope_mod_imports",
+        "rust_fn_scope_item_holes",
         "rust_block_scope_imports",
         "rust_self_module_imports",
         "_rust_fn_scope_keys",
@@ -487,7 +488,16 @@ class ImportProcessor:
         # The bool marks WEAK entries: an impure inline mod's use fanned
         # out to the functions declared in its block.
         self._rust_pending_fn_scope_uses: dict[
-            str, list[tuple[int, int, dict[str, str], bool]]
+            str,
+            list[
+                tuple[
+                    int,
+                    int,
+                    dict[str, str],
+                    bool,
+                    list[tuple[int, int, frozenset[str]]],
+                ]
+            ],
         ] = {}
         # Function-body uses, keyed by the enclosing function's registered
         # qn. Kept OUT of import_mapping: Rust puts `mod run` and `fn run`
@@ -499,6 +509,14 @@ class ImportProcessor:
         # resolver consults it only after local items, unlike the body-use
         # map above which shadows everything.
         self.rust_fn_scope_mod_imports: dict[str, dict[str, str]] = {}
+        # Spans of the nested blocks inside a function body that declare
+        # function items directly, with those names, keyed by the same qn
+        # as the body-use map above. Every plain block is an item scope in
+        # Rust, so a call written inside one binds the block's own item and
+        # never the body use the map holds (issue #1026).
+        self.rust_fn_scope_item_holes: dict[
+            str, list[tuple[int, int, frozenset[str]]]
+        ] = {}
         # Uses inside const/static initializer blocks, keyed by file
         # module qn: (block start byte, block end byte, imports, nested
         # mod spans, nested fn spans, nested item scopes with their
@@ -2391,6 +2409,7 @@ class ImportProcessor:
         for key in self._rust_fn_scope_keys.pop(module_qn, ()):
             self.rust_fn_scope_imports.pop(key, None)
             self.rust_fn_scope_mod_imports.pop(key, None)
+            self.rust_fn_scope_item_holes.pop(key, None)
         for key in self._rust_inline_scope_keys.pop(module_qn, ()):
             self.import_mapping.pop(key, None)
 
@@ -2460,6 +2479,7 @@ class ImportProcessor:
                         scope_node.start_point[1],
                         resolved_imports,
                         False,
+                        rs_utils.rust_block_scope_holes(scope_node)[2],
                     )
                 )
             else:
@@ -2513,7 +2533,7 @@ class ImportProcessor:
             # ends up holding.
             for line, col in rs_utils.enclosing_mod_fn_spans(use_node):
                 self._rust_pending_fn_scope_uses.setdefault(module_qn, []).append(
-                    (line, col, resolved_imports, True)
+                    (line, col, resolved_imports, True, [])
                 )
 
     def retract_rust_mod_scope_uses(self, module_qn: str) -> None:
@@ -2599,6 +2619,7 @@ class ImportProcessor:
             start_col,
             imports,
             weak,
+            item_holes,
         ) in self._rust_pending_fn_scope_uses.pop(module_qn, []):
             location = function_locations.get((module_qn, start_line, start_col))
             if location is None:
@@ -2612,6 +2633,7 @@ class ImportProcessor:
                 self.rust_fn_scope_mod_imports.setdefault(key, {}).update(imports)
             else:
                 self.rust_fn_scope_imports.setdefault(key, {}).update(imports)
+                self.rust_fn_scope_item_holes[key] = item_holes
             self._rust_fn_scope_keys.setdefault(module_qn, set()).add(key)
 
     def _parse_go_imports(self, captures: dict, module_qn: str) -> None:

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -495,7 +495,7 @@ class ImportProcessor:
                     int,
                     dict[str, str],
                     bool,
-                    list[tuple[int, int, frozenset[str]]],
+                    list[tuple[int, int, dict[str, tuple[int, int]]]],
                 ]
             ],
         ] = {}
@@ -510,12 +510,13 @@ class ImportProcessor:
         # map above which shadows everything.
         self.rust_fn_scope_mod_imports: dict[str, dict[str, str]] = {}
         # Spans of the nested blocks inside a function body that declare
-        # function items directly, with those names, keyed by the same qn
-        # as the body-use map above. Every plain block is an item scope in
-        # Rust, so a call written inside one binds the block's own item and
-        # never the body use the map holds (issue #1026).
+        # function items directly, each mapped to the REGISTERED qn of the
+        # item it declares, keyed by the same qn as the body-use map above.
+        # Every plain block is an item scope in Rust, so a call written
+        # inside one binds that block's own item, never the body use the
+        # map holds nor whatever else answers to the name (issue #1026).
         self.rust_fn_scope_item_holes: dict[
-            str, list[tuple[int, int, frozenset[str]]]
+            str, list[tuple[int, int, dict[str, str]]]
         ] = {}
         # Uses inside const/static initializer blocks, keyed by file
         # module qn: (block start byte, block end byte, imports, nested
@@ -537,7 +538,7 @@ class ImportProcessor:
                     dict[str, str],
                     list[tuple[int, int]],
                     list[tuple[int, int]],
-                    list[tuple[int, int, frozenset[str]]],
+                    list[tuple[int, int, dict[str, tuple[int, int]]]],
                 ]
             ],
         ] = {}
@@ -2633,7 +2634,17 @@ class ImportProcessor:
                 self.rust_fn_scope_mod_imports.setdefault(key, {}).update(imports)
             else:
                 self.rust_fn_scope_imports.setdefault(key, {}).update(imports)
-                self.rust_fn_scope_item_holes[key] = item_holes
+                self.rust_fn_scope_item_holes[key] = [
+                    (start, end, resolved)
+                    for start, end, items in item_holes
+                    if (
+                        resolved := {
+                            name: item.qualified_name
+                            for name, span in items.items()
+                            if (item := function_locations.get((module_qn, *span)))
+                        }
+                    )
+                ]
             self._rust_fn_scope_keys.setdefault(module_qn, set()).add(key)
 
     def _parse_go_imports(self, captures: dict, module_qn: str) -> None:

--- a/codebase_rag/parsers/rs/utils.py
+++ b/codebase_rag/parsers/rs/utils.py
@@ -399,7 +399,7 @@ def rust_block_scope_holes(
 ) -> tuple[
     list[tuple[int, int]],
     list[tuple[int, int]],
-    list[tuple[int, int, frozenset[str]]],
+    list[tuple[int, int, dict[str, tuple[int, int]]]],
 ]:
     """Byte spans of the scope-forming items nested inside a block.
 
@@ -412,7 +412,8 @@ def rust_block_scope_holes(
     block in the subtree is an item scope in Rust (a fn body, a let or
     const initializer, an if/match/loop body alike), so each nested
     block declaring function items as DIRECT children is recorded with
-    those names, and a call inside it naming one binds the local item,
+    those items by name and span, and a call inside it naming one binds
+    that local item,
     never the initializer block's use (rustc-verified; items deeper
     inside are invisible at that block's level, and methods in impl or
     trait bodies are not bare names at all). The walk descends
@@ -421,7 +422,7 @@ def rust_block_scope_holes(
     """
     mod_holes: list[tuple[int, int]] = []
     fn_holes: list[tuple[int, int]] = []
-    item_scopes: list[tuple[int, int, frozenset[str]]] = []
+    item_scopes: list[tuple[int, int, dict[str, tuple[int, int]]]] = []
     stack = list(block.children)
     while stack:
         current = stack.pop()
@@ -430,23 +431,32 @@ def rust_block_scope_holes(
         elif current.type == cs.TS_RS_FUNCTION_ITEM:
             fn_holes.append((current.start_byte, current.end_byte))
         elif current.type == cs.TS_RS_BLOCK and (
-            names := _rust_direct_block_item_names(current)
+            items := _rust_direct_block_items(current)
         ):
-            item_scopes.append((current.start_byte, current.end_byte, names))
+            item_scopes.append((current.start_byte, current.end_byte, items))
         stack.extend(current.children)
     return mod_holes, fn_holes, item_scopes
 
 
-def _rust_direct_block_item_names(block_node: Node) -> frozenset[str]:
-    names: set[str] = set()
+def _rust_direct_block_items(block_node: Node) -> dict[str, tuple[int, int]]:
+    """Function items declared directly in a block, by name and span key.
+
+    The span (1-based line, column) is the item's identity: a block item
+    and a same-named item at module level register flat in one module, so
+    only the span tells a caller which of them a call in the block binds.
+    """
+    items: dict[str, tuple[int, int]] = {}
     for child in block_node.children:
         if (
             child.type == cs.TS_RS_FUNCTION_ITEM
             and (name_node := child.child_by_field_name(cs.FIELD_NAME))
             and (text := name_node.text) is not None
         ):
-            names.add(text.decode(cs.RS_ENCODING_UTF8))
-    return frozenset(names)
+            items[text.decode(cs.RS_ENCODING_UTF8)] = (
+                child.start_point[0] + 1,
+                child.start_point[1],
+            )
+    return items
 
 
 def enclosing_mod_fn_spans(node: Node) -> list[tuple[int, int]]:

--- a/codebase_rag/tests/test_rust_block_item_shadows_fn_use.py
+++ b/codebase_rag/tests/test_rust_block_item_shadows_fn_use.py
@@ -1,0 +1,113 @@
+"""A nested block's own fn item outranks the enclosing function's body use.
+
+`use crate::gamma::g;` at the top of a function body binds `g` for the
+rest of that body, but a nested block declaring its own `const fn g` is
+an item scope: calls written inside it bind the block's item, and calls
+after the block keep binding the use (issue #1026).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.test_rust_crate_path_trait_linking import (
+    _calls,
+    _write,
+    create_and_run_updater,
+)
+
+
+def test_block_item_shadows_the_enclosing_function_body_use(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    project = temp_repo / "rs_block_item"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\n',
+            "src/lib.rs": "pub mod gamma;\npub mod a;\n",
+            "src/gamma.rs": "pub const fn g() -> u32 {\n    3\n}\n",
+            "src/a.rs": (
+                "pub const fn f0() -> u32 {\n"
+                "    use crate::gamma::g;\n"
+                "    let z = {\n"
+                "        const fn g() -> u32 {\n"
+                "            21\n"
+                "        }\n"
+                "        g()\n"
+                "    };\n"
+                "    z\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    caller = "rs_block_item.src.a.f0"
+    assert (caller, "rs_block_item.src.a.g") in calls, calls
+    assert (caller, "rs_block_item.src.gamma.g") not in calls, calls
+
+
+def test_function_body_use_still_binds_outside_the_declaring_block(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The item scope is the block, not the whole body: a call written after
+    # the block closes is out of the item's reach and binds the use again.
+    project = temp_repo / "rs_block_item_after"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\n',
+            "src/lib.rs": "pub mod gamma;\npub mod a;\n",
+            "src/gamma.rs": "pub const fn g() -> u32 {\n    3\n}\n",
+            "src/a.rs": (
+                "pub const fn f0() -> u32 {\n"
+                "    use crate::gamma::g;\n"
+                "    let z = {\n"
+                "        const fn g() -> u32 {\n"
+                "            21\n"
+                "        }\n"
+                "        0\n"
+                "    };\n"
+                "    z + g()\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    caller = "rs_block_item_after.src.a.f0"
+    assert (caller, "rs_block_item_after.src.gamma.g") in calls, calls
+
+
+def test_block_item_of_another_name_leaves_the_body_use_alone(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # An item scope only shadows the names it declares; a call inside the
+    # block naming something else still binds the enclosing body's use.
+    project = temp_repo / "rs_block_item_other"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\n',
+            "src/lib.rs": "pub mod gamma;\npub mod a;\n",
+            "src/gamma.rs": "pub const fn g() -> u32 {\n    3\n}\n",
+            "src/a.rs": (
+                "pub const fn f0() -> u32 {\n"
+                "    use crate::gamma::g;\n"
+                "    let z = {\n"
+                "        const fn h() -> u32 {\n"
+                "            21\n"
+                "        }\n"
+                "        g() + h()\n"
+                "    };\n"
+                "    z\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    caller = "rs_block_item_other.src.a.f0"
+    assert (caller, "rs_block_item_other.src.gamma.g") in calls, calls

--- a/codebase_rag/tests/test_rust_block_item_shadows_fn_use.py
+++ b/codebase_rag/tests/test_rust_block_item_shadows_fn_use.py
@@ -49,6 +49,89 @@ def test_block_item_shadows_the_enclosing_function_body_use(
     assert (caller, "rs_block_item.src.gamma.g") not in calls, calls
 
 
+def test_block_item_binds_over_a_same_named_module_item(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # Standing the body use down is only half the answer: the block's own
+    # item is what the call binds, and a same-named item at module level is
+    # what a name-keyed lookup reaches for instead. Both are registered flat
+    # in the same module, so only the block item's own span tells them apart.
+    project = temp_repo / "rs_block_item_twin"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\n',
+            "src/lib.rs": "pub mod gamma;\npub mod a;\n",
+            "src/gamma.rs": "pub const fn g() -> u32 {\n    3\n}\n",
+            "src/a.rs": (
+                "pub const fn g() -> u32 {\n"
+                "    9\n"
+                "}\n"
+                "\n"
+                "pub const fn f0() -> u32 {\n"
+                "    use crate::gamma::g;\n"
+                "    let z = {\n"
+                "        const fn g() -> u32 {\n"
+                "            21\n"
+                "        }\n"
+                "        g()\n"
+                "    };\n"
+                "    z\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    caller = "rs_block_item_twin.src.a.f0"
+    # The block item registered under a span-suffixed variant, the module
+    # item having taken the natural qn first.
+    assert (caller, "rs_block_item_twin.src.a.g@8") in calls, calls
+    assert (caller, "rs_block_item_twin.src.a.g") not in calls, calls
+    assert (caller, "rs_block_item_twin.src.gamma.g") not in calls, calls
+
+
+def test_block_item_binds_over_a_same_named_inline_mod_item(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The same contest one scope deeper, where the twin is the enclosing
+    # inline mod's own item and the scope walk, not the same-module probe,
+    # is what a name lookup would answer from.
+    project = temp_repo / "rs_block_item_mod"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\n',
+            "src/lib.rs": "pub mod gamma;\npub mod a;\n",
+            "src/gamma.rs": "pub const fn g() -> u32 {\n    3\n}\n",
+            "src/a.rs": (
+                "pub mod inner {\n"
+                "    pub const fn g() -> u32 {\n"
+                "        7\n"
+                "    }\n"
+                "\n"
+                "    pub const fn f0() -> u32 {\n"
+                "        use crate::gamma::g;\n"
+                "        let z = {\n"
+                "            const fn g() -> u32 {\n"
+                "                21\n"
+                "            }\n"
+                "            g()\n"
+                "        };\n"
+                "        z\n"
+                "    }\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    caller = "rs_block_item_mod.src.a.inner.f0"
+    assert (caller, "rs_block_item_mod.src.a.inner.g@9") in calls, calls
+    assert (caller, "rs_block_item_mod.src.a.inner.g") not in calls, calls
+    assert (caller, "rs_block_item_mod.src.gamma.g") not in calls, calls
+
+
 def test_function_body_use_still_binds_outside_the_declaring_block(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.540"
+version = "0.0.542"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #1026.

A `use` at the top of a Rust function body binds its name for the rest of that body, but a nested block declaring its own function item is a separate item scope: calls written inside the block bind the block's item, and only calls outside it keep binding the `use`.

```rust
pub const fn f0() -> u32 {
    use crate::gamma::g;
    let z = {
        const fn g() -> u32 {
            21
        }
        g()          // rustc: 21, the block's own item
    };
    z
}
```

`_try_resolve_rust_inline_scope` read the caller's body uses with no regard for where the call sits, so `g()` bound `crate::gamma::g` and the block-local item took no edge at all.

## Change

Each function-body `use` now records the spans of the nested blocks in that function that declare function items directly, reusing the item-scope walk the initializer-block machinery already runs. Those items resolve to the qn the registry actually handed them, through the same span lookup the function-scope key itself goes through, and a call sited inside a block binds its item directly.

Binding by span rather than by name is the part that matters. A block item and a same-named item at module level both register flat in one module, one holding the natural qn and the other a `@<line>` variant, so a name lookup answers with whichever of them registered first. The first cut of this branch stood the `use` down and left the name lookup to it, which turned a wrong edge into a different wrong edge; the adversarial pre-push review caught it and the test that missed it had no module-level twin in its fixture.

## Tests

Red first, five of them. `test_block_item_shadows_the_enclosing_function_body_use` bound `gamma.g` before the fix. Two pin the contest against a same-named twin, one at module level and one in an enclosing inline `mod`, where the wrong answer is the twin rather than the import. Two pin the boundaries: a call after the block closes still binds the `use`, and a block declaring some other name leaves the `use` alone.

## Out of scope

A block-local item still wins by name, not by span, for a function with no body `use` at all, so a call written after the block can reach it. Filed as #1061.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Rust call resolution for nested block-scoped functions.
  * Local function declarations now correctly take precedence over imports and outer-scope functions.
  * Scope boundaries are respected so declarations do not incorrectly affect unrelated blocks.

* **Tests**
  * Added coverage for shadowing behavior across nested blocks, modules, and matching names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->