### PR TITLE
feat: model Dart Process.run and Socket.connect flows via a PROCESS ResourceKind

### DIFF
--- a/codebase_rag/constants/ast_dart.py
+++ b/codebase_rag/constants/ast_dart.py
@@ -97,6 +97,8 @@ TS_DART_FORMAL_PARAMETER_LIST = "formal_parameter_list"
 TS_DART_SWITCH_STATEMENT_CASE = "switch_statement_case"
 TS_DART_SWITCH_STATEMENT_DEFAULT = "switch_statement_default"
 TS_DART_TEMPLATE_SUBSTITUTION = "template_substitution"
+# The bare `$name` interpolation form wraps its name in this node type.
+TS_DART_IDENTIFIER_DOLLAR_ESCAPED = "identifier_dollar_escaped"
 # `[String m]` (optional positional) and `{String? m}` (named) both wrap their
 # `formal_parameter`s in an `optional_formal_parameters` node (issue #1173).
 TS_DART_OPTIONAL_FORMAL_PARAMETERS = "optional_formal_parameters"

--- a/codebase_rag/constants/ast_dart.py
+++ b/codebase_rag/constants/ast_dart.py
@@ -23,6 +23,10 @@ TS_DART_LABEL = "label"
 # Python's `conditional_expression` node TYPE but orders operands
 # [condition, consequence, alternative], not [body, condition, alternative].
 TS_DART_LIST_LITERAL = "list_literal"
+# `await expr` parses as unary_expression > await_expression > chain; the
+# awaited value carries the chain's taint and handle (issue #1224).
+TS_DART_UNARY_EXPRESSION = "unary_expression"
+TS_DART_AWAIT_EXPRESSION = "await_expression"
 TS_DART_SET_OR_MAP_LITERAL = "set_or_map_literal"
 # Inside a set_or_map_literal: a MAP entry is a `pair` whose `value` field
 # holds the stored expression; `type_arguments` (`<String, T>{...}`) carry

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -2002,7 +2002,34 @@ class FlowProcessor:
         if len(rhs) == 1 and rhs[0].type == cs.TS_DART_IDENTIFIER and rhs[0].text:
             alias = rhs[0].text.decode(cs.ENCODING_UTF8)
             return tainted.get(alias), handles.get(alias, frozenset())
+        if len(rhs) == 1 and rhs[0].type == cs.TS_DART_STRING_LITERAL:
+            return self._dart_interpolation_taint(rhs[0], tainted, jc), frozenset()
         return None, frozenset()
+
+    def _dart_interpolation_taint(
+        self, literal: Node, tainted: _TaintMap, jc: _JsCtx
+    ) -> Taint | None:
+        # `'$k'` and `'${a.b}'` embed expressions inside the literal; shell
+        # payloads are routinely built this way, so each substitution is
+        # evaluated and the taints merged (issue #1224 review). The bare
+        # `$k` form parses its name as identifier_dollar_escaped, which the
+        # alias path does not recognise, so it is looked up by text.
+        merged: Taint | None = None
+        for child in literal.named_children:
+            if child.type != cs.TS_DART_TEMPLATE_SUBSTITUTION:
+                continue
+            inner = [c for c in child.named_children if c.type != cs.TS_COMMENT]
+            if (
+                len(inner) == 1
+                and inner[0].type == cs.TS_DART_IDENTIFIER_DOLLAR_ESCAPED
+                and inner[0].text
+            ):
+                taint = tainted.get(inner[0].text.decode(cs.ENCODING_UTF8))
+            else:
+                taint, _ = self._dart_rhs(inner, tainted, {}, jc)
+            if taint is not None:
+                merged = taint if merged is None else _merge_taint(merged, taint)
+        return merged
 
     def _dart_member_source(
         self, nodes: list[Node], jc: _JsCtx

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -1952,6 +1952,15 @@ class FlowProcessor:
         # project-callee return (pending), or a plain identifier alias.
         if not rhs:
             return None, frozenset()
+        if len(rhs) == 1 and rhs[0].type in (
+            cs.TS_DART_UNARY_EXPRESSION,
+            cs.TS_DART_AWAIT_EXPRESSION,
+        ):
+            # `await Socket.connect(...)` wraps the chain one node deep per
+            # level; the awaited (or negated) value carries the chain's taint
+            # and handle, so unwrap and re-evaluate (issue #1224).
+            inner = [c for c in rhs[0].named_children if c.type != cs.TS_COMMENT]
+            return self._dart_rhs(inner, tainted, handles, jc)
         source = self._dart_member_source(rhs, jc)
         if source is not None:
             return Taint(frozenset({source}), frozenset()), frozenset()
@@ -2148,8 +2157,29 @@ class FlowProcessor:
             else:
                 continue
             taint, _ = self._dart_rhs(chain, tainted, {}, jc)
+            if (
+                taint is None
+                and len(chain) == 1
+                and chain[0].type == cs.TS_DART_LIST_LITERAL
+            ):
+                taint = self._dart_list_literal_taint(chain[0], tainted, jc)
             out.append((via, taint))
         return out
+
+    def _dart_list_literal_taint(
+        self, literal: Node, tainted: _TaintMap, jc: _JsCtx
+    ) -> Taint | None:
+        # A `Process.run('sh', ['-c', k])`-style call carries its payload
+        # INSIDE a list literal; each element expression is evaluated on its
+        # own so a tainted element taints the argument (issue #1224).
+        merged: Taint | None = None
+        for element in literal.named_children:
+            if element.type == cs.TS_COMMENT:
+                continue
+            taint, _ = self._dart_rhs([element], tainted, {}, jc)
+            if taint is not None:
+                merged = taint if merged is None else _merge_taint(merged, taint)
+        return merged
 
     def _dart_return_taint(
         self, node: Node, tainted: _TaintMap, jc: _JsCtx

--- a/codebase_rag/parsers/io_access/constants.py
+++ b/codebase_rag/parsers/io_access/constants.py
@@ -24,6 +24,9 @@ class ResourceKind(StrEnum):
     STDERR = "STDERR"
     ENV = "ENV"
     SOCKET = "SOCKET"
+    # Subprocess execution (issue #1224): the resource is the command being
+    # run, so a tainted argument reaching it models command injection.
+    PROCESS = "PROCESS"
     ENDPOINT = "ENDPOINT"
     # A codegen contract operation (issue #912): client stubs and server
     # implementations of the same contract meet at one shared node keyed

--- a/codebase_rag/parsers/io_access/registry.py
+++ b/codebase_rag/parsers/io_access/registry.py
@@ -491,6 +491,10 @@ _DART_SINKS: tuple[IOSink, ...] = (
     IOSink("stderr.writeln", ResourceKind.STDERR, IODirection.WRITE),
     IOSink("http.get", ResourceKind.NETWORK, IODirection.READ, target_arg=0),
     IOSink("http.post", ResourceKind.NETWORK, IODirection.WRITE, target_arg=0),
+    # Subprocess execution (issue #1224): the command (arg 0) is the resource
+    # identity, the argument list (arg 1) the injectable payload.
+    IOSink("Process.run", ResourceKind.PROCESS, IODirection.WRITE, target_arg=0),
+    IOSink("Process.start", ResourceKind.PROCESS, IODirection.WRITE, target_arg=0),
 )
 
 IO_SINKS: dict[cs.SupportedLanguage, tuple[IOSink, ...]] = {
@@ -813,6 +817,9 @@ IO_LEAN_HANDLE_CONSTRUCTORS: dict[
     # (issue #1173). The read/write mode is per-method, so may-write by default.
     cs.SupportedLanguage.DART: (
         HandleConstructor("File", ResourceKind.FILE, target_arg=0),
+        # `var s = await Socket.connect(host, port)` binds a SOCKET handle
+        # whose identity is the host (issue #1224).
+        HandleConstructor("Socket.connect", ResourceKind.SOCKET, target_arg=0),
     ),
 }
 
@@ -1188,6 +1195,15 @@ IO_LEAN_HANDLE_METHODS: dict[
             "writeAsStringSync": IODirection.WRITE,
             "writeAsBytes": IODirection.WRITE,
             "writeAsBytesSync": IODirection.WRITE,
+        },
+        # Socket handle methods (issue #1224): listen consumes the stream,
+        # the add/write family sends on it.
+        ResourceKind.SOCKET: {
+            "listen": IODirection.READ,
+            "add": IODirection.WRITE,
+            "addStream": IODirection.WRITE,
+            "write": IODirection.WRITE,
+            "writeln": IODirection.WRITE,
         },
     },
 }

--- a/codebase_rag/tests/test_flow_dart_edges.py
+++ b/codebase_rag/tests/test_flow_dart_edges.py
@@ -201,3 +201,16 @@ def test_dart_env_flows_to_socket_write(tmp_path: Path) -> None:
         "}\n"
     )
     assert (_ENV_K, "resource::SOCKET::example.com") in _run_flow(tmp_path, source)
+
+
+def test_dart_env_flows_through_string_interpolation_to_process(tmp_path: Path) -> None:
+    # Shell payloads are routinely interpolated: `'echo $k'` embeds the
+    # tainted expression inside the literal, both in the `$k` and `${...}`
+    # forms (issue #1224 review).
+    source = (
+        "void leak() {\n"
+        "  var k = Platform.environment['K'];\n"
+        "  Process.run('sh', ['-c', 'echo $k']);\n"
+        "}\n"
+    )
+    assert (_ENV_K, "resource::PROCESS::sh") in _run_flow(tmp_path, source)

--- a/codebase_rag/tests/test_flow_dart_edges.py
+++ b/codebase_rag/tests/test_flow_dart_edges.py
@@ -175,3 +175,29 @@ def test_dart_untainted_io_emits_no_flow(tmp_path: Path) -> None:
         "}\n"
     )
     assert _run_flow(tmp_path, source) == set()
+
+
+def test_dart_env_flows_to_process_run_argument(tmp_path: Path) -> None:
+    # `Process.run('sh', [k])` executes a subprocess: the command literal is
+    # the PROCESS resource identity and the tainted argument list reaching it
+    # models command injection (issue #1224).
+    source = (
+        "void leak() {\n"
+        "  var k = Platform.environment['K'];\n"
+        "  Process.run('sh', ['-c', k]);\n"
+        "}\n"
+    )
+    assert (_ENV_K, "resource::PROCESS::sh") in _run_flow(tmp_path, source)
+
+
+def test_dart_env_flows_to_socket_write(tmp_path: Path) -> None:
+    # `Socket.connect(host, port)` binds a SOCKET handle keyed by the host;
+    # `s.write(k)` sends the ENV-tainted value on it (issue #1224).
+    source = (
+        "void leak() async {\n"
+        "  var k = Platform.environment['K'];\n"
+        "  var s = await Socket.connect('example.com', 80);\n"
+        "  s.write(k);\n"
+        "}\n"
+    )
+    assert (_ENV_K, "resource::SOCKET::example.com") in _run_flow(tmp_path, source)


### PR DESCRIPTION
Closes #1224.

## What

1. **A new `PROCESS` ResourceKind**: subprocess execution keyed by the command being run, so a tainted argument reaching it models command injection. Scoped to Dart per the issue's own guidance; other languages' exec sinks can adopt the kind in their own follow-ups.
2. **Dart sinks**: `Process.run` / `Process.start` as PROCESS write sinks with the command (arg 0) as the resource identity.
3. **`Socket.connect(host, port)`** as a SOCKET lean handle constructor keyed by the host, with a Dart socket method table (`listen` READ; `add`/`addStream`/`write`/`writeln` WRITE).

## Two walk gaps the realistic shapes exposed

- `Process.run('sh', ['-c', k])` carries its payload INSIDE a list literal, which the Dart argument scan could not see (the sink fired only for top-level identifiers). List-literal arguments now evaluate each element expression and merge the taints.
- `var s = await Socket.connect(...)` parses as `unary_expression > await_expression > chain`, which broke the binding RHS entirely (the handle never bound). `_dart_rhs` now unwraps single-node unary/await wrappers and re-evaluates the inner chain; the awaited (or negated) value soundly carries the chain's taint and handle.

## Tests

RED-first: `Platform.environment` taint reaching `Process.run`'s list-literal argument emits `ENV::K -> PROCESS::sh`, and reaching `s.write(k)` through an awaited `Socket.connect('example.com', 80)` emits `ENV::K -> SOCKET::example.com`. The 367-test flow battery passes; no coverage flag changes (Dart was already flow-registered), so `test_flow_verdict` is untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Dart analysis support for subprocess execution and socket communication.
  * Added tracking for socket connections and read/write operations.
  * Improved detection of tainted data in `await` expressions, list arguments, and string interpolation.

* **Bug Fixes**
  * Improved propagation of taint and handles through asynchronous expressions and nested values.

* **Tests**
  * Added coverage for tainted environment data reaching subprocesses, socket writes, and shell commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->