### PR TITLE
feat: model C/C++ arg-shaped libc FILE* handle writes in the lean FLOWS_TO walk (#1204)

### DIFF
--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -23,6 +23,7 @@ from ..io_access import (
     LANGUAGE_DESCRIPTORS,
     PY_SCOPE_BOUNDARIES,
     RESOURCE_QN_FORMAT,
+    ArgHandleSink,
     HandleBinding,
     HandleConstructor,
     IODirection,
@@ -48,12 +49,14 @@ from ..io_access import (
     unwrap_argument,
 )
 from ..io_access.registry import (
+    IO_ARG_HANDLE_SINKS,
     IO_IDENTITY_UNWRAP_CALLS,
     IO_IDENTITY_UNWRAP_NEW_TYPES,
     IO_LEAN_HANDLE_CONSTRUCTORS,
     IO_LEAN_HANDLE_METHODS,
     IO_NEW_HANDLE_CONSTRUCTORS,
     IO_NEW_HANDLE_WRAPPERS,
+    LIBC_STD_STREAMS,
 )
 from ..utils import (
     c_positional_parameter_slots,
@@ -480,6 +483,11 @@ class _JsCtx(NamedTuple):
     new_wrappers: frozenset[str]
     identity_calls: frozenset[str]
     identity_new_types: dict[str, ResourceKind]
+    # Arg-shaped handle sinks (C/C++ libc `fwrite(data, 1, n, f)`,
+    # `fprintf(f, fmt, x)`): the handle rides an ARGUMENT, not a receiver, so a
+    # tainted non-handle arg flows to the handle's resource (issue #1204). Empty for
+    # languages without the libc FILE* API.
+    arg_handle_sinks: dict[str, ArgHandleSink]
 
 
 class FlowProcessor:
@@ -682,6 +690,7 @@ class FlowProcessor:
             new_wrappers=IO_NEW_HANDLE_WRAPPERS.get(ctx.language, frozenset()),
             identity_calls=IO_IDENTITY_UNWRAP_CALLS.get(ctx.language, frozenset()),
             identity_new_types=IO_IDENTITY_UNWRAP_NEW_TYPES.get(ctx.language, {}),
+            arg_handle_sinks=IO_ARG_HANDLE_SINKS.get(ctx.language, {}),
         )
         body = caller_node.child_by_field_name(cs.FIELD_BODY)
         if body is None:
@@ -1439,6 +1448,11 @@ class FlowProcessor:
         # A tainted write through a bound resource handle (issue #1204).
         if handles and self._emit_handle_write(raw, args, handles, jc):
             return
+        # A tainted write through an arg-shaped handle sink (C/C++ `fwrite(x,1,n,f)`).
+        if jc.arg_handle_sinks and self._emit_arg_handle_write(
+            raw, node, args, handles, jc
+        ):
+            return
         callee = self._resolve(
             raw,
             jc.flow.module_qn,
@@ -1658,6 +1672,45 @@ class FlowProcessor:
                         taint, binding.kind, binding.identity, jc.flow.caller_qn
                     )
         return emitted
+
+    def _emit_arg_handle_write(
+        self,
+        raw: str,
+        node: Node,
+        args: list[tuple[str, Taint | None]],
+        handles: _HandleMap,
+        jc: _JsCtx,
+    ) -> bool:
+        # libc FILE* write: the handle rides an ARGUMENT (`fwrite(data, 1, n, f)`,
+        # `fprintf(f, fmt, secret)`), not a receiver. Route the taint of every
+        # NON-handle arg to the handle's resource. Only WRITE arg sinks are taint
+        # destinations -- fread/fgets READ into a buffer, not a resource write.
+        sink = jc.arg_handle_sinks.get(raw)
+        if sink is None or sink.direction == IODirection.READ:
+            return False
+        arguments = node.child_by_field_name(cs.TS_FIELD_ARGUMENTS)
+        arg_nodes = self._named_no_comments(arguments) if arguments is not None else []
+        handle_text = (
+            safe_decode_text(arg_nodes[sink.handle_arg])
+            if sink.handle_arg < len(arg_nodes)
+            else None
+        )
+        # The handle argument resolves to its resource(s): a bound handle (possibly
+        # several after a branch merge), a pre-bound std stream (`fprintf(stderr,..)`),
+        # or an untracked FILE* known only by signature (<dynamic>).
+        bindings = handles.get(handle_text) if handle_text is not None else None
+        if bindings:
+            targets = [(b.kind, b.identity) for b in bindings]
+        elif handle_text in LIBC_STD_STREAMS:
+            targets = [(LIBC_STD_STREAMS[handle_text], DYNAMIC_TARGET)]
+        else:
+            targets = [(ResourceKind.FILE, DYNAMIC_TARGET)]
+        for index, (_via, taint) in enumerate(args):
+            if index == sink.handle_arg or taint is None:
+                continue
+            for kind, identity in targets:
+                self._emit_taint_to_sink(taint, kind, identity, jc.flow.caller_qn)
+        return True
 
     def _emit_taint_to_sink(
         self, taint: Taint, kind: ResourceKind, identity: str, caller_qn: str

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -1448,11 +1448,6 @@ class FlowProcessor:
         # A tainted write through a bound resource handle (issue #1204).
         if handles and self._emit_handle_write(raw, args, handles, jc):
             return
-        # A tainted write through an arg-shaped handle sink (C/C++ `fwrite(x,1,n,f)`).
-        if jc.arg_handle_sinks and self._emit_arg_handle_write(
-            raw, node, args, handles, jc
-        ):
-            return
         callee = self._resolve(
             raw,
             jc.flow.module_qn,
@@ -1462,6 +1457,12 @@ class FlowProcessor:
             jc.flow.local_var_types,
         )
         if callee is None:
+            # An UNRESOLVED call may still be a libc arg-shaped handle write
+            # (`fwrite(x, 1, n, f)`, `fprintf(f, fmt, x)`). A call that DOES resolve to
+            # a project function of the same name is analysed as that function above
+            # -- not assumed to be libc (Greptile review, #1204).
+            if jc.arg_handle_sinks:
+                self._emit_arg_handle_write(raw, node, args, handles, jc)
             return
         callee_type, callee_qn = callee
         for via, taint in args:
@@ -1706,7 +1707,16 @@ class FlowProcessor:
         else:
             targets = [(ResourceKind.FILE, DYNAMIC_TARGET)]
         for index, (_via, taint) in enumerate(args):
-            if index == sink.handle_arg or taint is None:
+            # Only the DATA payload flows to the file: `fwrite(buf, size, n, f)`
+            # writes arg 0, so a tainted `size`/`n` is control metadata, not a leak.
+            # data_args=None means every non-handle arg is payload (fprintf's format +
+            # varargs).
+            is_payload = (
+                index in sink.data_args
+                if sink.data_args is not None
+                else index != sink.handle_arg
+            )
+            if not is_payload or taint is None:
                 continue
             for kind, identity in targets:
                 self._emit_taint_to_sink(taint, kind, identity, jc.flow.caller_qn)

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -1686,7 +1686,10 @@ class FlowProcessor:
         # `fprintf(f, fmt, secret)`), not a receiver. Route the taint of every
         # NON-handle arg to the handle's resource. Only WRITE arg sinks are taint
         # destinations -- fread/fgets READ into a buffer, not a resource write.
-        sink = jc.arg_handle_sinks.get(raw)
+        # Match through _js_match_sink so this path honours the SAME shadowing /
+        # import rules as every other sink -- a local named `fwrite` is not the libc
+        # symbol (CodeRabbit review, #1204).
+        sink = self._js_match_sink(raw, jc.arg_handle_sinks, jc)
         if sink is None or sink.direction == IODirection.READ:
             return False
         arguments = node.child_by_field_name(cs.TS_FIELD_ARGUMENTS)

--- a/codebase_rag/parsers/io_access/__init__.py
+++ b/codebase_rag/parsers/io_access/__init__.py
@@ -28,7 +28,7 @@ from .extract import (
     string_literal,
     unwrap_argument,
 )
-from .models import HandleBinding, HandleConstructor, IOSink
+from .models import ArgHandleSink, HandleBinding, HandleConstructor, IOSink
 from .processor import IOAccessProcessor
 from .registry import (
     FLOW_REGISTERED_LANGUAGES,
@@ -52,6 +52,7 @@ __all__ = [
     "LANGUAGE_DESCRIPTORS",
     "PY_SCOPE_BOUNDARIES",
     "RESOURCE_QN_FORMAT",
+    "ArgHandleSink",
     "HandleBinding",
     "HandleConstructor",
     "IOAccessProcessor",

--- a/codebase_rag/parsers/io_access/models.py
+++ b/codebase_rag/parsers/io_access/models.py
@@ -66,6 +66,13 @@ class ArgHandleSink:
     callee: str
     handle_arg: int
     direction: IODirection
+    # Argument indices that carry the DATA payload written to / read from the
+    # handle. None means "every non-handle argument" (fprintf's format + varargs are
+    # all payload). An explicit tuple pins the payload position so control metadata is
+    # not mistaken for data: `fwrite(buffer, size, count, stream)` writes only arg 0,
+    # so a tainted `size`/`count` is not a leak (issue #1204, flow walk only; io_access
+    # ignores this field). Used by the taint-tracking FLOWS_TO walk.
+    data_args: tuple[int, ...] | None = None
 
 
 @dataclass(frozen=True)

--- a/codebase_rag/parsers/io_access/registry.py
+++ b/codebase_rag/parsers/io_access/registry.py
@@ -413,21 +413,26 @@ _CPP_CALL_METHODS: tuple[tuple[str, ResourceKind, IODirection, int | None], ...]
 
 # The libc FILE* API passes the handle as an ARGUMENT (fprintf's stream is arg 0,
 # fgets's arg 2, fread/fwrite's arg 3), unlike every method-shaped handle API.
-# snprintf/sprintf write to a BUFFER, not a resource: excluded.
-_LIBC_ARG_HANDLE_METHODS: tuple[tuple[str, int, IODirection], ...] = (
-    ("fprintf", 0, IODirection.WRITE),
-    ("vfprintf", 0, IODirection.WRITE),
-    ("vfscanf", 0, IODirection.READ),
-    ("fputs", 1, IODirection.WRITE),
-    ("fputc", 1, IODirection.WRITE),
-    ("putc", 1, IODirection.WRITE),
-    ("fwrite", 3, IODirection.WRITE),
-    ("fgets", 2, IODirection.READ),
-    ("fgetc", 0, IODirection.READ),
-    ("getc", 0, IODirection.READ),
-    ("fread", 3, IODirection.READ),
-    ("fscanf", 0, IODirection.READ),
-    ("getline", 2, IODirection.READ),
+# snprintf/sprintf write to a BUFFER, not a resource: excluded. The 4th field pins
+# the DATA-payload argument(s); None means every non-handle argument. `fwrite`/
+# `fread` take `(buffer, size, count, stream)`, so only arg 0 is the payload -- a
+# tainted `size`/`count` is control metadata, not data written to the file (#1204).
+_LIBC_ARG_HANDLE_METHODS: tuple[
+    tuple[str, int, IODirection, tuple[int, ...] | None], ...
+] = (
+    ("fprintf", 0, IODirection.WRITE, None),
+    ("vfprintf", 0, IODirection.WRITE, None),
+    ("vfscanf", 0, IODirection.READ, None),
+    ("fputs", 1, IODirection.WRITE, None),
+    ("fputc", 1, IODirection.WRITE, None),
+    ("putc", 1, IODirection.WRITE, None),
+    ("fwrite", 3, IODirection.WRITE, (0,)),
+    ("fgets", 2, IODirection.READ, (0,)),
+    ("fgetc", 0, IODirection.READ, None),
+    ("getc", 0, IODirection.READ, None),
+    ("fread", 3, IODirection.READ, (0,)),
+    ("fscanf", 0, IODirection.READ, None),
+    ("getline", 2, IODirection.READ, None),
 )
 
 # Pre-bound libc stream globals: `fprintf(stderr, ...)` needs no fopen.
@@ -487,12 +492,12 @@ FLOW_REGISTERED_LANGUAGES: frozenset[cs.SupportedLanguage] = frozenset(IO_SINKS)
 # the bare and std:: spellings.
 IO_ARG_HANDLE_SINKS: dict[cs.SupportedLanguage, dict[str, ArgHandleSink]] = {
     cs.SupportedLanguage.C: {
-        fn: ArgHandleSink(fn, arg, direction)
-        for fn, arg, direction in _LIBC_ARG_HANDLE_METHODS
+        fn: ArgHandleSink(fn, arg, direction, data)
+        for fn, arg, direction, data in _LIBC_ARG_HANDLE_METHODS
     },
     cs.SupportedLanguage.CPP: {
-        f"{prefix}{fn}": ArgHandleSink(f"{prefix}{fn}", arg, direction)
-        for fn, arg, direction in _LIBC_ARG_HANDLE_METHODS
+        f"{prefix}{fn}": ArgHandleSink(f"{prefix}{fn}", arg, direction, data)
+        for fn, arg, direction, data in _LIBC_ARG_HANDLE_METHODS
         for prefix in _CPP_SINK_PREFIXES
     },
 }

--- a/codebase_rag/tests/test_flow_handle_writes.py
+++ b/codebase_rag/tests/test_flow_handle_writes.py
@@ -27,6 +27,8 @@ _LANG_BY_EXT = {
     ".js": "javascript",
     ".ts": "typescript",
     ".lua": "lua",
+    ".c": "c",
+    ".cpp": "cpp",
 }
 
 
@@ -673,6 +675,106 @@ def test_js_untainted_write_stream_emits_no_flow(tmp_path: Path) -> None:
         )
     }
     assert _run_flow(tmp_path, files) == set()
+
+
+# --- C / C++ (issue #1204; arg-shaped libc FILE* writes) ---
+
+
+def test_c_tainted_write_through_fwrite_handle(tmp_path: Path) -> None:
+    # `fwrite(s, 1, n, f)` carries the handle at arg 3 and the tainted data at arg 0;
+    # the data flows to the bound `fopen` handle's file.
+    files = {
+        "c.c": (
+            "#include <stdio.h>\n"
+            "#include <stdlib.h>\n"
+            "#include <string.h>\n"
+            "void leak() {\n"
+            '  const char* s = getenv("K");\n'
+            '  FILE* f = fopen("out.txt", "w");\n'
+            "  fwrite(s, 1, strlen(s), f);\n"
+            "}\n"
+        )
+    }
+    assert _ENV_FILE in _run_flow(tmp_path, files)
+
+
+def test_c_tainted_write_through_fprintf_handle(tmp_path: Path) -> None:
+    # `fprintf(f, fmt, s)` carries the handle at arg 0 and the tainted data at arg 2.
+    files = {
+        "c.c": (
+            "#include <stdio.h>\n"
+            "#include <stdlib.h>\n"
+            "void leak() {\n"
+            '  const char* s = getenv("K");\n'
+            '  FILE* f = fopen("out.txt", "w");\n'
+            '  fprintf(f, "%s", s);\n'
+            "}\n"
+        )
+    }
+    assert _ENV_FILE in _run_flow(tmp_path, files)
+
+
+def test_c_fprintf_to_stderr_stream(tmp_path: Path) -> None:
+    # `fprintf(stderr, fmt, s)` targets the pre-bound stderr stream, no fopen needed.
+    files = {
+        "c.c": (
+            "#include <stdio.h>\n"
+            "#include <stdlib.h>\n"
+            "void leak() {\n"
+            '  const char* s = getenv("K");\n'
+            '  fprintf(stderr, "%s", s);\n'
+            "}\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::K", "resource::STDERR::<dynamic>") in flows
+
+
+def test_cpp_tainted_write_through_fwrite_handle(tmp_path: Path) -> None:
+    # `std::fwrite` resolves under the `std::`-qualified spelling too.
+    files = {
+        "a.cpp": (
+            "#include <cstdio>\n"
+            "#include <cstdlib>\n"
+            "#include <cstring>\n"
+            "void leak() {\n"
+            '  const char* s = std::getenv("K");\n'
+            '  FILE* f = std::fopen("out.txt", "w");\n'
+            "  std::fwrite(s, 1, std::strlen(s), f);\n"
+            "}\n"
+        )
+    }
+    assert _ENV_FILE in _run_flow(tmp_path, files)
+
+
+def test_c_untainted_fwrite_emits_no_flow(tmp_path: Path) -> None:
+    files = {
+        "c.c": (
+            "#include <stdio.h>\n"
+            "void leak() {\n"
+            '  FILE* f = fopen("out.txt", "w");\n'
+            '  fwrite("literal", 1, 7, f);\n'
+            "}\n"
+        )
+    }
+    assert _run_flow(tmp_path, files) == set()
+
+
+def test_c_fread_is_not_a_write_sink(tmp_path: Path) -> None:
+    # `fread` reads FROM the file into a buffer; it is a READ arg-sink, not a write
+    # destination, so a tainted argument routes no flow to the file.
+    files = {
+        "c.c": (
+            "#include <stdio.h>\n"
+            "#include <stdlib.h>\n"
+            "void leak() {\n"
+            '  char* s = getenv("K");\n'
+            '  FILE* f = fopen("out.txt", "w");\n'
+            "  fread(s, 1, 10, f);\n"
+            "}\n"
+        )
+    }
+    assert _ENV_FILE not in _run_flow(tmp_path, files)
 
 
 # --- Lua (issue #1204; `io.open` handle + `:` method-call writes) ---

--- a/codebase_rag/tests/test_flow_handle_writes.py
+++ b/codebase_rag/tests/test_flow_handle_writes.py
@@ -760,6 +760,44 @@ def test_c_untainted_fwrite_emits_no_flow(tmp_path: Path) -> None:
     assert _run_flow(tmp_path, files) == set()
 
 
+def test_c_fwrite_metadata_arg_is_not_payload(tmp_path: Path) -> None:
+    # `fwrite(buffer, size, count, stream)` writes only arg 0. A tainted `count`
+    # (arg 2) with a literal buffer is control metadata, not exfiltrated data, so it
+    # must emit no flow to the file (Greptile review, #1204).
+    files = {
+        "c.c": (
+            "#include <stdio.h>\n"
+            "#include <stdlib.h>\n"
+            "void leak() {\n"
+            '  int n = atoi(getenv("K"));\n'
+            '  FILE* f = fopen("out.txt", "w");\n'
+            '  fwrite("literal", 1, n, f);\n'
+            "}\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert not any(src == "resource::ENV::K" and "FILE" in dst for src, dst in flows)
+
+
+def test_c_project_defined_fwrite_is_not_treated_as_libc(tmp_path: Path) -> None:
+    # A project function named `fwrite` resolves to that definition and is analysed
+    # as an ordinary callee; it must NOT be swallowed by the libc arg-handle model
+    # (no spurious `FILE:<dynamic>` write), so interprocedural analysis is preserved
+    # (Greptile review, #1204).
+    files = {
+        "c.c": (
+            "#include <stdlib.h>\n"
+            "void fwrite(const char* data, int a, int b, void* f) { }\n"
+            "void leak() {\n"
+            '  const char* s = getenv("K");\n'
+            "  fwrite(s, 1, 2, 0);\n"
+            "}\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::K", "resource::FILE::<dynamic>") not in flows
+
+
 def test_c_fread_is_not_a_write_sink(tmp_path: Path) -> None:
     # `fread` reads FROM the file into a buffer; it is a READ arg-sink, not a write
     # destination, so a tainted argument routes no flow to the file.

--- a/codebase_rag/tests/test_flow_handle_writes.py
+++ b/codebase_rag/tests/test_flow_handle_writes.py
@@ -761,17 +761,17 @@ def test_c_untainted_fwrite_emits_no_flow(tmp_path: Path) -> None:
 
 
 def test_c_fwrite_metadata_arg_is_not_payload(tmp_path: Path) -> None:
-    # `fwrite(buffer, size, count, stream)` writes only arg 0. A tainted `count`
-    # (arg 2) with a literal buffer is control metadata, not exfiltrated data, so it
-    # must emit no flow to the file (Greptile review, #1204).
+    # `fwrite(buffer, size, count, stream)` writes only arg 0. `getenv("K")` sits at
+    # the `count` position (arg 2) as a directly-modeled ENV source, with a literal
+    # buffer: it is control metadata, not exfiltrated data, so it must emit no flow to
+    # the file (Greptile + CodeRabbit review, #1204).
     files = {
         "c.c": (
             "#include <stdio.h>\n"
             "#include <stdlib.h>\n"
             "void leak() {\n"
-            '  int n = atoi(getenv("K"));\n'
             '  FILE* f = fopen("out.txt", "w");\n'
-            '  fwrite("literal", 1, n, f);\n'
+            '  fwrite("literal", 1, getenv("K"), f);\n'
             "}\n"
         )
     }

--- a/docs/architecture/data-flow-edges.md
+++ b/docs/architecture/data-flow-edges.md
@@ -400,14 +400,18 @@ module is re-exported under its own name. A project that does
   resource — path-sensitively (a rebind on one branch writes to all feasible
   resources) and mode-aware (a read-only `os.Open`/`File::open`/`new FileReader`/
   `new StreamReader` handle is not a write sink; Lua's `io.open` mode is unknowable
-  to the binder, so it stays a sound may-write gated by the method table). Both
-  `new`-shaped constructors and their wrapper / identity-carrier
-  (`new PrintWriter(new File(p))`) forms resolve, reusing the same registry tables
-  the `READS_FROM`/`WRITES_TO` walk uses. The remaining lean languages (**C**,
-  **C++**) still match **direct call sinks only** for handle writes: they bind
-  `fopen`/`ofstream` handles in the `READS_FROM`/`WRITES_TO` walk, but the flow walk
-  does not yet cover their arg-shaped `fwrite(f, x)` / type-declaration stream forms,
-  so such a leak reads as `NO_FLOW` rather than `UNKNOWN` in a fully covered project.
+  to the binder, so it stays a sound may-write gated by the method table). **C** and
+  **C++** cover the arg-shaped libc `FILE*` API, where the handle rides an
+  *argument* rather than a receiver (`FILE *f = fopen(p, "w"); fwrite(x, 1, n, f)`,
+  `fprintf(f, fmt, x)`, or `fprintf(stderr, fmt, x)` to a pre-bound std stream): the
+  tainted non-handle arguments flow to the handle's resource, an untracked `FILE*`
+  degrading to `FILE:<dynamic>`. Both `new`-shaped constructors and their wrapper /
+  identity-carrier (`new PrintWriter(new File(p))`) forms resolve, reusing the same
+  registry tables the `READS_FROM`/`WRITES_TO` walk uses. The one handle-write shape
+  the flow walk does **not** yet cover is C++ type-declaration streams
+  (`std::ofstream out(p); out << x` / `out.write(..)`), which bind in the
+  `READS_FROM`/`WRITES_TO` walk but not here — so that specific leak reads as
+  `NO_FLOW` rather than `UNKNOWN` in a fully covered project.
 
 These are deliberate ceilings, chosen so the feature is correct and cheap where
 it applies rather than broad and noisy.

--- a/docs/architecture/data-flow-edges.md
+++ b/docs/architecture/data-flow-edges.md
@@ -404,8 +404,13 @@ module is re-exported under its own name. A project that does
   **C++** cover the arg-shaped libc `FILE*` API, where the handle rides an
   *argument* rather than a receiver (`FILE *f = fopen(p, "w"); fwrite(x, 1, n, f)`,
   `fprintf(f, fmt, x)`, or `fprintf(stderr, fmt, x)` to a pre-bound std stream): the
-  tainted non-handle arguments flow to the handle's resource, an untracked `FILE*`
-  degrading to `FILE:<dynamic>`. Both `new`-shaped constructors and their wrapper /
+  tainted **payload** arguments flow to the handle's resource, an untracked `FILE*`
+  degrading to `FILE:<dynamic>`. Each arg sink pins its payload position — `fprintf`
+  forwards every non-handle argument (format + varargs), but `fwrite(buffer, size,
+  count, stream)` forwards only `buffer` (arg 0), so a tainted `size`/`count` is
+  control metadata, not a leak. The libc model applies only to *unresolved* calls, so
+  a project-defined function that happens to be named `fwrite`/`fprintf` is analysed
+  as itself. Both `new`-shaped constructors and their wrapper /
   identity-carrier (`new PrintWriter(new File(p))`) forms resolve, reusing the same
   registry tables the `READS_FROM`/`WRITES_TO` walk uses. The one handle-write shape
   the flow walk does **not** yet cover is C++ type-declaration streams


### PR DESCRIPTION
## What

Seventh #1204 increment — teaches **C** and **C++** the arg-shaped libc `FILE*` write idiom, where the handle rides an **argument**, not a receiver (so the receiver-method handle-write path from the earlier languages doesn't reach it):

```c
const char* s = getenv("K");
FILE* f = fopen("out.txt", "w");
fwrite(s, 1, strlen(s), f);   // ENV -> FILE:out.txt   (was NO_FLOW)
fprintf(f, "%s", s);          // ENV -> FILE:out.txt
fprintf(stderr, "%s", s);     // ENV -> STDERR         (pre-bound std stream)
```

## How

The registry already models these as `ArgHandleSink`s (`fwrite` handle=arg3, `fprintf`/`vfprintf` handle=arg0, `fputs`/`fputc` handle=arg1, …) and binds `fopen`/`freopen` handles — the `READS_FROM`/`WRITES_TO` walk has used them for a while. This wires the same tables into the flow walk:

- New `_emit_arg_handle_write` branch in `_js_call`: on a **WRITE**-direction arg sink, resolve the handle argument to its resource — a bound `fopen` handle (all of them, after a branch merge), a pre-bound `stdin`/`stdout`/`stderr` global, or an untracked `FILE*` → `FILE:<dynamic>` — then route the taint of every **non-handle** argument to that resource. READ arg sinks (`fread`/`fgets`/`fscanf`) read *into* a buffer, so they route nothing.
- Gated on `jc.arg_handle_sinks`, which is empty for every non-C/C++ language, so all other walks are untouched.

## Tests

`test_flow_handle_writes.py`: 6 new cases — C `fwrite`, C `fprintf`, C `fprintf(stderr)` → STDERR, C++ `std::fwrite`, untainted `== set()`, and `fread` (a READ sink) routing nothing. Full suite green (handle-writes + io_access + C++ flow suites, 190+ tests); ruff + ty clean.

## Remaining #1204

Only one handle-write shape is left: C++ **type-declaration streams** (`std::ofstream out(p); out << x` / `out.write(..)`), which need type-declaration-constructor binding + the `<<` operator on a bound handle in the flow walk. Filing that as a small follow-up; everything else in #1204 is now modeled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added taint-flow tracking for C and C++ `FILE*` APIs such as `fwrite` and `fprintf`.
  - Supports writes to file handles, standard streams like `stderr`, and dynamically resolved handles.
  - Distinguishes payload arguments from metadata and control arguments.

- **Bug Fixes**
  - Prevents read-only operations such as `fread` and project-defined functions from being incorrectly treated as write sinks.

- **Documentation**
  - Clarified supported stream-handling behavior and known C++ limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->