### PR TITLE
fix: validate role API keys at MCP startup before constructing services

### DIFF
--- a/codebase_rag/mcp/server.py
+++ b/codebase_rag/mcp/server.py
@@ -77,6 +77,17 @@ def create_server() -> tuple[Server, MemgraphIngestor]:
         logger.error(lg.MCP_SERVER_CONFIG_ERROR.format(error=e))
         raise
 
+    # Fail at startup with the role-aware missing-key diagnostic rather than
+    # letting the first tool call surface a wrapped provider error from deep
+    # inside CypherGenerator or the orchestrator (issue #1125). Local
+    # providers pass through the validator's existing exemption.
+    try:
+        settings.active_orchestrator_config.validate_api_key(cs.ModelRole.ORCHESTRATOR)
+        settings.active_cypher_config.validate_api_key(cs.ModelRole.CYPHER)
+    except ValueError as e:
+        logger.error(lg.MCP_SERVER_CONFIG_ERROR.format(error=e))
+        raise
+
     logger.info(lg.MCP_SERVER_INIT_SERVICES)
 
     ingestor = MemgraphIngestor(

--- a/codebase_rag/tests/test_mcp_startup_key_validation.py
+++ b/codebase_rag/tests/test_mcp_startup_key_validation.py
@@ -1,0 +1,81 @@
+"""MCP startup must fail with the role-aware missing-key diagnostic (issue #1125),
+not a wrapped provider error from the first tool call."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.config import ModelConfig
+from codebase_rag.mcp import server as srv
+
+
+def _remote_config_without_key() -> ModelConfig:
+    return ModelConfig(provider="anthropic", model_id="claude-sonnet-5", api_key=None)
+
+
+def _local_config() -> ModelConfig:
+    return ModelConfig(provider="ollama", model_id="llama3.2", api_key=None)
+
+
+class TestStartupKeyValidation:
+    def test_remote_provider_without_key_fails_before_services(
+        self, tmp_path: Path
+    ) -> None:
+        with (
+            patch.dict(os.environ, {"TARGET_REPO_PATH": str(tmp_path)}),
+            patch.object(
+                type(srv.settings),
+                "active_orchestrator_config",
+                property(lambda self: _remote_config_without_key()),
+            ),
+            patch.object(
+                type(srv.settings),
+                "active_cypher_config",
+                property(lambda self: _local_config()),
+            ),
+            patch.object(srv, "MemgraphIngestor") as ingestor,
+        ):
+            with pytest.raises(ValueError, match=cs.ModelRole.ORCHESTRATOR):
+                srv.create_server()
+            ingestor.assert_not_called()
+
+    def test_cypher_role_is_validated_too(self, tmp_path: Path) -> None:
+        with (
+            patch.dict(os.environ, {"TARGET_REPO_PATH": str(tmp_path)}),
+            patch.object(
+                type(srv.settings),
+                "active_orchestrator_config",
+                property(lambda self: _local_config()),
+            ),
+            patch.object(
+                type(srv.settings),
+                "active_cypher_config",
+                property(lambda self: _remote_config_without_key()),
+            ),
+            patch.object(srv, "MemgraphIngestor"),
+        ):
+            with pytest.raises(ValueError, match=cs.ModelRole.CYPHER):
+                srv.create_server()
+
+    def test_local_providers_keep_their_keyless_exemption(self, tmp_path: Path) -> None:
+        with (
+            patch.dict(os.environ, {"TARGET_REPO_PATH": str(tmp_path)}),
+            patch.object(
+                type(srv.settings),
+                "active_orchestrator_config",
+                property(lambda self: _local_config()),
+            ),
+            patch.object(
+                type(srv.settings),
+                "active_cypher_config",
+                property(lambda self: _local_config()),
+            ),
+            patch.object(srv, "MemgraphIngestor"),
+            patch.object(srv, "CypherGenerator"),
+            patch.object(srv, "create_mcp_tools_registry"),
+        ):
+            server, _ = srv.create_server()
+            assert server is not None


### PR DESCRIPTION
## Summary

- MCP server startup now runs `ModelConfig.validate_api_key()` for both the orchestrator and Cypher roles before constructing any service, so a remote provider configured without a role key fails immediately with the documented role-aware diagnostic instead of a wrapped `LLMGenerationError` from inside the first tool call
- Local providers keep their existing keyless exemption in the validator untouched

## Type of Change

- [x] Bug fix

## Related Issues

Closes #1125

## Test Plan

- [x] Unit tests: remote orchestrator without a key fails before `MemgraphIngestor` is ever constructed; the Cypher role is validated independently; an all-local configuration still starts keyless
- [x] Regression check: both failure tests are RED with the validation call stashed and green with it

## Checklist

- [x] PR title follows Conventional Commits format
- [x] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [x] No new comments or docstrings beyond the file's existing style

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added startup validation for required API keys when using remote orchestrator and Cypher providers.
  * Configuration errors are now reported before service initialization, with diagnostics identifying the affected provider.
  * Local providers remain exempt from API-key requirements.

* **Tests**
  * Added coverage for missing-key scenarios and local provider exemptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->