### PR TITLE
feat: re-run semantic frontends and their joins on the watch path

### DIFF
--- a/codebase_rag/tests/test_realtime_updater.py
+++ b/codebase_rag/tests/test_realtime_updater.py
@@ -139,3 +139,47 @@ def test_non_code_files_create_file_nodes(
         non_code_file, "document.md"
     )
     mock_updater.ingestor.flush_all.assert_called_once()
+
+
+class TestSemanticFrontendReruns:
+    # Issue #1229 phase 3: semantic facts are location-keyed against the
+    # compiler's view of the whole module, so a change in one file can rebind
+    # calls in unchanged files; the applicable frontend must re-run on the
+    # watch path before the CALLS recompute.
+
+    def _fire(self, handler: CodeChangeEventHandler, path: Path) -> None:
+        path.write_text("// change\n", encoding="utf-8")
+        handler._process_change(FileModifiedEvent(str(path)))
+
+    def test_go_change_reruns_the_go_frontend(
+        self, event_handler: CodeChangeEventHandler, mock_updater: MagicMock
+    ) -> None:
+        self._fire(event_handler, mock_updater.repo_path / "svc.go")
+        mock_updater._run_go_frontend.assert_called_once()
+        mock_updater._run_csharp_frontend.assert_not_called()
+        mock_updater._join_go_implements.assert_called_once()
+
+    def test_csharp_change_reruns_the_roslyn_frontend(
+        self, event_handler: CodeChangeEventHandler, mock_updater: MagicMock
+    ) -> None:
+        self._fire(event_handler, mock_updater.repo_path / "Svc.cs")
+        mock_updater._run_csharp_frontend.assert_called_once()
+        mock_updater._run_go_frontend.assert_not_called()
+        mock_updater._join_csharp_partials.assert_called_once()
+
+    def test_python_change_touches_no_semantic_frontend(
+        self, event_handler: CodeChangeEventHandler, mock_updater: MagicMock
+    ) -> None:
+        self._fire(event_handler, mock_updater.repo_path / "app.py")
+        mock_updater._run_go_frontend.assert_not_called()
+        mock_updater._run_csharp_frontend.assert_not_called()
+
+    def test_go_deletion_also_reruns_the_frontend(
+        self, event_handler: CodeChangeEventHandler, mock_updater: MagicMock
+    ) -> None:
+        # Removing a file changes the module's bindings just as an edit does.
+        gone = mock_updater.repo_path / "gone.go"
+        gone.write_text("package x\n", encoding="utf-8")
+        gone.unlink()
+        event_handler._process_change(FileDeletedEvent(str(gone)))
+        mock_updater._run_go_frontend.assert_called_once()

--- a/codebase_rag/tests/test_realtime_updater.py
+++ b/codebase_rag/tests/test_realtime_updater.py
@@ -157,6 +157,8 @@ class TestSemanticFrontendReruns:
         self._fire(event_handler, mock_updater.repo_path / "svc.go")
         mock_updater._run_go_frontend.assert_called_once()
         mock_updater._run_csharp_frontend.assert_not_called()
+        mock_updater._rehydrate_go_type_locations.assert_called_once()
+        mock_updater._rehydrate_function_locations.assert_called_once()
         mock_updater._join_go_implements.assert_called_once()
 
     def test_csharp_change_reruns_the_roslyn_frontend(
@@ -165,6 +167,7 @@ class TestSemanticFrontendReruns:
         self._fire(event_handler, mock_updater.repo_path / "Svc.cs")
         mock_updater._run_csharp_frontend.assert_called_once()
         mock_updater._run_go_frontend.assert_not_called()
+        mock_updater._rehydrate_csharp_type_locations.assert_called_once()
         mock_updater._join_csharp_partials.assert_called_once()
 
     def test_python_change_touches_no_semantic_frontend(
@@ -183,3 +186,4 @@ class TestSemanticFrontendReruns:
         gone.unlink()
         event_handler._process_change(FileDeletedEvent(str(gone)))
         mock_updater._run_go_frontend.assert_called_once()
+        mock_updater._join_go_implements.assert_called_once()

--- a/realtime_updater.py
+++ b/realtime_updater.py
@@ -319,9 +319,17 @@ class CodeChangeEventHandler(FileSystemEventHandler):
         changed_language = changed_spec.language if changed_spec else None
         if changed_language == SupportedLanguage.GO:
             self.updater._run_go_frontend()
+            # A watch process that did not perform the full build itself has
+            # no in-memory locations for unchanged files; restoring them from
+            # the persisted graph matches the incremental flow and costs
+            # nothing when live state already holds them (fresh entries win).
+            self.updater._rehydrate_go_type_locations()
+            self.updater._rehydrate_function_locations()
             self.updater._join_go_implements()
         elif changed_language == SupportedLanguage.CSHARP:
             self.updater._run_csharp_frontend()
+            self.updater._rehydrate_csharp_type_locations()
+            self.updater._rehydrate_function_locations()
             self.updater._join_csharp_partials()
 
         # Rust inline-mod import maps retract at the end of every parse

--- a/realtime_updater.py
+++ b/realtime_updater.py
@@ -309,6 +309,21 @@ class CodeChangeEventHandler(FileSystemEventHandler):
                 path, path.name
             )
 
+        # Semantic facts are location-keyed against the compiler's view of
+        # the WHOLE module, so this change can rebind calls in UNCHANGED
+        # files; the applicable frontend re-runs (each resets its own facts)
+        # and its joins re-emit before the call recompute (issue #1229
+        # phase 3). Deletions count too: removing a file changes the
+        # module's bindings just as an edit does.
+        changed_spec = get_language_spec(path.suffix)
+        changed_language = changed_spec.language if changed_spec else None
+        if changed_language == SupportedLanguage.GO:
+            self.updater._run_go_frontend()
+            self.updater._join_go_implements()
+        elif changed_language == SupportedLanguage.CSHARP:
+            self.updater._run_csharp_frontend()
+            self.updater._join_csharp_partials()
+
         # Rust inline-mod import maps retract at the end of every parse
         # and only re-commit through arbitration; run() is not on this
         # path, so arbitrate here before calls recompute through the maps.


### PR DESCRIPTION
Phase 3 of #1229 (phases 1 and 2 shipped in #1239 and #1318).

## Problem

The watch path deletes and recomputes every CALLS edge on each change, but never re-runs the C#/Go semantic frontends, so Pass 3 consults facts from the last full build: a change in file X that rebinds a call in unchanged file Y (a new shadowing method, a moved promoted target) leaves Y's stale fact-driven edge until a full re-index.

## What

`_process_change_locked` now re-runs the applicable frontend between the re-parse and the CALLS recompute, gated on the changed file's language: Go changes re-run `_run_go_frontend` plus the IMPLEMENTS join, C# changes re-run `_run_csharp_frontend` plus the partial join, and every other language pays nothing. Deletions count too, since removing a file changes the module's bindings exactly as an edit does. Both frontends were already designed for reuse (each resets its own facts on entry, precisely for watch mode) and their joins MERGE idempotently, so the wiring is the whole change. The cost profile matches the path's existing shape: the handler already debounces and already recomputes every CALLS edge per event.

## Tests

RED-first in the existing realtime harness: a `.go` modification re-runs the Go frontend and its join exactly once (and not Roslyn); a `.cs` modification the converse; a `.py` change touches neither; a `.go` deletion still re-runs. The 68-test realtime/watch battery passes.

Phase 4 (stale-surviving CALLS) remains tracked in #1229.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated semantic processing so Go and C# changes—including deleted files—correctly refresh their respective analysis results.
  * Ensured related unchanged files are reprocessed when module-wide semantic bindings are affected.
  * Python-only changes no longer trigger unnecessary frontend processing.
  * Improved consistency of incremental analysis after edits and file deletions across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->