### PR TITLE
test: fail a run that swallowed a per-file pass failure

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1921,7 +1921,7 @@ class GraphUpdater:
         try:
             file_bytes = file_path.read_bytes()
         except OSError as e:
-            logger.error(ls.CALL_PROCESSING_FAILED, path=file_path, error=e)
+            logger.error(ls.AST_RELOAD_FAILED, path=file_path, error=e)
             return None
         root_node = parse_with_preproc_recovery(parser, file_bytes, language).root_node
         self.factory._func_class_captures_cache.pop(file_path, None)

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -457,6 +457,10 @@ FILE_OUTSIDE_ROOT = "Security risk: Attempted to {action} file outside of projec
 # Call processor logs
 CALL_PROCESSING_FILE = "Processing calls in cached AST for: {path}"
 CALL_PROCESSING_FAILED = "Failed to process calls in {path}: {error}"
+# Re-reading a file evicted from the bounded AST cache is tolerate-and-continue,
+# not a pass failure, and must not borrow the message above: the test harness
+# fails a run on that one (issue #1070).
+AST_RELOAD_FAILED = "Could not re-read {path} for call attribution: {error}"
 CALL_FOUND_NODES = "Found {count} call nodes in {language} for {caller}"
 CALL_SKIP_CLASS = "Skipping CALLS edge from {caller} to {call_name} (callee is Class node: {callee_qn})"
 CALL_FOUND = (

--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -96,6 +96,56 @@ def create_mock_node(
 
 logger.remove()
 
+# Every per-file pass swallows all exceptions so one bad file cannot abandon a
+# whole index, and only logs. Nothing looked at those logs, so a bug inside a
+# pass dropped the file's edges while the run reported success, and the suite
+# saw it at best as unrelated assertion failures elsewhere (issue #1070). One
+# entry per pass, and the import pass logs at WARNING rather than ERROR.
+_PASS_FAILURE_PREFIXES = (
+    "Failed to process calls in ",
+    "Failed to parse or ingest ",
+    "Failed to parse imports in ",
+    "Error parsing ",
+)
+
+
+@pytest.fixture(autouse=True)
+def _fail_on_swallowed_pass_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Generator[list[str], None, None]:
+    """Fail any test whose indexing run swallowed a pass failure (issue #1070).
+
+    Armed around `GraphUpdater.run` rather than around the whole test, and
+    autouse rather than folded into the updater helpers. Most test files build
+    an updater and call `run()` themselves, so a gate the next test bypasses by
+    not calling a helper is no gate; and scoping it to the run keeps it off the
+    unit tests that call a parser directly to exercise its own error path.
+
+    A test that means to index a broken file requests this fixture, asserts on
+    the list and clears it.
+    """
+    failures: list[str] = []
+    original_run = GraphUpdater.run
+
+    def run_watching_for_pass_failures(self: GraphUpdater, force: bool = False) -> None:
+        sink_id = logger.add(
+            lambda message: failures.append(message.record["message"]),
+            level="WARNING",
+            filter=lambda record: record["message"].startswith(_PASS_FAILURE_PREFIXES),
+        )
+        try:
+            original_run(self, force)
+        finally:
+            logger.remove(sink_id)
+
+    monkeypatch.setattr(GraphUpdater, "run", run_watching_for_pass_failures)
+    yield failures
+    assert_no_pass_failures(failures)
+
+
+def assert_no_pass_failures(failures: list[str]) -> None:
+    assert not failures, "a per-file pass failed:\n" + "\n".join(failures)
+
 
 @pytest.fixture(autouse=True)
 def _disable_stack_autostart() -> Generator[None, None, None]:

--- a/codebase_rag/tests/test_pass_failures_fail_the_suite.py
+++ b/codebase_rag/tests/test_pass_failures_fail_the_suite.py
@@ -1,0 +1,95 @@
+"""The harness fails a run that swallowed a per-file pass failure (#1070).
+
+One case per pass, since each swallows into its own message at its own level,
+and a prefix the gate does not watch is a pass it does not cover.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag.parsers import dependency_parser
+from codebase_rag.parsers.call_processor import CallProcessor
+from codebase_rag.parsers.definition_processor import DefinitionProcessor
+from codebase_rag.parsers.import_processor import ImportProcessor
+from codebase_rag.tests.conftest import assert_no_pass_failures, create_and_run_updater
+
+_SOURCE = (
+    "import os\n\n\ndef alpha():\n    return beta()\n\n\ndef beta():\n    return 1\n"
+)
+
+
+def _boom(*_args: object, **_kwargs: object) -> None:
+    raise RuntimeError("pass exploded")
+
+
+def _run_with_broken_pass(
+    temp_repo: Path,
+    mock_ingestor: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+    target: object,
+    attribute: str,
+) -> None:
+    (temp_repo / "pyproject.toml").write_text(
+        '[project]\nname = "p"\nversion = "0"\ndependencies = ["requests"]\n',
+        encoding="utf-8",
+    )
+    (temp_repo / "m.py").write_text(_SOURCE, encoding="utf-8")
+    monkeypatch.setattr(target, attribute, _boom)
+    create_and_run_updater(temp_repo, mock_ingestor)
+
+
+@pytest.mark.parametrize(
+    ("target", "attribute", "expected"),
+    [
+        (CallProcessor, "_ingest_function_calls", "Failed to process calls in "),
+        (DefinitionProcessor, "_ingest_all_functions", "Failed to parse or ingest "),
+        (ImportProcessor, "_parse_python_imports", "Failed to parse imports in "),
+        (dependency_parser.toml, "load", "Error parsing "),
+    ],
+    ids=["calls", "definitions", "imports", "dependencies"],
+)
+def test_a_raising_pass_is_caught_and_would_fail_the_run(
+    temp_repo: Path,
+    mock_ingestor: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+    _fail_on_swallowed_pass_errors: list[str],
+    target: type,
+    attribute: str,
+    expected: str,
+) -> None:
+    # Each pass swallows into its OWN message, at its own level, so one entry
+    # per pass is what the gate needs and each is pinned separately here. The
+    # patched target sits INSIDE the pass's own try, since replacing the method
+    # that holds the handler would let the caller's handler catch it instead.
+    _run_with_broken_pass(temp_repo, mock_ingestor, monkeypatch, target, attribute)
+    failures = _fail_on_swallowed_pass_errors
+    assert any(f.startswith(expected) for f in failures), failures
+    # What the autouse gate does with them at teardown, asserted here because a
+    # teardown failure is not observable from inside the test.
+    with pytest.raises(AssertionError, match="a per-file pass failed"):
+        assert_no_pass_failures(failures)
+    # Owned by this test: the run really did fail, so clear it before teardown.
+    failures.clear()
+
+
+def test_a_clean_run_leaves_the_gate_quiet(
+    temp_repo: Path,
+    mock_ingestor: MagicMock,
+    _fail_on_swallowed_pass_errors: list[str],
+) -> None:
+    # The gate has to stay silent on a working index, or it is unusable: this
+    # is the same fixture, unbroken, producing the call edge it should.
+    (temp_repo / "m.py").write_text(_SOURCE, encoding="utf-8")
+    create_and_run_updater(temp_repo, mock_ingestor)
+    assert not _fail_on_swallowed_pass_errors, _fail_on_swallowed_pass_errors
+    calls = {
+        (c.args[0][2], c.args[2][2])
+        for c in mock_ingestor.ensure_relationship_batch.call_args_list
+        if c.args[1] == "CALLS"
+    }
+    base = temp_repo.name
+    assert (f"{base}.m.alpha", f"{base}.m.beta") in calls, calls

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.547"
+version = "0.0.548"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #1070.

Every per-file pass catches all exceptions so one bad file cannot abandon a whole repository index, and logs. Nothing looked at those logs, so a bug inside a pass dropped every edge for the file and the run reported success.

I found this by writing one: a `NameError` from a missing import in the Rust call path (while working on #1069) left a graph with `DEFINES`, `IMPLEMENTS` and `OVERRIDES` edges and not one `CALLS` edge. It reached me as six unrelated assertion failures about wrong types, with nothing naming the exception.

## Change

An autouse fixture arms a log sink around `GraphUpdater.run` and fails the test if a pass logged a failure during it.

Autouse rather than folded into the updater helpers, because 96 test files build an updater and call `run()` themselves; a gate the next test bypasses by not calling a helper is not a gate. Scoped to the run rather than to the whole test, because the unit tests that call a parser directly to exercise its own error path are not indexing runs and must stay green. Patching at class level covers a second `run()` on a returned updater too.

One prefix per pass. Each swallows into its own message, and the import pass logs at WARNING rather than ERROR, so watching only the two ERROR messages would have left it uncovered.

The AST-reload path in `graph_updater.py` was borrowing `CALL_PROCESSING_FAILED` for a plain `OSError` when re-reading a file evicted from the bounded cache. That is tolerate-and-continue by design, not a pass failure, so it now has its own message. The old text also read as a pass bug in the logs, which it never was.

## Tests

Four passes, one case each, each verified to fail when its prefix is removed from the watch list. Plus a clean run, which must leave the gate quiet and still produce its call edge, or the gate is unusable.

Each patched target sits INSIDE the pass's own `try`. Patching the method that holds the handler lets the caller's handler catch it instead, and the test then passes against the wrong prefix; that is how the import case first went green.

## What this does not cover, deliberately

The realtime/watch path is a separate entry point and is not gated. A test there indexes a file it has already deleted and logs a failure that is correct behaviour, so a test-wide gate produced a false positive on it. Widening to that path means telling its expected failures from real ones first.

Production still swallows and continues, which is the right call for indexing a repository with one unparseable file. This makes the class of bug visible to the suite; it does not change what a real run does with a bad file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when reloading files for call attribution, making failures easier to identify.

* **Tests**
  * Added safeguards to ensure failures during code analysis are not silently ignored.
  * Added regression coverage for call, definition, import, and dependency-processing failures.
  * Added verification that clean analysis runs complete without triggering failure alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->