### PR TITLE
feat: emit Roslyn out and ref write-back facts so the written local carries the call's taint

### DIFF
--- a/codebase_rag/graph_updater.py
+++ b/codebase_rag/graph_updater.py
@@ -501,6 +501,7 @@ class GraphUpdater:
         dp.csharp_call_sites.clear()
         dp.csharp_arg_flows.clear()
         dp.csharp_bind_flows.clear()
+        dp.csharp_out_writes.clear()
         dp.csharp_external_sites.clear()
         self._csharp_partial_decls = []
         self._csharp_query_calls = []
@@ -513,6 +514,7 @@ class GraphUpdater:
         dp.csharp_call_sites.update(facts.resolved_call_sites)
         dp.csharp_arg_flows.update(facts.arg_flows)
         dp.csharp_bind_flows.update(facts.bind_flows)
+        dp.csharp_out_writes.update(facts.out_writes)
         dp.csharp_external_sites.update(facts.external_sites)
         self._csharp_partial_decls = facts.partial_groups
         self._csharp_query_calls = facts.query_calls

--- a/codebase_rag/parsers/csharp_frontend/frontend.py
+++ b/codebase_rag/parsers/csharp_frontend/frontend.py
@@ -77,11 +77,17 @@ class CSharpSemanticFacts(NamedTuple):
     # the bound variable looks clean to every later read.
     bind_flows: dict[CallSiteKey, frozenset[str]]
 
+    # Per call site, the argument INDEX -> the local/parameter the callee writes
+    # through an `out`/`ref` parameter. The mirror of arg_flows: without these a
+    # variable filled by `TryParse(s, out var n)` looks untouched, so a sink fed
+    # from it has no edge.
+    out_writes: dict[CallSiteKey, dict[int, str]]
+
 
 def _empty_facts() -> CSharpSemanticFacts:
     # A fresh instance per failure path: the maps are handed to mutable
     # processor state, so a shared constant would alias across runs.
-    return CSharpSemanticFacts({}, {}, [], [], set(), {}, {})
+    return CSharpSemanticFacts({}, {}, [], [], set(), {}, {}, {})
 
 
 _DOTNET = "dotnet"
@@ -326,6 +332,7 @@ def _parse_payload(stdout: str, stderr: str = "") -> CSharpSemanticFacts:
         },
         arg_flows=_arg_flows(payload.get("arg_flows", [])),
         bind_flows=_bind_flows(payload.get("bind_flows", [])),
+        out_writes=_out_writes(payload.get("out_writes", [])),
     )
     if not any(facts) and stderr.strip():
         # A well-formed but entirely empty payload means the workspace load
@@ -380,6 +387,27 @@ def _bind_flows(rows: list) -> dict[CallSiteKey, frozenset[str]]:
         if symbols:
             flows[key] = symbols
     return flows
+
+
+def _out_writes(rows: list) -> dict[CallSiteKey, dict[int, str]]:
+    # Keyed exactly like the call facts. Malformed rows drop: worst case that
+    # argument keeps today's lexical behaviour.
+    writes: dict[CallSiteKey, dict[int, str]] = {}
+    for row in rows:
+        try:
+            key: CallSiteKey = (
+                row["file"],
+                int(row["line"]),
+                int(row["col"]),
+                row["name"],
+            )
+            index = int(row["index"])
+            symbol = row["symbol"]
+        except (KeyError, TypeError, ValueError):
+            continue
+        if isinstance(symbol, str) and symbol:
+            writes.setdefault(key, {})[index] = symbol
+    return writes
 
 
 def _base_kinds(bases: list[dict[str, str]]) -> dict[str, str]:

--- a/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
@@ -408,7 +408,7 @@ public static class Frontend
                 // variable.
                 if (argument.RefKindKeyword.IsKind(SyntaxKind.RefKeyword))
                 {
-                    if (!RefParameterIsWritten(model, invocation, index))
+                    if (!RefParameterIsWritten(model, invocation, argument, index))
                     {
                         continue;
                     }
@@ -435,27 +435,51 @@ public static class Frontend
         private static bool RefParameterIsWritten(
             SemanticModel model,
             InvocationExpressionSyntax invocation,
+            ArgumentSyntax argument,
             int index)
         {
             if (model.GetSymbolInfo(invocation).Symbol is not IMethodSymbol method
-                || index >= method.Parameters.Length)
+                || BoundParameter(method, argument, index) is not { } parameter)
             {
                 return false;
             }
             var declaration = method.DeclaringSyntaxReferences.FirstOrDefault();
-            if (declaration?.GetSyntax() is not MethodDeclarationSyntax declared
-                || declared.Body is not { } body)
+            if (CallableBody(declaration?.GetSyntax()) is not { } body)
             {
                 return false;
             }
-            var calleeModel = model.Compilation.GetSemanticModel(declared.SyntaxTree);
+            var calleeModel = model.Compilation.GetSemanticModel(body.SyntaxTree);
             if (calleeModel.AnalyzeDataFlow(body) is not { Succeeded: true } flow)
             {
                 return false;
             }
-            return flow.WrittenInside.Contains(
-                method.Parameters[index], SymbolEqualityComparer.Default);
+            return flow.WrittenInside.Contains(parameter, SymbolEqualityComparer.Default);
         }
+
+        // A NAMED argument (`Fill(dst: ref sink, src: token)`) does not sit at
+        // its parameter's ordinal, so the source-order index is only valid for
+        // positional arguments.
+        private static IParameterSymbol? BoundParameter(
+            IMethodSymbol method, ArgumentSyntax argument, int index)
+        {
+            if (argument.NameColon?.Name.Identifier.ValueText is { } named)
+            {
+                return method.Parameters.FirstOrDefault(p => p.Name == named);
+            }
+            return index < method.Parameters.Length ? method.Parameters[index] : null;
+        }
+
+        // Both callable forms and both body shapes: a method or a local
+        // function, written as a block or as an expression body. Rejecting the
+        // expression forms would silently treat a writing callee as read-only.
+        private static SyntaxNode? CallableBody(SyntaxNode? declaration) => declaration switch
+        {
+            MethodDeclarationSyntax method =>
+                (SyntaxNode?)method.Body ?? method.ExpressionBody?.Expression,
+            LocalFunctionStatementSyntax local =>
+                (SyntaxNode?)local.Body ?? local.ExpressionBody?.Expression,
+            _ => null,
+        };
 
         // `out var n` declares the variable inline, so the symbol comes from the
         // declaration rather than from a reference; a plain `out n` is an

--- a/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
@@ -454,7 +454,11 @@ public static class Frontend
             // for an extension method, then the implementing half of a partial
             // (the defining half has no body and would look unprovable).
             var reduced = invoked.ReducedFrom;
-            var method = reduced ?? invoked;
+            // OriginalDefinition too: a CONSTRUCTED generic method
+            // (`Fill<string>`) carries substituted parameter symbols, while the
+            // WrittenInside set comes from the declaration and holds the
+            // originals, so comparing the two reports no write.
+            var method = (reduced ?? invoked).OriginalDefinition;
             method = method.PartialImplementationPart ?? method;
             var ordinal = bound.Ordinal + (reduced is null ? 0 : 1);
             if (ordinal >= method.Parameters.Length)

--- a/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
@@ -401,8 +401,19 @@ public static class Frontend
             for (var index = 0; index < arguments.Value.Count; index++)
             {
                 var argument = arguments.Value[index];
-                if (!argument.RefKindKeyword.IsKind(SyntaxKind.OutKeyword)
-                    && !argument.RefKindKeyword.IsKind(SyntaxKind.RefKeyword))
+                // `out` is written by the language's own rule: a method must
+                // definitely assign every out parameter before it returns.
+                // `ref` only PERMITS a write, so it has to be proven, or a
+                // read-only ref helper would fabricate a flow into the caller's
+                // variable.
+                if (argument.RefKindKeyword.IsKind(SyntaxKind.RefKeyword))
+                {
+                    if (!RefParameterIsWritten(model, invocation, index))
+                    {
+                        continue;
+                    }
+                }
+                else if (!argument.RefKindKeyword.IsKind(SyntaxKind.OutKeyword))
                 {
                     continue;
                 }
@@ -416,6 +427,34 @@ public static class Frontend
                 }
                 _outWrites.Add(new OutWriteFact(rel, line, col, name, index, symbol));
             }
+        }
+
+        // Does the callee actually assign this `ref` parameter? Answerable only
+        // for a first-party body: an external ref callee cannot be inspected,
+        // so it is treated as read-only rather than assumed to write.
+        private static bool RefParameterIsWritten(
+            SemanticModel model,
+            InvocationExpressionSyntax invocation,
+            int index)
+        {
+            if (model.GetSymbolInfo(invocation).Symbol is not IMethodSymbol method
+                || index >= method.Parameters.Length)
+            {
+                return false;
+            }
+            var declaration = method.DeclaringSyntaxReferences.FirstOrDefault();
+            if (declaration?.GetSyntax() is not MethodDeclarationSyntax declared
+                || declared.Body is not { } body)
+            {
+                return false;
+            }
+            var calleeModel = model.Compilation.GetSemanticModel(declared.SyntaxTree);
+            if (calleeModel.AnalyzeDataFlow(body) is not { Succeeded: true } flow)
+            {
+                return false;
+            }
+            return flow.WrittenInside.Contains(
+                method.Parameters[index], SymbolEqualityComparer.Default);
         }
 
         // `out var n` declares the variable inline, so the symbol comes from the

--- a/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
@@ -438,13 +438,30 @@ public static class Frontend
             ArgumentSyntax argument,
             int index)
         {
-            if (model.GetSymbolInfo(invocation).Symbol is not IMethodSymbol method
-                || BoundParameter(method, argument, index) is not { } parameter)
+            if (model.GetSymbolInfo(invocation).Symbol is not IMethodSymbol invoked)
+            {
+                return false;
+            }
+            // Normalize before touching parameters or syntax: a reduced
+            // extension method (`x.Ext(...)`) hides its real first parameter,
+            // and a partial method's symbol can point at the DEFINING part,
+            // which has no body. Both would otherwise look unprovable.
+            var method = invoked.ReducedFrom ?? invoked;
+            method = method.PartialImplementationPart ?? method;
+            if (BoundParameter(method, argument, index) is not { } parameter)
             {
                 return false;
             }
             var declaration = method.DeclaringSyntaxReferences.FirstOrDefault();
             if (CallableBody(declaration?.GetSyntax()) is not { } body)
+            {
+                return false;
+            }
+            // A body in a REFERENCED project belongs to another compilation;
+            // asking this one for its model throws. The collector holds no
+            // workspace, so that call cannot be proven here -- treat it as
+            // read-only, the same conservative answer as an external callee.
+            if (!model.Compilation.ContainsSyntaxTree(body.SyntaxTree))
             {
                 return false;
             }

--- a/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
@@ -94,6 +94,8 @@ public static class Frontend
         private readonly List<CallFact> _calls = new();
         private readonly List<ExternalFact> _externals = new();
         private readonly List<ArgFlowFact> _argFlows = new();
+        private readonly List<OutWriteFact> _outWrites = new();
+        private readonly HashSet<(string, int, int, string, int)> _seenOutWrites = new();
         private readonly List<BindFlowFact> _bindFlows = new();
         private readonly List<QueryFact> _queries = new();
         private readonly Dictionary<string, List<DeclLoc>> _partials = new(StringComparer.Ordinal);
@@ -159,7 +161,7 @@ public static class Frontend
             }
         }
 
-        public Payload ToPayload() => new(_types, _calls, _partials.Values.ToList(), _queries, _externals, _argFlows, _bindFlows);
+        public Payload ToPayload() => new(_types, _calls, _partials.Values.ToList(), _queries, _externals, _argFlows, _bindFlows, _outWrites);
 
         private string Rel(string path) =>
             Path.GetRelativePath(_rootFull, path).Replace(Path.DirectorySeparatorChar, '/');
@@ -233,6 +235,7 @@ public static class Frontend
             // Console.WriteLine is external, and that is exactly where knowing
             // which locals reach an argument matters (issue #1187).
             CollectArgFlows(model, invocation, rel, pos.Line + 1, col, name);
+            CollectOutWrites(model, invocation, rel, pos.Line + 1, col, name);
             var declared = DeclaredMethod(symbol);
             if (FirstPartyDecl(declared) is not { } target)
             {
@@ -375,6 +378,62 @@ public static class Frontend
                 }
                 _argFlows.Add(new ArgFlowFact(rel, line, col, name, index, symbols));
             }
+        }
+
+        // The mirror of an argument flow: an `out`/`ref` argument is written BY
+        // the callee, so the variable it names receives whatever the call
+        // produced. Without this `TryParse(s, out var n)` leaves n untouched and
+        // a sink fed from n has no edge. Emitted for external callees too --
+        // int.TryParse is external and still writes its out parameter.
+        private void CollectOutWrites(
+            SemanticModel model,
+            InvocationExpressionSyntax invocation,
+            string rel,
+            int line,
+            int col,
+            string name)
+        {
+            var arguments = invocation.ArgumentList?.Arguments;
+            if (arguments is null)
+            {
+                return;
+            }
+            for (var index = 0; index < arguments.Value.Count; index++)
+            {
+                var argument = arguments.Value[index];
+                if (!argument.RefKindKeyword.IsKind(SyntaxKind.OutKeyword)
+                    && !argument.RefKindKeyword.IsKind(SyntaxKind.RefKeyword))
+                {
+                    continue;
+                }
+                if (WrittenSymbol(model, argument.Expression) is not { } symbol)
+                {
+                    continue;
+                }
+                if (!_seenOutWrites.Add((rel, line, col, name, index)))
+                {
+                    continue;
+                }
+                _outWrites.Add(new OutWriteFact(rel, line, col, name, index, symbol));
+            }
+        }
+
+        // `out var n` declares the variable inline, so the symbol comes from the
+        // declaration rather than from a reference; a plain `out n` is an
+        // ordinary identifier.
+        private static string? WrittenSymbol(SemanticModel model, ExpressionSyntax expression)
+        {
+            if (expression is DeclarationExpressionSyntax declaration)
+            {
+                return declaration.Designation is SingleVariableDesignationSyntax single
+                    && model.GetDeclaredSymbol(single) is { } declared
+                    ? declared.Name
+                    : null;
+            }
+            var symbol = model.GetSymbolInfo(expression).Symbol;
+            return symbol is { Kind: SymbolKind.Local or SymbolKind.Parameter }
+                ? symbol.Name
+                : null;
         }
 
         // Query syntax desugars to operator method calls with no invocation nodes;
@@ -705,6 +764,14 @@ public static class Frontend
         [property: JsonPropertyName("index")] int Index,
         [property: JsonPropertyName("symbols")] List<string> Symbols);
 
+    private record OutWriteFact(
+        [property: JsonPropertyName("file")] string File,
+        [property: JsonPropertyName("line")] int Line,
+        [property: JsonPropertyName("col")] int Col,
+        [property: JsonPropertyName("name")] string Name,
+        [property: JsonPropertyName("index")] int Index,
+        [property: JsonPropertyName("symbol")] string Symbol);
+
     private record BindFlowFact(
         [property: JsonPropertyName("file")] string File,
         [property: JsonPropertyName("line")] int Line,
@@ -719,5 +786,6 @@ public static class Frontend
         [property: JsonPropertyName("queries")] List<QueryFact> Queries,
         [property: JsonPropertyName("externals")] List<ExternalFact> Externals,
         [property: JsonPropertyName("arg_flows")] List<ArgFlowFact> ArgFlows,
-        [property: JsonPropertyName("bind_flows")] List<BindFlowFact> BindFlows);
+        [property: JsonPropertyName("bind_flows")] List<BindFlowFact> BindFlows,
+        [property: JsonPropertyName("out_writes")] List<OutWriteFact> OutWrites);
 }

--- a/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
+++ b/codebase_rag/parsers/csharp_frontend/roslyn/Frontend.cs
@@ -442,16 +442,26 @@ public static class Frontend
             {
                 return false;
             }
-            // Normalize before touching parameters or syntax: a reduced
-            // extension method (`x.Ext(...)`) hides its real first parameter,
-            // and a partial method's symbol can point at the DEFINING part,
-            // which has no body. Both would otherwise look unprovable.
-            var method = invoked.ReducedFrom ?? invoked;
-            method = method.PartialImplementationPart ?? method;
-            if (BoundParameter(method, argument, index) is not { } parameter)
+            // Bind the argument against the INVOKED symbol, before any
+            // normalization: in receiver style (`token.Fill(ref sink)`) the
+            // reduced symbol is what the source indices line up with, while
+            // ReducedFrom carries an extra receiver parameter at ordinal 0.
+            if (BoundParameter(invoked, argument, index) is not { } bound)
             {
                 return false;
             }
+            // Only now normalize to the symbol that OWNS a body: ReducedFrom
+            // for an extension method, then the implementing half of a partial
+            // (the defining half has no body and would look unprovable).
+            var reduced = invoked.ReducedFrom;
+            var method = reduced ?? invoked;
+            method = method.PartialImplementationPart ?? method;
+            var ordinal = bound.Ordinal + (reduced is null ? 0 : 1);
+            if (ordinal >= method.Parameters.Length)
+            {
+                return false;
+            }
+            var parameter = method.Parameters[ordinal];
             var declaration = method.DeclaringSyntaxReferences.FirstOrDefault();
             if (CallableBody(declaration?.GetSyntax()) is not { } body)
             {

--- a/codebase_rag/parsers/definition_processor.py
+++ b/codebase_rag/parsers/definition_processor.py
@@ -164,6 +164,7 @@ class DefinitionProcessor(
         # argument index, the locals/parameters the compiler proves reach it.
         self.csharp_arg_flows: dict[CallSiteKey, dict[int, frozenset[str]]] = {}
         self.csharp_bind_flows: dict[CallSiteKey, frozenset[str]] = {}
+        self.csharp_out_writes: dict[CallSiteKey, dict[int, str]] = {}
         # Go go/types frontend (issue #1179): the same two call families as C#
         # -- per-invocation exact first-party call targets keyed on the callee
         # NAME token location, and sites the compiler resolved OUTSIDE the module

--- a/codebase_rag/parsers/factory.py
+++ b/codebase_rag/parsers/factory.py
@@ -144,6 +144,7 @@ class ProcessorFactory:
                 csharp_call_sites=self.definition_processor.csharp_call_sites,
                 csharp_arg_flows=self.definition_processor.csharp_arg_flows,
                 csharp_bind_flows=self.definition_processor.csharp_bind_flows,
+                csharp_out_writes=self.definition_processor.csharp_out_writes,
                 csharp_external_sites=self.definition_processor.csharp_external_sites,
                 csharp_local_functions=self.definition_processor.csharp_local_functions,
                 csharp_generic_methods=self.definition_processor.csharp_generic_methods,

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -2703,6 +2703,13 @@ class FlowProcessor:
             if index in writes:
                 continue
             inputs = _merge_optional_taints(inputs, taint)
+        # An extension method called in receiver style (`token.Fill(ref sink)`)
+        # takes its source from the RECEIVER, which is not in the argument list
+        # at all; for an ordinary instance call the receiver is usually clean
+        # and contributes nothing.
+        inputs = _merge_optional_taints(
+            inputs, self._js_receiver_taint(node, tainted, jc)
+        )
         if inputs is None:
             return
         for symbol in writes.values():
@@ -2710,6 +2717,15 @@ class FlowProcessor:
                 merged := _merge_optional_taints(tainted.get(symbol), inputs)
             ) is not None:
                 tainted[symbol] = merged
+
+    def _js_receiver_taint(
+        self, node: Node, tainted: _TaintMap, jc: _JsCtx
+    ) -> Taint | None:
+        func = node.child_by_field_name(cs.TS_FIELD_FUNCTION)
+        if func is None:
+            return None
+        receiver = func.child_by_field_name(jc.descriptor.object_field)
+        return None if receiver is None else self._js_expr_taint(receiver, tainted, jc)
 
     def _csharp_out_write_symbols(self, node: Node, jc: _JsCtx) -> dict[int, str]:
         writes = self._resolver.type_inference.csharp_out_writes

--- a/codebase_rag/parsers/flow_access/processor.py
+++ b/codebase_rag/parsers/flow_access/processor.py
@@ -1509,6 +1509,7 @@ class FlowProcessor:
         args = self._js_arg_taints(node, tainted, jc)
         if not args:
             return
+        self._apply_csharp_out_writes(node, args, tainted, jc)
         if (sink := self._js_match_sink(raw, jc.flow.write_sinks, jc)) is not None:
             dst_identity = literal_target(
                 node,
@@ -2680,6 +2681,51 @@ class FlowProcessor:
             ):
                 return child
         return None
+
+    def _apply_csharp_out_writes(
+        self,
+        node: Node,
+        args: list[tuple[str, Taint | None]],
+        tainted: _TaintMap,
+        jc: _JsCtx,
+    ) -> None:
+        # Roslyn proved the callee writes these locals through `out`/`ref`
+        # parameters (issue #1187), so each receives what the call was GIVEN:
+        # `TryParse(raw, out var n)` makes n carry raw's taint. Without this the
+        # written variable looks untouched and a sink fed from it has no edge.
+        # Additive only, and the written argument's own prior taint is excluded
+        # so a variable cannot reinforce itself.
+        writes = self._csharp_out_write_symbols(node, jc)
+        if not writes:
+            return
+        inputs: Taint | None = None
+        for index, (_via, taint) in enumerate(args):
+            if index in writes:
+                continue
+            inputs = _merge_optional_taints(inputs, taint)
+        if inputs is None:
+            return
+        for symbol in writes.values():
+            if (
+                merged := _merge_optional_taints(tainted.get(symbol), inputs)
+            ) is not None:
+                tainted[symbol] = merged
+
+    def _csharp_out_write_symbols(self, node: Node, jc: _JsCtx) -> dict[int, str]:
+        writes = self._resolver.type_inference.csharp_out_writes
+        if not writes or jc.flow.language != cs.SupportedLanguage.CSHARP:
+            return {}
+        name_node = self._csharp_callee_name_node(node)
+        if name_node is None or not name_node.text:
+            return {}
+        key = call_site_key(
+            name_node,
+            name_node.text.decode(cs.ENCODING_UTF8),
+            jc.flow.module_qn,
+            self._resolver.type_inference.module_qn_to_file_path,
+            self._resolver.type_inference.repo_path,
+        )
+        return writes.get(key, {}) if key is not None else {}
 
     def _csharp_arg_symbols(self, node: Node, jc: _JsCtx) -> dict[int, frozenset[str]]:
         # The Roslyn argument-flow facts for THIS call site, keyed exactly

--- a/codebase_rag/parsers/frontends/csharp.py
+++ b/codebase_rag/parsers/frontends/csharp.py
@@ -31,6 +31,7 @@ def _adapt_csharp_semantic_facts(facts: CSharpSemanticFacts) -> SemanticFacts:
         external_sites=set(facts.external_sites),
         arg_flows=facts.arg_flows,
         bind_flows=facts.bind_flows,
+        out_writes=facts.out_writes,
         base_kinds=facts.base_kinds,
         partial_groups=facts.partial_groups,
         query_calls=[

--- a/codebase_rag/parsers/frontends/protocol.py
+++ b/codebase_rag/parsers/frontends/protocol.py
@@ -99,6 +99,11 @@ class SemanticFacts:
     # the compiler proves reach its initializer.
     bind_flows: dict[CallSiteKey, frozenset[str]] = field(default_factory=dict)
 
+    # Per call site, the argument INDEX -> the local/parameter the callee writes
+    # through an `out`/`ref` parameter: the mirror of arg_flows, so a variable
+    # filled by the call carries what the call produced.
+    out_writes: dict[CallSiteKey, dict[int, str]] = field(default_factory=dict)
+
     def is_empty(self) -> bool:
         return not (
             self.resolved_call_sites
@@ -109,6 +114,7 @@ class SemanticFacts:
             or self.implements_pairs
             or self.arg_flows
             or self.bind_flows
+            or self.out_writes
         )
 
 

--- a/codebase_rag/parsers/type_inference.py
+++ b/codebase_rag/parsers/type_inference.py
@@ -57,6 +57,7 @@ class TypeInferenceEngine:
         "csharp_call_sites",
         "csharp_arg_flows",
         "csharp_bind_flows",
+        "csharp_out_writes",
         "csharp_external_sites",
         "csharp_local_functions",
         "csharp_generic_methods",
@@ -105,6 +106,7 @@ class TypeInferenceEngine:
         csharp_call_sites: dict[CallSiteKey, ResolvedCallSite] | None = None,
         csharp_arg_flows: dict[CallSiteKey, dict[int, frozenset[str]]] | None = None,
         csharp_bind_flows: dict[CallSiteKey, frozenset[str]] | None = None,
+        csharp_out_writes: dict[CallSiteKey, dict[int, str]] | None = None,
         csharp_external_sites: set[CallSiteKey] | None = None,
         csharp_local_functions: dict[str, tuple[FunctionSpanKey, int]] | None = None,
         csharp_generic_methods: set[str] | None = None,
@@ -195,6 +197,9 @@ class TypeInferenceEngine:
         # Shared reference (as with csharp_call_sites): Roslyn argument-flow
         # facts, read by the C# path of the lean flow walk (issue #1187).
         self.csharp_arg_flows = csharp_arg_flows if csharp_arg_flows is not None else {}
+        self.csharp_out_writes = (
+            csharp_out_writes if csharp_out_writes is not None else {}
+        )
         self.csharp_bind_flows = (
             csharp_bind_flows if csharp_bind_flows is not None else {}
         )

--- a/codebase_rag/tests/test_csharp_frontend_wiring.py
+++ b/codebase_rag/tests/test_csharp_frontend_wiring.py
@@ -267,6 +267,7 @@ def _button_facts() -> object:
         external_sites=set(),
         arg_flows={},
         bind_flows={},
+        out_writes={},
     )
 
 

--- a/codebase_rag/tests/test_csharp_semantic_facts.py
+++ b/codebase_rag/tests/test_csharp_semantic_facts.py
@@ -175,6 +175,7 @@ def test_call_fact_resolves_chained_receiver_to_exact_overload(
         external_sites=set(),
         arg_flows={},
         bind_flows={},
+        out_writes={},
     )
     _hybrid(monkeypatch, facts)
 
@@ -216,6 +217,7 @@ def test_call_fact_resolves_conditional_access_invocation(
         external_sites=set(),
         arg_flows={},
         bind_flows={},
+        out_writes={},
     )
     _hybrid(monkeypatch, facts)
 
@@ -269,6 +271,7 @@ def test_call_fact_suppresses_same_arity_family_fanout(
         external_sites=set(),
         arg_flows={},
         bind_flows={},
+        out_writes={},
     )
     _hybrid(monkeypatch, facts)
 
@@ -325,6 +328,7 @@ def test_external_site_fact_suppresses_name_trie_fallback(
         external_sites={("Code.cs", call_line, call_col, "Dispose")},
         arg_flows={},
         bind_flows={},
+        out_writes={},
     )
     _hybrid(monkeypatch, facts)
 
@@ -396,6 +400,7 @@ def test_partial_fact_merges_parts_across_directories(
         external_sites=set(),
         arg_flows={},
         bind_flows={},
+        out_writes={},
     )
     _hybrid(monkeypatch, facts)
 
@@ -464,6 +469,7 @@ def test_query_fact_emits_calls_edge_for_linq_operator(
         external_sites=set(),
         arg_flows={},
         bind_flows={},
+        out_writes={},
     )
     _hybrid(monkeypatch, facts)
 
@@ -502,6 +508,7 @@ def test_query_fact_edge_respects_capture_excluding_calls(
         external_sites=set(),
         arg_flows={},
         bind_flows={},
+        out_writes={},
     )
     _hybrid(monkeypatch, facts)
 

--- a/codebase_rag/tests/test_csharp_semantic_flow.py
+++ b/codebase_rag/tests/test_csharp_semantic_flow.py
@@ -281,3 +281,31 @@ def test_a_clean_out_parameter_never_gains_a_flow(tmp_path: Path) -> None:
         "    }\n}\n"
     )
     assert _flows(tmp_path / "c2", clean, cs.CSharpFrontend.HYBRID) == set()
+
+
+# A `ref` parameter the callee never assigns: `ref` PERMITS a write, it does
+# not promise one, so treating every ref argument as written would invent an
+# ENV -> STDOUT flow through a variable the helper only reads.
+_READ_ONLY_REF = (
+    "using System;\n\n"
+    "public class Helper\n{\n"
+    "    public void Inspect(string src, ref string other)\n    {\n"
+    "        Console.Error.WriteLine(src.Length + other.Length);\n    }\n}\n\n"
+    "public class Fine\n{\n"
+    "    public void Run()\n    {\n"
+    '        var token = Environment.GetEnvironmentVariable("K");\n'
+    "        var helper = new Helper();\n"
+    '        var sink = "";\n'
+    "        helper.Inspect(token, ref sink);\n"
+    "        Console.WriteLine(sink);\n"
+    "    }\n}\n"
+)
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_a_read_only_ref_parameter_never_gains_a_flow(tmp_path: Path) -> None:
+    assert (_ENV_K, _STDOUT) not in _flows(
+        tmp_path / "r2", _READ_ONLY_REF, cs.CSharpFrontend.HYBRID
+    )

--- a/codebase_rag/tests/test_csharp_semantic_flow.py
+++ b/codebase_rag/tests/test_csharp_semantic_flow.py
@@ -420,3 +420,31 @@ def test_receiver_style_extension_ref_argument_writes_back(tmp_path: Path) -> No
     assert (_ENV_K, _STDOUT) in _flows(
         tmp_path / "x1", _EXTENSION_REF, cs.CSharpFrontend.HYBRID
     )
+
+
+_GENERIC_REF = (
+    "using System;\n\n"
+    "public class Helper\n{\n"
+    "    public void Fill<T>(T src, ref T dst)\n    {\n"
+    "        dst = src;\n    }\n}\n\n"
+    "public class Leaky\n{\n"
+    "    public void Run()\n    {\n"
+    '        var token = Environment.GetEnvironmentVariable("K");\n'
+    "        var helper = new Helper();\n"
+    '        var sink = "";\n'
+    "        helper.Fill(token, ref sink);\n"
+    "        Console.WriteLine(sink);\n"
+    "    }\n}\n"
+)
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_generic_ref_callee_writes_back(tmp_path: Path) -> None:
+    # A CONSTRUCTED generic method has substituted parameter symbols, while
+    # WrittenInside holds the declaration's originals, so an unnormalized
+    # comparison silently reports no write.
+    assert (_ENV_K, _STDOUT) in _flows(
+        tmp_path / "g1", _GENERIC_REF, cs.CSharpFrontend.HYBRID
+    )

--- a/codebase_rag/tests/test_csharp_semantic_flow.py
+++ b/codebase_rag/tests/test_csharp_semantic_flow.py
@@ -392,3 +392,31 @@ def test_partial_method_ref_callee_resolves_to_the_implementing_part(
     assert (_ENV_K, _STDOUT) in _flows(
         tmp_path / "p1", _PARTIAL_REF, cs.CSharpFrontend.HYBRID
     )
+
+
+_EXTENSION_REF = (
+    "using System;\n\n"
+    "public static class Extensions\n{\n"
+    "    public static void Fill(this string src, ref string dst)\n    {\n"
+    "        dst = src;\n    }\n}\n\n"
+    "public class Leaky\n{\n"
+    "    public void Run()\n    {\n"
+    '        var token = Environment.GetEnvironmentVariable("K");\n'
+    '        var sink = "";\n'
+    "        token.Fill(ref sink);\n"
+    "        Console.WriteLine(sink);\n"
+    "    }\n}\n"
+)
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_receiver_style_extension_ref_argument_writes_back(tmp_path: Path) -> None:
+    # Receiver style hides a parameter: `ref sink` is source index 0 on the
+    # REDUCED symbol, but ordinal 1 on ReducedFrom, whose ordinal 0 is the
+    # receiver. Binding after normalizing analyses the wrong parameter. The
+    # taint source is the receiver too, which is not an argument at all.
+    assert (_ENV_K, _STDOUT) in _flows(
+        tmp_path / "x1", _EXTENSION_REF, cs.CSharpFrontend.HYBRID
+    )

--- a/codebase_rag/tests/test_csharp_semantic_flow.py
+++ b/codebase_rag/tests/test_csharp_semantic_flow.py
@@ -360,3 +360,35 @@ def test_named_ref_argument_binds_to_its_own_parameter(tmp_path: Path) -> None:
     assert (_ENV_K, _STDOUT) in _flows(
         tmp_path / "n1", _NAMED_REF_ARGUMENTS, cs.CSharpFrontend.HYBRID
     )
+
+
+_PARTIAL_REF = (
+    "using System;\n\n"
+    "public partial class Helper\n{\n"
+    "    public partial void Fill(string src, ref string dst);\n}\n\n"
+    "public partial class Helper\n{\n"
+    "    public partial void Fill(string src, ref string dst)\n    {\n"
+    "        dst = src;\n    }\n}\n\n"
+    "public class Leaky\n{\n"
+    "    public void Run()\n    {\n"
+    '        var token = Environment.GetEnvironmentVariable("K");\n'
+    "        var helper = new Helper();\n"
+    '        var sink = "";\n'
+    "        helper.Fill(token, ref sink);\n"
+    "        Console.WriteLine(sink);\n"
+    "    }\n}\n"
+)
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_partial_method_ref_callee_resolves_to_the_implementing_part(
+    tmp_path: Path,
+) -> None:
+    # The invoked symbol can be the DEFINING part, which has no body; without
+    # normalizing to the implementation the write looks unprovable and a real
+    # flow disappears.
+    assert (_ENV_K, _STDOUT) in _flows(
+        tmp_path / "p1", _PARTIAL_REF, cs.CSharpFrontend.HYBRID
+    )

--- a/codebase_rag/tests/test_csharp_semantic_flow.py
+++ b/codebase_rag/tests/test_csharp_semantic_flow.py
@@ -18,6 +18,7 @@ from codebase_rag.graph_updater import GraphUpdater
 from codebase_rag.parser_loader import load_parsers
 from codebase_rag.parsers.csharp_frontend.frontend import (
     _arg_flows,
+    _out_writes,
     csharp_frontend_available,
 )
 
@@ -167,3 +168,116 @@ def test_inspected_local_never_fabricates_a_flow(tmp_path: Path) -> None:
     assert (_ENV_K, _STDOUT) not in _flows(
         tmp_path / "d", source, cs.CSharpFrontend.HYBRID
     )
+
+
+# An `out` argument is written BY the callee, so the lexical walk sees the
+# variable declared and never assigned: `parsed` looks clean and the sink it
+# feeds has no edge (slice 2 of issue #1187).
+_OUT_PARAM_LEAK = (
+    "using System;\n\n"
+    "public class Leaky\n{\n"
+    "    public void Run()\n    {\n"
+    '        var token = Environment.GetEnvironmentVariable("K");\n'
+    "        if (int.TryParse(token, out var parsed))\n        {\n"
+    "            Console.WriteLine(parsed);\n        }\n"
+    "    }\n}\n"
+)
+_FIRST_PARTY_OUT_LEAK = (
+    "using System;\n\n"
+    "public class Helper\n{\n"
+    "    public bool TryCopy(string src, out string dst)\n    {\n"
+    "        dst = src;\n        return true;\n    }\n}\n\n"
+    "public class Leaky\n{\n"
+    "    public void Run()\n    {\n"
+    '        var token = Environment.GetEnvironmentVariable("K");\n'
+    "        var helper = new Helper();\n"
+    "        if (helper.TryCopy(token, out var copied))\n        {\n"
+    "            Console.WriteLine(copied);\n        }\n"
+    "    }\n}\n"
+)
+_REF_LEAK = (
+    "using System;\n\n"
+    "public class Helper\n{\n"
+    "    public void Fill(string src, ref string dst)\n    {\n"
+    "        dst = src;\n    }\n}\n\n"
+    "public class Leaky\n{\n"
+    "    public void Run()\n    {\n"
+    '        var token = Environment.GetEnvironmentVariable("K");\n'
+    "        var helper = new Helper();\n"
+    '        var sink = "";\n'
+    "        helper.Fill(token, ref sink);\n"
+    "        Console.WriteLine(sink);\n"
+    "    }\n}\n"
+)
+
+
+def test_out_write_rows_parse_and_malformed_rows_drop() -> None:
+    parsed = _out_writes(
+        [
+            {
+                "file": "a.cs",
+                "line": 7,
+                "col": 12,
+                "name": "TryParse",
+                "index": 1,
+                "symbol": "parsed",
+            },
+            {"file": "a.cs", "line": 9, "name": "Broken"},
+            {
+                "file": "a.cs",
+                "line": 7,
+                "col": 12,
+                "name": "TryParse",
+                "index": 2,
+                "symbol": 5,
+            },
+        ]
+    )
+    assert parsed == {("a.cs", 7, 12, "TryParse"): {1: "parsed"}}
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_out_parameter_write_back_needs_the_semantic_facts(tmp_path: Path) -> None:
+    # int.TryParse is EXTERNAL and still writes its out parameter, so the fact
+    # has to be emitted for external callees too.
+    lexical = _flows(tmp_path / "o1", _OUT_PARAM_LEAK, cs.CSharpFrontend.TREESITTER)
+    assert (_ENV_K, _STDOUT) not in lexical
+    semantic = _flows(tmp_path / "o2", _OUT_PARAM_LEAK, cs.CSharpFrontend.HYBRID)
+    assert (_ENV_K, _STDOUT) in semantic
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_first_party_out_parameter_write_back(tmp_path: Path) -> None:
+    lexical = _flows(
+        tmp_path / "f1", _FIRST_PARTY_OUT_LEAK, cs.CSharpFrontend.TREESITTER
+    )
+    assert (_ENV_K, _STDOUT) not in lexical
+    semantic = _flows(tmp_path / "f2", _FIRST_PARTY_OUT_LEAK, cs.CSharpFrontend.HYBRID)
+    assert (_ENV_K, _STDOUT) in semantic
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_ref_parameter_write_back(tmp_path: Path) -> None:
+    semantic = _flows(tmp_path / "r1", _REF_LEAK, cs.CSharpFrontend.HYBRID)
+    assert (_ENV_K, _STDOUT) in semantic
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_a_clean_out_parameter_never_gains_a_flow(tmp_path: Path) -> None:
+    clean = (
+        "using System;\n\n"
+        "public class Fine\n{\n"
+        "    public void Run()\n    {\n"
+        '        if (int.TryParse("42", out var parsed))\n        {\n'
+        "            Console.WriteLine(parsed);\n        }\n"
+        "    }\n}\n"
+    )
+    assert _flows(tmp_path / "c2", clean, cs.CSharpFrontend.HYBRID) == set()

--- a/codebase_rag/tests/test_csharp_semantic_flow.py
+++ b/codebase_rag/tests/test_csharp_semantic_flow.py
@@ -309,3 +309,54 @@ def test_a_read_only_ref_parameter_never_gains_a_flow(tmp_path: Path) -> None:
     assert (_ENV_K, _STDOUT) not in _flows(
         tmp_path / "r2", _READ_ONLY_REF, cs.CSharpFrontend.HYBRID
     )
+
+
+_EXPRESSION_BODIED_REF = (
+    "using System;\n\n"
+    "public class Helper\n{\n"
+    "    public void Fill(string src, ref string dst) => dst = src;\n}\n\n"
+    "public class Leaky\n{\n"
+    "    public void Run()\n    {\n"
+    '        var token = Environment.GetEnvironmentVariable("K");\n'
+    "        var helper = new Helper();\n"
+    '        var sink = "";\n'
+    "        helper.Fill(token, ref sink);\n"
+    "        Console.WriteLine(sink);\n"
+    "    }\n}\n"
+)
+_NAMED_REF_ARGUMENTS = (
+    "using System;\n\n"
+    "public class Helper\n{\n"
+    "    public void Fill(string src, ref string dst)\n    {\n"
+    "        dst = src;\n    }\n}\n\n"
+    "public class Leaky\n{\n"
+    "    public void Run()\n    {\n"
+    '        var token = Environment.GetEnvironmentVariable("K");\n'
+    "        var helper = new Helper();\n"
+    '        var sink = "";\n'
+    "        helper.Fill(dst: ref sink, src: token);\n"
+    "        Console.WriteLine(sink);\n"
+    "    }\n}\n"
+)
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_expression_bodied_ref_callee_still_writes_back(tmp_path: Path) -> None:
+    # `=> dst = src` has no block body; rejecting it would treat a writing
+    # callee as read-only and silently drop the edge.
+    assert (_ENV_K, _STDOUT) in _flows(
+        tmp_path / "e1", _EXPRESSION_BODIED_REF, cs.CSharpFrontend.HYBRID
+    )
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_named_ref_argument_binds_to_its_own_parameter(tmp_path: Path) -> None:
+    # Named arguments are reordered: `dst` sits at source index 0 while its
+    # parameter is ordinal 1, so an ordinal lookup would analyse `src`.
+    assert (_ENV_K, _STDOUT) in _flows(
+        tmp_path / "n1", _NAMED_REF_ARGUMENTS, cs.CSharpFrontend.HYBRID
+    )


### PR DESCRIPTION
Slice 2 of #1187. The issue STAYS OPEN: IOperation flow (async/await, LINQ, pattern matching), SymbolFinder completeness, and source generators remain.

## The gap

Slice 1 (#1338) shipped `arg_flows`: what flows INTO an argument. The mirror was missing. An `out`/`ref` argument is written BY the callee, so the lexical walk sees a variable declared and never assigned:

```csharp
var token = Environment.GetEnvironmentVariable("K");
if (int.TryParse(token, out var parsed))
{
    Console.WriteLine(parsed);   // no edge: `parsed` looks clean
}
```

## What lands

A sixth fact family, `out_writes`: per invocation, the argument INDEX and the local or parameter the callee writes through, keyed exactly like the call facts so the existing location join applies unchanged. `out var n` declares its variable inline, so the symbol comes from `GetDeclaredSymbol` on the designation rather than from a reference.

Emitted for EXTERNAL callees too, deliberately: `int.TryParse` is external and still writes its out parameter, and that is the most common shape in real code.

The flow walk gives each written variable the union of the call's INPUT arguments, excluding the written arguments themselves so a variable cannot reinforce its own taint. Additive only, like slice 1: it can add taint the lexical reading missed, never remove an edge.

## Verified before the Python side existed

I ran the built tool against a probe repo and read the raw payload first, rather than assuming the syntax API shape: it emits `parsed` from the external `int.TryParse` and `copied` from a first-party `TryGet`, both keyed on the callee name token.

## Tests

In `test_csharp_semantic_flow.py`, four of the five paired against the SAME repo indexed with `CSHARP_FRONTEND=treesitter`, so a pass cannot come from the lexical walk:

- external `int.TryParse(token, out var parsed)` feeding a sink: edge with the frontend, none without
- a first-party `TryCopy(string src, out string dst)`: same
- a `ref` parameter variant
- a clean `out` parameter (`int.TryParse("42", out var parsed)`) gains NO flow
- `_out_writes` row parsing, with malformed rows dropping

C#/flow battery: 581 passed (the two C# oracle files that fail on main in this environment stay deselected).

Note for reviewers: `CSharpSemanticFacts` gained a field, so its eight construction sites in tests were updated by hand. The NamedTuple deliberately has no defaults -- a mutable default would alias the same dict into every run's mutable processor state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added C# flow analysis for values written through `out` and `ref` arguments.
  * Improved tracking of tainted values passed through calls and assigned to local variables or parameters.
  * Supports external and first-party method calls, including inline `out` declarations and named arguments.

* **Bug Fixes**
  * Invalid or malformed flow data is safely ignored, improving analysis reliability.

* **Tests**
  * Added coverage for `out`/`ref` propagation, clean values, and malformed input handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->