### PR TITLE
feat: capture the concrete receiver class on PHP instance-call trace edges

### DIFF
--- a/codebase_rag/tests/test_dynamic_trace_xdebug.py
+++ b/codebase_rag/tests/test_dynamic_trace_xdebug.py
@@ -6,11 +6,30 @@
 
 from __future__ import annotations
 
+import shutil
+import subprocess
+import textwrap
+
 import pytest
 
 from codebase_rag import constants as cs
 from codebase_rag.trace.records import read_trace_file
 from codebase_rag.trace.xdebug import convert_xdebug_trace
+
+
+def _php_with_xdebug() -> str | None:
+    """The php interpreter path when it can load Xdebug, else None."""
+    php = shutil.which("php")
+    if php is None:
+        return None
+    probe = subprocess.run(
+        [php, "-r", 'echo extension_loaded("xdebug") ? "yes" : "no";'],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return php if probe.stdout.strip() == "yes" else None
+
 
 _HEADER = "Version: 3.5.3\nFile format: 4\nTRACE START [2026-08-14 02:07:42]\n"
 _FOOTER = "\t\t\t0.001855\t479056\nTRACE END   [2026-08-14 02:07:42]\n"
@@ -137,6 +156,24 @@ def test_callee_defining_files_are_recovered_from_child_call_sites(tmp_path):
     assert handle.callee.line == 16
 
 
+def test_instance_calls_capture_the_concrete_receiver_class(tmp_path):
+    # Xdebug names an instance call with the runtime class, so the converter
+    # records which implementation ran; static calls carry no receiver type.
+    repo = tmp_path.as_posix()
+    _count, _header, records = _convert(tmp_path, _sample_rows(repo))
+
+    edges = {(r.caller.qualname, r.callee.qualname): r for r in records}
+    assert edges[("describeAnimal", r"App\Services\Dog->sound")].receiver_types == (
+        "Dog",
+    )
+    assert edges[("describeAnimal", r"App\Services\Cat->sound")].receiver_types == (
+        "Cat",
+    )
+    # A static call is not dynamic dispatch: no receiver type.
+    handle = edges[("{main}", r"App\Services\Registry::handle")]
+    assert handle.receiver_types == ()
+
+
 def test_workload_label_lands_on_every_record(tmp_path):
     repo = tmp_path.as_posix()
     _count, _header, records = _convert(
@@ -154,3 +191,64 @@ def test_malformed_trace_is_rejected(tmp_path):
 
     with pytest.raises(ValueError):
         convert_xdebug_trace(trace_path, output=tmp_path / "out.jsonl")
+
+
+_php = _php_with_xdebug()
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(_php is None, reason="php with the Xdebug extension is unavailable")
+def test_live_xdebug_trace_captures_polymorphic_dispatch(tmp_path):
+    # dispatch(Animal) calls $a->sound() through the interface; static analysis
+    # cannot know which implementation runs. The trace records the concrete
+    # Dog/Cat receiver on each edge, and a trait method called on the using
+    # class is captured too.
+    (tmp_path / "app.php").write_text(
+        textwrap.dedent("""\
+            <?php
+            interface Animal { public function sound(): string; }
+            class Dog implements Animal { public function sound(): string { return "woof"; } }
+            class Cat implements Animal { public function sound(): string { return "meow"; } }
+            trait TGreeter { public function greet(): string { return get_class($this); } }
+            class Service { use TGreeter; }
+            function dispatch(Animal $a): string { return $a->sound(); }
+            function run(): void {
+                foreach ([new Dog(), new Cat(), new Dog()] as $a) { dispatch($a); }
+                (new Service())->greet();
+            }
+            run();
+            """)
+    )
+    assert _php is not None
+    subprocess.run(
+        [
+            _php,
+            "-d",
+            "xdebug.mode=trace",
+            "-d",
+            "xdebug.start_with_request=yes",
+            "-d",
+            "xdebug.trace_format=1",
+            "-d",
+            "xdebug.output_dir=.",
+            "-d",
+            "xdebug.trace_output_name=run",
+            "app.php",
+        ],
+        check=True,
+        capture_output=True,
+        cwd=tmp_path,
+    )
+    trace = next(tmp_path.glob("run.xt*"))
+    output = tmp_path / "trace.jsonl"
+    count = convert_xdebug_trace(trace, output=output, workload="phpunit")
+
+    assert count > 0
+    _header, records_iter = read_trace_file(output)
+    edges = {(r.caller.qualname, r.callee.qualname): r for r in records_iter}
+    dog = edges[("dispatch", "Dog->sound")]
+    assert dog.count == 2
+    assert dog.receiver_types == ("Dog",)
+    assert edges[("dispatch", "Cat->sound")].receiver_types == ("Cat",)
+    # The trait method greet() called on the using class is observed too.
+    assert edges[("run", "Service->greet")].receiver_types == ("Service",)

--- a/codebase_rag/tests/test_dynamic_trace_xdebug.py
+++ b/codebase_rag/tests/test_dynamic_trace_xdebug.py
@@ -18,16 +18,25 @@ from codebase_rag.trace.xdebug import convert_xdebug_trace
 
 
 def _php_with_xdebug() -> str | None:
-    """The php interpreter path when it can load Xdebug, else None."""
+    """The php interpreter path when it can load Xdebug, else None.
+
+    Evaluated at import (collection) time, so the probe is bounded by a finite
+    timeout: a stalled interpreter must degrade to "unavailable", never hang
+    pytest collection.
+    """
     php = shutil.which("php")
     if php is None:
         return None
-    probe = subprocess.run(
-        [php, "-r", 'echo extension_loaded("xdebug") ? "yes" : "no";'],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        probe = subprocess.run(
+            [php, "-r", 'echo extension_loaded("xdebug") ? "yes" : "no";'],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=15,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
     return php if probe.stdout.strip() == "yes" else None
 
 

--- a/codebase_rag/trace/xdebug.py
+++ b/codebase_rag/trace/xdebug.py
@@ -113,6 +113,22 @@ def _nearest_opaque_ancestor(calls: list[_Call], call: _Call) -> _Call | None:
     return calls[ancestor] if ancestor is not None else None
 
 
+def _receiver_types(qualname: str) -> tuple[str, ...]:
+    """The concrete receiver class of an instance call, or ``()``.
+
+    Xdebug names an instance call ``Class->method`` with the *runtime* class of
+    the object, so a call through an interface or base type records which
+    implementation actually ran. Static calls (``Class::method``) are not
+    dynamic dispatch, so they carry no receiver type. The namespace is dropped
+    to match the path-derived graph names.
+    """
+    if cs.TRACE_PHP_INSTANCE_SEPARATOR not in qualname:
+        return ()
+    owner = qualname.split(cs.TRACE_PHP_INSTANCE_SEPARATOR, 1)[0]
+    owner = owner.rsplit(cs.TRACE_PHP_NAMESPACE_SEPARATOR, 1)[-1].strip()
+    return (owner,) if owner else ()
+
+
 def convert_xdebug_trace(
     trace_path: Path,
     output: Path,
@@ -155,7 +171,7 @@ def convert_xdebug_trace(
             callee=callee,
             count=count,
             workloads=workloads,
-            receiver_types=(),
+            receiver_types=_receiver_types(callee.qualname),
         )
         for (caller, callee), count in edges.items()
     ]

--- a/docs/guide/dynamic-tracing.md
+++ b/docs/guide/dynamic-tracing.md
@@ -168,10 +168,16 @@ never call anything resolve by their `Class::method` name tail instead;
 when several declarations share that tail, the frame is counted as
 `unresolved[ambiguous]` rather than guessed.
 Closures resolve through the file and line range embedded in their runtime
-name. Calls through `__call` attribute to the magic method itself, since
-the graph has no notion of the proxied target. Expect significant tracing
-overhead (Xdebug instruments everything); it is meant for test runs, not
-production.
+name. Instance calls (`$obj->method()`) record the concrete runtime class as
+the edge's `dynamic_receiver_types`, so a dispatch through an interface or base
+type shows which implementation ran; static calls (`Class::method()`) are not
+dynamic dispatch and carry none. A trait method called on the using class is
+observed under that class (`UsingClass->method`); it resolves by span when its
+defining position is recovered, but a leaf trait method that makes no calls
+falls back to the name tail and may be counted `unresolved`. Calls through
+`__call` attribute to the magic method itself, since the graph has no notion of
+the proxied target. Expect significant tracing overhead (Xdebug instruments
+everything); it is meant for test runs, not production.
 
 ## Recording a Lua trace
 


### PR DESCRIPTION
## What

Two of #1253's gaps: no real traced-run demonstration, and `receiver_types` hardcoded empty despite Xdebug naming instance calls with the concrete runtime class.

## Changes

- **Receiver capture**: `convert_xdebug_trace` now populates `receiver_types` with the concrete receiver class for instance calls (`Class->method` -> `Class`, namespace stripped). A dispatch through an interface or base type therefore records which implementation actually ran; static calls (`Class::method`) are not dynamic dispatch and carry none. Metadata only, no effect on resolution.
- **Live E2E test** (`test_live_xdebug_trace_captures_polymorphic_dispatch`, `@pytest.mark.slow`, skipped unless php+Xdebug are present): traces a real PHP program where `dispatch(Animal)` calls `$a->sound()` polymorphically, and asserts the runtime-only `dispatch -> Dog->sound` (x2) / `Cat->sound` edges with `receiver_types` of `Dog`/`Cat`, plus a trait method (`Service->greet`) captured under the using class. Verified locally against PHP 8.3 + Xdebug 3.
- **Unit test** for receiver capture against the synthetic sample; **docs** note the receiver-class capture and the leaf-trait-method resolution limitation.

## Scope note

The leaf-trait-method *resolution* gap (a trait method that makes no calls, so it falls to the `Owner.method` name tail which cannot match the graph's `TraitName.method` node) is documented rather than forced: a safe fix needs trait-usage information the frame resolver does not currently load, and guessing by bare method name would mis-resolve unrelated same-named methods. Non-leaf trait methods already resolve correctly by span.

Refs #1253, #1244.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic PHP tracing now records the concrete runtime class handling instance method calls.
  * Trace results distinguish instance dispatch from static calls and support trait-based method resolution.

* **Bug Fixes**
  * Improved attribution for polymorphic calls and magic `__call` handling.
  * Unresolved trait methods are represented accurately in trace results.

* **Documentation**
  * Updated dynamic tracing guidance to explain receiver types, trait methods, static calls, and unresolved methods.
  * Clarified how magic method calls are attributed in tracing output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->