### PR TITLE
fix: index ambient namespace function signatures as merged receiver bindings

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -709,7 +709,29 @@ class _JsFileBindingCollector:
             cs.TS_JS_AUGMENTED_ASSIGNMENT_EXPRESSION,
         ):
             self._visit_assignment(node)
+        elif node_type == cs.TS_FUNCTION_SIGNATURE:
+            self._visit_function_signature(node, fn_container)
         return True, frame
+
+    def _visit_function_signature(self, node: Node, fn_container: Node) -> None:
+        # An ambient namespace member (`declare namespace N { export function
+        # helper(): number }`) is a function_signature, yet declaration
+        # merging makes it a real introduction in every sibling block of the
+        # same namespace: a call there that TS resolves to the merged member
+        # must not fall through to a same-named file-level function (issue
+        # #996). Count-only (no function node) so it can only suppress, and
+        # replicated across the merge group like other exported members;
+        # file-level overload signatures stay uncollected — they denote the
+        # same function as their implementation. Ambient members are exported
+        # whether or not they carry the keyword, so every namespace-level
+        # signature replicates.
+        if fn_container.type not in (cs.TS_INTERNAL_MODULE, cs.TS_MODULE):
+            return
+        name_node = node.child_by_field_name(cs.FIELD_NAME)
+        if name_node is None or not (sig_name := safe_decode_text(name_node)):
+            return
+        self._add(sig_name, None, fn_container)
+        self._ns_exported.append((sig_name, None, fn_container))
 
     def _visit_callable(
         self, node: Node, fn_container: Node

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -730,8 +730,35 @@ class _JsFileBindingCollector:
         name_node = node.child_by_field_name(cs.FIELD_NAME)
         if name_node is None or not (sig_name := safe_decode_text(name_node)):
             return
+        if self._sibling_implementation_exists(node, sig_name):
+            # An overload signature beside its implementation in the same
+            # block denotes THAT implementation, not a distinct introduction;
+            # counting it would discard correct resolutions to the
+            # implementation. Only declaration-only signatures participate.
+            return
         self._add(sig_name, None, fn_container)
         self._ns_exported.append((sig_name, None, fn_container))
+
+    @staticmethod
+    def _sibling_implementation_exists(node: Node, sig_name: str) -> bool:
+        block = node.parent
+        if block is not None and block.type == cs.TS_EXPORT_STATEMENT:
+            block = block.parent
+        if block is None:
+            return False
+        for sibling in block.named_children:
+            candidate: Node | None = sibling
+            if sibling.type == cs.TS_EXPORT_STATEMENT:
+                candidate = next(iter(sibling.named_children), None)
+            if candidate is None or candidate.type not in (
+                cs.TS_FUNCTION_DECLARATION,
+                cs.TS_GENERATOR_FUNCTION_DECLARATION,
+            ):
+                continue
+            impl_name = candidate.child_by_field_name(cs.FIELD_NAME)
+            if impl_name is not None and safe_decode_text(impl_name) == sig_name:
+                return True
+        return False
 
     def _visit_callable(
         self, node: Node, fn_container: Node

--- a/codebase_rag/tests/test_ts_ambient_namespace_receiver_binding.py
+++ b/codebase_rag/tests/test_ts_ambient_namespace_receiver_binding.py
@@ -78,6 +78,30 @@ namespace N { export function use (): number { return helper.call(this) } }
     assert not wrong, wrong
 
 
+def test_overload_signatures_beside_their_implementation_still_resolve(
+    tmp_path: Path,
+) -> None:
+    cap = _run(
+        tmp_path,
+        """
+namespace N {
+  export function pick (x: string): string
+  export function pick (x: number): number
+  export function pick (x: unknown): unknown { return x }
+  export function use (): unknown { return pick.call(this, 1) }
+}
+""",
+    )
+    edges = [
+        r
+        for r in cap.rels
+        if r[1] == "CALLS"
+        and str(r[0]).endswith(".use")
+        and str(r[2]).startswith(f"{PROJECT}.a.N.pick")
+    ]
+    assert edges, [r for r in cap.rels if r[1] == "CALLS"]
+
+
 def test_without_ambient_merge_the_file_level_binding_still_resolves(
     tmp_path: Path,
 ) -> None:

--- a/codebase_rag/tests/test_ts_ambient_namespace_receiver_binding.py
+++ b/codebase_rag/tests/test_ts_ambient_namespace_receiver_binding.py
@@ -1,0 +1,98 @@
+# A merged ambient namespace member (`declare namespace N { export function
+# helper(): number }`) is where TS resolves a `helper.call(this)` receiver
+# inside a value block of N; the binding index must see that introduction so
+# the site has TWO relevant bindings and suppresses, instead of falling
+# through to a same-named file-level function and emitting a wrong edge.
+# Issue #996, surfaced by the #995 review.
+from __future__ import annotations
+
+from pathlib import Path
+
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.types_defs import PropertyDict, PropertyValue, ResultRow
+
+PROJECT = "p"
+
+
+class _Capture:
+    def __init__(self) -> None:
+        self.rels: list[tuple[PropertyValue, str, PropertyValue]] = []
+
+    def ensure_node_batch(self, label: str, properties: PropertyDict) -> None:
+        return None
+
+    def ensure_relationship_batch(
+        self,
+        from_spec: tuple[str, str, PropertyValue],
+        rel_type: str,
+        to_spec: tuple[str, str, PropertyValue],
+        properties: PropertyDict | None = None,
+    ) -> None:
+        self.rels.append((from_spec[2], str(rel_type), to_spec[2]))
+
+    def flush_all(self) -> None:
+        return None
+
+    def fetch_all(
+        self, query: str, params: PropertyDict | None = None
+    ) -> list[ResultRow]:
+        return []
+
+    def execute_write(self, query: str, params: PropertyDict | None = None) -> None:
+        return None
+
+
+def _run(tmp_path: Path, src: str, filename: str = "a.ts") -> _Capture:
+    (tmp_path / filename).write_text(src)
+    parsers, queries = load_parsers()
+    cap = _Capture()
+    GraphUpdater(
+        ingestor=cap,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name=PROJECT,
+    ).run(force=True)
+    return cap
+
+
+def test_merged_ambient_member_suppresses_file_level_fallthrough(
+    tmp_path: Path,
+) -> None:
+    cap = _run(
+        tmp_path,
+        """
+function helper (): number { return 1 }
+declare namespace N { export function helper (): number }
+namespace N { export function use (): number { return helper.call(this) } }
+""",
+    )
+    wrong = [
+        r
+        for r in cap.rels
+        if r[1] == "CALLS"
+        and str(r[0]).endswith(".use")
+        and str(r[2]) == f"{PROJECT}.a.helper"
+    ]
+    assert not wrong, wrong
+
+
+def test_without_ambient_merge_the_file_level_binding_still_resolves(
+    tmp_path: Path,
+) -> None:
+    cap = _run(
+        tmp_path,
+        """
+function helper (): number { return 1 }
+namespace N { export function use (): number { return helper.call(this) } }
+""",
+    )
+    edges = [
+        r
+        for r in cap.rels
+        if r[1] == "CALLS"
+        and str(r[0]).endswith(".use")
+        and str(r[2]) == f"{PROJECT}.a.helper"
+    ]
+    assert edges, [r for r in cap.rels if r[1] == "CALLS"]


### PR DESCRIPTION
## Summary

- `_JsFileBindingCollector` now collects `function_signature` members of namespace blocks as count-only introductions and replicates them across the namespace's merge group, exactly like other exported members
- A call in a value block of a merged namespace that TS resolves to the merged ambient member (`declare namespace N { export function helper(): number }`) now sees TWO relevant introductions and suppresses, instead of falling through to a same-named file-level function and emitting a wrong CALLS edge
- File-level overload signatures stay uncollected — they denote the same function as their implementation, so collecting them would only cost correct resolutions
- Count-only entries can never resolve, only suppress, preserving the index's over-collection discipline

## Type of Change

- [x] Bug fix

## Related Issues

Closes #996

## Test Plan

- [x] Regression: the issue's exact repro emits no wrong-target CALLS edge (RED without the fix — the pre-fix run emits `N@4.use -CALLS-> a.helper`), plus a positive control proving an unmerged namespace still resolves the file-level binding
- [x] 207-test sweep across fn.call/apply, this-binding, TypeScript and namespace suites

## Checklist

- [x] PR title follows Conventional Commits format
- [x] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [x] No new comments or docstrings beyond the existing style

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript ambient namespace handling so function signatures resolve to the correct namespace members.
  * Prevented merged namespace members from incorrectly falling back to similarly named file-level helper functions.
  * Preserved correct resolution for overloads, functions outside merged namespaces, and non-merged namespace scenarios.

* **Tests**
  * Added coverage for ambient namespace receiver binding, overload resolution, and call-edge behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->