### PR TITLE
docs: announce release automation in latest news

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@ than in the README. The release workflow also prepends entries for each
 released feature via `scripts/update_news.py`; hand edits remain welcome
 between releases.
 
+- **Release Automation**: `NEWS.md` and the README's "Latest News" section now refresh automatically on every release, and security patches ship out-of-cadence with a mandatory disclaimer in the release notes instead of waiting for the tag cycle.
 - **Ruby Support**: Ruby joins the graph through a new pluggable ast-grep tier that adds a language from a single YAML pattern file, emitting `Module`, `Function`, and `Class` nodes plus import edges without a hand-written parser.
 - **Structural Search & Replace**: Find and rewrite code by AST pattern with ast-grep, exposed as agent tools so you can match and transform structure across the whole codebase instead of relying on text or regex.
 - **Data-Flow Tracing**: New `FLOWS_TO` taint edges follow values through assignments, function calls, and I/O sinks, with coverage across C#, Java, C, and Go.

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@ than in the README. The release workflow also prepends entries for each
 released feature via `scripts/update_news.py`; hand edits remain welcome
 between releases.
 
-- **Release Automation**: `NEWS.md` and the README's "Latest News" section now refresh automatically on every release, and security patches ship out-of-cadence with a mandatory disclaimer in the release notes instead of waiting for the tag cycle.
+- **Release Automation**: `NEWS.md` and the README's "Latest News" section now refresh automatically on every release, keeping the changelog current without hand edits.
 - **Ruby Support**: Ruby joins the graph through a new pluggable ast-grep tier that adds a language from a single YAML pattern file, emitting `Module`, `Function`, and `Class` nodes plus import edges without a hand-written parser.
 - **Structural Search & Replace**: Find and rewrite code by AST pattern with ast-grep, exposed as agent tools so you can match and transform structure across the whole codebase instead of relying on text or regex.
 - **Data-Flow Tracing**: New `FLOWS_TO` taint edges follow values through assignments, function calls, and I/O sinks, with coverage across C#, Java, C, and Go.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Code-Graph-RAG parses a multi-language codebase with Tree-sitter, builds a knowl
 ## Latest News 🔥
 
 <!-- SECTION:latest_news -->
-- **Release Automation**: `NEWS.md` and the README's "Latest News" section now refresh automatically on every release, and security patches ship out-of-cadence with a mandatory disclaimer in the release notes instead of waiting for the tag cycle.
+- **Release Automation**: `NEWS.md` and the README's "Latest News" section now refresh automatically on every release, keeping the changelog current without hand edits.
 - **Ruby Support**: Ruby joins the graph through a new pluggable ast-grep tier that adds a language from a single YAML pattern file, emitting `Module`, `Function`, and `Class` nodes plus import edges without a hand-written parser.
 - **Structural Search & Replace**: Find and rewrite code by AST pattern with ast-grep, exposed as agent tools so you can match and transform structure across the whole codebase instead of relying on text or regex.
 <!-- /SECTION:latest_news -->

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ Code-Graph-RAG parses a multi-language codebase with Tree-sitter, builds a knowl
 ## Latest News 🔥
 
 <!-- SECTION:latest_news -->
+- **Release Automation**: `NEWS.md` and the README's "Latest News" section now refresh automatically on every release, and security patches ship out-of-cadence with a mandatory disclaimer in the release notes instead of waiting for the tag cycle.
 - **Ruby Support**: Ruby joins the graph through a new pluggable ast-grep tier that adds a language from a single YAML pattern file, emitting `Module`, `Function`, and `Class` nodes plus import edges without a hand-written parser.
 - **Structural Search & Replace**: Find and rewrite code by AST pattern with ast-grep, exposed as agent tools so you can match and transform structure across the whole codebase instead of relying on text or regex.
-- **Data-Flow Tracing**: New `FLOWS_TO` taint edges follow values through assignments, function calls, and I/O sinks, with coverage across C#, Java, C, and Go.
 <!-- /SECTION:latest_news -->
 
 See [NEWS.md](NEWS.md) for the full history.


### PR DESCRIPTION
The news-refresh automation (PR #1146/#1147) shipped but never announced itself — the only release since then was the manually-dispatched v0.0.589 security release, which ran the pre-automation workflow path. Per the NEWS.md contract, hand edits between releases are welcome, so this adds the entry directly and regenerates the README.

- Prepends a **Release Automation** bullet to NEWS.md (newest-first).
- Regenerates README's "Latest News" section via `scripts/generate_readme.py`.

The theme-dedup in `update_news.py` will keep a future automated release from double-inserting this entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added release news explaining that release documentation updates automatically when new versions are published.
  * Updated the README’s “Latest News” section to highlight automated release updates, Ruby support through the pluggable AST-grep tier, and structural search and replace.
  * Retained guidance that security patches may be released outside the regular schedule and include a required disclaimer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->