### PR TITLE
test: add a live cargo + pprof-rs E2E for the Rust tracer

### DIFF
--- a/codebase_rag/tests/test_dynamic_trace_rust.py
+++ b/codebase_rag/tests/test_dynamic_trace_rust.py
@@ -7,6 +7,8 @@
 from __future__ import annotations
 
 import gzip
+import shutil
+import subprocess
 
 import pytest
 
@@ -192,3 +194,93 @@ def test_malformed_profile_is_rejected(tmp_path):
         convert_rust_pprof(
             profile_path, repo_root=tmp_path, output=tmp_path / "out.jsonl"
         )
+
+
+_CARGO_TOML = """\
+[package]
+name = "cgrtrace_demo"
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+pprof = { version = "0.13", features = ["protobuf-codec"] }
+
+[profile.release]
+debug = true
+"""
+
+# `dispatch` calls through a `dyn Animal` (dynamic dispatch); `apply` is a
+# generic monomorphised for Dog and Cat. Both keep work after the call so the
+# callee is not in tail position (else the frame is elided), and #[inline(never)]
+# keeps them as distinct frames in the optimised build.
+_MAIN_RS = """\
+use pprof::protos::Message;
+
+trait Animal { fn speak(&self) -> u64; }
+struct Dog;
+struct Cat;
+impl Animal for Dog {
+    #[inline(never)]
+    fn speak(&self) -> u64 { let mut a=0u64; for i in 0..8_000_000u64 { a=a.wrapping_add(i%7);} a }
+}
+impl Animal for Cat {
+    #[inline(never)]
+    fn speak(&self) -> u64 { let mut a=0u64; for i in 0..8_000_000u64 { a=a.wrapping_add(i%5);} a }
+}
+
+#[inline(never)]
+fn dispatch(a: &dyn Animal) -> u64 { let r = a.speak(); r.wrapping_add(1) }
+
+#[inline(never)]
+fn apply<T: Animal>(a: &T) -> u64 { let r = a.speak(); r.wrapping_add(2) }
+
+fn main() {
+    let guard = pprof::ProfilerGuard::new(250).unwrap();
+    let mut total = 0u64;
+    for i in 0..8 { let a: &dyn Animal = if i%2==0 {&Dog} else {&Cat}; total = total.wrapping_add(dispatch(a)); }
+    for _ in 0..4 { total = total.wrapping_add(apply(&Dog)); total = total.wrapping_add(apply(&Cat)); }
+    if total == 12345 { println!("{total}"); }
+    if let Ok(report) = guard.report().build() {
+        let mut f = std::fs::File::create("cpu.pb").unwrap();
+        report.pprof().unwrap().write_to_writer(&mut f).unwrap();
+    }
+}
+"""
+
+cargo = shutil.which("cargo")
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(cargo is None, reason="cargo toolchain not available")
+def test_live_cargo_pprof_captures_dyn_and_generic(tmp_path):
+    # A real cargo build + run under pprof-rs: the dyn Trait call and the
+    # monomorphised generic must both surface as project edges, with the two
+    # generic instantiations collapsed onto the one `apply` definition.
+    (tmp_path / "Cargo.toml").write_text(_CARGO_TOML)
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "main.rs").write_text(_MAIN_RS)
+
+    build = subprocess.run(
+        [cargo, "build", "--release"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=600,
+        check=False,
+    )
+    if build.returncode != 0:
+        # The one dependency (pprof) is fetched from crates.io; without network
+        # the build cannot proceed, so skip rather than fail.
+        pytest.skip(f"cargo build failed (offline?): {build.stderr[-300:]}")
+    binary = tmp_path / "target" / "release" / "cgrtrace_demo"
+    subprocess.run([str(binary)], cwd=tmp_path, check=True, capture_output=True)
+
+    output = tmp_path / "trace.jsonl"
+    convert_rust_pprof(tmp_path / "cpu.pb", repo_root=tmp_path, output=output)
+
+    _header, records = read_trace_file(output)
+    edges = {(r.caller.qualname, r.callee.qualname) for r in records}
+    # The dyn Trait dispatch static analysis cannot resolve.
+    assert ("dispatch", "speak") in edges, sorted(edges)
+    # apply::<Dog> and apply::<Cat> both collapse onto the generic `apply`.
+    assert ("apply", "speak") in edges, sorted(edges)

--- a/codebase_rag/tests/test_dynamic_trace_rust.py
+++ b/codebase_rag/tests/test_dynamic_trace_rust.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import gzip
 import shutil
 import subprocess
+import sys
 
 import pytest
 
@@ -249,9 +250,25 @@ fn main() {
 
 cargo = shutil.which("cargo")
 
+# Substrings that mark a crates.io connectivity failure (vs. a real build error).
+_CARGO_NETWORK_ERRORS = (
+    "failed to download",
+    "failed to get",
+    "failed to query replaced source",
+    "could not resolve host",
+    "network failure",
+    "spurious network error",
+    "timed out",
+    "no such host",
+    "connection refused",
+)
+
 
 @pytest.mark.slow
-@pytest.mark.skipif(cargo is None, reason="cargo toolchain not available")
+@pytest.mark.skipif(
+    cargo is None or sys.platform != "linux",
+    reason="needs cargo; pprof-rs symbolisation is validated on Linux",
+)
 def test_live_cargo_pprof_captures_dyn_and_generic(tmp_path):
     # A real cargo build + run under pprof-rs: the dyn Trait call and the
     # monomorphised generic must both surface as project edges, with the two
@@ -269,11 +286,15 @@ def test_live_cargo_pprof_captures_dyn_and_generic(tmp_path):
         check=False,
     )
     if build.returncode != 0:
-        # The one dependency (pprof) is fetched from crates.io; without network
-        # the build cannot proceed, so skip rather than fail.
-        pytest.skip(f"cargo build failed (offline?): {build.stderr[-300:]}")
+        # `pprof` is fetched from crates.io; skip only for a genuine network
+        # failure, and fail on a real build error so regressions are not hidden.
+        if any(marker in build.stderr.lower() for marker in _CARGO_NETWORK_ERRORS):
+            pytest.skip(f"crates.io unreachable: {build.stderr[-300:]}")
+        raise AssertionError(f"cargo build failed:\n{build.stderr[-1000:]}")
     binary = tmp_path / "target" / "release" / "cgrtrace_demo"
-    subprocess.run([str(binary)], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        [str(binary)], cwd=tmp_path, check=True, capture_output=True, timeout=300
+    )
 
     output = tmp_path / "trace.jsonl"
     convert_rust_pprof(tmp_path / "cpu.pb", repo_root=tmp_path, output=output)
@@ -282,5 +303,9 @@ def test_live_cargo_pprof_captures_dyn_and_generic(tmp_path):
     edges = {(r.caller.qualname, r.callee.qualname) for r in records}
     # The dyn Trait dispatch static analysis cannot resolve.
     assert ("dispatch", "speak") in edges, sorted(edges)
-    # apply::<Dog> and apply::<Cat> both collapse onto the generic `apply`.
-    assert ("apply", "speak") in edges, sorted(edges)
+    # apply::<Dog> and apply::<Cat> collapse onto the one generic `apply` node:
+    # every speak caller whose name starts with apply must be exactly `apply`.
+    apply_callers = {
+        caller for caller, callee in edges if callee == "speak" and "apply" in caller
+    }
+    assert apply_callers == {"apply"}, sorted(apply_callers)

--- a/codebase_rag/tests/test_dynamic_trace_rust.py
+++ b/codebase_rag/tests/test_dynamic_trace_rust.py
@@ -274,7 +274,9 @@ def _is_crates_io_outage(stderr: str) -> bool:
     text = stderr.lower()
     if any(marker in text for marker in _CARGO_FETCH_CONTEXT):
         return True
-    in_registry_context = "crates.io" in text or "registry" in text
+    in_registry_context = any(
+        token in text for token in ("registry", "index", "download")
+    )
     return in_registry_context and any(m in text for m in _CARGO_CONNECTIVITY)
 
 

--- a/codebase_rag/tests/test_dynamic_trace_rust.py
+++ b/codebase_rag/tests/test_dynamic_trace_rust.py
@@ -250,18 +250,32 @@ fn main() {
 
 cargo = shutil.which("cargo")
 
-# Substrings that mark a crates.io connectivity failure (vs. a real build error).
-_CARGO_NETWORK_ERRORS = (
+# Phrases cargo prints only while acquiring dependencies from the registry; any
+# one of these is an unambiguous crates.io fetch failure.
+_CARGO_FETCH_CONTEXT = (
     "failed to download",
     "failed to get",
     "failed to query replaced source",
-    "could not resolve host",
-    "network failure",
     "spurious network error",
-    "timed out",
+    "failed to update registry",
+)
+# Bare connectivity errors: a build script or a real compile error can also
+# print these, so they only count as an outage inside a registry-fetch context.
+_CARGO_CONNECTIVITY = (
+    "could not resolve host",
     "no such host",
     "connection refused",
+    "network failure",
+    "timed out",
 )
+
+
+def _is_crates_io_outage(stderr: str) -> bool:
+    text = stderr.lower()
+    if any(marker in text for marker in _CARGO_FETCH_CONTEXT):
+        return True
+    in_registry_context = "crates.io" in text or "registry" in text
+    return in_registry_context and any(m in text for m in _CARGO_CONNECTIVITY)
 
 
 @pytest.mark.slow
@@ -288,7 +302,7 @@ def test_live_cargo_pprof_captures_dyn_and_generic(tmp_path):
     if build.returncode != 0:
         # `pprof` is fetched from crates.io; skip only for a genuine network
         # failure, and fail on a real build error so regressions are not hidden.
-        if any(marker in build.stderr.lower() for marker in _CARGO_NETWORK_ERRORS):
+        if _is_crates_io_outage(build.stderr):
             pytest.skip(f"crates.io unreachable: {build.stderr[-300:]}")
         raise AssertionError(f"cargo build failed:\n{build.stderr[-1000:]}")
     binary = tmp_path / "target" / "release" / "cgrtrace_demo"

--- a/docs/guide/dynamic-tracing.md
+++ b/docs/guide/dynamic-tracing.md
@@ -268,15 +268,21 @@ demangler (`cgr trace convert` reads the profile whether or not it is gzipped):
 
 ```toml
 # Cargo.toml
-[dev-dependencies]
+[dependencies]
 pprof = { version = "0.13", features = ["protobuf-codec"] }
+
+# Trace a release build with symbols kept: pprof-rs's sampler can trip a
+# debug-assertion (a slice-alignment check) in a dev build on recent
+# toolchains, so profile the release profile with debug info on.
+[profile.release]
+debug = true
 ```
 
 ```rust
-// In a test or a small harness that exercises the workload:
+// In a small harness (or a `--release` integration test) that runs the workload:
 use pprof::protos::Message; // brings write_to_writer into scope
 
-let guard = pprof::ProfilerGuard::new(100).unwrap();
+let guard = pprof::ProfilerGuard::new(250).unwrap();
 run_the_workload();
 if let Ok(report) = guard.report().build() {
     let profile = report.pprof().unwrap();
@@ -286,18 +292,18 @@ if let Ok(report) = guard.report().build() {
 ```
 
 ```bash
-cargo test                # dev profile: runs the harness above, writing cpu.pb
+cargo run --release       # runs the harness above, writing cpu.pb
 cgr trace convert cpu.pb --language rust \
-    --repo-path /path/to/your-repo --workload cargo-test
+    --repo-path /path/to/your-repo --workload cargo
 cgr trace ingest cgr-trace.jsonl --repo-path /path/to/your-repo
 ```
 
 Sampled stacks make `dyn Trait` dispatch and calls through function pointers
-visible; counts are sample counts, so give the workload enough CPU time. Trace a
-non-optimized build (the default `cargo test` / `cargo run` dev profile,
-`opt-level = 0`) so callees are not inlined away; `debug = true` only preserves
-symbols and line tables and does not reduce inlining in an optimized `--release`
-build, so add it to whichever profile you trace but do not rely on it alone. The
+visible; counts are sample counts, so give the workload enough CPU time. An
+optimized build inlines small functions and turns a pass-through wrapper
+(`fn f(a) { a.method() }`) into a tail call whose frame the sampler never sees;
+mark functions you want as distinct frames `#[inline(never)]`, and keep work
+after the call so the callee is not in tail position. The
 demangler strips the legacy `::h` symbol hash, collapses
 generic instantiations and trait-qualified receivers
 (`<Dog as Animal>::speak`) to their bare member, and marks closures


### PR DESCRIPTION
Closes the last open acceptance criteria on #1251 with a real toolchain run.

A `@pytest.mark.slow` live test (skipped without `cargo`; skipped rather than failed if crates.io is unreachable) builds and runs a cargo project under `pprof-rs` and converts the profile, asserting:
- **AC1** a traced cargo run produces dynamic edges;
- **AC2** a runtime-only edge through `&dyn Animal` (`dispatch -> speak`) that static analysis cannot resolve;
- **AC3** a generic `apply<T>` monomorphised for Dog and Cat whose instantiations collapse onto the single `apply` node.

Building the live case corrected two errors in the shipped recipe (docs updated): pprof-rs trips a debug-assertion in a **dev** build on Rust 1.95, so use a **release** build with `debug = true`; and an optimized build inlines/tail-call-elides pass-through wrappers, so traced functions are marked `#[inline(never)]` with work kept after the call.

Verified locally against rustc/cargo 1.95 + pprof 0.13. Closes #1251. Refs #1244.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Rust dynamic tracing guidance to use release builds with debug information.
  * Added recommendations for preserving sampled call frames when compiler optimizations inline or tail-call functions.
  * Refined profiling examples and sampling settings.

* **Tests**
  * Added an integration test validating dynamic trait dispatch and generic-call trace edges in Rust profiles.
  * The test skips gracefully when Cargo dependencies or build requirements are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->