### PR TITLE
ci: build binaries on build-input PRs and weekly schedule

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -4,6 +4,19 @@ on:
   push:
     tags:
       - "v*"
+  # Binaries are otherwise first exercised on a release tag, where a failure
+  # ships a broken release (issue #1145). Build them pre-merge on any PR that
+  # touches a build input, and weekly to surface upstream drift (dropped
+  # wheels, resolver changes) that arrives without any repo commit.
+  pull_request:
+    paths:
+      - ".github/workflows/build-binaries.yml"
+      - "build_binary.py"
+      - "**.spec"
+      - "pyproject.toml"
+      - "uv.lock"
+  schedule:
+    - cron: "17 5 * * 1"
   workflow_dispatch:
   release:
     types: [created]

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -12,6 +12,8 @@ on:
     paths:
       - ".github/workflows/build-binaries.yml"
       - "build_binary.py"
+      - "main.py"
+      - "codebase_rag/constants/build.py"
       - "**.spec"
       - "pyproject.toml"
       - "uv.lock"


### PR DESCRIPTION
Closes #1145.

Binaries were only ever built on the every-50th release tag, so the first PyInstaller bundle exercised was the public release itself — which is how #1143 shipped v0.0.584 with a broken darwin-amd64 leg, and how v0.0.187/v0.0.209/v0.0.245 failed before it. Two new triggers shrink the detection window:

- **`pull_request` filtered to build inputs** (`build-binaries.yml`, `build_binary.py`, `*.spec`, `pyproject.toml`, `uv.lock`): any repo change that can affect the bundle must pass all four legs' `--version` smoke test before merge. Dependency changes arrive as `uv.lock` edits, so they are covered.
- **Weekly `schedule` (Mon 05:17 UTC)** building the default branch: upstream drift such as cryptography 50 dropping Intel macOS wheels arrives via the resolver with no repo commit, and only a scheduled build can catch it before the next release does.

The release upload and signing jobs stay gated on `refs/tags/v`, so PR and scheduled runs only build, smoke-test, and store workflow artifacts. No test-suite change: the change is workflow triggers only; the `--version` smoke step that already caught #1143 is the detector, now running at two extra moments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Binary builds now run automatically for qualifying pull requests.
  * Added a weekly scheduled binary build.
  * Existing tag, manual, and release-based build triggers remain supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->