### PR TITLE
feat: add FLOWS_TO lean-walk coverage for Dart (#1173)

### DIFF
--- a/codebase_rag/constants/ast_dart.py
+++ b/codebase_rag/constants/ast_dart.py
@@ -93,6 +93,9 @@ TS_DART_FORMAL_PARAMETER_LIST = "formal_parameter_list"
 TS_DART_SWITCH_STATEMENT_CASE = "switch_statement_case"
 TS_DART_SWITCH_STATEMENT_DEFAULT = "switch_statement_default"
 TS_DART_TEMPLATE_SUBSTITUTION = "template_substitution"
+# `[String m]` (optional positional) and `{String? m}` (named) both wrap their
+# `formal_parameter`s in an `optional_formal_parameters` node (issue #1173).
+TS_DART_OPTIONAL_FORMAL_PARAMETERS = "optional_formal_parameters"
 
 # Type/class-like declarations (all captured as @class)
 TS_DART_CLASS_DEFINITION = "class_definition"

--- a/codebase_rag/constants/ast_dart.py
+++ b/codebase_rag/constants/ast_dart.py
@@ -80,6 +80,20 @@ TS_DART_INITIALIZED_IDENTIFIER = "initialized_identifier"
 TS_DART_INITIALIZED_VARIABLE_DEFINITION = "initialized_variable_definition"
 TS_DART_FORMAL_PARAMETER = "formal_parameter"
 
+# FLOWS_TO lean-walk node types (issue #1173). Dart has no call-expression node:
+# calls/members/bindings are flat sibling `selector` chains reconstructed by the
+# dart/utils.py helpers (dart_call_name, dart_member_read_name, dart_body_node).
+TS_DART_STRING_LITERAL = "string_literal"
+TS_DART_INDEX_SELECTOR = "index_selector"
+TS_DART_ASSIGNMENT_EXPRESSION = "assignment_expression"
+TS_DART_EXPRESSION_STATEMENT = "expression_statement"
+TS_DART_LOCAL_VARIABLE_DECLARATION = "local_variable_declaration"
+TS_DART_ASSIGNABLE_EXPRESSION = "assignable_expression"
+TS_DART_FORMAL_PARAMETER_LIST = "formal_parameter_list"
+TS_DART_SWITCH_STATEMENT_CASE = "switch_statement_case"
+TS_DART_SWITCH_STATEMENT_DEFAULT = "switch_statement_default"
+TS_DART_TEMPLATE_SUBSTITUTION = "template_substitution"
+
 # Type/class-like declarations (all captured as @class)
 TS_DART_CLASS_DEFINITION = "class_definition"
 TS_DART_MIXIN_DECLARATION = "mixin_declaration"

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -91,18 +91,6 @@ _BUILTIN_QN_PREFIX = f"{cs.BUILTIN_PREFIX}{cs.SEPARATOR_DOT}"
 _DART_ASSIGN_OP = "="
 
 
-def _dart_name(node: Node | None) -> str | None:
-    # The identifier text of a simple Dart argument (`sink(k)` -> "k"); None for a
-    # non-identifier argument, so a taint-map lookup on it misses.
-    if (
-        node is not None
-        and node.type == cs.TS_DART_IDENTIFIER
-        and node.text is not None
-    ):
-        return node.text.decode(cs.ENCODING_UTF8)
-    return None
-
-
 # The `kind` half of an argument `via` tag (VIA_ARG_FORMAT / VIA_KW_FORMAT),
 # used to map a call-site argument back to the callee's parameter (issue #1142).
 _VIA_SEPARATOR = ":"
@@ -1874,7 +1862,12 @@ class FlowProcessor:
         block = next(
             (c for c in body.named_children if c.type == cs.TS_DART_BLOCK), None
         )
-        return list(block.named_children) if block is not None else []
+        if block is not None:
+            return list(block.named_children)
+        # An expression-bodied declaration `=> expr` (function/method/getter) has no
+        # block: the whole `function_body` is walked for the expression's call
+        # effects and evaluated as the implicit return value (Greptile review, #1173).
+        return [body]
 
     @staticmethod
     def _dart_selector_is_call(node: Node) -> bool:
@@ -1895,7 +1888,9 @@ class FlowProcessor:
             self._dart_bind(node, tainted, handles, jc)
         elif self._dart_selector_is_call(node):
             self._dart_call(node, tainted, handles, jc)
-        elif node_type == cs.TS_RETURN_STATEMENT:
+        elif node_type in (cs.TS_RETURN_STATEMENT, cs.TS_DART_FUNCTION_BODY):
+            # `return expr;` and an arrow body `=> expr` both contribute the
+            # expression's taint to the return summary (issue #1173).
             returned = self._dart_return_taint(node, tainted, jc)
             if returned is not None:
                 self._acc_returns_taint = True
@@ -2092,34 +2087,68 @@ class FlowProcessor:
                     (jc.flow.caller_qn, pname, callee_qn, via)
                 )
 
-    def _dart_arg_taints(
-        self, selector: Node, tainted: _TaintMap, jc: _JsCtx
-    ) -> list[tuple[str, Taint | None]]:
-        # The positional arguments of a Dart call, taken from the selector's
-        # `argument_part` -> `arguments` -> `argument` wrappers.
+    @staticmethod
+    def _dart_arguments(selector: Node) -> Node | None:
+        # The `arguments` node inside a call selector's `argument_part`.
         argpart = next(
             (c for c in selector.named_children if c.type == cs.TS_DART_ARGUMENT_PART),
             None,
         )
         if argpart is None:
-            return []
-        arguments = next(
+            return None
+        return next(
             (c for c in argpart.named_children if c.type == cs.TS_DART_ARGUMENTS), None
         )
+
+    @staticmethod
+    def _dart_named_arg(arg: Node) -> tuple[str | None, list[Node]]:
+        # `named_argument` -> `label`(identifier `:`) + the value CHAIN (which may be
+        # a selector chain such as `message: Platform.environment['K']`).
+        name: str | None = None
+        value: list[Node] = []
+        for child in arg.named_children:
+            if child.type == cs.TS_DART_LABEL:
+                ident = next(
+                    (
+                        c
+                        for c in child.named_children
+                        if c.type == cs.TS_DART_IDENTIFIER
+                    ),
+                    None,
+                )
+                if ident is not None and ident.text is not None:
+                    name = ident.text.decode(cs.ENCODING_UTF8)
+            elif child.type != cs.TS_COMMENT:
+                value.append(child)
+        return name, value
+
+    def _dart_arg_taints(
+        self, selector: Node, tainted: _TaintMap, jc: _JsCtx
+    ) -> list[tuple[str, Taint | None]]:
+        # A Dart call's arguments: positional `argument` wrappers (via `arg:<index>`)
+        # and `named_argument` values (`sink(message: x)`, via `kw:<name>`). Each
+        # argument is a full expression CHAIN (a bare identifier, a
+        # `Platform.environment['K']` source, or a `src()` call), evaluated via
+        # `_dart_rhs` so inline sources reach the sink too (issue #1173).
+        arguments = self._dart_arguments(selector)
         if arguments is None:
             return []
         out: list[tuple[str, Taint | None]] = []
-        index = 0
+        positional = 0
         for arg in arguments.named_children:
-            if arg.type != cs.TS_DART_ARGUMENT:
+            if arg.type == cs.TS_DART_ARGUMENT:
+                chain = [c for c in arg.named_children if c.type != cs.TS_COMMENT]
+                via = VIA_ARG_FORMAT.format(index=positional)
+                positional += 1
+            elif arg.type == cs.TS_DART_NAMED_ARGUMENT:
+                name, chain = self._dart_named_arg(arg)
+                if name is None:
+                    continue
+                via = VIA_KW_FORMAT.format(name=name)
+            else:
                 continue
-            inner = next(
-                (c for c in arg.named_children if c.type != cs.TS_COMMENT), None
-            )
-            arg_name = _dart_name(inner)
-            taint = tainted.get(arg_name) if arg_name is not None else None
-            out.append((VIA_ARG_FORMAT.format(index=index), taint))
-            index += 1
+            taint, _ = self._dart_rhs(chain, tainted, {}, jc)
+            out.append((via, taint))
         return out
 
     def _dart_return_taint(
@@ -2131,25 +2160,19 @@ class FlowProcessor:
         return taint
 
     def _dart_first_string_arg(self, selector: Node) -> str:
-        argpart = next(
-            (c for c in selector.named_children if c.type == cs.TS_DART_ARGUMENT_PART),
-            None,
-        )
-        if argpart is None:
-            return DYNAMIC_TARGET
-        arguments = next(
-            (c for c in argpart.named_children if c.type == cs.TS_DART_ARGUMENTS), None
-        )
+        arguments = self._dart_arguments(selector)
         if arguments is None:
             return DYNAMIC_TARGET
         for arg in arguments.named_children:
-            if arg.type != cs.TS_DART_ARGUMENT:
+            if arg.type == cs.TS_DART_ARGUMENT:
+                chain = [c for c in arg.named_children if c.type != cs.TS_COMMENT]
+            elif arg.type == cs.TS_DART_NAMED_ARGUMENT:
+                _, chain = self._dart_named_arg(arg)
+            else:
                 continue
-            inner = next(
-                (c for c in arg.named_children if c.type != cs.TS_COMMENT), None
-            )
-            if inner is not None and inner.type == cs.TS_DART_STRING_LITERAL:
-                return self._dart_string_literal(inner)
+            first = chain[0] if chain else None
+            if first is not None and first.type == cs.TS_DART_STRING_LITERAL:
+                return self._dart_string_literal(first)
         return DYNAMIC_TARGET
 
     @staticmethod

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -13,6 +13,7 @@ from ... import constants as cs
 from ...capture import CaptureSelection
 from ...services import IngestorProtocol
 from ..call_resolver import CallResolver
+from ..dart.utils import dart_body_node, dart_call_name, dart_member_read_name
 from ..import_processor import ImportProcessor
 from ..io_access import (
     DYNAMIC_TARGET,
@@ -64,6 +65,7 @@ from ..utils import (
     cpp_declarator_name,
     cpp_positional_parameter_slots,
     csharp_positional_parameter_slots,
+    dart_positional_parameter_slots,
     function_span_key,
     go_positional_parameter_slots,
     java_positional_parameter_slots,
@@ -84,6 +86,22 @@ from .constants import (
 )
 
 _BUILTIN_QN_PREFIX = f"{cs.BUILTIN_PREFIX}{cs.SEPARATOR_DOT}"
+# The Dart `=` assignment token node type (no dedicated constant); the flow walk
+# splits a Dart binding on it (issue #1173).
+_DART_ASSIGN_OP = "="
+
+
+def _dart_name(node: Node | None) -> str | None:
+    # The identifier text of a simple Dart argument (`sink(k)` -> "k"); None for a
+    # non-identifier argument, so a taint-map lookup on it misses.
+    if (
+        node is not None
+        and node.type == cs.TS_DART_IDENTIFIER
+        and node.text is not None
+    ):
+        return node.text.decode(cs.ENCODING_UTF8)
+    return None
+
 
 # The `kind` half of an argument `via` tag (VIA_ARG_FORMAT / VIA_KW_FORMAT),
 # used to map a call-site argument back to the callee's parameter (issue #1142).
@@ -183,6 +201,8 @@ def _lean_parameter_slots(
         return c_positional_parameter_slots(func_node)
     if language == cs.SupportedLanguage.PHP:
         return php_positional_parameter_slots(func_node)
+    if language == cs.SupportedLanguage.DART:
+        return dart_positional_parameter_slots(func_node)
     return [], None
 
 
@@ -332,12 +352,14 @@ _SWITCH_ARM_TYPES = frozenset(
         cs.TS_JS_SWITCH_CASE,
         cs.TS_JS_SWITCH_DEFAULT,
         cs.TS_PHP_DEFAULT_STATEMENT,
+        cs.TS_DART_SWITCH_STATEMENT_CASE,
+        cs.TS_DART_SWITCH_STATEMENT_DEFAULT,
     }
 )
 # Arms a previous case can fall INTO (no break modeling: the entry unions
 # the previous arm's exit). Go cases and Java arrow rules never fall
 # through, so they enter only from the header state. PHP `case`/`default`
-# fall through C-style (`case_statement` shares the C++ spelling).
+# and Dart `switch_statement_case`/`_default` fall through C-style.
 _FALLTHROUGH_ARM_TYPES = frozenset(
     {
         cs.TS_JAVA_SWITCH_BLOCK_STATEMENT_GROUP,
@@ -345,14 +367,21 @@ _FALLTHROUGH_ARM_TYPES = frozenset(
         cs.TS_JS_SWITCH_CASE,
         cs.TS_JS_SWITCH_DEFAULT,
         cs.TS_PHP_DEFAULT_STATEMENT,
+        cs.TS_DART_SWITCH_STATEMENT_CASE,
+        cs.TS_DART_SWITCH_STATEMENT_DEFAULT,
     }
 )
 
 # Arm node types spelled `default` explicitly (Go default_case, JS
-# switch_default, PHP default_statement); the other grammars mark default
-# structurally.
+# switch_default, PHP default_statement, Dart switch_statement_default); the
+# other grammars mark default structurally.
 _EXPLICIT_DEFAULT_ARM_TYPES = frozenset(
-    {cs.TS_GO_DEFAULT_CASE, cs.TS_JS_SWITCH_DEFAULT, cs.TS_PHP_DEFAULT_STATEMENT}
+    {
+        cs.TS_GO_DEFAULT_CASE,
+        cs.TS_JS_SWITCH_DEFAULT,
+        cs.TS_PHP_DEFAULT_STATEMENT,
+        cs.TS_DART_SWITCH_STATEMENT_DEFAULT,
+    }
 )
 
 
@@ -717,13 +746,18 @@ class FlowProcessor:
             arg_handle_sinks=IO_ARG_HANDLE_SINKS.get(ctx.language, {}),
             type_ctors=IO_TYPE_HANDLE_CONSTRUCTORS.get(ctx.language, {}),
         )
-        body = caller_node.child_by_field_name(cs.FIELD_BODY)
-        if body is None:
-            statements = list(caller_node.named_children)
-        elif body.type == descriptor.block_scope_type:
-            statements = list(body.named_children)
+        if ctx.language == cs.SupportedLanguage.DART:
+            # Dart's body is a SIBLING `function_body` of the captured signature,
+            # not a `body` field (issue #1173).
+            statements = self._dart_body_statements(caller_node)
         else:
-            statements = [body]
+            body = caller_node.child_by_field_name(cs.FIELD_BODY)
+            if body is None:
+                statements = list(caller_node.named_children)
+            elif body.type == descriptor.block_scope_type:
+                statements = list(body.named_children)
+            else:
+                statements = [body]
         state = _LeanState(taint={}, handles={})
         # Seed each parameter as a pseudo-origin so a sink or callee hand-off it
         # reaches becomes a parameter-taint summary composed at finalize, exactly
@@ -1244,6 +1278,10 @@ class FlowProcessor:
     ) -> None:
         # The leaf effect of one node on the taint map: bind (JS/Go), Go range
         # kill, a call's sink/arg edges, or a return's contribution to the summary.
+        if jc.flow.language == cs.SupportedLanguage.DART:
+            # Dart's sibling-chain grammar takes a dedicated leaf path (issue #1173).
+            self._apply_dart_leaf(node, tainted, handles, jc)
+            return
         node_type = node.type
         d = jc.descriptor
         if jc.type_ctors and node_type == cs.TS_CPP_DECLARATION:
@@ -1822,6 +1860,307 @@ class FlowProcessor:
             if child.type == d.string_type:
                 return string_literal(child, d.string_type, d.string_content_type)
         return DYNAMIC_TARGET
+
+    # --- Dart lean walk (issue #1173). Dart has no call-expression node: calls,
+    # member reads and bindings are flat sibling `selector` chains, so it takes a
+    # dedicated leaf path reusing the dart/utils.py reconstructors. ---
+
+    def _dart_body_statements(self, caller_node: Node) -> list[Node]:
+        # The captured Dart signature's sibling `function_body` -> its `block`'s
+        # statements. A `program` (module-level) caller has no function body.
+        body = dart_body_node(caller_node)
+        if body is None:
+            return []
+        block = next(
+            (c for c in body.named_children if c.type == cs.TS_DART_BLOCK), None
+        )
+        return list(block.named_children) if block is not None else []
+
+    @staticmethod
+    def _dart_selector_is_call(node: Node) -> bool:
+        return node.type == cs.TS_DART_SELECTOR and any(
+            c.type == cs.TS_DART_ARGUMENT_PART for c in node.named_children
+        )
+
+    def _apply_dart_leaf(
+        self, node: Node, tainted: _TaintMap, handles: _HandleMap, jc: _JsCtx
+    ) -> None:
+        # Dart leaf effects: a `var x = <chain>` / `x = <chain>` binding, a call
+        # (a `selector` holding an `argument_part`), or a return.
+        node_type = node.type
+        if node_type in (
+            cs.TS_DART_INITIALIZED_VARIABLE_DEFINITION,
+            cs.TS_DART_ASSIGNMENT_EXPRESSION,
+        ):
+            self._dart_bind(node, tainted, handles, jc)
+        elif self._dart_selector_is_call(node):
+            self._dart_call(node, tainted, handles, jc)
+        elif node_type == cs.TS_RETURN_STATEMENT:
+            returned = self._dart_return_taint(node, tainted, jc)
+            if returned is not None:
+                self._acc_returns_taint = True
+                self._acc_return_taint = _merge_taint(self._acc_return_taint, returned)
+
+    @staticmethod
+    def _dart_binding_name_and_rhs(node: Node) -> tuple[str | None, list[Node]]:
+        # `var k = <rhs...>` / `k = <rhs...>`: the name is the last identifier before
+        # `=` (unwrapping an `assignable_expression` LHS), the RHS is the named
+        # children after `=` (a spread selector chain).
+        eq_index = next(
+            (i for i, c in enumerate(node.children) if c.type == _DART_ASSIGN_OP),
+            None,
+        )
+        if eq_index is None:
+            return None, []
+        name: str | None = None
+        for child in node.children[:eq_index]:
+            target = child
+            if target.type == cs.TS_DART_ASSIGNABLE_EXPRESSION:
+                target = next(
+                    (
+                        c
+                        for c in target.named_children
+                        if c.type == cs.TS_DART_IDENTIFIER
+                    ),
+                    target,
+                )
+            if target.type == cs.TS_DART_IDENTIFIER and target.text is not None:
+                name = target.text.decode(cs.ENCODING_UTF8)
+        rhs = [c for c in node.children[eq_index + 1 :] if c.is_named]
+        return name, rhs
+
+    def _dart_bind(
+        self, node: Node, tainted: _TaintMap, handles: _HandleMap, jc: _JsCtx
+    ) -> None:
+        name, rhs = self._dart_binding_name_and_rhs(node)
+        if name is None:
+            return
+        taint, bindings = self._dart_rhs(rhs, tainted, handles, jc)
+        if taint is not None:
+            tainted[name] = taint
+        else:
+            tainted.pop(name, None)
+        if bindings:
+            handles[name] = bindings
+        else:
+            handles.pop(name, None)
+
+    def _dart_rhs(
+        self,
+        rhs: list[Node],
+        tainted: _TaintMap,
+        handles: _HandleMap,
+        jc: _JsCtx,
+    ) -> tuple[Taint | None, frozenset[HandleBinding]]:
+        # The taint and/or handle a Dart binding RHS yields: a `Platform.environment`
+        # member source, a `File(path)` handle constructor, a read-source call, a
+        # project-callee return (pending), or a plain identifier alias.
+        if not rhs:
+            return None, frozenset()
+        source = self._dart_member_source(rhs, jc)
+        if source is not None:
+            return Taint(frozenset({source}), frozenset()), frozenset()
+        call_sel = next((n for n in rhs if self._dart_selector_is_call(n)), None)
+        if call_sel is not None:
+            raw = dart_call_name(call_sel)
+            if raw is not None:
+                ctor = self._js_match_sink(raw, jc.handle_ctors, jc)
+                if ctor is not None and ctor.direction != IODirection.READ:
+                    identity = self._dart_first_string_arg(call_sel)
+                    return None, frozenset({HandleBinding(ctor.kind, identity)})
+                read = self._js_match_sink(raw, jc.flow.read_sinks, jc)
+                if read is not None:
+                    identity = (
+                        self._dart_first_string_arg(call_sel)
+                        if read.target_arg == 0
+                        else DYNAMIC_TARGET
+                    )
+                    return (
+                        Taint(
+                            frozenset({HandleBinding(read.kind, identity)}), frozenset()
+                        ),
+                        frozenset(),
+                    )
+                callee = self._resolve(
+                    raw,
+                    jc.flow.module_qn,
+                    jc.flow.class_context,
+                    jc.flow.caller_qn,
+                    jc.flow.language,
+                    jc.flow.local_var_types,
+                )
+                if callee is not None:
+                    self._return_edge_candidates.append(
+                        (callee[0], callee[1], jc.flow.caller_spec)
+                    )
+                    return Taint(frozenset(), frozenset({callee[1]})), frozenset()
+            return None, frozenset()
+        if len(rhs) == 1 and rhs[0].type == cs.TS_DART_IDENTIFIER and rhs[0].text:
+            alias = rhs[0].text.decode(cs.ENCODING_UTF8)
+            return tainted.get(alias), handles.get(alias, frozenset())
+        return None, frozenset()
+
+    def _dart_member_source(
+        self, nodes: list[Node], jc: _JsCtx
+    ) -> HandleBinding | None:
+        # `Platform.environment['K']`: a bound member read. `dart_member_read_name`
+        # on the `.environment` selector yields the prefix; the key comes from a
+        # trailing `index_selector`'s string literal.
+        for index, node in enumerate(nodes):
+            if node.type != cs.TS_DART_SELECTOR:
+                continue
+            name = dart_member_read_name(node)
+            if name is None:
+                continue
+            for prefix, kind in jc.member_reads:
+                if name == prefix:
+                    identity = self._dart_index_key(nodes[index + 1 :])
+                    return HandleBinding(kind=kind, identity=identity)
+        return None
+
+    def _dart_index_key(self, following: list[Node]) -> str:
+        # The string key inside a trailing `index_selector` (`['K']` -> `K`).
+        for node in following:
+            index_sel = self._find_dart_index_selector(node)
+            if index_sel is not None:
+                for child in index_sel.named_children:
+                    if child.type == cs.TS_DART_STRING_LITERAL:
+                        return self._dart_string_literal(child)
+        return DYNAMIC_TARGET
+
+    @staticmethod
+    def _find_dart_index_selector(node: Node) -> Node | None:
+        if node.type == cs.TS_DART_INDEX_SELECTOR:
+            return node
+        for child in node.named_children:
+            if child.type == cs.TS_DART_INDEX_SELECTOR:
+                return child
+            nested = FlowProcessor._find_dart_index_selector(child)
+            if nested is not None:
+                return nested
+        return None
+
+    def _dart_call(
+        self, selector: Node, tainted: _TaintMap, handles: _HandleMap, jc: _JsCtx
+    ) -> None:
+        raw = dart_call_name(selector)
+        if raw is None:
+            return
+        args = self._dart_arg_taints(selector, tainted, jc)
+        if (sink := self._js_match_sink(raw, jc.flow.write_sinks, jc)) is not None:
+            dst = (
+                self._dart_first_string_arg(selector)
+                if sink.target_arg == 0
+                else DYNAMIC_TARGET
+            )
+            for _via, taint in args:
+                if taint is not None:
+                    self._emit_taint_to_sink(taint, sink.kind, dst, jc.flow.caller_qn)
+            return
+        if handles and self._emit_handle_write(raw, args, handles, jc):
+            return
+        callee = self._resolve(
+            raw,
+            jc.flow.module_qn,
+            jc.flow.class_context,
+            jc.flow.caller_qn,
+            jc.flow.language,
+            jc.flow.local_var_types,
+        )
+        if callee is None:
+            return
+        callee_type, callee_qn = callee
+        for via, taint in args:
+            if taint is None:
+                continue
+            if taint.origins:
+                self.ingestor.ensure_relationship_batch(
+                    jc.flow.caller_spec,
+                    cs.RelationshipType.FLOWS_TO,
+                    (callee_type, cs.KEY_QUALIFIED_NAME, callee_qn),
+                    properties={KEY_VIA: via, KEY_KIND: FlowKind.ARG.value},
+                )
+            elif taint.pending:
+                self._deferred_arg_edges.append(
+                    (taint.pending, jc.flow.caller_spec, callee_type, callee_qn, via)
+                )
+            if taint.origins or taint.pending:
+                token = _passthrough_result_token(jc.flow.caller_qn, selector)
+                self._param_call_sites.append((taint, callee_qn, via, token))
+            for pname in taint.params:
+                self._param_flow_edges.append(
+                    (jc.flow.caller_qn, pname, callee_qn, via)
+                )
+
+    def _dart_arg_taints(
+        self, selector: Node, tainted: _TaintMap, jc: _JsCtx
+    ) -> list[tuple[str, Taint | None]]:
+        # The positional arguments of a Dart call, taken from the selector's
+        # `argument_part` -> `arguments` -> `argument` wrappers.
+        argpart = next(
+            (c for c in selector.named_children if c.type == cs.TS_DART_ARGUMENT_PART),
+            None,
+        )
+        if argpart is None:
+            return []
+        arguments = next(
+            (c for c in argpart.named_children if c.type == cs.TS_DART_ARGUMENTS), None
+        )
+        if arguments is None:
+            return []
+        out: list[tuple[str, Taint | None]] = []
+        index = 0
+        for arg in arguments.named_children:
+            if arg.type != cs.TS_DART_ARGUMENT:
+                continue
+            inner = next(
+                (c for c in arg.named_children if c.type != cs.TS_COMMENT), None
+            )
+            arg_name = _dart_name(inner)
+            taint = tainted.get(arg_name) if arg_name is not None else None
+            out.append((VIA_ARG_FORMAT.format(index=index), taint))
+            index += 1
+        return out
+
+    def _dart_return_taint(
+        self, node: Node, tainted: _TaintMap, jc: _JsCtx
+    ) -> Taint | None:
+        # A Dart `return <chain>;` contributes the chain's taint to the summary.
+        rhs = [c for c in node.named_children if c.type != cs.TS_COMMENT]
+        taint, _ = self._dart_rhs(rhs, tainted, {}, jc)
+        return taint
+
+    def _dart_first_string_arg(self, selector: Node) -> str:
+        argpart = next(
+            (c for c in selector.named_children if c.type == cs.TS_DART_ARGUMENT_PART),
+            None,
+        )
+        if argpart is None:
+            return DYNAMIC_TARGET
+        arguments = next(
+            (c for c in argpart.named_children if c.type == cs.TS_DART_ARGUMENTS), None
+        )
+        if arguments is None:
+            return DYNAMIC_TARGET
+        for arg in arguments.named_children:
+            if arg.type != cs.TS_DART_ARGUMENT:
+                continue
+            inner = next(
+                (c for c in arg.named_children if c.type != cs.TS_COMMENT), None
+            )
+            if inner is not None and inner.type == cs.TS_DART_STRING_LITERAL:
+                return self._dart_string_literal(inner)
+        return DYNAMIC_TARGET
+
+    @staticmethod
+    def _dart_string_literal(node: Node) -> str:
+        # A Dart string_literal has no content child; the text (with quotes) is
+        # inline. Interpolation (`'$x'`) collapses to <dynamic>.
+        if node.text is None:
+            return DYNAMIC_TARGET
+        if any(c.type == cs.TS_DART_TEMPLATE_SUBSTITUTION for c in node.named_children):
+            return DYNAMIC_TARGET
+        return node.text.decode(cs.ENCODING_UTF8).strip(cs.DART_QUOTE_CHARS)
 
     def _emit_taint_to_sink(
         self, taint: Taint, kind: ResourceKind, identity: str, caller_qn: str

--- a/codebase_rag/parsers/io_access/descriptor.py
+++ b/codebase_rag/parsers/io_access/descriptor.py
@@ -488,6 +488,39 @@ _LUA_DESCRIPTOR = LanguageDescriptor(
     handle_method_separator=cs.CHAR_COLON,
 )
 
+_DART_DESCRIPTOR = LanguageDescriptor(
+    # Dart has NO call-expression node: calls/members/bindings are flat sibling
+    # `selector` chains reconstructed by the dart/utils.py helpers, so the flow walk
+    # takes a Dart-specific leaf path (issue #1173). Most call/member/binding FIELDS
+    # here are inert; the ones that matter are the node TYPES the walk dispatches on.
+    call_type=cs.TS_DART_SELECTOR,
+    string_type=cs.TS_DART_STRING_LITERAL,
+    # A Dart string_literal has no content child; its content is read inline from
+    # node.text (quote-stripped) by a Dart branch in string_literal().
+    string_content_type=cs.TS_DART_STRING_LITERAL,
+    keyword_arg_type=None,
+    nested_scope_types=cs.DART_NESTED_SCOPE_NODE_TYPES,
+    identifier_type=cs.TS_DART_IDENTIFIER,
+    declarator_type=cs.TS_DART_INITIALIZED_VARIABLE_DEFINITION,
+    params_field=cs.FIELD_PARAMETERS,
+    block_scope_type=cs.TS_DART_BLOCK,
+    extra_declarator_types=frozenset(),
+    loop_declarator_types=frozenset(),
+    statement_container_type=None,
+    sinks_require_import=False,
+    hoisted_declarations=False,
+    decl_in_own_initializer=False,
+    declaration_statement_type=None,
+    macro_type=None,
+    # Inert: Dart member/subscript reads use the sibling-chain path, not these fields.
+    member_expression_type=cs.TS_DART_SELECTOR,
+    subscript_type=cs.TS_DART_INDEX_SELECTOR,
+    object_field=cs.FIELD_OBJECT,
+    property_field=cs.TS_FIELD_NAME,
+    subscript_index_field=cs.TS_FIELD_INDEX,
+    argument_wrapper_type=cs.TS_DART_ARGUMENT,
+)
+
 _PHP_DESCRIPTOR = LanguageDescriptor(
     call_type=cs.TS_PHP_FUNCTION_CALL_EXPRESSION,
     string_type=cs.TS_PHP_ENCAPSED_STRING,
@@ -551,4 +584,5 @@ LANGUAGE_DESCRIPTORS: dict[cs.SupportedLanguage, LanguageDescriptor] = {
     cs.SupportedLanguage.CSHARP: _CSHARP_DESCRIPTOR,
     cs.SupportedLanguage.LUA: _LUA_DESCRIPTOR,
     cs.SupportedLanguage.PHP: _PHP_DESCRIPTOR,
+    cs.SupportedLanguage.DART: _DART_DESCRIPTOR,
 }

--- a/codebase_rag/parsers/io_access/registry.py
+++ b/codebase_rag/parsers/io_access/registry.py
@@ -480,6 +480,19 @@ _PHP_SINKS: tuple[IOSink, ...] = (
     IOSink("fsockopen", ResourceKind.NETWORK, IODirection.READ_WRITE, target_arg=0),
 )
 
+# Dart direct-call I/O sinks (issue #1173). Keyed by the callee text `dart_call_name`
+# reconstructs from the selector chain (`print`, `stdout.write`, `stderr.writeln`).
+# Dart file writes go through the `File` handle (below), not a direct sink.
+_DART_SINKS: tuple[IOSink, ...] = (
+    IOSink("print", ResourceKind.STDOUT, IODirection.WRITE),
+    IOSink("stdout.write", ResourceKind.STDOUT, IODirection.WRITE),
+    IOSink("stdout.writeln", ResourceKind.STDOUT, IODirection.WRITE),
+    IOSink("stderr.write", ResourceKind.STDERR, IODirection.WRITE),
+    IOSink("stderr.writeln", ResourceKind.STDERR, IODirection.WRITE),
+    IOSink("http.get", ResourceKind.NETWORK, IODirection.READ, target_arg=0),
+    IOSink("http.post", ResourceKind.NETWORK, IODirection.WRITE, target_arg=0),
+)
+
 IO_SINKS: dict[cs.SupportedLanguage, tuple[IOSink, ...]] = {
     cs.SupportedLanguage.PYTHON: _PYTHON_SINKS,
     cs.SupportedLanguage.JS: _JS_TS_SINKS,
@@ -497,6 +510,7 @@ IO_SINKS: dict[cs.SupportedLanguage, tuple[IOSink, ...]] = {
     ),
     cs.SupportedLanguage.LUA: _LUA_SINKS,
     cs.SupportedLanguage.PHP: _PHP_SINKS,
+    cs.SupportedLanguage.DART: _DART_SINKS,
 }
 
 # The languages the flow/I-O analysis covers at all: a Module in any other
@@ -583,6 +597,9 @@ IO_MEMBER_READS: dict[cs.SupportedLanguage, tuple[tuple[str, ResourceKind], ...]
     cs.SupportedLanguage.TS: _JS_TS_MEMBER_READS,
     cs.SupportedLanguage.TSX: _JS_TS_MEMBER_READS,
     cs.SupportedLanguage.PHP: _PHP_MEMBER_READS,
+    # Dart `Platform.environment['K']` is a process-env read (issue #1173); the
+    # sibling-chain shape is resolved by the Dart-specific member-source path.
+    cs.SupportedLanguage.DART: (("Platform.environment", ResourceKind.ENV),),
 }
 
 # Calls whose result is a resource handle; later method calls on the bound variable
@@ -791,6 +808,11 @@ IO_LEAN_HANDLE_CONSTRUCTORS: dict[
     # (arg-shaped, below). The mode (arg 1) is not inspected, so may-write (#1174).
     cs.SupportedLanguage.PHP: (
         HandleConstructor("fopen", ResourceKind.FILE, target_arg=0),
+    ),
+    # Dart `var f = File(path)` binds a FILE handle used via `f.writeAsString(data)`
+    # (issue #1173). The read/write mode is per-method, so may-write by default.
+    cs.SupportedLanguage.DART: (
+        HandleConstructor("File", ResourceKind.FILE, target_arg=0),
     ),
 }
 
@@ -1152,6 +1174,20 @@ IO_LEAN_HANDLE_METHODS: dict[
             "write": IODirection.WRITE,
             "read": IODirection.READ,
             "lines": IODirection.READ,
+        },
+    },
+    # Dart `File` handle methods (issue #1173): the async and *Sync forms both count.
+    cs.SupportedLanguage.DART: {
+        ResourceKind.FILE: {
+            "readAsString": IODirection.READ,
+            "readAsStringSync": IODirection.READ,
+            "readAsBytes": IODirection.READ,
+            "readAsBytesSync": IODirection.READ,
+            "readAsLines": IODirection.READ,
+            "writeAsString": IODirection.WRITE,
+            "writeAsStringSync": IODirection.WRITE,
+            "writeAsBytes": IODirection.WRITE,
+            "writeAsBytesSync": IODirection.WRITE,
         },
     },
 }

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -1039,6 +1039,38 @@ def php_positional_parameter_slots(
     return names, None
 
 
+def dart_positional_parameter_slots(
+    func_node: Node,
+) -> tuple[list[str | None], int | None]:
+    # Dart parameters live in a `formal_parameter_list` child of the signature (not
+    # a field); each `formal_parameter` binds a `name` identifier. Optional/named/
+    # field-formal shapes without a simple `name` field append None so later slots
+    # do not shift. Dart has no variadic parameter (issue #1173).
+    params = next(
+        (
+            c
+            for c in func_node.named_children
+            if c.type == cs.TS_DART_FORMAL_PARAMETER_LIST
+        ),
+        None,
+    )
+    if params is None:
+        return [], None
+    names: list[str | None] = []
+    for param in params.named_children:
+        name_node = (
+            param.child_by_field_name(cs.TS_FIELD_NAME)
+            if param.type == cs.TS_DART_FORMAL_PARAMETER
+            else None
+        )
+        names.append(
+            name_node.text.decode(cs.ENCODING_UTF8)
+            if name_node is not None and name_node.text is not None
+            else None
+        )
+    return names, None
+
+
 def _js_ts_field_member_name(
     node: ASTNode, language: cs.SupportedLanguage | None
 ) -> str | None:

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -1043,9 +1043,11 @@ def dart_positional_parameter_slots(
     func_node: Node,
 ) -> tuple[list[str | None], int | None]:
     # Dart parameters live in a `formal_parameter_list` child of the signature (not
-    # a field); each `formal_parameter` binds a `name` identifier. Optional/named/
-    # field-formal shapes without a simple `name` field append None so later slots
-    # do not shift. Dart has no variadic parameter (issue #1173).
+    # a field); each `formal_parameter` binds a `name` identifier. Optional-positional
+    # `[a, b]` and named `{a, b}` params wrap their formal_parameters in an
+    # `optional_formal_parameters` node, which is flattened. Dart requires those to
+    # come LAST, so appending them keeps every positional index correct while still
+    # seeding named params for `kw:<name>` composition. No variadic slot (#1173).
     params = next(
         (
             c
@@ -1058,17 +1060,24 @@ def dart_positional_parameter_slots(
         return [], None
     names: list[str | None] = []
     for param in params.named_children:
-        name_node = (
-            param.child_by_field_name(cs.TS_FIELD_NAME)
-            if param.type == cs.TS_DART_FORMAL_PARAMETER
-            else None
-        )
-        names.append(
-            name_node.text.decode(cs.ENCODING_UTF8)
-            if name_node is not None and name_node.text is not None
-            else None
-        )
+        if param.type == cs.TS_DART_FORMAL_PARAMETER:
+            names.append(_dart_parameter_name(param))
+        elif param.type == cs.TS_DART_OPTIONAL_FORMAL_PARAMETERS:
+            names.extend(
+                _dart_parameter_name(inner)
+                for inner in param.named_children
+                if inner.type == cs.TS_DART_FORMAL_PARAMETER
+            )
     return names, None
+
+
+def _dart_parameter_name(param: Node) -> str | None:
+    name_node = param.child_by_field_name(cs.TS_FIELD_NAME)
+    return (
+        name_node.text.decode(cs.ENCODING_UTF8)
+        if name_node is not None and name_node.text is not None
+        else None
+    )
 
 
 def _js_ts_field_member_name(

--- a/codebase_rag/tests/test_flow_dart_edges.py
+++ b/codebase_rag/tests/test_flow_dart_edges.py
@@ -75,7 +75,7 @@ def test_dart_tainted_argument_into_callee(tmp_path: Path) -> None:
     # A tainted value passed as an argument reaches a sink inside the callee: the
     # parameter-to-sink summary composes across function bodies.
     source = (
-        "void sink(String m) { print(m); }\n"
+        "void sink(String? m) { print(m); }\n"
         "void leak() {\n"
         "  var k = Platform.environment['K'];\n"
         "  sink(k);\n"
@@ -88,7 +88,7 @@ def test_dart_return_taint_fixpoint(tmp_path: Path) -> None:
     # A callee returning a tainted value taints the caller's binding through the
     # return-taint fixpoint.
     source = (
-        "String src() { return Platform.environment['K']; }\n"
+        "String? src() { return Platform.environment['K']; }\n"
         "void leak() {\n"
         "  var v = src();\n"
         "  print(v);\n"
@@ -112,7 +112,7 @@ def test_dart_branch_merge_preserves_taint(tmp_path: Path) -> None:
 def test_dart_expression_bodied_callee(tmp_path: Path) -> None:
     # An arrow-bodied `=> print(v)` sink is walked (Greptile/CodeRabbit review).
     source = (
-        "void sink(String v) => print(v);\n"
+        "void sink(String? v) => print(v);\n"
         "void leak() {\n"
         "  var k = Platform.environment['K'];\n"
         "  sink(k);\n"
@@ -124,7 +124,7 @@ def test_dart_expression_bodied_callee(tmp_path: Path) -> None:
 def test_dart_expression_bodied_source_return(tmp_path: Path) -> None:
     # An arrow body `=> expr` is the implicit return value, feeding the fixpoint.
     source = (
-        "String src() => Platform.environment['K'];\n"
+        "String? src() => Platform.environment['K'];\n"
         "void leak() {\n"
         "  var v = src();\n"
         "  print(v);\n"

--- a/codebase_rag/tests/test_flow_dart_edges.py
+++ b/codebase_rag/tests/test_flow_dart_edges.py
@@ -109,6 +109,63 @@ def test_dart_branch_merge_preserves_taint(tmp_path: Path) -> None:
     assert (_ENV_K, _STDOUT) in _run_flow(tmp_path, source)
 
 
+def test_dart_expression_bodied_callee(tmp_path: Path) -> None:
+    # An arrow-bodied `=> print(v)` sink is walked (Greptile/CodeRabbit review).
+    source = (
+        "void sink(String v) => print(v);\n"
+        "void leak() {\n"
+        "  var k = Platform.environment['K'];\n"
+        "  sink(k);\n"
+        "}\n"
+    )
+    assert (_ENV_K, _STDOUT) in _run_flow(tmp_path, source)
+
+
+def test_dart_expression_bodied_source_return(tmp_path: Path) -> None:
+    # An arrow body `=> expr` is the implicit return value, feeding the fixpoint.
+    source = (
+        "String src() => Platform.environment['K'];\n"
+        "void leak() {\n"
+        "  var v = src();\n"
+        "  print(v);\n"
+        "}\n"
+    )
+    assert (_ENV_K, _STDOUT) in _run_flow(tmp_path, source)
+
+
+def test_dart_inline_source_argument(tmp_path: Path) -> None:
+    # A non-identifier argument is a full chain: `print(Platform.environment['K'])`
+    # evaluates the inline source (Greptile/CodeRabbit review).
+    source = "void leak() {\n  print(Platform.environment['K']);\n}\n"
+    assert (_ENV_K, _STDOUT) in _run_flow(tmp_path, source)
+
+
+def test_dart_named_argument_flows_to_sink(tmp_path: Path) -> None:
+    # A named argument `sink(message: k)` propagates via `kw:message` to the named
+    # parameter (which is flattened out of `optional_formal_parameters` and seeded).
+    source = (
+        "void sink({String? message}) { print(message); }\n"
+        "void leak() {\n"
+        "  var k = Platform.environment['K'];\n"
+        "  sink(message: k);\n"
+        "}\n"
+    )
+    assert (_ENV_K, _STDOUT) in _run_flow(tmp_path, source)
+
+
+def test_dart_optional_positional_parameter(tmp_path: Path) -> None:
+    # An optional-positional parameter `[String? m]` is flattened into slot 0, so a
+    # positional argument still composes to the sink.
+    source = (
+        "void sink([String? m]) { print(m); }\n"
+        "void leak() {\n"
+        "  var k = Platform.environment['K'];\n"
+        "  sink(k);\n"
+        "}\n"
+    )
+    assert (_ENV_K, _STDOUT) in _run_flow(tmp_path, source)
+
+
 def test_dart_untainted_io_emits_no_flow(tmp_path: Path) -> None:
     source = (
         "void leak() {\n"

--- a/codebase_rag/tests/test_flow_dart_edges.py
+++ b/codebase_rag/tests/test_flow_dart_edges.py
@@ -1,0 +1,120 @@
+"""FLOWS_TO lean-walk coverage for Dart (issue #1173). Dart was absent from
+`IO_SINKS`, so its modules carried `flow_covered: false` and flow queries over Dart
+reported UNKNOWN. Dart has no call-expression node -- calls, member reads and
+bindings are flat sibling `selector` chains -- so the walk takes a Dart-specific
+leaf path reusing the dart/utils.py reconstructors. These tests exercise a
+`Platform.environment` source reaching a `print`/`File` handle sink, tainted
+arguments crossing into callees, the return-taint fixpoint, and a branch merge."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.capture import resolve_capture
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+FLOWS_TO = cs.RelationshipType.FLOWS_TO.value
+_CAPTURE_IO = resolve_capture([cs.CaptureGroup.IO.value])
+_STDOUT = "resource::STDOUT::<dynamic>"
+_ENV_K = "resource::ENV::K"
+
+
+def _run_flow(tmp_path: Path, source: str) -> set[tuple[str, str]]:
+    parsers, queries = load_parsers()
+    if "dart" not in parsers:
+        pytest.skip("dart parser not available")
+    (tmp_path / "a.dart").write_text(source, encoding="utf-8")
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock,
+        repo_path=tmp_path,
+        parsers=parsers,
+        queries=queries,
+        capture=_CAPTURE_IO,
+    ).run()
+    return {
+        (c.args[0][2], c.args[2][2])
+        for c in mock.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) == FLOWS_TO
+    }
+
+
+def test_dart_platform_environment_flows_to_print(tmp_path: Path) -> None:
+    # `Platform.environment['K']` is a process-env source; `print` writes STDOUT.
+    source = "void leak() {\n  var k = Platform.environment['K'];\n  print(k);\n}\n"
+    assert (_ENV_K, _STDOUT) in _run_flow(tmp_path, source)
+
+
+def test_dart_env_flows_to_file_handle_write(tmp_path: Path) -> None:
+    # `File(path)` binds a FILE handle; `f.writeAsString(k)` writes the ENV-tainted
+    # value to the file.
+    source = (
+        "void leak() {\n"
+        "  var k = Platform.environment['K'];\n"
+        "  var f = File('out.txt');\n"
+        "  f.writeAsString(k);\n"
+        "}\n"
+    )
+    assert (_ENV_K, "resource::FILE::out.txt") in _run_flow(tmp_path, source)
+
+
+def test_dart_stdout_write_sink(tmp_path: Path) -> None:
+    # `stdout.write(x)` is a STDOUT sink reached via the selector-chain call name.
+    source = (
+        "void leak() {\n  var k = Platform.environment['K'];\n  stdout.write(k);\n}\n"
+    )
+    assert (_ENV_K, _STDOUT) in _run_flow(tmp_path, source)
+
+
+def test_dart_tainted_argument_into_callee(tmp_path: Path) -> None:
+    # A tainted value passed as an argument reaches a sink inside the callee: the
+    # parameter-to-sink summary composes across function bodies.
+    source = (
+        "void sink(String m) { print(m); }\n"
+        "void leak() {\n"
+        "  var k = Platform.environment['K'];\n"
+        "  sink(k);\n"
+        "}\n"
+    )
+    assert (_ENV_K, _STDOUT) in _run_flow(tmp_path, source)
+
+
+def test_dart_return_taint_fixpoint(tmp_path: Path) -> None:
+    # A callee returning a tainted value taints the caller's binding through the
+    # return-taint fixpoint.
+    source = (
+        "String src() { return Platform.environment['K']; }\n"
+        "void leak() {\n"
+        "  var v = src();\n"
+        "  print(v);\n"
+        "}\n"
+    )
+    assert (_ENV_K, _STDOUT) in _run_flow(tmp_path, source)
+
+
+def test_dart_branch_merge_preserves_taint(tmp_path: Path) -> None:
+    # Taint assigned in one if arm survives the MAY join to a post-merge sink.
+    source = (
+        "void leak(bool x) {\n"
+        "  var s = '';\n"
+        "  if (x) { s = Platform.environment['K']; } else { s = 'safe'; }\n"
+        "  print(s);\n"
+        "}\n"
+    )
+    assert (_ENV_K, _STDOUT) in _run_flow(tmp_path, source)
+
+
+def test_dart_untainted_io_emits_no_flow(tmp_path: Path) -> None:
+    source = (
+        "void leak() {\n"
+        "  var f = File('out.txt');\n"
+        "  f.writeAsString('literal');\n"
+        "  print('constant');\n"
+        "}\n"
+    )
+    assert _run_flow(tmp_path, source) == set()

--- a/codebase_rag/tests/test_flow_verdict.py
+++ b/codebase_rag/tests/test_flow_verdict.py
@@ -60,13 +60,13 @@ def test_no_flow_requires_full_coverage() -> None:
 
 def test_unknown_names_the_gaps() -> None:
     result = flow_reachability_verdict(
-        _query_fn([], ["legacy/script.scala", "legacy/tool.dart"]),
+        _query_fn([], ["legacy/script.scala", "legacy/tool.rb"]),
         "p",
         "p.a.src",
         "p.a.sink",
     )
     assert result.verdict == FLOW_VERDICT_UNKNOWN
-    assert result.gaps == ("legacy/script.scala", "legacy/tool.dart")
+    assert result.gaps == ("legacy/script.scala", "legacy/tool.rb")
 
 
 def test_equal_names_without_an_edge_are_not_a_path() -> None:
@@ -114,14 +114,15 @@ def test_indexing_records_flow_coverage_per_module(
     temp_repo: Path, mock_ingestor: MagicMock
 ) -> None:
     (temp_repo / "covered.py").write_text("def f():\n    return 1\n")
-    # Lua joined FLOW_REGISTERED_LANGUAGES in #1175 and PHP in #1174; Scala is still
-    # outside it, so it stays the honest "uncovered" example here.
+    # Lua joined FLOW_REGISTERED_LANGUAGES in #1175, PHP in #1174, Dart in #1173;
+    # Scala is still outside it, so it stays the honest "uncovered" example here.
     (temp_repo / "lua_covered.lua").write_text("local function f() return 1 end\n")
     (temp_repo / "php_covered.php").write_text("<?php\nfunction f() { return 1; }\n")
+    (temp_repo / "dart_covered.dart").write_text("int f() { return 1; }\n")
     (temp_repo / "uncovered.scala").write_text("object U { def f(): Int = 1 }\n")
     parsers, queries = load_parsers()
-    if not {"php", "lua", "scala"} <= set(parsers):
-        pytest.skip("php/lua/scala parser not available")
+    if not {"php", "lua", "dart", "scala"} <= set(parsers):
+        pytest.skip("php/lua/dart/scala parser not available")
     updater = GraphUpdater(
         ingestor=mock_ingestor,
         repo_path=temp_repo,
@@ -135,6 +136,7 @@ def test_indexing_records_flow_coverage_per_module(
     assert modules[f"{project}.covered"]["flow_covered"] is True
     assert modules[f"{project}.lua_covered"]["flow_covered"] is True
     assert modules[f"{project}.php_covered"]["flow_covered"] is True
+    assert modules[f"{project}.dart_covered"]["flow_covered"] is True
     assert modules[f"{project}.uncovered"]["flow_covered"] is False
 
 

--- a/docs/architecture/data-flow-edges.md
+++ b/docs/architecture/data-flow-edges.md
@@ -384,7 +384,7 @@ module is re-exported under its own name. A project that does
   tainted value reached a call — and is emitted alongside the forward composition above.
   Sources and sinks are direct I/O calls from the registry.
 - The source/sink registry covers Python, JavaScript, TypeScript (including TSX),
-  Go, Java, Rust, C, C++, C#, Lua, and PHP; a language not in the registry emits no
+  Go, Java, Rust, C, C++, C#, Lua, PHP, and Dart; a language not in the registry emits no
   I/O or flow edges until its table is added. PHP models `$_GET`/`$_POST`/
   `$_REQUEST`/`$_COOKIE` (untrusted HTTP input → NETWORK) and `$_ENV`/`$_SERVER`
   (→ ENV) superglobal sources, `getenv`/`file_get_contents` reads,
@@ -427,7 +427,7 @@ it applies rather than broad and noisy.
 
 ## Language coverage
 
-`FLOWS_TO` covers **12 of the 14 supported languages** — every language whose
+`FLOWS_TO` covers **13 of the 14 supported languages** — every language whose
 source/sink table is registered in `FLOW_REGISTERED_LANGUAGES`
 (`codebase_rag/parsers/io_access/registry.py`). Python uses the deep,
 path-sensitive walk; the rest use the descriptor-driven lean walk. A language
@@ -450,7 +450,7 @@ edges, so a reachability question over it returns `UNKNOWN` rather than
 | Lua | ✅ | lean descriptor |
 | PHP | ✅ | lean descriptor |
 | Scala | ❌ | not covered — no sink table |
-| Dart | ❌ | not covered — no sink table |
+| Dart | ✅ | lean descriptor + Dart selector-chain path |
 
 ## Coverage metadata and the three-verdict query
 


### PR DESCRIPTION
## What

Closes #1173 — brings **Dart** into the descriptor-driven lean `FLOWS_TO` walk. Dart was absent from `IO_SINKS`, so every Dart `Module` carried `flow_covered: false` and flow queries over Dart reported `UNKNOWN`. This is the **13th of 14** languages covered; only Scala (#1176, blocked) remains.

```dart
var k = Platform.environment['K'];
print(k);                                   // ENV:K -> STDOUT
var f = File('out.txt'); f.writeAsString(k); // ENV:K -> FILE:out.txt
```

## Why it's not a drop-in descriptor (unlike PHP/Lua)

Dart's tree-sitter grammar has **no call-expression node**: calls, member reads, and bindings are flat sibling `selector` chains (`print(p)` = `identifier 'print'` + `selector(argument_part(...))`; `Platform.environment['K']` = `identifier` + `selector(.environment)` + `selector(index_selector)`; the function body is a *sibling* `function_body`, not a `body` field). The lean walk's "a call is one node with function/arguments fields" model doesn't hold. So Dart takes a **dedicated leaf path** (`_apply_dart_leaf` and helpers) that reuses the existing `dart/utils.py` reconstructors (`dart_call_name`, `dart_member_read_name`, `dart_body_node`) built for the CALLS pipeline.

## How

- **Descriptor + registry**: `_DART_DESCRIPTOR` (call/member/binding *fields* largely inert), `IO_SINKS` (`print`, `stdout`/`stderr.write`/`writeln`, `http.get`/`post`), `IO_MEMBER_READS` (`Platform.environment` → ENV), `File` handle constructor + read/write method table.
- **Dart leaf path** (all gated on `language == DART`, so the other 12 languages are untouched): body resolution via `dart_body_node`; call detection (a `selector` holding an `argument_part`) → `dart_call_name` + arg extraction from the `argument_part`; multi-`value` binding extraction (`var k = <chain>` / `s = <chain>`) with RHS evaluation (member source / `File` handle ctor / read-source call / project-callee return / alias); `Platform.environment['K']` member source with the key read from the `index_selector`; quote-stripped inline string identities.
- **`dart_positional_parameter_slots`** (utils) for cross-function parameter→sink composition.
- Dart switch-arm node types added to the `_SWITCH_ARM_TYPES`/fallthrough/default sets (if/for/while/do/try/switch share their strings and work for free).

## Tests

`test_flow_dart_edges.py`: 7 cases — `Platform.environment` → print, → `File` handle write, `stdout.write` sink, tainted arg into callee, return-taint fixpoint, if/else branch merge, untainted `== set()`. Full flow + io regression green across all languages (the `_apply_js_leaf` Dart guard and `_FLAT_*` additions verified non-disturbing); `test_flow_verdict` updated (Dart now covered, Scala remains the uncovered example); ruff + ty clean.

## Deferred (fast-follow)

Inline handle chains `File(p).writeAsString(d)` (the `()`-hop callee name), `File` **read** sources (needs handle-read→taint, which no language models yet), string **interpolation** identities, **cascades** (`f..writeAsString(a)`), `async`/`await` unwrapping, and broader `HttpClient` network surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Dart support for data-flow analysis across assignments, calls, returns, branches, parameters, and selectors.
  * Added Dart I/O modeling for environment reads, console and HTTP output, standard streams, and file operations.
  * Added recognition of Dart switch cases, string literals, indexing, templates, and related syntax.

* **Documentation**
  * Updated coverage documentation to include Dart, increasing supported flow-covered languages from 12 to 13.

* **Tests**
  * Added coverage for Dart data-flow scenarios, parameter handling, sinks, branches, and untainted values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->