### PR TITLE
feat: infer TypeScript variable types from explicit annotations

### DIFF
--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -254,6 +254,11 @@ FIELD_FINALIZER = "finalizer"
 # body each iteration, so taint the body carries into it reaches the next one.
 FIELD_INCREMENT = "increment"
 
+# Generic container type names whose sole type argument is the element type,
+# so `Array<User>` annotates the variable as `User`, not `Array`.
+JS_ARRAY_TYPE_NAME = "Array"
+JS_READONLY_ARRAY_TYPE_NAME = "ReadonlyArray"
+
 # JS/TS module system node types
 TS_TYPE_ANNOTATION = "type_annotation"
 TS_IMPORT_ALIAS = "import_alias"

--- a/codebase_rag/constants/ast_nodes.py
+++ b/codebase_rag/constants/ast_nodes.py
@@ -242,6 +242,10 @@ TS_DO_STATEMENT = "do_statement"
 TS_BREAK_STATEMENT = "break_statement"
 TS_TYPE_DESCRIPTOR = "type_descriptor"
 TS_TYPE_IDENTIFIER = "type_identifier"
+# `User[]` in a type annotation: an element type followed by `[` `]`.
+TS_ARRAY_TYPE = "array_type"
+# The `<...>` argument list of a generic type (`Array<User>` -> `<User>`).
+TS_TYPE_ARGUMENTS = "type_arguments"
 
 TS_RETURN_STATEMENT = "return_statement"
 TS_RETURN = "return"

--- a/codebase_rag/parsers/js_ts/type_inference.py
+++ b/codebase_rag/parsers/js_ts/type_inference.py
@@ -43,6 +43,13 @@ if TYPE_CHECKING:
 
 _JS_DECLARATOR_QUERY = "(variable_declarator) @declarator"
 
+# Generic containers whose sole type argument IS the variable's element type,
+# so `Array<User>` infers `User` rather than the container `Array`. Every other
+# generic (`Map<string, User>`, `Promise<User>`) infers the container itself.
+_JS_ELEMENT_GENERICS = frozenset(
+    {cs.JS_ARRAY_TYPE_NAME, cs.JS_READONLY_ARRAY_TYPE_NAME}
+)
+
 
 class JsTypeInferenceEngine:
     __slots__ = (
@@ -100,60 +107,14 @@ class JsTypeInferenceEngine:
         if declarator_nodes is not None:
             for current in declarator_nodes:
                 declarator_count += 1
-                name_node = current.child_by_field_name("name")
-                value_node = current.child_by_field_name("value")
-                if name_node and value_node:
-                    var_name_text = name_node.text
-                    if var_name_text:
-                        var_name = safe_decode_text(name_node)
-                        if var_name is not None:
-                            logger.debug(
-                                ls.JS_VAR_DECLARATOR_FOUND,
-                                var_name=var_name,
-                                module_qn=module_qn,
-                            )
-                            if var_type := self._infer_js_variable_type_from_value(
-                                value_node, module_qn
-                            ):
-                                local_var_types[var_name] = var_type
-                                logger.debug(
-                                    ls.JS_VAR_INFERRED,
-                                    var_name=var_name,
-                                    var_type=var_type,
-                                )
-                            else:
-                                logger.debug(ls.JS_VAR_INFER_FAILED, var_name=var_name)
+                self._record_declarator_type(current, module_qn, local_var_types)
         else:
             stack: list[ASTNode] = [caller_node]
             while stack:
                 current = stack.pop()
                 if current.type == cs.TS_VARIABLE_DECLARATOR:
                     declarator_count += 1
-                    name_node = current.child_by_field_name("name")
-                    value_node = current.child_by_field_name("value")
-                    if name_node and value_node:
-                        var_name_text = name_node.text
-                        if var_name_text:
-                            var_name = safe_decode_text(name_node)
-                            if var_name is not None:
-                                logger.debug(
-                                    ls.JS_VAR_DECLARATOR_FOUND,
-                                    var_name=var_name,
-                                    module_qn=module_qn,
-                                )
-                                if var_type := self._infer_js_variable_type_from_value(
-                                    value_node, module_qn
-                                ):
-                                    local_var_types[var_name] = var_type
-                                    logger.debug(
-                                        ls.JS_VAR_INFERRED,
-                                        var_name=var_name,
-                                        var_type=var_type,
-                                    )
-                                else:
-                                    logger.debug(
-                                        ls.JS_VAR_INFER_FAILED, var_name=var_name
-                                    )
+                    self._record_declarator_type(current, module_qn, local_var_types)
                 stack.extend(reversed(current.children))
 
         logger.debug(
@@ -162,6 +123,102 @@ class JsTypeInferenceEngine:
             declarator_count=declarator_count,
         )
         return local_var_types
+
+    def _record_declarator_type(
+        self, declarator: ASTNode, module_qn: str, local_var_types: dict[str, str]
+    ) -> None:
+        name_node = declarator.child_by_field_name(cs.FIELD_NAME)
+        if name_node is None or not name_node.text:
+            return
+        var_name = safe_decode_text(name_node)
+        if var_name is None:
+            return
+        logger.debug(ls.JS_VAR_DECLARATOR_FOUND, var_name=var_name, module_qn=module_qn)
+
+        var_type: str | None = None
+        value_node = declarator.child_by_field_name(cs.FIELD_VALUE)
+        if value_node is not None:
+            var_type = self._infer_js_variable_type_from_value(value_node, module_qn)
+        # The explicit annotation is the fallback: `const u: User = maybe()`
+        # types `u` even when the initialiser's own type cannot be inferred,
+        # and `let u: User;` has no initialiser to read at all.
+        if var_type is None:
+            type_node = declarator.child_by_field_name(cs.FIELD_TYPE)
+            if type_node is not None:
+                var_type = self._infer_js_variable_type_from_annotation(
+                    type_node, module_qn
+                )
+
+        if var_type is not None:
+            local_var_types[var_name] = var_type
+            logger.debug(ls.JS_VAR_INFERRED, var_name=var_name, var_type=var_type)
+        else:
+            logger.debug(ls.JS_VAR_INFER_FAILED, var_name=var_name)
+
+    def _infer_js_variable_type_from_annotation(
+        self, type_annotation_node: ASTNode, module_qn: str
+    ) -> str | None:
+        type_node = self._annotation_type_node(type_annotation_node)
+        if type_node is None:
+            return None
+        element_name = self._annotation_element_name(type_node)
+        if element_name is None:
+            return None
+        class_qn = self._resolve_js_class_name(element_name, module_qn)
+        return class_qn or element_name
+
+    @staticmethod
+    def _annotation_type_node(type_annotation_node: ASTNode) -> ASTNode | None:
+        # A `type_annotation` is `: <type>`; the type is its first child that is
+        # itself a type node (skipping the `:` token).
+        for child in type_annotation_node.children:
+            if child.type in (
+                cs.TS_TYPE_IDENTIFIER,
+                cs.TS_ARRAY_TYPE,
+                cs.TS_GENERIC_TYPE,
+            ):
+                return child
+        return None
+
+    def _annotation_element_name(self, type_node: ASTNode) -> str | None:
+        node_type = type_node.type
+        if node_type == cs.TS_TYPE_IDENTIFIER:
+            return safe_decode_text(type_node)
+        if node_type == cs.TS_ARRAY_TYPE:
+            # `User[]` -> `User`; a primitive element (`string[]`) has no
+            # class to resolve, so it is left uninferred.
+            return self._first_type_identifier(type_node)
+        if node_type == cs.TS_GENERIC_TYPE:
+            return self._generic_element_name(type_node)
+        return None
+
+    def _generic_element_name(self, generic_node: ASTNode) -> str | None:
+        container: ASTNode | None = None
+        type_arguments: ASTNode | None = None
+        for child in generic_node.children:
+            if child.type == cs.TS_TYPE_IDENTIFIER and container is None:
+                container = child
+            elif child.type == cs.TS_TYPE_ARGUMENTS:
+                type_arguments = child
+        if container is None:
+            return None
+        container_name = safe_decode_text(container)
+        if container_name in _JS_ELEMENT_GENERICS and type_arguments is not None:
+            arguments = [
+                child
+                for child in type_arguments.children
+                if child.type == cs.TS_TYPE_IDENTIFIER
+            ]
+            if len(arguments) == 1:
+                return safe_decode_text(arguments[0])
+        return container_name
+
+    @staticmethod
+    def _first_type_identifier(node: ASTNode) -> str | None:
+        for child in node.children:
+            if child.type == cs.TS_TYPE_IDENTIFIER:
+                return safe_decode_text(child)
+        return None
 
     def _infer_js_variable_type_from_value(
         self, value_node: ASTNode, module_qn: str

--- a/codebase_rag/tests/test_js_type_inference_unit.py
+++ b/codebase_rag/tests/test_js_type_inference_unit.py
@@ -58,6 +58,46 @@ def create_call_expression_with_member(object_name: str, method_name: str) -> Mo
     )
 
 
+def create_type_identifier(name: str) -> MockNode:
+    return create_mock_node(cs.TS_TYPE_IDENTIFIER, name)
+
+
+def create_type_annotation(type_node: MockNode) -> MockNode:
+    colon = create_mock_node(":", ":")
+    return create_mock_node(cs.TS_TYPE_ANNOTATION, children=[colon, type_node])
+
+
+def create_array_type(element_node: MockNode) -> MockNode:
+    open_bracket = create_mock_node("[", "[")
+    close_bracket = create_mock_node("]", "]")
+    return create_mock_node(
+        cs.TS_ARRAY_TYPE, children=[element_node, open_bracket, close_bracket]
+    )
+
+
+def create_generic_type(container_name: str, arg_nodes: list[MockNode]) -> MockNode:
+    container = create_type_identifier(container_name)
+    type_arguments = create_mock_node(cs.TS_TYPE_ARGUMENTS, children=arg_nodes)
+    return create_mock_node(cs.TS_GENERIC_TYPE, children=[container, type_arguments])
+
+
+def create_declarator_with_annotation(
+    var_name: str,
+    type_node: MockNode,
+    value_node: MockNode | None = None,
+) -> MockNode:
+    name_node = create_mock_node(cs.TS_IDENTIFIER, var_name)
+    annotation = create_type_annotation(type_node)
+    children = [name_node, annotation]
+    if value_node is not None:
+        children.append(value_node)
+    return create_mock_node(
+        cs.TS_VARIABLE_DECLARATOR,
+        fields={"name": name_node, "type": annotation, "value": value_node},
+        children=children,
+    )
+
+
 @pytest.fixture
 def mock_import_processor() -> MagicMock:
     processor = MagicMock(spec=ImportProcessor)
@@ -428,6 +468,161 @@ class TestBuildLocalVariableTypeMap:
         )
 
         assert result == {}
+
+
+class TestInferJsVariableTypeFromAnnotation:
+    def test_plain_type_identifier_returns_name(
+        self,
+        js_type_engine: JsTypeInferenceEngine,
+    ) -> None:
+        annotation = create_type_annotation(create_type_identifier("User"))
+
+        result = js_type_engine._infer_js_variable_type_from_annotation(
+            annotation,  # ty: ignore[invalid-argument-type]  # MockNode not Node
+            "myapp.main",
+        )
+
+        assert result == "User"
+
+    def test_array_type_returns_element_name(
+        self,
+        js_type_engine: JsTypeInferenceEngine,
+    ) -> None:
+        annotation = create_type_annotation(
+            create_array_type(create_type_identifier("User"))
+        )
+
+        result = js_type_engine._infer_js_variable_type_from_annotation(
+            annotation,  # ty: ignore[invalid-argument-type]  # MockNode not Node
+            "myapp.main",
+        )
+
+        assert result == "User"
+
+    def test_array_element_resolves_class_qn(
+        self,
+        js_type_engine: JsTypeInferenceEngine,
+        mock_function_registry: MagicMock,
+    ) -> None:
+        mock_function_registry.__contains__ = MagicMock(
+            side_effect=lambda x: x == "myapp.main.User"
+        )
+        mock_function_registry.__getitem__ = MagicMock(return_value=NodeType.CLASS)
+        annotation = create_type_annotation(
+            create_array_type(create_type_identifier("User"))
+        )
+
+        result = js_type_engine._infer_js_variable_type_from_annotation(
+            annotation,  # ty: ignore[invalid-argument-type]  # MockNode not Node
+            "myapp.main",
+        )
+
+        assert result == "myapp.main.User"
+
+    def test_generic_array_returns_element_name(
+        self,
+        js_type_engine: JsTypeInferenceEngine,
+    ) -> None:
+        annotation = create_type_annotation(
+            create_generic_type("Array", [create_type_identifier("User")])
+        )
+
+        result = js_type_engine._infer_js_variable_type_from_annotation(
+            annotation,  # ty: ignore[invalid-argument-type]  # MockNode not Node
+            "myapp.main",
+        )
+
+        assert result == "User"
+
+    def test_non_element_generic_returns_container_name(
+        self,
+        js_type_engine: JsTypeInferenceEngine,
+    ) -> None:
+        annotation = create_type_annotation(
+            create_generic_type(
+                "Map",
+                [create_type_identifier("string"), create_type_identifier("User")],
+            )
+        )
+
+        result = js_type_engine._infer_js_variable_type_from_annotation(
+            annotation,  # ty: ignore[invalid-argument-type]  # MockNode not Node
+            "myapp.main",
+        )
+
+        assert result == "Map"
+
+    def test_primitive_array_element_is_uninferrable(
+        self,
+        js_type_engine: JsTypeInferenceEngine,
+    ) -> None:
+        annotation = create_type_annotation(
+            create_array_type(create_mock_node("predefined_type", "string"))
+        )
+
+        result = js_type_engine._infer_js_variable_type_from_annotation(
+            annotation,  # ty: ignore[invalid-argument-type]  # MockNode not Node
+            "myapp.main",
+        )
+
+        assert result is None
+
+
+class TestBuildLocalVariableTypeMapFromAnnotations:
+    def test_annotation_types_variable_without_value(
+        self,
+        js_type_engine: JsTypeInferenceEngine,
+    ) -> None:
+        var_decl = create_declarator_with_annotation(
+            "names", create_array_type(create_type_identifier("User"))
+        )
+        root_node = create_mock_node("program", children=[var_decl])
+
+        result = js_type_engine.build_local_variable_type_map(
+            root_node,  # ty: ignore[invalid-argument-type]  # MockNode not Node
+            "myapp.main",
+        )
+
+        assert result == {"names": "User"}
+
+    def test_value_inference_takes_precedence_over_annotation(
+        self,
+        js_type_engine: JsTypeInferenceEngine,
+    ) -> None:
+        # `const x: Base = new Derived()` — the constructed type is more
+        # specific than the declared one, so the value wins.
+        var_decl = create_declarator_with_annotation(
+            "instance",
+            create_type_identifier("Base"),
+            value_node=create_new_expression("Derived"),
+        )
+        root_node = create_mock_node("program", children=[var_decl])
+
+        result = js_type_engine.build_local_variable_type_map(
+            root_node,  # ty: ignore[invalid-argument-type]  # MockNode not Node
+            "myapp.main",
+        )
+
+        assert result == {"instance": "Derived"}
+
+    def test_annotation_is_fallback_when_value_uninferrable(
+        self,
+        js_type_engine: JsTypeInferenceEngine,
+    ) -> None:
+        string_literal = create_mock_node("string_literal", "hello")
+        var_decl = create_declarator_with_annotation(
+            "user",
+            create_type_identifier("User"),
+            value_node=string_literal,
+        )
+        root_node = create_mock_node("program", children=[var_decl])
+
+        result = js_type_engine.build_local_variable_type_map(
+            root_node,  # ty: ignore[invalid-argument-type]  # MockNode not Node
+            "myapp.main",
+        )
+
+        assert result == {"user": "User"}
 
 
 class TestGetDeclaratorsViaQueryException:


### PR DESCRIPTION
## Summary

- Infer a JS/TS local variable's type from its **explicit type annotation** when the initializer can't be typed (`const u: User = maybe()`, `let names: User[];`).
- Unwrap the **element type** of `User[]` and `Array<T>`/`ReadonlyArray<T>` annotations; other generics (`Map<…>`, `Promise<…>`) resolve to the container name.
- Extracted names flow through the existing `_resolve_js_class_name`, so results are class QNs where resolvable, bare names otherwise — matching the value-based path, which still takes precedence.

## Type of Change

- [x] New feature

## Related Issues

Addresses the TypeScript "Parse Type Annotations" and "Extract Element Type from Array/Generic Types" gaps in `docs/TODO.md`. No dedicated tracking issue; related to #1180.

## Test Plan

- [x] Unit tests pass (`uv run pytest -n auto -m "not integration"`)
- [x] New tests added
- [x] Integration tests pass (`make test-integration`, requires Docker) — 296 passed, 8 skipped
- [x] Manual testing (verified array/generic/plain-identifier annotations against the tree-sitter-typescript grammar)

New unit tests in `codebase_rag/tests/test_js_type_inference_unit.py`:
- `TestInferJsVariableTypeFromAnnotation` — plain identifier, `User[]`, `Array<User>`, non-element generic (`Map`), QN resolution, primitive-element non-inference.
- `TestBuildLocalVariableTypeMapFromAnnotations` — annotation types a value-less declarator, value wins over annotation, annotation is the fallback for an uninferrable value.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] All pre-commit checks pass (ruff, ruff-format, ty on changed files, bandit, conventional + single-line commit message)
- [x] No hardcoded strings in non-config/non-constants files (`Array`/`ReadonlyArray` live in `constants/ast_js.py`)
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [ ] No new comments or docstrings — added why/how comments consistent with this file and recent merged commits (per CONTRIBUTING's Comment Policy)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved TypeScript type inference from variable annotations.
  * Added support for identifying plain types, arrays, and generic `Array`/`ReadonlyArray` types.
  * Preserved value-based inference when both an initializer and annotation are available.
  * Added fallback to annotations when initializer-based inference is unavailable.

* **Tests**
  * Expanded coverage for annotated declarations, arrays, generic types, class names, and unsupported primitive arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->