### PR TITLE
chore(ruff): add PLR0917 to ignore list alongside PLR0913

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,7 @@ ignore = [
     "PLR2004",  # magic value comparison (too noisy)
     "PLC0415",  # import not at top-level (intentional lazy imports)
     "PLR0913",  # too many arguments (often unavoidable)
+    "PLR0917",  # too many positional arguments (often unavoidable)
     "PLR0911",  # too many return statements
     "PLR0912",  # too many branches
     "PLR0915",  # too many statements


### PR DESCRIPTION
### Summary
- Add `PLR0917` (too many positional arguments) to Ruff's ignore list in `pyproject.toml` alongside `PLR0913`.
- Ensures `ruff check .` passes cleanly on latest Ruff versions where `PLR0917` is enabled under the `PL` ruleset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality checks to allow functions with many positional arguments without raising a lint warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->