### PR TITLE
ci: statically link OpenSSL when cryptography builds from source on Intel macOS

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -53,7 +53,18 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: Install dependencies
+        shell: bash
         run: |
+          # cryptography ships no Intel macOS wheels since v50, so uv compiles it from
+          # source on this leg. Statically link OpenSSL (as the official wheels do) so the
+          # extension does not resolve against whichever libssl.3.dylib PyInstaller happens
+          # to bundle — see issue #1143. The cache clean is required because uv's
+          # built-wheel cache is not keyed by these env vars.
+          if [ "${{ matrix.platform }}" = "darwin" ] && [ "${{ matrix.arch }}" = "amd64" ]; then
+            export OPENSSL_DIR="$(brew --prefix openssl@3)"
+            export OPENSSL_STATIC=1
+            uv cache clean cryptography
+          fi
           uv sync --extra treesitter-full
           uv add --dev pyinstaller
 


### PR DESCRIPTION
Closes #1143.

cryptography ships no Intel macOS wheels since v50, so on `macos-15-intel` uv compiles it from source; the Rust extension then links dynamically against Homebrew's OpenSSL 3.2+, while PyInstaller bundles the older OpenSSL 3.0 `libssl.3.dylib` from the setup-python toolchain under the same basename. At runtime the bundled libssl lacks `SSL_get0_group_name` and the binary dies on import ([failing run](https://github.com/vitali87/code-graph-rag/actions/runs/31339246275)).

Fix: on the darwin-amd64 leg only, export `OPENSSL_DIR=$(brew --prefix openssl@3)` and `OPENSSL_STATIC=1` before `uv sync`, matching how the official wheels are built, so `_rust.abi3.so` references no external libssl at all. `uv cache clean cryptography` forces the rebuild because uv's built-wheel cache is not keyed by these env vars. `shell: bash` is pinned since the step now uses bash syntax and Windows defaults to pwsh.

Validation: `workflow_dispatch` of Build Binaries on this branch — darwin-amd64 must pass the `--version` smoke step, other legs stay green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Intel macOS builds by configuring static OpenSSL linking during dependency installation.
  * Added cache cleanup to help prevent stale dependency issues during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->