### PR TITLE
fix: derive orchestrator prompt tool names from AgenticToolName so the prompt matches the registered tools

### DIFF
--- a/codebase_rag/prompts.py
+++ b/codebase_rag/prompts.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING
 
+from loguru import logger
+
 from .cypher_queries import (
     CYPHER_EXAMPLE_CLASS_METHODS,
     CYPHER_EXAMPLE_CODE_SMELLS,
@@ -17,6 +19,7 @@ from .cypher_queries import (
     CYPHER_EXAMPLE_TASKS,
 )
 from .schema_builder import GRAPH_SCHEMA_DEFINITION
+from .tools.tool_descriptions import AgenticToolName
 from .types_defs import ToolNames
 
 if TYPE_CHECKING:
@@ -24,16 +27,23 @@ if TYPE_CHECKING:
 
 
 def extract_tool_names(tools: list["Tool"]) -> ToolNames:
-    tool_map = {t.name: t.name for t in tools}
+    registered = {t.name for t in tools}
+
+    def pick(canonical: AgenticToolName) -> str:
+        if canonical not in registered:
+            logger.warning(
+                f"Tool '{canonical}' is not registered on the agent; "
+                "the orchestrator prompt references it anyway"
+            )
+        return str(canonical)
+
     return ToolNames(
-        query_graph=tool_map.get(
-            "query_codebase_knowledge_graph", "query_codebase_knowledge_graph"
-        ),
-        read_file=tool_map.get("read_file_content", "read_file_content"),
-        semantic_search=tool_map.get("semantic_code_search", "semantic_code_search"),
-        create_file=tool_map.get("create_new_file", "create_new_file"),
-        edit_file=tool_map.get("replace_code_surgically", "replace_code_surgically"),
-        shell_command=tool_map.get("execute_shell_command", "execute_shell_command"),
+        query_graph=pick(AgenticToolName.QUERY_GRAPH),
+        read_file=pick(AgenticToolName.READ_FILE),
+        semantic_search=pick(AgenticToolName.SEMANTIC_SEARCH),
+        create_file=pick(AgenticToolName.CREATE_FILE),
+        edit_file=pick(AgenticToolName.REPLACE_CODE),
+        shell_command=pick(AgenticToolName.EXECUTE_SHELL),
     )
 
 

--- a/codebase_rag/prompts.py
+++ b/codebase_rag/prompts.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 def extract_tool_names(tools: list["Tool"]) -> ToolNames:
     registered = {t.name for t in tools}
 
-    def pick(canonical: AgenticToolName) -> str:
+    def resolve_tool_name(canonical: AgenticToolName) -> str:
         if canonical not in registered:
             logger.warning(
                 f"Tool '{canonical}' is not registered on the agent; "
@@ -38,12 +38,12 @@ def extract_tool_names(tools: list["Tool"]) -> ToolNames:
         return str(canonical)
 
     return ToolNames(
-        query_graph=pick(AgenticToolName.QUERY_GRAPH),
-        read_file=pick(AgenticToolName.READ_FILE),
-        semantic_search=pick(AgenticToolName.SEMANTIC_SEARCH),
-        create_file=pick(AgenticToolName.CREATE_FILE),
-        edit_file=pick(AgenticToolName.REPLACE_CODE),
-        shell_command=pick(AgenticToolName.EXECUTE_SHELL),
+        query_graph=resolve_tool_name(AgenticToolName.QUERY_GRAPH),
+        read_file=resolve_tool_name(AgenticToolName.READ_FILE),
+        semantic_search=resolve_tool_name(AgenticToolName.SEMANTIC_SEARCH),
+        create_file=resolve_tool_name(AgenticToolName.CREATE_FILE),
+        edit_file=resolve_tool_name(AgenticToolName.REPLACE_CODE),
+        shell_command=resolve_tool_name(AgenticToolName.EXECUTE_SHELL),
     )
 
 

--- a/codebase_rag/tests/test_prompt_tool_names.py
+++ b/codebase_rag/tests/test_prompt_tool_names.py
@@ -1,0 +1,62 @@
+"""Regression tests for issue #1199: the orchestrator system prompt must only
+reference tool names that are actually registered on the agent."""
+
+from pydantic_ai import Tool
+
+from codebase_rag.prompts import build_rag_orchestrator_prompt, extract_tool_names
+from codebase_rag.tools.tool_descriptions import AgenticToolName
+
+STALE_TOOL_NAMES = (
+    "query_codebase_knowledge_graph",
+    "read_file_content",
+    "semantic_code_search",
+    "create_new_file",
+    "replace_code_surgically",
+    "execute_shell_command",
+)
+
+
+def _noop(**kwargs: object) -> str:
+    return ""
+
+
+def _all_registered_tools() -> list[Tool]:
+    return [
+        Tool(function=_noop, name=str(name), description=str(name), takes_ctx=False)
+        for name in AgenticToolName
+    ]
+
+
+def test_extract_tool_names_returns_registered_names() -> None:
+    tools = _all_registered_tools()
+    registered = {tool.name for tool in tools}
+
+    names = extract_tool_names(tools)
+
+    for field, value in names._asdict().items():
+        assert value in registered, f"{field} resolved to unregistered '{value}'"
+
+
+def test_prompt_references_registered_names_not_stale_ones() -> None:
+    tools = _all_registered_tools()
+    registered = {tool.name for tool in tools}
+
+    prompt = build_rag_orchestrator_prompt(tools)
+
+    for stale in STALE_TOOL_NAMES:
+        assert stale not in prompt
+    for value in extract_tool_names(tools):
+        assert value in registered
+        assert f"`{value}`" in prompt
+
+
+def test_extract_tool_names_tolerates_missing_tool() -> None:
+    tools = [
+        tool
+        for tool in _all_registered_tools()
+        if tool.name != str(AgenticToolName.SEMANTIC_SEARCH)
+    ]
+
+    names = extract_tool_names(tools)
+
+    assert names.semantic_search == str(AgenticToolName.SEMANTIC_SEARCH)


### PR DESCRIPTION
Fixes #1199.

`extract_tool_names()` looked tools up by their pre-rename names (`query_codebase_knowledge_graph`, `read_file_content`, …). Since 5185ab4a every tool registers under its `AgenticToolName` short form, so the lookup always missed and the `.get()` defaults — the same stale long names — were interpolated into the orchestrator system prompt. Models that follow prompt prose (small local models, per the issue's Ollama demonstration) then call a tool name absent from the schema, which is dropped silently and burns the run's request limit on empty turns.

## Change

- `extract_tool_names()` now derives each name from `AgenticToolName` directly, so a future rename cannot drift: the enum is the single source of truth for both registration and prompt text.
- A tool missing from the registered list logs a warning instead of raising, because a legitimate configuration exists where one of the six is absent: the MCP path (`mcp/tools.py`) omits `semantic_search` when the vector backend is unavailable. Raising (as sketched in the issue) would crash that path.

## Tests

`test_prompt_tool_names.py`:
- every name `extract_tool_names()` returns is registered on the agent;
- the built prompt backtick-references all six resolved names and contains none of the six stale ones;
- a tool list without `semantic_search` still resolves to the canonical name without raising (the MCP configuration).

Also ran the issue's pure-Python repro script: all six names now resolve to registered names and the stale name no longer appears in the prompt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool-name handling to consistently use recognized names.
  * Added warnings when expected tools are unavailable while preserving fallback behavior.
  * Updated prompt generation to avoid referencing outdated or unregistered tools.

* **Tests**
  * Added coverage for registered tool names, stale-name exclusion, and missing semantic-search tools.
  * Verified prompts remain accurate when optional tools are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->