### PR TITLE
fix(mcp): stop marking orchestrator/cypher API keys required in server.json

### DIFF
--- a/codebase_rag/tests/test_server_manifest.py
+++ b/codebase_rag/tests/test_server_manifest.py
@@ -1,0 +1,23 @@
+"""server.json must not mark an env var isRequired when the runtime can start without it."""
+
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _env_vars() -> dict[str, dict[str, object]]:
+    manifest = json.loads((REPO_ROOT / "server.json").read_text())
+    variables = manifest["packages"][0]["environmentVariables"]
+    return {entry["name"]: entry for entry in variables}
+
+
+class TestApiKeyEnvVarsNotUnconditionallyRequired:
+    """isRequired can't express "required unless ollama"
+    (test_local_providers_skip_validation), so it must be False."""
+
+    def test_orchestrator_api_key_not_marked_required(self) -> None:
+        assert _env_vars()["ORCHESTRATOR_API_KEY"]["isRequired"] is False
+
+    def test_cypher_api_key_not_marked_required(self) -> None:
+        assert _env_vars()["CYPHER_API_KEY"]["isRequired"] is False

--- a/server.json
+++ b/server.json
@@ -38,8 +38,8 @@
         },
         {
           "name": "ORCHESTRATOR_API_KEY",
-          "description": "API key for the orchestrator LLM provider",
-          "isRequired": true,
+          "description": "API key for the orchestrator LLM provider (not required when ORCHESTRATOR_PROVIDER is ollama)",
+          "isRequired": false,
           "isSecret": true
         },
         {
@@ -54,8 +54,8 @@
         },
         {
           "name": "CYPHER_API_KEY",
-          "description": "API key for the Cypher LLM provider",
-          "isRequired": true,
+          "description": "API key for the Cypher LLM provider (not required when CYPHER_PROVIDER is ollama)",
+          "isRequired": false,
           "isSecret": true
         },
         {


### PR DESCRIPTION
`ModelConfig.validate_api_key()` already skips the check entirely for a local provider (`test_local_providers_skip_validation` in `test_config_validation.py`): with `ORCHESTRATOR_PROVIDER`/`CYPHER_PROVIDER` set to `ollama`, the orchestrator and Cypher agents start with no API key at all. `server.json` marked `ORCHESTRATOR_API_KEY` and `CYPHER_API_KEY` as `isRequired: true` unconditionally, so an MCP client (Claude Desktop, etc.) blocks a user from configuring the server with Ollama unless they supply a key the runtime never checks.

The MCP manifest schema has no way to express "required unless ollama", so the correct value is `isRequired: false`, leaving the actual requirement to `validate_api_key()`'s own error message when a key really is missing. Both descriptions now say when the key is not required.

Fixes #1062.

## Verification

- Added `test_server_manifest.py`, asserting both flags are `false`: fails against unmodified `server.json` (`isRequired: true`), passes after the fix.
- `uv run pytest codebase_rag/tests/test_server_manifest.py codebase_rag/tests/test_config_validation.py codebase_rag/tests/test_mcp_server.py` (33 tests) passes.
- `uv run ruff check .`, `uv run ruff format --check .`, `uv run ty check` all clean.
- Did not check whether an MCP client actually surfaces `isRequired` in its setup UI the way the issue describes; verified only that the manifest now matches the runtime's own documented, tested behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added validation to ensure the orchestrator and Cypher API keys are treated as optional in the server configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->