### PR TITLE
fix: keep the full bracketed computed name when registering object-literal symbol members

### DIFF
--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -215,6 +215,7 @@ JS_SHORT_CIRCUIT_OPERATORS: frozenset[str] = frozenset({"||", "??", "&&"})
 # (`[Symbol.iterator]`, `[Symbol.toStringTag]`) as the definition pass
 # registers it; user symbol keys register without the `Symbol.` path.
 JS_WELL_KNOWN_SYMBOL_NAME_PREFIX = "[Symbol."
+JS_COMPUTED_NAME_PREFIX = "["
 JS_COMPUTED_NAME_SUFFIX = "]"
 JS_WELL_KNOWN_SYMBOL_BRACKET_PREFIX = "[Symbol["
 JS_SYMBOL_FOR_PREFIX = "for("

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -587,7 +587,17 @@ class FunctionIngestMixin:
         # than recomputing from the path, so same-stem cross-language siblings stay
         # distinct.
         func_qn = module_qn + cs.SEPARATOR_DOT + cs.SEPARATOR_DOT.join(parts)
-        simple_name = func_qn.rsplit(cs.SEPARATOR_DOT, 1)[-1]
+        # A plain dotted name (Lua `M.foo`) keeps only its final segment, as
+        # the qn rsplit always did. A computed bracket name is different: its
+        # dot belongs to the name itself, and re-splitting registered an
+        # object-literal `[Symbol.iterator]` member as `iterator]`
+        # (issue #998).
+        simple_name = (
+            func_name
+            if func_name.startswith(cs.JS_COMPUTED_NAME_PREFIX)
+            and func_name.endswith(cs.JS_COMPUTED_NAME_SUFFIX)
+            else func_qn.rsplit(cs.SEPARATOR_DOT, 1)[-1]
+        )
 
         is_exported = export_detection.is_exported(func_node, simple_name, language)
         return FunctionResolution(func_qn, simple_name, is_exported)

--- a/codebase_rag/tests/test_js_object_literal_symbol_member_name.py
+++ b/codebase_rag/tests/test_js_object_literal_symbol_member_name.py
@@ -1,0 +1,52 @@
+"""An object-literal member keyed by a computed symbol must register with its
+full bracketed name, not a dot-mangled fragment (issue #998)."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.tests.conftest import get_relationships
+
+SOURCE = """
+const obj = {
+  [Symbol.iterator] () { return helper() }
+}
+function helper () { return 1 }
+module.exports = { obj }
+"""
+
+
+def _function_nodes(mock_ingestor: MagicMock) -> dict[str, str]:
+    return {
+        c.args[1]["qualified_name"]: c.args[1].get("name")
+        for c in mock_ingestor.ensure_node_batch.call_args_list
+        if str(c.args[0]) == "Function"
+    }
+
+
+def test_computed_symbol_member_keeps_its_bracketed_name(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    (temp_repo / "obj.js").write_text(SOURCE, encoding="utf-8")
+    parsers, queries = load_parsers()
+    updater = GraphUpdater(
+        ingestor=mock_ingestor,
+        repo_path=temp_repo,
+        parsers=parsers,
+        queries=queries,
+    )
+    updater.run()
+
+    project = temp_repo.name
+    functions = _function_nodes(mock_ingestor)
+    member_qn = f"{project}.obj.[Symbol.iterator]"
+    assert member_qn in functions, functions
+    assert functions[member_qn] == "[Symbol.iterator]", functions[member_qn]
+    assert "iterator]" not in functions.values()
+
+    calls = get_relationships(mock_ingestor, "CALLS")
+    helper_qn = f"{project}.obj.helper"
+    assert any(
+        call.args[0][2] == member_qn and call.args[2][2] == helper_qn for call in calls
+    ), [c.args for c in calls]


### PR DESCRIPTION
## Summary

- `_try_unified_fqn_resolution` derived the simple name by re-splitting the finished qn on dots, so an object-literal member keyed by a computed symbol registered with a mangled name — `[Symbol.iterator]` became `iterator]` (its qn was already correct)
- The name now keeps the full bracket form when the extracted name is a computed `[...]` key; plain dotted names (Lua `M.foo`) keep their final-segment behaviour unchanged
- With the un-mangled name, the well-known-symbol liveness rule recognises the member label-independently (the #1006 allowlist matches the qn), and its private callees stay live

## Type of Change

- [x] Bug fix

## Related Issues

Closes #998

## Test Plan

- [x] New regression test: the exact issue repro registers with name `[Symbol.iterator]`, no `iterator]` fragment anywhere, and the member→helper CALLS edge exists — RED without the fix
- [x] 430-test sweep across lua/object-literal/arrow/export/dead-code naming paths

## Checklist

- [x] PR title follows Conventional Commits format
- [x] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [x] No new comments or docstrings beyond the existing style

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JavaScript and TypeScript indexing for computed member names, preserving full bracketed names.
  * Ensured computed symbol-named object-literal methods retain their correct display and qualified names.
  * Preserved accurate call relationships for these methods.

* **Tests**
  * Added regression coverage for computed symbol-named object-literal methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->