### PR TITLE
ci: enforce the no-em-dash rule in release notes and news

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -161,7 +161,7 @@ jobs:
           DETAIL=""
           if [ -n "$GHSA" ]; then
             DETAIL=$(gh api "repos/${GITHUB_REPOSITORY}/security-advisories/${GHSA}" \
-              --jq '"\(.summary) (\(.severity) severity, CVSS \(.cvss.score // "n/a")) — advisory [\(.ghsa_id)](https://github.com/'"${GITHUB_REPOSITORY}"'/security/advisories/\(.ghsa_id))\(if .cve_id then " / " + .cve_id else "" end)."' \
+              --jq '"\(.summary) (\(.severity) severity, CVSS \(.cvss.score // "n/a")), advisory [\(.ghsa_id)](https://github.com/'"${GITHUB_REPOSITORY}"'/security/advisories/\(.ghsa_id))\(if .cve_id then " / " + .cve_id else "" end)."' \
               2>/dev/null || true)
           fi
           {
@@ -170,9 +170,9 @@ jobs:
             if [ -n "$DETAIL" ]; then
               echo "$DETAIL"
             elif [ -n "$GHSA" ]; then
-              echo "This release contains a security fix — see advisory [$GHSA](https://github.com/${GITHUB_REPOSITORY}/security/advisories/$GHSA)."
+              echo "This release contains a security fix; see advisory [$GHSA](https://github.com/${GITHUB_REPOSITORY}/security/advisories/$GHSA)."
             else
-              echo "This release contains a security fix — see the [Security Advisories](https://github.com/${GITHUB_REPOSITORY}/security/advisories) page."
+              echo "This release contains a security fix; see the [Security Advisories](https://github.com/${GITHUB_REPOSITORY}/security/advisories) page."
             fi
             echo
             echo "**Upgrading is strongly recommended.**"
@@ -201,7 +201,8 @@ jobs:
             -d @/tmp/req.json \
             "${HIGHLIGHTS_API_URL}/v1/chat/completions" \
           | jq -er '.choices[0].message.content // empty' \
-          | sed -e '/<think>/,/<\/think>/d' > /tmp/highlights.md
+          | sed -e '/<think>/,/<\/think>/d' \
+          | perl -CSD -pe 's/[\x{2014}\x{2013}]/-/g' > /tmp/highlights.md
 
       - name: Generate news bullets
         if: steps.decide.outputs.release == 'true'
@@ -226,7 +227,8 @@ jobs:
             -d @/tmp/newsreq.json \
             "${HIGHLIGHTS_API_URL}/v1/chat/completions" \
           | jq -er '.choices[0].message.content // empty' \
-          | sed -e '/<think>/,/<\/think>/d' > /tmp/newsbullets.md
+          | sed -e '/<think>/,/<\/think>/d' \
+          | perl -CSD -pe 's/[\x{2014}\x{2013}]/-/g' > /tmp/newsbullets.md
 
       - name: Install uv
         if: steps.decide.outputs.release == 'true'

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,13 +3,13 @@
 Newest first. Entries are the project's headline **features and capabilities**
 for users: new language support, analysis, querying, graph, and integrations.
 They are NOT for CI, developer tooling, release or build automation, refactors,
-documentation, tests, or bug fixes — leave that kind out. The top three entries
+documentation, tests, or bug fixes; leave that kind out. The top three entries
 are rendered into the README's "Latest News" section by
 `scripts/generate_readme.py`, so edit them here rather than in the README. The
 release workflow also prepends feature entries via `scripts/update_news.py`
 (which drops non-feature themes); hand edits remain welcome between releases.
 
-- **Runtime Call Tracing**: A dynamic tracer runs your code (typically the test suite) and merges the calls that actually happened into the graph as `CALLS` edges — flagged where static analysis missed them — so dispatch through interfaces, virtual methods, function pointers, reflection, and framework routing becomes visible. Convert a run from Python, the JVM, Node.js, .NET, PHP, Lua, Dart, or Go with `cgr trace`.
+- **Runtime Call Tracing**: A dynamic tracer runs your code (typically the test suite) and merges the calls that actually happened into the graph as `CALLS` edges (flagged where static analysis missed them), so dispatch through interfaces, virtual methods, function pointers, reflection, and framework routing becomes visible. Convert a run from Python, the JVM, Node.js, .NET, PHP, Lua, Dart, or Go with `cgr trace`.
 - **Ruby Support**: Ruby joins the graph through a new pluggable ast-grep tier that adds a language from a single YAML pattern file, emitting `Module`, `Function`, and `Class` nodes plus import edges without a hand-written parser.
 - **Structural Search & Replace**: Find and rewrite code by AST pattern with ast-grep, exposed as agent tools so you can match and transform structure across the whole codebase instead of relying on text or regex.
 - **Data-Flow Tracing**: New `FLOWS_TO` taint edges follow values through assignments, function calls, and I/O sinks. This release adds C#, Java, C, and Go, bringing tracing to 10 languages (Python, JavaScript, TypeScript/TSX, Go, Java, Rust, C++, C, and C#).

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Code-Graph-RAG parses a multi-language codebase with Tree-sitter, builds a knowl
 ## Latest News 🔥
 
 <!-- SECTION:latest_news -->
-- **Runtime Call Tracing**: A dynamic tracer runs your code (typically the test suite) and merges the calls that actually happened into the graph as `CALLS` edges — flagged where static analysis missed them — so dispatch through interfaces, virtual methods, function pointers, reflection, and framework routing becomes visible. Convert a run from Python, the JVM, Node.js, .NET, PHP, Lua, Dart, or Go with `cgr trace`.
+- **Runtime Call Tracing**: A dynamic tracer runs your code (typically the test suite) and merges the calls that actually happened into the graph as `CALLS` edges (flagged where static analysis missed them), so dispatch through interfaces, virtual methods, function pointers, reflection, and framework routing becomes visible. Convert a run from Python, the JVM, Node.js, .NET, PHP, Lua, Dart, or Go with `cgr trace`.
 - **Ruby Support**: Ruby joins the graph through a new pluggable ast-grep tier that adds a language from a single YAML pattern file, emitting `Module`, `Function`, and `Class` nodes plus import edges without a hand-written parser.
 - **Structural Search & Replace**: Find and rewrite code by AST pattern with ast-grep, exposed as agent tools so you can match and transform structure across the whole codebase instead of relying on text or regex.
 <!-- /SECTION:latest_news -->

--- a/codebase_rag/tests/test_update_news.py
+++ b/codebase_rag/tests/test_update_news.py
@@ -34,6 +34,16 @@ class TestExtractBullets:
     def test_empty_fragment_yields_nothing(self) -> None:
         assert extract_bullets("") == []
 
+    def test_normalises_em_and_en_dashes(self) -> None:
+        # House style forbids em/en dashes; the updater must strip them even if
+        # the model ignores the prompt instruction.
+        em, en = chr(0x2014), chr(0x2013)
+        fragment = f"- **Web Search**: search the web {em} fast, over 3{en}5 sources.\n"
+        (bullet,) = extract_bullets(fragment)
+        assert em not in bullet
+        assert en not in bullet
+        assert bullet == "- **Web Search**: search the web - fast, over 3-5 sources."
+
     def test_drops_non_feature_themed_bullets(self) -> None:
         fragment = (
             "- **Release Automation**: NEWS.md refreshes on every release.\n"

--- a/scripts/update_news.py
+++ b/scripts/update_news.py
@@ -52,6 +52,16 @@ def is_feature_theme(theme: str) -> bool:
     return NON_FEATURE_THEME.search(theme) is None
 
 
+def _normalize_dashes(text: str) -> str:
+    """Replace em-dashes and en-dashes with a hyphen; house style forbids them.
+
+    The generator prompts already ask the model to avoid them, but a prompt is
+    not a guarantee, so every bullet written into NEWS.md is normalised here.
+    ``chr`` keeps the dash characters out of this source file too.
+    """
+    return text.replace(chr(0x2014), "-").replace(chr(0x2013), "-")
+
+
 def extract_bullets(fragment: str) -> list[str]:
     """Return the well-formed, feature-themed news bullets in a fragment.
 
@@ -61,7 +71,7 @@ def extract_bullets(fragment: str) -> list[str]:
     """
     bullets: list[str] = []
     for line in fragment.splitlines():
-        stripped = line.rstrip()
+        stripped = _normalize_dashes(line.rstrip())
         match = BULLET_PATTERN.match(stripped)
         if match and is_feature_theme(match.group("theme")):
             bullets.append(stripped)


### PR DESCRIPTION
## Why

House style forbids em-dashes and en-dashes, and the release Highlights/News prompts already say so — but a prompt instruction is not enforcement, and the model (and I) still emit them. The Runtime Call Tracing NEWS entry shipped with two em-dashes, and the security-notice step wrote them straight into release bodies.

## What

- **Fix the live violation**: reworded the Runtime Call Tracing `NEWS.md` entry to use parentheses/commas, and regenerated the README.
- **Enforce at both generators**: the Highlights and News steps now pipe their model output through `perl -CSD -pe 's/[\x{2014}\x{2013}]/-/g'`, so em/en dashes are stripped before the text is used.
- **Belt-and-suspenders in the tested path**: `scripts/update_news.py` normalizes em/en dashes out of every bullet it writes into NEWS.md (covered by `test_normalises_em_and_en_dashes`).
- **Security notice**: replaced the em-dashes in the release security-notice text (they bypass the Highlights/News strip).

No literal em/en dash characters are introduced into the repo (the strippers use `\x{}` / `chr(0x2014)`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated news and feature-entry wording to use consistent comma punctuation instead of em dashes.
  * Preserved all documented feature descriptions and behavior.

* **Bug Fixes**
  * Improved generated news formatting by converting em and en dashes to standard hyphens.
  * Standardized punctuation in security advisories and fallback notices.

* **Tests**
  * Added coverage to verify consistent dash formatting in extracted news bullets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->