### PR TITLE
feat: bundled javac fact provider attributes Java call sites

### DIFF
--- a/codebase_rag/config.py
+++ b/codebase_rag/config.py
@@ -213,6 +213,7 @@ class AppConfig(BaseSettings):
     # tree-sitter stays the standalone-correct backbone.
     GO_FRONTEND: cs.GoFrontend = cs.GoFrontend.AUTO
     PYTHON_FRONTEND: cs.PythonFrontend = cs.PythonFrontend.HEURISTIC
+    JAVA_FRONTEND: cs.JavaFrontend = cs.JavaFrontend.HEURISTIC
     LOMBOK_JAR: str | None = None
     CAPTURE_FUNCTION_LOCAL_DEFINITIONS: bool = Field(
         True, validation_alias="CGR_CAPTURE_LOCAL_DEFINITIONS"

--- a/codebase_rag/constants/core.py
+++ b/codebase_rag/constants/core.py
@@ -150,6 +150,7 @@ PARSER_FINGERPRINT_TOOL_GLOBS: tuple[str, ...] = ("*.cs", "*.csproj")
 PARSER_FINGERPRINT_TOOL_SOURCES: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("parsers/csharp_frontend/roslyn", ("*.cs", "*.csproj")),
     ("parsers/go_frontend/gotypes", ("*.go", "*.mod", "*.sum")),
+    ("parsers/java_frontend/javac", ("*.java",)),
 )
 GRAMMAR_DIST_PREFIX = "tree-sitter"
 GRAMMAR_VERSION_FMT = "{name}=={version}"

--- a/codebase_rag/constants/core.py
+++ b/codebase_rag/constants/core.py
@@ -150,7 +150,7 @@ PARSER_FINGERPRINT_TOOL_GLOBS: tuple[str, ...] = ("*.cs", "*.csproj")
 PARSER_FINGERPRINT_TOOL_SOURCES: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("parsers/csharp_frontend/roslyn", ("*.cs", "*.csproj")),
     ("parsers/go_frontend/gotypes", ("*.go", "*.mod", "*.sum")),
-    ("parsers/java_frontend/javac", ("*.java",)),
+    ("parsers/java_frontend/javac", ("**/*.java",)),
 )
 GRAMMAR_DIST_PREFIX = "tree-sitter"
 GRAMMAR_VERSION_FMT = "{name}=={version}"

--- a/codebase_rag/constants/languages.py
+++ b/codebase_rag/constants/languages.py
@@ -116,6 +116,15 @@ class CSharpFrontend(StrEnum):
     HYBRID = "hybrid"
 
 
+class JavaFrontend(StrEnum):
+    # HEURISTIC is the default: the tree-sitter walkers plus the name trie.
+    # JAVAC layers the Compiler Tree API's attributed facts on top (issue
+    # #1181); it degrades to HEURISTIC without a JDK, and the parser
+    # fingerprint records the RESOLVED mode.
+    HEURISTIC = "heuristic"
+    JAVAC = "javac"
+
+
 class PythonFrontend(StrEnum):
     # HEURISTIC is the default: the tree-sitter walkers plus the name trie.
     # JEDI layers in-process semantic facts on top (issue #1183); it degrades
@@ -433,3 +442,7 @@ IGNORE_SUFFIXES = frozenset(
 
 # pathspec style for .cgrignore / --exclude patterns (#495).
 GITWILDMATCH_STYLE = "gitignore"
+
+# JDK binaries the Java frontend probes and runs (issue #1181).
+JAVAC_BIN = "javac"
+JAVA_BIN = "java"

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -926,3 +926,14 @@ FINGERPRINT_DIST_UNREADABLE = (
     "Skipping a distribution whose metadata could not be read while computing "
     "the parser fingerprint"
 )
+JAVA_FRONTEND_RUNNING = "javac frontend: attributing Java sources"
+JAVA_FRONTEND_BUILD_FAILED = (
+    "javac frontend tool build failed ({stderr}); using tree-sitter"
+)
+JAVA_FRONTEND_RUN_FAILED = "javac frontend did not finish ({error}); using tree-sitter"
+JAVA_FRONTEND_PARSE_FAILED = (
+    "javac frontend emitted unreadable output (stdout={stdout}, stderr={stderr})"
+)
+JAVA_FRONTEND_FACTS = (
+    "javac facts: {calls} resolved call sites, {externals} external sites"
+)

--- a/codebase_rag/parser_fingerprint.py
+++ b/codebase_rag/parser_fingerprint.py
@@ -69,6 +69,7 @@ def _frontend_settings() -> list[str]:
     from .parsers.cpp_frontend import resolve_cpp_frontend
     from .parsers.csharp_frontend import resolve_csharp_frontend
     from .parsers.go_frontend import resolve_go_frontend
+    from .parsers.java_frontend import resolve_java_frontend
     from .parsers.java_lombok import current_lombok_version
     from .parsers.py_frontend import resolve_python_frontend
 
@@ -77,6 +78,7 @@ def _frontend_settings() -> list[str]:
         f"CSHARP_FRONTEND={resolve_csharp_frontend().value}",
         f"GO_FRONTEND={resolve_go_frontend().value}",
         f"PYTHON_FRONTEND={resolve_python_frontend().value}",
+        f"JAVA_FRONTEND={resolve_java_frontend().value}",
         f"LOMBOK={current_lombok_version() or 'absent'}",
     ]
 

--- a/codebase_rag/parsers/frontends/__init__.py
+++ b/codebase_rag/parsers/frontends/__init__.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 # Import for side effect: each frontend module self-registers into the registry.
 from . import csharp as _csharp  # noqa: E402,F401  (registers CSharpFrontend)
 from . import go as _go  # noqa: E402,F401  (registers GoFrontend)
+from . import java as _java  # noqa: E402,F401  (registers JavaJavacFrontend)
 from . import python as _python  # noqa: E402,F401  (registers PythonJediFrontend)
 from .protocol import (
     CallSiteKey,

--- a/codebase_rag/parsers/frontends/java.py
+++ b/codebase_rag/parsers/frontends/java.py
@@ -38,6 +38,9 @@ class JavaJavacFrontend:
         return repo_path.exists()
 
     def run(self, repo_path: Path, files: Sequence[Path]) -> SemanticFacts:
+        # Stage 1 attributes the whole repo in one javac run: a narrowed file
+        # list cannot bind calls whose targets live in the files it omits.
+        del files
         return _adapt_java_semantic_facts(run_java_frontend(repo_path))
 
 

--- a/codebase_rag/parsers/frontends/java.py
+++ b/codebase_rag/parsers/frontends/java.py
@@ -1,0 +1,44 @@
+"""Java LanguageFrontend registration (issue #1181): the bundled javac fact
+provider. Availability is a working JDK; the tool builds once into the cache
+under the shared build lock."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+from ...constants.languages import SupportedLanguage
+from ..java_frontend import java_frontend_available, run_java_frontend
+from .protocol import ResolvedCallSite, SemanticFacts
+from .registry import register_frontend
+
+
+def _adapt_java_semantic_facts(facts) -> SemanticFacts:
+    # JavaCallSite and ResolvedCallSite are structurally identical.
+    return SemanticFacts(
+        resolved_call_sites={
+            key: ResolvedCallSite(
+                site.name, site.target_file, site.target_line, site.target_col
+            )
+            for key, site in facts.call_sites.items()
+        },
+        external_sites=set(facts.external_sites),
+    )
+
+
+class JavaJavacFrontend:
+    """Compiler Tree API fact provider for Java."""
+
+    language: SupportedLanguage = SupportedLanguage.JAVA
+
+    def available(self) -> bool:
+        return java_frontend_available()
+
+    def applies(self, repo_path: Path) -> bool:
+        return repo_path.exists()
+
+    def run(self, repo_path: Path, files: Sequence[Path]) -> SemanticFacts:
+        return _adapt_java_semantic_facts(run_java_frontend(repo_path))
+
+
+register_frontend(JavaJavacFrontend())

--- a/codebase_rag/parsers/java_frontend/__init__.py
+++ b/codebase_rag/parsers/java_frontend/__init__.py
@@ -1,0 +1,15 @@
+from .frontend import (
+    JavaCallSite,
+    JavaSemanticFacts,
+    java_frontend_available,
+    resolve_java_frontend,
+    run_java_frontend,
+)
+
+__all__ = [
+    "JavaCallSite",
+    "JavaSemanticFacts",
+    "java_frontend_available",
+    "resolve_java_frontend",
+    "run_java_frontend",
+]

--- a/codebase_rag/parsers/java_frontend/frontend.py
+++ b/codebase_rag/parsers/java_frontend/frontend.py
@@ -1,0 +1,213 @@
+"""Bundled javac fact provider for Java (issue #1181).
+
+Java's resolution is the largest pure-heuristic stack in the repo: it matches
+by name and arity where the language resolves overloads BY ARGUMENT TYPE. The
+JDK ships the authoritative answer in the Compiler Tree API, so a small
+bundled tool parses and ATTRIBUTES the repo's sources and emits the two
+standard fact families.
+
+Stage 1 attributes without the project classpath: intra-repo binding is still
+exact, and a symbol that resolves outside repo source becomes an external
+proof. An unattributed site (a genuinely missing dependency) emits nothing at
+all, leaving the heuristics in charge -- a miss is never mistaken for a proof.
+Any missing piece (no JDK, a build failure, a crash) degrades to pure
+tree-sitter, the standing frontend invariant.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import NamedTuple
+
+from loguru import logger
+
+from ... import constants as cs
+from ... import logs as ls
+from ...config import settings
+from ..build_lock import acquire_build_lock, release_build_lock
+from ..frontends.protocol import CallSiteKey
+
+_TOOL_SRC = Path(__file__).parent / "javac"
+_TOOL_SOURCE = "Frontend.java"
+_MAIN_CLASS = "Frontend"
+_CLASS_FILE = "Frontend.class"
+_BUILD_LOCK = ".build-lock"
+_LOCK_TRIES = 600
+_LOCK_POLL_SECONDS = 0.5
+_RUN_TIMEOUT = 900
+_PROBE_TIMEOUT = 10.0
+
+
+class JavaCallSite(NamedTuple):
+    """The declaration a call binds to, per javac's attribution."""
+
+    name: str
+    target_file: str
+    target_line: int
+    target_col: int
+
+
+class JavaSemanticFacts(NamedTuple):
+    """Everything one javac run learned about the repo."""
+
+    call_sites: dict[CallSiteKey, JavaCallSite]
+    external_sites: set[CallSiteKey]
+
+
+def _empty_facts() -> JavaSemanticFacts:
+    # A fresh instance per failure path: the maps are handed to mutable
+    # processor state, so a shared constant would alias across runs.
+    return JavaSemanticFacts({}, set())
+
+
+def _toolchain_runs(binary: str) -> bool:
+    # `which` only proves the binary exists. macOS ships stub shims that exit
+    # non-zero the moment they run, so a which-only check reports a JDK that
+    # is not there; require a clean `-version`.
+    path = shutil.which(binary)
+    if path is None:
+        return False
+    try:
+        proc = subprocess.run(
+            [path, "-version"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_PROBE_TIMEOUT,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return proc.returncode == 0
+
+
+def java_frontend_available() -> bool:
+    return _toolchain_runs(cs.JAVAC_BIN) and _toolchain_runs(cs.JAVA_BIN)
+
+
+def resolve_java_frontend() -> cs.JavaFrontend:
+    # The single source of truth for the EFFECTIVE frontend; the parser
+    # fingerprint records the RESOLVED mode so a javac-backed graph and a
+    # heuristic one never share an identity.
+    mode = settings.JAVA_FRONTEND
+    if mode == cs.JavaFrontend.HEURISTIC:
+        return mode
+    if not java_frontend_available():
+        return cs.JavaFrontend.HEURISTIC
+    return cs.JavaFrontend.JAVAC
+
+
+def _cache_dir() -> Path:
+    return settings.CGR_HOME.expanduser() / "java_javac"
+
+
+def _class_fresh(out_dir: Path) -> bool:
+    compiled = out_dir / _CLASS_FILE
+    if not compiled.is_file():
+        return False
+    return compiled.stat().st_mtime >= (_TOOL_SRC / _TOOL_SOURCE).stat().st_mtime
+
+
+def _build_tool(javac: str) -> Path | None:
+    cache = _cache_dir()
+    out_dir = cache / "out"
+    if _class_fresh(out_dir):
+        return out_dir
+    cache.mkdir(parents=True, exist_ok=True)
+    handle = acquire_build_lock(
+        cache / _BUILD_LOCK,
+        lambda: _class_fresh(out_dir),
+        _LOCK_TRIES,
+        _LOCK_POLL_SECONDS,
+    )
+    if handle is None:
+        return out_dir if _class_fresh(out_dir) else None
+    try:
+        if not _class_fresh(out_dir):
+            out_dir.mkdir(parents=True, exist_ok=True)
+            proc = subprocess.run(
+                [javac, "-d", str(out_dir), str(_TOOL_SRC / _TOOL_SOURCE)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if proc.returncode != 0:
+                logger.warning(
+                    ls.JAVA_FRONTEND_BUILD_FAILED.format(stderr=proc.stderr.strip())
+                )
+                return None
+    finally:
+        release_build_lock(handle)
+    return out_dir if _class_fresh(out_dir) else None
+
+
+def _parse_payload(stdout: str, stderr: str = "") -> JavaSemanticFacts:
+    lines = [line for line in stdout.splitlines() if line.strip()]
+    if not lines:
+        logger.error(ls.JAVA_FRONTEND_PARSE_FAILED.format(stdout=stdout, stderr=stderr))
+        return _empty_facts()
+    try:
+        payload = json.loads(lines[-1])
+    except json.JSONDecodeError:
+        logger.error(ls.JAVA_FRONTEND_PARSE_FAILED.format(stdout=stdout, stderr=stderr))
+        return _empty_facts()
+    if not isinstance(payload, dict):
+        logger.error(ls.JAVA_FRONTEND_PARSE_FAILED.format(stdout=stdout, stderr=stderr))
+        return _empty_facts()
+    facts = _empty_facts()
+    for site in payload.get("calls", []):
+        try:
+            key: CallSiteKey = (
+                site["file"],
+                int(site["line"]),
+                int(site["col"]),
+                site["name"],
+            )
+            facts.call_sites[key] = JavaCallSite(
+                site["name"],
+                site["tfile"],
+                int(site["tline"]),
+                int(site["tcol"]),
+            )
+        except (KeyError, TypeError, ValueError):
+            # A malformed row drops rather than failing the payload: those
+            # sites fall back to the heuristics.
+            continue
+    for site in payload.get("externals", []):
+        try:
+            facts.external_sites.add(
+                (site["file"], int(site["line"]), int(site["col"]), site["name"])
+            )
+        except (KeyError, TypeError, ValueError):
+            continue
+    return facts
+
+
+def run_java_frontend(repo_path: Path) -> JavaSemanticFacts:
+    javac = shutil.which(cs.JAVAC_BIN)
+    java = shutil.which(cs.JAVA_BIN)
+    if javac is None or java is None:
+        return _empty_facts()
+    out_dir = _build_tool(javac)
+    if out_dir is None:
+        return _empty_facts()
+    logger.info(ls.JAVA_FRONTEND_RUNNING)
+    try:
+        proc = subprocess.run(
+            [java, "-cp", str(out_dir), _MAIN_CLASS, str(repo_path)],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_RUN_TIMEOUT,
+            env={
+                **os.environ,
+                "CGR_IGNORE_DIRS": ",".join(sorted(cs.IGNORE_PATTERNS)),
+            },
+        )
+    except (subprocess.SubprocessError, OSError) as error:
+        logger.warning(ls.JAVA_FRONTEND_RUN_FAILED.format(error=error))
+        return _empty_facts()
+    return _parse_payload(proc.stdout, proc.stderr)

--- a/codebase_rag/parsers/java_frontend/frontend.py
+++ b/codebase_rag/parsers/java_frontend/frontend.py
@@ -33,8 +33,8 @@ from ..frontends.protocol import CallSiteKey
 
 _TOOL_SRC = Path(__file__).parent / "javac"
 _TOOL_SOURCE = "Frontend.java"
-_MAIN_CLASS = "Frontend"
-_CLASS_FILE = "Frontend.class"
+_MAIN_CLASS = "cgr.Frontend"
+_CLASS_FILE = "cgr/Frontend.class"
 _BUILD_LOCK = ".build-lock"
 _LOCK_TRIES = 600
 _LOCK_POLL_SECONDS = 0.5
@@ -215,6 +215,8 @@ def run_java_frontend(repo_path: Path) -> JavaSemanticFacts:
             [java, "-cp", str(out_dir), _MAIN_CLASS, str(repo_path)],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             check=False,
             timeout=_RUN_TIMEOUT,
             env={

--- a/codebase_rag/parsers/java_frontend/frontend.py
+++ b/codebase_rag/parsers/java_frontend/frontend.py
@@ -36,6 +36,7 @@ _TOOL_SOURCE = "Frontend.java"
 _MAIN_CLASS = "cgr.Frontend"
 _CLASS_FILE = "cgr/Frontend.class"
 _BUILD_LOCK = ".build-lock"
+_STAGING_DIR = "staging"
 _LOCK_TRIES = 600
 _LOCK_POLL_SECONDS = 0.5
 _BUILD_TIMEOUT = 120
@@ -127,29 +128,48 @@ def _build_tool(javac: str) -> Path | None:
     if handle is None:
         return out_dir if _class_fresh(out_dir) else None
     try:
-        if not _class_fresh(out_dir):
-            out_dir.mkdir(parents=True, exist_ok=True)
-            try:
-                proc = subprocess.run(
-                    [javac, "-d", str(out_dir), str(_TOOL_SRC / _TOOL_SOURCE)],
-                    capture_output=True,
-                    text=True,
-                    check=False,
-                    timeout=_BUILD_TIMEOUT,
-                )
-            except (subprocess.SubprocessError, OSError) as error:
-                # A stalled toolchain must not hold indexing hostage: the
-                # frontend degrades to tree-sitter like every other failure.
-                logger.warning(ls.JAVA_FRONTEND_BUILD_FAILED.format(stderr=error))
-                return None
-            if proc.returncode != 0:
-                logger.warning(
-                    ls.JAVA_FRONTEND_BUILD_FAILED.format(stderr=proc.stderr.strip())
-                )
-                return None
+        if not _class_fresh(out_dir) and not _compile_tool(javac, cache, out_dir):
+            return None
     finally:
         release_build_lock(handle)
     return out_dir if _class_fresh(out_dir) else None
+
+
+def _compile_tool(javac: str, cache: Path, out_dir: Path) -> bool:
+    # Compile into a staging directory and publish by rename: a build killed
+    # mid-write would otherwise leave a truncated class file whose mtime looks
+    # fresh, and every later run would launch it, fail, and degrade -- for
+    # good. A crash between the two steps leaves no build at all, which the
+    # next run simply repeats.
+    staging = cache / _STAGING_DIR
+    shutil.rmtree(staging, ignore_errors=True)
+    staging.mkdir(parents=True, exist_ok=True)
+    try:
+        proc = subprocess.run(
+            [javac, "-d", str(staging), str(_TOOL_SRC / _TOOL_SOURCE)],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_BUILD_TIMEOUT,
+        )
+    except (subprocess.SubprocessError, OSError) as error:
+        # A stalled toolchain must not hold indexing hostage: the frontend
+        # degrades to tree-sitter like every other failure.
+        logger.warning(ls.JAVA_FRONTEND_BUILD_FAILED.format(stderr=error))
+        shutil.rmtree(staging, ignore_errors=True)
+        return False
+    if proc.returncode != 0:
+        logger.warning(ls.JAVA_FRONTEND_BUILD_FAILED.format(stderr=proc.stderr.strip()))
+        shutil.rmtree(staging, ignore_errors=True)
+        return False
+    try:
+        shutil.rmtree(out_dir, ignore_errors=True)
+        staging.rename(out_dir)
+    except OSError as error:
+        logger.warning(ls.JAVA_FRONTEND_BUILD_FAILED.format(stderr=error))
+        shutil.rmtree(staging, ignore_errors=True)
+        return False
+    return True
 
 
 def _parse_payload(stdout: str, stderr: str = "") -> JavaSemanticFacts:

--- a/codebase_rag/parsers/java_frontend/frontend.py
+++ b/codebase_rag/parsers/java_frontend/frontend.py
@@ -38,6 +38,7 @@ _CLASS_FILE = "Frontend.class"
 _BUILD_LOCK = ".build-lock"
 _LOCK_TRIES = 600
 _LOCK_POLL_SECONDS = 0.5
+_BUILD_TIMEOUT = 120
 _RUN_TIMEOUT = 900
 _PROBE_TIMEOUT = 10.0
 
@@ -128,12 +129,19 @@ def _build_tool(javac: str) -> Path | None:
     try:
         if not _class_fresh(out_dir):
             out_dir.mkdir(parents=True, exist_ok=True)
-            proc = subprocess.run(
-                [javac, "-d", str(out_dir), str(_TOOL_SRC / _TOOL_SOURCE)],
-                capture_output=True,
-                text=True,
-                check=False,
-            )
+            try:
+                proc = subprocess.run(
+                    [javac, "-d", str(out_dir), str(_TOOL_SRC / _TOOL_SOURCE)],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                    timeout=_BUILD_TIMEOUT,
+                )
+            except (subprocess.SubprocessError, OSError) as error:
+                # A stalled toolchain must not hold indexing hostage: the
+                # frontend degrades to tree-sitter like every other failure.
+                logger.warning(ls.JAVA_FRONTEND_BUILD_FAILED.format(stderr=error))
+                return None
             if proc.returncode != 0:
                 logger.warning(
                     ls.JAVA_FRONTEND_BUILD_FAILED.format(stderr=proc.stderr.strip())
@@ -157,8 +165,15 @@ def _parse_payload(stdout: str, stderr: str = "") -> JavaSemanticFacts:
     if not isinstance(payload, dict):
         logger.error(ls.JAVA_FRONTEND_PARSE_FAILED.format(stdout=stdout, stderr=stderr))
         return _empty_facts()
+    calls = payload.get("calls", [])
+    externals = payload.get("externals", [])
     facts = _empty_facts()
-    for site in payload.get("calls", []):
+    if not isinstance(calls, list) or not isinstance(externals, list):
+        # Well-formed JSON carrying the wrong types for the fact arrays: a
+        # tool contract violation, not a per-row defect.
+        logger.error(ls.JAVA_FRONTEND_PARSE_FAILED.format(stdout=stdout, stderr=stderr))
+        return facts
+    for site in calls:
         try:
             key: CallSiteKey = (
                 site["file"],
@@ -176,7 +191,7 @@ def _parse_payload(stdout: str, stderr: str = "") -> JavaSemanticFacts:
             # A malformed row drops rather than failing the payload: those
             # sites fall back to the heuristics.
             continue
-    for site in payload.get("externals", []):
+    for site in externals:
         try:
             facts.external_sites.add(
                 (site["file"], int(site["line"]), int(site["col"]), site["name"])
@@ -209,5 +224,14 @@ def run_java_frontend(repo_path: Path) -> JavaSemanticFacts:
         )
     except (subprocess.SubprocessError, OSError) as error:
         logger.warning(ls.JAVA_FRONTEND_RUN_FAILED.format(error=error))
+        return _empty_facts()
+    if proc.returncode != 0:
+        # Partial JSON from a run that then failed would be a partial view of
+        # the repo presented as a complete one.
+        logger.warning(
+            ls.JAVA_FRONTEND_RUN_FAILED.format(
+                error=proc.stderr.strip() or proc.returncode
+            )
+        )
         return _empty_facts()
     return _parse_payload(proc.stdout, proc.stderr)

--- a/codebase_rag/parsers/java_frontend/frontend.py
+++ b/codebase_rag/parsers/java_frontend/frontend.py
@@ -32,7 +32,7 @@ from ..build_lock import acquire_build_lock, release_build_lock
 from ..frontends.protocol import CallSiteKey
 
 _TOOL_SRC = Path(__file__).parent / "javac"
-_TOOL_SOURCE = "Frontend.java"
+_TOOL_SOURCE = "cgr/Frontend.java"
 _MAIN_CLASS = "cgr.Frontend"
 _CLASS_FILE = "cgr/Frontend.class"
 _BUILD_LOCK = ".build-lock"

--- a/codebase_rag/parsers/java_frontend/javac/Frontend.java
+++ b/codebase_rag/parsers/java_frontend/javac/Frontend.java
@@ -10,6 +10,8 @@
 // discarded. Emits one JSON line: {"calls": [...], "externals": [...]},
 // each keyed on the callee NAME token as (file, line, byte col, name) --
 // the same join contract the C# and Go frontends use.
+package cgr;
+
 import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.IdentifierTree;
@@ -22,7 +24,10 @@ import com.sun.source.util.SourcePositions;
 import com.sun.source.util.TreePath;
 import com.sun.source.util.TreePathScanner;
 import com.sun.source.util.Trees;
+import java.io.FileDescriptor;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -47,25 +52,38 @@ import javax.tools.ToolProvider;
 
 public final class Frontend {
 
+    private static final String EMPTY_PAYLOAD = "{\"calls\":[],\"externals\":[]}";
+
     private Frontend() {
     }
 
     public static void main(String[] args) throws Exception {
+        emit(payload(args));
+    }
+
+    // The payload is a wire format, so the stream is pinned to UTF-8: on the
+    // JDK 17 floor `System.out` still encodes with the platform default, which
+    // would mangle a non-ASCII identifier on a cp1252 host.
+    private static void emit(String payload) {
+        PrintStream out = new PrintStream(
+                new FileOutputStream(FileDescriptor.out), true, StandardCharsets.UTF_8);
+        out.println(payload);
+        out.flush();
+    }
+
+    private static String payload(String[] args) throws Exception {
         if (args.length < 1) {
-            System.out.println("{\"calls\":[],\"externals\":[]}");
-            return;
+            return EMPTY_PAYLOAD;
         }
         Path root = Paths.get(args[0]).toRealPath();
         Set<String> ignored = ignoredDirs();
         List<Path> sources = javaSources(root, ignored);
         if (sources.isEmpty()) {
-            System.out.println("{\"calls\":[],\"externals\":[]}");
-            return;
+            return EMPTY_PAYLOAD;
         }
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         if (compiler == null) {
-            System.out.println("{\"calls\":[],\"externals\":[]}");
-            return;
+            return EMPTY_PAYLOAD;
         }
         DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
         try (StandardJavaFileManager fileManager =
@@ -81,7 +99,7 @@ public final class Frontend {
             for (CompilationUnitTree unit : parsed) {
                 collector.collect(unit);
             }
-            System.out.println(collector.toJson());
+            return collector.toJson();
         }
     }
 
@@ -153,11 +171,11 @@ public final class Frontend {
 
         @Override
         public Void visitMethodInvocation(MethodInvocationTree node, Void ignored) {
-            record(node);
+            recordCall(node);
             return super.visitMethodInvocation(node, ignored);
         }
 
-        private void record(MethodInvocationTree node) {
+        private void recordCall(MethodInvocationTree node) {
             ExpressionTree select = node.getMethodSelect();
             String name = calleeName(select);
             if (name == null || name.equals("super") || name.equals("this")) {
@@ -229,21 +247,25 @@ public final class Frontend {
         private static int nameTokenOffset(String source, String name, int start, int end) {
             for (int at = source.indexOf(name, start); at >= 0 && at < end;
                     at = source.indexOf(name, at + 1)) {
-                if (at > 0 && Character.isJavaIdentifierPart(source.charAt(at - 1))) {
-                    continue;
-                }
-                if (isAnnotationName(source, at)) {
-                    continue;
-                }
-                int after = at + name.length();
-                while (after < end && Character.isWhitespace(source.charAt(after))) {
-                    after++;
-                }
-                if (after < end && source.charAt(after) == '(') {
+                if (isDeclaredNameAt(source, name, at, end)) {
                     return at;
                 }
             }
             return -1;
+        }
+
+        private static boolean isDeclaredNameAt(String source, String name, int at, int end) {
+            if (at > 0 && Character.isJavaIdentifierPart(source.charAt(at - 1))) {
+                return false;
+            }
+            if (isAnnotationName(source, at)) {
+                return false;
+            }
+            int after = at + name.length();
+            while (after < end && Character.isWhitespace(source.charAt(after))) {
+                after++;
+            }
+            return after < end && source.charAt(after) == '(';
         }
 
         private String calleeName(ExpressionTree select) {

--- a/codebase_rag/parsers/java_frontend/javac/Frontend.java
+++ b/codebase_rag/parsers/java_frontend/javac/Frontend.java
@@ -12,6 +12,7 @@
 // the same join contract the C# and Go frontends use.
 package cgr;
 
+import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.IdentifierTree;
@@ -233,33 +234,59 @@ public final class Frontend {
             if (source == null) {
                 return null;
             }
-            int at = nameTokenOffset(source, name, (int) start, (int) Math.min(end, source.length()));
+            MethodTree method = (MethodTree) tree;
+            int at = nameTokenOffset(
+                    source,
+                    name,
+                    (int) start,
+                    (int) Math.min(end, source.length()),
+                    annotationRanges(declUnit, method));
             if (at < 0) {
                 return null;
             }
             return position(declUnit, declRel, at);
         }
 
+        // A MethodTree starts at its modifiers, so its annotations are part of
+        // the header text being searched. Their SOURCE RANGES come from the
+        // AST rather than a lexical scan: an annotation may share the method's
+        // name, carry parenthesised arguments, be qualified, or hold a comment
+        // between the '@' and the name, and the parser has already settled all
+        // of that.
+        private long[][] annotationRanges(CompilationUnitTree declUnit, MethodTree method) {
+            List<? extends AnnotationTree> annotations = method.getModifiers().getAnnotations();
+            long[][] ranges = new long[annotations.size()][2];
+            for (int i = 0; i < ranges.length; i++) {
+                AnnotationTree annotation = annotations.get(i);
+                ranges[i][0] = positions.getStartPosition(declUnit, annotation);
+                ranges[i][1] = positions.getEndPosition(declUnit, annotation);
+            }
+            return ranges;
+        }
+
         // The declaration's NAME token, matching the key the tree-sitter side
-        // produces. Annotations belong to the method header and may carry
-        // parenthesised arguments, so the first '(' is not a reliable bound:
-        // take the first identifier-bounded occurrence that a '(' follows.
-        private static int nameTokenOffset(String source, String name, int start, int end) {
+        // produces: the first identifier-bounded occurrence outside every
+        // annotation that a '(' follows.
+        private static int nameTokenOffset(
+                String source, String name, int start, int end, long[][] annotations) {
             for (int at = source.indexOf(name, start); at >= 0 && at < end;
                     at = source.indexOf(name, at + 1)) {
-                if (isDeclaredNameAt(source, name, at, end)) {
+                if (isDeclaredNameAt(source, name, at, end, annotations)) {
                     return at;
                 }
             }
             return -1;
         }
 
-        private static boolean isDeclaredNameAt(String source, String name, int at, int end) {
+        private static boolean isDeclaredNameAt(
+                String source, String name, int at, int end, long[][] annotations) {
             if (at > 0 && Character.isJavaIdentifierPart(source.charAt(at - 1))) {
                 return false;
             }
-            if (isAnnotationName(source, at)) {
-                return false;
+            for (long[] range : annotations) {
+                if (range[0] >= 0 && at >= range[0] && at < range[1]) {
+                    return false;
+                }
             }
             int after = at + name.length();
             while (after < end && Character.isWhitespace(source.charAt(after))) {
@@ -284,22 +311,6 @@ public final class Frontend {
                 return end < 0 ? -1 : end - name.length();
             }
             return positions.getStartPosition(unit, select);
-        }
-
-        // A declaration annotation may share the method's name and carry
-        // arguments (@make() String make()), so the '(' test alone would
-        // select the annotation type.
-        private static boolean isAnnotationName(String source, int at) {
-            int before = at - 1;
-            while (before >= 0
-                    && (Character.isJavaIdentifierPart(source.charAt(before))
-                            || source.charAt(before) == '.')) {
-                before--;
-            }
-            while (before >= 0 && Character.isWhitespace(source.charAt(before))) {
-                before--;
-            }
-            return before >= 0 && source.charAt(before) == '@';
         }
 
         private int[] lineStartsOf(CompilationUnitTree tree, String source) {

--- a/codebase_rag/parsers/java_frontend/javac/Frontend.java
+++ b/codebase_rag/parsers/java_frontend/javac/Frontend.java
@@ -1,0 +1,329 @@
+// Java semantic fact provider (issue #1181), bundled and built once like the
+// Roslyn and gotypes tools. Java's resolution is the largest pure-heuristic
+// stack in the repo -- matching by name and arity where the language demands
+// overload resolution BY ARGUMENT TYPE -- and the JDK ships the authoritative
+// answer in the Compiler Tree API.
+//
+// Stage 1 attributes WITHOUT the project classpath: intra-repo binding is
+// still exact, and every symbol that does not resolve to repo source becomes
+// an external proof. Diagnostics from missing dependencies are expected and
+// discarded. Emits one JSON line: {"calls": [...], "externals": [...]},
+// each keyed on the callee NAME token as (file, line, byte col, name) --
+// the same join contract the C# and Go frontends use.
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.IdentifierTree;
+import com.sun.source.tree.MemberSelectTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.util.JavacTask;
+import com.sun.source.util.SourcePositions;
+import com.sun.source.util.TreePath;
+import com.sun.source.util.TreePathScanner;
+import com.sun.source.util.Trees;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+
+public final class Frontend {
+
+    private Frontend() {
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length < 1) {
+            System.out.println("{\"calls\":[],\"externals\":[]}");
+            return;
+        }
+        Path root = Paths.get(args[0]).toRealPath();
+        Set<String> ignored = ignoredDirs();
+        List<Path> sources = javaSources(root, ignored);
+        if (sources.isEmpty()) {
+            System.out.println("{\"calls\":[],\"externals\":[]}");
+            return;
+        }
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        if (compiler == null) {
+            System.out.println("{\"calls\":[],\"externals\":[]}");
+            return;
+        }
+        DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
+        try (StandardJavaFileManager fileManager =
+                compiler.getStandardFileManager(diagnostics, null, StandardCharsets.UTF_8)) {
+            Iterable<? extends JavaFileObject> units =
+                    fileManager.getJavaFileObjectsFromPaths(sources);
+            // -proc:none: never run repository-controlled annotation processors.
+            JavacTask task = (JavacTask) compiler.getTask(
+                    null, fileManager, diagnostics, Arrays.asList("-proc:none"), null, units);
+            Iterable<? extends CompilationUnitTree> parsed = task.parse();
+            task.analyze();
+            Collector collector = new Collector(root, Trees.instance(task));
+            for (CompilationUnitTree unit : parsed) {
+                collector.collect(unit);
+            }
+            System.out.println(collector.toJson());
+        }
+    }
+
+    private static Set<String> ignoredDirs() {
+        String raw = System.getenv("CGR_IGNORE_DIRS");
+        if (raw == null || raw.isEmpty()) {
+            return new HashSet<>();
+        }
+        return new HashSet<>(Arrays.asList(raw.split(",")));
+    }
+
+    private static List<Path> javaSources(Path root, Set<String> ignored) throws IOException {
+        try (var stream = Files.walk(root)) {
+            return stream
+                    .filter(Files::isRegularFile)
+                    .filter(p -> p.toString().endsWith(".java"))
+                    .filter(p -> {
+                        Path rel = root.relativize(p);
+                        for (Path part : rel) {
+                            if (ignored.contains(part.toString())) {
+                                return false;
+                            }
+                        }
+                        return true;
+                    })
+                    .collect(Collectors.toList());
+        }
+    }
+
+    private static final class Collector extends TreePathScanner<Void, Void> {
+        private final Path root;
+        private final Trees trees;
+        private final SourcePositions positions;
+        private final List<String> calls = new ArrayList<>();
+        private final Set<String> externals = new LinkedHashSet<>();
+        private final Set<String> seenCalls = new HashSet<>();
+        private final Map<String, String> sourceCache = new HashMap<>();
+        private CompilationUnitTree unit;
+        private String rel;
+
+        Collector(Path root, Trees trees) {
+            this.root = root;
+            this.trees = trees;
+            this.positions = trees.getSourcePositions();
+        }
+
+        void collect(CompilationUnitTree tree) {
+            String relative = relativize(tree);
+            if (relative == null) {
+                return;
+            }
+            this.unit = tree;
+            this.rel = relative;
+            scan(tree, null);
+        }
+
+        private String relativize(CompilationUnitTree tree) {
+            try {
+                Path path = Paths.get(tree.getSourceFile().toUri()).toRealPath();
+                if (!path.startsWith(root)) {
+                    return null;
+                }
+                return root.relativize(path).toString().replace('\\', '/');
+            } catch (IOException | IllegalArgumentException e) {
+                return null;
+            }
+        }
+
+        @Override
+        public Void visitMethodInvocation(MethodInvocationTree node, Void ignored) {
+            record(node);
+            return super.visitMethodInvocation(node, ignored);
+        }
+
+        private void record(MethodInvocationTree node) {
+            ExpressionTree select = node.getMethodSelect();
+            String name = calleeName(select);
+            if (name == null || name.equals("super") || name.equals("this")) {
+                // Implicit constructor delegation has no name token in the
+                // source, so the tree-sitter side has nothing to join to.
+                return;
+            }
+            Element element = trees.getElement(new TreePath(getCurrentPath(), select));
+            if (!(element instanceof ExecutableElement)) {
+                // Unattributed (a missing dependency): the heuristics stay in
+                // charge -- an unresolved site is never an external proof.
+                return;
+            }
+            long start = nameStart(select, name);
+            if (start < 0) {
+                return;
+            }
+            Position site = position(unit, rel, start);
+            if (site == null) {
+                return;
+            }
+            TreePath declaration = trees.getPath(element);
+            if (declaration == null) {
+                externals.add(externalJson(site, name));
+                return;
+            }
+            String declRel = relativize(declaration.getCompilationUnit());
+            if (declRel == null) {
+                externals.add(externalJson(site, name));
+                return;
+            }
+            Position target = declarationPosition(declaration, name, declRel);
+            if (target == null) {
+                return;
+            }
+            String key = site.line + ":" + site.col + ":" + name;
+            if (!seenCalls.add(key)) {
+                return;
+            }
+            calls.add(callJson(site, name, target));
+        }
+
+        private Position declarationPosition(TreePath declaration, String name, String declRel) {
+            Tree tree = declaration.getLeaf();
+            if (!(tree instanceof MethodTree)) {
+                return null;
+            }
+            CompilationUnitTree declUnit = declaration.getCompilationUnit();
+            long start = positions.getStartPosition(declUnit, tree);
+            long end = positions.getEndPosition(declUnit, tree);
+            if (start < 0 || end < 0) {
+                return null;
+            }
+            String source = sourceOf(declUnit);
+            if (source == null) {
+                return null;
+            }
+            // The declaration's NAME token, matching the tree-sitter side's
+            // key: search the header (never the body) for the identifier.
+            int header = source.indexOf('(', (int) start);
+            int limit = header < 0 ? (int) Math.min(end, source.length()) : header;
+            int at = source.lastIndexOf(name, limit);
+            if (at < (int) start) {
+                return null;
+            }
+            return position(declUnit, declRel, at);
+        }
+
+        private String calleeName(ExpressionTree select) {
+            if (select instanceof MemberSelectTree member) {
+                return member.getIdentifier().toString();
+            }
+            if (select instanceof IdentifierTree identifier) {
+                return identifier.getName().toString();
+            }
+            return null;
+        }
+
+        private long nameStart(ExpressionTree select, String name) {
+            if (select instanceof MemberSelectTree) {
+                long end = positions.getEndPosition(unit, select);
+                return end < 0 ? -1 : end - name.length();
+            }
+            return positions.getStartPosition(unit, select);
+        }
+
+        private String sourceOf(CompilationUnitTree tree) {
+            String key = tree.getSourceFile().toUri().toString();
+            String cached = sourceCache.get(key);
+            if (cached != null) {
+                return cached;
+            }
+            try {
+                String text = tree.getSourceFile().getCharContent(true).toString();
+                sourceCache.put(key, text);
+                return text;
+            } catch (IOException | UncheckedIOException e) {
+                return null;
+            }
+        }
+
+        // (1-based line, 0-based BYTE column) of a character offset: the join
+        // key the tree-sitter side produces, so UTF-8 width must be measured,
+        // never character counts.
+        private Position position(CompilationUnitTree tree, String relPath, long offset) {
+            String source = sourceOf(tree);
+            if (source == null || offset < 0 || offset > source.length()) {
+                return null;
+            }
+            int line = 1;
+            int lineStart = 0;
+            for (int i = 0; i < offset; i++) {
+                if (source.charAt(i) == '\n') {
+                    line++;
+                    lineStart = i + 1;
+                }
+            }
+            String prefix = source.substring(lineStart, (int) offset);
+            int byteCol = prefix.getBytes(StandardCharsets.UTF_8).length;
+            return new Position(relPath, line, byteCol);
+        }
+
+        private String callJson(Position site, String name, Position target) {
+            return "{\"file\":" + quote(site.file)
+                    + ",\"line\":" + site.line
+                    + ",\"col\":" + site.col
+                    + ",\"name\":" + quote(name)
+                    + ",\"tfile\":" + quote(target.file)
+                    + ",\"tline\":" + target.line
+                    + ",\"tcol\":" + target.col + "}";
+        }
+
+        private String externalJson(Position site, String name) {
+            return "{\"file\":" + quote(site.file)
+                    + ",\"line\":" + site.line
+                    + ",\"col\":" + site.col
+                    + ",\"name\":" + quote(name) + "}";
+        }
+
+        String toJson() {
+            return "{\"calls\":[" + String.join(",", calls)
+                    + "],\"externals\":[" + String.join(",", externals) + "]}";
+        }
+
+        private static String quote(String value) {
+            StringBuilder out = new StringBuilder("\"");
+            for (int i = 0; i < value.length(); i++) {
+                char c = value.charAt(i);
+                switch (c) {
+                    case '"' -> out.append("\\\"");
+                    case '\\' -> out.append("\\\\");
+                    case '\n' -> out.append("\\n");
+                    case '\r' -> out.append("\\r");
+                    case '\t' -> out.append("\\t");
+                    default -> {
+                        if (c < 0x20) {
+                            out.append(String.format("\\u%04x", (int) c));
+                        } else {
+                            out.append(c);
+                        }
+                    }
+                }
+            }
+            return out.append('"').toString();
+        }
+    }
+
+    private record Position(String file, int line, int col) {
+    }
+}

--- a/codebase_rag/parsers/java_frontend/javac/Frontend.java
+++ b/codebase_rag/parsers/java_frontend/javac/Frontend.java
@@ -119,6 +119,7 @@ public final class Frontend {
         private final Set<String> externals = new LinkedHashSet<>();
         private final Set<String> seenCalls = new HashSet<>();
         private final Map<String, String> sourceCache = new HashMap<>();
+        private final Map<String, int[]> lineStartCache = new HashMap<>();
         private CompilationUnitTree unit;
         private String rel;
 
@@ -192,7 +193,7 @@ public final class Frontend {
             if (target == null) {
                 return;
             }
-            String key = site.line + ":" + site.col + ":" + name;
+            String key = site.file + ":" + site.line + ":" + site.col + ":" + name;
             if (!seenCalls.add(key)) {
                 return;
             }
@@ -214,15 +215,32 @@ public final class Frontend {
             if (source == null) {
                 return null;
             }
-            // The declaration's NAME token, matching the tree-sitter side's
-            // key: search the header (never the body) for the identifier.
-            int header = source.indexOf('(', (int) start);
-            int limit = header < 0 ? (int) Math.min(end, source.length()) : header;
-            int at = source.lastIndexOf(name, limit);
-            if (at < (int) start) {
+            int at = nameTokenOffset(source, name, (int) start, (int) Math.min(end, source.length()));
+            if (at < 0) {
                 return null;
             }
             return position(declUnit, declRel, at);
+        }
+
+        // The declaration's NAME token, matching the key the tree-sitter side
+        // produces. Annotations belong to the method header and may carry
+        // parenthesised arguments, so the first '(' is not a reliable bound:
+        // take the first identifier-bounded occurrence that a '(' follows.
+        private static int nameTokenOffset(String source, String name, int start, int end) {
+            for (int at = source.indexOf(name, start); at >= 0 && at < end;
+                    at = source.indexOf(name, at + 1)) {
+                if (at > 0 && Character.isJavaIdentifierPart(source.charAt(at - 1))) {
+                    continue;
+                }
+                int after = at + name.length();
+                while (after < end && Character.isWhitespace(source.charAt(after))) {
+                    after++;
+                }
+                if (after < end && source.charAt(after) == '(') {
+                    return at;
+                }
+            }
+            return -1;
         }
 
         private String calleeName(ExpressionTree select) {
@@ -241,6 +259,27 @@ public final class Frontend {
                 return end < 0 ? -1 : end - name.length();
             }
             return positions.getStartPosition(unit, select);
+        }
+
+        private int[] lineStartsOf(CompilationUnitTree tree, String source) {
+            String key = tree.getSourceFile().toUri().toString();
+            int[] cached = lineStartCache.get(key);
+            if (cached != null) {
+                return cached;
+            }
+            List<Integer> starts = new ArrayList<>();
+            starts.add(0);
+            for (int i = 0; i < source.length(); i++) {
+                if (source.charAt(i) == '\n') {
+                    starts.add(i + 1);
+                }
+            }
+            int[] offsets = new int[starts.size()];
+            for (int i = 0; i < offsets.length; i++) {
+                offsets[i] = starts.get(i);
+            }
+            lineStartCache.put(key, offsets);
+            return offsets;
         }
 
         private String sourceOf(CompilationUnitTree tree) {
@@ -266,15 +305,13 @@ public final class Frontend {
             if (source == null || offset < 0 || offset > source.length()) {
                 return null;
             }
-            int line = 1;
-            int lineStart = 0;
-            for (int i = 0; i < offset; i++) {
-                if (source.charAt(i) == '\n') {
-                    line++;
-                    lineStart = i + 1;
-                }
-            }
-            String prefix = source.substring(lineStart, (int) offset);
+            // Binary search over cached line starts: a linear rescan per call
+            // site is quadratic in the size of a large source file.
+            int[] lineStarts = lineStartsOf(tree, source);
+            int found = Arrays.binarySearch(lineStarts, (int) offset);
+            int index = found >= 0 ? found : -found - 2;
+            int line = index + 1;
+            String prefix = source.substring(lineStarts[index], (int) offset);
             int byteCol = prefix.getBytes(StandardCharsets.UTF_8).length;
             return new Position(relPath, line, byteCol);
         }

--- a/codebase_rag/parsers/java_frontend/javac/Frontend.java
+++ b/codebase_rag/parsers/java_frontend/javac/Frontend.java
@@ -232,6 +232,9 @@ public final class Frontend {
                 if (at > 0 && Character.isJavaIdentifierPart(source.charAt(at - 1))) {
                     continue;
                 }
+                if (isAnnotationName(source, at)) {
+                    continue;
+                }
                 int after = at + name.length();
                 while (after < end && Character.isWhitespace(source.charAt(after))) {
                     after++;
@@ -259,6 +262,22 @@ public final class Frontend {
                 return end < 0 ? -1 : end - name.length();
             }
             return positions.getStartPosition(unit, select);
+        }
+
+        // A declaration annotation may share the method's name and carry
+        // arguments (@make() String make()), so the '(' test alone would
+        // select the annotation type.
+        private static boolean isAnnotationName(String source, int at) {
+            int before = at - 1;
+            while (before >= 0
+                    && (Character.isJavaIdentifierPart(source.charAt(before))
+                            || source.charAt(before) == '.')) {
+                before--;
+            }
+            while (before >= 0 && Character.isWhitespace(source.charAt(before))) {
+                before--;
+            }
+            return before >= 0 && source.charAt(before) == '@';
         }
 
         private int[] lineStartsOf(CompilationUnitTree tree, String source) {

--- a/codebase_rag/parsers/java_frontend/javac/cgr/Frontend.java
+++ b/codebase_rag/parsers/java_frontend/javac/cgr/Frontend.java
@@ -66,10 +66,10 @@ public final class Frontend {
     // JDK 17 floor `System.out` still encodes with the platform default, which
     // would mangle a non-ASCII identifier on a cp1252 host.
     private static void emit(String payload) {
-        PrintStream out = new PrintStream(
-                new FileOutputStream(FileDescriptor.out), true, StandardCharsets.UTF_8);
-        out.println(payload);
-        out.flush();
+        try (PrintStream out = new PrintStream(
+                new FileOutputStream(FileDescriptor.out), true, StandardCharsets.UTF_8)) {
+            out.println(payload);
+        }
     }
 
     private static String payload(String[] args) throws Exception {

--- a/codebase_rag/tests/test_java_frontend.py
+++ b/codebase_rag/tests/test_java_frontend.py
@@ -1,0 +1,108 @@
+# Bundled javac fact provider, PR1 of issue #1181. Java's heuristics match by
+# name and ARITY, so two same-arity overloads are indistinguishable to them;
+# javac attributes each call to the declaration the language actually selects.
+# This PR ships the provider only -- resolver consumption is the follow-up, so
+# these tests assert the FACTS, not graph edges.
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.parsers.java_frontend import (
+    java_frontend_available,
+    resolve_java_frontend,
+    run_java_frontend,
+)
+from codebase_rag.parsers.java_frontend.frontend import _parse_payload
+
+_WIDGET = (
+    "package com.app;\n\n"
+    "public class Widget {\n"
+    "    public String handle(String text) {\n        return text;\n    }\n\n"
+    "    public String handle(int count) {\n"
+    "        return String.valueOf(count);\n    }\n}\n"
+)
+_CALLER = (
+    "package com.app;\n\n"
+    "import java.util.ArrayList;\nimport java.util.List;\n\n"
+    "public class Caller {\n"
+    "    public String run() {\n"
+    "        Widget widget = new Widget();\n"
+    "        List<String> items = new ArrayList<>();\n"
+    "        items.add(widget.handle(42));\n"
+    '        return widget.handle("text");\n    }\n}\n'
+)
+
+
+def _write_repo(repo: Path) -> None:
+    package = repo / "src/main/java/com/app"
+    package.mkdir(parents=True)
+    (package / "Widget.java").write_text(_WIDGET, encoding="utf-8")
+    (package / "Caller.java").write_text(_CALLER, encoding="utf-8")
+
+
+def test_parse_payload_reads_both_sections() -> None:
+    facts = _parse_payload(
+        '{"calls": [{"file": "A.java", "line": 5, "col": 8, "name": "handle",'
+        ' "tfile": "B.java", "tline": 3, "tcol": 4}],'
+        ' "externals": [{"file": "A.java", "line": 9, "col": 2, "name": "add"}]}'
+    )
+    assert facts.call_sites[("A.java", 5, 8, "handle")].target_line == 3
+    assert facts.external_sites == {("A.java", 9, 2, "add")}
+
+
+def test_parse_payload_degrades_on_bad_output() -> None:
+    for payload in ("", "not json", "[1, 2]", "{}"):
+        facts = _parse_payload(payload)
+        assert facts.call_sites == {}
+        assert facts.external_sites == set()
+
+
+def test_parse_payload_drops_malformed_rows() -> None:
+    facts = _parse_payload(
+        '{"calls": [{"file": "A.java", "line": "x", "col": 8, "name": "h",'
+        ' "tfile": "B.java", "tline": 3, "tcol": 4},'
+        ' {"file": "A.java", "line": 5, "col": 8, "name": "h",'
+        ' "tfile": "B.java", "tline": 3, "tcol": 4}],'
+        ' "externals": [{"file": "A.java", "name": "broken"}]}'
+    )
+    assert list(facts.call_sites) == [("A.java", 5, 8, "h")]
+    assert facts.external_sites == set()
+
+
+def test_heuristic_is_the_default_resolution() -> None:
+    assert resolve_java_frontend() == cs.JavaFrontend.HEURISTIC
+
+
+@pytest.mark.skipif(
+    not java_frontend_available(), reason="javac frontend needs a working JDK"
+)
+def test_same_arity_overloads_bind_by_argument_type(tmp_path: Path) -> None:
+    repo = tmp_path / "proj"
+    _write_repo(repo)
+    facts = run_java_frontend(repo)
+    caller = "src/main/java/com/app/Caller.java"
+    widget = "src/main/java/com/app/Widget.java"
+    targets = {
+        key[1]: (site.target_file, site.target_line)
+        for key, site in facts.call_sites.items()
+        if key[0] == caller and key[3] == "handle"
+    }
+    # Same name, same arity: only attribution can tell these apart.
+    assert targets[10] == (widget, 8)
+    assert targets[11] == (widget, 4)
+
+
+@pytest.mark.skipif(
+    not java_frontend_available(), reason="javac frontend needs a working JDK"
+)
+def test_jdk_calls_become_external_proofs(tmp_path: Path) -> None:
+    repo = tmp_path / "proj"
+    _write_repo(repo)
+    facts = run_java_frontend(repo)
+    external_names = {key[3] for key in facts.external_sites}
+    assert {"add", "valueOf"} <= external_names
+    # A proven-external site must never also carry a first-party target.
+    assert not {key for key in facts.call_sites if key in facts.external_sites}

--- a/codebase_rag/tests/test_java_frontend.py
+++ b/codebase_rag/tests/test_java_frontend.py
@@ -5,17 +5,19 @@
 # these tests assert the FACTS, not graph edges.
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 import pytest
 
 from codebase_rag import constants as cs
+from codebase_rag.parsers.java_frontend import frontend as java_frontend_module
 from codebase_rag.parsers.java_frontend import (
     java_frontend_available,
     resolve_java_frontend,
     run_java_frontend,
 )
-from codebase_rag.parsers.java_frontend.frontend import _parse_payload
+from codebase_rag.parsers.java_frontend.frontend import _compile_tool, _parse_payload
 
 _WIDGET = (
     "package com.app;\n\n"
@@ -196,3 +198,91 @@ def test_non_ascii_identifiers_survive_the_wire(tmp_path: Path) -> None:
     facts = run_java_frontend(repo)
     names = {key[3] for key in facts.call_sites}
     assert "gr\u00fc\u00dfe" in names
+
+
+def _seeded_cache(tmp_path: Path) -> tuple[Path, Path, Path]:
+    cache = tmp_path / "java_javac"
+    out = cache / "out"
+    (out / "cgr").mkdir(parents=True)
+    published = out / "cgr/Frontend.class"
+    published.write_bytes(b"good")
+    return cache, out, published
+
+
+def _staging_writer(returncode: int):
+    def fake_run(command, **kwargs):
+        staging = Path(command[2])
+        (staging / "cgr").mkdir(parents=True, exist_ok=True)
+        (staging / "cgr/Frontend.class").write_bytes(b"partial")
+        return subprocess.CompletedProcess(command, returncode, "", "boom")
+
+    return fake_run
+
+
+def test_a_failed_build_never_publishes_a_partial_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A build that dies mid-write would otherwise leave a truncated class file
+    # whose mtime looks fresh, and every later run would launch it and fail.
+    cache, out, published = _seeded_cache(tmp_path)
+    monkeypatch.setattr(
+        java_frontend_module.subprocess, "run", _staging_writer(returncode=1)
+    )
+    assert _compile_tool("javac", cache, out) is False
+    assert published.read_bytes() == b"good"
+    assert not (cache / "staging").exists()
+
+
+def test_a_timed_out_build_leaves_no_staging_behind(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache, out, published = _seeded_cache(tmp_path)
+
+    def timeout_run(command, **kwargs):
+        staging = Path(command[2])
+        (staging / "cgr").mkdir(parents=True, exist_ok=True)
+        raise subprocess.TimeoutExpired(command, 1)
+
+    monkeypatch.setattr(java_frontend_module.subprocess, "run", timeout_run)
+    assert _compile_tool("javac", cache, out) is False
+    assert published.read_bytes() == b"good"
+    assert not (cache / "staging").exists()
+
+
+def test_a_successful_build_replaces_the_published_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache, out, published = _seeded_cache(tmp_path)
+    monkeypatch.setattr(
+        java_frontend_module.subprocess, "run", _staging_writer(returncode=0)
+    )
+    assert _compile_tool("javac", cache, out) is True
+    assert published.read_bytes() == b"partial"
+    assert not (cache / "staging").exists()
+
+
+@pytest.mark.skipif(
+    not java_frontend_available(), reason="javac frontend needs a working JDK"
+)
+def test_a_comment_inside_the_annotation_does_not_hide_it(tmp_path: Path) -> None:
+    # Java treats a comment as whitespace, so it may sit between the '@' and
+    # the annotation name. Annotation extents come from the AST for exactly
+    # this reason: no lexical scan has to know that.
+    repo = tmp_path / "proj"
+    package = repo / "src/main/java/com/app"
+    package.mkdir(parents=True)
+    (package / "make.java").write_text(
+        "package com.app;\n\npublic @interface make {\n"
+        '    String value() default "";\n}\n',
+        encoding="utf-8",
+    )
+    (package / "Commented.java").write_text(
+        "package com.app;\n\npublic class Commented {\n"
+        '    @/* here */make("x")\n'
+        '    public String make() {\n        return "m";\n    }\n\n'
+        "    public String pick() {\n        return make();\n    }\n}\n",
+        encoding="utf-8",
+    )
+    facts = run_java_frontend(repo)
+    site = facts.call_sites[("src/main/java/com/app/Commented.java", 10, 15, "make")]
+    assert site.target_line == 5

--- a/codebase_rag/tests/test_java_frontend.py
+++ b/codebase_rag/tests/test_java_frontend.py
@@ -36,6 +36,16 @@ _CALLER = (
 )
 
 
+# Byte-identical geometry in two files: the same callee name at the same line
+# and column, each binding inside its own file.
+_TWIN = (
+    "package com.app;\n\n"
+    "public class {name} {{\n"
+    "    public String pick() {{\n        return make();\n    }}\n\n"
+    '    public String make() {{\n        return "x";\n    }}\n}}\n'
+)
+
+
 def _write_repo(repo: Path) -> None:
     package = repo / "src/main/java/com/app"
     package.mkdir(parents=True)
@@ -106,3 +116,26 @@ def test_jdk_calls_become_external_proofs(tmp_path: Path) -> None:
     assert {"add", "valueOf"} <= external_names
     # A proven-external site must never also carry a first-party target.
     assert not {key for key in facts.call_sites if key in facts.external_sites}
+
+
+@pytest.mark.skipif(
+    not java_frontend_available(), reason="javac frontend needs a working JDK"
+)
+def test_same_position_in_two_files_keeps_both_sites(tmp_path: Path) -> None:
+    # The dedup key spans the whole repo, so it must carry the file: two
+    # files laid out alike put an identical call at an identical position.
+    repo = tmp_path / "proj"
+    package = repo / "src/main/java/com/app"
+    package.mkdir(parents=True)
+    for name in ("Alpha", "Beta"):
+        (package / f"{name}.java").write_text(_TWIN.format(name=name), encoding="utf-8")
+    facts = run_java_frontend(repo)
+    bound = {
+        key[0]: site.target_file
+        for key, site in facts.call_sites.items()
+        if key[3] == "make"
+    }
+    assert bound == {
+        "src/main/java/com/app/Alpha.java": "src/main/java/com/app/Alpha.java",
+        "src/main/java/com/app/Beta.java": "src/main/java/com/app/Beta.java",
+    }

--- a/codebase_rag/tests/test_java_frontend.py
+++ b/codebase_rag/tests/test_java_frontend.py
@@ -6,6 +6,8 @@
 from __future__ import annotations
 
 import subprocess
+import tomllib
+from fnmatch import fnmatch
 from pathlib import Path
 
 import pytest
@@ -286,3 +288,15 @@ def test_a_comment_inside_the_annotation_does_not_hide_it(tmp_path: Path) -> Non
     facts = run_java_frontend(repo)
     site = facts.call_sites[("src/main/java/com/app/Commented.java", 10, 15, "make")]
     assert site.target_line == 5
+
+
+def test_the_tool_source_ships_in_the_wheel() -> None:
+    # The provider builds from a bundled source file, so an installed wheel
+    # that omits it would report the frontend available and then fail to
+    # build it on every run.
+    root = Path(__file__).resolve().parents[2]
+    config = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
+    patterns = config["tool"]["setuptools"]["package-data"]["codebase_rag"]
+    source = java_frontend_module._TOOL_SRC / java_frontend_module._TOOL_SOURCE
+    relative = source.relative_to(root / "codebase_rag").as_posix()
+    assert any(fnmatch(relative, pattern) for pattern in patterns)

--- a/codebase_rag/tests/test_java_frontend.py
+++ b/codebase_rag/tests/test_java_frontend.py
@@ -82,6 +82,13 @@ def test_parse_payload_drops_malformed_rows() -> None:
     assert facts.external_sites == set()
 
 
+def test_parse_payload_rejects_non_list_sections() -> None:
+    for payload in ('{"calls": null}', '{"externals": 5}', '{"calls": {}}'):
+        facts = _parse_payload(payload)
+        assert facts.call_sites == {}
+        assert facts.external_sites == set()
+
+
 def test_heuristic_is_the_default_resolution() -> None:
     assert resolve_java_frontend() == cs.JavaFrontend.HEURISTIC
 
@@ -139,3 +146,33 @@ def test_same_position_in_two_files_keeps_both_sites(tmp_path: Path) -> None:
         "src/main/java/com/app/Alpha.java": "src/main/java/com/app/Alpha.java",
         "src/main/java/com/app/Beta.java": "src/main/java/com/app/Beta.java",
     }
+
+
+@pytest.mark.skipif(
+    not java_frontend_available(), reason="javac frontend needs a working JDK"
+)
+def test_declaration_name_wins_over_a_same_named_annotation(tmp_path: Path) -> None:
+    # A declaration annotation belongs to the method header and may carry
+    # arguments, so an annotation type sharing the method's name looks exactly
+    # like the name token being searched for.
+    repo = tmp_path / "proj"
+    package = repo / "src/main/java/com/app"
+    package.mkdir(parents=True)
+    (package / "make.java").write_text(
+        "package com.app;\n\npublic @interface make {\n"
+        '    String value() default "";\n}\n',
+        encoding="utf-8",
+    )
+    (package / "Annotated.java").write_text(
+        "package com.app;\n\npublic class Annotated {\n"
+        '    @make("x")\n'
+        '    public String make() {\n        return "m";\n    }\n\n'
+        "    public String pick() {\n        return make();\n    }\n}\n",
+        encoding="utf-8",
+    )
+    facts = run_java_frontend(repo)
+    site = facts.call_sites[("src/main/java/com/app/Annotated.java", 10, 15, "make")]
+    assert (site.target_file, site.target_line) == (
+        "src/main/java/com/app/Annotated.java",
+        5,
+    )

--- a/codebase_rag/tests/test_java_frontend.py
+++ b/codebase_rag/tests/test_java_frontend.py
@@ -176,3 +176,23 @@ def test_declaration_name_wins_over_a_same_named_annotation(tmp_path: Path) -> N
         "src/main/java/com/app/Annotated.java",
         5,
     )
+
+
+@pytest.mark.skipif(
+    not java_frontend_available(), reason="javac frontend needs a working JDK"
+)
+def test_non_ascii_identifiers_survive_the_wire(tmp_path: Path) -> None:
+    # The payload crosses a pipe, so both ends pin UTF-8: a platform-default
+    # encoder would mangle these names and drop the facts on the floor.
+    repo = tmp_path / "proj"
+    package = repo / "src/main/java/com/app"
+    package.mkdir(parents=True)
+    (package / "Grusse.java").write_text(
+        "package com.app;\n\npublic class Grusse {\n"
+        '    public String gr\u00fc\u00dfe() {\n        return "hi";\n    }\n\n'
+        "    public String call() {\n        return gr\u00fc\u00dfe();\n    }\n}\n",
+        encoding="utf-8",
+    )
+    facts = run_java_frontend(repo)
+    names = {key[3] for key in facts.call_sites}
+    assert "gr\u00fc\u00dfe" in names

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ codebase_rag = [
     "parsers/go_frontend/gotypes/*.go",
     "parsers/go_frontend/gotypes/go.mod",
     "parsers/go_frontend/gotypes/go.sum",
+    "parsers/java_frontend/javac/cgr/*.java",
     "parsers/ast_grep_patterns/*.yaml",
     "analyzers/ast_grep_rules/*/*.yaml",
 ]


### PR DESCRIPTION
PR1 of #1181 — the fact provider. Mirrors the Go rollout (#1179 shipped as provider then consumer), so the issue STAYS OPEN and the resolver consumption lands next.

## Why

Java's resolution is the repo's largest pure-heuristic stack: it matches by name and ARITY, while the language resolves overloads by ARGUMENT TYPE. Two same-arity overloads are indistinguishable to the heuristics; the JDK ships the authoritative answer in the Compiler Tree API, which `evals/oracles/java_oracle` already uses.

## What's in

- **`parsers/java_frontend/javac/Frontend.java`**: a bundled tool that runs `JavacTask` parse + `analyze()` (attribute) over the repo's sources with `-proc:none` (repository-controlled annotation processors are never executed) and emits one JSON line of `calls` and `externals`, each keyed on the callee NAME token as `(file, line, byte col, name)` — the same join contract the Roslyn and gotypes tools use. Columns are measured in UTF-8 bytes, computed from the compilation unit's own source text, so they match tree-sitter.
- **Stage 1 = no-classpath attribution** (the issue's staging): intra-repo binding is exact without the project classpath, symbols attributed outside repo source become external proofs, and diagnostics from genuinely missing dependencies are discarded. An UNATTRIBUTED site emits nothing at all — a miss is never mistaken for an external proof.
- Implicit constructor delegation (`super`/`this`) is filtered: it has no name token in the source, so the tree-sitter side has nothing to join to.
- **Python side**: availability probes run `-version` and require a clean exit (macOS ships stub shims that pass a which-only check), the tool builds once into `~/.cgr/java_javac` under the shared crash-safe build lock from #1227, `JAVA_FRONTEND` (heuristic default | javac) gates it, and the parser fingerprint records the RESOLVED mode so a javac-backed graph and a heuristic one never share an identity. Every failure path returns fresh empty facts.

## Verified

On a fixture with `handle(String)` and `handle(int)` — same name, same arity — `widget.handle(42)` attributes to the `int` declaration and `widget.handle("text")` to the `String` one; `List.add` and `String.valueOf` land as external proofs.

## Tests

`test_java_frontend.py`: payload parsing (well-formed, empty/non-JSON/wrong-shape degradation, malformed-row dropping), the heuristic default, and two JDK-gated end-to-end assertions — same-arity overloads binding by argument type, and JDK calls becoming external proofs with no site both proven external and first-party. 6 passed; fingerprint/registry battery 37 passed.

No resolver changes in this PR: nothing consumes these facts yet, so graph output is byte-for-byte unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Java code analysis with heuristic and `javac`-based modes.
  * Improved Java method-call resolution, including overloaded methods and external JDK references.
  * Automatically detects available Java tooling and falls back to heuristic analysis when needed.
  * Added caching to speed up repeated Java analysis.

* **Bug Fixes**
  * Improved handling of Java compilation, parsing, execution, and malformed output.
  * Java frontend changes now correctly invalidate affected analysis results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->