### PR TITLE
fix: keep a Rust body-local item from taking a reachable qualified name

### DIFF
--- a/codebase_rag/constants/fqn_specs.py
+++ b/codebase_rag/constants/fqn_specs.py
@@ -140,6 +140,7 @@ from .ast_python import (
 from .ast_rust import (
     TS_RS_CALL_EXPRESSION,
     TS_RS_CLOSURE_EXPRESSION,
+    TS_RS_CONST_ITEM,
     TS_RS_ENUM_ITEM,
     TS_RS_EXTERN_CRATE_DECLARATION,
     TS_RS_FUNCTION_ITEM,
@@ -149,6 +150,7 @@ from .ast_rust import (
     TS_RS_MACRO_INVOCATION,
     TS_RS_MOD_ITEM,
     TS_RS_SOURCE_FILE,
+    TS_RS_STATIC_ITEM,
     TS_RS_STRUCT_ITEM,
     TS_RS_TRAIT_ITEM,
     TS_RS_TYPE_ITEM,
@@ -409,6 +411,16 @@ RS_TYPE_NODE_TYPES = (
     TS_RS_TYPE_ITEM,
 )
 RS_IDENT_NODE_TYPES = (TS_RS_FUNCTION_ITEM, TS_RS_MOD_ITEM)
+
+# Nodes whose body holds items no path from another module can name.
+RS_BODY_LOCAL_CONTAINERS = frozenset(
+    {
+        TS_RS_FUNCTION_ITEM,
+        TS_RS_CLOSURE_EXPRESSION,
+        TS_RS_CONST_ITEM,
+        TS_RS_STATIC_ITEM,
+    }
+)
 
 CPP_NAME_NODE_TYPES = (
     CppNodeType.CLASS_SPECIFIER,

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -115,6 +115,13 @@ def _method_belongs_directly(
 def _skip_method(
     method_node: Node, class_node: Node, class_body: Node, lang_config: LanguageSpec
 ) -> bool:
+    # Both walks below stop at a bodied function but cross a Rust const/static
+    # initializer without noticing, so an item written in one inside an impl
+    # was ingested as a method of that type and took its name (issue #1037).
+    if lang_config.language == cs.SupportedLanguage.RUST and rs_utils.is_body_local(
+        method_node
+    ):
+        return True
     if settings.CAPTURE_FUNCTION_LOCAL_DEFINITIONS:
         return not _method_belongs_directly(method_node, class_node, lang_config)
     return _is_nested_inside_function(method_node, class_body, lang_config)

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -191,6 +191,7 @@ class DefinitionProcessor(
         # Unnamed JS/TS function expressions held back until the named
         # JS passes have claimed their spans (one node per source function).
         self._deferred_js_anonymous: list = []
+        self._deferred_rust_body_local: list = []
         # Macro-invocation-shaped C++ nodes held until every class (incl.
         # rehydrated ones) is known; resolve_deferred_cpp_artifacts decides
         # orphaned-ctor vs macro.
@@ -392,6 +393,9 @@ class DefinitionProcessor(
                 combined_captures=combined_captures,
             )
             if language == cs.SupportedLanguage.RUST:
+                # The methods above have claimed their names; a body-local item
+                # may now take what is left of the one it shares.
+                self._flush_deferred_rust_body_local()
                 # Function-body uses key on the REGISTERED qn of their
                 # enclosing function, knowable only now that dedup variants
                 # (`natural@<line>`) have been handed out.

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -498,6 +498,7 @@ class FunctionIngestMixin:
             )
 
     def _flush_deferred_rust_body_local(self) -> None:
+        """Register the file's held-back Rust body-local items (issue #1037)."""
         deferred = self._deferred_rust_body_local
         self._deferred_rust_body_local = []
         for entry in deferred:
@@ -509,6 +510,19 @@ class FunctionIngestMixin:
                 entry.lang_config,
                 entry.lang_queries,
             )
+            # A call-bound local (`let s = make()`) types from this map, so the
+            # return type has to be recorded here too. Under the qn the
+            # registry HANDED OUT, which for a body-local item contesting a
+            # module item of that name is the `@<line>` variant: recording
+            # under the proposed qn would overwrite the module item's own
+            # return type and mistype every caller of it.
+            location = self.function_locations.get(
+                function_span_key(entry.module_qn, entry.func_node)
+            )
+            if location is not None and (
+                return_type := rs_utils.extract_return_type_name(entry.func_node, None)
+            ):
+                self.method_return_types[location.qualified_name] = return_type
 
     def _flush_deferred_js_anonymous(self) -> None:
         deferred = self._deferred_js_anonymous

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -141,14 +141,16 @@ class _DeferredCppPrototype(NamedTuple):
     lang_queries: LanguageQueries
 
 
-class _DeferredJsAnonymous(NamedTuple):
-    """Unnamed JS/TS function expression held back until named passes claim.
+class _DeferredRegistration(NamedTuple):
+    """A function held back from the generic pass until later passes claim.
 
-    The generic function pass runs before the JS-specific passes, so
-    registering `anonymous_row_col` eagerly minted a second node for every
-    function a named pass registers later (521 locations on thrift's JS
-    corpora). Registration happens at the per-file flush, only for spans no
-    named pass claimed.
+    Two shapes need this. An unnamed JS/TS function expression may be one a
+    named pass registers under its real name, and registering
+    `anonymous_row_col` eagerly minted a second node for every one of them
+    (521 locations on thrift's JS corpora). A Rust definition written inside a
+    function body owns no name any caller can reach, so it must not take one
+    from the method or module item that does (issue #1037). Registration
+    happens at the per-file flush.
     """
 
     func_node: Node
@@ -237,7 +239,8 @@ class FunctionIngestMixin:
     function_locations: dict[FunctionSpanKey, FunctionLocation]
     cpp_definition_spans: dict[str, list[CppDefinitionSpan]]
     macro_qns: set[str]
-    _deferred_js_anonymous: list[_DeferredJsAnonymous]
+    _deferred_js_anonymous: list[_DeferredRegistration]
+    _deferred_rust_body_local: list[_DeferredRegistration]
     _deferred_cpp_artifacts: list[_DeferredCppArtifact]
     _deferred_cpp_prototypes: list[_DeferredCppPrototype]
     class_inheritance: dict[str, list[str]]
@@ -388,7 +391,29 @@ class FunctionIngestMixin:
             # registration was a duplicate node).
             if language in cs.JS_TS_LANGUAGES and resolution.is_anonymous:
                 self._deferred_js_anonymous.append(
-                    _DeferredJsAnonymous(
+                    _DeferredRegistration(
+                        func_node,
+                        resolution,
+                        module_qn,
+                        language,
+                        lang_config,
+                        lang_queries,
+                    )
+                )
+                continue
+
+            # A Rust item written inside a function body, a closure or a
+            # const/static initializer is reachable by path from nowhere, yet it
+            # registers in the qn space of the module or impl target that
+            # encloses it. Registering it here would let it take the natural qn
+            # of the method or module item of that name, which does own it and
+            # whose callers then resolve to this one; hold it back until those
+            # have claimed their names (issue #1037).
+            if language == cs.SupportedLanguage.RUST and rs_utils.is_body_local(
+                func_node
+            ):
+                self._deferred_rust_body_local.append(
+                    _DeferredRegistration(
                         func_node,
                         resolution,
                         module_qn,
@@ -470,6 +495,19 @@ class FunctionIngestMixin:
                 label=label,
                 qualified_name=qualified_name,
                 container_qn=None,
+            )
+
+    def _flush_deferred_rust_body_local(self) -> None:
+        deferred = self._deferred_rust_body_local
+        self._deferred_rust_body_local = []
+        for entry in deferred:
+            self._register_function(
+                entry.func_node,
+                entry.resolution,
+                entry.module_qn,
+                entry.language,
+                entry.lang_config,
+                entry.lang_queries,
             )
 
     def _flush_deferred_js_anonymous(self) -> None:
@@ -1556,6 +1594,14 @@ class FunctionIngestMixin:
         return f"{module_qn}.{func_name}"
 
     def _is_method(self, func_node: Node, lang_config: LanguageSpec) -> bool:
+        # A const/static initializer is a body like a function's, but it is no
+        # function node, so the shared walk climbs out of it to the impl above
+        # and calls the item inside it a method of that type. It is a free
+        # function local to the initializer (issue #1037).
+        if lang_config.language == cs.SupportedLanguage.RUST and rs_utils.is_body_local(
+            func_node
+        ):
+            return False
         return is_method_node(func_node, lang_config)
 
     def _csharp_scope_qn(self, node: Node, module_qn: str) -> str:

--- a/codebase_rag/parsers/rs/utils.py
+++ b/codebase_rag/parsers/rs/utils.py
@@ -416,6 +416,25 @@ def rust_use_scope(node: Node) -> tuple[Node | None, list[str] | None, bool]:
     return None, parts, pure
 
 
+def is_body_local(node: Node) -> bool:
+    """True when *node* sits directly in a function body or an initializer.
+
+    Such an item is in scope for that body alone: no path from another module
+    names it, so it owns none of the qn its enclosing module or impl target
+    hands out (issue #1037). A type declared in the body is a different
+    matter, and the walk stops there: an `impl` written in a method body is
+    still the owner of the methods inside it, whatever encloses the impl.
+    """
+    current = node.parent
+    while current is not None and current.type != cs.TS_RS_SOURCE_FILE:
+        if current.type in cs.SPEC_RS_CLASS_TYPES:
+            return False
+        if current.type in cs.RS_BODY_LOCAL_CONTAINERS:
+            return True
+        current = current.parent
+    return False
+
+
 def enclosing_mod_names(node: Node) -> frozenset[str]:
     """Names of `mod` items in scope at the node's own module level.
 

--- a/codebase_rag/tests/test_rust_block_item_scope_boundary.py
+++ b/codebase_rag/tests/test_rust_block_item_scope_boundary.py
@@ -91,25 +91,25 @@ def test_a_sibling_function_does_not_bind_another_block_item(
     )
     create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
     calls = _calls(mock_ingestor)
-    # The block item registered first and took the natural qn, so the
-    # module's own item is the one carrying a span suffix here.
-    assert (
-        "rs_boundary_sibling.src.a.f1",
-        "rs_boundary_sibling.src.a.g@15",
-    ) in calls, calls
+    # The module's own item keeps the natural qn: it is the one a path from
+    # anywhere can name, so the block item takes the span suffix (issue #1037).
     assert (
         "rs_boundary_sibling.src.a.f1",
         "rs_boundary_sibling.src.a.g",
+    ) in calls, calls
+    assert (
+        "rs_boundary_sibling.src.a.f1",
+        "rs_boundary_sibling.src.a.g@3",
     ) not in calls, calls
     # The call inside the block still reaches the block's own item, and
     # only it: the natural qn carries a dedup bucket holding the module
     # item too, which must not be fanned out onto.
-    assert ("rs_boundary_sibling.src.a.f0", "rs_boundary_sibling.src.a.g") in calls, (
+    assert ("rs_boundary_sibling.src.a.f0", "rs_boundary_sibling.src.a.g@3") in calls, (
         calls
     )
     assert (
         "rs_boundary_sibling.src.a.f0",
-        "rs_boundary_sibling.src.a.g@15",
+        "rs_boundary_sibling.src.a.g",
     ) not in calls, calls
 
 
@@ -188,24 +188,24 @@ def test_block_item_survives_the_module_keyed_resolution_cache(
     )
     create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
     calls = _calls(mock_ingestor)
-    assert ("rs_boundary_cache.src.a.f0", "rs_boundary_cache.src.a.g") in calls, calls
     assert (
-        "rs_boundary_cache.src.a.f1",
-        "rs_boundary_cache.src.a.g@15",
+        "rs_boundary_cache.src.a.f0",
+        "rs_boundary_cache.src.a.g@7",
     ) in calls, calls
+    assert ("rs_boundary_cache.src.a.f1", "rs_boundary_cache.src.a.g") in calls, calls
     assert (
         "rs_boundary_cache.src.a.f1",
-        "rs_boundary_cache.src.a.g",
+        "rs_boundary_cache.src.a.g@7",
     ) not in calls, calls
 
 
 def test_block_item_declared_after_the_module_item_keeps_the_boundary(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:
-    # Which of the two same-named items holds the natural qn follows
-    # registration order, so the boundary has to hold with the module item
-    # first as well: the dedup bucket the natural qn carries must not fan a
-    # resolved call out onto the other scope's item.
+    # The module item holds the natural qn wherever it is written, so this
+    # reads the same as its sibling above; what it adds is the source order
+    # that used to decide the question. The dedup bucket the natural qn
+    # carries must not fan a resolved call out onto the other scope's item.
     project = temp_repo / "rs_boundary_order"
     _write(
         project,

--- a/codebase_rag/tests/test_rust_block_item_shadows_fn_use.py
+++ b/codebase_rag/tests/test_rust_block_item_shadows_fn_use.py
@@ -84,8 +84,8 @@ def test_block_item_binds_over_a_same_named_module_item(
     create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
     calls = _calls(mock_ingestor)
     caller = "rs_block_item_twin.src.a.f0"
-    # The block item registered under a span-suffixed variant, the module
-    # item having taken the natural qn first.
+    # The block item registered under a span-suffixed variant: the module's
+    # own item is the one a path can name, so it keeps the natural qn.
     assert (caller, "rs_block_item_twin.src.a.g@8") in calls, calls
     assert (caller, "rs_block_item_twin.src.a.g") not in calls, calls
     assert (caller, "rs_block_item_twin.src.gamma.g") not in calls, calls

--- a/codebase_rag/tests/test_rust_nested_fn_in_impl_method.py
+++ b/codebase_rag/tests/test_rust_nested_fn_in_impl_method.py
@@ -1,0 +1,207 @@
+"""A Rust definition in a function body takes no name that is reachable.
+
+An item written inside a function body, a closure or a const initializer is
+in scope for that body alone, yet it registers in the qn space of the module
+or impl target enclosing it. The generic function pass ran before the method
+pass, so such an item claimed the natural qn first and the method or module
+item that owns the name was pushed onto a `@<line>` variant no caller
+resolves to (issue #1037).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.test_rust_crate_path_trait_linking import (
+    _calls,
+    _write,
+    create_and_run_updater,
+)
+
+_IMPL = (
+    "pub struct S;\n"
+    "\n"
+    "impl S {\n"
+    "    pub fn helper(&self) -> u32 {\n"
+    "        1\n"
+    "    }\n"
+    "    pub fn run(&self) -> u32 {\n"
+    "        fn helper() -> u32 {\n"
+    "            2\n"
+    "        }\n"
+    "        helper()\n"
+    "    }\n"
+    "}\n"
+)
+
+
+def _qns(mock_ingestor: MagicMock, label: str) -> set[str]:
+    return {
+        str(c.args[1]["qualified_name"])
+        for c in mock_ingestor.ensure_node_batch.call_args_list
+        if c.args[0] == label
+    }
+
+
+def test_nested_fn_leaves_the_method_its_own_qualified_name(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    project = temp_repo / "rs_nested_fn"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\n',
+            "src/lib.rs": "pub mod foo;\n",
+            "src/foo.rs": _IMPL,
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    methods = _qns(mock_ingestor, "Method")
+    functions = _qns(mock_ingestor, "Function")
+    assert "rs_nested_fn.src.foo.S.helper" in methods, methods
+    assert "rs_nested_fn.src.foo.S.helper@4" not in methods, methods
+    # The body-local fn is left with the variant, and it is a Function node,
+    # so the CALLS edge from `run` has an endpoint that exists.
+    assert "rs_nested_fn.src.foo.S.helper@8" in functions, functions
+    assert "rs_nested_fn.src.foo.S.helper" not in functions, functions
+
+
+def test_method_call_from_another_module_binds_the_method(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    project = temp_repo / "rs_nested_fn_outside"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\n',
+            "src/lib.rs": "pub mod foo;\npub mod bar;\n",
+            "src/foo.rs": _IMPL,
+            "src/bar.rs": (
+                "use crate::foo::S;\n"
+                "pub fn outside(s: &S) -> u32 {\n"
+                "    s.helper()\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    caller = "rs_nested_fn_outside.src.bar.outside"
+    method = "rs_nested_fn_outside.src.foo.S.helper"
+    # The edge alone proves nothing while the body-local fn could hold that
+    # same qn, so the label the qn belongs to is part of the assertion.
+    assert method in _qns(mock_ingestor, "Method"), _qns(mock_ingestor, "Method")
+    assert (caller, method) in calls, calls
+    assert (caller, f"{method}@8") not in calls, calls
+
+
+def test_the_body_local_fn_still_binds_its_own_call(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # Standing the body-local item down from the natural qn must not cost it
+    # the call written inside its own body, which is the one call in the file
+    # that really does mean it rather than the method.
+    project = temp_repo / "rs_nested_fn_inner"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\n',
+            "src/lib.rs": "pub mod foo;\n",
+            "src/foo.rs": _IMPL,
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    run = "rs_nested_fn_inner.src.foo.S.run"
+    assert (run, "rs_nested_fn_inner.src.foo.S.helper@8") in calls, calls
+    assert (run, "rs_nested_fn_inner.src.foo.S.helper") not in calls, calls
+
+
+def test_free_function_body_item_does_not_take_a_public_fn_name(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The same theft one scope out, where both items really do share a qn:
+    # a fn nested in a free function is written first, so source order alone
+    # handed it the module-level name and every importer of the public
+    # `helper` resolved to an item private to `run`'s body.
+    project = temp_repo / "rs_body_local_free"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\n',
+            "src/lib.rs": "pub mod foo;\npub mod bar;\n",
+            "src/foo.rs": (
+                "pub fn run() -> u32 {\n"
+                "    fn helper() -> u32 {\n"
+                "        2\n"
+                "    }\n"
+                "    helper()\n"
+                "}\n"
+                "\n"
+                "pub fn helper() -> u32 {\n"
+                "    9\n"
+                "}\n"
+            ),
+            "src/bar.rs": (
+                "use crate::foo::helper;\npub fn outside() -> u32 {\n    helper()\n}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    base = "rs_body_local_free.src"
+    assert (f"{base}.bar.outside", f"{base}.foo.helper") in calls, calls
+    assert (f"{base}.bar.outside", f"{base}.foo.helper@2") not in calls, calls
+    assert (f"{base}.foo.run", f"{base}.foo.helper@2") in calls, calls
+    assert (f"{base}.foo.run", f"{base}.foo.helper") not in calls, calls
+
+
+def test_const_initializer_item_does_not_take_a_method_name(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # An associated-const initializer is no function body, but an item inside
+    # one is just as unreachable, and it competes for the same impl-qualified
+    # name as the method beside it.
+    project = temp_repo / "rs_const_body_local"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\n',
+            "src/lib.rs": "pub mod foo;\npub mod bar;\n",
+            "src/foo.rs": (
+                "pub struct S;\n"
+                "\n"
+                "impl S {\n"
+                "    pub const C: u32 = {\n"
+                "        const fn helper() -> u32 {\n"
+                "            2\n"
+                "        }\n"
+                "        helper()\n"
+                "    };\n"
+                "    pub fn helper(&self) -> u32 {\n"
+                "        1\n"
+                "    }\n"
+                "}\n"
+            ),
+            "src/bar.rs": (
+                "use crate::foo::S;\n"
+                "pub fn outside(s: &S) -> u32 {\n"
+                "    s.helper()\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    base = "rs_const_body_local.src"
+    methods = _qns(mock_ingestor, "Method")
+    functions = _qns(mock_ingestor, "Function")
+    # `S.helper` alone is no assertion: the initializer's item registered under
+    # it too, as a Method. The demotion of the real method to a variant is what
+    # tells the two apart.
+    assert f"{base}.foo.S.helper" in methods, methods
+    assert f"{base}.foo.S.helper@10" not in methods, methods
+    assert f"{base}.foo.S.helper@5" in functions, functions
+    assert (f"{base}.bar.outside", f"{base}.foo.S.helper") in calls, calls
+    assert (f"{base}.bar.outside", f"{base}.foo.S.helper@5") not in calls, calls

--- a/codebase_rag/tests/test_rust_nested_fn_in_impl_method.py
+++ b/codebase_rag/tests/test_rust_nested_fn_in_impl_method.py
@@ -157,6 +157,70 @@ def test_free_function_body_item_does_not_take_a_public_fn_name(
     assert (f"{base}.foo.run", f"{base}.foo.helper") not in calls, calls
 
 
+def test_body_local_fn_return_type_leaves_the_module_item_its_own(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # Holding the registration back must not cost the fn its return type, and
+    # the qn to record it under is the one the registry handed out, not the one
+    # resolution proposed: a body-local fn contesting a module item lands on
+    # the variant, and recording under the proposal overwrites the module
+    # item's own return type, mistyping every caller of it.
+    #
+    # The other direction, a chained call inside the body typing from the
+    # body-local fn, needs the call site the name-keyed lookup does not take;
+    # filed as #1069.
+    project = temp_repo / "rs_body_local_return"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\n',
+            "src/lib.rs": "pub mod foo;\n",
+            "src/foo.rs": (
+                "pub struct T;\n"
+                "pub struct U;\n"
+                "\n"
+                "impl T {\n"
+                "    pub fn run(&self) -> u32 {\n"
+                "        1\n"
+                "    }\n"
+                "}\n"
+                "\n"
+                "impl U {\n"
+                "    pub fn run(&self) -> u32 {\n"
+                "        2\n"
+                "    }\n"
+                "}\n"
+                "\n"
+                "pub fn make() -> U {\n"
+                "    U\n"
+                "}\n"
+                "\n"
+                "pub fn outer() -> u32 {\n"
+                "    fn make() -> T {\n"
+                "        T\n"
+                "    }\n"
+                "    let t = make();\n"
+                "    t.run()\n"
+                "}\n"
+                "\n"
+                "pub fn sibling() -> u32 {\n"
+                "    let u = make();\n"
+                "    u.run()\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    base = "rs_body_local_return.src"
+    assert (f"{base}.foo.sibling", f"{base}.foo.U.run") in calls, calls
+    assert (f"{base}.foo.sibling", f"{base}.foo.T.run") not in calls, calls
+    # The call to the body-local fn itself still binds it, so the return type
+    # is recorded against a callee the graph really reaches.
+    assert (f"{base}.foo.outer", f"{base}.foo.make@21") in calls, calls
+    assert (f"{base}.foo.outer", f"{base}.foo.make") not in calls, calls
+
+
 def test_const_initializer_item_does_not_take_a_method_name(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.545"
+version = "0.0.547"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #1037.

A Rust item written inside a function body is in scope for that body alone, yet it registers in the qn space of the module or impl target enclosing it. The generic function pass runs before the method pass, so the body-local item claimed the natural qn first and the item that owns the name was pushed onto a `@<line>` variant.

```rust
pub struct S;

impl S {
    pub fn helper(&self) -> u32 {
        1
    }
    pub fn run(&self) -> u32 {
        fn helper() -> u32 {
            2
        }
        helper()
    }
}
```

`foo.S.helper` was the item inside `run`, the method was `foo.S.helper@4`, and `s.helper()` written in another module bound the one buried in `run`'s body. The CALLS edge also carried the FUNCTION label into a qn space of METHOD nodes, which is what the issue reports: on a real database the edge is dropped.

## Change

A body-local definition is held back from the generic pass and registered once the methods of the file have claimed their names, the way an unnamed JS/TS function expression already waits for the named passes. It then takes the `@<line>` variant, which is what it should have had: the natural qn belongs to the item a path can name.

Two things had to agree with that. An item inside a const or static initializer was being ingested as a method of the impl above, because the walks that stop at a bodied function cross an initializer without noticing; it is a free function local to the initializer. And the body-local test itself stops at a type, so an `impl` written inside a method body still owns the methods inside it.

## The same theft outside an impl

The pre-push review found the shape this generalises to, and it is on main today without an impl anywhere:

```rust
pub fn run() -> u32 {
    fn helper() -> u32 { 2 }
    helper()
}

pub fn helper() -> u32 { 9 }
```

Both are `foo.helper` and the body-local one is written first, so source order alone handed it the name. Every importer of the public `helper` resolved to an item private to `run`'s body, and the public function was left with no incoming edge at all, which reads as dead code. It is covered here.

## Tests

Red first, all five, each verified against the fix disabled in place: the method keeps its own qn and the body-local fn takes the variant; a method call from another module binds the method; the body-local fn keeps the one call that really does mean it; the free-function shape above; and the const-initializer shape.

Four existing assertions in the block-item tests named the block item by the natural qn and the module item by the variant. Every binding in them is unchanged and the two now read the other way round, which is the point.

## Two rejected approaches, recorded because they look right

Dropping the impl segment from a body-local item's qn moves it into the module namespace, where it takes the module-level item's name instead. The theft relocates rather than ends.

Making the enclosing function a qn segment (`foo.S.run.helper`) is self-consistent and fixes every case, but flat registration of nested items is what the block-item machinery from #1026 and #1061 is built on, and the import-map key mirrors the registered path. It broke 31 tests and would be a change to the Rust qn model, not a fix to this bug.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Rust code analysis for functions and methods defined inside function bodies, methods, and constant initializers.
  * Prevented nested Rust functions from being incorrectly associated with enclosing public functions or methods.
  * Improved name resolution so calls correctly target items visible at their location.

* **Tests**
  * Added coverage for nested Rust functions, shadowing, scope boundaries, and constant initializers.
  * Updated expectations for qualified names of local items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->