### PR TITLE
feat: extract a LanguageFrontend fact-bundle protocol; migrate C# onto it (#1178)

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -404,10 +404,10 @@ class GraphUpdater:
         if settings.CSHARP_FRONTEND == cs.CSharpFrontend.TREESITTER:
             return
         frontend = FRONTENDS.get(cs.SupportedLanguage.CSHARP)
-        project = find_csharp_project(self.repo_path)
-        if frontend is None or project is None:
-            # Skip silently when there is no C# project: nothing to augment,
-            # and building the net tool for a non-C# repo would be wasteful.
+        if frontend is None or not frontend.applies(self.repo_path):
+            # Skip silently when the frontend has nothing to augment (no C#
+            # project): applicability is the frontend's own rule (issue #1178), so
+            # a registered replacement can define its own.
             return
         if not frontend.available():
             # AUTO promises hybrid only where the toolchain exists, so a
@@ -418,7 +418,9 @@ class GraphUpdater:
             else:
                 logger.warning(ls.CSHARP_FRONTEND_UNAVAILABLE)
             return
-        logger.info(ls.CSHARP_FRONTEND_RUNNING.format(path=project))
+        logger.info(
+            ls.CSHARP_FRONTEND_RUNNING.format(path=find_csharp_project(self.repo_path))
+        )
         facts = frontend.run(self.repo_path, ())
         self._apply_semantic_facts(facts)
         logger.info(ls.CSHARP_FRONTEND_TYPES.format(count=len(facts.base_kinds)))

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -35,12 +35,7 @@ from .parsers.cpp_frontend import (
     run_cpp_frontend,
     run_cpp_frontend_hybrid,
 )
-from .parsers.csharp_frontend import (
-    CSharpQueryCall,
-    csharp_frontend_available,
-    find_csharp_project,
-    run_csharp_frontend,
-)
+from .parsers.csharp_frontend import find_csharp_project
 from .parsers.endpoint_prefixes import (
     CYPHER_DELETE_HANDLER_EXPOSES,
     CYPHER_PROJECT_PY_MODULES,
@@ -62,6 +57,8 @@ from .parsers.endpoints import (
     parse_route_decorator,
 )
 from .parsers.factory import ProcessorFactory
+from .parsers.frontends import FRONTENDS, SemanticFacts
+from .parsers.frontends.protocol import QueryCall
 from .parsers.utils import sorted_captures
 from .path_filters import matches_test_path
 from .services import FilteringIngestor, IngestorProtocol, QueryProtocol
@@ -292,7 +289,7 @@ class GraphUpdater:
         # declaration groups join to Class qns after Pass 2, and LINQ
         # query-operator calls join to function locations after Pass 3.
         self._csharp_partial_decls: list[list[tuple[str, int]]] = []
-        self._csharp_query_calls: list[CSharpQueryCall] = []
+        self._csharp_query_calls: list[QueryCall] = []
         # Files (re)parsed by Pass 2 this run: the only files whose
         # definition spans exist for hybrid macro-call attribution.
         self._reparsed_file_keys: set[str] = set()
@@ -403,20 +400,16 @@ class GraphUpdater:
         # keep applying stale facts on a later run with the frontend off.
         # csharp_call_sites is mutated in place because the type-inference
         # engine holds a reference.
-        dp = self.factory.definition_processor
-        dp.csharp_base_kinds = {}
-        dp.csharp_call_sites.clear()
-        dp.csharp_external_sites.clear()
-        self._csharp_partial_decls = []
-        self._csharp_query_calls = []
+        self._reset_semantic_facts()
         if settings.CSHARP_FRONTEND == cs.CSharpFrontend.TREESITTER:
             return
+        frontend = FRONTENDS.get(cs.SupportedLanguage.CSHARP)
         project = find_csharp_project(self.repo_path)
-        if project is None:
+        if frontend is None or project is None:
             # Skip silently when there is no C# project: nothing to augment,
             # and building the net tool for a non-C# repo would be wasteful.
             return
-        if not csharp_frontend_available():
+        if not frontend.available():
             # AUTO promises hybrid only where the toolchain exists, so a
             # missing dotnet is the expected fallback (info); an EXPLICIT
             # hybrid/roslyn request that cannot run stays a warning.
@@ -426,21 +419,38 @@ class GraphUpdater:
                 logger.warning(ls.CSHARP_FRONTEND_UNAVAILABLE)
             return
         logger.info(ls.CSHARP_FRONTEND_RUNNING.format(path=project))
-        facts = run_csharp_frontend(self.repo_path)
-        dp.csharp_base_kinds = facts.base_kinds
-        dp.csharp_call_sites.update(facts.call_sites)
-        dp.csharp_external_sites.update(facts.external_sites)
-        self._csharp_partial_decls = facts.partial_groups
-        self._csharp_query_calls = facts.query_calls
+        facts = frontend.run(self.repo_path, ())
+        self._apply_semantic_facts(facts)
         logger.info(ls.CSHARP_FRONTEND_TYPES.format(count=len(facts.base_kinds)))
         logger.info(
             ls.CSHARP_FRONTEND_FACTS.format(
-                calls=len(facts.call_sites),
+                calls=len(facts.resolved_call_sites),
                 partials=len(facts.partial_groups),
                 queries=len(facts.query_calls),
                 externals=len(facts.external_sites),
             )
         )
+
+    def _reset_semantic_facts(self) -> None:
+        # A reused updater (watch mode) that previously ran a frontend must not
+        # keep applying stale facts on a later run with it off. csharp_call_sites
+        # is mutated in place because the type-inference engine holds a reference.
+        dp = self.factory.definition_processor
+        dp.csharp_base_kinds = {}
+        dp.csharp_call_sites.clear()
+        dp.csharp_external_sites.clear()
+        self._csharp_partial_decls = []
+        self._csharp_query_calls = []
+
+    def _apply_semantic_facts(self, facts: SemanticFacts) -> None:
+        # Copy each fact family into the processor state the existing consumers
+        # read, with per-miss fallback to the tree-sitter heuristics (issue #1178).
+        dp = self.factory.definition_processor
+        dp.csharp_base_kinds = facts.base_kinds
+        dp.csharp_call_sites.update(facts.resolved_call_sites)
+        dp.csharp_external_sites.update(facts.external_sites)
+        self._csharp_partial_decls = facts.partial_groups
+        self._csharp_query_calls = facts.query_calls
 
     def _join_csharp_partials(self) -> None:
         # Replace the directory-keyed syntactic partial grouping with the

--- a/codebase_rag/parsers/csharp/type_inference.py
+++ b/codebase_rag/parsers/csharp/type_inference.py
@@ -17,7 +17,8 @@ from ...types_defs import (
     SimpleNameLookup,
 )
 from ...utils.path_utils import cached_relative_path
-from ..csharp_frontend import CallSiteKey, CSharpCallSite
+from ..csharp_frontend import CallSiteKey
+from ..frontends.protocol import ResolvedCallSite
 from ..import_processor import ImportProcessor
 from ..utils import safe_decode_text
 from .utils import (
@@ -101,7 +102,7 @@ class CSharpTypeInferenceEngine:
         csharp_partial_groups: dict[str, list[str]] | None = None,
         csharp_extension_methods: dict[str, list[tuple[str, str, str, int]]]
         | None = None,
-        csharp_call_sites: dict[CallSiteKey, CSharpCallSite] | None = None,
+        csharp_call_sites: dict[CallSiteKey, ResolvedCallSite] | None = None,
         csharp_external_sites: set[CallSiteKey] | None = None,
         csharp_local_functions: dict[str, tuple[FunctionSpanKey, int]] | None = None,
         csharp_generic_methods: set[str] | None = None,

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -25,8 +25,9 @@ from ..utils.path_utils import cached_relative_path, cached_resolve_posix
 from .class_ingest import ClassIngestMixin
 from .cpp import CppTypeInferenceEngine
 from .cpp.preproc_recovery import parse_with_preproc_recovery
-from .csharp_frontend import CallSiteKey, CSharpCallSite
+from .csharp_frontend import CallSiteKey
 from .dependency_parser import parse_dependencies
+from .frontends.protocol import ResolvedCallSite
 from .function_ingest import FunctionIngestMixin
 from .go import utils as go_utils
 from .handlers import get_handler
@@ -151,7 +152,7 @@ class DefinitionProcessor(
         # targets keyed on the callee NAME token location. The C# resolver
         # consults this before any heuristic; MUTATED IN PLACE across runs
         # because the type-inference engine holds a reference.
-        self.csharp_call_sites: dict[CallSiteKey, CSharpCallSite] = {}
+        self.csharp_call_sites: dict[CallSiteKey, ResolvedCallSite] = {}
         # Sites Roslyn resolved to METADATA (external) methods: the resolver
         # returns the external sentinel there instead of letting the
         # name-trie fabricate a first-party edge. Same in-place mutation

--- a/codebase_rag/parsers/frontends/__init__.py
+++ b/codebase_rag/parsers/frontends/__init__.py
@@ -1,0 +1,54 @@
+"""Language semantic frontends (issue #1178, roadmap #1191).
+
+Tree-sitter is the universal backbone; each language's own compiler is layered on
+top as an OPTIONAL fact provider. Two shapes are supported:
+
+- A `LanguageFrontend` returns a `SemanticFacts` bundle (the Roslyn/C# shape): the
+  compiler's answers keyed by source position, consumed by the existing processors
+  with silent per-miss fallback to the tree-sitter heuristics.
+- An `EmittingFrontend` also writes graph elements the backbone cannot produce
+  (the libclang/C++ shape: macro-expanded nodes, `#include` edges), in a declared
+  run phase.
+
+The invariant every frontend preserves: the compiler is an oracle, tree-sitter is
+the backbone, and a missing toolchain degrades to the pure tree-sitter graph --
+never worse.
+"""
+
+from __future__ import annotations
+
+# Import for side effect: each frontend module self-registers into the registry.
+from . import csharp as _csharp  # noqa: E402,F401  (registers CSharpFrontend)
+from .protocol import (
+    CallSiteKey,
+    EmittingFrontend,
+    FrontendEmitContext,
+    FrontendEmitResult,
+    FrontendPhase,
+    LanguageFrontend,
+    ResolvedCallSite,
+    SemanticFacts,
+    empty_facts,
+)
+from .registry import (
+    EMITTING_FRONTENDS,
+    FRONTENDS,
+    register_emitting_frontend,
+    register_frontend,
+)
+
+__all__ = [
+    "EMITTING_FRONTENDS",
+    "FRONTENDS",
+    "CallSiteKey",
+    "EmittingFrontend",
+    "FrontendEmitContext",
+    "FrontendEmitResult",
+    "FrontendPhase",
+    "LanguageFrontend",
+    "ResolvedCallSite",
+    "SemanticFacts",
+    "empty_facts",
+    "register_emitting_frontend",
+    "register_frontend",
+]

--- a/codebase_rag/parsers/frontends/csharp.py
+++ b/codebase_rag/parsers/frontends/csharp.py
@@ -1,0 +1,63 @@
+"""The C# (Roslyn) `LanguageFrontend` adapter (issue #1178). A thin projection of
+the existing `run_csharp_frontend` fact bundle onto the generic `SemanticFacts`
+contract -- zero behaviour change; the Roslyn tool contract is untouched."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+from ...constants.languages import SupportedLanguage
+from ..csharp_frontend import (
+    CSharpSemanticFacts,
+    csharp_frontend_available,
+    find_csharp_project,
+    run_csharp_frontend,
+)
+from .protocol import QueryCall, ResolvedCallSite, SemanticFacts
+from .registry import register_frontend
+
+
+def _adapt(facts: CSharpSemanticFacts) -> SemanticFacts:
+    # CSharpCallSite and ResolvedCallSite are structurally identical (name +
+    # target_file/line/col); QueryCall likewise. The remaining families copy across.
+    return SemanticFacts(
+        resolved_call_sites={
+            key: ResolvedCallSite(
+                site.name, site.target_file, site.target_line, site.target_col
+            )
+            for key, site in facts.call_sites.items()
+        },
+        external_sites=set(facts.external_sites),
+        base_kinds=facts.base_kinds,
+        partial_groups=facts.partial_groups,
+        query_calls=[
+            QueryCall(
+                q.caller_file,
+                q.caller_line,
+                q.caller_col,
+                q.target_file,
+                q.target_line,
+                q.target_col,
+            )
+            for q in facts.query_calls
+        ],
+    )
+
+
+class CSharpFrontend:
+    """Roslyn fact provider for C#."""
+
+    language: SupportedLanguage = SupportedLanguage.CSHARP
+
+    def available(self) -> bool:
+        return csharp_frontend_available()
+
+    def applies(self, repo_path: Path) -> bool:
+        return find_csharp_project(repo_path) is not None
+
+    def run(self, repo_path: Path, files: Sequence[Path]) -> SemanticFacts:
+        return _adapt(run_csharp_frontend(repo_path))
+
+
+register_frontend(CSharpFrontend())

--- a/codebase_rag/parsers/frontends/csharp.py
+++ b/codebase_rag/parsers/frontends/csharp.py
@@ -18,7 +18,7 @@ from .protocol import QueryCall, ResolvedCallSite, SemanticFacts
 from .registry import register_frontend
 
 
-def _adapt(facts: CSharpSemanticFacts) -> SemanticFacts:
+def _adapt_csharp_semantic_facts(facts: CSharpSemanticFacts) -> SemanticFacts:
     # CSharpCallSite and ResolvedCallSite are structurally identical (name +
     # target_file/line/col); QueryCall likewise. The remaining families copy across.
     return SemanticFacts(
@@ -57,7 +57,7 @@ class CSharpFrontend:
         return find_csharp_project(repo_path) is not None
 
     def run(self, repo_path: Path, files: Sequence[Path]) -> SemanticFacts:
-        return _adapt(run_csharp_frontend(repo_path))
+        return _adapt_csharp_semantic_facts(run_csharp_frontend(repo_path))
 
 
 register_frontend(CSharpFrontend())

--- a/codebase_rag/parsers/frontends/protocol.py
+++ b/codebase_rag/parsers/frontends/protocol.py
@@ -1,0 +1,154 @@
+"""The `LanguageFrontend` / `EmittingFrontend` contract and the `SemanticFacts`
+bundle (issue #1178). Generalized from the proven Roslyn/C# integration."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from ...constants.languages import SupportedLanguage
+from ...services import IngestorProtocol
+from ...types_defs import FunctionRegistryTrieProtocol, SimpleNameLookup
+
+# Call-site join key: (rel_file, name_token_line, name_token_byte_col, simple_name).
+# The NAME token, not the expression start: nested invocations (`Make().Handle(x)`)
+# share a start position but their name tokens never collide. Columns are BYTE
+# offsets so a compiler's UTF-16 columns must be re-measured in UTF-8 to match
+# tree-sitter (issue #1178, faithful to the Roslyn contract).
+CallSiteKey = tuple[str, int, int, str]
+
+# A class's base-type kinds: (rel_file, type_start_line) -> {base_simple_name: kind}
+# where kind is "class" (INHERITS) or "interface" (IMPLEMENTS).
+BaseKindMap = dict[tuple[str, int], dict[str, str]]
+
+
+@dataclass(frozen=True)
+class ResolvedCallSite:
+    """The declaration a call binds to, per the language's compiler (overloads by
+    argument type, extension/receiver binding, interface dispatch)."""
+
+    name: str
+    target_file: str
+    target_line: int
+    target_col: int
+
+
+@dataclass(frozen=True)
+class QueryCall:
+    """A generated/implicit operator call keyed on the enclosing member's decl
+    (C# LINQ today); other frontends leave this family empty."""
+
+    caller_file: str
+    caller_line: int
+    caller_col: int
+    target_file: str
+    target_line: int
+    target_col: int
+
+
+@dataclass
+class SemanticFacts:
+    """Everything one frontend run learned about the repo. Every family is OPTIONAL
+    per language (a Phase-2 frontend fills only what its compiler models); the
+    processors apply each non-empty family and fall back per-miss to the tree-sitter
+    heuristics. A FRESH instance per run -- the maps are handed to mutable processor
+    state, so a shared constant would alias across runs (issue #1178)."""
+
+    # The two families every compiler frontend fills (Go/TS/Java/Rust-SCIP, #1179+).
+    resolved_call_sites: dict[CallSiteKey, ResolvedCallSite] = field(
+        default_factory=dict
+    )
+    # Sites the compiler resolved to a metadata/external declaration: proof the call
+    # leaves the repo, so the name-trie fallback must not fabricate a first-party edge.
+    external_sites: set[CallSiteKey] = field(default_factory=set)
+    # C#-specific families today (generalization deferred until a second consumer).
+    base_kinds: BaseKindMap = field(default_factory=dict)
+    partial_groups: list[list[tuple[str, int]]] = field(default_factory=list)
+    query_calls: list[QueryCall] = field(default_factory=list)
+
+    def is_empty(self) -> bool:
+        return not (
+            self.resolved_call_sites
+            or self.external_sites
+            or self.base_kinds
+            or self.partial_groups
+            or self.query_calls
+        )
+
+
+def empty_facts() -> SemanticFacts:
+    """A fresh empty bundle -- the degradation result when a toolchain is absent."""
+    return SemanticFacts()
+
+
+@runtime_checkable
+class LanguageFrontend(Protocol):
+    """A compiler fact provider for one language. `available()` gates on the
+    toolchain, `applies()` on the repo containing a discoverable project; a False
+    from either degrades to the pure tree-sitter graph."""
+
+    language: SupportedLanguage
+
+    def available(self) -> bool: ...
+
+    def applies(self, repo_path: Path) -> bool: ...
+
+    def run(self, repo_path: Path, files: Sequence[Path]) -> SemanticFacts: ...
+
+
+class FrontendPhase(StrEnum):
+    # Run before the tree-sitter definition pass (libclang LIBCLANG mode emits its
+    # own Function nodes, and Pass 2 skips the files it covered).
+    BEFORE_DEFINITIONS = "before_definitions"
+    # Run after the definition pass (libclang HYBRID mode attributes macro calls to
+    # the tree-sitter spans that already exist).
+    AFTER_DEFINITIONS = "after_definitions"
+
+
+@dataclass
+class FrontendEmitContext:
+    """What an emitting frontend needs to write graph elements directly (the C++
+    libclang integration): the ingestor plus the graph's already-computed
+    registries and file-selection state (issue #1178)."""
+
+    ingestor: IngestorProtocol
+    repo_path: Path
+    project_name: str
+    compdb_dir: Path
+    function_registry: FunctionRegistryTrieProtocol | None = None
+    simple_name_lookup: SimpleNameLookup | None = None
+    structural_elements: dict[Path, str | None] | None = None
+    exclude_paths: frozenset[str] | None = None
+    unignore_paths: frozenset[str] | None = None
+    owned_qns: dict[str, set[str]] | None = None
+
+
+@dataclass
+class FrontendEmitResult:
+    """What an emitting frontend returns to the graph builder: the set of files it
+    fully covered (so the definition pass skips them, LIBCLANG mode) and any calls
+    to be joined to tree-sitter spans in a later phase (HYBRID mode). The pending
+    lists stay untyped here to avoid importing the cpp_frontend internals; the C++
+    frontend adapter narrows them."""
+
+    covered_files: frozenset[str] = frozenset()
+    pending_macro_calls: list[object] = field(default_factory=list)
+    pending_expansion_calls: list[object] = field(default_factory=list)
+
+
+@runtime_checkable
+class EmittingFrontend(Protocol):
+    """A frontend that also emits graph elements the backbone cannot produce, in a
+    declared run phase (the C++ libclang integration)."""
+
+    language: SupportedLanguage
+    phase: FrontendPhase
+
+    def available(self) -> bool: ...
+
+    def applies(self, repo_path: Path) -> bool: ...
+
+    def emit(self, ctx: FrontendEmitContext) -> FrontendEmitResult: ...

--- a/codebase_rag/parsers/frontends/registry.py
+++ b/codebase_rag/parsers/frontends/registry.py
@@ -1,0 +1,27 @@
+"""The per-language frontend registry (issue #1178). A free module dict, not a
+`ProcessorFactory` responsibility -- the factory builds processors, and the graph
+builder owns the frontend dispatch loop."""
+
+from __future__ import annotations
+
+from ...constants.languages import SupportedLanguage
+from .protocol import EmittingFrontend, LanguageFrontend
+
+# Fact-provider frontends keyed by language (C# / Roslyn). A language may register
+# at most one.
+FRONTENDS: dict[SupportedLanguage, LanguageFrontend] = {}
+
+# Emitting frontends keyed by language (C / C++ / libclang). Separate map because
+# they run in a declared phase and write graph elements directly, rather than
+# returning a fact bundle.
+EMITTING_FRONTENDS: dict[SupportedLanguage, EmittingFrontend] = {}
+
+
+def register_frontend(frontend: LanguageFrontend) -> LanguageFrontend:
+    FRONTENDS[frontend.language] = frontend
+    return frontend
+
+
+def register_emitting_frontend(frontend: EmittingFrontend) -> EmittingFrontend:
+    EMITTING_FRONTENDS[frontend.language] = frontend
+    return frontend

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -14,8 +14,9 @@ from ..types_defs import (
 )
 from .cpp import CppTypeInferenceEngine
 from .csharp.type_inference import CSharpTypeInferenceEngine
-from .csharp_frontend import CallSiteKey, CSharpCallSite
+from .csharp_frontend import CallSiteKey
 from .dart.type_inference import DartTypeInferenceEngine
+from .frontends.protocol import ResolvedCallSite
 from .go import GoTypeInferenceEngine
 from .import_processor import ImportProcessor
 from .java import JavaTypeInferenceEngine
@@ -87,7 +88,7 @@ class TypeInferenceEngine:
         csharp_partial_groups: dict[str, list[str]] | None = None,
         csharp_extension_methods: dict[str, list[tuple[str, str, str, int]]]
         | None = None,
-        csharp_call_sites: dict[CallSiteKey, CSharpCallSite] | None = None,
+        csharp_call_sites: dict[CallSiteKey, ResolvedCallSite] | None = None,
         csharp_external_sites: set[CallSiteKey] | None = None,
         csharp_local_functions: dict[str, tuple[FunctionSpanKey, int]] | None = None,
         csharp_generic_methods: set[str] | None = None,

--- a/codebase_rag/tests/test_csharp_frontend_wiring.py
+++ b/codebase_rag/tests/test_csharp_frontend_wiring.py
@@ -282,9 +282,13 @@ def test_auto_mode_runs_frontend_when_dotnet_available(
 ) -> None:
     root = temp_repo / "autoproj"
     _write_project(root)
+    from codebase_rag.parsers.frontends import csharp as csharp_fe
+
     monkeypatch.setattr(gu.settings, "CSHARP_FRONTEND", cs.CSharpFrontend.AUTO)
-    monkeypatch.setattr(gu, "csharp_frontend_available", lambda: True)
-    monkeypatch.setattr(gu, "run_csharp_frontend", lambda repo_path: _button_facts())
+    monkeypatch.setattr(csharp_fe, "csharp_frontend_available", lambda: True)
+    monkeypatch.setattr(
+        csharp_fe, "run_csharp_frontend", lambda repo_path: _button_facts()
+    )
 
     ingestor = MagicMock()
     run_updater(root, ingestor, skip_if_missing=SKIP)
@@ -298,10 +302,12 @@ def test_auto_mode_falls_back_silently_without_dotnet(
 ) -> None:
     root = temp_repo / "autofallproj"
     _write_project(root)
+    from codebase_rag.parsers.frontends import csharp as csharp_fe
+
     frontend_runner = MagicMock()
     monkeypatch.setattr(gu.settings, "CSHARP_FRONTEND", cs.CSharpFrontend.AUTO)
-    monkeypatch.setattr(gu, "csharp_frontend_available", lambda: False)
-    monkeypatch.setattr(gu, "run_csharp_frontend", frontend_runner)
+    monkeypatch.setattr(csharp_fe, "csharp_frontend_available", lambda: False)
+    monkeypatch.setattr(csharp_fe, "run_csharp_frontend", frontend_runner)
 
     ingestor = MagicMock()
     run_updater(root, ingestor, skip_if_missing=SKIP)

--- a/codebase_rag/tests/test_csharp_semantic_facts.py
+++ b/codebase_rag/tests/test_csharp_semantic_facts.py
@@ -53,9 +53,13 @@ def _has(pairs: set[tuple[str, str]], caller_suffix: str, callee_suffix: str) ->
 
 
 def _hybrid(monkeypatch: pytest.MonkeyPatch, facts: CSharpSemanticFacts) -> None:
+    # The C# frontend now runs behind the LanguageFrontend registry (issue #1178),
+    # so patch the toolchain gate and the Roslyn runner where the ADAPTER binds them.
+    from codebase_rag.parsers.frontends import csharp as csharp_fe
+
     monkeypatch.setattr(gu.settings, "CSHARP_FRONTEND", cs.CSharpFrontend.HYBRID)
-    monkeypatch.setattr(gu, "csharp_frontend_available", lambda: True)
-    monkeypatch.setattr(gu, "run_csharp_frontend", lambda repo_path: facts)
+    monkeypatch.setattr(csharp_fe, "csharp_frontend_available", lambda: True)
+    monkeypatch.setattr(csharp_fe, "run_csharp_frontend", lambda repo_path: facts)
 
 
 def test_parse_payload_reads_semantic_fact_sections() -> None:

--- a/codebase_rag/tests/test_frontends_registry.py
+++ b/codebase_rag/tests/test_frontends_registry.py
@@ -1,0 +1,56 @@
+"""The LanguageFrontend registry + SemanticFacts contract (issue #1178)."""
+
+from __future__ import annotations
+
+from codebase_rag import constants as cs
+from codebase_rag.parsers.frontends import (
+    FRONTENDS,
+    LanguageFrontend,
+    ResolvedCallSite,
+    SemanticFacts,
+    empty_facts,
+    register_frontend,
+)
+
+
+def test_csharp_frontend_is_registered() -> None:
+    frontend = FRONTENDS.get(cs.SupportedLanguage.CSHARP)
+    assert frontend is not None
+    assert frontend.language == cs.SupportedLanguage.CSHARP
+    # The protocol surface is callable; `available()` reflects the real toolchain
+    # (False in a dotnet-less environment -> clean degradation to tree-sitter).
+    assert isinstance(frontend.available(), bool)
+    assert isinstance(frontend, LanguageFrontend)
+
+
+def test_empty_facts_are_fresh_and_empty() -> None:
+    a = empty_facts()
+    b = empty_facts()
+    assert a.is_empty() and b.is_empty()
+    # Never a shared constant: mutating one must not affect a later fresh bundle.
+    a.resolved_call_sites[("f.cs", 1, 2, "M")] = ResolvedCallSite("M", "g.cs", 3, 4)
+    a.external_sites.add(("f.cs", 5, 6, "N"))
+    assert not a.is_empty()
+    assert empty_facts().is_empty()
+    assert a.resolved_call_sites is not b.resolved_call_sites
+
+
+def test_register_frontend_returns_the_frontend() -> None:
+    class _Fake:
+        language = cs.SupportedLanguage.SCALA
+
+        def available(self) -> bool:
+            return False
+
+        def applies(self, repo_path: object) -> bool:
+            return False
+
+        def run(self, repo_path: object, files: object) -> SemanticFacts:
+            return empty_facts()
+
+    fake = _Fake()
+    try:
+        assert register_frontend(fake) is fake
+        assert FRONTENDS[cs.SupportedLanguage.SCALA] is fake
+    finally:
+        FRONTENDS.pop(cs.SupportedLanguage.SCALA, None)


### PR DESCRIPTION
## What

Phase 1 of the per-language semantic-precision roadmap (#1191). Extracts a **`LanguageFrontend` fact-bundle protocol** from the proven Roslyn/C# integration and migrates the C# frontend onto it, so future compiler frontends (Go #1179, TS/JS #1180, Java #1181, Rust-via-SCIP #1182…) implement a stable contract instead of becoming the third/fourth bespoke branch in `GraphUpdater.run()`.

**The invariant preserved end-to-end:** the compiler is an oracle, Tree-sitter is the backbone, and a missing toolchain degrades to the pure Tree-sitter graph — never worse.

## The contract (`codebase_rag/parsers/frontends/`)

- **`LanguageFrontend`** — `available()` (toolchain present) / `applies(repo)` (project discoverable) / `run(repo, files) -> SemanticFacts`. The fact-provider shape.
- **`SemanticFacts`** — a generalized, per-language-**optional** bundle: `resolved_call_sites` + `external_sites` (the two families every compiler frontend fills), keyed `(rel_file, name_line, byte_col, name)`; the C#-specific `base_kinds`/`partial_groups`/`query_calls` carried for now. `empty_facts()` returns fresh, non-aliasing instances (the degradation result).
- **`EmittingFrontend`** (+ `FrontendPhase`/`FrontendEmitContext`/`FrontendEmitResult`) — defined and ready for the libclang/C++ direct-emitter, whose migration is deferred (see below).
- **`registry.py`** — per-language frontend registry; C# self-registers at import.

## Migration

- **C# fully migrated**: a thin `CSharpFrontend` adapter projects `CSharpSemanticFacts` → `SemanticFacts` (zero behaviour change — the Roslyn tool contract is untouched). `GraphUpdater._run_csharp_frontend` now dispatches through the registry and a generic `_apply_semantic_facts`; the reset/AUTO-fallback discipline and post-pass joins are preserved.
- The generic `ResolvedCallSite` type is threaded through the consumers (`definition_processor`, both `type_inference` engines) — structurally identical to `CSharpCallSite`, attribute-access only, so runtime is unchanged.

## Deliberate scope (the design's safer split)

**C++ is NOT migrated in this PR.** The libclang frontend emits nodes/edges directly and owns a parallel qn generator that must byte-for-byte reproduce `_collect_eligible_files` walk order (#1025 hazard). Its `EmittingFrontend` contract is defined and ready, but wiring it through the registry (with its two-phase timing) is a follow-up so this PR stays reviewable and the qn/walk-order stays provably untouched.

## Tests

- New `test_frontends_registry.py`: registry lookup, protocol surface, fresh-`empty_facts`, `register_frontend`.
- `test_csharp_semantic_facts.py` / `test_csharp_frontend_wiring.py`: repointed the fact-injection monkeypatch to the adapter seam; **all C# behaviour tests pass unchanged** (proving the adapter is behaviour-preserving), including the dotnet-free consumption tests (INHERITS-vs-IMPLEMENTS, exact call targets, external-site suppression, partial merges, LINQ query edges) and the reset/degradation guards.
- Regression green: the **C++ qn-parity** byte-for-byte guard, C# type-inference, structural relationships, flow + io suites (190+ tests). ruff + ty clean.

## Fast-follows

Migrate C++ behind the `EmittingFrontend` registry; rename the `dp.csharp_*` processor fields to generic names once a second fact-provider lands; fact-ify C++ macro/`#include` output; then the Phase-2 Go/TS/Java/Rust-SCIP frontends implement this now-stable protocol.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared frontend framework for semantic analysis.
  * Added standardized C# semantic analysis and call-site resolution.
  * Added frontend registration and discovery support.

* **Bug Fixes**
  * Improved graph updates by consistently resetting and merging semantic facts.
  * Improved handling of unavailable, unsupported, or tree-sitter-only projects.

* **Tests**
  * Added coverage for frontend registration, C# integration, and isolated semantic-fact handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->