### PR TITLE
fix: emit C# LINQ query-call edges through the capture-filtering sink

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -589,7 +589,10 @@ class GraphUpdater:
             target = located(fact.target_file, fact.target_line, fact.target_col)
             if caller is None or target is None:
                 continue
-            self.ingestor.ensure_relationship_batch(
+            # Through _sink (the capture-filtering wrapper), not the raw
+            # ingestor, so a capture that disables CALLS suppresses these
+            # synthesized LINQ query-operator edges too (issue #1236).
+            self._sink.ensure_relationship_batch(
                 (caller.label, cs.KEY_QUALIFIED_NAME, caller.qualified_name),
                 cs.RelationshipType.CALLS,
                 (target.label, cs.KEY_QUALIFIED_NAME, target.qualified_name),

--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -15,6 +15,7 @@ import pytest
 from loguru import logger
 
 from codebase_rag import graph_audit
+from codebase_rag.capture import CaptureSelection
 from codebase_rag.graph_updater import GraphUpdater
 from codebase_rag.parser_loader import load_parsers
 from codebase_rag.types_defs import GraphNodeRecord, GraphRelRecord
@@ -259,6 +260,7 @@ def create_and_run_updater(
     skip_if_missing: str | None = None,
     exclude_paths: frozenset[str] | None = None,
     unignore_paths: frozenset[str] | None = None,
+    capture: CaptureSelection | None = None,
 ) -> GraphUpdater:
     parsers, queries = load_parsers()
     if skip_if_missing and skip_if_missing not in parsers:
@@ -270,6 +272,7 @@ def create_and_run_updater(
         queries=queries,
         exclude_paths=exclude_paths,
         unignore_paths=unignore_paths,
+        capture=capture,
     )
     updater.run()
     _audit_recorded_graph(mock_ingestor)

--- a/codebase_rag/tests/test_csharp_semantic_facts.py
+++ b/codebase_rag/tests/test_csharp_semantic_facts.py
@@ -13,13 +13,18 @@ import pytest
 
 from codebase_rag import constants as cs
 from codebase_rag import graph_updater as gu
+from codebase_rag.capture import ALL_ENABLED, CaptureSelection
 from codebase_rag.parsers.csharp_frontend import (
     CSharpCallSite,
     CSharpQueryCall,
     CSharpSemanticFacts,
 )
 from codebase_rag.parsers.csharp_frontend.frontend import _parse_payload
-from codebase_rag.tests.conftest import get_relationships, run_updater
+from codebase_rag.tests.conftest import (
+    create_and_run_updater,
+    get_relationships,
+    run_updater,
+)
 
 SKIP = "c_sharp"
 
@@ -455,6 +460,46 @@ def test_query_fact_emits_calls_edge_for_linq_operator(
 
     calls = _pairs(ingestor, "CALLS")
     assert _has(calls, "N.Q.Go(Src)", "N.Ops.Select(Src, object)"), calls
+
+
+def test_query_fact_edge_respects_capture_excluding_calls(
+    temp_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The synthesized LINQ query-operator edge must honour the capture contract:
+    # with CALLS disabled it is suppressed, because the join emits through the
+    # capture-filtering sink, not the raw ingestor (issue #1236). Same fixture
+    # and fact as the edge test above; only the capture differs.
+    root = temp_repo / "linqcapture"
+    root.mkdir()
+    (root / "Ops.cs").write_text(_LINQ_OPS, encoding="utf-8")
+    (root / "Src.cs").write_text(_LINQ_SRC_TYPE, encoding="utf-8")
+    (root / "Q.cs").write_text(_LINQ_QUERY, encoding="utf-8")
+    (root / "Sample.csproj").write_text(_CSPROJ, encoding="utf-8")
+
+    caller_line, caller_col = _loc(_LINQ_QUERY, "public object Go(Src s)")
+    target_line, target_col = _loc(_LINQ_OPS, "public static object Select")
+    facts = CSharpSemanticFacts(
+        base_kinds={},
+        call_sites={},
+        partial_groups=[],
+        query_calls=[
+            CSharpQueryCall(
+                "Q.cs", caller_line, caller_col, "Ops.cs", target_line, target_col
+            )
+        ],
+        external_sites=set(),
+    )
+    _hybrid(monkeypatch, facts)
+
+    no_calls = CaptureSelection(
+        enabled_rels=ALL_ENABLED.enabled_rels - {cs.RelationshipType.CALLS},
+        enabled_node_labels=ALL_ENABLED.enabled_node_labels,
+    )
+    ingestor = MagicMock()
+    create_and_run_updater(root, ingestor, skip_if_missing=SKIP, capture=no_calls)
+
+    calls = _pairs(ingestor, "CALLS")
+    assert not _has(calls, "N.Q.Go(Src)", "N.Ops.Select(Src, object)"), calls
 
 
 _E2E_CODE = """namespace N;


### PR DESCRIPTION
Fixes #1236.

## What

`GraphUpdater._emit_csharp_query_calls` emitted its synthesized LINQ query-operator `CALLS` edges through the **raw** `self.ingestor`, bypassing `self._sink` — the `FilteringIngestor` capture wrapper that every other graph-element emission uses (contract at graph_updater.py:235-238). So a capture configured to exclude `CALLS` still wrote these Roslyn query edges.

Surfaced during the #1235 review, where CodeRabbit flagged the same raw-ingestor pattern I'd mirrored for the Go IMPLEMENTS join (fixed there in-PR); this is the C# counterpart.

## How

One-line change: emit through `self._sink.ensure_relationship_batch`. `_join_csharp_partials` only mutates `csharp_partial_groups` (emits nothing), so it needs no change; the Go `_join_go_implements` already uses `_sink`.

## Test

`test_query_fact_edge_respects_capture_excluding_calls` — the existing LINQ fixture/fact with a capture that excludes `CALLS`; the query-operator edge must be absent. The companion positive test (default capture → edge present) still passes. Adds a `capture` passthrough to the `create_and_run_updater` test helper.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * LINQ query-operation call relationships now correctly honor relationship capture settings.
  * Excluding `CALLS` relationships from capture also suppresses synthesized LINQ call edges.

* **Tests**
  * Added coverage to verify that capture filtering works correctly for C# LINQ query relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->