### PR TITLE
feat: bind Java calls through the javac facts and suppress proven-external edges

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -548,6 +548,35 @@ class GraphUpdater:
             )
         )
 
+    def _run_java_frontend(self) -> None:
+        # The javac frontend (issue #1181) runs AFTER Pass 2, like the Jedi one:
+        # its call facts join against the function_locations Pass 2 just filled,
+        # including the name-token alias the Java method registration adds.
+        # Reset first so a reused updater (watch mode) that previously ran the
+        # frontend does not keep applying stale facts on a later run with it
+        # off; the maps are mutated in place because the type-inference engine
+        # holds a reference.
+        dp = self.factory.definition_processor
+        dp.java_call_sites.clear()
+        dp.java_external_sites.clear()
+        if settings.JAVA_FRONTEND == cs.JavaFrontend.HEURISTIC:
+            return
+        frontend = FRONTENDS.get(cs.SupportedLanguage.JAVA)
+        if frontend is None or not frontend.applies(self.repo_path):
+            return
+        if not frontend.available():
+            logger.warning(ls.JAVA_FRONTEND_UNAVAILABLE)
+            return
+        facts = frontend.run(self.repo_path, ())
+        dp.java_call_sites.update(facts.resolved_call_sites)
+        dp.java_external_sites.update(facts.external_sites)
+        logger.info(
+            ls.JAVA_FRONTEND_FACTS.format(
+                calls=len(facts.resolved_call_sites),
+                externals=len(facts.external_sites),
+            )
+        )
+
     def _run_python_frontend(self) -> None:
         # In-process Jedi facts (issue #1183): exact first-party callees
         # through re-exports/decorators and external proofs for calls leaving
@@ -883,6 +912,10 @@ class GraphUpdater:
         # calls against the function_locations Pass 2 just filled) and needs
         # the parsed-file list, which Pass 2 produced (issue #1183).
         self._run_python_frontend()
+
+        # Same posture for Java (issue #1181): the facts resolve against the
+        # method name-token locations Pass 2 registered.
+        self._run_java_frontend()
 
         # HYBRID must run after Pass 2: an incremental run deletes each
         # changed file's Module subtree before re-parsing it, so macro

--- a/codebase_rag/logs.py
+++ b/codebase_rag/logs.py
@@ -934,6 +934,9 @@ JAVA_FRONTEND_RUN_FAILED = "javac frontend did not finish ({error}); using tree-
 JAVA_FRONTEND_PARSE_FAILED = (
     "javac frontend emitted unreadable output (stdout={stdout}, stderr={stderr})"
 )
+JAVA_FRONTEND_UNAVAILABLE = (
+    "JAVA_FRONTEND is set to javac but no working JDK was found; using tree-sitter"
+)
 JAVA_FRONTEND_FACTS = (
     "javac facts: {calls} resolved call sites, {externals} external sites"
 )

--- a/codebase_rag/parsers/call_processor.py
+++ b/codebase_rag/parsers/call_processor.py
@@ -36,6 +36,7 @@ from .go import type_inference as go_ti
 from .go import utils as go_utils
 from .import_processor import ImportProcessor
 from .io_access import IOAccessProcessor
+from .java import type_inference as java_ti
 from .java import utils as java_utils
 from .js_ts import utils as js_ts_utils
 from .lua import utils as lua_utils
@@ -3310,9 +3311,19 @@ class CallProcessor:
                 if callee_info is None:
                     continue
             elif is_java and call_node.type == method_invocation_type:
-                callee_info = resolver.resolve_java_method_call(
-                    call_node, module_qn, local_var_types, caller_qn
-                )
+                # The javac frontend (issue #1181): a HIT is the declaration the
+                # compiler bound this call to, which the ARGUMENT TYPES select
+                # and name-and-arity matching cannot; the external sentinel is
+                # its proof that the call leaves the repo, so no first-party
+                # edge is fabricated. Any miss (incl. the frontend being off, so
+                # both fact maps are empty) falls back to today's Java resolver.
+                callee_info = resolver.resolve_java_call_site(call_node, module_qn)
+                if callee_info == java_ti.JAVA_EXTERNAL_TARGET:
+                    callee_info = None
+                elif callee_info is None:
+                    callee_info = resolver.resolve_java_method_call(
+                        call_node, module_qn, local_var_types, caller_qn
+                    )
             elif is_csharp and call_node.type == cs.TS_CSHARP_INVOCATION_EXPRESSION:
                 callee_info = resolver.resolve_csharp_method_call(
                     call_node, module_qn, call_var_types, caller_qn

--- a/codebase_rag/parsers/call_resolver.py
+++ b/codebase_rag/parsers/call_resolver.py
@@ -3046,6 +3046,15 @@ class CallResolver:
             call_node, module_qn
         )
 
+    def resolve_java_call_site(
+        self,
+        call_node: Node,
+        module_qn: str,
+    ) -> tuple[str, str] | None:
+        return self.type_inference.java_type_inference.resolve_java_call_site(
+            call_node, module_qn
+        )
+
     def resolve_python_call_site(
         self,
         call_node: Node,

--- a/codebase_rag/parsers/class_ingest/mixin.py
+++ b/codebase_rag/parsers/class_ingest/mixin.py
@@ -1621,15 +1621,18 @@ class ClassIngestMixin:
             # this pass's twin.
             if ingested_qn is not None and module_qn is not None:
                 span = function_span_key(module_qn, method_node)
+                location = FunctionLocation(
+                    label=cs.NodeLabel.METHOD.value,
+                    qualified_name=ingested_qn,
+                    container_qn=class_qn,
+                )
                 if (
                     language != cs.SupportedLanguage.RUST
                     or span not in self.function_locations
                 ):
-                    self.function_locations[span] = FunctionLocation(
-                        label=cs.NodeLabel.METHOD.value,
-                        qualified_name=ingested_qn,
-                        container_qn=class_qn,
-                    )
+                    self.function_locations[span] = location
+                if language == cs.SupportedLanguage.JAVA:
+                    self._register_java_name_alias(module_qn, method_node, location)
             if (
                 language == cs.SupportedLanguage.CSHARP
                 and ingested_qn is not None
@@ -1664,6 +1667,25 @@ class ClassIngestMixin:
                     self.method_return_types[
                         f"{class_qn}{cs.SEPARATOR_DOT}{method_name}"
                     ] = return_type
+
+    def _register_java_name_alias(
+        self, module_qn: str, method_node: Node, location: FunctionLocation
+    ) -> None:
+        # The javac frontend (issue #1181) keys a call target at the callee NAME
+        # token, but function_span_key keys at the declaration start -- the
+        # modifiers, so `    public String handle(` records col 4 while the tool
+        # reports the col of `handle`. Register a SECOND location at the name so
+        # the semantic join resolves, mirroring the Go alias.
+        # setdefault, not assignment: two methods sharing a line could put this
+        # alias on another method's span key, and the span record is the
+        # authoritative one.
+        name_node = method_node.child_by_field_name(cs.FIELD_NAME)
+        if name_node is None:
+            return
+        self.function_locations.setdefault(
+            (module_qn, name_node.start_point[0] + 1, name_node.start_point[1]),
+            location,
+        )
 
     def _process_inline_modules(
         self,

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -171,6 +171,11 @@ class DefinitionProcessor(
         # engine holds the reference.
         self.go_call_sites: dict[CallSiteKey, ResolvedCallSite] = {}
         self.go_external_sites: set[CallSiteKey] = set()
+        # javac frontend facts (issue #1181): an exact first-party callee the
+        # name-and-arity heuristics cannot pick, and the proofs that a call
+        # leaves the repo. Empty when the frontend is off.
+        self.java_call_sites: dict[CallSiteKey, ResolvedCallSite] = {}
+        self.java_external_sites: set[CallSiteKey] = set()
         # go/types-proven implementer->interface pairs (each end a declaring
         # identifier position), stashed here at frontend time and resolved to
         # IMPLEMENTS edges after Pass 2 fills go_type_locations below.

--- a/codebase_rag/parsers/factory.py
+++ b/codebase_rag/parsers/factory.py
@@ -137,6 +137,8 @@ class ProcessorFactory:
                 python_call_sites=self.definition_processor.python_call_sites,
                 python_external_sites=self.definition_processor.python_external_sites,
                 go_external_sites=self.definition_processor.go_external_sites,
+                java_call_sites=self.definition_processor.java_call_sites,
+                java_external_sites=self.definition_processor.java_external_sites,
                 csharp_partial_groups=self.definition_processor.csharp_partial_groups,
                 csharp_extension_methods=self.definition_processor.csharp_extension_methods,
                 csharp_call_sites=self.definition_processor.csharp_call_sites,

--- a/codebase_rag/parsers/java/type_inference.py
+++ b/codebase_rag/parsers/java/type_inference.py
@@ -8,11 +8,16 @@ from ... import constants as cs
 from ... import logs as ls
 from ...types_defs import (
     ASTNode,
+    FunctionLocation,
     FunctionRegistryTrieProtocol,
+    FunctionSpanKey,
     LanguageQueries,
     SimpleNameLookup,
 )
+from ..frontends.protocol import CallSiteKey, ResolvedCallSite
 from ..import_processor import ImportProcessor
+from ..semantic_call_join import call_site_key, declared_location
+from ..utils import safe_decode_text
 from .method_resolver import JavaMethodResolverMixin
 from .type_resolver import JavaTypeResolverMixin
 from .utils import find_package_start_index
@@ -20,6 +25,11 @@ from .variable_analyzer import JavaVariableAnalyzerMixin
 
 if TYPE_CHECKING:
     from ..factory import ASTCacheProtocol
+
+
+# The sentinel a proven-external call resolves to: not a target, an instruction
+# to emit no first-party edge at all.
+JAVA_EXTERNAL_TARGET: tuple[str, str] = ("", "")
 
 
 class JavaTypeInferenceEngine(
@@ -40,6 +50,10 @@ class JavaTypeInferenceEngine(
         "_lookup_cache",
         "_lookup_in_progress",
         "_fqn_to_module_qn",
+        "java_call_sites",
+        "java_external_sites",
+        "function_locations",
+        "_rel_to_module",
     )
 
     def __init__(
@@ -53,6 +67,9 @@ class JavaTypeInferenceEngine(
         module_qn_to_file_path: dict[str, Path],
         class_inheritance: dict[str, list[str]],
         simple_name_lookup: SimpleNameLookup,
+        java_call_sites: dict[CallSiteKey, ResolvedCallSite] | None = None,
+        java_external_sites: set[CallSiteKey] | None = None,
+        function_locations: dict[FunctionSpanKey, FunctionLocation] | None = None,
     ):
         self.import_processor = import_processor
         self.function_registry = function_registry
@@ -64,10 +81,62 @@ class JavaTypeInferenceEngine(
         self.class_inheritance = class_inheritance
         self.simple_name_lookup = simple_name_lookup
 
+        self.java_call_sites = java_call_sites if java_call_sites is not None else {}
+        self.java_external_sites = (
+            java_external_sites if java_external_sites is not None else set()
+        )
+        self.function_locations = (
+            function_locations if function_locations is not None else {}
+        )
+        self._rel_to_module: dict[str, str] = {}
+
         self._lookup_cache: dict[str, str | None] = {}
         self._lookup_in_progress: set[str] = set()
 
         self._fqn_to_module_qn: dict[str, list[str]] = self._build_fqn_lookup_map()
+
+    def resolve_java_call_site(
+        self, call_node: ASTNode, module_qn: str
+    ) -> tuple[str, str] | None:
+        # The javac path: a HIT is the declaration the compiler bound this call
+        # to (the overload argument types select, which name-and-arity matching
+        # cannot), and the external sentinel is its proof that the call leaves
+        # the repo. Any miss returns None so the caller falls back to the
+        # tree-sitter heuristics.
+        if not (self.java_call_sites or self.java_external_sites):
+            return None
+        key = self._java_call_site_key(call_node, module_qn)
+        if key is None:
+            return None
+        fact = self.java_call_sites.get(key)
+        if fact is not None:
+            return declared_location(
+                fact.target_file,
+                fact.target_line,
+                fact.target_col,
+                self.function_locations,
+                self.module_qn_to_file_path,
+                self.repo_path,
+                self._rel_to_module,
+            )
+        if key in self.java_external_sites:
+            return JAVA_EXTERNAL_TARGET
+        return None
+
+    def _java_call_site_key(
+        self, call_node: ASTNode, module_qn: str
+    ) -> CallSiteKey | None:
+        # The callee NAME token, matching the tool's own choice: the `name`
+        # field of method_invocation carries it for both `m()` and `x.m()`.
+        name_node = call_node.child_by_field_name(cs.TS_FIELD_NAME)
+        if name_node is None:
+            return None
+        name = safe_decode_text(name_node)
+        if not name:
+            return None
+        return call_site_key(
+            name_node, name, module_qn, self.module_qn_to_file_path, self.repo_path
+        )
 
     def _build_fqn_lookup_map(self) -> dict[str, list[str]]:
         fqn_map: dict[str, list[str]] = {}

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -48,6 +48,8 @@ class TypeInferenceEngine:
         "go_function_return_types",
         "go_call_sites",
         "go_external_sites",
+        "java_call_sites",
+        "java_external_sites",
         "python_call_sites",
         "python_external_sites",
         "csharp_partial_groups",
@@ -93,6 +95,8 @@ class TypeInferenceEngine:
         go_function_return_types: dict[str, str] | None = None,
         go_call_sites: dict[CallSiteKey, ResolvedCallSite] | None = None,
         go_external_sites: set[CallSiteKey] | None = None,
+        java_call_sites: dict[CallSiteKey, ResolvedCallSite] | None = None,
+        java_external_sites: set[CallSiteKey] | None = None,
         python_call_sites: dict[CallSiteKey, ResolvedCallSite] | None = None,
         python_external_sites: set[CallSiteKey] | None = None,
         csharp_partial_groups: dict[str, list[str]] | None = None,
@@ -155,6 +159,10 @@ class TypeInferenceEngine:
         self.go_call_sites = go_call_sites if go_call_sites is not None else {}
         self.go_external_sites = (
             go_external_sites if go_external_sites is not None else set()
+        )
+        self.java_call_sites = java_call_sites if java_call_sites is not None else {}
+        self.java_external_sites = (
+            java_external_sites if java_external_sites is not None else set()
         )
         # Shared references, same discipline: the Jedi call-site facts and
         # external proofs (issue #1183), populated after construction.
@@ -267,6 +275,9 @@ class TypeInferenceEngine:
                 module_qn_to_file_path=self.module_qn_to_file_path,
                 class_inheritance=self.class_inheritance,
                 simple_name_lookup=self.simple_name_lookup,
+                java_call_sites=self.java_call_sites,
+                java_external_sites=self.java_external_sites,
+                function_locations=self.function_locations,
             )
         return self._java_type_inference
 

--- a/codebase_rag/tests/test_function_locations_reuse.py
+++ b/codebase_rag/tests/test_function_locations_reuse.py
@@ -132,3 +132,34 @@ def test_unchanged_module_keeps_resolving_across_runs(
     live = f"{name}.src.foo.S.run"
     assert (live, f"{name}.src.alpha.helper") in calls, calls
     assert (f"{name}.src.foo.f", f"{name}.src.beta.helper") in calls, calls
+
+
+def test_setdefault_records_the_module_index() -> None:
+    # The Java name alias (issue #1181) writes through setdefault, and
+    # dict.setdefault bypasses the overridden __setitem__: a record it wrote
+    # would survive drop_module and shadow the live registration on a re-parse.
+    from codebase_rag.types_defs import FunctionLocation, FunctionLocations
+
+    locations = FunctionLocations()
+    location = FunctionLocation(
+        label="Method", qualified_name="m.C.f()", container_qn="m.C"
+    )
+    locations.setdefault(("m", 4, 18), location)
+    assert locations[("m", 4, 18)] is location
+    locations.drop_module("m")
+    assert ("m", 4, 18) not in locations
+
+
+def test_setdefault_keeps_the_existing_record() -> None:
+    from codebase_rag.types_defs import FunctionLocation, FunctionLocations
+
+    locations = FunctionLocations()
+    first = FunctionLocation(
+        label="Method", qualified_name="m.C.f()", container_qn="m.C"
+    )
+    second = FunctionLocation(
+        label="Method", qualified_name="m.C.g()", container_qn="m.C"
+    )
+    locations[("m", 4, 18)] = first
+    assert locations.setdefault(("m", 4, 18), second) is first
+    assert locations[("m", 4, 18)] is first

--- a/codebase_rag/tests/test_java_semantic_facts.py
+++ b/codebase_rag/tests/test_java_semantic_facts.py
@@ -1,0 +1,124 @@
+# Resolver consumption of the javac facts (PR2 of issue #1181). The heuristics
+# match by name and ARITY; the language selects an overload by ARGUMENT TYPE, so
+# a call to a same-arity overload is a coin flip without the compiler. These
+# tests assert the CALLS edges, and each one asserts what the heuristics do on
+# the same repo, so a passing result cannot come from the fallback.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codebase_rag import constants as cs
+from codebase_rag.config import settings
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.parsers.java_frontend import java_frontend_available
+from codebase_rag.tests.conftest import get_relationships
+
+# Subtype dispatch: a String argument matches NEITHER parameter type by name,
+# and Java picks the most specific applicable overload (CharSequence). Name-and
+# -arity matching has nothing to go on and takes the first same-arity
+# declaration, so the two answers differ.
+_WIDGET = (
+    "package com.app;\n\n"
+    "public class Widget {\n"
+    '    public String handle(Object value) {\n        return "object";\n    }\n\n'
+    "    public String handle(CharSequence value) {\n"
+    '        return "chars";\n    }\n}\n'
+)
+_CALLER = (
+    "package com.app;\n\n"
+    "public class Caller {\n"
+    "    public String run() {\n"
+    "        Widget widget = new Widget();\n"
+    '        String text = "x";\n'
+    "        return widget.handle(text);\n    }\n}\n"
+)
+
+
+def _write_repo(repo: Path) -> None:
+    package = repo / "src/main/java/com/app"
+    package.mkdir(parents=True)
+    (package / "Widget.java").write_text(_WIDGET, encoding="utf-8")
+    (package / "Caller.java").write_text(_CALLER, encoding="utf-8")
+
+
+def _call_targets(repo: Path) -> set[str]:
+    parsers, queries = load_parsers()
+    mock = MagicMock()
+    GraphUpdater(ingestor=mock, repo_path=repo, parsers=parsers, queries=queries).run()
+    return {c.args[2][2] for c in get_relationships(mock, "CALLS")}
+
+
+@pytest.mark.skipif(
+    not java_frontend_available(), reason="javac frontend needs a working JDK"
+)
+def test_the_frontend_binds_the_overload_the_compiler_selects(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "proj"
+    _write_repo(repo)
+    monkeypatch.setattr(settings, "JAVA_FRONTEND", cs.JavaFrontend.JAVAC)
+    targets = _call_targets(repo)
+    assert any(t.endswith("Widget.handle(CharSequence)") for t in targets)
+    assert not any(t.endswith("Widget.handle(Object)") for t in targets)
+
+
+def test_the_heuristics_alone_pick_the_wrong_overload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The discriminator: with the frontend OFF the same repo binds to the FIRST
+    # same-arity declaration. If this ever starts passing, the test above no
+    # longer proves the frontend is doing the work.
+    repo = tmp_path / "proj"
+    _write_repo(repo)
+    monkeypatch.setattr(settings, "JAVA_FRONTEND", cs.JavaFrontend.HEURISTIC)
+    targets = _call_targets(repo)
+    assert any(t.endswith("Widget.handle(Object)") for t in targets)
+
+
+# A static import makes the call UNQUALIFIED, so the heuristic's module-wide
+# name scan finds the same-named local static; javac knows it resolved to the
+# JDK.
+_JDK_CALLER = (
+    "package com.app;\n\n"
+    "import static java.lang.String.valueOf;\n\n"
+    "class Decoy {\n"
+    '    public static String valueOf(int n) {\n        return "decoy";\n    }\n}\n\n'
+    "public class JdkCaller {\n"
+    "    public String run() {\n"
+    "        return valueOf(42);\n    }\n}\n"
+)
+
+
+def _write_jdk_repo(repo: Path) -> None:
+    package = repo / "src/main/java/com/app"
+    package.mkdir(parents=True)
+    (package / "JdkCaller.java").write_text(_JDK_CALLER, encoding="utf-8")
+
+
+@pytest.mark.skipif(
+    not java_frontend_available(), reason="javac frontend needs a working JDK"
+)
+def test_a_proven_external_call_fabricates_no_first_party_edge(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "proj"
+    _write_jdk_repo(repo)
+    monkeypatch.setattr(settings, "JAVA_FRONTEND", cs.JavaFrontend.JAVAC)
+    targets = _call_targets(repo)
+    assert not any(t.endswith("Decoy.valueOf(int)") for t in targets)
+
+
+def test_the_heuristics_alone_fabricate_the_jdk_call(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The discriminator for the external proof: `String.valueOf` leaves the
+    # repo, but a same-named local static is indistinguishable to a name scan.
+    repo = tmp_path / "proj"
+    _write_jdk_repo(repo)
+    monkeypatch.setattr(settings, "JAVA_FRONTEND", cs.JavaFrontend.HEURISTIC)
+    targets = _call_targets(repo)
+    assert any(t.endswith("Decoy.valueOf(int)") for t in targets)

--- a/codebase_rag/tests/test_realtime_updater.py
+++ b/codebase_rag/tests/test_realtime_updater.py
@@ -170,12 +170,24 @@ class TestSemanticFrontendReruns:
         mock_updater._rehydrate_csharp_type_locations.assert_called_once()
         mock_updater._join_csharp_partials.assert_called_once()
 
+    def test_java_change_reruns_the_javac_frontend(
+        self, event_handler: CodeChangeEventHandler, mock_updater: MagicMock
+    ) -> None:
+        # javac facts are keyed by (file, line, byte col): an edit that shifts
+        # a call would otherwise keep binding through the previous run's
+        # positions, and a stale external proof would keep suppressing an edge.
+        self._fire(event_handler, mock_updater.repo_path / "Svc.java")
+        mock_updater._run_java_frontend.assert_called_once()
+        mock_updater._rehydrate_function_locations.assert_called_once()
+        mock_updater._run_go_frontend.assert_not_called()
+
     def test_python_change_touches_no_semantic_frontend(
         self, event_handler: CodeChangeEventHandler, mock_updater: MagicMock
     ) -> None:
         self._fire(event_handler, mock_updater.repo_path / "app.py")
         mock_updater._run_go_frontend.assert_not_called()
         mock_updater._run_csharp_frontend.assert_not_called()
+        mock_updater._run_java_frontend.assert_not_called()
 
     def test_go_deletion_also_reruns_the_frontend(
         self, event_handler: CodeChangeEventHandler, mock_updater: MagicMock

--- a/codebase_rag/types_defs.py
+++ b/codebase_rag/types_defs.py
@@ -631,6 +631,16 @@ class FunctionLocations(dict[FunctionSpanKey, FunctionLocation]):
         for key, value in other.items():
             self[key] = value
 
+    def setdefault(  # type: ignore[override]
+        self, key: FunctionSpanKey, default: FunctionLocation
+    ) -> FunctionLocation:
+        # dict.setdefault bypasses __setitem__ just like dict.update does, so a
+        # record written through it would be invisible to the module index and
+        # survive drop_module -- the stale-record bug this map exists to stop.
+        if key not in self:
+            self[key] = default
+        return self[key]
+
     def drop_module(self, module_qn: str) -> None:
         """Forget every span record a module contributed, before it re-parses."""
         for key in self._by_module.pop(module_qn, ()):

--- a/realtime_updater.py
+++ b/realtime_updater.py
@@ -331,6 +331,13 @@ class CodeChangeEventHandler(FileSystemEventHandler):
             self.updater._rehydrate_csharp_type_locations()
             self.updater._rehydrate_function_locations()
             self.updater._join_csharp_partials()
+        elif changed_language == SupportedLanguage.JAVA:
+            # The javac facts (issue #1181) are keyed by (file, line, byte
+            # col), so an edit that shifts a call by even one byte would
+            # otherwise keep binding it through the previous run's positions,
+            # and a stale external proof would keep suppressing a live edge.
+            self.updater._run_java_frontend()
+            self.updater._rehydrate_function_locations()
         elif changed_language == SupportedLanguage.PYTHON:
             # The Jedi facts (issue #1183) are position-keyed against the
             # repo-wide import graph, so an edit can rebind call sites in


### PR DESCRIPTION
Closes #1181. PR2 of two: #1341 shipped the javac fact provider, this makes the resolver consume it. Same two-step rollout the Go frontend used in #1179.

## The join had to be fixed first

The facts key a call target at the callee NAME token, but `function_span_key` keys a Java method at the DECLARATION start, which is the modifiers: `    public String handle(` records col 4 while the tool reports the col of `handle`. Same line, different column, so every single fact would have missed. That is the failure mode worth naming, because it is silent: the heuristics answer instead, the tests look green, and the frontend appears to work while contributing nothing.

`_register_java_name_alias` registers a SECOND `function_locations` entry at the name token, mirroring `_register_go_name_alias`, which exists for exactly the same asymmetry.

## A latent bug in FunctionLocations

The alias writes through `setdefault` (the span record must win if two methods share a line). `FunctionLocations` overrides `__setitem__` and `update` to maintain its module index, and its docstring argues the index belongs to the map rather than to each of nine write sites, but `setdefault` was not overridden, and `dict.setdefault` bypasses `__setitem__` exactly like `dict.update` does. A record written through it would have been invisible to `drop_module` and survived an incremental re-parse: the stale-record bug (#1019) this class exists to prevent. Now overridden, with tests.

## Consumption

`resolve_java_call_site` on the Java engine: a HIT resolves the target through the shared `declared_location` join, and a proven-external site returns the sentinel so no first-party edge is fabricated. Any miss returns None and the existing Java resolver answers, so the frontend can only add precision, never remove a resolution it has no opinion on. The facts load after Pass 2 (the alias index has to exist first) and the maps are cleared at the start of each run, so a reused updater in watch mode does not keep applying stale facts after the setting flips.

Note the hook placement: the Java branch in `call_processor` sits EARLIER in the dispatch chain than the Go and Python ones, so the semantic path had to go inside it. My first attempt appended a branch in the Go/Python position and it was simply unreachable.

## Tests

Every assertion is paired with the same repo indexed with the frontend OFF, so a pass cannot come from the fallback:

- **Overload by argument type**: `handle(Object)` vs `handle(CharSequence)` called with a `String`. Java picks the most specific applicable overload; the argument type matches NEITHER parameter name, so name-and-arity matching takes the first declaration. Frontend on binds `CharSequence`, frontend off binds `Object`.
- **External proof**: a static import of `java.lang.String.valueOf` with a same-named local static in the file. The call is unqualified, so the module-wide name scan finds the local one; javac knows it resolved to the JDK. Frontend on emits no edge, frontend off fabricates `Decoy.valueOf(int)`.

I dropped a first pair of external tests that used a qualified `String.valueOf(42)`: the heuristics already emit nothing there, so the test would have passed without proving anything.

Batteries: 700 passed across java, function_locations, frontends and fingerprint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Java call resolution using compiler-derived type information.
  * Added accurate handling for overloaded methods and external static calls.
  * Java processing now falls back to heuristic resolution when compiler information is unavailable.
  * Real-time updates now reprocess changed Java files automatically.

* **Bug Fixes**
  * Prevented incorrect repository links for external Java methods.
  * Improved function location tracking and cleanup.

* **Tests**
  * Added coverage for Java resolution, external calls, real-time updates, and function locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->