### PR TITLE
fix: rehydrate C# type locations for incremental partial joins (#1229 phase 1)

### DIFF
--- a/codebase_rag/constants/graph.py
+++ b/codebase_rag/constants/graph.py
@@ -453,6 +453,19 @@ CYPHER_ALL_INHERITS = (
     "r.base_index AS base_index "
     "ORDER BY child_qn, base_index"
 )
+
+# C# type declaration locations for incremental runs: _join_csharp_partials
+# resolves each Roslyn partial-declaration location against csharp_type_locations,
+# which Pass 2 fills only for RE-PARSED files. Rebuild the (path, start_line) ->
+# qn entries for types in UNCHANGED .cs files from the persisted graph so a
+# partial part in an unchanged file still joins its group (issue #1229).
+CYPHER_ALL_CSHARP_TYPE_LOCATIONS = (
+    "MATCH (n) WHERE (n:Class OR n:Interface OR n:Enum) "
+    "AND n.qualified_name STARTS WITH $project_prefix "
+    "AND n.path ENDS WITH '.cs' "
+    "RETURN n.qualified_name AS qualified_name, n.path AS path, "
+    "n.start_line AS start_line"
+)
 KEY_CHILD_QN = "child_qn"
 KEY_BASE_QN = "base_qn"
 KEY_BASE_INDEX = "base_index"

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -760,6 +760,13 @@ class GraphUpdater:
         logger.info(ls.PASS_2_FILES)
         self._process_files(force=force)
 
+        # Before the partial join on an incremental run: rebuild the type
+        # locations for unchanged .cs files so a partial part living in one
+        # still joins its group (issue #1229). Pass-2 entries for re-parsed
+        # files are already present and take precedence.
+        if not force:
+            self._rehydrate_csharp_type_locations()
+
         # Partial groups join AFTER Pass 2: the Roslyn declaration
         # locations resolve against the Class qns Pass 2 just registered.
         self._join_csharp_partials()
@@ -1340,6 +1347,45 @@ class GraphUpdater:
             pairs.sort(key=lambda pair: (pair[0] is None, pair[0] or 0))
             result[child] = [base for _index, base in pairs]
         return result
+
+    def _rehydrate_csharp_type_locations(self) -> None:
+        # Incremental runs fill csharp_type_locations only from re-parsed files,
+        # but _join_csharp_partials resolves every partial-declaration location
+        # against it. Restore the (path, start_line) -> qn entries for types in
+        # UNCHANGED .cs files from the persisted graph so a partial part in an
+        # unchanged file still joins its group (issue #1229). A re-parsed file's
+        # fresh Pass-2 entry is kept (not overwritten); a stale rehydrated
+        # position for a type that moved is simply never queried by the join.
+        if not isinstance(self.ingestor, QueryProtocol):
+            return
+        locations = self.factory.definition_processor.csharp_type_locations
+        try:
+            rows = self.ingestor.fetch_all(
+                cs.CYPHER_ALL_CSHARP_TYPE_LOCATIONS,
+                {cs.KEY_PROJECT_PREFIX: self.project_name + "."},
+            )
+        except Exception:
+            if not self._is_full_build:
+                raise
+            logger.warning(ls.REHYDRATE_QUERY_FAILED)
+            return
+        restored = 0
+        for row in rows:
+            path = row.get(cs.KEY_PATH)
+            start_line = row.get(cs.KEY_START_LINE)
+            qn = row.get(cs.KEY_QUALIFIED_NAME)
+            if not (
+                isinstance(path, str)
+                and isinstance(start_line, int)
+                and isinstance(qn, str)
+            ):
+                continue
+            key = (path, start_line)
+            if key not in locations:
+                locations[key] = qn
+                restored += 1
+        if restored:
+            logger.info(ls.CSHARP_TYPE_LOCATIONS_REHYDRATED.format(count=restored))
 
     def _capture_inbound_edges(self, reindexed_keys: list[str]) -> list[ResultRow]:
         # Record the reference edges unchanged files point at the re-indexed

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -763,8 +763,10 @@ class GraphUpdater:
         # Before the partial join on an incremental run: rebuild the type
         # locations for unchanged .cs files so a partial part living in one
         # still joins its group (issue #1229). Pass-2 entries for re-parsed
-        # files are already present and take precedence.
-        if not force:
+        # files are already present and take precedence. A cacheless full build
+        # (force=False but _is_full_build) already re-parsed every file, so the
+        # project-wide query would be wasted work -- skip it.
+        if not force and not self._is_full_build:
             self._rehydrate_csharp_type_locations()
 
         # Partial groups join AFTER Pass 2: the Roslyn declaration

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1379,8 +1379,11 @@ class GraphUpdater:
             if not (
                 isinstance(path, str)
                 and isinstance(start_line, int)
+                and not isinstance(start_line, bool)
                 and isinstance(qn, str)
             ):
+                # bool is an int subclass; a stray True would key as line 1 and
+                # shadow a real line-1 type, so reject it explicitly.
                 continue
             key = (path, start_line)
             if key not in locations:

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -836,6 +836,9 @@ REHYDRATE_QUERY_FAILED = (
     "Could not read persisted definitions from the graph; continuing with "
     "only this run's freshly parsed registry."
 )
+CSHARP_TYPE_LOCATIONS_REHYDRATED = (
+    "Rehydrated {count} C# type location(s) from the graph for the partial join"
+)
 INBOUND_CAPTURE_FAILED = (
     "Could not read inbound edges from the graph; this full rebuild "
     "re-parses every caller, so the edges are re-resolved from source."

--- a/codebase_rag/tests/test_csharp_type_location_rehydration.py
+++ b/codebase_rag/tests/test_csharp_type_location_rehydration.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from codebase_rag import constants as cs
 from codebase_rag import graph_updater as gu
 from codebase_rag.parser_loader import load_parsers
@@ -123,3 +125,94 @@ def test_rehydration_keeps_the_fresh_pass2_entry(tmp_path: Path) -> None:
     # The fresh Pass-2 line survives; the join keys off the current fact
     # position, so the stale rehydrated (path, 5) entry is simply never queried.
     assert dp.csharp_type_locations[("dirA/W.cs", 9)] == "proj.dirA.W"
+
+
+class _NonQueryGraph:
+    """An ingestor that does NOT satisfy QueryProtocol (no fetch_all /
+    execute_write), so rehydration must no-op rather than crash."""
+
+    def ensure_node_batch(self, label: str, properties: PropertyDict) -> None:
+        return None
+
+    def ensure_relationship_batch(self, *args: object, **kwargs: object) -> None:
+        return None
+
+    def flush_all(self) -> None:
+        return None
+
+
+class _RaisingGraph(_TypeLocGraph):
+    def __init__(self) -> None:
+        super().__init__([])
+
+    def fetch_all(
+        self, query: str, params: PropertyDict | None = None
+    ) -> list[ResultRow]:
+        raise RuntimeError("graph read failed")
+
+
+def test_rehydration_noops_without_query_protocol(tmp_path: Path) -> None:
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    parsers, queries = load_parsers()
+    updater = gu.GraphUpdater(
+        ingestor=_NonQueryGraph(), repo_path=repo, parsers=parsers, queries=queries
+    )
+    dp = updater.factory.definition_processor
+
+    updater._rehydrate_csharp_type_locations()  # must not raise
+
+    assert dp.csharp_type_locations == {}
+
+
+def test_rehydration_reraises_query_error_on_incremental(tmp_path: Path) -> None:
+    # A genuine incremental run (not a full build) cannot silently proceed on a
+    # degraded read -- it would drop real partial groups -- so the error raises.
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    parsers, queries = load_parsers()
+    updater = gu.GraphUpdater(
+        ingestor=_RaisingGraph(), repo_path=repo, parsers=parsers, queries=queries
+    )
+    updater._is_full_build = False
+
+    with pytest.raises(RuntimeError):
+        updater._rehydrate_csharp_type_locations()
+
+
+def test_rehydration_tolerates_query_error_on_full_build(tmp_path: Path) -> None:
+    # A full build has every location from Pass 2 already, so a failed read is
+    # only a warning -- rehydration returns without touching the map.
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    parsers, queries = load_parsers()
+    updater = gu.GraphUpdater(
+        ingestor=_RaisingGraph(), repo_path=repo, parsers=parsers, queries=queries
+    )
+    updater._is_full_build = True
+
+    updater._rehydrate_csharp_type_locations()  # must not raise
+
+    assert updater.factory.definition_processor.csharp_type_locations == {}
+
+
+def test_rehydration_skips_malformed_rows(tmp_path: Path) -> None:
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    updater = _updater(
+        repo,
+        [
+            {cs.KEY_QUALIFIED_NAME: "proj.Bad", cs.KEY_PATH: "b.cs"},  # no start_line
+            {
+                cs.KEY_QUALIFIED_NAME: "proj.NotInt",
+                cs.KEY_PATH: "c.cs",
+                cs.KEY_START_LINE: "x",  # non-int line
+            },
+            _persisted_type("proj.", "good.cs", 4, "Good"),
+        ],
+    )
+    dp = updater.factory.definition_processor
+
+    updater._rehydrate_csharp_type_locations()
+
+    assert dp.csharp_type_locations == {("good.cs", 4): "proj.Good"}

--- a/codebase_rag/tests/test_csharp_type_location_rehydration.py
+++ b/codebase_rag/tests/test_csharp_type_location_rehydration.py
@@ -1,0 +1,125 @@
+# Issue #1229 (Phase 1): on an incremental run, _join_csharp_partials resolves
+# each Roslyn partial-declaration location against csharp_type_locations, which
+# Pass 2 fills only for RE-PARSED files. Without rehydration, a partial part in
+# an UNCHANGED .cs file has no entry, so its group silently drops below the
+# 2-member threshold and the parts stop spanning to each other. These tests
+# drive the rehydration + join directly (no C# toolchain, no real DB) via a
+# tiny QueryProtocol fake that answers the type-location query from seeded rows.
+from __future__ import annotations
+
+from pathlib import Path
+
+from codebase_rag import constants as cs
+from codebase_rag import graph_updater as gu
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.types_defs import PropertyDict, ResultRow
+
+
+class _TypeLocGraph:
+    """Answers only CYPHER_ALL_CSHARP_TYPE_LOCATIONS (as the persisted graph
+    would for unchanged .cs types); every other query returns []."""
+
+    def __init__(self, rows: list[ResultRow]) -> None:
+        self._rows = rows
+
+    def ensure_node_batch(self, label: str, properties: PropertyDict) -> None:
+        return None
+
+    def ensure_relationship_batch(self, *args: object, **kwargs: object) -> None:
+        return None
+
+    def flush_all(self) -> None:
+        return None
+
+    def fetch_all(
+        self, query: str, params: PropertyDict | None = None
+    ) -> list[ResultRow]:
+        if query != cs.CYPHER_ALL_CSHARP_TYPE_LOCATIONS:
+            return []
+        prefix = str((params or {}).get(cs.KEY_PROJECT_PREFIX, ""))
+        return [
+            r
+            for r in self._rows
+            if str(r.get(cs.KEY_QUALIFIED_NAME, "")).startswith(prefix)
+        ]
+
+    def execute_write(self, query: str, params: PropertyDict | None = None) -> None:
+        return None
+
+
+def _updater(repo: Path, rows: list[ResultRow]) -> gu.GraphUpdater:
+    parsers, queries = load_parsers()
+    return gu.GraphUpdater(
+        ingestor=_TypeLocGraph(rows),
+        repo_path=repo,
+        parsers=parsers,
+        queries=queries,
+    )
+
+
+def _persisted_type(prefix: str, path: str, line: int, name: str) -> ResultRow:
+    return {
+        cs.KEY_QUALIFIED_NAME: f"{prefix}{name}",
+        cs.KEY_PATH: path,
+        cs.KEY_START_LINE: line,
+    }
+
+
+def test_rehydration_lets_partial_group_span_an_unchanged_file(tmp_path: Path) -> None:
+    # Two parts of one partial class in different dirs get distinct tree-sitter
+    # qns; Roslyn proves they are one symbol. On incremental, dirA is re-parsed
+    # (fresh Pass-2 entry) and dirB is unchanged (rehydrated). The group must
+    # form across both.
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    updater = _updater(repo, [_persisted_type("proj.", "dirB/W.cs", 3, "dirB.W")])
+    dp = updater.factory.definition_processor
+
+    # Pass-2 result for the re-parsed file only.
+    dp.csharp_type_locations[("dirA/W.cs", 5)] = "proj.dirA.W"
+    # Roslyn says these two locations are the same partial symbol.
+    updater._csharp_partial_decls = [[("dirA/W.cs", 5), ("dirB/W.cs", 3)]]
+
+    updater._rehydrate_csharp_type_locations()
+    updater._join_csharp_partials()
+
+    group = dp.csharp_partial_groups.get("proj.dirA.W")
+    assert group is not None, dp.csharp_partial_groups
+    assert set(group) == {"proj.dirA.W", "proj.dirB.W"}, group
+
+
+def test_without_rehydration_the_unchanged_part_is_dropped(tmp_path: Path) -> None:
+    # Negative control: same setup, but the unchanged part is never rehydrated
+    # (empty graph), so the group falls below two members and is not formed --
+    # the exact staleness Phase 1 fixes.
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    updater = _updater(repo, [])
+    dp = updater.factory.definition_processor
+
+    dp.csharp_type_locations[("dirA/W.cs", 5)] = "proj.dirA.W"
+    updater._csharp_partial_decls = [[("dirA/W.cs", 5), ("dirB/W.cs", 3)]]
+
+    updater._rehydrate_csharp_type_locations()
+    updater._join_csharp_partials()
+
+    assert dp.csharp_partial_groups == {}
+
+
+def test_rehydration_keeps_the_fresh_pass2_entry(tmp_path: Path) -> None:
+    # A re-parsed file whose type moved lines must keep its FRESH Pass-2 entry;
+    # a stale persisted position for the same path must not overwrite it.
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    updater = _updater(
+        repo,
+        [_persisted_type("proj.", "dirA/W.cs", 5, "dirA.W")],  # stale line
+    )
+    dp = updater.factory.definition_processor
+    dp.csharp_type_locations[("dirA/W.cs", 9)] = "proj.dirA.W"  # fresh Pass-2 line
+
+    updater._rehydrate_csharp_type_locations()
+
+    # The fresh Pass-2 line survives; the join keys off the current fact
+    # position, so the stale rehydrated (path, 5) entry is simply never queried.
+    assert dp.csharp_type_locations[("dirA/W.cs", 9)] == "proj.dirA.W"

--- a/codebase_rag/tests/test_csharp_type_location_rehydration.py
+++ b/codebase_rag/tests/test_csharp_type_location_rehydration.py
@@ -208,6 +208,11 @@ def test_rehydration_skips_malformed_rows(tmp_path: Path) -> None:
                 cs.KEY_PATH: "c.cs",
                 cs.KEY_START_LINE: "x",  # non-int line
             },
+            {
+                cs.KEY_QUALIFIED_NAME: "proj.BoolLine",
+                cs.KEY_PATH: "d.cs",
+                cs.KEY_START_LINE: True,  # bool is an int subclass -> reject
+            },
             _persisted_type("proj.", "good.cs", 4, "Good"),
         ],
     )


### PR DESCRIPTION
First phase of #1229 (incremental staleness of the semantic frontends' location-keyed facts). See the [phased plan](https://github.com/vitali87/code-graph-rag/issues/1229) — this is Phase 1, the self-contained, no-schema-change slice.

## Problem

On an incremental `run(force=False)`, `_join_csharp_partials` resolves each Roslyn partial-declaration location against `csharp_type_locations`, which Pass 2 populates **only for re-parsed files**. So a partial-class part living in an **unchanged** `.cs` file has no entry; if that drops the group below two members, the parts stop spanning to each other until a full re-index.

## Fix

A new `_rehydrate_csharp_type_locations`, run between Pass 2 and the partial join on `not force`, rebuilds `(path, start_line) → qn` for types in unchanged `.cs` files from the persisted graph (`CYPHER_ALL_CSHARP_TYPE_LOCATIONS` over `Class`/`Interface`/`Enum` nodes — `path` + `start_line` are already persisted, so **no schema change**). It mirrors `_rehydrate_class_inheritance_from_graph` (same `QueryProtocol` guard, same failure handling). A re-parsed file's fresh Pass-2 entry is kept — the rehydration only adds missing keys, so a moved type's stale persisted position is never queried.

## Scope

C# partial-class staleness on the `run()` incremental path only. The remaining phases (Go `go_type_locations` + `function_locations`, which need `start_col` persisted; the watch path in `realtime_updater.py`; stale-surviving CALLS) are tracked in #1229 and carry a graph-schema decision.

## Tests

`test_csharp_type_location_rehydration.py` (no C# toolchain / DB — a tiny `QueryProtocol` fake answers the type-location query):
- rehydration lets a partial group span an unchanged-file part;
- negative control — without rehydration the unchanged part drops and no group forms;
- a re-parsed file's fresh Pass-2 line is not overwritten by a stale persisted position.

Refs #1229.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved incremental C# analysis so declarations spanning unchanged files are retained.
  - Ensured newly discovered type locations take precedence over previously stored positions.
  - Added clearer handling and reporting when type-location data cannot be restored.
  - Improved consistency between incremental and full analysis results.

- **Tests**
  - Added coverage for partial declarations across changed and unchanged files.
  - Verified incomplete groups are excluded when required location data is unavailable.
  - Tested behavior for malformed data and restoration failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->