### PR TITLE
feat: add Node.js runtime call tracing via V8 cpuprofile conversion

### DIFF
--- a/codebase_rag/cli_help.py
+++ b/codebase_rag/cli_help.py
@@ -71,6 +71,7 @@ CMD_WORKSPACE_REMOVE_REPO = "Remove a repository from a workspace by path"
 CMD_TRACE = "Ingest runtime call traces as dynamic CALLS edges"
 CMD_TRACE_GROUP = CMD_TRACE
 CMD_TRACE_INGEST = "Resolve a trace file against a project and write dynamic edges"
+CMD_TRACE_CONVERT = "Convert a V8 .cpuprofile (node --cpu-prof) to a trace file"
 
 CMD_STOP = "Stop the shared stack (alias for cgr daemon down)"
 CMD_STATUS = "Show stack state and the last sync time for each project"
@@ -110,6 +111,13 @@ HELP_TRACE_PROJECT_NAME = (
 )
 EXAMPLES_TRACE_INGEST = (
     "EXAMPLE\n\n  pytest --cgr-trace\n\n"
+    "  cgr trace ingest cgr-trace.jsonl --repo-path ./my-repo"
+)
+HELP_TRACE_OUTPUT = "Where to write the converted trace file."
+HELP_TRACE_WORKLOAD = "Workload label to attach to every converted record."
+EXAMPLES_TRACE_CONVERT = (
+    "EXAMPLE\n\n  node --cpu-prof --cpu-prof-name=run.cpuprofile app.js\n\n"
+    "  cgr trace convert run.cpuprofile --repo-path ./my-repo\n\n"
     "  cgr trace ingest cgr-trace.jsonl --repo-path ./my-repo"
 )
 

--- a/codebase_rag/constants/trace.py
+++ b/codebase_rag/constants/trace.py
@@ -23,14 +23,22 @@ TRACE_KEY_RECEIVER_TYPES = "receiver_types"
 
 TRACE_LANGUAGE_PYTHON = "python"
 TRACE_LANGUAGE_JVM = "jvm"
+TRACE_LANGUAGE_JS = "javascript"
 TRACE_TOOL_NAME = "cgr-trace"
 TRACE_TOOL_NAME_JVM = "cgr-trace-jvm"
+TRACE_TOOL_NAME_CPUPROFILE = "cgr-trace-cpuprofile"
 TRACE_DEFAULT_OUTPUT = "cgr-trace.jsonl"
 
 # Python runtime qualname markers.
 TRACE_QUALNAME_LOCALS = "<locals>"
 TRACE_QUALNAME_MODULE = "<module>"
 TRACE_SYNTHETIC_PREFIX = "<"
+
+# V8 cpuprofile markers.
+TRACE_QUALNAME_ANONYMOUS = "<anonymous>"
+TRACE_JS_FILE_URL_PREFIX = "file://"
+
+TRACE_ERR_BAD_CPUPROFILE = "{path} is not a V8 .cpuprofile (missing node tree)."
 
 # JVM runtime name markers.
 TRACE_JVM_CONSTRUCTOR = "<init>"

--- a/codebase_rag/tests/test_dynamic_trace_cli.py
+++ b/codebase_rag/tests/test_dynamic_trace_cli.py
@@ -10,7 +10,11 @@ from click.testing import CliRunner
 
 from codebase_rag import constants as cs
 from codebase_rag.trace.cli import cli
-from codebase_rag.trace.records import TraceHeader, write_trace_file
+from codebase_rag.trace.records import (
+    TraceHeader,
+    read_trace_file,
+    write_trace_file,
+)
 
 
 class _RecordingGraph:
@@ -71,6 +75,83 @@ def test_ingest_command_prints_summary(tmp_path, monkeypatch):
     assert "records:          0" in result.output
     assert "edges written:    0" in result.output
     assert len(graph.queries) == 2
+
+
+def test_convert_command_writes_interchange_trace(tmp_path):
+    import json as jsonlib
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    profile = {
+        "nodes": [
+            {
+                "id": 1,
+                "callFrame": {
+                    "functionName": "runAll",
+                    "url": f"file://{repo.as_posix()}/main.js",
+                    "lineNumber": 2,
+                    "columnNumber": 0,
+                },
+                "hitCount": 1,
+                "children": [2],
+            },
+            {
+                "id": 2,
+                "callFrame": {
+                    "functionName": "helper",
+                    "url": f"file://{repo.as_posix()}/main.js",
+                    "lineNumber": 6,
+                    "columnNumber": 0,
+                },
+                "hitCount": 3,
+                "children": [],
+            },
+        ],
+        "startTime": 0,
+        "endTime": 1,
+        "samples": [],
+        "timeDeltas": [],
+    }
+    profile_path = tmp_path / "main.cpuprofile"
+    profile_path.write_text(jsonlib.dumps(profile))
+    output = tmp_path / "trace.jsonl"
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "convert",
+            str(profile_path),
+            "--repo-path",
+            str(repo),
+            "--output",
+            str(output),
+            "--workload",
+            "suite",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    header, records = read_trace_file(output)
+    assert header.language == cs.TRACE_LANGUAGE_JS
+    (record,) = list(records)
+    assert (record.caller.qualname, record.callee.qualname) == ("runAll", "helper")
+    assert record.workloads == ("suite",)
+    assert "1" in result.output
+
+
+def test_convert_command_fails_cleanly_on_malformed_profile(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    profile_path = tmp_path / "broken.cpuprofile"
+    profile_path.write_text("{}")
+
+    result = CliRunner().invoke(
+        cli,
+        ["convert", str(profile_path), "--repo-path", str(repo)],
+    )
+
+    assert result.exit_code == 1
+    assert "cpuprofile" in result.output.lower()
 
 
 def test_ingest_command_fails_cleanly_on_malformed_trace(tmp_path, monkeypatch):

--- a/codebase_rag/tests/test_dynamic_trace_cli.py
+++ b/codebase_rag/tests/test_dynamic_trace_cli.py
@@ -88,7 +88,7 @@ def test_convert_command_writes_interchange_trace(tmp_path):
                 "id": 1,
                 "callFrame": {
                     "functionName": "runAll",
-                    "url": f"file://{repo.as_posix()}/main.js",
+                    "url": (repo / "main.js").as_uri(),
                     "lineNumber": 2,
                     "columnNumber": 0,
                 },
@@ -99,7 +99,7 @@ def test_convert_command_writes_interchange_trace(tmp_path):
                 "id": 2,
                 "callFrame": {
                     "functionName": "helper",
-                    "url": f"file://{repo.as_posix()}/main.js",
+                    "url": (repo / "main.js").as_uri(),
                     "lineNumber": 6,
                     "columnNumber": 0,
                 },

--- a/codebase_rag/tests/test_dynamic_trace_cpuprofile.py
+++ b/codebase_rag/tests/test_dynamic_trace_cpuprofile.py
@@ -230,3 +230,17 @@ def test_duplicate_node_id_is_rejected_not_overwritten(tmp_path):
     }
     with pytest.raises(ValueError):
         _convert_raw(tmp_path, profile)
+
+
+def test_percent_escaped_url_is_decoded(tmp_path):
+    from codebase_rag.trace.cpuprofile import _url_to_path
+
+    # Spaces and other characters arrive percent-encoded; the decoded path must
+    # match the real repo prefix.
+    assert _url_to_path("file:///repo/my%20dir/main.js") == "/repo/my dir/main.js"
+
+
+def test_non_int_child_entry_is_rejected_not_dropped(tmp_path):
+    profile = {"nodes": [{"id": 1, "callFrame": _frame("a", "", 0), "children": ["x"]}]}
+    with pytest.raises(ValueError):
+        _convert_raw(tmp_path, profile)

--- a/codebase_rag/tests/test_dynamic_trace_cpuprofile.py
+++ b/codebase_rag/tests/test_dynamic_trace_cpuprofile.py
@@ -1,0 +1,138 @@
+# V8 .cpuprofile files (node --cpu-prof) encode observed call stacks as a
+# node tree; the converter must turn project-scoped parent/child links into
+# interchange call records, seeing through runtime-internal frames, mapping
+# 0-based lines to 1-based, and attributing module toplevels (issue #1247).
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.trace.cpuprofile import convert_cpuprofile
+from codebase_rag.trace.records import read_trace_file
+
+
+def _frame(function_name, url, line):
+    return {
+        "functionName": function_name,
+        "scriptId": "1",
+        "url": url,
+        "lineNumber": line,
+        "columnNumber": 0,
+    }
+
+
+def _node(node_id, frame, children=(), hit_count=0):
+    return {
+        "id": node_id,
+        "callFrame": frame,
+        "hitCount": hit_count,
+        "children": list(children),
+    }
+
+
+def _profile(tmp_path):
+    """(root)->(main toplevel)->runAll->[handle->greet, forEach->callback]."""
+    repo = tmp_path.as_posix()
+    main = f"file://{repo}/main.js"
+    registry = f"file://{repo}/src/registry.js"
+    vendored = f"file://{repo}/node_modules/lib/index.js"
+    return {
+        "nodes": [
+            _node(1, _frame("(root)", "", 0), children=[2]),
+            _node(2, _frame("", main, 0), children=[3], hit_count=1),
+            _node(3, _frame("runAll", main, 2), children=[4, 6, 8], hit_count=2),
+            _node(4, _frame("handle", registry, 6), children=[5], hit_count=3),
+            # The registry dispatch static analysis cannot see.
+            _node(5, _frame("greet", registry, 10), hit_count=7),
+            # A runtime-internal frame between two project frames must be
+            # walked through, like the JVM agent's stack walk.
+            _node(6, _frame("forEach", "node:internal/per_context", 40), children=[7]),
+            _node(7, _frame("callback", main, 8), hit_count=4),
+            # Vendored code under the repo root stays out of scope.
+            _node(8, _frame("vendored", vendored, 1), hit_count=9),
+        ],
+        "startTime": 0,
+        "endTime": 1000,
+        "samples": [],
+        "timeDeltas": [],
+    }
+
+
+def _convert(tmp_path, workload=None):
+    profile_path = tmp_path / "main.cpuprofile"
+    profile_path.write_text(json.dumps(_profile(tmp_path)))
+    output = tmp_path / "trace.jsonl"
+    count = convert_cpuprofile(
+        profile_path, repo_root=tmp_path, output=output, workload=workload
+    )
+    header, records = read_trace_file(output)
+    return count, header, list(records)
+
+
+def test_converts_project_edges_with_one_based_lines(tmp_path):
+    count, header, records = _convert(tmp_path)
+
+    assert header.language == cs.TRACE_LANGUAGE_JS
+    assert header.repo_root == str(tmp_path)
+    assert count == len(records)
+    edges = {(r.caller.qualname, r.callee.qualname): r for r in records}
+
+    dispatch = edges[("handle", "greet")]
+    assert dispatch.caller.path.endswith("src/registry.js")
+    assert dispatch.caller.line == 7
+    assert dispatch.callee.line == 11
+
+
+def test_edge_counts_are_callee_subtree_samples(tmp_path):
+    _count, _header, records = _convert(tmp_path)
+    edges = {(r.caller.qualname, r.callee.qualname): r for r in records}
+
+    # handle's subtree: own 3 + greet 7.
+    assert edges[("runAll", "handle")].count == 10
+    assert edges[("handle", "greet")].count == 7
+
+
+def test_toplevel_frame_maps_to_module_qualname(tmp_path):
+    _count, _header, records = _convert(tmp_path)
+    edges = {(r.caller.qualname, r.callee.qualname): r for r in records}
+
+    assert (cs.TRACE_QUALNAME_MODULE, "runAll") in edges
+
+
+def test_runtime_internal_frames_are_walked_through(tmp_path):
+    _count, _header, records = _convert(tmp_path)
+    edges = {(r.caller.qualname, r.callee.qualname): r for r in records}
+
+    assert ("runAll", "callback") in edges
+    assert not any("forEach" in pair for edge in edges for pair in edge)
+
+
+def test_vendored_and_internal_frames_never_appear(tmp_path):
+    _count, _header, records = _convert(tmp_path)
+
+    for record in records:
+        assert "node_modules" not in record.caller.path
+        assert "node_modules" not in record.callee.path
+        assert not record.caller.path.startswith("node:")
+        assert not record.callee.path.startswith("node:")
+
+
+def test_workload_label_lands_on_every_record(tmp_path):
+    _count, _header, records = _convert(tmp_path, workload="suite")
+
+    assert records
+    for record in records:
+        assert record.workloads == ("suite",)
+
+
+def test_malformed_profile_is_rejected(tmp_path):
+    profile_path = tmp_path / "broken.cpuprofile"
+    profile_path.write_text("{}")
+
+    with pytest.raises(ValueError):
+        convert_cpuprofile(
+            profile_path, repo_root=tmp_path, output=tmp_path / "out.jsonl"
+        )

--- a/codebase_rag/tests/test_dynamic_trace_cpuprofile.py
+++ b/codebase_rag/tests/test_dynamic_trace_cpuprofile.py
@@ -136,3 +136,63 @@ def test_malformed_profile_is_rejected(tmp_path):
         convert_cpuprofile(
             profile_path, repo_root=tmp_path, output=tmp_path / "out.jsonl"
         )
+
+
+def _convert_raw(tmp_path, profile):
+    profile_path = tmp_path / "raw.cpuprofile"
+    profile_path.write_text(json.dumps(profile))
+    return convert_cpuprofile(
+        profile_path, repo_root=tmp_path, output=tmp_path / "out.jsonl"
+    )
+
+
+def test_missing_child_reference_is_rejected_not_crashed(tmp_path):
+    profile = {
+        "nodes": [_node(1, _frame("(root)", "", 0), children=[99])],
+        "samples": [],
+        "timeDeltas": [],
+    }
+
+    with pytest.raises(ValueError):
+        _convert_raw(tmp_path, profile)
+
+
+def test_cyclic_or_shared_children_are_rejected_not_crashed(tmp_path):
+    url = f"file://{tmp_path.as_posix()}/main.js"
+    profile = {
+        "nodes": [
+            _node(1, _frame("a", url, 1), children=[2]),
+            _node(2, _frame("b", url, 2), children=[1]),
+        ],
+        "samples": [],
+        "timeDeltas": [],
+    }
+
+    with pytest.raises(ValueError):
+        _convert_raw(tmp_path, profile)
+
+
+def test_deep_profiles_do_not_hit_the_recursion_limit(tmp_path):
+    url = f"file://{tmp_path.as_posix()}/main.js"
+    depth = 5000
+    nodes = [
+        _node(i, _frame(f"f{i}", url, i), children=[i + 1], hit_count=1)
+        for i in range(1, depth)
+    ]
+    nodes.append(_node(depth, _frame(f"f{depth}", url, depth), hit_count=1))
+    profile = {"nodes": nodes, "samples": [], "timeDeltas": []}
+
+    count = _convert_raw(tmp_path, profile)
+
+    assert count == depth - 1
+
+
+def test_windows_drive_letter_urls_keep_project_frames(tmp_path):
+    from pathlib import Path as _Path
+
+    from codebase_rag.trace.cpuprofile import _url_to_path
+
+    assert _url_to_path("file:///C:/repo/main.js") == str(_Path("C:/repo/main.js"))
+    assert _url_to_path(f"file://{tmp_path.as_posix()}/main.js") == str(
+        tmp_path / "main.js"
+    )

--- a/codebase_rag/tests/test_dynamic_trace_cpuprofile.py
+++ b/codebase_rag/tests/test_dynamic_trace_cpuprofile.py
@@ -159,7 +159,7 @@ def test_missing_child_reference_is_rejected_not_crashed(tmp_path):
 
 
 def test_cyclic_or_shared_children_are_rejected_not_crashed(tmp_path):
-    url = f"file://{tmp_path.as_posix()}/main.js"
+    url = (tmp_path / "main.js").as_uri()
     profile = {
         "nodes": [
             _node(1, _frame("a", url, 1), children=[2]),
@@ -174,7 +174,7 @@ def test_cyclic_or_shared_children_are_rejected_not_crashed(tmp_path):
 
 
 def test_deep_profiles_do_not_hit_the_recursion_limit(tmp_path):
-    url = f"file://{tmp_path.as_posix()}/main.js"
+    url = (tmp_path / "main.js").as_uri()
     depth = 5000
     nodes = [
         _node(i, _frame(f"f{i}", url, i), children=[i + 1], hit_count=1)

--- a/codebase_rag/tests/test_dynamic_trace_cpuprofile.py
+++ b/codebase_rag/tests/test_dynamic_trace_cpuprofile.py
@@ -35,10 +35,11 @@ def _node(node_id, frame, children=(), hit_count=0):
 
 def _profile(tmp_path):
     """(root)->(main toplevel)->runAll->[handle->greet, forEach->callback]."""
-    repo = tmp_path.as_posix()
-    main = f"file://{repo}/main.js"
-    registry = f"file://{repo}/src/registry.js"
-    vendored = f"file://{repo}/node_modules/lib/index.js"
+    # Build file URLs with as_uri() so a Windows drive path yields a valid
+    # `file:///C:/...` URI (drive kept out of the authority) on any platform.
+    main = (tmp_path / "main.js").as_uri()
+    registry = (tmp_path / "src" / "registry.js").as_uri()
+    vendored = (tmp_path / "node_modules" / "lib" / "index.js").as_uri()
     return {
         "nodes": [
             _node(1, _frame("(root)", "", 0), children=[2]),
@@ -188,11 +189,44 @@ def test_deep_profiles_do_not_hit_the_recursion_limit(tmp_path):
 
 
 def test_windows_drive_letter_urls_keep_project_frames(tmp_path):
-    from pathlib import Path as _Path
-
     from codebase_rag.trace.cpuprofile import _url_to_path
 
-    assert _url_to_path("file:///C:/repo/main.js") == str(_Path("C:/repo/main.js"))
-    assert _url_to_path(f"file://{tmp_path.as_posix()}/main.js") == str(
-        tmp_path / "main.js"
+    # A Windows drive URL keeps its drive and normalises to POSIX separators so
+    # it matches the POSIX root_prefix on any platform.
+    assert _url_to_path("file:///C:/repo/main.js") == "C:/repo/main.js"
+    assert (
+        _url_to_path((tmp_path / "main.js").as_uri())
+        == (tmp_path / "main.js").as_posix()
     )
+
+
+def test_invalid_json_is_rejected_as_trace_format_error(tmp_path):
+    profile_path = tmp_path / "bad.cpuprofile"
+    profile_path.write_text("{invalid")
+
+    with pytest.raises(ValueError):
+        convert_cpuprofile(
+            profile_path, repo_root=tmp_path, output=tmp_path / "out.jsonl"
+        )
+
+
+def test_non_object_node_is_rejected_not_crashed(tmp_path):
+    with pytest.raises(ValueError):
+        _convert_raw(tmp_path, {"nodes": ["not-an-object"]})
+
+
+def test_non_list_children_is_rejected_not_crashed(tmp_path):
+    profile = {"nodes": [{"id": 1, "callFrame": _frame("a", "", 0), "children": 3}]}
+    with pytest.raises(ValueError):
+        _convert_raw(tmp_path, profile)
+
+
+def test_duplicate_node_id_is_rejected_not_overwritten(tmp_path):
+    profile = {
+        "nodes": [
+            _node(1, _frame("(root)", "", 0)),
+            _node(1, _frame("dup", "", 0)),
+        ]
+    }
+    with pytest.raises(ValueError):
+        _convert_raw(tmp_path, profile)

--- a/codebase_rag/tests/test_dynamic_trace_resolution_js.py
+++ b/codebase_rag/tests/test_dynamic_trace_resolution_js.py
@@ -1,0 +1,141 @@
+# V8 profile frames carry bare function names (never dotted paths), file
+# URLs, and function-declaration lines; the JS resolver must join them onto
+# the graph's dotted qualified names by path plus line span, with the name
+# as a tiebreak (issue #1247).
+
+from __future__ import annotations
+
+from codebase_rag import constants as cs
+from codebase_rag.trace.records import FramePoint
+from codebase_rag.trace.resolution import (
+    CallableNode,
+    JsFrameResolver,
+    ResolutionStats,
+)
+
+_P = "demo"
+
+
+def _node(label, qualified_name, path, start_line, end_line):
+    return CallableNode(
+        label=label,
+        qualified_name=qualified_name,
+        path=path,
+        start_line=start_line,
+        end_line=end_line,
+    )
+
+
+def _nodes():
+    return [
+        _node(cs.NodeLabel.MODULE, f"{_P}.src.utils", "src/utils.js", None, None),
+        _node(cs.NodeLabel.FUNCTION, f"{_P}.src.utils.greet", "src/utils.js", 3, 5),
+        _node(
+            cs.NodeLabel.METHOD, f"{_P}.src.utils.Person.greet", "src/utils.js", 10, 12
+        ),
+        _node(
+            cs.NodeLabel.FUNCTION,
+            f"{_P}.src.utils.outer.inner",
+            "src/utils.js",
+            18,
+            20,
+        ),
+        _node(cs.NodeLabel.FUNCTION, f"{_P}.src.utils.outer", "src/utils.js", 16, 24),
+        # A truly anonymous callback, named from its 0-based start point.
+        _node(
+            cs.NodeLabel.FUNCTION,
+            f"{_P}.src.utils.outer.anonymous_21_8",
+            "src/utils.js",
+            22,
+            23,
+        ),
+        # An overload implementation carrying the duplicate marker.
+        _node(
+            cs.NodeLabel.FUNCTION,
+            f"{_P}.src.store.useStore@27",
+            "src/store.ts",
+            27,
+            30,
+        ),
+    ]
+
+
+def _resolver(tmp_path):
+    return JsFrameResolver(tmp_path, _nodes())
+
+
+def _frame(tmp_path, rel_path, qualname, line):
+    return FramePoint(path=str(tmp_path / rel_path), qualname=qualname, line=line)
+
+
+def test_resolves_top_level_function_and_method_by_name_and_span(tmp_path):
+    resolver = _resolver(tmp_path)
+    stats = ResolutionStats()
+
+    top = resolver.resolve(_frame(tmp_path, "src/utils.js", "greet", 3), stats)
+    method = resolver.resolve(_frame(tmp_path, "src/utils.js", "greet", 10), stats)
+
+    assert top is not None
+    assert top.qualified_name == f"{_P}.src.utils.greet"
+    assert method is not None
+    assert method.qualified_name == f"{_P}.src.utils.Person.greet"
+    assert stats.total == 0
+
+
+def test_resolves_module_toplevel_frame_to_module_node(tmp_path):
+    resolved = _resolver(tmp_path).resolve(
+        _frame(tmp_path, "src/utils.js", cs.TRACE_QUALNAME_MODULE, 1),
+        ResolutionStats(),
+    )
+
+    assert resolved is not None
+    assert resolved.label == cs.NodeLabel.MODULE
+    assert resolved.qualified_name == f"{_P}.src.utils"
+
+
+def test_resolves_nested_function_to_innermost_span(tmp_path):
+    resolved = _resolver(tmp_path).resolve(
+        _frame(tmp_path, "src/utils.js", "inner", 18), ResolutionStats()
+    )
+
+    assert resolved is not None
+    assert resolved.qualified_name == f"{_P}.src.utils.outer.inner"
+
+
+def test_resolves_anonymous_frame_by_span(tmp_path):
+    resolved = _resolver(tmp_path).resolve(
+        _frame(tmp_path, "src/utils.js", cs.TRACE_QUALNAME_ANONYMOUS, 22),
+        ResolutionStats(),
+    )
+
+    assert resolved is not None
+    assert resolved.qualified_name == f"{_P}.src.utils.outer.anonymous_21_8"
+
+
+def test_resolves_duplicate_marker_variant_by_natural_name(tmp_path):
+    resolved = _resolver(tmp_path).resolve(
+        _frame(tmp_path, "src/store.ts", "useStore", 28), ResolutionStats()
+    )
+
+    assert resolved is not None
+    assert resolved.qualified_name == f"{_P}.src.store.useStore@27"
+
+
+def test_unresolved_reasons_are_categorised(tmp_path):
+    resolver = _resolver(tmp_path)
+    stats = ResolutionStats()
+
+    outside = resolver.resolve(
+        FramePoint(path="/elsewhere/x.js", qualname="f", line=1), stats
+    )
+    unknown = resolver.resolve(_frame(tmp_path, "src/gone.js", "f", 1), stats)
+    missing = resolver.resolve(_frame(tmp_path, "src/utils.js", "ghost", 99), stats)
+
+    assert outside is None
+    assert unknown is None
+    assert missing is None
+    assert stats.unresolved == {
+        cs.TraceUnresolvedReason.OUTSIDE_REPO.value: 1,
+        cs.TraceUnresolvedReason.UNKNOWN_PATH.value: 1,
+        cs.TraceUnresolvedReason.NO_MATCH.value: 1,
+    }

--- a/codebase_rag/trace/cli.py
+++ b/codebase_rag/trace/cli.py
@@ -68,3 +68,52 @@ def ingest_cmd(trace_file: Path, repo_path: Path, project_name: str | None) -> N
     )
     for reason, count in sorted(summary.resolution.unresolved.items()):
         click.echo(f"  unresolved[{reason}]: {count}")
+
+
+@cli.command(
+    "convert",
+    help=ch.CMD_TRACE_CONVERT,
+    short_help=ch.CMD_TRACE_CONVERT,
+    epilog=ch.EXAMPLES_TRACE_CONVERT,
+)
+@click.argument(
+    "profile_file",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.option(
+    "--repo-path",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    required=True,
+    help=ch.HELP_TRACE_REPO_PATH,
+)
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help=ch.HELP_TRACE_OUTPUT,
+)
+@click.option("--workload", default=None, help=ch.HELP_TRACE_WORKLOAD)
+def convert_cmd(
+    profile_file: Path,
+    repo_path: Path,
+    output: Path | None,
+    workload: str | None,
+) -> None:
+    from .. import constants as cs
+    from .cpuprofile import convert_cpuprofile
+    from .records import TraceFormatError
+
+    resolved_output = output or Path(cs.TRACE_DEFAULT_OUTPUT)
+    try:
+        count = convert_cpuprofile(
+            profile_file,
+            repo_root=repo_path,
+            output=resolved_output,
+            workload=workload,
+        )
+    except TraceFormatError as e:
+        logger.error(str(e))
+        click.secho(str(e), fg="red", err=True)
+        sys.exit(1)
+    click.echo(f"call records written: {count} -> {resolved_output}")

--- a/codebase_rag/trace/cpuprofile.py
+++ b/codebase_rag/trace/cpuprofile.py
@@ -17,7 +17,9 @@ scheduled it.
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
@@ -31,7 +33,7 @@ from .records import (
 )
 
 if TYPE_CHECKING:
-    from pathlib import Path
+    pass
 
 
 @dataclass(frozen=True, slots=True)
@@ -41,16 +43,61 @@ class _ProfileFrame:
     line: int
 
 
+def _aggregate_project_edges(
+    frames: dict[int, _ProfileFrame | None],
+    children: dict[int, list[int]],
+    subtree: dict[int, int],
+    roots: list[int],
+) -> dict[tuple[_ProfileFrame, _ProfileFrame], int]:
+    """Weighted caller/callee pairs between project frames.
+
+    Walks the forest keeping each node's nearest project ancestor, so
+    runtime-internal frames between two project frames are seen through;
+    each project node contributes its subtree's sample weight to the edge
+    from that ancestor.
+    """
+    edges: dict[tuple[_ProfileFrame, _ProfileFrame], int] = {}
+    stack: list[tuple[int, _ProfileFrame | None]] = [
+        (root, None) for root in roots
+    ]
+    while stack:
+        node_id, ancestor = stack.pop()
+        frame = frames[node_id]
+        if frame is not None:
+            if ancestor is not None:
+                key = (ancestor, frame)
+                edges[key] = edges.get(key, 0) + max(subtree[node_id], 1)
+            ancestor = frame
+        stack.extend((child, ancestor) for child in children[node_id])
+    return edges
+
+
+_DRIVE_LETTER = re.compile(r"^/[A-Za-z]:/")
+
+
+def _url_to_path(url: str) -> str:
+    """A ``file://`` URL as a native filesystem path.
+
+    Windows URLs carry the drive letter after the root slash
+    (``file:///C:/repo``); stripping that slash and normalising separators
+    keeps project frames matchable against the repo prefix on any platform.
+    """
+    path = urlparse(url).path
+    if _DRIVE_LETTER.match(path):
+        path = path[1:]
+    return str(Path(path))
+
+
 def _project_frame(
     call_frame: dict[str, object], root_prefix: str
 ) -> _ProfileFrame | None:
     url = call_frame.get("url")
     if not isinstance(url, str) or not url.startswith(cs.TRACE_JS_FILE_URL_PREFIX):
         return None
-    path = urlparse(url).path
+    path = _url_to_path(url)
     if not path.startswith(root_prefix):
         return None
-    if not cs.TRACE_EXCLUDED_DIR_NAMES.isdisjoint(path.split("/")):
+    if not cs.TRACE_EXCLUDED_DIR_NAMES.isdisjoint(Path(path).parts):
         return None
     line = call_frame.get("lineNumber")
     if not isinstance(line, int) or isinstance(line, bool) or line < 0:
@@ -92,33 +139,33 @@ def convert_cpuprofile(
         hit_count = node.get("hitCount", 0)
         hits[node_id] = hit_count if isinstance(hit_count, int) else 0
 
-    child_ids = {c for kids in children.values() for c in kids}
+    # A well-formed profile is a forest: every child id exists and has
+    # exactly one parent. Anything else (dangling ids, shared children,
+    # cycles) is a malformed profile, not a crash.
+    all_children = [c for kids in children.values() for c in kids]
+    child_ids = set(all_children)
+    if len(all_children) != len(child_ids) or not child_ids.issubset(frames):
+        raise TraceFormatError(cs.TRACE_ERR_BAD_CPUPROFILE.format(path=profile_path))
     roots = [node_id for node_id in frames if node_id not in child_ids]
 
-    # Total samples in each subtree, bottom-up over the (acyclic) tree.
+    # Total samples in each subtree: children first, then parents, without
+    # recursing (V8 stacks can be deeper than the interpreter allows).
+    order: list[int] = []
+    stack = list(roots)
+    while stack:
+        node_id = stack.pop()
+        order.append(node_id)
+        stack.extend(children[node_id])
+    if len(order) != len(frames):
+        # Nodes unreachable from any root can only mean a cycle.
+        raise TraceFormatError(cs.TRACE_ERR_BAD_CPUPROFILE.format(path=profile_path))
     subtree: dict[int, int] = {}
+    for node_id in reversed(order):
+        subtree[node_id] = hits[node_id] + sum(
+            subtree[c] for c in children[node_id]
+        )
 
-    def _subtree(node_id: int) -> int:
-        cached = subtree.get(node_id)
-        if cached is None:
-            cached = hits[node_id] + sum(_subtree(c) for c in children[node_id])
-            subtree[node_id] = cached
-        return cached
-
-    edges: dict[tuple[_ProfileFrame, _ProfileFrame], int] = {}
-
-    def _walk(node_id: int, ancestor: _ProfileFrame | None) -> None:
-        frame = frames[node_id]
-        if frame is not None:
-            if ancestor is not None:
-                key = (ancestor, frame)
-                edges[key] = edges.get(key, 0) + max(_subtree(node_id), 1)
-            ancestor = frame
-        for child in children[node_id]:
-            _walk(child, ancestor)
-
-    for root in roots:
-        _walk(root, None)
+    edges = _aggregate_project_edges(frames, children, subtree, roots)
 
     workloads = (workload,) if workload else ()
     records = [

--- a/codebase_rag/trace/cpuprofile.py
+++ b/codebase_rag/trace/cpuprofile.py
@@ -83,7 +83,9 @@ def _url_to_path(url: str) -> str:
     path = urlparse(url).path
     if _DRIVE_LETTER.match(path):
         path = path[1:]
-    return str(Path(path))
+    # Normalise to POSIX separators so a Windows drive path (`C:\repo\main.js`)
+    # matches the POSIX `root_prefix`; the graph stores POSIX paths too.
+    return Path(path).as_posix()
 
 
 def _project_frame(
@@ -115,7 +117,12 @@ def convert_cpuprofile(
     workload: str | None = None,
 ) -> int:
     """Write ``profile_path``'s project call edges to ``output``; returns count."""
-    raw = json.loads(profile_path.read_text(encoding="utf-8"))
+    try:
+        raw = json.loads(profile_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        raise TraceFormatError(
+            cs.TRACE_ERR_BAD_CPUPROFILE.format(path=profile_path)
+        ) from e
     nodes = raw.get("nodes") if isinstance(raw, dict) else None
     if not isinstance(nodes, list) or not nodes:
         raise TraceFormatError(cs.TRACE_ERR_BAD_CPUPROFILE.format(path=profile_path))
@@ -125,14 +132,24 @@ def convert_cpuprofile(
     children: dict[int, list[int]] = {}
     hits: dict[int, int] = {}
     for node in nodes:
+        if not isinstance(node, dict):
+            raise TraceFormatError(
+                cs.TRACE_ERR_BAD_CPUPROFILE.format(path=profile_path)
+            )
         node_id = node.get("id")
         call_frame = node.get("callFrame")
-        if not isinstance(node_id, int) or not isinstance(call_frame, dict):
+        raw_children = node.get("children", [])
+        if (
+            not isinstance(node_id, int)
+            or isinstance(node_id, bool)
+            or node_id in children
+            or not isinstance(call_frame, dict)
+            or not isinstance(raw_children, list)
+        ):
             raise TraceFormatError(
                 cs.TRACE_ERR_BAD_CPUPROFILE.format(path=profile_path)
             )
         frames[node_id] = _project_frame(call_frame, root_prefix)
-        raw_children = node.get("children", [])
         children[node_id] = [c for c in raw_children if isinstance(c, int)]
         hit_count = node.get("hitCount", 0)
         hits[node_id] = hit_count if isinstance(hit_count, int) else 0

--- a/codebase_rag/trace/cpuprofile.py
+++ b/codebase_rag/trace/cpuprofile.py
@@ -57,9 +57,7 @@ def _aggregate_project_edges(
     from that ancestor.
     """
     edges: dict[tuple[_ProfileFrame, _ProfileFrame], int] = {}
-    stack: list[tuple[int, _ProfileFrame | None]] = [
-        (root, None) for root in roots
-    ]
+    stack: list[tuple[int, _ProfileFrame | None]] = [(root, None) for root in roots]
     while stack:
         node_id, ancestor = stack.pop()
         frame = frames[node_id]
@@ -161,9 +159,7 @@ def convert_cpuprofile(
         raise TraceFormatError(cs.TRACE_ERR_BAD_CPUPROFILE.format(path=profile_path))
     subtree: dict[int, int] = {}
     for node_id in reversed(order):
-        subtree[node_id] = hits[node_id] + sum(
-            subtree[c] for c in children[node_id]
-        )
+        subtree[node_id] = hits[node_id] + sum(subtree[c] for c in children[node_id])
 
     edges = _aggregate_project_edges(frames, children, subtree, roots)
 

--- a/codebase_rag/trace/cpuprofile.py
+++ b/codebase_rag/trace/cpuprofile.py
@@ -1,0 +1,145 @@
+"""Convert V8 CPU profiles (``node --cpu-prof``) to the trace interchange format.
+
+A ``.cpuprofile`` encodes every observed call stack as a tree: each node is a
+function frame, each parent/child link a caller/callee relationship the
+sampler actually saw. That makes the tree a genuine (if sampled) dynamic call
+graph: edges through registries, event emitters, and dynamic ``import()`` are
+present whenever a sample landed inside them. Counts are sample counts, not
+call counts; they order edges by weight but do not enumerate invocations.
+
+Runtime-internal frames (``node:``), files outside the repository, and
+excluded directories such as ``node_modules`` are not project code; edges see
+through them to the nearest project ancestor, mirroring the JVM agent's stack
+walk, so ``list.forEach(callback)`` attributes the callback to the code that
+scheduled it.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+from .. import constants as cs
+from .records import (
+    CallRecord,
+    FramePoint,
+    TraceFormatError,
+    TraceHeader,
+    write_trace_file,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class _ProfileFrame:
+    path: str
+    qualname: str
+    line: int
+
+
+def _project_frame(
+    call_frame: dict[str, object], root_prefix: str
+) -> _ProfileFrame | None:
+    url = call_frame.get("url")
+    if not isinstance(url, str) or not url.startswith(cs.TRACE_JS_FILE_URL_PREFIX):
+        return None
+    path = urlparse(url).path
+    if not path.startswith(root_prefix):
+        return None
+    if not cs.TRACE_EXCLUDED_DIR_NAMES.isdisjoint(path.split("/")):
+        return None
+    line = call_frame.get("lineNumber")
+    if not isinstance(line, int) or isinstance(line, bool) or line < 0:
+        return None
+    name = call_frame.get("functionName")
+    if not isinstance(name, str) or not name:
+        # V8 reports module toplevels as a nameless frame at line 0; other
+        # nameless frames are anonymous functions, resolvable only by span.
+        name = cs.TRACE_QUALNAME_MODULE if line == 0 else cs.TRACE_QUALNAME_ANONYMOUS
+    return _ProfileFrame(path=path, qualname=name, line=line + 1)
+
+
+def convert_cpuprofile(
+    profile_path: Path,
+    repo_root: Path,
+    output: Path,
+    workload: str | None = None,
+) -> int:
+    """Write ``profile_path``'s project call edges to ``output``; returns count."""
+    raw = json.loads(profile_path.read_text(encoding="utf-8"))
+    nodes = raw.get("nodes") if isinstance(raw, dict) else None
+    if not isinstance(nodes, list) or not nodes:
+        raise TraceFormatError(cs.TRACE_ERR_BAD_CPUPROFILE.format(path=profile_path))
+
+    root_prefix = repo_root.resolve().as_posix() + "/"
+    frames: dict[int, _ProfileFrame | None] = {}
+    children: dict[int, list[int]] = {}
+    hits: dict[int, int] = {}
+    for node in nodes:
+        node_id = node.get("id")
+        call_frame = node.get("callFrame")
+        if not isinstance(node_id, int) or not isinstance(call_frame, dict):
+            raise TraceFormatError(
+                cs.TRACE_ERR_BAD_CPUPROFILE.format(path=profile_path)
+            )
+        frames[node_id] = _project_frame(call_frame, root_prefix)
+        raw_children = node.get("children", [])
+        children[node_id] = [c for c in raw_children if isinstance(c, int)]
+        hit_count = node.get("hitCount", 0)
+        hits[node_id] = hit_count if isinstance(hit_count, int) else 0
+
+    child_ids = {c for kids in children.values() for c in kids}
+    roots = [node_id for node_id in frames if node_id not in child_ids]
+
+    # Total samples in each subtree, bottom-up over the (acyclic) tree.
+    subtree: dict[int, int] = {}
+
+    def _subtree(node_id: int) -> int:
+        cached = subtree.get(node_id)
+        if cached is None:
+            cached = hits[node_id] + sum(_subtree(c) for c in children[node_id])
+            subtree[node_id] = cached
+        return cached
+
+    edges: dict[tuple[_ProfileFrame, _ProfileFrame], int] = {}
+
+    def _walk(node_id: int, ancestor: _ProfileFrame | None) -> None:
+        frame = frames[node_id]
+        if frame is not None:
+            if ancestor is not None:
+                key = (ancestor, frame)
+                edges[key] = edges.get(key, 0) + max(_subtree(node_id), 1)
+            ancestor = frame
+        for child in children[node_id]:
+            _walk(child, ancestor)
+
+    for root in roots:
+        _walk(root, None)
+
+    workloads = (workload,) if workload else ()
+    records = [
+        CallRecord(
+            caller=FramePoint(
+                path=caller.path, qualname=caller.qualname, line=caller.line
+            ),
+            callee=FramePoint(
+                path=callee.path, qualname=callee.qualname, line=callee.line
+            ),
+            count=count,
+            workloads=workloads,
+            receiver_types=(),
+        )
+        for (caller, callee), count in edges.items()
+    ]
+    header = TraceHeader(
+        version=cs.TRACE_FORMAT_VERSION,
+        language=cs.TRACE_LANGUAGE_JS,
+        repo_root=str(repo_root),
+        tracer=cs.TRACE_TOOL_NAME_CPUPROFILE,
+    )
+    write_trace_file(output, header, records)
+    return len(records)

--- a/codebase_rag/trace/cpuprofile.py
+++ b/codebase_rag/trace/cpuprofile.py
@@ -21,7 +21,7 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 from .. import constants as cs
 from .records import (
@@ -80,7 +80,9 @@ def _url_to_path(url: str) -> str:
     (``file:///C:/repo``); stripping that slash and normalising separators
     keeps project frames matchable against the repo prefix on any platform.
     """
-    path = urlparse(url).path
+    # V8 URLs (and Path.as_uri) percent-encode spaces and other characters;
+    # decode so the path matches the real repo prefix.
+    path = unquote(urlparse(url).path)
     if _DRIVE_LETTER.match(path):
         path = path[1:]
     # Normalise to POSIX separators so a Windows drive path (`C:\repo\main.js`)
@@ -145,12 +147,15 @@ def convert_cpuprofile(
             or node_id in children
             or not isinstance(call_frame, dict)
             or not isinstance(raw_children, list)
+            or not all(
+                isinstance(c, int) and not isinstance(c, bool) for c in raw_children
+            )
         ):
             raise TraceFormatError(
                 cs.TRACE_ERR_BAD_CPUPROFILE.format(path=profile_path)
             )
         frames[node_id] = _project_frame(call_frame, root_prefix)
-        children[node_id] = [c for c in raw_children if isinstance(c, int)]
+        children[node_id] = list(raw_children)
         hit_count = node.get("hitCount", 0)
         hits[node_id] = hit_count if isinstance(hit_count, int) else 0
 

--- a/codebase_rag/trace/ingest.py
+++ b/codebase_rag/trace/ingest.py
@@ -23,6 +23,7 @@ from .records import read_trace_file
 from .resolution import (
     CallableNode,
     FrameResolver,
+    JsFrameResolver,
     JvmFrameResolver,
     ResolutionStats,
 )
@@ -46,6 +47,8 @@ def _resolver_for(
 ) -> FrameResolverProtocol:
     if header.language == cs.TRACE_LANGUAGE_JVM:
         return JvmFrameResolver(nodes)
+    if header.language == cs.TRACE_LANGUAGE_JS:
+        return JsFrameResolver(repo_root, nodes)
     return FrameResolver(repo_root, nodes)
 
 

--- a/codebase_rag/trace/resolution.py
+++ b/codebase_rag/trace/resolution.py
@@ -155,6 +155,72 @@ def _signatureless(qualified_name: str) -> str:
     return head if sep else qualified_name
 
 
+class JsFrameResolver:
+    """Maps V8 profile frames of one project to graph nodes.
+
+    V8 reports bare function names, never dotted scope chains, so the
+    suffix-matching the Python resolver uses cannot work. Resolution anchors
+    on the repo-relative path, narrows to nodes whose final qualified-name
+    part equals the frame's name, and picks the innermost span containing
+    the declaration line (the converter already made V8's 0-based lines
+    1-based, aligning them with node start lines). Anonymous frames resolve
+    by span alone; module toplevels map to the file's Module node.
+    """
+
+    def __init__(self, repo_root: Path, nodes: list[CallableNode]) -> None:
+        self._repo_root = repo_root.resolve()
+        self._root_prefix = str(self._repo_root) + os.sep
+        self._callables_by_path: dict[str, list[CallableNode]] = {}
+        self._modules_by_path: dict[str, CallableNode] = {}
+        for node in nodes:
+            if node.label == cs.NodeLabel.MODULE:
+                self._modules_by_path[node.path] = node
+            else:
+                self._callables_by_path.setdefault(node.path, []).append(node)
+
+    def resolve(
+        self, frame: FramePoint, stats: ResolutionStats
+    ) -> ResolvedFrame | None:
+        if not frame.path.startswith(self._root_prefix):
+            stats.record(cs.TraceUnresolvedReason.OUTSIDE_REPO)
+            return None
+        rel_path = Path(frame.path).relative_to(self._repo_root).as_posix()
+
+        if frame.qualname == cs.TRACE_QUALNAME_MODULE:
+            module = self._modules_by_path.get(rel_path)
+            if module is None:
+                stats.record(cs.TraceUnresolvedReason.UNKNOWN_PATH)
+                return None
+            return ResolvedFrame(
+                label=module.label, qualified_name=module.qualified_name
+            )
+
+        candidates = self._callables_by_path.get(rel_path)
+        if not candidates:
+            stats.record(cs.TraceUnresolvedReason.UNKNOWN_PATH)
+            return None
+
+        by_name: list[CallableNode] = []
+        if not frame.qualname.startswith(cs.TRACE_SYNTHETIC_PREFIX):
+            by_name = [
+                n
+                for n in candidates
+                if _natural_qualified_name(n.qualified_name).rsplit(
+                    cs.SEPARATOR_DOT, 1
+                )[-1]
+                == frame.qualname
+            ]
+        chosen = (
+            _innermost_span_containing_line(by_name, frame.line)
+            or (min(by_name, key=lambda n: n.qualified_name) if by_name else None)
+            or _innermost_span_containing_line(candidates, frame.line)
+        )
+        if chosen is None:
+            stats.record(cs.TraceUnresolvedReason.NO_MATCH)
+            return None
+        return ResolvedFrame(label=chosen.label, qualified_name=chosen.qualified_name)
+
+
 class JvmFrameResolver:
     """Maps JVM runtime frames of one project to graph nodes.
 

--- a/docs/guide/dynamic-tracing.md
+++ b/docs/guide/dynamic-tracing.md
@@ -7,9 +7,11 @@ which functions actually called which, and merges those observations into the
 graph alongside the statically derived `CALLS` edges.
 
 Currently supported for **Python** codebases (Python 3.12+ at runtime, via
-`sys.monitoring`) and **Java/Scala** codebases (via a zero-dependency
-`java.lang.instrument` agent, JDK 24+). Other language runtimes are tracked
-in [issue #1244](https://github.com/vitali87/code-graph-rag/issues/1244).
+`sys.monitoring`), **Java/Scala** codebases (via a zero-dependency
+`java.lang.instrument` agent, JDK 24+), and **JavaScript/TypeScript** codebases
+(by converting a V8 `--cpu-prof` profile with `cgr trace convert`). Other
+language runtimes are tracked in
+[issue #1244](https://github.com/vitali87/code-graph-rag/issues/1244).
 
 ## Recording a trace
 

--- a/docs/guide/dynamic-tracing.md
+++ b/docs/guide/dynamic-tracing.md
@@ -81,6 +81,34 @@ static analysis cannot see. Concrete receiver classes are sampled on
 virtual and interface calls, so the graph records which implementation
 actually handled a dispatch.
 
+## Recording a Node.js trace (JavaScript, TypeScript)
+
+No agent is needed: V8's built-in sampling profiler already records observed
+call stacks, and Node ships it behind one flag. Run any workload (a test
+run, a server under load, a script) with profiling on, then convert the
+profile:
+
+```bash
+node --cpu-prof --cpu-prof-name=run.cpuprofile app.js
+cgr trace convert run.cpuprofile --repo-path /path/to/your-repo --workload smoke
+cgr trace ingest cgr-trace.jsonl --repo-path /path/to/your-repo
+```
+
+Parent/child links in the profile are caller/callee relationships the
+sampler actually observed, so dispatch through registries, event emitters,
+and dynamic `import()` shows up whenever samples landed there. Two caveats
+distinguish this from the instrumented Python and JVM tracers:
+
+- **Sampling.** Short-lived calls can be missed entirely, and
+  `dynamic_call_count` holds sample counts (relative weight), not call
+  counts. Lower `--cpu-prof-interval` (microseconds, default 1000) to
+  tighten coverage at the cost of larger profiles.
+- **Transpiled output.** Frames point at the JavaScript that executed. If
+  you index `.ts` sources but run transpiled output from `dist/`, those
+  frames count as `unresolved[unknown_path]`; source-map translation is a
+  planned follow-up. Running TS directly (via a runner that keeps file
+  paths) or indexing the built tree avoids the gap today.
+
 ## Ingesting a trace
 
 Parse the repository into the graph first (`cgr start --repo-path ... --update-graph`),


### PR DESCRIPTION
Part of #1244, first increment of #1247. **Stacked on #1260** (base branch is `feat/1248-jvm-dynamic-tracing`); only the last two commits are new.

## What

Dynamic call-graph capture for Node.js codebases with zero dependencies and zero agent code: V8's built-in sampling profiler already records observed call stacks, so capture is just `node --cpu-prof`, and this PR adds the two missing pieces:

- **`cgr trace convert`**: turns a `.cpuprofile` into the shared trace interchange format from #1245. Parent/child links in the profile tree are caller/callee relationships the sampler actually observed; the converter keeps only project frames (repo-scoped, `node_modules` excluded), sees through `node:` runtime internals to the nearest project ancestor (mirroring the JVM agent's stack walk), converts V8's 0-based lines to 1-based, maps nameless toplevel frames to `<module>` and nameless functions to `<anonymous>`, and records subtree sample counts as edge weights.
- **`JsFrameResolver`**: V8 reports bare function names, never dotted scope chains, so the Python resolver's suffix matching cannot work. Resolution anchors on the repo-relative path, narrows to nodes whose final qualified-name part equals the frame name, and picks the innermost span containing the declaration line; anonymous frames resolve by span alone, module toplevels map to Module nodes, and `@line` duplicate markers are handled. `ingest_trace` dispatches on the trace header's `language`.

## Mechanism choice (from the issue's list)

`Profiler.startPreciseCoverage` gives executed functions but no edges; loader-hook instrumentation needs a bundled JS parser (a real dependency) and misses intra-module calls. Sampling gives true observed edges at zero dependency cost, so it lands first. Two documented caveats: counts are sample weights (not call counts), and short-lived calls can be missed (tune `--cpu-prof-interval`). Source-map translation for transpiled `dist/` output (the TS acceptance criterion) is the planned second increment; the docs state today's limitation plainly.

## Verification

Live end-to-end against Memgraph: sample JS project (Map-based handler registry) indexed, run under `node --cpu-prof`, converted, ingested:

- The registry dispatch `handle -> greet` (invisible to static analysis) lands as a runtime-only edge with `static_missed: true`
- `module -> runAll -> handle` chain confirmed static with sample weights and the workload label on every edge
- 0 unresolved frames

13 new unit tests (converter shape, see-through, exclusion, line conversion, workloads, malformed profiles; resolver name/span/anonymous/duplicate-marker cases; CLI convert command), all red/green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `cgr trace convert` for converting Node.js V8 CPU profiles into trace records.
  * Added JavaScript and TypeScript tracing with frame resolution, call relationships, sample counts, and optional workload metadata.
  * Added validation and clear error reporting for malformed or unsupported profiles.
* **Documentation**
  * Added guidance for generating, converting, and ingesting Node.js CPU profiles, including sampling behavior, profiler tuning, and limitations when resolving transpiled frames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->