### PR TITLE
feat: add FLOWS_TO lean-walk coverage for PHP (#1174)

### DIFF
--- a/codebase_rag/constants/ast_php.py
+++ b/codebase_rag/constants/ast_php.py
@@ -33,3 +33,27 @@ TS_PHP_ATTRIBUTE = "attribute"
 TS_PHP_ATTRIBUTE_GROUP = "attribute_group"
 TS_PHP_VISIBILITY_MODIFIER = "visibility_modifier"
 TS_PHP_USE_DECLARATION = "use_declaration"
+
+# FLOWS_TO lean-walk node types (issue #1174). PHP variables carry a `$` prefix
+# (`variable_name` -> `.text == "$s"`), so a local can never shadow a builtin sink.
+TS_PHP_VARIABLE_NAME = "variable_name"
+TS_PHP_ENCAPSED_STRING = "encapsed_string"
+TS_PHP_STRING_CONTENT = "string_content"
+TS_PHP_COMPOUND_STATEMENT = "compound_statement"
+TS_PHP_FORMAL_PARAMETERS = "formal_parameters"
+TS_PHP_SIMPLE_PARAMETER = "simple_parameter"
+TS_PHP_ARGUMENT = "argument"
+TS_PHP_MEMBER_ACCESS_EXPRESSION = "member_access_expression"
+TS_PHP_SUBSCRIPT_EXPRESSION = "subscript_expression"
+# `echo $a, $b;` (echo_statement) and `print $x` (print_intrinsic) write STDOUT;
+# multiple echo operands wrap in a sequence_expression.
+TS_PHP_ECHO_STATEMENT = "echo_statement"
+TS_PHP_PRINT_INTRINSIC = "print_intrinsic"
+TS_PHP_SEQUENCE_EXPRESSION = "sequence_expression"
+TS_PHP_FOREACH_STATEMENT = "foreach_statement"
+TS_PHP_DEFAULT_STATEMENT = "default_statement"
+# `if` emits its elseif/else chain as flat sibling `alternative` children; an
+# `else_if_clause` is a CONDITIONAL alternative (so a chain ending in one still
+# leaves an implicit skip path), an `else_clause` is the terminal not-then path.
+TS_PHP_ELSE_IF_CLAUSE = "else_if_clause"
+TS_PHP_ELSE_CLAUSE = "else_clause"

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -622,9 +622,18 @@ class FlowProcessor:
             class_context=class_context,
             language=language,
             import_map=self._import_processor.import_mapping.get(module_qn, {}),
-            read_sinks={s.callee: s for s in sinks if s.direction == IODirection.READ},
+            # A READ_WRITE sink (PHP `curl_exec`/`fsockopen`, verb-agnostic like a DB
+            # execute) is BOTH a read source and a write sink, so it enters both maps
+            # -- otherwise it would fall out of both and emit nothing (CodeRabbit, #1174).
+            read_sinks={
+                s.callee: s
+                for s in sinks
+                if s.direction in (IODirection.READ, IODirection.READ_WRITE)
+            },
             write_sinks={
-                s.callee: s for s in sinks if s.direction == IODirection.WRITE
+                s.callee: s
+                for s in sinks
+                if s.direction in (IODirection.WRITE, IODirection.READ_WRITE)
             },
             macro_sinks=IO_MACRO_SINKS.get(language, {}),
             stream_sinks=IO_STREAM_SINKS.get(language, {}),
@@ -2155,6 +2164,10 @@ class FlowProcessor:
         # the head through the import map on `::` (`use std::env; env::var` ->
         # `std::env::var`; a fully-qualified `std::env::var` has an unimported `std`
         # head and stays as-is); a head bound to a local name is shadowed.
+        if jc.descriptor.case_insensitive_call_names:
+            # PHP function names are case-insensitive (`GETENV` == `getenv`); the
+            # registry keys are lowercase (issue #1174).
+            raw = raw.lower()
         scope_sep = jc.descriptor.scope_separator
         if scope_sep is not None:
             scoped_head, _, scoped_rest = raw.partition(scope_sep)

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -68,6 +68,7 @@ from ..utils import (
     go_positional_parameter_slots,
     java_positional_parameter_slots,
     js_ts_positional_parameter_slots,
+    php_positional_parameter_slots,
     python_free_variable_names,
     python_parameter_names,
     rust_positional_parameter_slots,
@@ -180,6 +181,8 @@ def _lean_parameter_slots(
         return rust_positional_parameter_slots(func_node)
     if language == cs.SupportedLanguage.C:
         return c_positional_parameter_slots(func_node)
+    if language == cs.SupportedLanguage.PHP:
+        return php_positional_parameter_slots(func_node)
     return [], None
 
 
@@ -294,6 +297,7 @@ _FLAT_LOOP_TYPES = frozenset(
         cs.TS_CPP_FOR_RANGE_LOOP,
         cs.TS_RS_FOR_EXPRESSION,
         cs.TS_RS_WHILE_EXPRESSION,
+        cs.TS_PHP_FOREACH_STATEMENT,
     }
 )
 # Loops whose body ALWAYS runs at least once (do-while, Rust `loop`): no
@@ -327,24 +331,28 @@ _SWITCH_ARM_TYPES = frozenset(
         cs.TS_CPP_CASE_STATEMENT,
         cs.TS_JS_SWITCH_CASE,
         cs.TS_JS_SWITCH_DEFAULT,
+        cs.TS_PHP_DEFAULT_STATEMENT,
     }
 )
 # Arms a previous case can fall INTO (no break modeling: the entry unions
 # the previous arm's exit). Go cases and Java arrow rules never fall
-# through, so they enter only from the header state.
+# through, so they enter only from the header state. PHP `case`/`default`
+# fall through C-style (`case_statement` shares the C++ spelling).
 _FALLTHROUGH_ARM_TYPES = frozenset(
     {
         cs.TS_JAVA_SWITCH_BLOCK_STATEMENT_GROUP,
         cs.TS_CPP_CASE_STATEMENT,
         cs.TS_JS_SWITCH_CASE,
         cs.TS_JS_SWITCH_DEFAULT,
+        cs.TS_PHP_DEFAULT_STATEMENT,
     }
 )
 
 # Arm node types spelled `default` explicitly (Go default_case, JS
-# switch_default); the other grammars mark default structurally.
+# switch_default, PHP default_statement); the other grammars mark default
+# structurally.
 _EXPLICIT_DEFAULT_ARM_TYPES = frozenset(
-    {cs.TS_GO_DEFAULT_CASE, cs.TS_JS_SWITCH_DEFAULT}
+    {cs.TS_GO_DEFAULT_CASE, cs.TS_JS_SWITCH_DEFAULT, cs.TS_PHP_DEFAULT_STATEMENT}
 )
 
 
@@ -1052,9 +1060,13 @@ class FlowProcessor:
         # to the whole if statement (restored on exit), so neither shadows a
         # source/sink past its scope.
         pre_if_shadows = set(jc.local_names)
-        consequence = node.child_by_field_name(cs.TS_FIELD_CONSEQUENCE)
-        alternative = node.child_by_field_name(cs.FIELD_ALTERNATIVE)
-        skip = {n.id for n in (consequence, alternative) if n is not None}
+        consequence = node.child_by_field_name(jc.descriptor.if_consequence_field)
+        # Most grammars carry a single `alternative` (else block or nested else-if);
+        # PHP emits the whole chain as several sibling `alternative` children
+        # (`else_if_clause`* then an optional `else_clause`), so gather them all
+        # (issue #1174). For Go/Java/C++/Rust this list is 0 or 1 element -> unchanged.
+        alternatives = node.children_by_field_name(cs.FIELD_ALTERNATIVE)
+        skip = {n.id for n in (consequence, *alternatives) if n is not None}
         for child in node.named_children:
             if child.id not in skip:
                 state = self._walk_flat_stmt(child, state, jc)
@@ -1063,13 +1075,16 @@ class FlowProcessor:
         if consequence is not None:
             branch_exits.append(self._walk_flat_stmt(consequence, state.copy(), jc))
             self._restore_shadows(pre_shadows, jc)
-        if alternative is not None:
-            # else_clause holds either a block or a nested if (else-if chain); the
-            # recursion handles both and merges within.
+        for alternative in alternatives:
+            # A block/nested-if (Go/Java/…) or a PHP else-if/else clause; the
+            # recursion walks each in its own branch copy and merges (a MAY
+            # over-approximation for the mutually-exclusive elseif arms).
             branch_exits.append(self._walk_flat_stmt(alternative, state.copy(), jc))
             self._restore_shadows(pre_shadows, jc)
-        else:
-            # No else: the skip path preserves the incoming state.
+        # An implicit skip path (condition false, nothing runs) survives unless the
+        # chain ends in a TERMINAL else: one plain alternative (else block / nested
+        # if) is terminal; a PHP chain ending in `else_if_clause` is not.
+        if not alternatives or alternatives[-1].type == cs.TS_PHP_ELSE_IF_CLAUSE:
             branch_exits.append(state.copy())
         self._restore_shadows(pre_if_shadows, jc)
         return self._merge_lean(branch_exits)
@@ -1246,6 +1261,8 @@ class FlowProcessor:
             self._flow_macro(node, tainted, jc)
         elif d.stream_sink_type is not None and node_type == d.stream_sink_type:
             self._flow_stream(node, tainted, handles, jc)
+        elif d.keyword_stdout_write_types and node_type in d.keyword_stdout_write_types:
+            self._flow_keyword_write(node, tainted, jc)
         elif node_type == cs.TS_RETURN_STATEMENT:
             returned = self._js_return_taint(node, tainted, jc)
             if returned is not None:
@@ -1936,6 +1953,25 @@ class FlowProcessor:
                     stack.append(child)
         return out
 
+    def _flow_keyword_write(self, node: Node, tainted: _TaintMap, jc: _JsCtx) -> None:
+        # A keyword output construct (PHP `echo $a, $b;` / `print $x`) writes each
+        # operand to STDOUT with no callee name (issue #1174). `echo` takes several
+        # operands wrapped in a `sequence_expression`; `print` a single operand.
+        for child in node.named_children:
+            if child.type == cs.TS_COMMENT:
+                continue
+            operands = (
+                child.named_children
+                if child.type == cs.TS_PHP_SEQUENCE_EXPRESSION
+                else (child,)
+            )
+            for operand in operands:
+                taint = self._js_expr_taint(operand, tainted, jc)
+                if taint is not None:
+                    self._emit_taint_to_sink(
+                        taint, ResourceKind.STDOUT, DYNAMIC_TARGET, jc.flow.caller_qn
+                    )
+
     def _flow_stream(
         self, node: Node, tainted: _TaintMap, handles: _HandleMap, jc: _JsCtx
     ) -> None:
@@ -2055,6 +2091,13 @@ class FlowProcessor:
 
     def _js_member_source(self, node: Node, jc: _JsCtx) -> HandleBinding | None:
         obj = node.child_by_field_name(jc.descriptor.object_field)
+        if obj is None and node.type == jc.descriptor.subscript_type:
+            # PHP `$_ENV["K"]` is a FIELDLESS subscript: the indexed object is the
+            # first named child (issue #1174). Guarded so field-based grammars
+            # (JS/Java/…) never take this path.
+            obj = next(
+                (c for c in node.named_children if c.type != cs.TS_COMMENT), None
+            )
         if obj is None or obj.text is None:
             return None
         obj_text = obj.text.decode(cs.ENCODING_UTF8)
@@ -2075,6 +2118,12 @@ class FlowProcessor:
                 return prop.text.decode(cs.ENCODING_UTF8)
             return DYNAMIC_TARGET
         index = node.child_by_field_name(d.subscript_index_field)
+        if index is None:
+            # Fieldless subscript (PHP `$_ENV["K"]`): the key is the first
+            # string-literal child.
+            index = next(
+                (c for c in node.named_children if c.type == d.string_type), None
+            )
         if index is not None and index.type == d.string_type:
             return string_literal(index, d.string_type, d.string_content_type)
         return DYNAMIC_TARGET

--- a/codebase_rag/parsers/io_access/descriptor.py
+++ b/codebase_rag/parsers/io_access/descriptor.py
@@ -168,6 +168,18 @@ class LanguageDescriptor:
     # separately). Issue #1204.
     taint_transparent_methods: frozenset[str] = frozenset()
 
+    # Statement/expression node types that write their operand(s) to STDOUT with no
+    # callee name (PHP `echo $x, $y;` / `print $x`), handled like a keyword sink:
+    # every operand's taint (a `sequence_expression` unwrapped to its elements) flows
+    # to STDOUT. Empty for languages whose output is call- or macro-shaped. Issue #1174.
+    keyword_stdout_write_types: frozenset[str] = frozenset()
+
+    # Field on an `if` node holding the then-branch. Most grammars use `consequence`;
+    # PHP's `if_statement` uses `body` and emits the whole elseif/else chain as
+    # MULTIPLE sibling `alternative` children (issue #1174). The flat if-walker reads
+    # the consequence via this field and gathers every `alternative`.
+    if_consequence_field: str = cs.TS_FIELD_CONSEQUENCE
+
 
 _JS_TS_DESCRIPTOR = LanguageDescriptor(
     call_type=cs.TS_CALL_EXPRESSION,
@@ -470,6 +482,51 @@ _LUA_DESCRIPTOR = LanguageDescriptor(
     handle_method_separator=cs.CHAR_COLON,
 )
 
+_PHP_DESCRIPTOR = LanguageDescriptor(
+    call_type=cs.TS_PHP_FUNCTION_CALL_EXPRESSION,
+    string_type=cs.TS_PHP_ENCAPSED_STRING,
+    string_content_type=cs.TS_PHP_STRING_CONTENT,
+    keyword_arg_type=None,
+    nested_scope_types=frozenset(
+        {
+            cs.TS_PHP_FUNCTION_DEFINITION,
+            cs.TS_PHP_METHOD_DECLARATION,
+            cs.TS_PHP_ANONYMOUS_FUNCTION,
+            cs.TS_PHP_ARROW_FUNCTION,
+        }
+    ),
+    # PHP variables are `$name`; a local can never shadow a builtin sink (which has
+    # no `$`), so the shadow machinery is inert like C++/C#/Rust. The fields below
+    # are wired to real PHP nodes but never suppress a genuine sink.
+    identifier_type=cs.TS_PHP_VARIABLE_NAME,
+    declarator_type=cs.TS_ASSIGNMENT_EXPRESSION,
+    params_field=cs.FIELD_PARAMETERS,
+    block_scope_type=cs.TS_PHP_COMPOUND_STATEMENT,
+    extra_declarator_types=frozenset(),
+    loop_declarator_types=frozenset(),
+    statement_container_type=None,
+    sinks_require_import=False,
+    hoisted_declarations=False,
+    decl_in_own_initializer=False,
+    declaration_statement_type=None,
+    macro_type=None,
+    # Superglobal reads are subscripts (`$_GET["q"]`); member access (`$o->p`) is
+    # wired but unused by any PHP member-read row.
+    member_expression_type=cs.TS_PHP_MEMBER_ACCESS_EXPRESSION,
+    subscript_type=cs.TS_PHP_SUBSCRIPT_EXPRESSION,
+    object_field=cs.FIELD_OBJECT,
+    property_field=cs.TS_FIELD_NAME,
+    subscript_index_field=cs.TS_FIELD_INDEX,
+    # Each call argument wraps in an `argument` node, like C#.
+    argument_wrapper_type=cs.TS_PHP_ARGUMENT,
+    # `echo`/`print` write STDOUT; PHP `if` uses a `body` field + multiple
+    # `alternative` children (issue #1174).
+    keyword_stdout_write_types=frozenset(
+        {cs.TS_PHP_ECHO_STATEMENT, cs.TS_PHP_PRINT_INTRINSIC}
+    ),
+    if_consequence_field=cs.FIELD_BODY,
+)
+
 # Non-Python languages with a direct-sink descriptor. Python keeps its own
 # handle-aware walk; each new language lands one entry (plus registry rows).
 LANGUAGE_DESCRIPTORS: dict[cs.SupportedLanguage, LanguageDescriptor] = {
@@ -486,4 +543,5 @@ LANGUAGE_DESCRIPTORS: dict[cs.SupportedLanguage, LanguageDescriptor] = {
     cs.SupportedLanguage.C: _CPP_DESCRIPTOR,
     cs.SupportedLanguage.CSHARP: _CSHARP_DESCRIPTOR,
     cs.SupportedLanguage.LUA: _LUA_DESCRIPTOR,
+    cs.SupportedLanguage.PHP: _PHP_DESCRIPTOR,
 }

--- a/codebase_rag/parsers/io_access/descriptor.py
+++ b/codebase_rag/parsers/io_access/descriptor.py
@@ -180,6 +180,12 @@ class LanguageDescriptor:
     # the consequence via this field and gathers every `alternative`.
     if_consequence_field: str = cs.TS_FIELD_CONSEQUENCE
 
+    # True when the language's FUNCTION names are case-insensitive (PHP: `GETENV`
+    # == `getenv`). The registry keys are lowercase, so the callee is lowercased
+    # before sink/handle matching. Variable names and superglobals stay
+    # case-sensitive -- they are matched elsewhere, not through this path. Issue #1174.
+    case_insensitive_call_names: bool = False
+
 
 _JS_TS_DESCRIPTOR = LanguageDescriptor(
     call_type=cs.TS_CALL_EXPRESSION,
@@ -525,6 +531,7 @@ _PHP_DESCRIPTOR = LanguageDescriptor(
         {cs.TS_PHP_ECHO_STATEMENT, cs.TS_PHP_PRINT_INTRINSIC}
     ),
     if_consequence_field=cs.FIELD_BODY,
+    case_insensitive_call_names=True,
 )
 
 # Non-Python languages with a direct-sink descriptor. Python keeps its own

--- a/codebase_rag/parsers/io_access/registry.py
+++ b/codebase_rag/parsers/io_access/registry.py
@@ -464,6 +464,22 @@ _LUA_SINKS: tuple[IOSink, ...] = (
     IOSink("io.read", ResourceKind.STDIN, IODirection.READ),
 )
 
+# PHP direct-call I/O sinks (issue #1174). Keyed by the bare callee text from
+# `function_call_expression` (`getenv`, `file_put_contents`): PHP builtins are
+# global, so the catalogue is not import-gated, and a `$`-prefixed local can never
+# shadow a bare builtin name. `file_put_contents(path, data)` carries the tainted
+# data at arg 1 and the target path at arg 0. `echo`/`print` are keyword sinks
+# (handled by the walk, not this table); handle-based `fwrite` is an arg sink below.
+_PHP_SINKS: tuple[IOSink, ...] = (
+    IOSink("file_get_contents", ResourceKind.FILE, IODirection.READ, target_arg=0),
+    IOSink("readfile", ResourceKind.FILE, IODirection.READ, target_arg=0),
+    IOSink("file_put_contents", ResourceKind.FILE, IODirection.WRITE, target_arg=0),
+    IOSink("getenv", ResourceKind.ENV, IODirection.READ, target_arg=0),
+    # curl_exec's handle carries no literal target; fsockopen's hostname is arg 0.
+    IOSink("curl_exec", ResourceKind.NETWORK, IODirection.READ_WRITE),
+    IOSink("fsockopen", ResourceKind.NETWORK, IODirection.READ_WRITE, target_arg=0),
+)
+
 IO_SINKS: dict[cs.SupportedLanguage, tuple[IOSink, ...]] = {
     cs.SupportedLanguage.PYTHON: _PYTHON_SINKS,
     cs.SupportedLanguage.JS: _JS_TS_SINKS,
@@ -480,6 +496,7 @@ IO_SINKS: dict[cs.SupportedLanguage, tuple[IOSink, ...]] = {
         for fn, kind, direction, arg in _CPP_CALL_METHODS
     ),
     cs.SupportedLanguage.LUA: _LUA_SINKS,
+    cs.SupportedLanguage.PHP: _PHP_SINKS,
 }
 
 # The languages the flow/I-O analysis covers at all: a Module in any other
@@ -499,6 +516,12 @@ IO_ARG_HANDLE_SINKS: dict[cs.SupportedLanguage, dict[str, ArgHandleSink]] = {
         f"{prefix}{fn}": ArgHandleSink(f"{prefix}{fn}", arg, direction, data)
         for fn, arg, direction, data in _LIBC_ARG_HANDLE_METHODS
         for prefix in _CPP_SINK_PREFIXES
+    },
+    # PHP `fwrite($handle, $data)` REVERSES the libc order: the handle is arg 0 and
+    # the payload arg 1 (issue #1174). fputs is an alias; fputcsv writes a row array.
+    cs.SupportedLanguage.PHP: {
+        fn: ArgHandleSink(fn, 0, IODirection.WRITE, (1,))
+        for fn in ("fwrite", "fputs", "fputcsv")
     },
 }
 
@@ -542,10 +565,24 @@ _JS_TS_MEMBER_READS: tuple[tuple[str, ResourceKind], ...] = (
     ("process.env", ResourceKind.ENV),
 )
 
+# PHP superglobal taint sources (issue #1174): `$_GET["q"]` etc. are subscripts on
+# a superglobal `variable_name`. HTTP-controlled input ($_GET/$_POST/$_REQUEST/
+# $_COOKIE) is untrusted NETWORK; $_ENV/$_SERVER are process ENV. Prefix strings
+# include the `$` (matched against the superglobal's `variable_name.text`).
+_PHP_MEMBER_READS: tuple[tuple[str, ResourceKind], ...] = (
+    ("$_GET", ResourceKind.NETWORK),
+    ("$_POST", ResourceKind.NETWORK),
+    ("$_REQUEST", ResourceKind.NETWORK),
+    ("$_COOKIE", ResourceKind.NETWORK),
+    ("$_ENV", ResourceKind.ENV),
+    ("$_SERVER", ResourceKind.ENV),
+)
+
 IO_MEMBER_READS: dict[cs.SupportedLanguage, tuple[tuple[str, ResourceKind], ...]] = {
     cs.SupportedLanguage.JS: _JS_TS_MEMBER_READS,
     cs.SupportedLanguage.TS: _JS_TS_MEMBER_READS,
     cs.SupportedLanguage.TSX: _JS_TS_MEMBER_READS,
+    cs.SupportedLanguage.PHP: _PHP_MEMBER_READS,
 }
 
 # Calls whose result is a resource handle; later method calls on the bound variable
@@ -750,6 +787,11 @@ IO_LEAN_HANDLE_CONSTRUCTORS: dict[
         for prefix in _CPP_SINK_PREFIXES
     ),
     cs.SupportedLanguage.LUA: _LUA_LEAN_HANDLE_CONSTRUCTORS,
+    # `$f = fopen($path, "w")` returns a FILE handle used via `fwrite($f, $data)`
+    # (arg-shaped, below). The mode (arg 1) is not inspected, so may-write (#1174).
+    cs.SupportedLanguage.PHP: (
+        HandleConstructor("fopen", ResourceKind.FILE, target_arg=0),
+    ),
 }
 
 # `new`-shaped handle constructors keyed by the written type name (Java

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -1014,6 +1014,31 @@ def c_positional_parameter_slots(
     return names, variadic_index
 
 
+def php_positional_parameter_slots(
+    func_node: Node,
+) -> tuple[list[str | None], int | None]:
+    # PHP formal parameters: each `simple_parameter` binds a `name` field whose
+    # `variable_name` text carries the `$` prefix (`$m`), matching how the callee
+    # body references the parameter -- so a seeded parameter pseudo-origin and its
+    # in-body uses key identically. Variadic (`...$args`) and constructor
+    # property-promotion parameters are a follow-up (issue #1174).
+    params = func_node.child_by_field_name(cs.FIELD_PARAMETERS)
+    if params is None:
+        return [], None
+    names: list[str | None] = []
+    for param in params.named_children:
+        if param.type != cs.TS_PHP_SIMPLE_PARAMETER:
+            names.append(None)
+            continue
+        name_node = param.child_by_field_name(cs.TS_FIELD_NAME)
+        names.append(
+            name_node.text.decode(cs.ENCODING_UTF8)
+            if name_node is not None and name_node.text is not None
+            else None
+        )
+    return names, None
+
+
 def _js_ts_field_member_name(
     node: ASTNode, language: cs.SupportedLanguage | None
 ) -> str | None:

--- a/codebase_rag/tests/test_flow_php_edges.py
+++ b/codebase_rag/tests/test_flow_php_edges.py
@@ -1,0 +1,147 @@
+"""FLOWS_TO lean-walk coverage for PHP (issue #1174). PHP was absent from
+`IO_SINKS`, so its modules carried `flow_covered: false` and every flow query over
+PHP reported UNKNOWN. These tests exercise the descriptor-driven lean walk: a
+superglobal / `getenv` source reaching an `echo`/`file_put_contents`/`fwrite` sink
+emits a resource->resource edge, tainted arguments cross into callees, returned
+taint feeds the fixpoint, and a branch merge preserves taint on any path."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.capture import resolve_capture
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+FLOWS_TO = cs.RelationshipType.FLOWS_TO.value
+_CAPTURE_IO = resolve_capture([cs.CaptureGroup.IO.value])
+_STDOUT = "resource::STDOUT::<dynamic>"
+
+
+def _run_flow(tmp_path: Path, source: str) -> set[tuple[str, str]]:
+    parsers, queries = load_parsers()
+    if "php" not in parsers:
+        pytest.skip("php parser not available")
+    (tmp_path / "a.php").write_text(source, encoding="utf-8")
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        capture=_CAPTURE_IO,
+    ).run()
+    return {
+        (c.args[0][2], c.args[2][2])
+        for c in mock.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) == FLOWS_TO
+    }
+
+
+def test_php_superglobal_get_flows_to_echo(tmp_path: Path) -> None:
+    # `$_GET["q"]` is untrusted HTTP input (NETWORK); `echo` writes it to STDOUT.
+    source = '<?php\nfunction leak() {\n  $g = $_GET["q"];\n  echo $g;\n}\n'
+    assert ("resource::NETWORK::q", _STDOUT) in _run_flow(tmp_path, source)
+
+
+def test_php_env_superglobal_flows_to_print(tmp_path: Path) -> None:
+    # `$_ENV["K"]` is a process-env source; `print` is the single-operand keyword sink.
+    source = '<?php\nfunction leak() {\n  $e = $_ENV["K"];\n  print $e;\n}\n'
+    assert ("resource::ENV::K", _STDOUT) in _run_flow(tmp_path, source)
+
+
+def test_php_getenv_flows_to_file_put_contents(tmp_path: Path) -> None:
+    # `getenv` reads ENV; `file_put_contents(path, data)` writes the tainted data
+    # (arg 1) to the file named by arg 0.
+    source = (
+        "<?php\nfunction leak() {\n"
+        '  $s = getenv("K");\n'
+        '  file_put_contents("out.txt", $s);\n'
+        "}\n"
+    )
+    assert ("resource::ENV::K", "resource::FILE::out.txt") in _run_flow(
+        tmp_path, source
+    )
+
+
+def test_php_tainted_argument_into_callee(tmp_path: Path) -> None:
+    # A tainted value passed as an argument reaches a sink INSIDE the callee: the
+    # parameter-to-sink summary composes across function bodies (issue #1169 machinery).
+    source = (
+        "<?php\nfunction sink($m) { echo $m; }\n"
+        "function leak() {\n"
+        '  $s = getenv("K");\n'
+        "  sink($s);\n"
+        "}\n"
+    )
+    assert ("resource::ENV::K", _STDOUT) in _run_flow(tmp_path, source)
+
+
+def test_php_return_taint_fixpoint(tmp_path: Path) -> None:
+    # A callee that RETURNS a tainted value taints the caller's binding through the
+    # return-taint fixpoint, even though `src` is defined before its taint is known.
+    source = (
+        '<?php\nfunction src() { return getenv("K"); }\n'
+        "function leak() {\n"
+        "  $v = src();\n"
+        "  echo $v;\n"
+        "}\n"
+    )
+    assert ("resource::ENV::K", _STDOUT) in _run_flow(tmp_path, source)
+
+
+def test_php_branch_merge_preserves_taint(tmp_path: Path) -> None:
+    # Taint assigned on ONE branch of an if/else survives the MAY join, so the sink
+    # after the merge still sees it (validates the PHP `body`/multi-`alternative`
+    # if-walk).
+    source = (
+        "<?php\nfunction leak($x) {\n"
+        '  if ($x) { $s = getenv("K"); } else { $s = "safe"; }\n'
+        "  echo $s;\n"
+        "}\n"
+    )
+    assert ("resource::ENV::K", _STDOUT) in _run_flow(tmp_path, source)
+
+
+def test_php_elseif_chain_preserves_taint(tmp_path: Path) -> None:
+    # The taint is set in an `elseif` arm; the flat sibling-`alternative` walk must
+    # still union it into the join.
+    source = (
+        "<?php\nfunction leak($x, $y) {\n"
+        '  if ($x) { $s = "a"; }\n'
+        '  elseif ($y) { $s = getenv("K"); }\n'
+        '  else { $s = "b"; }\n'
+        "  echo $s;\n"
+        "}\n"
+    )
+    assert ("resource::ENV::K", _STDOUT) in _run_flow(tmp_path, source)
+
+
+def test_php_tainted_write_through_fopen_handle(tmp_path: Path) -> None:
+    # `fopen` binds a FILE handle; `fwrite($f, $data)` REVERSES the libc arg order
+    # (handle arg 0, data arg 1), so the tainted data flows to the file.
+    source = (
+        "<?php\nfunction leak() {\n"
+        '  $s = getenv("K");\n'
+        '  $f = fopen("out.txt", "w");\n'
+        "  fwrite($f, $s);\n"
+        "}\n"
+    )
+    assert ("resource::ENV::K", "resource::FILE::out.txt") in _run_flow(
+        tmp_path, source
+    )
+
+
+def test_php_untainted_io_emits_no_flow(tmp_path: Path) -> None:
+    source = (
+        "<?php\nfunction leak() {\n"
+        '  $f = fopen("out.txt", "w");\n'
+        '  fwrite($f, "literal");\n'
+        '  echo "constant";\n'
+        "}\n"
+    )
+    assert _run_flow(tmp_path, source) == set()

--- a/codebase_rag/tests/test_flow_php_edges.py
+++ b/codebase_rag/tests/test_flow_php_edges.py
@@ -136,6 +136,28 @@ def test_php_tainted_write_through_fopen_handle(tmp_path: Path) -> None:
     )
 
 
+def test_php_builtin_names_are_case_insensitive(tmp_path: Path) -> None:
+    # PHP function names are case-insensitive, so `GETENV`/`FILE_PUT_CONTENTS`
+    # resolve to the same sinks as their lowercase spellings (CodeRabbit review).
+    source = (
+        "<?php\nfunction leak() {\n"
+        '  $s = GETENV("K");\n'
+        '  FILE_PUT_CONTENTS("out.txt", $s);\n'
+        "}\n"
+    )
+    assert ("resource::ENV::K", "resource::FILE::out.txt") in _run_flow(
+        tmp_path, source
+    )
+
+
+def test_php_curl_exec_response_is_a_network_read_source(tmp_path: Path) -> None:
+    # `curl_exec` is a READ_WRITE sink; its response is an untrusted NETWORK read
+    # source, so echoing it flows NETWORK -> STDOUT (validates READ_WRITE entering
+    # the read-sink map, CodeRabbit review).
+    source = "<?php\nfunction leak($ch) {\n  $r = curl_exec($ch);\n  echo $r;\n}\n"
+    assert ("resource::NETWORK::<dynamic>", _STDOUT) in _run_flow(tmp_path, source)
+
+
 def test_php_untainted_io_emits_no_flow(tmp_path: Path) -> None:
     source = (
         "<?php\nfunction leak() {\n"

--- a/codebase_rag/tests/test_flow_verdict.py
+++ b/codebase_rag/tests/test_flow_verdict.py
@@ -60,13 +60,13 @@ def test_no_flow_requires_full_coverage() -> None:
 
 def test_unknown_names_the_gaps() -> None:
     result = flow_reachability_verdict(
-        _query_fn([], ["legacy/script.scala", "legacy/tool.php"]),
+        _query_fn([], ["legacy/script.scala", "legacy/tool.dart"]),
         "p",
         "p.a.src",
         "p.a.sink",
     )
     assert result.verdict == FLOW_VERDICT_UNKNOWN
-    assert result.gaps == ("legacy/script.scala", "legacy/tool.php")
+    assert result.gaps == ("legacy/script.scala", "legacy/tool.dart")
 
 
 def test_equal_names_without_an_edge_are_not_a_path() -> None:
@@ -114,12 +114,14 @@ def test_indexing_records_flow_coverage_per_module(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:
     (temp_repo / "covered.py").write_text("def f():\n    return 1\n")
-    # Lua joined FLOW_REGISTERED_LANGUAGES in #1175; PHP is still outside it.
+    # Lua joined FLOW_REGISTERED_LANGUAGES in #1175 and PHP in #1174; Scala is still
+    # outside it, so it stays the honest "uncovered" example here.
     (temp_repo / "lua_covered.lua").write_text("local function f() return 1 end\n")
-    (temp_repo / "uncovered.php").write_text("<?php\nfunction f() { return 1; }\n")
+    (temp_repo / "php_covered.php").write_text("<?php\nfunction f() { return 1; }\n")
+    (temp_repo / "uncovered.scala").write_text("object U { def f(): Int = 1 }\n")
     parsers, queries = load_parsers()
-    if "php" not in parsers or "lua" not in parsers:
-        pytest.skip("php/lua parser not available")
+    if not {"php", "lua", "scala"} <= set(parsers):
+        pytest.skip("php/lua/scala parser not available")
     updater = GraphUpdater(
         ingestor=mock_ingestor,
         repo_path=temp_repo,
@@ -132,6 +134,7 @@ def test_indexing_records_flow_coverage_per_module(
     project = temp_repo.name
     assert modules[f"{project}.covered"]["flow_covered"] is True
     assert modules[f"{project}.lua_covered"]["flow_covered"] is True
+    assert modules[f"{project}.php_covered"]["flow_covered"] is True
     assert modules[f"{project}.uncovered"]["flow_covered"] is False
 
 

--- a/docs/architecture/data-flow-edges.md
+++ b/docs/architecture/data-flow-edges.md
@@ -427,7 +427,7 @@ it applies rather than broad and noisy.
 
 ## Language coverage
 
-`FLOWS_TO` covers **11 of the 14 supported languages** — every language whose
+`FLOWS_TO` covers **12 of the 14 supported languages** — every language whose
 source/sink table is registered in `FLOW_REGISTERED_LANGUAGES`
 (`codebase_rag/parsers/io_access/registry.py`). Python uses the deep,
 path-sensitive walk; the rest use the descriptor-driven lean walk. A language

--- a/docs/architecture/data-flow-edges.md
+++ b/docs/architecture/data-flow-edges.md
@@ -384,8 +384,12 @@ module is re-exported under its own name. A project that does
   tainted value reached a call — and is emitted alongside the forward composition above.
   Sources and sinks are direct I/O calls from the registry.
 - The source/sink registry covers Python, JavaScript, TypeScript (including TSX),
-  Go, Java, Rust, C, C++, C#, and Lua; a language not in the registry emits no I/O
-  or flow edges until its table is added.
+  Go, Java, Rust, C, C++, C#, Lua, and PHP; a language not in the registry emits no
+  I/O or flow edges until its table is added. PHP models `$_GET`/`$_POST`/
+  `$_REQUEST`/`$_COOKIE` (untrusted HTTP input → NETWORK) and `$_ENV`/`$_SERVER`
+  (→ ENV) superglobal sources, `getenv`/`file_get_contents` reads,
+  `file_put_contents` and `echo`/`print` (keyword STDOUT sinks) writes, and
+  `fopen` + arg-shaped `fwrite`/`fputs` handle writes.
 - Handle-based writes in the lean (non-Python) `FLOWS_TO` walk are being taught
   incrementally (issue #1204). **Go**, **Rust**, **Java**, **C#**, **JS/TS**, and
   **Lua** now track handle bindings, so a taint written through a file/socket handle
@@ -444,7 +448,7 @@ edges, so a reachability question over it returns `UNKNOWN` rather than
 | C | ✅ | lean descriptor |
 | C# | ✅ | lean descriptor |
 | Lua | ✅ | lean descriptor |
-| PHP | ❌ | not covered — no sink table |
+| PHP | ✅ | lean descriptor |
 | Scala | ❌ | not covered — no sink table |
 | Dart | ❌ | not covered — no sink table |
 


### PR DESCRIPTION
## What

Closes #1174 — brings **PHP** into the descriptor-driven lean `FLOWS_TO` walk. PHP was absent from `IO_SINKS`, so every PHP `Module` carried `flow_covered: false` and flow queries over PHP reported `UNKNOWN`. Now:

- **Superglobal sources**: `$_GET`/`$_POST`/`$_REQUEST`/`$_COOKIE` → NETWORK (untrusted HTTP input), `$_ENV`/`$_SERVER` → ENV.
- **Sinks**: `file_get_contents`/`readfile`/`getenv` (reads), `file_put_contents` (write), `echo`/`print` (STDOUT keyword sinks), `fopen` + `fwrite`/`fputs`/`fputcsv` (handle writes).
- Cross-function arg taint, return-taint fixpoint, and path-sensitive branch merges all work.

```php
$g = $_GET["q"]; echo $g;                       // NETWORK:q -> STDOUT
$s = getenv("K"); file_put_contents("out.txt", $s);  // ENV:K -> FILE:out.txt
$f = fopen("out.txt", "w"); fwrite($f, $s);     // ENV:K -> FILE:out.txt
```

## How

Descriptor + registry work, plus a few small **backward-compatible** shared-walker generalizations (each defaulted so the other 10 languages are untouched — full flow regression green):

1. **Descriptor** `_PHP_DESCRIPTOR` (`function_call_expression`, `encapsed_string`, `variable_name` identifiers with the `$` prefix, `argument` wrapper like C#, `member_access`/`subscript` for superglobals).
2. **Two new descriptor fields** (both default-empty): `keyword_stdout_write_types` (PHP `echo_statement`/`print_intrinsic` → a new `_flow_keyword_write` branch routing each operand's taint to STDOUT, unwrapping `sequence_expression` for `echo $a, $b`) and `if_consequence_field` (PHP `if` uses a `body` field, not `consequence`).
3. **`_walk_flat_if` generalization**: reads the consequence via `if_consequence_field` and gathers *all* `alternative` children via `children_by_field_name` — PHP emits the elseif/else chain as flat siblings; Go/Java/C++/Rust have 0/1, so their behavior is identical. The implicit skip path survives unless the chain ends in a terminal `else`.
4. **Fieldless-subscript fallback** in `_js_member_source`/`_js_member_identity` (PHP `$_ENV["K"]` has no `object`/`index` fields) — guarded so field-based grammars never take it.
5. **Registry**: PHP `IO_SINKS`, `IO_MEMBER_READS`, `IO_LEAN_HANDLE_CONSTRUCTORS` (`fopen`), `IO_ARG_HANDLE_SINKS` (`fwrite`/`fputs`/`fputcsv` — note PHP **reverses** the libc arg order: handle arg 0, data arg 1). `FLOW_REGISTERED_LANGUAGES` picks up PHP automatically.
6. **`php_positional_parameter_slots`** (utils) so cross-function parameter→sink composition keys on the `$`-prefixed name.
7. Branch node types: `foreach_statement` → loop types, `default_statement` → switch-arm sets (`case_statement` already shares the C++ spelling).

## Tests

`test_flow_php_edges.py`: 9 cases — superglobal→echo, `$_ENV`→print, getenv→file_put_contents, tainted arg into callee, return-taint fixpoint, if/else and elseif-chain branch merges, fopen+fwrite handle, untainted `== set()`. Full flow + io regression green (the shared `_walk_flat_if` change verified against all languages); ruff + ty clean.

## Deferred (fast-follow)

`match` value-taint (the `match_expression`/Rust string collision is safe — mis-route emits nothing), `echo` string interpolation/concatenation, single-quote string identity, foreach loop-var taint, member-call handles.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PHP support for data-flow analysis, including superglobal and environment sources.
  * Added tracking for file, network, and standard-output sinks, including handle-based writes.
  * Improved flow tracking across function arguments, returns, loops, conditionals, and switch branches.
  * Added case-insensitive handling for PHP built-in functions.

* **Documentation**
  * Updated supported-language and PHP data-flow documentation.

* **Tests**
  * Added coverage for PHP taint propagation, sinks, handles, branching, and untainted values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->