### PR TITLE
feat: Roslyn argument and binding flow facts sharpen C# taint propagation

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -499,6 +499,8 @@ class GraphUpdater:
         dp = self.factory.definition_processor
         dp.csharp_base_kinds = {}
         dp.csharp_call_sites.clear()
+        dp.csharp_arg_flows.clear()
+        dp.csharp_bind_flows.clear()
         dp.csharp_external_sites.clear()
         self._csharp_partial_decls = []
         self._csharp_query_calls = []
@@ -509,6 +511,8 @@ class GraphUpdater:
         dp = self.factory.definition_processor
         dp.csharp_base_kinds = facts.base_kinds
         dp.csharp_call_sites.update(facts.resolved_call_sites)
+        dp.csharp_arg_flows.update(facts.arg_flows)
+        dp.csharp_bind_flows.update(facts.bind_flows)
         dp.csharp_external_sites.update(facts.external_sites)
         self._csharp_partial_decls = facts.partial_groups
         self._csharp_query_calls = facts.query_calls

--- a/codebase_rag/parsers/csharp_frontend/frontend.py
+++ b/codebase_rag/parsers/csharp_frontend/frontend.py
@@ -68,12 +68,20 @@ class CSharpSemanticFacts(NamedTuple):
     # declaration): the compiler proof that the call leaves the repo, so
     # the name-trie fallback must not fabricate a first-party edge there.
     external_sites: set[CallSiteKey]
+    # Per invocation argument, the locals/parameters Roslyn's definite-
+    # assignment analysis proves reach it (issue #1187): the compiler's
+    # answer where the lexical flow walk guesses from syntax.
+    arg_flows: dict[CallSiteKey, dict[int, frozenset[str]]]
+    # Per local declarator, the locals/parameters that reach its INITIALIZER:
+    # without these the tainted value stops at the initializer expression and
+    # the bound variable looks clean to every later read.
+    bind_flows: dict[CallSiteKey, frozenset[str]]
 
 
 def _empty_facts() -> CSharpSemanticFacts:
     # A fresh instance per failure path: the maps are handed to mutable
     # processor state, so a shared constant would alias across runs.
-    return CSharpSemanticFacts({}, {}, [], [], set())
+    return CSharpSemanticFacts({}, {}, [], [], set(), {}, {})
 
 
 _DOTNET = "dotnet"
@@ -316,6 +324,8 @@ def _parse_payload(stdout: str, stderr: str = "") -> CSharpSemanticFacts:
             (site["file"], int(site["line"]), int(site["col"]), site["name"])
             for site in payload.get("externals", [])
         },
+        arg_flows=_arg_flows(payload.get("arg_flows", [])),
+        bind_flows=_bind_flows(payload.get("bind_flows", [])),
     )
     if not any(facts) and stderr.strip():
         # A well-formed but entirely empty payload means the workspace load
@@ -323,6 +333,53 @@ def _parse_payload(stdout: str, stderr: str = "") -> CSharpSemanticFacts:
         # tool's diagnostics instead of looking identical to success.
         logger.warning(ls.CSHARP_FRONTEND_NO_FACTS.format(stderr=stderr.strip()))
     return facts
+
+
+def _arg_flows(rows: list) -> dict[CallSiteKey, dict[int, frozenset[str]]]:
+    # Keyed exactly like the call facts, so the resolver's existing
+    # location join applies unchanged. A malformed row is dropped rather
+    # than failing the whole payload: worst case those arguments fall back
+    # to the lexical evaluation.
+    flows: dict[CallSiteKey, dict[int, frozenset[str]]] = {}
+    for row in rows:
+        try:
+            key: CallSiteKey = (
+                row["file"],
+                int(row["line"]),
+                int(row["col"]),
+                row["name"],
+            )
+            index = int(row["index"])
+            symbols = frozenset(
+                symbol for symbol in row["symbols"] if isinstance(symbol, str)
+            )
+        except (KeyError, TypeError, ValueError):
+            continue
+        if symbols:
+            flows.setdefault(key, {})[index] = symbols
+    return flows
+
+
+def _bind_flows(rows: list) -> dict[CallSiteKey, frozenset[str]]:
+    # Keyed at the declarator's NAME token, the same (file, line, byte col,
+    # name) shape as every other family. Malformed rows drop.
+    flows: dict[CallSiteKey, frozenset[str]] = {}
+    for row in rows:
+        try:
+            key: CallSiteKey = (
+                row["file"],
+                int(row["line"]),
+                int(row["col"]),
+                row["name"],
+            )
+            symbols = frozenset(
+                symbol for symbol in row["symbols"] if isinstance(symbol, str)
+            )
+        except (KeyError, TypeError, ValueError):
+            continue
+        if symbols:
+            flows[key] = symbols
+    return flows
 
 
 def _base_kinds(bases: list[dict[str, str]]) -> dict[str, str]:

--- a/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
@@ -295,6 +295,22 @@ public static class Frontend
         // The locals/parameters whose values reach this expression region.
         private static List<string> FlowSymbols(SemanticModel model, SyntaxNode region)
         {
+            // A conditional's CONDITION is read but never becomes the value, and
+            // AnalyzeDataFlow counts every read; analysing the branches instead
+            // keeps the same rule the flow walk already applies to `a ? b : c`,
+            // so inspecting a tainted local cannot fabricate a flow.
+            if (region is ParenthesizedExpressionSyntax parenthesized)
+            {
+                return FlowSymbols(model, parenthesized.Expression);
+            }
+            if (region is ConditionalExpressionSyntax conditional)
+            {
+                return FlowSymbols(model, conditional.WhenTrue)
+                    .Concat(FlowSymbols(model, conditional.WhenFalse))
+                    .Distinct(StringComparer.Ordinal)
+                    .OrderBy(n => n, StringComparer.Ordinal)
+                    .ToList();
+            }
             DataFlowAnalysis analysis;
             try
             {
@@ -310,8 +326,17 @@ public static class Frontend
             {
                 return new List<string>();
             }
+            // DataFlowsIn ONLY: it is exactly "assigned outside, read inside",
+            // i.e. the values that genuinely reach this region. ReadInside
+            // would also catch a local merely INSPECTED without contributing
+            // (`secret == null ? "ok" : "ok"`), fabricating taint. Symbols
+            // declared inside the region (lambda parameters, `out` and
+            // pattern declarations) are excluded so a same-named enclosing
+            // variable cannot leak in through them.
+            var declaredInside = new HashSet<ISymbol>(
+                analysis.VariablesDeclared, SymbolEqualityComparer.Default);
             return analysis.DataFlowsIn
-                .Concat(analysis.ReadInside)
+                .Where(s => !declaredInside.Contains(s))
                 .Where(s => s.Kind is SymbolKind.Local or SymbolKind.Parameter)
                 .Select(s => s.Name)
                 .Where(n => !string.IsNullOrEmpty(n))

--- a/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
@@ -93,11 +93,15 @@ public static class Frontend
         private readonly List<TypeFact> _types = new();
         private readonly List<CallFact> _calls = new();
         private readonly List<ExternalFact> _externals = new();
+        private readonly List<ArgFlowFact> _argFlows = new();
+        private readonly List<BindFlowFact> _bindFlows = new();
         private readonly List<QueryFact> _queries = new();
         private readonly Dictionary<string, List<DeclLoc>> _partials = new(StringComparer.Ordinal);
         private readonly HashSet<(string, int)> _seenTypes = new();
         private readonly HashSet<(string, int, int, string)> _seenCalls = new();
         private readonly HashSet<(string, int, int, string)> _seenExternals = new();
+        private readonly HashSet<(string, int, int, string, int)> _seenArgFlows = new();
+        private readonly HashSet<(string, int, int, string)> _seenBindFlows = new();
         private readonly HashSet<(string, int, int, string, int, string)> _seenQueries = new();
 
         private readonly HashSet<string> _firstPartyAssemblies;
@@ -146,13 +150,16 @@ public static class Frontend
                     case QueryExpressionSyntax query:
                         CollectQuery(model, query, rel);
                         break;
+                    case VariableDeclaratorSyntax declarator:
+                        CollectBindFlow(model, declarator, rel);
+                        break;
                     default:
                         break;
                 }
             }
         }
 
-        public Payload ToPayload() => new(_types, _calls, _partials.Values.ToList(), _queries, _externals);
+        public Payload ToPayload() => new(_types, _calls, _partials.Values.ToList(), _queries, _externals, _argFlows, _bindFlows);
 
         private string Rel(string path) =>
             Path.GetRelativePath(_rootFull, path).Replace(Path.DirectorySeparatorChar, '/');
@@ -222,6 +229,10 @@ public static class Frontend
             var pos = location.GetLineSpan().StartLinePosition;
             var col = ByteCol(location, pos);
             var name = nameToken.ValueText;
+            // Argument flow BEFORE the first-party/external split: a sink like
+            // Console.WriteLine is external, and that is exactly where knowing
+            // which locals reach an argument matters (issue #1187).
+            CollectArgFlows(model, invocation, rel, pos.Line + 1, col, name);
             var declared = DeclaredMethod(symbol);
             if (FirstPartyDecl(declared) is not { } target)
             {
@@ -252,6 +263,93 @@ public static class Frontend
                 return;
             }
             _calls.Add(new CallFact(rel, pos.Line + 1, col, name, target.File, target.Line, target.Col));
+        }
+
+        // Which locals/parameters reach a local's INITIALIZER, per the same
+        // analysis: without this the tainted value stops at the initializer
+        // expression and the bound variable looks clean, so a sink reading it
+        // reports nothing (issue #1187).
+        private void CollectBindFlow(
+            SemanticModel model, VariableDeclaratorSyntax declarator, string rel)
+        {
+            if (declarator.Initializer?.Value is not { } value)
+            {
+                return;
+            }
+            var symbols = FlowSymbols(model, value);
+            if (symbols.Count == 0)
+            {
+                return;
+            }
+            var location = declarator.Identifier.GetLocation();
+            var pos = location.GetLineSpan().StartLinePosition;
+            var col = ByteCol(location, pos);
+            var name = declarator.Identifier.ValueText;
+            if (!_seenBindFlows.Add((rel, pos.Line + 1, col, name)))
+            {
+                return;
+            }
+            _bindFlows.Add(new BindFlowFact(rel, pos.Line + 1, col, name, symbols));
+        }
+
+        // The locals/parameters whose values reach this expression region.
+        private static List<string> FlowSymbols(SemanticModel model, SyntaxNode region)
+        {
+            DataFlowAnalysis analysis;
+            try
+            {
+                analysis = model.AnalyzeDataFlow(region);
+            }
+            catch (ArgumentException)
+            {
+                // A region Roslyn rejects outright leaves the lexical walk in
+                // charge for that expression.
+                return new List<string>();
+            }
+            if (!analysis.Succeeded)
+            {
+                return new List<string>();
+            }
+            return analysis.DataFlowsIn
+                .Concat(analysis.ReadInside)
+                .Where(s => s.Kind is SymbolKind.Local or SymbolKind.Parameter)
+                .Select(s => s.Name)
+                .Where(n => !string.IsNullOrEmpty(n))
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(n => n, StringComparer.Ordinal)
+                .ToList();
+        }
+
+        // Which locals/parameters actually reach each argument, per Roslyn's
+        // definite-assignment analysis: symbol-accurate where the lexical walk
+        // guesses from syntax, so shadowed names, builder chains, casts, and
+        // conditional expressions all thread correctly (issue #1187).
+        private void CollectArgFlows(
+            SemanticModel model,
+            InvocationExpressionSyntax invocation,
+            string rel,
+            int line,
+            int col,
+            string name)
+        {
+            var arguments = invocation.ArgumentList?.Arguments;
+            if (arguments is null)
+            {
+                return;
+            }
+            for (var index = 0; index < arguments.Value.Count; index++)
+            {
+                var symbols = FlowSymbols(model, arguments.Value[index].Expression);
+                if (symbols.Count == 0)
+                {
+                    continue;
+                }
+                if (!_seenArgFlows.Add((rel, line, col, name, index)))
+                {
+                    continue;
+                }
+                _argFlows.Add(new ArgFlowFact(rel, line, col, name, index, symbols));
+            }
         }
 
         // Query syntax desugars to operator method calls with no invocation nodes;
@@ -574,10 +672,27 @@ public static class Frontend
         [property: JsonPropertyName("col")] int Col,
         [property: JsonPropertyName("name")] string Name);
 
+    private record ArgFlowFact(
+        [property: JsonPropertyName("file")] string File,
+        [property: JsonPropertyName("line")] int Line,
+        [property: JsonPropertyName("col")] int Col,
+        [property: JsonPropertyName("name")] string Name,
+        [property: JsonPropertyName("index")] int Index,
+        [property: JsonPropertyName("symbols")] List<string> Symbols);
+
+    private record BindFlowFact(
+        [property: JsonPropertyName("file")] string File,
+        [property: JsonPropertyName("line")] int Line,
+        [property: JsonPropertyName("col")] int Col,
+        [property: JsonPropertyName("name")] string Name,
+        [property: JsonPropertyName("symbols")] List<string> Symbols);
+
     private record Payload(
         [property: JsonPropertyName("types")] List<TypeFact> Types,
         [property: JsonPropertyName("calls")] List<CallFact> Calls,
         [property: JsonPropertyName("partials")] List<List<DeclLoc>> Partials,
         [property: JsonPropertyName("queries")] List<QueryFact> Queries,
-        [property: JsonPropertyName("externals")] List<ExternalFact> Externals);
+        [property: JsonPropertyName("externals")] List<ExternalFact> Externals,
+        [property: JsonPropertyName("arg_flows")] List<ArgFlowFact> ArgFlows,
+        [property: JsonPropertyName("bind_flows")] List<BindFlowFact> BindFlows);
 }

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -160,6 +160,10 @@ class DefinitionProcessor(
         # name-trie fabricate a first-party edge. Same in-place mutation
         # discipline as csharp_call_sites.
         self.csharp_external_sites: set[CallSiteKey] = set()
+        # Roslyn argument-flow facts (issue #1187): per call site and
+        # argument index, the locals/parameters the compiler proves reach it.
+        self.csharp_arg_flows: dict[CallSiteKey, dict[int, frozenset[str]]] = {}
+        self.csharp_bind_flows: dict[CallSiteKey, frozenset[str]] = {}
         # Go go/types frontend (issue #1179): the same two call families as C#
         # -- per-invocation exact first-party call targets keyed on the callee
         # NAME token location, and sites the compiler resolved OUTSIDE the module

--- a/codebase_rag/parsers/factory.py
+++ b/codebase_rag/parsers/factory.py
@@ -140,6 +140,8 @@ class ProcessorFactory:
                 csharp_partial_groups=self.definition_processor.csharp_partial_groups,
                 csharp_extension_methods=self.definition_processor.csharp_extension_methods,
                 csharp_call_sites=self.definition_processor.csharp_call_sites,
+                csharp_arg_flows=self.definition_processor.csharp_arg_flows,
+                csharp_bind_flows=self.definition_processor.csharp_bind_flows,
                 csharp_external_sites=self.definition_processor.csharp_external_sites,
                 csharp_local_functions=self.definition_processor.csharp_local_functions,
                 csharp_generic_methods=self.definition_processor.csharp_generic_methods,

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -61,6 +61,7 @@ from ..io_access.registry import (
     IO_TYPE_HANDLE_CONSTRUCTORS,
     LIBC_STD_STREAMS,
 )
+from ..semantic_call_join import call_site_key
 from ..utils import (
     c_positional_parameter_slots,
     cpp_declarator_name,
@@ -1346,7 +1347,13 @@ class FlowProcessor:
                 if spread
                 else (values[index] if index < len(values) else None)
             )
-            computed.append((name, self._js_expr_taint(rhs, tainted, jc), rhs))
+            taint = self._js_expr_taint(rhs, tainted, jc)
+            # Roslyn proved which locals reach this initializer (issue #1187):
+            # union their taint so a value the syntactic reader cannot thread
+            # (builder chain, cast, conditional) still taints the binding.
+            for symbol in self._csharp_bind_symbols(node, name, jc):
+                taint = _merge_optional_taints(taint, tainted.get(symbol))
+            computed.append((name, taint, rhs))
         for name, taint, rhs in computed:
             if taint is not None:
                 tainted[name] = taint
@@ -2626,14 +2633,83 @@ class FlowProcessor:
         # C# wraps each arg in an `argument` node, so unwrap to the real
         # expression before reading its taint (no-op for the bare-arg grammars).
         wrapper = jc.descriptor.argument_wrapper_type
+        semantic = self._csharp_arg_symbols(node, jc)
         for index, child in enumerate(self._named_no_comments(args)):
-            out.append(
-                (
-                    VIA_ARG_FORMAT.format(index=index),
-                    self._js_expr_taint(unwrap_argument(child, wrapper), tainted, jc),
-                )
-            )
+            taint = self._js_expr_taint(unwrap_argument(child, wrapper), tainted, jc)
+            # Roslyn proved which locals reach this argument (issue #1187):
+            # union their taint with the syntactic reading, so a builder
+            # chain, cast, or conditional the walker cannot thread still
+            # propagates. Additive only -- never removes a lexical edge.
+            for symbol in semantic.get(index, ()):  # type: ignore[union-attr]
+                taint = _merge_optional_taints(taint, tainted.get(symbol))
+            out.append((VIA_ARG_FORMAT.format(index=index), taint))
         return out
+
+    def _csharp_bind_symbols(self, node: Node, name: str, jc: _JsCtx) -> frozenset[str]:
+        # The bind-flow fact for THIS declarator, matched on its name token;
+        # empty for every other language and whenever the frontend is off.
+        flows = self._resolver.type_inference.csharp_bind_flows
+        if not flows or jc.flow.language != cs.SupportedLanguage.CSHARP:
+            return frozenset()
+        name_node = self._csharp_declarator_name_node(node, name)
+        if name_node is None:
+            return frozenset()
+        key = call_site_key(
+            name_node,
+            name,
+            jc.flow.module_qn,
+            self._resolver.type_inference.module_qn_to_file_path,
+            self._resolver.type_inference.repo_path,
+        )
+        return flows.get(key, frozenset()) if key is not None else frozenset()
+
+    @staticmethod
+    def _csharp_declarator_name_node(node: Node, name: str) -> Node | None:
+        candidate = node.child_by_field_name(cs.TS_FIELD_NAME)
+        if (
+            candidate is not None
+            and candidate.text
+            and candidate.text.decode(cs.ENCODING_UTF8) == name
+        ):
+            return candidate
+        for child in node.named_children:
+            if (
+                child.type == cs.TS_CSHARP_IDENTIFIER
+                and child.text
+                and child.text.decode(cs.ENCODING_UTF8) == name
+            ):
+                return child
+        return None
+
+    def _csharp_arg_symbols(self, node: Node, jc: _JsCtx) -> dict[int, frozenset[str]]:
+        # The Roslyn argument-flow facts for THIS call site, keyed exactly
+        # like the call facts; empty for every other language and whenever
+        # the frontend is off.
+        flows = self._resolver.type_inference.csharp_arg_flows
+        if not flows or jc.flow.language != cs.SupportedLanguage.CSHARP:
+            return {}
+        name_node = self._csharp_callee_name_node(node)
+        if name_node is None or not name_node.text:
+            return {}
+        key = call_site_key(
+            name_node,
+            name_node.text.decode(cs.ENCODING_UTF8),
+            jc.flow.module_qn,
+            self._resolver.type_inference.module_qn_to_file_path,
+            self._resolver.type_inference.repo_path,
+        )
+        return flows.get(key, {}) if key is not None else {}
+
+    @staticmethod
+    def _csharp_callee_name_node(call_node: Node) -> Node | None:
+        # The callee NAME token, matching the Roslyn tool's key: the member
+        # name for `obj.M(x)`, the bare identifier for `M(x)`.
+        func = call_node.child_by_field_name(cs.TS_FIELD_FUNCTION)
+        if func is None:
+            return None
+        if func.type == cs.TS_CSHARP_MEMBER_ACCESS_EXPRESSION:
+            return func.child_by_field_name(cs.TS_CSHARP_FIELD_NAME)
+        return func
 
     def _js_return_taint(
         self, node: Node, tainted: _TaintMap, jc: _JsCtx

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -2700,16 +2700,54 @@ class FlowProcessor:
         )
         return flows.get(key, {}) if key is not None else {}
 
-    @staticmethod
-    def _csharp_callee_name_node(call_node: Node) -> Node | None:
-        # The callee NAME token, matching the Roslyn tool's key: the member
-        # name for `obj.M(x)`, the bare identifier for `M(x)`.
-        func = call_node.child_by_field_name(cs.TS_FIELD_FUNCTION)
-        if func is None:
+    @classmethod
+    def _csharp_callee_name_node(cls, call_node: Node) -> Node | None:
+        # The callee NAME token, mirroring the Roslyn tool's CalleeNameToken
+        # arm for arm: member access and member binding (`c?.Handle(x)`) take
+        # their `name`, and a generic name (`Method<T>(x)`) reduces to its
+        # bare identifier -- otherwise the keys would never match and those
+        # call sites would silently lose their facts.
+        return cls._csharp_name_token(
+            call_node.child_by_field_name(cs.TS_FIELD_FUNCTION)
+        )
+
+    @classmethod
+    def _csharp_name_token(cls, node: Node | None) -> Node | None:
+        if node is None:
             return None
-        if func.type == cs.TS_CSHARP_MEMBER_ACCESS_EXPRESSION:
-            return func.child_by_field_name(cs.TS_CSHARP_FIELD_NAME)
-        return func
+        if node.type in (
+            cs.TS_CSHARP_MEMBER_ACCESS_EXPRESSION,
+            cs.TS_CSHARP_MEMBER_BINDING_EXPRESSION,
+        ):
+            named = node.child_by_field_name(cs.TS_CSHARP_FIELD_NAME)
+            if named is None:
+                # member_binding_expression exposes its name as the sole
+                # named child in some grammar versions.
+                named = next(iter(node.named_children), None)
+            return cls._csharp_name_token(named)
+        if node.type == cs.TS_CSHARP_CONDITIONAL_ACCESS_EXPRESSION:
+            # `c?.Handle(x)`: the invoked name lives in the trailing
+            # member_binding_expression, not in a named field.
+            return cls._csharp_name_token(
+                next(
+                    (
+                        child
+                        for child in node.named_children
+                        if child.type == cs.TS_CSHARP_MEMBER_BINDING_EXPRESSION
+                    ),
+                    None,
+                )
+            )
+        if node.type == cs.TS_CSHARP_GENERIC_NAME:
+            return next(
+                (
+                    child
+                    for child in node.named_children
+                    if child.type == cs.TS_CSHARP_IDENTIFIER
+                ),
+                None,
+            )
+        return node
 
     def _js_return_taint(
         self, node: Node, tainted: _TaintMap, jc: _JsCtx

--- a/codebase_rag/parsers/frontends/csharp.py
+++ b/codebase_rag/parsers/frontends/csharp.py
@@ -29,6 +29,8 @@ def _adapt_csharp_semantic_facts(facts: CSharpSemanticFacts) -> SemanticFacts:
             for key, site in facts.call_sites.items()
         },
         external_sites=set(facts.external_sites),
+        arg_flows=facts.arg_flows,
+        bind_flows=facts.bind_flows,
         base_kinds=facts.base_kinds,
         partial_groups=facts.partial_groups,
         query_calls=[

--- a/codebase_rag/parsers/frontends/protocol.py
+++ b/codebase_rag/parsers/frontends/protocol.py
@@ -88,6 +88,16 @@ class SemanticFacts:
     # IMPLEMENTS edges for a structurally-typed language with no syntactic base
     # list (Go #1179); languages with a base list use `base_kinds` instead.
     implements_pairs: list[ImplementsPair] = field(default_factory=list)
+    # Per invocation argument, the locals/parameters the compiler proves
+    # reach it (C# Roslyn today, issue #1187). The flow walk unions their
+    # taint with its own syntactic evaluation, so an expression shape the
+    # walker cannot thread still propagates.
+    arg_flows: dict[CallSiteKey, dict[int, frozenset[str]]] = field(
+        default_factory=dict
+    )
+    # Per local declarator (keyed at its name token), the locals/parameters
+    # the compiler proves reach its initializer.
+    bind_flows: dict[CallSiteKey, frozenset[str]] = field(default_factory=dict)
 
     def is_empty(self) -> bool:
         return not (
@@ -97,6 +107,8 @@ class SemanticFacts:
             or self.partial_groups
             or self.query_calls
             or self.implements_pairs
+            or self.arg_flows
+            or self.bind_flows
         )
 
 

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -53,6 +53,8 @@ class TypeInferenceEngine:
         "csharp_partial_groups",
         "csharp_extension_methods",
         "csharp_call_sites",
+        "csharp_arg_flows",
+        "csharp_bind_flows",
         "csharp_external_sites",
         "csharp_local_functions",
         "csharp_generic_methods",
@@ -97,6 +99,8 @@ class TypeInferenceEngine:
         csharp_extension_methods: dict[str, list[tuple[str, str, str, int]]]
         | None = None,
         csharp_call_sites: dict[CallSiteKey, ResolvedCallSite] | None = None,
+        csharp_arg_flows: dict[CallSiteKey, dict[int, frozenset[str]]] | None = None,
+        csharp_bind_flows: dict[CallSiteKey, frozenset[str]] | None = None,
         csharp_external_sites: set[CallSiteKey] | None = None,
         csharp_local_functions: dict[str, tuple[FunctionSpanKey, int]] | None = None,
         csharp_generic_methods: set[str] | None = None,
@@ -179,6 +183,12 @@ class TypeInferenceEngine:
         # after construction and read by the C# resolver's semantic path.
         self.csharp_call_sites = (
             csharp_call_sites if csharp_call_sites is not None else {}
+        )
+        # Shared reference (as with csharp_call_sites): Roslyn argument-flow
+        # facts, read by the C# path of the lean flow walk (issue #1187).
+        self.csharp_arg_flows = csharp_arg_flows if csharp_arg_flows is not None else {}
+        self.csharp_bind_flows = (
+            csharp_bind_flows if csharp_bind_flows is not None else {}
         )
         self.csharp_external_sites = (
             csharp_external_sites if csharp_external_sites is not None else set()

--- a/codebase_rag/tests/test_csharp_frontend_wiring.py
+++ b/codebase_rag/tests/test_csharp_frontend_wiring.py
@@ -265,6 +265,8 @@ def _button_facts() -> object:
         partial_groups=[],
         query_calls=[],
         external_sites=set(),
+        arg_flows={},
+        bind_flows={},
     )
 
 

--- a/codebase_rag/tests/test_csharp_semantic_facts.py
+++ b/codebase_rag/tests/test_csharp_semantic_facts.py
@@ -173,6 +173,8 @@ def test_call_fact_resolves_chained_receiver_to_exact_overload(
         partial_groups=[],
         query_calls=[],
         external_sites=set(),
+        arg_flows={},
+        bind_flows={},
     )
     _hybrid(monkeypatch, facts)
 
@@ -212,6 +214,8 @@ def test_call_fact_resolves_conditional_access_invocation(
         partial_groups=[],
         query_calls=[],
         external_sites=set(),
+        arg_flows={},
+        bind_flows={},
     )
     _hybrid(monkeypatch, facts)
 
@@ -263,6 +267,8 @@ def test_call_fact_suppresses_same_arity_family_fanout(
         partial_groups=[],
         query_calls=[],
         external_sites=set(),
+        arg_flows={},
+        bind_flows={},
     )
     _hybrid(monkeypatch, facts)
 
@@ -317,6 +323,8 @@ def test_external_site_fact_suppresses_name_trie_fallback(
         partial_groups=[],
         query_calls=[],
         external_sites={("Code.cs", call_line, call_col, "Dispose")},
+        arg_flows={},
+        bind_flows={},
     )
     _hybrid(monkeypatch, facts)
 
@@ -386,6 +394,8 @@ def test_partial_fact_merges_parts_across_directories(
         partial_groups=[[("dirA/Part1.cs", line_a), ("dirB/Part2.cs", line_b)]],
         query_calls=[],
         external_sites=set(),
+        arg_flows={},
+        bind_flows={},
     )
     _hybrid(monkeypatch, facts)
 
@@ -452,6 +462,8 @@ def test_query_fact_emits_calls_edge_for_linq_operator(
             )
         ],
         external_sites=set(),
+        arg_flows={},
+        bind_flows={},
     )
     _hybrid(monkeypatch, facts)
 
@@ -488,6 +500,8 @@ def test_query_fact_edge_respects_capture_excluding_calls(
             )
         ],
         external_sites=set(),
+        arg_flows={},
+        bind_flows={},
     )
     _hybrid(monkeypatch, facts)
 

--- a/codebase_rag/tests/test_csharp_semantic_flow.py
+++ b/codebase_rag/tests/test_csharp_semantic_flow.py
@@ -121,3 +121,49 @@ def test_untainted_local_never_gains_a_flow(tmp_path: Path) -> None:
         "    }\n}\n"
     )
     assert _flows(tmp_path / "c", clean, cs.CSharpFrontend.HYBRID) == set()
+
+
+def test_callee_name_token_matches_every_roslyn_shape() -> None:
+    # The Python key must mirror the tool's CalleeNameToken arm for arm, or
+    # these call sites silently lose their facts (review on #1338).
+    from codebase_rag.parser_loader import load_parsers
+    from codebase_rag.parsers.flow_access.processor import FlowProcessor
+
+    parsers, _queries = load_parsers()
+    parser = parsers[cs.SupportedLanguage.CSHARP]
+    tree = parser.parse(
+        b"class A { void M(C c, string t) { c?.Handle(t); Gen<int>(t);"
+        b" c.Obj.Do<T>(t); Plain(t); } }"
+    )
+    names: list[str] = []
+
+    def walk(node) -> None:
+        if node.type == "invocation_expression":
+            token = FlowProcessor._csharp_callee_name_node(node)
+            assert token is not None
+            names.append(token.text.decode("utf-8"))
+        for child in node.children:
+            walk(child)
+
+    walk(tree.root_node)
+    assert names == ["Handle", "Gen", "Do", "Plain"]
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_inspected_local_never_fabricates_a_flow(tmp_path: Path) -> None:
+    # A tainted local merely INSPECTED contributes no value to the result:
+    # DataFlowsIn excludes it, so no edge is fabricated (review on #1338).
+    source = (
+        "using System;\n\n"
+        "public class Inspect\n{\n"
+        "    public void Run()\n    {\n"
+        '        var token = Environment.GetEnvironmentVariable("K");\n'
+        '        var verdict = token == null ? "missing" : "present";\n'
+        "        Console.WriteLine(verdict);\n"
+        "    }\n}\n"
+    )
+    assert (_ENV_K, _STDOUT) not in _flows(
+        tmp_path / "d", source, cs.CSharpFrontend.HYBRID
+    )

--- a/codebase_rag/tests/test_csharp_semantic_flow.py
+++ b/codebase_rag/tests/test_csharp_semantic_flow.py
@@ -1,0 +1,123 @@
+# Roslyn argument-flow facts, slice 1 of issue #1187. C# has the repo's
+# deepest semantic integration but its FLOWS_TO edges came from the lexical
+# lean walk. AnalyzeDataFlow answers "which locals reach this argument"
+# exactly, so expression shapes the syntactic walker cannot thread (builder
+# chains, casts, conditionals) still propagate taint. Additive by design: the
+# facts only ever ADD taint the lexical reading missed.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.capture import resolve_capture
+from codebase_rag.config import settings
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.parsers.csharp_frontend.frontend import (
+    _arg_flows,
+    csharp_frontend_available,
+)
+
+FLOWS_TO = cs.RelationshipType.FLOWS_TO.value
+_CAPTURE_IO = resolve_capture([cs.CaptureGroup.IO.value])
+_ENV_K = "resource::ENV::K"
+_STDOUT = "resource::STDOUT::<dynamic>"
+
+_CSPROJ = (
+    '<Project Sdk="Microsoft.NET.Sdk">\n'
+    "  <PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup>\n"
+    "</Project>\n"
+)
+# The builder chain is the discriminator: the lexical walk cannot thread the
+# tainted local through `new StringBuilder().Append(t).ToString()`.
+_BUILDER_LEAK = (
+    "using System;\nusing System.Text;\n\n"
+    "public class Leaky\n{\n"
+    "    public void Run()\n    {\n"
+    '        var token = Environment.GetEnvironmentVariable("K");\n'
+    "        var wrapped = new StringBuilder().Append(token).ToString();\n"
+    "        Console.WriteLine(wrapped);\n"
+    "    }\n}\n"
+)
+
+
+def _flows(
+    tmp_path: Path, source: str, mode: cs.CSharpFrontend
+) -> set[tuple[str, str]]:
+    repo = tmp_path / "proj"
+    repo.mkdir(parents=True, exist_ok=True)
+    (repo / "proj.csproj").write_text(_CSPROJ, encoding="utf-8")
+    (repo / "Program.cs").write_text(source, encoding="utf-8")
+    parsers, queries = load_parsers()
+    previous = settings.CSHARP_FRONTEND
+    settings.CSHARP_FRONTEND = mode
+    try:
+        mock = MagicMock()
+        GraphUpdater(
+            ingestor=mock,
+            repo_path=repo,
+            parsers=parsers,
+            queries=queries,
+            capture=_CAPTURE_IO,
+        ).run()
+    finally:
+        settings.CSHARP_FRONTEND = previous
+    return {
+        (c.args[0][2], c.args[2][2])
+        for c in mock.ensure_relationship_batch.call_args_list
+        if str(c.args[1]) == FLOWS_TO
+    }
+
+
+def test_arg_flow_rows_parse_and_malformed_rows_drop() -> None:
+    parsed = _arg_flows(
+        [
+            {
+                "file": "a.cs",
+                "line": 4,
+                "col": 8,
+                "name": "WriteLine",
+                "index": 0,
+                "symbols": ["token", 5, "other"],
+            },
+            {"file": "a.cs", "line": 9, "name": "Broken"},
+            {
+                "file": "a.cs",
+                "line": 4,
+                "col": 8,
+                "name": "WriteLine",
+                "index": 1,
+                "symbols": [],
+            },
+        ]
+    )
+    assert parsed == {("a.cs", 4, 8, "WriteLine"): {0: frozenset({"token", "other"})}}
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_builder_chain_taint_needs_the_semantic_facts(tmp_path: Path) -> None:
+    lexical = _flows(tmp_path / "a", _BUILDER_LEAK, cs.CSharpFrontend.TREESITTER)
+    assert (_ENV_K, _STDOUT) not in lexical
+    semantic = _flows(tmp_path / "b", _BUILDER_LEAK, cs.CSharpFrontend.HYBRID)
+    assert (_ENV_K, _STDOUT) in semantic
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_untainted_local_never_gains_a_flow(tmp_path: Path) -> None:
+    clean = (
+        "using System;\nusing System.Text;\n\n"
+        "public class Fine\n{\n"
+        "    public void Run()\n    {\n"
+        '        var plain = "constant";\n'
+        "        var wrapped = new StringBuilder().Append(plain).ToString();\n"
+        "        Console.WriteLine(wrapped);\n"
+        "    }\n}\n"
+    )
+    assert _flows(tmp_path / "c", clean, cs.CSharpFrontend.HYBRID) == set()


### PR DESCRIPTION
Slice 1 of #1187 (the issue stays open for the IOperation, SymbolFinder, and source-generator families). C# has the repo's deepest semantic integration, yet its FLOWS_TO edges came from the lexical lean walk; the compilation the bundled Roslyn tool already builds knows the real answer.

## Two new fact families

`Frontend.cs` computes both with `SemanticModel.AnalyzeDataFlow`, keyed at NAME tokens exactly like the existing call facts (same UTF-8 byte-column join contract):

- **`arg_flows`** — per invocation argument, the locals/parameters whose values reach it. Collected BEFORE the first-party/external split, because the sinks that matter (`Console.WriteLine`) are external.
- **`bind_flows`** — per local declarator, the locals/parameters that reach its INITIALIZER. Without this the tainted value stops at the initializer expression and the bound variable looks clean to every later read, so the chain never reaches the sink.

A region Roslyn rejects (`ArgumentException`) or fails to analyse leaves the lexical walk in charge for that expression.

## Consumption

Both families thread through `CSharpSemanticFacts` → `SemanticFacts` → `DefinitionProcessor` → `TypeInferenceEngine` (shared references, same discipline as `csharp_call_sites`) into the lean flow walk: `_lean_bind` and `_js_arg_taints` UNION the taint of the proven symbols with their own syntactic reading. Additive by construction — the facts can only add taint the lexical reading missed, never remove an edge it found — and inert for every other language and whenever the frontend is off.

## The discriminator

```csharp
var token = Environment.GetEnvironmentVariable("K");
var wrapped = new StringBuilder().Append(token).ToString();
Console.WriteLine(wrapped);
```

`CSHARP_FRONTEND=treesitter` finds no flow (the walker cannot thread the builder chain); `hybrid` reports `resource::ENV::K -> resource::STDOUT::<dynamic>`. Both directions are asserted in one test, so the improvement cannot silently regress to parity. A clean local through the same chain yields nothing.

## Tests

`test_csharp_semantic_flow.py`: the discriminator pair (dotnet-gated), the clean-local negative, and a pure-Python unit test of the `arg_flows` parser (malformed rows drop, well-formed rows parse). Existing C# fact constructions updated for the two new families — kept required rather than defaulted, since mutable NamedTuple defaults would alias the maps the processors mutate. C#/flow battery green (574 passed) with the two known dotnet-dependent oracle files deselected; they fail on main in this environment too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added C# argument-flow and variable-binding flow analysis.
  * Improved taint and data-flow tracking across method calls, arguments, and variable initializers.
  * Added support for common C# invocation shapes, including conditional access and generic methods.
  * Filtered malformed or empty analysis results while preserving valid flow information.

* **Bug Fixes**
  * Prevented stale flow data from carrying over between analysis runs.

* **Tests**
  * Added coverage for flow parsing, chained calls, callee resolution, and untainted variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->