### PR TITLE
fix: give an inline mod under a trait or impl body a consistent qn (#1018)

### DIFF
--- a/codebase_rag/parsers/class_ingest/identity.py
+++ b/codebase_rag/parsers/class_ingest/identity.py
@@ -117,12 +117,18 @@ def build_nested_qualified_name_for_class(
     module_qn: str,
     class_name: str,
     lang_config: LanguageSpec,
+    include_impl_targets: bool = False,
 ) -> str | None:
     if not isinstance(class_node.parent, Node):
         return None
 
+    # An inline mod under an `impl Type` body keys under that target
+    # (foo.S.inner), exactly as the items inside it do, so their DEFINES chain
+    # agrees with the Module node (issue #1018). Class/struct qns keep the
+    # default (impl targets excluded) so this stays opt-in.
     path_parts = rs_utils.build_module_path(
         class_node,
+        include_impl_targets=include_impl_targets,
         include_classes=True,
         class_node_types=lang_config.class_node_types,
     )

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -1700,7 +1700,11 @@ class ClassIngestMixin:
 
             module_name = safe_decode_text(module_name_node)
             nested_qn = id_.build_nested_qualified_name_for_class(
-                module_node, module_qn, module_name or "", lang_config
+                module_node,
+                module_qn,
+                module_name or "",
+                lang_config,
+                include_impl_targets=True,
             )
             inline_module_qn = nested_qn or f"{module_qn}.{module_name}"
 
@@ -1739,8 +1743,17 @@ class ClassIngestMixin:
 
             # Link the inline module into the containment tree: its enclosing
             # module (file module, or an outer mod) DEFINES it. Without this the
-            # inline Module node is an orphan defining nothing.
-            parent_module_qn = inline_module_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
+            # inline Module node is an orphan defining nothing. The parent is
+            # the nearest enclosing MODULE, not the qn's rsplit prefix: a mod
+            # under a trait/impl body keeps the class scope in its qn
+            # (foo.T.inner), whose prefix foo.T is the TRAIT node, not a module,
+            # so a Module->Module DEFINES to it would dangle (issue #1018).
+            enclosing_mods = rs_utils.build_module_path(module_node)
+            parent_module_qn = (
+                f"{module_qn}{cs.SEPARATOR_DOT}{cs.SEPARATOR_DOT.join(enclosing_mods)}"
+                if enclosing_mods
+                else module_qn
+            )
             if parent_module_qn and parent_module_qn != inline_module_qn:
                 self.ingestor.ensure_relationship_batch(
                     (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, parent_module_qn),

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -1744,16 +1744,35 @@ class ClassIngestMixin:
             # Link the inline module into the containment tree: its enclosing
             # module (file module, or an outer mod) DEFINES it. Without this the
             # inline Module node is an orphan defining nothing. The parent is
-            # the nearest enclosing MODULE, not the qn's rsplit prefix: a mod
-            # under a trait/impl body keeps the class scope in its qn
-            # (foo.T.inner), whose prefix foo.T is the TRAIT node, not a module,
-            # so a Module->Module DEFINES to it would dangle (issue #1018).
-            enclosing_mods = rs_utils.build_module_path(module_node)
-            parent_module_qn = (
-                f"{module_qn}{cs.SEPARATOR_DOT}{cs.SEPARATOR_DOT.join(enclosing_mods)}"
-                if enclosing_mods
-                else module_qn
-            )
+            # the nearest enclosing MODULE node, whose qn is rebuilt with the
+            # same scoped construction used to register it. Neither the qn's
+            # rsplit prefix nor a mods-only re-walk works: under a trait/impl
+            # body a mod keeps the class scope in its qn (foo.T.outer), so the
+            # prefix foo.T is the TRAIT node (not a module), and a mods-only
+            # walk drops that scope to foo.outer (which does not exist) — either
+            # way the Module->Module DEFINES dangles (issues #1018, nested #1166).
+            enclosing_module_node = module_node.parent
+            while (
+                enclosing_module_node is not None
+                and enclosing_module_node.type != cs.TS_RS_MOD_ITEM
+            ):
+                enclosing_module_node = enclosing_module_node.parent
+            if enclosing_module_node is not None:
+                enclosing_name = safe_decode_text(
+                    enclosing_module_node.child_by_field_name(cs.FIELD_NAME)
+                )
+                parent_module_qn = (
+                    id_.build_nested_qualified_name_for_class(
+                        enclosing_module_node,
+                        module_qn,
+                        enclosing_name or "",
+                        lang_config,
+                        include_impl_targets=True,
+                    )
+                    or f"{module_qn}{cs.SEPARATOR_DOT}{enclosing_name}"
+                )
+            else:
+                parent_module_qn = module_qn
             if parent_module_qn and parent_module_qn != inline_module_qn:
                 self.ingestor.ensure_relationship_batch(
                     (cs.NodeLabel.MODULE, cs.KEY_QUALIFIED_NAME, parent_module_qn),

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -2086,13 +2086,16 @@ class FunctionIngestMixin:
 
             current = current.parent
 
-        # A Rust item inside `mod inner` is contained by that inline module, not the
-        # file module. Its enclosing module qn is the file module plus the mod path;
-        # the inline Module node carries that exact qn.
-        if language == cs.SupportedLanguage.RUST and (
-            mod_parts := rs_utils.build_module_path(func_node)
+        # A Rust item inside `mod inner` is contained by that inline module, not
+        # the file module. Its enclosing module qn is the item's OWN qn minus the
+        # item segment: re-deriving the mod path with build_module_path drops the
+        # class scope an inline mod under a trait/impl body carries (foo.inner vs
+        # foo.T.inner), so the DEFINES edge dangles off the inline Module node,
+        # which keeps that scope (issue #1018). The item qn already carries it.
+        if language == cs.SupportedLanguage.RUST and rs_utils.build_module_path(
+            func_node
         ):
-            nested = module_qn + cs.SEPARATOR_DOT + cs.SEPARATOR_DOT.join(mod_parts)
+            nested = func_qn.rsplit(cs.SEPARATOR_DOT, 1)[0]
             return cs.NodeLabel.MODULE, nested, None
 
         return cs.NodeLabel.MODULE, module_qn, None

--- a/codebase_rag/tests/test_rust_crate_path_trait_linking.py
+++ b/codebase_rag/tests/test_rust_crate_path_trait_linking.py
@@ -6340,3 +6340,48 @@ def test_inline_mod_in_an_impl_body_has_consistent_module_and_defines_qns(
     defines = _pairs(mock_ingestor, RelationshipType.DEFINES.value)
     assert (f"{base}.foo", f"{base}.foo.S.inner") in defines, defines
     assert (f"{base}.foo.S.inner", f"{base}.foo.S.inner.g") in defines, defines
+
+
+def test_nested_inline_mods_in_a_trait_body_keep_the_scoped_parent_qn(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # A mod nested inside another mod inside a trait body: the inner mod's
+    # enclosing-module DEFINES must point at the outer mod's SCOPED qn
+    # (foo.T.outer), not a mods-only re-walk that drops the trait scope to
+    # foo.outer (a node that does not exist), which would dangle the edge
+    # (CodeRabbit review on PR #1166).
+    project = temp_repo / "rs_nested_inline_mod_trait"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_nested_inline_mod_trait"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": "pub mod foo;\n",
+            "src/foo.rs": (
+                "pub trait T {\n"
+                "    const C: u32 = {\n"
+                "        mod outer {\n"
+                "            pub mod inner {\n"
+                "                pub const fn g() -> u32 {\n                    1\n                }\n"
+                "            }\n"
+                "        }\n"
+                "        outer::inner::g()\n"
+                "    };\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    base = "rs_nested_inline_mod_trait.src"
+    modules = _module_qns(mock_ingestor)
+    assert f"{base}.foo.T.outer" in modules, modules
+    assert f"{base}.foo.T.outer.inner" in modules, modules
+    assert f"{base}.foo.outer" not in modules, modules
+    defines = _pairs(mock_ingestor, RelationshipType.DEFINES.value)
+    assert (f"{base}.foo", f"{base}.foo.T.outer") in defines, defines
+    assert (f"{base}.foo.T.outer", f"{base}.foo.T.outer.inner") in defines, defines
+    assert (
+        f"{base}.foo.T.outer.inner",
+        f"{base}.foo.T.outer.inner.g",
+    ) in defines, defines

--- a/codebase_rag/tests/test_rust_crate_path_trait_linking.py
+++ b/codebase_rag/tests/test_rust_crate_path_trait_linking.py
@@ -6255,3 +6255,88 @@ def test_two_bodied_cfg_twin_mods_keep_separate_uses(
     assert (f"{base}.foo.run.gb", f"{base}.beta.helper") in calls, calls
     assert (f"{base}.foo.run.ga", f"{base}.beta.helper") not in calls, calls
     assert (f"{base}.foo.run.gb", f"{base}.alpha.helper") not in calls, calls
+
+
+def _module_qns(mock_ingestor: MagicMock) -> set[str]:
+    return {
+        props["qualified_name"]
+        for label, props in (
+            c[0] for c in mock_ingestor.ensure_node_batch.call_args_list
+        )
+        if label == "Module"
+    }
+
+
+def test_inline_mod_in_a_trait_body_has_consistent_module_and_defines_qns(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # An inline mod in a trait const initializer keeps the trait scope in its
+    # qn (foo.T.inner). Its Module node, the DEFINES from its enclosing module,
+    # and the DEFINES to its own functions must all agree, or the graph audit
+    # reports an orphan module and a dangling edge (issue #1018).
+    project = temp_repo / "rs_inline_mod_trait"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_inline_mod_trait"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": "pub mod foo;\n",
+            "src/foo.rs": (
+                "pub trait T {\n"
+                "    const C: u32 = {\n"
+                "        mod inner {\n"
+                "            pub const fn g() -> u32 {\n                1\n            }\n"
+                "        }\n"
+                "        inner::g()\n"
+                "    };\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    base = "rs_inline_mod_trait.src"
+    modules = _module_qns(mock_ingestor)
+    assert f"{base}.foo.T.inner" in modules, modules
+    assert f"{base}.foo.inner" not in modules, modules
+    defines = _pairs(mock_ingestor, RelationshipType.DEFINES.value)
+    assert (f"{base}.foo", f"{base}.foo.T.inner") in defines, defines
+    assert (f"{base}.foo.T.inner", f"{base}.foo.T.inner.g") in defines, defines
+
+
+def test_inline_mod_in_an_impl_body_has_consistent_module_and_defines_qns(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The impl-body variant: the items inside key under the impl target
+    # (foo.S.inner.g), so the inline Module node keys as foo.S.inner too, and
+    # its enclosing-module DEFINES and function DEFINES must agree (issue
+    # #1018).
+    project = temp_repo / "rs_inline_mod_impl"
+    _write(
+        project,
+        {
+            "Cargo.toml": (
+                '[package]\nname = "rs_inline_mod_impl"\nversion = "0.1.0"\n'
+            ),
+            "src/lib.rs": "pub mod foo;\n",
+            "src/foo.rs": (
+                "pub struct S;\n\n"
+                "impl S {\n"
+                "    pub const C: u32 = {\n"
+                "        mod inner {\n"
+                "            pub const fn g() -> u32 {\n                1\n            }\n"
+                "        }\n"
+                "        inner::g()\n"
+                "    };\n"
+                "}\n"
+            ),
+        },
+    )
+    create_and_run_updater(project, mock_ingestor, skip_if_missing="rust")
+    base = "rs_inline_mod_impl.src"
+    modules = _module_qns(mock_ingestor)
+    assert f"{base}.foo.S.inner" in modules, modules
+    assert f"{base}.foo.inner" not in modules, modules
+    defines = _pairs(mock_ingestor, RelationshipType.DEFINES.value)
+    assert (f"{base}.foo", f"{base}.foo.S.inner") in defines, defines
+    assert (f"{base}.foo.S.inner", f"{base}.foo.S.inner.g") in defines, defines


### PR DESCRIPTION
Closes #1018.

## The bug
An inline `mod` declared inside a trait or impl body (e.g. in a const initializer) produced three qns that disagreed, so `graph_audit` reported an orphan Module node and dangling DEFINES edges:

- Module node: `foo.T.inner` (trait) / `foo.inner` (impl — impl target dropped)
- Function DEFINES parent: `foo.inner` (class/trait scope dropped)
- Contained functions: `foo.T.inner.g` / `foo.S.inner.g` (scope kept)

So `foo.T.inner` had no outgoing DEFINES (orphan), `foo.inner -> ...g` dangled, and `(Module foo.T) -> ...` referenced a trait node as if it were a module.

## Fix — make node, containment, and items agree
Three aligned changes so the inline mod, its enclosing-module DEFINES, and its items all key the same way:

1. **Module node qn** (`build_nested_qualified_name_for_class`, opt-in `include_impl_targets`): a mod under `impl S` now keys `foo.S.inner`, matching the items inside it (`foo.S.inner.g`), exactly as a mod under `trait T` already keyed `foo.T.inner`. Class/struct qns keep the old default, so the change is scoped to the inline-module caller.
2. **Function DEFINES parent** (`_determine_function_parent`): derived from the item’s OWN qn (`func_qn.rsplit`) instead of a mods-only re-walk that dropped the class scope, so it always matches the item and its Module node.
3. **Inline-module DEFINES parent** (`_process_inline_modules`): the nearest enclosing MODULE (via a mods-only walk), not the qn’s rsplit prefix — a mod under a trait/impl has a class node (not a module) as that prefix, which would dangle.

## Tests
- `test_inline_mod_in_a_trait_body_...` and `test_inline_mod_in_an_impl_body_...` (both new): assert the Module node exists at the expected qn and both DEFINES edges (`module -> inline mod`, `inline mod -> its fn`) are present and consistent. The conftest graph-audit (which raised the original violations) now passes for both fixtures.
- Full Rust suites: 177 passed, 2 skipped, no regressions. Lint + type-check clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Rust code navigation and indexing for inline modules nested within traits, implementations, and associated constants.
  * Preserved accurate qualified names and containment relationships for nested functions and modules.

* **Tests**
  * Added regression coverage for complex Rust trait, implementation, and nested-module scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->