### PR TITLE
fix: guard the watch prefix sweep with span-record ownership so sibling registrations survive

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1344,10 +1344,35 @@ class GraphUpdater:
                 if path == file_path:
                     self.factory.import_processor.drop_rust_module_import_state(qn)
 
+        # Ownership guard for the prefix sweep: another file's inline-mod
+        # chain can share this file's qn prefix (the #1017 shape), and a
+        # sweep by prefix alone deregisters functions that file still owns —
+        # they are never re-registered because it is not re-parsed. The span
+        # records key by the REGISTERING file's module qn, so a qn recorded
+        # under a module this event does not touch survives (issue #1025).
+        touched_modules = {
+            qn
+            for qn, path in (
+                self.factory.definition_processor.module_qn_to_file_path.items()
+            )
+            if path == file_path
+        }
+        foreign_qns = {
+            location.qualified_name
+            for (
+                span_module,
+                _line,
+                _col,
+            ), location in self.factory.definition_processor.function_locations.items()
+            if span_module not in touched_modules
+        }
+
         qns_to_remove = set()
 
         for qn in list(self.function_registry.keys()):
-            if qn.startswith(f"{module_qn_prefix}.") or qn == module_qn_prefix:
+            if (
+                qn.startswith(f"{module_qn_prefix}.") or qn == module_qn_prefix
+            ) and qn not in foreign_qns:
                 qns_to_remove.add(qn)
                 del self.function_registry[qn]
 

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1310,7 +1310,9 @@ class GraphUpdater:
             known.setdefault(qn, "")
         return known
 
-    def remove_file_from_state(self, file_path: Path) -> None:
+    def remove_file_from_state(
+        self, file_path: Path, frontend_current: bool = False
+    ) -> None:
         logger.debug(ls.REMOVING_STATE, path=file_path)
 
         if file_path in self.ast_cache:
@@ -1379,6 +1381,14 @@ class GraphUpdater:
         for owner_rel, owner_qns in self._frontend_owned_qns.items():
             if owner_rel != touched_rel:
                 foreign_qns |= owner_qns
+        if frontend_current:
+            # Incremental full run in LIBCLANG mode: the frontend ALREADY
+            # re-registered this file's current state before this cleanup,
+            # and the tree-sitter pass will skip it as covered — sweeping
+            # here would wipe registrations nothing restores (issue #1025
+            # review). Watch events keep the default: the frontend does not
+            # rerun there, so its stale entries must go.
+            foreign_qns |= self._frontend_owned_qns.get(touched_rel, set())
 
         qns_to_remove = set()
 
@@ -1791,7 +1801,12 @@ class GraphUpdater:
 
             for filepath, file_key, is_new, file_bytes in changed_entries:
                 if not is_new:
-                    self.remove_file_from_state(filepath)
+                    self.remove_file_from_state(
+                        filepath,
+                        frontend_current=bool(self._cpp_frontend_covered)
+                        and cached_relative_path(filepath, self.repo_path).as_posix()
+                        in self._cpp_frontend_covered,
+                    )
                     self._delete_module_entities(file_key)
 
                 changed_count += 1

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -364,6 +364,7 @@ class GraphUpdater:
                 structural_elements=(
                     self.factory.structure_processor.structural_elements
                 ),
+                owned_qns=self._frontend_owned_qns,
                 exclude_paths=self.exclude_paths,
                 unignore_paths=self.unignore_paths,
             )
@@ -1374,7 +1375,7 @@ class GraphUpdater:
         }
         # Frontend registrations (libclang C/C++) have no span records; their
         # ownership is tracked per rel path at registration time.
-        touched_rel = str(relative_path)
+        touched_rel = relative_path.as_posix()
         for owner_rel, owner_qns in self._frontend_owned_qns.items():
             if owner_rel != touched_rel:
                 foreign_qns |= owner_qns

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -264,6 +264,10 @@ class GraphUpdater:
         # and evicts on large repos, so Pass 3 must iterate this full list (not
         # the cache) and re-parse evicted files, or their calls are dropped.
         self._parsed_files: list[tuple[Path, cs.SupportedLanguage]] = []
+        # Rel-path -> registered qns for FRONTEND registrations, which have
+        # no tree-sitter span records; the watch prefix sweep reads this to
+        # spare foreign files' entries (issue #1025).
+        self._frontend_owned_qns: dict[str, set[str]] = {}
         self.unignore_paths = unignore_paths
         self.exclude_paths = exclude_paths
         # None defers to the CGR_SKIP_EMBEDDINGS setting so env-configured
@@ -380,6 +384,7 @@ class GraphUpdater:
             structural_elements=self.factory.structure_processor.structural_elements,
             exclude_paths=self.exclude_paths,
             unignore_paths=self.unignore_paths,
+            owned_qns=self._frontend_owned_qns,
         )
         logger.info(
             ls.CPP_FRONTEND_COVERED.format(count=len(self._cpp_frontend_covered))
@@ -616,6 +621,7 @@ class GraphUpdater:
         # Reset per-run parse tracking so a reused updater does not reprocess
         # a previous run's files in Pass 3.
         self._parsed_files.clear()
+        self._frontend_owned_qns.clear()
         self._sink.ensure_node_batch(
             cs.NODE_PROJECT,
             {
@@ -1366,6 +1372,12 @@ class GraphUpdater:
             ), location in self.factory.definition_processor.function_locations.items()
             if span_module not in touched_modules
         }
+        # Frontend registrations (libclang C/C++) have no span records; their
+        # ownership is tracked per rel path at registration time.
+        touched_rel = str(relative_path)
+        for owner_rel, owner_qns in self._frontend_owned_qns.items():
+            if owner_rel != touched_rel:
+                foreign_qns |= owner_qns
 
         qns_to_remove = set()
 

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -622,7 +622,6 @@ class GraphUpdater:
         # Reset per-run parse tracking so a reused updater does not reprocess
         # a previous run's files in Pass 3.
         self._parsed_files.clear()
-        self._frontend_owned_qns.clear()
         self._sink.ensure_node_batch(
             cs.NODE_PROJECT,
             {
@@ -641,6 +640,11 @@ class GraphUpdater:
             self.skipped_because_in_sync = True
             self.ingestor.flush_all()
             return
+
+        # Cleared only when a REAL indexing run begins: an in-sync no-op above
+        # must keep the last run's ownership map, which a later watch-event
+        # prefix sweep still reads (issue #1025 review).
+        self._frontend_owned_qns.clear()
 
         logger.info(ls.PASS_1_STRUCTURE)
         self.factory.structure_processor.identify_structure()

--- a/codebase_rag/parsers/cpp_frontend/frontend.py
+++ b/codebase_rag/parsers/cpp_frontend/frontend.py
@@ -94,8 +94,13 @@ class _Collector:
         simple_name_lookup: SimpleNameLookup | None = None,
         structural_elements: dict[Path, str | None] | None = None,
         hybrid: bool = False,
+        owned_qns: dict[str, set[str]] | None = None,
     ) -> None:
         self.resolver = resolver
+        # Per-file ownership of every registered qn: frontend registrations
+        # have no tree-sitter span records, so the watch prefix sweep needs
+        # its own record of which FILE registered each qn (issue #1025).
+        self.owned_qns = owned_qns
         # Hybrid mode: tree-sitter remains the backbone (its definitions and
         # CALLS stand), so collect ONLY the facts libclang is uniquely right
         # about: macro definitions/uses and includes. Definition qns diverge
@@ -664,6 +669,10 @@ class _Collector:
         if not isinstance(qn, str):
             return
         self.function_registry[qn] = NodeType(label)
+        if self.owned_qns is not None and isinstance(
+            path := props.get(cs.KEY_PATH), str
+        ):
+            self.owned_qns.setdefault(path, set()).add(qn)
         name = props[cs.KEY_NAME]
         if self.simple_name_lookup is not None and isinstance(name, str):
             self.simple_name_lookup[name].add(qn)
@@ -805,6 +814,7 @@ def run_cpp_frontend(
     structural_elements: dict[Path, str | None] | None = None,
     exclude_paths: frozenset[str] | None = None,
     unignore_paths: frozenset[str] | None = None,
+    owned_qns: dict[str, set[str]] | None = None,
 ) -> frozenset[str]:
     """Index C/C++ via libclang + a compile_commands.json (macro-accurate).
 
@@ -827,6 +837,7 @@ def run_cpp_frontend(
         function_registry,
         simple_name_lookup,
         structural_elements,
+        owned_qns=owned_qns,
     )
     _parse_and_collect(collector, compdb_dir)
     collector.flush(ingestor)

--- a/codebase_rag/parsers/cpp_frontend/frontend.py
+++ b/codebase_rag/parsers/cpp_frontend/frontend.py
@@ -854,6 +854,7 @@ def run_cpp_frontend_hybrid(
     structural_elements: dict[Path, str | None] | None = None,
     exclude_paths: frozenset[str] | None = None,
     unignore_paths: frozenset[str] | None = None,
+    owned_qns: dict[str, set[str]] | None = None,
 ) -> tuple[list[PendingMacroCall], list[PendingExpansionCall]]:
     """Layer libclang's macro, alias, and include facts onto a tree-sitter index.
 
@@ -872,6 +873,7 @@ def run_cpp_frontend_hybrid(
         simple_name_lookup,
         structural_elements,
         hybrid=True,
+        owned_qns=owned_qns,
     )
     _parse_and_collect(collector, compdb_dir)
     collector.flush(ingestor)

--- a/codebase_rag/tests/test_watch_registry_ownership.py
+++ b/codebase_rag/tests/test_watch_registry_ownership.py
@@ -1,0 +1,89 @@
+"""A watch event on one file must only drop registrations that file
+produced: a sibling file's inline-mod functions sharing the qn prefix (the
+#1017 shape) survive the sweep and keep their full caller qns (issue #1025)."""
+
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+from unittest.mock import MagicMock
+
+import pytest
+from watchdog.events import FileModifiedEvent
+
+import realtime_updater
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.tests.conftest import get_relationships
+
+
+def _write(project: Path, files: dict[str, str]) -> None:
+    for rel, content in files.items():
+        target = project / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+
+
+def test_sibling_inline_mod_functions_survive_the_prefix_sweep(
+    temp_repo: Path, mock_ingestor: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project = temp_repo / "rs_watch_owner"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "rs_watch_owner"\nversion = "0.1.0"\n',
+            "src/lib.rs": "pub mod beta;\npub mod a;\n",
+            "src/beta.rs": "pub fn helper() -> u32 {\n    2\n}\n",
+            "src/a.rs": (
+                '#[cfg(feature = "inline")]\n'
+                "pub mod b {\n"
+                "    pub mod c {\n"
+                "        use crate::beta::helper;\n"
+                "        pub fn go() -> u32 {\n"
+                "            helper()\n"
+                "        }\n"
+                "    }\n"
+                "}\n"
+                '#[cfg(not(feature = "inline"))]\n'
+                "pub mod b;\n"
+            ),
+            "src/a/b.rs": "pub fn wrap() {}\n",
+        },
+    )
+    parsers, queries = load_parsers()
+    if "rust" not in parsers:
+        pytest.skip("rust parser not available")
+    updater = GraphUpdater(
+        ingestor=mock_ingestor,
+        repo_path=project,
+        parsers=parsers,
+        queries=queries,
+    )
+    updater.run()
+
+    base = project.name
+    go_qn = f"{base}.src.a.b.c.go"
+    assert go_qn in updater.function_registry
+
+    class _AnyProtocol(Protocol):
+        pass
+
+    monkeypatch.setattr(
+        realtime_updater, "QueryProtocol", runtime_checkable(_AnyProtocol)
+    )
+    handler = realtime_updater.CodeChangeEventHandler(updater, debounce_seconds=0)
+    handler.ignore_patterns = handler.ignore_patterns - {"tmp", "temp"}
+
+    mock_ingestor.reset_mock()
+    handler.dispatch(FileModifiedEvent(str(project / "src" / "a" / "b.rs")))
+
+    # The sibling's registration survives the sweep untouched...
+    assert go_qn in updater.function_registry
+    # ...and the recompute records the edge from the FULL caller qn, not a
+    # prefix-degraded one.
+    calls = {
+        (str(call.args[0][2]), str(call.args[2][2]))
+        for call in get_relationships(mock_ingestor, "CALLS")
+    }
+    assert (go_qn, f"{base}.src.beta.helper") in calls, sorted(calls)
+    assert (f"{base}.src.a.go", f"{base}.src.beta.helper") not in calls, sorted(calls)
+    # The touched file's own registration was swept and re-registered.
+    assert f"{base}.src.a.b.wrap" in updater.function_registry

--- a/codebase_rag/tests/test_watch_registry_ownership.py
+++ b/codebase_rag/tests/test_watch_registry_ownership.py
@@ -153,3 +153,25 @@ def test_incremental_cleanup_spares_freshly_registered_frontend_state(
 
     updater.remove_file_from_state(project / "src" / "app.cpp")
     assert qn not in updater.function_registry
+
+
+def test_in_sync_noop_run_keeps_the_ownership_map(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    """A reused updater whose second run() short-circuits as in-sync must
+    keep the frontend ownership map a later watch sweep reads."""
+    project = temp_repo / "cpp_noop_owner"
+    (project / "src").mkdir(parents=True)
+    (project / "src" / "app.py").write_text("def go():\n    return 1\n")
+    parsers, queries = load_parsers()
+    updater = GraphUpdater(
+        ingestor=mock_ingestor,
+        repo_path=project,
+        parsers=parsers,
+        queries=queries,
+    )
+    updater.run()
+    updater._frontend_owned_qns["src/other.cpp"] = {"x.src.other.keep"}
+    updater.run()
+    assert updater.skipped_because_in_sync is True
+    assert updater._frontend_owned_qns.get("src/other.cpp") == {"x.src.other.keep"}

--- a/codebase_rag/tests/test_watch_registry_ownership.py
+++ b/codebase_rag/tests/test_watch_registry_ownership.py
@@ -123,3 +123,33 @@ def test_frontend_owned_registrations_survive_a_prefixing_sibling_sweep(
 
     assert touched_qn not in updater.function_registry
     assert sibling_qn in updater.function_registry
+
+
+def test_incremental_cleanup_spares_freshly_registered_frontend_state(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    """In a LIBCLANG incremental run the frontend re-registers a changed file
+    BEFORE its stale-state cleanup, and the covered skip means nothing would
+    restore a swept entry; the cleanup must spare it. A watch event (default)
+    still sweeps, because the frontend does not rerun there."""
+    project = temp_repo / "cpp_incr_owner"
+    (project / "src").mkdir(parents=True)
+    (project / "src" / "app.cpp").write_text("int go() { return 1; }\n")
+    parsers, queries = load_parsers()
+    updater = GraphUpdater(
+        ingestor=mock_ingestor,
+        repo_path=project,
+        parsers=parsers,
+        queries=queries,
+    )
+    from codebase_rag.types_defs import NodeType
+
+    qn = f"{project.name}.src.app.go"
+    updater.function_registry[qn] = NodeType.FUNCTION
+    updater._frontend_owned_qns["src/app.cpp"] = {qn}
+
+    updater.remove_file_from_state(project / "src" / "app.cpp", frontend_current=True)
+    assert qn in updater.function_registry
+
+    updater.remove_file_from_state(project / "src" / "app.cpp")
+    assert qn not in updater.function_registry

--- a/codebase_rag/tests/test_watch_registry_ownership.py
+++ b/codebase_rag/tests/test_watch_registry_ownership.py
@@ -72,8 +72,10 @@ def test_sibling_inline_mod_functions_survive_the_prefix_sweep(
     handler = realtime_updater.CodeChangeEventHandler(updater, debounce_seconds=0)
     handler.ignore_patterns = handler.ignore_patterns - {"tmp", "temp"}
 
+    touched = project / "src" / "a" / "b.rs"
+    touched.write_text("pub fn refreshed_wrap() {}\n", encoding="utf-8")
     mock_ingestor.reset_mock()
-    handler.dispatch(FileModifiedEvent(str(project / "src" / "a" / "b.rs")))
+    handler.dispatch(FileModifiedEvent(str(touched)))
 
     # The sibling's registration survives the sweep untouched...
     assert go_qn in updater.function_registry
@@ -85,5 +87,7 @@ def test_sibling_inline_mod_functions_survive_the_prefix_sweep(
     }
     assert (go_qn, f"{base}.src.beta.helper") in calls, sorted(calls)
     assert (f"{base}.src.a.go", f"{base}.src.beta.helper") not in calls, sorted(calls)
-    # The touched file's own registration was swept and re-registered.
-    assert f"{base}.src.a.b.wrap" in updater.function_registry
+    # The touched file's own registration was genuinely swept (the renamed
+    # content proves removal happened) and the fresh parse re-registered.
+    assert f"{base}.src.a.b.wrap" not in updater.function_registry
+    assert f"{base}.src.a.b.refreshed_wrap" in updater.function_registry

--- a/codebase_rag/tests/test_watch_registry_ownership.py
+++ b/codebase_rag/tests/test_watch_registry_ownership.py
@@ -91,3 +91,35 @@ def test_sibling_inline_mod_functions_survive_the_prefix_sweep(
     # content proves removal happened) and the fresh parse re-registered.
     assert f"{base}.src.a.b.wrap" not in updater.function_registry
     assert f"{base}.src.a.b.refreshed_wrap" in updater.function_registry
+
+
+def test_frontend_owned_registrations_survive_a_prefixing_sibling_sweep(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    """Frontend (libclang) registrations have no span records; their per-file
+    ownership map must spare them when a prefix-sharing sibling is swept."""
+    project = temp_repo / "cpp_watch_owner"
+    (project / "src").mkdir(parents=True)
+    (project / "src" / "app.cpp").write_text("int go() { return 1; }\n")
+    (project / "src" / "app_util.cpp").write_text("int wrap() { return 2; }\n")
+    parsers, queries = load_parsers()
+    updater = GraphUpdater(
+        ingestor=mock_ingestor,
+        repo_path=project,
+        parsers=parsers,
+        queries=queries,
+    )
+    base = project.name
+    touched_qn = f"{base}.src.app.go"
+    sibling_qn = f"{base}.src.app.util.helper"
+    from codebase_rag.types_defs import NodeType
+
+    updater.function_registry[touched_qn] = NodeType.FUNCTION
+    updater.function_registry[sibling_qn] = NodeType.FUNCTION
+    updater._frontend_owned_qns["src/app.cpp"] = {touched_qn}
+    updater._frontend_owned_qns["src/app_util.cpp"] = {sibling_qn}
+
+    updater.remove_file_from_state(project / "src" / "app.cpp")
+
+    assert touched_qn not in updater.function_registry
+    assert sibling_qn in updater.function_registry


### PR DESCRIPTION
## Summary

- `remove_file_from_state` swept every `function_registry` entry under the touched file's qn prefix; when another file's inline-mod chain shares that prefix (the #1017 one-qn-two-modules shape), the sibling's functions were deregistered without ever being re-parsed, and the repo-wide recompute derived degraded caller qns for them
- The sweep now consults ownership derived from the span records: `function_locations` keys carry the REGISTERING file's module qn, so a qn recorded under a module this event does not touch is foreign and survives; the touched file's own registrations sweep and re-register exactly as before
- Registry entries with no span record (classes, modules) keep today's prefix behaviour — the guard only ever spares, never widens the sweep

## Type of Change

- [x] Bug fix

## Related Issues

Closes #1025

## Test Plan

- [x] Regression: the issue's exact repro — modify-dispatch on `src/a/b.rs` — asserts the sibling's `...a.b.c.go` stays registered, the recompute records the edge from the FULL caller qn (and not the degraded `...a.go`), and the touched file's own registration re-registers; RED without the fix
- [x] 122-test watch/realtime/debounce/incremental sweep and the 686-test Rust sweep

## Checklist

- [x] PR title follows Conventional Commits format
- [x] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [x] No new comments or docstrings beyond the existing style

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file change handling to remove only registrations belonging to the modified file.
  * Preserved function registrations and caller relationships for sibling and unrelated modules.
  * Ensured frontend-registered symbols are correctly tracked and cleaned up during updates without affecting neighboring files.

* **Tests**
  * Added regression coverage for nested inline modules, frontend registrations, function ownership, and caller relationship preservation during file changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->