### PR TITLE
fix: prune the Rust redirect sweep with the indexer's exclude and unignore predicate

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -81,10 +81,9 @@ from .utils.dependencies import has_semantic_dependencies
 from .utils.fqn_resolver import find_function_source_by_fqn
 from .utils.path_utils import (
     cached_relative_path,
-    matches_ignore_patterns,
+    should_keep_dir,
     should_skip_path,
     should_skip_rel_file,
-    unignore_could_match_within,
 )
 from .utils.source_extraction import extract_source_with_fallback
 
@@ -1480,28 +1479,8 @@ class GraphUpdater:
         return None, None
 
     def _should_keep_dir(self, dirname: str, dir_prefix: str) -> bool:
-        rel_dir = f"{dir_prefix}{dirname}"
-        # an explicit exclude can never be rescued by unignore (excludes win
-        # at the file level too), so prune the subtree outright.
-        if self.exclude_paths and matches_ignore_patterns(
-            f"{rel_dir}/", self.exclude_paths
-        ):
-            return False
-        if dirname not in cs.IGNORE_PATTERNS:
-            return True
-        # Cargo's src/bin/ holds first-party binaries, not build output;
-        # mirrors has_ignored_dir_part.
-        if (
-            dirname == cs.DIR_BIN
-            and dir_prefix.rstrip(cs.SEPARATOR_SLASH).rsplit(cs.SEPARATOR_SLASH, 1)[-1]
-            == cs.DIR_SRC
-        ):
-            return True
-        return bool(
-            self.unignore_paths
-            and any(
-                unignore_could_match_within(u, rel_dir) for u in self.unignore_paths
-            )
+        return should_keep_dir(
+            dirname, dir_prefix, self.exclude_paths, self.unignore_paths
         )
 
     def _drop_cache_if_graph_lost(self) -> None:

--- a/codebase_rag/parsers/factory.py
+++ b/codebase_rag/parsers/factory.py
@@ -79,6 +79,8 @@ class ProcessorFactory:
                 project_name=self.project_name,
                 ingestor=self.ingestor,
                 function_registry=self.function_registry,
+                exclude_paths=self.exclude_paths,
+                unignore_paths=self.unignore_paths,
             )
         return self._import_processor
 

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -3,7 +3,7 @@ import os
 import posixpath
 import re
 import tomllib
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
 from functools import lru_cache
 from pathlib import Path
 from typing import NamedTuple
@@ -1812,26 +1812,35 @@ class ImportProcessor:
                     name, dir_prefix, self.exclude_paths, self.unignore_paths
                 )
             )
-            for filename in sorted(filenames):
-                if not filename.endswith(cs.EXT_RS):
-                    continue
-                if should_skip_rel_file(
-                    f"{dir_prefix}{filename}",
-                    here,
-                    cs.EXT_RS,
-                    exclude_paths=self.exclude_paths,
-                    unignore_paths=self.unignore_paths,
-                ):
-                    continue
-                for key, declarer in self._rust_redirects_in(
-                    Path(dirpath, filename), list(here)
-                ):
+            for path in self._swept_rust_files(dirpath, dir_prefix, here, filenames):
+                for key, declarer in self._rust_redirects_in(path, list(here)):
                     # Several files may name one target (a helper shared by
                     # two binaries), and rustc compiles it into each tree.
                     # The graph keys it once, so the walk order decides.
                     parents.setdefault(key, declarer)
         self._rust_redirect_parents = parents
         return parents
+
+    def _swept_rust_files(
+        self,
+        dirpath: str,
+        dir_prefix: str,
+        here: tuple[str, ...],
+        filenames: list[str],
+    ) -> Iterator[Path]:
+        """One directory's Rust sources the indexer would hold, sorted."""
+        for filename in sorted(filenames):
+            if not filename.endswith(cs.EXT_RS):
+                continue
+            if should_skip_rel_file(
+                f"{dir_prefix}{filename}",
+                here,
+                cs.EXT_RS,
+                exclude_paths=self.exclude_paths,
+                unignore_paths=self.unignore_paths,
+            ):
+                continue
+            yield Path(dirpath, filename)
 
     def _rust_redirects_in(
         self, path: Path, dir_parts: list[str]

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -22,7 +22,7 @@ from ..types_defs import (
     FunctionSpanKey,
     LanguageQueries,
 )
-from ..utils.path_utils import has_ignored_dir_part
+from ..utils.path_utils import should_keep_dir, should_skip_rel_file
 from .cpp_frontend.qn import build_module_qn_map
 from .dart import dart_extract_uri, dart_local_name, dart_resolve_import
 from .go import discover_go_module_paths, resolve_go_import_path
@@ -440,6 +440,8 @@ class ImportProcessor:
         "project_name",
         "ingestor",
         "function_registry",
+        "exclude_paths",
+        "unignore_paths",
         "import_mapping",
         "commonjs_direct_exports",
         "conditional_imports",
@@ -485,11 +487,17 @@ class ImportProcessor:
         project_name: str,
         ingestor: IngestorProtocol | None = None,
         function_registry: FunctionRegistryTrieProtocol | None = None,
+        exclude_paths: frozenset[str] | None = None,
+        unignore_paths: frozenset[str] | None = None,
     ) -> None:
         self.repo_path = repo_path
         self.project_name = project_name
         self.ingestor = ingestor
         self.function_registry = function_registry
+        # The same sets the indexer walks with, so the redirect sweep sees
+        # exactly the files the graph holds (issue #1088).
+        self.exclude_paths = exclude_paths
+        self.unignore_paths = unignore_paths
         self.import_mapping: dict[str, dict[str, str]] = {}
         # CommonJS modules whose ENTIRE export is one function
         # (`module.exports = function (...) {...}`): module qn -> the
@@ -1791,17 +1799,29 @@ class ImportProcessor:
             except ValueError:
                 continue
             # Sorted so the tie-break below is the same on every filesystem,
-            # and pruned by the same predicate the indexer walks with, or a
-            # declaration under Cargo's src/bin/ (first-party, not build
-            # output) is missed for files the graph does hold.
+            # and pruned by the very predicate the indexer walks with: a
+            # declaration in a subtree the user excluded must claim nothing,
+            # and one in a subtree `.cgrignore` rescued must be read, or
+            # `super::` in the target counts from the wrong module (issue
+            # #1088). Cargo's src/bin/ carve-out rides along (issue #1085).
+            dir_prefix = f"{'/'.join(here)}/" if here else ""
             dirnames[:] = sorted(
                 name
                 for name in dirnames
-                if not name.startswith(cs.SEPARATOR_DOT)
-                and not has_ignored_dir_part((*here, name))
+                if should_keep_dir(
+                    name, dir_prefix, self.exclude_paths, self.unignore_paths
+                )
             )
             for filename in sorted(filenames):
                 if not filename.endswith(cs.EXT_RS):
+                    continue
+                if should_skip_rel_file(
+                    f"{dir_prefix}{filename}",
+                    here,
+                    cs.EXT_RS,
+                    exclude_paths=self.exclude_paths,
+                    unignore_paths=self.unignore_paths,
+                ):
                     continue
                 for key, declarer in self._rust_redirects_in(
                     Path(dirpath, filename), list(here)

--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -254,7 +254,11 @@ def run_updater(
 
 
 def create_and_run_updater(
-    repo_path: Path, mock_ingestor: MagicMock, skip_if_missing: str | None = None
+    repo_path: Path,
+    mock_ingestor: MagicMock,
+    skip_if_missing: str | None = None,
+    exclude_paths: frozenset[str] | None = None,
+    unignore_paths: frozenset[str] | None = None,
 ) -> GraphUpdater:
     parsers, queries = load_parsers()
     if skip_if_missing and skip_if_missing not in parsers:
@@ -264,6 +268,8 @@ def create_and_run_updater(
         repo_path=repo_path,
         parsers=parsers,
         queries=queries,
+        exclude_paths=exclude_paths,
+        unignore_paths=unignore_paths,
     )
     updater.run()
     _audit_recorded_graph(mock_ingestor)

--- a/codebase_rag/tests/test_rust_redirect_sweep_ignore_filters.py
+++ b/codebase_rag/tests/test_rust_redirect_sweep_ignore_filters.py
@@ -1,0 +1,132 @@
+"""The `#[path]` redirect sweep must see exactly what the indexer indexes.
+
+The sweep walks the repository for redirect declarations and prunes with
+the built-in ignore set alone, while the indexer also honours `--exclude`
+and `.cgrignore` rescues (issue #1088). A declaration inside an excluded
+subtree then claims the qn of an indexed file, sending `super::` in that
+file towards a module the user asked cgr not to index; a declaration in a
+rescued subtree is missed, leaving `super::` on the physical climb where a
+shadow sibling answers.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.test_rust_crate_path_trait_linking import (
+    _calls,
+    _write,
+    create_and_run_updater,
+)
+
+
+def test_a_redirect_declared_in_an_excluded_subtree_claims_nothing(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `--exclude tools/` removes the whole subtree from the index, so the
+    # declaration in tools/gen.rs must not move src/fixtures/rig.rs: with
+    # no declarer in the graph, `super::` in it keeps the physical climb.
+    # The map is asserted directly because every module the poisoned entry
+    # can answer with is unindexed, so the resolver's fallback happens to
+    # land the right edge today; the poison is the map entry itself.
+    project = temp_repo / "rs_sweep_excluded_dir"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_sweep_excluded_dir"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": "pub fn top() -> i32 {\n    0\n}\n",
+            "src/fixtures/sib.rs": "pub fn run() -> i32 {\n    1\n}\n",
+            "src/fixtures/rig.rs": (
+                "pub fn build() -> i32 {\n    super::sib::run()\n}\n"
+            ),
+            "tools/gen.rs": (
+                '#[path = "../src/fixtures/rig.rs"]\nmod rig;\nmod sib;\nfn main() {}\n'
+            ),
+            "tools/gen/sib.rs": "pub fn run() -> i32 {\n    9\n}\n",
+        },
+    )
+    updater = create_and_run_updater(
+        project,
+        mock_ingestor,
+        skip_if_missing="rust",
+        exclude_paths=frozenset({"tools/"}),
+    )
+    parents = updater.factory.import_processor._rust_redirect_parent_map()
+    assert parents == {}, parents
+    calls = _calls(mock_ingestor)
+    caller = "rs_sweep_excluded_dir.src.fixtures.rig.build"
+    assert (caller, "rs_sweep_excluded_dir.src.fixtures.sib.run") in calls, calls
+    assert not [pair for pair in calls if ".tools." in pair[1]], calls
+
+
+def test_a_redirect_excluded_by_a_file_pattern_claims_nothing(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The exclusion names one FILE, so the directory walk keeps tools/ and
+    # only the per-file filter can drop the declaration. Here the decoy
+    # module IS indexed, so a sweep that reads the excluded file records a
+    # live wrong edge rather than a dangling one.
+    project = temp_repo / "rs_sweep_excluded_file"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_sweep_excluded_file"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": "pub fn top() -> i32 {\n    0\n}\n",
+            "src/fixtures/sib.rs": "pub fn run() -> i32 {\n    1\n}\n",
+            "src/fixtures/rig.rs": (
+                "pub fn build() -> i32 {\n    super::sib::run()\n}\n"
+            ),
+            "tools/gen.rs": (
+                '#[path = "../src/fixtures/rig.rs"]\nmod rig;\nmod sib;\nfn main() {}\n'
+            ),
+            "tools/gen/sib.rs": "pub fn run() -> i32 {\n    9\n}\n",
+        },
+    )
+    create_and_run_updater(
+        project,
+        mock_ingestor,
+        skip_if_missing="rust",
+        exclude_paths=frozenset({"tools/gen.rs"}),
+    )
+    calls = _calls(mock_ingestor)
+    caller = "rs_sweep_excluded_file.src.fixtures.rig.build"
+    assert (caller, "rs_sweep_excluded_file.src.fixtures.sib.run") in calls, calls
+    assert (caller, "rs_sweep_excluded_file.tools.gen.sib.run") not in calls, calls
+
+
+def test_a_redirect_rescued_by_unignore_moves_its_target(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `build` is a built-in ignore rescued by a `.cgrignore` unignore, so
+    # the indexer walks it and the graph holds build/gen.rs. The sweep has
+    # to walk there too, or the redirect is missed and `super::` in the
+    # target resolves to the physical shadow beside the file.
+    project = temp_repo / "rs_sweep_rescued"
+    _write(
+        project,
+        {
+            "Cargo.toml": ('[package]\nname = "rs_sweep_rescued"\nversion = "0.1.0"\n'),
+            "src/lib.rs": "pub fn top() -> i32 {\n    0\n}\n",
+            "src/fixtures/sib.rs": "pub fn run() -> i32 {\n    9\n}\n",
+            "src/fixtures/rig.rs": (
+                "pub fn build() -> i32 {\n    super::sib::run()\n}\n"
+            ),
+            "build/gen.rs": (
+                '#[path = "../src/fixtures/rig.rs"]\nmod rig;\nmod sib;\n'
+            ),
+            "build/gen/sib.rs": "pub fn run() -> i32 {\n    1\n}\n",
+        },
+    )
+    create_and_run_updater(
+        project,
+        mock_ingestor,
+        skip_if_missing="rust",
+        unignore_paths=frozenset({"build/"}),
+    )
+    calls = _calls(mock_ingestor)
+    caller = "rs_sweep_rescued.src.fixtures.rig.build"
+    assert (caller, "rs_sweep_rescued.build.gen.sib.run") in calls, calls
+    assert (caller, "rs_sweep_rescued.src.fixtures.sib.run") not in calls, calls

--- a/codebase_rag/utils/path_utils.py
+++ b/codebase_rag/utils/path_utils.py
@@ -77,6 +77,39 @@ def unignore_could_match_within(pattern: str, rel_dir: str) -> bool:
     )
 
 
+def should_keep_dir(
+    dirname: str,
+    dir_prefix: str,
+    exclude_paths: frozenset[str] | None = None,
+    unignore_paths: frozenset[str] | None = None,
+) -> bool:
+    """Whether a repository walk descends into this directory.
+
+    The one predicate every whole-repo walk prunes with, so a sweep that
+    reads files the indexer skipped (or skips files the indexer holds)
+    cannot happen by construction (issue #1088).
+    """
+    rel_dir = f"{dir_prefix}{dirname}"
+    # an explicit exclude can never be rescued by unignore (excludes win
+    # at the file level too), so prune the subtree outright.
+    if exclude_paths and matches_ignore_patterns(f"{rel_dir}/", exclude_paths):
+        return False
+    if dirname not in cs.IGNORE_PATTERNS:
+        return True
+    # Cargo's src/bin/ holds first-party binaries, not build output;
+    # mirrors has_ignored_dir_part.
+    if (
+        dirname == cs.DIR_BIN
+        and dir_prefix.rstrip(cs.SEPARATOR_SLASH).rsplit(cs.SEPARATOR_SLASH, 1)[-1]
+        == cs.DIR_SRC
+    ):
+        return True
+    return bool(
+        unignore_paths
+        and any(unignore_could_match_within(u, rel_dir) for u in unignore_paths)
+    )
+
+
 def should_skip_path(
     path: Path,
     repo_path: Path,

--- a/uv.lock
+++ b/uv.lock
@@ -404,7 +404,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.557"
+version = "0.0.559"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- The `#[path]` redirect sweep now prunes directories and skips files with the same `--exclude`/`.cgrignore` predicate the indexer walks with, so a declaration in an excluded subtree claims nothing and one in a rescued subtree is read (issue #1088).
- The indexer's `_should_keep_dir` body moves to `path_utils.should_keep_dir` and both walks call it, so the two cannot drift again.
- `ImportProcessor` receives `exclude_paths`/`unignore_paths` from the factory; the sweep's blanket dot-directory skip is gone, since the indexer has no such rule (dot directories are excluded through `IGNORE_PATTERNS`, which both sides read).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD or tooling
- [ ] Dependencies

## Related Issues

Closes #1088. The same-family gaps found while fixing this are filed as #1099 (C++ module qn map) and #1100 (Rust neighbour/entry declaration reads).

## Test Plan

- [x] Unit tests pass (`make test-parallel` or `uv run pytest -n auto -m "not integration"`)
- [x] New tests added
- [ ] Integration tests pass (`make test-integration`, requires Docker)
- [ ] Manual testing (describe below)

Three new tests, each red before the fix:

- a redirect declared in a `--exclude`d subtree leaves the parent map empty (the resolver's fallback happens to land the right physical edge today, so the map itself is asserted);
- a redirect excluded by a FILE pattern, where the decoy module stays indexed, no longer records the wrong CALLS edge into the excluded declarer's tree;
- a redirect in a built-in-ignored directory rescued by `.cgrignore` moves its target, so `super::` in the target resolves through the declarer instead of the physical shadow sibling.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [ ] No new comments or docstrings (code should be self-documenting): the new `should_keep_dir` carries a docstring and the sweep carries a why-comment, matching the density of the surrounding predicates in `path_utils.py`; they record the invariant (sweep and indexer walk the same set) that the code alone cannot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository indexing consistency for excluded, ignored, and unignored directories and files.
  * Rust redirect mappings now reflect the same filtering rules as indexed source files.
  * Preserved discovery of eligible files in Cargo `src/bin` directories.
  * Ensured restored paths are correctly included in indexing and redirect mapping.
* **Tests**
  * Added coverage for excluded directories, file patterns, and paths restored by unignore rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->