### PR TITLE
feat: build orchestrator prompt sections conditionally on registered tools

### DIFF
--- a/codebase_rag/prompts.py
+++ b/codebase_rag/prompts.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from loguru import logger
@@ -26,11 +28,19 @@ if TYPE_CHECKING:
     from pydantic_ai import Tool
 
 
-def extract_tool_names(tools: list["Tool"]) -> ToolNames:
+PROMPT_OPTIONAL_TOOLS = frozenset({AgenticToolName.SEMANTIC_SEARCH})
+
+
+def extract_registered_tools(tools: list[Tool]) -> frozenset[AgenticToolName]:
+    registered = {t.name for t in tools}
+    return frozenset(name for name in AgenticToolName if name in registered)
+
+
+def extract_tool_names(tools: list[Tool]) -> ToolNames:
     registered = {t.name for t in tools}
 
     def resolve_tool_name(canonical: AgenticToolName) -> str:
-        if canonical not in registered:
+        if canonical not in registered and canonical not in PROMPT_OPTIONAL_TOOLS:
             logger.warning(
                 f"Tool '{canonical}' is not registered on the agent; "
                 "the orchestrator prompt references it anyway"
@@ -129,42 +139,26 @@ def _format_active_projects_block(active_projects: list[str] | None) -> str:
     )
 
 
-def build_rag_orchestrator_prompt(
-    tools: list["Tool"],
-    project_instructions: str | None = None,
-    active_projects: list[str] | None = None,
+ENTRY_POINT_RECOGNITION_PATTERNS = """       **Entry Point Recognition Patterns**:
+       - Python: `if __name__ == "__main__"`, `main()` function, CLI scripts, `app.run()`
+       - JavaScript/TypeScript: `index.js`, `main.ts`, `app.js`, `server.js`, package.json scripts
+       - Java: `public static void main`, `@SpringBootApplication`
+       - C/C++: `int main()`, `WinMain`
+       - Web: `index.html`, routing configurations, startup middleware"""
+
+
+def _build_search_strategy_section(
+    t: ToolNames, semantic_search_registered: bool
 ) -> str:
-    t = extract_tool_names(tools)
-    base = f"""You are an expert AI assistant for analyzing codebases. Your answers are based **EXCLUSIVELY** on information retrieved using your tools.
-
-**CRITICAL RULES:**
-1.  **TOOL-ONLY ANSWERS**: You must ONLY use information from the tools provided. Do not use external knowledge.
-2.  **NATURAL LANGUAGE QUERIES**: When using the `{t.query_graph}` tool, ALWAYS use natural language questions. NEVER write Cypher queries directly - the tool will translate your natural language into the appropriate database query.
-3.  **HONESTY**: If a tool fails or returns no results, you MUST state that clearly and report any error messages. Do not invent answers.
-4.  **CHOOSE THE RIGHT TOOL FOR THE FILE TYPE**:
-    - For source code files (.py, .ts, etc.), use `{t.read_file}`.
-    - Images and PDFs the user references are attached inline to the message; read them directly from your own multimodal input.
-
-**Your General Approach:**
-1.  **Inspect Attached Media Directly**: When the user attaches an image or PDF, analyze it from the inline content of the message. Do not call a tool for it.
-2.  **Deep Dive into Code**: When you identify a relevant component (e.g., a folder), you must go beyond documentation.
-    a. First, check if documentation files like `README.md` exist and read them for context. For configuration, look for files appropriate to the language (e.g., `pyproject.toml` for Python, `package.json` for Node.js).
-    b. **Then, you MUST dive into the source code.** Explore the `src` directory (or equivalent). Identify and read key files (e.g., `main.py`, `index.ts`, `app.ts`) to understand the implementation details, logic, and functionality.
-    c. Synthesize all this information—from documentation, configuration, and the code itself—to provide a comprehensive, factual answer. Do not just describe the files; explain what the code *does*.
-    d. Only ask for clarification if, after a thorough investigation, the user's intent is still unclear.
-3.  **Choose the Right Search Strategy - SEMANTIC FIRST for Intent**:
+    if semantic_search_registered:
+        return f"""3.  **Choose the Right Search Strategy - SEMANTIC FIRST for Intent**:
     a. **WHEN TO USE SEMANTIC SEARCH FIRST**: Always start with `{t.semantic_search}` for ANY of these patterns:
        - "main entry point", "startup", "initialization", "bootstrap", "launcher"
        - "error handling", "validation", "authentication"
        - "where is X done", "how does Y work", "find Z logic"
        - Any question about PURPOSE, INTENT, or FUNCTIONALITY
 
-       **Entry Point Recognition Patterns**:
-       - Python: `if __name__ == "__main__"`, `main()` function, CLI scripts, `app.run()`
-       - JavaScript/TypeScript: `index.js`, `main.ts`, `app.js`, `server.js`, package.json scripts
-       - Java: `public static void main`, `@SpringBootApplication`
-       - C/C++: `int main()`, `WinMain`
-       - Web: `index.html`, routing configurations, startup middleware
+{ENTRY_POINT_RECOGNITION_PATTERNS}
 
     b. **WHEN TO USE GRAPH DIRECTLY**: Only use `{t.query_graph}` directly for pure structural queries:
        - "What does function X call?" (when you already know X's name)
@@ -183,24 +177,92 @@ def build_rag_orchestrator_prompt(
        3. `{t.read_file}` for main.py with targeted sections (use offset/limit for large files)
        4. Look for the true application entry point (main function, __main__ block, CLI commands)
        5. If you find CLI frameworks (typer, click, argparse), read relevant command sections only
-       6. Summarize execution flow concisely rather than showing all details
+       6. Summarize execution flow concisely rather than showing all details"""
+    return f"""3.  **Choose the Right Search Strategy - GRAPH FIRST**:
+    a. **START WITH THE GRAPH**: Use `{t.query_graph}` with natural language questions for structural and exploratory queries alike:
+       - "What does function X call?" (when you already know X's name)
+       - "List methods of User class" (when you know the exact class name)
+       - "Show files in folder Y" (when you know the exact folder path)
+       - For questions about PURPOSE, INTENT, or FUNCTIONALITY ("main entry point", "error handling", "where is X done"), query for the names, keywords, or decorators the code likely uses, then read the candidates.
+
+{ENTRY_POINT_RECOGNITION_PATTERNS}
+
+    b. **RECOMMENDED SEQUENCE**: For most queries, use this sequence:
+       1. Use `{t.query_graph}` to locate relevant code elements by name, keyword, or relationship
+       2. **CRITICAL**: Always read the actual files using `{t.read_file}` to examine source code
+       3. For entry points specifically: Look for `if __name__ == "__main__"`, `main()` functions, or CLI entry points
+
+    c. **Tool Chaining Example**: For "main entry point and what it calls":
+       1. `{t.query_graph}` to find candidate entry points (e.g., functions named `main` or CLI command functions)
+       2. `{t.query_graph}` to find specific function relationships
+       3. `{t.read_file}` for main.py with targeted sections (use offset/limit for large files)
+       4. Look for the true application entry point (main function, __main__ block, CLI commands)
+       5. If you find CLI frameworks (typer, click, argparse), read relevant command sections only
+       6. Summarize execution flow concisely rather than showing all details"""
+
+
+def _build_candidate_discovery_step(semantic_search_registered: bool) -> str:
+    if semantic_search_registered:
+        return "Find candidate functions via semantic search"
+    return "Find candidate functions via graph queries"
+
+
+def _build_token_management_section(semantic_search_registered: bool) -> str:
+    if semantic_search_registered:
+        return """7.  **Token Management**: Be efficient with context usage:
+    a. For semantic search, use focused queries (not overly broad terms)
+    b. For file reading, read specific sections when possible using offset/limit
+    c. Summarize large results rather than including full content
+    d. Prioritize most relevant findings over comprehensive coverage"""
+    return """7.  **Token Management**: Be efficient with context usage:
+    a. For file reading, read specific sections when possible using offset/limit
+    b. Summarize large results rather than including full content
+    c. Prioritize most relevant findings over comprehensive coverage"""
+
+
+def build_rag_orchestrator_prompt(
+    tools: list[Tool],
+    project_instructions: str | None = None,
+    active_projects: list[str] | None = None,
+) -> str:
+    t = extract_tool_names(tools)
+    semantic_search_registered = AgenticToolName.SEMANTIC_SEARCH in (
+        extract_registered_tools(tools)
+    )
+    search_strategy = _build_search_strategy_section(t, semantic_search_registered)
+    candidate_discovery = _build_candidate_discovery_step(semantic_search_registered)
+    token_management = _build_token_management_section(semantic_search_registered)
+    base = f"""You are an expert AI assistant for analyzing codebases. Your answers are based **EXCLUSIVELY** on information retrieved using your tools.
+
+**CRITICAL RULES:**
+1.  **TOOL-ONLY ANSWERS**: You must ONLY use information from the tools provided. Do not use external knowledge.
+2.  **NATURAL LANGUAGE QUERIES**: When using the `{t.query_graph}` tool, ALWAYS use natural language questions. NEVER write Cypher queries directly - the tool will translate your natural language into the appropriate database query.
+3.  **HONESTY**: If a tool fails or returns no results, you MUST state that clearly and report any error messages. Do not invent answers.
+4.  **CHOOSE THE RIGHT TOOL FOR THE FILE TYPE**:
+    - For source code files (.py, .ts, etc.), use `{t.read_file}`.
+    - Images and PDFs the user references are attached inline to the message; read them directly from your own multimodal input.
+
+**Your General Approach:**
+1.  **Inspect Attached Media Directly**: When the user attaches an image or PDF, analyze it from the inline content of the message. Do not call a tool for it.
+2.  **Deep Dive into Code**: When you identify a relevant component (e.g., a folder), you must go beyond documentation.
+    a. First, check if documentation files like `README.md` exist and read them for context. For configuration, look for files appropriate to the language (e.g., `pyproject.toml` for Python, `package.json` for Node.js).
+    b. **Then, you MUST dive into the source code.** Explore the `src` directory (or equivalent). Identify and read key files (e.g., `main.py`, `index.ts`, `app.ts`) to understand the implementation details, logic, and functionality.
+    c. Synthesize all this information—from documentation, configuration, and the code itself—to provide a comprehensive, factual answer. Do not just describe the files; explain what the code *does*.
+    d. Only ask for clarification if, after a thorough investigation, the user's intent is still unclear.
+{search_strategy}
 4.  **Plan Before Writing or Modifying**:
     a. Before using `{t.create_file}`, `{t.edit_file}`, or modifying files, you MUST explore the codebase to find the correct location and file structure.
     b. For shell commands: If `{t.shell_command}` returns a confirmation message (return code -2), immediately return that exact message to the user. When they respond "yes", call the tool again with `user_confirmed=True`.
 5.  **Execute Shell Commands**: The `{t.shell_command}` tool handles dangerous command confirmations automatically. If it returns a confirmation prompt, pass it directly to the user.
 6.  **Complete the Investigation Cycle**: For entry point queries, you MUST:
-    a. Find candidate functions via semantic search
+    a. {candidate_discovery}
     b. Explore their relationships via graph queries
     c. **AUTOMATICALLY read main.py** (or main entry file) - NEVER ask the user for permission
     d. Look for the ACTUAL startup code: `if __name__ == "__main__"`, CLI commands, `main()` functions
     e. If CLI framework detected (typer, click, argparse), examine command functions
     f. Distinguish between helper functions and the real application entry point
     g. Show the complete execution flow from the true entry point through initialization
-7.  **Token Management**: Be efficient with context usage:
-    a. For semantic search, use focused queries (not overly broad terms)
-    b. For file reading, read specific sections when possible using offset/limit
-    c. Summarize large results rather than including full content
-    d. Prioritize most relevant findings over comprehensive coverage
+{token_management}
 8.  **Synthesize Answer**: Analyze and explain the retrieved content. Cite your sources (file paths or qualified names). Report any errors gracefully.
 """
     base += _format_active_projects_block(active_projects)

--- a/codebase_rag/tests/test_prompt_tool_names.py
+++ b/codebase_rag/tests/test_prompt_tool_names.py
@@ -1,9 +1,15 @@
-"""Regression tests for issue #1199: the orchestrator system prompt must only
-reference tool names that are actually registered on the agent."""
+"""Regression tests for issues #1199 and #1201: the orchestrator system prompt
+must only reference tool names that are actually registered on the agent, and
+must build its strategy sections conditionally on tool availability."""
 
+from loguru import logger
 from pydantic_ai import Tool
 
-from codebase_rag.prompts import build_rag_orchestrator_prompt, extract_tool_names
+from codebase_rag.prompts import (
+    build_rag_orchestrator_prompt,
+    extract_registered_tools,
+    extract_tool_names,
+)
 from codebase_rag.tools.tool_descriptions import AgenticToolName
 
 STALE_TOOL_NAMES = (
@@ -25,6 +31,10 @@ def _all_registered_tools() -> list[Tool]:
         Tool(function=_noop, name=str(name), description=str(name), takes_ctx=False)
         for name in AgenticToolName
     ]
+
+
+def _tools_without(excluded: AgenticToolName) -> list[Tool]:
+    return [tool for tool in _all_registered_tools() if tool.name != str(excluded)]
 
 
 def test_extract_tool_names_returns_registered_names() -> None:
@@ -51,12 +61,57 @@ def test_prompt_references_registered_names_not_stale_ones() -> None:
 
 
 def test_extract_tool_names_tolerates_missing_tool() -> None:
-    tools = [
-        tool
-        for tool in _all_registered_tools()
-        if tool.name != str(AgenticToolName.SEMANTIC_SEARCH)
-    ]
+    tools = _tools_without(AgenticToolName.SEMANTIC_SEARCH)
 
     names = extract_tool_names(tools)
 
     assert names.semantic_search == str(AgenticToolName.SEMANTIC_SEARCH)
+
+
+def test_extract_registered_tools_reflects_registration() -> None:
+    registered = extract_registered_tools(
+        _tools_without(AgenticToolName.SEMANTIC_SEARCH)
+    )
+
+    assert AgenticToolName.SEMANTIC_SEARCH not in registered
+    assert AgenticToolName.QUERY_GRAPH in registered
+
+
+def test_extract_registered_tools_full_toolset() -> None:
+    registered = extract_registered_tools(_all_registered_tools())
+
+    assert registered == frozenset(AgenticToolName)
+
+
+def test_prompt_omits_semantic_search_when_unregistered() -> None:
+    tools = _tools_without(AgenticToolName.SEMANTIC_SEARCH)
+
+    prompt = build_rag_orchestrator_prompt(tools)
+
+    assert f"`{AgenticToolName.SEMANTIC_SEARCH}`" not in prompt
+    assert "semantic" not in prompt.lower()
+    assert "GRAPH FIRST" in prompt
+    assert f"`{AgenticToolName.QUERY_GRAPH}`" in prompt
+    assert f"`{AgenticToolName.READ_FILE}`" in prompt
+
+
+def test_prompt_keeps_semantic_strategy_with_full_toolset() -> None:
+    prompt = build_rag_orchestrator_prompt(_all_registered_tools())
+
+    assert "SEMANTIC FIRST" in prompt
+    assert "WHEN TO USE SEMANTIC SEARCH FIRST" in prompt
+    assert "HYBRID APPROACH (RECOMMENDED)" in prompt
+    assert f"`{AgenticToolName.SEMANTIC_SEARCH}`" in prompt
+
+
+def test_missing_semantic_search_does_not_warn_but_missing_required_does() -> None:
+    messages: list[str] = []
+    sink_id = logger.add(lambda message: messages.append(str(message)), level="WARNING")
+    try:
+        extract_tool_names(_tools_without(AgenticToolName.SEMANTIC_SEARCH))
+        assert not any(str(AgenticToolName.SEMANTIC_SEARCH) in m for m in messages)
+
+        extract_tool_names(_tools_without(AgenticToolName.QUERY_GRAPH))
+        assert any(str(AgenticToolName.QUERY_GRAPH) in m for m in messages)
+    finally:
+        logger.remove(sink_id)


### PR DESCRIPTION
## Summary

- `build_rag_orchestrator_prompt` now builds its strategy sections conditionally on which canonical tools are registered: when `semantic_search` is absent (the MCP path without a vector backend), the SEMANTIC FIRST strategy section, the semantic investigation-cycle step, and the semantic token-management bullet are replaced by graph-first guidance, so the model is never instructed to start with a tool that is not in its schema.
- New `extract_registered_tools` sibling to `extract_tool_names` exposes the registered canonical-tool set. The #1200 drift warning stays but now fires only for tools the prompt references unconditionally, so it indicates a genuinely unexpected registration gap rather than a known configuration.
- With the full toolset the built prompt is byte-identical to the previous output (verified by diffing the old and new builder output), so existing configurations see no change.

## Type of Change

- [x] New feature

## Related Issues

Closes #1201

## Test Plan

- [x] Unit tests pass (`uv run pytest -n auto -m "not integration"`)
- [x] New tests added

Extended `codebase_rag/tests/test_prompt_tool_names.py` in both directions per the issue: built from a tool list without `semantic_search`, the prompt neither backtick-references it nor instructs starting with semantic search (asserts `"semantic" not in prompt.lower()`), and graph-first guidance is present; built from the full list, the SEMANTIC FIRST / HYBRID APPROACH strategy section is still there, guarding against the section silently disappearing. Also covers `extract_registered_tools` and the warning split (missing `semantic_search` no longer warns; missing required tools still do). The new tests were RED-verified against the previous implementation.

`structural_search`/`structural_replace` are also conditionally registered in the MCP path but are not referenced anywhere in the orchestrator prompt today, so there is no section to gate for them; `extract_registered_tools` reports the full registered set, so gating them later needs no further API change.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [x] No new comments or docstrings (code should be self-documenting)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved search guidance based on which search tools are available.
  * Added support for semantic-search and graph-search workflows, including candidate discovery and token-management instructions.
  * Improved recognition of project entry points during investigations.

* **Bug Fixes**
  * Added warnings and safer handling when required search tools are unavailable.

* **Tests**
  * Expanded coverage for tool detection, conditional guidance, and missing-tool scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->