### PR TITLE
fix: decline crate paths through an unrepresentable path redirect (#1082)

### DIFF
--- a/codebase_rag/constants/core.py
+++ b/codebase_rag/constants/core.py
@@ -99,6 +99,13 @@ MAIN_RS = "main.rs"
 SEPARATOR_DOUBLE_COLON = "::"
 SEPARATOR_PROTOTYPE = ".prototype."
 RUST_CRATE_KEYWORD = "crate"
+# A Rust crate path whose module is backed by a file the qn scheme cannot key
+# (an unrepresentable `#[path]` target: absolute, Windows-separated, or a climb
+# above the repository root) has no referent in the graph. The resolvers return
+# this qn so the path binds nothing and callers treat it as a decided drop
+# rather than falling back to a name-derived shadow file (issue #1082). The NUL
+# byte keeps it distinct from every real qn while remaining an ordinary str.
+RUST_UNRESOLVABLE_QN = "\x00unrepresentable"
 BUILTIN_PREFIX = "builtin"
 IIFE_FUNC_PREFIX = "iife_func_"
 IIFE_ARROW_PREFIX = "iife_arrow_"

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -1006,10 +1006,32 @@ class CallResolver:
                 self._simple_resolution_cache[cache_key] = result
             return result
 
+        # A bare name imported from an unrepresentable #[path] module is
+        # spoken for by that (unresolvable) import: the precise probes above
+        # already declined, so drop it rather than let the trie rebind it to
+        # a name-derived shadow file that merely shares the name (issue #1082).
+        if (
+            language == cs.SupportedLanguage.RUST
+            and cs.SEPARATOR_DOT not in call_name
+            and self._rust_name_maps_unresolvable(call_name, module_qn, caller_qn)
+        ):
+            if use_cache:
+                self._simple_resolution_cache[cache_key] = None
+            return None
+
         result = self._try_resolve_via_trie(call_name, module_qn, language, call_point)
         if use_cache:
             self._simple_resolution_cache[cache_key] = result
         return result
+
+    def _rust_name_maps_unresolvable(
+        self, call_name: str, module_qn: str, caller_qn: str | None
+    ) -> bool:
+        import_mapping = self.import_processor.import_mapping
+        for scope in (*self._rust_enclosing_scopes(module_qn, caller_qn), module_qn):
+            if import_mapping.get(scope, {}).get(call_name) == cs.RUST_UNRESOLVABLE_QN:
+                return True
+        return False
 
     def _resolve_dart_external_base_arg_member(
         self,
@@ -1442,11 +1464,13 @@ class CallResolver:
                 )
             ) and not self._rust_block_item_hidden(local[1], module_qn, call_point):
                 return local, None
-            target = (
-                weak
-                if weak is not None
-                else import_mapping.get(scope, {}).get(call_name)
-            )
+            raw = import_mapping.get(scope, {}).get(call_name)
+            if raw == cs.RUST_UNRESOLVABLE_QN:
+                # An unrepresentable #[path] import binds no scope: keep
+                # walking rather than surfacing the sentinel as a target
+                # (issue #1082).
+                raw = None
+            target = weak if weak is not None else raw
             if target is not None:
                 return None, target
             scope = scope.rsplit(cs.SEPARATOR_DOT, 1)[0]
@@ -1645,6 +1669,11 @@ class CallResolver:
     def _decide_rust_module_item(
         self, mapped: str, rest: list[str], item: str, owner: str
     ) -> tuple[tuple[str, str] | None, bool]:
+        if mapped == cs.RUST_UNRESOLVABLE_QN:
+            # A name imported from an unrepresentable #[path] module has no
+            # referent: decided drop so no fallback binds a name-derived
+            # shadow file (issue #1082).
+            return None, True
         resolved = self._rust_local_qn(mapped, owner)
         if resolved is None:
             head = mapped.split(cs.SEPARATOR_DOUBLE_COLON, 1)[0]

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -1595,6 +1595,12 @@ class CallResolver:
         base = self.import_processor._rewrite_rust_local_use_path(
             cs.SEPARATOR_DOUBLE_COLON.join(object_path), effective_module
         )
+        if base == cs.RUST_UNRESOLVABLE_QN:
+            # The path names a module backed by a file the qn scheme cannot
+            # key (an unrepresentable #[path]): it has no referent, so drop it
+            # rather than let a weaker fallback bind a name-derived shadow
+            # file that merely sits where the name points (issue #1082).
+            return None, True
         if cs.SEPARATOR_DOUBLE_COLON in base:
             return None, False
         return self._decide_rust_base(base, item)

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -1465,12 +1465,13 @@ class CallResolver:
             ) and not self._rust_block_item_hidden(local[1], module_qn, call_point):
                 return local, None
             raw = import_mapping.get(scope, {}).get(call_name)
-            if raw == cs.RUST_UNRESOLVABLE_QN:
-                # An unrepresentable #[path] import binds no scope: keep
-                # walking rather than surfacing the sentinel as a target
-                # (issue #1082).
-                raw = None
             target = weak if weak is not None else raw
+            if target == cs.RUST_UNRESOLVABLE_QN:
+                # An inner unrepresentable #[path] import still OWNS the
+                # imported name and shadows any outer same-named item, so it
+                # is a deliberate drop: stop the walk and hand the sentinel
+                # back rather than letting an outer binding answer (#1082).
+                return None, target
             if target is not None:
                 return None, target
             scope = scope.rsplit(cs.SEPARATOR_DOT, 1)[0]

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -276,6 +276,11 @@ class ClassIngestMixin:
             rewritten = self.import_processor._rewrite_rust_local_use_path(
                 path, module_qn
             )
+            if rewritten == cs.RUST_UNRESOLVABLE_QN:
+                # The trait path traverses an unrepresentable #[path] module:
+                # it has no referent, so it must not become a synthetic
+                # external trait qn (issue #1082).
+                return anchored, None
             return (rewritten, anchored) if rewritten != path else (anchored, None)
         # The head is itself a name a `use` may have bound (`use std::io;`
         # then `impl io::Read`), and only the expanded crate says who speaks
@@ -1759,11 +1764,16 @@ class ClassIngestMixin:
             # where the qn scheme keys the module, so the name-derived
             # spellings below back nothing at all here (issue #1035).
             return {redirect}
-        candidates = {
-            self.import_processor._rust_resolve_relative(
-                module_qn, [*chain, module_name], module_qn
-            )
-        }
+        resolved_candidate = self.import_processor._rust_resolve_relative(
+            module_qn, [*chain, module_name], module_qn
+        )
+        # An unrepresentable #[path] target yields no candidate qn (issue
+        # #1082); the file-derived spelling below still applies for a chain.
+        candidates = (
+            set()
+            if resolved_candidate == cs.RUST_UNRESOLVABLE_QN
+            else {resolved_candidate}
+        )
         if chain:
             # A chain declaration's target FILE lives under the declaring
             # file's directory tree regardless of the inline qn nesting

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -278,9 +278,10 @@ class ClassIngestMixin:
             )
             if rewritten == cs.RUST_UNRESOLVABLE_QN:
                 # The trait path traverses an unrepresentable #[path] module:
-                # it has no referent, so it must not become a synthetic
-                # external trait qn (issue #1082).
-                return anchored, None
+                # it has no referent. Surface the sentinel so the caller drops
+                # the relationship entirely, rather than the name-anchored qn,
+                # which would rebind to a same-named trait shadow (issue #1082).
+                return cs.RUST_UNRESOLVABLE_QN, None
             return (rewritten, anchored) if rewritten != path else (anchored, None)
         # The head is itself a name a `use` may have bound (`use std::io;`
         # then `impl io::Read`), and only the expanded crate says who speaks
@@ -1275,36 +1276,43 @@ class ClassIngestMixin:
                 trait_name,
                 owner_module_qn,
             )
-            # The trait (or the impl target) may live in a file not yet
-            # parsed; hold the IMPLEMENTS edge back for
-            # resolve_deferred_inherits so an unresolvable trait
-            # (std::fmt::Display) emits no phantom edge.
-            trait_entry = DeferredInherit(
-                rel_type=cs.RelationshipType.IMPLEMENTS,
-                child_qn=class_qn,
-                parent_qn=trait_qn,
-                module_qn=owner_module_qn,
-                base_index=0,
-                language=cs.SupportedLanguage.RUST,
-                alt_parent_qn=alt_trait_qn,
-            )
-            self._deferred_inherits.append(trait_entry)
-            # Collect this block's methods against the trait AS WRITTEN: if the
-            # trait belongs to another crate, its dispatch is the only caller
-            # they can ever have (issue #1048). The decision waits for
-            # resolve_deferred_inherits, when every first-party trait is
-            # registered.
-            trait_impl_method_qns = impl_method_qns
-            self._rust_trait_impls.append(
-                RustTraitImpl(
-                    entry=trait_entry,
-                    spelling=rs_utils.extract_impl_trait_path(class_node) or trait_name,
-                    method_qns=trait_impl_method_qns,
+            if trait_qn != cs.RUST_UNRESOLVABLE_QN:
+                # The trait (or the impl target) may live in a file not yet
+                # parsed; hold the IMPLEMENTS edge back for
+                # resolve_deferred_inherits so an unresolvable trait
+                # (std::fmt::Display) emits no phantom edge. A trait path
+                # through an unrepresentable #[path] module has no referent at
+                # all, so it is skipped entirely rather than bound to a
+                # name-derived shadow trait (issue #1082).
+                trait_entry = DeferredInherit(
+                    rel_type=cs.RelationshipType.IMPLEMENTS,
+                    child_qn=class_qn,
+                    parent_qn=trait_qn,
+                    module_qn=owner_module_qn,
+                    base_index=0,
+                    language=cs.SupportedLanguage.RUST,
+                    alt_parent_qn=alt_trait_qn,
                 )
-            )
-            # Record the implementer so a Rust trait call to the sole concrete
-            # impl redirects, matching the class-declaration IMPLEMENTS path.
-            self.interface_implementers.setdefault(trait_qn, set()).add(class_qn)
+                self._deferred_inherits.append(trait_entry)
+                # Collect this block's methods against the trait AS WRITTEN: if
+                # the trait belongs to another crate, its dispatch is the only
+                # caller they can ever have (issue #1048). The decision waits
+                # for resolve_deferred_inherits, when every first-party trait
+                # is registered.
+                trait_impl_method_qns = impl_method_qns
+                self._rust_trait_impls.append(
+                    RustTraitImpl(
+                        entry=trait_entry,
+                        spelling=(
+                            rs_utils.extract_impl_trait_path(class_node) or trait_name
+                        ),
+                        method_qns=trait_impl_method_qns,
+                    )
+                )
+                # Record the implementer so a Rust trait call to the sole
+                # concrete impl redirects, matching the class-declaration
+                # IMPLEMENTS path.
+                self.interface_implementers.setdefault(trait_qn, set()).add(class_qn)
 
         body_node = class_node.child_by_field_name("body")
 

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -1270,6 +1270,7 @@ class ClassIngestMixin:
         # from the trait map as no information and guesses (issue #1078).
         impl_method_qns: list[str] = []
         trait_impl_method_qns: list[str] | None = None
+        trait_unrepresentable = False
         if trait_name := rs_utils.extract_impl_trait(class_node):
             trait_qn, alt_trait_qn = self._resolve_rust_trait_qn(
                 rs_utils.extract_impl_trait_path(class_node) or trait_name,
@@ -1313,6 +1314,12 @@ class ClassIngestMixin:
                 # concrete impl redirects, matching the class-declaration
                 # IMPLEMENTS path.
                 self.interface_implementers.setdefault(trait_qn, set()).add(class_qn)
+            else:
+                # The trait path has no referent, so no OVERRIDES target is
+                # knowable: classify these methods as inherent (below) so the
+                # generic override pass never matches them by name against a
+                # DIFFERENT same-named trait the type also implements (#1082).
+                trait_unrepresentable = True
 
         body_node = class_node.child_by_field_name("body")
 
@@ -1397,7 +1404,10 @@ class ClassIngestMixin:
         # The PATH decides, not the name: `extract_impl_trait` reads no name
         # off `impl std::ops::Add<u32> for S`, and calling that inherent would
         # bar a real trait impl's methods from ever overriding.
-        if rs_utils.extract_impl_trait_path(class_node) is None:
+        if (
+            rs_utils.extract_impl_trait_path(class_node) is None
+            or trait_unrepresentable
+        ):
             self.rust_inherent_impl_methods.update(impl_method_qns)
 
     def _ingest_class_methods(

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -2238,7 +2238,7 @@ class ImportProcessor:
 
     def _rust_walk_mods(
         self, parts: list[str], rest: list[str], dir_backed: bool = False
-    ) -> list[str]:
+    ) -> list[str] | None:
         """Walk a path tail from a resolved module prefix, honouring `#[path]`.
 
         Only the crate ENTRY's redirects are read above, and the tail used to
@@ -2256,12 +2256,15 @@ class ImportProcessor:
                 break
             decls, base = found
             redirect = decls.redirects.get(segment)
-            target = (
-                rs_utils.path_attribute_qn_parts(base, redirect) if redirect else None
-            )
-            if redirect is None or target is None:
+            if redirect is None:
                 out, dir_backed = [*out, segment], False
                 continue
+            target = rs_utils.path_attribute_qn_parts(base, redirect)
+            if target is None:
+                # A #[path] the qn scheme cannot key names a file outside the
+                # indexed tree: no module qn is its referent, so decline
+                # rather than attach the name-derived sibling shadow (#1082).
+                return None
             # A redirect onto a `mod.rs` names the DIRECTORY, and the qn
             # scheme drops the `mod` segment, so the resulting parts are
             # indistinguishable from a plain file module: without this the
@@ -2274,9 +2277,10 @@ class ImportProcessor:
     def _rust_join_mods(
         self, parts: list[str], rest: list[str], dir_backed: bool = False
     ) -> str:
-        return cs.SEPARATOR_DOT.join(
-            [self.project_name, *self._rust_walk_mods(parts, rest, dir_backed)]
-        )
+        walked = self._rust_walk_mods(parts, rest, dir_backed)
+        if walked is None:
+            return cs.RUST_UNRESOLVABLE_QN
+        return cs.SEPARATOR_DOT.join([self.project_name, *walked])
 
     def _rust_attach(
         self, dir_parts: list[str], stem: str, rest: list[str], definitive: bool
@@ -2296,13 +2300,18 @@ class ImportProcessor:
             if redirect := chosen.redirects.get(rest[0]):
                 # The declaration names its backing file outright, and the
                 # module keys under that file, so the declared name never
-                # appears in the qn at all (issue #1035).
-                if target := rs_utils.path_attribute_qn_parts(dir_parts, redirect):
-                    return self._rust_join_mods(
-                        target,
-                        rest[1:],
-                        redirect.rsplit(cs.SEPARATOR_SLASH, 1)[-1] == cs.MOD_RS,
-                    )
+                # appears in the qn at all (issue #1035). A target the qn
+                # scheme cannot key names a file outside the indexed tree:
+                # decline rather than fall through to the name-derived
+                # sibling shadow below (issue #1082).
+                target = rs_utils.path_attribute_qn_parts(dir_parts, redirect)
+                if target is None:
+                    return cs.RUST_UNRESOLVABLE_QN
+                return self._rust_join_mods(
+                    target,
+                    rest[1:],
+                    redirect.rsplit(cs.SEPARATOR_SLASH, 1)[-1] == cs.MOD_RS,
+                )
             if rest[0] in file_mods:
                 return self._rust_join_mods([*dir_parts, rest[0]], rest[1:])
             if rest[0] in items:
@@ -2375,6 +2384,8 @@ class ImportProcessor:
         if not rest:
             return base_qn
         walked = self._rust_walk_mods(parts, rest)
+        if walked is None:
+            return cs.RUST_UNRESOLVABLE_QN
         if walked == [*parts, *rest]:
             # No redirect fired, so keep base_qn verbatim rather than
             # rebuilding it from project_name, which re-splits differently

--- a/codebase_rag/parsers/import_processor.py
+++ b/codebase_rag/parsers/import_processor.py
@@ -895,6 +895,11 @@ class ImportProcessor:
                 for full_name in self.import_mapping[module_qn].values():
                     if (module_qn, full_name) in self._cpp_declaration_mappings:
                         continue
+                    if full_name == cs.RUST_UNRESOLVABLE_QN:
+                        # The unrepresentable-#[path] sentinel stays in the map
+                        # for name binding but names no module, so it must never
+                        # become a phantom IMPORTS edge (issue #1082).
+                        continue
                     self._deferred_import_edges.append(
                         DeferredImportEdge(
                             module_qn=module_qn,
@@ -912,6 +917,11 @@ class ImportProcessor:
         # Entry point for import shapes discovered outside parse_imports (the
         # CommonJS destructuring fallback); every IMPORTS edge goes through the same
         # deferred verification.
+        if full_name == cs.RUST_UNRESOLVABLE_QN:
+            # The sentinel names a module the qn scheme cannot key (an
+            # unrepresentable #[path] target): it has no referent, so it must
+            # never become a phantom ExternalModule IMPORTS edge (issue #1082).
+            return
         self._deferred_import_edges.append(
             DeferredImportEdge(
                 module_qn=module_qn, full_name=full_name, language=language

--- a/codebase_rag/tests/test_rust_path_attribute_mod.py
+++ b/codebase_rag/tests/test_rust_path_attribute_mod.py
@@ -667,10 +667,41 @@ def test_use_import_through_unrepresentable_redirect_emits_no_phantom(
     calls = _calls(mock_ingestor)
     base = "rs_unrep_use.src"
     assert (f"{base}.a.run", f"{base}.helpers.fixture") not in calls, calls
+    # The only import in the crate names an unrepresentable module, so no
+    # IMPORTS edge is valid: not the sentinel, and not a shadow fallback.
     imports = _pairs(mock_ingestor, RelationshipType.IMPORTS.value)
-    assert not any(
-        "\x00" in target or "unrepresentable" in target for _src, target in imports
-    ), imports
+    assert not imports, imports
+
+
+def test_inner_unrepresentable_use_shadows_an_outer_same_named_item(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # An inner inline mod's `use` of a name through an unrepresentable #[path]
+    # still OWNS that name inside the mod, shadowing an outer same-named item:
+    # the inner call must drop, not bind the outer fixture (issue #1082).
+    project = temp_repo / "rs_unrep_shadow"
+    _write(
+        project,
+        {
+            "Cargo.toml": ('[package]\nname = "rs_unrep_shadow"\nversion = "0.1.0"\n'),
+            "src/lib.rs": "pub mod a;\n",
+            "src/a.rs": (
+                "pub fn fixture() -> i32 {\n    9\n}\n\n"
+                "pub mod inner {\n"
+                '    #[path = "/nowhere/helpers.rs"]\n'
+                "    mod helpers;\n\n"
+                "    use crate::a::inner::helpers::fixture;\n\n"
+                "    pub fn run() -> i32 {\n"
+                "        fixture()\n"
+                "    }\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    base = "rs_unrep_shadow.src"
+    assert (f"{base}.a.inner.run", f"{base}.a.fixture") not in calls, calls
 
 
 def _scan_cost_per_char(source: str) -> tuple[float, RustEntryDecls]:

--- a/codebase_rag/tests/test_rust_path_attribute_mod.py
+++ b/codebase_rag/tests/test_rust_path_attribute_mod.py
@@ -704,6 +704,35 @@ def test_inner_unrepresentable_use_shadows_an_outer_same_named_item(
     assert (f"{base}.a.inner.run", f"{base}.a.fixture") not in calls, calls
 
 
+def test_impl_of_a_trait_through_unrepresentable_redirect_binds_nothing(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `impl crate::helpers::T for S` where helpers is unrepresentable: the
+    # trait path has no referent, so it must not bind an IMPLEMENTS edge to a
+    # same-named decoy trait the name-anchored fallback would find (#1082).
+    project = temp_repo / "rs_unrep_trait"
+    _write(
+        project,
+        {
+            "Cargo.toml": ('[package]\nname = "rs_unrep_trait"\nversion = "0.1.0"\n'),
+            "src/lib.rs": (
+                '#[path = "/nowhere/helpers.rs"]\nmod helpers;\n\n'
+                "pub mod decoy;\npub mod a;\n"
+            ),
+            "src/decoy.rs": "pub trait T {\n    fn go(&self) -> i32;\n}\n",
+            "src/a.rs": (
+                "pub struct S;\n\n"
+                "impl crate::helpers::T for S {\n"
+                "    fn go(&self) -> i32 {\n        1\n    }\n}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    implements = _pairs(mock_ingestor, RelationshipType.IMPLEMENTS.value)
+    base = "rs_unrep_trait.src"
+    assert (f"{base}.a.S", f"{base}.decoy.T") not in implements, implements
+
+
 def _scan_cost_per_char(source: str) -> tuple[float, RustEntryDecls]:
     """Best-of-three seconds per scanned character, and what was found."""
     top_level = _rs_top_level_only(_rs_strip_comments_and_strings(source))

--- a/codebase_rag/tests/test_rust_path_attribute_mod.py
+++ b/codebase_rag/tests/test_rust_path_attribute_mod.py
@@ -613,6 +613,33 @@ def test_an_absolute_redirect_claims_nothing(
     assert not any("nowhere" in gate for gate in gates), gates
 
 
+def test_an_absolute_redirect_binds_no_crate_path(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The crate-path side must stand down like the gate: a #[path] naming a
+    # file outside the indexed tree has no referent, so crate::helpers must
+    # resolve to nothing rather than fall back to the name-derived sibling
+    # src/helpers.rs, an undeclared shadow the mod never backs (issue #1082).
+    project = temp_repo / "rs_path_attr_abs_call"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_path_attr_abs_call"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": (
+                '#[path = "/nowhere/helpers.rs"]\nmod helpers;\n\npub mod a;\n'
+            ),
+            "src/helpers.rs": "pub fn fixture() -> i32 {\n    1\n}\n",
+            "src/a.rs": ("pub fn run() -> i32 {\n    crate::helpers::fixture()\n}\n"),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    base = "rs_path_attr_abs_call.src"
+    assert (f"{base}.a.run", f"{base}.helpers.fixture") not in calls, calls
+
+
 def _scan_cost_per_char(source: str) -> tuple[float, RustEntryDecls]:
     """Best-of-three seconds per scanned character, and what was found."""
     top_level = _rs_top_level_only(_rs_strip_comments_and_strings(source))

--- a/codebase_rag/tests/test_rust_path_attribute_mod.py
+++ b/codebase_rag/tests/test_rust_path_attribute_mod.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 from codebase_rag import constants as cs
+from codebase_rag.constants import RelationshipType
 from codebase_rag.parsers.import_processor import (
     RustEntryDecls,
     _rs_entry_decls_of,
@@ -21,6 +22,7 @@ from codebase_rag.parsers.import_processor import (
 from codebase_rag.tests.test_rust_cfg_test_mod_declarations import _declared_gates
 from codebase_rag.tests.test_rust_crate_path_trait_linking import (
     _calls,
+    _pairs,
     _write,
     create_and_run_updater,
 )
@@ -638,6 +640,37 @@ def test_an_absolute_redirect_binds_no_crate_path(
     calls = _calls(mock_ingestor)
     base = "rs_path_attr_abs_call.src"
     assert (f"{base}.a.run", f"{base}.helpers.fixture") not in calls, calls
+
+
+def test_use_import_through_unrepresentable_redirect_emits_no_phantom(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # A `use` of an item from an unrepresentable-#[path] module must not bind
+    # the name-derived shadow src/helpers.rs, and the unresolvable sentinel
+    # must never leak out as a phantom IMPORTS edge (issue #1082).
+    project = temp_repo / "rs_unrep_use"
+    _write(
+        project,
+        {
+            "Cargo.toml": ('[package]\nname = "rs_unrep_use"\nversion = "0.1.0"\n'),
+            "src/lib.rs": (
+                '#[path = "/nowhere/helpers.rs"]\nmod helpers;\n\npub mod a;\n'
+            ),
+            "src/helpers.rs": "pub fn fixture() -> i32 {\n    1\n}\n",
+            "src/a.rs": (
+                "use crate::helpers::fixture;\n\npub fn run() -> i32 {\n"
+                "    fixture()\n}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    calls = _calls(mock_ingestor)
+    base = "rs_unrep_use.src"
+    assert (f"{base}.a.run", f"{base}.helpers.fixture") not in calls, calls
+    imports = _pairs(mock_ingestor, RelationshipType.IMPORTS.value)
+    assert not any(
+        "\x00" in target or "unrepresentable" in target for _src, target in imports
+    ), imports
 
 
 def _scan_cost_per_char(source: str) -> tuple[float, RustEntryDecls]:

--- a/codebase_rag/tests/test_rust_path_attribute_mod.py
+++ b/codebase_rag/tests/test_rust_path_attribute_mod.py
@@ -708,8 +708,10 @@ def test_impl_of_a_trait_through_unrepresentable_redirect_binds_nothing(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:
     # `impl crate::helpers::T for S` where helpers is unrepresentable: the
-    # trait path has no referent, so it must not bind an IMPLEMENTS edge to a
-    # same-named decoy trait the name-anchored fallback would find (#1082).
+    # trait path has no referent, so it binds no IMPLEMENTS edge to a
+    # same-named decoy trait the name-anchored fallback would find, and its
+    # methods must not misbind as OVERRIDES of another trait S implements
+    # whose method shares the name (#1082).
     project = temp_repo / "rs_unrep_trait"
     _write(
         project,
@@ -717,20 +719,25 @@ def test_impl_of_a_trait_through_unrepresentable_redirect_binds_nothing(
             "Cargo.toml": ('[package]\nname = "rs_unrep_trait"\nversion = "0.1.0"\n'),
             "src/lib.rs": (
                 '#[path = "/nowhere/helpers.rs"]\nmod helpers;\n\n'
-                "pub mod decoy;\npub mod a;\n"
+                "pub mod decoy;\npub mod other;\npub mod a;\n"
             ),
             "src/decoy.rs": "pub trait T {\n    fn go(&self) -> i32;\n}\n",
+            "src/other.rs": "pub trait Other {\n    fn go(&self) -> i32;\n}\n",
             "src/a.rs": (
                 "pub struct S;\n\n"
                 "impl crate::helpers::T for S {\n"
-                "    fn go(&self) -> i32 {\n        1\n    }\n}\n"
+                "    fn go(&self) -> i32 {\n        1\n    }\n}\n\n"
+                "impl crate::other::Other for S {\n"
+                "    fn go(&self) -> i32 {\n        2\n    }\n}\n"
             ),
         },
     )
     create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
-    implements = _pairs(mock_ingestor, RelationshipType.IMPLEMENTS.value)
     base = "rs_unrep_trait.src"
+    implements = _pairs(mock_ingestor, RelationshipType.IMPLEMENTS.value)
     assert (f"{base}.a.S", f"{base}.decoy.T") not in implements, implements
+    overrides = _pairs(mock_ingestor, RelationshipType.OVERRIDES.value)
+    assert (f"{base}.a.S.go", f"{base}.decoy.T.go") not in overrides, overrides
 
 
 def _scan_cost_per_char(source: str) -> tuple[float, RustEntryDecls]:


### PR DESCRIPTION
Closes #1082.

## The bug
A `#[path]` naming a file the qn scheme cannot key (an absolute path, a Windows separator, or a climb above the repository root) makes `path_attribute_qn_parts` return `None`. The gate side already stands down for these targets, but the crate-path side did not: it treated the redirect exactly like a declaration with no redirect and fell back to the name-derived module, binding an undeclared sibling shadow that happens to sit where the name points.

```
src/lib.rs      #[path = "/nowhere/helpers.rs"] mod helpers; pub mod a;
src/helpers.rs  pub fn fixture() -> i32 { 1 }        // declared by nobody
src/a.rs        pub fn run() -> i32 { crate::helpers::fixture() }
```

Actual: `a.run -> src.helpers.fixture` (the shadow). Expected: no edge.

## Fix
Give the resolvers a way to say "no qn names this module" rather than a spelling, via a shared sentinel `cs.RUST_UNRESOLVABLE_QN` (contains a NUL, so it equals no real qn but stays an ordinary `str`, so nothing that sorts or formats resolved qns breaks):

- `_rust_walk_mods` returns `None` when a redirect is present but unrepresentable (instead of appending the name); `_rust_join_mods` and `_rust_resolve_relative` surface that as the sentinel.
- `_rust_attach` returns the sentinel at its redirect branch instead of falling through to the name-derived `rest[0] in file_mods` probe.
- In `call_resolver`, a crate/self/super path that resolves to the sentinel is a **decided drop** (`None, True`), so no weaker fallback binds the shadow — mirroring how the gate stands down.

Both bug sites (`_rust_attach`, `_rust_walk_mods`) now classify the same thing the same way.

## Tests
- `test_an_absolute_redirect_binds_no_crate_path` (RED-verified): the repro above; asserts no `a.run -> helpers.fixture` edge. Reverting the fix restores the shadow binding.
- The existing gate tests (`test_an_absolute_redirect_claims_nothing`, `test_a_drive_qualified_redirect_claims_nothing`) and the representable-redirect crate-path tests stay green.
- Core Rust resolution suites (`test_rust_crate_path_trait_linking`, `test_rust_path_attribute_mod`, `test_rust_cfg_test_mod_declarations`): 177 passed, 2 skipped. Lint + type-check clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Rust module path resolution for `#[path]` redirects.
  * Prevented unresolved paths from incorrectly falling back to similarly named sibling modules or outer-scope bindings.
  * Avoided synthetic trait targets, phantom calls, and import relationships for unrepresentable module paths.
  * Preserved valid path-derived module candidates while excluding unresolved ones.

* **Tests**
  * Added regression coverage for absolute Rust path redirects, unresolved sibling targets, and imports through invalid redirects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->