### PR TITLE
fix: resolve super:: inside a Rust #[path] target against the module tree

### DIFF
--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -459,6 +459,7 @@ class ImportProcessor:
         "_rust_dir_listing",
         "_rust_entry_mod_decls",
         "_rust_module_mod_decls",
+        "_rust_redirect_parents",
         "_rust_explicit_targets",
         "_rust_auto_build_flags",
         "_rust_workspace_crates",
@@ -519,6 +520,10 @@ class ImportProcessor:
         self._rust_module_mod_decls: dict[
             tuple[tuple[str, ...], bool], tuple[RustEntryDecls, list[str]] | None
         ] = {}
+        # `#[path]` target qn -> the module that DECLARES it, for the `super::`
+        # climb inside such a file (issue #1083). Lazy: a file cannot say who
+        # declares it, so filling this at all means sweeping the repository.
+        self._rust_redirect_parents: dict[str, str] | None = None
         # Explicit Cargo target entry paths per package dir ([[bin]]/[lib]/
         # [[example]]/[[test]]/[[bench]] `path` overrides): such entries
         # root their own crates wherever they sit, unlike auto-targets
@@ -1745,6 +1750,88 @@ class ImportProcessor:
         self._rust_module_mod_decls[key] = found
         return found
 
+    def _rust_module_is_declared(self, parts: list[str]) -> bool:
+        """Whether this module's own physical neighbour declares it.
+
+        True of every ordinary module, which is what keeps the redirect sweep
+        off the hot path: only a file no neighbour declares can be the target
+        of a `#[path]` written somewhere else.
+        """
+        if not parts:
+            return False
+        parent, name = parts[:-1], parts[-1]
+        found = self._rust_module_decls(parent)
+        if found is not None and name in found[0].mods:
+            return True
+        return any(
+            name in decls.mods for decls in self._rust_entry_decls(parent).values()
+        )
+
+    def _rust_redirect_parent_map(self) -> dict[str, str]:
+        """Every `#[path]` target's qn, mapped to the module declaring it.
+
+        Built by one sweep of the repository's Rust sources: a file cannot say
+        who declares it, and the declaration may sit in any file at all. The
+        prescan is what keeps that affordable, since a source with no
+        `#[path = "..."]` anywhere in it costs one regex search and no more.
+        """
+        if self._rust_redirect_parents is not None:
+            return self._rust_redirect_parents
+        parents: dict[str, str] = {}
+        for dirpath, dirnames, filenames in os.walk(self.repo_path):
+            dirnames[:] = [
+                name
+                for name in dirnames
+                if name not in cs.IGNORE_PATTERNS
+                and not name.startswith(cs.SEPARATOR_DOT)
+            ]
+            for filename in filenames:
+                if not filename.endswith(cs.EXT_RS):
+                    continue
+                path = Path(dirpath, filename)
+                try:
+                    source = path.read_text(
+                        encoding=cs.RS_ENCODING_UTF8, errors="ignore"
+                    )
+                except OSError:
+                    continue
+                if _RS_PATH_ATTRIBUTE_PATTERN.search(source) is None:
+                    continue
+                try:
+                    dir_parts = list(path.relative_to(self.repo_path).parts[:-1])
+                except ValueError:
+                    continue
+                stem = filename[: -len(cs.EXT_RS)]
+                # A mod.rs IS its directory's module, so it contributes no
+                # segment of its own; every other file contributes its stem.
+                declarer = cs.SEPARATOR_DOT.join(
+                    [self.project_name, *dir_parts]
+                    if stem == cs.INDEX_MOD
+                    else [self.project_name, *dir_parts, stem]
+                )
+                decls = _rs_entry_decls_of(
+                    _rs_top_level_only(_rs_strip_comments_and_strings(source))
+                )
+                for redirect in decls.redirects.values():
+                    if target := rs_utils.path_attribute_qn_parts(dir_parts, redirect):
+                        key = cs.SEPARATOR_DOT.join([self.project_name, *target])
+                        parents[key] = declarer
+        self._rust_redirect_parents = parents
+        return parents
+
+    def _rust_logical_parent(self, module_qn: str) -> str | None:
+        """The module that declares this one, when `#[path]` moved its file.
+
+        The attribute moves the FILE, not the module's place in the tree, so
+        `super::` written inside the target means the DECLARING module rather
+        than a sibling of the file (issue #1083). An ordinary module is
+        declared by its own physical neighbour and answers None.
+        """
+        parts = module_qn.split(cs.SEPARATOR_DOT)[1:]
+        if not parts or self._rust_module_is_declared(parts):
+            return None
+        return self._rust_redirect_parent_map().get(module_qn)
+
     def _rust_walk_mods(
         self, parts: list[str], rest: list[str], dir_backed: bool = False
     ) -> list[str]:
@@ -1914,7 +2001,13 @@ class ImportProcessor:
             depth = 0
             while depth < len(parts) and parts[depth] == cs.KEYWORD_SUPER:
                 depth += 1
-            keep = max(len(base_parts) - depth, 1)
+            climbs = depth
+            if (logical := self._rust_logical_parent(module_qn)) is not None:
+                # The first `super` is the DECLARING module, which `#[path]`
+                # moved this file away from; any further ones climb from
+                # there, exactly as they would had the file never moved.
+                base_parts, climbs = logical.split(cs.SEPARATOR_DOT), depth - 1
+            keep = max(len(base_parts) - climbs, 1)
             base = cs.SEPARATOR_DOT.join(base_parts[:keep])
             return self._rust_resolve_relative(base, parts[depth:], module_qn)
         if (
@@ -2484,6 +2577,7 @@ class ImportProcessor:
         self._rust_dir_listing.clear()
         self._rust_entry_mod_decls.clear()
         self._rust_module_mod_decls.clear()
+        self._rust_redirect_parents = None
         self._rust_explicit_targets.clear()
         self._rust_auto_build_flags.clear()
         self._rust_workspace_crates = None

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -22,6 +22,7 @@ from ..types_defs import (
     FunctionSpanKey,
     LanguageQueries,
 )
+from ..utils.path_utils import has_ignored_dir_part
 from .cpp_frontend.qn import build_module_qn_map
 from .dart import dart_extract_uri, dart_local_name, dart_resolve_import
 from .go import discover_go_module_paths, resolve_go_import_path
@@ -518,7 +519,8 @@ class ImportProcessor:
         # directory its `#[path]` targets count from. Kept apart from the
         # entry map, whose every stem is a crate root candidate (issue #1065).
         self._rust_module_mod_decls: dict[
-            tuple[tuple[str, ...], bool], tuple[RustEntryDecls, list[str]] | None
+            tuple[tuple[str, ...], bool, bool],
+            tuple[RustEntryDecls, list[str]] | None,
         ] = {}
         # `#[path]` target qn -> the module that DECLARES it, for the `super::`
         # climb inside such a file (issue #1083). Lazy: a file cannot say who
@@ -1689,7 +1691,10 @@ class ImportProcessor:
         return decls
 
     def _rust_module_decls(
-        self, module_parts: list[str], dir_backed: bool = False
+        self,
+        module_parts: list[str],
+        dir_backed: bool = False,
+        want_mods: bool = False,
     ) -> tuple[RustEntryDecls, list[str]] | None:
         """Declarations of the file backing a module, and its `#[path]` base.
 
@@ -1698,9 +1703,10 @@ class ImportProcessor:
         Declaring both is a rustc error, so either may be preferred, EXCEPT
         when the caller already knows the module is directory-backed. None
         when no file backs the module: an inline `mod`, or a segment that was
-        never a module at all.
+        never a module at all. Only redirects survive the prescan below, so a
+        caller reading any other field must ask for the full scan.
         """
-        key = (tuple(module_parts), dir_backed)
+        key = (tuple(module_parts), dir_backed, want_mods)
         if key in self._rust_module_mod_decls:
             return self._rust_module_mod_decls[key]
         if not module_parts:
@@ -1731,7 +1737,7 @@ class ImportProcessor:
             # Uncached, so the next access retries: a storm's transient
             # absence must not bake in "this module declares nothing".
             return None
-        if _RS_PATH_ATTRIBUTE_PATTERN.search(source) is None:
+        if not want_mods and _RS_PATH_ATTRIBUTE_PATTERN.search(source) is None:
             # Only redirects are read here, and both the lexer and the
             # declaration scan behind them cost far more than this prescan
             # (the scan is superlinear in file length, so a 30k-line
@@ -1753,14 +1759,15 @@ class ImportProcessor:
     def _rust_module_is_declared(self, parts: list[str]) -> bool:
         """Whether this module's own physical neighbour declares it.
 
-        True of every ordinary module, which is what keeps the redirect sweep
-        off the hot path: only a file no neighbour declares can be the target
-        of a `#[path]` written somewhere else.
+        A file that is BOTH declared where it sits and named by a `#[path]`
+        elsewhere is an ordinary module of the tree its own declaration sits
+        in: rustc compiles it into both, and only the neighbour's spelling
+        keeps `super::` inside it pointing where the file physically is.
         """
         if not parts:
             return False
         parent, name = parts[:-1], parts[-1]
-        found = self._rust_module_decls(parent)
+        found = self._rust_module_decls(parent, want_mods=True)
         if found is not None and name in found[0].mods:
             return True
         return any(
@@ -1768,7 +1775,7 @@ class ImportProcessor:
         )
 
     def _rust_redirect_parent_map(self) -> dict[str, str]:
-        """Every `#[path]` target's qn, mapped to the module declaring it.
+        """Every moved module's qn, mapped to the module declaring it.
 
         Built by one sweep of the repository's Rust sources: a file cannot say
         who declares it, and the declaration may sit in any file at all. The
@@ -1779,28 +1786,32 @@ class ImportProcessor:
             return self._rust_redirect_parents
         parents: dict[str, str] = {}
         for dirpath, dirnames, filenames in os.walk(self.repo_path):
-            dirnames[:] = [
+            try:
+                here = Path(dirpath).relative_to(self.repo_path).parts
+            except ValueError:
+                continue
+            # Sorted so the tie-break below is the same on every filesystem,
+            # and pruned by the same predicate the indexer walks with, or a
+            # declaration under Cargo's src/bin/ (first-party, not build
+            # output) is missed for files the graph does hold.
+            dirnames[:] = sorted(
                 name
                 for name in dirnames
-                if name not in cs.IGNORE_PATTERNS
-                and not name.startswith(cs.SEPARATOR_DOT)
-            ]
-            for filename in filenames:
+                if not name.startswith(cs.SEPARATOR_DOT)
+                and not has_ignored_dir_part((*here, name))
+            )
+            for filename in sorted(filenames):
                 if not filename.endswith(cs.EXT_RS):
                     continue
-                path = Path(dirpath, filename)
                 try:
-                    source = path.read_text(
+                    source = Path(dirpath, filename).read_text(
                         encoding=cs.RS_ENCODING_UTF8, errors="ignore"
                     )
                 except OSError:
                     continue
                 if _RS_PATH_ATTRIBUTE_PATTERN.search(source) is None:
                     continue
-                try:
-                    dir_parts = list(path.relative_to(self.repo_path).parts[:-1])
-                except ValueError:
-                    continue
+                dir_parts = list(here)
                 stem = filename[: -len(cs.EXT_RS)]
                 # A mod.rs IS its directory's module, so it contributes no
                 # segment of its own; every other file contributes its stem.
@@ -1813,9 +1824,14 @@ class ImportProcessor:
                     _rs_top_level_only(_rs_strip_comments_and_strings(source))
                 )
                 for redirect in decls.redirects.values():
-                    if target := rs_utils.path_attribute_qn_parts(dir_parts, redirect):
-                        key = cs.SEPARATOR_DOT.join([self.project_name, *target])
-                        parents[key] = declarer
+                    target = rs_utils.path_attribute_qn_parts(dir_parts, redirect)
+                    if target is None or self._rust_module_is_declared(target):
+                        continue
+                    key = cs.SEPARATOR_DOT.join([self.project_name, *target])
+                    # Several files may name one target (a helper shared by
+                    # two binaries), and rustc compiles it into each tree.
+                    # The graph keys it once, so the walk order decides.
+                    parents.setdefault(key, declarer)
         self._rust_redirect_parents = parents
         return parents
 
@@ -1824,13 +1840,29 @@ class ImportProcessor:
 
         The attribute moves the FILE, not the module's place in the tree, so
         `super::` written inside the target means the DECLARING module rather
-        than a sibling of the file (issue #1083). An ordinary module is
-        declared by its own physical neighbour and answers None.
+        than a sibling of the file (issue #1083). An ordinary module answers
+        None, as does anything below a moved one: an inline `mod` inside the
+        target keeps its own place, and the climb reaches the declarer by
+        stepping through the file's module first.
         """
-        parts = module_qn.split(cs.SEPARATOR_DOT)[1:]
-        if not parts or self._rust_module_is_declared(parts):
-            return None
         return self._rust_redirect_parent_map().get(module_qn)
+
+    def _rust_super_base(self, module_qn: str, depth: int) -> str:
+        """Climb `depth` module parents from a module.
+
+        Each step asks who DECLARES the module rather than which directory
+        holds its file, and the declaring module may itself have been moved
+        by a `#[path]` of its own. Where none was, the two are the same.
+        """
+        parts = module_qn.split(cs.SEPARATOR_DOT)
+        for _ in range(depth):
+            if (
+                logical := self._rust_logical_parent(cs.SEPARATOR_DOT.join(parts))
+            ) is not None:
+                parts = logical.split(cs.SEPARATOR_DOT)
+            elif len(parts) > 1:
+                parts = parts[:-1]
+        return cs.SEPARATOR_DOT.join(parts)
 
     def _rust_walk_mods(
         self, parts: list[str], rest: list[str], dir_backed: bool = False
@@ -1997,18 +2029,10 @@ class ImportProcessor:
         if head == cs.KEYWORD_SELF:
             return self._rust_resolve_relative(module_qn, parts[1:], module_qn)
         if head == cs.KEYWORD_SUPER:
-            base_parts = module_qn.split(cs.SEPARATOR_DOT)
             depth = 0
             while depth < len(parts) and parts[depth] == cs.KEYWORD_SUPER:
                 depth += 1
-            climbs = depth
-            if (logical := self._rust_logical_parent(module_qn)) is not None:
-                # The first `super` is the DECLARING module, which `#[path]`
-                # moved this file away from; any further ones climb from
-                # there, exactly as they would had the file never moved.
-                base_parts, climbs = logical.split(cs.SEPARATOR_DOT), depth - 1
-            keep = max(len(base_parts) - climbs, 1)
-            base = cs.SEPARATOR_DOT.join(base_parts[:keep])
+            base = self._rust_super_base(module_qn, depth)
             return self._rust_resolve_relative(base, parts[depth:], module_qn)
         if (
             head not in local_mods
@@ -2624,7 +2648,14 @@ class ImportProcessor:
                 else (*dir_parts, file_path.stem)
             )
             for dir_backed in (False, True):
-                self._rust_module_mod_decls.pop((module, dir_backed), None)
+                for want_mods in (False, True):
+                    self._rust_module_mod_decls.pop(
+                        (module, dir_backed, want_mods), None
+                    )
+            # Whole-map, because the edit may have added or removed a
+            # redirect naming any file at all, and a stale declarer keeps
+            # `super::` in a file it no longer moves pointing at it.
+            self._rust_redirect_parents = None
         if (
             file_path.name in (cs.LIB_RS, cs.MAIN_RS)
             or file_path.name in self._rust_explicit_entry_files(tuple(dir_parts))

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -1803,37 +1803,50 @@ class ImportProcessor:
             for filename in sorted(filenames):
                 if not filename.endswith(cs.EXT_RS):
                     continue
-                try:
-                    source = Path(dirpath, filename).read_text(
-                        encoding=cs.RS_ENCODING_UTF8, errors="ignore"
-                    )
-                except OSError:
-                    continue
-                if _RS_PATH_ATTRIBUTE_PATTERN.search(source) is None:
-                    continue
-                dir_parts = list(here)
-                stem = filename[: -len(cs.EXT_RS)]
-                # A mod.rs IS its directory's module, so it contributes no
-                # segment of its own; every other file contributes its stem.
-                declarer = cs.SEPARATOR_DOT.join(
-                    [self.project_name, *dir_parts]
-                    if stem == cs.INDEX_MOD
-                    else [self.project_name, *dir_parts, stem]
-                )
-                decls = _rs_entry_decls_of(
-                    _rs_top_level_only(_rs_strip_comments_and_strings(source))
-                )
-                for redirect in decls.redirects.values():
-                    target = rs_utils.path_attribute_qn_parts(dir_parts, redirect)
-                    if target is None or self._rust_module_is_declared(target):
-                        continue
-                    key = cs.SEPARATOR_DOT.join([self.project_name, *target])
+                for key, declarer in self._rust_redirects_in(
+                    Path(dirpath, filename), list(here)
+                ):
                     # Several files may name one target (a helper shared by
                     # two binaries), and rustc compiles it into each tree.
                     # The graph keys it once, so the walk order decides.
                     parents.setdefault(key, declarer)
         self._rust_redirect_parents = parents
         return parents
+
+    def _rust_redirects_in(
+        self, path: Path, dir_parts: list[str]
+    ) -> list[tuple[str, str]]:
+        """Modules one file's `#[path]` attributes move, each with its declarer.
+
+        A target its own physical neighbour also declares is left out: rustc
+        compiles such a file into both trees, and the neighbour's spelling is
+        the one `super::` inside it counts from.
+        """
+        try:
+            source = path.read_text(encoding=cs.RS_ENCODING_UTF8, errors="ignore")
+        except OSError:
+            return []
+        if _RS_PATH_ATTRIBUTE_PATTERN.search(source) is None:
+            return []
+        # A mod.rs IS its directory's module, so it contributes no segment of
+        # its own; every other file contributes its stem.
+        declarer = cs.SEPARATOR_DOT.join(
+            [self.project_name, *dir_parts]
+            if path.stem == cs.INDEX_MOD
+            else [self.project_name, *dir_parts, path.stem]
+        )
+        decls = _rs_entry_decls_of(
+            _rs_top_level_only(_rs_strip_comments_and_strings(source))
+        )
+        moved = []
+        for redirect in decls.redirects.values():
+            target = rs_utils.path_attribute_qn_parts(dir_parts, redirect)
+            if target is None or self._rust_module_is_declared(target):
+                continue
+            moved.append(
+                (cs.SEPARATOR_DOT.join([self.project_name, *target]), declarer)
+            )
+        return moved
 
     def _rust_logical_parent(self, module_qn: str) -> str | None:
         """The module that declares this one, when `#[path]` moved its file.

--- a/codebase_rag/tests/test_rust_path_attribute_mod.py
+++ b/codebase_rag/tests/test_rust_path_attribute_mod.py
@@ -234,6 +234,65 @@ def test_a_redirect_onto_a_mod_rs_is_not_read_off_its_sibling_shadow(
     ], calls
 
 
+def test_super_inside_a_redirect_target_climbs_the_module_tree(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `#[path]` moves the FILE, not the module's place in the tree. `rig` is
+    # `crate::engine::rig`, so `super` is `engine` and `super::sib` is backed
+    # by src/engine/sib.rs. Popping a segment off the file's own qn lands on
+    # src/fixtures instead, where an undeclared shadow answers (issue #1083).
+    project = temp_repo / "rs_path_attr_super_target"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_path_attr_super_target"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": "pub mod engine;\n",
+            "src/engine.rs": '#[path = "fixtures/rig.rs"]\npub mod rig;\npub mod sib;\n',
+            "src/engine/sib.rs": "pub fn run() -> i32 {\n    1\n}\n",
+            "src/fixtures/sib.rs": "pub fn run() -> i32 {\n    9\n}\n",
+            "src/fixtures/rig.rs": (
+                "pub fn build() -> i32 {\n    super::sib::run()\n}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    caller = "rs_path_attr_super_target.src.fixtures.rig.build"
+    assert (caller, "rs_path_attr_super_target.src.engine.sib.run") in calls, calls
+    assert (caller, "rs_path_attr_super_target.src.fixtures.sib.run") not in calls, (
+        calls
+    )
+
+
+def test_super_from_an_ordinary_module_still_climbs_its_own_directory(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The redirect map must claim only files a redirect names. A plain module
+    # in the same directory keeps the physical climb, which for it IS the
+    # module tree.
+    project = temp_repo / "rs_path_attr_super_plain"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_path_attr_super_plain"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": "pub mod engine;\n",
+            "src/engine.rs": "pub mod rig;\npub mod sib;\n",
+            "src/engine/sib.rs": "pub fn run() -> i32 {\n    1\n}\n",
+            "src/engine/rig.rs": (
+                "pub fn build() -> i32 {\n    super::sib::run()\n}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    caller = "rs_path_attr_super_plain.src.engine.rig.build"
+    assert (caller, "rs_path_attr_super_plain.src.engine.sib.run") in calls, calls
+
+
 def test_a_commented_out_redirect_does_not_hijack_a_live_declaration(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:

--- a/codebase_rag/tests/test_rust_path_attribute_mod.py
+++ b/codebase_rag/tests/test_rust_path_attribute_mod.py
@@ -293,6 +293,199 @@ def test_super_from_an_ordinary_module_still_climbs_its_own_directory(
     assert (caller, "rs_path_attr_super_plain.src.engine.sib.run") in calls, calls
 
 
+def test_a_module_declared_where_it_sits_keeps_its_own_super(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # rustc compiles a file into every tree that declares it, and `helper` is
+    # declared by its own neighbour as well as aliased from `a`. The
+    # neighbour's spelling is the one `super::` inside it counts from, so an
+    # alias written anywhere else must not move it.
+    project = temp_repo / "rs_path_attr_super_alias"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_path_attr_super_alias"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": "pub mod a;\npub mod b;\n",
+            "src/b.rs": "pub mod helper;\npub mod sib;\n",
+            "src/b/sib.rs": "pub fn run() -> i32 {\n    1\n}\n",
+            "src/b/helper.rs": "pub fn build() -> i32 {\n    super::sib::run()\n}\n",
+            "src/a.rs": '#[path = "b/helper.rs"]\npub mod aliased;\npub mod sib;\n',
+            "src/a/sib.rs": "pub fn run() -> i32 {\n    9\n}\n",
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    caller = "rs_path_attr_super_alias.src.b.helper.build"
+    assert (caller, "rs_path_attr_super_alias.src.b.sib.run") in calls, calls
+    assert (caller, "rs_path_attr_super_alias.src.a.sib.run") not in calls, calls
+
+
+def test_super_super_from_a_redirect_target_climbs_declarer_by_declarer(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `b` is `crate::a::b` and `a` is `crate::a`, both moved, so the two
+    # climbs are one hop each through the declaring module and land on the
+    # crate root. Popping segments off the declarer's own path instead stops
+    # inside src/fx, where a shadow answers.
+    project = temp_repo / "rs_path_attr_super_nested"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_path_attr_super_nested"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": '#[path = "fx/a.rs"]\npub mod a;\npub mod top;\n',
+            "src/fx/a.rs": '#[path = "b.rs"]\npub mod b;\n',
+            "src/fx/b.rs": ("pub fn build() -> i32 {\n    super::super::top::f()\n}\n"),
+            "src/top.rs": "pub fn f() -> i32 {\n    1\n}\n",
+            "src/fx/top.rs": "pub fn f() -> i32 {\n    9\n}\n",
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    caller = "rs_path_attr_super_nested.src.fx.b.build"
+    assert (caller, "rs_path_attr_super_nested.src.top.f") in calls, calls
+    assert (caller, "rs_path_attr_super_nested.src.fx.top.f") not in calls, calls
+
+
+def test_super_from_an_inline_mod_inside_a_redirect_target_climbs_the_tree(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `#[cfg(test)] mod tests { use super::super::*; }` is the shape a
+    # `#[path]`-ed fixture file invites. The inline mod keeps its own place,
+    # so the first climb is the file's module and only the second is moved.
+    project = temp_repo / "rs_path_attr_super_inline"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_path_attr_super_inline"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": "pub mod engine;\n",
+            "src/engine.rs": '#[path = "fixtures/rig.rs"]\npub mod rig;\npub mod sib;\n',
+            "src/engine/sib.rs": "pub fn run() -> i32 {\n    1\n}\n",
+            "src/fixtures/sib.rs": "pub fn run() -> i32 {\n    9\n}\n",
+            "src/fixtures/rig.rs": (
+                "pub mod inner {\n"
+                "    use super::super::sib::run;\n"
+                "\n"
+                "    pub fn build() -> i32 {\n"
+                "        run()\n"
+                "    }\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    caller = "rs_path_attr_super_inline.src.fixtures.rig.inner.build"
+    assert (caller, "rs_path_attr_super_inline.src.engine.sib.run") in calls, calls
+    assert (caller, "rs_path_attr_super_inline.src.fixtures.sib.run") not in calls, (
+        calls
+    )
+
+
+def test_a_redirect_under_cargos_src_bin_still_moves_its_target(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `bin` is a build-output ignore EXCEPT directly under src/, where cargo
+    # keeps first-party binaries. The graph holds those files, so the sweep
+    # that reads their declarations has to walk there too.
+    project = temp_repo / "rs_path_attr_super_bin"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_path_attr_super_bin"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": "pub fn lib_root() -> i32 {\n    0\n}\n",
+            "src/bin/tool.rs": (
+                '#[path = "fx/rig.rs"]\nmod rig;\nmod sib;\nfn main() {}\n'
+            ),
+            "src/bin/tool/sib.rs": "pub fn run() -> i32 {\n    1\n}\n",
+            "src/bin/fx/sib.rs": "pub fn run() -> i32 {\n    9\n}\n",
+            "src/bin/fx/rig.rs": (
+                "pub fn build() -> i32 {\n    super::sib::run()\n}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    caller = "rs_path_attr_super_bin.src.bin.fx.rig.build"
+    assert (caller, "rs_path_attr_super_bin.src.bin.tool.sib.run") in calls, calls
+    assert (caller, "rs_path_attr_super_bin.src.bin.fx.sib.run") not in calls, calls
+
+
+def test_two_declarers_of_one_target_resolve_the_same_way_everywhere(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # A helper shared by two modules compiles into both trees, and the graph
+    # keys it once, so `super::` in it has to pick one. The pick is the walk
+    # order, which is sorted precisely so a developer machine and CI agree.
+    project = temp_repo / "rs_path_attr_super_dup"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_path_attr_super_dup"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": "pub mod alpha;\npub mod omega;\n",
+            "src/alpha.rs": (
+                '#[path = "fx/shared.rs"]\npub mod shared;\n'
+                "pub fn helper() -> i32 {\n    1\n}\n"
+            ),
+            "src/omega.rs": (
+                '#[path = "fx/shared.rs"]\npub mod shared;\n'
+                "pub fn helper() -> i32 {\n    2\n}\n"
+            ),
+            "src/fx/shared.rs": "pub fn build() -> i32 {\n    super::helper()\n}\n",
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    caller = "rs_path_attr_super_dup.src.fx.shared.build"
+    assert (caller, "rs_path_attr_super_dup.src.alpha.helper") in calls, calls
+    assert (caller, "rs_path_attr_super_dup.src.omega.helper") not in calls, calls
+
+
+def test_a_new_redirect_moves_its_target_for_the_watcher(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The realtime watcher re-parses without entering _process_files, so the
+    # per-run reset never fires. An edit that adds or drops a redirect
+    # changes who declares the target, and a stale map keeps `super::` in
+    # that file pointing where it no longer belongs.
+    project = temp_repo / "rs_path_attr_super_watch"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_path_attr_super_watch"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": "pub mod engine;\n",
+            "src/engine.rs": "pub mod sib;\n",
+            "src/engine/sib.rs": "pub fn run() -> i32 {\n    1\n}\n",
+            "src/fixtures/rig.rs": (
+                "pub fn build() -> i32 {\n    super::sib::run()\n}\n"
+            ),
+        },
+    )
+    updater = create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    processor = updater.factory.import_processor
+    target = "rs_path_attr_super_watch.src.fixtures.rig"
+    assert processor._rust_logical_parent(target) is None
+    engine = project / "src" / "engine.rs"
+    engine.write_text(
+        '#[path = "fixtures/rig.rs"]\npub mod rig;\npub mod sib;\n', encoding="utf-8"
+    )
+    processor.refresh_rust_path_caches_for(engine, created=False)
+    assert (
+        processor._rust_logical_parent(target) == "rs_path_attr_super_watch.src.engine"
+    )
+
+
 def test_a_commented_out_redirect_does_not_hijack_a_live_declaration(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.554"
+version = "0.0.555"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #1083.

## Summary

`#[path]` moves the FILE, not the module's position in the tree. cgr keys the module by where the file sits, which is the deliberate qn scheme (#1035), but `super::` written inside that file climbed the PHYSICAL path and bound a sibling of the target file.

```
src/lib.rs           pub mod engine;
src/engine.rs        #[path = "fixtures/rig.rs"]
                     pub mod rig;
                     pub mod sib;
src/engine/sib.rs    pub fn run() -> i32 { 1 }     // rustc's target
src/fixtures/sib.rs  pub fn run() -> i32 { 9 }     // declared by nobody
src/fixtures/rig.rs  pub fn build() -> i32 { super::sib::run() }
```

`rig`'s module path is `crate::engine::rig`, so `super` is `engine`. cgr bound `src.fixtures.sib.run`, the undeclared shadow.

## Fix

Every `super` step asks who DECLARES the module rather than which directory holds its file. For an ordinary module those are the same, so the climb is unchanged; for a moved one it lands on the declarer, and a declarer that was itself moved is followed the same way, one hop per `super`.

Answering that needs a reverse index, because a file cannot say who declares it and the declaration may sit in any file at all. Two things keep it affordable:

- The sweep reuses the `#[path = "..."]` prescan added in #1081, so a source with no such attribute anywhere in it costs one regex search and no lexing. Measured on a 182-file Rust repo whose worktree also holds a 174G untracked build tree: 1.07s, once per run, against an index measured in minutes. A repo without that tree: 0.017s.
- A target its own physical neighbour also declares never enters the index at all. rustc compiles such a file into both trees, and the neighbour's spelling is the one `super::` inside it counts from, so an alias written elsewhere must not move it.

The index is cached for the run, cleared with the other Rust path caches, and dropped whole on any `.rs` event the realtime watcher sees, since that edit may have added or removed a redirect naming any file at all.

The sweep walks with the same predicate the indexer uses, so a declaration under Cargo's `src/bin` (first-party binaries, not build output) is read, and it walks sorted, so a target named by two declarers resolves the same way on a developer machine and in CI.

## Tests

- `test_super_inside_a_redirect_target_climbs_the_module_tree` is the repro, with the decoy at the physical location. Without the decoy the edge lands correctly anyway, because the physical spelling resolves nowhere and a later fallback recovers it, so the decoy is what makes the test discriminate.
- `test_super_from_an_ordinary_module_still_climbs_its_own_directory` pins the unmoved climb.
- `test_a_module_declared_where_it_sits_keeps_its_own_super` pins the alias case: a module declared by its neighbour keeps the physical climb no matter who else names its file.
- `test_super_super_from_a_redirect_target_climbs_declarer_by_declarer` pins two moved hops, and `test_super_from_an_inline_mod_inside_a_redirect_target_climbs_the_tree` the `mod tests { use super::super::*; }` shape a moved fixture file invites.
- `test_a_redirect_under_cargos_src_bin_still_moves_its_target` and `test_two_declarers_of_one_target_resolve_the_same_way_everywhere` pin the walk.
- `test_a_new_redirect_moves_its_target_for_the_watcher` pins the eviction the realtime path needs.

## Out of scope

- A redirect written inside an inline `mod` block. The declaration scan keeps only depth-0 text, so those reach neither this index nor the crate-path side, which is the behaviour they had before.
- A CALL path (rather than a `use`) written with `super::` inside an inline `mod`, filed as #1086: the call resolver declines relative paths from a caller nested below the file module and matches by name instead, which predates this and is unchanged.
- The sweep honours the built-in ignore set but not `--exclude` or `.cgrignore`, filed as #1088.
- `self::` inside a redirected file, which is already right: a redirected module's children live relative to the target file, so the physical spelling is the module tree there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Rust module resolution for modules redirected with `#[path]`.
  * Corrected `super::` references across nested redirects, aliases, and inline modules.
  * Ensured resolution updates correctly when source files or redirects change.
  * Added deterministic handling for duplicate module declarations.

* **Tests**
  * Added coverage for redirected, inline, binary, nested, aliased, and ordinary Rust modules.
  * Added regression coverage for cache refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->