### PR TITLE
feat: call-relative closure-capture cell semantics in the Python flow walk

### DIFF
--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -3568,12 +3568,15 @@ class FlowProcessor:
             return
         if (previous := self._pending_captures.pop(name, None)) is not None:
             self._commit_pending_capture(previous)
+        snapshot = {
+            fv: taint for fv in free_vars if (taint := state.get(fv)) is not None
+        }
         self._pending_captures[name] = _PendingCapture(
             nested_qn=nested_qn,
             def_node=def_node,
             caller_qn=ctx.caller_qn,
             free_vars=free_vars,
-            snapshot={fv: t for fv in free_vars if (t := state.get(fv)) is not None},
+            snapshot=snapshot,
         )
 
     def _commit_capture_state(
@@ -3609,10 +3612,10 @@ class FlowProcessor:
         if record is None:
             return
         record.called = True
-        self._commit_capture_state(
-            record,
-            {fv: t for fv in record.free_vars if (t := state.get(fv)) is not None},
-        )
+        cell_state = {
+            fv: taint for fv in record.free_vars if (taint := state.get(fv)) is not None
+        }
+        self._commit_capture_state(record, cell_state)
 
     def _note_capture_escape(self, name: str) -> None:
         record = self._pending_captures.get(name)
@@ -3636,6 +3639,11 @@ class FlowProcessor:
             return
         if expr.type == cs.TS_PY_IDENTIFIER and expr.text is not None:
             self._note_capture_escape(expr.text.decode(cs.ENCODING_UTF8))
+            return
+        if expr.type == cs.TS_PY_KEYWORD_ARGUMENT:
+            # `other(send=None)`: the label names a PARAMETER, not the
+            # closure; only the value can carry it onward.
+            self._note_capture_escapes_in(expr.child_by_field_name(cs.FIELD_VALUE))
             return
         for child in expr.named_children:
             self._note_capture_escapes_in(child)

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -3021,6 +3021,11 @@ class FlowProcessor:
     def _apply_assignment(self, node: Node, tainted: _TaintMap, ctx: _FlowCtx) -> None:
         left = node.child_by_field_name(cs.TS_FIELD_LEFT)
         right = node.child_by_field_name(cs.TS_FIELD_RIGHT)
+        if right is not None and right.type == cs.TS_PY_IDENTIFIER and right.text:
+            # A closure assigned ANYWHERE (holder.callback = send, d[k] = send)
+            # escapes, even when the non-identifier target makes this
+            # assignment otherwise untrackable (issue #1211 review).
+            self._note_capture_escape(right.text.decode(cs.ENCODING_UTF8))
         if (
             left is None
             or right is None
@@ -3225,6 +3230,8 @@ class FlowProcessor:
         for child in _return_value_nodes(node):
             if child.type == cs.TS_PY_IDENTIFIER and child.text is not None:
                 name = child.text.decode(cs.ENCODING_UTF8)
+                # `return send` hands the closure to the caller: it escapes.
+                self._note_capture_escape(name)
                 if (taint := tainted.get(name)) is not None:
                     tainted_here = True
                     result = _merge_taint(result, taint)

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -3021,11 +3021,11 @@ class FlowProcessor:
     def _apply_assignment(self, node: Node, tainted: _TaintMap, ctx: _FlowCtx) -> None:
         left = node.child_by_field_name(cs.TS_FIELD_LEFT)
         right = node.child_by_field_name(cs.TS_FIELD_RIGHT)
-        if right is not None and right.type == cs.TS_PY_IDENTIFIER and right.text:
-            # A closure assigned ANYWHERE (holder.callback = send, d[k] = send)
-            # escapes, even when the non-identifier target makes this
-            # assignment otherwise untrackable (issue #1211 review).
-            self._note_capture_escape(right.text.decode(cs.ENCODING_UTF8))
+        # A closure carried ANYWHERE in the RHS (holder.callback = send,
+        # d[k] = (send), x = send if c else other) escapes, even when the
+        # non-identifier target makes the assignment otherwise untrackable
+        # (issue #1211 review); direct-call callees are exempt.
+        self._note_capture_escapes_in(right)
         if (
             left is None
             or right is None
@@ -3228,10 +3228,11 @@ class FlowProcessor:
         result = _EMPTY_TAINT
         tainted_here = False
         for child in _return_value_nodes(node):
+            # Any returned expression may hand the closure to the caller
+            # (`return send`, `return send if c else other`): it escapes.
+            self._note_capture_escapes_in(child)
             if child.type == cs.TS_PY_IDENTIFIER and child.text is not None:
                 name = child.text.decode(cs.ENCODING_UTF8)
-                # `return send` hands the closure to the caller: it escapes.
-                self._note_capture_escape(name)
                 if (taint := tainted.get(name)) is not None:
                     tainted_here = True
                     result = _merge_taint(result, taint)
@@ -3617,6 +3618,27 @@ class FlowProcessor:
         record = self._pending_captures.get(name)
         if record is not None:
             record.escaped = True
+
+    def _note_capture_escapes_in(self, expr: Node | None) -> None:
+        # Every identifier VALUE anywhere in this expression escapes its
+        # closure: wrappers, conditionals, containers, and call ARGUMENTS all
+        # hand the function object onward. The one exception is a call's
+        # callee position -- `send()` is the direct invocation the
+        # call-relative path handles -- so calls recurse into arguments only.
+        # Over-marking is conservative-safe (escape means the def-site MAY
+        # snapshot), never a lost flow.
+        if expr is None:
+            return
+        if expr.type == cs.TS_PY_CALL:
+            self._note_capture_escapes_in(
+                expr.child_by_field_name(cs.TS_FIELD_ARGUMENTS)
+            )
+            return
+        if expr.type == cs.TS_PY_IDENTIFIER and expr.text is not None:
+            self._note_capture_escape(expr.text.decode(cs.ENCODING_UTF8))
+            return
+        for child in expr.named_children:
+            self._note_capture_escapes_in(child)
 
     def _flush_pending_captures(self) -> None:
         # Scope end: an escaped closure may run at ANY time with any cell

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections import defaultdict, deque
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, NamedTuple
 
 from tree_sitter import Node
@@ -522,6 +523,20 @@ class _JsCtx(NamedTuple):
     type_ctors: dict[str, ResourceKind]
 
 
+@dataclass
+class _PendingCapture:
+    """A nested def whose captured-cell composition is deferred until the walk
+    learns HOW the closure is used (issue #1211)."""
+
+    nested_qn: str
+    def_node: Node
+    caller_qn: str
+    free_vars: tuple[str, ...]
+    snapshot: dict[str, Taint]
+    called: bool = False
+    escaped: bool = False
+
+
 class FlowProcessor:
     """Detects intra-procedural value flow in a function body and emits FLOWS_TO
     edges: resource->resource (a read source reaches a write sink), caller->callee
@@ -604,6 +619,7 @@ class FlowProcessor:
         # element is the per-call-site pass-through token (issue #1168). Composed
         # against the parameter-sink closure in finalize to emit origin -> sink.
         self._param_call_sites: list[tuple[Taint, str, str, str]] = []
+        self._pending_captures: dict[str, _PendingCapture] = {}
         # Per-function positional parameter slots so a call site's arg:<index>
         # resolves to the right callee parameter. The Python path truncates at
         # the first variadic/keyword-only boundary (self/cls dropped) and has no
@@ -702,8 +718,10 @@ class FlowProcessor:
         for fv in python_free_variable_names(caller_node):
             if fv not in tainted:
                 tainted[fv] = Taint(frozenset(), frozenset(), frozenset({fv}))
+        self._pending_captures.clear()
         for node in scope_seed_nodes(caller_node):
             tainted = self._walk_stmt(node, tainted, ctx)
+        self._flush_pending_captures()
 
         if self._acc_returns_taint:
             self._summaries[caller_qn] = self._acc_return_taint
@@ -3027,7 +3045,12 @@ class FlowProcessor:
         # return, and value-selection forms (`a if c else b`, `a or b`,
         # `a and b`) union their operands (the result MAY be either).
         if node.type == cs.TS_PY_IDENTIFIER and node.text is not None:
-            return tainted.get(node.text.decode(cs.ENCODING_UTF8))
+            text = node.text.decode(cs.ENCODING_UTF8)
+            # A VALUE use of a locally-defined closure name escapes it: it may
+            # be stored/passed/returned and run later with any cell value, so
+            # its capture falls back to the def-site MAY snapshot (#1211).
+            self._note_capture_escape(text)
+            return tainted.get(text)
         if node.type == cs.TS_PY_PARENTHESIZED_EXPRESSION:
             inner = next(iter(node.named_children), None)
             return self._py_value_taint(inner, tainted, ctx) if inner else None
@@ -3084,6 +3107,9 @@ class FlowProcessor:
         raw = call_name(node)
         if raw is None:
             return
+        # BEFORE the no-args early return: a zero-arg `send()` is exactly the
+        # direct closure invocation whose cell state matters (issue #1211).
+        self._note_capture_call(raw, tainted)
         # Evaluate every argument through the value-taint evaluator, so a source
         # or tainted callee written inline -- log_it(os.getenv("K")) -- is seen,
         # not only a bare tainted identifier (CodeRabbit review on PR #1167).
@@ -3509,13 +3535,13 @@ class FlowProcessor:
 
     def _record_captures(self, def_node: Node, state: _TaintMap, ctx: _FlowCtx) -> None:
         # A nested function may capture tainted enclosing-scope variables through
-        # its environment. For each free variable tainted at the definition site,
-        # record a capture keyed by the nested function's qn and via kw:<name>, so
-        # the existing parameter-summary finalize composes it exactly as a keyword
-        # argument would (issue #1197). A capture carrying concrete origins/pending
-        # is a resolvable call site; one carrying only the enclosing function's own
-        # parameters records a transitive flow edge, so a variable captured through
-        # two nested levels still composes.
+        # its environment. A closure captures a CELL, not a value, so the state
+        # that matters is the cell's value when the closure RUNS (issue #1211):
+        # a direct same-scope call commits the capture from the state AT that
+        # call, while a closure that escapes (stored, passed, returned) or is
+        # never called locally keeps the def-site MAY snapshot of #1197 -- the
+        # walk cannot know when an escaped closure runs, so the safe
+        # over-approximation stands. Redefinition commits the old record first.
         resolved = self._nested_def_name(def_node)
         if resolved is None:
             return
@@ -3529,16 +3555,71 @@ class FlowProcessor:
             if loc is not None
             else f"{ctx.caller_qn}{cs.SEPARATOR_DOT}{name}"
         )
-        for fv in python_free_variable_names(inner):
-            taint = state.get(fv)
+        free_vars = tuple(python_free_variable_names(inner))
+        if not free_vars:
+            return
+        if (previous := self._pending_captures.pop(name, None)) is not None:
+            self._commit_pending_capture(previous)
+        self._pending_captures[name] = _PendingCapture(
+            nested_qn=nested_qn,
+            def_node=def_node,
+            caller_qn=ctx.caller_qn,
+            free_vars=free_vars,
+            snapshot={fv: t for fv in free_vars if (t := state.get(fv)) is not None},
+        )
+
+    def _commit_capture_state(
+        self, record: _PendingCapture, cell_state: dict[str, Taint]
+    ) -> None:
+        # Keyed by the nested function's qn and via kw:<name>, so the existing
+        # parameter-summary finalize composes it exactly as a keyword argument
+        # would (issue #1197). A capture carrying concrete origins/pending is a
+        # resolvable call site; one carrying only the enclosing function's own
+        # parameters records a transitive flow edge, so a variable captured
+        # through two nested levels still composes.
+        for fv in record.free_vars:
+            taint = cell_state.get(fv)
             if taint is None:
                 continue
             via = VIA_KW_FORMAT.format(name=fv)
             if taint.origins or taint.pending:
-                token = _passthrough_result_token(ctx.caller_qn, def_node)
-                self._param_call_sites.append((taint, nested_qn, via, token))
+                token = _passthrough_result_token(record.caller_qn, record.def_node)
+                self._param_call_sites.append((taint, record.nested_qn, via, token))
             for pname in taint.params:
-                self._param_flow_edges.append((ctx.caller_qn, pname, nested_qn, via))
+                self._param_flow_edges.append(
+                    (record.caller_qn, pname, record.nested_qn, via)
+                )
+
+    def _commit_pending_capture(self, record: _PendingCapture) -> None:
+        self._commit_capture_state(record, record.snapshot)
+
+    def _note_capture_call(self, raw: str, state: _TaintMap) -> None:
+        # A direct call of a locally-defined closure: the cell holds the
+        # CURRENT threaded state, so this invocation composes with it -- the
+        # path-sensitive branch copies make a partially-cleaned merge stay MAY.
+        record = self._pending_captures.get(raw)
+        if record is None:
+            return
+        record.called = True
+        self._commit_capture_state(
+            record,
+            {fv: t for fv in record.free_vars if (t := state.get(fv)) is not None},
+        )
+
+    def _note_capture_escape(self, name: str) -> None:
+        record = self._pending_captures.get(name)
+        if record is not None:
+            record.escaped = True
+
+    def _flush_pending_captures(self) -> None:
+        # Scope end: an escaped closure may run at ANY time with any cell
+        # value, and a never-called one may still be reached through its qn,
+        # so both keep the def-site MAY snapshot (#1197 semantics). A closure
+        # only ever called directly already committed per-invocation states.
+        for record in self._pending_captures.values():
+            if record.escaped or not record.called:
+                self._commit_pending_capture(record)
+        self._pending_captures.clear()
 
     def _param_name_for_via(self, callee_qn: str, via: str) -> str | None:
         # Map an argument's `via` tag to the callee's parameter name: `kw:<name>`

--- a/codebase_rag/tests/test_flow_edges.py
+++ b/codebase_rag/tests/test_flow_edges.py
@@ -1351,3 +1351,36 @@ def test_capture_composes_for_duplicate_named_nested_defs(tmp_path: Path) -> Non
         )
     }
     assert _has_env_k_to_stdout_flow(_run_flow(tmp_path, files))
+
+
+def test_attribute_assigned_closure_escapes(tmp_path: Path) -> None:
+    # `holder.callback = send` stores the closure on an object: it may run
+    # later with any cell value, so the def-site MAY snapshot stands even
+    # though the only direct call happens after the clean reassign.
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "class H:\n    pass\n\n"
+            "def handler(holder):\n"
+            "    token = os.getenv('K')\n"
+            "    def send():\n        print(token)\n"
+            "    token = 'clean'\n"
+            "    holder.callback = send\n"
+            "    send()\n"
+        )
+    }
+    assert _has_env_k_to_stdout_flow(_run_flow(tmp_path, files))
+
+
+def test_returned_closure_escapes(tmp_path: Path) -> None:
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "def handler():\n"
+            "    token = os.getenv('K')\n"
+            "    def send():\n        print(token)\n"
+            "    token = 'clean'\n"
+            "    return send\n"
+        )
+    }
+    assert _has_env_k_to_stdout_flow(_run_flow(tmp_path, files))

--- a/codebase_rag/tests/test_flow_edges.py
+++ b/codebase_rag/tests/test_flow_edges.py
@@ -1416,3 +1416,21 @@ def test_assigned_call_result_is_not_an_escape(tmp_path: Path) -> None:
         )
     }
     assert not _has_env_k_to_stdout_flow(_run_flow(tmp_path, files))
+
+
+def test_keyword_argument_label_is_not_an_escape(tmp_path: Path) -> None:
+    # `other(send=None)` names a PARAMETER of other; the closure never
+    # travels, so the call-relative silence after the clean reassign holds.
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "def other(send=None):\n    return send\n\n"
+            "def handler():\n"
+            "    token = os.getenv('K')\n"
+            "    def send():\n        print(token)\n"
+            "    token = 'clean'\n"
+            "    other(send=None)\n"
+            "    send()\n"
+        )
+    }
+    assert not _has_env_k_to_stdout_flow(_run_flow(tmp_path, files))

--- a/codebase_rag/tests/test_flow_edges.py
+++ b/codebase_rag/tests/test_flow_edges.py
@@ -1135,13 +1135,13 @@ def test_capture_taint_reaches_sink_in_nested_function(tmp_path: Path) -> None:
     assert _has_env_k_to_stdout_flow(_run_flow(tmp_path, files))
 
 
-def test_capture_taint_survives_reassignment_after_the_def(tmp_path: Path) -> None:
-    # MAY semantics (issue #1197): the capture is recorded from the def-site state,
-    # where `token` is tainted. A closure captures a cell, and the walk does not model
-    # call order, so the tool cannot assume the later reassignment precedes every
-    # invocation -- the closure may run with the tainted value. Reporting the flow is
-    # the safe over-approximation (no false negative); precise call-relative cell
-    # tracking is a separate follow-up.
+def test_direct_call_after_unconditional_clean_reassign_is_silent(
+    tmp_path: Path,
+) -> None:
+    # Call-relative cell semantics (issue #1211): the closure's only direct
+    # invocation runs after `token` was unconditionally reassigned clean, so
+    # the cell holds no taint at any call and no flow is reported. (The
+    # def-site MAY snapshot of #1197 still governs escaped closures below.)
     files = {
         "m.py": (
             "import os\n\n"
@@ -1150,6 +1150,70 @@ def test_capture_taint_survives_reassignment_after_the_def(tmp_path: Path) -> No
             "    def send():\n        print(token)\n"
             "    token = 'clean'\n"
             "    send()\n"
+        )
+    }
+    assert not _has_env_k_to_stdout_flow(_run_flow(tmp_path, files))
+
+
+def test_direct_call_before_clean_reassign_still_flows(tmp_path: Path) -> None:
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "def handler():\n"
+            "    token = os.getenv('K')\n"
+            "    def send():\n        print(token)\n"
+            "    send()\n"
+            "    token = 'clean'\n"
+        )
+    }
+    assert _has_env_k_to_stdout_flow(_run_flow(tmp_path, files))
+
+
+def test_escaped_closure_keeps_the_def_site_may_snapshot(tmp_path: Path) -> None:
+    # Stored closures may run at any time with any cell value: the walk cannot
+    # order their invocations, so the def-site MAY snapshot stands even though
+    # the reassignment precedes the store (issue #1211).
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "callbacks = []\n\n"
+            "def handler():\n"
+            "    token = os.getenv('K')\n"
+            "    def send():\n        print(token)\n"
+            "    token = 'clean'\n"
+            "    callbacks.append(send)\n"
+        )
+    }
+    assert _has_env_k_to_stdout_flow(_run_flow(tmp_path, files))
+
+
+def test_branch_local_clean_reassign_keeps_the_flow(tmp_path: Path) -> None:
+    # The reassignment cleans only one path; the merge unions the states, so a
+    # call after it still sees the MAY-tainted cell.
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "def handler(flag):\n"
+            "    token = os.getenv('K')\n"
+            "    def send():\n        print(token)\n"
+            "    if flag:\n"
+            "        token = 'clean'\n"
+            "    send()\n"
+        )
+    }
+    assert _has_env_k_to_stdout_flow(_run_flow(tmp_path, files))
+
+
+def test_never_called_closure_keeps_the_def_site_snapshot(tmp_path: Path) -> None:
+    # A closure with no local call is still reachable through its qn; the
+    # def-site MAY snapshot keeps its capture summary composable.
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "def handler():\n"
+            "    token = os.getenv('K')\n"
+            "    def send():\n        print(token)\n"
+            "    token = 'clean'\n"
         )
     }
     assert _has_env_k_to_stdout_flow(_run_flow(tmp_path, files))

--- a/codebase_rag/tests/test_flow_edges.py
+++ b/codebase_rag/tests/test_flow_edges.py
@@ -1384,3 +1384,35 @@ def test_returned_closure_escapes(tmp_path: Path) -> None:
         )
     }
     assert _has_env_k_to_stdout_flow(_run_flow(tmp_path, files))
+
+
+def test_conditionally_returned_closure_escapes(tmp_path: Path) -> None:
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "def handler(flag):\n"
+            "    token = os.getenv('K')\n"
+            "    def send():\n        print(token)\n"
+            "    token = 'clean'\n"
+            "    return send if flag else None\n"
+        )
+    }
+    assert _has_env_k_to_stdout_flow(_run_flow(tmp_path, files))
+
+
+def test_assigned_call_result_is_not_an_escape(tmp_path: Path) -> None:
+    # `x = send()` is a direct invocation whose RESULT is stored, not an
+    # escape of the closure itself: the call-relative path governs, so a
+    # call after the unconditional clean reassign stays silent.
+    files = {
+        "m.py": (
+            "import os\n\n"
+            "def handler():\n"
+            "    token = os.getenv('K')\n"
+            "    def send():\n        print(token)\n"
+            "    token = 'clean'\n"
+            "    x = send()\n"
+            "    return x\n"
+        )
+    }
+    assert not _has_env_k_to_stdout_flow(_run_flow(tmp_path, files))


### PR DESCRIPTION
Closes #1211, the flagged heavy lift from #1197's review: the captured CELL is now modeled at each invocation, not only at the definition site.

## Semantics

A nested def's capture composition is DEFERRED into a pending record (nested qn, free vars, def-site snapshot) instead of committing immediately. The walk then decides per use:

- **Direct same-scope call** (`send()`): commits the capture from the CURRENT threaded state at that call, once per invocation. Because the Python walk is path-sensitive (branch copies unioned at merges), branch-correct MAY semantics fall out for free: a reassignment-to-clean on ONE branch still reports at a post-merge call; an UNCONDITIONAL reassignment before the only call reports nothing.
- **Escape** (any VALUE use of the name — stored, passed, returned): the closure may run at any time with any cell value, so the def-site MAY snapshot of #1197 stands, detected in the identifier value-taint path (the direct-call callee never routes through it).
- **Never called locally**: still reachable through its qn, so the def-site snapshot also stands.
- **Redefinition** of the name commits the old record def-site-style first.

The hook sits BEFORE `_apply_call`'s no-args early return — a zero-arg `send()` is exactly the invocation whose cell state matters. Non-Python lean walks are untouched (#1197 captures are Python-only).

## Test changes

`test_capture_taint_survives_reassignment_after_the_def` pinned the interim conservative behavior for def -> unconditional clean reassign -> call, with a comment naming call-relative tracking as the follow-up; that exact case is what this PR refines, so it becomes `test_direct_call_after_unconditional_clean_reassign_is_silent` asserting NO flow. Four new tests pin the rest of the matrix: call-before-reassign flows; escaped closure keeps the MAY snapshot despite a prior clean reassign; branch-local reassign keeps the flow at a post-merge call; a never-called closure keeps the def-site snapshot. The two-level transitive composition test is unchanged and green.

Flow battery (flow edges, verdicts, corpus, Dart/PHP/Scala): 120 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data-flow tracking through nested Python closures.
  * Direct calls now reflect the closure’s current captured state.
  * Escaped or unused closures retain their definition-time state.
  * Improved accuracy for closures that are reassigned, branched, returned, conditionally returned, or stored in properties and containers.
  * Closure calls without arguments are handled correctly.
  * Storing a direct call’s result or passing keyword arguments no longer incorrectly marks a closure as escaped.

* **Tests**
  * Added coverage for reassignment, escaping, branching, returning, and nested closure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->