### PR TITLE
feat: type TS/JS variables from annotations and for-of loops from element types

### DIFF
--- a/codebase_rag/constants/ast_js.py
+++ b/codebase_rag/constants/ast_js.py
@@ -256,6 +256,21 @@ FIELD_INCREMENT = "increment"
 
 # JS/TS module system node types
 TS_TYPE_ANNOTATION = "type_annotation"
+# TypeScript type-annotation shapes (issue #1303). Arrays and array-shaped
+# generics carry their element in the canonical `list[<element>]` marker,
+# which only for-of loop-variable inference unwraps.
+TS_ARRAY_TYPE = "array_type"
+TS_GENERIC_TYPE = "generic_type"
+TS_UNION_TYPE = "union_type"
+TS_TYPE_IDENTIFIER = "type_identifier"
+TS_NESTED_TYPE_IDENTIFIER = "nested_type_identifier"
+TS_JS_OPERATOR_OF = "of"
+TS_NULLISH_TYPE_TEXTS = frozenset({"null", "undefined"})
+TS_ARRAY_GENERIC_NAMES = frozenset(
+    {"Array", "ReadonlyArray", "Set", "Iterable", "IterableIterator"}
+)
+JS_LIST_TYPE_PREFIX = "list["
+JS_LIST_TYPE_FORMAT = "list[{element}]"
 TS_IMPORT_ALIAS = "import_alias"
 TS_JS_WITH_STATEMENT = "with_statement"
 TS_CLASS_STATIC_BLOCK = "class_static_block"

--- a/codebase_rag/parsers/js_ts/type_inference.py
+++ b/codebase_rag/parsers/js_ts/type_inference.py
@@ -62,9 +62,15 @@ def _tree_root(node: ASTNode) -> ASTNode:
 
 
 def _find_function_declaration(root: ASTNode, name: str) -> ASTNode | None:
-    """A same-file free function by name: a declaration, or an arrow bound
-    by a declarator (`const f = (): T => ...`), whose annotation rides the
-    arrow node."""
+    """The single same-file free function by name, else ``None``.
+
+    Matches a declaration or an arrow bound by a declarator (`const f =
+    (): T => ...`, whose annotation rides the arrow node). Without lexical
+    scope resolution, two same-named functions (a local shadowing a
+    top-level one) cannot be attributed to a call site, so more than one
+    match yields nothing rather than a possibly wrong binding.
+    """
+    matches: list[ASTNode] = []
     stack: list[ASTNode] = [root]
     while stack:
         current = stack.pop()
@@ -74,7 +80,7 @@ def _find_function_declaration(root: ASTNode, name: str) -> ASTNode | None:
         ):
             name_node = current.child_by_field_name("name")
             if name_node is not None and safe_decode_text(name_node) == name:
-                return current
+                matches.append(current)
         elif current.type == cs.TS_VARIABLE_DECLARATOR:
             name_node = current.child_by_field_name("name")
             value_node = current.child_by_field_name("value")
@@ -84,9 +90,9 @@ def _find_function_declaration(root: ASTNode, name: str) -> ASTNode | None:
                 and value_node.type == cs.TS_ARROW_FUNCTION
                 and safe_decode_text(name_node) == name
             ):
-                return value_node
+                matches.append(value_node)
         stack.extend(reversed(current.children))
-    return None
+    return matches[0] if len(matches) == 1 else None
 
 
 class JsTypeInferenceEngine:
@@ -281,8 +287,18 @@ class JsTypeInferenceEngine:
         ):
             return
         loop_var = safe_decode_text(left)
+        if not loop_var:
+            return
         element = self._for_of_element_type(right, local_var_types, module_qn)
-        if loop_var and element:
+        # The map is function-wide while the loop binding is block-scoped: the
+        # header REBINDS the name, so an entry that disagrees with the loop's
+        # element (or an element the engine cannot type) would emit wrong
+        # edges on one side of the loop. Dropping it beats guessing.
+        existing = local_var_types.get(loop_var)
+        if existing is not None and existing != element:
+            del local_var_types[loop_var]
+            return
+        if element:
             local_var_types[loop_var] = element
             logger.debug(ls.JS_VAR_INFERRED, var_name=loop_var, var_type=element)
 
@@ -296,16 +312,28 @@ class JsTypeInferenceEngine:
             # A scalar return is not an element type; only the marker unwraps.
             return _container_element(self._call_return_type(right, module_qn))
         if right.type == cs.TS_ARRAY:
-            # `for (const w of [new Widget(), ...])`: the literal names its
-            # element directly, the JS analogue of an annotation.
-            for child in right.named_children:
-                if child.type == cs.TS_NEW_EXPRESSION and (
-                    class_name := ut.extract_constructor_name(child)
-                ):
-                    return self._resolve_js_class_name(class_name, module_qn) or (
-                        class_name
-                    )
+            return self._array_literal_element_type(right, module_qn)
         return None
+
+    def _array_literal_element_type(
+        self, array_node: ASTNode, module_qn: str
+    ) -> str | None:
+        """`[new Widget(), new Widget()]` names its element; a literal whose
+        elements construct different classes, or mix constructions with other
+        expressions, guarantees nothing and yields ``None``."""
+        element: str | None = None
+        for child in array_node.named_children:
+            if child.type != cs.TS_NEW_EXPRESSION:
+                return None
+            class_name = ut.extract_constructor_name(child)
+            if not class_name:
+                return None
+            resolved = self._resolve_js_class_name(class_name, module_qn) or class_name
+            if element is None:
+                element = resolved
+            elif element != resolved:
+                return None
+        return element
 
     def _call_return_type(self, call_node: ASTNode, module_qn: str) -> str | None:
         func_node = call_node.child_by_field_name("function")

--- a/codebase_rag/parsers/js_ts/type_inference.py
+++ b/codebase_rag/parsers/js_ts/type_inference.py
@@ -44,6 +44,51 @@ if TYPE_CHECKING:
 _JS_DECLARATOR_QUERY = "(variable_declarator) @declarator"
 
 
+def _container_element(type_str: str | None) -> str | None:
+    """The element inside a canonical ``list[<element>]`` marker, else ``None``."""
+    if (
+        type_str
+        and type_str.startswith(cs.JS_LIST_TYPE_PREFIX)
+        and type_str.endswith("]")
+    ):
+        return type_str[len(cs.JS_LIST_TYPE_PREFIX) : -1] or None
+    return None
+
+
+def _tree_root(node: ASTNode) -> ASTNode:
+    while node.parent is not None:
+        node = node.parent
+    return node
+
+
+def _find_function_declaration(root: ASTNode, name: str) -> ASTNode | None:
+    """A same-file free function by name: a declaration, or an arrow bound
+    by a declarator (`const f = (): T => ...`), whose annotation rides the
+    arrow node."""
+    stack: list[ASTNode] = [root]
+    while stack:
+        current = stack.pop()
+        if current.type in (
+            cs.TS_FUNCTION_DECLARATION,
+            cs.TS_GENERATOR_FUNCTION_DECLARATION,
+        ):
+            name_node = current.child_by_field_name("name")
+            if name_node is not None and safe_decode_text(name_node) == name:
+                return current
+        elif current.type == cs.TS_VARIABLE_DECLARATOR:
+            name_node = current.child_by_field_name("name")
+            value_node = current.child_by_field_name("value")
+            if (
+                name_node is not None
+                and value_node is not None
+                and value_node.type == cs.TS_ARROW_FUNCTION
+                and safe_decode_text(name_node) == name
+            ):
+                return value_node
+        stack.extend(reversed(current.children))
+    return None
+
+
 class JsTypeInferenceEngine:
     __slots__ = (
         "import_processor",
@@ -100,61 +145,19 @@ class JsTypeInferenceEngine:
         if declarator_nodes is not None:
             for current in declarator_nodes:
                 declarator_count += 1
-                name_node = current.child_by_field_name("name")
-                value_node = current.child_by_field_name("value")
-                if name_node and value_node:
-                    var_name_text = name_node.text
-                    if var_name_text:
-                        var_name = safe_decode_text(name_node)
-                        if var_name is not None:
-                            logger.debug(
-                                ls.JS_VAR_DECLARATOR_FOUND,
-                                var_name=var_name,
-                                module_qn=module_qn,
-                            )
-                            if var_type := self._infer_js_variable_type_from_value(
-                                value_node, module_qn
-                            ):
-                                local_var_types[var_name] = var_type
-                                logger.debug(
-                                    ls.JS_VAR_INFERRED,
-                                    var_name=var_name,
-                                    var_type=var_type,
-                                )
-                            else:
-                                logger.debug(ls.JS_VAR_INFER_FAILED, var_name=var_name)
+                self._record_declarator(current, local_var_types, module_qn)
         else:
             stack: list[ASTNode] = [caller_node]
             while stack:
                 current = stack.pop()
                 if current.type == cs.TS_VARIABLE_DECLARATOR:
                     declarator_count += 1
-                    name_node = current.child_by_field_name("name")
-                    value_node = current.child_by_field_name("value")
-                    if name_node and value_node:
-                        var_name_text = name_node.text
-                        if var_name_text:
-                            var_name = safe_decode_text(name_node)
-                            if var_name is not None:
-                                logger.debug(
-                                    ls.JS_VAR_DECLARATOR_FOUND,
-                                    var_name=var_name,
-                                    module_qn=module_qn,
-                                )
-                                if var_type := self._infer_js_variable_type_from_value(
-                                    value_node, module_qn
-                                ):
-                                    local_var_types[var_name] = var_type
-                                    logger.debug(
-                                        ls.JS_VAR_INFERRED,
-                                        var_name=var_name,
-                                        var_type=var_type,
-                                    )
-                                else:
-                                    logger.debug(
-                                        ls.JS_VAR_INFER_FAILED, var_name=var_name
-                                    )
+                    self._record_declarator(current, local_var_types, module_qn)
                 stack.extend(reversed(current.children))
+
+        # After declarators so a loop over an already-typed variable can read
+        # its container marker.
+        self._seed_for_of_variables(caller_node, local_var_types, module_qn)
 
         logger.debug(
             ls.JS_VAR_TYPE_MAP_BUILT,
@@ -162,6 +165,177 @@ class JsTypeInferenceEngine:
             declarator_count=declarator_count,
         )
         return local_var_types
+
+    def _record_declarator(
+        self, declarator: ASTNode, local_var_types: dict[str, str], module_qn: str
+    ) -> None:
+        """One declarator's type: the annotation is declared truth and wins
+        over value inference; an annotation-only ``let u: User;`` still types.
+        """
+        name_node = declarator.child_by_field_name("name")
+        if name_node is None or not name_node.text:
+            return
+        var_name = safe_decode_text(name_node)
+        if var_name is None:
+            return
+        logger.debug(ls.JS_VAR_DECLARATOR_FOUND, var_name=var_name, module_qn=module_qn)
+        # Precedence: a `new` expression is exact runtime truth and beats the
+        # declared annotation (`const s: IService = new UserService()` types as
+        # the concrete class); the annotation beats the remaining value
+        # heuristics; an annotation-only `let u: User;` still types.
+        value_node = declarator.child_by_field_name("value")
+        var_type = None
+        if value_node is not None and value_node.type == cs.TS_NEW_EXPRESSION:
+            var_type = self._infer_js_variable_type_from_value(value_node, module_qn)
+        if var_type is None and (type_node := declarator.child_by_field_name("type")):
+            var_type = self._annotation_type(type_node, module_qn)
+        if var_type is None and value_node is not None:
+            var_type = self._infer_js_variable_type_from_value(value_node, module_qn)
+        if var_type:
+            local_var_types[var_name] = var_type
+            logger.debug(ls.JS_VAR_INFERRED, var_name=var_name, var_type=var_type)
+        else:
+            logger.debug(ls.JS_VAR_INFER_FAILED, var_name=var_name)
+
+    def _annotation_type(self, annotation_node: ASTNode, module_qn: str) -> str | None:
+        """The type of a ``type_annotation`` node (`: User`, `: User[]`, ...)."""
+        inner = next(iter(annotation_node.named_children), None)
+        return self._type_from_type_node(inner, module_qn) if inner else None
+
+    def _type_from_type_node(self, node: ASTNode, module_qn: str) -> str | None:
+        if node.type == cs.TS_UNION_TYPE:
+            # `User | null` names a single concrete member; wider unions are
+            # not a receiver type.
+            members = [
+                child
+                for child in node.named_children
+                if (safe_decode_text(child) or "") not in cs.TS_NULLISH_TYPE_TEXTS
+            ]
+            if len(members) == 1:
+                return self._type_from_type_node(members[0], module_qn)
+            return None
+        if node.type == cs.TS_ARRAY_TYPE:
+            inner = next(iter(node.named_children), None)
+            element = self._type_from_type_node(inner, module_qn) if inner else None
+            return self._element_marker(element)
+        if node.type == cs.TS_GENERIC_TYPE:
+            return self._generic_type(node, module_qn)
+        if node.type == cs.TS_TYPE_IDENTIFIER:
+            name = safe_decode_text(node)
+            if not name:
+                return None
+            return self._resolve_js_class_name(name, module_qn) or name
+        if node.type == cs.TS_NESTED_TYPE_IDENTIFIER:
+            return safe_decode_text(node)
+        return None
+
+    def _generic_type(self, node: ASTNode, module_qn: str) -> str | None:
+        """`Array<User>` and friends carry an element; other generics do not."""
+        name_node = node.child_by_field_name("name")
+        if (
+            name_node is None
+            or (safe_decode_text(name_node) or "") not in cs.TS_ARRAY_GENERIC_NAMES
+        ):
+            return None
+        arguments = next(
+            (child for child in node.named_children if child != name_node), None
+        )
+        if arguments is None:
+            return None
+        argument_types = list(arguments.named_children)
+        if len(argument_types) != 1:
+            return None
+        return self._element_marker(
+            self._type_from_type_node(argument_types[0], module_qn)
+        )
+
+    @staticmethod
+    def _element_marker(element: str | None) -> str | None:
+        # Nested containers (`User[][]`) have no scalar element to iterate to.
+        if element is None or element.startswith(cs.JS_LIST_TYPE_PREFIX):
+            return None
+        return cs.JS_LIST_TYPE_FORMAT.format(element=element)
+
+    def _seed_for_of_variables(
+        self, caller_node: ASTNode, local_var_types: dict[str, str], module_qn: str
+    ) -> None:
+        stack: list[ASTNode] = [caller_node]
+        while stack:
+            node = stack.pop()
+            if node.type == cs.TS_JS_FOR_IN_STATEMENT:
+                self._seed_one_for_of(node, local_var_types, module_qn)
+            stack.extend(reversed(node.children))
+
+    def _seed_one_for_of(
+        self, node: ASTNode, local_var_types: dict[str, str], module_qn: str
+    ) -> None:
+        operator = node.child_by_field_name("operator")
+        left = node.child_by_field_name("left")
+        right = node.child_by_field_name("right")
+        if (
+            operator is None
+            or left is None
+            or right is None
+            or safe_decode_text(operator) != cs.TS_JS_OPERATOR_OF
+            or left.type != cs.TS_IDENTIFIER
+        ):
+            return
+        loop_var = safe_decode_text(left)
+        element = self._for_of_element_type(right, local_var_types, module_qn)
+        if loop_var and element:
+            local_var_types[loop_var] = element
+            logger.debug(ls.JS_VAR_INFERRED, var_name=loop_var, var_type=element)
+
+    def _for_of_element_type(
+        self, right: ASTNode, local_var_types: dict[str, str], module_qn: str
+    ) -> str | None:
+        if right.type == cs.TS_IDENTIFIER:
+            name = safe_decode_text(right)
+            return _container_element(local_var_types.get(name)) if name else None
+        if right.type == cs.TS_CALL_EXPRESSION:
+            # A scalar return is not an element type; only the marker unwraps.
+            return _container_element(self._call_return_type(right, module_qn))
+        if right.type == cs.TS_ARRAY:
+            # `for (const w of [new Widget(), ...])`: the literal names its
+            # element directly, the JS analogue of an annotation.
+            for child in right.named_children:
+                if child.type == cs.TS_NEW_EXPRESSION and (
+                    class_name := ut.extract_constructor_name(child)
+                ):
+                    return self._resolve_js_class_name(class_name, module_qn) or (
+                        class_name
+                    )
+        return None
+
+    def _call_return_type(self, call_node: ASTNode, module_qn: str) -> str | None:
+        func_node = call_node.child_by_field_name("function")
+        if func_node is None:
+            return None
+        if func_node.type == cs.TS_IDENTIFIER:
+            # The shared method lookup only knows `Class.method` shapes, so a
+            # free function is located in its own file's tree (imported
+            # functions stay out of reach without AST access; honest miss).
+            callee = safe_decode_text(func_node)
+            if not callee:
+                return None
+            fn_node = _find_function_declaration(_tree_root(call_node), callee)
+            if fn_node is None:
+                return None
+            fn_qn = f"{module_qn}{cs.SEPARATOR_DOT}{callee}"
+            return self._annotated_return_type_of(
+                fn_node, module_qn
+            ) or self._analyze_return_statements(fn_node, fn_qn)
+        if func_node.type == cs.TS_MEMBER_EXPRESSION and (
+            method_call := ut.extract_method_call(func_node)
+        ):
+            return self._infer_js_method_return_type(method_call, module_qn)
+        return None
+
+    def _annotated_return_type_of(
+        self, callable_node: ASTNode, module_qn: str
+    ) -> str | None:
+        annotation = callable_node.child_by_field_name("return_type")
+        return self._annotation_type(annotation, module_qn) if annotation else None
 
     def _infer_js_variable_type_from_value(
         self, value_node: ASTNode, module_qn: str
@@ -230,7 +404,11 @@ class JsTypeInferenceEngine:
             logger.debug(ls.JS_METHOD_AST_NOT_FOUND, method_qn=method_qn)
             return None
 
-        return_type = self._analyze_return_statements(method_node, method_qn)
+        # A declared return annotation is the cheapest, most reliable source;
+        # body analysis is the fallback (issue #1303).
+        return_type = self._annotated_return_type_of(
+            method_node, module_qn
+        ) or self._analyze_return_statements(method_node, method_qn)
         logger.debug(
             ls.JS_RETURN_ANALYZED, method_qn=method_qn, return_type=return_type
         )

--- a/codebase_rag/tests/test_js_type_inference_integration.py
+++ b/codebase_rag/tests/test_js_type_inference_integration.py
@@ -727,3 +727,79 @@ export class Screen {
     if missing:
         pytest.fail(f"Missing annotation-typed calls: {missing}")
     assert not any(callee == decoy for _caller, callee in found)
+
+
+class TestForOfConservativeCeilings:
+    # Review round on #1306: without lexical scoping the engine must prefer
+    # no binding over a possibly wrong one.
+
+    def test_shadowed_loop_variable_drops_the_binding(
+        self, ts_parser, js_type_engine: JsTypeInferenceEngine
+    ) -> None:
+        code = b"""
+const item: Widget = fetchOne();
+for (const item of banners) { item.show(); }
+"""
+        tree = ts_parser.parse(code)
+        result = js_type_engine.build_local_variable_type_map(
+            tree.root_node, "myapp.main", cs.SupportedLanguage.TS
+        )
+        # The name is block-shadowed with a conflicting type: either binding
+        # would emit wrong edges on one side of the loop, so neither survives.
+        assert "item" not in result
+
+    def test_for_of_rebinding_same_type_is_kept(
+        self, ts_parser, js_type_engine: JsTypeInferenceEngine
+    ) -> None:
+        code = b"""
+const widgets: Widget[] = fetchAll();
+for (const w of widgets) { w.render(); }
+"""
+        tree = ts_parser.parse(code)
+        result = js_type_engine.build_local_variable_type_map(
+            tree.root_node, "myapp.main", cs.SupportedLanguage.TS
+        )
+        assert result["w"] == "Widget"
+
+    def test_heterogeneous_array_literal_yields_nothing(
+        self, js_parser, js_type_engine: JsTypeInferenceEngine
+    ) -> None:
+        code = b"""
+for (const x of [new Widget(), new Banner()]) { x.render(); }
+"""
+        tree = js_parser.parse(code)
+        result = js_type_engine.build_local_variable_type_map(
+            tree.root_node, "myapp.main"
+        )
+        assert "x" not in result
+
+    def test_array_literal_mixing_constructions_and_names_yields_nothing(
+        self, js_parser, js_type_engine: JsTypeInferenceEngine
+    ) -> None:
+        code = b"""
+for (const x of [new Widget(), fallback]) { x.render(); }
+"""
+        tree = js_parser.parse(code)
+        result = js_type_engine.build_local_variable_type_map(
+            tree.root_node, "myapp.main"
+        )
+        assert "x" not in result
+
+    def test_duplicate_function_names_are_ambiguous(
+        self, ts_parser, js_type_engine: JsTypeInferenceEngine
+    ) -> None:
+        # A local `load` shadowing a top-level one cannot be attributed to
+        # the call site without lexical scoping: no binding, never a guess.
+        code = b"""
+function load(): Banner[] { return JSON.parse("[]"); }
+
+function screen(): void {
+    const load = (): Widget[] => JSON.parse("[]");
+    for (const x of load()) { x.render(); }
+}
+"""
+        tree = ts_parser.parse(code)
+        result = js_type_engine.build_local_variable_type_map(
+            tree.root_node, "myapp.main", cs.SupportedLanguage.TS
+        )
+        assert "x" not in result

--- a/codebase_rag/tests/test_js_type_inference_integration.py
+++ b/codebase_rag/tests/test_js_type_inference_integration.py
@@ -554,3 +554,176 @@ function safeCreate() {
         assert result["risky"] == "RiskyOperation"
         assert "fallback" in result
         assert result["fallback"] == "FallbackHandler"
+
+
+class TestTsAnnotationAndForOfTypes:
+    # TS type annotations and for-of loop variables (issue #1303): the
+    # annotation is declared truth and wins over value inference; arrays and
+    # array-shaped generics carry their element in the canonical
+    # `list[<element>]` marker, which only for-of unwraps.
+
+    def test_scalar_annotation_types_the_variable(
+        self, ts_parser, js_type_engine: JsTypeInferenceEngine
+    ) -> None:
+        code = b"const u: User = fetchOne();"
+        tree = ts_parser.parse(code)
+        result = js_type_engine.build_local_variable_type_map(
+            tree.root_node, "myapp.main", cs.SupportedLanguage.TS
+        )
+        assert result["u"] == "User"
+
+    def test_array_annotation_carries_the_element_marker(
+        self, ts_parser, js_type_engine: JsTypeInferenceEngine
+    ) -> None:
+        code = b"const users: User[] = fetchAll();"
+        tree = ts_parser.parse(code)
+        result = js_type_engine.build_local_variable_type_map(
+            tree.root_node, "myapp.main", cs.SupportedLanguage.TS
+        )
+        assert result["users"] == "list[User]"
+
+    def test_generic_array_annotation_carries_the_element_marker(
+        self, ts_parser, js_type_engine: JsTypeInferenceEngine
+    ) -> None:
+        code = b"const users: Array<User> = fetchAll();"
+        tree = ts_parser.parse(code)
+        result = js_type_engine.build_local_variable_type_map(
+            tree.root_node, "myapp.main", cs.SupportedLanguage.TS
+        )
+        assert result["users"] == "list[User]"
+
+    def test_nullable_union_annotation_takes_the_concrete_member(
+        self, ts_parser, js_type_engine: JsTypeInferenceEngine
+    ) -> None:
+        code = b"const u: User | null = fetchOne();"
+        tree = ts_parser.parse(code)
+        result = js_type_engine.build_local_variable_type_map(
+            tree.root_node, "myapp.main", cs.SupportedLanguage.TS
+        )
+        assert result["u"] == "User"
+
+    def test_annotation_without_initializer_still_types(
+        self, ts_parser, js_type_engine: JsTypeInferenceEngine
+    ) -> None:
+        code = b"let u: User;"
+        tree = ts_parser.parse(code)
+        result = js_type_engine.build_local_variable_type_map(
+            tree.root_node, "myapp.main", cs.SupportedLanguage.TS
+        )
+        assert result["u"] == "User"
+
+    def test_for_of_over_annotated_array_types_the_loop_variable(
+        self, ts_parser, js_type_engine: JsTypeInferenceEngine
+    ) -> None:
+        code = b"""
+const users: User[] = fetchAll();
+for (const u of users) { u.save(); }
+"""
+        tree = ts_parser.parse(code)
+        result = js_type_engine.build_local_variable_type_map(
+            tree.root_node, "myapp.main", cs.SupportedLanguage.TS
+        )
+        assert result["u"] == "User"
+
+    def test_for_in_is_not_for_of(
+        self, ts_parser, js_type_engine: JsTypeInferenceEngine
+    ) -> None:
+        # `for (const k in users)` iterates keys, never elements.
+        code = b"""
+const users: User[] = fetchAll();
+for (const k in users) { log(k); }
+"""
+        tree = ts_parser.parse(code)
+        result = js_type_engine.build_local_variable_type_map(
+            tree.root_node, "myapp.main", cs.SupportedLanguage.TS
+        )
+        assert "k" not in result
+
+    def test_for_of_over_array_literal_of_constructions(
+        self, js_parser, js_type_engine: JsTypeInferenceEngine
+    ) -> None:
+        # Plain JS has no annotations; a literal of constructions still names
+        # its element.
+        code = b"""
+for (const w of [new Widget(), new Widget()]) { w.render(); }
+"""
+        tree = js_parser.parse(code)
+        result = js_type_engine.build_local_variable_type_map(
+            tree.root_node, "myapp.main"
+        )
+        assert result["w"] == "Widget"
+
+
+def test_ts_annotations_bind_loop_method_calls_end_to_end(tmp_path, mock_ingestor):
+    # Full-pipeline proof for issue #1303: the bodies return through
+    # JSON.parse, so the annotations are the only typing evidence, and the
+    # decoy class shares the method name so only a typed receiver can bind.
+    from pathlib import Path
+
+    from codebase_rag.graph_updater import GraphUpdater
+    from codebase_rag.parser_loader import load_parsers
+
+    project_path = Path(tmp_path) / "ts_annotation_test"
+    project_path.mkdir()
+    (project_path / "app.ts").write_text(
+        encoding="utf-8",
+        data="""
+export class Widget {
+    render(): string { return "w"; }
+}
+
+export class Banner {
+    render(): string { return "b"; }
+}
+
+export function loadWidgets(): Widget[] {
+    return JSON.parse("[]");
+}
+
+export class Screen {
+    drawDirect(): void {
+        for (const w of loadWidgets()) {
+            w.render();
+        }
+    }
+
+    drawStored(): void {
+        const widgets: Widget[] = loadWidgets();
+        for (const w of widgets) {
+            w.render();
+        }
+    }
+
+    drawOne(): void {
+        const single: Widget = JSON.parse("{}");
+        single.render();
+    }
+}
+""",
+    )
+
+    parsers, queries = load_parsers()
+    updater = GraphUpdater(
+        ingestor=mock_ingestor,
+        repo_path=project_path,
+        parsers=parsers,
+        queries=queries,
+    )
+    updater.run()
+
+    project_name = project_path.name
+    found = {
+        (c[0][0][2], c[0][2][2])
+        for c in mock_ingestor.ensure_relationship_batch.call_args_list
+        if len(c[0]) >= 3 and c[0][1] == "CALLS" and c[0][2][0] == NodeType.METHOD
+    }
+    render = f"{project_name}.app.Widget.render"
+    decoy = f"{project_name}.app.Banner.render"
+    missing = [
+        (caller, render)
+        for method in ("drawDirect", "drawStored", "drawOne")
+        if ((caller := f"{project_name}.app.Screen.{method}"), render) not in found
+    ]
+    if missing:
+        pytest.fail(f"Missing annotation-typed calls: {missing}")
+    assert not any(callee == decoy for _caller, callee in found)

--- a/codebase_rag/tests/test_js_type_inference_integration.py
+++ b/codebase_rag/tests/test_js_type_inference_integration.py
@@ -733,9 +733,28 @@ class TestForOfConservativeCeilings:
     # Review round on #1306: without lexical scoping the engine must prefer
     # no binding over a possibly wrong one.
 
-    def test_shadowed_loop_variable_drops_the_binding(
+    def test_shadowed_loop_variable_with_conflicting_type_drops_the_binding(
         self, ts_parser, js_type_engine: JsTypeInferenceEngine
     ) -> None:
+        # Both bindings are typed: `item` is Widget outside the loop and
+        # Banner inside it; either single entry would emit wrong edges on one
+        # side of the loop, so neither survives.
+        code = b"""
+const banners: Banner[] = fetchBanners();
+const item: Widget = fetchOne();
+for (const item of banners) { item.show(); }
+"""
+        tree = ts_parser.parse(code)
+        result = js_type_engine.build_local_variable_type_map(
+            tree.root_node, "myapp.main", cs.SupportedLanguage.TS
+        )
+        assert "item" not in result
+
+    def test_shadowed_loop_variable_with_untypable_element_drops_the_binding(
+        self, ts_parser, js_type_engine: JsTypeInferenceEngine
+    ) -> None:
+        # The header rebinds the name even when the element cannot be typed:
+        # keeping the outer Widget would type the loop body wrongly.
         code = b"""
 const item: Widget = fetchOne();
 for (const item of banners) { item.show(); }
@@ -744,14 +763,15 @@ for (const item of banners) { item.show(); }
         result = js_type_engine.build_local_variable_type_map(
             tree.root_node, "myapp.main", cs.SupportedLanguage.TS
         )
-        # The name is block-shadowed with a conflicting type: either binding
-        # would emit wrong edges on one side of the loop, so neither survives.
         assert "item" not in result
 
     def test_for_of_rebinding_same_type_is_kept(
         self, ts_parser, js_type_engine: JsTypeInferenceEngine
     ) -> None:
+        # A pre-existing binding of the SAME type agrees with the loop
+        # element, so the entry survives.
         code = b"""
+const w: Widget = fetchOne();
 const widgets: Widget[] = fetchAll();
 for (const w of widgets) { w.render(); }
 """


### PR DESCRIPTION
Closes #1303. The three connected gaps land together, in dependency order, mirroring the Python approach in #1305.

## What

1. **Variable type annotations are parsed.** A declarator's `type` field types the local: plain `type_identifier` (resolved in scope), dotted `nested_type_identifier`, and `T | null`/`T | undefined` unions taking the single concrete member. Precedence is deliberate: a `new` expression is exact runtime truth and beats the annotation (`const s: IService = new UserService()` types as the concrete class, preserving existing behaviour); the annotation beats the remaining value heuristics; an annotation-only `let u: User;` still types.
2. **Element types extract.** `User[]` and array-shaped generics (`Array/ReadonlyArray/Set/Iterable/IterableIterator<User>`) carry their element in the canonical `list[<element>]` marker. Nested containers (`User[][]`) have no scalar element and yield nothing. The marker can never mis-bind as a receiver: it misses every class lookup exactly like an untyped variable did before.
3. **For-of loop variables infer.** `for (const u of users)` types `u` from the iterable: an annotated variable's marker, a call's return (the callee's return-type annotation is now consulted before body analysis, and same-file free functions/arrows are located in their tree since the shared lookup only knows Class.method shapes), or a plain-JS array literal of constructions. `for..in` (key iteration) is explicitly excluded via the statement's `operator` field, and a scalar call return never unwraps into an element.

Method return-type annotations (`getUsers(): User[]`) are consulted ahead of return-statement analysis in the existing member-call path, which both feeds the for-of case and improves scalar receiver typing generally.

## Tests

Engine-level tests against real parsers cover each annotation shape, the null-union, the annotation-only declaration, for-of vs for-in, and the JS array-literal case. An end-to-end GraphUpdater test uses a decoy class sharing the method name (bare-name fallback ambiguous, so only typed receivers can bind) with bodies returning through `JSON.parse` (annotations are the only evidence), across the direct-call, stored-variable, and scalar-annotation shapes. All 60 JS tests and the 522-test Python/type-inference battery pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved JavaScript and TypeScript type inference for annotated variables, arrays, nullable unions, generic arrays, and `for...of` loops.
  * Enhanced function return inference using declared return types and same-file function definitions.
  * Improved method resolution for objects created from annotated types and JavaScript array literals.

* **Bug Fixes**
  * Prevented incorrect inference for `for...in` loops, heterogeneous arrays, conflicting shadowed variables, ambiguous functions, and unrelated methods with matching names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->