### PR TITLE
fix: rewrite pattern-in-WHERE cleanup queries for Memgraph 3.x and pin engine image

### DIFF
--- a/codebase_rag/constants/graph.py
+++ b/codebase_rag/constants/graph.py
@@ -372,8 +372,15 @@ CYPHER_DELETE_FOLDER = "MATCH (f:Folder {absolute_path: $path}) DETACH DELETE f"
 CYPHER_DELETE_CALLS = "MATCH ()-[r:CALLS]->() DELETE r"
 # Removes external import-target Module nodes that no module imports anymore
 # (e.g. an imported name that was renamed/removed on an incremental rebuild).
+# OPTIONAL MATCH + count instead of `WHERE NOT (m)<--()`: Memgraph 3.x
+# rejects pattern expressions inside WHERE, and this form is accepted by
+# both 2.x and 3.x (issue #1257).
 CYPHER_DELETE_ORPHAN_EXTERNAL_MODULES = (
-    "MATCH (m:ExternalModule) WHERE NOT (m)<--() DETACH DELETE m"
+    "MATCH (m:ExternalModule) "
+    "OPTIONAL MATCH (x)-->(m) "
+    "WITH m, count(x) AS inbound "
+    "WHERE inbound = 0 "
+    "DETACH DELETE m"
 )
 CYPHER_PROJECT_MODULE_PATHS = (
     # The bare-name alternative covers the repository-root __init__.py,

--- a/codebase_rag/cypher_queries.py
+++ b/codebase_rag/cypher_queries.py
@@ -3,9 +3,15 @@ from .constants import CYPHER_DEFAULT_LIMIT, NodeLabel, RelationshipType
 CYPHER_DELETE_ALL = "MATCH (n) DETACH DELETE n;"
 
 # Graph structural integrity audit (issue #646). A zero-degree Project is a
-# valid empty-repo graph, so the orphan scan exempts it.
+# valid empty-repo graph, so the orphan scan exempts it. OPTIONAL MATCH +
+# count instead of `WHERE NOT (n)--()`: Memgraph 3.x rejects pattern
+# expressions inside WHERE, and this form is accepted by both 2.x and 3.x
+# (issue #1257).
 CYPHER_AUDIT_ORPHANS = (
-    "MATCH (n) WHERE NOT (n)--() AND NOT n:Project "
+    "MATCH (n) WHERE NOT n:Project "
+    "OPTIONAL MATCH (n)--(x) "
+    "WITH n, count(x) AS degree "
+    "WHERE degree = 0 "
     "RETURN labels(n)[0] AS label, count(n) AS orphans"
 )
 CYPHER_AUDIT_LABELS = "MATCH (n) UNWIND labels(n) AS label RETURN DISTINCT label"

--- a/codebase_rag/docker-compose.yaml
+++ b/codebase_rag/docker-compose.yaml
@@ -4,7 +4,10 @@
 # #1012). Set CGR_STACK_BIND_HOST=0.0.0.0 to expose the stack deliberately.
 services:
   memgraph:
-    image: memgraph/memgraph-mage
+    # Pinned: engine upgrades change accepted Cypher syntax (issue #1257,
+    # Memgraph 3.x dropped pattern-in-WHERE), so `latest` must not float.
+    # Bump deliberately and run the integration suite against the new tag.
+    image: memgraph/memgraph-mage:3.3
     ports:
       - "${CGR_STACK_BIND_HOST:-127.0.0.1}:${MEMGRAPH_PORT:-7687}:7687"
       - "${CGR_STACK_BIND_HOST:-127.0.0.1}:${MEMGRAPH_HTTP_PORT:-7444}:7444"

--- a/codebase_rag/docker-compose.yaml
+++ b/codebase_rag/docker-compose.yaml
@@ -4,10 +4,11 @@
 # #1012). Set CGR_STACK_BIND_HOST=0.0.0.0 to expose the stack deliberately.
 services:
   memgraph:
-    # Pinned: engine upgrades change accepted Cypher syntax (issue #1257,
-    # Memgraph 3.x dropped pattern-in-WHERE), so `latest` must not float.
-    # Bump deliberately and run the integration suite against the new tag.
-    image: memgraph/memgraph-mage:3.3
+    # Pinned by digest: engine upgrades change accepted Cypher syntax (issue
+    # #1257, Memgraph 3.x dropped pattern-in-WHERE), and memgraph-mage has no
+    # patch-level tags, so even `3.3` can float to a rebuilt image. Bump
+    # deliberately and run the integration suite against the new digest.
+    image: memgraph/memgraph-mage:3.3@sha256:4579a70a2a095026d2e4039a5b0a4756e8e0e8a37ea0350f71240346efe343e8
     ports:
       - "${CGR_STACK_BIND_HOST:-127.0.0.1}:${MEMGRAPH_PORT:-7687}:7687"
       - "${CGR_STACK_BIND_HOST:-127.0.0.1}:${MEMGRAPH_HTTP_PORT:-7444}:7444"

--- a/codebase_rag/tests/integration/conftest.py
+++ b/codebase_rag/tests/integration/conftest.py
@@ -36,7 +36,9 @@ def memgraph_container() -> Generator[dict[str, str | int], None, None]:
     from testcontainers.core.container import DockerContainer
     from testcontainers.core.wait_strategies import LogMessageWaitStrategy
 
-    container = DockerContainer("memgraph/memgraph:latest")
+    # Same engine line the packaged stack pins (issue #1257): integration
+    # tests must exercise the syntax the shipped Memgraph actually accepts.
+    container = DockerContainer("memgraph/memgraph:3.3.0")
     container.with_exposed_ports(7687)
     container.waiting_for(LogMessageWaitStrategy("You are running Memgraph"))
 

--- a/codebase_rag/tests/test_graph_audit.py
+++ b/codebase_rag/tests/test_graph_audit.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import collections
 
 from codebase_rag import constants as cs
+from codebase_rag import cypher_queries as cq
 from codebase_rag import graph_audit as ga
 from codebase_rag.types_defs import GraphNodeRecord, GraphRelRecord, PropertyDict
 
@@ -271,7 +272,7 @@ class TestLiveGraphAudit:
     def test_clean_live_graph_passes(self) -> None:
         fetch = self._fetch_factory(
             {
-                "NOT (n)--()": [],
+                cq.CYPHER_AUDIT_ORPHANS: [],
                 "UNWIND labels(n)": [],
                 "type(r)": [],
             }
@@ -280,7 +281,7 @@ class TestLiveGraphAudit:
 
     def test_live_orphans_flagged(self) -> None:
         fetch = self._fetch_factory(
-            {"NOT (n)--()": [{"label": "Method", "orphans": 427}]}
+            {cq.CYPHER_AUDIT_ORPHANS: [{"label": "Method", "orphans": 427}]}
         )
         violations = ga.collect_live_violations(fetch)
         checks = [v.check for v in violations]

--- a/codebase_rag/tests/test_health_checker.py
+++ b/codebase_rag/tests/test_health_checker.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import mgclient  # ty: ignore[unresolved-import]
 import pytest
 
+from codebase_rag.cypher_queries import CYPHER_AUDIT_ORPHANS
 from codebase_rag.tools.health_checker import HealthChecker
 
 
@@ -90,7 +91,9 @@ def test_check_graph_integrity_passes_on_clean_graph(
 def test_check_graph_integrity_reports_orphans(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    cursor = _FakeCursor({"NOT (n)--()": [("Method", 427)]}, ["label", "orphans"])
+    cursor = _FakeCursor(
+        {CYPHER_AUDIT_ORPHANS: [("Method", 427)]}, ["label", "orphans"]
+    )
     monkeypatch.setattr(mgclient, "connect", lambda **_: _FakeConnection(cursor))
 
     results = HealthChecker().check_graph_integrity()

--- a/codebase_rag/tests/test_memgraph3_cypher_compat.py
+++ b/codebase_rag/tests/test_memgraph3_cypher_compat.py
@@ -1,0 +1,37 @@
+# Memgraph 3.x rejects pattern expressions inside WHERE clauses
+# (`WHERE NOT (m)<--()` fails with "Not yet implemented: atom expression"),
+# which crashed `cgr start --update-graph` post-sync (issue #1257). Every
+# shipped Cypher constant must avoid the pattern-in-WHERE shape; the
+# OPTIONAL MATCH + count rewrite is accepted by Memgraph 2.x and 3.x alike.
+
+from __future__ import annotations
+
+from codebase_rag import constants, cypher_queries
+
+# A pattern expression used as a WHERE predicate closes (or opens) with an
+# anonymous empty node `()` adjacent to an edge; legitimate MATCH-clause
+# patterns bind at least the end they consume.
+_FORBIDDEN_FRAGMENTS = (")--()", "<--()", "-->()", "()--(", "()<--", "()-->")
+
+
+def _string_constants(module) -> dict[str, str]:
+    return {
+        name: value
+        for name, value in vars(module).items()
+        if name.isupper() and isinstance(value, str)
+    }
+
+
+def test_no_pattern_expressions_in_where_clauses():
+    offenders = []
+    for module in (cypher_queries, constants):
+        for name, value in _string_constants(module).items():
+            for fragment in _FORBIDDEN_FRAGMENTS:
+                if fragment in value:
+                    offenders.append((module.__name__, name, fragment))
+    assert not offenders, offenders
+
+
+def test_orphan_cleanup_queries_use_portable_rewrite():
+    assert "OPTIONAL MATCH" in constants.CYPHER_DELETE_ORPHAN_EXTERNAL_MODULES
+    assert "OPTIONAL MATCH" in cypher_queries.CYPHER_AUDIT_ORPHANS

--- a/codebase_rag/tests/test_memgraph3_cypher_compat.py
+++ b/codebase_rag/tests/test_memgraph3_cypher_compat.py
@@ -6,12 +6,37 @@
 
 from __future__ import annotations
 
+import re
+
+import pytest
+
 from codebase_rag import constants, cypher_queries
 
-# A pattern expression used as a WHERE predicate closes (or opens) with an
-# anonymous empty node `()` adjacent to an edge; legitimate MATCH-clause
-# patterns bind at least the end they consume.
-_FORBIDDEN_FRAGMENTS = (")--()", "<--()", "-->()", "()--(", "()<--", "()-->")
+# A WHERE predicate ends at the next clause keyword (or the query's end).
+_WHERE_SPLIT = re.compile(r"\bWHERE\b")
+_CLAUSE_BOUNDARY = re.compile(
+    r"\b(RETURN|WITH|MATCH|OPTIONAL|UNWIND|MERGE|DETACH|DELETE|SET|REMOVE"
+    r"|CREATE|ORDER|SKIP|LIMIT|CALL|UNION)\b"
+)
+# A relationship pattern inside a predicate: a closing node paren joined to an
+# opening one by an edge (`--`, `<--`, `-->`, or a bracketed relationship).
+_RELATIONSHIP_IN_PREDICATE = re.compile(r"\)\s*<?-\s*(?:\[[^\]]*\]\s*)?->?\s*\(")
+
+
+def _where_predicates(query: str) -> list[str]:
+    predicates = []
+    for tail in _WHERE_SPLIT.split(query)[1:]:
+        boundary = _CLAUSE_BOUNDARY.search(tail)
+        predicates.append(tail[: boundary.start()] if boundary else tail)
+    return predicates
+
+
+def _pattern_predicates(query: str) -> list[str]:
+    return [
+        predicate.strip()
+        for predicate in _where_predicates(query)
+        if _RELATIONSHIP_IN_PREDICATE.search(predicate)
+    ]
 
 
 def _string_constants(module) -> dict[str, str]:
@@ -22,16 +47,52 @@ def _string_constants(module) -> dict[str, str]:
     }
 
 
+@pytest.mark.parametrize(
+    "query",
+    [
+        # The two shapes that crashed on Memgraph 3.3.0 before the rewrite.
+        "MATCH (m:ExternalModule) WHERE NOT (m)<--() DETACH DELETE m",
+        "MATCH (n) WHERE NOT n:Project AND NOT (n)--() RETURN labels(n)[0]",
+        "MATCH (n) WHERE NOT (n)-[:REL]->() RETURN n",
+        "MATCH (n) WHERE (n)<-[:DEFINES]-(:Module) RETURN n",
+    ],
+)
+def test_detector_flags_pattern_predicates(query: str) -> None:
+    assert _pattern_predicates(query)
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        # Patterns are legal in MATCH clauses; only WHERE predicates matter.
+        "MATCH ()-->(n) WHERE n.x = 0 RETURN n",
+        "MATCH (n) OPTIONAL MATCH (n)--(x) WITH n, count(x) AS degree "
+        "WHERE degree = 0 RETURN n",
+        "MATCH (a)-[r:CALLS]->(b) WHERE coalesce(r.static_missed, false) = false "
+        "RETURN a",
+        "MATCH (n) WHERE n.qualified_name STARTS WITH $prefix RETURN n",
+    ],
+)
+def test_detector_permits_legal_queries(query: str) -> None:
+    assert _pattern_predicates(query) == []
+
+
 def test_no_pattern_expressions_in_where_clauses():
     offenders = []
     for module in (cypher_queries, constants):
         for name, value in _string_constants(module).items():
-            for fragment in _FORBIDDEN_FRAGMENTS:
-                if fragment in value:
-                    offenders.append((module.__name__, name, fragment))
+            for predicate in _pattern_predicates(value):
+                offenders.append((module.__name__, name, predicate))
     assert not offenders, offenders
 
 
 def test_orphan_cleanup_queries_use_portable_rewrite():
-    assert "OPTIONAL MATCH" in constants.CYPHER_DELETE_ORPHAN_EXTERNAL_MODULES
-    assert "OPTIONAL MATCH" in cypher_queries.CYPHER_AUDIT_ORPHANS
+    delete_orphans = constants.CYPHER_DELETE_ORPHAN_EXTERNAL_MODULES
+    assert "OPTIONAL MATCH" in delete_orphans
+    assert "count(x) AS inbound" in delete_orphans
+    assert "WHERE inbound = 0" in delete_orphans
+
+    audit_orphans = cypher_queries.CYPHER_AUDIT_ORPHANS
+    assert "OPTIONAL MATCH" in audit_orphans
+    assert "count(x) AS degree" in audit_orphans
+    assert "WHERE degree = 0" in audit_orphans


### PR DESCRIPTION
Closes #1257.

## What

Memgraph 3.x rejects pattern expressions inside `WHERE` (`WHERE NOT (m)<--()` fails with `Not yet implemented: atom expression`), which crashed `cgr start --update-graph` in the post-sync cleanup phase on a fresh `memgraph-mage:latest` pull.

Three changes:

- **Rewrote both affected queries** with the `OPTIONAL MATCH` + count form, which Memgraph 2.x and 3.x both accept (it is also the rewrite the 3.x error message itself recommends), so the fix is backwards compatible for users pinned to older engines:
  - `CYPHER_DELETE_ORPHAN_EXTERNAL_MODULES` (`constants/graph.py`)
  - `CYPHER_AUDIT_ORPHANS` (`cypher_queries.py`)
- **Pinned the stack engine image** to `memgraph/memgraph-mage:3.3` in `codebase_rag/docker-compose.yaml` (root-cause mitigation: `latest` floating is how an engine syntax change reached users unannounced), and pinned the integration-test container to the same engine line (`memgraph/memgraph:3.3.0`) so CI exercises the syntax the shipped engine actually accepts.
- **Added a regression test** (`test_memgraph3_cypher_compat.py`) that scans every shipped Cypher string constant for the pattern-in-WHERE shape (anonymous empty-node pattern fragments), so the incompatible form cannot reappear silently.

No version detection: a single portable query serves both engine lines, so a version-to-query matrix would add a probe, a branch, and a testing burden for zero benefit. The performance trade-off (counting inbound edges instead of an early-exit existence check) is negligible for these once-per-sync cleanup queries.

## Verification

- Against live Memgraph 3.3.0: both rewritten queries execute; the previously crashing `cgr start --repo-path <sample> --update-graph` now completes with `Graph update completed!` and intact node counts.
- New regression tests pass; `test_graph_updater_pruning` (which asserts against the rewritten constant) passes unchanged; ruff/ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved orphan-node and external-module cleanup to reliably detect items with no relationships.
  - Enhanced compatibility with Memgraph 3.x, helping prevent query failures during graph audits and maintenance.

- **Chores**
  - Standardized Memgraph services and integration tests on version 3.3 for more consistent behavior.

- **Tests**
  - Added coverage for supported query syntax and orphan-cleanup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->