### PR TITLE
fix: resolve a Rust super:: call against the module the caller is really in

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -919,6 +919,7 @@ class CallProcessor:
         ast_cache: ASTCacheProtocol | None = None,
         go_package_names: Mapping[str, str] | None = None,
         rehydrated_definition_paths: dict[str, str] | None = None,
+        rust_function_modules: dict[str, str] | None = None,
     ) -> None:
         self.ingestor = ingestor
         self.repo_path = repo_path
@@ -957,6 +958,7 @@ class CallProcessor:
             type_aliases=type_aliases,
             interface_implementers=interface_implementers,
             rehydrated_definition_paths=rehydrated_definition_paths,
+            rust_function_modules=rust_function_modules,
         )
         # Inter-procedural callable-parameter flow: ordered params per function and
         # the per-call-site argument bindings, resolved to a fixpoint in finalize.

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -86,6 +86,7 @@ class CallResolver:
         "_pending_field_bindings",
         "_module_language_cache",
         "rehydrated_definition_paths",
+        "rust_function_modules",
     )
 
     def __init__(
@@ -97,6 +98,7 @@ class CallResolver:
         type_aliases: dict[str, str] | None = None,
         interface_implementers: dict[str, set[str]] | None = None,
         rehydrated_definition_paths: dict[str, str] | None = None,
+        rust_function_modules: dict[str, str] | None = None,
     ) -> None:
         self.function_registry = function_registry
         self.import_processor = import_processor
@@ -138,6 +140,12 @@ class CallResolver:
             rehydrated_definition_paths
             if rehydrated_definition_paths is not None
             else {}
+        )
+        # {Rust function qn: containing module qn}, recorded from the AST during
+        # ingestion (shared ref). The authority on how many levels a `super::`
+        # written inside it climbs (issue #1086).
+        self.rust_function_modules = (
+            rust_function_modules if rust_function_modules is not None else {}
         )
 
     def record_ctor_params(self, class_qn: str, params: tuple[str, ...]) -> None:
@@ -1539,17 +1547,24 @@ class CallResolver:
         module_qn: str,
         caller_qn: str | None,
     ) -> tuple[tuple[str, str] | None, bool]:
-        # crate:: is chain-independent; self::/super:: resolve against the
-        # caller's innermost enclosing MOD chain, which a caller nested
-        # below the file module (an inline mod or an impl block,
-        # indistinguishable in qn space) does not expose, so those stay
-        # with the ordinary fallbacks.
-        if object_path[0] != cs.RUST_CRATE_KEYWORD and self._rust_enclosing_scopes(
-            module_qn, caller_qn
-        ):
-            return None, False
+        # crate:: is chain-independent; self::/super:: count from the caller's
+        # enclosing MOD chain, which qn space cannot reconstruct -- an inline
+        # mod and an impl block are both a bare segment. The ingest pass walked
+        # the AST and recorded the answer, so read it (issue #1086).
+        effective_module = module_qn
+        if object_path[0] != cs.RUST_CRATE_KEYWORD:
+            recorded = self.rust_function_modules.get(caller_qn) if caller_qn else None
+            if recorded is None:
+                # No record: a caller the ingest pass never registered (a
+                # rehydrated definition, a body-local fn). Guessing the depth
+                # would mint a WRONG edge, so decline as before and let the
+                # ordinary fallbacks keep their weaker but safe answer.
+                if self._rust_enclosing_scopes(module_qn, caller_qn):
+                    return None, False
+            else:
+                effective_module = recorded
         base = self.import_processor._rewrite_rust_local_use_path(
-            cs.SEPARATOR_DOUBLE_COLON.join(object_path), module_qn
+            cs.SEPARATOR_DOUBLE_COLON.join(object_path), effective_module
         )
         if cs.SEPARATOR_DOUBLE_COLON in base:
             return None, False

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -188,6 +188,7 @@ class ClassIngestMixin:
     cpp_module_interfaces: set[str]
     _deferred_cpp_module_impls: list[tuple[str, str]]
     declared_module_qns: set[str]
+    rust_function_modules: dict[str, str]
     pending_endpoints: list[tuple[cs.NodeLabel, str, list[str], str | None]]
 
     def _namespace_qn(self, class_qn: str, module_qn: str) -> str:
@@ -1354,6 +1355,10 @@ class ClassIngestMixin:
             # its calls to this pass's twin.
             if ingested_qn is not None:
                 impl_method_qns.append(ingested_qn)
+                # An impl block is no module, so the method's `super::` counts
+                # from the impl's own enclosing module -- the file module unless
+                # the block sits in an inline `mod` (issue #1086).
+                self.rust_function_modules[ingested_qn] = owner_module_qn
                 span = function_span_key(module_qn, method_node)
                 if span not in self.function_locations:
                     self.function_locations[span] = FunctionLocation(
@@ -1505,6 +1510,15 @@ class ClassIngestMixin:
             ):
                 self.method_return_types[ingested_qn] = dart_return
             if ingested_qn is not None:
+                # Rust trait bodies reach here rather than the impl path above;
+                # a trait is no module either (issue #1086).
+                rs_utils.record_effective_module(
+                    self.rust_function_modules,
+                    ingested_qn,
+                    method_node,
+                    module_qn,
+                    language,
+                )
                 record_cpp_definition_span(
                     self.cpp_definition_spans,
                     language,

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -237,6 +237,11 @@ class DefinitionProcessor(
         # Inline (non-file) module qns, e.g. Rust `mod x {}`; deferred
         # import verification counts them as real internal targets.
         self.declared_module_qns: set[str] = set()
+        # {Rust function/method qn: the module qn it is contained by}, taken
+        # from the AST at ingest because qn space cannot distinguish an inline
+        # `mod` from an impl block. Pass-3 resolves `super::`/`self::` against
+        # it (issue #1086).
+        self.rust_function_modules: dict[str, str] = {}
         # Route-decorated handlers deferred from Pass 2: endpoint templates
         # need router mount prefixes, which may live in modules parsed later
         # (issue #877). (label, qn, route decorators, module_qn).

--- a/codebase_rag/parsers/factory.py
+++ b/codebase_rag/parsers/factory.py
@@ -164,5 +164,6 @@ class ProcessorFactory:
                 rehydrated_definition_paths=(
                     self.definition_processor.rehydrated_definition_paths
                 ),
+                rust_function_modules=(self.definition_processor.rust_function_modules),
             )
         return self._call_processor

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -239,6 +239,7 @@ class FunctionIngestMixin:
     function_locations: dict[FunctionSpanKey, FunctionLocation]
     cpp_definition_spans: dict[str, list[CppDefinitionSpan]]
     macro_qns: set[str]
+    rust_function_modules: dict[str, str]
     _deferred_js_anonymous: list[_DeferredRegistration]
     _deferred_rust_body_local: list[_DeferredRegistration]
     _deferred_cpp_artifacts: list[_DeferredCppArtifact]
@@ -1252,6 +1253,15 @@ class FunctionIngestMixin:
         )
 
         self.function_registry[resolution.qualified_name] = NodeType.FUNCTION
+        # Keyed by the UNIQUE qn, since a collision rename above (issue #1017)
+        # is the key Pass-3 will look this up by.
+        rs_utils.record_effective_module(
+            self.rust_function_modules,
+            resolution.qualified_name,
+            func_node,
+            module_qn,
+            language,
+        )
         if is_macro:
             self.macro_qns.add(resolution.qualified_name)
         self.function_registry.mark_callable_params(

--- a/codebase_rag/parsers/rs/utils.py
+++ b/codebase_rag/parsers/rs/utils.py
@@ -615,7 +615,7 @@ def record_effective_module(
     store: dict[str, str],
     qn: str,
     node: Node,
-    module_qn: str,
+    module_qn: str | None,
     language: cs.SupportedLanguage | None,
 ) -> None:
     """Record the MODULE a Rust item is contained by, keyed by its registered qn.
@@ -629,7 +629,9 @@ def record_effective_module(
     the same walk that builds the qn -- rather than re-derived at resolve time
     (issue #1086).
     """
-    if language != cs.SupportedLanguage.RUST:
+    if language != cs.SupportedLanguage.RUST or module_qn is None:
+        # No module to count from: recording the mod chain alone would key a
+        # relative fragment the resolver would read as an absolute qn.
         return
     mod_parts = build_module_path(node)
     store[qn] = (

--- a/codebase_rag/parsers/rs/utils.py
+++ b/codebase_rag/parsers/rs/utils.py
@@ -611,6 +611,34 @@ def enclosing_mod_fn_spans(node: Node) -> list[tuple[int, int]]:
     return spans
 
 
+def record_effective_module(
+    store: dict[str, str],
+    qn: str,
+    node: Node,
+    module_qn: str,
+    language: cs.SupportedLanguage | None,
+) -> None:
+    """Record the MODULE a Rust item is contained by, keyed by its registered qn.
+
+    `super::`/`self::` count from the innermost enclosing `mod`, which an impl
+    block is NOT, and qn space cannot tell the two apart: an inline mod and an
+    impl target are both a bare segment, and an impl target the graph never
+    registers (`impl Serialize for Vec<u8>`) is indistinguishable from a mod by
+    lookup alone. Guessing wrong climbs one level too few and mints a WRONG
+    edge, which revives dead code, so the answer is taken from the AST here --
+    the same walk that builds the qn -- rather than re-derived at resolve time
+    (issue #1086).
+    """
+    if language != cs.SupportedLanguage.RUST:
+        return
+    mod_parts = build_module_path(node)
+    store[qn] = (
+        module_qn + cs.SEPARATOR_DOT + cs.SEPARATOR_DOT.join(mod_parts)
+        if mod_parts
+        else module_qn
+    )
+
+
 def build_module_path(
     node: Node,
     include_impl_targets: bool = False,

--- a/codebase_rag/tests/test_rust_path_attribute_mod.py
+++ b/codebase_rag/tests/test_rust_path_attribute_mod.py
@@ -764,3 +764,74 @@ def test_redirect_inside_an_inline_module_gates_the_file_it_names(
     create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
     gates = _declared_gates(mock_ingestor, "rs_path_attr_inline.src.lib")
     assert "rs_path_attr_inline.src.outer.redirected" in gates, gates
+
+
+def test_a_super_call_from_an_inline_mod_resolves_through_the_written_path(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The same climb as the `use` above, written at the CALL instead. The
+    # resolver used to decline every relative path from a caller nested below
+    # the file module, because an inline mod and an impl block are one shape in
+    # qn space, and the enclosing-scope fallback then matched the tail by NAME
+    # against the file's own physical ancestors -- landing on the undeclared
+    # shadow that happens to sit there (issue #1086).
+    project = temp_repo / "rs_inline_super_call"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_inline_super_call"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": "pub mod engine;\n",
+            "src/engine.rs": '#[path = "fixtures/rig.rs"]\npub mod rig;\npub mod sib;\n',
+            "src/engine/sib.rs": "pub fn run() -> i32 {\n    1\n}\n",
+            "src/fixtures/sib.rs": "pub fn run() -> i32 {\n    9\n}\n",
+            "src/fixtures/rig.rs": (
+                "pub mod inner {\n"
+                "    pub fn build() -> i32 {\n"
+                "        super::super::sib::run()\n"
+                "    }\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    caller = "rs_inline_super_call.src.fixtures.rig.inner.build"
+    assert (caller, "rs_inline_super_call.src.engine.sib.run") in calls, calls
+    assert (caller, "rs_inline_super_call.src.fixtures.sib.run") not in calls, calls
+
+
+def test_a_super_call_from_a_cfg_test_mod_resolves_through_the_written_path(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `#[cfg(test)] mod tests { ... super::super::... }` inside a `#[path]`-ed
+    # fixture file is the shape that reaches this most often (issue #1086). The
+    # gate makes no difference to the climb: `tests` is an inline mod like any
+    # other, so the first hop is the file's module and only the second is moved.
+    project = temp_repo / "rs_cfg_test_super_call"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_cfg_test_super_call"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": "pub mod engine;\n",
+            "src/engine.rs": '#[path = "fixtures/rig.rs"]\npub mod rig;\npub mod sib;\n',
+            "src/engine/sib.rs": "pub fn run() -> i32 {\n    1\n}\n",
+            "src/fixtures/sib.rs": "pub fn run() -> i32 {\n    9\n}\n",
+            "src/fixtures/rig.rs": (
+                "#[cfg(test)]\n"
+                "mod tests {\n"
+                "    pub fn check() -> i32 {\n"
+                "        super::super::sib::run()\n"
+                "    }\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    caller = "rs_cfg_test_super_call.src.fixtures.rig.tests.check"
+    assert (caller, "rs_cfg_test_super_call.src.engine.sib.run") in calls, calls
+    assert (caller, "rs_cfg_test_super_call.src.fixtures.sib.run") not in calls, calls

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.557"
+version = "0.0.558"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #1086.

## The defect

`_resolve_rust_prefixed_path` declined every `self::`/`super::` path written by a caller nested below the file module:

```python
if object_path[0] != cs.RUST_CRATE_KEYWORD and self._rust_enclosing_scopes(
    module_qn, caller_qn
):
    return None, False
```

The call then fell to the enclosing-scope walk, which matches the tail by NAME against each ancestor of the file's own qn. That agrees with rustc whenever the file sits where its module sits — which is why the ordinary case looks fine — and answers with whatever same-named module happens to sit in a physical ancestor when a `#[path]` moved it:

```
recorded: rs.src.fixtures.rig.inner.build -> rs.src.fixtures.sib.run
rustc:    rs.src.fixtures.rig.inner.build -> rs.src.engine.sib.run
```

`src/fixtures/sib.rs` is declared by nobody. A wrong CALLS edge revives dead code, so this is the expensive failure direction, not a missing-edge one.

## Why the obvious discriminator does not work

The decline is not laziness — an inline `mod` and an impl block are the same shape in qn space, and they count differently: `super::` inside `mod inner` counts from `inner`, while inside `impl S` it counts from the FILE module, because an impl block is not a module.

The registry looks like it could tell them apart, and cannot. `None` means "not registered", which covers inline mods AND any impl target the graph does not hold, so `impl Serialize for Vec<u8>` in a file that also writes `super::` would read as an inline module named `Vec` and every `super::` in that block would climb one level too few.

## The fix

The authoritative answer is the AST, and the ingest pass is already standing on it: `rs_utils.build_module_path` walks the enclosing `mod` chain (impl targets excluded) to build the function's own qn. Record what it found, keyed by the registered qn, and have the resolver read it instead of guessing.

From there the existing use-side machinery does the rest. `_rewrite_rust_local_use_path` documents that exact contract — *"module_qn must be the EFFECTIVE module of the use declaration, including inline `mod` blocks"* — and its `super::` branch climbs through `_rust_super_base`, declarer by declarer (#1085), so a `#[path]` anywhere along the chain is honoured. Tracing the repro: from `…fixtures.rig.inner`, hop one strips to `…fixtures.rig`, hop two finds `rig`'s declarer and yields `…src.engine`.

Recorded at three sites, covering free functions (keyed by the UNIQUE qn, since a collision rename per #1017 is the key Pass 3 looks up by), impl methods, and trait bodies. A caller with no record — rehydrated from the graph, or body-local — declines exactly as before rather than guessing a depth.

## Tests

Two, both on the `#[path]` fixture shape the issue names:

- the issue's repro, `super::super::sib::run()` written at the call from an inline mod
- the same climb from `#[cfg(test)] mod tests { … }`, which the issue calls out as where this is written most often

Both assert the shadow is NOT bound, not merely that the right target is.

## Found while fixing this, filed separately

**#1093** — a `super::item()` call whose tail resolves in the caller's own module is decided by `_try_resolve_via_imports` before the Rust module-qualified probe runs, so it never reaches this resolver at all and the `super::` is ignored. Confirmed independent by execution: forcing this PR's table empty leaves that edge byte-identical. `self::item()` has the same shape.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Rust call resolution for `self::` and `super::` paths in nested, inline, trait, and redirected modules.
  - Prevented incorrect resolution through physical-path shadows when module context is ambiguous.
  - Preserved reliable resolution for `crate::` paths.
  - Improved module-context handling for Rust functions and methods.

- **Tests**
  - Added regression coverage for nested Rust modules and `#[path]`-redirected files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->