### PR TITLE
feat: closure-capture taint for the Python flow walk via capture summaries (#1197)

### DIFF
--- a/codebase_rag/constants/ast_python.py
+++ b/codebase_rag/constants/ast_python.py
@@ -49,6 +49,7 @@ TS_PY_COMPARISON_OPERATOR = "comparison_operator"
 TS_FIELD_OPERATORS = "operators"
 TS_PY_IF_STATEMENT = "if_statement"
 TS_PY_TRY_STATEMENT = "try_statement"
+TS_PY_GLOBAL_STATEMENT = "global_statement"
 # Match statement: arms are exclusive; an UNGUARDED `case _` (empty
 # case_pattern) always matches, removing the implicit no-match path.
 TS_PY_MATCH_STATEMENT = "match_statement"

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1052,6 +1052,7 @@ class CallProcessor:
             import_processor,
             self._resolver,
             selection=selection,
+            function_locations=self.function_locations,
         )
 
     def _get_node_name(self, node: Node, field: str = cs.FIELD_NAME) -> str | None:

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -48,6 +48,7 @@ from ..utils import (
     go_positional_parameter_slots,
     java_positional_parameter_slots,
     js_ts_positional_parameter_slots,
+    python_free_variable_names,
     python_parameter_names,
     rust_positional_parameter_slots,
     safe_decode_text,
@@ -588,6 +589,14 @@ class FlowProcessor:
         positional = _py_positional_param_names(caller_node)
         if positional:
             self._positional_params[caller_qn] = positional
+        # Seed each free variable as a capture pseudo-origin so a sink it reaches
+        # becomes a capture summary composed at finalize against the enclosing
+        # definition site (issue #1197). A free var matches only kw:<name>, so it
+        # records no positional slot; a free var that is never a tainted capture
+        # records a summary no call site composes, so it stays inert.
+        for fv in python_free_variable_names(caller_node):
+            if fv not in tainted:
+                tainted[fv] = Taint(frozenset(), frozenset(), frozenset({fv}))
         for node in scope_seed_nodes(caller_node):
             tainted = self._walk_stmt(node, tainted, ctx)
 
@@ -1782,7 +1791,10 @@ class FlowProcessor:
     def _walk_stmt(self, node: Node, state: _TaintMap, ctx: _FlowCtx) -> _TaintMap:
         node_type = node.type
         if node_type in PY_SCOPE_BOUNDARIES:
-            # Nested def/class: only its header executes in this scope.
+            # Nested def/class: only its header executes in this scope. Record any
+            # enclosing taint its body captures BEFORE walking the header, using
+            # the def-site state (issue #1197); the body is left to its own pass.
+            self._record_captures(node, state, ctx)
             for header in definition_header_nodes(node):
                 state = self._walk_stmt(header, state, ctx)
             return state
@@ -2415,6 +2427,53 @@ class FlowProcessor:
                     dst |= src
                     changed = True
         return closure
+
+    @staticmethod
+    def _nested_def_name(def_node: Node) -> tuple[str, Node] | None:
+        # The bound name and function_definition node of a nested def, unwrapping a
+        # decorated_definition. None for a nested CLASS (its methods' qns are
+        # class-nested, out of scope) or an unnamed def.
+        inner = def_node
+        if def_node.type == cs.TS_PY_DECORATED_DEFINITION:
+            inner = next(
+                (
+                    c
+                    for c in def_node.children
+                    if c.type
+                    in (cs.TS_PY_FUNCTION_DEFINITION, cs.TS_PY_CLASS_DEFINITION)
+                ),
+                def_node,
+            )
+        if inner.type != cs.TS_PY_FUNCTION_DEFINITION:
+            return None
+        name_node = inner.child_by_field_name(cs.FIELD_NAME)
+        name = safe_decode_text(name_node) if name_node is not None else None
+        return (name, inner) if name else None
+
+    def _record_captures(self, def_node: Node, state: _TaintMap, ctx: _FlowCtx) -> None:
+        # A nested function may capture tainted enclosing-scope variables through
+        # its environment. For each free variable tainted at the definition site,
+        # record a capture keyed by the nested function's qn and via kw:<name>, so
+        # the existing parameter-summary finalize composes it exactly as a keyword
+        # argument would (issue #1197). A capture carrying concrete origins/pending
+        # is a resolvable call site; one carrying only the enclosing function's own
+        # parameters records a transitive flow edge, so a variable captured through
+        # two nested levels still composes.
+        resolved = self._nested_def_name(def_node)
+        if resolved is None:
+            return
+        name, inner = resolved
+        nested_qn = f"{ctx.caller_qn}{cs.SEPARATOR_DOT}{name}"
+        for fv in python_free_variable_names(inner):
+            taint = state.get(fv)
+            if taint is None:
+                continue
+            via = VIA_KW_FORMAT.format(name=fv)
+            if taint.origins or taint.pending:
+                token = _passthrough_result_token(ctx.caller_qn, def_node)
+                self._param_call_sites.append((taint, nested_qn, via, token))
+            for pname in taint.params:
+                self._param_flow_edges.append((ctx.caller_qn, pname, nested_qn, via))
 
     def _param_name_for_via(self, callee_qn: str, via: str) -> str | None:
         # Map an argument's `via` tag to the callee's parameter name: `kw:<name>`

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 from collections import defaultdict, deque
 from collections.abc import Callable
-from typing import NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
 from tree_sitter import Node
+
+if TYPE_CHECKING:
+    from ...types_defs import FunctionLocation, FunctionSpanKey
 
 from ... import constants as cs
 from ...capture import CaptureSelection
@@ -45,6 +48,7 @@ from ..utils import (
     c_positional_parameter_slots,
     cpp_positional_parameter_slots,
     csharp_positional_parameter_slots,
+    function_span_key,
     go_positional_parameter_slots,
     java_positional_parameter_slots,
     js_ts_positional_parameter_slots,
@@ -444,11 +448,17 @@ class FlowProcessor:
         import_processor: ImportProcessor,
         resolver: CallResolver,
         selection: CaptureSelection,
+        function_locations: dict[FunctionSpanKey, FunctionLocation] | None = None,
     ) -> None:
         self.ingestor = ingestor
         self._import_processor = import_processor
         self._resolver = resolver
         self._selection = selection
+        # Span-key -> registered FunctionLocation, so a nested def's capture record
+        # uses the SAME (suffix-aware) qn the definition pass assigned, matching the
+        # qn its own walk is keyed under; without it a duplicate-named nested def
+        # would record under a reconstructed unsuffixed qn that never composes.
+        self._function_locations = function_locations or {}
         self._enabled = selection.rel_enabled(cs.RelationshipType.FLOWS_TO)
         # Per-function return-taint SUMMARY collected during the walk: caller QN
         # -> the Taint it returns (resolved origins + pending callee QNs whose
@@ -2463,7 +2473,15 @@ class FlowProcessor:
         if resolved is None:
             return
         name, inner = resolved
-        nested_qn = f"{ctx.caller_qn}{cs.SEPARATOR_DOT}{name}"
+        # Use the qn the definition pass registered for this exact node (it carries
+        # the duplicate-name suffix a manual reconstruction would miss); fall back to
+        # the reconstructed name only when the node was not registered.
+        loc = self._function_locations.get(function_span_key(ctx.module_qn, inner))
+        nested_qn = (
+            loc.qualified_name
+            if loc is not None
+            else f"{ctx.caller_qn}{cs.SEPARATOR_DOT}{name}"
+        )
         for fv in python_free_variable_names(inner):
             taint = state.get(fv)
             if taint is None:

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -598,6 +598,26 @@ def _python_collect_bound_targets(node: Node, out: set[str]) -> None:
                 left = child.child_by_field_name(cs.TS_FIELD_LEFT)
                 if left is not None:
                     _python_collect_target_identifiers(left, out)
+            elif child_type == cs.TS_PY_FOR_STATEMENT:
+                left = child.child_by_field_name(cs.TS_FIELD_LEFT)
+                if left is not None:
+                    _python_collect_target_identifiers(left, out)
+            elif child_type == cs.TS_PY_AS_PATTERN_TARGET:
+                # `with ... as x` and `except ... as x` bind x here.
+                _python_collect_target_identifiers(child, out)
+            elif child_type in _PY_IMPORT_STATEMENTS:
+                _python_collect_import_bound_names(child, out)
+            elif child_type == cs.TS_PY_GLOBAL_STATEMENT:
+                # `global x` rebinds x to module scope: it is not a capture of the
+                # enclosing function, so exclude it like a local binding.
+                for c in child.named_children:
+                    if c.type == cs.TS_PY_IDENTIFIER and (name := safe_decode_text(c)):
+                        out.add(name)
+            elif child_type == cs.TS_PY_CASE_PATTERN:
+                # A `match` case binds its capture names; collect every identifier
+                # in the pattern (over-approximating value patterns is harmless --
+                # it only excludes a rare captured name used in a value position).
+                _python_collect_target_identifiers(child, out)
             stack.append(child)
 
 
@@ -608,6 +628,30 @@ def _python_collect_target_identifiers(node: Node, out: set[str]) -> None:
         return
     for child in node.children:
         _python_collect_target_identifiers(child, out)
+
+
+_PY_IMPORT_STATEMENTS = frozenset(
+    {cs.TS_PY_IMPORT_STATEMENT, cs.TS_PY_IMPORT_FROM_STATEMENT}
+)
+
+
+def _python_collect_import_bound_names(node: Node, out: set[str]) -> None:
+    # `import a.b` binds `a`; `import a.b as c` binds `c`; `from m import x` binds
+    # `x`; `from m import x as y` binds `y`. The imported items live under the
+    # `name` field; the from-module (`module_name` field) is the source, not a
+    # local binding, so it is skipped by keying off `name` only.
+    for item in node.children_by_field_name(cs.FIELD_NAME):
+        if item.type == cs.TS_ALIASED_IMPORT:
+            alias = item.child_by_field_name(cs.FIELD_ALIAS)
+            if alias is not None and (name := safe_decode_text(alias)):
+                out.add(name)
+        elif item.type == cs.TS_PY_DOTTED_NAME:
+            first = next(
+                (c for c in item.named_children if c.type == cs.TS_PY_IDENTIFIER),
+                None,
+            )
+            if first is not None and (name := safe_decode_text(first)):
+                out.add(name)
 
 
 def _python_collect_identifier_reads(node: Node, out: set[str]) -> None:

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -614,10 +614,8 @@ def _python_collect_bound_targets(node: Node, out: set[str]) -> None:
                     if c.type == cs.TS_PY_IDENTIFIER and (name := safe_decode_text(c)):
                         out.add(name)
             elif child_type == cs.TS_PY_CASE_PATTERN:
-                # A `match` case binds its capture names; collect every identifier
-                # in the pattern (over-approximating value patterns is harmless --
-                # it only excludes a rare captured name used in a value position).
-                _python_collect_target_identifiers(child, out)
+                # A `match` case binds only its CAPTURE names, not value patterns.
+                _python_collect_case_pattern_bindings(child, out)
             stack.append(child)
 
 
@@ -628,6 +626,27 @@ def _python_collect_target_identifiers(node: Node, out: set[str]) -> None:
         return
     for child in node.children:
         _python_collect_target_identifiers(child, out)
+
+
+def _python_collect_case_pattern_bindings(node: Node, out: set[str]) -> None:
+    # A `match` case binds its CAPTURE patterns and nothing else. A bare name
+    # (`case token:`, `case [token]:`) parses as a single-identifier dotted_name and
+    # binds; a multi-part dotted_name (`case sentinel.token:`) is a VALUE pattern
+    # that compares and binds nothing -- collecting its identifiers would wrongly
+    # exclude a captured name used in a value position. `as` aliases are collected
+    # by the general as_pattern_target branch. Only single-identifier dotted_names
+    # (and their `_` wildcard, which decodes to nothing) are captured here.
+    stack: list[Node] = [node]
+    while stack:
+        current = stack.pop()
+        if current.type == cs.TS_PY_DOTTED_NAME:
+            idents = [
+                c for c in current.named_children if c.type == cs.TS_PY_IDENTIFIER
+            ]
+            if len(idents) == 1 and (name := safe_decode_text(idents[0])):
+                out.add(name)
+            continue
+        stack.extend(current.children)
 
 
 _PY_IMPORT_STATEMENTS = frozenset(

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -610,6 +610,34 @@ def _python_collect_target_identifiers(node: Node, out: set[str]) -> None:
         _python_collect_target_identifiers(child, out)
 
 
+def _python_collect_identifier_reads(node: Node, out: set[str]) -> None:
+    stack: list[Node] = [node]
+    while stack:
+        current = stack.pop()
+        if current.type == cs.TS_PY_IDENTIFIER:
+            if name := safe_decode_text(current):
+                out.add(name)
+            continue
+        stack.extend(current.children)
+
+
+def python_free_variable_names(func_node: Node) -> set[str]:
+    # Names READ in a nested function's body that it does not bind itself (its
+    # parameters, local assignment targets, and nested def/class names). Descends
+    # into inner nested scopes so a variable used only in a doubly-nested body is
+    # still free for this function -- needed so a capture composes transitively.
+    # Conservative: over-approximates (globals, builtins, and attribute names are
+    # swept in), but a capture only composes when a bare-name read reaches a sink
+    # AND that name is tainted at the definition site, so the extras record
+    # summaries that never compose -- sound and inert (issue #1197).
+    body = func_node.child_by_field_name(cs.FIELD_BODY)
+    if body is None:
+        return set()
+    reads: set[str] = set()
+    _python_collect_identifier_reads(body, reads)
+    return reads - _python_scope_bound_names(func_node)
+
+
 def python_parameter_names(func_node: Node) -> list[str]:
     # Ordered parameter names with a leading self/cls dropped, so positions line
     # up with how call-site arguments map to parameters for bound methods.

--- a/codebase_rag/tests/test_flow_edges.py
+++ b/codebase_rag/tests/test_flow_edges.py
@@ -1116,3 +1116,68 @@ def test_param_taint_passthrough_returns_fresh_value_no_flow(tmp_path: Path) -> 
         )
     }
     assert not _has_env_k_to_stdout_flow(_run_flow(tmp_path, files))
+
+
+def test_capture_taint_reaches_sink_in_nested_function(tmp_path: Path) -> None:
+    # Closure capture (issue #1197): the nested `send` closes over the tainted
+    # `token`, which is neither its parameter nor its local. Its body is walked as
+    # its own caller, so without capture seeding the ENV read never connects to the
+    # STDOUT sink -- the "secrets captured into a callback" false negative.
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "def handler():\n"
+            "    token = os.getenv('K')\n"
+            "    def send():\n        print(token)\n"
+            "    send()\n"
+        )
+    }
+    assert _has_env_k_to_stdout_flow(_run_flow(tmp_path, files))
+
+
+def test_capture_taint_survives_reassignment_after_the_def(tmp_path: Path) -> None:
+    # MAY semantics: the capture is recorded from the def-site state, where `token`
+    # is tainted; a later reassignment to a clean value cannot retroactively erase
+    # the taint that was live when the closure was defined.
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "def handler():\n"
+            "    token = os.getenv('K')\n"
+            "    def send():\n        print(token)\n"
+            "    token = 'clean'\n"
+            "    send()\n"
+        )
+    }
+    assert _has_env_k_to_stdout_flow(_run_flow(tmp_path, files))
+
+
+def test_capture_taint_composes_through_two_nested_levels(tmp_path: Path) -> None:
+    # `token` is captured by `middle` and again by `inner`; the qn-keyed capture
+    # summaries compose transitively, exactly like a two-hop parameter wrapper.
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "def handler():\n"
+            "    token = os.getenv('K')\n"
+            "    def middle():\n"
+            "        def inner():\n            print(token)\n"
+            "        inner()\n"
+            "    middle()\n"
+        )
+    }
+    assert _has_env_k_to_stdout_flow(_run_flow(tmp_path, files))
+
+
+def test_untainted_captured_variable_emits_no_flow(tmp_path: Path) -> None:
+    # Negative control: the captured `token` holds a literal, so the free-variable
+    # seed is never a real capture and no flow is emitted.
+    files = {
+        "m.py": (
+            "def handler():\n"
+            "    token = 'literal'\n"
+            "    def send():\n        print(token)\n"
+            "    send()\n"
+        )
+    }
+    assert not _has_env_k_to_stdout_flow(_run_flow(tmp_path, files))

--- a/codebase_rag/tests/test_flow_edges.py
+++ b/codebase_rag/tests/test_flow_edges.py
@@ -1136,9 +1136,12 @@ def test_capture_taint_reaches_sink_in_nested_function(tmp_path: Path) -> None:
 
 
 def test_capture_taint_survives_reassignment_after_the_def(tmp_path: Path) -> None:
-    # MAY semantics: the capture is recorded from the def-site state, where `token`
-    # is tainted; a later reassignment to a clean value cannot retroactively erase
-    # the taint that was live when the closure was defined.
+    # MAY semantics (issue #1197): the capture is recorded from the def-site state,
+    # where `token` is tainted. A closure captures a cell, and the walk does not model
+    # call order, so the tool cannot assume the later reassignment precedes every
+    # invocation -- the closure may run with the tainted value. Reporting the flow is
+    # the safe over-approximation (no false negative); precise call-relative cell
+    # tracking is a separate follow-up.
     files = {
         "m.py": (
             "import os\n\n"
@@ -1181,3 +1184,69 @@ def test_untainted_captured_variable_emits_no_flow(tmp_path: Path) -> None:
         )
     }
     assert not _has_env_k_to_stdout_flow(_run_flow(tmp_path, files))
+
+
+def test_for_loop_local_binding_is_not_a_capture(tmp_path: Path) -> None:
+    # `token` is bound by the nested `for`, so it is the closure's own local, not a
+    # capture of the enclosing tainted `token`; no flow (CodeRabbit review, #1197).
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "def handler():\n"
+            "    token = os.getenv('K')\n"
+            "    def send():\n"
+            "        for token in ('clean',):\n            print(token)\n"
+            "    send()\n"
+        )
+    }
+    assert not _has_env_k_to_stdout_flow(_run_flow(tmp_path, files))
+
+
+def test_import_local_binding_is_not_a_capture(tmp_path: Path) -> None:
+    # A nested `import token` binds `token` locally; it must not be classified as a
+    # capture of the enclosing tainted `token`.
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "def handler():\n"
+            "    token = os.getenv('K')\n"
+            "    def send():\n        import token\n        print(token)\n"
+            "    send()\n"
+        )
+    }
+    assert not _has_env_k_to_stdout_flow(_run_flow(tmp_path, files))
+
+
+def test_with_and_except_as_bindings_are_not_captures(tmp_path: Path) -> None:
+    # `with ... as token` and `except ... as token` both bind `token` locally.
+    for body in (
+        "        with open('x') as token:\n            print(token)\n",
+        "        try:\n            pass\n"
+        "        except Exception as token:\n            print(token)\n",
+    ):
+        files = {
+            "m.py": (
+                "import os\n\n"
+                "def handler():\n"
+                "    token = os.getenv('K')\n"
+                "    def send():\n" + body + "    send()\n"
+            )
+        }
+        assert not _has_env_k_to_stdout_flow(_run_flow(tmp_path, files))
+
+
+def test_capture_composes_for_duplicate_named_nested_defs(tmp_path: Path) -> None:
+    # Two nested defs share the name `send`; the definition pass suffixes their qns.
+    # The capture must be recorded under the SAME registered qn the redefined `send`
+    # is walked with, or its flow is lost (Greptile review, #1197).
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "def factory():\n"
+            "    token = os.getenv('K')\n"
+            "    def send():\n        print('safe')\n"
+            "    def send():\n        print(token)\n"
+            "    send()\n"
+        )
+    }
+    assert _has_env_k_to_stdout_flow(_run_flow(tmp_path, files))

--- a/codebase_rag/tests/test_flow_edges.py
+++ b/codebase_rag/tests/test_flow_edges.py
@@ -1235,6 +1235,43 @@ def test_with_and_except_as_bindings_are_not_captures(tmp_path: Path) -> None:
         assert not _has_env_k_to_stdout_flow(_run_flow(tmp_path, files))
 
 
+def test_match_value_pattern_does_not_hide_a_capture(tmp_path: Path) -> None:
+    # `case sentinel.token:` is a value pattern (multi-part dotted name) that binds
+    # nothing; the `token` read in the case body is the enclosing capture, so the
+    # flow must survive -- collecting value-pattern identifiers would hide it
+    # (CodeRabbit review, #1197).
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "sentinel = object()\n\n"
+            "def handler():\n"
+            "    token = os.getenv('K')\n"
+            "    def send(x):\n"
+            "        match x:\n            case sentinel.token:\n"
+            "                print(token)\n"
+            "    send(1)\n"
+        )
+    }
+    assert _has_env_k_to_stdout_flow(_run_flow(tmp_path, files))
+
+
+def test_match_capture_pattern_binds_locally_no_flow(tmp_path: Path) -> None:
+    # `case token:` is a capture pattern binding `token` locally, so it is the
+    # closure's own binding, not a capture of the enclosing tainted `token`.
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "def handler():\n"
+            "    token = os.getenv('K')\n"
+            "    def send(x):\n"
+            "        match x:\n            case token:\n"
+            "                print(token)\n"
+            "    send(1)\n"
+        )
+    }
+    assert not _has_env_k_to_stdout_flow(_run_flow(tmp_path, files))
+
+
 def test_capture_composes_for_duplicate_named_nested_defs(tmp_path: Path) -> None:
     # Two nested defs share the name `send`; the definition pass suffixes their qns.
     # The capture must be recorded under the SAME registered qn the redefined `send`


### PR DESCRIPTION
Closes #1197. Every flow walk seeds a function's taint map from its own parameters only. A nested function that **captures** a tainted enclosing-scope variable starts from nothing, so a sink in its body sees no taint — a silent false negative orthogonal to parameter taint (#1169) and the nested-header walk (#1196): this is taint that crosses scopes *through the environment*, not through the call.

```python
def handler():
    token = os.getenv('K')      # tainted in handler's walk
    def send(): print(token)     # walked as its own caller: token unknown -> no edge
    send()
```

## Key insight — no new subsystem
A captured free variable is mechanically identical to a **keyword-matched parameter** of the nested function. So the fix reuses the entire parameter-summary machinery (#1142/#1168/#1169) with **zero changes to `finalize()`**:

1. **Seed** each free variable of a function as a capture pseudo-origin (`params` field), exactly as real parameters are seeded, so a sink/return it reaches records a summary.
2. **Record** at each nested-def site (in the `PY_SCOPE_BOUNDARIES` branch, using the def-site state) a capture keyed by the nested function's qn with `via = kw:<freevar>` — a resolvable call site when the captured value carries concrete origins, or a transitive `_param_flow_edge` when it carries only the enclosing function's own parameters.
3. **Compose** at finalize: `_param_name_for_via` already returns the name directly for a `kw:<name>` via, so `_resolve_param_sinks` + the existing call-site drain emit the real `source → sink` edge — order-independently (the nested function may be walked before its encloser) and transitively (nested-twice composes through the same closure as a two-hop parameter wrapper).

New pieces: `python_free_variable_names` (+ a reads collector) in `utils.py` — conservative (over-approximates; a free var that is never a tainted capture records a summary no call site composes, so it stays inert), and `_record_captures`/`_nested_def_name` in the processor.

## Semantics
- **MAY**: the capture is recorded from the def-site `state`, which is already the union over all paths reaching the def — so a reassignment *after* the nested def cannot retroactively erase taint that was live when the closure was defined.
- Scoped to **Python** (deep walk) as the issue directs; the finalize composition is already language-agnostic, so the lean walk extends later by reusing its shadow/local-name bookkeeping.

Known conservative limits (documented in code, all out of scope for #1197): taint assigned strictly *after* the def but before the call (capture-by-reference), methods of a nested class capturing an enclosing local, and duplicate-name nested-def qn reconstruction.

## Tests (`test_flow_edges.py`)
Capture-then-call, capture-with-later-reassignment (MAY), nested-twice (transitive), and an untainted-captured negative control — all asserting (or refuting) `resource::ENV::K → resource::STDOUT::<dynamic>`.

Broad flow/io/param regression: **1344 passed, 9 skipped**. Full flow suite: 94 passed. lint/format/ty clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Python taint analysis for closures and nested functions.
  * Captured variables now propagate taint across nested scopes, including reassignment, multiple nesting levels, and duplicate nested definitions.
  * Literal and locally bound values—such as loop, import, context, exception, and pattern variables—are correctly excluded from flow results.

* **Tests**
  * Added coverage for nested closure propagation, reassignment, transitive captures, duplicate definitions, and positive and negative pattern-binding cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->