### PR TITLE
fix: bind a Rust impl block to the trait its own written path names

### DIFF
--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -280,6 +280,14 @@ class ClassIngestMixin:
         # for the trait.
         import_map = self.import_processor.import_mapping.get(module_qn, {})
         expanded = f"{import_map.get(head, head)}{cs.SEPARATOR_DOUBLE_COLON}{tail}"
+        if expanded.startswith(f"{self.project_name}{cs.SEPARATOR_DOT}"):
+            # A `use` of a first-party module, already rewritten to its qn:
+            # the binding says which module the head means, so the path is
+            # every bit as exact as the crate-relative spelling above.
+            return (
+                expanded.replace(cs.SEPARATOR_DOUBLE_COLON, cs.SEPARATOR_DOT),
+                anchored,
+            )
         crate = expanded.split(cs.SEPARATOR_DOUBLE_COLON, 1)[0]
         if crate in cs.RS_STDLIB_CRATES or (
             self.import_processor.rust_head_is_external_dep(crate, module_qn)
@@ -680,6 +688,31 @@ class ClassIngestMixin:
             stack.extend(implements_map.get(ancestor, []))
         return False
 
+    def _rust_reexport_target(self, entry: DeferredInherit) -> str | None:
+        """Where a `pub use` in the named module declares the parent.
+
+        `crate::Base` is a legal path for a trait the crate root re-exports,
+        and it is exact, but the trait registers where it is DECLARED. The
+        binding says where that is, so the written path still decides and no
+        project-wide sweep of the simple name has to (issue #1080). Only a
+        registered target answers: a re-export OUT of the project resolves
+        nowhere first-party, and guessing there would bind a decoy.
+        """
+        if entry.language != cs.SupportedLanguage.RUST:
+            return None
+        owner, _, item = entry.parent_qn.rpartition(cs.SEPARATOR_DOT)
+        bound = self.import_processor.import_mapping.get(owner, {}).get(item)
+        if not bound:
+            return None
+        target = (
+            bound
+            if bound.startswith(f"{self.project_name}{cs.SEPARATOR_DOT}")
+            else self.import_processor._rust_resolve_relative(
+                owner, bound.split(cs.SEPARATOR_DOUBLE_COLON), owner
+            )
+        )
+        return target if self.function_registry.get(target) is not None else None
+
     def _resolve_deferred_parent_qn(
         self, entry: DeferredInherit
     ) -> tuple[str, bool] | None:
@@ -717,6 +750,8 @@ class ClassIngestMixin:
             return None
         if self.function_registry.get(entry.parent_qn) is not None:
             return entry.parent_qn, False
+        if (followed := self._rust_reexport_target(entry)) is not None:
+            return followed, False
         if entry.alt_parent_qn is not None:
             # The written path was exact and still landed on nothing, which a
             # re-export does: `crate::Base` names the entry module while the

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -249,24 +249,43 @@ class ClassIngestMixin:
     def _resolve_to_qn(self, name: str, module_qn: str) -> str:
         return self._resolve_class_name(name, module_qn) or f"{module_qn}.{name}"
 
-    def _resolve_rust_trait_qn(self, path: str, name: str, module_qn: str) -> str:
-        """Qn for the trait an `impl ... for Type` block names.
+    def _resolve_rust_trait_qn(
+        self, path: str, name: str, module_qn: str
+    ) -> tuple[str, str | None]:
+        """Qn for the trait an `impl ... for Type` block names, and a fallback.
 
-        A crate-relative path names its trait outright, and resolving the
-        SIMPLE name instead ends in a project-wide sweep that any same-named
-        trait can answer: `impl crate::z::Base for S` recorded `a.Base`
-        (issue #1080). Every other head keeps the simple name, which is what
-        a `use` binds and what the external-trait check reads the spelling
-        for.
+        Resolving the SIMPLE name alone ends in a project-wide sweep that any
+        same-named trait can answer, so `impl crate::z::Base for S` recorded
+        `a.Base` (issue #1080). The written path outranks the sweep wherever
+        it says where to look: a crate-relative head names a first-party
+        module outright, and a head the toolchain or the manifest speaks for
+        names another crate's trait, which no first-party sweep may answer
+        for however the spelling collides.
+
+        The crate-relative answer carries the name-anchored one as a
+        fallback, since `crate::Base` for a re-exported trait names the entry
+        module while the trait registers where it is declared.
         """
-        head = path.split(cs.SEPARATOR_DOUBLE_COLON, 1)[0]
+        head, _, tail = path.partition(cs.SEPARATOR_DOUBLE_COLON)
+        anchored = self._resolve_to_qn(name, module_qn)
+        if not tail:
+            return anchored, None
         if head in (cs.RUST_CRATE_KEYWORD, cs.KEYWORD_SELF, cs.KEYWORD_SUPER):
             rewritten = self.import_processor._rewrite_rust_local_use_path(
                 path, module_qn
             )
-            if rewritten != path:
-                return rewritten
-        return self._resolve_to_qn(name, module_qn)
+            return (rewritten, anchored) if rewritten != path else (anchored, None)
+        # The head is itself a name a `use` may have bound (`use std::io;`
+        # then `impl io::Read`), and only the expanded crate says who speaks
+        # for the trait.
+        import_map = self.import_processor.import_mapping.get(module_qn, {})
+        expanded = f"{import_map.get(head, head)}{cs.SEPARATOR_DOUBLE_COLON}{tail}"
+        crate = expanded.split(cs.SEPARATOR_DOUBLE_COLON, 1)[0]
+        if crate in cs.RS_STDLIB_CRATES or (
+            self.import_processor.rust_head_is_external_dep(crate, module_qn)
+        ):
+            return expanded, None
+        return anchored, None
 
     def _ingest_cpp_module_declarations(
         self,
@@ -698,6 +717,14 @@ class ClassIngestMixin:
             return None
         if self.function_registry.get(entry.parent_qn) is not None:
             return entry.parent_qn, False
+        if entry.alt_parent_qn is not None:
+            # The written path was exact and still landed on nothing, which a
+            # re-export does: `crate::Base` names the entry module while the
+            # trait registers where it is declared. The second spelling gets
+            # the whole chain, not just the registry probe above.
+            return self._resolve_deferred_parent_qn(
+                entry._replace(parent_qn=entry.alt_parent_qn, alt_parent_qn=None)
+            )
         project_prefix = f"{self.project_name}{cs.SEPARATOR_DOT}"
         if not entry.parent_qn.startswith(project_prefix):
             external = entry.parent_qn.replace(
@@ -1190,7 +1217,7 @@ class ClassIngestMixin:
         impl_method_qns: list[str] = []
         trait_impl_method_qns: list[str] | None = None
         if trait_name := rs_utils.extract_impl_trait(class_node):
-            trait_qn = self._resolve_rust_trait_qn(
+            trait_qn, alt_trait_qn = self._resolve_rust_trait_qn(
                 rs_utils.extract_impl_trait_path(class_node) or trait_name,
                 trait_name,
                 owner_module_qn,
@@ -1206,6 +1233,7 @@ class ClassIngestMixin:
                 module_qn=owner_module_qn,
                 base_index=0,
                 language=cs.SupportedLanguage.RUST,
+                alt_parent_qn=alt_trait_qn,
             )
             self._deferred_inherits.append(trait_entry)
             # Collect this block's methods against the trait AS WRITTEN: if the

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -249,6 +249,25 @@ class ClassIngestMixin:
     def _resolve_to_qn(self, name: str, module_qn: str) -> str:
         return self._resolve_class_name(name, module_qn) or f"{module_qn}.{name}"
 
+    def _resolve_rust_trait_qn(self, path: str, name: str, module_qn: str) -> str:
+        """Qn for the trait an `impl ... for Type` block names.
+
+        A crate-relative path names its trait outright, and resolving the
+        SIMPLE name instead ends in a project-wide sweep that any same-named
+        trait can answer: `impl crate::z::Base for S` recorded `a.Base`
+        (issue #1080). Every other head keeps the simple name, which is what
+        a `use` binds and what the external-trait check reads the spelling
+        for.
+        """
+        head = path.split(cs.SEPARATOR_DOUBLE_COLON, 1)[0]
+        if head in (cs.RUST_CRATE_KEYWORD, cs.KEYWORD_SELF, cs.KEYWORD_SUPER):
+            rewritten = self.import_processor._rewrite_rust_local_use_path(
+                path, module_qn
+            )
+            if rewritten != path:
+                return rewritten
+        return self._resolve_to_qn(name, module_qn)
+
     def _ingest_cpp_module_declarations(
         self,
         root_node: Node,
@@ -1171,7 +1190,11 @@ class ClassIngestMixin:
         impl_method_qns: list[str] = []
         trait_impl_method_qns: list[str] | None = None
         if trait_name := rs_utils.extract_impl_trait(class_node):
-            trait_qn = self._resolve_to_qn(trait_name, owner_module_qn)
+            trait_qn = self._resolve_rust_trait_qn(
+                rs_utils.extract_impl_trait_path(class_node) or trait_name,
+                trait_name,
+                owner_module_qn,
+            )
             # The trait (or the impl target) may live in a file not yet
             # parsed; hold the IMPLEMENTS edge back for
             # resolve_deferred_inherits so an unresolvable trait

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -696,22 +696,33 @@ class ClassIngestMixin:
         binding says where that is, so the written path still decides and no
         project-wide sweep of the simple name has to (issue #1080). Only a
         registered target answers: a re-export OUT of the project resolves
-        nowhere first-party, and guessing there would bind a decoy.
+        nowhere first-party, and guessing there would bind a decoy. A facade
+        module that re-exports what it was itself given is the usual reason
+        the crate root can name the trait at all, so the chain is followed to
+        its end rather than one hop.
         """
         if entry.language != cs.SupportedLanguage.RUST:
             return None
-        owner, _, item = entry.parent_qn.rpartition(cs.SEPARATOR_DOT)
-        bound = self.import_processor.import_mapping.get(owner, {}).get(item)
-        if not bound:
-            return None
-        target = (
-            bound
-            if bound.startswith(f"{self.project_name}{cs.SEPARATOR_DOT}")
-            else self.import_processor._rust_resolve_relative(
-                owner, bound.split(cs.SEPARATOR_DOUBLE_COLON), owner
+        qn = entry.parent_qn
+        seen = {qn}
+        while True:
+            owner, _, item = qn.rpartition(cs.SEPARATOR_DOT)
+            bound = self.import_processor.import_mapping.get(owner, {}).get(item)
+            if not bound:
+                return None
+            qn = (
+                bound
+                if bound.startswith(f"{self.project_name}{cs.SEPARATOR_DOT}")
+                else self.import_processor._rust_resolve_relative(
+                    owner, bound.split(cs.SEPARATOR_DOUBLE_COLON), owner
+                )
             )
-        )
-        return target if self.function_registry.get(target) is not None else None
+            if qn in seen:
+                # Two modules re-exporting each other's name never declare it.
+                return None
+            seen.add(qn)
+            if self.function_registry.get(qn) is not None:
+                return qn
 
     def _resolve_deferred_parent_qn(
         self, entry: DeferredInherit

--- a/codebase_rag/parsers/rs/utils.py
+++ b/codebase_rag/parsers/rs/utils.py
@@ -307,7 +307,15 @@ def extract_impl_trait(impl_node: Node) -> str | None:
     # simple name (a trait impl means Type IMPLEMENTS Trait).
     if impl_node.type != cs.TS_IMPL_ITEM:
         return None
-    return _impl_field_type_name(impl_node, cs.FIELD_TRAIT)
+    if name := _impl_field_type_name(impl_node, cs.FIELD_TRAIT):
+        return name
+    # A generic wrapping a SCOPED path (`std::ops::Add<u32>`) is the one
+    # trait spelling the field walk reads no name off, and the whole block
+    # then read as no trait impl at all: no IMPLEMENTS edge, no implementer,
+    # no override for its methods. The written path's last segment is the
+    # simple name (issue #1080).
+    path = extract_impl_trait_path(impl_node)
+    return path.rsplit(cs.SEPARATOR_DOUBLE_COLON, 1)[-1] if path else None
 
 
 def extract_impl_trait_path(impl_node: Node) -> str | None:

--- a/codebase_rag/tests/test_rust_external_trait_impl_flag.py
+++ b/codebase_rag/tests/test_rust_external_trait_impl_flag.py
@@ -199,11 +199,18 @@ def test_generic_scoped_external_trait_impl_is_flagged(
     # extractor read nothing off, so the block reached none of this: no
     # RustTraitImpl was recorded and its methods stayed ordinary dead-code
     # candidates however plainly `std` speaks for the trait (issue #1080).
+    # `other::Add` is a same-named FIRST-PARTY trait, which the simple-name
+    # resolution behind the trait binding sweeps up project-wide. Letting it
+    # answer for `std::ops::Add` says `S` implements an unrelated trait,
+    # carries liveness in from that trait's method, and silences the external
+    # root this test is about. A head the toolchain speaks for settles it.
     props = _build(
         temp_repo / "rsgenericscoped",
         mock_ingestor,
         {
             "lib.rs": (
+                "pub mod other;\n"
+                "\n"
                 "pub struct S(u32);\n"
                 "\n"
                 "impl std::ops::Add<u32> for S {\n"
@@ -212,10 +219,21 @@ def test_generic_scoped_external_trait_impl_is_flagged(
                 "        S(self.0 + other)\n"
                 "    }\n"
                 "}\n"
-            )
+            ),
+            "other.rs": (
+                "pub trait Add<T> {\n    fn add(self, other: T) -> Self;\n}\n"
+            ),
         },
     )
     assert _prop(props, "S.add").get(cs.KEY_OVERRIDES_EXTERNAL) is True
+    # Nothing here overrides anything first-party: the only trait implemented
+    # belongs to std, and `other::Add` is a stranger that shares its name.
+    overrides = {
+        (call.args[0][2], call.args[2][2])
+        for call in mock_ingestor.ensure_relationship_batch.call_args_list
+        if call.args[1] == cs.RelationshipType.OVERRIDES.value
+    }
+    assert not overrides, overrides
 
 
 def test_first_party_trait_impl_is_not_flagged(

--- a/codebase_rag/tests/test_rust_external_trait_impl_flag.py
+++ b/codebase_rag/tests/test_rust_external_trait_impl_flag.py
@@ -192,6 +192,32 @@ def test_generic_external_trait_impl_is_flagged(
     assert _prop(props, "Seq.from_iter").get(cs.KEY_OVERRIDES_EXTERNAL) is True
 
 
+def test_generic_scoped_external_trait_impl_is_flagged(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # A generic wrapped around a SCOPED path is the spelling the trait-name
+    # extractor read nothing off, so the block reached none of this: no
+    # RustTraitImpl was recorded and its methods stayed ordinary dead-code
+    # candidates however plainly `std` speaks for the trait (issue #1080).
+    props = _build(
+        temp_repo / "rsgenericscoped",
+        mock_ingestor,
+        {
+            "lib.rs": (
+                "pub struct S(u32);\n"
+                "\n"
+                "impl std::ops::Add<u32> for S {\n"
+                "    type Output = S;\n"
+                "    fn add(self, other: u32) -> S {\n"
+                "        S(self.0 + other)\n"
+                "    }\n"
+                "}\n"
+            )
+        },
+    )
+    assert _prop(props, "S.add").get(cs.KEY_OVERRIDES_EXTERNAL) is True
+
+
 def test_first_party_trait_impl_is_not_flagged(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:

--- a/codebase_rag/tests/test_rust_trait_impl_override_edges.py
+++ b/codebase_rag/tests/test_rust_trait_impl_override_edges.py
@@ -199,8 +199,9 @@ def test_a_generic_scoped_trait_impl_implements_the_trait_it_names(
     # The block above needed a supertrait to reach `Base` at all: on its own,
     # `impl crate::b::Base<u32> for S` read as no trait impl whatsoever, so no
     # IMPLEMENTS edge was queued and no implementer recorded (issue #1080).
-    # `src/c.rs` declares a same-named trait the project-wide simple-name
-    # sweep answers with, so only reading the WRITTEN path lands on `b`.
+    # The decoy sits in `a` and the real target in `z`, so the project-wide
+    # simple-name sweep the old resolution ends in picks the wrong one and
+    # only reading the WRITTEN path lands on `z`.
     project = temp_repo / "rs_scoped_generic_implements"
     _write(
         project,
@@ -208,12 +209,12 @@ def test_a_generic_scoped_trait_impl_implements_the_trait_it_names(
             "Cargo.toml": (
                 '[package]\nname = "rs_scoped_generic_implements"\nversion = "0.1.0"\n'
             ),
-            "src/lib.rs": "pub mod b;\npub mod c;\npub mod foo;\n",
-            "src/b.rs": "pub trait Base<T> { fn run(&self) -> T; }\n",
-            "src/c.rs": "pub trait Base<T> { fn run(&self) -> T; }\n",
+            "src/lib.rs": "pub mod a;\npub mod z;\npub mod foo;\n",
+            "src/a.rs": "pub trait Base<T> { fn run(&self) -> T; }\n",
+            "src/z.rs": "pub trait Base<T> { fn run(&self) -> T; }\n",
             "src/foo.rs": (
                 "pub struct S;\n\n"
-                "impl crate::b::Base<u32> for S {\n"
+                "impl crate::z::Base<u32> for S {\n"
                 "    fn run(&self) -> u32 { 1 }\n"
                 "}\n"
             ),
@@ -223,10 +224,42 @@ def test_a_generic_scoped_trait_impl_implements_the_trait_it_names(
     base = "rs_scoped_generic_implements.src"
     implements = _pairs(mock_ingestor, RelationshipType.IMPLEMENTS.value)
     overrides = _overrides(mock_ingestor)
-    assert (f"{base}.foo.S", f"{base}.b.Base") in implements, implements
-    assert (f"{base}.foo.S", f"{base}.c.Base") not in implements, implements
-    assert (f"{base}.foo.S.run", f"{base}.b.Base.run") in overrides, overrides
-    assert (f"{base}.foo.S.run", f"{base}.c.Base.run") not in overrides, overrides
+    assert (f"{base}.foo.S", f"{base}.z.Base") in implements, implements
+    assert (f"{base}.foo.S", f"{base}.a.Base") not in implements, implements
+    assert (f"{base}.foo.S.run", f"{base}.z.Base.run") in overrides, overrides
+    assert (f"{base}.foo.S.run", f"{base}.a.Base.run") not in overrides, overrides
+
+
+def test_a_crate_path_to_a_re_exported_trait_keeps_its_edges(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `pub use inner::Base;` in the crate root makes `crate::Base` legal, but
+    # the trait registers where it is DECLARED. Reading the written path alone
+    # lands on the entry module, which holds no such node, so the exact answer
+    # has to fall back to the name-anchored one rather than emit nothing.
+    project = temp_repo / "rs_reexported_trait"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_reexported_trait"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": "pub mod inner;\npub mod foo;\npub use inner::Base;\n",
+            "src/inner.rs": "pub trait Base { fn run(&self) -> u32; }\n",
+            "src/foo.rs": (
+                "pub struct S;\n\n"
+                "impl crate::Base for S {\n"
+                "    fn run(&self) -> u32 { 1 }\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    base = "rs_reexported_trait.src"
+    implements = _pairs(mock_ingestor, RelationshipType.IMPLEMENTS.value)
+    overrides = _overrides(mock_ingestor)
+    assert (f"{base}.foo.S", f"{base}.inner.Base") in implements, implements
+    assert (f"{base}.foo.S.run", f"{base}.inner.Base.run") in overrides, overrides
 
 
 def test_a_plain_scoped_trait_impl_implements_the_trait_it_names(

--- a/codebase_rag/tests/test_rust_trait_impl_override_edges.py
+++ b/codebase_rag/tests/test_rust_trait_impl_override_edges.py
@@ -335,6 +335,44 @@ def test_a_re_exported_trait_resolves_through_the_binding_not_a_sweep(
     assert (f"{base}.foo.S.run", f"{base}.a.Base.run") not in overrides, overrides
 
 
+def test_a_re_export_of_a_re_export_still_reaches_the_declaring_module(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # A facade module that itself re-exports is the usual reason a crate root
+    # can say `pub use facade::Base`. Following one binding and stopping at an
+    # unregistered qn hands the rest of the chain back to the sweep.
+    project = temp_repo / "rs_reexport_chain_trait"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_reexport_chain_trait"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": (
+                "pub mod a;\npub mod facade;\npub mod inner;\npub mod foo;\n"
+                "pub use facade::Base;\n"
+            ),
+            "src/a.rs": "pub trait Base { fn run(&self) -> u32; }\n",
+            "src/facade.rs": "pub use crate::inner::Base;\n",
+            "src/inner.rs": "pub trait Base { fn run(&self) -> u32; }\n",
+            "src/foo.rs": (
+                "pub struct S;\n\n"
+                "impl crate::Base for S {\n"
+                "    fn run(&self) -> u32 { 1 }\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    base = "rs_reexport_chain_trait.src"
+    implements = _pairs(mock_ingestor, RelationshipType.IMPLEMENTS.value)
+    overrides = _overrides(mock_ingestor)
+    assert (f"{base}.foo.S", f"{base}.inner.Base") in implements, implements
+    assert (f"{base}.foo.S", f"{base}.a.Base") not in implements, implements
+    assert (f"{base}.foo.S.run", f"{base}.inner.Base.run") in overrides, overrides
+    assert (f"{base}.foo.S.run", f"{base}.a.Base.run") not in overrides, overrides
+
+
 def test_a_locally_bound_module_head_names_the_trait_it_was_bound_to(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:

--- a/codebase_rag/tests/test_rust_trait_impl_override_edges.py
+++ b/codebase_rag/tests/test_rust_trait_impl_override_edges.py
@@ -298,6 +298,80 @@ def test_a_plain_scoped_trait_impl_implements_the_trait_it_names(
     assert (f"{base}.foo.S.run", f"{base}.a.Base.run") not in overrides, overrides
 
 
+def test_a_re_exported_trait_resolves_through_the_binding_not_a_sweep(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `crate::Base` is exact about where to look, and the crate root's own
+    # `pub use` says where the trait is declared. Falling back to the simple
+    # name instead hands the choice to a project-wide sweep, which the decoy
+    # in `a` answers first.
+    project = temp_repo / "rs_reexport_decoy_trait"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_reexport_decoy_trait"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": (
+                "pub mod a;\npub mod inner;\npub mod foo;\npub use inner::Base;\n"
+            ),
+            "src/a.rs": "pub trait Base { fn run(&self) -> u32; }\n",
+            "src/inner.rs": "pub trait Base { fn run(&self) -> u32; }\n",
+            "src/foo.rs": (
+                "pub struct S;\n\n"
+                "impl crate::Base for S {\n"
+                "    fn run(&self) -> u32 { 1 }\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    base = "rs_reexport_decoy_trait.src"
+    implements = _pairs(mock_ingestor, RelationshipType.IMPLEMENTS.value)
+    overrides = _overrides(mock_ingestor)
+    assert (f"{base}.foo.S", f"{base}.inner.Base") in implements, implements
+    assert (f"{base}.foo.S", f"{base}.a.Base") not in implements, implements
+    assert (f"{base}.foo.S.run", f"{base}.inner.Base.run") in overrides, overrides
+    assert (f"{base}.foo.S.run", f"{base}.a.Base.run") not in overrides, overrides
+
+
+def test_a_locally_bound_module_head_names_the_trait_it_was_bound_to(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `use crate::z as alias;` then `impl alias::Base` is the same written
+    # path one indirection on, and the binding says exactly which module the
+    # head means. Testing the expansion only for externality throws that away
+    # and hands a first-party spelling back to the sweep, where the decoy in
+    # `a` answers first.
+    project = temp_repo / "rs_alias_scoped_implements"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_alias_scoped_implements"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": "pub mod a;\npub mod z;\npub mod foo;\n",
+            "src/a.rs": "pub trait Base { fn run(&self) -> u32; }\n",
+            "src/z.rs": "pub trait Base { fn run(&self) -> u32; }\n",
+            "src/foo.rs": (
+                "use crate::z as alias;\n\n"
+                "pub struct S;\n\n"
+                "impl alias::Base for S {\n"
+                "    fn run(&self) -> u32 { 1 }\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    base = "rs_alias_scoped_implements.src"
+    implements = _pairs(mock_ingestor, RelationshipType.IMPLEMENTS.value)
+    overrides = _overrides(mock_ingestor)
+    assert (f"{base}.foo.S", f"{base}.z.Base") in implements, implements
+    assert (f"{base}.foo.S", f"{base}.a.Base") not in implements, implements
+    assert (f"{base}.foo.S.run", f"{base}.z.Base.run") in overrides, overrides
+    assert (f"{base}.foo.S.run", f"{base}.a.Base.run") not in overrides, overrides
+
+
 def test_block_order_not_trait_name_decides_the_override_target(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:

--- a/codebase_rag/tests/test_rust_trait_impl_override_edges.py
+++ b/codebase_rag/tests/test_rust_trait_impl_override_edges.py
@@ -193,6 +193,78 @@ def test_a_scoped_generic_trait_impl_is_not_mistaken_for_inherent(
     assert (f"{base}.foo.S.go", f"{base}.foo.Alpha.go") in overrides, overrides
 
 
+def test_a_generic_scoped_trait_impl_implements_the_trait_it_names(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The block above needed a supertrait to reach `Base` at all: on its own,
+    # `impl crate::b::Base<u32> for S` read as no trait impl whatsoever, so no
+    # IMPLEMENTS edge was queued and no implementer recorded (issue #1080).
+    # `src/c.rs` declares a same-named trait the project-wide simple-name
+    # sweep answers with, so only reading the WRITTEN path lands on `b`.
+    project = temp_repo / "rs_scoped_generic_implements"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_scoped_generic_implements"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": "pub mod b;\npub mod c;\npub mod foo;\n",
+            "src/b.rs": "pub trait Base<T> { fn run(&self) -> T; }\n",
+            "src/c.rs": "pub trait Base<T> { fn run(&self) -> T; }\n",
+            "src/foo.rs": (
+                "pub struct S;\n\n"
+                "impl crate::b::Base<u32> for S {\n"
+                "    fn run(&self) -> u32 { 1 }\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    base = "rs_scoped_generic_implements.src"
+    implements = _pairs(mock_ingestor, RelationshipType.IMPLEMENTS.value)
+    overrides = _overrides(mock_ingestor)
+    assert (f"{base}.foo.S", f"{base}.b.Base") in implements, implements
+    assert (f"{base}.foo.S", f"{base}.c.Base") not in implements, implements
+    assert (f"{base}.foo.S.run", f"{base}.b.Base.run") in overrides, overrides
+    assert (f"{base}.foo.S.run", f"{base}.c.Base.run") not in overrides, overrides
+
+
+def test_a_plain_scoped_trait_impl_implements_the_trait_it_names(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # Without the generic wrapper the trait NAME does come out, but only as
+    # the bare `Base`, whose resolution ends in a project-wide sweep any
+    # same-named trait can answer. The decoy is deliberately in `a` and the
+    # real target in `z`, so the sweep's own ordering picks the wrong one and
+    # only the written path lands on the trait the block names.
+    project = temp_repo / "rs_scoped_plain_implements"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_scoped_plain_implements"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": "pub mod a;\npub mod z;\npub mod foo;\n",
+            "src/a.rs": "pub trait Base { fn run(&self) -> u32; }\n",
+            "src/z.rs": "pub trait Base { fn run(&self) -> u32; }\n",
+            "src/foo.rs": (
+                "pub struct S;\n\n"
+                "impl crate::z::Base for S {\n"
+                "    fn run(&self) -> u32 { 1 }\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    base = "rs_scoped_plain_implements.src"
+    implements = _pairs(mock_ingestor, RelationshipType.IMPLEMENTS.value)
+    overrides = _overrides(mock_ingestor)
+    assert (f"{base}.foo.S", f"{base}.z.Base") in implements, implements
+    assert (f"{base}.foo.S", f"{base}.a.Base") not in implements, implements
+    assert (f"{base}.foo.S.run", f"{base}.z.Base.run") in overrides, overrides
+    assert (f"{base}.foo.S.run", f"{base}.a.Base.run") not in overrides, overrides
+
+
 def test_block_order_not_trait_name_decides_the_override_target(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -666,6 +666,11 @@ class DeferredInherit(NamedTuple):
     own module qn as a guess; the edge is emitted after Pass 2 with the guess
     re-resolved against the full registry. An unresolvable parent emits no
     edge rather than a phantom the database would drop.
+
+    `alt_parent_qn` is a second spelling to try when the first names no
+    registered node: a written path can be exact about where to look and
+    still point at a module that only RE-EXPORTS the parent, where the
+    name-anchored guess is what finds the declaring one.
     """
 
     rel_type: RelationshipType
@@ -674,6 +679,7 @@ class DeferredInherit(NamedTuple):
     module_qn: str
     base_index: int
     language: SupportedLanguage
+    alt_parent_qn: str | None = None
 
 
 class RustTraitImpl(NamedTuple):

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.553"
+version = "0.0.554"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #1080.

## Summary

Two defects, one root: the trait an `impl ... for Type` block names was never read off the block's own written path.

**The block could read as no trait impl at all.** `extract_impl_trait` unwraps a `generic_type` only when its direct child is a `type_identifier`, so a generic wrapped around a scoped path (`impl std::ops::Add<u32> for S`, `impl<T> crate::al::Alpha<T> for S`) yielded `None` and the whole trait branch was skipped. No `IMPLEMENTS` edge was queued, no implementer recorded, no `RustTraitImpl` collected, and therefore no `OVERRIDES` edge for its methods and no external-trait flag either. The spellings are ordinary: `std::ops::Add`, `serde::de::Visitor`, any workspace trait reached by `crate::`.

**When the name did come out, it was only the simple name.** Resolving that ends in a project-wide sweep, so a same-named trait anywhere else could answer for it. On the fixture in the tests, `impl crate::z::Base for S` recorded `IMPLEMENTS a.Base`: a false edge, not a missing one.

## Fix

`extract_impl_trait` falls back to the last segment of the written path, which is the simple name by construction. Only the trait side changes; `extract_impl_target` keeps its behaviour, since a target written as a scoped path lives in another module and anchoring it here would mint a class qn no type owns.

`_resolve_rust_trait_qn` lets the written path outrank the sweep wherever it says where to look:

- A `crate::`/`super::`/`self::` head names a first-party module outright, so it resolves through the crate-path machinery.
- A head the toolchain or the manifest speaks for names another crate's trait, so no first-party sweep may answer for it however the spelling collides. The head is expanded through the import map first, since `use std::io;` then `impl io::Read` writes a head that stands for `std`.
- Anything else keeps the name-anchored resolution it has always had. An unresolved head is not evidence of externality (#1048), and rooting on it would hide a genuinely dead first-party trait impl.

The crate-relative answer carries the name-anchored one as a fallback, held on the deferred entry and tried when the first spelling names no registered node. `pub use inner::Base;` in the crate root makes `crate::Base` legal while the trait registers at `inner::Base`, and without the fallback that impl would lose both its edges.

## Consequence worth naming

Methods of a generic-scoped external trait impl now get `overrides_external`, so they root the dead-code walk instead of reporting dead. That follows from the block being recognised as a trait impl at all, and it is the same treatment `impl FromIterator<u8> for Seq` has had since #1048.

## Tests

Five tests, each proven to fail against the specific half of the fix it pins:

- `test_a_generic_scoped_trait_impl_implements_the_trait_it_names` had no `IMPLEMENTS` edge of any kind.
- `test_a_plain_scoped_trait_impl_implements_the_trait_it_names` recorded the decoy trait.
- `test_a_crate_path_to_a_re_exported_trait_keeps_its_edges` loses both edges without the fallback.
- `test_generic_scoped_external_trait_impl_is_flagged` covers the flag, and asserts no `OVERRIDES` edge at all, so the first-party decoy cannot answer for `std::ops::Add`.

- `test_a_locally_bound_module_head_names_the_trait_it_was_bound_to` covers `use crate::z as alias; impl alias::Base`, whose expansion was tested only for externality and then discarded back to the sweep.
- `test_a_re_exported_trait_resolves_through_the_binding_not_a_sweep` covers `pub use inner::Base;` with a decoy: the crate root's binding names the declaring module, so the fallback never decides.

Every decoy is placed so the sweep's own ordering picks the wrong one: the decoy sorts before the real target, or the broken build passes for the wrong reason.

Full unit suite: 6553 passed, 5 skipped. Baseline `main` collects 6552; this branch collects 6558, the difference being exactly these six new tests.

## Out of scope

- A non-keyword scoped head that is neither a stdlib crate nor a manifest-proven dependency (`some_mod::Trait`, where `some_mod` may be a local `mod`). It keeps its name-anchored resolution, because externalising on an unresolved head is the expensive error direction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Rust trait implementation detection for generic and scoped trait paths.
  * Correctly identifies external traits without confusing them with same-named local traits.
  * Preserves implementation and override relationships when traits are accessed through crate re-exports, chained re-exports, or local aliases.
  * Improves resolution when traits are referenced through alternate qualified paths.

* **Tests**
  * Added coverage for scoped, generic, external, aliased, and re-exported Rust trait implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->