### PR TITLE
fix: honour a Rust #[path] redirect declared outside a crate entry file

### DIFF
--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -458,6 +458,7 @@ class ImportProcessor:
         "_cpp_declaration_mappings",
         "_rust_dir_listing",
         "_rust_entry_mod_decls",
+        "_rust_module_mod_decls",
         "_rust_explicit_targets",
         "_rust_auto_build_flags",
         "_rust_workspace_crates",
@@ -511,6 +512,12 @@ class ImportProcessor:
         self._rust_dir_listing: dict[str, frozenset[str]] = {}
         self._rust_entry_mod_decls: dict[
             tuple[str, ...], dict[str, RustEntryDecls]
+        ] = {}
+        # Same, for an ORDINARY module file: its own declarations, plus the
+        # directory its `#[path]` targets count from. Kept apart from the
+        # entry map, whose every stem is a crate root candidate (issue #1065).
+        self._rust_module_mod_decls: dict[
+            tuple[str, ...], tuple[RustEntryDecls, list[str]] | None
         ] = {}
         # Explicit Cargo target entry paths per package dir ([[bin]]/[lib]/
         # [[example]]/[[test]]/[[bench]] `path` overrides): such entries
@@ -1676,6 +1683,78 @@ class ImportProcessor:
             decls[stem] = _rs_entry_decls_of(top_level)
         return decls
 
+    def _rust_module_decls(
+        self, module_parts: list[str]
+    ) -> tuple[RustEntryDecls, list[str]] | None:
+        """Declarations of the file backing a module, and its `#[path]` base.
+
+        `src/engine.rs` and `src/engine/mod.rs` both back `src.engine`, and a
+        redirect written in either counts from the directory the file sits in.
+        None when no file backs the module: an inline `mod`, or a segment that
+        was never a module at all.
+        """
+        key = tuple(module_parts)
+        if key in self._rust_module_mod_decls:
+            return self._rust_module_mod_decls[key]
+        if not module_parts:
+            return None
+        parent = module_parts[:-1]
+        if f"{module_parts[-1]}{cs.EXT_RS}" in self._rust_dir_entries(
+            self.repo_path.joinpath(*parent)
+        ):
+            path, base = (
+                self.repo_path.joinpath(*parent, f"{module_parts[-1]}{cs.EXT_RS}"),
+                parent,
+            )
+        elif cs.MOD_RS in self._rust_dir_entries(
+            self.repo_path.joinpath(*module_parts)
+        ):
+            path, base = (
+                self.repo_path.joinpath(*module_parts, cs.MOD_RS),
+                module_parts,
+            )
+        else:
+            self._rust_module_mod_decls[key] = None
+            return None
+        try:
+            source = path.read_text(encoding=cs.RS_ENCODING_UTF8, errors="ignore")
+        except OSError:
+            # Uncached, so the next access retries: a storm's transient
+            # absence must not bake in "this module declares nothing".
+            return None
+        found = (
+            _rs_entry_decls_of(
+                _rs_top_level_only(_rs_strip_comments_and_strings(source))
+            ),
+            list(base),
+        )
+        self._rust_module_mod_decls[key] = found
+        return found
+
+    def _rust_join_mods(self, parts: list[str], rest: list[str]) -> str:
+        """Join a resolved module prefix to a path tail, honouring `#[path]`.
+
+        Only the crate ENTRY's redirects are read above, and the tail used to
+        attach by name straight past a redirect declared in any other file,
+        landing on a qn no module owns or on an undeclared shadow file that
+        happens to sit where the declared name points (issue #1065).
+        """
+        out = list(parts)
+        for index, segment in enumerate(rest):
+            found = self._rust_module_decls(out)
+            if found is None:
+                # Past the module tree and into items, whose names back no
+                # file and so can declare nothing.
+                out.extend(rest[index:])
+                break
+            decls, base = found
+            redirect = decls.redirects.get(segment)
+            target = (
+                rs_utils.path_attribute_qn_parts(base, redirect) if redirect else None
+            )
+            out = target if target is not None else [*out, segment]
+        return cs.SEPARATOR_DOT.join([self.project_name, *out])
+
     def _rust_attach(
         self, dir_parts: list[str], stem: str, rest: list[str], definitive: bool
     ) -> str:
@@ -1696,11 +1775,9 @@ class ImportProcessor:
                 # module keys under that file, so the declared name never
                 # appears in the qn at all (issue #1035).
                 if target := rs_utils.path_attribute_qn_parts(dir_parts, redirect):
-                    return cs.SEPARATOR_DOT.join(
-                        [self.project_name, *target, *rest[1:]]
-                    )
+                    return self._rust_join_mods(target, rest[1:])
             if rest[0] in file_mods:
-                return cs.SEPARATOR_DOT.join([self.project_name, *dir_parts, *rest])
+                return self._rust_join_mods([*dir_parts, rest[0]], rest[1:])
             if rest[0] in items:
                 return cs.SEPARATOR_DOT.join(
                     [self.project_name, *dir_parts, stem, *rest]
@@ -1709,7 +1786,7 @@ class ImportProcessor:
             f"{rest[0]}{cs.EXT_RS}" in entries
             or (rest[0] in entries and (directory / rest[0]).is_dir())
         ):
-            return cs.SEPARATOR_DOT.join([self.project_name, *dir_parts, *rest])
+            return self._rust_join_mods([*dir_parts, rest[0]], rest[1:])
         if rest and not definitive and chosen is not None:
             # When a file compiles into BOTH crates (lib.rs and main.rs each
             # declare its module), the path can only mean the entry that
@@ -1762,7 +1839,7 @@ class ImportProcessor:
             # The base IS a crate entry module (self:: in lib.rs); a module
             # merely NAMED main/lib deeper in the tree attaches normally.
             return self._rust_attach(parts[:-1], parts[-1], rest, definitive=True)
-        return cs.SEPARATOR_DOT.join([base_qn, *rest]) if rest else base_qn
+        return self._rust_join_mods(parts, rest) if rest else base_qn
 
     def _rewrite_rust_local_use_path(
         self,
@@ -1817,7 +1894,7 @@ class ImportProcessor:
         if kind == "file":
             # An auto-target crate (src/bin/tool.rs): items and
             # submodules both nest under the entry file's qn.
-            return cs.SEPARATOR_DOT.join([self.project_name, *root_parts, *rest])
+            return self._rust_join_mods(root_parts, rest)
         if kind == "entry":
             # An explicit manifest target: the root file IS the entry,
             # so submodule files sit beside it and items nest in it.
@@ -2362,6 +2439,7 @@ class ImportProcessor:
         # were filled; called per run by GraphUpdater._process_files.
         self._rust_dir_listing.clear()
         self._rust_entry_mod_decls.clear()
+        self._rust_module_mod_decls.clear()
         self._rust_explicit_targets.clear()
         self._rust_auto_build_flags.clear()
         self._rust_workspace_crates = None
@@ -2398,6 +2476,16 @@ class ImportProcessor:
             dir_parts = directory.relative_to(self.repo_path).parts
         except ValueError:
             return
+        if file_path.suffix == cs.EXT_RS:
+            # Any .rs file may back a module and declare a redirect, so its
+            # own entry is evicted rather than replaced: an unreadable file
+            # then re-reads on the next access instead of caching a hole.
+            module = (
+                dir_parts
+                if file_path.stem == cs.INDEX_MOD
+                else (*dir_parts, file_path.stem)
+            )
+            self._rust_module_mod_decls.pop(module, None)
         if (
             file_path.name in (cs.LIB_RS, cs.MAIN_RS)
             or file_path.name in self._rust_explicit_entry_files(tuple(dir_parts))

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -517,7 +517,7 @@ class ImportProcessor:
         # directory its `#[path]` targets count from. Kept apart from the
         # entry map, whose every stem is a crate root candidate (issue #1065).
         self._rust_module_mod_decls: dict[
-            tuple[str, ...], tuple[RustEntryDecls, list[str]] | None
+            tuple[tuple[str, ...], bool], tuple[RustEntryDecls, list[str]] | None
         ] = {}
         # Explicit Cargo target entry paths per package dir ([[bin]]/[lib]/
         # [[example]]/[[test]]/[[bench]] `path` overrides): such entries
@@ -1684,23 +1684,27 @@ class ImportProcessor:
         return decls
 
     def _rust_module_decls(
-        self, module_parts: list[str]
+        self, module_parts: list[str], dir_backed: bool = False
     ) -> tuple[RustEntryDecls, list[str]] | None:
         """Declarations of the file backing a module, and its `#[path]` base.
 
         `src/engine.rs` and `src/engine/mod.rs` both back `src.engine`, and a
         redirect written in either counts from the directory the file sits in.
-        None when no file backs the module: an inline `mod`, or a segment that
-        was never a module at all.
+        Declaring both is a rustc error, so either may be preferred, EXCEPT
+        when the caller already knows the module is directory-backed. None
+        when no file backs the module: an inline `mod`, or a segment that was
+        never a module at all.
         """
-        key = tuple(module_parts)
+        key = (tuple(module_parts), dir_backed)
         if key in self._rust_module_mod_decls:
             return self._rust_module_mod_decls[key]
         if not module_parts:
             return None
         parent = module_parts[:-1]
-        if f"{module_parts[-1]}{cs.EXT_RS}" in self._rust_dir_entries(
-            self.repo_path.joinpath(*parent)
+        if (
+            not dir_backed
+            and f"{module_parts[-1]}{cs.EXT_RS}"
+            in self._rust_dir_entries(self.repo_path.joinpath(*parent))
         ):
             path, base = (
                 self.repo_path.joinpath(*parent, f"{module_parts[-1]}{cs.EXT_RS}"),
@@ -1722,17 +1726,29 @@ class ImportProcessor:
             # Uncached, so the next access retries: a storm's transient
             # absence must not bake in "this module declares nothing".
             return None
-        found = (
-            _rs_entry_decls_of(
-                _rs_top_level_only(_rs_strip_comments_and_strings(source))
-            ),
-            list(base),
-        )
+        if _RS_PATH_ATTRIBUTE_PATTERN.search(source) is None:
+            # Only redirects are read here, and both the lexer and the
+            # declaration scan behind them cost far more than this prescan
+            # (the scan is superlinear in file length, so a 30k-line
+            # generated module spends tens of seconds proving it declares no
+            # redirect). Searching the RAW source overshoots by the
+            # commented-out and quoted spellings, which merely fall through
+            # to the real scan; nothing it misses can be a redirect.
+            found = (RustEntryDecls(set(), set(), {}), list(base))
+        else:
+            found = (
+                _rs_entry_decls_of(
+                    _rs_top_level_only(_rs_strip_comments_and_strings(source))
+                ),
+                list(base),
+            )
         self._rust_module_mod_decls[key] = found
         return found
 
-    def _rust_join_mods(self, parts: list[str], rest: list[str]) -> str:
-        """Join a resolved module prefix to a path tail, honouring `#[path]`.
+    def _rust_walk_mods(
+        self, parts: list[str], rest: list[str], dir_backed: bool = False
+    ) -> list[str]:
+        """Walk a path tail from a resolved module prefix, honouring `#[path]`.
 
         Only the crate ENTRY's redirects are read above, and the tail used to
         attach by name straight past a redirect declared in any other file,
@@ -1741,7 +1757,7 @@ class ImportProcessor:
         """
         out = list(parts)
         for index, segment in enumerate(rest):
-            found = self._rust_module_decls(out)
+            found = self._rust_module_decls(out, dir_backed)
             if found is None:
                 # Past the module tree and into items, whose names back no
                 # file and so can declare nothing.
@@ -1752,8 +1768,24 @@ class ImportProcessor:
             target = (
                 rs_utils.path_attribute_qn_parts(base, redirect) if redirect else None
             )
-            out = target if target is not None else [*out, segment]
-        return cs.SEPARATOR_DOT.join([self.project_name, *out])
+            if redirect is None or target is None:
+                out, dir_backed = [*out, segment], False
+                continue
+            # A redirect onto a `mod.rs` names the DIRECTORY, and the qn
+            # scheme drops the `mod` segment, so the resulting parts are
+            # indistinguishable from a plain file module: without this the
+            # next hop reads the sibling `<parts>.rs`, an undeclared shadow
+            # rustc never compiles into this path.
+            out = target
+            dir_backed = redirect.rsplit(cs.SEPARATOR_SLASH, 1)[-1] == cs.MOD_RS
+        return out
+
+    def _rust_join_mods(
+        self, parts: list[str], rest: list[str], dir_backed: bool = False
+    ) -> str:
+        return cs.SEPARATOR_DOT.join(
+            [self.project_name, *self._rust_walk_mods(parts, rest, dir_backed)]
+        )
 
     def _rust_attach(
         self, dir_parts: list[str], stem: str, rest: list[str], definitive: bool
@@ -1775,7 +1807,11 @@ class ImportProcessor:
                 # module keys under that file, so the declared name never
                 # appears in the qn at all (issue #1035).
                 if target := rs_utils.path_attribute_qn_parts(dir_parts, redirect):
-                    return self._rust_join_mods(target, rest[1:])
+                    return self._rust_join_mods(
+                        target,
+                        rest[1:],
+                        redirect.rsplit(cs.SEPARATOR_SLASH, 1)[-1] == cs.MOD_RS,
+                    )
             if rest[0] in file_mods:
                 return self._rust_join_mods([*dir_parts, rest[0]], rest[1:])
             if rest[0] in items:
@@ -1839,7 +1875,15 @@ class ImportProcessor:
             # The base IS a crate entry module (self:: in lib.rs); a module
             # merely NAMED main/lib deeper in the tree attaches normally.
             return self._rust_attach(parts[:-1], parts[-1], rest, definitive=True)
-        return self._rust_join_mods(parts, rest) if rest else base_qn
+        if not rest:
+            return base_qn
+        walked = self._rust_walk_mods(parts, rest)
+        if walked == [*parts, *rest]:
+            # No redirect fired, so keep base_qn verbatim rather than
+            # rebuilding it from project_name, which re-splits differently
+            # when the repository directory name itself contains a dot.
+            return cs.SEPARATOR_DOT.join([base_qn, *rest])
+        return cs.SEPARATOR_DOT.join([self.project_name, *walked])
 
     def _rewrite_rust_local_use_path(
         self,
@@ -2485,7 +2529,8 @@ class ImportProcessor:
                 if file_path.stem == cs.INDEX_MOD
                 else (*dir_parts, file_path.stem)
             )
-            self._rust_module_mod_decls.pop(module, None)
+            for dir_backed in (False, True):
+                self._rust_module_mod_decls.pop((module, dir_backed), None)
         if (
             file_path.name in (cs.LIB_RS, cs.MAIN_RS)
             or file_path.name in self._rust_explicit_entry_files(tuple(dir_parts))

--- a/codebase_rag/tests/test_rust_path_attribute_mod.py
+++ b/codebase_rag/tests/test_rust_path_attribute_mod.py
@@ -199,6 +199,41 @@ def test_a_relative_path_resolves_a_redirect_declared_beside_it(
     assert (caller, "rs_path_attr_super.src.engine.rig.build") not in calls, calls
 
 
+def test_a_redirect_onto_a_mod_rs_is_not_read_off_its_sibling_shadow(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # A redirect naming `platform/mod.rs` backs the DIRECTORY, and the qn
+    # scheme drops the `mod` segment, so `src.platform` looks exactly like a
+    # plain file module. Continuing the walk from the sibling `src/platform.rs`
+    # reads an undeclared shadow, whose own redirect then sends `inner` to a
+    # third file rustc never compiles into this path.
+    project = temp_repo / "rs_path_attr_modrs"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_path_attr_modrs"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": "pub mod engine;\npub mod a;\n",
+            "src/engine.rs": '#[path = "platform/mod.rs"]\npub mod platform;\n',
+            "src/platform/mod.rs": "pub mod inner;\n",
+            "src/platform/inner.rs": "pub fn go() -> i32 {\n    1\n}\n",
+            "src/platform.rs": '#[path = "elsewhere/inner.rs"]\npub mod inner;\n',
+            "src/elsewhere/inner.rs": "pub fn other() -> i32 {\n    9\n}\n",
+            "src/a.rs": (
+                "pub fn run() -> i32 {\n    crate::engine::platform::inner::go()\n}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    caller = "rs_path_attr_modrs.src.a.run"
+    assert (caller, "rs_path_attr_modrs.src.platform.inner.go") in calls, calls
+    assert not [
+        pair for pair in calls if pair[0] == caller and "elsewhere" in pair[1]
+    ], calls
+
+
 def test_a_commented_out_redirect_does_not_hijack_a_live_declaration(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:

--- a/codebase_rag/tests/test_rust_path_attribute_mod.py
+++ b/codebase_rag/tests/test_rust_path_attribute_mod.py
@@ -142,6 +142,63 @@ def test_crate_path_resolves_through_a_redirected_module(
     ) not in calls, calls
 
 
+def test_crate_path_resolves_a_redirect_declared_outside_an_entry_file(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The redirect sits in src/engine.rs, an ordinary module file, so only
+    # the crate entry's declarations used to be consulted and the tail of
+    # the path attached by name. src/engine/rig.rs is present and declared
+    # by nobody, which is exactly where the name-derived spelling lands
+    # (issue #1065); rustc compiles src/fixtures/rig.rs.
+    project = temp_repo / "rs_path_attr_deep"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_path_attr_deep"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": "pub mod engine;\npub mod a;\n",
+            "src/engine.rs": ('#[path = "fixtures/rig.rs"]\npub mod rig;\n'),
+            "src/fixtures/rig.rs": "pub fn build() -> i32 {\n    2\n}\n",
+            "src/engine/rig.rs": "pub fn build() -> i32 {\n    9\n}\n",
+            "src/a.rs": ("pub fn go() -> i32 {\n    crate::engine::rig::build()\n}\n"),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    caller = "rs_path_attr_deep.src.a.go"
+    assert (caller, "rs_path_attr_deep.src.fixtures.rig.build") in calls, calls
+    assert (caller, "rs_path_attr_deep.src.engine.rig.build") not in calls, calls
+
+
+def test_a_relative_path_resolves_a_redirect_declared_beside_it(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `super::rig` from a sibling module reaches the same declaration by a
+    # different route, and that route never touched the entry map at all.
+    project = temp_repo / "rs_path_attr_super"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_path_attr_super"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": "pub mod engine;\n",
+            "src/engine.rs": (
+                '#[path = "fixtures/rig.rs"]\npub mod rig;\npub mod a;\n'
+            ),
+            "src/fixtures/rig.rs": "pub fn build() -> i32 {\n    2\n}\n",
+            "src/engine/rig.rs": "pub fn build() -> i32 {\n    9\n}\n",
+            "src/engine/a.rs": ("pub fn go() -> i32 {\n    super::rig::build()\n}\n"),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    caller = "rs_path_attr_super.src.engine.a.go"
+    assert (caller, "rs_path_attr_super.src.fixtures.rig.build") in calls, calls
+    assert (caller, "rs_path_attr_super.src.engine.rig.build") not in calls, calls
+
+
 def test_a_commented_out_redirect_does_not_hijack_a_live_declaration(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.553"
+version = "0.0.554"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #1065.

## Summary

`#[path = "..."]` on a `mod` declaration reached crate-path resolution only for declarations written in a crate ENTRY file. `_rust_attach` consulted the entry's redirect map for the FIRST path segment and then attached every segment after it by name, so a redirect declared in an ordinary module file was invisible.

The path then resolved to the name-derived qn, which either names nothing or names a different file that happens to sit where the declared name points. In the repro that file is `src/engine/rig.rs`, present and declared by nobody, while rustc compiles `src/fixtures/rig.rs`.

## Fix

`_rust_walk_mods` walks the path tail one segment at a time. For each segment it reads the declarations of the file backing the module accumulated so far (`src/engine.rs` or `src/engine/mod.rs`, whichever exists) and takes its redirect target when there is one. The walk stops at the first segment that backs no file, which is where the module tree ends and items begin.

Every site that joins a resolved module prefix to a tail routes through it: the entry redirect branch, the entry `mod` branch, the filesystem probe, the auto-target crate root, and the `super::`/`self::` relative resolver, which never consulted the entry map at all.

A redirect naming a `mod.rs` backs the DIRECTORY, and the qn scheme drops the `mod` segment, so the resulting parts look exactly like a plain file module. The walk carries that knowledge to the next hop, or it would read the sibling `<parts>.rs`, an undeclared shadow rustc never compiles into that path.

Module declarations are cached per module like the entry ones, cleared by `reset_rust_path_caches` and evicted per file by the watcher refresh. A failed read caches nothing, so a storm's transient absence does not bake in "this module declares nothing".

## Cost

Only redirects are read from a module file, and the declaration scan behind them is superlinear in file length: on a 178-file Rust repo one 34k-line generated module accounted for most of a 6.5x indexing regression. A linear prescan for the `#[path = "..."]` spelling in the raw source skips the lexer and the scan entirely for the files that have none, which is nearly all of them. Searching the raw source overshoots by the commented-out and quoted spellings, which merely fall through to the real scan; nothing it misses can be a redirect.

Measured on that repo, full rebuild, alternating in one process: new 305.2s / old 273.5s, then new 283.8s / old 310.0s. The ordering decides which wins, so the difference is noise; the CALLS edge set is byte-identical both rounds (only-new 0, only-old 0).

## Tests

Three RED tests, each proven to fail without the corresponding part of the fix:

- `test_crate_path_resolves_a_redirect_declared_outside_an_entry_file` covers `crate::engine::rig::build()`.
- `test_a_relative_path_resolves_a_redirect_declared_beside_it` covers `super::rig::build()` from a sibling module, a route that bypassed the entry map entirely.
- `test_a_redirect_onto_a_mod_rs_is_not_read_off_its_sibling_shadow` covers the directory-backed target; without the flag the walk reads the shadow's own redirect and the call edge disappears.

Each carries a decoy at the location the broken resolution lands on, so an implementation that resolves the redirect but keeps attaching by name fails them.

## Out of scope

- Redirects declared inside an inline `mod` block, whose base directory includes the inline chain. The gate side already reads those; the crate-path side keeps its current behaviour.
- The superlinear declaration scan itself, which entry files have always paid; the prescan above keeps this change from widening its reach.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Rust module resolution when modules use `#[path]` redirects.
  * Correctly follows redirects across nested modules, sibling paths, crate references, and relative paths.
  * Prevents incorrect resolution to shadow files when redirected targets are present.
  * Improved handling of file-backed and directory-backed modules.

* **Tests**
  * Added coverage for redirected modules, `super::` references, and `mod.rs` targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->