### PR TITLE
fix: reject invalid source location ranges

### DIFF
--- a/codebase_rag/tests/test_source_extraction.py
+++ b/codebase_rag/tests/test_source_extraction.py
@@ -239,6 +239,18 @@ class TestExtractSourceWithFallback:
 
 
 class TestValidateSourceLocation:
+    def test_rejects_zero_start_line(self) -> None:
+        valid, path = validate_source_location("/path/to/file.py", 0, 10)
+
+        assert valid is False
+        assert path is None
+
+    def test_rejects_zero_end_line(self) -> None:
+        valid, path = validate_source_location("/path/to/file.py", 1, 0)
+
+        assert valid is False
+        assert path is None
+
     def test_rejects_negative_start_line(self) -> None:
         valid, path = validate_source_location("/path/to/file.py", -1, 10)
 

--- a/codebase_rag/tests/test_source_extraction.py
+++ b/codebase_rag/tests/test_source_extraction.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from codebase_rag.utils.source_extraction import (
     extract_source_lines,
     extract_source_with_fallback,
@@ -239,32 +241,18 @@ class TestExtractSourceWithFallback:
 
 
 class TestValidateSourceLocation:
-    def test_rejects_zero_start_line(self) -> None:
-        valid, path = validate_source_location("/path/to/file.py", 0, 10)
-
-        assert valid is False
-        assert path is None
-
-    def test_rejects_zero_end_line(self) -> None:
-        valid, path = validate_source_location("/path/to/file.py", 1, 0)
-
-        assert valid is False
-        assert path is None
-
-    def test_rejects_negative_start_line(self) -> None:
-        valid, path = validate_source_location("/path/to/file.py", -1, 10)
-
-        assert valid is False
-        assert path is None
-
-    def test_rejects_negative_end_line(self) -> None:
-        valid, path = validate_source_location("/path/to/file.py", 1, -10)
-
-        assert valid is False
-        assert path is None
-
-    def test_rejects_reversed_line_range(self) -> None:
-        valid, path = validate_source_location("/path/to/file.py", 10, 1)
+    @pytest.mark.parametrize(
+        ("start_line", "end_line"),
+        [
+            pytest.param(0, 10, id="zero-start"),
+            pytest.param(1, 0, id="zero-end"),
+            pytest.param(-1, 10, id="negative-start"),
+            pytest.param(1, -10, id="negative-end"),
+            pytest.param(10, 1, id="reversed-range"),
+        ],
+    )
+    def test_rejects_invalid_line_range(self, start_line: int, end_line: int) -> None:
+        valid, path = validate_source_location("/path/to/file.py", start_line, end_line)
 
         assert valid is False
         assert path is None

--- a/codebase_rag/tests/test_source_extraction.py
+++ b/codebase_rag/tests/test_source_extraction.py
@@ -239,6 +239,24 @@ class TestExtractSourceWithFallback:
 
 
 class TestValidateSourceLocation:
+    def test_rejects_negative_start_line(self) -> None:
+        valid, path = validate_source_location("/path/to/file.py", -1, 10)
+
+        assert valid is False
+        assert path is None
+
+    def test_rejects_negative_end_line(self) -> None:
+        valid, path = validate_source_location("/path/to/file.py", 1, -10)
+
+        assert valid is False
+        assert path is None
+
+    def test_rejects_reversed_line_range(self) -> None:
+        valid, path = validate_source_location("/path/to/file.py", 10, 1)
+
+        assert valid is False
+        assert path is None
+
     def test_returns_true_for_valid_location(self) -> None:
         valid, path = validate_source_location("/path/to/file.py", 1, 10)
 

--- a/codebase_rag/utils/source_extraction.py
+++ b/codebase_rag/utils/source_extraction.py
@@ -70,7 +70,13 @@ def extract_source_with_fallback(
 def validate_source_location(
     file_path: str | None, start_line: int | None, end_line: int | None
 ) -> tuple[bool, Path | None]:
-    if not all([file_path, start_line, end_line]):
+    if (
+        not file_path
+        or start_line is None
+        or end_line is None
+        or start_line < 1
+        or end_line < start_line
+    ):
         return False, None
 
     try:


### PR DESCRIPTION
## Summary

- Reject negative and reversed source ranges during location validation.
- Keep invalid locations from reaching the source extraction path.
- Add focused regression coverage for each invalid boundary.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation
- [ ] CI/CD or tooling
- [ ] Dependencies

## Related Issues

No existing issue found.

## Test Plan

- [ ] Unit tests pass (`make test-parallel` or `uv run pytest -n auto -m "not integration"`)
- [x] New tests added
- [ ] Integration tests pass (`make test-integration`, requires Docker)
- [x] Manual testing (describe below)

Focused validation:

- `uv run pytest -q codebase_rag/tests/test_source_extraction.py` (37 passed)
- `uv run ruff format --check codebase_rag/utils/source_extraction.py codebase_rag/tests/test_source_extraction.py`
- `uv run ruff check codebase_rag/utils/source_extraction.py codebase_rag/tests/test_source_extraction.py`
- `uv run ty check codebase_rag/utils/source_extraction.py`
- `git diff --check`

Repository-wide local unit tests were also attempted on the unchanged base and reached 7,161 passed / 142 skipped, with two unrelated failures and one collection error caused by optional dependencies and the Intel macOS environment. CI remains the authoritative full-suite result.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] All pre-commit checks pass (`make pre-commit`)
- [x] No hardcoded strings in non-config/non-constants files
- [x] No `# type: ignore`, `cast()`, `Any`, or `object` type hints
- [x] No new comments or docstrings (code should be self-documenting)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source location validation to reject missing paths, unspecified line values, zero or negative line numbers, and invalid ranges where the ending line precedes the starting line.
  * Prevents malformed source references from being accepted, resulting in more reliable source extraction and clearer handling of invalid input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->