### PR TITLE
feat: JS/TS source-map resolution reporting + live TS e2e assertions (#1247)

### DIFF
--- a/codebase_rag/constants/trace.py
+++ b/codebase_rag/constants/trace.py
@@ -153,3 +153,9 @@ TRACE_MSG_INGEST_SUMMARY = (
     "static_missed={missed} unresolved={unresolved}"
 )
 TRACE_MSG_UNRESOLVED_DETAIL = "  unresolved[{reason}]={count}"
+
+TRACE_MSG_SOURCEMAP_RESOLUTION = (
+    "source-map resolution: {resolved}/{total} project frames resolved to "
+    "source ({rate})"
+)
+TRACE_MSG_SOURCEMAP_DETAIL = "  source_map[{outcome}]={count}"

--- a/codebase_rag/tests/test_dynamic_trace_sourcemap.py
+++ b/codebase_rag/tests/test_dynamic_trace_sourcemap.py
@@ -12,6 +12,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
+from loguru import logger
 
 from codebase_rag.trace.cpuprofile import convert_cpuprofile
 from codebase_rag.trace.records import read_trace_file
@@ -187,6 +188,55 @@ def test_convert_remaps_transpiled_frames_to_typescript(tmp_path):
     assert edges[("run", "handle")].callee.line == 12
 
 
+def test_convert_reports_resolution_rate_and_categorises_failures(tmp_path):
+    # Four project frames, one per source-map outcome: a mapped position that
+    # resolves, a file with no map, a mapped file whose position no segment
+    # covers, and a file whose map is malformed. The converter must report the
+    # resolution rate and categorise each failure so coverage gaps are visible.
+    map_path = _write_map(tmp_path)  # dist/app.js (+ valid app.js.map)
+    dist = map_path.parent
+    (dist / "uncovered.js").write_text("// x\n//# sourceMappingURL=uncovered.js.map\n")
+    (dist / "uncovered.js.map").write_text(_APP_JS_MAP)
+    (dist / "bad.js").write_text("// x\n//# sourceMappingURL=bad.js.map\n")
+    (dist / "bad.js.map").write_text("{ this is not valid json")
+    (tmp_path / "plain.js").write_text("function f() {}\n")
+
+    profile = {
+        "nodes": [
+            _cpuprofile_node(1, "(root)", "", 0, 0, [2]),
+            # (1, 14) maps to greet in src/app.ts: RESOLVED.
+            _cpuprofile_node(2, "greet", (dist / "app.js").as_uri(), 1, 14, [3]),
+            # No map beside plain.js: NO_MAP (kept at its generated position).
+            _cpuprofile_node(3, "f", (tmp_path / "plain.js").as_uri(), 5, 0, [4]),
+            # A valid map, but no segment covers line 9999: UNCOVERED.
+            _cpuprofile_node(4, "g", (dist / "uncovered.js").as_uri(), 9999, 0, [5]),
+            # The map file exists but is not valid JSON: MALFORMED.
+            _cpuprofile_node(5, "h", (dist / "bad.js").as_uri(), 3, 0, []),
+        ],
+        "samples": [],
+        "timeDeltas": [],
+    }
+    profile_path = tmp_path / "run.cpuprofile"
+    profile_path.write_text(json.dumps(profile))
+
+    messages: list[str] = []
+    sink_id = logger.add(messages.append, level="INFO", format="{message}")
+    try:
+        convert_cpuprofile(
+            profile_path, repo_root=tmp_path, output=tmp_path / "trace.jsonl"
+        )
+    finally:
+        logger.remove(sink_id)
+
+    joined = "\n".join(messages)
+    assert (
+        "source-map resolution: 1/4 project frames resolved to source (25%)" in joined
+    ), joined
+    assert "source_map[no_map]=1" in joined, joined
+    assert "source_map[uncovered]=1" in joined, joined
+    assert "source_map[malformed]=1" in joined, joined
+
+
 def _node_with_tsc() -> tuple[str, str] | None:
     node = shutil.which("node")
     tsc = shutil.which("tsc")
@@ -239,7 +289,14 @@ def test_live_typescript_trace_resolves_to_source(tmp_path):
         cwd=tmp_path,
     )
     output = tmp_path / "trace.jsonl"
-    convert_cpuprofile(tmp_path / "run.cpuprofile", repo_root=tmp_path, output=output)
+    messages: list[str] = []
+    sink_id = logger.add(messages.append, level="INFO", format="{message}")
+    try:
+        convert_cpuprofile(
+            tmp_path / "run.cpuprofile", repo_root=tmp_path, output=output
+        )
+    finally:
+        logger.remove(sink_id)
 
     _header, records = read_trace_file(output)
     # Sampling and V8 inlining make which specific frames appear nondeterministic,
@@ -248,6 +305,15 @@ def test_live_typescript_trace_resolves_to_source(tmp_path):
     # was relocated off the transpiled dist/*.js onto its .ts source.
     assert records
     assert any(record.callee.path.endswith(".ts") for record in records)
+    # The runtime-only edge: handle() calls registry[name](), a dispatch through a
+    # dictionary that static analysis cannot resolve. greet is the hot leaf, so it
+    # is reliably sampled and must land on its .ts source, not the dist/*.js.
+    assert any(
+        record.callee.qualname == "greet" and record.callee.path.endswith(".ts")
+        for record in records
+    ), [(r.callee.qualname, r.callee.path) for r in records]
+    # The resolution rate is reported so source-map coverage is visible.
+    assert any("source-map resolution:" in message for message in messages), messages
 
 
 def test_malformed_map_url_is_ignored(tmp_path):

--- a/codebase_rag/tests/test_dynamic_trace_sourcemap.py
+++ b/codebase_rag/tests/test_dynamic_trace_sourcemap.py
@@ -254,17 +254,24 @@ def test_live_typescript_trace_resolves_to_source(tmp_path):
     node, tsc = _toolchain
     src = tmp_path / "src"
     src.mkdir()
+    # greet carries the CPU work so it is the hot leaf: a sampler reliably lands
+    # inside it with handle (its only caller, through the registry) on the stack,
+    # making the runtime-only handle -> greet edge dependable rather than flaky.
     (src / "app.ts").write_text(
-        "type Handler = () => string;\n"
+        "type Handler = () => number;\n"
         "const registry: Record<string, Handler> = {};\n"
-        "function greet(): string { return 'hi'; }\n"
+        "function greet(): number {\n"
+        "    let a = 0;\n"
+        "    for (let i = 0; i < 20000000; i++) { a += i % 7; }\n"
+        "    return a;\n"
+        "}\n"
         "function register(name: string, fn: Handler): void { registry[name] = fn; }\n"
-        "function handle(name: string): string { return registry[name](); }\n"
+        "function handle(name: string): number { return registry[name](); }\n"
         "function run(): void {\n"
         "    register('greet', greet);\n"
-        "    let out = '';\n"
-        "    for (let i = 0; i < 3000000; i++) { out = handle('greet'); }\n"
-        "    if (out.length < 0) console.log(out);\n"
+        "    let out = 0;\n"
+        "    for (let i = 0; i < 30; i++) { out += handle('greet'); }\n"
+        "    if (out < 0) console.log(out);\n"
         "}\n"
         "run();\n"
     )
@@ -306,12 +313,19 @@ def test_live_typescript_trace_resolves_to_source(tmp_path):
     assert records
     assert any(record.callee.path.endswith(".ts") for record in records)
     # The runtime-only edge: handle() calls registry[name](), a dispatch through a
-    # dictionary that static analysis cannot resolve. greet is the hot leaf, so it
-    # is reliably sampled and must land on its .ts source, not the dist/*.js.
-    assert any(
-        record.callee.qualname == "greet" and record.callee.path.endswith(".ts")
+    # dictionary that static analysis cannot resolve. greet is the hot leaf called
+    # only by handle, and --no-opt keeps both as distinct frames, so the concrete
+    # handle -> greet edge is reliably sampled and both endpoints must relocate
+    # off the transpiled dist/*.js onto their .ts source.
+    dispatch = [
+        record
         for record in records
-    ), [(r.callee.qualname, r.callee.path) for r in records]
+        if record.caller.qualname == "handle" and record.callee.qualname == "greet"
+    ]
+    assert dispatch, [(r.caller.qualname, r.callee.qualname) for r in records]
+    for record in dispatch:
+        assert record.caller.path.endswith(".ts"), record.caller.path
+        assert record.callee.path.endswith(".ts"), record.callee.path
     # The resolution rate is reported so source-map coverage is visible.
     assert any("source-map resolution:" in message for message in messages), messages
 

--- a/codebase_rag/trace/cpuprofile.py
+++ b/codebase_rag/trace/cpuprofile.py
@@ -18,10 +18,13 @@ from __future__ import annotations
 
 import json
 import re
+from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
 from urllib.parse import unquote, urlparse
+
+from loguru import logger
 
 from .. import constants as cs
 from .records import (
@@ -31,7 +34,7 @@ from .records import (
     TraceHeader,
     write_trace_file,
 )
-from .sourcemap import SourceMapIndex
+from .sourcemap import SourceMapIndex, SourceMapOutcome
 
 
 @dataclass(frozen=True, slots=True)
@@ -93,7 +96,10 @@ def _is_index(value: object) -> bool:
 
 
 def _project_frame(
-    call_frame: dict[str, object], root_prefix: str, source_maps: SourceMapIndex
+    call_frame: dict[str, object],
+    root_prefix: str,
+    source_maps: SourceMapIndex,
+    stats: Counter[SourceMapOutcome],
 ) -> _ProfileFrame | None:
     url = call_frame.get("url")
     if not isinstance(url, str) or not url.startswith(cs.TRACE_JS_FILE_URL_PREFIX):
@@ -113,9 +119,12 @@ def _project_frame(
     # original TypeScript/JavaScript position, so the frame lands on the source
     # node the graph indexed; without a map the generated position stands.
     column = call_frame.get("columnNumber")
-    remapped = None
     if _is_index(column):
-        remapped = source_maps.remap(generated_path, line, cast("int", column))
+        remapped, outcome = source_maps.remap_detailed(
+            generated_path, line, cast("int", column)
+        )
+    else:
+        remapped, outcome = None, SourceMapOutcome.NO_MAP
     if remapped is not None:
         path, source_line = remapped
     else:
@@ -124,6 +133,9 @@ def _project_frame(
         return None
     if not cs.TRACE_EXCLUDED_DIR_NAMES.isdisjoint(Path(path).parts):
         return None
+    # Only project frames count toward the resolution rate; the source-map
+    # outcome categorises whether each landed on its source or fell back.
+    stats[outcome] += 1
     return _ProfileFrame(path=path, qualname=name, line=source_line)
 
 
@@ -139,6 +151,7 @@ def _parse_nodes(
     root_prefix: str,
     profile_path: Path,
     source_maps: SourceMapIndex,
+    stats: Counter[SourceMapOutcome],
 ) -> tuple[dict[int, _ProfileFrame | None], dict[int, list[int]], dict[int, int]]:
     """Validate each profile node and index frames, children, and hit counts."""
     frames: dict[int, _ProfileFrame | None] = {}
@@ -164,12 +177,31 @@ def _parse_nodes(
                 cs.TRACE_ERR_BAD_CPUPROFILE.format(path=profile_path)
             )
         frames[node_id] = _project_frame(
-            cast("dict[str, object]", call_frame), root_prefix, source_maps
+            cast("dict[str, object]", call_frame), root_prefix, source_maps, stats
         )
         children[node_id] = list(cast("list[int]", raw_children))
         hit_count = node.get("hitCount", 0)
         hits[node_id] = hit_count if isinstance(hit_count, int) else 0
     return frames, children, hits
+
+
+def _report_resolution(stats: Counter[SourceMapOutcome]) -> None:
+    """Log the source-map resolution rate and categorise any failures."""
+    total = sum(stats.values())
+    if not total:
+        return
+    resolved = stats[SourceMapOutcome.RESOLVED]
+    logger.info(
+        cs.TRACE_MSG_SOURCEMAP_RESOLUTION.format(
+            resolved=resolved, total=total, rate=f"{resolved / total:.0%}"
+        )
+    )
+    for outcome in SourceMapOutcome:
+        count = stats[outcome]
+        if outcome is not SourceMapOutcome.RESOLVED and count:
+            logger.info(
+                cs.TRACE_MSG_SOURCEMAP_DETAIL.format(outcome=outcome.value, count=count)
+            )
 
 
 def convert_cpuprofile(
@@ -190,9 +222,11 @@ def convert_cpuprofile(
         raise TraceFormatError(cs.TRACE_ERR_BAD_CPUPROFILE.format(path=profile_path))
 
     root_prefix = repo_root.resolve().as_posix() + "/"
+    resolution: Counter[SourceMapOutcome] = Counter()
     frames, children, hits = _parse_nodes(
-        nodes, root_prefix, profile_path, SourceMapIndex()
+        nodes, root_prefix, profile_path, SourceMapIndex(), resolution
     )
+    _report_resolution(resolution)
 
     # A well-formed profile is a forest: every child id exists and has
     # exactly one parent. Anything else (dangling ids, shared children,

--- a/codebase_rag/trace/sourcemap.py
+++ b/codebase_rag/trace/sourcemap.py
@@ -19,12 +19,23 @@ from __future__ import annotations
 import bisect
 import json
 from dataclasses import dataclass
+from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 from urllib.parse import unquote, urlsplit
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+
+
+class SourceMapOutcome(StrEnum):
+    """The result of trying to relocate a generated frame to its source."""
+
+    RESOLVED = "resolved"  # a source map covered the position
+    NO_MAP = "no_map"  # no source map referenced or found beside the file
+    UNCOVERED = "uncovered"  # a map loaded but no segment covers the position
+    MALFORMED = "malformed"  # a map file was found but could not be parsed
+
 
 _B64_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
 _B64_INDEX = {char: index for index, char in enumerate(_B64_ALPHABET)}
@@ -279,34 +290,47 @@ class SourceMapIndex:
     """Lazily loads and caches the source map for each generated file."""
 
     def __init__(self) -> None:
-        self._cache: dict[str, SourceMap | None] = {}
+        self._cache: dict[str, tuple[SourceMap | None, SourceMapOutcome]] = {}
 
-    def _map_for(self, js_path: str) -> SourceMap | None:
+    def _map_for(self, js_path: str) -> tuple[SourceMap | None, SourceMapOutcome]:
         if js_path not in self._cache:
             self._cache[js_path] = self._load(Path(js_path))
         return self._cache[js_path]
 
     @staticmethod
-    def _load(path: Path) -> SourceMap | None:
+    def _load(path: Path) -> tuple[SourceMap | None, SourceMapOutcome]:
         referenced = _sniff_map_reference(path)
         candidates: Iterable[Path] = (
             [referenced] if referenced else [path.with_name(path.name + ".map")]
         )
+        found = False
         for candidate in candidates:
             if candidate.is_file():
+                found = True
                 loaded = load_source_map(candidate)
                 if loaded is not None:
-                    return loaded
-        return None
+                    return loaded, SourceMapOutcome.RESOLVED
+        # A map file was present but every candidate failed to parse; otherwise
+        # no map is referenced or sitting beside the generated file at all.
+        return None, (SourceMapOutcome.MALFORMED if found else SourceMapOutcome.NO_MAP)
 
-    def remap(self, path: str, line: int, column: int) -> tuple[str, int] | None:
-        """Map a generated ``(path, line, column)`` back to source ``(path, line)``.
+    def remap_detailed(
+        self, path: str, line: int, column: int
+    ) -> tuple[tuple[str, int] | None, SourceMapOutcome]:
+        """Remap a generated ``(path, line, column)`` and report the outcome.
 
         ``line`` and ``column`` are 0-based (as V8 reports them); the returned
-        line is 1-based. Returns None when no map covers the position, so the
-        caller keeps the generated frame.
+        line is 1-based. The position is None (and the caller keeps the generated
+        frame) whenever the outcome is not ``RESOLVED``.
         """
-        source_map = self._map_for(path)
+        source_map, load_outcome = self._map_for(path)
         if source_map is None:
-            return None
-        return source_map.original_position(line, column)
+            return None, load_outcome
+        position = source_map.original_position(line, column)
+        if position is None:
+            return None, SourceMapOutcome.UNCOVERED
+        return position, SourceMapOutcome.RESOLVED
+
+    def remap(self, path: str, line: int, column: int) -> tuple[str, int] | None:
+        """The remapped source position, or None when no map covers it."""
+        return self.remap_detailed(path, line, column)[0]

--- a/docs/guide/dynamic-tracing.md
+++ b/docs/guide/dynamic-tracing.md
@@ -117,6 +117,14 @@ distinguish this from the instrumented Python and JVM tracers:
   or for a generated position that has no mapping (runtime glue, an occasional
   module wrapper), the frame keeps its generated `dist/*.js` location; keep the
   `.js.map` beside the `.js` so the converter can find it.
+- **Resolution reporting.** Conversion logs a source-map resolution rate over
+  the project frames it kept (for example `source-map resolution: 42/50 project
+  frames resolved to source (84%)`) and categorises the misses so coverage gaps
+  are visible rather than silent: `no_map` (no map referenced or found beside the
+  file), `uncovered` (a map loaded but no segment covers the position), and
+  `malformed` (a map file was found but could not be parsed). A low rate with
+  many `no_map` misses usually means source maps are off in the build; `malformed`
+  points at a broken emit.
 
 ## Recording a .NET trace (C#)
 


### PR DESCRIPTION
Fills the remaining acceptance-criteria gaps for #1247 (JS/TS/TSX tracer). The V8 `.cpuprofile` converter, source-map (v3) remapping, and JS/TS resolution already existed and are unit-tested; this adds resolution-rate reporting with categorised source-map failures, and strengthens the live TS end-to-end assertions.

## Changes

- **Source-map resolution reporting** (`sourcemap.py`, `cpuprofile.py`): `SourceMapIndex.remap_detailed` now returns the outcome alongside the position, classified as `resolved` / `no_map` / `uncovered` / `malformed` (new `SourceMapOutcome`). `convert_cpuprofile` accumulates the outcome of every project frame it keeps and logs a resolution rate plus a per-category breakdown (`source-map resolution: N/M project frames resolved to source (P%)`, then `source_map[no_map]=...` etc.), so source-map coverage gaps are visible instead of silent.
- **Deterministic categorisation test** (`test_convert_reports_resolution_rate_and_categorises_failures`): four project frames, one per outcome (a mapped position that resolves, a file with no map, a mapped-but-uncovered position, and a malformed map), asserting the logged rate and each failure category.
- **Live TS e2e strengthened** (`test_live_typescript_trace_resolves_to_source`): in addition to the existing "a frame relocated to `.ts`" invariant, it now asserts the runtime-only registry-dispatch target (`greet`, reached through `registry[name]()`, opaque to static analysis) resolves to its `.ts` source, and that the resolution-rate summary is emitted. Built with real `tsc --sourceMap` + `node --cpu-prof` (`--no-opt` keeps frames).

## Acceptance criteria

- [x] Traced test run of a sample TS project produces dynamic edges resolved to TS source nodes (live `tsc` + `node --cpu-prof`, edges land on `src/*.ts`)
- [x] At least one demonstrated runtime-only edge (registry dispatch `handle -> greet` through `registry[name]()`; the converter docstring and docs also cover event emitters and dynamic `import()`)
- [x] Resolution rate reported; source-map failures categorized (`resolved`/`no_map`/`uncovered`/`malformed`, logged with a rate)
- [x] Docs page covering usage and caveats

Verified locally against real Node 18 + tsc: full `test_dynamic_trace_sourcemap.py` and `test_dynamic_trace_cpuprofile.py` (28 tests) pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed source-map resolution reporting during Node.js trace conversion.
  * Displays the percentage of project frames mapped back to source files.
  * Categorizes unresolved frames as missing, uncovered, or malformed source maps.

* **Bug Fixes**
  * Improved distinction between unavailable and invalid source maps during trace processing.

* **Documentation**
  * Updated dynamic tracing guidance with source-map resolution metrics and outcome details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->