### PR TITLE
feat: resolve JVM frames in eBPF pprof profiles (--language jvm)

### DIFF
--- a/codebase_rag/cli_help.py
+++ b/codebase_rag/cli_help.py
@@ -122,9 +122,10 @@ HELP_TRACE_INCLUDE = (
 HELP_TRACE_LANGUAGE = (
     "Override the auto-detected source language. Rust pprof profiles share Go's "
     "gzipped-protobuf format, so pass 'rust' to demangle them as Rust. For an "
-    "eBPF profile of an interpreted runtime, pass '--format ebpf --language "
-    "python' together to resolve the in-kernel-unwound source frames against "
-    "the Python graph ('python' is an eBPF-only override)."
+    "eBPF profile of a managed runtime, pass '--format ebpf --language python' "
+    "(or '--language jvm') together to resolve the in-kernel-unwound source "
+    "frames against that language's graph ('python' and 'jvm' are eBPF-only "
+    "overrides)."
 )
 HELP_TRACE_FORMAT = (
     "Force a profile format instead of auto-detecting it. Use 'ebpf' for pprof "

--- a/codebase_rag/tests/test_dynamic_trace_ebpf.py
+++ b/codebase_rag/tests/test_dynamic_trace_ebpf.py
@@ -920,7 +920,11 @@ def test_jvm_scala_frames_attribute_to_the_scala_file(tmp_path):
         language=cs.TRACE_LANGUAGE_JVM,
     )
     _header, records = read_trace_file(output)
-    paths = {r.caller.path for r in records} | {r.callee.path for r in records}
+    materialized = list(records)
+    assert materialized
+    paths = {r.caller.path for r in materialized} | {
+        r.callee.path for r in materialized
+    }
     assert paths == {"workload/Service.scala"}
 
 
@@ -951,7 +955,12 @@ def test_jvm_stem_matching_both_java_and_scala_is_ambiguous(tmp_path):
     finally:
         logger.remove(sink)
     assert count == 0
-    assert any("unmapped build paths" in m for m in messages)
+    # Collision-specific evidence: the four Service-stem frames (spin, handle,
+    # leaf, lambda) join the JDK class and the VM blob in the unmapped report,
+    # 6 frames across 3 distinct paths, where the unambiguous fixture reports
+    # only the 2 non-project frames.
+    expected = cs.TRACE_MSG_EBPF_UNMAPPED.format(count=6, paths=3)
+    assert any(expected in m for m in messages)
 
 
 def test_jvm_trace_ingests_to_calls_edges(tmp_path):

--- a/codebase_rag/tests/test_dynamic_trace_ebpf.py
+++ b/codebase_rag/tests/test_dynamic_trace_ebpf.py
@@ -763,3 +763,183 @@ def test_interpreted_python_trace_ingests_to_calls_edges(tmp_path):
     }
     # Runtime-only edges from a sampled profile carry the sampled provenance flag.
     assert all(props[cs.TRACE_PROP_SAMPLED] for _f, _t, props in graph.edges)
+
+
+# --- JVM frames (issue #1287 follow-up) ------------------------------------
+#
+# Both real JVM symbolisation routes emit the same grammar, captured on a JDK 17
+# workload via ``-XX:+DumpPerfMapAtExit`` (what perf-map-reading profilers
+# surface) and confirmed against the OpenTelemetry profiler's HotSpot demangler:
+#
+#   long workload.Service$Inner.spin(workload.Service, int)
+#   void workload.Service$$Lambda$1/0x00007d62f8000c20.run()
+#   int java.lang.Object.hashCode()          (JDK class, out of project)
+#   Interpreter                              (VM blob, unparseable)
+#
+# The perf-map route carries no file and no line; the OpenTelemetry route adds
+# a source basename and line. Either way the package in the symbol derives the
+# path (``workload/Service.java``), the convention ``JvmFrameResolver`` speaks.
+
+_JVM_SPIN = "long workload.Service$Inner.spin(workload.Service, int)"
+_JVM_HANDLE = "long workload.Service.handleRequest(int)"
+_JVM_LEAF = "long workload.Service.leafCompute(int)"
+_JVM_LAMBDA = "void workload.Service$$Lambda$1/0x00007d62f8000c20.run()"
+_JVM_JDK = "int java.lang.Object.hashCode()"
+_JVM_BLOB = "Interpreter"
+
+
+def _jvm_profile_bytes() -> bytes:
+    strings = [
+        "",
+        _JVM_SPIN,  # 1: perf-map shape, no file, no line
+        _JVM_HANDLE,  # 2: OTel shape, basename + line below
+        _JVM_LEAF,  # 3: perf-map shape
+        _JVM_JDK,  # 4: JDK class, out of project
+        _JVM_BLOB,  # 5: VM blob
+        _JVM_LAMBDA,  # 6: synthetic lambda class with address hash
+        "Service.java",  # 7: OTel source basename
+        "[anon:jit]",  # 8: JIT mapping name, no build id
+    ]
+    idx = {s: i for i, s in enumerate(strings)}
+    table = b"".join(_string(s) for s in strings)
+    functions = (
+        _function(1, idx[_JVM_SPIN], 0, 0)
+        + _function(2, idx[_JVM_HANDLE], idx["Service.java"], 6)
+        + _function(3, idx[_JVM_LEAF], 0, 0)
+        + _function(4, idx[_JVM_JDK], 0, 0)
+        + _function(5, idx[_JVM_BLOB], 0, 0)
+        + _function(6, idx[_JVM_LAMBDA], 0, 0)
+    )
+    mappings = _mapping(1, idx["[anon:jit]"], 0)
+    locations = (
+        _location(1, 1, [(1, 0)])
+        + _location(2, 1, [(2, 9)])
+        + _location(3, 1, [(3, 0)])
+        + _location(4, 1, [(4, 0)])
+        + _location(5, 1, [(5, 0)])
+        + _location(6, 1, [(6, 0)])
+    )
+    samples = (
+        # Leaf-first: leafCompute, hashCode (JDK, seen through), handleRequest,
+        # Interpreter (VM blob, seen through), spin.
+        _sample([3, 4, 2, 5, 1], 11, [])
+        # Leaf-first: lambda body under spin.
+        + _sample([6, 1], 2, [])
+    )
+    return table + functions + mappings + locations + samples
+
+
+def _jvm_convert(tmp_path, **kwargs):
+    src = tmp_path / "src" / "main" / "java" / "workload" / "Service.java"
+    src.parent.mkdir(parents=True, exist_ok=True)
+    src.write_text("class Service {}\n", encoding="utf-8")
+    profile = tmp_path / "jvm.pb.gz"
+    profile.write_bytes(gzip.compress(_jvm_profile_bytes()))
+    output = tmp_path / "trace.jsonl"
+    kwargs.setdefault("language", cs.TRACE_LANGUAGE_JVM)
+    count = convert_ebpf_pprof(profile, repo_root=tmp_path, output=output, **kwargs)
+    header, records = read_trace_file(output)
+    return count, header, list(records), output
+
+
+def test_jvm_frames_derive_package_paths_for_the_resolver(tmp_path):
+    count, header, records, _ = _jvm_convert(tmp_path)
+    assert header.language == cs.TRACE_LANGUAGE_JVM
+    assert header.sampled is True
+    edges = {
+        (r.caller.qualname, r.callee.qualname): (r.caller, r.callee) for r in records
+    }
+    assert set(edges) == {
+        ("Service$Inner.spin", "Service.handleRequest"),
+        ("Service.handleRequest", "Service.leafCompute"),
+        ("Service$Inner.spin", "Service$$Lambda$1.run"),
+    }
+    caller, callee = edges[("Service$Inner.spin", "Service.handleRequest")]
+    # The package derives the path; the return type and the parameter list are
+    # gone; the nested-class chain survives as the resolver's $ notation.
+    assert caller.path == "workload/Service.java"
+    assert caller.line == 0
+    assert callee.path == "workload/Service.java"
+    # The OTel-shaped frame keeps its definition line for span disambiguation.
+    assert callee.line == 6
+    # The lambda class keeps its chain but drops the address hash.
+    _, lam = edges[("Service$Inner.spin", "Service$$Lambda$1.run")]
+    assert lam.qualname == "Service$$Lambda$1.run"
+    assert count == 3
+
+
+def test_jvm_out_of_project_and_vm_frames_are_counted_not_resolved(tmp_path):
+    messages: list[str] = []
+    sink = logger.add(messages.append, level="INFO", format="{message}")
+    try:
+        _count, _header, records, _ = _jvm_convert(tmp_path)
+    finally:
+        logger.remove(sink)
+    names = {r.caller.qualname for r in records} | {r.callee.qualname for r in records}
+    # The JDK frame and the VM blob are seen through, never edge endpoints.
+    assert not any("hashCode" in n or "Interpreter" in n for n in names)
+    assert any("unmapped build paths" in m for m in messages)
+
+
+def test_jvm_symbol_grammar_covers_both_routes():
+    from codebase_rag.trace.ebpf_pprof import _jvm_source_stem, _jvm_symbol_parts
+
+    # Constructor, Scala object, and the OTel dot-rewritten lambda hash.
+    assert _jvm_symbol_parts("void workload.Service.<init>()") == (
+        "workload",
+        "Service",
+        "<init>",
+    )
+    assert _jvm_symbol_parts("long demo.Util$.free(int)") == ("demo", "Util$", "free")
+    assert _jvm_source_stem("demo", "Util$") == "demo/Util"
+    assert _jvm_symbol_parts(
+        "void workload.Service$$Lambda$1.0x00007d62f8000c20.run()"
+    ) == ("workload", "Service$$Lambda$1", "run")
+    # Default package: the class alone names the file.
+    assert _jvm_symbol_parts("int Main.run()") == ("", "Main", "run")
+    assert _jvm_source_stem("", "Main") == "Main"
+    # VM blobs and native symbols do not parse as a dotted member.
+    assert _jvm_symbol_parts("Interpreter") is None
+    assert _jvm_symbol_parts("StubRoutines (1)") is None
+    assert _jvm_symbol_parts("JavaCalls::call_helper(JavaValue*)") is None
+
+
+def test_jvm_trace_ingests_to_calls_edges(tmp_path):
+    # End-to-end proof: convert a JVM eBPF profile, then ingest it through the
+    # real JvmFrameResolver and confirm package-derived frames bind to nodes.
+    project = "svc__cafebabe"
+    node_path = "src/main/java/workload/Service.java"
+    module = f"{project}.src.main.java.workload.Service"
+
+    def row(label, qn, start, end):
+        return {
+            cs.KEY_LABEL: label,
+            cs.KEY_QUALIFIED_NAME: qn,
+            cs.KEY_PATH: node_path,
+            cs.KEY_START_LINE: start,
+            cs.KEY_END_LINE: end,
+        }
+
+    callables = [
+        row(cs.NodeLabel.METHOD, f"{module}.Service.Inner.spin(Service, int)", 24, 31),
+        row(cs.NodeLabel.METHOD, f"{module}.Service.handleRequest(int)", 6, 14),
+        row(cs.NodeLabel.METHOD, f"{module}.Service.leafCompute(int)", 16, 22),
+    ]
+    _count, _header, _records, output = _jvm_convert(tmp_path)
+    graph = _FakePyGraph(callables, [])
+    summary = ingest_trace(output, graph, tmp_path, project)
+
+    resolved = {(frm, to) for frm, to, _props in graph.edges}
+    assert resolved == {
+        (
+            f"{module}.Service.Inner.spin(Service, int)",
+            f"{module}.Service.handleRequest(int)",
+        ),
+        (
+            f"{module}.Service.handleRequest(int)",
+            f"{module}.Service.leafCompute(int)",
+        ),
+    }
+    # The synthetic lambda frame has no line to span-match: unresolved, counted.
+    assert summary.unresolved == 1
+    assert all(props[cs.TRACE_PROP_SAMPLED] for _f, _t, props in graph.edges)

--- a/codebase_rag/tests/test_dynamic_trace_ebpf.py
+++ b/codebase_rag/tests/test_dynamic_trace_ebpf.py
@@ -904,6 +904,56 @@ def test_jvm_symbol_grammar_covers_both_routes():
     assert _jvm_symbol_parts("JavaCalls::call_helper(JavaValue*)") is None
 
 
+def test_jvm_scala_frames_attribute_to_the_scala_file(tmp_path):
+    # With only a Scala source present the derived path takes the .scala
+    # extension; extension order must not bias attribution toward Java.
+    src = tmp_path / "src" / "main" / "scala" / "workload" / "Service.scala"
+    src.parent.mkdir(parents=True, exist_ok=True)
+    src.write_text("class Service\n", encoding="utf-8")
+    profile = tmp_path / "jvm.pb.gz"
+    profile.write_bytes(gzip.compress(_jvm_profile_bytes()))
+    output = tmp_path / "trace.jsonl"
+    convert_ebpf_pprof(
+        profile,
+        repo_root=tmp_path,
+        output=output,
+        language=cs.TRACE_LANGUAGE_JVM,
+    )
+    _header, records = read_trace_file(output)
+    paths = {r.caller.path for r in records} | {r.callee.path for r in records}
+    assert paths == {"workload/Service.scala"}
+
+
+def test_jvm_stem_matching_both_java_and_scala_is_ambiguous(tmp_path):
+    # The symbol carries no source-language discriminator: when both files
+    # exist the frame is counted unmapped instead of guessed (Greptile's
+    # collision case on PR #1299). A ceiling yields nothing, never a wrong
+    # link.
+    for rel in (
+        "src/main/java/workload/Service.java",
+        "src/main/scala/workload/Service.scala",
+    ):
+        src = tmp_path / rel
+        src.parent.mkdir(parents=True, exist_ok=True)
+        src.write_text("class Service\n", encoding="utf-8")
+    profile = tmp_path / "jvm.pb.gz"
+    profile.write_bytes(gzip.compress(_jvm_profile_bytes()))
+    output = tmp_path / "trace.jsonl"
+    messages: list[str] = []
+    sink = logger.add(messages.append, level="INFO", format="{message}")
+    try:
+        count = convert_ebpf_pprof(
+            profile,
+            repo_root=tmp_path,
+            output=output,
+            language=cs.TRACE_LANGUAGE_JVM,
+        )
+    finally:
+        logger.remove(sink)
+    assert count == 0
+    assert any("unmapped build paths" in m for m in messages)
+
+
 def test_jvm_trace_ingests_to_calls_edges(tmp_path):
     # End-to-end proof: convert a JVM eBPF profile, then ingest it through the
     # real JvmFrameResolver and confirm package-derived frames bind to nodes.

--- a/codebase_rag/trace/ebpf_pprof.py
+++ b/codebase_rag/trace/ebpf_pprof.py
@@ -356,16 +356,25 @@ class _JvmFrameBuilder:
     convention ``JvmFrameResolver`` already speaks. Frames whose derived path
     matches no repository source file (JDK and library classes, VM blobs,
     native symbols) are counted, not resolved, the same visibility contract as
-    unmapped build paths.
+    unmapped build paths. A stem that matches under more than one extension
+    (``pkg/Dup.java`` and ``pkg/Dup.scala`` both exist) is ambiguous -- the
+    symbol carries no source-language discriminator -- and is counted rather
+    than guessed, the resolver's own ceiling discipline (issue #1246).
     """
 
     def __init__(self, profile: _Profile, repo_root: Path) -> None:
         self._profile = profile
-        self._sources = [
-            path.relative_to(repo_root).as_posix()
-            for ext in _JVM_SOURCE_EXTENSIONS
-            for path in repo_root.rglob(f"*{ext}")
-        ]
+        # Every path suffix of every JVM source file, one traversal, so each
+        # candidate check below is one set lookup instead of a linear scan.
+        extensions = set(_JVM_SOURCE_EXTENSIONS)
+        self._source_suffixes: set[str] = set()
+        for path in repo_root.rglob("*"):
+            if path.suffix not in extensions or not path.is_file():
+                continue
+            parts = path.relative_to(repo_root).as_posix().split(cs.SEPARATOR_SLASH)
+            self._source_suffixes.update(
+                cs.SEPARATOR_SLASH.join(parts[index:]) for index in range(len(parts))
+            )
         self._cache: dict[int, FramePoint | None] = {}
         self.unmapped_paths: Counter[str] = Counter()
 
@@ -398,15 +407,12 @@ class _JvmFrameBuilder:
 
     def _project_path(self, package: str, simple: str) -> str | None:
         stem = _jvm_source_stem(package, simple)
-        for ext in _JVM_SOURCE_EXTENSIONS:
-            candidate = stem + ext
-            suffix = cs.SEPARATOR_SLASH + candidate
-            if any(
-                source == candidate or source.endswith(suffix)
-                for source in self._sources
-            ):
-                return candidate
-        return None
+        matches = [
+            stem + ext
+            for ext in _JVM_SOURCE_EXTENSIONS
+            if stem + ext in self._source_suffixes
+        ]
+        return matches[0] if len(matches) == 1 else None
 
 
 def _jvm_source_stem(package: str, simple: str) -> str:

--- a/codebase_rag/trace/ebpf_pprof.py
+++ b/codebase_rag/trace/ebpf_pprof.py
@@ -35,11 +35,22 @@ perf-map symbolisation route prepends), filters to the project by source-path
 containment, and emits ``language=python`` so ingestion routes the records to
 Python's existing frame resolver -- the same resolver the ``sys.monitoring``
 tracer feeds.
+
+JVM frames (``--language jvm``) are managed the same way but carry no usable
+path at all: both symbolisation routes -- the JDK's own perf map
+(``-XX:+DumpPerfMapAtExit`` / ``jcmd Compiler.perfmap``, which perf-map-reading
+profilers surface verbatim) and the OpenTelemetry profiler's HotSpot demangler
+-- emit ``long workload.Service$Inner.spin(workload.Service, int)``. The
+package in the symbol is the path: ``workload/Service`` joins a repository
+source file by suffix, the same package-derived convention the in-process JVM
+agent emits, so ingestion routes ``language=jvm`` records to the existing
+``JvmFrameResolver`` unchanged.
 """
 
 from __future__ import annotations
 
 import posixpath
+import re
 from collections import Counter
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
@@ -98,7 +109,39 @@ _INTERPRETED_NAME_FNS = {
     cs.TRACE_LANGUAGE_PYTHON: _interpreted_name,
 }
 
-_SUPPORTED_LANGUAGES = frozenset(_DEMANGLERS) | frozenset(_INTERPRETED_NAME_FNS)
+# JVM frames are managed-runtime frames too, but they need a dedicated builder
+# (the package inside the symbol is the path), not just a name normaliser.
+_INTERPRETED_LANGUAGES = frozenset(_INTERPRETED_NAME_FNS) | {cs.TRACE_LANGUAGE_JVM}
+
+_SUPPORTED_LANGUAGES = frozenset(_DEMANGLERS) | _INTERPRETED_LANGUAGES
+
+# Synthetic lambda classes carry an address hash after the class chain:
+# ``Service$$Lambda$1/0x00007d62f8000c20`` from the JDK perf map, with the
+# slash rewritten to a dot by the OpenTelemetry demangler.
+_JVM_LAMBDA_HASH = re.compile(r"[/.]0x[0-9a-fA-F]+$")
+
+_JVM_SOURCE_EXTENSIONS = cs.JAVA_EXTENSIONS + cs.SCALA_EXTENSIONS
+
+
+def _jvm_symbol_parts(name: str) -> tuple[str, str, str] | None:
+    """A JVM frame symbol's (package, class chain, method), or ``None``.
+
+    Both real symbolisation routes emit the same grammar, e.g.
+    ``long workload.Service$Inner.spin(workload.Service, int)``: an optional
+    return type, the dotted class FQN with ``$``-separated nesting, the
+    method, and an optional parameter list. VM blobs (``Interpreter``,
+    ``StubRoutines (1)``) and native symbols do not parse as a dotted member
+    and are rejected.
+    """
+    head = name.split("(", 1)[0].rsplit(" ", 1)[-1]
+    class_fqn, sep, method = head.rpartition(cs.SEPARATOR_DOT)
+    if not sep or not method:
+        return None
+    class_fqn = _JVM_LAMBDA_HASH.sub("", class_fqn)
+    package, _, simple = class_fqn.rpartition(cs.SEPARATOR_DOT)
+    if not simple:
+        return None
+    return package, simple, method
 
 
 @dataclass(slots=True)
@@ -303,6 +346,80 @@ class _FrameBuilder:
         )
 
 
+class _JvmFrameBuilder:
+    """Resolves JVM symbol frames to package-derived in-project frames.
+
+    A JVM frame carries no usable native path: the perf-map route has no file
+    and the OpenTelemetry route only a basename. The package in the symbol is
+    the path -- ``workload.Service$Inner.spin`` derives ``workload/Service``
+    and joins a repository source file by suffix, the package-derived
+    convention ``JvmFrameResolver`` already speaks. Frames whose derived path
+    matches no repository source file (JDK and library classes, VM blobs,
+    native symbols) are counted, not resolved, the same visibility contract as
+    unmapped build paths.
+    """
+
+    def __init__(self, profile: _Profile, repo_root: Path) -> None:
+        self._profile = profile
+        self._sources = [
+            path.relative_to(repo_root).as_posix()
+            for ext in _JVM_SOURCE_EXTENSIONS
+            for path in repo_root.rglob(f"*{ext}")
+        ]
+        self._cache: dict[int, FramePoint | None] = {}
+        self.unmapped_paths: Counter[str] = Counter()
+
+    def frame(self, function_id: int) -> FramePoint | None:
+        if function_id not in self._cache:
+            self._cache[function_id] = self._build(function_id)
+        return self._cache[function_id]
+
+    def _build(self, function_id: int) -> FramePoint | None:
+        function = self._profile.functions.get(function_id)
+        strings = self._profile.strings
+        name_index = getattr(function, "name_index", 0)
+        if function is None or not 0 < name_index < len(strings):
+            return None
+        symbol = strings[name_index]
+        parts = _jvm_symbol_parts(symbol)
+        if parts is None:
+            self.unmapped_paths[symbol] += 1
+            return None
+        package, simple, method = parts
+        path = self._project_path(package, simple)
+        if path is None:
+            self.unmapped_paths[_jvm_source_stem(package, simple)] += 1
+            return None
+        return FramePoint(
+            path=path,
+            qualname=f"{simple}{cs.SEPARATOR_DOT}{method}",
+            line=max(getattr(function, "start_line", 0), 0),
+        )
+
+    def _project_path(self, package: str, simple: str) -> str | None:
+        stem = _jvm_source_stem(package, simple)
+        for ext in _JVM_SOURCE_EXTENSIONS:
+            candidate = stem + ext
+            suffix = cs.SEPARATOR_SLASH + candidate
+            if any(
+                source == candidate or source.endswith(suffix)
+                for source in self._sources
+            ):
+                return candidate
+        return None
+
+
+def _jvm_source_stem(package: str, simple: str) -> str:
+    """The package-derived source path of a class chain, without extension.
+
+    The outermost class names the file; nested, anonymous, and synthetic
+    lambda classes all live in it. A Scala object's trailing ``$`` falls away
+    with the split.
+    """
+    outer = simple.split(cs.TRACE_JVM_NESTED_MARKER, 1)[0]
+    return posixpath.join(package.replace(cs.SEPARATOR_DOT, cs.SEPARATOR_SLASH), outer)
+
+
 def _mapping_selected(
     location: _Location, profile: _Profile, build_id: str | None
 ) -> bool:
@@ -338,7 +455,7 @@ def _mapping_name(profile: _Profile, location: _Location) -> str:
 def _resolved_frames(
     sample: _LabeledSample,
     profile: _Profile,
-    builder: _FrameBuilder,
+    builder: _FrameBuilder | _JvmFrameBuilder,
     build_id: str | None,
     unsymbolised: Counter[str],
     *,
@@ -374,7 +491,7 @@ def _resolved_frames(
 
 def _accumulate(
     profile: _Profile,
-    builder: _FrameBuilder,
+    builder: _FrameBuilder | _JvmFrameBuilder,
     *,
     build_id: str | None,
     service: tuple[str, str] | None,
@@ -443,12 +560,12 @@ def convert_ebpf_pprof(
     ``build_id`` filters to one binary's mapping; ``service`` (a ``key, value``
     pair) filters samples; ``workload_label`` maps a sample label to per-edge
     ``workloads``; ``language`` selects the symbol demangler (native runtimes)
-    or the interpreted-frame name normaliser (Python), the latter reusing the
-    language's existing ingest-time frame resolver.
+    or the managed-runtime frame path (Python name normalisation, JVM
+    package-derived paths), the latter reusing the language's existing
+    ingest-time frame resolver.
     """
-    interpreted = language in _INTERPRETED_NAME_FNS
-    name_fn = _INTERPRETED_NAME_FNS.get(language) or _DEMANGLERS.get(language)
-    if name_fn is None:
+    interpreted = language in _INTERPRETED_LANGUAGES
+    if language not in _SUPPORTED_LANGUAGES:
         raise TraceFormatError(
             cs.TRACE_ERR_EBPF_LANGUAGE.format(
                 language=language, supported=", ".join(sorted(_SUPPORTED_LANGUAGES))
@@ -462,8 +579,13 @@ def convert_ebpf_pprof(
     if not profile.strings or not profile.functions or not profile.samples:
         raise TraceFormatError(cs.TRACE_ERR_BAD_PPROF.format(path=profile_path))
 
-    root_prefix = repo_root.resolve().as_posix() + "/"
-    builder = _FrameBuilder(profile, root_prefix, path_map or [], name_fn)
+    builder: _FrameBuilder | _JvmFrameBuilder
+    if language == cs.TRACE_LANGUAGE_JVM:
+        builder = _JvmFrameBuilder(profile, repo_root)
+    else:
+        root_prefix = repo_root.resolve().as_posix() + "/"
+        name_fn = _INTERPRETED_NAME_FNS.get(language) or _DEMANGLERS[language]
+        builder = _FrameBuilder(profile, root_prefix, path_map or [], name_fn)
     edges, unsymbolised = _accumulate(
         profile,
         builder,

--- a/docs/guide/dynamic-tracing.md
+++ b/docs/guide/dynamic-tracing.md
@@ -525,7 +525,9 @@ JVM `-XX:+PreserveFramePointer` or the profiler cannot unwind through JIT
 frames at all, and expect inlining to hide callees, since the JIT aggressively
 inlines hot methods and a perf-map symbol only names the outermost one. A
 Scala class whose source file does not share the class's name derives a path
-that matches no file and is counted unmapped.
+that matches no file and is counted unmapped, and so is a class whose stem
+matches both a Java and a Scala file, since the symbol carries no
+source-language discriminator to pick between them.
 
 Like every eBPF profile, these profiles are sampled: ingested edges carry
 `dynamic_sampled: true` and their `dynamic_call_count` is an approximate sample

--- a/docs/guide/dynamic-tracing.md
+++ b/docs/guide/dynamic-tracing.md
@@ -482,7 +482,7 @@ wall-clock** profiles use the same pprof format and convert through the same
 I/O-bound paths (a handler that lives in `await`) that a CPU profile barely
 samples.
 
-### Interpreted runtimes (`--language python`)
+### Managed runtimes (`--language python`, `--language jvm`)
 
 The `--language go`/`rust`/`cpp` paths above cover natively compiled binaries,
 whose frames are addresses in the target's own binary. eBPF profilers
@@ -509,10 +509,28 @@ reported like any other unmapped path, never silently dropped. `--path-map` maps
 the container/build source root to the repository the same way it does for native
 frames.
 
-Like every eBPF profile, Python profiles are sampled: ingested edges carry
+JVM frames take the same road with `--language jvm`, but the symbol itself is
+the path. Both real symbolisation routes emit the same grammar, e.g.
+`long workload.Service$Inner.spin(workload.Service, int)`: the JDK's own perf
+map (`-XX:+DumpPerfMapAtExit` on JDK 17+, or `jcmd <pid> Compiler.perfmap`,
+which perf-map-reading profilers surface verbatim) and the OpenTelemetry
+profiler's HotSpot demangler. The converter strips the return type and the
+parameter list and derives the frame's path from the package
+(`workload/Service.java`), the same package-derived convention the in-process
+JVM agent emits, so ingestion routes the records to the existing JVM frame
+resolver. Frames whose derived path matches no source file in the repository
+(JDK and library classes, VM blobs like `Interpreter`, native symbols) are
+counted and reported, never edge endpoints. Two JVM-specific caveats: give the
+JVM `-XX:+PreserveFramePointer` or the profiler cannot unwind through JIT
+frames at all, and expect inlining to hide callees, since the JIT aggressively
+inlines hot methods and a perf-map symbol only names the outermost one. A
+Scala class whose source file does not share the class's name derives a path
+that matches no file and is counted unmapped.
+
+Like every eBPF profile, these profiles are sampled: ingested edges carry
 `dynamic_sampled: true` and their `dynamic_call_count` is an approximate sample
-count, not the exact per-call total the in-process `sys.monitoring` Python tracer
-records.
+count, not the exact per-call total the in-process tracers (`sys.monitoring`,
+the JVM agent) record.
 
 ## Ingesting a trace
 


### PR DESCRIPTION
Closes out the JVM half of #1287's interpreted/managed-runtime follow-up, the same way #1297 did for Python: the frame grammar was captured from a real JDK 17 workload, not assumed.

## What

`cgr trace convert prod.pb.gz --format ebpf --language jvm` now resolves JVM frames from eBPF continuous-profiler pprof profiles and emits `language=jvm` records, which ingestion routes to the existing `JvmFrameResolver` with zero ingest changes.

## The real frame shapes (captured, then confirmed upstream)

Captured on this JDK 17 workload via `-XX:+DumpPerfMapAtExit` (the perf map that perf-map-reading profilers surface verbatim), and confirmed identical to the OpenTelemetry eBPF profiler's HotSpot demangler output (`interpreter/hotspot/demangle.go` builds the same `ret pkg.Class.method(params)` string, dots for slashes):

```
long workload.Service$Inner.spin(workload.Service, int)
void workload.Service$$Lambda$1/0x00007d62f8000c20.run()
void workload.Service.lambda$main$0(workload.Service)
int java.lang.Object.hashCode()
Interpreter
```

The perf-map route carries no file and no line; the OTel route adds a source basename and a line. Either way the filename field is useless for repo joining, so **the package in the symbol is the path**: `workload.Service$Inner.spin` derives `workload/Service.java`, exactly the package-derived suffix convention `JvmFrameResolver` already speaks for the in-process JVM agent.

## How

- `_jvm_symbol_parts` parses the shared grammar (optional return type, dotted FQN with `$` nesting, optional parameter list); VM blobs (`Interpreter`, `StubRoutines (1)`) and native symbols do not parse and are counted, not resolved. Synthetic lambda-class address hashes are stripped in both spellings (`/0x...` perf-map, `.0x...` after OTel's dot rewrite).
- `_JvmFrameBuilder` scopes frames to the project by checking the derived path against the repository's actual `.java`/`.scala`/`.sc` files (suffix match), the JVM analogue of the Python path's source-containment check. JDK/library classes fall out here and are reported via the existing unmapped-path counter.
- Like the Python path, JVM frames bypass the `--build-id` mapping filter (JIT code lives in anonymous mappings with no build id).
- Docs: the interpreted-runtimes section is now "Managed runtimes" and covers the JVM recipe plus its two operational caveats (`-XX:+PreserveFramePointer`, JIT inlining hiding callees).

## Tests

All fixture symbols are verbatim strings from the real capture. Coverage: package-derived paths and `$` chains survive to the resolver; the OTel-shaped frame keeps its definition line; JDK classes and VM blobs are seen through and counted; the symbol grammar table (constructors, Scala objects, default package, both lambda-hash spellings, native rejects); and an end-to-end convert-then-ingest through the real `JvmFrameResolver` binding to METHOD nodes with `dynamic_sampled: true`, with the line-less synthetic lambda frame counted unresolved rather than misbound.

Remaining in #1287: Ruby frames are structurally blocked on Ruby graph support (#118); there are no Ruby nodes to bind to.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JVM support for managed-runtime eBPF profiling.
  * JVM symbols can be mapped to Java and Scala source paths, including nested classes and lambdas.
  * Added support for perf-map and OpenTelemetry symbol formats.
  * Added filtering for irrelevant JDK and virtual-machine frames.
  * Improved reporting for unresolved and unmapped frames, including sampled-edge details.

* **Documentation**
  * Updated CLI help and tracing guidance with JVM profiling support, limitations, and sampling details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->