### PR TITLE
fix: walk the C++ module qn map with --exclude and .cgrignore

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -360,6 +360,8 @@ class GraphUpdater:
                 structural_elements=(
                     self.factory.structure_processor.structural_elements
                 ),
+                exclude_paths=self.exclude_paths,
+                unignore_paths=self.unignore_paths,
             )
             logger.info(
                 ls.CPP_FRONTEND_HYBRID_PENDING.format(
@@ -376,6 +378,8 @@ class GraphUpdater:
             function_registry=self.function_registry,
             simple_name_lookup=self.simple_name_lookup,
             structural_elements=self.factory.structure_processor.structural_elements,
+            exclude_paths=self.exclude_paths,
+            unignore_paths=self.unignore_paths,
         )
         logger.info(
             ls.CPP_FRONTEND_COVERED.format(count=len(self._cpp_frontend_covered))

--- a/codebase_rag/parsers/cpp_frontend/frontend.py
+++ b/codebase_rag/parsers/cpp_frontend/frontend.py
@@ -803,6 +803,8 @@ def run_cpp_frontend(
     function_registry: FunctionRegistryTrieProtocol | None = None,
     simple_name_lookup: SimpleNameLookup | None = None,
     structural_elements: dict[Path, str | None] | None = None,
+    exclude_paths: frozenset[str] | None = None,
+    unignore_paths: frozenset[str] | None = None,
 ) -> frozenset[str]:
     """Index C/C++ via libclang + a compile_commands.json (macro-accurate).
 
@@ -821,7 +823,7 @@ def run_cpp_frontend(
     CONTAINS_MODULE (the full-replace path used by GraphUpdater).
     """
     collector = _Collector(
-        CppQnResolver(repo_path, project_name),
+        CppQnResolver(repo_path, project_name, exclude_paths, unignore_paths),
         function_registry,
         simple_name_lookup,
         structural_elements,
@@ -839,6 +841,8 @@ def run_cpp_frontend_hybrid(
     function_registry: FunctionRegistryTrieProtocol | None = None,
     simple_name_lookup: SimpleNameLookup | None = None,
     structural_elements: dict[Path, str | None] | None = None,
+    exclude_paths: frozenset[str] | None = None,
+    unignore_paths: frozenset[str] | None = None,
 ) -> tuple[list[PendingMacroCall], list[PendingExpansionCall]]:
     """Layer libclang's macro, alias, and include facts onto a tree-sitter index.
 
@@ -852,7 +856,7 @@ def run_cpp_frontend_hybrid(
     the caller joins each to tree-sitter definition spans after Pass 2.
     """
     collector = _Collector(
-        CppQnResolver(repo_path, project_name),
+        CppQnResolver(repo_path, project_name, exclude_paths, unignore_paths),
         function_registry,
         simple_name_lookup,
         structural_elements,

--- a/codebase_rag/parsers/cpp_frontend/qn.py
+++ b/codebase_rag/parsers/cpp_frontend/qn.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ... import constants as cs
-from ...utils.path_utils import should_skip_rel_file
+from ...utils.path_utils import should_keep_dir, should_skip_rel_file
 from ..cpp.utils import convert_operator_symbol_to_name
 from . import constants as fc
 
@@ -13,26 +13,47 @@ if TYPE_CHECKING:
     from clang.cindex import Cursor
 
 
-def _eligible_rel_files(repo_path: Path) -> list[str]:
+def _eligible_rel_files(
+    repo_path: Path,
+    exclude_paths: frozenset[str] | None = None,
+    unignore_paths: frozenset[str] | None = None,
+) -> list[str]:
     # Reproduce GraphUpdater._collect_eligible_files' ordering exactly: an
-    # os.walk with dirnames AND filenames sorted, top-down. The module-qn
-    # disambiguation below depends on this order (the file processed LATER in a
-    # basename collision gets its extension appended), so it must match cgr's
-    # tree-sitter pass to produce identical qualified names.
+    # os.walk with dirnames AND filenames sorted, top-down, pruned and filtered
+    # with the same predicates. The module-qn disambiguation below depends on
+    # this order (the file processed LATER in a basename collision gets its
+    # extension appended), so it must match cgr's tree-sitter pass to produce
+    # identical qualified names. Walking a different file set is what makes the
+    # two disagree: an excluded file claiming a base qn pushes the indexed file
+    # onto the suffixed one, and a .cgrignore rescue the map never sees leaves
+    # an indexed file with no qn at all (issue #1099).
     repo_str = str(repo_path)
     repo_prefix_len = len(repo_str) + 1
+    state_filenames = cs.CGR_STATE_FILENAMES
     rels: list[str] = []
     for dirpath, dirnames, filenames in os.walk(repo_str):
         rel_dir = "" if len(dirpath) < repo_prefix_len else dirpath[repo_prefix_len:]
         rel_dir = rel_dir.replace(os.sep, "/")
         dir_parts = tuple(rel_dir.split("/")) if rel_dir else ()
         dir_prefix = f"{rel_dir}/" if rel_dir else ""
-        dirnames[:] = sorted(dirnames)
+        dirnames[:] = sorted(
+            d
+            for d in dirnames
+            if should_keep_dir(d, dir_prefix, exclude_paths, unignore_paths)
+        )
         for fname in sorted(filenames):
+            if fname in state_filenames:
+                continue
             dot = fname.rfind(".")
             suffix = fname[dot:] if dot != -1 else ""
             rel_path_str = f"{dir_prefix}{fname}"
-            if not should_skip_rel_file(rel_path_str, dir_parts, suffix):
+            if not should_skip_rel_file(
+                rel_path_str,
+                dir_parts,
+                suffix,
+                exclude_paths=exclude_paths,
+                unignore_paths=unignore_paths,
+            ):
                 rels.append(rel_path_str)
     return rels
 
@@ -46,13 +67,18 @@ def _base_module_qn(rel: str, project_name: str) -> str:
     return cs.SEPARATOR_DOT.join([project_name, *parts])
 
 
-def build_module_qn_map(repo_path: Path, project_name: str) -> dict[str, str]:
+def build_module_qn_map(
+    repo_path: Path,
+    project_name: str,
+    exclude_paths: frozenset[str] | None = None,
+    unignore_paths: frozenset[str] | None = None,
+) -> dict[str, str]:
     # Mirror DefinitionProcessor._disambiguate_module_qn: a base qn is claimed
     # by the first file (in walk order); a later file colliding on that base qn
     # gets its extension appended (foo.cpp -> proj.foo, foo.h -> proj.foo.h).
     claimed: dict[str, str] = {}
     result: dict[str, str] = {}
-    for rel in _eligible_rel_files(repo_path):
+    for rel in _eligible_rel_files(repo_path, exclude_paths, unignore_paths):
         base = _base_module_qn(rel, project_name)
         existing = claimed.get(base)
         if existing is None or existing == rel:
@@ -73,10 +99,18 @@ class CppQnResolver:
     resolver), because the whole graph keys on them.
     """
 
-    def __init__(self, repo_path: Path, project_name: str) -> None:
+    def __init__(
+        self,
+        repo_path: Path,
+        project_name: str,
+        exclude_paths: frozenset[str] | None = None,
+        unignore_paths: frozenset[str] | None = None,
+    ) -> None:
         self.repo_path = repo_path.resolve()
         self.project_name = project_name
-        self._module_qn = build_module_qn_map(self.repo_path, project_name)
+        self._module_qn = build_module_qn_map(
+            self.repo_path, project_name, exclude_paths, unignore_paths
+        )
 
     def rel_path(self, absolute_file: str) -> str | None:
         try:

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -3084,7 +3084,10 @@ class ImportProcessor:
         """
         if self._cpp_module_qn_map is None:
             self._cpp_module_qn_map = build_module_qn_map(
-                self.repo_path, self.project_name
+                self.repo_path,
+                self.project_name,
+                self.exclude_paths,
+                self.unignore_paths,
             )
             self._cpp_qn_to_rel = {
                 qn: rel for rel, qn in self._cpp_module_qn_map.items()

--- a/codebase_rag/tests/test_cpp_qn_map_exclude_unignore.py
+++ b/codebase_rag/tests/test_cpp_qn_map_exclude_unignore.py
@@ -1,0 +1,137 @@
+"""Regression tests for the C++ module-qn map's walk filters (issue #1099).
+
+``build_module_qn_map`` reproduces ``GraphUpdater._collect_eligible_files`` so
+the libclang path synthesises qualified names byte-identical to the tree-sitter
+pass. It used to walk without ``--exclude``/``.cgrignore``, so the two saw
+different file sets and disagreed on the qn of any file caught by a basename
+collision.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parsers.cpp_frontend.qn import build_module_qn_map
+
+PROJECT = "proj"
+
+
+def _write(repo: Path, rel: str, body: str = "int x;\n") -> None:
+    target = repo / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(body, encoding="utf-8")
+
+
+def _indexer_rel_files(
+    repo: Path,
+    exclude_paths: frozenset[str] | None = None,
+    unignore_paths: frozenset[str] | None = None,
+) -> set[str]:
+    """The exact file set the tree-sitter pass would index."""
+    updater = GraphUpdater.__new__(GraphUpdater)
+    updater.repo_path = repo
+    updater.exclude_paths = exclude_paths
+    updater.unignore_paths = unignore_paths
+    updater._single_file = None
+    return {key for _path, key in updater._collect_eligible_files()}
+
+
+class TestExcludedFilesDoNotClaimQns:
+    def test_excluded_collision_partner_leaves_the_base_qn_free(
+        self, tmp_path: Path
+    ) -> None:
+        # foo.cpp sorts before foo.h, so it claims proj.foo and pushes foo.h
+        # onto proj.foo.h. Excluding foo.cpp must hand proj.foo back to foo.h,
+        # which is what the tree-sitter pass keys it as.
+        _write(tmp_path, "foo.cpp")
+        _write(tmp_path, "foo.h")
+
+        qn_map = build_module_qn_map(
+            tmp_path, PROJECT, exclude_paths=frozenset({"foo.cpp"})
+        )
+
+        assert "foo.cpp" not in qn_map
+        assert qn_map["foo.h"] == f"{PROJECT}.foo"
+
+    def test_unexcluded_collision_still_suffixes(self, tmp_path: Path) -> None:
+        _write(tmp_path, "foo.cpp")
+        _write(tmp_path, "foo.h")
+
+        qn_map = build_module_qn_map(tmp_path, PROJECT)
+
+        assert qn_map["foo.cpp"] == f"{PROJECT}.foo"
+        assert qn_map["foo.h"] == f"{PROJECT}.foo.h"
+
+    def test_excluded_directory_is_pruned(self, tmp_path: Path) -> None:
+        _write(tmp_path, "src/keep.cpp")
+        _write(tmp_path, "vendor/drop.cpp")
+
+        qn_map = build_module_qn_map(
+            tmp_path, PROJECT, exclude_paths=frozenset({"vendor"})
+        )
+
+        assert "src/keep.cpp" in qn_map
+        assert not any(rel.startswith("vendor/") for rel in qn_map)
+
+
+class TestUnignoreRescuedFilesGetQns:
+    def test_rescued_file_is_visible_to_the_map(self, tmp_path: Path) -> None:
+        # node_modules is a built-in ignore; a .cgrignore rescue puts it back
+        # in the index, so an #include resolving to it needs a qn.
+        _write(tmp_path, "src/main.cpp")
+        _write(tmp_path, "node_modules/lib/thing.h")
+
+        qn_map = build_module_qn_map(
+            tmp_path, PROJECT, unignore_paths=frozenset({"node_modules"})
+        )
+
+        assert qn_map["node_modules/lib/thing.h"] == f"{PROJECT}.node_modules.lib.thing"
+
+    def test_without_the_rescue_the_file_stays_invisible(self, tmp_path: Path) -> None:
+        _write(tmp_path, "src/main.cpp")
+        _write(tmp_path, "node_modules/lib/thing.h")
+
+        qn_map = build_module_qn_map(tmp_path, PROJECT)
+
+        assert "node_modules/lib/thing.h" not in qn_map
+
+
+class TestParityWithTheIndexerWalk:
+    def test_same_file_set_under_exclude(self, tmp_path: Path) -> None:
+        _write(tmp_path, "foo.cpp")
+        _write(tmp_path, "foo.h")
+        _write(tmp_path, "src/keep.cpp")
+        _write(tmp_path, "vendor/drop.cpp")
+        excludes = frozenset({"vendor", "foo.cpp"})
+
+        qn_map = build_module_qn_map(tmp_path, PROJECT, exclude_paths=excludes)
+
+        assert set(qn_map) == _indexer_rel_files(tmp_path, exclude_paths=excludes)
+
+    def test_same_file_set_under_unignore(self, tmp_path: Path) -> None:
+        _write(tmp_path, "src/main.cpp")
+        _write(tmp_path, "node_modules/lib/thing.h")
+        rescues = frozenset({"node_modules"})
+
+        qn_map = build_module_qn_map(tmp_path, PROJECT, unignore_paths=rescues)
+
+        assert set(qn_map) == _indexer_rel_files(tmp_path, unignore_paths=rescues)
+
+    def test_same_file_set_with_no_filters(self, tmp_path: Path) -> None:
+        _write(tmp_path, "foo.cpp")
+        _write(tmp_path, "foo.h")
+        _write(tmp_path, "src/deep/nested.hpp")
+
+        qn_map = build_module_qn_map(tmp_path, PROJECT)
+
+        assert set(qn_map) == _indexer_rel_files(tmp_path)
+
+    def test_state_files_are_skipped_like_the_indexer(self, tmp_path: Path) -> None:
+        _write(tmp_path, "src/main.cpp")
+        _write(tmp_path, ".cgr-hash-cache.json", "{}")
+
+        qn_map = build_module_qn_map(tmp_path, PROJECT)
+
+        assert ".cgr-hash-cache.json" not in qn_map
+        assert set(qn_map) == _indexer_rel_files(tmp_path)


### PR DESCRIPTION
Closes #1099.

## Changes

`cpp_frontend/qn.py::_eligible_rel_files` now mirrors `GraphUpdater._collect_eligible_files` completely:

- prunes directories with `should_keep_dir(...)` (it pruned nothing at all before)
- passes `exclude_paths`/`unignore_paths` to `should_skip_rel_file`
- skips `cs.CGR_STATE_FILENAMES`, which the indexer skips and this walk did not

`build_module_qn_map` and `CppQnResolver` take the two sets, threaded from `GraphUpdater` through `run_cpp_frontend` / `run_cpp_frontend_hybrid`, and from `ImportProcessor` (which already held both) at the include-resolution call site.

## Tests

`codebase_rag/tests/test_cpp_qn_map_exclude_unignore.py`:

- an excluded `foo.cpp` no longer claims `proj.foo`, so the indexed `foo.h` keeps it instead of being pushed onto `proj.foo.h`
- a `.cgrignore`-rescued file under `node_modules/` gets a qn instead of being invisible
- an excluded directory is pruned
- **parity**: the qn map's key set equals `GraphUpdater._collect_eligible_files`' file set, under exclude, under unignore, with no filters, and with a state file present

6 of the 9 fail without the fix. Full C++ suite: 462 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * C++ code indexing now consistently respects excluded and explicitly included paths across standard and hybrid processing.
  * Improved module-file discovery by skipping filtered directories, state files, and ineligible files.
  * Prevented incorrect qualified-name mappings caused by excluded files or filename collisions.

* **Tests**
  * Added coverage confirming filtering behavior and consistency between C++ indexing and repository file discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->