### PR TITLE
docs: refresh stale AI model suggestions and add missing context windows

### DIFF
--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -193,10 +193,10 @@ Configure via `.env` or environment variables:
 | `MEMGRAPH_HOST` | `localhost` | Memgraph hostname |
 | `MEMGRAPH_PORT` | `7687` | Memgraph port |
 | `ORCHESTRATOR_PROVIDER` | | Provider: `google`, `openai`, `anthropic`, `azure`, `ollama`, `minimax`, `litellm_proxy` |
-| `ORCHESTRATOR_MODEL` | | Model ID (e.g. `gpt-4o`, `gemini-2.5-pro`) |
+| `ORCHESTRATOR_MODEL` | | Model ID (e.g. `claude-opus-5`, `gpt-4o`, `gemini-2.5-pro`) |
 | `ORCHESTRATOR_API_KEY` | | API key for the provider (not needed for `ollama`) |
 | `CYPHER_PROVIDER` | | Provider for Cypher generation |
-| `CYPHER_MODEL` | | Model ID for Cypher generation (e.g. `codellama`, `gpt-4o-mini`) |
+| `CYPHER_MODEL` | | Model ID for Cypher generation (e.g. `claude-haiku-4-5`, `codellama`, `gpt-4o-mini`) |
 | `CYPHER_API_KEY` | | API key for Cypher provider (not needed for `ollama`) |
 | `TARGET_REPO_PATH` | `.` | Default repository path |
 

--- a/codebase_rag/constants/providers.py
+++ b/codebase_rag/constants/providers.py
@@ -96,6 +96,8 @@ DEFAULT_CONTEXT_WINDOW = 200_000
 MODEL_CONTEXT_WINDOWS: dict[str, int] = {
     "MiniMax-M3": 1_000_000,
     "MiniMax-M2.7": 204_800,
+    "claude-opus-5": 1_000_000,
+    "claude-sonnet-5": 1_000_000,
     "claude-opus-4-8": 1_000_000,
     "claude-opus-4-7": 1_000_000,
     "claude-opus-4-6": 200_000,

--- a/codebase_rag/tests/test_provider_classes.py
+++ b/codebase_rag/tests/test_provider_classes.py
@@ -269,7 +269,13 @@ class TestAnthropicProvider:
 
     @pytest.mark.parametrize(
         ("model_id", "context_window"),
-        [("claude-opus-4-8", 1_000_000), ("claude-opus-4-7", 1_000_000)],
+        [
+            ("claude-opus-5", 1_000_000),
+            ("claude-sonnet-5", 1_000_000),
+            ("claude-opus-4-8", 1_000_000),
+            ("claude-opus-4-7", 1_000_000),
+            ("claude-haiku-4-5", 200_000),
+        ],
     )
     def test_anthropic_context_windows(
         self, model_id: str, context_window: int

--- a/docs/claude-code-setup.md
+++ b/docs/claude-code-setup.md
@@ -14,7 +14,7 @@ cd /path/to/your/project
 claude mcp add --transport stdio code-graph-rag \
   --env TARGET_REPO_PATH="$(pwd)" \
   --env CYPHER_PROVIDER=google \
-  --env CYPHER_MODEL=gemini-2.0-flash \
+  --env CYPHER_MODEL=gemini-2.5-flash \
   --env CYPHER_API_KEY=your-google-api-key \
   -- uv run --directory /absolute/path/to/code-graph-rag code-graph-rag mcp-server
 ```
@@ -33,7 +33,7 @@ Specify the repository path explicitly:
 claude mcp add --transport stdio code-graph-rag \
   --env TARGET_REPO_PATH=/absolute/path/to/your/project \
   --env CYPHER_PROVIDER=google \
-  --env CYPHER_MODEL=gemini-2.0-flash \
+  --env CYPHER_MODEL=gemini-2.5-flash \
   --env CYPHER_API_KEY=your-google-api-key \
   -- uv run --directory /absolute/path/to/code-graph-rag code-graph-rag mcp-server
 ```
@@ -85,7 +85,7 @@ docker run -p 7687:7687 -p 7444:7444 memgraph/memgraph-platform
 **OpenAI** (recommended):
 ```bash
 --env CYPHER_PROVIDER=openai \
---env CYPHER_MODEL=gpt-4 \
+--env CYPHER_MODEL=gpt-4o \
 --env CYPHER_API_KEY=sk-...
 ```
 
@@ -110,14 +110,14 @@ Add separate named instances for different projects:
 claude mcp add --transport stdio code-graph-rag-backend \
   --env TARGET_REPO_PATH=/path/to/backend \
   --env CYPHER_PROVIDER=openai \
-  --env CYPHER_MODEL=gpt-4 \
+  --env CYPHER_MODEL=gpt-4o \
   --env CYPHER_API_KEY=your-api-key \
   -- uv run --directory /path/to/code-graph-rag code-graph-rag mcp-server
 
 claude mcp add --transport stdio code-graph-rag-frontend \
   --env TARGET_REPO_PATH=/path/to/frontend \
   --env CYPHER_PROVIDER=openai \
-  --env CYPHER_MODEL=gpt-4 \
+  --env CYPHER_MODEL=gpt-4o \
   --env CYPHER_API_KEY=your-api-key \
   -- uv run --directory /path/to/code-graph-rag code-graph-rag mcp-server
 ```

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -32,6 +32,18 @@ CYPHER_MODEL=gpt-4o-mini
 CYPHER_API_KEY=sk-your-openai-key
 ```
 
+### All Anthropic Models
+
+```bash
+ORCHESTRATOR_PROVIDER=anthropic
+ORCHESTRATOR_MODEL=claude-opus-5
+ORCHESTRATOR_API_KEY=sk-ant-your-anthropic-key
+
+CYPHER_PROVIDER=anthropic
+CYPHER_MODEL=claude-haiku-4-5
+CYPHER_API_KEY=sk-ant-your-anthropic-key
+```
+
 ### All Google Models
 
 ```bash
@@ -82,7 +94,7 @@ Get your MiniMax API key from the [MiniMax Platform](https://platform.minimax.io
 | Variable | Description |
 |----------|-------------|
 | `ORCHESTRATOR_PROVIDER` | Provider name (`google`, `openai`, `anthropic`, `azure`, `ollama`, `minimax`, `litellm_proxy`) |
-| `ORCHESTRATOR_MODEL` | Model ID (e.g., `gemini-2.5-pro`, `gpt-4o`, `llama3.2`) |
+| `ORCHESTRATOR_MODEL` | Model ID (e.g., `claude-opus-5`, `gemini-2.5-pro`, `gpt-4o`, `llama3.2`) |
 | `ORCHESTRATOR_API_KEY` | API key for the provider (if required) |
 | `ORCHESTRATOR_ENDPOINT` | Custom endpoint URL (if required) |
 | `ORCHESTRATOR_PROJECT_ID` | Google Cloud project ID (for Vertex AI) |
@@ -96,7 +108,7 @@ Get your MiniMax API key from the [MiniMax Platform](https://platform.minimax.io
 | Variable | Description |
 |----------|-------------|
 | `CYPHER_PROVIDER` | Provider name (`google`, `openai`, `anthropic`, `azure`, `ollama`, `minimax`, `litellm_proxy`) |
-| `CYPHER_MODEL` | Model ID (e.g., `gemini-2.5-flash`, `gpt-4o-mini`, `codellama`) |
+| `CYPHER_MODEL` | Model ID (e.g., `claude-haiku-4-5`, `gemini-2.5-flash`, `gpt-4o-mini`, `codellama`) |
 | `CYPHER_API_KEY` | API key for the provider (if required) |
 | `CYPHER_ENDPOINT` | Custom endpoint URL (if required) |
 | `CYPHER_PROJECT_ID` | Google Cloud project ID (for Vertex AI) |

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -49,8 +49,8 @@ cgr start --repo-path /path/to/your/repo \
 
 ```bash
 cgr start --repo-path /path/to/your/repo \
-  --orchestrator google:gemini-2.0-flash-thinking-exp-01-21 \
-  --cypher google:gemini-2.5-flash-lite-preview-06-17
+  --orchestrator google:gemini-2.5-pro \
+  --cypher google:gemini-2.5-flash
 ```
 
 **Example queries:**

--- a/docs/guide/cli-reference.md
+++ b/docs/guide/cli-reference.md
@@ -34,8 +34,8 @@ cgr start --repo-path /path/to/repo [OPTIONS]
 | `--update-graph` | Parse and ingest the repository into the knowledge graph |
 | `--clean` | Delete every project from the shared graph and clear the selected repository's sync cache. With `--update-graph`, rebuild after deletion. |
 | `--batch-size` | Override Memgraph flush batch size |
-| `--orchestrator` | Specify provider:model for main operations (e.g., `google:gemini-2.5-pro`, `ollama:llama3.2`) |
-| `--cypher` | Specify provider:model for graph queries (e.g., `google:gemini-2.5-flash`, `ollama:codellama`) |
+| `--orchestrator` | Specify provider:model for main operations (e.g., `anthropic:claude-opus-5`, `google:gemini-2.5-pro`, `ollama:llama3.2`) |
+| `--cypher` | Specify provider:model for graph queries (e.g., `anthropic:claude-haiku-4-5`, `google:gemini-2.5-flash`, `ollama:codellama`) |
 | `-o`, `--output` | Write the updated graph to a JSON path. Requires `--update-graph`. |
 
 ### `cgr export`

--- a/docs/guide/code-optimization.md
+++ b/docs/guide/code-optimization.md
@@ -39,7 +39,7 @@ The agent incorporates guidance from your reference documents when suggesting op
 ```bash
 cgr optimize javascript \
   --repo-path /path/to/frontend \
-  --orchestrator google:gemini-2.0-flash-thinking-exp-01-21
+  --orchestrator google:gemini-2.5-pro
 ```
 
 ```bash

--- a/docs/guide/mcp-server.md
+++ b/docs/guide/mcp-server.md
@@ -14,7 +14,7 @@ Code-Graph-RAG can run as an MCP (Model Context Protocol) server, enabling seaml
 claude mcp add --transport stdio code-graph-rag \
   --env TARGET_REPO_PATH=/absolute/path/to/your/project \
   --env CYPHER_PROVIDER=openai \
-  --env CYPHER_MODEL=gpt-4 \
+  --env CYPHER_MODEL=gpt-4o \
   --env CYPHER_API_KEY=your-api-key \
   -- code-graph-rag mcp-server
 ```
@@ -25,7 +25,7 @@ claude mcp add --transport stdio code-graph-rag \
 claude mcp add --transport stdio code-graph-rag \
   --env TARGET_REPO_PATH=/absolute/path/to/your/project \
   --env CYPHER_PROVIDER=openai \
-  --env CYPHER_MODEL=gpt-4 \
+  --env CYPHER_MODEL=gpt-4o \
   --env CYPHER_API_KEY=your-api-key \
   -- uv run --directory /path/to/code-graph-rag code-graph-rag mcp-server
 ```
@@ -38,7 +38,7 @@ cd /path/to/your/project
 claude mcp add --transport stdio code-graph-rag \
   --env TARGET_REPO_PATH="$(pwd)" \
   --env CYPHER_PROVIDER=google \
-  --env CYPHER_MODEL=gemini-2.0-flash \
+  --env CYPHER_MODEL=gemini-2.5-flash \
   --env CYPHER_API_KEY=your-google-api-key \
   -- uv run --directory /absolute/path/to/code-graph-rag code-graph-rag mcp-server
 ```
@@ -89,7 +89,7 @@ cgr daemon up
 
     ```bash
     --env CYPHER_PROVIDER=openai \
-    --env CYPHER_MODEL=gpt-4 \
+    --env CYPHER_MODEL=gpt-4o \
     --env CYPHER_API_KEY=sk-...
     ```
 
@@ -116,14 +116,14 @@ Add separate named instances for different projects:
 claude mcp add --transport stdio code-graph-rag-backend \
   --env TARGET_REPO_PATH=/path/to/backend \
   --env CYPHER_PROVIDER=openai \
-  --env CYPHER_MODEL=gpt-4 \
+  --env CYPHER_MODEL=gpt-4o \
   --env CYPHER_API_KEY=your-api-key \
   -- uv run --directory /path/to/code-graph-rag code-graph-rag mcp-server
 
 claude mcp add --transport stdio code-graph-rag-frontend \
   --env TARGET_REPO_PATH=/path/to/frontend \
   --env CYPHER_PROVIDER=openai \
-  --env CYPHER_MODEL=gpt-4 \
+  --env CYPHER_MODEL=gpt-4o \
   --env CYPHER_API_KEY=your-api-key \
   -- uv run --directory /path/to/code-graph-rag code-graph-rag mcp-server
 ```

--- a/docs/sdk/cypher-generator.md
+++ b/docs/sdk/cypher-generator.md
@@ -27,6 +27,11 @@ The Cypher generator uses the configured Cypher provider. Set it via environment
 ```bash
 CYPHER_PROVIDER=google
 CYPHER_MODEL=gemini-2.5-flash
+
+# or Anthropic
+CYPHER_PROVIDER=anthropic
+CYPHER_MODEL=claude-haiku-4-5
+CYPHER_API_KEY=sk-ant-your-anthropic-key
 CYPHER_API_KEY=your-api-key
 ```
 
@@ -36,6 +41,9 @@ Or programmatically:
 from cgr import settings
 
 settings.set_cypher("google", "gemini-2.5-flash", api_key="your-key")
+
+# or Anthropic
+settings.set_cypher("anthropic", "claude-haiku-4-5", api_key="sk-ant-...")
 ```
 
 ## Supported Providers

--- a/docs/sdk/cypher-generator.md
+++ b/docs/sdk/cypher-generator.md
@@ -42,6 +42,7 @@ settings.set_cypher("google", "gemini-2.5-flash", api_key="your-key")
 
 | Provider | Example Models |
 |----------|---------------|
+| Anthropic | `claude-opus-5`, `claude-sonnet-5`, `claude-haiku-4-5` |
 | Google | `gemini-2.5-pro`, `gemini-2.5-flash` |
 | OpenAI | `gpt-4o`, `gpt-4o-mini` |
 | Ollama | `codellama`, `llama3.2` |

--- a/docs/sdk/cypher-generator.md
+++ b/docs/sdk/cypher-generator.md
@@ -27,12 +27,15 @@ The Cypher generator uses the configured Cypher provider. Set it via environment
 ```bash
 CYPHER_PROVIDER=google
 CYPHER_MODEL=gemini-2.5-flash
+CYPHER_API_KEY=your-google-api-key
+```
 
-# or Anthropic
+Or with Anthropic:
+
+```bash
 CYPHER_PROVIDER=anthropic
 CYPHER_MODEL=claude-haiku-4-5
 CYPHER_API_KEY=sk-ant-your-anthropic-key
-CYPHER_API_KEY=your-api-key
 ```
 
 Or programmatically:
@@ -40,10 +43,15 @@ Or programmatically:
 ```python
 from cgr import settings
 
-settings.set_cypher("google", "gemini-2.5-flash", api_key="your-key")
+settings.set_cypher("google", "gemini-2.5-flash", api_key="your-google-api-key")
+```
 
-# or Anthropic
-settings.set_cypher("anthropic", "claude-haiku-4-5", api_key="sk-ant-...")
+Or with Anthropic:
+
+```python
+from cgr import settings
+
+settings.set_cypher("anthropic", "claude-haiku-4-5", api_key="sk-ant-your-key")
 ```
 
 ## Supported Providers


### PR DESCRIPTION
Closes #1049.

The issue is a screenshot of stale model suggestions, so I scoped it to what is verifiable rather than guessing at recommendations.

## A real bug found along the way

`MODEL_CONTEXT_WINDOWS` had no entry for the current Anthropic models, so `_context_usage` fell through to `DEFAULT_CONTEXT_WINDOW` (200K) and the status bar under-reported the window by 5x on 1M-context models. That is exactly the failure #705 added this table to prevent. Added `claude-opus-5` and `claude-sonnet-5` at 1M, and extended the parametrised test to cover them plus `claude-haiku-4-5` at 200K.

## Docs

- **Anthropic examples added** where the docs previously listed only OpenAI/Google/Ollama — configuration guide, CLI reference, cypher-generator provider table, and both env-var tables.
- **Expired identifiers replaced**: `gemini-2.0-flash-thinking-exp-01-21` and `gemini-2.5-flash-lite-preview-06-17` were dated experimental/preview builds; bare `gpt-4` appeared in seven copy-pasteable MCP and Claude Code setup snippets.

## On sourcing

Anthropic model IDs are taken from the current Anthropic model reference, not written from memory. For OpenAI and Google I deliberately did **not** invent newer IDs — I normalised the stale ones to identifiers this repository already uses elsewhere (`gpt-4o`, `gemini-2.5-pro`, `gemini-2.5-flash`), which is an internal-consistency change I can stand behind. If you want the OpenAI/Google recommendations moved to their latest models, that is a judgement call about which models to endorse and I would rather you make it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Anthropic configuration examples for orchestration, Cypher generation, CLI usage, and SDK integrations.
  - Added 1-million-token context-window support for Claude Opus 5 and Claude Sonnet 5.
  - Expanded documented Anthropic model coverage, including Claude Haiku 4.5 and earlier Claude versions.

- **Documentation**
  - Updated setup, quick-start, optimization, and MCP examples to use current Gemini and OpenAI models.
  - Refreshed model identifiers and provider configuration examples throughout the README and guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->