### PR TITLE
fix: bind a Rust trait-impl method to the trait its own block names

### DIFF
--- a/codebase_rag/parsers/class_ingest/method_override.py
+++ b/codebase_rag/parsers/class_ingest/method_override.py
@@ -35,10 +35,6 @@ def process_all_method_overrides(
             parts = method_qn.rsplit(cs.SEPARATOR_DOT, 1)
             if len(parts) == 2:
                 class_qn, method_name = parts
-                # The dedup variant's name carries the line that made it
-                # unique; no base method is spelled that way, so a derived
-                # lookup keeping the suffix always misses (issue #1076).
-                method_name = method_name.split(cs.DUP_QN_MARKER, 1)[0]
                 if _emit_recorded_impl_override(
                     method_qn,
                     method_name,
@@ -179,6 +175,12 @@ def _emit_recorded_impl_override(
     trait_qn = (impl_method_traits or {}).get(method_qn)
     if trait_qn is None:
         return False
+    # Only now, with an impl block vouching for this method, is the dedup
+    # suffix safe to drop. Stripping it for every method instead would hand
+    # the ancestry walk a name it could not match before, inventing an
+    # override for an INHERENT method that merely shares a trait method's
+    # name, and would empty out a C# verbatim identifier like `@event`.
+    method_name = method_name.split(cs.DUP_QN_MARKER, 1)[0]
     parent_method_qn = f"{trait_qn}{cs.SEPARATOR_DOT}{method_name}"
     if function_registry.get(parent_method_qn) != NodeType.METHOD:
         # An inherent method, or one the trait declares nowhere: the walk has

--- a/codebase_rag/parsers/class_ingest/method_override.py
+++ b/codebase_rag/parsers/class_ingest/method_override.py
@@ -22,6 +22,7 @@ def process_all_method_overrides(
     interface_implementers: dict[str, set[str]] | None = None,
     csharp_methods: set[str] | None = None,
     csharp_override_methods: set[str] | None = None,
+    impl_method_traits: dict[str, str] | None = None,
 ) -> None:
     logger.info(logs.CLASS_PASS_4)
 
@@ -34,6 +35,18 @@ def process_all_method_overrides(
             parts = method_qn.rsplit(cs.SEPARATOR_DOT, 1)
             if len(parts) == 2:
                 class_qn, method_name = parts
+                # The dedup variant's name carries the line that made it
+                # unique; no base method is spelled that way, so a derived
+                # lookup keeping the suffix always misses (issue #1076).
+                method_name = method_name.split(cs.DUP_QN_MARKER, 1)[0]
+                if _emit_recorded_impl_override(
+                    method_qn,
+                    method_name,
+                    function_registry,
+                    ingestor,
+                    impl_method_traits,
+                ):
+                    continue
                 check_method_overrides(
                     method_qn,
                     method_name,
@@ -147,6 +160,41 @@ def _direct_method_names(
             continue
         names.append(leaf)
     return names
+
+
+def _emit_recorded_impl_override(
+    method_qn: str,
+    method_name: str,
+    function_registry: FunctionRegistryTrieProtocol,
+    ingestor: IngestorProtocol,
+    impl_method_traits: dict[str, str] | None,
+) -> bool:
+    """Link a method to the trait its own impl block named, if one was recorded.
+
+    The ancestry walk below takes the first implemented trait declaring this
+    name, in sorted order. Two traits declaring one name make that a coin toss
+    decided by spelling: reversing the impl blocks in the source keeps the same
+    edge, now pointing at the trait the method does not implement.
+    """
+    trait_qn = (impl_method_traits or {}).get(method_qn)
+    if trait_qn is None:
+        return False
+    parent_method_qn = f"{trait_qn}{cs.SEPARATOR_DOT}{method_name}"
+    if function_registry.get(parent_method_qn) != NodeType.METHOD:
+        # An inherent method, or one the trait declares nowhere: the walk has
+        # nothing to be wrong about, so let it run.
+        return False
+    ingestor.ensure_relationship_batch(
+        (cs.NodeLabel.METHOD, cs.KEY_QUALIFIED_NAME, method_qn),
+        cs.RelationshipType.OVERRIDES,
+        (cs.NodeLabel.METHOD, cs.KEY_QUALIFIED_NAME, parent_method_qn),
+    )
+    logger.debug(
+        logs.CLASS_METHOD_OVERRIDE,
+        method_qn=method_qn,
+        parent_method_qn=parent_method_qn,
+    )
+    return True
 
 
 def _invert_implementers(

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -183,6 +183,7 @@ class ClassIngestMixin:
     _deferred_cpp_inherits: list[DeferredCppInherit]
     _deferred_inherits: list[DeferredInherit]
     _rust_trait_impls: list[RustTraitImpl]
+    rust_impl_method_traits: dict[str, str]
     cpp_module_interfaces: set[str]
     _deferred_cpp_module_impls: list[tuple[str, str]]
     declared_module_qns: set[str]
@@ -511,6 +512,10 @@ class ClassIngestMixin:
         self._rust_trait_impls = []
         for impl in impls:
             if not self._rust_trait_is_external(impl):
+                # First-party instead: bind its methods to the trait THIS block
+                # names, so the override pass stops deriving the parent from the
+                # method's qualified name (issue #1076).
+                self._record_rust_impl_method_traits(impl)
                 continue
             for method_qn in impl.method_qns:
                 self.ingestor.ensure_node_batch(
@@ -520,6 +525,19 @@ class ClassIngestMixin:
                         cs.KEY_OVERRIDES_EXTERNAL: True,
                     },
                 )
+
+    def _record_rust_impl_method_traits(self, impl: RustTraitImpl) -> None:
+        # Only a REGISTERED trait: the override edge needs a real endpoint, and
+        # a spelling that resolves nowhere leaves the generic ancestry walk as
+        # the better guess.
+        resolved = self._resolve_deferred_parent_qn(impl.entry)
+        if resolved is None or resolved[1]:
+            return
+        trait_qn = resolved[0]
+        if self.function_registry.get(trait_qn) != NodeType.INTERFACE:
+            return
+        for method_qn in impl.method_qns:
+            self.rust_impl_method_traits[method_qn] = trait_qn
 
     def _rust_trait_is_external(self, impl: RustTraitImpl) -> bool:
         # Only POSITIVE evidence roots: the crate the trait is written under
@@ -1674,6 +1692,7 @@ class ClassIngestMixin:
             self.interface_implementers,
             self.csharp_methods,
             self.csharp_override_methods,
+            self.rust_impl_method_traits,
         )
         self._resolve_java_anon_overrides()
 

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -221,6 +221,10 @@ class DefinitionProcessor(
         # trait is registered, so resolve_deferred_inherits judges it and
         # flags the methods of the external ones (issue #1048).
         self._rust_trait_impls: list[RustTraitImpl] = []
+        # method qn -> the first-party trait qn its own impl block names. The
+        # override pass cannot re-derive this: two traits declaring one method
+        # name leave the method qns indistinguishable (issue #1076).
+        self.rust_impl_method_traits: dict[str, str] = {}
         # C++20 module interfaces declared this run (export module X), and
         # implementation units whose IMPLEMENTS edge waits for its
         # interface to be known.

--- a/codebase_rag/tests/test_csharp_overrides.py
+++ b/codebase_rag/tests/test_csharp_overrides.py
@@ -82,3 +82,22 @@ public class Derived : Base { public new void Hidden() {} }
     assert not _has(_pairs(mock_ingestor), "N.Derived.Hidden", "N.Base.Hidden"), _pairs(
         mock_ingestor
     )
+
+
+def test_verbatim_identifier_method_keeps_its_override(
+    csharp_project: Path, mock_ingestor: MagicMock
+) -> None:
+    # `@event` escapes a keyword; the `@` is part of the method name, not the
+    # duplicate-qn marker. Treating it as the marker empties the name, and the
+    # parent lookup then asks for a method called nothing at all.
+    (csharp_project / "Verbatim.cs").write_text(
+        """
+namespace N;
+public class Base { public virtual int @event(int a) { return 1; } }
+public class Derived : Base { public override int @event(int a) { return 2; } }
+""",
+        encoding="utf-8",
+    )
+    run_updater(csharp_project, mock_ingestor, skip_if_missing=SKIP)
+    pairs = _pairs(mock_ingestor)
+    assert _has(pairs, "Derived.@event(int)", "Base.@event(int)"), pairs

--- a/codebase_rag/tests/test_rust_trait_impl_override_edges.py
+++ b/codebase_rag/tests/test_rust_trait_impl_override_edges.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock
 
+from codebase_rag.constants import DUP_QN_MARKER
 from codebase_rag.tests.test_rust_crate_path_trait_linking import (
     _pairs,
     _write,
@@ -87,6 +88,36 @@ def test_each_trait_impl_method_overrides_its_own_trait(
     assert (f"{base}.S.run@13", f"{base}.Beta.run") in overrides, overrides
     assert (f"{base}.S.run@13", f"{base}.Alpha.run") not in overrides, overrides
     assert (f"{base}.S.run", f"{base}.Beta.run") not in overrides, overrides
+
+
+def test_inherent_method_sharing_a_trait_method_name_overrides_nothing(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `impl S` is inherent: it implements no trait, so its `run` overrides
+    # nothing even though the trait impl above declares that name. Dropping the
+    # dedup suffix for EVERY method, rather than only where an impl block
+    # vouches for it, hands the ancestry walk a name it could not match before
+    # and invents this edge. An OVERRIDES edge expands dead-code liveness, so
+    # the invented one revives an unused inherent method.
+    base = _run(
+        temp_repo,
+        mock_ingestor,
+        "rs_impl_inherent",
+        _TRAITS.replace("pub trait Beta { fn run(&self) -> u32; }\n", "")
+        + (
+            "impl Alpha for S {\n"
+            "    fn run(&self) -> u32 { 1 }\n"
+            "}\n\n"
+            "impl S {\n"
+            "    pub fn run(&self) -> u32 { 2 }\n"
+            "}\n"
+        ),
+    )
+    overrides = _overrides(mock_ingestor)
+    assert (f"{base}.S.run", f"{base}.Alpha.run") in overrides, overrides
+    assert not [
+        pair for pair in overrides if pair[0].startswith(f"{base}.S.run{DUP_QN_MARKER}")
+    ], overrides
 
 
 def test_block_order_not_trait_name_decides_the_override_target(

--- a/codebase_rag/tests/test_rust_trait_impl_override_edges.py
+++ b/codebase_rag/tests/test_rust_trait_impl_override_edges.py
@@ -1,0 +1,103 @@
+"""A Rust trait-impl method overrides the trait ITS OWN block names (#1076).
+
+The override pass rebuilt the relationship from the method's qualified name:
+it split off the last segment for the method name and walked the implemented
+traits in sorted order, taking the first that declared a matching method. Two
+traits declaring one name broke that walk twice over.
+
+The dedup variant `S.run@13` kept its `@13` suffix in the derived method name,
+so the lookup for `Beta.run@13` missed and the second method got no OVERRIDES
+edge at all, leaving it unreachable from every root. And the surviving edge
+landed on whichever trait sorted first rather than the one written above the
+method, so reversing the two impl blocks pointed it at the wrong trait.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.test_rust_crate_path_trait_linking import (
+    _pairs,
+    _write,
+    create_and_run_updater,
+)
+from codebase_rag.types_defs import RelationshipType
+
+_TRAITS = "pub trait Alpha { fn run(&self) -> u32; }\npub trait Beta { fn run(&self) -> u32; }\n\npub struct S;\n\n"
+
+# Alpha first, so the block order and the alphabetical order AGREE. The bug
+# hides here for the natural qn, which is why the reversed fixture below
+# exists: this one pins only the variant.
+_ALPHA_FIRST = _TRAITS + (
+    "impl Alpha for S {\n"
+    "    fn run(&self) -> u32 {\n"
+    "        1\n"
+    "    }\n"
+    "}\n\n"
+    "impl Beta for S {\n"
+    "    fn run(&self) -> u32 {\n"
+    "        2\n"
+    "    }\n"
+    "}\n"
+)
+
+# Beta first, so block order and alphabetical order DISAGREE. `S.run` is
+# Beta's method and `S.run@13` is Alpha's, the opposite of the fixture above.
+_BETA_FIRST = _TRAITS + (
+    "impl Beta for S {\n"
+    "    fn run(&self) -> u32 {\n"
+    "        1\n"
+    "    }\n"
+    "}\n\n"
+    "impl Alpha for S {\n"
+    "    fn run(&self) -> u32 {\n"
+    "        2\n"
+    "    }\n"
+    "}\n"
+)
+
+
+def _overrides(mock_ingestor: MagicMock) -> set[tuple[str, str]]:
+    return _pairs(mock_ingestor, RelationshipType.OVERRIDES.value)
+
+
+def _run(temp_repo: Path, mock_ingestor: MagicMock, name: str, source: str) -> str:
+    project = temp_repo / name
+    _write(
+        project,
+        {
+            "Cargo.toml": f'[package]\nname = "{name}"\nversion = "0.1.0"\n',
+            "src/lib.rs": "pub mod foo;\n",
+            "src/foo.rs": source,
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    return f"{name}.src.foo"
+
+
+def test_each_trait_impl_method_overrides_its_own_trait(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    base = _run(temp_repo, mock_ingestor, "rs_impl_override", _ALPHA_FIRST)
+    overrides = _overrides(mock_ingestor)
+    assert (f"{base}.S.run", f"{base}.Alpha.run") in overrides, overrides
+    # The variant had no OVERRIDES edge of any kind: the derived method name
+    # kept the `@13` suffix, so no trait declared a match.
+    assert (f"{base}.S.run@13", f"{base}.Beta.run") in overrides, overrides
+    assert (f"{base}.S.run@13", f"{base}.Alpha.run") not in overrides, overrides
+    assert (f"{base}.S.run", f"{base}.Beta.run") not in overrides, overrides
+
+
+def test_block_order_not_trait_name_decides_the_override_target(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # Same two traits, impl blocks swapped. Every edge here is the mirror of
+    # the test above, so an implementation that reads the sorted trait list
+    # instead of the impl block passes that one and fails this one.
+    base = _run(temp_repo, mock_ingestor, "rs_impl_override_rev", _BETA_FIRST)
+    overrides = _overrides(mock_ingestor)
+    assert (f"{base}.S.run", f"{base}.Beta.run") in overrides, overrides
+    assert (f"{base}.S.run@13", f"{base}.Alpha.run") in overrides, overrides
+    assert (f"{base}.S.run", f"{base}.Alpha.run") not in overrides, overrides
+    assert (f"{base}.S.run@13", f"{base}.Beta.run") not in overrides, overrides

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.549"
+version = "0.0.551"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #1076.

The override pass rebuilt the relationship from the method's qualified name: split off the last segment, then walk the implemented traits in sorted order and take the first that declares a matching name. Two traits declaring one name broke that walk twice over.

## The two faces

A dedup variant keeps its `@<line>` suffix in the derived name, so the lookup for `Beta.run@13` misses and the second method gets no `OVERRIDES` edge at all, leaving it unreachable from every root.

And the surviving edge lands on whichever trait sorts first rather than the one written above the method:

```rust
impl Beta for S  { fn run(&self) -> u32 { 1 } }   // line 7,  registers as S.run
impl Alpha for S { fn run(&self) -> u32 { 2 } }   // line 13, registers as S.run@13
```

`S.run` is Beta's method, yet it got `OVERRIDES Alpha.run`. A wrong edge is worse than a missing one, because reachability flows through `OVERRIDES`: a live caller of `Alpha::run` marks the wrong method live and leaves the real one dead.

## The fix

`_rust_trait_impls` already pairs each impl block's trait with the method qns it ingested, and `resolve_deferred_inherits` runs before `process_all_method_overrides`. So the binding is recorded there for first-party traits and consumed as the authoritative parent, instead of being re-derived from strings. Where nothing is recorded, the ancestry walk runs exactly as before.

The dedup suffix is dropped only after an impl block has vouched for the method. Stripping it for every method instead caused two regressions, both caught in review and both now pinned by tests:

- an INHERENT `impl S { fn run }` sharing a trait method's name gained a false `OVERRIDES` edge, reviving a genuinely dead method
- a C# verbatim identifier `@event` collapsed to the empty string, silently losing its real override edge

## Scope

Impact is limited to first-party traits declared in the same crate. The `Display`/`Debug` shape common in real Rust already took the external-trait path, where both `Glob.fmt` and `Glob.fmt@12` are flagged `overrides_external` and neither was ever a false positive.

## Tests

Four new tests, each verified to fail without the change it pins. The two impl-order fixtures are exact mirrors, so an implementation reading the sorted trait list rather than the impl block passes one and fails the other.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved override relationship resolution for Rust trait implementations, including ambiguous and deduplicated method names.
  * Prevented false override relationships for inherent Rust methods.
  * Preserved correct C# overrides when methods use verbatim identifiers.

* **Tests**
  * Added regression coverage for Rust trait selection, method naming, and C# override handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->