### PR TITLE
fix: never give a Rust inherent impl method an override edge

### DIFF
--- a/codebase_rag/parsers/class_ingest/method_override.py
+++ b/codebase_rag/parsers/class_ingest/method_override.py
@@ -29,41 +29,41 @@ def process_all_method_overrides(
 
     implemented_interfaces = _invert_implementers(interface_implementers or {})
     for method_qn in function_registry.keys():
-        if (
-            function_registry[method_qn] == NodeType.METHOD
-            and cs.SEPARATOR_DOT in method_qn
+        if function_registry[method_qn] != NodeType.METHOD:
+            continue
+        # A dotless qn has no class to walk from; rpartition leaves class_qn
+        # empty for it, which is the same set the membership test used to skip.
+        class_qn, _, method_name = method_qn.rpartition(cs.SEPARATOR_DOT)
+        if not class_qn:
+            continue
+        # Positive evidence first: a recorded trait binding names the parent
+        # outright, so it outranks a classification drawn from absence,
+        # whichever way the two ever disagree.
+        if _emit_recorded_impl_override(
+            method_qn,
+            method_name,
+            function_registry,
+            ingestor,
+            impl_method_traits,
         ):
-            parts = method_qn.rsplit(cs.SEPARATOR_DOT, 1)
-            if len(parts) == 2:
-                class_qn, method_name = parts
-                # Positive evidence first: a recorded trait binding names the
-                # parent outright, so it outranks a classification drawn from
-                # absence, whichever way the two ever disagree.
-                if _emit_recorded_impl_override(
-                    method_qn,
-                    method_name,
-                    function_registry,
-                    ingestor,
-                    impl_method_traits,
-                ):
-                    continue
-                if inherent_impl_methods and method_qn in inherent_impl_methods:
-                    # Written in an inherent `impl Type` block, so it implements
-                    # nothing. Rust has no inheritance, and the walk below would
-                    # otherwise hand it the first trait the type implements that
-                    # happens to declare this name.
-                    continue
-                check_method_overrides(
-                    method_qn,
-                    method_name,
-                    class_qn,
-                    function_registry,
-                    class_inheritance,
-                    ingestor,
-                    implemented_interfaces,
-                    csharp_methods,
-                    csharp_override_methods,
-                )
+            continue
+        if inherent_impl_methods and method_qn in inherent_impl_methods:
+            # Written in an inherent `impl Type` block, so it implements
+            # nothing. Rust has no inheritance, and the walk below would
+            # otherwise hand it the first trait the type implements that
+            # happens to declare this name.
+            continue
+        check_method_overrides(
+            method_qn,
+            method_name,
+            class_qn,
+            function_registry,
+            class_inheritance,
+            ingestor,
+            implemented_interfaces,
+            csharp_methods,
+            csharp_override_methods,
+        )
     _process_mro_shadow_overrides(function_registry, class_inheritance, ingestor)
 
 

--- a/codebase_rag/parsers/class_ingest/method_override.py
+++ b/codebase_rag/parsers/class_ingest/method_override.py
@@ -23,6 +23,7 @@ def process_all_method_overrides(
     csharp_methods: set[str] | None = None,
     csharp_override_methods: set[str] | None = None,
     impl_method_traits: dict[str, str] | None = None,
+    inherent_impl_methods: set[str] | None = None,
 ) -> None:
     logger.info(logs.CLASS_PASS_4)
 
@@ -35,6 +36,12 @@ def process_all_method_overrides(
             parts = method_qn.rsplit(cs.SEPARATOR_DOT, 1)
             if len(parts) == 2:
                 class_qn, method_name = parts
+                if inherent_impl_methods and method_qn in inherent_impl_methods:
+                    # Written in an inherent `impl Type` block, so it implements
+                    # nothing. Rust has no inheritance, and the walk below would
+                    # otherwise hand it the first trait the type implements that
+                    # happens to declare this name.
+                    continue
                 if _emit_recorded_impl_override(
                     method_qn,
                     method_name,

--- a/codebase_rag/parsers/class_ingest/method_override.py
+++ b/codebase_rag/parsers/class_ingest/method_override.py
@@ -36,12 +36,9 @@ def process_all_method_overrides(
             parts = method_qn.rsplit(cs.SEPARATOR_DOT, 1)
             if len(parts) == 2:
                 class_qn, method_name = parts
-                if inherent_impl_methods and method_qn in inherent_impl_methods:
-                    # Written in an inherent `impl Type` block, so it implements
-                    # nothing. Rust has no inheritance, and the walk below would
-                    # otherwise hand it the first trait the type implements that
-                    # happens to declare this name.
-                    continue
+                # Positive evidence first: a recorded trait binding names the
+                # parent outright, so it outranks a classification drawn from
+                # absence, whichever way the two ever disagree.
                 if _emit_recorded_impl_override(
                     method_qn,
                     method_name,
@@ -49,6 +46,12 @@ def process_all_method_overrides(
                     ingestor,
                     impl_method_traits,
                 ):
+                    continue
+                if inherent_impl_methods and method_qn in inherent_impl_methods:
+                    # Written in an inherent `impl Type` block, so it implements
+                    # nothing. Rust has no inheritance, and the walk below would
+                    # otherwise hand it the first trait the type implements that
+                    # happens to declare this name.
                     continue
                 check_method_overrides(
                     method_qn,

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -184,6 +184,7 @@ class ClassIngestMixin:
     _deferred_inherits: list[DeferredInherit]
     _rust_trait_impls: list[RustTraitImpl]
     rust_impl_method_traits: dict[str, str]
+    rust_inherent_impl_methods: set[str]
     cpp_module_interfaces: set[str]
     _deferred_cpp_module_impls: list[tuple[str, str]]
     declared_module_qns: set[str]
@@ -1164,6 +1165,10 @@ class ClassIngestMixin:
         # `impl Trait for Type` means Type IMPLEMENTS Trait. The target type's
         # node label may be Class/Enum/Type, so match the relationship source
         # to its registered label (else the IMPLEMENTS edge never resolves).
+        # Collected either way: an inherent block's methods implement nothing,
+        # which the override pass has to be TOLD, or it reads their absence
+        # from the trait map as no information and guesses (issue #1078).
+        impl_method_qns: list[str] = []
         trait_impl_method_qns: list[str] | None = None
         if trait_name := rs_utils.extract_impl_trait(class_node):
             trait_qn = self._resolve_to_qn(trait_name, owner_module_qn)
@@ -1185,7 +1190,7 @@ class ClassIngestMixin:
             # they can ever have (issue #1048). The decision waits for
             # resolve_deferred_inherits, when every first-party trait is
             # registered.
-            trait_impl_method_qns = []
+            trait_impl_method_qns = impl_method_qns
             self._rust_trait_impls.append(
                 RustTraitImpl(
                     entry=trait_entry,
@@ -1251,8 +1256,7 @@ class ClassIngestMixin:
             # its own qn, and overwriting the record would re-attribute
             # its calls to this pass's twin.
             if ingested_qn is not None:
-                if trait_impl_method_qns is not None:
-                    trait_impl_method_qns.append(ingested_qn)
+                impl_method_qns.append(ingested_qn)
                 span = function_span_key(module_qn, method_node)
                 if span not in self.function_locations:
                     self.function_locations[span] = FunctionLocation(
@@ -1273,6 +1277,9 @@ class ClassIngestMixin:
                 self.method_return_types[
                     f"{class_qn}{cs.SEPARATOR_DOT}{method_name}"
                 ] = return_type
+
+        if trait_impl_method_qns is None:
+            self.rust_inherent_impl_methods.update(impl_method_qns)
 
     def _ingest_class_methods(
         self,
@@ -1693,6 +1700,7 @@ class ClassIngestMixin:
             self.csharp_methods,
             self.csharp_override_methods,
             self.rust_impl_method_traits,
+            self.rust_inherent_impl_methods,
         )
         self._resolve_java_anon_overrides()
 

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -1278,7 +1278,10 @@ class ClassIngestMixin:
                     f"{class_qn}{cs.SEPARATOR_DOT}{method_name}"
                 ] = return_type
 
-        if trait_impl_method_qns is None:
+        # The PATH decides, not the name: `extract_impl_trait` reads no name
+        # off `impl std::ops::Add<u32> for S`, and calling that inherent would
+        # bar a real trait impl's methods from ever overriding.
+        if rs_utils.extract_impl_trait_path(class_node) is None:
             self.rust_inherent_impl_methods.update(impl_method_qns)
 
     def _ingest_class_methods(

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -225,6 +225,10 @@ class DefinitionProcessor(
         # override pass cannot re-derive this: two traits declaring one method
         # name leave the method qns indistinguishable (issue #1076).
         self.rust_impl_method_traits: dict[str, str] = {}
+        # Methods of an inherent `impl Type` block. Rust has no
+        # inheritance, so these override nothing and must never reach the
+        # ancestry walk (issue #1078).
+        self.rust_inherent_impl_methods: set[str] = set()
         # C++20 module interfaces declared this run (export module X), and
         # implementation units whose IMPLEMENTS edge waits for its
         # interface to be known.

--- a/codebase_rag/tests/test_rust_trait_impl_override_edges.py
+++ b/codebase_rag/tests/test_rust_trait_impl_override_edges.py
@@ -149,7 +149,48 @@ def test_inherent_impl_written_first_still_overrides_nothing(
         f"{base}.S.run{DUP_QN_MARKER}10",
         f"{base}.Alpha.run",
     ) in overrides, overrides
-    assert (f"{base}.S.run", f"{base}.Alpha.run") not in overrides, overrides
+    # Nothing at all from the natural qn, not merely no edge to Alpha: a gate
+    # that silenced some other trait too would satisfy the narrower check.
+    assert not [pair for pair in overrides if pair[0] == f"{base}.S.run"], overrides
+
+
+def test_a_scoped_generic_trait_impl_is_not_mistaken_for_inherent(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `impl b::Base<u32> for S` is a trait impl, but the trait NAME extractor
+    # reads nothing off a generic wrapped around a scoped path and returns
+    # None, exactly as it does for a genuinely inherent block. Classifying by
+    # that would bar a real trait impl's methods from ever overriding, and this
+    # spelling is ordinary: std::ops::Add, serde::de::Visitor.
+    # `Alpha` names `Base` as a supertrait, which is what puts `Base` in S's
+    # ancestry: the scoped-generic block alone records no implementer, a
+    # separate pre-existing gap this test does not speak to.
+    project = temp_repo / "rs_scoped_generic_impl"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_scoped_generic_impl"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": "pub mod b;\npub mod foo;\n",
+            "src/b.rs": "pub trait Base<T> { fn run(&self) -> T; }\n",
+            "src/foo.rs": (
+                "pub trait Alpha: crate::b::Base<u32> { fn go(&self); }\n\n"
+                "pub struct S;\n\n"
+                "impl crate::b::Base<u32> for S {\n"
+                "    fn run(&self) -> u32 { 1 }\n"
+                "}\n\n"
+                "impl Alpha for S {\n"
+                "    fn go(&self) {}\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    overrides = _overrides(mock_ingestor)
+    base = "rs_scoped_generic_impl.src"
+    assert (f"{base}.foo.S.run", f"{base}.b.Base.run") in overrides, overrides
+    assert (f"{base}.foo.S.go", f"{base}.foo.Alpha.go") in overrides, overrides
 
 
 def test_block_order_not_trait_name_decides_the_override_target(

--- a/codebase_rag/tests/test_rust_trait_impl_override_edges.py
+++ b/codebase_rag/tests/test_rust_trait_impl_override_edges.py
@@ -120,6 +120,38 @@ def test_inherent_method_sharing_a_trait_method_name_overrides_nothing(
     ], overrides
 
 
+def test_inherent_impl_written_first_still_overrides_nothing(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # Same two blocks, inherent one FIRST, so the inherent method takes the
+    # natural qn and the trait method takes the variant. The trait binding is
+    # recorded only for the variant, and absence from that map used to send the
+    # inherent method to the ancestry walk, which found the one trait `S`
+    # implements and linked it. Rust has no inheritance: a method outside an
+    # `impl Trait for` block overrides nothing, whatever it is named (#1078).
+    base = _run(
+        temp_repo,
+        mock_ingestor,
+        "rs_impl_inherent_first",
+        _TRAITS.replace("pub trait Beta { fn run(&self) -> u32; }\n", "")
+        + (
+            "impl S {\n"
+            "    pub fn run(&self) -> u32 { 2 }\n"
+            "}\n\n"
+            "impl Alpha for S {\n"
+            "    fn run(&self) -> u32 { 1 }\n"
+            "}\n"
+        ),
+    )
+    overrides = _overrides(mock_ingestor)
+    # The trait method's `fn` sits on line 10, so it holds the variant here.
+    assert (
+        f"{base}.S.run{DUP_QN_MARKER}10",
+        f"{base}.Alpha.run",
+    ) in overrides, overrides
+    assert (f"{base}.S.run", f"{base}.Alpha.run") not in overrides, overrides
+
+
 def test_block_order_not_trait_name_decides_the_override_target(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:


### PR DESCRIPTION
Closes #1078.

Rust has no inheritance, so a method can only override when it is written in an `impl Trait for Type` block. A method in an inherent `impl Type` block implements nothing. The override pass could not tell the two apart, so an inherent method sharing a name with a trait the type also implements was linked to it.

```rust
pub trait Alpha { fn run(&self) -> u32; }
pub struct S;
impl S { pub fn run(&self) -> u32 { 2 } }          // inherent
impl Alpha for S { fn run(&self) -> u32 { 1 } }    // trait impl
```

Before, both methods pointed at `Alpha.run`. After, only the trait-impl method does, whichever of the two happens to hold the deduplicated qualified name.

Reachability expands along `OVERRIDES`, so the false edge kept an unused inherent method alive and suppressed a genuine dead-code candidate.

## The fix

`_ingest_rust_impl_methods` already knows which block it is in. It now collects the block's method qns either way and records the inherent ones, so the override pass is told rather than left to infer from absence.

The classifier keys on `extract_impl_trait_path`, not `extract_impl_trait`. The latter reads no name off a generic wrapped around a scoped path, returning `None` for `impl std::ops::Add<u32> for S` exactly as it does for a genuinely inherent block:

```
trait=None  path=std::ops::Add       impl std::ops::Add<u32> for S
trait=None  path=crate::al::Alpha    impl<T> crate::al::Alpha<T> for S
trait=None  path=None                impl S
trait=None  path=None                impl<T> S<T>
```

An earlier draft classified by name and barred those real trait impls from ever overriding. That regression is pinned by `test_a_scoped_generic_trait_impl_is_not_mistaken_for_inherent`, verified to fail against it.

The recorded trait binding is also consulted before the inherent gate, so positive evidence outranks a classification drawn from absence if the two ever disagree.

## Tests

Two new tests, each verified to fail without the change it pins, plus the existing three still green. The inherent-first fixture asserts nothing at all comes from the natural qn rather than merely no edge to `Alpha`, so an over-broad gate that silenced another trait would not pass.

## Out of scope

`impl path::Trait<Args> for Type` records no entry in `interface_implementers`, because that path also reads the trait NAME. So such a block alone still yields no override edge; the test above reaches `Base` through a supertrait instead. Pre-existing and unchanged here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Rust code analysis to distinguish inherent implementation methods from trait implementations.
  - Prevented inherent methods from being incorrectly reported as overrides, regardless of implementation block order.
  - Improved detection of scoped and generic trait implementations.
  - Ensured trait override relationships use accurate, deduplicated method names.

- **Tests**
  - Added regression coverage for Rust inherent implementations and generic trait implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->