### PR TITLE
feat: demonstrate C++ virtual-dispatch tracing and report unresolved addresses

### DIFF
--- a/codebase_rag/constants/trace.py
+++ b/codebase_rag/constants/trace.py
@@ -73,6 +73,10 @@ TRACE_ERR_ADDRS_DROPPED = (
     "{path} overflowed the shim's edge table: call edges were dropped, so the "
     "trace is incomplete and cannot honour exact invocation counts."
 )
+TRACE_MSG_ADDRS_UNRESOLVED = (
+    "{count} of {total} instrumented addresses did not symbolise to a source "
+    "position (missing debug info or stripped symbols); their edges were dropped."
+)
 TRACE_ERR_BAD_XDEBUG = (
     "{path} is not an Xdebug computerized trace (expected 'File format: 4')."
 )

--- a/codebase_rag/tests/test_dynamic_trace_instrumented.py
+++ b/codebase_rag/tests/test_dynamic_trace_instrumented.py
@@ -13,6 +13,7 @@ import textwrap
 from pathlib import Path
 
 import pytest
+from loguru import logger
 
 from codebase_rag import constants as cs
 from codebase_rag.trace.instrumented import convert_instrumented
@@ -120,7 +121,36 @@ def test_malformed_addrs_is_rejected(tmp_path):
         )
 
 
+def test_unresolved_addresses_are_reported(tmp_path):
+    # An address that symbolises to no source position (stripped symbols /
+    # missing debug info) must be reported, not silently dropped.
+    repo = tmp_path.as_posix()
+    symbols = {
+        0x1000: ("main", f"{repo}/main.c", 3),
+        0x2000: ("run", f"{repo}/main.c", 7),
+        0x3000: ("??", "??", 0),
+    }
+    addrs_path = _write_addrs(tmp_path, [(0x1000, 0x2000, 4), (0x2000, 0x3000, 2)])
+
+    messages: list[str] = []
+    sink_id = logger.add(messages.append, level="WARNING", format="{message}")
+    try:
+        count = convert_instrumented(
+            addrs_path,
+            repo_root=tmp_path,
+            output=tmp_path / "trace.jsonl",
+            symbolizer=lambda _e, _s, _a: symbols,
+        )
+    finally:
+        logger.remove(sink_id)
+
+    # The run -> ?? edge is dropped; only main -> run survives.
+    assert count == 1
+    assert any("did not symbolise" in message for message in messages)
+
+
 cc = shutil.which("cc")
+cxx = shutil.which("c++") or shutil.which("g++")
 atos = shutil.which("atos") or shutil.which("addr2line")
 
 
@@ -194,3 +224,87 @@ def test_live_instrumented_binary_produces_registry_dispatch(tmp_path):
     assert dispatch is not None, sorted(edges)
     assert dispatch.count == 5
     assert edges[("main", "handle")].count == 5
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    sys.platform == "win32" or cc is None or cxx is None or atos is None,
+    reason="C/C++ toolchain unavailable, or Windows/PE (the shim targets ELF/Mach-O)",
+)
+def test_live_cpp_virtual_dispatch_produces_virtual_edge(tmp_path):
+    (tmp_path / "main.cpp").write_text(
+        textwrap.dedent("""
+            struct Animal {
+                virtual ~Animal() = default;
+                virtual int speak() = 0;
+            };
+            struct Dog : Animal {
+                int speak() override;
+            };
+            int Dog::speak() { return 7; }
+
+            static int dispatch(Animal* a) {
+                return a->speak();     // virtual call through the trait object
+            }
+
+            int main() {
+                Dog d;
+                int out = 0;
+                for (int i = 0; i < 5; i++) {
+                    out += dispatch(&d);
+                }
+                return out == 35 ? 0 : 1;
+            }
+        """)
+    )
+    shim_object = tmp_path / "shim.o"
+    main_object = tmp_path / "main.o"
+    binary = tmp_path / "app"
+    # The shim is C: a C++ driver would compile the .c file as C++ and fail, so
+    # build it with the C compiler and link the instrumented C++ object with the
+    # C++ driver. Only the C++ translation unit carries -finstrument-functions.
+    subprocess.run(
+        [str(cc), "-pthread", "-c", str(_SHIM), "-o", str(shim_object)],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        [
+            str(cxx),
+            "-finstrument-functions",
+            "-g",
+            "-O0",
+            "-c",
+            str(tmp_path / "main.cpp"),
+            "-o",
+            str(main_object),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        [str(cxx), "-pthread", str(main_object), str(shim_object), "-o", str(binary)],
+        check=True,
+        capture_output=True,
+    )
+    addrs = tmp_path / "cgr-trace.addrs"
+    subprocess.run(
+        [str(binary)],
+        check=True,
+        capture_output=True,
+        env=dict(os.environ, CGR_TRACE_ADDRS=str(addrs)),
+        cwd=tmp_path,
+    )
+
+    output = tmp_path / "trace.jsonl"
+    count = convert_instrumented(addrs, repo_root=tmp_path, output=output)
+
+    assert count > 0
+    header, records_iter = read_trace_file(output)
+    assert header.language == cs.TRACE_LANGUAGE_CPP
+    edges = {(r.caller.qualname, r.callee.qualname): r for r in records_iter}
+    # The virtual call a->speak() resolves to Dog::speak - the runtime-only edge
+    # static analysis cannot resolve through the abstract Animal interface.
+    virtual = edges.get(("dispatch", "speak"))
+    assert virtual is not None, sorted(edges)
+    assert virtual.count == 5

--- a/codebase_rag/tests/test_dynamic_trace_instrumented.py
+++ b/codebase_rag/tests/test_dynamic_trace_instrumented.py
@@ -122,15 +122,19 @@ def test_malformed_addrs_is_rejected(tmp_path):
 
 
 def test_unresolved_addresses_are_reported(tmp_path):
-    # An address that symbolises to no source position (stripped symbols /
-    # missing debug info) must be reported, not silently dropped.
+    # An address that symbolises to no usable source position must be reported,
+    # not silently dropped. Two failure modes: no name at all (`??`), and a
+    # valid name with no file/line because debug info was stripped.
     repo = tmp_path.as_posix()
     symbols = {
         0x1000: ("main", f"{repo}/main.c", 3),
         0x2000: ("run", f"{repo}/main.c", 7),
         0x3000: ("??", "??", 0),
+        0x4000: ("stripped_fn", "", 0),
     }
-    addrs_path = _write_addrs(tmp_path, [(0x1000, 0x2000, 4), (0x2000, 0x3000, 2)])
+    addrs_path = _write_addrs(
+        tmp_path, [(0x1000, 0x2000, 4), (0x2000, 0x3000, 2), (0x2000, 0x4000, 1)]
+    )
 
     messages: list[str] = []
     sink_id = logger.add(messages.append, level="WARNING", format="{message}")
@@ -144,9 +148,12 @@ def test_unresolved_addresses_are_reported(tmp_path):
     finally:
         logger.remove(sink_id)
 
-    # The run -> ?? edge is dropped; only main -> run survives.
+    # Only main -> run survives; both the ?? and the position-less named frame
+    # are dropped, and both are counted in the warning (2 of 4 addresses).
     assert count == 1
-    assert any("did not symbolise" in message for message in messages)
+    assert any(
+        "2 of 4" in message and "did not symbolise" in message for message in messages
+    )
 
 
 cc = shutil.which("cc")

--- a/codebase_rag/trace/instrumented.py
+++ b/codebase_rag/trace/instrumented.py
@@ -21,6 +21,8 @@ import subprocess
 from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING
 
+from loguru import logger
+
 from .. import constants as cs
 from .records import (
     CallRecord,
@@ -154,9 +156,17 @@ def convert_instrumented(
     symbols = resolve(exe, slide, addresses)
 
     root_prefix = repo_root.resolve().as_posix() + "/"
+    # An address that symbolised to no source position at all (addr2line/atos
+    # returned an empty name or ``??``) is genuinely unresolved, distinct from an
+    # address that resolved to glue outside the repository; report the former so
+    # a symbolisation gap is visible rather than silently dropped.
+    unresolved: set[int] = set()
 
     def _frame(address: int) -> FramePoint | None:
         name, path, line = symbols.get(address, ("", "", 0))
+        if not name or name == "??":
+            unresolved.add(address)
+            return None
         if not path.startswith(root_prefix) or line <= 0:
             return None
         return FramePoint(path=path, qualname=_bare_name(name), line=line)
@@ -169,6 +179,13 @@ def convert_instrumented(
             continue
         key = (caller, callee)
         edges[key] = edges.get(key, 0) + count
+
+    if unresolved:
+        logger.warning(
+            cs.TRACE_MSG_ADDRS_UNRESOLVED.format(
+                count=len(unresolved), total=len(addresses)
+            )
+        )
 
     workloads = (workload,) if workload else ()
     records = [

--- a/codebase_rag/trace/instrumented.py
+++ b/codebase_rag/trace/instrumented.py
@@ -156,18 +156,19 @@ def convert_instrumented(
     symbols = resolve(exe, slide, addresses)
 
     root_prefix = repo_root.resolve().as_posix() + "/"
-    # An address that symbolised to no source position at all (addr2line/atos
-    # returned an empty name or ``??``) is genuinely unresolved, distinct from an
-    # address that resolved to glue outside the repository; report the former so
-    # a symbolisation gap is visible rather than silently dropped.
+    # An address that symbolised to no usable source position (addr2line/atos
+    # returned an empty/``??`` name, or a name but no file/line because debug
+    # info was stripped) is genuinely unresolved, distinct from an address that
+    # resolved to a real position in glue outside the repository; report the
+    # former so a symbolisation gap is visible rather than silently dropped.
     unresolved: set[int] = set()
 
     def _frame(address: int) -> FramePoint | None:
         name, path, line = symbols.get(address, ("", "", 0))
-        if not name or name == "??":
+        if not name or name == "??" or not path or path == "??" or line <= 0:
             unresolved.add(address)
             return None
-        if not path.startswith(root_prefix) or line <= 0:
+        if not path.startswith(root_prefix):
             return None
         return FramePoint(path=path, qualname=_bare_name(name), line=line)
 

--- a/docs/guide/dynamic-tracing.md
+++ b/docs/guide/dynamic-tracing.md
@@ -251,6 +251,8 @@ A single-file shim (`codebase_rag/trace/c_agent/cgr_trace_shim.c`, no
 dependencies beyond pthreads) rides the compiler's own instrumentation and
 records **every call exactly**:
 
+For a **C** project, compile the sources and the shim together:
+
 ```bash
 cc -pthread -finstrument-functions -g -O0 your_sources... \
    codebase_rag/trace/c_agent/cgr_trace_shim.c -o app
@@ -259,19 +261,36 @@ cgr trace convert cgr-trace.addrs --repo-path /path/to/your-repo --workload smok
 cgr trace ingest cgr-trace.jsonl --repo-path /path/to/your-repo
 ```
 
+For a **C++** project, compile the shim with the C compiler (it is C, and a
+C++ driver would compile the `.c` file as C++ and fail) and link the
+instrumented C++ objects with the C++ driver; only the C++ translation units
+carry `-finstrument-functions`:
+
+```bash
+cc  -pthread -c codebase_rag/trace/c_agent/cgr_trace_shim.c -o cgr_shim.o
+c++ -pthread -finstrument-functions -g -O0 -c your_sources... # -> *.o
+c++ -pthread your_objects... cgr_shim.o -o app
+```
+
+In CMake, add `cgr_trace_shim.c` to the target's sources (CMake compiles a
+`.c` file with the C compiler on its own) and set
+`-finstrument-functions -g -O0` on the traced build type; the shim links in
+without a separate step.
+
 The shim records function-address pairs and the main image's load bias;
 conversion symbolises them with `atos` (macOS) or `addr2line` (ELF). PIE
 binaries need no special build flag — the shim records the ASLR slide and
 the converter subtracts it before symbolising, so the default hardened
-(PIE) build works. Calls through function pointers and virtual dispatch
-land with true invocation counts; C++ names demangle and normalise to their
-bare member form, with source positions carrying identity. Frames that
+(PIE) build works. Calls through function pointers (C) and virtual dispatch
+(C++) land with true invocation counts; C++ names demangle and normalise to
+their bare member form, with source positions carrying identity. Frames that
 symbolise outside the repository (libc, the C++ runtime) drop their edges
-rather than being guessed. Overhead is one mutex-guarded table insert per
-call — fine for test workloads, not for production; the edge table holds
-65k distinct pairs, and conversion **rejects** a trace the shim marked
-`dropped` (table overflowed) rather than pass off an incomplete call graph
-as exact.
+rather than being guessed, and addresses that do not symbolise at all
+(stripped symbols, missing debug info) are counted and reported rather than
+silently dropped. Overhead is one mutex-guarded table insert per call — fine
+for test workloads, not for production; the edge table holds 65k distinct
+pairs, and conversion **rejects** a trace the shim marked `dropped` (table
+overflowed) rather than pass off an incomplete call graph as exact.
 
 ## Ingesting a trace
 

--- a/docs/guide/dynamic-tracing.md
+++ b/docs/guide/dynamic-tracing.md
@@ -285,9 +285,10 @@ the converter subtracts it before symbolising, so the default hardened
 (C++) land with true invocation counts; C++ names demangle and normalise to
 their bare member form, with source positions carrying identity. Frames that
 symbolise outside the repository (libc, the C++ runtime) drop their edges
-rather than being guessed, and addresses that do not symbolise at all
-(stripped symbols, missing debug info) are counted and reported rather than
-silently dropped. Overhead is one mutex-guarded table insert per call — fine
+rather than being guessed. An edge whose caller or callee does not resolve to
+a project frame is excluded from the converted trace; addresses that do not
+symbolise at all (stripped symbols, missing debug info) are additionally
+counted and reported, so that symbolisation gap is visible rather than silent. Overhead is one mutex-guarded table insert per call — fine
 for test workloads, not for production; the edge table holds 65k distinct
 pairs, and conversion **rejects** a trace the shim marked `dropped` (table
 overflowed) rather than pass off an incomplete call graph as exact.


### PR DESCRIPTION
## What

Closes the two dominant gaps that kept #1252 open: the C++ virtual-call demonstration and the silent dropping of unresolvable addresses.

## Why

The instrumented C/C++ tracer already worked for C (function-pointer dispatch, live-tested), but #1252's acceptance criteria also require a demonstrated **C++ virtual-call** edge and that **unresolved addresses be reported** rather than silently dropped. Neither existed.

## Changes

- **C++ virtual-dispatch live test** (`test_live_cpp_virtual_dispatch_produces_virtual_edge`, `@pytest.mark.slow`, skipped without a C/C++ toolchain): compiles an `Animal`/`Dog` program where `dispatch(Animal*)` calls `a->speak()` through the abstract interface, runs the instrumented binary, and asserts the runtime-only `dispatch -> speak` edge (count 5) that static analysis cannot resolve through the trait object. The test encodes the correct build recipe — the shim is C, so it is compiled with the C compiler (`cc -c`) and linked with the C++ objects by the C++ driver; only the C++ translation unit carries `-finstrument-functions`. Compiling the `.c` shim with a C++ driver fails, which is why this was never demonstrated before.
- **Unresolved-address reporting**: `convert_instrumented` now distinguishes an address that symbolised to no source position at all (empty name or `??` from addr2line/atos — stripped symbols or missing debug info) from one that resolved to glue outside the repo, and logs a warning with the count (`TRACE_MSG_ADDRS_UNRESOLVED`) instead of dropping it silently. Unit-tested.
- **Docs**: the C/C++ section now gives separate C and C++ build recipes (including the CMake note) and documents the unresolved-address reporting.

## Tests

- `test_live_cpp_virtual_dispatch_produces_virtual_edge` — real compile + run, asserts the virtual edge (verified locally with gcc/g++/addr2line).
- `test_unresolved_addresses_are_reported` — a `??` symbol is dropped and the warning fires.

Refs #1252, #1244.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dynamic tracing now reports unresolved addresses instead of silently dropping them.
  * Unresolved trace edges are excluded from results while their counts remain visible in warnings.
  * C++ virtual dispatch traces now correctly capture runtime call relationships and invocation counts.

* **Documentation**
  * Updated C and C++ dynamic tracing setup instructions, including CMake guidance.
  * Clarified behavior for function pointers, virtual dispatch, and unsymbolized addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->