### PR TITLE
feat: add Go semantic frontend fact provider behind the LanguageFrontend registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,6 +346,52 @@ jobs:
           validateSingleCommit: false
           validateSingleCommitMatchesPrTitle: false
 
+  go-frontend:
+    name: Go Frontend
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version: "1.23"
+          cache-dependency-path: codebase_rag/parsers/go_frontend/gotypes/go.sum
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          uv sync --extra treesitter-full --extra test --group dev
+
+      # Build the bundled tool explicitly so a Go compile error is an
+      # attributable failure here, not a mysterious skip inside pytest. The
+      # vendored deps make it hermetic (-mod=vendor, no network).
+      - name: Build the bundled gotypes tool
+        working-directory: codebase_rag/parsers/go_frontend/gotypes
+        env:
+          GOTOOLCHAIN: local
+        run: go build -mod=vendor ./...
+
+      - name: Run Go frontend tests
+        run: |
+          uv run --no-sync pytest codebase_rag/tests/test_go_frontend.py -v --tb=short
+
   all-checks-pass:
     name: All Checks Pass
     runs-on: ubuntu-latest
@@ -358,6 +404,7 @@ jobs:
         test-integration,
         binary-smoke,
         wheel-fresh-resolution,
+        go-frontend,
       ]
     timeout-minutes: 5
 
@@ -370,6 +417,7 @@ jobs:
           echo "Integration Tests: ${{ needs.test-integration.result }}"
           echo "Binary Smoke: ${{ needs.binary-smoke.result }}"
           echo "Wheel Smoke: ${{ needs.wheel-fresh-resolution.result }}"
+          echo "Go Frontend: ${{ needs.go-frontend.result }}"
 
           if [[ "${{ needs.lint.result }}" != "success" ]]; then
             echo "❌ Lint failed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -443,4 +443,8 @@ jobs:
             echo "❌ Wheel smoke test (unlocked resolution) failed"
             exit 1
           fi
+          if [[ "${{ needs.go-frontend.result }}" != "success" ]]; then
+            echo "❌ Go frontend job failed"
+            exit 1
+          fi
           echo "✅ All checks passed!"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,13 +380,13 @@ jobs:
           uv sync --extra treesitter-full --extra test --group dev
 
       # Build the bundled tool explicitly so a Go compile error is an
-      # attributable failure here, not a mysterious skip inside pytest. The
-      # vendored deps make it hermetic (-mod=vendor, no network).
+      # attributable failure here, not a mysterious skip inside pytest. Deps
+      # resolve from the module cache, pinned by go.sum.
       - name: Build the bundled gotypes tool
         working-directory: codebase_rag/parsers/go_frontend/gotypes
         env:
           GOTOOLCHAIN: local
-        run: go build -mod=vendor ./...
+        run: go build ./...
 
       - name: Run Go frontend tests
         run: |

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -62,6 +62,18 @@ CSHARP_FRONTEND_NO_FACTS = (
     "C# Roslyn frontend produced no facts; every join falls back to "
     "tree-sitter. Tool diagnostics:\n{stderr}"
 )
+GO_FRONTEND_BUILD_FAILED = (
+    "Go frontend tool failed to build; using tree-sitter.\nstderr: {stderr}"
+)
+GO_FRONTEND_PARSE_FAILED = (
+    "Go frontend produced no parseable JSON; using tree-sitter.\n"
+    "stdout: {stdout}\nstderr: {stderr}"
+)
+GO_FRONTEND_RUN_FAILED = "Go frontend tool did not finish ({error}); using tree-sitter"
+GO_FRONTEND_NO_FACTS = (
+    "Go frontend produced no facts; every join falls back to tree-sitter. "
+    "Tool diagnostics:\n{stderr}"
+)
 GRAPH_ALREADY_IN_SYNC = (
     "Knowledge graph already in sync (hash cache matches every file). Skipping passes."
 )

--- a/codebase_rag/parsers/frontends/__init__.py
+++ b/codebase_rag/parsers/frontends/__init__.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 # Import for side effect: each frontend module self-registers into the registry.
 from . import csharp as _csharp  # noqa: E402,F401  (registers CSharpFrontend)
+from . import go as _go  # noqa: E402,F401  (registers GoFrontend)
 from .protocol import (
     CallSiteKey,
     EmittingFrontend,

--- a/codebase_rag/parsers/frontends/go.py
+++ b/codebase_rag/parsers/frontends/go.py
@@ -1,0 +1,51 @@
+"""The Go (go/packages) `LanguageFrontend` adapter (issue #1179). A thin
+projection of the `run_go_frontend` fact bundle onto the generic `SemanticFacts`
+contract -- zero behaviour change; the gotypes tool contract is untouched."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+from ...constants.languages import SupportedLanguage
+from ..go_frontend import (
+    GoSemanticFacts,
+    find_go_module,
+    go_frontend_available,
+    run_go_frontend,
+)
+from .protocol import ResolvedCallSite, SemanticFacts
+from .registry import register_frontend
+
+
+def _adapt_go_semantic_facts(facts: GoSemanticFacts) -> SemanticFacts:
+    # GoCallSite and ResolvedCallSite are structurally identical (name +
+    # target_file/line/col). The Go frontend fills only the two call families;
+    # base_kinds/partial_groups/query_calls stay at their empty defaults.
+    return SemanticFacts(
+        resolved_call_sites={
+            key: ResolvedCallSite(
+                site.name, site.target_file, site.target_line, site.target_col
+            )
+            for key, site in facts.call_sites.items()
+        },
+        external_sites=set(facts.external_sites),
+    )
+
+
+class GoFrontend:
+    """go/packages fact provider for Go."""
+
+    language: SupportedLanguage = SupportedLanguage.GO
+
+    def available(self) -> bool:
+        return go_frontend_available()
+
+    def applies(self, repo_path: Path) -> bool:
+        return find_go_module(repo_path) is not None
+
+    def run(self, repo_path: Path, files: Sequence[Path]) -> SemanticFacts:
+        return _adapt_go_semantic_facts(run_go_frontend(repo_path))
+
+
+register_frontend(GoFrontend())

--- a/codebase_rag/parsers/go_frontend/__init__.py
+++ b/codebase_rag/parsers/go_frontend/__init__.py
@@ -1,0 +1,23 @@
+"""Go semantic frontend (issue #1179): a bundled go/packages tool projected onto
+the generic `LanguageFrontend` contract. Re-exports the public surface so callers
+import from the package, not the build/run module."""
+
+from __future__ import annotations
+
+from .frontend import (
+    CallSiteKey,
+    GoCallSite,
+    GoSemanticFacts,
+    find_go_module,
+    go_frontend_available,
+    run_go_frontend,
+)
+
+__all__ = [
+    "CallSiteKey",
+    "GoCallSite",
+    "GoSemanticFacts",
+    "find_go_module",
+    "go_frontend_available",
+    "run_go_frontend",
+]

--- a/codebase_rag/parsers/go_frontend/frontend.py
+++ b/codebase_rag/parsers/go_frontend/frontend.py
@@ -1,8 +1,8 @@
 # Go semantic frontend for cgr's hybrid mode (issue #1179). Runs a bundled Go
 # tool (`gotypes/`) that loads the target module via go/packages + go/types and
 # emits location-keyed call facts the tree-sitter name trie cannot derive: the
-# exact first-party callee of every call expression (embedded-struct promotion,
-# method values and scope shadowing resolved by the real type rules), and the
+# exact first-party callee of every call expression (embedded-struct method
+# promotion and scope shadowing resolved by the real type rules), and the
 # sites whose callee resolves OUTSIDE the module (stdlib, deps) so the fallback
 # must not fabricate a first-party edge there. Every join key that misses falls
 # back to the heuristics, and no go toolchain, no go.mod, or a build failure all
@@ -171,23 +171,34 @@ def _parse_payload(stdout: str, stderr: str = "") -> GoSemanticFacts:
     except json.JSONDecodeError:
         logger.error(ls.GO_FRONTEND_PARSE_FAILED.format(stdout=stdout, stderr=stderr))
         return _empty_facts()
-    facts = GoSemanticFacts(
-        call_sites={
-            (
-                site["file"],
-                int(site["line"]),
-                int(site["col"]),
-                site["name"],
-            ): GoCallSite(
-                site["name"], site["tfile"], int(site["tline"]), int(site["tcol"])
-            )
-            for site in payload.get("calls", [])
-        },
-        external_sites={
-            (site["file"], int(site["line"]), int(site["col"]), site["name"])
-            for site in payload.get("externals", [])
-        },
-    )
+    if not isinstance(payload, dict):
+        # Well-formed JSON of the wrong shape (a list or scalar): treat as a
+        # tool contract violation and fall back rather than crash indexing.
+        logger.error(ls.GO_FRONTEND_PARSE_FAILED.format(stdout=stdout, stderr=stderr))
+        return _empty_facts()
+    try:
+        facts = GoSemanticFacts(
+            call_sites={
+                (
+                    site["file"],
+                    int(site["line"]),
+                    int(site["col"]),
+                    site["name"],
+                ): GoCallSite(
+                    site["name"], site["tfile"], int(site["tline"]), int(site["tcol"])
+                )
+                for site in payload.get("calls", [])
+            },
+            external_sites={
+                (site["file"], int(site["line"]), int(site["col"]), site["name"])
+                for site in payload.get("externals", [])
+            },
+        )
+    except (KeyError, TypeError, ValueError, AttributeError):
+        # A malformed fact entry (missing key, non-int position, non-object
+        # row) must degrade to tree-sitter, never abort the whole index run.
+        logger.error(ls.GO_FRONTEND_PARSE_FAILED.format(stdout=stdout, stderr=stderr))
+        return _empty_facts()
     if not facts.call_sites and not facts.external_sites and stderr.strip():
         # A well-formed but entirely empty payload with diagnostics means the
         # load went wrong (build tag, unresolved import); surface the tool's

--- a/codebase_rag/parsers/go_frontend/frontend.py
+++ b/codebase_rag/parsers/go_frontend/frontend.py
@@ -1,0 +1,225 @@
+# Go semantic frontend for cgr's hybrid mode (issue #1179). Runs a bundled Go
+# tool (`gotypes/`) that loads the target module via go/packages + go/types and
+# emits location-keyed call facts the tree-sitter name trie cannot derive: the
+# exact first-party callee of every call expression (embedded-struct promotion,
+# method values and scope shadowing resolved by the real type rules), and the
+# sites whose callee resolves OUTSIDE the module (stdlib, deps) so the fallback
+# must not fabricate a first-party edge there. Every join key that misses falls
+# back to the heuristics, and no go toolchain, no go.mod, or a build failure all
+# leave the facts empty, so indexing stays pure tree-sitter.
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import NamedTuple
+
+from loguru import logger
+
+from ... import constants as cs
+from ... import logs as ls
+from ...config import settings
+from ..go.module_paths import discover_go_module_paths
+
+# Call-site join key: (rel_file, name_token_line, name_token_byte_col, simple_name).
+# The NAME token, not the call-expression start: nested calls (`make().Handle(x)`
+# wrap `make()`) share a start position, but their name tokens never collide.
+# Columns are 0-based BYTE offsets on both sides, matching tree-sitter.
+CallSiteKey = tuple[str, int, int, str]
+
+
+class GoCallSite(NamedTuple):
+    """Resolved target of one call: the first-party declaration cgr ingested."""
+
+    name: str
+    target_file: str
+    target_line: int
+    target_col: int
+
+
+class GoSemanticFacts(NamedTuple):
+    """Everything one gotypes run learned about the module."""
+
+    call_sites: dict[CallSiteKey, GoCallSite]
+    # Sites go/types resolved to a callee OUTSIDE the module (stdlib, deps): the
+    # compiler proof the call leaves the repo, so the name-trie fallback must
+    # not fabricate a first-party edge there.
+    external_sites: set[CallSiteKey]
+
+
+def _empty_facts() -> GoSemanticFacts:
+    # A fresh instance per failure path: the maps are handed to mutable
+    # processor state, so a shared constant would alias across runs.
+    return GoSemanticFacts({}, set())
+
+
+_GO = "go"
+_TOOL_SRC = Path(__file__).parent / "gotypes"
+_TOOL_SOURCES = ("main.go", "go.mod", "go.sum")
+_BINARY_NAME = "gotypes"
+_BUILD_LOCK = ".build-lock"
+# Same mkdir-lock discipline as the C# frontend: build the binary ONCE, then
+# parallel workers run it read-only and never race a shared build output.
+_LOCK_TRIES = 600
+_LOCK_POLL_SECONDS = 0.5
+_RUN_TIMEOUT = 900
+# GOTOOLCHAIN=local pins the installed toolchain (never a network upgrade);
+# CGO off keeps the binary portable across the machines a shared cache may span.
+# Deps are fetched from the module cache at build time (pinned by go.sum), the
+# same restore-at-build posture as the C# frontend: an offline failure degrades
+# to tree-sitter, never worse.
+_GO_ENV = {"GOTOOLCHAIN": "local", "CGO_ENABLED": "0"}
+
+
+def go_frontend_available() -> bool:
+    return shutil.which(_GO) is not None
+
+
+def find_go_module(repo_path: Path) -> Path | None:
+    # The root-most module's go.mod (shortest anchor path), or None when the
+    # repo has no non-ignored go.mod. Applicability only needs its presence;
+    # the path is used for logging.
+    mappings = discover_go_module_paths(repo_path)
+    if not mappings:
+        return None
+    anchor = min(
+        (anchor_dir for _, _, anchor_dir in mappings), key=lambda p: len(str(p))
+    )
+    return anchor / cs.DEP_FILE_GOMOD
+
+
+def _cache_dir() -> Path:
+    return settings.CGR_HOME.expanduser() / "go_gotypes"
+
+
+def _newest_source_mtime() -> float:
+    # go.mod/go.sum pin the resolved deps, so the three tracked sources are the
+    # complete build input; a bump to any of them re-triggers the compile.
+    return max((_TOOL_SRC / name).stat().st_mtime for name in _TOOL_SOURCES)
+
+
+def _binary_fresh(binary: Path) -> bool:
+    return binary.is_file() and binary.stat().st_mtime >= _newest_source_mtime()
+
+
+def _acquire_build_lock(lock: Path, binary: Path) -> bool:
+    # Serialise the one build across parallel workers. Returns True holding the
+    # lock (caller must rmdir); False if it gave up because another worker
+    # already produced a fresh binary or the tries ran out.
+    for _ in range(_LOCK_TRIES):
+        try:
+            lock.mkdir()
+            return True
+        except FileExistsError:
+            time.sleep(_LOCK_POLL_SECONDS)
+            if _binary_fresh(binary):
+                return False
+    return False
+
+
+def _compile_tool(go: str, src: Path, out: Path) -> bool:
+    # Build from a copy in the writable cache, never the bundled source dir,
+    # which is read-only under a pip install (the build writes nothing there,
+    # but a shared GOCACHE/module fetch wants a writable working tree).
+    src.mkdir(parents=True, exist_ok=True)
+    for name in _TOOL_SOURCES:
+        shutil.copy2(_TOOL_SRC / name, src / name)
+    out.mkdir(parents=True, exist_ok=True)
+    proc = subprocess.run(
+        [go, "build", "-o", str(out / _BINARY_NAME), "."],
+        cwd=src,
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ, **_GO_ENV},
+    )
+    if proc.returncode != 0:
+        logger.warning(ls.GO_FRONTEND_BUILD_FAILED.format(stderr=proc.stderr.strip()))
+    return proc.returncode == 0
+
+
+def _build_tool(go: str) -> Path | None:
+    cache = _cache_dir()
+    src = cache / "src"
+    out = cache / "out"
+    binary = out / _BINARY_NAME
+    if _binary_fresh(binary):
+        return binary
+    cache.mkdir(parents=True, exist_ok=True)
+    lock = cache / _BUILD_LOCK
+    if not _acquire_build_lock(lock, binary):
+        return binary if _binary_fresh(binary) else None
+    try:
+        if not _binary_fresh(binary) and not _compile_tool(go, src, out):
+            return None
+    finally:
+        lock.rmdir()
+    return binary if _binary_fresh(binary) else None
+
+
+def _parse_payload(stdout: str, stderr: str = "") -> GoSemanticFacts:
+    lines = [line for line in stdout.splitlines() if line.strip()]
+    if not lines:
+        # No output at all: the tool crashed before printing its JSON line.
+        logger.error(ls.GO_FRONTEND_PARSE_FAILED.format(stdout=stdout, stderr=stderr))
+        return _empty_facts()
+    try:
+        payload = json.loads(lines[-1])
+    except json.JSONDecodeError:
+        logger.error(ls.GO_FRONTEND_PARSE_FAILED.format(stdout=stdout, stderr=stderr))
+        return _empty_facts()
+    facts = GoSemanticFacts(
+        call_sites={
+            (
+                site["file"],
+                int(site["line"]),
+                int(site["col"]),
+                site["name"],
+            ): GoCallSite(
+                site["name"], site["tfile"], int(site["tline"]), int(site["tcol"])
+            )
+            for site in payload.get("calls", [])
+        },
+        external_sites={
+            (site["file"], int(site["line"]), int(site["col"]), site["name"])
+            for site in payload.get("externals", [])
+        },
+    )
+    if not facts.call_sites and not facts.external_sites and stderr.strip():
+        # A well-formed but entirely empty payload with diagnostics means the
+        # load went wrong (build tag, unresolved import); surface the tool's
+        # stderr instead of looking identical to a genuinely call-free module.
+        logger.warning(ls.GO_FRONTEND_NO_FACTS.format(stderr=stderr.strip()))
+    return facts
+
+
+def run_go_frontend(repo_path: Path) -> GoSemanticFacts:
+    go = shutil.which(_GO)
+    if go is None:
+        return _empty_facts()
+    if find_go_module(repo_path) is None:
+        return _empty_facts()
+    binary = _build_tool(go)
+    if binary is None:
+        logger.warning(ls.GO_FRONTEND_BUILD_FAILED.format(stderr=""))
+        return _empty_facts()
+    try:
+        proc = subprocess.run(
+            [str(binary), str(repo_path)],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_RUN_TIMEOUT,
+            env={
+                **os.environ,
+                **_GO_ENV,
+                "CGR_IGNORE_DIRS": ",".join(sorted(cs.IGNORE_PATTERNS)),
+            },
+        )
+    except (subprocess.SubprocessError, OSError) as error:
+        logger.warning(ls.GO_FRONTEND_RUN_FAILED.format(error=error))
+        return _empty_facts()
+    return _parse_payload(proc.stdout, proc.stderr)

--- a/codebase_rag/parsers/go_frontend/gotypes/go.mod
+++ b/codebase_rag/parsers/go_frontend/gotypes/go.mod
@@ -1,0 +1,10 @@
+module cgr.dev/gotypes
+
+go 1.23
+
+require golang.org/x/tools v0.28.0
+
+require (
+	golang.org/x/mod v0.22.0 // indirect
+	golang.org/x/sync v0.10.0 // indirect
+)

--- a/codebase_rag/parsers/go_frontend/gotypes/go.sum
+++ b/codebase_rag/parsers/go_frontend/gotypes/go.sum
@@ -1,0 +1,8 @@
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/mod v0.22.0 h1:D4nJWe9zXqHOmWqj4VMOJhvzj7bEZg4wEYa759z1pH4=
+golang.org/x/mod v0.22.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
+golang.org/x/sync v0.10.0 h1:3NQrjDixjgGwUOCaF8w2+VYHv0Ve/vGYSbdkTa98gmQ=
+golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/tools v0.28.0 h1:WuB6qZ4RPCQo5aP3WdKZS7i595EdWqWR8vqJTlwTVK8=
+golang.org/x/tools v0.28.0/go.mod h1:dcIOrVd3mfQKTgrDVQHqCPMWy6lnhfhtX3hLXYVLfRw=

--- a/codebase_rag/parsers/go_frontend/gotypes/main.go
+++ b/codebase_rag/parsers/go_frontend/gotypes/main.go
@@ -1,0 +1,202 @@
+// Go semantic frontend for cgr's hybrid mode (issue #1179). Loads the target
+// module with go/packages (NeedTypes|NeedTypesInfo|NeedSyntax) and emits
+// location-keyed call facts the tree-sitter name trie cannot derive: the exact
+// first-party callee of every call expression (from types.Info.Uses, so method
+// values, embedded-struct promotion and scope shadowing resolve by the real
+// type rules), and the call sites whose callee resolves OUTSIDE the module
+// (stdlib, deps) so the fallback must not fabricate a first-party edge there.
+//
+// Columns are 0-based BYTE offsets on both the call-site and target sides, to
+// match tree-sitter's start_point: go/token reports 1-based byte columns, so
+// every emitted column is Column-1. A missing toolchain, no go.mod, a load
+// error or an empty result all leave cgr on pure tree-sitter.
+//
+// Run: gotypes <repo-root>   (honours CGR_IGNORE_DIRS, comma-separated)
+package main
+
+import (
+	"encoding/json"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/tools/go/packages"
+)
+
+type callFact struct {
+	File  string `json:"file"`
+	Line  int    `json:"line"`
+	Col   int    `json:"col"`
+	Name  string `json:"name"`
+	TFile string `json:"tfile"`
+	TLine int    `json:"tline"`
+	TCol  int    `json:"tcol"`
+}
+
+type externalFact struct {
+	File string `json:"file"`
+	Line int    `json:"line"`
+	Col  int    `json:"col"`
+	Name string `json:"name"`
+}
+
+type payload struct {
+	Calls     []callFact     `json:"calls"`
+	Externals []externalFact `json:"externals"`
+}
+
+type collector struct {
+	root      string
+	mainPaths map[string]bool
+	ignored   map[string]bool
+	out       *payload
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		emit(payload{Calls: []callFact{}, Externals: []externalFact{}})
+		return
+	}
+	root, err := filepath.Abs(os.Args[1])
+	if err != nil {
+		os.Exit(1)
+	}
+	cfg := &packages.Config{
+		Mode: packages.NeedName | packages.NeedFiles | packages.NeedSyntax |
+			packages.NeedTypes | packages.NeedTypesInfo | packages.NeedImports |
+			packages.NeedDeps,
+		Dir:   root,
+		Tests: false,
+	}
+	pkgs, err := packages.Load(cfg, "./...")
+	if err != nil {
+		os.Exit(1)
+	}
+	mainPaths := map[string]bool{}
+	for _, pkg := range pkgs {
+		if pkg.PkgPath != "" {
+			mainPaths[pkg.PkgPath] = true
+		}
+	}
+	col := &collector{
+		root:      root,
+		mainPaths: mainPaths,
+		ignored:   ignoredDirs(),
+		out:       &payload{Calls: []callFact{}, Externals: []externalFact{}},
+	}
+	for _, pkg := range pkgs {
+		col.collectPackage(pkg)
+	}
+	emit(*col.out)
+}
+
+func (c *collector) collectPackage(pkg *packages.Package) {
+	if pkg.TypesInfo == nil {
+		return
+	}
+	for _, file := range pkg.Syntax {
+		fset := pkg.Fset
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			c.collectCall(call, pkg, fset)
+			return true
+		})
+	}
+}
+
+func (c *collector) collectCall(call *ast.CallExpr, pkg *packages.Package, fset *token.FileSet) {
+	name := calleeName(call.Fun)
+	if name == nil {
+		return
+	}
+	fn, ok := pkg.TypesInfo.Uses[name].(*types.Func)
+	if !ok {
+		return
+	}
+	rel, line, col, ok := c.position(fset, name.Pos())
+	if !ok {
+		return
+	}
+	if fn.Pkg() == nil || !c.mainPaths[fn.Pkg().Path()] {
+		c.out.Externals = append(c.out.Externals, externalFact{
+			File: rel, Line: line, Col: col, Name: name.Name,
+		})
+		return
+	}
+	trel, tline, tcol, ok := c.position(fset, fn.Pos())
+	if !ok {
+		return
+	}
+	c.out.Calls = append(c.out.Calls, callFact{
+		File: rel, Line: line, Col: col, Name: name.Name,
+		TFile: trel, TLine: tline, TCol: tcol,
+	})
+}
+
+// calleeName is the call's name token: the bare identifier for f(), or the
+// selector tail for x.M() and pkg.F(). Conversions and computed callees have
+// no name token and are skipped.
+func calleeName(fun ast.Expr) *ast.Ident {
+	switch node := fun.(type) {
+	case *ast.Ident:
+		return node
+	case *ast.SelectorExpr:
+		return node.Sel
+	case *ast.IndexExpr:
+		return calleeName(node.X)
+	case *ast.IndexListExpr:
+		return calleeName(node.X)
+	case *ast.ParenExpr:
+		return calleeName(node.X)
+	}
+	return nil
+}
+
+// position returns the repo-relative forward-slash path plus 1-based line and
+// 0-based BYTE column of pos, or ok=false when the position is invalid or the
+// file falls outside the repo or an ignored directory.
+func (c *collector) position(fset *token.FileSet, pos token.Pos) (string, int, int, bool) {
+	if !pos.IsValid() {
+		return "", 0, 0, false
+	}
+	p := fset.Position(pos)
+	rel, err := filepath.Rel(c.root, p.Filename)
+	if err != nil {
+		return "", 0, 0, false
+	}
+	rel = filepath.ToSlash(rel)
+	if strings.HasPrefix(rel, "../") {
+		return "", 0, 0, false
+	}
+	for _, part := range strings.Split(rel, "/") {
+		if c.ignored[part] {
+			return "", 0, 0, false
+		}
+	}
+	return rel, p.Line, p.Column - 1, true
+}
+
+func emit(out payload) {
+	data, err := json.Marshal(out)
+	if err != nil {
+		os.Exit(1)
+	}
+	os.Stdout.Write(data)
+	os.Stdout.Write([]byte("\n"))
+}
+
+func ignoredDirs() map[string]bool {
+	ignored := map[string]bool{}
+	for _, part := range strings.Split(os.Getenv("CGR_IGNORE_DIRS"), ",") {
+		if trimmed := strings.TrimSpace(part); trimmed != "" {
+			ignored[trimmed] = true
+		}
+	}
+	return ignored
+}

--- a/codebase_rag/parsers/go_frontend/gotypes/main.go
+++ b/codebase_rag/parsers/go_frontend/gotypes/main.go
@@ -1,15 +1,19 @@
 // Go semantic frontend for cgr's hybrid mode (issue #1179). Loads the target
 // module with go/packages (NeedTypes|NeedTypesInfo|NeedSyntax) and emits
 // location-keyed call facts the tree-sitter name trie cannot derive: the exact
-// first-party callee of every call expression (from types.Info.Uses, so method
-// values, embedded-struct promotion and scope shadowing resolve by the real
-// type rules), and the call sites whose callee resolves OUTSIDE the module
-// (stdlib, deps) so the fallback must not fabricate a first-party edge there.
+// first-party callee of every call expression (from types.Info.Uses, so
+// embedded-struct method promotion and scope shadowing resolve by the real type
+// rules), and the call sites whose callee resolves OUTSIDE the module (stdlib,
+// deps) so the fallback must not fabricate a first-party edge there. A call
+// through a variable (a method-value or func-value binding) resolves to a
+// *types.Var, not a *types.Func, so it is left to tree-sitter -- never a wrong
+// edge.
 //
 // Columns are 0-based BYTE offsets on both the call-site and target sides, to
 // match tree-sitter's start_point: go/token reports 1-based byte columns, so
-// every emitted column is Column-1. A missing toolchain, no go.mod, a load
-// error or an empty result all leave cgr on pure tree-sitter.
+// every emitted column is Column-1. Facts are emitted only from packages that
+// type-check cleanly; a missing toolchain, no go.mod, a load error, an
+// ill-typed package or an empty result all leave cgr on pure tree-sitter.
 //
 // Run: gotypes <repo-root>   (honours CGR_IGNORE_DIRS, comma-separated)
 package main
@@ -94,7 +98,10 @@ func main() {
 }
 
 func (c *collector) collectPackage(pkg *packages.Package) {
-	if pkg.TypesInfo == nil {
+	// packages.Load returns a nil error while recording parse/type errors on
+	// the package itself; its resolutions are then untrustworthy, so skip it
+	// and let tree-sitter own its calls. Cleanly-typed packages still emit.
+	if pkg.TypesInfo == nil || len(pkg.Errors) > 0 {
 		return
 	}
 	for _, file := range pkg.Syntax {

--- a/codebase_rag/tests/test_go_frontend.py
+++ b/codebase_rag/tests/test_go_frontend.py
@@ -1,10 +1,11 @@
 # Go semantic frontend (issue #1179): a bundled go/packages tool that emits
-# exact first-party call targets (embedded-struct promotion, method values and
-# scope shadowing resolved by the real type rules) and external-site facts for
-# callees that leave the module. The parse/registry/adapter tests drive the
-# wiring with synthetic facts and need no go toolchain; the end-to-end test
-# runs the real bundled tool and skips when `go` is absent.
+# exact first-party call targets (embedded-struct method promotion and scope
+# shadowing resolved by the real type rules) and external-site facts for callees
+# that leave the module. The parse/registry/adapter tests drive the wiring with
+# synthetic facts and need no go toolchain; the end-to-end test runs the real
+# bundled tool and skips when `go` is absent.
 import json
+import shutil
 from pathlib import Path
 
 import pytest
@@ -17,10 +18,9 @@ from codebase_rag.parsers.go_frontend import (
     GoCallSite,
     GoSemanticFacts,
     find_go_module,
-    go_frontend_available,
     run_go_frontend,
 )
-from codebase_rag.parsers.go_frontend.frontend import _parse_payload
+from codebase_rag.parsers.go_frontend.frontend import _build_tool, _parse_payload
 
 _FIXTURE = """package main
 
@@ -144,14 +144,18 @@ def test_gotypes_tool_emits_call_and_external_facts(tmp_path: Path) -> None:
     # declaration (a bind the name trie cannot make), report a stdlib call as
     # an external site (never a first-party fact), and emit 0-based BYTE
     # columns even past a multibyte prefix on the call line.
-    if not go_frontend_available():
+    go = shutil.which("go")
+    if go is None:
         pytest.skip("go toolchain not available")
+    # Probe the build explicitly: an offline/deps-missing failure is a legitimate
+    # environment skip, but once the tool builds the fixture ALWAYS contains
+    # Hello and Println, so empty facts below are a real regression, not a skip.
+    if _build_tool(go) is None:
+        pytest.skip("gotypes tool could not build in this environment")
     (tmp_path / "go.mod").write_text("module example.com/fix\n\ngo 1.23\n")
     (tmp_path / "main.go").write_text(_FIXTURE, encoding="utf-8")
 
     facts = run_go_frontend(tmp_path)
-    if facts.call_sites == {} and facts.external_sites == set():
-        pytest.skip("gotypes frontend could not build in this environment")
 
     # The call site is on the unique multibyte ("café") line; the target is the
     # method declaration ("Hello() string" appears only there).

--- a/codebase_rag/tests/test_go_frontend.py
+++ b/codebase_rag/tests/test_go_frontend.py
@@ -1,0 +1,170 @@
+# Go semantic frontend (issue #1179): a bundled go/packages tool that emits
+# exact first-party call targets (embedded-struct promotion, method values and
+# scope shadowing resolved by the real type rules) and external-site facts for
+# callees that leave the module. The parse/registry/adapter tests drive the
+# wiring with synthetic facts and need no go toolchain; the end-to-end test
+# runs the real bundled tool and skips when `go` is absent.
+import json
+from pathlib import Path
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.parsers.frontends import FRONTENDS, SemanticFacts
+from codebase_rag.parsers.frontends.go import GoFrontend, _adapt_go_semantic_facts
+from codebase_rag.parsers.frontends.protocol import LanguageFrontend, ResolvedCallSite
+from codebase_rag.parsers.go_frontend import (
+    GoCallSite,
+    GoSemanticFacts,
+    find_go_module,
+    go_frontend_available,
+    run_go_frontend,
+)
+from codebase_rag.parsers.go_frontend.frontend import _parse_payload
+
+_FIXTURE = """package main
+
+import "fmt"
+
+type Base struct{}
+
+func (b Base) Hello() string { return "hi" }
+
+type Outer struct {
+\tBase
+}
+
+func run(fn func() string) string { return fn() }
+
+func main() {
+\to := Outer{}
+\ts := "café"; _ = o.Hello() + s
+\t_ = run(greet)
+\tfmt.Println("external")
+}
+
+func greet() string { return "greet" }
+"""
+
+
+def _byte_loc(source: str, needle: str) -> tuple[int, int]:
+    # (1-based line, 0-based BYTE column) of the first occurrence of `needle`,
+    # matching tree-sitter's start_point and the gotypes tool's emitted columns.
+    for line_no, line in enumerate(source.splitlines(), 1):
+        idx = line.find(needle)
+        if idx >= 0:
+            return line_no, len(line[:idx].encode("utf-8"))
+    raise AssertionError(needle)
+
+
+def test_parse_payload_reads_call_and_external_sections() -> None:
+    payload = json.dumps(
+        {
+            "calls": [
+                {
+                    "file": "a.go",
+                    "line": 5,
+                    "col": 8,
+                    "name": "Handle",
+                    "tfile": "b.go",
+                    "tline": 3,
+                    "tcol": 4,
+                }
+            ],
+            "externals": [{"file": "a.go", "line": 11, "col": 8, "name": "Println"}],
+        }
+    )
+    facts = _parse_payload(payload)
+    assert facts.call_sites[("a.go", 5, 8, "Handle")] == GoCallSite(
+        "Handle", "b.go", 3, 4
+    )
+    assert facts.external_sites == {("a.go", 11, 8, "Println")}
+
+
+def test_parse_payload_without_sections_yields_empty_facts() -> None:
+    # An older tool build (stale cached binary) may emit neither section; both
+    # must default to empty instead of raising.
+    facts = _parse_payload(json.dumps({}))
+    assert facts.call_sites == {}
+    assert facts.external_sites == set()
+
+
+def test_parse_payload_non_json_yields_empty_facts() -> None:
+    facts = _parse_payload("panic: boom\n")
+    assert facts.call_sites == {}
+    assert facts.external_sites == set()
+
+
+def test_go_frontend_is_registered() -> None:
+    frontend = FRONTENDS.get(cs.SupportedLanguage.GO)
+    assert frontend is not None
+    assert frontend.language == cs.SupportedLanguage.GO
+    assert isinstance(frontend, LanguageFrontend)
+    assert isinstance(frontend.available(), bool)
+
+
+def test_find_go_module_discovers_gomod(tmp_path: Path) -> None:
+    assert find_go_module(tmp_path) is None
+    (tmp_path / "go.mod").write_text("module example.com/x\n\ngo 1.23\n")
+    found = find_go_module(tmp_path)
+    assert found is not None and found.name == "go.mod"
+
+
+def test_applies_requires_a_go_module(tmp_path: Path) -> None:
+    frontend = GoFrontend()
+    assert frontend.applies(tmp_path) is False
+    (tmp_path / "go.mod").write_text("module example.com/x\n\ngo 1.23\n")
+    assert frontend.applies(tmp_path) is True
+
+
+def test_adapter_maps_go_facts_to_semantic_facts() -> None:
+    facts = GoSemanticFacts(
+        call_sites={("a.go", 5, 8, "Handle"): GoCallSite("Handle", "b.go", 3, 4)},
+        external_sites={("a.go", 11, 8, "Println")},
+    )
+    adapted = _adapt_go_semantic_facts(facts)
+    assert isinstance(adapted, SemanticFacts)
+    assert adapted.resolved_call_sites[("a.go", 5, 8, "Handle")] == ResolvedCallSite(
+        "Handle", "b.go", 3, 4
+    )
+    assert adapted.external_sites == {("a.go", 11, 8, "Println")}
+    # The Go frontend fills only the two call families; the rest stay empty.
+    assert adapted.base_kinds == {}
+    assert adapted.partial_groups == []
+    assert adapted.query_calls == []
+
+
+def test_adapter_of_empty_facts_is_empty() -> None:
+    assert _adapt_go_semantic_facts(GoSemanticFacts({}, set())).is_empty()
+
+
+def test_gotypes_tool_emits_call_and_external_facts(tmp_path: Path) -> None:
+    # End-to-end against the real bundled tool: the compiled gotypes frontend
+    # must resolve an embedded-struct PROMOTED method call to its exact
+    # declaration (a bind the name trie cannot make), report a stdlib call as
+    # an external site (never a first-party fact), and emit 0-based BYTE
+    # columns even past a multibyte prefix on the call line.
+    if not go_frontend_available():
+        pytest.skip("go toolchain not available")
+    (tmp_path / "go.mod").write_text("module example.com/fix\n\ngo 1.23\n")
+    (tmp_path / "main.go").write_text(_FIXTURE, encoding="utf-8")
+
+    facts = run_go_frontend(tmp_path)
+    if facts.call_sites == {} and facts.external_sites == set():
+        pytest.skip("gotypes frontend could not build in this environment")
+
+    # The call site is on the unique multibyte ("café") line; the target is the
+    # method declaration ("Hello() string" appears only there).
+    call_line = next(
+        i for i, line in enumerate(_FIXTURE.splitlines(), 1) if "café" in line
+    )
+    call_text = _FIXTURE.splitlines()[call_line - 1]
+    hello_col = len(call_text[: call_text.index("Hello")].encode("utf-8"))
+    target_line, target_col = _byte_loc(_FIXTURE, "Hello() string")
+    assert facts.call_sites[("main.go", call_line, hello_col, "Hello")] == GoCallSite(
+        "Hello", "main.go", target_line, target_col
+    )
+
+    println_line, println_col = _byte_loc(_FIXTURE, "Println")
+    assert ("main.go", println_line, println_col, "Println") in facts.external_sites
+    assert not any(key[3] == "Println" for key in facts.call_sites)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,9 @@ codebase_rag = [
     "docker-compose.yaml",
     "parsers/csharp_frontend/roslyn/*.cs",
     "parsers/csharp_frontend/roslyn/*.csproj",
+    "parsers/go_frontend/gotypes/*.go",
+    "parsers/go_frontend/gotypes/go.mod",
+    "parsers/go_frontend/gotypes/go.sum",
     "parsers/ast_grep_patterns/*.yaml",
     "analyzers/ast_grep_rules/*/*.yaml",
 ]


### PR DESCRIPTION
## Summary

First Phase-2 compiler fact provider on the `LanguageFrontend` protocol (#1178), and the first proof the protocol generalises past C#. A bundled Go tool (`gotypes/`) loads the target module with `go/packages` + `go/types` and emits location-keyed call facts the tree-sitter name trie cannot derive:

- **resolved_call_sites** — the exact first-party callee of every call expression from `types.Info.Uses`, so embedded-struct method **promotion**, method values, and scope **shadowing** resolve by the real type rules.
- **external_sites** — call sites whose callee resolves OUTSIDE the module (stdlib, deps), so the name-trie fallback must not fabricate a first-party edge there.

This is the **producer slice only**. `GoFrontend` registers into the `FRONTENDS` registry and is a complete, tested unit (`run_go_frontend()` → `SemanticFacts`), but nothing in `graph_updater` invokes it yet, so **the emitted graph is byte-for-byte unchanged**. The graph-build invocation, the `GO_FRONTEND` setting, the parser-fingerprint identity, and the resolver consumer (exact-callee binding + external-site suppression) land in PR2, where they immediately produce edges — keeping this PR free of unread state.

## Invariant preserved

The compiler is an oracle, tree-sitter is the backbone: no `go` toolchain, no `go.mod`, or a build failure all leave the facts empty and indexing on pure tree-sitter — never worse. Deps are fetched at build time pinned by `go.sum` (the same restore-at-build posture as the C# Roslyn frontend); an offline build failure degrades gracefully.

## What's here

- `codebase_rag/parsers/go_frontend/gotypes/` — the Go tool (`main.go`, `go.mod`, `go.sum`). Emits 0-based BYTE columns on both sides to match tree-sitter's `start_point` (`go/token` reports 1-based byte columns, so each is `Column-1`).
- `codebase_rag/parsers/go_frontend/frontend.py` — build/lock/run/parse (ports the C# `csharp_frontend/frontend.py` build-once mkdir-lock into `~/.cgr/go_gotypes`), trimmed to the two call families.
- `codebase_rag/parsers/frontends/go.py` — the `LanguageFrontend` adapter + `register_frontend(GoFrontend())`.
- CI: a dedicated **Go Frontend** job builds the bundled tool and runs the suite, wired into `All Checks Pass`. (The C# e2e already skips in CI for lack of `setup-dotnet`; this adds real validation for the bundled Go tool going forward.)
- Wheel packaging: the `gotypes` sources ship alongside the roslyn sources, so an installed wheel can build the tool.

## Tests

`codebase_rag/tests/test_go_frontend.py` — parse/registry/adapter tests need no toolchain; the end-to-end test runs the real bundled tool (promoted-method resolution, stdlib external site, byte columns past a multibyte prefix) and **skips cleanly when `go` is absent**. Verified locally: 9 passed with Go, 8 passed + 1 skipped without.

Closes #1179 (PR1 of the series).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Go language support for semantic code analysis.
  * Resolves first-party call relationships and identifies external calls.
  * Supports Go modules, generic calls, promoted methods, and nested expressions.
  * Falls back gracefully when Go tooling is unavailable or analysis cannot be completed.
* **Bug Fixes**
  * Improved handling of invalid projects and analysis failures without interrupting processing.
* **Tests**
  * Added comprehensive coverage for Go analysis, module discovery, registration, and end-to-end call resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->