### PR TITLE
feat: add PHP runtime call tracing via Xdebug trace conversion

### DIFF
--- a/codebase_rag/constants/trace.py
+++ b/codebase_rag/constants/trace.py
@@ -110,6 +110,7 @@ class TraceUnresolvedReason(StrEnum):
     SYNTHETIC = "synthetic"
     UNKNOWN_PATH = "unknown_path"
     NO_MATCH = "no_match"
+    AMBIGUOUS = "ambiguous"
 
 
 TRACE_ERR_BAD_HEADER = "Trace file {path} does not start with a valid cgr trace header."

--- a/codebase_rag/constants/trace.py
+++ b/codebase_rag/constants/trace.py
@@ -25,10 +25,12 @@ TRACE_LANGUAGE_PYTHON = "python"
 TRACE_LANGUAGE_JVM = "jvm"
 TRACE_LANGUAGE_JS = "javascript"
 TRACE_LANGUAGE_DOTNET = "dotnet"
+TRACE_LANGUAGE_PHP = "php"
 TRACE_TOOL_NAME = "cgr-trace"
 TRACE_TOOL_NAME_JVM = "cgr-trace-jvm"
 TRACE_TOOL_NAME_CPUPROFILE = "cgr-trace-cpuprofile"
 TRACE_TOOL_NAME_SPEEDSCOPE = "cgr-trace-speedscope"
+TRACE_TOOL_NAME_XDEBUG = "cgr-trace-xdebug"
 TRACE_DEFAULT_OUTPUT = "cgr-trace.jsonl"
 
 # Python runtime qualname markers.
@@ -50,6 +52,20 @@ TRACE_DOTNET_ASSEMBLY_SEPARATOR = "!"
 TRACE_DOTNET_CTOR = "..ctor"
 TRACE_DOTNET_CCTOR = "..cctor"
 TRACE_DOTNET_NESTED_MARKER = "+"
+
+# Xdebug computerized-trace markers (trace_format=1, file format 4).
+TRACE_ERR_BAD_XDEBUG = (
+    "{path} is not an Xdebug computerized trace (expected 'File format: 4')."
+)
+TRACE_XDEBUG_FORMAT_LINE = "File format: 4"
+TRACE_XDEBUG_MAIN = "{main}"
+TRACE_XDEBUG_GLUE_FUNCTIONS = frozenset(
+    {"require", "require_once", "include", "include_once", "eval"}
+)
+TRACE_PHP_INSTANCE_SEPARATOR = "->"
+TRACE_PHP_STATIC_SEPARATOR = "::"
+TRACE_PHP_NAMESPACE_SEPARATOR = "\\"
+TRACE_PHP_CLOSURE_PREFIX = "{closure:"
 
 # JVM runtime name markers.
 TRACE_JVM_CONSTRUCTOR = "<init>"

--- a/codebase_rag/tests/test_dynamic_trace_cli.py
+++ b/codebase_rag/tests/test_dynamic_trace_cli.py
@@ -226,15 +226,13 @@ def test_convert_command_requires_repo_path_for_cpuprofiles(tmp_path):
 
 
 def test_convert_command_fails_cleanly_on_unreadable_xt(tmp_path, monkeypatch):
-    from pathlib import Path as _Path
-
     trace_path = tmp_path / "run.xt"
     trace_path.write_text("File format: 4\n")
 
-    def _deny(self, *args, **kwargs):
-        raise PermissionError(f"denied: {self}")
+    def _deny(*args, **kwargs):
+        raise PermissionError(f"denied: {trace_path}")
 
-    monkeypatch.setattr(_Path, "read_text", _deny)
+    monkeypatch.setattr("codebase_rag.trace.xdebug.convert_xdebug_trace", _deny)
     result = CliRunner().invoke(cli, ["convert", str(trace_path)])
 
     assert result.exit_code == 1

--- a/codebase_rag/tests/test_dynamic_trace_cli.py
+++ b/codebase_rag/tests/test_dynamic_trace_cli.py
@@ -225,6 +225,22 @@ def test_convert_command_requires_repo_path_for_cpuprofiles(tmp_path):
     assert "--repo-path" in result.output
 
 
+def test_convert_command_fails_cleanly_on_unreadable_xt(tmp_path, monkeypatch):
+    from pathlib import Path as _Path
+
+    trace_path = tmp_path / "run.xt"
+    trace_path.write_text("File format: 4\n")
+
+    def _deny(self, *args, **kwargs):
+        raise PermissionError(f"denied: {self}")
+
+    monkeypatch.setattr(_Path, "read_text", _deny)
+    result = CliRunner().invoke(cli, ["convert", str(trace_path)])
+
+    assert result.exit_code == 1
+    assert "denied" in result.output
+
+
 def test_ingest_command_fails_cleanly_on_malformed_trace(tmp_path, monkeypatch):
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/codebase_rag/tests/test_dynamic_trace_resolution_php.py
+++ b/codebase_rag/tests/test_dynamic_trace_resolution_php.py
@@ -115,6 +115,29 @@ def test_resolves_closure_frames_by_embedded_position(tmp_path):
     assert resolved.qualified_name == f"{_P}.src.Shapes.outer.anonymous_9_10"
 
 
+def test_ambiguous_name_tails_are_unresolved_not_guessed(tmp_path):
+    # Two unrelated classes named Dog in different files: a pathless frame
+    # must not attach the edge to whichever sorts first.
+    nodes = [
+        *_NODES,
+        _node(
+            cs.NodeLabel.METHOD,
+            f"{_P}.src.Alpha.Dog.sound",
+            "src/Alpha.php",
+            3,
+            6,
+        ),
+    ]
+    stats = ResolutionStats()
+
+    resolved = PhpFrameResolver(tmp_path, nodes).resolve(
+        _frame(tmp_path, "", r"App\Services\Dog->sound", 0), stats
+    )
+
+    assert resolved is None
+    assert stats.unresolved == {cs.TraceUnresolvedReason.AMBIGUOUS.value: 1}
+
+
 def test_unresolved_reasons_are_categorised(tmp_path):
     resolver = _resolver(tmp_path)
     stats = ResolutionStats()

--- a/codebase_rag/tests/test_dynamic_trace_resolution_php.py
+++ b/codebase_rag/tests/test_dynamic_trace_resolution_php.py
@@ -1,0 +1,135 @@
+# PHP qualified names are path-derived (the namespace declaration is
+# ignored), so Xdebug frames resolve primarily by file plus line span; the
+# runtime name's class/method tail is the fallback when a leaf callee's
+# defining file could not be recovered (issue #1253).
+
+from __future__ import annotations
+
+from codebase_rag import constants as cs
+from codebase_rag.trace.records import FramePoint
+from codebase_rag.trace.resolution import (
+    CallableNode,
+    PhpFrameResolver,
+    ResolutionStats,
+)
+
+_P = "demo"
+
+
+def _node(label, qualified_name, path, start_line, end_line):
+    return CallableNode(
+        label=label,
+        qualified_name=qualified_name,
+        path=path,
+        start_line=start_line,
+        end_line=end_line,
+    )
+
+
+_NODES = [
+    _node(cs.NodeLabel.MODULE, f"{_P}.main", "main.php", None, None),
+    _node(cs.NodeLabel.FUNCTION, f"{_P}.main.describeAnimal", "main.php", 11, 14),
+    _node(
+        cs.NodeLabel.METHOD,
+        f"{_P}.src.Registry.Registry.handle",
+        "src/Registry.php",
+        14,
+        17,
+    ),
+    _node(
+        cs.NodeLabel.METHOD,
+        f"{_P}.src.Registry.Registry.greet",
+        "src/Registry.php",
+        19,
+        22,
+    ),
+    _node(cs.NodeLabel.METHOD, f"{_P}.src.Animal.Dog.sound", "src/Animal.php", 12, 15),
+    _node(
+        cs.NodeLabel.FUNCTION,
+        f"{_P}.src.Shapes.outer.anonymous_9_10",
+        "src/Shapes.php",
+        10,
+        12,
+    ),
+    _node(cs.NodeLabel.FUNCTION, f"{_P}.src.Shapes.outer", "src/Shapes.php", 5, 20),
+]
+
+
+def _resolver(tmp_path):
+    return PhpFrameResolver(tmp_path, _NODES)
+
+
+def _frame(tmp_path, rel_path, qualname, line):
+    path = str(tmp_path / rel_path) if rel_path else ""
+    return FramePoint(path=path, qualname=qualname, line=line)
+
+
+def test_resolves_caller_frames_by_call_site_span(tmp_path):
+    resolved = _resolver(tmp_path).resolve(
+        _frame(tmp_path, "main.php", "describeAnimal", 13), ResolutionStats()
+    )
+
+    assert resolved is not None
+    assert resolved.qualified_name == f"{_P}.main.describeAnimal"
+
+
+def test_resolves_main_frame_to_module(tmp_path):
+    resolved = _resolver(tmp_path).resolve(
+        _frame(tmp_path, "main.php", cs.TRACE_XDEBUG_MAIN, 20), ResolutionStats()
+    )
+
+    assert resolved is not None
+    assert resolved.label == cs.NodeLabel.MODULE
+    assert resolved.qualified_name == f"{_P}.main"
+
+
+def test_resolves_enriched_callee_by_span_despite_namespace(tmp_path):
+    # The runtime name carries a namespace the graph never stores; the
+    # recovered defining position must decide.
+    resolved = _resolver(tmp_path).resolve(
+        _frame(tmp_path, "src/Registry.php", r"App\Services\Registry::handle", 16),
+        ResolutionStats(),
+    )
+
+    assert resolved is not None
+    assert resolved.qualified_name == f"{_P}.src.Registry.Registry.handle"
+
+
+def test_resolves_pathless_leaf_by_class_method_tail(tmp_path):
+    resolved = _resolver(tmp_path).resolve(
+        _frame(tmp_path, "", r"App\Services\Dog->sound", 0), ResolutionStats()
+    )
+
+    assert resolved is not None
+    assert resolved.qualified_name == f"{_P}.src.Animal.Dog.sound"
+
+
+def test_resolves_closure_frames_by_embedded_position(tmp_path):
+    qualname = f"{{closure:{tmp_path / 'src/Shapes.php'}:10-12}}"
+
+    resolved = _resolver(tmp_path).resolve(
+        _frame(tmp_path, "", qualname, 0), ResolutionStats()
+    )
+
+    assert resolved is not None
+    assert resolved.qualified_name == f"{_P}.src.Shapes.outer.anonymous_9_10"
+
+
+def test_unresolved_reasons_are_categorised(tmp_path):
+    resolver = _resolver(tmp_path)
+    stats = ResolutionStats()
+
+    outside = resolver.resolve(
+        FramePoint(path="/elsewhere/x.php", qualname="f", line=1), stats
+    )
+    unknown = resolver.resolve(_frame(tmp_path, "src/Gone.php", "f", 1), stats)
+    missing = resolver.resolve(_frame(tmp_path, "", r"App\Ghost->vanish", 0), stats)
+
+    assert outside is None
+    assert unknown is None
+    assert missing is None
+    assert stats.unresolved == {
+        cs.TraceUnresolvedReason.OUTSIDE_REPO.value: 1,
+        cs.TraceUnresolvedReason.UNKNOWN_PATH.value: 1,
+        cs.TraceUnresolvedReason.NO_MATCH.value: 1,
+    }

--- a/codebase_rag/tests/test_dynamic_trace_xdebug.py
+++ b/codebase_rag/tests/test_dynamic_trace_xdebug.py
@@ -1,0 +1,156 @@
+# Xdebug computerized traces (trace_format=1) record every call with the
+# concrete receiver class and the call site; the converter must turn entry
+# rows into exact interchange call records, seeing through require/include
+# and internal frames, and keeping module toplevels addressable
+# (issue #1253).
+
+from __future__ import annotations
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.trace.records import read_trace_file
+from codebase_rag.trace.xdebug import convert_xdebug_trace
+
+_HEADER = "Version: 3.5.3\nFile format: 4\nTRACE START [2026-08-14 02:07:42]\n"
+_FOOTER = "\t\t\t0.001855\t479056\nTRACE END   [2026-08-14 02:07:42]\n"
+
+
+def _entry(level, fn_id, name, user_defined, include_file, filename, line):
+    return (
+        f"{level}\t{fn_id}\t0\t0.001\t480000\t{name}\t{user_defined}\t"
+        f"{include_file}\t{filename}\t{line}\t0"
+    )
+
+
+def _exit(level, fn_id):
+    return f"{level}\t{fn_id}\t1\t0.002\t480000"
+
+
+def _write(tmp_path, rows):
+    trace_path = tmp_path / "run.xt"
+    trace_path.write_text(_HEADER + "\n".join(rows) + "\n" + _FOOTER)
+    return trace_path
+
+
+def _convert(tmp_path, rows, workload=None):
+    output = tmp_path / "trace.jsonl"
+    count = convert_xdebug_trace(
+        _write(tmp_path, rows), output=output, workload=workload
+    )
+    header, records = read_trace_file(output)
+    return count, header, list(records)
+
+
+def _sample_rows(repo):
+    main = f"{repo}/main.php"
+    registry = f"{repo}/src/Registry.php"
+    return [
+        _entry(1, 0, "{main}", 1, "", main, 0),
+        # require pulls in a file; it is glue, not an edge endpoint.
+        _entry(2, 1, "require", 1, registry, main, 3),
+        _exit(2, 1),
+        _entry(2, 2, "describeAnimal", 1, "", main, 20),
+        _entry(3, 3, r"App\Services\Dog->sound", 1, "", main, 13),
+        _exit(3, 3),
+        _exit(2, 2),
+        _entry(2, 4, "describeAnimal", 1, "", main, 20),
+        _entry(3, 5, r"App\Services\Cat->sound", 1, "", main, 13),
+        _exit(3, 5),
+        _exit(2, 4),
+        _entry(2, 6, r"App\Services\Registry::handle", 1, "", main, 23),
+        # An internal frame (call_user_func) between two project frames.
+        _entry(3, 7, "call_user_func", 0, "", registry, 16),
+        _entry(4, 8, r"App\Services\Registry::greet", 1, "", registry, 16),
+        _exit(4, 8),
+        _exit(3, 7),
+        _exit(2, 6),
+        _exit(1, 0),
+    ]
+
+
+def test_converts_calls_with_exact_counts(tmp_path):
+    repo = tmp_path.as_posix()
+    count, header, records = _convert(tmp_path, _sample_rows(repo))
+
+    assert header.language == cs.TRACE_LANGUAGE_PHP
+    assert count == len(records)
+    edges = {(r.caller.qualname, r.callee.qualname): r for r in records}
+    assert edges[("describeAnimal", r"App\Services\Dog->sound")].count == 1
+    assert edges[("{main}", "describeAnimal")].count == 2
+
+
+def test_internal_frames_are_walked_through(tmp_path):
+    repo = tmp_path.as_posix()
+    _count, _header, records = _convert(tmp_path, _sample_rows(repo))
+
+    edges = {(r.caller.qualname, r.callee.qualname) for r in records}
+    assert (
+        r"App\Services\Registry::handle",
+        r"App\Services\Registry::greet",
+    ) in edges
+    assert not any("call_user_func" in pair for edge in edges for pair in edge)
+
+
+def test_require_frames_never_become_endpoints(tmp_path):
+    repo = tmp_path.as_posix()
+    _count, _header, records = _convert(tmp_path, _sample_rows(repo))
+
+    for record in records:
+        assert record.caller.qualname != "require"
+        assert record.callee.qualname != "require"
+
+
+def test_toplevel_frame_keeps_its_defining_file(tmp_path):
+    repo = tmp_path.as_posix()
+    _count, _header, records = _convert(tmp_path, _sample_rows(repo))
+
+    toplevel_edges = [r for r in records if r.caller.qualname == "{main}"]
+    assert toplevel_edges
+    for record in toplevel_edges:
+        assert record.caller.path == f"{repo}/main.php"
+
+
+def test_call_sites_annotate_caller_frames(tmp_path):
+    repo = tmp_path.as_posix()
+    _count, _header, records = _convert(tmp_path, _sample_rows(repo))
+
+    edges = {(r.caller.qualname, r.callee.qualname): r for r in records}
+    dispatch = edges[("describeAnimal", r"App\Services\Dog->sound")]
+    # The call happened at main.php:13, inside describeAnimal's span.
+    assert dispatch.caller.path == f"{repo}/main.php"
+    assert dispatch.caller.line == 13
+
+
+def test_callee_defining_files_are_recovered_from_child_call_sites(tmp_path):
+    # Xdebug entry rows carry only the call site, never where the callee is
+    # defined; but a callee that itself calls something reveals its own file
+    # through its child's call site. handle's child (greet's entry) sits in
+    # Registry.php, so the main->handle edge learns handle's defining file
+    # and line, enabling span-based resolution against path-derived qns.
+    repo = tmp_path.as_posix()
+    _count, _header, records = _convert(tmp_path, _sample_rows(repo))
+
+    edges = {(r.caller.qualname, r.callee.qualname): r for r in records}
+    handle = edges[("{main}", r"App\Services\Registry::handle")]
+    assert handle.callee.path == f"{repo}/src/Registry.php"
+    assert handle.callee.line == 16
+
+
+def test_workload_label_lands_on_every_record(tmp_path):
+    repo = tmp_path.as_posix()
+    _count, _header, records = _convert(
+        tmp_path, _sample_rows(repo), workload="phpunit"
+    )
+
+    assert records
+    for record in records:
+        assert record.workloads == ("phpunit",)
+
+
+def test_malformed_trace_is_rejected(tmp_path):
+    trace_path = tmp_path / "broken.xt"
+    trace_path.write_text("not an xdebug trace\n")
+
+    with pytest.raises(ValueError):
+        convert_xdebug_trace(trace_path, output=tmp_path / "out.jsonl")

--- a/codebase_rag/trace/cli.py
+++ b/codebase_rag/trace/cli.py
@@ -121,7 +121,7 @@ def convert_cmd(
             count = convert_xdebug_trace(
                 profile_file, output=resolved_output, workload=workload
             )
-        except TraceFormatError as e:
+        except (TraceFormatError, OSError) as e:
             _fail(str(e))
             return
         click.echo(f"call records written: {count} -> {resolved_output}")

--- a/codebase_rag/trace/cli.py
+++ b/codebase_rag/trace/cli.py
@@ -114,6 +114,19 @@ def convert_cmd(
         click.secho(message, fg="red", err=True)
         sys.exit(1)
 
+    from .xdebug import convert_xdebug_trace
+
+    if profile_file.suffix == ".xt":
+        try:
+            count = convert_xdebug_trace(
+                profile_file, output=resolved_output, workload=workload
+            )
+        except TraceFormatError as e:
+            _fail(str(e))
+            return
+        click.echo(f"call records written: {count} -> {resolved_output}")
+        return
+
     try:
         raw = json.loads(profile_file.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as e:

--- a/codebase_rag/trace/ingest.py
+++ b/codebase_rag/trace/ingest.py
@@ -26,6 +26,7 @@ from .resolution import (
     FrameResolver,
     JsFrameResolver,
     JvmFrameResolver,
+    PhpFrameResolver,
     ResolutionStats,
 )
 
@@ -52,6 +53,8 @@ def _resolver_for(
         return JsFrameResolver(repo_root, nodes)
     if header.language == cs.TRACE_LANGUAGE_DOTNET:
         return DotnetFrameResolver(nodes)
+    if header.language == cs.TRACE_LANGUAGE_PHP:
+        return PhpFrameResolver(repo_root, nodes)
     return FrameResolver(repo_root, nodes)
 
 

--- a/codebase_rag/trace/resolution.py
+++ b/codebase_rag/trace/resolution.py
@@ -223,6 +223,109 @@ class JsFrameResolver:
 
 
 _DOTNET_ARITY = re.compile(r"`\d+")
+_PHP_CLOSURE = re.compile(r"^\{closure:(?P<path>.+):(?P<start>\d+)-\d+\}$")
+
+
+class PhpFrameResolver:
+    """Maps Xdebug frames of one project to graph nodes.
+
+    PHP qualified names are path-derived (the namespace declaration is
+    ignored), so resolution is span-first: frames carrying a file position
+    (call sites, recovered defining positions, closure names embedding
+    their file and lines) resolve to the innermost containing node. Leaf
+    callees whose defining file could not be recovered fall back to the
+    runtime name's ``Class.method`` tail, which drops the namespace exactly
+    as the graph does.
+    """
+
+    def __init__(self, repo_root: Path, nodes: list[CallableNode]) -> None:
+        self._repo_root = repo_root.resolve()
+        self._root_prefix = str(self._repo_root) + os.sep
+        self._callables_by_path: dict[str, list[CallableNode]] = {}
+        self._modules_by_path: dict[str, CallableNode] = {}
+        for node in nodes:
+            if node.label == cs.NodeLabel.MODULE:
+                self._modules_by_path[node.path] = node
+            else:
+                self._callables_by_path.setdefault(node.path, []).append(node)
+
+    def resolve(
+        self, frame: FramePoint, stats: ResolutionStats
+    ) -> ResolvedFrame | None:
+        closure = _PHP_CLOSURE.match(frame.qualname)
+        if closure:
+            return self._resolve_position(
+                closure.group("path"), int(closure.group("start")), stats
+            )
+        if frame.path:
+            if frame.qualname == cs.TRACE_XDEBUG_MAIN:
+                return self._resolve_module(frame.path, stats)
+            return self._resolve_position(frame.path, frame.line, stats)
+        return self._resolve_by_name_tail(frame.qualname, stats)
+
+    def _relative(self, path: str) -> str | None:
+        if not path.startswith(self._root_prefix):
+            return None
+        return Path(path).relative_to(self._repo_root).as_posix()
+
+    def _resolve_module(
+        self, path: str, stats: ResolutionStats
+    ) -> ResolvedFrame | None:
+        rel_path = self._relative(path)
+        if rel_path is None:
+            stats.record(cs.TraceUnresolvedReason.OUTSIDE_REPO)
+            return None
+        module = self._modules_by_path.get(rel_path)
+        if module is None:
+            stats.record(cs.TraceUnresolvedReason.UNKNOWN_PATH)
+            return None
+        return ResolvedFrame(label=module.label, qualified_name=module.qualified_name)
+
+    def _resolve_position(
+        self, path: str, line: int, stats: ResolutionStats
+    ) -> ResolvedFrame | None:
+        rel_path = self._relative(path)
+        if rel_path is None:
+            stats.record(cs.TraceUnresolvedReason.OUTSIDE_REPO)
+            return None
+        candidates = self._callables_by_path.get(rel_path)
+        if not candidates:
+            stats.record(cs.TraceUnresolvedReason.UNKNOWN_PATH)
+            return None
+        chosen = _innermost_span_containing_line(candidates, line)
+        if chosen is None:
+            stats.record(cs.TraceUnresolvedReason.NO_MATCH)
+            return None
+        return ResolvedFrame(label=chosen.label, qualified_name=chosen.qualified_name)
+
+    def _resolve_by_name_tail(
+        self, qualname: str, stats: ResolutionStats
+    ) -> ResolvedFrame | None:
+        for separator in (
+            cs.TRACE_PHP_INSTANCE_SEPARATOR,
+            cs.TRACE_PHP_STATIC_SEPARATOR,
+        ):
+            if separator in qualname:
+                owner, _, method = qualname.partition(separator)
+                owner = owner.rsplit(cs.TRACE_PHP_NAMESPACE_SEPARATOR, 1)[-1]
+                tail = f"{cs.SEPARATOR_DOT}{owner}{cs.SEPARATOR_DOT}{method}"
+                break
+        else:
+            plain = qualname.rsplit(cs.TRACE_PHP_NAMESPACE_SEPARATOR, 1)[-1]
+            tail = f"{cs.SEPARATOR_DOT}{plain}"
+        matches = [
+            node
+            for nodes in self._callables_by_path.values()
+            for node in nodes
+            if _natural_qualified_name(node.qualified_name).endswith(tail)
+        ]
+        if not matches:
+            stats.record(cs.TraceUnresolvedReason.NO_MATCH)
+            return None
+        chosen = min(matches, key=lambda n: n.qualified_name)
+        return ResolvedFrame(label=chosen.label, qualified_name=chosen.qualified_name)
+
+
 _DOTNET_STATE_MACHINE = re.compile(r"^<(\w+)>d__\d+$")
 _DOTNET_LAMBDA_BODY = re.compile(r"^<(\w+)>b__\w+$")
 _DOTNET_DISPLAY_CLASS = re.compile(r"^<>c(__DisplayClass\w*)?$")

--- a/codebase_rag/trace/resolution.py
+++ b/codebase_rag/trace/resolution.py
@@ -322,7 +322,13 @@ class PhpFrameResolver:
         if not matches:
             stats.record(cs.TraceUnresolvedReason.NO_MATCH)
             return None
-        chosen = min(matches, key=lambda n: n.qualified_name)
+        if len(matches) > 1:
+            # The tail dropped the namespace, so several unrelated classes
+            # can collide; guessing would attach the edge (and its static
+            # classification) to the wrong declaration.
+            stats.record(cs.TraceUnresolvedReason.AMBIGUOUS)
+            return None
+        chosen = matches[0]
         return ResolvedFrame(label=chosen.label, qualified_name=chosen.qualified_name)
 
 

--- a/codebase_rag/trace/xdebug.py
+++ b/codebase_rag/trace/xdebug.py
@@ -1,0 +1,169 @@
+"""Convert Xdebug computerized traces to the trace interchange format.
+
+``xdebug.mode=trace`` with ``xdebug.trace_format=1`` records every call as a
+tab-separated entry row carrying the resolved function name (with the
+concrete receiver class, so ``$animal->sound()`` shows which implementation
+ran), whether the function is user-defined, and the call site's file and
+line. Unlike the sampled JS and .NET converters, these are exact call
+records: counts are true invocation counts.
+
+Xdebug never reports where a function is defined, only where it was called
+from. Conversion therefore runs in two passes: the first collects every
+call with its stack parent, and infers each frame's defining file and an
+in-body line from its children's call sites (a call made *by* a function
+necessarily sits inside its body). The second pass emits edges whose
+endpoints carry those recovered positions, which matters because PHP
+qualified names are path-derived (the namespace declaration is ignored), so
+span-based resolution against file plus line is far more reliable than
+names alone.
+
+Internal functions (``call_user_func``, callback-taking array functions)
+and file-inclusion pseudo-frames are glue, not endpoints; edges see through
+them to the nearest user-defined ancestor.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from .. import constants as cs
+from .records import (
+    CallRecord,
+    FramePoint,
+    TraceFormatError,
+    TraceHeader,
+    write_trace_file,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_ENTRY_MIN_COLUMNS = 10
+_COL_LEVEL = 0
+_COL_KIND = 2
+_COL_NAME = 5
+_COL_USER_DEFINED = 6
+_COL_FILENAME = 8
+_COL_LINE = 9
+_KIND_ENTRY = "0"
+
+
+@dataclass(slots=True)
+class _Call:
+    """One observed invocation, linked to the call that made it."""
+
+    qualname: str
+    call_file: str
+    call_line: int
+    transparent: bool
+    parent: int | None
+    defining_file: str = ""
+    defining_line: int = 0
+    children_seen: bool = field(default=False)
+
+
+def _parse_calls(lines: list[str]) -> list[_Call]:
+    calls: list[_Call] = []
+    stack: dict[int, int] = {}
+    for line in lines:
+        columns = line.split("\t")
+        if len(columns) < _ENTRY_MIN_COLUMNS or columns[_COL_KIND] != _KIND_ENTRY:
+            continue
+        try:
+            level = int(columns[_COL_LEVEL])
+            call_line = int(columns[_COL_LINE])
+        except ValueError:
+            continue
+        name = columns[_COL_NAME]
+        call_file = columns[_COL_FILENAME]
+        user_defined = columns[_COL_USER_DEFINED] == "1"
+        transparent = not user_defined or name in cs.TRACE_XDEBUG_GLUE_FUNCTIONS
+
+        parent_index = stack.get(level - 1)
+        call = _Call(
+            qualname=name,
+            call_file=call_file,
+            call_line=call_line,
+            transparent=transparent,
+            parent=parent_index,
+        )
+        if name == cs.TRACE_XDEBUG_MAIN:
+            call.defining_file = call_file
+        index = len(calls)
+        calls.append(call)
+        stack[level] = index
+
+        # This call's site lies inside its parent's body, revealing where
+        # the parent is defined. Glue frames pass the position through.
+        ancestor = parent_index
+        while ancestor is not None and calls[ancestor].transparent:
+            ancestor = calls[ancestor].parent
+        if ancestor is not None and not calls[ancestor].children_seen:
+            calls[ancestor].children_seen = True
+            calls[ancestor].defining_file = call_file
+            calls[ancestor].defining_line = call_line
+    return calls
+
+
+def _nearest_opaque_ancestor(calls: list[_Call], call: _Call) -> _Call | None:
+    ancestor = call.parent
+    while ancestor is not None and calls[ancestor].transparent:
+        ancestor = calls[ancestor].parent
+    return calls[ancestor] if ancestor is not None else None
+
+
+def convert_xdebug_trace(
+    trace_path: Path,
+    output: Path,
+    workload: str | None = None,
+) -> int:
+    """Write ``trace_path``'s call edges to ``output``; returns record count."""
+    lines = trace_path.read_text(encoding="utf-8", errors="replace").splitlines()
+    if not any(line.startswith(cs.TRACE_XDEBUG_FORMAT_LINE) for line in lines[:5]):
+        raise TraceFormatError(cs.TRACE_ERR_BAD_XDEBUG.format(path=trace_path))
+
+    calls = _parse_calls(lines)
+    # Runtime names embed the namespace, so they identify one declaration;
+    # any invocation that revealed its defining position speaks for all of
+    # them, keeping repeated calls aggregated onto a single edge.
+    defining: dict[str, tuple[str, int]] = {}
+    for call in calls:
+        if call.defining_file and call.qualname not in defining:
+            defining[call.qualname] = (call.defining_file, call.defining_line)
+    edges: dict[tuple[FramePoint, FramePoint], int] = {}
+    for call in calls:
+        if call.transparent:
+            continue
+        parent = _nearest_opaque_ancestor(calls, call)
+        if parent is None:
+            continue
+        caller = FramePoint(
+            qualname=parent.qualname, path=call.call_file, line=call.call_line
+        )
+        defining_file, defining_line = defining.get(call.qualname, ("", 0))
+        callee = FramePoint(
+            qualname=call.qualname, path=defining_file, line=defining_line
+        )
+        key = (caller, callee)
+        edges[key] = edges.get(key, 0) + 1
+
+    workloads = (workload,) if workload else ()
+    records = [
+        CallRecord(
+            caller=caller,
+            callee=callee,
+            count=count,
+            workloads=workloads,
+            receiver_types=(),
+        )
+        for (caller, callee), count in edges.items()
+    ]
+    header = TraceHeader(
+        version=cs.TRACE_FORMAT_VERSION,
+        language=cs.TRACE_LANGUAGE_PHP,
+        repo_root="",
+        tracer=cs.TRACE_TOOL_NAME_XDEBUG,
+    )
+    write_trace_file(output, header, records)
+    return len(records)

--- a/docs/guide/dynamic-tracing.md
+++ b/docs/guide/dynamic-tracing.md
@@ -161,7 +161,9 @@ where functions are defined, so the converter recovers each function's
 defining file from its own calls' positions; PHP qualified names are
 path-derived (the namespace declaration is not part of them), and
 resolution is span-first on those recovered positions. Leaf functions that
-never call anything resolve by their `Class::method` name tail instead.
+never call anything resolve by their `Class::method` name tail instead;
+when several declarations share that tail, the frame is counted as
+`unresolved[ambiguous]` rather than guessed.
 Closures resolve through the file and line range embedded in their runtime
 name. Calls through `__call` attribute to the magic method itself, since
 the graph has no notion of the proxied target. Expect significant tracing

--- a/docs/guide/dynamic-tracing.md
+++ b/docs/guide/dynamic-tracing.md
@@ -142,6 +142,32 @@ node, and nested-class `+` to dotted nesting. Two caveats:
   the graph's source-text signatures, so all overloads of a name collapse
   onto one deterministic node.
 
+## Recording a PHP trace
+
+Xdebug's function tracing records every call exactly (no sampling), with
+the concrete receiver class resolved through variable calls,
+`call_user_func`, and magic methods:
+
+```bash
+php -d xdebug.mode=trace -d xdebug.start_with_request=yes \
+    -d xdebug.trace_format=1 -d xdebug.output_dir=. \
+    -d xdebug.trace_output_name=run vendor/bin/phpunit
+cgr trace convert run.xt --workload phpunit
+cgr trace ingest cgr-trace.jsonl --repo-path /path/to/your-repo
+```
+
+Counts are true invocation counts. Xdebug reports call sites rather than
+where functions are defined, so the converter recovers each function's
+defining file from its own calls' positions; PHP qualified names are
+path-derived (the namespace declaration is not part of them), and
+resolution is span-first on those recovered positions. Leaf functions that
+never call anything resolve by their `Class::method` name tail instead.
+Closures resolve through the file and line range embedded in their runtime
+name. Calls through `__call` attribute to the magic method itself, since
+the graph has no notion of the proxied target. Expect significant tracing
+overhead (Xdebug instruments everything); it is meant for test runs, not
+production.
+
 ## Ingesting a trace
 
 Parse the repository into the graph first (`cgr start --repo-path ... --update-graph`),

--- a/docs/guide/dynamic-tracing.md
+++ b/docs/guide/dynamic-tracing.md
@@ -6,12 +6,11 @@ at runtime. Dynamic tracing runs your code (typically the test suite), records
 which functions actually called which, and merges those observations into the
 graph alongside the statically derived `CALLS` edges.
 
-Currently supported for **Python** codebases (Python 3.12+ at runtime, via
-`sys.monitoring`), **Java/Scala** codebases (via a zero-dependency
-`java.lang.instrument` agent, JDK 24+), and **JavaScript/TypeScript** codebases
-(by converting a V8 `--cpu-prof` profile with `cgr trace convert`). Other
-language runtimes are tracked in
-[issue #1244](https://github.com/vitali87/code-graph-rag/issues/1244).
+Currently supported runtimes: **Python** (3.12+, via `sys.monitoring`),
+**Java/Scala** (zero-dependency `java.lang.instrument` agent, JDK 24+),
+**Node.js** (V8 cpuprofile conversion), **.NET** (dotnet-trace speedscope
+conversion), and **PHP** (Xdebug trace conversion). Remaining runtimes are
+tracked in [issue #1244](https://github.com/vitali87/code-graph-rag/issues/1244).
 
 ## Recording a trace
 


### PR DESCRIPTION
Part of #1244, first increment of #1253. **Stacked on #1262** (base branch is `feat/1249-dotnet-dynamic-tracing`); only the last commit is new.

## What

Dynamic call-graph capture for PHP via Xdebug function traces (route 1 from the issue): `xdebug.mode=trace` with the computerized format records **every call exactly** — no sampling — with the concrete receiver class resolved through variable calls, `call_user_func`, and magic methods. `cgr trace convert` now reads `.xt` files, and a `PhpFrameResolver` handles PHP's resolution quirks:

- **Two-pass defining-file recovery.** Xdebug records call sites, never where functions are defined. The converter's first pass infers each function's defining file and an in-body line from its own calls' positions (a call made *by* a function necessarily sits inside its body); the second pass emits edges carrying those recovered positions. This matters because PHP qualified names are path-derived — the namespace declaration is not part of them — so span-based resolution against file+line is far more reliable than names.
- **Resolution**: span-first for any frame with a position (call sites, recovered positions, closures via the file:line range embedded in `{closure:...}` names); `{main}` maps to Module nodes; leaf callees that never call anything fall back to the runtime name's `Class::method` tail (namespace dropped exactly as the graph does). `require`/`include`/`eval` pseudo-frames and internal functions are glue, seen through to the nearest user-defined ancestor.

## Verification

Live end-to-end with PHP 8.5 + Xdebug 3.5.3 against Memgraph (sample with interface dispatch, an array-callable registry, and a variable static method call):

- `describeAnimal -> Dog::sound / Cat::sound` (interface dispatch) — runtime-only, `static_missed: true`
- `Registry::handle -> Registry::greet` (array-callable registry dispatch) — runtime-only
- `{main} -> Registry::handle` via `Registry::$method('greet')` (variable static call, invisible to parsing) — runtime-only
- `{main} -> describeAnimal` (x2, exact counts) and `{main} -> register` confirmed static; 0 unresolved frames

Overhead is documented as significant (Xdebug instruments everything; test runs only). PHPUnit per-test workload provenance is a follow-up; the run-level `--workload` label works today.

14 new unit tests (trace parsing, glue see-through, defining-file recovery, call-site annotation; span/name/closure/module resolution paths; CLI `.xt` sniffing), all red/green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PHP trace support through Xdebug trace conversion.
  * Added automatic resolution of PHP functions, methods, closures, namespaces, and call relationships.
  * Added `.xt` trace conversion through the command-line interface, including workload metadata and clear error reporting.
  * Added support for .NET tracing documentation alongside existing runtimes.

* **Documentation**
  * Documented PHP tracing workflows, resolution behavior, ambiguity handling, and performance considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->