### PR TITLE
feat: taint Dart handle-read bindings and listen callback parameters

### DIFF
--- a/codebase_rag/constants/ast_dart.py
+++ b/codebase_rag/constants/ast_dart.py
@@ -69,6 +69,7 @@ DART_PATTERN_NODE_SUFFIX = "_pattern"
 # swallows a trailing ternary as its LAST named child.
 DART_EXPRESSION_NODE_SUFFIX = "_expression"
 TS_DART_FUNCTION_EXPRESSION = "function_expression"
+TS_DART_FUNCTION_EXPRESSION_BODY = "function_expression_body"
 TS_DART_LOCAL_FUNCTION_DECLARATION = "local_function_declaration"
 
 # Nodes opening their OWN variable scope: the local-type walk must not descend,

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -1985,6 +1985,9 @@ class FlowProcessor:
                         ),
                         frozenset(),
                     )
+                handle_read = self._dart_handle_read_taint(raw, handles, jc)
+                if handle_read is not None:
+                    return handle_read, frozenset()
                 callee = self._resolve(
                     raw,
                     jc.flow.module_qn,
@@ -2030,6 +2033,122 @@ class FlowProcessor:
             if taint is not None:
                 merged = taint if merged is None else _merge_taint(merged, taint)
         return merged
+
+    def _dart_walk_read_callbacks(
+        self,
+        raw: str,
+        selector: Node,
+        tainted: _TaintMap,
+        handles: _HandleMap,
+        jc: _JsCtx,
+    ) -> None:
+        # `s.listen((data) { ... })` delivers data FROM the handle's resource
+        # into the callback parameter. The lean walk skips nested callable
+        # bodies by design, so the callback block is walked here with a COPY
+        # of the state whose parameters are seeded by the handle's bindings
+        # (issue #1316); the copy keeps the seeding scoped to the lambda.
+        recv, sep, method = raw.rpartition(jc.descriptor.handle_method_separator)
+        if not sep:
+            return
+        origins = {
+            binding
+            for binding in handles.get(recv, frozenset())
+            if jc.handle_methods.get(binding.kind, {}).get(method) == IODirection.READ
+        }
+        if not origins:
+            return
+        arguments = self._dart_arguments(selector)
+        if arguments is None:
+            return
+        seed = Taint(frozenset(origins), frozenset())
+        for arg in arguments.named_children:
+            if arg.type != cs.TS_DART_ARGUMENT:
+                continue
+            fn = next(
+                (
+                    c
+                    for c in arg.named_children
+                    if c.type == cs.TS_DART_FUNCTION_EXPRESSION
+                ),
+                None,
+            )
+            if fn is None:
+                continue
+            inner = dict(tainted)
+            for name in self._dart_lambda_param_names(fn):
+                inner[name] = seed
+            state = _LeanState(taint=inner, handles=dict(handles))
+            for stmt in self._dart_lambda_body_statements(fn):
+                state = self._walk_flat_stmt(stmt, state, jc)
+
+    @staticmethod
+    def _dart_lambda_param_names(fn: Node) -> list[str]:
+        plist = next(
+            (
+                c
+                for c in fn.named_children
+                if c.type == cs.TS_DART_FORMAL_PARAMETER_LIST
+            ),
+            None,
+        )
+        if plist is None:
+            return []
+        names: list[str] = []
+        for param in plist.named_children:
+            ident = (
+                param
+                if param.type == cs.TS_DART_IDENTIFIER
+                else next(
+                    (
+                        c
+                        for c in param.named_children
+                        if c.type == cs.TS_DART_IDENTIFIER
+                    ),
+                    None,
+                )
+            )
+            if ident is not None and ident.text:
+                names.append(ident.text.decode(cs.ENCODING_UTF8))
+        return names
+
+    @staticmethod
+    def _dart_lambda_body_statements(fn: Node) -> list[Node]:
+        body = next(
+            (
+                c
+                for c in fn.named_children
+                if c.type == cs.TS_DART_FUNCTION_EXPRESSION_BODY
+            ),
+            None,
+        )
+        if body is None:
+            return []
+        block = next(
+            (c for c in body.named_children if c.type == cs.TS_DART_BLOCK), None
+        )
+        if block is not None:
+            return list(block.named_children)
+        return [body]
+
+    def _dart_handle_read_taint(
+        self, raw: str, handles: _HandleMap, jc: _JsCtx
+    ) -> Taint | None:
+        # A read METHOD on a bound handle yields data FROM the resource
+        # (`var d = f.readAsString()`), the read mirror of
+        # `_emit_handle_write` (issue #1316). READ_WRITE methods count: a DB
+        # execute's result is resource data too.
+        recv, sep, method = raw.rpartition(jc.descriptor.handle_method_separator)
+        if not sep:
+            return None
+        origins = {
+            binding
+            for binding in handles.get(recv, frozenset())
+            if jc.handle_methods.get(binding.kind, {}).get(method)
+            in (IODirection.READ, IODirection.READ_WRITE)
+        }
+        if not origins:
+            return None
+        return Taint(frozenset(origins), frozenset())
 
     def _dart_member_source(
         self, nodes: list[Node], jc: _JsCtx
@@ -2090,6 +2209,7 @@ class FlowProcessor:
             return
         if handles and self._emit_handle_write(raw, args, handles, jc):
             return
+        self._dart_walk_read_callbacks(raw, selector, tainted, handles, jc)
         callee = self._resolve(
             raw,
             jc.flow.module_qn,

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -2074,12 +2074,25 @@ class FlowProcessor:
             )
             if fn is None:
                 continue
+            names = self._dart_lambda_param_names(fn)
             inner = dict(tainted)
-            for name in self._dart_lambda_param_names(fn):
+            inner_handles = dict(handles)
+            added_locals = [n for n in names if n not in jc.local_names]
+            for name in names:
+                # The parameter SHADOWS every outer meaning of the name: a
+                # same-named outer handle must not receive the callback's
+                # calls, and a parameter named after a builtin sink must not
+                # match it (review on #1317).
                 inner[name] = seed
-            state = _LeanState(taint=inner, handles=dict(handles))
-            for stmt in self._dart_lambda_body_statements(fn):
-                state = self._walk_flat_stmt(stmt, state, jc)
+                inner_handles.pop(name, None)
+                jc.local_names.add(name)
+            try:
+                state = _LeanState(taint=inner, handles=inner_handles)
+                for stmt in self._dart_lambda_body_statements(fn):
+                    state = self._walk_flat_stmt(stmt, state, jc)
+            finally:
+                for name in added_locals:
+                    jc.local_names.discard(name)
 
     @staticmethod
     def _dart_lambda_param_names(fn: Node) -> list[str]:
@@ -2093,22 +2106,26 @@ class FlowProcessor:
         )
         if plist is None:
             return []
+        # Optional-positional (`[data]`) and named (`{data}`) parameters sit
+        # under wrapper nodes, so the list is walked recursively; a typed
+        # parameter's NAME is its last identifier (`String data`), never the
+        # type (review on #1317).
         names: list[str] = []
-        for param in plist.named_children:
-            ident = (
-                param
-                if param.type == cs.TS_DART_IDENTIFIER
-                else next(
-                    (
-                        c
-                        for c in param.named_children
-                        if c.type == cs.TS_DART_IDENTIFIER
-                    ),
-                    None,
-                )
-            )
-            if ident is not None and ident.text:
-                names.append(ident.text.decode(cs.ENCODING_UTF8))
+        stack = list(plist.named_children)
+        while stack:
+            node = stack.pop()
+            if node.type == cs.TS_DART_FORMAL_PARAMETER:
+                idents = [
+                    c
+                    for c in node.named_children
+                    if c.type == cs.TS_DART_IDENTIFIER and c.text
+                ]
+                if idents:
+                    names.append(idents[-1].text.decode(cs.ENCODING_UTF8))
+            elif node.type == cs.TS_DART_IDENTIFIER and node.text:
+                names.append(node.text.decode(cs.ENCODING_UTF8))
+            else:
+                stack.extend(node.named_children)
         return names
 
     @staticmethod

--- a/codebase_rag/tests/test_flow_dart_edges.py
+++ b/codebase_rag/tests/test_flow_dart_edges.py
@@ -257,3 +257,42 @@ def test_dart_listen_callback_parameter_carries_the_socket_taint(
         "}\n"
     )
     assert ("resource::SOCKET::example.com", _STDOUT) in _run_flow(tmp_path, source)
+
+
+def test_dart_listen_callback_optional_and_typed_parameters_seed(
+    tmp_path: Path,
+) -> None:
+    # Optional-positional (`[data]`) parameters sit under a wrapper node and
+    # typed parameters carry the type as their first identifier; both forms
+    # must still seed (review on #1317).
+    source = (
+        "void leak() async {\n"
+        "  var s = await Socket.connect('example.com', 80);\n"
+        "  s.listen(([data]) { print(data); });\n"
+        "}\n"
+    )
+    assert ("resource::SOCKET::example.com", _STDOUT) in _run_flow(tmp_path, source)
+    source = (
+        "void leak2() async {\n"
+        "  var s = await Socket.connect('example.com', 80);\n"
+        "  s.listen((String data) { print(data); });\n"
+        "}\n"
+    )
+    assert ("resource::SOCKET::example.com", _STDOUT) in _run_flow(tmp_path, source)
+
+
+def test_dart_listen_callback_parameter_shadows_an_outer_handle(
+    tmp_path: Path,
+) -> None:
+    # The parameter rebinds the name inside the lambda: a write through it
+    # must not reach the OUTER handle's resource.
+    source = (
+        "void leak() async {\n"
+        "  var k = Platform.environment['K'];\n"
+        "  var f = File('out.txt');\n"
+        "  var s = await Socket.connect('example.com', 80);\n"
+        "  s.listen((f) { f.writeAsString(k); });\n"
+        "}\n"
+    )
+    edges = _run_flow(tmp_path, source)
+    assert (_ENV_K, "resource::FILE::out.txt") not in edges

--- a/codebase_rag/tests/test_flow_dart_edges.py
+++ b/codebase_rag/tests/test_flow_dart_edges.py
@@ -214,3 +214,46 @@ def test_dart_env_flows_through_string_interpolation_to_process(tmp_path: Path) 
         "}\n"
     )
     assert (_ENV_K, "resource::PROCESS::sh") in _run_flow(tmp_path, source)
+
+
+def test_dart_file_read_binding_carries_the_resource_taint(tmp_path: Path) -> None:
+    # `var d = f.readAsString()` yields data FROM the file: the binding must
+    # carry the FILE resource as origin so a later sink links it (issue #1316).
+    source = (
+        "void leak() {\n"
+        "  var f = File('in.txt');\n"
+        "  var d = f.readAsString();\n"
+        "  print(d);\n"
+        "}\n"
+    )
+    assert ("resource::FILE::in.txt", _STDOUT) in _run_flow(tmp_path, source)
+
+
+def test_dart_awaited_read_binding_carries_the_resource_taint(
+    tmp_path: Path,
+) -> None:
+    # The async form routes through the await unwrap before the handle-read
+    # path; the binding must carry the same origin.
+    source = (
+        "void leak() async {\n"
+        "  var f = File('in.txt');\n"
+        "  var d = await f.readAsBytes();\n"
+        "  print(d);\n"
+        "}\n"
+    )
+    assert ("resource::FILE::in.txt", _STDOUT) in _run_flow(tmp_path, source)
+
+
+def test_dart_listen_callback_parameter_carries_the_socket_taint(
+    tmp_path: Path,
+) -> None:
+    # `s.listen((data) { ... })` delivers data FROM the connected socket into
+    # the callback parameter; the body is walked with the parameter seeded by
+    # the socket's resource identity (issue #1316).
+    source = (
+        "void leak() async {\n"
+        "  var s = await Socket.connect('example.com', 80);\n"
+        "  s.listen((data) { print(data); });\n"
+        "}\n"
+    )
+    assert ("resource::SOCKET::example.com", _STDOUT) in _run_flow(tmp_path, source)


### PR DESCRIPTION
Closes #1316.

The Dart handle-method tables carried READ rows since #1173 that nothing consumed: `var d = f.readAsString()` bound nothing, and `s.listen((data) { ... })` could not seed its callback. Both halves land here.

## What

1. **Binding reads**: a read METHOD on a bound handle evaluated as an RHS now yields the handle's resource bindings as taint, the read mirror of `_emit_handle_write`. READ_WRITE methods count (a DB execute's result is resource data too). The await unwrap from #1315 composes, so `var d = await f.readAsBytes()` carries the same origin.
2. **Listen callbacks**: the lean walk skips nested callable bodies by design, so `s.listen((data) { ... })` walks the callback block explicitly with a COPY of the state whose parameters are seeded by the handle's bindings; the copy keeps the seeding scoped to the lambda, and the body statements route through the ordinary branch-and-merge walker so nested control flow inside the callback behaves like any other body.

## Tests

RED-first: `File('in.txt')` read bindings (sync and awaited) emit `FILE::in.txt -> STDOUT` through a later `print`; the awaited `Socket.connect('example.com', 80)` listen callback emits `SOCKET::example.com -> STDOUT` from `print(data)` inside the lambda. The 371-test flow battery passes. (During development an insertion anchor matched a second, non-Dart call site and broke 118 flow tests; the battery caught it before commit and the call now lives only on the Dart path.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Dart data-flow analysis for file and socket resources.
  * Read results now correctly carry resource taint through direct and awaited operations.
  * Callback parameters from readable handles are tracked, including nested flows, optional or typed parameters, and shadowed handles.

* **Tests**
  * Added coverage for file reads, awaited reads, socket-listener callbacks, callback parameter variations, and handle shadowing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->