### PR TITLE
fix: resolve a Rust #[path] mod declaration to the file it names

### DIFF
--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import posixpath
 from abc import abstractmethod
 from bisect import bisect_left, bisect_right
-from collections.abc import Mapping
-from pathlib import Path
+from collections.abc import Mapping, Sequence
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, NamedTuple
 
 from loguru import logger
@@ -1518,6 +1519,7 @@ class ClassIngestMixin:
                     module_node,
                     module_qn,
                     safe_decode_text(module_name_node) or "",
+                    decorators,
                 )
                 (gated_targets if gated else ungated_targets).update(candidates)
                 continue
@@ -1574,7 +1576,11 @@ class ClassIngestMixin:
             self.ingestor.ensure_node_batch(cs.NodeLabel.MODULE, decl_props)
 
     def _rust_cfg_test_candidates(
-        self, module_node: Node, module_qn: str, module_name: str
+        self,
+        module_node: Node,
+        module_qn: str,
+        module_name: str,
+        decorators: Sequence[object] = (),
     ) -> set[str]:
         """Qualified-name candidates for a bodyless declaration's target.
 
@@ -1591,6 +1597,13 @@ class ClassIngestMixin:
         if not module_name:
             return set()
         chain = rs_utils.build_module_path(module_node)
+        if not chain and (
+            redirect := self._rust_path_attribute_qn(module_qn, decorators)
+        ):
+            # `#[path]` names the backing file outright, and the file is
+            # where the qn scheme keys the module, so the name-derived
+            # spellings below back nothing at all here (issue #1035).
+            return {redirect}
         candidates = {
             self.import_processor._rust_resolve_relative(
                 module_qn, [*chain, module_name], module_qn
@@ -1614,6 +1627,34 @@ class ClassIngestMixin:
                     )
                 )
         return candidates
+
+    def _rust_path_attribute_qn(
+        self, module_qn: str, decorators: Sequence[object]
+    ) -> str | None:
+        """The qn of the file a `#[path]` declaration redirects to.
+
+        The path is relative to the directory holding the declaring file.
+        A `mod.rs` target names the directory itself, which is the qn the
+        indexer gives that directory's module.
+        """
+        redirect = rs_utils.path_attribute_target(decorators)
+        file_path = self.module_qn_to_file_path.get(module_qn)
+        if redirect is None or file_path is None:
+            return None
+        declaring = cached_relative_path(file_path, self.repo_path)
+        target = PurePosixPath(
+            posixpath.normpath(declaring.parent.as_posix() + "/" + redirect)
+        )
+        if target.suffix == cs.EXT_RS:
+            target = (
+                target.parent if target.stem == cs.INDEX_MOD else target.with_suffix("")
+            )
+        parts = [part for part in target.parts if part not in ("", ".")]
+        if not parts or any(part == ".." for part in parts):
+            # The redirect climbs out of the repository: no indexed module
+            # answers to it, so nothing is claimed.
+            return None
+        return cs.SEPARATOR_DOT.join([self.project_name, *parts])
 
     def process_all_method_overrides(self) -> None:
         mo.process_all_method_overrides(

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -1596,9 +1596,7 @@ class ClassIngestMixin:
         if not module_name:
             return set()
         chain = rs_utils.build_module_path(module_node)
-        if not chain and (
-            redirect := self._rust_path_attribute_qn(module_qn, decorators)
-        ):
+        if redirect := self._rust_path_attribute_qn(module_qn, chain, decorators):
             # `#[path]` names the backing file outright, and the file is
             # where the qn scheme keys the module, so the name-derived
             # spellings below back nothing at all here (issue #1035).
@@ -1628,19 +1626,27 @@ class ClassIngestMixin:
         return candidates
 
     def _rust_path_attribute_qn(
-        self, module_qn: str, decorators: Sequence[object]
+        self, module_qn: str, chain: list[str], decorators: Sequence[object]
     ) -> str | None:
         """The qn of the file a `#[path]` declaration redirects to.
 
-        The path is relative to the directory holding the declaring file.
-        A `mod.rs` target names the directory itself, which is the qn the
-        indexer gives that directory's module.
+        The path counts from the directory holding the declaring file, and
+        a `mod.rs` target names the directory itself, which is the qn the
+        indexer gives that directory's module. Inside inline `mod` blocks
+        the chain joins that directory, and a file that is not itself a
+        module root (anything but lib.rs, main.rs or mod.rs) contributes
+        its own stem as a directory first, exactly as rustc counts it.
         """
         redirect = rs_utils.path_attribute_target(decorators)
         file_path = self.module_qn_to_file_path.get(module_qn)
         if redirect is None or file_path is None:
             return None
-        dir_parts = cached_relative_path(file_path, self.repo_path).parts[:-1]
+        declaring = cached_relative_path(file_path, self.repo_path)
+        dir_parts = list(declaring.parts[:-1])
+        if chain:
+            if declaring.stem not in cs.RS_ENTRY_STEMS:
+                dir_parts.append(declaring.stem)
+            dir_parts.extend(chain)
         parts = rs_utils.path_attribute_qn_parts(dir_parts, redirect)
         return (
             None

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import posixpath
 from abc import abstractmethod
 from bisect import bisect_left, bisect_right
 from collections.abc import Mapping, Sequence
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple
 
 from loguru import logger
@@ -1641,20 +1640,13 @@ class ClassIngestMixin:
         file_path = self.module_qn_to_file_path.get(module_qn)
         if redirect is None or file_path is None:
             return None
-        declaring = cached_relative_path(file_path, self.repo_path)
-        target = PurePosixPath(
-            posixpath.normpath(declaring.parent.as_posix() + "/" + redirect)
+        dir_parts = cached_relative_path(file_path, self.repo_path).parts[:-1]
+        parts = rs_utils.path_attribute_qn_parts(dir_parts, redirect)
+        return (
+            None
+            if parts is None
+            else cs.SEPARATOR_DOT.join([self.project_name, *parts])
         )
-        if target.suffix == cs.EXT_RS:
-            target = (
-                target.parent if target.stem == cs.INDEX_MOD else target.with_suffix("")
-            )
-        parts = [part for part in target.parts if part not in ("", ".")]
-        if not parts or any(part == ".." for part in parts):
-            # The redirect climbs out of the repository: no indexed module
-            # answers to it, so nothing is claimed.
-            return None
-        return cs.SEPARATOR_DOT.join([self.project_name, *parts])
 
     def process_all_method_overrides(self) -> None:
         mo.process_all_method_overrides(

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -201,10 +201,21 @@ class RustEntryDecls(NamedTuple):
 
 
 def _rs_entry_decls_of(top_level: str) -> RustEntryDecls:
+    # One name may be declared once per cfg (`#[cfg(unix)] mod platform;`
+    # beside its windows twin), each redirected somewhere else. Exactly one
+    # of them compiles and nothing here knows which, so disagreeing targets
+    # are ambiguous and the name keeps no redirect at all.
     redirects: dict[str, str] = {}
+    ambiguous: set[str] = set()
     for attributes, name in _RS_MOD_REDIRECT_PATTERN.findall(top_level):
-        if match := _RS_PATH_ATTRIBUTE_PATTERN.search(attributes):
-            redirects[name] = match.group(1)
+        match = _RS_PATH_ATTRIBUTE_PATTERN.search(attributes)
+        target = match.group(1) if match else None
+        if name in redirects and redirects[name] != target:
+            ambiguous.add(name)
+        elif target is not None:
+            redirects[name] = target
+    for name in ambiguous:
+        redirects.pop(name, None)
     return RustEntryDecls(
         set(_RS_MOD_DECL_PATTERN.findall(top_level)),
         set(_RS_ITEM_DECL_PATTERN.findall(top_level)),

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -71,12 +71,15 @@ _RS_MOD_DECL_PATTERN = re.compile(
 # Only the plain string form is read: a cfg_attr wrapper is conditional and
 # no single target speaks for it (issue #1035).
 _RS_MOD_REDIRECT_PATTERN = re.compile(
-    r"^[ \t]*((?:#\[[^\]\n]*\][ \t]*\n?)*)"
-    r"(?:pub[ \t]*(?:\([^)]*\))?[ \t]+)?"
-    r"mod[ \t]+(?:r#)?([A-Za-z_][A-Za-z0-9_]*)[ \t]*;",
+    r"^\s*((?:#\[[^\]\n]*\]\s*)*)"
+    r"(?:pub\s*(?:\([^)]*\))?\s+)?"
+    r"mod\s+(?:r#)?([A-Za-z_][A-Za-z0-9_]*)\s*;",
     re.MULTILINE,
 )
-_RS_PATH_ATTRIBUTE_PATTERN = re.compile(r'#\[[ \t]*path[ \t]*=[ \t]*"([^"]+)"[ \t]*\]')
+_RS_PATH_ATTRIBUTE_PATTERN = re.compile(r'#\[\s*path\s*=\s*"([^"\n]+)"\s*\]')
+# The opening of a path attribute, matched against the code the lexer has
+# already emitted, so the literal that follows can be kept verbatim.
+_RS_PATH_ATTRIBUTE_OPEN = re.compile(r"#\[\s*path\s*=\s*$")
 _RS_ITEM_DECL_PATTERN = re.compile(
     r"^\s*(?:#\[[^\]\n]*\]\s*)*(?:pub\s*(?:\([^)]*\))?\s+)?"
     r'(?:(?:unsafe|async|const|extern\s+"[^"]*")\s+)*'
@@ -99,6 +102,13 @@ def _rs_strip_comments_and_strings(source: str) -> str:
     A regex cannot do this: block comments NEST, and string literals may
     contain comment markers (`const P: &str = "/*";`) or newline-separated
     text that would fake a `mod x;` line.
+
+    The one literal kept is a `#[path = "..."]` value, which names the file
+    backing a mod declaration and so has to survive for the declaration
+    scan to read it (issue #1035). Keeping it is safe precisely because
+    this lexer decides it: the opening `#[path =` is matched in code the
+    lexer has already walked, so no comment or outer string can present
+    one.
     """
     out: list[str] = []
     i, n = 0, len(source)
@@ -137,6 +147,7 @@ def _rs_strip_comments_and_strings(source: str) -> str:
                 out.append('""')
                 continue
         if c == '"':
+            start = i
             i += 1
             while i < n:
                 if source[i] == "\\":
@@ -146,7 +157,9 @@ def _rs_strip_comments_and_strings(source: str) -> str:
                     i += 1
                     break
                 i += 1
-            out.append('""')
+            literal = source[start:i]
+            keep = _RS_PATH_ATTRIBUTE_OPEN.search("".join(out[-80:])) is not None
+            out.append(literal if keep and "\n" not in literal else '""')
             continue
         if c == "'":
             # A char literal ('x', '\n', '\u{7f}'); a lifetime ('a) has no
@@ -187,37 +200,16 @@ class RustEntryDecls(NamedTuple):
     redirects: dict[str, str]
 
 
-def _rs_entry_decls_of(top_level: str, source: str) -> RustEntryDecls:
-    # The blanked text is what decides which declarations are real, since
-    # a string literal cannot fake a `mod x;` there. It also empties every
-    # string, so the `#[path]` VALUE survives only in the raw source: read
-    # it there and keep it only for a name the blanked scan confirmed.
-    mods = set(_RS_MOD_DECL_PATTERN.findall(top_level))
+def _rs_entry_decls_of(top_level: str) -> RustEntryDecls:
     redirects: dict[str, str] = {}
-    for attributes, name in _RS_MOD_REDIRECT_PATTERN.findall(source):
-        if name in mods and (match := _RS_PATH_ATTRIBUTE_PATTERN.search(attributes)):
+    for attributes, name in _RS_MOD_REDIRECT_PATTERN.findall(top_level):
+        if match := _RS_PATH_ATTRIBUTE_PATTERN.search(attributes):
             redirects[name] = match.group(1)
     return RustEntryDecls(
-        mods,
+        set(_RS_MOD_DECL_PATTERN.findall(top_level)),
         set(_RS_ITEM_DECL_PATTERN.findall(top_level)),
         redirects,
     )
-
-
-def _rs_redirect_parts(dir_parts: list[str], redirect: str) -> list[str] | None:
-    """Repo-relative qn segments for a `#[path]` target, or None if it escapes.
-
-    The path counts from the directory holding the declaring entry file,
-    and a `mod.rs` target names that directory rather than a file beside
-    it.
-    """
-    parts = posixpath.normpath(posixpath.join(*dir_parts, redirect)).split("/")
-    if parts and parts[-1].endswith(cs.EXT_RS):
-        stem = parts.pop()[: -len(cs.EXT_RS)]
-        if stem != cs.INDEX_MOD:
-            parts.append(stem)
-    cleaned = [part for part in parts if part not in ("", ".")]
-    return None if not cleaned or ".." in cleaned else cleaned
 
 
 def _rs_top_level_only(stripped: str) -> str:
@@ -1678,7 +1670,7 @@ class ImportProcessor:
                 # tie-break's real but wrong answer.
                 continue
             top_level = _rs_top_level_only(_rs_strip_comments_and_strings(source))
-            decls[stem] = _rs_entry_decls_of(top_level, source)
+            decls[stem] = _rs_entry_decls_of(top_level)
         return decls
 
     def _rust_attach(
@@ -1700,7 +1692,7 @@ class ImportProcessor:
                 # The declaration names its backing file outright, and the
                 # module keys under that file, so the declared name never
                 # appears in the qn at all (issue #1035).
-                if target := _rs_redirect_parts(dir_parts, redirect):
+                if target := rs_utils.path_attribute_qn_parts(dir_parts, redirect):
                     return cs.SEPARATOR_DOT.join(
                         [self.project_name, *target, *rest[1:]]
                     )
@@ -2429,7 +2421,7 @@ class ImportProcessor:
                     top_level = _rs_top_level_only(
                         _rs_strip_comments_and_strings(source)
                     )
-                    stems[file_path.stem] = _rs_entry_decls_of(top_level, source)
+                    stems[file_path.stem] = _rs_entry_decls_of(top_level)
         if file_path.name == cs.PKG_CARGO_TOML:
             # A manifest edit can add, remove, or repoint explicit targets
             # anywhere in its package, and a CREATED manifest moves the

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -6,6 +6,7 @@ import tomllib
 from collections.abc import Mapping
 from functools import lru_cache
 from pathlib import Path
+from typing import NamedTuple
 
 from loguru import logger
 from tree_sitter import Node
@@ -65,6 +66,17 @@ _RS_MOD_DECL_PATTERN = re.compile(
 # importing module. `mod` here catches INLINE `mod x { ... }` blocks, which
 # declare a name in the entry module but pull no file into the crate (the
 # bodyless pattern above is what assigns files).
+# A `#[path = "..."]` attribute among a bodyless declaration's attributes
+# names the file backing it, which is where the qn scheme keys the module.
+# Only the plain string form is read: a cfg_attr wrapper is conditional and
+# no single target speaks for it (issue #1035).
+_RS_MOD_REDIRECT_PATTERN = re.compile(
+    r"^[ \t]*((?:#\[[^\]\n]*\][ \t]*\n?)*)"
+    r"(?:pub[ \t]*(?:\([^)]*\))?[ \t]+)?"
+    r"mod[ \t]+(?:r#)?([A-Za-z_][A-Za-z0-9_]*)[ \t]*;",
+    re.MULTILINE,
+)
+_RS_PATH_ATTRIBUTE_PATTERN = re.compile(r'#\[[ \t]*path[ \t]*=[ \t]*"([^"]+)"[ \t]*\]')
 _RS_ITEM_DECL_PATTERN = re.compile(
     r"^\s*(?:#\[[^\]\n]*\]\s*)*(?:pub\s*(?:\([^)]*\))?\s+)?"
     r'(?:(?:unsafe|async|const|extern\s+"[^"]*")\s+)*'
@@ -162,6 +174,50 @@ def _rs_strip_comments_and_strings(source: str) -> str:
         out.append(c)
         i += 1
     return "".join(out)
+
+
+class RustEntryDecls(NamedTuple):
+    """What an entry file's top level declares, for crate attribution."""
+
+    mods: set[str]
+    items: set[str]
+    # Declared name -> the file path its `#[path]` attribute names, kept
+    # separate because the qn scheme keys the module by that FILE while
+    # every crate path names it by the declared name (issue #1035).
+    redirects: dict[str, str]
+
+
+def _rs_entry_decls_of(top_level: str, source: str) -> RustEntryDecls:
+    # The blanked text is what decides which declarations are real, since
+    # a string literal cannot fake a `mod x;` there. It also empties every
+    # string, so the `#[path]` VALUE survives only in the raw source: read
+    # it there and keep it only for a name the blanked scan confirmed.
+    mods = set(_RS_MOD_DECL_PATTERN.findall(top_level))
+    redirects: dict[str, str] = {}
+    for attributes, name in _RS_MOD_REDIRECT_PATTERN.findall(source):
+        if name in mods and (match := _RS_PATH_ATTRIBUTE_PATTERN.search(attributes)):
+            redirects[name] = match.group(1)
+    return RustEntryDecls(
+        mods,
+        set(_RS_ITEM_DECL_PATTERN.findall(top_level)),
+        redirects,
+    )
+
+
+def _rs_redirect_parts(dir_parts: list[str], redirect: str) -> list[str] | None:
+    """Repo-relative qn segments for a `#[path]` target, or None if it escapes.
+
+    The path counts from the directory holding the declaring entry file,
+    and a `mod.rs` target names that directory rather than a file beside
+    it.
+    """
+    parts = posixpath.normpath(posixpath.join(*dir_parts, redirect)).split("/")
+    if parts and parts[-1].endswith(cs.EXT_RS):
+        stem = parts.pop()[: -len(cs.EXT_RS)]
+        if stem != cs.INDEX_MOD:
+            parts.append(stem)
+    cleaned = [part for part in parts if part not in ("", ".")]
+    return None if not cleaned or ".." in cleaned else cleaned
 
 
 def _rs_top_level_only(stripped: str) -> str:
@@ -450,7 +506,7 @@ class ImportProcessor:
         # reset_rust_path_caches so watch re-runs re-observe the filesystem.
         self._rust_dir_listing: dict[str, frozenset[str]] = {}
         self._rust_entry_mod_decls: dict[
-            tuple[str, ...], dict[str, tuple[set[str], set[str]]]
+            tuple[str, ...], dict[str, RustEntryDecls]
         ] = {}
         # Explicit Cargo target entry paths per package dir ([[bin]]/[lib]/
         # [[example]]/[[test]]/[[bench]] `path` overrides): such entries
@@ -1524,7 +1580,7 @@ class ImportProcessor:
             # declares that module (cargo-verified: src/cli/sub.rs builds
             # into the lib when lib.rs declares `mod cli;`).
             return top, True
-        declaring = [stem for stem, (mods, _items) in decls.items() if top in mods]
+        declaring = [stem for stem, entry in decls.items() if top in entry.mods]
         if declaring:
             return declaring[0], len(declaring) == 1
         for stem in ("lib", "main"):
@@ -1560,8 +1616,8 @@ class ImportProcessor:
             # hole exactly like an unreadable lib.rs and does.
             claiming = {
                 stem
-                for stem, (mods, items) in decls.items()
-                if mods or (items - {"main"})
+                for stem, entry in decls.items()
+                if entry.mods or (entry.items - {"main"})
             }
             if (
                 not build_hole
@@ -1583,10 +1639,8 @@ class ImportProcessor:
                 return stem, True
         return "lib", False
 
-    def _rust_entry_decls(
-        self, dir_parts: list[str]
-    ) -> dict[str, tuple[set[str], set[str]]]:
-        """Per entry stem: (mod declarations, top-level item names)."""
+    def _rust_entry_decls(self, dir_parts: list[str]) -> dict[str, RustEntryDecls]:
+        """Per entry stem: mod declarations, item names, `#[path]` targets."""
         key = tuple(dir_parts)
         decls = self._rust_entry_mod_decls.setdefault(key, {})
         entries = self._rust_dir_entries(self.repo_path.joinpath(*dir_parts))
@@ -1624,10 +1678,7 @@ class ImportProcessor:
                 # tie-break's real but wrong answer.
                 continue
             top_level = _rs_top_level_only(_rs_strip_comments_and_strings(source))
-            decls[stem] = (
-                set(_RS_MOD_DECL_PATTERN.findall(top_level)),
-                set(_RS_ITEM_DECL_PATTERN.findall(top_level)),
-            )
+            decls[stem] = _rs_entry_decls_of(top_level, source)
         return decls
 
     def _rust_attach(
@@ -1644,7 +1695,15 @@ class ImportProcessor:
         entries = self._rust_dir_entries(directory)
         chosen = self._rust_entry_decls(dir_parts).get(stem)
         if rest and chosen is not None:
-            file_mods, items = chosen
+            file_mods, items = chosen.mods, chosen.items
+            if redirect := chosen.redirects.get(rest[0]):
+                # The declaration names its backing file outright, and the
+                # module keys under that file, so the declared name never
+                # appears in the qn at all (issue #1035).
+                if target := _rs_redirect_parts(dir_parts, redirect):
+                    return cs.SEPARATOR_DOT.join(
+                        [self.project_name, *target, *rest[1:]]
+                    )
             if rest[0] in file_mods:
                 return cs.SEPARATOR_DOT.join([self.project_name, *dir_parts, *rest])
             if rest[0] in items:
@@ -1660,8 +1719,8 @@ class ImportProcessor:
             # When a file compiles into BOTH crates (lib.rs and main.rs each
             # declare its module), the path can only mean the entry that
             # DECLARES the item; the chosen entry declaring it returned above.
-            for other, (_mods, items) in self._rust_entry_decls(dir_parts).items():
-                if other != stem and rest[0] in items:
+            for other, other_decls in self._rust_entry_decls(dir_parts).items():
+                if other != stem and rest[0] in other_decls.items:
                     stem = other
                     break
         return cs.SEPARATOR_DOT.join([self.project_name, *dir_parts, stem, *rest])
@@ -2370,10 +2429,7 @@ class ImportProcessor:
                     top_level = _rs_top_level_only(
                         _rs_strip_comments_and_strings(source)
                     )
-                    stems[file_path.stem] = (
-                        set(_RS_MOD_DECL_PATTERN.findall(top_level)),
-                        set(_RS_ITEM_DECL_PATTERN.findall(top_level)),
-                    )
+                    stems[file_path.stem] = _rs_entry_decls_of(top_level, source)
         if file_path.name == cs.PKG_CARGO_TOML:
             # A manifest edit can add, remove, or repoint explicit targets
             # anywhere in its package, and a CREATED manifest moves the

--- a/codebase_rag/parsers/rs/utils.py
+++ b/codebase_rag/parsers/rs/utils.py
@@ -33,11 +33,19 @@ def path_attribute_qn_parts(
     repository root names a file the qn scheme never keys, so nothing is
     claimed rather than a spelling guessed at.
     """
-    if not redirect.endswith(cs.EXT_RS) or ntpath.isabs(redirect) or "\\" in redirect:
-        # Only a `.rs` file backs a module, and an absolute path names one
-        # the qn scheme never keys. `ntpath` is what recognises BOTH forms
-        # of absolute (a leading slash and a `C:` drive) whatever platform
-        # the indexer itself runs on.
+    if (
+        not redirect.endswith(cs.EXT_RS)
+        or redirect.startswith("/")
+        or ntpath.splitdrive(redirect)[0]
+        or "\\" in redirect
+    ):
+        # Only a `.rs` file backs a module, and a rooted path names one the
+        # qn scheme never keys. Both rooted forms are spelled out here: a
+        # leading slash, and a `C:` drive that `ntpath` is what recognises
+        # whatever platform the indexer itself runs on. `ntpath.isabs` is
+        # not the check, since 3.13 changed it to call a single leading
+        # slash relative (to the current drive), which is true of Windows
+        # but says nothing about whether the repository holds the file.
         return None
     parts = posixpath.normpath(posixpath.join(*dir_parts, redirect)).split("/")
     stem = parts.pop()[: -len(cs.EXT_RS)]

--- a/codebase_rag/parsers/rs/utils.py
+++ b/codebase_rag/parsers/rs/utils.py
@@ -1,9 +1,23 @@
-from collections.abc import Sequence
+import re
+from collections.abc import Iterable, Sequence
 
 from tree_sitter import Node
 
 from ... import constants as cs
 from ..utils import safe_decode_text
+
+# `#[path = "support/helpers.rs"]` redirects the mod declaration it sits on
+# to an arbitrary file. Only the plain string form is read: a cfg_attr
+# wrapper is conditional and no single target speaks for it.
+_RS_PATH_ATTRIBUTE = re.compile(r'^#\[\s*path\s*=\s*"([^"]+)"\s*\]$')
+
+
+def path_attribute_target(decorators: Iterable[object]) -> str | None:
+    """The file a `#[path = "..."]` attribute points the declaration at."""
+    for decorator in decorators:
+        if match := _RS_PATH_ATTRIBUTE.match(str(decorator).strip()):
+            return match.group(1)
+    return None
 
 
 def _collect_path_parts(node: Node, parts: list[str]) -> None:

--- a/codebase_rag/parsers/rs/utils.py
+++ b/codebase_rag/parsers/rs/utils.py
@@ -1,3 +1,4 @@
+import ntpath
 import posixpath
 import re
 from collections.abc import Iterable, Sequence
@@ -26,15 +27,17 @@ def path_attribute_qn_parts(
 ) -> list[str] | None:
     """Qn segments for a `#[path]` target, or None when none can be named.
 
-    The path counts from the directory holding the declaring file, and a
-    `mod.rs` target names that directory rather than a file beside it. An
-    absolute path, a Windows separator, or a climb above the repository
-    root names a file the qn scheme never keys, so nothing is claimed
-    rather than a spelling guessed at.
+    `dir_parts` is the directory the path counts from, and a `mod.rs`
+    target names that directory rather than a file beside it. An absolute
+    path, a Windows separator, a non-`.rs` target, or a climb above the
+    repository root names a file the qn scheme never keys, so nothing is
+    claimed rather than a spelling guessed at.
     """
-    if not redirect.endswith(cs.EXT_RS) or redirect.startswith("/") or "\\" in redirect:
-        # Only a `.rs` file backs a module, and an absolute or
-        # backslash-separated path names one the qn scheme never keys.
+    if not redirect.endswith(cs.EXT_RS) or ntpath.isabs(redirect) or "\\" in redirect:
+        # Only a `.rs` file backs a module, and an absolute path names one
+        # the qn scheme never keys. `ntpath` is what recognises BOTH forms
+        # of absolute (a leading slash and a `C:` drive) whatever platform
+        # the indexer itself runs on.
         return None
     parts = posixpath.normpath(posixpath.join(*dir_parts, redirect)).split("/")
     stem = parts.pop()[: -len(cs.EXT_RS)]

--- a/codebase_rag/parsers/rs/utils.py
+++ b/codebase_rag/parsers/rs/utils.py
@@ -1,3 +1,4 @@
+import posixpath
 import re
 from collections.abc import Iterable, Sequence
 
@@ -18,6 +19,31 @@ def path_attribute_target(decorators: Iterable[object]) -> str | None:
         if match := _RS_PATH_ATTRIBUTE.match(str(decorator).strip()):
             return match.group(1)
     return None
+
+
+def path_attribute_qn_parts(
+    dir_parts: Sequence[str], redirect: str
+) -> list[str] | None:
+    """Qn segments for a `#[path]` target, or None when none can be named.
+
+    The path counts from the directory holding the declaring file, and a
+    `mod.rs` target names that directory rather than a file beside it. An
+    absolute path, a Windows separator, or a climb above the repository
+    root names a file the qn scheme never keys, so nothing is claimed
+    rather than a spelling guessed at.
+    """
+    if not redirect.endswith(cs.EXT_RS) or redirect.startswith("/") or "\\" in redirect:
+        # Only a `.rs` file backs a module, and an absolute or
+        # backslash-separated path names one the qn scheme never keys.
+        return None
+    parts = posixpath.normpath(posixpath.join(*dir_parts, redirect)).split("/")
+    stem = parts.pop()[: -len(cs.EXT_RS)]
+    if not stem:
+        return None
+    if stem != cs.INDEX_MOD:
+        parts.append(stem)
+    cleaned = [part for part in parts if part not in ("", ".")]
+    return None if not cleaned or ".." in cleaned else cleaned
 
 
 def _collect_path_parts(node: Node, parts: list[str]) -> None:

--- a/codebase_rag/tests/test_rust_cfg_test_mod_declarations.py
+++ b/codebase_rag/tests/test_rust_cfg_test_mod_declarations.py
@@ -186,12 +186,13 @@ def test_gate_survives_interleaved_doc_comment(
     assert "rs_cfgtest_doc.src.testutil" in gates, gates
 
 
-def test_path_attribute_declaration_mints_no_orphan_module(
+def test_path_attribute_declaration_gates_the_file_it_names(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:
-    # A #[path]-redirected target lands at a qn the scheme cannot predict:
-    # the recorded candidate names no real module and stays inert, and no
-    # node is minted for it (the fixture audit rejects orphans).
+    # A #[path]-redirected target keys under the FILE the attribute names,
+    # so that is the qn the gate records (issue #1035). The name-derived
+    # spelling backs nothing and must not be recorded, and no node is
+    # minted for either (the fixture audit rejects orphans).
     project = temp_repo / "rs_cfgtest_pathattr"
     _write(
         project,
@@ -211,7 +212,8 @@ def test_path_attribute_declaration_mints_no_orphan_module(
     create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
 
     gates = _declared_gates(mock_ingestor, "rs_cfgtest_pathattr.src.lib")
-    assert "rs_cfgtest_pathattr.src.helpers" in gates, gates
+    assert "rs_cfgtest_pathattr.src.support.helpers" in gates, gates
+    assert "rs_cfgtest_pathattr.src.helpers" not in gates, gates
 
 
 def test_gate_on_bodied_inline_module_marks_its_own_node(

--- a/codebase_rag/tests/test_rust_path_attribute_mod.py
+++ b/codebase_rag/tests/test_rust_path_attribute_mod.py
@@ -1,10 +1,10 @@
 """A `#[path]` attribute redirects a Rust mod declaration to another file.
 
 The qn scheme is path-derived, so the target keys under where the FILE
-sits while every declaration-side resolution computes the name-derived
-spelling, a qn no module owns. The `#[cfg(test)]` gate recorded on such a
-declaration therefore names nothing and the target counts as production
-code (issue #1035).
+sits, while every declaration-side resolution used to compute the
+name-derived spelling: a qn no module owns. Both consumers now read the
+attribute, so a `#[cfg(test)]` gate reaches the file it names and a crate
+path through the declared name lands on that file too (issue #1035).
 """
 
 from pathlib import Path
@@ -24,8 +24,8 @@ def test_path_attribute_gate_names_the_target_file_module(
 ) -> None:
     # `#[path = "support/helpers.rs"] mod helpers;` in src/lib.rs backs
     # src/support/helpers.rs, which indexes as src.support.helpers. The
-    # name-derived src.helpers owns nothing, so the gate stays inert and
-    # `fixture` reads as production code.
+    # name-derived src.helpers owns nothing, so recording it leaves the
+    # gate inert and `fixture` reads as production code.
     project = temp_repo / "rs_path_attr"
     _write(
         project,
@@ -135,3 +135,128 @@ def test_crate_path_resolves_through_a_redirected_module(
         "rs_path_attr_call.src.a.run",
         "rs_path_attr_call.src.decoy.fixture",
     ) not in calls, calls
+
+
+def test_a_commented_out_redirect_does_not_hijack_a_live_declaration(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The declaration scan reads comment-and-string-blanked source so that
+    # no comment or literal can present a declaration. The `#[path]` value
+    # has to survive that blanking to be read at all, and keeping it must
+    # not reopen the door: an attribute inside a comment is not one.
+    project = temp_repo / "rs_path_attr_comment"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_path_attr_comment"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": (
+                "/* previous layout:\n"
+                '#[path = "decoy.rs"]\n'
+                "mod helpers;\n"
+                "*/\n"
+                "mod helpers;\n"
+                "pub mod decoy;\n"
+                "pub mod a;\n"
+            ),
+            "src/helpers.rs": "pub fn fixture() -> i32 {\n    7\n}\n",
+            "src/decoy.rs": "pub fn fixture() -> i32 {\n    1\n}\n",
+            "src/a.rs": "pub fn run() -> i32 {\n    crate::helpers::fixture()\n}\n",
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    caller = "rs_path_attr_comment.src.a.run"
+    assert (caller, "rs_path_attr_comment.src.helpers.fixture") in calls, calls
+    assert (caller, "rs_path_attr_comment.src.decoy.fixture") not in calls, calls
+
+
+def test_a_redirect_inside_a_string_literal_is_not_read(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # A raw string may hold whole lines of Rust; none of it is code.
+    project = temp_repo / "rs_path_attr_string"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_path_attr_string"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": (
+                'pub const SAMPLE: &str = r#"\n'
+                '#[path = "decoy.rs"]\n'
+                "mod helpers;\n"
+                '"#;\n'
+                "mod helpers;\n"
+                "pub mod decoy;\n"
+                "pub mod a;\n"
+            ),
+            "src/helpers.rs": "pub fn fixture() -> i32 {\n    7\n}\n",
+            "src/decoy.rs": "pub fn fixture() -> i32 {\n    1\n}\n",
+            "src/a.rs": "pub fn run() -> i32 {\n    crate::helpers::fixture()\n}\n",
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    caller = "rs_path_attr_string.src.a.run"
+    assert (caller, "rs_path_attr_string.src.helpers.fixture") in calls, calls
+    assert (caller, "rs_path_attr_string.src.decoy.fixture") not in calls, calls
+
+
+def test_a_redirect_declared_inside_a_macro_body_is_read(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # Platform modules are routinely declared inside `cfg_if!`, and the
+    # declaration scan keeps depth-0 macro bodies for exactly that reason,
+    # so a redirect written there is a real one.
+    project = temp_repo / "rs_path_attr_macro"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_path_attr_macro"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": (
+                "pub mod a;\n"
+                "cfg_if! {\n"
+                '    #[path = "support/helpers.rs"]\n'
+                "    mod helpers;\n"
+                "}\n"
+            ),
+            "src/support/helpers.rs": "pub fn fixture() -> i32 {\n    7\n}\n",
+            "src/decoy.rs": "pub fn fixture() -> i32 {\n    1\n}\n",
+            "src/a.rs": "pub fn run() -> i32 {\n    crate::helpers::fixture()\n}\n",
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    caller = "rs_path_attr_macro.src.a.run"
+    assert (
+        caller,
+        "rs_path_attr_macro.src.support.helpers.fixture",
+    ) in calls, calls
+
+
+def test_an_absolute_redirect_claims_nothing(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # An absolute path names a file outside the indexed tree, so both the
+    # gate and the crate path stand down rather than inventing a spelling.
+    project = temp_repo / "rs_path_attr_abs"
+    _write(
+        project,
+        {
+            "Cargo.toml": ('[package]\nname = "rs_path_attr_abs"\nversion = "0.1.0"\n'),
+            "src/lib.rs": (
+                "#[cfg(test)]\n"
+                '#[path = "/nowhere/helpers.rs"]\n'
+                "mod helpers;\n"
+                "\n"
+                "pub fn add() -> i32 {\n    1\n}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    gates = _declared_gates(mock_ingestor, "rs_path_attr_abs.src.lib")
+    assert not any("nowhere" in gate for gate in gates), gates

--- a/codebase_rag/tests/test_rust_path_attribute_mod.py
+++ b/codebase_rag/tests/test_rust_path_attribute_mod.py
@@ -11,6 +11,11 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 from codebase_rag import constants as cs
+from codebase_rag.parsers.import_processor import (
+    _rs_entry_decls_of,
+    _rs_strip_comments_and_strings,
+    _rs_top_level_only,
+)
 from codebase_rag.tests.test_rust_cfg_test_mod_declarations import _declared_gates
 from codebase_rag.tests.test_rust_crate_path_trait_linking import (
     _calls,
@@ -260,3 +265,107 @@ def test_an_absolute_redirect_claims_nothing(
     create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
     gates = _declared_gates(mock_ingestor, "rs_path_attr_abs.src.lib")
     assert not any("nowhere" in gate for gate in gates), gates
+
+
+def test_two_cfg_variants_of_one_name_claim_no_single_target() -> None:
+    # Platform modules are declared once per cfg under a single name, each
+    # redirected somewhere else. Exactly one compiles and nothing in a
+    # static scan knows which, so the name keeps no redirect rather than
+    # the one that happens to be written last.
+    source = (
+        "#[cfg(unix)]\n"
+        '#[path = "sys/unix.rs"]\n'
+        "mod platform;\n"
+        "#[cfg(windows)]\n"
+        '#[path = "sys/windows.rs"]\n'
+        "mod platform;\n"
+    )
+    decls = _rs_entry_decls_of(
+        _rs_top_level_only(_rs_strip_comments_and_strings(source))
+    )
+    assert "platform" in decls.mods, decls
+    assert decls.redirects == {}, decls.redirects
+
+
+def test_two_cfg_variants_gate_both_of_their_targets(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The gate side sees each declaration on its own, and both really are
+    # gated, so both targets are recorded whichever one compiles.
+    project = temp_repo / "rs_path_attr_cfg_gate"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_path_attr_cfg_gate"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": (
+                "#[cfg(test)]\n"
+                '#[path = "sys/unix.rs"]\n'
+                "mod platform;\n"
+                "#[cfg(test)]\n"
+                '#[path = "sys/windows.rs"]\n'
+                "mod other;\n"
+            ),
+            "src/sys/unix.rs": "pub fn boot() -> i32 {\n    1\n}\n",
+            "src/sys/windows.rs": "pub fn boot() -> i32 {\n    2\n}\n",
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    gates = _declared_gates(mock_ingestor, "rs_path_attr_cfg_gate.src.lib")
+    assert "rs_path_attr_cfg_gate.src.sys.unix" in gates, gates
+    assert "rs_path_attr_cfg_gate.src.sys.windows" in gates, gates
+
+
+def test_a_drive_qualified_redirect_claims_nothing(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `C:/...` is absolute on Windows and carries no separator this check
+    # would otherwise notice.
+    project = temp_repo / "rs_path_attr_drive"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_path_attr_drive"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": (
+                "#[cfg(test)]\n"
+                '#[path = "C:/outside/helpers.rs"]\n'
+                "mod helpers;\n"
+                "\n"
+                "pub fn add() -> i32 {\n    1\n}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    gates = _declared_gates(mock_ingestor, "rs_path_attr_drive.src.lib")
+    assert not any("outside" in gate or "C:" in gate for gate in gates), gates
+
+
+def test_redirect_inside_an_inline_module_gates_the_file_it_names(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # Inside an inline block the path counts from the declaring file's
+    # directory plus the inline chain, so the gate still has to name the
+    # file the indexer keyed the module by.
+    project = temp_repo / "rs_path_attr_inline"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_path_attr_inline"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": (
+                "pub mod outer {\n"
+                "    #[cfg(test)]\n"
+                '    #[path = "redirected.rs"]\n'
+                "    mod child;\n"
+                "}\n"
+            ),
+            "src/outer/redirected.rs": ("pub(crate) fn fixture() -> i32 {\n    7\n}\n"),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    gates = _declared_gates(mock_ingestor, "rs_path_attr_inline.src.lib")
+    assert "rs_path_attr_inline.src.outer.redirected" in gates, gates

--- a/codebase_rag/tests/test_rust_path_attribute_mod.py
+++ b/codebase_rag/tests/test_rust_path_attribute_mod.py
@@ -1,0 +1,137 @@
+"""A `#[path]` attribute redirects a Rust mod declaration to another file.
+
+The qn scheme is path-derived, so the target keys under where the FILE
+sits while every declaration-side resolution computes the name-derived
+spelling, a qn no module owns. The `#[cfg(test)]` gate recorded on such a
+declaration therefore names nothing and the target counts as production
+code (issue #1035).
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag import constants as cs
+from codebase_rag.tests.test_rust_cfg_test_mod_declarations import _declared_gates
+from codebase_rag.tests.test_rust_crate_path_trait_linking import (
+    _calls,
+    _write,
+    create_and_run_updater,
+)
+
+
+def test_path_attribute_gate_names_the_target_file_module(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `#[path = "support/helpers.rs"] mod helpers;` in src/lib.rs backs
+    # src/support/helpers.rs, which indexes as src.support.helpers. The
+    # name-derived src.helpers owns nothing, so the gate stays inert and
+    # `fixture` reads as production code.
+    project = temp_repo / "rs_path_attr"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "rs_path_attr"\nversion = "0.1.0"\n',
+            "src/lib.rs": (
+                "#[cfg(test)]\n"
+                '#[path = "support/helpers.rs"]\n'
+                "mod helpers;\n"
+                "\n"
+                "pub fn add(a: i32, b: i32) -> i32 {\n"
+                "    a + b\n"
+                "}\n"
+            ),
+            "src/support/helpers.rs": ("pub(crate) fn fixture() -> i32 {\n    7\n}\n"),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    gates = _declared_gates(mock_ingestor, "rs_path_attr.src.lib")
+    assert "rs_path_attr.src.support.helpers" in gates, gates
+
+
+def test_path_attribute_target_beside_a_plain_file(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The path is relative to the DIRECTORY holding the declaring file,
+    # never to a directory named after it, so a plain (non mod-rs) file
+    # redirects its declaration into its own parent directory.
+    project = temp_repo / "rs_path_attr_plain"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_path_attr_plain"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": "pub mod engine;\n",
+            "src/engine.rs": (
+                "#[cfg(test)]\n"
+                '#[path = "fixtures/rig.rs"]\n'
+                "mod rig;\n"
+                "\n"
+                "pub fn run() -> i32 {\n"
+                "    1\n"
+                "}\n"
+            ),
+            "src/fixtures/rig.rs": "pub(crate) fn build() -> i32 {\n    2\n}\n",
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    gates = _declared_gates(mock_ingestor, "rs_path_attr_plain.src.engine")
+    assert "rs_path_attr_plain.src.fixtures.rig" in gates, gates
+
+
+def test_declaration_without_a_path_attribute_is_untouched(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The ordinary spelling still resolves through the relative-path
+    # machinery; only a redirected declaration takes the file-derived qn.
+    project = temp_repo / "rs_path_attr_none"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_path_attr_none"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": "#[cfg(test)]\nmod helpers;\n\npub fn add() -> i32 {\n    1\n}\n",
+            "src/helpers.rs": "pub(crate) fn fixture() -> i32 {\n    7\n}\n",
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    gates = _declared_gates(mock_ingestor, "rs_path_attr_none.src.lib")
+    assert "rs_path_attr_none.src.helpers" in gates, gates
+    assert not any(cs.SEPARATOR_DOT + "support" in gate for gate in gates), gates
+
+
+def test_crate_path_resolves_through_a_redirected_module(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `crate::helpers::fixture()` names the module by its DECLARED name
+    # while the module keys under the redirected file, so the crate path
+    # has to land on the file's qn to reach anything at all.
+    project = temp_repo / "rs_path_attr_call"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_path_attr_call"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": (
+                '#[path = "support/helpers.rs"]\n'
+                "mod helpers;\n"
+                "pub mod a;\n"
+                "pub mod decoy;\n"
+            ),
+            "src/support/helpers.rs": "pub(crate) fn fixture() -> i32 {\n    7\n}\n",
+            "src/decoy.rs": "pub fn fixture() -> i32 {\n    1\n}\n",
+            "src/a.rs": ("pub fn run() -> i32 {\n    crate::helpers::fixture()\n}\n"),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    assert (
+        "rs_path_attr_call.src.a.run",
+        "rs_path_attr_call.src.support.helpers.fixture",
+    ) in calls, calls
+    assert (
+        "rs_path_attr_call.src.a.run",
+        "rs_path_attr_call.src.decoy.fixture",
+    ) not in calls, calls

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.543"
+version = "0.0.545"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #1035.

A `#[path]` attribute points a Rust `mod` declaration at an arbitrary file, and the qn scheme keys the module by where that FILE sits. Every declaration-side resolution computed the name-derived spelling instead, a qn no module owns, so the `#[cfg(test)]` gate recorded on such a declaration named nothing and its target counted as production code.

```rust
// src/lib.rs
#[cfg(test)]
#[path = "support/helpers.rs"]
mod helpers;
```

The file indexes at `src.support.helpers`; the gate was recorded against `src.helpers`.

## Change

Both consumers now read the attribute and share one resolution, `path_attribute_qn_parts`, so they cannot drift apart: the path counts from the directory holding the declaring file, a `mod.rs` target names that directory, and an absolute path, a Windows separator, a non-`.rs` target, or a climb above the repository root claims nothing rather than guessing a spelling.

The declaration scan needed the value to survive its own defences. It reads comment-and-string-blanked source precisely so that no comment or literal can present a `mod x;` line, and that blanking was emptying the `#[path]` value along with every other string. The lexer now keeps that one literal, and only that one: it matches the opening `#[path =` in code it has already walked, so no comment or outer string can present one.

## Tests

Red first. Two cover the gate and one covers a crate path through a redirected module.

Four more came out of the pre-push review, each red against the first cut of this branch: a commented-out redirect above a live declaration, a redirect inside a raw string, a redirect inside a `cfg_if!` body (the shape the surrounding scan was written for, which the first cut silently skipped), and an absolute path.

The crate-path test needed a decoy to mean anything. It passed the moment it was written because the simple-name fallback found the only `fixture` in the fixture repo; a second `fixture` in another module turned it red and showed the path binding the wrong module entirely.

One existing test asserted the old behaviour outright, that the inert name-derived spelling gets recorded. It now asserts the corrected target and keeps its no-orphan check.

## Out of scope

Crate paths through a redirect declared outside a crate entry file, filed as #1065. `#[path]` on bodied inline modules and `cfg_attr`-conditional paths remain out of scope as the issue states.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Rust module indexing for `#[path]` declarations, including redirected files and `mod.rs` directory targets.
  * Corrected module qualification, crate-path resolution, and configuration gating for redirected modules.
  * Prevented commented, string-literal, unsupported, or out-of-tree paths from being incorrectly interpreted as module redirects.

* **Tests**
  * Added comprehensive coverage for redirected modules, inline modules, configuration gates, macros, plain files, and invalid paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->