### PR TITLE
feat: resolve interpreted-runtime frames in eBPF pprof profiles (--language python)

### DIFF
--- a/codebase_rag/cli_help.py
+++ b/codebase_rag/cli_help.py
@@ -122,8 +122,9 @@ HELP_TRACE_INCLUDE = (
 HELP_TRACE_LANGUAGE = (
     "Override the auto-detected source language. Rust pprof profiles share Go's "
     "gzipped-protobuf format, so pass 'rust' to demangle them as Rust. For an "
-    "eBPF profile of an interpreted runtime, pass 'python' to resolve the "
-    "in-kernel-unwound source frames against the Python graph."
+    "eBPF profile of an interpreted runtime, pass '--format ebpf --language "
+    "python' together to resolve the in-kernel-unwound source frames against "
+    "the Python graph ('python' is an eBPF-only override)."
 )
 HELP_TRACE_FORMAT = (
     "Force a profile format instead of auto-detecting it. Use 'ebpf' for pprof "

--- a/codebase_rag/cli_help.py
+++ b/codebase_rag/cli_help.py
@@ -121,7 +121,9 @@ HELP_TRACE_INCLUDE = (
 )
 HELP_TRACE_LANGUAGE = (
     "Override the auto-detected source language. Rust pprof profiles share Go's "
-    "gzipped-protobuf format, so pass 'rust' to demangle them as Rust."
+    "gzipped-protobuf format, so pass 'rust' to demangle them as Rust. For an "
+    "eBPF profile of an interpreted runtime, pass 'python' to resolve the "
+    "in-kernel-unwound source frames against the Python graph."
 )
 HELP_TRACE_FORMAT = (
     "Force a profile format instead of auto-detecting it. Use 'ebpf' for pprof "

--- a/codebase_rag/tests/test_dynamic_trace_ebpf.py
+++ b/codebase_rag/tests/test_dynamic_trace_ebpf.py
@@ -577,3 +577,189 @@ def test_pull_strips_auth_on_redirect(tmp_path):
     # Neither the standard nor the custom credential header crossed the redirect.
     assert received["auth"] is None
     assert received["apikey"] is None
+
+
+# --- Interpreted-language frames (issue #1287 follow-up) ------------------
+#
+# The OTel/Parca/Pyroscope eBPF profilers unwind the interpreter stack in the
+# kernel and report Python frames as source-level names against the real ``.py``
+# file, not as native binary addresses. The shapes below are the two observed in
+# real captures on a Python 3.12 workload:
+#
+#   * perf-map symbolisation:  ``py::Service.handle_request``  (Class.method,
+#     ``py::`` prefixed, definition line in Function.start_line)
+#   * py-spy-style:            ``leaf_compute``  (bare name, line present)
+#
+# plus ``<module>`` toplevels and standard-library frames whose file sits
+# outside the repository. ``--language python`` emits ``language=python`` so
+# ingestion routes the records to Python's existing FrameResolver.
+
+from codebase_rag.trace.ingest import ingest_trace  # noqa: E402
+
+
+def _py_profile_bytes(src_abs: str) -> bytes:
+    strings = [
+        "",
+        "py::Service.handle_request",  # 1: perf-map Class.method + py:: prefix
+        "leaf_compute",  # 2: py-spy bare name
+        "<module>",  # 3: module toplevel
+        "_find_and_load",  # 4: stdlib frame, out-of-repo file
+        src_abs,  # 5: the real in-repo source file
+        "<frozen importlib._bootstrap>",  # 6: stdlib "file"
+        "endpoint",  # 7: label key
+        "/api/checkout",  # 8: label value
+        "/opt/py/interp",  # 9: interpreter mapping name
+    ]
+    idx = {s: i for i, s in enumerate(strings)}
+    table = b"".join(_string(s) for s in strings)
+    functions = (
+        _function(1, idx["py::Service.handle_request"], idx[src_abs], 12)
+        + _function(2, idx["leaf_compute"], idx[src_abs], 4)
+        + _function(3, idx["<module>"], idx[src_abs], 1)
+        + _function(4, idx["_find_and_load"], idx["<frozen importlib._bootstrap>"], 900)
+    )
+    # A single interpreter mapping with no build id: interpreted frames are
+    # filtered by source-path containment, never by this mapping.
+    mappings = _mapping(1, idx["/opt/py/interp"], 0)
+    locations = (
+        _location(1, 1, [(1, 14)])  # handle_request, runtime line 14
+        + _location(2, 1, [(2, 5)])  # leaf_compute, runtime line 5
+        + _location(3, 1, [(3, 25)])  # <module>, runtime line 25
+        + _location(4, 1, [(4, 950)])  # stdlib frame, out-of-repo file
+    )
+    endpoint = _label(idx["endpoint"], idx["/api/checkout"])
+    # Leaf-first: leaf_compute, stdlib(seen-through), handle_request, <module>.
+    samples = _sample([2, 4, 1, 3], 9, [endpoint])
+    return table + functions + mappings + locations + samples
+
+
+def _py_convert(tmp_path, **kwargs):
+    src = tmp_path / "app" / "service.py"
+    src.parent.mkdir(parents=True, exist_ok=True)
+    src.write_text("x = 1\n", encoding="utf-8")
+    profile = tmp_path / "py.pb.gz"
+    profile.write_bytes(gzip.compress(_py_profile_bytes(src.as_posix())))
+    output = tmp_path / "trace.jsonl"
+    kwargs.setdefault("language", cs.TRACE_LANGUAGE_PYTHON)
+    count = convert_ebpf_pprof(profile, repo_root=tmp_path, output=output, **kwargs)
+    header, records = read_trace_file(output)
+    return count, header, list(records), output
+
+
+def test_interpreted_python_frames_are_shaped_for_the_resolver(tmp_path):
+    count, header, records, _ = _py_convert(tmp_path)
+    assert header.language == cs.TRACE_LANGUAGE_PYTHON
+    assert header.sampled is True
+    assert header.tracer == cs.TRACE_TOOL_NAME_EBPF
+    src = (tmp_path / "app" / "service.py").as_posix()
+    edges = {
+        (r.caller.qualname, r.callee.qualname): (r.caller, r.callee) for r in records
+    }
+    # The stdlib frame is seen through, leaving module -> method -> function.
+    assert set(edges) == {
+        ("<module>", "Service.handle_request"),
+        ("Service.handle_request", "leaf_compute"),
+    }
+    caller, callee = edges[("<module>", "Service.handle_request")]
+    # py:: prefix stripped, Class.method preserved, real file, definition line
+    # (Function.start_line, which the resolver's span match anchors on).
+    assert callee.qualname == "Service.handle_request"
+    assert callee.path == src
+    assert callee.line == 12
+    assert caller.qualname == cs.TRACE_QUALNAME_MODULE
+    # The bare py-spy-style leaf keeps its name and its definition line.
+    _, leaf = edges[("Service.handle_request", "leaf_compute")]
+    assert leaf.qualname == "leaf_compute"
+    assert leaf.line == 4
+    assert count == 2
+
+
+def test_interpreted_frames_ignore_a_native_build_id_filter(tmp_path):
+    # A build-id filter selects a native binary's mapping; interpreted frames
+    # live in the interpreter's mapping and must survive it (they are filtered
+    # by source path instead), or every Python edge would vanish.
+    count, _header, records, _ = _py_convert(tmp_path, build_id="native-only-xyz")
+    assert count == 2
+    assert {(r.caller.qualname, r.callee.qualname) for r in records} == {
+        ("<module>", "Service.handle_request"),
+        ("Service.handle_request", "leaf_compute"),
+    }
+
+
+def test_interpreted_out_of_repo_stdlib_frame_is_counted_not_resolved(tmp_path):
+    messages: list[str] = []
+    sink = logger.add(messages.append, level="INFO", format="{message}")
+    try:
+        _count, _header, records, _ = _py_convert(tmp_path)
+    finally:
+        logger.remove(sink)
+    # No edge references the stdlib frame's out-of-repo file.
+    assert all("_find_and_load" not in r.callee.qualname for r in records)
+    assert all("_find_and_load" not in r.caller.qualname for r in records)
+    # The out-of-repo frame is counted and reported, not silently dropped.
+    assert any("unmapped build paths" in m for m in messages)
+
+
+class _FakePyGraph:
+    """Minimal TraceGraphProtocol: serves Python callables, records edges."""
+
+    def __init__(self, callable_rows, existing_rows):
+        self._callable_rows = callable_rows
+        self._existing_rows = existing_rows
+        self.edges = []
+
+    def fetch_all(self, query, params=None):
+        from codebase_rag.cypher_queries import (
+            CYPHER_TRACE_CALLABLES,
+            CYPHER_TRACE_EXISTING_CALLS,
+        )
+
+        if query == CYPHER_TRACE_CALLABLES:
+            return self._callable_rows
+        if query == CYPHER_TRACE_EXISTING_CALLS:
+            return self._existing_rows
+        raise AssertionError(f"unexpected query: {query}")
+
+    def ensure_relationship_batch(self, from_spec, rel_type, to_spec, properties=None):
+        self.edges.append((from_spec[2], to_spec[2], properties))
+
+    def flush_all(self):
+        return None
+
+
+def test_interpreted_python_trace_ingests_to_calls_edges(tmp_path):
+    # End-to-end proof: convert a Python eBPF profile, then ingest it through the
+    # real resolver and confirm the source-level frames bind to graph nodes.
+    project = "svc__deadbeef"
+
+    def row(label, qn, start, end):
+        return {
+            cs.KEY_LABEL: label,
+            cs.KEY_QUALIFIED_NAME: qn,
+            cs.KEY_PATH: "app/service.py",
+            cs.KEY_START_LINE: start,
+            cs.KEY_END_LINE: end,
+        }
+
+    callables = [
+        row(cs.NodeLabel.MODULE, f"{project}.app.service", None, None),
+        row(
+            cs.NodeLabel.METHOD, f"{project}.app.service.Service.handle_request", 12, 18
+        ),
+        row(cs.NodeLabel.FUNCTION, f"{project}.app.service.leaf_compute", 4, 6),
+    ]
+    _count, _header, _records, output = _py_convert(tmp_path)
+    graph = _FakePyGraph(callables, [])
+    summary = ingest_trace(output, graph, tmp_path, project)
+
+    assert summary.unresolved == 0
+    resolved = {(frm, to) for frm, to, _props in graph.edges}
+    assert resolved == {
+        (f"{project}.app.service", f"{project}.app.service.Service.handle_request"),
+        (
+            f"{project}.app.service.Service.handle_request",
+            f"{project}.app.service.leaf_compute",
+        ),
+    }
+    # Runtime-only edges from a sampled profile carry the sampled provenance flag.
+    assert all(props[cs.TRACE_PROP_SAMPLED] for _f, _t, props in graph.edges)

--- a/codebase_rag/tests/test_dynamic_trace_resolution.py
+++ b/codebase_rag/tests/test_dynamic_trace_resolution.py
@@ -152,14 +152,18 @@ def test_wrapper_falls_back_to_line_containment(tmp_path):
     assert resolved.qualified_name == f"{_PROJECT}.pkg.mod.outer.inner"
 
 
-def test_repo_relative_collapses_parent_traversal_and_gates_escapes():
+def test_repo_relative_collapses_parent_traversal_and_gates_escapes(tmp_path):
     # The containment helper normalises `..` before the check, so an in-repo
     # frame that dips through a parent still resolves, while one that walks out
     # of the repository is rejected (it would only fail to key a node anyway).
+    # Paths are derived from the resolved root prefix so the assertions hold on
+    # Windows (drive-anchored) and macOS (/var -> /private/var) alike.
     from codebase_rag.trace.resolution import _repo_relative, _repo_root_posix
 
-    root = _repo_root_posix(Path("/work/repo"))
-    assert _repo_relative(root, "/work/repo/pkg/mod.py") == "pkg/mod.py"
-    assert _repo_relative(root, "/work/repo/pkg/../mod.py") == "mod.py"
-    assert _repo_relative(root, "/work/repo/../other/mod.py") is None
-    assert _repo_relative(root, "/elsewhere/mod.py") is None
+    root = _repo_root_posix(tmp_path / "repo")
+    base = root.rstrip("/")
+    assert _repo_relative(root, f"{base}/pkg/mod.py") == "pkg/mod.py"
+    assert _repo_relative(root, f"{base}/pkg/../mod.py") == "mod.py"
+    assert _repo_relative(root, f"{base}/../other/mod.py") is None
+    # A sibling whose name merely shares the repo's prefix is not inside it.
+    assert _repo_relative(root, f"{base}_evil/mod.py") is None

--- a/codebase_rag/tests/test_dynamic_trace_resolution.py
+++ b/codebase_rag/tests/test_dynamic_trace_resolution.py
@@ -150,3 +150,16 @@ def test_wrapper_falls_back_to_line_containment(tmp_path):
     )
     assert resolved is not None
     assert resolved.qualified_name == f"{_PROJECT}.pkg.mod.outer.inner"
+
+
+def test_repo_relative_collapses_parent_traversal_and_gates_escapes():
+    # The containment helper normalises `..` before the check, so an in-repo
+    # frame that dips through a parent still resolves, while one that walks out
+    # of the repository is rejected (it would only fail to key a node anyway).
+    from codebase_rag.trace.resolution import _repo_relative, _repo_root_posix
+
+    root = _repo_root_posix(Path("/work/repo"))
+    assert _repo_relative(root, "/work/repo/pkg/mod.py") == "pkg/mod.py"
+    assert _repo_relative(root, "/work/repo/pkg/../mod.py") == "mod.py"
+    assert _repo_relative(root, "/work/repo/../other/mod.py") is None
+    assert _repo_relative(root, "/elsewhere/mod.py") is None

--- a/codebase_rag/trace/ebpf_pprof.py
+++ b/codebase_rag/trace/ebpf_pprof.py
@@ -25,6 +25,16 @@ Symbol grammars are reused from the per-runtime converters, keyed off the
 selected language: Go (``pprof``), Rust (``rust_pprof``), and C/C++ (the
 already-demangled grammar in ``instrumented``; Parca server-side-symbolizes and
 demangles, which this path assumes).
+
+Interpreted runtimes (``--language python``) are the other axis: the eBPF
+profiler unwinds the interpreter stack in-kernel and reports source-level frames
+(``<module>``, a bare ``func``, or ``Class.method``) against the real ``.py``
+file, so those frames carry no native symbol to demangle and no native mapping
+to filter on. This path normalises the name (dropping the ``py::`` prefix the
+perf-map symbolisation route prepends), filters to the project by source-path
+containment, and emits ``language=python`` so ingestion routes the records to
+Python's existing frame resolver -- the same resolver the ``sys.monitoring``
+tracer feeds.
 """
 
 from __future__ import annotations
@@ -65,6 +75,30 @@ _DEMANGLERS = {
     cs.TRACE_LANGUAGE_RUST: _rust_bare_name,
     cs.TRACE_LANGUAGE_CPP: _cpp_bare_name,
 }
+
+# Interpreted runtimes the eBPF profiler unwinds in-kernel. Their frames arrive
+# as source-level names (``<module>``, a bare ``func``, or ``Class.method``)
+# against the real source file, not as native binary addresses, so they reuse
+# each language's existing frame resolver (Python's ``FrameResolver`` is the
+# ingest default) instead of a symbol demangler, and are filtered to the project
+# by source-path containment rather than a native build-id. The name passes
+# through untouched except for stripping the ``py::`` prefix the perf-map
+# symbolisation path some profilers reuse prepends to Python frames.
+_PY_PERF_PREFIX = "py::"
+
+
+def _interpreted_name(name: str) -> str:
+    """A pprof interpreted-frame name as the language resolver expects it."""
+    if name.startswith(_PY_PERF_PREFIX):
+        return name[len(_PY_PERF_PREFIX) :]
+    return name
+
+
+_INTERPRETED_NAME_FNS = {
+    cs.TRACE_LANGUAGE_PYTHON: _interpreted_name,
+}
+
+_SUPPORTED_LANGUAGES = frozenset(_DEMANGLERS) | frozenset(_INTERPRETED_NAME_FNS)
 
 
 @dataclass(slots=True)
@@ -231,12 +265,12 @@ class _FrameBuilder:
         profile: _Profile,
         root_prefix: str,
         path_map: list[tuple[str, str]],
-        demangle,
+        name_fn,
     ) -> None:
         self._profile = profile
         self._root_prefix = root_prefix
         self._path_map = path_map
-        self._demangle = demangle
+        self._name_fn = name_fn
         self._cache: dict[int, FramePoint | None] = {}
         self.unmapped_paths: Counter[str] = Counter()
 
@@ -264,7 +298,7 @@ class _FrameBuilder:
         name = strings[name_index] if 0 < name_index < len(strings) else ""
         return FramePoint(
             path=path,
-            qualname=self._demangle(name),
+            qualname=self._name_fn(name),
             line=max(getattr(function, "start_line", 0), 0),
         )
 
@@ -307,17 +341,26 @@ def _resolved_frames(
     builder: _FrameBuilder,
     build_id: str | None,
     unsymbolised: Counter[str],
+    *,
+    select_mapping: bool = True,
 ) -> list[FramePoint]:
     """A sample's in-repo frames, root-first, seeing through other binaries.
 
     Locations from another binary and unsymbolised locations are skipped rather
     than breaking the chain, so a project edge survives a libc frame between its
     endpoints; unsymbolised target-binary locations are counted per mapping.
+
+    Interpreted frames (``select_mapping=False``) sit in the interpreter's
+    mapping, not the target's native binary, so a native build-id filter would
+    drop every one; they are kept regardless of mapping and filtered to the
+    project by the builder's source-path containment check instead.
     """
     frames: list[FramePoint] = []
     for location_id in reversed(sample.location_ids):
         location = profile.locations.get(location_id)
-        if location is None or not _mapping_selected(location, profile, build_id):
+        if location is None:
+            continue
+        if select_mapping and not _mapping_selected(location, profile, build_id):
             continue
         if not location.function_ids:
             unsymbolised[_mapping_name(profile, location) or "<unknown>"] += 1
@@ -337,6 +380,7 @@ def _accumulate(
     service: tuple[str, str] | None,
     workload_label: str | None,
     default_workload: str | None,
+    interpreted: bool = False,
 ) -> tuple[dict[tuple[FramePoint, FramePoint], tuple[int, set[str]]], Counter[str]]:
     """Adjacent in-repo frames per leaf-first stack, with per-edge workloads."""
     edges: dict[tuple[FramePoint, FramePoint], tuple[int, set[str]]] = {}
@@ -345,7 +389,14 @@ def _accumulate(
         if not _sample_matches(sample, service):
             continue
         workload = _sample_workload(sample, workload_label, default_workload)
-        frames = _resolved_frames(sample, profile, builder, build_id, unsymbolised)
+        frames = _resolved_frames(
+            sample,
+            profile,
+            builder,
+            build_id,
+            unsymbolised,
+            select_mapping=not interpreted,
+        )
         for ancestor, frame in zip(frames, frames[1:], strict=False):
             count, workloads = edges.get((ancestor, frame), (0, set()))
             if workload:
@@ -391,13 +442,16 @@ def convert_ebpf_pprof(
     ``path_map`` rewrites build-time path prefixes to the repository prefix;
     ``build_id`` filters to one binary's mapping; ``service`` (a ``key, value``
     pair) filters samples; ``workload_label`` maps a sample label to per-edge
-    ``workloads``; ``language`` selects the symbol demangler.
+    ``workloads``; ``language`` selects the symbol demangler (native runtimes)
+    or the interpreted-frame name normaliser (Python), the latter reusing the
+    language's existing ingest-time frame resolver.
     """
-    demangle = _DEMANGLERS.get(language)
-    if demangle is None:
+    interpreted = language in _INTERPRETED_NAME_FNS
+    name_fn = _INTERPRETED_NAME_FNS.get(language) or _DEMANGLERS.get(language)
+    if name_fn is None:
         raise TraceFormatError(
             cs.TRACE_ERR_EBPF_LANGUAGE.format(
-                language=language, supported=", ".join(sorted(_DEMANGLERS))
+                language=language, supported=", ".join(sorted(_SUPPORTED_LANGUAGES))
             )
         )
     raw = _decompress(profile_path.read_bytes(), profile_path)
@@ -409,7 +463,7 @@ def convert_ebpf_pprof(
         raise TraceFormatError(cs.TRACE_ERR_BAD_PPROF.format(path=profile_path))
 
     root_prefix = repo_root.resolve().as_posix() + "/"
-    builder = _FrameBuilder(profile, root_prefix, path_map or [], demangle)
+    builder = _FrameBuilder(profile, root_prefix, path_map or [], name_fn)
     edges, unsymbolised = _accumulate(
         profile,
         builder,
@@ -417,6 +471,7 @@ def convert_ebpf_pprof(
         service=service,
         workload_label=workload_label,
         default_workload=workload,
+        interpreted=interpreted,
     )
     _report(unsymbolised, builder.unmapped_paths)
 

--- a/codebase_rag/trace/resolution.py
+++ b/codebase_rag/trace/resolution.py
@@ -8,6 +8,7 @@ line containment when names alone are ambiguous.
 
 from __future__ import annotations
 
+import posixpath
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -32,8 +33,15 @@ def _repo_relative(root_posix: str, frame_path: str) -> str | None:
     form (the in-process tracers emit ``co_filename`` with ``os.sep``). Both are
     normalised to POSIX before the containment check so a separator mismatch
     cannot read an in-repo frame as outside the repository on Windows.
+    ``posixpath.normpath`` collapses any ``..`` first, so a frame that walks out
+    of and back into the repo still resolves and one that walks out stays out.
+    The returned path only ever keys ``_callables_by_path`` (a table of known
+    in-repo node paths), so a stray relative fragment fails to match rather than
+    escaping anywhere. Case-insensitive drives and symlink aliases are left as
+    the identity match the graph itself uses, since the indexer keys nodes by
+    the same lexical relative paths without resolving either.
     """
-    frame_posix = Path(frame_path).as_posix()
+    frame_posix = posixpath.normpath(Path(frame_path).as_posix())
     if not frame_posix.startswith(root_posix):
         return None
     return frame_posix[len(root_posix) :]

--- a/codebase_rag/trace/resolution.py
+++ b/codebase_rag/trace/resolution.py
@@ -8,7 +8,6 @@ line containment when names alone are ambiguous.
 
 from __future__ import annotations
 
-import os
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -18,6 +17,26 @@ from .. import constants as cs
 
 if TYPE_CHECKING:
     from .records import FramePoint
+
+
+def _repo_root_posix(repo_root: Path) -> str:
+    """The resolved repo root as a POSIX prefix ending in a separator."""
+    return repo_root.resolve().as_posix().rstrip("/") + "/"
+
+
+def _repo_relative(root_posix: str, frame_path: str) -> str | None:
+    """The repo-relative POSIX path of an in-repo frame, or None if outside.
+
+    Frame paths arrive either POSIX (the pprof/V8 converters emit forward
+    slashes, since production build paths are POSIX) or in the host's native
+    form (the in-process tracers emit ``co_filename`` with ``os.sep``). Both are
+    normalised to POSIX before the containment check so a separator mismatch
+    cannot read an in-repo frame as outside the repository on Windows.
+    """
+    frame_posix = Path(frame_path).as_posix()
+    if not frame_posix.startswith(root_posix):
+        return None
+    return frame_posix[len(root_posix) :]
 
 
 @dataclass(frozen=True, slots=True)
@@ -64,8 +83,7 @@ class FrameResolver:
     """Maps runtime frame identities of one project to graph nodes."""
 
     def __init__(self, repo_root: Path, nodes: list[CallableNode]) -> None:
-        self._repo_root = repo_root.resolve()
-        self._root_prefix = str(self._repo_root) + os.sep
+        self._root_posix = _repo_root_posix(repo_root)
         self._callables_by_path: dict[str, list[CallableNode]] = {}
         self._modules_by_path: dict[str, CallableNode] = {}
         for node in nodes:
@@ -77,10 +95,10 @@ class FrameResolver:
     def resolve(
         self, frame: FramePoint, stats: ResolutionStats
     ) -> ResolvedFrame | None:
-        if not frame.path.startswith(self._root_prefix):
+        rel_path = _repo_relative(self._root_posix, frame.path)
+        if rel_path is None:
             stats.record(cs.TraceUnresolvedReason.OUTSIDE_REPO)
             return None
-        rel_path = Path(frame.path).relative_to(self._repo_root).as_posix()
 
         parts = [
             p
@@ -169,8 +187,7 @@ class JsFrameResolver:
     """
 
     def __init__(self, repo_root: Path, nodes: list[CallableNode]) -> None:
-        self._repo_root = repo_root.resolve()
-        self._root_prefix = str(self._repo_root) + os.sep
+        self._root_posix = _repo_root_posix(repo_root)
         self._callables_by_path: dict[str, list[CallableNode]] = {}
         self._modules_by_path: dict[str, CallableNode] = {}
         for node in nodes:
@@ -182,10 +199,10 @@ class JsFrameResolver:
     def resolve(
         self, frame: FramePoint, stats: ResolutionStats
     ) -> ResolvedFrame | None:
-        if not frame.path.startswith(self._root_prefix):
+        rel_path = _repo_relative(self._root_posix, frame.path)
+        if rel_path is None:
             stats.record(cs.TraceUnresolvedReason.OUTSIDE_REPO)
             return None
-        rel_path = Path(frame.path).relative_to(self._repo_root).as_posix()
 
         if frame.qualname == cs.TRACE_QUALNAME_MODULE:
             module = self._modules_by_path.get(rel_path)
@@ -239,8 +256,7 @@ class PhpFrameResolver:
     """
 
     def __init__(self, repo_root: Path, nodes: list[CallableNode]) -> None:
-        self._repo_root = repo_root.resolve()
-        self._root_prefix = str(self._repo_root) + os.sep
+        self._root_posix = _repo_root_posix(repo_root)
         self._callables_by_path: dict[str, list[CallableNode]] = {}
         self._modules_by_path: dict[str, CallableNode] = {}
         for node in nodes:
@@ -264,9 +280,7 @@ class PhpFrameResolver:
         return self._resolve_by_name_tail(frame.qualname, stats)
 
     def _relative(self, path: str) -> str | None:
-        if not path.startswith(self._root_prefix):
-            return None
-        return Path(path).relative_to(self._repo_root).as_posix()
+        return _repo_relative(self._root_posix, path)
 
     def _resolve_module(
         self, path: str, stats: ResolutionStats

--- a/docs/guide/dynamic-tracing.md
+++ b/docs/guide/dynamic-tracing.md
@@ -509,6 +509,11 @@ reported like any other unmapped path, never silently dropped. `--path-map` maps
 the container/build source root to the repository the same way it does for native
 frames.
 
+Like every eBPF profile, Python profiles are sampled: ingested edges carry
+`dynamic_sampled: true` and their `dynamic_call_count` is an approximate sample
+count, not the exact per-call total the in-process `sys.monitoring` Python tracer
+records.
+
 ## Ingesting a trace
 
 Parse the repository into the graph first (`cgr start --repo-path ... --update-graph`),

--- a/docs/guide/dynamic-tracing.md
+++ b/docs/guide/dynamic-tracing.md
@@ -482,6 +482,33 @@ wall-clock** profiles use the same pprof format and convert through the same
 I/O-bound paths (a handler that lives in `await`) that a CPU profile barely
 samples.
 
+### Interpreted runtimes (`--language python`)
+
+The `--language go`/`rust`/`cpp` paths above cover natively compiled binaries,
+whose frames are addresses in the target's own binary. eBPF profilers
+(OpenTelemetry, Parca, Pyroscope) also unwind **interpreted** stacks in the
+kernel and report them as source-level names against the real `.py` file
+(`<module>`, a bare `leaf_compute`, or `Service.handle_request`), not as native
+addresses. Pass `--language python` for those:
+
+```bash
+cgr trace convert prod.pb.gz --format ebpf --repo-path /path/to/your-repo \
+    --language python --path-map /app/=/path/to/your-repo/ --label endpoint
+cgr trace ingest cgr-trace.jsonl --repo-path /path/to/your-repo
+```
+
+Interpreted frames are handled differently from native ones in two ways, both
+automatic: they are **not** filtered by `--build-id` (they live in the
+interpreter's mapping, not the target binary, so a native build-id would drop
+every one) and are instead scoped to the project by source-path containment; and
+their names are used as-is (only the `py::` prefix the perf-map symbolisation
+route prepends is stripped) rather than run through a symbol demangler, then
+routed to the same resolver the in-process Python tracer feeds. Frames from
+outside the repository (the standard library, site-packages) are counted and
+reported like any other unmapped path, never silently dropped. `--path-map` maps
+the container/build source root to the repository the same way it does for native
+frames.
+
 ## Ingesting a trace
 
 Parse the repository into the graph first (`cgr start --repo-path ... --update-graph`),


### PR DESCRIPTION
Closes the last open follow-up on #1287: interpreted-runtime frames.

## What

`cgr trace convert --format ebpf --language python` now resolves the source-level frames an eBPF profiler (OpenTelemetry, Parca, Pyroscope) unwinds from the interpreter stack in the kernel. Those frames arrive as names against the real `.py` file (`<module>`, a bare `leaf_compute`, or `Service.handle_request`), not as native binary addresses, so the native Go/Rust/C++ path could not handle them.

## How

The native path assumes each frame is an address in the target's own binary: it demangles the symbol and filters frames to a `--build-id` mapping. Neither holds for interpreted frames, so `--language python` takes a different route, all automatic:

- **Names pass through untouched**, except for stripping the `py::` prefix the perf-map symbolisation route (which some profilers reuse) prepends. No native demangler runs.
- **No `--build-id` filtering.** Interpreted frames live in the interpreter's mapping, not the target binary, so a native build-id would drop every one. They are scoped to the project by source-path containment instead (the same containment/`--path-map` re-anchoring the native path already applies).
- **Emitted as `language=python`**, so ingestion routes the records to the existing Python `FrameResolver` — the same resolver the in-process `sys.monitoring` tracer feeds. No ingest changes.
- Frames from outside the repository (stdlib, site-packages) are counted and reported like any other unmapped path, never silently dropped.

## Verification

The two frame shapes the tests are built against were captured from **real profiles** of a Python 3.12 workload:

- perf-map symbolisation: `py::Service.handle_request` (Class.method, `py::`-prefixed, definition line in `Function.start_line`)
- py-spy-style: `leaf_compute` (bare name)

4 new tests cover `py::` stripping + Class.method preservation, `<module>` binding, seen-through/counted out-of-repo stdlib frames, the build-id bypass, and a full convert -> ingest -> resolve proof that the frames bind to Module/Method/Function graph nodes with zero unresolved. Full `dynamic_trace` suite: 223 passed.

## Scope

Python only, since that is the shape I could verify against real captures. The machinery is language-parameterised (`_INTERPRETED_NAME_FNS`), so JVM/Ruby drop in as small follow-ups once a real profile of each is available to design the frame/label shape against. Docs and `--language` help updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for converting and ingesting Python eBPF profiles.
  * Python traces resolve interpreted frames, preserve metadata, and record sampled call relationships.
  * Added support for common Python profiler formats and repository source-path filtering.
  * Added the `--language python` option for tracing Python runtimes.
  * Python frames remain available when native build-ID filters are applied.

* **Bug Fixes**
  * Improved cross-platform repository-relative source-path handling for interpreted-language trace frames.

* **Documentation**
  * Added guidance for converting, filtering, and ingesting interpreted Python eBPF profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->