### PR TITLE
docs: add Trendshift #1 trending badge to the README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
   <img src="assets/logo-light-any.png" alt="Code-Graph-RAG Logo" width="480">
 
   <p>
+    <a href="https://trendshift.io/repositories/99619" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/repositories/99619" alt="vitali87/code-graph-rag | Trendshift" width="250" height="55"/></a>
+  </p>
+
+  <p>
   <!-- Badges below are commented out while the GitHub account is suspended. Restore them when the account is reinstated.
        Stars/Forks: shields.io hits GitHub's API (returns "repo not found" for suspended accounts).
        gitcgr: indexes from GitHub (shows "not indexed" while unavailable).


### PR DESCRIPTION
code-graph-rag was featured as **#1 Repository of the Day** on GitHub Trending. This adds the official [Trendshift](https://trendshift.io/repositories/99619) badge in its own centered block directly under the logo, above the status-badge row.

- Cleaned the alt text from the embed snippet (`vitali87%2Fcode-graph-rag` → `vitali87/code-graph-rag`).
- Header is hand-maintained (outside the `generate_readme.py` `SECTION` markers), so the generator leaves it untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a centered Trendshift repository badge below the project logo in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->