### PR TITLE
docs: state real 10-language FLOWS_TO coverage and add a per-language table (#1172)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,5 +11,5 @@ release workflow also prepends feature entries via `scripts/update_news.py`
 
 - **Ruby Support**: Ruby joins the graph through a new pluggable ast-grep tier that adds a language from a single YAML pattern file, emitting `Module`, `Function`, and `Class` nodes plus import edges without a hand-written parser.
 - **Structural Search & Replace**: Find and rewrite code by AST pattern with ast-grep, exposed as agent tools so you can match and transform structure across the whole codebase instead of relying on text or regex.
-- **Data-Flow Tracing**: New `FLOWS_TO` taint edges follow values through assignments, function calls, and I/O sinks, with coverage across C#, Java, C, and Go.
+- **Data-Flow Tracing**: New `FLOWS_TO` taint edges follow values through assignments, function calls, and I/O sinks. This release adds C#, Java, C, and Go, bringing tracing to 10 languages (Python, JavaScript, TypeScript/TSX, Go, Java, Rust, C++, C, and C#).
 - **C# and Dart Support**: Full C# (with Roslyn semantic analysis) and Dart/Flutter now join the graph, bringing the total to 14 supported languages.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Code-Graph-RAG parses a multi-language codebase with Tree-sitter, builds a knowl
 <!-- SECTION:latest_news -->
 - **Ruby Support**: Ruby joins the graph through a new pluggable ast-grep tier that adds a language from a single YAML pattern file, emitting `Module`, `Function`, and `Class` nodes plus import edges without a hand-written parser.
 - **Structural Search & Replace**: Find and rewrite code by AST pattern with ast-grep, exposed as agent tools so you can match and transform structure across the whole codebase instead of relying on text or regex.
-- **Data-Flow Tracing**: New `FLOWS_TO` taint edges follow values through assignments, function calls, and I/O sinks, with coverage across C#, Java, C, and Go.
+- **Data-Flow Tracing**: New `FLOWS_TO` taint edges follow values through assignments, function calls, and I/O sinks. This release adds C#, Java, C, and Go, bringing tracing to 10 languages (Python, JavaScript, TypeScript/TSX, Go, Java, Rust, C++, C, and C#).
 <!-- /SECTION:latest_news -->
 
 See [NEWS.md](NEWS.md) for the full history.

--- a/docs/architecture/data-flow-edges.md
+++ b/docs/architecture/data-flow-edges.md
@@ -386,6 +386,33 @@ module is re-exported under its own name. A project that does
 These are deliberate ceilings, chosen so the feature is correct and cheap where
 it applies rather than broad and noisy.
 
+## Language coverage
+
+`FLOWS_TO` covers **10 of the 14 supported languages** — every language whose
+source/sink table is registered in `FLOW_REGISTERED_LANGUAGES`
+(`codebase_rag/parsers/io_access/registry.py`). Python uses the deep,
+path-sensitive walk; the rest use the descriptor-driven lean walk. A language
+outside this set is still parsed into the graph — it simply emits no `FLOWS_TO`
+edges, so a reachability question over it returns `UNKNOWN` rather than
+`NO_FLOW` (see the three-verdict query below).
+
+| Language | `FLOWS_TO` | Walk |
+| --- | --- | --- |
+| Python | ✅ | deep, path-sensitive |
+| JavaScript | ✅ | lean descriptor |
+| TypeScript | ✅ | lean descriptor |
+| TSX | ✅ | lean descriptor |
+| Go | ✅ | lean descriptor |
+| Java | ✅ | lean descriptor |
+| Rust | ✅ | lean descriptor |
+| C++ | ✅ | lean descriptor |
+| C | ✅ | lean descriptor |
+| C# | ✅ | lean descriptor |
+| Lua | ❌ | not covered — no sink table |
+| PHP | ❌ | not covered — no sink table |
+| Scala | ❌ | not covered — no sink table |
+| Dart | ❌ | not covered — no sink table |
+
 ## Coverage metadata and the three-verdict query
 
 An empty flow result is ambiguous on its own: "no flow exists" and "the flow


### PR DESCRIPTION
Closes #1172.

## Problem
The latest-release bullet in `README.md` / `NEWS.md` read as the *full* FLOWS_TO support matrix — "data flow only works in C#, Java, C, Go" — when those are merely the languages that release *added*. The landing site renders this bullet, so it understated real coverage.

## Actual coverage
`FLOW_REGISTERED_LANGUAGES` (derived from `IO_SINKS`) covers **10 of the 14** supported languages: Python (deep walk) + JavaScript, TypeScript, TSX, Go, Java, Rust, C++, C, C# (lean walk). Uncovered: Lua, PHP, Scala, Dart (`flow_covered: false`; `flow_verdict` reports UNKNOWN, the #1050 behaviour).

## Fix
- Reworded the NEWS/README bullet to state the real 10-language coverage and frame C#/Java/C/Go as the languages *added* that release.
- Added a per-language `FLOWS_TO` coverage table (10 covered + 4 uncovered, with walk type) to `docs/architecture/data-flow-edges.md` as the authoritative, linkable source.
- Regenerated the README section from NEWS via `scripts/generate_readme.py`.

## Acceptance
- The bullet can no longer be read as a 4-language matrix.
- Docs contain an explicit table naming the 10 covered and 4 uncovered languages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release information to list the 10 languages supported by data-flow tracing: Python, JavaScript, TypeScript/TSX, Go, Java, Rust, C++, C, and C#.
  * Added language-coverage details for data-flow edges across 14 languages.
  * Documented differences in tracing behavior and clarified that unsupported languages produce no flow edges and return `UNKNOWN` for reachability queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->