### PR TITLE
fix: scope use declarations in out-of-function expression blocks (#1016)

### DIFF
--- a/codebase_rag/parsers/rs/utils.py
+++ b/codebase_rag/parsers/rs/utils.py
@@ -393,6 +393,13 @@ def rust_use_scope(node: Node) -> tuple[Node | None, list[str] | None, bool]:
                 # that block alone (rustc-verified): store it span-gated
                 # like an initializer-block use, never fn-wide.
                 return block, None, True
+            if current.type in cs.FQN_RS_SCOPE_TYPES and block is not None:
+                # An expression block in a class-body position (enum
+                # discriminant, array length, const-generic default) is
+                # scoped to that block alone, exactly like a const/static
+                # initializer: a class type has no qn a use could key on,
+                # so store it span-gated instead of dropping it (#1016).
+                return block, None, True
             nearest = current
             break
         current = current.parent

--- a/codebase_rag/tests/test_rust_crate_path_trait_linking.py
+++ b/codebase_rag/tests/test_rust_crate_path_trait_linking.py
@@ -1983,6 +1983,8 @@ def test_assoc_const_block_use_does_not_pollute_file_map(
     base = "rs_const_block_use.src"
     assert (f"{base}.foo.other", f"{base}.beta.helper") in calls, calls
     assert (f"{base}.foo.other", f"{base}.alpha.helper") not in calls, calls
+    assert (f"{base}.foo", f"{base}.alpha.helper") in calls, calls
+    assert (f"{base}.foo", f"{base}.beta.helper") not in calls, calls
     imports = _pairs(mock_ingestor, RelationshipType.IMPORTS.value)
     assert (f"{base}.foo", f"{base}.alpha") in imports, imports
     assert (f"{base}.foo", f"{base}.beta") in imports, imports
@@ -3716,6 +3718,44 @@ def test_initializer_block_use_binds_the_blocks_own_call_at_file_level(
     assert (f"{base}.a", f"{base}.gamma.helper") in calls, calls
     mapping = updater.factory.import_processor.import_mapping.get(f"{base}.a")
     assert not mapping or "helper" not in mapping, mapping
+
+
+def test_enum_discriminant_block_use_binds_the_blocks_own_call(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # An enum discriminant is an expression block outside any function or
+    # const/static item. A use inside it is scoped to that block alone: the
+    # discriminant's own call must bind through it, while a sibling fn keeps
+    # the file-level use and the file import map stays unpolluted (#1016).
+    project = temp_repo / "rs_enum_disc_block"
+    _write(
+        project,
+        {
+            "Cargo.toml": '[package]\nname = "rs_enum_disc_block"\nversion = "0.1.0"\n',
+            "src/lib.rs": "pub mod beta;\npub mod gamma;\npub mod a;\n",
+            "src/beta.rs": "pub const fn helper() -> u32 {\n    2\n}\n",
+            "src/gamma.rs": "pub const fn helper() -> u32 {\n    3\n}\n",
+            "src/a.rs": (
+                "use crate::beta::helper;\n\n"
+                "#[repr(u32)]\n"
+                "pub enum E {\n"
+                "    A = { use crate::gamma::helper; helper() },\n"
+                "}\n\n"
+                "pub fn f() -> u32 {\n"
+                "    helper()\n"
+                "}\n"
+            ),
+        },
+    )
+    updater = create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    base = "rs_enum_disc_block.src"
+    assert (f"{base}.a", f"{base}.gamma.helper") in calls, calls
+    assert (f"{base}.a.f", f"{base}.beta.helper") in calls, calls
+    assert (f"{base}.a.f", f"{base}.gamma.helper") not in calls, calls
+    mapping = updater.factory.import_processor.import_mapping.get(f"{base}.a")
+    assert mapping and mapping.get("helper") == f"{base}.beta.helper", mapping
 
 
 def test_initializer_block_use_binds_the_blocks_own_call_in_a_fn(


### PR DESCRIPTION
Closes #1016.

## Background
The block-scope machinery for `use` declarations inside const/static initializers already landed with the #1007-era work — those literal repros are covered by existing green tests (`test_initializer_block_use_binds_the_blocks_own_call_at_file_level`, `test_assoc_const_block_use_does_not_pollute_file_map`). This closes the **residual** the issue flags: the *other* out-of-function expression blocks.

## The bug
`rust_use_scope` returned the enclosing block as the scope only for `const_item`/`static_item`. For an expression block in a **class-body position** — an **enum discriminant**, **array-length**, or **const-generic default** — the walk hit the class type (enum/struct/trait/impl), fell through to the drop path, and stored no mapping. The block-local `use` was discarded, so a bare call inside the block resolved through the *file* import map and mis-bound (e.g. an enum discriminant’s `helper()` bound `beta::helper` instead of its own `use crate::gamma::helper`).

## Fix
One classifier branch in `rust_use_scope` (`codebase_rag/parsers/rs/utils.py`): when a real expression `block` was captured on the way up and the nearest scope is a class type, return `(block, None, True)` — span-gated, exactly like the const/static path. The rest of the pipeline (storage in `rust_block_scope_imports`, hole-punching, site-gated resolution, module-level caller attribution) already generalizes, so no other production change is needed.

**Safety:** mod/enum/struct/trait/impl *bodies* are not `block` nodes (they are `declaration_list` / `enum_variant_list` / `field_declaration_list`), so gating on `block is not None` cannot misclassify a genuine file/mod-scoped `use`. The mod-chain path is only reached when no block was captured.

## Tests
- **New, RED-verified:** `test_enum_discriminant_block_use_binds_the_blocks_own_call` — the discriminant’s own call binds its block use (`gamma`), a sibling fn keeps the file-level use (`beta`), and the file map is not overwritten. Reverting the classifier change flips the discriminant call to `beta` (the mis-bind), confirming RED.
- **Coverage gap closed:** added the initializer’s own-call direction assertion to `test_assoc_const_block_use_does_not_pollute_file_map`.
- Full `test_rust_crate_path_trait_linking.py` suite: **137 passed, 2 skipped**, no regressions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Rust import resolution within nested expression blocks.
  * Calls inside associated-constant and enum-discriminant blocks now use the correct local imports.
  * Preserved file-level imports for sibling functions.

* **Tests**
  * Added coverage for block-local import resolution in associated constants and enum discriminants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->