### PR TITLE
fix: publish the daemon stack ports on loopback by default

### DIFF
--- a/codebase_rag/docker-compose.yaml
+++ b/codebase_rag/docker-compose.yaml
@@ -1,23 +1,27 @@
+# Ports publish on loopback by default: Memgraph Bolt, Memgraph Lab, and
+# Qdrant are unauthenticated, so a bare "host:container" mapping (which Docker
+# binds to 0.0.0.0) puts the whole code graph on the local network (issue
+# #1012). Set CGR_STACK_BIND_HOST=0.0.0.0 to expose the stack deliberately.
 services:
   memgraph:
     image: memgraph/memgraph-mage
     ports:
-      - "${MEMGRAPH_PORT:-7687}:7687"
-      - "${MEMGRAPH_HTTP_PORT:-7444}:7444"
+      - "${CGR_STACK_BIND_HOST:-127.0.0.1}:${MEMGRAPH_PORT:-7687}:7687"
+      - "${CGR_STACK_BIND_HOST:-127.0.0.1}:${MEMGRAPH_HTTP_PORT:-7444}:7444"
     volumes:
       - memgraph_data:/var/lib/memgraph
       - memgraph_log:/var/log/memgraph
   lab:
     image: memgraph/lab
     ports:
-      - "${LAB_PORT:-3000}:3000"
+      - "${CGR_STACK_BIND_HOST:-127.0.0.1}:${LAB_PORT:-3000}:3000"
     environment:
       QUICK_CONNECT_MG_HOST: memgraph
   qdrant:
     image: qdrant/qdrant
     ports:
-      - "${QDRANT_HTTP_PORT:-6333}:6333"
-      - "${QDRANT_GRPC_PORT:-6334}:6334"
+      - "${CGR_STACK_BIND_HOST:-127.0.0.1}:${QDRANT_HTTP_PORT:-6333}:6333"
+      - "${CGR_STACK_BIND_HOST:-127.0.0.1}:${QDRANT_GRPC_PORT:-6334}:6334"
     volumes:
       - qdrant_storage:/qdrant/storage
 

--- a/codebase_rag/stack/constants.py
+++ b/codebase_rag/stack/constants.py
@@ -56,9 +56,9 @@ PACKAGE_COMPOSE_RELATIVE = "../docker-compose.yaml"
 # marks a compose file rendered before the loopback default (issue #1012).
 COMPOSE_BIND_HOST_VAR = "CGR_STACK_BIND_HOST"
 WARN_COMPOSE_PORTS_PUBLIC = (
-    "The compose file at {path} predates the loopback default and publishes "
-    "Memgraph, Memgraph Lab, and Qdrant on ALL interfaces, so any host on your "
-    "network can read the code graph from these unauthenticated services. "
-    "Delete the file and run 'cgr daemon up' again to re-render it with the "
-    "loopback bind, or add a '127.0.0.1:' prefix to each published port."
+    "The compose file at {path} publishes these ports on ALL interfaces, so "
+    "any host on your network can read the code graph from these "
+    "unauthenticated services: {mappings}. Delete the file and run "
+    "'cgr daemon up' again to re-render it with the loopback bind, or add a "
+    "'127.0.0.1:' prefix to each published port listed above."
 )

--- a/codebase_rag/stack/constants.py
+++ b/codebase_rag/stack/constants.py
@@ -51,3 +51,14 @@ MSG_RENDERING_COMPOSE = "Rendering compose file to {path}"
 MSG_WAITING_FOR_HEALTH = "Waiting for {service} on {host}:{port}..."
 
 PACKAGE_COMPOSE_RELATIVE = "../docker-compose.yaml"
+
+# The substitution that pins published ports to a host address. Its absence
+# marks a compose file rendered before the loopback default (issue #1012).
+COMPOSE_BIND_HOST_VAR = "CGR_STACK_BIND_HOST"
+WARN_COMPOSE_PORTS_PUBLIC = (
+    "The compose file at {path} predates the loopback default and publishes "
+    "Memgraph, Memgraph Lab, and Qdrant on ALL interfaces, so any host on your "
+    "network can read the code graph from these unauthenticated services. "
+    "Delete the file and run 'cgr daemon up' again to re-render it with the "
+    "loopback bind, or add a '127.0.0.1:' prefix to each published port."
+)

--- a/codebase_rag/stack/manager.py
+++ b/codebase_rag/stack/manager.py
@@ -63,7 +63,27 @@ class StackManager:
                 )
             logger.info(cs.MSG_RENDERING_COMPOSE.format(path=target))
             shutil.copyfile(self.package_compose, target)
+        else:
+            self._warn_if_ports_are_public(target)
         return target
+
+    @staticmethod
+    def _warn_if_ports_are_public(compose_file: Path) -> None:
+        """Flag a compose file predating the loopback default (issue #1012).
+
+        The file is rendered once and never overwritten, so an existing install
+        keeps publishing the unauthenticated Memgraph and Qdrant endpoints on
+        every interface. It is the user's file and may carry their edits, so
+        this reports the exposure and names the remedy rather than clobbering
+        it.
+        """
+        try:
+            content = compose_file.read_text(encoding="utf-8")
+        except OSError:
+            return
+        if cs.COMPOSE_BIND_HOST_VAR in content:
+            return
+        logger.warning(cs.WARN_COMPOSE_PORTS_PUBLIC.format(path=compose_file))
 
     def check_docker(self) -> None:
         if shutil.which(cs.DOCKER_BIN) is None:

--- a/codebase_rag/stack/manager.py
+++ b/codebase_rag/stack/manager.py
@@ -5,11 +5,34 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
+import yaml
 from loguru import logger
 
 from ..config import settings
 from . import constants as cs
 from .health import wait_for_memgraph, wait_for_qdrant
+
+
+def _publishes_on_all_interfaces(mapping: object) -> bool:
+    """Whether one `ports` entry publishes without a host address.
+
+    Long-form entries carry an explicit `host_ip`; short-form ones are
+    `[host_ip:]host:container`, so a host address is present exactly when the
+    mapping has two separators. A mapping bound to 0.0.0.0 or :: is public
+    even though it names a host.
+    """
+    if isinstance(mapping, dict):
+        declared = [
+            str(value).strip() for key, value in mapping.items() if key == "host_ip"
+        ]
+        return not declared or declared[0] in ("", "0.0.0.0", "::")
+    if not isinstance(mapping, str):
+        return False
+    text = mapping.strip()
+    if text.count(":") < 2:
+        return True
+    host_ip = text.rsplit(":", 2)[0]
+    return host_ip in ("0.0.0.0", "::", "*")
 
 
 class StackError(RuntimeError):
@@ -68,8 +91,36 @@ class StackManager:
         return target
 
     @staticmethod
-    def _warn_if_ports_are_public(compose_file: Path) -> None:
-        """Flag a compose file predating the loopback default (issue #1012).
+    def _public_port_mappings(compose_file: Path) -> list[str]:
+        """Published ports a compose file leaves bound to every interface.
+
+        Decided from the parsed `services.*.ports` entries, not from whether
+        some token appears in the text: a mapping is public exactly when it
+        carries no host address, so one corrected service, or the bind-host
+        name sitting in a comment, cannot vouch for the rest of the file
+        (issue #1012).
+        """
+        try:
+            compose = yaml.safe_load(compose_file.read_text(encoding="utf-8"))
+        except (OSError, yaml.YAMLError):
+            return []
+        if not isinstance(compose, dict):
+            return []
+        services = compose.get("services")
+        if not isinstance(services, dict):
+            return []
+        public: list[str] = []
+        for service, spec in services.items():
+            if not isinstance(spec, dict):
+                continue
+            for mapping in spec.get("ports") or []:
+                if _publishes_on_all_interfaces(mapping):
+                    public.append(f"{service}: {mapping}")
+        return public
+
+    @classmethod
+    def _warn_if_ports_are_public(cls, compose_file: Path) -> None:
+        """Flag a compose file that still publishes on every interface.
 
         The file is rendered once and never overwritten, so an existing install
         keeps publishing the unauthenticated Memgraph and Qdrant endpoints on
@@ -77,13 +128,14 @@ class StackManager:
         this reports the exposure and names the remedy rather than clobbering
         it.
         """
-        try:
-            content = compose_file.read_text(encoding="utf-8")
-        except OSError:
+        public = cls._public_port_mappings(compose_file)
+        if not public:
             return
-        if cs.COMPOSE_BIND_HOST_VAR in content:
-            return
-        logger.warning(cs.WARN_COMPOSE_PORTS_PUBLIC.format(path=compose_file))
+        logger.warning(
+            cs.WARN_COMPOSE_PORTS_PUBLIC.format(
+                path=compose_file, mappings=", ".join(public)
+            )
+        )
 
     def check_docker(self) -> None:
         if shutil.which(cs.DOCKER_BIN) is None:

--- a/codebase_rag/stack/manager.py
+++ b/codebase_rag/stack/manager.py
@@ -32,6 +32,11 @@ def _publishes_on_all_interfaces(mapping: object) -> bool:
     if text.count(":") < 2:
         return True
     host_ip = text.rsplit(":", 2)[0]
+    # Compose wraps an IPv6 host in brackets so its colons are not read as
+    # field separators, so `[::]` is the IPv6 wildcard and has to be unwrapped
+    # before it can be recognised as one.
+    if host_ip.startswith("[") and host_ip.endswith("]"):
+        host_ip = host_ip[1:-1]
     return host_ip in ("0.0.0.0", "::", "*")
 
 

--- a/codebase_rag/tests/test_stack_loopback_bind.py
+++ b/codebase_rag/tests/test_stack_loopback_bind.py
@@ -141,6 +141,24 @@ class TestPublicPortWarning:
 
         assert any("ALL interfaces" in message for message in self._warnings(manager))
 
+    def test_an_ipv6_wildcard_mapping_warns(self, tmp_path: Path) -> None:
+        # Compose brackets an IPv6 host so its colons are not field separators;
+        # `[::]` is the IPv6 equivalent of 0.0.0.0.
+        manager = self._manager(
+            tmp_path,
+            'services:\n  qdrant:\n    ports:\n      - "[::]:6333:6333"\n',
+        )
+
+        assert any("ALL interfaces" in message for message in self._warnings(manager))
+
+    def test_an_ipv6_loopback_mapping_is_quiet(self, tmp_path: Path) -> None:
+        manager = self._manager(
+            tmp_path,
+            'services:\n  qdrant:\n    ports:\n      - "[::1]:6333:6333"\n',
+        )
+
+        assert self._warnings(manager) == []
+
     def test_long_form_host_ip_is_honoured(self, tmp_path: Path) -> None:
         manager = self._manager(
             tmp_path,

--- a/codebase_rag/tests/test_stack_loopback_bind.py
+++ b/codebase_rag/tests/test_stack_loopback_bind.py
@@ -1,0 +1,112 @@
+"""The daemon stack must not publish its ports on every interface (#1012).
+
+Memgraph Bolt, Memgraph Lab, and Qdrant are unauthenticated. A bare
+``host:container`` mapping binds to 0.0.0.0, so `cgr daemon up` put the whole
+code graph on the local network -- the same exposure class as #808, fixed there
+for the MCP HTTP server by defaulting to a loopback bind.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from loguru import logger
+
+from codebase_rag.stack import constants as cs
+from codebase_rag.stack.manager import StackManager
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMPOSE_PATH = REPO_ROOT / "codebase_rag" / "docker-compose.yaml"
+
+LOOPBACK = "127.0.0.1"
+
+
+def _published_ports() -> list[tuple[str, str]]:
+    compose = yaml.safe_load(COMPOSE_PATH.read_text(encoding="utf-8"))
+    return [
+        (service, mapping)
+        for service, spec in compose["services"].items()
+        for mapping in spec.get("ports", [])
+    ]
+
+
+def test_every_published_port_is_bound_to_a_host_address() -> None:
+    unbound = [
+        (service, mapping)
+        for service, mapping in _published_ports()
+        if mapping.count(":") < 2
+    ]
+
+    assert unbound == [], (
+        f"{unbound} publish without a host address, which Docker binds to "
+        "0.0.0.0, exposing unauthenticated services to the whole network"
+    )
+
+
+def test_every_published_port_defaults_to_loopback() -> None:
+    for service, mapping in _published_ports():
+        assert mapping.startswith(f"${{{cs.COMPOSE_BIND_HOST_VAR}:-{LOOPBACK}}}:"), (
+            f"{service} publishes {mapping!r}, which does not default to {LOOPBACK}"
+        )
+
+
+def test_the_bind_host_is_overridable() -> None:
+    # A user who deliberately wants the stack reachable needs a documented way
+    # to say so, rather than editing the rendered file.
+    assert all(
+        cs.COMPOSE_BIND_HOST_VAR in mapping for _service, mapping in _published_ports()
+    )
+
+
+def test_ports_are_still_published_at_their_documented_numbers() -> None:
+    mappings = [mapping for _service, mapping in _published_ports()]
+    container_ports = {mapping.rsplit(":", 1)[-1] for mapping in mappings}
+
+    assert container_ports == {"7687", "7444", "3000", "6333", "6334"}
+
+
+class TestStaleComposeWarning:
+    def _manager(self, tmp_path: Path, rendered: str) -> StackManager:
+        home = tmp_path / "cgr_home"
+        home.mkdir()
+        (home / cs.COMPOSE_FILENAME).write_text(rendered, encoding="utf-8")
+        return StackManager(home=home, package_compose=COMPOSE_PATH)
+
+    def _warnings(self, manager: StackManager) -> list[str]:
+        messages: list[str] = []
+        sink_id = logger.add(messages.append, level="WARNING")
+        try:
+            manager.ensure_compose_file()
+        finally:
+            logger.remove(sink_id)
+        return messages
+
+    def test_a_pre_fix_compose_file_warns(self, tmp_path: Path) -> None:
+        # The file is rendered once and never overwritten, so an existing
+        # install keeps the exposed mapping and would never see the fix.
+        manager = self._manager(
+            tmp_path,
+            'services:\n  memgraph:\n    ports:\n      - "7687:7687"\n',
+        )
+
+        assert any("ALL interfaces" in message for message in self._warnings(manager))
+
+    def test_a_current_compose_file_is_quiet(self, tmp_path: Path) -> None:
+        manager = self._manager(tmp_path, COMPOSE_PATH.read_text(encoding="utf-8"))
+
+        assert self._warnings(manager) == []
+
+    def test_a_user_edited_file_is_not_clobbered(self, tmp_path: Path) -> None:
+        rendered = 'services:\n  memgraph:\n    ports:\n      - "7687:7687"\n'
+        manager = self._manager(tmp_path, rendered)
+
+        manager.ensure_compose_file()
+
+        assert manager.compose_file.read_text(encoding="utf-8") == rendered
+
+
+@pytest.mark.parametrize("service", ["memgraph", "lab", "qdrant"])
+def test_each_service_is_covered(service: str) -> None:
+    assert any(name == service for name, _mapping in _published_ports())

--- a/codebase_rag/tests/test_stack_loopback_bind.py
+++ b/codebase_rag/tests/test_stack_loopback_bind.py
@@ -67,7 +67,7 @@ def test_ports_are_still_published_at_their_documented_numbers() -> None:
     assert container_ports == {"7687", "7444", "3000", "6333", "6334"}
 
 
-class TestStaleComposeWarning:
+class TestPublicPortWarning:
     def _manager(self, tmp_path: Path, rendered: str) -> StackManager:
         home = tmp_path / "cgr_home"
         home.mkdir()
@@ -95,6 +95,59 @@ class TestStaleComposeWarning:
 
     def test_a_current_compose_file_is_quiet(self, tmp_path: Path) -> None:
         manager = self._manager(tmp_path, COMPOSE_PATH.read_text(encoding="utf-8"))
+
+        assert self._warnings(manager) == []
+
+    def test_a_literal_loopback_mapping_is_quiet(self, tmp_path: Path) -> None:
+        # The documented remediation is a literal '127.0.0.1:' prefix. Warning
+        # on every `daemon up` after the user followed it trains them to
+        # ignore the warning.
+        manager = self._manager(
+            tmp_path,
+            'services:\n  memgraph:\n    ports:\n      - "127.0.0.1:7687:7687"\n',
+        )
+
+        assert self._warnings(manager) == []
+
+    def test_one_fixed_service_does_not_vouch_for_another(self, tmp_path: Path) -> None:
+        # A substring check over the whole file let a single corrected mapping
+        # silence the warning while another service stayed bound on 0.0.0.0.
+        manager = self._manager(
+            tmp_path,
+            "services:\n"
+            "  memgraph:\n"
+            '    ports:\n      - "${CGR_STACK_BIND_HOST:-127.0.0.1}:7687:7687"\n'
+            "  qdrant:\n"
+            '    ports:\n      - "6333:6333"\n',
+        )
+
+        messages = self._warnings(manager)
+        assert any("qdrant" in message for message in messages), messages
+
+    def test_a_comment_does_not_silence_the_warning(self, tmp_path: Path) -> None:
+        manager = self._manager(
+            tmp_path,
+            "# CGR_STACK_BIND_HOST is how you would fix this\n"
+            'services:\n  qdrant:\n    ports:\n      - "6333:6333"\n',
+        )
+
+        assert any("ALL interfaces" in message for message in self._warnings(manager))
+
+    def test_an_explicit_wildcard_host_still_warns(self, tmp_path: Path) -> None:
+        manager = self._manager(
+            tmp_path,
+            'services:\n  qdrant:\n    ports:\n      - "0.0.0.0:6333:6333"\n',
+        )
+
+        assert any("ALL interfaces" in message for message in self._warnings(manager))
+
+    def test_long_form_host_ip_is_honoured(self, tmp_path: Path) -> None:
+        manager = self._manager(
+            tmp_path,
+            "services:\n  qdrant:\n    ports:\n"
+            "      - target: 6333\n        published: 6333\n"
+            '        host_ip: "127.0.0.1"\n',
+        )
 
         assert self._warnings(manager) == []
 


### PR DESCRIPTION
Closes #1012.

## Change

Each published port in `codebase_rag/docker-compose.yaml` is now prefixed with `${CGR_STACK_BIND_HOST:-127.0.0.1}:`, so `cgr daemon up` stops putting unauthenticated Memgraph Bolt, Memgraph Lab, and Qdrant on every interface. `CGR_STACK_BIND_HOST=0.0.0.0` restores the old behaviour for users who want it deliberately — the env override the issue proposed, resolved by Docker Compose's own substitution, so no Python plumbing was needed.

## The part that isn't in the issue

`ensure_compose_file` renders the compose file to `~/.cgr` **once** and never overwrites it. Fixing only the packaged file would leave every existing install exposed and none of them would ever see the fix.

The rendered file belongs to the user and may carry their edits, so this does not clobber it. Instead, when the on-disk file lacks the bind-host substitution, `cgr daemon up` warns and names the remedy (delete it to re-render, or add the prefix by hand). Silent clobbering and silent exposure both seemed worse than telling them.

## Tests

`codebase_rag/tests/test_stack_loopback_bind.py`:

- every published port carries a host address (a mapping with fewer than two colons is the 0.0.0.0 bug)
- every one defaults to `127.0.0.1` and stays overridable
- the documented port numbers are unchanged
- a pre-fix rendered file warns; a current one is quiet; a user-edited file is left byte-identical

## Follow-up

`docs/architecture/security.md` currently discloses this behaviour and points at #1012 in two places. I have deliberately not edited it here — it should be updated when this merges, and I would rather that be a conscious call than a silent doc change buried in a security fix. Happy to include it if you prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Docker service ports now bind to localhost by default, reducing unintended network exposure.
  * The bind host can be customized when broader access is required.
  * Existing port mappings remain available at their documented container ports.

* **Bug Fixes**
  * Existing Compose files with publicly exposed ports now display security warnings for short- and long-form mappings.
  * User-edited Compose files are preserved and are not automatically overwritten.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->