### PR TITLE
feat: auto-refresh NEWS.md and README latest news on every release

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -90,25 +90,6 @@ jobs:
           echo "new=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "Bumping version from $CURRENT to $NEW_VERSION (type: ${{ steps.bump_type.outputs.type }})"
 
-      - name: Update pyproject.toml
-        if: steps.check_manual.outputs.skip == 'false'
-        run: |
-          sed -i 's/^version = ".*"/version = "${{ steps.bump_version.outputs.new }}"/' pyproject.toml
-
-      - name: Update server.json
-        if: steps.check_manual.outputs.skip == 'false'
-        run: |
-          sed -i 's/"version": "[^"]*"/"version": "${{ steps.bump_version.outputs.new }}"/g' server.json
-
-      - name: Commit version bump
-        if: steps.check_manual.outputs.skip == 'false'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add pyproject.toml server.json
-          git commit -m "chore: bump version to ${{ steps.bump_version.outputs.new }}"
-          git push
-
       - name: Decide whether this tag ships a release
         if: steps.check_manual.outputs.skip == 'false'
         id: decide
@@ -130,25 +111,17 @@ jobs:
           echo "release=$RELEASE" >> $GITHUB_OUTPUT
           echo "latest=$LATEST" >> $GITHUB_OUTPUT
 
-      - name: Create git tag
-        if: steps.check_manual.outputs.skip == 'false'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git tag "v${{ steps.bump_version.outputs.new }}"
-          if [ "${{ steps.decide.outputs.release }}" = "true" ]; then
-            git push origin "v${{ steps.bump_version.outputs.new }}"
-          else
-            git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "v${{ steps.bump_version.outputs.new }}"
-          fi
-
       - name: Generate release notes
         if: steps.decide.outputs.release == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # target_commitish lets the API build notes for a tag that does not
+          # exist yet, so the news can be folded into the commit that gets
+          # tagged below (issue #1146).
           gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
             -f tag_name="v${{ steps.bump_version.outputs.new }}" \
+            -f target_commitish="${GITHUB_SHA}" \
             -f previous_tag_name="${{ steps.decide.outputs.latest }}" \
             --jq .body > /tmp/notes.md
 
@@ -175,6 +148,82 @@ jobs:
             "${HIGHLIGHTS_API_URL}/v1/chat/completions" \
           | jq -er '.choices[0].message.content // empty' \
           | sed -e '/<think>/,/<\/think>/d' > /tmp/highlights.md
+
+      - name: Generate news bullets
+        if: steps.decide.outputs.release == 'true'
+        continue-on-error: true
+        env:
+          HIGHLIGHTS_API_URL: ${{ secrets.HIGHLIGHTS_API_URL }}
+          HIGHLIGHTS_API_TOKEN: ${{ secrets.HIGHLIGHTS_API_TOKEN }}
+          HIGHLIGHTS_RESOLVE: ${{ secrets.HIGHLIGHTS_RESOLVE }}
+        run: |
+          [ -n "$HIGHLIGHTS_API_URL" ] || exit 0
+          RESOLVE_ARGS=()
+          [ -n "$HIGHLIGHTS_RESOLVE" ] && RESOLVE_ARGS=(--resolve "$HIGHLIGHTS_RESOLVE")
+          sed -E 's| by @[^ ]+ in https://[^ ]+||' /tmp/notes.md > /tmp/titles.md
+          grep -E '^- \*\*' NEWS.md | head -8 > /tmp/known.md || true
+          jq -n --rawfile notes /tmp/titles.md --rawfile known /tmp/known.md \
+            '{model: "default", temperature: 0.3, max_tokens: 600, messages: [
+              {role: "user", content: ("Write news entries for a software project README: a markdown bullet list of at most 3 items, each line in exactly the format \"- **Theme**: sentence.\" with a short bold theme of one to four words followed by a colon and one plain-English sentence aimed at users. Only cover genuinely new user-facing capabilities grounded strictly in the pull request titles below; ignore fixes, refactors, CI and dependency changes; do not invent anything. Do not repeat or rephrase any of these existing entries:\n\n" + $known + "\nIf nothing qualifies, output nothing at all. Use British English. Never use em-dashes or en-dashes. Output only the bullet lines.\n\nPull request titles:\n\n" + $notes)}
+            ]}' > /tmp/newsreq.json
+          curl -sf --max-time 1500 "${RESOLVE_ARGS[@]}" \
+            -H "Authorization: Bearer ${HIGHLIGHTS_API_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d @/tmp/newsreq.json \
+            "${HIGHLIGHTS_API_URL}/v1/chat/completions" \
+          | jq -er '.choices[0].message.content // empty' \
+          | sed -e '/<think>/,/<\/think>/d' > /tmp/newsbullets.md
+
+      - name: Install uv
+        if: steps.decide.outputs.release == 'true'
+        uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Update NEWS.md and regenerate README
+        if: steps.decide.outputs.release == 'true'
+        continue-on-error: true
+        run: |
+          # A NEWS.md change without the README re-render would drift from the
+          # generate-README pre-commit hook, so revert both if the render fails.
+          python3 scripts/update_news.py /tmp/newsbullets.md
+          if ! git diff --quiet NEWS.md; then
+            if ! (uv sync --frozen && uv run --frozen python scripts/generate_readme.py); then
+              git checkout -- NEWS.md README.md
+            fi
+          fi
+
+      - name: Update pyproject.toml
+        if: steps.check_manual.outputs.skip == 'false'
+        run: |
+          sed -i 's/^version = ".*"/version = "${{ steps.bump_version.outputs.new }}"/' pyproject.toml
+
+      - name: Update server.json
+        if: steps.check_manual.outputs.skip == 'false'
+        run: |
+          sed -i 's/"version": "[^"]*"/"version": "${{ steps.bump_version.outputs.new }}"/g' server.json
+
+      - name: Commit version bump
+        if: steps.check_manual.outputs.skip == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml server.json NEWS.md README.md
+          git commit -m "chore: bump version to ${{ steps.bump_version.outputs.new }}"
+          git push
+
+      - name: Create git tag
+        if: steps.check_manual.outputs.skip == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git tag "v${{ steps.bump_version.outputs.new }}"
+          if [ "${{ steps.decide.outputs.release }}" = "true" ]; then
+            git push origin "v${{ steps.bump_version.outputs.new }}"
+          else
+            git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "v${{ steps.bump_version.outputs.new }}"
+          fi
 
       - name: Create release
         if: steps.decide.outputs.release == 'true'

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,9 @@
 
 Newest first. The top three entries are rendered into the README's "Latest News"
 section automatically by `scripts/generate_readme.py`, so edit them here rather
-than in the README.
+than in the README. The release workflow also prepends entries for each
+released feature via `scripts/update_news.py`; hand edits remain welcome
+between releases.
 
 - **Ruby Support**: Ruby joins the graph through a new pluggable ast-grep tier that adds a language from a single YAML pattern file, emitting `Module`, `Function`, and `Class` nodes plus import edges without a hand-written parser.
 - **Structural Search & Replace**: Find and rewrite code by AST pattern with ast-grep, exposed as agent tools so you can match and transform structure across the whole codebase instead of relying on text or regex.

--- a/codebase_rag/readme_sections.py
+++ b/codebase_rag/readme_sections.py
@@ -231,8 +231,10 @@ def format_dependencies(deps: list[str]) -> str:
 
 def format_latest_news(news_path: Path, limit: int = 3) -> str:
     # Render the top `limit` bullet entries from NEWS.md into the README's
-    # "Latest News" section. NEWS.md is the hand-curated source of truth
-    # (newest first); the generator only syncs it into the README.
+    # "Latest News" section. NEWS.md is the source of truth (newest first):
+    # the release workflow prepends entries via scripts/update_news.py and
+    # hand edits remain welcome between releases (issue #1146); the generator
+    # only syncs it into the README.
     try:
         content = news_path.read_text(encoding=ENCODING_UTF8)
     except OSError:

--- a/codebase_rag/tests/test_update_news.py
+++ b/codebase_rag/tests/test_update_news.py
@@ -67,6 +67,26 @@ class TestPrependNews:
         assert inserted == ["- **First Feature**: The very first entry."]
         assert updated.endswith("- **First Feature**: The very first entry.\n")
 
+    def test_duplicate_theme_within_one_fragment_inserted_once(self) -> None:
+        fragment = (
+            "- **Web Search**: The agent can now search the web.\n"
+            "- **web search**: The same theme phrased again.\n"
+        )
+        updated, inserted = prepend_news(NEWS, fragment)
+        assert inserted == ["- **Web Search**: The agent can now search the web."]
+        assert "phrased again" not in updated
+
+    def test_fragment_is_capped_at_three_entries(self) -> None:
+        fragment = (
+            "- **One**: first.\n"
+            "- **Two**: second.\n"
+            "- **Three**: third.\n"
+            "- **Four**: fourth.\n"
+        )
+        updated, inserted = prepend_news(NEWS, fragment)
+        assert len(inserted) == 3
+        assert "- **Four**" not in updated
+
     def test_mixed_fragment_inserts_only_fresh_themes(self) -> None:
         fragment = (
             "- **Web Search**: The agent can now search the web.\n"

--- a/codebase_rag/tests/test_update_news.py
+++ b/codebase_rag/tests/test_update_news.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from scripts.update_news import existing_themes, extract_bullets, prepend_news
+
+NEWS = """# Latest News
+
+Newest first. The top three entries are rendered into the README's "Latest News"
+section automatically by `scripts/generate_readme.py`, so edit them here rather
+than in the README.
+
+- **Ruby Support**: Ruby joins the graph through a new pluggable ast-grep tier.
+- **Data-Flow Tracing**: New `FLOWS_TO` taint edges follow values through assignments.
+"""
+
+
+class TestExtractBullets:
+    def test_keeps_only_wellformed_entries(self) -> None:
+        fragment = (
+            "## Highlights\n"
+            "- **Web Search**: The agent can now search the web.\n"
+            "* **Wrong Marker**: star bullets are not the NEWS format.\n"
+            "- **Empty Body**: \n"
+            "- plain bullet without a theme\n"
+        )
+        assert extract_bullets(fragment) == [
+            "- **Web Search**: The agent can now search the web."
+        ]
+
+    def test_empty_fragment_yields_nothing(self) -> None:
+        assert extract_bullets("") == []
+
+
+class TestExistingThemes:
+    def test_collects_casefolded_themes(self) -> None:
+        assert existing_themes(NEWS) == {"ruby support", "data-flow tracing"}
+
+
+class TestPrependNews:
+    def test_inserts_above_newest_entry_preserving_header(self) -> None:
+        fragment = "- **Web Search**: The agent can now search the web.\n"
+        updated, inserted = prepend_news(NEWS, fragment)
+        assert inserted == ["- **Web Search**: The agent can now search the web."]
+        bullet_lines = [
+            line for line in updated.splitlines() if line.startswith("- **")
+        ]
+        assert bullet_lines[0].startswith("- **Web Search**")
+        assert bullet_lines[1].startswith("- **Ruby Support**")
+        assert updated.startswith("# Latest News")
+
+    def test_duplicate_theme_is_dropped_case_insensitively(self) -> None:
+        fragment = "- **ruby support**: Ruby again, phrased differently.\n"
+        updated, inserted = prepend_news(NEWS, fragment)
+        assert inserted == []
+        assert updated == NEWS
+
+    def test_rerun_with_same_fragment_is_idempotent(self) -> None:
+        fragment = "- **Web Search**: The agent can now search the web.\n"
+        once, _ = prepend_news(NEWS, fragment)
+        twice, inserted = prepend_news(once, fragment)
+        assert inserted == []
+        assert twice == once
+
+    def test_news_without_entries_appends_after_header(self) -> None:
+        header_only = "# Latest News\n\nNothing yet.\n"
+        fragment = "- **First Feature**: The very first entry.\n"
+        updated, inserted = prepend_news(header_only, fragment)
+        assert inserted == ["- **First Feature**: The very first entry."]
+        assert updated.endswith("- **First Feature**: The very first entry.\n")
+
+    def test_mixed_fragment_inserts_only_fresh_themes(self) -> None:
+        fragment = (
+            "- **Web Search**: The agent can now search the web.\n"
+            "- **Data-Flow Tracing**: already covered by an older entry.\n"
+            "- **Static Binaries**: Intel macOS builds link OpenSSL statically.\n"
+        )
+        updated, inserted = prepend_news(NEWS, fragment)
+        assert inserted == [
+            "- **Web Search**: The agent can now search the web.",
+            "- **Static Binaries**: Intel macOS builds link OpenSSL statically.",
+        ]
+        assert "already covered" not in updated

--- a/scripts/update_news.py
+++ b/scripts/update_news.py
@@ -23,6 +23,8 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
 BULLET_PATTERN = re.compile(r"^- \*\*(?P<theme>[^*]+?)\*\*: \S.*$")
 
+MAX_ENTRIES = 3
+
 
 def extract_bullets(fragment: str) -> list[str]:
     """Return the well-formed news bullets contained in a markdown fragment."""
@@ -46,15 +48,24 @@ def prepend_news(news: str, fragment: str) -> tuple[str, list[str]]:
     """Insert fragment bullets with unseen themes above the newest NEWS entry.
 
     Returns the updated NEWS.md content and the bullets that were inserted.
-    Bullets whose theme already appears anywhere in NEWS.md are dropped, which
-    makes a rerun of the same release idempotent.
+    Bullets whose theme already appears anywhere in NEWS.md or earlier in the
+    same fragment are dropped, which makes a rerun of the same release
+    idempotent, and at most MAX_ENTRIES bullets are accepted per fragment so
+    an over-long AI response cannot flood the file.
     """
     themes = existing_themes(news)
-    fresh = [
-        bullet
-        for bullet in extract_bullets(fragment)
-        if BULLET_PATTERN.match(bullet).group("theme").casefold() not in themes  # type: ignore[union-attr]
-    ]
+    fresh: list[str] = []
+    for bullet in extract_bullets(fragment):
+        match = BULLET_PATTERN.match(bullet)
+        if match is None:
+            continue
+        theme = match.group("theme").casefold()
+        if theme in themes:
+            continue
+        fresh.append(bullet)
+        themes.add(theme)
+        if len(fresh) == MAX_ENTRIES:
+            break
     if not fresh:
         return news, []
 

--- a/scripts/update_news.py
+++ b/scripts/update_news.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Prepend release news bullets to NEWS.md.
+
+Reads a markdown fragment (the AI-generated bullets for the release being cut)
+and inserts every bullet whose bold theme is not already present in NEWS.md
+above the existing entries, keeping the hand-written header intact. Bullets
+must match the NEWS.md entry format exactly: `- **Theme**: sentence`. Anything
+else in the fragment is ignored, so a malformed or empty AI response degrades
+to a no-op instead of corrupting the file. Exit code 0 always signals NEWS.md
+is in a valid state; the caller decides whether a no-op warrants skipping the
+follow-up README regeneration. Standard library only, so the release workflow
+can run it before the project environment is synced (issue #1146).
+"""
+
+# ruff: noqa: T201
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+BULLET_PATTERN = re.compile(r"^- \*\*(?P<theme>[^*]+?)\*\*: \S.*$")
+
+
+def extract_bullets(fragment: str) -> list[str]:
+    """Return the well-formed news bullets contained in a markdown fragment."""
+    return [
+        line.rstrip()
+        for line in fragment.splitlines()
+        if BULLET_PATTERN.match(line.rstrip())
+    ]
+
+
+def existing_themes(news: str) -> set[str]:
+    """Return the casefolded bold themes of every entry already in NEWS.md."""
+    return {
+        match.group("theme").casefold()
+        for line in news.splitlines()
+        if (match := BULLET_PATTERN.match(line.strip()))
+    }
+
+
+def prepend_news(news: str, fragment: str) -> tuple[str, list[str]]:
+    """Insert fragment bullets with unseen themes above the newest NEWS entry.
+
+    Returns the updated NEWS.md content and the bullets that were inserted.
+    Bullets whose theme already appears anywhere in NEWS.md are dropped, which
+    makes a rerun of the same release idempotent.
+    """
+    themes = existing_themes(news)
+    fresh = [
+        bullet
+        for bullet in extract_bullets(fragment)
+        if BULLET_PATTERN.match(bullet).group("theme").casefold() not in themes  # type: ignore[union-attr]
+    ]
+    if not fresh:
+        return news, []
+
+    lines = news.splitlines(keepends=True)
+    insert_at = len(lines)
+    for index, line in enumerate(lines):
+        if BULLET_PATTERN.match(line.strip()):
+            insert_at = index
+            break
+
+    if not news.endswith("\n"):
+        lines.append("\n")
+    updated = (
+        lines[:insert_at] + [f"{bullet}\n" for bullet in fresh] + lines[insert_at:]
+    )
+    return "".join(updated), fresh
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: update_news.py <bullets-file>", file=sys.stderr)
+        return 2
+
+    fragment_path = Path(sys.argv[1])
+    if not fragment_path.is_file():
+        print(f"no bullets file at {fragment_path}, nothing to do")
+        return 0
+
+    news_path = PROJECT_ROOT / "NEWS.md"
+    news = news_path.read_text(encoding="utf-8")
+    updated, inserted = prepend_news(news, fragment_path.read_text(encoding="utf-8"))
+    if not inserted:
+        print("no new themes to add, NEWS.md unchanged")
+        return 0
+
+    news_path.write_text(updated, encoding="utf-8")
+    for bullet in inserted:
+        print(f"added: {bullet}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #1146.

The every-50-tag release automation already AI-generates a `## Highlights` section from PR titles, but `NEWS.md` — rendered into the README's `Latest News 🔥` section by `scripts/generate_readme.py` — was only updated by hand, so releases shipped while the README news went stale.

This wires news maintenance into the same release path of `version-bump.yml`:

- **Release decision moves before the bump commit**, so the news lands in the very commit that gets tagged and released — no follow-up push, no workflow retrigger. `generate-notes` gains `target_commitish`, which lets the API build notes for a tag that does not exist yet.
- **A second AI call** (same endpoint and secrets as Highlights, `continue-on-error`) writes at most 3 bullets in the exact `- **Theme**: sentence` NEWS format, grounded strictly in PR titles, told to skip themes already present in NEWS.md and to output nothing for a fixes-only span.
- **`scripts/update_news.py`** (stdlib only, unit-tested) prepends only well-formed bullets with unseen themes — a malformed or empty AI response degrades to a no-op, and reruns are idempotent.
- **`scripts/generate_readme.py` re-renders the README section**; if the render fails, both files are reverted so NEWS.md and the README never drift from the generate-README pre-commit hook.
- NEWS.md's header and the `format_latest_news` comment are updated to describe the new contract: automation prepends at releases, hand edits remain welcome between them.

Tests: `codebase_rag/tests/test_update_news.py` — 8 cases covering extraction, casefolded dedupe, idempotent reruns, header preservation, and empty-file behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release automation now adds new feature highlights to release news before publishing.
  * Duplicate themes are filtered, updates are limited to three entries, and repeated updates remain safe.
* **Documentation**
  * The README is regenerated from the latest news content during releases.
  * Release guidance explains automated news updates while preserving support for manual edits.
* **Bug Fixes**
  * Improved handling of empty, malformed, or missing news input during release preparation.
  * Release files and documentation are finalized before tagging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->