### PR TITLE
fix: bind each cfg/impl twin module's functions through their own use (#1017)

### DIFF
--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -3240,16 +3240,20 @@ class ImportProcessor:
         self._rust_pending_mod_scope_uses.setdefault(module_qn, []).append(
             (effective_qn, pure_chain, resolved_imports)
         )
-        if not pure_chain:
-            # A fn-local mod can lose the shared-key arbitration to a pure
-            # twin (issue #1017: one qn, two modules), yet its own functions
-            # still see this use: fan it out to their spans so the weak
-            # fn-scope map answers for them instead of whatever the key
-            # ends up holding.
-            for line, col in rs_utils.enclosing_mod_fn_spans(use_node):
-                self._rust_pending_fn_scope_uses.setdefault(module_qn, []).append(
-                    (line, col, resolved_imports, True)
-                )
+        # Fan every inline-mod use out to its own functions' spans as weak
+        # fn-scope entries, so a function binds through its enclosing mod
+        # body even when the shared qn key is corrupted (issue #1017: one
+        # qn, two modules). A fn-local mod can lose the shared-key
+        # arbitration to a pure twin, and two pure cfg/macro twins merge
+        # onto one key and overwrite each other; either way the span-gated
+        # fn-scope map answers for each function instead of whatever the key
+        # ends up holding. enclosing_mod_fn_spans is empty unless the use
+        # sits directly in an inline `mod {}` body, so file-level uses are
+        # untouched.
+        for line, col in rs_utils.enclosing_mod_fn_spans(use_node):
+            self._rust_pending_fn_scope_uses.setdefault(module_qn, []).append(
+                (line, col, resolved_imports, True)
+            )
 
     def retract_rust_mod_scope_uses(self, module_qn: str) -> None:
         # Reverse replay so a key shadowing another file's entries (the

--- a/codebase_rag/tests/test_rust_crate_path_trait_linking.py
+++ b/codebase_rag/tests/test_rust_crate_path_trait_linking.py
@@ -2080,6 +2080,60 @@ def test_method_local_mod_use_reaches_its_own_functions(
     assert (f"{base}.foo.S.inner.g", f"{base}.foo.helper") not in calls, calls
 
 
+def test_two_impls_method_local_mod_inner_keep_separate_uses(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # Two impls of the same type each declare a method-local `mod inner`;
+    # both share the effective scope qn foo.S.inner, but their block-local
+    # uses import different helpers. Each inner's function must bind through
+    # its OWN use, not a merged foo.S.inner import map (#1017 shape 3).
+    project = temp_repo / "rs_two_impls_inner"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_two_impls_inner"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": "pub mod alpha;\npub mod beta;\npub mod foo;\n",
+            "src/alpha.rs": "pub fn helper() -> u32 {\n    2\n}\n",
+            "src/beta.rs": "pub fn helper() -> u32 {\n    3\n}\n",
+            "src/foo.rs": (
+                "pub struct S;\n\n"
+                "impl S {\n"
+                "    pub fn m(&self) -> u32 {\n"
+                "        mod inner {\n"
+                "            use crate::alpha::helper;\n\n"
+                "            pub fn gm() -> u32 {\n"
+                "                helper()\n"
+                "            }\n"
+                "        }\n"
+                "        inner::gm()\n"
+                "    }\n"
+                "}\n\n"
+                "impl S {\n"
+                "    pub fn n(&self) -> u32 {\n"
+                "        mod inner {\n"
+                "            use crate::beta::helper;\n\n"
+                "            pub fn gn() -> u32 {\n"
+                "                helper()\n"
+                "            }\n"
+                "        }\n"
+                "        inner::gn()\n"
+                "    }\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    base = "rs_two_impls_inner.src"
+    assert (f"{base}.foo.S.inner.gm", f"{base}.alpha.helper") in calls, calls
+    assert (f"{base}.foo.S.inner.gn", f"{base}.beta.helper") in calls, calls
+    assert (f"{base}.foo.S.inner.gm", f"{base}.beta.helper") not in calls, calls
+    assert (f"{base}.foo.S.inner.gn", f"{base}.alpha.helper") not in calls, calls
+
+
 def test_const_block_mod_function_keeps_first_claimed_span(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:
@@ -6156,3 +6210,48 @@ def test_watch_modify_of_an_already_deleted_file_leaves_the_listing_alone(
     )
     assert listing is not None, "the full run should have cached the src listing"
     assert "gamma2.rs" not in listing, sorted(listing)
+
+
+def test_two_bodied_cfg_twin_mods_keep_separate_uses(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # Two mutually-exclusive cfg twins declare a bodied `mod run` in one
+    # file; both share the qn foo.run and are indexed unconditionally, but
+    # each twin imports a different helper. A twin's function must bind
+    # through its OWN mod-body use, not the merged foo.run map (#1017).
+    project = temp_repo / "rs_cfg_twin_bodied"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_cfg_twin_bodied"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": "pub mod alpha;\npub mod beta;\npub mod foo;\n",
+            "src/alpha.rs": "pub fn helper() -> u32 {\n    2\n}\n",
+            "src/beta.rs": "pub fn helper() -> u32 {\n    3\n}\n",
+            "src/foo.rs": (
+                '#[cfg(feature = "ext")]\n'
+                "pub mod run {\n"
+                "    use crate::alpha::helper;\n\n"
+                "    pub fn ga() -> u32 {\n"
+                "        helper()\n"
+                "    }\n"
+                "}\n\n"
+                '#[cfg(not(feature = "ext"))]\n'
+                "pub mod run {\n"
+                "    use crate::beta::helper;\n\n"
+                "    pub fn gb() -> u32 {\n"
+                "        helper()\n"
+                "    }\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+
+    calls = _calls(mock_ingestor)
+    base = "rs_cfg_twin_bodied.src"
+    assert (f"{base}.foo.run.ga", f"{base}.alpha.helper") in calls, calls
+    assert (f"{base}.foo.run.gb", f"{base}.beta.helper") in calls, calls
+    assert (f"{base}.foo.run.ga", f"{base}.beta.helper") not in calls, calls
+    assert (f"{base}.foo.run.gb", f"{base}.alpha.helper") not in calls, calls


### PR DESCRIPTION
Closes the remaining observable mis-binding in #1017.

## Context
Most of #1017 is already handled on `main` via span-gating + cross-file arbitration (not module-qn dedup, which would break `super::`/`self::`/`crate::` path resolution). The common colliding shapes have passing tests. This closes the one shape that still mis-bound and had no test.

## The bug
When two **bodied** modules share one qn — two mutually-exclusive cfg twins, or two impls of one type each with a method-local `mod inner` — both are indexed and their mod-scope `use` maps merge onto the shared `import_mapping[qn]` (last writer wins). A function in the earlier twin then binds through the later twin's imports:

```rust
#[cfg(feature = "ext")]      pub mod run { use crate::alpha::helper; pub fn ga() -> u32 { helper() } }
#[cfg(not(feature = "ext"))] pub mod run { use crate::beta::helper;  pub fn gb() -> u32 { helper() } }
```

`ga` wrongly resolved to `beta::helper` instead of `alpha::helper`.

## Fix
`_parse_rust_use_declaration` already fans an inline-mod use out to its own functions' spans as weak fn-scope entries — but only for **non-pure** chains (fn-local mods). Pure twins skipped it, so they merged on the shared key. Dropping the `if not pure_chain:` guard makes every inline-mod use also register span-gated per its own functions, so each function binds through its enclosing mod body regardless of what the merged key holds.

`enclosing_mod_fn_spans` returns spans only for a use sitting directly in an inline `mod {}` body, so **file-level and `mod foo;` uses are untouched** — the change is confined to inline bodied mods, exactly where twins occur.

## Tests (both RED-verified)
- `test_two_bodied_cfg_twin_mods_keep_separate_uses` — the cfg-twin case above; each twin's fn binds its own helper. Reverting the fix flips `ga` to `beta`.
- `test_two_impls_method_local_mod_inner_keep_separate_uses` — two impls of `S`, each a method-local `mod inner` importing a different helper.
- Full `test_rust_crate_path_trait_linking.py`: 139 passed, 2 skipped, no regressions. Block-item suites: 11 passed. Lint + type-check clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Rust import resolution inside inline modules.
  * Prevented imports from separate implementation blocks or configuration-specific module variants from being incorrectly shared.
  * Preserved distinct helper imports for isolated modules, improving code navigation and analysis accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->