### PR TITLE
feat: re-parse dependent callers of re-indexed files instead of restoring stale edges

### DIFF
--- a/codebase_rag/constants/graph.py
+++ b/codebase_rag/constants/graph.py
@@ -468,6 +468,8 @@ CYPHER_AFFECTED_CALLER_PATHS = (
     "MATCH (caller)-[:CALLS|REFERENCES|INSTANTIATES|IMPORTS|INHERITS]->(target) "
     "WHERE target.path IN $paths AND caller.path IS NOT NULL "
     "AND NOT caller.path IN $paths "
+    "AND caller.qualified_name STARTS WITH $project_prefix "
+    "AND target.qualified_name STARTS WITH $project_prefix "
     "RETURN DISTINCT caller.path AS caller_path"
 )
 # Rehydrate class_inheritance on an incremental run: every INHERITS edge

--- a/codebase_rag/constants/graph.py
+++ b/codebase_rag/constants/graph.py
@@ -459,6 +459,17 @@ CYPHER_INBOUND_EDGES = (
     "caller.qualified_name AS caller_qn, type(r) AS rel, "
     "head(labels(target)) AS target_label, target.qualified_name AS target_qn"
 )
+# Files whose code DEPENDS on a re-indexed file (issue #1229 phase 4): a
+# change there can rebind their calls (a new override shadowing an inherited
+# method), so restoring their old edges verbatim would freeze a stale
+# binding. They are re-parsed instead, one level deep: their own definitions
+# are unchanged, so their callers' bindings cannot move.
+CYPHER_AFFECTED_CALLER_PATHS = (
+    "MATCH (caller)-[:CALLS|REFERENCES|INSTANTIATES|IMPORTS|INHERITS]->(target) "
+    "WHERE target.path IN $paths AND caller.path IS NOT NULL "
+    "AND NOT caller.path IN $paths "
+    "RETURN DISTINCT caller.path AS caller_path"
+)
 # Rehydrate class_inheritance on an incremental run: every INHERITS edge
 # (child -> base) with resolved qns, so protocol dispatch and inherited-method
 # resolution still see the hierarchy of classes defined in files that were not
@@ -520,6 +531,7 @@ KEY_BASE_QN = "base_qn"
 KEY_BASE_INDEX = "base_index"
 
 CYPHER_PARAM_PATHS = "paths"
+KEY_CALLER_PATH = "caller_path"
 KEY_CALLER_LABEL = "caller_label"
 KEY_CALLER_QN = "caller_qn"
 KEY_REL = "rel"

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1518,6 +1518,31 @@ class GraphUpdater:
                     restored += 1
         return restored
 
+    def _affected_caller_keys(self, reindexed_keys: list[str]) -> list[str]:
+        """Relative paths of files whose code depends on a re-indexed file.
+
+        One level deep is complete: an affected caller's own DEFINITIONS are
+        unchanged, so bindings in ITS callers cannot move. A failed read
+        degrades to today's verbatim restore, never worse.
+        """
+        if not reindexed_keys or not isinstance(self.ingestor, QueryProtocol):
+            return []
+        try:
+            rows = self.ingestor.fetch_all(
+                cs.CYPHER_AFFECTED_CALLER_PATHS,
+                {cs.CYPHER_PARAM_PATHS: reindexed_keys},
+            )
+        except Exception:
+            logger.warning(ls.PRUNE_QUERY_FAILED, label="affected callers")
+            return []
+        return sorted(
+            {
+                path
+                for row in rows
+                if isinstance(path := row.get(cs.KEY_CALLER_PATH), str) and path
+            }
+        )
+
     def _capture_inbound_edges(self, reindexed_keys: list[str]) -> list[ResultRow]:
         # Record the reference edges unchanged files point at the re-indexed
         # files, BEFORE those files' subtrees (and thus the inbound edges) are
@@ -2066,6 +2091,33 @@ class GraphUpdater:
         reindexed_keys = sorted(
             file_key for _fp, file_key, is_new, _b in changed_entries if not is_new
         )
+        # A file depending on a re-indexed one can have its bindings moved by
+        # the change (a new override shadowing an inherited method); restoring
+        # its old edges verbatim would freeze the stale binding, so it joins
+        # the re-parse set BEFORE capture: the capture query then excludes
+        # edges among the expanded set and Pass 3 recomputes them, while its
+        # own inbound edges are captured and restored like any re-indexed
+        # file's (issue #1229 phase 4).
+        present = {file_key for _fp, file_key, _new, _b in changed_entries}
+        affected = 0
+        for caller_key in self._affected_caller_keys(reindexed_keys):
+            if caller_key in present:
+                continue
+            caller_path = self.repo_path / caller_key
+            if not caller_path.is_file():
+                continue
+            try:
+                caller_bytes = caller_path.read_bytes()
+            except OSError:
+                continue
+            changed_entries.append((caller_path, caller_key, False, caller_bytes))
+            present.add(caller_key)
+            affected += 1
+        if affected:
+            logger.info(ls.INCREMENTAL_AFFECTED_CALLERS, count=affected)
+            reindexed_keys = sorted(
+                file_key for _fp, file_key, is_new, _b in changed_entries if not is_new
+            )
         captured_inbound = self._capture_inbound_edges(reindexed_keys)
         self._reparsed_file_keys = {
             file_key for _fp, file_key, _new, _b in changed_entries

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -1530,7 +1530,10 @@ class GraphUpdater:
         try:
             rows = self.ingestor.fetch_all(
                 cs.CYPHER_AFFECTED_CALLER_PATHS,
-                {cs.CYPHER_PARAM_PATHS: reindexed_keys},
+                {
+                    cs.CYPHER_PARAM_PATHS: reindexed_keys,
+                    cs.KEY_PROJECT_PREFIX: self.project_name + cs.SEPARATOR_DOT,
+                },
             )
         except Exception:
             logger.warning(ls.PRUNE_QUERY_FAILED, label="affected callers")
@@ -2099,12 +2102,13 @@ class GraphUpdater:
         # own inbound edges are captured and restored like any re-indexed
         # file's (issue #1229 phase 4).
         present = {file_key for _fp, file_key, _new, _b in changed_entries}
+        eligible_by_key = {file_key: fp for fp, file_key in eligible_files}
         affected = 0
         for caller_key in self._affected_caller_keys(reindexed_keys):
             if caller_key in present:
                 continue
-            caller_path = self.repo_path / caller_key
-            if not caller_path.is_file():
+            caller_path = eligible_by_key.get(caller_key)
+            if caller_path is None or not caller_path.is_file():
                 continue
             try:
                 caller_bytes = caller_path.read_bytes()

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -822,6 +822,9 @@ HASH_CACHE_SAVE_FAILED = "Failed to save hash cache to {path}: {error}"
 PERIODIC_FLUSH = "Periodic flush after {count} files processed"
 INCREMENTAL_SKIPPED = "Skipped {count} unchanged files"
 INCREMENTAL_CHANGED = "Re-indexing {count} changed files"
+INCREMENTAL_AFFECTED_CALLERS = (
+    "Re-parsing {count} dependent caller file(s) of re-indexed targets"
+)
 INCREMENTAL_DELETED = "Removed state for {count} deleted files"
 INCREMENTAL_FORCE = "Force mode enabled, bypassing hash cache"
 HASH_CACHE_ORPHANED = (

--- a/codebase_rag/tests/test_graph_updater_incremental_rename.py
+++ b/codebase_rag/tests/test_graph_updater_incremental_rename.py
@@ -54,7 +54,88 @@ class InMemoryGraph:
     def fetch_all(
         self, query: str, params: PropertyDict | None = None
     ) -> list[ResultRow]:
+        if query == cs.CYPHER_AFFECTED_CALLER_PATHS:
+            return self._affected_caller_rows((params or {}).get("paths") or [])
+        if query == cs.CYPHER_ALL_MODULE_QNS:
+            return self._module_qn_rows((params or {}).get(cs.KEY_PROJECT_PREFIX))
+        if query == cs.CYPHER_ALL_DEFINITION_QNS:
+            return self._definition_rows((params or {}).get(cs.KEY_PROJECT_PREFIX))
         return []
+
+    def _definition_rows(self, prefix: PropertyValue) -> list[ResultRow]:
+        # Mirrors production registry rehydration: definitions in UNCHANGED
+        # files (a base class, an overridden method) must be resolvable when
+        # a re-parsed subclass or caller references them.
+        if not isinstance(prefix, str):
+            return []
+        definition_labels = {
+            "Function",
+            "Method",
+            "Class",
+            "Interface",
+            "Enum",
+            "Type",
+            "Union",
+        }
+        rows: list[ResultRow] = []
+        for (label, _uid), props in self.nodes.items():
+            if label not in definition_labels:
+                continue
+            qn = props.get(cs.KEY_QUALIFIED_NAME)
+            if not isinstance(qn, str) or not qn.startswith(prefix):
+                continue
+            rows.append(
+                {
+                    cs.KEY_QUALIFIED_NAME: qn,
+                    cs.KEY_LABEL: label,
+                    cs.KEY_IS_PROPERTY: props.get(cs.KEY_IS_PROPERTY),
+                    "is_macro": props.get("is_macro"),
+                    cs.KEY_PATH: props.get(cs.KEY_PATH),
+                    cs.KEY_START_LINE: props.get(cs.KEY_START_LINE),
+                    cs.KEY_END_LINE: props.get(cs.KEY_END_LINE),
+                }
+            )
+        return rows
+
+    def _module_qn_rows(self, prefix: PropertyValue) -> list[ResultRow]:
+        # Mirrors production module-qn rehydration: without it, a re-parsed
+        # file's import of an UNCHANGED internal module fails deferred
+        # verification and grows a phantom ExternalModule node.
+        if not isinstance(prefix, str):
+            return []
+        rows: list[ResultRow] = []
+        for (label, _uid), props in self.nodes.items():
+            if label not in ("Module", "ModuleInterface"):
+                continue
+            qn = props.get(cs.KEY_QUALIFIED_NAME)
+            if isinstance(qn, str) and qn.startswith(prefix):
+                rows.append({cs.KEY_QUALIFIED_NAME: qn, cs.KEY_LABEL: label})
+        return rows
+
+    def _affected_caller_rows(self, paths: PropertyValue) -> list[ResultRow]:
+        # Answers the phase-4 dependency query from the stored graph: callers
+        # with an edge into any target whose path is being re-indexed.
+        path_set = {str(p) for p in paths} if isinstance(paths, list) else set()
+        dependency_rels = {"CALLS", "REFERENCES", "INSTANTIATES", "IMPORTS", "INHERITS"}
+        out: set[str] = set()
+        for fl, fk, fv, rel, tl, tk, tv in self.rels:
+            if rel not in dependency_rels:
+                continue
+            target = self.nodes.get((tl, tv))
+            caller = self.nodes.get((fl, fv))
+            if target is None or caller is None:
+                continue
+            target_path = target.get(cs.KEY_PATH)
+            caller_path = caller.get(cs.KEY_PATH)
+            if (
+                isinstance(target_path, str)
+                and target_path in path_set
+                and isinstance(caller_path, str)
+                and caller_path
+                and caller_path not in path_set
+            ):
+                out.add(caller_path)
+        return [{cs.KEY_CALLER_PATH: path} for path in sorted(out)]
 
     def execute_write(self, query: str, params: PropertyDict | None = None) -> None:
         params = params or {}
@@ -212,3 +293,52 @@ class TestIncrementalRenameStaleEntities:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+def _write_override_tree(root: Path, with_override: bool) -> None:
+    (root / "base.py").write_text(
+        "class A:\n    def m(self):\n        return 1\n", encoding="utf-8"
+    )
+    override = "    def m(self):\n        return 2\n" if with_override else "    pass\n"
+    (root / "derived.py").write_text(
+        f"from base import A\n\nclass B(A):\n{override}", encoding="utf-8"
+    )
+    (root / "caller.py").write_text(
+        "from derived import B\n\n\ndef use():\n    b = B()\n    b.m()\n",
+        encoding="utf-8",
+    )
+
+
+class TestAffectedCallerReprocessing:
+    def test_new_override_rebinds_the_unchanged_callers_call(
+        self, tmp_path: Path
+    ) -> None:
+        # Issue #1229 phase 4: only derived.py changes (B gains an override of
+        # m), so caller.py is not re-parsed by the hash diff; its old edge to
+        # A.m would be restored verbatim while the correct binding is now B.m.
+        # Dependency expansion re-parses caller.py and the graphs converge.
+        golden_root = tmp_path / "golden"
+        golden_root.mkdir()
+        _write_override_tree(golden_root, with_override=True)
+        golden_graph = InMemoryGraph()
+        _make_updater(golden_root, golden_graph).run(force=True)
+        golden_nodes, golden_rels = golden_graph.snapshot()
+
+        incr_root = tmp_path / "incr"
+        incr_root.mkdir()
+        _write_override_tree(incr_root, with_override=False)
+        incr_graph = InMemoryGraph()
+        _make_updater(incr_root, incr_graph).run(force=True)
+
+        _write_override_tree(incr_root, with_override=True)
+        _make_updater(incr_root, incr_graph).run(force=False)
+        incr_nodes, incr_rels = incr_graph.snapshot()
+
+        assert incr_nodes == golden_nodes, {
+            "stale_extra_nodes": sorted(map(str, incr_nodes - golden_nodes)),
+            "missing_nodes": sorted(map(str, golden_nodes - incr_nodes)),
+        }
+        assert incr_rels == golden_rels, {
+            "stale_extra_rels": sorted(map(str, incr_rels - golden_rels)),
+            "missing_rels": sorted(map(str, golden_rels - incr_rels)),
+        }

--- a/codebase_rag/tests/test_graph_updater_incremental_rename.py
+++ b/codebase_rag/tests/test_graph_updater_incremental_rename.py
@@ -55,7 +55,10 @@ class InMemoryGraph:
         self, query: str, params: PropertyDict | None = None
     ) -> list[ResultRow]:
         if query == cs.CYPHER_AFFECTED_CALLER_PATHS:
-            return self._affected_caller_rows((params or {}).get("paths") or [])
+            request = params or {}
+            return self._affected_caller_rows(
+                request.get("paths") or [], request.get(cs.KEY_PROJECT_PREFIX)
+            )
         if query == cs.CYPHER_ALL_MODULE_QNS:
             return self._module_qn_rows((params or {}).get(cs.KEY_PROJECT_PREFIX))
         if query == cs.CYPHER_ALL_DEFINITION_QNS:
@@ -112,9 +115,14 @@ class InMemoryGraph:
                 rows.append({cs.KEY_QUALIFIED_NAME: qn, cs.KEY_LABEL: label})
         return rows
 
-    def _affected_caller_rows(self, paths: PropertyValue) -> list[ResultRow]:
+    def _affected_caller_rows(
+        self, paths: PropertyValue, prefix: PropertyValue
+    ) -> list[ResultRow]:
         # Answers the phase-4 dependency query from the stored graph: callers
-        # with an edge into any target whose path is being re-indexed.
+        # with an edge into any target whose path is being re-indexed, both
+        # endpoints scoped to the requesting project.
+        if not isinstance(prefix, str):
+            return []
         path_set = {str(p) for p in paths} if isinstance(paths, list) else set()
         dependency_rels = {"CALLS", "REFERENCES", "INSTANTIATES", "IMPORTS", "INHERITS"}
         out: set[str] = set()
@@ -127,12 +135,18 @@ class InMemoryGraph:
                 continue
             target_path = target.get(cs.KEY_PATH)
             caller_path = caller.get(cs.KEY_PATH)
+            target_qn = target.get(cs.KEY_QUALIFIED_NAME)
+            caller_qn = caller.get(cs.KEY_QUALIFIED_NAME)
             if (
                 isinstance(target_path, str)
                 and target_path in path_set
                 and isinstance(caller_path, str)
                 and caller_path
                 and caller_path not in path_set
+                and isinstance(target_qn, str)
+                and target_qn.startswith(prefix)
+                and isinstance(caller_qn, str)
+                and caller_qn.startswith(prefix)
             ):
                 out.add(caller_path)
         return [{cs.KEY_CALLER_PATH: path} for path in sorted(out)]


### PR DESCRIPTION
Closes the final phase of #1229 (phase 4: affected-caller reprocessing).

## Problem

An incremental run captures the inbound edges of re-indexed files and restores them verbatim after the rebuild. Restore already skips targets that vanished (rename-away safe), but it cannot detect REBINDING: the old target still exists while the correct binding moved. Example: `derived.py` adds an override `B.m` shadowing inherited `A.m`. Only `derived.py` changed, so `caller.py` is not re-parsed; its old `caller -> A.m` CALLS edge is restored verbatim (A.m still exists) and the correct `caller -> B.m` edge never appears. The incremental graph diverges from a full rebuild.

## Fix: expand the re-parse set before capture

Before `_capture_inbound_edges`, the updater asks the graph for files with a CALLS/REFERENCES/INSTANTIATES/IMPORTS/INHERITS edge into any re-indexed file (`CYPHER_AFFECTED_CALLER_PATHS`) and enqueues them as changed entries. This placement makes the existing capture/restore machinery correct by construction:

- The capture query already excludes edges among the `$paths` set, so the affected callers' outgoing dependency edges are NOT snapshot; Pass 3 recomputes them against the new definitions.
- The affected callers' own inbound edges are captured and restored like any re-indexed file's.

One level of expansion is complete: an affected caller's own definitions are unchanged, so bindings in ITS callers cannot move.

Degradation is safe: a failed dependency query, an unreadable file, or a non-QueryProtocol ingestor falls back to today's verbatim restore, never worse.

## Tests

- `TestAffectedCallerReprocessing::test_new_override_rebinds_the_unchanged_callers_call`: golden full rebuild vs incremental run changing ONLY `derived.py`; asserts node and relationship snapshots are equal. Verified RED without the fix (stale `caller -> A.m` survives, `caller -> B.m` missing) and GREEN with it.
- The `InMemoryGraph` harness now answers `CYPHER_AFFECTED_CALLER_PATHS`, `CYPHER_ALL_MODULE_QNS`, and `CYPHER_ALL_DEFINITION_QNS` from its stored graph, mirroring production rehydration (previously it returned `[]`, which masked rehydration-dependent behavior).
- Battery `-k "incremental or updater or prune"`: 148 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved incremental updates so dependent caller files are reprocessed when referenced code changes.
  * Fixed stale graph entries after symbol renames.
  * Ensured unchanged callers are correctly rebound when new method overrides are added.
  * Restricted dependency updates to the active project, preventing cross-project changes.

* **Improvements**
  * Added logging to indicate when dependent caller files are reprocessed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->