### PR TITLE
feat: ingest eBPF continuous-profiler pprof profiles (#1287)

### DIFF
--- a/codebase_rag/cli_help.py
+++ b/codebase_rag/cli_help.py
@@ -123,6 +123,37 @@ HELP_TRACE_LANGUAGE = (
     "Override the auto-detected source language. Rust pprof profiles share Go's "
     "gzipped-protobuf format, so pass 'rust' to demangle them as Rust."
 )
+HELP_TRACE_FORMAT = (
+    "Force a profile format instead of auto-detecting it. Use 'ebpf' for pprof "
+    "profiles from an eBPF continuous profiler (Parca, Pyroscope, OTel, perf)."
+)
+HELP_TRACE_PATH_MAP = (
+    "Re-anchor a production build path to the repo, as BUILD_PREFIX=REPO_PREFIX. "
+    "Repeatable; applied before the in-repo check (ebpf format)."
+)
+HELP_TRACE_BUILD_ID = (
+    "Keep only frames from the mapping with this build id or binary filename "
+    "(ebpf format); other binaries are seen through."
+)
+HELP_TRACE_SERVICE = (
+    "Keep only samples whose label matches, as KEY=VALUE (ebpf format)."
+)
+HELP_TRACE_LABEL = (
+    "Sample label whose value becomes each edge's workload (ebpf format)."
+)
+HELP_TRACE_COMMIT = (
+    "The commit the profiled binary was built from; warns if it differs from "
+    "the repository HEAD at convert time (ebpf format)."
+)
+ERR_TRACE_CONVERT_BAD_FORMAT = "Unknown --format '{format}'; supported: ebpf."
+ERR_TRACE_CONVERT_BAD_PATH_MAP = (
+    "Invalid --path-map '{value}'; expected BUILD_PREFIX=REPO_PREFIX."
+)
+ERR_TRACE_CONVERT_BAD_SERVICE = "Invalid --service '{value}'; expected KEY=VALUE."
+MSG_TRACE_COMMIT_MISMATCH = (
+    "Profiled commit {profiled} differs from repository HEAD {head}; edges may "
+    "resolve against moved or renamed code."
+)
 ERR_TRACE_CONVERT_BAD_LANGUAGE = (
     "Unknown --language '{language}'; supported override values: {supported}."
 )

--- a/codebase_rag/constants/trace.py
+++ b/codebase_rag/constants/trace.py
@@ -165,9 +165,9 @@ TRACE_ERR_EBPF_LANGUAGE = (
     "Unsupported eBPF profile language {language!r}; supported: {supported}."
 )
 TRACE_MSG_EBPF_UNSYMBOLIZED = (
-    "eBPF symbolisation: {count} unsymbolized locations across {mappings} mappings"
+    "eBPF symbolisation: {count} unsymbolised locations across {mappings} mappings"
 )
-TRACE_MSG_EBPF_MAPPING_DETAIL = "  unsymbolized[{name}]={count}"
+TRACE_MSG_EBPF_MAPPING_DETAIL = "  unsymbolised[{name}]={count}"
 TRACE_MSG_EBPF_UNMAPPED = (
     "{count} frames at {paths} unmapped build paths (add --path-map to re-anchor)"
 )

--- a/codebase_rag/constants/trace.py
+++ b/codebase_rag/constants/trace.py
@@ -45,6 +45,7 @@ TRACE_TOOL_NAME_XDEBUG = "cgr-trace-xdebug"
 TRACE_TOOL_NAME_PPROF = "cgr-trace-pprof"
 TRACE_TOOL_NAME_RUST_PPROF = "cgr-trace-rust-pprof"
 TRACE_TOOL_NAME_INSTRUMENTED = "cgr-trace-instrumented"
+TRACE_TOOL_NAME_EBPF = "cgr-trace-ebpf"
 TRACE_DEFAULT_OUTPUT = "cgr-trace.jsonl"
 
 # Python runtime qualname markers.
@@ -159,3 +160,14 @@ TRACE_MSG_SOURCEMAP_RESOLUTION = (
     "source ({rate})"
 )
 TRACE_MSG_SOURCEMAP_DETAIL = "  source_map[{outcome}]={count}"
+
+TRACE_ERR_EBPF_LANGUAGE = (
+    "Unsupported eBPF profile language {language!r}; supported: {supported}."
+)
+TRACE_MSG_EBPF_UNSYMBOLIZED = (
+    "eBPF symbolisation: {count} unsymbolized locations across {mappings} mappings"
+)
+TRACE_MSG_EBPF_MAPPING_DETAIL = "  unsymbolized[{name}]={count}"
+TRACE_MSG_EBPF_UNMAPPED = (
+    "{count} frames at {paths} unmapped build paths (add --path-map to re-anchor)"
+)

--- a/codebase_rag/tests/test_dynamic_trace_ebpf.py
+++ b/codebase_rag/tests/test_dynamic_trace_ebpf.py
@@ -1,0 +1,281 @@
+# eBPF continuous-profiler pprof profiles share Go's protobuf wire format but
+# add mappings (per-binary build ids), per-sample labels, and build-time paths.
+# The converter must re-anchor those paths to the repo, filter by build id and
+# label, map a label to workloads, and count unsymbolized locations per mapping
+# rather than dropping them (issue #1287).
+
+from __future__ import annotations
+
+import gzip
+
+import pytest
+from loguru import logger
+
+from codebase_rag import constants as cs
+from codebase_rag.trace.ebpf_pprof import convert_ebpf_pprof
+from codebase_rag.trace.records import TraceFormatError, read_trace_file
+
+
+def _varint(value: int) -> bytes:
+    out = bytearray()
+    while True:
+        bits = value & 0x7F
+        value >>= 7
+        if value:
+            out.append(bits | 0x80)
+        else:
+            out.append(bits)
+            return bytes(out)
+
+
+def _uint(field: int, value: int) -> bytes:
+    return _varint(field << 3) + _varint(value)
+
+
+def _msg(field: int, payload: bytes) -> bytes:
+    return _varint((field << 3) | 2) + _varint(len(payload)) + payload
+
+
+def _string(value: str) -> bytes:
+    return _msg(6, value.encode())
+
+
+def _function(fid: int, name: int, filename: int, start_line: int) -> bytes:
+    return _msg(
+        5, _uint(1, fid) + _uint(2, name) + _uint(4, filename) + _uint(5, start_line)
+    )
+
+
+def _mapping(mid: int, filename: int, build_id: int) -> bytes:
+    return _msg(3, _uint(1, mid) + _uint(5, filename) + _uint(6, build_id))
+
+
+def _location(lid: int, mapping_id: int, entries: list[tuple[int, int]]) -> bytes:
+    payload = _uint(1, lid) + _uint(2, mapping_id)
+    for function_id, line in entries:
+        payload += _msg(4, _uint(1, function_id) + _uint(2, line))
+    return _msg(4, payload)
+
+
+def _label(key: int, value: int) -> bytes:
+    return _msg(3, _uint(1, key) + _uint(2, value))
+
+
+def _sample(location_ids: list[int], value: int, labels: list[bytes]) -> bytes:
+    payload = b"".join(_uint(1, lid) for lid in location_ids)
+    payload += _uint(2, value)
+    payload += b"".join(labels)
+    return _msg(2, payload)
+
+
+# String table indices.
+_S = {
+    "": 0,
+    "main.handle": 1,
+    "main.greet": 2,
+    "/build/src/app/service.go": 3,
+    "abc123": 4,  # target build id
+    "/app/service": 5,  # target mapping filename
+    "libc_internal": 6,
+    "/usr/lib/libc.so": 7,
+    "libc": 8,  # libc build id
+    "endpoint": 9,  # label key
+    "/api/greet": 10,  # label value
+    "service": 11,  # service label key
+    "checkout": 12,  # service label value
+}
+
+
+def _profile_bytes() -> bytes:
+    strings = b"".join(_string(s) for s in _S)
+    functions = (
+        _function(1, _S["main.handle"], _S["/build/src/app/service.go"], 10)
+        + _function(2, _S["main.greet"], _S["/build/src/app/service.go"], 20)
+        + _function(3, _S["libc_internal"], _S["/usr/lib/libc.so"], 1)
+    )
+    mappings = _mapping(1, _S["/app/service"], _S["abc123"]) + _mapping(
+        2, _S["/usr/lib/libc.so"], _S["libc"]
+    )
+    locations = (
+        _location(1, 1, [(1, 12)])  # handle, target binary
+        + _location(2, 1, [(2, 22)])  # greet, target binary
+        + _location(3, 2, [(3, 5)])  # libc frame, other binary
+        + _location(4, 1, [])  # unsymbolized location in the target binary
+    )
+    endpoint = _label(_S["endpoint"], _S["/api/greet"])
+    svc = _label(_S["service"], _S["checkout"])
+    samples = (
+        # handle -> libc -> greet (leaf-first): the libc frame is seen through.
+        _sample([2, 3, 1], 7, [endpoint, svc])
+        # handle -> unsymbolized leaf: counted, no edge.
+        + _sample([4, 1], 3, [endpoint, svc])
+    )
+    return strings + functions + mappings + locations + samples
+
+
+def _convert(tmp_path, **kwargs):
+    profile = tmp_path / "cpu.pb.gz"
+    profile.write_bytes(gzip.compress(_profile_bytes()))
+    output = tmp_path / "trace.jsonl"
+    path_map = [("/build/src/", tmp_path.as_posix() + "/src/")]
+    kwargs.setdefault("path_map", path_map)
+    count = convert_ebpf_pprof(profile, repo_root=tmp_path, output=output, **kwargs)
+    header, records = read_trace_file(output)
+    return count, header, list(records)
+
+
+def test_reanchors_paths_and_captures_seen_through_edge(tmp_path):
+    count, header, records = _convert(
+        tmp_path, build_id="abc123", workload_label="endpoint"
+    )
+
+    assert header.language == cs.TRACE_LANGUAGE_GO
+    assert header.sampled is True
+    assert count == len(records) == 1
+    record = records[0]
+    # The dyn edge survives the libc frame between the two project frames, and
+    # both endpoints re-anchor from /build/src to the repo.
+    assert (record.caller.qualname, record.callee.qualname) == ("handle", "greet")
+    assert record.count == 7
+    assert record.caller.path == (tmp_path / "src/app/service.go").as_posix()
+    assert record.callee.path.endswith("src/app/service.go")
+    # The chosen label became the workload (production's "which endpoint ran it").
+    assert record.workloads == ("/api/greet",)
+
+
+def test_unsymbolized_locations_are_counted_per_mapping(tmp_path):
+    messages: list[str] = []
+    sink_id = logger.add(messages.append, level="INFO", format="{message}")
+    try:
+        _convert(tmp_path, build_id="abc123")
+    finally:
+        logger.remove(sink_id)
+
+    joined = "\n".join(messages)
+    assert "eBPF symbolisation: 1 unsymbolized locations" in joined, joined
+    assert "unsymbolized[/app/service]=1" in joined, joined
+
+
+def test_service_label_filters_samples(tmp_path):
+    # A non-matching service selector drops every sample, so no edges remain.
+    count, _header, records = _convert(
+        tmp_path, build_id="abc123", service=("service", "billing")
+    )
+    assert count == 0
+    assert records == []
+
+
+def test_unmapped_build_paths_are_reported_not_resolved(tmp_path):
+    # Without a --path-map, the /build/src paths never enter the repo; the frames
+    # are counted as unmapped and no edge is produced.
+    messages: list[str] = []
+    sink_id = logger.add(messages.append, level="INFO", format="{message}")
+    try:
+        count, _header, records = _convert(tmp_path, path_map=[], build_id="abc123")
+    finally:
+        logger.remove(sink_id)
+
+    assert count == 0
+    assert any("unmapped build paths" in message for message in messages), messages
+
+
+def test_workload_falls_back_to_cli_value_without_a_label(tmp_path):
+    _count, _header, records = _convert(
+        tmp_path, build_id="abc123", workload="prod-overlay"
+    )
+    assert records
+    for record in records:
+        assert record.workloads == ("prod-overlay",)
+
+
+def test_unsupported_language_is_rejected(tmp_path):
+    profile = tmp_path / "cpu.pb.gz"
+    profile.write_bytes(gzip.compress(_profile_bytes()))
+    with pytest.raises(TraceFormatError):
+        convert_ebpf_pprof(
+            profile,
+            repo_root=tmp_path,
+            output=tmp_path / "out.jsonl",
+            language="cobol",
+        )
+
+
+def test_malformed_profile_is_rejected(tmp_path):
+    profile = tmp_path / "broken.pb.gz"
+    profile.write_bytes(gzip.compress(b"not a pprof"))
+    with pytest.raises(TraceFormatError):
+        convert_ebpf_pprof(profile, repo_root=tmp_path, output=tmp_path / "out.jsonl")
+
+
+def _write_profile(tmp_path):
+    profile = tmp_path / "cpu.pb.gz"
+    profile.write_bytes(gzip.compress(_profile_bytes()))
+    return profile
+
+
+def test_cli_convert_format_ebpf_writes_records(tmp_path):
+    from click.testing import CliRunner
+
+    from codebase_rag.trace.cli import cli
+
+    profile = _write_profile(tmp_path)
+    output = tmp_path / "trace.jsonl"
+    result = CliRunner().invoke(
+        cli,
+        [
+            "convert",
+            str(profile),
+            "--format",
+            "ebpf",
+            "--repo-path",
+            str(tmp_path),
+            "-o",
+            str(output),
+            "--path-map",
+            f"/build/src/={tmp_path.as_posix()}/src/",
+            "--build-id",
+            "abc123",
+            "--label",
+            "endpoint",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    _header, records = read_trace_file(output)
+    edges = {(r.caller.qualname, r.callee.qualname) for r in records}
+    assert ("handle", "greet") in edges
+
+
+def test_cli_rejects_unknown_format(tmp_path):
+    from click.testing import CliRunner
+
+    from codebase_rag.trace.cli import cli
+
+    profile = _write_profile(tmp_path)
+    result = CliRunner().invoke(
+        cli, ["convert", str(profile), "--format", "perf", "--repo-path", str(tmp_path)]
+    )
+    assert result.exit_code == 1
+    assert "Unknown --format" in result.output
+
+
+def test_cli_rejects_malformed_path_map(tmp_path):
+    from click.testing import CliRunner
+
+    from codebase_rag.trace.cli import cli
+
+    profile = _write_profile(tmp_path)
+    result = CliRunner().invoke(
+        cli,
+        [
+            "convert",
+            str(profile),
+            "--format",
+            "ebpf",
+            "--repo-path",
+            str(tmp_path),
+            "--path-map",
+            "no-equals-sign",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "Invalid --path-map" in result.output

--- a/codebase_rag/tests/test_dynamic_trace_ebpf.py
+++ b/codebase_rag/tests/test_dynamic_trace_ebpf.py
@@ -1,7 +1,7 @@
 # eBPF continuous-profiler pprof profiles share Go's protobuf wire format but
 # add mappings (per-binary build ids), per-sample labels, and build-time paths.
 # The converter must re-anchor those paths to the repo, filter by build id and
-# label, map a label to workloads, and count unsymbolized locations per mapping
+# label, map a label to workloads, and count unsymbolised locations per mapping
 # rather than dropping them (issue #1287).
 
 from __future__ import annotations
@@ -12,7 +12,11 @@ import pytest
 from loguru import logger
 
 from codebase_rag import constants as cs
-from codebase_rag.trace.ebpf_pprof import convert_ebpf_pprof
+from codebase_rag.trace.ebpf_pprof import (
+    _prefix_matches,
+    _reanchor,
+    convert_ebpf_pprof,
+)
 from codebase_rag.trace.records import TraceFormatError, read_trace_file
 
 
@@ -100,14 +104,14 @@ def _profile_bytes() -> bytes:
         _location(1, 1, [(1, 12)])  # handle, target binary
         + _location(2, 1, [(2, 22)])  # greet, target binary
         + _location(3, 2, [(3, 5)])  # libc frame, other binary
-        + _location(4, 1, [])  # unsymbolized location in the target binary
+        + _location(4, 1, [])  # unsymbolised location in the target binary
     )
     endpoint = _label(_S["endpoint"], _S["/api/greet"])
     svc = _label(_S["service"], _S["checkout"])
     samples = (
         # handle -> libc -> greet (leaf-first): the libc frame is seen through.
         _sample([2, 3, 1], 7, [endpoint, svc])
-        # handle -> unsymbolized leaf: counted, no edge.
+        # handle -> unsymbolised leaf: counted, no edge.
         + _sample([4, 1], 3, [endpoint, svc])
     )
     return strings + functions + mappings + locations + samples
@@ -143,7 +147,7 @@ def test_reanchors_paths_and_captures_seen_through_edge(tmp_path):
     assert record.workloads == ("/api/greet",)
 
 
-def test_unsymbolized_locations_are_counted_per_mapping(tmp_path):
+def test_unsymbolised_locations_are_counted_per_mapping(tmp_path):
     messages: list[str] = []
     sink_id = logger.add(messages.append, level="INFO", format="{message}")
     try:
@@ -152,8 +156,8 @@ def test_unsymbolized_locations_are_counted_per_mapping(tmp_path):
         logger.remove(sink_id)
 
     joined = "\n".join(messages)
-    assert "eBPF symbolisation: 1 unsymbolized locations" in joined, joined
-    assert "unsymbolized[/app/service]=1" in joined, joined
+    assert "eBPF symbolisation: 1 unsymbolised locations" in joined, joined
+    assert "unsymbolised[/app/service]=1" in joined, joined
 
 
 def test_service_label_filters_samples(tmp_path):
@@ -279,3 +283,91 @@ def test_cli_rejects_malformed_path_map(tmp_path):
     )
     assert result.exit_code == 1
     assert "Invalid --path-map" in result.output
+
+
+@pytest.mark.parametrize(
+    "option,error", [("--path-map", "path-map"), ("--service", "service")]
+)
+def test_cli_rejects_empty_option_key(tmp_path, option, error):
+    # `--path-map =REPO` would re-anchor every path; `--service =VALUE` selects no
+    # label. An empty key must be rejected, not silently accepted.
+    from click.testing import CliRunner
+
+    from codebase_rag.trace.cli import cli
+
+    profile = _write_profile(tmp_path)
+    result = CliRunner().invoke(
+        cli,
+        [
+            "convert",
+            str(profile),
+            "--format",
+            "ebpf",
+            "--repo-path",
+            str(tmp_path),
+            option,
+            "=value",
+        ],
+    )
+    assert result.exit_code == 1
+    assert error in result.output
+
+
+def test_path_map_matches_only_at_a_component_boundary():
+    # /build/src must not swallow /build/src-other: a partial-component match
+    # would emit false in-repo frames for a sibling directory.
+    assert _prefix_matches("/build/src/app.go", "/build/src")
+    assert _prefix_matches("/build/src", "/build/src")
+    assert not _prefix_matches("/build/src-other/app.go", "/build/src")
+    mapping = [("/build/src", "/repo/src")]
+    assert _reanchor("/build/src/app.go", mapping) == "/repo/src/app.go"
+    assert _reanchor("/build/src-other/app.go", mapping) == "/build/src-other/app.go"
+
+
+def _two_frame_profile(caller_path: str, callee_path: str) -> bytes:
+    strings = [
+        "",
+        "main.caller",
+        "main.callee",
+        caller_path,
+        callee_path,
+        "/svc",
+        "bid",
+    ]
+    table = b"".join(_string(s) for s in strings)
+    functions = _function(1, 1, 3, 10) + _function(2, 2, 4, 20)
+    mapping = _mapping(1, 5, 6)
+    locations = _location(1, 1, [(1, 12)]) + _location(2, 1, [(2, 22)])
+    # leaf-first: callee then caller, so root-first is caller -> callee.
+    sample = _sample([2, 1], 5, [])
+    return table + functions + mapping + locations + sample
+
+
+def test_reanchored_path_cannot_escape_the_repository(tmp_path):
+    # A profile path with `..` re-anchors under the repo prefix but resolves
+    # outside it; the traversal must be rejected, not injected as an edge.
+    profile = tmp_path / "cpu.pb.gz"
+    profile.write_bytes(
+        gzip.compress(
+            _two_frame_profile("/build/src/caller.go", "/build/src/../../outside.go")
+        )
+    )
+    output = tmp_path / "trace.jsonl"
+    messages: list[str] = []
+    sink_id = logger.add(messages.append, level="INFO", format="{message}")
+    try:
+        count = convert_ebpf_pprof(
+            profile,
+            repo_root=tmp_path,
+            output=output,
+            path_map=[("/build/src/", tmp_path.as_posix() + "/src/")],
+        )
+    finally:
+        logger.remove(sink_id)
+
+    assert count == 0
+    _header, records = read_trace_file(output)
+    for record in records:
+        assert "outside" not in record.caller.path
+        assert "outside" not in record.callee.path
+    assert any("unmapped build paths" in message for message in messages), messages

--- a/codebase_rag/trace/cli.py
+++ b/codebase_rag/trace/cli.py
@@ -113,10 +113,14 @@ def _require_repo(repo_path: Path | None) -> Path:
 
 
 def _parse_key_value(value: str, error_template: str) -> tuple[str, str]:
-    """Split a ``KEY=VALUE`` option, raising a usage error when it lacks ``=``."""
-    if "=" not in value:
+    """Split a ``KEY=VALUE`` option; a usage error when it lacks ``=`` or a key.
+
+    An empty key (``=value``) would re-anchor every path or select no label, so
+    it is rejected rather than silently matching everything.
+    """
+    key, sep, val = value.partition("=")
+    if not sep or not key:
         raise _ConvertUsageError(error_template.format(value=value))
-    key, _sep, val = value.partition("=")
     return key, val
 
 

--- a/codebase_rag/trace/cli.py
+++ b/codebase_rag/trace/cli.py
@@ -112,6 +112,73 @@ def _require_repo(repo_path: Path | None) -> Path:
     return repo_path
 
 
+def _parse_key_value(value: str, error_template: str) -> tuple[str, str]:
+    """Split a ``KEY=VALUE`` option, raising a usage error when it lacks ``=``."""
+    if "=" not in value:
+        raise _ConvertUsageError(error_template.format(value=value))
+    key, _sep, val = value.partition("=")
+    return key, val
+
+
+def _warn_commit_mismatch(commit: str | None, repo_path: Path) -> None:
+    """Warn when the profiled binary's commit differs from the repo HEAD."""
+    if commit is None:
+        return
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_path), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return
+    head = result.stdout.strip()
+    if head and not head.startswith(commit) and not commit.startswith(head):
+        message = ch.MSG_TRACE_COMMIT_MISMATCH.format(profiled=commit, head=head)
+        logger.warning(message)
+        click.secho(message, fg="yellow", err=True)
+
+
+def _convert_ebpf(
+    profile_file: Path,
+    repo_path: Path | None,
+    resolved_output: Path,
+    workload: str | None,
+    language: str | None,
+    path_map: tuple[str, ...],
+    build_id: str | None,
+    service: str | None,
+    label: str | None,
+    commit: str | None,
+) -> int:
+    """Convert an eBPF-profiler pprof profile with re-anchoring and filtering."""
+    from .. import constants as cs
+    from .ebpf_pprof import convert_ebpf_pprof
+
+    repo = _require_repo(repo_path)
+    mappings = [
+        _parse_key_value(entry, ch.ERR_TRACE_CONVERT_BAD_PATH_MAP) for entry in path_map
+    ]
+    service_pair = (
+        _parse_key_value(service, ch.ERR_TRACE_CONVERT_BAD_SERVICE) if service else None
+    )
+    _warn_commit_mismatch(commit, repo)
+    return convert_ebpf_pprof(
+        profile_file,
+        repo_root=repo,
+        output=resolved_output,
+        workload=workload,
+        path_map=mappings,
+        build_id=build_id,
+        service=service_pair,
+        workload_label=label,
+        language=language or cs.TRACE_LANGUAGE_GO,
+    )
+
+
 def _convert_profile(
     profile_file: Path,
     repo_path: Path | None,
@@ -218,6 +285,12 @@ def _convert_profile(
 @click.option("--include", default=None, help=ch.HELP_TRACE_INCLUDE)
 @click.option("--workload", default=None, help=ch.HELP_TRACE_WORKLOAD)
 @click.option("--language", default=None, help=ch.HELP_TRACE_LANGUAGE)
+@click.option("--format", "fmt", default=None, help=ch.HELP_TRACE_FORMAT)
+@click.option("--path-map", "path_map", multiple=True, help=ch.HELP_TRACE_PATH_MAP)
+@click.option("--build-id", default=None, help=ch.HELP_TRACE_BUILD_ID)
+@click.option("--service", default=None, help=ch.HELP_TRACE_SERVICE)
+@click.option("--label", default=None, help=ch.HELP_TRACE_LABEL)
+@click.option("--commit", default=None, help=ch.HELP_TRACE_COMMIT)
 def convert_cmd(
     profile_file: Path,
     repo_path: Path | None,
@@ -225,14 +298,36 @@ def convert_cmd(
     include: str | None,
     workload: str | None,
     language: str | None,
+    fmt: str | None,
+    path_map: tuple[str, ...],
+    build_id: str | None,
+    service: str | None,
+    label: str | None,
+    commit: str | None,
 ) -> None:
     from .. import constants as cs
 
     resolved_output = output or Path(cs.TRACE_DEFAULT_OUTPUT)
     try:
-        count = _convert_profile(
-            profile_file, repo_path, resolved_output, include, workload, language
-        )
+        if fmt == "ebpf":
+            count = _convert_ebpf(
+                profile_file,
+                repo_path,
+                resolved_output,
+                workload,
+                language,
+                path_map,
+                build_id,
+                service,
+                label,
+                commit,
+            )
+        elif fmt is not None:
+            raise _ConvertUsageError(ch.ERR_TRACE_CONVERT_BAD_FORMAT.format(format=fmt))
+        else:
+            count = _convert_profile(
+                profile_file, repo_path, resolved_output, include, workload, language
+            )
     # TraceFormatError subclasses ValueError, so ValueError covers it (and the
     # malformed-number / non-UTF-8 cases) without listing it redundantly.
     except (OSError, ValueError, _ConvertUsageError) as e:

--- a/codebase_rag/trace/ebpf_pprof.py
+++ b/codebase_rag/trace/ebpf_pprof.py
@@ -1,0 +1,405 @@
+"""Convert eBPF continuous-profiler pprof profiles to the interchange format.
+
+eBPF profilers (Parca, Pyroscope, the OpenTelemetry eBPF profiler, ``perf``
+-> pprof) sample stacks from outside the process at the kernel level: zero
+instrumentation of the target, fleet-wide, continuous. Their output is the
+same pprof wire format the Go/Rust converters decode, so production call
+chains fuse through the existing ingest door as ``dynamic_sampled`` edges.
+
+Three things separate a fleet profile from ``go test -cpuprofile`` output, all
+handled here rather than in the shared decoder:
+
+* **Mappings** (pprof field 3) name the binary each location came from; a fleet
+  profile mixes the target service, libc, and the kernel. Locations are filtered
+  to a target build-id or mapping filename, and unsymbolized locations are
+  counted per mapping instead of being dropped silently.
+* **Sample labels** (Sample field 3) carry ``pid``/``service``/``endpoint`` tags.
+  A label filters to the target service, and a chosen label becomes the edge's
+  ``workloads`` -- production's analogue of "which test exercised this edge".
+* **Path re-anchoring.** Production binaries are built elsewhere
+  (``/build/src/...``, container prefixes), so a ``--path-map`` rewrites the
+  build prefix to the repository prefix before the in-repo check; unmapped
+  frames keep their path and are counted as misses.
+
+Symbol grammars are reused from the per-runtime converters, keyed off the
+selected language: Go (``pprof``), Rust (``rust_pprof``), and C/C++ (the
+already-demangled grammar in ``instrumented``; Parca server-side-symbolizes and
+demangles, which this path assumes).
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+from .. import constants as cs
+from .instrumented import _bare_name as _cpp_bare_name
+from .pprof import (
+    _bare_name as _go_bare_name,
+)
+from .pprof import (
+    _decompress,
+    _fields,
+    _parse_function,
+    _repeated_uint,
+)
+from .records import (
+    CallRecord,
+    FramePoint,
+    TraceFormatError,
+    TraceHeader,
+    write_trace_file,
+)
+from .rust_pprof import _bare_name as _rust_bare_name
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# Bare-member demanglers reused from the per-runtime converters.
+_DEMANGLERS = {
+    cs.TRACE_LANGUAGE_GO: _go_bare_name,
+    cs.TRACE_LANGUAGE_RUST: _rust_bare_name,
+    cs.TRACE_LANGUAGE_CPP: _cpp_bare_name,
+}
+
+
+@dataclass(slots=True)
+class _Mapping:
+    filename_index: int = 0
+    build_id_index: int = 0
+
+
+@dataclass(slots=True)
+class _Location:
+    mapping_id: int = 0
+    function_ids: list[int] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class _LabeledSample:
+    location_ids: list[int]
+    weight: int
+    labels: dict[str, str]
+
+
+def _parse_mapping(payload: bytes) -> tuple[int, _Mapping]:
+    """A mapping's id, filename string index, and build-id string index."""
+    mapping_id = 0
+    mapping = _Mapping()
+    for field_num, _wire, value in _fields(payload):
+        if not isinstance(value, int):
+            continue
+        if field_num == 1:
+            mapping_id = value
+        elif field_num == 5:
+            mapping.filename_index = value
+        elif field_num == 6:
+            mapping.build_id_index = value
+    return mapping_id, mapping
+
+
+def _parse_location(payload: bytes) -> tuple[int, _Location]:
+    """A location's id, mapping id, and function ids (inline frames)."""
+    location_id = 0
+    location = _Location()
+    for field_num, _wire, value in _fields(payload):
+        if field_num == 1 and isinstance(value, int):
+            location_id = value
+        elif field_num == 2 and isinstance(value, int):
+            location.mapping_id = value
+        elif field_num == 4 and isinstance(value, bytes):
+            for line_field, _lw, line_value in _fields(value):
+                if line_field == 1 and isinstance(line_value, int):
+                    location.function_ids.append(line_value)
+    return location_id, location
+
+
+def _parse_label(payload: bytes) -> tuple[int, int]:
+    """A label's key string index and (string) value index; numeric labels 0."""
+    key_index = 0
+    str_index = 0
+    for field_num, _wire, value in _fields(payload):
+        if not isinstance(value, int):
+            continue
+        if field_num == 1:
+            key_index = value
+        elif field_num == 2:
+            str_index = value
+    return key_index, str_index
+
+
+def _parse_sample(payload: bytes, strings: list[str]) -> _LabeledSample:
+    location_ids: list[int] = []
+    weight = 0
+    labels: dict[str, str] = {}
+    for field_num, wire, value in _fields(payload):
+        if field_num == 1:
+            location_ids.extend(_repeated_uint(wire, value))
+        elif field_num == 2 and not weight:
+            values = _repeated_uint(wire, value)
+            weight = values[0] if values else 0
+        elif field_num == 3 and isinstance(value, bytes):
+            key_index, str_index = _parse_label(value)
+            key = _string_at(strings, key_index)
+            val = _string_at(strings, str_index)
+            if key:
+                labels[key] = val
+    return _LabeledSample(location_ids, max(weight, 1), labels)
+
+
+def _string_at(strings: list[str], index: int) -> str:
+    return strings[index] if 0 <= index < len(strings) else ""
+
+
+@dataclass(slots=True)
+class _Profile:
+    strings: list[str]
+    functions: dict[int, object]
+    locations: dict[int, _Location]
+    mappings: dict[int, _Mapping]
+    samples: list[_LabeledSample]
+
+
+def _decode(raw: bytes) -> _Profile:
+    """Decode the pprof message, keeping mappings, labels, and location owners."""
+    strings: list[str] = []
+    functions: dict[int, object] = {}
+    locations: dict[int, _Location] = {}
+    mappings: dict[int, _Mapping] = {}
+    sample_payloads: list[bytes] = []
+    for field_num, _wire, value in _fields(raw):
+        if not isinstance(value, bytes):
+            continue
+        if field_num == 2:
+            # Labels reference the string table; defer until it is fully read.
+            sample_payloads.append(value)
+        elif field_num == 3:
+            mapping_id, mapping = _parse_mapping(value)
+            mappings[mapping_id] = mapping
+        elif field_num == 4:
+            location_id, location = _parse_location(value)
+            locations[location_id] = location
+        elif field_num == 5:
+            function_id, function = _parse_function(value)
+            functions[function_id] = function
+        elif field_num == 6:
+            strings.append(value.decode("utf-8", errors="replace"))
+    samples = [_parse_sample(payload, strings) for payload in sample_payloads]
+    return _Profile(strings, functions, locations, mappings, samples)
+
+
+def _reanchor(path: str, path_map: list[tuple[str, str]]) -> str:
+    """Rewrite a build-time path prefix to the repository prefix, first match."""
+    for build_prefix, repo_prefix in path_map:
+        if path.startswith(build_prefix):
+            return repo_prefix + path[len(build_prefix) :]
+    return path
+
+
+class _FrameBuilder:
+    """Resolves function ids to in-repo frames, tracking symbolisation gaps."""
+
+    def __init__(
+        self,
+        profile: _Profile,
+        root_prefix: str,
+        path_map: list[tuple[str, str]],
+        demangle,
+    ) -> None:
+        self._profile = profile
+        self._root_prefix = root_prefix
+        self._path_map = path_map
+        self._demangle = demangle
+        self._cache: dict[int, FramePoint | None] = {}
+        self.unmapped_paths: Counter[str] = Counter()
+
+    def frame(self, function_id: int) -> FramePoint | None:
+        if function_id not in self._cache:
+            self._cache[function_id] = self._build(function_id)
+        return self._cache[function_id]
+
+    def _build(self, function_id: int) -> FramePoint | None:
+        function = self._profile.functions.get(function_id)
+        strings = self._profile.strings
+        filename_index = getattr(function, "filename_index", 0)
+        if function is None or not 0 < filename_index < len(strings):
+            return None
+        path = _reanchor(strings[filename_index], self._path_map)
+        if not path.startswith(self._root_prefix):
+            # A production build path no --path-map rewrote into the repo: keep
+            # the original and count it, so re-anchoring gaps are visible.
+            self.unmapped_paths[strings[filename_index]] += 1
+            return None
+        name_index = getattr(function, "name_index", 0)
+        name = strings[name_index] if 0 < name_index < len(strings) else ""
+        return FramePoint(
+            path=path,
+            qualname=self._demangle(name),
+            line=max(getattr(function, "start_line", 0), 0),
+        )
+
+
+def _mapping_selected(
+    location: _Location, profile: _Profile, build_id: str | None
+) -> bool:
+    """Whether a location's binary is the target (no filter selects every one)."""
+    if build_id is None:
+        return True
+    mapping = profile.mappings.get(location.mapping_id)
+    if mapping is None:
+        return False
+    return build_id in (
+        _string_at(profile.strings, mapping.build_id_index),
+        _string_at(profile.strings, mapping.filename_index),
+    ) or _string_at(profile.strings, mapping.filename_index).endswith(build_id)
+
+
+def _sample_matches(sample: _LabeledSample, service: tuple[str, str] | None) -> bool:
+    return service is None or sample.labels.get(service[0]) == service[1]
+
+
+def _sample_workload(
+    sample: _LabeledSample, workload_label: str | None, default: str | None
+) -> str | None:
+    if workload_label is not None:
+        return sample.labels.get(workload_label) or default
+    return default
+
+
+def _mapping_name(profile: _Profile, location: _Location) -> str:
+    mapping = profile.mappings.get(location.mapping_id)
+    return _string_at(profile.strings, mapping.filename_index) if mapping else ""
+
+
+def _accumulate(
+    profile: _Profile,
+    builder: _FrameBuilder,
+    *,
+    build_id: str | None,
+    service: tuple[str, str] | None,
+    workload_label: str | None,
+    default_workload: str | None,
+) -> tuple[dict[tuple[FramePoint, FramePoint], tuple[int, set[str]]], Counter[str]]:
+    """Adjacent in-repo frames per leaf-first stack, with per-edge workloads.
+
+    Locations from other binaries and unsymbolized locations are seen through
+    (they do not reset the ancestor), so a project edge survives a libc frame
+    between its endpoints. Unsymbolized locations in the target binary are
+    counted per mapping rather than dropped silently.
+    """
+    edges: dict[tuple[FramePoint, FramePoint], tuple[int, set[str]]] = {}
+    unsymbolized: Counter[str] = Counter()
+    for sample in profile.samples:
+        if not _sample_matches(sample, service):
+            continue
+        workload = _sample_workload(sample, workload_label, default_workload)
+        ancestor: FramePoint | None = None
+        for location_id in reversed(sample.location_ids):
+            location = profile.locations.get(location_id)
+            if location is None or not _mapping_selected(location, profile, build_id):
+                continue
+            if not location.function_ids:
+                unsymbolized[_mapping_name(profile, location) or "<unknown>"] += 1
+                continue
+            for function_id in reversed(location.function_ids):
+                frame = builder.frame(function_id)
+                if frame is None:
+                    continue
+                if ancestor is not None:
+                    count, workloads = edges.get((ancestor, frame), (0, set()))
+                    if workload:
+                        workloads.add(workload)
+                    edges[(ancestor, frame)] = (count + sample.weight, workloads)
+                ancestor = frame
+    return edges, unsymbolized
+
+
+def _report(unsymbolized: Counter[str], unmapped_paths: Counter[str]) -> None:
+    """Log symbolisation and path-anchoring gaps so they are visible."""
+    total_unsymbolized = sum(unsymbolized.values())
+    if total_unsymbolized:
+        logger.info(
+            cs.TRACE_MSG_EBPF_UNSYMBOLIZED.format(
+                count=total_unsymbolized, mappings=len(unsymbolized)
+            )
+        )
+        for name, count in unsymbolized.most_common():
+            logger.info(cs.TRACE_MSG_EBPF_MAPPING_DETAIL.format(name=name, count=count))
+    total_unmapped = sum(unmapped_paths.values())
+    if total_unmapped:
+        logger.info(
+            cs.TRACE_MSG_EBPF_UNMAPPED.format(
+                count=total_unmapped, paths=len(unmapped_paths)
+            )
+        )
+
+
+def convert_ebpf_pprof(
+    profile_path: Path,
+    repo_root: Path,
+    output: Path,
+    *,
+    workload: str | None = None,
+    path_map: list[tuple[str, str]] | None = None,
+    build_id: str | None = None,
+    service: tuple[str, str] | None = None,
+    workload_label: str | None = None,
+    language: str = cs.TRACE_LANGUAGE_GO,
+) -> int:
+    """Convert an eBPF-profiler pprof profile to project call edges.
+
+    ``path_map`` rewrites build-time path prefixes to the repository prefix;
+    ``build_id`` filters to one binary's mapping; ``service`` (a ``key, value``
+    pair) filters samples; ``workload_label`` maps a sample label to per-edge
+    ``workloads``; ``language`` selects the symbol demangler.
+    """
+    demangle = _DEMANGLERS.get(language)
+    if demangle is None:
+        raise TraceFormatError(
+            cs.TRACE_ERR_EBPF_LANGUAGE.format(
+                language=language, supported=", ".join(sorted(_DEMANGLERS))
+            )
+        )
+    raw = _decompress(profile_path.read_bytes(), profile_path)
+    try:
+        profile = _decode(raw)
+    except TraceFormatError as e:
+        raise TraceFormatError(cs.TRACE_ERR_BAD_PPROF.format(path=profile_path)) from e
+    if not profile.strings or not profile.functions or not profile.samples:
+        raise TraceFormatError(cs.TRACE_ERR_BAD_PPROF.format(path=profile_path))
+
+    root_prefix = repo_root.resolve().as_posix() + "/"
+    builder = _FrameBuilder(profile, root_prefix, path_map or [], demangle)
+    edges, unsymbolized = _accumulate(
+        profile,
+        builder,
+        build_id=build_id,
+        service=service,
+        workload_label=workload_label,
+        default_workload=workload,
+    )
+    _report(unsymbolized, builder.unmapped_paths)
+
+    fallback = (workload,) if workload else ()
+    records = [
+        CallRecord(
+            caller=caller,
+            callee=callee,
+            count=count,
+            workloads=tuple(sorted(workloads)) if workloads else fallback,
+            receiver_types=(),
+        )
+        for (caller, callee), (count, workloads) in edges.items()
+    ]
+    header = TraceHeader(
+        version=cs.TRACE_FORMAT_VERSION,
+        language=language,
+        repo_root=str(repo_root),
+        tracer=cs.TRACE_TOOL_NAME_EBPF,
+        sampled=True,
+    )
+    write_trace_file(output, header, records)
+    return len(records)

--- a/codebase_rag/trace/ebpf_pprof.py
+++ b/codebase_rag/trace/ebpf_pprof.py
@@ -102,6 +102,15 @@ def _parse_mapping(payload: bytes) -> tuple[int, _Mapping]:
     return mapping_id, mapping
 
 
+def _line_function_ids(line_payload: bytes) -> list[int]:
+    """The function ids of a Location's inline Line records."""
+    return [
+        value
+        for line_field, _wire, value in _fields(line_payload)
+        if line_field == 1 and isinstance(value, int)
+    ]
+
+
 def _parse_location(payload: bytes) -> tuple[int, _Location]:
     """A location's id, mapping id, and function ids (inline frames)."""
     location_id = 0
@@ -112,9 +121,7 @@ def _parse_location(payload: bytes) -> tuple[int, _Location]:
         elif field_num == 2 and isinstance(value, int):
             location.mapping_id = value
         elif field_num == 4 and isinstance(value, bytes):
-            for line_field, _lw, line_value in _fields(value):
-                if line_field == 1 and isinstance(line_value, int):
-                    location.function_ids.append(line_value)
+            location.function_ids.extend(_line_function_ids(value))
     return location_id, location
 
 
@@ -294,6 +301,34 @@ def _mapping_name(profile: _Profile, location: _Location) -> str:
     return _string_at(profile.strings, mapping.filename_index) if mapping else ""
 
 
+def _resolved_frames(
+    sample: _LabeledSample,
+    profile: _Profile,
+    builder: _FrameBuilder,
+    build_id: str | None,
+    unsymbolised: Counter[str],
+) -> list[FramePoint]:
+    """A sample's in-repo frames, root-first, seeing through other binaries.
+
+    Locations from another binary and unsymbolised locations are skipped rather
+    than breaking the chain, so a project edge survives a libc frame between its
+    endpoints; unsymbolised target-binary locations are counted per mapping.
+    """
+    frames: list[FramePoint] = []
+    for location_id in reversed(sample.location_ids):
+        location = profile.locations.get(location_id)
+        if location is None or not _mapping_selected(location, profile, build_id):
+            continue
+        if not location.function_ids:
+            unsymbolised[_mapping_name(profile, location) or "<unknown>"] += 1
+            continue
+        for function_id in reversed(location.function_ids):
+            frame = builder.frame(function_id)
+            if frame is not None:
+                frames.append(frame)
+    return frames
+
+
 def _accumulate(
     profile: _Profile,
     builder: _FrameBuilder,
@@ -303,37 +338,19 @@ def _accumulate(
     workload_label: str | None,
     default_workload: str | None,
 ) -> tuple[dict[tuple[FramePoint, FramePoint], tuple[int, set[str]]], Counter[str]]:
-    """Adjacent in-repo frames per leaf-first stack, with per-edge workloads.
-
-    Locations from other binaries and unsymbolised locations are seen through
-    (they do not reset the ancestor), so a project edge survives a libc frame
-    between its endpoints. Unsymbolised locations in the target binary are
-    counted per mapping rather than dropped silently.
-    """
+    """Adjacent in-repo frames per leaf-first stack, with per-edge workloads."""
     edges: dict[tuple[FramePoint, FramePoint], tuple[int, set[str]]] = {}
     unsymbolised: Counter[str] = Counter()
     for sample in profile.samples:
         if not _sample_matches(sample, service):
             continue
         workload = _sample_workload(sample, workload_label, default_workload)
-        ancestor: FramePoint | None = None
-        for location_id in reversed(sample.location_ids):
-            location = profile.locations.get(location_id)
-            if location is None or not _mapping_selected(location, profile, build_id):
-                continue
-            if not location.function_ids:
-                unsymbolised[_mapping_name(profile, location) or "<unknown>"] += 1
-                continue
-            for function_id in reversed(location.function_ids):
-                frame = builder.frame(function_id)
-                if frame is None:
-                    continue
-                if ancestor is not None:
-                    count, workloads = edges.get((ancestor, frame), (0, set()))
-                    if workload:
-                        workloads.add(workload)
-                    edges[(ancestor, frame)] = (count + sample.weight, workloads)
-                ancestor = frame
+        frames = _resolved_frames(sample, profile, builder, build_id, unsymbolised)
+        for ancestor, frame in zip(frames, frames[1:], strict=False):
+            count, workloads = edges.get((ancestor, frame), (0, set()))
+            if workload:
+                workloads.add(workload)
+            edges[(ancestor, frame)] = (count + sample.weight, workloads)
     return edges, unsymbolised
 
 

--- a/codebase_rag/trace/ebpf_pprof.py
+++ b/codebase_rag/trace/ebpf_pprof.py
@@ -11,7 +11,7 @@ handled here rather than in the shared decoder:
 
 * **Mappings** (pprof field 3) name the binary each location came from; a fleet
   profile mixes the target service, libc, and the kernel. Locations are filtered
-  to a target build-id or mapping filename, and unsymbolized locations are
+  to a target build-id or mapping filename, and unsymbolised locations are
   counted per mapping instead of being dropped silently.
 * **Sample labels** (Sample field 3) carry ``pid``/``service``/``endpoint`` tags.
   A label filters to the target service, and a chosen label becomes the edge's
@@ -29,6 +29,7 @@ demangles, which this path assumes).
 
 from __future__ import annotations
 
+import posixpath
 from collections import Counter
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
@@ -191,12 +192,28 @@ def _decode(raw: bytes) -> _Profile:
     return _Profile(strings, functions, locations, mappings, samples)
 
 
+def _prefix_matches(path: str, prefix: str) -> bool:
+    """Whether ``prefix`` matches ``path`` at a path-component boundary.
+
+    ``/build/src`` matches ``/build/src/x`` but not ``/build/src-other/x``.
+    """
+    if not path.startswith(prefix):
+        return False
+    rest = path[len(prefix) :]
+    return prefix.endswith("/") or rest == "" or rest.startswith("/")
+
+
 def _reanchor(path: str, path_map: list[tuple[str, str]]) -> str:
     """Rewrite a build-time path prefix to the repository prefix, first match."""
     for build_prefix, repo_prefix in path_map:
-        if path.startswith(build_prefix):
+        if _prefix_matches(path, build_prefix):
             return repo_prefix + path[len(build_prefix) :]
     return path
+
+
+def _within_repo(path: str, root_prefix: str) -> bool:
+    """Whether a normalised path is the repo root or sits inside it."""
+    return path == root_prefix.rstrip("/") or path.startswith(root_prefix)
 
 
 class _FrameBuilder:
@@ -227,11 +244,14 @@ class _FrameBuilder:
         filename_index = getattr(function, "filename_index", 0)
         if function is None or not 0 < filename_index < len(strings):
             return None
-        path = _reanchor(strings[filename_index], self._path_map)
-        if not path.startswith(self._root_prefix):
-            # A production build path no --path-map rewrote into the repo: keep
-            # the original and count it, so re-anchoring gaps are visible.
-            self.unmapped_paths[strings[filename_index]] += 1
+        original = strings[filename_index]
+        # normpath collapses any ``..`` so a re-anchored path cannot traverse out
+        # of the repo and still pass the containment check below.
+        path = posixpath.normpath(_reanchor(original, self._path_map))
+        if not _within_repo(path, self._root_prefix):
+            # No --path-map rewrote this build path into the repo (or it escaped
+            # via ``..``): keep the original and count it, so gaps are visible.
+            self.unmapped_paths[original] += 1
             return None
         name_index = getattr(function, "name_index", 0)
         name = strings[name_index] if 0 < name_index < len(strings) else ""
@@ -285,13 +305,13 @@ def _accumulate(
 ) -> tuple[dict[tuple[FramePoint, FramePoint], tuple[int, set[str]]], Counter[str]]:
     """Adjacent in-repo frames per leaf-first stack, with per-edge workloads.
 
-    Locations from other binaries and unsymbolized locations are seen through
+    Locations from other binaries and unsymbolised locations are seen through
     (they do not reset the ancestor), so a project edge survives a libc frame
-    between its endpoints. Unsymbolized locations in the target binary are
+    between its endpoints. Unsymbolised locations in the target binary are
     counted per mapping rather than dropped silently.
     """
     edges: dict[tuple[FramePoint, FramePoint], tuple[int, set[str]]] = {}
-    unsymbolized: Counter[str] = Counter()
+    unsymbolised: Counter[str] = Counter()
     for sample in profile.samples:
         if not _sample_matches(sample, service):
             continue
@@ -302,7 +322,7 @@ def _accumulate(
             if location is None or not _mapping_selected(location, profile, build_id):
                 continue
             if not location.function_ids:
-                unsymbolized[_mapping_name(profile, location) or "<unknown>"] += 1
+                unsymbolised[_mapping_name(profile, location) or "<unknown>"] += 1
                 continue
             for function_id in reversed(location.function_ids):
                 frame = builder.frame(function_id)
@@ -314,19 +334,19 @@ def _accumulate(
                         workloads.add(workload)
                     edges[(ancestor, frame)] = (count + sample.weight, workloads)
                 ancestor = frame
-    return edges, unsymbolized
+    return edges, unsymbolised
 
 
-def _report(unsymbolized: Counter[str], unmapped_paths: Counter[str]) -> None:
+def _report(unsymbolised: Counter[str], unmapped_paths: Counter[str]) -> None:
     """Log symbolisation and path-anchoring gaps so they are visible."""
-    total_unsymbolized = sum(unsymbolized.values())
-    if total_unsymbolized:
+    total_unsymbolised = sum(unsymbolised.values())
+    if total_unsymbolised:
         logger.info(
             cs.TRACE_MSG_EBPF_UNSYMBOLIZED.format(
-                count=total_unsymbolized, mappings=len(unsymbolized)
+                count=total_unsymbolised, mappings=len(unsymbolised)
             )
         )
-        for name, count in unsymbolized.most_common():
+        for name, count in unsymbolised.most_common():
             logger.info(cs.TRACE_MSG_EBPF_MAPPING_DETAIL.format(name=name, count=count))
     total_unmapped = sum(unmapped_paths.values())
     if total_unmapped:
@@ -373,7 +393,7 @@ def convert_ebpf_pprof(
 
     root_prefix = repo_root.resolve().as_posix() + "/"
     builder = _FrameBuilder(profile, root_prefix, path_map or [], demangle)
-    edges, unsymbolized = _accumulate(
+    edges, unsymbolised = _accumulate(
         profile,
         builder,
         build_id=build_id,
@@ -381,7 +401,7 @@ def convert_ebpf_pprof(
         workload_label=workload_label,
         default_workload=workload,
     )
-    _report(unsymbolized, builder.unmapped_paths)
+    _report(unsymbolised, builder.unmapped_paths)
 
     fallback = (workload,) if workload else ()
     records = [

--- a/docs/guide/dynamic-tracing.md
+++ b/docs/guide/dynamic-tracing.md
@@ -439,7 +439,7 @@ protobuf magic. Three things differ from a `go test -cpuprofile`:
 
 - **Mappings.** A fleet profile mixes the target service, libc, and the kernel.
   `--build-id` keeps only the mapping whose build id (or binary filename) matches;
-  other binaries are seen through, like any glue frame. Unsymbolized locations in
+  other binaries are seen through, like any glue frame. Unsymbolised locations in
   the target binary are counted per mapping and logged, not dropped silently.
 - **Path re-anchoring.** Production binaries are built elsewhere
   (`/build/src/...`, container prefixes), so `--path-map BUILD=REPO` rewrites the
@@ -451,10 +451,10 @@ protobuf magic. Three things differ from a `go test -cpuprofile`:
   value to each edge's `workloads` — production's analogue of "which test ran it".
 
 `--language` selects the demangler (`go`, `rust`, or `cpp`; C/C++ frames must
-arrive server-side-symbolized and demangled, which Parca provides). Caveats:
+arrive server-side-symbolised and demangled, which Parca provides). Caveats:
 optimized production builds inline aggressively, so coverage is structurally
 lower than test-suite traces (absence of an edge still never means dead code);
-symbolization needs frame pointers or DWARF in the deployed binary; and the
+symbolisation needs frame pointers or DWARF in the deployed binary; and the
 profiled binary may lag the indexed graph, which `--commit` surfaces.
 
 ## Ingesting a trace

--- a/docs/guide/dynamic-tracing.md
+++ b/docs/guide/dynamic-tracing.md
@@ -13,7 +13,9 @@ conversion), **PHP** (Xdebug trace conversion), **Lua** (a pure-Lua
 `debug.sethook` agent), **Dart** (a VM Service sample collector),
 **Go** (pprof CPU-profile conversion), **C/C++** (a
 `-finstrument-functions` shim), and **Rust** (pprof-rs CPU-profile
-conversion). Remaining runtimes are tracked in
+conversion). For production fleets, an **eBPF continuous profiler** (Parca,
+Pyroscope, OpenTelemetry, `perf`) can be ingested through the same pprof door
+(`--format ebpf`). All per-runtime tracers landed under
 [issue #1244](https://github.com/vitali87/code-graph-rag/issues/1244).
 
 ## Recording a trace
@@ -410,6 +412,50 @@ counted and reported, so that symbolisation gap is visible rather than silent. O
 for test workloads, not for production; the edge table holds 65k distinct
 pairs, and conversion **rejects** a trace the shim marked `dropped` (table
 overflowed) rather than pass off an incomplete call graph as exact.
+
+## Recording a production trace (eBPF continuous profilers)
+
+Every recipe above traces a test or dev workload from inside the runtime. An
+eBPF continuous profiler (Parca, Pyroscope, the OpenTelemetry eBPF profiler,
+`perf` exported to pprof) instead samples stacks from the kernel: no
+instrumentation of the target, roughly 1% overhead, fleet-wide and continuous.
+Its output is the same pprof wire format the Go and Rust recipes decode, so a
+production overlay ingests through the same door:
+
+```bash
+# obtain a merged pprof from your profiler (e.g. Parca's query API), then:
+cgr trace convert prod.pb.gz --format ebpf --repo-path /path/to/your-repo \
+    --language go \
+    --build-id 8f3a...   `# keep only the target binary's mapping` \
+    --path-map /build/src/=/path/to/your-repo/src/ \
+    --label endpoint     `# a sample label becomes each edge's workload` \
+    --service service_name=checkout \
+    --commit 1a2b3c4       `# warns if it differs from the repo HEAD`
+cgr trace ingest cgr-trace.jsonl --repo-path /path/to/your-repo
+```
+
+`--format ebpf` is required because eBPF profiles share Go pprof's gzipped
+protobuf magic. Three things differ from a `go test -cpuprofile`:
+
+- **Mappings.** A fleet profile mixes the target service, libc, and the kernel.
+  `--build-id` keeps only the mapping whose build id (or binary filename) matches;
+  other binaries are seen through, like any glue frame. Unsymbolized locations in
+  the target binary are counted per mapping and logged, not dropped silently.
+- **Path re-anchoring.** Production binaries are built elsewhere
+  (`/build/src/...`, container prefixes), so `--path-map BUILD=REPO` rewrites the
+  prefix before the in-repo check (repeatable). Frames no map re-anchors keep
+  their path and are counted so the gap is visible; this is the source-map idea
+  from the Node.js recipe applied to native builds.
+- **Labels.** Profilers attach `pid`/`service`/`endpoint` tags per sample.
+  `--service KEY=VALUE` filters to one service; `--label KEY` maps that label's
+  value to each edge's `workloads` — production's analogue of "which test ran it".
+
+`--language` selects the demangler (`go`, `rust`, or `cpp`; C/C++ frames must
+arrive server-side-symbolized and demangled, which Parca provides). Caveats:
+optimized production builds inline aggressively, so coverage is structurally
+lower than test-suite traces (absence of an edge still never means dead code);
+symbolization needs frame pointers or DWARF in the deployed binary; and the
+profiled binary may lag the indexed graph, which `--commit` surfaces.
 
 ## Ingesting a trace
 

--- a/docs/guide/dynamic-tracing.md
+++ b/docs/guide/dynamic-tracing.md
@@ -450,8 +450,11 @@ protobuf magic. Three things differ from a `go test -cpuprofile`:
   `--service KEY=VALUE` filters to one service; `--label KEY` maps that label's
   value to each edge's `workloads` — production's analogue of "which test ran it".
 
-`--language` selects the demangler (`go`, `rust`, or `cpp`; C/C++ frames must
-arrive server-side-symbolised and demangled, which Parca provides). Caveats:
+`--language` selects how symbol names are normalised to their bare member
+(`go`, `rust`, or `cpp`). This normalises names; it does not symbolise addresses
+or demangle mangled symbols, so C/C++ frames must arrive already
+server-side-symbolised and demangled (which Parca provides) for `--language cpp`
+to reduce them correctly. Caveats:
 optimized production builds inline aggressively, so coverage is structurally
 lower than test-suite traces (absence of an edge still never means dead code);
 symbolisation needs frame pointers or DWARF in the deployed binary; and the


### PR DESCRIPTION
Implements the v1 slice of #1287: a production-grade collection path that ingests pprof profiles from eBPF continuous profilers (Parca, Pyroscope, the OpenTelemetry eBPF profiler, `perf`-derived pprof) into the same hybrid graph as the per-runtime tracers, through the existing ingest door with `dynamic_sampled` provenance.

## New front door: `cgr trace convert profile.pb.gz --format ebpf`

eBPF profiles share Go pprof's gzipped-protobuf magic, so the format is explicit. `ebpf_pprof.py` reuses `pprof.py`'s dependency-free decoder primitives and adds the three structural differences the issue calls out:

- **Mappings (pprof field 3).** Fleet profiles mix the target service, libc, and the kernel. `--build-id` keeps only the mapping whose build id or binary filename matches; other binaries are seen through like any glue frame. Unsymbolized locations in the target binary are counted per mapping and logged, not dropped silently (the same symbolization-gap honesty the C shim documents).
- **Sample labels (Sample field 3).** `--service KEY=VALUE` filters samples to one service; `--label KEY` maps that label's value to each edge's `workloads` — production's analogue of "which test exercised this edge".
- **Path re-anchoring** (the one genuinely new requirement). `--path-map BUILD_PREFIX=REPO_PREFIX` (repeatable) rewrites build-time paths before the in-repo check; frames no map re-anchors keep their path and are counted, mirroring the source-map relocation from #1247.

Plus: `--language` selects the demangler (`go`/`rust`/`cpp`, reusing the existing per-runtime grammars; C/C++ assumes server-side-symbolized profiles, which Parca provides), and `--commit` warns when the profiled binary's commit differs from the repo HEAD at convert time.

Ingest (`trace/ingest.py`) and the interchange schema are untouched — everything downstream of `FramePoint` was already paid for.

## Tests

`test_dynamic_trace_ebpf.py` hand-encodes pprof protobufs and covers: path re-anchoring, a runtime-only edge seen through a filtered libc frame, label→workload, service filtering, per-mapping unsymbolized counting, unmapped-path reporting, CLI-value workload fallback, unsupported-language and malformed rejection, and the CLI wiring (`--format ebpf`, unknown-format and malformed `--path-map` usage errors).

## Out of v1 scope (per the issue)

`cgr trace pull` (query a Parca/Pyroscope API), in-kernel interpreted-language frame resolution, and off-CPU/wallclock profiles — all layer on without touching ingest.

Verified locally: `test_dynamic_trace_ebpf.py`, `test_dynamic_trace_pprof.py`, `test_dynamic_trace_rust.py`, `test_dynamic_trace_cli.py` (38 tests) pass; ruff + ty clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for converting eBPF pprof profiles, including compressed profiles, into trace records.
  * Added build-ID filtering, path remapping, service and workload labels, language selection, and commit metadata.
  * Added symbolization and reporting for unsymbolized or unmapped frames.
  * Added validation for unsupported formats, invalid profiles, and malformed options.
  * Added warnings when profile and repository commits do not match.

* **Documentation**
  * Expanded dynamic tracing guidance with supported eBPF profilers, conversion examples, filtering, and known limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->