### PR TITLE
fix: stop pre-commit hooks mutating the dev venv and lockfile

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     hooks:
       - id: ty
         name: ty check
-        entry: uv run ty check --exclude codebase_rag/tests/ --exclude benchmarks/ --exclude optimize/ --exclude codec/ --exclude grammars/ --exclude query_modules/
+        entry: uv run --frozen --no-sync ty check --exclude codebase_rag/tests/ --exclude benchmarks/ --exclude optimize/ --exclude codec/ --exclude grammars/ --exclude query_modules/
         language: system
         types: [python]
         exclude: ^(codec/.*_pb2\.py|benchmarks/|optimize/|grammars/|query_modules/)$
@@ -28,7 +28,7 @@ repos:
     hooks:
       - id: generate-readme
         name: generate README sections
-        entry: uv run python scripts/hooks/generate_readme.py
+        entry: uv run --frozen --no-sync python scripts/hooks/generate_readme.py
         language: system
         pass_filenames: false
         always_run: true

--- a/codebase_rag/tests/test_pre_commit_no_sync.py
+++ b/codebase_rag/tests/test_pre_commit_no_sync.py
@@ -1,0 +1,99 @@
+"""Regression tests for the local pre-commit hooks (issue #1097).
+
+A bare ``uv run`` re-syncs the environment to the default dependency set and
+re-resolves the lockfile before executing, so a commit silently uninstalls every
+extra from the developer's virtualenv and rewrites ``uv.lock`` underneath the
+commit. The local hooks must therefore run with ``--no-sync`` and ``--frozen``.
+"""
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONFIG_PATH = REPO_ROOT / ".pre-commit-config.yaml"
+
+REQUIRED_UV_RUN_FLAGS = ("--no-sync", "--frozen")
+
+
+def _local_hook_entries() -> list[tuple[str, list[str]]]:
+    config = yaml.safe_load(CONFIG_PATH.read_text(encoding="utf-8"))
+    return [
+        (hook["id"], hook["entry"].split())
+        for repo in config["repos"]
+        if repo["repo"] == "local"
+        for hook in repo["hooks"]
+        if "entry" in hook
+    ]
+
+
+def _uv_run_hooks() -> list[tuple[str, list[str]]]:
+    return [
+        (hook_id, tokens)
+        for hook_id, tokens in _local_hook_entries()
+        if tokens[:2] == ["uv", "run"]
+    ]
+
+
+def _uv_run_flags(tokens: list[str]) -> list[str]:
+    flags = []
+    for token in tokens[2:]:
+        if not token.startswith("-"):
+            break
+        flags.append(token)
+    return flags
+
+
+def test_local_hooks_exercise_uv_run() -> None:
+    assert _uv_run_hooks(), (
+        "expected at least one local hook launched through `uv run`; "
+        "these tests guard flags that would otherwise silently disappear"
+    )
+
+
+def test_uv_run_hooks_do_not_mutate_the_developer_environment() -> None:
+    offenders = {
+        hook_id: [
+            flag for flag in REQUIRED_UV_RUN_FLAGS if flag not in _uv_run_flags(tokens)
+        ]
+        for hook_id, tokens in _uv_run_hooks()
+    }
+    missing = {hook_id: flags for hook_id, flags in offenders.items() if flags}
+    assert missing == {}, (
+        f"local hooks are missing required `uv run` flags: {missing}. "
+        "Without --no-sync a commit strips extras from the developer's venv; "
+        "without --frozen it rewrites uv.lock mid-commit"
+    )
+
+
+def test_required_flags_precede_the_hook_command() -> None:
+    for hook_id, tokens in _uv_run_hooks():
+        flags = _uv_run_flags(tokens)
+        for required in REQUIRED_UV_RUN_FLAGS:
+            assert required in flags, (
+                f"hook {hook_id!r} must pass {required} to `uv run` itself, not "
+                f"to the command it launches: {' '.join(tokens)!r}"
+            )
+
+
+def test_hook_scripts_do_not_shell_out_to_a_bare_uv_run() -> None:
+    hook_scripts = sorted((REPO_ROOT / "scripts" / "hooks").glob("*.py"))
+    assert hook_scripts, "expected hook scripts under scripts/hooks/"
+
+    offenders = []
+    for script in hook_scripts:
+        source = script.read_text(encoding="utf-8")
+        if '"uv", "run"' not in source:
+            continue
+        for required in REQUIRED_UV_RUN_FLAGS:
+            if (
+                f'"uv", "run", "{required}"' not in source
+                and f'"{required}"' not in source
+            ):
+                offenders.append((script.name, required))
+
+    assert offenders == [], (
+        f"hook scripts shell out to `uv run` without required flags: {offenders}. "
+        "A nested bare `uv run` re-syncs the venv and rewrites uv.lock even when "
+        "the pre-commit entry itself is guarded"
+    )

--- a/codebase_rag/tests/test_pre_commit_no_sync.py
+++ b/codebase_rag/tests/test_pre_commit_no_sync.py
@@ -6,6 +6,7 @@ extra from the developer's virtualenv and rewrites ``uv.lock`` underneath the
 commit. The local hooks must therefore run with ``--no-sync`` and ``--frozen``.
 """
 
+import ast
 from pathlib import Path
 
 import yaml
@@ -76,24 +77,69 @@ def test_required_flags_precede_the_hook_command() -> None:
             )
 
 
+def uv_run_vectors(source: str) -> list[list[str]]:
+    """Every static ``["uv", "run", ...]`` argument vector in a script.
+
+    Parsed per call rather than grepped over the whole file: one guarded
+    invocation must not vouch for a second bare one sitting beside it.
+    """
+    vectors: list[list[str]] = []
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.List | ast.Tuple):
+            continue
+        literals = [
+            element.value
+            for element in node.elts
+            if isinstance(element, ast.Constant) and isinstance(element.value, str)
+        ]
+        if len(literals) == len(node.elts) and literals[:2] == ["uv", "run"]:
+            vectors.append(literals)
+    return vectors
+
+
+def unguarded_uv_run_vectors(source: str) -> list[list[str]]:
+    """The vectors missing a required flag BEFORE the launched command."""
+    return [
+        vector
+        for vector in uv_run_vectors(source)
+        if any(flag not in _uv_run_flags(vector) for flag in REQUIRED_UV_RUN_FLAGS)
+    ]
+
+
 def test_hook_scripts_do_not_shell_out_to_a_bare_uv_run() -> None:
     hook_scripts = sorted((REPO_ROOT / "scripts" / "hooks").glob("*.py"))
     assert hook_scripts, "expected hook scripts under scripts/hooks/"
 
-    offenders = []
-    for script in hook_scripts:
-        source = script.read_text(encoding="utf-8")
-        if '"uv", "run"' not in source:
-            continue
-        for required in REQUIRED_UV_RUN_FLAGS:
-            if (
-                f'"uv", "run", "{required}"' not in source
-                and f'"{required}"' not in source
-            ):
-                offenders.append((script.name, required))
+    offenders = {
+        script.name: unguarded_uv_run_vectors(script.read_text(encoding="utf-8"))
+        for script in hook_scripts
+    }
+    unguarded = {name: vectors for name, vectors in offenders.items() if vectors}
 
-    assert offenders == [], (
-        f"hook scripts shell out to `uv run` without required flags: {offenders}. "
+    assert unguarded == {}, (
+        f"hook scripts shell out to `uv run` without required flags: {unguarded}. "
         "A nested bare `uv run` re-syncs the venv and rewrites uv.lock even when "
         "the pre-commit entry itself is guarded"
     )
+
+
+class TestNestedInvocationDetection:
+    GUARDED = 'subprocess.run(["uv", "run", "--frozen", "--no-sync", "python", "x.py"])'
+    BARE = 'subprocess.run(["uv", "run", "python", "y.py"])'
+
+    def test_a_guarded_invocation_alone_passes(self) -> None:
+        assert unguarded_uv_run_vectors(self.GUARDED) == []
+
+    def test_a_bare_invocation_alone_is_caught(self) -> None:
+        assert unguarded_uv_run_vectors(self.BARE)
+
+    def test_a_guarded_invocation_does_not_vouch_for_a_bare_one(self) -> None:
+        # The whole-file search this replaced passed on exactly this shape.
+        source = f"{self.GUARDED}\n{self.BARE}\n"
+
+        assert unguarded_uv_run_vectors(source) == [["uv", "run", "python", "y.py"]]
+
+    def test_flags_after_the_command_do_not_count(self) -> None:
+        source = 'subprocess.run(["uv", "run", "python", "--frozen", "--no-sync"])'
+
+        assert unguarded_uv_run_vectors(source)

--- a/codebase_rag/tests/test_pre_commit_no_sync.py
+++ b/codebase_rag/tests/test_pre_commit_no_sync.py
@@ -85,16 +85,30 @@ def uv_run_vectors(source: str) -> list[list[str]]:
     """
     vectors: list[list[str]] = []
     for node in ast.walk(ast.parse(source)):
-        if not isinstance(node, ast.List | ast.Tuple):
+        # Only the argv of an actual subprocess launch counts. Matching every
+        # list literal would flag an unrelated `EXAMPLE = ["uv", "run", ...]`
+        # constant that never runs anything.
+        if not isinstance(node, ast.Call) or not _is_subprocess_launch(node.func):
             continue
-        literals = [
-            element.value
-            for element in node.elts
-            if isinstance(element, ast.Constant) and isinstance(element.value, str)
-        ]
-        if len(literals) == len(node.elts) and literals[:2] == ["uv", "run"]:
-            vectors.append(literals)
+        for argument in [*node.args, *(kw.value for kw in node.keywords)]:
+            if not isinstance(argument, ast.List | ast.Tuple):
+                continue
+            literals = [
+                element.value
+                for element in argument.elts
+                if isinstance(element, ast.Constant) and isinstance(element.value, str)
+            ]
+            if len(literals) == len(argument.elts) and literals[:2] == ["uv", "run"]:
+                vectors.append(literals)
     return vectors
+
+
+def _is_subprocess_launch(func: ast.expr) -> bool:
+    """Whether a call expression launches a child process."""
+    launchers = {"run", "call", "check_call", "check_output", "Popen"}
+    if isinstance(func, ast.Attribute):
+        return func.attr in launchers
+    return isinstance(func, ast.Name) and func.id in launchers
 
 
 def unguarded_uv_run_vectors(source: str) -> list[list[str]]:
@@ -138,6 +152,18 @@ class TestNestedInvocationDetection:
         source = f"{self.GUARDED}\n{self.BARE}\n"
 
         assert unguarded_uv_run_vectors(source) == [["uv", "run", "python", "y.py"]]
+
+    def test_an_unrelated_literal_is_not_an_offender(self) -> None:
+        # A constant that merely looks like an argv launches nothing.
+        source = 'EXAMPLE = ["uv", "run", "python", "example.py"]'
+
+        assert unguarded_uv_run_vectors(source) == []
+
+    def test_a_bare_launch_is_caught_through_any_subprocess_helper(self) -> None:
+        for call in ("subprocess.call", "subprocess.check_call", "subprocess.Popen"):
+            source = f'{call}(["uv", "run", "python", "y.py"])'
+
+            assert unguarded_uv_run_vectors(source), call
 
     def test_flags_after_the_command_do_not_count(self) -> None:
         source = 'subprocess.run(["uv", "run", "python", "--frozen", "--no-sync"])'

--- a/codebase_rag/tests/test_pre_commit_no_sync.py
+++ b/codebase_rag/tests/test_pre_commit_no_sync.py
@@ -83,12 +83,16 @@ def uv_run_vectors(source: str) -> list[list[str]]:
     Parsed per call rather than grepped over the whole file: one guarded
     invocation must not vouch for a second bare one sitting beside it.
     """
+    tree = ast.parse(source)
+    modules, direct = _subprocess_aliases(tree)
     vectors: list[list[str]] = []
-    for node in ast.walk(ast.parse(source)):
+    for node in ast.walk(tree):
         # Only the argv of an actual subprocess launch counts. Matching every
         # list literal would flag an unrelated `EXAMPLE = ["uv", "run", ...]`
         # constant that never runs anything.
-        if not isinstance(node, ast.Call) or not _is_subprocess_launch(node.func):
+        if not isinstance(node, ast.Call) or not _is_subprocess_launch(
+            node.func, modules, direct
+        ):
             continue
         for argument in [*node.args, *(kw.value for kw in node.keywords)]:
             if not isinstance(argument, ast.List | ast.Tuple):
@@ -103,12 +107,38 @@ def uv_run_vectors(source: str) -> list[list[str]]:
     return vectors
 
 
-def _is_subprocess_launch(func: ast.expr) -> bool:
+LAUNCHERS = frozenset({"run", "call", "check_call", "check_output", "Popen"})
+
+
+def _subprocess_aliases(tree: ast.Module) -> tuple[set[str], set[str]]:
+    """Names bound to `subprocess`, and launcher names imported from it.
+
+    A method merely *called* `run` proves nothing — `runner.run([...])` is not
+    a child process. Only a callee that resolves back to `subprocess` counts.
+    """
+    modules: set[str] = set()
+    direct: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "subprocess":
+                    modules.add(alias.asname or alias.name)
+        elif isinstance(node, ast.ImportFrom) and node.module == "subprocess":
+            for alias in node.names:
+                if alias.name in LAUNCHERS:
+                    direct.add(alias.asname or alias.name)
+    return modules, direct
+
+
+def _is_subprocess_launch(func: ast.expr, modules: set[str], direct: set[str]) -> bool:
     """Whether a call expression launches a child process."""
-    launchers = {"run", "call", "check_call", "check_output", "Popen"}
     if isinstance(func, ast.Attribute):
-        return func.attr in launchers
-    return isinstance(func, ast.Name) and func.id in launchers
+        return (
+            func.attr in LAUNCHERS
+            and isinstance(func.value, ast.Name)
+            and func.value.id in modules
+        )
+    return isinstance(func, ast.Name) and func.id in direct
 
 
 def unguarded_uv_run_vectors(source: str) -> list[list[str]]:
@@ -138,8 +168,8 @@ def test_hook_scripts_do_not_shell_out_to_a_bare_uv_run() -> None:
 
 
 class TestNestedInvocationDetection:
-    GUARDED = 'subprocess.run(["uv", "run", "--frozen", "--no-sync", "python", "x.py"])'
-    BARE = 'subprocess.run(["uv", "run", "python", "y.py"])'
+    GUARDED = 'import subprocess\nsubprocess.run(["uv", "run", "--frozen", "--no-sync", "python", "x.py"])'
+    BARE = 'import subprocess\nsubprocess.run(["uv", "run", "python", "y.py"])'
 
     def test_a_guarded_invocation_alone_passes(self) -> None:
         assert unguarded_uv_run_vectors(self.GUARDED) == []
@@ -161,11 +191,31 @@ class TestNestedInvocationDetection:
 
     def test_a_bare_launch_is_caught_through_any_subprocess_helper(self) -> None:
         for call in ("subprocess.call", "subprocess.check_call", "subprocess.Popen"):
-            source = f'{call}(["uv", "run", "python", "y.py"])'
+            source = f'import subprocess\n{call}(["uv", "run", "python", "y.py"])'
 
             assert unguarded_uv_run_vectors(source), call
 
+    def test_an_unrelated_run_method_is_not_a_launch(self) -> None:
+        # `runner.run(...)` is not a child process just because the method is
+        # named `run`; the receiver has to resolve to subprocess.
+        source = 'runner.run(["uv", "run", "python", "y.py"])'
+
+        assert unguarded_uv_run_vectors(source) == []
+
+    def test_a_module_alias_still_resolves(self) -> None:
+        source = 'import subprocess as sp\nsp.run(["uv", "run", "python", "y.py"])'
+
+        assert unguarded_uv_run_vectors(source)
+
+    def test_a_direct_import_still_resolves(self) -> None:
+        source = 'from subprocess import run\nrun(["uv", "run", "python", "y.py"])'
+
+        assert unguarded_uv_run_vectors(source)
+
     def test_flags_after_the_command_do_not_count(self) -> None:
-        source = 'subprocess.run(["uv", "run", "python", "--frozen", "--no-sync"])'
+        source = (
+            "import subprocess\n"
+            'subprocess.run(["uv", "run", "python", "--frozen", "--no-sync"])'
+        )
 
         assert unguarded_uv_run_vectors(source)

--- a/scripts/hooks/generate_readme.py
+++ b/scripts/hooks/generate_readme.py
@@ -18,7 +18,7 @@ targets = [repo_root / relative for relative in TARGET_FILES]
 before = [digest(target) for target in targets]
 
 result = subprocess.run(
-    ["uv", "run", "python", "scripts/generate_readme.py"],
+    ["uv", "run", "--frozen", "--no-sync", "python", "scripts/generate_readme.py"],
     check=False,
     cwd=repo_root,
     capture_output=True,


### PR DESCRIPTION
Closes #1097.

## Problem

The `ty` and `generate-readme` local hooks ran `uv run` without `--no-sync`, so every commit re-synced `.venv` to the default dependency set and silently uninstalled every extra (`pymilvus`, `torch`, `qdrant-client`, ...). `ty` then reported a false `unresolved-import` failure caused by the hook itself, and the developer was left with a degraded environment.

## Changes

- `--no-sync` on both local hook entries, as the issue asks.
- `--frozen` alongside it. `--no-sync` stops the venv mutation but `uv run` still re-resolves and rewrites `uv.lock`; pre-commit then fails the commit with "files were modified by this hook". Same defect class, one flag away.
- `scripts/hooks/generate_readme.py:21` shells out to a **nested** bare `uv run python scripts/generate_readme.py`. Fixing the pre-commit entry alone does not fix the readme hook — this nested call is the one that actually re-syncs. Both flags added there too.

## Tests

`codebase_rag/tests/test_pre_commit_no_sync.py` parses `.pre-commit-config.yaml` and asserts every local `uv run` hook passes both flags *to `uv run` itself* rather than to the command it launches, and greps `scripts/hooks/*.py` for nested bare `uv run` calls.

Verified RED before the fix (all guards fail), GREEN after. A full `pre-commit run` now leaves the worktree and `.venv` untouched, where before it failed on `ty` and rewrote `uv.lock`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability and consistency of automated project checks and README generation by using locked, offline-compatible environments.
  * Prevented automated checks from unexpectedly updating or resolving project dependencies during execution.

* **Tests**
  * Added regression coverage to verify required environment settings are applied consistently across local automation hooks.
  * Added validation to catch incorrectly configured command options and unprotected nested commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->