### PR TITLE
fix: name a Rust inline mod under class scope by one qn rule

### DIFF
--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -1661,10 +1661,9 @@ class ClassIngestMixin:
                 continue
 
             module_name = safe_decode_text(module_name_node)
-            nested_qn = id_.build_nested_qualified_name_for_class(
+            inline_module_qn = self._rust_inline_module_qn(
                 module_node, module_qn, module_name or "", lang_config
             )
-            inline_module_qn = nested_qn or f"{module_qn}.{module_name}"
 
             module_props: PropertyDict = {
                 cs.KEY_QUALIFIED_NAME: inline_module_qn,
@@ -1694,12 +1693,19 @@ class ClassIngestMixin:
             self.declared_module_qns.add(inline_module_qn)
 
             # Link the inline module into the containment tree: its enclosing
-            # module (file module, or an outer mod) DEFINES it. Without this the
-            # inline Module node is an orphan defining nothing.
-            parent_module_qn = inline_module_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
-            if parent_module_qn and parent_module_qn != inline_module_qn:
+            # scope DEFINES it. Without this the inline Module node is an
+            # orphan defining nothing. The parent is not always a Module: a
+            # `mod` written in a trait const initializer or an impl method
+            # body hangs off the TYPE, whose node carries a Class/Interface/
+            # Enum label, and a hard-coded Module label dangles (issue #1018).
+            parent_qn = inline_module_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
+            if parent_qn and parent_qn != inline_module_qn:
                 self.ingestor.ensure_relationship_batch(
-                    (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, parent_module_qn),
+                    (
+                        self._registered_label(parent_qn),
+                        cs.KEY_QUALIFIED_NAME,
+                        parent_qn,
+                    ),
                     cs.RelationshipType.DEFINES,
                     (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, inline_module_qn),
                 )
@@ -1710,6 +1716,34 @@ class ClassIngestMixin:
             if ungated_targets:
                 decl_props[cs.KEY_RUST_UNGATED_MODS] = sorted(ungated_targets)
             self.ingestor.ensure_node_batch(cs.NodeLabel.MODULE, decl_props)
+
+    def _rust_inline_module_qn(
+        self,
+        module_node: Node,
+        module_qn: str,
+        module_name: str,
+        lang_config: LanguageSpec,
+    ) -> str:
+        """The qn of an inline `mod`, under the scope rule its own items use.
+
+        Module ingestion named these by mod and type segments while the
+        function fqn walk also keeps the enclosing IMPL target, so a `mod`
+        written in an impl method body became `foo.inner` while the functions
+        inside it registered as `foo.S.inner.g`: the Module node, its DEFINES
+        edge, and its contents landed under three different qns (issue #1018).
+        """
+        chain = rs_utils.build_module_path(
+            module_node,
+            include_impl_targets=True,
+            include_classes=True,
+            class_node_types=lang_config.class_node_types,
+        )
+        return cs.SEPARATOR_DOT.join([module_qn, *chain, module_name])
+
+    def _registered_label(self, qn: str) -> cs.NodeLabel:
+        """The label a qn was registered under, for an edge endpoint match."""
+        node_type = self.function_registry.get(qn)
+        return cs.NodeLabel(node_type.value) if node_type else cs.NodeLabel.MODULE
 
     def _rust_cfg_test_candidates(
         self,

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -2068,10 +2068,22 @@ class FunctionIngestMixin:
 
         # A Rust item inside `mod inner` is contained by that inline module, not the
         # file module. Its enclosing module qn is the file module plus the mod path;
-        # the inline Module node carries that exact qn.
-        if language == cs.SupportedLanguage.RUST and (
-            mod_parts := rs_utils.build_module_path(func_node)
+        # the inline Module node carries that exact qn, so this walk has to use the
+        # scope rule the Module node was named under -- type and impl segments
+        # included -- or the DEFINES edge names a module that does not exist
+        # (issue #1018).
+        # The mods-only walk is what decides whether an inline `mod` encloses
+        # this item at all; the full walk then spells that module the way its
+        # Module node was named.
+        if language == cs.SupportedLanguage.RUST and rs_utils.build_module_path(
+            func_node
         ):
+            mod_parts = rs_utils.build_module_path(
+                func_node,
+                include_impl_targets=True,
+                include_classes=True,
+                class_node_types=lang_config.class_node_types,
+            )
             nested = module_qn + cs.SEPARATOR_DOT + cs.SEPARATOR_DOT.join(mod_parts)
             return cs.NodeLabel.MODULE, nested, None
 

--- a/codebase_rag/tests/test_rust_inline_mod_under_class_scope.py
+++ b/codebase_rag/tests/test_rust_inline_mod_under_class_scope.py
@@ -1,0 +1,123 @@
+"""An inline `mod` under a trait or impl body needs ONE qn scheme.
+
+The module ingestion pass names such a module by mod segments only
+(`foo.inner`) while the function fqn walk keeps the class segment
+(`foo.T.inner.g`). The Module node, its DEFINES edge, and the functions inside
+it then sit under divergent qns, so the graph audit reports both an orphan
+Module node and a dangling DEFINES edge (issue #1018).
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.tests.test_rust_crate_path_trait_linking import (
+    _write,
+    create_and_run_updater,
+)
+
+CARGO = '[package]\nname = "{name}"\nversion = "0.1.0"\n'
+
+TRAIT_CONST = """pub trait T {
+    const C: u32 = {
+        mod inner {
+            pub const fn g() -> u32 { 1 }
+        }
+        inner::g()
+    };
+}
+"""
+
+TRAIT_DEFAULT_METHOD = """pub trait T {
+    fn run(&self) -> u32 {
+        mod inner {
+            pub fn g() -> u32 { 1 }
+        }
+        inner::g()
+    }
+}
+"""
+
+IMPL_BODY = """pub struct S;
+
+impl S {
+    pub fn run(&self) -> u32 {
+        mod inner {
+            pub fn g() -> u32 { 1 }
+        }
+        inner::g()
+    }
+}
+"""
+
+
+def _module_qns(mock_ingestor: MagicMock) -> set[str]:
+    return {
+        call[0][1]["qualified_name"]
+        for call in mock_ingestor.ensure_node_batch.call_args_list
+        if call[0][0] == "Module"
+    }
+
+
+def _function_qns(mock_ingestor: MagicMock) -> set[str]:
+    return {
+        call[0][1]["qualified_name"]
+        for call in mock_ingestor.ensure_node_batch.call_args_list
+        if call[0][0] in ("Function", "Method")
+    }
+
+
+def _index(temp_repo: Path, mock_ingestor: MagicMock, name: str, foo: str) -> None:
+    project = temp_repo / name
+    _write(
+        project,
+        {
+            "Cargo.toml": CARGO.format(name=name),
+            "src/lib.rs": "pub mod foo;\n",
+            "src/foo.rs": foo,
+        },
+    )
+    # create_and_run_updater runs the graph audit, which fails on the orphan
+    # Module node and the dangling DEFINES edge this issue produces.
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+
+def test_inline_mod_in_a_trait_const_initializer(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    name = "rs_mod_trait_const"
+    _index(temp_repo, mock_ingestor, name, TRAIT_CONST)
+
+    modules = _module_qns(mock_ingestor)
+    functions = _function_qns(mock_ingestor)
+    inner = {qn for qn in modules if qn.endswith(".inner")}
+    assert len(inner) == 1, modules
+    holder = next(iter(inner))
+    assert any(qn.startswith(f"{holder}.") for qn in functions), (holder, functions)
+
+
+def test_inline_mod_in_a_trait_default_method(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    name = "rs_mod_trait_method"
+    _index(temp_repo, mock_ingestor, name, TRAIT_DEFAULT_METHOD)
+
+    modules = _module_qns(mock_ingestor)
+    functions = _function_qns(mock_ingestor)
+    inner = {qn for qn in modules if qn.endswith(".inner")}
+    assert len(inner) == 1, modules
+    holder = next(iter(inner))
+    assert any(qn.startswith(f"{holder}.") for qn in functions), (holder, functions)
+
+
+def test_inline_mod_in_an_impl_method(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    name = "rs_mod_impl_method"
+    _index(temp_repo, mock_ingestor, name, IMPL_BODY)
+
+    modules = _module_qns(mock_ingestor)
+    functions = _function_qns(mock_ingestor)
+    inner = {qn for qn in modules if qn.endswith(".inner")}
+    assert len(inner) == 1, modules
+    holder = next(iter(inner))
+    assert any(qn.startswith(f"{holder}.") for qn in functions), (holder, functions)

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -851,7 +851,19 @@ RELATIONSHIP_SCHEMAS: tuple[RelationshipSchema, ...] = (
         (NodeLabel.MODULE,),
     ),
     RelationshipSchema(
-        (NodeLabel.MODULE, NodeLabel.FUNCTION, NodeLabel.METHOD, NodeLabel.CLASS),
+        # A Rust `mod` written in a trait const initializer or an impl method
+        # body is defined by the TYPE, whose node carries an Interface/Enum/
+        # Type/Union label as readily as Class (issue #1018).
+        (
+            NodeLabel.MODULE,
+            NodeLabel.FUNCTION,
+            NodeLabel.METHOD,
+            NodeLabel.CLASS,
+            NodeLabel.INTERFACE,
+            NodeLabel.ENUM,
+            NodeLabel.TYPE,
+            NodeLabel.UNION,
+        ),
         RelationshipType.DEFINES,
         (
             NodeLabel.CLASS,


### PR DESCRIPTION
Closes #1018.

> **Stacked on #1113 (issue #1019)** only because it was branched after it; the two changes are independent. Merge #1113 first and this retargets cleanly.

## What was diverging

Three different scope rules named the same thing. For `impl S { fn run() { mod inner { fn g() {} } } }`:

| | qn produced |
|---|---|
| Module node (`build_nested_qualified_name_for_class`) | `foo.inner` — mods + types, impl target dropped |
| functions inside it (FQN specs walk) | `foo.S.inner.g` — impl target kept |
| the containment DEFINES source (`build_module_path` default) | `foo.inner` — mods only |

The audit reported exactly what the issue described:

```
Module 'foo.T.inner' has no relationships
(Module 'foo.T')-[:DEFINES]->(Module 'foo.T.inner') references a nonexistent node
(Module 'foo.inner')-[:DEFINES]->(Function 'foo.T.inner.g') references a nonexistent node
```

## Change

1. **One rule.** New `_rust_inline_module_qn` names the inline module with impl targets *and* type segments included — the rule its own functions already use. The containment walk in `function_ingest` uses the same rule, so the DEFINES source names the module that exists.
2. **The parent is not always a Module.** `mod` in a trait const initializer or an impl method body hangs off the TYPE, whose node carries a Class/Interface/Enum label. The lexical-parent edge now resolves the parent's registered label via the function registry (the pattern already used for Dart `implements` and Java anonymous overrides) instead of hard-coding `Module`.
3. `RELATIONSHIP_SCHEMAS` documents Interface/Enum/Type/Union as DEFINES sources, which the audit then accepts.

The containment walk keeps using the **mods-only** walk to decide *whether* an inline mod encloses the item at all, and only then spells it with the full rule. Without that guard the branch fires for every method in an impl and 15 Rust tests fail on a DEFINES from a Module named after the type — caught and fixed before commit.

## Tests

`codebase_rag/tests/test_rust_inline_mod_under_class_scope.py` covers all three shapes from the issue and its linked review rounds — trait const initializer, trait default method, impl method — asserting a single `.inner` Module qn that the contained functions actually nest under. `create_and_run_updater` runs the graph audit, so each test also fails on any orphan or dangling edge.

All three fail without the fix. Rust suite: 873 passed.