### PR TITLE
fix: root src/bin mod.rs and explicit mod.rs targets as their own crates

### DIFF
--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -1764,18 +1764,19 @@ class ImportProcessor:
                 # cargo-verified), so it attaches classically with
                 # itself as the definitive entry stem.
                 return "entry", qn_parts
-        if (
-            stem in cs.RS_ENTRY_STEMS
-            and f"{stem}{cs.EXT_RS}"
-            in self._rust_dir_entries(self.repo_path.joinpath(*dir_parts))
-            and self._rust_is_auto_target_dir(dir_parts, stem)
+        if stem in cs.RS_ENTRY_STEMS and f"{stem}{cs.EXT_RS}" in self._rust_dir_entries(
+            self.repo_path.joinpath(*dir_parts)
         ):
-            # An entry-stem FILE in a direct auto-target location
-            # (src/bin/main.rs beside src/bin/mod.rs) keeps its own crate:
-            # its qn carries the stem only when a sibling claimed the dir
-            # qn, and the ancestor mod.rs check below must not swallow it
+            # An entry-stem FILE that is a target in its own right — by
+            # auto location (src/bin/main.rs beside src/bin/mod.rs) or by
+            # explicit manifest path — keeps its own crate: its qn carries
+            # the stem only when a sibling claimed the dir qn, and the
+            # ancestor mod.rs check below must not swallow it
             # (issue #1031 review).
-            return "file", qn_parts
+            if self._rust_is_auto_target_dir(dir_parts, stem):
+                return "file", qn_parts
+            if self._rust_is_explicit_target(dir_parts, stem):
+                return "entry", qn_parts
         if self._rust_is_mod_rs_target(qn_parts):
             # Cargo compiles src/bin/mod.rs (or an explicit target whose
             # path ends in mod.rs) as a target named `mod` whose crate root

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -1764,6 +1764,18 @@ class ImportProcessor:
                 # cargo-verified), so it attaches classically with
                 # itself as the definitive entry stem.
                 return "entry", qn_parts
+        if (
+            stem in cs.RS_ENTRY_STEMS
+            and f"{stem}{cs.EXT_RS}"
+            in self._rust_dir_entries(self.repo_path.joinpath(*dir_parts))
+            and self._rust_is_auto_target_dir(dir_parts, stem)
+        ):
+            # An entry-stem FILE in a direct auto-target location
+            # (src/bin/main.rs beside src/bin/mod.rs) keeps its own crate:
+            # its qn carries the stem only when a sibling claimed the dir
+            # qn, and the ancestor mod.rs check below must not swallow it
+            # (issue #1031 review).
+            return "file", qn_parts
         if self._rust_is_mod_rs_target(qn_parts):
             # Cargo compiles src/bin/mod.rs (or an explicit target whose
             # path ends in mod.rs) as a target named `mod` whose crate root
@@ -1996,16 +2008,19 @@ class ImportProcessor:
         key = (tuple(module_parts), dir_backed, want_mods)
         if key in self._rust_module_mod_decls:
             return self._rust_module_mod_decls[key]
-        if not module_parts:
+        if not module_parts and not dir_backed:
+            # Only a dir-backed root can live at the bare project qn: a
+            # root-level explicit `path = "mod.rs"` target (issue #1031).
             return None
         parent = module_parts[:-1]
         # A file the indexer skipped backs nothing: the graph holds no such
         # module, so its declarations must not decide where an indexed one
         # sits. Falling through lets mod.rs back the module when only the
         # sibling .rs was excluded (issue #1100).
-        sibling = f"{module_parts[-1]}{cs.EXT_RS}"
+        sibling = f"{module_parts[-1]}{cs.EXT_RS}" if module_parts else ""
         if (
             not dir_backed
+            and module_parts
             and sibling in self._rust_dir_entries(self.repo_path.joinpath(*parent))
             and self._rust_file_is_indexed([*parent, sibling])
         ):

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -1769,9 +1769,10 @@ class ImportProcessor:
             # path ends in mod.rs) as a target named `mod` whose crate root
             # is the file itself. The mod.rs spelling maps the module to its
             # DIRECTORY qn, so that qn is the file root and `mod x;` inside
-            # it resolves beside it — exactly the file-root nesting
+            # it resolves beside it — file-root nesting whose declarations
+            # come from mod.rs, not a sibling `<dir>.rs` shadow
             # (issue #1031).
-            return "file", qn_parts
+            return "dir_file", qn_parts
         for i in range(len(dir_parts), -1, -1):
             if i >= 1:
                 name = dir_parts[i - 1]
@@ -2275,6 +2276,20 @@ class ImportProcessor:
         beside the entry point, so route through _rust_attach.
         """
         parts = base_qn.split(cs.SEPARATOR_DOT)[1:]
+        mod_stem = cs.MOD_RS[: -len(cs.EXT_RS)]
+        if (
+            parts
+            and cs.MOD_RS in self._rust_dir_entries(self.repo_path.joinpath(*parts))
+            and (
+                self._rust_is_auto_target_dir(parts, mod_stem)
+                or self._rust_is_explicit_target(parts, mod_stem)
+            )
+        ):
+            # The base qn IS a mod.rs-backed target (src/bin/mod.rs): its
+            # self:: — and super:: chains landing on it — attach beside
+            # mod.rs, never through a sibling entry stem like src/bin's
+            # main.rs (issue #1031).
+            return self._rust_join_mods(parts, rest, dir_backed=True)
         if self._rust_is_crate_root_dir(parts):
             stem, definitive = self._rust_entry_stem(parts, importer_qn)
             return self._rust_attach(parts, stem, rest, definitive)
@@ -2367,6 +2382,11 @@ class ImportProcessor:
             # An auto-target crate (src/bin/tool.rs): items and
             # submodules both nest under the entry file's qn.
             return self._rust_join_mods(root_parts, rest)
+        if kind == "dir_file":
+            # A mod.rs-backed target (src/bin/mod.rs): same nesting, but
+            # the root's declarations live in mod.rs, so the walk must not
+            # read a sibling `<dir>.rs` shadow.
+            return self._rust_join_mods(root_parts, rest, dir_backed=True)
         if kind == "entry":
             # An explicit manifest target: the root file IS the entry,
             # so submodule files sit beside it and items nest in it.

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -1760,6 +1760,18 @@ class ImportProcessor:
                 # cargo-verified), so it attaches classically with
                 # itself as the definitive entry stem.
                 return "entry", qn_parts
+        mod_stem = cs.MOD_RS[: -len(cs.EXT_RS)]
+        if cs.MOD_RS in self._rust_dir_entries(self.repo_path.joinpath(*qn_parts)) and (
+            self._rust_is_auto_target_dir(qn_parts, mod_stem)
+            or self._rust_is_explicit_target(qn_parts, mod_stem)
+        ):
+            # Cargo compiles src/bin/mod.rs (or an explicit target whose
+            # path ends in mod.rs) as a target named `mod` whose crate root
+            # is the file itself. The mod.rs spelling maps the module to its
+            # DIRECTORY qn, so that qn is the file root and `mod x;` inside
+            # it resolves beside it — exactly the file-root nesting
+            # (issue #1031).
+            return "file", qn_parts
         for i in range(len(dir_parts), -1, -1):
             if i >= 1:
                 name = dir_parts[i - 1]
@@ -1798,8 +1810,13 @@ class ImportProcessor:
             # declared submodules here (cargo-verified), with the entry
             # stem chosen by the declaring scan over the explicit stems.
             return False
-        if cs.MOD_RS in entries:
-            # The mod.rs spelling of a module directory.
+        if cs.MOD_RS in entries and not self._rust_is_auto_target_dir(
+            dir_parts, cs.MOD_RS[: -len(cs.EXT_RS)]
+        ):
+            # The mod.rs spelling of a module directory — except in a direct
+            # auto-target location, where mod.rs is itself a target named
+            # `mod` and must not stop its main.rs sibling from rooting the
+            # directory (issue #1031).
             return False
         if dir_parts and f"{dir_parts[-1]}{cs.EXT_RS}" in self._rust_dir_entries(
             self.repo_path.joinpath(*dir_parts[:-1])

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -1744,6 +1744,10 @@ class ImportProcessor:
         """
         qn_parts = module_qn.split(cs.SEPARATOR_DOT)[1:]
         if not qn_parts:
+            # A root-level explicit `path = "mod.rs"` target maps to the
+            # bare project qn; nothing else roots there (issue #1031).
+            if self._rust_is_mod_rs_target([]):
+                return "dir_file", []
             return None
         dir_parts, stem = qn_parts[:-1], qn_parts[-1]
         if (
@@ -1760,11 +1764,7 @@ class ImportProcessor:
                 # cargo-verified), so it attaches classically with
                 # itself as the definitive entry stem.
                 return "entry", qn_parts
-        mod_stem = cs.MOD_RS[: -len(cs.EXT_RS)]
-        if cs.MOD_RS in self._rust_dir_entries(self.repo_path.joinpath(*qn_parts)) and (
-            self._rust_is_auto_target_dir(qn_parts, mod_stem)
-            or self._rust_is_explicit_target(qn_parts, mod_stem)
-        ):
+        if self._rust_is_mod_rs_target(qn_parts):
             # Cargo compiles src/bin/mod.rs (or an explicit target whose
             # path ends in mod.rs) as a target named `mod` whose crate root
             # is the file itself. The mod.rs spelling maps the module to its
@@ -1781,9 +1781,23 @@ class ImportProcessor:
                     self.repo_path.joinpath(*parent)
                 ) and self._rust_is_auto_target_dir(parent, name):
                     return "file", dir_parts[:i]
+            if self._rust_is_mod_rs_target(dir_parts[:i]):
+                # A DESCENDANT module of a mod.rs-backed target (declared
+                # from src/bin/mod.rs) roots at that target's directory qn,
+                # exactly like the target itself (issue #1031).
+                return "dir_file", dir_parts[:i]
             if self._rust_is_crate_root_dir(dir_parts[:i]):
                 return "classic", dir_parts[:i]
         return None
+
+    def _rust_is_mod_rs_target(self, dir_parts: list[str]) -> bool:
+        mod_stem = cs.MOD_RS[: -len(cs.EXT_RS)]
+        return cs.MOD_RS in self._rust_dir_entries(
+            self.repo_path.joinpath(*dir_parts)
+        ) and (
+            self._rust_is_auto_target_dir(dir_parts, mod_stem)
+            or self._rust_is_explicit_target(dir_parts, mod_stem)
+        )
 
     def _rust_is_crate_root_dir(self, dir_parts: list[str]) -> bool:
         # A directory is a crate root only when it holds an entry file AND is
@@ -2276,15 +2290,7 @@ class ImportProcessor:
         beside the entry point, so route through _rust_attach.
         """
         parts = base_qn.split(cs.SEPARATOR_DOT)[1:]
-        mod_stem = cs.MOD_RS[: -len(cs.EXT_RS)]
-        if (
-            parts
-            and cs.MOD_RS in self._rust_dir_entries(self.repo_path.joinpath(*parts))
-            and (
-                self._rust_is_auto_target_dir(parts, mod_stem)
-                or self._rust_is_explicit_target(parts, mod_stem)
-            )
-        ):
+        if self._rust_is_mod_rs_target(parts):
             # The base qn IS a mod.rs-backed target (src/bin/mod.rs): its
             # self:: — and super:: chains landing on it — attach beside
             # mod.rs, never through a sibling entry stem like src/bin's

--- a/codebase_rag/tests/test_rust_bin_mod_rs_target.py
+++ b/codebase_rag/tests/test_rust_bin_mod_rs_target.py
@@ -1,0 +1,89 @@
+"""Cargo compiles src/bin/mod.rs (and explicit mod.rs-path targets) as a
+target named `mod` whose crate root is the file itself; its crate:: paths
+must resolve to the directory qn the mod.rs spelling maps to, never the
+phantom project root (issue #1031)."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.parsers.import_processor import ImportProcessor
+
+
+def _processor(repo: Path) -> ImportProcessor:
+    return ImportProcessor(
+        repo_path=repo,
+        project_name="proj",
+        ingestor=None,
+        function_registry=None,
+    )
+
+
+def _manifest(repo: Path, extra: str = "") -> None:
+    (repo / "Cargo.toml").write_text(
+        '[package]\nname = "rs_bin_mod"\nversion = "0.1.0"\nedition = "2021"\n' + extra
+    )
+
+
+BIN_MOD_SOURCE = """
+use crate::helper as h;
+
+pub const fn helper() -> u32 { 7 }
+
+fn main() { let _ = h(); }
+"""
+
+
+def test_src_bin_mod_rs_roots_its_own_crate(tmp_path: Path) -> None:
+    _manifest(tmp_path)
+    (tmp_path / "src" / "bin").mkdir(parents=True)
+    (tmp_path / "src" / "bin" / "mod.rs").write_text(BIN_MOD_SOURCE)
+    processor = _processor(tmp_path)
+    assert processor._rust_crate_root("proj.src.bin") == ("file", ["src", "bin"])
+
+
+def test_src_bin_mod_rs_crate_paths_resolve_to_the_directory_qn(
+    tmp_path: Path, mock_ingestor: MagicMock
+) -> None:
+    _manifest(tmp_path)
+    (tmp_path / "src" / "bin").mkdir(parents=True)
+    (tmp_path / "src" / "bin" / "mod.rs").write_text(BIN_MOD_SOURCE)
+    parsers, queries = load_parsers()
+    updater = GraphUpdater(
+        ingestor=mock_ingestor,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name="proj",
+    )
+    updater.run()
+    imports = updater.factory.import_processor.import_mapping.get("proj.src.bin", {})
+    assert imports.get("h") == "proj.src.bin.helper", imports
+
+
+def test_explicit_mod_rs_target_roots_its_own_crate(tmp_path: Path) -> None:
+    _manifest(tmp_path, '\n[[bin]]\nname = "tool"\npath = "src/tool/mod.rs"\n')
+    (tmp_path / "src" / "tool").mkdir(parents=True)
+    (tmp_path / "src" / "tool" / "mod.rs").write_text("fn main() {}\n")
+    processor = _processor(tmp_path)
+    assert processor._rust_crate_root("proj.src.tool") == ("file", ["src", "tool"])
+
+
+def test_mod_rs_sibling_does_not_unroot_src_bin_main(tmp_path: Path) -> None:
+    _manifest(tmp_path)
+    (tmp_path / "src" / "bin").mkdir(parents=True)
+    (tmp_path / "src" / "bin" / "main.rs").write_text("fn main() {}\n")
+    (tmp_path / "src" / "bin" / "mod.rs").write_text("fn main() {}\n")
+    processor = _processor(tmp_path)
+    assert processor._rust_is_crate_root_dir(["src", "bin"]) is True
+
+
+def test_ordinary_module_directory_mod_rs_stays_a_module(tmp_path: Path) -> None:
+    _manifest(tmp_path)
+    (tmp_path / "src" / "foo").mkdir(parents=True)
+    (tmp_path / "src" / "lib.rs").write_text("pub mod foo;\n")
+    (tmp_path / "src" / "foo" / "mod.rs").write_text("pub fn f() {}\n")
+    processor = _processor(tmp_path)
+    assert processor._rust_crate_root("proj.src.foo") == ("classic", ["src"])
+    assert processor._rust_is_crate_root_dir(["src", "foo"]) is False

--- a/codebase_rag/tests/test_rust_bin_mod_rs_target.py
+++ b/codebase_rag/tests/test_rust_bin_mod_rs_target.py
@@ -135,3 +135,46 @@ def test_self_paths_in_src_bin_mod_rs_resolve_to_the_directory_qn(
     updater.run()
     imports = updater.factory.import_processor.import_mapping.get("proj.src.bin", {})
     assert imports.get("sh") == "proj.src.bin.helper", imports
+
+
+def test_descendant_module_roots_at_the_mod_rs_target(
+    tmp_path: Path, mock_ingestor: MagicMock
+) -> None:
+    """A submodule declared from src/bin/mod.rs roots at the target's
+    directory qn, so its crate:: paths stay inside the mod crate."""
+    _manifest(tmp_path)
+    child = tmp_path / "src" / "bin" / "child"
+    child.mkdir(parents=True)
+    (tmp_path / "src" / "bin" / "mod.rs").write_text(
+        "mod child;\n\npub const fn helper() -> u32 { 7 }\n\nfn main() {}\n"
+    )
+    (child / "mod.rs").write_text(
+        "use crate::helper as h;\npub fn use_it() -> u32 { h() }\n"
+    )
+    processor = _processor(tmp_path)
+    assert processor._rust_crate_root("proj.src.bin.child") == (
+        "dir_file",
+        ["src", "bin"],
+    )
+    parsers, queries = load_parsers()
+    updater = GraphUpdater(
+        ingestor=mock_ingestor,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name="proj",
+    )
+    updater.run()
+    imports = updater.factory.import_processor.import_mapping.get(
+        "proj.src.bin.child", {}
+    )
+    assert imports.get("h") == "proj.src.bin.helper", imports
+
+
+def test_root_level_explicit_mod_rs_target_roots_the_project_qn(
+    tmp_path: Path,
+) -> None:
+    _manifest(tmp_path, '\n[[bin]]\nname = "tool"\npath = "mod.rs"\n')
+    (tmp_path / "mod.rs").write_text("fn main() {}\n")
+    processor = _processor(tmp_path)
+    assert processor._rust_crate_root("proj") == ("dir_file", [])

--- a/codebase_rag/tests/test_rust_bin_mod_rs_target.py
+++ b/codebase_rag/tests/test_rust_bin_mod_rs_target.py
@@ -40,7 +40,7 @@ def test_src_bin_mod_rs_roots_its_own_crate(tmp_path: Path) -> None:
     (tmp_path / "src" / "bin").mkdir(parents=True)
     (tmp_path / "src" / "bin" / "mod.rs").write_text(BIN_MOD_SOURCE)
     processor = _processor(tmp_path)
-    assert processor._rust_crate_root("proj.src.bin") == ("file", ["src", "bin"])
+    assert processor._rust_crate_root("proj.src.bin") == ("dir_file", ["src", "bin"])
 
 
 def test_src_bin_mod_rs_crate_paths_resolve_to_the_directory_qn(
@@ -67,7 +67,7 @@ def test_explicit_mod_rs_target_roots_its_own_crate(tmp_path: Path) -> None:
     (tmp_path / "src" / "tool").mkdir(parents=True)
     (tmp_path / "src" / "tool" / "mod.rs").write_text("fn main() {}\n")
     processor = _processor(tmp_path)
-    assert processor._rust_crate_root("proj.src.tool") == ("file", ["src", "tool"])
+    assert processor._rust_crate_root("proj.src.tool") == ("dir_file", ["src", "tool"])
 
 
 def test_mod_rs_sibling_does_not_unroot_src_bin_main(tmp_path: Path) -> None:
@@ -87,3 +87,51 @@ def test_ordinary_module_directory_mod_rs_stays_a_module(tmp_path: Path) -> None
     processor = _processor(tmp_path)
     assert processor._rust_crate_root("proj.src.foo") == ("classic", ["src"])
     assert processor._rust_is_crate_root_dir(["src", "foo"]) is False
+
+
+def test_mod_rs_root_redirects_read_mod_rs_not_a_dir_shadow(
+    tmp_path: Path, mock_ingestor: MagicMock
+) -> None:
+    """The root's declarations live in mod.rs: a #[path] redirect declared
+    there must steer crate:: paths, which a dir-unaware walk (looking for a
+    src/bin.rs entry) would never see."""
+    _manifest(tmp_path)
+    (tmp_path / "src" / "bin").mkdir(parents=True)
+    (tmp_path / "src" / "bin" / "mod.rs").write_text(
+        '#[path = "alt.rs"]\nmod sub;\nuse crate::sub::f as g;\nfn main() { g(); }\n'
+    )
+    (tmp_path / "src" / "bin" / "alt.rs").write_text("pub fn f() {}\n")
+    parsers, queries = load_parsers()
+    updater = GraphUpdater(
+        ingestor=mock_ingestor,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name="proj",
+    )
+    updater.run()
+    imports = updater.factory.import_processor.import_mapping.get("proj.src.bin", {})
+    assert imports.get("g") == "proj.src.bin.alt.f", imports
+
+
+def test_self_paths_in_src_bin_mod_rs_resolve_to_the_directory_qn(
+    tmp_path: Path, mock_ingestor: MagicMock
+) -> None:
+    _manifest(tmp_path)
+    (tmp_path / "src" / "bin").mkdir(parents=True)
+    (tmp_path / "src" / "bin" / "main.rs").write_text("fn main() {}\n")
+    (tmp_path / "src" / "bin" / "mod.rs").write_text(
+        "use self::helper as sh;\n\npub const fn helper() -> u32 { 7 }\n\n"
+        "fn main() { let _ = sh(); }\n"
+    )
+    parsers, queries = load_parsers()
+    updater = GraphUpdater(
+        ingestor=mock_ingestor,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name="proj",
+    )
+    updater.run()
+    imports = updater.factory.import_processor.import_mapping.get("proj.src.bin", {})
+    assert imports.get("sh") == "proj.src.bin.helper", imports

--- a/codebase_rag/tests/test_rust_bin_mod_rs_target.py
+++ b/codebase_rag/tests/test_rust_bin_mod_rs_target.py
@@ -234,3 +234,38 @@ def test_root_level_mod_rs_redirects_are_read(
     updater.run()
     imports = updater.factory.import_processor.import_mapping.get("proj", {})
     assert imports.get("g") == "proj.alt.f", imports
+
+
+def test_explicit_main_target_keeps_its_crate_beside_explicit_mod_target(
+    tmp_path: Path, mock_ingestor: MagicMock
+) -> None:
+    _manifest(
+        tmp_path,
+        '\n[[bin]]\nname = "tools"\npath = "src/tools/mod.rs"\n\n'
+        '[[bin]]\nname = "tools-main"\npath = "src/tools/main.rs"\n',
+    )
+    tools = tmp_path / "src" / "tools"
+    tools.mkdir(parents=True)
+    (tools / "mod.rs").write_text("fn main() {}\n")
+    (tools / "main.rs").write_text(
+        "use crate::own as o;\n\npub const fn own() -> u32 { 1 }\n\n"
+        "fn main() { let _ = o(); }\n"
+    )
+    processor = _processor(tmp_path)
+    assert processor._rust_crate_root("proj.src.tools.main") == (
+        "entry",
+        ["src", "tools", "main"],
+    )
+    parsers, queries = load_parsers()
+    updater = GraphUpdater(
+        ingestor=mock_ingestor,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name="proj",
+    )
+    updater.run()
+    imports = updater.factory.import_processor.import_mapping.get(
+        "proj.src.tools.main", {}
+    )
+    assert imports.get("o") == "proj.src.tools.main.own", imports

--- a/codebase_rag/tests/test_rust_bin_mod_rs_target.py
+++ b/codebase_rag/tests/test_rust_bin_mod_rs_target.py
@@ -178,3 +178,59 @@ def test_root_level_explicit_mod_rs_target_roots_the_project_qn(
     (tmp_path / "mod.rs").write_text("fn main() {}\n")
     processor = _processor(tmp_path)
     assert processor._rust_crate_root("proj") == ("dir_file", [])
+
+
+def test_src_bin_main_keeps_its_own_crate_beside_mod_rs(
+    tmp_path: Path, mock_ingestor: MagicMock
+) -> None:
+    """With both siblings, main.rs's crate:: items nest under its own qn."""
+    _manifest(tmp_path)
+    (tmp_path / "src" / "bin").mkdir(parents=True)
+    (tmp_path / "src" / "bin" / "mod.rs").write_text(
+        "pub const fn helper() -> u32 { 7 }\nfn main() {}\n"
+    )
+    (tmp_path / "src" / "bin" / "main.rs").write_text(
+        "use crate::own as o;\n\npub const fn own() -> u32 { 1 }\n\n"
+        "fn main() { let _ = o(); }\n"
+    )
+    processor = _processor(tmp_path)
+    assert processor._rust_crate_root("proj.src.bin.main") == (
+        "file",
+        ["src", "bin", "main"],
+    )
+    parsers, queries = load_parsers()
+    updater = GraphUpdater(
+        ingestor=mock_ingestor,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name="proj",
+    )
+    updater.run()
+    imports = updater.factory.import_processor.import_mapping.get(
+        "proj.src.bin.main", {}
+    )
+    assert imports.get("o") == "proj.src.bin.main.own", imports
+
+
+def test_root_level_mod_rs_redirects_are_read(
+    tmp_path: Path, mock_ingestor: MagicMock
+) -> None:
+    """#[path] redirects declared in a root-level mod.rs target steer its
+    crate:: paths."""
+    _manifest(tmp_path, '\n[[bin]]\nname = "tool"\npath = "mod.rs"\n')
+    (tmp_path / "mod.rs").write_text(
+        '#[path = "alt.rs"]\nmod sub;\nuse crate::sub::f as g;\nfn main() { g(); }\n'
+    )
+    (tmp_path / "alt.rs").write_text("pub fn f() {}\n")
+    parsers, queries = load_parsers()
+    updater = GraphUpdater(
+        ingestor=mock_ingestor,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        project_name="proj",
+    )
+    updater.run()
+    imports = updater.factory.import_processor.import_mapping.get("proj", {})
+    assert imports.get("g") == "proj.alt.f", imports


### PR DESCRIPTION
## Summary

- `_rust_crate_root` now recognises a module whose directory holds a mod.rs that is itself a cargo target — src/bin/mod.rs (a bin named `mod`, cargo-verified in the issue) or an explicit manifest target whose path ends in mod.rs — and roots it as a file crate at the directory qn the mod.rs spelling maps to, so its `crate::` paths resolve to itself instead of the phantom project root
- The `mod.rs` veto in `_rust_is_crate_root_dir` no longer fires in direct auto-target locations, where mod.rs is a target rather than the directory's module spelling — a main.rs sibling keeps rooting src/bin
- Ordinary module directories (src/foo/mod.rs declared from lib.rs) keep their classic-root resolution untouched

## Type of Change

- [x] Bug fix

## Related Issues

Closes #1031

## Test Plan

- [x] Five regressions, four RED without the fix: the issue's exact repro end-to-end (`use crate::helper as h` maps to the directory qn), the whitebox file-root classification, the explicit mod.rs-path target, the main.rs+mod.rs sibling case, and the ordinary-module negative control
- [x] 678-test `-k rust -n auto` sweep green

## Checklist

- [x] PR title follows Conventional Commits format
- [x] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [x] No new comments or docstrings beyond the existing style

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Rust project analysis for `mod.rs` crate roots in automatic and explicitly configured targets.
  * Preserved correct behavior when `mod.rs` appears alongside other crate roots, such as `main.rs`.
  * Improved crate-relative, self-relative, redirected module, and import path resolution.
  * Maintained expected handling for ordinary Rust module directories.

* **Tests**
  * Added coverage for root-level and nested `mod.rs` targets, sibling files, redirects, imports, and standard module directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->