### PR TITLE
test: pin each Rust duplicate-qn method to its own outgoing calls

### DIFF
--- a/codebase_rag/tests/test_rust_crate_path_trait_linking.py
+++ b/codebase_rag/tests/test_rust_crate_path_trait_linking.py
@@ -1581,10 +1581,11 @@ def test_duplicate_method_qn_owns_its_body_use_and_its_calls(
                 "impl Beta for S {\n"
                 "    fn run(&self) -> u32 {\n"
                 "        use crate::alpha::other;\n"
-                "        other()\n"
+                "        other() + beta_only()\n"
                 "    }\n"
                 "}\n\n"
                 "pub fn other() -> u32 { 1 }\n"
+                "pub fn beta_only() -> u32 { 3 }\n"
             ),
         },
     )
@@ -1594,12 +1595,16 @@ def test_duplicate_method_qn_owns_its_body_use_and_its_calls(
     base = "rs_dup_method_use.src"
     assert (f"{base}.foo.S.run", f"{base}.foo.other") in calls, calls
     assert (f"{base}.foo.S.run", f"{base}.alpha.other") not in calls, calls
-    # And the caller side keys on the variant too (issue #1014): before this
-    # worked, BOTH methods' calls were attributed to the natural qn, so the
-    # variant had no outgoing edge and alpha::other lost its only reference
-    # and read as dead. Each direction is pinned, since an attribution that
-    # merged the two the other way round would satisfy either one alone.
+    # And the caller side keys on the variant too (issue #1014): both methods'
+    # calls used to be attributed to the natural qn, leaving the variant with
+    # no outgoing edge at all. `beta_only` is called with no `use` in sight, so
+    # it pins caller attribution itself rather than the scope-import lookup
+    # that `other` alone would resolve through.
     assert (f"{base}.foo.S.run@13", f"{base}.alpha.other") in calls, calls
+    assert (f"{base}.foo.S.run@13", f"{base}.foo.beta_only") in calls, calls
+    assert (f"{base}.foo.S.run", f"{base}.foo.beta_only") not in calls, calls
+    # Attribution moves calls, it does not copy them: a variant that collected
+    # BOTH methods' calls would satisfy every assertion above.
     assert (f"{base}.foo.S.run@13", f"{base}.foo.other") not in calls, calls
     scope_uses = updater.factory.import_processor.rust_fn_scope_imports.get(
         f"{base}.foo.S.run@13"

--- a/codebase_rag/tests/test_rust_crate_path_trait_linking.py
+++ b/codebase_rag/tests/test_rust_crate_path_trait_linking.py
@@ -1555,7 +1555,7 @@ def test_nested_fn_body_use_applies_to_nested_fn(
     assert (f"{base}.foo.inner", f"{base}.foo.helper") not in calls, calls
 
 
-def test_duplicate_method_qn_does_not_steal_body_use(
+def test_duplicate_method_qn_owns_its_body_use_and_its_calls(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:
     # Two traits implemented for the SAME type both name their method `run`,
@@ -1594,9 +1594,13 @@ def test_duplicate_method_qn_does_not_steal_body_use(
     base = "rs_dup_method_use.src"
     assert (f"{base}.foo.S.run", f"{base}.foo.other") in calls, calls
     assert (f"{base}.foo.S.run", f"{base}.alpha.other") not in calls, calls
-    # Beta::run's use is keyed on its dedup variant, ready for the caller
-    # side: the method call pass still attributes Beta::run's calls to the
-    # natural qn (issue #1014), so no @13 caller edge exists yet.
+    # And the caller side keys on the variant too (issue #1014): before this
+    # worked, BOTH methods' calls were attributed to the natural qn, so the
+    # variant had no outgoing edge and alpha::other lost its only reference
+    # and read as dead. Each direction is pinned, since an attribution that
+    # merged the two the other way round would satisfy either one alone.
+    assert (f"{base}.foo.S.run@13", f"{base}.alpha.other") in calls, calls
+    assert (f"{base}.foo.S.run@13", f"{base}.foo.other") not in calls, calls
     scope_uses = updater.factory.import_processor.rust_fn_scope_imports.get(
         f"{base}.foo.S.run@13"
     )

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.549"
+version = "0.0.550"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #1014.

The behaviour #1014 asked for already works: PR #1027 fixed it as a side effect of the Rust crate-path resolution work. Nothing asserted it, and the existing test carried a comment saying the caller edge did not exist yet, so a regression would have been silent.

## Evidence

Running the issue's own repro at `aad859a7` (the last commit before #1027) and at current main:

```
aad859a7   S.run -> foo.other      S.run -> foo.other        <- both methods, one caller
3421e107   S.run -> foo.other      S.run@13 -> alpha.other   <- separated
```

Pre-fix the variant had no outgoing edge at all and Beta::run's call was credited to the first method.

## What this adds

`test_duplicate_method_qn_owns_its_body_use_and_its_calls` (renamed from `..._does_not_steal_body_use`, which no longer described what it asserts) now pins the caller side as well as the import map. Three of its assertions fail on the pre-fix build:

- `(S.run@13, alpha.other) in calls`
- `(S.run@13, foo.beta_only) in calls`
- `(S.run, foo.beta_only) not in calls`

`beta_only` is new to the fixture and is called from the variant with no `use` in scope, so the test pins caller attribution itself rather than the scope-import lookup that `other` alone resolves through. A fourth assertion pins that attribution moves calls rather than copying them.

## Out of scope

A dedup variant gets no `OVERRIDES` edge: `process_all_method_overrides` splits `foo.S.run@13` into `method_name="run@13"` and looks up `foo.Beta.run@13`, which is not in the registry. `S.run@13` is therefore unreachable from every root, so anything it calls stays dead-inside-dead. Filed as #1076.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for duplicate method implementations and qualified-name handling.
  - Added verification that calls are attributed only to the correct implementation, including imported and local call variants.
  - Confirmed the original method retains only its own call references, improving confidence in code navigation and analysis results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->