### PR TITLE
feat: consume Go types.Implements facts as IMPLEMENTS edges and sole-impl dispatch

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -521,7 +521,10 @@ class GraphUpdater:
                 continue
             impl_qn, impl_label = impl
             iface_qn, iface_label = iface
-            self.ingestor.ensure_relationship_batch(
+            # Through _sink (the capture-filtering wrapper), not the raw
+            # ingestor, so a capture that disables IMPLEMENTS suppresses this
+            # edge too -- graph-element emission must honour the capture contract.
+            self._sink.ensure_relationship_batch(
                 (impl_label, cs.KEY_QUALIFIED_NAME, impl_qn),
                 cs.RelationshipType.IMPLEMENTS,
                 (iface_label, cs.KEY_QUALIFIED_NAME, iface_qn),

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -490,11 +490,46 @@ class GraphUpdater:
         dp = self.factory.definition_processor
         dp.go_call_sites.clear()
         dp.go_external_sites.clear()
+        dp.go_implements.clear()
 
     def _apply_go_semantic_facts(self, facts: SemanticFacts) -> None:
         dp = self.factory.definition_processor
         dp.go_call_sites.update(facts.resolved_call_sites)
         dp.go_external_sites.update(facts.external_sites)
+        dp.go_implements.extend(facts.implements_pairs)
+
+    def _join_go_implements(self) -> None:
+        # go/types proved each implementer->interface pair structurally; both
+        # ends carry a declaring-identifier position that resolves to the Pass-2
+        # type node through go_type_locations. On a two-sided hit, emit the
+        # IMPLEMENTS edge and record the implementer so a call through the
+        # interface with a SOLE implementer also edges to the concrete method
+        # (resolver.interface_sole_impl_targets, no extra wiring). A miss on
+        # either end drops the pair rather than risk a dangling edge.
+        dp = self.factory.definition_processor
+        if not dp.go_implements:
+            return
+        emitted = 0
+        for pair in dp.go_implements:
+            impl = dp.go_type_locations.get(
+                (pair.impl_file, pair.impl_line, pair.impl_col)
+            )
+            iface = dp.go_type_locations.get(
+                (pair.iface_file, pair.iface_line, pair.iface_col)
+            )
+            if impl is None or iface is None:
+                continue
+            impl_qn, impl_label = impl
+            iface_qn, iface_label = iface
+            self.ingestor.ensure_relationship_batch(
+                (impl_label, cs.KEY_QUALIFIED_NAME, impl_qn),
+                cs.RelationshipType.IMPLEMENTS,
+                (iface_label, cs.KEY_QUALIFIED_NAME, iface_qn),
+            )
+            dp.interface_implementers.setdefault(iface_qn, set()).add(impl_qn)
+            emitted += 1
+        if emitted:
+            logger.info(ls.GO_FRONTEND_IMPLEMENTS_JOINED.format(count=emitted))
 
     def _join_csharp_partials(self) -> None:
         # Replace the directory-keyed syntactic partial grouping with the
@@ -722,6 +757,10 @@ class GraphUpdater:
         # Partial groups join AFTER Pass 2: the Roslyn declaration
         # locations resolve against the Class qns Pass 2 just registered.
         self._join_csharp_partials()
+
+        # Go IMPLEMENTS pairs join AFTER Pass 2 for the same reason: both ends
+        # resolve against the go_type_locations index Pass 2 just registered.
+        self._join_go_implements()
 
         # HYBRID must run after Pass 2: an incremental run deletes each
         # changed file's Module subtree before re-parsing it, so macro

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -70,6 +70,9 @@ GO_FRONTEND_AUTO_FALLBACK = "Go frontend AUTO: go not found; using tree-sitter o
 GO_FRONTEND_FACTS = (
     "Go go/types frontend facts: {calls} call site(s), {externals} external site(s)"
 )
+GO_FRONTEND_IMPLEMENTS_JOINED = (
+    "Go go/types frontend: {count} IMPLEMENTS edge(s) joined to Pass-2 type nodes"
+)
 GO_FRONTEND_BUILD_FAILED = (
     "Go frontend tool failed to build; using tree-sitter.\nstderr: {stderr}"
 )

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -173,6 +173,7 @@ class ClassIngestMixin:
     csharp_extension_methods: dict[str, list[tuple[str, str, str, int]]]
     csharp_base_kinds: dict[tuple[str, int], dict[str, str]]
     csharp_type_locations: dict[tuple[str, int], str]
+    go_type_locations: dict[tuple[str, int, int], tuple[str, str]]
     class_field_guard_inner: dict[str, dict[str, str]]
     class_field_element_types: dict[str, dict[str, str]]
     method_return_types: dict[str, str]
@@ -1115,6 +1116,17 @@ class ClassIngestMixin:
                 csharp_base_kinds = self.csharp_base_kinds.get(
                     (rel_path, class_start_line)
                 )
+        elif language == cs.SupportedLanguage.GO and file_path is not None:
+            # Reverse index for the go/types frontend's implements facts: each
+            # ImplementsPair end (a declaring identifier position) joins back to
+            # this type's qn + node label after Pass 2. A Go type_spec's
+            # start_point IS the name token, so the position matches directly --
+            # no name alias (unlike Go funcs, keyed at the func keyword).
+            rel_path = cached_relative_path(file_path, self.repo_path).as_posix()
+            self.go_type_locations[(rel_path, class_start_line, class_start_col)] = (
+                class_qn,
+                str(node_type),
+            )
         rel.create_class_relationships(
             member_node,
             class_qn,

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -27,7 +27,7 @@ from .cpp import CppTypeInferenceEngine
 from .cpp.preproc_recovery import parse_with_preproc_recovery
 from .csharp_frontend import CallSiteKey
 from .dependency_parser import parse_dependencies
-from .frontends.protocol import ResolvedCallSite
+from .frontends.protocol import ImplementsPair, ResolvedCallSite
 from .function_ingest import FunctionIngestMixin
 from .go import utils as go_utils
 from .handlers import get_handler
@@ -165,6 +165,14 @@ class DefinitionProcessor(
         # engine holds the reference.
         self.go_call_sites: dict[CallSiteKey, ResolvedCallSite] = {}
         self.go_external_sites: set[CallSiteKey] = set()
+        # go/types-proven implementer->interface pairs (each end a declaring
+        # identifier position), stashed here at frontend time and resolved to
+        # IMPLEMENTS edges after Pass 2 fills go_type_locations below.
+        self.go_implements: list[ImplementsPair] = []
+        # (rel_file, type_start_line, type_start_col) -> (class qn, node label)
+        # for every ingested Go type. Go's type_spec start_point IS the name
+        # token, so the frontend's pair positions join here directly (no alias).
+        self.go_type_locations: dict[tuple[str, int, int], tuple[str, str]] = {}
         # (rel_file, type_start_line) -> class qn for every ingested C# type,
         # the reverse of the Roslyn fact keys, so partial declaration groups
         # join back to the Pass-2 Class nodes.

--- a/codebase_rag/tests/test_go_semantic_facts.py
+++ b/codebase_rag/tests/test_go_semantic_facts.py
@@ -13,7 +13,8 @@ import pytest
 
 from codebase_rag import constants as cs
 from codebase_rag import graph_updater as gu
-from codebase_rag.parsers.go_frontend import GoCallSite, GoSemanticFacts
+from codebase_rag.parsers.frontends.protocol import ImplementsPair
+from codebase_rag.parsers.go_frontend import GoCallSite, GoImplements, GoSemanticFacts
 from codebase_rag.tests.conftest import get_relationships, run_updater
 
 SKIP = "go"
@@ -167,12 +168,14 @@ def test_frontend_off_clears_stale_go_facts(
         "Old", "stale.go", 2, 0
     )
     dp.go_external_sites.add(("stale.go", 3, 0, "Ext"))
+    dp.go_implements.append(ImplementsPair("stale.go", 4, 0, "stale.go", 5, 0))
     monkeypatch.setattr(gu.settings, "GO_FRONTEND", cs.GoFrontend.TREESITTER)
 
     updater._run_go_frontend()
 
     assert dp.go_call_sites == {}
     assert dp.go_external_sites == set()
+    assert dp.go_implements == []
 
 
 def test_auto_without_toolchain_matches_frontend_off(
@@ -268,3 +271,106 @@ def test_gotypes_end_to_end_binds_promoted_call_through_real_facts(
     calls = _pairs(ingestor, "CALLS")
     assert _has(calls, "Run", "Base.Do"), calls
     assert not any(ce.endswith("Println") for _, ce in calls), calls
+
+
+_IMPLEMENTS_SRC = """package sample
+
+type Speaker interface{ Speak() string }
+
+type Dog struct{}
+
+func (d Dog) Speak() string { return "woof" }
+
+func Run(s Speaker) {
+\t_ = s.Speak()
+}
+"""
+
+
+def _impl_facts(implements: list[GoImplements]) -> GoSemanticFacts:
+    return GoSemanticFacts(call_sites={}, external_sites=set(), implements=implements)
+
+
+def test_implements_fact_emits_edge_to_the_pass2_type_nodes(
+    temp_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A go/types implements pair joins to the Pass-2 type nodes (positions match
+    # the ingested type_spec start, which is the NAME token for Go types) and
+    # emits an IMPLEMENTS edge from the struct to the interface it satisfies.
+    root = temp_repo / "goimpl"
+    root.mkdir()
+    (root / "go.mod").write_text("module example.com/impl\n\ngo 1.23\n")
+    (root / "sample.go").write_text(_IMPLEMENTS_SRC, encoding="utf-8")
+
+    dog_line, dog_col = _byte_loc(_IMPLEMENTS_SRC, "Dog struct")
+    spk_line, spk_col = _byte_loc(_IMPLEMENTS_SRC, "Speaker interface")
+    facts = _impl_facts(
+        [GoImplements("sample.go", dog_line, dog_col, "sample.go", spk_line, spk_col)]
+    )
+    _gotypes(monkeypatch, facts)
+
+    ingestor = MagicMock()
+    run_updater(root, ingestor, skip_if_missing=SKIP)
+
+    assert _has(_pairs(ingestor, "IMPLEMENTS"), "Dog", "Speaker"), _pairs(
+        ingestor, "IMPLEMENTS"
+    )
+    # The payoff comes free: populating interface_implementers makes the
+    # `s.Speak()` call through the interface ALSO edge to the sole concrete
+    # implementer's method (resolver.interface_sole_impl_targets).
+    assert _has(_pairs(ingestor, "CALLS"), "Run", "Dog.Speak"), _pairs(
+        ingestor, "CALLS"
+    )
+
+
+def test_implements_position_miss_drops_the_edge(
+    temp_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A pair whose implementer position matches no ingested type node is dropped
+    # rather than emitted as a dangling IMPLEMENTS edge.
+    root = temp_repo / "goimplmiss"
+    root.mkdir()
+    (root / "go.mod").write_text("module example.com/miss\n\ngo 1.23\n")
+    (root / "sample.go").write_text(_IMPLEMENTS_SRC, encoding="utf-8")
+
+    spk_line, spk_col = _byte_loc(_IMPLEMENTS_SRC, "Speaker interface")
+    facts = _impl_facts(
+        [GoImplements("sample.go", 999, 0, "sample.go", spk_line, spk_col)]
+    )
+    _gotypes(monkeypatch, facts)
+
+    ingestor = MagicMock()
+    run_updater(root, ingestor, skip_if_missing=SKIP)
+
+    assert not _has(_pairs(ingestor, "IMPLEMENTS"), "Dog", "Speaker")
+
+
+def test_gotypes_end_to_end_emits_implements_from_real_facts(
+    temp_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # End-to-end with REAL facts: the tool's emitted implements positions match
+    # the ingested Go type nodes, so the Dog -> Speaker IMPLEMENTS edge lands
+    # with no synthetic maps.
+    from codebase_rag.parsers.go_frontend import (
+        go_frontend_available,
+        run_go_frontend,
+    )
+
+    go = shutil.which("go")
+    if go is None or not go_frontend_available():
+        pytest.skip("go toolchain not available")
+    root = temp_repo / "goimple2e"
+    root.mkdir()
+    (root / "go.mod").write_text("module example.com/imple2e\n\ngo 1.23\n")
+    (root / "sample.go").write_text(_IMPLEMENTS_SRC, encoding="utf-8")
+
+    if not run_go_frontend(root).implements:
+        pytest.skip("gotypes frontend could not build in this environment")
+
+    monkeypatch.setattr(gu.settings, "GO_FRONTEND", cs.GoFrontend.GOTYPES)
+    ingestor = MagicMock()
+    run_updater(root, ingestor, skip_if_missing=SKIP)
+
+    assert _has(_pairs(ingestor, "IMPLEMENTS"), "Dog", "Speaker"), _pairs(
+        ingestor, "IMPLEMENTS"
+    )


### PR DESCRIPTION
## What

The consumer half of the Go IMPLEMENTS feature (#1179), completing the producer merged in #1234. The `gotypes` frontend already emits `SemanticFacts.implements_pairs` (compiler-proven implementer→interface position pairs); this PR turns them into **IMPLEMENTS graph edges** — the only source of Go IMPLEMENTS relationships, since Go interfaces are satisfied structurally with no syntactic base list to read.

The payoff comes **for free**: populating `interface_implementers` makes a call through an interface with a *sole* concrete implementer also edge to that implementer's method, via the existing `resolver.interface_sole_impl_targets` — no resolver or call-processor changes.

## How

- **`definition_processor.py`**: two new fields — `go_implements` (the stashed pairs) and `go_type_locations` (`(rel_file, line, col) → (qn, node label)` for every ingested Go type).
- **`class_ingest/mixin.py`**: in `_process_class_node`, a Go branch records each `type_spec`'s `(rel_file, start_line, start_col) → (qn, label)`. **No name-position alias is needed** (unlike Go functions): a Go `type_spec`'s `start_point` *is* the name token, so the producer's pair positions join directly — verified against the repo's own tree-sitter-go parser.
- **`graph_updater.py`**: `_apply_go_semantic_facts` stashes the pairs and `_reset_go_semantic_facts` clears them (watch-safe); a new `_join_go_implements` runs **after Pass 2** (mirroring `_join_csharp_partials`, since the frontend loads before Pass 2 and the type-location index fills *during* it). It resolves both ends, emits `IMPLEMENTS`, and records `interface_implementers`. A miss on either end drops the pair rather than emit a dangling edge.

## Tests (`test_go_semantic_facts.py`)

- `test_implements_fact_emits_edge_to_the_pass2_type_nodes` — synthetic pair → `IMPLEMENTS Dog→Speaker`, **and** the free `Run→Dog.Speak` sole-impl dispatch edge.
- `test_implements_position_miss_drops_the_edge` — an unmatched position emits nothing.
- `test_gotypes_end_to_end_emits_implements_from_real_facts` — real toolchain, no synthetic maps.
- `test_frontend_off_clears_stale_go_facts` extended to cover `go_implements` reset.

Refs #1179.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Go code analysis now recognizes verified interface implementations.
  * Interface method calls can be resolved through their implementing types.
  * Processing logs report the number of implementation relationships detected.

* **Bug Fixes**
  * Invalid or unmatched implementation facts are excluded from results.
  * Stale Go implementation data is cleared when Go analysis is disabled.

* **Tests**
  * Added coverage for successful joins, call resolution, position mismatches, and toolchain-generated facts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->