### PR TITLE
test: lock in JS/TS handle-write coverage and correct docs (#1204)

### DIFF
--- a/codebase_rag/tests/test_flow_handle_writes.py
+++ b/codebase_rag/tests/test_flow_handle_writes.py
@@ -19,7 +19,14 @@ FLOWS_TO = cs.RelationshipType.FLOWS_TO.value
 _CAPTURE_IO = resolve_capture([cs.CaptureGroup.IO.value])
 
 
-_LANG_BY_EXT = {".go": "go", ".rs": "rust", ".java": "java", ".cs": "c_sharp"}
+_LANG_BY_EXT = {
+    ".go": "go",
+    ".rs": "rust",
+    ".java": "java",
+    ".cs": "c_sharp",
+    ".js": "javascript",
+    ".ts": "typescript",
+}
 
 
 def _run_flow(tmp_path: Path, files: dict[str, str]) -> set[tuple[str, str]]:
@@ -621,6 +628,44 @@ def test_csharp_untainted_new_handle_write_emits_no_flow(tmp_path: Path) -> None
             '    var w = new StreamWriter("out.txt");\n'
             '    w.Write("literal");\n'
             "  }\n"
+            "}\n"
+        )
+    }
+    assert _ENV_FILE not in _run_flow(tmp_path, files)
+
+
+def _js_ts_write_stream(rel: str) -> dict[str, str]:
+    return {
+        rel: (
+            "function leak() {\n"
+            "  const s = process.env.K;\n"
+            "  const ws = fs.createWriteStream('out.txt');\n"
+            "  ws.write(s);\n"
+            "}\n"
+        )
+    }
+
+
+# --- JS/TS (issue #1204; coverage predates the Go/Rust/Java/C# increments via the
+# call-shaped `fs.createWriteStream` handle table, but was previously untested). ---
+
+
+def test_js_tainted_write_through_write_stream(tmp_path: Path) -> None:
+    # `fs.createWriteStream('out.txt')` is a WRITE handle; `ws.write(process.env.K)`
+    # reaches the file. `process.env.K` is the ENV read source.
+    assert _ENV_FILE in _run_flow(tmp_path, _js_ts_write_stream("a.js"))
+
+
+def test_ts_tainted_write_through_write_stream(tmp_path: Path) -> None:
+    assert _ENV_FILE in _run_flow(tmp_path, _js_ts_write_stream("a.ts"))
+
+
+def test_js_untainted_write_stream_emits_no_flow(tmp_path: Path) -> None:
+    files = {
+        "a.js": (
+            "function leak() {\n"
+            "  const ws = fs.createWriteStream('out.txt');\n"
+            "  ws.write('literal');\n"
             "}\n"
         )
     }

--- a/codebase_rag/tests/test_flow_handle_writes.py
+++ b/codebase_rag/tests/test_flow_handle_writes.py
@@ -661,6 +661,8 @@ def test_ts_tainted_write_through_write_stream(tmp_path: Path) -> None:
 
 
 def test_js_untainted_write_stream_emits_no_flow(tmp_path: Path) -> None:
+    # A literal write through the handle taints nothing, so the walk emits no
+    # FLOWS_TO edge at all (not merely "not the ENV->FILE one").
     files = {
         "a.js": (
             "function leak() {\n"
@@ -669,7 +671,7 @@ def test_js_untainted_write_stream_emits_no_flow(tmp_path: Path) -> None:
             "}\n"
         )
     }
-    assert _ENV_FILE not in _run_flow(tmp_path, files)
+    assert _run_flow(tmp_path, files) == set()
 
 
 def test_csharp_sqlcommand_inherits_every_merged_connection(tmp_path: Path) -> None:

--- a/docs/architecture/data-flow-edges.md
+++ b/docs/architecture/data-flow-edges.md
@@ -387,24 +387,27 @@ module is re-exported under its own name. A project that does
   Go, Java, Rust, C, C++, C#, and Lua; a language not in the registry emits no I/O
   or flow edges until its table is added.
 - Handle-based writes in the lean (non-Python) `FLOWS_TO` walk are being taught
-  incrementally (issue #1204). **Go**, **Rust**, **Java**, and **C#** now track
-  handle bindings, so a taint written through a file/socket handle
+  incrementally (issue #1204). **Go**, **Rust**, **Java**, **C#**, and **JS/TS**
+  now track handle bindings, so a taint written through a file/socket handle
   (`f := os.Create(p); f.Write(x)`, Rust
   `let mut f = File::create(p)?; f.write_all(s.as_bytes())?`, Java
   `new FileWriter(p).write(s)` — including the wrapper
   `new BufferedWriter(new FileWriter(p))` and factory
-  `Files.newBufferedWriter(Path.of(p))` forms — or C#
-  `new StreamWriter(p).Write(s)`) emits a flow edge to the handle's resource —
+  `Files.newBufferedWriter(Path.of(p))` forms — C#
+  `new StreamWriter(p).Write(s)`, or JS/TS
+  `fs.createWriteStream(p).write(s)`) emits a flow edge to the handle's resource —
   path-sensitively (a rebind on one branch writes to all feasible resources) and
   mode-aware (a read-only `os.Open`/`File::open`/`new FileReader`/`new StreamReader`
   handle is not a write sink). Both `new`-shaped constructors and their wrapper /
   identity-carrier (`new PrintWriter(new File(p))`) forms resolve, reusing the same
   registry tables the `READS_FROM`/`WRITES_TO` walk uses. The remaining lean
-  languages (JS/TS, C, C++, Lua) still match **direct call sinks only** — a
-  handle-method write there (`io.open(p):write(x)`) emits no flow edge, so such a
-  leak reads as `NO_FLOW` rather than `UNKNOWN` in a fully covered project. This
-  bites Lua hardest, since Lua has no direct file-write sink at all (and no handle
-  tables in either walk yet).
+  languages (C, C++, Lua) still match **direct call sinks only** for handle writes —
+  a handle-method write there (`io.open(p):write(x)`) emits no flow edge, so such a
+  leak reads as `NO_FLOW` rather than `UNKNOWN` in a fully covered project. (C/C++
+  bind `fopen`/`ofstream` handles in the `READS_FROM`/`WRITES_TO` walk, but the
+  flow walk does not yet cover their arg-shaped `fwrite(f, x)` / type-declaration
+  stream forms.) This bites Lua hardest, since Lua has no direct file-write sink at
+  all (and no handle tables in either walk yet).
 
 These are deliberate ceilings, chosen so the feature is correct and cheap where
 it applies rather than broad and noisy.


### PR DESCRIPTION
## What

While landing the Java/C# handle-write increment (#1215), I verified the remaining lean languages and found that **JS/TS handle writes already emit** `FLOWS_TO` edges — `fs.createWriteStream('out.txt')` binds a WRITE handle (via the pre-existing `IO_LEAN_HANDLE_CONSTRUCTORS` / `IO_LEAN_HANDLE_METHODS` JS/TS tables) and `ws.write(process.env.K)` flows to the file. This has worked since the language-agnostic handle machinery landed (Go, #1212), but:

1. It had **no guarding test**, and
2. The architecture doc **incorrectly** listed JS/TS under "still match direct call sinks only."

## Changes

- **Tests** (`test_flow_handle_writes.py`): add JS + TS positive cases (`fs.createWriteStream(...).write(process.env.K)` → `ENV → FILE:out.txt`) and a JS untainted-negative, locking in the pre-existing coverage.
- **Docs** (`data-flow-edges.md`): move JS/TS into the covered list (Go, Rust, Java, C#, JS/TS); narrow the "remaining" list to **C, C++, Lua**, and add a clarifying note that C/C++ *do* bind `fopen`/`ofstream` handles in the `READS_FROM`/`WRITES_TO` walk but the flow walk does not yet cover their arg-shaped `fwrite(f, x)` / type-declaration stream forms.

No production-code changes — this is coverage + accuracy only. Verified empirically before writing the tests.

## Tests

36 handle-write cases pass (Go/Rust/Java/C#/JS/TS). The genuinely-remaining #1204 work is C, C++ (arg-shaped `fwrite` + type-declaration streams), and Lua (no handle tables yet).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for tracking tainted data written through `fs.createWriteStream(...).write(...)` in JavaScript and TypeScript.
  - Literal writes are correctly excluded from flow results, reducing false-positive data-flow findings.

- **Documentation**
  - Updated data-flow documentation with JavaScript and TypeScript examples.
  - Clarified handle-based write support and language-specific limitations for C, C++, and Lua.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->