### PR TITLE
feat: add C and C++ runtime call tracing via a -finstrument-functions shim

### DIFF
--- a/codebase_rag/constants/trace.py
+++ b/codebase_rag/constants/trace.py
@@ -29,12 +29,14 @@ TRACE_LANGUAGE_PHP = "php"
 TRACE_LANGUAGE_LUA = "lua"
 TRACE_LANGUAGE_DART = "dart"
 TRACE_LANGUAGE_GO = "go"
+TRACE_LANGUAGE_CPP = "cpp"
 TRACE_TOOL_NAME = "cgr-trace"
 TRACE_TOOL_NAME_JVM = "cgr-trace-jvm"
 TRACE_TOOL_NAME_CPUPROFILE = "cgr-trace-cpuprofile"
 TRACE_TOOL_NAME_SPEEDSCOPE = "cgr-trace-speedscope"
 TRACE_TOOL_NAME_XDEBUG = "cgr-trace-xdebug"
 TRACE_TOOL_NAME_PPROF = "cgr-trace-pprof"
+TRACE_TOOL_NAME_INSTRUMENTED = "cgr-trace-instrumented"
 TRACE_DEFAULT_OUTPUT = "cgr-trace.jsonl"
 
 # Python runtime qualname markers.
@@ -59,6 +61,8 @@ TRACE_DOTNET_NESTED_MARKER = "+"
 
 # Xdebug computerized-trace markers (trace_format=1, file format 4).
 TRACE_ERR_BAD_PPROF = "{path} is not a pprof CPU profile."
+TRACE_ERR_BAD_ADDRS = "{path} is not a cgr instrumented address trace."
+TRACE_ERR_NO_SYMBOLIZER = "Neither atos nor addr2line is available to symbolise."
 TRACE_ERR_BAD_XDEBUG = (
     "{path} is not an Xdebug computerized trace (expected 'File format: 4')."
 )

--- a/codebase_rag/constants/trace.py
+++ b/codebase_rag/constants/trace.py
@@ -63,9 +63,9 @@ TRACE_DOTNET_NESTED_MARKER = "+"
 TRACE_ERR_BAD_PPROF = "{path} is not a pprof CPU profile."
 TRACE_ERR_BAD_ADDRS = "{path} is not a cgr instrumented address trace."
 TRACE_ERR_NO_SYMBOLIZER = "Neither atos nor addr2line is available to symbolise."
-TRACE_WARN_ADDRS_DROPPED = (
-    "{path} overflowed the shim's edge table: some call edges were dropped, so "
-    "this trace is incomplete."
+TRACE_ERR_ADDRS_DROPPED = (
+    "{path} overflowed the shim's edge table: call edges were dropped, so the "
+    "trace is incomplete and cannot honour exact invocation counts."
 )
 TRACE_ERR_BAD_XDEBUG = (
     "{path} is not an Xdebug computerized trace (expected 'File format: 4')."

--- a/codebase_rag/constants/trace.py
+++ b/codebase_rag/constants/trace.py
@@ -63,6 +63,10 @@ TRACE_DOTNET_NESTED_MARKER = "+"
 TRACE_ERR_BAD_PPROF = "{path} is not a pprof CPU profile."
 TRACE_ERR_BAD_ADDRS = "{path} is not a cgr instrumented address trace."
 TRACE_ERR_NO_SYMBOLIZER = "Neither atos nor addr2line is available to symbolise."
+TRACE_WARN_ADDRS_DROPPED = (
+    "{path} overflowed the shim's edge table: some call edges were dropped, so "
+    "this trace is incomplete."
+)
 TRACE_ERR_BAD_XDEBUG = (
     "{path} is not an Xdebug computerized trace (expected 'File format: 4')."
 )

--- a/codebase_rag/tests/test_dynamic_trace_cli.py
+++ b/codebase_rag/tests/test_dynamic_trace_cli.py
@@ -276,6 +276,20 @@ def test_convert_command_sniffs_addrs_and_requires_repo_path(tmp_path):
     assert "--repo-path" in result.output
 
 
+def test_convert_command_fails_cleanly_on_bad_addrs_number(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    addrs_path = tmp_path / "cgr-trace.addrs"
+    addrs_path.write_text("exe /bin/app\nslide 0\nZZZZ 2000 1\n")
+
+    result = CliRunner().invoke(
+        cli, ["convert", str(addrs_path), "--repo-path", str(repo)]
+    )
+
+    assert result.exit_code == 1
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+
+
 def test_ingest_command_fails_cleanly_on_malformed_trace(tmp_path, monkeypatch):
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/codebase_rag/tests/test_dynamic_trace_cli.py
+++ b/codebase_rag/tests/test_dynamic_trace_cli.py
@@ -266,6 +266,16 @@ def test_convert_command_sniffs_pprof_and_requires_repo_path(tmp_path):
     assert "--repo-path" in result.output
 
 
+def test_convert_command_sniffs_addrs_and_requires_repo_path(tmp_path):
+    addrs_path = tmp_path / "cgr-trace.addrs"
+    addrs_path.write_text("exe /bin/app\nslide 0\n1000 2000 1\n")
+
+    result = CliRunner().invoke(cli, ["convert", str(addrs_path)])
+
+    assert result.exit_code == 1
+    assert "--repo-path" in result.output
+
+
 def test_ingest_command_fails_cleanly_on_malformed_trace(tmp_path, monkeypatch):
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/codebase_rag/tests/test_dynamic_trace_instrumented.py
+++ b/codebase_rag/tests/test_dynamic_trace_instrumented.py
@@ -12,6 +12,7 @@ import textwrap
 from pathlib import Path
 
 import pytest
+from loguru import logger
 
 from codebase_rag import constants as cs
 from codebase_rag.trace.instrumented import convert_instrumented
@@ -62,6 +63,56 @@ def test_converts_symbolised_pairs_with_exact_counts(tmp_path):
     assert method.callee.line == 12
     for record in records:
         assert record.workloads == ("ctest",)
+
+
+def test_executable_path_with_spaces_is_preserved(tmp_path):
+    repo = tmp_path.as_posix()
+    captured: dict[str, object] = {}
+
+    def _record(exe, slide, addrs):
+        captured["exe"] = exe
+        return {
+            0x1000: ("main", f"{repo}/main.c", 3),
+            0x2000: ("run", f"{repo}/main.c", 7),
+        }
+
+    addrs_path = _write_addrs(
+        tmp_path, [(0x1000, 0x2000, 4)], exe="/opt/my app/bin/app"
+    )
+
+    count = convert_instrumented(
+        addrs_path,
+        repo_root=tmp_path,
+        output=tmp_path / "trace.jsonl",
+        symbolizer=_record,
+    )
+
+    assert captured["exe"] == "/opt/my app/bin/app"
+    assert count == 1
+
+
+def test_dropped_marker_warns_of_incomplete_trace(tmp_path):
+    repo = tmp_path.as_posix()
+    addrs_path = tmp_path / "cgr-trace.addrs"
+    addrs_path.write_text("exe /bin/app\nslide 0\ndropped 1\n1000 2000 4\n")
+    symbols = {0x1000: ("main", f"{repo}/m.c", 3), 0x2000: ("run", f"{repo}/m.c", 7)}
+
+    warnings: list[str] = []
+    sink_id = logger.add(
+        lambda message: warnings.append(message.record["message"]), level="WARNING"
+    )
+    try:
+        count = convert_instrumented(
+            addrs_path,
+            repo_root=tmp_path,
+            output=tmp_path / "trace.jsonl",
+            symbolizer=lambda exe, slide, addrs: symbols,
+        )
+    finally:
+        logger.remove(sink_id)
+
+    assert count == 1
+    assert any("incomplete" in message.lower() for message in warnings)
 
 
 def test_malformed_addrs_is_rejected(tmp_path):

--- a/codebase_rag/tests/test_dynamic_trace_instrumented.py
+++ b/codebase_rag/tests/test_dynamic_trace_instrumented.py
@@ -12,7 +12,6 @@ import textwrap
 from pathlib import Path
 
 import pytest
-from loguru import logger
 
 from codebase_rag import constants as cs
 from codebase_rag.trace.instrumented import convert_instrumented
@@ -91,28 +90,19 @@ def test_executable_path_with_spaces_is_preserved(tmp_path):
     assert count == 1
 
 
-def test_dropped_marker_warns_of_incomplete_trace(tmp_path):
+def test_dropped_marker_rejects_incomplete_trace(tmp_path):
     repo = tmp_path.as_posix()
     addrs_path = tmp_path / "cgr-trace.addrs"
     addrs_path.write_text("exe /bin/app\nslide 0\ndropped 1\n1000 2000 4\n")
     symbols = {0x1000: ("main", f"{repo}/m.c", 3), 0x2000: ("run", f"{repo}/m.c", 7)}
 
-    warnings: list[str] = []
-    sink_id = logger.add(
-        lambda message: warnings.append(message.record["message"]), level="WARNING"
-    )
-    try:
-        count = convert_instrumented(
+    with pytest.raises(TraceFormatError, match="incomplete"):
+        convert_instrumented(
             addrs_path,
             repo_root=tmp_path,
             output=tmp_path / "trace.jsonl",
             symbolizer=lambda exe, slide, addrs: symbols,
         )
-    finally:
-        logger.remove(sink_id)
-
-    assert count == 1
-    assert any("incomplete" in message.lower() for message in warnings)
 
 
 def test_malformed_addrs_is_rejected(tmp_path):

--- a/codebase_rag/tests/test_dynamic_trace_instrumented.py
+++ b/codebase_rag/tests/test_dynamic_trace_instrumented.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import sys
 import textwrap
 from pathlib import Path
 
@@ -124,7 +125,8 @@ atos = shutil.which("atos") or shutil.which("addr2line")
 
 @pytest.mark.slow
 @pytest.mark.skipif(
-    cc is None or atos is None, reason="C toolchain or symboliser unavailable"
+    sys.platform == "win32" or cc is None or atos is None,
+    reason="C toolchain unavailable, or Windows/PE (the shim targets ELF/Mach-O)",
 )
 def test_live_instrumented_binary_produces_registry_dispatch(tmp_path):
     (tmp_path / "main.c").write_text(

--- a/codebase_rag/tests/test_dynamic_trace_instrumented.py
+++ b/codebase_rag/tests/test_dynamic_trace_instrumented.py
@@ -1,0 +1,152 @@
+# The -finstrument-functions shim records exact function-address pairs; the
+# converter must symbolise them, scope to the repository, normalise C++
+# names, and emit interchange records with true invocation counts
+# (issue #1252). The live test compiles and runs a real instrumented binary.
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.trace.instrumented import convert_instrumented
+from codebase_rag.trace.records import TraceFormatError, read_trace_file
+
+_SHIM = Path(__file__).resolve().parents[1] / "trace" / "c_agent" / "cgr_trace_shim.c"
+
+
+def _write_addrs(tmp_path, pairs, exe="/bin/app", slide=4096):
+    lines = [f"exe {exe}", f"slide {slide}"]
+    lines += [f"{caller:x} {callee:x} {count}" for caller, callee, count in pairs]
+    addrs_path = tmp_path / "cgr-trace.addrs"
+    addrs_path.write_text("\n".join(lines) + "\n")
+    return addrs_path
+
+
+def test_converts_symbolised_pairs_with_exact_counts(tmp_path):
+    repo = tmp_path.as_posix()
+    symbols = {
+        0x1000: ("main", f"{repo}/main.c", 20),
+        0x2000: ("handle", f"{repo}/registry.c", 8),
+        0x3000: ("Dog::sound()", f"{repo}/animal.cpp", 12),
+        0x4000: ("printf", "/usr/lib/libc/stdio.c", 100),
+    }
+    addrs_path = _write_addrs(
+        tmp_path,
+        [(0x1000, 0x2000, 7), (0x2000, 0x3000, 3), (0x2000, 0x4000, 9)],
+    )
+    output = tmp_path / "trace.jsonl"
+
+    count = convert_instrumented(
+        addrs_path,
+        repo_root=tmp_path,
+        output=output,
+        workload="ctest",
+        symbolizer=lambda exe, slide, addrs: symbols,
+    )
+
+    header, records_iter = read_trace_file(output)
+    records = list(records_iter)
+    assert header.language == cs.TRACE_LANGUAGE_CPP
+    assert count == len(records) == 2
+    edges = {(r.caller.qualname, r.callee.qualname): r for r in records}
+    assert edges[("main", "handle")].count == 7
+    method = edges[("handle", "sound")]
+    assert method.count == 3
+    assert method.callee.path.endswith("animal.cpp")
+    assert method.callee.line == 12
+    for record in records:
+        assert record.workloads == ("ctest",)
+
+
+def test_malformed_addrs_is_rejected(tmp_path):
+    addrs_path = tmp_path / "broken.addrs"
+    addrs_path.write_text("nothing here\n")
+
+    with pytest.raises(TraceFormatError):
+        convert_instrumented(
+            addrs_path,
+            repo_root=tmp_path,
+            output=tmp_path / "out.jsonl",
+            symbolizer=lambda exe, slide, addrs: {},
+        )
+
+
+cc = shutil.which("cc")
+atos = shutil.which("atos") or shutil.which("addr2line")
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    cc is None or atos is None, reason="C toolchain or symboliser unavailable"
+)
+def test_live_instrumented_binary_produces_registry_dispatch(tmp_path):
+    (tmp_path / "main.c").write_text(
+        textwrap.dedent("""
+            #include <stdio.h>
+
+            static int (*handlers[4])(void);
+            static int handler_count = 0;
+
+            static int greet(void) {
+                return 42;
+            }
+
+            static void reg(int (*fn)(void)) {
+                handlers[handler_count++] = fn;
+            }
+
+            static int handle(int index) {
+                return handlers[index]();
+            }
+
+            int main(void) {
+                reg(greet);
+                int out = 0;
+                for (int i = 0; i < 5; i++) {
+                    out += handle(0);
+                }
+                printf("%d\\n", out);
+                return 0;
+            }
+        """)
+    )
+    binary = tmp_path / "app"
+    subprocess.run(
+        [
+            str(cc),
+            "-finstrument-functions",
+            "-g",
+            "-O0",
+            str(tmp_path / "main.c"),
+            str(_SHIM),
+            "-o",
+            str(binary),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    addrs = tmp_path / "cgr-trace.addrs"
+    subprocess.run(
+        [str(binary)],
+        check=True,
+        capture_output=True,
+        env=dict(os.environ, CGR_TRACE_ADDRS=str(addrs)),
+        cwd=tmp_path,
+    )
+
+    output = tmp_path / "trace.jsonl"
+    count = convert_instrumented(addrs, repo_root=tmp_path, output=output)
+
+    assert count > 0
+    _header, records_iter = read_trace_file(output)
+    edges = {(r.caller.qualname, r.callee.qualname): r for r in records_iter}
+    dispatch = edges.get(("handle", "greet"))
+    assert dispatch is not None, sorted(edges)
+    assert dispatch.count == 5
+    assert edges[("main", "handle")].count == 5

--- a/codebase_rag/tests/test_dynamic_trace_records.py
+++ b/codebase_rag/tests/test_dynamic_trace_records.py
@@ -147,3 +147,4 @@ def test_lua_language_tag_constant():
     assert trace_constants.TRACE_LANGUAGE_LUA == "lua"
     assert trace_constants.TRACE_LANGUAGE_GO == "go"
     assert trace_constants.TRACE_LANGUAGE_DART == "dart"
+    assert trace_constants.TRACE_LANGUAGE_CPP == "cpp"

--- a/codebase_rag/trace/c_agent/cgr_trace_shim.c
+++ b/codebase_rag/trace/c_agent/cgr_trace_shim.c
@@ -117,6 +117,9 @@ CGR_ATTR static void cgr_write(void) {
 #endif
   fprintf(out, "exe %s\n", exe);
   fprintf(out, "slide %ld\n", slide);
+  /* Serialize under the same lock cgr_record takes, so a thread still running
+   * at exit cannot mutate the table or dropped flag mid-write. */
+  pthread_mutex_lock(&cgr_lock);
   if (cgr_dropped) {
     fprintf(out, "dropped 1\n");
   }
@@ -128,6 +131,7 @@ CGR_ATTR static void cgr_write(void) {
               (unsigned long long)cgr_table[index].count);
     }
   }
+  pthread_mutex_unlock(&cgr_lock);
   fclose(out);
 }
 

--- a/codebase_rag/trace/c_agent/cgr_trace_shim.c
+++ b/codebase_rag/trace/c_agent/cgr_trace_shim.c
@@ -1,0 +1,143 @@
+/* cgr runtime call tracer shim for C and C++ (issue #1252).
+ *
+ * Compile the target with instrumentation and link this file:
+ *
+ *   cc -finstrument-functions -g -O0 your_sources... cgr_trace_shim.c -o app
+ *
+ * The compiler injects __cyg_profile_func_enter/exit around every function;
+ * the shim keeps a per-thread call stack of function addresses and counts
+ * exact (caller, callee) pairs in a fixed-size open-addressing table. At
+ * process exit it writes cgr-trace.addrs (override with CGR_TRACE_ADDRS):
+ *
+ *   exe <executable path>
+ *   slide <ASLR slide of the main image, decimal>
+ *   <caller addr hex> <callee addr hex> <count>
+ *
+ * `cgr trace convert` symbolises those addresses (atos on macOS, addr2line
+ * elsewhere) into the trace interchange format. Everything here is
+ * no_instrument_function so the shim never traces itself; overhead is a
+ * mutex-guarded table insert per call, acceptable for test workloads.
+ */
+
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
+#else
+#include <unistd.h>
+#endif
+
+#define CGR_ATTR __attribute__((no_instrument_function))
+
+#define CGR_STACK_MAX 4096
+#define CGR_TABLE_BITS 16
+#define CGR_TABLE_SIZE (1u << CGR_TABLE_BITS)
+#define CGR_TABLE_MASK (CGR_TABLE_SIZE - 1u)
+
+typedef struct {
+  void *caller;
+  void *callee;
+  uint64_t count;
+} cgr_edge;
+
+static cgr_edge cgr_table[CGR_TABLE_SIZE];
+static pthread_mutex_t cgr_lock = PTHREAD_MUTEX_INITIALIZER;
+static _Thread_local void *cgr_stack[CGR_STACK_MAX];
+static _Thread_local int cgr_depth = 0;
+static int cgr_dropped = 0;
+
+CGR_ATTR static uint64_t cgr_hash(void *caller, void *callee) {
+  uint64_t h = (uint64_t)(uintptr_t)caller * 0x9E3779B97F4A7C15ull;
+  h ^= (uint64_t)(uintptr_t)callee + 0x517CC1B727220A95ull + (h << 6) + (h >> 2);
+  return h;
+}
+
+CGR_ATTR static void cgr_record(void *caller, void *callee) {
+  uint64_t slot = cgr_hash(caller, callee) & CGR_TABLE_MASK;
+  pthread_mutex_lock(&cgr_lock);
+  for (uint32_t probe = 0; probe < CGR_TABLE_SIZE; probe++) {
+    cgr_edge *edge = &cgr_table[(slot + probe) & CGR_TABLE_MASK];
+    if (edge->count == 0) {
+      edge->caller = caller;
+      edge->callee = callee;
+      edge->count = 1;
+      pthread_mutex_unlock(&cgr_lock);
+      return;
+    }
+    if (edge->caller == caller && edge->callee == callee) {
+      edge->count++;
+      pthread_mutex_unlock(&cgr_lock);
+      return;
+    }
+  }
+  cgr_dropped = 1; /* table full: stop distinguishing, keep running */
+  pthread_mutex_unlock(&cgr_lock);
+}
+
+CGR_ATTR static void cgr_write(void) {
+  const char *path = getenv("CGR_TRACE_ADDRS");
+  if (path == NULL || path[0] == '\0') {
+    path = "cgr-trace.addrs";
+  }
+  FILE *out = fopen(path, "w");
+  if (out == NULL) {
+    return;
+  }
+  char exe[4096] = "";
+#ifdef __APPLE__
+  uint32_t size = sizeof exe;
+  _NSGetExecutablePath(exe, &size);
+  long slide = (long)_dyld_get_image_vmaddr_slide(0);
+#else
+  ssize_t got = readlink("/proc/self/exe", exe, sizeof exe - 1);
+  if (got > 0) {
+    exe[got] = '\0';
+  }
+  long slide = 0; /* build with -no-pie, or symbolise with a load base */
+#endif
+  fprintf(out, "exe %s\n", exe);
+  fprintf(out, "slide %ld\n", slide);
+  if (cgr_dropped) {
+    fprintf(out, "dropped 1\n");
+  }
+  for (uint32_t index = 0; index < CGR_TABLE_SIZE; index++) {
+    if (cgr_table[index].count != 0) {
+      fprintf(out, "%llx %llx %llu\n",
+              (unsigned long long)(uintptr_t)cgr_table[index].caller,
+              (unsigned long long)(uintptr_t)cgr_table[index].callee,
+              (unsigned long long)cgr_table[index].count);
+    }
+  }
+  fclose(out);
+}
+
+CGR_ATTR void __cyg_profile_func_enter(void *this_fn, void *call_site);
+CGR_ATTR void __cyg_profile_func_exit(void *this_fn, void *call_site);
+
+static int cgr_registered = 0;
+
+void __cyg_profile_func_enter(void *this_fn, void *call_site) {
+  (void)call_site;
+  if (!cgr_registered) {
+    cgr_registered = 1;
+    atexit(cgr_write);
+  }
+  if (cgr_depth > 0 && cgr_depth <= CGR_STACK_MAX) {
+    cgr_record(cgr_stack[cgr_depth - 1], this_fn);
+  }
+  if (cgr_depth < CGR_STACK_MAX) {
+    cgr_stack[cgr_depth] = this_fn;
+  }
+  cgr_depth++;
+}
+
+void __cyg_profile_func_exit(void *this_fn, void *call_site) {
+  (void)this_fn;
+  (void)call_site;
+  if (cgr_depth > 0) {
+    cgr_depth--;
+  }
+}

--- a/codebase_rag/trace/c_agent/cgr_trace_shim.c
+++ b/codebase_rag/trace/c_agent/cgr_trace_shim.c
@@ -30,7 +30,7 @@
 
 #ifdef __APPLE__
 #include <mach-o/dyld.h>
-#else
+#elif defined(__linux__)
 #include <link.h>
 #include <unistd.h>
 #endif
@@ -82,7 +82,7 @@ CGR_ATTR static void cgr_record(void *caller, void *callee) {
   pthread_mutex_unlock(&cgr_lock);
 }
 
-#ifndef __APPLE__
+#ifdef __linux__
 /* The first object dl_iterate_phdr reports is the main program; its
  * dlpi_addr is the load bias (the ASLR slide for a PIE, 0 for -no-pie). */
 CGR_ATTR static int cgr_main_load_bias(struct dl_phdr_info *info, size_t size,
@@ -103,18 +103,20 @@ CGR_ATTR static void cgr_write(void) {
     return;
   }
   char exe[4096] = "";
+  long slide = 0;
 #ifdef __APPLE__
   uint32_t size = sizeof exe;
   _NSGetExecutablePath(exe, &size);
-  long slide = (long)_dyld_get_image_vmaddr_slide(0);
-#else
+  slide = (long)_dyld_get_image_vmaddr_slide(0);
+#elif defined(__linux__)
   ssize_t got = readlink("/proc/self/exe", exe, sizeof exe - 1);
   if (got > 0) {
     exe[got] = '\0';
   }
-  long slide = 0;
   dl_iterate_phdr(cgr_main_load_bias, &slide);
 #endif
+  /* On other platforms exe stays empty and the converter rejects the trace:
+   * symbolisation here targets ELF (addr2line) and Mach-O (atos) only. */
   fprintf(out, "exe %s\n", exe);
   fprintf(out, "slide %ld\n", slide);
   /* Serialize under the same lock cgr_record takes, so a thread still running

--- a/codebase_rag/trace/c_agent/cgr_trace_shim.c
+++ b/codebase_rag/trace/c_agent/cgr_trace_shim.c
@@ -93,30 +93,49 @@ CGR_ATTR static int cgr_main_load_bias(struct dl_phdr_info *info, size_t size,
 }
 #endif
 
+CGR_ATTR static void cgr_exe_path(char *exe, size_t exe_size, long *slide) {
+  exe[0] = '\0';
+  *slide = 0;
+#ifdef __APPLE__
+  uint32_t size = (uint32_t)exe_size;
+  if (_NSGetExecutablePath(exe, &size) != 0) {
+    exe[0] = '\0'; /* buffer too small: leave empty, the converter rejects it */
+  }
+  *slide = (long)_dyld_get_image_vmaddr_slide(0);
+#elif defined(__linux__)
+  ssize_t got = readlink("/proc/self/exe", exe, exe_size - 1);
+  /* readlink does not NUL-terminate, and a full buffer means truncation; a
+   * truncated path would mis-symbolise, so treat it as unknown. */
+  if (got > 0 && (size_t)got < exe_size - 1) {
+    exe[got] = '\0';
+  } else {
+    exe[0] = '\0';
+  }
+  dl_iterate_phdr(cgr_main_load_bias, slide);
+#else
+  (void)exe_size; /* other platforms: exe stays empty, targets ELF/Mach-O only */
+#endif
+}
+
 CGR_ATTR static void cgr_write(void) {
   const char *path = getenv("CGR_TRACE_ADDRS");
   if (path == NULL || path[0] == '\0') {
     path = "cgr-trace.addrs";
   }
-  FILE *out = fopen(path, "w");
+  /* Write to a sibling temp file and rename on success, so a crash or a
+   * partial/failed write never publishes a truncated trace as complete. */
+  char tmp[4200];
+  int printed = snprintf(tmp, sizeof tmp, "%s.tmp", path);
+  if (printed < 0 || (size_t)printed >= sizeof tmp) {
+    return;
+  }
+  FILE *out = fopen(tmp, "w");
   if (out == NULL) {
     return;
   }
-  char exe[4096] = "";
-  long slide = 0;
-#ifdef __APPLE__
-  uint32_t size = sizeof exe;
-  _NSGetExecutablePath(exe, &size);
-  slide = (long)_dyld_get_image_vmaddr_slide(0);
-#elif defined(__linux__)
-  ssize_t got = readlink("/proc/self/exe", exe, sizeof exe - 1);
-  if (got > 0) {
-    exe[got] = '\0';
-  }
-  dl_iterate_phdr(cgr_main_load_bias, &slide);
-#endif
-  /* On other platforms exe stays empty and the converter rejects the trace:
-   * symbolisation here targets ELF (addr2line) and Mach-O (atos) only. */
+  char exe[4096];
+  long slide;
+  cgr_exe_path(exe, sizeof exe, &slide);
   fprintf(out, "exe %s\n", exe);
   fprintf(out, "slide %ld\n", slide);
   /* Serialize under the same lock cgr_record takes, so a thread still running
@@ -134,7 +153,15 @@ CGR_ATTR static void cgr_write(void) {
     }
   }
   pthread_mutex_unlock(&cgr_lock);
-  fclose(out);
+  int ok = (ferror(out) == 0);
+  if (fclose(out) != 0) {
+    ok = 0;
+  }
+  if (ok) {
+    rename(tmp, path);
+  } else {
+    remove(tmp);
+  }
 }
 
 CGR_ATTR void __cyg_profile_func_enter(void *this_fn, void *call_site);

--- a/codebase_rag/trace/c_agent/cgr_trace_shim.c
+++ b/codebase_rag/trace/c_agent/cgr_trace_shim.c
@@ -10,7 +10,7 @@
  * process exit it writes cgr-trace.addrs (override with CGR_TRACE_ADDRS):
  *
  *   exe <executable path>
- *   slide <ASLR slide of the main image, decimal>
+ *   slide <load bias of the main image, decimal; ASLR slide for a PIE>
  *   <caller addr hex> <callee addr hex> <count>
  *
  * `cgr trace convert` symbolises those addresses (atos on macOS, addr2line
@@ -18,6 +18,10 @@
  * no_instrument_function so the shim never traces itself; overhead is a
  * mutex-guarded table insert per call, acceptable for test workloads.
  */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE /* dl_iterate_phdr on glibc */
+#endif
 
 #include <pthread.h>
 #include <stdint.h>
@@ -27,6 +31,7 @@
 #ifdef __APPLE__
 #include <mach-o/dyld.h>
 #else
+#include <link.h>
 #include <unistd.h>
 #endif
 
@@ -77,6 +82,17 @@ CGR_ATTR static void cgr_record(void *caller, void *callee) {
   pthread_mutex_unlock(&cgr_lock);
 }
 
+#ifndef __APPLE__
+/* The first object dl_iterate_phdr reports is the main program; its
+ * dlpi_addr is the load bias (the ASLR slide for a PIE, 0 for -no-pie). */
+CGR_ATTR static int cgr_main_load_bias(struct dl_phdr_info *info, size_t size,
+                                       void *data) {
+  (void)size;
+  *(long *)data = (long)info->dlpi_addr;
+  return 1;
+}
+#endif
+
 CGR_ATTR static void cgr_write(void) {
   const char *path = getenv("CGR_TRACE_ADDRS");
   if (path == NULL || path[0] == '\0') {
@@ -96,7 +112,8 @@ CGR_ATTR static void cgr_write(void) {
   if (got > 0) {
     exe[got] = '\0';
   }
-  long slide = 0; /* build with -no-pie, or symbolise with a load base */
+  long slide = 0;
+  dl_iterate_phdr(cgr_main_load_bias, &slide);
 #endif
   fprintf(out, "exe %s\n", exe);
   fprintf(out, "slide %ld\n", slide);

--- a/codebase_rag/trace/c_agent/cgr_trace_shim.c
+++ b/codebase_rag/trace/c_agent/cgr_trace_shim.c
@@ -134,14 +134,13 @@ CGR_ATTR static void cgr_write(void) {
 CGR_ATTR void __cyg_profile_func_enter(void *this_fn, void *call_site);
 CGR_ATTR void __cyg_profile_func_exit(void *this_fn, void *call_site);
 
-static int cgr_registered = 0;
+static pthread_once_t cgr_once = PTHREAD_ONCE_INIT;
+
+CGR_ATTR static void cgr_register_atexit(void) { atexit(cgr_write); }
 
 void __cyg_profile_func_enter(void *this_fn, void *call_site) {
   (void)call_site;
-  if (!cgr_registered) {
-    cgr_registered = 1;
-    atexit(cgr_write);
-  }
+  pthread_once(&cgr_once, cgr_register_atexit);
   if (cgr_depth > 0 && cgr_depth <= CGR_STACK_MAX) {
     cgr_record(cgr_stack[cgr_depth - 1], this_fn);
   }

--- a/codebase_rag/trace/cli.py
+++ b/codebase_rag/trace/cli.py
@@ -178,19 +178,15 @@ def convert_cmd(
     workload: str | None,
 ) -> None:
     from .. import constants as cs
-    from .records import TraceFormatError
 
     resolved_output = output or Path(cs.TRACE_DEFAULT_OUTPUT)
     try:
         count = _convert_profile(
             profile_file, repo_path, resolved_output, include, workload
         )
-    except (
-        TraceFormatError,
-        OSError,
-        ValueError,
-        _ConvertUsageError,
-    ) as e:
+    # TraceFormatError subclasses ValueError, so ValueError covers it (and the
+    # malformed-number / non-UTF-8 cases) without listing it redundantly.
+    except (OSError, ValueError, _ConvertUsageError) as e:
         logger.error(str(e))
         click.secho(str(e), fg="red", err=True)
         sys.exit(1)

--- a/codebase_rag/trace/cli.py
+++ b/codebase_rag/trace/cli.py
@@ -89,6 +89,16 @@ def _convert_profile(
     """
     import json
 
+    if profile_file.suffix == ".addrs":
+        # C/C++ instrumented address traces need symbolisation plus the repo.
+        from .instrumented import convert_instrumented
+
+        if repo_path is None:
+            raise _ConvertUsageError(ch.ERR_TRACE_CONVERT_NEEDS_REPO)
+        return convert_instrumented(
+            profile_file, repo_root=repo_path, output=resolved_output, workload=workload
+        )
+
     with profile_file.open("rb") as fh:
         magic = fh.read(2)
 

--- a/codebase_rag/trace/cli.py
+++ b/codebase_rag/trace/cli.py
@@ -177,8 +177,6 @@ def convert_cmd(
     include: str | None,
     workload: str | None,
 ) -> None:
-    import json
-
     from .. import constants as cs
     from .records import TraceFormatError
 
@@ -190,8 +188,7 @@ def convert_cmd(
     except (
         TraceFormatError,
         OSError,
-        UnicodeDecodeError,
-        json.JSONDecodeError,
+        ValueError,
         _ConvertUsageError,
     ) as e:
         logger.error(str(e))

--- a/codebase_rag/trace/ingest.py
+++ b/codebase_rag/trace/ingest.py
@@ -54,6 +54,7 @@ def _resolver_for(
         cs.TRACE_LANGUAGE_LUA,
         cs.TRACE_LANGUAGE_DART,
         cs.TRACE_LANGUAGE_GO,
+        cs.TRACE_LANGUAGE_CPP,
     ):
         # Lua-agent and Dart-collector frames share V8's shape: repo paths,
         # bare runtime names, 1-based definition lines, <module>/<anonymous>

--- a/codebase_rag/trace/instrumented.py
+++ b/codebase_rag/trace/instrumented.py
@@ -21,6 +21,8 @@ import subprocess
 from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING
 
+from loguru import logger
+
 from .. import constants as cs
 from .records import (
     CallRecord,
@@ -115,19 +117,26 @@ def convert_instrumented(
     """Write ``addrs_path``'s symbolised call edges to ``output``."""
     exe = ""
     slide = 0
+    dropped = False
     pairs: list[tuple[int, int, int]] = []
     for line in addrs_path.read_text(encoding="utf-8").splitlines():
-        parts = line.split()
-        if len(parts) == 2 and parts[0] == "exe":
-            exe = parts[1]
-        elif len(parts) == 2 and parts[0] == "slide":
-            slide = int(parts[1])
-        elif len(parts) == 2 and parts[0] == "dropped":
-            continue
-        elif len(parts) == 3:
-            pairs.append((int(parts[0], 16), int(parts[1], 16), int(parts[2])))
+        # Header keys are single tokens; the value is the rest of the line so
+        # an executable path may contain spaces. Edge rows are three tokens.
+        key, _sep, rest = line.partition(" ")
+        if key == "exe":
+            exe = rest
+        elif key == "slide" and rest.lstrip("-").isdigit():
+            slide = int(rest)
+        elif key == "dropped":
+            dropped = True
+        else:
+            parts = line.split()
+            if len(parts) == 3:
+                pairs.append((int(parts[0], 16), int(parts[1], 16), int(parts[2])))
     if not exe or not pairs:
         raise TraceFormatError(cs.TRACE_ERR_BAD_ADDRS.format(path=addrs_path))
+    if dropped:
+        logger.warning(cs.TRACE_WARN_ADDRS_DROPPED.format(path=addrs_path))
 
     addresses = sorted({a for pair in pairs for a in pair[:2]})
     resolve = symbolizer or _default_symbolizer()

--- a/codebase_rag/trace/instrumented.py
+++ b/codebase_rag/trace/instrumented.py
@@ -21,8 +21,6 @@ import subprocess
 from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING
 
-from loguru import logger
-
 from .. import constants as cs
 from .records import (
     CallRecord,
@@ -136,7 +134,10 @@ def convert_instrumented(
     if not exe or not pairs:
         raise TraceFormatError(cs.TRACE_ERR_BAD_ADDRS.format(path=addrs_path))
     if dropped:
-        logger.warning(cs.TRACE_WARN_ADDRS_DROPPED.format(path=addrs_path))
+        # The shim's fixed table overflowed and lost caller/callee pairs, so
+        # the exact invocation-count contract can no longer hold. Refuse the
+        # trace rather than pass off an incomplete call graph as exact.
+        raise TraceFormatError(cs.TRACE_ERR_ADDRS_DROPPED.format(path=addrs_path))
 
     addresses = sorted({a for pair in pairs for a in pair[:2]})
     resolve = symbolizer or _default_symbolizer()

--- a/codebase_rag/trace/instrumented.py
+++ b/codebase_rag/trace/instrumented.py
@@ -105,14 +105,12 @@ def _default_symbolizer() -> Symbolizer:
     raise TraceFormatError(cs.TRACE_ERR_NO_SYMBOLIZER)
 
 
-def convert_instrumented(
-    addrs_path: Path,
-    repo_root: Path,
-    output: Path,
-    workload: str | None = None,
-    symbolizer: Symbolizer | None = None,
-) -> int:
-    """Write ``addrs_path``'s symbolised call edges to ``output``."""
+def _parse_addrs(addrs_path: Path) -> tuple[str, int, list[tuple[int, int, int]]]:
+    """The executable path, load slide, and (caller, callee, count) edges.
+
+    Raises ``TraceFormatError`` for an unparseable trace or one the shim
+    marked ``dropped`` (its edge table overflowed, so counts are incomplete).
+    """
     exe = ""
     slide = 0
     dropped = False
@@ -138,6 +136,18 @@ def convert_instrumented(
         # the exact invocation-count contract can no longer hold. Refuse the
         # trace rather than pass off an incomplete call graph as exact.
         raise TraceFormatError(cs.TRACE_ERR_ADDRS_DROPPED.format(path=addrs_path))
+    return exe, slide, pairs
+
+
+def convert_instrumented(
+    addrs_path: Path,
+    repo_root: Path,
+    output: Path,
+    workload: str | None = None,
+    symbolizer: Symbolizer | None = None,
+) -> int:
+    """Write ``addrs_path``'s symbolised call edges to ``output``."""
+    exe, slide, pairs = _parse_addrs(addrs_path)
 
     addresses = sorted({a for pair in pairs for a in pair[:2]})
     resolve = symbolizer or _default_symbolizer()

--- a/codebase_rag/trace/instrumented.py
+++ b/codebase_rag/trace/instrumented.py
@@ -1,0 +1,171 @@
+"""Convert C/C++ instrumented address traces to the interchange format.
+
+The ``cgr_trace_shim.c`` agent (compiled into the target with
+``-finstrument-functions``) records exact (caller, callee) function-address
+pairs and writes them with the executable path and ASLR slide. This
+converter symbolises those addresses into function names and source
+positions — ``atos`` on macOS, ``addr2line`` elsewhere — and emits
+interchange records. Counts are true invocation counts.
+
+C++ names demangle to ``Dog::sound()``; identity for resolution is the
+symbolised source position (span-first, like every native tracer here), so
+names normalise to their bare member form. Frames that symbolise outside
+the repository (libc, the C++ runtime) are glue: the shim already recorded
+direct caller/callee pairs, so out-of-repo endpoints simply drop the edge.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from collections.abc import Callable, Sequence
+from typing import TYPE_CHECKING
+
+from .. import constants as cs
+from .records import (
+    CallRecord,
+    FramePoint,
+    TraceFormatError,
+    TraceHeader,
+    write_trace_file,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+Symbolizer = Callable[[str, int, Sequence[int]], dict[int, tuple[str, str, int]]]
+
+
+def _bare_name(symbol: str) -> str:
+    """``Dog::sound(int)`` as the member name ``sound``."""
+    head = symbol.split("(", 1)[0].strip()
+    return head.rsplit("::", 1)[-1] or cs.TRACE_QUALNAME_ANONYMOUS
+
+
+def _atos_symbolizer(
+    exe: str, slide: int, addresses: Sequence[int]
+) -> dict[int, tuple[str, str, int]]:
+    """macOS symbolisation; atos output: ``name (in x) (file.c:12)``."""
+    command = [
+        "atos",
+        "-fullPath",
+        "-o",
+        exe,
+        "-s",
+        hex(slide),
+        *[hex(address) for address in addresses],
+    ]
+    result = subprocess.run(command, capture_output=True, text=True, check=True)
+    symbols: dict[int, tuple[str, str, int]] = {}
+    lines = result.stdout.splitlines()
+    for address, line in zip(addresses, lines, strict=False):
+        name = line.split(" (in ", 1)[0].strip()
+        path = ""
+        line_no = 0
+        if line.endswith(")") and "(" in line:
+            position = line.rsplit("(", 1)[1].rstrip(")")
+            file_part, separator, line_part = position.rpartition(":")
+            if separator and line_part.isdigit():
+                path = file_part
+                line_no = int(line_part)
+        symbols[address] = (name, path, line_no)
+    return symbols
+
+
+def _addr2line_symbolizer(
+    exe: str, slide: int, addresses: Sequence[int]
+) -> dict[int, tuple[str, str, int]]:
+    """ELF symbolisation; addr2line -f -C prints name then file:line."""
+    command = [
+        "addr2line",
+        "-e",
+        exe,
+        "-f",
+        "-C",
+        *[hex(address - slide) for address in addresses],
+    ]
+    result = subprocess.run(command, capture_output=True, text=True, check=True)
+    lines = result.stdout.splitlines()
+    symbols: dict[int, tuple[str, str, int]] = {}
+    for index, address in enumerate(addresses):
+        name = lines[index * 2] if index * 2 < len(lines) else ""
+        position = lines[index * 2 + 1] if index * 2 + 1 < len(lines) else ""
+        file_part, separator, line_part = position.rpartition(":")
+        line_no = int(line_part) if separator and line_part.isdigit() else 0
+        path = "" if file_part in ("", "??") else file_part
+        symbols[address] = (name, path, line_no)
+    return symbols
+
+
+def _default_symbolizer() -> Symbolizer:
+    if shutil.which("atos"):
+        return _atos_symbolizer
+    if shutil.which("addr2line"):
+        return _addr2line_symbolizer
+    raise TraceFormatError(cs.TRACE_ERR_NO_SYMBOLIZER)
+
+
+def convert_instrumented(
+    addrs_path: Path,
+    repo_root: Path,
+    output: Path,
+    workload: str | None = None,
+    symbolizer: Symbolizer | None = None,
+) -> int:
+    """Write ``addrs_path``'s symbolised call edges to ``output``."""
+    exe = ""
+    slide = 0
+    pairs: list[tuple[int, int, int]] = []
+    for line in addrs_path.read_text(encoding="utf-8").splitlines():
+        parts = line.split()
+        if len(parts) == 2 and parts[0] == "exe":
+            exe = parts[1]
+        elif len(parts) == 2 and parts[0] == "slide":
+            slide = int(parts[1])
+        elif len(parts) == 2 and parts[0] == "dropped":
+            continue
+        elif len(parts) == 3:
+            pairs.append((int(parts[0], 16), int(parts[1], 16), int(parts[2])))
+    if not exe or not pairs:
+        raise TraceFormatError(cs.TRACE_ERR_BAD_ADDRS.format(path=addrs_path))
+
+    addresses = sorted({a for pair in pairs for a in pair[:2]})
+    resolve = symbolizer or _default_symbolizer()
+    symbols = resolve(exe, slide, addresses)
+
+    root_prefix = repo_root.resolve().as_posix() + "/"
+
+    def _frame(address: int) -> FramePoint | None:
+        name, path, line = symbols.get(address, ("", "", 0))
+        if not path.startswith(root_prefix) or line <= 0:
+            return None
+        return FramePoint(path=path, qualname=_bare_name(name), line=line)
+
+    edges: dict[tuple[FramePoint, FramePoint], int] = {}
+    for caller_address, callee_address, count in pairs:
+        caller = _frame(caller_address)
+        callee = _frame(callee_address)
+        if caller is None or callee is None:
+            continue
+        key = (caller, callee)
+        edges[key] = edges.get(key, 0) + count
+
+    workloads = (workload,) if workload else ()
+    records = [
+        CallRecord(
+            caller=caller,
+            callee=callee,
+            count=count,
+            workloads=workloads,
+            receiver_types=(),
+        )
+        for (caller, callee), count in edges.items()
+    ]
+    header = TraceHeader(
+        version=cs.TRACE_FORMAT_VERSION,
+        language=cs.TRACE_LANGUAGE_CPP,
+        repo_root=str(repo_root),
+        tracer=cs.TRACE_TOOL_NAME_INSTRUMENTED,
+    )
+    write_trace_file(output, header, records)
+    return len(records)

--- a/docs/guide/dynamic-tracing.md
+++ b/docs/guide/dynamic-tracing.md
@@ -252,23 +252,26 @@ dependencies beyond pthreads) rides the compiler's own instrumentation and
 records **every call exactly**:
 
 ```bash
-cc -finstrument-functions -g -O0 your_sources... \
+cc -pthread -finstrument-functions -g -O0 your_sources... \
    codebase_rag/trace/c_agent/cgr_trace_shim.c -o app
 ./app        # writes cgr-trace.addrs (override with CGR_TRACE_ADDRS)
 cgr trace convert cgr-trace.addrs --repo-path /path/to/your-repo --workload smoke
 cgr trace ingest cgr-trace.jsonl --repo-path /path/to/your-repo
 ```
 
-The shim records function-address pairs; conversion symbolises them with
-`atos` (macOS) or `addr2line` (ELF; build with `-no-pie` there so the
-recorded addresses match the symbol table). Calls through function
-pointers and virtual dispatch land with true invocation counts; C++ names
-demangle and normalise to their bare member form, with source positions
-carrying identity. Frames that symbolise outside the repository (libc, the
-C++ runtime) drop their edges rather than being guessed. Overhead is one
-mutex-guarded table insert per call — fine for test workloads, not for
-production; the edge table holds 65k distinct pairs and marks the trace
-`dropped` if exceeded.
+The shim records function-address pairs and the main image's load bias;
+conversion symbolises them with `atos` (macOS) or `addr2line` (ELF). PIE
+binaries need no special build flag — the shim records the ASLR slide and
+the converter subtracts it before symbolising, so the default hardened
+(PIE) build works. Calls through function pointers and virtual dispatch
+land with true invocation counts; C++ names demangle and normalise to their
+bare member form, with source positions carrying identity. Frames that
+symbolise outside the repository (libc, the C++ runtime) drop their edges
+rather than being guessed. Overhead is one mutex-guarded table insert per
+call — fine for test workloads, not for production; the edge table holds
+65k distinct pairs, and conversion **rejects** a trace the shim marked
+`dropped` (table overflowed) rather than pass off an incomplete call graph
+as exact.
 
 ## Ingesting a trace
 

--- a/docs/guide/dynamic-tracing.md
+++ b/docs/guide/dynamic-tracing.md
@@ -10,8 +10,9 @@ Currently supported runtimes: **Python** (3.12+, via `sys.monitoring`),
 **Java/Scala** (zero-dependency `java.lang.instrument` agent, JDK 24+),
 **Node.js** (V8 cpuprofile conversion), **.NET** (dotnet-trace speedscope
 conversion), **PHP** (Xdebug trace conversion), **Lua** (a pure-Lua
-`debug.sethook` agent), **Dart** (a VM Service sample collector), and
-**Go** (pprof CPU-profile conversion). Remaining runtimes are tracked in
+`debug.sethook` agent), **Dart** (a VM Service sample collector),
+**Go** (pprof CPU-profile conversion), and **C/C++** (a
+`-finstrument-functions` shim). Remaining runtimes are tracked in
 [issue #1244](https://github.com/vitali87/code-graph-rag/issues/1244).
 
 ## Recording a trace
@@ -243,6 +244,31 @@ their enclosing declaration by span; receivers and generic instantiations
 are stripped from names, with declaration-line spans carrying identity.
 Frames from the Go runtime, the standard library, and `vendor/` are seen
 through to the nearest project frame.
+
+## Recording a C or C++ trace
+
+A single-file shim (`codebase_rag/trace/c_agent/cgr_trace_shim.c`, no
+dependencies beyond pthreads) rides the compiler's own instrumentation and
+records **every call exactly**:
+
+```bash
+cc -finstrument-functions -g -O0 your_sources... \
+   codebase_rag/trace/c_agent/cgr_trace_shim.c -o app
+./app        # writes cgr-trace.addrs (override with CGR_TRACE_ADDRS)
+cgr trace convert cgr-trace.addrs --repo-path /path/to/your-repo --workload smoke
+cgr trace ingest cgr-trace.jsonl --repo-path /path/to/your-repo
+```
+
+The shim records function-address pairs; conversion symbolises them with
+`atos` (macOS) or `addr2line` (ELF; build with `-no-pie` there so the
+recorded addresses match the symbol table). Calls through function
+pointers and virtual dispatch land with true invocation counts; C++ names
+demangle and normalise to their bare member form, with source positions
+carrying identity. Frames that symbolise outside the repository (libc, the
+C++ runtime) drop their edges rather than being guessed. Overhead is one
+mutex-guarded table insert per call — fine for test workloads, not for
+production; the edge table holds 65k distinct pairs and marks the trace
+`dropped` if exceeded.
 
 ## Ingesting a trace
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,8 +13,12 @@ sonar.tests=codebase_rag/tests
 # -- so it is excluded from analysis rather than fought rule by rule. The Dart
 # collector is likewise standalone tooling: Sonar does not run `dart pub get`,
 # so every `package:vm_service` symbol reports as undefined; it is built and
-# analysed by the Dart toolchain, not SonarDart.
-sonar.exclusions=**/__pycache__/**,**/*.pyc,codebase_rag/tests/**,codebase_rag/trace/jvm_agent/**,codebase_rag/trace/dart_collector/**
+# analysed by the Dart toolchain, not SonarDart. The C/C++ instrumentation
+# shim is likewise standalone tooling: it is compiled into the traced target
+# by that target's own toolchain (with `-finstrument-functions`), needs
+# `_GNU_SOURCE`/`dl_iterate_phdr` glibc contracts SonarCFamily cannot see
+# without a build wrapper, and is exercised by the live instrumented test.
+sonar.exclusions=**/__pycache__/**,**/*.pyc,codebase_rag/tests/**,codebase_rag/trace/jvm_agent/**,codebase_rag/trace/dart_collector/**,codebase_rag/trace/c_agent/**
 sonar.security.exclusions=codebase_rag/tests/**
 
 # The only coverage report is Python (below); the bundled compiler-frontend
@@ -22,7 +26,7 @@ sonar.security.exclusions=codebase_rag/tests/**
 # verified by their own CI jobs and live runs, not the Python suite, so they
 # must not sit in the coverage denominator with no report to satisfy them.
 # They stay analysed for bugs/smells -- only coverage is waived.
-sonar.coverage.exclusions=**/*.go,**/*.cs,**/*.csproj,**/*.java,**/*.lua,**/*.dart
+sonar.coverage.exclusions=**/*.go,**/*.cs,**/*.csproj,**/*.java,**/*.lua,**/*.dart,**/*.c
 
 sonar.python.version=3.12
 sonar.python.coverage.reportPaths=coverage.xml


### PR DESCRIPTION
Part of #1244, first increment of #1252. **Stacked on #1266** (base branch is `feat/1250-go-dynamic-tracing`); only the last commit is new.

## What

Dynamic call-graph capture for C and C++ via the compiler's own instrumentation — **exact call records**, no sampling:

- **`cgr_trace_shim.c`** (~150 lines, pthreads only): compiled into the target with `-finstrument-functions`, it maintains a per-thread call stack in `__cyg_profile_func_enter/exit`, counts exact (caller, callee) function-address pairs in a fixed open-addressing table (65k pairs, `dropped` marker if exceeded), and writes them at exit with the executable path and ASLR slide (macOS `_dyld_get_image_vmaddr_slide`; ELF documented as `-no-pie`).
- **`convert_instrumented`**: symbolises the addresses (`atos -fullPath` on macOS, `addr2line -f -C` elsewhere; injectable symbolizer for tests) into names and source positions, normalises C++ `Dog::sound(int)` to bare member names, scopes to the repository (libc/C++-runtime endpoints drop their edges rather than being guessed), and emits interchange records with true invocation counts.
- `cgr trace convert` sniffs `.addrs` input; ingestion routes `language: "cpp"` to the shared span-first resolver.

## Verification

Live end-to-end against Memgraph (clang 17, function-pointer registry sample compiled `-finstrument-functions -g -O0`):

- `handle -> greet` — dispatch through a function-pointer array — runtime-only (`static_missed: true`) with the exact count x5
- `main -> reg`, `main -> handle` (x5) confirmed static; 0 unresolved

The unit suite includes a **live compile-and-run test** (skipped without a C toolchain + symboliser): builds the instrumented binary with the real shim, runs it, symbolises with the real `atos`, and asserts the dispatch edge and counts. Plus injected-symbolizer tests for C++ name normalisation, out-of-repo dropping, and malformed input.

With this PR the epic's per-language coverage stands at nine runtimes (Python, JVM, Node, .NET, PHP, Lua, Dart, Go, C/C++); Rust (#1251) remains, pending a stable rustc instrumentation flag or an eBPF/sampling route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added C/C++ dynamic tracing through compiler instrumentation.
  * Added conversion of address traces into symbolized call records with invocation counts and workload metadata.
  * Added C++ trace handling, source-frame resolution, name normalization, and repository filtering.
* **Bug Fixes**
  * Added validation for malformed, incomplete, or unsupported traces and unavailable symbolization tools.
  * Address-trace conversion now requires a repository path and reports invalid input cleanly.
* **Documentation**
  * Documented setup, conversion, limitations, overhead, and external-frame handling.
* **Tests**
  * Added coverage for conversion, symbolization, filtering, and live instrumented binaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->