### PR TITLE
ci: ship security patches out-of-cadence with a mandatory release disclaimer

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -97,8 +97,26 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           LATEST=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name 2>/dev/null || echo "")
+          # A security patch must ship immediately rather than waiting for the
+          # RELEASE_EVERY cadence (issue #1149). The triggering commit counts as
+          # a security fix when its message carries a GHSA id (advisory-fork
+          # merges do), an explicit [security] marker, or an associated pull
+          # request labelled "security".
+          MESSAGE=$(git log -1 --pretty=%B)
+          SECURITY=false
+          case "$MESSAGE" in
+            *GHSA-*|*'[security]'*) SECURITY=true ;;
+          esac
+          if [ "$SECURITY" != "true" ] && gh api \
+              "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
+              --jq '.[].labels[].name' 2>/dev/null | grep -qx security; then
+            SECURITY=true
+          fi
+          GHSA=$(printf '%s' "$MESSAGE" | grep -oiE 'GHSA(-[0-9a-z]{4}){3}' | head -1 || true)
           RELEASE=false
-          if [ -n "$LATEST" ]; then
+          if [ "$SECURITY" = "true" ]; then
+            RELEASE=true
+          elif [ -n "$LATEST" ]; then
             TAGS_SINCE=$(git ls-remote --tags origin "refs/tags/v*" \
               | awk -F'refs/tags/' '{print $2}' \
               | grep -v '\^{}' \
@@ -110,6 +128,8 @@ jobs:
           fi
           echo "release=$RELEASE" >> $GITHUB_OUTPUT
           echo "latest=$LATEST" >> $GITHUB_OUTPUT
+          echo "security=$SECURITY" >> $GITHUB_OUTPUT
+          echo "ghsa=$GHSA" >> $GITHUB_OUTPUT
 
       - name: Generate release notes
         if: steps.decide.outputs.release == 'true'
@@ -124,6 +144,39 @@ jobs:
             -f target_commitish="${GITHUB_SHA}" \
             -f previous_tag_name="${{ steps.decide.outputs.latest }}" \
             --jq .body > /tmp/notes.md
+
+      - name: Prepend security notice
+        if: steps.decide.outputs.release == 'true' && steps.decide.outputs.security == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # A security release must never ship silent notes: always prepend a
+          # 🔒 Security section, enriched from the advisory when it is already
+          # published, else a pointer to it. Guarantees the disclaimer even if
+          # the advisory is published after the release is cut (issue #1149).
+          GHSA="${{ steps.decide.outputs.ghsa }}"
+          DETAIL=""
+          if [ -n "$GHSA" ]; then
+            DETAIL=$(gh api "repos/${GITHUB_REPOSITORY}/security-advisories/${GHSA}" \
+              --jq '"\(.summary) (\(.severity) severity, CVSS \(.cvss.score // "n/a")) — advisory [\(.ghsa_id)](https://github.com/'"${GITHUB_REPOSITORY}"'/security/advisories/\(.ghsa_id))\(if .cve_id then " / " + .cve_id else "" end)."' \
+              2>/dev/null || true)
+          fi
+          {
+            echo "## 🔒 Security"
+            echo
+            if [ -n "$DETAIL" ]; then
+              echo "$DETAIL"
+            elif [ -n "$GHSA" ]; then
+              echo "This release contains a security fix — see advisory [$GHSA](https://github.com/${GITHUB_REPOSITORY}/security/advisories/$GHSA)."
+            else
+              echo "This release contains a security fix — see the [Security Advisories](https://github.com/${GITHUB_REPOSITORY}/security/advisories) page."
+            fi
+            echo
+            echo "**Upgrading is strongly recommended.**"
+            echo
+            cat /tmp/notes.md
+          } > /tmp/notes.sec.md
+          mv /tmp/notes.sec.md /tmp/notes.md
 
       - name: Generate highlights
         if: steps.decide.outputs.release == 'true'

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -103,16 +103,19 @@ jobs:
           # merges do), an explicit [security] marker, or an associated pull
           # request labelled "security".
           MESSAGE=$(git log -1 --pretty=%B)
+          GHSA=$(printf '%s' "$MESSAGE" | grep -oiE 'GHSA(-[0-9a-z]{4}){3}' | head -1 || true)
           SECURITY=false
           case "$MESSAGE" in
-            *GHSA-*|*'[security]'*) SECURITY=true ;;
+            *'[security]'*) SECURITY=true ;;
           esac
+          if [ -n "$GHSA" ]; then
+            SECURITY=true
+          fi
           if [ "$SECURITY" != "true" ] && gh api \
               "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
               --jq '.[].labels[].name' 2>/dev/null | grep -qx security; then
             SECURITY=true
           fi
-          GHSA=$(printf '%s' "$MESSAGE" | grep -oiE 'GHSA(-[0-9a-z]{4}){3}' | head -1 || true)
           RELEASE=false
           if [ "$SECURITY" = "true" ]; then
             RELEASE=true
@@ -174,9 +177,7 @@ jobs:
             echo
             echo "**Upgrading is strongly recommended.**"
             echo
-            cat /tmp/notes.md
-          } > /tmp/notes.sec.md
-          mv /tmp/notes.sec.md /tmp/notes.md
+          } > /tmp/security.md
 
       - name: Generate highlights
         if: steps.decide.outputs.release == 'true'
@@ -284,10 +285,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="v${{ steps.bump_version.outputs.new }}"
-          if [ -s /tmp/highlights.md ]; then
-            cat /tmp/highlights.md /tmp/notes.md > /tmp/body.md
-          else
-            cp /tmp/notes.md /tmp/body.md
-          fi
+          : > /tmp/body.md
+          # The 🔒 Security disclaimer must lead the release body, above the
+          # AI highlights and the generated changelog (issue #1149).
+          [ -s /tmp/security.md ] && cat /tmp/security.md >> /tmp/body.md
+          [ -s /tmp/highlights.md ] && cat /tmp/highlights.md >> /tmp/body.md
+          cat /tmp/notes.md >> /tmp/body.md
           gh release create "$TAG" --title "$TAG" --notes-file /tmp/body.md --verify-tag \
             || gh release edit "$TAG" --notes-file /tmp/body.md


### PR DESCRIPTION
Closes #1149.

Two gaps this incident (GHSA-85gg) exposed, both fixed in `version-bump.yml`:

**1. Security fixes waited for the 50-tag cadence.** `decide` now flags the triggering commit as a security fix when its message carries a GHSA id (advisory-fork merges do), an explicit `[security]` marker, or an associated PR labelled `security` — and forces `release=true` regardless of the `RELEASE_EVERY` counter. Because release tags are pushed over the deploy key, this automatically fans out to PyPI publish **and** the signed binary release, so a security patch reaches every channel immediately instead of up to ~50 tags later.

**2. A security release could ship silent notes.** A new `Prepend security notice` step always injects a `## 🔒 Security` section into the release body for a security release — enriched from the advisory (summary, severity, CVSS, GHSA/CVE links) when it is already published, with graceful fallbacks to an advisory link or the advisories page when it is not. Upgrading-strongly-recommended line always present.

Detection is dual-path so it covers both normal labelled PRs and coordinated-disclosure merges from the temporary advisory fork (which have no main-repo PR but do carry the GHSA id in the merge message).

Manual override: put `[security]` in a commit message to force an out-of-cadence, disclaimer-bearing release for anything the automatic detection would miss.

No test-suite change — workflow-trigger/notes logic only; YAML validated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Security-related releases can now be issued outside the standard release cadence.
  * Release notes prominently identify security releases and include the relevant advisory identifier or advisory link when available.
  * Security notices are placed at the beginning of release notes so important security information is immediately visible.
  * Security release detection supports security advisories, security labels, and explicit security markers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->