### PR TITLE
feat: delombok overlay parses Lombok-expanded sources keyed by the original path

### DIFF
--- a/codebase_rag/config.py
+++ b/codebase_rag/config.py
@@ -213,6 +213,7 @@ class AppConfig(BaseSettings):
     # tree-sitter stays the standalone-correct backbone.
     GO_FRONTEND: cs.GoFrontend = cs.GoFrontend.AUTO
     PYTHON_FRONTEND: cs.PythonFrontend = cs.PythonFrontend.HEURISTIC
+    LOMBOK_JAR: str | None = None
     CAPTURE_FUNCTION_LOCAL_DEFINITIONS: bool = Field(
         True, validation_alias="CGR_CAPTURE_LOCAL_DEFINITIONS"
     )

--- a/codebase_rag/constants/core.py
+++ b/codebase_rag/constants/core.py
@@ -118,8 +118,14 @@ KEYWORD_CONSTRUCTOR = "constructor"
 HASH_CACHE_FILENAME = ".cgr-hash-cache.json"
 DIR_MTIMES_FILENAME = ".cgr-dir-mtimes.json"
 PARSER_FINGERPRINT_FILENAME = ".cgr-parser-fingerprint"
+DELOMBOK_STATE_FILENAME = ".cgr-delombok-state.json"
 CGR_STATE_FILENAMES: frozenset[str] = frozenset(
-    {HASH_CACHE_FILENAME, DIR_MTIMES_FILENAME, PARSER_FINGERPRINT_FILENAME}
+    {
+        HASH_CACHE_FILENAME,
+        DIR_MTIMES_FILENAME,
+        PARSER_FINGERPRINT_FILENAME,
+        DELOMBOK_STATE_FILENAME,
+    }
 )
 
 # Inputs to the parser fingerprint: everything that changes how source files

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -67,7 +67,7 @@ from .parsers.java_generated import (
 )
 from .parsers.java_lombok import (
     build_delombok_overlay,
-    current_lombok_version,
+    current_lombok_identity,
     overlay_identity,
 )
 from .parsers.utils import sorted_captures
@@ -1023,6 +1023,16 @@ class GraphUpdater:
         self._prune_orphan_nodes()
 
         self._generate_semantic_embeddings()
+
+        # The delombok state commits ONLY here, after every pass and the
+        # graph flush succeeded: a run that dies mid-way must not convince
+        # its successor that the overlay-affected files were reprocessed.
+        # Single-file runs never commit it.
+        if self._delombok_state_changed and self._single_file is None:
+            _save_delombok_state(
+                self.repo_path / cs.DELOMBOK_STATE_FILENAME,
+                self._delombok_state_candidate,
+            )
 
     def _emit_pending_endpoints(self) -> None:
         if not self.capture.rel_enabled(cs.RelationshipType.EXPOSES):
@@ -2082,7 +2092,7 @@ class GraphUpdater:
             "keys": sorted(self._delombok_overlay),
             # Two Lombok versions can expand identically today and diverge on
             # the next annotation edit; the version keeps the state honest.
-            "lombok": current_lombok_version(),
+            "lombok": current_lombok_identity(),
         }
         self._delombok_state_changed = previous != current
         self._delombok_stale_keys = (
@@ -2361,11 +2371,6 @@ class GraphUpdater:
             logger.info(ls.INCREMENTAL_UNREADABLE, count=unreadable_count)
 
         _save_hash_cache(cache_path, new_hashes)
-        if self._delombok_state_changed and self._single_file is None:
-            _save_delombok_state(
-                self.repo_path / cs.DELOMBOK_STATE_FILENAME,
-                self._delombok_state_candidate,
-            )
         _save_dir_mtimes(dir_mtimes_path, self._collected_dir_mtimes)
         # Stamp only full builds: re-stamping an incremental run would
         # silence the staleness warning while unchanged files still carry

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -65,7 +65,11 @@ from .parsers.java_generated import (
     generated_prefixes_for,
     unignore_patterns_for,
 )
-from .parsers.java_lombok import build_delombok_overlay, overlay_identity
+from .parsers.java_lombok import (
+    build_delombok_overlay,
+    current_lombok_version,
+    overlay_identity,
+)
 from .parsers.utils import sorted_captures
 from .path_filters import matches_test_path
 from .services import FilteringIngestor, IngestorProtocol, QueryProtocol
@@ -169,16 +173,27 @@ def _load_hash_cache(cache_path: Path) -> FileHashCache:
     return {}
 
 
+_EMPTY_DELOMBOK_STATE: dict = {"identity": "", "keys": [], "lombok": ""}
+
+
 def _load_delombok_state(state_path: Path) -> dict:
     try:
         loaded = json.loads(state_path.read_text(encoding=cs.ENCODING_UTF8))
     except (OSError, json.JSONDecodeError):
-        return {"identity": "", "keys": []}
+        return _EMPTY_DELOMBOK_STATE.copy()
     if not isinstance(loaded, dict):
-        return {"identity": "", "keys": []}
+        return _EMPTY_DELOMBOK_STATE.copy()
+    identity = loaded.get("identity")
+    keys = loaded.get("keys")
+    lombok = loaded.get("lombok")
     return {
-        "identity": loaded.get("identity", ""),
-        "keys": sorted(loaded.get("keys", [])),
+        "identity": identity if isinstance(identity, str) else "",
+        "keys": (
+            sorted(key for key in keys if isinstance(key, str))
+            if isinstance(keys, list)
+            else []
+        ),
+        "lombok": lombok if isinstance(lombok, str) else "",
     }
 
 
@@ -309,6 +324,7 @@ class GraphUpdater:
         self._delombok_overlay: dict[str, bytes] = {}
         self._delombok_state_changed = False
         self._delombok_stale_keys: set[str] = set()
+        self._delombok_state_candidate: dict = _EMPTY_DELOMBOK_STATE.copy()
         self.exclude_paths = exclude_paths
         # None defers to the CGR_SKIP_EMBEDDINGS setting so env-configured
         # callers (MCP, workspace sync) opt out without a CLI flag.
@@ -2060,11 +2076,13 @@ class GraphUpdater:
         # so without forcing them through a reparse the graph would keep
         # stale (or never gain) generated members.
         self._delombok_overlay = build_delombok_overlay(self.repo_path)
-        state_path = self.repo_path / cs.DELOMBOK_STATE_FILENAME
-        previous = _load_delombok_state(state_path)
+        previous = _load_delombok_state(self.repo_path / cs.DELOMBOK_STATE_FILENAME)
         current = {
             "identity": overlay_identity(self._delombok_overlay),
             "keys": sorted(self._delombok_overlay),
+            # Two Lombok versions can expand identically today and diverge on
+            # the next annotation edit; the version keeps the state honest.
+            "lombok": current_lombok_version(),
         }
         self._delombok_state_changed = previous != current
         self._delombok_stale_keys = (
@@ -2072,8 +2090,10 @@ class GraphUpdater:
             if self._delombok_state_changed
             else set()
         )
-        if self._delombok_state_changed:
-            _save_delombok_state(state_path, current)
+        # Held in memory until the run SUCCEEDS: persisting now would let a
+        # crashed run convince its successor that the stale files were
+        # already reprocessed. Single-file runs never commit it either.
+        self._delombok_state_candidate = current
 
     def _collect_eligible_files(self) -> list[tuple[Path, str]]:
         if self._single_file is not None:
@@ -2341,6 +2361,11 @@ class GraphUpdater:
             logger.info(ls.INCREMENTAL_UNREADABLE, count=unreadable_count)
 
         _save_hash_cache(cache_path, new_hashes)
+        if self._delombok_state_changed and self._single_file is None:
+            _save_delombok_state(
+                self.repo_path / cs.DELOMBOK_STATE_FILENAME,
+                self._delombok_state_candidate,
+            )
         _save_dir_mtimes(dir_mtimes_path, self._collected_dir_mtimes)
         # Stamp only full builds: re-stamping an incremental run would
         # silence the staleness warning while unchanged files still carry

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -65,7 +65,7 @@ from .parsers.java_generated import (
     generated_prefixes_for,
     unignore_patterns_for,
 )
-from .parsers.java_lombok import build_delombok_overlay
+from .parsers.java_lombok import build_delombok_overlay, overlay_identity
 from .parsers.utils import sorted_captures
 from .path_filters import matches_test_path
 from .services import FilteringIngestor, IngestorProtocol, QueryProtocol
@@ -167,6 +167,28 @@ def _load_hash_cache(cache_path: Path) -> FileHashCache:
     except (json.JSONDecodeError, OSError) as e:
         logger.warning(ls.HASH_CACHE_LOAD_FAILED, path=cache_path, error=e)
     return {}
+
+
+def _load_delombok_state(state_path: Path) -> dict:
+    try:
+        loaded = json.loads(state_path.read_text(encoding=cs.ENCODING_UTF8))
+    except (OSError, json.JSONDecodeError):
+        return {"identity": "", "keys": []}
+    if not isinstance(loaded, dict):
+        return {"identity": "", "keys": []}
+    return {
+        "identity": loaded.get("identity", ""),
+        "keys": sorted(loaded.get("keys", [])),
+    }
+
+
+def _save_delombok_state(state_path: Path, state: dict) -> None:
+    try:
+        state_path.write_text(
+            json.dumps(state, sort_keys=True), encoding=cs.ENCODING_UTF8
+        )
+    except OSError:
+        return None
 
 
 def _save_hash_cache(cache_path: Path, hashes: FileHashCache) -> None:
@@ -285,6 +307,8 @@ class GraphUpdater:
         self.unignore_paths = unignore_paths
         self._configured_unignore_paths = unignore_paths
         self._delombok_overlay: dict[str, bytes] = {}
+        self._delombok_state_changed = False
+        self._delombok_stale_keys: set[str] = set()
         self.exclude_paths = exclude_paths
         # None defers to the CGR_SKIP_EMBEDDINGS setting so env-configured
         # callers (MCP, workspace sync) opt out without a CLI flag.
@@ -1956,6 +1980,10 @@ class GraphUpdater:
             logger.warning(ls.PARSER_FINGERPRINT_MISMATCH)
 
     def _is_already_in_sync(self) -> bool:
+        if self._delombok_state_changed:
+            # The overlay's effect changed while the checked-in bytes did
+            # not; the affected files must reparse.
+            return False
         if self._single_file is not None:
             return False
         cache_path = self.repo_path / cs.HASH_CACHE_FILENAME
@@ -2026,8 +2054,26 @@ class GraphUpdater:
             logger.info(ls.GENERATED_SOURCES_REGISTERED, count=len(roots))
         # Delombok overlay (issue #1140 tier 1): rebuilt per run so a jar or
         # annotation appearing between watch runs is picked up; empty means
-        # raw parsing everywhere, exactly as before.
+        # raw parsing everywhere, exactly as before. The persisted identity
+        # detects overlay CHANGES (jar appears/vanishes, version bump): the
+        # affected files' cached hashes still match the checked-in source,
+        # so without forcing them through a reparse the graph would keep
+        # stale (or never gain) generated members.
         self._delombok_overlay = build_delombok_overlay(self.repo_path)
+        state_path = self.repo_path / cs.DELOMBOK_STATE_FILENAME
+        previous = _load_delombok_state(state_path)
+        current = {
+            "identity": overlay_identity(self._delombok_overlay),
+            "keys": sorted(self._delombok_overlay),
+        }
+        self._delombok_state_changed = previous != current
+        self._delombok_stale_keys = (
+            set(previous.get("keys", ())) | set(current["keys"])
+            if self._delombok_state_changed
+            else set()
+        )
+        if self._delombok_state_changed:
+            _save_delombok_state(state_path, current)
 
     def _collect_eligible_files(self) -> list[tuple[Path, str]]:
         if self._single_file is not None:
@@ -2089,6 +2135,8 @@ class GraphUpdater:
         cache_path = self.repo_path / cs.HASH_CACHE_FILENAME
         dir_mtimes_path = self.repo_path / cs.DIR_MTIMES_FILENAME
         old_hashes = _load_hash_cache(cache_path) if not force else {}
+        for stale_key in self._delombok_stale_keys:
+            old_hashes.pop(stale_key, None)
         is_full_build = (force or not old_hashes) and self._single_file is None
         self._is_full_build = is_full_build
         cache_mtime = cache_path.stat().st_mtime if cache_path.is_file() else 0.0
@@ -2199,6 +2247,7 @@ class GraphUpdater:
                 caller_bytes = caller_path.read_bytes()
             except OSError:
                 continue
+            caller_bytes = self._delombok_overlay.get(caller_key, caller_bytes)
             changed_entries.append((caller_path, caller_key, False, caller_bytes))
             present.add(caller_key)
             affected += 1

--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -65,6 +65,7 @@ from .parsers.java_generated import (
     generated_prefixes_for,
     unignore_patterns_for,
 )
+from .parsers.java_lombok import build_delombok_overlay
 from .parsers.utils import sorted_captures
 from .path_filters import matches_test_path
 from .services import FilteringIngestor, IngestorProtocol, QueryProtocol
@@ -283,6 +284,7 @@ class GraphUpdater:
         self._frontend_owned_qns: dict[str, set[str]] = {}
         self.unignore_paths = unignore_paths
         self._configured_unignore_paths = unignore_paths
+        self._delombok_overlay: dict[str, bytes] = {}
         self.exclude_paths = exclude_paths
         # None defers to the CGR_SKIP_EMBEDDINGS setting so env-configured
         # callers (MCP, workspace sync) opt out without a CLI flag.
@@ -2022,6 +2024,10 @@ class GraphUpdater:
         self.factory.structure_processor.unignore_paths = resolved
         if roots:
             logger.info(ls.GENERATED_SOURCES_REGISTERED, count=len(roots))
+        # Delombok overlay (issue #1140 tier 1): rebuilt per run so a jar or
+        # annotation appearing between watch runs is picked up; empty means
+        # raw parsing everywhere, exactly as before.
+        self._delombok_overlay = build_delombok_overlay(self.repo_path)
 
     def _collect_eligible_files(self) -> list[tuple[Path, str]]:
         if self._single_file is not None:
@@ -2137,6 +2143,10 @@ class GraphUpdater:
                 unreadable_keys.add(file_key)
                 continue
             current_hash, file_bytes = hashed
+            # The hash keys the CHECKED-IN source (cache invalidation follows
+            # edits); the PARSE may consume the delomboked expansion instead,
+            # so Lombok-generated members become real graph nodes (#1140).
+            file_bytes = self._delombok_overlay.get(file_key, file_bytes)
 
             current_file_keys.add(file_key)
             new_hashes[file_key] = current_hash
@@ -2380,6 +2390,8 @@ class GraphUpdater:
             return None
         try:
             file_bytes = file_path.read_bytes()
+            overlay_key = cached_relative_path(file_path, self.repo_path).as_posix()
+            file_bytes = self._delombok_overlay.get(overlay_key, file_bytes)
         except OSError as e:
             logger.error(ls.AST_RELOAD_FAILED, path=file_path, error=e)
             return None

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -920,3 +920,5 @@ PY_FRONTEND_BUDGET_DEGRADED = (
 GENERATED_SOURCES_REGISTERED = (
     "Indexing {count} annotation-processor generated source root(s)"
 )
+DELOMBOK_RUN_FAILED = "delombok run failed ({error}); parsing raw source"
+DELOMBOK_OVERLAY_BUILT = "Delombok overlay covers {count} Lombok-affected file(s)"

--- a/codebase_rag/parser_fingerprint.py
+++ b/codebase_rag/parser_fingerprint.py
@@ -66,6 +66,7 @@ def _frontend_settings() -> list[str]:
     from .parsers.cpp_frontend import resolve_cpp_frontend
     from .parsers.csharp_frontend import resolve_csharp_frontend
     from .parsers.go_frontend import resolve_go_frontend
+    from .parsers.java_lombok import find_lombok_jar, lombok_jar_version
     from .parsers.py_frontend import resolve_python_frontend
 
     return [
@@ -73,6 +74,7 @@ def _frontend_settings() -> list[str]:
         f"CSHARP_FRONTEND={resolve_csharp_frontend().value}",
         f"GO_FRONTEND={resolve_go_frontend().value}",
         f"PYTHON_FRONTEND={resolve_python_frontend().value}",
+        f"LOMBOK={lombok_jar_version(jar) if (jar := find_lombok_jar()) else 'absent'}",
     ]
 
 

--- a/codebase_rag/parser_fingerprint.py
+++ b/codebase_rag/parser_fingerprint.py
@@ -66,7 +66,7 @@ def _frontend_settings() -> list[str]:
     from .parsers.cpp_frontend import resolve_cpp_frontend
     from .parsers.csharp_frontend import resolve_csharp_frontend
     from .parsers.go_frontend import resolve_go_frontend
-    from .parsers.java_lombok import find_lombok_jar, lombok_jar_version
+    from .parsers.java_lombok import current_lombok_version
     from .parsers.py_frontend import resolve_python_frontend
 
     return [
@@ -74,7 +74,7 @@ def _frontend_settings() -> list[str]:
         f"CSHARP_FRONTEND={resolve_csharp_frontend().value}",
         f"GO_FRONTEND={resolve_go_frontend().value}",
         f"PYTHON_FRONTEND={resolve_python_frontend().value}",
-        f"LOMBOK={lombok_jar_version(jar) if (jar := find_lombok_jar()) else 'absent'}",
+        f"LOMBOK={current_lombok_version() or 'absent'}",
     ]
 
 

--- a/codebase_rag/parsers/java_lombok.py
+++ b/codebase_rag/parsers/java_lombok.py
@@ -13,6 +13,7 @@ source exactly as before.
 
 from __future__ import annotations
 
+import hashlib
 import re
 import shutil
 import subprocess
@@ -32,13 +33,23 @@ _M2_LOMBOK_GLOB = "repository/org/projectlombok/lombok/*/lombok-*.jar"
 _JAR_VERSION_RE = re.compile(r"lombok-(.+)\.jar$")
 
 
+def _version_sort_key(jar: Path) -> tuple:
+    # Numeric-aware: lombok-1.18.30 outranks lombok-1.18.9, which plain
+    # lexicographic path sorting gets backwards.
+    version = lombok_jar_version(jar)
+    parts = []
+    for piece in version.split("."):
+        parts.append((0, int(piece)) if piece.isdigit() else (1, piece))
+    return tuple(parts)
+
+
 def find_lombok_jar() -> Path | None:
     configured = settings.LOMBOK_JAR
     if configured:
         path = Path(configured)
         return path if path.is_file() else None
     m2 = Path.home() / ".m2"
-    candidates = sorted(m2.glob(_M2_LOMBOK_GLOB))
+    candidates = sorted(m2.glob(_M2_LOMBOK_GLOB), key=_version_sort_key)
     return candidates[-1] if candidates else None
 
 
@@ -134,3 +145,17 @@ def build_delombok_overlay(repo_path: Path) -> dict[str, bytes]:
     if overlay:
         logger.info(ls.DELOMBOK_OVERLAY_BUILT, count=len(overlay))
     return overlay
+
+
+def overlay_identity(overlay: dict[str, bytes]) -> str:
+    """A stable digest of the overlay's effect: which files it covers and what
+    it expands them to. Any change (jar appearing/vanishing, version bump,
+    annotation edits changing the expansion) must force those files through a
+    reparse, or the graph keeps stale generated members."""
+    if not overlay:
+        return ""
+    digest = hashlib.sha256()
+    for key in sorted(overlay):
+        digest.update(key.encode(cs.ENCODING_UTF8))
+        digest.update(hashlib.sha256(overlay[key]).digest())
+    return digest.hexdigest()

--- a/codebase_rag/parsers/java_lombok.py
+++ b/codebase_rag/parsers/java_lombok.py
@@ -147,6 +147,14 @@ def build_delombok_overlay(repo_path: Path) -> dict[str, bytes]:
     return overlay
 
 
+def current_lombok_version() -> str:
+    # Module-global lookup on purpose: tests and callers patch
+    # find_lombok_jar on THIS module, and an import-by-value caller would
+    # bypass the patch (and the configured jar) silently.
+    jar = find_lombok_jar()
+    return lombok_jar_version(jar) if jar is not None else ""
+
+
 def overlay_identity(overlay: dict[str, bytes]) -> str:
     """A stable digest of the overlay's effect: which files it covers and what
     it expands them to. Any change (jar appearing/vanishing, version bump,

--- a/codebase_rag/parsers/java_lombok.py
+++ b/codebase_rag/parsers/java_lombok.py
@@ -155,6 +155,20 @@ def current_lombok_version() -> str:
     return lombok_jar_version(jar) if jar is not None else ""
 
 
+def current_lombok_identity() -> str:
+    """Version plus a content digest: a same-named configured jar
+    (/tools/lombok.jar) replaced in place must still flip the persisted
+    state, or its unchanged expansions would never reparse."""
+    jar = find_lombok_jar()
+    if jar is None:
+        return ""
+    try:
+        digest = hashlib.sha256(jar.read_bytes()).hexdigest()[:16]
+    except OSError:
+        digest = "unreadable"
+    return f"{lombok_jar_version(jar)}:{digest}"
+
+
 def overlay_identity(overlay: dict[str, bytes]) -> str:
     """A stable digest of the overlay's effect: which files it covers and what
     it expands them to. Any change (jar appearing/vanishing, version bump,

--- a/codebase_rag/parsers/java_lombok.py
+++ b/codebase_rag/parsers/java_lombok.py
@@ -1,0 +1,136 @@
+"""Delombok overlay (issue #1140, tier 1).
+
+Lombok annotations (@Getter, @Builder, @Data) expand to real API surface only
+inside the compiler; the checked-in source never contains the generated
+members, so calls into them dangle. When Lombok is in play and its jar is
+locatable, `delombok` (Lombok's official source-to-source expander) runs into
+a per-run scratch directory and the expanded BYTES are parsed in place of the
+raw file -- keyed by the ORIGINAL path, so qualified names, containment, and
+the hash cache (which must track the checked-in source) are untouched. Any
+missing piece (no jar, no java, a failed run) degrades to parsing the raw
+source exactly as before.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from loguru import logger
+
+from .. import constants as cs
+from .. import logs as ls
+from ..config import settings
+from .java_generated import _build_dirs
+
+_LOMBOK_MARKER = "lombok"
+_DELOMBOK_TIMEOUT = 300
+_M2_LOMBOK_GLOB = "repository/org/projectlombok/lombok/*/lombok-*.jar"
+_JAR_VERSION_RE = re.compile(r"lombok-(.+)\.jar$")
+
+
+def find_lombok_jar() -> Path | None:
+    configured = settings.LOMBOK_JAR
+    if configured:
+        path = Path(configured)
+        return path if path.is_file() else None
+    m2 = Path.home() / ".m2"
+    candidates = sorted(m2.glob(_M2_LOMBOK_GLOB))
+    return candidates[-1] if candidates else None
+
+
+def lombok_jar_version(jar: Path) -> str:
+    match = _JAR_VERSION_RE.search(jar.name)
+    return match.group(1) if match else jar.name
+
+
+def _lombok_used(build_dir: Path) -> bool:
+    for name in ("pom.xml", "build.gradle", "build.gradle.kts"):
+        build_file = build_dir / name
+        try:
+            if build_file.is_file() and _LOMBOK_MARKER in build_file.read_text(
+                encoding=cs.ENCODING_UTF8, errors="replace"
+            ):
+                return True
+        except OSError:
+            continue
+    return False
+
+
+def _run_delombok(java: str, jar: Path, source_root: Path, out_dir: Path) -> bool:
+    try:
+        proc = subprocess.run(
+            [
+                java,
+                "-jar",
+                str(jar),
+                "delombok",
+                str(source_root),
+                "-d",
+                str(out_dir),
+                "--onlyChanged",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_DELOMBOK_TIMEOUT,
+        )
+    except (subprocess.SubprocessError, OSError) as error:
+        logger.warning(ls.DELOMBOK_RUN_FAILED.format(error=error))
+        return False
+    if proc.returncode != 0:
+        logger.warning(ls.DELOMBOK_RUN_FAILED.format(error=proc.stderr.strip()[:300]))
+        return False
+    return True
+
+
+def _overlay_from_root(
+    repo_path: Path, source_root: Path, out_dir: Path
+) -> dict[str, bytes]:
+    overlay: dict[str, bytes] = {}
+    for expanded in out_dir.rglob(f"*{cs.EXT_JAVA}"):
+        rel_in_root = expanded.relative_to(out_dir)
+        original = source_root / rel_in_root
+        if not original.is_file():
+            continue
+        try:
+            expanded_bytes = expanded.read_bytes()
+            if expanded_bytes == original.read_bytes():
+                # --onlyChanged should skip these, but an identical copy
+                # would only waste overlay memory.
+                continue
+        except OSError:
+            continue
+        overlay[original.relative_to(repo_path).as_posix()] = expanded_bytes
+    return overlay
+
+
+def build_delombok_overlay(repo_path: Path) -> dict[str, bytes]:
+    """Repo-relative path -> delomboked bytes for every Lombok-affected file;
+    empty (raw parsing everywhere) unless Lombok, its jar, and java all line up."""
+    repo_path = repo_path.resolve()
+    java = shutil.which("java")
+    if java is None:
+        return {}
+    jar = find_lombok_jar()
+    if jar is None:
+        return {}
+    overlay: dict[str, bytes] = {}
+    for build_dir in _build_dirs(repo_path):
+        if not _lombok_used(build_dir):
+            continue
+        for root_parts in cs.JAVA_MAVEN_SOURCE_ROOTS:
+            source_root = build_dir.joinpath(*root_parts)
+            if not source_root.is_dir():
+                continue
+            with tempfile.TemporaryDirectory(prefix="cgr-delombok-") as scratch:
+                if _run_delombok(java, jar, source_root, Path(scratch)):
+                    overlay.update(
+                        _overlay_from_root(repo_path, source_root, Path(scratch))
+                    )
+    if overlay:
+        logger.info(ls.DELOMBOK_OVERLAY_BUILT, count=len(overlay))
+    return overlay

--- a/codebase_rag/tests/test_delombok_overlay.py
+++ b/codebase_rag/tests/test_delombok_overlay.py
@@ -234,3 +234,41 @@ def test_maven_cache_prefers_the_numerically_newest_jar(
     monkeypatch.setattr(java_lombok.settings, "LOMBOK_JAR", None)
     jar = java_lombok.find_lombok_jar()
     assert jar is not None and jar.name == "lombok-1.18.30.jar"
+
+
+def test_jar_version_change_alone_marks_the_state_changed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Identical expansion under a different Lombok version still flips the
+    # persisted state: versions that agree today can diverge on the next
+    # annotation edit, so the files go through one honest reparse.
+    repo = tmp_path / "proj"
+    _write_repo(repo)
+    _fake_delombok(monkeypatch)
+    monkeypatch.setattr(
+        java_lombok, "find_lombok_jar", lambda: Path("/fake/lombok-1.18.30.jar")
+    )
+    parsers, queries = load_parsers()
+    updater = GraphUpdater(
+        ingestor=MagicMock(),
+        repo_path=repo,
+        parsers=parsers,
+        queries=queries,
+        capture=ALL_ENABLED,
+    )
+    updater.run()
+    monkeypatch.setattr(
+        java_lombok, "find_lombok_jar", lambda: Path("/fake/lombok-1.18.42.jar")
+    )
+    updater.run()
+    assert updater._delombok_state_changed
+
+
+def test_corrupt_state_file_degrades_to_the_empty_state(tmp_path: Path) -> None:
+    from codebase_rag.graph_updater import _load_delombok_state
+
+    state = tmp_path / "state.json"
+    for payload in ('{"keys": null}', "[1, 2]", "not json", '{"identity": 5}'):
+        state.write_text(payload, encoding="utf-8")
+        loaded = _load_delombok_state(state)
+        assert loaded == {"identity": "", "keys": [], "lombok": ""}

--- a/codebase_rag/tests/test_delombok_overlay.py
+++ b/codebase_rag/tests/test_delombok_overlay.py
@@ -38,7 +38,17 @@ def _write_repo(repo: Path) -> None:
     (repo / "src/main/java/com/app/Widget.java").write_text(_RAW, encoding="utf-8")
 
 
+def _fake_java(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        java_lombok.shutil,
+        "which",
+        lambda command: "/fake/java" if command == "java" else None,
+    )
+
+
 def _fake_delombok(monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_java(monkeypatch)
+
     def fake_run(java, jar, source_root, out_dir):
         for original in Path(source_root).rglob("*.java"):
             target = Path(out_dir) / original.relative_to(source_root)
@@ -57,7 +67,7 @@ def _fake_delombok(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
-def _run(repo: Path) -> MagicMock:
+def _index_repo_with_mock_ingestor(repo: Path) -> MagicMock:
     parsers, queries = load_parsers()
     mock = MagicMock()
     GraphUpdater(
@@ -84,7 +94,7 @@ def test_expanded_member_lands_in_the_graph(
     repo = tmp_path / "proj"
     _write_repo(repo)
     _fake_delombok(monkeypatch)
-    mock = _run(repo)
+    mock = _index_repo_with_mock_ingestor(repo)
     assert any("Widget.getName" in qn for qn in _method_qns(mock))
     # The overlay never touches the checked-in source.
     assert "@Getter" in (repo / "src/main/java/com/app/Widget.java").read_text()
@@ -95,8 +105,9 @@ def test_without_a_jar_raw_source_parses_unchanged(
 ) -> None:
     repo = tmp_path / "proj"
     _write_repo(repo)
+    _fake_java(monkeypatch)
     monkeypatch.setattr(java_lombok, "find_lombok_jar", lambda: None)
-    mock = _run(repo)
+    mock = _index_repo_with_mock_ingestor(repo)
     assert not any("Widget.getName" in qn for qn in _method_qns(mock))
 
 
@@ -109,6 +120,7 @@ def test_lombok_free_build_never_invokes_delombok(
     (repo / "src/main/java/com/app/Plain.java").write_text(
         "package com.app;\npublic class Plain {}\n", encoding="utf-8"
     )
+    _fake_java(monkeypatch)
     monkeypatch.setattr(
         java_lombok, "find_lombok_jar", lambda: Path("/fake/lombok.jar")
     )
@@ -118,7 +130,7 @@ def test_lombok_free_build_never_invokes_delombok(
         "_run_delombok",
         lambda *a: calls.append("run") or True,
     )
-    _run(repo)
+    _index_repo_with_mock_ingestor(repo)
     assert calls == []
 
 
@@ -159,5 +171,66 @@ def test_hash_cache_keys_the_checked_in_source(
 def test_real_delombok_end_to_end(tmp_path: Path) -> None:
     repo = tmp_path / "proj"
     _write_repo(repo)
-    mock = _run(repo)
+    mock = _index_repo_with_mock_ingestor(repo)
     assert any("Widget.getName" in qn for qn in _method_qns(mock))
+
+
+def test_no_java_degrades_to_raw_parsing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "proj"
+    _write_repo(repo)
+    monkeypatch.setattr(java_lombok.shutil, "which", lambda _c: None)
+    monkeypatch.setattr(
+        java_lombok, "find_lombok_jar", lambda: Path("/fake/lombok.jar")
+    )
+    mock = _index_repo_with_mock_ingestor(repo)
+    assert not any("Widget.getName" in qn for qn in _method_qns(mock))
+
+
+def test_jar_appearing_after_a_raw_index_forces_the_reparse(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The checked-in bytes never changed, so the hash cache alone would skip
+    # every Java file; the persisted overlay identity forces the affected
+    # files through a reparse when the jar appears (and symmetrically when
+    # it vanishes).
+    repo = tmp_path / "proj"
+    _write_repo(repo)
+    _fake_java(monkeypatch)
+    monkeypatch.setattr(java_lombok, "find_lombok_jar", lambda: None)
+    parsers, queries = load_parsers()
+    mock = MagicMock()
+    updater = GraphUpdater(
+        ingestor=mock,
+        repo_path=repo,
+        parsers=parsers,
+        queries=queries,
+        capture=ALL_ENABLED,
+    )
+    updater.run()
+    assert not any(".getName(" in qn for qn in _method_qns(mock))
+    _fake_delombok(monkeypatch)
+    mock.reset_mock()
+    updater.run()
+    # The reused updater re-registers the class under a duplicate-name
+    # suffix (Widget@N), so the assertion matches the METHOD name only.
+    assert any(".getName(" in qn for qn in _method_qns(mock))
+    monkeypatch.setattr(java_lombok, "find_lombok_jar", lambda: None)
+    mock.reset_mock()
+    updater.run()
+    assert not any(".getName(" in qn for qn in _method_qns(mock))
+
+
+def test_maven_cache_prefers_the_numerically_newest_jar(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    m2 = tmp_path / ".m2"
+    for version in ("1.18.9", "1.18.30"):
+        jar_dir = m2 / "repository/org/projectlombok/lombok" / version
+        jar_dir.mkdir(parents=True)
+        (jar_dir / f"lombok-{version}.jar").write_bytes(b"jar")
+    monkeypatch.setattr(java_lombok.Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setattr(java_lombok.settings, "LOMBOK_JAR", None)
+    jar = java_lombok.find_lombok_jar()
+    assert jar is not None and jar.name == "lombok-1.18.30.jar"

--- a/codebase_rag/tests/test_delombok_overlay.py
+++ b/codebase_rag/tests/test_delombok_overlay.py
@@ -233,7 +233,8 @@ def test_maven_cache_prefers_the_numerically_newest_jar(
     monkeypatch.setattr(java_lombok.Path, "home", classmethod(lambda cls: tmp_path))
     monkeypatch.setattr(java_lombok.settings, "LOMBOK_JAR", None)
     jar = java_lombok.find_lombok_jar()
-    assert jar is not None and jar.name == "lombok-1.18.30.jar"
+    assert jar is not None
+    assert jar.name == "lombok-1.18.30.jar"
 
 
 def test_jar_version_change_alone_marks_the_state_changed(
@@ -272,3 +273,42 @@ def test_corrupt_state_file_degrades_to_the_empty_state(tmp_path: Path) -> None:
         state.write_text(payload, encoding="utf-8")
         loaded = _load_delombok_state(state)
         assert loaded == {"identity": "", "keys": [], "lombok": ""}
+
+
+def test_replaced_same_named_jar_flips_the_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A configured /tools/lombok.jar replaced in place keeps its name, so
+    # the identity must digest the CONTENT.
+    jar = tmp_path / "lombok.jar"
+    jar.write_bytes(b"first")
+    monkeypatch.setattr(java_lombok, "find_lombok_jar", lambda: jar)
+    first = java_lombok.current_lombok_identity()
+    jar.write_bytes(b"second")
+    assert java_lombok.current_lombok_identity() != first
+
+
+def test_failed_run_never_commits_the_overlay_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from codebase_rag import constants as cs
+
+    repo = tmp_path / "proj"
+    _write_repo(repo)
+    _fake_delombok(monkeypatch)
+    parsers, queries = load_parsers()
+    updater = GraphUpdater(
+        ingestor=MagicMock(),
+        repo_path=repo,
+        parsers=parsers,
+        queries=queries,
+        capture=ALL_ENABLED,
+    )
+    monkeypatch.setattr(
+        updater,
+        "_generate_semantic_embeddings",
+        lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    with pytest.raises(RuntimeError):
+        updater.run()
+    assert not (repo / cs.DELOMBOK_STATE_FILENAME).exists()

--- a/codebase_rag/tests/test_delombok_overlay.py
+++ b/codebase_rag/tests/test_delombok_overlay.py
@@ -1,0 +1,163 @@
+# Issue #1140 tier 1: Lombok-generated members exist only after expansion, so
+# the updater parses delomboked BYTES keyed by the ORIGINAL path. The seam is
+# subprocess-shaped: these tests fake the delombok run (no jar in CI) and
+# assert the graph gains the expanded member while the on-disk source lacks
+# it, the hash cache keys the checked-in bytes, and every missing piece
+# degrades to raw parsing.
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag.capture import ALL_ENABLED
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.parsers import java_lombok
+
+_RAW = (
+    "package com.app;\n\nimport lombok.Getter;\n\n@Getter\n"
+    "public class Widget {\n    private String name;\n}\n"
+)
+_EXPANDED = (
+    "package com.app;\n\npublic class Widget {\n    private String name;\n\n"
+    "    public String getName() {\n        return this.name;\n    }\n}\n"
+)
+
+
+def _write_repo(repo: Path) -> None:
+    (repo / "src/main/java/com/app").mkdir(parents=True)
+    (repo / "pom.xml").write_text(
+        "<project><dependencies><dependency>"
+        "<groupId>org.projectlombok</groupId><artifactId>lombok</artifactId>"
+        "</dependency></dependencies></project>",
+        encoding="utf-8",
+    )
+    (repo / "src/main/java/com/app/Widget.java").write_text(_RAW, encoding="utf-8")
+
+
+def _fake_delombok(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(java, jar, source_root, out_dir):
+        for original in Path(source_root).rglob("*.java"):
+            target = Path(out_dir) / original.relative_to(source_root)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(
+                _EXPANDED
+                if "@Getter" in original.read_text()
+                else original.read_text(),
+                encoding="utf-8",
+            )
+        return True
+
+    monkeypatch.setattr(java_lombok, "_run_delombok", fake_run)
+    monkeypatch.setattr(
+        java_lombok, "find_lombok_jar", lambda: Path("/fake/lombok.jar")
+    )
+
+
+def _run(repo: Path) -> MagicMock:
+    parsers, queries = load_parsers()
+    mock = MagicMock()
+    GraphUpdater(
+        ingestor=mock,
+        repo_path=repo,
+        parsers=parsers,
+        queries=queries,
+        capture=ALL_ENABLED,
+    ).run()
+    return mock
+
+
+def _method_qns(mock: MagicMock) -> set[str]:
+    return {
+        c.args[1]["qualified_name"]
+        for c in mock.ensure_node_batch.call_args_list
+        if str(c.args[0]) == "Method"
+    }
+
+
+def test_expanded_member_lands_in_the_graph(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "proj"
+    _write_repo(repo)
+    _fake_delombok(monkeypatch)
+    mock = _run(repo)
+    assert any("Widget.getName" in qn for qn in _method_qns(mock))
+    # The overlay never touches the checked-in source.
+    assert "@Getter" in (repo / "src/main/java/com/app/Widget.java").read_text()
+
+
+def test_without_a_jar_raw_source_parses_unchanged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "proj"
+    _write_repo(repo)
+    monkeypatch.setattr(java_lombok, "find_lombok_jar", lambda: None)
+    mock = _run(repo)
+    assert not any("Widget.getName" in qn for qn in _method_qns(mock))
+
+
+def test_lombok_free_build_never_invokes_delombok(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "proj"
+    (repo / "src/main/java/com/app").mkdir(parents=True)
+    (repo / "pom.xml").write_text("<project/>", encoding="utf-8")
+    (repo / "src/main/java/com/app/Plain.java").write_text(
+        "package com.app;\npublic class Plain {}\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        java_lombok, "find_lombok_jar", lambda: Path("/fake/lombok.jar")
+    )
+    calls: list[str] = []
+    monkeypatch.setattr(
+        java_lombok,
+        "_run_delombok",
+        lambda *a: calls.append("run") or True,
+    )
+    _run(repo)
+    assert calls == []
+
+
+def test_hash_cache_keys_the_checked_in_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Editing the ORIGINAL file must invalidate the cache even though the
+    # parse consumed overlay bytes; a reused updater re-parses it.
+    repo = tmp_path / "proj"
+    _write_repo(repo)
+    _fake_delombok(monkeypatch)
+    parsers, queries = load_parsers()
+    mock = MagicMock()
+    updater = GraphUpdater(
+        ingestor=mock,
+        repo_path=repo,
+        parsers=parsers,
+        queries=queries,
+        capture=ALL_ENABLED,
+    )
+    updater.run()
+    widget = repo / "src/main/java/com/app/Widget.java"
+    widget.write_text(_RAW.replace("name;", "name;\n    private int age;"), "utf-8")
+    mock.reset_mock()
+    updater.run()
+    reparsed = {
+        c.args[1].get("path")
+        for c in mock.ensure_node_batch.call_args_list
+        if str(c.args[0]) == "Module"
+    }
+    assert "src/main/java/com/app/Widget.java" in reparsed
+
+
+@pytest.mark.skipif(
+    shutil.which("java") is None or java_lombok.find_lombok_jar() is None,
+    reason="real delombok e2e needs java and a lombok jar",
+)
+def test_real_delombok_end_to_end(tmp_path: Path) -> None:
+    repo = tmp_path / "proj"
+    _write_repo(repo)
+    mock = _run(repo)
+    assert any("Widget.getName" in qn for qn in _method_qns(mock))


### PR DESCRIPTION
Closes #1140 (tier 1; tier 2 shipped in #1329). Lombok members (@Getter, @Builder, @Data) exist only after expansion, so calls into them dangled in the checked-in source.

## How it works

- **Detection**: a build file next to the source (pom.xml / build.gradle[.kts]) mentioning lombok, plus a locatable jar — the `LOMBOK_JAR` setting or the newest `~/.m2/repository/org/projectlombok/lombok/*/lombok-*.jar` — plus `java` on PATH. Any missing piece degrades to raw parsing exactly as before.
- **Expansion**: `java -jar lombok.jar delombok <source-root> -d <scratch> --onlyChanged` per maven source root, into a per-run temp directory. Expanded files identical to the original are dropped from the overlay.
- **The overlay seam**: the updater swaps the PARSE bytes (`changed_entries`, and the single-file path) for overlay entries keyed by the ORIGINAL repo-relative path — qualified names, containment, and paths are untouched, and the hash cache keys the CHECKED-IN bytes so editing the original invalidates as usual (test-pinned with a reused updater).
- **Graph identity**: the parser fingerprint records the lombok jar version (or `absent`), so an expanded graph and a raw graph never share an identity; a jar appearing between watch runs is picked up because the overlay is rebuilt per run.

## Tests

Seam tests run with a FAKE delombok (no jar needed in CI): the expanded `getName` lands in the graph while the on-disk file still carries `@Getter`; no jar → raw parse unchanged; a lombok-free build never invokes delombok; editing the original invalidates the cache despite the overlay. Plus a real end-to-end gated on java + a jar — verified locally against lombok 1.18.42, producing `Widget.getName` from actual delombok output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Lombok-enhanced Java projects, including generated fields, methods, and constructors in code search and graph results.
  - Automatically detects Lombok installations or uses a configured Lombok JAR.
  - Tracks Lombok versions and generated-source changes to keep analysis current.

- **Bug Fixes**
  - Preserves checked-in source files while using generated source only for analysis.
  - Gracefully falls back to standard parsing when Lombok tooling is unavailable.
  - Reprocesses affected files when Lombok configuration or generated output changes.
  - Prevents incomplete analysis state from being saved after failed processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->