### PR TITLE
fix(evals): probe javac/java -version so a broken JDK shim reports unavailable

### DIFF
--- a/codebase_rag/tests/test_java_oracle_probe.py
+++ b/codebase_rag/tests/test_java_oracle_probe.py
@@ -1,0 +1,48 @@
+# The Java availability probe must run the toolchain, not just find it: macOS
+# ships /usr/bin/javac shims that exist with no JDK and exit non-zero, and a
+# wedged binary must never stall pytest collection (PR #1308).
+
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+
+from evals.oracles import java_available
+from evals.oracles.java_oracle import _toolchain_runs
+
+
+def test_probe_reports_unavailable_when_binary_is_missing(monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda _name: None)
+    assert _toolchain_runs("javac") is False
+
+
+def test_probe_reports_unavailable_for_a_broken_shim(monkeypatch):
+    # The macOS no-JDK shim: present on PATH, exits non-zero when invoked.
+    monkeypatch.setattr("shutil.which", lambda _name: "/usr/bin/javac")
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *a, **k: SimpleNamespace(returncode=1, stdout="", stderr=""),
+    )
+    assert _toolchain_runs("javac") is False
+
+
+def test_probe_reports_unavailable_when_the_binary_hangs(monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda _name: "/usr/bin/javac")
+
+    def hang(*_a, **kwargs):
+        assert kwargs.get("timeout") is not None
+        raise subprocess.TimeoutExpired(cmd="javac", timeout=kwargs["timeout"])
+
+    monkeypatch.setattr("subprocess.run", hang)
+    assert _toolchain_runs("javac") is False
+
+
+def test_available_requires_both_toolchain_binaries(monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda cmd, **k: SimpleNamespace(
+            returncode=0 if cmd[0].endswith("javac") else 1, stdout="", stderr=""
+        ),
+    )
+    assert java_available() is False

--- a/evals/oracles/java_oracle.py
+++ b/evals/oracles/java_oracle.py
@@ -17,10 +17,30 @@ _CLASS = _ORACLE_DIR / f"{ec.JAVA_ORACLE_CLASS}.class"
 _CALLABLE_KINDS = frozenset({cs.NodeLabel.FUNCTION.value, cs.NodeLabel.METHOD.value})
 
 
+def _toolchain_runs(bin_name: str) -> bool:
+    # `shutil.which` only proves the binary is on PATH. On macOS, /usr/bin/javac
+    # and /usr/bin/java are stub shims that exist even with no JDK installed and
+    # exit non-zero ("Unable to locate a Java Runtime") the moment they run. A
+    # which-only check therefore reports Java available, the oracle tests fail
+    # to skip, and `_ensure_compiled()` blows up with CalledProcessError. Probe
+    # `-version` and require a clean exit so a broken shim reads as unavailable.
+    path = shutil.which(bin_name)
+    if path is None:
+        return False
+    try:
+        result = subprocess.run(
+            [path, "-version"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return False
+    return result.returncode == 0
+
+
 def java_available() -> bool:
-    return (
-        shutil.which(ec.JAVAC_BIN) is not None and shutil.which(ec.JAVA_BIN) is not None
-    )
+    return _toolchain_runs(ec.JAVAC_BIN) and _toolchain_runs(ec.JAVA_BIN)
 
 
 def _ensure_compiled() -> None:

--- a/evals/oracles/java_oracle.py
+++ b/evals/oracles/java_oracle.py
@@ -16,6 +16,10 @@ _SOURCE = _ORACLE_DIR / ec.JAVA_ORACLE_SOURCE
 _CLASS = _ORACLE_DIR / f"{ec.JAVA_ORACLE_CLASS}.class"
 _CALLABLE_KINDS = frozenset({cs.NodeLabel.FUNCTION.value, cs.NodeLabel.METHOD.value})
 
+# A real `-version` probe answers in well under a second; the bound exists so a
+# wedged shim can never stall pytest collection through a skip condition.
+_PROBE_TIMEOUT_SECONDS = 10.0
+
 
 def _toolchain_runs(bin_name: str) -> bool:
     # `shutil.which` only proves the binary is on PATH. On macOS, /usr/bin/javac
@@ -33,8 +37,9 @@ def _toolchain_runs(bin_name: str) -> bool:
             capture_output=True,
             text=True,
             check=False,
+            timeout=_PROBE_TIMEOUT_SECONDS,
         )
-    except OSError:
+    except (OSError, subprocess.TimeoutExpired):
         return False
     return result.returncode == 0
 


### PR DESCRIPTION
## Problem

`java_available()` in `evals/oracles/java_oracle.py` only checked that `javac`/`java` were present on `PATH` via `shutil.which`. On macOS, `/usr/bin/javac` and `/usr/bin/java` are **stub shims that exist even when no JDK is installed** — they print `Unable to locate a Java Runtime` and exit non-zero the moment they're invoked.

As a result, on a machine with no real JDK:
- `java_available()` returns `True` (the shim is on PATH),
- the Java oracle tests therefore do **not** skip,
- `_ensure_compiled()` runs `javac ... check=True` and raises `CalledProcessError`,

so 7 Java oracle tests **error** instead of skipping:

```
test_java_anon_member_containment_oracle.py::test_anonymous_class_members_anchor_to_module
test_java_containment_oracle.py::test_cgr_matches_jdk_oracle_on_containment_edges
test_java_inheritance_oracle.py::test_cgr_matches_jdk_oracle_on_inheritance_edges
test_java_retrieval_eval.py::test_oracle_captures_first_party_java_calls
test_java_retrieval_eval.py::test_cgr_matches_oracle_on_clean_java_project
test_java_span_oracle.py::test_cgr_matches_jdk_oracle_on_node_spans
test_java_structure_oracle.py::test_cgr_matches_jdk_oracle_on_java_structure
```

## Fix

Probe `<bin> -version` and require a clean (zero) exit code, so a non-functional shim reads as unavailable. `_toolchain_runs()` replaces the which-only check.

## Verification

- With only the broken macOS shim on PATH: the 7 oracle tests now **skip** cleanly (previously errored).
- With a real JDK (OpenJDK 26) on PATH: all 8 oracle tests **pass**.
- Full non-integration suite: **7208 passed, 39 skipped, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Java environment detection by verifying that both the compiler and runtime are installed and executable.
  * Java is now reported as unavailable when either tool is missing, fails its version check, or becomes unresponsive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->