### PR TITLE
Add OrcaRouter as a named provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,17 @@
 # CYPHER_ENDPOINT=http://litellm:4000/v1
 # CYPHER_API_KEY=sk-your-litellm-key
 
+# Example 7: OrcaRouter (multi-provider AI gateway)
+# ORCHESTRATOR_PROVIDER=orcarouter
+# ORCHESTRATOR_MODEL=openai/gpt-4o-mini
+# ORCHESTRATOR_API_KEY=sk-orca-your-key
+# ORCHESTRATOR_ENDPOINT=https://api.orcarouter.ai/v1
+
+# CYPHER_PROVIDER=orcarouter
+# CYPHER_MODEL=anthropic/claude-sonnet-5
+# CYPHER_API_KEY=sk-orca-your-key
+# CYPHER_ENDPOINT=https://api.orcarouter.ai/v1
+
 # Thinking budget for reasoning models (optional)
 # ORCHESTRATOR_THINKING_BUDGET=10000
 # CYPHER_THINKING_BUDGET=5000

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -192,7 +192,7 @@ Configure via `.env` or environment variables:
 |----------|---------|-------------|
 | `MEMGRAPH_HOST` | `localhost` | Memgraph hostname |
 | `MEMGRAPH_PORT` | `7687` | Memgraph port |
-| `ORCHESTRATOR_PROVIDER` | | Provider: `google`, `openai`, `anthropic`, `azure`, `ollama`, `minimax`, `litellm_proxy` |
+| `ORCHESTRATOR_PROVIDER` | | Provider: `google`, `openai`, `anthropic`, `azure`, `ollama`, `minimax`, `litellm_proxy`, `orcarouter` |
 | `ORCHESTRATOR_MODEL` | | Model ID (e.g. `gpt-5.6-terra`, `gemini-3.6-flash`, `claude-sonnet-5`, `qwen2.5-coder`) |
 | `ORCHESTRATOR_API_KEY` | | API key for the provider (not needed for `ollama`) |
 | `CYPHER_PROVIDER` | | Provider for Cypher generation |

--- a/codebase_rag/config.py
+++ b/codebase_rag/config.py
@@ -52,6 +52,11 @@ API_KEY_INFO: dict[str, ApiKeyInfoEntry] = {
         "url": "https://platform.minimax.io/user-center/basic-information/interface-key",
         "name": "MiniMax",
     },
+    cs.Provider.ORCAROUTER: {
+        "env_var": "ORCAROUTER_API_KEY",
+        "url": "https://www.orcarouter.ai",
+        "name": "OrcaRouter",
+    },
 }
 
 
@@ -124,6 +129,7 @@ class ModelConfig:
             cs.Provider.ANTHROPIC: cs.ENV_ANTHROPIC_API_KEY,
             cs.Provider.AZURE: cs.ENV_AZURE_API_KEY,
             cs.Provider.MINIMAX: cs.ENV_MINIMAX_API_KEY,
+            cs.Provider.ORCAROUTER: cs.ENV_ORCAROUTER_API_KEY,
         }
         env_key = provider_env_keys.get(provider_lower)
         if (

--- a/codebase_rag/constants/providers.py
+++ b/codebase_rag/constants/providers.py
@@ -16,6 +16,7 @@ class Provider(StrEnum):
     AZURE = "azure"
     LITELLM_PROXY = "litellm_proxy"
     MINIMAX = "minimax"
+    ORCAROUTER = "orcarouter"
 
 
 DEFAULT_MODEL_ROLE = "model"
@@ -31,6 +32,7 @@ ENV_AZURE_API_KEY = "AZURE_API_KEY"
 ENV_AZURE_ENDPOINT = "AZURE_OPENAI_ENDPOINT"
 ENV_AZURE_API_VERSION = "AZURE_API_VERSION"
 ENV_MINIMAX_API_KEY = "MINIMAX_API_KEY"
+ENV_ORCAROUTER_API_KEY = "ORCAROUTER_API_KEY"
 
 
 class GoogleProviderType(StrEnum):
@@ -41,6 +43,7 @@ class GoogleProviderType(StrEnum):
 # Provider endpoints
 OPENAI_DEFAULT_ENDPOINT = "https://api.openai.com/v1"
 MINIMAX_DEFAULT_ENDPOINT = "https://api.minimax.io/v1"
+ORCAROUTER_DEFAULT_ENDPOINT = "https://api.orcarouter.ai/v1"
 MINIMAX_ANTHROPIC_SDK_PATH = "/anthropic"
 OLLAMA_HEALTH_PATH = "/api/tags"
 GOOGLE_CLOUD_SCOPE = "https://www.googleapis.com/auth/cloud-platform"

--- a/codebase_rag/exceptions.py
+++ b/codebase_rag/exceptions.py
@@ -23,6 +23,10 @@ MINIMAX_NO_KEY = (
     "MiniMax provider requires api_key. "
     "Set ORCHESTRATOR_API_KEY or CYPHER_API_KEY or MINIMAX_API_KEY in .env file."
 )
+ORCAROUTER_NO_KEY = (
+    "OrcaRouter provider requires api_key. "
+    "Set ORCHESTRATOR_API_KEY or CYPHER_API_KEY or ORCAROUTER_API_KEY in .env file."
+)
 OLLAMA_NOT_RUNNING = (
     "Ollama server not responding at {endpoint}. "
     "Make sure Ollama is running: ollama serve"

--- a/codebase_rag/providers/base.py
+++ b/codebase_rag/providers/base.py
@@ -295,6 +295,37 @@ class MiniMaxProvider(ModelProvider):
         return OpenAIChatModel(model_id, provider=provider)
 
 
+class OrcaRouterProvider(ModelProvider):
+    __slots__ = ("api_key", "endpoint")
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        endpoint: str | None = None,
+        **kwargs: str | int | None,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.api_key = _resolve_api_key(api_key, cs.ENV_ORCAROUTER_API_KEY)
+        self.endpoint = endpoint or cs.ORCAROUTER_DEFAULT_ENDPOINT
+
+    @property
+    def provider_name(self) -> cs.Provider:
+        return cs.Provider.ORCAROUTER
+
+    def validate_config(self) -> None:
+        if not self.api_key:
+            raise ValueError(ex.ORCAROUTER_NO_KEY)
+
+    def create_model(
+        self, model_id: str, **kwargs: str | int | None
+    ) -> OpenAIChatModel:
+        self.validate_config()
+        # api_key is guaranteed to be set by validate_config
+        assert self.api_key is not None
+        provider = PydanticOpenAIProvider(api_key=self.api_key, base_url=self.endpoint)
+        return OpenAIChatModel(model_id, provider=provider)
+
+
 PROVIDER_REGISTRY: dict[str, type[ModelProvider]] = {
     cs.Provider.GOOGLE: GoogleProvider,
     cs.Provider.OPENAI: OpenAIProvider,
@@ -302,6 +333,7 @@ PROVIDER_REGISTRY: dict[str, type[ModelProvider]] = {
     cs.Provider.ANTHROPIC: AnthropicProvider,
     cs.Provider.AZURE: AzureOpenAIProvider,
     cs.Provider.MINIMAX: MiniMaxProvider,
+    cs.Provider.ORCAROUTER: OrcaRouterProvider,
 }
 
 # Import LiteLLM provider after base classes are defined to avoid circular import

--- a/codebase_rag/tests/test_provider_classes.py
+++ b/codebase_rag/tests/test_provider_classes.py
@@ -10,6 +10,7 @@ from pydantic_ai.models.openai import OpenAIChatModel, OpenAIResponsesModel
 
 from codebase_rag.constants import (
     ENV_MINIMAX_API_KEY,
+    ENV_ORCAROUTER_API_KEY,
     MODEL_CONTEXT_WINDOWS,
     GoogleProviderType,
     Provider,
@@ -22,6 +23,7 @@ from codebase_rag.providers.base import (
     ModelProvider,
     OllamaProvider,
     OpenAIProvider,
+    OrcaRouterProvider,
     get_provider,
     list_providers,
     register_provider,
@@ -62,6 +64,10 @@ class TestProviderRegistry:
         assert isinstance(minimax_provider, MiniMaxProvider)
         assert minimax_provider.provider_name == Provider.MINIMAX
 
+        orcarouter_provider = get_provider(Provider.ORCAROUTER, api_key="test-key")
+        assert isinstance(orcarouter_provider, OrcaRouterProvider)
+        assert orcarouter_provider.provider_name == Provider.ORCAROUTER
+
     def test_get_invalid_provider(self) -> None:
         with pytest.raises(ValueError, match="Unknown provider 'invalid_provider'"):
             get_provider("invalid_provider")
@@ -86,7 +92,8 @@ class TestProviderRegistry:
         assert Provider.AZURE in providers
         assert Provider.LITELLM_PROXY in providers
         assert Provider.MINIMAX in providers
-        assert len(providers) >= 7
+        assert Provider.ORCAROUTER in providers
+        assert len(providers) >= 8
 
     def test_register_custom_provider(self) -> None:
         class CustomProvider(ModelProvider):
@@ -428,6 +435,60 @@ class TestMiniMaxProvider:
         provider = get_provider(Provider.MINIMAX, api_key="test-key")
         assert isinstance(provider, MiniMaxProvider)
         assert provider.provider_name == Provider.MINIMAX
+
+
+class TestOrcaRouterProvider:
+    @pytest.fixture(autouse=True)
+    def clear_orcarouter_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(ENV_ORCAROUTER_API_KEY, raising=False)
+
+    def test_orcarouter_configuration(self) -> None:
+        provider = OrcaRouterProvider(
+            api_key="or-test-key",
+            endpoint="https://api.orcarouter.ai/v1",
+        )
+        assert provider.provider_name == Provider.ORCAROUTER
+        assert provider.api_key == "or-test-key"
+        assert provider.endpoint == "https://api.orcarouter.ai/v1"
+        provider.validate_config()
+
+    def test_orcarouter_default_endpoint(self) -> None:
+        provider = OrcaRouterProvider(api_key="test-key", endpoint=None)
+        assert provider.endpoint == "https://api.orcarouter.ai/v1"
+
+    def test_orcarouter_validation_error(self) -> None:
+        provider = OrcaRouterProvider()
+        with pytest.raises(ValueError, match="OrcaRouter provider requires api_key"):
+            provider.validate_config()
+
+    def test_orcarouter_api_key_from_env(self) -> None:
+        with patch.dict("os.environ", {ENV_ORCAROUTER_API_KEY: "env-or-key"}):
+            provider = OrcaRouterProvider()
+            assert provider.api_key == "env-or-key"
+
+    @patch("codebase_rag.providers.base.PydanticOpenAIProvider")
+    @patch("codebase_rag.providers.base.OpenAIChatModel")
+    def test_orcarouter_model_creation(
+        self, mock_chat_model: Any, mock_openai_provider: Any
+    ) -> None:
+        provider = OrcaRouterProvider(api_key="or-test-key")
+        mock_model = MagicMock()
+        mock_chat_model.return_value = mock_model
+
+        result = provider.create_model("orcarouter/auto")
+
+        mock_openai_provider.assert_called_once_with(
+            api_key="or-test-key", base_url="https://api.orcarouter.ai/v1"
+        )
+        mock_chat_model.assert_called_once_with(
+            "orcarouter/auto", provider=mock_openai_provider.return_value
+        )
+        assert result == mock_model
+
+    def test_get_orcarouter_provider(self) -> None:
+        provider = get_provider(Provider.ORCAROUTER, api_key="test-key")
+        assert isinstance(provider, OrcaRouterProvider)
+        assert provider.provider_name == Provider.ORCAROUTER
 
 
 class TestModelCreation:

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -77,11 +77,30 @@ Both model IDs work with either compatible endpoint. For the China service, use
 
 Get your MiniMax API key from the [MiniMax Platform](https://platform.minimax.io/user-center/basic-information/interface-key).
 
+### OrcaRouter Models
+
+```bash
+ORCHESTRATOR_PROVIDER=orcarouter
+ORCHESTRATOR_MODEL=openai/gpt-4o-mini
+ORCHESTRATOR_API_KEY=sk-orca-your-key
+ORCHESTRATOR_ENDPOINT=https://api.orcarouter.ai/v1
+
+CYPHER_PROVIDER=orcarouter
+CYPHER_MODEL=anthropic/claude-sonnet-5
+CYPHER_API_KEY=sk-orca-your-key
+CYPHER_ENDPOINT=https://api.orcarouter.ai/v1
+```
+
+[OrcaRouter](https://www.orcarouter.ai) is a multi-provider AI gateway. Model IDs
+use a `provider/model` namespace (e.g., `openai/gpt-4o-mini`,
+`anthropic/claude-sonnet-5`); the `orcarouter` provider routes any supported
+model through your `sk-orca-` key. Get one at https://www.orcarouter.ai.
+
 ## Orchestrator Model Settings
 
 | Variable | Description |
 |----------|-------------|
-| `ORCHESTRATOR_PROVIDER` | Provider name (`google`, `openai`, `anthropic`, `azure`, `ollama`, `minimax`, `litellm_proxy`) |
+| `ORCHESTRATOR_PROVIDER` | Provider name (`google`, `openai`, `anthropic`, `azure`, `ollama`, `minimax`, `litellm_proxy`, `orcarouter`) |
 | `ORCHESTRATOR_MODEL` | Model ID (e.g., `gemini-3.6-flash`, `gpt-5.6-terra`, `claude-sonnet-5`, `qwen2.5-coder`; `gemini-3.1-pro-preview` for a heavier option) |
 | `ORCHESTRATOR_API_KEY` | API key for the provider (if required) |
 | `ORCHESTRATOR_ENDPOINT` | Custom endpoint URL (if required) |
@@ -95,7 +114,7 @@ Get your MiniMax API key from the [MiniMax Platform](https://platform.minimax.io
 
 | Variable | Description |
 |----------|-------------|
-| `CYPHER_PROVIDER` | Provider name (`google`, `openai`, `anthropic`, `azure`, `ollama`, `minimax`, `litellm_proxy`) |
+| `CYPHER_PROVIDER` | Provider name (`google`, `openai`, `anthropic`, `azure`, `ollama`, `minimax`, `litellm_proxy`, `orcarouter`) |
 | `CYPHER_MODEL` | Model ID (e.g., `gemini-3.5-flash-lite`, `gpt-5.6-luna`, `qwen2.5-coder`) |
 | `CYPHER_API_KEY` | API key for the provider (if required) |
 | `CYPHER_ENDPOINT` | Custom endpoint URL (if required) |


### PR DESCRIPTION
## Summary

Adds [OrcaRouter](https://www.orcarouter.ai) as a named model provider. OrcaRouter is an OpenAI-compatible model routing gateway that exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax, xAI and others behind a single endpoint and API key. It also provides gateway-level security controls for AI agents.

I'm an engineer on the OrcaRouter team.

## What this changes

- `codebase_rag/constants/providers.py`: adds `Provider.ORCAROUTER`, `ENV_ORCAROUTER_API_KEY`, and `ORCAROUTER_DEFAULT_ENDPOINT`
- `codebase_rag/providers/base.py`: adds `OrcaRouterProvider` (registry entry + `create_model` -> pydantic-ai `OpenAIChatModel` against `https://api.orcarouter.ai/v1`, auth via `ORCAROUTER_API_KEY`)
- `codebase_rag/exceptions.py`: adds `ORCAROUTER_NO_KEY`
- `codebase_rag/config.py`: adds OrcaRouter to `API_KEY_INFO` and the provider api-key map
- `codebase_rag/tests/test_provider_classes.py`: adds a full `TestOrcaRouterProvider` class
- `.env.example`, `docs/getting-started/configuration.md`, `PYPI_README.md`: provider examples and docs alongside the existing providers

## Why a separate provider rather than the OpenAI-compatible escape hatch

This mirrors how MiniMax is wired in this repo, so the model picker, config validation, docs and `.env.example` stay consistent for users who want to route through OrcaRouter.

## How to use it

1. Get an API key at https://www.orcarouter.ai/console (keys start with `sk-orca-`).
2. Set `ORCAROUTER_API_KEY` (or use `ORCHESTRATOR_API_KEY` / `CYPHER_API_KEY`).
3. Pick a model id such as `openai/gpt-4o-mini`, `anthropic/claude-sonnet-5` or `deepseek/deepseek-chat`. The full catalog is at https://www.orcarouter.ai/models.

```bash
ORCHESTRATOR_PROVIDER=orcarouter
ORCHESTRATOR_MODEL=openai/gpt-4o-mini
ORCHESTRATOR_API_KEY=sk-orca-your-key
ORCHESTRATOR_ENDPOINT=https://api.orcarouter.ai/v1
```

## Verification

- Unit tests: 61 passed in `test_provider_classes.py` (7 new OrcaRouter tests)
- `ruff check .` and `ruff format --check .` clean (ruff 0.14.14 per `uv.lock`)
- Live API: routed an `openai/gpt-4o-mini` request through the gateway via `OrcaRouterProvider` + pydantic-ai `Agent`; model returned `ORCAROUTER-LIVE-OK`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added OrcaRouter as a supported provider for orchestrator and cypher models.
  - Supports API key configuration through settings or the `ORCAROUTER_API_KEY` environment variable.
  - Added a default OrcaRouter endpoint and OpenAI-compatible model integration.

- **Documentation**
  - Added OrcaRouter configuration examples and provider listings.
  - Added an environment configuration template.

- **Bug Fixes**
  - Added clear validation messaging when OrcaRouter credentials are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->