### PR TITLE
fix: restore theme-aware README logo so it is legible on dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
 <div align="center">
-  <!-- Bitbucket strips <picture>/<source> tags, so we use a single light-mode <img>. Restore the theme-aware <picture> block below when the GitHub account is reinstated:
   <picture>
-    <source srcset="assets/logo-dark-any.png" media="(prefers-color-scheme: dark)">
-    <source srcset="assets/logo-light-any.png" media="(prefers-color-scheme: light)">
-    <img src="assets/logo-dark-any.png" alt="Code-Graph-RAG Logo" width="480">
+    <source media="(prefers-color-scheme: dark)" srcset="assets/logo-dark-any.png">
+    <source media="(prefers-color-scheme: light)" srcset="assets/logo-light-any.png">
+    <img src="assets/logo-light-any.png" alt="Code-Graph-RAG Logo" width="480">
   </picture>
-  -->
-  <img src="assets/logo-light-any.png" alt="Code-Graph-RAG Logo" width="480">
 
   <p>
     <a href="https://trendshift.io/repositories/99619" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/repositories/99619" alt="vitali87/code-graph-rag | Trendshift" width="250" height="55"/></a>


### PR DESCRIPTION
The README header used a single light-mode logo (`logo-light-any.png`, dark lettering), so on GitHub's dark theme the "Code-Graph-RAG" title and tagline nearly vanished against the dark background.

Restores the theme-aware `<picture>` block (it was commented out with a stale "Bitbucket strips `<picture>`, restore when the GitHub account is reinstated" note — the account is reinstated):

- Dark theme → `logo-dark-any.png` (bright lettering)
- Light theme → `logo-light-any.png` (dark lettering)
- `<img>` fallback → light logo, safe for white-background renderers (PyPI, etc.)

Header is hand-maintained (outside the `generate_readme.py` `SECTION` markers), so the generator leaves it untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README branding to display the appropriate logo for dark and light themes.
  - Improved visual consistency by using theme-specific logo variants.
  - Removed outdated fallback content and restoration notes from the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->