### PR TITLE
feat: FLOWS_TO lean-walk coverage for Lua (#1175)

### DIFF
--- a/codebase_rag/constants/ast_lua.py
+++ b/codebase_rag/constants/ast_lua.py
@@ -5,6 +5,7 @@ from .ast_nodes import TS_STRING, TS_STRING_LITERAL
 LUA_STRING_TYPES = (TS_STRING, TS_STRING_LITERAL)
 
 TS_DOT_INDEX_EXPRESSION = "dot_index_expression"
+TS_LUA_BRACKET_INDEX_EXPRESSION = "bracket_index_expression"
 TS_LUA_VARIABLE_DECLARATION = "variable_declaration"
 TS_LUA_ASSIGNMENT_STATEMENT = "assignment_statement"
 TS_LUA_VARIABLE_LIST = "variable_list"
@@ -12,6 +13,11 @@ TS_LUA_EXPRESSION_LIST = "expression_list"
 TS_LUA_FUNCTION_CALL = "function_call"
 TS_LUA_METHOD_INDEX_EXPRESSION = "method_index_expression"
 TS_LUA_IDENTIFIER = "identifier"
+TS_LUA_STRING_CONTENT = "string_content"
+TS_LUA_BLOCK = "block"
+# `dot_index_expression` / `bracket_index_expression` field names: the accessed
+# table is `table`, the member/key is `field`.
+TS_LUA_FIELD_TABLE = "table"
 TS_LUA_LOCAL_STATEMENT = "local_statement"
 LUA_STATEMENT_SUFFIX = "statement"
 LUA_DEFAULT_VAR_TYPES = (TS_LUA_IDENTIFIER,)

--- a/codebase_rag/parsers/io_access/descriptor.py
+++ b/codebase_rag/parsers/io_access/descriptor.py
@@ -133,6 +133,14 @@ class LanguageDescriptor:
     object_url_client_calls: bool = False
     object_literal_type: str | None = None
     pair_type: str | None = None
+    # Container nodes that wrap a binding's targets and values when they are NOT
+    # direct `left`/`right` or `name`/`value` fields on the binding node. Lua's
+    # `assignment_statement` holds its LHS names under a `variable_list` (each a
+    # `name` field) and its RHS values under an `expression_list` (each a `value`
+    # field), so the binding walk descends through these containers. None for the
+    # grammars whose binding node exposes targets/values directly.
+    binding_target_container_type: str | None = None
+    binding_value_container_type: str | None = None
 
 
 _JS_TS_DESCRIPTOR = LanguageDescriptor(
@@ -397,6 +405,41 @@ _CSHARP_DESCRIPTOR = LanguageDescriptor(
     declarator_value_is_last_child=True,
 )
 
+_LUA_DESCRIPTOR = LanguageDescriptor(
+    call_type=cs.TS_LUA_FUNCTION_CALL,
+    string_type=cs.TS_STRING,
+    string_content_type=cs.TS_LUA_STRING_CONTENT,
+    keyword_arg_type=None,
+    nested_scope_types=frozenset(
+        {cs.TS_LUA_FUNCTION_DECLARATION, cs.TS_LUA_FUNCTION_DEFINITION}
+    ),
+    # Lua is declare-at-point (`local x = ...`); a local shadows only later uses.
+    # Sink heads (`os`/`io`/`print`) are globals, not imports, so no import gate.
+    identifier_type=cs.TS_LUA_IDENTIFIER,
+    declarator_type=cs.TS_LUA_ASSIGNMENT_STATEMENT,
+    params_field=cs.FIELD_PARAMETERS,
+    block_scope_type=cs.TS_LUA_BLOCK,
+    extra_declarator_types=frozenset(),
+    loop_declarator_types=frozenset(),
+    statement_container_type=None,
+    sinks_require_import=False,
+    hoisted_declarations=False,
+    decl_in_own_initializer=False,
+    declaration_statement_type=None,
+    macro_type=None,
+    # Inert (no IO_MEMBER_READS for Lua): env access is a call (`os.getenv`).
+    # Wired with Lua's dot/bracket index shapes so a future value-level sink is
+    # right (`table`/`field` fields).
+    member_expression_type=cs.TS_DOT_INDEX_EXPRESSION,
+    subscript_type=cs.TS_LUA_BRACKET_INDEX_EXPRESSION,
+    object_field=cs.TS_LUA_FIELD_TABLE,
+    property_field=cs.FIELD_FIELD,
+    subscript_index_field=cs.FIELD_FIELD,
+    # `local x = os.getenv(..)` binds through list containers (issue #1175).
+    binding_target_container_type=cs.TS_LUA_VARIABLE_LIST,
+    binding_value_container_type=cs.TS_LUA_EXPRESSION_LIST,
+)
+
 # Non-Python languages with a direct-sink descriptor. Python keeps its own
 # handle-aware walk; each new language lands one entry (plus registry rows).
 LANGUAGE_DESCRIPTORS: dict[cs.SupportedLanguage, LanguageDescriptor] = {
@@ -412,4 +455,5 @@ LANGUAGE_DESCRIPTORS: dict[cs.SupportedLanguage, LanguageDescriptor] = {
     # reuses it verbatim.
     cs.SupportedLanguage.C: _CPP_DESCRIPTOR,
     cs.SupportedLanguage.CSHARP: _CSHARP_DESCRIPTOR,
+    cs.SupportedLanguage.LUA: _LUA_DESCRIPTOR,
 }

--- a/codebase_rag/parsers/io_access/extract.py
+++ b/codebase_rag/parsers/io_access/extract.py
@@ -426,6 +426,22 @@ def binding_targets_values(
         return targets, lean_binding_values(
             node.child_by_field_name(cs.FIELD_VALUE), descriptor
         )
+    if (
+        descriptor.binding_target_container_type is not None
+        and node.type == descriptor.declarator_type
+    ):
+        # Lua's `assignment_statement` wraps its targets in a `variable_list`
+        # (each a `name` field) and its values in an `expression_list` (each a
+        # `value` field); a multi-assign `a, b = f(), g()` pairs them by position.
+        container_targets: list[str | None] = []
+        container_values: list[Node] = []
+        for child in node.named_children:
+            if child.type == descriptor.binding_target_container_type:
+                for name in child.children_by_field_name(cs.TS_FIELD_NAME):
+                    container_targets.extend(lean_binding_targets(name, descriptor))
+            elif child.type == descriptor.binding_value_container_type:
+                container_values.extend(child.children_by_field_name(cs.FIELD_VALUE))
+        return container_targets, container_values
     targets = []
     for name in node.children_by_field_name(cs.TS_FIELD_NAME):
         targets.extend(lean_binding_targets(name, descriptor))

--- a/codebase_rag/parsers/io_access/registry.py
+++ b/codebase_rag/parsers/io_access/registry.py
@@ -445,6 +445,20 @@ _CPP_SINKS: tuple[IOSink, ...] = tuple(
     for prefix in _CPP_SINK_PREFIXES
 )
 
+# Lua direct-call I/O sinks (issue #1175). Keyed by the callee text
+# reconstructed from `function_call` (`print`, `os.getenv`, `io.write`): `os`/`io`
+# are globals, `print` is a builtin, so the table is not import-gated. Lua has no
+# keyword args, so the env key is positional arg 0. Handle-based file I/O
+# (`io.open(path)` + `f:write`) writes through a method call on a handle, which
+# the flow walk does not track, so it stays a follow-up (io.open is not a direct
+# sink -- its args are a path and mode, never the tainted data).
+_LUA_SINKS: tuple[IOSink, ...] = (
+    IOSink("os.getenv", ResourceKind.ENV, IODirection.READ, target_arg=0),
+    IOSink("print", ResourceKind.STDOUT, IODirection.WRITE),
+    IOSink("io.write", ResourceKind.STDOUT, IODirection.WRITE),
+    IOSink("io.read", ResourceKind.STDIN, IODirection.READ),
+)
+
 IO_SINKS: dict[cs.SupportedLanguage, tuple[IOSink, ...]] = {
     cs.SupportedLanguage.PYTHON: _PYTHON_SINKS,
     cs.SupportedLanguage.JS: _JS_TS_SINKS,
@@ -460,6 +474,7 @@ IO_SINKS: dict[cs.SupportedLanguage, tuple[IOSink, ...]] = {
         IOSink(fn, kind, direction, target_arg=arg)
         for fn, kind, direction, arg in _CPP_CALL_METHODS
     ),
+    cs.SupportedLanguage.LUA: _LUA_SINKS,
 }
 
 # The languages the flow/I-O analysis covers at all: a Module in any other

--- a/codebase_rag/tests/test_flow_lean_branches.py
+++ b/codebase_rag/tests/test_flow_lean_branches.py
@@ -332,5 +332,46 @@ def test_rust_loop_kill_has_no_skip_path(tmp_path: Path) -> None:
     assert ("resource::ENV::SECRET", "resource::FILE::out.txt") not in flows
 
 
+def test_lua_env_to_stdout_via_print(tmp_path: Path) -> None:
+    # Lua joins FLOWS_TO coverage (issue #1175): a source read nested directly in
+    # a print sink emits the resource-to-resource edge.
+    files = {"m.lua": ('function leak()\n  print(os.getenv("SECRET"))\nend\n')}
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") in flows
+
+
+def test_lua_env_to_stdout_via_io_write(tmp_path: Path) -> None:
+    files = {"m.lua": ('function leak()\n  io.write(os.getenv("SECRET"))\nend\n')}
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") in flows
+
+
+def test_lua_env_to_stdout_bound_local(tmp_path: Path) -> None:
+    # The source is bound to a local first (`local s = os.getenv(..)`); the
+    # binding walk descends Lua's variable_list/expression_list so the taint
+    # attaches to `s` and reaches the sink (issue #1175).
+    files = {
+        "m.lua": ('function leak()\n  local s = os.getenv("SECRET")\n  print(s)\nend\n')
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") in flows
+
+
+def test_lua_kill_local_before_sink_no_flow(tmp_path: Path) -> None:
+    # Negative control: the local is reassigned to a clean value on every path
+    # before the sink, so the ENV taint is killed and no edge is emitted.
+    files = {
+        "m.lua": (
+            "function leak()\n"
+            '  local s = os.getenv("SECRET")\n'
+            '  s = "safe"\n'
+            "  print(s)\n"
+            "end\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::SECRET", "resource::STDOUT::<dynamic>") not in flows
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/codebase_rag/tests/test_flow_verdict.py
+++ b/codebase_rag/tests/test_flow_verdict.py
@@ -35,7 +35,7 @@ def test_found_returns_the_path() -> None:
     result = flow_reachability_verdict(
         _query_fn(
             [("p.a.src", "p.a.mid"), ("p.a.mid", "p.a.sink"), ("p.a.mid", "p.a.x")],
-            ["uncovered.lua"],
+            ["uncovered.php"],
         ),
         "p",
         "p.a.src",
@@ -60,13 +60,13 @@ def test_no_flow_requires_full_coverage() -> None:
 
 def test_unknown_names_the_gaps() -> None:
     result = flow_reachability_verdict(
-        _query_fn([], ["legacy/script.lua", "legacy/tool.php"]),
+        _query_fn([], ["legacy/script.scala", "legacy/tool.php"]),
         "p",
         "p.a.src",
         "p.a.sink",
     )
     assert result.verdict == FLOW_VERDICT_UNKNOWN
-    assert result.gaps == ("legacy/script.lua", "legacy/tool.php")
+    assert result.gaps == ("legacy/script.scala", "legacy/tool.php")
 
 
 def test_equal_names_without_an_edge_are_not_a_path() -> None:
@@ -114,10 +114,12 @@ def test_indexing_records_flow_coverage_per_module(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:
     (temp_repo / "covered.py").write_text("def f():\n    return 1\n")
-    (temp_repo / "uncovered.lua").write_text("local function f() return 1 end\n")
+    # Lua joined FLOW_REGISTERED_LANGUAGES in #1175; PHP is still outside it.
+    (temp_repo / "lua_covered.lua").write_text("local function f() return 1 end\n")
+    (temp_repo / "uncovered.php").write_text("<?php\nfunction f() { return 1; }\n")
     parsers, queries = load_parsers()
-    if "lua" not in parsers:
-        pytest.skip("lua parser not available")
+    if "php" not in parsers or "lua" not in parsers:
+        pytest.skip("php/lua parser not available")
     updater = GraphUpdater(
         ingestor=mock_ingestor,
         repo_path=temp_repo,
@@ -129,6 +131,7 @@ def test_indexing_records_flow_coverage_per_module(
     modules = _module_props(mock_ingestor)
     project = temp_repo.name
     assert modules[f"{project}.covered"]["flow_covered"] is True
+    assert modules[f"{project}.lua_covered"]["flow_covered"] is True
     assert modules[f"{project}.uncovered"]["flow_covered"] is False
 
 

--- a/docs/architecture/data-flow-edges.md
+++ b/docs/architecture/data-flow-edges.md
@@ -391,8 +391,8 @@ module is re-exported under its own name. A project that does
   `io.open(p):write(x)`, `File::create(p).write(x)`) emits no flow edge, uniformly
   across every lean language — the handle-tracking tables feed the `READS_FROM`/
   `WRITES_TO` walk, not the flow walk. So a handle-only write leak reads as `NO_FLOW`
-  rather than `UNKNOWN` under `flow_covered`; teaching the flow walk to track handle
-  bindings (cross-language) is tracked in #1204. This bites Lua hardest, since Lua has
+  rather than `UNKNOWN` in a fully covered project; teaching the flow walk to track
+  handle bindings (cross-language) is tracked in #1204. This bites Lua hardest, since Lua has
   no direct file-write sink at all.
 
 These are deliberate ceilings, chosen so the feature is correct and cheap where

--- a/docs/architecture/data-flow-edges.md
+++ b/docs/architecture/data-flow-edges.md
@@ -392,7 +392,7 @@ it applies rather than broad and noisy.
 
 ## Language coverage
 
-`FLOWS_TO` covers **10 of the 14 supported languages** — every language whose
+`FLOWS_TO` covers **11 of the 14 supported languages** — every language whose
 source/sink table is registered in `FLOW_REGISTERED_LANGUAGES`
 (`codebase_rag/parsers/io_access/registry.py`). Python uses the deep,
 path-sensitive walk; the rest use the descriptor-driven lean walk. A language
@@ -412,7 +412,7 @@ edges, so a reachability question over it returns `UNKNOWN` rather than
 | C++ | ✅ | lean descriptor |
 | C | ✅ | lean descriptor |
 | C# | ✅ | lean descriptor |
-| Lua | ❌ | not covered — no sink table |
+| Lua | ✅ | lean descriptor |
 | PHP | ❌ | not covered — no sink table |
 | Scala | ❌ | not covered — no sink table |
 | Dart | ❌ | not covered — no sink table |

--- a/docs/architecture/data-flow-edges.md
+++ b/docs/architecture/data-flow-edges.md
@@ -386,6 +386,14 @@ module is re-exported under its own name. A project that does
 - The source/sink registry covers Python, JavaScript, TypeScript (including TSX),
   Go, Java, Rust, C, C++, C#, and Lua; a language not in the registry emits no I/O
   or flow edges until its table is added.
+- The lean (non-Python) `FLOWS_TO` walk matches **direct call sinks only**; a taint
+  that reaches a resource through a handle method (`os.Create(p).Write(x)`,
+  `io.open(p):write(x)`, `File::create(p).write(x)`) emits no flow edge, uniformly
+  across every lean language — the handle-tracking tables feed the `READS_FROM`/
+  `WRITES_TO` walk, not the flow walk. So a handle-only write leak reads as `NO_FLOW`
+  rather than `UNKNOWN` under `flow_covered`; teaching the flow walk to track handle
+  bindings (cross-language) is tracked in #1204. This bites Lua hardest, since Lua has
+  no direct file-write sink at all.
 
 These are deliberate ceilings, chosen so the feature is correct and cheap where
 it applies rather than broad and noisy.

--- a/docs/architecture/data-flow-edges.md
+++ b/docs/architecture/data-flow-edges.md
@@ -384,8 +384,8 @@ module is re-exported under its own name. A project that does
   tainted value reached a call — and is emitted alongside the forward composition above.
   Sources and sinks are direct I/O calls from the registry.
 - The source/sink registry covers Python, JavaScript, TypeScript (including TSX),
-  Go, Java, Rust, C, C++, and C#; a language not in the registry emits no I/O or
-  flow edges until its table is added.
+  Go, Java, Rust, C, C++, C#, and Lua; a language not in the registry emits no I/O
+  or flow edges until its table is added.
 
 These are deliberate ceilings, chosen so the feature is correct and cheap where
 it applies rather than broad and noisy.


### PR DESCRIPTION
Closes #1175. Adds Lua to `FLOWS_TO` coverage, moving the registered set from 10 to 11 of the 14 supported languages.

## What
The lean flow walk (`parsers/flow_access/processor.py`) is descriptor-driven, so most of this is a registry + descriptor increment:

- **`LanguageDescriptor`** (`descriptor.py`): a `_LUA_DESCRIPTOR` wiring Lua's node types (`function_call`, `assignment_statement`, `block`, `dot_index_expression`/`bracket_index_expression`, `string_content`). Lua is declare-at-point and its sink heads (`os`/`io`/`print`) are globals, so no import gate.
- **`IO_SINKS`** (`registry.py`): `_LUA_SINKS` — `os.getenv` (ENV read), `print` + `io.write` (STDOUT), `io.read` (STDIN). Registering it flips `FLOW_REGISTERED_LANGUAGES`, so Lua `Module` nodes now carry `flow_covered: true` and the three-verdict query stops reporting UNKNOWN for Lua.
- **Binding support** (`extract.py`): Lua's `local x = f()` nests its LHS/RHS under `variable_list`/`expression_list` containers rather than `left`/`right` or `name`/`value` fields, so `binding_targets_values` gained two optional descriptor fields (`binding_target_container_type`/`binding_value_container_type`) and a branch that descends the containers. Ordering-safe: Go's `assignment_statement` carries real `left`/`right` fields and returns from the first branch, never reaching the new one.

## Scope boundaries (deliberate, documented in comments)
- **File-handle I/O** (`io.open(path)` + `f:write`) is out of scope: the flow walk only matches direct call sinks carrying both path and data, and Lua file writes go through a method call on a handle. `io.open` is not a direct sink (its args are path + mode, never the tainted data).
- **Parameter taint** (#1169) does not apply to Lua: it has no positional-parameter-slot extractor, so Lua parameters seed no taint — identical to Java/C#/Rust today.

## Tests
Four flow regressions in `test_flow_lean_branches.py`: `os.getenv` → `print` and → `io.write` (direct), bound-local (`local s = os.getenv(); print(s)`, exercising the binding extension), and a kill negative-control. Updated `test_flow_verdict.py` to assert Lua is now `flow_covered` (PHP is the still-uncovered example). Full flow + I/O regression: 1193 passed, 6 skipped. lint/format/ty clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Lua support for data-flow analysis, including variable bindings, table access, function calls, and standard input/output operations.
  * Added support for tracking values through Lua multi-assignment patterns.
  * Added Lua coverage to indexing and flow analysis.

* **Bug Fixes**
  * Improved handling of Lua reassignment scenarios to prevent stale taint results.

* **Documentation**
  * Updated data-flow coverage documentation to include Lua and clarify current flow-analysis limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->