### PR TITLE
fix: scope Rust block-local items to the block that declares them

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -3695,7 +3695,20 @@ class CallProcessor:
                 callee_type = cs.NodeLabel.METHOD
                 callee_qn = init_qn
 
-            for target_qn in resolver.function_registry.variants(callee_qn):
+            targets = resolver.function_registry.variants(callee_qn)
+            if len(
+                targets
+            ) > 1 and not resolver.import_processor.rust_block_item_qns.isdisjoint(
+                targets
+            ):
+                # The dedup bucket holds a Rust block-local item beside an
+                # item of another scope. Those are different functions
+                # sharing a natural name, not spellings of one callee, and
+                # the span-gated probe already chose between them, so the
+                # hedge that fans an ambiguous callee onto its twins would
+                # cross the block boundary here (issue #1061).
+                targets = [callee_qn]
+            for target_qn in targets:
                 # A duplicate-suffixed variant may be a DIFFERENT kind of
                 # node (a TS namespace merged onto a function registers as
                 # a class); only callable variants take a CALLS edge, and

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -802,6 +802,7 @@ class CallResolver:
             and caller_qn
             and (
                 module_qn in self.import_processor.rust_block_scope_imports
+                or module_qn in self.import_processor.rust_block_items
                 or (
                     caller_qn.startswith(f"{module_qn}{cs.SEPARATOR_DOT}")
                     and (
@@ -861,7 +862,7 @@ class CallResolver:
         # this point same-module wins. Elsewhere imports shadow module-level
         # definitions.
         if language == cs.SupportedLanguage.RUST and (
-            result := self._try_resolve_same_module(call_name, module_qn)
+            result := self._try_resolve_same_module(call_name, module_qn, call_point)
         ):
             if use_cache:
                 self._simple_resolution_cache[cache_key] = result
@@ -874,7 +875,7 @@ class CallResolver:
                 self._simple_resolution_cache[cache_key] = result
             return result
 
-        if result := self._try_resolve_same_module(call_name, module_qn):
+        if result := self._try_resolve_same_module(call_name, module_qn, call_point):
             if use_cache:
                 self._simple_resolution_cache[cache_key] = result
             return result
@@ -961,7 +962,7 @@ class CallResolver:
                 self._simple_resolution_cache[cache_key] = result
             return result
 
-        result = self._try_resolve_via_trie(call_name, module_qn, language)
+        result = self._try_resolve_via_trie(call_name, module_qn, language, call_point)
         if use_cache:
             self._simple_resolution_cache[cache_key] = result
         return result
@@ -1366,7 +1367,7 @@ class CallResolver:
         )
         if target is None:
             local, target = self._rust_walk_enclosing_scopes(
-                call_name, module_qn, caller_qn
+                call_name, module_qn, caller_qn, call_point
             )
             if local is not None:
                 return (local,)
@@ -1375,7 +1376,7 @@ class CallResolver:
         return (self._follow_rust_scope_target(target),)
 
     def _rust_walk_enclosing_scopes(
-        self, call_name: str, module_qn: str, caller_qn: str
+        self, call_name: str, module_qn: str, caller_qn: str, call_point: int | None
     ) -> tuple[tuple[str, str] | None, str | None]:
         """Walk the caller's inline mods outwards for an item or an import.
 
@@ -1390,10 +1391,14 @@ class CallResolver:
         scope = caller_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
         while len(scope) > len(module_qn):
             # The scope segment may be an impl target whose method a
-            # bare path can never name (issue #1011).
-            if local := self._scope_candidate(
-                scope, call_name, cs.SupportedLanguage.RUST
-            ):
+            # bare path can never name (issue #1011). A block-local item
+            # that took the scope's flat qn answers to that name too, and
+            # is out of scope wherever its block is not (issue #1061).
+            if (
+                local := self._scope_candidate(
+                    scope, call_name, cs.SupportedLanguage.RUST
+                )
+            ) and not self._rust_block_item_hidden(local[1], module_qn, call_point):
                 return local, None
             target = (
                 weak
@@ -1404,6 +1409,25 @@ class CallResolver:
                 return None, target
             scope = scope.rsplit(cs.SEPARATOR_DOT, 1)[0]
         return None, None
+
+    def _rust_block_item_hidden(
+        self, qn: str, module_qn: str, call_point: int | None
+    ) -> bool:
+        """Is `qn` a Rust block-local item this call site sits outside of?
+
+        A site with no recorded position cannot be placed against the
+        block's span. Flow and taint passes resolve that way, so an
+        unplaceable site keeps the item reachable rather than losing the
+        edge outright.
+        """
+        if call_point is None or qn not in self.import_processor.rust_block_item_qns:
+            return False
+        return not any(
+            start <= call_point < end and qn in items.values()
+            for start, end, items in self.import_processor.rust_block_items.get(
+                module_qn, ()
+            )
+        )
 
     def _rust_block_item_at(
         self, module_qn: str, name: str, call_point: int | None
@@ -1713,14 +1737,12 @@ class CallResolver:
         return result
 
     def _try_resolve_same_module(
-        self, call_name: str, module_qn: str
+        self, call_name: str, module_qn: str, call_point: int | None = None
     ) -> tuple[str, str] | None:
         same_module_func_qn = f"{module_qn}.{call_name}"
-        if same_module_func_qn in self.import_processor.rust_block_item_qns:
-            # A Rust block-local item registered flat under the module's
-            # own name. It is in scope for its block alone, and a call
-            # written there was served by _rust_block_item_at long before
-            # this probe (issue #1061).
+        if self._rust_block_item_hidden(same_module_func_qn, module_qn, call_point):
+            # A Rust block-local item that took the module's own flat qn.
+            # It is in scope for its block alone (issue #1061).
             return None
         if same_module_func_qn in self.function_registry:
             logger.debug(
@@ -1729,7 +1751,9 @@ class CallResolver:
             return self.function_registry[same_module_func_qn], same_module_func_qn
         return None
 
-    def _nameable_candidates(self, candidates: list[str], module_qn: str) -> list[str]:
+    def _nameable_candidates(
+        self, candidates: list[str], module_qn: str, call_point: int | None = None
+    ) -> list[str]:
         # The simple-name fallback matches on the last name segment alone, so
         # it can offer a definition written in a language the caller's cannot
         # call into (a Python `asyncio.sleep` binding to a `sleep` closure in
@@ -1737,7 +1761,6 @@ class CallResolver:
         # so drop it; a candidate whose language cannot be determined is kept,
         # so the fallback still answers wherever this evidence is missing.
         caller_language = self._module_language(module_qn)
-        block_items = self.import_processor.rust_block_item_qns
         reachable = [
             qn
             for qn in candidates
@@ -1745,7 +1768,7 @@ class CallResolver:
             # A Rust block-local item is nameable inside its own block
             # alone, and the site-gated probe answered there already
             # (issue #1061); by simple name it is never a candidate.
-            and qn not in block_items
+            and not self._rust_block_item_hidden(qn, module_qn, call_point)
         ]
         # A definition scoped inside another function's body is named from
         # elsewhere only when it escapes (a factory returns it, CommonJS
@@ -1806,13 +1829,14 @@ class CallResolver:
         call_name: str,
         module_qn: str,
         language: cs.SupportedLanguage | None = None,
+        call_point: int | None = None,
     ) -> tuple[str, str] | None:
         search_name = _SEARCH_NAME_CACHE.get(call_name)
         if search_name is None:
             search_name = _SEPARATOR_PATTERN.split(call_name)[-1]
             _SEARCH_NAME_CACHE[call_name] = search_name
         possible_matches = self._nameable_candidates(
-            self.function_registry.find_ending_with(search_name), module_qn
+            self.function_registry.find_ending_with(search_name), module_qn, call_point
         )
         if language == cs.SupportedLanguage.RUST and search_name == call_name:
             # A bare Rust path NEVER names a method (inherent methods need

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -1359,7 +1359,7 @@ class CallResolver:
             or not caller_qn.startswith(f"{module_qn}{cs.SEPARATOR_DOT}")
         ):
             return None
-        if item_qn := self._rust_block_item_at(caller_qn, call_name, call_point):
+        if item_qn := self._rust_block_item_at(module_qn, call_name, call_point):
             return ((self.function_registry[item_qn], item_qn),)
         target = self.import_processor.rust_fn_scope_imports.get(caller_qn, {}).get(
             call_name
@@ -1406,18 +1406,20 @@ class CallResolver:
         return None, None
 
     def _rust_block_item_at(
-        self, caller_qn: str, name: str, call_point: int | None
+        self, module_qn: str, name: str, call_point: int | None
     ) -> str | None:
         """The item `name` binds to in the innermost block holding this site.
 
         Innermost wins: nested blocks may each declare the name, and only
-        the tightest one is in scope where the call is written.
+        the tightest one is in scope where the call is written. Keyed by
+        FILE, not by caller: a fn declared inside the block is inside the
+        block, so its own body binds the block's items too.
         """
         if call_point is None:
             return None
         best: tuple[int, str] | None = None
-        for start, end, items in self.import_processor.rust_fn_scope_item_holes.get(
-            caller_qn, ()
+        for start, end, items in self.import_processor.rust_block_items.get(
+            module_qn, ()
         ):
             item_qn = items.get(name)
             if item_qn is None or not (start <= call_point < end):
@@ -1714,6 +1716,12 @@ class CallResolver:
         self, call_name: str, module_qn: str
     ) -> tuple[str, str] | None:
         same_module_func_qn = f"{module_qn}.{call_name}"
+        if same_module_func_qn in self.import_processor.rust_block_item_qns:
+            # A Rust block-local item registered flat under the module's
+            # own name. It is in scope for its block alone, and a call
+            # written there was served by _rust_block_item_at long before
+            # this probe (issue #1061).
+            return None
         if same_module_func_qn in self.function_registry:
             logger.debug(
                 ls.CALL_SAME_MODULE, call_name=call_name, qn=same_module_func_qn
@@ -1729,10 +1737,15 @@ class CallResolver:
         # so drop it; a candidate whose language cannot be determined is kept,
         # so the fallback still answers wherever this evidence is missing.
         caller_language = self._module_language(module_qn)
+        block_items = self.import_processor.rust_block_item_qns
         reachable = [
             qn
             for qn in candidates
             if self._languages_can_call(caller_language, self._module_language(qn))
+            # A Rust block-local item is nameable inside its own block
+            # alone, and the site-gated probe answered there already
+            # (issue #1061); by simple name it is never a candidate.
+            and qn not in block_items
         ]
         # A definition scoped inside another function's body is named from
         # elsewhere only when it escapes (a factory returns it, CommonJS

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -732,10 +732,11 @@ class CallResolver:
         # enclosing-scope and same-module ones below: a use shadows outer
         # items for the remainder of its block (rustc-verified), so even
         # the file's own same-named item loses to it. A nested fn's own
-        # body use still outranks the block, and a containing block that
-        # declares the name itself opts out entirely (the probes below
-        # find its flat-registered item, except where the enclosing fn's
-        # own body use shadows it there, issue #1026). A `::`-qualified
+        # body use still outranks the block. Ahead of all of it stands an
+        # item the call's own block declares, which every use loses to;
+        # that probe belongs HERE rather than with the scope walk, since
+        # a module-level initializer's caller qn is the module itself and
+        # never reaches the walk (issues #1026 and #1061). A `::`-qualified
         # first segment
         # bound by the block (`T::assoc()` under `use crate::beta::T`)
         # resolves through a map holding just that binding.
@@ -744,6 +745,10 @@ class CallResolver:
             and caller_qn
             and cs.SEPARATOR_DOT not in call_name
         ):
+            if cs.SEPARATOR_DOUBLE_COLON not in call_name and (
+                item_qn := self._rust_block_item_at(module_qn, call_name, call_point)
+            ):
+                return self.function_registry[item_qn], item_qn
             first = call_name.split(cs.SEPARATOR_DOUBLE_COLON, 1)[0]
             if block_hit := self._rust_block_import_at(module_qn, first, call_point):
                 block_target, defers = block_hit
@@ -1360,8 +1365,6 @@ class CallResolver:
             or not caller_qn.startswith(f"{module_qn}{cs.SEPARATOR_DOT}")
         ):
             return None
-        if item_qn := self._rust_block_item_at(module_qn, call_name, call_point):
-            return ((self.function_registry[item_qn], item_qn),)
         target = self.import_processor.rust_fn_scope_imports.get(caller_qn, {}).get(
             call_name
         )

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -398,6 +398,11 @@ class DefinitionProcessor(
                 self.import_processor.finalise_rust_function_scope_uses(
                     module_qn, self.function_locations
                 )
+                # Block-local items key on their own registered qn, which
+                # the same pass has just handed out.
+                self.import_processor.record_rust_block_items(
+                    module_qn, root_node, self.function_locations
+                )
                 # Inline-mod maps were visible to this file's own impl
                 # ingestion above; retract them until the flush-time
                 # arbitration decides key ownership across all files.

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -2633,11 +2633,14 @@ class ImportProcessor:
         root_node: Node,
         function_locations: Mapping[FunctionSpanKey, FunctionLocation],
     ) -> None:
-        # Runs beside finalise_rust_function_scope_uses, once the registry
-        # has handed out the qns (natural or `natural@<start_line>`) these
-        # spans have to be spoken of by. An item span with no record was
-        # never registered, so no call can bind it and the name stays with
-        # whatever else answers to it.
+        """Record this file's block-local function items by span and by qn.
+
+        Runs beside finalise_rust_function_scope_uses, once the registry
+        has handed out the qns (natural or `natural@<start_line>`) these
+        spans have to be spoken of by. An item span with no record was
+        never registered, so no call can bind it and the name stays with
+        whatever else answers to it.
+        """
         scopes: list[tuple[int, int, dict[str, str]]] = []
         for start, end, items in rs_utils.rust_block_item_scopes(root_node):
             resolved = {

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -407,7 +407,8 @@ class ImportProcessor:
         "_rust_pending_fn_scope_uses",
         "rust_fn_scope_imports",
         "rust_fn_scope_mod_imports",
-        "rust_fn_scope_item_holes",
+        "rust_block_items",
+        "rust_block_item_qns",
         "rust_block_scope_imports",
         "rust_self_module_imports",
         "_rust_fn_scope_keys",
@@ -488,16 +489,7 @@ class ImportProcessor:
         # The bool marks WEAK entries: an impure inline mod's use fanned
         # out to the functions declared in its block.
         self._rust_pending_fn_scope_uses: dict[
-            str,
-            list[
-                tuple[
-                    int,
-                    int,
-                    dict[str, str],
-                    bool,
-                    list[tuple[int, int, dict[str, tuple[int, int]]]],
-                ]
-            ],
+            str, list[tuple[int, int, dict[str, str], bool]]
         ] = {}
         # Function-body uses, keyed by the enclosing function's registered
         # qn. Kept OUT of import_mapping: Rust puts `mod run` and `fn run`
@@ -509,15 +501,15 @@ class ImportProcessor:
         # resolver consults it only after local items, unlike the body-use
         # map above which shadows everything.
         self.rust_fn_scope_mod_imports: dict[str, dict[str, str]] = {}
-        # Spans of the nested blocks inside a function body that declare
-        # function items directly, each mapped to the REGISTERED qn of the
-        # item it declares, keyed by the same qn as the body-use map above.
-        # Every plain block is an item scope in Rust, so a call written
-        # inside one binds that block's own item, never the body use the
-        # map holds nor whatever else answers to the name (issue #1026).
-        self.rust_fn_scope_item_holes: dict[
-            str, list[tuple[int, int, dict[str, str]]]
-        ] = {}
+        # Every plain block in a file that declares function items directly,
+        # by span, each name mapped to the REGISTERED qn of the item it
+        # declares. Blocks nest inside functions and never overlap, so the
+        # innermost block holding a call site is the scope that binds these
+        # names, whatever else in the module answers to them (issue #1026),
+        # and the companion set of those qns is what keeps a name lookup
+        # from reaching them from outside their block (issue #1061).
+        self.rust_block_items: dict[str, list[tuple[int, int, dict[str, str]]]] = {}
+        self.rust_block_item_qns: set[str] = set()
         # Uses inside const/static initializer blocks, keyed by file
         # module qn: (block start byte, block end byte, imports, nested
         # mod spans, nested fn spans, nested item scopes with their
@@ -2406,11 +2398,12 @@ class ImportProcessor:
         self._rust_pending_mod_scope_uses.pop(module_qn, None)
         self._rust_mod_scope_registry.pop(module_qn, None)
         self.rust_block_scope_imports.pop(module_qn, None)
+        for _start, _end, items in self.rust_block_items.pop(module_qn, ()):
+            self.rust_block_item_qns.difference_update(items.values())
         self.rust_self_module_imports.pop(module_qn, None)
         for key in self._rust_fn_scope_keys.pop(module_qn, ()):
             self.rust_fn_scope_imports.pop(key, None)
             self.rust_fn_scope_mod_imports.pop(key, None)
-            self.rust_fn_scope_item_holes.pop(key, None)
         for key in self._rust_inline_scope_keys.pop(module_qn, ()):
             self.import_mapping.pop(key, None)
 
@@ -2480,7 +2473,6 @@ class ImportProcessor:
                         scope_node.start_point[1],
                         resolved_imports,
                         False,
-                        rs_utils.rust_block_scope_holes(scope_node)[2],
                     )
                 )
             else:
@@ -2534,7 +2526,7 @@ class ImportProcessor:
             # ends up holding.
             for line, col in rs_utils.enclosing_mod_fn_spans(use_node):
                 self._rust_pending_fn_scope_uses.setdefault(module_qn, []).append(
-                    (line, col, resolved_imports, True, [])
+                    (line, col, resolved_imports, True)
                 )
 
     def retract_rust_mod_scope_uses(self, module_qn: str) -> None:
@@ -2620,7 +2612,6 @@ class ImportProcessor:
             start_col,
             imports,
             weak,
-            item_holes,
         ) in self._rust_pending_fn_scope_uses.pop(module_qn, []):
             location = function_locations.get((module_qn, start_line, start_col))
             if location is None:
@@ -2634,18 +2625,32 @@ class ImportProcessor:
                 self.rust_fn_scope_mod_imports.setdefault(key, {}).update(imports)
             else:
                 self.rust_fn_scope_imports.setdefault(key, {}).update(imports)
-                self.rust_fn_scope_item_holes[key] = [
-                    (start, end, resolved)
-                    for start, end, items in item_holes
-                    if (
-                        resolved := {
-                            name: item.qualified_name
-                            for name, span in items.items()
-                            if (item := function_locations.get((module_qn, *span)))
-                        }
-                    )
-                ]
             self._rust_fn_scope_keys.setdefault(module_qn, set()).add(key)
+
+    def record_rust_block_items(
+        self,
+        module_qn: str,
+        root_node: Node,
+        function_locations: Mapping[FunctionSpanKey, FunctionLocation],
+    ) -> None:
+        # Runs beside finalise_rust_function_scope_uses, once the registry
+        # has handed out the qns (natural or `natural@<start_line>`) these
+        # spans have to be spoken of by. An item span with no record was
+        # never registered, so no call can bind it and the name stays with
+        # whatever else answers to it.
+        scopes: list[tuple[int, int, dict[str, str]]] = []
+        for start, end, items in rs_utils.rust_block_item_scopes(root_node):
+            resolved = {
+                name: location.qualified_name
+                for name, span in items.items()
+                if (location := function_locations.get((module_qn, *span)))
+            }
+            if not resolved:
+                continue
+            scopes.append((start, end, resolved))
+            self.rust_block_item_qns.update(resolved.values())
+        if scopes:
+            self.rust_block_items[module_qn] = scopes
 
     def _parse_go_imports(self, captures: dict, module_qn: str) -> None:
         for import_node in captures.get(cs.CAPTURE_IMPORT, []):

--- a/codebase_rag/parsers/rs/utils.py
+++ b/codebase_rag/parsers/rs/utils.py
@@ -438,6 +438,27 @@ def rust_block_scope_holes(
     return mod_holes, fn_holes, item_scopes
 
 
+def rust_block_item_scopes(
+    root: Node,
+) -> list[tuple[int, int, dict[str, tuple[int, int]]]]:
+    """Every plain block in the file that declares function items directly.
+
+    A block item is in scope for the block alone, yet it registers flat in
+    the enclosing module beside the module's own items, so the span is the
+    only thing that says which calls may reach it (issue #1061).
+    """
+    scopes: list[tuple[int, int, dict[str, tuple[int, int]]]] = []
+    stack = [root]
+    while stack:
+        current = stack.pop()
+        if current.type == cs.TS_RS_BLOCK and (
+            items := _rust_direct_block_items(current)
+        ):
+            scopes.append((current.start_byte, current.end_byte, items))
+        stack.extend(current.children)
+    return scopes
+
+
 def _rust_direct_block_items(block_node: Node) -> dict[str, tuple[int, int]]:
     """Function items declared directly in a block, by name and span key.
 

--- a/codebase_rag/tests/test_rust_block_item_scope_boundary.py
+++ b/codebase_rag/tests/test_rust_block_item_scope_boundary.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock
 
+from codebase_rag.tests.test_flow_edges import _has, _run_flow
 from codebase_rag.tests.test_rust_crate_path_trait_linking import (
     _calls,
     _write,
@@ -100,10 +101,16 @@ def test_a_sibling_function_does_not_bind_another_block_item(
         "rs_boundary_sibling.src.a.f1",
         "rs_boundary_sibling.src.a.g",
     ) not in calls, calls
-    # The call inside the block still reaches the block's own item.
+    # The call inside the block still reaches the block's own item, and
+    # only it: the natural qn carries a dedup bucket holding the module
+    # item too, which must not be fanned out onto.
     assert ("rs_boundary_sibling.src.a.f0", "rs_boundary_sibling.src.a.g") in calls, (
         calls
     )
+    assert (
+        "rs_boundary_sibling.src.a.f0",
+        "rs_boundary_sibling.src.a.g@15",
+    ) not in calls, calls
 
 
 def test_a_nested_function_inside_the_block_sees_the_block_item(
@@ -143,3 +150,123 @@ def test_a_nested_function_inside_the_block_sees_the_block_item(
     caller = "rs_boundary_nested.src.a.inner"
     assert (caller, "rs_boundary_nested.src.a.g@7") in calls, calls
     assert (caller, "rs_boundary_nested.src.a.g") not in calls, calls
+
+
+def test_block_item_survives_the_module_keyed_resolution_cache(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # A file with no `use` anywhere leaves the file-keyed resolution cache
+    # armed, and block items make resolution site-dependent: whichever call
+    # resolves first would otherwise answer for every later call of that
+    # name in the file, block or no block.
+    project = temp_repo / "rs_boundary_cache"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\n',
+            "src/lib.rs": "pub mod a;\n",
+            "src/a.rs": (
+                "pub const fn f1() -> u32 {\n"
+                "    g()\n"
+                "}\n"
+                "\n"
+                "pub const fn f0() -> u32 {\n"
+                "    let z = {\n"
+                "        const fn g() -> u32 {\n"
+                "            21\n"
+                "        }\n"
+                "        g()\n"
+                "    };\n"
+                "    z\n"
+                "}\n"
+                "\n"
+                "pub const fn g() -> u32 {\n"
+                "    9\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    assert ("rs_boundary_cache.src.a.f0", "rs_boundary_cache.src.a.g") in calls, calls
+    assert (
+        "rs_boundary_cache.src.a.f1",
+        "rs_boundary_cache.src.a.g@15",
+    ) in calls, calls
+    assert (
+        "rs_boundary_cache.src.a.f1",
+        "rs_boundary_cache.src.a.g",
+    ) not in calls, calls
+
+
+def test_block_item_declared_after_the_module_item_keeps_the_boundary(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # Which of the two same-named items holds the natural qn follows
+    # registration order, so the boundary has to hold with the module item
+    # first as well: the dedup bucket the natural qn carries must not fan a
+    # resolved call out onto the other scope's item.
+    project = temp_repo / "rs_boundary_order"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\n',
+            "src/lib.rs": "pub mod a;\n",
+            "src/a.rs": (
+                "pub fn g() -> u32 {\n"
+                "    9\n"
+                "}\n"
+                "\n"
+                "pub fn f0() -> u32 {\n"
+                "    let z = {\n"
+                "        fn g() -> u32 {\n"
+                "            21\n"
+                "        }\n"
+                "        g()\n"
+                "    };\n"
+                "    z\n"
+                "}\n"
+                "\n"
+                "pub fn f1() -> u32 {\n"
+                "    g()\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    assert ("rs_boundary_order.src.a.f0", "rs_boundary_order.src.a.g@7") in calls, calls
+    assert (
+        "rs_boundary_order.src.a.f0",
+        "rs_boundary_order.src.a.g",
+    ) not in calls, calls
+    assert ("rs_boundary_order.src.a.f1", "rs_boundary_order.src.a.g") in calls, calls
+    assert (
+        "rs_boundary_order.src.a.f1",
+        "rs_boundary_order.src.a.g@7",
+    ) not in calls, calls
+
+
+def test_flow_edges_still_reach_a_block_item(tmp_path: Path) -> None:
+    # The taint walk resolves callees without a call site position, so it
+    # cannot be told which side of a block boundary it stands on. Scoping
+    # must not answer "outside" there and drop the flow edge.
+    edges = _run_flow(
+        tmp_path,
+        {
+            "main.rs": (
+                "fn boot() {\n"
+                '    let secret = std::env::var("SECRET").unwrap();\n'
+                "    let z = {\n"
+                "        fn sink(v: String) {\n"
+                '            println!("{}", v);\n'
+                "        }\n"
+                "        sink(secret);\n"
+                "        1\n"
+                "    };\n"
+                "    let _ = z;\n"
+                "}\n"
+            )
+        },
+    )
+    assert _has(edges, "main.boot", "main.sink"), edges

--- a/codebase_rag/tests/test_rust_block_item_scope_boundary.py
+++ b/codebase_rag/tests/test_rust_block_item_scope_boundary.py
@@ -1,0 +1,145 @@
+"""A block-local Rust fn item is out of scope once its block closes.
+
+Such an item registers flat in the enclosing module, so bare-name
+resolution reached it from anywhere in that scope and a call written
+after the block bound it instead of whatever is really in scope there
+(issue #1061).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.test_rust_crate_path_trait_linking import (
+    _calls,
+    _write,
+    create_and_run_updater,
+)
+
+
+def test_call_after_the_block_does_not_bind_the_block_item(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The mod-level `use` is what is in scope at `z + g()`; the block's own
+    # `g` died with its block. No same-named twin exists here, so the block
+    # item holds the natural qn and a name lookup answers with it.
+    project = temp_repo / "rs_boundary_use"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\n',
+            "src/lib.rs": "pub mod gamma;\npub mod a;\n",
+            "src/gamma.rs": "pub const fn g() -> u32 {\n    3\n}\n",
+            "src/a.rs": (
+                "pub mod inner {\n"
+                "    use crate::gamma::g;\n"
+                "\n"
+                "    pub const fn f0() -> u32 {\n"
+                "        let z = {\n"
+                "            const fn g() -> u32 {\n"
+                "                21\n"
+                "            }\n"
+                "            0\n"
+                "        };\n"
+                "        z + g()\n"
+                "    }\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    caller = "rs_boundary_use.src.a.inner.f0"
+    assert (caller, "rs_boundary_use.src.gamma.g") in calls, calls
+    assert (caller, "rs_boundary_use.src.a.inner.g") not in calls, calls
+
+
+def test_a_sibling_function_does_not_bind_another_block_item(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The block item is not a module item: a different function in the same
+    # file never sees it, and the module's own same-named item is what its
+    # call binds.
+    project = temp_repo / "rs_boundary_sibling"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\n',
+            "src/lib.rs": "pub mod a;\n",
+            "src/a.rs": (
+                "pub const fn f0() -> u32 {\n"
+                "    let z = {\n"
+                "        const fn g() -> u32 {\n"
+                "            21\n"
+                "        }\n"
+                "        g()\n"
+                "    };\n"
+                "    z\n"
+                "}\n"
+                "\n"
+                "pub const fn f1() -> u32 {\n"
+                "    g()\n"
+                "}\n"
+                "\n"
+                "pub const fn g() -> u32 {\n"
+                "    9\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    # The block item registered first and took the natural qn, so the
+    # module's own item is the one carrying a span suffix here.
+    assert (
+        "rs_boundary_sibling.src.a.f1",
+        "rs_boundary_sibling.src.a.g@15",
+    ) in calls, calls
+    assert (
+        "rs_boundary_sibling.src.a.f1",
+        "rs_boundary_sibling.src.a.g",
+    ) not in calls, calls
+    # The call inside the block still reaches the block's own item.
+    assert ("rs_boundary_sibling.src.a.f0", "rs_boundary_sibling.src.a.g") in calls, (
+        calls
+    )
+
+
+def test_a_nested_function_inside_the_block_sees_the_block_item(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # Scope is where the call is WRITTEN, not which function owns it: a fn
+    # declared inside the block is inside the block, so its body binds the
+    # block's item even though it is a caller of its own.
+    project = temp_repo / "rs_boundary_nested"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\n',
+            "src/lib.rs": "pub mod a;\n",
+            "src/a.rs": (
+                "pub const fn g() -> u32 {\n"
+                "    9\n"
+                "}\n"
+                "\n"
+                "pub fn f0() -> u32 {\n"
+                "    let z = {\n"
+                "        const fn g() -> u32 {\n"
+                "            21\n"
+                "        }\n"
+                "        fn inner() -> u32 {\n"
+                "            g()\n"
+                "        }\n"
+                "        inner()\n"
+                "    };\n"
+                "    z\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    caller = "rs_boundary_nested.src.a.inner"
+    assert (caller, "rs_boundary_nested.src.a.g@7") in calls, calls
+    assert (caller, "rs_boundary_nested.src.a.g") not in calls, calls

--- a/codebase_rag/tests/test_rust_crate_path_trait_linking.py
+++ b/codebase_rag/tests/test_rust_crate_path_trait_linking.py
@@ -4223,6 +4223,9 @@ def test_inner_block_own_item_beats_block_use_at_block_level(
     base = "rs_inner_block_item_a.src"
     assert not any(dst == f"{base}.gamma.g" for _src, dst in calls), calls
     assert any(dst.startswith(f"{base}.a.g@") for _src, dst in calls), calls
+    # And ONLY the block's item: the module's own `g` is a different
+    # function that happens to share the natural qn (issue #1061).
+    assert not any(dst == f"{base}.a.g" for _src, dst in calls), calls
 
 
 def test_inner_let_block_item_beats_block_use_in_nested_fn(

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.542"
+version = "0.0.543"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #1061. Extends #1060, now merged.

A Rust `fn` item declared inside a block is in scope for that block alone, but it registers flat in the enclosing module beside the module's own items. Bare-name resolution therefore reached it from anywhere in that scope.

```rust
pub mod inner {
    use crate::gamma::g;

    pub const fn f0() -> u32 {
        let z = {
            const fn g() -> u32 {
                21
            }
            0
        };
        z + g()      // rustc: 3, through the mod-level use
    }
}
```

cgr bound the block's `g`, which is out of scope by the time that call is written.

## Change

Block item scopes move from the caller-keyed map #1060 introduced to one keyed by file, collected once per parse where the root node and the registered qns are both in hand. Keying by file is what fixes the other direction of the same question: a `fn` declared inside a block is inside the block, so its own body binds the block's items even though it is a caller in its own right.

The registered qns of those items also form a rejection set, consulted by the three probes that could otherwise reach one by name from outside its block: the same-module probe, the enclosing-scope walk, and the simple-name trie fallback. Only the span-gated probe can reach a block item now.

## Tests

Red first, all three. A call after the block closes binds the mod-level `use`; a sibling function binds the module's own item and not the block's; and a `fn` nested inside the block binds the block's item from its own body.

Worth recording from the sibling fixture: which of two same-named items holds the natural qn and which gets the `@<line>` suffix follows registration order, not nesting, so there the block item took the natural qn and the module-level item is the suffixed one. Nothing but the span distinguishes them.

## Three defects the pre-push review found in the first cut, each now covered

Making the item map file-wide **armed the file-keyed resolution cache** for exactly the files that must not use it. A file with no `use` anywhere left it on, so whichever call resolved first answered for every later call of that name and an in-block call silently lost its edge. The cache gate now stands down for any file holding block items.

The rejection was **unconditional, and the taint walk resolves callees with no call site position**, so it could not be placed against a block span and lost `FLOWS_TO` edges outright. Scoping now answers "outside" only where the site is known; an unplaceable site keeps the item reachable.

The **dedup bucket fanned a resolved callee onto its `@<line>` twin**, which walks straight across the boundary in whichever direction the natural qn happened to fall. Those twins are different functions sharing a name, not spellings of one callee, so a bucket mixing a block item with another scope's item no longer fans out.

A fourth was a test that asserted only membership and let a wrong edge through unchecked; it now asserts the absence too.

The suite then caught one more of my own: a module-level `static` initializer's caller qn **is** the module qn, so the block-item probe never ran there. That probe moved up beside the initializer-block probe, where every call site reaches it. The existing `#1007` test covering that shape had been passing on the dedup fanout alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Rust call resolution for functions declared inside blocks.
  * Prevented references from crossing block boundaries or incorrectly linking to same-named module functions.
  * Preserved correct resolution for nested functions, declaration order, and calls outside local blocks.
  * Maintained flow-analysis paths to block-local functions and reliable results when resolution caching is used.

* **Tests**
  * Added coverage for Rust block scope, caching, nested functions, declaration order, and flow-edge traversal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->