### PR TITLE
fix: type Java chained call receivers by the inner call's return type

### DIFF
--- a/codebase_rag/parsers/java/method_resolver.py
+++ b/codebase_rag/parsers/java/method_resolver.py
@@ -14,6 +14,7 @@ from ..utils import safe_decode_text
 from .utils import (
     extract_class_info,
     extract_method_call_info,
+    extract_method_info,
     get_class_context_from_qn,
 )
 
@@ -78,6 +79,34 @@ def _java_param_type_names(qn: str) -> list[str]:
         p.split(cs.CHAR_ANGLE_OPEN, 1)[0].rsplit(cs.SEPARATOR_DOT, 1)[-1].strip()
         for p in parts
     ]
+
+
+def _simple_type_name(type_text: str) -> str:
+    return (
+        type_text.split(cs.CHAR_ANGLE_OPEN, 1)[0]
+        .rsplit(cs.SEPARATOR_DOT, 1)[-1]
+        .strip()
+    )
+
+
+def _pick_declared_overload(
+    declarations: list[ASTNode], param_types: tuple[str, ...]
+) -> ASTNode | None:
+    # Without a signature to match, the first declaration is all there is. With
+    # one, prefer the declaration whose parameter types match it: overloads may
+    # differ in return type, and the caller has already chosen which one it is.
+    if not declarations:
+        return None
+    if not param_types:
+        return declarations[0]
+    for declaration in declarations:
+        declared = tuple(
+            _simple_type_name(text)
+            for text in extract_method_info(declaration)[cs.KEY_PARAMETERS]
+        )
+        if declared == param_types:
+            return declaration
+    return declarations[0]
 
 
 def _overload_matches_arg_types(qn: str, arg_types: tuple[str | None, ...]) -> bool:
@@ -563,7 +592,12 @@ class JavaMethodResolverMixin:
 
         return self._heuristic_method_return_type(method_call)
 
-    def _find_method_return_type(self, class_qn: str, method_name: str) -> str | None:
+    def _find_method_return_type(
+        self,
+        class_qn: str,
+        method_name: str,
+        param_types: tuple[str, ...] = (),
+    ) -> str | None:
         if not class_qn or not method_name:
             return None
 
@@ -574,41 +608,62 @@ class JavaMethodResolverMixin:
             return None
 
         return self._find_method_return_type_in_ast(
-            ctx.root_node, ctx.target_class_name, method_name, ctx.module_qn
+            ctx.root_node,
+            ctx.target_class_name,
+            method_name,
+            ctx.module_qn,
+            param_types,
         )
 
     def _find_method_return_type_in_ast(
-        self, node: ASTNode, class_name: str, method_name: str, module_qn: str
+        self,
+        node: ASTNode,
+        class_name: str,
+        method_name: str,
+        module_qn: str,
+        param_types: tuple[str, ...] = (),
     ) -> str | None:
-        if node.type == cs.TS_CLASS_DECLARATION:
+        # Interfaces, enums and records declare methods too, and instance-method
+        # lookup already binds through them, so a chain whose inner call is
+        # declared on one must be typeable the same way.
+        if node.type in cs.JAVA_CLASS_NODE_TYPES:
             if (
                 name_node := node.child_by_field_name(cs.KEY_NAME)
             ) and safe_decode_text(name_node) == class_name:
                 if body_node := node.child_by_field_name(cs.FIELD_BODY):
                     return self._search_methods_in_class_body(
-                        body_node, method_name, module_qn
+                        body_node, method_name, module_qn, param_types
                     )
 
         for child in node.children:
             if result := self._find_method_return_type_in_ast(
-                child, class_name, method_name, module_qn
+                child, class_name, method_name, module_qn, param_types
             ):
                 return result
 
         return None
 
     def _search_methods_in_class_body(
-        self, body_node: ASTNode, method_name: str, module_qn: str
+        self,
+        body_node: ASTNode,
+        method_name: str,
+        module_qn: str,
+        param_types: tuple[str, ...] = (),
     ) -> str | None:
-        for child in body_node.children:
-            if child.type == cs.TS_METHOD_DECLARATION:
-                if (
-                    name_node := child.child_by_field_name(cs.KEY_NAME)
-                ) and safe_decode_text(name_node) == method_name:
-                    if (type_node := child.child_by_field_name(cs.KEY_TYPE)) and (
-                        return_type := safe_decode_text(type_node)
-                    ):
-                        return self._resolve_java_type_name(return_type, module_qn)
+        named = [
+            child
+            for child in body_node.children
+            if child.type == cs.TS_METHOD_DECLARATION
+            and (name_node := child.child_by_field_name(cs.KEY_NAME)) is not None
+            and safe_decode_text(name_node) == method_name
+        ]
+        chosen = _pick_declared_overload(named, param_types)
+        if chosen is None:
+            return None
+        if (type_node := chosen.child_by_field_name(cs.KEY_TYPE)) and (
+            return_type := safe_decode_text(type_node)
+        ):
+            return self._resolve_java_type_name(return_type, module_qn)
         return None
 
     def _heuristic_method_return_type(self, method_call: str) -> str | None:
@@ -694,7 +749,12 @@ class JavaMethodResolverMixin:
         class_qn, _, method_name = unsignatured.rpartition(cs.SEPARATOR_DOT)
         if not class_qn or not method_name:
             return None
-        return self._find_method_return_type(class_qn, method_name)
+        # The signature of the OVERLOAD the inner call resolved to: overloads
+        # may declare different return types, and a name-only lookup would type
+        # the chain from whichever one is declared first.
+        return self._find_method_return_type(
+            class_qn, method_name, tuple(_java_param_type_names(method_qn))
+        )
 
     def _do_resolve_java_method_call(
         self,

--- a/codebase_rag/parsers/java/method_resolver.py
+++ b/codebase_rag/parsers/java/method_resolver.py
@@ -665,6 +665,37 @@ class JavaMethodResolverMixin:
             arg_types.append(var_type or None)
         return tuple(arg_types)
 
+    @staticmethod
+    def _has_call_receiver(call_node: ASTNode) -> bool:
+        receiver = call_node.child_by_field_name(cs.TS_FIELD_OBJECT)
+        return receiver is not None and receiver.type == cs.TS_METHOD_INVOCATION
+
+    def _chained_receiver_type(
+        self,
+        call_node: ASTNode,
+        local_var_types: dict[str, str],
+        module_qn: str,
+    ) -> str | None:
+        receiver = call_node.child_by_field_name(cs.TS_FIELD_OBJECT)
+        if receiver is None:
+            return None
+        # Recursion walks the chain leftwards; the leftmost receiver is an
+        # identifier or field access, which the existing paths already type.
+        resolved = self._do_resolve_java_method_call(
+            receiver, local_var_types, module_qn
+        )
+        if not resolved:
+            return None
+        return self._declared_return_type_of(resolved[1])
+
+    def _declared_return_type_of(self, method_qn: str) -> str | None:
+        open_idx = method_qn.find(cs.CHAR_PAREN_OPEN)
+        unsignatured = method_qn[:open_idx] if open_idx >= 0 else method_qn
+        class_qn, _, method_name = unsignatured.rpartition(cs.SEPARATOR_DOT)
+        if not class_qn or not method_name:
+            return None
+        return self._find_method_return_type(class_qn, method_name)
+
     def _do_resolve_java_method_call(
         self,
         call_node: ASTNode,
@@ -689,6 +720,25 @@ class JavaMethodResolverMixin:
             return None
 
         logger.debug(ls.JAVA_RESOLVING_CALL, method=method_name, object=object_ref)
+
+        # A chained step (`from(..).where(..)`) has a method_invocation receiver,
+        # which carries no name to look up. Typing it means resolving the inner
+        # call first and reading its DECLARED return type -- the same thing the
+        # compiler does, and what makes `return this;` builders resolve.
+        if self._has_call_receiver(call_node):
+            if chained_type := self._chained_receiver_type(
+                call_node, local_var_types, module_qn
+            ):
+                logger.debug(ls.JAVA_OBJ_TYPE_RESOLVED, type=chained_type)
+                return self._resolve_instance_method(
+                    chained_type, str(method_name), module_qn, arg_count, arg_types
+                )
+            # An untypeable receiver (a call into a third-party type) leaves the
+            # step unresolved. It must not reach the unqualified path below:
+            # `expr().m()` is never `this.m()`, and that scan binds by name
+            # alone, which is how the chain used to land on an unrelated class.
+            logger.debug(ls.JAVA_OBJ_TYPE_UNKNOWN, object=method_name)
+            return None
 
         if not object_ref:
             logger.debug(ls.JAVA_RESOLVING_STATIC, method=method_name)

--- a/codebase_rag/tests/test_java_field_access_chains.py
+++ b/codebase_rag/tests/test_java_field_access_chains.py
@@ -387,3 +387,145 @@ def test_generic_scoped_superclass_extraction() -> None:
         f"generic superclass should extract the base name; "
         f"got {generic_simple.get('superclass')!r}"
     )
+
+
+def test_fluent_chain_binds_each_step_to_the_receivers_return_type(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # A chained step's receiver is a method_invocation, which was never typed,
+    # so every step after the first fell through to the module-wide name scan
+    # and bound to whichever class declared a matching name first (issue #1334).
+    project = temp_repo / "proj"
+    (project / "src").mkdir(parents=True)
+    (project / "src" / "Main.java").write_text(
+        """
+class Decoy {
+    public Decoy where(String c) { return this; }
+    public void execute() { }
+}
+class QueryBuilder {
+    public QueryBuilder from(String table) { return this; }
+    public QueryBuilder where(String condition) { return this; }
+    public void execute() { }
+}
+public class Main {
+    public static void main(String[] args) {
+        QueryBuilder obj = new QueryBuilder();
+        obj.from("users").where("id = 1").execute();
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    _run(project, mock_ingestor)
+    targets = _call_targets(mock_ingestor)
+    assert "proj.src.Main.QueryBuilder.from(String)" in targets
+    assert "proj.src.Main.QueryBuilder.where(String)" in targets
+    assert "proj.src.Main.QueryBuilder.execute()" in targets
+    assert not {t for t in targets if "Decoy" in t}
+
+
+def test_chain_across_files_types_each_step(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The inner call's declared return type names a class in another file, so
+    # the step after it can only bind once that type is resolved.
+    project = temp_repo / "proj"
+    (project / "src").mkdir(parents=True)
+    (project / "src" / "Rows.java").write_text(
+        """
+public class Rows {
+    public Rows limit(int n) { return this; }
+    public int count() { return 0; }
+}
+""",
+        encoding="utf-8",
+    )
+    (project / "src" / "Session.java").write_text(
+        """
+public class Session {
+    public Rows query(String sql) { return new Rows(); }
+}
+""",
+        encoding="utf-8",
+    )
+    (project / "src" / "Other.java").write_text(
+        """
+public class Other {
+    public Other limit(int n) { return this; }
+    public int count() { return 1; }
+}
+""",
+        encoding="utf-8",
+    )
+    (project / "src" / "Main.java").write_text(
+        """
+public class Main {
+    public static void main(String[] args) {
+        Session s = new Session();
+        s.query("select 1").limit(10).count();
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    _run(project, mock_ingestor)
+    targets = _call_targets(mock_ingestor)
+    assert "proj.src.Session.Session.query(String)" in targets
+    assert "proj.src.Rows.Rows.limit(int)" in targets
+    assert "proj.src.Rows.Rows.count()" in targets
+    assert not {t for t in targets if "Other" in t}
+
+
+def test_an_unresolvable_inner_call_falls_back_instead_of_fabricating(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The receiver is a call into an unknown third-party type: there is no
+    # declared return type to read, so the step must stay unresolved rather
+    # than bind to a same-named method elsewhere in the module.
+    project = temp_repo / "proj"
+    (project / "src").mkdir(parents=True)
+    (project / "src" / "Main.java").write_text(
+        """
+class Local {
+    public void trim() { }
+}
+public class Main {
+    public static void main(String[] args) {
+        java.util.List<String> raw = new java.util.ArrayList<>();
+        raw.get(0).trim();
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    _run(project, mock_ingestor)
+    assert "proj.src.Main.Local.trim()" not in _call_targets(mock_ingestor)
+
+
+def test_overloaded_chain_steps_bind_by_arity(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    project = temp_repo / "proj"
+    (project / "src").mkdir(parents=True)
+    (project / "src" / "Main.java").write_text(
+        """
+class Builder {
+    public Builder with(String a) { return this; }
+    public Builder with(String a, String b) { return this; }
+    public void build() { }
+}
+public class Main {
+    public static void main(String[] args) {
+        Builder b = new Builder();
+        b.with("a").with("b", "c").build();
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    _run(project, mock_ingestor)
+    targets = _call_targets(mock_ingestor)
+    assert "proj.src.Main.Builder.with(String)" in targets
+    assert "proj.src.Main.Builder.with(String,String)" in targets
+    assert "proj.src.Main.Builder.build()" in targets

--- a/codebase_rag/tests/test_java_field_access_chains.py
+++ b/codebase_rag/tests/test_java_field_access_chains.py
@@ -529,3 +529,70 @@ public class Main {
     assert "proj.src.Main.Builder.with(String)" in targets
     assert "proj.src.Main.Builder.with(String,String)" in targets
     assert "proj.src.Main.Builder.build()" in targets
+
+
+def test_chain_types_from_the_selected_overload_not_the_first(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # Overloads may declare different return types, so the chain must be typed
+    # from the overload the inner call actually resolved to, not from whichever
+    # one the class declares first.
+    project = temp_repo / "proj"
+    (project / "src").mkdir(parents=True)
+    (project / "src" / "Main.java").write_text(
+        """
+class Wrong {
+    public void selectedOnly() { }
+}
+class Selected {
+    public void selectedOnly() { }
+}
+class Factory {
+    public Wrong create(Integer wrongArg) { return new Wrong(); }
+    public Selected create(String selectedArg) { return new Selected(); }
+}
+public class Main {
+    public static void main(String[] args) {
+        Factory factory = new Factory();
+        String selectedArg = "pick me";
+        factory.create(selectedArg).selectedOnly();
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    _run(project, mock_ingestor)
+    targets = _call_targets(mock_ingestor)
+    assert "proj.src.Main.Factory.create(String)" in targets
+    assert "proj.src.Main.Selected.selectedOnly()" in targets
+    assert "proj.src.Main.Wrong.selectedOnly()" not in targets
+
+
+def test_chain_through_an_interface_declared_method(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # Instance-method lookup already binds through interfaces, so a chain whose
+    # inner call is declared on one must be typeable the same way.
+    project = temp_repo / "proj"
+    (project / "src").mkdir(parents=True)
+    (project / "src" / "Main.java").write_text(
+        """
+class Builder {
+    public void build() { }
+}
+interface Factory {
+    Builder query();
+}
+class RealFactory implements Factory {
+    public Builder query() { return new Builder(); }
+}
+public class Main {
+    public static void run(Factory factory) {
+        factory.query().build();
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    _run(project, mock_ingestor)
+    assert "proj.src.Main.Builder.build()" in _call_targets(mock_ingestor)


### PR DESCRIPTION
Closes #1334.

## The bug

A chained step's receiver is a `method_invocation`, and that node type was never typed. `extract_method_call_info` returned `object=None` for it, which is the same shape an unqualified call has, so `from("users").where("id = 1")` was resolved as though it were `this.where(...)` and fell into the module-wide name scan. The scan binds by name alone, so the chain landed on whichever class happened to declare a matching name first. On the issue's reproduction that is `Decoy`.

## The fix

When the receiver is a call, resolve THAT call first and read its declared return type, which is what the compiler does and what makes `return this;` builders work. Recursion walks the chain leftwards until it reaches an identifier or field-access receiver, which the existing paths already type, so arbitrary depth works without a special case per length. Each step keeps the existing arity- and argument-type-aware overload pick, because each step is resolved through the normal instance-method path once its receiver type is known.

## The second fabrication

Once a call receiver is recognised, an untypeable one (a call returning a third-party type) must NOT fall through to the unqualified path either: `expr().m()` is never `this.m()`. It previously did, which is the same name-only scan that produced the wrong edge in the first place. Such a step now stays unresolved. This trades a coincidentally-correct edge for silence in the single-candidate case, which is the trade the issue asks for: the old behaviour was right only by accident and wrong as soon as a second class declared the name.

## Tests

In `test_java_field_access_chains.py`, verified red first:

- the issue's exact `QueryBuilder`/`Decoy` reproduction, asserting all three expected edges and no `Decoy` edge at all
- a chain across three files where the inner call's return type names a class declared elsewhere, with a decoy class carrying both method names
- an untypeable receiver (`raw.get(0).trim()` on a `java.util.List`) asserting no edge is fabricated to a same-named local method
- overloaded chain steps binding by arity, `with(String)` and `with(String,String)` on the same chain

Full Java battery: 658 passed, 1 skipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Java method resolution for chained and fluent calls.
  - Correctly resolves chained calls across files, interfaces, and overloaded methods.
  - Uses the selected overload’s return type when determining subsequent calls.
  - Prevents incorrect method matches when return types cannot be determined.

- **Tests**
  - Added coverage for same-file and cross-file chains, overloads by arity, interface-declared methods, selected overload return types, and unresolved external types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->