### PR TITLE
feat(dead-code): report symbols in structural-tier languages as unanalyzed

### DIFF
--- a/codebase_rag/cli.py
+++ b/codebase_rag/cli.py
@@ -1256,6 +1256,7 @@ def _emit_dead_code(
     output_format: cs.DeadCodeFormat,
     output: Path | None,
     project_name: str,
+    structural_tier_symbols: int = 0,
 ) -> None:
     if output_format == cs.DeadCodeFormat.JSON:
         payload = json.dumps(candidates, indent=2)
@@ -1271,25 +1272,40 @@ def _emit_dead_code(
         typer.echo(payload)
         return
 
+    # The coverage notice follows the table into whichever sink it goes, so a
+    # saved report (CI artifact, shared review) never reads as "all clean"
+    # when whole languages went unanalyzed.
+    notice = (
+        cs.CLI_DEADCODE_STRUCTURAL_TIER_SKIPPED.format(count=structural_tier_symbols)
+        if structural_tier_symbols
+        else ""
+    )
     table = _build_dead_code_table(candidates, project_name)
     if output is not None:
         with output.open("w", encoding=cs.ENCODING_UTF8) as fh:
-            Console(file=fh).print(table)
+            file_console = Console(file=fh)
+            file_console.print(table)
+            if notice:
+                file_console.print(notice)
         app_context.console.print(
             style(
                 cs.CLI_DEADCODE_WRITTEN.format(count=len(candidates), path=output),
                 cs.Color.GREEN,
             )
         )
+        if notice:
+            app_context.console.print(style(notice, cs.Color.YELLOW))
         return
 
     if not candidates:
         app_context.console.print(style(cs.CLI_DEADCODE_NONE, cs.Color.GREEN))
-        return
-    app_context.console.print(table)
-    app_context.console.print(
-        style(cs.CLI_DEADCODE_SUMMARY.format(count=len(candidates)), cs.Color.GREEN)
-    )
+    else:
+        app_context.console.print(table)
+        app_context.console.print(
+            style(cs.CLI_DEADCODE_SUMMARY.format(count=len(candidates)), cs.Color.GREEN)
+        )
+    if notice:
+        app_context.console.print(style(notice, cs.Color.YELLOW))
 
 
 @app.command(
@@ -1372,18 +1388,9 @@ def dead_code(
     candidates = [
         _to_dead_code_row(row) for row in _filter_excluded_rows(rows, exclude)
     ]
-    _emit_dead_code(candidates, output_format, output, resolved)
-    # Printed after the result (including "none found") so the report never
-    # implies coverage of languages the structural tier cannot analyze.
-    if structural_tier_symbols and output_format == cs.DeadCodeFormat.TABLE:
-        app_context.console.print(
-            style(
-                cs.CLI_DEADCODE_STRUCTURAL_TIER_SKIPPED.format(
-                    count=structural_tier_symbols
-                ),
-                cs.Color.YELLOW,
-            )
-        )
+    _emit_dead_code(
+        candidates, output_format, output, resolved, structural_tier_symbols
+    )
 
     if fail_on_found and candidates:
         raise typer.Exit(1)

--- a/codebase_rag/cli.py
+++ b/codebase_rag/cli.py
@@ -1330,7 +1330,7 @@ def dead_code(
         False, "--fail-on-found", help=ch.HELP_DEADCODE_FAIL_ON_FOUND
     ),
 ) -> None:
-    from .dead_code import collect_dead_code
+    from .dead_code import collect_dead_code_with_coverage
 
     show_progress = output_format == cs.DeadCodeFormat.TABLE and output is None
     if show_progress:
@@ -1339,13 +1339,14 @@ def dead_code(
     projects: list[str] = []
     resolved: str | None = None
     rows: list[ResultRow] = []
+    structural_tier_symbols = 0
     try:
         with connect_memgraph(batch_size=1) as ingestor:
             projects = ingestor.list_projects()
             resolved = _resolve_dead_code_project(project_name, projects)
             if resolved is not None:
                 logger.info(ls.DEADCODE_SCANNING.format(project_name=resolved))
-                rows = collect_dead_code(
+                rows, structural_tier_symbols = collect_dead_code_with_coverage(
                     ingestor,
                     resolved,
                     _dead_code_config(
@@ -1372,6 +1373,17 @@ def dead_code(
         _to_dead_code_row(row) for row in _filter_excluded_rows(rows, exclude)
     ]
     _emit_dead_code(candidates, output_format, output, resolved)
+    # Printed after the result (including "none found") so the report never
+    # implies coverage of languages the structural tier cannot analyze.
+    if structural_tier_symbols and output_format == cs.DeadCodeFormat.TABLE:
+        app_context.console.print(
+            style(
+                cs.CLI_DEADCODE_STRUCTURAL_TIER_SKIPPED.format(
+                    count=structural_tier_symbols
+                ),
+                cs.Color.YELLOW,
+            )
+        )
 
     if fail_on_found and candidates:
         raise typer.Exit(1)

--- a/codebase_rag/constants/cli.py
+++ b/codebase_rag/constants/cli.py
@@ -137,6 +137,10 @@ CLI_DEADCODE_LINE_RANGE = "{start}-{end}"
 CLI_DEADCODE_SUMMARY = "{count} candidate(s) for review."
 CLI_DEADCODE_NONE = "No unreachable functions or methods found."
 CLI_DEADCODE_WRITTEN = "Wrote {count} candidate(s) to {path}"
+CLI_DEADCODE_STRUCTURAL_TIER_SKIPPED = (
+    "{count} symbol(s) in structural-tier languages were not analyzed "
+    "(no call graph for these languages)."
+)
 CLI_ERR_DEADCODE_FAILED = "Failed to scan for dead code: {error}"
 CLI_ERR_DEADCODE_NO_PROJECTS = (
     "No projects found in the graph. Index a repository first with 'cgr start'."

--- a/codebase_rag/dead_code.py
+++ b/codebase_rag/dead_code.py
@@ -837,9 +837,41 @@ def _row_qn(row: ResultRow) -> str:
     return str(row.get(cs.KEY_QUALIFIED_NAME) or "")
 
 
+def count_structural_tier_symbols(node_rows: list[ResultRow]) -> int:
+    """Count symbols the reachability walk could never have reported.
+
+    The ast-grep tier emits no CALLS edges and marks its symbols exported, so
+    they are unconditional roots. Reporting this count keeps a "no dead code"
+    result honest about the languages that were never analyzed.
+    """
+    from .parsers.ast_grep_tier import structural_tier_extensions
+
+    extensions = structural_tier_extensions()
+    if not extensions:
+        return 0
+    symbol_labels = {_FUNCTION, _METHOD, _CLASS}
+    return sum(
+        1
+        for row in node_rows
+        if str(row.get(cs.KEY_LABEL) or "") in symbol_labels
+        and str(row.get(cs.KEY_PATH) or "").endswith(tuple(extensions))
+    )
+
+
 def collect_dead_code(
     ingestor: GraphQueryClient, project_name: str, config: DeadCodeConfig
 ) -> list[ResultRow]:
+    return collect_dead_code_with_coverage(ingestor, project_name, config)[0]
+
+
+def collect_dead_code_with_coverage(
+    ingestor: GraphQueryClient, project_name: str, config: DeadCodeConfig
+) -> tuple[list[ResultRow], int]:
+    """Dead-code rows plus the count of symbols no analysis could cover.
+
+    The count rides along here because it needs the unfiltered node rows, which
+    only this fetch has; recomputing it in the CLI would mean a second query.
+    """
     prefix = project_name + cs.SEPARATOR_DOT
     params: dict[str, PropertyValue] = {cs.KEY_PROJECT_PREFIX: prefix}
 
@@ -863,4 +895,4 @@ def collect_dead_code(
     dead = dead_code_from_graph(nodes, rels, prefix, config)
     rows = [row for row in node_rows if _row_qn(row) in dead]
     rows.sort(key=_row_qn)
-    return rows
+    return rows, count_structural_tier_symbols(node_rows)

--- a/codebase_rag/parsers/ast_grep_tier.py
+++ b/codebase_rag/parsers/ast_grep_tier.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from functools import cache
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -59,6 +60,21 @@ def load_pattern_configs() -> dict[str, _LangConfig]:
         for extension in extensions:
             configs[extension] = config
     return configs
+
+
+@cache
+def structural_tier_extensions() -> frozenset[str]:
+    """File extensions handled by this tier, for consumers that must skip them.
+
+    Analyses built on the call graph (dead code) cannot say anything about a
+    language parsed here, since the tier emits no CALLS edges. Reading the
+    shipped configs keeps those consumers correct as languages are added.
+    Returns empty if the [ast-grep] extra is absent, matching the disabled tier.
+    """
+    try:
+        return frozenset(load_pattern_configs())
+    except Exception:  # noqa: BLE001
+        return frozenset()
 
 
 def _strip_quotes(text: str) -> str:

--- a/codebase_rag/tests/test_dead_code_structural_tier_notice.py
+++ b/codebase_rag/tests/test_dead_code_structural_tier_notice.py
@@ -1,0 +1,213 @@
+# Symbols from ast-grep tier languages carry is_exported=True (the tier has no
+# visibility analysis and marks them exported so dead-code does not false-flag
+# every one). That makes them unconditional roots, so dead-code analysis can
+# never report them -- correct, but silently zero-recall: a Ruby-heavy repo
+# gets "no dead code found" with no hint that its Ruby was never analyzed.
+# These cover the count that makes the exemption visible in the report.
+from __future__ import annotations
+
+import json
+import re
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from codebase_rag import constants as cs
+from codebase_rag import cypher_queries as cq
+from codebase_rag.cli import app
+from codebase_rag.dead_code import (
+    collect_dead_code,
+    count_structural_tier_symbols,
+    default_dead_code_config,
+)
+from codebase_rag.types_defs import PropertyValue, ResultRow
+
+_FUNCTION = cs.NodeLabel.FUNCTION.value
+_CLASS = cs.NodeLabel.CLASS.value
+_MODULE = cs.NodeLabel.MODULE.value
+_CALLS = cs.RelationshipType.CALLS.value
+
+
+class FakeIngestor:
+    def __init__(self, nodes: list[ResultRow], rels: list[ResultRow]) -> None:
+        self._nodes = nodes
+        self._rels = rels
+
+    def fetch_all(
+        self, query: str, params: dict[str, PropertyValue] | None = None
+    ) -> list[ResultRow]:
+        if query == cq.CYPHER_DEAD_CODE_NODES:
+            return self._nodes
+        return self._rels
+
+
+def _node(
+    label: str, qn: str, name: str, path: str, *, is_exported: bool = False
+) -> ResultRow:
+    return {
+        "label": label,
+        "qualified_name": qn,
+        "name": name,
+        "path": path,
+        "start_line": 1,
+        "end_line": 2,
+        "decorators": [],
+        "is_exported": is_exported,
+        "overrides_external": False,
+    }
+
+
+def _ruby_and_python_nodes() -> list[ResultRow]:
+    # Ruby nodes as AstGrepTier._emit_definition writes them: is_exported=True.
+    return [
+        _node(_MODULE, "proj.lib.orders", "orders.rb", "lib/orders.rb"),
+        _node(
+            _FUNCTION,
+            "proj.lib.orders.process_order",
+            "process_order",
+            "lib/orders.rb",
+            is_exported=True,
+        ),
+        _node(
+            _CLASS,
+            "proj.lib.orders.Order",
+            "Order",
+            "lib/orders.rb",
+            is_exported=True,
+        ),
+        _node(_MODULE, "proj.app", "app.py", "app.py"),
+        _node(_FUNCTION, "proj.app.orphan", "orphan", "app.py"),
+    ]
+
+
+class TestCountStructuralTierSymbols:
+    def test_counts_only_structural_tier_symbols(self) -> None:
+        # The Python orphan is analyzable and must not inflate the notice; the
+        # Ruby module node is not a candidate symbol either.
+        count = count_structural_tier_symbols(_ruby_and_python_nodes())
+
+        assert count == 2
+
+    def test_zero_when_no_structural_tier_files(self) -> None:
+        nodes = [
+            _node(_MODULE, "proj.app", "app.py", "app.py"),
+            _node(_FUNCTION, "proj.app.orphan", "orphan", "app.py"),
+        ]
+
+        assert count_structural_tier_symbols(nodes) == 0
+
+    def test_zero_when_ast_grep_extra_missing(self) -> None:
+        # Without the [ast-grep] extra the tier emits nothing, so there is
+        # nothing to disclaim: degrade to no notice rather than raising.
+        from codebase_rag.parsers import ast_grep_tier
+
+        # structural_tier_extensions() is cached, so clear it around the patch
+        # to exercise the real load path in both directions.
+        ast_grep_tier.structural_tier_extensions.cache_clear()
+        try:
+            with patch.object(
+                ast_grep_tier,
+                "load_pattern_configs",
+                side_effect=ImportError("no yaml"),
+            ):
+                assert count_structural_tier_symbols(_ruby_and_python_nodes()) == 0
+        finally:
+            ast_grep_tier.structural_tier_extensions.cache_clear()
+
+    def test_counts_are_independent_of_reported_dead_code(self) -> None:
+        # The exempted Ruby symbols stay unreported (the exemption is correct);
+        # only the Python orphan is dead. The notice is what surfaces the gap.
+        nodes = _ruby_and_python_nodes()
+        config = default_dead_code_config(include_tests=True, include_classes=True)
+
+        rows = collect_dead_code(FakeIngestor(nodes, []), "proj", config)
+
+        assert [row["qualified_name"] for row in rows] == ["proj.app.orphan"]
+        assert count_structural_tier_symbols(nodes) == 2
+
+    def test_extensions_track_the_tier_pattern_configs(self) -> None:
+        # The count must follow whatever languages the tier ships, so adding a
+        # new ast_grep_patterns/*.yaml needs no change here.
+        from codebase_rag.parsers.ast_grep_tier import structural_tier_extensions
+
+        extensions = structural_tier_extensions()
+
+        assert ".rb" in extensions
+        assert ".py" not in extensions
+
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _plain_text(output: str) -> str:
+    # Strip styling and collapse rich's wrap breaks so assertions match the
+    # message as written rather than as laid out for the terminal width.
+    return " ".join(_ANSI_RE.sub("", output).split())
+
+
+def _mock_ingestor(nodes: list[ResultRow]) -> MagicMock:
+    mock = MagicMock()
+    mock.list_projects.return_value = ["proj"]
+
+    def _fetch(
+        query: str, params: dict[str, PropertyValue] | None = None
+    ) -> list[ResultRow]:
+        return nodes if query == cq.CYPHER_DEAD_CODE_NODES else []
+
+    mock.fetch_all.side_effect = _fetch
+    mock.__enter__ = MagicMock(return_value=mock)
+    mock.__exit__ = MagicMock(return_value=False)
+    return mock
+
+
+class TestDeadCodeCommandNotice:
+    def test_notice_shown_when_nothing_reported(self) -> None:
+        # The case the notice exists for: every Ruby symbol is exempt, so the
+        # report says "none found" and must not imply Ruby was covered.
+        ruby_only = [
+            _node(_MODULE, "proj.lib.orders", "orders.rb", "lib/orders.rb"),
+            _node(
+                _FUNCTION,
+                "proj.lib.orders.process_order",
+                "process_order",
+                "lib/orders.rb",
+                is_exported=True,
+            ),
+        ]
+        with patch(
+            "codebase_rag.cli.connect_memgraph", return_value=_mock_ingestor(ruby_only)
+        ):
+            result = CliRunner().invoke(app, ["dead-code"])
+
+        assert result.exit_code == 0
+        # Rich styles and wraps the line, so match on plain text with ANSI
+        # escapes and inserted breaks removed.
+        plain = _plain_text(result.output)
+        assert cs.CLI_DEADCODE_NONE in plain
+        assert "1 symbol(s) in structural-tier languages were not analyzed" in plain
+
+    def test_no_notice_without_structural_tier_symbols(self) -> None:
+        python_only = [
+            _node(_MODULE, "proj.app", "app.py", "app.py"),
+            _node(_FUNCTION, "proj.app.orphan", "orphan", "app.py"),
+        ]
+        with patch(
+            "codebase_rag.cli.connect_memgraph",
+            return_value=_mock_ingestor(python_only),
+        ):
+            result = CliRunner().invoke(app, ["dead-code"])
+
+        assert result.exit_code == 0
+        assert "structural-tier" not in _plain_text(result.output)
+
+    def test_json_output_stays_parseable(self) -> None:
+        # The notice must not contaminate machine-readable output.
+        nodes = _ruby_and_python_nodes()
+        with patch(
+            "codebase_rag.cli.connect_memgraph", return_value=_mock_ingestor(nodes)
+        ):
+            result = CliRunner().invoke(app, ["dead-code", "--format", "json"])
+
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert [row["qualified_name"] for row in payload] == ["proj.app.orphan"]

--- a/codebase_rag/tests/test_dead_code_structural_tier_notice.py
+++ b/codebase_rag/tests/test_dead_code_structural_tier_notice.py
@@ -25,6 +25,7 @@ from codebase_rag.dead_code import (
 from codebase_rag.types_defs import PropertyValue, ResultRow
 
 _FUNCTION = cs.NodeLabel.FUNCTION.value
+_METHOD = cs.NodeLabel.METHOD.value
 _CLASS = cs.NodeLabel.CLASS.value
 _MODULE = cs.NodeLabel.MODULE.value
 _CALLS = cs.RelationshipType.CALLS.value
@@ -77,6 +78,16 @@ def _ruby_and_python_nodes() -> list[ResultRow]:
             "lib/orders.rb",
             is_exported=True,
         ),
+        # Method is counted alongside Function and Class, so it belongs in the
+        # fixture: without it, dropping Method from the counted labels would
+        # not fail a single test.
+        _node(
+            _METHOD,
+            "proj.lib.orders.Order.total",
+            "total",
+            "lib/orders.rb",
+            is_exported=True,
+        ),
         _node(_MODULE, "proj.app", "app.py", "app.py"),
         _node(_FUNCTION, "proj.app.orphan", "orphan", "app.py"),
     ]
@@ -88,7 +99,7 @@ class TestCountStructuralTierSymbols:
         # Ruby module node is not a candidate symbol either.
         count = count_structural_tier_symbols(_ruby_and_python_nodes())
 
-        assert count == 2
+        assert count == 3
 
     def test_zero_when_no_structural_tier_files(self) -> None:
         nodes = [
@@ -128,7 +139,7 @@ class TestCountStructuralTierSymbols:
         ast_grep_tier.structural_tier_extensions.cache_clear()
         try:
             with patch.dict(sys.modules, {"ast_grep_py": None}):
-                assert count_structural_tier_symbols(_ruby_and_python_nodes()) == 2
+                assert count_structural_tier_symbols(_ruby_and_python_nodes()) == 3
         finally:
             ast_grep_tier.structural_tier_extensions.cache_clear()
 
@@ -141,7 +152,7 @@ class TestCountStructuralTierSymbols:
         rows = collect_dead_code(FakeIngestor(nodes, []), "proj", config)
 
         assert [row["qualified_name"] for row in rows] == ["proj.app.orphan"]
-        assert count_structural_tier_symbols(nodes) == 2
+        assert count_structural_tier_symbols(nodes) == 3
 
     def test_extensions_track_the_tier_pattern_configs(self) -> None:
         # The count must follow whatever languages the tier ships, so adding a
@@ -244,7 +255,7 @@ class TestDeadCodeCommandNotice:
 
         assert result.exit_code == 0
         saved = _plain_text((tmp_path / "report.txt").read_text(encoding="utf-8"))
-        assert "2 symbol(s) in structural-tier languages were not analyzed" in saved
+        assert "3 symbol(s) in structural-tier languages were not analyzed" in saved
 
     def test_saved_json_report_stays_parseable(self, tmp_path: Path) -> None:
         # The JSON artifact must remain machine-readable, so the notice belongs

--- a/codebase_rag/tests/test_dead_code_structural_tier_notice.py
+++ b/codebase_rag/tests/test_dead_code_structural_tier_notice.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import re
 import sys
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from typer.testing import CliRunner
@@ -227,4 +228,36 @@ class TestDeadCodeCommandNotice:
 
         assert result.exit_code == 0
         payload = json.loads(result.output)
+        assert [row["qualified_name"] for row in payload] == ["proj.app.orphan"]
+
+    def test_saved_table_report_carries_the_notice(self, tmp_path: Path) -> None:
+        # A report read from a file (CI artifact, shared review) must carry the
+        # same disclaimer as the console: otherwise the saved copy shows an
+        # empty table and reads as "this code is clean".
+        with patch(
+            "codebase_rag.cli.connect_memgraph",
+            return_value=_mock_ingestor(_ruby_and_python_nodes()),
+        ):
+            result = CliRunner().invoke(
+                app, ["dead-code", "--output", str(tmp_path / "report.txt")]
+            )
+
+        assert result.exit_code == 0
+        saved = _plain_text((tmp_path / "report.txt").read_text(encoding="utf-8"))
+        assert "2 symbol(s) in structural-tier languages were not analyzed" in saved
+
+    def test_saved_json_report_stays_parseable(self, tmp_path: Path) -> None:
+        # The JSON artifact must remain machine-readable, so the notice belongs
+        # only in the human-facing table format.
+        out = tmp_path / "report.json"
+        with patch(
+            "codebase_rag.cli.connect_memgraph",
+            return_value=_mock_ingestor(_ruby_and_python_nodes()),
+        ):
+            result = CliRunner().invoke(
+                app, ["dead-code", "--format", "json", "--output", str(out)]
+            )
+
+        assert result.exit_code == 0
+        payload = json.loads(out.read_text(encoding="utf-8"))
         assert [row["qualified_name"] for row in payload] == ["proj.app.orphan"]

--- a/codebase_rag/tests/test_dead_code_structural_tier_notice.py
+++ b/codebase_rag/tests/test_dead_code_structural_tier_notice.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import re
+import sys
 from unittest.mock import MagicMock, patch
 
 from typer.testing import CliRunner
@@ -111,6 +112,22 @@ class TestCountStructuralTierSymbols:
                 side_effect=ImportError("no yaml"),
             ):
                 assert count_structural_tier_symbols(_ruby_and_python_nodes()) == 0
+        finally:
+            ast_grep_tier.structural_tier_extensions.cache_clear()
+
+    def test_counts_tier_symbols_without_ast_grep_py_installed(self) -> None:
+        # Partial install (pyyaml present, ast_grep_py absent) must NOT gate the
+        # count on the local import: the graph is shared, so a repo indexed
+        # where the extra WAS installed has real tier symbols in it. Reporting
+        # 0 here would hide them, which is the dishonest report this exists to
+        # prevent. Locally-indexed repos are unaffected -- a disabled tier
+        # emits no nodes, so there is nothing to count either way.
+        from codebase_rag.parsers import ast_grep_tier
+
+        ast_grep_tier.structural_tier_extensions.cache_clear()
+        try:
+            with patch.dict(sys.modules, {"ast_grep_py": None}):
+                assert count_structural_tier_symbols(_ruby_and_python_nodes()) == 2
         finally:
             ast_grep_tier.structural_tier_extensions.cache_clear()
 

--- a/codebase_rag/tests/test_dead_code_structural_tier_notice.py
+++ b/codebase_rag/tests/test_dead_code_structural_tier_notice.py
@@ -261,3 +261,35 @@ class TestDeadCodeCommandNotice:
         assert result.exit_code == 0
         payload = json.loads(out.read_text(encoding="utf-8"))
         assert [row["qualified_name"] for row in payload] == ["proj.app.orphan"]
+
+    def test_notice_alone_does_not_fail_the_build(self) -> None:
+        # The notice is informational: exempt symbols are not findings, so
+        # --fail-on-found must still exit 0 when nothing is actually dead.
+        # Otherwise indexing a Ruby file would break someone's CI gate.
+        ruby_only = [
+            _node(_MODULE, "proj.lib.orders", "orders.rb", "lib/orders.rb"),
+            _node(
+                _FUNCTION,
+                "proj.lib.orders.process_order",
+                "process_order",
+                "lib/orders.rb",
+                is_exported=True,
+            ),
+        ]
+        with patch(
+            "codebase_rag.cli.connect_memgraph", return_value=_mock_ingestor(ruby_only)
+        ):
+            result = CliRunner().invoke(app, ["dead-code", "--fail-on-found"])
+
+        assert result.exit_code == 0
+        assert "structural-tier" in _plain_text(result.output)
+
+    def test_real_candidate_still_fails_the_build(self) -> None:
+        # Guard the other direction: the notice must not mask a real finding.
+        with patch(
+            "codebase_rag.cli.connect_memgraph",
+            return_value=_mock_ingestor(_ruby_and_python_nodes()),
+        ):
+            result = CliRunner().invoke(app, ["dead-code", "--fail-on-found"])
+
+        assert result.exit_code == 1

--- a/docs/guide/dead-code.md
+++ b/docs/guide/dead-code.md
@@ -27,7 +27,7 @@ That exemption is deliberate: without call edges every symbol would look
 unreachable. But it means a clean report says nothing about those languages, so
 the command prints how many symbols were skipped:
 
-```
+```text
 No unreachable functions or methods found.
 12 symbol(s) in structural-tier languages were not analyzed (no call graph for these languages).
 ```

--- a/docs/guide/dead-code.md
+++ b/docs/guide/dead-code.md
@@ -16,6 +16,22 @@ reached only through dynamic dispatch, reflection, string-keyed lookups, or an
 external framework that the static graph cannot see may still be reported. Read
 each candidate before removing it.
 
+## Language Coverage
+
+Detection needs a call graph, so it covers only the
+[fully supported languages](../architecture/language-support.md). Languages
+served by the structural (ast-grep) tier, such as Ruby, produce no `CALLS`
+edges, so their symbols are always treated as reachable and never reported.
+
+That exemption is deliberate: without call edges every symbol would look
+unreachable. But it means a clean report says nothing about those languages, so
+the command prints how many symbols were skipped:
+
+```
+No unreachable functions or methods found.
+12 symbol(s) in structural-tier languages were not analyzed (no call graph for these languages).
+```
+
 ## Prerequisites
 
 Index the repository first, so the graph exists in Memgraph:


### PR DESCRIPTION
## Problem

`AstGrepTier._emit_definition` stamps every symbol it emits with `is_exported: True`, deliberately, so that dead-code analysis does not false-flag languages that have no visibility analysis. The dead-code engine roots any candidate with `is_exported: True`, so those symbols are never reported. That behaviour is correct (the tier emits no CALLS edges, so reachability could only produce false positives) but it is silently zero-recall.

The consequence is a misleading report: a Ruby-heavy repository prints "No unreachable functions or methods found." with no indication that its Ruby was never analyzed at all. The user cannot distinguish "your code is clean" from "this language was skipped".

## Change

`cgr dead-code` now prints a notice after the result when the graph contains symbols from structural-tier languages:

```
No unreachable functions or methods found.
12 symbol(s) in structural-tier languages were not analyzed (no call graph for these languages).
```

No behavioural change to what is reported as dead: the exemption stays exactly as it was. This only makes the coverage gap visible.

Details:

- `structural_tier_extensions()` in `ast_grep_tier.py` exposes the extensions the tier handles, read from the shipped `ast_grep_patterns/*.yaml`. Adding a new tier language therefore needs no change here. Cached, since the shipped configs are fixed at runtime.
- `count_structural_tier_symbols()` in `dead_code.py` counts `Function`/`Method`/`Class` nodes whose path has a tier extension.
- `collect_dead_code_with_coverage()` returns the rows plus that count. The count needs the unfiltered node rows, which only that fetch has, so computing it in the CLI would have meant a second query. `collect_dead_code()` keeps its existing signature and delegates, so no existing caller changes.
- The notice is table-format only, so JSON output stays machine-parseable.
- If the `[ast-grep]` extra is absent the tier emits nothing, so the extension set is empty and no notice is printed, rather than raising.

## Tests

`test_dead_code_structural_tier_notice.py`, 8 tests, written red first:

- the count includes only tier symbols (not the Python orphan, not module nodes)
- zero when no tier files are present
- zero, not an exception, when the `[ast-grep]` extra is missing
- the count is independent of what is reported dead (Ruby stays exempt; only the Python orphan is reported)
- extensions are read from the tier's pattern configs (`.rb` in, `.py` out)
- CLI: the notice appears alongside "none found", which is the case it exists for
- CLI: no notice when there are no tier symbols
- CLI: JSON output stays parseable

All 52 existing dead-code tests pass. `ruff check`, `ruff format --check`, and `ty check` are clean on the changed files.

Note: `test_ast_grep_tier.py`, `test_ts_*`, `test_rust_iter_closure_param_typing.py`, and `test_unixcoder_unit.py` fail on this machine because of missing optional dependencies (`ast_grep_py`, `tree_sitter_rust`, `torch`). Verified identical failures on a clean worktree at HEAD, so they are unrelated to this change.

## Context

Follow-up to a discussion about adding structural support for more languages and promoting them to full support over time. Making the tier's analysis boundary visible is what keeps that strategy honest as more languages are added: every future YAML language inherits both the exemption and this disclosure automatically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dead-code reports now show how many symbols were skipped because call-graph coverage was unavailable.
  * Coverage notices appear in console output and saved human-readable reports, including when no candidates are found.
  * Structural-tier language symbols are now identified for coverage reporting.

* **Bug Fixes**
  * JSON output remains unchanged and parseable.
  * Analysis continues gracefully when language configuration or structural-analysis support is unavailable.

* **Documentation**
  * Added guidance on dead-code language coverage and skipped symbols.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->