### PR TITLE
test: live PHPUnit xdebug e2e + measured overhead (#1253)

### DIFF
--- a/codebase_rag/tests/test_dynamic_trace_xdebug.py
+++ b/codebase_rag/tests/test_dynamic_trace_xdebug.py
@@ -261,3 +261,111 @@ def test_live_xdebug_trace_captures_polymorphic_dispatch(tmp_path):
     assert edges[("dispatch", "Cat->sound")].receiver_types == ("Cat",)
     # The trait method greet() called on the using class is observed too.
     assert edges[("run", "Service->greet")].receiver_types == ("Service",)
+
+
+_phpunit = shutil.which("phpunit")
+
+_PHPUNIT_SRC = """\
+<?php
+trait TStamp { public function stamp(): string { return static::class; } }
+class Greeter {
+    use TStamp;
+    public function hello(): string { return "hi"; }
+    public function bye(): string { return "bye"; }
+}
+class Registry {
+    private array $ops;
+    public function __construct() { $this->ops = ['run' => fn(Greeter $g) => $g->hello()]; }
+    public function invoke(string $key, Greeter $g): string { $fn = $this->ops[$key]; return $fn($g); }
+    public function call(Greeter $g, string $method): string { return $g->$method(); }
+}
+"""
+
+_PHPUNIT_TEST = """\
+<?php
+use PHPUnit\\Framework\\TestCase;
+require_once __DIR__ . '/../src/Handlers.php';
+final class RegistryTest extends TestCase {
+    public function testVariableMethodCall(): void {
+        $r = new Registry(); $g = new Greeter();
+        $this->assertSame("hi", $r->call($g, "hello"));
+        $this->assertSame("bye", $r->call($g, "bye"));
+    }
+    public function testClosureAndContainer(): void {
+        $this->assertSame("hi", (new Registry())->invoke("run", new Greeter()));
+    }
+    public function testTrait(): void {
+        $this->assertSame("Greeter", (new Greeter())->stamp());
+    }
+}
+"""
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    _php is None or _phpunit is None,
+    reason="php with the Xdebug extension and a phpunit executable are required",
+)
+def test_live_phpunit_run_captures_variable_call_closure_and_trait(tmp_path):
+    # A real PHPUnit run under Xdebug tracing: the runtime-only edge is the
+    # variable method call `$g->$method()` (the callee name is data, opaque to
+    # static analysis); a container-held closure and a trait method must resolve
+    # too. PHPUnit's own framework frames are left in the trace and scoped out at
+    # ingest, so only the project edges are asserted here.
+    (tmp_path / "src").mkdir()
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "src" / "Handlers.php").write_text(_PHPUNIT_SRC)
+    (tmp_path / "tests" / "RegistryTest.php").write_text(_PHPUNIT_TEST)
+    assert _php is not None and _phpunit is not None
+    subprocess.run(
+        [
+            _php,
+            "-d",
+            "xdebug.mode=trace",
+            "-d",
+            "xdebug.start_with_request=yes",
+            "-d",
+            "xdebug.trace_format=1",
+            "-d",
+            "xdebug.output_dir=.",
+            "-d",
+            "xdebug.trace_output_name=run",
+            _phpunit,
+            "tests/RegistryTest.php",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        timeout=300,
+    )
+    trace = next(tmp_path.glob("run.xt*"))
+    output = tmp_path / "trace.jsonl"
+    count = convert_xdebug_trace(trace, output=output, workload="phpunit")
+
+    assert count > 0
+    _header, records_iter = read_trace_file(output)
+    records = list(records_iter)
+    edges = {(r.caller.qualname, r.callee.qualname): r for r in records}
+
+    # Variable method call `$g->$method()`: the runtime-only edge, resolved to
+    # both concrete methods with the receiver class captured.
+    hello = edges[("Registry->call", "Greeter->hello")]
+    assert hello.receiver_types == ("Greeter",)
+    assert edges[("Registry->call", "Greeter->bye")].receiver_types == ("Greeter",)
+
+    # The container-held closure resolves through its embedded file:line, both
+    # as a callee of invoke() and as the caller of the method it dispatches to.
+    closure_callees = {
+        callee
+        for caller, callee in edges
+        if caller == "Registry->invoke" and callee.startswith("Registry->{closure:")
+    }
+    assert closure_callees, sorted(c for _, c in edges if "closure" in c)
+    closure = next(iter(closure_callees))
+    assert "Handlers.php" in closure
+    assert (closure, "Greeter->hello") in edges, sorted(edges)
+
+    # The trait method resolves under the using class (Greeter), not the trait.
+    trait = edges[("RegistryTest->testTrait", "Greeter->stamp")]
+    assert trait.receiver_types == ("Greeter",)

--- a/codebase_rag/tests/test_dynamic_trace_xdebug.py
+++ b/codebase_rag/tests/test_dynamic_trace_xdebug.py
@@ -316,7 +316,8 @@ def test_live_phpunit_run_captures_variable_call_closure_and_trait(tmp_path):
     (tmp_path / "tests").mkdir()
     (tmp_path / "src" / "Handlers.php").write_text(_PHPUNIT_SRC)
     (tmp_path / "tests" / "RegistryTest.php").write_text(_PHPUNIT_TEST)
-    assert _php is not None and _phpunit is not None
+    assert _php is not None
+    assert _phpunit is not None
     subprocess.run(
         [
             _php,

--- a/docs/guide/dynamic-tracing.md
+++ b/docs/guide/dynamic-tracing.md
@@ -181,8 +181,12 @@ observed under that class (`UsingClass->method`); it resolves by span when its
 defining position is recovered, but a leaf trait method that makes no calls
 falls back to the name tail and may be counted `unresolved`. Calls through
 `__call` attribute to the magic method itself, since the graph has no notion of
-the proxied target. Expect significant tracing overhead (Xdebug instruments
-everything); it is meant for test runs, not production.
+the proxied target. Tracing overhead is significant (Xdebug records every call):
+measured at roughly 15-20x wall-clock on a CPU-bound loop (about 17x on 1.2M
+calls, PHP 8.3 with Xdebug 3), and the machine-readable trace grows by roughly
+150 bytes per call, so a busy suite can produce a multi-hundred-megabyte file.
+It is meant for test runs, not production; scope tracing to the suite you need
+and convert one process at a time.
 
 ## Recording a Lua trace
 


### PR DESCRIPTION
Fills the remaining acceptance-criteria gaps for #1253 (PHP Xdebug tracer). The Xdebug trace parser, receiver-class capture, closure resolution, trait handling, and unresolved/ambiguous categorisation already existed and are tested; this adds the PHPUnit end-to-end run, the variable-method-call demonstration, and the measured overhead.

## Changes

- **Live PHPUnit e2e test** (`test_live_phpunit_run_captures_variable_call_closure_and_trait`): a real `phpunit` run under `xdebug.mode=trace` over a sample project, converted and asserted. Gated on `php` (with Xdebug) and a `phpunit` executable, like the other live tracer tests. Covers three things in one run:
  - **Variable method call** `$g->$method()` (the runtime-only edge: the callee name is data, opaque to static analysis) resolves to both concrete methods with the receiver class captured (`Registry->call -> Greeter->hello`/`Greeter->bye`, receiver `Greeter`).
  - **Container-held closure** resolves through its embedded `file:line`, both as a callee of `invoke()` and as the caller of the method it dispatches to (`Registry->invoke -> {closure:...Handlers.php} -> Greeter->hello`).
  - **Trait method** resolves under the using class, not the trait (`Greeter->stamp`, receiver `Greeter`).
- **Overhead measured and documented**: measured ~17x wall-clock on a 1.2M-call CPU-bound loop (PHP 8.3 + Xdebug 3), ~150 bytes of trace per call; the docs now give the number and the scoping/one-process-at-a-time guidance instead of a qualitative note.

## Acceptance criteria

- [x] Traced PHPUnit run of a sample project produces dynamic edges
- [x] Demonstrated runtime-only edge through a variable method call (`$g->$method()`)
- [x] Trait and closure frames resolve correctly; unresolved frames reported (closure/trait in the new e2e; unresolved + ambiguous in `test_dynamic_trace_resolution_php.py`)
- [x] Overhead measured and documented
- [x] Docs page covering usage and caveats

Verified locally against real PHP 8.3 + Xdebug 3 + PHPUnit 11.5: full `test_dynamic_trace_xdebug.py` and `test_dynamic_trace_resolution_php.py` (18 tests) pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on Xdebug tracing performance, including expected slowdown and trace sizes.
  * Recommended tracing targeted test runs individually to reduce resource usage.

* **Tests**
  * Added coverage for PHPUnit tracing of variable method calls, closures, and trait methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->