### PR TITLE
fix: type a Rust local from the block item its call site names

### DIFF
--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -13,6 +13,7 @@ from ..language_spec import get_language_for_extension
 from ..types_defs import FunctionRegistryTrieProtocol, NodeType
 from .import_processor import ImportProcessor
 from .py import resolve_class_name
+from .rs import utils as rs_utils
 from .type_inference import TypeInferenceEngine
 from .utils import follow_reexports
 
@@ -1442,20 +1443,12 @@ class CallResolver:
         FILE, not by caller: a fn declared inside the block is inside the
         block, so its own body binds the block's items too.
         """
-        if call_point is None:
-            return None
-        best: tuple[int, str] | None = None
-        for start, end, items in self.import_processor.rust_block_items.get(
-            module_qn, ()
-        ):
-            item_qn = items.get(name)
-            if item_qn is None or not (start <= call_point < end):
-                continue
-            if (best is None or end - start < best[0]) and (
-                item_qn in self.function_registry
-            ):
-                best = (end - start, item_qn)
-        return best[1] if best else None
+        return rs_utils.block_item_at(
+            self.import_processor.rust_block_items.get(module_qn, ()),
+            self.function_registry,
+            name,
+            call_point,
+        )
 
     def _try_resolve_rust_module_qualified(
         self, call_name: str, module_qn: str, caller_qn: str | None

--- a/codebase_rag/parsers/rs/type_inference.py
+++ b/codebase_rag/parsers/rs/type_inference.py
@@ -454,13 +454,13 @@ class RustTypeInferenceEngine:
 
     def collect_call_var_bindings(
         self, caller_node: Node
-    ) -> list[tuple[str, list[str]]]:
+    ) -> list[tuple[str, list[str], int]]:
         # `let x = Type::assoc(...)` / `let x = Type::assoc(...).unwrap()`: pair the
         # bound name with the callee chain segments (base type first, then method
         # hops: `['Command', 'from_frame']`). The unified engine walks the segments
         # through the return-type map to type `x`. Only type-rooted associated-call
         # chains are collected.
-        bindings: list[tuple[str, list[str]]] = []
+        bindings: list[tuple[str, list[str], int]] = []
         if body := caller_node.child_by_field_name(cs.FIELD_BODY):
             self._collect_call_bindings(body, bindings)
         return bindings
@@ -639,7 +639,7 @@ class RustTypeInferenceEngine:
         return bindings
 
     def _collect_call_bindings(
-        self, node: Node, bindings: list[tuple[str, list[str]]]
+        self, node: Node, bindings: list[tuple[str, list[str], int]]
     ) -> None:
         if node.type == cs.TS_RS_LET_DECLARATION:
             self._collect_call_binding(node, bindings)
@@ -647,7 +647,7 @@ class RustTypeInferenceEngine:
             self._collect_call_bindings(child, bindings)
 
     def _collect_call_binding(
-        self, node: Node, bindings: list[tuple[str, list[str]]]
+        self, node: Node, bindings: list[tuple[str, list[str], int]]
     ) -> None:
         pattern = node.child_by_field_name(cs.TS_FIELD_PATTERN)
         value = node.child_by_field_name(cs.FIELD_VALUE)
@@ -663,7 +663,11 @@ class RustTypeInferenceEngine:
             # its return type. Only an invoked base counts.
             if len(segments) == 1 and value_expr.type not in cs.RS_CALL_OR_GENERIC_FN:
                 return
-            bindings.append((name, segments))
+            # The offset of the CALL, not of the `let`: it is the call whose
+            # name a block item shadows, and the two differ when the call sits
+            # in a block nested inside the initializer. Every other block-scope
+            # probe is handed the call node's own start (issue #1069).
+            bindings.append((name, segments, value_expr.start_byte))
 
     def _callee_chain_segments(self, node: Node) -> list[str] | None:
         # Flatten a Rust value expression into ordered chain segments, base first:

--- a/codebase_rag/parsers/rs/utils.py
+++ b/codebase_rag/parsers/rs/utils.py
@@ -6,6 +6,7 @@ from collections.abc import Iterable, Sequence
 from tree_sitter import Node
 
 from ... import constants as cs
+from ...types_defs import FunctionRegistryTrieProtocol
 from ..utils import safe_decode_text
 
 # `#[path = "support/helpers.rs"]` redirects the mod declaration it sits on
@@ -414,6 +415,31 @@ def rust_use_scope(node: Node) -> tuple[Node | None, list[str] | None, bool]:
         current = current.parent
     parts.reverse()
     return None, parts, pure
+
+
+def block_item_at(
+    block_items: Iterable[tuple[int, int, dict[str, str]]],
+    registry: FunctionRegistryTrieProtocol,
+    name: str,
+    call_point: int | None,
+) -> str | None:
+    """The item `name` binds to in the innermost block holding this site.
+
+    Innermost wins: nested blocks may each declare the name, and only the
+    tightest one is in scope where the site is written. Keyed by FILE, not by
+    caller: a fn declared inside the block is inside the block, so its own
+    body binds the block's items too.
+    """
+    if call_point is None:
+        return None
+    best: tuple[int, str] | None = None
+    for start, end, items in block_items:
+        item_qn = items.get(name)
+        if item_qn is None or not (start <= call_point < end):
+            continue
+        if (best is None or end - start < best[0]) and item_qn in registry:
+            best = (end - start, item_qn)
+    return best[1] if best else None
 
 
 def is_body_local(node: Node) -> bool:

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -23,6 +23,7 @@ from .js_ts import JsTypeInferenceEngine
 from .lua import LuaTypeInferenceEngine
 from .py import PythonTypeInferenceEngine, resolve_class_name
 from .rs import RustTypeInferenceEngine
+from .rs import utils as rs_utils
 
 if TYPE_CHECKING:
     from .factory import ASTCacheProtocol
@@ -558,13 +559,15 @@ class TypeInferenceEngine:
         # later `cmd.apply()` resolves to the real type, not the ambiguous name-only
         # trie fallback. Only fills names not already typed.
         bounds: dict[str, list[str]] | None = None
-        for name, segments in self.rust_type_inference.collect_call_var_bindings(
-            caller_node
-        ):
+        for (
+            name,
+            segments,
+            call_point,
+        ) in self.rust_type_inference.collect_call_var_bindings(caller_node):
             if name in var_types:
                 continue
             if return_type := self._infer_rust_call_return_type(
-                segments, module_qn, var_types
+                segments, module_qn, var_types, call_point
             ):
                 var_types[name] = return_type
                 if len(segments) == 2 and segments[0] == cs.KEYWORD_SELF:
@@ -580,7 +583,11 @@ class TypeInferenceEngine:
                     self._apply_rust_generic_bound(bounds, module_qn, var_types, name)
 
     def _infer_rust_call_return_type(
-        self, segments: list[str], module_qn: str, var_types: dict[str, str]
+        self,
+        segments: list[str],
+        module_qn: str,
+        var_types: dict[str, str],
+        call_point: int | None,
     ) -> str | None:
         # Walk a flattened chain to the type it yields:
         #   ['Command','from_frame']  -> base type Command, method from_frame
@@ -591,7 +598,9 @@ class TypeInferenceEngine:
         # field) -> field-type -> method-return -> identity.
         if not segments:
             return None
-        current_type = self._rust_chain_base_type(segments, module_qn, var_types)
+        current_type = self._rust_chain_base_type(
+            segments, module_qn, var_types, call_point
+        )
         if current_type is None:
             return None
         # Inner type of the guard-wrapped field just hopped through, pending a guard
@@ -623,14 +632,18 @@ class TypeInferenceEngine:
         return current_type
 
     def _rust_chain_base_type(
-        self, segments: list[str], module_qn: str, var_types: dict[str, str]
+        self,
+        segments: list[str],
+        module_qn: str,
+        var_types: dict[str, str],
+        call_point: int | None,
     ) -> str | None:
         # Base of a flattened chain: a typed local (self/var) when present in
         # var_types, else a free fn called by bare name (`let s = make()`), else the
         # segment itself as a type name, useful only when there are hops to walk, so
         # a bare unresolved name types nothing.
         base = var_types.get(segments[0]) or self._rust_free_fn_return_type(
-            segments[0], module_qn
+            segments[0], module_qn, call_point
         )
         if base is not None:
             return base
@@ -666,12 +679,35 @@ class TypeInferenceEngine:
             )
         return self._resolve_class_name(type_name, module_qn) or type_name
 
-    def _rust_free_fn_return_type(self, name: str, module_qn: str) -> str | None:
+    def _rust_free_fn_return_type(
+        self, name: str, module_qn: str, call_point: int | None
+    ) -> str | None:
         # Return type of a free fn called by bare name: same-module first, then a
         # `use`-imported fn resolved through its raw `::` path. A type-name base
         # (`Maker::make`) misses here because a bare type is never a recorded key
         # (fns and types share a name only across Rust's separate fn/type namespaces,
         # which idiomatic code never does).
+        # A body-local fn shadows the module's own for the block it is written
+        # in, and it registers under a `@<line>` variant when the module item
+        # owns the natural qn, so the site decides which of the two is meant
+        # (issue #1069).
+        if shadowing := rs_utils.block_item_at(
+            self.import_processor.rust_block_items.get(module_qn, ()),
+            self.function_registry,
+            name,
+            call_point,
+        ):
+            # The site names the block item, so the module item of that name is
+            # not what is meant, whatever comes of the block item's own return.
+            # A unit or tuple return records nothing, and a generic return
+            # records a type parameter that resolves to no class here; either
+            # way the answer is no type rather than the module item's, since
+            # the known-external guard would delete the edge the trie fallback
+            # still finds and an unresolvable binding is worse than none.
+            shadow_type = self.method_return_types.get(shadowing)
+            if shadow_type and self._rust_binding_type_resolves(shadow_type, module_qn):
+                return shadow_type
+            return None
         if return_type := self.method_return_types.get(
             f"{module_qn}{cs.SEPARATOR_DOT}{name}"
         ):

--- a/codebase_rag/tests/test_rust_free_function_return_types.py
+++ b/codebase_rag/tests/test_rust_free_function_return_types.py
@@ -186,8 +186,10 @@ def test_generic_returning_shadow_does_not_fall_through_to_the_module_item(
     # item's own return.
     source = (
         "pub struct Aaa;\n"
+        "pub struct Zed;\n"
         "impl Aaa { pub fn run(&self) -> u32 { 1 } }\n"
-        "pub fn make() -> Aaa { Aaa }\n"
+        "impl Zed { pub fn run(&self) -> u32 { 2 } }\n"
+        "pub fn make() -> Zed { Zed }\n"
         "pub fn outer() -> u32 {\n"
         "    fn make<X: Default>() -> X { X::default() }\n"
         "    let t = make::<Aaa>();\n"
@@ -196,4 +198,9 @@ def test_generic_returning_shadow_does_not_fall_through_to_the_module_item(
     )
     calls = _run_calls(temp_repo, mock_ingestor, {"m.rs": source})
     base = f"{temp_repo.name}.m"
+    # Naming Zed after Aaa separates the two ways this can go wrong: falling
+    # through to the module item types the local Zed, while recording the
+    # unresolvable parameter deletes the edge outright. Neither is the
+    # untyped local the trie then answers for.
     assert (f"{base}.outer", f"{base}.Aaa.run") in calls, calls
+    assert (f"{base}.outer", f"{base}.Zed.run") not in calls, calls

--- a/codebase_rag/tests/test_rust_free_function_return_types.py
+++ b/codebase_rag/tests/test_rust_free_function_return_types.py
@@ -103,6 +103,97 @@ def test_bare_identifier_binding_is_not_a_call() -> None:
     parser = Parser(Language(tsrust.language()))
     src = b"fn user() { let f = make; let s = make(); }\n"
     fn_node = parser.parse(src).root_node.children[0]
-    bindings = dict(rs_ti.RustTypeInferenceEngine().collect_call_var_bindings(fn_node))
+    collected = rs_ti.RustTypeInferenceEngine().collect_call_var_bindings(fn_node)
+    bindings = {name: segments for name, segments, _point in collected}
     assert "f" not in bindings, bindings
     assert bindings.get("s") == ["make"]
+    # The CALL's own offset rides along, so a shadowing block item can be told
+    # from the module item of that name (issue #1069). The `let` starts earlier
+    # and the two differ once the call sits in a nested block.
+    assert [point for _name, _segments, point in collected] == [src.index(b"make()")], (
+        collected
+    )
+
+
+# The block item returns Zzz and the module item Aaa, so the name-only trie
+# fallback an untyped local falls to would answer Aaa: only reading the block
+# item's OWN return type gets Zzz, and the assertion can tell the two apart.
+BODY_LOCAL_FACTORY = (
+    "pub struct Aaa;\n"
+    "pub struct Zzz;\n"
+    "impl Aaa { pub fn run(&self) -> u32 { 1 } }\n"
+    "impl Zzz { pub fn run(&self) -> u32 { 2 } }\n"
+    "pub fn make() -> Aaa { Aaa }\n"
+    "pub fn outer() -> u32 {\n"
+    "    fn make() -> Zzz { Zzz }\n"
+    "    let t = make();\n"
+    "    t.run()\n"
+    "}\n"
+    "pub fn sibling() -> u32 {\n"
+    "    let u = make();\n"
+    "    u.run()\n"
+    "}\n"
+)
+
+
+def test_body_local_factory_types_from_its_own_return(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # A body-local `fn make` shadows the module's own for the whole of the
+    # body it is written in, and it registers under a `@<line>` variant
+    # because the module item owns the natural qn. The return-type lookup
+    # keyed by name alone could only ever read the module item, so the local
+    # bound from the shadowing fn typed as the module fn's return (#1069).
+    calls = _run_calls(temp_repo, mock_ingestor, {"m.rs": BODY_LOCAL_FACTORY})
+    base = f"{temp_repo.name}.m"
+    assert (f"{base}.outer", f"{base}.Zzz.run") in calls, calls
+    assert (f"{base}.outer", f"{base}.Aaa.run") not in calls, calls
+    # The module item's own callers are unaffected by the shadowing.
+    assert (f"{base}.sibling", f"{base}.Aaa.run") in calls, calls
+    assert (f"{base}.sibling", f"{base}.Zzz.run") not in calls, calls
+
+
+def test_unit_returning_shadow_does_not_fall_through_to_the_module_item(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # A shadow with no recorded return type records nothing at all: a unit
+    # return has no type name. The site still names the block item, so the
+    # module item's return is not the answer either, and typing the local
+    # from it fabricates a call on a value that was never of that type.
+    source = (
+        "pub struct Aaa;\n"
+        "pub struct Zed;\n"
+        "impl Aaa { pub fn run(&self) -> u32 { 1 } }\n"
+        "impl Zed { pub fn run(&self) -> u32 { 2 } }\n"
+        "pub fn make() -> Zed { Zed }\n"
+        "pub fn outer() {\n"
+        "    fn make() { }\n"
+        "    let u = make();\n"
+        "    u.run();\n"
+        "}\n"
+    )
+    calls = _run_calls(temp_repo, mock_ingestor, {"m.rs": source})
+    base = f"{temp_repo.name}.m"
+    assert (f"{base}.outer", f"{base}.Zed.run") not in calls, calls
+
+
+def test_generic_returning_shadow_does_not_fall_through_to_the_module_item(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # A generic return records the type PARAMETER, which resolves to no class
+    # here. Recording it would let the known-external guard delete the edge the
+    # trie fallback still finds, so it types nothing rather than the module
+    # item's own return.
+    source = (
+        "pub struct Aaa;\n"
+        "impl Aaa { pub fn run(&self) -> u32 { 1 } }\n"
+        "pub fn make() -> Aaa { Aaa }\n"
+        "pub fn outer() -> u32 {\n"
+        "    fn make<X: Default>() -> X { X::default() }\n"
+        "    let t = make::<Aaa>();\n"
+        "    t.run()\n"
+        "}\n"
+    )
+    calls = _run_calls(temp_repo, mock_ingestor, {"m.rs": source})
+    base = f"{temp_repo.name}.m"
+    assert (f"{base}.outer", f"{base}.Aaa.run") in calls, calls


### PR DESCRIPTION
Closes #1069. Follows #1068, now merged.

A Rust fn declared in a function body shadows a module fn of the same name, and it registers under a `@<line>` variant because the module item owns the natural qn. The return-type lookup took a name and a module qn and no call site, so it could only ever read the module item.

```rust
pub fn make() -> Aaa { Aaa }

pub fn outer() -> u32 {
    fn make() -> Zzz { Zzz }
    let t = make();
    t.run()
}
```

`make()` itself resolved correctly to the block item, since the span probe from #1061 answers that. Only the type of `t` came from the module item, so `t.run()` bound `Aaa::run`.

## Change

The offset of the call the local is bound from now rides along with the binding, down to the lookup, which prefers a block item whose span encloses it. Rather than write a second copy of that span probe, the one in the call resolver moved to `rs_utils.block_item_at` and both read it: a second copy that could drift is what caused #1037.

A located block item settles the question outright. If it records no return type, or one that resolves to no class here, the answer is no type rather than the module item's, since a binding that resolves to nothing lets the known-external guard delete an edge the trie fallback would still find. That rule is the existing one for closure-parameter bindings.

## Tests

Four, each verified to fail against the specific part of the fix it covers. The shadowed local types from its own fn and not the module's; the module item's own callers are untouched; a unit-returning shadow does not fall through to the module item; and a generic-returning shadow types nothing rather than an unresolvable name.

The fixture types are named so that the wrong answer is distinguishable from the right one. An earlier draft used `T` and `U`, where the name-only trie fallback an untyped local falls to happens to land on the correct method anyway, so the test passed against an implementation that never read the block item's return type at all. The pre-push review caught that.

## Two defects found on the way, filed rather than folded in

**#1070.** I referenced `rs_utils` in `call_resolver.py` without importing it. The module still imported cleanly, because that `NameError` is raised at call time. Every Rust call resolution then raised, `process_calls_in_file` caught it, and the graph came out with `DEFINES`, `IMPLEMENTS` and `OVERRIDES` edges and not one `CALLS` edge, while the run reported success. The catch is right to exist, but a caught exception there should fail the suite the way a dangling relationship already does.

**#1071.** `register_unique_qn` builds a dedup variant from the start line alone, so two same-named functions on one line become one node and one of them leaves the graph. `function_span_key` already carries the column for exactly this reason. Pre-existing and reachable from any language whose variants can share a line.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Rust type inference for functions defined within local blocks.
  * Correctly resolves shadowed functions based on their position in the source.
  * Prevents incorrect fallback to module-level return types when local functions cannot be resolved.
  * Improved handling of unit and generic function returns.

* **Tests**
  * Added regression coverage for scoped function shadowing, call positions, and invoked bindings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->