### PR TITLE
fix: gate Rust declaration reads on the indexer's exclude and unignore sets

### DIFF
--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -3,7 +3,7 @@ import os
 import posixpath
 import re
 import tomllib
-from collections.abc import Iterator, Mapping
+from collections.abc import Iterator, Mapping, Sequence
 from functools import lru_cache
 from pathlib import Path
 from typing import NamedTuple
@@ -1168,6 +1168,27 @@ class ImportProcessor:
             self._rust_dir_listing[key] = cached
         return cached
 
+    def _rust_file_is_indexed(self, rel_parts: Sequence[str]) -> bool:
+        """Whether the graph holds this file, per `--exclude` and `.cgrignore`.
+
+        The redirect sweep already walks with the indexer's predicate (#1088),
+        but the per-file declaration reads behind it did not, so a declaration
+        in a file the user excluded still decided where an indexed module sits
+        (issue #1100).
+        """
+        if not rel_parts:
+            return False
+        filename = rel_parts[-1]
+        dot = filename.rfind(cs.SEPARATOR_DOT)
+        suffix = filename[dot:] if dot != -1 else ""
+        return not should_skip_rel_file(
+            cs.SEPARATOR_SLASH.join(rel_parts),
+            tuple(rel_parts[:-1]),
+            suffix,
+            exclude_paths=self.exclude_paths,
+            unignore_paths=self.unignore_paths,
+        )
+
     def _rust_is_auto_target_dir(self, dir_parts: list[str], stem: str) -> bool:
         # Cargo auto-target locations whose .rs files are their OWN crate
         # roots: src/bin/*.rs, and examples/tests/benches/*.rs plus
@@ -1680,6 +1701,10 @@ class ImportProcessor:
         for entry in scan:
             if entry not in entries:
                 continue
+            if not self._rust_file_is_indexed([*dir_parts, entry]):
+                # An excluded entry file's `mod` declarations shape crate path
+                # and gate resolution for modules the graph does hold.
+                continue
             stem = entry.rsplit(cs.SEPARATOR_DOT, 1)[0]
             if stem in decls:
                 continue
@@ -1720,18 +1745,23 @@ class ImportProcessor:
         if not module_parts:
             return None
         parent = module_parts[:-1]
+        # A file the indexer skipped backs nothing: the graph holds no such
+        # module, so its declarations must not decide where an indexed one
+        # sits. Falling through lets mod.rs back the module when only the
+        # sibling .rs was excluded (issue #1100).
+        sibling = f"{module_parts[-1]}{cs.EXT_RS}"
         if (
             not dir_backed
-            and f"{module_parts[-1]}{cs.EXT_RS}"
-            in self._rust_dir_entries(self.repo_path.joinpath(*parent))
+            and sibling in self._rust_dir_entries(self.repo_path.joinpath(*parent))
+            and self._rust_file_is_indexed([*parent, sibling])
         ):
             path, base = (
-                self.repo_path.joinpath(*parent, f"{module_parts[-1]}{cs.EXT_RS}"),
+                self.repo_path.joinpath(*parent, sibling),
                 parent,
             )
         elif cs.MOD_RS in self._rust_dir_entries(
             self.repo_path.joinpath(*module_parts)
-        ):
+        ) and self._rust_file_is_indexed([*module_parts, cs.MOD_RS]):
             path, base = (
                 self.repo_path.joinpath(*module_parts, cs.MOD_RS),
                 module_parts,

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -2743,7 +2743,14 @@ class ImportProcessor:
             # _rust_entry_stem to its non-definitive fallback, letting the
             # item tie-break flip a definitive crate attribution.
             stems = self._rust_entry_mod_decls.get(tuple(dir_parts))
-            if stems is not None:
+            # The watcher's own relevance filter only knows the built-in
+            # ignores, so an `--exclude`d entry file still reaches here. Its
+            # declarations must not enter the cache: `_rust_entry_decls`
+            # gates its OWN reads, but returns whatever this path cached
+            # before that gate ever runs (issue #1100).
+            if stems is not None and self._rust_file_is_indexed(
+                [*dir_parts, file_path.name]
+            ):
                 try:
                     source = file_path.read_text(
                         encoding=cs.RS_ENCODING_UTF8, errors="ignore"

--- a/codebase_rag/tests/test_rust_decl_reads_ignore_filters.py
+++ b/codebase_rag/tests/test_rust_decl_reads_ignore_filters.py
@@ -166,3 +166,36 @@ def test_an_excluded_sibling_file_falls_through_to_mod_rs(
     )
     assert found is not None
     assert "extra" in found[0].mods, found
+
+
+def test_watch_refresh_does_not_cache_an_excluded_entry_file(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The watcher's relevance filter only knows the built-in ignores, so an
+    # excluded entry file still reaches refresh_rust_path_caches_for. If its
+    # declarations land in the cache, _rust_entry_decls returns them before
+    # its own exclude gate ever runs.
+    name = "rs_watch_excluded_entry"
+    project = temp_repo / name
+    _write(
+        project,
+        {
+            "Cargo.toml": CARGO.format(name=name),
+            "src/lib.rs": "pub mod alpha;\n",
+            "src/main.rs": "mod beta;\nfn main() {}\n",
+            "src/alpha.rs": "pub fn run() -> i32 {\n    1\n}\n",
+            "src/beta.rs": "pub fn run() -> i32 {\n    2\n}\n",
+        },
+    )
+    updater = create_and_run_updater(
+        project,
+        mock_ingestor,
+        skip_if_missing="rust",
+        exclude_paths=frozenset({"src/main.rs"}),
+    )
+    processor = updater.factory.import_processor
+
+    processor.refresh_rust_path_caches_for(project / "src" / "main.rs", created=False)
+
+    decls = processor._rust_entry_decls(["src"])
+    assert "main" not in decls, decls

--- a/codebase_rag/tests/test_rust_decl_reads_ignore_filters.py
+++ b/codebase_rag/tests/test_rust_decl_reads_ignore_filters.py
@@ -1,0 +1,168 @@
+"""Rust declaration reads must see exactly what the indexer indexes.
+
+The `#[path]` redirect sweep walks with the indexer's predicate (issue #1088),
+but the per-file declaration reads behind it read candidate declaring files
+straight from disk (issue #1100). A `mod` declaration in a file the user
+excluded then decides where an indexed module sits: the target keeps its
+physical `super::` climb into a tree the graph does not hold, instead of
+following the redirect that IS indexed.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.test_rust_crate_path_trait_linking import (
+    _calls,
+    _write,
+    create_and_run_updater,
+)
+
+CARGO = '[package]\nname = "{name}"\nversion = "0.1.0"\n'
+
+
+def _redirect_corpus(name: str) -> dict[str, str]:
+    # src/fixtures/mod.rs declares `rig` where the file physically sits, so
+    # rustc compiles it into that tree and the redirect in tools/gen.rs is
+    # suppressed. Excluding mod.rs removes that tree from the graph entirely.
+    return {
+        "Cargo.toml": CARGO.format(name=name),
+        "src/lib.rs": "pub mod fixtures;\n",
+        "src/fixtures/mod.rs": "pub mod rig;\npub mod sib;\n",
+        "src/fixtures/sib.rs": "pub fn run() -> i32 {\n    1\n}\n",
+        "src/fixtures/rig.rs": "pub fn build() -> i32 {\n    super::sib::run()\n}\n",
+        "tools/gen.rs": (
+            '#[path = "../src/fixtures/rig.rs"]\nmod rig;\nmod sib;\nfn main() {}\n'
+        ),
+        "tools/gen/sib.rs": "pub fn run() -> i32 {\n    9\n}\n",
+    }
+
+
+def test_an_indexed_declaring_neighbour_still_suppresses_the_redirect(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # Control: with every file indexed, the physical declaration wins and
+    # `super::` counts from src.fixtures, exactly as rustc does.
+    name = "rs_decl_neighbour_indexed"
+    project = temp_repo / name
+    _write(project, _redirect_corpus(name))
+
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    caller = f"{name}.src.fixtures.rig.build"
+    assert (caller, f"{name}.src.fixtures.sib.run") in calls, calls
+
+
+def test_an_excluded_declaring_neighbour_no_longer_suppresses_the_redirect(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # src/fixtures/mod.rs is excluded, so the graph holds no tree in which
+    # rig is declared where it sits. The only declaration the graph does hold
+    # is the redirect in tools/gen.rs, so `super::` must count from there.
+    name = "rs_decl_neighbour_excluded"
+    project = temp_repo / name
+    _write(project, _redirect_corpus(name))
+
+    updater = create_and_run_updater(
+        project,
+        mock_ingestor,
+        skip_if_missing="rust",
+        exclude_paths=frozenset({"src/fixtures/mod.rs"}),
+    )
+
+    processor = updater.factory.import_processor
+    assert not processor._rust_module_is_declared(["src", "fixtures", "rig"])
+
+    # The Module node stays keyed by the file's own path; it is the `super::`
+    # climb inside it that follows the redirect instead of the physical tree.
+    calls = _calls(mock_ingestor)
+    caller = f"{name}.src.fixtures.rig.build"
+    assert (caller, f"{name}.tools.gen.sib.run") in calls, calls
+    assert (caller, f"{name}.src.fixtures.sib.run") not in calls, calls
+
+
+def test_excluded_entry_file_declarations_do_not_shape_resolution(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # An entry file's `mod` declarations feed crate path and gate resolution.
+    # One the indexer skipped must contribute nothing to that map.
+    name = "rs_decl_entry_excluded"
+    project = temp_repo / name
+    _write(
+        project,
+        {
+            "Cargo.toml": CARGO.format(name=name),
+            "src/lib.rs": "pub mod alpha;\n",
+            "src/main.rs": "mod beta;\nfn main() {}\n",
+            "src/alpha.rs": "pub fn run() -> i32 {\n    1\n}\n",
+            "src/beta.rs": "pub fn run() -> i32 {\n    2\n}\n",
+        },
+    )
+
+    updater = create_and_run_updater(
+        project,
+        mock_ingestor,
+        skip_if_missing="rust",
+        exclude_paths=frozenset({"src/main.rs"}),
+    )
+
+    decls = updater.factory.import_processor._rust_entry_decls(["src"])
+    assert "main" not in decls, decls
+    assert "lib" in decls, decls
+
+
+def test_unexcluded_entry_files_still_contribute_declarations(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    name = "rs_decl_entry_indexed"
+    project = temp_repo / name
+    _write(
+        project,
+        {
+            "Cargo.toml": CARGO.format(name=name),
+            "src/lib.rs": "pub mod alpha;\n",
+            "src/main.rs": "mod beta;\nfn main() {}\n",
+            "src/alpha.rs": "pub fn run() -> i32 {\n    1\n}\n",
+            "src/beta.rs": "pub fn run() -> i32 {\n    2\n}\n",
+        },
+    )
+
+    updater = create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    decls = updater.factory.import_processor._rust_entry_decls(["src"])
+    assert {"lib", "main"} <= set(decls), decls
+    assert "beta" in decls["main"].mods, decls
+
+
+def test_an_excluded_sibling_file_falls_through_to_mod_rs(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # src/engine.rs and src/engine/mod.rs both back src.engine. Declaring
+    # both is a rustc error, but excluding one leaves the other as the only
+    # file the graph holds, so it must be the one whose declarations count.
+    name = "rs_decl_sibling_excluded"
+    project = temp_repo / name
+    _write(
+        project,
+        {
+            "Cargo.toml": CARGO.format(name=name),
+            "src/lib.rs": "pub mod engine;\n",
+            "src/engine.rs": "pub mod thing;\n",
+            "src/engine/mod.rs": "pub mod thing;\npub mod extra;\n",
+            "src/engine/thing.rs": "pub fn run() -> i32 {\n    1\n}\n",
+            "src/engine/extra.rs": "pub fn run() -> i32 {\n    2\n}\n",
+        },
+    )
+
+    updater = create_and_run_updater(
+        project,
+        mock_ingestor,
+        skip_if_missing="rust",
+        exclude_paths=frozenset({"src/engine.rs"}),
+    )
+
+    found = updater.factory.import_processor._rust_module_decls(
+        ["src", "engine"], want_mods=True
+    )
+    assert found is not None
+    assert "extra" in found[0].mods, found

--- a/codebase_rag/tests/test_rust_decl_reads_ignore_filters.py
+++ b/codebase_rag/tests/test_rust_decl_reads_ignore_filters.py
@@ -195,6 +195,13 @@ def test_watch_refresh_does_not_cache_an_excluded_entry_file(
     )
     processor = updater.factory.import_processor
 
+    # Establish the precondition explicitly: the refresh only writes when the
+    # entry-declaration cache already holds this directory, so without this
+    # the assertion below could hold for the wrong reason.
+    primed = processor._rust_entry_decls(["src"])
+    assert "lib" in primed, primed
+    assert "main" not in primed, primed
+
     processor.refresh_rust_path_caches_for(project / "src" / "main.rs", created=False)
 
     decls = processor._rust_entry_decls(["src"])


### PR DESCRIPTION
Closes #1100.

Follows #1088/#1102: the redirect sweep's *walk* now uses the indexer's predicate, but the per-file reads behind it still read from disk unfiltered.

## Changes

New `ImportProcessor._rust_file_is_indexed(rel_parts)` — the same `should_skip_rel_file` check `_swept_rust_files` already uses — gates both disk reads:

- **`_rust_entry_decls`**: an excluded entry file's `mod` declarations no longer shape crate path and gate resolution.
- **`_rust_module_decls`**: an excluded `engine.rs` no longer backs `src.engine`, and the lookup **falls through** to `engine/mod.rs` when only the sibling was excluded — the file the graph actually holds is the one whose declarations count.

`_rust_module_is_declared` is fixed transitively; it reads only through those two.

## Tests

`codebase_rag/tests/test_rust_decl_reads_ignore_filters.py`, in the style of the #1088 tests:

- **the issue's headline case**: `src/fixtures/mod.rs` declares `rig` where the file sits, suppressing the redirect in `tools/gen.rs`. Excluding `mod.rs` removes that tree from the graph, so `super::` inside `rig.rs` must now follow the redirect that *is* indexed. Asserted both via `_rust_module_is_declared` and via the recorded CALLS edge.
- an excluded entry file contributes no declarations; an unexcluded one still does
- the `mod.rs` fall-through

Two of the five are controls that pass either way; the other three are RED without the fix. Full Rust suite: 875 passed.

One clarification vs. the issue text: the target Module node stays keyed by its own file path. It is the `super::` climb *inside* it that follows the redirect, not the node's qn.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Rust module resolution when files are excluded by ignore filters.
  * Excluded entry files and sibling modules no longer incorrectly affect declaration resolution.
  * Valid alternative module declarations are now detected correctly.
  * Watch refreshes no longer cache declarations from excluded entry files.

* **Tests**
  * Added regression coverage for indexed and excluded Rust files, redirects, entry declarations, fallback module resolution, and watch refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->