### PR TITLE
fix: type a nested Java call argument from its selected overload

### DIFF
--- a/codebase_rag/constants/ast_python.py
+++ b/codebase_rag/constants/ast_python.py
@@ -151,3 +151,4 @@ TYPE_INFERENCE_BASE_MODEL = "BaseModel"
 
 ATTR_TYPE_INFERENCE_IN_PROGRESS = "_type_inference_in_progress"
 GUARD_INHERITED_METHOD = "_inherited_method_guard"
+GUARD_NESTED_JAVA_CALL = "_nested_java_call_guard"

--- a/codebase_rag/parsers/java/method_resolver.py
+++ b/codebase_rag/parsers/java/method_resolver.py
@@ -204,7 +204,10 @@ class JavaMethodResolverMixin:
 
     @abstractmethod
     def _infer_java_type_from_expression(
-        self, expr_node: ASTNode, module_qn: str
+        self,
+        expr_node: ASTNode,
+        module_qn: str,
+        local_var_types: dict[str, str] | None = None,
     ) -> str | None: ...
 
     @abstractmethod
@@ -748,7 +751,9 @@ class JavaMethodResolverMixin:
                 # or a call carries it in the expression: the shared inference
                 # types all of them (issue #1344).
                 arg_types.append(
-                    self._infer_java_type_from_expression(child, module_qn)
+                    self._infer_java_type_from_expression(
+                        child, module_qn, local_var_types
+                    )
                 )
                 continue
             name = safe_decode_text(child)

--- a/codebase_rag/parsers/java/variable_analyzer.py
+++ b/codebase_rag/parsers/java/variable_analyzer.py
@@ -7,6 +7,7 @@ from loguru import logger
 
 from ... import constants as cs
 from ... import logs as ls
+from ...decorators import recursion_guard
 from ...types_defs import ASTNode
 from ..utils import safe_decode_text
 from .utils import (
@@ -159,7 +160,7 @@ class JavaVariableAnalyzerMixin:
 
         if value_node := declarator_node.child_by_field_name(cs.FIELD_VALUE):
             if inferred_type := self._infer_java_type_from_expression(
-                value_node, module_qn
+                value_node, module_qn, local_var_types
             ):
                 resolved_type = self._resolve_java_type_name(inferred_type, module_qn)
                 local_var_types[var_name] = resolved_type
@@ -229,7 +230,7 @@ class JavaVariableAnalyzerMixin:
             return
 
         if inferred_type := self._infer_java_type_from_expression(
-            right_node, module_qn
+            right_node, module_qn, local_var_types
         ):
             resolved_type = self._resolve_java_type_name(inferred_type, module_qn)
             local_var_types[var_name] = resolved_type
@@ -328,7 +329,10 @@ class JavaVariableAnalyzerMixin:
                         break
 
     def _infer_java_type_from_expression(
-        self, expr_node: ASTNode, module_qn: str
+        self,
+        expr_node: ASTNode,
+        module_qn: str,
+        local_var_types: dict[str, str] | None = None,
     ) -> str | None:
         match expr_node.type:
             case cs.TS_OBJECT_CREATION_EXPRESSION:
@@ -336,7 +340,9 @@ class JavaVariableAnalyzerMixin:
                     return safe_decode_text(type_node)
 
             case cs.TS_METHOD_INVOCATION:
-                return self._infer_java_method_return_type(expr_node, module_qn)
+                return self._infer_java_method_return_type(
+                    expr_node, module_qn, local_var_types
+                )
 
             case cs.TS_IDENTIFIER:
                 if var_name := safe_decode_text(expr_node):
@@ -381,7 +387,10 @@ class JavaVariableAnalyzerMixin:
         return None
 
     def _infer_java_method_return_type(
-        self, method_call_node: ASTNode, module_qn: str
+        self,
+        method_call_node: ASTNode,
+        module_qn: str,
+        local_var_types: dict[str, str] | None = None,
     ) -> str | None:
         call_info = extract_method_call_info(method_call_node)
         if not call_info:
@@ -391,6 +400,19 @@ class JavaVariableAnalyzerMixin:
         if not method_name:
             return None
 
+        # Resolve the nested call properly first: it is overload-sensitive, and
+        # the name-only lookup below takes the FIRST declaration's return type,
+        # so `take(make("x"))` could be typed from `make(int)`. The resolved qn
+        # carries the SELECTED signature, which reads back the right return
+        # type. Needs the caller's variable types, or the receiver of an
+        # instance call cannot be typed (issue #1348).
+        if (
+            resolved := self._resolve_nested_java_call(
+                method_call_node, module_qn, local_var_types or {}
+            )
+        ) and (declared := self._declared_return_type_of(resolved[1])):
+            return declared
+
         object_ref = call_info[cs.FIELD_OBJECT]
         call_string = (
             f"{object_ref}{cs.SEPARATOR_DOT}{method_name}"
@@ -398,6 +420,33 @@ class JavaVariableAnalyzerMixin:
             else str(method_name)
         )
         return self._resolve_java_method_return_type(call_string, module_qn)
+
+    @abstractmethod
+    def _do_resolve_java_method_call(
+        self,
+        call_node: ASTNode,
+        local_var_types: dict[str, str],
+        module_qn: str,
+        caller_qn: str | None = None,
+    ) -> tuple[str, str] | None: ...
+
+    @abstractmethod
+    def _declared_return_type_of(self, method_qn: str) -> str | None: ...
+
+    @recursion_guard(
+        key_func=lambda self, call_node, *_, **__: call_node.id,
+        guard_name=cs.GUARD_NESTED_JAVA_CALL,
+    )
+    def _resolve_nested_java_call(
+        self,
+        call_node: ASTNode,
+        module_qn: str,
+        local_var_types: dict[str, str],
+    ) -> tuple[str, str] | None:
+        # Guarded: resolution infers its ARGUMENT types, and typing an argument
+        # comes back here, so a call nested in its own argument list would
+        # recurse without a brake.
+        return self._do_resolve_java_method_call(call_node, local_var_types, module_qn)
 
     def _infer_java_field_access_type(
         self, field_access_node: ASTNode, module_qn: str

--- a/codebase_rag/parsers/java/variable_analyzer.py
+++ b/codebase_rag/parsers/java/variable_analyzer.py
@@ -352,10 +352,17 @@ class JavaVariableAnalyzerMixin:
 
             case cs.TS_IDENTIFIER:
                 if var_name := safe_decode_text(expr_node):
+                    # The caller's own locals first: the module-wide lookup is
+                    # name-keyed across every method, so a same-named local in
+                    # another method would answer for this one (issue #1348).
+                    if local_var_types and var_name in local_var_types:
+                        return local_var_types[var_name]
                     return self._lookup_variable_type(var_name, module_qn)
 
             case cs.TS_FIELD_ACCESS:
-                return self._infer_java_field_access_type(expr_node, module_qn)
+                return self._infer_java_field_access_type(
+                    expr_node, module_qn, local_var_types
+                )
 
             case cs.TS_STRING_LITERAL:
                 return cs.JAVA_TYPE_STRING
@@ -443,7 +450,10 @@ class JavaVariableAnalyzerMixin:
         return self._do_resolve_java_method_call(call_node, local_var_types, module_qn)
 
     def _infer_java_field_access_type(
-        self, field_access_node: ASTNode, module_qn: str
+        self,
+        field_access_node: ASTNode,
+        module_qn: str,
+        local_var_types: dict[str, str] | None = None,
     ) -> str | None:
         object_node = field_access_node.child_by_field_name(cs.FIELD_OBJECT)
         field_node = field_access_node.child_by_field_name(cs.FIELD_FIELD)
@@ -459,10 +469,12 @@ class JavaVariableAnalyzerMixin:
         # recurse to infer that inner type before the outer field, so multi-level
         # access resolves instead of failing on a non-variable name.
         if object_node.type == cs.TS_FIELD_ACCESS:
-            object_type = self._infer_java_field_access_type(object_node, module_qn)
+            object_type = self._infer_java_field_access_type(
+                object_node, module_qn, local_var_types
+            )
         elif object_name := safe_decode_text(object_node):
             object_type = self._resolve_field_access_base_type(
-                object_name, field_access_node, module_qn
+                object_name, field_access_node, module_qn, local_var_types
             )
         else:
             object_type = None
@@ -472,8 +484,16 @@ class JavaVariableAnalyzerMixin:
         return None
 
     def _resolve_field_access_base_type(
-        self, object_name: str, field_access_node: ASTNode, module_qn: str
+        self,
+        object_name: str,
+        field_access_node: ASTNode,
+        module_qn: str,
+        local_var_types: dict[str, str] | None = None,
     ) -> str | None:
+        # The caller's own locals win over the module-wide, name-keyed map,
+        # which cannot tell two methods' same-named variables apart.
+        if local_var_types and object_name in local_var_types:
+            return local_var_types[object_name]
         # `this`/`super` are receiver keywords, not variables: resolve them to the
         # containing class or its superclass so nested chains rooted at them
         # (e.g. `var c = this.address.city`) infer a type.

--- a/codebase_rag/parsers/java/variable_analyzer.py
+++ b/codebase_rag/parsers/java/variable_analyzer.py
@@ -24,6 +24,32 @@ if TYPE_CHECKING:
     from ...types_defs import ASTCacheProtocol
 
 
+def _java_literal_type(expr_node: ASTNode) -> str | None:
+    # A literal's type is fixed by its node type, and for the numeric ones by
+    # its suffix: `1L` is a long, `1.5f` a float.
+    node_type = expr_node.type
+    if node_type == cs.TS_STRING_LITERAL:
+        return cs.JAVA_TYPE_STRING
+    if node_type == cs.TS_JAVA_CHARACTER_LITERAL:
+        return cs.JAVA_TYPE_CHAR
+    if node_type in (cs.TS_TRUE, cs.TS_FALSE):
+        return cs.JAVA_TYPE_BOOLEAN
+    text = safe_decode_text(expr_node) or ""
+    if node_type in cs.TS_JAVA_FLOATING_POINT_LITERALS:
+        return (
+            cs.JAVA_TYPE_FLOAT
+            if text.endswith(cs.JAVA_FLOAT_SUFFIXES)
+            else cs.JAVA_TYPE_DOUBLE
+        )
+    if node_type in cs.TS_JAVA_INTEGER_LITERALS:
+        return (
+            cs.JAVA_TYPE_LONG_PRIMITIVE
+            if text.endswith(cs.JAVA_LONG_SUFFIXES)
+            else cs.JAVA_TYPE_INT
+        )
+    return None
+
+
 class JavaVariableAnalyzerMixin:
     __slots__ = ()
     ast_cache: ASTCacheProtocol
@@ -340,6 +366,11 @@ class JavaVariableAnalyzerMixin:
         module_qn: str,
         local_var_types: dict[str, str] | None = None,
     ) -> str | None:
+        # Literals carry their type in the node itself, with no lookup and no
+        # scope: keeping them out of this switch keeps it readable.
+        if (literal := _java_literal_type(expr_node)) is not None:
+            return literal
+
         match expr_node.type:
             case cs.TS_OBJECT_CREATION_EXPRESSION:
                 if type_node := expr_node.child_by_field_name(cs.FIELD_TYPE):
@@ -362,31 +393,6 @@ class JavaVariableAnalyzerMixin:
             case cs.TS_FIELD_ACCESS:
                 return self._infer_java_field_access_type(
                     expr_node, module_qn, local_var_types
-                )
-
-            case cs.TS_STRING_LITERAL:
-                return cs.JAVA_TYPE_STRING
-
-            case cs.TS_JAVA_CHARACTER_LITERAL:
-                return cs.JAVA_TYPE_CHAR
-
-            case node_type if node_type in cs.TS_JAVA_FLOATING_POINT_LITERALS:
-                text = safe_decode_text(expr_node) or ""
-                return (
-                    cs.JAVA_TYPE_FLOAT
-                    if text.endswith(cs.JAVA_FLOAT_SUFFIXES)
-                    else cs.JAVA_TYPE_DOUBLE
-                )
-
-            case cs.TS_TRUE | cs.TS_FALSE:
-                return cs.JAVA_TYPE_BOOLEAN
-
-            case node_type if node_type in cs.TS_JAVA_INTEGER_LITERALS:
-                text = safe_decode_text(expr_node) or ""
-                return (
-                    cs.JAVA_TYPE_LONG_PRIMITIVE
-                    if text.endswith(cs.JAVA_LONG_SUFFIXES)
-                    else cs.JAVA_TYPE_INT
                 )
 
             case cs.TS_ARRAY_CREATION_EXPRESSION:

--- a/codebase_rag/parsers/java/variable_analyzer.py
+++ b/codebase_rag/parsers/java/variable_analyzer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from loguru import logger
@@ -30,6 +31,11 @@ class JavaVariableAnalyzerMixin:
     class_inheritance: dict[str, list[str]]
     _lookup_cache: dict[str, str | None]
     _lookup_in_progress: set[str]
+    # Annotation only, never a def: this mixin precedes JavaMethodResolverMixin
+    # in the MRO, so even an @abstractmethod stub here would SHADOW the real
+    # implementation and silently resolve every call to None.
+    _do_resolve_java_method_call: Callable[..., tuple[str, str] | None]
+    _declared_return_type_of: Callable[[str], str | None]
 
     @abstractmethod
     def _resolve_java_type_name(self, type_name: str, module_qn: str) -> str: ...
@@ -420,18 +426,6 @@ class JavaVariableAnalyzerMixin:
             else str(method_name)
         )
         return self._resolve_java_method_return_type(call_string, module_qn)
-
-    @abstractmethod
-    def _do_resolve_java_method_call(
-        self,
-        call_node: ASTNode,
-        local_var_types: dict[str, str],
-        module_qn: str,
-        caller_qn: str | None = None,
-    ) -> tuple[str, str] | None: ...
-
-    @abstractmethod
-    def _declared_return_type_of(self, method_qn: str) -> str | None: ...
 
     @recursion_guard(
         key_func=lambda self, call_node, *_, **__: call_node.id,

--- a/codebase_rag/tests/test_java_nested_call_arguments.py
+++ b/codebase_rag/tests/test_java_nested_call_arguments.py
@@ -1,0 +1,120 @@
+# Issue #1348: a nested call argument was typed by NAME only, so an overloaded
+# inner call contributed the first declaration's return type and the outer call
+# bound the wrong overload.
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from codebase_rag.graph_updater import GraphUpdater
+from codebase_rag.parser_loader import load_parsers
+from codebase_rag.tests.conftest import get_relationships
+
+_SOURCE = """
+class Wrong {{ }}
+class Right {{ }}
+class Factory {{
+    public Wrong make(int n) {{ return new Wrong(); }}
+    public Right make(String s) {{ return new Right(); }}
+    public void take(Wrong wrong) {{ }}
+    public void take(Right right) {{ }}
+}}
+public class Main {{
+    public static void main(String[] args) {{
+        Factory factory = new Factory();
+        {call}
+    }}
+}}
+"""
+
+
+def _targets(project: Path, mock_ingestor: MagicMock, source: str) -> set[str]:
+    (project / "src").mkdir(parents=True)
+    (project / "src" / "Main.java").write_text(source, encoding="utf-8")
+    parsers, queries = load_parsers()
+    GraphUpdater(
+        ingestor=mock_ingestor, repo_path=project, parsers=parsers, queries=queries
+    ).run()
+    return {c.args[2][2] for c in get_relationships(mock_ingestor, "CALLS")}
+
+
+def test_nested_call_is_typed_from_its_selected_overload(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    targets = _targets(
+        temp_repo / "proj",
+        mock_ingestor,
+        _SOURCE.format(call='factory.take(factory.make("x"));'),
+    )
+    assert "proj.src.Main.Factory.make(String)" in targets
+    assert "proj.src.Main.Factory.take(Right)" in targets
+    assert "proj.src.Main.Factory.take(Wrong)" not in targets
+
+
+def test_the_other_nested_overload_selects_the_other_target(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The mirror case: the ranking must follow the argument, not the
+    # declaration order of `make`.
+    targets = _targets(
+        temp_repo / "proj",
+        mock_ingestor,
+        _SOURCE.format(call="factory.take(factory.make(1));"),
+    )
+    assert "proj.src.Main.Factory.take(Wrong)" in targets
+    assert "proj.src.Main.Factory.take(Right)" not in targets
+
+
+def test_nested_call_on_a_field_receiver(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # The receiver is a field rather than a local, so it resolves through the
+    # field-type lookup instead of the caller's variable map.
+    targets = _targets(
+        temp_repo / "proj",
+        mock_ingestor,
+        """
+class Wrong { }
+class Right { }
+class Factory {
+    public Wrong make(int n) { return new Wrong(); }
+    public Right make(String s) { return new Right(); }
+    public void take(Wrong wrong) { }
+    public void take(Right right) { }
+}
+public class Main {
+    private Factory factory = new Factory();
+    public void run() {
+        this.factory.take(this.factory.make("x"));
+    }
+}
+""",
+    )
+    assert "proj.src.Main.Factory.take(Right)" in targets
+    assert "proj.src.Main.Factory.take(Wrong)" not in targets
+
+
+def test_a_deeply_nested_argument_chain_terminates(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # Argument typing calls resolution and resolution types arguments, so a
+    # call nested inside its own argument list must not recurse without a
+    # brake; three levels is enough to exercise the descent.
+    targets = _targets(
+        temp_repo / "proj",
+        mock_ingestor,
+        """
+class Factory {
+    public String echo(String s) { return s; }
+    public void take(String s) { }
+}
+public class Main {
+    public static void main(String[] args) {
+        Factory factory = new Factory();
+        factory.take(factory.echo(factory.echo(factory.echo("x"))));
+    }
+}
+""",
+    )
+    assert "proj.src.Main.Factory.take(String)" in targets
+    assert "proj.src.Main.Factory.echo(String)" in targets

--- a/codebase_rag/tests/test_java_nested_call_arguments.py
+++ b/codebase_rag/tests/test_java_nested_call_arguments.py
@@ -118,3 +118,38 @@ public class Main {
     )
     assert "proj.src.Main.Factory.take(String)" in targets
     assert "proj.src.Main.Factory.echo(String)" in targets
+
+
+def test_field_access_argument_uses_the_active_methods_locals(
+    temp_repo: Path, mock_ingestor: MagicMock
+) -> None:
+    # `holder` is declared in TWO methods with different types. The base of a
+    # field-access argument must resolve through the CALLER's locals, not a
+    # module-wide name lookup that can land on the other method's variable.
+    targets = _targets(
+        temp_repo / "proj",
+        mock_ingestor,
+        """
+class Wrong { }
+class Right { }
+class WrongHolder { public Wrong target = new Wrong(); }
+class RightHolder { public Right target = new Right(); }
+class Factory {
+    public void take(Wrong wrong) { }
+    public void take(Right right) { }
+}
+public class Main {
+    public void run() {
+        RightHolder holder = new RightHolder();
+        Factory factory = new Factory();
+        factory.take(holder.target);
+    }
+    public void other() {
+        WrongHolder holder = new WrongHolder();
+        System.out.println(holder);
+    }
+}
+""",
+    )
+    assert "proj.src.Main.Factory.take(Right)" in targets
+    assert "proj.src.Main.Factory.take(Wrong)" not in targets


### PR DESCRIPTION
Closes #1348. Raised by CodeRabbit on #1346, filed rather than bolted on, fixed here.

## The bug

`_infer_java_method_return_type` typed a nested call by NAME (`_resolve_java_method_return_type` builds a `receiver.method` string), so an overloaded inner call contributed the FIRST declaration's return type. `take(make("x"))` was typed from `make(int)` and bound `take(Wrong)`, even though the inner `make(String)` edge itself was already correct.

Same defect the chained-receiver path had in #1343, fixed the same way: resolve the inner call, then read the return type back off the SELECTED signature via `_declared_return_type_of`.

## Why it needed its own PR

It could not be done from where the code sat. `_infer_java_type_from_expression` and `_infer_java_method_return_type` never received `local_var_types`, so the receiver of an instance call (`factory`, a local) could not be typed, the inner resolution returned None, and nothing improved. This threads the caller's variable types through both, which is the change that touches every caller and is why it did not ride along with the literal-typing fix.

`_resolve_nested_java_call` carries a `@recursion_guard`. To be precise about what that is for: argument typing calls resolution and resolution types arguments, so the descent is mutual. I did not observe an infinite recursion (each step moves to a child node), so the guard is defensive rather than a fix for an observed hang; `test_a_deeply_nested_argument_chain_terminates` exercises three levels.

## A mistake worth recording in the diff

My first attempt declared `_do_resolve_java_method_call` and `_declared_return_type_of` as `@abstractmethod` stubs on `JavaVariableAnalyzerMixin`, matching how `JavaMethodResolverMixin` declares ITS cross-mixin dependencies. That broke 72 tests: the MRO is (TypeResolver, VariableAnalyzer, MethodResolver), so a stub in VariableAnalyzer PRECEDES the real implementation and wins, resolving every Java call to None. The direction matters -- only a mixin that comes later may declare abstracts for methods implemented earlier. They are annotation-only declarations now, with a comment saying why, since an annotation creates no runtime attribute.

## Tests

`test_java_nested_call_arguments.py`, verified red first: the issue's `make(int)`/`make(String)` reproduction, its mirror with the int argument selecting the other target (so the pick follows the argument, not the declaration order of `make`), the same shape with a FIELD receiver rather than a local, and the three-level chain.

Java battery: 689 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Java method resolution for nested calls and overloaded methods.
  * Nested call arguments now use local-variable and field types to select the correct overload.
  * Improved return-type inference across nested method calls and field-access chains.
  * Prevented unbounded recursion when resolving deeply nested method-call chains.

* **Tests**
  * Added coverage for nested overloads, field-based receivers, deeply nested calls, and locally declared variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->