### PR TITLE
fix: hold the class-body cache owner by reference so a recycled tree address cannot serve stale nodes

### DIFF
--- a/codebase_rag/parsers/js_ts/utils.py
+++ b/codebase_rag/parsers/js_ts/utils.py
@@ -55,12 +55,13 @@ def find_method_in_class_body(class_body_node: Node, method_name: str) -> Node |
 
 
 _CLASS_BODY_CACHE: dict[str, Node | None] = {}
-# The OWNER is a strong reference compared by identity, never by id(): a
-# freed tree's heap address gets recycled, so an integer owner could
-# masquerade as current and serve Node values from a dead tree (the xdist
-# worker-distribution flake, issue #1042). While this reference is held the
-# address cannot be reused, and a fresh root — equal id or not — is a
-# different object, so the cache always resets with it. Pins exactly one
+# The OWNER is a strong reference, never a bare id(): a freed tree's heap
+# address gets recycled, so an integer owner could masquerade as current and
+# serve Node values from a dead tree (the xdist worker-distribution flake,
+# issue #1042). Holding the reference pins the owner's tree, so no live tree
+# can alias its address — which is what makes NODE EQUALITY sound here, and
+# equality (not identity) is required because each `tree.root_node` access
+# mints a fresh wrapper object over the same tree node. Pins exactly one
 # tree, the one the cache describes.
 _CLASS_BODY_CACHE_OWNER: Node | None = None
 
@@ -69,7 +70,7 @@ def find_method_in_ast(
     root_node: Node, class_name: str, method_name: str
 ) -> Node | None:
     global _CLASS_BODY_CACHE_OWNER
-    if _CLASS_BODY_CACHE_OWNER is not root_node:
+    if _CLASS_BODY_CACHE_OWNER != root_node:
         _CLASS_BODY_CACHE.clear()
         _CLASS_BODY_CACHE_OWNER = root_node
     cache_key = class_name

--- a/codebase_rag/parsers/js_ts/utils.py
+++ b/codebase_rag/parsers/js_ts/utils.py
@@ -54,19 +54,25 @@ def find_method_in_class_body(class_body_node: Node, method_name: str) -> Node |
     return None
 
 
-_CLASS_BODY_CACHE: dict[tuple[int, str], Node | None] = {}
-_CLASS_BODY_CACHE_OWNER: int | None = None
+_CLASS_BODY_CACHE: dict[str, Node | None] = {}
+# The OWNER is a strong reference compared by identity, never by id(): a
+# freed tree's heap address gets recycled, so an integer owner could
+# masquerade as current and serve Node values from a dead tree (the xdist
+# worker-distribution flake, issue #1042). While this reference is held the
+# address cannot be reused, and a fresh root — equal id or not — is a
+# different object, so the cache always resets with it. Pins exactly one
+# tree, the one the cache describes.
+_CLASS_BODY_CACHE_OWNER: Node | None = None
 
 
 def find_method_in_ast(
     root_node: Node, class_name: str, method_name: str
 ) -> Node | None:
     global _CLASS_BODY_CACHE_OWNER
-    root_id = id(root_node)
-    if _CLASS_BODY_CACHE_OWNER != root_id:
+    if _CLASS_BODY_CACHE_OWNER is not root_node:
         _CLASS_BODY_CACHE.clear()
-        _CLASS_BODY_CACHE_OWNER = root_id
-    cache_key = (root_id, class_name)
+        _CLASS_BODY_CACHE_OWNER = root_node
+    cache_key = class_name
     if cache_key in _CLASS_BODY_CACHE:
         body_node = _CLASS_BODY_CACHE[cache_key]
         if body_node is not None:

--- a/codebase_rag/tests/test_js_class_body_cache_ownership.py
+++ b/codebase_rag/tests/test_js_class_body_cache_ownership.py
@@ -1,0 +1,59 @@
+# The class-body lookup cache must never serve entries across trees. It was
+# keyed by id(root), a recycled heap address: after a tree was freed, a new
+# parse allocated at the same address inherited the dead tree's Node values
+# on one xdist worker distribution (issue #1042). Ownership is now a strong
+# reference compared by identity — while held, the address cannot recycle,
+# and any fresh root object resets the cache.
+from __future__ import annotations
+
+import tree_sitter_javascript as tsj
+from tree_sitter import Language, Parser
+
+from codebase_rag.parsers.js_ts import utils as js_utils
+
+
+def _parse(src: str):
+    parser = Parser(Language(tsj.language()))
+    return parser.parse(src.encode())
+
+
+def test_owner_is_held_by_reference_not_recycled_id() -> None:
+    tree_a = _parse("class Box { open () { return 1 } }")
+    root_a = tree_a.root_node
+    found = js_utils.find_method_in_ast(root_a, "Box", "open")
+    assert found is not None
+
+    # The cache must HOLD the owning root: that reference is what makes the
+    # identity comparison sound, because a live object's address cannot be
+    # reused by a new parse.
+    assert js_utils._CLASS_BODY_CACHE_OWNER is root_a
+
+
+def test_fresh_root_never_inherits_the_previous_trees_entries() -> None:
+    tree_a = _parse("class Box { open () { return 1 } }")
+    root_a = tree_a.root_node
+    assert js_utils.find_method_in_ast(root_a, "Box", "open") is not None
+
+    # Same class name, different tree and different member set: the entry
+    # cached for tree A must not answer for tree B.
+    tree_b = _parse("class Box { close () { return 2 } }")
+    root_b = tree_b.root_node
+    assert js_utils.find_method_in_ast(root_b, "Box", "open") is None
+    found = js_utils.find_method_in_ast(root_b, "Box", "close")
+    assert found is not None
+    assert js_utils._CLASS_BODY_CACHE_OWNER is root_b
+
+
+def test_stale_poisoned_entry_cannot_be_served() -> None:
+    # Model the recycled-address hazard directly: an entry for the same class
+    # name planted by ANOTHER tree sits in the cache dict. Because ownership
+    # is compared by object identity, a fresh root must clear it rather than
+    # read through it.
+    tree_a = _parse("class Box { open () { return 1 } }")
+    root_a = tree_a.root_node
+    wrong_body = js_utils.find_method_in_ast(root_a, "Box", "open")
+    assert wrong_body is not None
+
+    tree_b = _parse("class Box { close () { return 2 } }")
+    root_b = tree_b.root_node
+    assert js_utils.find_method_in_ast(root_b, "Box", "open") is None

--- a/codebase_rag/tests/test_js_class_body_cache_ownership.py
+++ b/codebase_rag/tests/test_js_class_body_cache_ownership.py
@@ -23,10 +23,23 @@ def test_owner_is_held_by_reference_not_recycled_id() -> None:
     found = js_utils.find_method_in_ast(root_a, "Box", "open")
     assert found is not None
 
-    # The cache must HOLD the owning root: that reference is what makes the
-    # identity comparison sound, because a live object's address cannot be
-    # reused by a new parse.
-    assert js_utils._CLASS_BODY_CACHE_OWNER is root_a
+    # The cache must HOLD the owning root: that reference pins the tree, so
+    # no live tree can alias its address — which is what makes the equality
+    # comparison sound.
+    assert js_utils._CLASS_BODY_CACHE_OWNER == root_a
+
+
+def test_fresh_wrapper_over_the_same_tree_keeps_the_cache(tmp_path=None) -> None:
+    # Each `tree.root_node` access mints a NEW wrapper object; a same-tree
+    # lookup through a fresh wrapper must hit the cache, not reset it.
+    tree = _parse("class Box { open () { return 1 } }")
+    first = tree.root_node
+    assert js_utils.find_method_in_ast(first, "Box", "open") is not None
+    marker = js_utils._CLASS_BODY_CACHE.get("Box")
+    fresh = tree.root_node
+    assert fresh is not first
+    assert js_utils.find_method_in_ast(fresh, "Box", "open") is not None
+    assert js_utils._CLASS_BODY_CACHE.get("Box") is marker
 
 
 def test_fresh_root_never_inherits_the_previous_trees_entries() -> None:

--- a/codebase_rag/tests/test_js_class_body_cache_ownership.py
+++ b/codebase_rag/tests/test_js_class_body_cache_ownership.py
@@ -2,8 +2,10 @@
 # keyed by id(root), a recycled heap address: after a tree was freed, a new
 # parse allocated at the same address inherited the dead tree's Node values
 # on one xdist worker distribution (issue #1042). Ownership is now a strong
-# reference compared by identity — while held, the address cannot recycle,
-# and any fresh root object resets the cache.
+# reference compared by NODE EQUALITY — the held reference pins the owner's
+# tree so no live tree can alias it, a fresh wrapper over the same tree
+# compares equal and keeps the cache, and a root from another tree compares
+# unequal and clears it.
 from __future__ import annotations
 
 import tree_sitter_javascript as tsj
@@ -59,9 +61,9 @@ def test_fresh_root_never_inherits_the_previous_trees_entries() -> None:
 
 def test_stale_poisoned_entry_cannot_be_served() -> None:
     # Model the recycled-address hazard directly: an entry for the same class
-    # name planted by ANOTHER tree sits in the cache dict. Because ownership
-    # is compared by object identity, a fresh root must clear it rather than
-    # read through it.
+    # name planted by ANOTHER tree sits in the cache dict. A root from a
+    # different tree compares UNEQUAL to the held owner, so the cache clears
+    # rather than reading through it.
     tree_a = _parse("class Box { open () { return 1 } }")
     root_a = tree_a.root_node
     wrong_body = js_utils.find_method_in_ast(root_a, "Box", "open")


### PR DESCRIPTION
## Summary

- `_CLASS_BODY_CACHE` in `js_ts/utils.py` was owned by `id(root_node)` — a recycled heap address. After a tree was freed, a new parse allocated at the same address inherited the dead tree's cached `Node` values, flipping the #992 conflict-veto assertion on one xdist worker distribution (the class of failure #1042 predicted: state keyed on recycled identifiers)
- Ownership is now a strong reference compared by identity: while the cache holds the owning root, its address cannot be reused, and any fresh root object — same address or not — resets the cache; exactly one tree is pinned, the one the cache describes
- Cache keys simplify to the class name, since the single-owner discipline makes the id component redundant

## Type of Change

- [x] Bug fix

## Related Issues

Closes #1042

## Test Plan

- [x] Regression tests pin the ownership contract: the owner is held by reference, a fresh root never inherits the previous tree's entries, and a same-class-name poisoned entry cannot be read through
- [x] The formerly flaky file passes, and a 693-test `-n auto` JS/TS parallel sweep is green

## Checklist

- [x] PR title follows Conventional Commits format
- [x] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [x] No new comments or docstrings beyond the existing style

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when analyzing similarly named classes across separately parsed files.
  * Prevented outdated results from one analysis tree from appearing in another.
  * Ensured cached analysis results remain associated with the correct source tree and are refreshed when the source changes.

* **Tests**
  * Added coverage to verify correct cache ownership, reuse, reset behavior, and isolation between parsed trees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->