### PR TITLE
feat: cgr trace pull — fetch and convert eBPF pprof over HTTP (#1287 follow-up)

### DIFF
--- a/codebase_rag/cli_help.py
+++ b/codebase_rag/cli_help.py
@@ -157,9 +157,19 @@ HELP_TRACE_PULL_HEADER = (
     "repeatable."
 )
 HELP_TRACE_PULL_TIMEOUT = "HTTP request timeout in seconds (default 60)."
-ERR_TRACE_PULL_BAD_URL = "Unsupported URL {url!r}; expected an http:// or https:// URL."
-ERR_TRACE_PULL_BAD_HEADER = "Invalid --header {value!r}; expected NAME=VALUE."
-ERR_TRACE_PULL_FAILED = "Could not download {url!r}: {error}."
+ERR_TRACE_PULL_BAD_URL = "Unsupported URL {url}; expected an http:// or https:// URL."
+# The header value can be a bearer token, so it is never echoed back.
+ERR_TRACE_PULL_BAD_HEADER = (
+    "Invalid --header; expected NAME=VALUE (for example Authorization=Bearer TOKEN)."
+)
+ERR_TRACE_PULL_FAILED = "Could not download {url}: {error}."
+ERR_TRACE_PULL_TOO_LARGE = (
+    "Profile at {url} exceeds the maximum download size (256 MB)."
+)
+ERR_TRACE_PULL_SAVE_EQUALS_OUTPUT = (
+    "--save and --output must be different paths (--output holds the converted "
+    "trace, --save the downloaded profile)."
+)
 EXAMPLES_TRACE_PULL = (
     "EXAMPLE\n\n"
     "  cgr trace pull https://parca.example/api/... \\\n"

--- a/codebase_rag/cli_help.py
+++ b/codebase_rag/cli_help.py
@@ -145,6 +145,29 @@ HELP_TRACE_COMMIT = (
     "The commit the profiled binary was built from; warns if it differs from "
     "the repository HEAD at convert time (ebpf format)."
 )
+CMD_TRACE_PULL = (
+    "Download a pprof profile from an eBPF continuous profiler over HTTP and "
+    "convert it (Parca download, Pyroscope render?format=pprof, or any URL)."
+)
+HELP_TRACE_PULL_SAVE = (
+    "Keep the downloaded pprof at this path; by default it is removed after conversion."
+)
+HELP_TRACE_PULL_HEADER = (
+    "Extra HTTP request header as NAME=VALUE (e.g. Authorization=Bearer TOKEN); "
+    "repeatable."
+)
+HELP_TRACE_PULL_TIMEOUT = "HTTP request timeout in seconds (default 60)."
+ERR_TRACE_PULL_BAD_URL = "Unsupported URL {url!r}; expected an http:// or https:// URL."
+ERR_TRACE_PULL_BAD_HEADER = "Invalid --header {value!r}; expected NAME=VALUE."
+ERR_TRACE_PULL_FAILED = "Could not download {url!r}: {error}."
+EXAMPLES_TRACE_PULL = (
+    "EXAMPLE\n\n"
+    "  cgr trace pull https://parca.example/api/... \\\n"
+    "      --repo-path ./my-repo --build-id 8f3a \\\n"
+    "      --path-map /build/src/=./my-repo/src/ \\\n"
+    "      --header Authorization=Bearer $TOKEN\n\n"
+    "  cgr trace ingest cgr-trace.jsonl --repo-path ./my-repo"
+)
 ERR_TRACE_CONVERT_BAD_FORMAT = "Unknown --format '{format}'; supported: ebpf."
 ERR_TRACE_CONVERT_BAD_PATH_MAP = (
     "Invalid --path-map '{value}'; expected BUILD_PREFIX=REPO_PREFIX."

--- a/codebase_rag/tests/test_dynamic_trace_ebpf.py
+++ b/codebase_rag/tests/test_dynamic_trace_ebpf.py
@@ -494,3 +494,79 @@ def test_cli_pull_reports_download_failure(tmp_path):
     )
     assert result.exit_code == 1
     assert "Could not download" in result.output
+
+
+def test_cli_pull_rejects_save_equal_output(tmp_path):
+    from click.testing import CliRunner
+
+    from codebase_rag.trace.cli import cli
+
+    same = tmp_path / "same.jsonl"
+    result = CliRunner().invoke(
+        cli,
+        [
+            "pull",
+            "http://127.0.0.1:1/x",
+            "--repo-path",
+            str(tmp_path),
+            "-o",
+            str(same),
+            "--save",
+            str(same),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "--save and --output" in result.output
+
+
+def test_pull_download_is_size_capped(tmp_path, monkeypatch):
+    import codebase_rag.trace.cli as cli_mod
+
+    monkeypatch.setattr(cli_mod, "_MAX_PROFILE_BYTES", 16)
+    with _pprof_server(gzip.compress(_profile_bytes())) as url:
+        with pytest.raises(cli_mod._ConvertUsageError):
+            cli_mod._download_pprof(url, (), 10.0)
+
+
+def test_pull_strips_auth_on_redirect(tmp_path):
+    # A redirect must not forward the Authorization header to the new location,
+    # so a profiler endpoint cannot exfiltrate a bearer token via a 302.
+    from codebase_rag.trace.cli import _download_pprof
+
+    payload = gzip.compress(_profile_bytes())
+    received: dict[str, str | None] = {}
+
+    class Target(BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802
+            received["auth"] = self.headers.get("Authorization")
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *_args):
+            return
+
+    target = ThreadingHTTPServer(("127.0.0.1", 0), Target)
+    threading.Thread(target=target.serve_forever, daemon=True).start()
+    target_url = f"http://127.0.0.1:{target.server_address[1]}/target.pb.gz"
+
+    class Redirector(BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802
+            self.send_response(302)
+            self.send_header("Location", target_url)
+            self.end_headers()
+
+        def log_message(self, *_args):
+            return
+
+    redirector = ThreadingHTTPServer(("127.0.0.1", 0), Redirector)
+    threading.Thread(target=redirector.serve_forever, daemon=True).start()
+    redirect_url = f"http://127.0.0.1:{redirector.server_address[1]}/start"
+    try:
+        data = _download_pprof(redirect_url, ("Authorization=Bearer secret",), 10.0)
+    finally:
+        target.shutdown()
+        redirector.shutdown()
+
+    assert data == payload
+    assert received["auth"] is None

--- a/codebase_rag/tests/test_dynamic_trace_ebpf.py
+++ b/codebase_rag/tests/test_dynamic_trace_ebpf.py
@@ -539,6 +539,7 @@ def test_pull_strips_auth_on_redirect(tmp_path):
     class Target(BaseHTTPRequestHandler):
         def do_GET(self):  # noqa: N802
             received["auth"] = self.headers.get("Authorization")
+            received["apikey"] = self.headers.get("X-Api-Key")
             self.send_response(200)
             self.end_headers()
             self.wfile.write(payload)
@@ -563,10 +564,16 @@ def test_pull_strips_auth_on_redirect(tmp_path):
     threading.Thread(target=redirector.serve_forever, daemon=True).start()
     redirect_url = f"http://127.0.0.1:{redirector.server_address[1]}/start"
     try:
-        data = _download_pprof(redirect_url, ("Authorization=Bearer secret",), 10.0)
+        data = _download_pprof(
+            redirect_url,
+            ("Authorization=Bearer secret", "X-Api-Key=vendor-token"),
+            10.0,
+        )
     finally:
         target.shutdown()
         redirector.shutdown()
 
     assert data == payload
+    # Neither the standard nor the custom credential header crossed the redirect.
     assert received["auth"] is None
+    assert received["apikey"] is None

--- a/codebase_rag/tests/test_dynamic_trace_ebpf.py
+++ b/codebase_rag/tests/test_dynamic_trace_ebpf.py
@@ -6,7 +6,10 @@
 
 from __future__ import annotations
 
+import contextlib
 import gzip
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import pytest
 from loguru import logger
@@ -371,3 +374,123 @@ def test_reanchored_path_cannot_escape_the_repository(tmp_path):
         assert "outside" not in record.caller.path
         assert "outside" not in record.callee.path
     assert any("unmapped build paths" in message for message in messages), messages
+
+
+@contextlib.contextmanager
+def _pprof_server(payload: bytes, require_auth: str | None = None):
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802 - BaseHTTPRequestHandler API
+            if require_auth and self.headers.get("Authorization") != require_auth:
+                self.send_response(401)
+                self.end_headers()
+                return
+            self.send_response(200)
+            self.send_header("Content-Type", "application/octet-stream")
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *_args):  # silence per-request logging
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}/profile.pb.gz"
+    finally:
+        server.shutdown()
+
+
+def test_cli_pull_downloads_and_converts(tmp_path):
+    from click.testing import CliRunner
+
+    from codebase_rag.trace.cli import cli
+
+    output = tmp_path / "trace.jsonl"
+    with _pprof_server(
+        gzip.compress(_profile_bytes()), require_auth="Bearer tok"
+    ) as url:
+        result = CliRunner().invoke(
+            cli,
+            [
+                "pull",
+                url,
+                "--repo-path",
+                str(tmp_path),
+                "-o",
+                str(output),
+                "--path-map",
+                f"/build/src/={tmp_path.as_posix()}/src/",
+                "--build-id",
+                "abc123",
+                "--label",
+                "endpoint",
+                "--header",
+                "Authorization=Bearer tok",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    _header, records = read_trace_file(output)
+    edges = {(r.caller.qualname, r.callee.qualname) for r in records}
+    assert ("handle", "greet") in edges
+
+
+def test_cli_pull_saves_profile_when_requested(tmp_path):
+    from click.testing import CliRunner
+
+    from codebase_rag.trace.cli import cli
+
+    saved = tmp_path / "prod.pb.gz"
+    with _pprof_server(gzip.compress(_profile_bytes())) as url:
+        result = CliRunner().invoke(
+            cli,
+            [
+                "pull",
+                url,
+                "--repo-path",
+                str(tmp_path),
+                "-o",
+                str(tmp_path / "trace.jsonl"),
+                "--save",
+                str(saved),
+                "--path-map",
+                f"/build/src/={tmp_path.as_posix()}/src/",
+                "--build-id",
+                "abc123",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    assert saved.is_file()
+
+
+def test_cli_pull_rejects_non_http_url(tmp_path):
+    from click.testing import CliRunner
+
+    from codebase_rag.trace.cli import cli
+
+    result = CliRunner().invoke(
+        cli, ["pull", "file:///etc/passwd", "--repo-path", str(tmp_path)]
+    )
+    assert result.exit_code == 1
+    assert "Unsupported URL" in result.output
+
+
+def test_cli_pull_reports_download_failure(tmp_path):
+    from click.testing import CliRunner
+
+    from codebase_rag.trace.cli import cli
+
+    # Port 1 refuses immediately, so the failure is reported, not raised.
+    result = CliRunner().invoke(
+        cli,
+        [
+            "pull",
+            "http://127.0.0.1:1/x",
+            "--repo-path",
+            str(tmp_path),
+            "--timeout",
+            "5",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "Could not download" in result.output

--- a/codebase_rag/trace/cli.py
+++ b/codebase_rag/trace/cli.py
@@ -183,6 +183,27 @@ def _convert_ebpf(
     )
 
 
+def _download_pprof(url: str, headers: tuple[str, ...], timeout: float) -> bytes:
+    """GET a pprof profile over HTTP(S); a usage error on a bad URL or failure."""
+    import urllib.error
+    import urllib.parse
+    import urllib.request
+
+    if urllib.parse.urlsplit(url).scheme not in ("http", "https"):
+        raise _ConvertUsageError(ch.ERR_TRACE_PULL_BAD_URL.format(url=url))
+    request = urllib.request.Request(url)  # noqa: S310 - scheme checked above
+    for header in headers:
+        key, value = _parse_key_value(header, ch.ERR_TRACE_PULL_BAD_HEADER)
+        request.add_header(key, value)
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
+            return response.read()
+    except (urllib.error.URLError, OSError) as e:
+        raise _ConvertUsageError(
+            ch.ERR_TRACE_PULL_FAILED.format(url=url, error=e)
+        ) from e
+
+
 def _convert_profile(
     profile_file: Path,
     repo_path: Path | None,
@@ -334,6 +355,92 @@ def convert_cmd(
             )
     # TraceFormatError subclasses ValueError, so ValueError covers it (and the
     # malformed-number / non-UTF-8 cases) without listing it redundantly.
+    except (OSError, ValueError, _ConvertUsageError) as e:
+        logger.error(str(e))
+        click.secho(str(e), fg="red", err=True)
+        sys.exit(1)
+    click.echo(f"call records written: {count} -> {resolved_output}")
+
+
+@cli.command(
+    "pull",
+    help=ch.CMD_TRACE_PULL,
+    short_help=ch.CMD_TRACE_PULL,
+    epilog=ch.EXAMPLES_TRACE_PULL,
+)
+@click.argument("url")
+@click.option(
+    "--repo-path",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=None,
+    help=ch.HELP_TRACE_REPO_PATH,
+)
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help=ch.HELP_TRACE_OUTPUT,
+)
+@click.option(
+    "--save",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help=ch.HELP_TRACE_PULL_SAVE,
+)
+@click.option("--header", "headers", multiple=True, help=ch.HELP_TRACE_PULL_HEADER)
+@click.option("--timeout", default=60.0, type=float, help=ch.HELP_TRACE_PULL_TIMEOUT)
+@click.option("--workload", default=None, help=ch.HELP_TRACE_WORKLOAD)
+@click.option("--language", default=None, help=ch.HELP_TRACE_LANGUAGE)
+@click.option("--path-map", "path_map", multiple=True, help=ch.HELP_TRACE_PATH_MAP)
+@click.option("--build-id", default=None, help=ch.HELP_TRACE_BUILD_ID)
+@click.option("--service", default=None, help=ch.HELP_TRACE_SERVICE)
+@click.option("--label", default=None, help=ch.HELP_TRACE_LABEL)
+@click.option("--commit", default=None, help=ch.HELP_TRACE_COMMIT)
+def pull_cmd(
+    url: str,
+    repo_path: Path | None,
+    output: Path | None,
+    save: Path | None,
+    headers: tuple[str, ...],
+    timeout: float,
+    workload: str | None,
+    language: str | None,
+    path_map: tuple[str, ...],
+    build_id: str | None,
+    service: str | None,
+    label: str | None,
+    commit: str | None,
+) -> None:
+    import tempfile
+
+    from .. import constants as cs
+
+    resolved_output = output or Path(cs.TRACE_DEFAULT_OUTPUT)
+    try:
+        data = _download_pprof(url, headers, timeout)
+        # Persist the profile where the caller asked, else in a temp file that is
+        # removed after conversion (a cron overlay does not need to keep it).
+        profile_path = save or Path(
+            tempfile.mkstemp(suffix=".pb.gz", prefix="cgr-ebpf-")[1]
+        )
+        try:
+            profile_path.write_bytes(data)
+            count = _convert_ebpf(
+                profile_path,
+                repo_path,
+                resolved_output,
+                workload,
+                language,
+                path_map,
+                build_id,
+                service,
+                label,
+                commit,
+            )
+        finally:
+            if save is None:
+                profile_path.unlink(missing_ok=True)
     except (OSError, ValueError, _ConvertUsageError) as e:
         logger.error(str(e))
         click.secho(str(e), fg="red", err=True)

--- a/codebase_rag/trace/cli.py
+++ b/codebase_rag/trace/cli.py
@@ -183,25 +183,66 @@ def _convert_ebpf(
     )
 
 
+# A merged fleet pprof profile is aggregated and small; cap the download so a
+# malicious or runaway endpoint cannot exhaust memory or run unattended forever.
+_MAX_PROFILE_BYTES = 256 * 1024 * 1024
+
+
+def _redact_url(url: str) -> str:
+    """A log-safe form of a URL: scheme, host, and path, without userinfo/query."""
+    import urllib.parse
+
+    parts = urllib.parse.urlsplit(url)
+    return urllib.parse.urlunsplit(
+        (parts.scheme, parts.hostname or "", parts.path, "", "")
+    )
+
+
 def _download_pprof(url: str, headers: tuple[str, ...], timeout: float) -> bytes:
-    """GET a pprof profile over HTTP(S); a usage error on a bad URL or failure."""
-    import urllib.error
+    """GET a pprof profile over HTTP(S); a usage error on a bad URL or failure.
+
+    Redirects are followed but never carry credentials across them and must stay
+    on http(s); the body is read under a size cap. ``urllib.error.URLError`` is
+    an ``OSError`` subclass, so one ``except OSError`` covers both.
+    """
     import urllib.parse
     import urllib.request
 
     if urllib.parse.urlsplit(url).scheme not in ("http", "https"):
-        raise _ConvertUsageError(ch.ERR_TRACE_PULL_BAD_URL.format(url=url))
+        raise _ConvertUsageError(ch.ERR_TRACE_PULL_BAD_URL.format(url=_redact_url(url)))
+
     request = urllib.request.Request(url)  # noqa: S310 - scheme checked above
     for header in headers:
         key, value = _parse_key_value(header, ch.ERR_TRACE_PULL_BAD_HEADER)
-        request.add_header(key, value)
+        # Credentials go in as unredirected headers so urllib never resends them
+        # to a redirect target (a 302 cannot exfiltrate a bearer token).
+        if key.lower() in ("authorization", "cookie", "proxy-authorization"):
+            request.add_unredirected_header(key, value)
+        else:
+            request.add_header(key, value)
+    # An opener with only HTTP(S) handlers: a redirect to file:// or ftp:// has no
+    # handler and fails, so a redirect cannot bypass the scheme check above.
+    opener = urllib.request.OpenerDirector()
+    for handler in (
+        urllib.request.HTTPHandler,
+        urllib.request.HTTPSHandler,
+        urllib.request.HTTPRedirectHandler,
+        urllib.request.HTTPErrorProcessor,
+        urllib.request.HTTPDefaultErrorHandler,
+    ):
+        opener.add_handler(handler())
     try:
-        with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
-            return response.read()
-    except (urllib.error.URLError, OSError) as e:
+        with opener.open(request, timeout=timeout) as response:  # noqa: S310
+            data = response.read(_MAX_PROFILE_BYTES + 1)
+    except OSError as e:
         raise _ConvertUsageError(
-            ch.ERR_TRACE_PULL_FAILED.format(url=url, error=e)
+            ch.ERR_TRACE_PULL_FAILED.format(url=_redact_url(url), error=e)
         ) from e
+    if len(data) > _MAX_PROFILE_BYTES:
+        raise _ConvertUsageError(
+            ch.ERR_TRACE_PULL_TOO_LARGE.format(url=_redact_url(url))
+        )
+    return data
 
 
 def _convert_profile(
@@ -412,18 +453,26 @@ def pull_cmd(
     label: str | None,
     commit: str | None,
 ) -> None:
+    import os
     import tempfile
 
     from .. import constants as cs
 
     resolved_output = output or Path(cs.TRACE_DEFAULT_OUTPUT)
     try:
+        if save is not None and save.resolve() == resolved_output.resolve():
+            raise _ConvertUsageError(ch.ERR_TRACE_PULL_SAVE_EQUALS_OUTPUT)
         data = _download_pprof(url, headers, timeout)
         # Persist the profile where the caller asked, else in a temp file that is
         # removed after conversion (a cron overlay does not need to keep it).
-        profile_path = save or Path(
-            tempfile.mkstemp(suffix=".pb.gz", prefix="cgr-ebpf-")[1]
-        )
+        # mkstemp returns an open fd; close it so Windows does not lock the file
+        # against the write below.
+        if save is not None:
+            profile_path = save
+        else:
+            handle, temp_name = tempfile.mkstemp(suffix=".pb.gz", prefix="cgr-ebpf-")
+            os.close(handle)
+            profile_path = Path(temp_name)
         try:
             profile_path.write_bytes(data)
             count = _convert_ebpf(

--- a/codebase_rag/trace/cli.py
+++ b/codebase_rag/trace/cli.py
@@ -214,12 +214,10 @@ def _download_pprof(url: str, headers: tuple[str, ...], timeout: float) -> bytes
     request = urllib.request.Request(url)  # noqa: S310 - scheme checked above
     for header in headers:
         key, value = _parse_key_value(header, ch.ERR_TRACE_PULL_BAD_HEADER)
-        # Credentials go in as unredirected headers so urllib never resends them
-        # to a redirect target (a 302 cannot exfiltrate a bearer token).
-        if key.lower() in ("authorization", "cookie", "proxy-authorization"):
-            request.add_unredirected_header(key, value)
-        else:
-            request.add_header(key, value)
+        # Every caller-supplied header goes in unredirected: it was meant for this
+        # endpoint, and any of them (Authorization, X-Api-Key, X-Scope-OrgID, ...)
+        # may be a credential, so urllib must not resend it to a redirect target.
+        request.add_unredirected_header(key, value)
     # An opener with only HTTP(S) handlers: a redirect to file:// or ftp:// has no
     # handler and fails, so a redirect cannot bypass the scheme check above.
     opener = urllib.request.OpenerDirector()

--- a/docs/guide/dynamic-tracing.md
+++ b/docs/guide/dynamic-tracing.md
@@ -475,11 +475,12 @@ cgr trace ingest cgr-trace.jsonl --repo-path /path/to/your-repo
 ```
 
 Ingest is idempotent (properties are set, not accumulated), so a cron'd `pull`
-plus `ingest` keeps a continuously refreshing production overlay. **Off-CPU or
-wallclock** profiles use the same pprof format and convert through the same
-`--format ebpf` / `pull` path; their sample weights are blocked-time rather than
-CPU-time, which surfaces I/O-bound paths (a handler that lives in `await`) that a
-CPU profile barely samples.
+plus `ingest` keeps a continuously refreshing production overlay. **Off-CPU and
+wall-clock** profiles use the same pprof format and convert through the same
+`--format ebpf` / `pull` path; off-CPU profiles weight samples by blocked
+(off-CPU) duration and wall-clock profiles by elapsed time, so both surface
+I/O-bound paths (a handler that lives in `await`) that a CPU profile barely
+samples.
 
 ## Ingesting a trace
 

--- a/docs/guide/dynamic-tracing.md
+++ b/docs/guide/dynamic-tracing.md
@@ -460,6 +460,27 @@ lower than test-suite traces (absence of an edge still never means dead code);
 symbolisation needs frame pointers or DWARF in the deployed binary; and the
 profiled binary may lag the indexed graph, which `--commit` surfaces.
 
+`cgr trace pull` fetches the profile in one step instead of downloading it by
+hand: it GETs a pprof over HTTP(S) and converts it with the same eBPF options.
+The URL is whatever your profiler serves as pprof bytes (a Parca download, a
+Pyroscope `render?format=pprof` query, or any endpoint), and `--header` adds
+auth:
+
+```bash
+cgr trace pull "https://parca.example/...&format=pprof" \
+    --repo-path /path/to/your-repo --build-id 8f3a \
+    --path-map /build/src/=/path/to/your-repo/src/ \
+    --label endpoint --header "Authorization=Bearer $TOKEN"
+cgr trace ingest cgr-trace.jsonl --repo-path /path/to/your-repo
+```
+
+Ingest is idempotent (properties are set, not accumulated), so a cron'd `pull`
+plus `ingest` keeps a continuously refreshing production overlay. **Off-CPU or
+wallclock** profiles use the same pprof format and convert through the same
+`--format ebpf` / `pull` path; their sample weights are blocked-time rather than
+CPU-time, which surfaces I/O-bound paths (a handler that lives in `await`) that a
+CPU profile barely samples.
+
 ## Ingesting a trace
 
 Parse the repository into the graph first (`cgr start --repo-path ... --update-graph`),


### PR DESCRIPTION
Implements the headline follow-up from #1287: a one-shot `cgr trace pull` that downloads a merged pprof profile over HTTP(S) and converts it with the eBPF path, so a cron'd `pull` + `ingest` keeps a continuously refreshing production overlay (ingest is idempotent). Also documents off-CPU/wallclock profile support.

## What

- **`cgr trace pull URL`** — a new sibling of `convert`/`ingest`. GETs pprof bytes over HTTP(S) (stdlib `urllib`, no new dependency), writes them to a temp file (or `--save PATH`), and runs the same eBPF conversion, sharing every option (`--repo-path`, `--path-map`, `--build-id`, `--service`, `--label`, `--language`, `--commit`, `--workload`, `-o`). `--header NAME=VALUE` (repeatable) adds auth; `--timeout` bounds the request. The URL is whatever the profiler serves as pprof — a Parca download, a Pyroscope `render?format=pprof` query, or any endpoint — so it commits to no single vendor API.
- **Safety**: only `http`/`https` URLs are accepted (rejects `file://` etc.); download failures report cleanly (exit 1) rather than raising.
- **Off-CPU / wallclock**: documented that these use the same pprof format and convert through the same path, with sample weights being blocked-time (surfacing I/O-bound paths a CPU profile misses).

## Tests

Added CLI tests that stand up a local `ThreadingHTTPServer` serving a canned pprof and assert: `pull` downloads (with a bearer header), converts, and produces the expected edge; `--save` keeps the profile; a non-HTTP URL is rejected; and a refused connection reports a download failure. Full `test_dynamic_trace_ebpf.py` (18 tests) passes; ruff + ty clean.

## Still open on #1287

Interpreted-language frame resolution (OTel in-kernel Python/Ruby/JVM unwinding) and a vendor-specific query builder remain as separate follow-ups; this ships the generic-URL pull and off-CPU coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `cgr trace pull` to download pprof profiles over HTTP(S) and convert them into trace data.
  * Supports authentication headers, configurable timeouts, optional profile saving, filtering, symbolization, and off-CPU or wall-clock profiles.

* **Bug Fixes**
  * Added validation and clear errors for invalid URLs, headers, download failures, size limits, and conflicting output paths.
  * Protects credentials during redirects and redacts sensitive URL information.

* **Documentation**
  * Added usage examples and guidance for pull-and-ingest tracing workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->