### PR TITLE
docs: correct stale lean flow-walk comments to the current path-sensitive behaviour

### DIFF
--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -582,8 +582,10 @@ class FlowProcessor:
         else:
             # Flat-language path-sensitive MAY walk (issue #714 follow-up):
             # if/loop/try/switch/match nodes branch-and-merge like the JS walk
-            # (loops union the skip path and re-walk once for loop-carried
-            # taint, try seeds each handler with union(pre, body_exit)), and
+            # (zero-or-more loops union the skip path and re-walk once for
+            # loop-carried taint -- do-while/Rust `loop` bodies always run, so
+            # their pre-state stays out of the merge -- and try seeds each
+            # handler with union(pre, body_exit)), and
             # the live shadow set is snapshotted per branch and restored at the
             # merge, so a block-scoped Go/Java declaration inside a branch does
             # not leak its shadow past the join.

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -548,7 +548,7 @@ class FlowProcessor:
         if self._acc_returns_taint:
             self._summaries[caller_qn] = self._acc_return_taint
 
-    # Lean non-Python (JS/TS) straight-line flow (issue #714) below.
+    # Lean non-Python path-sensitive flow (issue #714) below.
     def _process_lean_flow(
         self,
         caller_node: Node,
@@ -580,14 +580,13 @@ class FlowProcessor:
             for node in statements:
                 tainted = self._walk_js_stmt(node, tainted, jc)
         else:
-            # Go/Java path-sensitive MAY walk (issue #714 follow-up): an
-            # if_statement branches-and-merges like the JS walk (its condition/
-            # consequence/alternative fields are shared across the grammars), and
+            # Flat-language path-sensitive MAY walk (issue #714 follow-up):
+            # if/loop/try/switch/match nodes branch-and-merge like the JS walk
+            # (loops union the skip path and re-walk once for loop-carried
+            # taint, try seeds each handler with union(pre, body_exit)), and
             # the live shadow set is snapshotted per branch and restored at the
-            # merge, so a block-scoped Go/Java declaration inside a branch does not
-            # leak its shadow past the join. Loops and try are walked straight-line
-            # (one source-order pass), matching the previous flat behaviour --
-            # loop-carried and per-branch try taint stay a follow-up.
+            # merge, so a block-scoped Go/Java declaration inside a branch does
+            # not leak its shadow past the join.
             for node in statements:
                 tainted = self._walk_flat_stmt(node, tainted, jc)
         if self._acc_returns_taint:


### PR DESCRIPTION
Two comments in `codebase_rag/parsers/flow_access/processor.py` still describe the lean flow walk as it was before the #714 path-sensitivity follow-ups landed:

- The section header called the lean walk "(JS/TS) straight-line flow" — it now covers all nine non-Python languages and is path-sensitive.
- The flat-walk branch comment claimed "Loops and try are walked straight-line (one source-order pass) … loop-carried and per-branch try taint stay a follow-up." That follow-up has landed: `_walk_flat_stmt` routes loops to `_walk_flat_loop` (two-pass skip-path union that catches loop-carried taint), try to `_walk_flat_try` (each handler seeded with union(pre, body_exit)), plus the switch/match walkers.

Comment-only change — no behaviour touched, so no new tests. The third "straight-line" occurrence (in `_walk_flat_mandatory_loop`) is accurate and left alone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how non-Python flow analysis follows paths through conditionals, loops, try/catch logic, switch statements, and pattern matching.
  * Documented handling of values carried across loop iterations and restoration of branch-local changes.
  * Updated guidance to better explain analysis results for complex control structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->