### PR TITLE
chore: update retired Claude model ids in server.json and review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
+          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.8)
+          # model: "claude-opus-4-8"
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |

--- a/server.json
+++ b/server.json
@@ -34,7 +34,7 @@
         {
           "name": "ORCHESTRATOR_MODEL",
           "description": "Model name for the orchestrator agent",
-          "default": "claude-sonnet-4-20250514"
+          "default": "claude-sonnet-4-6"
         },
         {
           "name": "ORCHESTRATOR_API_KEY",
@@ -50,7 +50,7 @@
         {
           "name": "CYPHER_MODEL",
           "description": "Model name for Cypher query generation",
-          "default": "claude-sonnet-4-20250514"
+          "default": "claude-sonnet-4-6"
         },
         {
           "name": "CYPHER_API_KEY",


### PR DESCRIPTION
## Summary

- `server.json` advertises `claude-sonnet-4-20250514` as the default for `ORCHESTRATOR_MODEL` and `CYPHER_MODEL`. That id was retired on 15 June 2026, so anyone who installs the MCP server and takes the published defaults starts from an id the API no longer serves.
- The commented model line in `.github/workflows/claude-code-review.yml` points at `claude-opus-4-1-20250805`, which retires on 5 August 2026. Uncommenting it after that date breaks the review job.

| File | Line | Before | After |
| --- | --- | --- | --- |
| `server.json` | 37 | `claude-sonnet-4-20250514` | `claude-sonnet-4-6` |
| `server.json` | 53 | `claude-sonnet-4-20250514` | `claude-sonnet-4-6` |
| `.github/workflows/claude-code-review.yml` | 41-42 | `claude-opus-4-1-20250805`, "Claude Opus 4.1" | `claude-opus-4-8`, "Claude Opus 4.8" |

Retirement dates come from the Anthropic deprecation page: https://platform.claude.com/docs/en/about-claude/model-deprecations

Both replacements already appear in `codebase_rag/constants/providers.py`, so the context-window table covers them without further edits.

## What I left alone

`codebase_rag/constants/providers.py` and the tests under `codebase_rag/tests/` already use current ids, and the entries for older models there are a capability table rather than a model choice, so removing them would drop real data.

The same workflow comment says the action "defaults to Claude Sonnet 4". I did not touch that clause because it describes `anthropics/claude-code-action` behaviour rather than anything configured here, and I have not verified what that default is today.

## Type of Change

- [x] CI/CD or tooling
- [x] Bug fix

## Test Plan

- [x] Manual testing: `server.json` still parses as JSON, and the workflow change is inside a comment, so the job is unaffected until someone uncomments it.

Nothing executable changed, so the Python suite is untouched by this diff.

## Checklist

- [x] PR title follows Conventional Commits format
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [x] No new comments or docstrings

---

I read this diff line by line before opening it, and I am happy to adjust or drop any part of it. What brought me here was a checker I maintain that flags retired Claude model ids, so I am saying that up front rather than leaving you to wonder. I have not run either id against the API to reproduce a failure, the claim rests on the published retirement dates. If you would rather handle this your own way, or would rather not get this kind of contribution at all, tell me and I will not send another.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default AI model configuration to use the latest Claude Sonnet version.
  * Updated the example Claude Opus model reference in the code review workflow documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->