### PR TITLE
ci: smoke the built wheel against unlocked dependency resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,47 @@ jobs:
       - name: Test binary
         run: ./dist/code-graph-rag-* --version
 
+  # Every other job installs from uv.lock, so no job exercises the dependency
+  # resolution a real `pip install code-graph-rag` performs: newest versions
+  # satisfying the pyproject.toml floors. This job does, so a dependency that
+  # ships a breaking major inside our declared range fails here instead of in a
+  # user's terminal a week later (#1096).
+  wheel-fresh-resolution:
+    name: Wheel Smoke (unlocked resolution)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Build wheel
+        run: uv build --wheel
+
+      # Deliberately plain venv + pip: uv.lock must not participate.
+      - name: Install the wheel with unlocked resolution
+        run: |
+          python -m venv .fresh-venv
+          ./.fresh-venv/bin/python -m pip install --upgrade pip
+          ./.fresh-venv/bin/python -m pip install dist/*.whl
+
+      - name: Record resolved dependency versions
+        run: ./.fresh-venv/bin/python -m pip list
+
+      - name: Smoke the freshly resolved install
+        run: |
+          ./.fresh-venv/bin/python -c "import codebase_rag"
+          ./.fresh-venv/bin/cgr --version
+          ./.fresh-venv/bin/python scripts/smoke_wheel.py
+
   pr-title-check:
     name: PR Title Convention
     runs-on: ubuntu-latest
@@ -272,7 +313,15 @@ jobs:
     name: All Checks Pass
     runs-on: ubuntu-latest
     if: always()
-    needs: [lint, typecheck, test-unit, test-integration, binary-smoke]
+    needs:
+      [
+        lint,
+        typecheck,
+        test-unit,
+        test-integration,
+        binary-smoke,
+        wheel-fresh-resolution,
+      ]
     timeout-minutes: 5
 
     steps:
@@ -283,6 +332,7 @@ jobs:
           echo "Unit Tests: ${{ needs.test-unit.result }}"
           echo "Integration Tests: ${{ needs.test-integration.result }}"
           echo "Binary Smoke: ${{ needs.binary-smoke.result }}"
+          echo "Wheel Smoke: ${{ needs.wheel-fresh-resolution.result }}"
 
           if [[ "${{ needs.lint.result }}" != "success" ]]; then
             echo "❌ Lint failed"
@@ -302,6 +352,10 @@ jobs:
           fi
           if [[ "${{ needs.binary-smoke.result }}" != "success" ]]; then
             echo "❌ Binary smoke test failed"
+            exit 1
+          fi
+          if [[ "${{ needs.wheel-fresh-resolution.result }}" != "success" ]]; then
+            echo "❌ Wheel smoke test (unlocked resolution) failed"
             exit 1
           fi
           echo "✅ All checks passed!"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,8 +244,13 @@ jobs:
     timeout-minutes: 20
 
     steps:
+      # This job installs freshly resolved third-party packages and then runs
+      # repository code, so it must not leave the workflow token in the local
+      # git config for that code to read.
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1

--- a/codebase_rag/tests/test_wheel_smoke_job.py
+++ b/codebase_rag/tests/test_wheel_smoke_job.py
@@ -1,0 +1,114 @@
+"""Guards for the unlocked-resolution CI job (issue #1096).
+
+Every other CI job installs from ``uv.lock``, so a dependency shipping a
+breaking major inside our declared floors reaches PyPI unnoticed. The job and
+its smoke script are the only thing standing between that and a user's
+terminal, so both are pinned here.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+SMOKE_SCRIPT = REPO_ROOT / "scripts" / "smoke_wheel.py"
+
+JOB_ID = "wheel-fresh-resolution"
+GATE_JOB_ID = "all-checks-pass"
+
+
+def _workflow() -> dict:
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def _job_run_script(job: dict) -> str:
+    return "\n".join(step.get("run", "") for step in job["steps"])
+
+
+@pytest.fixture(scope="module")
+def smoke_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("smoke_wheel", SMOKE_SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["smoke_wheel"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestWorkflowJob:
+    def test_job_exists(self) -> None:
+        assert JOB_ID in _workflow()["jobs"], (
+            f"{JOB_ID} is the only CI job that resolves dependencies the way a "
+            "fresh `pip install code-graph-rag` does"
+        )
+
+    def test_job_builds_a_wheel_and_installs_it_without_the_lock(self) -> None:
+        script = _job_run_script(_workflow()["jobs"][JOB_ID])
+
+        assert "uv build" in script
+        assert "pip install dist/" in script
+        assert "uv sync" not in script, (
+            "uv sync installs from uv.lock, which is exactly the resolution "
+            "this job exists to avoid"
+        )
+        assert "uv run" not in script, (
+            "uv run resolves against uv.lock; the smoke must run from the "
+            "freshly resolved venv's interpreter"
+        )
+
+    def test_job_runs_the_smoke_script(self) -> None:
+        script = _job_run_script(_workflow()["jobs"][JOB_ID])
+
+        assert "scripts/smoke_wheel.py" in script
+        assert "cgr --version" in script
+
+    def test_failure_blocks_the_aggregate_gate(self) -> None:
+        gate = _workflow()["jobs"][GATE_JOB_ID]
+
+        assert JOB_ID in gate["needs"], (
+            f"{GATE_JOB_ID} must depend on {JOB_ID}, or the job can fail "
+            "without blocking a merge"
+        )
+        assert f"needs.{JOB_ID}.result" in _job_run_script(gate), (
+            f"{GATE_JOB_ID} lists {JOB_ID} but never checks its result"
+        )
+
+
+class TestSmokeScript:
+    def test_script_exists_and_defines_checks(self, smoke_module: ModuleType) -> None:
+        assert smoke_module.CHECKS, "the smoke script runs no checks"
+
+    def test_usage_property_check_passes_on_the_installed_pydantic_ai(
+        self, smoke_module: ModuleType
+    ) -> None:
+        # RED on pydantic-ai < 2.0, where `usage` is still callable (#964).
+        smoke_module.check_agent_run_result_usage_is_a_property()
+
+    def test_agent_loop_check_passes_on_the_installed_pydantic_ai(
+        self, smoke_module: ModuleType
+    ) -> None:
+        smoke_module.check_agent_loop_reports_usage()
+
+    def test_main_reports_failure_when_a_check_raises(
+        self, smoke_module: ModuleType, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def broken() -> None:
+            raise smoke_module.SmokeFailure("simulated dependency break")
+
+        monkeypatch.setattr(smoke_module, "CHECKS", (broken,))
+
+        assert smoke_module.main() == 1
+
+    def test_main_succeeds_when_every_check_passes(
+        self, smoke_module: ModuleType, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(smoke_module, "CHECKS", (lambda: None,))
+
+        assert smoke_module.main() == 0

--- a/codebase_rag/tests/test_wheel_smoke_job.py
+++ b/codebase_rag/tests/test_wheel_smoke_job.py
@@ -63,6 +63,17 @@ class TestWorkflowJob:
             "freshly resolved venv's interpreter"
         )
 
+    def test_checkout_does_not_persist_credentials(self) -> None:
+        # The job installs freshly resolved third-party packages and then runs
+        # repository code; a persisted workflow token would be readable by it.
+        checkout = next(
+            step
+            for step in _workflow()["jobs"][JOB_ID]["steps"]
+            if step.get("uses", "").startswith("actions/checkout")
+        )
+
+        assert checkout.get("with", {}).get("persist-credentials") is False
+
     def test_job_runs_the_smoke_script(self) -> None:
         script = _job_run_script(_workflow()["jobs"][JOB_ID])
 

--- a/codebase_rag/tests/test_wheel_smoke_job.py
+++ b/codebase_rag/tests/test_wheel_smoke_job.py
@@ -74,6 +74,17 @@ class TestWorkflowJob:
 
         assert checkout.get("with", {}).get("persist-credentials") is False
 
+    def test_job_installs_into_an_isolated_venv(self) -> None:
+        # The isolation is the point: the wheel must be exercised from a fresh
+        # interpreter, not from the lock-synced dev environment.
+        script = _job_run_script(_workflow()["jobs"][JOB_ID])
+
+        assert "python -m venv" in script
+        assert "./.fresh-venv/bin/python -m pip install dist/" in script
+        assert "./.fresh-venv/bin/python" in script, (
+            "the smoke must run on the fresh venv's interpreter"
+        )
+
     def test_job_runs_the_smoke_script(self) -> None:
         script = _job_run_script(_workflow()["jobs"][JOB_ID])
 

--- a/scripts/smoke_wheel.py
+++ b/scripts/smoke_wheel.py
@@ -1,0 +1,130 @@
+# ruff: noqa: T201
+"""Smoke the installed wheel against freshly resolved dependencies (issue #1096).
+
+CI otherwise only ever installs from ``uv.lock``, so a dependency that releases
+a breaking major inside our declared floor ships to PyPI unnoticed: #964 was a
+`pydantic-ai` 2.0 change that broke every fresh install for days while CI stayed
+green. This script runs against whatever versions plain resolution picked and
+exercises the third-party surfaces the app actually calls.
+
+Run it from a clean environment that has the wheel installed, not from a
+lock-synced dev checkout.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import sys
+from importlib.metadata import version
+
+
+class SmokeFailure(Exception):
+    """A dependency surface the application depends on has changed shape."""
+
+
+def check_package_imports() -> None:
+    """The installed wheel must be what imports, never the source checkout.
+
+    Running this from the repo root would otherwise let a working source tree
+    mask a wheel that cannot import at all.
+    """
+    import codebase_rag
+
+    module_file = getattr(codebase_rag, "__file__", None)
+    if not module_file:
+        raise SmokeFailure("codebase_rag imported without a module file")
+
+    print(f"      codebase_rag imported from {module_file}")
+    if "site-packages" not in module_file:
+        raise SmokeFailure(
+            f"codebase_rag was imported from {module_file}, which is not an "
+            "installed package; this smoke must run against the built wheel"
+        )
+
+
+def check_cli_entry_point() -> None:
+    from codebase_rag.cli import app
+
+    if app is None:
+        raise SmokeFailure("codebase_rag.cli.app is not importable")
+
+
+def check_agent_run_result_usage_is_a_property() -> None:
+    """`main.py` reads ``response.usage`` as an attribute, not a call."""
+    from pydantic_ai.agent import AgentRunResult
+
+    usage_attr = inspect.getattr_static(AgentRunResult, "usage")
+    if not isinstance(usage_attr, property):
+        raise SmokeFailure(
+            f"AgentRunResult.usage is {type(usage_attr).__name__}, not a property; "
+            f"codebase_rag/main.py reads it as an attribute "
+            f"(pydantic-ai {version('pydantic-ai')})"
+        )
+
+
+def check_agent_loop_reports_usage() -> None:
+    """Run a real agent turn against a stub model and price its usage.
+
+    This is the exact sequence `_run_agent_turn` performs: read ``.usage`` off
+    the result, pull token counts off it, and hand it to the pricing helper.
+    """
+    from pydantic_ai import Agent
+    from pydantic_ai.models.test import TestModel
+
+    from codebase_rag.services.usage_cost import price_run
+
+    agent = Agent(TestModel())
+    response = asyncio.run(agent.run("smoke"))
+
+    run_usage = response.usage
+    for field in ("input_tokens", "output_tokens"):
+        if not isinstance(getattr(run_usage, field, None), int):
+            raise SmokeFailure(
+                f"RunUsage.{field} is missing or not an int; "
+                f"codebase_rag/main.py accumulates it per turn "
+                f"(pydantic-ai {version('pydantic-ai')})"
+            )
+
+    # Unknown models have no public price, so None is the expected answer here;
+    # a raised exception is not.
+    price_run(run_usage, "test", "test-model")
+
+    if not response.new_messages():
+        raise SmokeFailure("agent run produced no messages to extend the history with")
+
+
+CHECKS = (
+    check_package_imports,
+    check_cli_entry_point,
+    check_agent_run_result_usage_is_a_property,
+    check_agent_loop_reports_usage,
+)
+
+
+def main() -> int:
+    failures: list[str] = []
+    for check in CHECKS:
+        try:
+            check()
+        except Exception as exc:
+            failures.append(f"{check.__name__}: {exc}")
+            print(f"FAIL  {check.__name__}: {exc}", file=sys.stderr)
+        else:
+            print(f"ok    {check.__name__}")
+
+    if failures:
+        print(
+            f"\n{len(failures)} smoke check(s) failed against freshly resolved "
+            "dependencies. A dependency released a breaking version inside the "
+            "range pyproject.toml declares.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"\nAll {len(CHECKS)} smoke checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #1096.

## The job

`wheel-fresh-resolution` does exactly what the issue proposes:

1. `uv build --wheel`
2. plain `python -m venv` + `pip install dist/*.whl` — **no `uv sync`, no `uv run`**, so `uv.lock` never participates
3. `python -c "import codebase_rag"`, `cgr --version`, then `scripts/smoke_wheel.py`

It is wired into `all-checks-pass` (both `needs:` and the result check), so a failure actually blocks a merge rather than going unnoticed.

## The smoke script

`scripts/smoke_wheel.py` exercises the third-party surfaces the app calls, not just import health:

- **`AgentRunResult.usage` is a property**, via `inspect.getattr_static`. This is the #964 break precisely.
- **A real agent turn** against pydantic-ai's `TestModel`: reads `response.usage`, pulls `input_tokens`/`output_tokens` off it, and hands it to `price_run` — the exact sequence `main.py` performs, with mocked responses and no network.
- **Imports resolve from site-packages**, not the source checkout. Without this the job would pass on a working source tree even if the wheel could not import at all.

## Verified end to end locally

- Built the wheel, installed it unlocked into a clean venv (resolution picked pydantic-ai 2.18.0), smoke passed and confirmed the import came from site-packages.
- Downgraded that venv to `pydantic-ai==1.102.0` — the version the lock held while every fresh install was broken — and the smoke **fails with exit 1**:
  ```
  FAIL  check_agent_run_result_usage_is_a_property: AgentRunResult.usage is
        _DeprecatedCallableProperty, not a property (pydantic-ai 1.102.0)
  ```
  Worth noting the agent-loop check still passes on 1.102.0, because `_DeprecatedCallableProperty` allows attribute access with a warning. That is exactly why the explicit property check earns its place.

`codebase_rag/tests/test_wheel_smoke_job.py` pins the job's shape (builds a wheel, installs without the lock, no `uv sync`/`uv run`, blocks the gate) so the guarantee cannot be quietly removed.

## Known gap

This catches a bad release on the next PR or push, not the day it happens — `ci.yml` has no `schedule` trigger and adding one would run every job nightly. Happy to add a scheduled trigger scoped to just this job if you want the tighter loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated validation for packaged builds installed with freshly resolved dependencies.
  * The overall quality gate now reports and blocks on packaged-build validation failures.

* **Tests**
  * Added smoke checks for package imports, command-line availability, agent execution, usage reporting, and pricing behavior.
  * Added coverage for dependency compatibility, workflow configuration, smoke-check execution, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->