### PR TITLE
feat: model Go handle-based writes in the lean FLOWS_TO walk (#1204)

### DIFF
--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -196,6 +196,24 @@ def _merge_taint(a: Taint, b: Taint) -> Taint:
 
 # Live taint state threaded through the walk: variable -> its Taint.
 type _TaintMap = dict[str, Taint]
+# Live handle bindings threaded through the lean walk: variable -> the resource
+# handles it may hold. Set-valued so a name bound to different handles on
+# different branches writes to ALL of them at a later method call (issue #1204).
+type _HandleMap = dict[str, frozenset[HandleBinding]]
+
+
+class _LeanState(NamedTuple):
+    # Path-sensitive state threaded through the lean (non-Python) walk: the taint
+    # map plus the resource-handle map, copied at branch entry and MAY-unioned at
+    # the join exactly as the taint map alone was (issue #1204). Bundling the two
+    # keeps every `state = self._walk_x(...)` call site unchanged.
+    taint: _TaintMap
+    handles: _HandleMap
+
+    def copy(self) -> _LeanState:
+        # frozensets are immutable, so a shallow copy of each dict is a full copy.
+        return _LeanState(dict(self.taint), dict(self.handles))
+
 
 # Return wrappers whose taint lives in their elements: `return (x)`,
 # `return a, b`, `return [x]`. Unwrapped so a tainted identifier/call inside
@@ -441,10 +459,9 @@ class _JsCtx(NamedTuple):
     local_names: set[str]
     # Handle-based writes (issue #1204): a local bound to a resource handle
     # (`f := os.Create("out")`) so a tainted write through it (`f.Write(secret)`)
-    # emits a flow edge to the handle's resource. MUTABLE, flat/last-write-wins
-    # like io_access's handle walk; the ctor/method tables are the per-language
-    # registry views. Empty tables (no handle support for the language) => inert.
-    handles: dict[str, HandleBinding]
+    # emits a flow edge to the handle's resource. The live bindings ride the
+    # path-sensitive _LeanState (branch-merged like taint); these are the constant
+    # per-language registry views. Empty tables (no handle support) => inert.
     handle_ctors: dict[str, HandleConstructor]
     handle_methods: dict[ResourceKind, dict[str, IODirection]]
 
@@ -494,7 +511,7 @@ class FlowProcessor:
         # the switch with the state it saw THEN, not the arm's end state).
         # Loop walkers push None to shield the collector: a break in a
         # nested loop targets that loop, not the enclosing switch.
-        self._break_exit_stack: list[list[_TaintMap] | None] = []
+        self._break_exit_stack: list[list[_LeanState] | None] = []
         self._deferred_resource_flows: list[
             tuple[frozenset[str], ResourceKind, str]
         ] = []
@@ -641,7 +658,6 @@ class FlowProcessor:
             descriptor=descriptor,
             member_reads=member_reads,
             local_names=self._js_local_names(caller_node, descriptor, ctx.language),
-            handles={},
             handle_ctors={
                 c.callee: c for c in IO_LEAN_HANDLE_CONSTRUCTORS.get(ctx.language, ())
             },
@@ -654,7 +670,7 @@ class FlowProcessor:
             statements = list(body.named_children)
         else:
             statements = [body]
-        tainted: _TaintMap = {}
+        state = _LeanState(taint={}, handles={})
         # Seed each parameter as a pseudo-origin so a sink or callee hand-off it
         # reaches becomes a parameter-taint summary composed at finalize, exactly
         # as the Python walk does (issue #1169 extends #1142/#1168 to the lean
@@ -664,7 +680,7 @@ class FlowProcessor:
         lean_names, lean_variadic = _lean_parameter_slots(caller_node, ctx.language)
         for pname in lean_names:
             if pname is not None:
-                tainted[pname] = Taint(frozenset(), frozenset(), frozenset({pname}))
+                state.taint[pname] = Taint(frozenset(), frozenset(), frozenset({pname}))
         if lean_names:
             self._positional_params[ctx.caller_qn] = lean_names
             if lean_variadic is not None:
@@ -675,7 +691,7 @@ class FlowProcessor:
             # state and unioned at the merge, so taint surviving on ANY path
             # survives and a kill counts only when it happens on EVERY path.
             for node in statements:
-                tainted = self._walk_js_stmt(node, tainted, jc)
+                state = self._walk_js_stmt(node, state, jc)
         else:
             # Flat-language path-sensitive MAY walk (issue #714 follow-up):
             # if/loop/try/switch/match nodes branch-and-merge like the JS walk
@@ -687,11 +703,11 @@ class FlowProcessor:
             # merge, so a block-scoped Go/Java declaration inside a branch does
             # not leak its shadow past the join.
             for node in statements:
-                tainted = self._walk_flat_stmt(node, tainted, jc)
+                state = self._walk_flat_stmt(node, state, jc)
         if self._acc_returns_taint:
             self._summaries[ctx.caller_qn] = self._acc_return_taint
 
-    def _walk_flat_stmt(self, node: Node, state: _TaintMap, jc: _JsCtx) -> _TaintMap:
+    def _walk_flat_stmt(self, node: Node, state: _LeanState, jc: _JsCtx) -> _LeanState:
         # Structured walk for the non-hoisted flat languages (Go, Java, Rust,
         # C++): if/loop/try/match nodes branch-and-merge (issue #714 follow-up);
         # every other node applies its leaf effect and threads state through its
@@ -718,12 +734,12 @@ class FlowProcessor:
             return self._walk_switch(node, state, jc, self._walk_flat_stmt)
         if node_type == cs.TS_RS_MATCH_EXPRESSION:
             return self._walk_flat_match(node, state, jc)
-        self._apply_js_leaf(node, state, jc)
+        self._apply_js_leaf(node, state.taint, state.handles, jc)
         for child in node.named_children:
             state = self._walk_flat_stmt(child, state, jc)
         return state
 
-    def _walk_flat_loop(self, node: Node, state: _TaintMap, jc: _JsCtx) -> _TaintMap:
+    def _walk_flat_loop(self, node: Node, state: _LeanState, jc: _JsCtx) -> _LeanState:
         # Loop shield: a break inside the body targets THIS loop, never an
         # enclosing switch arm's collector.
         self._shield_breaks()
@@ -733,8 +749,8 @@ class FlowProcessor:
             self._unshield_breaks()
 
     def _walk_flat_loop_inner(
-        self, node: Node, state: _TaintMap, jc: _JsCtx
-    ) -> _TaintMap:
+        self, node: Node, state: _LeanState, jc: _JsCtx
+    ) -> _LeanState:
         # The body runs zero or more times: union the skip path with one pass,
         # then re-walk once from that merge so taint carried from a later
         # iteration into an earlier statement is caught (same two-pass
@@ -747,27 +763,27 @@ class FlowProcessor:
         # the loop var to the iterable's taint) runs before the body.
         pre_loop_shadows = set(jc.local_names)
         if node.type in jc.descriptor.extra_declarator_types:
-            self._apply_js_leaf(node, state, jc)
+            self._apply_js_leaf(node, state.taint, state.handles, jc)
         body = node.child_by_field_name(cs.FIELD_BODY)
         state, update = self._walk_loop_header(node, state, jc, body)
         if body is None:
             self._restore_shadows(pre_loop_shadows, jc)
             return state
         header_shadows = set(jc.local_names)
-        once = self._walk_flat_stmt(body, dict(state), jc)
+        once = self._walk_flat_stmt(body, state.copy(), jc)
         if update is not None:
             once = self._walk_flat_stmt(update, once, jc)
         self._restore_shadows(header_shadows, jc)
-        merged = self._merge([state, once])
-        twice = self._walk_flat_stmt(body, dict(merged), jc)
+        merged = self._merge_lean([state, once])
+        twice = self._walk_flat_stmt(body, merged.copy(), jc)
         if update is not None:
             twice = self._walk_flat_stmt(update, twice, jc)
         self._restore_shadows(pre_loop_shadows, jc)
-        return self._merge([state, twice])
+        return self._merge_lean([state, twice])
 
     def _walk_loop_header(
-        self, node: Node, state: _TaintMap, jc: _JsCtx, body: Node | None
-    ) -> tuple[_TaintMap, Node | None]:
+        self, node: Node, state: _LeanState, jc: _JsCtx, body: Node | None
+    ) -> tuple[_LeanState, Node | None]:
         # Walk the pre-body header children and return the update clause
         # unwalked: a C-style for's update runs only AFTER a completed body
         # iteration, never on the zero-iteration path and never before the
@@ -788,8 +804,8 @@ class FlowProcessor:
         return state, update
 
     def _walk_go_for_clause(
-        self, clause: Node, update: Node | None, state: _TaintMap, jc: _JsCtx
-    ) -> _TaintMap:
+        self, clause: Node, update: Node | None, state: _LeanState, jc: _JsCtx
+    ) -> _LeanState:
         # Go's init;cond;post for_clause: walk everything but the post
         # (update) statement, which the loop walk defers past the body.
         for part in clause.named_children:
@@ -798,8 +814,8 @@ class FlowProcessor:
         return state
 
     def _walk_flat_mandatory_loop(
-        self, node: Node, state: _TaintMap, jc: _JsCtx
-    ) -> _TaintMap:
+        self, node: Node, state: _LeanState, jc: _JsCtx
+    ) -> _LeanState:
         # A do-while / Rust `loop` body ALWAYS runs at least once, so the
         # pre-loop state is NOT part of the exit merge (a kill in the body
         # kills on every straight-line path), and a do-while condition runs
@@ -814,10 +830,10 @@ class FlowProcessor:
     def _walk_mandatory_loop(
         self,
         node: Node,
-        state: _TaintMap,
+        state: _LeanState,
         jc: _JsCtx,
-        walk: Callable[[Node, _TaintMap, _JsCtx], _TaintMap],
-    ) -> _TaintMap:
+        walk: Callable[[Node, _LeanState, _JsCtx], _LeanState],
+    ) -> _LeanState:
         # Loop shield: a break inside the body targets THIS loop, never an
         # enclosing switch arm's collector.
         self._shield_breaks()
@@ -829,28 +845,28 @@ class FlowProcessor:
     def _walk_mandatory_loop_inner(
         self,
         node: Node,
-        state: _TaintMap,
+        state: _LeanState,
         jc: _JsCtx,
-        walk: Callable[[Node, _TaintMap, _JsCtx], _TaintMap],
-    ) -> _TaintMap:
+        walk: Callable[[Node, _LeanState, _JsCtx], _LeanState],
+    ) -> _LeanState:
         body = node.child_by_field_name(cs.FIELD_BODY)
         condition = node.child_by_field_name(cs.TS_FIELD_CONDITION)
         pre_shadows = set(jc.local_names)
-        once = dict(state)
+        once = state.copy()
         if body is not None:
             once = walk(body, once, jc)
         if condition is not None:
             once = walk(condition, once, jc)
         self._restore_shadows(pre_shadows, jc)
-        twice = dict(once)
+        twice = once.copy()
         if body is not None:
             twice = walk(body, twice, jc)
         if condition is not None:
             twice = walk(condition, twice, jc)
         self._restore_shadows(pre_shadows, jc)
-        return self._merge([once, twice])
+        return self._merge_lean([once, twice])
 
-    def _walk_flat_try(self, node: Node, state: _TaintMap, jc: _JsCtx) -> _TaintMap:
+    def _walk_flat_try(self, node: Node, state: _LeanState, jc: _JsCtx) -> _LeanState:
         # The try body may run fully (no-throw path) or partially before a
         # catch, so each handler is seeded with union(pre, body_exit): taint
         # killed inside the body still reaches the handler, since the throw
@@ -869,22 +885,24 @@ class FlowProcessor:
                 continue
             state = self._walk_flat_stmt(child, state, jc)
         body_exit = (
-            self._walk_flat_stmt(body, dict(state), jc)
+            self._walk_flat_stmt(body, state.copy(), jc)
             if body is not None
-            else dict(state)
+            else state.copy()
         )
         self._restore_shadows(pre_shadows, jc)
-        branch_exits: list[_TaintMap] = [body_exit]
+        branch_exits: list[_LeanState] = [body_exit]
         finally_clause: Node | None = None
         for child in node.named_children:
             if child.type == cs.TS_JS_CATCH_CLAUSE:
                 branch_exits.append(
-                    self._walk_flat_stmt(child, self._merge([state, body_exit]), jc)
+                    self._walk_flat_stmt(
+                        child, self._merge_lean([state, body_exit]), jc
+                    )
                 )
                 self._restore_shadows(pre_shadows, jc)
             elif child.type == cs.TS_JS_FINALLY_CLAUSE:
                 finally_clause = child
-        merged = self._merge(branch_exits)
+        merged = self._merge_lean(branch_exits)
         if finally_clause is not None:
             merged = self._walk_flat_stmt(finally_clause, merged, jc)
             self._restore_shadows(pre_shadows, jc)
@@ -893,10 +911,10 @@ class FlowProcessor:
     def _walk_switch(
         self,
         node: Node,
-        state: _TaintMap,
+        state: _LeanState,
         jc: _JsCtx,
-        walk: Callable[[Node, _TaintMap, _JsCtx], _TaintMap],
-    ) -> _TaintMap:
+        walk: Callable[[Node, _LeanState, _JsCtx], _LeanState],
+    ) -> _LeanState:
         # Shared switch-family branch-and-merge (Go switch/type-switch/
         # select, Java switch, C++ switch, JS/TS switch). The header
         # (initializer, switched value, condition) runs on all paths; each
@@ -925,29 +943,29 @@ class FlowProcessor:
             return state
         exits, has_default = self._walk_switch_arms(arms, state, jc, walk)
         if not has_default:
-            exits.append(dict(state))
+            exits.append(state.copy())
         self._restore_shadows(pre_switch_shadows, jc)
-        return self._merge(exits)
+        return self._merge_lean(exits)
 
     def _walk_switch_arms(
         self,
         arms: list[Node],
-        state: _TaintMap,
+        state: _LeanState,
         jc: _JsCtx,
-        walk: Callable[[Node, _TaintMap, _JsCtx], _TaintMap],
-    ) -> tuple[list[_TaintMap], bool]:
+        walk: Callable[[Node, _LeanState, _JsCtx], _LeanState],
+    ) -> tuple[list[_LeanState], bool]:
         pre_arm_shadows = set(jc.local_names)
-        exits: list[_TaintMap] = []
-        fall_in: _TaintMap | None = None
+        exits: list[_LeanState] = []
+        fall_in: _LeanState | None = None
         has_default = False
         for index, arm in enumerate(arms):
             has_default = has_default or _switch_arm_is_default(arm)
-            entry = dict(state)
+            entry = state.copy()
             # fall_in is non-None exactly when the PREVIOUS arm can fall
             # into this one (C-family arm without a trailing break, or a Go
             # arm ending in the explicit `fallthrough` keyword).
             if fall_in is not None:
-                entry = self._merge([entry, fall_in])
+                entry = self._merge_lean([entry, fall_in])
             # Each break inside the arm exits the switch with the state it
             # saw THEN (a conditional break before a later kill carries the
             # live taint out), captured by the arm's own collector.
@@ -969,7 +987,7 @@ class FlowProcessor:
             fall_in = arm_exit if falls else None
         return exits, has_default
 
-    def _walk_flat_match(self, node: Node, state: _TaintMap, jc: _JsCtx) -> _TaintMap:
+    def _walk_flat_match(self, node: Node, state: _LeanState, jc: _JsCtx) -> _LeanState:
         # Rust match: the scrutinee runs on all paths; each arm is walked
         # against a copy and unioned (MAY join). Arms are exhaustive, so the
         # merge is over the arms only (no implicit skip path).
@@ -980,15 +998,15 @@ class FlowProcessor:
         if body is None:
             return state
         pre_shadows = set(jc.local_names)
-        arm_exits: list[_TaintMap] = []
+        arm_exits: list[_LeanState] = []
         for arm in body.named_children:
             if arm.type != cs.TS_RS_MATCH_ARM:
                 continue
-            arm_exits.append(self._walk_flat_stmt(arm, dict(state), jc))
+            arm_exits.append(self._walk_flat_stmt(arm, state.copy(), jc))
             self._restore_shadows(pre_shadows, jc)
-        return self._merge(arm_exits) if arm_exits else state
+        return self._merge_lean(arm_exits) if arm_exits else state
 
-    def _walk_flat_if(self, node: Node, state: _TaintMap, jc: _JsCtx) -> _TaintMap:
+    def _walk_flat_if(self, node: Node, state: _LeanState, jc: _JsCtx) -> _LeanState:
         # The header (any initializer + condition) runs on all paths; each of the
         # then / else(-if) / implicit skip paths is walked against a copy and
         # unioned (MAY join). Two shadow scopes are restored: a branch grows the
@@ -1004,29 +1022,29 @@ class FlowProcessor:
             if child.id not in skip:
                 state = self._walk_flat_stmt(child, state, jc)
         pre_shadows = set(jc.local_names)
-        branch_exits: list[_TaintMap] = []
+        branch_exits: list[_LeanState] = []
         if consequence is not None:
-            branch_exits.append(self._walk_flat_stmt(consequence, dict(state), jc))
+            branch_exits.append(self._walk_flat_stmt(consequence, state.copy(), jc))
             self._restore_shadows(pre_shadows, jc)
         if alternative is not None:
             # else_clause holds either a block or a nested if (else-if chain); the
             # recursion handles both and merges within.
-            branch_exits.append(self._walk_flat_stmt(alternative, dict(state), jc))
+            branch_exits.append(self._walk_flat_stmt(alternative, state.copy(), jc))
             self._restore_shadows(pre_shadows, jc)
         else:
             # No else: the skip path preserves the incoming state.
-            branch_exits.append(dict(state))
+            branch_exits.append(state.copy())
         self._restore_shadows(pre_if_shadows, jc)
-        return self._merge(branch_exits)
+        return self._merge_lean(branch_exits)
 
-    def _record_break_exit(self, state: _TaintMap) -> None:
+    def _record_break_exit(self, state: _LeanState) -> None:
         # Snapshot the live state at a `break` for the enclosing switch
         # arm's collector. None on top = a loop shield (the break targets
         # that loop); empty stack = no enclosing switch at all. A labeled
         # break targeting a farther construct still records here: the
         # extra state only widens the MAY join, the sound direction.
         if self._break_exit_stack and self._break_exit_stack[-1] is not None:
-            self._break_exit_stack[-1].append(dict(state))
+            self._break_exit_stack[-1].append(state.copy())
 
     def _shield_breaks(self) -> None:
         self._break_exit_stack.append(None)
@@ -1041,7 +1059,7 @@ class FlowProcessor:
         jc.local_names.clear()
         jc.local_names.update(pre_shadows)
 
-    def _walk_js_stmt(self, node: Node, state: _TaintMap, jc: _JsCtx) -> _TaintMap:
+    def _walk_js_stmt(self, node: Node, state: _LeanState, jc: _JsCtx) -> _LeanState:
         # Path-sensitive walk for JS/TS: control-flow nodes branch-and-merge, every
         # other node applies its leaf effect and threads state through its children
         # in source order (so a nested call in an argument is still seen).
@@ -1072,32 +1090,32 @@ class FlowProcessor:
             # AFTER it, so this is the mandatory-loop shape, not the
             # zero-or-more loop walk.
             return self._walk_mandatory_loop(node, state, jc, self._walk_js_stmt)
-        self._apply_js_leaf(node, state, jc)
+        self._apply_js_leaf(node, state.taint, state.handles, jc)
         for child in node.named_children:
             state = self._walk_js_stmt(child, state, jc)
         return state
 
-    def _walk_js_if(self, node: Node, state: _TaintMap, jc: _JsCtx) -> _TaintMap:
+    def _walk_js_if(self, node: Node, state: _LeanState, jc: _JsCtx) -> _LeanState:
         # The condition runs on all paths; each of the then / else(-if) / implicit
         # skip paths is walked against a copy and unioned (MAY join).
         cond = node.child_by_field_name(cs.TS_FIELD_CONDITION)
         if cond is not None:
             state = self._walk_js_stmt(cond, state, jc)
-        branch_exits: list[_TaintMap] = []
+        branch_exits: list[_LeanState] = []
         consequence = node.child_by_field_name(cs.TS_FIELD_CONSEQUENCE)
         if consequence is not None:
-            branch_exits.append(self._walk_js_stmt(consequence, dict(state), jc))
+            branch_exits.append(self._walk_js_stmt(consequence, state.copy(), jc))
         alternative = node.child_by_field_name(cs.FIELD_ALTERNATIVE)
         if alternative is not None:
             # else_clause holds either a block or a nested if (else-if chain); the
             # recursion handles both and merges within.
-            branch_exits.append(self._walk_js_stmt(alternative, dict(state), jc))
+            branch_exits.append(self._walk_js_stmt(alternative, state.copy(), jc))
         else:
             # No else: the skip path preserves the incoming state.
-            branch_exits.append(dict(state))
-        return self._merge(branch_exits)
+            branch_exits.append(state.copy())
+        return self._merge_lean(branch_exits)
 
-    def _walk_js_loop(self, node: Node, state: _TaintMap, jc: _JsCtx) -> _TaintMap:
+    def _walk_js_loop(self, node: Node, state: _LeanState, jc: _JsCtx) -> _LeanState:
         # Loop shield: a break inside the body targets THIS loop, never an
         # enclosing switch arm's collector.
         self._shield_breaks()
@@ -1107,8 +1125,8 @@ class FlowProcessor:
             self._unshield_breaks()
 
     def _walk_js_loop_inner(
-        self, node: Node, state: _TaintMap, jc: _JsCtx
-    ) -> _TaintMap:
+        self, node: Node, state: _LeanState, jc: _JsCtx
+    ) -> _LeanState:
         # The initializer/condition/iterable runs before the body; the body runs
         # zero or more times, so union the skip path with one pass, then re-walk
         # once from that merge to catch taint carried from a later iteration into
@@ -1128,39 +1146,41 @@ class FlowProcessor:
                 continue
             state = self._walk_js_stmt(child, state, jc)
         if body is not None:
-            once = self._walk_js_stmt(body, dict(state), jc)
+            once = self._walk_js_stmt(body, state.copy(), jc)
             if increment is not None:
                 once = self._walk_js_stmt(increment, once, jc)
-            merged = self._merge([state, once])
-            twice = self._walk_js_stmt(body, dict(merged), jc)
+            merged = self._merge_lean([state, once])
+            twice = self._walk_js_stmt(body, merged.copy(), jc)
             if increment is not None:
                 twice = self._walk_js_stmt(increment, twice, jc)
-            state = self._merge([state, twice])
+            state = self._merge_lean([state, twice])
         return state
 
-    def _walk_js_try(self, node: Node, state: _TaintMap, jc: _JsCtx) -> _TaintMap:
+    def _walk_js_try(self, node: Node, state: _LeanState, jc: _JsCtx) -> _LeanState:
         # The try body may run fully (no-throw path) or partially before a catch;
         # seed the handler with union(pre, body_exit) so taint introduced before a
         # throw still reaches it. A finally runs on the merged state of both.
         body = node.child_by_field_name(cs.FIELD_BODY)
         body_exit = (
-            self._walk_js_stmt(body, dict(state), jc)
+            self._walk_js_stmt(body, state.copy(), jc)
             if body is not None
-            else dict(state)
+            else state.copy()
         )
-        branch_exits: list[_TaintMap] = [body_exit]
+        branch_exits: list[_LeanState] = [body_exit]
         handler = node.child_by_field_name(cs.FIELD_HANDLER)
         if handler is not None:
             branch_exits.append(
-                self._walk_js_stmt(handler, self._merge([state, body_exit]), jc)
+                self._walk_js_stmt(handler, self._merge_lean([state, body_exit]), jc)
             )
-        merged = self._merge(branch_exits)
+        merged = self._merge_lean(branch_exits)
         finalizer = node.child_by_field_name(cs.FIELD_FINALIZER)
         if finalizer is not None:
             merged = self._walk_js_stmt(finalizer, merged, jc)
         return merged
 
-    def _apply_js_leaf(self, node: Node, tainted: _TaintMap, jc: _JsCtx) -> None:
+    def _apply_js_leaf(
+        self, node: Node, tainted: _TaintMap, handles: _HandleMap, jc: _JsCtx
+    ) -> None:
         # The leaf effect of one node on the taint map: bind (JS/Go), Go range
         # kill, a call's sink/arg edges, or a return's contribution to the summary.
         node_type = node.type
@@ -1169,14 +1189,14 @@ class FlowProcessor:
             cs.TS_ASSIGNMENT_EXPRESSION,
             cs.TS_GO_ASSIGNMENT_STATEMENT,
         ):
-            self._lean_bind(node, tainted, jc)
+            self._lean_bind(node, tainted, handles, jc)
         elif node_type in d.extra_declarator_types:
             if node_type == cs.TS_GO_RANGE_CLAUSE:
-                self._lean_kill(node, tainted, jc)
+                self._lean_kill(node, tainted, handles, jc)
             else:
-                self._lean_bind(node, tainted, jc)
+                self._lean_bind(node, tainted, handles, jc)
         elif node_type == d.call_type:
-            self._js_call(node, tainted, jc)
+            self._js_call(node, tainted, handles, jc)
         elif d.macro_type is not None and node_type == d.macro_type:
             self._flow_macro(node, tainted, jc)
         elif d.stream_sink_type is not None and node_type == d.stream_sink_type:
@@ -1187,7 +1207,9 @@ class FlowProcessor:
                 self._acc_returns_taint = True
                 self._acc_return_taint = _merge_taint(self._acc_return_taint, returned)
 
-    def _lean_bind(self, node: Node, tainted: _TaintMap, jc: _JsCtx) -> None:
+    def _lean_bind(
+        self, node: Node, tainted: _TaintMap, handles: _HandleMap, jc: _JsCtx
+    ) -> None:
         # Bind LHS name(s) to their RHS taint across the grammars: JS uses a single
         # `name`/`value` (declarator) or `left`/`right` (assignment); Go uses `left`/
         # `right` expression_lists (`:=`, `=`) or `name`/`value` (`var`/`const`).
@@ -1216,18 +1238,22 @@ class FlowProcessor:
             else:
                 tainted.pop(name, None)
             # Track (or kill) the resource handle bound to this name, so a later
-            # tainted write through it emits a flow edge (issue #1204).
+            # tainted write through it emits a flow edge (issue #1204). A binding is
+            # a STRONG update (replaces the set), so straight-line reassignment
+            # redirects the handle; only a branch join widens a name to multiple.
             if jc.handle_ctors:
                 binding = self._lean_handle_binding(rhs, jc)
                 if binding is not None:
-                    jc.handles[name] = binding
+                    handles[name] = frozenset({binding})
                 else:
-                    jc.handles.pop(name, None)
+                    handles.pop(name, None)
         # Register the bound names AFTER reading the RHS (which still saw the
         # pre-declaration scope): a Go shadow applies only from here forward.
         self._register_shadows(targets, jc)
 
-    def _lean_kill(self, node: Node, tainted: _TaintMap, jc: _JsCtx) -> None:
+    def _lean_kill(
+        self, node: Node, tainted: _TaintMap, handles: _HandleMap, jc: _JsCtx
+    ) -> None:
         left = node.child_by_field_name(cs.FIELD_LEFT)
         if left is None:
             return
@@ -1235,6 +1261,7 @@ class FlowProcessor:
         for name in names:
             if name is not None:
                 tainted.pop(name, None)
+                handles.pop(name, None)
         self._register_shadows(names, jc)
 
     @staticmethod
@@ -1338,7 +1365,9 @@ class FlowProcessor:
                     return self._js_expr_taint(receiver, tainted, jc)
         return None
 
-    def _js_call(self, node: Node, tainted: _TaintMap, jc: _JsCtx) -> None:
+    def _js_call(
+        self, node: Node, tainted: _TaintMap, handles: _HandleMap, jc: _JsCtx
+    ) -> None:
         raw = call_name(node)
         if raw is None:
             return
@@ -1375,7 +1404,7 @@ class FlowProcessor:
                     )
             return
         # A tainted write through a bound resource handle (issue #1204).
-        if jc.handles and self._emit_handle_write(raw, args, jc):
+        if handles and self._emit_handle_write(raw, args, handles, jc):
             return
         callee = self._resolve(
             raw,
@@ -1429,7 +1458,9 @@ class FlowProcessor:
         if raw is None:
             return None
         ctor = self._js_match_sink(raw, jc.handle_ctors, jc)
-        if ctor is None:
+        if ctor is None or ctor.direction == IODirection.READ:
+            # A READ-only handle (`os.Open`) is never a write sink; do not bind it,
+            # so a later `f.Write(...)` through it emits nothing (issue #1204).
             return None
         identity = literal_target(
             rhs,
@@ -1445,28 +1476,36 @@ class FlowProcessor:
         return HandleBinding(ctor.kind, identity)
 
     def _emit_handle_write(
-        self, raw: str, args: list[tuple[str, Taint | None]], jc: _JsCtx
+        self,
+        raw: str,
+        args: list[tuple[str, Taint | None]],
+        handles: _HandleMap,
+        jc: _JsCtx,
     ) -> bool:
         # A tainted write through a bound handle (`f.Write(secret)`) is a flow to
         # the handle's resource (issue #1204). Split the callee into receiver +
-        # method; if the receiver is a bound handle and the method WRITES (or is a
-        # read/write like a DB execute), route each tainted arg to the resource.
-        # Pure READ methods are not sinks. Untainted args emit nothing.
+        # method; for EACH handle the receiver may hold (a name can hold different
+        # handles on different branches), if the method WRITES (or is read/write
+        # like a DB execute), route each tainted arg to that resource. Pure READ
+        # methods are not sinks; untainted args emit nothing.
         recv, sep, method = raw.rpartition(cs.SEPARATOR_DOT)
         if not sep:
             return False
-        binding = jc.handles.get(recv)
-        if binding is None:
+        bindings = handles.get(recv)
+        if not bindings:
             return False
-        direction = jc.handle_methods.get(binding.kind, {}).get(method)
-        if direction is None or direction == IODirection.READ:
-            return False
-        for _via, taint in args:
-            if taint is not None:
-                self._emit_taint_to_sink(
-                    taint, binding.kind, binding.identity, jc.flow.caller_qn
-                )
-        return True
+        emitted = False
+        for binding in bindings:
+            direction = jc.handle_methods.get(binding.kind, {}).get(method)
+            if direction is None or direction == IODirection.READ:
+                continue
+            emitted = True
+            for _via, taint in args:
+                if taint is not None:
+                    self._emit_taint_to_sink(
+                        taint, binding.kind, binding.identity, jc.flow.caller_qn
+                    )
+        return emitted
 
     def _emit_taint_to_sink(
         self, taint: Taint, kind: ResourceKind, identity: str, caller_qn: str
@@ -1876,6 +1915,18 @@ class FlowProcessor:
                 existing = out.get(var)
                 out[var] = _merge_taint(existing, taint) if existing else taint
         return out
+
+    @staticmethod
+    def _merge_lean(states: list[_LeanState]) -> _LeanState:
+        # MAY union of both maps across branches (issue #1204). Taint reuses
+        # _merge; handles union per name, so a variable that may hold either of
+        # two handles on different paths writes to BOTH at a later method call.
+        handles: _HandleMap = {}
+        for s in states:
+            for name, bindings in s.handles.items():
+                existing = handles.get(name)
+                handles[name] = existing | bindings if existing else bindings
+        return _LeanState(FlowProcessor._merge([s.taint for s in states]), handles)
 
     def _walk_stmt(self, node: Node, state: _TaintMap, ctx: _FlowCtx) -> _TaintMap:
         node_type = node.type

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -24,6 +24,7 @@ from ..io_access import (
     PY_SCOPE_BOUNDARIES,
     RESOURCE_QN_FORMAT,
     HandleBinding,
+    HandleConstructor,
     IODirection,
     IOSink,
     LanguageDescriptor,
@@ -43,6 +44,10 @@ from ..io_access import (
     scope_seed_nodes,
     string_literal,
     unwrap_argument,
+)
+from ..io_access.registry import (
+    IO_LEAN_HANDLE_CONSTRUCTORS,
+    IO_LEAN_HANDLE_METHODS,
 )
 from ..utils import (
     c_positional_parameter_slots,
@@ -434,6 +439,14 @@ class _JsCtx(NamedTuple):
     # declarations for JS/TS) and grown with each Go binding as the walk reaches
     # it, so a later Go shadow never suppresses an earlier valid source read.
     local_names: set[str]
+    # Handle-based writes (issue #1204): a local bound to a resource handle
+    # (`f := os.Create("out")`) so a tainted write through it (`f.Write(secret)`)
+    # emits a flow edge to the handle's resource. MUTABLE, flat/last-write-wins
+    # like io_access's handle walk; the ctor/method tables are the per-language
+    # registry views. Empty tables (no handle support for the language) => inert.
+    handles: dict[str, HandleBinding]
+    handle_ctors: dict[str, HandleConstructor]
+    handle_methods: dict[ResourceKind, dict[str, IODirection]]
 
 
 class FlowProcessor:
@@ -628,6 +641,11 @@ class FlowProcessor:
             descriptor=descriptor,
             member_reads=member_reads,
             local_names=self._js_local_names(caller_node, descriptor, ctx.language),
+            handles={},
+            handle_ctors={
+                c.callee: c for c in IO_LEAN_HANDLE_CONSTRUCTORS.get(ctx.language, ())
+            },
+            handle_methods=IO_LEAN_HANDLE_METHODS.get(ctx.language, {}),
         )
         body = caller_node.child_by_field_name(cs.FIELD_BODY)
         if body is None:
@@ -1182,7 +1200,7 @@ class FlowProcessor:
         # map before any LHS is updated, so `a, b = b, a` swaps correctly. Compute
         # all taints first, then apply, or an earlier LHS update would corrupt a
         # later RHS read of the same name.
-        computed: list[tuple[str, Taint | None]] = []
+        computed: list[tuple[str, Taint | None, Node | None]] = []
         for index, name in enumerate(targets):
             if name is None:
                 continue
@@ -1191,12 +1209,20 @@ class FlowProcessor:
                 if spread
                 else (values[index] if index < len(values) else None)
             )
-            computed.append((name, self._js_expr_taint(rhs, tainted, jc)))
-        for name, taint in computed:
+            computed.append((name, self._js_expr_taint(rhs, tainted, jc), rhs))
+        for name, taint, rhs in computed:
             if taint is not None:
                 tainted[name] = taint
             else:
                 tainted.pop(name, None)
+            # Track (or kill) the resource handle bound to this name, so a later
+            # tainted write through it emits a flow edge (issue #1204).
+            if jc.handle_ctors:
+                binding = self._lean_handle_binding(rhs, jc)
+                if binding is not None:
+                    jc.handles[name] = binding
+                else:
+                    jc.handles.pop(name, None)
         # Register the bound names AFTER reading the RHS (which still saw the
         # pre-declaration scope): a Go shadow applies only from here forward.
         self._register_shadows(targets, jc)
@@ -1348,6 +1374,9 @@ class FlowProcessor:
                         (sink.kind, dst_identity)
                     )
             return
+        # A tainted write through a bound resource handle (issue #1204).
+        if jc.handles and self._emit_handle_write(raw, args, jc):
+            return
         callee = self._resolve(
             raw,
             jc.flow.module_qn,
@@ -1386,6 +1415,58 @@ class FlowProcessor:
                 self._param_flow_edges.append(
                     (jc.flow.caller_qn, pname, callee_qn, via)
                 )
+
+    def _lean_handle_binding(
+        self, rhs: Node | None, jc: _JsCtx
+    ) -> HandleBinding | None:
+        # Resolve a RHS handle-constructor call (`os.Create("out")`) to a
+        # HandleBinding, shadow-aware and import-normalised exactly like sink
+        # matching. None when the RHS is not a registered handle constructor
+        # (issue #1204).
+        if rhs is None or rhs.type != jc.descriptor.call_type:
+            return None
+        raw = call_name(rhs)
+        if raw is None:
+            return None
+        ctor = self._js_match_sink(raw, jc.handle_ctors, jc)
+        if ctor is None:
+            return None
+        identity = literal_target(
+            rhs,
+            ctor.target_arg,
+            ctor.target_kw,
+            string_type=jc.descriptor.string_type,
+            content_type=jc.descriptor.string_content_type,
+            keyword_arg_type=jc.descriptor.keyword_arg_type,
+            wrapper_type=jc.descriptor.argument_wrapper_type,
+            template_type=jc.descriptor.template_string_type,
+            substitution_type=jc.descriptor.template_substitution_type,
+        )
+        return HandleBinding(ctor.kind, identity)
+
+    def _emit_handle_write(
+        self, raw: str, args: list[tuple[str, Taint | None]], jc: _JsCtx
+    ) -> bool:
+        # A tainted write through a bound handle (`f.Write(secret)`) is a flow to
+        # the handle's resource (issue #1204). Split the callee into receiver +
+        # method; if the receiver is a bound handle and the method WRITES (or is a
+        # read/write like a DB execute), route each tainted arg to the resource.
+        # Pure READ methods are not sinks. Untainted args emit nothing.
+        recv, sep, method = raw.rpartition(cs.SEPARATOR_DOT)
+        if not sep:
+            return False
+        binding = jc.handles.get(recv)
+        if binding is None:
+            return False
+        direction = jc.handle_methods.get(binding.kind, {}).get(method)
+        if direction is None or direction == IODirection.READ:
+            return False
+        for _via, taint in args:
+            if taint is not None:
+                self._emit_taint_to_sink(
+                    taint, binding.kind, binding.identity, jc.flow.caller_qn
+                )
+        return True
 
     def _emit_taint_to_sink(
         self, taint: Taint, kind: ResourceKind, identity: str, caller_qn: str
@@ -1678,9 +1759,7 @@ class FlowProcessor:
         return HandleBinding(kind=sink.kind, identity=identity)
 
     @staticmethod
-    def _js_match_sink(
-        raw: str, sink_map: dict[str, IOSink], jc: _JsCtx
-    ) -> IOSink | None:
+    def _js_match_sink[T](raw: str, sink_map: dict[str, T], jc: _JsCtx) -> T | None:
         # Same shadow-aware matching as io_access: a locally-bound name is not
         # the builtin; the import-normalised name matches first (so an aliased
         # builtin resolves), then the raw dotted name only when its head resolves

--- a/codebase_rag/parsers/io_access/models.py
+++ b/codebase_rag/parsers/io_access/models.py
@@ -50,6 +50,12 @@ class HandleConstructor:
     # identity (C# `new SqlCommand(sql, conn)` inherits conn's DB identity from
     # arg1). None where the identity is a literal target_arg.
     handle_arg: int | None = None
+    # Access capability of the constructed handle. The lean write-flow walk
+    # (issue #1204) suppresses write emission for a READ-only handle: `os.Open` is
+    # read-only, so `f.Write` on it is not a real sink. Defaults to READ_WRITE so
+    # io_access -- which never inspects this field -- is unchanged, and a
+    # flag-dependent ctor (`os.OpenFile`) stays a sound may-write.
+    direction: IODirection = IODirection.READ_WRITE
 
 
 @dataclass(frozen=True)

--- a/codebase_rag/parsers/io_access/registry.py
+++ b/codebase_rag/parsers/io_access/registry.py
@@ -645,8 +645,14 @@ _JS_TS_LEAN_HANDLE_CONSTRUCTORS: tuple[HandleConstructor, ...] = (
 # os.Open / os.Create are ALSO direct sinks (the construction touches the path);
 # os.OpenFile is a handle only, because its direction depends on flags.
 _GO_LEAN_HANDLE_CONSTRUCTORS: tuple[HandleConstructor, ...] = (
-    HandleConstructor("os.Open", ResourceKind.FILE, target_arg=0),
-    HandleConstructor("os.Create", ResourceKind.FILE, target_arg=0),
+    HandleConstructor(
+        "os.Open", ResourceKind.FILE, target_arg=0, direction=IODirection.READ
+    ),
+    HandleConstructor(
+        "os.Create", ResourceKind.FILE, target_arg=0, direction=IODirection.WRITE
+    ),
+    # Flag-dependent (O_RDONLY/O_WRONLY/O_RDWR); may-write is the sound
+    # over-approximation for a taint tool -- never silently drop a real write.
     HandleConstructor("os.OpenFile", ResourceKind.FILE, target_arg=0),
     HandleConstructor("database/sql.Open", ResourceKind.DATABASE, target_arg=1),
     HandleConstructor("net.Dial", ResourceKind.SOCKET, target_arg=1),

--- a/codebase_rag/tests/test_flow_handle_writes.py
+++ b/codebase_rag/tests/test_flow_handle_writes.py
@@ -123,3 +123,87 @@ def test_go_read_method_is_not_a_write_sink(tmp_path: Path) -> None:
         )
     }
     assert _ENV_FILE not in _run_flow(tmp_path, files)
+
+
+def test_go_read_only_open_handle_write_emits_no_flow(tmp_path: Path) -> None:
+    # `os.Open` is read-only, so `f.Write` on it is not a real write sink and must
+    # emit no edge (constructor access mode gates write emission).
+    files = {
+        "main.go": (
+            "package main\n\n"
+            'import "os"\n\n'
+            "func leak() {\n"
+            '\ts := os.Getenv("K")\n'
+            '\tf, _ := os.Open("out.txt")\n'
+            "\tf.Write([]byte(s))\n"
+            "}\n"
+        )
+    }
+    assert _ENV_FILE not in _run_flow(tmp_path, files)
+
+
+def test_go_conditional_rebind_emits_to_both_files(tmp_path: Path) -> None:
+    # `f` may hold either handle after the if, so the write must reach BOTH files
+    # (path-sensitive MAY merge of the handle bindings).
+    files = {
+        "main.go": (
+            "package main\n\n"
+            'import "os"\n\n'
+            "func leak(cond bool) {\n"
+            '\ts := os.Getenv("K")\n'
+            '\tf, _ := os.Create("first.txt")\n'
+            "\tif cond {\n"
+            '\t\tf, _ = os.Create("second.txt")\n'
+            "\t}\n"
+            "\tf.WriteString(s)\n"
+            "}\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::K", "resource::FILE::first.txt") in flows
+    assert ("resource::ENV::K", "resource::FILE::second.txt") in flows
+
+
+def test_go_for_rebind_preserves_outer_flow(tmp_path: Path) -> None:
+    # A rebind inside a for body may or may not run; the outer handle's flow must
+    # survive the loop join alongside the loop-body handle.
+    files = {
+        "main.go": (
+            "package main\n\n"
+            'import "os"\n\n'
+            "func leak(items []int) {\n"
+            '\ts := os.Getenv("K")\n'
+            '\tf, _ := os.Create("first.txt")\n'
+            "\tfor range items {\n"
+            '\t\tf, _ = os.Create("loop.txt")\n'
+            "\t}\n"
+            "\tf.WriteString(s)\n"
+            "}\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::K", "resource::FILE::first.txt") in flows
+    assert ("resource::ENV::K", "resource::FILE::loop.txt") in flows
+
+
+def test_go_switch_rebind_preserves_outer_flow(tmp_path: Path) -> None:
+    # A rebind in one switch arm (no default) leaves the outer handle live on the
+    # implicit no-match path; the write must reach both.
+    files = {
+        "main.go": (
+            "package main\n\n"
+            'import "os"\n\n'
+            "func leak(n int) {\n"
+            '\ts := os.Getenv("K")\n'
+            '\tf, _ := os.Create("first.txt")\n'
+            "\tswitch n {\n"
+            "\tcase 1:\n"
+            '\t\tf, _ = os.Create("case1.txt")\n'
+            "\t}\n"
+            "\tf.WriteString(s)\n"
+            "}\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::K", "resource::FILE::first.txt") in flows
+    assert ("resource::ENV::K", "resource::FILE::case1.txt") in flows

--- a/codebase_rag/tests/test_flow_handle_writes.py
+++ b/codebase_rag/tests/test_flow_handle_writes.py
@@ -109,6 +109,8 @@ def test_go_handle_reassignment_tracks_the_new_resource(tmp_path: Path) -> None:
 
 def test_go_read_method_is_not_a_write_sink(tmp_path: Path) -> None:
     # A read through the handle is not a taint sink; only writes emit flow edges.
+    # The arg is genuinely tainted (`[]byte(s)` preserves taint), so this validates
+    # that `Read` is classified as a READ method, not merely that the arg is clean.
     files = {
         "main.go": (
             "package main\n\n"
@@ -116,8 +118,7 @@ def test_go_read_method_is_not_a_write_sink(tmp_path: Path) -> None:
             "func leak() {\n"
             '\ts := os.Getenv("K")\n'
             '\tf, _ := os.Create("out.txt")\n'
-            "\tbuf := make([]byte, len(s))\n"
-            "\tf.Read(buf)\n"
+            "\tf.Read([]byte(s))\n"
             "}\n"
         )
     }

--- a/codebase_rag/tests/test_flow_handle_writes.py
+++ b/codebase_rag/tests/test_flow_handle_writes.py
@@ -1,0 +1,124 @@
+"""Handle-based writes in the lean FLOWS_TO walk (issue #1204). A tainted value
+written through a resource handle (`f := os.Create(..); f.Write(secret)`) must
+emit a flow edge to the handle's resource, instead of the false NO_FLOW the walk
+produced when it modelled only direct call sinks. First landing: Go."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.capture import resolve_capture
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+FLOWS_TO = cs.RelationshipType.FLOWS_TO.value
+_CAPTURE_IO = resolve_capture([cs.CaptureGroup.IO.value])
+
+
+def _run_flow(tmp_path: Path, files: dict[str, str]) -> set[tuple[str, str]]:
+    parsers, queries = load_parsers()
+    if "go" not in parsers:
+        pytest.skip("go parser not available")
+    for rel, content in files.items():
+        (tmp_path / rel).write_text(content, encoding="utf-8")
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        capture=_CAPTURE_IO,
+    ).run()
+    return {
+        (c.args[0][2], c.args[2][2])
+        for c in mock.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) == FLOWS_TO
+    }
+
+
+_ENV_FILE = ("resource::ENV::K", "resource::FILE::out.txt")
+
+
+def test_go_tainted_write_through_file_handle(tmp_path: Path) -> None:
+    files = {
+        "main.go": (
+            "package main\n\n"
+            'import "os"\n\n'
+            "func leak() {\n"
+            '\ts := os.Getenv("K")\n'
+            '\tf, _ := os.Create("out.txt")\n'
+            "\tf.Write([]byte(s))\n"
+            "}\n"
+        )
+    }
+    assert _ENV_FILE in _run_flow(tmp_path, files)
+
+
+def test_go_tainted_write_string_through_file_handle(tmp_path: Path) -> None:
+    files = {
+        "main.go": (
+            "package main\n\n"
+            'import "os"\n\n'
+            "func leak() {\n"
+            '\ts := os.Getenv("K")\n'
+            '\tf, _ := os.Create("out.txt")\n'
+            "\tf.WriteString(s)\n"
+            "}\n"
+        )
+    }
+    assert _ENV_FILE in _run_flow(tmp_path, files)
+
+
+def test_go_untainted_handle_write_emits_no_flow(tmp_path: Path) -> None:
+    files = {
+        "main.go": (
+            "package main\n\n"
+            'import "os"\n\n'
+            "func leak() {\n"
+            '\tf, _ := os.Create("out.txt")\n'
+            '\tf.WriteString("literal")\n'
+            "}\n"
+        )
+    }
+    assert _ENV_FILE not in _run_flow(tmp_path, files)
+
+
+def test_go_handle_reassignment_tracks_the_new_resource(tmp_path: Path) -> None:
+    # Rebinding the handle var to a second file redirects the write; the taint
+    # must reach the SECOND file only, never the first.
+    files = {
+        "main.go": (
+            "package main\n\n"
+            'import "os"\n\n'
+            "func leak() {\n"
+            '\ts := os.Getenv("K")\n'
+            '\tf, _ := os.Create("first.txt")\n'
+            '\tf, _ = os.Create("second.txt")\n'
+            "\tf.WriteString(s)\n"
+            "}\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::K", "resource::FILE::second.txt") in flows
+    assert ("resource::ENV::K", "resource::FILE::first.txt") not in flows
+
+
+def test_go_read_method_is_not_a_write_sink(tmp_path: Path) -> None:
+    # A read through the handle is not a taint sink; only writes emit flow edges.
+    files = {
+        "main.go": (
+            "package main\n\n"
+            'import "os"\n\n'
+            "func leak() {\n"
+            '\ts := os.Getenv("K")\n'
+            '\tf, _ := os.Create("out.txt")\n'
+            "\tbuf := make([]byte, len(s))\n"
+            "\tf.Read(buf)\n"
+            "}\n"
+        )
+    }
+    assert _ENV_FILE not in _run_flow(tmp_path, files)

--- a/docs/architecture/data-flow-edges.md
+++ b/docs/architecture/data-flow-edges.md
@@ -386,14 +386,16 @@ module is re-exported under its own name. A project that does
 - The source/sink registry covers Python, JavaScript, TypeScript (including TSX),
   Go, Java, Rust, C, C++, C#, and Lua; a language not in the registry emits no I/O
   or flow edges until its table is added.
-- The lean (non-Python) `FLOWS_TO` walk matches **direct call sinks only**; a taint
-  that reaches a resource through a handle method (`os.Create(p).Write(x)`,
-  `io.open(p):write(x)`, `File::create(p).write(x)`) emits no flow edge, uniformly
-  across every lean language — the handle-tracking tables feed the `READS_FROM`/
-  `WRITES_TO` walk, not the flow walk. So a handle-only write leak reads as `NO_FLOW`
-  rather than `UNKNOWN` in a fully covered project; teaching the flow walk to track
-  handle bindings (cross-language) is tracked in #1204. This bites Lua hardest, since Lua has
-  no direct file-write sink at all.
+- Handle-based writes in the lean (non-Python) `FLOWS_TO` walk are being taught
+  incrementally (issue #1204). **Go** now tracks handle bindings, so a taint written
+  through a file/socket/db handle (`f := os.Create(p); f.Write(x)`) emits a flow edge
+  to the handle's resource. The remaining lean languages (Rust, Java, C#, JS/TS, C,
+  C++, Lua) still match **direct call sinks only** — a handle-method write there
+  (`io.open(p):write(x)`, `File::create(p).write(x)`) emits no flow edge, so such a
+  leak reads as `NO_FLOW` rather than `UNKNOWN` in a fully covered project. The
+  handle-tracking tables that feed the `READS_FROM`/`WRITES_TO` walk are the reuse
+  target as each language lands. This bites Lua hardest, since Lua has no direct
+  file-write sink at all (and no handle tables in either walk yet).
 
 These are deliberate ceilings, chosen so the feature is correct and cheap where
 it applies rather than broad and noisy.


### PR DESCRIPTION
First landing of #1204. The lean (non-Python) FLOWS_TO walk matched **direct call sinks only**, so a taint written through a resource handle (`f, _ := os.Create(p); f.Write(secret)`) emitted no flow edge while the module was `flow_covered` — a false NO_FLOW. This teaches the walk to track handle bindings, starting with **Go** (every handle table it needs already exists in the registry).

## Scope (incremental — #1204 is a multi-language effort)
Go only. Follow-ups will extend the same mechanism to Rust, Java/C#, JS/TS, C/C++, and Lua (which additionally needs new registry tables + colon-receiver handling). Go is the cleanest first landing: call-shaped constructors (`os.Create`/`os.OpenFile`/`os.Open`) and dotted-receiver methods (`f.Write`/`f.WriteString`), both already catalogued in `IO_LEAN_HANDLE_CONSTRUCTORS`/`IO_LEAN_HANDLE_METHODS`.

## How it works (reuses existing flow-walk machinery — no io_access refactor)
- `_JsCtx` gains a mutable `handles: dict[str, HandleBinding]` plus the per-language ctor/method registry views (empty ⇒ inert for every not-yet-supported language).
- `_lean_bind` resolves a handle-constructor RHS to a `HandleBinding(kind, identity)` and binds it to the LHS name (rebinding to a non-handle kills it) — via `_lean_handle_binding`, which reuses the walk's OWN `_js_match_sink` (generalized to a TypeVar; all existing sink call sites unchanged) for shadow-aware, import-normalised constructor matching and `literal_target` for the resource identity. So constructor resolution shares the flow walk's sink-matching logic rather than duplicating io_access's resolver.
- `_js_call` adds a handle-method-write branch (`_emit_handle_write`): if the callee is `recv.method`, `recv` is a bound handle, and `method` writes (or is read/write), each **tainted** argument is routed through the existing `_emit_taint_to_sink` with the handle's kind + identity.

## Composition & soundness
Because it funnels through the existing `_emit_taint_to_sink`, it composes for free with parameter taint (#1169), return composition (#712), and the three-verdict coverage. **No false positives**: an untainted handle write passes empty taint and emits nothing; a pure READ method is not a sink. Handle binding is flat/last-write-wins (matching io_access's stance); block-scoped handle precision is a follow-up.

## Tests (`test_flow_handle_writes.py`)
Go: tainted `f.Write([]byte(s))` and `f.WriteString(s)` → `resource::ENV::K → resource::FILE::out.txt`; untainted write → no edge; handle reassignment → taint reaches the SECOND file only; a `f.Read(...)` → no edge.

Broad flow/io/handle/sink/taint regression: **909 passed, 9 skipped**. lint/format/ty clean. Doc caveat in `data-flow-edges.md` updated to reflect Go's new coverage and the remaining-languages status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Go data-flow analysis to detect tainted data written through file, socket, and database handles.
  * Tracks handle reassignment and control-flow branches so writes are associated with possible resources.
  * Read-only handles and methods are excluded from write-flow results.
  * Supports common file-handle write operations, including string writes, with access-direction awareness.

* **Documentation**
  * Updated data-flow documentation to describe Go handle tracking and language-specific analysis coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->