### PR TITLE
fix: claim nothing for an unrepresentable Rust #[path] target

### DIFF
--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -1546,6 +1546,11 @@ class CallResolver:
         base = self.import_processor._rust_resolve_relative(
             module_qn, list(object_path), module_qn
         )
+        if base is None:
+            # The path runs through a `#[path]` target the qn scheme cannot
+            # key, so no module here is its referent: a decided drop, never a
+            # bare-name guess at the shadow file (issue #1082).
+            return None, True
         return self._decide_rust_base(base, item)
 
     def _rust_self_module_head(
@@ -1584,6 +1589,8 @@ class CallResolver:
         base = self.import_processor._rewrite_rust_local_use_path(
             cs.SEPARATOR_DOUBLE_COLON.join(object_path), effective_qn
         )
+        if base is None:
+            return None, True
         if cs.SEPARATOR_DOUBLE_COLON in base:
             return None, False
         return self._decide_rust_base(base, item)
@@ -1681,6 +1688,8 @@ class CallResolver:
         head_qn = self.import_processor._rust_resolve_relative(
             owner, segments[:1], owner
         )
+        if head_qn is None:
+            return None
         if (
             head_qn in self.type_inference.module_qn_to_file_path
             or head_qn in self.import_processor.import_mapping

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -251,7 +251,7 @@ class ClassIngestMixin:
 
     def _resolve_rust_trait_qn(
         self, path: str, name: str, module_qn: str
-    ) -> tuple[str, str | None]:
+    ) -> tuple[str | None, str | None]:
         """Qn for the trait an `impl ... for Type` block names, and a fallback.
 
         Resolving the SIMPLE name alone ends in a project-wide sweep that any
@@ -274,9 +274,14 @@ class ClassIngestMixin:
             rewritten = self.import_processor._rewrite_rust_local_use_path(
                 path, module_qn
             )
-            if rewritten is None or rewritten == path:
-                # None means the path runs through a `#[path]` target the qn
-                # scheme cannot key, so it names nothing here (issue #1082).
+            if rewritten is None:
+                # The path runs through a `#[path]` target the qn scheme
+                # cannot key. Falling back to the name-anchored candidate
+                # would let a same-named indexed trait collect IMPLEMENTS and
+                # OVERRIDES edges it has no claim to, which is the very
+                # shadow-binding this drop exists to prevent (issue #1082).
+                return None, None
+            if rewritten == path:
                 return anchored, None
             return rewritten, anchored
         # The head is itself a name a `use` may have bound (`use std::io;`
@@ -1269,12 +1274,20 @@ class ClassIngestMixin:
         # from the trait map as no information and guesses (issue #1078).
         impl_method_qns: list[str] = []
         trait_impl_method_qns: list[str] | None = None
-        if trait_name := rs_utils.extract_impl_trait(class_node):
-            trait_qn, alt_trait_qn = self._resolve_rust_trait_qn(
+        trait_name = rs_utils.extract_impl_trait(class_node)
+        trait_qn, alt_trait_qn = (
+            self._resolve_rust_trait_qn(
                 rs_utils.extract_impl_trait_path(class_node) or trait_name,
                 trait_name,
                 owner_module_qn,
             )
+            if trait_name
+            else (None, None)
+        )
+        # No trait qn means the written path runs through a `#[path]` target
+        # the qn scheme cannot key, so no first-party trait is its referent
+        # and this block records no IMPLEMENTS edge at all (issue #1082).
+        if trait_name and trait_qn is not None:
             # The trait (or the impl target) may live in a file not yet
             # parsed; hold the IMPLEMENTS edge back for
             # resolve_deferred_inherits so an unresolvable trait
@@ -1748,7 +1761,13 @@ class ClassIngestMixin:
         relative = self.import_processor._rust_resolve_relative(
             module_qn, [*chain, module_name], module_qn
         )
-        candidates = {relative} if relative is not None else set()
+        if relative is None:
+            # The declaration redirects through a `#[path]` target the qn
+            # scheme cannot key. The name-derived spellings below would hand
+            # its `#[cfg(test)]` gating to whatever indexed module happens to
+            # occupy one of those names (issue #1082).
+            return set()
+        candidates = {relative}
         if chain:
             # A chain declaration's target FILE lives under the declaring
             # file's directory tree regardless of the inline qn nesting

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -274,7 +274,11 @@ class ClassIngestMixin:
             rewritten = self.import_processor._rewrite_rust_local_use_path(
                 path, module_qn
             )
-            return (rewritten, anchored) if rewritten != path else (anchored, None)
+            if rewritten is None or rewritten == path:
+                # None means the path runs through a `#[path]` target the qn
+                # scheme cannot key, so it names nothing here (issue #1082).
+                return anchored, None
+            return rewritten, anchored
         # The head is itself a name a `use` may have bound (`use std::io;`
         # then `impl io::Read`), and only the expanded crate says who speaks
         # for the trait.
@@ -710,13 +714,16 @@ class ClassIngestMixin:
             bound = self.import_processor.import_mapping.get(owner, {}).get(item)
             if not bound:
                 return None
-            qn = (
+            resolved = (
                 bound
                 if bound.startswith(f"{self.project_name}{cs.SEPARATOR_DOT}")
                 else self.import_processor._rust_resolve_relative(
                     owner, bound.split(cs.SEPARATOR_DOUBLE_COLON), owner
                 )
             )
+            if resolved is None:
+                return None
+            qn = resolved
             if qn in seen:
                 # Two modules re-exporting each other's name never declare it.
                 return None
@@ -1738,11 +1745,10 @@ class ClassIngestMixin:
             # where the qn scheme keys the module, so the name-derived
             # spellings below back nothing at all here (issue #1035).
             return {redirect}
-        candidates = {
-            self.import_processor._rust_resolve_relative(
-                module_qn, [*chain, module_name], module_qn
-            )
-        }
+        relative = self.import_processor._rust_resolve_relative(
+            module_qn, [*chain, module_name], module_qn
+        )
+        candidates = {relative} if relative is not None else set()
         if chain:
             # A chain declaration's target FILE lives under the declaring
             # file's directory tree regardless of the inline qn nesting

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -1908,13 +1908,18 @@ class ImportProcessor:
 
     def _rust_walk_mods(
         self, parts: list[str], rest: list[str], dir_backed: bool = False
-    ) -> list[str]:
+    ) -> list[str] | None:
         """Walk a path tail from a resolved module prefix, honouring `#[path]`.
 
         Only the crate ENTRY's redirects are read above, and the tail used to
         attach by name straight past a redirect declared in any other file,
         landing on a qn no module owns or on an undeclared shadow file that
         happens to sit where the declared name points (issue #1065).
+
+        None when a redirect names a file the qn scheme cannot key, which is
+        NOT the same as no redirect at all: no qn names the module, so the
+        caller must drop rather than fall back to the declared name and bind
+        whatever sibling happens to sit there (issue #1082).
         """
         out = list(parts)
         for index, segment in enumerate(rest):
@@ -1926,12 +1931,12 @@ class ImportProcessor:
                 break
             decls, base = found
             redirect = decls.redirects.get(segment)
-            target = (
-                rs_utils.path_attribute_qn_parts(base, redirect) if redirect else None
-            )
-            if redirect is None or target is None:
+            if redirect is None:
                 out, dir_backed = [*out, segment], False
                 continue
+            target = rs_utils.path_attribute_qn_parts(base, redirect)
+            if target is None:
+                return None
             # A redirect onto a `mod.rs` names the DIRECTORY, and the qn
             # scheme drops the `mod` segment, so the resulting parts are
             # indistinguishable from a plain file module: without this the
@@ -1943,14 +1948,15 @@ class ImportProcessor:
 
     def _rust_join_mods(
         self, parts: list[str], rest: list[str], dir_backed: bool = False
-    ) -> str:
-        return cs.SEPARATOR_DOT.join(
-            [self.project_name, *self._rust_walk_mods(parts, rest, dir_backed)]
-        )
+    ) -> str | None:
+        walked = self._rust_walk_mods(parts, rest, dir_backed)
+        if walked is None:
+            return None
+        return cs.SEPARATOR_DOT.join([self.project_name, *walked])
 
     def _rust_attach(
         self, dir_parts: list[str], stem: str, rest: list[str], definitive: bool
-    ) -> str:
+    ) -> str | None:
         # A crate-root-relative path: the first segment names either a
         # submodule FILE/directory beside the entry point (crate::flags ->
         # src.flags) or an item/inline mod declared IN the entry file
@@ -1966,13 +1972,18 @@ class ImportProcessor:
             if redirect := chosen.redirects.get(rest[0]):
                 # The declaration names its backing file outright, and the
                 # module keys under that file, so the declared name never
-                # appears in the qn at all (issue #1035).
-                if target := rs_utils.path_attribute_qn_parts(dir_parts, redirect):
-                    return self._rust_join_mods(
-                        target,
-                        rest[1:],
-                        redirect.rsplit(cs.SEPARATOR_SLASH, 1)[-1] == cs.MOD_RS,
-                    )
+                # appears in the qn at all (issue #1035). A target the qn
+                # scheme cannot key names no module here: falling through to
+                # the declared name would bind an undeclared sibling that
+                # merely sits where the name points (issue #1082).
+                target = rs_utils.path_attribute_qn_parts(dir_parts, redirect)
+                if target is None:
+                    return None
+                return self._rust_join_mods(
+                    target,
+                    rest[1:],
+                    redirect.rsplit(cs.SEPARATOR_SLASH, 1)[-1] == cs.MOD_RS,
+                )
             if rest[0] in file_mods:
                 return self._rust_join_mods([*dir_parts, rest[0]], rest[1:])
             if rest[0] in items:
@@ -1996,7 +2007,7 @@ class ImportProcessor:
 
     def _rust_resolve_relative(
         self, base_qn: str, rest: list[str], importer_qn: str
-    ) -> str:
+    ) -> str | None:
         """Attach path segments to a super::/self:: base module.
 
         The base may be an ordinary file module (children append: src/foo.rs
@@ -2039,6 +2050,8 @@ class ImportProcessor:
         if not rest:
             return base_qn
         walked = self._rust_walk_mods(parts, rest)
+        if walked is None:
+            return None
         if walked == [*parts, *rest]:
             # No redirect fired, so keep base_qn verbatim rather than
             # rebuilding it from project_name, which re-splits differently
@@ -2051,7 +2064,7 @@ class ImportProcessor:
         full_path: str,
         module_qn: str,
         local_mods: frozenset[str] = frozenset(),
-    ) -> str:
+    ) -> str | None:
         """Rewrite a crate::/super::/self:: use path to a project qn.
 
         Stored raw, these paths resolve nowhere: class resolution hands them
@@ -2063,6 +2076,10 @@ class ImportProcessor:
         way, unless a `mod` in the declaring scope (local_mods) claims it:
         rustc binds the local module first (issue #1033). External paths
         (std::fmt) pass through unchanged.
+
+        None when the path runs through a `#[path]` target the qn scheme
+        cannot key: no qn names that module, so a caller must drop rather
+        than record a spelling (issue #1082).
         """
         parts = full_path.split(cs.SEPARATOR_DOUBLE_COLON)
         head = parts[0]
@@ -2085,7 +2102,7 @@ class ImportProcessor:
             return self._rust_attach(list(dir_parts), stem, parts[1:], definitive=True)
         return full_path
 
-    def _rust_rewrite_crate_path(self, rest: list[str], module_qn: str) -> str:
+    def _rust_rewrite_crate_path(self, rest: list[str], module_qn: str) -> str | None:
         root = self._rust_crate_root(module_qn)
         if root is None:
             return (
@@ -2805,6 +2822,13 @@ class ImportProcessor:
             resolved = self._rewrite_rust_local_use_path(
                 full_path, resolve_qn, local_mods
             )
+            if resolved is None:
+                # The path runs through a `#[path]` target the qn scheme
+                # cannot key. Recording the raw spelling would externalise it
+                # into a phantom module node, and recording the name-derived
+                # one would bind a shadow file, so the name stays unbound
+                # (issue #1082).
+                continue
             if imported_name.startswith(cs.RS_SELF_MODULE_PREFIX):
                 imported_name = imported_name[len(cs.RS_SELF_MODULE_PREFIX) :]
                 # A `{self}` item binds a MODULE, which lives in Rust's type

--- a/codebase_rag/tests/test_rust_unrepresentable_path_target.py
+++ b/codebase_rag/tests/test_rust_unrepresentable_path_target.py
@@ -1,0 +1,123 @@
+"""An unrepresentable `#[path]` target must claim nothing at all.
+
+`path_attribute_qn_parts` returns None for a target the qn scheme cannot key
+(an absolute path, a Windows separator, a climb above the repo root). Crate-path
+resolution treated that exactly like a declaration with NO redirect and fell
+back to the name-derived module, binding an undeclared sibling that happens to
+sit where the declared name points (issue #1082). The gate side already stands
+down for these; the crate-path side did not.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.test_rust_crate_path_trait_linking import (
+    _calls,
+    _write,
+    create_and_run_updater,
+)
+
+CARGO = '[package]\nname = "{name}"\nversion = "0.1.0"\n'
+
+
+def _corpus(name: str, redirect: str) -> dict[str, str]:
+    return {
+        "Cargo.toml": CARGO.format(name=name),
+        "src/lib.rs": (f'#[path = "{redirect}"]\nmod helpers;\npub mod a;\n'),
+        "src/helpers.rs": "pub fn fixture() -> i32 {\n    1\n}\n",
+        "src/a.rs": "pub fn run() -> i32 {\n    crate::helpers::fixture()\n}\n",
+    }
+
+
+def _helper_edges(mock_ingestor: MagicMock, name: str) -> set[tuple[str, str]]:
+    return {
+        pair
+        for pair in _calls(mock_ingestor)
+        if pair[0] == f"{name}.src.a.run" and "helpers" in pair[1]
+    }
+
+
+def test_absolute_redirect_binds_no_shadow(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # src/helpers.rs is declared by nobody; the module is backed by a file
+    # outside the indexed tree, so nothing in the graph is its referent.
+    name = "rs_path_absolute"
+    project = temp_repo / name
+    _write(project, _corpus(name, "/nowhere/helpers.rs"))
+
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    assert _helper_edges(mock_ingestor, name) == set()
+
+
+def test_windows_separator_redirect_binds_no_shadow(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    name = "rs_path_windows"
+    project = temp_repo / name
+    _write(project, _corpus(name, "..\\\\outside\\\\helpers.rs"))
+
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    assert _helper_edges(mock_ingestor, name) == set()
+
+
+def test_climb_above_repo_root_binds_no_shadow(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    name = "rs_path_climb"
+    project = temp_repo / name
+    _write(project, _corpus(name, "../../../outside/helpers.rs"))
+
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    assert _helper_edges(mock_ingestor, name) == set()
+
+
+def test_a_representable_redirect_still_binds_its_target(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # Control: an in-tree redirect must keep working, keying under the file
+    # it names rather than the declared module name.
+    name = "rs_path_ok"
+    project = temp_repo / name
+    _write(
+        project,
+        {
+            "Cargo.toml": CARGO.format(name=name),
+            "src/lib.rs": (
+                '#[path = "fixtures/helpers.rs"]\nmod helpers;\npub mod a;\n'
+            ),
+            "src/fixtures/helpers.rs": "pub fn fixture() -> i32 {\n    2\n}\n",
+            "src/a.rs": "pub fn run() -> i32 {\n    crate::helpers::fixture()\n}\n",
+        },
+    )
+
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    assert (f"{name}.src.a.run", f"{name}.src.fixtures.helpers.fixture") in calls, calls
+
+
+def test_no_redirect_still_binds_the_named_module(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # Control: a declaration with no `#[path]` at all is the case the buggy
+    # branch conflated the unrepresentable target with. It must be unaffected.
+    name = "rs_path_none"
+    project = temp_repo / name
+    _write(
+        project,
+        {
+            "Cargo.toml": CARGO.format(name=name),
+            "src/lib.rs": "mod helpers;\npub mod a;\n",
+            "src/helpers.rs": "pub fn fixture() -> i32 {\n    1\n}\n",
+            "src/a.rs": "pub fn run() -> i32 {\n    crate::helpers::fixture()\n}\n",
+        },
+    )
+
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    assert (f"{name}.src.a.run", f"{name}.src.helpers.fixture") in calls, calls

--- a/codebase_rag/tests/test_rust_unrepresentable_path_target.py
+++ b/codebase_rag/tests/test_rust_unrepresentable_path_target.py
@@ -121,3 +121,44 @@ def test_no_redirect_still_binds_the_named_module(
 
     calls = _calls(mock_ingestor)
     assert (f"{name}.src.a.run", f"{name}.src.helpers.fixture") in calls, calls
+
+
+def _implements(mock_ingestor: MagicMock) -> set[tuple[str, str]]:
+    return {
+        (call[0][0][2], call[0][2][2])
+        for call in mock_ingestor.ensure_relationship_batch.call_args_list
+        if call[0][1] == "IMPLEMENTS"
+    }
+
+
+def test_trait_path_through_an_unrepresentable_redirect_binds_no_trait(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `crate::helpers::Base` runs through a redirect the qn scheme cannot key.
+    # Falling back to the name-anchored candidate would hand the same-named
+    # indexed trait in src/other.rs an IMPLEMENTS edge it has no claim to.
+    name = "rs_path_trait"
+    project = temp_repo / name
+    _write(
+        project,
+        {
+            "Cargo.toml": CARGO.format(name=name),
+            "src/lib.rs": (
+                '#[path = "/nowhere/helpers.rs"]\nmod helpers;\n'
+                "pub mod other;\npub mod user;\n"
+            ),
+            "src/helpers.rs": "pub trait Base {\n    fn go(&self) -> i32;\n}\n",
+            "src/other.rs": "pub trait Base {\n    fn go(&self) -> i32;\n}\n",
+            "src/user.rs": (
+                "pub struct S;\n"
+                "impl crate::helpers::Base for S {\n"
+                "    fn go(&self) -> i32 {\n        1\n    }\n"
+                "}\n"
+            ),
+        },
+    )
+
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    edges = _implements(mock_ingestor)
+    assert not [pair for pair in edges if pair[1].endswith("Base")], edges


### PR DESCRIPTION
Closes #1082.

> **Stacked on #1111 (issue #1086) → #1110 (issue #1093)**, which touch adjacent lines in the same resolver. Merge in that order and each retargets cleanly.

## Change

The issue's framing was the design: both sites classify the same thing, so both must be able to say *"no qn names this module"* rather than return a spelling.

`_rust_walk_mods` conflated the two cases in one condition:

```python
if redirect is None or target is None:      # attach by name
```

They are not the same. No redirect means attach by name; a redirect whose target the qn scheme cannot key means **nothing here is the module's referent**. Split, and return `None` for the second. `_rust_attach` had the identical fall-through and gets the identical treatment.

`None` then propagates through `_rust_join_mods` → `_rust_resolve_relative` / `_rust_rewrite_crate_path` → `_rewrite_rust_local_use_path`, and each consumer does the right thing with it:

- `_try_resolve_rust_module_qualified` and `_resolve_rust_prefixed_path` return a **decided drop** — never an undecided fall-through, which would let a bare-name trie guess find the shadow anyway.
- Rust `use` storage skips the binding entirely. Recording the raw spelling would externalise it into a phantom module node (#1007); recording the name-derived one would bind the shadow.
- The class-ingest trait-path and re-export-chase sites drop the candidate.

## Tests

`codebase_rag/tests/test_rust_unrepresentable_path_target.py` covers all three unrepresentable forms `path_attribute_qn_parts` rejects — absolute path, Windows separator, climb above the repo root — each asserting no edge to the undeclared `src/helpers.rs` shadow, plus two controls:

- a representable in-tree redirect still keys under the file it names
- a declaration with **no** `#[path]` at all still binds the named module — the case the buggy branch conflated it with

Three fail without the fix; both controls pass either way.

Rust + import-parsing + class-ingest suites: 952 passed. `ty` clean.