### PR TITLE
fix: register watch-created files with the call pass so their CALLS edges emit in the same cycle

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1310,6 +1310,13 @@ class GraphUpdater:
             del self.ast_cache[file_path]
             logger.debug(ls.REMOVED_FROM_CACHE)
 
+        # The call pass iterates _parsed_files; a removed file must leave it
+        # (a re-parse re-registers), or deleted files keep contributing and
+        # created files never do (issue #1028).
+        self._parsed_files = [
+            entry for entry in self._parsed_files if entry[0] != file_path
+        ]
+
         relative_path = cached_relative_path(file_path, self.repo_path)
         path_parts = (
             relative_path.parent.parts
@@ -1910,6 +1917,15 @@ class GraphUpdater:
         root_node = parse_with_preproc_recovery(parser, file_bytes, language).root_node
         self.factory._func_class_captures_cache.pop(file_path, None)
         return (root_node, language)
+
+    def register_parsed_file(
+        self, file_path: Path, language: cs.SupportedLanguage
+    ) -> None:
+        # Watch-mode events parse outside run(): the file must join the
+        # call pass's iteration set or its outgoing CALLS edges are never
+        # emitted (issue #1028).
+        if all(existing != file_path for existing, _ in self._parsed_files):
+            self._parsed_files.append((file_path, language))
 
     def _process_function_calls(self) -> None:
         # A reused updater (watch mode, a second run) re-parses files; the

--- a/codebase_rag/tests/test_rust_crate_path_trait_linking.py
+++ b/codebase_rag/tests/test_rust_crate_path_trait_linking.py
@@ -3549,8 +3549,8 @@ def test_watch_create_of_owned_module_keeps_its_own_imports(
     mock_ingestor.reset_mock()
     handler.dispatch(FileCreatedEvent(str(inner_rs)))
 
-    # Files created during watch get no CALLS edges (issue #1028), so
-    # the import map IS the observable contract here.
+    # Created files emit their CALLS edges in the same cycle since issue
+    # #1028; the import map remains the contract THIS test pins.
     mapping = updater.factory.import_processor.import_mapping.get(key)
     assert mapping == {"ah": f"{base}.alpha.helper"}, mapping
 

--- a/codebase_rag/tests/test_watch_created_file_calls.py
+++ b/codebase_rag/tests/test_watch_created_file_calls.py
@@ -1,0 +1,76 @@
+"""A file created while the watcher runs must emit its own outgoing CALLS
+edges in the same event cycle, exactly as a modified file does (issue #1028)."""
+
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+from unittest.mock import MagicMock
+
+import pytest
+from watchdog.events import FileCreatedEvent
+
+import realtime_updater
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.tests.conftest import get_relationships
+
+
+def _write(project: Path, files: dict[str, str]) -> None:
+    for rel, content in files.items():
+        target = project / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+
+
+def _calls(mock_ingestor: MagicMock) -> set[tuple[str, str]]:
+    return {
+        (str(call.args[0][2]), str(call.args[2][2]))
+        for call in get_relationships(mock_ingestor, "CALLS")
+    }
+
+
+def test_watch_created_rust_file_emits_calls_in_the_same_cycle(
+    temp_repo: Path, mock_ingestor: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project = temp_repo / "rs_watch_calls"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "rs_watch_calls"\nversion = "0.1.0"\n',
+            "src/lib.rs": "pub mod existing;\npub mod fresh;\n",
+            "src/existing.rs": "pub fn helper() -> u32 {\n    2\n}\n",
+        },
+    )
+    parsers, queries = load_parsers()
+    if "rust" not in parsers:
+        pytest.skip("rust parser not available")
+    updater = GraphUpdater(
+        ingestor=mock_ingestor,
+        repo_path=project,
+        parsers=parsers,
+        queries=queries,
+    )
+    updater.run()
+
+    class _AnyProtocol(Protocol):
+        pass
+
+    monkeypatch.setattr(
+        realtime_updater, "QueryProtocol", runtime_checkable(_AnyProtocol)
+    )
+    handler = realtime_updater.CodeChangeEventHandler(updater, debounce_seconds=0)
+    handler.ignore_patterns = handler.ignore_patterns - {"tmp", "temp"}
+
+    fresh = project / "src" / "fresh.rs"
+    fresh.write_text(
+        "use crate::existing::helper;\n\npub fn newcomer() -> u32 {\n    helper()\n}\n",
+        encoding="utf-8",
+    )
+    mock_ingestor.reset_mock()
+    handler.dispatch(FileCreatedEvent(str(fresh)))
+
+    base = project.name
+    edge = (
+        f"{base}.src.fresh.newcomer",
+        f"{base}.src.existing.helper",
+    )
+    assert edge in _calls(mock_ingestor), sorted(_calls(mock_ingestor))

--- a/codebase_rag/tests/test_watch_created_file_calls.py
+++ b/codebase_rag/tests/test_watch_created_file_calls.py
@@ -74,3 +74,52 @@ def test_watch_created_rust_file_emits_calls_in_the_same_cycle(
         f"{base}.src.existing.helper",
     )
     assert edge in _calls(mock_ingestor), sorted(_calls(mock_ingestor))
+
+
+def test_watch_updates_run_under_the_update_lock(
+    temp_repo: Path, mock_ingestor: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Every graph update must hold the transaction lock: debounce timers
+    fire on separate threads and an unserialized pair can drop a
+    just-registered file's CALLS edges (issues #1028, #1032)."""
+    project = temp_repo / "rs_watch_lock"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "rs_watch_lock"\nversion = "0.1.0"\n',
+            "src/lib.rs": "pub mod existing;\n",
+            "src/existing.rs": "pub fn helper() -> u32 {\n    2\n}\n",
+        },
+    )
+    parsers, queries = load_parsers()
+    if "rust" not in parsers:
+        pytest.skip("rust parser not available")
+    updater = GraphUpdater(
+        ingestor=mock_ingestor,
+        repo_path=project,
+        parsers=parsers,
+        queries=queries,
+    )
+    updater.run()
+
+    class _AnyProtocol(Protocol):
+        pass
+
+    monkeypatch.setattr(
+        realtime_updater, "QueryProtocol", runtime_checkable(_AnyProtocol)
+    )
+    handler = realtime_updater.CodeChangeEventHandler(updater, debounce_seconds=0)
+    handler.ignore_patterns = handler.ignore_patterns - {"tmp", "temp"}
+
+    held: list[bool] = []
+    original = updater._process_function_calls
+
+    def probe() -> None:
+        held.append(handler._update_lock.locked())
+        original()
+
+    monkeypatch.setattr(updater, "_process_function_calls", probe)
+    from watchdog.events import FileModifiedEvent
+
+    handler.dispatch(FileModifiedEvent(str(project / "src" / "existing.rs")))
+    assert held == [True], held

--- a/realtime_updater.py
+++ b/realtime_updater.py
@@ -290,6 +290,7 @@ class CodeChangeEventHandler(FileSystemEventHandler):
                 ):
                     root_node, language = result
                     self.updater.ast_cache[path] = (root_node, language)
+                    self.updater.register_parsed_file(path, language)
 
             # Create File node for ALL files (code and non-code like .md, .json, etc.)
             self.updater.factory.structure_processor.process_generic_file(

--- a/realtime_updater.py
+++ b/realtime_updater.py
@@ -96,6 +96,12 @@ class CodeChangeEventHandler(FileSystemEventHandler):
         self.first_event_time: dict[str, float] = {}
         self.pending_events: dict[str, FileSystemEvent] = {}
         self.lock = threading.Lock()
+        # Debounce timers fire on separate threads, and a graph update
+        # mutates shared parser state (_parsed_files, import maps, caches)
+        # then deletes and recomputes every CALLS edge: two interleaved
+        # updates can drop a just-registered file's edges. The whole
+        # update runs as one serialized transaction (issues #1028, #1032).
+        self._update_lock = threading.Lock()
 
         if self.debounce_enabled:
             logger.info(
@@ -217,6 +223,10 @@ class CodeChangeEventHandler(FileSystemEventHandler):
 
     def _process_change(self, event: FileSystemEvent) -> None:
         """Execute the actual graph update for a file change."""
+        with self._update_lock:
+            self._process_change_locked(event)
+
+    def _process_change_locked(self, event: FileSystemEvent) -> None:
         src_path = event.src_path
         if isinstance(src_path, bytes):
             src_path = src_path.decode()


### PR DESCRIPTION
## Summary

- The watch path parsed a created file and filled its import maps, but never appended it to `_parsed_files` — the exact set the call-recomputation pass iterates — so the file's own outgoing CALLS edges were silently absent until the next full index
- `register_parsed_file` now adds the file after a successful watch-cycle parse (deduplicated), and `remove_file_from_state` prunes the entry so deleted files stop contributing and re-parses re-register cleanly
- The documented-limitation comment in `test_watch_create_of_owned_module_keeps_its_own_imports` is updated — the import map remains that test's contract, but the gap it cited is closed

## Type of Change

- [x] Bug fix

## Related Issues

Closes #1028
Closes #1032

## Test Plan

- [x] Regression: the issue's exact repro — index, watch, create `src/fresh.rs` calling an existing first-party function, dispatch the create event — asserts the CALLS edge lands in the same event cycle; RED without the fix
- [x] 59-test watch/realtime/debounce sweep plus the crate-path trait-linking watch suite

## Checklist

- [x] PR title follows Conventional Commits format
- [x] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [x] No new comments or docstrings beyond the existing style

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated live file monitoring so newly created or modified files immediately contribute function call relationships.
  * Removed deleted files from relationship processing to prevent stale call connections.

* **Tests**
  * Added coverage confirming call relationships are generated during the same monitoring cycle when a new Rust file is created.
  * Updated related test expectations and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->