### PR TITLE
feat: persist start and name columns and rehydrate the col-keyed location indexes

### DIFF
--- a/codebase_rag/constants/graph.py
+++ b/codebase_rag/constants/graph.py
@@ -27,6 +27,12 @@ KEY_IS_MACRO = "is_macro"
 KEY_QUERY = "query"
 KEY_RESPONSE = "response"
 KEY_START_LINE = "start_line"
+# Column of the definition's own start token, and of its NAME token where the
+# two differ (Go keys semantic call targets at the name identifier while span
+# keys sit at the `func` keyword). Persisted so incremental runs can rehydrate
+# the col-keyed location indexes for unchanged files (issue #1240).
+KEY_START_COL = "start_col"
+KEY_NAME_START_COL = "name_start_col"
 KEY_END_LINE = "end_line"
 KEY_PATH = "path"
 KEY_ABSOLUTE_PATH = "absolute_path"
@@ -480,6 +486,31 @@ CYPHER_ALL_CSHARP_TYPE_LOCATIONS = (
     "AND n.path ENDS WITH '.cs' "
     "RETURN n.qualified_name AS qualified_name, n.path AS path, "
     "n.start_line AS start_line"
+)
+
+# Col-keyed location rehydration fetches (issue #1240). Both guard for
+# start_col's absence in Python: a pre-#1240 graph has none and degrades to
+# today's behavior until re-indexed.
+CYPHER_ALL_GO_TYPE_LOCATIONS = (
+    "MATCH (n) WHERE (n:Class OR n:Interface OR n:Enum OR n:Type OR n:Union) "
+    "AND n.qualified_name STARTS WITH $project_prefix "
+    "RETURN labels(n)[0] AS label, n.qualified_name AS qualified_name, "
+    "n.path AS path, n.start_line AS start_line, n.start_col AS start_col"
+)
+CYPHER_ALL_FUNCTION_LOCATIONS = (
+    "MATCH (m:Module)-[:DEFINES]->(f:Function) "
+    "WHERE m.qualified_name STARTS WITH $project_prefix "
+    "RETURN labels(f)[0] AS label, f.qualified_name AS qualified_name, "
+    "m.qualified_name AS module_qn, f.start_line AS start_line, "
+    "f.start_col AS start_col, f.name_start_col AS name_start_col"
+)
+CYPHER_ALL_METHOD_LOCATIONS = (
+    "MATCH (m:Module)-[:DEFINES]->(c)-[:DEFINES_METHOD]->(f:Method) "
+    "WHERE m.qualified_name STARTS WITH $project_prefix "
+    "RETURN labels(f)[0] AS label, f.qualified_name AS qualified_name, "
+    "c.qualified_name AS container_qn, "
+    "m.qualified_name AS module_qn, f.start_line AS start_line, "
+    "f.start_col AS start_col, f.name_start_col AS name_start_col"
 )
 KEY_CHILD_QN = "child_qn"
 KEY_BASE_QN = "base_qn"

--- a/codebase_rag/constants/graph.py
+++ b/codebase_rag/constants/graph.py
@@ -32,6 +32,7 @@ KEY_START_LINE = "start_line"
 # keys sit at the `func` keyword). Persisted so incremental runs can rehydrate
 # the col-keyed location indexes for unchanged files (issue #1240).
 KEY_START_COL = "start_col"
+KEY_NAME_START_LINE = "name_start_line"
 KEY_NAME_START_COL = "name_start_col"
 KEY_END_LINE = "end_line"
 KEY_PATH = "path"
@@ -502,7 +503,8 @@ CYPHER_ALL_FUNCTION_LOCATIONS = (
     "WHERE m.qualified_name STARTS WITH $project_prefix "
     "RETURN labels(f)[0] AS label, f.qualified_name AS qualified_name, "
     "m.qualified_name AS module_qn, f.start_line AS start_line, "
-    "f.start_col AS start_col, f.name_start_col AS name_start_col"
+    "f.start_col AS start_col, f.name_start_line AS name_start_line, "
+    "f.name_start_col AS name_start_col"
 )
 CYPHER_ALL_METHOD_LOCATIONS = (
     "MATCH (m:Module)-[:DEFINES]->(c)-[:DEFINES_METHOD]->(f:Method) "
@@ -510,7 +512,8 @@ CYPHER_ALL_METHOD_LOCATIONS = (
     "RETURN labels(f)[0] AS label, f.qualified_name AS qualified_name, "
     "c.qualified_name AS container_qn, "
     "m.qualified_name AS module_qn, f.start_line AS start_line, "
-    "f.start_col AS start_col, f.name_start_col AS name_start_col"
+    "f.start_col AS start_col, f.name_start_line AS name_start_line, "
+    "f.name_start_col AS name_start_col"
 )
 KEY_CHILD_QN = "child_qn"
 KEY_BASE_QN = "base_qn"

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -68,6 +68,7 @@ from .types_defs import (
     CppDefinitionSpan,
     EmbeddingQueryResult,
     FunctionLocation,
+    FunctionLocations,
     LanguageQueries,
     NodeType,
     PendingExpansionCall,
@@ -85,6 +86,14 @@ from .utils.path_utils import (
     should_skip_rel_file,
 )
 from .utils.source_extraction import extract_source_with_fallback
+
+
+def _persisted_int(value: object) -> int | None:
+    # bool is an int subclass; a stray True would key as 1 and shadow a real
+    # entry, so it is rejected explicitly (same discipline as the C# path).
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    return None
 
 
 def _owning_module_qn(qn: str, module_qns: set[str]) -> str | None:
@@ -769,6 +778,11 @@ class GraphUpdater:
         # project-wide query would be wasted work -- skip it.
         if not force and not self._is_full_build:
             self._rehydrate_csharp_type_locations()
+            # Same posture for the col-keyed indexes (issue #1240): the Go
+            # IMPLEMENTS and semantic-call joins below resolve against
+            # locations Pass 2 filled only for re-parsed files.
+            self._rehydrate_go_type_locations()
+            self._rehydrate_function_locations()
 
         # Partial groups join AFTER Pass 2: the Roslyn declaration
         # locations resolve against the Class qns Pass 2 just registered.
@@ -1392,6 +1406,111 @@ class GraphUpdater:
                 restored += 1
         if restored:
             logger.info(ls.CSHARP_TYPE_LOCATIONS_REHYDRATED.format(count=restored))
+
+    def _rehydrate_go_type_locations(self) -> None:
+        # Incremental runs fill go_type_locations only from re-parsed files,
+        # but _join_go_implements resolves BOTH ends of each pair against it.
+        # Restore (path, line, col) -> (qn, label) for types in unchanged .go
+        # files from the persisted graph (issue #1240). A pre-#1240 graph has
+        # no start_col: those rows are skipped and behavior degrades to
+        # today's until a re-index.
+        if not isinstance(self.ingestor, QueryProtocol):
+            return
+        locations = self.factory.definition_processor.go_type_locations
+        try:
+            rows = self.ingestor.fetch_all(
+                cs.CYPHER_ALL_GO_TYPE_LOCATIONS,
+                {cs.KEY_PROJECT_PREFIX: self.project_name + "."},
+            )
+        except Exception:
+            if not self._is_full_build:
+                raise
+            logger.warning(ls.REHYDRATE_QUERY_FAILED)
+            return
+        restored = 0
+        for row in rows:
+            path = row.get(cs.KEY_PATH)
+            qn = row.get(cs.KEY_QUALIFIED_NAME)
+            label = row.get(cs.KEY_LABEL)
+            start_line = _persisted_int(row.get(cs.KEY_START_LINE))
+            start_col = _persisted_int(row.get(cs.KEY_START_COL))
+            if not (
+                isinstance(path, str)
+                and path.endswith(cs.EXT_GO)
+                and isinstance(qn, str)
+                and isinstance(label, str)
+                and start_line is not None
+                and start_col is not None
+            ):
+                continue
+            key = (path, start_line, start_col)
+            if key not in locations:
+                locations[key] = (qn, label)
+                restored += 1
+        if restored:
+            logger.info(ls.GO_TYPE_LOCATIONS_REHYDRATED.format(count=restored))
+
+    def _rehydrate_function_locations(self) -> None:
+        # The C#/Go semantic call + LINQ joins resolve targets against
+        # function_locations, keyed (module_qn, line, col) at the definition
+        # START; Go's join additionally keys at the NAME token, whose column
+        # is persisted separately (issue #1240). Fresh Pass-2 entries win;
+        # rehydrated records serve the joins only (Pass 3 touches re-parsed
+        # files exclusively), so a METHOD's container comes from the query
+        # and is_named stays True (generated qns never persist under Module
+        # DEFINES).
+        if not isinstance(self.ingestor, QueryProtocol):
+            return
+        locations = self.factory.definition_processor.function_locations
+        params = {cs.KEY_PROJECT_PREFIX: self.project_name + "."}
+        restored = 0
+        for query in (
+            cs.CYPHER_ALL_FUNCTION_LOCATIONS,
+            cs.CYPHER_ALL_METHOD_LOCATIONS,
+        ):
+            try:
+                rows = self.ingestor.fetch_all(query, params)
+            except Exception:
+                if not self._is_full_build:
+                    raise
+                logger.warning(ls.REHYDRATE_QUERY_FAILED)
+                return
+            restored += self._restore_function_rows(rows, locations)
+        if restored:
+            logger.info(ls.FUNCTION_LOCATIONS_REHYDRATED.format(count=restored))
+
+    @staticmethod
+    def _restore_function_rows(
+        rows: list[ResultRow], locations: FunctionLocations
+    ) -> int:
+        restored = 0
+        for row in rows:
+            module_qn = row.get("module_qn")
+            qn = row.get(cs.KEY_QUALIFIED_NAME)
+            label = row.get(cs.KEY_LABEL)
+            container = row.get("container_qn")
+            start_line = _persisted_int(row.get(cs.KEY_START_LINE))
+            start_col = _persisted_int(row.get(cs.KEY_START_COL))
+            name_col = _persisted_int(row.get(cs.KEY_NAME_START_COL))
+            if not (
+                isinstance(module_qn, str)
+                and isinstance(qn, str)
+                and isinstance(label, str)
+                and start_line is not None
+                and start_col is not None
+            ):
+                continue
+            record = FunctionLocation(
+                label=label,
+                qualified_name=qn,
+                container_qn=container if isinstance(container, str) else None,
+            )
+            for col in {start_col, name_col if name_col is not None else start_col}:
+                key = (module_qn, start_line, col)
+                if key not in locations:
+                    locations[key] = record
+                    restored += 1
+        return restored
 
     def _capture_inbound_edges(self, reindexed_keys: list[str]) -> list[ResultRow]:
         # Record the reference edges unchanged files point at the re-indexed

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1491,6 +1491,7 @@ class GraphUpdater:
             container = row.get("container_qn")
             start_line = _persisted_int(row.get(cs.KEY_START_LINE))
             start_col = _persisted_int(row.get(cs.KEY_START_COL))
+            name_line = _persisted_int(row.get(cs.KEY_NAME_START_LINE))
             name_col = _persisted_int(row.get(cs.KEY_NAME_START_COL))
             if not (
                 isinstance(module_qn, str)
@@ -1505,8 +1506,13 @@ class GraphUpdater:
                 qualified_name=qn,
                 container_qn=container if isinstance(container, str) else None,
             )
-            for col in {start_col, name_col if name_col is not None else start_col}:
-                key = (module_qn, start_line, col)
+            keys = {(module_qn, start_line, start_col)}
+            if name_col is not None:
+                # The NAME token can sit on a LATER line than the declaration
+                # start (a multiline Go receiver), so the alias keys at its
+                # own persisted line, never the declaration's.
+                keys.add((module_qn, name_line or start_line, name_col))
+            for key in keys:
                 if key not in locations:
                     locations[key] = record
                     restored += 1

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -843,6 +843,12 @@ REHYDRATE_QUERY_FAILED = (
 CSHARP_TYPE_LOCATIONS_REHYDRATED = (
     "Rehydrated {count} C# type location(s) from the graph for the partial join"
 )
+GO_TYPE_LOCATIONS_REHYDRATED = (
+    "Rehydrated {count} Go type location(s) from the persisted graph"
+)
+FUNCTION_LOCATIONS_REHYDRATED = (
+    "Rehydrated {count} function location(s) from the persisted graph"
+)
 INBOUND_CAPTURE_FAILED = (
     "Could not read inbound edges from the graph; this full rebuild "
     "re-parses every caller, so the edges are re-resolved from source."

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -1061,6 +1061,7 @@ class ClassIngestMixin:
             cs.KEY_MODIFIERS: modifiers,
             cs.KEY_DECORATORS: decorators,
             cs.KEY_START_LINE: class_start_line,
+            cs.KEY_START_COL: class_start_col,
             cs.KEY_END_LINE: class_node.end_point[0] + 1,
             cs.KEY_DOCSTRING: self._get_docstring(class_node),
             cs.KEY_IS_EXPORTED: is_exported,

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -50,18 +50,18 @@ if TYPE_CHECKING:
     from .handlers import LanguageHandler
 
 
-def _name_start_col(func_node: Node) -> int:
-    """Column of the definition's NAME token, falling back to the node start.
+def _name_start_point(func_node: Node) -> tuple[int, int]:
+    """(line, column) of the definition's NAME token, falling back to the
+    node start.
 
     Go's semantic call join keys targets at the name identifier while the
-    span key sits at the `func` keyword; persisting both columns lets an
-    incremental run rehydrate the name-token alias for unchanged files
-    (issue #1240).
+    span key sits at the `func` keyword; the name can even sit on a LATER
+    line (a multiline receiver), so both coordinates persist and the
+    incremental rehydration rebuilds the alias exactly (issue #1240).
     """
     name_node = func_node.child_by_field_name(cs.FIELD_NAME)
-    if name_node is None:
-        return func_node.start_point[1]
-    return name_node.start_point[1]
+    anchor = name_node if name_node is not None else func_node
+    return anchor.start_point[0] + 1, anchor.start_point[1]
 
 
 def _nearest_preceding_csharp_type(
@@ -778,7 +778,8 @@ class FunctionIngestMixin:
                 cs.KEY_DECORATORS: decorators,
                 cs.KEY_START_LINE: func_node.start_point[0] + 1,
                 cs.KEY_START_COL: func_node.start_point[1],
-                cs.KEY_NAME_START_COL: _name_start_col(func_node),
+                cs.KEY_NAME_START_LINE: _name_start_point(func_node)[0],
+                cs.KEY_NAME_START_COL: _name_start_point(func_node)[1],
                 cs.KEY_END_LINE: func_node.end_point[0] + 1,
                 cs.KEY_DOCSTRING: self._get_docstring(func_node),
             }
@@ -1420,7 +1421,8 @@ class FunctionIngestMixin:
             cs.KEY_DECORATORS: decorators,
             cs.KEY_START_LINE: func_node.start_point[0] + 1,
             cs.KEY_START_COL: func_node.start_point[1],
-            cs.KEY_NAME_START_COL: _name_start_col(func_node),
+            cs.KEY_NAME_START_LINE: _name_start_point(func_node)[0],
+            cs.KEY_NAME_START_COL: _name_start_point(func_node)[1],
             # Dart splits a definition into a signature node and a sibling
             # function_body; extend the end over that body so the snippet covers the
             # whole function (no-op for every other language).

--- a/codebase_rag/parsers/function_ingest.py
+++ b/codebase_rag/parsers/function_ingest.py
@@ -50,6 +50,20 @@ if TYPE_CHECKING:
     from .handlers import LanguageHandler
 
 
+def _name_start_col(func_node: Node) -> int:
+    """Column of the definition's NAME token, falling back to the node start.
+
+    Go's semantic call join keys targets at the name identifier while the
+    span key sits at the `func` keyword; persisting both columns lets an
+    incremental run rehydrate the name-token alias for unchanged files
+    (issue #1240).
+    """
+    name_node = func_node.child_by_field_name(cs.FIELD_NAME)
+    if name_node is None:
+        return func_node.start_point[1]
+    return name_node.start_point[1]
+
+
 def _nearest_preceding_csharp_type(
     func_node: Node, class_node_types: frozenset[str]
 ) -> Node | None:
@@ -763,6 +777,8 @@ class FunctionIngestMixin:
                 cs.KEY_MODIFIERS: modifiers,
                 cs.KEY_DECORATORS: decorators,
                 cs.KEY_START_LINE: func_node.start_point[0] + 1,
+                cs.KEY_START_COL: func_node.start_point[1],
+                cs.KEY_NAME_START_COL: _name_start_col(func_node),
                 cs.KEY_END_LINE: func_node.end_point[0] + 1,
                 cs.KEY_DOCSTRING: self._get_docstring(func_node),
             }
@@ -1403,6 +1419,8 @@ class FunctionIngestMixin:
             cs.KEY_MODIFIERS: modifiers,
             cs.KEY_DECORATORS: decorators,
             cs.KEY_START_LINE: func_node.start_point[0] + 1,
+            cs.KEY_START_COL: func_node.start_point[1],
+            cs.KEY_NAME_START_COL: _name_start_col(func_node),
             # Dart splits a definition into a signature node and a sibling
             # function_body; extend the end over that body so the snippet covers the
             # whole function (no-op for every other language).

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -31,6 +31,16 @@ if TYPE_CHECKING:
     from ..types_defs import FunctionRegistryTrieProtocol
 
 
+def _member_name_start_col(node: Node) -> int:
+    """Column of the definition's NAME token, falling back to the node start
+    (issue #1240: the persisted pair lets incremental runs rehydrate both the
+    span key and Go's name-token alias)."""
+    name_node = node.child_by_field_name(cs.FIELD_NAME)
+    if name_node is None:
+        return node.start_point[1]
+    return name_node.start_point[1]
+
+
 def follow_reexports(
     qn: str,
     import_mapping: dict[str, dict[str, str]],
@@ -1212,6 +1222,8 @@ def ingest_method(
         cs.KEY_MODIFIERS: modifiers,
         cs.KEY_DECORATORS: decorators,
         cs.KEY_START_LINE: method_start_line,
+        cs.KEY_START_COL: method_start_col,
+        cs.KEY_NAME_START_COL: _member_name_start_col(method_node),
         # Dart method signatures end before their sibling function_body;
         # extend the span over the body (no-op for other languages).
         cs.KEY_END_LINE: _method_end_line(method_node, language),
@@ -1358,6 +1370,8 @@ def module_function_props(
         cs.KEY_MODIFIERS: [],
         cs.KEY_DECORATORS: [],
         cs.KEY_START_LINE: function_node.start_point[0] + 1,
+        cs.KEY_START_COL: function_node.start_point[1],
+        cs.KEY_NAME_START_COL: _member_name_start_col(function_node),
         cs.KEY_END_LINE: function_node.end_point[0] + 1,
         cs.KEY_DOCSTRING: docstring,
         # JS/TS only (per this helper's contract), so the JS branch of the

--- a/codebase_rag/parsers/utils.py
+++ b/codebase_rag/parsers/utils.py
@@ -31,14 +31,14 @@ if TYPE_CHECKING:
     from ..types_defs import FunctionRegistryTrieProtocol
 
 
-def _member_name_start_col(node: Node) -> int:
-    """Column of the definition's NAME token, falling back to the node start
-    (issue #1240: the persisted pair lets incremental runs rehydrate both the
-    span key and Go's name-token alias)."""
+def _member_name_start_point(node: Node) -> tuple[int, int]:
+    """(line, column) of the definition's NAME token, falling back to the
+    node start (issue #1240: the persisted coordinates let incremental runs
+    rehydrate both the span key and Go's name-token alias, whose name can
+    sit on a later line than the declaration start)."""
     name_node = node.child_by_field_name(cs.FIELD_NAME)
-    if name_node is None:
-        return node.start_point[1]
-    return name_node.start_point[1]
+    anchor = name_node if name_node is not None else node
+    return anchor.start_point[0] + 1, anchor.start_point[1]
 
 
 def follow_reexports(
@@ -1223,7 +1223,8 @@ def ingest_method(
         cs.KEY_DECORATORS: decorators,
         cs.KEY_START_LINE: method_start_line,
         cs.KEY_START_COL: method_start_col,
-        cs.KEY_NAME_START_COL: _member_name_start_col(method_node),
+        cs.KEY_NAME_START_LINE: _member_name_start_point(method_node)[0],
+        cs.KEY_NAME_START_COL: _member_name_start_point(method_node)[1],
         # Dart method signatures end before their sibling function_body;
         # extend the span over the body (no-op for other languages).
         cs.KEY_END_LINE: _method_end_line(method_node, language),
@@ -1371,7 +1372,8 @@ def module_function_props(
         cs.KEY_DECORATORS: [],
         cs.KEY_START_LINE: function_node.start_point[0] + 1,
         cs.KEY_START_COL: function_node.start_point[1],
-        cs.KEY_NAME_START_COL: _member_name_start_col(function_node),
+        cs.KEY_NAME_START_LINE: _member_name_start_point(function_node)[0],
+        cs.KEY_NAME_START_COL: _member_name_start_point(function_node)[1],
         cs.KEY_END_LINE: function_node.end_point[0] + 1,
         cs.KEY_DOCSTRING: docstring,
         # JS/TS only (per this helper's contract), so the JS branch of the

--- a/codebase_rag/tests/test_col_keyed_location_rehydration.py
+++ b/codebase_rag/tests/test_col_keyed_location_rehydration.py
@@ -270,7 +270,10 @@ def test_nodes_persist_start_and_name_columns(tmp_path: Path) -> None:
         p for p in by_label.get("Function", []) if p.get(cs.KEY_NAME) == "main"
     ]
     methods = [p for p in by_label.get("Method", []) if p.get(cs.KEY_NAME) == "render"]
-    assert classes and cs.KEY_START_COL in classes[0]
-    assert functions and cs.KEY_START_COL in functions[0]
+    assert classes
+    assert cs.KEY_START_COL in classes[0]
+    assert functions
+    assert cs.KEY_START_COL in functions[0]
     assert functions[0][cs.KEY_NAME_START_COL] == 4
-    assert methods and methods[0][cs.KEY_START_COL] == 4
+    assert methods
+    assert methods[0][cs.KEY_START_COL] == 4

--- a/codebase_rag/tests/test_col_keyed_location_rehydration.py
+++ b/codebase_rag/tests/test_col_keyed_location_rehydration.py
@@ -184,6 +184,36 @@ def test_function_rehydration_keys_span_and_name_alias(tmp_path: Path) -> None:
     assert method.label == "Method"
 
 
+def test_alias_keys_at_the_name_tokens_own_line(tmp_path: Path) -> None:
+    # A multiline Go receiver puts the NAME on a later line than the
+    # declaration start; the alias must key at the name's persisted line,
+    # never the declaration's (review on #1318).
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    graph = _LocGraph(
+        methods=[
+            {
+                cs.KEY_QUALIFIED_NAME: "proj.pkg.s.Wide.Do",
+                cs.KEY_LABEL: "Method",
+                "container_qn": "proj.pkg.s.Wide",
+                "module_qn": "proj.pkg.s",
+                cs.KEY_START_LINE: 5,
+                cs.KEY_START_COL: 0,
+                cs.KEY_NAME_START_LINE: 7,
+                cs.KEY_NAME_START_COL: 2,
+            }
+        ]
+    )
+    updater = _updater(repo, graph)
+    dp = updater.factory.definition_processor
+
+    updater._rehydrate_function_locations()
+
+    assert ("proj.pkg.s", 5, 0) in dp.function_locations
+    assert ("proj.pkg.s", 7, 2) in dp.function_locations
+    assert ("proj.pkg.s", 5, 2) not in dp.function_locations
+
+
 def test_function_rehydration_never_overwrites_fresh_entries(tmp_path: Path) -> None:
     from codebase_rag.types_defs import FunctionLocation
 

--- a/codebase_rag/tests/test_col_keyed_location_rehydration.py
+++ b/codebase_rag/tests/test_col_keyed_location_rehydration.py
@@ -1,0 +1,246 @@
+# Issue #1240 (Phase 2 of #1229): the Go IMPLEMENTS and semantic-call joins
+# resolve positions against col-keyed indexes (go_type_locations,
+# function_locations) that Pass 2 fills only for RE-PARSED files. These tests
+# drive the rehydration + joins directly (no Go toolchain, no real DB) via a
+# QueryProtocol fake answering the location queries from seeded rows, exactly
+# like the Phase-1 C# harness.
+from __future__ import annotations
+
+from pathlib import Path
+
+from codebase_rag import constants as cs
+from codebase_rag import graph_updater as gu
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.parsers.frontends.protocol import ImplementsPair
+from codebase_rag.types_defs import PropertyDict, ResultRow
+
+
+class _LocGraph:
+    """Answers the three location queries from seeded row lists; records
+    relationship writes so the IMPLEMENTS join is observable."""
+
+    def __init__(
+        self,
+        go_types: list[ResultRow] | None = None,
+        functions: list[ResultRow] | None = None,
+        methods: list[ResultRow] | None = None,
+    ) -> None:
+        self._by_query = {
+            cs.CYPHER_ALL_GO_TYPE_LOCATIONS: go_types or [],
+            cs.CYPHER_ALL_FUNCTION_LOCATIONS: functions or [],
+            cs.CYPHER_ALL_METHOD_LOCATIONS: methods or [],
+        }
+        self.edges: list[tuple[str, str, str]] = []
+
+    def ensure_node_batch(self, label: str, properties: PropertyDict) -> None:
+        return None
+
+    def ensure_relationship_batch(
+        self, from_spec, rel_type, to_spec, properties=None
+    ) -> None:
+        self.edges.append((from_spec[2], str(rel_type), to_spec[2]))
+
+    def flush_all(self) -> None:
+        return None
+
+    def fetch_all(
+        self, query: str, params: PropertyDict | None = None
+    ) -> list[ResultRow]:
+        return self._by_query.get(query, [])
+
+    def execute_write(self, query: str, params: PropertyDict | None = None) -> None:
+        return None
+
+
+def _updater(repo: Path, graph: _LocGraph) -> gu.GraphUpdater:
+    parsers, queries = load_parsers()
+    return gu.GraphUpdater(
+        ingestor=graph, repo_path=repo, parsers=parsers, queries=queries
+    )
+
+
+def _go_type_row(qn: str, label: str, path: str, line: int, col: int) -> ResultRow:
+    return {
+        cs.KEY_QUALIFIED_NAME: qn,
+        cs.KEY_LABEL: label,
+        cs.KEY_PATH: path,
+        cs.KEY_START_LINE: line,
+        cs.KEY_START_COL: col,
+    }
+
+
+def test_go_implements_joins_across_an_unchanged_file(tmp_path: Path) -> None:
+    # The implementer is in a re-parsed file (fresh Pass-2 entry); the
+    # interface sits in an UNCHANGED file and resolves only through the
+    # rehydrated persisted location.
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    graph = _LocGraph(
+        go_types=[
+            _go_type_row("proj.pkg.iface.Store", "Interface", "pkg/iface.go", 3, 5)
+        ]
+    )
+    updater = _updater(repo, graph)
+    dp = updater.factory.definition_processor
+    dp.go_type_locations[("pkg/impl.go", 8, 5)] = ("proj.pkg.impl.DiskStore", "Class")
+    dp.go_implements = [
+        ImplementsPair(
+            impl_file="pkg/impl.go",
+            impl_line=8,
+            impl_col=5,
+            iface_file="pkg/iface.go",
+            iface_line=3,
+            iface_col=5,
+        )
+    ]
+
+    updater._rehydrate_go_type_locations()
+    updater._join_go_implements()
+
+    assert (
+        "proj.pkg.impl.DiskStore",
+        cs.RelationshipType.IMPLEMENTS.value,
+        "proj.pkg.iface.Store",
+    ) in [(a, r, b) for a, r, b in graph.edges]
+
+
+def test_go_type_rehydration_guards_old_graphs_and_fresh_entries(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    graph = _LocGraph(
+        go_types=[
+            # pre-#1240 row: no start_col persisted -> skipped cleanly.
+            {
+                cs.KEY_QUALIFIED_NAME: "proj.old.T",
+                cs.KEY_LABEL: "Class",
+                cs.KEY_PATH: "old/t.go",
+                cs.KEY_START_LINE: 2,
+                cs.KEY_START_COL: None,
+            },
+            # bool masquerading as an int is rejected, not keyed as col 1.
+            _go_type_row("proj.b.T", "Class", "b/t.go", 2, True),
+            # a non-Go path never enters the Go index.
+            _go_type_row("proj.cs.T", "Class", "cs/t.cs", 2, 4),
+            # a fresh Pass-2 entry is kept, not overwritten.
+            _go_type_row("proj.pkg.stale.Dup", "Class", "pkg/dup.go", 5, 0),
+        ]
+    )
+    updater = _updater(repo, graph)
+    dp = updater.factory.definition_processor
+    dp.go_type_locations[("pkg/dup.go", 5, 0)] = ("proj.pkg.fresh.Dup", "Class")
+
+    updater._rehydrate_go_type_locations()
+
+    assert dp.go_type_locations[("pkg/dup.go", 5, 0)] == (
+        "proj.pkg.fresh.Dup",
+        "Class",
+    )
+    assert ("old/t.go", 2, None) not in dp.go_type_locations
+    assert all("cs/t.cs" != key[0] for key in dp.go_type_locations)
+    assert len(dp.go_type_locations) == 1
+
+
+def test_function_rehydration_keys_span_and_name_alias(tmp_path: Path) -> None:
+    # Go keys semantic call targets at the NAME token while span keys sit at
+    # the `func` keyword; both persisted columns must key the same record.
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    graph = _LocGraph(
+        functions=[
+            {
+                cs.KEY_QUALIFIED_NAME: "proj.pkg.util.Do",
+                cs.KEY_LABEL: "Function",
+                "module_qn": "proj.pkg.util",
+                cs.KEY_START_LINE: 10,
+                cs.KEY_START_COL: 0,
+                cs.KEY_NAME_START_COL: 5,
+            }
+        ],
+        methods=[
+            {
+                cs.KEY_QUALIFIED_NAME: "proj.pkg.store.Disk.Put",
+                cs.KEY_LABEL: "Method",
+                "container_qn": "proj.pkg.store.Disk",
+                "module_qn": "proj.pkg.store",
+                cs.KEY_START_LINE: 22,
+                cs.KEY_START_COL: 0,
+                cs.KEY_NAME_START_COL: 18,
+            }
+        ],
+    )
+    updater = _updater(repo, graph)
+    dp = updater.factory.definition_processor
+
+    updater._rehydrate_function_locations()
+
+    span = dp.function_locations[("proj.pkg.util", 10, 0)]
+    alias = dp.function_locations[("proj.pkg.util", 10, 5)]
+    assert span == alias
+    assert span.qualified_name == "proj.pkg.util.Do"
+    method = dp.function_locations[("proj.pkg.store", 22, 18)]
+    assert method.container_qn == "proj.pkg.store.Disk"
+    assert method.label == "Method"
+
+
+def test_function_rehydration_never_overwrites_fresh_entries(tmp_path: Path) -> None:
+    from codebase_rag.types_defs import FunctionLocation
+
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    graph = _LocGraph(
+        functions=[
+            {
+                cs.KEY_QUALIFIED_NAME: "proj.m.stale",
+                cs.KEY_LABEL: "Function",
+                "module_qn": "proj.m",
+                cs.KEY_START_LINE: 4,
+                cs.KEY_START_COL: 0,
+                cs.KEY_NAME_START_COL: 5,
+            }
+        ]
+    )
+    updater = _updater(repo, graph)
+    dp = updater.factory.definition_processor
+    fresh = FunctionLocation(
+        label="Function", qualified_name="proj.m.fresh", container_qn=None
+    )
+    dp.function_locations[("proj.m", 4, 0)] = fresh
+
+    updater._rehydrate_function_locations()
+
+    assert dp.function_locations[("proj.m", 4, 0)] == fresh
+    # The alias key was still free and rehydrates to the persisted record.
+    assert dp.function_locations[("proj.m", 4, 5)].qualified_name == "proj.m.stale"
+
+
+def test_nodes_persist_start_and_name_columns(tmp_path: Path) -> None:
+    # The rehydration above only works if writes carry the columns; pin the
+    # additive schema on a real parse (language-agnostic writer paths).
+    from unittest.mock import MagicMock
+
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    (repo / "app.py").write_text(
+        "class Widget:\n    def render(self):\n        return 1\n\n"
+        "def main():\n    return 2\n",
+        encoding="utf-8",
+    )
+    parsers, queries = load_parsers()
+    mock = MagicMock()
+    gu.GraphUpdater(
+        ingestor=mock, repo_path=repo, parsers=parsers, queries=queries
+    ).run()
+    by_label: dict[str, list[PropertyDict]] = {}
+    for call in mock.ensure_node_batch.call_args_list:
+        by_label.setdefault(str(call.args[0]), []).append(call.args[1])
+    classes = [p for p in by_label.get("Class", []) if p.get(cs.KEY_NAME) == "Widget"]
+    functions = [
+        p for p in by_label.get("Function", []) if p.get(cs.KEY_NAME) == "main"
+    ]
+    methods = [p for p in by_label.get("Method", []) if p.get(cs.KEY_NAME) == "render"]
+    assert classes and cs.KEY_START_COL in classes[0]
+    assert functions and cs.KEY_START_COL in functions[0]
+    assert functions[0][cs.KEY_NAME_START_COL] == 4
+    assert methods and methods[0][cs.KEY_START_COL] == 4

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -780,31 +780,31 @@ NODE_SCHEMAS: tuple[NodeSchema, ...] = (
     ),
     NodeSchema(
         NodeLabel.CLASS,
-        "{qualified_name: string, name: string, modifiers: list[string], decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}",
+        "{qualified_name: string, name: string, modifiers: list[string], decorators: list[string], path: string, absolute_path: string, start_col: int?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}",
     ),
     NodeSchema(
         NodeLabel.FUNCTION,
-        "{qualified_name: string, name: string, modifiers: list[string], decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?, is_macro: boolean?}",
+        "{qualified_name: string, name: string, modifiers: list[string], decorators: list[string], path: string, absolute_path: string, start_col: int?, name_start_col: int?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?, is_macro: boolean?}",
     ),
     NodeSchema(
         NodeLabel.METHOD,
-        "{qualified_name: string, name: string, modifiers: list[string], decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?, is_property: boolean?, overrides_external: boolean?}",
+        "{qualified_name: string, name: string, modifiers: list[string], decorators: list[string], path: string, absolute_path: string, start_col: int?, name_start_col: int?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?, is_property: boolean?, overrides_external: boolean?}",
     ),
     NodeSchema(
         NodeLabel.INTERFACE,
-        "{qualified_name: string, name: string, path: string, absolute_path: string, modifiers: list[string]?, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}",
+        "{qualified_name: string, name: string, path: string, absolute_path: string, modifiers: list[string]?, decorators: list[string]?, start_col: int?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}",
     ),
     NodeSchema(
         NodeLabel.ENUM,
-        "{qualified_name: string, name: string, path: string, absolute_path: string, modifiers: list[string]?, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}",
+        "{qualified_name: string, name: string, path: string, absolute_path: string, modifiers: list[string]?, decorators: list[string]?, start_col: int?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}",
     ),
     NodeSchema(
         NodeLabel.TYPE,
-        "{qualified_name: string, name: string, path: string?, absolute_path: string?, modifiers: list[string]?, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}",
+        "{qualified_name: string, name: string, path: string?, absolute_path: string?, modifiers: list[string]?, decorators: list[string]?, start_col: int?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}",
     ),
     NodeSchema(
         NodeLabel.UNION,
-        "{qualified_name: string, name: string, path: string?, absolute_path: string?, modifiers: list[string]?, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}",
+        "{qualified_name: string, name: string, path: string?, absolute_path: string?, modifiers: list[string]?, decorators: list[string]?, start_col: int?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}",
     ),
     NodeSchema(
         NodeLabel.MODULE_INTERFACE,

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -784,11 +784,11 @@ NODE_SCHEMAS: tuple[NodeSchema, ...] = (
     ),
     NodeSchema(
         NodeLabel.FUNCTION,
-        "{qualified_name: string, name: string, modifiers: list[string], decorators: list[string], path: string, absolute_path: string, start_col: int?, name_start_col: int?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?, is_macro: boolean?}",
+        "{qualified_name: string, name: string, modifiers: list[string], decorators: list[string], path: string, absolute_path: string, start_col: int?, name_start_line: int?, name_start_col: int?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?, is_macro: boolean?}",
     ),
     NodeSchema(
         NodeLabel.METHOD,
-        "{qualified_name: string, name: string, modifiers: list[string], decorators: list[string], path: string, absolute_path: string, start_col: int?, name_start_col: int?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?, is_property: boolean?, overrides_external: boolean?}",
+        "{qualified_name: string, name: string, modifiers: list[string], decorators: list[string], path: string, absolute_path: string, start_col: int?, name_start_line: int?, name_start_col: int?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?, is_property: boolean?, overrides_external: boolean?}",
     ),
     NodeSchema(
         NodeLabel.INTERFACE,

--- a/docs/architecture/graph-schema.md
+++ b/docs/architecture/graph-schema.md
@@ -16,8 +16,8 @@ The knowledge graph uses a unified schema across all supported languages.
 | File | `{path: string, name: string, extension: string?, absolute_path: string}` |
 | Module | `{qualified_name: string, name: string, path: string, absolute_path: string, flow_covered: boolean?, start_line: int?, end_line: int?}` |
 | Class | `{qualified_name: string, name: string, modifiers: list[string], decorators: list[string], path: string, absolute_path: string, start_col: int?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
-| Function | same as Class, plus `is_macro: boolean?, name_start_col: int?` |
-| Method | same as Class, plus `is_property: boolean?, overrides_external: boolean?, name_start_col: int?` |
+| Function | same as Class, plus `is_macro: boolean?, name_start_line: int?, name_start_col: int?` |
+| Method | same as Class, plus `is_property: boolean?, overrides_external: boolean?, name_start_line: int?, name_start_col: int?` |
 | Interface | `{qualified_name: string, name: string, path: string, absolute_path: string, modifiers: list[string]?, decorators: list[string]?, start_col: int?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
 | Enum | same as Interface |
 | Type | same as Interface, but `path` and `absolute_path` are optional |

--- a/docs/architecture/graph-schema.md
+++ b/docs/architecture/graph-schema.md
@@ -15,10 +15,10 @@ The knowledge graph uses a unified schema across all supported languages.
 | Folder | `{path: string, name: string, absolute_path: string}` |
 | File | `{path: string, name: string, extension: string?, absolute_path: string}` |
 | Module | `{qualified_name: string, name: string, path: string, absolute_path: string, flow_covered: boolean?, start_line: int?, end_line: int?}` |
-| Class | `{qualified_name: string, name: string, modifiers: list[string], decorators: list[string], path: string, absolute_path: string, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
-| Function | same as Class, plus `is_macro: boolean?` |
-| Method | same as Class, plus `is_property: boolean?, overrides_external: boolean?` |
-| Interface | `{qualified_name: string, name: string, path: string, absolute_path: string, modifiers: list[string]?, decorators: list[string]?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
+| Class | `{qualified_name: string, name: string, modifiers: list[string], decorators: list[string], path: string, absolute_path: string, start_col: int?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
+| Function | same as Class, plus `is_macro: boolean?, name_start_col: int?` |
+| Method | same as Class, plus `is_property: boolean?, overrides_external: boolean?, name_start_col: int?` |
+| Interface | `{qualified_name: string, name: string, path: string, absolute_path: string, modifiers: list[string]?, decorators: list[string]?, start_col: int?, start_line: int?, end_line: int?, docstring: string?, is_exported: boolean?}` |
 | Enum | same as Interface |
 | Type | same as Interface, but `path` and `absolute_path` are optional |
 | Union | same as Type |


### PR DESCRIPTION
Closes #1240 (Phase 2 of #1229; Phase 1 was the C# type-location rehydration in #1239).

## Problem

`go_type_locations` (Go IMPLEMENTS join) and `function_locations` (C#/Go semantic call + LINQ joins) are keyed by `(…, start_line, start_col)`, but nodes persisted only `start_line`, so an incremental `run(force=False)` could not rehydrate them: a join endpoint in an unchanged file silently failed to resolve.

## The design decision the issue asked for

The issue offered re-keying the Go call join to the `func`-keyword start (removing the Pass-2 name-token alias and the gap in one move). Evaluated and not taken here: `types.Func.Pos()` is the declaring identifier, so the gotypes tool would need a cross-package name-pos to decl-pos pre-pass over `pkg.Syntax` before any call collection, and this environment has no Go toolchain to verify that change against the live frontend tests. Instead the schema persists BOTH columns: `start_col` (the definition's own start, additive on Class/Interface/Enum/Type/Union/Function/Method) and `name_start_col` (the NAME token, on Function/Method), so rehydration reconstructs the span key and the alias exactly as Pass 2 writes them. The re-key remains available as a Go-tool follow-up that would then let `name_start_col` retire.

## What

- All four node-writer paths carry the new columns (class mixin; both function_ingest sites; the utils method and JS-function builders), name column falling back to the node start when no name field exists.
- `_rehydrate_go_type_locations` and `_rehydrate_function_locations` mirror the Phase-1 template: same call-site gate (`not force and not _is_full_build`), guarded fetches, bool-rejecting int checks, fresh-Pass-2-entries-win. Function records restore under both persisted columns; method rows carry their container from the `DEFINES_METHOD` join; rehydrated records serve the joins only (Pass 3 touches re-parsed files exclusively).
- Old-graph guard: pre-#1240 rows have no `start_col` and are skipped cleanly, degrading to today's behavior until a re-index, exactly the Phase-1 posture.
- The new properties are registered in `NODE_SCHEMAS` and the graph-schema docs; the schema audit enforces this on every persisted node, which is how a missing registration initially failed 1526 tests across the suite before the full run caught it.

## Tests

Direct-drive harness mirroring Phase 1's: the Go IMPLEMENTS pair joins across an unchanged file through a rehydrated interface location; old-graph/bool/foreign-extension guards; span + name-alias keys resolve to one record with method containers intact; fresh entries are never overwritten; and a real-parse test pins that Class/Function/Method writes carry the columns (name column verified against the actual token offset). Full suite: 7608 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved source-location tracking for classes, functions, methods, and related declarations with optional line and column metadata.
  - Function and method locations now include both declaration spans and name-specific positions.
  - Incremental processing restores saved Go type, function, and method locations to preserve accurate relationships across runs.
  - Invalid, outdated, or incompatible saved location data is safely excluded.

- **Documentation**
  - Updated graph schema documentation to describe the new source-column metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->