### PR TITLE
fix: return deterministic directory listings

### DIFF
--- a/codebase_rag/tests/test_directory_lister.py
+++ b/codebase_rag/tests/test_directory_lister.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from pydantic_ai import Tool
@@ -45,6 +46,17 @@ class TestDirectoryListerInit:
 
 
 class TestListDirectoryContents:
+    def test_list_directory_contents_are_sorted(
+        self, directory_lister: DirectoryLister
+    ) -> None:
+        with patch(
+            "codebase_rag.tools.directory_lister.os.listdir",
+            return_value=["zeta.py", "alpha.py", "middle.py"],
+        ):
+            result = directory_lister.list_directory_contents(".")
+
+        assert result.splitlines() == ["alpha.py", "middle.py", "zeta.py"]
+
     def test_list_root_directory(
         self, directory_lister: DirectoryLister, sample_directory_structure: Path
     ) -> None:

--- a/codebase_rag/tools/directory_lister.py
+++ b/codebase_rag/tools/directory_lister.py
@@ -32,7 +32,7 @@ class DirectoryLister:
             if not target_path.is_dir():
                 return te.DIRECTORY_INVALID.format(path=directory_path)
 
-            if contents := os.listdir(target_path):
+            if contents := sorted(os.listdir(target_path)):
                 return "\n".join(contents)
             return te.DIRECTORY_EMPTY.format(path=directory_path)
 


### PR DESCRIPTION
## Summary

- Sort directory entries before returning them to agent callers.
- Add regression coverage for deliberately unordered filesystem results.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD or tooling
- [ ] Dependencies

## Related Issues

No existing issue found.

## Test Plan

- [ ] Unit tests pass (`make test-parallel` or `uv run pytest -n auto -m "not integration"`)
- [x] New tests added
- [ ] Integration tests pass (`make test-integration`, requires Docker)
- [x] Manual testing (describe below)

Focused validation:

- `uv run pytest -q codebase_rag/tests/test_directory_lister.py` (21 passed)
- `uv run ruff format --check codebase_rag/tools/directory_lister.py codebase_rag/tests/test_directory_lister.py`
- `uv run ruff check codebase_rag/tools/directory_lister.py codebase_rag/tests/test_directory_lister.py`
- `uv run ty check codebase_rag/tools/directory_lister.py`
- `git diff --check`

Repository-wide local unit tests were also attempted on the unchanged base and reached 7,161 passed / 142 skipped, with two unrelated failures and one collection error caused by optional dependencies and the Intel macOS environment. CI remains the authoritative full-suite result.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [x] No new comments or docstrings (code should be self-documenting)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Directory listings are now consistently returned in alphabetical order, regardless of the underlying filesystem order.

* **Tests**
  * Added coverage to verify deterministic sorting of directory contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->