### PR TITLE
feat: flag sampled-profiler trace edges as approximate in the interchange format

### DIFF
--- a/codebase_rag/constants/trace.py
+++ b/codebase_rag/constants/trace.py
@@ -20,6 +20,12 @@ TRACE_KEY_LINE = "line"
 TRACE_KEY_COUNT = "count"
 TRACE_KEY_WORKLOADS = "workloads"
 TRACE_KEY_RECEIVER_TYPES = "receiver_types"
+# Header flag: True when the tracer sampled the call stack (pprof, V8 cpuprofile,
+# dotnet-trace, Dart CPU samples) so parent/child adjacency and counts are
+# approximate, False when it instrumented every call (Python sys.monitoring, the
+# JVM agent, Xdebug, the C shim, the Lua hook) so edges and counts are exact.
+# Absent in pre-flag trace files, which read back as exact.
+TRACE_KEY_SAMPLED = "sampled"
 
 TRACE_LANGUAGE_PYTHON = "python"
 TRACE_LANGUAGE_JVM = "jvm"
@@ -114,6 +120,10 @@ TRACE_PROP_WORKLOADS = "dynamic_workloads"
 TRACE_PROP_WORKLOAD_COUNT = "dynamic_workload_count"
 TRACE_PROP_RECEIVER_TYPES = "dynamic_receiver_types"
 TRACE_PROP_STATIC_MISSED = "static_missed"
+# True when the edge came from a sampling profiler, so its presence and
+# dynamic_call_count are approximate (a sampled edge that was never sampled is
+# not evidence of dead code); False when the tracer observed every call.
+TRACE_PROP_SAMPLED = "dynamic_sampled"
 
 
 class TraceUnresolvedReason(StrEnum):

--- a/codebase_rag/tests/test_dynamic_trace_ingest.py
+++ b/codebase_rag/tests/test_dynamic_trace_ingest.py
@@ -126,12 +126,13 @@ def _record(repo: Path, caller, callee, count, workloads=()):
     )
 
 
-def _write_trace(repo: Path, trace_path: Path, records) -> None:
+def _write_trace(repo: Path, trace_path: Path, records, sampled: bool = False) -> None:
     header = TraceHeader(
         version=cs.TRACE_FORMAT_VERSION,
         language=cs.TRACE_LANGUAGE_PYTHON,
         repo_root=str(repo),
         tracer=cs.TRACE_TOOL_NAME,
+        sampled=sampled,
     )
     write_trace_file(trace_path, header, records)
 
@@ -183,9 +184,37 @@ def test_ingest_confirms_static_and_flags_missed_edges(tmp_path):
     assert confirmed[cs.TRACE_PROP_DYNAMIC] is True
     assert confirmed[cs.TRACE_PROP_STATIC_MISSED] is False
     assert confirmed[cs.TRACE_PROP_CALL_COUNT] == 4
+    # An exact tracer's edges are not flagged approximate.
+    assert confirmed[cs.TRACE_PROP_SAMPLED] is False
     assert missed[cs.TRACE_PROP_STATIC_MISSED] is True
     assert missed[cs.TRACE_PROP_WORKLOADS] == ["t::one", "t::two"]
     assert missed[cs.TRACE_PROP_WORKLOAD_COUNT] == 2
+
+
+def test_ingest_flags_sampled_trace_edges_as_approximate(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    trace_path = tmp_path / "trace.jsonl"
+    _write_trace(
+        repo,
+        trace_path,
+        [
+            _record(
+                repo,
+                ("pkg/registry.py", "handle", 5),
+                ("pkg/registry.py", "greet", 9),
+                4,
+            ),
+        ],
+        sampled=True,
+    )
+    graph = _graph()
+
+    ingest_trace(trace_path, graph, repo, _PROJECT)
+
+    (props,) = [props for (_frm, _rel, _to, props) in graph.edges]
+    assert props[cs.TRACE_PROP_SAMPLED] is True
+    assert props[cs.TRACE_PROP_DYNAMIC] is True
 
 
 def test_ingest_aggregates_same_edge_and_is_idempotent(tmp_path):

--- a/codebase_rag/tests/test_dynamic_trace_instrumented.py
+++ b/codebase_rag/tests/test_dynamic_trace_instrumented.py
@@ -54,6 +54,7 @@ def test_converts_symbolised_pairs_with_exact_counts(tmp_path):
     header, records_iter = read_trace_file(output)
     records = list(records_iter)
     assert header.language == cs.TRACE_LANGUAGE_CPP
+    assert header.sampled is False
     assert count == len(records) == 2
     edges = {(r.caller.qualname, r.callee.qualname): r for r in records}
     assert edges[("main", "handle")].count == 7

--- a/codebase_rag/tests/test_dynamic_trace_pprof.py
+++ b/codebase_rag/tests/test_dynamic_trace_pprof.py
@@ -124,6 +124,7 @@ def test_converts_stacks_to_edges_with_sample_weights(tmp_path):
     count, header, records = _convert(tmp_path)
 
     assert header.language == cs.TRACE_LANGUAGE_GO
+    assert header.sampled is True
     assert count == len(records)
     edges = {(r.caller.qualname, r.callee.qualname): r for r in records}
     dispatch = edges[("handle", "greet")]

--- a/codebase_rag/tests/test_dynamic_trace_records.py
+++ b/codebase_rag/tests/test_dynamic_trace_records.py
@@ -9,7 +9,14 @@ import json
 import pytest
 
 from codebase_rag import constants as cs
-from codebase_rag.trace.records import TraceFormatError, read_trace_file
+from codebase_rag.trace.records import (
+    CallRecord,
+    FramePoint,
+    TraceFormatError,
+    TraceHeader,
+    read_trace_file,
+    write_trace_file,
+)
 
 
 def _frame(line: object = 3) -> dict[str, object]:
@@ -133,6 +140,43 @@ def test_blank_lines_are_skipped(tmp_path):
     _header, records = read_trace_file(trace_path)
 
     assert list(records) == []
+
+
+@pytest.mark.parametrize("sampled", [True, False])
+def test_sampled_flag_round_trips(tmp_path, sampled):
+    trace_path = tmp_path / "trace.jsonl"
+    header = TraceHeader(
+        version=cs.TRACE_FORMAT_VERSION,
+        language=cs.TRACE_LANGUAGE_GO,
+        repo_root="/repo",
+        tracer=cs.TRACE_TOOL_NAME_PPROF,
+        sampled=sampled,
+    )
+    record = CallRecord(
+        caller=FramePoint(path="/repo/a.go", qualname="a", line=1),
+        callee=FramePoint(path="/repo/b.go", qualname="b", line=2),
+        count=1,
+        workloads=(),
+        receiver_types=(),
+    )
+    write_trace_file(trace_path, header, [record])
+    parsed, _records = read_trace_file(trace_path)
+    assert parsed.sampled is sampled
+
+
+def test_header_without_sampled_key_reads_as_exact(tmp_path):
+    # Pre-flag trace files omit `sampled`; they must remain readable and be
+    # treated as exact rather than rejected.
+    trace_path = _write_raw(tmp_path, _header_line())
+    header, _records = read_trace_file(trace_path)
+    assert header.sampled is False
+
+
+@pytest.mark.parametrize("sampled", ["true", 1, 0, None])
+def test_non_bool_sampled_is_rejected(tmp_path, sampled):
+    trace_path = _write_raw(tmp_path, _header_line(**{cs.TRACE_KEY_SAMPLED: sampled}))
+    with pytest.raises(TraceFormatError):
+        read_trace_file(trace_path)
 
 
 def test_lua_language_tag_constant():

--- a/codebase_rag/tests/test_dynamic_trace_speedscope.py
+++ b/codebase_rag/tests/test_dynamic_trace_speedscope.py
@@ -67,6 +67,8 @@ def test_converts_adjacent_project_frames_to_edges(tmp_path):
     count, header, records = _convert(tmp_path, profile)
 
     assert header.language == cs.TRACE_LANGUAGE_DOTNET
+    # A sampled speedscope profile yields approximate edges.
+    assert header.sampled is True
     assert count == len(records)
     edges = {(r.caller.qualname, r.callee.qualname): r for r in records}
     assert ("MyApp.Services.Registry.Handle", "MyApp.Services.Registry.Greet") in edges
@@ -161,6 +163,9 @@ def test_converts_evented_profiles_from_dotnet_trace(tmp_path):
     count, header, records = _convert(tmp_path, profile)
 
     assert header.language == cs.TRACE_LANGUAGE_DOTNET
+    # An evented profile records explicit open/close events, so its edges are
+    # exact and must not be flagged approximate.
+    assert header.sampled is False
     assert count == len(records)
     edges = {(r.caller.qualname, r.callee.qualname): r for r in records}
     # Main opened Handle twice through BCL glue; Handle opened Greet once.

--- a/codebase_rag/trace/cpuprofile.py
+++ b/codebase_rag/trace/cpuprofile.py
@@ -217,6 +217,7 @@ def convert_cpuprofile(
         language=cs.TRACE_LANGUAGE_JS,
         repo_root=str(repo_root),
         tracer=cs.TRACE_TOOL_NAME_CPUPROFILE,
+        sampled=True,
     )
     write_trace_file(output, header, records)
     return len(records)

--- a/codebase_rag/trace/dart_collector/bin/cgr_trace_collect.dart
+++ b/codebase_rag/trace/dart_collector/bin/cgr_trace_collect.dart
@@ -177,6 +177,8 @@ Future<void> main(List<String> argv) async {
     'language': 'dart',
     'repo_root': repo,
     'tracer': 'cgr-trace-dart',
+    // The VM Service delivers CPU samples, so edges and counts are approximate.
+    'sampled': true,
   }));
   final workloads = workload == null ? <String>[] : [workload];
   for (final (caller, callee, count) in edges.values) {

--- a/codebase_rag/trace/ingest.py
+++ b/codebase_rag/trace/ingest.py
@@ -138,7 +138,7 @@ def _load_existing_calls(
 
 
 def _edge_properties(
-    stats: _EdgeStats, static_missed: bool
+    stats: _EdgeStats, static_missed: bool, sampled: bool
 ) -> dict[str, PropertyValue]:
     workloads = sorted(stats.workloads)[: cs.TRACE_MAX_WORKLOADS_PER_EDGE]
     receivers = sorted(stats.receiver_types)[: cs.TRACE_MAX_RECEIVER_TYPES_PER_EDGE]
@@ -149,6 +149,7 @@ def _edge_properties(
         cs.TRACE_PROP_WORKLOADS: workloads,
         cs.TRACE_PROP_RECEIVER_TYPES: receivers,
         cs.TRACE_PROP_STATIC_MISSED: static_missed,
+        cs.TRACE_PROP_SAMPLED: sampled,
     }
 
 
@@ -194,7 +195,7 @@ def ingest_trace(
             (caller.label, cs.KEY_QUALIFIED_NAME, caller.qualified_name),
             cs.RelationshipType.CALLS,
             (callee.label, cs.KEY_QUALIFIED_NAME, callee.qualified_name),
-            properties=_edge_properties(stats, static_missed),
+            properties=_edge_properties(stats, static_missed, header.sampled),
         )
     ingestor.flush_all()
     logger.info(

--- a/codebase_rag/trace/instrumented.py
+++ b/codebase_rag/trace/instrumented.py
@@ -186,6 +186,7 @@ def convert_instrumented(
         language=cs.TRACE_LANGUAGE_CPP,
         repo_root=str(repo_root),
         tracer=cs.TRACE_TOOL_NAME_INSTRUMENTED,
+        sampled=False,
     )
     write_trace_file(output, header, records)
     return len(records)

--- a/codebase_rag/trace/pprof.py
+++ b/codebase_rag/trace/pprof.py
@@ -324,6 +324,7 @@ def convert_pprof(
         language=cs.TRACE_LANGUAGE_GO,
         repo_root=str(repo_root),
         tracer=cs.TRACE_TOOL_NAME_PPROF,
+        sampled=True,
     )
     write_trace_file(output, header, records)
     return len(records)

--- a/codebase_rag/trace/records.py
+++ b/codebase_rag/trace/records.py
@@ -37,6 +37,7 @@ class TraceHeader:
     language: str
     repo_root: str
     tracer: str
+    sampled: bool = False
 
 
 @dataclass(slots=True)
@@ -77,12 +78,13 @@ def write_trace_file(
     output: Path, header: TraceHeader, records: Iterable[CallRecord]
 ) -> None:
     with output.open("w", encoding="utf-8") as fh:
-        header_row: dict[str, str | int] = {
+        header_row: dict[str, str | int | bool] = {
             cs.TRACE_KEY_KIND: cs.TRACE_KIND_HEADER,
             cs.TRACE_KEY_VERSION: header.version,
             cs.TRACE_KEY_LANGUAGE: header.language,
             cs.TRACE_KEY_REPO_ROOT: header.repo_root,
             cs.TRACE_KEY_TRACER: header.tracer,
+            cs.TRACE_KEY_SAMPLED: header.sampled,
         }
         fh.write(json.dumps(header_row) + "\n")
         for record in records:
@@ -116,14 +118,22 @@ def _parse_header(trace_path: Path, line: str) -> TraceHeader:
     language = raw.get(cs.TRACE_KEY_LANGUAGE)
     repo_root = raw.get(cs.TRACE_KEY_REPO_ROOT)
     tracer = raw.get(cs.TRACE_KEY_TRACER)
+    # Pre-flag trace files omit `sampled`; they read back as exact. A present
+    # value must be a real boolean, not a truthy string or number.
+    sampled = raw.get(cs.TRACE_KEY_SAMPLED, False)
     if (
         not isinstance(language, str)
         or not isinstance(repo_root, str)
         or not isinstance(tracer, str)
+        or not isinstance(sampled, bool)
     ):
         raise TraceFormatError(cs.TRACE_ERR_BAD_HEADER.format(path=trace_path))
     return TraceHeader(
-        version=version, language=language, repo_root=repo_root, tracer=tracer
+        version=version,
+        language=language,
+        repo_root=repo_root,
+        tracer=tracer,
+        sampled=sampled,
     )
 
 

--- a/codebase_rag/trace/speedscope.py
+++ b/codebase_rag/trace/speedscope.py
@@ -149,9 +149,15 @@ def _accumulate_profiles(
     names: list[str | None],
     edges: dict[tuple[str, str], float],
     profile_path: Path,
-) -> None:
-    """Accumulate every recognised profile; raise if none was usable."""
+) -> bool:
+    """Accumulate every recognised profile; raise if none was usable.
+
+    Returns True when any accumulated profile was ``sampled`` (its edges are
+    approximate). An ``evented`` profile records explicit frame open/close
+    observations, so its edges are exact; a file mixing both is approximate.
+    """
     converted = False
+    sampled = False
     for raw_profile in profiles:
         if not isinstance(raw_profile, dict):
             continue
@@ -159,6 +165,7 @@ def _accumulate_profiles(
         kind = profile.get("type")
         if kind == "sampled":
             ok = _accumulate_sampled(profile, names, edges)
+            sampled = sampled or ok
         elif kind == "evented":
             ok = _accumulate_evented(profile, names, edges)
         else:
@@ -170,6 +177,7 @@ def _accumulate_profiles(
         converted = True
     if not converted:
         raise TraceFormatError(cs.TRACE_ERR_BAD_SPEEDSCOPE.format(path=profile_path))
+    return sampled
 
 
 def convert_speedscope(
@@ -194,7 +202,7 @@ def convert_speedscope(
     # Fractional sample weights accumulate as-is and round half-up only at
     # emission, so their combined contribution is never truncated away.
     edges: dict[tuple[str, str], float] = {}
-    _accumulate_profiles(profiles, names, edges, profile_path)
+    sampled = _accumulate_profiles(profiles, names, edges, profile_path)
 
     workloads = (workload,) if workload else ()
     records = [
@@ -212,7 +220,7 @@ def convert_speedscope(
         language=cs.TRACE_LANGUAGE_DOTNET,
         repo_root="",
         tracer=cs.TRACE_TOOL_NAME_SPEEDSCOPE,
-        sampled=True,
+        sampled=sampled,
     )
     write_trace_file(output, header, records)
     return len(records)

--- a/codebase_rag/trace/speedscope.py
+++ b/codebase_rag/trace/speedscope.py
@@ -212,6 +212,7 @@ def convert_speedscope(
         language=cs.TRACE_LANGUAGE_DOTNET,
         repo_root="",
         tracer=cs.TRACE_TOOL_NAME_SPEEDSCOPE,
+        sampled=True,
     )
     write_trace_file(output, header, records)
     return len(records)

--- a/codebase_rag/trace/tracer.py
+++ b/codebase_rag/trace/tracer.py
@@ -171,6 +171,7 @@ class CallGraphTracer:
             language=cs.TRACE_LANGUAGE_PYTHON,
             repo_root=str(self._repo_root),
             tracer=cs.TRACE_TOOL_NAME,
+            sampled=False,
         )
         write_trace_file(output, header, records)
         return len(records)

--- a/codebase_rag/trace/xdebug.py
+++ b/codebase_rag/trace/xdebug.py
@@ -164,6 +164,7 @@ def convert_xdebug_trace(
         language=cs.TRACE_LANGUAGE_PHP,
         repo_root="",
         tracer=cs.TRACE_TOOL_NAME_XDEBUG,
+        sampled=False,
     )
     write_trace_file(output, header, records)
     return len(records)

--- a/docs/guide/dynamic-tracing.md
+++ b/docs/guide/dynamic-tracing.md
@@ -293,6 +293,7 @@ properties:
 | `dynamic_workloads` | Test ids that exercised the edge (capped list). |
 | `dynamic_workload_count` | Uncapped number of distinct workloads. |
 | `dynamic_receiver_types` | Concrete receiver types observed for method calls. |
+| `dynamic_sampled` | `true` when the edge came from a sampling profiler (Go pprof, Node.js/V8, .NET `dotnet-trace`, Dart CPU samples), so its presence and `dynamic_call_count` are approximate; `false` when the tracer observed every call (Python, the JVM agent, Xdebug, the C shim, the Lua hook), so counts are exact. |
 | `static_missed: true` | No matching static `CALLS` edge existed in the graph at ingest time. Dynamic dispatch, reflection, and registries are the common causes; a stale or incomplete static graph produces the same flag. |
 
 An edge with `dynamic: true` and `static_missed: false` is a static edge


### PR DESCRIPTION
## What

Adds a `sampled` boolean to the trace interchange header and a `dynamic_sampled` property on the CALLS edges written by ingestion, so an edge captured by a sampling profiler is honestly distinguishable from one observed by an exact tracer.

Sampling profilers (Go pprof, Node.js/V8 cpuprofile, .NET `dotnet-trace`, Dart CPU samples) infer parent/child adjacency and counts from stack samples, so a missing edge is not evidence of dead code and `dynamic_call_count` is a relative weight. Exact tracers (Python `sys.monitoring`, the JVM agent, Xdebug, the C shim, the Lua hook) observe every call. Until now both looked identical in the graph.

## Why

This is the interchange-format field the runtime-tracing epic (#1244) called for and that #1255 (Dart, VM Service CPU samples) needs for its acceptance criterion "sampled edges clearly distinguishable from exact edges in the graph". The gap affected every sampled-profile language, not just Dart.

## Changes

- `TraceHeader.sampled` (defaults to `False`); written and parsed in the JSONL header. Pre-flag trace files omit the key and read back as exact; a present value must be a real boolean.
- Each converter tags its header: pprof/cpuprofile/speedscope and the Dart collector set `sampled=true`; the instrumented (C/C++), Xdebug (PHP), and Python tracers set `sampled=false`. The JVM and Lua agents are exact and rely on the default.
- Ingestion stamps `dynamic_sampled` on every edge from the header flag.
- Docs: new row in the edge-property table.

## Tests

- Round-trip of both flag values; backward-compat (missing key reads as exact); non-boolean rejection.
- Ingestion stamps `dynamic_sampled` true for a sampled trace and false for an exact one.
- Converter-level assertions (pprof sampled, instrumented exact).

Refs #1244, #1255.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trace data now records whether it originated from sampling-based profiling.
  * Dynamic call-graph edges indicate when their data is approximate due to sampling.
  * Sampled and fully instrumented traces are clearly distinguished across supported formats.
  * Trace formats remain compatible with older records lacking sampling metadata.

* **Documentation**
  * Updated dynamic tracing documentation to explain sampled data, approximate counts, and trace accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->