### PR TITLE
fix(realtime): delete files by absolute path

### DIFF
--- a/codebase_rag/tests/test_realtime_event_filtering.py
+++ b/codebase_rag/tests/test_realtime_event_filtering.py
@@ -132,7 +132,7 @@ class TestNonCodeFileHandling:
         ]
         assert len(delete_file_calls) == 1
         assert delete_file_calls[0].args[1] == {
-            cs.KEY_PATH: "notes.md",
+            cs.KEY_PATH: f.resolve().as_posix(),
         }
         mock_updater.factory.structure_processor.process_generic_file.assert_not_called()
 
@@ -199,7 +199,7 @@ class TestCypherDeleteFileQuery:
             if c.args[0] == cs.CYPHER_DELETE_FILE
         ]
         assert len(delete_file_calls) == 1
-        assert delete_file_calls[0].args[1] == {cs.KEY_PATH: "remove.py"}
+        assert delete_file_calls[0].args[1] == {cs.KEY_PATH: f2.resolve().as_posix()}
 
         delete_module_calls = [
             c

--- a/realtime_updater.py
+++ b/realtime_updater.py
@@ -266,7 +266,9 @@ class CodeChangeEventHandler(FileSystemEventHandler):
             },
         )
         # Delete File node (for all files including non-code like .md, .json)
-        ingestor.execute_write(CYPHER_DELETE_FILE, {KEY_PATH: relative_path_str})
+        ingestor.execute_write(
+            CYPHER_DELETE_FILE, {KEY_PATH: path.resolve().as_posix()}
+        )
         logger.debug(logs.DELETION_QUERY.format(path=relative_path_str))
 
         # Step 2: Clear in-memory state


### PR DESCRIPTION
## Summary

- delete realtime `File` nodes with their resolved absolute path so the query matches the `File.absolute_path` identity introduced by #898
- keep project-scoped `Module` deletion on its existing relative-path contract
- update the non-code deletion and targeted deletion assertions to prevent the stale-node regression

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD or tooling
- [ ] Dependencies

## Related Issues

Fixes #1141

## Test Plan

- [x] Unit tests pass (`make test-parallel` or `uv run pytest -n auto -m "not integration"`)
- [ ] New tests added
- [x] Integration tests pass (`make test-integration`, requires Docker)
- [ ] Manual testing (describe below)

Regression verification:
- before the production fix, the two updated assertions failed with relative paths
- focused realtime/watcher tests: 40 passed
- full non-integration suite: 6,786 passed, 35 skipped
- integration suite: 299 passed, 5 skipped
- all pre-commit hooks passed, including Ruff, format, ty, README generation, and Bandit

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [x] No new comments or docstrings (code should be self-documenting)

### AI assistance

AI assistance was used to investigate the issue, implement the focused fix, and update regression assertions. The final diff was manually reviewed and validated with the full test and pre-commit suites above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file deletion handling by consistently resolving file locations before removal.
  - Prevented path-related mismatches that could cause file-node deletions to target the wrong location.
  - Preserved existing module deletion behavior and project scope handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->