### PR TITLE
fix(graph): prune legacy target-resolved File identities

### DIFF
--- a/codebase_rag/constants/graph.py
+++ b/codebase_rag/constants/graph.py
@@ -29,6 +29,7 @@ KEY_RESPONSE = "response"
 KEY_START_LINE = "start_line"
 KEY_END_LINE = "end_line"
 KEY_PATH = "path"
+KEY_PATHS = "paths"
 KEY_ABSOLUTE_PATH = "absolute_path"
 # Whether flow analysis covered a Module: its language is in the source/sink
 # registry AND the FLOWS_TO capture group was enabled at indexing. Read by
@@ -391,6 +392,16 @@ CYPHER_COUNT_PROJECT_MODULES = (
 # Queries for orphan pruning: return all paths stored in the graph
 CYPHER_ALL_FILE_PATHS = (
     "MATCH (f:File) RETURN f.path AS path, f.absolute_path AS absolute_path"
+)
+# Pre-GHSA-85gg File nodes keyed on a leaf-dereferenced external target
+# fail the prune containment gate. Ownership via this project's CONTAINS_*
+# path lets a deleted symlink's leftover node be swept without touching a
+# sibling project's file that happens to share the relative path (#1156).
+CYPHER_PROJECT_OWNED_FILE_ABSOLUTE_PATHS = (
+    "MATCH (p:Project {name: $project_name})"
+    "-[:CONTAINS_PACKAGE|CONTAINS_FOLDER|CONTAINS_FILE*]->(f:File) "
+    "WHERE f.absolute_path IN $paths "
+    "RETURN DISTINCT f.absolute_path AS absolute_path"
 )
 CYPHER_ALL_MODULE_PATHS_INTERNAL = (
     "MATCH (m:Module) RETURN m.path AS path, m.qualified_name AS qualified_name"

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -80,7 +80,9 @@ from .types_defs import (
 from .utils.dependencies import has_semantic_dependencies
 from .utils.fqn_resolver import find_function_source_by_fqn
 from .utils.path_utils import (
+    cached_file_identity_posix,
     cached_relative_path,
+    cached_resolve_posix,
     should_keep_dir,
     should_skip_path,
     should_skip_rel_file,
@@ -2036,6 +2038,42 @@ class GraphUpdater:
         self.factory.call_processor.finalize_flow()
         self.factory.call_processor.finalize_dispatch()
 
+    def _abs_path_outside_repo(self, abs_path: str, repo_abs: str) -> bool:
+        return not (abs_path == repo_abs or abs_path.startswith(repo_abs + "/"))
+
+    def _is_live_legacy_target_resolved_file(
+        self, rel_path: str, abs_path: str, repo_abs: str
+    ) -> bool:
+        if not self._abs_path_outside_repo(abs_path, repo_abs):
+            return False
+        live = self.repo_path / rel_path
+        if not live.exists():
+            return False
+        if cached_file_identity_posix(live) == abs_path:
+            return False
+        return cached_resolve_posix(live) == abs_path
+
+    def _owned_file_absolute_paths(self, abs_paths: set[str]) -> set[str]:
+        if not abs_paths or not isinstance(self.ingestor, QueryProtocol):
+            return set()
+        try:
+            rows = self.ingestor.fetch_all(
+                cs.CYPHER_PROJECT_OWNED_FILE_ABSOLUTE_PATHS,
+                {
+                    cs.KEY_PROJECT_NAME: self.project_name,
+                    cs.KEY_PATHS: sorted(abs_paths),
+                },
+            )
+        except Exception:
+            logger.warning(ls.PRUNE_QUERY_FAILED, label=cs.NodeLabel.FILE)
+            return set()
+        owned: set[str] = set()
+        for row in rows:
+            value = row.get(cs.KEY_ABSOLUTE_PATH)
+            if isinstance(value, str) and value:
+                owned.add(value)
+        return owned
+
     def _prune_orphan_nodes(self) -> None:
         """Remove graph nodes whose files/folders no longer exist on disk."""
         if not isinstance(self.ingestor, QueryProtocol):
@@ -2047,16 +2085,17 @@ class GraphUpdater:
         project_prefix = self.project_name + "."
         repo_abs = self.repo_path.resolve().as_posix()
         prune_specs: list[tuple[str, str, str]] = [
-            (cs.CYPHER_ALL_FILE_PATHS, cs.CYPHER_DELETE_FILE, "File"),
+            (cs.CYPHER_ALL_FILE_PATHS, cs.CYPHER_DELETE_FILE, cs.NodeLabel.FILE),
             (
                 cs.CYPHER_ALL_MODULE_PATHS_INTERNAL,
                 cs.CYPHER_DELETE_MODULE,
-                "Module",
+                cs.NodeLabel.MODULE,
             ),
-            (cs.CYPHER_ALL_FOLDER_PATHS, cs.CYPHER_DELETE_FOLDER, "Folder"),
+            (cs.CYPHER_ALL_FOLDER_PATHS, cs.CYPHER_DELETE_FOLDER, cs.NodeLabel.FOLDER),
         ]
 
         read_failed = False
+        unverified_outside_files: list[tuple[str, str]] = []
         for query_all, delete_query, label in prune_specs:
             try:
                 rows = self.ingestor.fetch_all(query_all)
@@ -2077,9 +2116,27 @@ class GraphUpdater:
                 qn = r.get("qualified_name", "")
                 # Component-aware containment: a bare prefix test would also
                 # match a sibling root such as <repo>-old (issue #897).
-                if isinstance(abs_path, str) and not (
-                    abs_path == repo_abs or abs_path.startswith(repo_abs + "/")
-                ):
+                outside = isinstance(abs_path, str) and self._abs_path_outside_repo(
+                    abs_path, repo_abs
+                )
+                if outside:
+                    # A pre-GHSA-85gg File keyed on a leaf-dereferenced
+                    # external target fails this gate. Sweep it only when
+                    # we can prove it is ours: the relative path still
+                    # resolves to that target, or this project owns the
+                    # node. In-repo symlink mismatches stay: they share
+                    # the real file's key (issue #1156).
+                    if (
+                        label == cs.NodeLabel.FILE
+                        and isinstance(abs_path, str)
+                        and abs_path
+                    ):
+                        if self._is_live_legacy_target_resolved_file(
+                            path, abs_path, repo_abs
+                        ):
+                            orphans.append((path, abs_path))
+                        elif not (self.repo_path / path).exists():
+                            unverified_outside_files.append((path, abs_path))
                     continue
                 if isinstance(qn, str) and qn and not qn.startswith(project_prefix):
                     continue
@@ -2106,6 +2163,32 @@ class GraphUpdater:
                             delete_query, {cs.KEY_PATH: orphan_key}
                         )
                 total_pruned += len(orphans)
+
+        if (
+            not read_failed
+            and unverified_outside_files
+            and isinstance(self.ingestor, QueryProtocol)
+        ):
+            owned = self._owned_file_absolute_paths(
+                {key for _path, key in unverified_outside_files}
+            )
+            owned_orphans = [
+                (path, key) for path, key in unverified_outside_files if key in owned
+            ]
+            if owned_orphans:
+                logger.info(
+                    ls.PRUNE_FOUND,
+                    count=len(owned_orphans),
+                    label=cs.NodeLabel.FILE,
+                )
+                for orphan_path, orphan_key in owned_orphans:
+                    logger.debug(
+                        ls.PRUNE_DELETING, label=cs.NodeLabel.FILE, path=orphan_path
+                    )
+                    self.ingestor.execute_write(
+                        cs.CYPHER_DELETE_FILE, {cs.KEY_PATH: orphan_key}
+                    )
+                total_pruned += len(owned_orphans)
 
         if read_failed:
             # The same outage that broke the path reads would break (or act

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -2121,22 +2121,23 @@ class GraphUpdater:
                 )
                 if outside:
                     # A pre-GHSA-85gg File keyed on a leaf-dereferenced
-                    # external target fails this gate. Sweep it only when
-                    # we can prove it is ours: the relative path still
-                    # resolves to that target, or this project owns the
-                    # node. In-repo symlink mismatches stay: they share
-                    # the real file's key (issue #1156).
+                    # external target fails this gate. Queue it only when
+                    # the relative path still resolves to that target or
+                    # the path is gone; deletion waits on project
+                    # ownership. In-repo symlink mismatches stay: they
+                    # share the real file's key (issue #1156).
                     if (
                         label == cs.NodeLabel.FILE
                         and isinstance(abs_path, str)
                         and abs_path
+                        and (
+                            self._is_live_legacy_target_resolved_file(
+                                path, abs_path, repo_abs
+                            )
+                            or not (self.repo_path / path).exists()
+                        )
                     ):
-                        if self._is_live_legacy_target_resolved_file(
-                            path, abs_path, repo_abs
-                        ):
-                            orphans.append((path, abs_path))
-                        elif not (self.repo_path / path).exists():
-                            unverified_outside_files.append((path, abs_path))
+                        unverified_outside_files.append((path, abs_path))
                     continue
                 if isinstance(qn, str) and qn and not qn.startswith(project_prefix):
                     continue

--- a/codebase_rag/tests/test_graph_updater_pruning.py
+++ b/codebase_rag/tests/test_graph_updater_pruning.py
@@ -455,3 +455,151 @@ class TestPruneSiblingRootPrefix:
         ]
         assert len(file_deletes) == 1
         assert file_deletes[0].args[1] == {cs.KEY_PATH: own_abs}
+
+
+class TestPruneLegacyTargetResolvedFileIdentity:
+    def _updater(self, py_project: Path, mock_ingestor: MagicMock) -> GraphUpdater:
+        parsers, queries = load_parsers()
+        return GraphUpdater(
+            ingestor=mock_ingestor,
+            repo_path=py_project,
+            parsers=parsers,
+            queries=queries,
+        )
+
+    def test_prune_removes_live_legacy_external_symlink_file(
+        self, py_project: Path, mock_ingestor: MagicMock, tmp_path: Path
+    ) -> None:
+        outside = tmp_path / "outside_secret.py"
+        outside.write_text("secret = 1\n")
+        link = py_project / "vendor.py"
+        link.symlink_to(outside)
+        outside_abs = outside.resolve().as_posix()
+        link_identity = (py_project.resolve() / link.name).as_posix()
+        assert outside_abs != link_identity
+
+        updater = self._updater(py_project, mock_ingestor)
+        mock_ingestor.fetch_all.side_effect = [
+            [{"path": link.name, "absolute_path": outside_abs}],
+            [],
+            [],
+            [],
+        ]
+        updater._prune_orphan_nodes()
+
+        file_deletes = [
+            c
+            for c in mock_ingestor.execute_write.call_args_list
+            if c.args[0] == cs.CYPHER_DELETE_FILE
+        ]
+        assert len(file_deletes) == 1
+        assert file_deletes[0].args[1] == {cs.KEY_PATH: outside_abs}
+        owned_queries = [
+            c
+            for c in mock_ingestor.fetch_all.call_args_list
+            if c.args[0] == cs.CYPHER_PROJECT_OWNED_FILE_ABSOLUTE_PATHS
+        ]
+        assert owned_queries == []
+
+    def test_prune_removes_deleted_legacy_external_symlink_when_project_owned(
+        self, py_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        outside_abs = "/var/secret/legacy_vendor.py"
+        updater = self._updater(py_project, mock_ingestor)
+        mock_ingestor.fetch_all.side_effect = [
+            [{"path": "vendor.py", "absolute_path": outside_abs}],
+            [],
+            [],
+            [{cs.KEY_ABSOLUTE_PATH: outside_abs}],
+        ]
+        updater._prune_orphan_nodes()
+
+        file_deletes = [
+            c
+            for c in mock_ingestor.execute_write.call_args_list
+            if c.args[0] == cs.CYPHER_DELETE_FILE
+        ]
+        assert len(file_deletes) == 1
+        assert file_deletes[0].args[1] == {cs.KEY_PATH: outside_abs}
+        owned_queries = [
+            c
+            for c in mock_ingestor.fetch_all.call_args_list
+            if c.args[0] == cs.CYPHER_PROJECT_OWNED_FILE_ABSOLUTE_PATHS
+        ]
+        assert len(owned_queries) == 1
+        assert owned_queries[0].args[1] == {
+            cs.KEY_PROJECT_NAME: updater.project_name,
+            cs.KEY_PATHS: [outside_abs],
+        }
+
+    def test_prune_skips_unowned_outside_file_when_relative_path_missing(
+        self, py_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        outside_abs = "/other/project/app.py"
+        updater = self._updater(py_project, mock_ingestor)
+        mock_ingestor.fetch_all.side_effect = [
+            [{"path": "app.py", "absolute_path": outside_abs}],
+            [],
+            [],
+            [],
+        ]
+        updater._prune_orphan_nodes()
+
+        file_deletes = [
+            c
+            for c in mock_ingestor.execute_write.call_args_list
+            if c.args[0] == cs.CYPHER_DELETE_FILE
+        ]
+        assert file_deletes == []
+
+    def test_prune_keeps_in_repo_symlink_sharing_target_key(
+        self, py_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        target = py_project / "real.md"
+        target.write_text("payload\n")
+        link = py_project / "alias.md"
+        link.symlink_to(target)
+        target_abs = target.resolve().as_posix()
+
+        updater = self._updater(py_project, mock_ingestor)
+        mock_ingestor.fetch_all.side_effect = [
+            [{"path": link.name, "absolute_path": target_abs}],
+            [],
+            [],
+            [],
+        ]
+        updater._prune_orphan_nodes()
+
+        file_deletes = [
+            c
+            for c in mock_ingestor.execute_write.call_args_list
+            if c.args[0] == cs.CYPHER_DELETE_FILE
+        ]
+        assert file_deletes == []
+
+    def test_prune_keeps_file_under_symlinked_ancestor(
+        self, py_project: Path, mock_ingestor: MagicMock
+    ) -> None:
+        real_dir = py_project / "realdir"
+        real_dir.mkdir()
+        nested = real_dir / "nested.py"
+        nested.write_text("x = 1\n")
+        link_dir = py_project / "linkdir"
+        link_dir.symlink_to(real_dir)
+        stored_abs = nested.resolve().as_posix()
+
+        updater = self._updater(py_project, mock_ingestor)
+        mock_ingestor.fetch_all.side_effect = [
+            [{"path": "linkdir/nested.py", "absolute_path": stored_abs}],
+            [],
+            [],
+            [],
+        ]
+        updater._prune_orphan_nodes()
+
+        file_deletes = [
+            c
+            for c in mock_ingestor.execute_write.call_args_list
+            if c.args[0] == cs.CYPHER_DELETE_FILE
+        ]
+        assert file_deletes == []

--- a/codebase_rag/tests/test_graph_updater_pruning.py
+++ b/codebase_rag/tests/test_graph_updater_pruning.py
@@ -483,7 +483,7 @@ class TestPruneLegacyTargetResolvedFileIdentity:
             [{"path": link.name, "absolute_path": outside_abs}],
             [],
             [],
-            [],
+            [{cs.KEY_ABSOLUTE_PATH: outside_abs}],
         ]
         updater._prune_orphan_nodes()
 
@@ -499,7 +499,11 @@ class TestPruneLegacyTargetResolvedFileIdentity:
             for c in mock_ingestor.fetch_all.call_args_list
             if c.args[0] == cs.CYPHER_PROJECT_OWNED_FILE_ABSOLUTE_PATHS
         ]
-        assert owned_queries == []
+        assert len(owned_queries) == 1
+        assert owned_queries[0].args[1] == {
+            cs.KEY_PROJECT_NAME: updater.project_name,
+            cs.KEY_PATHS: [outside_abs],
+        }
 
     def test_prune_removes_deleted_legacy_external_symlink_when_project_owned(
         self, py_project: Path, mock_ingestor: MagicMock
@@ -521,6 +525,41 @@ class TestPruneLegacyTargetResolvedFileIdentity:
         ]
         assert len(file_deletes) == 1
         assert file_deletes[0].args[1] == {cs.KEY_PATH: outside_abs}
+        owned_queries = [
+            c
+            for c in mock_ingestor.fetch_all.call_args_list
+            if c.args[0] == cs.CYPHER_PROJECT_OWNED_FILE_ABSOLUTE_PATHS
+        ]
+        assert len(owned_queries) == 1
+        assert owned_queries[0].args[1] == {
+            cs.KEY_PROJECT_NAME: updater.project_name,
+            cs.KEY_PATHS: [outside_abs],
+        }
+
+    def test_prune_skips_live_external_symlink_when_not_project_owned(
+        self, py_project: Path, mock_ingestor: MagicMock, tmp_path: Path
+    ) -> None:
+        outside = tmp_path / "other_project_file.py"
+        outside.write_text("owned_elsewhere = 1\n")
+        link = py_project / "vendor.py"
+        link.symlink_to(outside)
+        outside_abs = outside.resolve().as_posix()
+
+        updater = self._updater(py_project, mock_ingestor)
+        mock_ingestor.fetch_all.side_effect = [
+            [{"path": link.name, "absolute_path": outside_abs}],
+            [],
+            [],
+            [],
+        ]
+        updater._prune_orphan_nodes()
+
+        file_deletes = [
+            c
+            for c in mock_ingestor.execute_write.call_args_list
+            if c.args[0] == cs.CYPHER_DELETE_FILE
+        ]
+        assert file_deletes == []
         owned_queries = [
             c
             for c in mock_ingestor.fetch_all.call_args_list


### PR DESCRIPTION
## Summary

- Incremental `--update-graph` now sweeps pre-GHSA-85gg `File` nodes that were keyed on a leaf-dereferenced **external** symlink target. Those nodes sit outside the repo, so the prune containment gate skipped them and they leaked forever.
- A still-present external symlink is recognized when `cached_resolve_posix(repo_path / path)` equals the stored `absolute_path` and that path disagrees with `cached_file_identity_posix(...)`.
- A deleted external symlink is swept only when this project owns the node (`CONTAINS_PACKAGE|CONTAINS_FOLDER|CONTAINS_FILE*` from `Project`). Sibling-project files that share a relative path stay untouched.
- In-repo symlink records that share the real file's key are left alone (the self-heal case from #1155). Symlinked *ancestors* are compared via parent-resolve identity so they do not false-positive.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD or tooling
- [ ] Dependencies

## Related Issues

Fixes #1156

## Test Plan

- [x] Unit tests pass (`uv run pytest codebase_rag/tests/test_graph_updater_pruning.py` — 21 passed, including the 16 existing prune tests)
- [x] New tests added (`TestPruneLegacyTargetResolvedFileIdentity`)
- [ ] Integration tests pass (`make test-integration`, requires Docker — not run locally; unit tests cover the prune decision table)
- [x] Manual testing (describe below)

RED verification (tests against unpatched `_prune_orphan_nodes`):

- `test_prune_removes_live_legacy_external_symlink_file` failed (`0` deletes)
- `test_prune_removes_deleted_legacy_external_symlink_when_project_owned` failed (`0` deletes)
- keep-safe tests still passed on the unpatched code

GREEN after the fix: 21/21 in `test_graph_updater_pruning.py`. Also 48 passed across prune + incremental updater tests.

Keep-safe coverage:

- unowned outside `File` with a missing relative path (sibling project) is not deleted
- in-repo symlink sharing the target's key is not deleted
- file under a symlinked ancestor is not deleted (identity uses parent-resolve, same as ingest)

Pre-commit on the changed files: ruff, ruff format, ty, README generation, bandit.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] All pre-commit checks pass (`pre-commit run --files` on the three changed files)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [x] No new comments or docstrings except the issue-#1156 invariant next to the existing #897 containment comments

### AI assistance

AI assistance was used to locate the prune/identity code, implement the focused fix, and write the RED-verified regression tests. The final diff was reviewed against `CONTRIBUTING.md` (constants, no `Any`, conventional commit, tests required) and run through the pre-commit hooks listed above.

## Why this is safe

`File` nodes are unique on `absolute_path`. Deleting an **outside** key cannot collapse an in-repo file. Deleting an in-repo identity mismatch *would* be unsafe (it is the real file's MERGE key), so that case is explicitly not pruned. Ownership is consulted only for missing-on-disk outside keys, so `test_prune_skips_other_projects` still holds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of stale file references, including symlinked and externally located files.
  * Preserved valid in-repository symlinks and files under symlinked directories.
  * Avoided removing external files unless they are confirmed to belong to the project.
  * Added more accurate project file path tracking for graph-based operations.
  * Improved handling of unresolved file locations during project cleanup to reduce unintended deletions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->