### PR TITLE
test: trace a real dart test file end-to-end via the VM Service collector

### DIFF
--- a/codebase_rag/tests/test_dynamic_trace_dart.py
+++ b/codebase_rag/tests/test_dynamic_trace_dart.py
@@ -227,9 +227,17 @@ def test_collector_traces_a_dart_test_file(tmp_path):
     )
     if pub_get.returncode != 0:
         pytest.skip(f"dart pub get failed (offline?): {pub_get.stderr[-200:]}")
-    subprocess.run(
-        [str(dart), "pub", "get"], cwd=_COLLECTOR_DIR, capture_output=True, check=True
+    collector_pub_get = subprocess.run(
+        [str(dart), "pub", "get"],
+        cwd=_COLLECTOR_DIR,
+        capture_output=True,
+        text=True,
+        check=False,
     )
+    if collector_pub_get.returncode != 0:
+        pytest.skip(
+            f"collector pub get failed (offline?): {collector_pub_get.stderr[-200:]}"
+        )
     output = tmp_path / "cgr-trace.jsonl"
     result = subprocess.run(
         [

--- a/codebase_rag/tests/test_dynamic_trace_dart.py
+++ b/codebase_rag/tests/test_dynamic_trace_dart.py
@@ -171,6 +171,92 @@ def test_collector_captures_dynamic_dispatch(dynamic_dispatch_trace):
     assert speak_defs <= observed, (sorted(speak_defs), sorted(observed))
 
 
+_TEST_PUBSPEC = """\
+name: cgr_dart_test_demo
+environment:
+  sdk: ^3.0.0
+dev_dependencies:
+  test: ^1.24.0
+"""
+
+_TEST_LIB = """\
+int greet() {
+  var a = 0;
+  for (var i = 0; i < 8000000; i++) {
+    a += i % 3;
+  }
+  return a;
+}
+
+final Map<String, int Function()> handlers = {'greet': greet};
+
+int handle(String name) => handlers[name]!();
+"""
+
+_TEST_FILE = """\
+import 'package:test/test.dart';
+import '../lib_work.dart';
+
+void main() {
+  test('registry dispatch', () {
+    var out = 0;
+    for (var i = 0; i < 12; i++) {
+      out += handle('greet');
+    }
+    expect(out, isNonNegative);
+  });
+}
+"""
+
+
+def test_collector_traces_a_dart_test_file(tmp_path):
+    # `dart test` forks an isolate per test file that a single VM Service
+    # attach cannot follow, so a test file is traced by pointing the collector
+    # at it directly: package:test runs the file's tests in-process, and the
+    # sampler captures the registry dispatch inside the test.
+    (tmp_path / "pubspec.yaml").write_text(_TEST_PUBSPEC)
+    (tmp_path / "lib_work.dart").write_text(_TEST_LIB)
+    (tmp_path / "test").mkdir()
+    (tmp_path / "test" / "work_test.dart").write_text(_TEST_FILE)
+    pub_get = subprocess.run(
+        [str(dart), "pub", "get"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if pub_get.returncode != 0:
+        pytest.skip(f"dart pub get failed (offline?): {pub_get.stderr[-200:]}")
+    subprocess.run(
+        [str(dart), "pub", "get"], cwd=_COLLECTOR_DIR, capture_output=True, check=True
+    )
+    output = tmp_path / "cgr-trace.jsonl"
+    result = subprocess.run(
+        [
+            str(dart),
+            "bin/cgr_trace_collect.dart",
+            "--repo",
+            str(tmp_path),
+            "--output",
+            str(output),
+            "--workload",
+            "dart-test",
+            "--",
+            str(tmp_path / "test" / "work_test.dart"),
+        ],
+        cwd=_COLLECTOR_DIR,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=300,
+    )
+    assert result.returncode == 0, result.stderr
+    _header, records = read_trace_file(output)
+    edges = {(r.caller.qualname, r.callee.qualname) for r in records}
+    # The registry dispatch, invisible to static analysis, observed inside a test.
+    assert ("handle", "greet") in edges, sorted(edges)
+
+
 def test_collector_scopes_and_labels_workloads(dart_trace):
     _header, records = dart_trace
 

--- a/docs/guide/dynamic-tracing.md
+++ b/docs/guide/dynamic-tracing.md
@@ -234,7 +234,10 @@ To trace a test suite, point the collector at a `package:test` file directly
 (`dart bin/cgr_trace_collect.dart --repo ... -- test/foo_test.dart`): running the
 file executes its tests in-process, which the collector samples. Do not wrap
 `dart test` itself, which forks an isolate per file that the single VM Service
-attach cannot follow.
+attach cannot follow. Running a file this way does not load the full `package:test`
+runner, so runner-dependent features (tags, sharding, custom reporters,
+platform selectors) are unavailable; it suits straightforward unit tests whose
+bodies run on invocation.
 
 ## Recording a Go trace
 

--- a/docs/guide/dynamic-tracing.md
+++ b/docs/guide/dynamic-tracing.md
@@ -230,6 +230,12 @@ resolve to their enclosing declaration by line span (the static tier
 creates no closure nodes). Extension methods (`Ext|method`) and setter
 names (`value=`) are normalized to their source spellings.
 
+To trace a test suite, point the collector at a `package:test` file directly
+(`dart bin/cgr_trace_collect.dart --repo ... -- test/foo_test.dart`): running the
+file executes its tests in-process, which the collector samples. Do not wrap
+`dart test` itself, which forks an isolate per file that the single VM Service
+attach cannot follow.
+
 ## Recording a Go trace
 
 Go's own profiler does the capture; `go test` exposes it directly, and the


### PR DESCRIPTION
Closes the last open acceptance criterion on #1255.

A live test (`@pytest.mark.slow`, skipped without `dart`; skipped rather than failed if `dart pub get` can't reach pub.dev) creates a `package:test` project and points the collector at the test file. Running the file executes its tests in-process (which the VM Service samples), and the trace captures the registry dispatch `handle -> greet` inside the test — a runtime-only edge.

Documented the approach: trace test suites by pointing the collector at a test file directly, not by wrapping `dart test` (which forks an isolate per file that a single VM Service attach cannot follow).

With this, all #1255 criteria are met: traced dart-test run produces edges (this PR); runtime-only edge via function value / `dynamic` dispatch (#1282); sampled edges distinguishable from exact via `dynamic_sampled` (#1273); docs. Closes #1255. Refs #1244.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration coverage for Dart test tracing, including registry-based function dispatch capture.
  * Added graceful skipping when package dependencies cannot be fetched.

* **Documentation**
  * Added guidance for tracing Dart `package:test` files directly.
  * Clarified that wrapping `dart test` is unsupported for tracing and noted limitations for tags, sharding, custom reporters, and platform selectors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->