### PR TITLE
test: cover the local-function ref write-back path

### DIFF
--- a/codebase_rag/tests/test_csharp_semantic_flow.py
+++ b/codebase_rag/tests/test_csharp_semantic_flow.py
@@ -448,3 +448,28 @@ def test_generic_ref_callee_writes_back(tmp_path: Path) -> None:
     assert (_ENV_K, _STDOUT) in _flows(
         tmp_path / "g1", _GENERIC_REF, cs.CSharpFrontend.HYBRID
     )
+
+
+_LOCAL_FUNCTION_REF = (
+    "using System;\n\n"
+    "public class Leaky\n{\n"
+    "    public void Run()\n    {\n"
+    '        var token = Environment.GetEnvironmentVariable("K");\n'
+    '        var sink = "";\n'
+    "        void Fill(string src, ref string dst)\n        {\n"
+    "            dst = src;\n        }\n"
+    "        Fill(token, ref sink);\n"
+    "        Console.WriteLine(sink);\n"
+    "    }\n}\n"
+)
+
+
+@pytest.mark.skipif(
+    not csharp_frontend_available(), reason="Roslyn frontend needs a dotnet toolchain"
+)
+def test_local_function_ref_callee_writes_back(tmp_path: Path) -> None:
+    # CallableBody handles LocalFunctionStatementSyntax, but nothing exercised
+    # it until now (issue #1353).
+    assert (_ENV_K, _STDOUT) in _flows(
+        tmp_path / "lf1", _LOCAL_FUNCTION_REF, cs.CSharpFrontend.HYBRID
+    )


### PR DESCRIPTION
Part of #1353. Closes the first of the four items left unfinished when #1351 was merged before its review completed.

## What this is

CodeRabbit asked for a local-function `ref` regression test on #1351 and I declined it as an unrealistic shape. That was my call to make and I made it badly: `CallableBody` handles `LocalFunctionStatementSyntax` in both body forms, so the branch was already there, carried by nothing but my reading of it.

The test now exists, and it earns its place -- with the `LocalFunctionStatementSyntax` arm removed from `CallableBody` it FAILS, so it exercises exactly the path it claims to.

Result: the path is correct. No production change needed, only the proof that was missing.

## Why a test-only PR rather than folding it into the next slice

#1351 merged with Greptile still reviewing commit 1 of 6, so nothing in that helper past the first commit has had a full adversarial pass. Keeping this small and separate gives the reviewers a clean diff over the region rather than burying it inside the next feature.

Remaining on #1353: cross-project `ref` bodies (needs a workspace threaded into `FactCollector`), the `IArgumentOperation` vs syntax-binding question that went unanswered, and a full Greptile pass over the final state of the helper.

17 passed in `test_csharp_semantic_flow.py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for detecting tainted data flowing through C# local functions with `ref` parameters.
  * Verified that environment-variable data reaching console output is correctly reported by the semantic analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->