### PR TITLE
feat: model Lua io.open handle writes in the lean FLOWS_TO walk (#1204)

### DIFF
--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -1640,7 +1640,7 @@ class FlowProcessor:
         # handles on different branches), if the method WRITES (or is read/write
         # like a DB execute), route each tainted arg to that resource. Pure READ
         # methods are not sinks; untainted args emit nothing.
-        recv, sep, method = raw.rpartition(cs.SEPARATOR_DOT)
+        recv, sep, method = raw.rpartition(jc.descriptor.handle_method_separator)
         if not sep:
             return False
         bindings = handles.get(recv)

--- a/codebase_rag/parsers/io_access/descriptor.py
+++ b/codebase_rag/parsers/io_access/descriptor.py
@@ -81,6 +81,11 @@ class LanguageDescriptor:
     # std::fs; fs::write` -> `std::fs::write`) not the default `.`, so a bare short
     # path matches std only when its head is genuinely imported. None = `.`.
     scope_separator: str | None = None
+    # Separator between a bound handle's receiver and its method in the callee text
+    # (`recv.method`). Lua spells handle-method calls with `:` (`f:write(x)`), every
+    # other lean grammar with `.`; the handle-write emission splits the callee on
+    # this to recover the receiver (issue #1204).
+    handle_method_separator: str = cs.SEPARATOR_DOT
     # Stream-insertion sink (C++ `std::cout << x`): a binary_expression whose
     # `operator` field equals stream_sink_operator and whose left-spine base
     # (cout/cerr) is a stream sink. None where the language has no such operator I/O.
@@ -461,6 +466,8 @@ _LUA_DESCRIPTOR = LanguageDescriptor(
     # `local x = os.getenv(..)` binds through list containers (issue #1175).
     binding_target_container_type=cs.TS_LUA_VARIABLE_LIST,
     binding_value_container_type=cs.TS_LUA_EXPRESSION_LIST,
+    # Lua handle methods are called with `:` (`f:write(secret)`), not `.` (#1204).
+    handle_method_separator=cs.CHAR_COLON,
 )
 
 # Non-Python languages with a direct-sink descriptor. Python keeps its own

--- a/codebase_rag/parsers/io_access/processor.py
+++ b/codebase_rag/parsers/io_access/processor.py
@@ -1580,10 +1580,11 @@ class IOAccessProcessor:
         lean_handles: _LeanHandles,
     ) -> bool:
         # `f.WriteString(s)` / `br.readLine()` / `out.write(..)`: a method call whose
-        # receiver is a bound handle variable is I/O on that handle's resource. Every
-        # lean grammar spells the receiver `recv.method` in the callee text (Rust
-        # field_expression methods included), so one dotted split covers them all.
-        receiver, sep, method = raw_name.rpartition(cs.SEPARATOR_DOT)
+        # receiver is a bound handle variable is I/O on that handle's resource. Most
+        # lean grammars spell the receiver `recv.method` in the callee text (Rust
+        # field_expression methods included); Lua spells it `recv:method` (`f:write`),
+        # so the split uses the descriptor's handle-method separator (issue #1204).
+        receiver, sep, method = raw_name.rpartition(descriptor.handle_method_separator)
         if not sep:
             return False
         binding = lean_handles.bindings.get(receiver)

--- a/codebase_rag/parsers/io_access/registry.py
+++ b/codebase_rag/parsers/io_access/registry.py
@@ -704,6 +704,15 @@ _RUST_LEAN_HANDLE_CONSTRUCTORS: tuple[HandleConstructor, ...] = (
     ),
 )
 
+# `io.open(path [, mode])` returns a FILE handle used via `:` methods
+# (`f:write(x)`, `f:read()`). The mode (arg 1) decides read vs write, but the lean
+# binder does not inspect it, so this stays a sound may-write READ_WRITE (like Go's
+# `os.OpenFile`): a real write is never dropped, and the method table gates emission
+# (a `f:read()` on it emits nothing).
+_LUA_LEAN_HANDLE_CONSTRUCTORS: tuple[HandleConstructor, ...] = (
+    HandleConstructor("io.open", ResourceKind.FILE, target_arg=0),
+)
+
 IO_LEAN_HANDLE_CONSTRUCTORS: dict[
     cs.SupportedLanguage, tuple[HandleConstructor, ...]
 ] = {
@@ -725,6 +734,7 @@ IO_LEAN_HANDLE_CONSTRUCTORS: dict[
         for fn in ("fopen", "freopen")
         for prefix in _CPP_SINK_PREFIXES
     ),
+    cs.SupportedLanguage.LUA: _LUA_LEAN_HANDLE_CONSTRUCTORS,
 }
 
 # `new`-shaped handle constructors keyed by the written type name (Java
@@ -1076,6 +1086,15 @@ IO_LEAN_HANDLE_METHODS: dict[
             "ExecuteScalarAsync": IODirection.READ,
             "ExecuteNonQuery": IODirection.WRITE,
             "ExecuteNonQueryAsync": IODirection.WRITE,
+        },
+    },
+    # Lua file-handle methods, called with `:` (`f:write(x)`, `f:read()`). The
+    # handle-method split uses the descriptor's `:` separator (issue #1204).
+    cs.SupportedLanguage.LUA: {
+        ResourceKind.FILE: {
+            "write": IODirection.WRITE,
+            "read": IODirection.READ,
+            "lines": IODirection.READ,
         },
     },
 }

--- a/codebase_rag/tests/test_flow_handle_writes.py
+++ b/codebase_rag/tests/test_flow_handle_writes.py
@@ -26,6 +26,7 @@ _LANG_BY_EXT = {
     ".cs": "c_sharp",
     ".js": "javascript",
     ".ts": "typescript",
+    ".lua": "lua",
 }
 
 
@@ -672,6 +673,54 @@ def test_js_untainted_write_stream_emits_no_flow(tmp_path: Path) -> None:
         )
     }
     assert _run_flow(tmp_path, files) == set()
+
+
+# --- Lua (issue #1204; `io.open` handle + `:` method-call writes) ---
+
+
+def test_lua_tainted_write_through_file_handle(tmp_path: Path) -> None:
+    # `io.open("out.txt", "w")` binds a FILE handle; `f:write(s)` (a `:` method call)
+    # writes the ENV-tainted `s` to the file.
+    files = {
+        "a.lua": (
+            'local s = os.getenv("K")\nlocal f = io.open("out.txt", "w")\nf:write(s)\n'
+        )
+    }
+    assert _ENV_FILE in _run_flow(tmp_path, files)
+
+
+def test_lua_untainted_handle_write_emits_no_flow(tmp_path: Path) -> None:
+    files = {"a.lua": ('local f = io.open("out.txt", "w")\nf:write("literal")\n')}
+    assert _run_flow(tmp_path, files) == set()
+
+
+def test_lua_read_method_is_not_a_write_sink(tmp_path: Path) -> None:
+    # `f:read(...)` is a READ method, so even a tainted argument emits no flow edge;
+    # only writes through the handle are sinks.
+    files = {
+        "a.lua": (
+            'local s = os.getenv("K")\nlocal f = io.open("out.txt", "w")\nf:read(s)\n'
+        )
+    }
+    assert _ENV_FILE not in _run_flow(tmp_path, files)
+
+
+def test_lua_conditional_rebind_emits_to_both_files(tmp_path: Path) -> None:
+    # A rebind of the handle in the if arm leaves both handles live at the write, so
+    # the taint reaches both files (path-sensitive MAY merge, as for Go/Rust/Java).
+    files = {
+        "a.lua": (
+            'local s = os.getenv("K")\n'
+            'local f = io.open("first.txt", "w")\n'
+            "if cond then\n"
+            '  f = io.open("second.txt", "w")\n'
+            "end\n"
+            "f:write(s)\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::K", "resource::FILE::first.txt") in flows
+    assert ("resource::ENV::K", "resource::FILE::second.txt") in flows
 
 
 def test_csharp_sqlcommand_inherits_every_merged_connection(tmp_path: Path) -> None:

--- a/docs/architecture/data-flow-edges.md
+++ b/docs/architecture/data-flow-edges.md
@@ -387,27 +387,27 @@ module is re-exported under its own name. A project that does
   Go, Java, Rust, C, C++, C#, and Lua; a language not in the registry emits no I/O
   or flow edges until its table is added.
 - Handle-based writes in the lean (non-Python) `FLOWS_TO` walk are being taught
-  incrementally (issue #1204). **Go**, **Rust**, **Java**, **C#**, and **JS/TS**
-  now track handle bindings, so a taint written through a file/socket handle
+  incrementally (issue #1204). **Go**, **Rust**, **Java**, **C#**, **JS/TS**, and
+  **Lua** now track handle bindings, so a taint written through a file/socket handle
   (`f := os.Create(p); f.Write(x)`, Rust
   `let mut f = File::create(p)?; f.write_all(s.as_bytes())?`, Java
   `new FileWriter(p).write(s)` — including the wrapper
   `new BufferedWriter(new FileWriter(p))` and factory
   `Files.newBufferedWriter(Path.of(p))` forms — C#
-  `new StreamWriter(p).Write(s)`, or JS/TS
-  `fs.createWriteStream(p).write(s)`) emits a flow edge to the handle's resource —
-  path-sensitively (a rebind on one branch writes to all feasible resources) and
-  mode-aware (a read-only `os.Open`/`File::open`/`new FileReader`/`new StreamReader`
-  handle is not a write sink). Both `new`-shaped constructors and their wrapper /
-  identity-carrier (`new PrintWriter(new File(p))`) forms resolve, reusing the same
-  registry tables the `READS_FROM`/`WRITES_TO` walk uses. The remaining lean
-  languages (C, C++, Lua) still match **direct call sinks only** for handle writes —
-  a handle-method write there (`io.open(p):write(x)`) emits no flow edge, so such a
-  leak reads as `NO_FLOW` rather than `UNKNOWN` in a fully covered project. (C/C++
-  bind `fopen`/`ofstream` handles in the `READS_FROM`/`WRITES_TO` walk, but the
-  flow walk does not yet cover their arg-shaped `fwrite(f, x)` / type-declaration
-  stream forms.) This bites Lua hardest, since Lua has no direct file-write sink at
-  all (and no handle tables in either walk yet).
+  `new StreamWriter(p).Write(s)`, JS/TS
+  `fs.createWriteStream(p).write(s)`, or Lua
+  `local f = io.open(p, "w"); f:write(s)`) emits a flow edge to the handle's
+  resource — path-sensitively (a rebind on one branch writes to all feasible
+  resources) and mode-aware (a read-only `os.Open`/`File::open`/`new FileReader`/
+  `new StreamReader` handle is not a write sink; Lua's `io.open` mode is unknowable
+  to the binder, so it stays a sound may-write gated by the method table). Both
+  `new`-shaped constructors and their wrapper / identity-carrier
+  (`new PrintWriter(new File(p))`) forms resolve, reusing the same registry tables
+  the `READS_FROM`/`WRITES_TO` walk uses. The remaining lean languages (**C**,
+  **C++**) still match **direct call sinks only** for handle writes: they bind
+  `fopen`/`ofstream` handles in the `READS_FROM`/`WRITES_TO` walk, but the flow walk
+  does not yet cover their arg-shaped `fwrite(f, x)` / type-declaration stream forms,
+  so such a leak reads as `NO_FLOW` rather than `UNKNOWN` in a fully covered project.
 
 These are deliberate ceilings, chosen so the feature is correct and cheap where
 it applies rather than broad and noisy.


### PR DESCRIPTION
## What

Sixth increment of issue #1204 (handle-based writes in the lean, non-Python `FLOWS_TO` walk). After Go/Rust/Java/C#/JS-TS, this teaches **Lua** — previously the hardest gap, since Lua has *no* direct file-write sink at all, so a `io.open`-based leak read as a false `NO_FLOW`.

```lua
local s = os.getenv("K")
local f = io.open("out.txt", "w")
f:write(s)                 -- ENV -> FILE:out.txt  (was NO_FLOW)
```

## How

Two pieces, both reused by the `READS_FROM`/`WRITES_TO` walk so the two stay consistent:

1. **Registry** — `io.open` as a call-shaped `FILE` handle constructor, plus a Lua handle-method table (`write` → WRITE, `read`/`lines` → READ). `io.open`'s mode (arg 1) decides read vs write, but the lean binder does not inspect it, so it stays a **sound may-write** `READ_WRITE` (like Go's `os.OpenFile`) — a real write is never dropped, and the method table gates emission (`f:read()` emits nothing).
2. **Colon method separator** — Lua spells handle-method calls with `:` (`f:write(x)`), not `.`. Added a `handle_method_separator` descriptor field (default `.`, Lua `:`) and wired the two handle-method split sites — the flow walk's `_emit_handle_write` and io_access's `_emit_lean_handle_method` — to use it. Every other language is unchanged (default `.`).

Path-sensitivity (a rebind on one branch writes to all feasible resources) carries over from the existing `_LeanState` machinery.

## Tests

`test_flow_handle_writes.py`: 4 new Lua cases — tainted `io.open(...,"w"); f:write(s)` → `ENV → FILE`, untainted `== set()`, `f:read(tainted)` emits nothing (READ gate), and a path-sensitive conditional rebind → both files. Verified in **both** walks (FLOWS_TO + WRITES_TO). Full suite green (handle-writes + io_access + Lua-specific suites, 400+ tests); ruff + ty clean.

## Remaining #1204

Only **C** and **C++** remain — their handle writes are arg-shaped (`fwrite(f, x)`) / type-declaration streams (`std::ofstream`), a structurally different binding the flow walk does not yet cover (they already bind in the `READS_FROM`/`WRITES_TO` walk).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Lua file-handle analysis for `io.open`, including `write`, `read`, and `lines` operations.
  * Lua colon-style method calls, such as `handle:write`, are now recognized.
  * Data-flow tracking now identifies tainted writes through Lua file handles.

* **Bug Fixes**
  * Improved handling of language-specific method syntax and conditional file-handle reassignment.

* **Documentation**
  * Updated data-flow documentation to describe Lua handle-based write tracking and mode uncertainty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->