### PR TITLE
feat: consume Go go/types facts for exact call binding and external-site suppression

### DIFF
--- a/codebase_rag/config.py
+++ b/codebase_rag/config.py
@@ -201,6 +201,11 @@ class AppConfig(BaseSettings):
     # them. HYBRID augments (base-vs-interface, overload and extension binding,
     # partial-class identity); tree-sitter stays the standalone-correct backbone.
     CSHARP_FRONTEND: cs.CSharpFrontend = cs.CSharpFrontend.AUTO
+    # Opt-in go/packages semantic layer for Go (issue #1179). AUTO uses it where a
+    # go toolchain is on PATH and degrades to pure tree-sitter otherwise. GOTYPES
+    # augments exact first-party call binding and external-site suppression;
+    # tree-sitter stays the standalone-correct backbone.
+    GO_FRONTEND: cs.GoFrontend = cs.GoFrontend.AUTO
     CAPTURE_FUNCTION_LOCAL_DEFINITIONS: bool = Field(
         True, validation_alias="CGR_CAPTURE_LOCAL_DEFINITIONS"
     )

--- a/codebase_rag/constants/core.py
+++ b/codebase_rag/constants/core.py
@@ -139,6 +139,12 @@ PY_SOURCE_GLOB = "*.py"
 # sources are folded into the parser fingerprint.
 PARSER_FINGERPRINT_TOOL_DIR = "parsers/csharp_frontend/roslyn"
 PARSER_FINGERPRINT_TOOL_GLOBS: tuple[str, ...] = ("*.cs", "*.csproj")
+# Bundled semantic-frontend tool sources (per (dir, globs)): parser code that
+# is not Python, so an edit must still trip the staleness fingerprint.
+PARSER_FINGERPRINT_TOOL_SOURCES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("parsers/csharp_frontend/roslyn", ("*.cs", "*.csproj")),
+    ("parsers/go_frontend/gotypes", ("*.go", "*.mod", "*.sum")),
+)
 GRAMMAR_DIST_PREFIX = "tree-sitter"
 GRAMMAR_VERSION_FMT = "{name}=={version}"
 GIT_DIR_NAME = ".git"

--- a/codebase_rag/constants/languages.py
+++ b/codebase_rag/constants/languages.py
@@ -116,6 +116,15 @@ class CSharpFrontend(StrEnum):
     HYBRID = "hybrid"
 
 
+class GoFrontend(StrEnum):
+    # AUTO resolves at run time: GOTYPES where a go toolchain is on PATH,
+    # TREESITTER otherwise (resolve_go_frontend). The parser fingerprint records
+    # the RESOLVED mode, so go and non-go graphs never share an identity.
+    AUTO = "auto"
+    TREESITTER = "treesitter"
+    GOTYPES = "gotypes"
+
+
 # JS/TS import specifier schemes naming genuinely external code (node
 # builtins, registries, URLs). Any OTHER scheme (`ext:` deno aliases,
 # bundler virtual modules) points at first-party code under a non-file-path

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -59,6 +59,7 @@ from .parsers.endpoints import (
 from .parsers.factory import ProcessorFactory
 from .parsers.frontends import FRONTENDS, SemanticFacts
 from .parsers.frontends.protocol import QueryCall
+from .parsers.go_frontend import find_go_module
 from .parsers.utils import sorted_captures
 from .path_filters import matches_test_path
 from .services import FilteringIngestor, IngestorProtocol, QueryProtocol
@@ -454,6 +455,47 @@ class GraphUpdater:
         self._csharp_partial_decls = facts.partial_groups
         self._csharp_query_calls = facts.query_calls
 
+    def _run_go_frontend(self) -> None:
+        # Optional go/types semantic pre-pass (issue #1179). GOTYPES/AUTO: load
+        # the module with go/packages and collect exact first-party call targets
+        # (Pass 3) and external sites the tree-sitter name trie cannot derive.
+        # Missing go, no go.mod, or a build failure all fall back to pure
+        # tree-sitter (empty facts). Reset first so a reused updater (watch mode)
+        # that previously ran the frontend does not keep applying stale facts on
+        # a later run with it off; the maps are mutated in place because the
+        # type-inference engine holds a reference.
+        self._reset_go_semantic_facts()
+        if settings.GO_FRONTEND == cs.GoFrontend.TREESITTER:
+            return
+        frontend = FRONTENDS.get(cs.SupportedLanguage.GO)
+        if frontend is None or not frontend.applies(self.repo_path):
+            return
+        if not frontend.available():
+            if settings.GO_FRONTEND == cs.GoFrontend.AUTO:
+                logger.info(ls.GO_FRONTEND_AUTO_FALLBACK)
+            else:
+                logger.warning(ls.GO_FRONTEND_UNAVAILABLE)
+            return
+        logger.info(ls.GO_FRONTEND_RUNNING.format(path=find_go_module(self.repo_path)))
+        facts = frontend.run(self.repo_path, ())
+        self._apply_go_semantic_facts(facts)
+        logger.info(
+            ls.GO_FRONTEND_FACTS.format(
+                calls=len(facts.resolved_call_sites),
+                externals=len(facts.external_sites),
+            )
+        )
+
+    def _reset_go_semantic_facts(self) -> None:
+        dp = self.factory.definition_processor
+        dp.go_call_sites.clear()
+        dp.go_external_sites.clear()
+
+    def _apply_go_semantic_facts(self, facts: SemanticFacts) -> None:
+        dp = self.factory.definition_processor
+        dp.go_call_sites.update(facts.resolved_call_sites)
+        dp.go_external_sites.update(facts.external_sites)
+
     def _join_csharp_partials(self) -> None:
         # Replace the directory-keyed syntactic partial grouping with the
         # Roslyn symbol-identity groups wherever Roslyn saw the type: parts
@@ -670,6 +712,9 @@ class GraphUpdater:
         # base-classification oracle that split_csharp_bases consults while
         # ingesting each type's INHERITS/IMPLEMENTS edges during Pass 2.
         self._run_csharp_frontend()
+        # Go facts are read at Pass 3 and the name-alias target index is filled
+        # during Pass 2, so loading them here (before Pass 2) is correct.
+        self._run_go_frontend()
 
         logger.info(ls.PASS_2_FILES)
         self._process_files(force=force)

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -62,6 +62,14 @@ CSHARP_FRONTEND_NO_FACTS = (
     "C# Roslyn frontend produced no facts; every join falls back to "
     "tree-sitter. Tool diagnostics:\n{stderr}"
 )
+GO_FRONTEND_RUNNING = "--- Go go/types frontend: {path} ---"
+GO_FRONTEND_UNAVAILABLE = (
+    "Go frontend enabled but the go toolchain is unavailable; using tree-sitter"
+)
+GO_FRONTEND_AUTO_FALLBACK = "Go frontend AUTO: go not found; using tree-sitter only"
+GO_FRONTEND_FACTS = (
+    "Go go/types frontend facts: {calls} call site(s), {externals} external site(s)"
+)
 GO_FRONTEND_BUILD_FAILED = (
     "Go frontend tool failed to build; using tree-sitter.\nstderr: {stderr}"
 )

--- a/codebase_rag/parser_fingerprint.py
+++ b/codebase_rag/parser_fingerprint.py
@@ -35,10 +35,12 @@ def _frontend_settings() -> list[str]:
     # does not, so the two must not share a fingerprint. Imported lazily to
     # keep this module free of the parsers package at import time.
     from .parsers.csharp_frontend import resolve_csharp_frontend
+    from .parsers.go_frontend import resolve_go_frontend
 
     return [
         f"CPP_FRONTEND={settings.CPP_FRONTEND.value}",
         f"CSHARP_FRONTEND={resolve_csharp_frontend().value}",
+        f"GO_FRONTEND={resolve_go_frontend().value}",
     ]
 
 
@@ -53,12 +55,13 @@ def _fingerprint_sources(root: Path) -> list[Path]:
         for name in cs.PARSER_FINGERPRINT_SOURCE_FILES
         if (path := root / name).is_file()
     )
-    # The bundled Roslyn frontend tool (.cs/.csproj) is parser code though not
-    # Python; an edit changes the semantic edges produced, so a tool change
-    # must trip the staleness warning.
-    tool_dir = root / cs.PARSER_FINGERPRINT_TOOL_DIR
-    for pattern in cs.PARSER_FINGERPRINT_TOOL_GLOBS:
-        sources.extend(path for path in tool_dir.glob(pattern) if path.is_file())
+    # The bundled semantic-frontend tools (Roslyn .cs/.csproj, gotypes
+    # .go/.mod/.sum) are parser code though not Python; an edit changes the
+    # semantic edges produced, so a tool change must trip the staleness warning.
+    for dirname, globs in cs.PARSER_FINGERPRINT_TOOL_SOURCES:
+        tool_dir = root / dirname
+        for pattern in globs:
+            sources.extend(path for path in tool_dir.glob(pattern) if path.is_file())
     return sorted(sources)
 
 

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -32,6 +32,7 @@ from .csharp import type_inference as csharp_ti
 from .dart import utils as dart_utils
 from .dispatch_registry import DispatchRegistryProcessor
 from .flow_access import FlowProcessor
+from .go import type_inference as go_ti
 from .go import utils as go_utils
 from .import_processor import ImportProcessor
 from .io_access import IOAccessProcessor
@@ -3359,6 +3360,29 @@ class CallProcessor:
                         class_context,
                         caller_qn,
                         language,
+                    )
+            elif (
+                language == cs.SupportedLanguage.GO
+                and call_node.type == cs.TS_GO_CALL_EXPRESSION
+            ):
+                # The go/types frontend (issue #1179): a HIT is the compiler's
+                # exact first-party callee (promotion, shadowing) the heuristic
+                # cannot type; the external sentinel proves the call leaves the
+                # module and suppresses trie fabrication. Any miss (incl. the
+                # frontend being off, so both fact maps are empty) falls back to
+                # today's Go resolver with call_point preserved.
+                callee_info = resolver.resolve_go_call_site(call_node, module_qn)
+                if callee_info == go_ti.GO_EXTERNAL_TARGET:
+                    callee_info = None
+                elif callee_info is None:
+                    callee_info = resolve_func(
+                        call_name,
+                        module_qn,
+                        call_var_types,
+                        class_context,
+                        caller_qn,
+                        language,
+                        call_point=call_node.start_byte,
                     )
             else:
                 callee_info = resolve_func(

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -3030,3 +3030,12 @@ class CallResolver:
         return self.type_inference.csharp_type_inference.resolve_csharp_method_call(
             call_node, local_var_types, module_qn, caller_qn
         )
+
+    def resolve_go_call_site(
+        self,
+        call_node: Node,
+        module_qn: str,
+    ) -> tuple[str, str] | None:
+        return self.type_inference.go_type_inference.resolve_go_call_site(
+            call_node, module_qn
+        )

--- a/codebase_rag/parsers/csharp/type_inference.py
+++ b/codebase_rag/parsers/csharp/type_inference.py
@@ -16,10 +16,10 @@ from ...types_defs import (
     NodeType,
     SimpleNameLookup,
 )
-from ...utils.path_utils import cached_relative_path
 from ..csharp_frontend import CallSiteKey
 from ..frontends.protocol import ResolvedCallSite
 from ..import_processor import ImportProcessor
+from ..semantic_call_join import call_site_key, declared_location
 from ..utils import safe_decode_text
 from .utils import (
     _normalize_type_name,
@@ -668,8 +668,14 @@ class CSharpTypeInferenceEngine:
             return None
         fact = self.csharp_call_sites.get(key)
         if fact is not None:
-            return self._declared_location(
-                fact.target_file, fact.target_line, fact.target_col
+            return declared_location(
+                fact.target_file,
+                fact.target_line,
+                fact.target_col,
+                self.function_locations,
+                self.module_qn_to_file_path,
+                self.repo_path,
+                self._rel_to_module,
             )
         if key in self.csharp_external_sites:
             # Roslyn resolved this site to a METADATA method: the call
@@ -686,18 +692,13 @@ class CSharpTypeInferenceEngine:
         name = safe_decode_text(name_node)
         if not name:
             return None
-        file_path = self.module_qn_to_file_path.get(module_qn)
-        if file_path is None:
-            return None
-        rel = cached_relative_path(file_path, self.repo_path).as_posix()
-        # Keyed on the callee NAME token (nested invocations share an
-        # expression start, never a name token), with generic arguments
-        # stripped to match Roslyn's symbol name.
-        return (
-            rel,
-            name_node.start_point[0] + 1,
-            name_node.start_point[1],
+        # Generic arguments stripped to match Roslyn's symbol name.
+        return call_site_key(
+            name_node,
             name.split(cs.CHAR_ANGLE_OPEN, 1)[0],
+            module_qn,
+            self.module_qn_to_file_path,
+            self.repo_path,
         )
 
     def _callee_name_node(self, call_node: Node) -> Node | None:
@@ -723,30 +724,6 @@ class CSharpTypeInferenceEngine:
             if binding is not None:
                 return binding.child_by_field_name(cs.FIELD_NAME)
         return None
-
-    def _declared_location(
-        self, rel_file: str, line: int, col: int
-    ) -> tuple[str, str] | None:
-        # The fact's target declaration location resolves through the exact
-        # (module_qn, start_line, start_col) record Pass 2 registered, so the
-        # returned label/qn are the ingested node's, signature included.
-        target_module = self._module_qn_for_rel_file(rel_file)
-        if target_module is None:
-            return None
-        location = self.function_locations.get((target_module, line, col))
-        if location is None:
-            return None
-        return location.label, location.qualified_name
-
-    def _module_qn_for_rel_file(self, rel_file: str) -> str | None:
-        # Lazy inverse of module_qn_to_file_path (which Pass 2 fills after
-        # this engine is constructed); rebuilt when new modules appeared.
-        if len(self._rel_to_module) != len(self.module_qn_to_file_path):
-            self._rel_to_module = {
-                cached_relative_path(path, self.repo_path).as_posix(): qn
-                for qn, path in self.module_qn_to_file_path.items()
-            }
-        return self._rel_to_module.get(rel_file)
 
     def _try_extension_call(
         self,

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -158,6 +158,13 @@ class DefinitionProcessor(
         # name-trie fabricate a first-party edge. Same in-place mutation
         # discipline as csharp_call_sites.
         self.csharp_external_sites: set[CallSiteKey] = set()
+        # Go go/types frontend (issue #1179): the same two call families as C#
+        # -- per-invocation exact first-party call targets keyed on the callee
+        # NAME token location, and sites the compiler resolved OUTSIDE the module
+        # (stdlib, deps). Same in-place mutation discipline; the Go type-inference
+        # engine holds the reference.
+        self.go_call_sites: dict[CallSiteKey, ResolvedCallSite] = {}
+        self.go_external_sites: set[CallSiteKey] = set()
         # (rel_file, type_start_line) -> class qn for every ingested C# type,
         # the reverse of the Roslyn fact keys, so partial declaration groups
         # join back to the Pass-2 Class nodes.

--- a/codebase_rag/parsers/factory.py
+++ b/codebase_rag/parsers/factory.py
@@ -133,6 +133,8 @@ class ProcessorFactory:
                 class_field_element_types=self.definition_processor.class_field_element_types,
                 method_return_types=self.definition_processor.method_return_types,
                 go_function_return_types=self.definition_processor.go_function_return_types,
+                go_call_sites=self.definition_processor.go_call_sites,
+                go_external_sites=self.definition_processor.go_external_sites,
                 csharp_partial_groups=self.definition_processor.csharp_partial_groups,
                 csharp_extension_methods=self.definition_processor.csharp_extension_methods,
                 csharp_call_sites=self.definition_processor.csharp_call_sites,

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -1134,7 +1134,7 @@ class FunctionIngestMixin:
                 if container_type is not None
                 else cs.NodeLabel.CLASS
             )
-            ingest_method(
+            method_qn = ingest_method(
                 method_node=entry.method_node,
                 container_qn=container_qn,
                 container_type=container_label,
@@ -1151,6 +1151,16 @@ class FunctionIngestMixin:
                 defer_containment=self._deferred_parent_links,
                 module_qn=entry.module_qn,
             )
+            if method_qn is not None:
+                self._register_go_name_alias(
+                    entry.module_qn,
+                    entry.method_node,
+                    FunctionLocation(
+                        label=cs.NodeLabel.METHOD.value,
+                        qualified_name=method_qn,
+                        container_qn=container_qn,
+                    ),
+                )
             # Record the method's return type so a chained call `c.Root().Run()`
             # resolves `Run` on the type `Root()` returns.
             method_name = self._extract_function_name(entry.method_node)
@@ -1163,6 +1173,22 @@ class FunctionIngestMixin:
         ingested = len(deferred)
         self._deferred_go_methods = []
         return ingested
+
+    def _register_go_name_alias(
+        self, module_qn: str, decl_node: Node, location: FunctionLocation
+    ) -> None:
+        # The go/types frontend (issue #1179) keys a call target at the callee
+        # NAME identifier, but function_span_key keys at the `func` keyword
+        # (col 0); register a SECOND location at the name token so the semantic
+        # join resolves. The name col is never 0, so this never collides with the
+        # span-key entry, and FunctionLocations.drop_module forgets it on an
+        # incremental re-parse.
+        name_node = decl_node.child_by_field_name(cs.FIELD_NAME)
+        if name_node is None:
+            return
+        self.function_locations[
+            (module_qn, name_node.start_point[0] + 1, name_node.start_point[1])
+        ] = location
 
     def _resolve_cpp_function(
         self, func_node: Node, module_qn: str
@@ -1292,6 +1318,8 @@ class FunctionIngestMixin:
             is_named=not resolution.is_anonymous,
         )
         self.function_locations[function_span_key(module_qn, func_node)] = location
+        if language == cs.SupportedLanguage.GO:
+            self._register_go_name_alias(module_qn, func_node, location)
         # Pin a C# local function to its HOST scope (method/ctor/enclosing local
         # fn) by span, plus its declared parameter count, so bare-name call
         # resolution honours C# scoping and arity (the host's signatured identity

--- a/codebase_rag/parsers/go/type_inference.py
+++ b/codebase_rag/parsers/go/type_inference.py
@@ -1,10 +1,21 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from tree_sitter import Node
 
 from ... import constants as cs
+from ...types_defs import FunctionLocation, FunctionSpanKey
+from ...utils.path_utils import cached_relative_path
+from ..csharp_frontend import CallSiteKey
+from ..frontends.protocol import ResolvedCallSite
 from ..utils import safe_decode_text
 from .utils import type_identifier_text
+
+# Sentinel returned when the go/types frontend resolved a call OUTSIDE the module
+# (stdlib, deps): the resolver suppresses the name-trie fallback there rather than
+# fabricating a first-party edge (mirrors CSHARP_EXTERNAL_TARGET).
+GO_EXTERNAL_TARGET: tuple[str, str] = ("", "")
 
 
 class GoTypeInferenceEngine:
@@ -14,7 +25,118 @@ class GoTypeInferenceEngine:
     # resolver turns a name into a class qn via the same _resolve_class_name path the
     # definition pass uses, so pointer/generic wrappers are stripped here down to the
     # underlying type identifier.
-    __slots__ = ()
+    #
+    # The go/types semantic frontend (issue #1179) adds an exact-callee join on top:
+    # the shared go_call_sites / go_external_sites facts (populated after
+    # construction) resolve a call to its declared target or suppress a fabricated
+    # first-party edge, with per-miss fallback to the stateless walker below.
+    __slots__ = (
+        "go_call_sites",
+        "go_external_sites",
+        "function_locations",
+        "module_qn_to_file_path",
+        "repo_path",
+        "_rel_to_module",
+    )
+
+    def __init__(
+        self,
+        go_call_sites: dict[CallSiteKey, ResolvedCallSite] | None = None,
+        go_external_sites: set[CallSiteKey] | None = None,
+        function_locations: dict[FunctionSpanKey, FunctionLocation] | None = None,
+        module_qn_to_file_path: dict[str, Path] | None = None,
+        repo_path: Path | None = None,
+    ) -> None:
+        self.go_call_sites = go_call_sites if go_call_sites is not None else {}
+        self.go_external_sites = (
+            go_external_sites if go_external_sites is not None else set()
+        )
+        self.function_locations = (
+            function_locations if function_locations is not None else {}
+        )
+        self.module_qn_to_file_path = (
+            module_qn_to_file_path if module_qn_to_file_path is not None else {}
+        )
+        self.repo_path = repo_path if repo_path is not None else Path()
+        self._rel_to_module: dict[str, str] = {}
+
+    def resolve_go_call_site(
+        self, call_node: Node, module_qn: str
+    ) -> tuple[str, str] | None:
+        # The go/types semantic path: an exact first-party callee (embedded-struct
+        # promotion, scope shadowing) the walker cannot type, or the external
+        # sentinel for a call the compiler proved leaves the module. Any miss
+        # returns None so the caller falls back to the tree-sitter heuristics.
+        if not (self.go_call_sites or self.go_external_sites):
+            return None
+        key = self._call_site_key(call_node, module_qn)
+        if key is None:
+            return None
+        fact = self.go_call_sites.get(key)
+        if fact is not None:
+            return self._declared_location(
+                fact.target_file, fact.target_line, fact.target_col
+            )
+        if key in self.go_external_sites:
+            return GO_EXTERNAL_TARGET
+        return None
+
+    def _call_site_key(self, call_node: Node, module_qn: str) -> CallSiteKey | None:
+        name_node = self._callee_name_node(call_node)
+        if name_node is None:
+            return None
+        name = safe_decode_text(name_node)
+        if not name:
+            return None
+        file_path = self.module_qn_to_file_path.get(module_qn)
+        if file_path is None:
+            return None
+        rel = cached_relative_path(file_path, self.repo_path).as_posix()
+        return (rel, name_node.start_point[0] + 1, name_node.start_point[1], name)
+
+    def _callee_name_node(self, call_node: Node) -> Node | None:
+        # The callee NAME token, matching the gotypes tool's `calleeName`: a bare
+        # identifier for `Foo()`, the `field` child for `x.M()` / `pkg.F()`, and
+        # the inner name for generic (`Gen[T]()`) and parenthesised callees.
+        func = call_node.child_by_field_name(cs.TS_FIELD_FUNCTION)
+        return self._name_from_callee(func)
+
+    def _name_from_callee(self, node: Node | None) -> Node | None:
+        if node is None:
+            return None
+        if node.type == cs.TS_GO_IDENTIFIER:
+            return node
+        if node.type == cs.TS_GO_SELECTOR_EXPRESSION:
+            return node.child_by_field_name(cs.FIELD_FIELD)
+        if node.type == cs.TS_GO_INDEX_EXPRESSION:
+            return self._name_from_callee(node.child_by_field_name(cs.FIELD_OPERAND))
+        if node.type == cs.TS_PARENTHESIZED_EXPRESSION:
+            inner = next((c for c in node.named_children), None)
+            return self._name_from_callee(inner)
+        return None
+
+    def _declared_location(
+        self, rel_file: str, line: int, col: int
+    ) -> tuple[str, str] | None:
+        # The fact's target position joins the (module_qn, name_line, name_col)
+        # alias Pass 2 registered for every Go decl (the func/method NAME token,
+        # NOT the func-keyword span key), so the returned label/qn are the
+        # ingested node's.
+        target_module = self._module_qn_for_rel_file(rel_file)
+        if target_module is None:
+            return None
+        location = self.function_locations.get((target_module, line, col))
+        if location is None:
+            return None
+        return location.label, location.qualified_name
+
+    def _module_qn_for_rel_file(self, rel_file: str) -> str | None:
+        if len(self._rel_to_module) != len(self.module_qn_to_file_path):
+            self._rel_to_module = {
+                cached_relative_path(path, self.repo_path).as_posix(): qn
+                for qn, path in self.module_qn_to_file_path.items()
+            }
+        return self._rel_to_module.get(rel_file)
 
     def build_local_variable_type_map(
         self, caller_node: Node, module_qn: str

--- a/codebase_rag/parsers/go/type_inference.py
+++ b/codebase_rag/parsers/go/type_inference.py
@@ -6,9 +6,9 @@ from tree_sitter import Node
 
 from ... import constants as cs
 from ...types_defs import FunctionLocation, FunctionSpanKey
-from ...utils.path_utils import cached_relative_path
 from ..csharp_frontend import CallSiteKey
 from ..frontends.protocol import ResolvedCallSite
+from ..semantic_call_join import call_site_key, declared_location
 from ..utils import safe_decode_text
 from .utils import type_identifier_text
 
@@ -74,8 +74,14 @@ class GoTypeInferenceEngine:
             return None
         fact = self.go_call_sites.get(key)
         if fact is not None:
-            return self._declared_location(
-                fact.target_file, fact.target_line, fact.target_col
+            return declared_location(
+                fact.target_file,
+                fact.target_line,
+                fact.target_col,
+                self.function_locations,
+                self.module_qn_to_file_path,
+                self.repo_path,
+                self._rel_to_module,
             )
         if key in self.go_external_sites:
             return GO_EXTERNAL_TARGET
@@ -88,11 +94,9 @@ class GoTypeInferenceEngine:
         name = safe_decode_text(name_node)
         if not name:
             return None
-        file_path = self.module_qn_to_file_path.get(module_qn)
-        if file_path is None:
-            return None
-        rel = cached_relative_path(file_path, self.repo_path).as_posix()
-        return (rel, name_node.start_point[0] + 1, name_node.start_point[1], name)
+        return call_site_key(
+            name_node, name, module_qn, self.module_qn_to_file_path, self.repo_path
+        )
 
     def _callee_name_node(self, call_node: Node) -> Node | None:
         # The callee NAME token, matching the gotypes tool's `calleeName`: a bare
@@ -114,29 +118,6 @@ class GoTypeInferenceEngine:
             inner = next((c for c in node.named_children), None)
             return self._name_from_callee(inner)
         return None
-
-    def _declared_location(
-        self, rel_file: str, line: int, col: int
-    ) -> tuple[str, str] | None:
-        # The fact's target position joins the (module_qn, name_line, name_col)
-        # alias Pass 2 registered for every Go decl (the func/method NAME token,
-        # NOT the func-keyword span key), so the returned label/qn are the
-        # ingested node's.
-        target_module = self._module_qn_for_rel_file(rel_file)
-        if target_module is None:
-            return None
-        location = self.function_locations.get((target_module, line, col))
-        if location is None:
-            return None
-        return location.label, location.qualified_name
-
-    def _module_qn_for_rel_file(self, rel_file: str) -> str | None:
-        if len(self._rel_to_module) != len(self.module_qn_to_file_path):
-            self._rel_to_module = {
-                cached_relative_path(path, self.repo_path).as_posix(): qn
-                for qn, path in self.module_qn_to_file_path.items()
-            }
-        return self._rel_to_module.get(rel_file)
 
     def build_local_variable_type_map(
         self, caller_node: Node, module_qn: str

--- a/codebase_rag/parsers/go_frontend/__init__.py
+++ b/codebase_rag/parsers/go_frontend/__init__.py
@@ -10,6 +10,7 @@ from .frontend import (
     GoSemanticFacts,
     find_go_module,
     go_frontend_available,
+    resolve_go_frontend,
     run_go_frontend,
 )
 
@@ -19,5 +20,6 @@ __all__ = [
     "GoSemanticFacts",
     "find_go_module",
     "go_frontend_available",
+    "resolve_go_frontend",
     "run_go_frontend",
 ]

--- a/codebase_rag/parsers/go_frontend/frontend.py
+++ b/codebase_rag/parsers/go_frontend/frontend.py
@@ -78,6 +78,22 @@ def go_frontend_available() -> bool:
     return shutil.which(_GO) is not None
 
 
+def resolve_go_frontend() -> cs.GoFrontend:
+    # The single source of truth for the EFFECTIVE frontend: without a go
+    # toolchain every gotypes-backed mode (AUTO, and an explicit GOTYPES, which
+    # the graph build degrades to tree-sitter with a warning) resolves to
+    # TREESITTER; with one, AUTO means GOTYPES. The parser fingerprint resolves
+    # through here so a graph's recorded identity matches the frontend that ran.
+    mode = settings.GO_FRONTEND
+    if mode == cs.GoFrontend.TREESITTER:
+        return mode
+    if not go_frontend_available():
+        return cs.GoFrontend.TREESITTER
+    if mode == cs.GoFrontend.AUTO:
+        return cs.GoFrontend.GOTYPES
+    return mode
+
+
 def find_go_module(repo_path: Path) -> Path | None:
     # The root-most module's go.mod (shortest anchor path), or None when the
     # repo has no non-ignored go.mod. Applicability only needs its presence;

--- a/codebase_rag/parsers/semantic_call_join.py
+++ b/codebase_rag/parsers/semantic_call_join.py
@@ -1,0 +1,79 @@
+"""Shared declaration join for the semantic frontends (C# Roslyn, Go go/types).
+
+A frontend fact carries a target declaration POSITION; both resolvers turn it
+into the ingested node's (label, qn) through the exact `function_locations`
+record Pass 2 registered. The C# and Go engines held byte-identical copies of
+this join, so it lives here once (issue #1179)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tree_sitter import Node
+
+from ..types_defs import FunctionLocation, FunctionSpanKey
+from ..utils.path_utils import cached_relative_path
+
+# (rel_file, name_token_line, name_token_byte_col, simple_name).
+CallSiteKey = tuple[str, int, int, str]
+
+
+def call_site_key(
+    name_node: Node,
+    simple_name: str,
+    module_qn: str,
+    module_qn_to_file_path: dict[str, Path],
+    repo_path: Path,
+) -> CallSiteKey | None:
+    # The location join key: the callee NAME token's (rel_file, line, byte_col)
+    # plus its simple name. Nested calls share an expression start but never a
+    # name token. The caller supplies simple_name so each language applies its
+    # own normalisation (C# strips generic arguments; Go passes it through).
+    file_path = module_qn_to_file_path.get(module_qn)
+    if file_path is None:
+        return None
+    rel = cached_relative_path(file_path, repo_path).as_posix()
+    return (rel, name_node.start_point[0] + 1, name_node.start_point[1], simple_name)
+
+
+def module_qn_for_rel_file(
+    rel_file: str,
+    module_qn_to_file_path: dict[str, Path],
+    repo_path: Path,
+    rel_to_module: dict[str, str],
+) -> str | None:
+    # Lazy inverse of module_qn_to_file_path (which Pass 2 fills after the engine
+    # is constructed); the passed-in cache is rebuilt in place when new modules
+    # appeared so the caller's reference stays valid.
+    if len(rel_to_module) != len(module_qn_to_file_path):
+        rel_to_module.clear()
+        rel_to_module.update(
+            {
+                cached_relative_path(path, repo_path).as_posix(): qn
+                for qn, path in module_qn_to_file_path.items()
+            }
+        )
+    return rel_to_module.get(rel_file)
+
+
+def declared_location(
+    rel_file: str,
+    line: int,
+    col: int,
+    function_locations: dict[FunctionSpanKey, FunctionLocation],
+    module_qn_to_file_path: dict[str, Path],
+    repo_path: Path,
+    rel_to_module: dict[str, str],
+) -> tuple[str, str] | None:
+    # The fact's target position resolves through the exact (module_qn,
+    # start_line, start_col) record Pass 2 registered, so the returned label/qn
+    # are the ingested node's, signature included.
+    target_module = module_qn_for_rel_file(
+        rel_file, module_qn_to_file_path, repo_path, rel_to_module
+    )
+    if target_module is None:
+        return None
+    location = function_locations.get((target_module, line, col))
+    if location is None:
+        return None
+    return location.label, location.qualified_name

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -46,6 +46,8 @@ class TypeInferenceEngine:
         "class_field_element_types",
         "method_return_types",
         "go_function_return_types",
+        "go_call_sites",
+        "go_external_sites",
         "csharp_partial_groups",
         "csharp_extension_methods",
         "csharp_call_sites",
@@ -85,6 +87,8 @@ class TypeInferenceEngine:
         class_field_element_types: dict[str, dict[str, str]] | None = None,
         method_return_types: dict[str, str] | None = None,
         go_function_return_types: dict[str, str] | None = None,
+        go_call_sites: dict[CallSiteKey, ResolvedCallSite] | None = None,
+        go_external_sites: set[CallSiteKey] | None = None,
         csharp_partial_groups: dict[str, list[str]] | None = None,
         csharp_extension_methods: dict[str, list[tuple[str, str, str, int]]]
         | None = None,
@@ -136,6 +140,13 @@ class TypeInferenceEngine:
         # FIRST return type, read only by the single-segment binding path.
         self.go_function_return_types = (
             go_function_return_types if go_function_return_types is not None else {}
+        )
+        # Shared references (as with csharp_call_sites): the go/types call-site
+        # facts and external sites, populated after construction and read by the
+        # Go resolver's semantic path (issue #1179).
+        self.go_call_sites = go_call_sites if go_call_sites is not None else {}
+        self.go_external_sites = (
+            go_external_sites if go_external_sites is not None else set()
         )
         self._go_free_fn_index: dict[tuple[str, str], str] = {}
         self._go_free_fn_index_size = -1
@@ -200,7 +211,13 @@ class TypeInferenceEngine:
     @property
     def go_type_inference(self) -> GoTypeInferenceEngine:
         if self._go_type_inference is None:
-            self._go_type_inference = GoTypeInferenceEngine()
+            self._go_type_inference = GoTypeInferenceEngine(
+                go_call_sites=self.go_call_sites,
+                go_external_sites=self.go_external_sites,
+                function_locations=self.function_locations,
+                module_qn_to_file_path=self.module_qn_to_file_path,
+                repo_path=self.repo_path,
+            )
         return self._go_type_inference
 
     @property

--- a/codebase_rag/tests/test_go_semantic_facts.py
+++ b/codebase_rag/tests/test_go_semantic_facts.py
@@ -1,0 +1,268 @@
+# Go go/types frontend consumer (issue #1179, PR2): the resolver wiring that
+# turns the producer's facts into graph edges -- exact first-party call binding
+# (embedded promotion, scope shadowing) and external-site suppression. The
+# synthetic-facts tests drive run_updater with a monkeypatched runner and need
+# no go toolchain; the end-to-end test runs the real bundled tool and skips
+# when `go` is absent. The join is location-keyed and degrades to the Go
+# heuristics on any key miss, so the frontend-off graph is unchanged.
+import shutil
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag import graph_updater as gu
+from codebase_rag.parsers.go_frontend import GoCallSite, GoSemanticFacts
+from codebase_rag.tests.conftest import get_relationships, run_updater
+
+SKIP = "go"
+
+
+def _byte_loc(source: str, needle: str) -> tuple[int, int]:
+    # (1-based line, 0-based BYTE column) of the first occurrence of `needle`.
+    for line_no, line in enumerate(source.splitlines(), 1):
+        idx = line.find(needle)
+        if idx >= 0:
+            return line_no, len(line[:idx].encode("utf-8"))
+    raise AssertionError(needle)
+
+
+def _pairs(mock_ingestor: MagicMock, rel_type: str) -> set[tuple[str, str]]:
+    return {
+        (c.args[0][2], c.args[2][2]) for c in get_relationships(mock_ingestor, rel_type)
+    }
+
+
+def _has(pairs: set[tuple[str, str]], caller_suffix: str, callee_suffix: str) -> bool:
+    return any(
+        ca.endswith(caller_suffix) and ce.endswith(callee_suffix) for ca, ce in pairs
+    )
+
+
+def _gotypes(monkeypatch: pytest.MonkeyPatch, facts: GoSemanticFacts) -> None:
+    # The Go frontend runs behind the LanguageFrontend registry, so patch the
+    # toolchain gate and the runner where the ADAPTER binds them.
+    from codebase_rag.parsers.frontends import go as go_fe
+
+    monkeypatch.setattr(gu.settings, "GO_FRONTEND", cs.GoFrontend.GOTYPES)
+    monkeypatch.setattr(go_fe, "go_frontend_available", lambda: True)
+    monkeypatch.setattr(go_fe, "run_go_frontend", lambda repo_path: facts)
+
+
+_AMBIGUOUS_SRC = """package sample
+
+type A struct{}
+
+func (a A) Handle() string { return "a" }
+
+type B struct{}
+
+func (b B) Handle() string { return "b" }
+
+type Handler interface{ Handle() string }
+
+func Run(h Handler) {
+\t_ = h.Handle()
+}
+"""
+
+
+def test_call_fact_overrides_heuristic_to_exact_implementation(
+    temp_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # `h.Handle()` on an interface receiver: the name-trie heuristic guesses the
+    # FIRST same-named method (A.Handle). Point the go/types fact at B.Handle
+    # (keyed on the callee NAME token, joined via the Pass-2 name alias) and the
+    # edge must bind B.Handle instead -- proving the compiler fact overrides the
+    # heuristic, not that both happen to agree.
+    root = temp_repo / "goexact"
+    root.mkdir()
+    (root / "go.mod").write_text("module example.com/exact\n\ngo 1.23\n")
+    (root / "sample.go").write_text(_AMBIGUOUS_SRC, encoding="utf-8")
+
+    # The CALL site is the unique `h.Handle()` line.
+    hcall_line, _ = _byte_loc(_AMBIGUOUS_SRC, "h.Handle()")
+    hcall_text = _AMBIGUOUS_SRC.splitlines()[hcall_line - 1]
+    hcall_col = len(hcall_text[: hcall_text.index("Handle")].encode("utf-8"))
+    target_line, target_col = _byte_loc(_AMBIGUOUS_SRC, 'Handle() string { return "b"')
+    facts = GoSemanticFacts(
+        call_sites={
+            ("sample.go", hcall_line, hcall_col, "Handle"): GoCallSite(
+                "Handle", "sample.go", target_line, target_col
+            )
+        },
+        external_sites=set(),
+    )
+    _gotypes(monkeypatch, facts)
+
+    ingestor = MagicMock()
+    run_updater(root, ingestor, skip_if_missing=SKIP)
+
+    calls = _pairs(ingestor, "CALLS")
+    assert _has(calls, "Run", "B.Handle"), calls
+    assert not _has(calls, "Run", "A.Handle"), calls
+
+
+_EXTERNAL_SRC = """package sample
+
+type Helper struct{}
+
+func (h Helper) Close() {}
+
+func Ping() {}
+
+func Run(c interface{ Close() }) {
+\tPing()
+\tc.Close()
+}
+"""
+
+
+def test_external_site_fact_suppresses_name_trie_fallback(
+    temp_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # `c.Close()` on an interface receiver: the compiler proved the callee
+    # leaves the module, so its external-site fact must suppress a fabricated
+    # edge onto the unrelated first-party Helper.Close, while the sibling
+    # first-party Ping() call in the same function still resolves.
+    root = temp_repo / "goexternal"
+    root.mkdir()
+    (root / "go.mod").write_text("module example.com/external\n\ngo 1.23\n")
+    (root / "sample.go").write_text(_EXTERNAL_SRC, encoding="utf-8")
+
+    close_line, _ = _byte_loc(_EXTERNAL_SRC, "c.Close()")
+    close_text = _EXTERNAL_SRC.splitlines()[close_line - 1]
+    close_col = len(close_text[: close_text.index("Close")].encode("utf-8"))
+    facts = GoSemanticFacts(
+        call_sites={},
+        external_sites={("sample.go", close_line, close_col, "Close")},
+    )
+    _gotypes(monkeypatch, facts)
+
+    ingestor = MagicMock()
+    run_updater(root, ingestor, skip_if_missing=SKIP)
+
+    calls = _pairs(ingestor, "CALLS")
+    assert not _has(calls, "Run", "Helper.Close"), calls
+    assert _has(calls, "Run", "Ping"), calls
+
+
+def test_frontend_off_clears_stale_go_facts(
+    temp_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Watch-mode reset must cover the Go fact stores: a later run with the
+    # frontend off may not keep binding stale targets.
+    from codebase_rag.parser_loader import load_parsers
+    from codebase_rag.parsers.frontends.protocol import ResolvedCallSite
+
+    parsers, queries = load_parsers()
+    updater = gu.GraphUpdater(
+        ingestor=MagicMock(), repo_path=temp_repo, parsers=parsers, queries=queries
+    )
+    dp = updater.factory.definition_processor
+    dp.go_call_sites[("stale.go", 1, 0, "Old")] = ResolvedCallSite(
+        "Old", "stale.go", 2, 0
+    )
+    dp.go_external_sites.add(("stale.go", 3, 0, "Ext"))
+    monkeypatch.setattr(gu.settings, "GO_FRONTEND", cs.GoFrontend.TREESITTER)
+
+    updater._run_go_frontend()
+
+    assert dp.go_call_sites == {}
+    assert dp.go_external_sites == set()
+
+
+def test_auto_without_toolchain_matches_frontend_off(
+    temp_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The core invariant: with GO_FRONTEND=AUTO and no go toolchain, the CALLS
+    # graph must be byte-identical to a run with the frontend fully off, so a
+    # missing compiler degrades to today's tree-sitter graph, never worse.
+    # SEPARATE dirs: a second updater on the same path would no-op on the
+    # incremental hash cache and produce an empty (falsely-matching) graph.
+    auto_root = temp_repo / "goinvariant_auto"
+    off_root = temp_repo / "goinvariant_off"
+    for r in (auto_root, off_root):
+        r.mkdir()
+        (r / "go.mod").write_text("module example.com/inv\n\ngo 1.23\n")
+        (r / "sample.go").write_text(_AMBIGUOUS_SRC, encoding="utf-8")
+
+    from codebase_rag.parsers.frontends import go as go_fe
+
+    monkeypatch.setattr(go_fe, "go_frontend_available", lambda: False)
+    monkeypatch.setattr(gu.settings, "GO_FRONTEND", cs.GoFrontend.AUTO)
+    ingestor_auto = MagicMock()
+    run_updater(auto_root, ingestor_auto, skip_if_missing=SKIP)
+
+    monkeypatch.setattr(gu.settings, "GO_FRONTEND", cs.GoFrontend.TREESITTER)
+    ingestor_off = MagicMock()
+    run_updater(off_root, ingestor_off, skip_if_missing=SKIP)
+
+    def _local(pairs: set[tuple[str, str]]) -> set[tuple[str, str]]:
+        # Strip the differing project-root prefix so the two graphs compare.
+        return {(a.split(".", 1)[-1], b.split(".", 1)[-1]) for a, b in pairs}
+
+    assert _local(_pairs(ingestor_auto, "CALLS")) == _local(
+        _pairs(ingestor_off, "CALLS")
+    )
+
+
+_E2E_SRC = """package sample
+
+import "fmt"
+
+type Base struct{}
+
+func (b Base) Do() string { return "base" }
+
+type Outer struct {
+\tBase
+}
+
+func Run() {
+\to := Outer{}
+\t_ = o.Do()
+\tfmt.Println("x")
+}
+"""
+
+
+def test_gotypes_end_to_end_binds_promoted_call_through_real_facts(
+    temp_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # End-to-end with REAL facts (no synthetic maps): proves the tool's emitted
+    # line/col keys match tree-sitter node positions AND the Pass-2 name-alias
+    # registry. `o.Do()` is a promoted embedded-method call; the fact binds it to
+    # Base.Do, and `fmt.Println` is an external site (no first-party edge).
+    from codebase_rag.parsers.go_frontend import (
+        go_frontend_available,
+        run_go_frontend,
+    )
+
+    go = shutil.which("go")
+    if go is None or not go_frontend_available():
+        pytest.skip("go toolchain not available")
+    root = temp_repo / "goe2e"
+    root.mkdir()
+    (root / "go.mod").write_text("module example.com/e2e\n\ngo 1.23\n")
+    (root / "sample.go").write_text(_E2E_SRC, encoding="utf-8")
+
+    facts = run_go_frontend(root)
+    if not facts.call_sites:
+        pytest.skip("gotypes frontend could not build in this environment")
+
+    # Guard the linchpin: the emitted target col is the NAME-node position, not
+    # the func-keyword span start (they differ for Go).
+    do_key = next(k for k in facts.call_sites if k[3] == "Do")
+    do_target = facts.call_sites[do_key]
+    name_line, name_col = _byte_loc(_E2E_SRC, "Do() string")
+    assert (do_target.target_line, do_target.target_col) == (name_line, name_col)
+
+    monkeypatch.setattr(gu.settings, "GO_FRONTEND", cs.GoFrontend.GOTYPES)
+    ingestor = MagicMock()
+    run_updater(root, ingestor, skip_if_missing=SKIP)
+
+    calls = _pairs(ingestor, "CALLS")
+    assert _has(calls, "Run", "Base.Do"), calls
+    assert not any(ce.endswith("Println") for _, ce in calls), calls


### PR DESCRIPTION
## Summary

PR2 of the Go semantic frontend (#1179). PR1 shipped the producer (the bundled `gotypes` tool + `GoFrontend` registered as a `LanguageFrontend`); this PR **wires the consumer** so the facts actually change the graph:

- **Exact first-party call binding** — a `resolved_call_sites` fact binds a call to the compiler's exact callee (embedded-struct promotion, scope shadowing) the tree-sitter heuristic cannot type, keyed on the callee NAME token.
- **External-site suppression** — an `external_sites` fact proves the callee leaves the module, so the name-trie must not fabricate a first-party edge onto an unrelated same-named member.

Gated by a new `GO_FRONTEND` setting (`AUTO`/`TREESITTER`/`GOTYPES`, same AUTO-resolves-at-runtime semantics as C#), and folded into the parser fingerprint so go/non-go graphs never share identity.

## The load-bearing detail: an asymmetric target join

The **source** (call-site) key mirrors C# safely. The **target** (declaration) key does **not**: the `gotypes` tool emits `fn.Pos()` from `go/types` — the function/method **NAME identifier** position — but `function_locations` is keyed by `function_span_key` = the `func`-keyword `start_point` (col 0). C# gets away with reusing `function_locations` because Roslyn's declaration location coincides with tree-sitter's `method_declaration.start_point`; **for Go they do not coincide**, so a verbatim reuse would miss every target.

**Fix:** Pass 2 registers a second `function_locations` entry per Go decl keyed at the NAME token (`_register_go_name_alias`, for both free functions and methods). Name col ≠ 0, so it never collides with the span-key entry, and `FunctionLocations.drop_module` forgets it on incremental re-parse. The real-toolchain e2e asserts the emitted target col equals the tree-sitter **name-node** start, guarding this exact hazard.

## Invariant preserved

With `GO_FRONTEND` unset/`AUTO` and no go toolchain, both fact maps are empty, `resolve_go_call_site` returns `None` immediately, and every call falls back to today's Go resolver **with `call_point` preserved** — the graph is unchanged. A dedicated test asserts the AUTO-without-toolchain CALLS graph equals the frontend-off graph.

## Scope

`resolved_call_sites` + `external_sites` only. Interface-method dispatch, `base_kinds` (IMPLEMENTS), and method-value/func-value indirect calls are deferred to PR3 (the tool already emits only the two call families). Nested-module loading and the crash-safe build lock are tracked in #1227.

## Tests (`test_go_semantic_facts.py`)

Synthetic-facts wiring (no toolchain): the fact **overrides** the heuristic (fact→`B.Handle` beats the heuristic's default `A.Handle`); external-site suppression; watch-mode reset of the Go fact stores; and the AUTO/no-toolchain == frontend-off invariant. Plus a real-toolchain e2e (skips without go) binding a promoted embedded-method call through real facts and guarding the name-vs-func position join. All 88 existing Go tests still pass unchanged.

Closes #1179 (PR2 of the series).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable Go parsing modes: automatic, Tree-sitter, or Go’s type-aware analysis.
  - Improved Go call resolution for interfaces, promoted methods, and external calls.
  - Added automatic fallback to Tree-sitter when semantic analysis is unavailable.
  - Parser freshness checks now include Go analysis tools.

- **Bug Fixes**
  - Improved matching for Go methods and functions.
  - Prevented incorrect relationships for known external targets.

- **Tests**
  - Added coverage for semantic resolution, fallback behavior, stale facts, and external calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->