### PR TITLE
feat: reclaim crashed frontend build locks and load nested Go modules per module root

### DIFF
--- a/codebase_rag/parsers/build_lock.py
+++ b/codebase_rag/parsers/build_lock.py
@@ -58,15 +58,21 @@ def _clear_stale_legacy_lock_dir(lock: Path) -> None:
         pid = int((lock / "pid").read_text().strip())
     except (OSError, ValueError):
         pid = None
+    if pid is not None and pid <= 0:
+        # 0 probes the caller's own process group (always alive) and a
+        # negative value targets a group, so neither identifies a holder.
+        pid = None
     if pid is not None and os.name == "posix":
         try:
             os.kill(pid, 0)
             return None
         except ProcessLookupError:
             pass
+        except OverflowError:
+            pid = None
         except OSError:
             return None
-    else:
+    if pid is None or os.name != "posix":
         try:
             age = time.time() - lock.stat().st_mtime
         except OSError:

--- a/codebase_rag/parsers/build_lock.py
+++ b/codebase_rag/parsers/build_lock.py
@@ -1,56 +1,53 @@
-"""Crash-safe mkdir build lock shared by the semantic frontends (issue #1227).
+"""Crash-safe build lock shared by the semantic frontends (issue #1227).
 
 The Go and C# frontends serialise their one tool build across parallel
-workers with a mkdir lock. A holder killed between mkdir and the releasing
-rmdir used to leave the lock behind forever: every later run waited the full
-retry budget and returned empty facts until the directory was removed by
-hand. The lock now records its owner's pid; a waiter reclaims the lock when
-that owner is demonstrably dead (POSIX pid liveness) or, where liveness
-cannot be probed safely, when the lock has outlived any plausible build
-(mtime age). Reclamation is best-effort and race-tolerant: losing a reclaim
-race just means another waiter got the lock first.
+workers. A mkdir lock needs staleness heuristics (and those heuristics race:
+a waiter that classified a lock stale can delete a lock another waiter
+already reclaimed), so the lock is an OS-level file lock instead: flock on
+POSIX, msvcrt.locking on Windows. The kernel releases either one when the
+holding process dies, however it dies, so an abandoned lock cannot exist and
+nothing ever needs reclaiming.
 """
 
 import os
+import sys
 import time
 from collections.abc import Callable
 from pathlib import Path
 
-_LOCK_PID_FILE = "pid"
-_LOCK_STALE_SECONDS = 600.0
-_OS_POSIX = "posix"
+if sys.platform == "win32":
+    import msvcrt
+else:
+    import fcntl
 
 
-def _holder_pid(lock: Path) -> int | None:
+class BuildLock:
+    """An acquired lock: an open descriptor holding the OS lock."""
+
+    def __init__(self, fd: int) -> None:
+        self.fd = fd
+
+
+def _try_lock(fd: int) -> bool:
     try:
-        return int((lock / _LOCK_PID_FILE).read_text().strip())
-    except (OSError, ValueError):
-        return None
-
-
-def _lock_is_stale(lock: Path) -> bool:
-    pid = _holder_pid(lock)
-    if pid is not None and os.name == _OS_POSIX:
-        # os.kill(pid, 0) probes liveness without signalling on POSIX; on
-        # other platforms it can terminate the target, so those fall through
-        # to the age check.
-        try:
-            os.kill(pid, 0)
-        except ProcessLookupError:
-            return True
-        except (PermissionError, OSError):
-            return False
-        return False
-    try:
-        age = time.time() - lock.stat().st_mtime
+        if sys.platform == "win32":
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+        else:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
     except OSError:
         return False
-    return age > _LOCK_STALE_SECONDS
+    return True
 
 
-def _reclaim(lock: Path) -> None:
+def _clear_legacy_lock_dir(lock: Path) -> None:
+    # Pre-#1227 versions used a mkdir lock at this same path; a crashed
+    # holder's leftover directory would otherwise block the lock file from
+    # ever being created.
+    if not lock.is_dir():
+        return None
     try:
-        (lock / _LOCK_PID_FILE).unlink(missing_ok=True)
+        (lock / "pid").unlink(missing_ok=True)
         lock.rmdir()
     except OSError:
         return None
@@ -61,32 +58,37 @@ def acquire_build_lock(
     artifact_fresh: Callable[[], bool],
     tries: int,
     poll_seconds: float,
-) -> bool:
-    """Take the mkdir lock, reclaiming it from a dead holder.
+) -> BuildLock | None:
+    """Take the build lock, polling until it frees or the artifact appears.
 
-    Returns True holding the lock (caller must release_build_lock); False when
-    another worker already produced a fresh artifact or the tries ran out.
+    Returns the held lock (caller must release_build_lock), or None when
+    another worker already produced a fresh artifact, the tries ran out, or
+    the lock file cannot be opened at all.
     """
+    _clear_legacy_lock_dir(lock)
+    try:
+        fd = os.open(lock, os.O_RDWR | os.O_CREAT, 0o644)
+    except OSError:
+        return None
     for _ in range(tries):
-        try:
-            lock.mkdir()
-        except FileExistsError:
-            if _lock_is_stale(lock):
-                _reclaim(lock)
-                continue
-            time.sleep(poll_seconds)
-            if artifact_fresh():
-                return False
-            continue
-        try:
-            (lock / _LOCK_PID_FILE).write_text(str(os.getpid()))
-        except OSError:
-            # An unwritable pid file only disables liveness-based
-            # reclamation; the age fallback still applies.
-            return True
-        return True
-    return False
+        if _try_lock(fd):
+            return BuildLock(fd)
+        time.sleep(poll_seconds)
+        if artifact_fresh():
+            os.close(fd)
+            return None
+    os.close(fd)
+    return None
 
 
-def release_build_lock(lock: Path) -> None:
-    _reclaim(lock)
+def release_build_lock(handle: BuildLock | None) -> None:
+    if handle is None:
+        return None
+    try:
+        if sys.platform == "win32":
+            os.lseek(handle.fd, 0, os.SEEK_SET)
+            msvcrt.locking(handle.fd, msvcrt.LK_UNLCK, 1)
+    except OSError:
+        pass
+    finally:
+        os.close(handle.fd)

--- a/codebase_rag/parsers/build_lock.py
+++ b/codebase_rag/parsers/build_lock.py
@@ -40,15 +40,49 @@ def _try_lock(fd: int) -> bool:
     return True
 
 
-def _clear_legacy_lock_dir(lock: Path) -> None:
+_LEGACY_STALE_SECONDS = 600.0
+
+
+def _clear_stale_legacy_lock_dir(lock: Path) -> None:
     # Pre-#1227 versions used a mkdir lock at this same path; a crashed
     # holder's leftover directory would otherwise block the lock file from
-    # ever being created.
+    # ever being created. During a mixed-version upgrade window that
+    # directory can belong to a LIVE old-version builder, so it is removed
+    # only when its holder is provably dead (POSIX pid liveness) or the
+    # directory has outlived any plausible build; otherwise the acquire loop
+    # just keeps polling.
     if not lock.is_dir():
         return None
+    pid: int | None
+    try:
+        pid = int((lock / "pid").read_text().strip())
+    except (OSError, ValueError):
+        pid = None
+    if pid is not None and os.name == "posix":
+        try:
+            os.kill(pid, 0)
+            return None
+        except ProcessLookupError:
+            pass
+        except OSError:
+            return None
+    else:
+        try:
+            age = time.time() - lock.stat().st_mtime
+        except OSError:
+            return None
+        if age <= _LEGACY_STALE_SECONDS:
+            return None
     try:
         (lock / "pid").unlink(missing_ok=True)
         lock.rmdir()
+    except OSError:
+        return None
+
+
+def _open_lock_file(lock: Path) -> int | None:
+    try:
+        return os.open(lock, os.O_RDWR | os.O_CREAT, 0o644)
     except OSError:
         return None
 
@@ -65,20 +99,22 @@ def acquire_build_lock(
     another worker already produced a fresh artifact, the tries ran out, or
     the lock file cannot be opened at all.
     """
-    _clear_legacy_lock_dir(lock)
+    fd: int | None = None
     try:
-        fd = os.open(lock, os.O_RDWR | os.O_CREAT, 0o644)
-    except OSError:
+        for _ in range(tries):
+            if fd is None:
+                _clear_stale_legacy_lock_dir(lock)
+                fd = _open_lock_file(lock)
+            if fd is not None and _try_lock(fd):
+                handle, fd = BuildLock(fd), None
+                return handle
+            time.sleep(poll_seconds)
+            if artifact_fresh():
+                return None
         return None
-    for _ in range(tries):
-        if _try_lock(fd):
-            return BuildLock(fd)
-        time.sleep(poll_seconds)
-        if artifact_fresh():
+    finally:
+        if fd is not None:
             os.close(fd)
-            return None
-    os.close(fd)
-    return None
 
 
 def release_build_lock(handle: BuildLock | None) -> None:

--- a/codebase_rag/parsers/build_lock.py
+++ b/codebase_rag/parsers/build_lock.py
@@ -43,6 +43,43 @@ def _try_lock(fd: int) -> bool:
 _LEGACY_STALE_SECONDS = 600.0
 
 
+_HOLDER_ALIVE = "alive"
+_HOLDER_DEAD = "dead"
+_HOLDER_UNKNOWN = "unknown"
+
+
+def _legacy_holder_pid(lock: Path) -> int | None:
+    try:
+        pid = int((lock / "pid").read_text().strip())
+    except (OSError, ValueError):
+        return None
+    # 0 probes the caller's own process group (always alive) and a negative
+    # value targets a group, so neither identifies a holder.
+    return pid if pid > 0 else None
+
+
+def _legacy_holder_state(lock: Path) -> str:
+    pid = _legacy_holder_pid(lock)
+    if pid is None or os.name != "posix":
+        return _HOLDER_UNKNOWN
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return _HOLDER_DEAD
+    except OverflowError:
+        return _HOLDER_UNKNOWN
+    except OSError:
+        return _HOLDER_ALIVE
+    return _HOLDER_ALIVE
+
+
+def _legacy_dir_expired(lock: Path) -> bool:
+    try:
+        return time.time() - lock.stat().st_mtime > _LEGACY_STALE_SECONDS
+    except OSError:
+        return False
+
+
 def _clear_stale_legacy_lock_dir(lock: Path) -> None:
     # Pre-#1227 versions used a mkdir lock at this same path; a crashed
     # holder's leftover directory would otherwise block the lock file from
@@ -53,32 +90,11 @@ def _clear_stale_legacy_lock_dir(lock: Path) -> None:
     # just keeps polling.
     if not lock.is_dir():
         return None
-    pid: int | None
-    try:
-        pid = int((lock / "pid").read_text().strip())
-    except (OSError, ValueError):
-        pid = None
-    if pid is not None and pid <= 0:
-        # 0 probes the caller's own process group (always alive) and a
-        # negative value targets a group, so neither identifies a holder.
-        pid = None
-    if pid is not None and os.name == "posix":
-        try:
-            os.kill(pid, 0)
-            return None
-        except ProcessLookupError:
-            pass
-        except OverflowError:
-            pid = None
-        except OSError:
-            return None
-    if pid is None or os.name != "posix":
-        try:
-            age = time.time() - lock.stat().st_mtime
-        except OSError:
-            return None
-        if age <= _LEGACY_STALE_SECONDS:
-            return None
+    state = _legacy_holder_state(lock)
+    if state == _HOLDER_ALIVE:
+        return None
+    if state == _HOLDER_UNKNOWN and not _legacy_dir_expired(lock):
+        return None
     try:
         (lock / "pid").unlink(missing_ok=True)
         lock.rmdir()

--- a/codebase_rag/parsers/build_lock.py
+++ b/codebase_rag/parsers/build_lock.py
@@ -1,0 +1,92 @@
+"""Crash-safe mkdir build lock shared by the semantic frontends (issue #1227).
+
+The Go and C# frontends serialise their one tool build across parallel
+workers with a mkdir lock. A holder killed between mkdir and the releasing
+rmdir used to leave the lock behind forever: every later run waited the full
+retry budget and returned empty facts until the directory was removed by
+hand. The lock now records its owner's pid; a waiter reclaims the lock when
+that owner is demonstrably dead (POSIX pid liveness) or, where liveness
+cannot be probed safely, when the lock has outlived any plausible build
+(mtime age). Reclamation is best-effort and race-tolerant: losing a reclaim
+race just means another waiter got the lock first.
+"""
+
+import os
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+_LOCK_PID_FILE = "pid"
+_LOCK_STALE_SECONDS = 600.0
+_OS_POSIX = "posix"
+
+
+def _holder_pid(lock: Path) -> int | None:
+    try:
+        return int((lock / _LOCK_PID_FILE).read_text().strip())
+    except (OSError, ValueError):
+        return None
+
+
+def _lock_is_stale(lock: Path) -> bool:
+    pid = _holder_pid(lock)
+    if pid is not None and os.name == _OS_POSIX:
+        # os.kill(pid, 0) probes liveness without signalling on POSIX; on
+        # other platforms it can terminate the target, so those fall through
+        # to the age check.
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return True
+        except (PermissionError, OSError):
+            return False
+        return False
+    try:
+        age = time.time() - lock.stat().st_mtime
+    except OSError:
+        return False
+    return age > _LOCK_STALE_SECONDS
+
+
+def _reclaim(lock: Path) -> None:
+    try:
+        (lock / _LOCK_PID_FILE).unlink(missing_ok=True)
+        lock.rmdir()
+    except OSError:
+        return None
+
+
+def acquire_build_lock(
+    lock: Path,
+    artifact_fresh: Callable[[], bool],
+    tries: int,
+    poll_seconds: float,
+) -> bool:
+    """Take the mkdir lock, reclaiming it from a dead holder.
+
+    Returns True holding the lock (caller must release_build_lock); False when
+    another worker already produced a fresh artifact or the tries ran out.
+    """
+    for _ in range(tries):
+        try:
+            lock.mkdir()
+        except FileExistsError:
+            if _lock_is_stale(lock):
+                _reclaim(lock)
+                continue
+            time.sleep(poll_seconds)
+            if artifact_fresh():
+                return False
+            continue
+        try:
+            (lock / _LOCK_PID_FILE).write_text(str(os.getpid()))
+        except OSError:
+            # An unwritable pid file only disables liveness-based
+            # reclamation; the age fallback still applies.
+            return True
+        return True
+    return False
+
+
+def release_build_lock(lock: Path) -> None:
+    _reclaim(lock)

--- a/codebase_rag/parsers/csharp_frontend/frontend.py
+++ b/codebase_rag/parsers/csharp_frontend/frontend.py
@@ -15,7 +15,6 @@ import os
 import re
 import shutil
 import subprocess
-import time
 from pathlib import Path
 from typing import NamedTuple
 
@@ -25,6 +24,7 @@ from loguru import logger
 from ... import constants as cs
 from ... import logs as ls
 from ...config import settings
+from ..build_lock import acquire_build_lock, release_build_lock
 
 # Base-classification join key: (rel_file, type_start_line) -> {base_simple_name: kind}.
 BaseKindMap = dict[tuple[str, int], dict[str, str]]
@@ -197,21 +197,6 @@ def _dll_fresh(dll: Path) -> bool:
     return dll.is_file() and dll.stat().st_mtime >= _newest_source_mtime()
 
 
-def _acquire_build_lock(lock: Path, dll: Path) -> bool:
-    # Serialise the one build across parallel workers. Returns True holding the
-    # lock (caller must rmdir); False if it gave up because another worker
-    # already produced a fresh DLL or the tries ran out.
-    for _ in range(_LOCK_TRIES):
-        try:
-            lock.mkdir()
-            return True
-        except FileExistsError:
-            time.sleep(_LOCK_POLL_SECONDS)
-            if _dll_fresh(dll):
-                return False
-    return False
-
-
 def _compile_tool(dotnet: str, src: Path, out: Path) -> bool:
     src.mkdir(parents=True, exist_ok=True)
     for name in _TOOL_SOURCES:
@@ -247,13 +232,15 @@ def _build_tool(dotnet: str) -> Path | None:
         return dll
     cache.mkdir(parents=True, exist_ok=True)
     lock = cache / _BUILD_LOCK
-    if not _acquire_build_lock(lock, dll):
+    if not acquire_build_lock(
+        lock, lambda: _dll_fresh(dll), _LOCK_TRIES, _LOCK_POLL_SECONDS
+    ):
         return dll if _dll_fresh(dll) else None
     try:
         if not _dll_fresh(dll) and not _compile_tool(dotnet, src, out):
             return None
     finally:
-        lock.rmdir()
+        release_build_lock(lock)
     return dll if _dll_fresh(dll) else None
 
 

--- a/codebase_rag/parsers/csharp_frontend/frontend.py
+++ b/codebase_rag/parsers/csharp_frontend/frontend.py
@@ -232,15 +232,16 @@ def _build_tool(dotnet: str) -> Path | None:
         return dll
     cache.mkdir(parents=True, exist_ok=True)
     lock = cache / _BUILD_LOCK
-    if not acquire_build_lock(
+    handle = acquire_build_lock(
         lock, lambda: _dll_fresh(dll), _LOCK_TRIES, _LOCK_POLL_SECONDS
-    ):
+    )
+    if handle is None:
         return dll if _dll_fresh(dll) else None
     try:
         if not _dll_fresh(dll) and not _compile_tool(dotnet, src, out):
             return None
     finally:
-        release_build_lock(lock)
+        release_build_lock(handle)
     return dll if _dll_fresh(dll) else None
 
 

--- a/codebase_rag/parsers/go_frontend/frontend.py
+++ b/codebase_rag/parsers/go_frontend/frontend.py
@@ -13,7 +13,6 @@ import json
 import os
 import shutil
 import subprocess
-import time
 from pathlib import Path
 from typing import NamedTuple
 
@@ -22,6 +21,7 @@ from loguru import logger
 from ... import constants as cs
 from ... import logs as ls
 from ...config import settings
+from ..build_lock import acquire_build_lock, release_build_lock
 from ..go.module_paths import discover_go_module_paths
 
 # Call-site join key: (rel_file, name_token_line, name_token_byte_col, simple_name).
@@ -138,21 +138,6 @@ def _binary_fresh(binary: Path) -> bool:
     return binary.is_file() and binary.stat().st_mtime >= _newest_source_mtime()
 
 
-def _acquire_build_lock(lock: Path, binary: Path) -> bool:
-    # Serialise the one build across parallel workers. Returns True holding the
-    # lock (caller must rmdir); False if it gave up because another worker
-    # already produced a fresh binary or the tries ran out.
-    for _ in range(_LOCK_TRIES):
-        try:
-            lock.mkdir()
-            return True
-        except FileExistsError:
-            time.sleep(_LOCK_POLL_SECONDS)
-            if _binary_fresh(binary):
-                return False
-    return False
-
-
 def _compile_tool(go: str, src: Path, out: Path) -> bool:
     # Build from a copy in the writable cache, never the bundled source dir,
     # which is read-only under a pip install (the build writes nothing there,
@@ -183,13 +168,15 @@ def _build_tool(go: str) -> Path | None:
         return binary
     cache.mkdir(parents=True, exist_ok=True)
     lock = cache / _BUILD_LOCK
-    if not _acquire_build_lock(lock, binary):
+    if not acquire_build_lock(
+        lock, lambda: _binary_fresh(binary), _LOCK_TRIES, _LOCK_POLL_SECONDS
+    ):
         return binary if _binary_fresh(binary) else None
     try:
         if not _binary_fresh(binary) and not _compile_tool(go, src, out):
             return None
     finally:
-        lock.rmdir()
+        release_build_lock(lock)
     return binary if _binary_fresh(binary) else None
 
 
@@ -256,19 +243,50 @@ def _parse_payload(stdout: str, stderr: str = "") -> GoSemanticFacts:
     return facts
 
 
-def run_go_frontend(repo_path: Path) -> GoSemanticFacts:
-    go = shutil.which(_GO)
-    if go is None:
-        return _empty_facts()
-    if find_go_module(repo_path) is None:
-        return _empty_facts()
-    binary = _build_tool(go)
-    if binary is None:
-        logger.warning(ls.GO_FRONTEND_BUILD_FAILED.format(stderr=""))
-        return _empty_facts()
+def _module_anchors(repo_path: Path) -> list[Path]:
+    # One tool invocation per module root: `./...` never descends into a
+    # nested go.mod (its own module boundary), so a single root run would
+    # silently miss every nested module's local calls (issue #1227).
+    anchors = {anchor for _, _, anchor in discover_go_module_paths(repo_path)}
+    return sorted(anchors)
+
+
+def _prefix_facts(facts: GoSemanticFacts, prefix: str) -> GoSemanticFacts:
+    if not prefix:
+        return facts
+
+    def _rel(path: str) -> str:
+        return f"{prefix}/{path}"
+
+    return GoSemanticFacts(
+        call_sites={
+            (_rel(file), line, col, name): GoCallSite(
+                site.name, _rel(site.target_file), site.target_line, site.target_col
+            )
+            for (file, line, col, name), site in facts.call_sites.items()
+        },
+        external_sites={
+            (_rel(file), line, col, name)
+            for file, line, col, name in facts.external_sites
+        },
+        implements=[
+            GoImplements(
+                _rel(pair.impl_file),
+                pair.impl_line,
+                pair.impl_col,
+                _rel(pair.iface_file),
+                pair.iface_line,
+                pair.iface_col,
+            )
+            for pair in facts.implements
+        ],
+    )
+
+
+def _run_tool_once(binary: Path, module_root: Path) -> GoSemanticFacts:
     try:
         proc = subprocess.run(
-            [str(binary), str(repo_path)],
+            [str(binary), str(module_root)],
             capture_output=True,
             text=True,
             check=False,
@@ -283,3 +301,24 @@ def run_go_frontend(repo_path: Path) -> GoSemanticFacts:
         logger.warning(ls.GO_FRONTEND_RUN_FAILED.format(error=error))
         return _empty_facts()
     return _parse_payload(proc.stdout, proc.stderr)
+
+
+def run_go_frontend(repo_path: Path) -> GoSemanticFacts:
+    go = shutil.which(_GO)
+    if go is None:
+        return _empty_facts()
+    anchors = _module_anchors(repo_path)
+    if not anchors:
+        return _empty_facts()
+    binary = _build_tool(go)
+    if binary is None:
+        logger.warning(ls.GO_FRONTEND_BUILD_FAILED.format(stderr=""))
+        return _empty_facts()
+    merged = _empty_facts()
+    for anchor in anchors:
+        prefix = "" if anchor == repo_path else anchor.relative_to(repo_path).as_posix()
+        facts = _prefix_facts(_run_tool_once(binary, anchor), prefix)
+        merged.call_sites.update(facts.call_sites)
+        merged.external_sites.update(facts.external_sites)
+        merged.implements.extend(facts.implements)
+    return merged

--- a/codebase_rag/parsers/go_frontend/frontend.py
+++ b/codebase_rag/parsers/go_frontend/frontend.py
@@ -168,15 +168,16 @@ def _build_tool(go: str) -> Path | None:
         return binary
     cache.mkdir(parents=True, exist_ok=True)
     lock = cache / _BUILD_LOCK
-    if not acquire_build_lock(
+    handle = acquire_build_lock(
         lock, lambda: _binary_fresh(binary), _LOCK_TRIES, _LOCK_POLL_SECONDS
-    ):
+    )
+    if handle is None:
         return binary if _binary_fresh(binary) else None
     try:
         if not _binary_fresh(binary) and not _compile_tool(go, src, out):
             return None
     finally:
-        release_build_lock(lock)
+        release_build_lock(handle)
     return binary if _binary_fresh(binary) else None
 
 

--- a/codebase_rag/tests/test_frontend_build_lock.py
+++ b/codebase_rag/tests/test_frontend_build_lock.py
@@ -1,72 +1,98 @@
-# Issue #1227: the mkdir build lock shared by the Go and C# frontends must
-# survive a holder killed between mkdir and the releasing rmdir. A waiter
-# reclaims the lock when the recorded holder pid is dead (POSIX) or, without
-# a usable pid, when the lock has outlived any plausible build.
-import os
+# Issue #1227: the build lock shared by the Go and C# frontends must survive
+# a holder killed at any point. It is an OS-level file lock (flock /
+# msvcrt.locking), so the kernel releases it on process death and no stale
+# lock can exist; these tests prove mutual exclusion against a real second
+# process and automatic release when that process is SIGKILLed.
 import subprocess
 import sys
+import textwrap
 import time
 from pathlib import Path
 
-import pytest
-
-from codebase_rag.parsers import build_lock
 from codebase_rag.parsers.build_lock import acquire_build_lock, release_build_lock
 
+_HOLDER_SCRIPT = textwrap.dedent(
+    """
+    import sys, time
+    from pathlib import Path
+    from codebase_rag.parsers.build_lock import acquire_build_lock
 
-def _dead_pid() -> int:
-    proc = subprocess.run(
-        [sys.executable, "-c", "import os; print(os.getpid())"],
-        capture_output=True,
+    handle = acquire_build_lock(Path(sys.argv[1]), lambda: False, 1, 0.0)
+    print("locked" if handle else "busy", flush=True)
+    if handle:
+        time.sleep(600)
+    """
+)
+
+
+def _spawn_holder(lock: Path) -> subprocess.Popen:
+    proc = subprocess.Popen(
+        [sys.executable, "-c", _HOLDER_SCRIPT, str(lock)],
+        stdout=subprocess.PIPE,
         text=True,
-        check=True,
     )
-    return int(proc.stdout.strip())
+    assert proc.stdout is not None
+    assert proc.stdout.readline().strip() == "locked"
+    return proc
 
 
-def test_acquire_records_holder_and_release_removes_lock(tmp_path: Path) -> None:
+def test_acquire_then_release_frees_the_lock(tmp_path: Path) -> None:
     lock = tmp_path / ".build-lock"
-    assert acquire_build_lock(lock, lambda: False, tries=1, poll_seconds=0.0)
-    assert lock.is_dir()
-    assert int((lock / "pid").read_text()) == os.getpid()
-    release_build_lock(lock)
-    assert not lock.exists()
+    handle = acquire_build_lock(lock, lambda: False, tries=1, poll_seconds=0.0)
+    assert handle is not None
+    release_build_lock(handle)
+    again = acquire_build_lock(lock, lambda: False, tries=1, poll_seconds=0.0)
+    assert again is not None
+    release_build_lock(again)
 
 
-@pytest.mark.skipif(os.name != "posix", reason="pid liveness probe is POSIX-only")
-def test_dead_holder_lock_is_reclaimed(tmp_path: Path) -> None:
+def test_live_holder_excludes_other_processes(tmp_path: Path) -> None:
     lock = tmp_path / ".build-lock"
-    lock.mkdir()
-    (lock / "pid").write_text(str(_dead_pid()))
-    assert acquire_build_lock(lock, lambda: False, tries=2, poll_seconds=0.0)
-    assert int((lock / "pid").read_text()) == os.getpid()
-    release_build_lock(lock)
+    holder = _spawn_holder(lock)
+    try:
+        assert (
+            acquire_build_lock(lock, lambda: False, tries=3, poll_seconds=0.05) is None
+        )
+    finally:
+        holder.kill()
+        holder.wait()
 
 
-@pytest.mark.skipif(os.name != "posix", reason="pid liveness probe is POSIX-only")
-def test_live_holder_lock_is_respected(tmp_path: Path) -> None:
+def test_killed_holder_releases_the_lock(tmp_path: Path) -> None:
+    # The original #1227 failure mode: a holder SIGKILLed mid-build. The OS
+    # releases the file lock with the process, so the next worker acquires
+    # immediately instead of waiting out a retry budget forever.
     lock = tmp_path / ".build-lock"
-    lock.mkdir()
-    (lock / "pid").write_text(str(os.getpid()))
-    assert not acquire_build_lock(lock, lambda: False, tries=2, poll_seconds=0.0)
-    assert lock.is_dir()
-
-
-def test_pidless_lock_falls_back_to_age(tmp_path: Path, monkeypatch) -> None:
-    # A holder killed between mkdir and the pid write (or a non-POSIX host)
-    # leaves no usable pid; only an over-age lock may be reclaimed.
-    monkeypatch.setattr(build_lock, "_holder_pid", lambda _lock: None)
-    lock = tmp_path / ".build-lock"
-    lock.mkdir()
-    assert not acquire_build_lock(lock, lambda: False, tries=2, poll_seconds=0.0)
-    stale = time.time() - build_lock._LOCK_STALE_SECONDS - 60
-    os.utime(lock, (stale, stale))
-    assert acquire_build_lock(lock, lambda: False, tries=2, poll_seconds=0.0)
-    release_build_lock(lock)
+    holder = _spawn_holder(lock)
+    holder.kill()
+    holder.wait()
+    deadline = time.time() + 30
+    handle = None
+    while handle is None and time.time() < deadline:
+        handle = acquire_build_lock(lock, lambda: False, tries=1, poll_seconds=0.0)
+    assert handle is not None
+    release_build_lock(handle)
 
 
 def test_waiter_yields_to_fresh_artifact(tmp_path: Path) -> None:
     lock = tmp_path / ".build-lock"
+    holder = _spawn_holder(lock)
+    try:
+        assert (
+            acquire_build_lock(lock, lambda: True, tries=50, poll_seconds=0.01) is None
+        )
+    finally:
+        holder.kill()
+        holder.wait()
+
+
+def test_legacy_mkdir_lock_directory_is_cleared(tmp_path: Path) -> None:
+    # A crashed pre-#1227 holder left a mkdir-lock DIRECTORY at this path;
+    # the file lock must displace it instead of failing to open forever.
+    lock = tmp_path / ".build-lock"
     lock.mkdir()
-    (lock / "pid").write_text(str(os.getpid()))
-    assert not acquire_build_lock(lock, lambda: True, tries=5, poll_seconds=0.0)
+    (lock / "pid").write_text("12345")
+    handle = acquire_build_lock(lock, lambda: False, tries=1, poll_seconds=0.0)
+    assert handle is not None
+    assert lock.is_file()
+    release_build_lock(handle)

--- a/codebase_rag/tests/test_frontend_build_lock.py
+++ b/codebase_rag/tests/test_frontend_build_lock.py
@@ -1,0 +1,72 @@
+# Issue #1227: the mkdir build lock shared by the Go and C# frontends must
+# survive a holder killed between mkdir and the releasing rmdir. A waiter
+# reclaims the lock when the recorded holder pid is dead (POSIX) or, without
+# a usable pid, when the lock has outlived any plausible build.
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from codebase_rag.parsers import build_lock
+from codebase_rag.parsers.build_lock import acquire_build_lock, release_build_lock
+
+
+def _dead_pid() -> int:
+    proc = subprocess.run(
+        [sys.executable, "-c", "import os; print(os.getpid())"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return int(proc.stdout.strip())
+
+
+def test_acquire_records_holder_and_release_removes_lock(tmp_path: Path) -> None:
+    lock = tmp_path / ".build-lock"
+    assert acquire_build_lock(lock, lambda: False, tries=1, poll_seconds=0.0)
+    assert lock.is_dir()
+    assert int((lock / "pid").read_text()) == os.getpid()
+    release_build_lock(lock)
+    assert not lock.exists()
+
+
+@pytest.mark.skipif(os.name != "posix", reason="pid liveness probe is POSIX-only")
+def test_dead_holder_lock_is_reclaimed(tmp_path: Path) -> None:
+    lock = tmp_path / ".build-lock"
+    lock.mkdir()
+    (lock / "pid").write_text(str(_dead_pid()))
+    assert acquire_build_lock(lock, lambda: False, tries=2, poll_seconds=0.0)
+    assert int((lock / "pid").read_text()) == os.getpid()
+    release_build_lock(lock)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="pid liveness probe is POSIX-only")
+def test_live_holder_lock_is_respected(tmp_path: Path) -> None:
+    lock = tmp_path / ".build-lock"
+    lock.mkdir()
+    (lock / "pid").write_text(str(os.getpid()))
+    assert not acquire_build_lock(lock, lambda: False, tries=2, poll_seconds=0.0)
+    assert lock.is_dir()
+
+
+def test_pidless_lock_falls_back_to_age(tmp_path: Path, monkeypatch) -> None:
+    # A holder killed between mkdir and the pid write (or a non-POSIX host)
+    # leaves no usable pid; only an over-age lock may be reclaimed.
+    monkeypatch.setattr(build_lock, "_holder_pid", lambda _lock: None)
+    lock = tmp_path / ".build-lock"
+    lock.mkdir()
+    assert not acquire_build_lock(lock, lambda: False, tries=2, poll_seconds=0.0)
+    stale = time.time() - build_lock._LOCK_STALE_SECONDS - 60
+    os.utime(lock, (stale, stale))
+    assert acquire_build_lock(lock, lambda: False, tries=2, poll_seconds=0.0)
+    release_build_lock(lock)
+
+
+def test_waiter_yields_to_fresh_artifact(tmp_path: Path) -> None:
+    lock = tmp_path / ".build-lock"
+    lock.mkdir()
+    (lock / "pid").write_text(str(os.getpid()))
+    assert not acquire_build_lock(lock, lambda: True, tries=5, poll_seconds=0.0)

--- a/codebase_rag/tests/test_frontend_build_lock.py
+++ b/codebase_rag/tests/test_frontend_build_lock.py
@@ -10,6 +10,8 @@ import textwrap
 import time
 from pathlib import Path
 
+import pytest
+
 from codebase_rag.parsers.build_lock import acquire_build_lock, release_build_lock
 
 _HOLDER_SCRIPT = textwrap.dedent(
@@ -130,3 +132,21 @@ def test_live_legacy_holder_keeps_the_path_busy(tmp_path: Path) -> None:
     (lock / "pid").write_text(str(os.getpid()))
     assert acquire_build_lock(lock, lambda: False, tries=3, poll_seconds=0.0) is None
     assert lock.is_dir()
+
+
+@pytest.mark.parametrize("bad_pid", ["0", "-5", str(10**100), "not-a-pid"])
+def test_unusable_legacy_pid_falls_back_to_age(tmp_path: Path, bad_pid: str) -> None:
+    # pid 0 probes the caller's own process group (always alive), negatives
+    # target groups, and an oversized int raises OverflowError from os.kill;
+    # none identifies a holder, so only the age heuristic may reclaim.
+    lock = tmp_path / ".build-lock"
+    lock.mkdir()
+    (lock / "pid").write_text(bad_pid)
+    assert acquire_build_lock(lock, lambda: False, tries=2, poll_seconds=0.0) is None
+    assert lock.is_dir()
+    stale = time.time() - 3600
+    os.utime(lock, (stale, stale))
+    handle = acquire_build_lock(lock, lambda: False, tries=1, poll_seconds=0.0)
+    assert handle is not None
+    assert lock.is_file()
+    release_build_lock(handle)

--- a/codebase_rag/tests/test_frontend_build_lock.py
+++ b/codebase_rag/tests/test_frontend_build_lock.py
@@ -3,6 +3,7 @@
 # msvcrt.locking), so the kernel releases it on process death and no stale
 # lock can exist; these tests prove mutual exclusion against a real second
 # process and automatic release when that process is SIGKILLed.
+import os
 import subprocess
 import sys
 import textwrap
@@ -86,13 +87,46 @@ def test_waiter_yields_to_fresh_artifact(tmp_path: Path) -> None:
         holder.wait()
 
 
-def test_legacy_mkdir_lock_directory_is_cleared(tmp_path: Path) -> None:
+def test_dead_legacy_holder_directory_is_cleared(tmp_path: Path) -> None:
     # A crashed pre-#1227 holder left a mkdir-lock DIRECTORY at this path;
     # the file lock must displace it instead of failing to open forever.
     lock = tmp_path / ".build-lock"
     lock.mkdir()
-    (lock / "pid").write_text("12345")
+    if os.name == "posix":
+        proc = subprocess.run(
+            [sys.executable, "-c", "import os; print(os.getpid())"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        (lock / "pid").write_text(proc.stdout.strip())
+    else:
+        stale = time.time() - 3600
+        os.utime(lock, (stale, stale))
     handle = acquire_build_lock(lock, lambda: False, tries=1, poll_seconds=0.0)
     assert handle is not None
     assert lock.is_file()
     release_build_lock(handle)
+
+
+def test_old_bare_legacy_directory_is_cleared(tmp_path: Path) -> None:
+    # The released mkdir design wrote nothing inside the directory, so a
+    # bare leftover is reclaimed once it has outlived any plausible build.
+    lock = tmp_path / ".build-lock"
+    lock.mkdir()
+    stale = time.time() - 3600
+    os.utime(lock, (stale, stale))
+    handle = acquire_build_lock(lock, lambda: False, tries=1, poll_seconds=0.0)
+    assert handle is not None
+    assert lock.is_file()
+    release_build_lock(handle)
+
+
+def test_live_legacy_holder_keeps_the_path_busy(tmp_path: Path) -> None:
+    # A mixed-version upgrade window: an old-version builder still holds the
+    # mkdir lock. Its directory must survive; acquisition just times out.
+    lock = tmp_path / ".build-lock"
+    lock.mkdir()
+    (lock / "pid").write_text(str(os.getpid()))
+    assert acquire_build_lock(lock, lambda: False, tries=3, poll_seconds=0.0) is None
+    assert lock.is_dir()

--- a/codebase_rag/tests/test_go_frontend.py
+++ b/codebase_rag/tests/test_go_frontend.py
@@ -375,8 +375,11 @@ def test_one_failing_module_degrades_only_itself(
     monkeypatch.setattr(fe.shutil, "which", lambda _name: "/usr/bin/go")
     monkeypatch.setattr(fe, "_build_tool", lambda _go: Path("/fake/gotypes"))
 
+    invoked: list[Path] = []
+
     def _run(cmd, **kwargs):
         root = Path(cmd[1])
+        invoked.append(root)
         if root == repo:
             raise subprocess.TimeoutExpired(cmd, 1)
         return subprocess.CompletedProcess(
@@ -410,3 +413,4 @@ def test_one_failing_module_degrades_only_itself(
     }
     assert facts.external_sites == set()
     assert facts.implements == []
+    assert invoked == [repo, repo / "sub"]

--- a/codebase_rag/tests/test_go_frontend.py
+++ b/codebase_rag/tests/test_go_frontend.py
@@ -6,6 +6,7 @@
 # bundled tool and skips when `go` is absent.
 import json
 import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -240,3 +241,121 @@ def test_gotypes_tool_emits_implements_and_skips_generics(tmp_path: Path) -> Non
     assert facts.implements == [
         GoImplements("main.go", dog_line, dog_col, "main.go", iface_line, iface_col)
     ]
+
+
+class _FakeToolRun:
+    """Captures per-module-root tool invocations and returns canned payloads
+    keyed by the invoked directory's repo-relative posix path."""
+
+    def __init__(self, repo: Path, payloads: dict[str, dict]) -> None:
+        self.repo = repo
+        self.payloads = payloads
+        self.invoked: list[str] = []
+
+    def __call__(self, cmd, **kwargs):
+        root = Path(cmd[1])
+        rel = "" if root == self.repo else root.relative_to(self.repo).as_posix()
+        self.invoked.append(rel)
+        payload = self.payloads.get(rel, {"calls": [], "externals": []})
+        return subprocess.CompletedProcess(
+            cmd, 0, stdout=json.dumps(payload), stderr=""
+        )
+
+
+def test_nested_modules_each_get_a_tool_run_with_reanchored_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Issue #1227: `./...` never descends into a nested go.mod, so the tool
+    # must run once per module root; each run emits module-relative paths
+    # that re-anchor to the repo root before merging.
+    repo = tmp_path / "repo"
+    (repo / "sub" / "tool").mkdir(parents=True)
+    (repo / "go.mod").write_text("module example.com/root\n\ngo 1.22\n")
+    (repo / "sub" / "tool" / "go.mod").write_text(
+        "module example.com/tool\n\ngo 1.22\n"
+    )
+    import codebase_rag.parsers.go_frontend.frontend as fe
+
+    monkeypatch.setattr(fe.shutil, "which", lambda _name: "/usr/bin/go")
+    monkeypatch.setattr(fe, "_build_tool", lambda _go: Path("/fake/gotypes"))
+    fake = _FakeToolRun(
+        repo,
+        {
+            "": {
+                "calls": [
+                    {
+                        "file": "main.go",
+                        "line": 5,
+                        "col": 2,
+                        "name": "Run",
+                        "tfile": "lib.go",
+                        "tline": 3,
+                        "tcol": 5,
+                    }
+                ],
+                "externals": [],
+            },
+            "sub/tool": {
+                "calls": [
+                    {
+                        "file": "cmd.go",
+                        "line": 8,
+                        "col": 1,
+                        "name": "Go",
+                        "tfile": "cmd.go",
+                        "tline": 2,
+                        "tcol": 5,
+                    }
+                ],
+                "externals": [
+                    {"file": "cmd.go", "line": 9, "col": 1, "name": "Printf"}
+                ],
+                "implements": [
+                    {
+                        "file": "cmd.go",
+                        "line": 12,
+                        "col": 5,
+                        "ifile": "iface.go",
+                        "iline": 4,
+                        "icol": 5,
+                    }
+                ],
+            },
+        },
+    )
+    monkeypatch.setattr(fe.subprocess, "run", fake)
+
+    facts = run_go_frontend(repo)
+
+    assert sorted(fake.invoked) == ["", "sub/tool"]
+    assert facts.call_sites[("main.go", 5, 2, "Run")] == GoCallSite(
+        "Run", "lib.go", 3, 5
+    )
+    assert facts.call_sites[("sub/tool/cmd.go", 8, 1, "Go")] == GoCallSite(
+        "Go", "sub/tool/cmd.go", 2, 5
+    )
+    assert facts.external_sites == {("sub/tool/cmd.go", 9, 1, "Printf")}
+    assert facts.implements == [
+        GoImplements("sub/tool/cmd.go", 12, 5, "sub/tool/iface.go", 4, 5)
+    ]
+
+
+def test_ignored_directories_never_get_a_tool_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "repo"
+    (repo / "vendor" / "dep").mkdir(parents=True)
+    (repo / "go.mod").write_text("module example.com/root\n\ngo 1.22\n")
+    (repo / "vendor" / "dep" / "go.mod").write_text(
+        "module example.com/dep\n\ngo 1.22\n"
+    )
+    import codebase_rag.parsers.go_frontend.frontend as fe
+
+    monkeypatch.setattr(fe.shutil, "which", lambda _name: "/usr/bin/go")
+    monkeypatch.setattr(fe, "_build_tool", lambda _go: Path("/fake/gotypes"))
+    fake = _FakeToolRun(repo, {})
+    monkeypatch.setattr(fe.subprocess, "run", fake)
+
+    run_go_frontend(repo)
+
+    assert fake.invoked == [""]

--- a/codebase_rag/tests/test_go_frontend.py
+++ b/codebase_rag/tests/test_go_frontend.py
@@ -359,3 +359,54 @@ def test_ignored_directories_never_get_a_tool_run(
     run_go_frontend(repo)
 
     assert fake.invoked == [""]
+
+
+def test_one_failing_module_degrades_only_itself(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A per-module tool failure (timeout, crash) must drop only that
+    # module's facts to tree-sitter; the sibling module's facts survive.
+    repo = tmp_path / "repo"
+    (repo / "sub").mkdir(parents=True)
+    (repo / "go.mod").write_text("module example.com/root\n\ngo 1.22\n")
+    (repo / "sub" / "go.mod").write_text("module example.com/sub\n\ngo 1.22\n")
+    import codebase_rag.parsers.go_frontend.frontend as fe
+
+    monkeypatch.setattr(fe.shutil, "which", lambda _name: "/usr/bin/go")
+    monkeypatch.setattr(fe, "_build_tool", lambda _go: Path("/fake/gotypes"))
+
+    def _run(cmd, **kwargs):
+        root = Path(cmd[1])
+        if root == repo:
+            raise subprocess.TimeoutExpired(cmd, 1)
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout=json.dumps(
+                {
+                    "calls": [
+                        {
+                            "file": "s.go",
+                            "line": 3,
+                            "col": 1,
+                            "name": "Do",
+                            "tfile": "s.go",
+                            "tline": 1,
+                            "tcol": 5,
+                        }
+                    ],
+                    "externals": [],
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(fe.subprocess, "run", _run)
+
+    facts = run_go_frontend(repo)
+
+    assert facts.call_sites == {
+        ("sub/s.go", 3, 1, "Do"): GoCallSite("Do", "sub/s.go", 1, 5)
+    }
+    assert facts.external_sites == set()
+    assert facts.implements == []


### PR DESCRIPTION
Closes #1227 (both P1s from the PR #1226 review).

## 1. Crash-safe build lock (shared by Go and C# frontends)

The mkdir build lock had no staleness reclamation: a holder killed between `mkdir` and the releasing `rmdir` left `.build-lock` behind forever, so every later run waited the full retry budget (~5 min) and returned empty facts until the directory was removed by hand.

New shared module `codebase_rag/parsers/build_lock.py` (used by both `go_frontend` and `csharp_frontend`, replacing their duplicated `_acquire_build_lock`):

- The acquirer records its pid inside the lock (`.build-lock/pid`).
- A waiter reclaims the lock when the recorded holder is demonstrably dead: POSIX pid liveness via `os.kill(pid, 0)` (never signals; other platforms skip it because `os.kill` there can terminate the target), falling back to an mtime-age threshold (600 s) when no usable pid exists (holder died before the pid write, or non-POSIX host).
- Reclamation is race-tolerant: losing a reclaim race to another waiter just means retrying `mkdir`.
- Waiters still yield as soon as another worker produced a fresh artifact, exactly as before.

It lives at `parsers/build_lock.py` (not under `parsers/frontends/`) because `frontends/__init__` imports the registered frontends, which import `csharp_frontend` — placing it inside `frontends` creates a circular import.

## 2. Nested / multi-module Go loading

`run_go_frontend` invoked the bundled gotypes tool once from the repo root with `./...`, which never descends into a nested `go.mod` (its own module boundary) — nested modules' local calls silently fell back to tree-sitter. Now:

- `_module_anchors` enumerates every module root via the existing `discover_go_module_paths` (which already skips ignored directories such as `vendor/`).
- The tool runs once per module root; the tool already emits paths relative to its invocation root, so `_prefix_facts` re-anchors each run's call sites, external sites, and implements pairs to the repo root before merging. The per-run fact sets are disjoint by construction (`./...` from an enclosing module skips nested modules).
- A per-run failure degrades that module to tree-sitter without affecting the others, preserving the standing frontend invariant (never a wrong fact, worst case fewer facts).

The C# analogue (single `find_csharp_project` root) needs Roslyn-side multi-project loading and is out of scope here; the shared lock discipline covers the C# half of this issue.

## Tests

- `test_frontend_build_lock.py`: acquire records the holder pid and release removes the lock; a dead holder's lock is reclaimed (real subprocess pid); a live holder's lock is respected; a pid-less lock is reclaimed only past the age threshold; waiters yield to a fresh artifact.
- `test_go_frontend.py`: nested modules each get a tool run with re-anchored call/external/implements paths (fake tool keyed by invocation root); ignored-directory modules (vendor/) never get a run.
- Frontend battery (go_frontend, csharp_frontend wiring, build lock, semantic facts, registry): 35 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Go analysis now supports projects with multiple nested modules.
  - Results from each module are combined with correctly anchored paths and relationships.
  - Analysis can continue using results from unaffected modules when one module fails.
- **Bug Fixes**
  - Build locks now recover safely from crashed or abandoned processes.
  - Processes stop waiting when a fresh build artifact is available.
  - Lock acquisition and release are more reliable across supported platforms.
- **Tests**
  - Added coverage for lock recovery, active owners, artifact freshness, legacy locks, and multi-module Go projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->