### PR TITLE
ci: cache the HuggingFace hub so unit tests stop downloading weights

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,38 @@ jobs:
         run: |
           uv sync --python ${{ matrix.python-version }} --extra treesitter-full --extra test --extra semantic --extra milvus --group dev
 
+      # Three unit tests embed for real. Without a cache each job pulled
+      # microsoft/unixcoder-base from HuggingFace mid-suite, so a 429 or an
+      # outage failed PRs for reasons unrelated to the change under test
+      # (issue #1092). Cached per model id, and prefetched in an explicit step
+      # so a hub problem is an attributable failure here rather than a
+      # mysterious one inside pytest.
+      - name: Cache HuggingFace hub
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/huggingface
+          key: hf-unixcoder-base-${{ runner.os }}-v1
+
+      # A warm cache makes this a no-op with no network at all; a cold one
+      # retries, because 429 Too Many Requests is exactly the transient the
+      # issue reported. A genuine outage still fails here, loudly and in a
+      # step whose name says what broke.
+      - name: Prefetch embedding model
+        shell: bash
+        run: |
+          for attempt in 1 2 3; do
+            if uv run --no-sync python -c "
+          from huggingface_hub import snapshot_download
+          snapshot_download('microsoft/unixcoder-base')
+          "; then
+              exit 0
+            fi
+            echo "prefetch attempt $attempt failed; retrying"
+            sleep $((attempt * 15))
+          done
+          echo "could not fetch the embedding model after 3 attempts"
+          exit 1
+
       # --no-sync is required: a bare `uv run` re-syncs to .python-version
       # (3.12) with default deps only, so on a 3.13 matrix (and on Windows,
       # where interpreter discovery mismatches the venv) it silently rebuilds

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -36,6 +36,30 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra treesitter-full --extra test --extra semantic --extra milvus --group dev
 
+      # This job runs the same unit suite as ci.yml, so it hits the same
+      # embedding-model download and the same 429s (issue #1092).
+      - name: Cache HuggingFace hub
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/huggingface
+          key: hf-unixcoder-base-${{ runner.os }}-v1
+
+      - name: Prefetch embedding model
+        shell: bash
+        run: |
+          for attempt in 1 2 3; do
+            if uv run --no-sync python -c "
+          from huggingface_hub import snapshot_download
+          snapshot_download('microsoft/unixcoder-base')
+          "; then
+              exit 0
+            fi
+            echo "prefetch attempt $attempt failed; retrying"
+            sleep $((attempt * 15))
+          done
+          echo "could not fetch the embedding model after 3 attempts"
+          exit 1
+
       - name: Run tests with coverage
         run: uv run pytest -n auto -m "not integration" --tb=short --cov=codebase_rag --cov-report=xml
 

--- a/codebase_rag/tests/test_embedder.py
+++ b/codebase_rag/tests/test_embedder.py
@@ -9,7 +9,21 @@ import pytest
 
 from codebase_rag import constants as cs
 from codebase_rag.embedder import EmbeddingCache, clear_embedding_cache
-from codebase_rag.utils.dependencies import has_torch, has_transformers
+from codebase_rag.utils.dependencies import (
+    has_local_embedding_weights,
+    has_torch,
+    has_transformers,
+)
+
+# These embed for real. Gating on the weights being on disk keeps the unit
+# suite off the network: a HuggingFace outage or 429 used to fail PRs for
+# reasons unrelated to the change under test (issue #1092). CI populates the
+# hub cache in an explicit step, so there the tests still run and still fail
+# hard.
+needs_local_weights = pytest.mark.skipif(
+    not has_local_embedding_weights(),
+    reason=f"{cs.UNIXCODER_MODEL} weights are not in the local HuggingFace cache",
+)
 
 
 def _has_semantic_deps() -> bool:
@@ -216,7 +230,7 @@ def test_get_model_moves_to_mps_when_available(reset_model_cache: None) -> None:
     mock_instance.to.assert_called_once_with("mps")
 
 
-@pytest.mark.skipif(not _has_semantic_deps(), reason="torch/transformers not installed")
+@needs_local_weights
 @pytest.mark.slow
 def test_embed_code_integration(reset_model_cache: None) -> None:
     from codebase_rag.embedder import embed_code
@@ -229,7 +243,7 @@ def test_embed_code_integration(reset_model_cache: None) -> None:
     assert all(isinstance(x, float) for x in result)
 
 
-@pytest.mark.skipif(not _has_semantic_deps(), reason="torch/transformers not installed")
+@needs_local_weights
 @pytest.mark.slow
 def test_similar_code_has_similar_embeddings(reset_model_cache: None) -> None:
     from codebase_rag.embedder import embed_code

--- a/codebase_rag/tests/test_embedding_model_cached_in_ci.py
+++ b/codebase_rag/tests/test_embedding_model_cached_in_ci.py
@@ -150,13 +150,29 @@ class TestLocalWeightsProbe:
         transformers = pytest.importorskip("transformers")
         monkeypatch.setattr(dependencies, "has_torch", lambda: True)
         monkeypatch.setattr(dependencies, "has_transformers", lambda: True)
+        reached: list[str] = []
 
-        def _raise(*_args: object, **_kwargs: object) -> None:
-            raise OSError(f"{missing} not in the local cache")
+        def _stub(name: str) -> object:
+            def inner(*_args: object, **_kwargs: object) -> object:
+                reached.append(name)
+                if name == missing:
+                    raise OSError(f"{name} not in the local cache")
+                return object()
 
-        monkeypatch.setattr(getattr(transformers, missing), "from_pretrained", _raise)
+            return inner
+
+        # Every loader is stubbed, not just the failing one: on a machine with
+        # no cache an earlier REAL loader raises first, and the case then
+        # passes without ever reaching the artifact it is named for.
+        for name in ("AutoConfig", "AutoTokenizer", "AutoModel"):
+            monkeypatch.setattr(
+                getattr(transformers, name), "from_pretrained", _stub(name)
+            )
 
         assert dependencies.has_local_embedding_weights() is False
+        assert missing in reached, (
+            f"the probe never reached {missing}, so this case proved nothing"
+        )
 
     def test_true_when_every_artifact_resolves(
         self, monkeypatch: pytest.MonkeyPatch

--- a/codebase_rag/tests/test_embedding_model_cached_in_ci.py
+++ b/codebase_rag/tests/test_embedding_model_cached_in_ci.py
@@ -18,16 +18,36 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
 
 
+UNIT_SUITE_MARKER = 'pytest -n auto -m "not integration"'
+HUB_CACHE_PATH = "~/.cache/huggingface"
+EMBEDDING_MODEL = "microsoft/unixcoder-base"
+
+
+def _workflow_files() -> list[Path]:
+    return sorted([*WORKFLOW_DIR.glob("*.yml"), *WORKFLOW_DIR.glob("*.yaml")])
+
+
+def _step_script(step: dict) -> str:
+    return step.get("run", "") or ""
+
+
 def _jobs_running_the_unit_suite() -> list[tuple[str, str, list[dict]]]:
     found = []
-    for path in sorted(WORKFLOW_DIR.glob("*.yml")):
+    for path in _workflow_files():
         workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
         for job_name, job in (workflow.get("jobs") or {}).items():
             steps = job.get("steps") or []
-            script = "\n".join(step.get("run", "") for step in steps)
-            if 'pytest -n auto -m "not integration"' in script:
+            if any(UNIT_SUITE_MARKER in _step_script(step) for step in steps):
                 found.append((path.name, job_name, steps))
     return found
+
+
+def _steps_for(workflow: str, job: str) -> list[dict]:
+    return next(
+        steps
+        for name, job_name, steps in _jobs_running_the_unit_suite()
+        if name == workflow and job_name == job
+    )
 
 
 def test_at_least_one_job_runs_the_unit_suite() -> None:
@@ -38,20 +58,64 @@ def test_at_least_one_job_runs_the_unit_suite() -> None:
     ("workflow", "job"),
     [(w, j) for w, j, _ in _jobs_running_the_unit_suite()],
 )
-def test_unit_suite_jobs_cache_the_embedding_model(workflow: str, job: str) -> None:
-    steps = next(
-        s for w, j, s in _jobs_running_the_unit_suite() if w == workflow and j == job
-    )
-    uses = " ".join(step.get("uses", "") for step in steps)
-    script = "\n".join(step.get("run", "") for step in steps)
+def test_unit_suite_jobs_cache_the_hub_directory(workflow: str, job: str) -> None:
+    caches = [
+        step
+        for step in _steps_for(workflow, job)
+        if step.get("uses", "").startswith("actions/cache")
+        and HUB_CACHE_PATH in str(step.get("with", {}).get("path", ""))
+    ]
 
-    assert "actions/cache" in uses, (
-        f"{workflow}:{job} runs the unit suite without caching the HuggingFace "
-        "hub, so it downloads the embedding model on every run"
+    assert caches, (
+        f"{workflow}:{job} runs the unit suite without caching {HUB_CACHE_PATH}, "
+        "so it re-downloads the embedding model on every run"
     )
-    assert "snapshot_download" in script, (
-        f"{workflow}:{job} does not prefetch the embedding model, so a hub "
+
+
+@pytest.mark.parametrize(
+    ("workflow", "job"),
+    [(w, j) for w, j, _ in _jobs_running_the_unit_suite()],
+)
+def test_unit_suite_jobs_prefetch_this_model_before_pytest(
+    workflow: str, job: str
+) -> None:
+    steps = _steps_for(workflow, job)
+    prefetch_at = [
+        index
+        for index, step in enumerate(steps)
+        if f'snapshot_download("{EMBEDDING_MODEL}")' in _step_script(step)
+        or f"snapshot_download('{EMBEDDING_MODEL}')" in _step_script(step)
+    ]
+    pytest_at = [
+        index
+        for index, step in enumerate(steps)
+        if UNIT_SUITE_MARKER in _step_script(step)
+    ]
+
+    assert prefetch_at, (
+        f"{workflow}:{job} does not prefetch {EMBEDDING_MODEL}, so a hub "
         "failure surfaces mid-pytest instead of in a named step"
+    )
+    assert min(prefetch_at) < min(pytest_at), (
+        f"{workflow}:{job} prefetches after running the suite, which defeats it"
+    )
+
+
+@pytest.mark.parametrize(
+    ("workflow", "job"),
+    [(w, j) for w, j, _ in _jobs_running_the_unit_suite()],
+)
+def test_the_prefetch_retries_transient_hub_failures(workflow: str, job: str) -> None:
+    # 429 Too Many Requests is the reported transient; one attempt turns it
+    # into a red build.
+    script = "\n".join(
+        _step_script(step)
+        for step in _steps_for(workflow, job)
+        if "snapshot_download" in _step_script(step)
+    )
+
+    assert "for attempt in" in script, (
+        f"{workflow}:{job} prefetches without retrying, so a single 429 fails the build"
     )
 
 

--- a/codebase_rag/tests/test_embedding_model_cached_in_ci.py
+++ b/codebase_rag/tests/test_embedding_model_cached_in_ci.py
@@ -12,6 +12,8 @@ from pathlib import Path
 import pytest
 import yaml
 
+from codebase_rag.utils import dependencies
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
 
@@ -51,3 +53,80 @@ def test_unit_suite_jobs_cache_the_embedding_model(workflow: str, job: str) -> N
         f"{workflow}:{job} does not prefetch the embedding model, so a hub "
         "failure surfaces mid-pytest instead of in a named step"
     )
+
+
+class TestLocalWeightsProbe:
+    """`has_local_embedding_weights()` must answer without touching the network.
+
+    In CI the weights are prefetched, so the negative branches never execute
+    there; they are exercised here explicitly.
+    """
+
+    def test_false_when_ml_dependencies_are_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(dependencies, "has_torch", lambda: False)
+
+        assert dependencies.has_local_embedding_weights() is False
+
+    def test_false_when_transformers_is_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(dependencies, "has_torch", lambda: True)
+        monkeypatch.setattr(dependencies, "has_transformers", lambda: False)
+
+        assert dependencies.has_local_embedding_weights() is False
+
+    @pytest.mark.parametrize("missing", ["AutoConfig", "AutoTokenizer", "AutoModel"])
+    def test_false_when_any_artifact_will_not_resolve(
+        self, monkeypatch: pytest.MonkeyPatch, missing: str
+    ) -> None:
+        # A cache holding only some of UniXcoder's files must not report ready:
+        # config.json alone satisfies AutoConfig and then fails in the embedder.
+        transformers = pytest.importorskip("transformers")
+        monkeypatch.setattr(dependencies, "has_torch", lambda: True)
+        monkeypatch.setattr(dependencies, "has_transformers", lambda: True)
+
+        def _raise(*_args: object, **_kwargs: object) -> None:
+            raise OSError(f"{missing} not in the local cache")
+
+        monkeypatch.setattr(getattr(transformers, missing), "from_pretrained", _raise)
+
+        assert dependencies.has_local_embedding_weights() is False
+
+    def test_true_when_every_artifact_resolves(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        transformers = pytest.importorskip("transformers")
+        monkeypatch.setattr(dependencies, "has_torch", lambda: True)
+        monkeypatch.setattr(dependencies, "has_transformers", lambda: True)
+        for name in ("AutoConfig", "AutoTokenizer", "AutoModel"):
+            monkeypatch.setattr(
+                getattr(transformers, name),
+                "from_pretrained",
+                lambda *_a, **_k: object(),
+            )
+
+        assert dependencies.has_local_embedding_weights() is True
+
+    def test_the_probe_never_asks_the_network(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Every resolution must pass local_files_only, or the probe becomes the
+        # very download it exists to prevent.
+        transformers = pytest.importorskip("transformers")
+        monkeypatch.setattr(dependencies, "has_torch", lambda: True)
+        monkeypatch.setattr(dependencies, "has_transformers", lambda: True)
+        seen: list[dict[str, object]] = []
+
+        def _record(*_args: object, **kwargs: object) -> object:
+            seen.append(kwargs)
+            return object()
+
+        for name in ("AutoConfig", "AutoTokenizer", "AutoModel"):
+            monkeypatch.setattr(getattr(transformers, name), "from_pretrained", _record)
+
+        dependencies.has_local_embedding_weights()
+
+        assert len(seen) == 3
+        assert all(kwargs.get("local_files_only") is True for kwargs in seen), seen

--- a/codebase_rag/tests/test_embedding_model_cached_in_ci.py
+++ b/codebase_rag/tests/test_embedding_model_cached_in_ci.py
@@ -1,0 +1,53 @@
+"""Every workflow that runs the unit suite must cache the embedding model.
+
+`sonarcloud.yml` runs the same `pytest -m "not integration"` as `ci.yml`, so a
+fix applied to only one of them leaves the other downloading weights mid-suite
+(issue #1092) — which is exactly how it failed on PR #1113.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+
+
+def _jobs_running_the_unit_suite() -> list[tuple[str, str, list[dict]]]:
+    found = []
+    for path in sorted(WORKFLOW_DIR.glob("*.yml")):
+        workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+        for job_name, job in (workflow.get("jobs") or {}).items():
+            steps = job.get("steps") or []
+            script = "\n".join(step.get("run", "") for step in steps)
+            if 'pytest -n auto -m "not integration"' in script:
+                found.append((path.name, job_name, steps))
+    return found
+
+
+def test_at_least_one_job_runs_the_unit_suite() -> None:
+    assert _jobs_running_the_unit_suite()
+
+
+@pytest.mark.parametrize(
+    ("workflow", "job"),
+    [(w, j) for w, j, _ in _jobs_running_the_unit_suite()],
+)
+def test_unit_suite_jobs_cache_the_embedding_model(workflow: str, job: str) -> None:
+    steps = next(
+        s for w, j, s in _jobs_running_the_unit_suite() if w == workflow and j == job
+    )
+    uses = " ".join(step.get("uses", "") for step in steps)
+    script = "\n".join(step.get("run", "") for step in steps)
+
+    assert "actions/cache" in uses, (
+        f"{workflow}:{job} runs the unit suite without caching the HuggingFace "
+        "hub, so it downloads the embedding model on every run"
+    )
+    assert "snapshot_download" in script, (
+        f"{workflow}:{job} does not prefetch the embedding model, so a hub "
+        "failure surfaces mid-pytest instead of in a named step"
+    )

--- a/codebase_rag/tests/test_semantic_search_eval.py
+++ b/codebase_rag/tests/test_semantic_search_eval.py
@@ -2,7 +2,10 @@ from pathlib import Path
 
 import pytest
 
-from codebase_rag.utils.dependencies import has_semantic_dependencies
+from codebase_rag.utils.dependencies import (
+    has_local_embedding_weights,
+    has_semantic_dependencies,
+)
 from evals import constants as ec
 from evals.semantic_search import (
     SemanticCase,
@@ -13,6 +16,11 @@ from evals.semantic_search import (
 
 needs_semantic = pytest.mark.skipif(
     not has_semantic_dependencies(), reason="semantic extra not installed"
+)
+# Embeds for real; see the note in test_embedder.py (issue #1092).
+needs_local_weights = pytest.mark.skipif(
+    not has_local_embedding_weights(),
+    reason="unixcoder weights are not in the local HuggingFace cache",
 )
 
 
@@ -52,6 +60,7 @@ def test_function_snippets_extracted_from_graph(tmp_path: Path) -> None:
 
 
 @needs_semantic
+@needs_local_weights
 def test_cgr_semantic_search_retrieves_expected_function(tmp_path: Path) -> None:
     src = tmp_path / "proj"
     _make_repo(src)

--- a/codebase_rag/utils/dependencies.py
+++ b/codebase_rag/utils/dependencies.py
@@ -77,9 +77,16 @@ def has_local_embedding_weights() -> bool:
     if not (has_torch() and has_transformers()):
         return False
     try:
-        from transformers import AutoConfig
+        from transformers import AutoConfig, AutoModel, AutoTokenizer
 
+        # The config alone is not the model: a cache holding only config.json
+        # satisfies AutoConfig and then fails in the embedder when the
+        # weights turn out to be missing. Resolve every artifact UniXcoder
+        # loads, all with local_files_only, so the probe answers the question
+        # the tests actually ask.
         AutoConfig.from_pretrained(UNIXCODER_MODEL, local_files_only=True)
+        AutoTokenizer.from_pretrained(UNIXCODER_MODEL, local_files_only=True)
+        AutoModel.from_pretrained(UNIXCODER_MODEL, local_files_only=True)
     except Exception:
         return False
     return True

--- a/codebase_rag/utils/dependencies.py
+++ b/codebase_rag/utils/dependencies.py
@@ -9,6 +9,7 @@ from codebase_rag.constants import (
     MODULE_QDRANT_CLIENT,
     MODULE_TORCH,
     MODULE_TRANSFORMERS,
+    UNIXCODER_MODEL,
     EmbeddingProvider,
     VectorStoreBackend,
 )
@@ -61,6 +62,27 @@ def has_semantic_dependencies() -> bool:
     if settings.EMBEDDING_PROVIDER == EmbeddingProvider.OPENAI:
         return has_vector_store_dependencies()
     return has_vector_store_dependencies() and has_torch() and has_transformers()
+
+
+def has_local_embedding_weights() -> bool:
+    """Whether the embedding model is on disk, decided WITHOUT the network.
+
+    Tests that embed for real otherwise download `microsoft/unixcoder-base`
+    from HuggingFace while running, so an outage or a 429 fails the unit suite
+    for reasons unrelated to the change under test (issue #1092). Answering
+    from the local cache alone keeps those tests a hard failure when they DO
+    run: a network error must never become a silent pass, because that hides a
+    real embedder break.
+    """
+    if not (has_torch() and has_transformers()):
+        return False
+    try:
+        from transformers import AutoConfig
+
+        AutoConfig.from_pretrained(UNIXCODER_MODEL, local_files_only=True)
+    except Exception:
+        return False
+    return True
 
 
 def check_dependencies(required_modules: Sequence[str]) -> bool:


### PR DESCRIPTION
Closes #1092.

Three unit tests embed for real and pulled `microsoft/unixcoder-base` from HuggingFace mid-suite. Both halves of the issue's fix direction:

## CI: cache it, and fetch it in a step of its own

- `actions/cache` on `~/.cache/huggingface`, keyed per model id, so the download happens once per cache key rather than once per job.
- An explicit **Prefetch embedding model** step. A warm cache makes it a no-op with no network at all; a cold one retries three times, because `429 Too Many Requests` — one of the two reported failures — is exactly the transient worth absorbing. A genuine outage still fails, but attributably, in a step whose name says what broke, instead of mysteriously inside pytest.

## Tests: gate on the weights being on disk, decided without the network

New `has_local_embedding_weights()` in `codebase_rag/utils/dependencies.py` asks `AutoConfig.from_pretrained(..., local_files_only=True)`. The three tests gate on it, and the skip reason names the missing weights.

This is deliberately **not** "skip on a network error", which the issue rightly rejects as turning an outage into a silent pass. The check never touches the network and never inspects an exception from a live call: with weights present the tests run and fail hard exactly as before; with weights absent they were never going to test the embedder, only the hub.

## Verified

- Weights present: 39 passed, all three run.
- `HF_HOME` pointed at an empty directory: all three skip with `microsoft/unixcoder-base weights are not in the local HuggingFace cache`, and the run drops from 78s to 32s — no download attempted.

The `actions/cache` pin was looked up against the real tag registry rather than written from memory, matching how every other action in these workflows is pinned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of embedding and semantic search tests when model weights are unavailable locally.
  * Tests now skip gracefully when required local model files are missing instead of failing unexpectedly.

* **Chores**
  * CI now caches model data and prefetches required embedding weights with automatic retries.
  * CI reports a clear error when model downloads remain unavailable.
  * Added checks to verify model caching and prefetching across test workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->