### PR TITLE
test: demonstrate Dart dynamic-dispatch capture via the VM Service collector

### DIFF
--- a/codebase_rag/tests/test_dynamic_trace_dart.py
+++ b/codebase_rag/tests/test_dynamic_trace_dart.py
@@ -154,11 +154,21 @@ def test_collector_captures_dynamic_dispatch(dynamic_dispatch_trace):
         if (r.caller.qualname, r.callee.qualname) == ("dispatchDynamic", "speak")
     ]
     assert dispatched, sorted({(r.caller.qualname, r.callee.qualname) for r in records})
-    # Each concrete implementation resolves to its own definition line, so a
-    # single dynamic call site maps to the real methods that ran.
     for record in dispatched:
         assert record.callee.path.endswith("main.dart")
-        assert record.callee.line > 0
+    # Both Dog.speak and Cat.speak run through the one dynamic call site, and
+    # each must resolve to its own definition line: a regression that dropped a
+    # receiver or collapsed both onto one line would fail here.
+    speak_defs = {
+        number
+        for number, line in enumerate(
+            textwrap.dedent(_DYNAMIC_SAMPLE).splitlines(), start=1
+        )
+        if "int speak() {" in line
+    }
+    assert len(speak_defs) == 2
+    observed = {record.callee.line for record in dispatched}
+    assert speak_defs <= observed, (sorted(speak_defs), sorted(observed))
 
 
 def test_collector_scopes_and_labels_workloads(dart_trace):

--- a/codebase_rag/tests/test_dynamic_trace_dart.py
+++ b/codebase_rag/tests/test_dynamic_trace_dart.py
@@ -53,10 +53,46 @@ _SAMPLE = """
 """
 
 
-@pytest.fixture(scope="module")
-def dart_trace(tmp_path_factory):
-    tmp_path = tmp_path_factory.mktemp("dyndart")
-    (tmp_path / "main.dart").write_text(textwrap.dedent(_SAMPLE))
+_DYNAMIC_SAMPLE = """
+    abstract class Animal {
+      int speak();
+    }
+
+    class Dog implements Animal {
+      int speak() {
+        var a = 0;
+        for (var i = 0; i < 6000000; i++) {
+          a += i % 7;
+        }
+        return a;
+      }
+    }
+
+    class Cat implements Animal {
+      int speak() {
+        var a = 0;
+        for (var i = 0; i < 6000000; i++) {
+          a += i % 5;
+        }
+        return a;
+      }
+    }
+
+    int dispatchDynamic(dynamic a) => a.speak();
+
+    void main() {
+      var total = 0;
+      for (var i = 0; i < 10; i++) {
+        dynamic animal = (i % 2 == 0) ? Dog() : Cat();
+        total += dispatchDynamic(animal);
+      }
+      print('total: $total');
+    }
+"""
+
+
+def _run_collector(tmp_path: Path, source: str) -> tuple:
+    (tmp_path / "main.dart").write_text(textwrap.dedent(source))
     output = tmp_path / "cgr-trace.jsonl"
     subprocess.run(
         [str(dart), "pub", "get"],
@@ -88,12 +124,41 @@ def dart_trace(tmp_path_factory):
     return header, list(records)
 
 
+@pytest.fixture(scope="module")
+def dart_trace(tmp_path_factory):
+    return _run_collector(tmp_path_factory.mktemp("dyndart"), _SAMPLE)
+
+
+@pytest.fixture(scope="module")
+def dynamic_dispatch_trace(tmp_path_factory):
+    return _run_collector(tmp_path_factory.mktemp("dyndispatch"), _DYNAMIC_SAMPLE)
+
+
 def test_collector_captures_registry_dispatch(dart_trace):
     header, records = dart_trace
 
     assert header.language == cs.TRACE_LANGUAGE_DART
     edges = {(r.caller.qualname, r.callee.qualname) for r in records}
     assert ("handle", "greet") in edges, sorted(edges)
+
+
+def test_collector_captures_dynamic_dispatch(dynamic_dispatch_trace):
+    # `dispatchDynamic(dynamic a) => a.speak()` calls through a `dynamic`, so
+    # the receiver's concrete class is unknowable statically; the VM samples
+    # resolve the call to the concrete implementation(s) that actually ran.
+    _header, records = dynamic_dispatch_trace
+
+    dispatched = [
+        r
+        for r in records
+        if (r.caller.qualname, r.callee.qualname) == ("dispatchDynamic", "speak")
+    ]
+    assert dispatched, sorted({(r.caller.qualname, r.callee.qualname) for r in records})
+    # Each concrete implementation resolves to its own definition line, so a
+    # single dynamic call site maps to the real methods that ran.
+    for record in dispatched:
+        assert record.callee.path.endswith("main.dart")
+        assert record.callee.line > 0
 
 
 def test_collector_scopes_and_labels_workloads(dart_trace):


### PR DESCRIPTION
Closes a #1255 acceptance gap: the collector was only tested against function-value/registry dispatch, not `dynamic`-typed dispatch, which the docs already claim to capture.

## What

Adds a live test (`test_collector_captures_dynamic_dispatch`, `@pytest.mark.slow`, skipped without the Dart toolchain) exercising `int dispatchDynamic(dynamic a) => a.speak();`. Because the receiver is `dynamic`, the concrete class is unknowable statically; the VM Service CPU samples resolve the call to the concrete `Dog.speak` / `Cat.speak` implementations that actually ran (each at its own definition line). Verified locally against Dart 3.13 — a single dynamic call site produces runtime-only `dispatchDynamic -> speak` edges to both concrete methods.

The collector runner is refactored into `_run_collector(tmp_path, source)` shared by the existing and new fixtures.

Refs #1255, #1244.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for Dart dynamic dispatch through abstract interfaces and concrete implementations.
  * Verified collected VM samples resolve calls to the correct concrete methods and valid source locations.
  * Improved test execution reuse while retaining existing registry-dispatch coverage.
  * Added a reusable workload fixture to support reliable dynamic-dispatch trace validation across test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->