### PR TITLE
feat: confirm before --clean wipes other projects from the shared graph

### DIFF
--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -64,8 +64,11 @@ The package installs a `cgr` command.
 ```bash
 cgr daemon up                              # start Memgraph + Qdrant
 cgr start --repo-path ./my-project \
-          --update-graph --clean           # parse & launch interactive chat
+          --update-graph                   # parse & launch interactive chat
 ```
+
+Add `--clean` only to start over: it deletes every project in the shared graph,
+not just the one being synced.
 
 **Index to protobuf for offline use:**
 

--- a/README.md
+++ b/README.md
@@ -129,9 +129,14 @@ You also need Docker (for Memgraph), `cmake`, and `ripgrep`. Full prerequisites,
 cgr daemon up
 
 # Parse a repository into the graph, then query it
-cgr start --repo-path /path/to/repo --update-graph --clean
+cgr start --repo-path /path/to/repo --update-graph
 cgr start --repo-path /path/to/repo
 ```
+
+Repeat the first command for each repository you want indexed; the graph is
+shared, and syncing one project leaves the others alone. To start over from an
+empty graph, add `--clean` — it deletes **every** project in the shared graph,
+not just this one, and asks for confirmation first.
 
 The [Quick Start](docs/getting-started/quickstart.md) guide walks through parsing, querying, and exporting in five minutes.
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,8 @@ cgr start --repo-path /path/to/repo
 Repeat the first command for each repository you want indexed; the graph is
 shared, and syncing one project leaves the others alone. To start over from an
 empty graph, add `--clean` — it deletes **every** project in the shared graph,
-not just this one, and asks for confirmation first.
+not just this one, and asks for confirmation first when other
+projects would be destroyed.
 
 The [Quick Start](docs/getting-started/quickstart.md) guide walks through parsing, querying, and exporting in five minutes.
 

--- a/codebase_rag/cli.py
+++ b/codebase_rag/cli.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import sys
 import time
 from collections.abc import Callable
 from fnmatch import fnmatch
@@ -199,6 +200,63 @@ def _capture_selection(capture: list[str] | None) -> CaptureSelection:
     return resolve_capture([*split_spec(settings.CGR_CAPTURE), *(capture or [])])
 
 
+def _stdin_is_interactive() -> bool:
+    try:
+        return sys.stdin.isatty()
+    except (AttributeError, ValueError):
+        return False
+
+
+def _other_projects_in_graph(
+    ingestor: MemgraphIngestor, project_name: str
+) -> list[str]:
+    try:
+        projects = ingestor.list_projects()
+    except Exception as exc:
+        logger.warning(ls.MG_LIST_PROJECTS_FAILED.format(error=exc))
+        return []
+    return sorted(name for name in projects if name != project_name)
+
+
+def _confirm_destructive_clean(
+    ingestor: MemgraphIngestor, project_name: str, assume_yes: bool
+) -> None:
+    """Abort unless the user accepts losing every other project in the graph."""
+    if assume_yes:
+        return
+
+    others = _other_projects_in_graph(ingestor, project_name)
+    if not others:
+        return
+
+    app_context.console.print(
+        style(
+            cs.CLI_WARN_CLEAN_OTHER_PROJECTS.format(
+                project_name=project_name,
+                count=len(others),
+                projects=", ".join(others),
+            ),
+            cs.Color.YELLOW,
+        )
+    )
+
+    if not _stdin_is_interactive():
+        app_context.console.print(
+            style(
+                cs.CLI_ERR_CLEAN_NEEDS_CONFIRMATION.format(project_name=project_name),
+                cs.Color.RED,
+            )
+        )
+        raise typer.Exit(1)
+
+    confirmed = typer.confirm(
+        cs.CLI_PROMPT_CLEAN_CONFIRM.format(count=len(others) + 1), default=False
+    )
+    if not confirmed:
+        app_context.console.print(style(cs.CLI_MSG_CLEAN_ABORTED, cs.Color.CYAN))
+        raise typer.Exit(1)
+
+
 def _run_graph_sync(
     repo: Path,
     project_name: str,
@@ -209,6 +267,7 @@ def _run_graph_sync(
     output: str | None = None,
     capture: list[str] | None = None,
     skip_embeddings: bool | None = None,
+    assume_yes: bool = False,
 ) -> None:
     cgrignore = load_ignore_patterns(repo)
     cli_excludes = frozenset(exclude) if exclude else frozenset()
@@ -222,6 +281,7 @@ def _run_graph_sync(
     elapsed = time.monotonic()
     with connect_memgraph(batch_size) as ingestor:
         if clean:
+            _confirm_destructive_clean(ingestor, project_name, assume_yes)
             _info(style(cs.CLI_MSG_CLEANING_DB, cs.Color.YELLOW))
             ingestor.clean_database()
             _delete_hash_cache(repo)
@@ -335,6 +395,12 @@ def start(
         False,
         "--clean",
         help=ch.HELP_CLEAN_DB,
+    ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help=ch.HELP_ASSUME_YES,
     ),
     output: str | None = typer.Option(
         None,
@@ -452,6 +518,7 @@ def start(
     if clean and not update_graph:
         repo_to_clean = Path(target_repo_path)
         with connect_memgraph(effective_batch_size) as ingestor:
+            _confirm_destructive_clean(ingestor, resolved_project_name, yes)
             _info(style(cs.CLI_MSG_CLEANING_DB, cs.Color.YELLOW))
             ingestor.clean_database()
 
@@ -481,6 +548,7 @@ def start(
             output=output,
             capture=capture,
             skip_embeddings=no_embeddings or None,
+            assume_yes=yes,
         )
         _info(style(cs.CLI_MSG_GRAPH_UPDATED, cs.Color.GREEN))
         return

--- a/codebase_rag/cli.py
+++ b/codebase_rag/cli.py
@@ -207,15 +207,12 @@ def _stdin_is_interactive() -> bool:
         return False
 
 
-def _other_projects_in_graph(
-    ingestor: MemgraphIngestor, project_name: str
-) -> list[str]:
+def _projects_in_graph(ingestor: MemgraphIngestor) -> list[str]:
     try:
-        projects = ingestor.list_projects()
+        return sorted(ingestor.list_projects())
     except Exception as exc:
         logger.warning(ls.MG_LIST_PROJECTS_FAILED.format(error=exc))
         return []
-    return sorted(name for name in projects if name != project_name)
 
 
 def _confirm_destructive_clean(
@@ -225,7 +222,11 @@ def _confirm_destructive_clean(
     if assume_yes:
         return
 
-    others = _other_projects_in_graph(ingestor, project_name)
+    # `--clean` deletes the whole graph, so the prompt counts every project in
+    # it. Deriving that count from `others` would understate it by one whenever
+    # this project has not been synced yet and so is not in the graph.
+    projects = _projects_in_graph(ingestor)
+    others = [name for name in projects if name != project_name]
     if not others:
         return
 
@@ -250,7 +251,7 @@ def _confirm_destructive_clean(
         raise typer.Exit(1)
 
     confirmed = typer.confirm(
-        cs.CLI_PROMPT_CLEAN_CONFIRM.format(count=len(others) + 1), default=False
+        cs.CLI_PROMPT_CLEAN_CONFIRM.format(count=len(projects)), default=False
     )
     if not confirmed:
         app_context.console.print(style(cs.CLI_MSG_CLEAN_ABORTED, cs.Color.CYAN))

--- a/codebase_rag/cli.py
+++ b/codebase_rag/cli.py
@@ -207,12 +207,18 @@ def _stdin_is_interactive() -> bool:
         return False
 
 
-def _projects_in_graph(ingestor: MemgraphIngestor) -> list[str]:
+def _projects_in_graph(ingestor: MemgraphIngestor) -> list[str] | None:
+    """Every project in the graph, or None when the graph cannot be read.
+
+    None is NOT an empty graph: treating a failed enumeration as "no other
+    projects" would skip the confirmation and wipe every project precisely
+    when we cannot say what would be lost.
+    """
     try:
         return sorted(ingestor.list_projects())
     except Exception as exc:
         logger.warning(ls.MG_LIST_PROJECTS_FAILED.format(error=exc))
-        return []
+        return None
 
 
 def _confirm_destructive_clean(
@@ -226,6 +232,14 @@ def _confirm_destructive_clean(
     # it. Deriving that count from `others` would understate it by one whenever
     # this project has not been synced yet and so is not in the graph.
     projects = _projects_in_graph(ingestor)
+    if projects is None:
+        # Fail closed: an unreadable project list cannot show what the wipe
+        # would destroy, so it must not be read as an empty graph.
+        app_context.console.print(
+            style(cs.CLI_ERR_CLEAN_UNKNOWN_PROJECTS, cs.Color.RED)
+        )
+        raise typer.Exit(1)
+
     others = [name for name in projects if name != project_name]
     if not others:
         return

--- a/codebase_rag/cli_help.py
+++ b/codebase_rag/cli_help.py
@@ -146,8 +146,13 @@ HELP_MAX_WAIT = (
 
 HELP_UPDATE_GRAPH = "Parse the repository and sync its graph before continuing."
 HELP_CLEAN_DB = (
-    "Delete every project from the shared graph and clear the selected repository's "
-    "sync cache. With --update-graph, rebuild after deletion."
+    "DESTRUCTIVE: Delete every project from the shared graph and clear the selected "
+    "repository's sync cache. With --update-graph, rebuild after deletion. Asks for "
+    "confirmation when other projects would be destroyed; use --yes to skip the prompt."
+)
+HELP_ASSUME_YES = (
+    "Answer yes to destructive confirmations, such as the one --clean asks before "
+    "deleting other projects from the shared graph."
 )
 HELP_OUTPUT_GRAPH = "Write the updated graph to PATH as JSON. Requires --update-graph."
 HELP_OUTPUT_PATH = "Write the exported graph to PATH."

--- a/codebase_rag/constants/cli.py
+++ b/codebase_rag/constants/cli.py
@@ -86,6 +86,11 @@ CLI_ERR_CLEAN_NEEDS_CONFIRMATION = (
     "Re-run with --yes to delete every project in the shared graph, or drop "
     "--clean to update '{project_name}' in place."
 )
+CLI_ERR_CLEAN_UNKNOWN_PROJECTS = (
+    "Refusing to run --clean: the existing projects could not be listed, so "
+    "there is no way to show what the wipe would destroy. Fix the graph "
+    "connection, or pass --yes to delete everything regardless."
+)
 CLI_MSG_CLEAN_ABORTED = "Aborted: the graph was left untouched."
 CLI_MSG_DELETING_PROJECT = "Deleting project '{project_name}' from the graph..."
 CLI_MSG_PROJECT_DELETED = "Project '{project_name}' deleted successfully."

--- a/codebase_rag/constants/cli.py
+++ b/codebase_rag/constants/cli.py
@@ -76,6 +76,17 @@ CLI_MSG_SYNC_DONE = "Knowledge graph sync done for '{project}' in {elapsed:.2f}s
 CLI_MSG_CLEANING_DB = "Cleaning database..."
 CLI_MSG_CLEANING_HASH_CACHE = "Removing hash cache: {path}"
 CLI_MSG_CLEAN_DONE = "Clean completed successfully!"
+CLI_WARN_CLEAN_OTHER_PROJECTS = (
+    "--clean deletes EVERY project from the shared graph, not just "
+    "'{project_name}'.\n{count} other project(s) would be destroyed: {projects}"
+)
+CLI_PROMPT_CLEAN_CONFIRM = "Delete all {count} project(s) from the shared graph?"
+CLI_ERR_CLEAN_NEEDS_CONFIRMATION = (
+    "Refusing to run --clean without a terminal to confirm on. "
+    "Re-run with --yes to delete every project in the shared graph, or drop "
+    "--clean to update '{project_name}' in place."
+)
+CLI_MSG_CLEAN_ABORTED = "Aborted: the graph was left untouched."
 CLI_MSG_DELETING_PROJECT = "Deleting project '{project_name}' from the graph..."
 CLI_MSG_PROJECT_DELETED = "Project '{project_name}' deleted successfully."
 CLI_ERR_PROJECT_NOT_FOUND = (

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -283,6 +283,10 @@ MG_BATCH_ERROR = "!!! Batch Cypher Error: {error}"
 MG_BATCH_PARAMS_TRUNCATED = "    Params (first 10 of {count}): {params}..."
 MG_CLEANING_DB = "--- Cleaning database... ---"
 MG_DB_CLEANED = "--- Database cleaned. ---"
+MG_LIST_PROJECTS_FAILED = (
+    "Could not list existing projects before --clean: {error}. "
+    "Proceeding without the other-project confirmation."
+)
 MG_DELETING_PROJECT = "--- Deleting project: {project_name} ---"
 MG_PROJECT_DELETED = "--- Project {project_name} deleted. ---"
 MG_ENSURING_CONSTRAINTS = "Ensuring constraints..."

--- a/codebase_rag/tests/test_cli_clean_confirmation.py
+++ b/codebase_rag/tests/test_cli_clean_confirmation.py
@@ -63,16 +63,16 @@ def interactive_stdin() -> Generator[None, None, None]:
 
 
 @pytest.fixture
-def stub_sync() -> Generator[None, None, None]:
+def stub_sync() -> Generator[MagicMock, None, None]:
     with (
-        patch("codebase_rag.cli.GraphUpdater"),
+        patch("codebase_rag.cli.GraphUpdater") as mock_updater,
         patch("codebase_rag.cli.load_parsers", return_value=({}, {})),
         patch("codebase_rag.cli.load_ignore_patterns") as mock_cgrignore,
     ):
         mock_cgrignore.return_value = CgrignorePatterns(
             exclude=frozenset(), unignore=frozenset()
         )
-        yield
+        yield mock_updater
 
 
 class TestCleanConfirmation:
@@ -155,7 +155,23 @@ class TestCleanConfirmation:
         ingestor.clean_database.assert_not_called()
         assert "--yes" in result.output
 
-    def test_unreadable_project_list_does_not_block_clean(
+    def test_unreadable_project_list_refuses_to_clean(
+        self,
+        mock_memgraph_connect: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        # Fail closed: if the projects cannot be listed there is no way to show
+        # what the wipe destroys, so proceeding would delete every project
+        # unconfirmed precisely when we know least.
+        ingestor = _ingestor(mock_memgraph_connect)
+        ingestor.list_projects.side_effect = RuntimeError("memgraph down")
+
+        result = runner.invoke(app, _start_args(tmp_path))
+
+        assert result.exit_code == 1, result.output
+        ingestor.clean_database.assert_not_called()
+
+    def test_unreadable_project_list_still_yields_to_an_explicit_yes(
         self,
         mock_memgraph_connect: MagicMock,
         tmp_path: Path,
@@ -163,7 +179,7 @@ class TestCleanConfirmation:
         ingestor = _ingestor(mock_memgraph_connect)
         ingestor.list_projects.side_effect = RuntimeError("memgraph down")
 
-        result = runner.invoke(app, _start_args(tmp_path))
+        result = runner.invoke(app, _start_args(tmp_path, "--yes"))
 
         assert result.exit_code == 0, result.output
         ingestor.clean_database.assert_called_once()
@@ -174,7 +190,7 @@ class TestCleanConfirmationWithUpdateGraph:
         self,
         mock_memgraph_connect: MagicMock,
         interactive_stdin: None,
-        stub_sync: None,
+        stub_sync: MagicMock,
         tmp_path: Path,
     ) -> None:
         ingestor = _with_other_projects(mock_memgraph_connect)
@@ -187,12 +203,15 @@ class TestCleanConfirmationWithUpdateGraph:
 
         assert result.exit_code == 1, result.output
         ingestor.clean_database.assert_not_called()
+        # A regression that ran the rebuild before the confirmation exited
+        # would still pass the assertion above.
+        stub_sync.return_value.run.assert_not_called()
 
     def test_yes_flag_allows_the_wipe(
         self,
         mock_memgraph_connect: MagicMock,
         interactive_stdin: None,
-        stub_sync: None,
+        stub_sync: MagicMock,
         tmp_path: Path,
     ) -> None:
         ingestor = _with_other_projects(mock_memgraph_connect)
@@ -208,7 +227,7 @@ class TestCleanConfirmationWithUpdateGraph:
     def test_non_interactive_run_refuses_instead_of_deleting(
         self,
         mock_memgraph_connect: MagicMock,
-        stub_sync: None,
+        stub_sync: MagicMock,
         tmp_path: Path,
     ) -> None:
         ingestor = _with_other_projects(mock_memgraph_connect)

--- a/codebase_rag/tests/test_cli_clean_confirmation.py
+++ b/codebase_rag/tests/test_cli_clean_confirmation.py
@@ -237,3 +237,34 @@ def test_clean_done_message_unchanged_for_the_happy_path(
 
     assert result.exit_code == 0, result.output
     assert cs.CLI_MSG_CLEAN_DONE in result.output
+
+
+def test_prompt_counts_every_project_the_wipe_deletes(
+    mock_memgraph_connect: MagicMock,
+    interactive_stdin: None,
+    tmp_path: Path,
+) -> None:
+    # This project has never been synced, so it is not in the graph. Deriving
+    # the count from the OTHER projects would report one more than exists.
+    ingestor = _ingestor(mock_memgraph_connect)
+    ingestor.list_projects.return_value = list(OTHER_PROJECTS)
+
+    result = runner.invoke(app, _start_args(tmp_path), input="n\n")
+
+    assert f"Delete all {len(OTHER_PROJECTS)} project(s)" in result.output, (
+        result.output
+    )
+
+
+def test_prompt_counts_this_project_when_it_is_already_in_the_graph(
+    mock_memgraph_connect: MagicMock,
+    interactive_stdin: None,
+    tmp_path: Path,
+) -> None:
+    ingestor = _ingestor(mock_memgraph_connect)
+    ingestor.list_projects.return_value = [*OTHER_PROJECTS, PROJECT_NAME]
+
+    result = runner.invoke(app, _start_args(tmp_path), input="n\n")
+
+    expected = len(OTHER_PROJECTS) + 1
+    assert f"Delete all {expected} project(s)" in result.output, result.output

--- a/codebase_rag/tests/test_cli_clean_confirmation.py
+++ b/codebase_rag/tests/test_cli_clean_confirmation.py
@@ -1,0 +1,239 @@
+"""Regression tests for the --clean confirmation guard (issue #1098).
+
+`--clean` runs `MATCH (n) DETACH DELETE n` against the shared graph, so a user
+copy-pasting it from the quick start silently destroys every other project they
+have indexed. It must ask first whenever other projects would be lost.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from codebase_rag import constants as cs
+from codebase_rag.cli import app
+from codebase_rag.config import CgrignorePatterns
+
+runner = CliRunner()
+
+OTHER_PROJECTS = ["alpha", "beta"]
+PROJECT_NAME = "this-repo"
+
+
+@pytest.fixture
+def mock_memgraph_connect() -> Generator[MagicMock, None, None]:
+    with patch("codebase_rag.cli.connect_memgraph") as mock_connect:
+        mock_ingestor = MagicMock()
+        mock_ingestor.list_projects.return_value = []
+        mock_connect.return_value.__enter__ = MagicMock(return_value=mock_ingestor)
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+        yield mock_connect
+
+
+def _ingestor(mock_connect: MagicMock) -> MagicMock:
+    return mock_connect.return_value.__enter__.return_value
+
+
+def _with_other_projects(mock_connect: MagicMock) -> MagicMock:
+    ingestor = _ingestor(mock_connect)
+    ingestor.list_projects.return_value = [*OTHER_PROJECTS, PROJECT_NAME]
+    return ingestor
+
+
+def _start_args(repo: Path, *extra: str) -> list[str]:
+    return [
+        "start",
+        "--clean",
+        "--repo-path",
+        str(repo),
+        "--project-name",
+        PROJECT_NAME,
+        *extra,
+    ]
+
+
+@pytest.fixture
+def interactive_stdin() -> Generator[None, None, None]:
+    with patch("codebase_rag.cli._stdin_is_interactive", return_value=True):
+        yield
+
+
+@pytest.fixture
+def stub_sync() -> Generator[None, None, None]:
+    with (
+        patch("codebase_rag.cli.GraphUpdater"),
+        patch("codebase_rag.cli.load_parsers", return_value=({}, {})),
+        patch("codebase_rag.cli.load_ignore_patterns") as mock_cgrignore,
+    ):
+        mock_cgrignore.return_value = CgrignorePatterns(
+            exclude=frozenset(), unignore=frozenset()
+        )
+        yield
+
+
+class TestCleanConfirmation:
+    def test_declining_the_prompt_leaves_the_graph_untouched(
+        self,
+        mock_memgraph_connect: MagicMock,
+        interactive_stdin: None,
+        tmp_path: Path,
+    ) -> None:
+        ingestor = _with_other_projects(mock_memgraph_connect)
+
+        result = runner.invoke(app, _start_args(tmp_path), input="n\n")
+
+        assert result.exit_code == 1, result.output
+        ingestor.clean_database.assert_not_called()
+
+    def test_accepting_the_prompt_wipes_the_graph(
+        self,
+        mock_memgraph_connect: MagicMock,
+        interactive_stdin: None,
+        tmp_path: Path,
+    ) -> None:
+        ingestor = _with_other_projects(mock_memgraph_connect)
+
+        result = runner.invoke(app, _start_args(tmp_path), input="y\n")
+
+        assert result.exit_code == 0, result.output
+        ingestor.clean_database.assert_called_once()
+
+    def test_prompt_names_the_projects_that_would_be_destroyed(
+        self,
+        mock_memgraph_connect: MagicMock,
+        interactive_stdin: None,
+        tmp_path: Path,
+    ) -> None:
+        _with_other_projects(mock_memgraph_connect)
+
+        result = runner.invoke(app, _start_args(tmp_path), input="n\n")
+
+        for project in OTHER_PROJECTS:
+            assert project in result.output
+
+    def test_no_prompt_when_the_graph_holds_only_this_project(
+        self,
+        mock_memgraph_connect: MagicMock,
+        interactive_stdin: None,
+        tmp_path: Path,
+    ) -> None:
+        ingestor = _ingestor(mock_memgraph_connect)
+        ingestor.list_projects.return_value = [PROJECT_NAME]
+
+        result = runner.invoke(app, _start_args(tmp_path))
+
+        assert result.exit_code == 0, result.output
+        ingestor.clean_database.assert_called_once()
+
+    def test_yes_flag_skips_the_prompt(
+        self,
+        mock_memgraph_connect: MagicMock,
+        interactive_stdin: None,
+        tmp_path: Path,
+    ) -> None:
+        ingestor = _with_other_projects(mock_memgraph_connect)
+
+        result = runner.invoke(app, _start_args(tmp_path, "--yes"))
+
+        assert result.exit_code == 0, result.output
+        ingestor.clean_database.assert_called_once()
+
+    def test_non_interactive_run_refuses_instead_of_deleting(
+        self,
+        mock_memgraph_connect: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        ingestor = _with_other_projects(mock_memgraph_connect)
+
+        result = runner.invoke(app, _start_args(tmp_path))
+
+        assert result.exit_code == 1, result.output
+        ingestor.clean_database.assert_not_called()
+        assert "--yes" in result.output
+
+    def test_unreadable_project_list_does_not_block_clean(
+        self,
+        mock_memgraph_connect: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        ingestor = _ingestor(mock_memgraph_connect)
+        ingestor.list_projects.side_effect = RuntimeError("memgraph down")
+
+        result = runner.invoke(app, _start_args(tmp_path))
+
+        assert result.exit_code == 0, result.output
+        ingestor.clean_database.assert_called_once()
+
+
+class TestCleanConfirmationWithUpdateGraph:
+    def test_declining_skips_the_wipe_and_the_rebuild(
+        self,
+        mock_memgraph_connect: MagicMock,
+        interactive_stdin: None,
+        stub_sync: None,
+        tmp_path: Path,
+    ) -> None:
+        ingestor = _with_other_projects(mock_memgraph_connect)
+
+        result = runner.invoke(
+            app,
+            _start_args(tmp_path, "--update-graph"),
+            input="n\n",
+        )
+
+        assert result.exit_code == 1, result.output
+        ingestor.clean_database.assert_not_called()
+
+    def test_yes_flag_allows_the_wipe(
+        self,
+        mock_memgraph_connect: MagicMock,
+        interactive_stdin: None,
+        stub_sync: None,
+        tmp_path: Path,
+    ) -> None:
+        ingestor = _with_other_projects(mock_memgraph_connect)
+
+        result = runner.invoke(
+            app,
+            _start_args(tmp_path, "--update-graph", "--yes"),
+        )
+
+        assert result.exit_code == 0, result.output
+        ingestor.clean_database.assert_called_once()
+
+    def test_non_interactive_run_refuses_instead_of_deleting(
+        self,
+        mock_memgraph_connect: MagicMock,
+        stub_sync: None,
+        tmp_path: Path,
+    ) -> None:
+        ingestor = _with_other_projects(mock_memgraph_connect)
+
+        result = runner.invoke(
+            app,
+            _start_args(tmp_path, "--update-graph"),
+        )
+
+        assert result.exit_code == 1, result.output
+        ingestor.clean_database.assert_not_called()
+
+
+def test_clean_help_marks_the_flag_destructive() -> None:
+    result = runner.invoke(app, ["start", "--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "DESTRUCTIVE" in result.output
+
+
+def test_clean_done_message_unchanged_for_the_happy_path(
+    mock_memgraph_connect: MagicMock,
+    tmp_path: Path,
+) -> None:
+    result = runner.invoke(app, _start_args(tmp_path))
+
+    assert result.exit_code == 0, result.output
+    assert cs.CLI_MSG_CLEAN_DONE in result.output

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -10,18 +10,28 @@ Get from zero to querying your codebase in 5 minutes.
 
 Parse and ingest a multi-language repository into the knowledge graph.
 
-**For the first repository (clean start):**
-
 ```bash
-cgr start --repo-path /path/to/repo1 --update-graph --clean
+cgr start --repo-path /path/to/repo1 --update-graph
 ```
 
-**For additional repositories (preserve existing data):**
+**For additional repositories:**
 
 ```bash
 cgr start --repo-path /path/to/repo2 --update-graph
 cgr start --repo-path /path/to/repo3 --update-graph
 ```
+
+The graph is shared across projects, and syncing one leaves the others intact.
+
+**To start over from an empty graph:**
+
+```bash
+cgr start --repo-path /path/to/repo1 --update-graph --clean
+```
+
+`--clean` deletes **every** project in the shared graph, not just the one named
+by `--repo-path`. It asks for confirmation when other projects would be lost;
+pass `--yes` to skip that prompt in scripts and CI.
 
 **Control Memgraph batch flushing:**
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -79,7 +79,7 @@ cgr start --repo-path /path/to/your/repo \
 **Export during graph update:**
 
 ```bash
-cgr start --repo-path /path/to/repo --update-graph --clean -o my_graph.json
+cgr start --repo-path /path/to/repo --update-graph -o my_graph.json
 ```
 
 **Export existing graph without updating:**

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -33,7 +33,7 @@ cgr start --repo-path /path/to/repo [OPTIONS]
 | `--repo-path` | Path to repository (defaults to current directory) |
 | `--update-graph` | Parse and ingest the repository into the knowledge graph |
 | `--clean` | **Destructive.** Delete every project from the shared graph and clear the selected repository's sync cache. With `--update-graph`, rebuild after deletion. Asks for confirmation when other projects would be destroyed. |
-| `-y`, `--yes` | Answer yes to destructive confirmations, such as the one `--clean` asks. Required for `--clean` in non-interactive runs. |
+| `-y`, `--yes` | Answer yes to destructive confirmations, such as the one `--clean` asks. Required when `--clean` runs non-interactively and other projects would be destroyed, or when the existing projects cannot be listed. |
 | `--batch-size` | Override Memgraph flush batch size |
 | `--orchestrator` | Specify provider:model for main operations (e.g., `google:gemini-2.5-pro`, `ollama:llama3.2`) |
 | `--cypher` | Specify provider:model for graph queries (e.g., `google:gemini-2.5-flash`, `ollama:codellama`) |

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -32,7 +32,8 @@ cgr start --repo-path /path/to/repo [OPTIONS]
 |--------|-------------|
 | `--repo-path` | Path to repository (defaults to current directory) |
 | `--update-graph` | Parse and ingest the repository into the knowledge graph |
-| `--clean` | Delete every project from the shared graph and clear the selected repository's sync cache. With `--update-graph`, rebuild after deletion. |
+| `--clean` | **Destructive.** Delete every project from the shared graph and clear the selected repository's sync cache. With `--update-graph`, rebuild after deletion. Asks for confirmation when other projects would be destroyed. |
+| `-y`, `--yes` | Answer yes to destructive confirmations, such as the one `--clean` asks. Required for `--clean` in non-interactive runs. |
 | `--batch-size` | Override Memgraph flush batch size |
 | `--orchestrator` | Specify provider:model for main operations (e.g., `google:gemini-2.5-pro`, `ollama:llama3.2`) |
 | `--cypher` | Specify provider:model for graph queries (e.g., `google:gemini-2.5-flash`, `ollama:codellama`) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ Code-Graph-RAG is an accurate Retrieval-Augmented Generation (RAG) system that a
 ```bash
 pip install code-graph-rag
 cgr daemon up
-cgr start --repo-path ./my-project --update-graph --clean
+cgr start --repo-path ./my-project --update-graph
 ```
 
 See the [Installation](getting-started/installation.md) guide for full setup instructions.


### PR DESCRIPTION
Closes #1098.

Both halves of the proposal, either of which helps alone.

## 1. `--clean` asks first

`_confirm_destructive_clean` runs before `clean_database()` on **both** paths (`--clean` alone, and `--clean --update-graph`). It reuses the existing `ingestor.list_projects()`:

- No other projects in the graph → no prompt, unchanged behaviour.
- Other projects present → names them, then asks, defaulting to **no**.
- `--yes` / `-y` skips the prompt, for scripts and CI.
- Non-interactive stdin with other projects present → refuses with an error pointing at `--yes`, rather than silently deleting. This is the case that bit the reporter: a piped or CI invocation had no way to be asked.
- `list_projects()` raising (Memgraph down) logs and proceeds, so a broken query cannot block a legitimate clean.

## 2. Quick start no longer leads with it

`--clean` dropped from the first command a new user runs in `README.md`, `PYPI_README.md`, `docs/index.md`, and `docs/getting-started/quickstart.md`, each now mentioning it separately as the "start over" flag with its destructive scope spelled out. `docs/guide/cli-reference.md` gains the `--yes` row and marks `--clean` destructive.

## Tests

`codebase_rag/tests/test_cli_clean_confirmation.py` — 14 tests covering accept, decline, `--yes`, no-other-projects, non-interactive refusal, unreadable project list, and the same matrix again under `--update-graph`.

Verified RED before the fix. The existing `test_cli_clean.py` still passes unchanged.

Note: `HELP_CLEAN_DB` keeps the literal phrase "Delete every project from" because `test_cli_smoke.py` asserts on it; the destructive marker was prepended rather than replacing it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added confirmation before `--clean` removes other projects from the shared graph.
  * Added `-y`/`--yes` to approve destructive cleaning, including automated runs.
  * Clean operations now stop safely when confirmation is declined, unavailable, or project information cannot be retrieved.

* **Documentation**
  * Clarified cleaning behavior in quick-start guides and the CLI reference.
  * Quick-start commands now update the graph without cleaning by default.
  * Documented how to add repositories and restart with an empty shared graph.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->