### PR TITLE
perf: keep the Rust declaration-scan attribute groups line-local and gather blocks by a linear walk

### DIFF
--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -57,7 +57,7 @@ _JS_SCHEME_RE = re.compile(r"^([a-zA-Z][a-zA-Z0-9.+-]*):")
 # commented-out declaration nor one hidden behind a string literal containing
 # a comment marker can flip the crate attribution.
 _RS_MOD_DECL_PATTERN = re.compile(
-    r"^[^\S\n]*(?:#\[[^\]\n]*\]\s*)*(?:pub\s*(?:\([^)]*\))?\s+)?"
+    r"^[^\S\n]*(?:#\[[^\]\n]*\][^\S\n]*)*(?:pub\s*(?:\([^)]*\))?\s+)?"
     r"mod\s+(?:r#)?([A-Za-z_][A-Za-z0-9_]*)\s*;",
     re.MULTILINE,
 )
@@ -72,17 +72,23 @@ _RS_MOD_DECL_PATTERN = re.compile(
 # Only the plain string form is read: a cfg_attr wrapper is conditional and
 # no single target speaks for it (issue #1035).
 _RS_MOD_REDIRECT_PATTERN = re.compile(
-    r"^[^\S\n]*((?:#\[[^\]\n]*\]\s*)*)"
+    r"^[^\S\n]*((?:#\[[^\]\n]*\][^\S\n]*)*)"
     r"(?:pub\s*(?:\([^)]*\))?\s+)?"
     r"mod\s+(?:r#)?([A-Za-z_][A-Za-z0-9_]*)\s*;",
     re.MULTILINE,
 )
+# One attribute-only line, for the linear back-walk that gathers the block
+# ABOVE a declaration. Keeping every attribute group line-local is what makes
+# a long unbroken attribute run scan linearly: with `\s*` crossing newlines,
+# every line of the run restarted a match attempt that consumed the rest of
+# the run before failing, which is quadratic in the run length (issue #1089).
+_RS_ATTRIBUTE_LINE_PATTERN = re.compile(r"^[^\S\n]*((?:#\[[^\]\n]*\][^\S\n]*)+)$")
 _RS_PATH_ATTRIBUTE_PATTERN = re.compile(r'#\[\s*path\s*=\s*"([^"\n]+)"\s*\]')
 # The opening of a path attribute, matched against the code the lexer has
 # already emitted, so the literal that follows can be kept verbatim.
 _RS_PATH_ATTRIBUTE_OPEN = re.compile(r"#\[\s*path\s*=\s*$")
 _RS_ITEM_DECL_PATTERN = re.compile(
-    r"^[^\S\n]*(?:#\[[^\]\n]*\]\s*)*(?:pub\s*(?:\([^)]*\))?\s+)?"
+    r"^[^\S\n]*(?:#\[[^\]\n]*\][^\S\n]*)*(?:pub\s*(?:\([^)]*\))?\s+)?"
     r'(?:(?:unsafe|async|const|extern\s+"[^"]*")\s+)*'
     r"(?:trait|struct|enum|fn|type|const|static|union|mod)"
     r"\s+(?:mut\s+)?(?:r#)?([A-Za-z_][A-Za-z0-9_]*)",
@@ -201,6 +207,25 @@ class RustEntryDecls(NamedTuple):
     redirects: dict[str, str]
 
 
+def _rs_preceding_attribute_lines(top_level: str, decl_start: int) -> str:
+    collected: list[str] = []
+    end = decl_start
+    while end > 0:
+        line_start = top_level.rfind("\n", 0, end - 1) + 1
+        line = top_level[line_start : end - 1]
+        if not line.strip():
+            # Whitespace between an attribute and its item is legal; keep
+            # walking, exactly as the old newline-crossing `\s*` matched.
+            end = line_start
+            continue
+        line_match = _RS_ATTRIBUTE_LINE_PATTERN.fullmatch(line)
+        if line_match is None:
+            break
+        collected.append(line_match.group(1))
+        end = line_start
+    return "".join(reversed(collected))
+
+
 def _rs_entry_decls_of(top_level: str) -> RustEntryDecls:
     # One name may be declared once per cfg (`#[cfg(unix)] mod platform;`
     # beside its windows twin), each redirected somewhere else. Exactly one
@@ -208,7 +233,12 @@ def _rs_entry_decls_of(top_level: str) -> RustEntryDecls:
     # are ambiguous and the name keeps no redirect at all.
     redirects: dict[str, str] = {}
     ambiguous: set[str] = set()
-    for attributes, name in _RS_MOD_REDIRECT_PATTERN.findall(top_level):
+    for decl in _RS_MOD_REDIRECT_PATTERN.finditer(top_level):
+        attributes, name = decl.group(1), decl.group(2)
+        # The pattern only sees SAME-LINE attributes now (line-local group,
+        # issue #1089); the block above the declaration is gathered by a
+        # linear walk over the preceding attribute-only lines.
+        attributes = _rs_preceding_attribute_lines(top_level, decl.start()) + attributes
         match = _RS_PATH_ATTRIBUTE_PATTERN.search(attributes)
         target = match.group(1) if match else None
         if name in redirects and redirects[name] != target:

--- a/codebase_rag/tests/test_rust_attr_run_scan_perf.py
+++ b/codebase_rag/tests/test_rust_attr_run_scan_perf.py
@@ -1,0 +1,59 @@
+"""The Rust declaration-scan patterns must stay linear on an unbroken run of
+attribute lines: the newline-crossing attribute group let every line of the
+run restart a match attempt that consumed the rest of the run (issue #1089)."""
+
+import time
+
+from codebase_rag.parsers.import_processor import (
+    _RS_ITEM_DECL_PATTERN,
+    _RS_MOD_DECL_PATTERN,
+    _RS_MOD_REDIRECT_PATTERN,
+    _rs_entry_decls_of,
+)
+
+
+def _attr_run(n: int) -> str:
+    return "#[allow(dead_code)]\n" * n
+
+
+def _scan_time(source: str) -> float:
+    start = time.perf_counter()
+    _RS_MOD_DECL_PATTERN.findall(source)
+    _RS_ITEM_DECL_PATTERN.findall(source)
+    list(_RS_MOD_REDIRECT_PATTERN.finditer(source))
+    return time.perf_counter() - start
+
+
+def test_unbroken_attribute_run_scans_linearly() -> None:
+    small = _scan_time(_attr_run(1000))
+    large = _scan_time(_attr_run(4000))
+    # Quadratic behaviour makes 4x the input ~16x the time; linear stays
+    # around 4x. The bound leaves generous headroom for loaded runners.
+    assert large < max(small * 10, 0.05), (small, large)
+    assert large < 2.0, large
+
+
+def test_attribute_block_above_declaration_still_redirects() -> None:
+    decls = _rs_entry_decls_of(
+        '#[allow(dead_code)]\n#[path = "alt.rs"]\n\npub mod sub;\n'
+    )
+    assert decls.redirects == {"sub": "alt.rs"}
+
+
+def test_same_line_attribute_still_redirects() -> None:
+    decls = _rs_entry_decls_of('#[path = "alt.rs"] mod sub;\n')
+    assert decls.redirects == {"sub": "alt.rs"}
+
+
+def test_cfg_twin_disagreement_stays_ambiguous() -> None:
+    decls = _rs_entry_decls_of(
+        '#[cfg(unix)]\n#[path = "unix.rs"]\nmod platform;\n'
+        '#[cfg(windows)]\n#[path = "windows.rs"]\nmod platform;\n'
+    )
+    assert "platform" not in decls.redirects
+
+
+def test_long_generated_attribute_run_before_item_still_matches() -> None:
+    source = _attr_run(300) + "pub mod tail;\n"
+    decls = _rs_entry_decls_of(source)
+    assert "tail" in decls.mods


### PR DESCRIPTION
## Summary

- The attribute group in all three Rust declaration patterns crossed newlines (`(?:#\[[^\]\n]*\]\s*)*`), so every line of an unbroken attribute run restarted a match attempt that consumed the rest of the run before failing — quadratic in the run length (the #1087 residual)
- The group is now line-local (`[^\S\n]*` instead of `\s*`): a declaration below an attribute block still anchors at its own line's `^`, and same-line attributes still match, so nothing changes in what matches
- The redirect scan, which needs the attribute BLOCK above a declaration for `#[path]`, gathers it with a linear backward walk over attribute-only lines that skips whitespace lines exactly as the old `\s*` did (blank lines between attributes and their item are legal Rust)
- Measured on a 4000-line unbroken attribute run: 11.53s → 0.007s

## Type of Change

- [x] Performance improvement

## Related Issues

Closes #1089

## Test Plan

- [x] Perf regression: the 1000→4000 scaling assertion is RED against the old patterns (which take ~11.5s on the large input) and green now
- [x] Behaviour pins: attribute-block-above redirects (with a blank line), same-line attribute redirects, cfg-twin disagreement staying ambiguous, and a 300-attribute generated run still matching its trailing item
- [x] 691-test `-k rust -n auto` sweep green

## Checklist

- [x] PR title follows Conventional Commits format
- [x] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [x] No new comments or docstrings beyond the existing style

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Rust declaration parsing for attributes spanning multiple lines.
  * Preserved module redirect detection across multiline and same-line attributes.
  * Prevented slowdowns when processing long runs of Rust attributes.
  * Improved handling of conflicting conditional module redirects.

* **Tests**
  * Added regression and performance coverage for Rust attribute and declaration scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->