### PR TITLE
feat: model C++ ofstream type-declaration stream writes in the lean FLOWS_TO walk (#1220)

### DIFF
--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -56,10 +56,12 @@ from ..io_access.registry import (
     IO_LEAN_HANDLE_METHODS,
     IO_NEW_HANDLE_CONSTRUCTORS,
     IO_NEW_HANDLE_WRAPPERS,
+    IO_TYPE_HANDLE_CONSTRUCTORS,
     LIBC_STD_STREAMS,
 )
 from ..utils import (
     c_positional_parameter_slots,
+    cpp_declarator_name,
     cpp_positional_parameter_slots,
     csharp_positional_parameter_slots,
     function_span_key,
@@ -488,6 +490,11 @@ class _JsCtx(NamedTuple):
     # tainted non-handle arg flows to the handle's resource (issue #1204). Empty for
     # languages without the libc FILE* API.
     arg_handle_sinks: dict[str, ArgHandleSink]
+    # Type-declaration handle constructors (C++ `std::ofstream out("x")`): a
+    # declaration whose written type is one of these binds a FILE handle on its
+    # declarator, so a later `out << x` / `out.write(..)` routes to that file
+    # (issue #1220). Empty for languages without type-declaration stream handles.
+    type_ctors: dict[str, ResourceKind]
 
 
 class FlowProcessor:
@@ -691,6 +698,7 @@ class FlowProcessor:
             identity_calls=IO_IDENTITY_UNWRAP_CALLS.get(ctx.language, frozenset()),
             identity_new_types=IO_IDENTITY_UNWRAP_NEW_TYPES.get(ctx.language, {}),
             arg_handle_sinks=IO_ARG_HANDLE_SINKS.get(ctx.language, {}),
+            type_ctors=IO_TYPE_HANDLE_CONSTRUCTORS.get(ctx.language, {}),
         )
         body = caller_node.child_by_field_name(cs.FIELD_BODY)
         if body is None:
@@ -1214,10 +1222,18 @@ class FlowProcessor:
         # kill, a call's sink/arg edges, or a return's contribution to the summary.
         node_type = node.type
         d = jc.descriptor
+        if jc.type_ctors and node_type == cs.TS_CPP_DECLARATION:
+            # C++ `std::ofstream out("x")`: bind the declarator as a FILE handle. The
+            # walk still recurses into the child init_declarator, which the guard
+            # below skips so it is not re-bound to no handle (issue #1220).
+            self._bind_lean_type_decl(node, handles, jc)
+            return
         if node_type == d.declarator_type or node_type in (
             cs.TS_ASSIGNMENT_EXPRESSION,
             cs.TS_GO_ASSIGNMENT_STATEMENT,
         ):
+            if jc.type_ctors and self._decl_type_is_handle(node.parent, jc):
+                return
             self._lean_bind(node, tainted, handles, jc)
         elif node_type in d.extra_declarator_types:
             if node_type == cs.TS_GO_RANGE_CLAUSE:
@@ -1229,7 +1245,7 @@ class FlowProcessor:
         elif d.macro_type is not None and node_type == d.macro_type:
             self._flow_macro(node, tainted, jc)
         elif d.stream_sink_type is not None and node_type == d.stream_sink_type:
-            self._flow_stream(node, tainted, jc)
+            self._flow_stream(node, tainted, handles, jc)
         elif node_type == cs.TS_RETURN_STATEMENT:
             returned = self._js_return_taint(node, tainted, jc)
             if returned is not None:
@@ -1725,6 +1741,62 @@ class FlowProcessor:
                 self._emit_taint_to_sink(taint, kind, identity, jc.flow.caller_qn)
         return True
 
+    def _bind_lean_type_decl(self, node: Node, handles: _HandleMap, jc: _JsCtx) -> None:
+        # C++ type-declaration handles: `std::ofstream out("x.txt")` (init_declarator
+        # with an argument_list value) and the most-vexing-parse `std::ofstream
+        # dyn(path)` (a function_declarator), each binding a FILE handle -- <dynamic>
+        # when the identity is not a string literal (issue #1220). Mirrors io_access's
+        # _bind_type_decl_handle, but writes the set-valued path-sensitive map.
+        type_node = node.child_by_field_name(cs.TS_FIELD_TYPE)
+        if type_node is None or type_node.text is None:
+            return
+        kind = jc.type_ctors.get(type_node.text.decode(cs.ENCODING_UTF8))
+        if kind is None:
+            return
+        for child in node.named_children:
+            if child.type == cs.TS_CPP_INIT_DECLARATOR:
+                name = cpp_declarator_name(
+                    child.child_by_field_name(cs.FIELD_DECLARATOR)
+                )
+                identity = self._first_string_arg(
+                    child.child_by_field_name(cs.FIELD_VALUE), jc
+                )
+            elif child.type == cs.TS_CPP_FUNCTION_DECLARATOR:
+                name = cpp_declarator_name(
+                    child.child_by_field_name(cs.FIELD_DECLARATOR)
+                )
+                identity = DYNAMIC_TARGET
+            else:
+                continue
+            if name is not None:
+                handles[name] = frozenset({HandleBinding(kind, identity)})
+
+    @staticmethod
+    def _decl_type_is_handle(decl: Node | None, jc: _JsCtx) -> bool:
+        # True when `decl` is a C++ declaration whose written type is a stream handle
+        # constructor -- its init_declarator is bound by _bind_lean_type_decl, so the
+        # normal declarator binding must skip it rather than pop the handle (#1220).
+        if decl is None or decl.type != cs.TS_CPP_DECLARATION:
+            return False
+        type_node = decl.child_by_field_name(cs.TS_FIELD_TYPE)
+        return (
+            type_node is not None
+            and type_node.text is not None
+            and type_node.text.decode(cs.ENCODING_UTF8) in jc.type_ctors
+        )
+
+    @staticmethod
+    def _first_string_arg(args: Node | None, jc: _JsCtx) -> str:
+        # The first string-literal argument of a constructor's argument_list
+        # (`std::ofstream in("x.txt", std::ios::binary)` -> x.txt).
+        if args is None:
+            return DYNAMIC_TARGET
+        d = jc.descriptor
+        for child in args.named_children:
+            if child.type == d.string_type:
+                return string_literal(child, d.string_type, d.string_content_type)
+        return DYNAMIC_TARGET
+
     def _emit_taint_to_sink(
         self, taint: Taint, kind: ResourceKind, identity: str, caller_qn: str
     ) -> None:
@@ -1864,11 +1936,15 @@ class FlowProcessor:
                     stack.append(child)
         return out
 
-    def _flow_stream(self, node: Node, tainted: _TaintMap, jc: _JsCtx) -> None:
+    def _flow_stream(
+        self, node: Node, tainted: _TaintMap, handles: _HandleMap, jc: _JsCtx
+    ) -> None:
         # A C++ stream sink (`std::cout << a << b`) nests left-associatively. Act
         # only at the TOP of the `<<` chain, walk the `left` spine to the base
-        # operand; if it is a stream sink (cout/cerr), flow the taint of every
-        # inserted operand to STDOUT. A non-stream base (arithmetic `x << 2`) misses.
+        # operand; if it is a stream sink (cout/cerr) OR a bound file handle
+        # (`out << x` on a std::ofstream, issue #1220), flow the taint of every
+        # inserted operand to that resource. A non-stream base (arithmetic `x << 2`)
+        # misses.
         d = jc.descriptor
         if not self._is_stream_insertion(node, d):
             return
@@ -1887,17 +1963,22 @@ class FlowProcessor:
             base = left
         if base.text is None:
             return
-        sink = self._js_match_sink(
-            base.text.decode(cs.ENCODING_UTF8), jc.flow.stream_sinks, jc
-        )
-        if sink is None:
+        base_text = base.text.decode(cs.ENCODING_UTF8)
+        sink = self._js_match_sink(base_text, jc.flow.stream_sinks, jc)
+        # cout/cerr write STDOUT/STDERR with no concrete resource; a bound handle
+        # base carries its file's identity (possibly several after a branch merge).
+        targets: list[tuple[ResourceKind, str]]
+        if sink is not None:
+            targets = [(sink.kind, DYNAMIC_TARGET)]
+        elif bindings := handles.get(base_text):
+            targets = [(b.kind, b.identity) for b in bindings]
+        else:
             return
         for operand in operands:
             taint = self._js_expr_taint(operand, tainted, jc)
             if taint is not None:
-                self._emit_taint_to_sink(
-                    taint, sink.kind, DYNAMIC_TARGET, jc.flow.caller_qn
-                )
+                for kind, identity in targets:
+                    self._emit_taint_to_sink(taint, kind, identity, jc.flow.caller_qn)
 
     @staticmethod
     def _is_stream_insertion(node: Node, descriptor: LanguageDescriptor) -> bool:

--- a/codebase_rag/parsers/io_access/registry.py
+++ b/codebase_rag/parsers/io_access/registry.py
@@ -734,9 +734,19 @@ IO_LEAN_HANDLE_CONSTRUCTORS: dict[
         HandleConstructor("fopen", ResourceKind.FILE, target_arg=0),
         HandleConstructor("freopen", ResourceKind.FILE, target_arg=0),
     ),
+    # fopen/freopen are the libc FILE* constructors; ofstream/fstream cover the
+    # move-ASSIGNMENT rebind form (`out = std::ofstream(p)`, a call-shaped
+    # construction) -- the declaration form (`std::ofstream out(p)`) binds via
+    # IO_TYPE_HANDLE_CONSTRUCTORS instead. ifstream is read-only, so it is not a
+    # write handle here (issue #1220).
     cs.SupportedLanguage.CPP: tuple(
-        HandleConstructor(f"{prefix}{fn}", ResourceKind.FILE, target_arg=0)
-        for fn in ("fopen", "freopen")
+        HandleConstructor(f"{prefix}{fn}", ResourceKind.FILE, target_arg=0, direction=d)
+        for fn, d in (
+            ("fopen", IODirection.READ_WRITE),
+            ("freopen", IODirection.READ_WRITE),
+            ("ofstream", IODirection.WRITE),
+            ("fstream", IODirection.READ_WRITE),
+        )
         for prefix in _CPP_SINK_PREFIXES
     ),
     cs.SupportedLanguage.LUA: _LUA_LEAN_HANDLE_CONSTRUCTORS,

--- a/codebase_rag/tests/test_flow_handle_writes.py
+++ b/codebase_rag/tests/test_flow_handle_writes.py
@@ -849,6 +849,25 @@ def test_cpp_tainted_write_through_ofstream_method(tmp_path: Path) -> None:
     assert _ENV_FILE in _run_flow(tmp_path, files)
 
 
+def test_cpp_ofstream_move_assignment_rebind(tmp_path: Path) -> None:
+    # `out = std::ofstream("out.txt")` is a call-shaped move-assignment rebind (not a
+    # type declaration); the ofstream call constructor binds the handle so a later
+    # `out << s` still reaches the file (CodeRabbit review, #1220).
+    files = {
+        "a.cpp": (
+            "#include <fstream>\n"
+            "#include <cstdlib>\n"
+            "void leak() {\n"
+            '  const char* s = std::getenv("K");\n'
+            "  std::ofstream out;\n"
+            '  out = std::ofstream("out.txt");\n'
+            "  out << s;\n"
+            "}\n"
+        )
+    }
+    assert _ENV_FILE in _run_flow(tmp_path, files)
+
+
 def test_cpp_cout_insertion_still_writes_stdout(tmp_path: Path) -> None:
     # The bound-handle branch must not regress the cout/cerr stream sinks: `cout << s`
     # still flows to STDOUT (its base is a stream sink, not a bound handle).

--- a/codebase_rag/tests/test_flow_handle_writes.py
+++ b/codebase_rag/tests/test_flow_handle_writes.py
@@ -798,6 +798,87 @@ def test_c_project_defined_fwrite_is_not_treated_as_libc(tmp_path: Path) -> None
     assert ("resource::ENV::K", "resource::FILE::<dynamic>") not in flows
 
 
+def test_cpp_tainted_write_through_ofstream_insertion(tmp_path: Path) -> None:
+    # `std::ofstream out("out.txt")` binds a FILE handle via its type declaration;
+    # `out << s` inserts the ENV-tainted `s` into that file (issue #1220).
+    files = {
+        "a.cpp": (
+            "#include <fstream>\n"
+            "#include <cstdlib>\n"
+            "void leak() {\n"
+            '  const char* s = std::getenv("K");\n'
+            '  std::ofstream out("out.txt");\n'
+            "  out << s;\n"
+            "}\n"
+        )
+    }
+    assert _ENV_FILE in _run_flow(tmp_path, files)
+
+
+def test_cpp_tainted_write_through_ofstream_chain(tmp_path: Path) -> None:
+    # A chained insertion `out << a << s << b` routes every operand; the tainted one
+    # still reaches the file.
+    files = {
+        "a.cpp": (
+            "#include <fstream>\n"
+            "#include <cstdlib>\n"
+            "void leak() {\n"
+            '  const char* s = std::getenv("K");\n'
+            '  std::ofstream out("out.txt");\n'
+            '  out << "prefix" << s << "\\n";\n'
+            "}\n"
+        )
+    }
+    assert _ENV_FILE in _run_flow(tmp_path, files)
+
+
+def test_cpp_tainted_write_through_ofstream_method(tmp_path: Path) -> None:
+    # `out.write(s, n)` is a method write on the bound ofstream handle.
+    files = {
+        "a.cpp": (
+            "#include <fstream>\n"
+            "#include <cstdlib>\n"
+            "#include <cstring>\n"
+            "void leak() {\n"
+            '  const char* s = std::getenv("K");\n'
+            '  std::ofstream out("out.txt");\n'
+            "  out.write(s, strlen(s));\n"
+            "}\n"
+        )
+    }
+    assert _ENV_FILE in _run_flow(tmp_path, files)
+
+
+def test_cpp_cout_insertion_still_writes_stdout(tmp_path: Path) -> None:
+    # The bound-handle branch must not regress the cout/cerr stream sinks: `cout << s`
+    # still flows to STDOUT (its base is a stream sink, not a bound handle).
+    files = {
+        "a.cpp": (
+            "#include <iostream>\n"
+            "#include <cstdlib>\n"
+            "void leak() {\n"
+            '  const char* s = std::getenv("K");\n'
+            "  std::cout << s;\n"
+            "}\n"
+        )
+    }
+    flows = _run_flow(tmp_path, files)
+    assert ("resource::ENV::K", "resource::STDOUT::<dynamic>") in flows
+
+
+def test_cpp_untainted_ofstream_emits_no_flow(tmp_path: Path) -> None:
+    files = {
+        "a.cpp": (
+            "#include <fstream>\n"
+            "void leak() {\n"
+            '  std::ofstream out("out.txt");\n'
+            '  out << "literal";\n'
+            "}\n"
+        )
+    }
+    assert _run_flow(tmp_path, files) == set()
+
+
 def test_c_fread_is_not_a_write_sink(tmp_path: Path) -> None:
     # `fread` reads FROM the file into a buffer; it is a READ arg-sink, not a write
     # destination, so a tainted argument routes no flow to the file.

--- a/docs/architecture/data-flow-edges.md
+++ b/docs/architecture/data-flow-edges.md
@@ -410,13 +410,13 @@ module is re-exported under its own name. A project that does
   count, stream)` forwards only `buffer` (arg 0), so a tainted `size`/`count` is
   control metadata, not a leak. The libc model applies only to *unresolved* calls, so
   a project-defined function that happens to be named `fwrite`/`fprintf` is analysed
-  as itself. Both `new`-shaped constructors and their wrapper /
-  identity-carrier (`new PrintWriter(new File(p))`) forms resolve, reusing the same
-  registry tables the `READS_FROM`/`WRITES_TO` walk uses. The one handle-write shape
-  the flow walk does **not** yet cover is C++ type-declaration streams
-  (`std::ofstream out(p); out << x` / `out.write(..)`), which bind in the
-  `READS_FROM`/`WRITES_TO` walk but not here — so that specific leak reads as
-  `NO_FLOW` rather than `UNKNOWN` in a fully covered project.
+  as itself. C++ also binds **type-declaration** stream handles
+  (`std::ofstream out(p)`), so a tainted `out << x` (stream insertion) or
+  `out.write(..)` reaches the file. Both `new`-shaped constructors and their wrapper
+  / identity-carrier (`new PrintWriter(new File(p))`) forms resolve, reusing the same
+  registry tables the `READS_FROM`/`WRITES_TO` walk uses. Every catalogued
+  handle-write shape across the lean languages now emits a flow edge rather than a
+  false `NO_FLOW`.
 
 These are deliberate ceilings, chosen so the feature is correct and cheap where
 it applies rather than broad and noisy.


### PR DESCRIPTION
## What

Closes #1220 — the **final** #1204 handle-write shape. Teaches the flow walk C++ **type-declaration stream handles**, the idiomatic modern-C++ file write:

```cpp
const char* s = std::getenv("K");
std::ofstream out("out.txt");
out << s;                    // ENV -> FILE:out.txt   (was NO_FLOW)
out << "prefix" << s << "\n"; // chained insertion
out.write(s, strlen(s));     // method write
```

## How

Two pieces (the second reuses the existing machinery once the handle is bound):

1. **Bind type-declaration handles** — `std::ofstream out("x")` is a `declaration` whose type is in `IO_TYPE_HANDLE_CONSTRUCTORS` (`ifstream`/`ofstream`/`fstream` → FILE), not a call- or `new`-shaped constructor. New `_bind_lean_type_decl` binds the declarator (and the most-vexing-parse `std::ofstream dyn(path)` → `FILE:<dynamic>`), mirroring io_access's `_bind_type_decl_handle`. A guard skips the child `init_declarator` so the normal declarator binding doesn't pop the just-bound handle. Gated on `jc.type_ctors`, which is C++-only.
2. **Route `out << x`** — `_flow_stream` (which already handles `std::cout << x` → STDOUT) now also routes a `<<` chain whose base is a **bound handle** to that handle's file resource (set-valued, so a branch-merged handle reaches every feasible file). `out.write(..)` needs no new code — it's a method call on the bound handle, handled by the existing receiver-method path.

## Tests

`test_flow_handle_writes.py`: 5 new cases — `out << s`, a chained insertion, `out.write`, an untainted `== set()`, and a `std::cout << s` regression proving the stream-sink path still flows to STDOUT. Full suite green (handle-writes + io_access + C/C++ flow + basic-syntax suites, 220+ tests); ruff + ty clean.

## Result

**#1204 is fully closed** — every catalogued handle-write shape across Go, Rust, Java, C#, JS/TS, Lua, C, and C++ now emits a `FLOWS_TO` edge instead of a false `NO_FLOW`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved C++ data-flow tracking for file streams, including `std::ofstream` insertion chains, `.write()` calls, and move-assignment rebinding.
  - Added support for read/write tracking with `std::fstream`, `fopen`, and `freopen`.
  - Tracks flow to multiple possible file resources when destinations are dynamic.
  - Preserves standard output tracking through `std::cout`.

- **Bug Fixes**
  - Prevents untainted literal file writes from producing false flow results.

- **Documentation**
  - Updated data-flow documentation to describe supported C++ stream-handle patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->