### PR TITLE
test: C/C++ CMake e2e + template-collapsing symbolisation (#1252)

### DIFF
--- a/codebase_rag/tests/test_dynamic_trace_instrumented.py
+++ b/codebase_rag/tests/test_dynamic_trace_instrumented.py
@@ -171,8 +171,29 @@ def test_bare_name_collapses_templates_and_demangles():
     assert _bare_name("ns::sub::foo(int)") == "foo"
     assert _bare_name("dispatch(Animal const*)") == "dispatch"
     assert _bare_name("main") == "main"
-    assert _bare_name("operator<(Dog const&, Dog const&)") == "operator<"
+    # A trailing const/ref qualifier is dropped, not mistaken for the name.
+    assert _bare_name("Reg::size(int) const") == "size"
+
+
+def test_bare_name_keeps_complete_operator_names():
+    # `addr2line -f -C` spells operators in full (including the trailing const
+    # cv-qualifier and the parameter list); the whole operator name must survive,
+    # never truncated to the first token.
+    assert _bare_name("F::operator<(F const&, F const&)") == "operator<"
     assert _bare_name("bool ns::operator<<(A const&)") == "operator<<"
+    assert _bare_name("F::operator<(F const&) const") == "operator<"
+    assert _bare_name("F::operator()(int)") == "operator()"
+    assert _bare_name("F::operator[](int)") == "operator[]"
+    assert _bare_name("operator new[](unsigned long, A&)") == "operator new[]"
+    assert _bare_name("operator new(unsigned long)") == "operator new"
+    assert _bare_name('operator"" _tag(unsigned long long)') == 'operator"" _tag'
+    # A qualified conversion operator keeps its complete conversion-type spelling,
+    # including the `::` inside it, rather than truncating at the first token.
+    assert _bare_name("X::operator std::string() const") == "operator std::string"
+    assert (
+        _bare_name("F::operator std::__cxx11::basic_string<char> () const")
+        == "operator std::__cxx11::basic_string<char>"
+    )
     assert _bare_name("") == cs.TRACE_QUALNAME_ANONYMOUS
 
 
@@ -341,11 +362,15 @@ def test_live_cpp_virtual_dispatch_produces_virtual_edge(tmp_path):
 _CMAKE_LISTS = """\
 cmake_minimum_required(VERSION 3.13)
 project(cgrdemo C CXX)
+find_package(Threads REQUIRED)
 add_executable(app main.cpp reg.c cgr_trace_shim.c)
 # The traced build type: -O0 keeps every frame (no inlining elides callees),
 # -g emits the DWARF the offline symboliser reads. The shim self-excludes with
 # no_instrument_function, so applying the flag to the whole target is safe.
 target_compile_options(app PRIVATE -finstrument-functions -g -O0)
+# The shim uses pthread_mutex_*/pthread_once; link pthreads explicitly so the
+# build works on toolchains where they are separate from libc.
+target_link_libraries(app PRIVATE Threads::Threads)
 """
 
 _CMAKE_MAIN = """\
@@ -471,8 +496,11 @@ def test_live_cmake_project_produces_dynamic_edges(tmp_path):
     assert edge_count("apply", "speak") == 8  # 4 * Dog + 4 * Cat
     assert len(callee_lines("apply", "speak")) == 2, records
 
-    # No template argument or return type leaks into any qualname.
+    # No template argument or return type leaks into any qualname; an operator
+    # name legitimately carries spaces (operator new[], a conversion type) so it
+    # is exempt from the no-space check.
     for record in records:
         for frame in (record.caller, record.callee):
             assert "<" not in frame.qualname, frame.qualname
-            assert " " not in frame.qualname, frame.qualname
+            if not frame.qualname.startswith("operator"):
+                assert " " not in frame.qualname, frame.qualname

--- a/codebase_rag/tests/test_dynamic_trace_instrumented.py
+++ b/codebase_rag/tests/test_dynamic_trace_instrumented.py
@@ -182,6 +182,9 @@ def test_bare_name_keeps_complete_operator_names():
     assert _bare_name("F::operator<(F const&, F const&)") == "operator<"
     assert _bare_name("bool ns::operator<<(A const&)") == "operator<<"
     assert _bare_name("F::operator<(F const&) const") == "operator<"
+    # Combined trailing qualifiers are all stripped (and the shrinking loop that
+    # does it cannot backtrack, unlike the earlier regex).
+    assert _bare_name("F::at(int) const && noexcept") == "at"
     assert _bare_name("F::operator()(int)") == "operator()"
     assert _bare_name("F::operator[](int)") == "operator[]"
     assert _bare_name("operator new[](unsigned long, A&)") == "operator new[]"

--- a/codebase_rag/tests/test_dynamic_trace_instrumented.py
+++ b/codebase_rag/tests/test_dynamic_trace_instrumented.py
@@ -16,7 +16,7 @@ import pytest
 from loguru import logger
 
 from codebase_rag import constants as cs
-from codebase_rag.trace.instrumented import convert_instrumented
+from codebase_rag.trace.instrumented import _bare_name, convert_instrumented
 from codebase_rag.trace.records import TraceFormatError, read_trace_file
 
 _SHIM = Path(__file__).resolve().parents[1] / "trace" / "c_agent" / "cgr_trace_shim.c"
@@ -156,9 +156,30 @@ def test_unresolved_addresses_are_reported(tmp_path):
     )
 
 
+def test_bare_name_collapses_templates_and_demangles():
+    # `addr2line -f -C` prints a template instantiation with its return type and
+    # its instantiated arguments (`int apply<Dog>(Dog const*)`); every
+    # instantiation must collapse to the one source definition so they share a
+    # node, methods drop their qualifier, and operators are kept whole.
+    assert _bare_name("int apply<Dog>(Dog const*)") == "apply"
+    assert _bare_name("int apply<Cat>(Cat const*)") == "apply"
+    assert _bare_name("int Cache::get<int>(int)") == "get"
+    assert _bare_name("std::vector<int> make<Dog>(Dog const&)") == "make"
+    assert _bare_name("unsigned int apply<Dog, Cat>(int)") == "apply"
+    assert _bare_name("Reg::handle(int)") == "handle"
+    assert _bare_name("Dog::sound(int)") == "sound"
+    assert _bare_name("ns::sub::foo(int)") == "foo"
+    assert _bare_name("dispatch(Animal const*)") == "dispatch"
+    assert _bare_name("main") == "main"
+    assert _bare_name("operator<(Dog const&, Dog const&)") == "operator<"
+    assert _bare_name("bool ns::operator<<(A const&)") == "operator<<"
+    assert _bare_name("") == cs.TRACE_QUALNAME_ANONYMOUS
+
+
 cc = shutil.which("cc")
 cxx = shutil.which("c++") or shutil.which("g++")
 atos = shutil.which("atos") or shutil.which("addr2line")
+cmake = shutil.which("cmake")
 
 
 @pytest.mark.slow
@@ -315,3 +336,143 @@ def test_live_cpp_virtual_dispatch_produces_virtual_edge(tmp_path):
     virtual = edges.get(("dispatch", "speak"))
     assert virtual is not None, sorted(edges)
     assert virtual.count == 5
+
+
+_CMAKE_LISTS = """\
+cmake_minimum_required(VERSION 3.13)
+project(cgrdemo C CXX)
+add_executable(app main.cpp reg.c cgr_trace_shim.c)
+# The traced build type: -O0 keeps every frame (no inlining elides callees),
+# -g emits the DWARF the offline symboliser reads. The shim self-excludes with
+# no_instrument_function, so applying the flag to the whole target is safe.
+target_compile_options(app PRIVATE -finstrument-functions -g -O0)
+"""
+
+_CMAKE_MAIN = """\
+struct Animal {
+    virtual ~Animal() = default;
+    virtual int speak() = 0;
+};
+struct Dog : Animal { int speak() override; };
+struct Cat : Animal { int speak() override; };
+int Dog::speak() { return 7; }
+int Cat::speak() { return 9; }
+
+static int dispatch(Animal* a) { return a->speak(); }
+
+// One template, two instantiations: apply<Dog> and apply<Cat> must collapse to
+// the one source definition `apply`, not two `apply<...>` nodes.
+template <typename T>
+static int apply(T* t) { return t->speak() + 1; }
+
+extern "C" int run_ptr();
+
+int main() {
+    Dog d;
+    Cat c;
+    int out = 0;
+    for (int i = 0; i < 5; i++) out += dispatch(&d);
+    for (int i = 0; i < 3; i++) out += dispatch(&c);
+    for (int i = 0; i < 4; i++) {
+        out += apply<Dog>(&d);
+        out += apply<Cat>(&c);
+    }
+    out += run_ptr();
+    return out > 0 ? 0 : 1;
+}
+"""
+
+_CMAKE_REG = """\
+static int greet(void) { return 1; }
+static int (*fp)(void);
+int run_ptr(void) {
+    fp = greet;              /* call through a function pointer (C) */
+    return fp();
+}
+"""
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    sys.platform == "win32"
+    or cmake is None
+    or cc is None
+    or cxx is None
+    or atos is None,
+    reason="cmake/C/C++ toolchain unavailable, or Windows/PE (shim targets ELF/Mach-O)",
+)
+def test_live_cmake_project_produces_dynamic_edges(tmp_path):
+    # AC: a traced test run of a sample CMake project produces dynamic edges,
+    # with a function-pointer edge (C) and a virtual edge (C++), and template
+    # instantiations collapsed to their one source definition.
+    (tmp_path / "CMakeLists.txt").write_text(_CMAKE_LISTS)
+    (tmp_path / "main.cpp").write_text(_CMAKE_MAIN)
+    (tmp_path / "reg.c").write_text(_CMAKE_REG)
+    shutil.copy(_SHIM, tmp_path / "cgr_trace_shim.c")
+
+    build = tmp_path / "build"
+    subprocess.run(
+        [str(cmake), "-S", str(tmp_path), "-B", str(build)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        [str(cmake), "--build", str(build)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    addrs = tmp_path / "cgr-trace.addrs"
+    subprocess.run(
+        [str(build / "app")],
+        check=True,
+        capture_output=True,
+        env=dict(os.environ, CGR_TRACE_ADDRS=str(addrs)),
+        cwd=tmp_path,
+    )
+
+    output = tmp_path / "trace.jsonl"
+    count = convert_instrumented(addrs, repo_root=tmp_path, output=output)
+
+    assert count > 0
+    header, records_iter = read_trace_file(output)
+    assert header.language == cs.TRACE_LANGUAGE_CPP
+    records = list(records_iter)
+
+    def edge_count(caller: str, callee: str) -> int:
+        return sum(
+            r.count
+            for r in records
+            if r.caller.qualname == caller and r.callee.qualname == callee
+        )
+
+    def callee_lines(caller: str, callee: str) -> set[int]:
+        return {
+            r.callee.line
+            for r in records
+            if r.caller.qualname == caller and r.callee.qualname == callee
+        }
+
+    edges = {(r.caller.qualname, r.callee.qualname) for r in records}
+
+    # Virtual dispatch through the abstract Animal interface (C++ runtime-only):
+    # both concrete receivers are recovered as distinct source positions.
+    assert edge_count("dispatch", "speak") == 8  # 5 * Dog + 3 * Cat
+    assert len(callee_lines("dispatch", "speak")) == 2, records
+
+    # Function-pointer call resolved at runtime (C runtime-only).
+    assert ("run_ptr", "greet") in edges, sorted(edges)
+
+    # Both apply<Dog> and apply<Cat> collapse onto the one `apply` node, yet the
+    # two concrete callees keep their own source positions.
+    speak_callers = {caller for caller, callee in edges if callee == "speak"}
+    assert speak_callers == {"dispatch", "apply"}, sorted(speak_callers)
+    assert edge_count("apply", "speak") == 8  # 4 * Dog + 4 * Cat
+    assert len(callee_lines("apply", "speak")) == 2, records
+
+    # No template argument or return type leaks into any qualname.
+    for record in records:
+        for frame in (record.caller, record.callee):
+            assert "<" not in frame.qualname, frame.qualname
+            assert " " not in frame.qualname, frame.qualname

--- a/codebase_rag/trace/instrumented.py
+++ b/codebase_rag/trace/instrumented.py
@@ -16,6 +16,7 @@ direct caller/callee pairs, so out-of-repo endpoints simply drop the edge.
 
 from __future__ import annotations
 
+import re
 import shutil
 import subprocess
 from collections.abc import Callable, Sequence
@@ -38,10 +39,71 @@ if TYPE_CHECKING:
 Symbolizer = Callable[[str, int, Sequence[int]], dict[int, tuple[str, str, int]]]
 
 
+# An operator's demangled name (``operator<``, ``operator()``, ``operator new``)
+# carries punctuation the angle/paren scan below cannot parse, so it is matched
+# whole and kept as-is.
+_OPERATOR = re.compile(r"\boperator(?:\s*\w+|\(\)|\[\]|\s*[^\w\s(]+)")
+
+
+def _strip_angle_groups(text: str) -> str:
+    """Drop every balanced ``<...>`` template-argument span, at any nesting."""
+    out: list[str] = []
+    depth = 0
+    for char in text:
+        if char == "<":
+            depth += 1
+        elif char == ">":
+            depth = max(depth - 1, 0)
+        elif depth == 0:
+            out.append(char)
+    return "".join(out)
+
+
+def _signature_head(symbol: str) -> str:
+    """The text before the parameter list, ignoring ``(`` inside ``<...>``."""
+    depth = 0
+    for index, char in enumerate(symbol):
+        if char == "<":
+            depth += 1
+        elif char == ">":
+            depth = max(depth - 1, 0)
+        elif char == "(" and depth == 0:
+            return symbol[:index]
+    return symbol
+
+
+def _drop_return_type(head: str) -> str:
+    """Drop a leading return type: templates demangle as ``ret name<...>``, and
+    the name begins after the last space that sits outside any ``<...>``."""
+    depth = 0
+    split_at = -1
+    for index, char in enumerate(head):
+        if char == "<":
+            depth += 1
+        elif char == ">":
+            depth = max(depth - 1, 0)
+        elif char == " " and depth == 0:
+            split_at = index
+    return head[split_at + 1 :]
+
+
 def _bare_name(symbol: str) -> str:
-    """``Dog::sound(int)`` as the member name ``sound``."""
-    head = symbol.split("(", 1)[0].strip()
-    return head.rsplit("::", 1)[-1] or cs.TRACE_QUALNAME_ANONYMOUS
+    """The bare member name of a demangled C/C++ symbol.
+
+    A template instantiation collapses to its source definition so every
+    instantiation shares one node (``int apply<Dog>(Dog const*)`` and
+    ``int apply<Cat>(Cat const*)`` both become ``apply``, ``int Cache::get<int>``
+    becomes ``get``); a method drops its qualifier (``Dog::sound(int)`` becomes
+    ``sound``); an ``operator`` name is kept whole.
+    """
+    text = symbol.strip()
+    if not text:
+        return cs.TRACE_QUALNAME_ANONYMOUS
+    match = _OPERATOR.search(text)
+    if match:
+        return re.sub(r"\s+", " ", match.group(0))
+    name = _strip_angle_groups(_drop_return_type(_signature_head(text)))
+    return name.rsplit("::", 1)[-1].strip() or cs.TRACE_QUALNAME_ANONYMOUS
 
 
 def _atos_symbolizer(

--- a/codebase_rag/trace/instrumented.py
+++ b/codebase_rag/trace/instrumented.py
@@ -40,12 +40,34 @@ Symbolizer = Callable[[str, int, Sequence[int]], dict[int, tuple[str, str, int]]
 
 
 # Trailing cv-/ref-/exception qualifiers a demangled method or operator carries
-# after its parameter list (``... const``, ``... &&``, ``... noexcept``).
-_TRAILING_QUALIFIERS = re.compile(r"(?:\s+(?:const|volatile|noexcept)|\s*&&?)+$")
+# after its parameter list (``... const``, ``... &&``, ``... noexcept``). Stripped
+# with a shrinking loop, not a regex, to avoid catastrophic backtracking.
+_TRAILING_QUALIFIERS = ("const", "volatile", "noexcept", "&&", "&")
 # ``operator`` at a name boundary, not followed by a word char, so an ``operator``
 # spelling (``operator<``, ``operator()``, ``operator new[]``, ``operator T``) is
 # recognised while an identifier like ``operatorX`` or ``cooperator`` is not.
 _OPERATOR = re.compile(r"\boperator(?![\w])")
+
+
+def _strip_trailing_qualifiers(text: str) -> str:
+    """Drop trailing cv-/ref-/exception qualifiers left after a parameter list."""
+    text = text.rstrip()
+    shrinking = True
+    while shrinking:
+        shrinking = False
+        for token in _TRAILING_QUALIFIERS:
+            if not text.endswith(token):
+                continue
+            start = len(text) - len(token)
+            # A word-like token (``const``) must sit at a boundary, so an
+            # identifier that merely ends in those letters is left alone.
+            preceding = text[start - 1] if start else ""
+            if token[0].isalpha() and (preceding.isalnum() or preceding == "_"):
+                continue
+            text = text[:start].rstrip()
+            shrinking = True
+            break
+    return text
 
 
 def _strip_angle_groups(text: str) -> str:
@@ -105,7 +127,7 @@ def _bare_name(symbol: str) -> str:
     ``sound``); an ``operator`` name is kept whole, including ``operator new[]``,
     ``operator()``, a user-defined literal, or a conversion operator's type.
     """
-    text = _TRAILING_QUALIFIERS.sub("", symbol.strip())
+    text = _strip_trailing_qualifiers(symbol.strip())
     if not text:
         return cs.TRACE_QUALNAME_ANONYMOUS
     head = _strip_trailing_params(text)

--- a/codebase_rag/trace/instrumented.py
+++ b/codebase_rag/trace/instrumented.py
@@ -39,10 +39,13 @@ if TYPE_CHECKING:
 Symbolizer = Callable[[str, int, Sequence[int]], dict[int, tuple[str, str, int]]]
 
 
-# An operator's demangled name (``operator<``, ``operator()``, ``operator new``)
-# carries punctuation the angle/paren scan below cannot parse, so it is matched
-# whole and kept as-is.
-_OPERATOR = re.compile(r"\boperator(?:\s*\w+|\(\)|\[\]|\s*[^\w\s(]+)")
+# Trailing cv-/ref-/exception qualifiers a demangled method or operator carries
+# after its parameter list (``... const``, ``... &&``, ``... noexcept``).
+_TRAILING_QUALIFIERS = re.compile(r"(?:\s+(?:const|volatile|noexcept)|\s*&&?)+$")
+# ``operator`` at a name boundary, not followed by a word char, so an ``operator``
+# spelling (``operator<``, ``operator()``, ``operator new[]``, ``operator T``) is
+# recognised while an identifier like ``operatorX`` or ``cooperator`` is not.
+_OPERATOR = re.compile(r"\boperator(?![\w])")
 
 
 def _strip_angle_groups(text: str) -> str:
@@ -59,17 +62,22 @@ def _strip_angle_groups(text: str) -> str:
     return "".join(out)
 
 
-def _signature_head(symbol: str) -> str:
-    """The text before the parameter list, ignoring ``(`` inside ``<...>``."""
+def _strip_trailing_params(text: str) -> str:
+    """Drop a trailing balanced ``(...)`` parameter list, counting only parens so
+    ``<...>`` and function-pointer parameters inside it are handled correctly."""
+    text = text.rstrip()
+    if not text.endswith(")"):
+        return text
     depth = 0
-    for index, char in enumerate(symbol):
-        if char == "<":
+    for index in range(len(text) - 1, -1, -1):
+        char = text[index]
+        if char == ")":
             depth += 1
-        elif char == ">":
-            depth = max(depth - 1, 0)
-        elif char == "(" and depth == 0:
-            return symbol[:index]
-    return symbol
+        elif char == "(":
+            depth -= 1
+            if depth == 0:
+                return text[:index].rstrip()
+    return text
 
 
 def _drop_return_type(head: str) -> str:
@@ -94,15 +102,17 @@ def _bare_name(symbol: str) -> str:
     instantiation shares one node (``int apply<Dog>(Dog const*)`` and
     ``int apply<Cat>(Cat const*)`` both become ``apply``, ``int Cache::get<int>``
     becomes ``get``); a method drops its qualifier (``Dog::sound(int)`` becomes
-    ``sound``); an ``operator`` name is kept whole.
+    ``sound``); an ``operator`` name is kept whole, including ``operator new[]``,
+    ``operator()``, a user-defined literal, or a conversion operator's type.
     """
-    text = symbol.strip()
+    text = _TRAILING_QUALIFIERS.sub("", symbol.strip())
     if not text:
         return cs.TRACE_QUALNAME_ANONYMOUS
-    match = _OPERATOR.search(text)
+    head = _strip_trailing_params(text)
+    match = _OPERATOR.search(head)
     if match:
-        return re.sub(r"\s+", " ", match.group(0))
-    name = _strip_angle_groups(_drop_return_type(_signature_head(text)))
+        return re.sub(r"\s+", " ", head[match.start() :]).strip()
+    name = _strip_angle_groups(_drop_return_type(head))
     return name.rsplit("::", 1)[-1].strip() or cs.TRACE_QUALNAME_ANONYMOUS
 
 

--- a/docs/guide/dynamic-tracing.md
+++ b/docs/guide/dynamic-tracing.md
@@ -349,9 +349,17 @@ c++ -pthread your_objects... cgr_shim.o -o app
 ```
 
 In CMake, add `cgr_trace_shim.c` to the target's sources (CMake compiles a
-`.c` file with the C compiler on its own) and set
-`-finstrument-functions -g -O0` on the traced build type; the shim links in
-without a separate step.
+`.c` file with the C compiler on its own), set `-finstrument-functions -g -O0`
+on the traced build type, and link pthreads (the shim uses
+`pthread_mutex_*`/`pthread_once`):
+
+```cmake
+find_package(Threads REQUIRED)
+target_compile_options(app PRIVATE -finstrument-functions -g -O0)
+target_link_libraries(app PRIVATE Threads::Threads)
+```
+
+The shim links in without a separate step.
 
 The shim records function-address pairs and the main image's load bias;
 conversion symbolises them with `atos` (macOS) or `addr2line` (ELF). PIE

--- a/docs/guide/dynamic-tracing.md
+++ b/docs/guide/dynamic-tracing.md
@@ -359,7 +359,11 @@ binaries need no special build flag — the shim records the ASLR slide and
 the converter subtracts it before symbolising, so the default hardened
 (PIE) build works. Calls through function pointers (C) and virtual dispatch
 (C++) land with true invocation counts; C++ names demangle and normalise to
-their bare member form, with source positions carrying identity. Frames that
+their bare member form, with source positions carrying identity. Template
+instantiations collapse to their one source definition (`apply<Dog>` and
+`apply<Cat>` both become `apply`), while each distinct callee keeps its own
+declaration-line position, so a virtual or templated call still resolves to
+every concrete receiver that ran. Frames that
 symbolise outside the repository (libc, the C++ runtime) drop their edges
 rather than being guessed. An edge whose caller or callee does not resolve to
 a project frame is excluded from the converted trace; addresses that do not


### PR DESCRIPTION
Closes the remaining acceptance-criteria gaps for #1252 (C/C++ `-finstrument-functions` tracer). The shim, offline symboliser, C function-pointer live test, C++ virtual live test, and unresolved-address reporting already existed; this fills the two gaps the audit found.

## Changes

- **Template-collapsing demangling** (`instrumented.py`): `addr2line -f -C` prints a template instantiation with its return type and instantiated arguments (`int apply<Dog>(Dog const*)`). `_bare_name` now strips the return type, collapses all balanced `<...>` template-argument spans, and drops the qualifier, so `apply<Dog>` and `apply<Cat>` both resolve to the one source definition `apply`, `int Cache::get<int>(int)` to `get`, while operator names (`operator<`, `operator<<`) are kept whole. Parsing is angle-bracket-aware, extracted into small helpers to keep complexity low.
- **CMake e2e test** (AC1): a sample CMake project (mixed C + C++, shim in the target sources with `-finstrument-functions -g -O0`) is configured, built, run, and converted; asserts a virtual edge (C++), a function-pointer edge (C), and template collapse, with both concrete receivers recovered as distinct source positions.
- **`_bare_name` unit test** (AC3): the demangled forms captured from real `addr2line` output, verifying template collapse, method/namespace stripping, and operator preservation.
- **Docs**: note that template instantiations collapse to their one source definition while each concrete callee keeps its position.

## Acceptance criteria

- [x] Traced test run of a sample CMake project produces dynamic edges
- [x] Demonstrated runtime-only edge through a function pointer (C) and a virtual call (C++)
- [x] Symbolization handles templates and demangling; unresolved addresses reported
- [x] Docs page covering usage and caveats

Verified locally against real `cmake` 3.28 + `gcc`/`g++` + `addr2line`: full `test_dynamic_trace_instrumented.py` (9 tests) passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved C/C++ dynamic tracing for virtual calls, function pointers, operators, and templates.
  * Template instantiations now share consistent member names while retaining accurate declaration locations.
  * Added support for resolving executed receivers in virtual and templated calls.
  * Added CMake configuration for instrumented tracing builds.

* **Documentation**
  * Updated dynamic tracing guidance with template-name normalization and declaration-line tracking.

* **Tests**
  * Added integration coverage for instrumented C/C++ builds and runtime call tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->