### PR TITLE
fix: drop a module's function_locations before it re-parses

### DIFF
--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -15,7 +15,7 @@ from ..types_defs import (
     CppDefinitionSpan,
     DeferredCppInherit,
     DeferredInherit,
-    FunctionLocation,
+    FunctionLocations,
     FunctionRegistryTrieProtocol,
     FunctionSpanKey,
     RustTraitImpl,
@@ -207,7 +207,7 @@ class DefinitionProcessor(
         # method node Pass 2 registered, so Pass-3 caller attribution reuses
         # the registered label/qn instead of re-deriving them structurally
         # (the walks diverge on preprocessor-distorted class bodies).
-        self.function_locations: dict[FunctionSpanKey, FunctionLocation] = {}
+        self.function_locations: FunctionLocations = FunctionLocations()
         # {rel path: [full line spans]} of every C/C++ function/method the
         # tree-sitter pass ingested; the hybrid C++ frontend's macro-use
         # CALLS resolve against these after Pass 2 (see CppDefinitionSpan).
@@ -369,6 +369,13 @@ class DefinitionProcessor(
                         cache_entry[key] = combined_captures[key]
                 if cache_entry:
                     self._func_class_captures_cache[file_path] = cache_entry
+
+            # A reused updater's second run re-parses this module into a map
+            # still holding the first run's spans. The key is (module_qn,
+            # line, col), so a function renamed in place keeps its key and the
+            # first-claim guard would block the live registration, filing body
+            # `use` imports under the dead qn (issue #1019).
+            self.function_locations.drop_module(module_qn)
 
             self.import_processor.parse_imports(
                 root_node,

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -17,6 +17,7 @@ from ..types_defs import (
     DeferredCppInherit,
     DeferredParentLink,
     FunctionLocation,
+    FunctionLocations,
     FunctionRegistryTrieProtocol,
     FunctionSpanKey,
     NodeType,
@@ -236,7 +237,7 @@ class FunctionIngestMixin:
     method_return_types: dict[str, str]
     go_function_return_types: dict[str, str]
     cpp_out_of_class_methods: dict[tuple[str, int], tuple[str, str]]
-    function_locations: dict[FunctionSpanKey, FunctionLocation]
+    function_locations: FunctionLocations
     cpp_definition_spans: dict[str, list[CppDefinitionSpan]]
     macro_qns: set[str]
     _deferred_js_anonymous: list[_DeferredRegistration]

--- a/codebase_rag/tests/test_function_locations_reuse.py
+++ b/codebase_rag/tests/test_function_locations_reuse.py
@@ -1,0 +1,134 @@
+"""`function_locations` must not survive a module's re-parse (issue #1019).
+
+The map is keyed by `(module_qn, start_line, start_col)` and was never cleared
+between runs of a reused GraphUpdater. A function renamed in place keeps its
+start position, so a second run reads the dead qn and files the enclosing
+method's body `use` under it; the live qn then resolves through the file map and
+binds the wrong helper.
+
+The codebase defends exactly this invariant elsewhere -- `reset_rust_path_caches`
+and `reset_js_receiver_bindings` exist so a reused updater's second run stays
+correct -- so it is pinned here the same way.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.tests.test_rust_crate_path_trait_linking import _calls, _write
+
+CARGO = '[package]\nname = "{name}"\nversion = "0.1.0"\n'
+
+
+def _method_source(method_name: str, tail: str = "") -> str:
+    return (
+        "use crate::beta::helper;\n"
+        "\n"
+        "pub struct S;\n"
+        "\n"
+        "impl S {\n"
+        f"    pub fn {method_name}(&self) -> u32 {{\n"
+        "        use crate::alpha::helper;\n"
+        "        helper()\n"
+        "    }\n"
+        "}\n"
+        "\n"
+        "pub fn f() -> u32 {\n"
+        "    helper()\n"
+        "}\n"
+        f"{tail}"
+    )
+
+
+def _corpus(name: str, method_name: str) -> dict[str, str]:
+    return {
+        "Cargo.toml": CARGO.format(name=name),
+        "src/lib.rs": "pub mod alpha;\npub mod beta;\npub mod foo;\n",
+        "src/alpha.rs": "pub fn helper() -> u32 {\n    1\n}\n",
+        "src/beta.rs": "pub fn helper() -> u32 {\n    2\n}\n",
+        "src/foo.rs": _method_source(method_name),
+    }
+
+
+def _reused_updater(project: Path, mock_ingestor: MagicMock) -> GraphUpdater:
+    parsers, queries = load_parsers()
+    if "rust" not in parsers:
+        pytest.skip("rust parser not available")
+    return GraphUpdater(
+        ingestor=mock_ingestor,
+        repo_path=project,
+        parsers=parsers,
+        queries=queries,
+    )
+
+
+def test_renamed_method_does_not_resolve_through_the_dead_qn(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    name = "rs_reuse_rename"
+    project = temp_repo / name
+    _write(project, _corpus(name, "run"))
+
+    updater = _reused_updater(project, mock_ingestor)
+    updater.run()
+
+    # Renamed in place: same start line and column, so the stale span key
+    # still matches and hands back FunctionLocation(qualified_name=...run).
+    _write(project, {"src/foo.rs": _method_source("go")})
+    mock_ingestor.reset_mock()
+    updater.run()
+
+    calls = _calls(mock_ingestor)
+    live = f"{name}.src.foo.S.go"
+    assert (live, f"{name}.src.alpha.helper") in calls, calls
+    assert (live, f"{name}.src.beta.helper") not in calls, calls
+
+
+def test_function_locations_hold_no_entry_for_the_dead_qn(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    name = "rs_reuse_map"
+    project = temp_repo / name
+    _write(project, _corpus(name, "run"))
+
+    updater = _reused_updater(project, mock_ingestor)
+    updater.run()
+
+    _write(project, {"src/foo.rs": _method_source("go")})
+    updater.run()
+
+    located = {
+        location.qualified_name
+        for location in updater.factory.definition_processor.function_locations.values()
+    }
+    assert f"{name}.src.foo.S.go" in located, located
+    assert f"{name}.src.foo.S.run" not in located, located
+
+
+def test_unchanged_module_keeps_resolving_across_runs(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # Control: purging on re-parse must not lose a module whose functions
+    # kept their names. The trailing item makes the file re-parse; without a
+    # content change the run is skipped as in-sync and records nothing.
+    name = "rs_reuse_stable"
+    project = temp_repo / name
+    _write(project, _corpus(name, "run"))
+
+    updater = _reused_updater(project, mock_ingestor)
+    updater.run()
+
+    _write(
+        project,
+        {"src/foo.rs": _method_source("run", "\npub fn added() -> u32 {\n    3\n}\n")},
+    )
+    mock_ingestor.reset_mock()
+    updater.run()
+
+    calls = _calls(mock_ingestor)
+    live = f"{name}.src.foo.S.run"
+    assert (live, f"{name}.src.alpha.helper") in calls, calls
+    assert (f"{name}.src.foo.f", f"{name}.src.beta.helper") in calls, calls

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -1,7 +1,14 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Awaitable, Callable, ItemsView, KeysView, Sequence
+from collections.abc import (
+    Awaitable,
+    Callable,
+    ItemsView,
+    KeysView,
+    Mapping,
+    Sequence,
+)
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
@@ -593,6 +600,41 @@ class FunctionLocation(NamedTuple):
     # node registered for `exports.f = function`), while a generated record
     # keeps the historical bubble-to-module attribution.
     is_named: bool = True
+
+
+class FunctionLocations(dict[FunctionSpanKey, FunctionLocation]):
+    """`function_locations` that knows which module each span came from.
+
+    A reused GraphUpdater re-parses a module into a map still holding the
+    previous run's spans, and the key is (module_qn, start_line, start_col):
+    a function renamed in place keeps its key, so the stale record survives
+    and the first-claim guard blocks the live registration (issue #1019).
+
+    Nine call sites across the definition and class passes write into this
+    map, so the module index is maintained by the map itself rather than at
+    each of them, where the next new write site would silently miss it.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._by_module: dict[str, set[FunctionSpanKey]] = {}
+
+    def __setitem__(self, key: FunctionSpanKey, value: FunctionLocation) -> None:
+        super().__setitem__(key, value)
+        self._by_module.setdefault(key[0], set()).add(key)
+
+    def update(  # type: ignore[override]
+        self, other: Mapping[FunctionSpanKey, FunctionLocation]
+    ) -> None:
+        # dict.update bypasses __setitem__ on a subclass, which would leave
+        # the index blind to whatever it wrote.
+        for key, value in other.items():
+            self[key] = value
+
+    def drop_module(self, module_qn: str) -> None:
+        """Forget every span record a module contributed, before it re-parses."""
+        for key in self._by_module.pop(module_qn, ()):
+            super().pop(key, None)
 
 
 class CppDefinitionSpan(NamedTuple):


### PR DESCRIPTION
Closes #1019.

Branches off `main` — independent of the other Rust PRs in flight.

## Change

`function_locations` is keyed by `(module_qn, start_line, start_col)` and was never cleared between runs of a reused GraphUpdater. A function renamed in place keeps its key, so the stale record survives, `_claim_function_span`'s first-claim guard blocks the live registration, and `finalise_rust_function_scope_uses` files the method's body `use` under the dead qn.

The issue suggested tracking the keys per module. I found **nine** write sites across the definition and class passes, so instead of wrapping each one — where the next new write site would silently miss the index — the map maintains the index itself: `FunctionLocations` (a `dict` subclass in `types_defs.py`) records `key[0]` on every `__setitem__` and exposes `drop_module(module_qn)`. `update` is overridden too, since `dict.update` bypasses `__setitem__` on a subclass.

`DefinitionProcessor.process_file` calls `drop_module` before the module's ingestion passes run. Cost stays proportional to the re-parsed file, as the issue asked.

## Tests

`codebase_rag/tests/test_function_locations_reuse.py` executes the two-run sequence against one updater instance:

- the renamed method resolves through its own body `use` (`alpha`), not the file-level one (`beta`)
- `function_locations` holds the live qn and no longer the dead one
- **control**: a module whose functions kept their names still resolves after a re-parse

The first two fail without the fix, reproducing the issue's predicted symptom exactly — `foo.S.go CALLS beta.helper` — and the map showing `foo.S.run` with no `foo.S.go` at all.

## Note on severity

Still latent in production: every CLI and MCP path builds a fresh updater. This pins the invariant the codebase already defends with `reset_rust_path_caches` and `reset_js_receiver_bindings`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed stale function mappings when reprocessing modules with reused parsing sessions.
  - Updated method renames to resolve to their current locations instead of outdated entries.
  - Preserved correct resolution for unchanged methods after module re-parsing.

- **Tests**
  - Added regression coverage for refreshed and reused parsing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->