### PR TITLE
fix: stop treating {str: func} dicts as dispatch registries (#1241)

### DIFF
--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -1035,7 +1035,6 @@ class CallProcessor:
             ingestor=ingestor,
             selection=selection,
             function_registry=function_registry,
-            import_processor=import_processor,
         )
         self._rpc_exposure = GoRpcExposureProcessor(
             ingestor=ingestor,

--- a/codebase_rag/parsers/dispatch_registry.py
+++ b/codebase_rag/parsers/dispatch_registry.py
@@ -1,18 +1,18 @@
 # String-keyed dispatch registries (issue #913). A handler registered under a
 # string key serves work scheduled elsewhere by that same string, invisibly to
-# call resolution. Registrations EXPOSE `resource::DISPATCH::<key>`; producers
-# passing the key through a recognised keyword emit WRITES_TO on the same node,
-# so the two sides meet without a resolution pass. A produced `name/deployment`
-# key additionally RESOLVES_TO the bare registered `name` when no exact
-# registration exists. Dynamic keys stay out: a ceiling yields nothing, never a
-# wrong link.
+# call resolution. A `@flow`/`@task` registrar decorator EXPOSES
+# `resource::DISPATCH::<key>`; a producer passing the key through a recognised
+# keyword emits WRITES_TO on the same node, so the two sides meet without a
+# resolution pass. A produced `name/deployment` key additionally RESOLVES_TO the
+# bare registered `name` when no exact registration exists. Dynamic keys stay
+# out: a ceiling yields nothing, never a wrong link.
 #
-# A `@flow`/`@task` registrar decorator is an explicit dispatch declaration and
-# EXPOSES eagerly. A module-level `{str: function}` dict is only a registry when
-# a producer actually dispatches to one of its keys (issue #1241): a bare
-# name->function dict (click's stream tables, command maps, plugin registries)
-# is a common idiom and is NOT dispatch on its own, so dict registrations are
-# deferred and emitted at finalize only for producer-corroborated keys.
+# Only an explicit `@flow`/`@task` decorator registers a handler. A module-level
+# `{str: function}` dict is NOT treated as a registry (issue #1241): it is
+# indistinguishable from an ordinary lookup table (click's stream tables,
+# command maps, plugin registries), and a DISPATCH resource keyed only by a bare
+# string cannot be tied back to a specific dict -- any corroboration by key text
+# alone manufactures false registries on coincidental collisions.
 from __future__ import annotations
 
 import ast
@@ -25,7 +25,6 @@ from .. import constants as cs
 from ..capture import CaptureSelection
 from ..services import IngestorProtocol, QueryProtocol
 from ..types_defs import FunctionRegistryTrieProtocol, NodeType
-from .import_processor import ImportProcessor
 from .io_access.constants import (
     DISPATCH_DEPLOYMENT_SEPARATOR,
     DISPATCH_NAME_KEYWORD,
@@ -59,13 +58,11 @@ class DispatchRegistryProcessor:
 
     __slots__ = (
         "_ingestor",
-        "_import_processor",
         "_function_registry",
         "_exposes_enabled",
         "_writes_enabled",
         "_resolves_enabled",
         "_module_registrations",
-        "_module_dict_candidates",
         "_module_producers",
         "_module_constants",
         "_module_deferred",
@@ -76,10 +73,8 @@ class DispatchRegistryProcessor:
         ingestor: IngestorProtocol,
         selection: CaptureSelection,
         function_registry: FunctionRegistryTrieProtocol,
-        import_processor: ImportProcessor,
     ) -> None:
         self._ingestor = ingestor
-        self._import_processor = import_processor
         self._function_registry = function_registry
         self._exposes_enabled = selection.rel_enabled(cs.RelationshipType.EXPOSES)
         self._writes_enabled = selection.rel_enabled(cs.RelationshipType.WRITES_TO)
@@ -87,10 +82,6 @@ class DispatchRegistryProcessor:
         # All bookkeeping is PER MODULE and replaced wholesale on re-process,
         # so a watch-mode re-parse cannot replay facts removed from source.
         self._module_registrations: dict[str, list[tuple[str, NodeType, str]]] = {}
-        # Dict-registry candidates are collected but NOT emitted during the
-        # file pass; finalize emits only those whose key a producer dispatches
-        # to (issue #1241), keyed by module so a re-parse replaces them.
-        self._module_dict_candidates: dict[str, list[tuple[str, NodeType, str]]] = {}
         self._module_producers: dict[str, list[tuple[tuple[str, str, str], str]]] = {}
         self._module_constants: dict[str, dict[str, str]] = {}
         self._module_deferred: dict[str, list[_DeferredProducer]] = {}
@@ -106,7 +97,6 @@ class DispatchRegistryProcessor:
         ):
             return
         self._module_registrations[module_qn] = []
-        self._module_dict_candidates[module_qn] = []
         self._module_producers[module_qn] = []
         self._module_constants[module_qn] = {}
         self._module_deferred[module_qn] = []
@@ -126,15 +116,11 @@ class DispatchRegistryProcessor:
                 if key := constants.get(deferred.identifier):
                     self._emit_produced_edge(deferred.caller_spec, key)
                     resolved_deferred.add(key)
+        if not self._resolves_enabled:
+            return
         produced = {
             key for entries in self._module_producers.values() for _spec, key in entries
         } | resolved_deferred
-        if any(self._module_dict_candidates.values()):
-            self._emit_corroborated_dict_registrations(
-                produced | self._db_produced_keys()
-            )
-        if not self._resolves_enabled:
-            return
         registered = {
             key
             for entries in self._module_registrations.values()
@@ -158,44 +144,20 @@ class DispatchRegistryProcessor:
 
     def _db_registered_keys(self) -> set[str]:
         # An incremental run reprocesses only changed files; registrations in
-        # untouched files exist solely in the database.
-        return self._db_dispatch_keys(cs.RelationshipType.EXPOSES.value)
-
-    def _db_produced_keys(self) -> set[str]:
-        # An incremental run reprocesses only changed files; a producer that
-        # corroborates a dict registry may live in an untouched file, so its
-        # WRITES_TO target persists only in the database (issue #1241).
-        return self._db_dispatch_keys(cs.RelationshipType.WRITES_TO.value)
-
-    def _db_dispatch_keys(self, relationship: str) -> set[str]:
-        # DISPATCH keys reachable over `relationship` in the live graph. A read
-        # failure (the graph briefly down mid-rebuild) must degrade to no seeds,
-        # never abort finalize -- the rebuild has to complete regardless.
+        # untouched files exist solely in the database. A read failure (the
+        # graph briefly down mid-rebuild) degrades to no seeds rather than
+        # aborting finalize -- the rebuild has to complete regardless.
         if not isinstance(self._ingestor, QueryProtocol):
             return set()
         try:
             rows = self._ingestor.fetch_all(
-                f"MATCH (h:Resource {{kind: 'DISPATCH'}})<-[:{relationship}]-() "
+                "MATCH (h:Resource {kind: 'DISPATCH'})<-[:EXPOSES]-() "
                 "RETURN DISTINCT h.name AS name"
             )
         except Exception:  # noqa: BLE001 - any read failure degrades to no seeds
-            logger.debug("DISPATCH {} seed read failed; no seeds", relationship)
+            logger.debug("DISPATCH registration seed read failed; no seeds")
             return set()
         return {name for row in rows if isinstance(name := row.get("name"), str)}
-
-    def _emit_corroborated_dict_registrations(self, produced: set[str]) -> None:
-        # A `{str: func}` dict is a genuine registry only when a producer
-        # dispatches to one of its keys (issue #1241). A bare name->function
-        # lookup with no matching producer is an ordinary table, not dispatch.
-        # A produced `name/deployment` key corroborates the bare `name` it
-        # resolves onto, mirroring the deployment-suffix join.
-        produced_heads = {
-            key.split(DISPATCH_DEPLOYMENT_SEPARATOR, 1)[0] for key in produced
-        }
-        for module_qn, candidates in self._module_dict_candidates.items():
-            for handler_qn, node_type, key in candidates:
-                if key in produced or key in produced_heads:
-                    self._emit_registration(module_qn, handler_qn, node_type, key)
 
     def _process_module_scope(self, root: Node, module_qn: str) -> None:
         constants = self._module_constants.setdefault(module_qn, {})
@@ -220,52 +182,6 @@ class DispatchRegistryProcessor:
             name = safe_decode_text(target)
             if name is not None and (text := _plain_string(value)) is not None:
                 constants[name] = text
-        elif value.type == cs.TS_PY_DICTIONARY:
-            self._process_dict_registry(value, module_qn)
-
-    def _process_dict_registry(self, dictionary: Node, module_qn: str) -> None:
-        # A registry ONLY when every entry maps a plain string literal to a
-        # module-declared function; one exception keeps config dicts out.
-        # Candidates are collected here and emitted at finalize only for keys a
-        # producer actually dispatches to (issue #1241).
-        entries: list[tuple[str, str, NodeType]] = []
-        for pair in dictionary.named_children:
-            if pair.type != cs.TS_PY_PAIR:
-                return
-            key_node = pair.child_by_field_name(cs.FIELD_KEY)
-            value_node = pair.child_by_field_name(cs.FIELD_VALUE)
-            key = _plain_string(key_node) if key_node is not None else None
-            if key is None or value_node is None:
-                return
-            if value_node.type != cs.TS_PY_IDENTIFIER:
-                return
-            handler = safe_decode_text(value_node)
-            if handler is None:
-                return
-            resolved = self._resolve_handler(module_qn, handler)
-            if resolved is None:
-                return
-            entries.append((key, *resolved))
-        for key, handler_qn, node_type in entries:
-            self._module_dict_candidates[module_qn].append((handler_qn, node_type, key))
-
-    def _resolve_handler(
-        self, module_qn: str, handler: str
-    ) -> tuple[str, NodeType] | None:
-        # A handler declared in the registry module itself, or imported into
-        # it (the production registries import from sibling modules; Python
-        # import mappings hold full project-prefixed qns).
-        import_map = self._import_processor.import_mapping.get(module_qn, {})
-        for handler_qn in (
-            f"{module_qn}{cs.SEPARATOR_DOT}{handler}",
-            import_map.get(handler),
-        ):
-            if handler_qn is None:
-                continue
-            node_type = self._function_registry.get(handler_qn)
-            if node_type in _HANDLER_NODE_LABELS:
-                return handler_qn, node_type
-        return None
 
     def _process_decorated(self, node: Node, module_qn: str) -> None:
         definition = node.child_by_field_name(cs.FIELD_DEFINITION)

--- a/codebase_rag/parsers/dispatch_registry.py
+++ b/codebase_rag/parsers/dispatch_registry.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import ast
 from typing import NamedTuple
 
+from loguru import logger
 from tree_sitter import Node
 
 from .. import constants as cs
@@ -128,7 +129,10 @@ class DispatchRegistryProcessor:
         produced = {
             key for entries in self._module_producers.values() for _spec, key in entries
         } | resolved_deferred
-        self._emit_corroborated_dict_registrations(produced | self._db_produced_keys())
+        if any(self._module_dict_candidates.values()):
+            self._emit_corroborated_dict_registrations(
+                produced | self._db_produced_keys()
+            )
         if not self._resolves_enabled:
             return
         registered = {
@@ -155,24 +159,28 @@ class DispatchRegistryProcessor:
     def _db_registered_keys(self) -> set[str]:
         # An incremental run reprocesses only changed files; registrations in
         # untouched files exist solely in the database.
-        if not isinstance(self._ingestor, QueryProtocol):
-            return set()
-        rows = self._ingestor.fetch_all(
-            "MATCH (h:Resource {kind: 'DISPATCH'})<-[:EXPOSES]-() "
-            "RETURN DISTINCT h.name AS name"
-        )
-        return {name for row in rows if isinstance(name := row.get("name"), str)}
+        return self._db_dispatch_keys(cs.RelationshipType.EXPOSES.value)
 
     def _db_produced_keys(self) -> set[str]:
         # An incremental run reprocesses only changed files; a producer that
         # corroborates a dict registry may live in an untouched file, so its
         # WRITES_TO target persists only in the database (issue #1241).
+        return self._db_dispatch_keys(cs.RelationshipType.WRITES_TO.value)
+
+    def _db_dispatch_keys(self, relationship: str) -> set[str]:
+        # DISPATCH keys reachable over `relationship` in the live graph. A read
+        # failure (the graph briefly down mid-rebuild) must degrade to no seeds,
+        # never abort finalize -- the rebuild has to complete regardless.
         if not isinstance(self._ingestor, QueryProtocol):
             return set()
-        rows = self._ingestor.fetch_all(
-            "MATCH (h:Resource {kind: 'DISPATCH'})<-[:WRITES_TO]-() "
-            "RETURN DISTINCT h.name AS name"
-        )
+        try:
+            rows = self._ingestor.fetch_all(
+                f"MATCH (h:Resource {{kind: 'DISPATCH'}})<-[:{relationship}]-() "
+                "RETURN DISTINCT h.name AS name"
+            )
+        except Exception:  # noqa: BLE001 - any read failure degrades to no seeds
+            logger.debug("DISPATCH {} seed read failed; no seeds", relationship)
+            return set()
         return {name for row in rows if isinstance(name := row.get("name"), str)}
 
     def _emit_corroborated_dict_registrations(self, produced: set[str]) -> None:

--- a/codebase_rag/parsers/dispatch_registry.py
+++ b/codebase_rag/parsers/dispatch_registry.py
@@ -1,12 +1,18 @@
 # String-keyed dispatch registries (issue #913). A handler registered under a
 # string key serves work scheduled elsewhere by that same string, invisibly to
-# call resolution. Registrations (module-level dict registries mapping string
-# literals to module functions, and `@flow`/`@task` registrar decorators)
-# EXPOSE `resource::DISPATCH::<key>`; producers passing the key through a
-# recognised keyword emit WRITES_TO on the same node, so the two sides meet
-# without a resolution pass. A produced `name/deployment` key additionally
-# RESOLVES_TO the bare registered `name` when no exact registration exists.
-# Dynamic keys stay out: a ceiling yields nothing, never a wrong link.
+# call resolution. Registrations EXPOSE `resource::DISPATCH::<key>`; producers
+# passing the key through a recognised keyword emit WRITES_TO on the same node,
+# so the two sides meet without a resolution pass. A produced `name/deployment`
+# key additionally RESOLVES_TO the bare registered `name` when no exact
+# registration exists. Dynamic keys stay out: a ceiling yields nothing, never a
+# wrong link.
+#
+# A `@flow`/`@task` registrar decorator is an explicit dispatch declaration and
+# EXPOSES eagerly. A module-level `{str: function}` dict is only a registry when
+# a producer actually dispatches to one of its keys (issue #1241): a bare
+# name->function dict (click's stream tables, command maps, plugin registries)
+# is a common idiom and is NOT dispatch on its own, so dict registrations are
+# deferred and emitted at finalize only for producer-corroborated keys.
 from __future__ import annotations
 
 import ast
@@ -21,7 +27,6 @@ from ..types_defs import FunctionRegistryTrieProtocol, NodeType
 from .import_processor import ImportProcessor
 from .io_access.constants import (
     DISPATCH_DEPLOYMENT_SEPARATOR,
-    DISPATCH_FRAMEWORK_MODULES,
     DISPATCH_NAME_KEYWORD,
     DISPATCH_PRODUCER_KEYWORDS,
     DISPATCH_REGISTRARS,
@@ -59,6 +64,7 @@ class DispatchRegistryProcessor:
         "_writes_enabled",
         "_resolves_enabled",
         "_module_registrations",
+        "_module_dict_candidates",
         "_module_producers",
         "_module_constants",
         "_module_deferred",
@@ -80,6 +86,10 @@ class DispatchRegistryProcessor:
         # All bookkeeping is PER MODULE and replaced wholesale on re-process,
         # so a watch-mode re-parse cannot replay facts removed from source.
         self._module_registrations: dict[str, list[tuple[str, NodeType, str]]] = {}
+        # Dict-registry candidates are collected but NOT emitted during the
+        # file pass; finalize emits only those whose key a producer dispatches
+        # to (issue #1241), keyed by module so a re-parse replaces them.
+        self._module_dict_candidates: dict[str, list[tuple[str, NodeType, str]]] = {}
         self._module_producers: dict[str, list[tuple[tuple[str, str, str], str]]] = {}
         self._module_constants: dict[str, dict[str, str]] = {}
         self._module_deferred: dict[str, list[_DeferredProducer]] = {}
@@ -95,6 +105,7 @@ class DispatchRegistryProcessor:
         ):
             return
         self._module_registrations[module_qn] = []
+        self._module_dict_candidates[module_qn] = []
         self._module_producers[module_qn] = []
         self._module_constants[module_qn] = {}
         self._module_deferred[module_qn] = []
@@ -114,6 +125,10 @@ class DispatchRegistryProcessor:
                 if key := constants.get(deferred.identifier):
                     self._emit_produced_edge(deferred.caller_spec, key)
                     resolved_deferred.add(key)
+        produced = {
+            key for entries in self._module_producers.values() for _spec, key in entries
+        } | resolved_deferred
+        self._emit_corroborated_dict_registrations(produced | self._db_produced_keys())
         if not self._resolves_enabled:
             return
         registered = {
@@ -121,9 +136,6 @@ class DispatchRegistryProcessor:
             for entries in self._module_registrations.values()
             for _qn, _type, key in entries
         } | self._db_registered_keys()
-        produced = {
-            key for entries in self._module_producers.values() for _spec, key in entries
-        } | resolved_deferred
         for key in sorted(produced):
             if DISPATCH_DEPLOYMENT_SEPARATOR not in key or key in registered:
                 continue
@@ -151,26 +163,44 @@ class DispatchRegistryProcessor:
         )
         return {name for row in rows if isinstance(name := row.get("name"), str)}
 
+    def _db_produced_keys(self) -> set[str]:
+        # An incremental run reprocesses only changed files; a producer that
+        # corroborates a dict registry may live in an untouched file, so its
+        # WRITES_TO target persists only in the database (issue #1241).
+        if not isinstance(self._ingestor, QueryProtocol):
+            return set()
+        rows = self._ingestor.fetch_all(
+            "MATCH (h:Resource {kind: 'DISPATCH'})<-[:WRITES_TO]-() "
+            "RETURN DISTINCT h.name AS name"
+        )
+        return {name for row in rows if isinstance(name := row.get("name"), str)}
+
+    def _emit_corroborated_dict_registrations(self, produced: set[str]) -> None:
+        # A `{str: func}` dict is a genuine registry only when a producer
+        # dispatches to one of its keys (issue #1241). A bare name->function
+        # lookup with no matching producer is an ordinary table, not dispatch.
+        # A produced `name/deployment` key corroborates the bare `name` it
+        # resolves onto, mirroring the deployment-suffix join.
+        produced_heads = {
+            key.split(DISPATCH_DEPLOYMENT_SEPARATOR, 1)[0] for key in produced
+        }
+        for module_qn, candidates in self._module_dict_candidates.items():
+            for handler_qn, node_type, key in candidates:
+                if key in produced or key in produced_heads:
+                    self._emit_registration(module_qn, handler_qn, node_type, key)
+
     def _process_module_scope(self, root: Node, module_qn: str) -> None:
         constants = self._module_constants.setdefault(module_qn, {})
-        # A `{str: func}` dict is only a dispatch registry when the module
-        # imports a task-queue / workflow framework (issue #1241): a bare
-        # name->function lookup table alone is not evidence of dispatch.
-        dict_registries = _module_imports_dispatch_framework(root)
         for stmt in root.named_children:
             if stmt.type == cs.TS_PY_EXPRESSION_STATEMENT and stmt.named_children:
                 self._process_module_assignment(
-                    stmt.named_children[0], module_qn, constants, dict_registries
+                    stmt.named_children[0], module_qn, constants
                 )
             elif stmt.type == cs.TS_PY_DECORATED_DEFINITION:
                 self._process_decorated(stmt, module_qn)
 
     def _process_module_assignment(
-        self,
-        node: Node,
-        module_qn: str,
-        constants: dict[str, str],
-        dict_registries: bool,
+        self, node: Node, module_qn: str, constants: dict[str, str]
     ) -> None:
         if node.type != cs.TS_PY_ASSIGNMENT:
             return
@@ -182,12 +212,14 @@ class DispatchRegistryProcessor:
             name = safe_decode_text(target)
             if name is not None and (text := _plain_string(value)) is not None:
                 constants[name] = text
-        elif value.type == cs.TS_PY_DICTIONARY and dict_registries:
+        elif value.type == cs.TS_PY_DICTIONARY:
             self._process_dict_registry(value, module_qn)
 
     def _process_dict_registry(self, dictionary: Node, module_qn: str) -> None:
         # A registry ONLY when every entry maps a plain string literal to a
         # module-declared function; one exception keeps config dicts out.
+        # Candidates are collected here and emitted at finalize only for keys a
+        # producer actually dispatches to (issue #1241).
         entries: list[tuple[str, str, NodeType]] = []
         for pair in dictionary.named_children:
             if pair.type != cs.TS_PY_PAIR:
@@ -207,7 +239,7 @@ class DispatchRegistryProcessor:
                 return
             entries.append((key, *resolved))
         for key, handler_qn, node_type in entries:
-            self._emit_registration(module_qn, handler_qn, node_type, key)
+            self._module_dict_candidates[module_qn].append((handler_qn, node_type, key))
 
     def _resolve_handler(
         self, module_qn: str, handler: str
@@ -360,37 +392,6 @@ class DispatchRegistryProcessor:
                 KEY_KIND: ResourceKind.DISPATCH.value,
             },
         )
-
-
-def _module_imports_dispatch_framework(root: Node) -> bool:
-    # True when any top-level import names a known task-queue / workflow
-    # framework (issue #1241). Relative imports are first-party and never
-    # match; only the leading dotted component is checked (`celery.result`
-    # -> `celery`).
-    for stmt in root.named_children:
-        if stmt.type == cs.TS_PY_IMPORT_STATEMENT:
-            targets = stmt.named_children
-        elif stmt.type == cs.TS_PY_IMPORT_FROM_STATEMENT:
-            module = stmt.child_by_field_name(cs.FIELD_MODULE_NAME)
-            targets = [module] if module is not None else []
-        else:
-            continue
-        for target in targets:
-            if _import_head(target) in DISPATCH_FRAMEWORK_MODULES:
-                return True
-    return False
-
-
-def _import_head(node: Node | None) -> str | None:
-    # Leading dotted component of an import target: `celery.app` -> `celery`.
-    # `celery.app as ca` unwraps the alias first; a relative import yields None.
-    if node is None:
-        return None
-    if node.type == cs.TS_ALIASED_IMPORT:
-        node = node.child_by_field_name(cs.FIELD_NAME)
-    if node is None or node.type != cs.TS_PY_DOTTED_NAME or not node.named_children:
-        return None
-    return safe_decode_text(node.named_children[0])
 
 
 def _resource_qn(key: str) -> str:

--- a/codebase_rag/parsers/dispatch_registry.py
+++ b/codebase_rag/parsers/dispatch_registry.py
@@ -21,6 +21,7 @@ from ..types_defs import FunctionRegistryTrieProtocol, NodeType
 from .import_processor import ImportProcessor
 from .io_access.constants import (
     DISPATCH_DEPLOYMENT_SEPARATOR,
+    DISPATCH_FRAMEWORK_MODULES,
     DISPATCH_NAME_KEYWORD,
     DISPATCH_PRODUCER_KEYWORDS,
     DISPATCH_REGISTRARS,
@@ -152,16 +153,24 @@ class DispatchRegistryProcessor:
 
     def _process_module_scope(self, root: Node, module_qn: str) -> None:
         constants = self._module_constants.setdefault(module_qn, {})
+        # A `{str: func}` dict is only a dispatch registry when the module
+        # imports a task-queue / workflow framework (issue #1241): a bare
+        # name->function lookup table alone is not evidence of dispatch.
+        dict_registries = _module_imports_dispatch_framework(root)
         for stmt in root.named_children:
             if stmt.type == cs.TS_PY_EXPRESSION_STATEMENT and stmt.named_children:
                 self._process_module_assignment(
-                    stmt.named_children[0], module_qn, constants
+                    stmt.named_children[0], module_qn, constants, dict_registries
                 )
             elif stmt.type == cs.TS_PY_DECORATED_DEFINITION:
                 self._process_decorated(stmt, module_qn)
 
     def _process_module_assignment(
-        self, node: Node, module_qn: str, constants: dict[str, str]
+        self,
+        node: Node,
+        module_qn: str,
+        constants: dict[str, str],
+        dict_registries: bool,
     ) -> None:
         if node.type != cs.TS_PY_ASSIGNMENT:
             return
@@ -173,7 +182,7 @@ class DispatchRegistryProcessor:
             name = safe_decode_text(target)
             if name is not None and (text := _plain_string(value)) is not None:
                 constants[name] = text
-        elif value.type == cs.TS_PY_DICTIONARY:
+        elif value.type == cs.TS_PY_DICTIONARY and dict_registries:
             self._process_dict_registry(value, module_qn)
 
     def _process_dict_registry(self, dictionary: Node, module_qn: str) -> None:
@@ -351,6 +360,37 @@ class DispatchRegistryProcessor:
                 KEY_KIND: ResourceKind.DISPATCH.value,
             },
         )
+
+
+def _module_imports_dispatch_framework(root: Node) -> bool:
+    # True when any top-level import names a known task-queue / workflow
+    # framework (issue #1241). Relative imports are first-party and never
+    # match; only the leading dotted component is checked (`celery.result`
+    # -> `celery`).
+    for stmt in root.named_children:
+        if stmt.type == cs.TS_PY_IMPORT_STATEMENT:
+            targets = stmt.named_children
+        elif stmt.type == cs.TS_PY_IMPORT_FROM_STATEMENT:
+            module = stmt.child_by_field_name(cs.FIELD_MODULE_NAME)
+            targets = [module] if module is not None else []
+        else:
+            continue
+        for target in targets:
+            if _import_head(target) in DISPATCH_FRAMEWORK_MODULES:
+                return True
+    return False
+
+
+def _import_head(node: Node | None) -> str | None:
+    # Leading dotted component of an import target: `celery.app` -> `celery`.
+    # `celery.app as ca` unwraps the alias first; a relative import yields None.
+    if node is None:
+        return None
+    if node.type == cs.TS_ALIASED_IMPORT:
+        node = node.child_by_field_name(cs.FIELD_NAME)
+    if node is None or node.type != cs.TS_PY_DOTTED_NAME or not node.named_children:
+        return None
+    return safe_decode_text(node.named_children[0])
 
 
 def _resource_qn(key: str) -> str:

--- a/codebase_rag/parsers/io_access/constants.py
+++ b/codebase_rag/parsers/io_access/constants.py
@@ -42,28 +42,6 @@ class ResourceKind(StrEnum):
 # Dispatch registrar decorators (`@flow(name=...)`, `@task`) and the producer
 # keywords whose literal value names the dispatched key (issue #913).
 DISPATCH_REGISTRARS = frozenset({"flow", "task"})
-# Task-queue / workflow frameworks whose presence corroborates that a
-# `{str: function}` module-level dict is a genuine dispatch registry rather
-# than an ordinary lookup table (issue #1241). A bare name->function dict is a
-# common Python idiom (stream tables, command maps, plugin registries); only a
-# module that imports one of these frameworks may treat such a dict as DISPATCH.
-DISPATCH_FRAMEWORK_MODULES = frozenset(
-    {
-        "celery",
-        "prefect",
-        "dramatiq",
-        "rq",
-        "huey",
-        "taskiq",
-        "arq",
-        "faust",
-        "luigi",
-        "airflow",
-        "temporalio",
-        "nameko",
-        "kombu",
-    }
-)
 DISPATCH_PRODUCER_KEYWORDS = frozenset({"workflow_name"})
 DISPATCH_NAME_KEYWORD = "name"
 DISPATCH_DEPLOYMENT_SEPARATOR = "/"

--- a/codebase_rag/parsers/io_access/constants.py
+++ b/codebase_rag/parsers/io_access/constants.py
@@ -42,6 +42,28 @@ class ResourceKind(StrEnum):
 # Dispatch registrar decorators (`@flow(name=...)`, `@task`) and the producer
 # keywords whose literal value names the dispatched key (issue #913).
 DISPATCH_REGISTRARS = frozenset({"flow", "task"})
+# Task-queue / workflow frameworks whose presence corroborates that a
+# `{str: function}` module-level dict is a genuine dispatch registry rather
+# than an ordinary lookup table (issue #1241). A bare name->function dict is a
+# common Python idiom (stream tables, command maps, plugin registries); only a
+# module that imports one of these frameworks may treat such a dict as DISPATCH.
+DISPATCH_FRAMEWORK_MODULES = frozenset(
+    {
+        "celery",
+        "prefect",
+        "dramatiq",
+        "rq",
+        "huey",
+        "taskiq",
+        "arq",
+        "faust",
+        "luigi",
+        "airflow",
+        "temporalio",
+        "nameko",
+        "kombu",
+    }
+)
 DISPATCH_PRODUCER_KEYWORDS = frozenset({"workflow_name"})
 DISPATCH_NAME_KEYWORD = "name"
 DISPATCH_DEPLOYMENT_SEPARATOR = "/"

--- a/codebase_rag/tests/test_dispatch_registries.py
+++ b/codebase_rag/tests/test_dispatch_registries.py
@@ -578,6 +578,46 @@ def test_dict_registry_corroboration_without_query_protocol(tmp_path: Path) -> N
     ), ingestor.rels
 
 
+def test_dict_corroboration_tolerates_unreadable_graph(tmp_path: Path) -> None:
+    # A graph whose every read raises (briefly down mid-rebuild) must not abort
+    # finalize: the DB producer seed degrades to nothing and the dict registry
+    # simply goes uncorroborated (issue #1241).
+    from codebase_rag import constants as cs2
+    from codebase_rag.capture import ALL_ENABLED
+    from codebase_rag.parsers.dispatch_registry import DispatchRegistryProcessor
+    from codebase_rag.types_defs import NodeType
+
+    parsers, _ = load_parsers()
+
+    class _DownIngestor(MagicMock):
+        def fetch_all(self, query, params=None):  # noqa: ANN001, ANN201
+            raise RuntimeError("graph down")
+
+        def execute_write(self, query, params=None):  # noqa: ANN001, ANN201
+            return None
+
+    class _Registry:
+        def get(self, qn: str):  # noqa: ANN201
+            return NodeType.FUNCTION if qn.endswith(".handle") else None
+
+    class _Imports:
+        import_mapping: dict = {}
+
+    processor = DispatchRegistryProcessor(
+        ingestor=_DownIngestor(),
+        selection=ALL_ENABLED,
+        function_registry=_Registry(),
+        import_processor=_Imports(),
+    )
+    registry = parsers["python"].parse(
+        b'def handle(ctx):\n    return 1\n\nhandlers = {\n    "handle": handle,\n}\n'
+    )
+    processor.process_file(
+        registry.root_node, "proj.registry", cs2.SupportedLanguage.PYTHON
+    )
+    processor.finalize()  # must not raise
+
+
 def test_resolves_only_capture_still_links_suffix(tmp_path: Path) -> None:
     # With only RESOLVES_TO enabled, the suffix link (and its endpoint
     # nodes) must still emit; the audit inside _run guards the structure.

--- a/codebase_rag/tests/test_dispatch_registries.py
+++ b/codebase_rag/tests/test_dispatch_registries.py
@@ -50,16 +50,22 @@ def _run(
     }
 
 
-def test_dict_registry_exposes_each_entry(tmp_path: Path) -> None:
+def test_dict_registry_exposes_producer_corroborated_entries(tmp_path: Path) -> None:
+    # A `{str: func}` dict registers a handler ONLY for keys a producer
+    # actually dispatches to (issue #1241): both keys here are produced.
     files = {
         "handlers.py": (
-            "from celery import shared_task\n\n"
             "def plain(ctx):\n    return 1\n\n"
             "def with_factoid(ctx):\n    return 2\n\n"
             "handlers = {\n"
             '    "plain": plain,\n'
             '    "with_factoid": with_factoid,\n'
             "}\n"
+        ),
+        "producer.py": (
+            "def schedule(client):\n"
+            '    client.deploy(workflow_name="plain")\n'
+            '    client.deploy(workflow_name="with_factoid")\n'
         ),
     }
     rels = _run(tmp_path, files)
@@ -80,11 +86,13 @@ def test_annotated_dict_registry_exposes(tmp_path: Path) -> None:
     # The verified production shape carries a type annotation.
     files = {
         "registry.py": (
-            "import celery\n\n"
             "def plain(ctx):\n    return 1\n\n"
             "handlers: dict = {\n"
             '    "plain": plain,\n'
             "}\n"
+        ),
+        "producer.py": (
+            'def schedule(client):\n    client.deploy(workflow_name="plain")\n'
         ),
     }
     rels = _run(tmp_path, files)
@@ -98,27 +106,27 @@ def test_annotated_dict_registry_exposes(tmp_path: Path) -> None:
 
 def test_mixed_dict_is_not_a_registry(tmp_path: Path) -> None:
     # The all-entries gate: one non-string key or non-function value keeps
-    # arbitrary config dicts out entirely.
+    # arbitrary config dicts out even when a producer names the key.
     files = {
         "config.py": (
-            "import celery\n\n"
             "def plain(ctx):\n    return 1\n\n"
             "settings = {\n"
             '    "plain": plain,\n'
             '    "retries": 3,\n'
             "}\n"
         ),
+        "producer.py": (
+            'def schedule(client):\n    client.deploy(workflow_name="plain")\n'
+        ),
     }
     rels = _run(tmp_path, files)
-    assert not any("resource::DISPATCH::" in b for _a, _r, b in rels), rels
+    assert not any(EXPOSES == r for _a, r, _b in rels), rels
 
 
-def test_dict_registry_without_framework_import_is_not_a_registry(
-    tmp_path: Path,
-) -> None:
+def test_dict_registry_without_producer_stays_out(tmp_path: Path) -> None:
     # Issue #1241: click's stream tables map string keys to module functions
-    # but are plain lookup tables, not workflow dispatch. Without a task-queue /
-    # workflow framework import the dict must NOT emit DISPATCH resources.
+    # but nothing dispatches to those keys -- they are plain lookup tables, not
+    # workflow dispatch, so no DISPATCH resource or EXPOSES edge is emitted.
     files = {
         "_compat.py": (
             "def get_binary_stdin():\n    return 1\n\n"
@@ -135,22 +143,57 @@ def test_dict_registry_without_framework_import_is_not_a_registry(
     assert not any("resource::DISPATCH::" in b for _a, _r, b in rels), rels
 
 
-def test_relative_import_does_not_enable_dict_registry(tmp_path: Path) -> None:
-    # A relative import is first-party; its leading component is empty, so it
-    # never corroborates dispatch (issue #1241).
+def test_dict_registry_exposes_only_produced_keys(tmp_path: Path) -> None:
+    # Selective corroboration (issue #1241): a producer dispatches to only one
+    # of the dict's two keys, so only that entry registers; the unproduced key
+    # stays out.
     files = {
-        "pkg/__init__.py": "",
-        "pkg/handlers.py": "def plain(ctx):\n    return 1\n",
-        "pkg/registry.py": (
-            "from . import handlers\n\n"
-            "from .handlers import plain\n\n"
-            "table = {\n"
-            '    "plain": plain,\n'
+        "handlers.py": (
+            "def used(ctx):\n    return 1\n\n"
+            "def unused(ctx):\n    return 2\n\n"
+            "handlers = {\n"
+            '    "used": used,\n'
+            '    "unused": unused,\n'
             "}\n"
+        ),
+        "producer.py": (
+            'def schedule(client):\n    client.deploy(workflow_name="used")\n'
         ),
     }
     rels = _run(tmp_path, files)
-    assert not any("resource::DISPATCH::" in b for _a, _r, b in rels), rels
+    project = tmp_path.name
+    assert (
+        f"{project}.handlers.used",
+        EXPOSES,
+        "resource::DISPATCH::used",
+    ) in rels, rels
+    assert not any("resource::DISPATCH::unused" in b for _a, _r, b in rels), rels
+
+
+def test_dict_registry_corroborated_by_deployment_suffix_producer(
+    tmp_path: Path,
+) -> None:
+    # A producer dispatching `run-things/dev` corroborates the bare `run-things`
+    # dict registration it resolves onto (issue #1241), mirroring the
+    # deployment-suffix join.
+    files = {
+        "handlers.py": (
+            "def run_things(ctx):\n    return 1\n\n"
+            "handlers = {\n"
+            '    "run-things": run_things,\n'
+            "}\n"
+        ),
+        "producer.py": (
+            'def schedule(client):\n    client.deploy(workflow_name="run-things/dev")\n'
+        ),
+    }
+    rels = _run(tmp_path, files)
+    project = tmp_path.name
+    assert (
+        f"{project}.handlers.run_things",
+        EXPOSES,
+        "resource::DISPATCH::run-things",
+    ) in rels, rels
 
 
 def test_flow_decorator_with_name_exposes(tmp_path: Path) -> None:
@@ -272,11 +315,13 @@ def test_imported_handler_values_expose(tmp_path: Path) -> None:
         "pkg/__init__.py": "",
         "pkg/handlers.py": ("def execute_turn(ctx):\n    return 1\n"),
         "pkg/registry.py": (
-            "import celery\n\n"
             "from pkg.handlers import execute_turn\n\n"
             "handlers = {\n"
             '    "execute_turn": execute_turn,\n'
             "}\n"
+        ),
+        "pkg/producer.py": (
+            'def schedule(client):\n    client.deploy(workflow_name="execute_turn")\n'
         ),
     }
     rels = _run(tmp_path, files)
@@ -421,6 +466,116 @@ def test_finalize_seeds_registrations_from_database(tmp_path: Path) -> None:
         if str(c.args[1]) == RESOLVES_TO
     ]
     assert resolves, ingestor.ensure_relationship_batch.call_args_list
+
+
+def test_dict_registry_corroborated_by_database_producer(tmp_path: Path) -> None:
+    # Incremental runs reprocess only changed files: a dict registry in a
+    # changed file whose only producer lives in an untouched file must still be
+    # corroborated, seeded from the live graph's WRITES_TO edges (issue #1241).
+    from codebase_rag import constants as cs2
+    from codebase_rag.capture import ALL_ENABLED
+    from codebase_rag.parsers.dispatch_registry import DispatchRegistryProcessor
+    from codebase_rag.types_defs import NodeType
+
+    parsers, _ = load_parsers()
+
+    class _QueryIngestor(MagicMock):
+        def fetch_all(self, query, params=None):  # noqa: ANN001, ANN201
+            # WRITES_TO producers exist only in the DB; EXPOSES query is empty.
+            return [{"name": "execute_turn"}] if "WRITES_TO" in query else []
+
+        def execute_write(self, query, params=None):  # noqa: ANN001, ANN201
+            return None
+
+    class _Registry:
+        def get(self, qn: str):  # noqa: ANN201
+            return NodeType.FUNCTION if qn.endswith(".execute_turn") else None
+
+    class _Imports:
+        import_mapping: dict = {}
+
+    ingestor = _QueryIngestor()
+    processor = DispatchRegistryProcessor(
+        ingestor=ingestor,
+        selection=ALL_ENABLED,
+        function_registry=_Registry(),
+        import_processor=_Imports(),
+    )
+    registry = parsers["python"].parse(
+        b'def execute_turn(ctx):\n    return 1\n\nhandlers = {\n    "execute_turn": execute_turn,\n}\n'
+    )
+    processor.process_file(
+        registry.root_node, "proj.registry", cs2.SupportedLanguage.PYTHON
+    )
+    processor.finalize()
+    exposes = [
+        c
+        for c in ingestor.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) == EXPOSES
+    ]
+    assert any(c.args[2][2] == "resource::DISPATCH::execute_turn" for c in exposes), (
+        exposes
+    )
+
+
+def test_dict_registry_corroboration_without_query_protocol(tmp_path: Path) -> None:
+    # A non-QueryProtocol ingestor cannot seed producers from the graph, so
+    # corroboration rests solely on producers found in the processed files
+    # (issue #1241): the in-module producer is enough.
+    from codebase_rag import constants as cs2
+    from codebase_rag.capture import ALL_ENABLED
+    from codebase_rag.parsers.dispatch_registry import DispatchRegistryProcessor
+    from codebase_rag.types_defs import NodeType, PropertyDict
+
+    parsers, _ = load_parsers()
+
+    class _PlainIngestor:
+        # Deliberately lacks fetch_all / execute_write -> not a QueryProtocol.
+        def __init__(self) -> None:
+            self.rels: list[tuple[object, object, object]] = []
+
+        def ensure_node_batch(self, label: str, properties: PropertyDict) -> None:
+            return None
+
+        def ensure_relationship_batch(
+            self, from_spec: object, rel_type: object, to_spec: object, **_: object
+        ) -> None:
+            self.rels.append((from_spec, rel_type, to_spec))
+
+        def flush_all(self) -> None:
+            return None
+
+    class _Registry:
+        def get(self, qn: str):  # noqa: ANN201
+            return NodeType.FUNCTION if qn.endswith((".handle", ".schedule")) else None
+
+    class _Imports:
+        import_mapping: dict = {}
+
+    ingestor = _PlainIngestor()
+    processor = DispatchRegistryProcessor(
+        ingestor=ingestor,
+        selection=ALL_ENABLED,
+        function_registry=_Registry(),
+        import_processor=_Imports(),
+    )
+    registry = parsers["python"].parse(
+        b'def handle(ctx):\n    return 1\n\nhandlers = {\n    "handle": handle,\n}\n'
+    )
+    producer = parsers["python"].parse(
+        b'def schedule(client):\n    client.deploy(workflow_name="handle")\n'
+    )
+    processor.process_file(
+        registry.root_node, "proj.registry", cs2.SupportedLanguage.PYTHON
+    )
+    processor.process_file(
+        producer.root_node, "proj.producer", cs2.SupportedLanguage.PYTHON
+    )
+    processor.finalize()
+    assert any(
+        str(rel) == EXPOSES and to[2] == "resource::DISPATCH::handle"
+        for _frm, rel, to in ingestor.rels
+    ), ingestor.rels
 
 
 def test_resolves_only_capture_still_links_suffix(tmp_path: Path) -> None:

--- a/codebase_rag/tests/test_dispatch_registries.py
+++ b/codebase_rag/tests/test_dispatch_registries.py
@@ -53,6 +53,7 @@ def _run(
 def test_dict_registry_exposes_each_entry(tmp_path: Path) -> None:
     files = {
         "handlers.py": (
+            "from celery import shared_task\n\n"
             "def plain(ctx):\n    return 1\n\n"
             "def with_factoid(ctx):\n    return 2\n\n"
             "handlers = {\n"
@@ -79,6 +80,7 @@ def test_annotated_dict_registry_exposes(tmp_path: Path) -> None:
     # The verified production shape carries a type annotation.
     files = {
         "registry.py": (
+            "import celery\n\n"
             "def plain(ctx):\n    return 1\n\n"
             "handlers: dict = {\n"
             '    "plain": plain,\n'
@@ -99,10 +101,51 @@ def test_mixed_dict_is_not_a_registry(tmp_path: Path) -> None:
     # arbitrary config dicts out entirely.
     files = {
         "config.py": (
+            "import celery\n\n"
             "def plain(ctx):\n    return 1\n\n"
             "settings = {\n"
             '    "plain": plain,\n'
             '    "retries": 3,\n'
+            "}\n"
+        ),
+    }
+    rels = _run(tmp_path, files)
+    assert not any("resource::DISPATCH::" in b for _a, _r, b in rels), rels
+
+
+def test_dict_registry_without_framework_import_is_not_a_registry(
+    tmp_path: Path,
+) -> None:
+    # Issue #1241: click's stream tables map string keys to module functions
+    # but are plain lookup tables, not workflow dispatch. Without a task-queue /
+    # workflow framework import the dict must NOT emit DISPATCH resources.
+    files = {
+        "_compat.py": (
+            "def get_binary_stdin():\n    return 1\n\n"
+            "def get_binary_stdout():\n    return 2\n\n"
+            "def get_binary_stderr():\n    return 3\n\n"
+            "binary_streams = {\n"
+            '    "stdin": get_binary_stdin,\n'
+            '    "stdout": get_binary_stdout,\n'
+            '    "stderr": get_binary_stderr,\n'
+            "}\n"
+        ),
+    }
+    rels = _run(tmp_path, files)
+    assert not any("resource::DISPATCH::" in b for _a, _r, b in rels), rels
+
+
+def test_relative_import_does_not_enable_dict_registry(tmp_path: Path) -> None:
+    # A relative import is first-party; its leading component is empty, so it
+    # never corroborates dispatch (issue #1241).
+    files = {
+        "pkg/__init__.py": "",
+        "pkg/handlers.py": "def plain(ctx):\n    return 1\n",
+        "pkg/registry.py": (
+            "from . import handlers\n\n"
+            "from .handlers import plain\n\n"
+            "table = {\n"
+            '    "plain": plain,\n'
             "}\n"
         ),
     }
@@ -229,6 +272,7 @@ def test_imported_handler_values_expose(tmp_path: Path) -> None:
         "pkg/__init__.py": "",
         "pkg/handlers.py": ("def execute_turn(ctx):\n    return 1\n"),
         "pkg/registry.py": (
+            "import celery\n\n"
             "from pkg.handlers import execute_turn\n\n"
             "handlers = {\n"
             '    "execute_turn": execute_turn,\n'

--- a/codebase_rag/tests/test_dispatch_registries.py
+++ b/codebase_rag/tests/test_dispatch_registries.py
@@ -1,10 +1,11 @@
 # String-keyed dispatch registries (issue #913): a handler registered under a
-# string key (module-level dict registry, or a `@flow`/`@task` registrar
-# decorator) EXPOSES `resource::DISPATCH::<key>`; a producer scheduling work
-# with a recognised dispatch keyword emits a WRITES_TO sink on the same node,
-# so both sides meet without a resolution pass. A produced `name/deployment`
-# key resolves to the bare registered `name` when no exact registration
-# exists.
+# string key by a `@flow`/`@task` registrar decorator EXPOSES
+# `resource::DISPATCH::<key>`; a producer scheduling work with a recognised
+# dispatch keyword emits a WRITES_TO sink on the same node, so both sides meet
+# without a resolution pass. A produced `name/deployment` key resolves to the
+# bare registered `name` when no exact registration exists. A module-level
+# `{str: func}` dict is deliberately NOT a registry (issue #1241): it is an
+# ordinary lookup table and cannot be tied to a DISPATCH key by key text alone.
 from __future__ import annotations
 
 from pathlib import Path
@@ -50,150 +51,40 @@ def _run(
     }
 
 
-def test_dict_registry_exposes_producer_corroborated_entries(tmp_path: Path) -> None:
-    # A `{str: func}` dict registers a handler ONLY for keys a producer
-    # actually dispatches to (issue #1241): both keys here are produced.
-    files = {
-        "handlers.py": (
-            "def plain(ctx):\n    return 1\n\n"
-            "def with_factoid(ctx):\n    return 2\n\n"
-            "handlers = {\n"
-            '    "plain": plain,\n'
-            '    "with_factoid": with_factoid,\n'
-            "}\n"
-        ),
-        "producer.py": (
-            "def schedule(client):\n"
-            '    client.deploy(workflow_name="plain")\n'
-            '    client.deploy(workflow_name="with_factoid")\n'
-        ),
-    }
-    rels = _run(tmp_path, files)
-    project = tmp_path.name
-    assert (
-        f"{project}.handlers.plain",
-        EXPOSES,
-        "resource::DISPATCH::plain",
-    ) in rels, rels
-    assert (
-        f"{project}.handlers.with_factoid",
-        EXPOSES,
-        "resource::DISPATCH::with_factoid",
-    ) in rels, rels
-
-
-def test_annotated_dict_registry_exposes(tmp_path: Path) -> None:
-    # The verified production shape carries a type annotation.
-    files = {
-        "registry.py": (
-            "def plain(ctx):\n    return 1\n\n"
-            "handlers: dict = {\n"
-            '    "plain": plain,\n'
-            "}\n"
-        ),
-        "producer.py": (
-            'def schedule(client):\n    client.deploy(workflow_name="plain")\n'
-        ),
-    }
-    rels = _run(tmp_path, files)
-    project = tmp_path.name
-    assert (
-        f"{project}.registry.plain",
-        EXPOSES,
-        "resource::DISPATCH::plain",
-    ) in rels, rels
-
-
-def test_mixed_dict_is_not_a_registry(tmp_path: Path) -> None:
-    # The all-entries gate: one non-string key or non-function value keeps
-    # arbitrary config dicts out even when a producer names the key.
-    files = {
-        "config.py": (
-            "def plain(ctx):\n    return 1\n\n"
-            "settings = {\n"
-            '    "plain": plain,\n'
-            '    "retries": 3,\n'
-            "}\n"
-        ),
-        "producer.py": (
-            'def schedule(client):\n    client.deploy(workflow_name="plain")\n'
-        ),
-    }
-    rels = _run(tmp_path, files)
-    assert not any(EXPOSES == r for _a, r, _b in rels), rels
-
-
-def test_dict_registry_without_producer_stays_out(tmp_path: Path) -> None:
-    # Issue #1241: click's stream tables map string keys to module functions
-    # but nothing dispatches to those keys -- they are plain lookup tables, not
-    # workflow dispatch, so no DISPATCH resource or EXPOSES edge is emitted.
+def test_dict_is_never_a_dispatch_registry(tmp_path: Path) -> None:
+    # Issue #1241: a `{str: func}` dict is an ordinary lookup table, never a
+    # dispatch registry. It is indistinguishable from click's stream tables,
+    # command maps or plugin registries, and a DISPATCH resource keyed only by a
+    # bare string cannot be tied back to a specific dict. Even when an unrelated
+    # producer dispatches a colliding key, the dict must NOT expose a handler --
+    # only the producer's own WRITES_TO edge is emitted. Only explicit
+    # `@flow`/`@task` decorators register handlers.
     files = {
         "_compat.py": (
             "def get_binary_stdin():\n    return 1\n\n"
             "def get_binary_stdout():\n    return 2\n\n"
-            "def get_binary_stderr():\n    return 3\n\n"
             "binary_streams = {\n"
             '    "stdin": get_binary_stdin,\n'
             '    "stdout": get_binary_stdout,\n'
-            '    "stderr": get_binary_stderr,\n'
             "}\n"
         ),
-    }
-    rels = _run(tmp_path, files)
-    assert not any("resource::DISPATCH::" in b for _a, _r, b in rels), rels
-
-
-def test_dict_registry_exposes_only_produced_keys(tmp_path: Path) -> None:
-    # Selective corroboration (issue #1241): a producer dispatches to only one
-    # of the dict's two keys, so only that entry registers; the unproduced key
-    # stays out.
-    files = {
-        "handlers.py": (
-            "def used(ctx):\n    return 1\n\n"
-            "def unused(ctx):\n    return 2\n\n"
-            "handlers = {\n"
-            '    "used": used,\n'
-            '    "unused": unused,\n'
-            "}\n"
-        ),
+        # An unrelated producer that happens to dispatch a colliding key must
+        # not turn the lookup table above into a registry (the cross-module
+        # collision that key-text corroboration would wrongly join).
         "producer.py": (
-            'def schedule(client):\n    client.deploy(workflow_name="used")\n'
+            'def schedule(client):\n    client.deploy(workflow_name="stdin")\n'
         ),
     }
     rels = _run(tmp_path, files)
     project = tmp_path.name
+    # The producer still writes to its own dispatch node...
     assert (
-        f"{project}.handlers.used",
-        EXPOSES,
-        "resource::DISPATCH::used",
+        f"{project}.producer.schedule",
+        WRITES_TO,
+        "resource::DISPATCH::stdin",
     ) in rels, rels
-    assert not any("resource::DISPATCH::unused" in b for _a, _r, b in rels), rels
-
-
-def test_dict_registry_corroborated_by_deployment_suffix_producer(
-    tmp_path: Path,
-) -> None:
-    # A producer dispatching `run-things/dev` corroborates the bare `run-things`
-    # dict registration it resolves onto (issue #1241), mirroring the
-    # deployment-suffix join.
-    files = {
-        "handlers.py": (
-            "def run_things(ctx):\n    return 1\n\n"
-            "handlers = {\n"
-            '    "run-things": run_things,\n'
-            "}\n"
-        ),
-        "producer.py": (
-            'def schedule(client):\n    client.deploy(workflow_name="run-things/dev")\n'
-        ),
-    }
-    rels = _run(tmp_path, files)
-    project = tmp_path.name
-    assert (
-        f"{project}.handlers.run_things",
-        EXPOSES,
-        "resource::DISPATCH::run-things",
-    ) in rels, rels
+    # ...but the dict never exposes any handler.
+    assert not any(EXPOSES == r for _a, r, _b in rels), rels
 
 
 def test_flow_decorator_with_name_exposes(tmp_path: Path) -> None:
@@ -307,32 +198,6 @@ def test_dynamic_producer_value_stays_out(tmp_path: Path) -> None:
     assert not any("resource::DISPATCH::" in b for _a, _r, b in rels), rels
 
 
-def test_imported_handler_values_expose(tmp_path: Path) -> None:
-    # The verified production registry imports its handlers from sibling
-    # modules; values must resolve through the import map, not just the
-    # registry module's own scope.
-    files = {
-        "pkg/__init__.py": "",
-        "pkg/handlers.py": ("def execute_turn(ctx):\n    return 1\n"),
-        "pkg/registry.py": (
-            "from pkg.handlers import execute_turn\n\n"
-            "handlers = {\n"
-            '    "execute_turn": execute_turn,\n'
-            "}\n"
-        ),
-        "pkg/producer.py": (
-            'def schedule(client):\n    client.deploy(workflow_name="execute_turn")\n'
-        ),
-    }
-    rels = _run(tmp_path, files)
-    project = tmp_path.name
-    assert (
-        f"{project}.pkg.handlers.execute_turn",
-        EXPOSES,
-        "resource::DISPATCH::execute_turn",
-    ) in rels, rels
-
-
 def test_partial_capture_selections_never_dangle(tmp_path: Path) -> None:
     # Dropping either side's relationship must not leave the suffix
     # resolution with a dangling endpoint (the structural audit inside _run
@@ -384,15 +249,11 @@ def test_reprocessed_module_drops_stale_facts(tmp_path: Path) -> None:
 
             return NodeType.FUNCTION if qn.endswith(".run_things") else None
 
-    class _Imports:
-        import_mapping: dict = {}
-
     ingestor = MagicMock()
     processor = DispatchRegistryProcessor(
         ingestor=ingestor,
         selection=ALL_ENABLED,
         function_registry=_Registry(),
-        import_processor=_Imports(),
     )
     with_flow = parsers["python"].parse(
         b'from prefect import flow\n\n@flow(name="run-things")\ndef run_things():\n    return 1\n'
@@ -443,15 +304,11 @@ def test_finalize_seeds_registrations_from_database(tmp_path: Path) -> None:
 
             return NodeType.FUNCTION if qn.endswith(".schedule") else None
 
-    class _Imports:
-        import_mapping: dict = {}
-
     ingestor = _QueryIngestor()
     processor = DispatchRegistryProcessor(
         ingestor=ingestor,
         selection=ALL_ENABLED,
         function_registry=_Registry(),
-        import_processor=_Imports(),
     )
     producer = parsers["python"].parse(
         b'def schedule(client):\n    client.deploy(workflow_name="run-things/dev")\n'
@@ -468,120 +325,10 @@ def test_finalize_seeds_registrations_from_database(tmp_path: Path) -> None:
     assert resolves, ingestor.ensure_relationship_batch.call_args_list
 
 
-def test_dict_registry_corroborated_by_database_producer(tmp_path: Path) -> None:
-    # Incremental runs reprocess only changed files: a dict registry in a
-    # changed file whose only producer lives in an untouched file must still be
-    # corroborated, seeded from the live graph's WRITES_TO edges (issue #1241).
-    from codebase_rag import constants as cs2
-    from codebase_rag.capture import ALL_ENABLED
-    from codebase_rag.parsers.dispatch_registry import DispatchRegistryProcessor
-    from codebase_rag.types_defs import NodeType
-
-    parsers, _ = load_parsers()
-
-    class _QueryIngestor(MagicMock):
-        def fetch_all(self, query, params=None):  # noqa: ANN001, ANN201
-            # WRITES_TO producers exist only in the DB; EXPOSES query is empty.
-            return [{"name": "execute_turn"}] if "WRITES_TO" in query else []
-
-        def execute_write(self, query, params=None):  # noqa: ANN001, ANN201
-            return None
-
-    class _Registry:
-        def get(self, qn: str):  # noqa: ANN201
-            return NodeType.FUNCTION if qn.endswith(".execute_turn") else None
-
-    class _Imports:
-        import_mapping: dict = {}
-
-    ingestor = _QueryIngestor()
-    processor = DispatchRegistryProcessor(
-        ingestor=ingestor,
-        selection=ALL_ENABLED,
-        function_registry=_Registry(),
-        import_processor=_Imports(),
-    )
-    registry = parsers["python"].parse(
-        b'def execute_turn(ctx):\n    return 1\n\nhandlers = {\n    "execute_turn": execute_turn,\n}\n'
-    )
-    processor.process_file(
-        registry.root_node, "proj.registry", cs2.SupportedLanguage.PYTHON
-    )
-    processor.finalize()
-    exposes = [
-        c
-        for c in ingestor.ensure_relationship_batch.call_args_list
-        if str(c.args[1]) == EXPOSES
-    ]
-    assert any(c.args[2][2] == "resource::DISPATCH::execute_turn" for c in exposes), (
-        exposes
-    )
-
-
-def test_dict_registry_corroboration_without_query_protocol(tmp_path: Path) -> None:
-    # A non-QueryProtocol ingestor cannot seed producers from the graph, so
-    # corroboration rests solely on producers found in the processed files
-    # (issue #1241): the in-module producer is enough.
-    from codebase_rag import constants as cs2
-    from codebase_rag.capture import ALL_ENABLED
-    from codebase_rag.parsers.dispatch_registry import DispatchRegistryProcessor
-    from codebase_rag.types_defs import NodeType, PropertyDict
-
-    parsers, _ = load_parsers()
-
-    class _PlainIngestor:
-        # Deliberately lacks fetch_all / execute_write -> not a QueryProtocol.
-        def __init__(self) -> None:
-            self.rels: list[tuple[object, object, object]] = []
-
-        def ensure_node_batch(self, label: str, properties: PropertyDict) -> None:
-            return None
-
-        def ensure_relationship_batch(
-            self, from_spec: object, rel_type: object, to_spec: object, **_: object
-        ) -> None:
-            self.rels.append((from_spec, rel_type, to_spec))
-
-        def flush_all(self) -> None:
-            return None
-
-    class _Registry:
-        def get(self, qn: str):  # noqa: ANN201
-            return NodeType.FUNCTION if qn.endswith((".handle", ".schedule")) else None
-
-    class _Imports:
-        import_mapping: dict = {}
-
-    ingestor = _PlainIngestor()
-    processor = DispatchRegistryProcessor(
-        ingestor=ingestor,
-        selection=ALL_ENABLED,
-        function_registry=_Registry(),
-        import_processor=_Imports(),
-    )
-    registry = parsers["python"].parse(
-        b'def handle(ctx):\n    return 1\n\nhandlers = {\n    "handle": handle,\n}\n'
-    )
-    producer = parsers["python"].parse(
-        b'def schedule(client):\n    client.deploy(workflow_name="handle")\n'
-    )
-    processor.process_file(
-        registry.root_node, "proj.registry", cs2.SupportedLanguage.PYTHON
-    )
-    processor.process_file(
-        producer.root_node, "proj.producer", cs2.SupportedLanguage.PYTHON
-    )
-    processor.finalize()
-    assert any(
-        str(rel) == EXPOSES and to[2] == "resource::DISPATCH::handle"
-        for _frm, rel, to in ingestor.rels
-    ), ingestor.rels
-
-
-def test_dict_corroboration_tolerates_unreadable_graph(tmp_path: Path) -> None:
-    # A graph whose every read raises (briefly down mid-rebuild) must not abort
-    # finalize: the DB producer seed degrades to nothing and the dict registry
-    # simply goes uncorroborated (issue #1241).
+def test_registration_seed_tolerates_unreadable_graph(tmp_path: Path) -> None:
+    # The suffix-resolution pass seeds registered keys from the live graph. A
+    # read failure (the graph briefly down mid-rebuild) must degrade to no seeds
+    # rather than aborting finalize -- the rebuild has to complete regardless.
     from codebase_rag import constants as cs2
     from codebase_rag.capture import ALL_ENABLED
     from codebase_rag.parsers.dispatch_registry import DispatchRegistryProcessor
@@ -598,22 +345,18 @@ def test_dict_corroboration_tolerates_unreadable_graph(tmp_path: Path) -> None:
 
     class _Registry:
         def get(self, qn: str):  # noqa: ANN201
-            return NodeType.FUNCTION if qn.endswith(".handle") else None
-
-    class _Imports:
-        import_mapping: dict = {}
+            return NodeType.FUNCTION if qn.endswith(".schedule") else None
 
     processor = DispatchRegistryProcessor(
         ingestor=_DownIngestor(),
         selection=ALL_ENABLED,
         function_registry=_Registry(),
-        import_processor=_Imports(),
     )
-    registry = parsers["python"].parse(
-        b'def handle(ctx):\n    return 1\n\nhandlers = {\n    "handle": handle,\n}\n'
+    producer = parsers["python"].parse(
+        b'def schedule(client):\n    client.deploy(workflow_name="run-things/dev")\n'
     )
     processor.process_file(
-        registry.root_node, "proj.registry", cs2.SupportedLanguage.PYTHON
+        producer.root_node, "proj.producer", cs2.SupportedLanguage.PYTHON
     )
     processor.finalize()  # must not raise
 


### PR DESCRIPTION
Fixes #1241.

## Problem
`DispatchRegistryProcessor` treated **any** module-level dict mapping plain string literals to module-declared functions as a workflow-dispatch handler registry, emitting a `resource::DISPATCH::<key>` node + `EXPOSES` edge per entry. This is a common Python idiom (stream tables, command maps, plugin/handler registries), so the false-positive rate was high — indexing **pallets/click** produced three bogus `resource::DISPATCH::stdin/stdout/stderr` nodes from its stream-accessor tables.

## Fix — remove the dict-registry heuristic
A `{str: function}` dict is **indistinguishable from an ordinary lookup table**, and a DISPATCH resource keyed only by a bare string cannot be tied back to a specific dict — so *any* corroboration by key text alone manufactures false registries on coincidental collisions. Two iterations during review (a workflow-framework-import gate, then producer corroboration) each narrowed but did not eliminate the false-positive class, as review (Greptile, T-Rex-verified) demonstrated. 

The precision-honouring resolution is to **stop treating dict lookups as registries entirely**. Only an explicit `@flow`/`@task` registrar decorator now registers a handler. The producer `WRITES_TO` path and the deployment-suffix `RESOLVES_TO` path are unchanged, and the DB registration seed now degrades gracefully if the graph is briefly unreadable mid-rebuild. This restores the module's stated philosophy: *"a ceiling yields nothing, never a wrong link."*

## What's removed
`_process_dict_registry`, `_resolve_handler`, and the (now-unused) `import_processor` dependency of `DispatchRegistryProcessor`.

## Verification
- Re-indexing click: **3 → 0** bogus DISPATCH nodes ✓
- Regression test `test_dict_is_never_a_dispatch_registry` encodes the cross-module collision Greptile raised: a producer dispatching `workflow_name="stdin"` does **not** turn an unrelated `{"stdin": fn}` lookup into a registry — the producer still `WRITES_TO` its own node, but the dict exposes nothing.
- `@flow`/`@task`, producer-keyword, suffix-resolution, and graph-down-tolerance paths all covered. 21 dispatch + 32 io_access + cacheless-rebuild tests pass; lint + type clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dispatch handlers are now recognized only from explicitly supported flow and task registrations.
  * Ordinary name-to-function dictionaries are no longer exposed as dispatch registries.
  * Deployment-specific registrations resolve correctly.
  * Database and graph lookup failures now degrade gracefully without interrupting processing.

* **Documentation**
  * Clarified which registration patterns are supported.

* **Tests**
  * Expanded coverage for unsupported mappings, seeded registrations, key matching, and lookup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->