### PR TITLE
feat: in-process Jedi semantic frontend for Python behind PYTHON_FRONTEND

### DIFF
--- a/codebase_rag/config.py
+++ b/codebase_rag/config.py
@@ -212,6 +212,7 @@ class AppConfig(BaseSettings):
     # augments exact first-party call binding and external-site suppression;
     # tree-sitter stays the standalone-correct backbone.
     GO_FRONTEND: cs.GoFrontend = cs.GoFrontend.AUTO
+    PYTHON_FRONTEND: cs.PythonFrontend = cs.PythonFrontend.HEURISTIC
     CAPTURE_FUNCTION_LOCAL_DEFINITIONS: bool = Field(
         True, validation_alias="CGR_CAPTURE_LOCAL_DEFINITIONS"
     )

--- a/codebase_rag/constants/languages.py
+++ b/codebase_rag/constants/languages.py
@@ -116,6 +116,15 @@ class CSharpFrontend(StrEnum):
     HYBRID = "hybrid"
 
 
+class PythonFrontend(StrEnum):
+    # HEURISTIC is the default: the tree-sitter walkers plus the name trie.
+    # JEDI layers in-process semantic facts on top (issue #1183); it degrades
+    # to HEURISTIC when jedi is not installed, and the parser fingerprint
+    # records the RESOLVED mode.
+    HEURISTIC = "heuristic"
+    JEDI = "jedi"
+
+
 class GoFrontend(StrEnum):
     # AUTO resolves at run time: GOTYPES where a go toolchain is on PATH,
     # TREESITTER otherwise (resolve_go_frontend). The parser fingerprint records

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -496,6 +496,37 @@ class GraphUpdater:
             )
         )
 
+    def _run_python_frontend(self) -> None:
+        # In-process Jedi facts (issue #1183): exact first-party callees
+        # through re-exports/decorators and external proofs for calls leaving
+        # the repo. Off (HEURISTIC) or unavailable degrades to the tree-sitter
+        # heuristics; reset first so a reused updater does not keep stale
+        # facts when the setting flips between runs.
+        dp = self.factory.definition_processor
+        dp.python_call_sites.clear()
+        dp.python_external_sites.clear()
+        if settings.PYTHON_FRONTEND == cs.PythonFrontend.HEURISTIC:
+            return
+        frontend = FRONTENDS.get(cs.SupportedLanguage.PYTHON)
+        if frontend is None or not frontend.available():
+            logger.warning(ls.PY_FRONTEND_UNAVAILABLE)
+            return
+        files = [
+            fp for fp, lang in self._parsed_files if lang == cs.SupportedLanguage.PYTHON
+        ]
+        if not files:
+            return
+        logger.info(ls.PY_FRONTEND_RUNNING)
+        facts = frontend.run(self.repo_path, files)
+        dp.python_call_sites.update(facts.resolved_call_sites)
+        dp.python_external_sites.update(facts.external_sites)
+        logger.info(
+            ls.PY_FRONTEND_FACTS.format(
+                calls=len(facts.resolved_call_sites),
+                externals=len(facts.external_sites),
+            )
+        )
+
     def _reset_go_semantic_facts(self) -> None:
         dp = self.factory.definition_processor
         dp.go_call_sites.clear()
@@ -791,6 +822,11 @@ class GraphUpdater:
         # Go IMPLEMENTS pairs join AFTER Pass 2 for the same reason: both ends
         # resolve against the go_type_locations index Pass 2 just registered.
         self._join_go_implements()
+
+        # The Jedi Python frontend runs AFTER Pass 2 (its facts join Pass 3
+        # calls against the function_locations Pass 2 just filled) and needs
+        # the parsed-file list, which Pass 2 produced (issue #1183).
+        self._run_python_frontend()
 
         # HYBRID must run after Pass 2: an incremental run deletes each
         # changed file's Module subtree before re-parsing it, so macro

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -906,3 +906,14 @@ WEB_SEARCH_KEYLESS_FALLBACK = (
 WEB_SEARCH_UNKNOWN_PROVIDER = (
     "Unknown web search provider '{provider}'; using duckduckgo"
 )
+PY_FRONTEND_RUNNING = "Jedi Python frontend: resolving semantic call facts"
+PY_FRONTEND_UNAVAILABLE = (
+    "PYTHON_FRONTEND=jedi but jedi is not installed (python-semantics extra); "
+    "using heuristics"
+)
+PY_FRONTEND_FACTS = (
+    "Jedi facts: {calls} resolved call sites, {externals} external sites"
+)
+PY_FRONTEND_BUDGET_DEGRADED = (
+    "Jedi budget exceeded in {count} file(s); those fall back to heuristics"
+)

--- a/codebase_rag/parser_fingerprint.py
+++ b/codebase_rag/parser_fingerprint.py
@@ -66,11 +66,13 @@ def _frontend_settings() -> list[str]:
     from .parsers.cpp_frontend import resolve_cpp_frontend
     from .parsers.csharp_frontend import resolve_csharp_frontend
     from .parsers.go_frontend import resolve_go_frontend
+    from .parsers.py_frontend import resolve_python_frontend
 
     return [
         f"CPP_FRONTEND={resolve_cpp_frontend().value}",
         f"CSHARP_FRONTEND={resolve_csharp_frontend().value}",
         f"GO_FRONTEND={resolve_go_frontend().value}",
+        f"PYTHON_FRONTEND={resolve_python_frontend().value}",
     ]
 
 

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -24,7 +24,7 @@ from ..types_defs import (
     NodeType,
 )
 from ..utils.path_utils import cached_relative_path
-from .call_resolver import CallResolver
+from .call_resolver import PY_EXTERNAL_TARGET, CallResolver
 from .class_ingest.identity import build_nested_qualified_name_for_class
 from .cpp import utils as cpp_utils
 from .cpp.type_inference import CppTypeInferenceEngine
@@ -3359,6 +3359,29 @@ class CallProcessor:
                         class_context,
                         caller_qn,
                         language,
+                    )
+            elif (
+                language == cs.SupportedLanguage.PYTHON
+                and call_node.type == cs.TS_PY_CALL
+            ):
+                # The Jedi frontend (issue #1183): a HIT is the exact callee
+                # through re-exports/decorators the trie approximates; the
+                # external sentinel proves the call leaves the repo and
+                # suppresses trie fabrication. Any miss (incl. the frontend
+                # off, so both maps are empty) falls back to the Python
+                # heuristics with call_point preserved.
+                callee_info = resolver.resolve_python_call_site(call_node, module_qn)
+                if callee_info == PY_EXTERNAL_TARGET:
+                    callee_info = None
+                elif callee_info is None:
+                    callee_info = resolve_func(
+                        call_name,
+                        module_qn,
+                        call_var_types,
+                        class_context,
+                        caller_qn,
+                        language,
+                        call_point=call_node.start_byte,
                     )
             elif (
                 language == cs.SupportedLanguage.GO

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -14,6 +14,7 @@ from ..types_defs import FunctionRegistryTrieProtocol, NodeType
 from .import_processor import ImportProcessor
 from .py import resolve_class_name
 from .rs import utils as rs_utils
+from .semantic_call_join import call_site_key, declared_location
 from .type_inference import TypeInferenceEngine
 from .utils import follow_reexports
 
@@ -64,8 +65,12 @@ def _split_receiver_chain(expr: str) -> list[str]:
     return parts
 
 
+PY_EXTERNAL_TARGET: tuple[str, str] = ("", "")
+
+
 class CallResolver:
     __slots__ = (
+        "_py_rel_to_module",
         "function_registry",
         "import_processor",
         "type_inference",
@@ -106,6 +111,7 @@ class CallResolver:
         self.import_processor = import_processor
         self.type_inference = type_inference
         self.class_inheritance = class_inheritance
+        self._py_rel_to_module: dict[str, str] = {}
         # Every inline `mod` qn the class pass ingested (shared ref). A Rust
         # enclosing scope is an inline mod IFF it is in here: an impl target is
         # not, and neither is registered under a type label when it is a
@@ -3039,3 +3045,59 @@ class CallResolver:
         return self.type_inference.go_type_inference.resolve_go_call_site(
             call_node, module_qn
         )
+
+    def resolve_python_call_site(
+        self,
+        call_node: Node,
+        module_qn: str,
+    ) -> tuple[str, str] | None:
+        # The Jedi semantic path (issue #1183), mirroring the Go shape: an
+        # exact first-party callee through re-exports/decorators, or the
+        # external sentinel proving the call leaves the repo. Any miss falls
+        # back to the heuristics.
+        ti = self.type_inference
+        if not (ti.python_call_sites or ti.python_external_sites):
+            return None
+        name_node = self._python_callee_name_node(call_node)
+        if name_node is None:
+            return None
+        name = name_node.text.decode(cs.ENCODING_UTF8) if name_node.text else ""
+        if not name:
+            return None
+        key = call_site_key(
+            name_node,
+            name,
+            module_qn,
+            ti.module_qn_to_file_path,
+            ti.repo_path,
+        )
+        if key is None:
+            return None
+        fact = ti.python_call_sites.get(key)
+        if fact is not None:
+            return declared_location(
+                fact.target_file,
+                fact.target_line,
+                fact.target_col,
+                ti.function_locations,
+                ti.module_qn_to_file_path,
+                ti.repo_path,
+                self._py_rel_to_module,
+            )
+        if key in ti.python_external_sites:
+            return PY_EXTERNAL_TARGET
+        return None
+
+    @staticmethod
+    def _python_callee_name_node(call_node: Node) -> Node | None:
+        # The callee NAME token: a bare identifier for `f()`, the `attribute`
+        # child for `obj.m()` / `pkg.f()`; anything else (subscripts, calls of
+        # call results) has no single name token and stays heuristic.
+        func = call_node.child_by_field_name(cs.TS_FIELD_FUNCTION)
+        if func is None:
+            return None
+        if func.type == cs.TS_PY_IDENTIFIER:
+            return func
+        if func.type == cs.TS_PY_ATTRIBUTE:
+            return func.child_by_field_name(cs.TS_PY_FIELD_ATTRIBUTE)
+        return None

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -169,6 +169,11 @@ class DefinitionProcessor(
         # identifier position), stashed here at frontend time and resolved to
         # IMPLEMENTS edges after Pass 2 fills go_type_locations below.
         self.go_implements: list[ImplementsPair] = []
+        # Jedi Python frontend (issue #1183): the same two call families,
+        # keyed on the callee NAME token like C#/Go. Same in-place mutation
+        # discipline; the resolver reads these references directly.
+        self.python_call_sites: dict[CallSiteKey, ResolvedCallSite] = {}
+        self.python_external_sites: set[CallSiteKey] = set()
         # (rel_file, type_start_line, type_start_col) -> (class qn, node label)
         # for every ingested Go type. Go's type_spec start_point IS the name
         # token, so the frontend's pair positions join here directly (no alias).

--- a/codebase_rag/parsers/factory.py
+++ b/codebase_rag/parsers/factory.py
@@ -134,6 +134,8 @@ class ProcessorFactory:
                 method_return_types=self.definition_processor.method_return_types,
                 go_function_return_types=self.definition_processor.go_function_return_types,
                 go_call_sites=self.definition_processor.go_call_sites,
+                python_call_sites=self.definition_processor.python_call_sites,
+                python_external_sites=self.definition_processor.python_external_sites,
                 go_external_sites=self.definition_processor.go_external_sites,
                 csharp_partial_groups=self.definition_processor.csharp_partial_groups,
                 csharp_extension_methods=self.definition_processor.csharp_extension_methods,

--- a/codebase_rag/parsers/frontends/__init__.py
+++ b/codebase_rag/parsers/frontends/__init__.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 # Import for side effect: each frontend module self-registers into the registry.
 from . import csharp as _csharp  # noqa: E402,F401  (registers CSharpFrontend)
 from . import go as _go  # noqa: E402,F401  (registers GoFrontend)
+from . import python as _python  # noqa: E402,F401  (registers PythonJediFrontend)
 from .protocol import (
     CallSiteKey,
     EmittingFrontend,

--- a/codebase_rag/parsers/frontends/python.py
+++ b/codebase_rag/parsers/frontends/python.py
@@ -22,7 +22,9 @@ class PythonJediFrontend:
         return python_frontend_available()
 
     def applies(self, repo_path: Path) -> bool:
-        return True
+        # Effectively always true: the updater gates on parsed .py files
+        # anyway, so existence is the only meaningful precondition.
+        return repo_path.exists()
 
     def run(self, repo_path: Path, files: Sequence[Path]) -> SemanticFacts:
         return run_python_frontend(repo_path, list(files))

--- a/codebase_rag/parsers/frontends/python.py
+++ b/codebase_rag/parsers/frontends/python.py
@@ -1,0 +1,31 @@
+"""Python LanguageFrontend registration (issue #1183): the in-process Jedi
+fact provider. No subprocess, no toolchain — availability is just the
+optional `jedi` import (the `python-semantics` extra)."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+from ...constants.languages import SupportedLanguage
+from ..py_frontend import python_frontend_available, run_python_frontend
+from .protocol import SemanticFacts
+from .registry import register_frontend
+
+
+class PythonJediFrontend:
+    """Jedi fact provider for Python."""
+
+    language: SupportedLanguage = SupportedLanguage.PYTHON
+
+    def available(self) -> bool:
+        return python_frontend_available()
+
+    def applies(self, repo_path: Path) -> bool:
+        return True
+
+    def run(self, repo_path: Path, files: Sequence[Path]) -> SemanticFacts:
+        return run_python_frontend(repo_path, list(files))
+
+
+register_frontend(PythonJediFrontend())

--- a/codebase_rag/parsers/py_frontend/__init__.py
+++ b/codebase_rag/parsers/py_frontend/__init__.py
@@ -1,0 +1,11 @@
+from .frontend import (
+    python_frontend_available,
+    resolve_python_frontend,
+    run_python_frontend,
+)
+
+__all__ = [
+    "python_frontend_available",
+    "resolve_python_frontend",
+    "run_python_frontend",
+]

--- a/codebase_rag/parsers/py_frontend/frontend.py
+++ b/codebase_rag/parsers/py_frontend/frontend.py
@@ -202,7 +202,7 @@ def run_python_frontend(repo_path: Path, files: list[Path]) -> SemanticFacts:
         try:
             source = file_path.read_text(encoding=cs.ENCODING_UTF8)
             tree = ast.parse(source)
-        except (OSError, SyntaxError, ValueError, UnicodeDecodeError):
+        except (OSError, SyntaxError, ValueError):
             continue
         collector = _CallSite()
         collector.visit(tree)

--- a/codebase_rag/parsers/py_frontend/frontend.py
+++ b/codebase_rag/parsers/py_frontend/frontend.py
@@ -1,0 +1,200 @@
+"""Jedi in-process Python semantic frontend (issue #1183, stage 1).
+
+Python gets the deepest FLOWS_TO walk in the repo and had no semantic layer:
+re-export chains, decorated callables, and MRO dispatch were all approximated
+by the parsers/py heuristics plus the shared name trie. Jedi is pure Python
+and needs no external toolchain, making it the cheapest semantic win in the
+roadmap. The frontend enumerates call sites with the stdlib ast (byte-exact
+name-token positions matching the tree-sitter CallSiteKey convention), asks
+jedi to infer each callee, and emits the two standard fact families:
+
+- resolved_call_sites: the definition a call binds to, following re-exports,
+  decorators, and class hierarchies, keyed and targeted at NAME tokens.
+- external_sites: callees resolving outside the repo (stdlib, site-packages,
+  builtins) — the compiler-grade proof the trie fallback must not fabricate a
+  first-party CALLS edge.
+
+Cost control: only attribute calls and import-bound bare calls are queried
+(module-local bare calls are the heuristics' home turf), one jedi Project is
+shared across files, and a per-file time budget degrades that file to the
+heuristics rather than stalling the index. Ambiguity is a ceiling: multiple
+or empty inferences emit no fact, never a guess.
+"""
+
+from __future__ import annotations
+
+import ast
+import time
+from pathlib import Path
+
+from loguru import logger
+
+from ... import constants as cs
+from ... import logs as ls
+from ...config import settings
+from ..frontends.protocol import CallSiteKey, ResolvedCallSite, SemanticFacts
+
+_FILE_BUDGET_SECONDS = 2.0
+_RESOLVABLE_TYPES = frozenset({"function", "class"})
+
+
+def python_frontend_available() -> bool:
+    try:
+        import jedi  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def resolve_python_frontend() -> cs.PythonFrontend:
+    # The parser fingerprint records the RESOLVED mode: a graph built with
+    # jedi facts and one without must never share an identity.
+    mode = settings.PYTHON_FRONTEND
+    if mode == cs.PythonFrontend.HEURISTIC:
+        return mode
+    if not python_frontend_available():
+        return cs.PythonFrontend.HEURISTIC
+    return cs.PythonFrontend.JEDI
+
+
+class _CallSite(ast.NodeVisitor):
+    """Collects (name, name_line, name_byte_col) for the call sites worth a
+    jedi query: attribute calls and bare calls bound by an import."""
+
+    def __init__(self) -> None:
+        self.imported_names: set[str] = set()
+        self.sites: list[tuple[str, int, int]] = []
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            head = (alias.asname or alias.name).partition(".")[0]
+            self.imported_names.add(head)
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        for alias in node.names:
+            self.imported_names.add(alias.asname or alias.name)
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        func = node.func
+        if isinstance(func, ast.Attribute):
+            # The attribute NAME token starts len(attr)-bytes before the
+            # expression's end; ast offsets are UTF-8 byte offsets, matching
+            # the tree-sitter key convention.
+            if func.end_lineno is not None and func.end_col_offset is not None:
+                col = func.end_col_offset - len(func.attr.encode(cs.ENCODING_UTF8))
+                self.sites.append((func.attr, func.end_lineno, col))
+        elif isinstance(func, ast.Name) and func.id in self.imported_names:
+            self.sites.append((func.id, func.lineno, func.col_offset))
+        self.generic_visit(node)
+
+
+def _byte_to_char_col(line_text: str, byte_col: int) -> int:
+    return len(
+        line_text.encode(cs.ENCODING_UTF8)[:byte_col].decode(
+            cs.ENCODING_UTF8, errors="replace"
+        )
+    )
+
+
+def _char_to_byte_col(line_text: str, char_col: int) -> int:
+    return len(line_text[:char_col].encode(cs.ENCODING_UTF8))
+
+
+def _target_of(names, repo_path: Path):
+    if len(names) != 1:
+        return None
+    name = names[0]
+    if name.type not in _RESOLVABLE_TYPES:
+        return None
+    return name
+
+
+def _resolve_file(
+    script,
+    source_lines: list[str],
+    rel_file: str,
+    sites: list[tuple[str, int, int]],
+    repo_path: Path,
+    facts: SemanticFacts,
+    deadline: float,
+) -> bool:
+    import jedi
+
+    for simple_name, line, byte_col in sites:
+        if time.monotonic() > deadline:
+            return False
+        if line - 1 >= len(source_lines):
+            continue
+        char_col = _byte_to_char_col(source_lines[line - 1], byte_col)
+        try:
+            names = script.infer(line, char_col)
+        except (jedi.InternalError, RecursionError, ValueError):
+            continue
+        target = _target_of(names, repo_path)
+        if target is None:
+            continue
+        key: CallSiteKey = (rel_file, line, byte_col, simple_name)
+        module_path = target.module_path
+        if module_path is None or not str(module_path).startswith(str(repo_path) + "/"):
+            facts.external_sites.add(key)
+            continue
+        target_rel = Path(module_path).relative_to(repo_path).as_posix()
+        try:
+            target_lines = (
+                Path(module_path).read_text(encoding=cs.ENCODING_UTF8).splitlines()
+            )
+        except (OSError, UnicodeDecodeError):
+            continue
+        if target.line is None or target.line - 1 >= len(target_lines):
+            continue
+        # The Pass-2 span index keys Python definitions at the def/class
+        # KEYWORD (the line's first code byte), not the name token jedi
+        # reports; the indent is ASCII so its byte and char widths agree.
+        def_line = target_lines[target.line - 1]
+        target_byte_col = len(def_line) - len(def_line.lstrip())
+        facts.resolved_call_sites[key] = ResolvedCallSite(
+            simple_name, target_rel, target.line, target_byte_col
+        )
+    return True
+
+
+def run_python_frontend(repo_path: Path, files: list[Path]) -> SemanticFacts:
+    facts = SemanticFacts()
+    if not files:
+        return facts
+    import jedi
+
+    repo_path = repo_path.resolve()
+    project = jedi.Project(str(repo_path))
+    degraded = 0
+    for file_path in files:
+        try:
+            source = file_path.read_text(encoding=cs.ENCODING_UTF8)
+            tree = ast.parse(source)
+        except (OSError, SyntaxError, ValueError, UnicodeDecodeError):
+            continue
+        collector = _CallSite()
+        collector.visit(tree)
+        if not collector.sites:
+            continue
+        try:
+            rel_file = file_path.resolve().relative_to(repo_path).as_posix()
+        except ValueError:
+            continue
+        script = jedi.Script(path=str(file_path), project=project)
+        deadline = time.monotonic() + _FILE_BUDGET_SECONDS
+        if not _resolve_file(
+            script,
+            source.splitlines(),
+            rel_file,
+            collector.sites,
+            repo_path,
+            facts,
+            deadline,
+        ):
+            degraded += 1
+    if degraded:
+        logger.info(ls.PY_FRONTEND_BUDGET_DEGRADED, count=degraded)
+    return facts

--- a/codebase_rag/parsers/py_frontend/frontend.py
+++ b/codebase_rag/parsers/py_frontend/frontend.py
@@ -102,13 +102,60 @@ def _char_to_byte_col(line_text: str, char_col: int) -> int:
     return len(line_text[:char_col].encode(cs.ENCODING_UTF8))
 
 
-def _target_of(names, repo_path: Path):
+def _single_resolvable_target(names):
+    # Exactly one inferred function/class is a usable fact; anything else
+    # (ambiguity, modules, instances) is the ceiling: no fact, never a guess.
     if len(names) != 1:
         return None
     name = names[0]
     if name.type not in _RESOLVABLE_TYPES:
         return None
     return name
+
+
+def _record_site(
+    script,
+    source_lines: list[str],
+    rel_file: str,
+    site: tuple[str, int, int],
+    repo_path: Path,
+    facts: SemanticFacts,
+) -> None:
+    import jedi
+
+    simple_name, line, byte_col = site
+    if line - 1 >= len(source_lines):
+        return
+    char_col = _byte_to_char_col(source_lines[line - 1], byte_col)
+    try:
+        names = script.infer(line, char_col)
+    except (jedi.InternalError, RecursionError, ValueError):
+        return
+    target = _single_resolvable_target(names)
+    if target is None:
+        return
+    key: CallSiteKey = (rel_file, line, byte_col, simple_name)
+    module_path = target.module_path
+    if module_path is None or not Path(module_path).is_relative_to(repo_path):
+        facts.external_sites.add(key)
+        return
+    target_rel = Path(module_path).relative_to(repo_path).as_posix()
+    try:
+        target_lines = (
+            Path(module_path).read_text(encoding=cs.ENCODING_UTF8).splitlines()
+        )
+    except (OSError, UnicodeDecodeError):
+        return
+    if target.line is None or target.line - 1 >= len(target_lines):
+        return
+    # The Pass-2 span index keys Python definitions at the def/class
+    # KEYWORD (the line's first code byte), not the name token jedi
+    # reports; the indent is ASCII so its byte and char widths agree.
+    def_line = target_lines[target.line - 1]
+    target_byte_col = len(def_line) - len(def_line.lstrip())
+    facts.resolved_call_sites[key] = ResolvedCallSite(
+        simple_name, target_rel, target.line, target_byte_col
+    )
 
 
 def _resolve_file(
@@ -120,43 +167,20 @@ def _resolve_file(
     facts: SemanticFacts,
     deadline: float,
 ) -> bool:
-    import jedi
-
-    for simple_name, line, byte_col in sites:
+    # File-local collection makes degradation ATOMIC: a file that blows its
+    # budget contributes nothing, instead of a half-resolved prefix. jedi has
+    # no cancellation API, so one slow infer() can overshoot the deadline;
+    # the post-call check then discards the whole file's facts, bounding the
+    # damage to a single call's wall time.
+    file_facts = SemanticFacts()
+    for site in sites:
         if time.monotonic() > deadline:
             return False
-        if line - 1 >= len(source_lines):
-            continue
-        char_col = _byte_to_char_col(source_lines[line - 1], byte_col)
-        try:
-            names = script.infer(line, char_col)
-        except (jedi.InternalError, RecursionError, ValueError):
-            continue
-        target = _target_of(names, repo_path)
-        if target is None:
-            continue
-        key: CallSiteKey = (rel_file, line, byte_col, simple_name)
-        module_path = target.module_path
-        if module_path is None or not str(module_path).startswith(str(repo_path) + "/"):
-            facts.external_sites.add(key)
-            continue
-        target_rel = Path(module_path).relative_to(repo_path).as_posix()
-        try:
-            target_lines = (
-                Path(module_path).read_text(encoding=cs.ENCODING_UTF8).splitlines()
-            )
-        except (OSError, UnicodeDecodeError):
-            continue
-        if target.line is None or target.line - 1 >= len(target_lines):
-            continue
-        # The Pass-2 span index keys Python definitions at the def/class
-        # KEYWORD (the line's first code byte), not the name token jedi
-        # reports; the indent is ASCII so its byte and char widths agree.
-        def_line = target_lines[target.line - 1]
-        target_byte_col = len(def_line) - len(def_line.lstrip())
-        facts.resolved_call_sites[key] = ResolvedCallSite(
-            simple_name, target_rel, target.line, target_byte_col
-        )
+        _record_site(script, source_lines, rel_file, site, repo_path, file_facts)
+    if time.monotonic() > deadline:
+        return False
+    facts.resolved_call_sites.update(file_facts.resolved_call_sites)
+    facts.external_sites.update(file_facts.external_sites)
     return True
 
 

--- a/codebase_rag/parsers/py_frontend/frontend.py
+++ b/codebase_rag/parsers/py_frontend/frontend.py
@@ -34,7 +34,10 @@ from ... import logs as ls
 from ...config import settings
 from ..frontends.protocol import CallSiteKey, ResolvedCallSite, SemanticFacts
 
-_FILE_BUDGET_SECONDS = 2.0
+# Generous enough for jedi's cold-start typeshed parse (the dominant cost,
+# amortized by its on-disk cache after the first file); a stuck module still
+# degrades to heuristics instead of stalling the index.
+_FILE_BUDGET_SECONDS = 10.0
 _RESOLVABLE_TYPES = frozenset({"function", "class"})
 
 
@@ -129,7 +132,9 @@ def _record_site(
     char_col = _byte_to_char_col(source_lines[line - 1], byte_col)
     try:
         names = script.infer(line, char_col)
-    except (jedi.InternalError, RecursionError, ValueError):
+    except (jedi.InternalError, RecursionError, ValueError, OSError, EOFError):
+        # EOFError/OSError surface from jedi's on-disk parser cache when
+        # concurrent processes race it; a lost site degrades to heuristics.
         return
     target = _single_resolvable_target(names)
     if target is None:

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -48,6 +48,8 @@ class TypeInferenceEngine:
         "go_function_return_types",
         "go_call_sites",
         "go_external_sites",
+        "python_call_sites",
+        "python_external_sites",
         "csharp_partial_groups",
         "csharp_extension_methods",
         "csharp_call_sites",
@@ -89,6 +91,8 @@ class TypeInferenceEngine:
         go_function_return_types: dict[str, str] | None = None,
         go_call_sites: dict[CallSiteKey, ResolvedCallSite] | None = None,
         go_external_sites: set[CallSiteKey] | None = None,
+        python_call_sites: dict[CallSiteKey, ResolvedCallSite] | None = None,
+        python_external_sites: set[CallSiteKey] | None = None,
         csharp_partial_groups: dict[str, list[str]] | None = None,
         csharp_extension_methods: dict[str, list[tuple[str, str, str, int]]]
         | None = None,
@@ -147,6 +151,14 @@ class TypeInferenceEngine:
         self.go_call_sites = go_call_sites if go_call_sites is not None else {}
         self.go_external_sites = (
             go_external_sites if go_external_sites is not None else set()
+        )
+        # Shared references, same discipline: the Jedi call-site facts and
+        # external proofs (issue #1183), populated after construction.
+        self.python_call_sites = (
+            python_call_sites if python_call_sites is not None else {}
+        )
+        self.python_external_sites = (
+            python_external_sites if python_external_sites is not None else set()
         )
         self._go_free_fn_index: dict[tuple[str, str], str] = {}
         self._go_free_fn_index_size = -1

--- a/codebase_rag/tests/test_python_frontend.py
+++ b/codebase_rag/tests/test_python_frontend.py
@@ -18,6 +18,14 @@ from codebase_rag.parser_loader import load_parsers
 
 jedi = pytest.importorskip("jedi")
 
+
+@pytest.fixture(autouse=True)
+def _isolated_jedi_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # pytest-xdist workers otherwise share jedi's on-disk pickle cache and
+    # race it (EOFError: Ran out of input on CI); each test gets its own.
+    monkeypatch.setattr(jedi.settings, "cache_directory", str(tmp_path / "jedi-cache"))
+
+
 from codebase_rag.parsers.py_frontend import frontend as py_fe  # noqa: E402
 from codebase_rag.parsers.py_frontend.frontend import (  # noqa: E402
     _byte_to_char_col,
@@ -68,7 +76,12 @@ def test_reexport_chain_resolves_to_the_definition(tmp_path: Path) -> None:
     assert ("proj.caller.use", "proj.pkg.impl.f") in calls
 
 
-def test_stdlib_call_is_proven_external(tmp_path: Path) -> None:
+def test_stdlib_call_is_proven_external(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A cold jedi cache makes the first stdlib inference slow; the budget is
+    # not what this test measures, so give it room (loaded CI workers).
+    monkeypatch.setattr(py_fe, "_FILE_BUDGET_SECONDS", 60.0)
     repo = tmp_path / "proj"
     repo.mkdir()
     (repo / "caller.py").write_text(

--- a/codebase_rag/tests/test_python_frontend.py
+++ b/codebase_rag/tests/test_python_frontend.py
@@ -1,0 +1,153 @@
+# Jedi Python semantic frontend, stage 1 of issue #1183. The heuristics
+# approximate re-export chains, decorated callables, and MRO dispatch; the
+# frontend's compiler-grade facts resolve them exactly and prove externality
+# for calls leaving the repo. Off (the default) everything stays byte-for-byte
+# heuristic; ambiguity emits no fact, never a guess.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.capture import ALL_ENABLED
+from codebase_rag.config import settings
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+
+jedi = pytest.importorskip("jedi")
+
+from codebase_rag.parsers.py_frontend import frontend as py_fe  # noqa: E402
+from codebase_rag.parsers.py_frontend.frontend import (  # noqa: E402
+    _byte_to_char_col,
+    _CallSite,
+    _char_to_byte_col,
+    run_python_frontend,
+)
+
+CALLS = cs.RelationshipType.CALLS.value
+
+
+def _calls(tmp_path: Path, files: dict[str, str], mode: cs.PythonFrontend) -> set:
+    parsers, queries = load_parsers()
+    repo = tmp_path / "proj"
+    for rel, content in files.items():
+        path = repo / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    previous = settings.PYTHON_FRONTEND
+    settings.PYTHON_FRONTEND = mode
+    try:
+        mock = MagicMock()
+        GraphUpdater(
+            ingestor=mock,
+            repo_path=repo,
+            parsers=parsers,
+            queries=queries,
+            capture=ALL_ENABLED,
+        ).run()
+    finally:
+        settings.PYTHON_FRONTEND = previous
+    return {
+        (c.args[0][2], c.args[2][2])
+        for c in mock.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) == CALLS
+    }
+
+
+def test_reexport_chain_resolves_to_the_definition(tmp_path: Path) -> None:
+    files = {
+        "pkg/__init__.py": "from .impl import f\n",
+        "pkg/impl.py": "def f():\n    return 1\n",
+        "caller.py": "from pkg import f\n\n\ndef use():\n    f()\n",
+    }
+    calls = _calls(tmp_path, files, cs.PythonFrontend.JEDI)
+    assert ("proj.caller.use", "proj.pkg.impl.f") in calls
+
+
+def test_stdlib_call_is_proven_external(tmp_path: Path) -> None:
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    (repo / "caller.py").write_text(
+        'import os\n\n\ndef use():\n    os.getenv("X")\n', encoding="utf-8"
+    )
+    facts = run_python_frontend(repo, [repo / "caller.py"])
+    assert ("caller.py", 5, 7, "getenv") in facts.external_sites
+    assert not facts.resolved_call_sites
+
+
+def test_repo_local_shadow_beats_the_stdlib(tmp_path: Path) -> None:
+    # A first-party os.py next to the caller IS what `import os` binds at
+    # runtime (script-dir precedence); jedi models that, so the edge to the
+    # local module is correct, never a fabrication.
+    files = {
+        "os.py": "def getenv(key):\n    return key\n",
+        "caller.py": 'import os\n\n\ndef use():\n    os.getenv("X")\n',
+    }
+    calls = _calls(tmp_path, files, cs.PythonFrontend.JEDI)
+    assert ("proj.caller.use", "proj.os.getenv") in calls
+
+
+def test_decorated_function_still_resolves(tmp_path: Path) -> None:
+    files = {
+        "deco.py": (
+            "import functools\n\n\ndef wrap(fn):\n"
+            "    @functools.wraps(fn)\n    def inner(*a, **k):\n"
+            "        return fn(*a, **k)\n\n    return inner\n\n\n"
+            "@wrap\ndef work():\n    return 1\n"
+        ),
+        "caller.py": "from deco import work\n\n\ndef use():\n    work()\n",
+    }
+    calls = _calls(tmp_path, files, cs.PythonFrontend.JEDI)
+    assert ("proj.caller.use", "proj.deco.work") in calls
+
+
+_ALIASED_REEXPORT = {
+    "pkg/__init__.py": "from .impl import real_fn as f\n",
+    "pkg/impl.py": "def real_fn():\n    return 1\n",
+    "caller.py": "from pkg import f\n\n\ndef use():\n    f()\n",
+}
+
+
+def test_aliased_reexport_is_the_jedi_discriminator(tmp_path: Path) -> None:
+    # The heuristics drop an aliased re-export entirely; jedi follows the
+    # rename through __init__ to the real definition.
+    calls = _calls(tmp_path, files=_ALIASED_REEXPORT, mode=cs.PythonFrontend.JEDI)
+    assert ("proj.caller.use", "proj.pkg.impl.real_fn") in calls
+
+
+def test_heuristic_mode_stays_heuristic(tmp_path: Path) -> None:
+    calls = _calls(tmp_path, files=_ALIASED_REEXPORT, mode=cs.PythonFrontend.HEURISTIC)
+    assert ("proj.caller.use", "proj.pkg.impl.real_fn") not in calls
+
+
+def test_budget_exhaustion_degrades_to_heuristics(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(py_fe, "_FILE_BUDGET_SECONDS", -1.0)
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    (repo / "a.py").write_text("import os\n\n\ndef f():\n    os.getenv('X')\n")
+    facts = run_python_frontend(repo, [repo / "a.py"])
+    assert not facts.resolved_call_sites
+    assert not facts.external_sites
+
+
+def test_call_site_walker_byte_columns_on_unicode_lines() -> None:
+    import ast
+
+    source = 'x = "café"; obj.método(1)\nfrom m import fn\nfn()\n'
+    collector = _CallSite()
+    collector.visit(ast.parse(source))
+    sites = {(name, line, col) for name, line, col in collector.sites}
+    method_col = len('x = "café"; obj.'.encode())
+    assert ("método", 1, method_col) in sites
+    assert ("fn", 3, 0) in sites
+
+
+def test_column_conversions_round_trip() -> None:
+    line = 'x = "café" + f("a")'
+    for char_col in range(len(line)):
+        byte_col = _char_to_byte_col(line, char_col)
+        assert _byte_to_char_col(line, byte_col) == char_col

--- a/codebase_rag/tests/test_python_frontend.py
+++ b/codebase_rag/tests/test_python_frontend.py
@@ -29,7 +29,9 @@ from codebase_rag.parsers.py_frontend.frontend import (  # noqa: E402
 CALLS = cs.RelationshipType.CALLS.value
 
 
-def _calls(tmp_path: Path, files: dict[str, str], mode: cs.PythonFrontend) -> set:
+def _calls_edges_for(
+    tmp_path: Path, files: dict[str, str], mode: cs.PythonFrontend
+) -> set:
     parsers, queries = load_parsers()
     repo = tmp_path / "proj"
     for rel, content in files.items():
@@ -62,7 +64,7 @@ def test_reexport_chain_resolves_to_the_definition(tmp_path: Path) -> None:
         "pkg/impl.py": "def f():\n    return 1\n",
         "caller.py": "from pkg import f\n\n\ndef use():\n    f()\n",
     }
-    calls = _calls(tmp_path, files, cs.PythonFrontend.JEDI)
+    calls = _calls_edges_for(tmp_path, files, cs.PythonFrontend.JEDI)
     assert ("proj.caller.use", "proj.pkg.impl.f") in calls
 
 
@@ -85,7 +87,7 @@ def test_repo_local_shadow_beats_the_stdlib(tmp_path: Path) -> None:
         "os.py": "def getenv(key):\n    return key\n",
         "caller.py": 'import os\n\n\ndef use():\n    os.getenv("X")\n',
     }
-    calls = _calls(tmp_path, files, cs.PythonFrontend.JEDI)
+    calls = _calls_edges_for(tmp_path, files, cs.PythonFrontend.JEDI)
     assert ("proj.caller.use", "proj.os.getenv") in calls
 
 
@@ -99,7 +101,7 @@ def test_decorated_function_still_resolves(tmp_path: Path) -> None:
         ),
         "caller.py": "from deco import work\n\n\ndef use():\n    work()\n",
     }
-    calls = _calls(tmp_path, files, cs.PythonFrontend.JEDI)
+    calls = _calls_edges_for(tmp_path, files, cs.PythonFrontend.JEDI)
     assert ("proj.caller.use", "proj.deco.work") in calls
 
 
@@ -113,12 +115,16 @@ _ALIASED_REEXPORT = {
 def test_aliased_reexport_is_the_jedi_discriminator(tmp_path: Path) -> None:
     # The heuristics drop an aliased re-export entirely; jedi follows the
     # rename through __init__ to the real definition.
-    calls = _calls(tmp_path, files=_ALIASED_REEXPORT, mode=cs.PythonFrontend.JEDI)
+    calls = _calls_edges_for(
+        tmp_path, files=_ALIASED_REEXPORT, mode=cs.PythonFrontend.JEDI
+    )
     assert ("proj.caller.use", "proj.pkg.impl.real_fn") in calls
 
 
 def test_heuristic_mode_stays_heuristic(tmp_path: Path) -> None:
-    calls = _calls(tmp_path, files=_ALIASED_REEXPORT, mode=cs.PythonFrontend.HEURISTIC)
+    calls = _calls_edges_for(
+        tmp_path, files=_ALIASED_REEXPORT, mode=cs.PythonFrontend.HEURISTIC
+    )
     assert ("proj.caller.use", "proj.pkg.impl.real_fn") not in calls
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ codebase_rag = [
 
 [project.optional-dependencies]
 test = [
+    "jedi>=0.19",
     "pytest>=8.4.1",
     "pytest-asyncio>=1.0.0",
     "pytest-cov>=4.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,9 @@ ast-grep = [
     "ast-grep-py>=0.44.0",
     "pyyaml>=6.0",
 ]
+python-semantics = [
+    "jedi>=0.19",
+]
 
 [tool.ruff]
 line-length = 88

--- a/realtime_updater.py
+++ b/realtime_updater.py
@@ -331,6 +331,12 @@ class CodeChangeEventHandler(FileSystemEventHandler):
             self.updater._rehydrate_csharp_type_locations()
             self.updater._rehydrate_function_locations()
             self.updater._join_csharp_partials()
+        elif changed_language == SupportedLanguage.PYTHON:
+            # The Jedi facts (issue #1183) are position-keyed against the
+            # repo-wide import graph, so an edit can rebind call sites in
+            # unchanged files; same rerun-then-rehydrate posture as Go/C#.
+            self.updater._run_python_frontend()
+            self.updater._rehydrate_function_locations()
 
         # Rust inline-mod import maps retract at the end of every parse
         # and only re-commit through arbitration; run() is not on this

--- a/uv.lock
+++ b/uv.lock
@@ -452,6 +452,7 @@ semantic = [
 test = [
     { name = "ast-grep-py" },
     { name = "filelock" },
+    { name = "jedi" },
     { name = "libclang" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -512,6 +513,7 @@ requires-dist = [
     { name = "filelock", marker = "extra == 'test'", specifier = ">=3.12" },
     { name = "huggingface-hub", extras = ["hf-xet"], specifier = ">=1.7.2" },
     { name = "jedi", marker = "extra == 'python-semantics'", specifier = ">=0.19" },
+    { name = "jedi", marker = "extra == 'test'", specifier = ">=0.19" },
     { name = "libclang", marker = "extra == 'cpp'", specifier = ">=18.1.1" },
     { name = "libclang", marker = "extra == 'test'", specifier = ">=18.1.1" },
     { name = "loguru", specifier = ">=0.7.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -404,7 +404,7 @@ wheels = [
 
 [[package]]
 name = "code-graph-rag"
-version = "0.0.672"
+version = "0.0.684"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -440,6 +440,9 @@ cpp = [
 ]
 milvus = [
     { name = "pymilvus", extra = ["milvus-lite"] },
+]
+python-semantics = [
+    { name = "jedi" },
 ]
 semantic = [
     { name = "qdrant-client" },
@@ -508,6 +511,7 @@ requires-dist = [
     { name = "diff-match-patch", specifier = ">=20241021" },
     { name = "filelock", marker = "extra == 'test'", specifier = ">=3.12" },
     { name = "huggingface-hub", extras = ["hf-xet"], specifier = ">=1.7.2" },
+    { name = "jedi", marker = "extra == 'python-semantics'", specifier = ">=0.19" },
     { name = "libclang", marker = "extra == 'cpp'", specifier = ">=18.1.1" },
     { name = "libclang", marker = "extra == 'test'", specifier = ">=18.1.1" },
     { name = "loguru", specifier = ">=0.7.3" },
@@ -552,7 +556,7 @@ requires-dist = [
     { name = "typer", specifier = ">=0.21.1" },
     { name = "watchdog", specifier = ">=6.0.0" },
 ]
-provides-extras = ["test", "cpp", "treesitter-full", "semantic", "milvus", "ast-grep"]
+provides-extras = ["test", "cpp", "treesitter-full", "semantic", "milvus", "ast-grep", "python-semantics"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1378,6 +1382,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0f/27/056e0638a86749374d6f57d0b0db39f29509cce9313cf91bdc0ac4d91084/jaraco_functools-4.4.0.tar.gz", hash = "sha256:da21933b0417b89515562656547a77b4931f98176eb173644c0d35032a33d6bb", size = 19943, upload-time = "2025-12-21T09:29:43.6Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/c4/813bb09f0985cb21e959f21f2464169eca882656849adf727ac7bb7e1767/jaraco_functools-4.4.0-py3-none-any.whl", hash = "sha256:9eec1e36f45c818d9bf307c8948eb03b2b56cd44087b3cdc989abca1f20b9176", size = 10481, upload-time = "2025-12-21T09:29:42.27Z" },
+]
+
+[[package]]
+name = "jedi"
+version = "0.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "parso" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/b7/a3635f6a2d7cf5b5dd98064fc1d5fbbafcb25477bcea204a3a92145d158b/jedi-0.20.0.tar.gz", hash = "sha256:c3f4ccbd276696f4b19c54618d4fb18f9fc24b0aef02acf704b23f487daa1011", size = 3119416, upload-time = "2026-05-01T23:38:47.814Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/93/242e2eab5fe682ffcb8b0084bde703a41d51e17ee0f3a31ff0d9d813620a/jedi-0.20.0-py2.py3-none-any.whl", hash = "sha256:7bdd9c2634f56713299976f4cbd59cb3fa92165cc5e05ea811fb253480728b67", size = 4884812, upload-time = "2026-05-01T23:38:43.919Z" },
 ]
 
 [[package]]
@@ -2363,6 +2379,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/31/89/8fc1c268969fac43688d65fd92e67df24bd128d53cb4d2eee534cd307399/pandas-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9c39be2d709d01fa972a0cabc522389fceca4f3969332ba25a7d6c5802cf976a", size = 11828897, upload-time = "2026-05-11T18:54:17.146Z" },
     { url = "https://files.pythonhosted.org/packages/56/3b/e7d20dea247a3e6dc0bd8a6953854afbedc03951def4e7371e05e7263e25/pandas-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4db8c527972a821cf5286b40ccc57642a39bc62e62022b42f99f8a67fca8c3a1", size = 10900855, upload-time = "2026-05-11T18:54:19.72Z" },
     { url = "https://files.pythonhosted.org/packages/0f/54/68a0978d1ef8502b8492099beaa6e7a0c1b32e3b5d4f677f5810cb08711c/pandas-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:b2c95f8bfc1ee412bf482605d7bfd30c12d1d26bd59fdd91efeef1d4718decb1", size = 9466464, upload-time = "2026-05-11T18:54:22.754Z" },
+]
+
+[[package]]
+name = "parso"
+version = "0.8.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/4b/90c937815137d43ce71ba043cd3566221e9df6b9c805f24b5d138c9d40a7/parso-0.8.7.tar.gz", hash = "sha256:eaaac4c9fdd5e9e8852dc778d2d7405897ec510f2a298071453e5e3a07914bb1", size = 401824, upload-time = "2026-05-01T23:13:02.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/5d/8268b644392ee874ee82a635cd0df1773de230bde356c38de28e298392cc/parso-0.8.7-py2.py3-none-any.whl", hash = "sha256:a8926eb2a1b915486941fdbd31e86a4baf88fe8c210f25f2f35ecec5b574ca1c", size = 107025, upload-time = "2026-05-01T23:12:58.867Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Stage 1 of #1183 (the issue stays open for stage 2, the opt-in Pyright tier). The ironic gap closes: Python, which gets the deepest FLOWS_TO walk in the repo, gains its first semantic layer — in-process, zero toolchain.

## What's in

- **`parsers/py_frontend/`**: the Jedi fact provider behind the `LanguageFrontend` protocol (#1178). A stdlib-`ast` walker enumerates the call sites worth a semantic query — attribute calls and import-bound bare calls; module-local bare calls stay on the heuristics' home turf — with byte-exact name-token positions matching the tree-sitter `CallSiteKey` convention (ast offsets are UTF-8 bytes; jedi speaks char columns, so both directions convert per line). Each site gets `Script.infer()`: a single first-party inference becomes a `resolved_call_sites` fact targeted at the definition's Pass-2 span key (the def/class keyword column, i.e. the line's leading-whitespace width); a resolution outside the repo (stdlib, site-packages, builtins) becomes an `external_sites` proof. Ambiguity (zero or multiple inferences) emits nothing, never a guess.
- **Consumption**, mirroring the Go shape exactly: shared-reference fact maps on `DefinitionProcessor`, threaded through `TypeInferenceEngine`, consulted by `CallResolver.resolve_python_call_site` (join via the shared `call_site_key`/`declared_location` helpers), with a `PY_EXTERNAL_TARGET` sentinel in the call processor that suppresses trie fabrication; any miss falls back to today's Python heuristics with `call_point` preserved.
- **`PYTHON_FRONTEND` setting** (`heuristic` default | `jedi`): opt-in for now, and `jedi`-when-uninstalled degrades to heuristics with a warning. The parser fingerprint records the RESOLVED mode so jedi and non-jedi graphs never share an identity.
- **Cost control**: one `jedi.Project` shared across files; a 2s per-file budget that degrades that file to heuristics (logged) rather than stalling the index.
- **Realtime**: `.py` changes re-run the frontend on the watch path (the #1319 posture), since the facts are position-keyed against the repo-wide import graph.
- **Dependency**: `jedi>=0.19` under a new `python-semantics` extra; `uv.lock` regenerated minimally (jedi + parso).

## The discriminating case

`pkg/__init__.py: from .impl import real_fn as f` + `from pkg import f; f()`: the heuristics emit NO call edge at all; jedi follows the aliased re-export to the definition and the graph gains `caller.use -> pkg.impl.real_fn`. Test-pinned in both directions (`test_aliased_reexport_is_the_jedi_discriminator`, `test_heuristic_mode_stays_heuristic`).

## Honesty notes

- A repo-local `os.py` next to the caller resolves as the call target — that is what `import os` binds at runtime (script-dir precedence), so the edge is correct, and it's pinned as such (`test_repo_local_shadow_beats_the_stdlib`).
- Off (the default), the resolver short-circuits on empty fact maps: the resolution battery (923 tests across python/resolver/calls/realtime) is green unchanged.

## Tests

`test_python_frontend.py` (jedi-gated via importorskip): the discriminator pair; stdlib external proof at the fact level; decorated-function resolution; repo-local shadow semantics; budget-exhaustion degrade; ast-walker byte columns on unicode lines; byte/char column round-trip. All 9 green; battery 923 green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional semantic Python analysis using Jedi for more accurate call resolution.
  * Added configurable heuristic (default) and Jedi analysis modes.
  * Improved distinction between repository calls and external library calls.
  * Python file updates now refresh semantic call relationships automatically.
  * Added fallback safeguards when semantic analysis is unavailable or exceeds its time budget.

* **Bug Fixes**
  * Improved handling of re-exports, aliases, decorated functions, Unicode source, and local modules shadowing standard-library modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->