### PR TITLE
feat: demangle C# local-function CLR frames to their nested source node

### DIFF
--- a/codebase_rag/tests/test_dynamic_trace_resolution_dotnet.py
+++ b/codebase_rag/tests/test_dynamic_trace_resolution_dotnet.py
@@ -64,6 +64,13 @@ _NODES = [
         f"{_P}.Worker.MyApp.Worker.Run.Local",
         path="Worker.cs",
     ),
+    # An accessor-hosted local nests at class level (the accessor body is not
+    # its own scope in the static tier).
+    _node(
+        cs.NodeLabel.METHOD,
+        f"{_P}.Worker.MyApp.Worker.Local",
+        path="Worker.cs",
+    ),
 ]
 
 
@@ -111,6 +118,15 @@ def test_resolves_local_function_to_nested_node():
 
     assert resolved is not None
     assert resolved.qualified_name.endswith("MyApp.Worker.Run.Local")
+
+
+def test_resolves_accessor_hosted_local_function_at_class_level():
+    # A local function inside a property accessor nests at class level, since
+    # the accessor body is not its own scope in the static tier.
+    resolved = _resolve("MyApp.Worker.<get_Size>g__Local|0_0")
+
+    assert resolved is not None
+    assert resolved.qualified_name.endswith("MyApp.Worker.Local")
 
 
 def test_resolves_property_accessors_to_property_node():

--- a/codebase_rag/tests/test_dynamic_trace_resolution_dotnet.py
+++ b/codebase_rag/tests/test_dynamic_trace_resolution_dotnet.py
@@ -58,6 +58,12 @@ _NODES = [
         f"{_P}.Box.MyApp.Outer.Inner.M",
         path="Box.cs",
     ),
+    # A C# local function nests under its hosting method.
+    _node(
+        cs.NodeLabel.METHOD,
+        f"{_P}.Worker.MyApp.Worker.Run.Local",
+        path="Worker.cs",
+    ),
 ]
 
 
@@ -95,6 +101,16 @@ def test_resolves_constructor_to_class_named_node():
 
     assert resolved is not None
     assert resolved.qualified_name.endswith("MyApp.Worker.Worker(string)")
+
+
+def test_resolves_local_function_to_nested_node():
+    # `<Run>g__Local|0_0` is a C# local function; it resolves to the
+    # `Run.Local` node the static tier nests under the hosting method, not to
+    # `Run` and not dropped as synthetic.
+    resolved = _resolve("MyApp.Worker.<Run>g__Local|0_0")
+
+    assert resolved is not None
+    assert resolved.qualified_name.endswith("MyApp.Worker.Run.Local")
 
 
 def test_resolves_property_accessors_to_property_node():

--- a/codebase_rag/trace/resolution.py
+++ b/codebase_rag/trace/resolution.py
@@ -334,12 +334,28 @@ class PhpFrameResolver:
 
 _DOTNET_STATE_MACHINE = re.compile(r"^<(\w+)>d__\d+$")
 _DOTNET_LAMBDA_BODY = re.compile(r"^<(\w+)>b__\w+$")
-# A C# local function compiles to ``<EnclosingMethod>g__LocalName|N_M``; unlike
-# a lambda it keeps a source name, so it resolves to the ``Method.Local`` node
-# the static tier nests under the hosting method rather than to the method.
-_DOTNET_LOCAL_FUNCTION = re.compile(r"^<(?P<method>\w+)>g__(?P<local>\w+)\|\w+$")
+# A C# local function compiles to ``<EnclosingHost>g__LocalName|N_M``; unlike a
+# lambda it keeps a source name, so it resolves to the node the static tier
+# nests under its host: a method (``Run`` -> ``Run.Local``) or an accessor body
+# (``get_X``/``set_X``, which is not its own scope, so the local nests at class
+# level). A constructor host (``<.ctor>``) carries a dot that the CLR-name
+# splitter consumes before this pattern is reached, so ctor-hosted locals stay
+# unresolved rather than mis-resolved.
+_DOTNET_LOCAL_FUNCTION = re.compile(r"^<(?P<host>\w+)>g__(?P<local>\w+)\|\w+$")
 _DOTNET_DISPLAY_CLASS = re.compile(r"^<>c(__DisplayClass\w*)?$")
 _DOTNET_ACCESSOR = re.compile(r"^(?:get|set)_(\w+)$")
+
+
+def _local_function_target(host: str, local: str) -> str:
+    """The dotted name of a C# local function under its host.
+
+    A plain method host keeps its name (``Run`` -> ``Run.Local``). An accessor
+    body (``get_X``/``set_X``) has no scope of its own, so the static tier nests
+    its local directly under the class; the host is dropped (``Local``).
+    """
+    if _DOTNET_ACCESSOR.match(host):
+        return local
+    return f"{host}{cs.SEPARATOR_DOT}{local}"
 
 
 def _demangle_clr_name(name: str) -> str | None:
@@ -383,9 +399,8 @@ def _demangle_clr_name(name: str) -> str | None:
         method = lambda_body.group(1)
     local_function = _DOTNET_LOCAL_FUNCTION.match(method)
     if local_function:
-        method = (
-            f"{local_function.group('method')}"
-            f"{cs.SEPARATOR_DOT}{local_function.group('local')}"
+        method = _local_function_target(
+            local_function.group("host"), local_function.group("local")
         )
     if not method or "<" in method or any("<" in part for part in chain):
         return None

--- a/codebase_rag/trace/resolution.py
+++ b/codebase_rag/trace/resolution.py
@@ -334,6 +334,10 @@ class PhpFrameResolver:
 
 _DOTNET_STATE_MACHINE = re.compile(r"^<(\w+)>d__\d+$")
 _DOTNET_LAMBDA_BODY = re.compile(r"^<(\w+)>b__\w+$")
+# A C# local function compiles to ``<EnclosingMethod>g__LocalName|N_M``; unlike
+# a lambda it keeps a source name, so it resolves to the ``Method.Local`` node
+# the static tier nests under the hosting method rather than to the method.
+_DOTNET_LOCAL_FUNCTION = re.compile(r"^<(?P<method>\w+)>g__(?P<local>\w+)\|\w+$")
 _DOTNET_DISPLAY_CLASS = re.compile(r"^<>c(__DisplayClass\w*)?$")
 _DOTNET_ACCESSOR = re.compile(r"^(?:get|set)_(\w+)$")
 
@@ -377,6 +381,12 @@ def _demangle_clr_name(name: str) -> str | None:
     lambda_body = _DOTNET_LAMBDA_BODY.match(method)
     if lambda_body:
         method = lambda_body.group(1)
+    local_function = _DOTNET_LOCAL_FUNCTION.match(method)
+    if local_function:
+        method = (
+            f"{local_function.group('method')}"
+            f"{cs.SEPARATOR_DOT}{local_function.group('local')}"
+        )
     if not method or "<" in method or any("<" in part for part in chain):
         return None
     return cs.SEPARATOR_DOT.join([*chain, method])

--- a/codebase_rag/trace/resolution.py
+++ b/codebase_rag/trace/resolution.py
@@ -346,6 +346,26 @@ _DOTNET_DISPLAY_CLASS = re.compile(r"^<>c(__DisplayClass\w*)?$")
 _DOTNET_ACCESSOR = re.compile(r"^(?:get|set)_(\w+)$")
 
 
+def _owner_chain(owner: str) -> tuple[list[str], str | None]:
+    """The declaring type chain and any state-machine source method.
+
+    Splits nested types on ``+``, dropping display classes (lambda hosts) and
+    unwrapping an async state machine (``<RunAsync>d__3``) to the method name it
+    stands for, which supersedes the frame's own method segment.
+    """
+    chain: list[str] = []
+    state_machine_method: str | None = None
+    for part in owner.split(cs.TRACE_DOTNET_NESTED_MARKER):
+        machine = _DOTNET_STATE_MACHINE.match(part)
+        if machine:
+            state_machine_method = machine.group(1)
+            continue
+        if _DOTNET_DISPLAY_CLASS.match(part):
+            continue
+        chain.append(part)
+    return chain, state_machine_method
+
+
 def _local_function_target(host: str, local: str) -> str:
     """The dotted name of a C# local function under its host.
 
@@ -381,15 +401,9 @@ def _demangle_clr_name(name: str) -> str | None:
         owner, separator, method = name.rpartition(cs.SEPARATOR_DOT)
         if not separator:
             return None
-    chain: list[str] = []
-    for part in owner.split(cs.TRACE_DOTNET_NESTED_MARKER):
-        machine = _DOTNET_STATE_MACHINE.match(part)
-        if machine:
-            method = machine.group(1)
-            continue
-        if _DOTNET_DISPLAY_CLASS.match(part):
-            continue
-        chain.append(part)
+    chain, state_machine_method = _owner_chain(owner)
+    if state_machine_method is not None:
+        method = state_machine_method
     if not chain:
         return None
     if constructor:

--- a/docs/guide/dynamic-tracing.md
+++ b/docs/guide/dynamic-tracing.md
@@ -135,9 +135,10 @@ cgr trace ingest cgr-trace.jsonl --repo-path /path/to/your-repo
 prefixes instead of the repository root, and resolution joins on the
 namespace-bearing qualified names the static tier stores. CLR name mangling
 is handled: async state machines (`Worker+<RunAsync>d__3.MoveNext`) resolve
-to the source method, display-class lambdas to their enclosing method,
-`.ctor` to the constructor node, `get_`/`set_` accessors to the property
-node, and nested-class `+` to dotted nesting. Two caveats:
+to the source method, display-class lambdas to their enclosing method, local
+functions (`<Run>g__Local|0_0`) to the `Run.Local` node nested under the
+hosting method, `.ctor` to the constructor node, `get_`/`set_` accessors to the
+property node, and nested-class `+` to dotted nesting. Two caveats:
 
 - **Sampling.** Edge counts reflect observed activations in the flame
   chart, not exact call counts; very short calls between samples can be


### PR DESCRIPTION
Closes a #1249 resolution gap: C# local-function frames from dotnet-trace were dropped as synthetic.

## What

A C# local function compiles to the CLR name `<EnclosingMethod>g__LocalName|N_M` (verified via reflection on a real `dotnet` build: `int Local()` inside `Run` -> `<Run>g__Local|0_0`). `_demangle_clr_name` had no rule for `g__`, so the frame hit the `"<" in method` guard and was dropped as `unresolved[synthetic]`.

Unlike a lambda (anonymous, resolved to its enclosing method), a local function keeps a source name, and the static C# tier nests it as a `Method.Local` node under the hosting method (confirmed by `test_local_function_*` in test_csharp_definitions.py). The new `_DOTNET_LOCAL_FUNCTION` rule demangles `<Run>g__Local|0_0` -> `Run.Local`, so `N.Sample.<Run>g__Local|0_0` resolves to the `N.Sample.Run.Local` node instead of being dropped.

## Tests

- `test_resolves_local_function_to_nested_node` (unit, synthetic CLR frame matching the reflection-verified format) asserts `MyApp.Worker.<Run>g__Local|0_0` -> `...MyApp.Worker.Run.Local`.
- Docs: added local functions to the CLR-demangling list.

Note: the dominant #1249 gap (concrete-receiver capture) still needs an instrumented CLR profiler and is out of scope here; this closes the local-function resolution hole the audit flagged.

Refs #1249, #1244.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved .NET trace resolution for C# local functions, mapping runtime names to their corresponding nested methods.
  * Preserved correct resolution for async methods, lambdas, constructors, and property accessors.

* **Documentation**
  * Updated dynamic tracing guidance with local-function and nested-class resolution examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->