### PR TITLE
test: stub dotnet availability so the fingerprint frontend test is hermetic

### DIFF
--- a/codebase_rag/tests/test_parser_fingerprint.py
+++ b/codebase_rag/tests/test_parser_fingerprint.py
@@ -113,9 +113,16 @@ class TestComputeParserFingerprint:
     ) -> None:
         # The frontend selection is part of the parser identity: flipping it
         # rewrites edges for unchanged sources, so it must change the
-        # fingerprint and trip the staleness warning (issue #738).
+        # fingerprint and trip the staleness warning (issue #738). The
+        # fingerprint records the RESOLVED mode, and without a dotnet
+        # toolchain HYBRID degrades to TREESITTER so both fingerprints
+        # collide; availability is stubbed so the test is hermetic on
+        # hosts without dotnet while still exercising the real
+        # resolution logic (issue #1101).
         from codebase_rag.config import settings as cfg
+        from codebase_rag.parsers.csharp_frontend import frontend
 
+        monkeypatch.setattr(frontend, "csharp_frontend_available", lambda: True)
         monkeypatch.setattr(cfg, "CSHARP_FRONTEND", cs.CSharpFrontend.TREESITTER)
         before = compute_parser_fingerprint()
         monkeypatch.setattr(cfg, "CSHARP_FRONTEND", cs.CSharpFrontend.HYBRID)

--- a/uv.lock
+++ b/uv.lock
@@ -404,7 +404,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.557"
+version = "0.0.559"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- `test_changes_when_csharp_frontend_setting_changes` asserts the parser fingerprint changes when `CSHARP_FRONTEND` flips from `TREESITTER` to `HYBRID`, but the fingerprint records the RESOLVED mode: without a dotnet toolchain `resolve_csharp_frontend()` degrades `HYBRID` to `TREESITTER`, both fingerprints collide, and the test fails on any host without dotnet.
- The test now stubs `csharp_frontend_available` to return `True`, so it is hermetic on every host while still exercising the real resolution logic.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD or tooling
- [ ] Dependencies

## Related Issues

Closes #1101.

## Test Plan

- [x] Unit tests pass (`make test-parallel` or `uv run pytest -n auto -m "not integration"`)
- [ ] New tests added
- [ ] Integration tests pass (`make test-integration`, requires Docker)
- [x] Manual testing (describe below)

The test failed deterministically on a host without dotnet before the stub (both fingerprints hashed to the same digest) and passes with it; the whole `test_parser_fingerprint.py` file passes (20 passed).

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [ ] No new comments or docstrings (code should be self-documenting): the stub carries a why-comment recording the resolved-mode collision it guards against, matching the density of the surrounding tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved C# frontend fingerprint test coverage for explicit hybrid mode.
  * Ensured the test remains reliable when the .NET toolchain is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->