### PR TITLE
feat: add .NET runtime call tracing via dotnet-trace speedscope conversion

### DIFF
--- a/codebase_rag/cli_help.py
+++ b/codebase_rag/cli_help.py
@@ -115,6 +115,14 @@ EXAMPLES_TRACE_INGEST = (
 )
 HELP_TRACE_OUTPUT = "Where to write the converted trace file."
 HELP_TRACE_WORKLOAD = "Workload label to attach to every converted record."
+HELP_TRACE_INCLUDE = (
+    "Comma-separated namespace prefixes to keep (dotnet-trace speedscope "
+    "profiles carry no file paths, so scoping is by name)."
+)
+ERR_TRACE_CONVERT_NEEDS_REPO = "V8 cpuprofiles need --repo-path to scope frames."
+ERR_TRACE_CONVERT_NEEDS_INCLUDE = (
+    "speedscope profiles need --include namespace prefixes to scope frames."
+)
 EXAMPLES_TRACE_CONVERT = (
     "EXAMPLE\n\n  node --cpu-prof --cpu-prof-name=run.cpuprofile app.js\n\n"
     "  cgr trace convert run.cpuprofile --repo-path ./my-repo\n\n"

--- a/codebase_rag/constants/trace.py
+++ b/codebase_rag/constants/trace.py
@@ -24,9 +24,11 @@ TRACE_KEY_RECEIVER_TYPES = "receiver_types"
 TRACE_LANGUAGE_PYTHON = "python"
 TRACE_LANGUAGE_JVM = "jvm"
 TRACE_LANGUAGE_JS = "javascript"
+TRACE_LANGUAGE_DOTNET = "dotnet"
 TRACE_TOOL_NAME = "cgr-trace"
 TRACE_TOOL_NAME_JVM = "cgr-trace-jvm"
 TRACE_TOOL_NAME_CPUPROFILE = "cgr-trace-cpuprofile"
+TRACE_TOOL_NAME_SPEEDSCOPE = "cgr-trace-speedscope"
 TRACE_DEFAULT_OUTPUT = "cgr-trace.jsonl"
 
 # Python runtime qualname markers.
@@ -39,6 +41,15 @@ TRACE_QUALNAME_ANONYMOUS = "<anonymous>"
 TRACE_JS_FILE_URL_PREFIX = "file://"
 
 TRACE_ERR_BAD_CPUPROFILE = "{path} is not a V8 .cpuprofile (missing node tree)."
+
+# dotnet-trace speedscope markers.
+TRACE_ERR_BAD_SPEEDSCOPE = (
+    "{path} is not a speedscope profile (missing frames or sampled profiles)."
+)
+TRACE_DOTNET_ASSEMBLY_SEPARATOR = "!"
+TRACE_DOTNET_CTOR = "..ctor"
+TRACE_DOTNET_CCTOR = "..cctor"
+TRACE_DOTNET_NESTED_MARKER = "+"
 
 # JVM runtime name markers.
 TRACE_JVM_CONSTRUCTOR = "<init>"

--- a/codebase_rag/tests/test_dynamic_trace_cli.py
+++ b/codebase_rag/tests/test_dynamic_trace_cli.py
@@ -154,6 +154,68 @@ def test_convert_command_fails_cleanly_on_malformed_profile(tmp_path):
     assert "cpuprofile" in result.output.lower()
 
 
+def test_convert_command_sniffs_speedscope_and_requires_include(tmp_path):
+    import json as jsonlib
+
+    speedscope = {
+        "shared": {
+            "frames": [
+                {"name": "MyApp!MyApp.Program.Main()"},
+                {"name": "MyApp!MyApp.Registry.Handle()"},
+            ]
+        },
+        "profiles": [
+            {
+                "type": "sampled",
+                "samples": [[0, 1]],
+                "weights": [3],
+            }
+        ],
+    }
+    profile_path = tmp_path / "trace.speedscope.json"
+    profile_path.write_text(jsonlib.dumps(speedscope))
+    output = tmp_path / "trace.jsonl"
+
+    missing_include = CliRunner().invoke(
+        cli, ["convert", str(profile_path), "--output", str(output)]
+    )
+    assert missing_include.exit_code == 1
+    assert "--include" in missing_include.output
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "convert",
+            str(profile_path),
+            "--include",
+            "MyApp",
+            "--output",
+            str(output),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    header, records = read_trace_file(output)
+    assert header.language == cs.TRACE_LANGUAGE_DOTNET
+    (record,) = list(records)
+    assert (record.caller.qualname, record.callee.qualname) == (
+        "MyApp.Program.Main",
+        "MyApp.Registry.Handle",
+    )
+
+
+def test_convert_command_requires_repo_path_for_cpuprofiles(tmp_path):
+    import json as jsonlib
+
+    profile_path = tmp_path / "main.cpuprofile"
+    profile_path.write_text(jsonlib.dumps({"nodes": [], "samples": []}))
+
+    result = CliRunner().invoke(cli, ["convert", str(profile_path)])
+
+    assert result.exit_code == 1
+    assert "--repo-path" in result.output
+
+
 def test_ingest_command_fails_cleanly_on_malformed_trace(tmp_path, monkeypatch):
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/codebase_rag/tests/test_dynamic_trace_cli.py
+++ b/codebase_rag/tests/test_dynamic_trace_cli.py
@@ -182,6 +182,15 @@ def test_convert_command_sniffs_speedscope_and_requires_include(tmp_path):
     assert missing_include.exit_code == 1
     assert "--include" in missing_include.output
 
+    # An include that normalises to nothing (commas/whitespace only) is
+    # rejected rather than silently producing an empty trace.
+    empty_include = CliRunner().invoke(
+        cli,
+        ["convert", str(profile_path), "--include", " , ", "--output", str(output)],
+    )
+    assert empty_include.exit_code == 1
+    assert "--include" in empty_include.output
+
     result = CliRunner().invoke(
         cli,
         [

--- a/codebase_rag/tests/test_dynamic_trace_ingest.py
+++ b/codebase_rag/tests/test_dynamic_trace_ingest.py
@@ -313,6 +313,61 @@ def test_ingest_dispatches_jvm_traces_to_jvm_resolution(tmp_path):
     assert props[cs.TRACE_PROP_CALL_COUNT] == 3
 
 
+def test_ingest_dispatches_dotnet_traces_to_name_resolution(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    trace_path = tmp_path / "trace.jsonl"
+    graph = _FakeGraph(
+        [
+            _callable_row(
+                cs.NodeLabel.METHOD,
+                f"{_PROJECT}.Worker.MyApp.Worker.RunAsync",
+                "Worker.cs",
+                3,
+                20,
+            ),
+            _callable_row(
+                cs.NodeLabel.METHOD,
+                f"{_PROJECT}.Worker.MyApp.Worker.Step",
+                "Worker.cs",
+                22,
+                30,
+            ),
+        ],
+        [],
+    )
+    header = TraceHeader(
+        version=cs.TRACE_FORMAT_VERSION,
+        language=cs.TRACE_LANGUAGE_DOTNET,
+        repo_root="",
+        tracer=cs.TRACE_TOOL_NAME_SPEEDSCOPE,
+    )
+    # .NET frames have no paths or lines; only CLR-name demangling can join.
+    write_trace_file(
+        trace_path,
+        header,
+        [
+            CallRecord(
+                caller=FramePoint(
+                    path="", qualname="MyApp.Worker+<RunAsync>d__3.MoveNext", line=0
+                ),
+                callee=FramePoint(path="", qualname="MyApp.Worker.Step", line=0),
+                count=4,
+                workloads=("dotnet-test",),
+                receiver_types=(),
+            )
+        ],
+    )
+
+    summary = ingest_trace(trace_path, graph, repo, _PROJECT)
+
+    assert summary.edges == 1
+    assert summary.unresolved == 0
+    ((frm, _rel, to, _props),) = graph.edges
+    assert frm[2].endswith("MyApp.Worker.RunAsync")
+    assert to[2].endswith("MyApp.Worker.Step")
+
+
 def test_ingest_counts_unresolved_frames(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/codebase_rag/tests/test_dynamic_trace_resolution_dotnet.py
+++ b/codebase_rag/tests/test_dynamic_trace_resolution_dotnet.py
@@ -134,3 +134,15 @@ def test_static_initializer_and_unknown_are_categorised():
         cs.TraceUnresolvedReason.SYNTHETIC.value: 1,
         cs.TraceUnresolvedReason.NO_MATCH.value: 1,
     }
+
+
+def test_resolves_generic_arity_names_to_source_nodes():
+    # dotnet-trace keeps CLR arity markers (`Cache`1`, `Get`1`); the graph
+    # stores the source spelling, so they must be stripped before matching.
+    nodes = [_node(cs.NodeLabel.METHOD, f"{_P}.Cache.MyApp.Cache.Get(string)")]
+    resolver = DotnetFrameResolver(nodes)
+
+    resolved = resolver.resolve(_frame("MyApp.Cache`1.Get`1"), ResolutionStats())
+
+    assert resolved is not None
+    assert resolved.qualified_name.endswith("MyApp.Cache.Get(string)")

--- a/codebase_rag/tests/test_dynamic_trace_resolution_dotnet.py
+++ b/codebase_rag/tests/test_dynamic_trace_resolution_dotnet.py
@@ -1,0 +1,136 @@
+# .NET sampled frames carry CLR names with no file paths: nested classes use
+# `+`, constructors are `.ctor`, properties are `get_`/`set_` accessors, and
+# async methods surface as compiler state machines. The resolver must
+# demangle these onto the graph's namespace-bearing qualified names
+# (issue #1249).
+
+from __future__ import annotations
+
+from codebase_rag import constants as cs
+from codebase_rag.trace.records import FramePoint
+from codebase_rag.trace.resolution import (
+    CallableNode,
+    DotnetFrameResolver,
+    ResolutionStats,
+)
+
+_P = "proj"
+
+
+def _node(label, qualified_name, path="Services/GreetingService.cs"):
+    return CallableNode(
+        label=label,
+        qualified_name=qualified_name,
+        path=path,
+        start_line=1,
+        end_line=50,
+    )
+
+
+_NODES = [
+    _node(
+        cs.NodeLabel.METHOD,
+        f"{_P}.Services.GreetingService.MyApp.Services.GreetingService.Greet(string)",
+    ),
+    # Zero-arg methods carry no parentheses in the graph.
+    _node(
+        cs.NodeLabel.METHOD,
+        f"{_P}.Services.GreetingService.MyApp.Services.GreetingService.Reset",
+    ),
+    _node(
+        cs.NodeLabel.METHOD,
+        f"{_P}.Worker.MyApp.Worker.RunAsync",
+        path="Worker.cs",
+    ),
+    _node(
+        cs.NodeLabel.METHOD,
+        f"{_P}.Worker.MyApp.Worker.Worker(string)",
+        path="Worker.cs",
+    ),
+    # A property is one Method node, no accessor prefix.
+    _node(
+        cs.NodeLabel.METHOD,
+        f"{_P}.Worker.MyApp.Worker.Size",
+        path="Worker.cs",
+    ),
+    _node(
+        cs.NodeLabel.METHOD,
+        f"{_P}.Box.MyApp.Outer.Inner.M",
+        path="Box.cs",
+    ),
+]
+
+
+def _resolver():
+    return DotnetFrameResolver(_NODES)
+
+
+def _frame(qualname):
+    return FramePoint(path="", qualname=qualname, line=0)
+
+
+def _resolve(qualname, stats=None):
+    return _resolver().resolve(_frame(qualname), stats or ResolutionStats())
+
+
+def test_resolves_plain_method_with_and_without_signature():
+    signatured = _resolve("MyApp.Services.GreetingService.Greet")
+    bare = _resolve("MyApp.Services.GreetingService.Reset")
+
+    assert signatured is not None
+    assert signatured.qualified_name.endswith("Greet(string)")
+    assert bare is not None
+    assert bare.qualified_name.endswith("GreetingService.Reset")
+
+
+def test_resolves_async_state_machine_to_source_method():
+    resolved = _resolve("MyApp.Worker+<RunAsync>d__3.MoveNext")
+
+    assert resolved is not None
+    assert resolved.qualified_name.endswith("MyApp.Worker.RunAsync")
+
+
+def test_resolves_constructor_to_class_named_node():
+    resolved = _resolve("MyApp.Worker..ctor")
+
+    assert resolved is not None
+    assert resolved.qualified_name.endswith("MyApp.Worker.Worker(string)")
+
+
+def test_resolves_property_accessors_to_property_node():
+    getter = _resolve("MyApp.Worker.get_Size")
+    setter = _resolve("MyApp.Worker.set_Size")
+
+    assert getter is not None
+    assert getter.qualified_name.endswith("MyApp.Worker.Size")
+    assert setter is not None
+    assert setter.qualified_name.endswith("MyApp.Worker.Size")
+
+
+def test_resolves_display_class_lambda_to_enclosing_method():
+    resolved = _resolve("MyApp.Worker+<>c.<RunAsync>b__2_0")
+
+    assert resolved is not None
+    assert resolved.qualified_name.endswith("MyApp.Worker.RunAsync")
+
+
+def test_resolves_nested_class_plus_to_dots():
+    resolved = _resolve("MyApp.Outer+Inner.M")
+
+    assert resolved is not None
+    assert resolved.qualified_name.endswith("MyApp.Outer.Inner.M")
+
+
+def test_static_initializer_and_unknown_are_categorised():
+    stats = ResolutionStats()
+    resolver = _resolver()
+
+    cctor = resolver.resolve(_frame("MyApp.Worker..cctor"), stats)
+    unknown = resolver.resolve(_frame("MyApp.Gone.Missing"), stats)
+
+    assert cctor is None
+    assert unknown is None
+    assert stats.unresolved == {
+        cs.TraceUnresolvedReason.SYNTHETIC.value: 1,
+        cs.TraceUnresolvedReason.NO_MATCH.value: 1,
+    }

--- a/codebase_rag/tests/test_dynamic_trace_speedscope.py
+++ b/codebase_rag/tests/test_dynamic_trace_speedscope.py
@@ -205,6 +205,31 @@ def test_fractional_weights_accumulate_before_rounding(tmp_path):
             "shared": {"frames": [{"name": n} for n in _FRAMES]},
             "profiles": [{"type": "evented", "events": {"not": "a list"}}],
         },
+        # A sampled stack that is not a list.
+        {
+            "shared": {"frames": [{"name": n} for n in _FRAMES]},
+            "profiles": [{"type": "sampled", "samples": ["nope"], "weights": [1]}],
+        },
+        # A frame index outside the frame table.
+        {
+            "shared": {"frames": [{"name": n} for n in _FRAMES]},
+            "profiles": [{"type": "sampled", "samples": [[999]], "weights": [1]}],
+        },
+        # A non-object event entry.
+        {
+            "shared": {"frames": [{"name": n} for n in _FRAMES]},
+            "profiles": [{"type": "evented", "events": ["nope"]}],
+        },
+        # An unknown event type.
+        {
+            "shared": {"frames": [{"name": n} for n in _FRAMES]},
+            "profiles": [{"type": "evented", "events": [{"type": "X", "frame": 0}]}],
+        },
+        # A close event with nothing open (stack underflow).
+        {
+            "shared": {"frames": [{"name": n} for n in _FRAMES]},
+            "profiles": [{"type": "evented", "events": [{"type": "C"}]}],
+        },
     ],
 )
 def test_recognised_profiles_with_malformed_payloads_are_rejected(tmp_path, profile):

--- a/codebase_rag/tests/test_dynamic_trace_speedscope.py
+++ b/codebase_rag/tests/test_dynamic_trace_speedscope.py
@@ -177,3 +177,41 @@ def test_malformed_speedscope_is_rejected(tmp_path):
 
     with pytest.raises(ValueError):
         convert_speedscope(profile_path, output=tmp_path / "out.jsonl", include=("X",))
+
+
+def test_fractional_weights_accumulate_before_rounding(tmp_path):
+    # Speedscope permits fractional weights; truncating each sample would
+    # lose their combined contribution (0.5 + 2.0 must round to 3, not 2).
+    profile = _speedscope(
+        _FRAMES,
+        samples=[[0, 1, 3], [0, 1, 3]],
+        weights=[0.5, 2.0],
+    )
+
+    _count, _header, records = _convert(tmp_path, profile)
+
+    edges = {(r.caller.qualname, r.callee.qualname): r for r in records}
+    assert edges[("MyApp.Program.Main", "MyApp.Services.Registry.Handle")].count == 3
+
+
+@pytest.mark.parametrize(
+    "profile",
+    [
+        {
+            "shared": {"frames": [{"name": n} for n in _FRAMES]},
+            "profiles": [{"type": "sampled", "samples": "nope", "weights": []}],
+        },
+        {
+            "shared": {"frames": [{"name": n} for n in _FRAMES]},
+            "profiles": [{"type": "evented", "events": {"not": "a list"}}],
+        },
+    ],
+)
+def test_recognised_profiles_with_malformed_payloads_are_rejected(tmp_path, profile):
+    profile_path = tmp_path / "trace.speedscope.json"
+    profile_path.write_text(json.dumps(profile))
+
+    with pytest.raises(ValueError):
+        convert_speedscope(
+            profile_path, output=tmp_path / "out.jsonl", include=("MyApp",)
+        )

--- a/codebase_rag/tests/test_dynamic_trace_speedscope.py
+++ b/codebase_rag/tests/test_dynamic_trace_speedscope.py
@@ -1,0 +1,179 @@
+# dotnet-trace exports sampled .NET stacks as speedscope JSON; the converter
+# must turn in-scope frame adjacencies into interchange call records, seeing
+# through runtime assemblies, stripping assembly prefixes and argument lists,
+# and weighting edges by sample weight (issue #1249).
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.trace.records import read_trace_file
+from codebase_rag.trace.speedscope import convert_speedscope
+
+
+def _speedscope(frames, samples, weights=None):
+    return {
+        "$schema": "https://www.speedscope.app/file-format-schema.json",
+        "shared": {"frames": [{"name": name} for name in frames]},
+        "profiles": [
+            {
+                "type": "sampled",
+                "name": "thread 1",
+                "unit": "milliseconds",
+                "startValue": 0,
+                "endValue": 100,
+                "samples": samples,
+                "weights": weights or [1] * len(samples),
+            }
+        ],
+    }
+
+
+_FRAMES = [
+    "Process64 Process(1) Args: ",  # synthetic root dotnet-trace emits
+    "MyApp!MyApp.Program.Main(class System.String[])",
+    "System.Private.CoreLib!System.Collections.Generic.Dictionary`2[...].get_Item(!0)",
+    "MyApp!MyApp.Services.Registry.Handle(class System.String)",
+    "MyApp!MyApp.Services.Registry.Greet()",
+    "Microsoft.Extensions.DependencyInjection!Microsoft.Extensions.Internal.Glue.Invoke()",
+    "MyApp!MyApp.Worker+<RunAsync>d__3.MoveNext()",
+]
+
+
+def _convert(tmp_path, profile, include=("MyApp",), workload=None):
+    profile_path = tmp_path / "trace.speedscope.json"
+    profile_path.write_text(json.dumps(profile))
+    output = tmp_path / "trace.jsonl"
+    count = convert_speedscope(
+        profile_path,
+        output=output,
+        include=include,
+        workload=workload,
+    )
+    header, records = read_trace_file(output)
+    return count, header, list(records)
+
+
+def test_converts_adjacent_project_frames_to_edges(tmp_path):
+    profile = _speedscope(
+        _FRAMES,
+        samples=[[0, 1, 3, 4], [0, 1, 3, 4], [0, 1, 3]],
+        weights=[2, 3, 1],
+    )
+
+    count, header, records = _convert(tmp_path, profile)
+
+    assert header.language == cs.TRACE_LANGUAGE_DOTNET
+    assert count == len(records)
+    edges = {(r.caller.qualname, r.callee.qualname): r for r in records}
+    assert ("MyApp.Services.Registry.Handle", "MyApp.Services.Registry.Greet") in edges
+    dispatch = edges[
+        ("MyApp.Services.Registry.Handle", "MyApp.Services.Registry.Greet")
+    ]
+    assert dispatch.count == 5
+    assert edges[("MyApp.Program.Main", "MyApp.Services.Registry.Handle")].count == 6
+
+
+def test_sees_through_runtime_assembly_frames(tmp_path):
+    # Main -> Dictionary.get_Item -> Handle: the BCL frame is glue.
+    profile = _speedscope(_FRAMES, samples=[[0, 1, 2, 3]])
+
+    _count, _header, records = _convert(tmp_path, profile)
+
+    edges = {(r.caller.qualname, r.callee.qualname) for r in records}
+    assert ("MyApp.Program.Main", "MyApp.Services.Registry.Handle") in edges
+    assert not any("Dictionary" in a or "Dictionary" in b for a, b in edges)
+
+
+def test_di_glue_between_project_frames_is_walked_through(tmp_path):
+    profile = _speedscope(_FRAMES, samples=[[0, 1, 5, 6]])
+
+    _count, _header, records = _convert(tmp_path, profile)
+
+    edges = {(r.caller.qualname, r.callee.qualname) for r in records}
+    assert ("MyApp.Program.Main", "MyApp.Worker+<RunAsync>d__3.MoveNext") in edges
+
+
+def test_frames_outside_include_prefixes_produce_no_edges(tmp_path):
+    profile = _speedscope(_FRAMES, samples=[[0, 2, 5]])
+
+    count, _header, records = _convert(tmp_path, profile)
+
+    assert count == 0
+    assert records == []
+
+
+def test_workload_label_lands_on_every_record(tmp_path):
+    profile = _speedscope(_FRAMES, samples=[[0, 1, 3]])
+
+    _count, _header, records = _convert(tmp_path, profile, workload="dotnet-test")
+
+    assert records
+    for record in records:
+        assert record.workloads == ("dotnet-test",)
+
+
+def test_recursive_frames_do_not_self_loop_per_sample(tmp_path):
+    # Handle appearing twice in one stack yields one Handle->Handle edge,
+    # not an edge per repetition.
+    profile = _speedscope(_FRAMES, samples=[[0, 1, 3, 3, 4]])
+
+    _count, _header, records = _convert(tmp_path, profile)
+
+    edges = {(r.caller.qualname, r.callee.qualname): r for r in records}
+    recursion = edges[
+        ("MyApp.Services.Registry.Handle", "MyApp.Services.Registry.Handle")
+    ]
+    assert recursion.count == 1
+
+
+def test_converts_evented_profiles_from_dotnet_trace(tmp_path):
+    # dotnet-trace convert emits evented profiles (frame open/close), not
+    # sampled ones; each in-scope activation under an in-scope ancestor is
+    # one observed call relationship.
+    profile = {
+        "shared": {"frames": [{"name": name} for name in _FRAMES]},
+        "profiles": [
+            {
+                "type": "evented",
+                "unit": "milliseconds",
+                "startValue": 0,
+                "endValue": 10,
+                "events": [
+                    {"type": "O", "frame": 1, "at": 0},
+                    {"type": "O", "frame": 2, "at": 1},
+                    {"type": "O", "frame": 3, "at": 2},
+                    {"type": "O", "frame": 4, "at": 3},
+                    {"type": "C", "frame": 4, "at": 4},
+                    {"type": "C", "frame": 3, "at": 5},
+                    {"type": "O", "frame": 3, "at": 6},
+                    {"type": "C", "frame": 3, "at": 7},
+                    {"type": "C", "frame": 2, "at": 8},
+                    {"type": "C", "frame": 1, "at": 9},
+                ],
+            }
+        ],
+    }
+
+    count, header, records = _convert(tmp_path, profile)
+
+    assert header.language == cs.TRACE_LANGUAGE_DOTNET
+    assert count == len(records)
+    edges = {(r.caller.qualname, r.callee.qualname): r for r in records}
+    # Main opened Handle twice through BCL glue; Handle opened Greet once.
+    assert edges[("MyApp.Program.Main", "MyApp.Services.Registry.Handle")].count == 2
+    assert (
+        edges[("MyApp.Services.Registry.Handle", "MyApp.Services.Registry.Greet")].count
+        == 1
+    )
+
+
+def test_malformed_speedscope_is_rejected(tmp_path):
+    profile_path = tmp_path / "broken.json"
+    profile_path.write_text("{}")
+
+    with pytest.raises(ValueError):
+        convert_speedscope(profile_path, output=tmp_path / "out.jsonl", include=("X",))

--- a/codebase_rag/trace/cli.py
+++ b/codebase_rag/trace/cli.py
@@ -139,12 +139,12 @@ def convert_cmd(
         else:
             # dotnet-trace speedscope: frames carry no paths, so scoping
             # needs namespace prefixes.
-            if not include:
+            prefixes = tuple(p.strip() for p in (include or "").split(",") if p.strip())
+            if not prefixes:
                 _fail(ch.ERR_TRACE_CONVERT_NEEDS_INCLUDE)
                 return
             from .speedscope import convert_speedscope
 
-            prefixes = tuple(p.strip() for p in include.split(",") if p.strip())
             count = convert_speedscope(
                 profile_file,
                 output=resolved_output,

--- a/codebase_rag/trace/cli.py
+++ b/codebase_rag/trace/cli.py
@@ -83,7 +83,7 @@ def ingest_cmd(trace_file: Path, repo_path: Path, project_name: str | None) -> N
 @click.option(
     "--repo-path",
     type=click.Path(exists=True, file_okay=False, path_type=Path),
-    required=True,
+    default=None,
     help=ch.HELP_TRACE_REPO_PATH,
 )
 @click.option(
@@ -93,27 +93,65 @@ def ingest_cmd(trace_file: Path, repo_path: Path, project_name: str | None) -> N
     default=None,
     help=ch.HELP_TRACE_OUTPUT,
 )
+@click.option("--include", default=None, help=ch.HELP_TRACE_INCLUDE)
 @click.option("--workload", default=None, help=ch.HELP_TRACE_WORKLOAD)
 def convert_cmd(
     profile_file: Path,
-    repo_path: Path,
+    repo_path: Path | None,
     output: Path | None,
+    include: str | None,
     workload: str | None,
 ) -> None:
+    import json
+
     from .. import constants as cs
-    from .cpuprofile import convert_cpuprofile
     from .records import TraceFormatError
 
     resolved_output = output or Path(cs.TRACE_DEFAULT_OUTPUT)
-    try:
-        count = convert_cpuprofile(
-            profile_file,
-            repo_root=repo_path,
-            output=resolved_output,
-            workload=workload,
-        )
-    except TraceFormatError as e:
-        logger.error(str(e))
-        click.secho(str(e), fg="red", err=True)
+
+    def _fail(message: str) -> None:
+        logger.error(message)
+        click.secho(message, fg="red", err=True)
         sys.exit(1)
+
+    try:
+        raw = json.loads(profile_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        _fail(str(e))
+        return
+    looks_like_cpuprofile = (isinstance(raw, dict) and "nodes" in raw) or (
+        profile_file.suffix == ".cpuprofile"
+    )
+    try:
+        if looks_like_cpuprofile:
+            # V8 cpuprofile: frames carry file URLs, so scoping needs the repo.
+            if repo_path is None:
+                _fail(ch.ERR_TRACE_CONVERT_NEEDS_REPO)
+                return
+            from .cpuprofile import convert_cpuprofile
+
+            count = convert_cpuprofile(
+                profile_file,
+                repo_root=repo_path,
+                output=resolved_output,
+                workload=workload,
+            )
+        else:
+            # dotnet-trace speedscope: frames carry no paths, so scoping
+            # needs namespace prefixes.
+            if not include:
+                _fail(ch.ERR_TRACE_CONVERT_NEEDS_INCLUDE)
+                return
+            from .speedscope import convert_speedscope
+
+            prefixes = tuple(p.strip() for p in include.split(",") if p.strip())
+            count = convert_speedscope(
+                profile_file,
+                output=resolved_output,
+                include=prefixes,
+                workload=workload,
+            )
+    except TraceFormatError as e:
+        _fail(str(e))
+        return
     click.echo(f"call records written: {count} -> {resolved_output}")

--- a/codebase_rag/trace/ingest.py
+++ b/codebase_rag/trace/ingest.py
@@ -22,6 +22,7 @@ from ..services import IngestorProtocol, QueryProtocol
 from .records import read_trace_file
 from .resolution import (
     CallableNode,
+    DotnetFrameResolver,
     FrameResolver,
     JsFrameResolver,
     JvmFrameResolver,
@@ -49,6 +50,8 @@ def _resolver_for(
         return JvmFrameResolver(nodes)
     if header.language == cs.TRACE_LANGUAGE_JS:
         return JsFrameResolver(repo_root, nodes)
+    if header.language == cs.TRACE_LANGUAGE_DOTNET:
+        return DotnetFrameResolver(nodes)
     return FrameResolver(repo_root, nodes)
 
 

--- a/codebase_rag/trace/resolution.py
+++ b/codebase_rag/trace/resolution.py
@@ -222,6 +222,7 @@ class JsFrameResolver:
         return ResolvedFrame(label=chosen.label, qualified_name=chosen.qualified_name)
 
 
+_DOTNET_ARITY = re.compile(r"`\d+")
 _DOTNET_STATE_MACHINE = re.compile(r"^<(\w+)>d__\d+$")
 _DOTNET_LAMBDA_BODY = re.compile(r"^<(\w+)>b__[\w_]+$")
 _DOTNET_DISPLAY_CLASS = re.compile(r"^<>c(__DisplayClass[\w_]*)?$")
@@ -238,6 +239,9 @@ def _demangle_clr_name(name: str) -> str | None:
     how the static tier names them; type initialisers have no source
     declaration at all.
     """
+    # dotnet-trace keeps CLR generic arity markers (``Dictionary`2``,
+    # ``Method`1``); the graph stores the source spelling, so strip them.
+    name = _DOTNET_ARITY.sub("", name)
     if name.endswith(cs.TRACE_DOTNET_CCTOR):
         return None
     constructor = name.endswith(cs.TRACE_DOTNET_CTOR)

--- a/codebase_rag/trace/resolution.py
+++ b/codebase_rag/trace/resolution.py
@@ -9,6 +9,7 @@ line containment when names alone are ambiguous.
 from __future__ import annotations
 
 import os
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -219,6 +220,100 @@ class JsFrameResolver:
             stats.record(cs.TraceUnresolvedReason.NO_MATCH)
             return None
         return ResolvedFrame(label=chosen.label, qualified_name=chosen.qualified_name)
+
+
+_DOTNET_STATE_MACHINE = re.compile(r"^<(\w+)>d__\d+$")
+_DOTNET_LAMBDA_BODY = re.compile(r"^<(\w+)>b__[\w_]+$")
+_DOTNET_DISPLAY_CLASS = re.compile(r"^<>c(__DisplayClass[\w_]*)?$")
+_DOTNET_ACCESSOR = re.compile(r"^(?:get|set)_(\w+)$")
+
+
+def _demangle_clr_name(name: str) -> str | None:
+    """CLR runtime names as dotted source names, or None for pure synthetics.
+
+    ``Ns.Worker+<RunAsync>d__3.MoveNext`` names the compiler's async state
+    machine; the source declaration is ``Ns.Worker.RunAsync``. Display
+    classes host lambda bodies whose best source anchor is the enclosing
+    method. Constructors (``..ctor``) take the class's own name, matching
+    how the static tier names them; type initialisers have no source
+    declaration at all.
+    """
+    if name.endswith(cs.TRACE_DOTNET_CCTOR):
+        return None
+    constructor = name.endswith(cs.TRACE_DOTNET_CTOR)
+    if constructor:
+        owner = name[: -len(cs.TRACE_DOTNET_CTOR)]
+        method = ""
+    else:
+        owner, separator, method = name.rpartition(cs.SEPARATOR_DOT)
+        if not separator:
+            return None
+    chain: list[str] = []
+    for part in owner.split(cs.TRACE_DOTNET_NESTED_MARKER):
+        machine = _DOTNET_STATE_MACHINE.match(part)
+        if machine:
+            method = machine.group(1)
+            continue
+        if _DOTNET_DISPLAY_CLASS.match(part):
+            continue
+        chain.append(part)
+    if not chain:
+        return None
+    if constructor:
+        method = chain[-1].rsplit(cs.SEPARATOR_DOT, 1)[-1]
+    lambda_body = _DOTNET_LAMBDA_BODY.match(method)
+    if lambda_body:
+        method = lambda_body.group(1)
+    if not method or "<" in method or any("<" in part for part in chain):
+        return None
+    return cs.SEPARATOR_DOT.join([*chain, method])
+
+
+class DotnetFrameResolver:
+    """Maps sampled .NET frames of one project to graph nodes.
+
+    dotnet-trace frames carry no file paths or lines, but C# qualified names
+    embed the declared namespace, so a demangled ``Namespace.Class.Method``
+    joins as a qualified-name suffix with the parameter signature stripped
+    (runtime argument types are CLR names that never match the graph's
+    source-text spellings, so overloads collapse onto one deterministic
+    node). Property accessors (``get_X``/``set_X``) fall back to the
+    property node when no literal match exists.
+    """
+
+    def __init__(self, nodes: list[CallableNode]) -> None:
+        self._nodes = [n for n in nodes if n.label != cs.NodeLabel.MODULE]
+
+    def resolve(
+        self, frame: FramePoint, stats: ResolutionStats
+    ) -> ResolvedFrame | None:
+        demangled = _demangle_clr_name(frame.qualname)
+        if demangled is None:
+            stats.record(cs.TraceUnresolvedReason.SYNTHETIC)
+            return None
+        chosen = self._match(demangled)
+        if chosen is None:
+            head, _, leaf = demangled.rpartition(cs.SEPARATOR_DOT)
+            accessor = _DOTNET_ACCESSOR.match(leaf)
+            if head and accessor:
+                chosen = self._match(f"{head}{cs.SEPARATOR_DOT}{accessor.group(1)}")
+        if chosen is None:
+            stats.record(cs.TraceUnresolvedReason.NO_MATCH)
+            return None
+        return ResolvedFrame(label=chosen.label, qualified_name=chosen.qualified_name)
+
+    def _match(self, demangled: str) -> CallableNode | None:
+        suffix = cs.SEPARATOR_DOT + demangled
+        matches = [
+            n
+            for n in self._nodes
+            if _signatureless(_natural_qualified_name(n.qualified_name)).endswith(
+                suffix
+            )
+        ]
+        if not matches:
+            return None
+        return min(matches, key=lambda n: n.qualified_name)
 
 
 class JvmFrameResolver:

--- a/codebase_rag/trace/speedscope.py
+++ b/codebase_rag/trace/speedscope.py
@@ -17,7 +17,7 @@ ancestor, mirroring the JVM agent's stack walk.
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from .. import constants as cs
 from .records import (
@@ -86,13 +86,14 @@ def _accumulate_evented(
 ) -> bool:
     """Frame open/close events replayed as a stack; each in-scope open under
     an in-scope ancestor counts one observed activation."""
-    events = profile.get("events", [])
+    events = profile.get("events")
     if not isinstance(events, list):
         return False
     stack: list[str | None] = []
-    for event in events:
-        if not isinstance(event, dict):
+    for raw_event in cast("list[object]", events):
+        if not isinstance(raw_event, dict):
             continue
+        event = cast("dict[str, object]", raw_event)
         kind = event.get("type")
         if kind == "O":
             frame_index = event.get("frame")

--- a/codebase_rag/trace/speedscope.py
+++ b/codebase_rag/trace/speedscope.py
@@ -61,14 +61,22 @@ def _accumulate_sampled(
         return False
     for position, stack in enumerate(samples):
         if not isinstance(stack, list):
-            continue
+            return False
         weight = weights[position] if position < len(weights) else 1
-        if not isinstance(weight, int | float) or weight <= 0:
+        if (
+            not isinstance(weight, int | float)
+            or isinstance(weight, bool)
+            or weight <= 0
+        ):
             weight = 1
         ancestor: str | None = None
         for frame_index in stack:
-            if not isinstance(frame_index, int) or not 0 <= frame_index < len(names):
-                continue
+            if (
+                not isinstance(frame_index, int)
+                or isinstance(frame_index, bool)
+                or not 0 <= frame_index < len(names)
+            ):
+                return False
             current = names[frame_index]
             if current is None:
                 continue
@@ -92,16 +100,18 @@ def _accumulate_evented(
     stack: list[str | None] = []
     for raw_event in cast("list[object]", events):
         if not isinstance(raw_event, dict):
-            continue
+            return False
         event = cast("dict[str, object]", raw_event)
         kind = event.get("type")
         if kind == "O":
             frame_index = event.get("frame")
-            current = (
-                names[frame_index]
-                if isinstance(frame_index, int) and 0 <= frame_index < len(names)
-                else None
-            )
+            if (
+                not isinstance(frame_index, int)
+                or isinstance(frame_index, bool)
+                or not 0 <= frame_index < len(names)
+            ):
+                return False
+            current = names[frame_index]
             if current is not None:
                 ancestor = next(
                     (name for name in reversed(stack) if name is not None), None
@@ -110,8 +120,12 @@ def _accumulate_evented(
                     key = (ancestor, current)
                     edges[key] = edges.get(key, 0) + 1
             stack.append(current)
-        elif kind == "C" and stack:
+        elif kind == "C":
+            if not stack:
+                return False
             stack.pop()
+        else:
+            return False
     return True
 
 

--- a/codebase_rag/trace/speedscope.py
+++ b/codebase_rag/trace/speedscope.py
@@ -52,13 +52,13 @@ def _scoped_name(name: object, include: Sequence[str]) -> str | None:
 def _accumulate_sampled(
     profile: dict[str, object],
     names: list[str | None],
-    edges: dict[tuple[str, str], int],
-) -> None:
+    edges: dict[tuple[str, str], float],
+) -> bool:
     """Adjacent in-scope frames in each sampled stack, weighted by sample."""
     samples = profile.get("samples", [])
     weights = profile.get("weights", [])
     if not isinstance(samples, list) or not isinstance(weights, list):
-        return
+        return False
     for position, stack in enumerate(samples):
         if not isinstance(stack, list):
             continue
@@ -74,20 +74,21 @@ def _accumulate_sampled(
                 continue
             if ancestor is not None:
                 key = (ancestor, current)
-                edges[key] = edges.get(key, 0) + int(weight)
+                edges[key] = edges.get(key, 0) + float(weight)
             ancestor = current
+    return True
 
 
 def _accumulate_evented(
     profile: dict[str, object],
     names: list[str | None],
-    edges: dict[tuple[str, str], int],
-) -> None:
+    edges: dict[tuple[str, str], float],
+) -> bool:
     """Frame open/close events replayed as a stack; each in-scope open under
     an in-scope ancestor counts one observed activation."""
     events = profile.get("events", [])
     if not isinstance(events, list):
-        return
+        return False
     stack: list[str | None] = []
     for event in events:
         if not isinstance(event, dict):
@@ -110,6 +111,7 @@ def _accumulate_evented(
             stack.append(current)
         elif kind == "C" and stack:
             stack.pop()
+    return True
 
 
 def convert_speedscope(
@@ -131,17 +133,25 @@ def convert_speedscope(
         for f in frames
     ]
 
-    edges: dict[tuple[str, str], int] = {}
+    # Fractional sample weights accumulate as-is and round half-up only at
+    # emission, so their combined contribution is never truncated away.
+    edges: dict[tuple[str, str], float] = {}
     converted = False
     for profile in profiles:
         if not isinstance(profile, dict):
             continue
         if profile.get("type") == "sampled":
+            if not _accumulate_sampled(profile, names, edges):
+                raise TraceFormatError(
+                    cs.TRACE_ERR_BAD_SPEEDSCOPE.format(path=profile_path)
+                )
             converted = True
-            _accumulate_sampled(profile, names, edges)
         elif profile.get("type") == "evented":
+            if not _accumulate_evented(profile, names, edges):
+                raise TraceFormatError(
+                    cs.TRACE_ERR_BAD_SPEEDSCOPE.format(path=profile_path)
+                )
             converted = True
-            _accumulate_evented(profile, names, edges)
     if not converted:
         raise TraceFormatError(cs.TRACE_ERR_BAD_SPEEDSCOPE.format(path=profile_path))
 
@@ -150,7 +160,7 @@ def convert_speedscope(
         CallRecord(
             caller=FramePoint(path="", qualname=caller, line=0),
             callee=FramePoint(path="", qualname=callee, line=0),
-            count=max(count, 1),
+            count=max(int(count + 0.5), 1),
             workloads=workloads,
             receiver_types=(),
         )

--- a/codebase_rag/trace/speedscope.py
+++ b/codebase_rag/trace/speedscope.py
@@ -1,0 +1,166 @@
+"""Convert dotnet-trace speedscope exports to the trace interchange format.
+
+``dotnet-trace collect`` samples managed stacks over EventPipe;
+``dotnet-trace convert --format speedscope`` exports them as speedscope JSON
+whose samples are full stacks, root first. Adjacent in-scope frames within a
+stack are caller/callee relationships the sampler actually observed, so
+dispatch through interfaces, DI containers, and reflection appears whenever
+samples landed there. Counts are sample weights, not call counts.
+
+.NET frames carry no source paths or lines, only
+``Assembly!Namespace.Class.Method(arg types)``. Scoping therefore works on
+name prefixes (the ``include`` namespaces) rather than file paths, and
+frames from runtime assemblies are walked through to the nearest in-scope
+ancestor, mirroring the JVM agent's stack walk.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from .. import constants as cs
+from .records import (
+    CallRecord,
+    FramePoint,
+    TraceFormatError,
+    TraceHeader,
+    write_trace_file,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+
+
+def _scoped_name(name: object, include: Sequence[str]) -> str | None:
+    """The frame's assembly-stripped, argument-stripped dotted name, if in scope."""
+    if not isinstance(name, str):
+        return None
+    _assembly, separator, rest = name.partition(cs.TRACE_DOTNET_ASSEMBLY_SEPARATOR)
+    if not separator:
+        return None
+    args_start = rest.find("(")
+    if args_start >= 0:
+        rest = rest[:args_start]
+    for prefix in include:
+        if rest == prefix or rest.startswith(prefix + cs.SEPARATOR_DOT):
+            return rest
+    return None
+
+
+def _accumulate_sampled(
+    profile: dict[str, object],
+    names: list[str | None],
+    edges: dict[tuple[str, str], int],
+) -> None:
+    """Adjacent in-scope frames in each sampled stack, weighted by sample."""
+    samples = profile.get("samples", [])
+    weights = profile.get("weights", [])
+    if not isinstance(samples, list) or not isinstance(weights, list):
+        return
+    for position, stack in enumerate(samples):
+        if not isinstance(stack, list):
+            continue
+        weight = weights[position] if position < len(weights) else 1
+        if not isinstance(weight, int | float) or weight <= 0:
+            weight = 1
+        ancestor: str | None = None
+        for frame_index in stack:
+            if not isinstance(frame_index, int) or not 0 <= frame_index < len(names):
+                continue
+            current = names[frame_index]
+            if current is None:
+                continue
+            if ancestor is not None:
+                key = (ancestor, current)
+                edges[key] = edges.get(key, 0) + int(weight)
+            ancestor = current
+
+
+def _accumulate_evented(
+    profile: dict[str, object],
+    names: list[str | None],
+    edges: dict[tuple[str, str], int],
+) -> None:
+    """Frame open/close events replayed as a stack; each in-scope open under
+    an in-scope ancestor counts one observed activation."""
+    events = profile.get("events", [])
+    if not isinstance(events, list):
+        return
+    stack: list[str | None] = []
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        kind = event.get("type")
+        if kind == "O":
+            frame_index = event.get("frame")
+            current = (
+                names[frame_index]
+                if isinstance(frame_index, int) and 0 <= frame_index < len(names)
+                else None
+            )
+            if current is not None:
+                ancestor = next(
+                    (name for name in reversed(stack) if name is not None), None
+                )
+                if ancestor is not None:
+                    key = (ancestor, current)
+                    edges[key] = edges.get(key, 0) + 1
+            stack.append(current)
+        elif kind == "C" and stack:
+            stack.pop()
+
+
+def convert_speedscope(
+    profile_path: Path,
+    output: Path,
+    include: Sequence[str],
+    workload: str | None = None,
+) -> int:
+    """Write ``profile_path``'s in-scope call edges to ``output``; returns count."""
+    raw = json.loads(profile_path.read_text(encoding="utf-8"))
+    shared = raw.get("shared") if isinstance(raw, dict) else None
+    frames = shared.get("frames") if isinstance(shared, dict) else None
+    profiles = raw.get("profiles") if isinstance(raw, dict) else None
+    if not isinstance(frames, list) or not isinstance(profiles, list):
+        raise TraceFormatError(cs.TRACE_ERR_BAD_SPEEDSCOPE.format(path=profile_path))
+
+    names: list[str | None] = [
+        _scoped_name(f.get("name") if isinstance(f, dict) else None, include)
+        for f in frames
+    ]
+
+    edges: dict[tuple[str, str], int] = {}
+    converted = False
+    for profile in profiles:
+        if not isinstance(profile, dict):
+            continue
+        if profile.get("type") == "sampled":
+            converted = True
+            _accumulate_sampled(profile, names, edges)
+        elif profile.get("type") == "evented":
+            converted = True
+            _accumulate_evented(profile, names, edges)
+    if not converted:
+        raise TraceFormatError(cs.TRACE_ERR_BAD_SPEEDSCOPE.format(path=profile_path))
+
+    workloads = (workload,) if workload else ()
+    records = [
+        CallRecord(
+            caller=FramePoint(path="", qualname=caller, line=0),
+            callee=FramePoint(path="", qualname=callee, line=0),
+            count=max(count, 1),
+            workloads=workloads,
+            receiver_types=(),
+        )
+        for (caller, callee), count in edges.items()
+    ]
+    header = TraceHeader(
+        version=cs.TRACE_FORMAT_VERSION,
+        language=cs.TRACE_LANGUAGE_DOTNET,
+        repo_root="",
+        tracer=cs.TRACE_TOOL_NAME_SPEEDSCOPE,
+    )
+    write_trace_file(output, header, records)
+    return len(records)

--- a/docs/guide/dynamic-tracing.md
+++ b/docs/guide/dynamic-tracing.md
@@ -111,6 +111,37 @@ distinguish this from the instrumented Python and JVM tracers:
   planned follow-up. Running TS directly (via a runner that keeps file
   paths) or indexing the built tree avoids the gap today.
 
+## Recording a .NET trace (C#)
+
+No agent is needed: the CLR's EventPipe sampler ships with the runtime, and
+`dotnet-trace` (a standard global tool) drives it:
+
+```bash
+dotnet tool install --global dotnet-trace
+dotnet-trace collect --output run.nettrace -- dotnet bin/Release/net10.0/MyApp.dll
+dotnet-trace convert run.nettrace --format speedscope --output run
+cgr trace convert run.speedscope.json --include MyApp --workload smoke
+cgr trace ingest cgr-trace.jsonl --repo-path /path/to/your-repo
+```
+
+.NET frames carry no file paths, so scoping uses `--include` namespace
+prefixes instead of the repository root, and resolution joins on the
+namespace-bearing qualified names the static tier stores. CLR name mangling
+is handled: async state machines (`Worker+<RunAsync>d__3.MoveNext`) resolve
+to the source method, display-class lambdas to their enclosing method,
+`.ctor` to the constructor node, `get_`/`set_` accessors to the property
+node, and nested-class `+` to dotted nesting. Two caveats:
+
+- **Sampling.** Edge counts reflect observed activations in the flame
+  chart, not exact call counts; very short calls between samples can be
+  missed. Receiver types on interface dispatch are not observable from
+  samples; the dispatch itself still appears because the concrete
+  implementation's frames are recorded (an instrumented profiler-based
+  tracer is the planned follow-up for receiver capture).
+- **Overloads.** Runtime argument types (CLR names) cannot be matched to
+  the graph's source-text signatures, so all overloads of a name collapse
+  onto one deterministic node.
+
 ## Ingesting a trace
 
 Parse the repository into the graph first (`cgr start --repo-path ... --update-graph`),


### PR DESCRIPTION
Part of #1244, first increment of #1249. **Stacked on #1261** (base branch is `feat/1247-js-dynamic-tracing`); only the last commit is new.

## What

Dynamic call-graph capture for C# codebases with no agent code: the CLR's EventPipe sampler ships with the runtime, `dotnet-trace` drives it, and this PR teaches `cgr trace convert` to read its speedscope export (both `sampled` and the `evented` flame-chart form dotnet-trace actually emits) plus a `DotnetFrameResolver` for CLR name demangling:

- **Conversion**: in-scope frame adjacencies become interchange call records; runtime-assembly frames (BCL, DI glue) are walked through to the nearest project frame, mirroring the JVM stack walk. .NET frames carry no file paths, so scoping uses `--include` namespace prefixes (boundary-aware), auto-sniffed against V8 cpuprofiles by the same `cgr trace convert` command.
- **Resolution**: C# qualified names embed the declared namespace (unlike Java's path-only grammar), so demangled `Namespace.Class.Method` joins as a signature-stripped qn suffix. Demangling covers async state machines (`Worker+<RunAsync>d__3.MoveNext` -> `Worker.RunAsync`), display-class lambdas (`<>c.<Bar>b__2_0` -> `Bar`), constructors (`..ctor` -> class-named node, `..cctor` dropped as synthetic), property accessors (`get_X`/`set_X` -> the property node), and nested-class `+` -> dotted nesting. Runtime CLR argument types can never match the graph's source-text signatures, so overloads collapse onto one deterministic node (documented).

## Verification

Live end-to-end against Memgraph: sample C# project (interface dispatch + `Dictionary<string, Func<string>>` registry) built with the .NET 10 SDK, traced with `dotnet-trace collect`, converted, ingested:

- Interface dispatch `Describe(IAnimal) -> Dog.Sound() / Cat.Sound()` lands as runtime-only edges (`static_missed: true`) — the acceptance criterion's dispatch-through-indirection edge
- Registry dispatch `Handle(string) -> Greet()` also runtime-only
- `Main -> Describe`, `Main -> Handle`, `Dog.Sound -> Dog.Work` confirmed static
- Activation counts are exact (x30 = the sample's loop count; the evented flame chart preserves every activation), 0 unresolved frames

Receiver types on dispatch are not observable from samples; the docs state this plainly and the instrumented profiler-based tracer remains the follow-up increment for that criterion. Async resolution is unit-tested via the state-machine demangler.

16 new unit tests (speedscope sampled/evented conversion, scoping, see-through, recursion; CLR demangling cases; CLI sniffing; ingest dispatch), all red/green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for converting sampled and evented .NET speedscope profiles into dynamic traces.
  * Added .NET frame resolution for async methods, lambdas, constructors, accessors, nested types, and compiler-generated names.
  * Added automatic detection of V8 CPU and speedscope profiles.
  * Added namespace filtering and optional repository-path handling with clear validation errors.

* **Documentation**
  * Added guidance for recording and converting .NET dynamic traces, including filtering, sampling limitations, and resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->