### PR TITLE
fix: harden C# indexing and shell-read approval defaults (adopts #1231)

### DIFF
--- a/codebase_rag/config.py
+++ b/codebase_rag/config.py
@@ -17,7 +17,11 @@ from . import exceptions as ex
 from . import logs
 from .types_defs import CgrignorePatterns, ModelConfigKwargs
 
-load_dotenv()
+# Load only the configuration file in the invocation directory.  The default
+# python-dotenv discovery walks parent directories, which can silently import
+# credentials from an unrelated workspace (and makes tests depend on the
+# caller's directory layout).
+load_dotenv(dotenv_path=Path.cwd() / ".env")
 
 
 class ApiKeyInfoEntry(TypedDict):
@@ -200,7 +204,9 @@ class AppConfig(BaseSettings):
     # HYBRID needs a dotnet SDK + a restorable .csproj/.sln and degrades without
     # them. HYBRID augments (base-vs-interface, overload and extension binding,
     # partial-class identity); tree-sitter stays the standalone-correct backbone.
-    CSHARP_FRONTEND: cs.CSharpFrontend = cs.CSharpFrontend.AUTO
+    # Default to tree-sitter so indexing an untrusted repository never auto-invokes
+    # MSBuild/Roslyn; opt into AUTO/HYBRID/ROSLYN explicitly (security, #1231).
+    CSHARP_FRONTEND: cs.CSharpFrontend = cs.CSharpFrontend.TREESITTER
     # Opt-in go/packages semantic layer for Go (issue #1179). AUTO uses it where a
     # go toolchain is on PATH and degrades to pure tree-sitter otherwise. GOTYPES
     # augments exact first-party call binding and external-site suppression;
@@ -243,35 +249,18 @@ class AppConfig(BaseSettings):
             "tee",
         }
     )
+    # Only commands that cannot accept filesystem paths are approval-free.
+    # Filesystem and Git reads require approval because their path syntaxes can
+    # escape the project root (absolute paths, traversal, symlinks, git -C, and
+    # --git-dir). Project-confined read/search tools should be preferred instead.
     SHELL_READ_ONLY_COMMANDS: frozenset[str] = frozenset(
         {
-            "ls",
-            "cat",
-            "find",
             "pwd",
-            "rg",
             "echo",
-            "wc",
-            "head",
-            "tail",
-            "sort",
-            "uniq",
-            "cut",
             "tr",
         }
     )
-    SHELL_SAFE_GIT_SUBCOMMANDS: frozenset[str] = frozenset(
-        {
-            "status",
-            "log",
-            "diff",
-            "show",
-            "ls-files",
-            "remote",
-            "config",
-            "branch",
-        }
-    )
+    SHELL_SAFE_GIT_SUBCOMMANDS: frozenset[str] = frozenset()
 
     QDRANT_DB_PATH: str = "./.qdrant_code_embeddings"
     QDRANT_URL: str | None = None

--- a/codebase_rag/constants/security.py
+++ b/codebase_rag/constants/security.py
@@ -55,6 +55,12 @@ SHELL_RETURN_CODE_ERROR = -1
 SHELL_PIPE_OPERATORS = ("|", "&&", "||", ";")
 SHELL_SUBSHELL_PATTERNS = ("$(", "`")
 SHELL_REDIRECT_OPERATORS = frozenset({">", ">>", "<", "<<"})
+# `find` actions that run a command or delete files, so they need approval even
+# though `find` itself is a read tool. Kept here so the security boundary is
+# auditable in one place rather than inline in the approval check.
+SHELL_FIND_MUTATING_ACTIONS = frozenset(
+    {"-delete", "-exec", "-execdir", "-ok", "-okdir"}
+)
 
 # Dangerous commands, absolutely blocked
 SHELL_DANGEROUS_COMMANDS = frozenset(

--- a/codebase_rag/providers/base.py
+++ b/codebase_rag/providers/base.py
@@ -46,12 +46,9 @@ class ModelProvider(ABC):
 
 
 def _resolve_api_key(api_key: str | None, env_var: str) -> str | None:
-    env_key = os.environ.get(env_var)
-    if env_key:
-        return env_key
     if api_key and api_key != cs.DEFAULT_API_KEY:
         return api_key
-    return None
+    return os.environ.get(env_var)
 
 
 class GoogleProvider(ModelProvider):

--- a/codebase_rag/tests/integration/test_shell_command_integration.py
+++ b/codebase_rag/tests/integration/test_shell_command_integration.py
@@ -125,11 +125,27 @@ class TestShellCommandToolIntegration:
     async def test_tool_executes_read_only_command_without_approval(
         self, shell_commander: ShellCommander
     ) -> None:
+        # A genuinely safe read-only command (no filesystem traversal) runs
+        # without approval. `ls` is now approval-gated because it can be pointed
+        # outside the workspace (see test_tool_requires_approval_for_filesystem_read).
         tool = create_shell_command_tool(shell_commander)
         mock_ctx = MagicMock()
         mock_ctx.tool_call_approved = False
-        result = await tool.function(mock_ctx, "ls")
+        result = await tool.function(mock_ctx, "pwd")
         assert result.return_code == 0
+
+    async def test_tool_requires_approval_for_filesystem_read(
+        self, shell_commander: ShellCommander
+    ) -> None:
+        # `ls` reads the filesystem and can traverse (ls /etc, ls ../), so the
+        # hardened default requires approval before it runs.
+        from pydantic_ai.exceptions import ApprovalRequired
+
+        tool = create_shell_command_tool(shell_commander)
+        mock_ctx = MagicMock()
+        mock_ctx.tool_call_approved = False
+        with pytest.raises(ApprovalRequired):
+            await tool.function(mock_ctx, "ls")
 
     async def test_tool_requires_approval_for_write_command(
         self, shell_commander: ShellCommander

--- a/codebase_rag/tests/test_config_validation.py
+++ b/codebase_rag/tests/test_config_validation.py
@@ -1,7 +1,37 @@
+import os
+import subprocess
+import sys
+
 import pytest
 
 from codebase_rag import constants as cs
 from codebase_rag.config import ModelConfig, format_missing_api_key_errors
+
+
+def test_import_does_not_walk_parent_directories_for_dotenv(tmp_path) -> None:
+    parent = tmp_path / "parent"
+    child = parent / "child"
+    child.mkdir(parents=True)
+    (parent / ".env").write_text("GOOGLE_API_KEY=parent-secret\n", encoding="utf-8")
+
+    env = os.environ.copy()
+    env.pop("GOOGLE_API_KEY", None)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import os; import codebase_rag.config; "
+            "print(os.environ.get('GOOGLE_API_KEY', 'missing'))",
+        ],
+        cwd=child,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "missing"
 
 
 class TestValidateApiKey:

--- a/codebase_rag/tests/test_csharp_frontend_wiring.py
+++ b/codebase_rag/tests/test_csharp_frontend_wiring.py
@@ -268,13 +268,15 @@ def _button_facts() -> object:
     )
 
 
-def test_default_csharp_frontend_is_auto() -> None:
-    # The shipped default: hybrid wherever a dotnet toolchain exists,
-    # pure tree-sitter otherwise. Read from the FIELD default because the
-    # test suite pins the live settings instance to tree-sitter.
+def test_default_csharp_frontend_is_treesitter() -> None:
+    # Indexing must not execute repository-controlled MSBuild targets or source
+    # generators unless the user explicitly opts into the Roslyn frontend.
     from codebase_rag.config import AppConfig
 
-    assert AppConfig.model_fields["CSHARP_FRONTEND"].default == cs.CSharpFrontend.AUTO
+    assert (
+        AppConfig.model_fields["CSHARP_FRONTEND"].default
+        == cs.CSharpFrontend.TREESITTER
+    )
 
 
 def test_auto_mode_runs_frontend_when_dotnet_available(

--- a/codebase_rag/tests/test_provider_classes.py
+++ b/codebase_rag/tests/test_provider_classes.py
@@ -112,6 +112,17 @@ class TestProviderRegistry:
 
 
 class TestGoogleProvider:
+    def test_explicit_key_takes_precedence_over_environment(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GOOGLE_API_KEY", "environment-key")
+
+        provider = GoogleProvider(
+            api_key="explicit-key", provider_type=GoogleProviderType.GLA
+        )
+
+        assert provider.api_key == "explicit-key"
+
     def test_google_gla_configuration(self) -> None:
         provider = GoogleProvider(
             api_key="test-key", provider_type=GoogleProviderType.GLA
@@ -135,7 +146,8 @@ class TestGoogleProvider:
 
         provider.validate_config()
 
-    def test_google_gla_validation_error(self) -> None:
+    def test_google_gla_validation_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
         provider = GoogleProvider(provider_type=GoogleProviderType.GLA)
 
         with pytest.raises(ValueError, match="Gemini GLA provider requires api_key"):

--- a/codebase_rag/tests/test_shell_command.py
+++ b/codebase_rag/tests/test_shell_command.py
@@ -90,18 +90,38 @@ class TestRequiresApproval:
             assert _requires_approval(cmd) is False
 
     def test_read_only_with_args_no_approval(self) -> None:
-        assert _requires_approval("ls -la") is False
-        assert _requires_approval("cat file.txt") is False
-        assert _requires_approval("find . -name '*.py'") is False
+        assert _requires_approval("pwd") is False
+        assert _requires_approval("echo hello") is False
+
+    def test_filesystem_reads_require_approval(self) -> None:
+        assert _requires_approval("ls -la") is True
+        assert _requires_approval("cat file.txt") is True
+        assert _requires_approval("cat /etc/passwd") is True
+        assert _requires_approval("cat ../outside.txt") is True
+        assert _requires_approval("find . -name '*.py'") is True
+        assert _requires_approval("rg secret ~/.config") is True
+        assert _requires_approval("head -10 /tmp/outside.txt") is True
 
     def test_safe_git_subcommands_no_approval(self) -> None:
-        for subcmd in settings.SHELL_SAFE_GIT_SUBCOMMANDS:
-            assert _requires_approval(f"git {subcmd}") is False
+        assert not settings.SHELL_SAFE_GIT_SUBCOMMANDS
+
+    def test_git_reads_require_approval_because_git_can_escape_project(self) -> None:
+        assert _requires_approval("git status") is True
+        assert _requires_approval("git -C ../other log") is True
+        assert (
+            _requires_approval("git --git-dir=../other/.git show HEAD:secret") is True
+        )
 
     def test_unsafe_git_subcommands_require_approval(self) -> None:
         assert _requires_approval("git push") is True
         assert _requires_approval("git commit -m 'msg'") is True
         assert _requires_approval("git reset --hard") is True
+        assert _requires_approval("git branch -D topic") is True
+        assert _requires_approval("git config core.sshCommand malicious") is True
+
+    def test_mutating_find_forms_require_approval(self) -> None:
+        assert _requires_approval("find . -delete") is True
+        assert _requires_approval("find . -exec rm {} +") is True
 
     def test_write_commands_require_approval(self) -> None:
         assert _requires_approval("rm file.txt") is True
@@ -232,14 +252,23 @@ class TestCreateShellCommandTool:
 
 
 class TestToolApprovalBehavior:
-    async def test_read_only_command_no_approval_needed(
+    async def test_pathless_command_no_approval_needed(
         self, shell_commander: ShellCommander
     ) -> None:
         tool = create_shell_command_tool(shell_commander)
         mock_ctx = MagicMock()
         mock_ctx.tool_call_approved = False
-        result = await tool.function(mock_ctx, "ls")
+        result = await tool.function(mock_ctx, "pwd")
         assert result.return_code == 0, result.stderr
+
+    async def test_filesystem_read_requires_approval(
+        self, shell_commander: ShellCommander
+    ) -> None:
+        tool = create_shell_command_tool(shell_commander)
+        mock_ctx = MagicMock()
+        mock_ctx.tool_call_approved = False
+        with pytest.raises(ApprovalRequired):
+            await tool.function(mock_ctx, "ls")
 
     async def test_write_command_requires_approval(
         self, shell_commander: ShellCommander
@@ -390,9 +419,9 @@ class TestRequiresApprovalWithRedirects:
     def test_heredoc_requires_approval(self) -> None:
         assert _requires_approval("cat << EOF") is True
 
-    def test_read_only_without_redirect_no_approval(self) -> None:
-        assert _requires_approval("ls -la") is False
-        assert _requires_approval("cat file.txt") is False
+    def test_pathless_command_without_redirect_no_approval(self) -> None:
+        assert _requires_approval("pwd") is False
+        assert _requires_approval("echo hello") is False
 
 
 class TestHasSubshell:
@@ -617,10 +646,10 @@ class TestShellOperators:
 
 
 class TestPipedCommandApproval:
-    def test_all_read_only_no_approval(self) -> None:
-        assert _requires_approval("ls | wc -l") is False
-        assert _requires_approval("find . -name '*.py' | head -10") is False
-        assert _requires_approval("cat file.txt | rg pattern | wc -l") is False
+    def test_filesystem_read_in_pipeline_requires_approval(self) -> None:
+        assert _requires_approval("ls | wc -l") is True
+        assert _requires_approval("find . -name '*.py' | head -10") is True
+        assert _requires_approval("cat file.txt | rg pattern | wc -l") is True
 
     def test_write_command_in_pipe_requires_approval(self) -> None:
         assert _requires_approval("ls | tee output.txt") is True

--- a/codebase_rag/tests/test_shell_command.py
+++ b/codebase_rag/tests/test_shell_command.py
@@ -102,6 +102,13 @@ class TestRequiresApproval:
         assert _requires_approval("rg secret ~/.config") is True
         assert _requires_approval("head -10 /tmp/outside.txt") is True
 
+    def test_find_mutating_actions_require_approval(self) -> None:
+        # Every action that runs a command or deletes files gates `find` behind
+        # approval, not just -exec/-delete.
+        for action in ("-delete", "-exec", "-execdir", "-ok", "-okdir"):
+            command = f"find . -name '*.py' {action} rm {{}} ;"
+            assert _requires_approval(command) is True, command
+
     def test_safe_git_subcommands_no_approval(self) -> None:
         assert not settings.SHELL_SAFE_GIT_SUBCOMMANDS
 

--- a/codebase_rag/tools/shell_command.py
+++ b/codebase_rag/tools/shell_command.py
@@ -227,6 +227,11 @@ def _has_redirect_operators(parts: list[str]) -> bool:
     return any(p in cs.SHELL_REDIRECT_OPERATORS for p in parts)
 
 
+def _find_requires_approval(parts: list[str]) -> bool:
+    mutating_actions = {"-delete", "-exec", "-execdir", "-ok", "-okdir"}
+    return any(part in mutating_actions for part in parts[1:])
+
+
 def _requires_approval(command: str) -> bool:
     if not command.strip():
         return True
@@ -255,6 +260,8 @@ def _requires_approval(command: str) -> bool:
 
             has_commands = True
             base_cmd = parts[0]
+            if base_cmd == "find" and _find_requires_approval(parts):
+                return True
             if base_cmd in settings.SHELL_READ_ONLY_COMMANDS:
                 continue
 

--- a/codebase_rag/tools/shell_command.py
+++ b/codebase_rag/tools/shell_command.py
@@ -228,8 +228,7 @@ def _has_redirect_operators(parts: list[str]) -> bool:
 
 
 def _find_requires_approval(parts: list[str]) -> bool:
-    mutating_actions = {"-delete", "-exec", "-execdir", "-ok", "-okdir"}
-    return any(part in mutating_actions for part in parts[1:])
+    return any(part in cs.SHELL_FIND_MUTATING_ACTIONS for part in parts[1:])
 
 
 def _requires_approval(command: str) -> bool:

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -163,4 +163,5 @@ This checks that all required dependencies and services are available.
 - **defusedxml**: XML bomb protection for Python stdlib modules
 - **huggingface-hub**: Client library to download and publish models, datasets and other repos on the huggingface.co hub
 - **pathspec**: Utility library for gitignore style pattern matching of file paths.
+- **pygments**: Pygments is a syntax highlighting package written in Python.
 <!-- /SECTION:dependencies -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,11 +50,12 @@ dependencies = [
     "rich>=14.2.0",
     "prompt-toolkit>=3.0.52",
     "diff-match-patch>=20241021",
-    "click>=8.3.1",
+    "click>=8.3.3",
     "protobuf>=6.33.5",
     "defusedxml>=0.7.1",
     "huggingface-hub[hf-xet]>=1.7.2",
     "pathspec>=1.0.4",
+    "pygments>=2.20.0",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -380,14 +380,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -404,7 +404,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.628"
+version = "0.0.660"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -418,6 +418,7 @@ dependencies = [
     { name = "protobuf" },
     { name = "pydantic-ai" },
     { name = "pydantic-settings" },
+    { name = "pygments" },
     { name = "pymgclient" },
     { name = "python-dotenv" },
     { name = "rich" },
@@ -499,7 +500,7 @@ fuzz = [
 requires-dist = [
     { name = "ast-grep-py", marker = "extra == 'ast-grep'", specifier = ">=0.44.0" },
     { name = "ast-grep-py", marker = "extra == 'test'", specifier = ">=0.44.0" },
-    { name = "click", specifier = ">=8.3.1" },
+    { name = "click", specifier = ">=8.3.3" },
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "diff-match-patch", specifier = ">=20241021" },
     { name = "filelock", marker = "extra == 'test'", specifier = ">=3.12" },
@@ -512,6 +513,7 @@ requires-dist = [
     { name = "protobuf", specifier = ">=6.33.5" },
     { name = "pydantic-ai", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
+    { name = "pygments", specifier = ">=2.20.0" },
     { name = "pymgclient", specifier = ">=1.5.1" },
     { name = "pymilvus", extras = ["milvus-lite"], marker = "extra == 'milvus'", specifier = ">=3.0.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.4.1" },
@@ -716,7 +718,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
@@ -747,43 +749,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 
 [[package]]
@@ -920,8 +922,8 @@ name = "faiss-cpu"
 version = "1.14.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "sys_platform != 'win32'" },
-    { name = "packaging", marker = "sys_platform != 'win32'" },
+    { name = "numpy" },
+    { name = "packaging" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/b0/48c083d01b7b68c463c1d56507147a9d733f791e1c469a77215a872a9fb5/faiss_cpu-1.14.3-cp310-abi3-macosx_14_0_arm64.whl", hash = "sha256:a9369863290a3f0e033757e4c10577b6ef7431f1cede394dabd0a137e4e2ed45", size = 4768290, upload-time = "2026-06-13T02:19:03.427Z" },
@@ -1592,7 +1594,7 @@ name = "macholib"
 version = "1.16.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "altgraph", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "altgraph" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
 wheels = [
@@ -1752,10 +1754,10 @@ name = "milvus-lite"
 version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "faiss-cpu", marker = "sys_platform != 'win32'" },
-    { name = "grpcio", marker = "sys_platform != 'win32'" },
-    { name = "numpy", marker = "sys_platform != 'win32'" },
-    { name = "pyarrow", marker = "sys_platform != 'win32'" },
+    { name = "faiss-cpu" },
+    { name = "grpcio" },
+    { name = "numpy" },
+    { name = "pyarrow" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7f/58/54c72981958073d365febeae8fed3115c87761f45905f2d4725f506b94d1/milvus_lite-3.1.0.tar.gz", hash = "sha256:8d467ae81173f1ede93723a80f08d85b91988b451cd2b7bbf9b5a7cfb875e04b", size = 636180, upload-time = "2026-07-15T06:40:58.177Z" }
 wheels = [
@@ -1948,7 +1950,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -1987,7 +1989,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -1999,7 +2001,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -2029,9 +2031,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-cusparse", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2043,7 +2045,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -2753,11 +2755,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
@@ -3426,8 +3428,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
Adopts and rebases **#1231** by @DMA-AI-agent (draft went stale on a conflicting base). Squashed to one commit preserving their authorship, resolved the conflicts against current `main`, regenerated the lockfile, and confirmed the security tests pass.

## What it hardens

- **Default C# indexing to tree-sitter** so indexing an untrusted repository never auto-invokes MSBuild/Roslyn; `AUTO`/`HYBRID`/`ROSLYN` remain opt-in.
- **Require approval for filesystem-capable and Git shell reads** — path traversal, absolute paths, symlink escapes, and the `git -C` / `--git-dir` forms that can read outside the workspace.
- **Stop parent-directory `.env` discovery** (dotenv now loads only `./.env`) so credentials from an unrelated workspace are never silently imported, while explicit API-key precedence is preserved.
- **Upgrade Click (>=8.3.3) and Pygments (>=2.20.0)** past known-vulnerable releases; `pygments` becomes a direct dependency (reflected in the generated dependency docs).
- Regression tests for each hardened behaviour.

## Adoption notes

- Rebased onto `main` (566a7c6e). Conflicts resolved in `config.py` (kept `main`'s new `GO_FRONTEND` line alongside the `CSHARP_FRONTEND = TREESITTER` change) and `uv.lock` (regenerated from the merged `pyproject.toml`; only click/pygments moved).
- The original commits used a non-conventional `security:` type; squashed into one `fix:` commit, authorship retained as @DMA-AI-agent.
- Verified locally: `test_config_validation`, `test_shell_command`, `test_provider_classes`, `test_csharp_frontend_wiring` (221 passed, 1 skipped); ruff + ty clean.

Closes #1231.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Explicit API keys now take precedence over configured environment values.
  * C# parsing now defaults to the Tree-sitter frontend; Roslyn requires explicit opt-in.
* **Security**
  * Shell operations involving filesystem access, Git, or mutating `find` actions now require approval.
  * Only limited pathless commands run without approval by default.
  * Environment files are loaded only from the current working directory.
* **Documentation**
  * Getting-started documentation now includes the required syntax-highlighting package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->