### PR TITLE
fix: resolve Rust super:: and self:: calls through the written path

### DIFF
--- a/codebase_rag/constants/ast_rust.py
+++ b/codebase_rag/constants/ast_rust.py
@@ -4,6 +4,7 @@ from .ast_java import TS_GENERIC_TYPE
 from .ast_nodes import TS_IDENTIFIER, TS_SCOPED_IDENTIFIER, TS_TYPE_IDENTIFIER
 from .ast_scala import TS_GENERIC_FUNCTION
 from .core import KEYWORD_SELF, KEYWORD_SUPER
+from .graph import NodeLabel
 
 TS_RS_SCOPED_TYPE_IDENTIFIER = "scoped_type_identifier"
 TS_RS_PRIMITIVE_TYPE = "primitive_type"
@@ -213,6 +214,19 @@ RS_MANIFEST_TARGET_TABLE_KEY = "target"
 # Crates shipped with the toolchain: external by construction, no
 # manifest needed to know a use head naming one is outside the project.
 RS_STDLIB_CRATES = frozenset({"std", "core", "alloc", "proc_macro"})
+
+# Node labels a Rust qn segment carries when it is a TYPE the caller sits
+# inside (an impl block), not an inline `mod`. An impl adds no module level,
+# so `super::` inside a method counts from the file module's parent (#1093).
+RS_TYPE_SCOPE_LABELS = frozenset(
+    {
+        NodeLabel.CLASS.value,
+        NodeLabel.INTERFACE.value,
+        NodeLabel.ENUM.value,
+        NodeLabel.TYPE.value,
+        NodeLabel.UNION.value,
+    }
+)
 
 # Traits the Rust prelude puts in scope with no `use`: an impl naming one
 # without importing it and without a same-named first-party declaration

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -919,6 +919,7 @@ class CallProcessor:
         ast_cache: ASTCacheProtocol | None = None,
         go_package_names: Mapping[str, str] | None = None,
         rehydrated_definition_paths: dict[str, str] | None = None,
+        declared_module_qns: set[str] | None = None,
     ) -> None:
         self.ingestor = ingestor
         self.repo_path = repo_path
@@ -957,6 +958,7 @@ class CallProcessor:
             type_aliases=type_aliases,
             interface_implementers=interface_implementers,
             rehydrated_definition_paths=rehydrated_definition_paths,
+            declared_module_qns=declared_module_qns,
         )
         # Inter-procedural callable-parameter flow: ordered params per function and
         # the per-call-site argument bindings, resolved to a fixpoint in finalize.

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -860,6 +860,26 @@ class CallResolver:
             if scoped is not None:
                 return scoped[0]
 
+        # A `crate::`/`self::`/`super::` path says outright which module holds
+        # the item, so it must not reach the probes that answer by NAME. Both
+        # the same-module and the import probe ignore the prefix and hand back
+        # the caller's OWN item of that name, which for `super::` is one module
+        # too low (issue #1093). Undecided here means the path names nothing
+        # first-party, so the ordinary fallbacks still run.
+        if (
+            language == cs.SupportedLanguage.RUST
+            and cs.SEPARATOR_DOUBLE_COLON in call_name
+            and call_name.split(cs.SEPARATOR_DOUBLE_COLON, 1)[0]
+            in (cs.RUST_CRATE_KEYWORD, cs.KEYWORD_SELF, cs.KEYWORD_SUPER)
+        ):
+            prefixed, decided = self._try_resolve_rust_module_qualified(
+                call_name, module_qn, caller_qn
+            )
+            if decided:
+                if use_cache:
+                    self._simple_resolution_cache[cache_key] = prefixed
+                return prefixed
+
         # Rust name resolution prefers items defined in the module itself: a
         # glob import NEVER shadows a local item, and a MODULE-scoped named
         # use colliding with one is a compile error (E0255). A use inside a
@@ -1540,11 +1560,13 @@ class CallResolver:
         caller_qn: str | None,
     ) -> tuple[tuple[str, str] | None, bool]:
         # crate:: is chain-independent; self::/super:: resolve against the
-        # caller's innermost enclosing MOD chain, which a caller nested
-        # below the file module (an inline mod or an impl block,
-        # indistinguishable in qn space) does not expose, so those stay
-        # with the ordinary fallbacks.
-        if object_path[0] != cs.RUST_CRATE_KEYWORD and self._rust_enclosing_scopes(
+        # caller's innermost enclosing MOD chain. An impl block also nests
+        # below the file module but is NOT a mod: `super::` inside a method
+        # counts from the file module's parent exactly as it does in a free
+        # function, and the type registry is what tells the two apart
+        # (issue #1093). A genuine inline mod chain still stays with the
+        # ordinary fallbacks (issue #1086).
+        if object_path[0] != cs.RUST_CRATE_KEYWORD and self._rust_enclosing_mod_scopes(
             module_qn, caller_qn
         ):
             return None, False
@@ -1569,6 +1591,22 @@ class CallResolver:
             scopes.append(scope)
             scope = scope.rsplit(cs.SEPARATOR_DOT, 1)[0]
         return scopes
+
+    def _rust_enclosing_mod_scopes(
+        self, module_qn: str, caller_qn: str | None
+    ) -> list[str]:
+        """Enclosing scopes that are inline `mod` blocks, not impl targets.
+
+        `_rust_enclosing_scopes` deliberately keeps impl targets, whose use
+        storage keys mirror mod scopes. A `super::` path cares which is which:
+        an impl block adds no module level, so a method's `super::` counts
+        from the file module's parent, while an inline mod's does not.
+        """
+        return [
+            scope
+            for scope in self._rust_enclosing_scopes(module_qn, caller_qn)
+            if self.function_registry.get(scope) not in cs.RS_TYPE_SCOPE_LABELS
+        ]
 
     def _decide_rust_module_item(
         self, mapped: str, rest: list[str], item: str, owner: str

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -86,6 +86,7 @@ class CallResolver:
         "_pending_field_bindings",
         "_module_language_cache",
         "rehydrated_definition_paths",
+        "declared_module_qns",
     )
 
     def __init__(
@@ -97,11 +98,20 @@ class CallResolver:
         type_aliases: dict[str, str] | None = None,
         interface_implementers: dict[str, set[str]] | None = None,
         rehydrated_definition_paths: dict[str, str] | None = None,
+        declared_module_qns: set[str] | None = None,
     ) -> None:
         self.function_registry = function_registry
         self.import_processor = import_processor
         self.type_inference = type_inference
         self.class_inheritance = class_inheritance
+        # Every inline `mod` qn the class pass ingested (shared ref). A Rust
+        # enclosing scope is an inline mod IFF it is in here: an impl target is
+        # not, and neither is registered under a type label when it is a
+        # primitive or an unindexed foreign type, so absence-of-a-type-label
+        # cannot tell the two apart (issue #1093 review).
+        self.declared_module_qns = (
+            declared_module_qns if declared_module_qns is not None else set()
+        )
         # {interface_qn: [implementer_qns]} (shared ref, populated during
         # ingestion). Used to redirect an interface-typed call to the single
         # concrete implementer's method (call-graph accuracy; single-impl only).
@@ -1601,11 +1611,17 @@ class CallResolver:
         storage keys mirror mod scopes. A `super::` path cares which is which:
         an impl block adds no module level, so a method's `super::` counts
         from the file module's parent, while an inline mod's does not.
+
+        Membership of the ingested inline-mod set is what decides it. Asking
+        the type registry instead only proves a scope is NOT a registered
+        type, which an impl target on a primitive or an unindexed foreign type
+        also is not (`impl Trait for u8`), so that test silently read those
+        impl blocks as modules and left `super::` one level short.
         """
         return [
             scope
             for scope in self._rust_enclosing_scopes(module_qn, caller_qn)
-            if self.function_registry.get(scope) not in cs.RS_TYPE_SCOPE_LABELS
+            if scope in self.declared_module_qns
         ]
 
     def _decide_rust_module_item(

--- a/codebase_rag/parsers/factory.py
+++ b/codebase_rag/parsers/factory.py
@@ -166,5 +166,6 @@ class ProcessorFactory:
                 rehydrated_definition_paths=(
                     self.definition_processor.rehydrated_definition_paths
                 ),
+                declared_module_qns=self.definition_processor.declared_module_qns,
             )
         return self._call_processor

--- a/codebase_rag/tests/test_rust_super_self_prefix_calls.py
+++ b/codebase_rag/tests/test_rust_super_self_prefix_calls.py
@@ -154,3 +154,34 @@ def test_use_super_item_declaration_still_resolves(
     calls = _calls(mock_ingestor)
     caller = f"{name}.src.engine.thing.build"
     assert (caller, f"{name}.src.engine.helper") in calls, calls
+
+
+def test_super_from_an_impl_on_an_unregistered_type_still_climbs(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `impl Trait for u8` has no Class node, so a scope that is merely absent
+    # from the type registry cannot be assumed to be an inline mod: doing so
+    # left `super::` one level short and bound the call inside this file.
+    name = "rs_super_primitive_impl"
+    project = temp_repo / name
+    _write(
+        project,
+        {
+            "Cargo.toml": CARGO.format(name=name),
+            "src/lib.rs": "pub mod area;\npub fn helper() -> i32 {\n    1\n}\n",
+            "src/area.rs": (
+                "pub fn helper() -> i32 {\n    9\n}\n"
+                "pub trait LocalTrait {\n    fn run(&self) -> i32;\n}\n"
+                "impl LocalTrait for u8 {\n"
+                "    fn run(&self) -> i32 {\n        super::helper()\n    }\n"
+                "}\n"
+            ),
+        },
+    )
+
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    caller = f"{name}.src.area.u8.run"
+    assert (caller, f"{name}.src.lib.helper") in calls, calls
+    assert (caller, f"{name}.src.area.helper") not in calls, calls

--- a/codebase_rag/tests/test_rust_super_self_prefix_calls.py
+++ b/codebase_rag/tests/test_rust_super_self_prefix_calls.py
@@ -1,0 +1,156 @@
+"""`super::`/`self::` calls must climb, not bind in the caller's own module.
+
+`_try_resolve_via_imports` answers a `super::item()` call with the item of that
+name in the caller's OWN module and never honours the prefix, and it runs before
+the Rust module-qualified probe that knows how to climb (issue #1093). The
+failure only surfaces when both modules hold the name; with only the outer one
+present the call drops instead, which is cheaper but still not rustc's edge.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.test_rust_crate_path_trait_linking import (
+    _calls,
+    _write,
+    create_and_run_updater,
+)
+
+CARGO = '[package]\nname = "{name}"\nversion = "0.1.0"\n'
+
+
+def test_super_call_from_an_impl_block_climbs_one_module(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    name = "rs_super_impl"
+    project = temp_repo / name
+    _write(
+        project,
+        {
+            "Cargo.toml": CARGO.format(name=name),
+            "src/lib.rs": "pub mod engine;\n",
+            "src/engine.rs": "pub mod thing;\npub fn helper() -> i32 {\n    1\n}\n",
+            "src/engine/thing.rs": (
+                "pub struct S;\n"
+                "pub fn helper() -> i32 {\n    9\n}\n"
+                "impl S {\n"
+                "    pub fn build() -> i32 {\n        super::helper()\n    }\n"
+                "}\n"
+            ),
+        },
+    )
+
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    caller = f"{name}.src.engine.thing.S.build"
+    assert (caller, f"{name}.src.engine.helper") in calls, calls
+    assert (caller, f"{name}.src.engine.thing.helper") not in calls, calls
+
+
+def test_super_call_from_a_free_function_climbs_one_module(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The impl block is incidental: it is the `super::` prefix reaching the
+    # import probe that decides, not the enclosing scope.
+    name = "rs_super_free"
+    project = temp_repo / name
+    _write(
+        project,
+        {
+            "Cargo.toml": CARGO.format(name=name),
+            "src/lib.rs": "pub mod engine;\n",
+            "src/engine.rs": "pub mod thing;\npub fn helper() -> i32 {\n    1\n}\n",
+            "src/engine/thing.rs": (
+                "pub fn helper() -> i32 {\n    9\n}\n"
+                "pub fn build() -> i32 {\n    super::helper()\n}\n"
+            ),
+        },
+    )
+
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    caller = f"{name}.src.engine.thing.build"
+    assert (caller, f"{name}.src.engine.helper") in calls, calls
+    assert (caller, f"{name}.src.engine.thing.helper") not in calls, calls
+
+
+def test_self_call_binds_in_the_callers_own_module(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `self::helper()` names THIS module's item, so the same-named outer one
+    # must not win either.
+    name = "rs_self_prefix"
+    project = temp_repo / name
+    _write(
+        project,
+        {
+            "Cargo.toml": CARGO.format(name=name),
+            "src/lib.rs": "pub mod engine;\n",
+            "src/engine.rs": "pub mod thing;\npub fn helper() -> i32 {\n    1\n}\n",
+            "src/engine/thing.rs": (
+                "pub fn helper() -> i32 {\n    9\n}\n"
+                "pub fn build() -> i32 {\n    self::helper()\n}\n"
+            ),
+        },
+    )
+
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    caller = f"{name}.src.engine.thing.build"
+    assert (caller, f"{name}.src.engine.thing.helper") in calls, calls
+    assert (caller, f"{name}.src.engine.helper") not in calls, calls
+
+
+def test_super_call_with_no_local_shadow_still_climbs(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # With only the outer item present the call used to drop rather than bind
+    # wrongly; it must reach the parent module either way.
+    name = "rs_super_no_shadow"
+    project = temp_repo / name
+    _write(
+        project,
+        {
+            "Cargo.toml": CARGO.format(name=name),
+            "src/lib.rs": "pub mod engine;\n",
+            "src/engine.rs": "pub mod thing;\npub fn helper() -> i32 {\n    1\n}\n",
+            "src/engine/thing.rs": (
+                "pub fn build() -> i32 {\n    super::helper()\n}\n"
+            ),
+        },
+    )
+
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    caller = f"{name}.src.engine.thing.build"
+    assert (caller, f"{name}.src.engine.helper") in calls, calls
+
+
+def test_use_super_item_declaration_still_resolves(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `use super::item;` resolves through the import half and is out of scope
+    # for this fix; pinned so the reordering does not disturb it.
+    name = "rs_use_super"
+    project = temp_repo / name
+    _write(
+        project,
+        {
+            "Cargo.toml": CARGO.format(name=name),
+            "src/lib.rs": "pub mod engine;\n",
+            "src/engine.rs": "pub mod thing;\npub fn helper() -> i32 {\n    1\n}\n",
+            "src/engine/thing.rs": (
+                "use super::helper;\npub fn build() -> i32 {\n    helper()\n}\n"
+            ),
+        },
+    )
+
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    caller = f"{name}.src.engine.thing.build"
+    assert (caller, f"{name}.src.engine.helper") in calls, calls


### PR DESCRIPTION
Closes #1093.

## Root cause, confirmed by reproduction

The issue's corpus reproduces exactly: `_try_resolve_via_imports` answers `super::helper()` with the caller's OWN `helper`, never honouring the prefix, and it runs before `_try_resolve_rust_module_qualified` — so `_resolve_rust_prefixed_path`, which knows how to climb, is never reached.

```
recorded: rs.src.engine.thing.S.build -> rs.src.engine.thing.helper
rustc:    rs.src.engine.thing.S.build -> rs.src.engine.helper
```

## Changes

**1. The prefixed-path probe gets first refusal.** A call whose first segment is `crate::`/`self::`/`super::` says outright which module holds the item, so it must not reach probes that answer by name. Undecided still falls through to every existing fallback, so nothing else changes.

**2. The enclosing-scope bail now distinguishes an impl block from an inline mod.** `_resolve_rust_prefixed_path` declined any caller nested below the file module because the two are "indistinguishable in qn space". They are distinguishable via the type registry: new `_rust_enclosing_mod_scopes` filters out scopes registered as `Class`/`Interface`/`Enum`/`Type`/`Union` (new `RS_TYPE_SCOPE_LABELS`). An impl block adds no module level, so a method's `super::` counts from the file module's parent exactly as a free function's does.

Change 1 alone fixes the free-function case; the issue's headline repro is inside an `impl`, which needs change 2 as well.

**This does not encroach on #1086.** A genuine inline `mod` chain still triggers the bail and keeps today's behaviour. Only impl targets are filtered out.

## Tests

`codebase_rag/tests/test_rust_super_self_prefix_calls.py`:

- the issue's exact corpus, `super::` from inside an `impl`
- the same from a free function (the impl is incidental, as the issue notes)
- **`self::helper()`** — the adjacent case the issue flags, pinned so the outer same-named item cannot win
- `super::` with no local shadow, which used to drop rather than bind wrongly
- `use super::item;`, out of scope here, pinned so the reordering does not disturb it

Two fail without the fix; all five pass with it.

## Regression coverage

Full unit suite: **6502 passed, 79 skipped**, no failures. `ruff` and `ty` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved resolution of Rust module-qualified calls using `crate::`, `self::`, and `super::`.
  - Corrected `super::` behavior from implementation blocks and free functions.
  - Preserved resolution for `use super::...` imports and calls without local name shadowing.

- **Tests**
  - Added regression coverage for Rust module, implementation-block, and import-based call resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->