### PR TITLE
feat: add Python runtime call tracing with dynamic CALLS edge provenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ evals/oracles/scala_oracle/.scala-build/
 evals/oracles/scala_oracle/.bsp/
 .cgr-hash-cache.json
 .cgr-dir-mtimes.json
+
+# Runtime call traces (pytest --cgr-trace default output)
+cgr-trace.jsonl

--- a/codebase_rag/cli.py
+++ b/codebase_rag/cli.py
@@ -45,6 +45,7 @@ from .stack.constants import StackState
 from .stack.manager import StackError
 from .tools.health_checker import HealthChecker
 from .tools.language import cli as language_cli
+from .trace.cli import cli as trace_cli
 from .types_defs import DeadCodeConfig, DeadCodeRow, ResultRow
 from .utils.path_utils import derive_project_name, resolve_repo_path
 from .vector_store import clear_all_embeddings, delete_project_embeddings
@@ -950,6 +951,18 @@ def daemon_command(ctx: typer.Context) -> None:
 )
 def workspace_command(ctx: typer.Context) -> None:
     _run_delegated_group(workspace_cli, ctx)
+
+
+@app.command(
+    name=ch.CLICommandName.TRACE,
+    help=ch.CMD_TRACE,
+    short_help=ch.CMD_TRACE,
+    add_help_option=False,
+    context_settings=_DELEGATED_GROUP_CONTEXT,
+    rich_help_panel=ch.PANEL_GRAPH,
+)
+def trace_command(ctx: typer.Context) -> None:
+    _run_delegated_group(trace_cli, ctx)
 
 
 @app.command(

--- a/codebase_rag/cli_help.py
+++ b/codebase_rag/cli_help.py
@@ -253,6 +253,7 @@ CLI_COMMANDS: dict[CLICommandName, str] = {
     CLICommandName.DELETE_PROJECT: CMD_DELETE_PROJECT,
     CLICommandName.LANGUAGE: CMD_LANGUAGE,
     CLICommandName.DAEMON: CMD_DAEMON,
+    CLICommandName.TRACE: CMD_TRACE,
     CLICommandName.WORKSPACE: CMD_WORKSPACE,
     CLICommandName.STOP: CMD_STOP,
     CLICommandName.STATUS: CMD_STATUS,

--- a/codebase_rag/cli_help.py
+++ b/codebase_rag/cli_help.py
@@ -15,6 +15,7 @@ class CLICommandName(StrEnum):
     DELETE_PROJECT = "delete-project"
     DAEMON = "daemon"
     WORKSPACE = "workspace"
+    TRACE = "trace"
     STOP = "stop"
     STATUS = "status"
     HELP = "help"
@@ -67,6 +68,10 @@ CMD_WORKSPACE_SHOW = "Show the repositories and project names in a workspace"
 CMD_WORKSPACE_ADD_REPO = "Add a repository to a workspace"
 CMD_WORKSPACE_REMOVE_REPO = "Remove a repository from a workspace by path"
 
+CMD_TRACE = "Ingest runtime call traces as dynamic CALLS edges"
+CMD_TRACE_GROUP = CMD_TRACE
+CMD_TRACE_INGEST = "Resolve a trace file against a project and write dynamic edges"
+
 CMD_STOP = "Stop the shared stack (alias for cgr daemon down)"
 CMD_STATUS = "Show stack state and the last sync time for each project"
 
@@ -94,6 +99,19 @@ EXAMPLES_HELP = "EXAMPLES\n\n  cgr help start\n\n  cgr help daemon logs"
 EPILOG_LANGUAGE = "Run 'cgr help language COMMAND' for command-specific help."
 EPILOG_DAEMON = "Run 'cgr help daemon COMMAND' for command-specific help."
 EPILOG_WORKSPACE = "Run 'cgr help workspace COMMAND' for command-specific help."
+EPILOG_TRACE = "Run 'cgr help trace COMMAND' for command-specific help."
+
+HELP_TRACE_REPO_PATH = (
+    "Repository the trace was recorded against. Used to derive the project "
+    "name and re-anchor traced file paths."
+)
+HELP_TRACE_PROJECT_NAME = (
+    "Project name to ingest into. Defaults to the name derived from --repo-path."
+)
+EXAMPLES_TRACE_INGEST = (
+    "EXAMPLE\n\n  pytest --cgr-trace\n\n"
+    "  cgr trace ingest cgr-trace.jsonl --repo-path ./my-repo"
+)
 
 HELP_WORKSPACE_DESCRIPTION = "Optional short description for the workspace."
 HELP_WORKSPACE_FORCE = "Overwrite an existing workspace with the same name."

--- a/codebase_rag/constants/__init__.py
+++ b/codebase_rag/constants/__init__.py
@@ -28,3 +28,4 @@ from .providers import *  # noqa: F403
 from .security import *  # noqa: F403
 from .stdlib_types import *  # noqa: F403
 from .structural import *  # noqa: F403
+from .trace import *  # noqa: F403

--- a/codebase_rag/constants/trace.py
+++ b/codebase_rag/constants/trace.py
@@ -1,0 +1,79 @@
+"""Constants for dynamic runtime call-trace capture and ingestion."""
+
+from enum import StrEnum
+
+# Interchange format (one JSON object per line; first line is the header).
+TRACE_FORMAT_VERSION = 1
+TRACE_KIND_HEADER = "header"
+TRACE_KIND_CALL = "call"
+
+TRACE_KEY_KIND = "kind"
+TRACE_KEY_VERSION = "version"
+TRACE_KEY_LANGUAGE = "language"
+TRACE_KEY_REPO_ROOT = "repo_root"
+TRACE_KEY_TRACER = "tracer"
+TRACE_KEY_CALLER = "caller"
+TRACE_KEY_CALLEE = "callee"
+TRACE_KEY_PATH = "path"
+TRACE_KEY_QUALNAME = "qualname"
+TRACE_KEY_LINE = "line"
+TRACE_KEY_COUNT = "count"
+TRACE_KEY_WORKLOADS = "workloads"
+TRACE_KEY_RECEIVER_TYPES = "receiver_types"
+
+TRACE_LANGUAGE_PYTHON = "python"
+TRACE_TOOL_NAME = "cgr-trace"
+TRACE_DEFAULT_OUTPUT = "cgr-trace.jsonl"
+
+# Python runtime qualname markers.
+TRACE_QUALNAME_LOCALS = "<locals>"
+TRACE_QUALNAME_MODULE = "<module>"
+TRACE_SYNTHETIC_PREFIX = "<"
+
+# Installed-dependency code frequently lives under the repo root (virtualenvs,
+# vendored packages); frames whose path contains any of these fragments are
+# not project code and are skipped at capture time.
+TRACE_EXCLUDED_PATH_PARTS = ("/site-packages/", "/.venv/", "/node_modules/")
+
+# Names whose first parameter marks a bound receiver worth sampling.
+TRACE_RECEIVER_PARAMS = ("self", "cls")
+# Receiver types are sampled only for the first N observations of a pair to
+# bound the cost of materialising frame locals on hot paths.
+TRACE_RECEIVER_SAMPLE_LIMIT = 8
+
+# Caps applied when writing edge properties so graph rows stay bounded.
+TRACE_MAX_WORKLOADS_PER_EDGE = 20
+TRACE_MAX_RECEIVER_TYPES_PER_EDGE = 10
+
+# Properties stored on CALLS edges by trace ingestion. A `dynamic` edge that
+# `static_missed` is a relationship the static passes could not see (dynamic
+# dispatch, reflection, registries); one without the flag confirms a static
+# edge at runtime.
+TRACE_PROP_DYNAMIC = "dynamic"
+TRACE_PROP_CALL_COUNT = "dynamic_call_count"
+TRACE_PROP_WORKLOADS = "dynamic_workloads"
+TRACE_PROP_WORKLOAD_COUNT = "dynamic_workload_count"
+TRACE_PROP_RECEIVER_TYPES = "dynamic_receiver_types"
+TRACE_PROP_STATIC_MISSED = "static_missed"
+
+
+class TraceUnresolvedReason(StrEnum):
+    """Why a traced frame could not be mapped to a graph node."""
+
+    OUTSIDE_REPO = "outside_repo"
+    SYNTHETIC = "synthetic"
+    UNKNOWN_PATH = "unknown_path"
+    NO_MATCH = "no_match"
+
+
+TRACE_ERR_BAD_HEADER = "Trace file {path} does not start with a valid cgr trace header."
+TRACE_ERR_VERSION = (
+    "Trace file {path} has format version {found}; this build reads version {expected}."
+)
+TRACE_ERR_BAD_RECORD = "Trace file {path} line {line}: malformed record."
+
+TRACE_MSG_INGEST_SUMMARY = (
+    "records={records} edges={edges} confirmed_static={confirmed} "
+    "static_missed={missed} unresolved={unresolved}"
+)
+TRACE_MSG_UNRESOLVED_DETAIL = "  unresolved[{reason}]={count}"

--- a/codebase_rag/constants/trace.py
+++ b/codebase_rag/constants/trace.py
@@ -31,9 +31,11 @@ TRACE_QUALNAME_MODULE = "<module>"
 TRACE_SYNTHETIC_PREFIX = "<"
 
 # Installed-dependency code frequently lives under the repo root (virtualenvs,
-# vendored packages); frames whose path contains any of these fragments are
-# not project code and are skipped at capture time.
-TRACE_EXCLUDED_PATH_PARTS = ("/site-packages/", "/.venv/", "/node_modules/")
+# vendored packages); frames whose path contains any of these directory names
+# are not project code and are skipped at capture time. Bare names, not
+# separator-delimited fragments, so matching works with both POSIX and Windows
+# separators in co_filename.
+TRACE_EXCLUDED_DIR_NAMES = frozenset({"site-packages", ".venv", "node_modules"})
 
 # Names whose first parameter marks a bound receiver worth sampling.
 TRACE_RECEIVER_PARAMS = ("self", "cls")

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -168,6 +168,25 @@ LIMIT 1
 """
 
 
+# Trace-ingestion fetches: every callable (plus Module, for module-level
+# callers) of one project, and the already-present CALLS pairs so runtime-only
+# edges can be flagged as static_missed.
+CYPHER_TRACE_CALLABLES = """
+MATCH (n)
+WHERE (n:Function OR n:Method OR n:Module)
+  AND n.qualified_name STARTS WITH $prefix
+RETURN labels(n)[0] AS label, n.qualified_name AS qualified_name,
+       n.path AS path, n.start_line AS start_line, n.end_line AS end_line
+"""
+
+CYPHER_TRACE_EXISTING_CALLS = """
+MATCH (a)-[r:CALLS]->(b)
+WHERE a.qualified_name STARTS WITH $prefix
+  AND b.qualified_name STARTS WITH $prefix
+RETURN a.qualified_name AS from_qn, b.qualified_name AS to_qn
+"""
+
+
 CYPHER_STATS_NODE_COUNTS = """
 MATCH (n)
 RETURN labels(n) AS labels, count(*) AS count

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -169,8 +169,11 @@ LIMIT 1
 
 
 # Trace-ingestion fetches: every callable (plus Module, for module-level
-# callers) of one project, and the already-present CALLS pairs so runtime-only
-# edges can be flagged as static_missed.
+# callers) of one project, and the statically discovered CALLS pairs so
+# runtime-only edges can be flagged as static_missed. Edges a previous trace
+# ingestion created (static_missed = true) are excluded, otherwise
+# re-ingesting a trace would reclassify its own runtime-only edges as
+# statically confirmed.
 CYPHER_TRACE_CALLABLES = """
 MATCH (n)
 WHERE (n:Function OR n:Method OR n:Module)
@@ -183,6 +186,7 @@ CYPHER_TRACE_EXISTING_CALLS = """
 MATCH (a)-[r:CALLS]->(b)
 WHERE a.qualified_name STARTS WITH $prefix
   AND b.qualified_name STARTS WITH $prefix
+  AND coalesce(r.static_missed, false) = false
 RETURN a.qualified_name AS from_qn, b.qualified_name AS to_qn
 """
 

--- a/codebase_rag/tests/conftest.py
+++ b/codebase_rag/tests/conftest.py
@@ -25,6 +25,9 @@ if TYPE_CHECKING:
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
+# pytester drives the cgr-trace pytest plugin end-to-end in its own sessions.
+pytest_plugins = ["pytester"]
+
 
 class NodeProtocol(Protocol):
     @property

--- a/codebase_rag/tests/test_cli_smoke.py
+++ b/codebase_rag/tests/test_cli_smoke.py
@@ -145,3 +145,9 @@ def test_help_command_rejects_unknown_command() -> None:
 
 def test_command_summaries_are_single_line() -> None:
     assert all("\n" not in summary for summary in ch.CLI_COMMANDS.values())
+
+
+def test_every_command_name_has_a_registry_entry() -> None:
+    # CLI_COMMANDS feeds the generated command tables (README, help); a
+    # CLICommandName member missing from it silently drops the command there.
+    assert set(ch.CLI_COMMANDS) == set(ch.CLICommandName)

--- a/codebase_rag/tests/test_dynamic_trace_cli.py
+++ b/codebase_rag/tests/test_dynamic_trace_cli.py
@@ -1,0 +1,89 @@
+# `cgr trace ingest` must run the ingestion pipeline against the configured
+# graph, print the resolution summary, and fail cleanly on malformed trace
+# files (issue #1246).
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+from click.testing import CliRunner
+
+from codebase_rag import constants as cs
+from codebase_rag.trace.cli import cli
+from codebase_rag.trace.records import TraceHeader, write_trace_file
+
+
+class _RecordingGraph:
+    def __init__(self):
+        self.queries = []
+
+    def fetch_all(self, query, params=None):
+        self.queries.append(query)
+        return []
+
+    def ensure_relationship_batch(self, from_spec, rel_type, to_spec, properties=None):
+        raise AssertionError("an empty trace must not write edges")
+
+    def flush_all(self):
+        pass
+
+
+def _patch_graph(monkeypatch, graph):
+    @contextmanager
+    def _connect(batch_size):
+        yield graph
+
+    monkeypatch.setattr("codebase_rag.main.connect_memgraph", _connect)
+
+
+def _write_header_only_trace(tmp_path):
+    trace_path = tmp_path / "trace.jsonl"
+    header = TraceHeader(
+        version=cs.TRACE_FORMAT_VERSION,
+        language=cs.TRACE_LANGUAGE_PYTHON,
+        repo_root=str(tmp_path),
+        tracer=cs.TRACE_TOOL_NAME,
+    )
+    write_trace_file(trace_path, header, [])
+    return trace_path
+
+
+def test_ingest_command_prints_summary(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    trace_path = _write_header_only_trace(tmp_path)
+    graph = _RecordingGraph()
+    _patch_graph(monkeypatch, graph)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "ingest",
+            str(trace_path),
+            "--repo-path",
+            str(repo),
+            "--project-name",
+            "proj",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "records:          0" in result.output
+    assert "edges written:    0" in result.output
+    assert len(graph.queries) == 2
+
+
+def test_ingest_command_fails_cleanly_on_malformed_trace(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    trace_path = tmp_path / "trace.jsonl"
+    trace_path.write_text("not a trace\n")
+    _patch_graph(monkeypatch, _RecordingGraph())
+
+    result = CliRunner().invoke(
+        cli,
+        ["ingest", str(trace_path), "--repo-path", str(repo)],
+    )
+
+    assert result.exit_code == 1
+    assert "header" in result.output.lower()

--- a/codebase_rag/tests/test_dynamic_trace_ingest.py
+++ b/codebase_rag/tests/test_dynamic_trace_ingest.py
@@ -1,0 +1,238 @@
+# Trace ingestion must decorate existing CALLS edges with dynamic provenance,
+# create runtime-only edges flagged static_missed, aggregate records that
+# resolve to the same edge, and stay idempotent across re-ingestion
+# (issue #1246).
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from codebase_rag import constants as cs
+from codebase_rag.cypher_queries import (
+    CYPHER_TRACE_CALLABLES,
+    CYPHER_TRACE_EXISTING_CALLS,
+)
+from codebase_rag.trace.ingest import ingest_trace
+from codebase_rag.trace.records import (
+    CallRecord,
+    FramePoint,
+    TraceHeader,
+    write_trace_file,
+)
+
+_PROJECT = "proj__deadbeef"
+
+
+class _FakeGraph:
+    """Duck-typed TraceGraphProtocol backed by canned query results."""
+
+    def __init__(self, callable_rows, existing_rows):
+        self._callable_rows = callable_rows
+        self._existing_rows = existing_rows
+        self.edges = []
+        self.flushed = 0
+
+    def fetch_all(self, query, params=None):
+        assert params == {cs.KEY_PREFIX: f"{_PROJECT}."}
+        if query == CYPHER_TRACE_CALLABLES:
+            return self._callable_rows
+        if query == CYPHER_TRACE_EXISTING_CALLS:
+            return self._existing_rows
+        raise AssertionError(f"unexpected query: {query}")
+
+    def execute_write(self, query, params=None):
+        raise AssertionError("ingestion must not issue raw writes")
+
+    def ensure_node_batch(self, label, properties):
+        raise AssertionError("ingestion must not create nodes")
+
+    def ensure_relationship_batch(self, from_spec, rel_type, to_spec, properties=None):
+        self.edges.append((from_spec, rel_type, to_spec, properties))
+
+    def flush_all(self):
+        self.flushed += 1
+
+
+def _callable_row(label, qualified_name, path, start_line, end_line):
+    return {
+        cs.KEY_LABEL: label,
+        cs.KEY_QUALIFIED_NAME: qualified_name,
+        cs.KEY_PATH: path,
+        cs.KEY_START_LINE: start_line,
+        cs.KEY_END_LINE: end_line,
+    }
+
+
+def _graph() -> _FakeGraph:
+    rows = [
+        _callable_row(
+            cs.NodeLabel.FUNCTION,
+            f"{_PROJECT}.pkg.registry.handle",
+            "pkg/registry.py",
+            5,
+            7,
+        ),
+        _callable_row(
+            cs.NodeLabel.FUNCTION,
+            f"{_PROJECT}.pkg.registry.greet",
+            "pkg/registry.py",
+            9,
+            10,
+        ),
+        _callable_row(
+            cs.NodeLabel.FUNCTION,
+            f"{_PROJECT}.pkg.entry.run_all",
+            "pkg/entry.py",
+            3,
+            8,
+        ),
+    ]
+    existing = [
+        {
+            cs.KEY_FROM_QN: f"{_PROJECT}.pkg.entry.run_all",
+            cs.KEY_TO_QN: f"{_PROJECT}.pkg.registry.handle",
+        }
+    ]
+    return _FakeGraph(rows, existing)
+
+
+def _record(repo: Path, caller, callee, count, workloads=()):
+    caller_rel, caller_qual, caller_line = caller
+    callee_rel, callee_qual, callee_line = callee
+    return CallRecord(
+        caller=FramePoint(
+            path=str(repo / caller_rel), qualname=caller_qual, line=caller_line
+        ),
+        callee=FramePoint(
+            path=str(repo / callee_rel), qualname=callee_qual, line=callee_line
+        ),
+        count=count,
+        workloads=tuple(workloads),
+        receiver_types=(),
+    )
+
+
+def _write_trace(repo: Path, trace_path: Path, records) -> None:
+    header = TraceHeader(
+        version=cs.TRACE_FORMAT_VERSION,
+        language=cs.TRACE_LANGUAGE_PYTHON,
+        repo_root=str(repo),
+        tracer=cs.TRACE_TOOL_NAME,
+    )
+    write_trace_file(trace_path, header, records)
+
+
+def test_ingest_confirms_static_and_flags_missed_edges(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    trace_path = tmp_path / "trace.jsonl"
+    _write_trace(
+        repo,
+        trace_path,
+        [
+            _record(
+                repo,
+                ("pkg/entry.py", "run_all", 3),
+                ("pkg/registry.py", "handle", 5),
+                4,
+                workloads=("t::one",),
+            ),
+            # Static analysis cannot see the registry dispatch; this edge must
+            # be created and flagged.
+            _record(
+                repo,
+                ("pkg/registry.py", "handle", 5),
+                ("pkg/registry.py", "greet", 9),
+                4,
+                workloads=("t::one", "t::two"),
+            ),
+        ],
+    )
+    graph = _graph()
+
+    summary = ingest_trace(trace_path, graph, repo, _PROJECT)
+
+    assert summary.records == 2
+    assert summary.edges == 2
+    assert summary.confirmed_static == 1
+    assert summary.static_missed == 1
+    assert summary.unresolved == 0
+    assert graph.flushed == 1
+
+    by_pair = {(frm[2], to[2]): props for (frm, _rel, to, props) in graph.edges}
+    confirmed = by_pair[
+        (f"{_PROJECT}.pkg.entry.run_all", f"{_PROJECT}.pkg.registry.handle")
+    ]
+    missed = by_pair[
+        (f"{_PROJECT}.pkg.registry.handle", f"{_PROJECT}.pkg.registry.greet")
+    ]
+    assert confirmed[cs.TRACE_PROP_DYNAMIC] is True
+    assert confirmed[cs.TRACE_PROP_STATIC_MISSED] is False
+    assert confirmed[cs.TRACE_PROP_CALL_COUNT] == 4
+    assert missed[cs.TRACE_PROP_STATIC_MISSED] is True
+    assert missed[cs.TRACE_PROP_WORKLOADS] == ["t::one", "t::two"]
+    assert missed[cs.TRACE_PROP_WORKLOAD_COUNT] == 2
+
+
+def test_ingest_aggregates_same_edge_and_is_idempotent(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    trace_path = tmp_path / "trace.jsonl"
+    # Two records resolving to the same edge (distinct caller lines within the
+    # same function) must merge into one write with summed counts.
+    _write_trace(
+        repo,
+        trace_path,
+        [
+            _record(
+                repo,
+                ("pkg/entry.py", "run_all", 3),
+                ("pkg/registry.py", "handle", 5),
+                2,
+            ),
+            _record(
+                repo,
+                ("pkg/entry.py", "run_all", 3),
+                ("pkg/registry.py", "handle", 5),
+                3,
+            ),
+        ],
+    )
+
+    first_graph = _graph()
+    first = ingest_trace(trace_path, first_graph, repo, _PROJECT)
+    second_graph = _graph()
+    second = ingest_trace(trace_path, second_graph, repo, _PROJECT)
+
+    assert first.edges == second.edges == 1
+    assert first_graph.edges == second_graph.edges
+    (_frm, _rel, _to, props) = first_graph.edges[0]
+    assert props[cs.TRACE_PROP_CALL_COUNT] == 5
+
+
+def test_ingest_counts_unresolved_frames(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    trace_path = tmp_path / "trace.jsonl"
+    _write_trace(
+        repo,
+        trace_path,
+        [
+            # Caller resolves; callee is a lambda the graph has no node for.
+            _record(
+                repo,
+                ("pkg/entry.py", "run_all", 3),
+                ("pkg/entry.py", "run_all.<locals>.<lambda>", 5),
+                1,
+            ),
+        ],
+    )
+    graph = _graph()
+
+    summary = ingest_trace(trace_path, graph, repo, _PROJECT)
+
+    assert summary.edges == 0
+    assert graph.edges == []
+    assert summary.resolution.unresolved == {
+        cs.TraceUnresolvedReason.SYNTHETIC.value: 1
+    }

--- a/codebase_rag/tests/test_dynamic_trace_ingest.py
+++ b/codebase_rag/tests/test_dynamic_trace_ingest.py
@@ -24,20 +24,34 @@ _PROJECT = "proj__deadbeef"
 
 
 class _FakeGraph:
-    """Duck-typed TraceGraphProtocol backed by canned query results."""
+    """Duck-typed TraceGraphProtocol modelling MERGE + existing-calls filtering.
+
+    Edges written via ``ensure_relationship_batch`` persist, and the
+    existing-calls query only reports edges without ``static_missed`` set, the
+    way ``CYPHER_TRACE_EXISTING_CALLS`` filters them, so re-ingestion tests
+    observe the state a prior ingestion left behind.
+    """
 
     def __init__(self, callable_rows, existing_rows):
         self._callable_rows = callable_rows
-        self._existing_rows = existing_rows
+        self._static_rows = existing_rows
         self.edges = []
         self.flushed = 0
+
+    def _existing_call_rows(self):
+        rows = list(self._static_rows)
+        for from_spec, _rel, to_spec, props in self.edges:
+            if props and props.get(cs.TRACE_PROP_STATIC_MISSED):
+                continue
+            rows.append({cs.KEY_FROM_QN: from_spec[2], cs.KEY_TO_QN: to_spec[2]})
+        return rows
 
     def fetch_all(self, query, params=None):
         assert params == {cs.KEY_PREFIX: f"{_PROJECT}."}
         if query == CYPHER_TRACE_CALLABLES:
             return self._callable_rows
         if query == CYPHER_TRACE_EXISTING_CALLS:
-            return self._existing_rows
+            return self._existing_call_rows()
         raise AssertionError(f"unexpected query: {query}")
 
     def execute_write(self, query, params=None):
@@ -199,15 +213,45 @@ def test_ingest_aggregates_same_edge_and_is_idempotent(tmp_path):
         ],
     )
 
-    first_graph = _graph()
-    first = ingest_trace(trace_path, first_graph, repo, _PROJECT)
-    second_graph = _graph()
-    second = ingest_trace(trace_path, second_graph, repo, _PROJECT)
+    graph = _graph()
+    first = ingest_trace(trace_path, graph, repo, _PROJECT)
+    second = ingest_trace(trace_path, graph, repo, _PROJECT)
 
     assert first.edges == second.edges == 1
-    assert first_graph.edges == second_graph.edges
-    (_frm, _rel, _to, props) = first_graph.edges[0]
+    assert graph.edges[0] == graph.edges[1]
+    (_frm, _rel, _to, props) = graph.edges[0]
     assert props[cs.TRACE_PROP_CALL_COUNT] == 5
+
+
+def test_reingest_preserves_runtime_only_classification(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    trace_path = tmp_path / "trace.jsonl"
+    # Static analysis cannot see this registry dispatch, so the first
+    # ingestion creates the edge with static_missed. The second ingestion then
+    # observes that edge in the graph; it must not mistake it for static
+    # confirmation and flip static_missed off.
+    _write_trace(
+        repo,
+        trace_path,
+        [
+            _record(
+                repo,
+                ("pkg/registry.py", "handle", 5),
+                ("pkg/registry.py", "greet", 9),
+                4,
+            ),
+        ],
+    )
+
+    graph = _graph()
+    first = ingest_trace(trace_path, graph, repo, _PROJECT)
+    second = ingest_trace(trace_path, graph, repo, _PROJECT)
+
+    assert first.static_missed == second.static_missed == 1
+    assert second.confirmed_static == 0
+    for _frm, _rel, _to, props in graph.edges:
+        assert props[cs.TRACE_PROP_STATIC_MISSED] is True
 
 
 def test_ingest_counts_unresolved_frames(tmp_path):

--- a/codebase_rag/tests/test_dynamic_trace_pytest_plugin.py
+++ b/codebase_rag/tests/test_dynamic_trace_pytest_plugin.py
@@ -1,0 +1,58 @@
+# End-to-end: `pytest --cgr-trace` must trace the session, tag records with
+# the test's node id as workload provenance, and write a readable trace file
+# at session end (issue #1246). Runs pytest in a subprocess so the inner
+# session's sys.monitoring profiler registration cannot collide with the
+# outer session's tooling.
+
+from __future__ import annotations
+
+import pytest
+
+from codebase_rag.trace.records import read_trace_file
+
+pytest_plugins = ["pytester"]
+
+
+@pytest.mark.slow
+def test_plugin_traces_session_and_tags_workloads(pytester: pytest.Pytester):
+    pytester.makepyfile(
+        app_under_trace=(
+            "def helper():\n    return 1\n\n\ndef entry():\n    return helper()\n"
+        )
+    )
+    pytester.makepyfile(
+        test_traced=(
+            "import app_under_trace\n"
+            "\n"
+            "\n"
+            "def test_entry():\n"
+            "    assert app_under_trace.entry() == 1\n"
+        )
+    )
+
+    # The plugin auto-loads through the pytest11 entry point; passing -p as
+    # well would register the module twice and abort the session.
+    result = pytester.runpytest_subprocess("--cgr-trace")
+
+    result.assert_outcomes(passed=1)
+    trace_file = pytester.path / "cgr-trace.jsonl"
+    assert trace_file.exists()
+
+    header, records_iter = read_trace_file(trace_file)
+    records = list(records_iter)
+    assert header.repo_root == str(pytester.path)
+
+    by_pair = {(r.caller.qualname, r.callee.qualname): r for r in records}
+    edge = by_pair.get(("entry", "helper"))
+    assert edge is not None, sorted(by_pair)
+    assert edge.count == 1
+    assert edge.workloads == ("test_traced.py::test_entry",)
+
+
+def test_plugin_is_inert_without_flag(pytester: pytest.Pytester):
+    pytester.makepyfile(test_noop="def test_ok():\n    assert True\n")
+
+    result = pytester.runpytest_subprocess()
+
+    result.assert_outcomes(passed=1)
+    assert not (pytester.path / "cgr-trace.jsonl").exists()

--- a/codebase_rag/tests/test_dynamic_trace_pytest_plugin.py
+++ b/codebase_rag/tests/test_dynamic_trace_pytest_plugin.py
@@ -13,8 +13,6 @@ import pytest
 from codebase_rag.trace.pytest_plugin import _OPT_OUTPUT, _output_path
 from codebase_rag.trace.records import read_trace_file
 
-pytest_plugins = ["pytester"]
-
 
 class _StubConfig:
     """Just enough of pytest.Config for output-path resolution."""
@@ -75,6 +73,44 @@ def test_plugin_traces_session_and_tags_workloads(pytester: pytest.Pytester):
     assert edge is not None, sorted(by_pair)
     assert edge.count == 1
     assert edge.workloads == ("test_traced.py::test_entry",)
+
+
+def test_plugin_hooks_run_in_process(pytester: pytest.Pytester):
+    # The subprocess variant above proves end-to-end behaviour; this
+    # in-process run exercises the hook implementations where coverage can
+    # observe them. It needs the profiler slot, so it skips under an outer
+    # `--cgr-trace` session.
+    import sys
+
+    try:
+        sys.monitoring.use_tool_id(sys.monitoring.PROFILER_ID, "probe")
+    except ValueError:
+        pytest.skip("sys.monitoring PROFILER_ID already claimed in this session")
+    sys.monitoring.free_tool_id(sys.monitoring.PROFILER_ID)
+
+    pytester.makepyfile(
+        app_in_process=(
+            "def helper():\n    return 2\n\n\ndef entry():\n    return helper()\n"
+        )
+    )
+    pytester.makepyfile(
+        test_in_process=(
+            "import app_in_process\n"
+            "\n"
+            "\n"
+            "def test_entry():\n"
+            "    assert app_in_process.entry() == 2\n"
+        )
+    )
+
+    result = pytester.runpytest_inprocess("--cgr-trace")
+
+    result.assert_outcomes(passed=1)
+    header, records_iter = read_trace_file(pytester.path / "cgr-trace.jsonl")
+    by_pair = {(r.caller.qualname, r.callee.qualname): r for r in records_iter}
+    edge = by_pair.get(("entry", "helper"))
+    assert edge is not None, sorted(by_pair)
+    assert edge.workloads == ("test_in_process.py::test_entry",)
 
 
 def test_plugin_is_inert_without_flag(pytester: pytest.Pytester):

--- a/codebase_rag/tests/test_dynamic_trace_pytest_plugin.py
+++ b/codebase_rag/tests/test_dynamic_trace_pytest_plugin.py
@@ -27,6 +27,26 @@ class _StubConfig:
         return self._output
 
 
+def test_plugin_module_defers_tracer_imports():
+    # The pytest11 entry point makes pytest import this module at startup in
+    # every session, before coverage tooling initialises and regardless of
+    # whether tracing is enabled; the tracer machinery must load only when a
+    # hook actually needs it.
+    import subprocess
+    import sys
+
+    probe = (
+        "import sys; import codebase_rag.trace.pytest_plugin; "
+        "leaked = [m for m in sys.modules if m in ("
+        "'codebase_rag.trace.tracer', 'codebase_rag.trace.records')]; "
+        "raise SystemExit(1 if leaked else 0)"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe], capture_output=True, check=False
+    )
+    assert result.returncode == 0
+
+
 def test_output_path_is_unchanged_without_xdist():
     assert _output_path(_StubConfig("cgr-trace.jsonl")) == Path("cgr-trace.jsonl")
 

--- a/codebase_rag/tests/test_dynamic_trace_pytest_plugin.py
+++ b/codebase_rag/tests/test_dynamic_trace_pytest_plugin.py
@@ -6,11 +6,39 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
+from codebase_rag.trace.pytest_plugin import _OPT_OUTPUT, _output_path
 from codebase_rag.trace.records import read_trace_file
 
 pytest_plugins = ["pytester"]
+
+
+class _StubConfig:
+    """Just enough of pytest.Config for output-path resolution."""
+
+    def __init__(self, output: str, workerid: str | None = None) -> None:
+        self._output = output
+        if workerid is not None:
+            self.workerinput = {"workerid": workerid}
+
+    def getoption(self, name: str) -> str:
+        assert name == _OPT_OUTPUT
+        return self._output
+
+
+def test_output_path_is_unchanged_without_xdist():
+    assert _output_path(_StubConfig("cgr-trace.jsonl")) == Path("cgr-trace.jsonl")
+
+
+def test_output_path_gets_worker_suffix_under_xdist():
+    # Under pytest-xdist every worker writes at session end; without a
+    # per-worker name they would all overwrite the same file.
+    assert _output_path(_StubConfig("cgr-trace.jsonl", workerid="gw1")) == Path(
+        "cgr-trace-gw1.jsonl"
+    )
 
 
 @pytest.mark.slow

--- a/codebase_rag/tests/test_dynamic_trace_records.py
+++ b/codebase_rag/tests/test_dynamic_trace_records.py
@@ -1,0 +1,60 @@
+# The trace interchange parser must reject malformed records instead of
+# letting corrupted values (bool masquerading as int, non-positive counts)
+# flow into graph edge properties (issue #1246).
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.trace.records import TraceFormatError, read_trace_file
+
+
+def _frame(line: object = 3) -> dict[str, object]:
+    return {
+        cs.TRACE_KEY_PATH: "/repo/pkg/mod.py",
+        cs.TRACE_KEY_QUALNAME: "fn",
+        cs.TRACE_KEY_LINE: line,
+    }
+
+
+def _write_trace(tmp_path, count: object = 1, line: object = 3):
+    header = {
+        cs.TRACE_KEY_KIND: cs.TRACE_KIND_HEADER,
+        cs.TRACE_KEY_VERSION: cs.TRACE_FORMAT_VERSION,
+        cs.TRACE_KEY_LANGUAGE: cs.TRACE_LANGUAGE_PYTHON,
+        cs.TRACE_KEY_REPO_ROOT: "/repo",
+        cs.TRACE_KEY_TRACER: cs.TRACE_TOOL_NAME,
+    }
+    record = {
+        cs.TRACE_KEY_KIND: cs.TRACE_KIND_CALL,
+        cs.TRACE_KEY_CALLER: _frame(),
+        cs.TRACE_KEY_CALLEE: _frame(line),
+        cs.TRACE_KEY_COUNT: count,
+        cs.TRACE_KEY_WORKLOADS: [],
+        cs.TRACE_KEY_RECEIVER_TYPES: [],
+    }
+    trace_path = tmp_path / "trace.jsonl"
+    trace_path.write_text(json.dumps(header) + "\n" + json.dumps(record) + "\n")
+    return trace_path
+
+
+def test_valid_record_parses(tmp_path):
+    _header, records = read_trace_file(_write_trace(tmp_path))
+    assert [r.count for r in records] == [1]
+
+
+@pytest.mark.parametrize("count", [True, False, 0, -1, "3", None, 1.5])
+def test_non_positive_or_non_int_count_is_rejected(tmp_path, count):
+    _header, records = read_trace_file(_write_trace(tmp_path, count=count))
+    with pytest.raises(TraceFormatError):
+        list(records)
+
+
+@pytest.mark.parametrize("line", [True, -1, "3", None])
+def test_bool_or_negative_line_is_rejected(tmp_path, line):
+    _header, records = read_trace_file(_write_trace(tmp_path, line=line))
+    with pytest.raises(TraceFormatError):
+        list(records)

--- a/codebase_rag/tests/test_dynamic_trace_records.py
+++ b/codebase_rag/tests/test_dynamic_trace_records.py
@@ -58,3 +58,78 @@ def test_bool_or_negative_line_is_rejected(tmp_path, line):
     _header, records = read_trace_file(_write_trace(tmp_path, line=line))
     with pytest.raises(TraceFormatError):
         list(records)
+
+
+def _write_raw(tmp_path, *lines: str):
+    trace_path = tmp_path / "trace.jsonl"
+    trace_path.write_text("\n".join(lines) + "\n")
+    return trace_path
+
+
+def _header_line(**overrides) -> str:
+    header = {
+        cs.TRACE_KEY_KIND: cs.TRACE_KIND_HEADER,
+        cs.TRACE_KEY_VERSION: cs.TRACE_FORMAT_VERSION,
+        cs.TRACE_KEY_LANGUAGE: cs.TRACE_LANGUAGE_PYTHON,
+        cs.TRACE_KEY_REPO_ROOT: "/repo",
+        cs.TRACE_KEY_TRACER: cs.TRACE_TOOL_NAME,
+    }
+    header.update(overrides)
+    return json.dumps(header)
+
+
+def test_empty_file_is_rejected(tmp_path):
+    trace_path = tmp_path / "trace.jsonl"
+    trace_path.write_text("")
+
+    with pytest.raises(TraceFormatError):
+        read_trace_file(trace_path)
+
+
+@pytest.mark.parametrize(
+    "first_line",
+    [
+        "not json at all",
+        json.dumps({"kind": "call"}),
+        json.dumps([1, 2, 3]),
+    ],
+)
+def test_malformed_header_is_rejected(tmp_path, first_line):
+    with pytest.raises(TraceFormatError):
+        read_trace_file(_write_raw(tmp_path, first_line))
+
+
+def test_unsupported_version_is_rejected(tmp_path):
+    trace_path = _write_raw(
+        tmp_path, _header_line(**{cs.TRACE_KEY_VERSION: cs.TRACE_FORMAT_VERSION + 1})
+    )
+
+    with pytest.raises(TraceFormatError) as excinfo:
+        read_trace_file(trace_path)
+    assert str(cs.TRACE_FORMAT_VERSION + 1) in str(excinfo.value)
+
+
+def test_non_string_header_field_is_rejected(tmp_path):
+    with pytest.raises(TraceFormatError):
+        read_trace_file(
+            _write_raw(tmp_path, _header_line(**{cs.TRACE_KEY_LANGUAGE: 7}))
+        )
+
+
+@pytest.mark.parametrize("record_line", ["{broken", "42", json.dumps({"kind": "call"})])
+def test_malformed_record_line_is_rejected(tmp_path, record_line):
+    _header, records = read_trace_file(
+        _write_raw(tmp_path, _header_line(), record_line)
+    )
+
+    with pytest.raises(TraceFormatError) as excinfo:
+        list(records)
+    assert "line 2" in str(excinfo.value)
+
+
+def test_blank_lines_are_skipped(tmp_path):
+    trace_path = _write_raw(tmp_path, _header_line(), "")
+
+    _header, records = read_trace_file(trace_path)
+
+    assert list(records) == []

--- a/codebase_rag/tests/test_dynamic_trace_resolution.py
+++ b/codebase_rag/tests/test_dynamic_trace_resolution.py
@@ -108,8 +108,10 @@ def test_duplicate_variants_disambiguate_by_line(tmp_path):
     stats = ResolutionStats()
     first = resolver.resolve(_frame(tmp_path, "pkg/dup.py", "helper", 5), stats)
     second = resolver.resolve(_frame(tmp_path, "pkg/dup.py", "helper", 12), stats)
-    assert first is not None and first.qualified_name.endswith("helper@5")
-    assert second is not None and second.qualified_name.endswith("helper@12")
+    assert first is not None
+    assert first.qualified_name.endswith("helper@5")
+    assert second is not None
+    assert second.qualified_name.endswith("helper@12")
 
 
 def test_unresolved_reasons_are_categorised(tmp_path):
@@ -125,8 +127,10 @@ def test_unresolved_reasons_are_categorised(tmp_path):
     unknown = resolver.resolve(_frame(tmp_path, "pkg/nope.py", "f", 1), stats)
     missing = resolver.resolve(_frame(tmp_path, "pkg/mod.py", "ghost", 99), stats)
 
-    assert outside is None and synthetic is None
-    assert unknown is None and missing is None
+    assert outside is None
+    assert synthetic is None
+    assert unknown is None
+    assert missing is None
     assert stats.unresolved == {
         cs.TraceUnresolvedReason.OUTSIDE_REPO.value: 1,
         cs.TraceUnresolvedReason.SYNTHETIC.value: 1,

--- a/codebase_rag/tests/test_dynamic_trace_resolution.py
+++ b/codebase_rag/tests/test_dynamic_trace_resolution.py
@@ -1,0 +1,148 @@
+# Runtime frames carry co_qualname artifacts (<locals>, <module>, <lambda>)
+# and the graph carries duplicate-definition markers (qn@line); the resolver
+# must bridge both notations and report why a frame cannot be mapped
+# (issue #1246).
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from codebase_rag import constants as cs
+from codebase_rag.trace.records import FramePoint
+from codebase_rag.trace.resolution import (
+    CallableNode,
+    FrameResolver,
+    ResolutionStats,
+)
+
+_PROJECT = "proj__deadbeef"
+
+
+def _node(
+    label: str,
+    qualified_name: str,
+    path: str,
+    start_line: int | None = None,
+    end_line: int | None = None,
+) -> CallableNode:
+    return CallableNode(
+        label=label,
+        qualified_name=qualified_name,
+        path=path,
+        start_line=start_line,
+        end_line=end_line,
+    )
+
+
+def _resolver(repo: Path) -> FrameResolver:
+    nodes = [
+        _node(cs.NodeLabel.MODULE, f"{_PROJECT}.pkg.mod", "pkg/mod.py"),
+        _node(
+            cs.NodeLabel.FUNCTION,
+            f"{_PROJECT}.pkg.mod.outer",
+            "pkg/mod.py",
+            1,
+            10,
+        ),
+        _node(
+            cs.NodeLabel.FUNCTION,
+            f"{_PROJECT}.pkg.mod.outer.inner",
+            "pkg/mod.py",
+            2,
+            4,
+        ),
+        _node(
+            cs.NodeLabel.METHOD,
+            f"{_PROJECT}.pkg.mod.Klass.method",
+            "pkg/mod.py",
+            12,
+            20,
+        ),
+        _node(
+            cs.NodeLabel.FUNCTION,
+            f"{_PROJECT}.pkg.dup.helper@5",
+            "pkg/dup.py",
+            5,
+            7,
+        ),
+        _node(
+            cs.NodeLabel.FUNCTION,
+            f"{_PROJECT}.pkg.dup.helper@12",
+            "pkg/dup.py",
+            12,
+            14,
+        ),
+    ]
+    return FrameResolver(repo, nodes)
+
+
+def _frame(repo: Path, rel: str, qualname: str, line: int) -> FramePoint:
+    return FramePoint(path=str(repo / rel), qualname=qualname, line=line)
+
+
+def test_resolves_nested_function_through_locals(tmp_path):
+    resolver = _resolver(tmp_path)
+    stats = ResolutionStats()
+    resolved = resolver.resolve(
+        _frame(tmp_path, "pkg/mod.py", "outer.<locals>.inner", 2), stats
+    )
+    assert resolved is not None
+    assert resolved.qualified_name == f"{_PROJECT}.pkg.mod.outer.inner"
+    assert stats.total == 0
+
+
+def test_resolves_method_and_module_level_code(tmp_path):
+    resolver = _resolver(tmp_path)
+    stats = ResolutionStats()
+    method = resolver.resolve(_frame(tmp_path, "pkg/mod.py", "Klass.method", 12), stats)
+    module = resolver.resolve(_frame(tmp_path, "pkg/mod.py", "<module>", 1), stats)
+    assert method is not None
+    assert method.label == cs.NodeLabel.METHOD
+    assert module is not None
+    assert module.label == cs.NodeLabel.MODULE
+    assert module.qualified_name == f"{_PROJECT}.pkg.mod"
+
+
+def test_duplicate_variants_disambiguate_by_line(tmp_path):
+    resolver = _resolver(tmp_path)
+    stats = ResolutionStats()
+    first = resolver.resolve(_frame(tmp_path, "pkg/dup.py", "helper", 5), stats)
+    second = resolver.resolve(_frame(tmp_path, "pkg/dup.py", "helper", 12), stats)
+    assert first is not None and first.qualified_name.endswith("helper@5")
+    assert second is not None and second.qualified_name.endswith("helper@12")
+
+
+def test_unresolved_reasons_are_categorised(tmp_path):
+    resolver = _resolver(tmp_path)
+    stats = ResolutionStats()
+
+    outside = resolver.resolve(
+        FramePoint(path="/somewhere/else/x.py", qualname="f", line=1), stats
+    )
+    synthetic = resolver.resolve(
+        _frame(tmp_path, "pkg/mod.py", "outer.<locals>.<lambda>", 3), stats
+    )
+    unknown = resolver.resolve(_frame(tmp_path, "pkg/nope.py", "f", 1), stats)
+    missing = resolver.resolve(_frame(tmp_path, "pkg/mod.py", "ghost", 99), stats)
+
+    assert outside is None and synthetic is None
+    assert unknown is None and missing is None
+    assert stats.unresolved == {
+        cs.TraceUnresolvedReason.OUTSIDE_REPO.value: 1,
+        cs.TraceUnresolvedReason.SYNTHETIC.value: 1,
+        cs.TraceUnresolvedReason.UNKNOWN_PATH.value: 1,
+        cs.TraceUnresolvedReason.NO_MATCH.value: 1,
+    }
+
+
+def test_wrapper_falls_back_to_line_containment(tmp_path):
+    # A decorator's wrapper can run under a name the static pass recorded
+    # differently; when the name lookup fails, the innermost span containing
+    # the runtime line must win.
+    resolver = _resolver(tmp_path)
+    stats = ResolutionStats()
+    resolved = resolver.resolve(
+        _frame(tmp_path, "pkg/mod.py", "renamed_at_runtime", 3), stats
+    )
+    assert resolved is not None
+    assert resolved.qualified_name == f"{_PROJECT}.pkg.mod.outer.inner"

--- a/codebase_rag/tests/test_dynamic_trace_tracer.py
+++ b/codebase_rag/tests/test_dynamic_trace_tracer.py
@@ -10,8 +10,21 @@ import sys
 import textwrap
 from pathlib import Path
 
+import pytest
+
 from codebase_rag.trace.records import read_trace_file
 from codebase_rag.trace.tracer import CallGraphTracer
+
+
+def _start_or_skip(tracer: CallGraphTracer) -> None:
+    # When this suite itself runs under `pytest --cgr-trace`, the session's
+    # plugin already holds sys.monitoring.PROFILER_ID and a second claim
+    # raises; these tests cannot share the slot, so they skip.
+    try:
+        tracer.start()
+    except ValueError:
+        pytest.skip("sys.monitoring PROFILER_ID already claimed in this session")
+
 
 _PKG_FILES = {
     "animals.py": """
@@ -71,7 +84,7 @@ def _trace_package(root: Path, package: str, workload: str | None) -> CallGraphT
     try:
         entry = importlib.import_module(f"{package}.entry")
         tracer = CallGraphTracer(root)
-        tracer.start()
+        _start_or_skip(tracer)
         try:
             if workload is not None:
                 tracer.set_workload(workload)
@@ -115,6 +128,40 @@ def test_tracer_scopes_to_repo_root_and_tags_workloads(tmp_path):
         assert record.caller.path.startswith(root)
         assert record.callee.path.startswith(root)
         assert record.workloads == ("tests/test_x.py::test_y",)
+
+
+def test_tracer_excludes_dependency_dirs_under_repo_root(tmp_path):
+    tracer = CallGraphTracer(tmp_path)
+
+    assert tracer._in_scope(str(tmp_path / "pkg" / "mod.py"))
+    assert not tracer._in_scope(str(tmp_path / ".venv" / "lib" / "dep.py"))
+    assert not tracer._in_scope(
+        str(tmp_path / ".venv" / "lib" / "site-packages" / "dep.py")
+    )
+    assert not tracer._in_scope(str(tmp_path / "web" / "node_modules" / "x.py"))
+
+
+def test_start_releases_tool_id_when_setup_fails(tmp_path, monkeypatch):
+    try:
+        sys.monitoring.use_tool_id(sys.monitoring.PROFILER_ID, "probe")
+    except ValueError:
+        pytest.skip("sys.monitoring PROFILER_ID already claimed in this session")
+    sys.monitoring.free_tool_id(sys.monitoring.PROFILER_ID)
+
+    tracer = CallGraphTracer(tmp_path)
+
+    def _boom(tool_id, events):
+        raise RuntimeError("setup failed")
+
+    monkeypatch.setattr(sys.monitoring, "set_events", _boom)
+    with pytest.raises(RuntimeError):
+        tracer.start()
+    monkeypatch.undo()
+
+    assert not tracer.active
+    # The profiler slot must be free again: claiming it succeeds.
+    sys.monitoring.use_tool_id(sys.monitoring.PROFILER_ID, "probe")
+    sys.monitoring.free_tool_id(sys.monitoring.PROFILER_ID)
 
 
 def test_tracer_write_read_roundtrip(tmp_path):

--- a/codebase_rag/tests/test_dynamic_trace_tracer.py
+++ b/codebase_rag/tests/test_dynamic_trace_tracer.py
@@ -1,0 +1,136 @@
+# The sys.monitoring tracer must observe Python-to-Python calls scoped to a
+# repository root, including edges static analysis cannot see (dispatch through
+# a registry dict) and the concrete receiver type behind an inherited method
+# call (issue #1246).
+
+from __future__ import annotations
+
+import importlib
+import sys
+import textwrap
+from pathlib import Path
+
+from codebase_rag.trace.records import read_trace_file
+from codebase_rag.trace.tracer import CallGraphTracer
+
+_PKG_FILES = {
+    "animals.py": """
+        class Animal:
+            def speak(self):
+                return self._sound()
+
+            def _sound(self):
+                return "generic"
+
+
+        class Dog(Animal):
+            def _sound(self):
+                return "woof"
+    """,
+    "registry.py": """
+        HANDLERS = {}
+
+
+        def register(name, fn):
+            HANDLERS[name] = fn
+
+
+        def handle(name):
+            return HANDLERS[name]()
+
+
+        def greet():
+            return "hi"
+
+
+        register("greet", greet)
+    """,
+    "entry.py": """
+        from .animals import Dog
+        from .registry import handle
+
+
+        def run_all():
+            dog = Dog()
+            dog.speak()
+            return handle("greet")
+    """,
+}
+
+
+def _write_package(root: Path, package: str) -> None:
+    pkg_dir = root / package
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("")
+    for name, source in _PKG_FILES.items():
+        (pkg_dir / name).write_text(textwrap.dedent(source))
+
+
+def _trace_package(root: Path, package: str, workload: str | None) -> CallGraphTracer:
+    sys.path.insert(0, str(root))
+    try:
+        entry = importlib.import_module(f"{package}.entry")
+        tracer = CallGraphTracer(root)
+        tracer.start()
+        try:
+            if workload is not None:
+                tracer.set_workload(workload)
+            entry.run_all()
+        finally:
+            tracer.stop()
+        return tracer
+    finally:
+        sys.path.remove(str(root))
+        for module_name in [m for m in sys.modules if m.startswith(package)]:
+            del sys.modules[module_name]
+
+
+def test_tracer_records_registry_dispatch_and_receiver_types(tmp_path):
+    package = "dyn_trace_pkg_a"
+    _write_package(tmp_path, package)
+    tracer = _trace_package(tmp_path, package, workload=None)
+
+    pairs = {(r.caller.qualname, r.callee.qualname): r for r in tracer.records()}
+    assert ("run_all", "Animal.speak") in pairs, pairs.keys()
+    assert ("Animal.speak", "Dog._sound") in pairs, pairs.keys()
+    # The registry dispatch is invisible to static analysis; the tracer must
+    # see handle() invoking greet() through the HANDLERS dict.
+    assert ("handle", "greet") in pairs, pairs.keys()
+
+    speak = pairs[("run_all", "Animal.speak")]
+    assert any(receiver.endswith("animals.Dog") for receiver in speak.receiver_types), (
+        speak.receiver_types
+    )
+
+
+def test_tracer_scopes_to_repo_root_and_tags_workloads(tmp_path):
+    package = "dyn_trace_pkg_b"
+    _write_package(tmp_path, package)
+    tracer = _trace_package(tmp_path, package, workload="tests/test_x.py::test_y")
+
+    records = tracer.records()
+    assert records
+    root = str(tmp_path)
+    for record in records:
+        assert record.caller.path.startswith(root)
+        assert record.callee.path.startswith(root)
+        assert record.workloads == ("tests/test_x.py::test_y",)
+
+
+def test_tracer_write_read_roundtrip(tmp_path):
+    package = "dyn_trace_pkg_c"
+    _write_package(tmp_path, package)
+    tracer = _trace_package(tmp_path, package, workload="w")
+
+    output = tmp_path / "trace.jsonl"
+    written = tracer.write(output)
+    header, records_iter = read_trace_file(output)
+    records = list(records_iter)
+
+    assert written == len(records)
+    assert header.repo_root == str(tmp_path)
+    in_memory = {
+        (r.caller.qualname, r.callee.qualname, r.count) for r in tracer.records()
+    }
+    round_tripped = {(r.caller.qualname, r.callee.qualname, r.count) for r in records}
+    assert in_memory == round_tripped

--- a/codebase_rag/tests/test_dynamic_trace_tracer.py
+++ b/codebase_rag/tests/test_dynamic_trace_tracer.py
@@ -164,6 +164,79 @@ def test_start_releases_tool_id_when_setup_fails(tmp_path, monkeypatch):
     sys.monitoring.free_tool_id(sys.monitoring.PROFILER_ID)
 
 
+_HOOK_MODULE = """
+    def callee():
+        pass
+
+
+    class Receiver:
+        def method(self):
+            _hook(Receiver.method.__code__, 0)
+
+
+    def call_method():
+        Receiver().method()
+
+
+    def caller():
+        _hook(callee.__code__, 0)
+
+
+    def outer():
+        caller()
+"""
+
+
+def _hook_namespace(tmp_path: Path, tracer: CallGraphTracer) -> dict:
+    # Executing the module from a file under the repo root gives its frames
+    # in-scope co_filenames, so the callback can be driven directly without
+    # claiming the interpreter-wide profiler slot.
+    path = tmp_path / "hookmod.py"
+    source = textwrap.dedent(_HOOK_MODULE)
+    path.write_text(source)
+    namespace = {"_hook": tracer._on_py_start}
+    exec(compile(source, str(path), "exec"), namespace)
+    return namespace
+
+
+def test_callback_aggregates_pairs_and_workloads(tmp_path):
+    tracer = CallGraphTracer(tmp_path)
+    namespace = _hook_namespace(tmp_path, tracer)
+
+    tracer.set_workload("w1")
+    namespace["outer"]()
+    namespace["outer"]()
+    tracer.set_workload(None)
+    namespace["outer"]()
+
+    records = {(r.caller.qualname, r.callee.qualname): r for r in tracer.records()}
+    edge = records[("outer", "callee")]
+    assert edge.count == 3
+    assert edge.workloads == ("w1",)
+
+
+def test_callback_samples_receiver_types(tmp_path):
+    tracer = CallGraphTracer(tmp_path)
+    namespace = _hook_namespace(tmp_path, tracer)
+
+    namespace["call_method"]()
+
+    records = {(r.caller.qualname, r.callee.qualname): r for r in tracer.records()}
+    edge = records[("call_method", "Receiver.method")]
+    assert len(edge.receiver_types) == 1
+    assert edge.receiver_types[0].endswith("Receiver")
+
+
+def test_callback_ignores_out_of_scope_callers(tmp_path):
+    tracer = CallGraphTracer(tmp_path)
+    namespace = _hook_namespace(tmp_path, tracer)
+
+    # Called from this test file, the caller frame lives outside tmp_path.
+    namespace["caller"]()
+
+    assert tracer.records() == []
+
+
 def test_tracer_write_read_roundtrip(tmp_path):
     package = "dyn_trace_pkg_c"
     _write_package(tmp_path, package)

--- a/codebase_rag/trace/__init__.py
+++ b/codebase_rag/trace/__init__.py
@@ -1,0 +1,1 @@
+"""Dynamic runtime call-graph capture (tracing) and graph ingestion."""

--- a/codebase_rag/trace/cli.py
+++ b/codebase_rag/trace/cli.py
@@ -1,0 +1,70 @@
+"""The `cgr trace` command group: runtime call-trace ingestion."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import click
+from loguru import logger
+
+from .. import cli_help as ch
+
+
+@click.group(
+    help=ch.CMD_TRACE_GROUP,
+    short_help=ch.CMD_TRACE_GROUP,
+    epilog=ch.EPILOG_TRACE,
+    no_args_is_help=True,
+)
+def cli() -> None:
+    pass
+
+
+@cli.command(
+    "ingest",
+    help=ch.CMD_TRACE_INGEST,
+    short_help=ch.CMD_TRACE_INGEST,
+    epilog=ch.EXAMPLES_TRACE_INGEST,
+)
+@click.argument(
+    "trace_file",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.option(
+    "--repo-path",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    required=True,
+    help=ch.HELP_TRACE_REPO_PATH,
+)
+@click.option("--project-name", default=None, help=ch.HELP_TRACE_PROJECT_NAME)
+def ingest_cmd(trace_file: Path, repo_path: Path, project_name: str | None) -> None:
+    from ..config import settings
+    from ..main import connect_memgraph
+    from ..utils.path_utils import derive_project_name
+    from .ingest import ingest_trace
+    from .records import TraceFormatError
+
+    resolved_project = project_name or derive_project_name(repo_path)
+    try:
+        with connect_memgraph(batch_size=settings.resolve_batch_size(None)) as ingestor:
+            summary = ingest_trace(
+                trace_path=trace_file,
+                ingestor=ingestor,
+                repo_path=repo_path,
+                project_name=resolved_project,
+            )
+    except TraceFormatError as e:
+        logger.error(str(e))
+        click.secho(str(e), fg="red", err=True)
+        sys.exit(1)
+
+    click.echo(
+        f"records:          {summary.records}\n"
+        f"edges written:    {summary.edges}\n"
+        f"confirmed static: {summary.confirmed_static}\n"
+        f"static missed:    {summary.static_missed}\n"
+        f"unresolved:       {summary.unresolved}"
+    )
+    for reason, count in sorted(summary.resolution.unresolved.items()):
+        click.echo(f"  unresolved[{reason}]: {count}")

--- a/codebase_rag/trace/cli.py
+++ b/codebase_rag/trace/cli.py
@@ -18,7 +18,7 @@ from .. import cli_help as ch
     no_args_is_help=True,
 )
 def cli() -> None:
-    pass
+    """Group callback: subcommands carry the behaviour."""
 
 
 @cli.command(

--- a/codebase_rag/trace/ingest.py
+++ b/codebase_rag/trace/ingest.py
@@ -1,0 +1,169 @@
+"""Ingest a runtime call trace into the graph as provenance-tagged CALLS edges.
+
+Records resolve to existing Function/Method/Module nodes; each resolved pair
+becomes one CALLS edge write. MERGE semantics collapse onto an existing static
+edge when there is one (the dynamic properties then decorate it), and create
+the edge when static analysis missed the relationship, in which case it is
+flagged ``static_missed``. Re-ingesting the same trace is idempotent: counts
+are SET, not incremented.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
+
+from loguru import logger
+
+from .. import constants as cs
+from ..cypher_queries import CYPHER_TRACE_CALLABLES, CYPHER_TRACE_EXISTING_CALLS
+from ..services import IngestorProtocol, QueryProtocol
+from .records import read_trace_file
+from .resolution import CallableNode, FrameResolver, ResolutionStats
+
+if TYPE_CHECKING:
+    from ..types_defs import PropertyValue, ResultRow
+    from .resolution import ResolvedFrame
+
+
+class TraceGraphProtocol(IngestorProtocol, QueryProtocol, Protocol):
+    """A graph client that can both query nodes and write edges."""
+
+
+@dataclass(slots=True)
+class _EdgeStats:
+    count: int = 0
+    workloads: set[str] = field(default_factory=set)
+    receiver_types: set[str] = field(default_factory=set)
+
+
+@dataclass(slots=True)
+class TraceIngestSummary:
+    records: int = 0
+    edges: int = 0
+    confirmed_static: int = 0
+    static_missed: int = 0
+    resolution: ResolutionStats = field(default_factory=ResolutionStats)
+
+    @property
+    def unresolved(self) -> int:
+        return self.resolution.total
+
+
+def _load_callables(
+    ingestor: TraceGraphProtocol, project_prefix: str
+) -> list[CallableNode]:
+    rows: list[ResultRow] = ingestor.fetch_all(
+        CYPHER_TRACE_CALLABLES, {cs.KEY_PREFIX: project_prefix}
+    )
+    nodes: list[CallableNode] = []
+    for row in rows:
+        label = row.get(cs.KEY_LABEL)
+        qualified_name = row.get(cs.KEY_QUALIFIED_NAME)
+        path = row.get(cs.KEY_PATH)
+        start_line = row.get(cs.KEY_START_LINE)
+        end_line = row.get(cs.KEY_END_LINE)
+        if (
+            not isinstance(label, str)
+            or not isinstance(qualified_name, str)
+            or not isinstance(path, str)
+        ):
+            continue
+        nodes.append(
+            CallableNode(
+                label=label,
+                qualified_name=qualified_name,
+                path=path,
+                start_line=start_line if isinstance(start_line, int) else None,
+                end_line=end_line if isinstance(end_line, int) else None,
+            )
+        )
+    return nodes
+
+
+def _load_existing_calls(
+    ingestor: TraceGraphProtocol, project_prefix: str
+) -> set[tuple[str, str]]:
+    rows = ingestor.fetch_all(
+        CYPHER_TRACE_EXISTING_CALLS, {cs.KEY_PREFIX: project_prefix}
+    )
+    pairs: set[tuple[str, str]] = set()
+    for row in rows:
+        from_qn = row.get(cs.KEY_FROM_QN)
+        to_qn = row.get(cs.KEY_TO_QN)
+        if isinstance(from_qn, str) and isinstance(to_qn, str):
+            pairs.add((from_qn, to_qn))
+    return pairs
+
+
+def _edge_properties(
+    stats: _EdgeStats, static_missed: bool
+) -> dict[str, PropertyValue]:
+    workloads = sorted(stats.workloads)[: cs.TRACE_MAX_WORKLOADS_PER_EDGE]
+    receivers = sorted(stats.receiver_types)[: cs.TRACE_MAX_RECEIVER_TYPES_PER_EDGE]
+    return {
+        cs.TRACE_PROP_DYNAMIC: True,
+        cs.TRACE_PROP_CALL_COUNT: stats.count,
+        cs.TRACE_PROP_WORKLOAD_COUNT: len(stats.workloads),
+        cs.TRACE_PROP_WORKLOADS: workloads,
+        cs.TRACE_PROP_RECEIVER_TYPES: receivers,
+        cs.TRACE_PROP_STATIC_MISSED: static_missed,
+    }
+
+
+def ingest_trace(
+    trace_path: Path,
+    ingestor: TraceGraphProtocol,
+    repo_path: Path,
+    project_name: str,
+) -> TraceIngestSummary:
+    """Resolve ``trace_path`` against ``project_name``'s graph and write edges."""
+    header, records = read_trace_file(trace_path)
+    repo_root = repo_path.resolve() if repo_path else Path(header.repo_root)
+    project_prefix = project_name + cs.SEPARATOR_DOT
+
+    nodes = _load_callables(ingestor, project_prefix)
+    existing = _load_existing_calls(ingestor, project_prefix)
+    resolver = FrameResolver(repo_root, nodes)
+
+    summary = TraceIngestSummary()
+    resolved_frames: dict[tuple[ResolvedFrame, ResolvedFrame], _EdgeStats] = {}
+    for record in records:
+        summary.records += 1
+        caller = resolver.resolve(record.caller, summary.resolution)
+        if caller is None:
+            continue
+        callee = resolver.resolve(record.callee, summary.resolution)
+        if callee is None:
+            continue
+        edge = resolved_frames.setdefault((caller, callee), _EdgeStats())
+        edge.count += record.count
+        edge.workloads.update(record.workloads)
+        edge.receiver_types.update(record.receiver_types)
+
+    for (caller, callee), stats in resolved_frames.items():
+        pair = (caller.qualified_name, callee.qualified_name)
+        static_missed = pair not in existing
+        if static_missed:
+            summary.static_missed += 1
+        else:
+            summary.confirmed_static += 1
+        summary.edges += 1
+        ingestor.ensure_relationship_batch(
+            (caller.label, cs.KEY_QUALIFIED_NAME, caller.qualified_name),
+            cs.RelationshipType.CALLS,
+            (callee.label, cs.KEY_QUALIFIED_NAME, callee.qualified_name),
+            properties=_edge_properties(stats, static_missed),
+        )
+    ingestor.flush_all()
+    logger.info(
+        cs.TRACE_MSG_INGEST_SUMMARY.format(
+            records=summary.records,
+            edges=summary.edges,
+            confirmed=summary.confirmed_static,
+            missed=summary.static_missed,
+            unresolved=summary.unresolved,
+        )
+    )
+    return summary

--- a/codebase_rag/trace/pytest_plugin.py
+++ b/codebase_rag/trace/pytest_plugin.py
@@ -1,0 +1,83 @@
+"""Pytest plugin exposing the cgr call-graph tracer.
+
+Inert unless ``--cgr-trace`` is passed. Each test's node id becomes the
+workload provenance for the calls it triggers, and the aggregated trace is
+written once at session end.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .. import constants as cs
+from .tracer import CallGraphTracer
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+_OPT_TRACE = "--cgr-trace"
+_OPT_OUTPUT = "--cgr-trace-output"
+_OPT_REPO = "--cgr-trace-repo"
+_STASH_KEY: pytest.StashKey[CallGraphTracer] = pytest.StashKey()
+
+_HELP_TRACE = "Record a cgr runtime call trace for this test session."
+_HELP_OUTPUT = "Where to write the trace file (default: %(default)s)."
+_HELP_REPO = "Repository root to scope tracing to (default: pytest rootdir)."
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    group = parser.getgroup(cs.TRACE_TOOL_NAME)
+    group.addoption(_OPT_TRACE, action="store_true", default=False, help=_HELP_TRACE)
+    group.addoption(
+        _OPT_OUTPUT,
+        default=cs.TRACE_DEFAULT_OUTPUT,
+        help=_HELP_OUTPUT,
+    )
+    group.addoption(_OPT_REPO, default=None, help=_HELP_REPO)
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    if not config.getoption(_OPT_TRACE):
+        return
+    repo_opt = config.getoption(_OPT_REPO)
+    repo_root = Path(repo_opt) if repo_opt else Path(str(config.rootpath))
+    tracer = CallGraphTracer(repo_root)
+    config.stash[_STASH_KEY] = tracer
+    tracer.start()
+
+
+@pytest.hookimpl(wrapper=True)
+def pytest_runtest_protocol(
+    item: pytest.Item, nextitem: pytest.Item | None
+) -> Iterator[object]:
+    tracer = item.config.stash.get(_STASH_KEY, None)
+    if tracer is not None:
+        tracer.set_workload(item.nodeid)
+    try:
+        return (yield)
+    finally:
+        if tracer is not None:
+            tracer.set_workload(None)
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    tracer = session.config.stash.get(_STASH_KEY, None)
+    if tracer is None or not tracer.active:
+        return
+    tracer.stop()
+    output = Path(str(session.config.getoption(_OPT_OUTPUT)))
+    count = tracer.write(output)
+    reporter = session.config.pluginmanager.get_plugin("terminalreporter")
+    if reporter is not None:
+        reporter.write_line(
+            f"{cs.TRACE_TOOL_NAME}: wrote {count} call records to {output}"
+        )
+
+
+def pytest_unconfigure(config: pytest.Config) -> None:
+    tracer = config.stash.get(_STASH_KEY, None)
+    if tracer is not None and tracer.active:
+        tracer.stop()

--- a/codebase_rag/trace/pytest_plugin.py
+++ b/codebase_rag/trace/pytest_plugin.py
@@ -81,7 +81,7 @@ def _output_path(config: _TraceOutputConfig) -> Path:
     return output
 
 
-def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+def pytest_sessionfinish(session: pytest.Session) -> None:
     tracer = session.config.stash.get(_STASH_KEY, None)
     if tracer is None or not tracer.active:
         return

--- a/codebase_rag/trace/pytest_plugin.py
+++ b/codebase_rag/trace/pytest_plugin.py
@@ -8,7 +8,7 @@ written once at session end.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 import pytest
 
@@ -63,12 +63,30 @@ def pytest_runtest_protocol(
             tracer.set_workload(None)
 
 
+class _TraceOutputConfig(Protocol):
+    """The slice of ``pytest.Config`` that output-path resolution reads."""
+
+    def getoption(self, name: str) -> object: ...
+
+
+def _output_path(config: _TraceOutputConfig) -> Path:
+    output = Path(str(config.getoption(_OPT_OUTPUT)))
+    # Under pytest-xdist every worker process traces its own interpreter and
+    # writes at session end; a shared name would leave only the last worker's
+    # trace. Ingest all per-worker files to cover the full run.
+    workerinput = getattr(config, "workerinput", None)
+    worker = workerinput.get("workerid") if isinstance(workerinput, dict) else None
+    if worker:
+        output = output.with_name(f"{output.stem}-{worker}{output.suffix}")
+    return output
+
+
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     tracer = session.config.stash.get(_STASH_KEY, None)
     if tracer is None or not tracer.active:
         return
     tracer.stop()
-    output = Path(str(session.config.getoption(_OPT_OUTPUT)))
+    output = _output_path(session.config)
     count = tracer.write(output)
     reporter = session.config.pluginmanager.get_plugin("terminalreporter")
     if reporter is not None:

--- a/codebase_rag/trace/pytest_plugin.py
+++ b/codebase_rag/trace/pytest_plugin.py
@@ -3,6 +3,11 @@
 Inert unless ``--cgr-trace`` is passed. Each test's node id becomes the
 workload provenance for the calls it triggers, and the aggregated trace is
 written once at session end.
+
+The pytest11 entry point makes pytest import this module at startup in every
+session, tracing or not, and before coverage tooling initialises. All tracer
+machinery is therefore imported lazily inside the hooks: untraced sessions
+pay nothing, and import-time lines are not misattributed as uncovered.
 """
 
 from __future__ import annotations
@@ -12,11 +17,10 @@ from typing import TYPE_CHECKING, Protocol
 
 import pytest
 
-from .. import constants as cs
-from .tracer import CallGraphTracer
-
 if TYPE_CHECKING:
     from collections.abc import Iterator
+
+    from .tracer import CallGraphTracer
 
 _OPT_TRACE = "--cgr-trace"
 _OPT_OUTPUT = "--cgr-trace-output"
@@ -29,6 +33,8 @@ _HELP_REPO = "Repository root to scope tracing to (default: pytest rootdir)."
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
+    from .. import constants as cs
+
     group = parser.getgroup(cs.TRACE_TOOL_NAME)
     group.addoption(_OPT_TRACE, action="store_true", default=False, help=_HELP_TRACE)
     group.addoption(
@@ -42,6 +48,8 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 def pytest_configure(config: pytest.Config) -> None:
     if not config.getoption(_OPT_TRACE):
         return
+    from .tracer import CallGraphTracer
+
     repo_opt = config.getoption(_OPT_REPO)
     repo_root = Path(repo_opt) if repo_opt else Path(str(config.rootpath))
     tracer = CallGraphTracer(repo_root)
@@ -85,6 +93,8 @@ def pytest_sessionfinish(session: pytest.Session) -> None:
     tracer = session.config.stash.get(_STASH_KEY, None)
     if tracer is None or not tracer.active:
         return
+    from .. import constants as cs
+
     tracer.stop()
     output = _output_path(session.config)
     count = tracer.write(output)

--- a/codebase_rag/trace/records.py
+++ b/codebase_rag/trace/records.py
@@ -66,6 +66,8 @@ def _frame_from_json(raw: dict[str, object]) -> FramePoint:
         not isinstance(path, str)
         or not isinstance(qualname, str)
         or not isinstance(line, int)
+        or isinstance(line, bool)
+        or line < 0
     ):
         raise TraceFormatError(repr(raw))
     return FramePoint(path=path, qualname=qualname, line=line)
@@ -143,6 +145,8 @@ def _parse_record(trace_path: Path, line_no: int, line: str) -> CallRecord:
         not isinstance(caller, dict)
         or not isinstance(callee, dict)
         or not isinstance(count, int)
+        or isinstance(count, bool)
+        or count < 1
         or not isinstance(workloads, list)
         or not isinstance(receivers, list)
     ):

--- a/codebase_rag/trace/records.py
+++ b/codebase_rag/trace/records.py
@@ -1,0 +1,181 @@
+"""Trace interchange format: JSONL records shared by every language tracer.
+
+The first line of a trace file is a header record; every following line is an
+aggregated call record. Paths are absolute as observed at runtime; ingestion
+re-anchors them against the header's ``repo_root`` (or an override).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .. import constants as cs
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
+
+
+class TraceFormatError(ValueError):
+    """Raised when a trace file is malformed or has an unsupported version."""
+
+
+@dataclass(frozen=True, slots=True)
+class FramePoint:
+    """One endpoint of an observed call, as reported by the runtime."""
+
+    path: str
+    qualname: str
+    line: int
+
+
+@dataclass(frozen=True, slots=True)
+class TraceHeader:
+    version: int
+    language: str
+    repo_root: str
+    tracer: str
+
+
+@dataclass(slots=True)
+class CallRecord:
+    """An aggregated caller/callee observation."""
+
+    caller: FramePoint
+    callee: FramePoint
+    count: int
+    workloads: tuple[str, ...]
+    receiver_types: tuple[str, ...]
+
+
+def _frame_to_json(point: FramePoint) -> dict[str, str | int]:
+    return {
+        cs.TRACE_KEY_PATH: point.path,
+        cs.TRACE_KEY_QUALNAME: point.qualname,
+        cs.TRACE_KEY_LINE: point.line,
+    }
+
+
+def _frame_from_json(raw: dict[str, object]) -> FramePoint:
+    path = raw.get(cs.TRACE_KEY_PATH)
+    qualname = raw.get(cs.TRACE_KEY_QUALNAME)
+    line = raw.get(cs.TRACE_KEY_LINE)
+    if (
+        not isinstance(path, str)
+        or not isinstance(qualname, str)
+        or not isinstance(line, int)
+    ):
+        raise TraceFormatError(repr(raw))
+    return FramePoint(path=path, qualname=qualname, line=line)
+
+
+def write_trace_file(
+    output: Path, header: TraceHeader, records: Iterable[CallRecord]
+) -> None:
+    with output.open("w", encoding="utf-8") as fh:
+        header_row: dict[str, str | int] = {
+            cs.TRACE_KEY_KIND: cs.TRACE_KIND_HEADER,
+            cs.TRACE_KEY_VERSION: header.version,
+            cs.TRACE_KEY_LANGUAGE: header.language,
+            cs.TRACE_KEY_REPO_ROOT: header.repo_root,
+            cs.TRACE_KEY_TRACER: header.tracer,
+        }
+        fh.write(json.dumps(header_row) + "\n")
+        for record in records:
+            row = {
+                cs.TRACE_KEY_KIND: cs.TRACE_KIND_CALL,
+                cs.TRACE_KEY_CALLER: _frame_to_json(record.caller),
+                cs.TRACE_KEY_CALLEE: _frame_to_json(record.callee),
+                cs.TRACE_KEY_COUNT: record.count,
+                cs.TRACE_KEY_WORKLOADS: list(record.workloads),
+                cs.TRACE_KEY_RECEIVER_TYPES: list(record.receiver_types),
+            }
+            fh.write(json.dumps(row) + "\n")
+
+
+def _parse_header(trace_path: Path, line: str) -> TraceHeader:
+    try:
+        raw = json.loads(line)
+    except json.JSONDecodeError as e:
+        raise TraceFormatError(cs.TRACE_ERR_BAD_HEADER.format(path=trace_path)) from e
+    if not isinstance(raw, dict) or raw.get(cs.TRACE_KEY_KIND) != cs.TRACE_KIND_HEADER:
+        raise TraceFormatError(cs.TRACE_ERR_BAD_HEADER.format(path=trace_path))
+    version = raw.get(cs.TRACE_KEY_VERSION)
+    if version != cs.TRACE_FORMAT_VERSION:
+        raise TraceFormatError(
+            cs.TRACE_ERR_VERSION.format(
+                path=trace_path,
+                found=version,
+                expected=cs.TRACE_FORMAT_VERSION,
+            )
+        )
+    language = raw.get(cs.TRACE_KEY_LANGUAGE)
+    repo_root = raw.get(cs.TRACE_KEY_REPO_ROOT)
+    tracer = raw.get(cs.TRACE_KEY_TRACER)
+    if (
+        not isinstance(language, str)
+        or not isinstance(repo_root, str)
+        or not isinstance(tracer, str)
+    ):
+        raise TraceFormatError(cs.TRACE_ERR_BAD_HEADER.format(path=trace_path))
+    return TraceHeader(
+        version=version, language=language, repo_root=repo_root, tracer=tracer
+    )
+
+
+def _parse_record(trace_path: Path, line_no: int, line: str) -> CallRecord:
+    try:
+        raw = json.loads(line)
+    except json.JSONDecodeError as e:
+        raise TraceFormatError(
+            cs.TRACE_ERR_BAD_RECORD.format(path=trace_path, line=line_no)
+        ) from e
+    caller = raw.get(cs.TRACE_KEY_CALLER) if isinstance(raw, dict) else None
+    callee = raw.get(cs.TRACE_KEY_CALLEE) if isinstance(raw, dict) else None
+    count = raw.get(cs.TRACE_KEY_COUNT) if isinstance(raw, dict) else None
+    workloads = raw.get(cs.TRACE_KEY_WORKLOADS, []) if isinstance(raw, dict) else None
+    receivers = (
+        raw.get(cs.TRACE_KEY_RECEIVER_TYPES, []) if isinstance(raw, dict) else None
+    )
+    if (
+        not isinstance(caller, dict)
+        or not isinstance(callee, dict)
+        or not isinstance(count, int)
+        or not isinstance(workloads, list)
+        or not isinstance(receivers, list)
+    ):
+        raise TraceFormatError(
+            cs.TRACE_ERR_BAD_RECORD.format(path=trace_path, line=line_no)
+        )
+    try:
+        return CallRecord(
+            caller=_frame_from_json(caller),
+            callee=_frame_from_json(callee),
+            count=count,
+            workloads=tuple(str(w) for w in workloads),
+            receiver_types=tuple(str(r) for r in receivers),
+        )
+    except TraceFormatError as e:
+        raise TraceFormatError(
+            cs.TRACE_ERR_BAD_RECORD.format(path=trace_path, line=line_no)
+        ) from e
+
+
+def read_trace_file(trace_path: Path) -> tuple[TraceHeader, Iterator[CallRecord]]:
+    """Parse a trace file, returning its header and a lazy record iterator."""
+    with trace_path.open("r", encoding="utf-8") as fh:
+        first = fh.readline()
+    if not first.strip():
+        raise TraceFormatError(cs.TRACE_ERR_BAD_HEADER.format(path=trace_path))
+    header = _parse_header(trace_path, first)
+
+    def _records() -> Iterator[CallRecord]:
+        with trace_path.open("r", encoding="utf-8") as fh:
+            fh.readline()
+            for line_no, line in enumerate(fh, start=2):
+                if line.strip():
+                    yield _parse_record(trace_path, line_no, line)
+
+    return header, _records()

--- a/codebase_rag/trace/resolution.py
+++ b/codebase_rag/trace/resolution.py
@@ -1,0 +1,141 @@
+"""Resolution of runtime frames to graph nodes.
+
+A traced frame is identified by ``(absolute path, co_qualname, first line)``;
+graph callables are identified by qualified name. The mapping strips runtime
+artifacts (``<locals>`` scopes, ``@line`` duplicate markers) and falls back to
+line containment when names alone are ambiguous.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .. import constants as cs
+
+if TYPE_CHECKING:
+    from .records import FramePoint
+
+
+@dataclass(frozen=True, slots=True)
+class CallableNode:
+    """A graph node a traced frame may resolve to."""
+
+    label: str
+    qualified_name: str
+    path: str
+    start_line: int | None
+    end_line: int | None
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedFrame:
+    label: str
+    qualified_name: str
+
+
+@dataclass(slots=True)
+class ResolutionStats:
+    """Counts of unresolvable frames, keyed by reason."""
+
+    unresolved: dict[str, int] = field(default_factory=dict)
+
+    def record(self, reason: cs.TraceUnresolvedReason) -> None:
+        self.unresolved[reason.value] = self.unresolved.get(reason.value, 0) + 1
+
+    @property
+    def total(self) -> int:
+        return sum(self.unresolved.values())
+
+
+def _natural_qualified_name(qualified_name: str) -> str:
+    """Strip the duplicate-definition marker (``qn@line`` or ``qn@line_col``)."""
+    base, _, suffix = qualified_name.rpartition(cs.DUP_QN_MARKER)
+    if not base:
+        return qualified_name
+    plain = suffix.replace(cs.DUP_QN_COLUMN_MARKER, "")
+    return base if plain.isdigit() else qualified_name
+
+
+class FrameResolver:
+    """Maps runtime frame identities of one project to graph nodes."""
+
+    def __init__(self, repo_root: Path, nodes: list[CallableNode]) -> None:
+        self._repo_root = repo_root.resolve()
+        self._root_prefix = str(self._repo_root) + os.sep
+        self._callables_by_path: dict[str, list[CallableNode]] = {}
+        self._modules_by_path: dict[str, CallableNode] = {}
+        for node in nodes:
+            if node.label == cs.NodeLabel.MODULE:
+                self._modules_by_path[node.path] = node
+            else:
+                self._callables_by_path.setdefault(node.path, []).append(node)
+
+    def resolve(
+        self, frame: FramePoint, stats: ResolutionStats
+    ) -> ResolvedFrame | None:
+        if not frame.path.startswith(self._root_prefix):
+            stats.record(cs.TraceUnresolvedReason.OUTSIDE_REPO)
+            return None
+        rel_path = Path(frame.path).relative_to(self._repo_root).as_posix()
+
+        parts = [
+            p
+            for p in frame.qualname.split(cs.SEPARATOR_DOT)
+            if p != cs.TRACE_QUALNAME_LOCALS
+        ]
+        if parts == [cs.TRACE_QUALNAME_MODULE]:
+            module = self._modules_by_path.get(rel_path)
+            if module is None:
+                stats.record(cs.TraceUnresolvedReason.UNKNOWN_PATH)
+                return None
+            return ResolvedFrame(
+                label=module.label, qualified_name=module.qualified_name
+            )
+        if any(p.startswith(cs.TRACE_SYNTHETIC_PREFIX) for p in parts):
+            stats.record(cs.TraceUnresolvedReason.SYNTHETIC)
+            return None
+
+        candidates = self._callables_by_path.get(rel_path)
+        if not candidates:
+            stats.record(cs.TraceUnresolvedReason.UNKNOWN_PATH)
+            return None
+
+        suffix = cs.SEPARATOR_DOT + cs.SEPARATOR_DOT.join(parts)
+        by_name = [
+            n
+            for n in candidates
+            if _natural_qualified_name(n.qualified_name).endswith(suffix)
+        ]
+        chosen = self._pick(by_name, frame.line) or self._pick(
+            candidates, frame.line, require_containment=True
+        )
+        if chosen is None:
+            stats.record(cs.TraceUnresolvedReason.NO_MATCH)
+            return None
+        return ResolvedFrame(label=chosen.label, qualified_name=chosen.qualified_name)
+
+    @staticmethod
+    def _pick(
+        candidates: list[CallableNode],
+        line: int,
+        require_containment: bool = False,
+    ) -> CallableNode | None:
+        if not candidates:
+            return None
+        containing = [
+            n
+            for n in candidates
+            if n.start_line is not None
+            and n.end_line is not None
+            and n.start_line <= line <= n.end_line
+        ]
+        if containing:
+            # The innermost span wins: a nested function's span sits inside
+            # its parent's, and the runtime line points at the inner def.
+            return max(containing, key=lambda n: n.start_line or 0)
+        if require_containment:
+            return None
+        return min(candidates, key=lambda n: n.qualified_name)

--- a/codebase_rag/trace/resolution.py
+++ b/codebase_rag/trace/resolution.py
@@ -109,8 +109,14 @@ class FrameResolver:
             for n in candidates
             if _natural_qualified_name(n.qualified_name).endswith(suffix)
         ]
-        chosen = self._pick(by_name, frame.line) or self._pick(
-            candidates, frame.line, require_containment=True
+        # Prefer a name match whose span contains the runtime line; among name
+        # matches without span data, take the first by qualified name so
+        # resolution stays deterministic. Only when no candidate matches by
+        # name does the line span alone decide.
+        chosen = (
+            self._innermost_span_containing_line(by_name, frame.line)
+            or (min(by_name, key=lambda n: n.qualified_name) if by_name else None)
+            or self._innermost_span_containing_line(candidates, frame.line)
         )
         if chosen is None:
             stats.record(cs.TraceUnresolvedReason.NO_MATCH)
@@ -118,13 +124,9 @@ class FrameResolver:
         return ResolvedFrame(label=chosen.label, qualified_name=chosen.qualified_name)
 
     @staticmethod
-    def _pick(
-        candidates: list[CallableNode],
-        line: int,
-        require_containment: bool = False,
+    def _innermost_span_containing_line(
+        candidates: list[CallableNode], line: int
     ) -> CallableNode | None:
-        if not candidates:
-            return None
         containing = [
             n
             for n in candidates
@@ -132,10 +134,8 @@ class FrameResolver:
             and n.end_line is not None
             and n.start_line <= line <= n.end_line
         ]
-        if containing:
-            # The innermost span wins: a nested function's span sits inside
-            # its parent's, and the runtime line points at the inner def.
-            return max(containing, key=lambda n: n.start_line or 0)
-        if require_containment:
+        if not containing:
             return None
-        return min(candidates, key=lambda n: n.qualified_name)
+        # The innermost span wins: a nested function's span sits inside
+        # its parent's, and the runtime line points at the inner def.
+        return max(containing, key=lambda n: n.start_line or 0)

--- a/codebase_rag/trace/tracer.py
+++ b/codebase_rag/trace/tracer.py
@@ -1,0 +1,164 @@
+"""Runtime call-graph tracer for Python built on ``sys.monitoring`` (PEP 669).
+
+Records caller/callee pairs for Python-to-Python calls whose code lives under a
+repository root, aggregating in memory and flushing to the trace interchange
+format. Receiver types are sampled for bound methods so dynamic dispatch can be
+resolved to the concrete implementation that ran.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .. import constants as cs
+from .records import CallRecord, FramePoint, TraceHeader, write_trace_file
+
+if TYPE_CHECKING:
+    from types import CodeType
+
+import os
+import sys
+
+_NO_WORKLOAD = -1
+
+
+@dataclass(slots=True)
+class _PairStats:
+    count: int = 0
+    workloads: set[int] = field(default_factory=set)
+    receiver_types: set[str] = field(default_factory=set)
+
+
+class CallGraphTracer:
+    """Aggregating tracer scoped to files under ``repo_root``.
+
+    Not reentrant: one instance may be started at a time per interpreter, since
+    ``sys.monitoring`` allows a single profiler tool registration.
+    """
+
+    def __init__(self, repo_root: Path) -> None:
+        self._repo_root = repo_root.resolve()
+        # Prefix comparison against co_filename must include the separator so
+        # a sibling directory like /repo-extras does not match /repo.
+        self._root_prefix = str(self._repo_root) + os.sep
+        self._pairs: dict[tuple[CodeType, CodeType], _PairStats] = {}
+        self._scope_cache: dict[str, bool] = {}
+        self._workloads: list[str] = []
+        self._workload_ids: dict[str, int] = {}
+        self._current_workload = _NO_WORKLOAD
+        self._active = False
+
+    @property
+    def active(self) -> bool:
+        return self._active
+
+    def set_workload(self, workload: str | None) -> None:
+        if workload is None:
+            self._current_workload = _NO_WORKLOAD
+            return
+        known = self._workload_ids.get(workload)
+        if known is None:
+            known = len(self._workloads)
+            self._workloads.append(workload)
+            self._workload_ids[workload] = known
+        self._current_workload = known
+
+    def start(self) -> None:
+        monitoring = sys.monitoring
+        monitoring.use_tool_id(monitoring.PROFILER_ID, cs.TRACE_TOOL_NAME)
+        monitoring.register_callback(
+            monitoring.PROFILER_ID, monitoring.events.PY_START, self._on_py_start
+        )
+        monitoring.set_events(monitoring.PROFILER_ID, monitoring.events.PY_START)
+        self._active = True
+
+    def stop(self) -> None:
+        if not self._active:
+            return
+        monitoring = sys.monitoring
+        monitoring.set_events(monitoring.PROFILER_ID, 0)
+        monitoring.register_callback(
+            monitoring.PROFILER_ID, monitoring.events.PY_START, None
+        )
+        monitoring.free_tool_id(monitoring.PROFILER_ID)
+        self._active = False
+
+    def _in_scope(self, filename: str) -> bool:
+        cached = self._scope_cache.get(filename)
+        if cached is None:
+            cached = filename.startswith(self._root_prefix) and not any(
+                part in filename for part in cs.TRACE_EXCLUDED_PATH_PARTS
+            )
+            self._scope_cache[filename] = cached
+        return cached
+
+    def _on_py_start(self, code: CodeType, instruction_offset: int) -> None:
+        if not self._in_scope(code.co_filename):
+            return
+        # The callback runs in its own frame; f_back is the frame that just
+        # started executing `code`, and its f_back is the caller.
+        callee_frame = sys._getframe(1)
+        caller_frame = callee_frame.f_back
+        if caller_frame is None:
+            return
+        caller_code = caller_frame.f_code
+        if not self._in_scope(caller_code.co_filename):
+            return
+        stats = self._pairs.get((caller_code, code))
+        if stats is None:
+            stats = _PairStats()
+            self._pairs[(caller_code, code)] = stats
+        stats.count += 1
+        if self._current_workload != _NO_WORKLOAD:
+            stats.workloads.add(self._current_workload)
+        # Materialising f_locals is comparatively expensive, so receivers are
+        # sampled only for a pair's first few observations.
+        if (
+            stats.count <= cs.TRACE_RECEIVER_SAMPLE_LIMIT
+            and code.co_argcount >= 1
+            and code.co_varnames[0] in cs.TRACE_RECEIVER_PARAMS
+        ):
+            receiver = callee_frame.f_locals.get(code.co_varnames[0])
+            if receiver is not None:
+                receiver_type = (
+                    receiver if isinstance(receiver, type) else type(receiver)
+                )
+                stats.receiver_types.add(
+                    f"{receiver_type.__module__}.{receiver_type.__qualname__}"
+                )
+
+    def _frame_point(self, code: CodeType) -> FramePoint:
+        return FramePoint(
+            path=code.co_filename,
+            qualname=code.co_qualname,
+            line=code.co_firstlineno,
+        )
+
+    def records(self) -> list[CallRecord]:
+        result: list[CallRecord] = []
+        for (caller_code, callee_code), stats in self._pairs.items():
+            workloads = tuple(sorted(self._workloads[i] for i in stats.workloads))
+            result.append(
+                CallRecord(
+                    caller=self._frame_point(caller_code),
+                    callee=self._frame_point(callee_code),
+                    count=stats.count,
+                    workloads=workloads,
+                    receiver_types=tuple(sorted(stats.receiver_types)),
+                )
+            )
+        return result
+
+    def write(self, output: Path) -> int:
+        """Flush aggregated observations to ``output``; returns record count."""
+        records = self.records()
+        header = TraceHeader(
+            version=cs.TRACE_FORMAT_VERSION,
+            language=cs.TRACE_LANGUAGE_PYTHON,
+            repo_root=str(self._repo_root),
+            tracer=cs.TRACE_TOOL_NAME,
+        )
+        write_trace_file(output, header, records)
+        return len(records)

--- a/codebase_rag/trace/tracer.py
+++ b/codebase_rag/trace/tracer.py
@@ -36,6 +36,12 @@ class CallGraphTracer:
 
     Not reentrant: one instance may be started at a time per interpreter, since
     ``sys.monitoring`` allows a single profiler tool registration.
+
+    Call counts and workload attribution are best-effort under threads:
+    ``sys.monitoring`` callbacks fire on every thread, aggregation is unlocked
+    (locking the hot path is not worth it for provenance metadata), and the
+    current workload is interpreter-wide, so calls made by background threads
+    are attributed to the workload the main thread set last.
     """
 
     def __init__(self, repo_root: Path) -> None:
@@ -68,10 +74,16 @@ class CallGraphTracer:
     def start(self) -> None:
         monitoring = sys.monitoring
         monitoring.use_tool_id(monitoring.PROFILER_ID, cs.TRACE_TOOL_NAME)
-        monitoring.register_callback(
-            monitoring.PROFILER_ID, monitoring.events.PY_START, self._on_py_start
-        )
-        monitoring.set_events(monitoring.PROFILER_ID, monitoring.events.PY_START)
+        try:
+            monitoring.register_callback(
+                monitoring.PROFILER_ID, monitoring.events.PY_START, self._on_py_start
+            )
+            monitoring.set_events(monitoring.PROFILER_ID, monitoring.events.PY_START)
+        except BaseException:
+            # Without this, a failed setup leaves the profiler slot claimed
+            # while stop() skips cleanup because _active stayed False.
+            monitoring.free_tool_id(monitoring.PROFILER_ID)
+            raise
         self._active = True
 
     def stop(self) -> None:
@@ -88,9 +100,9 @@ class CallGraphTracer:
     def _in_scope(self, filename: str) -> bool:
         cached = self._scope_cache.get(filename)
         if cached is None:
-            cached = filename.startswith(self._root_prefix) and not any(
-                part in filename for part in cs.TRACE_EXCLUDED_PATH_PARTS
-            )
+            cached = filename.startswith(
+                self._root_prefix
+            ) and cs.TRACE_EXCLUDED_DIR_NAMES.isdisjoint(Path(filename).parts)
             self._scope_cache[filename] = cached
         return cached
 

--- a/docs/architecture/graph-schema.md
+++ b/docs/architecture/graph-schema.md
@@ -68,7 +68,7 @@ The knowledge graph uses a unified schema across all supported languages.
 
 `REFERENCES` records a non-call mention of a callable or class (a function passed as a value, a callback stored in a dict). `INSTANTIATES` records a class being constructed. Both belong to the default `calls` capture group. The findings relationships (`IMPLEMENTS_PATTERN`, `HAS_SMELL`, `HAS_VULNERABILITY`) are opt-in with the `findings` capture group.
 
-`CALLS` edges are created by static analysis and carry no properties by default. [Dynamic call tracing](../guide/dynamic-tracing.md) decorates them with runtime provenance (`dynamic`, `dynamic_call_count`, `dynamic_workloads`, `dynamic_workload_count`, `dynamic_receiver_types`) and creates runtime-only edges flagged `static_missed: true` for relationships parsing cannot see, such as registry dispatch and reflection.
+`CALLS` edges are created by static analysis and carry no properties by default. [Dynamic call tracing](../guide/dynamic-tracing.md) decorates them with runtime provenance (`dynamic`, `dynamic_call_count`, `dynamic_workloads`, `dynamic_workload_count`, `dynamic_receiver_types`) and creates runtime-only edges flagged `static_missed: true` when no matching static edge existed in the graph at ingest time. Dynamic dispatch, reflection, and registries are the common causes.
 
 ## I/O and Data-Flow Edges
 

--- a/docs/architecture/graph-schema.md
+++ b/docs/architecture/graph-schema.md
@@ -68,6 +68,8 @@ The knowledge graph uses a unified schema across all supported languages.
 
 `REFERENCES` records a non-call mention of a callable or class (a function passed as a value, a callback stored in a dict). `INSTANTIATES` records a class being constructed. Both belong to the default `calls` capture group. The findings relationships (`IMPLEMENTS_PATTERN`, `HAS_SMELL`, `HAS_VULNERABILITY`) are opt-in with the `findings` capture group.
 
+`CALLS` edges are created by static analysis and carry no properties by default. [Dynamic call tracing](../guide/dynamic-tracing.md) decorates them with runtime provenance (`dynamic`, `dynamic_call_count`, `dynamic_workloads`, `dynamic_workload_count`, `dynamic_receiver_types`) and creates runtime-only edges flagged `static_missed: true` for relationships parsing cannot see, such as registry dispatch and reflection.
+
 ## I/O and Data-Flow Edges
 
 The `io` capture group (opt-in; excluded from the default capture set) adds three relationships that model how code touches external resources and how values move between them.

--- a/docs/guide/dynamic-tracing.md
+++ b/docs/guide/dynamic-tracing.md
@@ -24,6 +24,12 @@ test's node id is attached to the calls it triggered, so an edge in the graph
 can tell you *which tests* exercise it. Tracing is scoped to files under the
 pytest root; pass `--cgr-trace-repo PATH` if your repository root differs.
 
+Under `pytest-xdist` each worker traces its own interpreter and writes its own
+file with the worker id in the name (`cgr-trace-gw0.jsonl`, ...); ingest each
+file to cover the whole run. Within one process, workload attribution is
+best-effort for multi-threaded code: calls made by background threads are
+attributed to the test the main thread was running.
+
 Any other workload can be traced programmatically:
 
 ```python
@@ -59,7 +65,7 @@ properties:
 | `dynamic_workloads` | Test ids that exercised the edge (capped list). |
 | `dynamic_workload_count` | Uncapped number of distinct workloads. |
 | `dynamic_receiver_types` | Concrete receiver types observed for method calls. |
-| `static_missed: true` | No static `CALLS` edge existed for this pair: the relationship was invisible to parsing (dynamic dispatch, reflection, registries). |
+| `static_missed: true` | No matching static `CALLS` edge existed in the graph at ingest time. Dynamic dispatch, reflection, and registries are the common causes; a stale or incomplete static graph produces the same flag. |
 
 An edge with `dynamic: true` and `static_missed: false` is a static edge
 confirmed at runtime. Re-ingesting a trace is idempotent: properties are set,

--- a/docs/guide/dynamic-tracing.md
+++ b/docs/guide/dynamic-tracing.md
@@ -1,0 +1,84 @@
+# Dynamic Call Tracing
+
+Static analysis cannot see every call: dispatch through registries, `getattr`
+lookups, callbacks routed by frameworks, and monkey-patched targets only exist
+at runtime. Dynamic tracing runs your code (typically the test suite), records
+which functions actually called which, and merges those observations into the
+graph alongside the statically derived `CALLS` edges.
+
+Currently supported for **Python** codebases (Python 3.12+ at runtime, via
+`sys.monitoring`). Other language runtimes are tracked in
+[issue #1244](https://github.com/vitali87/code-graph-rag/issues/1244).
+
+## Recording a trace
+
+The `cgr` package ships a pytest plugin. It is inert unless enabled:
+
+```bash
+cd /path/to/your-repo
+pytest --cgr-trace
+```
+
+This writes `cgr-trace.jsonl` (override with `--cgr-trace-output PATH`). Each
+test's node id is attached to the calls it triggered, so an edge in the graph
+can tell you *which tests* exercise it. Tracing is scoped to files under the
+pytest root; pass `--cgr-trace-repo PATH` if your repository root differs.
+
+Any other workload can be traced programmatically:
+
+```python
+from pathlib import Path
+from codebase_rag.trace.tracer import CallGraphTracer
+
+tracer = CallGraphTracer(Path("/path/to/your-repo"))
+tracer.start()
+try:
+    run_your_workload()
+finally:
+    tracer.stop()
+tracer.write(Path("cgr-trace.jsonl"))
+```
+
+## Ingesting a trace
+
+Parse the repository into the graph first (`cgr start --repo-path ... --update-graph`),
+then ingest the trace against the same repository:
+
+```bash
+cgr trace ingest cgr-trace.jsonl --repo-path /path/to/your-repo
+```
+
+The ingest step resolves each recorded frame to the graph's `Function`,
+`Method`, or `Module` nodes and writes `CALLS` edges with dynamic-provenance
+properties:
+
+| Property | Meaning |
+|---|---|
+| `dynamic: true` | This edge was observed at runtime. |
+| `dynamic_call_count` | Total observed invocations in the trace. |
+| `dynamic_workloads` | Test ids that exercised the edge (capped list). |
+| `dynamic_workload_count` | Uncapped number of distinct workloads. |
+| `dynamic_receiver_types` | Concrete receiver types observed for method calls. |
+| `static_missed: true` | No static `CALLS` edge existed for this pair: the relationship was invisible to parsing (dynamic dispatch, reflection, registries). |
+
+An edge with `dynamic: true` and `static_missed: false` is a static edge
+confirmed at runtime. Re-ingesting a trace is idempotent: properties are set,
+not accumulated.
+
+The command reports resolution quality: frames outside the repository,
+synthetic code objects (lambdas, generator expressions), and names the graph
+does not know are counted per reason instead of being silently dropped.
+
+## Caveats
+
+- **Coverage honesty.** The dynamic view only reflects the workload that was
+  traced. The absence of a dynamic edge never means dead code; it means the
+  traced workload did not exercise that path.
+- **Staleness.** Dynamic properties describe the commit that was traced.
+  After significant edits, re-run the trace and ingest again; a full graph
+  rebuild with `--clean` discards dynamic edges entirely.
+- **Threading.** Counts are aggregated without locks; heavily threaded
+  workloads may undercount, though edge presence is unaffected.
+- **Overhead.** `sys.monitoring` keeps tracing cheap enough for test suites,
+  but expect measurable slowdown on call-heavy code. Receiver types are
+  sampled only for a pair's first few calls to bound the cost.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
     - Interactive Querying: guide/interactive-querying.md
     - Code Optimization: guide/code-optimization.md
     - Dead Code Detection: guide/dead-code.md
+    - Dynamic Call Tracing: guide/dynamic-tracing.md
     - Graph Export: guide/graph-export.md
     - Real-Time Updates: guide/realtime-updates.md
     - MCP Server: guide/mcp-server.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,9 @@ dependencies = [
 code-graph-rag = "codebase_rag.cli:app"
 cgr = "codebase_rag.cli:app"
 
+[project.entry-points.pytest11]
+cgr_trace = "codebase_rag.trace.pytest_plugin"
+
 [tool.uv]
 package = true
 

--- a/uv.lock
+++ b/uv.lock
@@ -404,7 +404,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.566"
+version = "0.0.628"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -716,7 +716,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
@@ -747,43 +747,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
 [[package]]
@@ -920,8 +920,8 @@ name = "faiss-cpu"
 version = "1.14.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "packaging" },
+    { name = "numpy", marker = "sys_platform != 'win32'" },
+    { name = "packaging", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/b0/48c083d01b7b68c463c1d56507147a9d733f791e1c469a77215a872a9fb5/faiss_cpu-1.14.3-cp310-abi3-macosx_14_0_arm64.whl", hash = "sha256:a9369863290a3f0e033757e4c10577b6ef7431f1cede394dabd0a137e4e2ed45", size = 4768290, upload-time = "2026-06-13T02:19:03.427Z" },
@@ -1592,7 +1592,7 @@ name = "macholib"
 version = "1.16.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "altgraph" },
+    { name = "altgraph", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
 wheels = [
@@ -1752,10 +1752,10 @@ name = "milvus-lite"
 version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "faiss-cpu" },
-    { name = "grpcio" },
-    { name = "numpy" },
-    { name = "pyarrow" },
+    { name = "faiss-cpu", marker = "sys_platform != 'win32'" },
+    { name = "grpcio", marker = "sys_platform != 'win32'" },
+    { name = "numpy", marker = "sys_platform != 'win32'" },
+    { name = "pyarrow", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7f/58/54c72981958073d365febeae8fed3115c87761f45905f2d4725f506b94d1/milvus_lite-3.1.0.tar.gz", hash = "sha256:8d467ae81173f1ede93723a80f08d85b91988b451cd2b7bbf9b5a7cfb875e04b", size = 636180, upload-time = "2026-07-15T06:40:58.177Z" }
 wheels = [
@@ -1948,7 +1948,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -1987,7 +1987,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -1999,7 +1999,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -2029,9 +2029,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2043,7 +2043,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -3426,8 +3426,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
Closes #1246. Implements the Python-facing slice of the #1245 foundation (interchange format, edge provenance schema, resolution layer, ingestion CLI) under epic #1244.

## What this adds

Static analysis cannot see dynamic dispatch, reflection, or registry lookups. This PR adds runtime call-graph capture for Python: run a workload under the tracer, record which functions actually called which, and merge those observations into the graph as provenance-tagged `CALLS` edges.

- **Tracer** (`codebase_rag/trace/tracer.py`): `sys.monitoring` (PEP 669) `PY_START` capture scoped to a repo root, with venv/site-packages exclusion, per-pair call counts, workload tagging, and sampled receiver types so dynamic dispatch resolves to the concrete implementation that ran.
- **Pytest plugin** (`codebase_rag/trace/pytest_plugin.py`, registered as a `pytest11` entry point): inert without `--cgr-trace`; each test's node id becomes workload provenance on the edges it exercised. Writes the trace at session end.
- **Interchange format** (`codebase_rag/trace/records.py`): versioned JSONL (header + aggregated call records) that future language tracers emit too; the reader rejects version mismatches.
- **Resolution** (`codebase_rag/trace/resolution.py`): maps runtime frames to graph nodes, stripping `<locals>`, resolving `<module>` frames to `Module` nodes, handling `qn@line` duplicate variants, and falling back to line containment; unresolvable frames are counted per reason, never dropped silently.
- **Ingestion** (`cgr trace ingest <file> --repo-path ...`): writes edges through the existing MERGE path. A pair static analysis already knew gets decorated (`dynamic`, `dynamic_call_count`, `dynamic_workloads`, `dynamic_workload_count`, `dynamic_receiver_types`); a runtime-only pair becomes a new edge flagged `static_missed: true`. Re-ingestion is idempotent (SET, not increment).
- **Docs**: `docs/guide/dynamic-tracing.md` (usage plus coverage-honesty and staleness caveats, in nav) and a provenance note in `docs/architecture/graph-schema.md`.

## Backwards compatibility

No new relationship type, no new labels, no migration. Untraced graphs read the new properties as null; the static pipeline still emits property-less CALLS and incremental re-syncs MERGE onto existing edges without touching dynamic properties. Endpoint labels are the ones the schema already allows for CALLS.

## Verification

- 13 new tests (tracer incl. registry-dispatch capture and receiver sampling, resolution, ingestion incl. idempotency, and a subprocess end-to-end of the pytest plugin). `ruff`, `ty`, and `mkdocs build --strict` clean.
- Validated against a live stack (`cgr daemon up` → index → `pytest --cgr-trace` → `cgr trace ingest` → query): a registry-dispatch sample produced 8 dynamic edges, 6 confirming static edges, 2 `static_missed` (the dict dispatches), correct receiver types (`Animal.speak` observed with `Dog`/`Cat` receivers), and a static-only `speak -> Animal._sound` edge runtime never took, which is the static/dynamic complement working as designed.
- Self-trace of this repo's own tests: 839 aggregated pairs across 17 workloads at roughly 2x wall clock before the venv-exclusion fix and well under it after.

Found while validating and filed separately: #1257 (Memgraph 3.x rejects the pattern-in-WHERE cleanup queries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Python runtime call tracing with workload and receiver-type metadata.
  * Added `cgr trace ingest` for importing JSONL traces into the call graph.
  * Added pytest options for enabling tracing, selecting output, repository scope, and workload tagging.
  * Added static-edge confirmation, runtime-only call identification, and idempotent ingestion.
  * Added resolution and ingestion statistics, including unresolved-frame diagnostics.

* **Documentation**
  * Added dynamic tracing guidance, examples, schema details, and usage limitations.

* **Bug Fixes**
  * Added validation and clear error handling for malformed trace files and unresolved frames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->