### PR TITLE
feat: add Go runtime call tracing via dependency-free pprof conversion

### DIFF
--- a/codebase_rag/constants/trace.py
+++ b/codebase_rag/constants/trace.py
@@ -28,11 +28,13 @@ TRACE_LANGUAGE_DOTNET = "dotnet"
 TRACE_LANGUAGE_PHP = "php"
 TRACE_LANGUAGE_LUA = "lua"
 TRACE_LANGUAGE_DART = "dart"
+TRACE_LANGUAGE_GO = "go"
 TRACE_TOOL_NAME = "cgr-trace"
 TRACE_TOOL_NAME_JVM = "cgr-trace-jvm"
 TRACE_TOOL_NAME_CPUPROFILE = "cgr-trace-cpuprofile"
 TRACE_TOOL_NAME_SPEEDSCOPE = "cgr-trace-speedscope"
 TRACE_TOOL_NAME_XDEBUG = "cgr-trace-xdebug"
+TRACE_TOOL_NAME_PPROF = "cgr-trace-pprof"
 TRACE_DEFAULT_OUTPUT = "cgr-trace.jsonl"
 
 # Python runtime qualname markers.
@@ -56,6 +58,7 @@ TRACE_DOTNET_CCTOR = "..cctor"
 TRACE_DOTNET_NESTED_MARKER = "+"
 
 # Xdebug computerized-trace markers (trace_format=1, file format 4).
+TRACE_ERR_BAD_PPROF = "{path} is not a pprof CPU profile."
 TRACE_ERR_BAD_XDEBUG = (
     "{path} is not an Xdebug computerized trace (expected 'File format: 4')."
 )

--- a/codebase_rag/tests/test_dynamic_trace_cli.py
+++ b/codebase_rag/tests/test_dynamic_trace_cli.py
@@ -239,6 +239,18 @@ def test_convert_command_fails_cleanly_on_unreadable_xt(tmp_path, monkeypatch):
     assert "denied" in result.output
 
 
+def test_convert_command_sniffs_pprof_and_requires_repo_path(tmp_path):
+    import gzip as gziplib
+
+    profile_path = tmp_path / "cpu.out"
+    profile_path.write_bytes(gziplib.compress(b"\x00"))
+
+    result = CliRunner().invoke(cli, ["convert", str(profile_path)])
+
+    assert result.exit_code == 1
+    assert "--repo-path" in result.output
+
+
 def test_ingest_command_fails_cleanly_on_malformed_trace(tmp_path, monkeypatch):
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/codebase_rag/tests/test_dynamic_trace_cli.py
+++ b/codebase_rag/tests/test_dynamic_trace_cli.py
@@ -154,6 +154,21 @@ def test_convert_command_fails_cleanly_on_malformed_profile(tmp_path):
     assert "cpuprofile" in result.output.lower()
 
 
+def test_convert_command_fails_cleanly_on_non_utf8_profile(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    profile_path = tmp_path / "invalid.profile"
+    profile_path.write_bytes(b"\xff\xfe\x00\x01")
+
+    result = CliRunner().invoke(
+        cli,
+        ["convert", str(profile_path), "--repo-path", str(repo)],
+    )
+
+    assert result.exit_code == 1
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+
+
 def test_convert_command_sniffs_speedscope_and_requires_include(tmp_path):
     import json as jsonlib
 

--- a/codebase_rag/tests/test_dynamic_trace_pprof.py
+++ b/codebase_rag/tests/test_dynamic_trace_pprof.py
@@ -160,6 +160,7 @@ def test_generic_receiver_methods_keep_their_member_name():
     assert _bare_name("main.Map[go.shape.int]") == "Map"
     assert _bare_name("main.(*Box[go.shape.[]uint8]).Put") == "Put"
     assert _bare_name("main.runAll.func1") == "<anonymous>"
+    assert _bare_name("main.runAll.func1.1") == "<anonymous>"
 
 
 def test_workload_label_lands_on_every_record(tmp_path):
@@ -173,6 +174,14 @@ def test_workload_label_lands_on_every_record(tmp_path):
 def test_malformed_profile_is_rejected(tmp_path):
     profile_path = tmp_path / "broken.out"
     profile_path.write_bytes(b"not a pprof")
+
+    with pytest.raises(ValueError):
+        convert_pprof(profile_path, repo_root=tmp_path, output=tmp_path / "out.jsonl")
+
+
+def test_truncated_gzip_profile_is_rejected(tmp_path):
+    profile_path = tmp_path / "truncated.out"
+    profile_path.write_bytes(gzip.compress(b"pprof")[:-3])
 
     with pytest.raises(ValueError):
         convert_pprof(profile_path, repo_root=tmp_path, output=tmp_path / "out.jsonl")

--- a/codebase_rag/tests/test_dynamic_trace_pprof.py
+++ b/codebase_rag/tests/test_dynamic_trace_pprof.py
@@ -153,6 +153,15 @@ def test_closures_and_methods_normalise(tmp_path):
     assert method.callee.line == 38
 
 
+def test_generic_receiver_methods_keep_their_member_name():
+    from codebase_rag.trace.pprof import _bare_name
+
+    assert _bare_name("example.com/pkg.(*Cache[go.shape.string]).Get") == "Get"
+    assert _bare_name("main.Map[go.shape.int]") == "Map"
+    assert _bare_name("main.(*Box[go.shape.[]uint8]).Put") == "Put"
+    assert _bare_name("main.runAll.func1") == "<anonymous>"
+
+
 def test_workload_label_lands_on_every_record(tmp_path):
     _count, _header, records = _convert(tmp_path, workload="go-test")
 

--- a/codebase_rag/tests/test_dynamic_trace_pprof.py
+++ b/codebase_rag/tests/test_dynamic_trace_pprof.py
@@ -1,0 +1,169 @@
+# Go pprof CPU profiles are gzipped protobufs whose samples reference
+# locations, lines, and functions; the converter must decode the wire
+# format without dependencies, normalize Go symbol names, and emit
+# interchange call records (issue #1250).
+
+from __future__ import annotations
+
+import gzip
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.trace.pprof import convert_pprof
+from codebase_rag.trace.records import read_trace_file
+
+
+def _varint(value: int) -> bytes:
+    out = bytearray()
+    while True:
+        bits = value & 0x7F
+        value >>= 7
+        if value:
+            out.append(bits | 0x80)
+        else:
+            out.append(bits)
+            return bytes(out)
+
+
+def _uint(field: int, value: int) -> bytes:
+    return _varint(field << 3) + _varint(value)
+
+
+def _msg(field: int, payload: bytes) -> bytes:
+    return _varint((field << 3) | 2) + _varint(len(payload)) + payload
+
+
+def _string(field: int, value: str) -> bytes:
+    return _msg(field, value.encode())
+
+
+def _function(fid, name_idx, filename_idx, start_line):
+    return _msg(
+        5,
+        _uint(1, fid)
+        + _uint(2, name_idx)
+        + _uint(4, filename_idx)
+        + _uint(5, start_line),
+    )
+
+
+def _location(lid, entries):
+    payload = _uint(1, lid)
+    for function_id, line in entries:
+        payload += _msg(4, _uint(1, function_id) + _uint(2, line))
+    return _msg(4, payload)
+
+
+def _sample(location_ids, value):
+    payload = b"".join(_uint(1, lid) for lid in location_ids)
+    payload += _uint(2, value)
+    return _msg(2, payload)
+
+
+def _profile(tmp_path):
+    repo = tmp_path.as_posix()
+    strings = [
+        "",
+        "main.main",
+        "main.runAll",
+        "main.handle",
+        "main.greet",
+        "main.runAll.func1",
+        "runtime.mapaccess1",
+        "main.(*Dog).Sound",
+        f"{repo}/main.go",
+        f"{repo}/registry.go",
+        "/usr/lib/go/src/runtime/map.go",
+        f"{repo}/vendor/dep/dep.go",
+        "vendor.Dep",
+    ]
+    idx = {value: position for position, value in enumerate(strings)}
+    payload = b""
+    # Samples reference locations leaf-first.
+    payload += _sample([4, 3, 2, 1], 7)  # greet <- handle <- runAll <- main
+    payload += _sample([4, 6, 3, 2, 1], 2)  # runtime frame between
+    payload += _sample([5, 2, 1], 3)  # closure under runAll
+    payload += _sample([7, 2, 1], 4)  # method frame
+    payload += _sample([8, 1], 9)  # vendored callee
+    payload += _location(1, [(1, 30)])
+    payload += _location(2, [(2, 12)])
+    payload += _location(3, [(3, 21)])
+    payload += _location(4, [(4, 26)])
+    payload += _location(5, [(5, 14)])
+    payload += _location(6, [(6, 100)])
+    payload += _location(7, [(7, 40)])
+    payload += _location(8, [(8, 5)])
+    payload += _function(1, idx["main.main"], idx[f"{repo}/main.go"], 28)
+    payload += _function(2, idx["main.runAll"], idx[f"{repo}/main.go"], 10)
+    payload += _function(3, idx["main.handle"], idx[f"{repo}/registry.go"], 19)
+    payload += _function(4, idx["main.greet"], idx[f"{repo}/registry.go"], 24)
+    payload += _function(5, idx["main.runAll.func1"], idx[f"{repo}/main.go"], 13)
+    payload += _function(
+        6, idx["runtime.mapaccess1"], idx["/usr/lib/go/src/runtime/map.go"], 90
+    )
+    payload += _function(7, idx["main.(*Dog).Sound"], idx[f"{repo}/main.go"], 38)
+    payload += _function(8, idx["vendor.Dep"], idx[f"{repo}/vendor/dep/dep.go"], 3)
+    for value in strings:
+        payload += _string(6, value)
+    return payload
+
+
+def _convert(tmp_path, workload=None):
+    profile_path = tmp_path / "cpu.out"
+    profile_path.write_bytes(gzip.compress(_profile(tmp_path)))
+    output = tmp_path / "trace.jsonl"
+    count = convert_pprof(
+        profile_path, repo_root=tmp_path, output=output, workload=workload
+    )
+    header, records = read_trace_file(output)
+    return count, header, list(records)
+
+
+def test_converts_stacks_to_edges_with_sample_weights(tmp_path):
+    count, header, records = _convert(tmp_path)
+
+    assert header.language == cs.TRACE_LANGUAGE_GO
+    assert count == len(records)
+    edges = {(r.caller.qualname, r.callee.qualname): r for r in records}
+    dispatch = edges[("handle", "greet")]
+    assert dispatch.count == 9  # 7 direct + 2 through the runtime frame
+    assert dispatch.callee.path.endswith("registry.go")
+    # Identity is the declaration line, matching graph start_lines.
+    assert dispatch.callee.line == 24
+    assert edges[("main", "runAll")].count == 16
+
+
+def test_runtime_and_vendored_frames_are_out_of_scope(tmp_path):
+    _count, _header, records = _convert(tmp_path)
+
+    for record in records:
+        assert "runtime" not in record.caller.qualname
+        assert "runtime" not in record.callee.qualname
+        assert "/vendor/" not in record.caller.path
+        assert "/vendor/" not in record.callee.path
+
+
+def test_closures_and_methods_normalise(tmp_path):
+    _count, _header, records = _convert(tmp_path)
+
+    edges = {(r.caller.qualname, r.callee.qualname): r for r in records}
+    assert ("runAll", cs.TRACE_QUALNAME_ANONYMOUS) in edges
+    method = edges[("runAll", "Sound")]
+    assert method.callee.line == 38
+
+
+def test_workload_label_lands_on_every_record(tmp_path):
+    _count, _header, records = _convert(tmp_path, workload="go-test")
+
+    assert records
+    for record in records:
+        assert record.workloads == ("go-test",)
+
+
+def test_malformed_profile_is_rejected(tmp_path):
+    profile_path = tmp_path / "broken.out"
+    profile_path.write_bytes(b"not a pprof")
+
+    with pytest.raises(ValueError):
+        convert_pprof(profile_path, repo_root=tmp_path, output=tmp_path / "out.jsonl")

--- a/codebase_rag/tests/test_dynamic_trace_records.py
+++ b/codebase_rag/tests/test_dynamic_trace_records.py
@@ -145,4 +145,5 @@ def test_lua_language_tag_constant():
 
     importlib.reload(trace_constants)
     assert trace_constants.TRACE_LANGUAGE_LUA == "lua"
+    assert trace_constants.TRACE_LANGUAGE_GO == "go"
     assert trace_constants.TRACE_LANGUAGE_DART == "dart"

--- a/codebase_rag/trace/cli.py
+++ b/codebase_rag/trace/cli.py
@@ -177,7 +177,13 @@ def convert_cmd(
         count = _convert_profile(
             profile_file, repo_path, resolved_output, include, workload
         )
-    except (TraceFormatError, OSError, json.JSONDecodeError, _ConvertUsageError) as e:
+    except (
+        TraceFormatError,
+        OSError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        _ConvertUsageError,
+    ) as e:
         logger.error(str(e))
         click.secho(str(e), fg="red", err=True)
         sys.exit(1)

--- a/codebase_rag/trace/cli.py
+++ b/codebase_rag/trace/cli.py
@@ -114,7 +114,33 @@ def convert_cmd(
         click.secho(message, fg="red", err=True)
         sys.exit(1)
 
+    from .pprof import convert_pprof
     from .xdebug import convert_xdebug_trace
+
+    magic = b""
+    try:
+        with profile_file.open("rb") as fh:
+            magic = fh.read(2)
+    except OSError as e:
+        _fail(str(e))
+        return
+    if magic == b"\x1f\x8b" or profile_file.suffix == ".pprof":
+        # Go pprof CPU profiles are gzipped protobufs.
+        if repo_path is None:
+            _fail(ch.ERR_TRACE_CONVERT_NEEDS_REPO)
+            return
+        try:
+            count = convert_pprof(
+                profile_file,
+                repo_root=repo_path,
+                output=resolved_output,
+                workload=workload,
+            )
+        except (TraceFormatError, OSError) as e:
+            _fail(str(e))
+            return
+        click.echo(f"call records written: {count} -> {resolved_output}")
+        return
 
     if profile_file.suffix == ".xt":
         try:

--- a/codebase_rag/trace/cli.py
+++ b/codebase_rag/trace/cli.py
@@ -70,6 +70,71 @@ def ingest_cmd(trace_file: Path, repo_path: Path, project_name: str | None) -> N
         click.echo(f"  unresolved[{reason}]: {count}")
 
 
+class _ConvertUsageError(Exception):
+    """A convert invocation missing an option the detected format requires."""
+
+
+def _convert_profile(
+    profile_file: Path,
+    repo_path: Path | None,
+    resolved_output: Path,
+    include: str | None,
+    workload: str | None,
+) -> int:
+    """Dispatch by profile format and write records; returns the record count.
+
+    Raises ``_ConvertUsageError`` when the format needs an option the caller
+    did not supply, and ``TraceFormatError``/``OSError``/``JSONDecodeError``
+    for unreadable or malformed profiles.
+    """
+    import json
+
+    with profile_file.open("rb") as fh:
+        magic = fh.read(2)
+
+    if magic == b"\x1f\x8b" or profile_file.suffix == ".pprof":
+        # Go pprof CPU profiles are gzipped protobufs.
+        from .pprof import convert_pprof
+
+        if repo_path is None:
+            raise _ConvertUsageError(ch.ERR_TRACE_CONVERT_NEEDS_REPO)
+        return convert_pprof(
+            profile_file, repo_root=repo_path, output=resolved_output, workload=workload
+        )
+
+    if profile_file.suffix == ".xt":
+        from .xdebug import convert_xdebug_trace
+
+        return convert_xdebug_trace(
+            profile_file, output=resolved_output, workload=workload
+        )
+
+    raw = json.loads(profile_file.read_text(encoding="utf-8"))
+    looks_like_cpuprofile = (isinstance(raw, dict) and "nodes" in raw) or (
+        profile_file.suffix == ".cpuprofile"
+    )
+    if looks_like_cpuprofile:
+        # V8 cpuprofile: frames carry file URLs, so scoping needs the repo.
+        from .cpuprofile import convert_cpuprofile
+
+        if repo_path is None:
+            raise _ConvertUsageError(ch.ERR_TRACE_CONVERT_NEEDS_REPO)
+        return convert_cpuprofile(
+            profile_file, repo_root=repo_path, output=resolved_output, workload=workload
+        )
+
+    # dotnet-trace speedscope: frames carry no paths, so scoping needs
+    # namespace prefixes.
+    from .speedscope import convert_speedscope
+
+    prefixes = tuple(p.strip() for p in (include or "").split(",") if p.strip())
+    if not prefixes:
+        raise _ConvertUsageError(ch.ERR_TRACE_CONVERT_NEEDS_INCLUDE)
+    return convert_speedscope(
+        profile_file, output=resolved_output, include=prefixes, workload=workload
+    )
+
+
 @cli.command(
     "convert",
     help=ch.CMD_TRACE_CONVERT,
@@ -108,89 +173,12 @@ def convert_cmd(
     from .records import TraceFormatError
 
     resolved_output = output or Path(cs.TRACE_DEFAULT_OUTPUT)
-
-    def _fail(message: str) -> None:
-        logger.error(message)
-        click.secho(message, fg="red", err=True)
+    try:
+        count = _convert_profile(
+            profile_file, repo_path, resolved_output, include, workload
+        )
+    except (TraceFormatError, OSError, json.JSONDecodeError, _ConvertUsageError) as e:
+        logger.error(str(e))
+        click.secho(str(e), fg="red", err=True)
         sys.exit(1)
-
-    from .pprof import convert_pprof
-    from .xdebug import convert_xdebug_trace
-
-    magic = b""
-    try:
-        with profile_file.open("rb") as fh:
-            magic = fh.read(2)
-    except OSError as e:
-        _fail(str(e))
-        return
-    if magic == b"\x1f\x8b" or profile_file.suffix == ".pprof":
-        # Go pprof CPU profiles are gzipped protobufs.
-        if repo_path is None:
-            _fail(ch.ERR_TRACE_CONVERT_NEEDS_REPO)
-            return
-        try:
-            count = convert_pprof(
-                profile_file,
-                repo_root=repo_path,
-                output=resolved_output,
-                workload=workload,
-            )
-        except (TraceFormatError, OSError) as e:
-            _fail(str(e))
-            return
-        click.echo(f"call records written: {count} -> {resolved_output}")
-        return
-
-    if profile_file.suffix == ".xt":
-        try:
-            count = convert_xdebug_trace(
-                profile_file, output=resolved_output, workload=workload
-            )
-        except (TraceFormatError, OSError) as e:
-            _fail(str(e))
-            return
-        click.echo(f"call records written: {count} -> {resolved_output}")
-        return
-
-    try:
-        raw = json.loads(profile_file.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as e:
-        _fail(str(e))
-        return
-    looks_like_cpuprofile = (isinstance(raw, dict) and "nodes" in raw) or (
-        profile_file.suffix == ".cpuprofile"
-    )
-    try:
-        if looks_like_cpuprofile:
-            # V8 cpuprofile: frames carry file URLs, so scoping needs the repo.
-            if repo_path is None:
-                _fail(ch.ERR_TRACE_CONVERT_NEEDS_REPO)
-                return
-            from .cpuprofile import convert_cpuprofile
-
-            count = convert_cpuprofile(
-                profile_file,
-                repo_root=repo_path,
-                output=resolved_output,
-                workload=workload,
-            )
-        else:
-            # dotnet-trace speedscope: frames carry no paths, so scoping
-            # needs namespace prefixes.
-            prefixes = tuple(p.strip() for p in (include or "").split(",") if p.strip())
-            if not prefixes:
-                _fail(ch.ERR_TRACE_CONVERT_NEEDS_INCLUDE)
-                return
-            from .speedscope import convert_speedscope
-
-            count = convert_speedscope(
-                profile_file,
-                output=resolved_output,
-                include=prefixes,
-                workload=workload,
-            )
-    except TraceFormatError as e:
-        _fail(str(e))
-        return
     click.echo(f"call records written: {count} -> {resolved_output}")

--- a/codebase_rag/trace/ingest.py
+++ b/codebase_rag/trace/ingest.py
@@ -53,6 +53,7 @@ def _resolver_for(
         cs.TRACE_LANGUAGE_JS,
         cs.TRACE_LANGUAGE_LUA,
         cs.TRACE_LANGUAGE_DART,
+        cs.TRACE_LANGUAGE_GO,
     ):
         # Lua-agent and Dart-collector frames share V8's shape: repo paths,
         # bare runtime names, 1-based definition lines, <module>/<anonymous>

--- a/codebase_rag/trace/pprof.py
+++ b/codebase_rag/trace/pprof.py
@@ -181,10 +181,14 @@ def _bare_name(symbol: str) -> str:
     segments = [s for s in tail.split(".") if s and not s.startswith("(")]
     if not segments:
         return cs.TRACE_QUALNAME_ANONYMOUS
-    leaf = segments[-1]
-    if _GO_CLOSURE_SEGMENT.match(leaf):
+    # A nested closure surfaces as `main.runAll.func1.1`; its final segment is
+    # a bare number, so test every trailing run of segments, not just the leaf.
+    if any(
+        _GO_CLOSURE_SEGMENT.fullmatch(".".join(segments[index:]))
+        for index in range(len(segments))
+    ):
         return cs.TRACE_QUALNAME_ANONYMOUS
-    return leaf
+    return segments[-1]
 
 
 def convert_pprof(
@@ -196,7 +200,12 @@ def convert_pprof(
     """Write ``profile_path``'s project call edges to ``output``; returns count."""
     raw = profile_path.read_bytes()
     if raw[:2] == b"\x1f\x8b":
-        raw = gzip.decompress(raw)
+        try:
+            raw = gzip.decompress(raw)
+        except (OSError, EOFError) as e:
+            raise TraceFormatError(
+                cs.TRACE_ERR_BAD_PPROF.format(path=profile_path)
+            ) from e
     try:
         parsed = list(_fields(raw))
     except TraceFormatError as e:

--- a/codebase_rag/trace/pprof.py
+++ b/codebase_rag/trace/pprof.py
@@ -158,9 +158,26 @@ def _bare_name(symbol: str) -> str:
     drop. Compiler-generated closure segments mark the frame anonymous.
     """
     tail = symbol.rsplit("/", 1)[-1]
-    bracket = tail.find("[")
-    if bracket >= 0:
-        tail = tail[:bracket]
+    # Remove generic instantiations without discarding what follows them:
+    # `(*Cache[go.shape.string]).Get` must keep `.Get`. Brackets nest in
+    # shape types, so strip balanced groups, not up to the first `]`.
+    while True:
+        start = tail.find("[")
+        if start < 0:
+            break
+        depth = 0
+        end = start
+        for end in range(start, len(tail)):
+            if tail[end] == "[":
+                depth += 1
+            elif tail[end] == "]":
+                depth -= 1
+                if depth == 0:
+                    break
+        if depth != 0:
+            tail = tail[:start]
+            break
+        tail = tail[:start] + tail[end + 1 :]
     segments = [s for s in tail.split(".") if s and not s.startswith("(")]
     if not segments:
         return cs.TRACE_QUALNAME_ANONYMOUS

--- a/codebase_rag/trace/pprof.py
+++ b/codebase_rag/trace/pprof.py
@@ -39,8 +39,10 @@ from .records import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
     from pathlib import Path
+
+_Sample = tuple[list[int], int]
 
 _WIRE_VARINT = 0
 _WIRE_FIXED64 = 1
@@ -150,6 +152,36 @@ def _parse_sample(payload: bytes) -> tuple[list[int], int]:
     return location_ids, max(weight, 1)
 
 
+def _matching_bracket(text: str, start: int) -> int:
+    """Index of the ``]`` closing the ``[`` at ``start``, or -1 if unbalanced."""
+    depth = 0
+    for index in range(start, len(text)):
+        if text[index] == "[":
+            depth += 1
+        elif text[index] == "]":
+            depth -= 1
+            if depth == 0:
+                return index
+    return -1
+
+
+def _strip_generics(tail: str) -> str:
+    """Drop ``[...]`` generic instantiations, keeping what follows them.
+
+    `(*Cache[go.shape.string]).Get` must keep `.Get`. Brackets nest in
+    shape types, so remove balanced groups rather than up to the first `]`;
+    an unbalanced group truncates the remainder.
+    """
+    while True:
+        start = tail.find("[")
+        if start < 0:
+            return tail
+        end = _matching_bracket(tail, start)
+        if end < 0:
+            return tail[:start]
+        tail = tail[:start] + tail[end + 1 :]
+
+
 def _bare_name(symbol: str) -> str:
     """``example.com/pkg.(*Dog).Sound`` as the member name ``Sound``.
 
@@ -157,27 +189,7 @@ def _bare_name(symbol: str) -> str:
     a tiebreak, so package paths, receivers, and generic instantiations
     drop. Compiler-generated closure segments mark the frame anonymous.
     """
-    tail = symbol.rsplit("/", 1)[-1]
-    # Remove generic instantiations without discarding what follows them:
-    # `(*Cache[go.shape.string]).Get` must keep `.Get`. Brackets nest in
-    # shape types, so strip balanced groups, not up to the first `]`.
-    while True:
-        start = tail.find("[")
-        if start < 0:
-            break
-        depth = 0
-        end = start
-        for end in range(start, len(tail)):
-            if tail[end] == "[":
-                depth += 1
-            elif tail[end] == "]":
-                depth -= 1
-                if depth == 0:
-                    break
-        if depth != 0:
-            tail = tail[:start]
-            break
-        tail = tail[:start] + tail[end + 1 :]
+    tail = _strip_generics(symbol.rsplit("/", 1)[-1])
     segments = [s for s in tail.split(".") if s and not s.startswith("(")]
     if not segments:
         return cs.TRACE_QUALNAME_ANONYMOUS
@@ -191,31 +203,25 @@ def _bare_name(symbol: str) -> str:
     return segments[-1]
 
 
-def convert_pprof(
-    profile_path: Path,
-    repo_root: Path,
-    output: Path,
-    workload: str | None = None,
-) -> int:
-    """Write ``profile_path``'s project call edges to ``output``; returns count."""
-    raw = profile_path.read_bytes()
-    if raw[:2] == b"\x1f\x8b":
-        try:
-            raw = gzip.decompress(raw)
-        except (OSError, EOFError) as e:
-            raise TraceFormatError(
-                cs.TRACE_ERR_BAD_PPROF.format(path=profile_path)
-            ) from e
+def _decompress(raw: bytes, profile_path: Path) -> bytes:
+    """Gunzip a gzipped profile; malformed input becomes a TraceFormatError."""
+    if raw[:2] != b"\x1f\x8b":
+        return raw
     try:
-        parsed = list(_fields(raw))
-    except TraceFormatError as e:
+        return gzip.decompress(raw)
+    except (OSError, EOFError) as e:
         raise TraceFormatError(cs.TRACE_ERR_BAD_PPROF.format(path=profile_path)) from e
 
+
+def _decode_profile(
+    raw: bytes,
+) -> tuple[list[str], dict[int, _Function], dict[int, list[int]], list[_Sample]]:
+    """The pprof message's string, function, location, and sample tables."""
     strings: list[str] = []
     functions: dict[int, _Function] = {}
     locations: dict[int, list[int]] = {}
-    samples: list[tuple[list[int], int]] = []
-    for field, _wire, value in parsed:
+    samples: list[_Sample] = []
+    for field, _wire, value in _fields(raw):
         if not isinstance(value, bytes):
             continue
         if field == 2:
@@ -228,6 +234,65 @@ def convert_pprof(
             functions[function_id] = function
         elif field == 6:
             strings.append(value.decode("utf-8", errors="replace"))
+    return strings, functions, locations, samples
+
+
+def _build_frame(
+    function: _Function | None, strings: list[str], root_prefix: str
+) -> FramePoint | None:
+    """A project FramePoint for the function, or None if out of scope."""
+    if function is None or not (0 < function.filename_index < len(strings)):
+        return None
+    path = strings[function.filename_index]
+    if not path.startswith(root_prefix):
+        return None
+    if _GO_EXCLUDED_DIR in path[len(root_prefix) :].split("/"):
+        return None
+    name = (
+        strings[function.name_index] if 0 < function.name_index < len(strings) else ""
+    )
+    return FramePoint(
+        path=path, qualname=_bare_name(name), line=max(function.start_line, 0)
+    )
+
+
+def _accumulate_edges(
+    samples: list[_Sample],
+    locations: dict[int, list[int]],
+    resolve: Callable[[int], FramePoint | None],
+) -> dict[tuple[FramePoint, FramePoint], int]:
+    """Adjacent in-project frames across each leaf-first sampled stack.
+
+    Samples are leaf-first; walk root-first, expanding inline frames
+    outermost-first within each location.
+    """
+    edges: dict[tuple[FramePoint, FramePoint], int] = {}
+    for location_ids, weight in samples:
+        ancestor: FramePoint | None = None
+        for location_id in reversed(location_ids):
+            for function_id in reversed(locations.get(location_id, [])):
+                frame = resolve(function_id)
+                if frame is None:
+                    continue
+                if ancestor is not None:
+                    key = (ancestor, frame)
+                    edges[key] = edges.get(key, 0) + weight
+                ancestor = frame
+    return edges
+
+
+def convert_pprof(
+    profile_path: Path,
+    repo_root: Path,
+    output: Path,
+    workload: str | None = None,
+) -> int:
+    """Write ``profile_path``'s project call edges to ``output``; returns count."""
+    raw = _decompress(profile_path.read_bytes(), profile_path)
+    try:
+        strings, functions, locations, samples = _decode_profile(raw)
+    except TraceFormatError as e:
+        raise TraceFormatError(cs.TRACE_ERR_BAD_PPROF.format(path=profile_path)) from e
     if not strings or not functions or not samples:
         raise TraceFormatError(cs.TRACE_ERR_BAD_PPROF.format(path=profile_path))
 
@@ -235,42 +300,13 @@ def convert_pprof(
     frames: dict[int, FramePoint | None] = {}
 
     def _frame(function_id: int) -> FramePoint | None:
-        if function_id in frames:
-            return frames[function_id]
-        built = None
-        function = functions.get(function_id)
-        if function is not None and 0 < function.filename_index < len(strings):
-            path = strings[function.filename_index]
-            in_repo = path.startswith(root_prefix)
-            parts = path[len(root_prefix) :].split("/") if in_repo else []
-            if in_repo and _GO_EXCLUDED_DIR not in parts:
-                name = (
-                    strings[function.name_index]
-                    if 0 < function.name_index < len(strings)
-                    else ""
-                )
-                built = FramePoint(
-                    path=path,
-                    qualname=_bare_name(name),
-                    line=max(function.start_line, 0),
-                )
-        frames[function_id] = built
-        return built
+        if function_id not in frames:
+            frames[function_id] = _build_frame(
+                functions.get(function_id), strings, root_prefix
+            )
+        return frames[function_id]
 
-    edges: dict[tuple[FramePoint, FramePoint], int] = {}
-    for location_ids, weight in samples:
-        ancestor: FramePoint | None = None
-        # Samples are leaf-first; walk root-first, expanding inline frames
-        # outermost-first within each location.
-        for location_id in reversed(location_ids):
-            for function_id in reversed(locations.get(location_id, [])):
-                frame = _frame(function_id)
-                if frame is None:
-                    continue
-                if ancestor is not None:
-                    key = (ancestor, frame)
-                    edges[key] = edges.get(key, 0) + weight
-                ancestor = frame
+    edges = _accumulate_edges(samples, locations, _frame)
 
     workloads = (workload,) if workload else ()
     records = [

--- a/codebase_rag/trace/pprof.py
+++ b/codebase_rag/trace/pprof.py
@@ -1,0 +1,267 @@
+"""Convert Go pprof CPU profiles to the trace interchange format.
+
+``go test -cpuprofile`` and ``runtime/pprof`` write gzipped protobuf
+profiles whose samples are observed stacks: locations reference functions
+with symbol names, source files, and declaration lines. Parent/child
+adjacency within a sampled stack is a caller/callee relationship the
+sampler actually saw, so dispatch through interface values and function
+values appears whenever samples landed there. Counts are sample counts,
+not call counts.
+
+The wire decoding below is deliberately dependency-free: pprof's schema is
+small and stable, and only samples, locations, lines, functions, and the
+string table are needed. Frames outside the repository (the Go runtime,
+the standard library, module cache) and vendored code are glue; edges see
+through them to the nearest project frame.
+
+Go symbol names carry package paths, receivers, and generic instantiations
+(``example.com/pkg.(*Dog).Sound``, ``main.Map[go.shape.int]``); resolution
+is span-first against declaration lines, so names normalise to their bare
+member form and compiler-generated closure symbols (``runAll.func1``)
+become ``<anonymous>``. Traced builds should disable inlining
+(``-gcflags=all=-l``) or inlined callees vanish from the profile.
+"""
+
+from __future__ import annotations
+
+import gzip
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from .. import constants as cs
+from .records import (
+    CallRecord,
+    FramePoint,
+    TraceFormatError,
+    TraceHeader,
+    write_trace_file,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+_WIRE_VARINT = 0
+_WIRE_FIXED64 = 1
+_WIRE_LEN = 2
+_WIRE_FIXED32 = 5
+
+_GO_CLOSURE_SEGMENT = re.compile(r"^func\d+(\.\d+)*$")
+_GO_EXCLUDED_DIR = "vendor"
+
+
+def _fields(data: bytes) -> Iterator[tuple[int, int, bytes | int]]:
+    position = 0
+    length = len(data)
+    while position < length:
+        tag, position = _varint(data, position)
+        field, wire = tag >> 3, tag & 0x7
+        if wire == _WIRE_VARINT:
+            value, position = _varint(data, position)
+            yield field, wire, value
+        elif wire == _WIRE_LEN:
+            size, position = _varint(data, position)
+            yield field, wire, data[position : position + size]
+            position += size
+        elif wire == _WIRE_FIXED64:
+            yield field, wire, int.from_bytes(data[position : position + 8], "little")
+            position += 8
+        elif wire == _WIRE_FIXED32:
+            yield field, wire, int.from_bytes(data[position : position + 4], "little")
+            position += 4
+        else:
+            raise TraceFormatError(str(wire))
+
+
+def _varint(data: bytes, position: int) -> tuple[int, int]:
+    result = 0
+    shift = 0
+    while True:
+        if position >= len(data):
+            raise TraceFormatError("truncated varint")
+        byte = data[position]
+        position += 1
+        result |= (byte & 0x7F) << shift
+        if not byte & 0x80:
+            return result, position
+        shift += 7
+
+
+def _repeated_uint(wire: int, value: bytes | int) -> list[int]:
+    """A repeated uint64 field arrives packed or one element at a time."""
+    if wire == _WIRE_VARINT and isinstance(value, int):
+        return [value]
+    if wire == _WIRE_LEN and isinstance(value, bytes):
+        out = []
+        position = 0
+        while position < len(value):
+            element, position = _varint(value, position)
+            out.append(element)
+        return out
+    return []
+
+
+@dataclass(slots=True)
+class _Function:
+    name_index: int = 0
+    filename_index: int = 0
+    start_line: int = 0
+
+
+def _parse_function(payload: bytes) -> tuple[int, _Function]:
+    function_id = 0
+    function = _Function()
+    for field, _wire, value in _fields(payload):
+        if field == 1 and isinstance(value, int):
+            function_id = value
+        elif field == 2 and isinstance(value, int):
+            function.name_index = value
+        elif field == 4 and isinstance(value, int):
+            function.filename_index = value
+        elif field == 5 and isinstance(value, int):
+            function.start_line = value
+    return function_id, function
+
+
+def _parse_location(payload: bytes) -> tuple[int, list[int]]:
+    """A location's function ids, innermost inline frame first."""
+    location_id = 0
+    function_ids: list[int] = []
+    for field, _wire, value in _fields(payload):
+        if field == 1 and isinstance(value, int):
+            location_id = value
+        elif field == 4 and isinstance(value, bytes):
+            for line_field, _lw, line_value in _fields(value):
+                if line_field == 1 and isinstance(line_value, int):
+                    function_ids.append(line_value)
+    return location_id, function_ids
+
+
+def _parse_sample(payload: bytes) -> tuple[list[int], int]:
+    location_ids: list[int] = []
+    weight = 0
+    for field, wire, value in _fields(payload):
+        if field == 1:
+            location_ids.extend(_repeated_uint(wire, value))
+        elif field == 2 and not weight:
+            values = _repeated_uint(wire, value)
+            weight = values[0] if values else 0
+    return location_ids, max(weight, 1)
+
+
+def _bare_name(symbol: str) -> str:
+    """``example.com/pkg.(*Dog).Sound`` as the member name ``Sound``.
+
+    Span resolution against declaration lines carries identity; the name is
+    a tiebreak, so package paths, receivers, and generic instantiations
+    drop. Compiler-generated closure segments mark the frame anonymous.
+    """
+    tail = symbol.rsplit("/", 1)[-1]
+    bracket = tail.find("[")
+    if bracket >= 0:
+        tail = tail[:bracket]
+    segments = [s for s in tail.split(".") if s and not s.startswith("(")]
+    if not segments:
+        return cs.TRACE_QUALNAME_ANONYMOUS
+    leaf = segments[-1]
+    if _GO_CLOSURE_SEGMENT.match(leaf):
+        return cs.TRACE_QUALNAME_ANONYMOUS
+    return leaf
+
+
+def convert_pprof(
+    profile_path: Path,
+    repo_root: Path,
+    output: Path,
+    workload: str | None = None,
+) -> int:
+    """Write ``profile_path``'s project call edges to ``output``; returns count."""
+    raw = profile_path.read_bytes()
+    if raw[:2] == b"\x1f\x8b":
+        raw = gzip.decompress(raw)
+    try:
+        parsed = list(_fields(raw))
+    except TraceFormatError as e:
+        raise TraceFormatError(cs.TRACE_ERR_BAD_PPROF.format(path=profile_path)) from e
+
+    strings: list[str] = []
+    functions: dict[int, _Function] = {}
+    locations: dict[int, list[int]] = {}
+    samples: list[tuple[list[int], int]] = []
+    for field, _wire, value in parsed:
+        if not isinstance(value, bytes):
+            continue
+        if field == 2:
+            samples.append(_parse_sample(value))
+        elif field == 4:
+            location_id, function_ids = _parse_location(value)
+            locations[location_id] = function_ids
+        elif field == 5:
+            function_id, function = _parse_function(value)
+            functions[function_id] = function
+        elif field == 6:
+            strings.append(value.decode("utf-8", errors="replace"))
+    if not strings or not functions or not samples:
+        raise TraceFormatError(cs.TRACE_ERR_BAD_PPROF.format(path=profile_path))
+
+    root_prefix = repo_root.resolve().as_posix() + "/"
+    frames: dict[int, FramePoint | None] = {}
+
+    def _frame(function_id: int) -> FramePoint | None:
+        if function_id in frames:
+            return frames[function_id]
+        built = None
+        function = functions.get(function_id)
+        if function is not None and 0 < function.filename_index < len(strings):
+            path = strings[function.filename_index]
+            in_repo = path.startswith(root_prefix)
+            parts = path[len(root_prefix) :].split("/") if in_repo else []
+            if in_repo and _GO_EXCLUDED_DIR not in parts:
+                name = (
+                    strings[function.name_index]
+                    if 0 < function.name_index < len(strings)
+                    else ""
+                )
+                built = FramePoint(
+                    path=path,
+                    qualname=_bare_name(name),
+                    line=max(function.start_line, 0),
+                )
+        frames[function_id] = built
+        return built
+
+    edges: dict[tuple[FramePoint, FramePoint], int] = {}
+    for location_ids, weight in samples:
+        ancestor: FramePoint | None = None
+        # Samples are leaf-first; walk root-first, expanding inline frames
+        # outermost-first within each location.
+        for location_id in reversed(location_ids):
+            for function_id in reversed(locations.get(location_id, [])):
+                frame = _frame(function_id)
+                if frame is None:
+                    continue
+                if ancestor is not None:
+                    key = (ancestor, frame)
+                    edges[key] = edges.get(key, 0) + weight
+                ancestor = frame
+
+    workloads = (workload,) if workload else ()
+    records = [
+        CallRecord(
+            caller=caller,
+            callee=callee,
+            count=count,
+            workloads=workloads,
+            receiver_types=(),
+        )
+        for (caller, callee), count in edges.items()
+    ]
+    header = TraceHeader(
+        version=cs.TRACE_FORMAT_VERSION,
+        language=cs.TRACE_LANGUAGE_GO,
+        repo_root=str(repo_root),
+        tracer=cs.TRACE_TOOL_NAME_PPROF,
+    )
+    write_trace_file(output, header, records)
+    return len(records)

--- a/docs/guide/dynamic-tracing.md
+++ b/docs/guide/dynamic-tracing.md
@@ -223,10 +223,15 @@ Go's own profiler does the capture; `go test` exposes it directly, and the
 converter reads the pprof protobuf without dependencies:
 
 ```bash
-go test -cpuprofile cpu.out -gcflags=all=-l ./...
+go test -cpuprofile cpu.out -gcflags=all=-l ./mypkg
 cgr trace convert cpu.out --repo-path /path/to/your-repo --workload go-test
 cgr trace ingest cgr-trace.jsonl --repo-path /path/to/your-repo
 ```
+
+Name one package (`./mypkg`), not `./...`: `go test` runs each package's
+test binary from that package's own source directory, so `./...` scatters a
+separate relative `cpu.out` into every package and the converter reads only
+one. Trace a single package per run, or convert each generated profile.
 
 Sampled stacks make dispatch through interface values and function values
 visible; counts are sample counts, so give workloads enough CPU time.

--- a/docs/guide/dynamic-tracing.md
+++ b/docs/guide/dynamic-tracing.md
@@ -9,9 +9,9 @@ graph alongside the statically derived `CALLS` edges.
 Currently supported runtimes: **Python** (3.12+, via `sys.monitoring`),
 **Java/Scala** (zero-dependency `java.lang.instrument` agent, JDK 24+),
 **Node.js** (V8 cpuprofile conversion), **.NET** (dotnet-trace speedscope
-conversion), and **PHP** (Xdebug trace conversion), **Lua** (a pure-Lua `debug.sethook`
-agent), and **Dart** (a VM Service sample collector). Remaining runtimes
-are tracked in
+conversion), **PHP** (Xdebug trace conversion), **Lua** (a pure-Lua
+`debug.sethook` agent), **Dart** (a VM Service sample collector), and
+**Go** (pprof CPU-profile conversion). Remaining runtimes are tracked in
 [issue #1244](https://github.com/vitali87/code-graph-rag/issues/1244).
 
 ## Recording a trace
@@ -216,6 +216,28 @@ Closures and async continuations surface as `<anonymous>` frames and
 resolve to their enclosing declaration by line span (the static tier
 creates no closure nodes). Extension methods (`Ext|method`) and setter
 names (`value=`) are normalized to their source spellings.
+
+## Recording a Go trace
+
+Go's own profiler does the capture; `go test` exposes it directly, and the
+converter reads the pprof protobuf without dependencies:
+
+```bash
+go test -cpuprofile cpu.out -gcflags=all=-l ./...
+cgr trace convert cpu.out --repo-path /path/to/your-repo --workload go-test
+cgr trace ingest cgr-trace.jsonl --repo-path /path/to/your-repo
+```
+
+Sampled stacks make dispatch through interface values and function values
+visible; counts are sample counts, so give workloads enough CPU time.
+`-gcflags=all=-l` disables inlining for the traced build — without it,
+inlined callees vanish from the profile entirely; the flag costs some
+runtime speed but preserves edges, which is the right trade for a traced
+test run. Compiler-generated closure symbols (`runAll.func1`) resolve to
+their enclosing declaration by span; receivers and generic instantiations
+are stripped from names, with declaration-line spans carrying identity.
+Frames from the Go runtime, the standard library, and `vendor/` are seen
+through to the nearest project frame.
 
 ## Ingesting a trace
 


### PR DESCRIPTION
Part of #1244, first increment of #1250. **Stacked on #1265** (base branch is `feat/1255-dart-dynamic-tracing`); only the last commit is new.

## What

Dynamic call-graph capture for Go with zero new tooling on the user's side: `go test -cpuprofile` (or any `runtime/pprof` capture) already records sampled stacks, and this PR adds a **dependency-free pprof protobuf decoder** — pprof's schema is small and stable, so ~130 lines of wire-format parsing (varints, length-delimited messages, packed repeated fields) cover samples, locations, inline-expanded lines, functions, and the string table with no protobuf library.

- Edges come from sampled-stack adjacency with the same project scoping and see-through as the other tracers (Go runtime, stdlib, module cache, and `vendor/` frames are glue).
- Go symbol normalization: package paths and receivers drop (`example.com/pkg.(*Dog).Sound` -> `Sound` — pointer/value receivers collapse exactly as the static tier's qualified names do), generic instantiations truncate at `[` (one graph node exists per generic, so shape instantiations collapse correctly), and compiler-generated closure symbols (`runAll.func1`) become `<anonymous>` and resolve by span (the static tier creates no closure nodes).
- Identity is `(path, declaration line)` — pprof's `Function.start_line` matches the graph's oracle-validated `start_line` — because Go qns embed the *file stem*, which pprof symbols (package-path based) cannot reconstruct. Resolution reuses `JsFrameResolver` unchanged.
- `cgr trace convert` sniffs pprof input by gzip magic (or `.pprof` extension).

**Inlining strategy (per the issue's acceptance criterion):** traced builds should pass `-gcflags=all=-l`; without it inlined callees vanish from the profile entirely. The converter does expand pprof inline frames outermost-first for partial recovery, and the trade-off is documented in the guide.

## Verification

Live end-to-end with Go 1.25 against Memgraph (`go test -cpuprofile cpu.out -gcflags=all=-l` on an interface + function-value-registry sample):

- `handle -> greet` — dispatch through a `map[string]func() int` — runtime-only (`static_missed: true`), the issue's acceptance-criterion edge
- `describe -> Dog.Sound` — interface dispatch resolved to the concrete method (confirmed static: the gotypes frontend already resolves this statically, and the runtime edge corroborates it)
- `TestRunAll -> runAll -> ...` — the test-to-code chain captured; 0 unresolved frames

5 unit tests build synthetic pprof profiles byte-by-byte with an in-test proto encoder (stack weights, runtime/vendor scoping, closure/method/generic normalization, malformed input), all red/green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for converting raw or compressed Go CPU profiles in pprof format into trace data.
  * Added Go trace ingestion with project-frame filtering, symbol normalization, call-edge aggregation, and workload metadata.
  * Added automatic pprof detection in the conversion command, with clear errors for malformed profiles, invalid input, and missing repository paths.

* **Documentation**
  * Documented capturing, converting, and ingesting Go traces, including sampling, symbol handling, and inlining considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->