### PR TITLE
feat: type Python loop variables from generic return annotations

### DIFF
--- a/codebase_rag/constants/ast_python.py
+++ b/codebase_rag/constants/ast_python.py
@@ -105,7 +105,9 @@ PY_GENERIC_CONTAINER_PATTERN = (
     r"AsyncIterator|AsyncIterable)\[(?P<inner>.+)\]$"
 )
 PY_TUPLE_CONTAINERS = frozenset({"tuple", "Tuple"})
-PY_GENERATOR_CONTAINERS = frozenset({"Generator", "AsyncGenerator"})
+# Yield type first; Generator[Y, S, R] takes up to three parameters while
+# AsyncGenerator[Y, S] takes up to two.
+PY_GENERATOR_ARG_LIMITS = {"Generator": 3, "AsyncGenerator": 2}
 PY_ELLIPSIS = "..."
 PY_OPTIONAL_PATTERN = r"^(?:typing\.)?Optional\[(?P<inner>.+)\]$"
 PY_LIST_TYPE_PREFIX = "list["

--- a/codebase_rag/constants/ast_python.py
+++ b/codebase_rag/constants/ast_python.py
@@ -96,6 +96,17 @@ PY_UNION_SEPARATOR = "|"
 PY_NONE = "None"
 # `-> Self` names the enclosing class, not a class called Self.
 PY_ANNOTATION_SELF = "Self"
+# Homogeneous-container return annotations (`-> list[Widget]`): the container
+# spelling is irrelevant downstream, only "iterable of element" survives, in
+# the canonical `list[<element>]` marker consumed by loop-variable inference.
+PY_GENERIC_CONTAINER_PATTERN = (
+    r"^(?:typing\.)?(?:list|List|set|Set|frozenset|FrozenSet|tuple|Tuple|"
+    r"Sequence|Collection|Iterable|Iterator|Generator|AsyncGenerator|"
+    r"AsyncIterator|AsyncIterable)\[(?P<inner>.+)\]$"
+)
+PY_OPTIONAL_PATTERN = r"^(?:typing\.)?Optional\[(?P<inner>.+)\]$"
+PY_LIST_TYPE_PREFIX = "list["
+PY_LIST_TYPE_FORMAT = "list[{element}]"
 
 PY_KEYWORD_SELF = "self"
 PY_KEYWORD_CLS = "cls"

--- a/codebase_rag/constants/ast_python.py
+++ b/codebase_rag/constants/ast_python.py
@@ -100,10 +100,13 @@ PY_ANNOTATION_SELF = "Self"
 # spelling is irrelevant downstream, only "iterable of element" survives, in
 # the canonical `list[<element>]` marker consumed by loop-variable inference.
 PY_GENERIC_CONTAINER_PATTERN = (
-    r"^(?:typing\.)?(?:list|List|set|Set|frozenset|FrozenSet|tuple|Tuple|"
+    r"^(?:typing\.)?(?P<name>list|List|set|Set|frozenset|FrozenSet|tuple|Tuple|"
     r"Sequence|Collection|Iterable|Iterator|Generator|AsyncGenerator|"
     r"AsyncIterator|AsyncIterable)\[(?P<inner>.+)\]$"
 )
+PY_TUPLE_CONTAINERS = frozenset({"tuple", "Tuple"})
+PY_GENERATOR_CONTAINERS = frozenset({"Generator", "AsyncGenerator"})
+PY_ELLIPSIS = "..."
 PY_OPTIONAL_PATTERN = r"^(?:typing\.)?Optional\[(?P<inner>.+)\]$"
 PY_LIST_TYPE_PREFIX = "list["
 PY_LIST_TYPE_FORMAT = "list[{element}]"

--- a/codebase_rag/parsers/py/ast_analyzer.py
+++ b/codebase_rag/parsers/py/ast_analyzer.py
@@ -35,8 +35,8 @@ def _homogeneous_element(name: str, inner: str) -> str | None:
         if len(parts) == 1 or (len(parts) == 2 and parts[1] == cs.PY_ELLIPSIS):
             return parts[0]
         return None
-    if name in cs.PY_GENERATOR_CONTAINERS:
-        return parts[0] if len(parts) <= 3 else None
+    if limit := cs.PY_GENERATOR_ARG_LIMITS.get(name):
+        return parts[0] if len(parts) <= limit else None
     return parts[0] if len(parts) == 1 else None
 
 

--- a/codebase_rag/parsers/py/ast_analyzer.py
+++ b/codebase_rag/parsers/py/ast_analyzer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Protocol
 
@@ -377,10 +378,12 @@ class PythonAstAnalyzerMixin(_AstBase):
     def _annotated_return_type(
         self, method_node: Node, method_qn: str, module_qn: str
     ) -> str | None:
-        # A declared `-> Widget` (or `-> Widget | None`, or the quoted forward-ref
-        # form) is the cheapest, most reliable return-type source; only a simple or
-        # dotted name is trusted, generics and multi-type unions fall through to
-        # body inference.
+        # A declared `-> Widget` (or `-> Widget | None`, the quoted forward-ref
+        # form, `-> Self`, or a homogeneous container like `-> list[Widget]`)
+        # is the cheapest, most reliable return-type source; anything else
+        # falls through to body inference. A container annotation produces the
+        # canonical `list[<element>]` marker so loop-variable inference can
+        # recover the element (issue #1304).
         type_node = method_node.child_by_field_name(cs.FIELD_RETURN_TYPE)
         if type_node is None or type_node.text is None:
             return None
@@ -393,6 +396,23 @@ class PythonAstAnalyzerMixin(_AstBase):
         if len(non_none) != 1:
             return None
         candidate = non_none[0]
+        if optional := re.match(cs.PY_OPTIONAL_PATTERN, candidate):
+            candidate = optional.group("inner").strip()
+        if container := re.match(cs.PY_GENERIC_CONTAINER_PATTERN, candidate):
+            # Generator[Widget, None, None] yields its first argument;
+            # tuple[Widget, ...] is homogeneous. A non-simple element
+            # (dict[str, X], nested generics) fails the trust check below.
+            element_text = container.group("inner").split(cs.CHAR_COMMA)[0].strip()
+            element = self._trusted_annotation_name(
+                element_text.strip("\"'"), method_qn, module_qn
+            )
+            return cs.PY_LIST_TYPE_FORMAT.format(element=element) if element else None
+        return self._trusted_annotation_name(candidate, method_qn, module_qn)
+
+    def _trusted_annotation_name(
+        self, candidate: str, method_qn: str, module_qn: str
+    ) -> str | None:
+        """A simple or dotted annotation name resolved in scope, else ``None``."""
         if not all(part.isidentifier() for part in candidate.split(cs.SEPARATOR_DOT)):
             return None
         if candidate == cs.PY_ANNOTATION_SELF:

--- a/codebase_rag/parsers/py/ast_analyzer.py
+++ b/codebase_rag/parsers/py/ast_analyzer.py
@@ -20,6 +20,26 @@ _PY_TRAVERSE_QUERY = (
     f"({cs.TS_PY_RETURN_STATEMENT}) @return_stmt"
 )
 
+
+def _homogeneous_element(name: str, inner: str) -> str | None:
+    """The single element type a container annotation guarantees, else ``None``.
+
+    ``tuple[Widget, Banner]`` guarantees nothing about a given element, so
+    only ``tuple[Widget]`` and the homogeneous ``tuple[Widget, ...]`` pass;
+    generators yield their first argument; every other container takes
+    exactly one. A nested-generic first argument survives to the caller's
+    trust check, which rejects it.
+    """
+    parts = [part.strip() for part in inner.split(cs.CHAR_COMMA)]
+    if name in cs.PY_TUPLE_CONTAINERS:
+        if len(parts) == 1 or (len(parts) == 2 and parts[1] == cs.PY_ELLIPSIS):
+            return parts[0]
+        return None
+    if name in cs.PY_GENERATOR_CONTAINERS:
+        return parts[0] if len(parts) <= 3 else None
+    return parts[0] if len(parts) == 1 else None
+
+
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
     from pathlib import Path
@@ -91,7 +111,10 @@ class PythonAstAnalyzerMixin(_AstBase):
 
     def _traverse_single_pass(
         self, node: Node, local_var_types: dict[str, str], module_qn: str
-    ) -> None:
+    ) -> tuple[list[Node], list[Node]]:
+        """Types locals in one traversal; returns (comprehensions, for
+        statements) so the coordinator can re-run loop inference after the
+        attribute passes populate ``self.x`` types."""
         assignments: list[Node] = []
         comprehensions: list[Node] = []
         for_statements: list[Node] = []
@@ -141,6 +164,7 @@ class PythonAstAnalyzerMixin(_AstBase):
         self._infer_instance_variable_types_from_assignments(
             assignments, local_var_types, module_qn
         )
+        return comprehensions, for_statements
 
     def _process_assignment_simple(
         self, assignment_node: Node, local_var_types: dict[str, str], module_qn: str
@@ -399,10 +423,11 @@ class PythonAstAnalyzerMixin(_AstBase):
         if optional := re.match(cs.PY_OPTIONAL_PATTERN, candidate):
             candidate = optional.group("inner").strip()
         if container := re.match(cs.PY_GENERIC_CONTAINER_PATTERN, candidate):
-            # Generator[Widget, None, None] yields its first argument;
-            # tuple[Widget, ...] is homogeneous. A non-simple element
-            # (dict[str, X], nested generics) fails the trust check below.
-            element_text = container.group("inner").split(cs.CHAR_COMMA)[0].strip()
+            element_text = _homogeneous_element(
+                container.group("name"), container.group("inner")
+            )
+            if element_text is None:
+                return None
             element = self._trusted_annotation_name(
                 element_text.strip("\"'"), method_qn, module_qn
             )

--- a/codebase_rag/parsers/py/expression_analyzer.py
+++ b/codebase_rag/parsers/py/expression_analyzer.py
@@ -59,10 +59,14 @@ class PythonExpressionAnalyzerMixin(_ExprBase):
                 func_node
                 and func_node.type == cs.TS_PY_IDENTIFIER
                 and func_node.text is not None
-                and (class_name := safe_decode_text(func_node))
-                and class_name[0].isupper()
+                and (callee := safe_decode_text(func_node))
             ):
-                return class_name
+                if callee[0].isupper():
+                    return callee
+                # A lowercase callee is a free-function factory: type from its
+                # return (annotation first), so `self.widgets = load_widgets()`
+                # seeds the attribute for methods that only read it.
+                return self._infer_free_function_return_type(callee, module_qn)
 
             if (
                 func_node

--- a/codebase_rag/parsers/py/type_inference.py
+++ b/codebase_rag/parsers/py/type_inference.py
@@ -92,12 +92,21 @@ class PythonTypeInferenceEngine(
         try:
             self._infer_parameter_types(caller_node, local_var_types, module_qn)
             # Single-pass traversal avoids O(5*N) traversals for type inference.
-            self._traverse_single_pass(caller_node, local_var_types, module_qn)
+            comprehensions, for_statements = self._traverse_single_pass(
+                caller_node, local_var_types, module_qn
+            )
             self._infer_instance_attributes_from_init(
                 caller_node, local_var_types, module_qn
             )
             self._infer_property_return_types(caller_node, local_var_types, module_qn)
             self._infer_class_annotation_types(caller_node, local_var_types, module_qn)
+            # Attribute-backed iterables (`for w in self.widgets`) only type
+            # after the attribute passes above populated `self.x`; re-running
+            # the loop analyzers picks them up (they never downgrade a type).
+            for comp in comprehensions:
+                self._analyze_comprehension(comp, local_var_types, module_qn)
+            for for_stmt in for_statements:
+                self._analyze_for_loop(for_stmt, local_var_types, module_qn)
             aliases = self._collect_local_aliases(caller_node)
             self._expand_chained_attribute_types(local_var_types, module_qn, aliases)
 

--- a/codebase_rag/parsers/py/type_inference.py
+++ b/codebase_rag/parsers/py/type_inference.py
@@ -91,7 +91,6 @@ class PythonTypeInferenceEngine(
 
         try:
             self._infer_parameter_types(caller_node, local_var_types, module_qn)
-            self._seed_self_receiver_type(caller_node, local_var_types, module_qn)
             # Single-pass traversal avoids O(5*N) traversals for type inference.
             comprehensions, for_statements = self._traverse_single_pass(
                 caller_node, local_var_types, module_qn

--- a/codebase_rag/parsers/py/type_inference.py
+++ b/codebase_rag/parsers/py/type_inference.py
@@ -91,6 +91,7 @@ class PythonTypeInferenceEngine(
 
         try:
             self._infer_parameter_types(caller_node, local_var_types, module_qn)
+            self._seed_self_receiver_type(caller_node, local_var_types, module_qn)
             # Single-pass traversal avoids O(5*N) traversals for type inference.
             comprehensions, for_statements = self._traverse_single_pass(
                 caller_node, local_var_types, module_qn

--- a/codebase_rag/parsers/py/variable_analyzer.py
+++ b/codebase_rag/parsers/py/variable_analyzer.py
@@ -21,6 +21,10 @@ if TYPE_CHECKING:
 
         def _find_class_node(self, class_qn: str) -> ASTNode | None: ...
 
+        def _find_class_in_scope(
+            self, class_name: str, module_qn: str
+        ) -> str | None: ...
+
         def _infer_method_call_return_type(
             self,
             method_call: str,
@@ -330,6 +334,23 @@ class PythonVariableAnalyzerMixin(_VarBase):
             if current.type == cs.TS_PY_ASSIGNMENT:
                 self._process_self_assignment(current, local_var_types, module_qn)
             stack.extend(reversed(current.children))
+
+    def _seed_self_receiver_type(
+        self, caller_node: ASTNode, local_var_types: dict[str, str], module_qn: str
+    ) -> None:
+        """Seed ``self`` with the enclosing class so ``self.helper()``
+        receivers resolve through the class's own methods (issue #1304
+        review: ``for w in self.load_widgets():``)."""
+        if cs.PY_KEYWORD_SELF in local_var_types:
+            return
+        if (class_node := self._enclosing_class_node(caller_node)) is None:
+            return
+        name_node = class_node.child_by_field_name(cs.FIELD_NAME)
+        if name_node is None or not (class_name := safe_decode_text(name_node)):
+            return
+        local_var_types[cs.PY_KEYWORD_SELF] = (
+            self._find_class_in_scope(class_name, module_qn) or class_name
+        )
 
     def _enclosing_class_node(self, node: ASTNode) -> ASTNode | None:
         current = node.parent

--- a/codebase_rag/parsers/py/variable_analyzer.py
+++ b/codebase_rag/parsers/py/variable_analyzer.py
@@ -21,9 +21,27 @@ if TYPE_CHECKING:
 
         def _find_class_node(self, class_qn: str) -> ASTNode | None: ...
 
+        def _infer_method_call_return_type(
+            self,
+            method_call: str,
+            module_qn: str,
+            local_var_types: dict[str, str] | None = None,
+        ) -> str | None: ...
+
     _VarBase: type = _VariableAnalyzerDeps
 else:
     _VarBase = object
+
+
+def _container_element_type(type_str: str | None) -> str | None:
+    """The element inside a canonical ``list[<element>]`` marker, else ``None``."""
+    if (
+        type_str
+        and type_str.startswith(cs.PY_LIST_TYPE_PREFIX)
+        and type_str.endswith("]")
+    ):
+        return type_str[len(cs.PY_LIST_TYPE_PREFIX) : -1] or None
+    return None
 
 
 class PythonVariableAnalyzerMixin(_VarBase):
@@ -208,6 +226,28 @@ class PythonVariableAnalyzerMixin(_VarBase):
     ) -> str | None:
         if iterable_node.type == cs.TS_PY_LIST:
             return self._infer_list_element_type(iterable_node)
+
+        if iterable_node.type == cs.TS_PY_CALL:
+            # `for w in load_widgets():` types through the callee's container
+            # return annotation (`-> list[Widget]`); a scalar return is not an
+            # element type, so only the container marker unwraps.
+            call_text = safe_decode_text(iterable_node)
+            if not call_text:
+                return None
+            return _container_element_type(
+                self._infer_method_call_return_type(
+                    call_text, module_qn, local_var_types
+                )
+            )
+
+        if iterable_node.type == cs.TS_PY_ATTRIBUTE:
+            # `for w in self.widgets:` reads the attribute's already-inferred
+            # container type (keyed as `self.widgets` by the self-assignment
+            # pass).
+            attr_text = safe_decode_text(iterable_node)
+            if not attr_text:
+                return None
+            return _container_element_type(local_var_types.get(attr_text))
 
         if (
             iterable_node.type != cs.TS_PY_IDENTIFIER
@@ -542,7 +582,9 @@ class PythonVariableAnalyzerMixin(_VarBase):
             and (var_type := local_var_types[var_name])
             and var_type != cs.TYPE_INFERENCE_LIST
         ):
-            return var_type
+            # A container-marked variable (`widgets = load_widgets()` with a
+            # `-> list[Widget]` annotation) iterates as its element type.
+            return _container_element_type(var_type) or var_type
         return self._infer_method_return_element_type(var_name, module_qn)
 
     def _infer_method_return_element_type(

--- a/codebase_rag/parsers/py/variable_analyzer.py
+++ b/codebase_rag/parsers/py/variable_analyzer.py
@@ -32,6 +32,8 @@ if TYPE_CHECKING:
             local_var_types: dict[str, str] | None = None,
         ) -> str | None: ...
 
+        def _get_method_return_type_from_ast(self, method_qn: str) -> str | None: ...
+
     _VarBase: type = _VariableAnalyzerDeps
 else:
     _VarBase = object
@@ -234,7 +236,9 @@ class PythonVariableAnalyzerMixin(_VarBase):
         if iterable_node.type == cs.TS_PY_CALL:
             # `for w in load_widgets():` types through the callee's container
             # return annotation (`-> list[Widget]`); a scalar return is not an
-            # element type, so only the container marker unwraps.
+            # element type, so only the container marker unwraps. A
+            # `self.load_more()` iterable falls back to the enclosing class's
+            # own method.
             call_text = safe_decode_text(iterable_node)
             if not call_text:
                 return None
@@ -242,6 +246,7 @@ class PythonVariableAnalyzerMixin(_VarBase):
                 self._infer_method_call_return_type(
                     call_text, module_qn, local_var_types
                 )
+                or self._self_method_element_type(iterable_node, module_qn)
             )
 
         if iterable_node.type == cs.TS_PY_ATTRIBUTE:
@@ -335,21 +340,38 @@ class PythonVariableAnalyzerMixin(_VarBase):
                 self._process_self_assignment(current, local_var_types, module_qn)
             stack.extend(reversed(current.children))
 
-    def _seed_self_receiver_type(
-        self, caller_node: ASTNode, local_var_types: dict[str, str], module_qn: str
-    ) -> None:
-        """Seed ``self`` with the enclosing class so ``self.helper()``
-        receivers resolve through the class's own methods (issue #1304
-        review: ``for w in self.load_widgets():``)."""
-        if cs.PY_KEYWORD_SELF in local_var_types:
-            return
-        if (class_node := self._enclosing_class_node(caller_node)) is None:
-            return
+    def _self_method_element_type(
+        self, call_node: ASTNode, module_qn: str
+    ) -> str | None:
+        """The return type of a ``self.m()`` call, resolved on the enclosing
+        class.
+
+        Deliberately scoped to iterable position: a general ``self`` receiver
+        must stay override-aware (an abstract stub's concrete sibling wins),
+        but an iterated call only needs the visible method's container
+        annotation.
+        """
+        func_node = call_node.child_by_field_name(cs.TS_FIELD_FUNCTION)
+        if func_node is None or func_node.type != cs.TS_PY_ATTRIBUTE:
+            return None
+        text = safe_decode_text(func_node)
+        if not text or not text.startswith(cs.PY_SELF_PREFIX):
+            return None
+        parts = text.split(cs.SEPARATOR_DOT)
+        if len(parts) != 2:
+            return None
+        if (class_node := self._enclosing_class_node(call_node)) is None:
+            return None
         name_node = class_node.child_by_field_name(cs.FIELD_NAME)
         if name_node is None or not (class_name := safe_decode_text(name_node)):
-            return
-        local_var_types[cs.PY_KEYWORD_SELF] = (
-            self._find_class_in_scope(class_name, module_qn) or class_name
+            return None
+        class_qn = self._find_class_in_scope(class_name, module_qn) or class_name
+        if cs.SEPARATOR_DOT not in class_qn:
+            # A same-module class resolves to its bare name; the method lookup
+            # needs the full module.Class.method shape.
+            class_qn = f"{module_qn}{cs.SEPARATOR_DOT}{class_qn}"
+        return self._get_method_return_type_from_ast(
+            f"{class_qn}{cs.SEPARATOR_DOT}{parts[1]}"
         )
 
     def _enclosing_class_node(self, node: ASTNode) -> ASTNode | None:

--- a/codebase_rag/tests/test_python_return_type_inference.py
+++ b/codebase_rag/tests/test_python_return_type_inference.py
@@ -502,7 +502,13 @@ def load_widgets() -> list[Widget]:
 def fetch_widgets() -> "Sequence[Widget]":
     return json.loads("[]")
 
+def stream_widgets() -> tuple[Widget, ...]:
+    return json.loads("[]")
+
 class Screen:
+    def __init__(self):
+        self.widgets = load_widgets()
+
     def draw_direct(self):
         for w in load_widgets():
             w.render()
@@ -514,6 +520,14 @@ class Screen:
 
     def draw_sequence(self):
         for w in fetch_widgets():
+            w.render()
+
+    def draw_attribute(self):
+        for w in self.widgets:
+            w.render()
+
+    def draw_homogeneous_tuple(self):
+        for w in stream_widgets():
             w.render()
 """,
     )
@@ -537,7 +551,13 @@ class Screen:
     decoy = f"{project_name}.app.Banner.render"
     missing = [
         (caller, render)
-        for method in ("draw_direct", "draw_stored", "draw_sequence")
+        for method in (
+            "draw_direct",
+            "draw_stored",
+            "draw_sequence",
+            "draw_attribute",
+            "draw_homogeneous_tuple",
+        )
         if ((caller := f"{project_name}.app.Screen.{method}"), render)
         not in found_method_calls
     ]
@@ -545,3 +565,19 @@ class Screen:
         pytest.fail(f"Missing generic-annotation loop calls: {missing}")
     # The annotation names Widget, so the decoy must never be linked.
     assert not any(callee == decoy for _caller, callee in found_method_calls)
+
+
+def test_homogeneous_element_rules():
+    # A heterogeneous tuple guarantees nothing about a given element, so it
+    # must never type a loop variable as its first member (the untyped frame
+    # then falls to the resolver's pre-existing bare-name behaviour).
+    from codebase_rag.parsers.py.ast_analyzer import _homogeneous_element
+
+    assert _homogeneous_element("tuple", "Widget") == "Widget"
+    assert _homogeneous_element("tuple", "Widget, ...") == "Widget"
+    assert _homogeneous_element("tuple", "Widget, Banner") is None
+    assert _homogeneous_element("Tuple", "Widget, Banner, Panel") is None
+    assert _homogeneous_element("Generator", "Widget, None, None") == "Widget"
+    assert _homogeneous_element("Generator", "Widget, None, None, X") is None
+    assert _homogeneous_element("list", "Widget") == "Widget"
+    assert _homogeneous_element("list", "Widget, Banner") is None

--- a/codebase_rag/tests/test_python_return_type_inference.py
+++ b/codebase_rag/tests/test_python_return_type_inference.py
@@ -471,3 +471,77 @@ def test_loop_variable_return_types(
 
     if missing_calls:
         pytest.fail(f"Missing loop variable return type calls: {missing_calls}")
+
+
+def test_generic_return_annotation_types_loop_variables(
+    tmp_path: Path, mock_ingestor: MagicMock
+) -> None:
+    # A `-> list[Widget]` annotation is the only evidence here: the bodies
+    # return through opaque calls, so body inference yields nothing and the
+    # loop variables can only type through the parsed generic (issue #1304).
+    project_path = tmp_path / "generic_annotation_test"
+    project_path.mkdir()
+    (project_path / "__init__.py").write_text(encoding="utf-8", data="")
+    (project_path / "app.py").write_text(
+        encoding="utf-8",
+        data="""import json
+
+class Widget:
+    def render(self) -> str:
+        return "w"
+
+class Banner:
+    # Decoy: shares the method name so the bare-name fallback is ambiguous
+    # and only a typed receiver can bind the calls below.
+    def render(self) -> str:
+        return "b"
+
+def load_widgets() -> list[Widget]:
+    return json.loads("[]")
+
+def fetch_widgets() -> "Sequence[Widget]":
+    return json.loads("[]")
+
+class Screen:
+    def draw_direct(self):
+        for w in load_widgets():
+            w.render()
+
+    def draw_stored(self):
+        widgets = load_widgets()
+        for w in widgets:
+            w.render()
+
+    def draw_sequence(self):
+        for w in fetch_widgets():
+            w.render()
+""",
+    )
+
+    parsers, queries = load_parsers()
+    updater = GraphUpdater(
+        ingestor=mock_ingestor,
+        repo_path=project_path,
+        parsers=parsers,
+        queries=queries,
+    )
+    updater.run()
+
+    project_name = project_path.name
+    found_method_calls = {
+        (c[0][0][2], c[0][2][2])
+        for c in mock_ingestor.ensure_relationship_batch.call_args_list
+        if len(c[0]) >= 3 and c[0][1] == "CALLS" and c[0][2][0] == NodeType.METHOD
+    }
+    render = f"{project_name}.app.Widget.render"
+    decoy = f"{project_name}.app.Banner.render"
+    missing = [
+        (caller, render)
+        for method in ("draw_direct", "draw_stored", "draw_sequence")
+        if ((caller := f"{project_name}.app.Screen.{method}"), render)
+        not in found_method_calls
+    ]
+    if missing:
+        pytest.fail(f"Missing generic-annotation loop calls: {missing}")
+    # The annotation names Widget, so the decoy must never be linked.
+    assert not any(callee == decoy for _caller, callee in found_method_calls)

--- a/codebase_rag/tests/test_python_return_type_inference.py
+++ b/codebase_rag/tests/test_python_return_type_inference.py
@@ -505,6 +505,9 @@ def fetch_widgets() -> "Sequence[Widget]":
 def stream_widgets() -> tuple[Widget, ...]:
     return json.loads("[]")
 
+def opt_widgets() -> Optional[list[Widget]]:
+    return json.loads("[]")
+
 class Screen:
     def __init__(self):
         self.widgets = load_widgets()
@@ -528,6 +531,17 @@ class Screen:
 
     def draw_homogeneous_tuple(self):
         for w in stream_widgets():
+            w.render()
+
+    def draw_optional(self):
+        for w in opt_widgets():
+            w.render()
+
+    def load_more(self) -> list[Widget]:
+        return json.loads("[]")
+
+    def draw_self_method(self):
+        for w in self.load_more():
             w.render()
 """,
     )
@@ -557,6 +571,8 @@ class Screen:
             "draw_sequence",
             "draw_attribute",
             "draw_homogeneous_tuple",
+            "draw_optional",
+            "draw_self_method",
         )
         if ((caller := f"{project_name}.app.Screen.{method}"), render)
         not in found_method_calls
@@ -579,5 +595,8 @@ def test_homogeneous_element_rules():
     assert _homogeneous_element("Tuple", "Widget, Banner, Panel") is None
     assert _homogeneous_element("Generator", "Widget, None, None") == "Widget"
     assert _homogeneous_element("Generator", "Widget, None, None, X") is None
+    # AsyncGenerator takes yield and send types only, never a return type.
+    assert _homogeneous_element("AsyncGenerator", "Widget, None") == "Widget"
+    assert _homogeneous_element("AsyncGenerator", "Widget, None, None") is None
     assert _homogeneous_element("list", "Widget") == "Widget"
     assert _homogeneous_element("list", "Widget, Banner") is None


### PR DESCRIPTION
Closes #1304.

## Scope correction first

The retired TODO entry this issue came from was partially stale: simple, dotted, `X | None`, quoted forward-ref, and `Self` return annotations are already parsed (`_annotated_return_type`, added in 573fd82b) and tried before body inference. What was genuinely missing is the generic case the TODO's own example showed: `-> list[User]` deliberately fell through to body inference, discarding the element type, and loop-variable inference could not see through calls or container-typed variables at all (it fell back to a plural-name "Repository" heuristic).

## What this does

`_annotated_return_type` now recognises homogeneous container annotations: `list/set/frozenset/tuple/Sequence/Collection/Iterable/Iterator/Generator` and their `typing.`-qualified and async spellings, plus an `Optional[...]` unwrap. The container spelling is irrelevant downstream, so the result is a canonical `list[<element>]` marker with the element resolved in scope (`Generator[W, None, None]` yields its first argument; `tuple[W, ...]` is homogeneous; a non-simple element like `dict[str, X]` fails the existing trust check and falls through to body inference exactly as before).

Loop-variable inference consumes the marker in three shapes:
- `for w in load_widgets():` — a call iterable types through the callee's return annotation (scalar returns do not unwrap; a scalar is not an element type)
- `widgets = load_widgets(); for w in widgets:` — the assignment already flows the marker into the local's type; iteration unwraps it
- `for w in self.widgets:` — attribute iterables read the `self.x` key the self-assignment pass populates

Receiver-position safety: a `list[qn]` marker composing into a method lookup (`list[qn].render`) misses the registry and resolves to None, which is exactly what an untyped variable did before, so no existing path can bind worse than it did.

## Test

The regression test's fixture carries a decoy class with the same method name, making the bare-name trie fallback ambiguous: only real receiver typing can bind `w.render()` to `Widget.render`, and the test asserts the decoy is never linked. Bodies return through `json.loads`, so the annotation is the only evidence. All 263 type-inference tests and the 285-test Python parser battery pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Python type inference for generic containers, including lists, tuples, generators, and optional annotations.
  * More accurately identifies loop-variable element types from function returns, attributes, comprehensions, and factory calls.
  * Better distinguishes class construction from free-function return values.

* **Bug Fixes**
  * Reduced incorrect method linking when iterable return types are ambiguous.

* **Tests**
  * Added coverage for generic return annotations and homogeneous container element inference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->