### PR TITLE
fix: skip distributions whose metadata cannot be read when fingerprinting parsers

### DIFF
--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -922,3 +922,7 @@ GENERATED_SOURCES_REGISTERED = (
 )
 DELOMBOK_RUN_FAILED = "delombok run failed ({error}); parsing raw source"
 DELOMBOK_OVERLAY_BUILT = "Delombok overlay covers {count} Lombok-affected file(s)"
+FINGERPRINT_DIST_UNREADABLE = (
+    "Skipping a distribution whose metadata could not be read while computing "
+    "the parser fingerprint"
+)

--- a/codebase_rag/parser_fingerprint.py
+++ b/codebase_rag/parser_fingerprint.py
@@ -8,7 +8,10 @@ import hashlib
 from importlib import metadata
 from pathlib import Path
 
+from loguru import logger
+
 from . import constants as cs
+from . import logs as ls
 
 
 def compute_parser_fingerprint(
@@ -99,9 +102,27 @@ def _fingerprint_sources(root: Path) -> list[Path]:
     return sorted(sources)
 
 
+def _grammar_entry(dist: metadata.Distribution) -> str | None:
+    # Reading a distribution's metadata can raise, not just return None: a
+    # half-written or malformed dist-info anywhere in site-packages makes
+    # importlib_metadata fail inside the `name` property. That must not abort
+    # the whole index run, so an unreadable distribution is skipped -- it can
+    # only be one this fingerprint would have listed, and a MISSING grammar
+    # entry changes the fingerprint, which already surfaces as the
+    # stale-graph warning rather than a silent wrong answer (issue #1339).
+    try:
+        name = dist.name
+        if not name or not name.lower().startswith(cs.GRAMMAR_DIST_PREFIX):
+            return None
+        return cs.GRAMMAR_VERSION_FMT.format(name=name.lower(), version=dist.version)
+    except Exception:
+        logger.debug(ls.FINGERPRINT_DIST_UNREADABLE)
+        return None
+
+
 def _grammar_versions() -> list[str]:
     return sorted(
-        cs.GRAMMAR_VERSION_FMT.format(name=dist.name.lower(), version=dist.version)
+        entry
         for dist in metadata.distributions()
-        if dist.name and dist.name.lower().startswith(cs.GRAMMAR_DIST_PREFIX)
+        if (entry := _grammar_entry(dist)) is not None
     )

--- a/codebase_rag/tests/test_parser_fingerprint_robustness.py
+++ b/codebase_rag/tests/test_parser_fingerprint_robustness.py
@@ -1,0 +1,53 @@
+# Issue #1339: a broken or half-written dist-info anywhere in site-packages
+# made importlib_metadata raise inside `dist.name`, and that propagated out of
+# compute_parser_fingerprint, aborting the whole index run. An unreadable
+# distribution must be skipped instead.
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag import parser_fingerprint as pf
+
+
+class _UnreadableDistribution:
+    """Mirrors importlib_metadata's failure mode: the property raises."""
+
+    @property
+    def name(self) -> str:
+        raise TypeError("'NoneType' object is not subscriptable")
+
+    @property
+    def version(self) -> str:
+        raise TypeError("'NoneType' object is not subscriptable")
+
+
+class _GrammarDistribution:
+    def __init__(self, name: str, version: str) -> None:
+        self.name = name
+        self.version = version
+
+
+def test_unreadable_distribution_is_skipped(monkeypatch: pytest.MonkeyPatch) -> None:
+    good = _GrammarDistribution(f"{cs.GRAMMAR_DIST_PREFIX}python", "0.23.0")
+    monkeypatch.setattr(
+        pf.metadata,
+        "distributions",
+        lambda: iter([_UnreadableDistribution(), good]),
+    )
+    versions = pf._grammar_versions()
+    assert versions == [
+        cs.GRAMMAR_VERSION_FMT.format(name=good.name.lower(), version=good.version)
+    ]
+
+
+def test_fingerprint_survives_an_unreadable_distribution(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        pf.metadata, "distributions", lambda: iter([_UnreadableDistribution()])
+    )
+    fingerprint = pf.compute_parser_fingerprint(repo_path=tmp_path)
+    assert fingerprint

--- a/codebase_rag/tests/test_parser_fingerprint_robustness.py
+++ b/codebase_rag/tests/test_parser_fingerprint_robustness.py
@@ -24,6 +24,19 @@ class _UnreadableDistribution:
         raise TypeError("'NoneType' object is not subscriptable")
 
 
+class _UnreadableVersionDistribution:
+    """A grammar distribution whose NAME reads fine but whose version does
+    not: the guard must cover the second read too, not just the first."""
+
+    @property
+    def name(self) -> str:
+        return f"{cs.GRAMMAR_DIST_PREFIX}rust"
+
+    @property
+    def version(self) -> str:
+        raise TypeError("'NoneType' object is not subscriptable")
+
+
 class _GrammarDistribution:
     def __init__(self, name: str, version: str) -> None:
         self.name = name
@@ -51,3 +64,15 @@ def test_fingerprint_survives_an_unreadable_distribution(
     )
     fingerprint = pf.compute_parser_fingerprint(repo_path=tmp_path)
     assert fingerprint
+
+
+def test_unreadable_version_is_skipped(monkeypatch: pytest.MonkeyPatch) -> None:
+    good = _GrammarDistribution(f"{cs.GRAMMAR_DIST_PREFIX}python", "0.23.0")
+    monkeypatch.setattr(
+        pf.metadata,
+        "distributions",
+        lambda: iter([_UnreadableVersionDistribution(), good]),
+    )
+    assert pf._grammar_versions() == [
+        cs.GRAMMAR_VERSION_FMT.format(name=good.name.lower(), version=good.version)
+    ]


### PR DESCRIPTION
Closes #1339.

`_grammar_versions` read `dist.name` unguarded while iterating every installed distribution. Reading distribution metadata can RAISE rather than return None — a half-written or malformed dist-info anywhere in site-packages makes importlib_metadata fail inside the `name` property with `TypeError: 'NoneType' object is not subscriptable` — and that propagated out of `compute_parser_fingerprint`, aborting the entire index run over a package the graph never touches.

Found when a background suite run raced a concurrent `uv run` that was reinstalling the project, but the environment is only the trigger: any broken third-party dist-info reproduces it.

## Fix

Each distribution is now read through a guarded `_grammar_entry` helper: an unreadable one is skipped with a debug log instead of raising. The degradation is honest — a skipped distribution can only be one this fingerprint would have listed, and a missing grammar entry CHANGES the fingerprint, which already surfaces through the existing stale-graph warning rather than silently claiming the graph is current.

## Tests

`test_parser_fingerprint_robustness.py` uses a stub distribution whose `name`/`version` properties raise (mirroring importlib_metadata's failure mode): the unreadable entry is skipped while a real grammar distribution still lists, and `compute_parser_fingerprint` completes when EVERY distribution is unreadable. Verified RED — both tests fail with the guard narrowed away — and the fingerprint battery is green (27 passed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parser fingerprint generation when package metadata cannot be read.
  * Unreadable distributions are now skipped instead of interrupting fingerprint generation.
  * Fingerprints can still be generated when all discovered distributions are unreadable.

* **Tests**
  * Added coverage for handling invalid or inaccessible distribution metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->